### PR TITLE
#15785 Repro: Tooltip shows incorrect values on unaggregated data with breakout

### DIFF
--- a/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
@@ -287,6 +287,29 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
     });
   });
 
+  it("should display correct value in a tooltip for unaggregated data with breakouts (metabase#15785)", () => {
+    visitQuestionAdhoc({
+      dataset_query: {
+        type: "native",
+        native: {
+          query:
+            "select 1 as axis, 5 as value, 9 as breakout union all\nselect 2 as axis, 6 as value, 10 as breakout union all\nselect 2 as axis, 6 as value, 10 as breakout",
+        },
+        database: 1,
+      },
+      display: "bar",
+      visualization_settings: {
+        "graph.dimensions": ["AXIS", "BREAKOUT"],
+        "graph.metrics": ["VALUE"],
+      },
+    });
+
+    cy.get(".bar")
+      .last()
+      .trigger("mousemove");
+    popover().findByText("12");
+  });
+
   it.skip("should drill-through a custom question that joins a native SQL question (metabase#14495)", () => {
     // Restrict "normal user" (belongs to the DATA_GROUP) from writing native queries
     cy.log("Fetch permissions graph");


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #15785

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js`
- All tests should pass

### Additional notes:
This issue seems to be fixed. I couldn't reproduce the wrong value from the initial issue.

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/115918344-b59d9900-a477-11eb-8eef-ede01323264c.png)

