### PR TITLE
Include application identifier in pg connections

### DIFF
--- a/src/metabase/config.clj
+++ b/src/metabase/config.clj
@@ -104,6 +104,11 @@
   local-process-uuid
   (str (UUID/randomUUID)))
 
+(defonce
+  ^{:doc "A string that contains identifying information about the Metabase version and the local process."}
+  mb-version-and-process-identifier
+  (format "%s [%s]" mb-app-id-string local-process-uuid))
+
 (defn- mb-session-cookie-samesite*
   []
   (let [same-site (str/lower-case (config-str :mb-session-cookie-samesite))]

--- a/src/metabase/db/spec.clj
+++ b/src/metabase/db/spec.clj
@@ -1,7 +1,8 @@
 (ns metabase.db.spec
   "Functions for creating JDBC DB specs for a given driver.
   Only databases that are supported as application DBs should have functions in this namespace;
-  otherwise, similar functions are only needed by drivers, and belong in those namespaces.")
+  otherwise, similar functions are only needed by drivers, and belong in those namespaces."
+  (:require [metabase.config :as config]))
 
 (defn h2
   "Create a Clojure JDBC database specification for a H2 database."
@@ -26,7 +27,8 @@
     :subprotocol                   "postgresql"
     :subname                       (make-subname host (or port 5432) db)
     ;; I think this is done to prevent conflicts with redshift driver registering itself to handle postgres://
-    :OpenSourceSubProtocolOverride true}
+    :OpenSourceSubProtocolOverride true
+    :ApplicationName               metabase.config/mb-version-and-process-identifier}
    (dissoc opts :host :port :db)))
 
 (defn mysql

--- a/src/metabase/db/spec.clj
+++ b/src/metabase/db/spec.clj
@@ -28,7 +28,7 @@
     :subname                       (make-subname host (or port 5432) db)
     ;; I think this is done to prevent conflicts with redshift driver registering itself to handle postgres://
     :OpenSourceSubProtocolOverride true
-    :ApplicationName               metabase.config/mb-version-and-process-identifier}
+    :ApplicationName               config/mb-version-and-process-identifier}
    (dissoc opts :host :port :db)))
 
 (defn mysql

--- a/test/metabase/db/spec_test.clj
+++ b/test/metabase/db/spec_test.clj
@@ -1,12 +1,14 @@
 (ns metabase.db.spec-test
   (:require [clojure.test :refer :all]
+            [metabase.config :as config]
             [metabase.db.spec :as db.spec]))
 
 (defn- default-pg-spec [db]
   {:classname                     "org.postgresql.Driver"
    :subprotocol                   "postgresql"
    :subname                       (format "//localhost:5432/%s" db)
-   :OpenSourceSubProtocolOverride true})
+   :OpenSourceSubProtocolOverride true
+   :ApplicationName               config/mb-version-and-process-identifier})
 
 (deftest basic-test
   (testing "Basic minimal config"

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -4,6 +4,7 @@
             [clojure.string :as str]
             [clojure.test :refer :all]
             [honeysql.core :as hsql]
+            [metabase.config :as config]
             [metabase.driver :as driver]
             [metabase.driver.postgres :as postgres]
             [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
@@ -52,7 +53,8 @@
             :subname                       "//localhost:5432/bird_sightings"
             :OpenSourceSubProtocolOverride true
             :user                          "camsaul"
-            :sslmode                       "disable"}
+            :sslmode                       "disable"
+            :ApplicationName               config/mb-version-and-process-identifier}
            (sql-jdbc.conn/connection-details->spec :postgres
              {:ssl    false
               :host   "localhost"
@@ -66,7 +68,8 @@
             :OpenSourceSubProtocolOverride true
             :user                          "camsaul"
             :ssl                           true
-            :sslmode                       "require"}
+            :sslmode                       "require"
+            :ApplicationName               config/mb-version-and-process-identifier}
            (sql-jdbc.conn/connection-details->spec :postgres
              {:ssl    true
               :host   "localhost"
@@ -78,7 +81,8 @@
             :subprotocol                   "postgresql"
             :subname                       "//localhost:5432/cool?prepareThreshold=0"
             :OpenSourceSubProtocolOverride true
-            :sslmode                       "disable"}
+            :sslmode                       "disable"
+            :ApplicationName               config/mb-version-and-process-identifier}
            (sql-jdbc.conn/connection-details->spec :postgres
              {:host               "localhost"
               :port               "5432"
@@ -95,7 +99,8 @@
             :sslcert                       "my-cert"
             :sslkey                        "my-key"
             :sslfactory                    "myfactoryoverride"
-            :sslrootcert                   "myrootcert"}
+            :sslrootcert                   "myrootcert"
+            :ApplicationName               config/mb-version-and-process-identifier}
            (sql-jdbc.conn/connection-details->spec :postgres
              {:ssl         true
               :host        "localhost"


### PR DESCRIPTION
Change the reported `application_name` for Postgres JDBC connections from `PostgreSQL JDBC Driver` (useless) to Metabase version + process UUID. This will let us identify the connections as originating from Metabase, and from a specific **process**

```
test-data=# SELECT count(*), datname, application_name FROM pg_stat_activity WHERE datname = 'test-data' GROUP BY datname, application_name;
 count |  datname  |                        application_name
-------+-----------+-----------------------------------------------------------------
    15 | test-data | Metabase v0.39.1-SNAPSHOT [04d518eb-df2d-4781-93b3-8701286fd45e
     1 | test-data | psql
(2 rows)
```