### PR TITLE
Basic type inference for custom expression

### DIFF
--- a/frontend/src/metabase/lib/expressions/typeinferencer.js
+++ b/frontend/src/metabase/lib/expressions/typeinferencer.js
@@ -1,0 +1,49 @@
+import { ExpressionVisitor } from "./visitor";
+import { compactSyntaxTree } from "./typechecker";
+
+export function infer(cst, env) {
+  class TypeInferer extends ExpressionVisitor {
+    constructor(env) {
+      super();
+      this.env = env;
+    }
+
+    numberLiteral() {
+      return "number";
+    }
+    stringLiteral() {
+      return "string";
+    }
+
+    relationalExpression(ctx) {
+      return "boolean";
+    }
+    logicalOrExpression(ctx) {
+      return "boolean";
+    }
+    logicalAndExpression(ctx) {
+      return "boolean";
+    }
+    logicalNotExpression(ctx) {
+      return "boolean";
+    }
+
+    additionExpression(ctx) {
+      return "number";
+    }
+
+    multiplicationExpression(ctx) {
+      return "number";
+    }
+
+    caseExpression(ctx) {
+      const args = ctx.arguments || [];
+      const types = args.map(arg => this.visit(arg));
+      return types[1];
+    }
+  }
+
+  const inferencer = new TypeInferer();
+  const compactCst = compactSyntaxTree(cst);
+  return inferencer.visit(compactCst);
+}

--- a/frontend/test/metabase/lib/expressions/typeinferencer.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/typeinferencer.unit.spec.js
@@ -60,21 +60,21 @@ describe("metabase/lib/expressions/typeinferencer", () => {
 
   it("should infer the result of numeric functions", () => {
     expect(type("SQRT(2)")).toEqual("number");
-    expect(type("ABS(Latitude)")).toEqual("number");
-    expect(type("FLOOR(Total / 2.45)")).toEqual("number");
+    expect(type("ABS([Latitude])")).toEqual("number");
+    expect(type("FLOOR([Total] / 2.45)")).toEqual("number");
   });
 
   it("should infer the result of string functions", () => {
-    expect(type("Ltrim(Name)")).toEqual("string");
-    expect(type("Concat(Upper(LastN), FirstN)")).toEqual("string");
-    expect(type("SUBSTRING(Product, 0, 3)")).toEqual("string");
-    expect(type("Length(Category)")).toEqual("number");
-    expect(type("Length(Category) > 0")).toEqual("boolean");
+    expect(type("Ltrim([Name])")).toEqual("string");
+    expect(type("Concat(Upper([LastN]), [FirstN])")).toEqual("string");
+    expect(type("SUBSTRING([Product], 0, 3)")).toEqual("string");
+    expect(type("Length([Category])")).toEqual("number");
+    expect(type("Length([Category]) > 0")).toEqual("boolean");
   });
 
   it.skip("should infer the result of CASE", () => {
-    expect(type("CASE(X, 1, 2)")).toEqual("number");
-    expect(type("CASE(Y, 'this', 'that')")).toEqual("string");
+    expect(type("CASE([X], 1, 2)")).toEqual("number");
+    expect(type("CASE([Y], 'this', 'that')")).toEqual("string");
     expect(type("CASE(BigSale, Price>100, Price>200)")).toEqual("boolean");
   });
 });

--- a/frontend/test/metabase/lib/expressions/typeinferencer.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/typeinferencer.unit.spec.js
@@ -1,0 +1,58 @@
+import { parse } from "metabase/lib/expressions/parser";
+import { infer } from "metabase/lib/expressions/typeinferencer";
+
+describe("metabase/lib/expressions/typeinferencer", () => {
+  function parseAs(source, startRule) {
+    let cst = null;
+    try {
+      const result = parse({ source, tokenVector: null, startRule });
+      cst = result.cst;
+    } catch (e) {}
+    return cst;
+  }
+
+  // workaround the limitation of the parsing expecting a strict top-level grammar rule
+  function tryParse(source) {
+    let cst = parseAs(source, "expression");
+    if (!cst) {
+      cst = parseAs(source, "boolean");
+    }
+    return cst;
+  }
+
+  function type(expression) {
+    return infer(tryParse(expression));
+  }
+
+  it("should infer the type of primitives", () => {
+    expect(type("0")).toEqual("number");
+    expect(type("1")).toEqual("number");
+    expect(type("3.14159")).toEqual("number");
+    expect(type('"Hola"')).toEqual("string");
+    expect(type("'Bonjour!'")).toEqual("string");
+  });
+
+  it("should infer the result of arithmetic operations", () => {
+    expect(type("[Price] + [Tax]")).toEqual("number");
+    expect(type("1.15 * [Total]")).toEqual("number");
+  });
+
+  it("should infer the result of logical operations", () => {
+    expect(type("NOT [Deal]")).toEqual("boolean");
+    expect(type("[A] OR [B]")).toEqual("boolean");
+    expect(type("[X] AND [Y]")).toEqual("boolean");
+    expect(type("[Rating] < 3 AND [Price] > 100")).toEqual("boolean");
+  });
+
+  it("should infer parenthesized subexpression", () => {
+    expect(type("(3.14159)")).toEqual("number");
+    expect(type('((((("Hola")))))')).toEqual("string");
+    expect(type("NOT ([Discount] > 0)")).toEqual("boolean");
+  });
+
+  it("should infer the result of CASE", () => {
+    expect(type("CASE(X, 1, 2)")).toEqual("number");
+    expect(type("CASE(Y, 'this', 'that')")).toEqual("string");
+    expect(type("CASE(BigSale, Price>100, Price>200)")).toEqual("boolean");
+  });
+});


### PR DESCRIPTION
For more context, see #15952.

Currently it's not being used anywhere, but a subsequent PR will start using this in the Dimension code.

In the mean-time, run the unit tests:
```
yarn test-unit frontend/test/metabase/lib/expressions/typeinferencer.unit.spec.js
```