### PR TITLE
Enable `maildev` SMTP server in CI for Cypress tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,9 +18,6 @@ executors:
     docker:
       - image: circleci/clojure:lein-2.9.5-node-browsers
       - image: maildev/maildev
-        environment:
-          MB_EMAIL_SMTP_HOST: maildev
-          MB_EMAIL_SMTP_PORT: 25
 
   # Java 11 tests also test Metabase with the at-rest encryption enabled. See
   # https://metabase.com/docs/latest/operations-guide/encrypting-database-details-at-rest.html for an explanation of

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,10 +12,15 @@ executors:
       - image: metabase/ci:lein-2.9.5-clojure-1.10.3.814
 
   # CircleCI base (Lein 2.9.5) + Node + Headless browsers + Clojure CLI - big one
+  # Maildev runs by default with all Cypress tests
   clojure-and-node-and-browsers:
     working_directory: /home/circleci/metabase/metabase/
     docker:
       - image: circleci/clojure:lein-2.9.5-node-browsers
+      - image: maildev/maildev
+        environment:
+          MB_EMAIL_SMTP_HOST: maildev
+          MB_EMAIL_SMTP_PORT: 1025
 
   # Java 11 tests also test Metabase with the at-rest encryption enabled. See
   # https://metabase.com/docs/latest/operations-guide/encrypting-database-details-at-rest.html for an explanation of
@@ -173,15 +178,6 @@ executors:
     docker:
       - image: circleci/clojure:lein-2.9.5-node-browsers
       - image: metabase/qa-databases:mysql-sample-8
-  
-  fe-maildev:
-    working_directory: /home/circleci/metabase/metabase/
-    docker:
-      - image: circleci/clojure:lein-2.9.5-node-browsers
-      - image: maildev/maildev
-        environment:
-          MB_EMAIL_SMTP_HOST: maildev
-          MB_EMAIL_SMTP_PORT: 25
 
 ########################################################################################################################
 #                                             MAP FRAGMENTS AND CACHE KEYS                                             #
@@ -1233,15 +1229,6 @@ workflows:
           before-steps:
             - wait-for-port:
                 port: 3306
-          <<: *Matrix
-      
-      - fe-tests-cypress:
-          name: fe-tests-cypress-maildev-<< matrix.edition >>
-          requires:
-            - build-uberjar-<< matrix.edition >>
-          e: fe-maildev
-          cypress-group: "maildev"
-          only-single-database: true
           <<: *Matrix
 
   nightly:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,6 +173,15 @@ executors:
     docker:
       - image: circleci/clojure:lein-2.9.5-node-browsers
       - image: metabase/qa-databases:mysql-sample-8
+  
+  fe-maildev:
+    working_directory: /home/circleci/metabase/metabase/
+    docker:
+      - image: circleci/clojure:lein-2.9.5-node-browsers
+      - image: maildev/maildev
+        environment:
+          MB_EMAIL_SMTP_HOST: maildev
+          MB_EMAIL_SMTP_PORT: 25
 
 ########################################################################################################################
 #                                             MAP FRAGMENTS AND CACHE KEYS                                             #
@@ -1224,6 +1233,15 @@ workflows:
           before-steps:
             - wait-for-port:
                 port: 3306
+          <<: *Matrix
+      
+      - fe-tests-cypress:
+          name: fe-tests-cypress-maildev-<< matrix.edition >>
+          requires:
+            - build-uberjar-<< matrix.edition >>
+          e: fe-maildev
+          cypress-group: "maildev"
+          only-single-database: true
           <<: *Matrix
 
   nightly:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ executors:
       - image: maildev/maildev
         environment:
           MB_EMAIL_SMTP_HOST: maildev
-          MB_EMAIL_SMTP_PORT: 1025
+          MB_EMAIL_SMTP_PORT: 25
 
   # Java 11 tests also test Metabase with the at-rest encryption enabled. See
   # https://metabase.com/docs/latest/operations-guide/encrypting-database-details-at-rest.html for an explanation of

--- a/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
@@ -373,10 +373,10 @@ describe("scenarios > admin > settings", () => {
 
     it("should send a test email for a valid SMTP configuration", () => {
       // We must clear maildev inbox before each run - this will be extracted and automated
-      cy.request("DELETE", "http://localhost:1080/email/all");
+      cy.request("DELETE", "http://localhost:80/email/all");
       cy.request("PUT", "/api/setting", {
         "email-smtp-host": "localhost",
-        "email-smtp-port": "1025",
+        "email-smtp-port": "25",
         "email-smtp-username": "admin",
         "email-smtp-password": "admin",
         "email-smtp-security": "none",
@@ -385,7 +385,7 @@ describe("scenarios > admin > settings", () => {
       cy.visit("/admin/settings/email");
       cy.findByText("Send test email").click();
       cy.findByText("Sent!");
-      cy.request("GET", "http://localhost:1080/email").then(({ body }) => {
+      cy.request("GET", "http://localhost:80/email").then(({ body }) => {
         const EMAIL_BODY = body[0].text;
         expect(EMAIL_BODY).to.include("Your Metabase emails are working");
       });

--- a/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
@@ -386,8 +386,8 @@ describe("scenarios > admin > settings", () => {
       cy.findByText("Send test email").click();
       cy.findByText("Sent!");
       cy.request("GET", "http://localhost:80/email").then(({ body }) => {
-        const EMAIL_BODY = body[0].text;
-        expect(EMAIL_BODY).to.include("Your Metabase emails are working");
+        const emailBody = body[0].text;
+        expect(emailBody).to.include("Your Metabase emails are working");
       });
     });
 

--- a/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
@@ -371,6 +371,26 @@ describe("scenarios > admin > settings", () => {
       cy.findByText("Sorry, something went wrong. Please try again.");
     });
 
+    it("should send a test email for a valid SMTP configuration", () => {
+      // We must clear maildev inbox before each run - this will be extracted and automated
+      cy.request("DELETE", "http://localhost:1080/email/all");
+      cy.request("PUT", "/api/setting", {
+        "email-smtp-host": "localhost",
+        "email-smtp-port": "1025",
+        "email-smtp-username": "admin",
+        "email-smtp-password": "admin",
+        "email-smtp-security": "none",
+        "email-from-address": "mailer@metabase.test",
+      });
+      cy.visit("/admin/settings/email");
+      cy.findByText("Send test email").click();
+      cy.findByText("Sent!");
+      cy.request("GET", "http://localhost:1080/email").then(({ body }) => {
+        const EMAIL_BODY = body[0].text;
+        expect(EMAIL_BODY).to.include("Your Metabase emails are working");
+      });
+    });
+
     it("should be able to clear email settings", () => {
       cy.visit("/admin/settings/email");
       cy.findByText("Clear").click();


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Adds `maildev` docker image to the main CircleCi executor used by Cypress
- Enables SMTP server in Cypress tests (we can now test pulses, dashboard subscriptions, password resets, and everything else email related)

### How to verify this works?
- All tests in Ci should pass
    - I've added one basic test in `frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js`
    - It passed in CI, confirming this works

- Locally, you need to spin up https://registry.hub.docker.com/r/maildev/maildev docker image along side with Cypress
- The default ports (which we're also using in CCI are `80` for UI and `25` for SMTP)