### PR TITLE
Custom expression editor: less intrusive suggestions

### DIFF
--- a/frontend/src/metabase/lib/expressions/suggest.js
+++ b/frontend/src/metabase/lib/expressions/suggest.js
@@ -1,79 +1,37 @@
 import _ from "underscore";
 
 import {
-  getExpressionName,
-  // dimensions:
   getDimensionName,
   formatDimensionName,
-  // metrics
   formatMetricName,
-  // segments
   formatSegmentName,
 } from "../expressions";
-
-import {
-  parserWithRecovery,
-  ExpressionCstVisitor,
-  ExpressionParser,
-} from "./parser";
-
-import {
-  AggregationFunctionName,
-  CLAUSE_TOKENS,
-  Case,
-  FunctionName,
-  Identifier,
-  IdentifierString,
-  LParen,
-  Minus,
-  NumberLiteral,
-  StringLiteral,
-  isTokenType,
-  lexerWithRecovery,
-} from "./lexer";
 
 import { partialMatch, enclosingFunction } from "./completer";
 
 import getHelpText from "./helper_text_strings";
 
-import { ExpressionDimension } from "metabase-lib/lib/Dimension";
 import {
-  FUNCTIONS,
-  OPERATORS,
+  EXPRESSION_FUNCTIONS,
+  AGGREGATION_FUNCTIONS,
   MBQL_CLAUSES,
-  isExpressionType,
-  getFunctionArgType,
   getMBQLName,
-  EXPRESSION_TYPES,
   EDITOR_FK_SYMBOLS,
 } from "./config";
 
-const FUNCTIONS_BY_TYPE = {};
-const OPERATORS_BY_TYPE = {};
-for (const type of EXPRESSION_TYPES) {
-  FUNCTIONS_BY_TYPE[type] = Array.from(FUNCTIONS)
-    .filter(name => isExpressionType(MBQL_CLAUSES[name].type, type))
-    .map(name => MBQL_CLAUSES[name]);
-  OPERATORS_BY_TYPE[type] = Array.from(OPERATORS)
-    .filter(name => isExpressionType(MBQL_CLAUSES[name].type, type))
-    .map(name => MBQL_CLAUSES[name]);
-}
-
 export function suggest({
   source,
-  cst,
   query,
   startRule,
   targetOffset = source.length,
-  expressionName,
 } = {}) {
+  let suggestions = [];
+
   const partialSource = source.slice(0, targetOffset);
-
   const matchPrefix = partialMatch(partialSource);
-  const partialSuggestionMode =
-    matchPrefix && matchPrefix.length > 0 && _.last(matchPrefix) !== "]";
 
-  if (!partialSuggestionMode) {
+  if (!matchPrefix || _.last(matchPrefix) === "]") {
+    // no keystroke to match? show help text for the enclosing function
     const functionDisplayName = enclosingFunction(partialSource);
     if (functionDisplayName) {
       const helpText = getHelpText(getMBQLName(functionDisplayName));
@@ -81,409 +39,103 @@ export function suggest({
         return { helpText };
       }
     }
+    return { suggestions };
   }
 
-  const lexResult = lexerWithRecovery.tokenize(partialSource);
-  if (lexResult.errors.length > 0) {
-    throw lexResult.errors;
-  }
-  let tokenVector = lexResult.tokens;
-  if (partialSuggestionMode) {
-    tokenVector = tokenVector.slice(0, -1);
-  }
-  const context = getContext({
-    cst,
-    tokenVector,
-    targetOffset,
-    startRule,
-  }) || { expectedType: startRule };
-
-  const { expectedType } = context;
-
-  let finalSuggestions = [];
-
-  const syntacticSuggestions = parserWithRecovery.computeContentAssist(
-    startRule,
-    tokenVector,
-  );
-
-  for (const suggestion of syntacticSuggestions) {
-    const { nextTokenType, ruleStack } = suggestion;
-
-    // first to avoid skipping if lastInputTokenIsUnclosedIdentifierString
-    if (nextTokenType === Identifier || nextTokenType === IdentifierString) {
-      // fields, metrics, segments
-      const parentRule = ruleStack.slice(-2, -1)[0];
-      const isDimension =
-        parentRule === "identifierExpression" &&
-        (isExpressionType(expectedType, "expression") ||
-          isExpressionType(expectedType, "boolean"));
-      const isSegment =
-        parentRule === "identifierExpression" &&
-        isExpressionType(expectedType, "boolean");
-      const isMetric =
-        parentRule === "identifierExpression" &&
-        isExpressionType(expectedType, "aggregation");
-
-      if (isDimension) {
-        let dimensions = [];
-        if (
-          context.token &&
-          context.clause &&
-          isTokenType(context.token.tokenType, AggregationFunctionName)
-        ) {
-          dimensions = query.aggregationFieldOptions(context.clause.name).all();
-        } else {
-          const dimensionFilter = dimension => {
-            // not itself
-            if (
-              dimension instanceof ExpressionDimension &&
-              dimension.name() === expressionName
-            ) {
-              return false;
-            }
-            if (expectedType === "expression" || expectedType === "boolean") {
-              return true;
-            }
-            const field = dimension.field();
-            return (
-              (isExpressionType("number", expectedType) && field.isNumeric()) ||
-              (isExpressionType("string", expectedType) && field.isString())
-            );
-          };
-          dimensions = query.dimensionOptions(dimensionFilter).all();
-        }
-        finalSuggestions.push(
-          ...dimensions.map(dimension => ({
-            type: "fields",
-            name: getDimensionName(dimension),
-            text: formatDimensionName(dimension) + " ",
-            alternates: EDITOR_FK_SYMBOLS.symbols.map(symbol =>
-              getDimensionName(dimension, symbol),
-            ),
-          })),
-        );
-      }
-      if (isSegment) {
-        finalSuggestions.push(
-          ...query.table().segments.map(segment => ({
-            type: "segments",
-            name: segment.name,
-            text: formatSegmentName(segment),
-          })),
-        );
-      }
-      if (isMetric) {
-        finalSuggestions.push(
-          ...query.table().metrics.map(metric => ({
-            type: "metrics",
-            name: metric.name,
-            text: formatMetricName(metric),
-          })),
-        );
-      }
-    } else if (
-      isTokenType(nextTokenType, FunctionName) ||
-      nextTokenType === Case
-    ) {
-      const database = query.database();
-      let functions = [];
-      if (isExpressionType(expectedType, "aggregation")) {
-        // special case for aggregation
-        finalSuggestions.push(
-          // ...query
-          //   .aggregationOperatorsWithoutRows()
-          //   .filter(a => getExpressionName(a.short))
-          //   .map(aggregationOperator =>
-          //     functionSuggestion(
-          //       "aggregations",
-          //       aggregationOperator.short,
-          //       aggregationOperator.fields.length > 0,
-          //     ),
-          //   ),
-          ...FUNCTIONS_BY_TYPE["aggregation"]
-            .filter(clause => database.hasFeature(clause.requiresFeature))
-            .map(clause =>
-              functionSuggestion(
-                "aggregations",
-                clause.name,
-                clause.args.length > 0,
-              ),
-            ),
-        );
-        finalSuggestions.push(
-          ...["sum-where", "count-where", "share"].map(short =>
-            functionSuggestion("aggregations", short, true),
-          ),
-        );
-        functions = FUNCTIONS_BY_TYPE["number"];
-      } else {
-        functions = FUNCTIONS_BY_TYPE[expectedType];
-      }
-      finalSuggestions.push(
-        ...functions
-          .filter(clause => database.hasFeature(clause.requiresFeature))
-          .map(clause => functionSuggestion("functions", clause.name)),
-      );
-      if (nextTokenType === Case) {
-        const caseSuggestion = {
+  if (_.first(matchPrefix) !== "[") {
+    suggestions.push({
+      type: "functions",
+      name: "case",
+      text: "case(",
+      index: targetOffset,
+    });
+    suggestions.push(
+      ...Array.from(EXPRESSION_FUNCTIONS)
+        .map(name => MBQL_CLAUSES[name])
+        .map(func => ({
           type: "functions",
-          name: "case",
-          text: "case(",
-        };
-        finalSuggestions.push(caseSuggestion);
-      }
-    } else if (
-      nextTokenType === StringLiteral ||
-      nextTokenType === NumberLiteral ||
-      nextTokenType === Minus
-    ) {
-      // skip number/string literal
-    } else {
-      console.warn("non exhaustive match", nextTokenType.name);
+          name: func.displayName,
+          text: func.displayName + "(",
+          index: targetOffset,
+        })),
+    );
+    if (startRule === "aggregation") {
+      suggestions.push(
+        ...Array.from(AGGREGATION_FUNCTIONS)
+          .map(name => MBQL_CLAUSES[name])
+          .map(func => ({
+            type: "aggregations",
+            name: func.displayName,
+            text: func.displayName + "(",
+            index: targetOffset,
+          })),
+      );
     }
+  }
+
+  if (_.last(matchPrefix) !== "]") {
+    suggestions.push(
+      ...query
+        .dimensionOptions(() => true)
+        .all()
+        .map(dimension => ({
+          type: "fields",
+          name: getDimensionName(dimension),
+          text: formatDimensionName(dimension) + " ",
+          alternates: EDITOR_FK_SYMBOLS.symbols.map(symbol =>
+            getDimensionName(dimension, symbol),
+          ),
+          index: targetOffset,
+        })),
+    );
+    suggestions.push(
+      ...query.table().segments.map(segment => ({
+        type: "segments",
+        name: segment.name,
+        text: formatSegmentName(segment),
+        index: targetOffset,
+      })),
+    );
+    suggestions.push(
+      ...query.table().metrics.map(metric => ({
+        type: "metrics",
+        name: metric.name,
+        text: formatMetricName(metric),
+        index: targetOffset,
+      })),
+    );
   }
 
   // throw away any suggestion that is not a suffix of the last partialToken.
-  if (partialSuggestionMode) {
-    const partial = matchPrefix.toLowerCase();
-    for (const suggestion of finalSuggestions) {
-      suggestion: for (const text of [
-        suggestion.name,
-        suggestion.text,
-        ...(suggestion.alternates || []),
-      ]) {
-        const lower = (text || "").toLowerCase();
-        if (lower.startsWith(partial)) {
-          suggestion.range = [0, partial.length];
+  const partial = matchPrefix.toLowerCase();
+  for (const suggestion of suggestions) {
+    suggestion: for (const text of [
+      suggestion.name,
+      suggestion.text,
+      ...(suggestion.alternates || []),
+    ]) {
+      const lower = (text || "").toLowerCase();
+      if (lower.startsWith(partial)) {
+        suggestion.range = [0, partial.length];
+        break suggestion;
+      }
+      let index = 0;
+      for (const part of lower.split(/\b/g)) {
+        if (part.startsWith(partial)) {
+          suggestion.range = [index, index + partial.length];
           break suggestion;
         }
-        let index = 0;
-        for (const part of lower.split(/\b/g)) {
-          if (part.startsWith(partial)) {
-            suggestion.range = [index, index + partial.length];
-            break suggestion;
-          }
-          index += part.length;
-        }
+        index += part.length;
       }
     }
-    finalSuggestions = finalSuggestions.filter(suggestion => suggestion.range);
   }
-  for (const suggestion of finalSuggestions) {
-    suggestion.index = targetOffset;
-    if (!suggestion.name) {
-      suggestion.name = suggestion.text;
-    }
-  }
+  suggestions = suggestions.filter(suggestion => suggestion.range);
 
   // deduplicate suggestions and sort by type then name
   return {
-    suggestions: _.chain(finalSuggestions)
+    suggestions: _.chain(suggestions)
       .uniq(suggestion => suggestion.text)
-      .sortBy("name")
-      .sortBy("type")
+      .sortBy("text")
       .value(),
-  };
-}
-
-function functionSuggestion(type, clause, parens = true) {
-  const name = getExpressionName(clause);
-  return {
-    type: type,
-    name: name,
-    text: name + (parens ? "(" : " "),
-  };
-}
-
-const contextParser = new ExpressionParser({
-  recoveryEnabled: true,
-  tokenRecoveryEnabled: false,
-});
-
-export function getContext({
-  source,
-  cst,
-  tokenVector = lexerWithRecovery.tokenize(source).tokens,
-  targetOffset = source.length,
-  startRule,
-  ...options
-}) {
-  if (!cst) {
-    contextParser.input = tokenVector;
-    cst = contextParser[startRule]();
-  }
-  const visitor = new ExpressionContextVisitor({
-    targetOffset: targetOffset,
-    tokenVector: tokenVector,
-    ...options,
-  });
-  return visitor.visit(cst);
-}
-
-function findNextTextualToken(tokenVector, prevTokenEndOffset) {
-  // The TokenVector is sorted, so we could use a BinarySearch to optimize performance
-  const prevTokenIdx = tokenVector.findIndex(
-    tok => tok.endOffset === prevTokenEndOffset,
-  );
-  for (let i = prevTokenIdx + 1; i >= 0 && i < tokenVector.length; i++) {
-    if (!/^\s+$/.test(tokenVector[i].image)) {
-      return tokenVector[i];
-    }
-  }
-  return null;
-}
-
-export class ExpressionContextVisitor extends ExpressionCstVisitor {
-  constructor({ targetOffset, tokenVector }) {
-    super();
-    this.targetOffset = targetOffset;
-    this.tokenVector = tokenVector;
-    this.stack = [];
-    this.validateVisitor();
-  }
-
-  _context(clauseToken, index, currentContext) {
-    const clause = CLAUSE_TOKENS.get(clauseToken.tokenType);
-    let expectedType = getFunctionArgType(clause, index);
-
-    if (
-      (expectedType === "expression" || expectedType === "number") &&
-      currentContext &&
-      currentContext.expectedType === "aggregation" &&
-      clause.type !== "aggregation"
-    ) {
-      expectedType = "aggregation";
-    }
-
-    return { clause, index, expectedType, clauseToken };
-  }
-
-  _isTarget(token) {
-    const { targetOffset, tokenVector } = this;
-    const next = findNextTextualToken(tokenVector, token.endOffset);
-    if (
-      targetOffset > token.endOffset &&
-      (next === null || targetOffset <= next.startOffset)
-    ) {
-      return true;
-    }
-    return false;
-  }
-
-  _function(ctx, currentContext) {
-    const { tokenVector } = this;
-    const clauseToken = ctx.functionName[0];
-    // special case: function clauses without parens sometimes causes the paren to be missing
-    const parenToken = ctx.LParen
-      ? ctx.LParen[0]
-      : findNextTextualToken(tokenVector, clauseToken.endOffset);
-    if (!parenToken || parenToken.tokenType !== LParen) {
-      return;
-    }
-    const tokens = [parenToken, ...(ctx.Comma || [])];
-    for (let index = 0; index < tokens.length; index++) {
-      const token = tokens[index];
-      if (this._isTarget(token)) {
-        return this._context(clauseToken, index, currentContext);
-      } else if (ctx.arguments && index < ctx.arguments.length) {
-        const match = this.visit(
-          ctx.arguments[index],
-          this._context(clauseToken, index, currentContext),
-        );
-        if (match) {
-          return match;
-        }
-      }
-    }
-  }
-
-  _operator(ctx, currentContext) {
-    // note: this should probably account for operator precedence / associativity but for now all of our operator clauses contain operators of the same precedence/associativity
-    for (let index = 0; index < ctx.operators.length; index++) {
-      const clauseToken = ctx.operators[index];
-      if (this._isTarget(clauseToken)) {
-        // NOTE: operators always (?) have the same type for every operand
-        return this._context(clauseToken, 0, currentContext);
-      } else {
-        const match = this.visit(
-          ctx.operands[index],
-          this._context(clauseToken, 0, currentContext),
-        );
-        if (match) {
-          return match;
-        }
-      }
-    }
-  }
-}
-
-const ALL_RULES = [
-  "any",
-  "expression",
-  "aggregation",
-  "boolean",
-  "string",
-  "number",
-  "additionExpression",
-  "multiplicationExpression",
-  "functionExpression",
-  "caseExpression",
-  "identifierExpression",
-  "identifier",
-  "identifierString",
-  "stringLiteral",
-  "numberLiteral",
-  "atomicExpression",
-  "parenthesisExpression",
-  "booleanExpression",
-  "booleanUnaryExpression",
-  "relationalExpression",
-  "logicalAndExpression",
-  "logicalOrExpression",
-  "logicalNotExpression",
-];
-
-const TYPE_RULES = new Set([
-  "expression",
-  "aggregation",
-  "boolean",
-  "string",
-  "number",
-]);
-
-for (const rule of ALL_RULES) {
-  ExpressionContextVisitor.prototype[rule] = function(ctx, currentContext) {
-    if (!currentContext && TYPE_RULES.has(rule)) {
-      currentContext = { expectedType: rule };
-    }
-
-    // if we have operators or a functionName then handle that specially
-    if (ctx.operators) {
-      const match = this._operator(ctx, currentContext);
-      if (match) {
-        return match;
-      }
-    }
-    if (ctx.functionName) {
-      const match = this._function(ctx, currentContext);
-      if (match) {
-        return match;
-      }
-    }
-
-    // this just visits every child
-    for (const type in ctx) {
-      for (const child of ctx[type]) {
-        if (!child.tokenType && child.name) {
-          const match = this.visit(child, currentContext);
-          if (match) {
-            return match;
-          }
-        } else if (this._isTarget(child)) {
-          return currentContext;
-        }
-      }
-    }
   };
 }

--- a/frontend/src/metabase/lib/expressions/suggest.js
+++ b/frontend/src/metabase/lib/expressions/suggest.js
@@ -136,6 +136,7 @@ export function suggest({
     suggestions: _.chain(suggestions)
       .uniq(suggestion => suggestion.text)
       .sortBy("text")
+      .sortBy("type")
       .value(),
   };
 }

--- a/frontend/src/metabase/lib/expressions/suggest.js
+++ b/frontend/src/metabase/lib/expressions/suggest.js
@@ -96,14 +96,16 @@ export function suggest({
         index: targetOffset,
       })),
     );
-    suggestions.push(
-      ...query.table().metrics.map(metric => ({
-        type: "metrics",
-        name: metric.name,
-        text: formatMetricName(metric),
-        index: targetOffset,
-      })),
-    );
+    if (startRule === "aggregation") {
+      suggestions.push(
+        ...query.table().metrics.map(metric => ({
+          type: "metrics",
+          name: metric.name,
+          text: formatMetricName(metric),
+          index: targetOffset,
+        })),
+      );
+    }
   }
 
   // throw away any suggestion that is not a suffix of the last partialToken.

--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -369,6 +369,7 @@ describe("scenarios > question > filter", () => {
     openProductsTable();
     cy.findByText("Filter").click();
     cy.findByText("Custom Expression").click();
+    typeInExpressionEditor("c");
 
     // This issue has two problematic parts. We're testing for both:
     cy.log("Popover should display all custom expression options");
@@ -380,7 +381,7 @@ describe("scenarios > question > filter", () => {
     cy.log("Should not display error prematurely");
     cy.get("[contenteditable='true']")
       .click()
-      .type("contains(");
+      .type("ontains(");
     cy.findByText(/Checks to see if string1 contains string2 within it./i);
     cy.button("Done").should("not.be.disabled");
     cy.get(".text-error").should("not.exist");
@@ -473,9 +474,10 @@ describe("scenarios > question > filter", () => {
   it("should offer case expression in the auto-complete suggestions", () => {
     openExpressionEditorFromFreshlyLoadedPage();
 
+    typeInExpressionEditor("c");
     popover().contains(/case/i);
 
-    typeInExpressionEditor("c");
+    typeInExpressionEditor("a");
 
     // "case" is still there after typing a bit
     popover().contains(/case/i);

--- a/frontend/test/metabase/scenarios/question/new.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/new.cy.spec.js
@@ -460,7 +460,7 @@ describe("scenarios > question > new", () => {
       });
     });
 
-    it.skip("distinct inside custom expression should suggest non-numeric types (metabase#13469)", () => {
+    it("distinct inside custom expression should suggest non-numeric types (metabase#13469)", () => {
       openReviewsTable({ mode: "notebook" });
       cy.findByText("Summarize").click();
       popover()

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -894,8 +894,11 @@ function joinTwoSavedQuestions() {
 }
 
 function addSimpleCustomColumn(name) {
+  cy.get("[contenteditable='true']")
+    .click()
+    .type("C");
   popover()
-    .findByText("Category")
+    .findByText("ategory")
     .click();
   cy.findByPlaceholderText("Something nice and descriptive")
     .click()


### PR DESCRIPTION
**Steps to try**

1. Ask a question, Custom question
2. Sample Dataset, Orders table
3. Filter, Custom Expression

**Before this PR**
Even when the input is empty and there is no matching, the user is already bombarded with tons of choices in the suggestion popover.

![image](https://user-images.githubusercontent.com/7288/138812527-c35ee83d-b1cc-49ae-993d-ba4d7dbf28f2.png)

**After this PR**
When the input is empty, there is no suggestion popover.

![image](https://user-images.githubusercontent.com/7288/138811950-af56775c-7662-4902-bf54-b4eb64c68bb4.png)

After one character (or more), then the suggestion popover shows the possible choices, based on prefix matching.

![image](https://user-images.githubusercontent.com/7288/138812118-92ae6410-ab43-4c21-a7ef-23dfd04dc4ce.png)

All available fields are still suggested whenever the user hits `[`:

![image](https://user-images.githubusercontent.com/7288/138934584-cd345c3b-6843-4e28-a754-f62fb54234cc.png)


**Note**

WIth this PR, we will lost a little bit of suggestion heuristics, e.g.:

* suggestions for `1+` includes functions like `concat` (doesn't make sense since it returns a string)
* suggestions for `average(` includes functions like `count` (non-sensible nested aggregation)

For the sake of making this PR simple, IMO it's an acceptable trade-off (consider the heuristics of the current status quo is also a hit-and-miss scenario). Later in some follow-ups, I plan to reintroduce those heuristics.
