### PR TITLE
#15744 Repro: Dashboard subscriptions don't include text cards

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard/subscriptions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/subscriptions.cy.spec.js
@@ -197,6 +197,28 @@ describe("scenarios > dashboard > subscriptions", () => {
         );
       });
     });
+
+    it.skip("should include text cards (metabase#15744)", () => {
+      const TEXT_CARD = "FooBar";
+
+      cy.visit("/dashboard/1");
+      cy.icon("pencil").click();
+      cy.icon("string").click();
+      cy.findByPlaceholderText(
+        "Write here, and use Markdown if you'd like",
+      ).type(TEXT_CARD);
+      cy.findByRole("button", { name: "Save" }).click();
+      cy.findByText("You're editing this dashboard.").should("not.exist");
+      assignRecipient();
+      // Click outside popover to close it and at the same time check that the text card content is shown as expected
+      cy.findByText(TEXT_CARD).click();
+      cy.findByText("Send email now").click();
+      cy.findByText(/^Sending/);
+      cy.findByText("Email sent");
+      cy.request("GET", "http://localhost:80/email").then(({ body }) => {
+        expect(body[0].html).to.include(TEXT_CARD);
+      });
+    });
   });
 
   describe("with Slack set up", () => {


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #15744

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/dashboard/subscriptions.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/115739643-63347d80-a38e-11eb-8eda-b876addf1336.png)

