### PR TITLE
Reorder test setup so that outer with-secret-key uses test driver

### DIFF
--- a/test/metabase/cmd/rotate_encryption_key_test.clj
+++ b/test/metabase/cmd/rotate_encryption_key_test.clj
@@ -54,15 +54,14 @@
               "89ulvIGoiYw6mNELuOoEZphQafnF/zYe+3vT+v70D1A=")))))
 
 (deftest rotate-encryption-key!-test
-  ;; (metabase.test.data.env/set-test-drivers! #{:mysql})
-  (eu/with-secret-key nil
-    (let [h2-fixture-db-file @cmd.test-util/fixture-db-file-path
-          db-name            (str "test_" (str/lower-case (mt/random-name)))
-          original-timestamp "2021-02-11 18:38:56.042236+00"
-          [k1 k2 k3]         ["89ulvIGoiYw6mNELuOoEZphQafnF/zYe+3vT+v70D1A="
-                              "yHa/6VEQuIItMyd5CNcgV9nXvzZcX6bWmiY0oOh6pLU="
-                              "BCQbKNVu6N8TQ2BwyTC0U0oCBqsvFVr2uhEM/tRgJUM="]]
-      (mt/test-drivers #{:postgres :h2 :mysql}
+  (let [h2-fixture-db-file @cmd.test-util/fixture-db-file-path
+        db-name            (str "test_" (str/lower-case (mt/random-name)))
+        original-timestamp "2021-02-11 18:38:56.042236+00"
+        [k1 k2 k3]         ["89ulvIGoiYw6mNELuOoEZphQafnF/zYe+3vT+v70D1A="
+                            "yHa/6VEQuIItMyd5CNcgV9nXvzZcX6bWmiY0oOh6pLU="
+                            "BCQbKNVu6N8TQ2BwyTC0U0oCBqsvFVr2uhEM/tRgJUM="]]
+    (mt/test-drivers #{:postgres :h2 :mysql}
+      (eu/with-secret-key nil
         (with-model-type :encrypted-json {:out #'interface/encrypted-json-out}
           (binding [mdb.connection/*db-type*   driver/*driver*
                     mdb.connection/*jdbc-spec* (persistent-jdbcspec driver/*driver* db-name)


### PR DESCRIPTION
It was a very slightly educated guess (shot in the dark) that this is what caused Vertica tests to fail, from [this commit](https://github.com/metabase/metabase/commit/a676a1a094cf2de86b65989a7b186dd8e7361f41) onward, but it seems to have done the trick. Maybe the unrestrained `with-secret-key` – outside of the scope of the test driver – caused the test database to be changed in a way that caused the test failure _only_ in Vertica, even though there were no database changes between `with-secret-key` and the `mt/test-drivers` scopes. Maybe it's a race condition present only in Vertica. :shrug: 

CC @jeff303: Just because you recently merged the failing test, and in case it may be of interest to what you're working on. :slightly_smiling_face: 