### PR TITLE
Serialization fixes part 1: support dashboard cards being in a different collection

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/names.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/names.clj
@@ -232,6 +232,7 @@
                          (str/join ", " (map name (keys (:value (ex-data e)))))
                          fully-qualified-name)
                     {:fully-qualified-name fully-qualified-name
+                     :resolve-name-failed? true
                      :context              context})))))))
 
 (defn name-for-logging

--- a/enterprise/backend/src/metabase_enterprise/serialization/specs.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/specs.clj
@@ -1,0 +1,9 @@
+(ns metabase-enterprise.serialization.specs
+  "Shared specs for serialization related code."
+  (:require [clojure.spec.alpha :as s]))
+
+;; a structure that represents items that can be loaded
+;; (s/def ::load-items (s/cat ::context map? ::model some? ::entity-dir string? ::entity-names (s/+ string?)))
+
+;; a structure that represents some items having failed to load; items are fully qualified entity names
+(s/def ::failed-name-resolution (s/map-of string? (s/+ string?)))

--- a/enterprise/backend/test/metabase_enterprise/serialization/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/load_test.clj
@@ -59,7 +59,8 @@
                          [Card          (Card card-id-nested)]
                          [Card          (Card card-id-nested-query)]
                          [Card          (Card card-id-native-query)]
-                         [DashboardCard (DashboardCard dashcard-id)]])]
+                         [DashboardCard (DashboardCard dashcard-id)]
+                         [DashboardCard (DashboardCard dashcard-with-click-actions)]])]
       (with-world-cleanup
         (load dump-dir {:on-error :abort :mode :skip})
         (doseq [[model entity] fingerprint]

--- a/enterprise/backend/test/metabase_enterprise/serialization/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/test_util.clj
@@ -106,7 +106,13 @@
                                              :position 0}]
                    DashboardCardSeries [~'_ {:dashboardcard_id ~'dashcard-id
                                              :card_id ~'card-id-nested
-                                             :position 1}]]
+                                             :position 1}]
+                   DashboardCard       [{~'dashcard-with-click-actions :id}
+                                        {:dashboard_id ~'dashboard-id
+                                         :card_id      ~'card-id-root}]
+                   DashboardCardSeries [~'_ {:dashboardcard_id ~'dashcard-with-click-actions
+                                             :card_id          ~'card-id-root
+                                             :position         2}]]
      ~@body))
 
 ;; Don't memoize as IDs change in each `with-world` context


### PR DESCRIPTION
Support dashboard cards being in a different collection

Make the load multimethod return a function, which serves as a "reload function", to be called after the first entire pass is complete (via cmd)

Updating various places to combine these functions together and invoke at the top level from cmd.clj when load finishes

Updating dashboard load implementation to check for presence of cards referred to by its dashcards, and if missing, reload those dashboards(s) on a second pass

Splitting out a separate load-dashboards fn that contains the bulk of the body from the previous multimethod implementation (which now delegates to it) to support easier reload functionality
