### PR TITLE
Munge setting names

### DIFF
--- a/frontend/test/__runner__/backend.js
+++ b/frontend/test/__runner__/backend.js
@@ -68,7 +68,7 @@ export const BackendResource = createSharedResource("BackendResource", {
               (process.env["MB_EDITION"] === "ee" &&
                 process.env["ENTERPRISE_TOKEN"]) ||
               undefined,
-            "MB_FIELD_FILTER_OPERATORS_ENABLED": "true",
+            MB_FIELD_FILTER_OPERATORS_ENABLED: "true",
           },
           stdio:
             process.env["DISABLE_LOGGING"] ||

--- a/frontend/test/__runner__/backend.js
+++ b/frontend/test/__runner__/backend.js
@@ -68,7 +68,7 @@ export const BackendResource = createSharedResource("BackendResource", {
               (process.env["MB_EDITION"] === "ee" &&
                 process.env["ENTERPRISE_TOKEN"]) ||
               undefined,
-            "MB_FIELD_FILTER_OPERATORS_ENABLED?": "true",
+            "MB_FIELD_FILTER_OPERATORS_ENABLED": "true",
           },
           stdio:
             process.env["DISABLE_LOGGING"] ||

--- a/project.clj
+++ b/project.clj
@@ -237,7 +237,7 @@
 
     :env
     {:mb-run-mode       "dev"
-     :mb-field-filter-operators-enabled? "true"
+     :mb-field-filter-operators-enabled "true"
      :mb-test-setting-1 "ABCDEFG"}
 
     :jvm-opts
@@ -331,7 +331,7 @@
     {:mb-run-mode     "test"
      :mb-db-in-memory "true"
      :mb-jetty-join   "false"
-     :mb-field-filter-operators-enabled? "true"
+     :mb-field-filter-operators-enabled "true"
      :mb-api-key      "test-api-key"
      ;; use a random port between 3001 and 3501. That way if you run multiple sets of tests at the same time locally
      ;; they won't stomp on each other

--- a/test/metabase/models/setting_test.clj
+++ b/test/metabase/models/setting_test.clj
@@ -567,6 +567,28 @@
                               "Test setting - this only shows up in dev (6)"
                               :visibility :internal)
                             (catch Exception e (ex-data e)))))))
+  (testing "Munge collision on first definition"
+    (defsetting ^:private test-setting-normal
+      "Test setting - this only shows up in dev (6)"
+      :visibility :internal)
+    (is (= {:existing-setting {:name :test-setting-normal, :munged-name "test-setting-normal"},
+            :new-setting {:name :test-setting-normal??, :munged-name "test-setting-normal"}}
+           (m/map-vals #(select-keys % [:name :munged-name])
+                       (try (defsetting ^:private test-setting-normal??
+                              "Test setting - this only shows up in dev (6)"
+                              :visibility :internal)
+                            (catch Exception e (ex-data e)))))))
+  (testing "Munge collision on second definition"
+    (defsetting ^:private test-setting-normal-1??
+      "Test setting - this only shows up in dev (6)"
+      :visibility :internal)
+    (is (= {:new-setting {:munged-name "test-setting-normal-1", :name :test-setting-normal-1},
+             :existing-setting {:munged-name "test-setting-normal-1", :name :test-setting-normal-1??}}
+           (m/map-vals #(select-keys % [:name :munged-name])
+                       (try (defsetting ^:private test-setting-normal-1
+                              "Test setting - this only shows up in dev (6)"
+                              :visibility :internal)
+                            (catch Exception e (ex-data e)))))))
   (testing "Removes characters not-compliant with shells"
-    (is (= "aaaa-bb-ccc"
-           (#'setting/munge-setting-name "aa'aa@#?-b@b-cc'?c?")))))
+    (is (= "aa1aa-b2b_cc3c"
+           (#'setting/munge-setting-name "aa1'aa@#?-b2@b_cc'3?c?")))))


### PR DESCRIPTION
Another attempt to handle question marks in settings. Munge names for when pulling from the environment, and ensure that no two settings have the same munged environment spot.