### PR TITLE
Handle token-like values in encryption key rotation

### DIFF
--- a/src/metabase/cmd.clj
+++ b/src/metabase/cmd.clj
@@ -57,7 +57,7 @@
       (println "Dump complete")
       (system-exit! 0))
     (catch Throwable e
-      (log/error e "MB_ENCRYPTION_SECRET_KEY does not correcty decrypt the existing data")
+      (log/error e "Failed to dump application database to H2 file")
       (system-exit! 1))))
 
 (defn ^:command profile

--- a/src/metabase/cmd/dump_to_h2.clj
+++ b/src/metabase/cmd/dump_to_h2.clj
@@ -37,7 +37,7 @@
      (when-not keep-existing?
        (copy.h2/delete-existing-h2-database-files! h2-filename))
      (copy/copy!  (mdb.conn/db-type) (mdb.conn/jdbc-spec) :h2 h2-jdbc-spec)
-     (if dump-plaintext?
+     (when dump-plaintext?
        (binding [mdb.conn/*db-type* :h2
                  mdb.conn/*jdbc-spec* h2-jdbc-spec
                  db/*db-connection* h2-jdbc-spec

--- a/src/metabase/cmd/rotate_encryption_key.clj
+++ b/src/metabase/cmd/rotate_encryption_key.clj
@@ -6,6 +6,7 @@
             [metabase.models :refer [Database Setting]]
             [metabase.models.setting.cache :as cache]
             [metabase.util.encryption :as encrypt]
+            [metabase.util.i18n :refer [trs]]
             [toucan.db :as db]))
 
 (defn rotate-encryption-key!
@@ -17,19 +18,17 @@
                               (encrypt/validate-and-hash-secret-key to-key))
                      identity)]
     (jdbc/with-db-transaction [t-conn (mdb.conn/jdbc-spec)]
+      (doseq [[id details] (db/select-id->field :details Database)]
+        (when (encrypt/possibly-encrypted-string? details)
+          (throw (ex-info (trs "Can't decrypt app db with MB_ENCRYPTION_SECRET_KEY") {:database-id id})))
+        (jdbc/update! t-conn
+                      :metabase_database
+                      {:details (encrypt-fn (json/encode details))}
+                      ["metabase_database.id = ?" id]))
       (doseq [[key value] (db/select-field->field :key :value Setting)]
-        (when (encrypt/possibly-encrypted-string? value)
-          (throw (Exception. "MB_ENCRYPTION_SECRET_KEY does not correctly decrypt files")))
         (if (= key "settings-last-updated")
           (cache/update-settings-last-updated!)
           (jdbc/update! t-conn
                         :setting
                         {:value (encrypt-fn value)}
-                        ["setting.key = ?" key])))
-      (doseq [[id details] (db/select-id->field :details Database)]
-        (jdbc/update! t-conn
-                      :metabase_database
-                      {:details (encrypt-fn (json/encode details))}
-                      ["metabase_database.id = ?" id])
-        (when (encrypt/possibly-encrypted-string? details)
-          (throw (Exception. "MB_ENCRYPTION_SECRET_KEY does not correctly decrypt files")))))))
+                        ["setting.key = ?" key]))))))

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -156,7 +156,7 @@
 
 (models/add-type! :encrypted-json
   :in  encrypted-json-in
-  :out #(cached-encrypted-json-out %)) ; needed indirection to allow with-redef in tests
+  :out cached-encrypted-json-out)
 
 (models/add-type! :encrypted-text
   :in  encryption/maybe-encrypt

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -156,7 +156,7 @@
 
 (models/add-type! :encrypted-json
   :in  encrypted-json-in
-  :out cached-encrypted-json-out)
+  :out #(cached-encrypted-json-out %)) ; needed indirection to allow with-redef in tests
 
 (models/add-type! :encrypted-text
   :in  encryption/maybe-encrypt

--- a/test/metabase/cmd/rotate_encryption_key_test.clj
+++ b/test/metabase/cmd/rotate_encryption_key_test.clj
@@ -99,19 +99,9 @@
                 (is (not= {:db "/tmp/k2.db"} (db/select-one-field :details Database :name "k2")))
                 (is (= {:db "/tmp/k3.db"} (db/select-one-field :details Database :name "k3")))))
 
-            (testing "full rollback when a database looks encrypted with a different key than the current one"
-              (let [db-details {:db "/tmp/test.db"}]
-                (eu/with-secret-key k3
-                  (db/update! Database 1 {:details db-details}))
-                (eu/with-secret-key k3
-                  (is (= db-details (db/select-one-field :details Database :id 1))))
-                (eu/with-secret-key k2
-                  (is (nil? (rotate-encryption-key! k3))))
-                (eu/with-secret-key k3
-                  (is (= db-details (db/select-one-field :details Database :id 1))))))
-
             (testing "rotate-encryption-key! to nil decrypts the encrypted keys"
               (db/update! Database 1 {:details "{\"db\":\"/tmp/test.db\"}"})
+              (db/update-where! Database {:name "k3"} :details "{\"db\":\"/tmp/test.db\"}")
               (eu/with-secret-key k2
                 (rotate-encryption-key! nil))
               (is (= "unencrypted value" (raw-value "nocrypt"))))


### PR DESCRIPTION
Failing on setting values for which `possibly-encrypted-string?` returns true will fail for token-like setting values.

Unlike settings values, metabase_database.details values are far more predictable. As such we can more reliably determine whether or not the field was successfully decrypted with the current encryption key, by looking at that field, than settings values.
