### PR TITLE
#15922 Repro: `isNull` function in Custom Columns does not work

### DIFF
--- a/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
@@ -588,4 +588,26 @@ describe("scenarios > question > custom columns", () => {
     cy.findByText(/Field formula/i).click(); // Click outside of formula field instead of blur
     cy.findByText("round([Temperature])").should("not.exist");
   });
+
+  it.skip("should work with `isNull` function (metabase#15922)", () => {
+    cy.intercept("POST", "/api/dataset").as("dataset");
+
+    openOrdersTable({ mode: "notebook" });
+    cy.findByText("Custom column").click();
+    popover().within(() => {
+      cy.get("[contenteditable='true']").type(`isnull([Discount])`, {
+        delay: 100,
+      });
+      cy.findByPlaceholderText("Something nice and descriptive").type(
+        "No discount",
+      );
+      cy.findByRole("button", { name: "Done" }).click();
+    });
+    cy.findByRole("button", { name: "Visualize" }).click();
+    cy.wait("@dataset").then(xhr => {
+      expect(xhr.response.body.error).to.not.exist;
+    });
+    cy.contains("37.65");
+    cy.findByText("No discount");
+  });
 });


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #15922

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/question/custom_column.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/117213649-2fc90880-adfc-11eb-8ac3-246ad5e126e9.png)

