### PR TITLE
Custom expression: improved message for dangling closing brackets

### DIFF
--- a/frontend/src/metabase/lib/expressions/tokenizer.js
+++ b/frontend/src/metabase/lib/expressions/tokenizer.js
@@ -318,9 +318,22 @@ export function tokenize(expression) {
         if (!char) {
           break;
         }
-        const message = t`Invalid character: ${char}`;
         const pos = index;
-        errors.push({ message, pos });
+        if (char === "]") {
+          const prev = tokens[tokens.length - 1];
+          const ref =
+            prev && prev.type === TOKEN.Identifier
+              ? source.slice(prev.start, prev.end)
+              : null;
+          console.log({ prev, ref });
+          const message = ref
+            ? t`Missing an opening bracket for ${ref}`
+            : t`Missing an opening bracket`;
+          errors.push({ message, pos });
+        } else {
+          const message = t`Invalid character: ${char}`;
+          errors.push({ message, pos });
+        }
         ++index;
       }
     }

--- a/frontend/test/metabase/lib/expressions/tokenizer.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/tokenizer.unit.spec.js
@@ -87,6 +87,12 @@ describe("metabase/lib/expressions/tokenizer", () => {
     );
   });
 
+  it("should catch a dangling closing bracket", () => {
+    expect(errors("floor(Total]*1.25)")[0].message).toEqual(
+      "Missing an opening bracket for Total",
+    );
+  });
+
   it("should allow escaping brackets within bracket identifiers", () => {
     expect(types("[T\\[]")).toEqual([T.Identifier]);
     expect(errors("[T\\[]")).toEqual([]);


### PR DESCRIPTION
Steps to try:
1. Ask a question, Custom question
2. Sample Dataset, Reviews table
3. Filter, Custom Expression, and type `Rating] > 3` (missing an opening bracket)

**Before this PR**

![image](https://user-images.githubusercontent.com/7288/117217820-e30f0e80-adb6-11eb-9ed2-e1e49a6e29d8.png)

**After this PR**

![image](https://user-images.githubusercontent.com/7288/117217828-e609ff00-adb6-11eb-9d55-2845a094b67c.png)
