### PR TITLE
#13095 Repro: Data point values uses formatting style of first serie on all series

### DIFF
--- a/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
@@ -41,16 +41,16 @@ describe("scenarios > visualizations > line chart", () => {
       dataset_query: {
         type: "query",
         query: {
-          "source-table": 2,
+          "source-table": ORDERS_ID,
           aggregation: [
-            ["sum", ["field", 15, null]],
+            ["sum", ["field", ORDERS.TOTAL, null]],
             [
               "aggregation-options",
-              ["/", ["avg", ["field", 10, null]], 10],
+              ["/", ["avg", ["field", ORDERS.QUANTITY, null]], 10],
               { "display-name": "AvgPct" },
             ],
           ],
-          breakout: [["field", 12, { "temporal-unit": "year" }]],
+          breakout: [["field", ORDERS.CREATED_AT, { "temporal-unit": "year" }]],
         },
         database: 1,
       },

--- a/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
@@ -35,4 +35,36 @@ describe("scenarios > visualizations > line chart", () => {
     cy.findByText("Right").click();
     cy.get(Y_AXIS_RIGHT_SELECTOR);
   });
+
+  it.skip("should be able to format data point values style independently on multi-series chart (metabase#13095)", () => {
+    visitQuestionAdhoc({
+      dataset_query: {
+        type: "query",
+        query: {
+          "source-table": 2,
+          aggregation: [
+            ["sum", ["field", 15, null]],
+            [
+              "aggregation-options",
+              ["/", ["avg", ["field", 10, null]], 10],
+              { "display-name": "AvgPct" },
+            ],
+          ],
+          breakout: [["field", 12, { "temporal-unit": "year" }]],
+        },
+        database: 1,
+      },
+      display: "line",
+      visualization_settings: {
+        "graph.show_values": true,
+        column_settings: {
+          '["name","expression"]': { number_style: "percent" },
+        },
+        "graph.dimensions": ["CREATED_AT"],
+        "graph.metrics": ["sum", "expression"],
+      },
+    });
+
+    cy.get(".value-labels").contains("30%");
+  });
 });


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #13095

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/116231168-d48e7a80-a758-11eb-9a01-10a63414f042.png)

