### PR TITLE
Refine GH Actions FE workflows: Separate FE tests from FE linters

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -2,6 +2,16 @@ name: Frontend Tests
 
 on:
   pull_request:
+    paths:
+      - '**/frontend/**'
+      - '!frontend/test/e2e/**'
+      - '!**/*.cy.*'
+      - '!**/*cypress*'
+      - '!**/*.md'
+      - 'shared/**'
+      - '**/package.json'
+      - '**/yarn.lock'
+      - '.github/workflows/**'
   push:
     branches:
       - master
@@ -12,15 +22,15 @@ on:
     tags:
       - '**'
     paths:
-    - '**/frontend/**'
-    - '!frontend/test/e2e/**'
-    - '!**/*.cy.*'
-    - '!**/*cypress*'
-    - '!**/*.md'
-    - 'shared/**'
-    - '**/package.json'
-    - '**/yarn.lock'
-    - '.github/workflows/**'
+      - '**/frontend/**'
+      - '!frontend/test/e2e/**'
+      - '!**/*.cy.*'
+      - '!**/*cypress*'
+      - '!**/*.md'
+      - 'shared/**'
+      - '**/package.json'
+      - '**/yarn.lock'
+      - '.github/workflows/**'
 
 jobs:
 

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -1,4 +1,4 @@
-name: Frontend
+name: Frontend Tests
 
 on:
   pull_request:
@@ -13,15 +13,18 @@ on:
       - '**'
     paths:
     - '**/frontend/**'
+    - '!frontend/test/e2e/**'
+    - '!**/*.cy.*'
+    - '!**/*cypress*'
+    - '!**/*.md'
     - 'shared/**'
-    - 'docs/**'
     - '**/package.json'
     - '**/yarn.lock'
     - '.github/workflows/**'
 
 jobs:
 
-  fe-linter-prettier:
+  fe-tests-unit:
     runs-on: ubuntu-20.04
     timeout-minutes: 10
     steps:
@@ -36,10 +39,10 @@ jobs:
         path: ~/.cache/yarn
         key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
     - run: yarn install --frozen-lockfile --prefer-offline
-    - run: yarn run lint-prettier
-      name: Run Prettier formatting linter
+    - run: yarn run test-unit
+      name: Run frontend unit tests
 
-  fe-linter-eslint:
+  fe-tests-timezones:
     runs-on: ubuntu-20.04
     timeout-minutes: 10
     steps:
@@ -54,23 +57,5 @@ jobs:
         path: ~/.cache/yarn
         key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
     - run: yarn install --frozen-lockfile --prefer-offline
-    - run: yarn run lint-eslint
-      name: Run ESLint linter
-
-  fe-linter-docs-links:
-    runs-on: ubuntu-20.04
-    timeout-minutes: 10
-    steps:
-    - uses: actions/checkout@v2
-    - name: Prepare Node.js
-      uses: actions/setup-node@v1
-      with:
-        node-version: 14.x
-    - name: Get yarn cache
-      uses: actions/cache@v2
-      with:
-        path: ~/.cache/yarn
-        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-    - run: yarn install --frozen-lockfile --prefer-offline
-    - run: yarn run lint-docs-links
-      name: Run docs links checker
+    - run: yarn run test-timezones
+      name: Run frontend timezones tests

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -2,6 +2,13 @@ name: Frontend
 
 on:
   pull_request:
+    paths:
+      - '**/frontend/**'
+      - 'shared/**'
+      - 'docs/**'
+      - '**/package.json'
+      - '**/yarn.lock'
+      - '.github/workflows/**'
   push:
     branches:
       - master
@@ -12,12 +19,12 @@ on:
     tags:
       - '**'
     paths:
-    - '**/frontend/**'
-    - 'shared/**'
-    - 'docs/**'
-    - '**/package.json'
-    - '**/yarn.lock'
-    - '.github/workflows/**'
+      - '**/frontend/**'
+      - 'shared/**'
+      - 'docs/**'
+      - '**/package.json'
+      - '**/yarn.lock'
+      - '.github/workflows/**'
 
 jobs:
 


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
@ariya May I suggest we separate frontend tests from frontend linters? This ensures that:
- Linters run for ALL frontend changes (including all tests - fe and e2e)
- Fronted tests (unit and timezones) DON'T run on e2e test files changes (or documentation changes)

### Bonus
Added benefit of this separation is the "parallelization" of workflows.
Unit and timezone tests took around 7 minutes to execute in CircleCI. My guess is that this number will be similar in GitHub Actions. If there is only a linting/formatting error in someone's commit (happens fairly often), that person would have to rerun all jobs in a workflow, triggering the execution of of frontend tests with it.
With this change, rerun will leave frontend tests intact, saving additional 4-5 minutes.

Also, I didn't see a benefit of running frontend tests for documentation changes and/or Cypress (e2e) changes. This PR addresses that as well.