### PR TITLE
Fix location of share icon

### DIFF
--- a/docs/administration-guide/12-public-links.md
+++ b/docs/administration-guide/12-public-links.md
@@ -10,7 +10,8 @@ First things first, you'll need to go to the Admin Panel and enable public shari
 ### Enable sharing on your dashboard or saved question
 
 ![Enable sharing](images/public-links/enable-links.png)
-Next, exit the Admin Panel and go to the dashboard or question that you want to share, then click on the `Sharing and Embedding` icon in the top-right of the screen (it looks like a box with an arrow pointing up). Then click on the toggle to enable public sharing for this dashboard or question.
+
+Next, exit the Admin Panel and go to the dashboard or question that you want to share, then click on the `Sharing and Embedding` icon in the bottom-right of the screen (it looks like an arrow pointing up and to the right). Then click on the toggle to enable public sharing for this dashboard or question.
 
 ### Copy, paste, and share!
 

--- a/docs/administration-guide/12-public-links.md
+++ b/docs/administration-guide/12-public-links.md
@@ -11,7 +11,9 @@ First things first, you'll need to go to the Admin Panel and enable public shari
 
 ![Enable sharing](images/public-links/enable-links.png)
 
-Next, exit the Admin Panel and go to the dashboard or question that you want to share, then click on the `Sharing and Embedding` icon in the bottom-right of the screen (it looks like an arrow pointing up and to the right). Then click on the toggle to enable public sharing for this dashboard or question.
+Next, exit the Admin Panel and go to question that you want to share, then click on the `Sharing and Embedding` icon in the bottom-right of the screen (it looks like an arrow pointing up and to the right). Then click on the toggle to enable public sharing for this question.
+
+In the case of a dashboard, the button is located on the top right of the page.
 
 ### Copy, paste, and share!
 


### PR DESCRIPTION
This is what the button looks like for us, on a saved question:

![image](https://user-images.githubusercontent.com/509837/117056530-05832800-ace2-11eb-8c9b-fd789db2ca70.png)

At some point in the past it looked different (eg https://github.com/metabase/metabase/pull/9592#issuecomment-500647869) so I'm not really sure when it changed.