### PR TITLE
Fix Whitelabel favicon not working in all browsers

### DIFF
--- a/frontend/test/metabase/scenarios/admin/settings/whitelabel.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/whitelabel.cy.spec.js
@@ -238,7 +238,7 @@ describeWithToken("formatting > whitelabel", () => {
       cy.visit("/admin/settings/whitelabel");
 
       cy.log("Add favicon");
-      cy.findByPlaceholderText("frontend_client/favicon.ico").type(
+      cy.findByPlaceholderText("/app/assets/img/favicon.ico").type(
         "https://cdn.ecosia.org/assets/images/ico/favicon.ico",
       );
       cy.get("ul")

--- a/resources/frontend_client/index_template.html
+++ b/resources/frontend_client/index_template.html
@@ -11,7 +11,6 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/app/assets/img/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/app/assets/img/favicon-16x16.png">
     <link rel="manifest" href="/app/assets/img/site.webmanifest">
-    <link rel="mask-icon" href="/app/assets/img/safari-pinned-tab.svg" color="#62a8e6">
     <link rel="shortcut icon" href="/app/assets/img/favicon.ico">
     <meta name="msapplication-TileColor" content="#2d89ef">
     <meta name="msapplication-config" content="/app/assets/img/browserconfig.xml">

--- a/resources/frontend_client/index_template.html
+++ b/resources/frontend_client/index_template.html
@@ -8,8 +8,6 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <link rel="apple-touch-icon" sizes="180x180" href="/app/assets/img/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="/app/assets/img/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/app/assets/img/favicon-16x16.png">
     <link rel="icon" href="{{{favicon}}}" />
     <link rel="manifest" href="/app/assets/img/site.webmanifest">
     <meta name="msapplication-TileColor" content="#2d89ef">

--- a/resources/frontend_client/index_template.html
+++ b/resources/frontend_client/index_template.html
@@ -10,16 +10,14 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/app/assets/img/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/app/assets/img/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/app/assets/img/favicon-16x16.png">
+    <link rel="icon" href="{{{favicon}}}" />
     <link rel="manifest" href="/app/assets/img/site.webmanifest">
-    <link rel="shortcut icon" href="/app/assets/img/favicon.ico">
     <meta name="msapplication-TileColor" content="#2d89ef">
     <meta name="msapplication-config" content="/app/assets/img/browserconfig.xml">
     <meta name="theme-color" content="#ffffff">
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <meta name="base-href" content="{{{baseHref}}}" />
     <meta name="uri" content="{{{uri}}}" />
-
-    <link rel="icon" href="{{{favicon}}}" />
 
     {{{embedCode}}}
 

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -242,7 +242,7 @@
   (deferred-tru "The url or image that you want to use as the favicon.")
   :visibility :public
   :type       :string
-  :default    "frontend_client/favicon.ico")
+  :default    "/app/assets/img/favicon.ico")
 
 (defsetting enable-password-login
   (deferred-tru "Allow logging in by email and password.")


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Attempts to fix whitelabel custom favicons not working in all browsers
- Fixes the default path for the favicon in `src/metabase/public_settings.clj`
- Removes duplicated requests:
    - `https://baseUrl/frontend_client/favicon.ico`(was resulting in not found)
    - `https://baseUrl/app/assets/img/favicon.ico`
- Removes obsolete favicon links following the advice from [this article](https://evilmartians.com/chronicles/how-to-favicon-in-2021-six-files-that-fit-most-needs) (quoted on CSS tricks) - brought up by @flamber
- Closes #15711 

### How to test this works?
_Make sure to clear cache in whatever browser you're testing!_

#### OSS version
- The default Metabase icon should be visible

#### EE version
- The default Metabase icon should be originally visible
- Make sure you have ENTERPRISE_TOKEN -> activate EE licence by going to the Admin > Enterprise
- Go to `/admin/settings/whitelabel` and paste the full link to any PNG favicon (or even any smaller png image, for that matter)
    - Github: `https://github.githubassets.com/favicons/favicon.png`
    - Firefox: `https://www.mozilla.org/media/protocol/img/logos/firefox/browser/logo-md.f0603b4c28b4.png` (not even favicon, but works)
    - Hard refresh (sometimes even couple of times if needed)
    - Make sure the new favicon is visible

### Screenshots
#### Github favicon
![image](https://user-images.githubusercontent.com/31325167/118051425-497cc980-b381-11eb-9bef-13ea07d79f97.png)

![image](https://user-images.githubusercontent.com/31325167/118051454-57cae580-b381-11eb-8a33-d43f82bbfb43.png)

![image](https://user-images.githubusercontent.com/31325167/118051509-7204c380-b381-11eb-8608-6eea3d7692ad.png)

![image](https://user-images.githubusercontent.com/31325167/118051619-995b9080-b381-11eb-9034-127fdb0ce464.png)


#### Firefox logo
![image](https://user-images.githubusercontent.com/31325167/118051769-d889e180-b381-11eb-92c6-376978004f02.png)


![image](https://user-images.githubusercontent.com/31325167/118050995-8c8a6d00-b380-11eb-8d13-3d27987cd261.png)

![image](https://user-images.githubusercontent.com/31325167/118051049-a3c95a80-b380-11eb-8350-a9317378e59f.png)

![image](https://user-images.githubusercontent.com/31325167/118051181-dc693400-b380-11eb-8350-a1976769004e.png)
