### PR TITLE
add data picker search

### DIFF
--- a/frontend/src/metabase/admin/people/components/SearchInput.jsx
+++ b/frontend/src/metabase/admin/people/components/SearchInput.jsx
@@ -6,7 +6,7 @@ import TextInput from "metabase/components/TextInput";
 
 const SearchInput = styled(TextInput).attrs({
   icon: <Icon name="search" size={16} />,
-  borderRadius: 'sm'
+  borderRadius: "sm",
 })`
   min-width: 286px;
 `;

--- a/frontend/src/metabase/admin/people/components/SearchInput.jsx
+++ b/frontend/src/metabase/admin/people/components/SearchInput.jsx
@@ -1,105 +1,14 @@
 import React from "react";
-import PropTypes from "prop-types";
-import styled, { css } from "styled-components";
-import { color } from "metabase/lib/colors";
+import styled from "styled-components";
 
 import Icon from "metabase/components/Icon";
-import { t } from "ttag";
+import TextInput from "metabase/components/TextInput";
 
-export default function SearchInput({
-  value,
-  placeholder,
-  onChange,
-  className,
-  hasClearButton,
-}) {
-  const handleClearClick = () => {
-    onChange("");
-  };
-
-  const showClearButton = hasClearButton && value.length > 0;
-
-  return (
-    <SearchFieldRoot className={className}>
-      <IconWrapper>
-        <Icon name="search" size={16} />
-      </IconWrapper>
-      <Input
-        hasClearButton
-        type="text"
-        placeholder={placeholder}
-        value={value}
-        onChange={e => onChange(e.target.value)}
-      />
-
-      {showClearButton && (
-        <ClearButton onClick={handleClearClick}>
-          <Icon name="close" size={12} />
-        </ClearButton>
-      )}
-    </SearchFieldRoot>
-  );
-}
-
-SearchInput.propTypes = {
-  onChange: PropTypes.func.isRequired,
-  placeholder: PropTypes.string,
-  value: PropTypes.string,
-  autoFocus: PropTypes.bool,
-  className: PropTypes.string,
-  hasClearButton: PropTypes.bool,
-};
-
-SearchInput.defaultProps = {
-  placeholder: t`Find...`,
-  value: "",
-  autoFocus: false,
-  hasClearButton: false,
-};
-
-const Input = styled.input`
+const SearchInput = styled(TextInput).attrs({
+  icon: <Icon name="search" size={16} />,
+  borderRadius: 'sm'
+})`
   min-width: 286px;
-  border-radius: 4px;
-  border: 1px solid ${color("border")};
-  padding: 0.75em 0.75em 0.75em 36px;
-  outline: none;
-  width: 100%;
-  font-size: 1.12em;
-  font-weight: 700;
-  color: ${color("text-dark")};
-
-  ${props =>
-    props.hasClearButton
-      ? css`
-          padding-right: 26px;
-        `
-      : null}
-
-  &:focus {
-    border-color: ${color("brand")};
-  }
 `;
 
-const SearchFieldRoot = styled.div`
-  position: relative;
-  display: flex;
-  align-items: center;
-`;
-
-const ClearButton = styled.button`
-  display: flex;
-  position: absolute;
-  right: 12px;
-  color: ${color("bg-dark")};
-  cursor: pointer;
-
-  &:hover {
-    color: ${color("text-dark")};
-  }
-`;
-
-const IconWrapper = styled.span`
-  position: absolute;
-  padding-left: 0.75rem;
-  color: ${color("text-light")};
-`;
+export default SearchInput;

--- a/frontend/src/metabase/components/AccordionList.jsx
+++ b/frontend/src/metabase/components/AccordionList.jsx
@@ -520,9 +520,10 @@ const AccordionListCell = ({
   } else if (type === "search") {
     content = (
       <ListSearchField
+        hasClearButton
         className="bg-white m1"
         onChange={onChangeSearchText}
-        searchText={searchText}
+        value={searchText}
         placeholder={searchPlaceholder}
         autoFocus
       />

--- a/frontend/src/metabase/components/ListSearchField.jsx
+++ b/frontend/src/metabase/components/ListSearchField.jsx
@@ -33,4 +33,4 @@ export default function ListSearchField(props) {
   );
 }
 
-ListSearchField.propTypes = TextInput.propTypes
+ListSearchField.propTypes = TextInput.propTypes;

--- a/frontend/src/metabase/components/ListSearchField.jsx
+++ b/frontend/src/metabase/components/ListSearchField.jsx
@@ -1,65 +1,36 @@
-/* eslint-disable react/prop-types */
-import React, { Component } from "react";
-import PropTypes from "prop-types";
+import React, { useEffect, useRef } from "react";
 
 import Icon from "metabase/components/Icon";
-import { t } from "ttag";
-import cx from "classnames";
+import TextInput from "metabase/components/TextInput";
 
-export default class ListSearchField extends Component {
-  static propTypes = {
-    onChange: PropTypes.func.isRequired,
-    placeholder: PropTypes.string,
-    searchText: PropTypes.string,
-    autoFocus: PropTypes.bool,
-  };
+export default function ListSearchField(props) {
+  const inputRef = useRef();
 
-  static defaultProps = {
-    placeholder: t`Find...`,
-    searchText: "",
-    autoFocus: false,
-  };
-
-  componentDidMount() {
-    if (this.props.autoFocus) {
-      // Call focus() with a small delay because instant input focus causes an abrupt scroll to top of page
-      // when ListSearchField is used inside a popover. It seems that it takes a while for Tether library
-      // to correctly position the popover.
-      setTimeout(() => this._input && this._input.focus(), 50);
+  useEffect(() => {
+    if (!props.autoFocus) {
+      return;
     }
-  }
 
-  render() {
-    const {
-      className,
-      inputClassName,
-      onChange,
-      placeholder,
-      searchText,
-    } = this.props;
-
-    return (
-      <div
-        className={cx(
-          className,
-          "bordered rounded text-light flex flex-full align-center",
-        )}
-      >
-        <span className="px1">
-          <Icon name="search" size={16} />
-        </span>
-        <input
-          className={cx(
-            inputClassName,
-            "p1 h4 input--borderless text-default flex-full",
-          )}
-          type="text"
-          placeholder={placeholder}
-          value={searchText}
-          onChange={e => onChange(e.target.value)}
-          ref={input => (this._input = input)}
-        />
-      </div>
+    // Call focus() with a small delay because instant input focus causes an abrupt scroll to top of page
+    // when ListSearchField is used inside a popover. It seems that it takes a while for Tether library
+    // to correctly position the popover.
+    const timerId = setTimeout(
+      () => inputRef.current && inputRef.current.focus(),
+      50,
     );
-  }
+    return () => clearTimeout(timerId);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <TextInput
+      {...props}
+      ref={inputRef}
+      padding="sm"
+      borderRadius="md"
+      icon={<Icon name="search" size={16} />}
+    />
+  );
 }
+
+ListSearchField.propTypes = TextInput.propTypes

--- a/frontend/src/metabase/components/TextInput.jsx
+++ b/frontend/src/metabase/components/TextInput.jsx
@@ -1,0 +1,139 @@
+import React, { forwardRef } from "react";
+import PropTypes from "prop-types";
+import styled, { css } from "styled-components";
+import { color } from "metabase/lib/colors";
+import { t } from "ttag";
+
+import Icon from "metabase/components/Icon";
+
+function TextInput({
+  value,
+  className,
+  placeholder,
+  onChange,
+  hasClearButton,
+  icon,
+  type,
+  ...rest
+}) {
+  const handleClearClick = () => {
+    onChange("");
+  };
+
+  const showClearButton = hasClearButton && value.length > 0;
+
+  return (
+    <TextInputRoot className={className}>
+      {icon && <IconWrapper>{icon}</IconWrapper>}
+      <Input
+        hasClearButton
+        hasIcon={!!icon}
+        placeholder={placeholder}
+        value={value}
+        type={type}
+        onChange={e => onChange(e.target.value)}
+        {...rest}
+      />
+
+      {showClearButton && (
+        <ClearButton onClick={handleClearClick}>
+          <Icon name="close" size={12} />
+        </ClearButton>
+      )}
+    </TextInputRoot>
+  );
+}
+
+TextInput.propTypes = {
+  onChange: PropTypes.func.isRequired,
+  placeholder: PropTypes.string,
+  value: PropTypes.string,
+  type: PropTypes.string,
+  autoFocus: PropTypes.bool,
+  className: PropTypes.string,
+  hasClearButton: PropTypes.bool,
+  icon: PropTypes.node,
+  padding: PropTypes.oneOf(["sm", "md"]),
+  borderRadius: PropTypes.oneOf(["sm", "md"]),
+};
+
+TextInput.defaultProps = {
+  placeholder: t`Find...`,
+  value: "",
+  type: "text",
+  autoFocus: false,
+  hasClearButton: false,
+  padding: "md",
+  borderRadius: "md",
+};
+
+const PADDING = {
+  sm: "0.5rem",
+  md: "0.75rem",
+};
+
+const BORDER_RADIUS = {
+  sm: "4px",
+  md: "8px",
+};
+
+const Input = styled.input`
+  border: 1px solid ${color("border")};
+  outline: none;
+  width: 100%;
+  font-size: 1.12em;
+  font-weight: 700;
+  color: ${color("text-dark")};
+  min-width: 200px;
+
+  ${({ borderRadius, padding }) => css`
+    border-radius: ${BORDER_RADIUS[borderRadius]};
+    padding: ${PADDING[padding]};
+  `}
+
+  ${props =>
+    props.hasClearButton
+      ? css`
+          padding-right: 26px;
+        `
+      : null}
+
+  ${props =>
+    props.hasIcon
+      ? css`
+          padding-left: 36px;
+        `
+      : null}
+
+  &:focus {
+    border-color: ${color("brand")};
+  }
+`;
+
+const TextInputRoot = styled.div`
+  position: relative;
+  display: flex;
+  align-items: center;
+`;
+
+const ClearButton = styled.button`
+  display: flex;
+  position: absolute;
+  right: 12px;
+  color: ${color("bg-dark")};
+  cursor: pointer;
+
+  &:hover {
+    color: ${color("text-dark")};
+  }
+`;
+
+const IconWrapper = styled.span`
+  position: absolute;
+  padding-left: 0.75rem;
+  color: ${color("text-light")};
+`;
+
+export default forwardRef(function TextInputWithForwardedRef(props, ref) {
+  return <TextInput forwardedRef={ref} {...props} />;
+});

--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -26,6 +26,8 @@ import { getMetadata } from "metabase/selectors/metadata";
 
 import _ from "underscore";
 
+const MIN_SEARCH_LENGTH = 2;
+
 // chooses a database
 const DATABASE_STEP = "DATABASE";
 // chooses a schema (given that a database has already been selected)
@@ -707,7 +709,7 @@ export class UnconnectedDataSelector extends Component {
     const { canChangeDatabase, selectedDatabaseId } = this.props;
     const searchDatabaseId = canChangeDatabase ? null : selectedDatabaseId;
 
-    const isSearchActive = searchText.length >= 2;
+    const isSearchActive = searchText.length >= MIN_SEARCH_LENGTH;
 
     return (
       <PopoverWithTrigger

--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -5,6 +5,7 @@ import PropTypes from "prop-types";
 import { t } from "ttag";
 import cx from "classnames";
 
+import ListSearchField from "metabase/components/ListSearchField";
 import ExternalLink from "metabase/components/ExternalLink";
 import Icon from "metabase/components/Icon";
 import PopoverWithTrigger from "metabase/components/PopoverWithTrigger";
@@ -16,6 +17,10 @@ import MetabaseSettings from "metabase/lib/settings";
 import Databases from "metabase/entities/databases";
 import Schemas from "metabase/entities/schemas";
 import Tables from "metabase/entities/tables";
+import {
+  SearchResults,
+  convertSearchResultToTableLikeItem,
+} from "./data-search";
 
 import { getMetadata } from "metabase/selectors/metadata";
 
@@ -145,6 +150,7 @@ export class UnconnectedDataSelector extends Component {
       selectedSchemaId: props.selectedSchemaId,
       selectedTableId: props.selectedTableId,
       selectedFieldId: props.selectedFieldId,
+      searchText: "",
     };
     const computedState = this._getComputedState(props, state);
     this.state = {
@@ -173,6 +179,8 @@ export class UnconnectedDataSelector extends Component {
     isInitiallyOpen: PropTypes.bool,
     renderAsSelect: PropTypes.bool,
     tableFilter: PropTypes.func,
+    hasTableSearch: PropTypes.bool,
+    canChangeDatabase: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -182,6 +190,8 @@ export class UnconnectedDataSelector extends Component {
     useOnlyAvailableSchema: true,
     hideSingleSchema: true,
     hideSingleDatabase: false,
+    hasTableSearch: false,
+    canChangeDatabase: true,
   };
 
   // computes selected metadata objects (`selectedDatabase`, etc) and options (`databases`, etc)
@@ -624,7 +634,7 @@ export class UnconnectedDataSelector extends Component {
   }
 
   renderActiveStep() {
-    const { combineDatabaseSchemaSteps } = this.props;
+    const { combineDatabaseSchemaSteps, hasTableSearch } = this.props;
     const props = {
       ...this.state,
 
@@ -637,6 +647,7 @@ export class UnconnectedDataSelector extends Component {
       isLoading: this.state.isLoading,
       hasNextStep: !!this.getNextStep(),
       onBack: this.getPreviousStep() ? this.previousStep : null,
+      hasFiltering: !hasTableSearch,
     };
 
     switch (this.state.activeStep) {
@@ -661,7 +672,43 @@ export class UnconnectedDataSelector extends Component {
     return null;
   }
 
+  showTableSearch = () => {
+    const { hasTableSearch, steps } = this.props;
+    const { activeStep } = this.state;
+    const hasTableStep = steps.includes(TABLE_STEP);
+    const isAllowedToShowOnActiveStep = [SCHEMA_STEP, DATABASE_STEP].includes(
+      activeStep,
+    );
+
+    return hasTableSearch && hasTableStep && isAllowedToShowOnActiveStep;
+  };
+
+  handleSearchTextChange = searchText =>
+    this.setState({
+      searchText,
+    });
+
+  handleSearchItemSelect = async item => {
+    const table = convertSearchResultToTableLikeItem(item);
+    await this.props.fetchFields(table.id);
+    if (this.props.setSourceTableFn) {
+      this.props.setSourceTableFn(table.id);
+    }
+    this.popover.current.toggle();
+    this.handleClose();
+  };
+
+  handleClose = () => {
+    this.setState({ searchText: "" });
+  };
+
   render() {
+    const { searchText } = this.state;
+    const { canChangeDatabase, selectedDatabaseId } = this.props;
+    const searchDatabaseId = canChangeDatabase ? null : selectedDatabaseId;
+
+    const isSearchActive = searchText.length >= 2;
+
     return (
       <PopoverWithTrigger
         id="DataPopover"
@@ -674,8 +721,26 @@ export class UnconnectedDataSelector extends Component {
         tetherOptions={this.props.tetherOptions}
         sizeToFit
         isOpen={this.props.isOpen}
+        onClose={this.handleClose}
       >
-        {this.renderActiveStep()}
+        {this.showTableSearch() && (
+          <ListSearchField
+            hasClearButton
+            className="bg-white m1"
+            onChange={this.handleSearchTextChange}
+            value={searchText}
+            placeholder={t`Search for a table...`}
+            autoFocus
+          />
+        )}
+        {isSearchActive && (
+          <SearchResults
+            searchQuery={searchText}
+            databaseId={searchDatabaseId}
+            onSelect={this.handleSearchItemSelect}
+          />
+        )}
+        {!isSearchActive && this.renderActiveStep()}
       </PopoverWithTrigger>
     );
   }
@@ -724,6 +789,7 @@ const SchemaPicker = ({
   selectedSchemaId,
   onChangeSchema,
   hasNextStep,
+  hasFiltering,
 }) => {
   const sections = [
     {
@@ -740,7 +806,7 @@ const SchemaPicker = ({
         key="schemaPicker"
         className="text-brand"
         sections={sections}
-        searchable
+        searchable={hasFiltering}
         onChange={item => onChangeSchema(item.schema)}
         itemIsSelected={item => item && item.schema.id === selectedSchemaId}
         renderItemIcon={() => <Icon name="folder" size={16} />}
@@ -836,6 +902,7 @@ const TablePicker = ({
   hasNextStep,
   onBack,
   isLoading,
+  hasFiltering,
 }) => {
   // In case DataSelector props get reseted
   if (!selectedDatabase) {
@@ -886,7 +953,7 @@ const TablePicker = ({
           sections={sections}
           maxHeight={Infinity}
           width={"100%"}
-          searchable
+          searchable={hasFiltering}
           onChange={item => onChangeTable(item.table)}
           itemIsSelected={item =>
             item.table && selectedTable
@@ -943,6 +1010,7 @@ class FieldPicker extends Component {
       selectedField,
       onChangeField,
       onBack,
+      hasFiltering,
     } = this.props;
 
     const header = (
@@ -982,7 +1050,7 @@ class FieldPicker extends Component {
           sections={sections}
           maxHeight={Infinity}
           width={"100%"}
-          searchable
+          searchable={hasFiltering}
           onChange={item => onChangeField(item.field)}
           itemIsSelected={item =>
             item.field && selectedField

--- a/frontend/src/metabase/query_builder/components/data-search/ItemLocation.jsx
+++ b/frontend/src/metabase/query_builder/components/data-search/ItemLocation.jsx
@@ -46,7 +46,7 @@ const TableLocation = ({ item }) => (
     {jt`Table in ${(
       <React.Fragment>
         <LocationLink to={Urls.browseDatabase({ id: item.database_id })}>
-          <Database.Name id={item.database_id} />{" "}
+          <Database.Name id={item.database_id} />
         </LocationLink>
         {item.table_schema && (
           <Schema.ListLoader

--- a/frontend/src/metabase/query_builder/components/data-search/ItemLocation.jsx
+++ b/frontend/src/metabase/query_builder/components/data-search/ItemLocation.jsx
@@ -1,0 +1,94 @@
+import React from "react";
+import PropTypes from "prop-types";
+import styled from "styled-components";
+import { jt } from "ttag";
+
+import * as Urls from "metabase/lib/urls";
+import Icon from "metabase/components/Icon";
+import Link from "metabase/components/Link";
+
+import Schema from "metabase/entities/schemas";
+import Database from "metabase/entities/databases";
+
+import { color } from "metabase/lib/colors";
+
+export const ItemLocation = ({ item }) => {
+  switch (item.model) {
+    case "card":
+      return <QuestionLocation item={item} />;
+    case "table":
+      return <TableLocation item={item} />;
+    default:
+      return null;
+  }
+};
+
+ItemLocation.propTypes = {
+  item: PropTypes.object.isRequired,
+};
+
+const QuestionLocation = ({ item }) => {
+  const collection = item.getCollection();
+
+  return jt`Saved question in ${(
+    <LocationLink to={Urls.collection(collection.id)}>
+      {collection.name}
+    </LocationLink>
+  )}`;
+};
+
+QuestionLocation.propTypes = {
+  item: PropTypes.object.isRequired,
+};
+
+const TableLocation = ({ item }) => (
+  <span>
+    {jt`Table in ${(
+      <React.Fragment>
+        <LocationLink to={Urls.browseDatabase({ id: item.database_id })}>
+          <Database.Name id={item.database_id} />{" "}
+        </LocationLink>
+        {item.table_schema && (
+          <Schema.ListLoader
+            query={{ dbId: item.database_id }}
+            loadingAndErrorWrapper={false}
+          >
+            {({ list }) =>
+              list && list.length > 1 ? (
+                <React.Fragment>
+                  <Icon
+                    className="text-light"
+                    name="chevronright"
+                    mx="4px"
+                    size={10}
+                  />
+                  <LocationLink
+                    to={Urls.browseSchema({
+                      db: { id: item.database_id },
+                      schema_name: item.table_schema,
+                    })}
+                  >
+                    {item.table_schema}
+                  </LocationLink>
+                </React.Fragment>
+              ) : null
+            }
+          </Schema.ListLoader>
+        )}
+      </React.Fragment>
+    )}`}
+  </span>
+);
+
+TableLocation.propTypes = {
+  item: PropTypes.object.isRequired,
+};
+
+const LocationLink = styled(Link)`
+  text-decoration: underline;
+  text-decoration-style: dashed;
+  text-underline-position: under;
+  &:hover {
+    color: ${color("brand")};
+  }
+`;

--- a/frontend/src/metabase/query_builder/components/data-search/SearchResultItem.jsx
+++ b/frontend/src/metabase/query_builder/components/data-search/SearchResultItem.jsx
@@ -1,0 +1,110 @@
+import styled from "styled-components";
+import React from "react";
+import PropTypes from "prop-types";
+
+import Icon from "metabase/components/Icon";
+import Text from "metabase/components/type/Text";
+
+import Schema from "metabase/entities/schemas";
+import Database from "metabase/entities/databases";
+
+import { color, lighten } from "metabase/lib/colors";
+
+export function SearchResultItem({ item, onSelect }) {
+  const handleClick = () => onSelect(item);
+
+  return (
+    <SearchResultItemRoot onClick={handleClick}>
+      <IconWrapper>
+        <Icon name="table" size={26} />
+      </IconWrapper>
+      <Details>
+        <Title>{item.name}</Title>
+        <Text fontSize={13} mb={0} mt={0}>
+          <ItemLocation item={item} />
+        </Text>
+      </Details>
+    </SearchResultItemRoot>
+  );
+}
+
+SearchResultItem.propTypes = {
+  item: PropTypes.object.isRequired,
+  onSelect: PropTypes.func.isRequired,
+};
+
+const Title = styled.div`
+  font-weight: 700;
+  font-size: 14px;
+  line-height: 17px;
+`;
+
+const ItemLocation = ({ item }) => {
+  switch (item.model) {
+    case "card":
+      return item.getCollection().name;
+    case "table":
+      return (
+        <React.Fragment>
+          <Database.Name id={item.database_id} />{" "}
+          {item.table_schema && (
+            <Schema.ListLoader
+              query={{ dbId: item.database_id }}
+              loadingAndErrorWrapper={false}
+            >
+              {({ list }) =>
+                list && list.length > 1 ? (
+                  <React.Fragment>
+                    <Icon
+                      className="text-light"
+                      name="chevronright"
+                      mx="4px"
+                      size={10}
+                    />
+                    {item.table_schema}
+                  </React.Fragment>
+                ) : null
+              }
+            </Schema.ListLoader>
+          )}
+        </React.Fragment>
+      );
+    default:
+      return null;
+  }
+};
+
+ItemLocation.propTypes = {
+  item: PropTypes.object.isRequired,
+};
+
+const IconWrapper = styled.div`
+  margin-right: 10px;
+  margin-left: 10px;
+  color: ${color("text-light")};
+`;
+
+const Details = styled.div`
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+`;
+
+const SearchResultItemRoot = styled.div`
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  min-height: 56px;
+  padding: 10px;
+  color: ${color("text-dark")};
+  width: 100%;
+
+  &:hover {
+    color: ${color("brand")};
+    background-color: ${lighten("brand", 0.63)};
+
+    ${IconWrapper} {
+      color: ${color("brand")};
+    }
+  }
+`;

--- a/frontend/src/metabase/query_builder/components/data-search/SearchResultItem.jsx
+++ b/frontend/src/metabase/query_builder/components/data-search/SearchResultItem.jsx
@@ -5,10 +5,9 @@ import PropTypes from "prop-types";
 import Icon from "metabase/components/Icon";
 import Text from "metabase/components/type/Text";
 
-import Schema from "metabase/entities/schemas";
-import Database from "metabase/entities/databases";
-
 import { color, lighten } from "metabase/lib/colors";
+
+import { ItemLocation } from "./ItemLocation";
 
 export function SearchResultItem({ item, onSelect }) {
   const handleClick = () => onSelect(item);
@@ -16,7 +15,7 @@ export function SearchResultItem({ item, onSelect }) {
   return (
     <SearchResultItemRoot onClick={handleClick}>
       <IconWrapper>
-        <Icon name="table" size={26} />
+        <Icon name="table2" size={22} />
       </IconWrapper>
       <Details>
         <Title>{item.name}</Title>
@@ -39,45 +38,6 @@ const Title = styled.div`
   line-height: 17px;
 `;
 
-const ItemLocation = ({ item }) => {
-  switch (item.model) {
-    case "card":
-      return item.getCollection().name;
-    case "table":
-      return (
-        <React.Fragment>
-          <Database.Name id={item.database_id} />{" "}
-          {item.table_schema && (
-            <Schema.ListLoader
-              query={{ dbId: item.database_id }}
-              loadingAndErrorWrapper={false}
-            >
-              {({ list }) =>
-                list && list.length > 1 ? (
-                  <React.Fragment>
-                    <Icon
-                      className="text-light"
-                      name="chevronright"
-                      mx="4px"
-                      size={10}
-                    />
-                    {item.table_schema}
-                  </React.Fragment>
-                ) : null
-              }
-            </Schema.ListLoader>
-          )}
-        </React.Fragment>
-      );
-    default:
-      return null;
-  }
-};
-
-ItemLocation.propTypes = {
-  item: PropTypes.object.isRequired,
-};
-
 const IconWrapper = styled.div`
   margin-right: 10px;
   margin-left: 10px;
@@ -90,7 +50,7 @@ const Details = styled.div`
   overflow: hidden;
 `;
 
-const SearchResultItemRoot = styled.div`
+const SearchResultItemRoot = styled.li`
   cursor: pointer;
   display: flex;
   align-items: center;

--- a/frontend/src/metabase/query_builder/components/data-search/SearchResults.jsx
+++ b/frontend/src/metabase/query_builder/components/data-search/SearchResults.jsx
@@ -9,14 +9,10 @@ import Search from "metabase/entities/search";
 
 import { SearchResultItem } from "./SearchResultItem";
 
-const MAX_SEARCH_RESULTS = 200;
-
 export function SearchResults({ searchQuery, onSelect, databaseId }) {
   const query = {
     q: searchQuery,
     models: ["table", "card"],
-    limit: MAX_SEARCH_RESULTS,
-    offset: 0,
   };
 
   if (databaseId) {
@@ -39,11 +35,15 @@ export function SearchResults({ searchQuery, onSelect, databaseId }) {
           }
 
           return (
-            <ol>
+            <ul>
               {list.map(item => (
-                <SearchResultItem item={item} onSelect={onSelect} />
+                <SearchResultItem
+                  key={`${item.id}_${item.model}`}
+                  item={item}
+                  onSelect={onSelect}
+                />
               ))}
-            </ol>
+            </ul>
           );
         }}
       </Search.ListLoader>

--- a/frontend/src/metabase/query_builder/components/data-search/SearchResults.jsx
+++ b/frontend/src/metabase/query_builder/components/data-search/SearchResults.jsx
@@ -1,0 +1,63 @@
+import React from "react";
+import styled from "styled-components";
+import PropTypes from "prop-types";
+import { t } from "ttag";
+
+import Icon from "metabase/components/Icon";
+
+import Search from "metabase/entities/search";
+
+import { SearchResultItem } from "./SearchResultItem";
+
+const MAX_SEARCH_RESULTS = 200;
+
+export function SearchResults({ searchQuery, onSelect, databaseId }) {
+  const query = {
+    q: searchQuery,
+    models: ["table", "card"],
+    limit: MAX_SEARCH_RESULTS,
+    offset: 0,
+  };
+
+  if (databaseId) {
+    query["table_db_id"] = databaseId;
+  }
+
+  return (
+    <SearchResultsRoot>
+      <Search.ListLoader query={query} wrapped reload debounced>
+        {({ list }) => {
+          if (list.length === 0) {
+            return (
+              <div className="flex flex-column align-center justify-center p4 text-medium text-centered">
+                <div className="my4">
+                  <Icon name="search" mb={1} size={32} />
+                  <h3 className="text-light">{t`No results found`}</h3>
+                </div>
+              </div>
+            );
+          }
+
+          return (
+            <ol>
+              {list.map(item => (
+                <SearchResultItem item={item} onSelect={onSelect} />
+              ))}
+            </ol>
+          );
+        }}
+      </Search.ListLoader>
+    </SearchResultsRoot>
+  );
+}
+
+SearchResults.propTypes = {
+  databaseId: PropTypes.string,
+  searchQuery: PropTypes.string.required,
+  onSelect: PropTypes.func.required,
+};
+
+const SearchResultsRoot = styled.div`
+  width: 300px;
+  overflow-y: auto;
+`;

--- a/frontend/src/metabase/query_builder/components/data-search/index.js
+++ b/frontend/src/metabase/query_builder/components/data-search/index.js
@@ -1,2 +1,2 @@
 export * from "./SearchResults";
-export * from "./utils"
+export * from "./utils";

--- a/frontend/src/metabase/query_builder/components/data-search/index.js
+++ b/frontend/src/metabase/query_builder/components/data-search/index.js
@@ -1,0 +1,2 @@
+export * from "./SearchResults";
+export * from "./utils"

--- a/frontend/src/metabase/query_builder/components/data-search/utils.js
+++ b/frontend/src/metabase/query_builder/components/data-search/utils.js
@@ -1,0 +1,12 @@
+export function convertSearchResultToTableLikeItem(searchResultItem) {
+  // NOTE: in the entire application when we want to use saved questions as tables
+  // we have to convert IDs by adding "card__" prefix to a question id
+  if (searchResultItem.model === "card") {
+    return {
+      ...searchResultItem,
+      id: `card__${searchResultItem.id}`,
+    };
+  }
+
+  return searchResultItem;
+}

--- a/frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx
@@ -112,8 +112,9 @@ export default class SelectPicker extends Component {
         {validOptions.length <= 10 && !regex ? null : (
           <div className="px1 pt1">
             <ListSearchField
+              hasClearButton
               onChange={this.updateSearchText}
-              searchText={this.state.searchText}
+              value={this.state.searchText}
               placeholder={t`Find a value`}
               autoFocus={true}
             />

--- a/frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx
@@ -13,6 +13,7 @@ function DataStep({ color, query, databases, updateQuery }) {
   return (
     <NotebookCell color={color}>
       <DatabaseSchemaAndTableDataSelector
+        hasTableSearch
         databaseQuery={{ saved: true }}
         selectedDatabaseId={query.databaseId()}
         selectedTableId={query.tableId()}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -123,6 +123,8 @@ class JoinClause extends React.Component {
         </PopoverWithTrigger>
 
         <DatabaseSchemaAndTableDataSelector
+          hasTableSearch
+          canChangeDatabase={false}
           databases={[
             query.database(),
             query.database().savedQuestionsDatabase(),

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSelector.jsx
@@ -6,6 +6,7 @@ import { DatabaseSchemaAndTableDataSelector } from "metabase/query_builder/compo
 export default function QuestionDataSelector({ query, triggerElement }) {
   return (
     <DatabaseSchemaAndTableDataSelector
+      hasTableSearch
       databaseQuery={{ saved: true }}
       selectedDatabaseId={query.databaseId()}
       selectedTableId={query.tableId()}

--- a/frontend/test/metabase/scenarios/question/new.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/new.cy.spec.js
@@ -85,29 +85,60 @@ describe("scenarios > question > new", () => {
     });
   });
 
+  describe("data picker search", () => {
+    beforeEach(() => {
+      cy.visit("/");
+      cy.findByText("Ask a question").click();
+    });
+
+    describe("on a (simple) question page", () => {
+      beforeEach(() => {
+        cy.findByText("Simple question").click();
+        cy.findByPlaceholderText("Search for a table...").type("Ord");
+      });
+
+      it("should allow to search saved questions", () => {
+        cy.findByText("Orders, Count").click();
+        cy.findByText("18,760");
+      });
+
+      it("should allow to search and select tables", () => {
+        cy.findAllByText("Orders")
+          .closest("li")
+          .findByText("Table in")
+          .click();
+        cy.url().should("include", "question#");
+        cy.findByText("Sample Dataset");
+        cy.findByText("Orders");
+      });
+    });
+
+    describe("on a (custom) question page", () => {
+      beforeEach(() => {
+        cy.findByText("Custom question").click();
+        cy.findByPlaceholderText("Search for a table...").type("Ord");
+      });
+
+      it("should allow to search saved questions", () => {
+        cy.findByText("Orders, Count").click();
+        cy.findByText("Visualize").click();
+        cy.findByText("18,760");
+      });
+
+      it("should allow to search and select tables", () => {
+        cy.findAllByText("Orders")
+          .closest("li")
+          .findByText("Table in")
+          .click();
+        cy.findByText("Visualize").click();
+        cy.url().should("include", "question#");
+        cy.findByText("Sample Dataset");
+        cy.findByText("Orders");
+      });
+    });
+  });
+
   describe("ask a (simple) question", () => {
-    it("should allow to search and select saved questions", () => {
-      cy.visit("/");
-      cy.contains("Ask a question").click();
-      cy.contains("Simple question").click();
-      cy.findByPlaceholderText("Search for a table...").type("Ord");
-      cy.contains("Orders, Count").click();
-      cy.contains("18,760");
-    });
-
-    it("should allow to search and select tables", () => {
-      cy.visit("/");
-      cy.contains("Ask a question").click();
-      cy.contains("Simple question").click();
-      cy.findByPlaceholderText("Search for a table...").type("Ord");
-      cy.contains("Orders")
-        .eq(0)
-        .click();
-      cy.url().should("include", "question#");
-      cy.contains("Sample Dataset");
-      cy.contains("Orders");
-    });
-
     it("should load orders table", () => {
       cy.visit("/");
       cy.contains("Ask a question").click();
@@ -270,30 +301,6 @@ describe("scenarios > question > new", () => {
   });
 
   describe("ask a (custom) question", () => {
-    it("should allow to search and select saved questions", () => {
-      cy.visit("/");
-      cy.contains("Ask a question").click();
-      cy.contains("Custom question").click();
-      cy.findByPlaceholderText("Search for a table...").type("Ord");
-      cy.contains("Orders, Count").click();
-      cy.contains("Visualize").click();
-      cy.contains("18,760");
-    });
-
-    it("should allow to search and select tables", () => {
-      cy.visit("/");
-      cy.contains("Ask a question").click();
-      cy.contains("Custom question").click();
-      cy.findByPlaceholderText("Search for a table...").type("Ord");
-      cy.contains("Orders")
-        .eq(0)
-        .click();
-      cy.contains("Visualize").click();
-      cy.url().should("include", "question#");
-      cy.contains("Sample Dataset");
-      cy.contains("Orders");
-    });
-
     it("should load orders table", () => {
       cy.visit("/");
       cy.contains("Ask a question").click();

--- a/frontend/test/metabase/scenarios/question/new.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/new.cy.spec.js
@@ -86,6 +86,28 @@ describe("scenarios > question > new", () => {
   });
 
   describe("ask a (simple) question", () => {
+    it("should allow to search and select saved questions", () => {
+      cy.visit("/");
+      cy.contains("Ask a question").click();
+      cy.contains("Simple question").click();
+      cy.findByPlaceholderText("Search for a table...").type("Ord");
+      cy.contains("Orders, Count").click();
+      cy.contains("18,760");
+    });
+
+    it("should allow to search and select tables", () => {
+      cy.visit("/");
+      cy.contains("Ask a question").click();
+      cy.contains("Simple question").click();
+      cy.findByPlaceholderText("Search for a table...").type("Ord");
+      cy.contains("Orders")
+        .eq(0)
+        .click();
+      cy.url().should("include", "question#");
+      cy.contains("Sample Dataset");
+      cy.contains("Orders");
+    });
+
     it("should load orders table", () => {
       cy.visit("/");
       cy.contains("Ask a question").click();
@@ -248,6 +270,30 @@ describe("scenarios > question > new", () => {
   });
 
   describe("ask a (custom) question", () => {
+    it("should allow to search and select saved questions", () => {
+      cy.visit("/");
+      cy.contains("Ask a question").click();
+      cy.contains("Custom question").click();
+      cy.findByPlaceholderText("Search for a table...").type("Ord");
+      cy.contains("Orders, Count").click();
+      cy.contains("Visualize").click();
+      cy.contains("18,760");
+    });
+
+    it("should allow to search and select tables", () => {
+      cy.visit("/");
+      cy.contains("Ask a question").click();
+      cy.contains("Custom question").click();
+      cy.findByPlaceholderText("Search for a table...").type("Ord");
+      cy.contains("Orders")
+        .eq(0)
+        .click();
+      cy.contains("Visualize").click();
+      cy.url().should("include", "question#");
+      cy.contains("Sample Dataset");
+      cy.contains("Orders");
+    });
+
     it("should load orders table", () => {
       cy.visit("/");
       cy.contains("Ask a question").click();


### PR DESCRIPTION
### Description

Added search input to the data picker on Simple Question and CustomQuestion pages. It searches for tables and saved questions.

On the CustomQuestion page, when selecting a joined data source, it searches for tables/questions only within an already selected database.

<img width="383" alt="Screen Shot 2021-05-04 at 03 34 20" src="https://user-images.githubusercontent.com/14301985/116948984-a1cd1080-ac89-11eb-9aca-8f1f4f4d3fd7.png">

Closes https://github.com/metabase/metabase/issues/15766
