### PR TITLE
Move dashboard card action buttons in a popover

### DIFF
--- a/frontend/src/metabase-types/types/Visualization.js
+++ b/frontend/src/metabase-types/types/Visualization.js
@@ -98,7 +98,6 @@ export type VisualizationProps = {
   isDashboard: boolean,
   isEditing: boolean,
   isSettings: boolean,
-  actionButtons: Node,
 
   onRender: ({
     yAxisSplit?: number[][],

--- a/frontend/src/metabase-types/types/Visualization.js
+++ b/frontend/src/metabase-types/types/Visualization.js
@@ -98,6 +98,7 @@ export type VisualizationProps = {
   isDashboard: boolean,
   isEditing: boolean,
   isSettings: boolean,
+  actionButtons: Node,
 
   onRender: ({
     yAxisSplit?: number[][],

--- a/frontend/src/metabase/css/core/colors.css
+++ b/frontend/src/metabase/css/core/colors.css
@@ -248,7 +248,7 @@
 
 .text-dark,
 :local(.text-dark),
-.text-dark-hover {
+.text-dark-hover:hover {
   color: var(--color-text-dark);
 }
 

--- a/frontend/src/metabase/css/dashboard.css
+++ b/frontend/src/metabase/css/dashboard.css
@@ -114,7 +114,7 @@
 
 .DashCard {
   position: relative;
-  z-index: 1;
+  z-index: 2;
 }
 
 .DashCard .Card {
@@ -123,7 +123,6 @@
   left: 0;
   bottom: 0;
   right: 0;
-  overflow: hidden;
   background-color: white;
   border: 1px solid var(--color-border);
 }
@@ -133,7 +132,6 @@
 }
 
 .Dash--editing .DashCard .Card {
-  pointer-events: none;
   transition: border 0.3s, background-color 0.3s;
 }
 
@@ -182,29 +180,13 @@
 
 .Dash--editing .DashCard.dragging,
 .Dash--editing .DashCard.resizing {
-  z-index: 2;
+  z-index: 3;
 }
 
 .Dash--editing .DashCard.dragging .Card,
 .Dash--editing .DashCard.resizing .Card {
   background-color: var(--color-bg-medium) !important;
   border: 1px solid var(--color-brand);
-}
-
-.DashCard .DashCard-actions {
-  pointer-events: none;
-  opacity: 0;
-  transition: opacity 0.3s linear;
-}
-
-.DashCard .DashCard-actions-persistent {
-  pointer-events: all;
-}
-
-.Dash--editing .DashCard:hover .DashCard-actions {
-  height: initial;
-  opacity: 1;
-  pointer-events: all;
 }
 
 .Dash--editing .DashCard .Visualization-slow-spinner {
@@ -215,12 +197,6 @@
 .Dash--editing .DashCard:hover .Visualization-slow-spinner {
   opacity: 0;
   transition: opacity 0.15s linear;
-}
-
-.Dash--editing .DashCard.dragging .DashCard-actions,
-.Dash--editing .DashCard.resizing .DashCard-actions {
-  opacity: 0;
-  transition: opacity 0.3s linear;
 }
 
 .Dash--editing .DashCard {
@@ -251,8 +227,8 @@
   position: absolute;
   width: 8px;
   height: 8px;
-  bottom: 10px;
-  right: 10px;
+  bottom: 6px;
+  right: 6px;
   border-bottom: 2px solid var(--color-border);
   border-right: 2px solid var(--color-border);
   border-bottom-right-radius: 2px;
@@ -281,11 +257,6 @@
 
 .Dash--editing .Card-title {
   pointer-events: none;
-}
-
-/* ensure action buttons do not respond to events when dragging */
-.Dash--editing.Dash--dragging .DashCard-actions {
-  pointer-events: none !important;
 }
 
 .Modal.AddSeriesModal {

--- a/frontend/src/metabase/css/dashboard.css
+++ b/frontend/src/metabase/css/dashboard.css
@@ -292,7 +292,10 @@
   .Dashboard.Dashboard--fullscreen .Header-title-name {
     font-size: 1em;
   }
-
+  /* keep the single row text cards to avoid overflow with a scroll bar */
+  .Dashboard.Dashboard--fullscreen .Text--single-row {
+    font-size: 0.85em;
+  }
   .Dashboard.Dashboard--fullscreen .fullscreen-text-small .LegendItem {
     font-size: 1em;
   }

--- a/frontend/src/metabase/css/dashboard.css
+++ b/frontend/src/metabase/css/dashboard.css
@@ -112,6 +112,10 @@
   margin-top: 1em;
 }
 
+.Dash--editing {
+  margin-top: 1.5em;
+}
+
 .DashCard {
   position: relative;
   z-index: 2;
@@ -133,6 +137,10 @@
 
 .Dash--editing .DashCard .Card {
   transition: border 0.3s, background-color 0.3s;
+}
+
+.Dash--editing .Card-title:first-of-type {
+  margin-top: 0.5rem;
 }
 
 .Dash--editing .DashCard:hover .Card .Card-heading {

--- a/frontend/src/metabase/dashboard/components/DashCard.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard.jsx
@@ -1,5 +1,6 @@
 /* eslint-disable react/prop-types */
 import React, { Component } from "react";
+import styled from "styled-components";
 import { connect } from "react-redux";
 import PropTypes from "prop-types";
 import ReactDOM from "react-dom";
@@ -60,6 +61,15 @@ export default class DashCard extends Component {
     navigateToNewCardFromDashboard: PropTypes.func.isRequired,
   };
 
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      showActionsPanel: false,
+      isPreviewingCard: false,
+    };
+  }
+
   async componentDidMount() {
     const { dashcard, markNewCardSeen } = this.props;
 
@@ -76,6 +86,24 @@ export default class DashCard extends Component {
   componentWillUnmount() {
     window.clearInterval(this.visibilityTimer);
   }
+
+  handlePreviewToggle = () => {
+    this.setState(prevState => ({
+      isPreviewingCard: !prevState.isPreviewingCard,
+    }));
+  };
+
+  handleMouseEnter = () => {
+    this.setState({
+      showActionsPanel: true,
+    });
+  };
+
+  handleMouseLeave = () => {
+    this.setState({
+      showActionsPanel: false,
+    });
+  };
 
   render() {
     const {
@@ -144,10 +172,19 @@ export default class DashCard extends Component {
       !isEditing &&
       mainCard.visualization_settings["dashcard.background"] === false;
 
+    const isEditingDashboardLayout =
+      isEditing &&
+      !(clickBehaviorSidebarDashcard != null || isEditingParameter);
+
+    const showActionsPanel =
+      isEditingDashboardLayout && this.state.showActionsPanel;
+
     return (
       <div
+        onMouseEnter={this.handleMouseEnter}
+        onMouseLeave={this.handleMouseLeave}
         className={cx(
-          "Card bordered rounded flex flex-column hover-parent hover--visibility",
+          "Card relative bordered rounded flex flex-column hover-parent hover--visibility",
           {
             "Card--slow": isSlow === "usually-slow",
           },
@@ -158,8 +195,29 @@ export default class DashCard extends Component {
             : null
         }
       >
+        {showActionsPanel ? (
+          <DashboardCardActionsPanel className="drag-disabled">
+            <DashCardActionButtons
+              series={series}
+              hasError={!!errorMessage}
+              isVirtualDashCard={isVirtualDashCard(dashcard)}
+              onRemove={onRemove}
+              onAddSeries={onAddSeries}
+              onReplaceAllVisualizationSettings={
+                this.props.onReplaceAllVisualizationSettings
+              }
+              showClickBehaviorSidebar={() =>
+                this.props.showClickBehaviorSidebar(dashcard.id)
+              }
+              isPreviewing={this.state.isPreviewingCard}
+              onPreviewToggle={this.handlePreviewToggle}
+            />
+          </DashboardCardActionsPanel>
+        ) : null}
         <WrappedVisualization
-          className="flex-full"
+          className={cx("flex-full", {
+            "pointer-events-none": isEditingDashboardLayout,
+          })}
           classNameWidgets={isEmbed && "text-light text-medium-hover"}
           error={errorMessage}
           errorIcon={errorIcon}
@@ -173,27 +231,14 @@ export default class DashCard extends Component {
           dashboard={dashboard}
           parameterValuesBySlug={params}
           isEditing={isEditing}
+          isPreviewing={this.state.isPreviewingCard}
           gridSize={
             this.props.isMobile
               ? undefined
               : { width: dashcard.sizeX, height: dashcard.sizeY }
           }
           actionButtons={
-            isEditing ? (
-              <DashCardActionButtons
-                series={series}
-                hasError={!!errorMessage}
-                isVirtualDashCard={isVirtualDashCard(dashcard)}
-                onRemove={onRemove}
-                onAddSeries={onAddSeries}
-                onReplaceAllVisualizationSettings={
-                  this.props.onReplaceAllVisualizationSettings
-                }
-                showClickBehaviorSidebar={() =>
-                  this.props.showClickBehaviorSidebar(dashcard.id)
-                }
-              />
-            ) : isEmbed ? (
+            isEmbed ? (
               <QueryDownloadWidget
                 className="m1 text-brand-hover text-light"
                 classNameClose="hover-child"
@@ -203,9 +248,7 @@ export default class DashCard extends Component {
                 token={dashcard.dashboard_id}
                 icon="download"
               />
-            ) : (
-              undefined
-            )
+            ) : null
           }
           onUpdateVisualizationSettings={
             this.props.onUpdateVisualizationSettings
@@ -251,6 +294,23 @@ export default class DashCard extends Component {
   }
 }
 
+const DashboardCardActionsPanel = styled.div`
+  padding: 0.25em;
+  position: absolute;
+  background: white;
+  transform: translateY(-100%);
+  top: 0;
+  right: 0;
+  border-radius: 8px;
+  box-shadow: 0px 1px 3px rgb(0 0 0 / 13%);
+  z-index: 3;
+  cursor: default;
+
+  .Dash--dragging & {
+    display: none;
+  }
+`;
+
 const DashCardActionButtons = ({
   series,
   isVirtualDashCard,
@@ -259,8 +319,20 @@ const DashCardActionButtons = ({
   onAddSeries,
   onReplaceAllVisualizationSettings,
   showClickBehaviorSidebar,
+  onPreviewToggle,
+  isPreviewing,
 }) => {
   const buttons = [];
+
+  if (getVisualizationRaw(series).visualization.supportPreviewing) {
+    buttons.push(
+      <ToggleCardPreviewButton
+        isPreviewing={isPreviewing}
+        onPreviewToggle={onPreviewToggle}
+      />,
+    );
+  }
+
   if (!hasError) {
     if (
       onReplaceAllVisualizationSettings &&
@@ -366,6 +438,29 @@ const AddSeriesButton = ({ series, onAddSeries }) => (
   </a>
 );
 
+const ToggleCardPreviewButton = ({ isPreviewing, onPreviewToggle }) => {
+  return (
+    <a
+      data-metabase-event={"Dashboard;Text;edit"}
+      className="text-light text-medium-hover cursor-pointer h3 flex-no-shrink relative mr1 drag-disabled"
+      onClick={onPreviewToggle}
+      style={HEADER_ACTION_STYLE}
+    >
+      <Tooltip tooltip={isPreviewing ? t`Edit` : t`Preview`}>
+        <span className="flex align-center">
+          <span className="flex" style={{ width: 18 }}>
+            {isPreviewing ? (
+              <Icon name="edit_document" size={HEADER_ICON_SIZE} />
+            ) : (
+              <Icon name="eye" size={18} />
+            )}
+          </span>
+        </span>
+      </Tooltip>
+    </a>
+  );
+};
+
 function getSeriesIconName(series) {
   try {
     const display = series[0].card.display;
@@ -380,7 +475,6 @@ const MIN_WIDTH_FOR_ON_CLICK_LABEL = 330;
 const ClickBehaviorSidebarOverlay = ({
   dashcard,
   dashcardWidth,
-  dashboard,
   showClickBehaviorSidebar,
   isShowingThisClickBehaviorSidebar,
 }) => {

--- a/frontend/src/metabase/dashboard/components/DashCard.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard.jsx
@@ -160,8 +160,7 @@ export default class DashCard extends Component {
       mainCard.visualization_settings["dashcard.background"] === false;
 
     const isEditingDashboardLayout =
-      isEditing &&
-      !(clickBehaviorSidebarDashcard != null || isEditingParameter);
+      isEditing && clickBehaviorSidebarDashcard == null && !isEditingParameter;
 
     return (
       <div

--- a/frontend/src/metabase/dashboard/components/DashCard.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard.jsx
@@ -65,7 +65,6 @@ export default class DashCard extends Component {
     super(props);
 
     this.state = {
-      showActionsPanel: false,
       isPreviewingCard: false,
     };
   }
@@ -91,18 +90,6 @@ export default class DashCard extends Component {
     this.setState(prevState => ({
       isPreviewingCard: !prevState.isPreviewingCard,
     }));
-  };
-
-  handleMouseEnter = () => {
-    this.setState({
-      showActionsPanel: true,
-    });
-  };
-
-  handleMouseLeave = () => {
-    this.setState({
-      showActionsPanel: false,
-    });
   };
 
   render() {
@@ -176,15 +163,10 @@ export default class DashCard extends Component {
       isEditing &&
       !(clickBehaviorSidebarDashcard != null || isEditingParameter);
 
-    const showActionsPanel =
-      isEditingDashboardLayout && this.state.showActionsPanel;
-
     return (
       <div
-        onMouseEnter={this.handleMouseEnter}
-        onMouseLeave={this.handleMouseLeave}
         className={cx(
-          "Card relative bordered rounded flex flex-column hover-parent hover--visibility",
+          "Card bordered rounded flex flex-column hover-parent hover--visibility",
           {
             "Card--slow": isSlow === "usually-slow",
           },
@@ -195,7 +177,7 @@ export default class DashCard extends Component {
             : null
         }
       >
-        {showActionsPanel ? (
+        {isEditingDashboardLayout ? (
           <DashboardCardActionsPanel className="drag-disabled">
             <DashCardActionButtons
               series={series}
@@ -295,16 +277,24 @@ export default class DashCard extends Component {
 }
 
 const DashboardCardActionsPanel = styled.div`
-  padding: 0.25em;
+  padding: 0.125em 0.25em;
   position: absolute;
   background: white;
-  transform: translateY(-100%);
+  transform: translateY(-50%);
   top: 0;
-  right: 0;
+  right: 20px;
   border-radius: 8px;
   box-shadow: 0px 1px 3px rgb(0 0 0 / 13%);
   z-index: 3;
   cursor: default;
+  transition: opacity 200ms;
+  opacity: 0;
+  pointer-events: none;
+
+  .Card:hover & {
+    opacity: 1;
+    pointer-events: all;
+  }
 
   .Dash--dragging & {
     display: none;
@@ -349,7 +339,7 @@ const DashCardActionButtons = ({
       buttons.push(
         <Tooltip tooltip={t`Click behavior`}>
           <a
-            className="text-light text-medium-hover drag-disabled mr1"
+            className="text-dark-hover drag-disabled mr1"
             data-metabase-event="Dashboard;Open Click Behavior Sidebar"
             onClick={showClickBehaviorSidebar}
             style={HEADER_ACTION_STYLE}
@@ -368,10 +358,7 @@ const DashCardActionButtons = ({
   }
 
   return (
-    <span
-      className="DashCard-actions flex align-center"
-      style={{ lineHeight: 1 }}
-    >
+    <span className="flex align-center text-medium" style={{ lineHeight: 1 }}>
       {buttons}
       <Tooltip tooltip={t`Remove`}>
         <RemoveButton className="ml1" onRemove={onRemove} />
@@ -393,7 +380,7 @@ const ChartSettingsButton = ({ series, onReplaceAllVisualizationSettings }) => (
         />
       </Tooltip>
     }
-    triggerClasses="text-light text-medium-hover cursor-pointer flex align-center flex-no-shrink mr1 drag-disabled"
+    triggerClasses="text-dark-hover cursor-pointer flex align-center flex-no-shrink mr1 drag-disabled"
   >
     <ChartSettingsWithState
       className="spread"
@@ -406,7 +393,7 @@ const ChartSettingsButton = ({ series, onReplaceAllVisualizationSettings }) => (
 
 const RemoveButton = ({ onRemove }) => (
   <a
-    className="text-light text-medium-hover drag-disabled"
+    className="text-dark-hover drag-disabled"
     data-metabase-event="Dashboard;Remove Card Modal"
     onClick={onRemove}
     style={HEADER_ACTION_STYLE}
@@ -418,7 +405,7 @@ const RemoveButton = ({ onRemove }) => (
 const AddSeriesButton = ({ series, onAddSeries }) => (
   <a
     data-metabase-event={"Dashboard;Edit Series Modal;open"}
-    className="text-light text-medium-hover cursor-pointer h3 flex-no-shrink relative mr1 drag-disabled"
+    className="text-dark-hover cursor-pointer h3 flex-no-shrink relative mr1 drag-disabled"
     onClick={onAddSeries}
     style={HEADER_ACTION_STYLE}
   >
@@ -442,7 +429,7 @@ const ToggleCardPreviewButton = ({ isPreviewing, onPreviewToggle }) => {
   return (
     <a
       data-metabase-event={"Dashboard;Text;edit"}
-      className="text-light text-medium-hover cursor-pointer h3 flex-no-shrink relative mr1 drag-disabled"
+      className="text-dark-hover cursor-pointer h3 flex-no-shrink relative mr1 drag-disabled"
       onClick={onPreviewToggle}
       style={HEADER_ACTION_STYLE}
     >

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
@@ -18,13 +18,14 @@ import {
   GRID_ASPECT_RATIO,
   GRID_MARGIN,
   DEFAULT_CARD_SIZE,
+  MIN_ROW_HEIGHT,
 } from "metabase/lib/dashboard_grid";
 
 import _ from "underscore";
 import cx from "classnames";
 
 const MOBILE_ASPECT_RATIO = 3 / 2;
-const MOBILE_TEXT_CARD_ROW_HEIGHT = 40;
+const MOBILE_TEXT_CARD_ROW_HEIGHT = 60;
 
 @ExplicitSize()
 export default class DashboardGrid extends Component {
@@ -286,7 +287,10 @@ export default class DashboardGrid extends Component {
 
   renderGrid() {
     const { dashboard, width } = this.props;
-    const rowHeight = Math.floor(width / GRID_WIDTH / GRID_ASPECT_RATIO);
+    const rowHeight = Math.max(
+      Math.floor(width / GRID_WIDTH / GRID_ASPECT_RATIO),
+      MIN_ROW_HEIGHT,
+    );
     return (
       <GridLayout
         className={cx("DashboardGrid", {

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
@@ -257,7 +257,6 @@ export default class DashboardGrid extends Component {
           "Dash--editing": this.isEditingLayout,
           "Dash--dragging": this.state.isDragging,
         })}
-        style={{ margin: 0 }}
       >
         {dashcards &&
           dashcards.map(dc => (

--- a/frontend/src/metabase/lib/dashboard_grid.js
+++ b/frontend/src/metabase/lib/dashboard_grid.js
@@ -6,6 +6,8 @@ export const GRID_MARGIN = 6;
 
 export const DEFAULT_CARD_SIZE = { width: 4, height: 4 };
 
+export const MIN_ROW_HEIGHT = 60;
+
 type DashCardPosition = {
   col: number,
   row: number,

--- a/frontend/src/metabase/visualizations/components/TableSimple.jsx
+++ b/frontend/src/metabase/visualizations/components/TableSimple.jsx
@@ -197,7 +197,11 @@ export default class TableSimple extends Component {
               </thead>
               <tbody>
                 {rowIndexes.slice(start, end + 1).map((rowIndex, index) => (
-                  <tr key={rowIndex} ref={index === 0 ? "firstRow" : null}>
+                  <tr
+                    key={rowIndex}
+                    ref={index === 0 ? "firstRow" : null}
+                    data-testid="table-row"
+                  >
                     {rows[rowIndex].map((value, columnIndex) => {
                       const column = cols[columnIndex];
                       const clicked = getTableCellClickedObject(

--- a/frontend/src/metabase/visualizations/visualizations/Text.css
+++ b/frontend/src/metabase/visualizations/visualizations/Text.css
@@ -6,20 +6,19 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-  padding: 1em 0 1em 1.5em;
+  padding: 0.5em 0.75em;
   height: 100%;
 }
-:local .Text.dashboard-is-editing {
-  padding: 2.8em 1.3em var(--text-card-padding) 1.3em;
-}
 :local .Text .text-card-textarea {
-  padding: 0.5em 0.75em 0.5em 0.75em;
+  padding: 0.25em 0.75em;
   font-size: 1.143em;
   line-height: 1.602em;
   pointer-events: all;
   resize: none;
   outline: none;
   border-radius: var(--default-border-radius);
+  min-height: unset;
+  height: inherit;
 }
 :local .Text .text-card-textarea:focus {
   border-color: var(--color-brand);
@@ -153,10 +152,4 @@
 :local .text-card-markdown img {
   width: 100%;
   height: auto;
-}
-
-@media screen and (--breakpoint-max-lg) {
-  :local .Text {
-    padding: 0.5em 0 0.5em 1em;
-  }
 }

--- a/frontend/src/metabase/visualizations/visualizations/Text.css
+++ b/frontend/src/metabase/visualizations/visualizations/Text.css
@@ -153,3 +153,7 @@
   width: 100%;
   height: auto;
 }
+
+:local .single-row {
+  margin: 0;
+}

--- a/frontend/src/metabase/visualizations/visualizations/Text.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Text.jsx
@@ -3,18 +3,10 @@ import React, { Component } from "react";
 import ReactMarkdown from "react-markdown";
 import styles from "./Text.css";
 
-import Icon from "metabase/components/Icon";
-
 import cx from "classnames";
 import { t } from "ttag";
 
 import type { VisualizationProps } from "metabase-types/types/Visualization";
-
-const HEADER_ICON_SIZE = 16;
-
-const HEADER_ACTION_STYLE = {
-  padding: 4,
-};
 
 type State = {
   isShowingRenderedOutput: boolean,
@@ -36,7 +28,6 @@ export default class Text extends Component {
     super(props);
 
     this.state = {
-      isShowingRenderedOutput: false,
       text: "",
     };
   }
@@ -49,6 +40,7 @@ export default class Text extends Component {
   static noHeader = true;
   static supportsSeries = false;
   static hidden = true;
+  static supportPreviewing = true;
 
   static minSize = { width: 4, height: 1 };
 
@@ -102,33 +94,12 @@ export default class Text extends Component {
     },
   };
 
-  UNSAFE_componentWillReceiveProps(newProps: VisualizationProps) {
-    // dashboard is going into edit mode
-    if (!this.props.isEditing && newProps.isEditing) {
-      this.onEdit();
-    }
-  }
-
   handleTextChange(text: string) {
     this.props.onUpdateVisualizationSettings({ text: text });
   }
 
-  onEdit() {
-    this.setState({ isShowingRenderedOutput: false });
-  }
-
-  onPreview() {
-    this.setState({ isShowingRenderedOutput: true });
-  }
-
   render() {
-    const {
-      className,
-      actionButtons,
-      gridSize,
-      settings,
-      isEditing,
-    } = this.props;
+    const { className, gridSize, settings, isEditing } = this.props;
     const isSmall = gridSize && gridSize.width < 4;
 
     if (isEditing) {
@@ -141,13 +112,7 @@ export default class Text extends Component {
             styles["dashboard-is-editing"],
           )}
         >
-          <TextActionButtons
-            actionButtons={actionButtons}
-            isShowingRenderedOutput={this.state.isShowingRenderedOutput}
-            onEdit={this.onEdit.bind(this)}
-            onPreview={this.onPreview.bind(this)}
-          />
-          {this.state.isShowingRenderedOutput ? (
+          {this.props.isPreviewing ? (
             <ReactMarkdown
               className={cx(
                 "full flex-full flex flex-column text-card-markdown",
@@ -195,62 +160,3 @@ export default class Text extends Component {
     }
   }
 }
-
-const TextActionButtons = ({
-  actionButtons,
-  isShowingRenderedOutput,
-  onEdit,
-  onPreview,
-}) => (
-  <div className="Card-title">
-    <div className="absolute top left p1 px2">
-      <span
-        className="DashCard-actions-persistent flex align-center"
-        style={{ lineHeight: 1 }}
-      >
-        <a
-          data-metabase-event={"Dashboard;Text;edit"}
-          className={cx(
-            "cursor-pointer h3 flex-no-shrink relative mr1 drag-disabled",
-            {
-              "text-light text-medium-hover": isShowingRenderedOutput,
-              "text-brand": !isShowingRenderedOutput,
-            },
-          )}
-          onClick={onEdit}
-          style={HEADER_ACTION_STYLE}
-        >
-          <span className="flex align-center">
-            <span className="flex">
-              <Icon
-                name="edit_document"
-                style={{ top: 0, left: 0 }}
-                size={HEADER_ICON_SIZE}
-              />
-            </span>
-          </span>
-        </a>
-
-        <a
-          data-metabase-event={"Dashboard;Text;preview"}
-          className={cx(
-            "cursor-pointer h3 flex-no-shrink relative mr1 drag-disabled",
-            {
-              "text-light text-medium-hover": !isShowingRenderedOutput,
-              "text-brand": isShowingRenderedOutput,
-            },
-          )}
-          onClick={onPreview}
-          style={HEADER_ACTION_STYLE}
-        >
-          <span className="flex align-center">
-            <span className="flex">
-              <Icon name="eye" style={{ top: 0, left: 0 }} size={20} />
-            </span>
-          </span>
-        </a>
-      </span>
-    </div>
-    <div className="absolute top right p1 px2">{actionButtons}</div>
-  </div>
-);

--- a/frontend/src/metabase/visualizations/visualizations/Text.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Text.jsx
@@ -100,18 +100,11 @@ export default class Text extends Component {
 
   render() {
     const { className, gridSize, settings, isEditing } = this.props;
-    const isSmall = gridSize && gridSize.width < 4;
+    const isSingleRow = gridSize && gridSize.height === 1;
 
     if (isEditing) {
       return (
-        <div
-          className={cx(
-            className,
-            styles.Text,
-            styles[isSmall ? "small" : "large"],
-            styles["dashboard-is-editing"],
-          )}
-        >
+        <div className={cx(className, styles.Text)}>
           {this.props.isPreviewing ? (
             <ReactMarkdown
               className={cx(
@@ -138,14 +131,12 @@ export default class Text extends Component {
     } else {
       return (
         <div
-          className={cx(
-            className,
-            styles.Text,
-            styles[isSmall ? "small" : "large"],
+          className={cx(className, styles.Text, {
             /* if the card is not showing a background we should adjust the left
              * padding to help align the titles with the wrapper */
-            { pl0: !settings["dashcard.background"] },
-          )}
+            pl0: !settings["dashcard.background"],
+            "Text--single-row": isSingleRow,
+          })}
         >
           <ReactMarkdown
             className={cx(

--- a/frontend/test/__support__/cypress.js
+++ b/frontend/test/__support__/cypress.js
@@ -1,4 +1,5 @@
 import "@testing-library/cypress/add-commands";
+import "cypress-real-events/support";
 import "@cypress/skip-test/support";
 import "./commands";
 
@@ -327,4 +328,10 @@ export function mockSessionProperty(propertyOrObject, value) {
       }
     });
   });
+}
+
+export function showDashboardCardActions(index = 0) {
+  cy.get(".DashCard")
+    .eq(index)
+    .realHover();
 }

--- a/frontend/test/metabase/scenarios/dashboard/chained-filters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/chained-filters.cy.spec.js
@@ -301,6 +301,7 @@ describe("scenarios > dashboard > chained filter", () => {
 
         cy.visit(`/dashboard/${DASHBOARD_ID}`);
         cy.icon("pencil").click();
+        cy.get(".DashCard").trigger("mouseover");
         cy.get(".DashCard .Icon-click").click({ force: true });
         cy.findByText(/Ean/i).click();
         cy.findByText("Update a dashboard filter").click();

--- a/frontend/test/metabase/scenarios/dashboard/chained-filters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/chained-filters.cy.spec.js
@@ -1,4 +1,8 @@
-import { restore, popover } from "__support__/cypress";
+import {
+  restore,
+  popover,
+  showDashboardCardActions,
+} from "__support__/cypress";
 import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
 
 const { PEOPLE, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATASET;
@@ -301,8 +305,8 @@ describe("scenarios > dashboard > chained filter", () => {
 
         cy.visit(`/dashboard/${DASHBOARD_ID}`);
         cy.icon("pencil").click();
-        cy.get(".DashCard").trigger("mouseover");
-        cy.get(".DashCard .Icon-click").click({ force: true });
+        showDashboardCardActions();
+        cy.icon("click").click();
         cy.findByText(/Ean/i).click();
         cy.findByText("Update a dashboard filter").click();
         cy.findByText("Available filters")

--- a/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
@@ -27,6 +27,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
       cy.visit(`/dashboard/${dashboardId}`),
     );
     cy.icon("pencil").click();
+    cy.get(".DashCard").trigger("mouseover");
     cy.icon("click").click({ force: true });
 
     // configure a URL click through on the  "MY_NUMBER" column
@@ -140,6 +141,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
       cy.visit(`/dashboard/${dashboardId}`),
     );
     cy.icon("pencil").click();
+    cy.get(".DashCard").trigger("mouseover");
     cy.icon("click").click({ force: true });
 
     // configure a dashboard target for the "MY_NUMBER" column
@@ -191,6 +193,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
       );
     });
     cy.icon("pencil").click();
+    cy.get(".DashCard").trigger("mouseover");
     cy.icon("click").click({ force: true });
 
     // configure clicks on "MY_NUMBER to update the param
@@ -233,6 +236,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
       cy.visit(`/dashboard/${dashboardId}`),
     );
     cy.icon("pencil").click();
+    cy.get(".DashCard").trigger("mouseover");
     cy.icon("click").click({ force: true });
 
     // configure clicks on "MY_NUMBER to update the param
@@ -575,6 +579,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
 
         cy.visit(`/dashboard/${DASHBOARD_ID}`);
         cy.icon("pencil").click();
+        cy.get(".DashCard").trigger("mouseover");
         // Edit "Visualization options"
         cy.get(".DashCard .Icon-palette").click({ force: true });
         cy.get(".Modal").within(() => {

--- a/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
@@ -3,6 +3,7 @@ import {
   modal,
   popover,
   createNativeQuestion,
+  showDashboardCardActions,
 } from "__support__/cypress";
 
 import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
@@ -27,8 +28,8 @@ describe("scenarios > dashboard > dashboard drill", () => {
       cy.visit(`/dashboard/${dashboardId}`),
     );
     cy.icon("pencil").click();
-    cy.get(".DashCard").trigger("mouseover");
-    cy.icon("click").click({ force: true });
+    showDashboardCardActions();
+    cy.icon("click").click();
 
     // configure a URL click through on the  "MY_NUMBER" column
     cy.findByText("On-click behavior for each column")
@@ -141,8 +142,8 @@ describe("scenarios > dashboard > dashboard drill", () => {
       cy.visit(`/dashboard/${dashboardId}`),
     );
     cy.icon("pencil").click();
-    cy.get(".DashCard").trigger("mouseover");
-    cy.icon("click").click({ force: true });
+    showDashboardCardActions();
+    cy.icon("click").click();
 
     // configure a dashboard target for the "MY_NUMBER" column
     cy.findByText("On-click behavior for each column")
@@ -193,8 +194,8 @@ describe("scenarios > dashboard > dashboard drill", () => {
       );
     });
     cy.icon("pencil").click();
-    cy.get(".DashCard").trigger("mouseover");
-    cy.icon("click").click({ force: true });
+    showDashboardCardActions();
+    cy.icon("click").click();
 
     // configure clicks on "MY_NUMBER to update the param
     cy.findByText("On-click behavior for each column")
@@ -236,8 +237,8 @@ describe("scenarios > dashboard > dashboard drill", () => {
       cy.visit(`/dashboard/${dashboardId}`),
     );
     cy.icon("pencil").click();
-    cy.get(".DashCard").trigger("mouseover");
-    cy.icon("click").click({ force: true });
+    showDashboardCardActions();
+    cy.icon("click").click();
 
     // configure clicks on "MY_NUMBER to update the param
     cy.findByText("On-click behavior for each column")
@@ -579,9 +580,9 @@ describe("scenarios > dashboard > dashboard drill", () => {
 
         cy.visit(`/dashboard/${DASHBOARD_ID}`);
         cy.icon("pencil").click();
-        cy.get(".DashCard").trigger("mouseover");
         // Edit "Visualization options"
-        cy.get(".DashCard .Icon-palette").click({ force: true });
+        showDashboardCardActions();
+        cy.icon("palette").click();
         cy.get(".Modal").within(() => {
           cy.findByText("Reset to defaults").click();
           cy.findByRole("button", { name: "Done" }).click();

--- a/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
@@ -256,6 +256,7 @@ describe("scenarios > dashboard", () => {
 
     // Add cross-filter click behavior manually
     cy.icon("pencil").click();
+    cy.get(".DashCard").trigger("mouseover");
     cy.get(".DashCard .Icon-click").click({ force: true });
     cy.findByText("COUNT(*)").click();
     cy.findByText("Update a dashboard filter").click();

--- a/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
@@ -5,6 +5,7 @@ import {
   restore,
   selectDashboardFilter,
   expectedRouteCalls,
+  showDashboardCardActions,
 } from "__support__/cypress";
 
 import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
@@ -256,8 +257,8 @@ describe("scenarios > dashboard", () => {
 
     // Add cross-filter click behavior manually
     cy.icon("pencil").click();
-    cy.get(".DashCard").trigger("mouseover");
-    cy.get(".DashCard .Icon-click").click({ force: true });
+    showDashboardCardActions();
+    cy.icon("click").click();
     cy.findByText("COUNT(*)").click();
     cy.findByText("Update a dashboard filter").click();
 

--- a/frontend/test/metabase/scenarios/dashboard/old-parameters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/old-parameters.cy.spec.js
@@ -53,7 +53,7 @@ describe("scenarios > dashboard > parameters", () => {
     cy.findByText("You're editing this dashboard.").should("not.exist");
     cy.findByText("Baker");
 
-    cy.contains("of 8");
+    cy.findAllByTestId("table-row").should("have.length", 8);
   });
 
   it("should filter by category", () => {

--- a/frontend/test/metabase/scenarios/dashboard/text-box.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/text-box.cy.spec.js
@@ -21,10 +21,16 @@ describe("scenarios > dashboard > text-box", () => {
       addTextBox("Text *text* __text__");
     });
 
-    it("should render edit and preview actions when editing", () => {
-      // Check edit options
+    it("should render correct icons for preview and edit modes", () => {
+      cy.get(".DashCard")
+        .eq(1)
+        .trigger("mouseover");
+
+      // edit mode
+      cy.icon("eye").click({ force: true });
+
+      // preview mode
       cy.icon("edit_document");
-      cy.icon("eye");
     });
 
     it("should not render edit and preview actions when not editing", () => {
@@ -59,9 +65,6 @@ describe("scenarios > dashboard > text-box", () => {
       // Add save text box to dash
       addTextBox("Dashboard testing text");
       cy.findByText("Save").click();
-
-      cy.findByText("Saving…");
-      cy.findByText("Saving…").should("not.exist");
 
       // Reload page
       cy.reload();

--- a/frontend/test/metabase/scenarios/dashboard/text-box.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/text-box.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore } from "__support__/cypress";
+import { restore, showDashboardCardActions } from "__support__/cypress";
 
 function addTextBox(string) {
   cy.icon("pencil").click();
@@ -22,12 +22,10 @@ describe("scenarios > dashboard > text-box", () => {
     });
 
     it("should render correct icons for preview and edit modes", () => {
-      cy.get(".DashCard")
-        .eq(1)
-        .trigger("mouseover");
+      showDashboardCardActions(1);
 
       // edit mode
-      cy.icon("eye").click({ force: true });
+      cy.icon("eye").click();
 
       // preview mode
       cy.icon("edit_document");

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "color-harmony": "^0.3.0",
     "core-js": "^3.1.4",
     "crossfilter": "^1.3.12",
+    "cypress-real-events": "^1.3.0",
     "d3": "^3.5.17",
     "d3-scale": "^2.1.0",
     "dc": "2.1.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4315,6 +4315,11 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
+cypress-real-events@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/cypress-real-events/-/cypress-real-events-1.3.0.tgz#d737d68dd590b28c71756d63fbf36b863e936912"
+  integrity sha512-IYkhC1C9tGR7eN5d4VmT/28swyYeRmj+c+e0YcblnnbF68CVAtpc4D+v1JiENZA4il8W5XEcI/FjI64ss2lIag==
+
 cypress@*, cypress@6.8.0, cypress@^6.8.0:
   version "6.8.0"
   resolved "https://registry.yarnpkg.com/cypress/-/cypress-6.8.0.tgz#8338f39212a8f71e91ff8c017a1b6e22d823d8c1"


### PR DESCRIPTION
## Description

### 1. Changing text cards and card actions UI

#### Before
Currently, 1 and 2 rows height text cards look not great in editing dashboard mode:
<img width="326" alt="Screen Shot 2021-04-15 at 23 20 52" src="https://user-images.githubusercontent.com/14301985/114933481-62a55f80-9e41-11eb-9b07-487bb55e272a.png">
<img width="325" alt="Screen Shot 2021-04-15 at 23 20 57" src="https://user-images.githubusercontent.com/14301985/114933493-6507b980-9e41-11eb-8fe4-9384b56245c1.png">
In addition to that, we decrease height with decreasing width of a window which leads to:
<img width="198" alt="Screen Shot 2021-04-15 at 23 22 36" src="https://user-images.githubusercontent.com/14301985/114933679-9ed8c000-9e41-11eb-8d45-2ae2787c9e20.png">

#### After
In order to keep 1-row height text cards usable, we decided not to shrink height on narrow screens and to move action buttons out of the card and show them on hover:
<img width="324" alt="Screen Shot 2021-04-19 at 23 54 18" src="https://user-images.githubusercontent.com/14301985/115302302-f725ff80-a16a-11eb-9cc9-2b8ac7db2834.png">

In order to make UX consistent, it was applied to all dashboard cards:
<img width="787" alt="Screen Shot 2021-04-19 at 23 55 01" src="https://user-images.githubusercontent.com/14301985/115302335-0147fe00-a16b-11eb-9e12-7452ae3f1e32.png">

It prevents having an overcrowded header on small cards with charts (before):
<img width="272" alt="Screen Shot 2021-04-22 at 19 55 23" src="https://user-images.githubusercontent.com/14301985/115754251-ae598b00-a3a4-11eb-89a8-dbd6395c2c74.png">

### 2. Set min height for rows of the dashboard grid

Set reasonable min height for a row so that cards on narrow screens are not that squeezed

#### Before
<img width="454" alt="Screen Shot 2021-04-20 at 00 00 18" src="https://user-images.githubusercontent.com/14301985/115303244-0c4f5e00-a16c-11eb-8419-9a0d611d1f4e.png">

#### After
<img width="457" alt="Screen Shot 2021-04-20 at 00 00 24" src="https://user-images.githubusercontent.com/14301985/115303365-30ab3a80-a16c-11eb-9288-3fd6fcd22aaf.png">


### 3. Set min height for text cards for mobile screen resolutions

#### Before
<img width="357" alt="Screen Shot 2021-04-20 at 00 01 45" src="https://user-images.githubusercontent.com/14301985/115303404-3d2f9300-a16c-11eb-8915-75492bcdaca9.png">

#### After
<img width="371" alt="Screen Shot 2021-04-20 at 00 01 50" src="https://user-images.githubusercontent.com/14301985/115303417-428cdd80-a16c-11eb-854e-d10624d9f18d.png">




