### PR TITLE
#15725 Repro: Summarize on saved question drops user defined metric 

### DIFF
--- a/frontend/test/metabase/scenarios/question/nested.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nested.cy.spec.js
@@ -527,6 +527,41 @@ describe("scenarios > question > nested", () => {
       cy.get(".ScalarValue").findByText(value);
     }
   });
+
+  it.skip("should not remove user defined metric when summarizing based on saved question (metabase#15725)", () => {
+    cy.createNativeQuestion({
+      name: "15725",
+      native: { query: "select 'A' as cat, 5 as val" },
+    });
+    // Window object gets recreated for every `cy.visit`
+    // See: https://stackoverflow.com/a/65218352/8815185
+    cy.visit("/question/new", {
+      onBeforeLoad(win) {
+        cy.spy(win.console, "warn").as("consoleWarn");
+      },
+    });
+    cy.findByText("Custom question").click();
+    cy.findByText("Saved Questions").click();
+    cy.findByText("15725").click();
+    // Summarize (Count of rows AND Sum of Val by Cat)
+    cy.findByText("Pick the metric you want to see").click();
+    cy.findByText("Count of rows").click();
+    cy.icon("add")
+      .last()
+      .click();
+    cy.findByText(/^Sum of/).click();
+    cy.findByText("VAL").click();
+    cy.findByText("Sum of VAL");
+    cy.findByText("Pick a column to group by").click();
+    cy.findByText("CAT").click();
+
+    cy.findByText("Visualize").click();
+    cy.get("@consoleWarn").should(
+      "not.be.calledWith",
+      "Removing invalid MBQL clause",
+    );
+    cy.findByText("Sum of VAL");
+  });
 });
 
 function ordersJoinProducts(name) {


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #15725

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/question/nested.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/115719605-8a824f00-a37c-11eb-86ff-c4e6c31f5747.png)

Sanity check - even if we remove the `console.warn` check, this test still fails because UI dropped `Sum of VAL`
![image](https://user-images.githubusercontent.com/31325167/115719817-c0273800-a37c-11eb-8994-8e8c01a02f84.png)

