### PR TITLE
Fix "select all" button in collections footer

### DIFF
--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -180,6 +180,8 @@ export default class CollectionContent extends React.Component {
         </Box>
         <BulkActions
           selected={selected}
+          onSelectAll={this.props.onSelectAll}
+          onSelectNone={this.props.onSelectNone}
           handleBulkArchive={this.handleBulkArchive}
           handleBulkMoveStart={this.handleBulkMoveStart}
           handleBulkMove={this.handleBulkMove}

--- a/frontend/src/metabase/components/BulkActionBar.jsx
+++ b/frontend/src/metabase/components/BulkActionBar.jsx
@@ -29,6 +29,7 @@ const BulkActionBar = ({ children, showing }) => (
           opacity,
           transform: `translateY(${translateY}px)`,
         }}
+        data-testid="bulk-action-bar"
       >
         <Card>{children}</Card>
       </FixedBottomBar>

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -477,25 +477,26 @@ describe("scenarios > collection_defaults", () => {
       cy.findByText("First Collection");
     });
 
-    it("should be possible to select all items using checkbox (metabase#14705)", () => {
-      cy.visit("/collection/root");
-      selectItemUsingCheckbox("Orders");
-      cy.findByText("1 item selected").should("be.visible");
-      cy.icon("dash").click();
-      cy.icon("dash").should("not.exist");
-      cy.findByText("4 items selected");
-    });
-
-    it("should be possible to deselect all items using checkbox (metabase#14705)", () => {
-      cy.visit("/collection/root");
-      selectItemUsingCheckbox("Orders");
-      cy.findByText("1 item selected").should("be.visible");
-      cy.icon("dash").click();
-      bulkActionsPanel().within(() => {
-        cy.icon("check").click();
+    describe("bulk selection (metabase#14705)", () => {
+      it("should be possible to select an item using checkbox", () => {
+        cy.visit("/collection/root");
+        selectItemUsingCheckbox("Orders");
+        cy.findByText("1 item selected").should("be.visible");
       });
-      cy.icon("check").should("not.exist");
-      bulkActionsPanel().should("not.be.visible");
+
+      it("should be possible to select all items at once", () => {
+        cy.icon("dash").click();
+        cy.icon("dash").should("not.exist");
+        cy.findByText("4 items selected");
+      });
+
+      it("should be possible to deselect all items an once", () => {
+        cy.findByTestId("bulk-action-bar").within(() => {
+          cy.icon("check").click();
+        });
+        cy.icon("check").should("not.exist");
+        cy.findByTestId("bulk-action-bar").should("not.be.visible");
+      });
     });
 
     it.skip("should be possible to select pinned item using checkbox (metabase#15338)", () => {
@@ -551,8 +552,4 @@ function selectItemUsingCheckbox(item, icon = "table") {
         .should("be.visible")
         .click();
     });
-}
-
-function bulkActionsPanel() {
-  return cy.get("[class*=Card]");
 }

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -477,7 +477,7 @@ describe("scenarios > collection_defaults", () => {
       cy.findByText("First Collection");
     });
 
-    it.skip("should let be possible to select all items using checkbox (metabase#14705)", () => {
+    it("should be possible to select all items using checkbox (metabase#14705)", () => {
       cy.visit("/collection/root");
       selectItemUsingCheckbox("Orders");
       cy.findByText("1 item selected").should("be.visible");

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -486,6 +486,18 @@ describe("scenarios > collection_defaults", () => {
       cy.findByText("4 items selected");
     });
 
+    it("should be possible to deselect all items using checkbox (metabase#14705)", () => {
+      cy.visit("/collection/root");
+      selectItemUsingCheckbox("Orders");
+      cy.findByText("1 item selected").should("be.visible");
+      cy.icon("dash").click();
+      bulkActionsPanel().within(() => {
+        cy.icon("check").click();
+      });
+      cy.icon("check").should("not.exist");
+      bulkActionsPanel().should("not.be.visible");
+    });
+
     it.skip("should be possible to select pinned item using checkbox (metabase#15338)", () => {
       cy.visit("/collection/root");
       openEllipsisMenuFor("Orders");
@@ -539,4 +551,8 @@ function selectItemUsingCheckbox(item, icon = "table") {
         .should("be.visible")
         .click();
     });
+}
+
+function bulkActionsPanel() {
+  return cy.get("[class*=Card]");
 }

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -477,26 +477,20 @@ describe("scenarios > collection_defaults", () => {
       cy.findByText("First Collection");
     });
 
-    describe("bulk selection (metabase#14705)", () => {
-      it("should be possible to select an item using checkbox", () => {
-        cy.visit("/collection/root");
-        selectItemUsingCheckbox("Orders");
-        cy.findByText("1 item selected").should("be.visible");
+    it("should be possible to apply bulk selection to items (metabase#14705)", () => {
+      cy.visit("/collection/root");
+      selectItemUsingCheckbox("Orders");
+      cy.findByText("1 item selected").should("be.visible");
+      // Select all
+      cy.icon("dash").click();
+      cy.icon("dash").should("not.exist");
+      cy.findByText("4 items selected");
+      // Deselect all
+      cy.findByTestId("bulk-action-bar").within(() => {
+        cy.icon("check").click();
       });
-
-      it("should be possible to select all items at once", () => {
-        cy.icon("dash").click();
-        cy.icon("dash").should("not.exist");
-        cy.findByText("4 items selected");
-      });
-
-      it("should be possible to deselect all items an once", () => {
-        cy.findByTestId("bulk-action-bar").within(() => {
-          cy.icon("check").click();
-        });
-        cy.icon("check").should("not.exist");
-        cy.findByTestId("bulk-action-bar").should("not.be.visible");
-      });
+      cy.icon("check").should("not.exist");
+      cy.findByTestId("bulk-action-bar").should("not.be.visible");
     });
 
     it.skip("should be possible to select pinned item using checkbox (metabase#15338)", () => {


### PR DESCRIPTION
Fixes #14705 

When you select items in a collection, you're supposed to be able to do "select all" or "deselect all" with a button in the footer bar. Right now nothing happens if you click the bulk selection control

### Demo

![2021-04-19 14 54 39](https://user-images.githubusercontent.com/17258145/115232637-9de4ae80-a11f-11eb-8545-68cfb371b2fe.gif)
