### PR TITLE
Parse number filter inputs

### DIFF
--- a/frontend/src/metabase/meta/Parameter.js
+++ b/frontend/src/metabase/meta/Parameter.js
@@ -325,28 +325,37 @@ function tagFilterForParameter(parameter: Parameter): TemplateTagFilter {
 
 // NOTE: this should mirror `template-tag-parameters` in src/metabase/api/embed.clj
 export function getTemplateTagParameters(tags: TemplateTag[]): Parameter[] {
+  function getTemplateTagType(tag) {
+    const { type } = tag;
+    if (type === "date") {
+      return "date/single";
+    } else if (areFieldFilterOperatorsEnabled() && type === "string") {
+      return "string/=";
+    } else if (areFieldFilterOperatorsEnabled() && type === "number") {
+      return "number/=";
+    } else {
+      return "category";
+    }
+  }
+
   return tags
     .filter(
       tag =>
         tag.type != null && (tag["widget-type"] || tag.type !== "dimension"),
     )
-    .map(tag => ({
-      id: tag.id,
-      type:
-        tag["widget-type"] ||
-        (tag.type === "date"
-          ? "date/single"
-          : areFieldFilterOperatorsEnabled()
-          ? "string/="
-          : "category"),
-      target:
-        tag.type === "dimension"
-          ? ["dimension", ["template-tag", tag.name]]
-          : ["variable", ["template-tag", tag.name]],
-      name: tag["display-name"],
-      slug: tag.name,
-      default: tag.default,
-    }));
+    .map(tag => {
+      return {
+        id: tag.id,
+        type: tag["widget-type"] || getTemplateTagType(tag),
+        target:
+          tag.type === "dimension"
+            ? ["dimension", ["template-tag", tag.name]]
+            : ["variable", ["template-tag", tag.name]],
+        name: tag["display-name"],
+        slug: tag.name,
+        default: tag.default,
+      };
+    });
 }
 
 export const getParametersBySlug = (

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -14,6 +14,7 @@ import {
 } from "metabase/visualizations";
 import { getComputedSettingsForSeries } from "metabase/visualizations/lib/settings/visualization";
 import { getParametersWithExtras } from "metabase/meta/Card";
+import { normalizeParameterValue } from "metabase/meta/Parameter";
 
 import Utils from "metabase/lib/utils";
 
@@ -144,7 +145,14 @@ const getLastRunParameterValues = createSelector(
 const getNextRunParameterValues = createSelector(
   [getParameters],
   parameters =>
-    parameters.map(parameter => parameter.value).filter(p => p !== undefined),
+    parameters
+      .map(parameter =>
+        // parameters are "normalized" immediately before a query run, so in order
+        // to compare current parameters to previously-used parameters we need
+        // to run parameters through this normalization function
+        normalizeParameterValue(parameter.type, parameter.value),
+      )
+      .filter(p => p !== undefined),
 );
 
 // Certain differences in a query should be ignored. `normalizeQuery`

--- a/frontend/test/metabase/meta/Parameter.unit.spec.js
+++ b/frontend/test/metabase/meta/Parameter.unit.spec.js
@@ -1,3 +1,4 @@
+import MetabaseSettings from "metabase/lib/settings";
 import {
   dateParameterValueToMBQL,
   stringParameterValueToMBQL,
@@ -6,9 +7,24 @@ import {
   getParametersBySlug,
   normalizeParameterValue,
   deriveFieldOperatorFromParameter,
+  getTemplateTagParameters,
 } from "metabase/meta/Parameter";
 
+MetabaseSettings.get = jest.fn();
+
+function mockFieldFilterOperatorsFlag(value) {
+  MetabaseSettings.get.mockImplementation(flag => {
+    if (flag === "field-filter-operators-enabled?") {
+      return value;
+    }
+  });
+}
+
 describe("metabase/meta/Parameter", () => {
+  beforeEach(() => {
+    MetabaseSettings.get.mockReturnValue(false);
+  });
+
   describe("dateParameterValueToMBQL", () => {
     it("should parse past30days", () => {
       expect(dateParameterValueToMBQL("past30days", null)).toEqual([
@@ -273,6 +289,160 @@ describe("metabase/meta/Parameter", () => {
         expect(deriveFieldOperatorFromParameter({ type: "date/single" })).toBe(
           undefined,
         );
+      });
+    });
+  });
+
+  describe("getTemplateTagParameters", () => {
+    let tags;
+    beforeEach(() => {
+      tags = [
+        {
+          "widget-type": "foo",
+          type: "string",
+          id: 1,
+          name: "a",
+          "display-name": "A",
+          default: "abc",
+        },
+        {
+          type: "string",
+          id: 2,
+          name: "b",
+          "display-name": "B",
+        },
+        {
+          type: "number",
+          id: 3,
+          name: "c",
+          "display-name": "C",
+        },
+        {
+          type: "date",
+          id: 4,
+          name: "d",
+          "display-name": "D",
+        },
+        {
+          "widget-type": "foo",
+          type: "dimension",
+          id: 5,
+          name: "e",
+          "display-name": "E",
+        },
+        {
+          type: null,
+          id: 6,
+        },
+        {
+          type: "dimension",
+          id: 7,
+          name: "f",
+          "display-name": "F",
+        },
+      ];
+    });
+
+    describe("field filter operators enabled", () => {
+      beforeEach(() => {
+        mockFieldFilterOperatorsFlag(true);
+      });
+
+      it("should convert tags into tag parameters with field filter operator types", () => {
+        const parametersWithFieldFilterOperatorTypes = [
+          {
+            default: "abc",
+            id: 1,
+            name: "A",
+            slug: "a",
+            target: ["variable", ["template-tag", "a"]],
+            type: "foo",
+          },
+          {
+            default: undefined,
+            id: 2,
+            name: "B",
+            slug: "b",
+            target: ["variable", ["template-tag", "b"]],
+            type: "string/=",
+          },
+          {
+            default: undefined,
+            id: 3,
+            name: "C",
+            slug: "c",
+            target: ["variable", ["template-tag", "c"]],
+            type: "number/=",
+          },
+          {
+            default: undefined,
+            id: 4,
+            name: "D",
+            slug: "d",
+            target: ["variable", ["template-tag", "d"]],
+            type: "date/single",
+          },
+          {
+            default: undefined,
+            id: 5,
+            name: "E",
+            slug: "e",
+            target: ["dimension", ["template-tag", "e"]],
+            type: "foo",
+          },
+        ];
+
+        expect(getTemplateTagParameters(tags)).toEqual(
+          parametersWithFieldFilterOperatorTypes,
+        );
+      });
+    });
+
+    describe("field filter operators disabled", () => {
+      it("should convert tags into tag parameters", () => {
+        const parameters = [
+          {
+            default: "abc",
+            id: 1,
+            name: "A",
+            slug: "a",
+            target: ["variable", ["template-tag", "a"]],
+            type: "foo",
+          },
+          {
+            default: undefined,
+            id: 2,
+            name: "B",
+            slug: "b",
+            target: ["variable", ["template-tag", "b"]],
+            type: "category",
+          },
+          {
+            default: undefined,
+            id: 3,
+            name: "C",
+            slug: "c",
+            target: ["variable", ["template-tag", "c"]],
+            type: "category",
+          },
+          {
+            default: undefined,
+            id: 4,
+            name: "D",
+            slug: "d",
+            target: ["variable", ["template-tag", "d"]],
+            type: "date/single",
+          },
+          {
+            default: undefined,
+            id: 5,
+            name: "E",
+            slug: "e",
+            target: ["dimension", ["template-tag", "e"]],
+            type: "foo",
+          },
+        ];
+        expect(getTemplateTagParameters(tags)).toEqual(parameters);
       });
     });
   });

--- a/frontend/test/metabase/scenarios/native/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/native.cy.spec.js
@@ -668,7 +668,7 @@ describe("scenarios > question > native", () => {
   ["off", "on"].forEach(testCase => {
     const isFeatureFlagTurnedOn = testCase === "off" ? false : true;
 
-    describe.skip("Feature flag causes problems with Text and Number filters in Native query (metabase#15981)", () => {
+    describe("Feature flag causes problems with Text and Number filters in Native query (metabase#15981)", () => {
       beforeEach(() => {
         mockSessionProperty(
           "field-filter-operators-enabled?",
@@ -682,7 +682,7 @@ describe("scenarios > question > native", () => {
         cy.intercept("POST", "/api/dataset").as("dataset");
       });
 
-      it(`text filter should work with the feature flag turned ${testCase}`, () => {
+      it.skip(`text filter should work with the feature flag turned ${testCase}`, () => {
         cy.get("@editor").type(
           "select * from PRODUCTS where CATEGORY = {{text_filter}}",
           {

--- a/frontend/test/metabase/scenarios/native/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/native.cy.spec.js
@@ -682,7 +682,7 @@ describe("scenarios > question > native", () => {
         cy.intercept("POST", "/api/dataset").as("dataset");
       });
 
-      it.skip(`text filter should work with the feature flag turned ${testCase}`, () => {
+      it(`text filter should work with the feature flag turned ${testCase}`, () => {
         cy.get("@editor").type(
           "select * from PRODUCTS where CATEGORY = {{text_filter}}",
           {
@@ -695,7 +695,7 @@ describe("scenarios > question > native", () => {
         cy.findByText("Rustic Paper Wallet");
         cy.icon("contract").click();
         cy.findByText("Showing 51 rows");
-        cy.get(".RunButton").should("not.exist");
+        cy.icon("play").should("not.exist");
       });
 
       it(`number filter should work with the feature flag turned ${testCase}`, () => {

--- a/src/metabase/api/embed.clj
+++ b/src/metabase/api/embed.clj
@@ -135,9 +135,10 @@
         :when                         (and tag-type
                                            (or widget-type (not= tag-type :dimension)))]
     {:id      (:id tag)
-     :type    (or widget-type (cond (= tag-type :date)                       :date/single
-                                    (params/field-filter-operators-enabled?) :string/=
-                                    :else                                    :category))
+     :type    (or widget-type (cond (= tag-type :date)                                                :date/single
+                                    (and params/field-filter-operators-enabled? (= tag-type :string)) :string/=
+                                    (and params/field-filter-operators-enabled? (= tag-type :number)) :number/=
+                                    :else                                                             :category))
      :target  (if (= tag-type :dimension)
                 [:dimension [:template-tag (:name tag)]]
                 [:variable  [:template-tag (:name tag)]])

--- a/src/metabase/api/embed.clj
+++ b/src/metabase/api/embed.clj
@@ -135,10 +135,10 @@
         :when                         (and tag-type
                                            (or widget-type (not= tag-type :dimension)))]
     {:id      (:id tag)
-     :type    (or widget-type (cond (= tag-type :date)                                                :date/single
-                                    (and params/field-filter-operators-enabled? (= tag-type :string)) :string/=
-                                    (and params/field-filter-operators-enabled? (= tag-type :number)) :number/=
-                                    :else                                                             :category))
+     :type    (or widget-type (cond (= tag-type :date)                                                  :date/single
+                                    (and (params/field-filter-operators-enabled?) (= tag-type :string)) :string/=
+                                    (and (params/field-filter-operators-enabled?) (= tag-type :number)) :number/=
+                                    :else                                                               :category))
      :target  (if (= tag-type :dimension)
                 [:dimension [:template-tag (:name tag)]]
                 [:variable  [:template-tag (:name tag)]])

--- a/src/metabase/driver/common/parameters/values.clj
+++ b/src/metabase/driver/common/parameters/values.clj
@@ -235,6 +235,13 @@
    (number? value) value
    ;; same goes for an instance of CommaSeperated values
    (instance? CommaSeparatedNumbers value) value
+
+   ;; newer operators use vectors as their arguments even if there's only one
+   (vector? value)
+   (let [values (map parse-number value)]
+     (if (next values)
+       (i/map->CommaSeparatedNumbers {:numbers values})
+       (first values)))
    ;; if the value is a string, then split it by commas in the string. Usually there should be none.
    ;; Parse each part as a number.
    (string? value)

--- a/test/metabase/driver/common/parameters/values_test.clj
+++ b/test/metabase/driver/common/parameters/values_test.clj
@@ -4,7 +4,6 @@
             [metabase.driver.common.parameters :as i]
             [metabase.driver.common.parameters.values :as values]
             [metabase.models :refer [Card Collection NativeQuerySnippet]]
-            [metabase.models.field :refer [map->FieldInstance]]
             [metabase.models.permissions :as perms]
             [metabase.models.permissions-group :as group]
             [metabase.query-processor :as qp]
@@ -19,6 +18,15 @@
            (#'values/value-for-tag
             {:name "id", :display-name "ID", :type :text, :required true, :default "100"}
             [{:type :category, :target [:variable [:template-tag "id"]], :value "2"}]))))
+  (testing "Multiple values with new operators"
+    (is (= 20
+           (#'values/value-for-tag
+            {:name "number_filter", :display-name "ID", :type :number, :required true, :default "100"}
+            [{:type :number/=, :value ["20"], :target [:variable [:template-tag "number_filter"]]}])))
+    (is (= (i/map->CommaSeparatedNumbers {:numbers [20 40]})
+           (#'values/value-for-tag
+            {:name "number_filter", :display-name "ID", :type :number, :required true, :default "100"}
+            [{:type :number/=, :value ["20" "40"], :target [:variable [:template-tag "number_filter"]]}]))))
 
   (testing "Unspecified value"
     (is (= i/no-value


### PR DESCRIPTION
This is half of https://github.com/metabase/metabase/issues/15981

The frontend feels a bit off on this. It's sending `"string/="`
instead of `"number/="` but the backend code knows that number filters
can ignore it. It's also sending strings from the text inputs when it
should be sending number types.

We've had a convention that the types come across as they should be:
numbers come in as numbers and strings as strings. This seems to break
that convention.

So I think we need some frontend changes: to send `:number/=` (even if that's ignored, it might not be in the future and this will be a weird surprise) and to send parsed numbers.

A repro of the observed behavior was the following:

```clojure
(some?
 (qp/process-query {:database 1,
                    :native
                    {:template-tags
                     {:number_filter
                      {:id "3f494325-fadc-2318-2547-21b71d36494a",
                       :name "number_filter",
                       :display-name "Number filter",
                       :type "number",
                       :default nil}},
                     :query "select * from ORDERS where QUANTITY = {{number_filter}}"},
                    :type "native",
                    :parameters [{:type "string/=",
                                  :value ["20"], ;; new style arg passing
                                  :target ["variable" ["template-tag" "number_filter"]]}]}))
```

The type and value on that parameter are acting like the new style we did. But they aren't particularly in the new format. When @daltojohnso is back I can get with him and we can iron this out.