### PR TITLE
fix replacement for plural message

### DIFF
--- a/bin/i18n/src/i18n/create_artifacts/frontend.clj
+++ b/bin/i18n/src/i18n/create_artifacts/frontend.clj
@@ -28,7 +28,7 @@
                     [(->ttag-reference (:id message))
                      (if (:plural? message)
                        {:msgid_plural (:id-plural message)
-                        :msgstr       (:str-plural message)}
+                        :msgstr       (map ->ttag-reference (:str-plural message))}
                        {:msgstr [(->ttag-reference (:str message))]})])))
             messages)})
 

--- a/bin/i18n/test/i18n/create_artifacts/frontend_test.clj
+++ b/bin/i18n/test/i18n/create_artifacts/frontend_test.clj
@@ -25,5 +25,5 @@
 
                           "${ 0 } Queryable Table"
                           {:msgid_plural "{0} Queryable Tables"
-                           :msgstr       ["{0] Tabla Consultable" "{0] Tablas consultables"]}}}}
+                           :msgstr       ["${ 0 } Tabla Consultable" "${ 0 } Tablas consultables"]}}}}
          (#'frontend/->i18n-map test-common/po-contents))))

--- a/bin/i18n/test/i18n/create_artifacts/test_common.clj
+++ b/bin/i18n/test/i18n/create_artifacts/test_common.clj
@@ -44,7 +44,7 @@
   {:id                "{0} Queryable Table"
    :id-plural         "{0} Queryable Tables"
    :str               nil
-   :str-plural        ["{0] Tabla Consultable" "{0] Tablas consultables"]
+   :str-plural        ["{0} Tabla Consultable" "{0} Tablas consultables"]
    :fuzzy?            false
    :plural?           true
    :source-references ["frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:77"]

--- a/test/metabase/api/login_history_test.clj
+++ b/test/metabase/api/login_history_test.clj
@@ -58,7 +58,7 @@
                  :device_description "Browser (Chrome/Windows)"
                  :ip_address         "185.233.100.23"
                  :active             true
-                 :location           "Begles, Nouvelle-Aquitaine, France"
+                 :location           "Talence, Nouvelle-Aquitaine, France"
                  :timezone           "CET"}
                 {:timestamp          "2021-03-18T15:52:20.172351-04:00"
                  :device_description "Browser (Chrome/Windows)"

--- a/test/metabase/server/request/util_test.clj
+++ b/test/metabase/server/request/util_test.clj
@@ -81,7 +81,7 @@
 
     ;; this is from the MaxMind sample high-risk IP address list https://www.maxmind.com/en/high-risk-ip-sample-list
     ["185.233.100.23"]
-    {"185.233.100.23" {:description "Begles, Nouvelle-Aquitaine, France", :timezone (t/zone-id "Europe/Paris")}}
+    {"185.233.100.23" {:description "Talence, Nouvelle-Aquitaine, France", :timezone (t/zone-id "Europe/Paris")}}
 
     ["127.0.0.1"]
     {"127.0.0.1" {:description "Unknown location", :timezone nil}}


### PR DESCRIPTION
Fix https://github.com/metabase/metabase/issues/15694

After this change, run the following command.
`./bin/i18n/build-translation-resources`

I confirmed the fix for plural placeholders in several languages.

![スクリーンショット 2021-05-11 2 12 35](https://user-images.githubusercontent.com/7043684/117705459-05fe5000-b207-11eb-8237-27ca407a0d0f.png)
![スクリーンショット 2021-05-11 2 24 17](https://user-images.githubusercontent.com/7043684/117705465-072f7d00-b207-11eb-88a3-4e9629437699.png)
![スクリーンショット 2021-05-11 2 25 35](https://user-images.githubusercontent.com/7043684/117705467-072f7d00-b207-11eb-9bbf-95c6699a55a8.png)


-----

###### Before submitting the PR, please make sure you do the following

- [x] If you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.

### Tests

- [x] Run the frontend and Cypress end-to-end tests with `yarn lint && yarn test`)
- [x] If there are changes to the backend codebase, run the backend tests with `lein test && lein lint && ./bin/reflection-linter`
- [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
      (unless it's a tiny documentation change).
