### PR TITLE
fix popover list height calcs

### DIFF
--- a/frontend/src/metabase/components/Popover.jsx
+++ b/frontend/src/metabase/components/Popover.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import ReactDOM from "react-dom";
+import _ from "underscore";
 
 import OnClickOutsideWrapper from "./OnClickOutsideWrapper";
 import Tether from "tether";
@@ -371,18 +372,7 @@ export default class Popover extends Component {
           }
 
           if (this.props.sizeToFit) {
-            const body = tetherOptions.element.querySelector(".PopoverBody");
-            if (this._tether.attachment.top === "top") {
-              if (constrainToScreen(body, "bottom", PAGE_PADDING)) {
-                body.classList.add("scroll-y");
-                body.classList.add("scroll-show");
-              }
-            } else if (this._tether.attachment.top === "bottom") {
-              if (constrainToScreen(body, "top", PAGE_PADDING)) {
-                body.classList.add("scroll-y");
-                body.classList.add("scroll-show");
-              }
-            }
+            this.resizePopoverToFitWindow(tetherOptions);
           }
         },
       );
@@ -392,6 +382,21 @@ export default class Popover extends Component {
       }
     }
   }
+
+  resizePopoverToFitWindow = _.debounce(tetherOptions => {
+    const body = tetherOptions.element.querySelector(".PopoverBody");
+    if (this._tether.attachment.top === "top") {
+      if (constrainToScreen(body, "bottom", PAGE_PADDING)) {
+        body.classList.add("scroll-y");
+        body.classList.add("scroll-show");
+      }
+    } else if (this._tether.attachment.top === "bottom") {
+      if (constrainToScreen(body, "top", PAGE_PADDING)) {
+        body.classList.add("scroll-y");
+        body.classList.add("scroll-show");
+      }
+    }
+  }, 50);
 
   render() {
     return <span className="hide" />;

--- a/frontend/src/metabase/components/Popover.jsx
+++ b/frontend/src/metabase/components/Popover.jsx
@@ -5,8 +5,6 @@ import ReactDOM from "react-dom";
 import OnClickOutsideWrapper from "./OnClickOutsideWrapper";
 import Tether from "tether";
 
-import { constrainToScreen } from "metabase/lib/dom";
-
 import cx from "classnames";
 
 import "./Popover.css";
@@ -306,13 +304,20 @@ export default class Popover extends Component {
             target: this._getTargetElement(),
           };
           if (this.props.tetherOptions) {
-            if (
-              this.props.sizeToFit &&
-              this.props.tetherOptions.targetAttachment.includes("top")
-            ) {
-              this.constrainPopoverToBetweenViewportTopAndTargetTop(
-                tetherOptions,
-              );
+            if (this.props.sizeToFit) {
+              if (this.props.tetherOptions.targetAttachment.includes("top")) {
+                this.constrainPopoverToBetweenViewportAndTarget(
+                  tetherOptions,
+                  "top",
+                );
+              } else if (
+                this.props.tetherOptions.targetAttachment.includes("bottom")
+              ) {
+                this.constrainPopoverToBetweenViewportAndTarget(
+                  tetherOptions,
+                  "bottom",
+                );
+              }
             }
 
             this._setTetherOptions({
@@ -374,23 +379,22 @@ export default class Popover extends Component {
               this._best = best;
             }
 
-            if (
-              this.props.sizeToFit &&
-              this._best.targetAttachmentY === "top"
-            ) {
-              this.constrainPopoverToBetweenViewportTopAndTargetTop(
-                tetherOptions,
-              );
+            if (this.props.sizeToFit) {
+              if (this._best.targetAttachmentY === "top") {
+                this.constrainPopoverToBetweenViewportAndTarget(
+                  tetherOptions,
+                  "top",
+                );
+              } else if (this._best.targetAttachmentY === "bottom") {
+                this.constrainPopoverToBetweenViewportAndTarget(
+                  tetherOptions,
+                  "bottom",
+                );
+              }
             }
 
             // finally set the best options
             this._setTetherOptions(tetherOptions, this._best);
-          }
-
-          if (this.props.sizeToFit && this._tether.attachment.top === "top") {
-            this.constrainPopoverToBetweenViewportBottomAndTargetBottom(
-              tetherOptions,
-            );
           }
         },
       );
@@ -401,19 +405,17 @@ export default class Popover extends Component {
     }
   }
 
-  constrainPopoverToBetweenViewportTopAndTargetTop(tetherOptions) {
+  constrainPopoverToBetweenViewportAndTarget(tetherOptions, direction) {
     const body = tetherOptions.element.querySelector(".PopoverBody");
     const target = this._getTargetElement();
-    const top = target.getBoundingClientRect().top;
-    body.style.maxHeight = top - PAGE_PADDING + "px";
-    body.classList.add("scroll-y");
-    body.classList.add("scroll-show");
-  }
-
-  constrainPopoverToBetweenViewportBottomAndTargetBottom(tetherOptions) {
-    const body = tetherOptions.element.querySelector(".PopoverBody");
-    // contrainToScreen may mutate body.style.maxHeight
-    if (constrainToScreen(body, "bottom", PAGE_PADDING)) {
+    const bodyHeight = body.getBoundingClientRect().height;
+    const space =
+      direction === "top"
+        ? target.getBoundingClientRect().top
+        : window.innerHeight - target.getBoundingClientRect().bottom;
+    const maxHeight = space - PAGE_PADDING;
+    if (bodyHeight > maxHeight) {
+      body.style.maxHeight = maxHeight + "px";
       body.classList.add("scroll-y");
       body.classList.add("scroll-show");
     }

--- a/frontend/src/metabase/components/Popover.jsx
+++ b/frontend/src/metabase/components/Popover.jsx
@@ -55,6 +55,16 @@ export default class Popover extends Component {
     alignHorizontalEdge: PropTypes.bool,
     // don't wrap the popover in an OnClickOutsideWrapper
     noOnClickOutsideWrapper: PropTypes.bool,
+    targetOffsetX: PropTypes.number,
+    targetOffsetY: PropTypes.number,
+    onClose: PropTypes.func,
+    className: PropTypes.string,
+    style: PropTypes.object,
+    children: PropTypes.element,
+    dismissOnClickOutside: PropTypes.func,
+    dismissOnEscape: PropTypes.func,
+    target: PropTypes.object,
+    targetEvent: PropTypes.object,
   };
 
   static defaultProps = {
@@ -290,91 +300,92 @@ export default class Popover extends Component {
         this,
         <span>{isOpen ? this._popoverComponent() : null}</span>,
         popoverElement,
-      );
-
-      const tetherOptions = {
-        element: popoverElement,
-        target: this._getTargetElement(),
-      };
-
-      if (this.props.tetherOptions) {
-        this._setTetherOptions({
-          ...tetherOptions,
-          ...this.props.tetherOptions,
-        });
-      } else {
-        if (!this._best || !this.props.pinInitialAttachment) {
-          let best = {
-            attachmentX: "center",
-            attachmentY: "top",
-            targetAttachmentX: "center",
-            targetAttachmentY: "bottom",
-            offsetX: 0,
-            offsetY: 0,
+        () => {
+          const tetherOptions = {
+            element: popoverElement,
+            target: this._getTargetElement(),
           };
 
-          // horizontal
-          best = this._getBestAttachmentOptions(
-            tetherOptions,
-            best,
-            this.props.horizontalAttachments,
-            ["left", "right"],
-            (best, attachmentX) => ({
-              ...best,
-              attachmentX: attachmentX,
-              targetAttachmentX: this.props.alignHorizontalEdge
-                ? attachmentX
-                : "center",
-              offsetX: {
-                center: 0,
-                left: -this.props.targetOffsetX,
-                right: this.props.targetOffsetX,
-              }[attachmentX],
-            }),
-          );
+          if (this.props.tetherOptions) {
+            this._setTetherOptions({
+              ...tetherOptions,
+              ...this.props.tetherOptions,
+            });
+          } else {
+            if (!this._best || !this.props.pinInitialAttachment) {
+              let best = {
+                attachmentX: "center",
+                attachmentY: "top",
+                targetAttachmentX: "center",
+                targetAttachmentY: "bottom",
+                offsetX: 0,
+                offsetY: 0,
+              };
 
-          // vertical
-          best = this._getBestAttachmentOptions(
-            tetherOptions,
-            best,
-            this.props.verticalAttachments,
-            ["top", "bottom"],
-            (best, attachmentY) => ({
-              ...best,
-              attachmentY: attachmentY,
-              targetAttachmentY: (this.props.alignVerticalEdge
-              ? attachmentY === "bottom"
-              : attachmentY === "top")
-                ? "bottom"
-                : "top",
-              offsetY: {
-                top: this.props.targetOffsetY,
-                bottom: -this.props.targetOffsetY,
-              }[attachmentY],
-            }),
-          );
+              // horizontal
+              best = this._getBestAttachmentOptions(
+                tetherOptions,
+                best,
+                this.props.horizontalAttachments,
+                ["left", "right"],
+                (best, attachmentX) => ({
+                  ...best,
+                  attachmentX: attachmentX,
+                  targetAttachmentX: this.props.alignHorizontalEdge
+                    ? attachmentX
+                    : "center",
+                  offsetX: {
+                    center: 0,
+                    left: -this.props.targetOffsetX,
+                    right: this.props.targetOffsetX,
+                  }[attachmentX],
+                }),
+              );
 
-          this._best = best;
-        }
+              // vertical
+              best = this._getBestAttachmentOptions(
+                tetherOptions,
+                best,
+                this.props.verticalAttachments,
+                ["top", "bottom"],
+                (best, attachmentY) => ({
+                  ...best,
+                  attachmentY: attachmentY,
+                  targetAttachmentY: (this.props.alignVerticalEdge
+                  ? attachmentY === "bottom"
+                  : attachmentY === "top")
+                    ? "bottom"
+                    : "top",
+                  offsetY: {
+                    top: this.props.targetOffsetY,
+                    bottom: -this.props.targetOffsetY,
+                  }[attachmentY],
+                }),
+              );
 
-        // finally set the best options
-        this._setTetherOptions(tetherOptions, this._best);
-      }
+              this._best = best;
+            }
 
-      if (this.props.sizeToFit) {
-        const body = tetherOptions.element.querySelector(".PopoverBody");
-        if (this._tether.attachment.top === "top") {
-          if (constrainToScreen(body, "bottom", PAGE_PADDING)) {
-            body.classList.add("scroll-y");
-            body.classList.add("scroll-show");
+            // finally set the best options
+            this._setTetherOptions(tetherOptions, this._best);
           }
-        } else if (this._tether.attachment.top === "bottom") {
-          if (constrainToScreen(body, "top", PAGE_PADDING)) {
-            body.classList.add("scroll-y");
-            body.classList.add("scroll-show");
+
+          if (this.props.sizeToFit) {
+            const body = tetherOptions.element.querySelector(".PopoverBody");
+            if (this._tether.attachment.top === "top") {
+              if (constrainToScreen(body, "bottom", PAGE_PADDING)) {
+                body.classList.add("scroll-y");
+                body.classList.add("scroll-show");
+              }
+            } else if (this._tether.attachment.top === "bottom") {
+              if (constrainToScreen(body, "top", PAGE_PADDING)) {
+                body.classList.add("scroll-y");
+                body.classList.add("scroll-show");
+              }
+            }
           }
-        }
-      }
+        },
+      );
     } else {
       if (this._popoverElement) {
         ReactDOM.unmountComponentAtNode(this._popoverElement);

--- a/frontend/src/metabase/components/Popover.jsx
+++ b/frontend/src/metabase/components/Popover.jsx
@@ -303,99 +303,77 @@ export default class Popover extends Component {
             element: popoverElement,
             target: this._getTargetElement(),
           };
-          if (this.props.tetherOptions) {
-            if (this.props.sizeToFit) {
-              if (this.props.tetherOptions.targetAttachment.includes("top")) {
-                this.constrainPopoverToBetweenViewportAndTarget(
-                  tetherOptions,
-                  "top",
-                );
-              } else if (
-                this.props.tetherOptions.targetAttachment.includes("bottom")
-              ) {
-                this.constrainPopoverToBetweenViewportAndTarget(
-                  tetherOptions,
-                  "bottom",
-                );
-              }
-            }
 
-            this._setTetherOptions({
-              ...tetherOptions,
-              ...this.props.tetherOptions,
-            });
-          } else {
-            if (!this._best || !this.props.pinInitialAttachment) {
-              let best = {
-                attachmentX: "center",
-                attachmentY: "top",
-                targetAttachmentX: "center",
-                targetAttachmentY: "bottom",
-                offsetX: 0,
-                offsetY: 0,
-              };
+          if (!this._best || !this.props.pinInitialAttachment) {
+            let best = {
+              attachmentX: "center",
+              attachmentY: "top",
+              targetAttachmentX: "center",
+              targetAttachmentY: "bottom",
+              offsetX: 0,
+              offsetY: 0,
+            };
 
-              // horizontal
-              best = this._getBestAttachmentOptions(
-                tetherOptions,
-                best,
-                this.props.horizontalAttachments,
-                ["left", "right"],
-                (best, attachmentX) => ({
-                  ...best,
-                  attachmentX: attachmentX,
-                  targetAttachmentX: this.props.alignHorizontalEdge
-                    ? attachmentX
-                    : "center",
-                  offsetX: {
-                    center: 0,
-                    left: -this.props.targetOffsetX,
-                    right: this.props.targetOffsetX,
-                  }[attachmentX],
-                }),
-              );
+            // horizontal
+            best = this._getBestAttachmentOptions(
+              tetherOptions,
+              best,
+              this.props.horizontalAttachments,
+              ["left", "right"],
+              (best, attachmentX) => ({
+                ...best,
+                attachmentX: attachmentX,
+                targetAttachmentX: this.props.alignHorizontalEdge
+                  ? attachmentX
+                  : "center",
+                offsetX: {
+                  center: 0,
+                  left: -this.props.targetOffsetX,
+                  right: this.props.targetOffsetX,
+                }[attachmentX],
+              }),
+            );
 
-              // vertical
-              best = this._getBestAttachmentOptions(
-                tetherOptions,
-                best,
-                this.props.verticalAttachments,
-                ["top", "bottom"],
-                (best, attachmentY) => ({
-                  ...best,
-                  attachmentY: attachmentY,
-                  targetAttachmentY: (this.props.alignVerticalEdge
-                  ? attachmentY === "bottom"
-                  : attachmentY === "top")
-                    ? "bottom"
-                    : "top",
-                  offsetY: {
-                    top: this.props.targetOffsetY,
-                    bottom: -this.props.targetOffsetY,
-                  }[attachmentY],
-                }),
-              );
+            // vertical
+            best = this._getBestAttachmentOptions(
+              tetherOptions,
+              best,
+              this.props.verticalAttachments,
+              ["top", "bottom"],
+              (best, attachmentY) => ({
+                ...best,
+                attachmentY: attachmentY,
+                targetAttachmentY: (this.props.alignVerticalEdge
+                ? attachmentY === "bottom"
+                : attachmentY === "top")
+                  ? "bottom"
+                  : "top",
+                offsetY: {
+                  top: this.props.targetOffsetY,
+                  bottom: -this.props.targetOffsetY,
+                }[attachmentY],
+              }),
+            );
 
-              this._best = best;
-            }
-
-            if (this.props.sizeToFit) {
-              if (this._best.targetAttachmentY === "top") {
-                this.constrainPopoverToBetweenViewportAndTarget(
-                  tetherOptions,
-                  "top",
-                );
-              } else if (this._best.targetAttachmentY === "bottom") {
-                this.constrainPopoverToBetweenViewportAndTarget(
-                  tetherOptions,
-                  "bottom",
-                );
-              }
-            }
-
-            // finally set the best options
-            this._setTetherOptions(tetherOptions, this._best);
+            this._best = best;
           }
+
+          if (this.props.sizeToFit) {
+            if (this._best.targetAttachmentY === "top") {
+              this.constrainPopoverToBetweenViewportAndTarget(
+                tetherOptions,
+                "top",
+              );
+            } else if (this._best.targetAttachmentY === "bottom") {
+              this.constrainPopoverToBetweenViewportAndTarget(
+                tetherOptions,
+                "bottom",
+              );
+            }
+          }
+
+          // finally set the best options
+          this._setTetherOptions(tetherOptions, this._best);
         },
       );
     } else {

--- a/frontend/src/metabase/components/Popover.jsx
+++ b/frontend/src/metabase/components/Popover.jsx
@@ -1,8 +1,6 @@
-/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import ReactDOM from "react-dom";
-import SandboxedPortal from "metabase/components/SandboxedPortal";
 
 import OnClickOutsideWrapper from "./OnClickOutsideWrapper";
 import Tether from "tether";
@@ -23,12 +21,11 @@ export default class Popover extends Component {
     super(props, context);
 
     this.state = {
-      // some child components of indeterminate height (see AccordionList) require a maxHeight prop in order to avoid overflowing off of the page
-      maxHeight: 0,
+      width: null,
+      height: null,
     };
 
-    this._popoverElement = this._createPopoverElement();
-    document.body.appendChild(this._popoverElement);
+    this.handleDismissal = this.handleDismissal.bind(this);
   }
 
   static propTypes = {
@@ -75,194 +72,96 @@ export default class Popover extends Component {
     noOnClickOutsideWrapper: false,
   };
 
-  _createPopoverElement() {
-    const el = document.createElement("div");
-    el.className = "PopoverContainer";
-    return el;
+  _getPopoverElement(isOpen) {
+    if (!this._popoverElement && isOpen) {
+      this._popoverElement = document.createElement("span");
+      this._popoverElement.className = "PopoverContainer";
+      document.body.appendChild(this._popoverElement);
+      this._timer = setInterval(() => {
+        const { width, height } = this._popoverElement.getBoundingClientRect();
+        if (this.state.width !== width || this.state.height !== height) {
+          this.setState({ width, height });
+        }
+      }, 100);
+    }
+    return this._popoverElement;
   }
 
   componentDidMount() {
-    this._updateContainerClass();
-
-    if (this.props.isOpen) {
-      this._updateTetherOptions();
-      this._updateMaxHeight();
-    }
+    this._renderPopover(this.props.isOpen);
   }
 
   componentDidUpdate() {
-    this._updateContainerClass();
-
-    if (this.props.isOpen) {
-      this._updateTetherOptions();
-      this._updateMaxHeight();
-    }
-  }
-
-  _updateMaxHeight() {
-    const maxHeight = this._getMaxHeight();
-    if (this.state.maxHeight !== maxHeight) {
-      this.setState({
-        maxHeight,
-      });
-    }
-  }
-
-  _updateContainerClass() {
-    if (this.props.isOpen) {
-      this._popoverElement.classList.add("PopoverContainer--open");
-    } else {
-      this._popoverElement.classList.remove("PopoverContainer--open");
-    }
+    this._renderPopover(this.props.isOpen);
   }
 
   componentWillUnmount() {
-    document.body.removeChild(this._popoverElement);
-    this._tether && this._tether.destroy();
+    if (this._tether) {
+      this._tether.destroy();
+      delete this._tether;
+    }
+    if (this._popoverElement) {
+      this._renderPopover(false);
+      ReactDOM.unmountComponentAtNode(this._popoverElement);
+      if (this._popoverElement.parentNode) {
+        this._popoverElement.parentNode.removeChild(this._popoverElement);
+      }
+      delete this._popoverElement;
+      clearInterval(this._timer);
+      delete this._timer;
+    }
   }
 
-  handleDismissal = (...args) => {
+  handleDismissal(...args) {
     if (this.props.onClose) {
       this.props.onClose(...args);
     }
-  };
+  }
 
-  _buildPopover() {
-    const {
-      id,
-      hasBackground,
-      autoWidth,
-      hasArrow,
-      className,
-      style,
-      children,
-      noOnClickOutsideWrapper,
-      dismissOnEscape,
-      dismissOnClickOutside,
-    } = this.props;
+  _popoverComponent() {
     const childProps = {
-      maxHeight: this.state.maxHeight,
+      maxHeight: this._getMaxHeight(),
     };
-    const popoverContent = (
+    const content = (
       <div
-        id={id}
+        id={this.props.id}
         className={cx(
           "PopoverBody",
           {
-            "PopoverBody--withBackground": hasBackground,
-            "PopoverBody--withArrow": hasArrow && hasBackground,
-            "PopoverBody--autoWidth": autoWidth,
+            "PopoverBody--withBackground": this.props.hasBackground,
+            "PopoverBody--withArrow":
+              this.props.hasArrow && this.props.hasBackground,
+            "PopoverBody--autoWidth": this.props.autoWidth,
           },
           // TODO kdoh 10/16/2017 we should eventually remove this
-          className,
+          this.props.className,
         )}
-        style={style}
+        style={this.props.style}
       >
-        {typeof children === "function"
-          ? children(childProps)
-          : React.Children.count(children) === 1 &&
+        {typeof this.props.children === "function"
+          ? this.props.children(childProps)
+          : React.Children.count(this.props.children) === 1 &&
             // NOTE: workaround for https://github.com/facebook/react/issues/12136
-            !Array.isArray(children)
-          ? React.cloneElement(React.Children.only(children), childProps)
-          : children}
+            !Array.isArray(this.props.children)
+          ? React.cloneElement(
+              React.Children.only(this.props.children),
+              childProps,
+            )
+          : this.props.children}
       </div>
     );
-
-    return noOnClickOutsideWrapper ? (
-      popoverContent
-    ) : (
-      <OnClickOutsideWrapper
-        handleDismissal={this.handleDismissal}
-        dismissOnEscape={dismissOnEscape}
-        dismissOnClickOutside={dismissOnClickOutside}
-      >
-        {popoverContent}
-      </OnClickOutsideWrapper>
-    );
-  }
-
-  _updateTetherOptions() {
-    const tetherOptions = {
-      element: this._popoverElement,
-      target: this._getTargetElement(),
-    };
-
-    if (this.props.tetherOptions) {
-      this._setTetherOptions({
-        ...tetherOptions,
-        ...this.props.tetherOptions,
-      });
+    if (this.props.noOnClickOutsideWrapper) {
+      return content;
     } else {
-      if (!this._best || !this.props.pinInitialAttachment) {
-        let best = {
-          attachmentX: "center",
-          attachmentY: "top",
-          targetAttachmentX: "center",
-          targetAttachmentY: "bottom",
-          offsetX: 0,
-          offsetY: 0,
-        };
-
-        // horizontal
-        best = this._getBestAttachmentOptions(
-          tetherOptions,
-          best,
-          this.props.horizontalAttachments,
-          ["left", "right"],
-          (best, attachmentX) => ({
-            ...best,
-            attachmentX: attachmentX,
-            targetAttachmentX: this.props.alignHorizontalEdge
-              ? attachmentX
-              : "center",
-            offsetX: {
-              center: 0,
-              left: -this.props.targetOffsetX,
-              right: this.props.targetOffsetX,
-            }[attachmentX],
-          }),
-        );
-
-        // vertical
-        best = this._getBestAttachmentOptions(
-          tetherOptions,
-          best,
-          this.props.verticalAttachments,
-          ["top", "bottom"],
-          (best, attachmentY) => ({
-            ...best,
-            attachmentY: attachmentY,
-            targetAttachmentY: (this.props.alignVerticalEdge
-            ? attachmentY === "bottom"
-            : attachmentY === "top")
-              ? "bottom"
-              : "top",
-            offsetY: {
-              top: this.props.targetOffsetY,
-              bottom: -this.props.targetOffsetY,
-            }[attachmentY],
-          }),
-        );
-
-        this._best = best;
-      }
-      if (this.props.sizeToFit) {
-        const body = tetherOptions.element.querySelector(".PopoverBody");
-        if (this._tether.attachment.top === "top") {
-          if (constrainToScreen(body, "bottom", PAGE_PADDING)) {
-            body.classList.add("scroll-y");
-            body.classList.add("scroll-show");
-          }
-        } else if (this._tether.attachment.top === "bottom") {
-          if (constrainToScreen(body, "top", PAGE_PADDING)) {
-            body.classList.add("scroll-y");
-            body.classList.add("scroll-show");
-          }
-        }
-      }
-
-      // finally set the best options
-      this._setTetherOptions(tetherOptions, this._best);
+      return (
+        <OnClickOutsideWrapper
+          handleDismissal={this.handleDismissal}
+          dismissOnEscape={this.props.dismissOnEscape}
+          dismissOnClickOutside={this.props.dismissOnClickOutside}
+        >
+          {content}
+        </OnClickOutsideWrapper>
+      );
     }
   }
 
@@ -277,15 +176,6 @@ export default class Popover extends Component {
     }
     if (this._tether) {
       this._tether.setOptions(tetherOptions);
-      // tether keeps a 3-member history.
-      // it seems to mutate viewport and page settings
-      // it keeps in its history to be wrong.
-      // this creates an absolutely wild bug
-      // that appears only if you click 4 times
-      if (this._tether.history && this._tether.history.length > 0) {
-        this._tether.history[0].page.top = this.props.targetOffsetY;
-        this._tether.history[0].viewport.top = this.props.targetOffsetY;
-      }
     } else {
       this._tether = new Tether(tetherOptions);
     }
@@ -384,15 +274,115 @@ export default class Popover extends Component {
     return target;
   }
 
+  _renderPopover(isOpen) {
+    const popoverElement = this._getPopoverElement(isOpen);
+    if (popoverElement) {
+      if (isOpen) {
+        popoverElement.classList.add("PopoverContainer--open");
+      } else {
+        popoverElement.classList.remove("PopoverContainer--open");
+      }
+    }
+
+    // popover is open, lets do this!
+    if (isOpen) {
+      ReactDOM.unstable_renderSubtreeIntoContainer(
+        this,
+        <span>{isOpen ? this._popoverComponent() : null}</span>,
+        popoverElement,
+      );
+
+      const tetherOptions = {
+        element: popoverElement,
+        target: this._getTargetElement(),
+      };
+
+      if (this.props.tetherOptions) {
+        this._setTetherOptions({
+          ...tetherOptions,
+          ...this.props.tetherOptions,
+        });
+      } else {
+        if (!this._best || !this.props.pinInitialAttachment) {
+          let best = {
+            attachmentX: "center",
+            attachmentY: "top",
+            targetAttachmentX: "center",
+            targetAttachmentY: "bottom",
+            offsetX: 0,
+            offsetY: 0,
+          };
+
+          // horizontal
+          best = this._getBestAttachmentOptions(
+            tetherOptions,
+            best,
+            this.props.horizontalAttachments,
+            ["left", "right"],
+            (best, attachmentX) => ({
+              ...best,
+              attachmentX: attachmentX,
+              targetAttachmentX: this.props.alignHorizontalEdge
+                ? attachmentX
+                : "center",
+              offsetX: {
+                center: 0,
+                left: -this.props.targetOffsetX,
+                right: this.props.targetOffsetX,
+              }[attachmentX],
+            }),
+          );
+
+          // vertical
+          best = this._getBestAttachmentOptions(
+            tetherOptions,
+            best,
+            this.props.verticalAttachments,
+            ["top", "bottom"],
+            (best, attachmentY) => ({
+              ...best,
+              attachmentY: attachmentY,
+              targetAttachmentY: (this.props.alignVerticalEdge
+              ? attachmentY === "bottom"
+              : attachmentY === "top")
+                ? "bottom"
+                : "top",
+              offsetY: {
+                top: this.props.targetOffsetY,
+                bottom: -this.props.targetOffsetY,
+              }[attachmentY],
+            }),
+          );
+
+          this._best = best;
+        }
+
+        // finally set the best options
+        this._setTetherOptions(tetherOptions, this._best);
+      }
+
+      if (this.props.sizeToFit) {
+        const body = tetherOptions.element.querySelector(".PopoverBody");
+        if (this._tether.attachment.top === "top") {
+          if (constrainToScreen(body, "bottom", PAGE_PADDING)) {
+            body.classList.add("scroll-y");
+            body.classList.add("scroll-show");
+          }
+        } else if (this._tether.attachment.top === "bottom") {
+          if (constrainToScreen(body, "top", PAGE_PADDING)) {
+            body.classList.add("scroll-y");
+            body.classList.add("scroll-show");
+          }
+        }
+      }
+    } else {
+      if (this._popoverElement) {
+        ReactDOM.unmountComponentAtNode(this._popoverElement);
+      }
+    }
+  }
+
   render() {
-    return (
-      <span className="hide">
-        {this.props.isOpen ? (
-          <SandboxedPortal container={this._popoverElement}>
-            {this._buildPopover()}
-          </SandboxedPortal>
-        ) : null}
-      </span>
-    );
+    return <span className="hide" />;
   }
 }

--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx
@@ -148,16 +148,7 @@ export default class ParameterFieldWidget extends Component<*, Props, State> {
       );
     } else {
       return (
-        <Popover
-          horizontalAttachments={["left", "right"]}
-          verticalAttachments={["top"]}
-          alignHorizontalEdge
-          alignVerticalEdge
-          targetOffsetY={-19}
-          targetOffsetX={33}
-          hasArrow={false}
-          onClose={() => focusChanged(false)}
-        >
+        <Popover hasArrow={false} onClose={() => focusChanged(false)}>
           <div className={cx(!isEqualsOp && "p2")}>
             {verboseName && !isEqualsOp && (
               <div className="text-bold mb1">{verboseName}...</div>


### PR DESCRIPTION
fixes #15591 

- revert `Popover` to pre react 16 upgrade 
- move side-effecty logic that depends on rendering to the third arg of `unstable_renderSubtreeIntoContainer`
- remove some config options from ParameterFieldWidget to make it handle being in a sidebar better
