### PR TITLE
Remove question mark from operators feature flag

### DIFF
--- a/frontend/src/metabase/meta/Dashboard.js
+++ b/frontend/src/metabase/meta/Dashboard.js
@@ -31,7 +31,7 @@ export type ParameterSection = {
 };
 
 const areFieldFilterOperatorsEnabled = () =>
-  MetabaseSettings.get("field-filter-operators-enabled?");
+  MetabaseSettings.get("field-filter-operators-enabled");
 
 const LOCATION_OPTIONS = [
   {

--- a/frontend/src/metabase/meta/Parameter.js
+++ b/frontend/src/metabase/meta/Parameter.js
@@ -40,7 +40,7 @@ type FieldPredicate = (field: Field) => boolean;
 type VariableFilter = (variable: Variable) => boolean;
 
 const areFieldFilterOperatorsEnabled = () =>
-  MetabaseSettings.get("field-filter-operators-enabled?");
+  MetabaseSettings.get("field-filter-operators-enabled");
 
 export const PARAMETER_OPERATOR_TYPES = {
   number: [

--- a/frontend/test/__runner__/backend.js
+++ b/frontend/test/__runner__/backend.js
@@ -68,7 +68,7 @@ export const BackendResource = createSharedResource("BackendResource", {
               (process.env["MB_EDITION"] === "ee" &&
                 process.env["ENTERPRISE_TOKEN"]) ||
               undefined,
-            "MB_FIELD_FILTER_OPERATORS_ENABLED": "true",
+            MB_FIELD_FILTER_OPERATORS_ENABLED: "true",
           },
           stdio:
             process.env["DISABLE_LOGGING"] ||

--- a/frontend/test/__runner__/backend.js
+++ b/frontend/test/__runner__/backend.js
@@ -68,7 +68,7 @@ export const BackendResource = createSharedResource("BackendResource", {
               (process.env["MB_EDITION"] === "ee" &&
                 process.env["ENTERPRISE_TOKEN"]) ||
               undefined,
-            "MB_FIELD_FILTER_OPERATORS_ENABLED?": "true",
+            "MB_FIELD_FILTER_OPERATORS_ENABLED": "true",
           },
           stdio:
             process.env["DISABLE_LOGGING"] ||

--- a/frontend/test/metabase/scenarios/dashboard/old-parameters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/old-parameters.cy.spec.js
@@ -3,7 +3,7 @@ import { popover, restore, mockSessionProperty } from "__support__/cypress";
 
 describe("scenarios > dashboard > parameters", () => {
   beforeEach(() => {
-    mockSessionProperty("field-filter-operators-enabled?", false);
+    mockSessionProperty("field-filter-operators-enabled", false);
     restore();
     cy.signInAsAdmin();
   });

--- a/project.clj
+++ b/project.clj
@@ -237,7 +237,7 @@
 
     :env
     {:mb-run-mode       "dev"
-     :mb-field-filter-operators-enabled? "true"
+     :mb-field-filter-operators-enabled "true"
      :mb-test-setting-1 "ABCDEFG"}
 
     :jvm-opts
@@ -331,7 +331,7 @@
     {:mb-run-mode     "test"
      :mb-db-in-memory "true"
      :mb-jetty-join   "false"
-     :mb-field-filter-operators-enabled? "true"
+     :mb-field-filter-operators-enabled "true"
      :mb-api-key      "test-api-key"
      ;; use a random port between 3001 and 3501. That way if you run multiple sets of tests at the same time locally
      ;; they won't stomp on each other

--- a/src/metabase/api/embed.clj
+++ b/src/metabase/api/embed.clj
@@ -136,7 +136,7 @@
                                            (or widget-type (not= tag-type :dimension)))]
     {:id      (:id tag)
      :type    (or widget-type (cond (= tag-type :date)                       :date/single
-                                    (params/field-filter-operators-enabled?) :string/=
+                                    (params/field-filter-operators-enabled)  :string/=
                                     :else                                    :category))
      :target  (if (= tag-type :dimension)
                 [:dimension [:template-tag (:name tag)]]

--- a/src/metabase/driver/common/parameters.clj
+++ b/src/metabase/driver/common/parameters.clj
@@ -8,7 +8,7 @@
             [pretty.core :refer [PrettyPrintable]]
             [schema.core :as s]))
 
-(defsetting field-filter-operators-enabled?
+(defsetting field-filter-operators-enabled
   (deferred-tru "Enable the new field-filter operators")
   :type       :boolean
   :visibility :public
@@ -20,7 +20,7 @@
   longer necessary; designed so it can be used in a threading context and just raised out."
   {:added "0.39.0"}
   [field-filter]
-  (if (field-filter-operators-enabled?)
+  (if (field-filter-operators-enabled)
     field-filter
     (throw (ex-info (tru "New field filter operators are not enabled")
                     {:type qp.error-type/invalid-parameter

--- a/test/metabase/driver/sql/parameters/substitute_test.clj
+++ b/test/metabase/driver/sql/parameters/substitute_test.clj
@@ -168,7 +168,7 @@
                                                 :value {:type  operator
                                                         :value value}})})))))))
     (testing "Throws if not enabled (#15488)"
-      (with-redefs [i/field-filter-operators-enabled? (constantly false)]
+      (with-redefs [i/field-filter-operators-enabled (constantly false)]
         (is (= :invalid-parameter
                (try
                  (substitute ["select * from venues where " (param "param")]

--- a/test/metabase/query_processor/middleware/parameters/mbql_test.clj
+++ b/test/metabase/query_processor/middleware/parameters/mbql_test.clj
@@ -162,7 +162,7 @@
                                      :type   :string/starts-with
                                      :target $name
                                      :value ["B"]}]})))))
-        (with-redefs [params/field-filter-operators-enabled? (constantly false)]
+        (with-redefs [params/field-filter-operators-enabled (constantly false)]
           (testing "Throws if not enabled (#15488)"
             (is (= {:type     qp.error-type/invalid-parameter
                     :operator :number/between}


### PR DESCRIPTION
We used a question mark in the feature flag setting for enabling the new field filter operators. This is not legal for bash so there was no way to set this. This is a simple and mechanical change to remove the question mark. I'm gonna make a parallel PR that will munge this away in the defsetting macro so other settings don't fall prey to this. But this is available and fine if we want/need to ship sooner than the other is ready.

** Edit
The munging fix is here and should probably be preferred over this change: https://github.com/metabase/metabase/pull/15640