### PR TITLE
make TableInteractive cell more button-like

### DIFF
--- a/frontend/src/metabase/visualizations/components/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive.jsx
@@ -513,6 +513,15 @@ export default class TableInteractive extends Component {
               }
             : undefined
         }
+        onKeyUp={
+          isClickable
+            ? e => {
+                e.key === "Enter" &&
+                  this.onVisualizationClick(clicked, e.currentTarget);
+              }
+            : undefined
+        }
+        tabIndex="0"
       >
         {this.props.renderTableCellWrapper(cellData)}
       </div>

--- a/frontend/src/metabase/visualizations/components/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive.jsx
@@ -506,7 +506,7 @@ export default class TableInteractive extends Component {
           "Table-FK": value != null && isFK(column),
           link: isClickable && isID(column),
         })}
-        onMouseUp={
+        onClick={
           isClickable
             ? e => {
                 this.onVisualizationClick(clicked, e.currentTarget);


### PR DESCRIPTION
This was annoying me--I kept accidentally triggering this cell because it used a `mouseup` event instead of a `click`. While I was tweaking that I noticed it wasn't keyboard accessible at all, so I went ahead a dropped a `tabIndex` + `mousedown` event on it.

before:
![annoying](https://user-images.githubusercontent.com/13057258/116281922-0db9f100-a73f-11eb-9f04-38794b86bf80.gif)

after:
![onclick](https://user-images.githubusercontent.com/13057258/116281942-13afd200-a73f-11eb-990e-f750c6ebd0ed.gif)

keyboard accessible:
![keyboard](https://user-images.githubusercontent.com/13057258/116281958-16aac280-a73f-11eb-9254-d8b24b618375.gif)




