### PR TITLE
Fix "select all" button in collections footer (#15670)

### DIFF
--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -180,6 +180,8 @@ export default class CollectionContent extends React.Component {
         </Box>
         <BulkActions
           selected={selected}
+          onSelectAll={this.props.onSelectAll}
+          onSelectNone={this.props.onSelectNone}
           handleBulkArchive={this.handleBulkArchive}
           handleBulkMoveStart={this.handleBulkMoveStart}
           handleBulkMove={this.handleBulkMove}

--- a/frontend/src/metabase/components/BulkActionBar.jsx
+++ b/frontend/src/metabase/components/BulkActionBar.jsx
@@ -29,6 +29,7 @@ const BulkActionBar = ({ children, showing }) => (
           opacity,
           transform: `translateY(${translateY}px)`,
         }}
+        data-testid="bulk-action-bar"
       >
         <Card>{children}</Card>
       </FixedBottomBar>

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -491,13 +491,20 @@ describe("scenarios > collection_defaults", () => {
       cy.findByText("First Collection");
     });
 
-    it.skip("should let be possible to select all items using checkbox (metabase#14705)", () => {
+    it("should be possible to apply bulk selection to items (metabase#14705)", () => {
       cy.visit("/collection/root");
       selectItemUsingCheckbox("Orders");
       cy.findByText("1 item selected").should("be.visible");
+      // Select all
       cy.icon("dash").click();
       cy.icon("dash").should("not.exist");
       cy.findByText("4 items selected");
+      // Deselect all
+      cy.findByTestId("bulk-action-bar").within(() => {
+        cy.icon("check").click();
+      });
+      cy.icon("check").should("not.exist");
+      cy.findByTestId("bulk-action-bar").should("not.be.visible");
     });
 
     it.skip("should be possible to select pinned item using checkbox (metabase#15338)", () => {


### PR DESCRIPTION
Cherry picks #15670 for `release-x.39.x`

When you select items in a collection, you're supposed to be able to do "select all" or "deselect all" with a button in the footer bar. Right now nothing happens if you click the bulk selection control

### Before

![107249335-20e2dd80-69e8-11eb-981d-b38c79e06e47](https://user-images.githubusercontent.com/17258145/115274844-c84b6180-a149-11eb-9342-3f811746f462.gif)

### After

![115232637-9de4ae80-a11f-11eb-8545-68cfb371b2fe](https://user-images.githubusercontent.com/17258145/115274580-815d6c00-a149-11eb-94a3-f880cda61cec.gif)
