### PR TITLE
Fix image width on Text Cards to use max-width

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/Text.css
+++ b/frontend/src/metabase/visualizations/visualizations/Text.css
@@ -151,7 +151,7 @@
 }
 
 :local .text-card-markdown img {
-  width: 100%;
+  max-width: 100%;
   height: auto;
 }
 


### PR DESCRIPTION
This fixes the bug identified in https://github.com/metabase/metabase/issues/15356 

### Before
![Screen Shot 2021-04-15 at 4 51 25 PM](https://user-images.githubusercontent.com/70500505/114952357-ef80f680-9e0a-11eb-83e7-84e5b6429162.png)

### After
![Screen Shot 2021-04-15 at 4 38 45 PM](https://user-images.githubusercontent.com/70500505/114952364-f3147d80-9e0a-11eb-94b9-81159e5ac700.png)

