### PR TITLE
Correct the arguments for PERCENTILE function

### DIFF
--- a/frontend/src/metabase/lib/expressions/config.js
+++ b/frontend/src/metabase/lib/expressions/config.js
@@ -117,7 +117,7 @@ export const MBQL_CLAUSES = {
   percentile: {
     displayName: `Percentile`,
     type: "aggregation",
-    args: ["number"],
+    args: ["number", "number"],
     requiresFeature: "percentile-aggregations",
   },
   // string functions

--- a/frontend/test/metabase-db/postgres/custom-column.cy.spec.js
+++ b/frontend/test/metabase-db/postgres/custom-column.cy.spec.js
@@ -76,7 +76,7 @@ describe("postgres > question > custom columns", () => {
     });
   });
 
-  it.skip("`Percentile` custom expression function should accept two parameters (metabase#15714)", () => {
+  it("`Percentile` custom expression function should accept two parameters (metabase#15714)", () => {
     cy.visit("/question/new");
     cy.findByText("Custom question").click();
     cy.findByText(PG_DB_NAME).click();

--- a/frontend/test/metabase/lib/expressions/typechecker.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/typechecker.unit.spec.js
@@ -110,6 +110,10 @@ describe("type-checker", () => {
     it("should accept a CASE expression with complex arguments", () => {
       expect(() => validate("CASE(Deal, 0.5*X, Y-Z)")).not.toThrow();
     });
+
+    it("should accept PERCENTILE with two arguments", () => {
+      expect(() => validate("PERCENTILE([Rating], .5)")).not.toThrow();
+    });
   });
 
   describe("for a filter", () => {


### PR DESCRIPTION
This fixes #15714

Steps to reproduce:
1. Ask a question, Custom question
2. Sample Dataset, Orders table
3. Custom column and type `percentile([Product → Rating] , 0.9)`

**Before**

![image](https://user-images.githubusercontent.com/7288/115612283-f0e56f80-a29f-11eb-9511-87672173185f.png)

**After**

![image](https://user-images.githubusercontent.com/7288/115612516-2e49fd00-a2a0-11eb-82b2-a18a18601e99.png)
