### PR TITLE
Allow multiple `--spec` arguments

### DIFF
--- a/frontend/test/__runner__/run_cypress_tests.js
+++ b/frontend/test/__runner__/run_cypress_tests.js
@@ -13,10 +13,12 @@ const server = BackendResource.get({ dbKey: "" });
 // --spec <single-spec-path> - Specifies a path to a single test file
 const userArgs = process.argv.slice(2);
 const isOpenMode = userArgs.includes("--open");
-const sourceFolder = userArgs.includes("--folder");
-const singleFile = userArgs.includes("--spec");
+const isFolderFlag = userArgs.includes("--folder");
+const isSpecFlag = userArgs.includes("--spec");
 const sourceFolderLocation = userArgs[userArgs.indexOf("--folder") + 1];
-const singleFileName = userArgs[userArgs.indexOf("--spec") + 1];
+const specs = userArgs[userArgs.indexOf("--spec") + 1];
+const isSingleSpec = !specs.match(/,/);
+const testFiles = isSingleSpec ? specs : specs.split(",");
 
 function readFile(fileName) {
   return new Promise(function(resolve, reject) {
@@ -38,13 +40,11 @@ const init = async () => {
     );
   }
 
-  if (sourceFolder) {
-    printBold(`Running tests in '${sourceFolderLocation}'`);
-  }
+  const logMessage = isFolderFlag
+    ? `Running tests in '${sourceFolderLocation}'`
+    : `Running '${testFiles}'`;
 
-  if (singleFile) {
-    printBold(`Running single spec '${singleFileName}'`);
-  }
+  printBold(logMessage);
 
   try {
     const version = await readFile(
@@ -70,10 +70,10 @@ const init = async () => {
 
   printBold("Starting Cypress");
   const baseConfig = { baseUrl: server.host };
-  const folderConfig = sourceFolder && {
+  const folderConfig = isFolderFlag && {
     integrationFolder: sourceFolderLocation,
   };
-  const specsConfig = singleFile && { testFiles: singleFileName };
+  const specsConfig = isSpecFlag && { testFiles };
   const ignoreConfig =
     // if we're not running specific tests, avoid including db and smoketests
     folderConfig || specsConfig

--- a/frontend/test/__runner__/run_cypress_tests.js
+++ b/frontend/test/__runner__/run_cypress_tests.js
@@ -39,40 +39,36 @@ const init = async () => {
   }
 
   if (sourceFolder) {
-    console.log(chalk.bold(`Running tests in '${sourceFolderLocation}'`));
+    printBold(`Running tests in '${sourceFolderLocation}'`);
   }
 
   if (singleFile) {
-    console.log(chalk.bold(`Running single spec '${singleFileName}'`));
+    printBold(`Running single spec '${singleFileName}'`);
   }
 
   try {
     const version = await readFile(
       __dirname + "/../../../resources/version.properties",
     );
-    console.log(chalk.bold("Running e2e test runner with this build:"));
+    printBold("Running e2e test runner with this build:");
     process.stdout.write(chalk.cyan(version));
-    console.log(
-      chalk.bold(
-        "If that version seems too old, please run `./bin/build version uberjar`.\n",
-      ),
+    printBold(
+      "If that version seems too old, please run `./bin/build version uberjar`.\n",
     );
   } catch (e) {
-    console.log(
-      chalk.bold(
-        "No version file found. Please run `./bin/build version uberjar`.",
-      ),
+    printBold(
+      "No version file found. Please run `./bin/build version uberjar`.",
     );
     process.exit(1);
   }
 
-  console.log(chalk.bold("Starting backend"));
+  printBold("Starting backend");
   await BackendResource.start(server);
 
-  console.log(chalk.bold("Generating snapshots"));
+  printBold("Generating snapshots");
   await generateSnapshots();
 
-  console.log(chalk.bold("Starting Cypress"));
+  printBold("Starting Cypress");
   const baseConfig = { baseUrl: server.host };
   const folderConfig = sourceFolder && {
     integrationFolder: sourceFolderLocation,
@@ -127,7 +123,7 @@ const init = async () => {
 };
 
 const cleanup = async (exitCode = 0) => {
-  console.log(chalk.bold("Cleaning up..."));
+  printBold("Cleaning up...");
   await BackendResource.stop(server);
   process.exit(exitCode);
 };
@@ -162,4 +158,8 @@ async function generateSnapshots() {
   return new Promise((resolve, reject) => {
     cypressProcess.on("exit", resolve);
   });
+}
+
+function printBold(message) {
+  console.log(chalk.bold(message));
 }


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- Allows someone to pass multiple `--spec` arguments when running Cypress

### How to verify this works?
- All tests should still pass in CI
- Run the following command:

`yarn test-cypress-open --spec "frontend/test/metabase/scenarios/question/**/*.cy.spec.js,frontend/test/metabase/scenarios/dashboard/**/*.cy.spec.js"`

The output should look like this (note how multiple specs are now in the array)
```bash
$ /Users/username/path/to/metabase-release-branch/node_modules/.bin/cypress open
  --config-file frontend/test/__support__/e2e/cypress.json
  --config '{"baseUrl":"http://localhost:4000","testFiles":["frontend/test/metabase/scenarios/question/**/*.cy.spec.js","frontend/test/metabase/scenarios/dashboard/**/*.cy.spec.js"]}'
  --env HAS_ENTERPRISE_TOKEN=true
```

Cypress GUI should show only 2 folders:
![image](https://user-images.githubusercontent.com/31325167/117043172-2e6ce280-ad0d-11eb-9b03-74bd665b5cd1.png)

### Related links:
- https://docs.cypress.io/guides/guides/command-line#cypress-run-spec-lt-spec-gt