### PR TITLE
Fix collections without subcollections have an expand arrow

### DIFF
--- a/frontend/src/metabase/collections/components/CollectionsList.jsx
+++ b/frontend/src/metabase/collections/components/CollectionsList.jsx
@@ -25,6 +25,8 @@ class CollectionsList extends React.Component {
         {collections.map(c => {
           const isOpen = openCollections.indexOf(c.id) >= 0;
           const action = isOpen ? this.props.onClose : this.props.onOpen;
+          const hasChildren =
+            Array.isArray(c.children) && c.children.length > 0;
           return (
             <Box key={c.id}>
               <CollectionDropTarget collection={c}>
@@ -48,7 +50,7 @@ class CollectionsList extends React.Component {
                           c.name.length > 25 ? "flex-start" : "center"
                         }
                       >
-                        {c.children && (
+                        {hasChildren && (
                           <Flex
                             className="absolute text-brand cursor-pointer"
                             align="center"

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -461,7 +461,7 @@ describe("scenarios > collection_defaults", () => {
       cy.findByText("Orders");
     });
 
-    it("collections without sub-collections shouldn't have chevron icon", () => {
+    it("collections without sub-collections shouldn't have chevron icon (metabase#14753)", () => {
       cy.visit("/collection/root");
       cy.findByText("Your personal collection")
         .parent()

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -461,7 +461,7 @@ describe("scenarios > collection_defaults", () => {
       cy.findByText("Orders");
     });
 
-    it.skip("collections without sub-collections shouldn't have chevron icon (metabase#14753)", () => {
+    it("collections without sub-collections shouldn't have chevron icon", () => {
       cy.visit("/collection/root");
       cy.findByText("Your personal collection")
         .parent()


### PR DESCRIPTION
At the collections page sidebar collections are displayed as a tree structure. The issue is if a collection doesn't have any collections inside of it, it still has an "expand" arrow

### Before

<img width="886" alt="107569205-a82d7e00-6bad-11eb-88b4-3bc873d6fe21" src="https://user-images.githubusercontent.com/17258145/114853452-796d9700-9dec-11eb-8253-432571e16205.png">

### After

<img width="660" alt="Screenshot 2021-04-15 at 13 10 33" src="https://user-images.githubusercontent.com/17258145/114853617-a457eb00-9dec-11eb-88be-d48a8bc3566c.png">


Fixes #14753 