### PR TITLE
Fix typo in api docs

### DIFF
--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -1913,7 +1913,7 @@ Update an existing `NativeQuerySnippet`.
 
 Notification about a potential schema change to one of our `Databases`.
   Caller can optionally specify a `:table_id` or `:table_name` in the body to limit updates to a single
-  `Table`. Optional Parameter `:scan` can be `"full" or "schema" for a full sync or a schema sync, available
+  `Table`. Optional Parameter `:scan` can be `"full"` or `"schema"` for a full sync or a schema sync, available
   regardless if a `:table_id` or `:table_name` is passed.
   This endpoint is secured by an API key that needs to be passed as a `X-METABASE-APIKEY` header which needs to be defined in
   the `MB_API_KEY` [environment variable](https://www.metabase.com/docs/latest/operations-guide/environment-variables.html#mb_api_key)


### PR DESCRIPTION
To add the rypos in the api doc I didn't fix in https://github.com/metabase/metabase/pull/15823