### PR TITLE
Custom expression: tweak error messages

### DIFF
--- a/frontend/src/metabase/lib/expressions/tokenizer.js
+++ b/frontend/src/metabase/lib/expressions/tokenizer.js
@@ -217,7 +217,7 @@ export function tokenize(expression) {
     const type = TOKEN.String;
     const end = index;
     const terminated = quote === source[end - 1];
-    const error = terminated ? null : t`Unterminated quoted string`;
+    const error = terminated ? null : t`Missing closing quotes`;
     return { type, value, start, end, error };
   };
 
@@ -245,7 +245,7 @@ export function tokenize(expression) {
     const type = TOKEN.Identifier;
     const end = index;
     const terminated = source[end - 1] === "]";
-    const error = terminated ? null : t`Unterminated bracket identifier`;
+    const error = terminated ? null : t`Missing a closing bracket`;
     return { type, start, end, error };
   };
 

--- a/frontend/test/metabase/lib/expressions/tokenizer.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/tokenizer.unit.spec.js
@@ -63,8 +63,8 @@ describe("metabase/lib/expressions/tokenizer", () => {
   });
 
   it("should catch unterminated string literals", () => {
-    expect(errors("'single")[0].message).toEqual("Unterminated quoted string");
-    expect(errors('"double')[0].message).toEqual("Unterminated quoted string");
+    expect(errors("'single")[0].message).toEqual("Missing closing quotes");
+    expect(errors('"double')[0].message).toEqual("Missing closing quotes");
   });
 
   it("should tokenize identifiers", () => {
@@ -78,7 +78,7 @@ describe("metabase/lib/expressions/tokenizer", () => {
   });
 
   it("should catch unterminated bracket", () => {
-    expect(errors("[T")[0].message).toEqual("Unterminated bracket identifier");
+    expect(errors("[T")[0].message).toEqual("Missing a closing bracket");
   });
 
   it("should catch new brackets within bracket identifiers", () => {

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -872,7 +872,7 @@ describe("scenarios > question > notebook", () => {
       cy.findAllByRole("button", { name: "Done" })
         .should("not.be.disabled")
         .click();
-      cy.findByText("Unterminated quoted string");
+      cy.findByText("Missing closing quotes");
     });
 
     it("should catch unterminated field reference", () => {
@@ -883,7 +883,7 @@ describe("scenarios > question > notebook", () => {
         cy.findByPlaceholderText("Something nice and descriptive")
           .click()
           .type("Massive Discount");
-        cy.contains(/^Unterminated bracket identifier/i);
+        cy.contains(/^Missing a closing bracket/i);
       });
     });
 


### PR DESCRIPTION
Steps to reproduce:
1. Ask a question, Custom question
2. Sample Dataset, Orders table
3. Filter, Custom Expression
4. Type `[Total] > 2  * [Discount` (forgotten `]`)
5. Press `Tab` to switch focus from the editor

**Before**

![image](https://user-images.githubusercontent.com/7288/116115897-67eb8100-a66f-11eb-8b2f-137d46409363.png)

**After**

![image](https://user-images.githubusercontent.com/7288/116773971-04b27380-aa0e-11eb-8dd2-3dbbb264b564.png)
