### PR TITLE
Fix hash checking in bin/build-for-test

### DIFF
--- a/bin/build-for-test
+++ b/bin/build-for-test
@@ -30,7 +30,7 @@ check-uberjar-hash() {
 
 build-uberjar-for-test() {
   ./bin/build version
-  echo "$VERSION_PROPERTY_NAME=$(source-hash)" >> resources/version.properties
+  echo -e "\n$VERSION_PROPERTY_NAME=$(source-hash)" >> resources/version.properties
   ./bin/build uberjar
 }
 


### PR DESCRIPTION
`./bin/build-for-test` always rebuilt the jar even if no source files had changed. The issue was due to a missing new line before the stored hash. We weren't extracting the hash correctly from existing jars and always though we should rebuild.