### PR TITLE
Fix typo in documentation

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -59,7 +59,7 @@ If you plan to work on the Metabase code and make changes then you'll need to un
 
 ### Overview
 
-The Metabase application has two basic compnents:
+The Metabase application has two basic components:
 
 1. a backend written in Clojure which contains a REST API as well as all the relevant code for talking to databases and processing queries.
 2. a frontend written as a Javascript single-page application which provides the web UI.


### PR DESCRIPTION
Hi all, 

just a typo fix inside a documentation file: `compnents` → `components`

Cheers!