### PR TITLE
Return "Duplicate" action for read-only dashboards

### DIFF
--- a/frontend/src/metabase/collections/components/NormalItem.jsx
+++ b/frontend/src/metabase/collections/components/NormalItem.jsx
@@ -43,7 +43,7 @@ export default function NormalItem({
             ? () => onMove([item])
             : null
         }
-        onCopy={collection.can_write && item.copy ? () => onCopy([item]) : null}
+        onCopy={item.copy ? () => onCopy([item]) : null}
         onArchive={
           collection.can_write && item.setArchived
             ? () => item.setArchived(true)

--- a/frontend/src/metabase/dashboard/components/DashboardHeader.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader.jsx
@@ -309,16 +309,16 @@ export default class DashboardHeader extends Component {
           {t`Revision history`}
         </Link>,
       );
+      extraButtons.push(
+        <Link
+          className={extraButtonClassNames}
+          to={location.pathname + "/copy"}
+          data-metabase-event={"Dashboard;Copy"}
+        >
+          {t`Duplicate`}
+        </Link>,
+      );
       if (canEdit) {
-        extraButtons.push(
-          <Link
-            className={extraButtonClassNames}
-            to={location.pathname + "/copy"}
-            data-metabase-event={"Dashboard;Copy"}
-          >
-            {t`Duplicate`}
-          </Link>,
-        );
         extraButtons.push(
           <Link
             className={extraButtonClassNames}

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -563,16 +563,13 @@ function clickRevert(event_name, index = 0) {
     .click();
 }
 
-function findEllipsisMenuFor(item, index = 0) {
+function openEllipsisMenuFor(item, index = 0) {
   return cy
     .findAllByText(item)
     .eq(index)
     .closest("a")
-    .find(".Icon-ellipsis");
-}
-
-function openEllipsisMenuFor(item, index = 0) {
-  findEllipsisMenuFor(item, index).click({ force: true });
+    .find(".Icon-ellipsis")
+    .click({ force: true });
 }
 
 function clickButton(name) {

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -366,11 +366,6 @@ describe("collection permissions", () => {
               cy.signIn(user);
             });
 
-            it("should not be offered to duplicate dashboard in collections they have `read` access to", () => {
-              cy.visit("/collection/root");
-              findEllipsisMenuFor("Orders in a dashboard").should("not.exist");
-            });
-
             ["/", "/collection/root"].forEach(route => {
               it.skip("should not be offered to save dashboard in collections they have `read` access to (metabase#15281)", () => {
                 const { first_name, last_name } = USERS[user];

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -366,6 +366,14 @@ describe("collection permissions", () => {
               cy.signIn(user);
             });
 
+            it("should be offered to duplicate dashboard in collections they have `read` access to", () => {
+              cy.visit("/collection/root");
+              openEllipsisMenuFor("Orders in a dashboard");
+              popover()
+                .findByText("Duplicate this item")
+                .should("exist");
+            });
+
             ["/", "/collection/root"].forEach(route => {
               it.skip("should not be offered to save dashboard in collections they have `read` access to (metabase#15281)", () => {
                 const { first_name, last_name } = USERS[user];
@@ -414,6 +422,14 @@ describe("collection permissions", () => {
                 cy.visit("/dashboard/1");
                 cy.icon("ellipsis").click();
                 cy.findByText("Duplicate").should("not.exist");
+              });
+
+              it("should be offered to duplicate dashboard in collections they have `read` access to", () => {
+                cy.visit("/dashboard/1");
+                cy.icon("ellipsis").click();
+                popover()
+                  .findByText("Duplicate")
+                  .should("exist");
               });
             });
           });

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -418,18 +418,10 @@ describe("collection permissions", () => {
                   .should("not.exist");
               });
 
-              it("should not be offered to duplicate dashboard in collections they have `read` access to", () => {
-                cy.visit("/dashboard/1");
-                cy.icon("ellipsis").click();
-                cy.findByText("Duplicate").should("not.exist");
-              });
-
               it("should be offered to duplicate dashboard in collections they have `read` access to", () => {
                 cy.visit("/dashboard/1");
                 cy.icon("ellipsis").click();
-                popover()
-                  .findByText("Duplicate")
-                  .should("exist");
+                popover().findByText("Duplicate");
               });
             });
           });


### PR DESCRIPTION
Reverts PR #15573 

Misunderstood the issue #15280 As @flamber [noted](https://github.com/metabase/metabase/pull/15613#pullrequestreview-636623324), users have to be able to duplicate dashboards from collections they have `read` access to. The problem is we suggest to save items to collections without `write` access. This is fixed by #15613