### PR TITLE
#15981 Repro: Feature flag causes problems with Text and Number filters in Native query

### DIFF
--- a/frontend/test/metabase/scenarios/native/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/native.cy.spec.js
@@ -695,7 +695,7 @@ describe("scenarios > question > native", () => {
         cy.findByText("Rustic Paper Wallet");
         cy.icon("contract").click();
         cy.findByText("Showing 51 rows");
-        cy.get("RunButton").should("not.exist");
+        cy.get(".RunButton").should("not.exist");
       });
 
       it(`number filter should work with the feature flag turned ${testCase}`, () => {

--- a/frontend/test/metabase/scenarios/native/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/native.cy.spec.js
@@ -648,9 +648,11 @@ describe("scenarios > question > native", () => {
   it.skip("should be able to add new columns after hiding some (metabase#15393)", () => {
     cy.visit("/");
     cy.icon("sql").click();
-    cy.get(".ace_content").type("select 1 as visible, 2 as hidden");
-    cy.get(".NativeQueryEditor .Icon-play")
+    cy.get(".ace_content")
       .as("editor")
+      .type("select 1 as visible, 2 as hidden");
+    cy.get(".NativeQueryEditor .Icon-play")
+      .as("runQuery")
       .click();
     cy.findByText("Settings").click();
     cy.findByTestId("sidebar-left")
@@ -659,9 +661,7 @@ describe("scenarios > question > native", () => {
       .siblings(".Icon-close")
       .click();
     cy.get("@editor").type("{movetoend}, 3 as added");
-    cy.get(".NativeQueryEditor .Icon-play")
-      .as("editor")
-      .click();
+    cy.get("@runQuery").click();
     cy.get("@sidebar").contains(/added/i);
   });
 });

--- a/frontend/test/metabase/scenarios/native/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/native.cy.spec.js
@@ -670,7 +670,6 @@ describe("scenarios > question > native", () => {
 
     describe.skip("Feature flag causes problems with Text and Number filters in Native query (metabase#15981)", () => {
       beforeEach(() => {
-        cy.signInAsNormalUser();
         mockSessionProperty(
           "field-filter-operators-enabled?",
           isFeatureFlagTurnedOn,

--- a/frontend/test/metabase/scenarios/native/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/native.cy.spec.js
@@ -664,4 +664,65 @@ describe("scenarios > question > native", () => {
     cy.get("@runQuery").click();
     cy.get("@sidebar").contains(/added/i);
   });
+
+  ["off", "on"].forEach(testCase => {
+    const isFeatureFlagTurnedOn = testCase === "off" ? false : true;
+
+    describe.skip("Feature flag causes problems with Text and Number filters in Native query (metabase#15981)", () => {
+      beforeEach(() => {
+        cy.signInAsNormalUser();
+        mockSessionProperty(
+          "field-filter-operators-enabled?",
+          isFeatureFlagTurnedOn,
+        );
+
+        cy.visit("/");
+        cy.icon("sql").click();
+        cy.get(".ace_content").as("editor");
+
+        cy.intercept("POST", "/api/dataset").as("dataset");
+      });
+
+      it(`text filter should work with the feature flag turned ${testCase}`, () => {
+        cy.get("@editor").type(
+          "select * from PRODUCTS where CATEGORY = {{text_filter}}",
+          {
+            parseSpecialCharSequences: false,
+          },
+        );
+        cy.get("fieldset").type("Gizmo");
+        cy.get(".NativeQueryEditor .Icon-play").click();
+        cy.wait("@dataset");
+        cy.findByText("Rustic Paper Wallet");
+        cy.icon("contract").click();
+        cy.findByText("Showing 51 rows");
+        cy.get("RunButton").should("not.exist");
+      });
+
+      it(`number filter should work with the feature flag turned ${testCase}`, () => {
+        cy.get("@editor").type(
+          "select * from ORDERS where QUANTITY = {{number_filter}}",
+          {
+            parseSpecialCharSequences: false,
+          },
+        );
+        cy.findByTestId("sidebar-right")
+          .as("sidebar")
+          .within(() => {
+            cy.get(".AdminSelect")
+              .contains("Text")
+              .click();
+          });
+        popover()
+          .contains("Number")
+          .click();
+        cy.get("fieldset").type("20");
+        cy.get(".NativeQueryEditor .Icon-play").click();
+        cy.wait("@dataset").then(xhr => {
+          expect(xhr.response.body.error).not.to.exist;
+        });
+        cy.get(".Visualization").contains("23.54");
+      });
+    });
+  });
 });


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #15981

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/native/native.cy.spec.js`
- Replace `describe.skip()` with `describe.only()` to run tests in isolation
- The tests that have the feature flag should fail until the related issue is fixed, while the ones with the feature flag turned off already work and don't need fixing

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
The current state
![image](https://user-images.githubusercontent.com/31325167/117692782-a4fe5a00-b1bd-11eb-8071-d27fc898acee.png)

1. Text filter with feature flag turned OFF
![image](https://user-images.githubusercontent.com/31325167/117693146-ff97b600-b1bd-11eb-8b22-a68c0e151b35.png)

2. Number filter with feature flag turned OFF
![image](https://user-images.githubusercontent.com/31325167/117693211-12aa8600-b1be-11eb-911a-47c8ff1704da.png)

3. Text filter with feature flag turned ON
![image](https://user-images.githubusercontent.com/31325167/117693355-3e2d7080-b1be-11eb-8d49-f6f3f619188c.png)

4. Number filter with feature flag turned ON
![image](https://user-images.githubusercontent.com/31325167/117693286-2bb33700-b1be-11eb-8158-4654cd504810.png)
