### PR TITLE
Update & edit Google sign-in docs

### DIFF
--- a/docs/administration-guide/10-single-sign-on.md
+++ b/docs/administration-guide/10-single-sign-on.md
@@ -10,13 +10,11 @@ As time goes on we may add other auth providers. If you have a service you’d l
 
 ### Enabling Google Sign-In
 
-To let your team start signing in with Google you’ll first need to create an application through Google’s [developer console](https://console.developers.google.com/projectselector/apis/library).
+To let your team start signing in with Google you’ll first need to create an application through Google’s [developer console](https://console.developers.google.com/projectselector2/apis/library).
 
-To create a new application follow [the instructions from Google here](https://developers.google.com/identity/sign-in/web/devconsole-project).
+Next, you'll have to create authorization credentials for your application by following [the instructions from Google here](https://developers.google.com/identity/sign-in/web/sign-in#create_authorization_credentials). Specify the URI of your Metabase instance in the “Authorized JavaScript origins” section. You should leave the “Authorized Redirect URIs” section blank.
 
-Note that when creating the app you only need to specify the url of your Metabase install in the “Javascript Origins” field. You should leave the “redirect-url” blank.
-
-Once you have your client_id, copy and paste it into the box on the Single Sign-On sections of your Metabase Admin settings page. ```XXXXXXXXXXXXXXXXXXXXX.apps.googleusercontent.com```
+Once you have your `client_id` (ending in `.apps.googleusercontent.com`), click `Configure` on the "Sign in with Google" section of the Authentication page in the Metabase Admin Panel. Paste your `client_id` into the first box.
 
 Now existing Metabase users signed into a Google account that matches their Metabase account email can sign in with just a click.
 


### PR DESCRIPTION
I was researching #9744 and it seems that the current Google link for setting up sign-in is still relevant, but only one section of it ("Create authorization credentials"). So instead of copying over those steps into the Metabase docs I tried to clarify some of the language so it's more explicit which parts to follow, and so that our docs more precisely match the language used by Google.

I was also wondering if it would be better to restructure the docs a bit and have info about each SSO provider on a separate page? Then if we add more details or new SSO providers we don't have to worry about a single page getting longer and longer. 

Resolves #9744