### PR TITLE
Omit revision history item from list if no `diff`

### DIFF
--- a/frontend/src/metabase/components/HistoryModal.jsx
+++ b/frontend/src/metabase/components/HistoryModal.jsx
@@ -34,10 +34,6 @@ export default class HistoryModal extends Component {
     }
   }
 
-  shouldRenderRevertButton(onRevert, hasSkippedMostRecentRevisionRevertButton) {
-    return onRevert && hasSkippedMostRecentRevisionRevertButton
-  }
-
   render() {
     const { revisions, onRevert, onClose } = this.props;
     const cellClassName = "p1 border-bottom";
@@ -46,7 +42,7 @@ export default class HistoryModal extends Component {
     // because we are omitting revision entries that
     // don't have descriptions.
     // They may be the very top entry so we have to use dedicated logic.
-    let hasSkippedMostRecentRevisionRevertButton = false
+    let hasSkippedMostRecentRevisionRevertButton = false;
 
     return (
       <ModalContent title={t`Revision history`} onClose={onClose}>
@@ -64,7 +60,8 @@ export default class HistoryModal extends Component {
               const revisionDescription = this.getRevisionDescription(revision);
 
               if (revisionDescription) {
-                const shouldRenderActionButton = this.shouldRenderRevertButton(onRevert, hasSkippedMostRecentRevisionRevertButton);
+                const shouldRenderRevertButton =
+                  onRevert && hasSkippedMostRecentRevisionRevertButton;
                 hasSkippedMostRecentRevisionRevertButton = true;
 
                 return (
@@ -79,7 +76,7 @@ export default class HistoryModal extends Component {
                       <span>{revisionDescription}</span>
                     </td>
                     <td className={cellClassName}>
-                      {shouldRenderActionButton && (
+                      {shouldRenderRevertButton && (
                         <ActionButton
                           actionFn={() => onRevert(revision)}
                           className="Button Button--small Button--danger text-uppercase"

--- a/frontend/src/metabase/components/HistoryModal.jsx
+++ b/frontend/src/metabase/components/HistoryModal.jsx
@@ -34,13 +34,23 @@ export default class HistoryModal extends Component {
     }
   }
 
+  shouldRenderRevisionEntry({ diff }) {
+    // diff may be null in "First revision"
+    if (diff === null) {
+      return true;
+    }
+
+    const { before, after } = diff;
+    return before !== null && after !== null;
+  }
+
   render() {
     const { revisions, onRevert, onClose } = this.props;
     const cellClassName = "p1 border-bottom";
 
     // We must keep track of having skipped the Revert button
-    // because we are omitting revision entries that
-    // don't have descriptions.
+    // because we are omitting certain revision entries,
+    // see function shouldRenderRevisionEntry
     // They may be the very top entry so we have to use dedicated logic.
     let hasSkippedMostRecentRevisionRevertButton = false;
 
@@ -57,9 +67,7 @@ export default class HistoryModal extends Component {
           </thead>
           <tbody>
             {revisions.map((revision, index) => {
-              const revisionDescription = this.getRevisionDescription(revision);
-
-              if (revisionDescription) {
+              if (this.shouldRenderRevisionEntry(revision)) {
                 const shouldRenderRevertButton =
                   onRevert && hasSkippedMostRecentRevisionRevertButton;
                 hasSkippedMostRecentRevisionRevertButton = true;
@@ -73,7 +81,7 @@ export default class HistoryModal extends Component {
                       {revision.user.common_name}
                     </td>
                     <td className={cellClassName}>
-                      <span>{revisionDescription}</span>
+                      <span>{this.getRevisionDescription(revision)}</span>
                     </td>
                     <td className={cellClassName}>
                       {shouldRenderRevertButton && (

--- a/frontend/src/metabase/components/HistoryModal.jsx
+++ b/frontend/src/metabase/components/HistoryModal.jsx
@@ -42,7 +42,7 @@ export default class HistoryModal extends Component {
     }
 
     const { before, after } = diff;
-    return before !== null && after !== null;
+    return before !== null || after !== null;
   }
 
   render() {

--- a/frontend/src/metabase/components/HistoryModal.jsx
+++ b/frontend/src/metabase/components/HistoryModal.jsx
@@ -36,6 +36,7 @@ export default class HistoryModal extends Component {
 
   shouldRenderRevisionEntry({ diff }) {
     // diff may be null in "First revision"
+    // or in the earliest revision kept in store
     if (diff === null) {
       return true;
     }

--- a/frontend/src/metabase/components/HistoryModal.jsx
+++ b/frontend/src/metabase/components/HistoryModal.jsx
@@ -24,7 +24,7 @@ export default class HistoryModal extends Component {
     onClose: PropTypes.func.isRequired,
   };
 
-  revisionDescription(revision) {
+  getRevisionDescription(revision) {
     if (revision.is_creation) {
       return t`First revision.`;
     } else if (revision.is_reversion) {
@@ -50,29 +50,37 @@ export default class HistoryModal extends Component {
             </tr>
           </thead>
           <tbody>
-            {revisions.map((revision, index) => (
-              <tr key={revision.id}>
-                <td className={cellClassName}>
-                  {formatDate(revision.timestamp)}
-                </td>
-                <td className={cellClassName}>{revision.user.common_name}</td>
-                <td className={cellClassName}>
-                  <span>{this.revisionDescription(revision)}</span>
-                </td>
-                <td className={cellClassName}>
-                  {index !== 0 && onRevert && (
-                    <ActionButton
-                      actionFn={() => onRevert(revision)}
-                      className="Button Button--small Button--danger text-uppercase"
-                      normalText={t`Revert`}
-                      activeText={t`Reverting…`}
-                      failedText={t`Revert failed`}
-                      successText={t`Reverted`}
-                    />
-                  )}
-                </td>
-              </tr>
-            ))}
+            {revisions.map((revision, index) => {
+              const revisionDescription = this.getRevisionDescription(revision);
+
+              if (revisionDescription) {
+                return (
+                  <tr key={revision.id}>
+                    <td className={cellClassName}>
+                      {formatDate(revision.timestamp)}
+                    </td>
+                    <td className={cellClassName}>
+                      {revision.user.common_name}
+                    </td>
+                    <td className={cellClassName}>
+                      <span>{revisionDescription}</span>
+                    </td>
+                    <td className={cellClassName}>
+                      {index !== 0 && onRevert && (
+                        <ActionButton
+                          actionFn={() => onRevert(revision)}
+                          className="Button Button--small Button--danger text-uppercase"
+                          normalText={t`Revert`}
+                          activeText={t`Reverting…`}
+                          failedText={t`Revert failed`}
+                          successText={t`Reverted`}
+                        />
+                      )}
+                    </td>
+                  </tr>
+                );
+              }
+            })}
           </tbody>
         </table>
       </ModalContent>

--- a/frontend/src/metabase/components/HistoryModal.jsx
+++ b/frontend/src/metabase/components/HistoryModal.jsx
@@ -34,9 +34,19 @@ export default class HistoryModal extends Component {
     }
   }
 
+  shouldRenderRevertButton(onRevert, hasSkippedMostRecentRevisionRevertButton) {
+    return onRevert && hasSkippedMostRecentRevisionRevertButton
+  }
+
   render() {
     const { revisions, onRevert, onClose } = this.props;
     const cellClassName = "p1 border-bottom";
+
+    // We must keep track of having skipped the Revert button
+    // because we are omitting revision entries that
+    // don't have descriptions.
+    // They may be the very top entry so we have to use dedicated logic.
+    let hasSkippedMostRecentRevisionRevertButton = false
 
     return (
       <ModalContent title={t`Revision history`} onClose={onClose}>
@@ -54,6 +64,9 @@ export default class HistoryModal extends Component {
               const revisionDescription = this.getRevisionDescription(revision);
 
               if (revisionDescription) {
+                const shouldRenderActionButton = this.shouldRenderRevertButton(onRevert, hasSkippedMostRecentRevisionRevertButton);
+                hasSkippedMostRecentRevisionRevertButton = true;
+
                 return (
                   <tr key={revision.id}>
                     <td className={cellClassName}>
@@ -66,7 +79,7 @@ export default class HistoryModal extends Component {
                       <span>{revisionDescription}</span>
                     </td>
                     <td className={cellClassName}>
-                      {index !== 0 && onRevert && (
+                      {shouldRenderActionButton && (
                         <ActionButton
                           actionFn={() => onRevert(revision)}
                           className="Button Button--small Button--danger text-uppercase"

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -464,7 +464,9 @@ describe("collection permissions", () => {
         // There is no fourth entry for editing the textbox as this
         // change currently creates a revision item with a `null` description.
         // TODO: consider generating a description for edited textboxes
-        const revisionHistoryEntries = cy.findAllByText("Bobby Tables").parent()
+        const revisionHistoryEntries = cy
+          .findAllByText("Bobby Tables")
+          .parent();
 
         revisionHistoryEntries.should("have.length", 3);
 

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -448,26 +448,22 @@ describe("collection permissions", () => {
 
         // Save the dashboard without any changes made to it (TODO: we should probably disable "Save" button in the first place)
         saveDashboard();
-
         cy.icon("pencil").click();
-        cy.findByPlaceholderText(
-          "Write here, and use Markdown if you'd like",
-        ).type("a");
         saveDashboard();
 
         openRevisionHistory();
+
+        const revisionHistoryEntries = cy
+          .findAllByText("Bobby Tables")
+          .parent();
 
         // This accounts for:
         // 1. First revision.
         // 2. added a card.
         // 3. rearranged the cards. (TODO: consider fixing this as cards we never rearranged)
-        // There is no fourth entry for editing the textbox as this
-        // change currently creates a revision item with a `null` description.
-        // TODO: consider generating a description for edited textboxes
-        const revisionHistoryEntries = cy
-          .findAllByText("Bobby Tables")
-          .parent();
 
+        // Revision history entries from saving no change
+        // should not be rendered.
         revisionHistoryEntries.should("have.length", 3);
 
         // Topmost visible revision history entry
@@ -639,7 +635,6 @@ function assertOnRequest(xhr_alias) {
 function visitAndEditDashboard(id) {
   cy.visit(`/dashboard/${id}`);
   cy.icon("pencil").click();
-  cy.icon("string").click();
 }
 
 function saveDashboard() {

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -453,7 +453,7 @@ describe("collection permissions", () => {
 
         openRevisionHistory();
 
-        cy.findByText("Bobby Tables");
+        cy.findByText("First revision.");
 
         cy.findAllByText("Revert").should("not.exist");
       });

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -464,7 +464,18 @@ describe("collection permissions", () => {
         // There is no fourth entry for editing the textbox as this
         // change currently creates a revision item with a `null` description.
         // TODO: consider generating a description for edited textboxes
-        cy.findAllByText("Bobby Tables").should("have.length", 3);
+        const revisionHistoryEntries = cy.findAllByText("Bobby Tables").parent()
+
+        revisionHistoryEntries.should("have.length", 3);
+
+        // Topmost visible revision history entry
+        // should not have a Revert button, as it's
+        // the latest practical one.
+        revisionHistoryEntries.first().within(() => {
+          cy.findByText("Revert").should("not.exist");
+        });
+
+        cy.findAllByText("Revert").should("have.length", 2);
       });
 
       it.skip("dashboard should update properly on revert (metabase#6884)", () => {

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -453,27 +453,9 @@ describe("collection permissions", () => {
 
         openRevisionHistory();
 
-        const revisionHistoryEntries = cy
-          .findAllByText("Bobby Tables")
-          .parent();
+        cy.findByText("Bobby Tables");
 
-        // This accounts for:
-        // 1. First revision.
-        // 2. added a card.
-        // 3. rearranged the cards. (TODO: consider fixing this as cards we never rearranged)
-
-        // Revision history entries from saving no change
-        // should not be rendered.
-        revisionHistoryEntries.should("have.length", 3);
-
-        // Topmost visible revision history entry
-        // should not have a Revert button, as it's
-        // the latest practical one.
-        revisionHistoryEntries.first().within(() => {
-          cy.findByText("Revert").should("not.exist");
-        });
-
-        cy.findAllByText("Revert").should("have.length", 2);
+        cy.findAllByText("Revert").should("not.exist");
       });
 
       it.skip("dashboard should update properly on revert (metabase#6884)", () => {


### PR DESCRIPTION
Fixes #1926 

## How to Test

1. Create a new Dashboard
2. Click pencil icon (top, right-hand) to edit
3. Click Save
4. Repeat 2 and 3 one or more times
5. Reload page on the browser
6. Click on **ellipsis (…)** icon (top, right-hand)
7. Click on **Revision History**

### After

1. Top history entry has "What" of "rearranged the cards".
2. Top history entry has no "Revert" button as it's the latest practical revision history entry.

![image](https://user-images.githubusercontent.com/380816/117354633-f1792b00-ae87-11eb-861a-99c0be1a6017.png)

### Before

Several entries with no "What", more fundamentally with no "diff" field in the entry. 
Each entry corresponds (in the testing instructions above) to a Save that follows no change in the Dashboard.

![image](https://user-images.githubusercontent.com/380816/117378167-3cf10080-aeab-11eb-8dab-8e07444c0e7c.png)