### PR TITLE
make Button, Radio, Toggle components more keyboard accessible

### DIFF
--- a/frontend/src/metabase/components/Radio.info.js
+++ b/frontend/src/metabase/components/Radio.info.js
@@ -1,3 +1,5 @@
+/* eslint-disable react/prop-types */
+
 import React from "react";
 import Radio from "metabase/components/Radio";
 
@@ -9,14 +11,18 @@ A standard radio button group.
 `;
 
 const PROPS = {
-  value: 0,
-  options: [{ name: "Gadget", value: 0 }, { name: "Gizmo", value: 1 }],
+  options: [{ name: "Gadget", initValue: 0 }, { name: "Gizmo", value: 1 }],
 };
 
+function RadioWrapper(props) {
+  const [value, setValue] = React.useState(props.initValue);
+  return <Radio {...props} value={value} onChange={setValue} />;
+}
+
 export const examples = {
-  default: <Radio {...PROPS} />,
-  underlined: <Radio {...PROPS} underlined />,
-  "show buttons": <Radio {...PROPS} showButtons />,
-  vertical: <Radio {...PROPS} vertical />,
-  bubble: <Radio {...PROPS} bubble />,
+  default: <RadioWrapper {...PROPS} />,
+  underlined: <RadioWrapper {...PROPS} underlined />,
+  "show buttons": <RadioWrapper {...PROPS} showButtons />,
+  vertical: <RadioWrapper {...PROPS} vertical />,
+  bubble: <RadioWrapper {...PROPS} bubble />,
 };

--- a/frontend/src/metabase/components/Radio.jsx
+++ b/frontend/src/metabase/components/Radio.jsx
@@ -85,7 +85,11 @@ export default class Radio extends Component {
               py={py}
               xspace={xspace}
               yspace={yspace}
+              tabIndex="0"
               onClick={e => onChange(optionValueFn(option))}
+              onKeyUp={e =>
+                e.key === "Enter" && onChange(optionValueFn(option))
+              }
             >
               {option.icon && <Icon name={option.icon} mr={1} />}
               <input

--- a/frontend/src/metabase/components/Radio.jsx
+++ b/frontend/src/metabase/components/Radio.jsx
@@ -71,12 +71,18 @@ export default class Radio extends Component {
     }
 
     return (
-      <List {...props} vertical={vertical} showButtons={showButtons}>
+      <List
+        {...props}
+        vertical={vertical}
+        showButtons={showButtons}
+        role="radiogroup"
+      >
         {options.map((option, index) => {
           const selected = value === optionValueFn(option);
           const last = index === options.length - 1;
           return (
             <Item
+              aria-checked={selected}
               key={optionKeyFn(option)}
               selected={selected}
               last={last}
@@ -87,7 +93,7 @@ export default class Radio extends Component {
               yspace={yspace}
               tabIndex="0"
               onClick={e => onChange(optionValueFn(option))}
-              onKeyUp={e =>
+              onKeyDown={e =>
                 e.key === "Enter" && onChange(optionValueFn(option))
               }
             >

--- a/frontend/src/metabase/components/Toggle.info.js
+++ b/frontend/src/metabase/components/Toggle.info.js
@@ -1,3 +1,5 @@
+/* eslint-disable react/prop-types */
+
 import React from "react";
 import Toggle from "metabase/components/Toggle";
 
@@ -8,7 +10,11 @@ export const description = `
 A standard toggle.
 `;
 
+function ToggleWrapper(props) {
+  const [value, setValue] = React.useState(false);
+  return <Toggle {...props} value={value} onChange={setValue} />;
+}
+
 export const examples = {
-  off: <Toggle value={false} />,
-  on: <Toggle value={true} />,
+  Toggle: <ToggleWrapper />,
 };

--- a/frontend/src/metabase/components/Toggle.jsx
+++ b/frontend/src/metabase/components/Toggle.jsx
@@ -20,9 +20,9 @@ export default class Toggle extends Component {
   };
 
   render() {
-    const { value, small, className, color, onChange, ...props } = this.props;
+    const { value, small, className, color, ...props } = this.props;
     return (
-      <a
+      <div
         {...props}
         className={cx(
           styles.toggle,
@@ -34,7 +34,9 @@ export default class Toggle extends Component {
           className,
         )}
         style={{ color: color || null }}
-        onClick={onChange ? this.handleClick : null}
+        tabIndex="0"
+        onClick={this.handleClick}
+        onKeyUp={e => e.key === "Enter" && this.handleClick()}
       />
     );
   }

--- a/frontend/src/metabase/components/Toggle.jsx
+++ b/frontend/src/metabase/components/Toggle.jsx
@@ -22,7 +22,10 @@ export default class Toggle extends Component {
   render() {
     const { value, small, className, color, ...props } = this.props;
     return (
-      <div
+      <a
+        tabIndex="0"
+        role="switch"
+        aria-checked={value}
         {...props}
         className={cx(
           styles.toggle,
@@ -34,9 +37,8 @@ export default class Toggle extends Component {
           className,
         )}
         style={{ color: color || null }}
-        tabIndex="0"
         onClick={this.handleClick}
-        onKeyUp={e => e.key === "Enter" && this.handleClick()}
+        onKeyDown={e => e.key === "Enter" && this.handleClick()}
       />
     );
   }

--- a/frontend/src/metabase/css/core/base.css
+++ b/frontend/src/metabase/css/core/base.css
@@ -101,7 +101,6 @@ button {
   border: 0;
   padding: 0;
   margin: 0;
-  outline: none;
   background-color: transparent;
 }
 

--- a/frontend/test/metabase/internal/__snapshots__/components.unit.spec.js.snap
+++ b/frontend/test/metabase/internal/__snapshots__/components.unit.spec.js.snap
@@ -1101,15 +1101,17 @@ exports[`Radio should render "bubble" correctly 1`] = `
     mb={null}
     mr={1}
     onClick={[Function]}
+    onKeyUp={[Function]}
     selected={true}
+    tabIndex="0"
   >
     <input
       checked={true}
       className="Form-radio"
-      id="radio-5-0"
+      id="radio-5-undefined"
       name="radio-5"
       type="radio"
-      value={0}
+      value={undefined}
     />
     <span>
       Gadget
@@ -1121,7 +1123,9 @@ exports[`Radio should render "bubble" correctly 1`] = `
     mb={null}
     mr={null}
     onClick={[Function]}
+    onKeyUp={[Function]}
     selected={false}
+    tabIndex="0"
   >
     <input
       checked={false}
@@ -1148,15 +1152,17 @@ exports[`Radio should render "default" correctly 1`] = `
     mb={null}
     mr={3}
     onClick={[Function]}
+    onKeyUp={[Function]}
     selected={true}
+    tabIndex="0"
   >
     <input
       checked={true}
       className="Form-radio"
-      id="radio-1-0"
+      id="radio-1-undefined"
       name="radio-1"
       type="radio"
-      value={0}
+      value={undefined}
     />
     <span>
       Gadget
@@ -1168,7 +1174,9 @@ exports[`Radio should render "default" correctly 1`] = `
     mb={null}
     mr={null}
     onClick={[Function]}
+    onKeyUp={[Function]}
     selected={false}
+    tabIndex="0"
   >
     <input
       checked={false}
@@ -1195,18 +1203,20 @@ exports[`Radio should render "show buttons" correctly 1`] = `
     mb={null}
     mr={3}
     onClick={[Function]}
+    onKeyUp={[Function]}
     selected={true}
+    tabIndex="0"
   >
     <input
       checked={true}
       className="Form-radio"
-      id="radio-3-0"
+      id="radio-3-undefined"
       name="radio-3"
       type="radio"
-      value={0}
+      value={undefined}
     />
     <label
-      htmlFor="radio-3-0"
+      htmlFor="radio-3-undefined"
     />
     <span>
       Gadget
@@ -1218,7 +1228,9 @@ exports[`Radio should render "show buttons" correctly 1`] = `
     mb={null}
     mr={null}
     onClick={[Function]}
+    onKeyUp={[Function]}
     selected={false}
+    tabIndex="0"
   >
     <input
       checked={false}
@@ -1248,15 +1260,17 @@ exports[`Radio should render "underlined" correctly 1`] = `
     mb={null}
     mr={3}
     onClick={[Function]}
+    onKeyUp={[Function]}
     selected={true}
+    tabIndex="0"
   >
     <input
       checked={true}
       className="Form-radio"
-      id="radio-2-0"
+      id="radio-2-undefined"
       name="radio-2"
       type="radio"
-      value={0}
+      value={undefined}
     />
     <span>
       Gadget
@@ -1268,7 +1282,9 @@ exports[`Radio should render "underlined" correctly 1`] = `
     mb={null}
     mr={null}
     onClick={[Function]}
+    onKeyUp={[Function]}
     selected={false}
+    tabIndex="0"
   >
     <input
       checked={false}
@@ -1295,18 +1311,20 @@ exports[`Radio should render "vertical" correctly 1`] = `
     mb={1}
     mr={null}
     onClick={[Function]}
+    onKeyUp={[Function]}
     selected={true}
+    tabIndex="0"
   >
     <input
       checked={true}
       className="Form-radio"
-      id="radio-4-0"
+      id="radio-4-undefined"
       name="radio-4"
       type="radio"
-      value={0}
+      value={undefined}
     />
     <label
-      htmlFor="radio-4-0"
+      htmlFor="radio-4-undefined"
     />
     <span>
       Gadget
@@ -1318,7 +1336,9 @@ exports[`Radio should render "vertical" correctly 1`] = `
     mb={null}
     mr={null}
     onClick={[Function]}
+    onKeyUp={[Function]}
     selected={false}
+    tabIndex="0"
   >
     <input
       checked={false}
@@ -2068,27 +2088,18 @@ exports[`Timeline should render "Optional footer" correctly 1`] = `
 </div>
 `;
 
-exports[`Toggle should render "off" correctly 1`] = `
-<a
+exports[`Toggle should render "Toggle" correctly 1`] = `
+<div
   className="no-decoration"
-  onClick={null}
+  onChange={[Function]}
+  onClick={[Function]}
+  onKeyUp={[Function]}
   style={
     Object {
       "color": null,
     }
   }
-/>
-`;
-
-exports[`Toggle should render "on" correctly 1`] = `
-<a
-  className="no-decoration"
-  onClick={null}
-  style={
-    Object {
-      "color": null,
-    }
-  }
+  tabIndex="0"
 />
 `;
 

--- a/frontend/test/metabase/internal/__snapshots__/components.unit.spec.js.snap
+++ b/frontend/test/metabase/internal/__snapshots__/components.unit.spec.js.snap
@@ -1094,14 +1094,16 @@ exports[`ProgressBar should render "Default" correctly 1`] = `
 exports[`Radio should render "bubble" correctly 1`] = `
 <ul
   className="Radio__BubbleList-sc-1y1p5xd-6 glBcvi Radio__BaseList-sc-1y1p5xd-0 kGqskW"
+  role="radiogroup"
 >
   <li
+    aria-checked={true}
     aria-selected={true}
     className="Radio__BubbleItem-sc-1y1p5xd-7 gROdwm Radio__BaseItem-sc-1y1p5xd-1 gUPocx"
     mb={null}
     mr={1}
     onClick={[Function]}
-    onKeyUp={[Function]}
+    onKeyDown={[Function]}
     selected={true}
     tabIndex="0"
   >
@@ -1118,12 +1120,13 @@ exports[`Radio should render "bubble" correctly 1`] = `
     </span>
   </li>
   <li
+    aria-checked={false}
     aria-selected={false}
     className="Radio__BubbleItem-sc-1y1p5xd-7 gsefvY Radio__BaseItem-sc-1y1p5xd-1 fLjBva"
     mb={null}
     mr={null}
     onClick={[Function]}
-    onKeyUp={[Function]}
+    onKeyDown={[Function]}
     selected={false}
     tabIndex="0"
   >
@@ -1145,14 +1148,16 @@ exports[`Radio should render "bubble" correctly 1`] = `
 exports[`Radio should render "default" correctly 1`] = `
 <ul
   className="Radio__NormalList-sc-1y1p5xd-2 text-bold cakGpL Radio__BaseList-sc-1y1p5xd-0 kGqskW"
+  role="radiogroup"
 >
   <li
+    aria-checked={true}
     aria-selected={true}
     className="Radio__NormalItem-sc-1y1p5xd-3 lnYbWW Radio__BaseItem-sc-1y1p5xd-1 bnxYLr"
     mb={null}
     mr={3}
     onClick={[Function]}
-    onKeyUp={[Function]}
+    onKeyDown={[Function]}
     selected={true}
     tabIndex="0"
   >
@@ -1169,12 +1174,13 @@ exports[`Radio should render "default" correctly 1`] = `
     </span>
   </li>
   <li
+    aria-checked={false}
     aria-selected={false}
     className="Radio__NormalItem-sc-1y1p5xd-3 iIAYuU Radio__BaseItem-sc-1y1p5xd-1 kiDbHp"
     mb={null}
     mr={null}
     onClick={[Function]}
-    onKeyUp={[Function]}
+    onKeyDown={[Function]}
     selected={false}
     tabIndex="0"
   >
@@ -1196,14 +1202,16 @@ exports[`Radio should render "default" correctly 1`] = `
 exports[`Radio should render "show buttons" correctly 1`] = `
 <ul
   className="Radio__NormalList-sc-1y1p5xd-2 cakGpL Radio__BaseList-sc-1y1p5xd-0 kGqskW"
+  role="radiogroup"
 >
   <li
+    aria-checked={true}
     aria-selected={true}
     className="Radio__NormalItem-sc-1y1p5xd-3 lnYbWW Radio__BaseItem-sc-1y1p5xd-1 bnxYLr"
     mb={null}
     mr={3}
     onClick={[Function]}
-    onKeyUp={[Function]}
+    onKeyDown={[Function]}
     selected={true}
     tabIndex="0"
   >
@@ -1223,12 +1231,13 @@ exports[`Radio should render "show buttons" correctly 1`] = `
     </span>
   </li>
   <li
+    aria-checked={false}
     aria-selected={false}
     className="Radio__NormalItem-sc-1y1p5xd-3 iIAYuU Radio__BaseItem-sc-1y1p5xd-1 fwIeaq"
     mb={null}
     mr={null}
     onClick={[Function]}
-    onKeyUp={[Function]}
+    onKeyDown={[Function]}
     selected={false}
     tabIndex="0"
   >
@@ -1253,14 +1262,16 @@ exports[`Radio should render "show buttons" correctly 1`] = `
 exports[`Radio should render "underlined" correctly 1`] = `
 <ul
   className="Radio__UnderlinedList-sc-1y1p5xd-4 yPTIp Radio__NormalList-sc-1y1p5xd-2 Radio__UnderlinedList-sc-1y1p5xd-4 yPTIp text-bold cakGpL Radio__BaseList-sc-1y1p5xd-0 kGqskW"
+  role="radiogroup"
 >
   <li
+    aria-checked={true}
     aria-selected={true}
     className="Radio__UnderlinedItem-sc-1y1p5xd-5 kaIiHA Radio__NormalItem-sc-1y1p5xd-3 lnYbWW Radio__BaseItem-sc-1y1p5xd-1 ljpocb"
     mb={null}
     mr={3}
     onClick={[Function]}
-    onKeyUp={[Function]}
+    onKeyDown={[Function]}
     selected={true}
     tabIndex="0"
   >
@@ -1277,12 +1288,13 @@ exports[`Radio should render "underlined" correctly 1`] = `
     </span>
   </li>
   <li
+    aria-checked={false}
     aria-selected={false}
     className="Radio__UnderlinedItem-sc-1y1p5xd-5 icIYCp Radio__NormalItem-sc-1y1p5xd-3 iIAYuU Radio__BaseItem-sc-1y1p5xd-1 iVApZB"
     mb={null}
     mr={null}
     onClick={[Function]}
-    onKeyUp={[Function]}
+    onKeyDown={[Function]}
     selected={false}
     tabIndex="0"
   >
@@ -1304,14 +1316,16 @@ exports[`Radio should render "underlined" correctly 1`] = `
 exports[`Radio should render "vertical" correctly 1`] = `
 <ul
   className="Radio__NormalList-sc-1y1p5xd-2 cakGpL Radio__BaseList-sc-1y1p5xd-0 dVUlxC"
+  role="radiogroup"
 >
   <li
+    aria-checked={true}
     aria-selected={true}
     className="Radio__NormalItem-sc-1y1p5xd-3 lnYbWW Radio__BaseItem-sc-1y1p5xd-1 dsZxQm"
     mb={1}
     mr={null}
     onClick={[Function]}
-    onKeyUp={[Function]}
+    onKeyDown={[Function]}
     selected={true}
     tabIndex="0"
   >
@@ -1331,12 +1345,13 @@ exports[`Radio should render "vertical" correctly 1`] = `
     </span>
   </li>
   <li
+    aria-checked={false}
     aria-selected={false}
     className="Radio__NormalItem-sc-1y1p5xd-3 iIAYuU Radio__BaseItem-sc-1y1p5xd-1 fwIeaq"
     mb={null}
     mr={null}
     onClick={[Function]}
-    onKeyUp={[Function]}
+    onKeyDown={[Function]}
     selected={false}
     tabIndex="0"
   >
@@ -2089,11 +2104,13 @@ exports[`Timeline should render "Optional footer" correctly 1`] = `
 `;
 
 exports[`Toggle should render "Toggle" correctly 1`] = `
-<div
+<a
+  aria-checked={false}
   className="no-decoration"
   onChange={[Function]}
   onClick={[Function]}
-  onKeyUp={[Function]}
+  onKeyDown={[Function]}
+  role="switch"
   style={
     Object {
       "color": null,


### PR DESCRIPTION
Using our app without a mouse is pretty difficult as some inputs can't be interacted with and others have no styling to show that they are active. I'm happy to improve the styling of these components beyond the default `outline` applied by the browser but we should at the very least show something so that keyboard users have a better time.

This video shows me tabbing across Button components, which currently have no `outline` when active. It also shows me tabbing over and interacting with Radio and Toggle components using keyboard only. Currently, they can't be interacted with using only keyboard.

https://user-images.githubusercontent.com/13057258/117346900-39cf2380-ae5d-11eb-8b0f-c30659d82de7.mov

