### PR TITLE
Cherry pick fix for `build-for-test` script from the `release-x.39.x` branch

### DIFF
--- a/bin/build-for-test
+++ b/bin/build-for-test
@@ -30,7 +30,7 @@ check-uberjar-hash() {
 
 build-uberjar-for-test() {
   ./bin/build version
-  echo "$VERSION_PROPERTY_NAME=$(source-hash)" >> resources/version.properties
+  echo -e "\n$VERSION_PROPERTY_NAME=$(source-hash)" >> resources/version.properties
   ./bin/build uberjar
 }
 


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- Cherry-picks improved cache mechanism in `bin/build-for-test` from the `release-x.39.x` branch (authored by @paulrosenzweig )