### PR TITLE
add timeline component

### DIFF
--- a/frontend/src/metabase/components/Timeline.info.js
+++ b/frontend/src/metabase/components/Timeline.info.js
@@ -1,0 +1,80 @@
+import React from "react";
+import moment from "moment";
+import styled from "styled-components";
+
+import Timeline from "metabase/components/Timeline";
+import { color } from "metabase/lib/colors";
+
+export const component = Timeline;
+export const category = "display";
+
+export const description = `
+A component for showing events in descending order.
+`;
+
+const Container = styled.div`
+  line-height: 1.5;
+  width: 350px;
+  border: 1px dashed ${color("bg-dark")};
+  border-radius: 0.5rem;
+  padding: 1rem;
+`;
+
+const items = [
+  {
+    icon: "verified",
+    title: "John Someone verified this",
+    description: "idk lol",
+    timestamp: moment()
+      .subtract(1, "day")
+      .valueOf(),
+    numComments: 5,
+  },
+  {
+    icon: "pencil",
+    title: "Foo edited this",
+    description: "Did a thing.",
+    timestamp: moment()
+      .subtract(1, "week")
+      .valueOf(),
+  },
+  {
+    icon: "warning_colorized",
+    title: "Someone McSomeone thinks something looks wrong",
+    description:
+      "Uh oh that's not correct. Uh oh that's not correct. Uh oh that's not correct. Uh oh that's not correct. Uh oh that's not correct. Uh oh that's not correct. Uh oh that's not correct. Uh oh that's not correct. Uh oh that's not correct. \nUh oh that's not correct. \nUh oh that's not correct. \nUh oh that's not correct. \nUh oh that's not correct. \nUh oh that's not correct. \nUh oh that's not correct. \nUh oh that's not correct. \nUh oh that's not correct. \nUh oh that's not correct. Uh oh that's not correct. Uh oh that's not correct. Uh oh that's not correct. Uh oh that's not",
+    timestamp: moment()
+      .subtract(2, "month")
+      .valueOf(),
+  },
+  {
+    icon: "clarification",
+    title: "Someone is confused",
+    description:
+      "Something something something something something something something something something something something something?",
+    timestamp: moment()
+      .subtract(1, "year")
+      .valueOf(),
+    numComments: 123,
+  },
+];
+
+function renderFooter(item) {
+  return item.numComments ? (
+    <a
+      href="/_internal/components/timeline"
+      className="text-underline"
+    >{`${item.numComments} comments`}</a>
+  ) : (
+    ""
+  );
+}
+
+export const examples = {
+  "Constrained width": (
+    <Container>
+      <Timeline items={items} />
+    </Container>
+  ),
+  "Optional footer": <Timeline items={items} renderFooter={renderFooter} />,
+};

--- a/frontend/src/metabase/components/Timeline.jsx
+++ b/frontend/src/metabase/components/Timeline.jsx
@@ -1,6 +1,5 @@
 import React, { useMemo } from "react";
 import PropTypes from "prop-types";
-import cx from "classnames";
 import _ from "underscore";
 import styled from "styled-components";
 import moment from "moment";
@@ -49,7 +48,7 @@ const Timeline = ({ className, items = [], renderFooter }) => {
     <TimelineContainer
       leftShift={halfIconSize}
       bottomShift={halfIconSize}
-      className={cx(className, "timeline")}
+      className={className}
     >
       <Border borderShift={halfIconSize} />
       {sortedFormattedItems.map((item, index) => {
@@ -60,24 +59,14 @@ const Timeline = ({ className, items = [], renderFooter }) => {
           <TimelineItem
             key={key}
             leftShift={halfIconSize}
-            className="timeline--item flex align-start justify-start mb2"
+            className="flex align-start justify-start mb2"
           >
-            <Icon
-              className="timeline--item-icon text-light"
-              name={icon}
-              size={iconSize}
-            />
-            <div className="timeline--item-details ml1">
-              <div className="timeline--item-title text-bold">{title}</div>
-              <div className="timeline--item-timestamp text-medium text-small">
-                {formattedTimestamp}
-              </div>
-              <div className="timeline--item-description">{description}</div>
-              {_.isFunction(renderFooter) && (
-                <div className="timeline--item-footer">
-                  {renderFooter(item)}
-                </div>
-              )}
+            <Icon className="text-light" name={icon} size={iconSize} />
+            <div className="ml1">
+              <div className="text-bold">{title}</div>
+              <div className="text-medium text-small">{formattedTimestamp}</div>
+              <div>{description}</div>
+              {_.isFunction(renderFooter) && <div>{renderFooter(item)}</div>}
             </div>
           </TimelineItem>
         );

--- a/frontend/src/metabase/components/Timeline.jsx
+++ b/frontend/src/metabase/components/Timeline.jsx
@@ -1,0 +1,95 @@
+import React, { useMemo } from "react";
+import PropTypes from "prop-types";
+import cx from "classnames";
+import _ from "underscore";
+import styled from "styled-components";
+import moment from "moment";
+
+import { color } from "metabase/lib/colors";
+
+import Icon from "metabase/components/Icon";
+
+const TimelineContainer = styled.div`
+  position: relative;
+  margin-left: ${props => props.leftShift}px;
+  margin-bottom: ${props => props.bottomShift}px;
+`;
+
+const TimelineItem = styled.div`
+  transform: translateX(-${props => props.leftShift}px);
+  white-space: pre-line;
+`;
+
+// shift the border down slightly so that it doesn't appear above the top-most icon
+const Border = styled.div`
+  position: absolute;
+  top: ${props => props.borderShift}px;
+  left: 0;
+  right: 0;
+  bottom: -${props => props.borderShift}px;
+  border-left: 1px solid ${color("border")};
+`;
+
+const Timeline = ({ className, items = [], renderFooter }) => {
+  const iconSize = 20;
+  const halfIconSize = iconSize / 2;
+
+  const sortedFormattedItems = useMemo(() => {
+    return items
+      .sort((a, b) => b.timestamp - a.timestamp)
+      .map(item => {
+        return {
+          ...item,
+          formattedTimestamp: moment(item.timestamp).fromNow(),
+        };
+      });
+  }, [items]);
+
+  return (
+    <TimelineContainer
+      leftShift={halfIconSize}
+      bottomShift={halfIconSize}
+      className={cx(className, "timeline")}
+    >
+      <Border borderShift={halfIconSize} />
+      {sortedFormattedItems.map((item, index) => {
+        const { icon, title, description, formattedTimestamp } = item;
+        const key = item.key == null ? index : item.key;
+
+        return (
+          <TimelineItem
+            key={key}
+            leftShift={halfIconSize}
+            className="timeline--item flex align-start justify-start mb2"
+          >
+            <Icon
+              className="timeline--item-icon text-light"
+              name={icon}
+              size={iconSize}
+            />
+            <div className="timeline--item-details ml1">
+              <div className="timeline--item-title text-bold">{title}</div>
+              <div className="timeline--item-timestamp text-medium text-small">
+                {formattedTimestamp}
+              </div>
+              <div className="timeline--item-description">{description}</div>
+              {_.isFunction(renderFooter) && (
+                <div className="timeline--item-footer">
+                  {renderFooter(item)}
+                </div>
+              )}
+            </div>
+          </TimelineItem>
+        );
+      })}
+    </TimelineContainer>
+  );
+};
+
+Timeline.propTypes = {
+  className: PropTypes.string,
+  items: PropTypes.array,
+  renderFooter: PropTypes.func,
+};
+
+export default Timeline;


### PR DESCRIPTION
A timeline component for use in the new saved question details left sidebar. Will be used to show revision history + moderation issue history.
<img width="266" alt="Screen Shot 2021-04-22 at 2 59 20 PM" src="https://user-images.githubusercontent.com/13057258/115790628-de406880-a37b-11eb-8c13-99a2119dda8a.png">

To keep the `Timeline` component a bit more unopinionated I've added a `renderFooter` prop so that events can have footers with actions specific to the given event. For example, moderation events may have comments, but revision history events will not.
<img width="182" alt="Screen Shot 2021-04-22 at 2 59 36 PM" src="https://user-images.githubusercontent.com/13057258/115790832-34ada700-a37c-11eb-8cd4-2deaf178065f.png">

To do the border overlapped by icons I've added an absolutely positioned div with `border-left` set that is slightly shifted so that the border doesn't appear above the pencil icon when it is the top-most event in the timeline:
<img width="287" alt="Screen Shot 2021-04-22 at 2 46 48 PM" src="https://user-images.githubusercontent.com/13057258/115790865-48f1a400-a37c-11eb-8c0b-b5f862ed1d47.png">

