### PR TITLE
Custom expression: allow parenthesized logical operations

### DIFF
--- a/frontend/src/metabase/lib/expressions/parser.js
+++ b/frontend/src/metabase/lib/expressions/parser.js
@@ -83,7 +83,7 @@ export class ExpressionParser extends CstParser {
 
     // an expression without aggregations in it
     $.RULE("expression", () => {
-      $.SUBRULE($.relationalExpression, {
+      $.SUBRULE($.booleanExpression, {
         LABEL: "expression",
         ARGS: ["expression"],
       });

--- a/frontend/test/metabase/lib/expressions/parser.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/parser.unit.spec.js
@@ -145,6 +145,10 @@ describe("metabase/lib/expressions/parser", () => {
     it("should accept a relational between a segment and a dimension", () => {
       expect(() => parseFilter("([Shipping] < 2) AND [Sale]")).not.toThrow();
     });
+    it("should accept parenthesized logical operations", () => {
+      expect(() => parseFilter("([Deal] AND [HighRating])")).not.toThrow();
+      expect(() => parseFilter("([Price] < 100 OR [Refurb])")).not.toThrow();
+    });
     it("should accept a function", () => {
       expect(() => parseFilter("between([Subtotal], 1, 2)")).not.toThrow();
     });

--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -918,7 +918,7 @@ describe("scenarios > question > filter", () => {
     cy.findByText("Total is less than Subtotal");
   });
 
-  it.skip("custom expression filter should allow the use of parentheses in combination with logical operators (metabase#15754)", () => {
+  it("custom expression filter should allow the use of parentheses in combination with logical operators (metabase#15754)", () => {
     openOrdersTable({ mode: "notebook" });
     cy.findByText("Filter").click();
     cy.findByText("Custom Expression").click();


### PR DESCRIPTION
This fixes #15754.

Steps to verify:
1. Ask a question, Custom question
2. Sample Dataset, Orders table
3. Filter, Custom Expression
4. Type `([Discount] > 0 AND [Quantity] > 2)`

**Before this PR**

![image](https://user-images.githubusercontent.com/7288/115967634-925f0200-a4e8-11eb-92a5-d77fe97835d8.png)

**After this PR**

The filter expression is recognized properly:

![image](https://user-images.githubusercontent.com/7288/115967708-e964d700-a4e8-11eb-80ed-db0380d833cf.png)


And to run the tests:
```
yarn test-unit frontend/test/metabase/lib/expressions/parser.unit.spec.js
yarn test-cypress-no-build --spec frontend/test/metabase/scenarios/question/filter.cy.spec.js
```