### PR TITLE
fix missing x axis in firefox

### DIFF
--- a/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
@@ -485,7 +485,14 @@ function computeXAxisMargin(chart) {
 export function checkXAxisLabelOverlap(chart, selector = "g.x text") {
   const rects = [];
   for (const elem of chart.selectAll(selector)[0]) {
-    rects.push(elem.getBoundingClientRect());
+    const rect = elem.getBoundingClientRect();
+
+    // Skip empty ticks because of their wrong positioning in Firefox
+    if (rect.width === 0 && rect.height === 0) {
+      continue;
+    }
+
+    rects.push(rect);
     if (
       rects.length > 1 &&
       rects[rects.length - 2].right + X_LABEL_MIN_SPACING >


### PR DESCRIPTION
### Description

When there are less than 7 ticks on the x-axis, dc.js inserts empty ticks in between real ones (I did not find any of our code doing that). These empty ticks are incorrectly positioned by Firefox which leads to miscalculation of ticks overlapping.

Fixes https://github.com/metabase/metabase/issues/13257