### PR TITLE
Fix alignment of company logo when whitelabelling is turned on

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LogoIcon.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LogoIcon.jsx
@@ -122,7 +122,7 @@ export default class LogoIcon extends Component {
       <span
         ref={c => (this._container = c)}
         className={cx(
-          "Icon",
+          "Icon text-centered",
           { "text-brand": !dark },
           { "text-white": dark },
           className,


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Centers the company (custom) logo on EE instances when whitelabel feature is turned on
- Fixes #15713

As explained in [this comment](https://github.com/metabase/metabase/issues/15713#issuecomment-824182706) in the original issue, we're using 2 different `Logo` components depending on the Metabase version.
In EE version, `enterprise/frontend/src/metabase-enterprise/whitelabel/components/LogoIcon.jsx` has a `<span>` wrapper around the logo.
The Logo is centered _implicitly_, because it inherits the alignment from one of the parent components. Because svg is inline element, that works. But when there is a wrapper/container around it, that breaks the "inheritance".

```
- parent (flex, flex-dir-column, align-items-center)
    - svg (centered)
```
vs
```
- parent (flex, flex-dir-column, align-items-center)
    - span
        - svg (alignment outside of span doesn't apply here)
```

Solution
```
- parent (flex, flex-dir-column, align-items-center)
    - span (add `text-centered` class that will apply to the children)
        - svg (alignment outside of span doesn't apply here)
```

### How to verify this works?
- Before we implement visual regression testing, this needs to be manually verified
- Spin up EE instance, make sure it's activated with "whitelabeling" turned on
- Log out
- You should see logo centered above the login form

![image](https://user-images.githubusercontent.com/31325167/115765015-84a16380-a3a6-11eb-826d-3e9ca2326774.png)

