### PR TITLE
add timeline with mock data to sidebar

### DIFF
--- a/frontend/src/metabase/components/HistoryModal.jsx
+++ b/frontend/src/metabase/components/HistoryModal.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import { t } from "ttag";
 import ActionButton from "metabase/components/ActionButton";
 import ModalContent from "metabase/components/ModalContent";
+import { getRevisionDescription } from "metabase/lib/revisions";
 
 import moment from "moment";
 
@@ -23,16 +24,6 @@ export default class HistoryModal extends Component {
     onRevert: PropTypes.func,
     onClose: PropTypes.func.isRequired,
   };
-
-  revisionDescription(revision) {
-    if (revision.is_creation) {
-      return t`First revision.`;
-    } else if (revision.is_reversion) {
-      return t`Reverted to an earlier revision and ${revision.description}`;
-    } else {
-      return revision.description;
-    }
-  }
 
   render() {
     const { revisions, onRevert, onClose } = this.props;
@@ -57,7 +48,7 @@ export default class HistoryModal extends Component {
                 </td>
                 <td className={cellClassName}>{revision.user.common_name}</td>
                 <td className={cellClassName}>
-                  <span>{this.revisionDescription(revision)}</span>
+                  <span>{getRevisionDescription(revision)}</span>
                 </td>
                 <td className={cellClassName}>
                   {index !== 0 && onRevert && (

--- a/frontend/src/metabase/components/Timeline.jsx
+++ b/frontend/src/metabase/components/Timeline.jsx
@@ -15,8 +15,13 @@ const TimelineContainer = styled.div`
 `;
 
 const TimelineItem = styled.div`
+  display: flex;
+  align-items: start;
+  justify-content: start;
   transform: translateX(-${props => props.leftShift}px);
   white-space: pre-line;
+  width: 100%;
+  margin-bottom: 1rem;
 `;
 
 // shift the border down slightly so that it doesn't appear above the top-most icon
@@ -56,14 +61,10 @@ const Timeline = ({ className, items = [], renderFooter }) => {
         const isNotLastEvent = index !== sortedFormattedItems.length - 1;
 
         return (
-          <TimelineItem
-            key={key}
-            leftShift={halfIconSize}
-            className="flex align-start justify-start mb2"
-          >
+          <TimelineItem key={key} leftShift={halfIconSize}>
             {isNotLastEvent && <Border borderShift={halfIconSize} />}
             <Icon className="relative text-light" name={icon} size={iconSize} />
-            <div className="ml1">
+            <div className="ml1 flex-1">
               <div className="text-bold">{title}</div>
               <div className="text-medium text-small">{formattedTimestamp}</div>
               <div>{description}</div>

--- a/frontend/src/metabase/components/Timeline.jsx
+++ b/frontend/src/metabase/components/Timeline.jsx
@@ -20,12 +20,12 @@ const TimelineItem = styled.div`
 `;
 
 // shift the border down slightly so that it doesn't appear above the top-most icon
+// also using a negative `bottom` to connect the border with the event icon beneath it
 const Border = styled.div`
   position: absolute;
   top: ${props => props.borderShift}px;
-  left: 0;
-  right: 0;
-  bottom: -${props => props.borderShift}px;
+  left: ${props => props.borderShift}px;
+  bottom: calc(-1rem - ${props => props.borderShift}px);
   border-left: 1px solid ${color("border")};
 `;
 
@@ -50,10 +50,10 @@ const Timeline = ({ className, items = [], renderFooter }) => {
       bottomShift={halfIconSize}
       className={className}
     >
-      <Border borderShift={halfIconSize} />
       {sortedFormattedItems.map((item, index) => {
         const { icon, title, description, formattedTimestamp } = item;
         const key = item.key == null ? index : item.key;
+        const isNotLastEvent = index !== sortedFormattedItems.length - 1;
 
         return (
           <TimelineItem
@@ -61,7 +61,8 @@ const Timeline = ({ className, items = [], renderFooter }) => {
             leftShift={halfIconSize}
             className="flex align-start justify-start mb2"
           >
-            <Icon className="text-light" name={icon} size={iconSize} />
+            {isNotLastEvent && <Border borderShift={halfIconSize} />}
+            <Icon className="relative text-light" name={icon} size={iconSize} />
             <div className="ml1">
               <div className="text-bold">{title}</div>
               <div className="text-medium text-small">{formattedTimestamp}</div>

--- a/frontend/src/metabase/css/core/flex.css
+++ b/frontend/src/metabase/css/core/flex.css
@@ -30,6 +30,10 @@
   flex: 0.5;
 }
 
+.flex-1 {
+  flex: 1;
+}
+
 .flex-3-quarters,
 :local(.flex-3-quarters) {
   flex: 0.75;

--- a/frontend/src/metabase/lib/revisions.js
+++ b/frontend/src/metabase/lib/revisions.js
@@ -1,0 +1,11 @@
+import { t } from "ttag";
+
+export function getRevisionDescription(revision) {
+  if (revision.is_creation) {
+    return t`First revision.`;
+  } else if (revision.is_reversion) {
+    return t`Reverted to an earlier revision and ${revision.description}`;
+  } else {
+    return revision.description;
+  }
+}

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -1386,3 +1386,8 @@ export async function createModerationReview(reviewParams) {
   await ModerationReviewApi.create(reviewParams);
   return softReloadCard();
 }
+
+export async function revertToRevision(revision) {
+  await revision.revert();
+  return reloadCard();
+}

--- a/frontend/src/metabase/query_builder/components/view/ViewSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewSidebar.jsx
@@ -18,14 +18,14 @@ const ViewSideBar = ({ left, right, width = 355, isOpen, children }) => (
   >
     {motionStyle => (
       <div
-        className={cx("bg-white relative overflow-x-hidden", {
+        className={cx("scroll-y bg-white relative overflow-x-hidden", {
           "border-right": left,
           "border-left": right,
         })}
         style={motionStyle}
       >
         <div
-          className="absolute top bottom scroll-y"
+          className="absolute top bottom"
           style={{
             width: width,
             right: left ? 0 : undefined,

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebarPanel.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebarPanel.jsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import SidebarContent from "metabase/query_builder/components/SidebarContent";
 import QuestionActionButtons from "metabase/questions/components/QuestionActionButtons";
 import ClampedText from "metabase/components/ClampedText";
-import { QuestionActivityTimeline } from "metabase/questions/components/QuestionActivityTimeline";
+import QuestionActivityTimeline from "metabase/questions/components/QuestionActivityTimeline";
 import { PLUGIN_MODERATION_COMPONENTS } from "metabase/plugins";
 import { SIDEBAR_VIEWS } from "./constants";
 

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebarPanel.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebarPanel.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import SidebarContent from "metabase/query_builder/components/SidebarContent";
 import QuestionActionButtons from "metabase/questions/components/QuestionActionButtons";
 import ClampedText from "metabase/components/ClampedText";
+import { QuestionActivityTimeline } from "metabase/questions/components/QuestionActivityTimeline";
 import { PLUGIN_MODERATION_COMPONENTS } from "metabase/plugins";
 import { SIDEBAR_VIEWS } from "./constants";
 
@@ -20,7 +21,7 @@ function QuestionDetailsSidebarPanel({ setView, question, onOpenModal }) {
       <div>
         <QuestionActionButtons canWrite={canWrite} onOpenModal={onOpenModal} />
         <ClampedText className="px2 pb2" text={description} visibleLines={8} />
-        <div className="px1 flex justify-between">
+        <div className="mx1 pb2 flex justify-between border-row-divider">
           <ModerationIssueActionMenu
             triggerClassName="Button--round text-brand border-brand"
             onAction={issueType => {
@@ -38,6 +39,7 @@ function QuestionDetailsSidebarPanel({ setView, question, onOpenModal }) {
             }}
           />
         </div>
+        <QuestionActivityTimeline className="px2 pt2" question={question} />
       </div>
     </SidebarContent>
   );

--- a/frontend/src/metabase/query_builder/reducers.js
+++ b/frontend/src/metabase/query_builder/reducers.js
@@ -74,11 +74,12 @@ const UI_CONTROLS_SIDEBAR_DEFAULTS = {
   isShowingQuestionDetailsSidebar: false,
 };
 
-// this is used to close toher sidebar when one is updated
+// this is used to close other sidebar when one is updated
 const CLOSED_NATIVE_EDITOR_SIDEBARS = {
   isShowingTemplateTagsEditor: false,
   isShowingSnippetSidebar: false,
   isShowingDataReference: false,
+  isShowingQuestionDetailsSidebar: false,
 };
 
 // various ui state options

--- a/frontend/src/metabase/questions/components/QuestionActivityTimeline.jsx
+++ b/frontend/src/metabase/questions/components/QuestionActivityTimeline.jsx
@@ -1,0 +1,66 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { t } from "ttag";
+
+import Revision from "metabase/entities/revisions";
+import Timeline from "metabase/components/Timeline";
+
+_QuestionActivityTimeline.propTypes = {
+  question: PropTypes.object,
+  className: PropTypes.string,
+  revisions: PropTypes.array,
+  canRevert: PropTypes.bool,
+};
+
+function _QuestionActivityTimeline({
+  question,
+  className,
+  revisions,
+  canRevert,
+}) {
+  const items = [
+    {
+      icon: "verified",
+      title: "John Someone verified this",
+      description: "idk lol",
+      timestamp: Date.now(),
+      numComments: 5,
+    },
+    {
+      icon: "pencil",
+      title: "Foo edited this",
+      description: "Did a thing.",
+      timestamp: Date.now(),
+    },
+    {
+      icon: "warning_colorized",
+      title: "Someone McSomeone thinks something looks wrong",
+      description:
+        "Uh oh that's not correct. Uh oh that's not correct. Uh oh that's not correct. Uh oh that's not correct. Uh oh that's not correct. Uh oh that's not correct. Uh oh that's not correct. Uh oh that's not correct. Uh oh that's not correct. \nUh oh that's not correct. \nUh oh that's not correct. \nUh oh that's not correct. \nUh oh that's not correct. \nUh oh that's not correct. \nUh oh that's not correct. \nUh oh that's not correct. \nUh oh that's not correct. \nUh oh that's not correct. Uh oh that's not correct. Uh oh that's not correct. Uh oh that's not correct. Uh oh that's not",
+      timestamp: Date.now(),
+    },
+    {
+      icon: "clarification",
+      title: "Someone is confused",
+      description:
+        "Something something something something something something something something something something something something?",
+      timestamp: Date.now(),
+      numComments: 123,
+    },
+  ];
+
+  return (
+    <div className={className}>
+      <div className="text-medium text-bold pb2">{t`Activity`}</div>
+      <Timeline items={items} />
+    </div>
+  );
+}
+
+export const QuestionActivityTimeline = Revision.loadList({
+  query: (state, props) => ({
+    model_type: "card",
+    model_id: props.question.id(),
+  }),
+  wrapped: true, // what does this do
+})(_QuestionActivityTimeline);


### PR DESCRIPTION
Adding the Activity section to the sidebar. Right now only shows revision history but will eventually also include moderation events. Leaving `HistoryModal` alone for now since I'm not showing the "Revert" button in the timeline until we fix the design (it is ugly).

Current appearance:
<img width="348" alt="Screen Shot 2021-05-06 at 9 30 42 PM" src="https://user-images.githubusercontent.com/13057258/117398187-ad4f5000-aeb2-11eb-92fe-8a37f6a00aa5.png">

Fixed the `Timeline` to stop the line at the bottom event in the timeline:
<img width="311" alt="Screen Shot 2021-05-06 at 9 30 53 PM" src="https://user-images.githubusercontent.com/13057258/117398190-afb1aa00-aeb2-11eb-8393-4778e23c735b.png">