### PR TITLE
Custom expression suggestion: refactor the logic for partial matching

### DIFF
--- a/frontend/src/metabase/lib/expressions/completer.js
+++ b/frontend/src/metabase/lib/expressions/completer.js
@@ -1,0 +1,21 @@
+import { tokenize, TOKEN } from "./tokenizer";
+import _ from "underscore";
+
+// Given an expression, get the last identifier as the prefix match.
+// Examples:
+//  "Lower" returns "Lower"
+//  "3 > [Rat" returns "[Rat"
+//  "[Expensive] " returns null (because of the whitespace)
+//  "IsNull([Tax])" returns null (last token is an operator)
+
+export function partialMatch(expression) {
+  const { tokens } = tokenize(expression);
+  const lastToken = _.last(tokens);
+  if (lastToken && lastToken.type === TOKEN.Identifier) {
+    if (lastToken.end === expression.length) {
+      return expression.slice(lastToken.start, lastToken.end);
+    }
+  }
+
+  return null;
+}

--- a/frontend/test/metabase/lib/expressions/completer.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/completer.unit.spec.js
@@ -1,0 +1,31 @@
+import { partialMatch } from "metabase/lib/expressions/completer";
+
+describe("metabase/lib/expressions/completer", () => {
+  describe("partialMatch", () => {
+    it("should get the function name", () => {
+      expect(partialMatch("Lowe")).toEqual("Lowe");
+      expect(partialMatch("NOT (ISNULL")).toEqual("ISNULL");
+    });
+
+    it("should get the field name", () => {
+      expect(partialMatch("[Deal]")).toEqual("[Deal]");
+      expect(partialMatch("A")).toEqual("A");
+      expect(partialMatch("B AND [Ca")).toEqual("[Ca");
+      expect(partialMatch("[Sale] or [Good]")).toEqual("[Good]");
+      expect(partialMatch("[")).toEqual("[");
+    });
+
+    it("should ignore operators and literals", () => {
+      expect(partialMatch("X OR")).toEqual(null);
+      expect(partialMatch("42 + ")).toEqual(null);
+      expect(partialMatch("3.14")).toEqual(null);
+      expect(partialMatch('"Hello')).toEqual(null);
+      expect(partialMatch("'world")).toEqual(null);
+    });
+
+    it("should handle empty input", () => {
+      expect(partialMatch("")).toEqual(null);
+      expect(partialMatch(" ")).toEqual(null);
+    });
+  });
+});

--- a/frontend/test/metabase/lib/expressions/completer.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/completer.unit.spec.js
@@ -17,7 +17,7 @@ describe("metabase/lib/expressions/completer", () => {
 
     it("should ignore operators and literals", () => {
       expect(partialMatch("X OR")).toEqual(null);
-      expect(partialMatch("42 + ")).toEqual(null);
+      expect(partialMatch("42 +")).toEqual(null);
       expect(partialMatch("3.14")).toEqual(null);
       expect(partialMatch('"Hello')).toEqual(null);
       expect(partialMatch("'world")).toEqual(null);


### PR DESCRIPTION
Add some more extensive unit tests.

Things should just work (TM).

For the unit tests:

```
yarn test-unit frontend/test/metabase/lib/expressions/
```
