### PR TITLE
Add diagnostic info for connection pools to Help page

### DIFF
--- a/frontend/src/metabase/admin/tasks/containers/Help.jsx
+++ b/frontend/src/metabase/admin/tasks/containers/Help.jsx
@@ -127,6 +127,15 @@ export default class Help extends Component {
           <AdminHeader title={t`Diagnostic Info`} className="mb2" />
           <p>{t`Please include these details in support requests. Thank you!`}</p>
           <InfoBlock>{detailString}</InfoBlock>
+          <p>{t`Advanced Details (click to download)`}</p>
+          <ul>
+            <li>
+              <a
+                download
+                href={UtilApi.connection_pool_details_url}
+              >{t`Connection Pool Details`}</a>
+            </li>
+          </ul>
         </Box>
       </Box>
     );

--- a/frontend/src/metabase/admin/tasks/containers/Help.jsx
+++ b/frontend/src/metabase/admin/tasks/containers/Help.jsx
@@ -127,7 +127,7 @@ export default class Help extends Component {
           <AdminHeader title={t`Diagnostic Info`} className="mb2" />
           <p>{t`Please include these details in support requests. Thank you!`}</p>
           <InfoBlock>{detailString}</InfoBlock>
-          <div className="text-medium text-bold text-uppercase">{t`Advanced Details (click to download)`}</div>
+          <div className="text-medium text-bold text-uppercase py2">{t`Advanced Details (click to download)`}</div>
           <ol>
             <HelpLink
               title={t`Connection Pool Details`}

--- a/frontend/src/metabase/admin/tasks/containers/Help.jsx
+++ b/frontend/src/metabase/admin/tasks/containers/Help.jsx
@@ -127,15 +127,14 @@ export default class Help extends Component {
           <AdminHeader title={t`Diagnostic Info`} className="mb2" />
           <p>{t`Please include these details in support requests. Thank you!`}</p>
           <InfoBlock>{detailString}</InfoBlock>
-          <p>{t`Advanced Details (click to download)`}</p>
-          <ul>
-            <li>
-              <a
-                download
-                href={UtilApi.connection_pool_details_url}
-              >{t`Connection Pool Details`}</a>
-            </li>
-          </ul>
+          <div className="text-medium text-bold text-uppercase">{t`Advanced Details (click to download)`}</div>
+          <ol>
+            <HelpLink
+              title={t`Connection Pool Details`}
+              description={t`Information about active and idle connections for all pools`}
+              link={UtilApi.connection_pool_details_url}
+            />
+          </ol>
         </Box>
       </Box>
     );

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -407,6 +407,7 @@ export const UtilApi = {
   random_token: GET("/api/util/random_token"),
   logs: GET("/api/util/logs"),
   bug_report_details: GET("/api/util/bug_report_details"),
+  connection_pool_details_url: "/api/util/diagnostic_info/connection_pool_info",
 };
 
 export const GeoJSONApi = {

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -407,6 +407,7 @@ export const UtilApi = {
   random_token: GET("/api/util/random_token"),
   logs: GET("/api/util/logs"),
   bug_report_details: GET("/api/util/bug_report_details"),
+  // this one does not need an HTTP verb because it's opened as an external link
   connection_pool_details_url: "/api/util/diagnostic_info/connection_pool_info",
 };
 

--- a/project.clj
+++ b/project.clj
@@ -166,7 +166,7 @@
                                  honeysql]]
    [user-agent "0.1.0"]                                               ; User-Agent string parser, for Login History page & elsewhere
    [weavejester/dependency "0.2.1"]                                   ; Dependency graphs and topological sorting
-   ]
+   [org.clojure/java.jmx "1.0.0"]]                                    ; JMX bean library, for exporting diagnostic info
 
   :main ^:skip-aot metabase.core
 
@@ -222,8 +222,8 @@
      [pjstadig/humane-test-output "0.10.0"]
      [reifyhealth/specmonstah "2.0.0"]                                ; Generate fixtures to test huge databases
      [ring/ring-mock "0.4.0"]
-     [talltale "0.5.4"]                                               ; Generate realistic data for fixtures
-     ]
+     [talltale "0.5.4"]]                                               ; Generate realistic data for fixtures
+
 
     :plugins
     [[lein-environ "1.1.0"] ; easy access to environment variables

--- a/src/metabase/api/util.clj
+++ b/src/metabase/api/util.clj
@@ -41,4 +41,10 @@
   {:system-info   (troubleshooting/system-info)
    :metabase-info (troubleshooting/metabase-info)})
 
+(api/defendpoint GET "/diagnostic_info/connection_pool_info"
+  "Returns database connection pool info for the current Metabase instance."
+  []
+  (api/check-superuser)
+  (troubleshooting/connection-pool-info))
+
 (api/define-routes)

--- a/src/metabase/api/util.clj
+++ b/src/metabase/api/util.clj
@@ -7,7 +7,8 @@
             [metabase.logger :as logger]
             [metabase.troubleshooting :as troubleshooting]
             [metabase.util.schema :as su]
-            [metabase.util.stats :as stats]))
+            [metabase.util.stats :as stats]
+            [ring.util.response :as ring.response]))
 
 (api/defendpoint POST "/password_check"
   "Endpoint that checks if the supplied password meets the currently configured password complexity rules."
@@ -45,6 +46,8 @@
   "Returns database connection pool info for the current Metabase instance."
   []
   (api/check-superuser)
-  (troubleshooting/connection-pool-info))
+  (let [pool-info (troubleshooting/connection-pool-info)
+        headers   {"Content-Disposition" "attachment; filename=\"connection_pool_info.json\""}]
+    (assoc (ring.response/response pool-info) :headers headers, :status 200)))
 
 (api/define-routes)

--- a/src/metabase/async/streaming_response.clj
+++ b/src/metabase/async/streaming_response.clj
@@ -220,13 +220,13 @@
   ;; async responses only
   compojure.response/Sendable
   (send* [this request respond* _]
-    (respond* (compojure.response/render this request)))
+    (respond* (compojure.response/render this request))))
 
   ;; TODO -- if we want this to work when running via `lein ring server` we need to add an impl for
   ;; `ring.core.protocols/StreamableResponseBody`. Not sure if we want to do that because it would result in different
   ;; behavior when running via `lein ring server` vs `lein run`/uberjar. Maybe better just to take `lein ring server`
   ;; out and replace it with an auto-reload version of `lein run`
-  )
+
 
 ;; TODO -- don't think any of this is needed any mo
 (defn- render [^StreamingResponse streaming-response gzip?]

--- a/src/metabase/troubleshooting.clj
+++ b/src/metabase/troubleshooting.clj
@@ -1,10 +1,12 @@
 (ns metabase.troubleshooting
   (:require [clojure.java.jdbc :as jdbc]
+            [clojure.java.jmx :as jmx]
             [metabase.config :as mc]
             [metabase.db :as mdb]
             [metabase.models.setting :as setting]
             [metabase.util.stats :as mus]
-            [toucan.db :as db]))
+            [toucan.db :as db])
+  (:import javax.management.ObjectName))
 
 (defn system-info
   "System info we ask for for bug reports"
@@ -37,3 +39,14 @@
    :run-mode                     (mc/config-kw :mb-run-mode)
    :version                      mc/mb-version-info
    :settings                     {:report-timezone (setting/get :report-timezone)}})
+
+(defn- conn-pool-bean-diag-info [acc ^ObjectName jmx-bean]
+  (let [bean-id   (.getCanonicalName jmx-bean)
+        props     [:numConnections :numIdleConnections :numBusyConnections :minPoolSize :maxPoolSize]]
+      (assoc acc (jmx/read bean-id :dataSourceName) (jmx/read bean-id props))))
+
+(defn connection-pool-info
+  "Builds a map of info about the current c3p0 connection pools managed by this Metabase instance."
+  []
+  (->> (reduce conn-pool-bean-diag-info {} (jmx/mbean-names "com.mchange.v2.c3p0:type=PooledDataSource,*"))
+       (assoc {} :connection-pools)))


### PR DESCRIPTION
Backend changes:
Add org.clojure/java.jmx dependency to project.clj for use in JMX bean querying
To troubleshooting.clj, add some functions to capture details from the c3p0 connection pool beans to a map
Add new API endpoint to invoke that from util.clj

Frontend changes:
In the Help page, add a new paragraph below the existing "Diagnostic Info" JSON blob for advanced details, envisioned as a list of download links (which users can then attach to tickets, etc.)
