### PR TITLE
Merge 15492 -> release-x.39.x

### DIFF
--- a/frontend/src/metabase/visualizations/lib/settings/series.js
+++ b/frontend/src/metabase/visualizations/lib/settings/series.js
@@ -127,7 +127,6 @@ export function seriesSetting({
           { name: t`Right`, value: "right" },
         ],
       },
-      getHidden: (single, settings, { series }) => series.length < 2,
     },
     show_series_values: {
       title: t`Show values for this series`,

--- a/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
@@ -1,0 +1,38 @@
+import { restore, visitQuestionAdhoc } from "__support__/cypress";
+import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
+
+const { ORDERS, ORDERS_ID } = SAMPLE_DATASET;
+
+const Y_AXIS_RIGHT_SELECTOR = ".axis.yr";
+
+const testQuery = {
+  type: "query",
+  query: {
+    "source-table": ORDERS_ID,
+    aggregation: [["count"]],
+    breakout: [["datetime-field", ["field-id", ORDERS.CREATED_AT], "month"]],
+  },
+  database: 1,
+};
+
+describe("scenarios > visualizations > line chart", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsNormalUser();
+    cy.server();
+  });
+
+  it("should be able to change y axis position (metabase#13487)", () => {
+    cy.route("POST", "/api/dataset").as("dataset");
+
+    visitQuestionAdhoc({
+      dataset_query: testQuery,
+      display: "line",
+    });
+
+    cy.wait("@dataset");
+    cy.findByText("Settings").click();
+    cy.findByText("Right").click();
+    cy.get(Y_AXIS_RIGHT_SELECTOR);
+  });
+});


### PR DESCRIPTION
There are only 2 PRs in `release-x.38.x` that are missing in `release-x.39.x`, #15492 and #15472.

I tried to merged these both in in #15680, but it's running in to test failures -- we have verified a legitimate regression of #15612.

It seems like #15492 is ok and #15472 was the one that caused the regression. This PR merges just #15492 in for now and we can worry about fixing #15472 for the 39.1 release.