### PR TITLE
Remove the `node` parameter from Cypress CI job matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -869,10 +869,6 @@ jobs:
       test-files-location:
         type: string
         default: ""
-      # Node number e.g. 1
-      node:
-        type: string
-        default: ""
       before-steps:
         type: steps
         default: []
@@ -1182,7 +1178,6 @@ workflows:
       - fe-tests-cypress:
           matrix:
             parameters:
-              node: ["1"]
               edition: ["ee", "oss"]
           name: e2e-tests-<< matrix.edition >>
           requires:


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Removes redundant `node` parameter from the Cypress CI job matrix

### Additional info:
- Before @paulrosenzweig removed the Cypress dashboard connection from our CI (used for parallelization) we had different nodes from 1-4 used to dynamically build job names, such as:
`fe-tests-cypress-1-oss`, `fe-tests-cypress-3-ee`, etc.
- Without orchestrated parallelization, there is no more the need for this parameter

Note: I prematurely removed the `-<< matrix.node >>` in the previous PR (https://github.com/metabase/metabase/commit/3980825e440023cda50247505b8d8f93df340f01#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L1187)