### PR TITLE
#15741 Repro: Custom expressions don't recognize floating point numbers with 0 omitted

### DIFF
--- a/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
@@ -481,4 +481,13 @@ describe("scenarios > question > custom columns", () => {
     });
     cy.get("[contenteditable='true']").contains("Sum([MyCC [2021]])");
   });
+
+  it.skip("should handle floating point numbers with '0' omitted (metabase#15741)", () => {
+    openOrdersTable({ mode: "notebook" });
+    cy.findByText("Custom column").click();
+    cy.get("[contenteditable='true']").type(".5 * [Discount]");
+    cy.findByPlaceholderText("Something nice and descriptive").type("Foo");
+    cy.findByText("Unknown Field: .5").should("not.exist");
+    cy.findByRole("button", { name: "Done" }).should("not.be.disabled");
+  });
 });


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #15741

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/question/custom_column.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/115745954-35eace00-a394-11eb-9435-ab9e039144f8.png)

