### PR TITLE
#15714 Repro: "Percentile" custom expression function should accept 2 parameters

### DIFF
--- a/frontend/test/metabase-db/postgres/custom-column.cy.spec.js
+++ b/frontend/test/metabase-db/postgres/custom-column.cy.spec.js
@@ -75,4 +75,24 @@ describe("postgres > question > custom columns", () => {
       cy.contains(ESCAPED_REGEX);
     });
   });
+
+  it.skip("`Percentile` custom expression function should accept two parameters (metabase#15714)", () => {
+    cy.visit("/question/new");
+    cy.findByText("Custom question").click();
+    cy.findByText(PG_DB_NAME).click();
+    cy.findByText("Orders").click();
+    cy.icon("add_data").click();
+    cy.get("[contenteditable='true']")
+      .click()
+      .type("Percentile([Subtotal], 0.1)");
+    cy.findByPlaceholderText("Something nice and descriptive")
+      .as("description")
+      .click();
+    cy.findByText("Function Percentile expects 1 argument").should("not.exist");
+    cy.get("@description").type("A");
+    cy.findByRole("button", { name: "Done" })
+      .should("not.be.disabled")
+      .click();
+    // Todo: Add positive assertions once this is fixed
+  });
 });


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #15714

### How to test this manually?
- `yarn test-cypress-open --folder frontend/test/metabase-db/`
- `frontend/test/metabase-db/postgres/custom-column.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/115605957-6d4d7200-a2e3-11eb-8e0e-45c291ca8240.png)

