### PR TITLE
Parallel building (frontend & backend) + unify running scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,93 +2,79 @@
 # STAGE 1.1: builder frontend
 ###################
 
-FROM node:12.20.1-alpine as frontend
-
-WORKDIR /app/source
-
-ENV FC_LANG en-US LC_CTYPE en_US.UTF-8
-
-# frontend dependencies
-COPY yarn.lock package.json .yarnrc ./
-RUN yarn install --frozen-lockfile
-
-###################
-# STAGE 1.2: builder backend
-###################
-
-FROM adoptopenjdk/openjdk11:alpine as backend
-
-WORKDIR /app/source
-
-ENV FC_LANG en-US LC_CTYPE en_US.UTF-8
-
-# bash:    various shell scripts
-# curl:    needed by script that installs Clojure CLI
-
-RUN apk add --no-cache curl bash
-
-# lein:    backend dependencies and building
-RUN curl https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein -o /usr/local/bin/lein && \
-  chmod +x /usr/local/bin/lein && \
-  /usr/local/bin/lein upgrade
-
-# backend dependencies
-COPY project.clj .
-RUN lein deps
-
-###################
-# STAGE 1.3: main builder
-###################
-
-FROM adoptopenjdk/openjdk11:alpine as builder
+FROM metabase/ci:java-11-lein-2.9.6-clj-1.10.3.822-04-22-2021 as frontend
 
 ARG MB_EDITION=oss
 
 WORKDIR /app/source
 
-ENV FC_LANG en-US LC_CTYPE en_US.UTF-8
+COPY . .
+RUN NODE_ENV=production MB_EDITION=$MB_EDITION yarn --frozen-lockfile && yarn build && bin/i18n/build-translation-resources
 
-# bash:    various shell scripts
-# curl:    needed by script that installs Clojure CLI
-# git:     ./bin/version
-# yarn:    frontend building
-# java-cacerts: installs updated cacerts to /etc/ssl/certs/java/cacerts
+###################
+# STAGE 1.2: backend deps
+###################
 
-RUN apk add --no-cache coreutils bash yarn git curl java-cacerts
+FROM metabase/ci:java-11-lein-2.9.6-clj-1.10.3.822-04-22-2021 as backend
 
-# lein:    backend dependencies and building
-RUN curl https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein -o /usr/local/bin/lein && \
-  chmod +x /usr/local/bin/lein && \
-  /usr/local/bin/lein upgrade
+WORKDIR /app/source
 
-# Clojure CLI (needed for some build scripts)
-RUN curl https://download.clojure.org/install/linux-install-1.10.1.708.sh -o /tmp/linux-install-1.10.1.708.sh && \
-  chmod +x /tmp/linux-install-1.10.1.708.sh && \
-  sh /tmp/linux-install-1.10.1.708.sh
+# backend dependencies
+COPY project.clj .
+RUN lein deps :tree
 
-COPY --from=frontend /app/source/. .
-COPY --from=backend /app/source/. .
-COPY --from=backend /root/. /root/
+###################
+# STAGE 1.3: drivers
+###################
+
+FROM metabase/ci:java-11-lein-2.9.6-clj-1.10.3.822-04-22-2021 as drivers
+
+ARG MB_EDITION=oss
+
+WORKDIR /app/source
+
+COPY --from=backend /root/.m2/repository/. /root/.m2/repository/.
 
 # add the rest of the source
 COPY . .
 
 # build the app
-RUN INTERACTIVE=false MB_EDITION=$MB_EDITION bin/build
+RUN INTERACTIVE=false MB_EDITION=$MB_EDITION sh bin/build-drivers.sh
+
+###################
+# STAGE 1.3: main builder
+###################
+
+FROM metabase/ci:java-11-lein-2.9.6-clj-1.10.3.822-04-22-2021 as builder
+
+ARG MB_EDITION=oss
+
+WORKDIR /app/source
+
+# try to reuse caching as much as possible
+COPY --from=frontend /root/.m2/repository/. /root/.m2/repository/.
+COPY --from=frontend /app/source/. .
+COPY --from=backend /root/.m2/repository/. /root/.m2/repository/.
+COPY --from=backend /app/source/. .
+COPY --from=drivers /root/.m2/repository/. /root/.m2/repository/.
+COPY --from=drivers /app/source/. .
+
+# build the app
+RUN INTERACTIVE=false MB_EDITION=$MB_EDITION bin/build uberjar
 
 # ###################
 # # STAGE 2: runner
 # ###################
 
-FROM adoptopenjdk/openjdk11:alpine-jre as runner
+## Remember that this runner image needs to be the same as bin/docker/Dockerfile with the exception that this one grabs the 
+## jar from the previous stage rather than the local build
 
-WORKDIR /app
+FROM adoptopenjdk/openjdk11:alpine-jre as runner
 
 ENV FC_LANG en-US LC_CTYPE en_US.UTF-8
 
 # dependencies
-RUN apk -U upgrade &&  \
-    apk add --update --no-cache bash ttf-dejavu fontconfig curl java-cacerts && \
+RUN apk upgrade && apk add --update-cache --no-cache bash ttf-dejavu fontconfig curl java-cacerts && \
     mkdir -p /app/certs && \
     curl https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem -o /app/certs/rds-combined-ca-bundle.pem  && \
     /opt/java/openjdk/bin/keytool -noprompt -import -trustcacerts -alias aws-rds -file /app/certs/rds-combined-ca-bundle.pem -keystore /etc/ssl/certs/java/cacerts -keypass changeit -storepass changeit && \
@@ -96,16 +82,12 @@ RUN apk -U upgrade &&  \
     /opt/java/openjdk/bin/keytool -noprompt -import -trustcacerts -alias azure-cert -file /app/certs/DigiCertGlobalRootG2.crt.pem -keystore /etc/ssl/certs/java/cacerts -keypass changeit -storepass changeit && \
     mkdir -p /plugins && chmod a+rwx /plugins
 
-# add fixed cacerts
-COPY --from=builder /etc/ssl/certs/java/cacerts /opt/java/openjdk/lib/security/cacerts
-
 # add Metabase script and uberjar
-RUN mkdir -p bin target/uberjar
-COPY --from=builder /app/source/target/uberjar/metabase.jar /app/target/uberjar/
-COPY --from=builder /app/source/bin/start /app/bin/
+COPY --from=builder /app/source/target/uberjar/metabase.jar /app/
+COPY bin/docker/run_metabase.sh /app/
 
 # expose our default runtime port
 EXPOSE 3000
 
 # run it
-ENTRYPOINT ["/app/bin/start"]
+ENTRYPOINT ["/app/run_metabase.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ COPY . .
 RUN INTERACTIVE=false MB_EDITION=$MB_EDITION sh bin/build-drivers.sh
 
 ###################
-# STAGE 1.3: main builder
+# STAGE 1.4: main builder
 ###################
 
 FROM metabase/ci:java-11-lein-2.9.6-clj-1.10.3.822-04-22-2021 as builder

--- a/bin/docker/Dockerfile
+++ b/bin/docker/Dockerfile
@@ -3,8 +3,7 @@ FROM adoptopenjdk/openjdk11:alpine-jre
 ENV FC_LANG en-US LC_CTYPE en_US.UTF-8
 
 # dependencies
-RUN apk -U upgrade &&  \
-    apk add --update --no-cache bash ttf-dejavu fontconfig curl java-cacerts && \
+RUN apk upgrade & apk add --update-cache --no-cache bash ttf-dejavu fontconfig curl java-cacerts && \
     mkdir -p /app/certs && \
     curl https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem -o /app/certs/rds-combined-ca-bundle.pem  && \
     /opt/java/openjdk/bin/keytool -noprompt -import -trustcacerts -alias aws-rds -file /app/certs/rds-combined-ca-bundle.pem -keystore /etc/ssl/certs/java/cacerts -keypass changeit -storepass changeit && \


### PR DESCRIPTION
Docker build now runs in 4 layers:
- frontend (which builds now separately) // yarn build ...
- BE deps (lein deps...)
- Drivers (sh build_drivers...)
- Main builder (grabs everything from previous layers and builds the uberjar) (bin/build uberjar...)

it also unifies /app/run_metabase.sh between build and release containers

The argument behind this change is that the frontend takes a long time to build while the backend builder is sitting idle till the frontend finishes building. Therefore I tried to build the entire frontend separately while I also separated the drivers build from the final build (which was being done together). The results end up with a 15% reduction in the build time (original builds took 2500 secs on my computer with my internet connection and now take 1500 secs).

If we can get this to build driver by driver (each of them separately) it can be compressed even more, but you run out of RAM quickly as there is no way to contain the RAM consumption of the build.