### PR TITLE
#15700 Repro: Cannot select category Field Filter in Native query on 0.39.0

### DIFF
--- a/frontend/test/metabase/scenarios/question/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/native.cy.spec.js
@@ -3,6 +3,7 @@ import {
   popover,
   modal,
   visitQuestionAdhoc,
+  mockSessionProperty,
 } from "__support__/cypress";
 import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
 import { USER_GROUPS } from "__support__/cypress_data";
@@ -604,6 +605,43 @@ describe("scenarios > question > native", () => {
     cy.get(".Visualization").within(() => {
       cy.findAllByText("Doohickey");
       cy.findAllByText("Gizmo").should("not.exist");
+    });
+  });
+
+  ["old", "new"].forEach(test => {
+    it(`${test} syntax:\n should be able to select category Field Filter in Native query (metabase#15700)`, () => {
+      if (test === "old") {
+        mockSessionProperty("field-filter-operators-enabled?", false);
+      }
+      const widgetType = test === "old" ? "Category" : "String";
+
+      cy.visit("/");
+      cy.icon("sql").click();
+      cy.get(".ace_content").type("{{filter}}", {
+        parseSpecialCharSequences: false,
+      });
+      cy.findByText("Variable type")
+        .parent()
+        .findByText("Text")
+        .click();
+      popover()
+        .findByText("Field Filter")
+        .click();
+      popover().within(() => {
+        cy.findByText("Sample Dataset");
+        cy.findByText("Products").click();
+      });
+      popover()
+        .findByText("Category")
+        .click();
+      cy.findByText("Filter widget type")
+        .parent()
+        .find(".AdminSelect")
+        .findByText(widgetType)
+        .click();
+      popover()
+        .find(".List-section")
+        .should("have.length.gt", 1);
     });
   });
 });


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Reproduces #15700 in two variants - with the old syntax and with the new one
- old syntax meaning `MB_FIELD_FILTER_OPERATORS_ENABLED=false` and the reverse for new syntax

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/question/native.cy.spec.js`
- All tests should pass

### Additional notes:
- The bug was fixed in #15701

### Screenshots:
Before the fix
![image](https://user-images.githubusercontent.com/31325167/115456865-f56c4280-a223-11eb-8a6a-4ac03e7fcc2a.png)

After the fix:
![image](https://user-images.githubusercontent.com/31325167/115456894-fef5aa80-a223-11eb-99f4-57b978fb08ce.png)

