### PR TITLE
#15891 Repro: Don't show Custom Expression helper when input is not in focus

### DIFF
--- a/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
@@ -575,4 +575,17 @@ describe("scenarios > question > custom columns", () => {
       .click();
     cy.findByPlaceholderText("Enter a number").should("not.exist");
   });
+
+  it.skip("custom expression helper shouldn't be visible when formula field is not in focus (metabase#15891)", () => {
+    openPeopleTable({ mode: "notebook" });
+    cy.findByText("Custom column").click();
+    popover().within(() => {
+      cy.get("[contenteditable='true']").type(`rou{enter}1.5`, {
+        delay: 100,
+      });
+    });
+    cy.findByText("round([Temperature])");
+    cy.findByText(/Field formula/i).click(); // Click outside of formula field instead of blur
+    cy.findByText("round([Temperature])").should("not.exist");
+  });
 });


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #15891 

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/question/custom_column.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/117198864-d1932a00-ade9-11eb-937a-30cfd30b1a5a.png)

