### PR TITLE
let users create moderation reviews via saved question sidebar

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/CreateModerationIssuePanel.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/CreateModerationIssuePanel.jsx
@@ -4,7 +4,6 @@ import { MODERATION_TEXT } from "metabase-enterprise/moderation/constants";
 import {
   getModerationStatusIcon,
   getColor,
-  getModerationStatus,
 } from "metabase-enterprise/moderation";
 import Icon from "metabase/components/Icon";
 import Button from "metabase/components/Button";

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/CreateModerationIssuePanel.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/CreateModerationIssuePanel.jsx
@@ -10,7 +10,7 @@ import Button from "metabase/components/Button";
 
 CreateModerationIssuePanel.propTypes = {
   issueType: PropTypes.string.isRequired,
-  onCancel: PropTypes.func.isRequired,
+  onReturn: PropTypes.func.isRequired,
   createModerationReview: PropTypes.func.isRequired,
   itemId: PropTypes.number.isRequired,
   itemType: PropTypes.string.isRequired,
@@ -18,24 +18,31 @@ CreateModerationIssuePanel.propTypes = {
 
 function CreateModerationIssuePanel({
   issueType,
-  onCancel,
+  onReturn,
   createModerationReview,
   itemId,
   itemType,
 }) {
   const [description, setDescription] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
   const icon = getModerationStatusIcon(issueType);
   const color = getColor(issueType);
 
-  const onCreateModerationReview = e => {
+  const onCreateModerationReview = async e => {
     e.preventDefault();
-    console.log("onCreateModerationReview");
-    // createModerationReview({
-    //   // TODO: I should redo the ACTIONS map to be keyed by statuses
-    //   status: getModerationStatus(issueType),
-    //   moderated_item_id: itemId,
-    //   moderated_item_type: itemType,
-    // });
+    setIsLoading(true);
+
+    try {
+      await createModerationReview({
+        status: issueType,
+        moderated_item_id: itemId,
+        moderated_item_type: itemType,
+      });
+
+      onReturn();
+    } catch (e) {
+      setIsLoading(false);
+    }
   };
 
   return (
@@ -61,12 +68,13 @@ function CreateModerationIssuePanel({
         value={description}
         onChange={e => setDescription(e.target.value)}
         placeholder={MODERATION_TEXT.actionCreationPlaceholder}
+        name="text"
       />
       <div className="flex column-gap-1 justify-end">
-        <Button type="button" onClick={onCancel}>
+        <Button disabled={isLoading} type="button" onClick={onReturn}>
           {MODERATION_TEXT.cancel}
         </Button>
-        <Button type="submit" primary>
+        <Button disabled={isLoading} type="submit" primary>
           {MODERATION_TEXT.moderator[issueType].actionCreationButton}
         </Button>
       </div>

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/CreateModerationIssuePanel.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/CreateModerationIssuePanel.jsx
@@ -4,14 +4,38 @@ import { MODERATION_TEXT } from "metabase-enterprise/moderation/constants";
 import {
   getModerationStatusIcon,
   getColor,
+  getModerationStatus,
 } from "metabase-enterprise/moderation";
 import Icon from "metabase/components/Icon";
 import Button from "metabase/components/Button";
 
-function CreateModerationIssuePanel({ issueType, onCancel }) {
+CreateModerationIssuePanel.propTypes = {
+  issueType: PropTypes.string.isRequired,
+  onCancel: PropTypes.func.isRequired,
+  createModerationReview: PropTypes.func.isRequired,
+  itemId: PropTypes.number.isRequired,
+  itemType: PropTypes.string.isRequired,
+};
+
+function CreateModerationIssuePanel({
+  issueType,
+  onCancel,
+  createModerationReview,
+  itemId,
+  itemType,
+}) {
   const [description, setDescription] = useState("");
   const icon = getModerationStatusIcon(issueType);
   const color = getColor(issueType);
+
+  const onCreateModerationReview = () => {
+    createModerationReview({
+      // TODO: I should redo the ACTIONS map to be keyed by statuses
+      status: getModerationStatus(issueType),
+      moderated_item_id: itemId,
+      moderated_item_type: itemType,
+    });
+  };
 
   return (
     <div className="p2 flex flex-column row-gap-2">
@@ -43,10 +67,5 @@ function CreateModerationIssuePanel({ issueType, onCancel }) {
     </div>
   );
 }
-
-CreateModerationIssuePanel.propTypes = {
-  issueType: PropTypes.string.isRequired,
-  onCancel: PropTypes.func.isRequired,
-};
 
 export default CreateModerationIssuePanel;

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/CreateModerationIssuePanel.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/CreateModerationIssuePanel.jsx
@@ -28,17 +28,22 @@ function CreateModerationIssuePanel({
   const icon = getModerationStatusIcon(issueType);
   const color = getColor(issueType);
 
-  const onCreateModerationReview = () => {
-    createModerationReview({
-      // TODO: I should redo the ACTIONS map to be keyed by statuses
-      status: getModerationStatus(issueType),
-      moderated_item_id: itemId,
-      moderated_item_type: itemType,
-    });
+  const onCreateModerationReview = e => {
+    e.preventDefault();
+    console.log("onCreateModerationReview");
+    // createModerationReview({
+    //   // TODO: I should redo the ACTIONS map to be keyed by statuses
+    //   status: getModerationStatus(issueType),
+    //   moderated_item_id: itemId,
+    //   moderated_item_type: itemType,
+    // });
   };
 
   return (
-    <div className="p2 flex flex-column row-gap-2">
+    <form
+      onSubmit={onCreateModerationReview}
+      className="p2 flex flex-column row-gap-2"
+    >
       <div className="flex align-center">
         <Icon className="mr1" name={icon} size={18} />
         <span className={`text-${color} text-bold`}>
@@ -59,12 +64,14 @@ function CreateModerationIssuePanel({
         placeholder={MODERATION_TEXT.actionCreationPlaceholder}
       />
       <div className="flex column-gap-1 justify-end">
-        <Button onClick={onCancel}>{MODERATION_TEXT.cancel}</Button>
-        <Button primary>
+        <Button type="button" onClick={onCancel}>
+          {MODERATION_TEXT.cancel}
+        </Button>
+        <Button type="submit" primary>
           {MODERATION_TEXT.moderator[issueType].actionCreationButton}
         </Button>
       </div>
-    </div>
+    </form>
   );
 }
 

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/CreateModerationIssuePanel.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/CreateModerationIssuePanel.jsx
@@ -1,5 +1,7 @@
 import React, { useState } from "react";
 import PropTypes from "prop-types";
+
+import { useAsyncFunction } from "metabase/lib/hooks";
 import { MODERATION_TEXT } from "metabase-enterprise/moderation/constants";
 import {
   getModerationStatusIcon,
@@ -19,30 +21,28 @@ CreateModerationIssuePanel.propTypes = {
 function CreateModerationIssuePanel({
   issueType,
   onReturn,
-  createModerationReview,
+  createModerationReview: _createModerationReview,
   itemId,
   itemType,
 }) {
   const [description, setDescription] = useState("");
-  const [isLoading, setIsLoading] = useState(false);
   const icon = getModerationStatusIcon(issueType);
   const color = getColor(issueType);
 
+  const [createModerationReview, isPending] = useAsyncFunction(
+    _createModerationReview,
+  );
+
   const onCreateModerationReview = async e => {
     e.preventDefault();
-    setIsLoading(true);
 
-    try {
-      await createModerationReview({
-        status: issueType,
-        moderated_item_id: itemId,
-        moderated_item_type: itemType,
-      });
+    await createModerationReview({
+      status: issueType,
+      moderated_item_id: itemId,
+      moderated_item_type: itemType,
+    });
 
-      onReturn();
-    } catch (e) {
-      setIsLoading(false);
-    }
+    onReturn();
   };
 
   return (
@@ -71,10 +71,10 @@ function CreateModerationIssuePanel({
         name="text"
       />
       <div className="flex column-gap-1 justify-end">
-        <Button disabled={isLoading} type="button" onClick={onReturn}>
+        <Button disabled={isPending} type="button" onClick={onReturn}>
           {MODERATION_TEXT.cancel}
         </Button>
-        <Button disabled={isLoading} type="submit" primary>
+        <Button disabled={isPending} type="submit" primary>
           {MODERATION_TEXT.moderator[issueType].actionCreationButton}
         </Button>
       </div>

--- a/enterprise/frontend/src/metabase-enterprise/moderation/constants.js
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/constants.js
@@ -3,20 +3,18 @@ import { t } from "ttag";
 // TODO: I should redo the ACTIONS map to be keyed by statuses
 // `verification` has no meaning to the BE -- it's status: "verified"
 export const ACTIONS = {
-  verification: {
-    type: "verification",
+  verified: {
+    type: "verified",
     icon: "verified",
     color: "brand",
-    moderationReviewStatus: "verified",
   },
-  flag: {
-    type: "flag",
+  misleading: {
+    type: "misleading",
     icon: "warning_colorized",
     color: "accent5",
-    moderationReviewStatus: "misleading",
   },
-  question: {
-    type: "question",
+  confused: {
+    type: "confused",
     icon: "clarification",
     color: "accent2",
     moderationReviewStatus: "confusing",
@@ -27,25 +25,25 @@ export const MODERATION_TEXT = {
   cancel: t`Cancel`,
   actionCreationPlaceholder: t`You can add details if you'd like`,
   user: {
-    verification: {},
+    verified: {},
     flag: {},
-    question: {},
+    confused: {},
   },
   moderator: {
     action: t`Moderate`,
-    verification: {
+    verified: {
       action: t`Verify this`,
-      actionCreationDescription: t`Everything look correct here? Verify this question to let others know.`,
+      actionCreationDescription: t`Everything look correct here? Verify this confused to let others know.`,
       actionCreationLabel: t`Add a note if you’d like`,
       actionCreationButton: t`Verify`,
     },
-    flag: {
+    misleading: {
       action: t`This is misleading`,
-      actionCreationDescription: t`Add a warning badge to this question and notify its editors that something’s off here.`,
+      actionCreationDescription: t`Add a warning badge to this confused and notify its editors that something’s off here.`,
       actionCreationLabel: t`Explain what’s wrong or misleading`,
       actionCreationButton: t`Flag as misleading`,
     },
-    question: {
+    confused: {
       action: t`This is confusing`,
       actionCreationDescription: "need text 1",
       actionCreationLabel: "need text 2",

--- a/enterprise/frontend/src/metabase-enterprise/moderation/constants.js
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/constants.js
@@ -1,20 +1,25 @@
 import { t } from "ttag";
 
+// TODO: I should redo the ACTIONS map to be keyed by statuses
+// `verification` has no meaning to the BE -- it's status: "verified"
 export const ACTIONS = {
   verification: {
     type: "verification",
     icon: "verified",
     color: "brand",
+    moderationReviewStatus: "verified",
   },
   flag: {
     type: "flag",
     icon: "warning_colorized",
     color: "accent5",
+    moderationReviewStatus: "misleading",
   },
   question: {
     type: "question",
     icon: "clarification",
     color: "accent2",
+    moderationReviewStatus: "confusing",
   },
 };
 

--- a/enterprise/frontend/src/metabase-enterprise/moderation/constants.js
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/constants.js
@@ -1,7 +1,5 @@
 import { t } from "ttag";
 
-// TODO: I should redo the ACTIONS map to be keyed by statuses
-// `verification` has no meaning to the BE -- it's status: "verified"
 export const ACTIONS = {
   verified: {
     type: "verified",
@@ -13,8 +11,8 @@ export const ACTIONS = {
     icon: "warning_colorized",
     color: "accent5",
   },
-  confused: {
-    type: "confused",
+  confusing: {
+    type: "confusing",
     icon: "clarification",
     color: "accent2",
     moderationReviewStatus: "confusing",
@@ -27,23 +25,23 @@ export const MODERATION_TEXT = {
   user: {
     verified: {},
     flag: {},
-    confused: {},
+    confusing: {},
   },
   moderator: {
     action: t`Moderate`,
     verified: {
       action: t`Verify this`,
-      actionCreationDescription: t`Everything look correct here? Verify this confused to let others know.`,
+      actionCreationDescription: t`Everything look correct here? Verify this question to let others know.`,
       actionCreationLabel: t`Add a note if you’d like`,
       actionCreationButton: t`Verify`,
     },
     misleading: {
       action: t`This is misleading`,
-      actionCreationDescription: t`Add a warning badge to this confused and notify its editors that something’s off here.`,
+      actionCreationDescription: t`Add a warning badge to this question and notify its editors that something’s off here.`,
       actionCreationLabel: t`Explain what’s wrong or misleading`,
       actionCreationButton: t`Flag as misleading`,
     },
-    confused: {
+    confusing: {
       action: t`This is confusing`,
       actionCreationDescription: "need text 1",
       actionCreationLabel: "need text 2",

--- a/enterprise/frontend/src/metabase-enterprise/moderation/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/index.js
@@ -13,11 +13,20 @@ Object.assign(PLUGIN_MODERATION_COMPONENTS, {
 });
 
 Object.assign(PLUGIN_MODERATION_SERVICE, {
-  getModerationStatusIcon,
+  getStatusIconForReview,
+  getColorForReview,
 });
 
 export function getModerationActionsList() {
-  return [ACTIONS.verified, ACTIONS.misleading, ACTIONS.confused];
+  return [ACTIONS.verified, ACTIONS.misleading, ACTIONS.confusing];
+}
+
+export function getStatusIconForReview(review) {
+  return getModerationStatusIcon(review && review.status);
+}
+
+export function getColorForReview(review) {
+  return getColor(review && review.status);
 }
 
 export function getModerationStatusIcon(type) {

--- a/enterprise/frontend/src/metabase-enterprise/moderation/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/index.js
@@ -17,7 +17,7 @@ Object.assign(PLUGIN_MODERATION_SERVICE, {
 });
 
 export function getModerationActionsList() {
-  return [ACTIONS.verification, ACTIONS.flag, ACTIONS.question];
+  return [ACTIONS.verified, ACTIONS.misleading, ACTIONS.confused];
 }
 
 export function getModerationStatusIcon(type) {
@@ -26,8 +26,4 @@ export function getModerationStatusIcon(type) {
 
 export function getColor(type) {
   return getIn(ACTIONS, [type, "color"]);
-}
-
-export function getModerationStatus(type) {
-  return getIn(ACTIONS, [type, "moderationReviewStatus"]);
 }

--- a/enterprise/frontend/src/metabase-enterprise/moderation/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/index.js
@@ -1,3 +1,4 @@
+import { getIn } from "icepick";
 import {
   PLUGIN_MODERATION_COMPONENTS,
   PLUGIN_MODERATION_SERVICE,
@@ -20,11 +21,13 @@ export function getModerationActionsList() {
 }
 
 export function getModerationStatusIcon(type) {
-  const { icon } = ACTIONS[type] || {};
-  return icon;
+  return getIn(ACTIONS, [type, "icon"]);
 }
 
 export function getColor(type) {
-  const { color } = ACTIONS[type] || {};
-  return color;
+  return getIn(ACTIONS, [type, "color"]);
+}
+
+export function getModerationStatus(type) {
+  return getIn(ACTIONS, [type, "moderationReviewStatus"]);
 }

--- a/frontend/src/metabase-lib/lib/Question.js
+++ b/frontend/src/metabase-lib/lib/Question.js
@@ -1,5 +1,5 @@
 import _ from "underscore";
-import { chain, assoc, dissoc, assocIn } from "icepick";
+import { chain, assoc, dissoc, assocIn, getIn } from "icepick";
 
 // NOTE: the order of these matters due to circular dependency issues
 import StructuredQuery, {
@@ -979,6 +979,14 @@ export default class Question {
       : this.markDirty(); // forces use of serialized question url
     const query = this.isNative() ? this._parameterValues : undefined;
     return question.getUrl({ originalQuestion: this, query });
+  }
+
+  getModerationReviews() {
+    return getIn(this, ["_card", "moderation_reviews"]);
+  }
+
+  getLatestModerationReview() {
+    return _.last(this.getModerationReviews);
   }
 }
 

--- a/frontend/src/metabase-lib/lib/Question.js
+++ b/frontend/src/metabase-lib/lib/Question.js
@@ -986,7 +986,7 @@ export default class Question {
   }
 
   getLatestModerationReview() {
-    return _.last(this.getModerationReviews);
+    return _.last(this.getModerationReviews());
   }
 }
 

--- a/frontend/src/metabase/lib/hooks.js
+++ b/frontend/src/metabase/lib/hooks.js
@@ -1,0 +1,34 @@
+import { useRef, useEffect, useMemo, useState } from "react";
+
+export function useAsyncFunction(fn) {
+  const [isPending, setIsPending] = useState(false);
+  const isUnmountedRef = useRef(false);
+
+  useEffect(() => {
+    () => {
+      isUnmountedRef.current = true;
+    };
+  }, []);
+
+  const safeFn = useMemo(() => {
+    return (...args) =>
+      new Promise((resolve, reject) => {
+        setIsPending(true);
+        return fn(...args)
+          .then(res => {
+            if (!isUnmountedRef.current) {
+              resolve(res);
+            }
+            setIsPending(false);
+          })
+          .catch(err => {
+            if (!isUnmountedRef.current) {
+              reject(err);
+            }
+            setIsPending(false);
+          });
+      });
+  }, [fn]);
+
+  return [safeFn, isPending];
+}

--- a/frontend/src/metabase/lib/hooks.js
+++ b/frontend/src/metabase/lib/hooks.js
@@ -1,11 +1,13 @@
 import { useRef, useEffect, useMemo, useState } from "react";
 
+// wraps the given async function in a promise that does not resolve
+// after the component has unmounted
 export function useAsyncFunction(fn) {
   const [isPending, setIsPending] = useState(false);
   const isUnmountedRef = useRef(false);
 
   useEffect(() => {
-    () => {
+    return () => {
       isUnmountedRef.current = true;
     };
   }, []);
@@ -17,15 +19,15 @@ export function useAsyncFunction(fn) {
         return fn(...args)
           .then(res => {
             if (!isUnmountedRef.current) {
+              setIsPending(false);
               resolve(res);
             }
-            setIsPending(false);
           })
           .catch(err => {
             if (!isUnmountedRef.current) {
+              setIsPending(false);
               reject(err);
             }
-            setIsPending(false);
           });
       });
   }, [fn]);

--- a/frontend/src/metabase/plugins/index.js
+++ b/frontend/src/metabase/plugins/index.js
@@ -63,5 +63,6 @@ export const PLUGIN_MODERATION_COMPONENTS = {
 };
 
 export const PLUGIN_MODERATION_SERVICE = {
-  getModerationStatusIcon: _.noop,
+  getStatusIconForReview: _.noop,
+  getColorForReview: _.noop,
 };

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -53,7 +53,12 @@ import {
   getSnippetCollectionId,
 } from "./selectors";
 
-import { MetabaseApi, CardApi, UserApi } from "metabase/services";
+import {
+  MetabaseApi,
+  CardApi,
+  UserApi,
+  ModerationReviewApi,
+} from "metabase/services";
 
 import { parse as urlParse } from "url";
 import querystring from "querystring";
@@ -1364,3 +1369,8 @@ export const showChartSettings = createAction(SHOW_CHART_SETTINGS);
 // these are just temporary mappings to appease the existing QB code and it's naming prefs
 export const onUpdateVisualizationSettings = updateCardVisualizationSettings;
 export const onReplaceAllVisualizationSettings = replaceAllCardVisualizationSettings;
+
+export async function createModerationReview(reviewParams) {
+  await ModerationReviewApi.create(reviewParams);
+  return reloadCard();
+}

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -734,6 +734,7 @@ export const setParameterValue = createAction(
   },
 );
 
+// refetches the card without triggering a run of the card's query
 export const SOFT_RELOAD_CARD = "metabase/qb/SOFT_RELOAD_CARD";
 export const softReloadCard = createThunkAction(SOFT_RELOAD_CARD, () => {
   return async (dispatch, getState) => {

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -734,6 +734,17 @@ export const setParameterValue = createAction(
   },
 );
 
+export const SOFT_RELOAD_CARD = "metabase/qb/SOFT_RELOAD_CARD";
+export const softReloadCard = createThunkAction(SOFT_RELOAD_CARD, () => {
+  return async (dispatch, getState) => {
+    const card = getState().qb.card;
+    const action = await dispatch(
+      Questions.actions.fetch({ id: card.id }, { reload: true }),
+    );
+    return Questions.HACK_getObjectFromAction(action);
+  };
+});
+
 // reloadCard
 export const RELOAD_CARD = "metabase/qb/RELOAD_CARD";
 export const reloadCard = createThunkAction(RELOAD_CARD, () => {
@@ -1372,5 +1383,5 @@ export const onReplaceAllVisualizationSettings = replaceAllCardVisualizationSett
 
 export async function createModerationReview(reviewParams) {
   await ModerationReviewApi.create(reviewParams);
-  return reloadCard();
+  return softReloadCard();
 }

--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -106,6 +106,7 @@ export default class View extends React.Component {
       fitClassNames,
       height,
       onOpenModal,
+      createModerationReview,
     } = this.props;
     const {
       aggregationIndex,
@@ -160,7 +161,11 @@ export default class View extends React.Component {
     ) : isShowingChartTypeSidebar ? (
       <ChartTypeSidebar {...this.props} onClose={this.props.onCloseChartType} />
     ) : isShowingQuestionDetailsSidebar ? (
-      <QuestionDetailsSidebar question={question} onOpenModal={onOpenModal} />
+      <QuestionDetailsSidebar
+        question={question}
+        onOpenModal={onOpenModal}
+        createModerationReview={createModerationReview}
+      />
     ) : null;
 
     const rightSideBar =

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebar.jsx
@@ -28,7 +28,7 @@ function QuestionDetailsSidebar({
       return (
         <CreateModerationIssuePanel
           {...viewProps}
-          onCancel={() => setView({ name: SIDEBAR_VIEWS.DETAILS })}
+          onReturn={() => setView({ name: SIDEBAR_VIEWS.DETAILS })}
           createModerationReview={createModerationReview}
           itemId={id}
           itemType="card"

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebar.jsx
@@ -1,15 +1,27 @@
 import React, { useState } from "react";
+import PropTypes from "prop-types";
 import QuestionDetailsSidebarPanel from "metabase/query_builder/components/view/sidebars/QuestionDetailsSidebarPanel";
 import { PLUGIN_MODERATION_COMPONENTS } from "metabase/plugins";
 import { SIDEBAR_VIEWS } from "./constants";
 const { CreateModerationIssuePanel } = PLUGIN_MODERATION_COMPONENTS;
 
-function QuestionDetailsSidebar(props) {
+QuestionDetailsSidebar.propTypes = {
+  question: PropTypes.object.isRequired,
+  onOpenModal: PropTypes.func.isRequired,
+  createModerationReview: PropTypes.func.isRequired,
+};
+
+function QuestionDetailsSidebar({
+  question,
+  onOpenModal,
+  createModerationReview,
+}) {
   const [view, setView] = useState({
     name: undefined,
     props: undefined,
   });
   const { name, props: viewProps } = view;
+  const id = question.id();
 
   switch (name) {
     case SIDEBAR_VIEWS.CREATE_ISSUE_PANEL:
@@ -17,11 +29,20 @@ function QuestionDetailsSidebar(props) {
         <CreateModerationIssuePanel
           {...viewProps}
           onCancel={() => setView({ name: SIDEBAR_VIEWS.DETAILS })}
+          createModerationReview={createModerationReview}
+          itemId={id}
+          itemType="card"
         />
       );
     case SIDEBAR_VIEWS.DETAILS:
     default:
-      return <QuestionDetailsSidebarPanel setView={setView} {...props} />;
+      return (
+        <QuestionDetailsSidebarPanel
+          setView={setView}
+          question={question}
+          onOpenModal={onOpenModal}
+        />
+      );
   }
 }
 

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
@@ -278,11 +278,8 @@ export default class QueryBuilder extends Component {
       uiControls: { modal, recentlySaved },
     } = this.props;
 
-    // const Panel = queryBuilderMode === "notebook" ? Notebook : View;
-    const Panel = View;
-
     return (
-      <Panel
+      <View
         {...this.props}
         // NOTE: these were lifted from QueryHeader. Move to Redux?
         modal={modal}

--- a/frontend/src/metabase/query_builder/reducers.js
+++ b/frontend/src/metabase/query_builder/reducers.js
@@ -13,6 +13,7 @@ import {
   SET_MODAL_SNIPPET,
   SET_SNIPPET_COLLECTION_ID,
   CLOSE_QB_NEWB_MODAL,
+  SOFT_RELOAD_CARD,
   RELOAD_CARD,
   API_CREATE_QUESTION,
   API_UPDATE_QUESTION,
@@ -232,6 +233,7 @@ export const card = handleActions(
     [INITIALIZE_QB]: {
       next: (state, { payload }) => (payload ? payload.card : null),
     },
+    [SOFT_RELOAD_CARD]: { next: (state, { payload }) => payload },
     [RELOAD_CARD]: { next: (state, { payload }) => payload },
     [SET_CARD_AND_RUN]: { next: (state, { payload }) => payload.card },
     [API_CREATE_QUESTION]: { next: (state, { payload }) => payload },

--- a/frontend/src/metabase/questions/components/SavedQuestionHeaderButton.jsx
+++ b/frontend/src/metabase/questions/components/SavedQuestionHeaderButton.jsx
@@ -1,11 +1,12 @@
 import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
+import cx from "classnames";
 
 import Button from "metabase/components/Button";
 
 import { PLUGIN_MODERATION_SERVICE } from "metabase/plugins";
-const { getModerationStatusIcon } = PLUGIN_MODERATION_SERVICE;
+const { getStatusIconForReview, getColorForReview } = PLUGIN_MODERATION_SERVICE;
 
 const StyledButton = styled(Button)`
   font-size: 1.25rem;
@@ -19,15 +20,15 @@ const StyledButton = styled(Button)`
 
 function SavedQuestionHeaderButton({ className, question, onClick, active }) {
   const latestModerationReview = question.getLatestModerationReview();
+  const color = getColorForReview(latestModerationReview);
+  const icon = getStatusIconForReview(latestModerationReview);
+
   return (
     <StyledButton
-      className={className}
+      className={cx(className, color && `text-${color}`)}
       onClick={onClick}
       iconRight="chevrondown"
-      icon={
-        latestModerationReview &&
-        getModerationStatusIcon(latestModerationReview.status)
-      }
+      icon={icon}
       active={active}
       iconSize={24}
     >

--- a/frontend/src/metabase/questions/components/SavedQuestionHeaderButton.jsx
+++ b/frontend/src/metabase/questions/components/SavedQuestionHeaderButton.jsx
@@ -31,6 +31,7 @@ function SavedQuestionHeaderButton({ className, question, onClick, active }) {
       icon={icon}
       active={active}
       iconSize={24}
+      data-testid="saved-question-header-button"
     >
       {question.displayName()}
     </StyledButton>

--- a/frontend/src/metabase/questions/components/SavedQuestionHeaderButton.jsx
+++ b/frontend/src/metabase/questions/components/SavedQuestionHeaderButton.jsx
@@ -5,6 +5,7 @@ import styled from "styled-components";
 import Button from "metabase/components/Button";
 
 import { PLUGIN_MODERATION_SERVICE } from "metabase/plugins";
+const { getModerationStatusIcon } = PLUGIN_MODERATION_SERVICE;
 
 const StyledButton = styled(Button)`
   font-size: 1.25rem;
@@ -17,14 +18,16 @@ const StyledButton = styled(Button)`
 `;
 
 function SavedQuestionHeaderButton({ className, question, onClick, active }) {
-  // this will shortly become something like `question.getModerationStatus()`
-  const moderationStatus = "verification";
+  const latestModerationReview = question.getLatestModerationReview();
   return (
     <StyledButton
       className={className}
       onClick={onClick}
       iconRight="chevrondown"
-      icon={PLUGIN_MODERATION_SERVICE.getModerationStatusIcon(moderationStatus)}
+      icon={
+        latestModerationReview &&
+        getModerationStatusIcon(latestModerationReview.status)
+      }
       active={active}
       iconSize={24}
     >

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -307,6 +307,10 @@ export const MetabaseApi = {
   }),
 };
 
+export const ModerationReviewApi = {
+  create: POST("/api/moderation-review"),
+};
+
 export const PulseApi = {
   list: GET("/api/pulse"),
   create: POST("/api/pulse"),

--- a/frontend/test/metabase/scenarios/question/saved.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/saved.cy.spec.js
@@ -94,7 +94,9 @@ describe("scenarios > question > saved", () => {
     cy.visit("/question/1");
     cy.wait("@query");
 
-    cy.get(".Button").find(".Icon-chevrondown").click();
+    cy.get(".Button")
+      .find(".Icon-chevrondown")
+      .click();
     cy.get(".Icon-clone").click();
 
     modal().within(() => {

--- a/frontend/test/metabase/scenarios/question/saved.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/saved.cy.spec.js
@@ -94,10 +94,8 @@ describe("scenarios > question > saved", () => {
     cy.visit("/question/1");
     cy.wait("@query");
 
-    cy.get(".Button")
-      .find(".Icon-chevrondown")
-      .click();
-    cy.get(".Icon-clone").click();
+    cy.findByTestId("saved-question-header-button").click();
+    cy.icon("clone").click();
 
     modal().within(() => {
       cy.findByLabelText("Name").should("have.value", "Orders - Duplicate");


### PR DESCRIPTION
Lets users create a `moderation-review` for a saved questioned. Eventually will be locked to moderators only. Can't see the text associated with a review right now but can see the latest review status by the change in the saved question header icon.

![dj-bucm-wire-up](https://user-images.githubusercontent.com/13057258/117186124-6288e780-ad8f-11eb-8c9d-3a477014d873.gif)
