### PR TITLE
Serialization fixes part 3: handling dashboard card click actions

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/dump.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/dump.clj
@@ -51,8 +51,8 @@
   (doseq [entity (flatten entities)]
     (try
       (spit-entity path entity)
-      (catch Throwable _
-        (log/error (trs "Error dumping {0}" (name-for-logging entity))))))
+      (catch Throwable e
+        (log/error e (trs "Error dumping {0}" (name-for-logging entity))))))
   (spit-yaml (str path "/manifest.yaml")
              {:serialization-version serialize/serialization-protocol-version
               :metabase-version      config/mb-version-info}))

--- a/enterprise/backend/src/metabase_enterprise/serialization/serialize.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/serialize.clj
@@ -21,8 +21,10 @@
             [metabase.models.segment :refer [Segment]]
             [metabase.models.table :refer [Table]]
             [metabase.models.user :refer [User]]
+            [metabase.shared.models.visualization-settings :as mb.viz]
             [metabase.util :as u]
-            [toucan.db :as db]))
+            [toucan.db :as db]
+            [cheshire.core :as json]))
 
 (def ^:const ^Long serialization-protocol-version
   "Current serialization protocol version.
@@ -112,12 +114,48 @@
                                field/values
                                (u/select-non-nil-keys [:values :human_readable_values]))))))
 
+(defn- field-id* [col-settings-key]
+  (when-let [{:keys [mb.viz/field-id]} (mb.viz/parse-column-ref col-settings-key)]
+    field-id))
+
+(defn- convert-column-settings-key [k]
+  (if-let [field-id (::mb.viz/field-id k)]
+    (-> (db/select-one Field :id field-id)
+        fully-qualified-name
+        mb.viz/column-ref-for-qualified-name)
+    k))
+
+(defn- convert-click-behavior [{:keys [::mb.viz/click-behavior-type ::mb.viz/link-type
+                                       ::mb.viz/link-target-id ::mb.viz/link-parameter-mapping] :as click}]
+  (if-let [new-target-id (case link-type
+                           ::mb.viz/card (-> (Card link-target-id)
+                                             fully-qualified-name)
+                           nil)]
+    (assoc click ::mb.viz/link-target-id new-target-id)
+    click))
+
+(defn- convert-column-settings-value [{:keys [::mb.viz/click-behavior] :as v}]
+  (cond (some? click-behavior)
+        (assoc v ::mb.viz/click-behavior (convert-click-behavior click-behavior))
+        :default
+        v))
+
+(defn- convert-column-settings [acc k v]
+  (assoc acc (convert-column-settings-key k) (convert-column-settings-value v)))
+
+(defn- convert-viz-settings [viz-settings]
+  (-> (mb.viz/from-db-form viz-settings)
+      (update ::mb.viz/column-settings (fn [col-settings]
+                                         (reduce-kv convert-column-settings {} col-settings)))
+      mb.viz/db-form))
+
 (defn- dashboard-cards-for-dashboard
   [dashboard]
-  (let [dashboard-cards (db/select DashboardCard :dashboard_id (u/the-id dashboard))
-        series          (when (not-empty dashboard-cards)
-                          (db/select DashboardCardSeries
-                            :dashboardcard_id [:in (map u/the-id dashboard-cards)]))]
+  (let [dashboard-cards   (db/select DashboardCard :dashboard_id (u/the-id dashboard))
+        series            (when (not-empty dashboard-cards)
+                            (db/select DashboardCardSeries
+                              :dashboardcard_id [:in (map u/the-id dashboard-cards)]))
+        viz-settings-keys [:visualization_settings :column_settings]]
     (for [dashboard-card dashboard-cards]
       (-> dashboard-card
           (assoc :series (for [series series
@@ -125,6 +163,7 @@
                            (-> series
                                (update :card_id (partial fully-qualified-name Card))
                                (dissoc :id :dashboardcard_id))))
+          (assoc :visualization_settings (convert-viz-settings (:visualization_settings dashboard-card)))
           strip-crud))))
 
 (defmethod serialize-one (type Dashboard)

--- a/enterprise/backend/src/metabase_enterprise/serialization/upsert.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/upsert.clj
@@ -36,7 +36,7 @@
    Segment             [:name :table_id]
    Collection          [:name :location]
    Dashboard           [:name :collection_id]
-   DashboardCard       [:card_id :dashboard_id :visualiation_settings]
+   DashboardCard       [:card_id :dashboard_id :visualization_settings]
    DashboardCardSeries [:dashboardcard_id :card_id]
    FieldValues         [:field_id]
    Dimension           [:field_id :human_readable_field_id]

--- a/enterprise/backend/test/metabase_enterprise/serialization/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/test_util.clj
@@ -2,6 +2,7 @@
   (:require [metabase-enterprise.serialization.names :as names]
             [metabase.models :refer [Card Collection Dashboard DashboardCard DashboardCardSeries Database Field Metric
                                      Segment Table]]
+            [metabase.shared.models.visualization-settings :as mb.viz]
             [metabase.test.data :as data]
             [toucan.util.test :as tt]
             [metabase-enterprise.serialization.names :refer [fully-qualified-name]]))
@@ -110,11 +111,17 @@
                                              :card_id ~'card-id-nested
                                              :position 1}]
                    DashboardCard       [{~'dashcard-with-click-actions :id}
-                                        {:dashboard_id ~'dashboard-id
-                                         :card_id      ~'card-id-root}]
-                   DashboardCardSeries [~'_ {:dashboardcard_id ~'dashcard-with-click-actions
-                                             :card_id          ~'card-id-root
-                                             :position         2}]]
+                                        {:dashboard_id           ~'dashboard-id
+                                         :card_id                ~'card-id-root
+                                         :visualization_settings (-> (mb.viz/visualization-settings)
+                                                                     (mb.viz/click-action
+                                                                      ~'numeric-field-id
+                                                                      ::mb.viz/card
+                                                                      ~'card-id)
+                                                                     mb.viz/db-form)}]
+                   DashboardCardSeries [~'_ {:dashboardcard_id   ~'dashcard-with-click-actions
+                                             :card_id            ~'card-id-root
+                                             :position           2}]]
      ~@body))
 
 ;; Don't memoize as IDs change in each `with-world` context

--- a/shared/src/metabase/shared/models/visualization_settings.cljc
+++ b/shared/src/metabase/shared/models/visualization_settings.cljc
@@ -1,0 +1,181 @@
+(ns metabase.shared.models.visualization-settings
+  "Utility code for dealing with visualization settings, from cards, dashboard cards, etc.
+
+  There are two ways of representing the same data, DB form and normalized form.  DB form is the \"legacy\" form, which
+  uses unqualified keywords, which map directly to column names via Toucan.  Normalized form, on the other hand, uses
+  namespaced keywords and generally \"unwraps\" the semantic structures as much as possible.
+
+  In general, operations/manipulations should happen on the normalized form, and when the DB form is needed again (ex:
+  for updating the database), the map can be converted back."
+  (:require #?(:clj  [cheshire.core :as json]
+               :cljs [cljs.reader :as cljs-reader]
+                     [cljs.js :as js])
+            [clojure.set :as set]
+            [clojure.spec.alpha :as s]
+            [medley.core :as m]))
+
+(defn visualization-settings
+  "Creates an empty visualization settings map. Intended for use in the context of a threading macro (ex: with
+  `click-action` or a similar function following as the next form)."
+  {:added "0.40.0"}
+  []
+  {})
+
+(defn column-ref-for-id
+  "Creates a normalized column ref map for the given field ID. This becomes the key in the `::column-settings` map."
+  {:added "0.40.0"}
+  [field-id]
+  {::field-id field-id})
+
+(s/def ::field-id integer?)
+
+(defn column-ref-for-qualified-name
+  "Creates a normalized column ref map for the given fully qualified name (string). This becomes the key in the
+  `::column-settings` map."
+  {:added "0.40.0"}
+  [field-qualified-name]
+  {::field-qualified-name field-qualified-name})
+
+(s/def ::field-id string?)
+
+(defn- keyname
+  "Returns the full string value of the key name, including any \"namespace\" portion followed by forward slash."
+  ;; from https://clojuredocs.org/clojure.core/name#example-58264f85e4b0782b632278bf
+  ;; Clojure interprets slashes as keyword/name separators, so we need to do something hacky to get the "full" name here
+  ;; because our "keyword value" (as parsed from JSON/YAML/etc.) might actually look like the string version of a
+  ;; Clojure vector, which itself can contain a fully qualified name for serialization
+  [key]
+  (str (namespace key) "/" (name key)))
+
+(defn- parse-json-string
+  "Parse the given `json-str` to a map. In Clojure, this uses Cheshire. In Clojurescript, it uses `cljs.reader`."
+  [json-str]
+  #?(:clj  (json/parse-string json-str)
+     :cljs (cljs-reader/read-string json-str)))
+
+(defn- encode-json-string
+  "Encode the given `obj` map as a JSON string. In Clojure, this uses Cheshire. In Clojurescript, it uses
+  `cljs.core.clj->js` in conjunction with `cljs.js`."
+  [obj]
+  #?(:clj  (json/encode obj)
+     :cljs (.stringify js/JSON (clj->js obj))))
+
+(defn parse-column-ref
+  "Opposite of the `column-ref-for-*` fns. Converts the given string representation of a column settings key into its
+  normalized form. The `col-ref` argument can be a string or keyword (which is produced by YAML parsing, for instance).
+  In case it is a keyword, it will be converted to its full name. \"Full\" means that the portions before and after any
+  slashes will be included verbatim (via the `keyname` helper fn). This is necessary because our serialization code
+  considers a forward slash to be a legitimate portion of a fully qualified name, whereas Clojure considers it to be a
+  namespace/local name separator."
+  {:added "0.40.0"}
+  [col-ref]
+  (let [[_ [t id _]] ((comp vec parse-json-string) (if (keyword? col-ref) (keyname col-ref) col-ref))]
+    (case t "field" (cond (int? id)    {::field-id id}
+                          (string? id) {::field-qualified-name id}))))
+
+(defn- with-col-settings [settings]
+  (if (contains? settings ::column-settings)
+    settings
+    (assoc settings ::column-settings {})))
+
+(defn- click-action* [entity-type entity-id]
+  {::click-behavior-type    ::link
+   ::link-type              entity-type
+   ::link-parameter-mapping {}
+   ::link-target-id         entity-id})
+
+(defn click-action
+  "Creates a click action from a given `from-field-id` Field identifier to the given `to-entity-type` having ID
+  `to-entity-id`. This happens in the normalized form, and hence this should be passed the output of another fn
+  (including, currently, `visualization-settings`). If the given `from-field-id` already has a click action, it will
+  be replaced."
+  {:added "0.40.0"}
+  [settings from-field-id to-entity-type to-entity-id]
+  (-> settings
+      with-col-settings
+      (update-in [::column-settings] #(assoc % (column-ref-for-id from-field-id)
+                                               {::click-behavior (click-action* to-entity-type to-entity-id)}))))
+
+(def ^:private db-to-normalized-click-action-type
+  {"link" ::link})
+
+(def ^:private normalized-to-db-click-action-type
+  (set/map-invert db-to-normalized-click-action-type))
+
+(def ^:private db-to-normalized-link-type
+  {"question" ::card})
+
+(def ^:private normalized-to-db-link-type
+  (set/map-invert db-to-normalized-link-type))
+
+(defn- db-form-entry-to-normalized
+  "Converts a :column_settings DB form to qualified form. Does the opposite of
+  `db-normalized-entry-to-db-form-entry-to-normalized`."
+  [m k v]
+  (case k
+    :click_behavior (assoc m ::click-behavior (-> v
+                                                  (assoc
+                                                   ::click-behavior-type
+                                                   (db-to-normalized-click-action-type (:type v)))
+                                                  (dissoc :type)
+                                                  (assoc ::link-type (db-to-normalized-link-type (:linkType v)))
+                                                  (dissoc :linkType)
+                                                  (set/rename-keys {:parameterMapping ::link-parameter-mapping
+                                                                    :targetId         ::link-target-id})))
+    (assoc m k v)))
+
+(defn from-db-form
+  "Converts a DB form of visualization settings (i.e. map with key `:visualization_settings`) into the equivalent
+  normalized form (i.e. map with key `::visualization-settings`."
+  {:added "0.40.0"}
+  [visualization_settings]
+  (if-let [col-settings (:column_settings visualization_settings)]
+    {::column-settings (->> col-settings
+                            (m/map-kv (fn [k v]
+                                        (let [k1 (parse-column-ref k)
+                                              v1 (reduce-kv db-form-entry-to-normalized {} v)]
+                                          [k1 v1]))))}
+    {}))
+
+(defn- normalized-entry-to-db-form
+  "Converts a ::column-settings entry from qualified form to DB form. Does the opposite of
+  `db-form-entry-to-normalized`."
+  [m k v]
+  (case k
+    ::click-behavior (assoc m :click_behavior (-> v
+                                                  (assoc
+                                                   :type
+                                                   (normalized-to-db-click-action-type (::click-behavior-type v)))
+                                                  (dissoc ::click-behavior-type)
+                                                  (assoc :linkType (normalized-to-db-link-type (::link-type v)))
+                                                  (dissoc ::link-type)
+                                                  (set/rename-keys {::link-parameter-mapping :parameterMapping
+                                                                    ::link-target-id         :targetId})))))
+
+(defn db-form-column-ref
+  "Creates the DB form of a column ref (i.e. the key in the column settings map) for the given normalized args. Either
+  `::field-id` or `::field-qualified-name` keys will be checked in the arg map to build the corresponding column ref
+  map."
+  {:added "0.40.0"}
+  [{:keys [::field-id ::field-qualified-name]}]
+  (-> (cond
+        (some? field-id)             ["ref" ["field" field-id nil]]
+        (some? field-qualified-name) ["ref" ["field" field-qualified-name nil]])
+      encode-json-string))
+
+(defn- db-form-column-settings [col-settings]
+  (->> col-settings
+       (m/map-kv (fn [k v]
+                   [(db-form-column-ref k) (reduce-kv normalized-entry-to-db-form {} v)]))))
+
+(defn db-form
+  "The opposite of `from-db-form`. Converts the normalized form of visualization settings (i.e. a map having
+  `::visualization-settings` into the equivalent DB form (i.e. a map having `:visualization_settings`)."
+  {:added "0.40.0"}
+  [settings]
+  (if-let [col-settings (::column-settings settings)]
+    (if (empty? col-settings)
+      {}
+      {:column_settings (db-form-column-settings col-settings)})
+    {}))
+

--- a/shared/test/metabase/shared/models/visualization_settings_test.cljc
+++ b/shared/test/metabase/shared/models/visualization_settings_test.cljc
@@ -1,0 +1,38 @@
+(ns metabase.shared.models.visualization-settings-test
+  (:require [clojure.test :as t]
+            #?(:cljs [goog.string :as gstring])
+            [metabase.shared.models.visualization-settings :as mb.viz]))
+
+(def fmt #?(:clj format :cljs gstring/format))
+
+(t/deftest parse-column-ref-strings-test
+  (t/testing "Column ref strings are parsed correctly"
+    (let [f-qual-nm "/databases/MY_DB/tables/MY_TBL/fields/COL1"
+          f-id      42]
+      (doseq [[input-str expected] [[(fmt "[\"ref\",[\"field\",%d,null]]" f-id) {::mb.viz/field-id f-id}]
+                                    [(fmt "[\"ref\",[\"field\",\"%s\",null]]" f-qual-nm)
+                                     {::mb.viz/field-qualified-name f-qual-nm}]]]
+        (t/is (= expected (mb.viz/parse-column-ref input-str)))))))
+
+(t/deftest form-conversion-test
+  (t/testing ":visualization_settings are correctly converted from DB to qualified form and back"
+    (let [f-id                42
+          target-id           19
+          db-click-behavior   {:type             "link"
+                               :linkType         "question"
+                               :parameterMapping {}
+                               :targetId         target-id}
+          db-col-settings     {(fmt "[\"ref\",[\"field\",%d,null]]" f-id) {:click_behavior db-click-behavior}}
+          db-viz-settings     {:column_settings db-col-settings}
+          norm-click-behavior {::mb.viz/click-behavior-type    ::mb.viz/link
+                               ::mb.viz/link-type              ::mb.viz/card
+                               ::mb.viz/link-parameter-mapping {}
+                               ::mb.viz/link-target-id         target-id}
+          norm-col-settings   {(mb.viz/column-ref-for-id f-id) {::mb.viz/click-behavior norm-click-behavior}}
+          norm-viz-settings   {::mb.viz/column-settings norm-col-settings}]
+      (doseq [[db-form norm-form] [[db-viz-settings norm-viz-settings]]]
+        (let [to-norm (mb.viz/from-db-form db-form)]
+          (t/is (= norm-form to-norm))
+          (let [to-db (mb.viz/db-form to-norm)]
+            (t/is (= db-form to-db))))))))
+


### PR DESCRIPTION
Add visualization settings shared model namespace with utility functions

Adding tests for viz settings

Update visualization_settings in dump to convert column_settings keys from field ID to fully qualified name, and update the click action target with the fully qualified name

Doing the reverse in load, using the same utility code

Updating the existing dashcard in the "world" roundtrip test to include the click action

Adding assertion for the click action in the assert-loaded-entity implementation for Dashboard
