### PR TITLE
Fix sidebar loading causes UI jump

### DIFF
--- a/frontend/src/metabase/collections/components/CollectionsList.jsx
+++ b/frontend/src/metabase/collections/components/CollectionsList.jsx
@@ -46,7 +46,7 @@ class CollectionsList extends React.Component {
                       <Flex
                         className="relative"
                         align={
-                          // if a colleciton name is somewhat long, align things at flex-start ("top") for a slightly better
+                          // if a collection name is somewhat long, align things at flex-start ("top") for a slightly better
                           // visual
                           c.name.length > 25 ? "flex-start" : "center"
                         }

--- a/frontend/src/metabase/collections/components/CollectionsList.jsx
+++ b/frontend/src/metabase/collections/components/CollectionsList.jsx
@@ -42,6 +42,8 @@ class CollectionsList extends React.Component {
                       onClick={() => c.children && action(c.id)}
                       hovered={hovered}
                       highlighted={highlighted}
+                      role="treeitem"
+                      aria-expanded={isOpen}
                     >
                       <Flex
                         className="relative"

--- a/frontend/src/metabase/collections/containers/CollectionSidebar.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar.jsx
@@ -142,7 +142,7 @@ class CollectionSidebar extends React.Component {
         ) : (
           <div className="text-brand text-centered">
             <LoadingSpinner />
-            <h2 className="text-normal text-light mt1">{t`Loading ...`}</h2>
+            <h2 className="text-normal text-light mt1">{t`Loading…`}</h2>
           </div>
         )}
       </Sidebar>

--- a/frontend/src/metabase/collections/containers/CollectionSidebar.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar.jsx
@@ -133,10 +133,11 @@ class CollectionSidebar extends React.Component {
   };
 
   render() {
-    const { loaded } = this.props;
+    const { allFetched } = this.props;
+
     return (
       <Sidebar w={340} pt={3} data-testid="sidebar">
-        {loaded ? (
+        {allFetched ? (
           this.renderContent()
         ) : (
           <div className="text-brand text-centered">

--- a/frontend/src/metabase/collections/containers/CollectionSidebar.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar.jsx
@@ -11,6 +11,7 @@ import Collection from "metabase/entities/collections";
 
 import Icon from "metabase/components/Icon";
 import Link from "metabase/components/Link";
+import LoadingSpinner from "metabase/components/LoadingSpinner";
 
 import CollectionsList from "metabase/collections/components/CollectionsList";
 import CollectionLink from "metabase/collections/components/CollectionLink";
@@ -41,16 +42,17 @@ const Sidebar = styled(Box)`
     we should eventually refactor code elsewhere in the app to use this by default instead of determining the relationships clientside, but this works in the interim
   */
   query: () => ({ tree: true }),
+  loadingAndErrorWrapper: false,
 })
 class CollectionSidebar extends React.Component {
   state = {
     openCollections: [],
   };
 
-  componentDidMount() {
-    // an array to store the ancestors
+  componentDidUpdate(prevProps) {
     const { collectionId, collections, loading } = this.props;
-    if (!loading) {
+    const loaded = prevProps.loading && !loading;
+    if (loaded) {
       const ancestors = getParentPath(collections, Number(collectionId)) || [];
       this.setState({ openCollections: ancestors });
     }
@@ -71,10 +73,10 @@ class CollectionSidebar extends React.Component {
   // TODO Should we update the API to filter archived collections?
   filterPersonalCollections = collection => !collection.archived;
 
-  render() {
+  renderContent = () => {
     const { currentUser, isRoot, collectionId, list } = this.props;
     return (
-      <Sidebar w={340} pt={3} data-testid="sidebar">
+      <React.Fragment>
         <CollectionLink
           to={Urls.collection("root")}
           selected={isRoot}
@@ -126,6 +128,22 @@ class CollectionSidebar extends React.Component {
             {t`View archive`}
           </Link>
         </Box>
+      </React.Fragment>
+    );
+  };
+
+  render() {
+    const { loaded } = this.props;
+    return (
+      <Sidebar w={340} pt={3} data-testid="sidebar">
+        {loaded ? (
+          this.renderContent()
+        ) : (
+          <div className="text-brand text-centered">
+            <LoadingSpinner />
+            <h2 className="text-normal text-light mt1">{t`Loading ...`}</h2>
+          </div>
+        )}
       </Sidebar>
     );
   }

--- a/frontend/src/metabase/collections/containers/CollectionSidebar.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar.jsx
@@ -141,7 +141,7 @@ class CollectionSidebar extends React.Component {
     const { allFetched } = this.props;
 
     return (
-      <Sidebar w={340} pt={3} data-testid="sidebar">
+      <Sidebar w={340} pt={3} data-testid="sidebar" role="tree">
         {allFetched ? (
           this.renderContent()
         ) : (

--- a/frontend/src/metabase/collections/containers/CollectionSidebar.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar.jsx
@@ -42,6 +42,11 @@ const Sidebar = styled(Box)`
     we should eventually refactor code elsewhere in the app to use this by default instead of determining the relationships clientside, but this works in the interim
   */
   query: () => ({ tree: true }),
+
+  // Using the default loading wrapper breaks the UI,
+  // as the sidebar has a unique fixed left layout
+  // It's disabled, so loading can be displayed appropriately
+  // See: https://github.com/metabase/metabase/issues/14603
   loadingAndErrorWrapper: false,
 })
 class CollectionSidebar extends React.Component {

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -388,18 +388,11 @@ describe("scenarios > collection_defaults", () => {
         "**New collection should immediately be open, showing nested children**",
       );
 
-      openDropdownFor(NEW_COLLECTION);
-      cy.findAllByText("First collection");
-      cy.findAllByText("Second collection");
-
-      // TODO: This was an original test that made sure the collection is indeed open immediately.
-      //       That part is going to be addressed in a separate issue.
-      // cy.findByText(NEW_COLLECTION)
-      //   .closest("a")
-      //   .within(() => {
-      //     cy.icon("chevrondown");
-      //     cy.findByText("First collection");
-      //   });
+      getSidebarCollectionChildren(cy.findByText(NEW_COLLECTION)).within(() => {
+        cy.icon("chevrondown");
+        cy.findByText("First collection");
+        cy.findByText("Second collection");
+      });
     });
 
     it("should update UI when nested child collection is moved to the root collection (metabase#14482)", () => {
@@ -581,4 +574,11 @@ function selectItemUsingCheckbox(item, icon = "table") {
         .should("be.visible")
         .click();
     });
+}
+
+function getSidebarCollectionChildren(item) {
+  return item
+    .closest("a")
+    .parent()
+    .siblings();
 }

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -388,8 +388,8 @@ describe("scenarios > collection_defaults", () => {
         "**New collection should immediately be open, showing nested children**",
       );
 
-      getSidebarCollectionChildren(cy.findByText(NEW_COLLECTION)).within(() => {
-        cy.icon("chevrondown");
+      getSidebarCollectionChildrenFor(NEW_COLLECTION).within(() => {
+        cy.icon("chevrondown").should("have.length", 2); // both target collection and "First collection" are open
         cy.findByText("First collection");
         cy.findByText("Second collection");
       });
@@ -576,9 +576,11 @@ function selectItemUsingCheckbox(item, icon = "table") {
     });
 }
 
-function getSidebarCollectionChildren(item) {
-  return item
+function getSidebarCollectionChildrenFor(item) {
+  return cy
+    .findByTestId("sidebar")
+    .findByText(item)
     .closest("a")
     .parent()
-    .siblings();
+    .parent();
 }


### PR DESCRIPTION
Closes #14603 

When going into collections for the first time during a sessions, the loading spinner is shown above the collection elements instead of on the side, which causes the UI to jump. Depending on how slow the load is, or how fast the user is, this might cause the user to click a different element.

### To Verify

1. Log out (the issue reproduces for the first time in a session)
2. (Optional) Open developer tools, open the Network tab and turn on some throttling, so the loading state lasts longer

<img width="525" src="https://user-images.githubusercontent.com/17258145/115601076-08474b80-a2e6-11eb-8e00-751339a8b194.png">

3. Visit `/collection/root`

### Demo

**Before**

<img width="676" alt="before" src="https://user-images.githubusercontent.com/17258145/115601354-5bb99980-a2e6-11eb-92f7-8ce1a0056da3.png">

**After**

<img width="676" alt="after" src="https://user-images.githubusercontent.com/17258145/115601362-5eb48a00-a2e6-11eb-954a-0352a9d2b57b.png">
