### PR TITLE
#15748 Repro: Custom Expression filter is showing a reference to the field id

### DIFF
--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -908,4 +908,13 @@ describe("scenarios > question > filter", () => {
     cy.findByText("Doohickey");
     cy.findByText("Gizmo").should("not.exist");
   });
+
+  it.skip("custom expression filter should reference fields by their name, not by their id (metabase#15748)", () => {
+    openOrdersTable({ mode: "notebook" });
+    cy.findByText("Filter").click();
+    cy.findByText("Custom Expression").click();
+    cy.get("[contenteditable=true]").type("[Total] < [Subtotal]");
+    cy.findByRole("button", { name: "Done" }).click();
+    cy.findByText("Total is less than Subtotal");
+  });
 });


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #15748

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/question/filter.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/115769256-a18c6580-a3ab-11eb-81bd-00bac62ab3f6.png)

