### PR TITLE
Fix "Our analytics" is initially suggested only to admins when saving items

### DIFF
--- a/frontend/src/metabase/entities/collections.js
+++ b/frontend/src/metabase/entities/collections.js
@@ -8,16 +8,36 @@ import { createSelector } from "reselect";
 
 import { GET } from "metabase/lib/api";
 
-import {
-  getUser,
-  getUserDefaultCollectionId,
-  getUserPersonalCollectionId,
-} from "metabase/selectors/user";
+import { getUser, getUserPersonalCollectionId } from "metabase/selectors/user";
 
 import { t } from "ttag";
 
 const listCollectionsTree = GET("/api/collection/tree");
 const listCollections = GET("/api/collection");
+
+export const ROOT_COLLECTION = {
+  id: "root",
+  name: t`Our analytics`,
+  location: "",
+  path: [],
+};
+
+export const PERSONAL_COLLECTION = {
+  id: undefined, // to be filled in by getExpandedCollectionsById
+  name: t`My personal collection`,
+  location: "/",
+  path: [ROOT_COLLECTION.id],
+  can_write: true,
+};
+
+// fake collection for admins that contains all other user's collections
+export const PERSONAL_COLLECTIONS = {
+  id: "personal", // placeholder id
+  name: t`All personal collections`,
+  location: "/",
+  path: [ROOT_COLLECTION.id],
+  can_write: false,
+};
 
 const Collections = createEntity({
   name: "collections",
@@ -86,7 +106,8 @@ const Collections = createEntity({
         (state, { params }) => (params ? params.collectionId : undefined),
         (state, { location }) =>
           location && location.query ? location.query.collectionId : undefined,
-        getUserDefaultCollectionId,
+        () => ROOT_COLLECTION.id,
+        getUserPersonalCollectionId,
       ],
       (collections, ...collectionIds) => {
         for (const collectionId of collectionIds) {
@@ -168,31 +189,6 @@ export const getCollectionType = (collectionId: string, state: {}) =>
     : collectionId !== undefined
     ? "other"
     : null;
-
-export const ROOT_COLLECTION = {
-  id: "root",
-  name: t`Our analytics`,
-  location: "",
-  path: [],
-};
-
-// the user's personal collection
-export const PERSONAL_COLLECTION = {
-  id: undefined, // to be filled in by getExpandedCollectionsById
-  name: t`My personal collection`,
-  location: "/",
-  path: ["root"],
-  can_write: true,
-};
-
-// fake collection for admins that contains all other user's collections
-export const PERSONAL_COLLECTIONS = {
-  id: "personal", // placeholder id
-  name: t`All personal collections`,
-  location: "/",
-  path: ["root"],
-  can_write: false,
-};
 
 type UserId = number;
 

--- a/frontend/src/metabase/selectors/user.js
+++ b/frontend/src/metabase/selectors/user.js
@@ -16,9 +16,3 @@ export const getUserPersonalCollectionId = createSelector(
   [getUser],
   user => (user && user.personal_collection_id) || null,
 );
-
-export const getUserDefaultCollectionId = createSelector(
-  [getUser, getUserIsAdmin, getUserPersonalCollectionId],
-  (user, isAdmin, personalCollectionId) =>
-    isAdmin ? null : personalCollectionId,
-);

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -12,7 +12,7 @@
 
 import { onlyOn } from "@cypress/skip-test";
 import { restore, popover } from "__support__/e2e/cypress";
-import { USERS } from "__support__/e2e/cypress_data";
+import { USERS, USER_GROUPS } from "__support__/e2e/cypress_data";
 
 const PERMISSIONS = {
   curate: ["admin", "normal", "nodata"],
@@ -653,6 +653,21 @@ describe("collection permissions", () => {
         });
       });
     });
+  });
+
+  it("should offer to save items to 'Our analytics' if user has a 'curate' access to it", () => {
+    cy.signInAsAdmin();
+    cy.updateCollectionGraph({
+      [USER_GROUPS.COLLECTION_GROUP]: { root: "write" },
+    });
+    cy.signIn("normal");
+
+    cy.visit("/question/new");
+    cy.findByText("Native query").click();
+    cy.get(".ace_content").type("select * from people");
+    cy.findByText("Save").click();
+
+    cy.get(".AdminSelect").findByText("Our analytics");
   });
 });
 

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -12,7 +12,7 @@
 
 import { onlyOn } from "@cypress/skip-test";
 import { restore, popover } from "__support__/e2e/cypress";
-import { USERS, USER_GROUPS } from "__support__/e2e/cypress_data";
+import { USERS } from "__support__/e2e/cypress_data";
 
 const PERMISSIONS = {
   curate: ["admin", "normal", "nodata"],
@@ -656,10 +656,6 @@ describe("collection permissions", () => {
   });
 
   it("should offer to save items to 'Our analytics' if user has a 'curate' access to it", () => {
-    cy.signInAsAdmin();
-    cy.updateCollectionGraph({
-      [USER_GROUPS.COLLECTION_GROUP]: { root: "write" },
-    });
     cy.signIn("normal");
 
     cy.visit("/question/new");

--- a/frontend/test/metabase/scenarios/native/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/native.cy.spec.js
@@ -229,7 +229,6 @@ describe("scenarios > question > native", () => {
     cy.findByText("Simple question").click();
     popover().within(() => {
       cy.findByText("Saved Questions").click();
-      cy.findByText("Robert Tableton's Personal Collection").click();
       cy.findByText(QUESTION).click();
     });
 


### PR DESCRIPTION
Whenever users save questions or dashboards, they need to select a collection to keep the item at. We have a mechanism for selecting the initial collection ID (I described it in more detail [here](https://github.com/metabase/metabase/pull/15613#issuecomment-827490956)). This PR fixes that "Our analytics" was sometimes suggested only to admin users, even if a normal user has 'curate' permission for it.

**To Verify**

1. Sign in as a **non-admin** user. The user must have a 'curate' permission to "Our analytics" collection
2. Create a native question (`/question/new` —> Native query)
3. Click "Save."
4. Collection picker's default value has to be "Our analytics" as the user has write access to it. Otherwise, it has to be the user's personal collection