### PR TITLE
Return 401 on auth failure instead of 400

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
@@ -59,7 +59,7 @@
                                    {:max-age three-minutes-in-seconds})
                        (catch Throwable e
                          (throw (ex-info (ex-message e)
-                                         {:status-code 401}
+                                         (assoc (ex-data e) :status-code 401)
                                          e))))
         login-attrs  (jwt-data->login-attributes jwt-data)
         email        (get jwt-data (jwt-attribute-email))

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
@@ -54,8 +54,13 @@
 
 (defn- login-jwt-user
   [jwt {{redirect :return_to} :params, :as request}]
-  (let [jwt-data     (jwt/unsign jwt (sso-settings/jwt-shared-secret)
-                                 {:max-age three-minutes-in-seconds})
+  (let [jwt-data     (try
+                       (jwt/unsign jwt (sso-settings/jwt-shared-secret)
+                                   {:max-age three-minutes-in-seconds})
+                       (catch Throwable e
+                         (throw (ex-info (tru "Couldn't unsign JWT")
+                                         {:status-code 401}
+                                         e))))
         login-attrs  (jwt-data->login-attributes jwt-data)
         email        (get jwt-data (jwt-attribute-email))
         first-name   (get jwt-data (jwt-attribute-firstname) "Unknown")

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
@@ -58,7 +58,7 @@
                        (jwt/unsign jwt (sso-settings/jwt-shared-secret)
                                    {:max-age three-minutes-in-seconds})
                        (catch Throwable e
-                         (throw (ex-info (tru "Couldn't unsign JWT")
+                         (throw (ex-info (ex-message e)
                                          {:status-code 401}
                                          e))))
         login-attrs  (jwt-data->login-attributes jwt-data)

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
@@ -103,7 +103,7 @@
   (testing "Check an expired JWT"
     (with-jwt-default-setup
       (is (= "Token is older than max-age (180)"
-             (:message (saml-test/client :get 500 "/auth/sso" {:request-options {:redirect-strategy :none}}
+             (:message (saml-test/client :get 401 "/auth/sso" {:request-options {:redirect-strategy :none}}
                                          :return_to default-redirect-uri
                                          :jwt (jwt/sign {:email "test@metabase.com", :first_name "Test" :last_name "User"
                                                          :iat   (- (buddy-util/now) (u/minutes->seconds 5))}

--- a/test/metabase/api/session_test.clj
+++ b/test/metabase/api/session_test.clj
@@ -244,7 +244,6 @@
         (dotimes [n 10]
           (send-password-reset))
         (let [error (fn []
-                      ; TODO (noahmoss) do I need to change this?
                       (-> (send-password-reset 400)
                           :errors
                           :email))]

--- a/test/metabase/api/session_test.clj
+++ b/test/metabase/api/session_test.clj
@@ -86,11 +86,11 @@
     (testing "Test for inactive user (user shouldn't be able to login if :is_active = false)"
       ;; Return same error as incorrect password to avoid leaking existence of user
       (is (= {:errors {:password "did not match stored password"}}
-             (mt/client :post 400 "session" (mt/user->credentials :trashbird)))))
+             (mt/client :post 401 "session" (mt/user->credentials :trashbird)))))
 
     (testing "Test for password checking"
       (is (= {:errors {:password "did not match stored password"}}
-             (mt/client :post 400 "session" (-> (mt/user->credentials :rasta)
+             (mt/client :post 401 "session" (-> (mt/user->credentials :rasta)
                                              (assoc :password "something else"))))))))
 
 (deftest login-throttling-test
@@ -98,7 +98,7 @@
                 " throttling works at the API level -- more tests in the throttle library itself:"
                 " https://github.com/metabase/throttle)")
     (let [login (fn []
-                  (-> (mt/client :post 400 "session" {:username "fakeaccount3000@metabase.com", :password "toucans"})
+                  (-> (mt/client :post 401 "session" {:username "fakeaccount3000@metabase.com", :password "toucans"})
                       :errors
                       :username))]
       ;; attempt to log in 10 times
@@ -143,7 +143,7 @@
         (let [response    (send-login-request (format "user-%d" n)
                                               {"x-forwarded-for" "10.1.2.3"})
               status-code (:status response)]
-          (assert (= status-code 400) (str "Unexpected response status code:" status-code))))
+          (assert (= status-code 401) (str "Unexpected response status code:" status-code))))
       (let [error (fn []
                     (-> (send-login-request "last-user" {"x-forwarded-for" "10.1.2.3"})
                         :body
@@ -163,11 +163,11 @@
         (let [response    (send-login-request (format "user-%d" n)
                                               {"x-forwarded-for" "10.1.2.3"})
               status-code (:status response)]
-          (assert (= status-code 400) (str "Unexpected response status code:" status-code))))
+          (assert (= status-code 401) (str "Unexpected response status code:" status-code))))
       (dotimes [n 50]
         (let [response    (send-login-request (format "round2-user-%d" n)) ; no x-forwarded-for
               status-code (:status response)]
-          (assert (= status-code 400) (str "Unexpected response status code:" status-code))))
+          (assert (= status-code 401) (str "Unexpected response status code:" status-code))))
       (let [error (fn []
                     (-> (send-login-request "last-user" {"x-forwarded-for" "10.1.2.3"})
                         :body
@@ -244,6 +244,7 @@
         (dotimes [n 10]
           (send-password-reset))
         (let [error (fn []
+                      ; TODO (noahmoss) do I need to change this?
                       (-> (send-password-reset 400)
                           :errors
                           :email))]
@@ -276,7 +277,7 @@
                                                                          :password (:new password)}))))
               (testing "Old creds should no longer work"
                 (is (= {:errors {:password "did not match stored password"}}
-                       (mt/client :post 400 "session" (:old creds)))))
+                       (mt/client :post 401 "session" (:old creds)))))
               (testing "New creds *should* work"
                 (is (schema= SessionResponse
                              (mt/client :post 200 "session" (:new creds)))))
@@ -541,12 +542,12 @@
       (testing "...but not if password login is disabled"
         (mt/with-temporary-setting-values [enable-password-login false]
           (is (= "Password login is disabled for this instance."
-                 (mt/client :post 400 "session" (mt/user->credentials :crowberto)))))))
+                 (mt/client :post 401 "session" (mt/user->credentials :crowberto)))))))
 
     (testing "Test that login will NOT fallback for users in LDAP but with an invalid password"
       ;; NOTE: there's a different password in LDAP for Lucky
       (is (= {:errors {:password "did not match stored password"}}
-             (mt/client :post 400 "session" (mt/user->credentials :lucky)))))
+             (mt/client :post 401 "session" (mt/user->credentials :lucky)))))
 
     (testing "Test that login will fallback to local for broken LDAP settings"
       (mt/with-temporary-setting-values [ldap-user-base "cn=wrong,cn=com"]

--- a/test/metabase/http_client.clj
+++ b/test/metabase/http_client.clj
@@ -230,9 +230,7 @@
 
 (def ^:private response-timeout-ms
   ;; CircleCI is crazy slow and likes to randomly pause, so use a much larger timeout when running on CI
-  (u/seconds->ms (if (env/env :ci)
-                   45
-                   15)))
+  (u/seconds->ms 45))
 
 (defn client-full-response
   "Identical to `client` except returns the full HTTP response map, not just the body of the response"

--- a/test/metabase/http_client.clj
+++ b/test/metabase/http_client.clj
@@ -250,7 +250,7 @@
 
   Examples:
 
-    (client :get 200 \"card/1\")                ; GET  http://localhost:3000/api/card/1, throw exception is status code != 200
+    (client :get 200 \"card/1\")                ; GET  http://localhost:3000/api/card/1, throw exception if status code != 200
     (client :get \"card\" :org 1)               ; GET  http://localhost:3000/api/card?org=1
     (client :post \"card\" {:name \"My Card\"}) ; POST http://localhost:3000/api/card with JSON-encoded body {:name \"My Card\"}
 

--- a/test/metabase/http_client.clj
+++ b/test/metabase/http_client.clj
@@ -228,9 +228,7 @@
      :query-parameters query-parameters
      :request-options  request-options}))
 
-(def ^:private response-timeout-ms
-  ;; CircleCI is crazy slow and likes to randomly pause, so use a much larger timeout when running on CI
-  (u/seconds->ms 45))
+(def ^:private response-timeout-ms (u/seconds->ms 45))
 
 (defn client-full-response
   "Identical to `client` except returns the full HTTP response map, not just the body of the response"


### PR DESCRIPTION
Changed HTTP 400 (bad request) response to 401 (unauthorized) in relevant places for better compliance with the HTTP spec. Also fixed a typo in an `http_client` comment.

Resolves #13140