### PR TITLE
Restore table visibility

### DIFF
--- a/frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx
@@ -191,13 +191,30 @@ function TableRow({
 }
 
 function ToggleHiddenButton({ setVisibilityForTables, tables, isHidden }) {
+  const [isLoading, setIsLoading] = React.useState(false);
+
+  const handleToggle = async e => {
+    e.stopPropagation();
+
+    if (isLoading) {
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      await setVisibilityForTables(tables, isHidden ? null : "hidden");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
   return (
     <Icon
+      tabIndex="0"
       name={isHidden ? "eye" : "eye_crossed_out"}
-      onClick={e => {
-        e.stopPropagation();
-        setVisibilityForTables(tables, isHidden ? null : "hidden");
-      }}
+      onClick={handleToggle}
+      onKeyUp={e => e.key === "Enter" && handleToggle(e)}
+      disabled={isLoading}
       tooltip={
         tables.length > 1
           ? isHidden
@@ -208,8 +225,11 @@ function ToggleHiddenButton({ setVisibilityForTables, tables, isHidden }) {
           : t`Hide`
       }
       size={18}
-      className={"float-right cursor-pointer"}
-      hover={{ color: color("brand") }}
+      className={cx(
+        "float-right",
+        isLoading ? "cursor-not-allowed" : "cursor-pointer",
+      )}
+      hover={{ color: isLoading ? undefined : color("brand") }}
     />
   );
 }

--- a/frontend/src/metabase/css/core/cursor.css
+++ b/frontend/src/metabase/css/core/cursor.css
@@ -12,3 +12,7 @@
 :local(.cursor-default) {
   cursor: default;
 }
+
+.cursor-not-allowed {
+  cursor: not-allowed;
+}

--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -86,7 +86,7 @@
     (submit-task
      (fn []
        (let [database (table/database (first newly-unhidden))]
-         (if (doto (driver/can-connect? (:engine database) (:details database)) tap>)
+         (if (driver.u/can-connect-with-details? (:engine database) (:details database))
            (doseq [table newly-unhidden]
              (log/info (u/format-color 'green (trs "Table ''{0}'' is now visible. Resyncing." (:name table))))
              (sync/sync-table! table))

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -320,7 +320,24 @@
                      @called))
               (set-visibility "technical")
               (is (= 2
-                     @called)))))))))
+                     @called))))))))
+  (testing "Bulk updating visibility"
+    (let [unhidden-ids (atom nil)]
+      (mt/with-temp* [Table [{id-1 :id} {}]
+                      Table [{id-2 :id} {:visibility_type "hidden"}]]
+        (with-redefs [table-api/sync-unhidden-tables (fn [unhidden] (reset! unhidden-ids (map :id unhidden)))]
+          (let [set-many-vis (fn [ids state]
+                               (reset! unhidden-ids nil)
+                               (mt/user-http-request :crowberto :put 200 "table/"
+                                                     {:ids ids :visibility_type state}))]
+            (set-many-vis [id-1 id-2] nil) ;; unhides only 2
+            (is (= @unhidden-ids [id-2]))
+
+            (set-many-vis [id-1 id-2] "hidden")
+            (is (= @unhidden-ids [])) ;; no syncing when they are hidden
+
+            (set-many-vis [id-1 id-2] nil) ;; both are made unhidden so both synced
+            (is (= @unhidden-ids [id-1 id-2]))))))))
 
 (deftest get-fks-test
   (testing "GET /api/table/:id/fks"


### PR DESCRIPTION
Addresses #15165

There are several issues in there:
- sync only if we can connect to the db. Don't let the timeout of getting a connection be the test. So added `driver/can-connect`
- syncing holds onto a jetty thread. So moved these off thread into a fixed thread executor service with a single thread
- hitting 15 individual tables could lock up the connection to the db. mitigated by moving things off thread with a quick connection check. This probably could benefit from some frontend UI that prevents other clicks until the request comes back. Request is far quicker now


Possible frontend work:
- Disable clicking more hide/show buttons on the frontend until the previous hide/show request has completed.

### When unhiding several tables at once and the db is not available:
Request took 31ms
<img width="1787" alt="image" src="https://user-images.githubusercontent.com/6377293/117077272-6835ed00-acfd-11eb-97ba-90f1a1253ca5.png">

### Unhiding individual tables and the db is not available
Request took 30ms
(image is actually the same)

### Bulk unhiding with mysql enabled:
Request took 36 ms
![image](https://user-images.githubusercontent.com/6377293/117077607-0de95c00-acfe-11eb-9d31-83ae4736af24.png)
