### PR TITLE
#15705 Repro: Dashboard subscription fails when using default dashboard filter value on native query with required parameter

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard/subscriptions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/subscriptions.cy.spec.js
@@ -55,7 +55,15 @@ describe("scenarios > dashboard > subscriptions", () => {
 
   describe("with email set up", () => {
     beforeEach(() => {
-      setupDummySMTP();
+      cy.request("DELETE", "http://localhost:80/email/all");
+      cy.request("PUT", "/api/setting", {
+        "email-smtp-host": "localhost",
+        "email-smtp-port": "25",
+        "email-smtp-username": "admin",
+        "email-smtp-password": "admin",
+        "email-smtp-security": "none",
+        "email-from-address": "mailer@metabase.test",
+      });
     });
 
     describe("with no existing subscriptions", () => {

--- a/frontend/test/metabase/scenarios/dashboard/subscriptions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/subscriptions.cy.spec.js
@@ -4,6 +4,7 @@ import {
   describeWithToken,
   describeOpenSourceOnly,
   popover,
+  mockSessionProperty,
 } from "__support__/cypress";
 import { USERS } from "__support__/cypress_data";
 const { admin } = USERS;
@@ -122,6 +123,79 @@ describe("scenarios > dashboard > subscriptions", () => {
       clickButton("Done");
       // Implicit assertion (word mustn't contain string "null")
       cy.findByText(/^Emailed monthly on the first (?!null)/);
+    });
+
+    it.skip("should work when using dashboard default filter value on native query with required parameter (metabase#15705)", () => {
+      // In order to reproduce this test, we need to use the old syntac for dashboard filters
+      mockSessionProperty("field-filter-operators-enabled?", false);
+
+      cy.createNativeQuestion({
+        name: "15705",
+        native: {
+          query: "SELECT COUNT(*) FROM ORDERS WHERE QUANTITY={{qty}}",
+          "template-tags": {
+            qty: {
+              id: "3cfb3686-0d13-48db-ab5b-100481a3a830",
+              name: "qty",
+              "display-name": "Qty",
+              type: "number",
+              required: true,
+            },
+          },
+        },
+      }).then(({ body: { id: QUESTION_ID } }) => {
+        cy.createDashboard("15705D").then(({ body: { id: DASHBOARD_ID } }) => {
+          // Add filter to the dashboard
+          cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}`, {
+            // Using the old dashboard filter syntax
+            parameters: [
+              {
+                name: "Quantity",
+                slug: "quantity",
+                id: "930e4001",
+                type: "category",
+                default: "20",
+              },
+            ],
+          });
+
+          // Add question to the dashboard
+          cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
+            cardId: QUESTION_ID,
+          }).then(({ body: { id: DASH_CARD_ID } }) => {
+            // Connect filter to that question
+            cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}/cards`, {
+              cards: [
+                {
+                  id: DASH_CARD_ID,
+                  card_id: QUESTION_ID,
+                  row: 0,
+                  col: 0,
+                  sizeX: 12,
+                  sizeY: 10,
+                  parameter_mappings: [
+                    {
+                      parameter_id: "930e4001",
+                      card_id: QUESTION_ID,
+                      target: ["variable", ["template-tag", "qty"]],
+                    },
+                  ],
+                },
+              ],
+            });
+          });
+          assignRecipient({ dashboard_id: DASHBOARD_ID });
+        });
+      });
+      // Click anywhere outside to close the popover
+      cy.findByText("15705D").click();
+      cy.findByText("Send email now").click();
+      cy.findByText("Email sent");
+      cy.request("GET", "http://localhost:80/email").then(({ body }) => {
+        expect(body[0].html).not.to.include(
+          "An error occurred while displaying this card.",
+        );
+      });
     });
   });
 
@@ -247,8 +321,8 @@ function openDashboardSubscriptions(dashboard_id = 1) {
   cy.findByText("Dashboard subscriptions").click();
 }
 
-function assignRecipient(user = admin) {
-  openDashboardSubscriptions();
+function assignRecipient({ user = admin, dashboard_id = 1 } = {}) {
+  openDashboardSubscriptions(dashboard_id);
   cy.findByText("Email it").click();
   cy.findByPlaceholderText("Enter user names or email addresses")
     .click()


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #15705

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/dashboard/subscriptions.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/115614052-77746e00-a2ed-11eb-9dc0-a8654fd63070.png)

