### PR TITLE
Custom expression tokenizer shouldn't barf on undefined char

### DIFF
--- a/frontend/src/metabase/lib/expressions/tokenizer.js
+++ b/frontend/src/metabase/lib/expressions/tokenizer.js
@@ -315,6 +315,9 @@ export function tokenize(expression) {
         }
       } else {
         const char = source[index];
+        if (!char) {
+          break;
+        }
         const message = t`Invalid character: ${char}`;
         const pos = index;
         errors.push({ message, pos });

--- a/frontend/test/metabase/lib/expressions/tokenizer.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/tokenizer.unit.spec.js
@@ -96,6 +96,7 @@ describe("metabase/lib/expressions/tokenizer", () => {
     expect(types("\n[Rating] ")).toEqual([T.Identifier]);
     expect(types("A\t  + ")).toEqual([T.Identifier, T.Operator]);
     expect(types("A \u3000  +\u2028")).toEqual([T.Identifier, T.Operator]);
+    expect(errors("[Expensive]  ")).toEqual([]);
   });
 
   it("should tokenize simple comparisons", () => {


### PR DESCRIPTION
This was a minor oversight.

Run the unit tests:
```
yarn test-unit frontend/test/metabase/lib/expressions/tokenizer.unit.spec.js
```
