### PR TITLE
Fix collections page loads slowly if contains lots of data

### DIFF
--- a/frontend/src/metabase/collections/components/CollectionsList.jsx
+++ b/frontend/src/metabase/collections/components/CollectionsList.jsx
@@ -27,7 +27,7 @@ class CollectionsList extends React.Component {
           const action = isOpen ? this.props.onClose : this.props.onOpen;
           const hasChildren =
             Array.isArray(c.children) &&
-            c.children.filter(child => !child.archived).length > 0;
+            c.children.some(child => !child.archived);
           return (
             <Box key={c.id}>
               <CollectionDropTarget collection={c}>

--- a/frontend/src/metabase/collections/components/ItemList.jsx
+++ b/frontend/src/metabase/collections/components/ItemList.jsx
@@ -32,6 +32,7 @@ export default function ItemList({
   showFilters,
   onMove,
   onCopy,
+  scrollElement,
 }) {
   const everythingName =
     collectionHasPins && items.length > 0 ? t`Everything else` : t`Everything`;
@@ -85,10 +86,8 @@ export default function ItemList({
             <VirtualizedList
               items={items}
               rowHeight={ROW_HEIGHT}
-              // needed in order to prevent an issue with content not fully rendering
-              // due to the collection content scrolling layout
-              useAutoSizerHeight={true}
               renderItem={renderListItem}
+              scrollElement={scrollElement}
             />
           </Box>
         </PinDropTarget>

--- a/frontend/src/metabase/collections/components/ItemList.jsx
+++ b/frontend/src/metabase/collections/components/ItemList.jsx
@@ -21,6 +21,7 @@ import PinDropTarget from "metabase/containers/dnd/PinDropTarget";
 const ROW_HEIGHT = 72;
 
 import { ANALYTICS_CONTEXT } from "metabase/collections/constants";
+
 export default function ItemList({
   items,
   collection,
@@ -35,6 +36,31 @@ export default function ItemList({
   const everythingName =
     collectionHasPins && items.length > 0 ? t`Everything else` : t`Everything`;
   const filters = assocIn(ITEM_TYPE_FILTERS, [0, "name"], everythingName);
+
+  const renderListItem = React.useCallback(
+    ({ item, index }) => (
+      <Box className="relative">
+        <ItemDragSource
+          item={item}
+          selection={selection}
+          collection={collection}
+        >
+          <NormalItem
+            key={`${item.model}:${item.id}`}
+            item={item}
+            onPin={() => item.setPinned(true)}
+            collection={collection}
+            selection={selection}
+            onToggleSelected={onToggleSelected}
+            onMove={onMove}
+            onCopy={onCopy}
+          />
+        </ItemDragSource>
+      </Box>
+    ),
+    [collection, onCopy, onMove, onToggleSelected, selection],
+  );
+
   return (
     <Box className="relative">
       {showFilters ? (
@@ -59,29 +85,10 @@ export default function ItemList({
             <VirtualizedList
               items={items}
               rowHeight={ROW_HEIGHT}
-              renderItem={({ item, index }) => (
-                <Box className="relative">
-                  <ItemDragSource
-                    item={item}
-                    selection={selection}
-                    collection={collection}
-                  >
-                    <NormalItem
-                      key={`${item.model}:${item.id}`}
-                      item={item}
-                      onPin={() => item.setPinned(true)}
-                      collection={collection}
-                      selection={selection}
-                      onToggleSelected={onToggleSelected}
-                      onMove={onMove}
-                      onCopy={onCopy}
-                    />
-                  </ItemDragSource>
-                </Box>
-              )}
               // needed in order to prevent an issue with content not fully rendering
               // due to the collection content scrolling layout
               useAutoSizerHeight={true}
+              renderItem={renderListItem}
             />
           </Box>
         </PinDropTarget>

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -112,6 +112,8 @@ export default class CollectionContent extends React.Component {
       selection,
       onToggleSelected,
       location,
+
+      scrollElement,
     } = this.props;
     const { selectedItems, selectedAction } = this.state;
 
@@ -157,6 +159,7 @@ export default class CollectionContent extends React.Component {
             />
           )}
           <ItemList
+            scrollElement={scrollElement}
             items={unpinnedItems}
             empty={unpinned.length === 0}
             showFilters={showFilters}

--- a/frontend/src/metabase/components/CollectionLanding.jsx
+++ b/frontend/src/metabase/components/CollectionLanding.jsx
@@ -10,6 +10,11 @@ import { PageWrapper } from "metabase/collections/components/Layout";
 const CollectionLanding = ({ params: { collectionId }, children }) => {
   const isRoot = collectionId === "root";
 
+  // This ref is passed to VirtualizedList inside CollectionContent
+  // List's scroll should not be attached to window (as by default)
+  // as it would break NavBar's and Sidebar's layout
+  const collectionContentContainerRef = React.useRef();
+
   return (
     <PageWrapper>
       <CollectionSidebar isRoot={isRoot} collectionId={collectionId} />
@@ -22,8 +27,13 @@ const CollectionLanding = ({ params: { collectionId }, children }) => {
         style={{ overflowY: "auto" }}
         ml={340}
         pb={4}
+        innerRef={collectionContentContainerRef}
       >
-        <CollectionContent isRoot={isRoot} collectionId={collectionId} />
+        <CollectionContent
+          isRoot={isRoot}
+          collectionId={collectionId}
+          scrollElement={collectionContentContainerRef.current}
+        />
       </Box>
       {
         // Need to have this here so the child modals will show up

--- a/frontend/src/metabase/components/VirtualizedList.jsx
+++ b/frontend/src/metabase/components/VirtualizedList.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 import { List, WindowScroller, AutoSizer } from "react-virtualized";
-import "react-virtualized/styles.css";
 
 function VirtualizedList({ items, rowHeight, renderItem, scrollElement }) {
   const rowRenderer = React.useCallback(

--- a/frontend/src/metabase/components/VirtualizedList.jsx
+++ b/frontend/src/metabase/components/VirtualizedList.jsx
@@ -3,7 +3,7 @@ import React from "react";
 import { List, WindowScroller, AutoSizer } from "react-virtualized";
 import "react-virtualized/styles.css";
 
-function VirtualizedList({ items, rowHeight, renderItem }) {
+function VirtualizedList({ items, rowHeight, renderItem, scrollElement }) {
   const rowRenderer = React.useCallback(
     ({ index, key, style }) => (
       <div key={key} style={style}>
@@ -16,7 +16,7 @@ function VirtualizedList({ items, rowHeight, renderItem }) {
   const renderScrollComponent = React.useCallback(
     ({ width }) => {
       return (
-        <WindowScroller>
+        <WindowScroller scrollElement={scrollElement}>
           {({ height, isScrolling, scrollTop }) => (
             <List
               autoHeight
@@ -32,7 +32,7 @@ function VirtualizedList({ items, rowHeight, renderItem }) {
         </WindowScroller>
       );
     },
-    [items, rowHeight, rowRenderer],
+    [items, rowHeight, rowRenderer, scrollElement],
   );
 
   return <AutoSizer>{renderScrollComponent}</AutoSizer>;

--- a/frontend/src/metabase/components/VirtualizedList.jsx
+++ b/frontend/src/metabase/components/VirtualizedList.jsx
@@ -1,39 +1,41 @@
 /* eslint-disable react/prop-types */
 import React from "react";
-
 import { List, WindowScroller, AutoSizer } from "react-virtualized";
+import "react-virtualized/styles.css";
 
-const VirtualizedList = ({
-  items,
-  rowHeight,
-  renderItem,
-  useAutoSizerHeight = false,
-}) => (
-  <AutoSizer>
-    {({ height: autosizerHeight, width }) => (
-      <WindowScroller>
-        {({ height, isScrolling, scrollTop }) => (
-          <List
-            autoHeight
-            width={width}
-            height={Math.min(
-              useAutoSizerHeight ? autosizerHeight : height,
-              rowHeight * items.length,
-            )}
-            isScrolling={isScrolling}
-            rowCount={items.length}
-            rowHeight={rowHeight}
-            rowRenderer={({ index, key, style }) => (
-              <div key={key} style={style}>
-                {renderItem({ item: items[index], index })}
-              </div>
-            )}
-            scrollTop={scrollTop}
-          />
-        )}
-      </WindowScroller>
-    )}
-  </AutoSizer>
-);
+function VirtualizedList({ items, rowHeight, renderItem }) {
+  const rowRenderer = React.useCallback(
+    ({ index, key, style }) => (
+      <div key={key} style={style}>
+        {renderItem({ item: items[index], index })}
+      </div>
+    ),
+    [items, renderItem],
+  );
+
+  const renderScrollComponent = React.useCallback(
+    ({ width }) => {
+      return (
+        <WindowScroller>
+          {({ height, isScrolling, scrollTop }) => (
+            <List
+              autoHeight
+              width={width}
+              height={Math.min(height, rowHeight * items.length)}
+              isScrolling={isScrolling}
+              rowCount={items.length}
+              rowHeight={rowHeight}
+              rowRenderer={rowRenderer}
+              scrollTop={scrollTop}
+            />
+          )}
+        </WindowScroller>
+      );
+    },
+    [items, rowHeight, rowRenderer],
+  );
+
+  return <AutoSizer>{renderScrollComponent}</AutoSizer>;
+}
 
 export default VirtualizedList;


### PR DESCRIPTION
Closes #15221

If users have lots of questions and dashboards, collections page opens really slowly (10 seconds and more for the Horror Show instance).

At the first glance, it looked like the server was responding slowly. But the page actually hangs because React tries to perform a huge render. It appeared the page was not using virtualized list correctly, and it tried to paint the whole dataset at once. This PR fixes virtualized list usage and the transitions are now instant ✨ Still need to wait until some data actually loads, but that's much more quick

The original proposed solution was to put a spinner here, but I think there is no need in it now? Increasing the dataset size shouldn't affect frontend performance, at least in terms of how long the router transition happens

### To Verify

1. Generate a huge dataset

```bash
> lein repl
> (metabase.db/setup-db!)
> (load-file "./test/metabase/test/generate.clj")
> (metabase.test.generate/generate-horror-show!)
```

2. Visit the main page
3. Click "Browse all items" button under the collections list

### Demo

Tested with 5000 dashboards and 50000 questions

**Before**

From the main page

![before-main-page](https://user-images.githubusercontent.com/17258145/115590523-b993b480-a2d9-11eb-8967-f36a764dcec9.gif)

Via URL

![before-from-url](https://user-images.githubusercontent.com/17258145/115590496-b4cf0080-a2d9-11eb-88ed-b340843e9bc2.gif)

**After**

From the main page

![after-main-page](https://user-images.githubusercontent.com/17258145/115590514-b7c9f100-a2d9-11eb-8337-6812738573cb.gif)

Via URL

![after-from-url](https://user-images.githubusercontent.com/17258145/115590520-b8fb1e00-a2d9-11eb-8623-cf02a8570590.gif)
