### PR TITLE
Cap the method cyclomatic complexity in the front-end code

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -23,7 +23,8 @@
     "react/jsx-key": 0,
     "prefer-const": [1, { "destructuring": "all" }],
     "no-useless-escape": 0,
-    "no-only-tests/no-only-tests": "error"
+    "no-only-tests/no-only-tests": "error",
+    "complexity": ["error", { "max": 54 }]
   },
   "globals": {
     "pending": false,


### PR DESCRIPTION
As we progress better with refactoring and simplification, the complexity threshold should be reduced as well.

See also #15870.

To test, run `yarn lint-eslint`.