### PR TITLE
#15578 Repro: Remapped columns failure in joined subquestions

### DIFF
--- a/frontend/test/metabase/scenarios/question/joins.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/joins.cy.spec.js
@@ -1,0 +1,43 @@
+import { restore, openProductsTable, popover } from "__support__/cypress";
+import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
+
+const { ORDERS, ORDERS_ID, PRODUCTS } = SAMPLE_DATASET;
+
+describe("scenarios > question > joined questions", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it.skip("joining on a question with remapped values should work (metabase#15578)", () => {
+    cy.intercept("POST", "/api/dataset").as("dataset");
+    // Remap display value
+    cy.request("POST", `/api/field/${ORDERS.PRODUCT_ID}/dimension`, {
+      name: "Product ID",
+      type: "external",
+      human_readable_field_id: PRODUCTS.TITLE,
+    });
+
+    cy.createQuestion({
+      name: "15578",
+      query: { "source-table": ORDERS_ID },
+    });
+    openProductsTable({ mode: "notebook" });
+    cy.findByText("Join data").click();
+    popover()
+      .findByText("Sample Dataset")
+      .click();
+    cy.findByText("Saved Questions").click();
+    cy.findByText("15578").click();
+    popover()
+      .findByText("ID")
+      .click();
+    popover()
+      .findByText("Product ID") // Implicit assertion - test will fail for multiple strings
+      .click();
+    cy.findByText("Visualize").click();
+    cy.wait("@dataset").then(xhr => {
+      expect(xhr.response.body.error).not.to.exist;
+    });
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #15578

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/question/joins.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
Test first fails because there are 2 "Product ID" items in a popover
![image](https://user-images.githubusercontent.com/31325167/114765971-1df8c600-9d66-11eb-9df0-52a3b1569dc0.png)


Sanity check - even if we ignore the first check and select the first "Product ID" (for local testing purposes only), the test should still fail on the visualization
![image](https://user-images.githubusercontent.com/31325167/114765879-fefa3400-9d65-11eb-9b80-8ae0f962bca1.png)

