### PR TITLE
#15893 Repro: Cannot use numeric value before an operator in Custom Expression

### DIFF
--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -932,6 +932,22 @@ describe("scenarios > question > filter", () => {
     cy.findByRole("button", { name: "Done" }).should("not.be.disabled");
   });
 
+  it.skip("custom expression filter should work with numeric value before an operator (metabase#15893)", () => {
+    cy.intercept("POST", "/api/dataset").as("dataset");
+
+    openOrdersTable({ mode: "notebook" });
+    cy.findByText("Filter").click();
+    cy.findByText("Custom Expression").click();
+    cy.get("[contenteditable=true]")
+      .type("0 < [ID]")
+      .blur();
+    cy.findByRole("button", { name: "Done" }).click();
+    cy.findByText("Visualize").click();
+    cy.wait("@dataset").then(xhr => {
+      expect(xhr.response.body.error).to.not.exist;
+    });
+  });
+
   it.skip("should work on twice summarized questions (metabase#15620)", () => {
     visitQuestionAdhoc({
       dataset_query: {


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #15893

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/question/filter.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/117196897-66e0ef00-ade7-11eb-852f-5d530abeea8c.png)

