### PR TITLE
set Example <pre> overflow to auto

### DIFF
--- a/frontend/src/metabase/internal/components/Example.jsx
+++ b/frontend/src/metabase/internal/components/Example.jsx
@@ -24,7 +24,7 @@ const Example = ({ children }) => {
               value={code}
             />
           </Absolute>
-          <pre>
+          <pre className="overflow-auto">
             <code>{code}</code>
           </pre>
         </Box>


### PR DESCRIPTION
the `<pre>` tag in `Example` can have overflow when there's a long line of text. Just making it look a little better.

before
<img width="889" alt="Screen Shot 2021-04-28 at 4 13 30 PM" src="https://user-images.githubusercontent.com/13057258/116483891-daf62280-a83c-11eb-9ab7-fbeb13a952ed.png">

after
<img width="875" alt="Screen Shot 2021-04-28 at 4 13 17 PM" src="https://user-images.githubusercontent.com/13057258/116483887-d893c880-a83c-11eb-87f6-d315812054be.png">
