### PR TITLE
#13217 Repro: Custom Field `concat` only shows filter options as numeric

### DIFF
--- a/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
@@ -4,6 +4,7 @@ import {
   _typeUsingGet,
   _typeUsingPlaceholder,
   openOrdersTable,
+  openPeopleTable,
   visitQuestionAdhoc,
 } from "__support__/cypress";
 
@@ -554,6 +555,23 @@ describe("scenarios > question > custom columns", () => {
     cy.findByText("Filter").click();
     popover()
       .findByText("13112")
+      .click();
+    cy.findByPlaceholderText("Enter a number").should("not.exist");
+  });
+
+  it.skip("filter based on `concat` function should not offer numeric options (metabase#13217)", () => {
+    openPeopleTable({ mode: "notebook" });
+    cy.findByText("Custom column").click();
+    popover().within(() => {
+      cy.get("[contenteditable='true']")
+        .type(`concat("State: ", [State])`)
+        .blur();
+      cy.findByPlaceholderText("Something nice and descriptive").type("13217");
+      cy.findByRole("button", { name: "Done" }).click();
+    });
+    cy.findByText("Filter").click();
+    popover()
+      .findByText("13217")
       .click();
     cy.findByPlaceholderText("Enter a number").should("not.exist");
   });


### PR DESCRIPTION
### Status
PENDING CI / PENDING REVIEW / READY _(choose one and update accordingly)_

### What does this PR accomplish?
- Reproduces #13217

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/question/custom_column.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/116256346-64d9b900-a773-11eb-93ab-0491986b48e1.png)

