### PR TITLE
Cypress: also open DevTools when using Chromium

### DIFF
--- a/frontend/test/cypress-plugins.js
+++ b/frontend/test/cypress-plugins.js
@@ -33,7 +33,7 @@ module.exports = (on, config) => {
 
   //  Open dev tools in Chrome by default
   on("before:browser:launch", (browser = {}, launchOptions) => {
-    if (browser.name === "chrome") {
+    if (browser.name === "chrome" || browser.name === "chromium") {
       launchOptions.args.push("--auto-open-devtools-for-tabs");
 
       return launchOptions;


### PR DESCRIPTION
How to test? Install Chromium and run `yarn test-cypress-open` and select Chromium before running the tests.

![image](https://user-images.githubusercontent.com/7288/116547332-9489dd80-a8a7-11eb-9a36-0df728904649.png)
 