### PR TITLE
#15441 Repro: Settings menu items order is reversed in EE version

### DIFF
--- a/frontend/test/metabase-smoketest/admin_setup.cy.spec.js
+++ b/frontend/test/metabase-smoketest/admin_setup.cy.spec.js
@@ -35,15 +35,6 @@ describe("smoketest > admin_setup", () => {
       cy.findByText("Metabase Admin");
       cy.findByText("dashboard").should("not.exist");
 
-      // check that the order of items under Settings is consistent between OSS and EE (metabase#15441)
-      cy.get(".AdminList .AdminList-items").as("settingsMenuItems");
-      cy.get("@settingsMenuItems")
-        .first()
-        .contains("Setup");
-      cy.get("@settingsMenuItems")
-        .last()
-        .contains("Caching");
-
       cy.findByText("Databases").click();
 
       cy.findByText("Sample Dataset");

--- a/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
@@ -326,6 +326,10 @@ describe("scenarios > admin > settings", () => {
   });
 
   it("should display the order of the settings items consistently between OSS/EE versions (metabase#15441)", () => {
+    const lastItem = Cypress.env("HAS_ENTERPRISE_TOKEN")
+      ? "Whitelabel"
+      : "Caching";
+
     cy.visit("/admin/settings/setup");
     cy.get(".AdminList .AdminList-item")
       .as("settingsOptions")
@@ -333,7 +337,7 @@ describe("scenarios > admin > settings", () => {
       .contains("Setup");
     cy.get("@settingsOptions")
       .last()
-      .contains("Whitelabel");
+      .contains(lastItem);
   });
 
   describe(" > email settings", () => {

--- a/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
@@ -325,6 +325,17 @@ describe("scenarios > admin > settings", () => {
     cy.findByText(/Site URL/i);
   });
 
+  it("should display the order of the settings items consistently between OSS/EE versions (metabase#15441)", () => {
+    cy.visit("/admin/settings/setup");
+    cy.get(".AdminList .AdminList-item")
+      .as("settingsOptions")
+      .first()
+      .contains("Setup");
+    cy.get("@settingsOptions")
+      .last()
+      .contains("Whitelabel");
+  });
+
   describe(" > email settings", () => {
     it("should be able to save email settings", () => {
       cy.visit("/admin/settings/email");


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #15441 

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js`
- All tests should pass

### Additional notes:
- The bug was fixed in #15607

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/114757913-b12cfe00-9d5c-11eb-9f21-a7cff3708016.png)

