### PR TITLE
add category/location options back to meta/Parameter options

### DIFF
--- a/frontend/src/metabase/meta/Parameter.js
+++ b/frontend/src/metabase/meta/Parameter.js
@@ -174,7 +174,26 @@ export function getParameterOptions(): ParameterOption[] {
       ? OPTIONS_WITH_OPERATOR_SUBTYPES.map(option =>
           buildOperatorSubtypeOptions(option),
         )
-      : [...PARAMETER_OPERATOR_TYPES["date"]]),
+      : [
+          { type: "category", name: t`Category` },
+          {
+            type: "location/city",
+            name: t`City`,
+          },
+          {
+            type: "location/state",
+            name: t`State`,
+          },
+          {
+            type: "location/zip_code",
+            name: t`ZIP or Postal Code`,
+          },
+          {
+            type: "location/country",
+            name: t`Country`,
+          },
+          ...PARAMETER_OPERATOR_TYPES["date"],
+        ]),
   ].flat();
 }
 


### PR DESCRIPTION
fixes #15700 

before the feature flag code was added there was an attempt made to decouple `meta/Dashboard` and `meta/Parameter` code a little bit. of course, that no longer works very well now that we need these options back.

![Screen Shot 2021-04-20 at 12 07 49 PM](https://user-images.githubusercontent.com/13057258/115450653-0cce1000-a1d1-11eb-9c2b-563a4d0d4702.png)
![Screen Shot 2021-04-20 at 12 07 34 PM](https://user-images.githubusercontent.com/13057258/115450658-0d66a680-a1d1-11eb-8658-deacd78f5076.png)
