### PR TITLE
fix incorrect selection range in expression triggers popover

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -163,6 +163,8 @@ export default class ExpressionEditorTextfield extends React.Component {
       this.state.source.length,
       this.state.source.length === 0,
     );
+
+    this._triggerAutosuggest();
   }
 
   onSuggestionSelected = index => {


### PR DESCRIPTION
## Description

### Steps to reproduce
- Ask a question, Custom question
- Sample Dataset, Products table
- Custom column with [Price] / 2 and give any name e.g. Sale
- Once the custom column is created, click on it to edit it again.

Expected:
Only `FIELD FORMULA` popover is visible

Actual:
In addition to `FIELD FORMULA` it shows field/formula suggestions popover because of miscalculations of selection positions.

## Background

Autofocus field triggers `onFocus` handler which triggers `_triggerAutosuggest` which triggers `this.onExpressionChange(this.state.source)` before the component is mounted. However we set correct caret position only in `componentDidMount`

With string refs, `ReactDOM.findDOMNode` returned `null` and did not set an incorrect state before the component was mounted:
```js
 const inputElement = ReactDOM.findDOMNode(this.refs.input);
 if (!inputElement) {
      return;
 }
```

To fix it I invoke `this._triggerAutosuggest()` in `componentDidMount` right after the correct caret position was set.

Fixes https://github.com/metabase/metabase/issues/15851