### PR TITLE
Fix archived personal sub-collections are displayed in the sidebar

### DIFF
--- a/frontend/src/metabase/collections/components/CollectionsList.jsx
+++ b/frontend/src/metabase/collections/components/CollectionsList.jsx
@@ -26,7 +26,8 @@ class CollectionsList extends React.Component {
           const isOpen = openCollections.indexOf(c.id) >= 0;
           const action = isOpen ? this.props.onClose : this.props.onOpen;
           const hasChildren =
-            Array.isArray(c.children) && c.children.length > 0;
+            Array.isArray(c.children) &&
+            c.children.filter(child => !child.archived).length > 0;
           return (
             <Box key={c.id}>
               <CollectionDropTarget collection={c}>

--- a/frontend/src/metabase/collections/containers/CollectionSidebar.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar.jsx
@@ -67,6 +67,10 @@ class CollectionSidebar extends React.Component {
       }),
     });
   };
+
+  // TODO Should we update the API to filter archived collections?
+  filterPersonalCollections = collection => !collection.archived;
+
   render() {
     const { currentUser, isRoot, collectionId, list } = this.props;
     return (
@@ -97,6 +101,7 @@ class CollectionSidebar extends React.Component {
               onOpen={this.onOpen}
               collections={currentUserPersonalCollections(list, currentUser.id)}
               initialIcon="person"
+              filter={this.filterPersonalCollections}
               currentCollection={collectionId}
             />
           </Box>

--- a/frontend/src/metabase/collections/containers/CollectionSidebar.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar.jsx
@@ -74,7 +74,7 @@ class CollectionSidebar extends React.Component {
   render() {
     const { currentUser, isRoot, collectionId, list } = this.props;
     return (
-      <Sidebar w={340} pt={3}>
+      <Sidebar w={340} pt={3} data-testid="sidebar">
         <CollectionLink
           to={Urls.collection("root")}
           selected={isRoot}

--- a/frontend/src/metabase/collections/containers/CollectionSidebar.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar.jsx
@@ -46,16 +46,7 @@ class CollectionSidebar extends React.Component {
   state = {
     openCollections: [],
   };
-  onOpen = id => {
-    this.setState({ openCollections: this.state.openCollections.concat(id) });
-  };
-  onClose = id => {
-    this.setState({
-      openCollections: this.state.openCollections.filter(c => {
-        return c !== id;
-      }),
-    });
-  };
+
   componentDidMount() {
     // an array to store the ancestors
     const { collectionId, collections, loading } = this.props;
@@ -64,6 +55,18 @@ class CollectionSidebar extends React.Component {
       this.setState({ openCollections: ancestors });
     }
   }
+
+  onOpen = id => {
+    this.setState({ openCollections: this.state.openCollections.concat(id) });
+  };
+
+  onClose = id => {
+    this.setState({
+      openCollections: this.state.openCollections.filter(c => {
+        return c !== id;
+      }),
+    });
+  };
   render() {
     const { currentUser, isRoot, collectionId, list } = this.props;
     return (

--- a/frontend/src/metabase/collections/utils.js
+++ b/frontend/src/metabase/collections/utils.js
@@ -1,6 +1,5 @@
 import { t } from "ttag";
 
-// return collections that aren't personal and aren't archived
 export function nonPersonalCollection(collection) {
   // @TODO - should this be an API thing?
   return !collection.personal_owner_id && !collection.archived;

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -463,9 +463,30 @@ describe("scenarios > collection_defaults", () => {
 
     it("collections without sub-collections shouldn't have chevron icon (metabase#14753)", () => {
       cy.visit("/collection/root");
-      cy.findByText("Your personal collection")
+      cy.findByTestId("sidebar")
+        .as("sidebar")
+        .findByText("Your personal collection")
         .parent()
         .find(".Icon-chevronright")
+        .should("not.exist");
+
+      // Ensure if sub-collection is archived, the chevron is not displayed
+      cy.get("@sidebar")
+        .findByText("First collection")
+        .click()
+        .findByText("Second collection")
+        .click();
+      cy.icon("pencil").click();
+      popover()
+        .findByText("Archive this collection")
+        .click();
+      cy.get(".Modal")
+        .findByRole("button", { name: "Archive" })
+        .click();
+      cy.get("@sidebar")
+        .findByText("First collection")
+        .parent()
+        .find(".Icon-chevrondown")
         .should("not.exist");
     });
 

--- a/frontend/test/metabase/scenarios/collections/personal-collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/personal-collections.cy.spec.js
@@ -115,7 +115,7 @@ describe("personal collections", () => {
           cy.get("@sidebar").findByText("Bar1");
         });
 
-        it.skip("should be able to archive collection(s) inside personal collection (metabase#15343)", () => {
+        it("should be able to archive collection(s) inside personal collection (metabase#15343)", () => {
           cy.icon("pencil").click();
           cy.findByText("Archive this collection").click();
           modal()


### PR DESCRIPTION
Fixes #15343 

Fixes archived personal sub-collections are displayed in the sidebar collection three

The easiest fix is to filter them on the client (as it's done now), but it looks like a thing that ideally has to be done on the server side. Also, I've seen a few cases where frontend could be radically simplified if we move some filtering parts to the backend (e.g. [filtering items by permissions](https://github.com/metabase/metabase/pull/15613)). Should we think about that?

### Demo

![2021-04-19 18 28 34](https://user-images.githubusercontent.com/17258145/115263813-65080200-a13e-11eb-9f1e-7e5232b9cc23.gif)
