### PR TITLE
Fix "remember me" checkbox on login 

### DIFF
--- a/docs/operations-guide/changing-session-expiration.md
+++ b/docs/operations-guide/changing-session-expiration.md
@@ -23,17 +23,21 @@ java -DMAX_SESSION_AGE=1440 -jar metabase.jar
 ### Using Session cookies
 
 Metabase also supports using [session
-cookies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#Session_cookies), which mean users will stay
-authenticated until they close their browser window. Once they close their browser window, next time they visit
-Metabase they'll have to log in again. Session expiration still applies, so even if you leave your browser window open
-forever, you'll still be required to re-authenticate after two weeks or whatever session expiration you've configured.
+cookies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#Session_cookies), which mean users will only stay
+authenticated until they close their browser. This can be enabled on a per-user basis by unchecking the "Remember me"
+box when logging in. Once the user closes their browser, the next time they visit Metabase they'll have to log in
+again. Session expiration still applies, so even if you leave your browser open forever, you'll still be
+required to re-authenticate after two weeks or whatever session expiration you've configured.
 
-You can tell Metabase to use session cookies with the environment variable or Java system property
+You can tell Metabase to always use session cookies with the environment variable or Java system property
 `MB_SESSION_COOKIES`:
 
 ```
 MB_SESSION_COOKIES=true java -jar metabase.jar
 ```
+
+Setting this environment variable will override the behavior of the "Remember me" checkbox and enforce the use of
+session cookies for all users.
 
 Note that browsers may use "session restoring", which means they automatically restore their previous session when
 reopened. In this case, the browser effectively acts as if it was never closed; session cookies will act

--- a/docs/operations-guide/environment-variables.md
+++ b/docs/operations-guide/environment-variables.md
@@ -946,7 +946,8 @@ Send email notifications to users in Admin group, when a new SSO users is create
 Type: boolean<br>
 Default: `null`
 
-When set to `true`, the user login session will expire, when the browser is closed. The user login session will always expire after the amount of time defined in [MAX_SESSION_AGE](#max_session_age) (by default 2 weeks).
+When set to `true`, the user login session will expire when the browser is closed. The user login session will always expire after the amount of time defined in [MAX_SESSION_AGE](#max_session_age) (by default 2 weeks).
+This overrides the "Remember me" checkbox when logging in.
 
 Also see the [Changing session expiration](changing-session-expiration.md) documentation page.
 

--- a/frontend/src/metabase/auth/components/LdapAndEmailForm.jsx
+++ b/frontend/src/metabase/auth/components/LdapAndEmailForm.jsx
@@ -25,6 +25,7 @@ export default class LdapAndEmailForm extends Component {
 
   render() {
     const ldapEnabled = Settings.ldapEnabled();
+    const rememberMeDisabled = Settings.get("session-cookies");
     return (
       <Form onSubmit={this.onSubmit}>
         {({ values, Form, FormField, FormSubmit, FormMessage }) => (
@@ -51,6 +52,7 @@ export default class LdapAndEmailForm extends Component {
               type="checkbox"
               title={t`Remember me`}
               initial={true}
+              hidden={rememberMeDisabled}
               horizontal
             />
             <FormMessage />

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -341,6 +341,12 @@
   :setter     :none
   :getter     (constantly password/active-password-complexity))
 
+(defsetting session-cookies
+  (deferred-tru "When set, enforces the use of session cookies for all users which expire when the browser is closed.")
+  :type       :boolean
+  :visibility :public
+  :default    nil)
+
 (defsetting report-timezone-short
   "Current report timezone abbreviation"
   :visibility :public

--- a/src/metabase/server/middleware/session.clj
+++ b/src/metabase/server/middleware/session.clj
@@ -10,6 +10,7 @@
             [metabase.driver.sql.query-processor :as sql.qp]
             [metabase.models.session :refer [Session]]
             [metabase.models.user :as user :refer [User]]
+            [metabase.public-settings :as public-settings]
             [metabase.server.request.util :as request.u]
             [metabase.util :as u]
             [metabase.util.i18n :as i18n :refer [deferred-trs tru]]
@@ -54,7 +55,7 @@
 (defn- use-permanent-cookies?
   "Check if we should use permanent cookies for a given request, which are not cleared when a browser sesion ends."
   [request]
-  (if (config/config-bool :mb-session-cookies)
+  (if (public-settings/session-cookies)
     ;; Disallow permanent cookies if MB_SESSION_COOKIES is set
     false
     ;; Otherwise check whether the user selected "remember me" during login

--- a/src/metabase/server/middleware/session.clj
+++ b/src/metabase/server/middleware/session.clj
@@ -58,7 +58,7 @@
     ;; Disallow permanent cookies if MB_SESSION_COOKIES is set
     false
     ;; Otherwise check whether the user selected "remember me" during login
-    (:remember (:body request))))
+    (get-in request [:body :remember])))
 
 (defmulti set-session-cookie
   "Add an appropriate cookie to persist a newly created Session to `response`."

--- a/src/metabase/server/middleware/session.clj
+++ b/src/metabase/server/middleware/session.clj
@@ -51,6 +51,15 @@
   [response]
   (reduce clear-cookie (wrap-body-if-needed response) [metabase-session-cookie metabase-embedded-session-cookie]))
 
+(defn- use-permanent-cookies?
+  "Check if we should use permanent cookies for a given request, which are not cleared when a browser sesion ends."
+  [request]
+  (if (config/config-bool :mb-session-cookies)
+    ;; Only allow session cookies if MB_SESSION_COOKIES is set
+    false
+    ;; Otherwise check the user's preference sent in the request
+    (:remember (:body request))))
+
 (defmulti set-session-cookie
   "Add an appropriate cookie to persist a newly created Session to `response`."
   {:arglists '([request response session])}
@@ -65,29 +74,28 @@
   [request response {session-uuid :id} :- {:id (s/cond-pre UUID u/uuid-regex), s/Keyword s/Any}]
   (let [response       (wrap-body-if-needed response)
         cookie-options (merge
-                        {:same-site config/mb-session-cookie-samesite
-                         :http-only true
-                         ;; TODO - we should set `site-path` as well. Don't want to enable this yet so we don't end
-                         ;; up breaking things
-                         :path      "/" #_ (site-path)}
-                        ;; If the env var `MB_SESSION_COOKIES=true`, do not set the `Max-Age` directive; cookies
-                        ;; with no `Max-Age` and no `Expires` directives are session cookies, and are deleted when
-                        ;; the browser is closed
-                        ;;
-                        ;; See https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#Session_cookies
-                        (when-not (config/config-bool :mb-session-cookies)
-                          ;; max-session age-is in minutes; Max-Age= directive should be in seconds
-                          {:max-age (* 60 (config/config-int :max-session-age))})
-                        ;; If the authentication request request was made over HTTPS (hopefully always except for
-                        ;; local dev instances) add `Secure` attribute so the cookie is only sent over HTTPS.
-                        (when (request.u/https? request)
-                          {:secure true})
-                        (when (= config/mb-session-cookie-samesite :none)
-                          (log/warn
-                           (str (deferred-trs "Session cookie's SameSite is configured to \"None\", but site is")
-                                (deferred-trs "served over an insecure connection. Some browsers will reject ")
-                                (deferred-trs "cookies under these conditions. ")
-                                (deferred-trs "https://www.chromestatus.com/feature/5633521622188032")))))]
+                         {:same-site config/mb-session-cookie-samesite
+                          :http-only true
+                          ;; TODO - we should set `site-path` as well. Don't want to enable this yet so we don't end
+                          ;; up breaking things
+                          :path      "/" #_ (site-path)}
+                         ;; If permanent cookies should be used, set the `Max-Age` directive; cookies with no
+                         ;; `Max-Age` and no `Expires` directives are session cookies, and are deleted when the
+                         ;; browser is closed.
+                         ;; See https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#define_the_lifetime_of_a_cookie
+                         (when (use-permanent-cookies? request)
+                           ;; max-session age-is in minutes; Max-Age= directive should be in seconds
+                           {:max-age (* 60 (config/config-int :max-session-age))})
+                         ;; If the authentication request request was made over HTTPS (hopefully always except for
+                         ;; local dev instances) add `Secure` attribute so the cookie is only sent over HTTPS.
+                         (when (request.u/https? request)
+                           {:secure true})
+                         (when (= config/mb-session-cookie-samesite :none)
+                           (log/warn
+                             (str (deferred-trs "Session cookie's SameSite is configured to \"None\", but site is")
+                                  (deferred-trs "served over an insecure connection. Some browsers will reject ")
+                                  (deferred-trs "cookies under these conditions. ")
+                                  (deferred-trs "https://www.chromestatus.com/feature/5633521622188032")))))]
     (resp/set-cookie response metabase-session-cookie (str session-uuid) cookie-options)))
 
 (s/defmethod set-session-cookie :full-app-embed

--- a/src/metabase/server/middleware/session.clj
+++ b/src/metabase/server/middleware/session.clj
@@ -74,28 +74,28 @@
   [request response {session-uuid :id} :- {:id (s/cond-pre UUID u/uuid-regex), s/Keyword s/Any}]
   (let [response       (wrap-body-if-needed response)
         cookie-options (merge
-                         {:same-site config/mb-session-cookie-samesite
-                          :http-only true
-                          ;; TODO - we should set `site-path` as well. Don't want to enable this yet so we don't end
-                          ;; up breaking things
-                          :path      "/" #_ (site-path)}
-                         ;; If permanent cookies should be used, set the `Max-Age` directive; cookies with no
-                         ;; `Max-Age` and no `Expires` directives are session cookies, and are deleted when the
-                         ;; browser is closed.
-                         ;; See https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#define_the_lifetime_of_a_cookie
-                         (when (use-permanent-cookies? request)
-                           ;; max-session age-is in minutes; Max-Age= directive should be in seconds
-                           {:max-age (* 60 (config/config-int :max-session-age))})
-                         ;; If the authentication request request was made over HTTPS (hopefully always except for
-                         ;; local dev instances) add `Secure` attribute so the cookie is only sent over HTTPS.
-                         (when (request.u/https? request)
-                           {:secure true})
-                         (when (= config/mb-session-cookie-samesite :none)
-                           (log/warn
-                             (str (deferred-trs "Session cookie's SameSite is configured to \"None\", but site is")
-                                  (deferred-trs "served over an insecure connection. Some browsers will reject ")
-                                  (deferred-trs "cookies under these conditions. ")
-                                  (deferred-trs "https://www.chromestatus.com/feature/5633521622188032")))))]
+                        {:same-site config/mb-session-cookie-samesite
+                         :http-only true
+                         ;; TODO - we should set `site-path` as well. Don't want to enable this yet so we don't end
+                         ;; up breaking things
+                         :path      "/" #_ (site-path)}
+                        ;; If permanent cookies should be used, set the `Max-Age` directive; cookies with no
+                        ;; `Max-Age` and no `Expires` directives are session cookies, and are deleted when the
+                        ;; browser is closed.
+                        ;; See https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#define_the_lifetime_of_a_cookie
+                        (when (use-permanent-cookies? request)
+                          ;; max-session age-is in minutes; Max-Age= directive should be in seconds
+                          {:max-age (* 60 (config/config-int :max-session-age))})
+                        ;; If the authentication request request was made over HTTPS (hopefully always except for
+                        ;; local dev instances) add `Secure` attribute so the cookie is only sent over HTTPS.
+                        (when (request.u/https? request)
+                          {:secure true})
+                        (when (= config/mb-session-cookie-samesite :none)
+                          (log/warn
+                           (str (deferred-trs "Session cookie's SameSite is configured to \"None\", but site is")
+                                (deferred-trs "served over an insecure connection. Some browsers will reject ")
+                                (deferred-trs "cookies under these conditions. ")
+                                (deferred-trs "https://www.chromestatus.com/feature/5633521622188032")))))]
     (resp/set-cookie response metabase-session-cookie (str session-uuid) cookie-options)))
 
 (s/defmethod set-session-cookie :full-app-embed

--- a/src/metabase/server/middleware/session.clj
+++ b/src/metabase/server/middleware/session.clj
@@ -55,9 +55,9 @@
   "Check if we should use permanent cookies for a given request, which are not cleared when a browser sesion ends."
   [request]
   (if (config/config-bool :mb-session-cookies)
-    ;; Only allow session cookies if MB_SESSION_COOKIES is set
+    ;; Disallow permanent cookies if MB_SESSION_COOKIES is set
     false
-    ;; Otherwise check the user's preference sent in the request
+    ;; Otherwise check whether the user selected "remember me" during login
     (:remember (:body request))))
 
 (defmulti set-session-cookie

--- a/test/metabase/server/middleware/session_test.clj
+++ b/test/metabase/server/middleware/session_test.clj
@@ -49,18 +49,25 @@
               {:value     (str uuid)
                :same-site :lax
                :http-only true
-               :path      "/"
-               :max-age   1209600}}
+               :path      "/"}}
              (-> (mw.session/set-session-cookie {} {} {:id uuid, :type :normal})
                  :cookies))))
-    (testing "if `MB_SESSION_COOKIES=true` we shouldn't set a `Max-Age`"
+    (testing "should set `Max-Age` if `remember` is true in request"
+      (is (= {:value     (str uuid)
+              :same-site :lax
+              :http-only true
+              :path      "/"
+              :max-age   1209600}
+             (-> (mw.session/set-session-cookie {:body {:remember true}} {} {:id uuid, :type :normal})
+                 (get-in [:cookies "metabase.SESSION"])))))
+    (testing "if `MB_SESSION_COOKIES=true` we shouldn't set a `Max-Age`, even if `remember` is true"
       (is (= {:value     (str uuid)
               :same-site :lax
               :http-only true
               :path      "/"}
              (let [env env/env]
                (with-redefs [env/env (assoc env :mb-session-cookies "true")]
-                 (-> (mw.session/set-session-cookie {} {} {:id uuid, :type :normal})
+                 (-> (mw.session/set-session-cookie {:body {:remember true}} {} {:id uuid, :type :normal})
                      (get-in [:cookies "metabase.SESSION"])))))))))
 
 ;; if request is an HTTPS request then we should set `:secure true`. There are several different headers we check for

--- a/test/metabase/server/middleware/session_test.clj
+++ b/test/metabase/server/middleware/session_test.clj
@@ -8,6 +8,7 @@
             [metabase.db :as mdb]
             [metabase.driver.sql.query-processor :as sql.qp]
             [metabase.models :refer [Session User]]
+            [metabase.public-settings :as public-settings]
             [metabase.server.middleware.session :as mw.session]
             [metabase.test :as mt]
             [metabase.util.i18n :as i18n]
@@ -66,7 +67,7 @@
               :http-only true
               :path      "/"}
              (let [env env/env]
-               (with-redefs [env/env (assoc env :mb-session-cookies "true")]
+               (mt/with-temporary-setting-values [session-cookies true]
                  (-> (mw.session/set-session-cookie {:body {:remember true}} {} {:id uuid, :type :normal})
                      (get-in [:cookies "metabase.SESSION"])))))))))
 


### PR DESCRIPTION
Previously, the "remember me" checkbox was sending a `remember` field to the backend in the login request, but that was being entirely ignored. This PR changes the behavior so that permanent cookies are used when `remember me` is checked, and session cookies (which expire on closing the browser) are used when the box is unchecked. Setting the `MB_SESSION_COOKIES` env var will override the checkbox and force the use of session cookies for all logins.

Also updated the docs, and fixed some indentation in session.clj which is why a lot of lines are changed there.

I went down a bit of a rabbit hole trying to figure out if it would be possible to modify the login UI when `MB_SESSION_COOKIES` is set, to hide or gray out the "Remember me" checkbox since it won't have any effect. But I couldn't quite figure out how to access the environment variable at that point in the code. If anyone has any pointers on how to do this I can update this PR to include it.

Resolves #15223 