### PR TITLE
#15946 Repro: Converting mongo question to native query doesn't pre-select table

### DIFF
--- a/frontend/test/metabase-db/mongo/native.cy.spec.js
+++ b/frontend/test/metabase-db/mongo/native.cy.spec.js
@@ -1,0 +1,25 @@
+import { restore, addMongoDatabase, modal } from "__support__/e2e/cypress";
+
+const MONGO_DB_NAME = "QA Mongo4";
+
+describe("mongodb > native query", () => {
+  before(() => {
+    restore();
+    cy.signInAsAdmin();
+    addMongoDatabase(MONGO_DB_NAME);
+  });
+
+  it.skip("converting a question to the native query should pre-select a table (metabase#15946)", () => {
+    cy.visit("/question/new");
+    cy.findByText("Custom question").click();
+    cy.findByText(MONGO_DB_NAME).click();
+    cy.findByText("Orders").click();
+    cy.get(".QueryBuilder .Icon-sql").click();
+    modal()
+      .findByText("Convert this question to a native query")
+      .click();
+    modal().should("not.exist");
+    cy.get(".GuiBuilder-data").contains(MONGO_DB_NAME);
+    cy.get(".GuiBuilder-data").contains("Orders");
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #15946

### How to test this manually?
- `yarn test-cypress-open --folder frontend/test/metabase-db/mongo`
- `frontend/test/metabase-db/mongo/native.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/117501613-91b17b80-af7e-11eb-8a0f-543d44c09720.png)

