### PR TITLE
Cypress run: guard against unspecified specs

### DIFF
--- a/frontend/test/__runner__/run_cypress_tests.js
+++ b/frontend/test/__runner__/run_cypress_tests.js
@@ -17,7 +17,7 @@ const isFolderFlag = userArgs.includes("--folder");
 const isSpecFlag = userArgs.includes("--spec");
 const sourceFolderLocation = userArgs[userArgs.indexOf("--folder") + 1];
 const specs = userArgs[userArgs.indexOf("--spec") + 1];
-const isSingleSpec = !specs.match(/,/);
+const isSingleSpec = !specs || !specs.match(/,/);
 const testFiles = isSingleSpec ? specs : specs.split(",");
 
 function readFile(fileName) {


### PR DESCRIPTION

How to test? Run `yarn test-cypress-no-build`.

**Before this PR**

Failed, with the message:

```
var isSingleSpec = !specs.match(/,/);
                          ^
TypeError: Cannot read property 'match' of undefined
```

**After this PR**

Tests are executed as usual.