### PR TITLE
Fix wrong tooltip on charts with unaggregated data

### DIFF
--- a/frontend/src/metabase/visualizations/lib/apply_tooltips.js
+++ b/frontend/src/metabase/visualizations/lib/apply_tooltips.js
@@ -84,16 +84,23 @@ export function getClickHoverObject(
     const { key } = d.data;
 
     // We look through the rows to match up they key in d.data to the x value
-    // from some row.
-    const row = datas[seriesIndex].find(
+    // from some rows. There might be multiple rows in case of unaggregated data.
+    const rows = datas[seriesIndex].filter(
       ([x]) => key === x || (moment.isMoment(key) && key.isSame(x)),
     );
 
-    // try to get row from _origin but fall back to the row we already have
-    const rawRow = (row && row._origin && row._origin.row) || row;
+    // try to get rows from _origin
+    const rawRows = rows
+      .map(row => {
+        return row._origin && row._origin.row;
+      })
+      .filter(Boolean);
+
+    // aggregate rows to show correct values from unaggregated data
+    const aggregatedRow = aggregateRows(rawRows.length > 0 ? rawRows : rows);
 
     // Loop over *all* of the columns and create the new array
-    if (rawRow) {
+    if (aggregatedRow) {
       data = rawCols.map((col, i) => {
         if (isNormalized && cols[1].field_ref === col.field_ref) {
           return {
@@ -108,11 +115,14 @@ export function getClickHoverObject(
         }
         return {
           key: getColumnDisplayName(col),
-          value: formatNull(rawRow[i]),
+          value: formatNull(aggregatedRow[i]),
           col: col,
         };
       });
-      dimensions = rawCols.map((column, i) => ({ column, value: rawRow[i] }));
+      dimensions = rawCols.map((column, i) => ({
+        column,
+        value: aggregatedRow[i],
+      }));
     }
   } else if (isBreakoutMultiseries) {
     // an area doesn't have any data, but might have a breakout series to show
@@ -187,6 +197,27 @@ function parseBooleanStringValue({ column, value }) {
     }
   }
   return value;
+}
+
+function aggregateRows(rows) {
+  if (!rows.length) {
+    return null;
+  }
+
+  const aggregatedRow = [...rows[0]];
+
+  for (let i = 1; i < rows.length; i++) {
+    // The first element is the X-axis value and should not be aggregated
+    for (let colIndex = 1; colIndex < rows[i].length; colIndex++) {
+      const value = rows[i][colIndex];
+
+      if (typeof value === "number") {
+        aggregatedRow[colIndex] += value;
+      }
+    }
+  }
+
+  return aggregatedRow;
 }
 
 export function setupTooltips(

--- a/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
@@ -261,7 +261,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
     cy.findByText("There was a problem with your question").should("not.exist");
   });
 
-  it.skip("should display correct value in a tooltip for unaggregated data (metabase#11907)", () => {
+  it("should display correct value in a tooltip for unaggregated data (metabase#11907)", () => {
     cy.createNativeQuestion({
       name: "11907",
       native: {


### PR DESCRIPTION
### Description

Fixes showing incorrect values in the tooltip when data is unaggregated.

The [previous attempt](https://github.com/metabase/metabase/pull/15472) to fix caused a regression on dashboard cards when multiple series are added.

Please approve the same fix for the master branch as well: https://github.com/metabase/metabase/pull/15783

### Screenshots

#### Question 1 
<img width="638" alt="Screen Shot 2021-04-23 at 02 12 45" src="https://user-images.githubusercontent.com/14301985/115796004-aff17600-a3d9-11eb-9d67-2fd265b17978.png">

#### Question 2
<img width="645" alt="Screen Shot 2021-04-23 at 02 12 30" src="https://user-images.githubusercontent.com/14301985/115796047-c39cdc80-a3d9-11eb-9e0c-c14fede9b7c8.png">

#### Dashboard
Correct tooltip for Question 1:
<img width="901" alt="Screen Shot 2021-04-23 at 02 13 28" src="https://user-images.githubusercontent.com/14301985/115796074-d0b9cb80-a3d9-11eb-9157-dbed2beb1da6.png">

Correct tooltip for Question 2:
<img width="904" alt="Screen Shot 2021-04-23 at 02 13 19" src="https://user-images.githubusercontent.com/14301985/115796101-e29b6e80-a3d9-11eb-8edb-2993f07ed55e.png">

Fixes https://github.com/metabase/metabase/issues/11907