### PR TITLE
Custom expression: friendlier message on mismatched parentheses

### DIFF
--- a/frontend/src/metabase/lib/expressions/tokenizer.js
+++ b/frontend/src/metabase/lib/expressions/tokenizer.js
@@ -326,3 +326,13 @@ export function tokenize(expression) {
 
   return main();
 }
+
+// e.g. "COUNTIF(([Total]-[Tax] <5" returns 2 (missing parentheses)
+export function countMatchingParentheses(expression) {
+  const { tokens } = tokenize(expression);
+  const isOpen = t => t.op === OPERATOR.OpenParenthesis;
+  const isClose = t => t.op === OPERATOR.CloseParenthesis;
+  const count = (c, token) =>
+    isOpen(token) ? c + 1 : isClose(token) ? c - 1 : c;
+  return tokens.reduce(count, 0);
+}

--- a/frontend/test/metabase/lib/expressions/tokenizer.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/tokenizer.unit.spec.js
@@ -2,6 +2,7 @@ import {
   tokenize,
   TOKEN as T,
   OPERATOR as OP,
+  countMatchingParentheses,
 } from "metabase/lib/expressions/tokenizer";
 
 describe("metabase/lib/expressions/tokenizer", () => {
@@ -131,5 +132,14 @@ describe("metabase/lib/expressions/tokenizer", () => {
     expect(errors("!")[0].message).toEqual("Invalid character: !");
     expect(errors(" % @")[1].message).toEqual("Invalid character: @");
     expect(errors("    #")[0].pos).toEqual(4);
+  });
+
+  it("should count matching parentheses", () => {
+    expect(countMatchingParentheses("()")).toEqual(0);
+    expect(countMatchingParentheses("(")).toEqual(1);
+    expect(countMatchingParentheses(")")).toEqual(-1);
+    expect(countMatchingParentheses("(A+(")).toEqual(2);
+    expect(countMatchingParentheses("SUMIF(")).toEqual(1);
+    expect(countMatchingParentheses("COUNTIF(Deal))")).toEqual(-1);
   });
 });

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -835,6 +835,20 @@ describe("scenarios > question > notebook", () => {
       });
     });
   });
+
+  describe("error feedback", () => {
+    it("should catch mismatched parentheses", () => {
+      openProductsTable({ mode: "notebook" });
+      cy.findByText("Custom column").click();
+      popover().within(() => {
+        cy.get("[contenteditable='true']").type("FLOOR [Price]/2)");
+        cy.findByPlaceholderText("Something nice and descriptive")
+          .click()
+          .type("Massive Discount");
+        cy.contains(/^Expecting an opening parenthesis/i);
+      });
+    });
+  });
 });
 
 // Extracted repro steps for #13000


### PR DESCRIPTION
Steps to reproduce:
1. Ask a question, Custom question
2. Sample Dataset, Product table
3. Filter, Custom Expression, and type `floor [Price] / 2)` (the mistake: forgotten open parenthesis)

**Before this PR**

![image](https://user-images.githubusercontent.com/7288/115781981-f4e0c280-a36f-11eb-85c6-e49df6b55413.png)

**After this PR**

![image](https://user-images.githubusercontent.com/7288/115782362-73d5fb00-a370-11eb-86f3-65d5ebbc4e95.png)


For the unit tests:
```
yarn test-unit frontend/test/metabase/lib/expressions/tokenizer.unit.spec.js
```

and for E2E tests:
```
yarn test-cypress-open --spec frontend/test/metabase/scenarios/question/notebook.cy.spec.js
```

