### PR TITLE
add Comment and CommentHeader UI components

### DIFF
--- a/frontend/src/metabase/components/ClampedText.jsx
+++ b/frontend/src/metabase/components/ClampedText.jsx
@@ -35,18 +35,15 @@ function ClampedText({ className, text, visibleLines }) {
   return (
     <div className={cx("clamped-text", className)}>
       <ClampedDiv
-        className="clamped-text--clamp"
         innerRef={clampedDiv}
         visibleLines={isClamped ? visibleLines : undefined}
       >
-        <div ref={innerDiv} className="clamped-text--text">
-          {text}
-        </div>
+        <div ref={innerDiv}>{text}</div>
       </ClampedDiv>
-      <div className="clamped-text--footer">
+      <div>
         {isOverflowing && (
           <Button
-            className="clamped-text--toggle"
+            className="p0 my1 text-underline-hover bg-transparent-hover"
             borderless
             onClick={() => setIsClamped(isClamped => !isClamped)}
           >

--- a/frontend/src/metabase/components/Comment.info.js
+++ b/frontend/src/metabase/components/Comment.info.js
@@ -1,0 +1,53 @@
+import React from "react";
+import Comment from "metabase/components/Comment";
+
+export const component = Comment;
+export const category = "display";
+export const description = `
+  A component for displaying a user comment.
+`;
+
+const TEXT =
+  "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras sit amet sagittis dui. Morbi in odio laoreet, finibus erat vitae, sagittis dui. Ut at mauris eget ligula volutpat pellentesque. Integer non faucibus urna. Maecenas faucibus ornare gravida. Aliquam orci tortor, ullamcorper et vehicula accumsan, malesuada in ipsum. Nullam auctor, justo et mattis fringilla, enim ipsum aliquet nunc, quis posuere odio erat in nulla. Suspendisse elementum, est et rutrum volutpat, purus mi placerat odio, sit amet blandit nulla diam at lectus. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Ut ultricies placerat mollis. Curabitur vestibulum semper turpis, id cursus ex dignissim id. Cras efficitur sed ligula ac dictum. Curabitur hendrerit metus eget vestibulum bibendum. Cras nulla arcu, condimentum in rhoncus eu, interdum ut sapien. Cras sed molestie tellus, quis aliquet nunc. Nulla nec est eu est condimentum facilisis sit amet et ex.";
+
+const ACTIONS = [
+  { icon: "alert", title: "foo", action: () => alert("foo") },
+  { icon: "bar", title: "bar", action: () => {} },
+];
+
+export const examples = {
+  Default: (
+    <Comment
+      title="Bobby Tables"
+      text={TEXT}
+      timestamp={Date.now()}
+      actions={ACTIONS}
+    />
+  ),
+  "Restrict lines shown by adding a `visibleLines` prop": (
+    <Comment
+      title="Bobby Tables"
+      text={TEXT}
+      timestamp={new Date("1995-12-17T03:24:00")}
+      visibleLines={3}
+    />
+  ),
+  "Width restricted": (
+    <div
+      style={{
+        width: 300,
+        padding: "1rem",
+        borderRadius: "10px",
+        border: "1px dashed black",
+      }}
+    >
+      <Comment
+        title="Bobby Tables"
+        text={TEXT}
+        timestamp="2010-10-10"
+        visibleLines={3}
+        actions={ACTIONS}
+      />
+    </div>
+  ),
+};

--- a/frontend/src/metabase/components/Comment.jsx
+++ b/frontend/src/metabase/components/Comment.jsx
@@ -1,0 +1,36 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+import ClampedText from "metabase/components/ClampedText";
+import CommentHeader from "metabase/components/CommentHeader";
+
+function Comment({
+  className,
+  title,
+  timestamp,
+  text,
+  visibleLines,
+  actions = [],
+}) {
+  return (
+    <div className={className} role="comment">
+      <CommentHeader title={title} timestamp={timestamp} actions={actions} />
+      <ClampedText text={text} visibleLines={visibleLines} />
+    </div>
+  );
+}
+
+Comment.propTypes = {
+  className: PropTypes.string,
+  title: PropTypes.node,
+  timestamp: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+    PropTypes.instanceOf(Date),
+  ]),
+  text: PropTypes.string,
+  visibleLines: PropTypes.number,
+  actions: PropTypes.instanceOf(Array),
+};
+
+export default Comment;

--- a/frontend/src/metabase/components/CommentHeader.jsx
+++ b/frontend/src/metabase/components/CommentHeader.jsx
@@ -1,0 +1,52 @@
+import React from "react";
+import PropTypes from "prop-types";
+import moment from "moment";
+import cx from "classnames";
+import EntityMenu from "metabase/components/EntityMenu";
+
+const TRIGGER_BUTTON_DIAMETER = "25px";
+const TRIGGER_PROPS = {
+  className: "text-light",
+  style: {
+    height: TRIGGER_BUTTON_DIAMETER,
+    width: TRIGGER_BUTTON_DIAMETER,
+  },
+};
+
+function CommentHeader({ className, title, timestamp, actions = [] }) {
+  const relativeTimestamp = timestamp ? moment(timestamp).fromNow() : "";
+  return (
+    <div className={cx("flex justify-between align-center", className)}>
+      <div>
+        <span className="text-bold">{title}</span>
+        {timestamp && (
+          <time className="pl1 text-light" dateTime={timestamp}>
+            {relativeTimestamp}
+          </time>
+        )}
+      </div>
+      {actions.length ? (
+        <EntityMenu
+          triggerIcon="ellipsis"
+          items={actions}
+          triggerProps={TRIGGER_PROPS}
+        />
+      ) : (
+        undefined
+      )}
+    </div>
+  );
+}
+
+CommentHeader.propTypes = {
+  className: PropTypes.string,
+  title: PropTypes.node,
+  timestamp: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+    PropTypes.instanceOf(Date),
+  ]),
+  actions: PropTypes.instanceOf(Array),
+};
+
+export default CommentHeader;

--- a/frontend/src/metabase/css/core/colors.css
+++ b/frontend/src/metabase/css/core/colors.css
@@ -316,7 +316,8 @@
   color: var(--color-text-medium);
 }
 
-.bg-transparent {
+.bg-transparent,
+.bg-transparent-hover:hover {
   background-color: transparent;
 }
 

--- a/frontend/test/metabase/components/ClampedText.unit.spec.js
+++ b/frontend/test/metabase/components/ClampedText.unit.spec.js
@@ -1,0 +1,60 @@
+import React from "react";
+import "@testing-library/jest-dom/extend-expect";
+import { render, screen } from "@testing-library/react";
+
+import ClampedText from "metabase/components/ClampedText";
+
+const isTextEl = el => el.classList.contains("clamped-text--text");
+const SEE_MORE = "See more";
+const SEE_LESS = "See less";
+const LESS_HEIGHT = 50;
+const MORE_HEIGHT = 100;
+const TEXT = "1\n2\n3";
+
+describe("ClampedText", () => {
+  const getBoundingClientRectMock = jest.fn();
+
+  beforeEach(() => {
+    Element.prototype.getBoundingClientRect = getBoundingClientRectMock;
+  });
+
+  describe("and the text is greater than the height of the container", () => {
+    beforeEach(() => {
+      getBoundingClientRectMock.mockImplementation(function() {
+        return {
+          height: isTextEl(this) ? MORE_HEIGHT : LESS_HEIGHT,
+        };
+      });
+
+      render(<ClampedText visibleLines={1} text={TEXT} />);
+    });
+
+    it("should show a toggle for showing expanded or clamped text", async () => {
+      screen.getByText(SEE_MORE).click();
+      screen.getByText(SEE_LESS).click();
+      screen.getByText(SEE_MORE);
+    });
+  });
+
+  describe("and the text is less than the height of the container", () => {
+    beforeEach(() => {
+      getBoundingClientRectMock.mockImplementation(function() {
+        return {
+          height: isTextEl(this) ? LESS_HEIGHT : MORE_HEIGHT,
+        };
+      });
+
+      render(<ClampedText visibleLines={1} text={TEXT} />);
+    });
+
+    it("should not show a toggle", () => {
+      expect(() => {
+        screen.getByText(SEE_MORE);
+      }).toThrow();
+
+      expect(() => {
+        screen.getByText(SEE_LESS);
+      }).toThrow();
+    });
+  });
+});

--- a/frontend/test/metabase/components/Comment.unit.spec.js
+++ b/frontend/test/metabase/components/Comment.unit.spec.js
@@ -1,0 +1,16 @@
+import React from "react";
+import "@testing-library/jest-dom/extend-expect";
+import { render, screen } from "@testing-library/react";
+
+import Comment from "metabase/components/Comment";
+
+describe("Comment", () => {
+  beforeEach(() => {
+    render(<Comment title="Foo" text="bar" />);
+  });
+
+  it("should display text", () => {
+    screen.getByText("Foo");
+    screen.getByText("bar");
+  });
+});

--- a/frontend/test/metabase/components/CommentHeader.unit.spec.js
+++ b/frontend/test/metabase/components/CommentHeader.unit.spec.js
@@ -1,0 +1,68 @@
+import React from "react";
+import "@testing-library/jest-dom/extend-expect";
+import { render, screen } from "@testing-library/react";
+
+import CommentHeader from "metabase/components/CommentHeader";
+
+const MENU_ICON_SELECTOR = ".icon-ellipsis";
+const TITLE = "Foo";
+
+describe("CommentHeader", () => {
+  let actions;
+  let mockFn;
+  let container;
+  let rerender;
+  beforeEach(() => {
+    mockFn = jest.fn();
+    actions = [
+      {
+        icon: "alert",
+        title: "alert",
+        action: () => mockFn(),
+      },
+    ];
+    const { container: _container, rerender: _rerender } = render(
+      <CommentHeader title={TITLE} timestamp={1} actions={actions} />,
+    );
+    container = _container;
+    rerender = _rerender;
+  });
+
+  it("should display the title", () => {
+    screen.getByText(TITLE);
+  });
+
+  it("should have an action menu", () => {
+    container.querySelector(MENU_ICON_SELECTOR).click();
+    screen.getByText("alert").click();
+    expect(mockFn).toHaveBeenCalled();
+  });
+
+  it("should show the given timestamp in relative time for number", () => {
+    screen.getByText(/[0-9]* years ago/);
+  });
+
+  it("should show the given timestamp in relative time for string", () => {
+    rerender(
+      <CommentHeader title={TITLE} timestamp="1900-10-10" actions={actions} />,
+    );
+    screen.getByText(/[0-9]* years ago/);
+  });
+
+  it("should show the given timestamp in relative time for date", () => {
+    rerender(
+      <CommentHeader
+        title={TITLE}
+        timestamp={new Date("1900")}
+        actions={actions}
+      />,
+    );
+    screen.getByText(/[0-9]* years ago/);
+  });
+
+  it("should be able to render without optional props", () => {
+    rerender(<CommentHeader title={TITLE} />);
+    expect(container.textContent).toEqual(TITLE);
+    expect(container.querySelector(MENU_ICON_SELECTOR)).toBe(null);
+  });
+});


### PR DESCRIPTION
I'm adding `Comment` and `CommentHeader` components. I've split out `CommentHeader` because it will be used in a future `EditableComment` component.


`Comment` uses `ClampedText` internally so you can set a `visibleLines` prop to limit the number of lines shown:
<img width="760" alt="Screen Shot 2021-04-28 at 2 13 52 PM" src="https://user-images.githubusercontent.com/13057258/116473893-a24e4d00-a82c-11eb-9bc0-937e9b66fcc3.png">
Expanded:
<img width="775" alt="Screen Shot 2021-04-28 at 2 13 58 PM" src="https://user-images.githubusercontent.com/13057258/116473886-9febf300-a82c-11eb-9db9-fd7575d951c4.png">

Width-constrained (as it will be) + optional action menu for actions like "edit" or "delete"--letting the consumer pass in what actions are shown to avoid being too opinionated here (BUCM mocks have a "Cancel request" option, for example).
<img width="490" alt="Screen Shot 2021-04-28 at 2 13 46 PM" src="https://user-images.githubusercontent.com/13057258/116473901-a4181080-a82c-11eb-9ac8-c79fa7ea75d5.png">
