### PR TITLE
Custom expression: display only one error message

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -242,8 +242,16 @@ export default class ExpressionEditorTextfield extends React.Component {
 
   onInputBlur = () => {
     this.clearSuggestions();
+
     const { tokenizerError, compileError } = this.state;
-    const displayError = [...tokenizerError, ...(compileError || [])];
+    let displayError = [...tokenizerError];
+    if (compileError) {
+      if (Array.isArray(compileError)) {
+        displayError = [...displayError, ...compileError];
+      } else {
+        displayError.push(compileError);
+      }
+    }
     this.setState({ displayError });
 
     // whenever our input blurs we push the updated expression to our parent if valid

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -243,7 +243,7 @@ export default class ExpressionEditorTextfield extends React.Component {
   onInputBlur = () => {
     this.clearSuggestions();
     const { tokenizerError, compileError } = this.state;
-    const displayError = [...tokenizerError, ...compileError || []];
+    const displayError = [...tokenizerError, ...(compileError || [])];
     this.setState({ displayError });
 
     // whenever our input blurs we push the updated expression to our parent if valid

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -886,6 +886,18 @@ describe("scenarios > question > notebook", () => {
         cy.contains(/^Unterminated bracket identifier/i);
       });
     });
+
+    it("should catch non-existent field reference", () => {
+      openProductsTable({ mode: "notebook" });
+      cy.findByText("Custom column").click();
+      popover().within(() => {
+        cy.get("[contenteditable='true']").type("abcdef");
+        cy.findByPlaceholderText("Something nice and descriptive")
+          .click()
+          .type("Non-existent");
+        cy.contains(/^Unknown Field: abcdef/i);
+      });
+    });
   });
 });
 


### PR DESCRIPTION
It's terrifying to see lots of error messages when the expression is invalid or not completed yet. To overcome this, we display only one, the highest-priority and most friendly message. The rank is:

* tokenization error, e.g. mismatched parentheses
* type-checking error, e.g. incorrect count of function arguments
* syntax error (from the parser)

Steps to try:
1. Ask a question, Custom question
2. Sample Dataset, Orders table
3. Summarize, Custom Expression
4. Type `countif` and press Tab

**Before this PR**

![image](https://user-images.githubusercontent.com/7288/116142377-b1979400-a68e-11eb-99fa-a3e36e347cd7.png)

**After this PR**

![image](https://user-images.githubusercontent.com/7288/116142453-c6742780-a68e-11eb-9d7c-53a93731fa14.png)
