### PR TITLE
Emit events outside of db/transaction

### DIFF
--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -123,9 +123,7 @@
                                                   :dashboardcard_id id
                                                   {:order-by [[:position :asc]]})))
        (update-dashboard-card-series! dashboard-card series)))
-    (u/prog1 (retrieve-dashboard-card id)
-      ;; todo: should this have an actor_id from the api user?
-      (events/publish-event! :dashboard-card-update <>))))
+    (retrieve-dashboard-card id)))
 
 (def ^:private NewDashboardCard
   {:dashboard_id                            su/IntGreaterThanZero
@@ -140,23 +138,21 @@
    DashboardCardSeries. Returns the newly created DashboardCard or throws an Exception."
   [dashboard-card :- NewDashboardCard]
   (let [{:keys [dashboard_id card_id creator_id parameter_mappings visualization_settings sizeX sizeY row col series]
-         :or   {sizeX 2, sizeY 2, series []}} dashboard-card
-        new-dashcard (db/transaction
-                      (let [dashboard-card (db/insert! DashboardCard
-                                                       :dashboard_id           dashboard_id
-                                                       :card_id                card_id
-                                                       :sizeX                  sizeX
-                                                       :sizeY                  sizeY
-                                                       :row                    (or row 0)
-                                                       :col                    (or col 0)
-                                                       :parameter_mappings     (or parameter_mappings [])
-                                                       :visualization_settings (or visualization_settings {}))]
-                        ;; add series to the DashboardCard
-                        (update-dashboard-card-series! dashboard-card series)
-                        ;; return the full DashboardCard
-                        (retrieve-dashboard-card (:id dashboard-card))))]
-    (u/prog1 new-dashcard
-      (events/publish-event! :dashboard-card-create (assoc <> :actor_id creator_id)))))
+         :or   {sizeX 2, sizeY 2, series []}} dashboard-card]
+    (db/transaction
+     (let [dashboard-card (db/insert! DashboardCard
+                                      :dashboard_id           dashboard_id
+                                      :card_id                card_id
+                                      :sizeX                  sizeX
+                                      :sizeY                  sizeY
+                                      :row                    (or row 0)
+                                      :col                    (or col 0)
+                                      :parameter_mappings     (or parameter_mappings [])
+                                      :visualization_settings (or visualization_settings {}))]
+       ;; add series to the DashboardCard
+       (update-dashboard-card-series! dashboard-card series)
+       ;; return the full DashboardCard
+       (retrieve-dashboard-card (:id dashboard-card))))))
 
 (defn delete-dashboard-card!
   "Delete a DashboardCard."


### PR DESCRIPTION
## Emit events outside of db/transaction

When emitting events (particularly revision events), the event handler
loads the item from the db to ensure that all post-processing is
done. If done from inside a transaction, there's a race between the
event handler looking up the object from the db and the transaction
completing to put the item in the db. When the event handler wins, the
following code fails:

```clojure
(push-revision! :entity       Dashboard,
                :id           id,
                :object       (Dashboard id), ;; this is nil
                :user-id      user-id,
                :is-creation? (= :dashboard-create topic)
                :message      revision-message)
```

and then the schema check for `push-revision!` fails `(map? object)`
and there is no event recorded for creation. On edit, it might get the
pre-edit version and record an incorrect message or not create the
revision for the latest change, preventing going back in the future.

I'm only doing this in dashboard but these changes should be audited
and applied everywhere