### PR TITLE
map category/location to string so we can treat them like string/= in UI

### DIFF
--- a/frontend/src/metabase/meta/Parameter.js
+++ b/frontend/src/metabase/meta/Parameter.js
@@ -563,6 +563,8 @@ function getParameterOperatorType(parameterType) {
     case "number":
       return NUMBER;
     case "string":
+    case "category":
+    case "location":
       return STRING;
     case "id":
       // id can technically be a FK but doesn't matter as both use default filter operators

--- a/frontend/test/metabase/meta/Parameter.unit.spec.js
+++ b/frontend/test/metabase/meta/Parameter.unit.spec.js
@@ -252,20 +252,24 @@ describe("metabase/meta/Parameter", () => {
       });
     });
 
-    describe("when parameter is NOT associated with an operator", () => {
-      it("should return undefined", () => {
+    describe("when parameter is location/category", () => {
+      it("should map to an = operator", () => {
         expect(
           deriveFieldOperatorFromParameter({
             type: "location/city",
-          }),
-        ).toBe(undefined);
+          }).name,
+        ).toBe("=");
 
         expect(
           deriveFieldOperatorFromParameter({
             type: "category",
-          }),
-        ).toBe(undefined);
+          }).name,
+        ).toBe("=");
+      });
+    });
 
+    describe("when parameter is NOT associated with an operator", () => {
+      it("should return undefined", () => {
         expect(deriveFieldOperatorFromParameter({ type: "date/single" })).toBe(
           undefined,
         );


### PR DESCRIPTION
fixes #15689 

`getParameterOperatorType` is used in `deriveFieldOperatorFromParameter` so we can map parameters to operators using their `type` string. I dumbly removed this code thinking it wasn't necessary anymore (as you can see from the unit test), but clearly it is needed.

![Screen Shot 2021-04-20 at 10 20 50 AM](https://user-images.githubusercontent.com/13057258/115438319-1a2fce00-a1c2-11eb-92bf-49d028abd7b5.png)
