### PR TITLE
#15737 Repro: X-Rays auto generated titles contain "null"

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard/x-rays.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/x-rays.cy.spec.js
@@ -1,7 +1,14 @@
-import { restore } from "__support__/cypress";
+import { restore, visitQuestionAdhoc } from "__support__/cypress";
 import { SAMPLE_DATASET } from "__support__/cypress_sample_dataset";
 
-const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATASET;
+const {
+  ORDERS,
+  ORDERS_ID,
+  PRODUCTS,
+  PRODUCTS_ID,
+  PEOPLE,
+  PEOPLE_ID,
+} = SAMPLE_DATASET;
 
 describe("scenarios > x-rays", () => {
   beforeEach(() => {
@@ -102,6 +109,30 @@ describe("scenarios > x-rays", () => {
       });
       cy.findByText("A look at the number of People");
       cy.get(".DashCard");
+    });
+
+    it.skip(`"${action.toUpperCase()}" should not show NULL in titles of generated dashboard cards (metabase#15737)`, () => {
+      cy.intercept("GET", "/api/automagic-dashboards/**").as("xray");
+      visitQuestionAdhoc({
+        name: "15737",
+        dataset_query: {
+          database: 1,
+          query: {
+            "source-table": PEOPLE_ID,
+            aggregation: [["count"]],
+            breakout: [["field", PEOPLE.SOURCE, null]],
+          },
+          type: "query",
+        },
+        display: "bar",
+      });
+
+      cy.get(".bar")
+        .first()
+        .click();
+      cy.findByText(action).click();
+      cy.wait("@xray");
+      cy.contains("null").should("not.exist");
     });
   });
 });


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #15737 

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/dashboard/x-rays.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
"X-rays"
![image](https://user-images.githubusercontent.com/31325167/115742973-7bf26280-a391-11eb-873a-0d2ad982235d.png)

"Compare to the rest"
![image](https://user-images.githubusercontent.com/31325167/115743029-8e6c9c00-a391-11eb-9715-833f6eceae45.png)

