### PR TITLE
Fix geocode test failures

### DIFF
--- a/test/metabase/api/login_history_test.clj
+++ b/test/metabase/api/login_history_test.clj
@@ -58,7 +58,7 @@
                  :device_description "Browser (Chrome/Windows)"
                  :ip_address         "185.233.100.23"
                  :active             true
-                 :location           "Begles, Nouvelle-Aquitaine, France"
+                 :location           "Talence, Nouvelle-Aquitaine, France"
                  :timezone           "CET"}
                 {:timestamp          "2021-03-18T15:52:20.172351-04:00"
                  :device_description "Browser (Chrome/Windows)"

--- a/test/metabase/server/request/util_test.clj
+++ b/test/metabase/server/request/util_test.clj
@@ -81,7 +81,7 @@
 
     ;; this is from the MaxMind sample high-risk IP address list https://www.maxmind.com/en/high-risk-ip-sample-list
     ["185.233.100.23"]
-    {"185.233.100.23" {:description "Begles, Nouvelle-Aquitaine, France", :timezone (t/zone-id "Europe/Paris")}}
+    {"185.233.100.23" {:description "Talence, Nouvelle-Aquitaine, France", :timezone (t/zone-id "Europe/Paris")}}
 
     ["127.0.0.1"]
     {"127.0.0.1" {:description "Unknown location", :timezone nil}}


### PR DESCRIPTION
Update tests in accordance with changed geocode API results ("Begles" -> "Talence")

See output of: https://get.geojs.io/v1/ip/geo.json?ip=185.233.100.23
