### PR TITLE
add history button to saved question header

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -9,6 +9,7 @@ import Link from "metabase/components/Link";
 import ButtonBar from "metabase/components/ButtonBar";
 import CollectionBadge from "metabase/questions/components/CollectionBadge";
 import SavedQuestionHeaderButton from "metabase/questions/components/SavedQuestionHeaderButton";
+import HistoryButton from "metabase/questions/components/HistoryButton";
 import ViewSection, { ViewHeading, ViewSubHeading } from "./ViewSection";
 
 import QuestionDataSource from "./QuestionDataSource";
@@ -28,7 +29,6 @@ import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
 const SavedQuestionHeaderButtonContainer = styled.div`
   position: relative;
   right: 0.5rem;
-  margin-bottom: 0.5rem;
 `;
 
 export class ViewTitleHeader extends React.Component {
@@ -111,17 +111,24 @@ export class ViewTitleHeader extends React.Component {
       >
         {isSaved ? (
           <div>
-            <SavedQuestionHeaderButtonContainer>
-              <SavedQuestionHeaderButton
-                question={question}
-                active={isShowingQuestionDetailsSidebar}
-                onClick={
-                  isShowingQuestionDetailsSidebar
-                    ? onCloseQuestionDetails
-                    : onOpenQuestionDetails
-                }
+            <div className="flex mb1">
+              <SavedQuestionHeaderButtonContainer>
+                <SavedQuestionHeaderButton
+                  question={question}
+                  active={isShowingQuestionDetailsSidebar}
+                  onClick={
+                    isShowingQuestionDetailsSidebar
+                      ? onCloseQuestionDetails
+                      : onOpenQuestionDetails
+                  }
+                />
+              </SavedQuestionHeaderButtonContainer>
+              <HistoryButton
+                onClick={() => onOpenModal("history")}
+                modelType="card"
+                modelId={question.id()}
               />
-            </SavedQuestionHeaderButtonContainer>
+            </div>
             <ViewSubHeading className="flex align-center flex-wrap">
               <CollectionBadge
                 className="mb1"

--- a/frontend/src/metabase/questions/components/HistoryButton.jsx
+++ b/frontend/src/metabase/questions/components/HistoryButton.jsx
@@ -1,0 +1,35 @@
+import React from "react";
+import PropTypes from "prop-types";
+import _ from "underscore";
+import moment from "moment";
+import { t } from "ttag";
+import Revision from "metabase/entities/revisions";
+import Button from "metabase/components/Button";
+
+function HistoryButton({ onClick, revisions }) {
+  const mostRecentRevision = _.first(revisions);
+  return mostRecentRevision ? (
+    <Button
+      className="text-underline text-light"
+      borderless
+      small
+      onClick={onClick}
+    >
+      {t`Edited ${moment(mostRecentRevision.timestamp).fromNow()}`}
+    </Button>
+  ) : null;
+}
+
+export default Revision.loadList({
+  query: (state, props) => ({
+    model_type: props.modelType,
+    model_id: props.modelId,
+  }),
+  loadingAndErrorWrapper: false,
+  wrapped: true,
+})(HistoryButton);
+
+HistoryButton.propTypes = {
+  onClick: PropTypes.func.isRequired,
+  revisions: PropTypes.array,
+};

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -519,8 +519,7 @@ describe("collection permissions", () => {
                 // For now that's not possible for user without data access (likely it will be again when #11719 is fixed)
                 cy.skipOn(user === "nodata");
                 cy.visit("/question/1");
-                cy.icon("pencil").click();
-                cy.findByText("View revision history").click();
+                cy.findByRole("button", { name: /Edited .*/ }).click();
                 clickRevert("First revision.");
                 cy.wait("@revert").then(xhr => {
                   expect(xhr.status).to.eq(200);
@@ -549,8 +548,7 @@ describe("collection permissions", () => {
               it("should not see question revert buttons (metabase#13229)", () => {
                 cy.signIn(user);
                 cy.visit("/question/1");
-                cy.icon("pencil").click();
-                cy.findByText("View revision history").click();
+                cy.findByRole("button", { name: /Edited .*/ }).click();
                 cy.findAllByRole("button", { name: "Revert" }).should(
                   "not.exist",
                 );


### PR DESCRIPTION
Replaces pencil icon revision history option with this button that has relative time text

![history-button](https://user-images.githubusercontent.com/13057258/116304566-8c228d00-a757-11eb-8e9d-d1422e9b8315.gif)
