### PR TITLE
Add Cypress test for typeahead search

### DIFF
--- a/frontend/test/metabase/scenarios/home/search.cy.spec.js
+++ b/frontend/test/metabase/scenarios/home/search.cy.spec.js
@@ -1,0 +1,25 @@
+import { restore } from "__support__/cypress";
+import { USERS } from "__support__/cypress_data";
+
+["admin", "normal"].forEach(user => {
+  describe(`search > ${user} user`, () => {
+    beforeEach(() => {
+      restore();
+      cy.signIn(user);
+      cy.visit("/");
+    });
+
+    // There was no issue for this, but it was implemented in pull request #15614
+    it("should be able to use typeahead search functionality", () => {
+      const personalCollectionsLength =
+        user === "admin" ? Object.entries(USERS).length : 1;
+
+      cy.findByPlaceholderText("Search…").type("pers");
+      cy.get(".LoadingSpinner").should("not.exist");
+      cy.findAllByText(/personal collection$/i).should(
+        "have.length",
+        personalCollectionsLength,
+      );
+    });
+  });
+});


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Adds Cypress coverage for typeahead search functionality for both admin and non-admin users
- Although the issue was never created (it was discovered offline), the fix was implemented in #15614

### Screenshots
Admin
![image](https://user-images.githubusercontent.com/31325167/114862197-87bcb280-9dee-11eb-9c6a-1edb06cbb203.png)

Non-admin
![image](https://user-images.githubusercontent.com/31325167/114862262-986d2880-9dee-11eb-8116-c7ed96b70d25.png)
