### PR TITLE
Switch from Nashorn to GraalVM JS engine; support Java 15+

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,11 @@ executors:
     docker:
       - image: circleci/clojure:lein-2.9.5-node-browsers
 
+  java-8:
+    working_directory: /home/circleci/metabase/metabase/
+    docker:
+      - image: circleci/clojure:openjdk-8-lein-2.9.5-buster
+
   # Java 11 tests also test Metabase with the at-rest encryption enabled. See
   # https://metabase.com/docs/latest/operations-guide/encrypting-database-details-at-rest.html for an explanation of
   # what this means.
@@ -26,6 +31,11 @@ executors:
       - image: metabase/ci:lein-2.9.5-clojure-1.10.3.814
         environment:
           MB_ENCRYPTION_SECRET_KEY: Orw0AAyzkO/kPTLJRxiyKoBHXa/d6ZcO+p+gpZO/wSQ=
+
+  java-16:
+    working_directory: /home/circleci/metabase/metabase/
+    docker:
+      - image: circleci/clojure:openjdk-16-lein-2.9.5-buster
 
   postgres-9-6:
     working_directory: /home/circleci/metabase/metabase/
@@ -963,6 +973,7 @@ workflows:
           name: be-tests-<< matrix.edition >>
           requires:
             - be-deps
+          e: java-8
           lein-command: with-profile +junit test
           skip-when-no-change: true
           <<: *Matrix
@@ -972,6 +983,15 @@ workflows:
           requires:
             - be-deps
           e: java-11
+          lein-command: with-profile +junit test
+          skip-when-no-change: true
+          <<: *Matrix
+
+      - lein:
+          name: be-tests-java-16-<< matrix.edition >>
+          requires:
+            - be-deps
+          e: java-16
           lein-command: with-profile +junit test
           skip-when-no-change: true
           <<: *Matrix

--- a/project.clj
+++ b/project.clj
@@ -141,6 +141,8 @@
    [org.clojars.pntblnk/clj-ldap "0.0.16"]                            ; LDAP client
    [org.eclipse.jetty/jetty-server "9.4.32.v20200930"]                ; We require JDK 8 which allows us to run Jetty 9.4, ring-jetty-adapter runs on 1.7 which forces an older version
    [org.flatland/ordered "1.5.9"]                                     ; ordered maps & sets
+   [org.graalvm.js/js "21.0.0.2"]                                     ; JavaScript engine
+   [org.graalvm.js/js-scriptengine "21.0.0.2"]
    [org.liquibase/liquibase-core "3.6.3"                              ; migration management (Java lib)
     :exclusions [ch.qos.logback/logback-classic]]
    [org.mariadb.jdbc/mariadb-java-client "2.6.2"]                     ; MySQL/MariaDB driver

--- a/src/metabase/pulse/render/color.clj
+++ b/src/metabase/pulse/render/color.clj
@@ -5,11 +5,7 @@
             [clojure.java.io :as io]
             [metabase.pulse.render.js-engine :as js]
             [metabase.util.i18n :refer [trs]]
-            [schema.core :as s])
-  (:import java.io.InputStream))
-
-(defn- ^InputStream get-classpath-resource [path]
-  (.getResourceAsStream (class []) path))
+            [schema.core :as s]))
 
 (def ^:private js-file-path "frontend_shared/color_selector.js")
 

--- a/src/metabase/pulse/render/color.clj
+++ b/src/metabase/pulse/render/color.clj
@@ -2,31 +2,28 @@
   "Namespaces that uses the Nashorn javascript engine to invoke some shared javascript code that we use to determine
   the background color of pulse table cells"
   (:require [cheshire.core :as json]
+            [clojure.java.io :as io]
+            [metabase.pulse.render.js-engine :as js]
             [metabase.util.i18n :refer [trs]]
             [schema.core :as s])
-  (:import java.io.InputStream
-           [javax.script Invocable ScriptEngineManager]
-           jdk.nashorn.api.scripting.JSObject))
-
-(defn- make-js-engine-with-script [^String script]
-  (let [engine-mgr (ScriptEngineManager.)
-        js-engine  (.getEngineByName engine-mgr "nashorn")]
-    (.eval js-engine script)
-    js-engine))
+  (:import java.io.InputStream))
 
 (defn- ^InputStream get-classpath-resource [path]
   (.getResourceAsStream (class []) path))
 
-(def ^:private js-engine
-  (let [js-file-path "/frontend_shared/color_selector.js"]
-    ;; The code that loads the JS engine is behind a delay so that we don't incur that cost on startup. The below
-    ;; assertion till look for the javascript file at startup and fail if it doesn't find it. This is to avoid a big
-    ;; delay in finding out that the system is broken
-    (assert (get-classpath-resource js-file-path)
-      (trs "Can''t find JS color selector at ''{0}''" js-file-path))
-    (delay
-     (with-open [stream (get-classpath-resource js-file-path)]
-       (make-js-engine-with-script (slurp stream))))))
+(def ^:private js-file-path "frontend_shared/color_selector.js")
+
+(def ^:private ^{:arglists '([])} js-engine
+  ;; The code that loads the JS engine is behind a delay so that we don't incur that cost on startup. The below
+  ;; assertion till look for the javascript file at startup and fail if it doesn't find it. This is to avoid a big
+  ;; delay in finding out that the system is broken
+  (let [file-url (io/resource js-file-path)]
+    (assert file-url (trs "Can''t find JS color selector at ''{0}''" js-file-path))
+    (let [dlay (delay
+                 (doto (js/engine)
+                   (js/eval (slurp file-url))))]
+      (fn []
+        @dlay))))
 
 (def ^:private QueryResults
   "This is a pretty loose schema, more as a safety net as we have a long feedback loop for this being broken as it's
@@ -43,19 +40,19 @@
   complex, but defined in a set of rules in `viz-settings`. There are some colors that are picked based on a
   particular cell value, others affect the row, so it's necessary to call this once for the resultset and then
   `get-background-color` on each cell."
-  [{:keys [cols rows]} :- QueryResults, viz-settings]
-  ;; NOTE: for development it is useful to replace the following line with this one so it reload each time:
-  ; (let [^Invocable engine (make-js-engine-with-script (slurp "resources/frontend_shared/color_selector.js"))
-  (let [^Invocable engine @js-engine
-        ;; Ideally we'd convert everything to JS data before invoking the function below, but converting rows would be
-        ;; expensive. The JS code is written to deal with `rows` in it's native Nashorn format but since `cols` and
-        ;; `viz-settings` are small, pass those as JSON so that they can be deserialized to pure JS objects once in JS
-        ;; code
-        js-fn-args (object-array [rows (json/generate-string cols) (json/generate-string viz-settings)])]
-    (.invokeFunction engine "makeCellBackgroundGetter" js-fn-args)))
+  [{:keys [cols rows]} :- QueryResults viz-settings]
+  ;; Ideally we'd convert everything to JS data before invoking the function below, but converting rows would be
+  ;; expensive. The JS code is written to deal with `rows` in it's native Nashorn format but since `cols` and
+  ;; `viz-settings` are small, pass those as JSON so that they can be deserialized to pure JS objects once in JS
+  ;; code
+  (js/invoke-by-name (js-engine) "makeCellBackgroundGetter"
+                     rows
+                     (json/generate-string cols)
+                     (json/generate-string viz-settings)))
 
 (defn get-background-color
-  "Get the correct color for a cell in a pulse table. This is intended to be invoked on each cell of every row in the
-  table. See `make-color-selector` for more info."
-  [^JSObject color-selector, cell-value column-name row-index]
-  (.call color-selector color-selector (object-array [cell-value row-index column-name])))
+  "Get the correct color for a cell in a pulse table. Returns color as string suitable for use CSS, e.g. a hex string or
+  `rgba()` string. This is intended to be invoked on each cell of every row in the table. See `make-color-selector`
+  for more info."
+  ^String [color-selector cell-value column-name row-index]
+  (js/invoke-function color-selector cell-value row-index column-name))

--- a/src/metabase/pulse/render/js_engine.clj
+++ b/src/metabase/pulse/render/js_engine.clj
@@ -1,0 +1,34 @@
+(ns metabase.pulse.render.js-engine
+  (:refer-clojure :exclude [eval])
+  (:require [metabase.util :as u])
+  (:import com.oracle.truffle.js.scriptengine.GraalJSScriptEngine
+           [javax.script Invocable ScriptEngine]
+           [org.graalvm.polyglot Context HostAccess]))
+
+(defn ^ScriptEngine engine
+  "Create a new JavaScript engine."
+  []
+  ;; see https://www.graalvm.org/reference-manual/js/ScriptEngine/#manually-creating-context-for-more-flexibility
+  (GraalJSScriptEngine/create
+   nil
+   (doto (Context/newBuilder (u/varargs String ["js"]))
+     ;; these options allow JavaScript to access Java classes such as arrays directly -- see
+     ;; https://www.graalvm.org/reference-manual/js/JavaInteroperability/
+     (.allowHostAccess HostAccess/ALL)
+     (.allowHostClassLookup (reify java.util.function.Predicate
+                              (test [_ _] true))))))
+
+(defn eval
+  "Eval a `javascript` snippet with `engine`, returning the result."
+  [^ScriptEngine engine ^String javascript]
+  (.eval engine javascript))
+
+(defn invoke-by-name
+  "Invoke a JavaScript function with `function-name` and `args`."
+  [^Invocable engine function-name & args]
+  (.invokeFunction engine (name function-name) (object-array args)))
+
+(defn invoke-function
+  "Invoke a JavaScript function object directly."
+  [^java.util.function.Function function & args]
+  (.apply function (object-array args)))

--- a/src/metabase/pulse/render/table.clj
+++ b/src/metabase/pulse/render/table.clj
@@ -4,8 +4,7 @@
             [metabase.pulse.render.color :as color]
             metabase.pulse.render.common
             [metabase.pulse.render.style :as style])
-  (:import jdk.nashorn.api.scripting.JSObject
-           metabase.pulse.render.common.NumericWrapper))
+  (:import metabase.pulse.render.common.NumericWrapper))
 
 (comment metabase.pulse.render.common/keep-me)
 
@@ -126,10 +125,10 @@
   background color for a given cell. `column-names` is different from the header in `header+rows` as the header is the
   display_name (i.e. human friendly. `header+rows` includes the text contents of the table we're about ready to
   create. If `normalized-zero` is set (defaults to 0), render values less than it as negative"
-  ([^JSObject color-selector column-names [header & rows :as contents]]
+  ([color-selector column-names [header & rows :as contents]]
    (render-table color-selector 0 column-names contents))
 
-  ([^JSObject color-selector normalized-zero column-names [header & rows]]
+  ([color-selector normalized-zero column-names [header & rows]]
    [:table {:style (style/style {:max-width "100%"
                                  :white-space :nowrap
                                  :padding-bottom :8px

--- a/test/metabase/pulse/render/color_test.clj
+++ b/test/metabase/pulse/render/color_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.pulse.render.color-test
   (:require [clojure.test :refer :all]
-            [metabase.pulse.render.color :as color]))
+            [metabase.pulse.render.color :as color]
+            [metabase.pulse.render.js-engine :as js]))
 
 (def ^:private red "#ff0000")
 (def ^:private green "#00ff00")
@@ -23,7 +24,9 @@
   "Setup a javascript engine with a stubbed script useful making sure `get-background-color` works independently from
   the real color picking script"
   [script & body]
-  `(with-redefs [color/js-engine (delay (#'color/make-js-engine-with-script ~script))]
+  `(with-redefs [color/js-engine (let [delay# (delay (doto (js/engine)
+                                                       (js/eval test-script)))]
+                                   (fn [] @delay#))]
      ~@body))
 
 (deftest color-test
@@ -38,7 +41,7 @@
 
 (deftest convert-keywords-test
   (testing (str "Same test as above, but make sure we convert any keywords as keywords don't get converted to "
-                "strings automatically when passed to a nashorn function")
+                "strings automatically when passed to a JavaScript function")
     (with-test-js-engine test-script
       (let [color-selector (color/make-color-selector {:cols [{:name "test"}]
                                                        :rows [[1] [2] [3] [4]]}


### PR DESCRIPTION
I figured out we can use the GraalVM JavaScript engine for our JavaScript execution needs, allowing us to finally remove our Nashorn dep and support Java 15 and 16.

I added tests against Java 16 (current latest) to CI and added Java 8 back which was accidentally changed in #15201.

Fixes #13881
Fixes #15707