### PR TITLE
Fix reflection warnings

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -170,9 +170,11 @@
 
   :main ^:skip-aot metabase.core
 
-  ;; Liquibase uses this manifest parameter to dynamically find extensions at startup (via classpath scanning, etc)
   :manifest
-  {"Liquibase-Package"
+  {;; log4j is multi-release and lein uberjar doesn't set this correctly in the manifest
+   "Multi-Release" true
+   ;; Liquibase uses this manifest parameter to dynamically find extensions at startup (via classpath scanning, etc)
+   "Liquibase-Package"
    #= (eval
        (str "liquibase.change,liquibase.changelog,liquibase.database,liquibase.parser,liquibase.precondition,"
             "liquibase.datatype,liquibase.serializer,liquibase.sqlgenerator,liquibase.executor,"


### PR DESCRIPTION
fixes https://github.com/metabase/metabase/issues/13625
log4j is a multi-release jar. Lein has a bug where this is not correctly set in the uberjar.

Issue on lein: https://github.com/technomancy/leiningen/issues/2744

## Before
> ~/p/w/metabase ❯❯❯ java -jar target/uberjar/metabase.jar
Warning: environ value /Users/dan/.sdkman/candidates/java/current for key :java-home has been overwritten with /Users/dan/.sdkman/candidates/java/11.0.11.hs-adpt
WARNING: sun.reflect.Reflection.getCallerClass is not supported. This will impact performance.
2021-05-11 13:49:17,147 INFO metabase.util :: Maximum memory available to JVM: 8.0 GB

## After
> ~/p/w/metabase ❯❯❯ java -jar target/uberjar/metabase.jar
Warning: environ value /Users/dan/.sdkman/candidates/java/current for key :java-home has been overwritten with /Users/dan/.sdkman/candidates/java/11.0.11.hs-adpt
2021-05-11 14:58:21,091 INFO metabase.util :: Maximum memory available to JVM: 8.0 GB