### PR TITLE
Add Cypress custom command `button`

### DIFF
--- a/frontend/test/__support__/e2e/commands.js
+++ b/frontend/test/__support__/e2e/commands.js
@@ -35,6 +35,10 @@ Cypress.Commands.add("icon", icon_name => {
   cy.get(`.Icon-${icon_name}`);
 });
 
+Cypress.Commands.add("button", button_name => {
+  cy.findByRole("button", { name: button_name });
+});
+
 Cypress.Commands.add("createDashboard", name => {
   cy.log(`Create a dashboard: ${name}`);
   cy.request("POST", "/api/dashboard", { name });

--- a/frontend/test/metabase-db/mongo/query.cy.spec.js
+++ b/frontend/test/metabase-db/mongo/query.cy.spec.js
@@ -67,7 +67,7 @@ describe("mongodb > user > query", () => {
       cy.server();
       cy.route("POST", "/api/dataset").as("dataset");
 
-      cy.findByText("Visualize").click();
+      cy.button("Visualize").click();
       cy.wait("@dataset");
 
       cy.log("Reported failing on stats ~v0.36.3");

--- a/frontend/test/metabase-db/postgres/custom-column.cy.spec.js
+++ b/frontend/test/metabase-db/postgres/custom-column.cy.spec.js
@@ -90,7 +90,7 @@ describe("postgres > question > custom columns", () => {
       .click();
     cy.findByText("Function Percentile expects 1 argument").should("not.exist");
     cy.get("@description").type("A");
-    cy.findByRole("button", { name: "Done" })
+    cy.button("Done")
       .should("not.be.disabled")
       .click();
     // Todo: Add positive assertions once this is fixed

--- a/frontend/test/metabase-db/postgres/custom-column.cy.spec.js
+++ b/frontend/test/metabase-db/postgres/custom-column.cy.spec.js
@@ -48,7 +48,7 @@ describe("postgres > question > custom columns", () => {
         .click();
     });
 
-    cy.findByText("Visualize").click();
+    cy.button("Visualize").click();
     cy.findByText("Arnold Adams");
   });
 

--- a/frontend/test/metabase-db/postgres/native.cy.spec.js
+++ b/frontend/test/metabase-db/postgres/native.cy.spec.js
@@ -16,7 +16,7 @@ describe("postgres > question > native", () => {
     cy.get(".ace_content").type("select pg_sleep(60)");
     cy.findByText("Save").click();
     cy.findByLabelText("Name").type("14957");
-    cy.findByRole("button", { name: "Save" }).click();
+    cy.button("Save").click();
     modal().should("not.exist");
   });
 });

--- a/frontend/test/metabase-smoketest/admin.cy.spec.js
+++ b/frontend/test/metabase-smoketest/admin.cy.spec.js
@@ -168,7 +168,7 @@ describe("metabase-smoketest > admin", () => {
 
       cy.findByText("Join data").click();
       cy.findByText("People").click();
-      cy.findByText("Visualize").click();
+      cy.button("Visualize").click();
 
       // Summarize by State
       cy.findAllByText("Summarize")

--- a/frontend/test/metabase-smoketest/admin_setup.cy.spec.js
+++ b/frontend/test/metabase-smoketest/admin_setup.cy.spec.js
@@ -478,7 +478,7 @@ describe("smoketest > admin_setup", () => {
         .last()
         .click();
       cy.findByText("Add filter").click();
-      cy.findByText("Visualize").click();
+      cy.button("Visualize").click();
 
       cy.findAllByText("Awesome Concrete Shoes");
       cy.findByText("Mediocre Wooden Bench").should("not.exist");

--- a/frontend/test/metabase-smoketest/user.cy.spec.js
+++ b/frontend/test/metabase-smoketest/user.cy.spec.js
@@ -24,7 +24,7 @@ describe("smoketest > user", () => {
 
     cy.findByText("Average of Rating");
 
-    cy.findByText("Visualize").click();
+    cy.button("Visualize").click();
 
     cy.icon("bar");
     cy.findAllByText("Vendor is not empty");
@@ -67,7 +67,7 @@ describe("smoketest > user", () => {
     popover().within(() => {
       cy.findAllByText("Title").click();
     });
-    cy.findByText("Visualize").click();
+    cy.button("Visualize").click();
 
     cy.get("@firstTableCell").contains("Aerodynamic Bronze Hat");
 
@@ -106,9 +106,9 @@ describe("smoketest > user", () => {
     cy.findByText("Greater than or equal to").click();
     cy.get("input[placeholder='Enter a number']").type("5");
     cy.findByText("Add filter").click();
-    cy.findByText("Visualize").click();
+    cy.button("Visualize").click();
 
-    cy.findByText("Visualize").should("not.exist");
+    cy.button("Visualize").should("not.exist");
     cy.get("svg");
     cy.findByText("Average of Rating is greater than or equal to 5");
 
@@ -180,7 +180,7 @@ describe("smoketest > user", () => {
     cy.findByText("Count of rows").click();
     cy.findByText("Pick a column to group by").click();
     cy.icon("calendar").click();
-    cy.findByText("Visualize").click();
+    cy.button("Visualize").click();
 
     cy.get("svg");
     cy.findAllByText("Created At");
@@ -223,7 +223,7 @@ describe("smoketest > user", () => {
       "Demo Column",
     );
     cy.findByText("Done").click();
-    cy.findByText("Visualize").click();
+    cy.button("Visualize").click();
 
     cy.findByText("ID");
     cy.icon("table2");
@@ -238,7 +238,7 @@ describe("smoketest > user", () => {
 
     cy.icon("join_left_outer").click();
     cy.findByText("People").click(); // column selection happens automatcially
-    cy.findByText("Visualize").click();
+    cy.button("Visualize").click();
 
     cy.findByText("User → ID");
     cy.findByText("Created At");
@@ -250,7 +250,7 @@ describe("smoketest > user", () => {
 
     cy.findByText("Row limit").click();
     cy.get("input[type='number']").type("10");
-    cy.findByText("Visualize").click();
+    cy.button("Visualize").click();
 
     cy.get(".TableInteractive-cellWrapper--firstColumn").should(
       "have.length",
@@ -281,7 +281,7 @@ describe("smoketest > user", () => {
     // Distinctions
     // *** This test needs to be improved with variables that will change if the Sample data changes
 
-    cy.findByText("Visualize").click();
+    cy.button("Visualize").click();
 
     cy.findByText("Category").click();
     cy.findByText("Distincts").click();
@@ -375,7 +375,7 @@ describe("smoketest > user", () => {
       .last()
       .click();
     cy.findByText("People").click();
-    cy.findByText("Visualize").click();
+    cy.button("Visualize").click();
 
     cy.findByText("Longitude").click();
 

--- a/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
@@ -44,7 +44,7 @@ describe("scenarios > admin > databases > add", () => {
     typeField("Database name", "test_postgres_db");
     typeField("Username", "uberadmin");
 
-    cy.findByRole("button", { name: "Save" })
+    cy.button("Save")
       .should("not.be.disabled")
       .click();
 
@@ -80,7 +80,7 @@ describe("scenarios > admin > databases > add", () => {
     typeField("Database name", "test_postgres_db");
     typeField("Username", "uberadmin");
 
-    cy.findByRole("button", { name: "Save" })
+    cy.button("Save")
       .should("not.be.disabled")
       .click();
 
@@ -88,7 +88,7 @@ describe("scenarios > admin > databases > add", () => {
 
     toggleFieldWithDisplayName("let me choose when Metabase syncs and scans");
 
-    cy.findByRole("button", { name: "Next" })
+    cy.button("Next")
       .should("not.be.disabled")
       .click();
 
@@ -107,17 +107,17 @@ describe("scenarios > admin > databases > add", () => {
     typeField("Database name", "test_postgres_db");
     typeField("Username", "uberadmin");
 
-    cy.findByRole("button", { name: "Save" }).should("not.be.disabled");
+    cy.button("Save").should("not.be.disabled");
 
     toggleFieldWithDisplayName("let me choose when Metabase syncs and scans");
 
-    cy.findByRole("button", { name: "Next" })
+    cy.button("Next")
       .should("not.be.disabled")
       .click();
 
     cy.findByText("Never, I'll do this manually if I need to").click();
 
-    cy.findByRole("button", { name: "Save" }).click();
+    cy.button("Save").click();
 
     cy.wait("@createDatabase").then(({ request }) => {
       expect(request.body.engine).to.equal("postgres");
@@ -144,7 +144,7 @@ describe("scenarios > admin > databases > add", () => {
     typeField("Database name", "test_postgres_db");
     typeField("Username", "uberadmin");
 
-    cy.findByRole("button", { name: "Save" }).click();
+    cy.button("Save").click();
 
     cy.wait("@createDatabase");
     cy.findByText("DATABASE CONNECTION ERROR").should("exist");
@@ -204,7 +204,7 @@ describe("scenarios > admin > databases > add", () => {
       }).as("createDatabase");
 
       // submit form and check that the file's body is included
-      cy.findByRole("button", { name: "Save" }).click();
+      cy.button("Save").click();
       cy.wait("@createDatabase").should(xhr => {
         expect(xhr.request.body.details["service-account-json"]).to.equal(
           '{"foo": 123}',

--- a/frontend/test/metabase/scenarios/admin/permissions/sandboxes.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/permissions/sandboxes.cy.spec.js
@@ -605,7 +605,7 @@ describeWithToken("formatting > sandboxes", () => {
             // Save the question
             cy.findByText("Save").click();
             modal().within(() => {
-              cy.findAllByRole("button", { name: "Save" }).click();
+              cy.button("Save").click();
             });
             // Wait for an update so the other queries don't accidentally cancel it
             cy.wait("@questionUpdate");
@@ -749,12 +749,12 @@ describeWithToken("formatting > sandboxes", () => {
         .eq(1) // No better way of doing this, undfortunately (see table above)
         .click();
       cy.findByText("Grant sandboxed access").click();
-      cy.findAllByRole("button", { name: "Change" }).click();
+      cy.button("Change").click();
       cy.findByText(
         "Use a saved question to create a custom view for this table",
       ).click();
       cy.findByText(QUESTION_NAME).click();
-      cy.findAllByRole("button", { name: "Save" }).click();
+      cy.button("Save").click();
 
       cy.wait("@sandboxTable").then(xhr => {
         expect(xhr.status).to.eq(400);
@@ -822,7 +822,7 @@ describeWithToken("formatting > sandboxes", () => {
             .find(".Icon-close")
             .click();
         });
-      cy.findAllByRole("button", { name: "Done" }).click();
+      cy.button("Done").click();
       // Rerun the query
       cy.icon("play")
         .last()

--- a/frontend/test/metabase/scenarios/admin/permissions/sandboxes.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/permissions/sandboxes.cy.spec.js
@@ -146,7 +146,7 @@ describeWithToken("formatting > sandboxes", () => {
         cy.findByText("Greater than").click();
         cy.findByPlaceholderText("Enter a number").type("100");
         cy.findByText("Add filter").click();
-        cy.findByText("Visualize").click();
+        cy.button("Visualize").click();
 
         cy.log("Make sure user is still sandboxed");
         cy.get(".TableInteractive-cellWrapper--firstColumn").should(
@@ -219,7 +219,7 @@ describeWithToken("formatting > sandboxes", () => {
           .click();
       });
 
-      cy.findByText("Visualize").click();
+      cy.button("Visualize").click();
       cy.findByText("Count by User → ID");
       cy.findByText("11"); // Sum of orders for user with ID #1
     });
@@ -778,7 +778,7 @@ describeWithToken("formatting > sandboxes", () => {
       cy.findByText("Count of rows").click();
       cy.findByText("Pick a column to group by").click();
       cy.findByText(/Products? → ID/).click();
-      cy.findByText("Visualize").click();
+      cy.button("Visualize").click();
 
       cy.wait("@dataset").then(xhr => {
         expect(xhr.response.body.error).not.to.exist;

--- a/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
@@ -406,7 +406,7 @@ describe("scenarios > admin > settings", () => {
       cy.visit("/admin/settings/email");
       cy.findByText("Send test email").scrollIntoView();
       // Needed to scroll the page down first to be able to use findByRole() - it fails otherwise
-      cy.findByRole("button", { name: "Save changes" }).should("be.disabled");
+      cy.button("Save changes").should("be.disabled");
     });
   });
 

--- a/frontend/test/metabase/scenarios/collections/personal-collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/personal-collections.cy.spec.js
@@ -106,7 +106,7 @@ describe("personal collections", () => {
           popover()
             .findByText("My personal collection") /* [3] */
             .click();
-          cy.findByRole("button", { name: "Update" }).click();
+          cy.button("Update").click();
           // Clicking on "Foo" would've closed it and would hide its sub-collections (if there were any).
           // By doing this, we're making sure "Bar" lives at the same level as "Foo"
           cy.get("@sidebar")

--- a/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
@@ -579,10 +579,10 @@ describe("scenarios > dashboard > dashboard drill", () => {
         cy.get(".DashCard .Icon-palette").click({ force: true });
         cy.get(".Modal").within(() => {
           cy.findByText("Reset to defaults").click();
-          cy.findByRole("button", { name: "Done" }).click();
+          cy.button("Done").click();
         });
         // Save the whole dashboard
-        cy.findByRole("button", { name: "Save" }).click();
+        cy.button("Save").click();
         cy.findByText("You're editing this dashboard.").should("not.exist");
         cy.log("Reported failing on v0.38.0 - link gets dropped");
         cy.get(".DashCard").findAllByText(LINK_NAME);

--- a/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
@@ -588,7 +588,7 @@ describe("scenarios > dashboard", () => {
         cy.findByPlaceholderText("Enter some text")
           .click()
           .type("Gizmo", { delay: 10 });
-        cy.findByRole("button", { name: "Add filter" })
+        cy.button("Add filter")
           .should("not.be.disabled")
           .click();
         cy.contains("Rustic Paper Wallet");
@@ -728,7 +728,7 @@ describe("scenarios > dashboard", () => {
       popover()
         .findByText("Organic")
         .click();
-      cy.findByRole("button", { name: "Add filter" }).click();
+      cy.button("Add filter").click();
       // Check that the search works
       cy.get("fieldset")
         .contains("Search")

--- a/frontend/test/metabase/scenarios/native/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/native.cy.spec.js
@@ -560,7 +560,7 @@ describe("scenarios > question > native", () => {
     popover()
       .findByText("Doohickey")
       .click();
-    cy.findByRole("button", { name: "Add filter" }).click();
+    cy.button("Add filter").click();
     // Rerun the query
     cy.get(".NativeQueryEditor .Icon-play").click();
     cy.wait("@dataset").wait("@dataset");
@@ -597,7 +597,7 @@ describe("scenarios > question > native", () => {
     popover()
       .findByText("Doohickey")
       .click();
-    cy.findByRole("button", { name: "Add filter" }).click();
+    cy.button("Add filter").click();
     cy.get(".NativeQueryEditor .Icon-play").click();
     cy.wait("@dataset").then(xhr => {
       expect(xhr.response.body.error).not.to.exist;

--- a/frontend/test/metabase/scenarios/onboarding/setup/user_settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/setup/user_settings.cy.spec.js
@@ -37,7 +37,7 @@ describe("user > settings", () => {
     cy.findByDisplayValue(first_name);
     cy.findByDisplayValue(last_name);
     cy.findByDisplayValue(email);
-    cy.findByRole("button", { name: "Update" }).should("be.disabled");
+    cy.button("Update").should("be.disabled");
   });
 
   it("should update the user without fetching memberships", () => {

--- a/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
@@ -41,7 +41,7 @@ describe("scenarios > question > custom columns", () => {
     cy.server();
     cy.route("POST", "/api/dataset").as("dataset");
 
-    cy.findByText("Visualize").click();
+    cy.button("Visualize").click();
     cy.wait("@dataset");
     cy.findByText("There was a problem with your question").should("not.exist");
     cy.get(".Visualization").contains(columnName);
@@ -62,7 +62,7 @@ describe("scenarios > question > custom columns", () => {
       cy.server();
       cy.route("POST", "/api/dataset").as("dataset");
 
-      cy.findByText("Visualize").click();
+      cy.button("Visualize").click();
       cy.wait("@dataset");
       cy.get(".Visualization").contains(columnName);
     });
@@ -108,7 +108,7 @@ describe("scenarios > question > custom columns", () => {
     cy.server();
     cy.route("POST", "/api/dataset").as("dataset");
 
-    cy.findByText("Visualize").click();
+    cy.button("Visualize").click();
     cy.wait("@dataset");
     cy.findByText("There was a problem with your question").should("not.exist");
     // This is a pre-save state of the question but the column name should appear
@@ -150,7 +150,7 @@ describe("scenarios > question > custom columns", () => {
     cy.server();
     cy.route("POST", "/api/dataset").as("dataset");
 
-    cy.findByText("Visualize").click();
+    cy.button("Visualize").click();
     cy.wait("@dataset");
 
     cy.get(".Visualization").within(() => {
@@ -188,11 +188,11 @@ describe("scenarios > question > custom columns", () => {
       cy.findByText("Done").click();
     });
 
-    cy.findByText("Visualize").click();
+    cy.button("Visualize").click();
 
     // wait for results to load
     cy.get(".LoadingSpinner").should("not.exist");
-    cy.findByText("Visualize").should("not.exist");
+    cy.button("Visualize").should("not.exist");
 
     cy.log(
       "**Fails in 0.35.0, 0.35.1, 0.35.2, 0.35.4 and the latest master (2020-10-21)**",
@@ -407,7 +407,7 @@ describe("scenarios > question > custom columns", () => {
     cy.get("[class*=NotebookCellItem]")
       .contains(CE_NAME)
       .should("not.exist");
-    cy.findByText("Visualize").click();
+    cy.button("Visualize").click();
 
     cy.wait("@dataset").then(xhr => {
       expect(xhr.response.body.error).to.not.exist;

--- a/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
@@ -489,7 +489,7 @@ describe("scenarios > question > custom columns", () => {
     cy.get("[contenteditable='true']").type(".5 * [Discount]");
     cy.findByPlaceholderText("Something nice and descriptive").type("Foo");
     cy.findByText("Unknown Field: .5").should("not.exist");
-    cy.findByRole("button", { name: "Done" }).should("not.be.disabled");
+    cy.button("Done").should("not.be.disabled");
   });
 
   describe.skip("contentedtable field (metabase#15734)", () => {
@@ -506,7 +506,7 @@ describe("scenarios > question > custom columns", () => {
           .blur();
       });
       cy.findByPlaceholderText("Something nice and descriptive").type("Math");
-      cy.findByRole("button", { name: "Done" }).should("not.be.disabled");
+      cy.button("Done").should("not.be.disabled");
     });
 
     it("should not accidentally delete CC formula value and/or CC name (metabase#15734-1)", () => {
@@ -515,7 +515,7 @@ describe("scenarios > question > custom columns", () => {
         .type("{movetoend}{leftarrow}{movetostart}{rightarrow}{rightarrow}")
         .blur();
       cy.findByDisplayValue("Math");
-      cy.findByRole("button", { name: "Done" }).should("not.be.disabled");
+      cy.button("Done").should("not.be.disabled");
     });
 
     /**
@@ -529,7 +529,7 @@ describe("scenarios > question > custom columns", () => {
         .type("{movetoend}{backspace}")
         .blur();
       cy.findByText("Expected expression");
-      cy.findByRole("button", { name: "Done" }).should("be.disabled");
+      cy.button("Done").should("be.disabled");
       cy.get("@formula").click(); /* [1] */
       cy.findByDisplayValue("Math");
     });
@@ -538,7 +538,7 @@ describe("scenarios > question > custom columns", () => {
       cy.viewport(1260, 800);
       cy.get("@formula").click(); /* [1] */
       cy.findByDisplayValue("Math");
-      cy.findByRole("button", { name: "Done" }).should("not.be.disabled");
+      cy.button("Done").should("not.be.disabled");
     });
   });
 
@@ -550,7 +550,7 @@ describe("scenarios > question > custom columns", () => {
         .type("case([Discount] > 0, [Created At], [Product → Created At])")
         .blur();
       cy.findByPlaceholderText("Something nice and descriptive").type("13112");
-      cy.findByRole("button", { name: "Done" }).click();
+      cy.button("Done").click();
     });
     cy.findByText("Filter").click();
     popover()
@@ -567,7 +567,7 @@ describe("scenarios > question > custom columns", () => {
         .type(`concat("State: ", [State])`)
         .blur();
       cy.findByPlaceholderText("Something nice and descriptive").type("13217");
-      cy.findByRole("button", { name: "Done" }).click();
+      cy.button("Done").click();
     });
     cy.findByText("Filter").click();
     popover()
@@ -601,9 +601,9 @@ describe("scenarios > question > custom columns", () => {
       cy.findByPlaceholderText("Something nice and descriptive").type(
         "No discount",
       );
-      cy.findByRole("button", { name: "Done" }).click();
+      cy.button("Done").click();
     });
-    cy.findByRole("button", { name: "Visualize" }).click();
+    cy.button("Visualize").click();
     cy.wait("@dataset").then(xhr => {
       expect(xhr.response.body.error).to.not.exist;
     });

--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -987,5 +987,4 @@ describe("scenarios > question > filter", () => {
     cy.findByText("AL").click();
     cy.button("Add filter").isVisibleInPopover();
   });
-  });
 });

--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -544,7 +544,7 @@ describe("scenarios > question > filter", () => {
       .click()
       .type("contains(");
     cy.findByText(/Checks to see if string1 contains string2 within it./i);
-    cy.findByRole("button", { name: "Done" }).should("not.be.disabled");
+    cy.button("Done").should("not.be.disabled");
     cy.get(".text-error").should("not.exist");
     cy.findAllByText(/Expected one of these possible Token sequences:/i).should(
       "not.exist",
@@ -702,8 +702,7 @@ describe("scenarios > question > filter", () => {
       .click()
       .clear()
       .type("NOT IsNull([Rating])", { delay: 50 });
-    cy.findAllByRole("button")
-      .contains("Done")
+    cy.button("Done")
       .should("not.be.disabled")
       .click();
 
@@ -714,8 +713,7 @@ describe("scenarios > question > filter", () => {
       .click()
       .clear()
       .type("NOT IsEmpty([Reviewer])", { delay: 50 });
-    cy.findAllByRole("button")
-      .contains("Done")
+    cy.button("Done")
       .should("not.be.disabled")
       .click();
 
@@ -849,7 +847,7 @@ describe("scenarios > question > filter", () => {
     cy.get("[contenteditable='true']").contains(
       'contains([Reviewer], "MULLER")',
     );
-    cy.findByRole("button", { name: "Done" }).click();
+    cy.button("Done").click();
     cy.wait("@dataset.2").then(xhr => {
       expect(xhr.response.body.data.rows).to.have.lengthOf(1);
     });
@@ -864,7 +862,7 @@ describe("scenarios > question > filter", () => {
     cy.get("[contenteditable='true']")
       .click()
       .type("3.14159");
-    cy.findAllByRole("button", { name: "Done" })
+    cy.button("Done")
       .should("not.be.disabled")
       .click();
     cy.findByText("Expecting boolean but found 3.14159");
@@ -878,7 +876,7 @@ describe("scenarios > question > filter", () => {
     cy.get("[contenteditable='true']")
       .click()
       .type('"TheAnswer"');
-    cy.findAllByRole("button", { name: "Done" })
+    cy.button("Done")
       .should("not.be.disabled")
       .click();
     cy.findByText('Expecting boolean but found "TheAnswer"');
@@ -903,7 +901,7 @@ describe("scenarios > question > filter", () => {
       .click();
     cy.findByText("Filter by this column").click();
     cy.findByPlaceholderText("Enter a number").type("42");
-    cy.findByRole("button", { name: "Update filter" })
+    cy.button("Update filter")
       .should("not.be.disabled")
       .click();
     cy.findByText("Doohickey");
@@ -915,7 +913,7 @@ describe("scenarios > question > filter", () => {
     cy.findByText("Filter").click();
     cy.findByText("Custom Expression").click();
     cy.get("[contenteditable=true]").type("[Total] < [Subtotal]");
-    cy.findByRole("button", { name: "Done" }).click();
+    cy.button("Done").click();
     cy.findByText("Total is less than Subtotal");
   });
 
@@ -929,7 +927,7 @@ describe("scenarios > question > filter", () => {
     cy.findByText(/^Expected closing parenthesis but found/).should(
       "not.exist",
     );
-    cy.findByRole("button", { name: "Done" }).should("not.be.disabled");
+    cy.button("Done").should("not.be.disabled");
   });
 
   it.skip("custom expression filter should work with numeric value before an operator (metabase#15893)", () => {
@@ -941,7 +939,7 @@ describe("scenarios > question > filter", () => {
     cy.get("[contenteditable=true]")
       .type("0 < [ID]")
       .blur();
-    cy.findByRole("button", { name: "Done" }).click();
+    cy.button("Done").click();
     cy.findByText("Visualize").click();
     cy.wait("@dataset").then(xhr => {
       expect(xhr.response.body.error).to.not.exist;
@@ -973,7 +971,7 @@ describe("scenarios > question > filter", () => {
       cy.findByText("Category").click();
       cy.findByText("Gizmo").click();
     });
-    cy.findByRole("button", { name: "Add filter" })
+    cy.button("Add filter")
       .should("not.be.disabled")
       .click();
     cy.get(".dot");
@@ -987,6 +985,7 @@ describe("scenarios > question > filter", () => {
       .findByText("State")
       .click();
     cy.findByText("AL").click();
-    cy.findByRole("button", { name: "Add filter" }).isVisibleInPopover();
+    cy.button("Add filter").isVisibleInPopover();
+  });
   });
 });

--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -219,7 +219,7 @@ describe("scenarios > question > filter", () => {
     cy.findByText("Add filter").click();
     cy.contains("Category is not Gizmo");
 
-    cy.findByText("Visualize").click();
+    cy.button("Visualize").click();
     // wait for results to load
     cy.get(".LoadingSpinner").should("not.exist");
     cy.log("The point of failure in 0.37.0-rc3");
@@ -718,7 +718,7 @@ describe("scenarios > question > filter", () => {
       .click();
 
     // check that filter is applied and rows displayed
-    cy.findByText("Visualize").click();
+    cy.button("Visualize").click();
     cy.contains("Showing 1,112 rows");
   });
 
@@ -940,7 +940,7 @@ describe("scenarios > question > filter", () => {
       .type("0 < [ID]")
       .blur();
     cy.button("Done").click();
-    cy.findByText("Visualize").click();
+    cy.button("Visualize").click();
     cy.wait("@dataset").then(xhr => {
       expect(xhr.response.body.error).to.not.exist;
     });

--- a/frontend/test/metabase/scenarios/question/joins.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/joins.cy.spec.js
@@ -35,7 +35,7 @@ describe("scenarios > question > joined questions", () => {
     popover()
       .findByText("Product ID") // Implicit assertion - test will fail for multiple strings
       .click();
-    cy.findByText("Visualize").click();
+    cy.button("Visualize").click();
     cy.wait("@dataset").then(xhr => {
       expect(xhr.response.body.error).not.to.exist;
     });

--- a/frontend/test/metabase/scenarios/question/nested.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nested.cy.spec.js
@@ -559,7 +559,7 @@ describe("scenarios > question > nested", () => {
       cy.findByText("Pick a column to group by").click();
       cy.findByText("CAT").click();
 
-      cy.findByText("Visualize").click();
+      cy.button("Visualize").click();
       cy.get("@consoleWarn").should(
         "not.be.calledWith",
         "Removing invalid MBQL clause",
@@ -571,7 +571,7 @@ describe("scenarios > question > nested", () => {
       cy.findByText("Pick a column to group by").click();
       cy.findByText("CAT").click();
 
-      cy.findByText("Visualize").click();
+      cy.button("Visualize").click();
       cy.wait("@dataset");
       cy.findAllByRole("button")
         .contains("Summarize")

--- a/frontend/test/metabase/scenarios/question/new.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/new.cy.spec.js
@@ -71,7 +71,7 @@ describe("scenarios > question > new", () => {
         .click();
       cy.findByText("Rating").click();
     });
-    cy.findByText("Visualize").click();
+    cy.button("Visualize").click();
     cy.get(".Visualization .bar").should("have.length", 6);
   });
 
@@ -269,7 +269,7 @@ describe("scenarios > question > new", () => {
         cy.findByPlaceholderText("Name (required)").type("twice max total");
         cy.findByText("Done").click();
       });
-      cy.findByText("Visualize").click();
+      cy.button("Visualize").click();
       cy.findByText("318.7");
     });
 

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -99,7 +99,7 @@ describe("scenarios > question > notebook", () => {
       .click()
       .clear()
       .type("contains([Category])", { delay: 50 });
-    cy.findAllByRole("button", { name: "Done" })
+    cy.button("Done")
       .should("not.be.disabled")
       .click();
     cy.contains(/^Function contains expects 2 arguments/i);
@@ -125,7 +125,7 @@ describe("scenarios > question > notebook", () => {
       .click()
       .clear()
       .type("[Price] > 1");
-    cy.findAllByRole("button", { name: "Done" }).click();
+    cy.button("Done").click();
 
     // change the corresponding custom expression
     cy.findByText("Price is greater than 1").click();
@@ -204,7 +204,7 @@ describe("scenarios > question > notebook", () => {
           }
         });
       cy.findByText("wolf.dina@yahoo.com").click();
-      cy.findByRole("button", { name: "Add filter" }).click();
+      cy.button("Add filter").click();
       cy.contains("Showing 1 row");
     });
 
@@ -265,8 +265,7 @@ describe("scenarios > question > notebook", () => {
           .click()
           .type("Sum Divide");
 
-        cy.findAllByRole("button")
-          .contains("Done")
+        cy.button("Done")
           .should("not.be.disabled")
           .click();
       });
@@ -661,7 +660,7 @@ describe("scenarios > question > notebook", () => {
         .click();
       cy.findByText("Greater than").click();
       cy.findByPlaceholderText("Enter a number").type(0);
-      cy.findByRole("button", { name: "Add filter" })
+      cy.button("Add filter")
         .should("not.be.disabled")
         .click();
     });
@@ -773,11 +772,11 @@ describe("scenarios > question > notebook", () => {
         .click()
         .type("Example", { delay: 100 });
 
-      cy.findAllByRole("button", { name: "Done" })
+      cy.button("Done")
         .should("not.be.disabled")
         .click();
 
-      cy.findAllByRole("button", { name: "Visualize" }).click();
+      cy.button("Visualize").click();
       cy.contains("Example");
       cy.contains("Big");
       cy.contains("Small");
@@ -794,11 +793,11 @@ describe("scenarios > question > notebook", () => {
 
       cy.contains(/^redundant input/i).should("not.exist");
 
-      cy.findAllByRole("button", { name: "Done" })
+      cy.button("Done")
         .should("not.be.disabled")
         .click();
 
-      cy.findAllByRole("button", { name: "Visualize" }).click();
+      cy.button("Visualize").click();
       cy.contains("Showing 97 rows");
     });
 
@@ -825,11 +824,11 @@ describe("scenarios > question > notebook", () => {
         cy.contains(/^expected closing parenthesis/i).should("not.exist");
         cy.contains(/^redundant input/i).should("not.exist");
 
-        cy.findAllByRole("button", { name: "Done" })
+        cy.button("Done")
           .should("not.be.disabled")
           .click();
 
-        cy.findAllByRole("button", { name: "Visualize" }).click();
+        cy.button("Visualize").click();
         cy.contains(filter);
         cy.contains(result);
       });

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -37,7 +37,7 @@ describe("scenarios > question > notebook", () => {
     cy.findByText("Not now").click();
     // enter "notebook" and visualize without changing anything
     cy.icon("notebook").click();
-    cy.findByText("Visualize").click();
+    cy.button("Visualize").click();
 
     // there were no changes to the question, so we shouldn't have the option to "Save"
     cy.findByText("Save").should("not.exist");
@@ -231,7 +231,7 @@ describe("scenarios > question > notebook", () => {
       popover().within(() => cy.findByText("A_COLUMN").click());
       popover().within(() => cy.findByText("B_COLUMN").click());
 
-      cy.findByText("Visualize").click();
+      cy.button("Visualize").click();
       cy.queryByText("Visualize").then($el => cy.wrap($el).should("not.exist")); // wait for that screen to disappear to avoid "multiple elements" errors
 
       // check that query worked
@@ -270,7 +270,7 @@ describe("scenarios > question > notebook", () => {
           .click();
       });
       cy.route("POST", "/api/dataset").as("visualization");
-      cy.findByText("Visualize").click();
+      cy.button("Visualize").click();
 
       cy.wait("@visualization").then(xhr => {
         expect(xhr.response.body.error).not.to.exist;
@@ -389,7 +389,7 @@ describe("scenarios > question > notebook", () => {
       popover()
         .contains(/Products? → Category/)
         .click();
-      cy.findByText("Visualize").click();
+      cy.button("Visualize").click();
 
       cy.findByText("12928_Q1 + 12928_Q2");
       cy.log("Reported failing in v1.35.4.1 and `master` on July, 16 2020");
@@ -735,7 +735,7 @@ describe("scenarios > question > notebook", () => {
         cy.findByText("Add filter").click();
       });
 
-      cy.findByText("Visualize").click();
+      cy.button("Visualize").click();
       cy.findByText("Gadget").should("exist");
       cy.findByText("Gizmo").should("not.exist");
 
@@ -887,7 +887,7 @@ function joinTwoSavedQuestions(ALIAS = "Joined Question") {
         cy.log("Reported in v0.36.0");
         cy.icon("notebook").click();
         cy.url().should("contain", "/notebook");
-        cy.findByText("Visualize").should("exist");
+        cy.button("Visualize").should("exist");
       });
     });
   });

--- a/frontend/test/metabase/scenarios/question/saved.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/saved.cy.spec.js
@@ -38,7 +38,7 @@ describe("scenarios > question > saved", () => {
 
     modal().within(() => {
       cy.findByText("Save question");
-      cy.findByRole("button", { name: /save/i }).as("saveButton");
+      cy.button("Save").as("saveButton");
       cy.get("@saveButton").should("not.be.disabled");
 
       cy.log(
@@ -119,7 +119,7 @@ describe("scenarios > question > saved", () => {
       .click();
     cy.get(".AdminSelect").findByText("Equal to");
     cy.findByPlaceholderText("Enter a number").type("4");
-    cy.findByRole("button", { name: "Add filter" })
+    cy.button("Add filter")
       .should("not.be.disabled")
       .click();
     cy.findByText("Synergistic Granite Chair");

--- a/frontend/test/metabase/scenarios/sharing/alert/alert.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/alert/alert.cy.spec.js
@@ -175,7 +175,7 @@ describe("scenarios > alert", () => {
         cy.findByPlaceholderText("Find...").type("Cr");
         cy.findByText("Created At").click();
       });
-      cy.findByText("Visualize").click();
+      cy.button("Visualize").click();
 
       // Set a goal
       setGoal("35");

--- a/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
@@ -35,7 +35,7 @@ describe("scenarios > dashboard > subscriptions", () => {
     cy.findByPlaceholderText("Write here, and use Markdown if you'd like")
       .click()
       .type("Foo");
-    cy.findByRole("button", { name: "Save" }).click();
+    cy.button("Save").click();
     cy.findByText("You're editing this dashboard.").should("not.exist");
     cy.icon("share")
       .closest("a")
@@ -206,7 +206,7 @@ describe("scenarios > dashboard > subscriptions", () => {
       cy.findByPlaceholderText(
         "Write here, and use Markdown if you'd like",
       ).type(TEXT_CARD);
-      cy.findByRole("button", { name: "Save" }).click();
+      cy.button("Save").click();
       cy.findByText("You're editing this dashboard.").should("not.exist");
       assignRecipient();
       // Click outside popover to close it and at the same time check that the text card content is shown as expected

--- a/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
@@ -240,7 +240,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
     cy.findByText("Add filter").click();
 
     // Visualize: line
-    cy.findByText("Visualize").click();
+    cy.button("Visualize").click();
     cy.findByText("Visualization").click();
     cy.icon("line").click();
     cy.findByText("Done").click();

--- a/frontend/test/metabase/scenarios/visualizations/trendline.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/trendline.cy.spec.js
@@ -26,10 +26,10 @@ describe("scenarios > question > trendline", () => {
     cy.findByText("by month").click();
     cy.findByText("Year").click();
 
-    cy.findByText("Visualize").click();
+    cy.button("Visualize").click();
 
     // Check graph is there
-    cy.findByText("Visualize").should("not.exist");
+    cy.button("Visualize").should("not.exist");
     cy.findByText("Visualization");
     cy.get("rect");
 

--- a/frontend/test/metabase/scenarios/visualizations/waterfall.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/waterfall.cy.spec.js
@@ -84,7 +84,7 @@ describe("scenarios > visualizations > waterfall", () => {
     cy.get("[contenteditable=true]")
       .type("between([Created At], '2016-01-01', '2016-08-01')")
       .blur();
-    cy.findByRole("button", { name: "Done" }).click();
+    cy.button("Done").click();
 
     cy.findByText("Visualize").click();
     cy.contains("Visualization").click();

--- a/frontend/test/metabase/scenarios/visualizations/waterfall.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/waterfall.cy.spec.js
@@ -86,7 +86,7 @@ describe("scenarios > visualizations > waterfall", () => {
       .blur();
     cy.button("Done").click();
 
-    cy.findByText("Visualize").click();
+    cy.button("Visualize").click();
     cy.contains("Visualization").click();
     cy.icon("waterfall").click();
 
@@ -100,7 +100,7 @@ describe("scenarios > visualizations > waterfall", () => {
     cy.findByText("Pick a column to group by").click();
     cy.findByText("Created At").click();
 
-    cy.findByText("Visualize").click();
+    cy.button("Visualize").click();
     cy.contains("Visualization").click();
     cy.icon("waterfall").click();
 


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Abstracts away Cypress Testing Library syntax `cy.findByRole("button", { "Foo" });` and uses shorter and easier to type (and remember) `cy.button("Foo");`
- Replaces all valid instances of such command in all tests
- Forces using `cy.button("Visualize");` instead of `cy.findByText("Visualize");` in all tests

### How to verify this still works?
- All tests should pass
- If you want to try it locally, this command should work both with the string and also with regex as an argument
    - `cy.button("Save");` should works just as same as `cy.button(/save/i);`

### Why do this?
It's cumbersome to type the long form of the original custom command, so many people avoid it and use `cy.findByText()`. Cypress testing library has really nice intent behind it that helps enforce (and test) good a11y practices in an application. This change will hopefully simplify and encourage the use of the proper command.

## WARNING!
This selector will not work on buttons with the nested structure! Good example is "Summarize" that you can see in "Simple question" GUI.
```html
<button
  ml="1"
  data-metabase-event="View Mode; Open Summary Widget"
  class="Button hide sm-show ViewButton-sc-1bti87e-0 bOvfhB Button-ygn2tx-0 cANzZu flex-no-shrink Button--medium"
>
  <div class="flex layout-centered">
    <svg
      class="Icon Icon-insight Icon-sc-1x67v3y-1 hFNRPZ"
      viewBox="0 0 32 32"
      width="14"
      height="14"
      fill="currentcolor"
      role="img"
      aria-label="insight icon"
    >
      <path
        d="M12.6325203 19.3674797 0 16 12.6325203 12.6325203 16 0 19.3674797 12.6325203 32 16 19.3674797 19.3674797 16 32z"
      ></path>
    </svg>
    <div class="ml1 hide sm-show">Summarize</div>
  </div>
</button>
```

For this I'd use:
```javascript
// Please note that we have to use findAll selector here!
// Cypress first finds ALL buttons, then picks the one that contains "Summarize"
cy.findAllByRole("button").contains("Summmarize");
```