### PR TITLE
Add QuestionActionButtons to question details sidebar

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -105,6 +105,7 @@ export default class View extends React.Component {
       mode,
       fitClassNames,
       height,
+      onOpenModal,
     } = this.props;
     const {
       aggregationIndex,
@@ -159,7 +160,7 @@ export default class View extends React.Component {
     ) : isShowingChartTypeSidebar ? (
       <ChartTypeSidebar {...this.props} onClose={this.props.onCloseChartType} />
     ) : isShowingQuestionDetailsSidebar ? (
-      <QuestionDetailsSidebar />
+      <QuestionDetailsSidebar question={question} onOpenModal={onOpenModal} />
     ) : null;
 
     const rightSideBar =

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebar.jsx
@@ -1,12 +1,24 @@
 import React from "react";
-import SidebarContent from "metabase/query_builder/components/SidebarContent";
+import PropTypes from "prop-types";
 
-function QuestionDetailsSidebar() {
+import SidebarContent from "metabase/query_builder/components/SidebarContent";
+import QuestionActionButtons from "metabase/questions/components/QuestionActionButtons";
+
+function QuestionDetailsSidebar({ question, onOpenModal }) {
+  const canWrite = question && question.canWrite();
+
   return (
     <SidebarContent className="full-height px1">
-      question details sidebar
+      <div>
+        <QuestionActionButtons canWrite={canWrite} onOpenModal={onOpenModal} />
+      </div>
     </SidebarContent>
   );
 }
+
+QuestionDetailsSidebar.propTypes = {
+  question: PropTypes.object.isRequired,
+  onOpenModal: PropTypes.func.isRequired,
+};
 
 export default QuestionDetailsSidebar;

--- a/frontend/src/metabase/questions/components/QuestionActionButtons.jsx
+++ b/frontend/src/metabase/questions/components/QuestionActionButtons.jsx
@@ -1,0 +1,64 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { t } from "ttag";
+import styled from "styled-components";
+
+import { color } from "metabase/lib/colors";
+
+import Button from "metabase/components/Button";
+
+const BlueHoverTextButton = styled(Button)`
+  :hover {
+    color: ${color("brand")};
+  }
+`;
+
+function QuestionActionButtons({ canWrite, onOpenModal }) {
+  return (
+    <div className="my1 flex justify-between align-center">
+      <BlueHoverTextButton
+        className="flex-1"
+        icon="add_to_dash"
+        borderless
+        iconSize={18}
+        onClick={() => onOpenModal("add-to-dashboard")}
+      >
+        Add to a dashboard
+      </BlueHoverTextButton>
+      {canWrite && (
+        <Button
+          tooltip={t`Duplicate this question`}
+          onlyIcon
+          icon="clone"
+          iconSize={18}
+          onClick={() => onOpenModal("clone")}
+        />
+      )}
+      {canWrite && (
+        <Button
+          tooltip={t`Move`}
+          onlyIcon
+          icon="move"
+          iconSize={18}
+          onClick={() => onOpenModal("move")}
+        />
+      )}
+      {canWrite && (
+        <Button
+          tooltip={t`Archive`}
+          onlyIcon
+          icon="archive"
+          iconSize={18}
+          onClick={() => onOpenModal("archive")}
+        />
+      )}
+    </div>
+  );
+}
+
+QuestionActionButtons.propTypes = {
+  canWrite: PropTypes.bool,
+  onOpenModal: PropTypes.func,
+};
+
+export default QuestionActionButtons;

--- a/frontend/src/metabase/questions/components/QuestionActionButtons.jsx
+++ b/frontend/src/metabase/questions/components/QuestionActionButtons.jsx
@@ -6,6 +6,7 @@ import styled from "styled-components";
 import { color } from "metabase/lib/colors";
 
 import Button from "metabase/components/Button";
+import Tooltip from "metabase/components/Tooltip";
 
 const BlueHoverTextButton = styled(Button)`
   :hover {
@@ -26,31 +27,34 @@ function QuestionActionButtons({ canWrite, onOpenModal }) {
         Add to a dashboard
       </BlueHoverTextButton>
       {canWrite && (
-        <Button
-          tooltip={t`Duplicate this question`}
-          onlyIcon
-          icon="clone"
-          iconSize={18}
-          onClick={() => onOpenModal("clone")}
-        />
+        <Tooltip tooltip={t`Duplicate this question`}>
+          <Button
+            onlyIcon
+            icon="clone"
+            iconSize={18}
+            onClick={() => onOpenModal("clone")}
+          />
+        </Tooltip>
       )}
       {canWrite && (
-        <Button
-          tooltip={t`Move`}
-          onlyIcon
-          icon="move"
-          iconSize={18}
-          onClick={() => onOpenModal("move")}
-        />
+        <Tooltip tooltip={t`Move`}>
+          <Button
+            onlyIcon
+            icon="move"
+            iconSize={18}
+            onClick={() => onOpenModal("move")}
+          />
+        </Tooltip>
       )}
       {canWrite && (
-        <Button
-          tooltip={t`Archive`}
-          onlyIcon
-          icon="archive"
-          iconSize={18}
-          onClick={() => onOpenModal("archive")}
-        />
+        <Tooltip tooltip={t`Archive`}>
+          <Button
+            onlyIcon
+            icon="archive"
+            iconSize={18}
+            onClick={() => onOpenModal("archive")}
+          />
+        </Tooltip>
       )}
     </div>
   );


### PR DESCRIPTION
nothin' fancy, just adding some buttons that replace most of the functionality of the pencil icon (not all -- editing the question description/name and revision history are still missing). intentionally punting broken cypress tests still so that i can work more on getting the bucm prototype out the door.

normal:
![Screen Shot 2021-04-21 at 3 30 47 PM](https://user-images.githubusercontent.com/13057258/115629306-f7331600-a2b6-11eb-8d64-517847d60fd9.png)

hovering over button with text:
![Screen Shot 2021-04-21 at 3 30 52 PM](https://user-images.githubusercontent.com/13057258/115629310-f7cbac80-a2b6-11eb-9231-60bc671594df.png)

hovering over icon button:
![Screen Shot 2021-04-21 at 3 30 58 PM](https://user-images.githubusercontent.com/13057258/115629311-f7cbac80-a2b6-11eb-84e4-27e3b395ce9b.png)

context:
![Screen Shot 2021-04-23 at 11 53 33 AM](https://user-images.githubusercontent.com/13057258/115917088-8f054100-a42a-11eb-9446-8b811384ec43.png)
