### PR TITLE
Use type inference in ExpressionDimensions

### DIFF
--- a/frontend/src/metabase-lib/lib/Dimension.js
+++ b/frontend/src/metabase-lib/lib/Dimension.js
@@ -25,6 +25,8 @@ import { DATETIME_UNITS, formatBucketing } from "metabase/lib/query_time";
 import type Aggregation from "./queries/structured/Aggregation";
 import StructuredQuery from "./queries/StructuredQuery";
 
+import { infer, MONOTYPE } from "metabase/lib/expressions/typeinferencer";
+
 /**
  * A dimension option returned by the query_metadata API
  */
@@ -1001,20 +1003,50 @@ export class ExpressionDimension extends Dimension {
   }
 
   field() {
+    const query = this._query;
+    const table = query ? query.table() : null;
+
+    let type = MONOTYPE.Number; // fallback
+    if (query) {
+      const datasetQuery = query.query();
+      const expressions = datasetQuery ? datasetQuery.expressions : {};
+      type = infer(expressions[this.name()]);
+    } else {
+      type = infer(this._args[0]);
+    }
+
+    let base_type = "type/Float"; // fallback
+    switch (type) {
+      case MONOTYPE.String:
+        base_type = "type/Text";
+        break;
+      case MONOTYPE.Boolean:
+        base_type = "type/Boolean";
+        break;
+      default:
+        break;
+    }
+
     return new Field({
       id: this.mbql(),
       name: this.name(),
       display_name: this.displayName(),
       semantic_type: null,
-      base_type: "type/Float",
-      // HACK: need to thread the query through to this fake Field
-      query: this._query,
-      table: this._query ? this._query.table() : null,
+      base_type,
+      query,
+      table,
     });
   }
 
   icon(): IconName {
-    // TODO: eventually will need to get the type from the return type of the expression
+    const { base_type } = this.field();
+    switch (base_type) {
+      case "type/Text":
+        return "string";
+      default:
+        break;
+    }
+
     return "int";
   }
 }

--- a/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
@@ -620,7 +620,7 @@ describe("Dimension", () => {
           id: ["expression", "Hello World"],
           name: "Hello World",
           display_name: "Hello World",
-          base_type: "type/Float",
+          base_type: "type/Text",
           semantic_type: null,
           field_ref: ["expression", "Hello World"],
         });

--- a/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
@@ -4,6 +4,7 @@ import {
   _typeUsingGet,
   _typeUsingPlaceholder,
   openOrdersTable,
+  openProductsTable,
   visitQuestionAdhoc,
 } from "__support__/e2e/cypress";
 
@@ -412,6 +413,28 @@ describe("scenarios > question > custom columns", () => {
       expect(xhr.response.body.error).to.not.exist;
     });
     cy.contains("37.65");
+  });
+
+  describe("data type", () => {
+    it("should understand string functions", () => {
+      openProductsTable({ mode: "notebook" });
+      cy.findByText("Custom column").click();
+      popover().within(() => {
+        cy.get("[contenteditable='true']")
+          .type("concat([Category], [Title])")
+          .blur();
+        cy.findByPlaceholderText("Something nice and descriptive").type(
+          "CategoryTitle",
+        );
+        cy.findByRole("button", { name: "Done" }).click();
+      });
+      cy.findByText("Filter").click();
+      popover()
+        .findByText("CategoryTitle")
+        .click();
+      cy.findByPlaceholderText("Enter a number").should("not.exist");
+      cy.findByPlaceholderText("Enter some text");
+    });
   });
 
   it("should handle using `case()` when referencing the same column names (metabase#14854)", () => {


### PR DESCRIPTION
Note: this works only for limited variants of expressions for custom column. More will come in subsequent PRs.
For more context, see #15952.

Steps to try:
1. Ask a question, Custom question
2. Sample Dataset, Products table
3. Custom Column, type `replace([Reviewer], "muller", "mueller")` and call it `CorrectName`
4. Filter, CorrectName.

**Before this PR**

![image](https://user-images.githubusercontent.com/7288/117478664-4e222780-af14-11eb-9a04-6cf0125eb30c.png)

**After this PR**

The field `CorrectName` is recognized as a text, not a number.

![image](https://user-images.githubusercontent.com/7288/117478787-6e51e680-af14-11eb-9819-c494b5da2343.png)
