### PR TITLE
Rename collection revision

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -8270,9 +8270,8 @@ databaseChangeLog:
         - dbms:
             type: postgresql
       changes:
-        - renameSequence:
-            oldSequenceName: collection_revision_id_seq
-            newSequenceName: collection_permission_graph_revision_id_seq
+        - sql:
+            - sql: ALTER SEQUENCE collection_revision_id_seq RENAME TO collection_permission_graph_revision_id_seq
 
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -8252,6 +8252,28 @@ databaseChangeLog:
             columnName: parameters
             defaultNullValue: '[]'
             tableName: pulse
+  - changeSet:
+      id: 300
+      author: dpsutton
+      comment: Added 0.40.0
+      changes:
+        - renameTable:
+            oldTableName: collection_revision
+            newTableName: collection_permission_graph_revision
+  - changeSet:
+      id: 301
+      author: dpsutton
+      comment: Added 0.40.0 renaming collection_revision to collection_permission_graph_revision
+      failOnError: false # mysql and h2 don't have this sequence
+      preConditions:
+        - onFail: MARK_RAN
+        - or:
+            - dbms:
+                type: postgresql
+      changes:
+        - renameSequence:
+            oldSequenceName: collection_revision_id_seq
+            newSequenceName: collection_permission_graph_revision_id_seq
 
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -8267,9 +8267,8 @@ databaseChangeLog:
       failOnError: false # mysql and h2 don't have this sequence
       preConditions:
         - onFail: MARK_RAN
-        - or:
-            - dbms:
-                type: postgresql
+        - dbms:
+            type: postgresql
       changes:
         - renameSequence:
             oldSequenceName: collection_revision_id_seq

--- a/src/metabase/cmd/copy.clj
+++ b/src/metabase/cmd/copy.clj
@@ -9,8 +9,8 @@
             [metabase.db.connection :as mdb.conn]
             [metabase.db.data-migrations :refer [DataMigrations]]
             [metabase.db.setup :as mdb.setup]
-            [metabase.models :refer [Activity Card CardFavorite Collection CollectionRevision Dashboard DashboardCard
-                                     DashboardCardSeries DashboardFavorite Database Dependency Dimension Field
+            [metabase.models :refer [Activity Card CardFavorite Collection CollectionPermissionGraphRevision Dashboard
+                                     DashboardCard DashboardCardSeries DashboardFavorite Database Dependency Dimension Field
                                      FieldValues LoginHistory Metric MetricImportantField NativeQuerySnippet Permissions
                                      PermissionsGroup PermissionsGroupMembership PermissionsRevision Pulse PulseCard
                                      PulseChannel PulseChannelRecipient Revision Segment Session Setting Table User
@@ -58,7 +58,7 @@
    ViewLog
    Session
    Collection
-   CollectionRevision
+   CollectionPermissionGraphRevision
    Dashboard
    Card
    CardFavorite

--- a/src/metabase/models.clj
+++ b/src/metabase/models.clj
@@ -3,7 +3,7 @@
             [metabase.models.card :as card]
             [metabase.models.card-favorite :as card-favorite]
             [metabase.models.collection :as collection]
-            [metabase.models.collection-revision :as collection-revision]
+            [metabase.models.collection-permission-graph-revision :as collection.perms]
             [metabase.models.dashboard :as dashboard]
             [metabase.models.dashboard-card :as dashboard-card]
             [metabase.models.dashboard-card-series :as dashboard-card-series]
@@ -42,7 +42,7 @@
          card/keep-me
          card-favorite/keep-me
          collection/keep-me
-         collection-revision/keep-me
+         collection.perms/keep-me
          dashboard/keep-me
          dashboard-card/keep-me
          dashboard-card-series/keep-me
@@ -80,7 +80,7 @@
  [card Card]
  [card-favorite CardFavorite]
  [collection Collection]
- [collection-revision CollectionRevision]
+ [collection.perms CollectionPermissionGraphRevision]
  [dashboard Dashboard]
  [dashboard-card DashboardCard]
  [dashboard-card-series DashboardCardSeries]

--- a/src/metabase/models.clj
+++ b/src/metabase/models.clj
@@ -3,7 +3,7 @@
             [metabase.models.card :as card]
             [metabase.models.card-favorite :as card-favorite]
             [metabase.models.collection :as collection]
-            [metabase.models.collection-permission-graph-revision :as collection.perms]
+            [metabase.models.collection-permission-graph-revision :as c-perm-revision]
             [metabase.models.dashboard :as dashboard]
             [metabase.models.dashboard-card :as dashboard-card]
             [metabase.models.dashboard-card-series :as dashboard-card-series]
@@ -42,7 +42,7 @@
          card/keep-me
          card-favorite/keep-me
          collection/keep-me
-         collection.perms/keep-me
+         c-perm-revision/keep-me
          dashboard/keep-me
          dashboard-card/keep-me
          dashboard-card-series/keep-me
@@ -80,7 +80,7 @@
  [card Card]
  [card-favorite CardFavorite]
  [collection Collection]
- [collection.perms CollectionPermissionGraphRevision]
+ [c-perm-revision CollectionPermissionGraphRevision]
  [dashboard Dashboard]
  [dashboard-card DashboardCard]
  [dashboard-card-series DashboardCardSeries]

--- a/src/metabase/models/collection/graph.clj
+++ b/src/metabase/models/collection/graph.clj
@@ -2,7 +2,7 @@
   (:require [clojure.data :as data]
             [metabase.api.common :as api :refer [*current-user-id*]]
             [metabase.models.collection :as collection :refer [Collection]]
-            [metabase.models.collection-permission-graph-revision :as collection.perms
+            [metabase.models.collection-permission-graph-revision :as c-perm-revision
              :refer [CollectionPermissionGraphRevision]]
             [metabase.models.permissions :as perms :refer [Permissions]]
             [metabase.models.permissions-group :refer [PermissionsGroup]]
@@ -85,7 +85,7 @@
   ([collection-namespace :- (s/maybe su/KeywordOrString)]
    (let [group-id->perms (group-id->permissions-set)
          collection-ids  (non-personal-collection-ids collection-namespace)]
-     {:revision (collection.perms/latest-id)
+     {:revision (c-perm-revision/latest-id)
       :groups   (into {} (for [group-id (db/select-ids PermissionsGroup)]
                            {group-id (group-permissions-graph collection-namespace (group-id->perms group-id) collection-ids)}))})))
 

--- a/src/metabase/models/collection/graph.clj
+++ b/src/metabase/models/collection/graph.clj
@@ -2,7 +2,8 @@
   (:require [clojure.data :as data]
             [metabase.api.common :as api :refer [*current-user-id*]]
             [metabase.models.collection :as collection :refer [Collection]]
-            [metabase.models.collection-revision :as collection-revision :refer [CollectionRevision]]
+            [metabase.models.collection-permission-graph-revision :as collection.perms
+             :refer [CollectionPermissionGraphRevision]]
             [metabase.models.permissions :as perms :refer [Permissions]]
             [metabase.models.permissions-group :refer [PermissionsGroup]]
             [metabase.util :as u]
@@ -84,7 +85,7 @@
   ([collection-namespace :- (s/maybe su/KeywordOrString)]
    (let [group-id->perms (group-id->permissions-set)
          collection-ids  (non-personal-collection-ids collection-namespace)]
-     {:revision (collection-revision/latest-id)
+     {:revision (collection.perms/latest-id)
       :groups   (into {} (for [group-id (db/select-ids PermissionsGroup)]
                            {group-id (group-permissions-graph collection-namespace (group-id->perms group-id) collection-ids)}))})))
 
@@ -123,7 +124,7 @@
   (when *current-user-id*
     ;; manually specify ID here so if one was somehow inserted in the meantime in the fraction of a second since we
     ;; called `check-revision-numbers` the PK constraint will fail and the transaction will abort
-    (db/insert! CollectionRevision
+    (db/insert! CollectionPermissionGraphRevision
       :id     (inc current-revision)
       :before  (assoc before-graph :namespace collection-namespace)
       :after   changes

--- a/src/metabase/models/collection_permission_graph_revision.clj
+++ b/src/metabase/models/collection_permission_graph_revision.clj
@@ -1,26 +1,26 @@
-(ns metabase.models.collection-revision
+(ns metabase.models.collection-permission-graph-revision
   (:require [metabase.util :as u]
             [metabase.util.i18n :refer [tru]]
             [toucan.db :as db]
             [toucan.models :as models]))
 
-(models/defmodel CollectionRevision :collection_revision)
+(models/defmodel CollectionPermissionGraphRevision :collection_permission_graph_revision)
 
 (defn- pre-insert [revision]
   (assoc revision :created_at :%now))
 
-(u/strict-extend (class CollectionRevision)
+(u/strict-extend (class CollectionPermissionGraphRevision)
   models/IModel
   (merge models/IModelDefaults
          {:types      (constantly {:before :json
                                    :after  :json})
           :pre-insert pre-insert
-          :pre-update (fn [& _] (throw (Exception. (tru "You cannot update a CollectionRevision!"))))}))
+          :pre-update (fn [& _] (throw (Exception. (tru "You cannot update a CollectionPermissionGraphRevision!"))))}))
 
 
 (defn latest-id
-  "Return the ID of the newest `CollectionRevision`, or zero if none have been made yet.
+  "Return the ID of the newest `CollectionPermissionGraphRevision`, or zero if none have been made yet.
    (This is used by the collection graph update logic that checks for changes since the original graph was fetched)."
   []
-  (or (:id (db/select-one [CollectionRevision [:%max.id :id]]))
+  (or (:id (db/select-one [CollectionPermissionGraphRevision [:%max.id :id]]))
       0))

--- a/test/metabase/models/collection/graph_test.clj
+++ b/test/metabase/models/collection/graph_test.clj
@@ -5,7 +5,8 @@
             [metabase.api.common :refer [*current-user-id*]]
             [metabase.models :refer [User]]
             [metabase.models.collection :as collection :refer [Collection]]
-            [metabase.models.collection-revision :as collection-revision :refer [CollectionRevision]]
+            [metabase.models.collection-permission-graph-revision :as collection.perms
+             :refer [CollectionPermissionGraphRevision]]
             [metabase.models.collection.graph :as graph]
             [metabase.models.permissions :as perms]
             [metabase.models.permissions-group :as group :refer [PermissionsGroup]]
@@ -38,7 +39,7 @@
                                                                        collection-id))))))))
 
 (defn- clear-graph-revisions! []
-  (db/delete! CollectionRevision))
+  (db/delete! CollectionPermissionGraphRevision))
 
 (defn- only-groups
   "Remove entries for non-'magic' groups from a fetched perms `graph`."
@@ -291,7 +292,7 @@
 
         (testing "No revision should have been saved"
           (is (= 0
-                 (collection-revision/latest-id)))))))
+                 (collection.perms/latest-id)))))))
 
   (testing "Make sure you can't be sneaky and edit descendants of Personal Collections either."
     (mt/with-temp Collection [collection {:location (lucky-collection-children-location)}]
@@ -339,7 +340,7 @@
             (is (= {"Currency A" :read, "Currency A -> B" :read, :root :none}
                    (nice-graph (graph/graph :currency)))))
 
-          ;; bind a current user so CollectionRevisions get saved.
+          ;; bind a current user so CollectionPermissionGraphRevisions get saved.
           (mt/with-test-user :crowberto
             (testing "Should be able to update the graph for the default namespace.\n"
               (let [before (graph/graph)]
@@ -351,14 +352,14 @@
                   (is (= {"Currency A" :read, "Currency A -> B" :read, :root :none}
                          (nice-graph (graph/graph :currency)))))
 
-                (testing "A CollectionRevision recording the *changes* to the perms graph should be saved."
+                (testing "A CollectionPermissionGraphRevision recording the *changes* to the perms graph should be saved."
                   (is (schema= {:id         su/IntGreaterThanZero
                                 :before     (s/eq (mt/obj->json->obj (assoc before :namespace nil)))
                                 :after      (s/eq {(keyword (str group-id)) {(keyword (str default-ab)) "write"}})
                                 :user_id    (s/eq (mt/user->id :crowberto))
                                 :created_at java.time.temporal.Temporal
                                 s/Keyword   s/Any}
-                               (db/select-one CollectionRevision {:order-by [[:id :desc]]}))))))
+                               (db/select-one CollectionPermissionGraphRevision {:order-by [[:id :desc]]}))))))
 
             (testing "Should be able to update the graph for a non-default namespace.\n"
               (let [before (graph/graph :currency)]
@@ -370,14 +371,14 @@
                   (is (= {"Default A" :read, "Default A -> B" :write, :root :none}
                          (nice-graph (graph/graph)))))
 
-                (testing "A CollectionRevision recording the *changes* to the perms graph should be saved."
+                (testing "A CollectionPermissionGraphRevision recording the *changes* to the perms graph should be saved."
                   (is (schema= {:id         su/IntGreaterThanZero
                                 :before     (s/eq (mt/obj->json->obj (assoc before :namespace "currency")))
                                 :after      (s/eq {(keyword (str group-id)) {(keyword (str currency-a)) "write"}})
                                 :user_id    (s/eq (mt/user->id :crowberto))
                                 :created_at java.time.temporal.Temporal
                                 s/Keyword   s/Any}
-                               (db/select-one CollectionRevision {:order-by [[:id :desc]]}))))))
+                               (db/select-one CollectionPermissionGraphRevision {:order-by [[:id :desc]]}))))))
 
             (testing "should be able to update permissions for the Root Collection in the default namespace via the graph"
               (graph/update-graph! (assoc (graph/graph) :groups {group-id {:root :read}}))
@@ -388,7 +389,7 @@
                 (is (= {:root :none, "Currency A" :write, "Currency A -> B" :read}
                        (nice-graph (graph/graph :currency)))))
 
-              (testing "A CollectionRevision recording the *changes* to the perms graph should be saved."
+              (testing "A CollectionPermissionGraphRevision recording the *changes* to the perms graph should be saved."
                 (is (schema= {:before   {:namespace (s/eq nil)
                                          :groups    {(keyword (str group-id)) {:root     (s/eq "none")
                                                                                s/Keyword s/Any}
@@ -396,7 +397,7 @@
                                          s/Keyword  s/Any}
                               :after    {(keyword (str group-id)) {:root (s/eq "read")}}
                               s/Keyword s/Any}
-                             (db/select-one CollectionRevision {:order-by [[:id :desc]]})))))
+                             (db/select-one CollectionPermissionGraphRevision {:order-by [[:id :desc]]})))))
 
             (testing "should be able to update permissions for Root Collection in non-default namespace"
               (graph/update-graph! :currency (assoc (graph/graph :currency) :groups {group-id {:root :write}}))
@@ -407,7 +408,7 @@
                 (is (= {:root :read, "Default A" :read, "Default A -> B" :write}
                        (nice-graph (graph/graph)))))
 
-              (testing "A CollectionRevision recording the *changes* to the perms graph should be saved."
+              (testing "A CollectionPermissionGraphRevision recording the *changes* to the perms graph should be saved."
                 (is (schema= {:before   {:namespace (s/eq "currency")
                                          :groups    {(keyword (str group-id)) {:root     (s/eq "none")
                                                                                s/Keyword s/Any}
@@ -415,7 +416,7 @@
                                          s/Keyword  s/Any}
                               :after    {(keyword (str group-id)) {:root (s/eq "write")}}
                               s/Keyword s/Any}
-                             (db/select-one CollectionRevision {:order-by [[:id :desc]]})))))))))))
+                             (db/select-one CollectionPermissionGraphRevision {:order-by [[:id :desc]]})))))))))))
 
 (defn- do-with-n-temp-users-with-personal-collections! [num-users thunk]
   (mt/with-model-cleanup [User Collection]

--- a/test/metabase/models/collection/graph_test.clj
+++ b/test/metabase/models/collection/graph_test.clj
@@ -5,7 +5,7 @@
             [metabase.api.common :refer [*current-user-id*]]
             [metabase.models :refer [User]]
             [metabase.models.collection :as collection :refer [Collection]]
-            [metabase.models.collection-permission-graph-revision :as collection.perms
+            [metabase.models.collection-permission-graph-revision :as c-perm-revision
              :refer [CollectionPermissionGraphRevision]]
             [metabase.models.collection.graph :as graph]
             [metabase.models.permissions :as perms]
@@ -292,7 +292,7 @@
 
         (testing "No revision should have been saved"
           (is (= 0
-                 (collection.perms/latest-id)))))))
+                 (c-perm-revision/latest-id)))))))
 
   (testing "Make sure you can't be sneaky and edit descendants of Personal Collections either."
     (mt/with-temp Collection [collection {:location (lucky-collection-children-location)}]


### PR DESCRIPTION
Table `collection_revision` renamed to `collection_permission_graph_revision`

In anticipation of collection revision history, need to free up the table name. this model/table is only used in two places and it relates to the collection permission graph history, not revisions to the collection.

Quite open to bikeshedding on 
- table name `collection_permission_graph_revision`
- namespace name `metabase.models.collection-permission-graph-revision`
- model name `CollectionPermissionGraphRevision`
- the ns alias `[metabase.models.collection-permission-graph-revision :as c-perm-revision]`


Bummer that we can't use preconditions on a change type that isn't supported by the dbms type. Wanted to use the built-in `renameSequence` with a precondition that we're on postgres but it doesn't check the precondition before validating that h2 doesn't support `renameSequence`