### PR TITLE
add description to details sidebar + edit action icon

### DIFF
--- a/frontend/src/metabase/components/ClampedText.jsx
+++ b/frontend/src/metabase/components/ClampedText.jsx
@@ -29,10 +29,7 @@ function ClampedText({ className, text, visibleLines }) {
 
     const clampedHeight = clampedDiv.current.getBoundingClientRect().height;
     const textHeight = innerDiv.current.getBoundingClientRect().height;
-
-    if (textHeight > clampedHeight) {
-      setIsOverflowing(true);
-    }
+    setIsOverflowing(textHeight > clampedHeight);
   }, [text]);
 
   return (

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebarPanel.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebarPanel.jsx
@@ -2,18 +2,21 @@ import React from "react";
 import PropTypes from "prop-types";
 import SidebarContent from "metabase/query_builder/components/SidebarContent";
 import QuestionActionButtons from "metabase/questions/components/QuestionActionButtons";
+import ClampedText from "metabase/components/ClampedText";
 import { PLUGIN_MODERATION_COMPONENTS } from "metabase/plugins";
 import { SIDEBAR_VIEWS } from "./constants";
 
 const { ModerationIssueActionMenu } = PLUGIN_MODERATION_COMPONENTS;
 
 function QuestionDetailsSidebarPanel({ setView, question, onOpenModal }) {
-  const canWrite = question && question.canWrite();
+  const canWrite = question.canWrite();
+  const description = question.description();
 
   return (
     <SidebarContent className="full-height px1">
       <div>
         <QuestionActionButtons canWrite={canWrite} onOpenModal={onOpenModal} />
+        <ClampedText className="pb2 px2" text={description} visibleLines={8} />
         <ModerationIssueActionMenu
           onAction={issueType => {
             setView({

--- a/frontend/src/metabase/questions/components/QuestionActionButtons.jsx
+++ b/frontend/src/metabase/questions/components/QuestionActionButtons.jsx
@@ -27,6 +27,16 @@ function QuestionActionButtons({ canWrite, onOpenModal }) {
         Add to a dashboard
       </BlueHoverTextButton>
       {canWrite && (
+        <Tooltip tooltip={t`Edit this question`}>
+          <Button
+            onlyIcon
+            icon="edit_document"
+            iconSize={18}
+            onClick={() => onOpenModal("edit")}
+          />
+        </Tooltip>
+      )}
+      {canWrite && (
         <Tooltip tooltip={t`Duplicate this question`}>
           <Button
             onlyIcon


### PR DESCRIPTION
Adds the question's description to the question details sidebar. To save some time I'm just re-adding the "edit" action to the top action bar instead of an inline, editable `ClampedText` component.

![question-description](https://user-images.githubusercontent.com/13057258/116316671-22aa7a80-a767-11eb-8114-06682be9b15c.gif)
