### PR TITLE
fix funnel dashboard card overflow

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard.jsx
@@ -196,7 +196,7 @@ export default class DashCard extends Component {
           </DashboardCardActionsPanel>
         ) : null}
         <WrappedVisualization
-          className={cx("flex-full", {
+          className={cx("flex-full overflow-hidden", {
             "pointer-events-none": isEditingDashboardLayout,
           })}
           classNameWidgets={isEmbed && "text-light text-medium-hover"}


### PR DESCRIPTION
### Description

In comparison to other visualizations, funnels require larger dashboard cards. But when there is no enough space they at least should not overflow:
<img width="1031" alt="Screen Shot 2021-04-29 at 20 47 23 (1)" src="https://user-images.githubusercontent.com/14301985/116611853-7ff92400-a93f-11eb-8db5-f5a01123e449.png">
