### PR TITLE
Dimension type inference: handle CASE and COALESCE

### DIFF
--- a/frontend/src/metabase/lib/expressions/typeinferencer.js
+++ b/frontend/src/metabase/lib/expressions/typeinferencer.js
@@ -32,9 +32,16 @@ export function infer(mbql, env) {
       return MONOTYPE.Boolean;
   }
 
-  if (op === "case" || op === "coalesce") {
-    // TODO
-    return MONOTYPE.Undefined;
+  if (op === "case") {
+    const clauses = mbql[1];
+    const first = clauses[0];
+    // TODO: type-checker must ensure the consistent types of all clauses.
+    return infer(first[1], env);
+  }
+
+  if (op === "coalesce") {
+    // TODO: type-checker must ensure the consistent types of all arguments
+    return infer(mbql[1], env);
   }
 
   const func = MBQL_CLAUSES[op];

--- a/frontend/test/metabase/lib/expressions/typeinferencer.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/typeinferencer.unit.spec.js
@@ -27,10 +27,13 @@ describe("metabase/lib/expressions/typeinferencer", () => {
       case "Price":
         return "number";
       case "FirstName":
+      case "LastName":
         return "string";
       case "BirthDate":
+      case "MiscDate":
         return "type/Temporal";
       case "Location":
+      case "Place":
         return "type/Coordinate";
     }
   }
@@ -92,9 +95,18 @@ describe("metabase/lib/expressions/typeinferencer", () => {
     expect(type("[Location]")).toEqual("type/Coordinate");
   });
 
-  it.skip("should infer the result of CASE", () => {
+  it("should infer the result of CASE", () => {
     expect(type("CASE([X], 1, 2)")).toEqual("number");
     expect(type("CASE([Y], 'this', 'that')")).toEqual("string");
-    expect(type("CASE(BigSale, Price>100, Price>200)")).toEqual("boolean");
+    expect(type("CASE([Z], [Price]>100, [Price]>200)")).toEqual("boolean");
+    expect(type("CASE([ABC], [FirstName], [LastName])")).toEqual("string");
+    expect(type("CASE([F], [BirthDate], [MiscDate])")).toEqual("type/Temporal");
+  });
+
+  it("should infer the result of COALESCE", () => {
+    expect(type("COALESCE([Price])")).toEqual("number");
+    expect(type("COALESCE([FirstName], [LastName])")).toEqual("string");
+    expect(type("COALESCE([BirthDate], [MiscDate])")).toEqual("type/Temporal");
+    expect(type("COALESCE([Place], [Location])")).toEqual("type/Coordinate");
   });
 });

--- a/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
@@ -475,7 +475,7 @@ describe("scenarios > question > custom columns", () => {
       cy.findByText("Days");
     });
 
-    it.only("should handle COALESCE", () => {
+    it("should handle COALESCE", () => {
       openOrdersTable({ mode: "notebook" });
       cy.findByText("Custom column").click();
       popover().within(() => {

--- a/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
@@ -453,6 +453,48 @@ describe("scenarios > question > custom columns", () => {
       cy.findByText("Previous");
       cy.findByText("Days");
     });
+
+    it("should handle CASE", () => {
+      openOrdersTable({ mode: "notebook" });
+      cy.findByText("Custom column").click();
+      popover().within(() => {
+        cy.get("[contenteditable='true']")
+          .type("case([Discount] > 0, [Created At], [Product → Created At])")
+          .blur();
+        cy.findByPlaceholderText("Something nice and descriptive").type(
+          "MiscDate",
+        );
+        cy.findByRole("button", { name: "Done" }).click();
+      });
+      cy.findByText("Filter").click();
+      popover()
+        .findByText("MiscDate")
+        .click();
+      cy.findByPlaceholderText("Enter a number").should("not.exist");
+      cy.findByText("Previous");
+      cy.findByText("Days");
+    });
+
+    it.only("should handle COALESCE", () => {
+      openOrdersTable({ mode: "notebook" });
+      cy.findByText("Custom column").click();
+      popover().within(() => {
+        cy.get("[contenteditable='true']")
+          .type("COALESCE([Product → Created At], [Created At])")
+          .blur();
+        cy.findByPlaceholderText("Something nice and descriptive").type(
+          "MiscDate",
+        );
+        cy.findByRole("button", { name: "Done" }).click();
+      });
+      cy.findByText("Filter").click();
+      popover()
+        .findByText("MiscDate")
+        .click();
+      cy.findByPlaceholderText("Enter a number").should("not.exist");
+      cy.findByText("Previous");
+      cy.findByText("Days");
+    });
   });
 
   it("should handle using `case()` when referencing the same column names (metabase#14854)", () => {


### PR DESCRIPTION
This requires PR #15982 to be merged first. See #15952 for the bigger context.

Steps to try:
1. Ask a question, Custom question
2. Sample Dataset, Orders table
3. Custom Column, type `case([Discount]>0, [Created At], [Product → Created At])` and call it MiscDate
4. Filter, choose MiscDate

**Before this PR**

The field MiscDate is incorrectly treated as a number:

![image](https://user-images.githubusercontent.com/7288/117743106-ffe28200-b1ba-11eb-8a2a-19b057ac6de1.png)

**After this PR**

The field MiscDate is **correctly** treated as a date:

![image](https://user-images.githubusercontent.com/7288/117743131-096bea00-b1bb-11eb-807c-b08c30d113e5.png)

Also, run the unit tests:
```
yarn test-unit frontend/test/metabase/lib/expressions/typeinferencer.unit.spec.js
```

and E2E:
```
yarn test-cypress-no-build --spec frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
```

**Note**: Any expression with `COALESCE`  should also work.