### PR TITLE
Add Explore results button to saved SQL questions

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -10,6 +10,7 @@ import ButtonBar from "metabase/components/ButtonBar";
 import CollectionBadge from "metabase/questions/components/CollectionBadge";
 
 import ViewSection, { ViewHeading, ViewSubHeading } from "./ViewSection";
+import ViewButton from "metabase/query_builder/components/view/ViewButton"
 
 import QuestionDataSource from "./QuestionDataSource";
 import QuestionDescription from "./QuestionDescription";
@@ -260,6 +261,13 @@ export class ViewTitleHeader extends React.Component {
                 data-metabase-event={`Notebook Mode; Convert to SQL Click`}
               />
             </Box>
+          )}
+          {question.query().database() && isNative && isSaved && (
+            <Link to={question.composeThisQuery().setDisplay("table").setSettings({}).getUrl()}>
+              <ViewButton medium p={[2, 1]} icon="insight" labelBreakpoint="sm">
+                {t`Explore results`}
+              </ViewButton>
+            </Link>
           )}
           {isRunnable && !isNativeEditorOpen && (
             <RunButtonWithTooltip

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -10,7 +10,7 @@ import ButtonBar from "metabase/components/ButtonBar";
 import CollectionBadge from "metabase/questions/components/CollectionBadge";
 
 import ViewSection, { ViewHeading, ViewSubHeading } from "./ViewSection";
-import ViewButton from "metabase/query_builder/components/view/ViewButton"
+import ViewButton from "metabase/query_builder/components/view/ViewButton";
 
 import QuestionDataSource from "./QuestionDataSource";
 import QuestionDescription from "./QuestionDescription";
@@ -263,7 +263,13 @@ export class ViewTitleHeader extends React.Component {
             </Box>
           )}
           {question.query().database() && isNative && isSaved && (
-            <Link to={question.composeThisQuery().setDisplay("table").setSettings({}).getUrl()}>
+            <Link
+              to={question
+                .composeThisQuery()
+                .setDisplay("table")
+                .setSettings({})
+                .getUrl()}
+            >
               <ViewButton medium p={[2, 1]} icon="insight" labelBreakpoint="sm">
                 {t`Explore results`}
               </ViewButton>


### PR DESCRIPTION
Updated version of #15010. We'd like to get this into 0.40 and use this as a way to flush out any potential corner cases like https://github.com/metabase/metabase/issues/15397. Instead of reverting the revert of the PR I just went ahead and re-implemented this using @paulrosenzweig's [cleaner recommendation](https://github.com/metabase/metabase/pull/15010#discussion_r599084621). 

Per the original PR.

## What this does

Adds an action to the header for saved SQL questions that opens the current saved question in the "simple mode" query builder to let users explore the results using more comfortable tools. In the long term I'd prefer you be able to interact right where you are without having to click another action, but this addition acts as a shortcut to let you effectively start a new question from this "table" like you can if you select "Saved questions" when starting a new question.