### PR TITLE
Fall back to base_type when calling parse-value-for-field-type

### DIFF
--- a/src/metabase/driver/common/parameters/values.clj
+++ b/src/metabase/driver/common/parameters/values.clj
@@ -265,17 +265,18 @@
 (s/defn ^:private update-filter-for-field-type :- ParsedParamValue
   "Update a Field Filter with a textual, or sequence of textual, values. The base type and semantic type of the field
   are used to determine what 'semantic' type interpretation is required (e.g. for UUID fields)."
-  [{{effective_type :effective_type, :as _field} :field, {value :value} :value, :as field-filter} :- FieldFilter]
-  (let [new-value (cond
+  [{field :field, {value :value} :value, :as field-filter} :- FieldFilter]
+  (let [effective-type (or (:effective_type field) (:base_type field))
+        new-value (cond
                     (string? value)
-                    (parse-value-for-field-type effective_type value)
+                    (parse-value-for-field-type effective-type value)
 
                     (and (sequential? value)
                          (every? string? value))
-                    (mapv (partial parse-value-for-field-type effective_type) value))]
+                    (mapv (partial parse-value-for-field-type effective-type) value))]
     (when (not= value new-value)
       (log/tracef "update filter for base-type: %s value: %s -> %s"
-                  (pr-str effective_type) (pr-str value) (pr-str new-value)))
+                  (pr-str effective-type) (pr-str value) (pr-str new-value)))
     (cond-> field-filter
       new-value (assoc-in [:value :value] new-value))))
 


### PR DESCRIPTION
Fixes #15901

Fall back to base_type when calling parse-value-for-field-type

I don't exactly follow what's going on in #15901. But it seems that
the field information can be kept in the db

> ""field_ref"":[""field"",""count(*)"",{""base-type"":""type/BigInteger""}]

And so we need to handle this base type here. Note that in the
function that calls `update-filter-for-field-type` it checks that the
field has a base_type.

I'm also a bit confused by the base_type vs base-type in the above
snippet. But again the calling code has

```clojure
(and (= param-type :dimension)
     (get-in value [:field :base_type]))
(update-filter-for-field-type value)
```

So it seems the field has a base_type rather than a base-type.

