### PR TITLE
Type inference can have access to the environment

### DIFF
--- a/frontend/src/metabase-lib/lib/Dimension.js
+++ b/frontend/src/metabase-lib/lib/Dimension.js
@@ -1010,21 +1010,32 @@ export class ExpressionDimension extends Dimension {
     if (query) {
       const datasetQuery = query.query();
       const expressions = datasetQuery ? datasetQuery.expressions : {};
-      type = infer(expressions[this.name()]);
+      const env = mbql => {
+        const dimension = Dimension.parseMBQL(
+          mbql,
+          this._metadata,
+          this._query,
+        );
+        return dimension.field().base_type;
+      };
+      type = infer(expressions[this.name()], env);
     } else {
       type = infer(this._args[0]);
     }
 
-    let base_type = "type/Float"; // fallback
-    switch (type) {
-      case MONOTYPE.String:
-        base_type = "type/Text";
-        break;
-      case MONOTYPE.Boolean:
-        base_type = "type/Boolean";
-        break;
-      default:
-        break;
+    let base_type = type;
+    if (!type.startsWith("type/")) {
+      base_type = "type/Float"; // fallback
+      switch (type) {
+        case MONOTYPE.String:
+          base_type = "type/Text";
+          break;
+        case MONOTYPE.Boolean:
+          base_type = "type/Boolean";
+          break;
+        default:
+          break;
+      }
     }
 
     return new Field({

--- a/frontend/src/metabase/lib/expressions/typeinferencer.js
+++ b/frontend/src/metabase/lib/expressions/typeinferencer.js
@@ -8,7 +8,7 @@ export const MONOTYPE = {
   Boolean: "boolean",
 };
 
-export function infer(mbql) {
+export function infer(mbql, env) {
   if (!Array.isArray(mbql)) {
     return typeof mbql;
   }
@@ -48,6 +48,10 @@ export function infer(mbql) {
       default:
         return returnType;
     }
+  }
+
+  if (op === "field" && env) {
+    return env(mbql);
   }
 
   return MONOTYPE.Undefined;

--- a/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
@@ -5,6 +5,7 @@ import {
   _typeUsingPlaceholder,
   openOrdersTable,
   openProductsTable,
+  openPeopleTable,
   visitQuestionAdhoc,
 } from "__support__/e2e/cypress";
 
@@ -434,6 +435,23 @@ describe("scenarios > question > custom columns", () => {
         .click();
       cy.findByPlaceholderText("Enter a number").should("not.exist");
       cy.findByPlaceholderText("Enter some text");
+    });
+
+    it("should relay the type of a date field", () => {
+      openPeopleTable({ mode: "notebook" });
+      cy.findByText("Custom column").click();
+      popover().within(() => {
+        _typeUsingGet("[contenteditable='true']", "[Birth Date]", 400);
+        _typeUsingPlaceholder("Something nice and descriptive", "DoB");
+        cy.findByText("Done").click();
+      });
+      cy.findByText("Filter").click();
+      popover()
+        .findByText("DoB")
+        .click();
+      cy.findByPlaceholderText("Enter a number").should("not.exist");
+      cy.findByText("Previous");
+      cy.findByText("Days");
     });
   });
 


### PR DESCRIPTION
In this case, to fetch the field type.

This requires PR #15965 to be merged first. See #15952 for the bigger context.

Steps to try:

1. Ask a question, Custom question
2. Sample Dataset, People table
3. Custom Column, choose _Birth Date_ and call it `DoB`
4. Filter, DoB.

**Before this PR**

The field DoB is incorrectly treated as a number:

![image](https://user-images.githubusercontent.com/7288/117620046-e7c02380-b124-11eb-8e9b-689a25c719a6.png)

**After this PR**

The field DoB is **correctly** treated as a date:

![image](https://user-images.githubusercontent.com/7288/117620068-eee73180-b124-11eb-8b92-285b118b1ed6.png)


Also, run the unit tests:
```
yarn test-unit frontend/test/metabase/lib/expressions/typeinferencer.unit.spec.js
```

and E2E:
```
yarn test-cypress-no-build --spec frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
```