### PR TITLE
#15734 Repro: Contenteditable field losing value and resetting CC formula

### DIFF
--- a/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
@@ -491,18 +491,57 @@ describe("scenarios > question > custom columns", () => {
     cy.findByRole("button", { name: "Done" }).should("not.be.disabled");
   });
 
-  it("contenteditable field should not accidentally delete CC formula value and/or CC name (metabase#15734)", () => {
-    openOrdersTable({ mode: "notebook" });
-    cy.findByText("Custom column").click();
-    cy.get("[contenteditable='true']")
-      .as("formula")
-      .type("1+1");
-    cy.findByPlaceholderText("Something nice and descriptive").type("Math");
-    cy.findByRole("button", { name: "Done" }).should("not.be.disabled");
-    cy.get("@formula")
-      .click()
-      .type("{movetoend}{leftarrow}{movetostart}{rightarrow}{rightarrow}");
-    cy.findByText("Math");
-    cy.findByRole("button", { name: "Done" }).should("not.be.disabled");
+  describe("contentedtable field (metabase#15734)", () => {
+    beforeEach(() => {
+      // This is the default screen size but we need it explicitly set for this test because of the resize later on
+      cy.viewport(1280, 800);
+
+      openOrdersTable({ mode: "notebook" });
+      cy.findByText("Custom column").click();
+      popover().within(() => {
+        cy.get("[contenteditable='true']")
+          .as("formula")
+          .type("1+1")
+          .blur();
+      });
+      // Ugly hack without which the contenteditable field loses value making all subsequent repros impossible
+      cy.get("@formula")
+        .clear()
+        .type("1 + 1");
+      cy.findByPlaceholderText("Something nice and descriptive").type("Math");
+      cy.findByRole("button", { name: "Done" }).should("not.be.disabled");
+    });
+
+    it("should not accidentally delete CC formula value and/or CC name (metabase#15734-1)", () => {
+      cy.get("@formula")
+        .click()
+        .type("{movetoend}{leftarrow}{movetostart}{rightarrow}{rightarrow}")
+        .blur();
+      cy.findByDisplayValue("Math");
+      cy.findByRole("button", { name: "Done" }).should("not.be.disabled");
+    });
+
+    /**
+     * 1. Explanation for `cy.get("@formula").click();`
+     *  - Without it, test runner is too fast and the test resutls in false positive.
+     *  - This gives it enough time to update the DOM. The same result can be achieved with `cy.wait(1)`
+     */
+    it.skip("should not erase CC formula and CC name when expression is incomplete (metabase#15734-2)", () => {
+      cy.get("@formula")
+        .click()
+        .type("{movetoend}{backspace}")
+        .blur();
+      cy.findByText("Expected expression");
+      cy.findByRole("button", { name: "Done" }).should("be.disabled");
+      cy.get("@formula").click(); /* [1] */
+      cy.findByDisplayValue("Math");
+    });
+
+    it.skip("should not erase CC formula and CC name on window resize", () => {
+      cy.viewport(1260, 800);
+      cy.get("@formula").click(); /* [1] */
+      cy.findByDisplayValue("Math");
+      cy.findByRole("button", { name: "Done" }).should("not.be.disabled");
+    });
   });
 });

--- a/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
@@ -490,4 +490,19 @@ describe("scenarios > question > custom columns", () => {
     cy.findByText("Unknown Field: .5").should("not.exist");
     cy.findByRole("button", { name: "Done" }).should("not.be.disabled");
   });
+
+  it("contenteditable field should not accidentally delete CC formula value and/or CC name (metabase#15734)", () => {
+    openOrdersTable({ mode: "notebook" });
+    cy.findByText("Custom column").click();
+    cy.get("[contenteditable='true']")
+      .as("formula")
+      .type("1+1");
+    cy.findByPlaceholderText("Something nice and descriptive").type("Math");
+    cy.findByRole("button", { name: "Done" }).should("not.be.disabled");
+    cy.get("@formula")
+      .click()
+      .type("{movetoend}{leftarrow}{movetostart}{rightarrow}{rightarrow}");
+    cy.findByText("Math");
+    cy.findByRole("button", { name: "Done" }).should("not.be.disabled");
+  });
 });


### PR DESCRIPTION
### Status
DRAFT
_Intentionally didn't SKIP the test before the fix, because I want to confirm it failing in CI. Merging https://github.com/metabase/metabase/pull/15608 will (at least partially) fix this issue in which case this test should pass (after rebase, of course).

As expected, [initial CI run](https://app.circleci.com/pipelines/github/metabase/metabase/15314/workflows/8f87da94-07a4-433e-95d8-2ccc753d9f78/jobs/586610) with unfixed issue on `master` failed.

### What does this PR accomplish?
- Reproduces #15734 

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/question/custom_column.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/115634367-c6300100-a309-11eb-93b7-f55992c566b3.png)

