### PR TITLE
Fix `data_ref.cy.spec.js` flake

### DIFF
--- a/frontend/test/metabase/scenarios/question/data_ref.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/data_ref.cy.spec.js
@@ -1,6 +1,6 @@
 import { restore } from "__support__/cypress";
 
-describe("scenarios > question > data reference sidebar", () => {
+describe("scenarios > native question > data reference sidebar", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
@@ -8,11 +8,12 @@ describe("scenarios > question > data reference sidebar", () => {
 
   it("should load needed data", () => {
     cy.visit("/question/new");
-    cy.contains("Native query").click();
-    cy.reload(); // reload to remove data preloaded on new question page
-    cy.icon("reference").click(); // open data ref
-    cy.contains("ORDERS").click();
-    cy.contains("QUANTITY").click();
-    cy.contains("Number of products bought.");
+    cy.findByText("Native query").click();
+    cy.icon("reference").click();
+    // Force-clicking was needed here because Cypress complains that "ORDERS" is covered by a <div>
+    // TODO: Maybe re-think the structure of that component because that div seems unnecessary anyway
+    cy.findByText("ORDERS").click({ force: true });
+    cy.findByText("QUANTITY").click({ force: true });
+    cy.findByText("Number of products bought.");
   });
 });


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Fixes a flake in `data_ref.cy.spec.js` ("should load needed data")

### Additional notes:
- [Example](https://app.circleci.com/pipelines/github/metabase/metabase/15083/workflows/8861bef7-ebf6-47f4-b688-f19cf7d1eb70/jobs/577513/tests#failed-test-0) of the failed CI run

Stress testing this fix locally:
![image](https://user-images.githubusercontent.com/31325167/114771218-9a8ea300-9d6c-11eb-8dbc-f3c39f254622.png)
