### PR TITLE
Custom expression: consistent message for missing parentheses

### DIFF
--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -845,7 +845,19 @@ describe("scenarios > question > notebook", () => {
         cy.findByPlaceholderText("Something nice and descriptive")
           .click()
           .type("Massive Discount");
-        cy.contains(/^Expecting an opening parenthesis/i);
+        cy.contains(/^Expecting an opening parenthesis after function FLOOR/i);
+      });
+    });
+
+    it("should catch missing parentheses", () => {
+      openProductsTable({ mode: "notebook" });
+      cy.findByText("Custom column").click();
+      popover().within(() => {
+        cy.get("[contenteditable='true']").type("LOWER [Vendor]");
+        cy.findByPlaceholderText("Something nice and descriptive")
+          .click()
+          .type("Massive Discount");
+        cy.contains(/^Expecting an opening parenthesis after function LOWER/i);
       });
     });
 


### PR DESCRIPTION
Steps to try:

1. Ask a question, Custom question
2. Sample Dataset, Products table
3. Custom column, type `CEIL [Price] / 3`

**Before this PR**

![image](https://user-images.githubusercontent.com/7288/116932985-cf797180-ac17-11eb-9059-c8b14d06fc13.png)

The above error message is still confusing, since there is exactly one argument after the function.

Note: a variant of the expression, `CEIL [Price] / 3)` (note the last `)` still yield the same (confusing) error message.

**After this PR**

![image](https://user-images.githubusercontent.com/7288/116932997-d30cf880-ac17-11eb-835c-be0aab365f7a.png)
