### PR TITLE
Display link to database integration docs when connecting a new database

### DIFF
--- a/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx
@@ -12,6 +12,7 @@ import title from "metabase/hoc/Title";
 
 import DeleteDatabaseModal from "../components/DeleteDatabaseModal";
 import ActionButton from "metabase/components/ActionButton";
+import AddDatabaseHelpCard from "metabase/components/AddDatabaseHelpCard";
 import Button from "metabase/components/Button";
 import Breadcrumbs from "metabase/components/Breadcrumbs";
 import Radio from "metabase/components/Radio";
@@ -41,16 +42,17 @@ const DATABASE_FORM_NAME = "database";
 const getLetUserControlScheduling = database =>
   getIn(database, ["details", "let-user-control-scheduling"]);
 
-const mapStateToProps = (state, props) => ({
-  database: getEditingDatabase(state),
-  databaseCreationStep: getDatabaseCreationStep(state),
-  letUserControlSchedulingSaved: getLetUserControlScheduling(
-    getEditingDatabase(state),
-  ),
-  letUserControlSchedulingForm: getLetUserControlScheduling(
-    getValues(state.form[DATABASE_FORM_NAME]),
-  ),
-});
+const mapStateToProps = (state, props) => {
+  const database = getEditingDatabase(state);
+  const formValues = getValues(state.form[DATABASE_FORM_NAME]);
+  return {
+    database,
+    databaseCreationStep: getDatabaseCreationStep(state),
+    selectedEngine: formValues ? formValues.engine : undefined,
+    letUserControlSchedulingSaved: getLetUserControlScheduling(database),
+    letUserControlSchedulingForm: getLetUserControlScheduling(formValues),
+  };
+};
 
 const mapDispatchToProps = {
   reset,
@@ -131,11 +133,11 @@ export default class DatabaseEditApp extends Component {
   render() {
     const {
       database,
+      selectedEngine,
       letUserControlSchedulingSaved,
       letUserControlSchedulingForm,
     } = this.props;
     const { currentTab } = this.state;
-
     const editingExistingDatabase = database && database.id != null;
     const addingNewDatabase = !editingExistingDatabase;
 
@@ -151,7 +153,7 @@ export default class DatabaseEditApp extends Component {
           ]}
         />
         <Flex pb={2}>
-          <Box w={620}>
+          <Box>
             <div className="pt0">
               {showTabs && (
                 <div className="border-bottom mb2">
@@ -163,37 +165,52 @@ export default class DatabaseEditApp extends Component {
                   />
                 </div>
               )}
-              <LoadingAndErrorWrapper loading={!database} error={null}>
-                {() => (
-                  <Databases.Form
-                    database={database}
-                    form={Databases.forms[currentTab]}
-                    formName={DATABASE_FORM_NAME}
-                    onSubmit={
-                      addingNewDatabase && currentTab === "connection"
-                        ? this.props.proceedWithDbCreation
-                        : this.props.saveDatabase
-                    }
-                    submitTitle={addingNewDatabase ? t`Save` : t`Save changes`}
-                    renderSubmit={
-                      // override use of ActionButton for the `Next` button
-                      addingNewDatabase &&
-                      currentTab === "connection" &&
-                      letUserControlSchedulingForm &&
-                      (({ handleSubmit, canSubmit }) => (
-                        <Button
-                          primary={canSubmit}
-                          disabled={!canSubmit}
-                          onClick={handleSubmit}
-                        >
-                          {t`Next`}
-                        </Button>
-                      ))
-                    }
-                    submitButtonComponent={Button}
-                  />
+              <Flex>
+                <Box w={620}>
+                  <LoadingAndErrorWrapper loading={!database} error={null}>
+                    {() => (
+                      <Databases.Form
+                        database={database}
+                        form={Databases.forms[currentTab]}
+                        formName={DATABASE_FORM_NAME}
+                        onSubmit={
+                          addingNewDatabase && currentTab === "connection"
+                            ? this.props.proceedWithDbCreation
+                            : this.props.saveDatabase
+                        }
+                        submitTitle={
+                          addingNewDatabase ? t`Save` : t`Save changes`
+                        }
+                        renderSubmit={
+                          // override use of ActionButton for the `Next` button
+                          addingNewDatabase &&
+                          currentTab === "connection" &&
+                          letUserControlSchedulingForm &&
+                          (({ handleSubmit, canSubmit }) => (
+                            <Button
+                              primary={canSubmit}
+                              disabled={!canSubmit}
+                              onClick={handleSubmit}
+                            >
+                              {t`Next`}
+                            </Button>
+                          ))
+                        }
+                        submitButtonComponent={Button}
+                      />
+                    )}
+                  </LoadingAndErrorWrapper>
+                </Box>
+                {addingNewDatabase && (
+                  <Box>
+                    <AddDatabaseHelpCard
+                      engine={selectedEngine}
+                      ml={26}
+                      data-testid="database-setup-help-card"
+                    />
+                  </Box>
                 )}
-              </LoadingAndErrorWrapper>
+              </Flex>
             </div>
           </Box>
 

--- a/frontend/src/metabase/components/AddDatabaseHelpCard.jsx
+++ b/frontend/src/metabase/components/AddDatabaseHelpCard.jsx
@@ -1,8 +1,10 @@
-import React from "react";
+import React, { useMemo } from "react";
 import PropTypes from "prop-types";
 import { Flex } from "grid-styled";
 
 import { t } from "ttag";
+
+import MetabaseSettings from "metabase/lib/settings";
 
 import ExternalLink from "metabase/components/ExternalLink";
 import Icon from "metabase/components/Icon";
@@ -12,6 +14,11 @@ const propTypes = {
 };
 
 function AddDatabaseHelpCard({ engine, ...props }) {
+  const displayName = useMemo(() => {
+    const engines = MetabaseSettings.get("engines");
+    return (engines[engine] || {})["driver-name"];
+  }, [engine]);
+
   return (
     <Flex
       p={2}
@@ -31,7 +38,9 @@ function AddDatabaseHelpCard({ engine, ...props }) {
         <Icon size={20} name="database" className="text-brand" />
       </Flex>
       <Flex flexDirection="column" justify="center" className="ml2">
-        <p className="text-medium m0">{t`Need help setting up`} MongoDB?</p>
+        <p className="text-medium m0">
+          {t`Need help setting up`} {displayName}?
+        </p>
         <ExternalLink className="text-brand text-bold">
           {t`Our docs can help.`}
         </ExternalLink>

--- a/frontend/src/metabase/components/AddDatabaseHelpCard.jsx
+++ b/frontend/src/metabase/components/AddDatabaseHelpCard.jsx
@@ -1,0 +1,45 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Flex } from "grid-styled";
+
+import { t } from "ttag";
+
+import ExternalLink from "metabase/components/ExternalLink";
+import Icon from "metabase/components/Icon";
+
+const propTypes = {
+  engine: PropTypes.string,
+};
+
+function AddDatabaseHelpCard({ engine, ...props }) {
+  return (
+    <Flex
+      p={2}
+      style={{ backgroundColor: "#F9FBFB", borderRadius: 10 }}
+      {...props}
+    >
+      <Flex
+        align="center"
+        justify="center"
+        className="circular"
+        style={{
+          minWidth: 52,
+          minHeight: 52,
+          backgroundColor: "#EEF2F5",
+        }}
+      >
+        <Icon size={20} name="database" className="text-brand" />
+      </Flex>
+      <Flex flexDirection="column" justify="center" className="ml2">
+        <p className="text-medium m0">{t`Need help setting up`} MongoDB?</p>
+        <ExternalLink className="text-brand text-bold">
+          {t`Our docs can help.`}
+        </ExternalLink>
+      </Flex>
+    </Flex>
+  );
+}
+
+AddDatabaseHelpCard.propTypes = propTypes;
+
+export default AddDatabaseHelpCard;

--- a/frontend/src/metabase/components/AddDatabaseHelpCard.jsx
+++ b/frontend/src/metabase/components/AddDatabaseHelpCard.jsx
@@ -13,14 +13,34 @@ const propTypes = {
   engine: PropTypes.string,
 };
 
-const CLOUD_HELP_URL = "https://www.metabase.com/help/cloud";
+export const ENGINE_DOCS = {
+  bigquery: MetabaseSettings.docsUrl("administration-guide/databases/bigquery"),
+  mongo: MetabaseSettings.docsUrl("administration-guide/databases/mongodb"),
+  mysql: MetabaseSettings.docsUrl("administration-guide/databases/mysql"),
+  oracle: MetabaseSettings.docsUrl("administration-guide/databases/oracle"),
+  snowflake: MetabaseSettings.docsUrl(
+    "administration-guide/databases/snowflake",
+  ),
+  vertica: MetabaseSettings.docsUrl("administration-guide/databases/vertica"),
+};
+
+export const GENERAL_DB_DOC = MetabaseSettings.docsUrl(
+  "administration-guide/01-managing-databases",
+);
+
+export const CLOUD_HELP_URL = "https://www.metabase.com/help/cloud";
 
 function AddDatabaseHelpCard({ engine, ...props }) {
   const displayName = useMemo(() => {
+    const hasEngineDoc = !!ENGINE_DOCS[engine];
+    if (!hasEngineDoc) {
+      return "your database";
+    }
     const engines = MetabaseSettings.get("engines");
     return (engines[engine] || {})["driver-name"];
   }, [engine]);
 
+  const docsLink = ENGINE_DOCS[engine] || GENERAL_DB_DOC;
   const shouldDisplayHelpLink = MetabaseSettings.isHosted();
 
   return (
@@ -49,9 +69,9 @@ function AddDatabaseHelpCard({ engine, ...props }) {
       >
         <div>
           <p className="text-medium m0">
-            {t`Need help setting up`} <span>{displayName}</span>?
+            {t`Need help setting up`} {displayName}?
           </p>
-          <ExternalLink className="text-brand text-bold">
+          <ExternalLink href={docsLink} className="text-brand text-bold">
             {t`Our docs can help.`}
           </ExternalLink>
         </div>

--- a/frontend/src/metabase/components/AddDatabaseHelpCard.jsx
+++ b/frontend/src/metabase/components/AddDatabaseHelpCard.jsx
@@ -9,10 +9,6 @@ import MetabaseSettings from "metabase/lib/settings";
 import ExternalLink from "metabase/components/ExternalLink";
 import Icon from "metabase/components/Icon";
 
-const propTypes = {
-  engine: PropTypes.string,
-};
-
 export const ENGINE_DOCS = {
   bigquery: MetabaseSettings.docsUrl("administration-guide/databases/bigquery"),
   mongo: MetabaseSettings.docsUrl("administration-guide/databases/mongodb"),
@@ -30,7 +26,18 @@ export const GENERAL_DB_DOC = MetabaseSettings.docsUrl(
 
 export const CLOUD_HELP_URL = "https://www.metabase.com/help/cloud";
 
-function AddDatabaseHelpCard({ engine, ...props }) {
+const propTypes = {
+  engine: PropTypes.string.isRequired,
+  hasCircle: PropTypes.bool,
+  style: PropTypes.object,
+};
+
+const defaultProps = {
+  hasCircle: true,
+  style: {},
+};
+
+function AddDatabaseHelpCard({ engine, hasCircle, style, ...props }) {
   const displayName = useMemo(() => {
     const hasEngineDoc = !!ENGINE_DOCS[engine];
     if (!hasEngineDoc) {
@@ -46,7 +53,12 @@ function AddDatabaseHelpCard({ engine, ...props }) {
   return (
     <Flex
       p={2}
-      style={{ backgroundColor: "#F9FBFB", borderRadius: 10, minWidth: 300 }}
+      style={{
+        backgroundColor: "#F9FBFB",
+        borderRadius: 10,
+        minWidth: 300,
+        ...style,
+      }}
       {...props}
     >
       <Flex
@@ -54,9 +66,9 @@ function AddDatabaseHelpCard({ engine, ...props }) {
         justify="center"
         className="flex-no-shrink circular"
         style={{
-          width: 52,
-          height: 52,
-          backgroundColor: "#EEF2F5",
+          width: hasCircle ? "52px" : "32px",
+          height: hasCircle ? "52px" : "32px",
+          backgroundColor: hasCircle ? "#EEF2F5" : "transparent",
         }}
       >
         <Icon size={20} name="database" className="text-brand" />
@@ -92,5 +104,6 @@ function AddDatabaseHelpCard({ engine, ...props }) {
 }
 
 AddDatabaseHelpCard.propTypes = propTypes;
+AddDatabaseHelpCard.defaultProps = defaultProps;
 
 export default AddDatabaseHelpCard;

--- a/frontend/src/metabase/components/AddDatabaseHelpCard.jsx
+++ b/frontend/src/metabase/components/AddDatabaseHelpCard.jsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from "react";
 import PropTypes from "prop-types";
+import styled from "styled-components";
 import { Flex } from "grid-styled";
 
 import { t, jt } from "ttag";
@@ -51,33 +52,20 @@ function AddDatabaseHelpCard({ engine, hasCircle, style, ...props }) {
   const shouldDisplayHelpLink = MetabaseSettings.isHosted();
 
   return (
-    <Flex
-      p={2}
-      style={{
-        backgroundColor: "#F9FBFB",
-        borderRadius: 10,
-        minWidth: 300,
-        ...style,
-      }}
-      {...props}
-    >
-      <Flex
+    <HelpCardContainer p={2} {...props}>
+      <IconContainer
         align="center"
         justify="center"
         className="flex-no-shrink circular"
-        style={{
-          width: hasCircle ? "52px" : "32px",
-          height: hasCircle ? "52px" : "32px",
-          backgroundColor: hasCircle ? "#EEF2F5" : "transparent",
-        }}
+        hasCircle={hasCircle}
       >
         <Icon size={20} name="database" className="text-brand" />
-      </Flex>
-      <Flex
+      </IconContainer>
+      <CardContent
         flexDirection="column"
         justify="center"
         className="ml2"
-        style={{ marginTop: shouldDisplayHelpLink ? "8px" : 0 }}
+        shouldDisplayHelpLink={shouldDisplayHelpLink}
       >
         <div>
           <p className="text-medium m0">
@@ -98,12 +86,28 @@ function AddDatabaseHelpCard({ engine, hasCircle, style, ...props }) {
             </ExternalLink>
           </p>
         )}
-      </Flex>
-    </Flex>
+      </CardContent>
+    </HelpCardContainer>
   );
 }
 
 AddDatabaseHelpCard.propTypes = propTypes;
 AddDatabaseHelpCard.defaultProps = defaultProps;
+
+const HelpCardContainer = styled(Flex)`
+  background-color: #f9fbfb;
+  border-radius: 10px;
+  min-width: 300px;
+`;
+
+const IconContainer = styled(Flex)`
+  width: ${props => (props.hasCircle ? "52px" : "32px")};
+  height: ${props => (props.hasCircle ? "52px" : "32px")};
+  background-color: ${props => (props.hasCircle ? "#EEF2F5" : "transparent")};
+`;
+
+const CardContent = styled(Flex)`
+  margin-top: ${props => (props.shouldDisplayHelpLink ? "8px" : 0)};
+`;
 
 export default AddDatabaseHelpCard;

--- a/frontend/src/metabase/components/AddDatabaseHelpCard.jsx
+++ b/frontend/src/metabase/components/AddDatabaseHelpCard.jsx
@@ -2,7 +2,7 @@ import React, { useMemo } from "react";
 import PropTypes from "prop-types";
 import { Flex } from "grid-styled";
 
-import { t } from "ttag";
+import { t, jt } from "ttag";
 
 import MetabaseSettings from "metabase/lib/settings";
 
@@ -13,37 +13,59 @@ const propTypes = {
   engine: PropTypes.string,
 };
 
+const CLOUD_HELP_URL = "https://www.metabase.com/help/cloud";
+
 function AddDatabaseHelpCard({ engine, ...props }) {
   const displayName = useMemo(() => {
     const engines = MetabaseSettings.get("engines");
     return (engines[engine] || {})["driver-name"];
   }, [engine]);
 
+  const shouldDisplayHelpLink = MetabaseSettings.isHosted();
+
   return (
     <Flex
       p={2}
-      style={{ backgroundColor: "#F9FBFB", borderRadius: 10 }}
+      style={{ backgroundColor: "#F9FBFB", borderRadius: 10, minWidth: 300 }}
       {...props}
     >
       <Flex
         align="center"
         justify="center"
-        className="circular"
+        className="flex-no-shrink circular"
         style={{
-          minWidth: 52,
-          minHeight: 52,
+          width: 52,
+          height: 52,
           backgroundColor: "#EEF2F5",
         }}
       >
         <Icon size={20} name="database" className="text-brand" />
       </Flex>
-      <Flex flexDirection="column" justify="center" className="ml2">
-        <p className="text-medium m0">
-          {t`Need help setting up`} {displayName}?
-        </p>
-        <ExternalLink className="text-brand text-bold">
-          {t`Our docs can help.`}
-        </ExternalLink>
+      <Flex
+        flexDirection="column"
+        justify="center"
+        className="ml2"
+        style={{ marginTop: shouldDisplayHelpLink ? "8px" : 0 }}
+      >
+        <div>
+          <p className="text-medium m0">
+            {t`Need help setting up`} <span>{displayName}</span>?
+          </p>
+          <ExternalLink className="text-brand text-bold">
+            {t`Our docs can help.`}
+          </ExternalLink>
+        </div>
+        {shouldDisplayHelpLink && (
+          <p className="mt2 text-medium m0">
+            {jt`Docs weren't enough?`}{" "}
+            <ExternalLink
+              href={CLOUD_HELP_URL}
+              className="text-brand text-bold"
+            >
+              Write us.
+            </ExternalLink>
+          </p>
+        )}
       </Flex>
     </Flex>
   );

--- a/frontend/src/metabase/components/AddDatabaseHelpCard.jsx
+++ b/frontend/src/metabase/components/AddDatabaseHelpCard.jsx
@@ -94,7 +94,7 @@ function AddDatabaseHelpCard({ engine, hasCircle, style, ...props }) {
               href={CLOUD_HELP_URL}
               className="text-brand text-bold"
             >
-              Write us.
+              {t`Write us.`}
             </ExternalLink>
           </p>
         )}

--- a/frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx
+++ b/frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx
@@ -19,6 +19,7 @@ export default class DatabaseConnectionStep extends Component {
     activeStep: PropTypes.number.isRequired,
     setActiveStep: PropTypes.func.isRequired,
 
+    formName: PropTypes.string.isRequired,
     databaseDetails: PropTypes.object,
     validateDatabase: PropTypes.func.isRequired,
     setDatabaseDetails: PropTypes.func.isRequired,
@@ -99,6 +100,7 @@ export default class DatabaseConnectionStep extends Component {
       databaseDetails,
       setActiveStep,
       stepNumber,
+      formName,
     } = this.props;
     let stepText = t`Add your data`;
     if (activeStep > stepNumber) {
@@ -131,6 +133,7 @@ export default class DatabaseConnectionStep extends Component {
           </div>
 
           <Databases.Form
+            formName={formName}
             form={Databases.forms.connection}
             database={databaseDetails}
             onSubmit={this.handleSubmit}

--- a/frontend/src/metabase/setup/components/Setup.jsx
+++ b/frontend/src/metabase/setup/components/Setup.jsx
@@ -2,11 +2,14 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { t } from "ttag";
+
+import MetabaseAnalytics from "metabase/lib/analytics";
+import MetabaseSettings from "metabase/lib/settings";
+
+import AddDatabaseHelpCard from "metabase/components/AddDatabaseHelpCard";
 import ExternalLink from "metabase/components/ExternalLink";
 import LogoIcon from "metabase/components/LogoIcon";
 import NewsletterForm from "metabase/components/NewsletterForm";
-import MetabaseAnalytics from "metabase/lib/analytics";
-import MetabaseSettings from "metabase/lib/settings";
 
 import LanguageStep from "./LanguageStep";
 import UserStep from "./UserStep";
@@ -28,7 +31,9 @@ export default class Setup extends Component {
     userDetails: PropTypes.object,
     languageDetails: PropTypes.object,
     setActiveStep: PropTypes.func.isRequired,
+    databaseFormName: PropTypes.string.isRequired,
     databaseDetails: PropTypes.object,
+    selectedDatabaseEngine: PropTypes.string,
   };
 
   constructor(props) {
@@ -98,7 +103,9 @@ export default class Setup extends Component {
     const {
       activeStep,
       setupComplete,
+      databaseFormName,
       databaseDetails,
+      selectedDatabaseEngine,
       userDetails,
     } = this.props;
 
@@ -145,6 +152,7 @@ export default class Setup extends Component {
               <DatabaseConnectionStep
                 {...this.props}
                 stepNumber={DATABASE_CONNECTION_STEP_NUMBER}
+                formName={databaseFormName}
               />
 
               {/* Have the ref for scrolling in UNSAFE_componentWillReceiveProps */}
@@ -187,6 +195,26 @@ export default class Setup extends Component {
               <div className="text-centered">{this.renderFooter()}</div>
             </div>
           </div>
+
+          {activeStep === DATABASE_CONNECTION_STEP_NUMBER && (
+            <div
+              style={{
+                position: "fixed",
+                left: "1em",
+                bottom: "1em",
+              }}
+            >
+              <AddDatabaseHelpCard
+                engine={selectedDatabaseEngine}
+                hasCircle={false}
+                data-testid="database-setup-help-card"
+                style={{
+                  border: "1px solid #F0F0F0",
+                  backgroundColor: "#FFF",
+                }}
+              />
+            </div>
+          )}
         </div>
       );
     }

--- a/frontend/src/metabase/setup/components/Setup.jsx
+++ b/frontend/src/metabase/setup/components/Setup.jsx
@@ -196,25 +196,26 @@ export default class Setup extends Component {
             </div>
           </div>
 
-          {activeStep === DATABASE_CONNECTION_STEP_NUMBER && (
-            <div
-              style={{
-                position: "fixed",
-                left: "1em",
-                bottom: "1em",
-              }}
-            >
-              <AddDatabaseHelpCard
-                engine={selectedDatabaseEngine}
-                hasCircle={false}
-                data-testid="database-setup-help-card"
+          {selectedDatabaseEngine &&
+            activeStep === DATABASE_CONNECTION_STEP_NUMBER && (
+              <div
                 style={{
-                  border: "1px solid #F0F0F0",
-                  backgroundColor: "#FFF",
+                  position: "fixed",
+                  left: "1em",
+                  bottom: "1em",
                 }}
-              />
-            </div>
-          )}
+              >
+                <AddDatabaseHelpCard
+                  engine={selectedDatabaseEngine}
+                  hasCircle={false}
+                  data-testid="database-setup-help-card"
+                  style={{
+                    border: "1px solid #F0F0F0",
+                    backgroundColor: "#FFF",
+                  }}
+                />
+              </div>
+            )}
         </div>
       );
     }

--- a/frontend/src/metabase/setup/containers/SetupApp.jsx
+++ b/frontend/src/metabase/setup/containers/SetupApp.jsx
@@ -5,7 +5,7 @@ import fitViewport from "metabase/hoc/FitViewPort";
 
 import Setup from "../components/Setup";
 
-import { setupSelectors } from "../selectors";
+import { DATABASE_FORM_NAME, setupSelectors } from "../selectors";
 import {
   setUserDetails,
   validatePassword,
@@ -37,6 +37,6 @@ const mapDispatchToProps = {
 @fitViewport
 export default class SetupApp extends Component {
   render() {
-    return <Setup {...this.props} />;
+    return <Setup {...this.props} databaseFormName={DATABASE_FORM_NAME} />;
   }
 }

--- a/frontend/src/metabase/setup/selectors.js
+++ b/frontend/src/metabase/setup/selectors.js
@@ -1,4 +1,7 @@
 import { createSelector } from "reselect";
+import { getValues } from "redux-form";
+
+export const DATABASE_FORM_NAME = "database";
 
 const activeStepSelector = state => state.setup.activeStep;
 const userDetailsSelector = state => state.setup.userDetails;
@@ -6,6 +9,11 @@ const databaseDetailsSelector = state => state.setup.databaseDetails;
 const allowTrackingSelector = state => state.setup.allowTracking;
 const setupErrorSelector = state => state.setup.setupError;
 const setupCompleteSelector = state => state.setup.setupComplete;
+
+function selectedDatabaseEngineSelector(state) {
+  const formValues = getValues(state.form[DATABASE_FORM_NAME]);
+  return formValues ? formValues.engine : undefined;
+}
 
 // our master selector which combines all of our partial selectors above
 export const setupSelectors = createSelector(
@@ -16,6 +24,7 @@ export const setupSelectors = createSelector(
     allowTrackingSelector,
     setupErrorSelector,
     setupCompleteSelector,
+    selectedDatabaseEngineSelector,
   ],
   (
     activeStep,
@@ -24,6 +33,7 @@ export const setupSelectors = createSelector(
     allowTracking,
     setupError,
     setupComplete,
+    selectedDatabaseEngine,
   ) => ({
     activeStep,
     userDetails,
@@ -31,5 +41,6 @@ export const setupSelectors = createSelector(
     allowTracking,
     setupError,
     setupComplete,
+    selectedDatabaseEngine,
   }),
 );

--- a/frontend/test/metabase/components/AddDatabaseHelpCard.unit.spec.js
+++ b/frontend/test/metabase/components/AddDatabaseHelpCard.unit.spec.js
@@ -4,7 +4,11 @@ import { render } from "@testing-library/react";
 
 import MetabaseSettings from "metabase/lib/settings";
 
-import AddDatabaseHelpCard from "metabase/components/AddDatabaseHelpCard";
+import AddDatabaseHelpCard, {
+  CLOUD_HELP_URL,
+  ENGINE_DOCS,
+  GENERAL_DB_DOC,
+} from "metabase/components/AddDatabaseHelpCard";
 
 const ENGINES = {
   redshift: {
@@ -48,8 +52,6 @@ const ENGINES = {
   },
 };
 
-jest.mock("metabase/lib/settings");
-
 function setup({ engine = "mongo", isHosted = false } = {}) {
   jest
     .spyOn(MetabaseSettings, "get")
@@ -60,9 +62,19 @@ function setup({ engine = "mongo", isHosted = false } = {}) {
 
 describe("AddDatabaseHelpCard", () => {
   Object.entries(ENGINES).forEach(([engine, info]) => {
+    const expectedDisplayName = ENGINE_DOCS[engine]
+      ? info["driver-name"]
+      : "your database";
+    const expectedDocsLink = ENGINE_DOCS[engine] || GENERAL_DB_DOC;
+
     it(`correctly displays hints for ${engine} setup`, () => {
       const { queryByText } = setup({ engine });
-      expect(queryByText(info["driver-name"])).toBeInTheDocument();
+      const docsLink = queryByText("Our docs can help.");
+      expect(
+        queryByText(`Need help setting up ${expectedDisplayName}?`),
+      ).toBeInTheDocument();
+      expect(docsLink).toBeInTheDocument();
+      expect(docsLink.getAttribute("href")).toBe(expectedDocsLink);
     });
   });
 
@@ -70,9 +82,7 @@ describe("AddDatabaseHelpCard", () => {
     const { queryByText } = setup({ isHosted: true });
     const helpLink = queryByText(/write us/i);
     expect(helpLink).toBeInTheDocument();
-    expect(helpLink.getAttribute("href")).toBe(
-      "https://www.metabase.com/help/cloud",
-    );
+    expect(helpLink.getAttribute("href")).toBe(CLOUD_HELP_URL);
   });
 
   it("should not display a help link if it's a self-hosted instance", () => {

--- a/frontend/test/metabase/components/AddDatabaseHelpCard.unit.spec.js
+++ b/frontend/test/metabase/components/AddDatabaseHelpCard.unit.spec.js
@@ -1,0 +1,65 @@
+import React from "react";
+import "@testing-library/jest-dom/extend-expect";
+import { render } from "@testing-library/react";
+
+import MetabaseSettings from "metabase/lib/settings";
+
+import AddDatabaseHelpCard from "metabase/components/AddDatabaseHelpCard";
+
+const ENGINES = {
+  redshift: {
+    "driver-name": "Amazon Redshift",
+  },
+  bigquery: {
+    "driver-name": "BigQuery",
+  },
+  druid: {
+    "driver-name": "Druid",
+  },
+  googleanalytics: {
+    "driver-name": "Google Analytics",
+  },
+  h2: {
+    "driver-name": "H2",
+  },
+  mongo: {
+    "driver-name": "MongoDB",
+  },
+  mysql: {
+    "driver-name": "MySQL",
+  },
+  postgres: {
+    "driver-name": "PostgreSQL",
+  },
+  presto: {
+    "driver-name": "Presto",
+  },
+  snowflake: {
+    "driver-name": "Snowflake",
+  },
+  sparksql: {
+    "driver-name": "Spark SQL",
+  },
+  sqlserver: {
+    "driver-name": "SQL Server",
+  },
+  sqlite: {
+    "driver-name": "SQLite",
+  },
+};
+
+jest.mock("metabase/lib/settings");
+
+describe("AddDatabaseHelpCard", () => {
+  Object.entries(ENGINES).forEach(([engine, info]) => {
+    jest
+      .spyOn(MetabaseSettings, "get")
+      .mockImplementation(setting => (setting === "engines" ? ENGINES : {}));
+
+    it(`correctly displays hints for ${engine} setup`, () => {
+      const driverName = info["driver-name"];
+      const { getByText } = render(<AddDatabaseHelpCard engine={engine} />);
+      expect(getByText(`Need help setting up ${driverName}?`)).toBeVisible();
+    });
+  });
+});

--- a/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
@@ -170,6 +170,18 @@ describe("scenarios > admin > databases > add", () => {
       cy.findByText(/Need help setting up (.*)\?/i);
       cy.findByRole("link", { name: /Our docs can help/i });
     });
+
+    cy.get("#formField-engine").click();
+    cy.findByText("MySQL").click();
+    cy.findByTestId("database-setup-help-card").findByText(
+      "Need help setting up MySQL?",
+    );
+
+    cy.get("#formField-engine").click();
+    cy.findByText("SQLite").click();
+    cy.findByTestId("database-setup-help-card").findByText(
+      "Need help setting up your database?",
+    );
   });
 
   describe("BigQuery", () => {

--- a/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
@@ -164,6 +164,14 @@ describe("scenarios > admin > databases > add", () => {
     });
   });
 
+  it("should display a setup help card", () => {
+    cy.visit("/admin/databases/create");
+    cy.findByTestId("database-setup-help-card").within(() => {
+      cy.findByText(/Need help setting up (.*)\?/i);
+      cy.findByRole("link", { name: /Our docs can help/i });
+    });
+  });
+
   describe("BigQuery", () => {
     it("should let you upload the service account json from a file", () => {
       cy.visit("/admin/databases/create");

--- a/frontend/test/metabase/scenarios/admin/databases/edit.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/edit.cy.spec.js
@@ -204,5 +204,14 @@ describe("scenarios > admin > databases > edit", () => {
       cy.wait("@delete");
       cy.url().should("match", /\/admin\/databases\/$/);
     });
+
+    it("should not display a setup help card", () => {
+      cy.intercept("GET", "/api/database/1").as("loadDatabase");
+
+      cy.visit("/admin/databases/1");
+      cy.wait("@loadDatabase");
+
+      cy.findByTestId("database-setup-help-card").should("not.exist");
+    });
   });
 });

--- a/frontend/test/metabase/scenarios/onboarding/setup/setup.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/setup/setup.cy.spec.js
@@ -1,5 +1,5 @@
 import path from "path";
-import { restore } from "__support__/e2e/cypress";
+import { restore, popover } from "__support__/e2e/cypress";
 
 // we're testing for one known (en) and one unknown (xx) locale
 const locales = ["en", "xx"];
@@ -90,37 +90,39 @@ describe("scenarios > setup", () => {
         exact: false,
       });
 
+      // test database setup help card is NOT displayed before DB is selected
+      cy.findByTestId("database-setup-help-card").should("not.exist");
+
       // test that you can return to user settings if you want
       cy.findByText("Hi, Testy. Nice to meet you!").click();
       cy.findByLabelText("Email").should("have.value", "testy@metabase.com");
 
-      // test database setup help card is NOT displayed
+      // test database setup help card is NOT displayed on other steps
       cy.findByTestId("database-setup-help-card").should("not.exist");
 
       // now back to database setting
       cy.findByText("Next").click();
 
-      // test database setup help card is displayed
+      // check database setup card changes copy
+      cy.get("#formField-engine .AdminSelect").click();
+      popover()
+        .findByText("MySQL")
+        .click();
       cy.findByTestId("database-setup-help-card").within(() => {
-        cy.findByText(/Need help setting up (.*)\?/i);
+        cy.findByText("Need help setting up MySQL?");
         cy.findByRole("link", { name: /Our docs can help/i });
       });
 
-      // check database setup card changes copy
-      cy.findByText("Select a database").click();
-      cy.findByText("MySQL").click();
-      cy.findByTestId("database-setup-help-card").findByText(
-        "Need help setting up MySQL?",
-      );
-
-      cy.get("#formField-engine").click();
-      cy.findByText("SQLite").click();
+      cy.get("#formField-engine .AdminSelect").click();
+      popover()
+        .findByText("SQLite")
+        .click();
       cy.findByTestId("database-setup-help-card").findByText(
         "Need help setting up your database?",
       );
 
       // add h2 database
-      cy.get("#formField-engine").click();
+      cy.get("#formField-engine .AdminSelect").click();
       cy.findByText("H2").click();
       cy.findByLabelText("Name").type("Metabase H2");
       cy.findByText("Next")

--- a/frontend/test/metabase/scenarios/onboarding/setup/setup.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/setup/setup.cy.spec.js
@@ -94,11 +94,33 @@ describe("scenarios > setup", () => {
       cy.findByText("Hi, Testy. Nice to meet you!").click();
       cy.findByLabelText("Email").should("have.value", "testy@metabase.com");
 
+      // test database setup help card is NOT displayed
+      cy.findByTestId("database-setup-help-card").should("not.exist");
+
       // now back to database setting
       cy.findByText("Next").click();
 
-      // add h2 database
+      // test database setup help card is displayed
+      cy.findByTestId("database-setup-help-card").within(() => {
+        cy.findByText(/Need help setting up (.*)\?/i);
+        cy.findByRole("link", { name: /Our docs can help/i });
+      });
+
+      // check database setup card changes copy
       cy.findByText("Select a database").click();
+      cy.findByText("MySQL").click();
+      cy.findByTestId("database-setup-help-card").findByText(
+        "Need help setting up MySQL?",
+      );
+
+      cy.get("#formField-engine").click();
+      cy.findByText("SQLite").click();
+      cy.findByTestId("database-setup-help-card").findByText(
+        "Need help setting up your database?",
+      );
+
+      // add h2 database
+      cy.get("#formField-engine").click();
       cy.findByText("H2").click();
       cy.findByLabelText("Name").type("Metabase H2");
       cy.findByText("Next")


### PR DESCRIPTION
This PR adds a call out to the database integration docs after a user picks the database type during Metabase setup or on the `/admin/database/create` page. For cloud instances, it also displays a link for contacting support (the link doesn't work right now).

I'll need to change the doc links as soon as I receive them, but the technical part of the project can be reviewed and should not change a lot ✌️ 

### To Verify

**Setup*

1. Launch empty Metabase instance
2. Select a language, fill in account info, proceed to the Database setup section
3. Select a database. A small card has to appear in the bottom left of the screen. If we have a dedicated doc for the selected database, it should link to it. Otherwise, the link points to [generic "Managing Databases" doc](https://www.metabase.com/docs/latest/administration-guide/01-managing-databases.html)

**Adding Database**

1. Open `/admin/database/create`
2. A small card has to appear on the left side of the page. If we have a dedicated doc for the selected database, it should link to it. Otherwise, the link points to [generic "Managing Databases" doc](https://www.metabase.com/docs/latest/administration-guide/01-managing-databases.html)

### Demo

⚠️ On some "setup" screenshots there are cases when a DB is not selected, but the card is already displayed.
This is [fixed](https://github.com/metabase/metabase/pull/16018/commits/9b6b8733b9de8eda5ac5ad04c0e740b2c03f47b0), the card will only show up if a DB is selected from the dropdown

**Setup (self-hosted)**

![2021-05-12 22 07 56](https://user-images.githubusercontent.com/17258145/118042965-6ca57a00-b37d-11eb-84de-5a4cb1307cdb.gif)

**Setup (cloud)**

<img width="1429" alt="Screenshot 2021-05-12 at 22 09 15" src="https://user-images.githubusercontent.com/17258145/118043005-7cbd5980-b37d-11eb-93cb-a76fd3b4ab35.png">

**Admin (self-hosted)**

<img width="1430" alt="Screenshot 2021-05-12 at 22 10 38" src="https://user-images.githubusercontent.com/17258145/118043037-847cfe00-b37d-11eb-936a-9a9a1f339cd2.png">

**Admin (cloud)**

<img width="1436" alt="Screenshot 2021-05-12 at 22 09 43" src="https://user-images.githubusercontent.com/17258145/118043055-8ba40c00-b37d-11eb-99b6-d82c49e1c736.png">
