### PR TITLE
#15808 Repro: Cannot add filter for an integer field in a question based on a saved native question

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/ViewSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewSidebar.jsx
@@ -18,6 +18,7 @@ const ViewSideBar = ({ left, right, width = 355, isOpen, children }) => (
   >
     {motionStyle => (
       <div
+        data-testid={right ? "sidebar-right" : "sidebar-left"}
         className={cx("bg-white relative overflow-x-hidden", {
           "border-right": left,
           "border-left": right,

--- a/frontend/test/metabase/scenarios/question/saved.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/saved.cy.spec.js
@@ -98,4 +98,26 @@ describe("scenarios > question > saved", () => {
       cy.wait("@cardCreate");
     });
   });
+
+  it.skip("should be able to use integer filter on a saved native query (metabase#15808)", () => {
+    cy.createNativeQuestion({
+      name: "15808",
+      native: { query: "select * from products" },
+    });
+    cy.visit("/question/new");
+    cy.findByText("Simple question").click();
+    cy.findByText("Saved Questions").click();
+    cy.findByText("15808").click();
+    cy.findByText("Filter").click();
+    cy.findByTestId("sidebar-right")
+      .findByText(/Rating/i)
+      .click();
+    cy.get(".AdminSelect").findByText("Equal to");
+    cy.findByPlaceholderText("Enter a number").type("4");
+    cy.findByRole("button", { name: "Add filter" })
+      .should("not.be.disabled")
+      .click();
+    cy.findByText("Synergistic Granite Chair");
+    cy.findByText("Rustic Paper Wallet").should("not.exist");
+  });
 });


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #15808
- Adds `data-testid` to the left and right sidebar for new questions in GUI mode

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/question/saved.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/116097538-858a0c00-a6aa-11eb-82e5-8aabbc1d11a4.png)


Sanity check - adding the same filter on a Products table
![image](https://user-images.githubusercontent.com/31325167/116097434-6e4b1e80-a6aa-11eb-8764-d43a3f31d72f.png)

