### PR TITLE
Custom expression editor: correctly accept the suggestion

### DIFF
--- a/frontend/src/metabase/lib/expressions/suggest.js
+++ b/frontend/src/metabase/lib/expressions/suggest.js
@@ -90,16 +90,6 @@ export function suggest({
     partialSuggestionMode = true;
   }
 
-  const identifierTrimOptions = lastInputTokenIsUnclosedIdentifierString
-    ? {
-        // use the last token's pattern anchored to the end of the text
-        prefixTrim: new RegExp(lastInputToken.tokenType.PATTERN.source + "$"),
-      }
-    : {
-        prefixTrim: new RegExp(Identifier.PATTERN.source + "$"),
-        postfixTrim: new RegExp("^" + Identifier.PATTERN.source + "\\s*"),
-      };
-
   const context = getContext({
     cst,
     tokenVector,
@@ -174,7 +164,6 @@ export function suggest({
             alternates: EDITOR_FK_SYMBOLS.symbols.map(symbol =>
               getDimensionName(dimension, symbol),
             ),
-            ...identifierTrimOptions,
           })),
         );
       }
@@ -184,7 +173,6 @@ export function suggest({
             type: "segments",
             name: segment.name,
             text: formatSegmentName(segment),
-            ...identifierTrimOptions,
           })),
         );
       }
@@ -194,7 +182,6 @@ export function suggest({
             type: "metrics",
             name: metric.name,
             text: formatMetricName(metric),
-            ...identifierTrimOptions,
           })),
         );
       }
@@ -248,9 +235,6 @@ export function suggest({
           type: "functions",
           name: "case",
           text: "case(",
-          postfixText: ")",
-          prefixTrim: /\w+$/,
-          postfixTrim: /^\w+(\(\)?|$)/,
         };
         finalSuggestions.push(caseSuggestion);
       }
@@ -317,9 +301,6 @@ function functionSuggestion(type, clause, parens = true) {
     type: type,
     name: name,
     text: name + (parens ? "(" : " "),
-    postfixText: parens ? ")" : " ",
-    prefixTrim: /\w+$/,
-    postfixTrim: parens ? /^\w+(\(\)?|$)/ : /^\w+\s*/,
   };
 }
 

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -172,22 +172,26 @@ export default class ExpressionEditorTextfield extends React.Component {
     const suggestion = suggestions && suggestions[index];
 
     if (suggestion) {
-      let prefix = source.slice(0, suggestion.index);
-      if (suggestion.prefixTrim) {
-        prefix = prefix.replace(suggestion.prefixTrim, "");
+      const { tokens } = tokenize(source);
+      const token = tokens.find(t => t.end >= suggestion.index);
+      if (token) {
+        const prefix = source.slice(0, token.start);
+        const postfix = source.slice(token.end);
+        const suggested = suggestion.text;
+        const paren = _.last(suggested) === "(";
+        const replacement = paren
+          ? suggested.slice(0, suggested.length - 1)
+          : suggested;
+        const updatedExpression = prefix + replacement.trim() + postfix;
+        this.onExpressionChange(updatedExpression);
+        setTimeout(() => {
+          this._setCaretPosition(prefix.length + replacement.length, true);
+        });
+      } else {
+        const newExpression = source + suggestion.text;
+        this.onExpressionChange(newExpression);
+        setTimeout(() => this._setCaretPosition(newExpression.length, true));
       }
-      let postfix = source.slice(suggestion.index);
-      if (suggestion.postfixTrim) {
-        postfix = postfix.replace(suggestion.postfixTrim, "");
-      }
-      if (!postfix && suggestion.postfixText) {
-        postfix = suggestion.postfixText;
-      }
-
-      this.onExpressionChange(prefix + suggestion.text + postfix);
-      setTimeout(() =>
-        this._setCaretPosition((prefix + suggestion.text).length, true),
-      );
     }
   };
 

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -178,10 +178,14 @@ export default class ExpressionEditorTextfield extends React.Component {
         const prefix = source.slice(0, token.start);
         const postfix = source.slice(token.end);
         const suggested = suggestion.text;
-        const paren = _.last(suggested) === "(";
-        const replacement = paren
-          ? suggested.slice(0, suggested.length - 1)
-          : suggested;
+
+        // e.g. source is "isnull(A" and suggested is "isempty("
+        // the result should be "isempty(A" and NOT "isempty((A"
+        const openParen = _.last(suggested) === "(";
+        const alreadyOpenParen = _.first(postfix.trimLeft()) === "(";
+        const extraTrim = openParen && alreadyOpenParen ? 1 : 0;
+        const replacement = suggested.slice(0, suggested.length - extraTrim);
+
         const updatedExpression = prefix + replacement.trim() + postfix;
         this.onExpressionChange(updatedExpression);
         const caretPos = updatedExpression.length - postfix.length;

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -184,8 +184,9 @@ export default class ExpressionEditorTextfield extends React.Component {
           : suggested;
         const updatedExpression = prefix + replacement.trim() + postfix;
         this.onExpressionChange(updatedExpression);
+        const caretPos = updatedExpression.length - postfix.length;
         setTimeout(() => {
-          this._setCaretPosition(prefix.length + replacement.length, true);
+          this._setCaretPosition(caretPos, true);
         });
       } else {
         const newExpression = source + suggestion.text;

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -907,6 +907,41 @@ describe("scenarios > question > notebook", () => {
       cy.get("[contenteditable='true']").type("[Price] ");
       cy.contains("/").should("not.exist");
     });
+
+    it("should correctly accept the chosen field suggestion", () => {
+      openProductsTable({ mode: "notebook" });
+      cy.findByText("Custom column").click();
+      cy.get("[contenteditable='true']").type(
+        "[Rating]{leftarrow}{leftarrow}{leftarrow}",
+      );
+
+      // accept the only suggested item, i.e. "[Rating]"
+      cy.get("[contenteditable='true']").type("{enter}");
+
+      // if the replacement is correct -> "[Rating]"
+      // if the replacement is wrong -> "[Rating] ng"
+      cy.get("[contenteditable='true']")
+        .contains("[Rating] ng")
+        .should("not.exist");
+    });
+
+    it("should correctly accept the chosen function suggestion", () => {
+      openProductsTable({ mode: "notebook" });
+      cy.findByText("Custom column").click();
+      cy.get("[contenteditable='true']").type("LTRIM([Title])");
+
+      // Place the cursor between "is" and "empty"
+      cy.get("[contenteditable='true']").type(
+        Array(13)
+          .fill("{leftarrow}")
+          .join(""),
+      );
+
+      // accept the first suggested function, i.e. "length"
+      cy.get("[contenteditable='true']").type("{enter}");
+
+      cy.get("[contenteditable='true']").contains("length([Title])");
+    });
   });
 });
 

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -943,6 +943,13 @@ describe("scenarios > question > notebook", () => {
       cy.get("[contenteditable='true']").contains("length([Title])");
     });
   });
+
+  it("should correctly insert function suggestion with the opening parenthesis", () => {
+    openProductsTable({ mode: "notebook" });
+    cy.findByText("Custom column").click();
+    cy.get("[contenteditable='true']").type("LOW{enter}");
+    cy.get("[contenteditable='true']").contains("lower(");
+  });
 });
 
 // Extracted repro steps for #13000


### PR DESCRIPTION
This is carried out via lexical replacement, i.e. finding the token to be replaced, instead of the rather-brittle and often-incorrect regex for prefix/postfix.

Run: `yarn test-cypress-open --spec frontend/test/metabase/scenarios/question/notebook.cy.spec.js`.

To play around manually:
1. Ask a question, Custom question
2. Sample Dataset, Products table
3. Filter, Custom Expression, type `[Rating] > 3`
4. Move the cursor so that it's between _t_ and _i_.
5. Click the suggestion item in the popup (which is still `Rating` since it's the only prefix-match).

**Before this PR**

The filter becomes terribly mangled.

![image](https://user-images.githubusercontent.com/7288/116619760-be69f100-a8f5-11eb-9ec3-f13c62a858ff.png)

**After this PR**

The filter is still `[Rating] > 3`, with the cursor placed right before `>`.

**NOTE**: Another steps to try is to use a function, e.g. first go with `isnull([Discount])` and then place the cursor in the function name `isnull` so that some suggestions are shown, among others `isempty`. Clicking on the suggestion should yield the new filter `isempty([Discount])`, without mangling anything.