### PR TITLE
Custom expression: First cut at removing operator suggestions

### DIFF
--- a/frontend/src/metabase/lib/expressions/suggest.js
+++ b/frontend/src/metabase/lib/expressions/suggest.js
@@ -1,5 +1,4 @@
 import _ from "underscore";
-import escape from "regexp.escape";
 
 import {
   getExpressionName,
@@ -19,26 +18,17 @@ import {
 } from "./parser";
 
 import {
-  AdditiveOperator,
   AggregationFunctionName,
-  BooleanOperatorUnary,
-  LogicalAndOperator,
-  LogicalOrOperator,
   CLAUSE_TOKENS,
   Case,
-  Comma,
-  FilterOperator,
   FunctionName,
   Identifier,
   IdentifierString,
   LParen,
   Minus,
-  MultiplicativeOperator,
   NumberLiteral,
-  RParen,
   StringLiteral,
   UnclosedQuotedString,
-  getSubTokenTypes,
   isTokenType,
   lexerWithRecovery,
 } from "./lexer";
@@ -211,35 +201,6 @@ export function suggest({
     } else if (lastInputTokenIsUnclosedIdentifierString) {
       // skip the rest
     } else if (
-      nextTokenType === AdditiveOperator ||
-      nextTokenType === MultiplicativeOperator
-    ) {
-      if (
-        isExpressionType("number", expectedType) ||
-        isExpressionType("aggregation", expectedType)
-      ) {
-        const tokenTypes = getSubTokenTypes(nextTokenType);
-        finalSuggestions.push(
-          ...tokenTypes.map(tokenType =>
-            operatorSuggestion(CLAUSE_TOKENS.get(tokenType).name),
-          ),
-        );
-      }
-    } else if (
-      nextTokenType === BooleanOperatorUnary ||
-      nextTokenType === LogicalAndOperator ||
-      nextTokenType === LogicalOrOperator ||
-      nextTokenType === FilterOperator
-    ) {
-      if (isExpressionType(expectedType, "boolean")) {
-        const tokenTypes = getSubTokenTypes(nextTokenType);
-        finalSuggestions.push(
-          ...tokenTypes.map(tokenType =>
-            operatorSuggestion(CLAUSE_TOKENS.get(tokenType).name),
-          ),
-        );
-      }
-    } else if (
       isTokenType(nextTokenType, FunctionName) ||
       nextTokenType === Case
     ) {
@@ -292,38 +253,6 @@ export function suggest({
           postfixTrim: /^\w+(\(\)?|$)/,
         };
         finalSuggestions.push(caseSuggestion);
-      }
-    } else if (nextTokenType === LParen) {
-      finalSuggestions.push({
-        type: "other",
-        name: "(",
-        text: " (",
-        postfixText: ")",
-        prefixTrim: /\s*$/,
-        postfixTrim: /^\s*\(?\s*/,
-      });
-    } else if (nextTokenType === RParen) {
-      finalSuggestions.push({
-        type: "other",
-        name: ")",
-        text: ") ",
-        prefixTrim: /\s*$/,
-        postfixTrim: /^\s*\)?\s*/,
-      });
-    } else if (nextTokenType === Comma) {
-      if (
-        context.clause &&
-        (context.clause.multiple ||
-          context.index < context.clause.args.length - 1)
-      ) {
-        finalSuggestions.push({
-          type: "other",
-          name: ",",
-          text: ", ",
-          postfixText: ",",
-          prefixTrim: /\s*$/,
-          postfixTrim: /^\s*,?\s*/,
-        });
       }
     } else if (
       nextTokenType === StringLiteral ||
@@ -379,20 +308,6 @@ export function suggest({
       .sortBy("name")
       .sortBy("type")
       .value(),
-  };
-}
-
-function operatorSuggestion(clause) {
-  const name = getExpressionName(clause);
-  return {
-    type: "operators",
-    name: name,
-    text: " " + name + " ",
-    prefixTrim: new RegExp(
-      "\\s*" + escape(name).replace(/(.{1})/g, "$1?") + "$",
-      "i",
-    ),
-    postfixTrim: new RegExp("/^s*" + escape(name) + "?s*/"),
   };
 }
 

--- a/frontend/test/metabase/lib/expressions/suggest.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/suggest.unit.spec.js
@@ -68,26 +68,6 @@ const FILTER_FUNCTIONS = [
   { text: "isnull(", type: "functions" },
   { text: "startsWith(", type: "functions" },
 ];
-const EXPRESSION_OPERATORS = [
-  { text: " * ", type: "operators" },
-  { text: " + ", type: "operators" },
-  { text: " - ", type: "operators" },
-  { text: " / ", type: "operators" },
-];
-const FILTER_OPERATORS = [
-  { text: " != ", type: "operators" },
-  { text: " < ", type: "operators" },
-  { text: " <= ", type: "operators" },
-  { text: " = ", type: "operators" },
-  { text: " > ", type: "operators" },
-  { text: " >= ", type: "operators" },
-];
-const UNARY_BOOLEAN_OPERATORS = [{ text: " NOT ", type: "operators" }];
-const BINARY_BOOLEAN_OPERATORS = [
-  { text: " AND ", type: "operators" },
-  { text: " OR ", type: "operators" },
-];
-const OPEN_PAREN = { type: "other", text: " (" };
 
 // custom metadata defined in __support__/expressions
 const METRICS_CUSTOM = [{ type: "metrics", text: "[metric]" }];
@@ -167,7 +147,6 @@ describe("metabase/lib/expression/suggest", () => {
             ...NUMERIC_FUNCTIONS,
             ...STRING_FUNCTIONS_EXCLUDING_REGEX,
           ].sort(suggestionSort),
-          OPEN_PAREN,
         ]);
       });
 
@@ -177,7 +156,6 @@ describe("metabase/lib/expression/suggest", () => {
           ...[{ type: "functions", text: "case(" }, ...NUMERIC_FUNCTIONS].sort(
             suggestionSort,
           ),
-          OPEN_PAREN,
         ]);
       });
       it("should suggest partial matches in expression", () => {
@@ -255,18 +233,8 @@ describe("metabase/lib/expression/suggest", () => {
             { text: "coalesce(", type: "functions" },
             ...STRING_FUNCTIONS,
             ...NUMERIC_FUNCTIONS,
-            OPEN_PAREN,
           ].sort(suggestionSort),
         );
-      });
-      it("should suggest numeric operators after field in an expression", () => {
-        expect(
-          suggest({
-            source: "Total ",
-            query: ORDERS.query(),
-            startRule: "expression",
-          }),
-        ).toEqual([...EXPRESSION_OPERATORS]);
       });
 
       it("should provide help text for the function", () => {
@@ -328,7 +296,6 @@ describe("metabase/lib/expression/suggest", () => {
             ...NUMERIC_FUNCTIONS,
           ].sort(suggestionSort),
           ...METRICS_CUSTOM,
-          OPEN_PAREN,
         ]);
       });
       it("should suggest partial matches in aggregation", () => {
@@ -356,7 +323,6 @@ describe("metabase/lib/expression/suggest", () => {
             ...NUMERIC_FUNCTIONS,
           ].sort(suggestionSort),
           ...METRICS_ORDERS,
-          OPEN_PAREN,
         ]);
       });
 
@@ -369,43 +335,17 @@ describe("metabase/lib/expression/suggest", () => {
         expect(name).toEqual("sum");
         expect(example).toEqual("Sum([Subtotal])");
       });
-
-      it("should give us the prefix trim regex in expressions that actually trims", () => {
-        expect(
-          "no".replace(
-            uncleanSuggest({
-              source: "no",
-              query: ORDERS.query(),
-              startRule: "boolean",
-            })[0].prefixTrim,
-            "",
-          ),
-        ).toEqual("");
-      });
     });
 
     describe("filter", () => {
-      it("should suggest comparison operators after field in a filter", () => {
-        expect(
-          suggest({
-            source: "Total ",
-            query: ORDERS.query(),
-            startRule: "boolean",
-          }),
-        ).toEqual([...FILTER_OPERATORS, ...BINARY_BOOLEAN_OPERATORS]);
-      });
-
       it("should suggest filter functions, fields, and segments in a filter", () => {
         expect(
           suggest({ source: "", query: ORDERS.query(), startRule: "boolean" }),
         ).toEqual([
           ...FIELDS_ORDERS,
-          ...[
-            { type: "functions", text: "case(" },
-            ...FILTER_FUNCTIONS,
-            ...UNARY_BOOLEAN_OPERATORS,
-          ].sort(suggestionSort),
-          OPEN_PAREN,
+          ...[{ type: "functions", text: "case(" }, ...FILTER_FUNCTIONS].sort(
+            suggestionSort,
+          ),
           ...SEGMENTS_ORDERS,
         ]);
       });

--- a/frontend/test/metabase/lib/expressions/suggest.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/suggest.unit.spec.js
@@ -128,10 +128,6 @@ describe("metabase/lib/expression/suggest", () => {
       return cleanSuggestions(suggest_(...args).suggestions);
     }
 
-    function uncleanSuggest(...args) {
-      return suggest_(...args).suggestions;
-    }
-
     function helpText(...args) {
       return suggest_(...args).helpText;
     }

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -899,6 +899,15 @@ describe("scenarios > question > notebook", () => {
       });
     });
   });
+
+  describe("typing suggestion", () => {
+    it("should not suggest arithmetic operators", () => {
+      openProductsTable({ mode: "notebook" });
+      cy.findByText("Custom column").click();
+      cy.get("[contenteditable='true']").type("[Price] ");
+      cy.contains("/").should("not.exist");
+    });
+  });
 });
 
 // Extracted repro steps for #13000


### PR DESCRIPTION
For more detailed context and overall plan, check #15761.

Run the unit tests:
```
yarn test-unit frontend/test/metabase/lib/expressions/suggest.unit.spec.js
```

Manual steps to try:
1. Ask a question, Custom question
2. Sample Dataset, Products table
3. Filter, Custom Expression
4. Type `[Price] ` and wait

**Before this PR**

![image](https://user-images.githubusercontent.com/7288/116316683-25a56b00-a767-11eb-8cb7-6c41cbfb3655.png)

**After this PR**

![image](https://user-images.githubusercontent.com/7288/116316736-3a81fe80-a767-11eb-96aa-016bf1cebf00.png)
