### PR TITLE
Fix Druid queries with multiple filters if some but not all are temporal

### DIFF
--- a/modules/drivers/druid/src/metabase/driver/druid/query_processor.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid/query_processor.clj
@@ -224,29 +224,22 @@
    :lowerStrict (not inclusive?)
    :upperStrict (not inclusive?)})
 
-(defmulti ^:private parse-filter
+(defmulti ^:private parse-filter*
   "Parse an MBQL `filter-clause` and generate an appropriate Druid filter map.
 
-    (parse-filter [:= [:field 1 null] 2]) ; -> {:type :selector, :dimension \"venue_price\", :value 2}"
+    (parse-filter* [:= [:field 1 nil] 2]) ; -> {:type :selector, :dimension \"venue_price\", :value 2}"
   {:arglists '([filter-clause])}
-  ;; dispatch function first checks to make sure this is a valid filter clause, then dispatches off of the clause name
-  ;; if it is.
-  (fn [[clause-name & args, :as filter-clause]]
-    (let [fields (mbql.u/match args :field)]
-      ;; and make sure none of the Fields are datetime Fields We'll handle :timestamp separately. It needs to go in
-      ;; :intervals instead
-      (when (empty? (mbql.u/match fields [:field _ (_ :guard :temporal-unit)]))
-        clause-name))))
+  mbql.u/dispatch-by-clause-name-or-class)
 
-(defmethod parse-filter nil
+(defmethod parse-filter* nil
   [_]
   nil)
 
-(defmethod parse-filter :between
+(defmethod parse-filter* :between
   [[_ field min-val max-val]]
   (filter:bound field, :lower min-val, :upper max-val))
 
-(defmethod parse-filter :contains
+(defmethod parse-filter* :contains
   [[_ field string-or-field options]]
   {:type      :search
    :dimension (->rvalue field)
@@ -254,56 +247,64 @@
                :value         (->rvalue string-or-field)
                :caseSensitive (get options :case-sensitive true)}})
 
-(defmethod parse-filter :starts-with
+(defmethod parse-filter* :starts-with
   [[_ field string-or-field options]]
   (filter:like field
                (str (escape-like-filter-pattern (->rvalue string-or-field)) \%)
                (get options :case-sensitive true)))
 
-(defmethod parse-filter :ends-with
+(defmethod parse-filter* :ends-with
   [[_ field string-or-field options]]
   (filter:like field
                (str \% (escape-like-filter-pattern (->rvalue string-or-field)))
                (get options :case-sensitive true)))
 
-(defmethod parse-filter :=
+(defmethod parse-filter* :=
   [[_ field value-or-field]]
   (filter:= field value-or-field))
 
-(defmethod parse-filter :!=
+(defmethod parse-filter* :!=
   [[_ field value-or-field]]
   (filter:not (filter:= field value-or-field)))
 
-(defmethod parse-filter :<
+(defmethod parse-filter* :<
   [[_ field value-or-field]]
   (filter:bound field, :upper value-or-field, :inclusive? false))
 
-(defmethod parse-filter :>
+(defmethod parse-filter* :>
   [[_ field value-or-field]]
   (filter:bound field, :lower value-or-field, :inclusive? false))
 
-(defmethod parse-filter :<=
+(defmethod parse-filter* :<=
   [[_ field value-or-field]]
   (filter:bound field, :upper value-or-field))
 
-(defmethod parse-filter :>=
+(defmethod parse-filter* :>=
   [[_ field value-or-field]]
   (filter:bound field, :lower value-or-field))
 
-(defmethod parse-filter :and
+(defmethod parse-filter* :and
   [[_ & args]]
   (when-let [fields (seq (keep identity (map parse-filter args)))]
     {:type :and, :fields (vec fields)}))
 
-(defmethod parse-filter :or
+(defmethod parse-filter* :or
   [[_ & args]]
   (when-let [fields (seq (keep identity (map parse-filter args)))]
     {:type :or, :fields (vec fields)}))
 
-(defmethod parse-filter :not
+(defmethod parse-filter* :not
   [[_ subclause]]
   (when-let [subclause (parse-filter subclause)]
     (filter:not subclause)))
+
+(defn- parse-filter [filter-clause]
+  ;; strip out all the filters against temporal fields. Those are handled separately, as intervals
+  (-> (mbql.u/replace filter-clause
+        [_ [:field _ (_ :guard :temporal-unit)] & _]
+        nil)
+      mbql.u/simplify-compound-filter
+      parse-filter*))
 
 (s/defn ^:private add-datetime-units* :- mbql.s/DateTimeValue
   "Return a `relative-datetime` clause with `n` units added to it."

--- a/modules/drivers/druid/src/metabase/driver/druid/query_processor.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid/query_processor.clj
@@ -285,17 +285,17 @@
 
 (defmethod parse-filter* :and
   [[_ & args]]
-  (when-let [fields (seq (keep identity (map parse-filter args)))]
+  (when-let [fields (seq (keep identity (map parse-filter* args)))]
     {:type :and, :fields (vec fields)}))
 
 (defmethod parse-filter* :or
   [[_ & args]]
-  (when-let [fields (seq (keep identity (map parse-filter args)))]
+  (when-let [fields (seq (keep identity (map parse-filter* args)))]
     {:type :or, :fields (vec fields)}))
 
 (defmethod parse-filter* :not
   [[_ subclause]]
-  (when-let [subclause (parse-filter subclause)]
+  (when-let [subclause (parse-filter* subclause)]
     (filter:not subclause)))
 
 (defn- parse-filter [filter-clause]

--- a/modules/drivers/druid/test/metabase/driver/druid/query_processor_test.clj
+++ b/modules/drivers/druid/test/metabase/driver/druid/query_processor_test.clj
@@ -2,6 +2,7 @@
   "Some tests to make sure the Druid Query Processor is generating sane Druid queries when compiling MBQL."
   (:require [cheshire.core :as json]
             [clojure.test :refer :all]
+            [clojure.tools.macro :as tools.macro]
             [java-time :as t]
             [medley.core :as m]
             [metabase.db.metadata-queries :as metadata-queries]
@@ -582,60 +583,91 @@
 
 (deftest numeric-filter-test
   (mt/test-driver :druid
-    (testing
-        (tqpt/with-flattened-dbdef
-          (letfn [(compiled [query]
-                    (-> (qp/query->native query) :query (select-keys [:filter :queryType])))]
-            (doseq [[message field] {"Make sure we can filter by numeric columns (#10935)" :venue_price
-                                     "We should be able to filter by Metrics (#11823)"     :count}
-                    :let            [field-clause [:field (mt/id :checkins field) nil]
-                                     field-name   (name field)]]
-              (testing message
-                (testing "scan query"
-                  (let [query (mt/mbql-query checkins
-                                {:fields   [$id $venue_price $venue_name]
-                                 :filter   [:= field-clause 1]
-                                 :order-by [[:desc $id]]
-                                 :limit    5})]
-                    (is (= {:filter    {:type :selector, :dimension field-name, :value 1}
-                            :queryType :scan}
-                           (compiled query)))
-                    (is (= ["931" "1" "Kinaree Thai Bistro"]
-                           (mt/first-row (qp/process-query query))))))
+    (tqpt/with-flattened-dbdef
+      (letfn [(compiled [query]
+                (-> (qp/query->native query) :query (select-keys [:filter :queryType])))]
+        (doseq [[message field] {"Make sure we can filter by numeric columns (#10935)" :venue_price
+                                 "We should be able to filter by Metrics (#11823)"     :count}
+                :let            [field-clause [:field (mt/id :checkins field) nil]
+                                 field-name   (name field)]]
+          (testing message
+            (testing "scan query"
+              (let [query (mt/mbql-query checkins
+                            {:fields   [$id $venue_price $venue_name]
+                             :filter   [:= field-clause 1]
+                             :order-by [[:desc $id]]
+                             :limit    5})]
+                (is (= {:filter    {:type :selector, :dimension field-name, :value 1}
+                        :queryType :scan}
+                       (compiled query)))
+                (is (= ["931" "1" "Kinaree Thai Bistro"]
+                       (mt/first-row (qp/process-query query))))))
 
-                (testing "topN query"
-                  (let [query (mt/mbql-query checkins
-                                {:aggregation [[:count]]
-                                 :breakout    [$venue_price]
-                                 :filter      [:= field-clause 1]})]
-                    (is (= {:filter    {:type :selector, :dimension field-name, :value 1}
-                            :queryType :topN}
-                           (compiled query)))
-                    (is (= ["1" 221]
-                           (mt/first-row (qp/process-query query))))))
+            (testing "topN query"
+              (let [query (mt/mbql-query checkins
+                            {:aggregation [[:count]]
+                             :breakout    [$venue_price]
+                             :filter      [:= field-clause 1]})]
+                (is (= {:filter    {:type :selector, :dimension field-name, :value 1}
+                        :queryType :topN}
+                       (compiled query)))
+                (is (= ["1" 221]
+                       (mt/first-row (qp/process-query query))))))
 
-                (testing "groupBy query"
-                  (let [query (mt/mbql-query checkins
-                                {:aggregation [[:aggregation-options [:distinct $checkins.venue_name] {:name "__count_0"}]]
-                                 :breakout    [$venue_category_name $user_name]
-                                 :order-by    [[:desc [:aggregation 0]] [:asc $checkins.venue_category_name]]
-                                 :filter      [:= field-clause 1]})]
-                    (is (= {:filter    {:type :selector, :dimension field-name, :value 1}
-                            :queryType :groupBy}
-                           (compiled query)))
-                    (is (= (case field
-                             :count       ["Bar" "Felipinho Asklepios" 8]
-                             :venue_price ["Mexican" "Conchúr Tihomir" 4])
-                           (mt/first-row (qp/process-query query))))))
+            (testing "groupBy query"
+              (let [query (mt/mbql-query checkins
+                            {:aggregation [[:aggregation-options [:distinct $checkins.venue_name] {:name "__count_0"}]]
+                             :breakout    [$venue_category_name $user_name]
+                             :order-by    [[:desc [:aggregation 0]] [:asc $checkins.venue_category_name]]
+                             :filter      [:= field-clause 1]})]
+                (is (= {:filter    {:type :selector, :dimension field-name, :value 1}
+                        :queryType :groupBy}
+                       (compiled query)))
+                (is (= (case field
+                         :count       ["Bar" "Felipinho Asklepios" 8]
+                         :venue_price ["Mexican" "Conchúr Tihomir" 4])
+                       (mt/first-row (qp/process-query query))))))
 
-                (testing "timeseries query"
-                  (let [query (mt/mbql-query checkins
-                                {:aggregation [[:count]]
-                                 :filter      [:= field-clause 1]})]
-                    (is (= {:queryType :timeseries
-                            :filter    {:type :selector, :dimension field-name, :value 1}}
-                           (compiled query)))
-                    (is (= (case field
-                             :count       [1000]
-                             :venue_price [221])
-                           (mt/first-row (qp/process-query query)))))))))))))
+            (testing "timeseries query"
+              (let [query (mt/mbql-query checkins
+                            {:aggregation [[:count]]
+                             :filter      [:= field-clause 1]})]
+                (is (= {:queryType :timeseries
+                        :filter    {:type :selector, :dimension field-name, :value 1}}
+                       (compiled query)))
+                (is (= (case field
+                         :count       [1000]
+                         :venue_price [221])
+                       (mt/first-row (qp/process-query query))))))))))))
+
+(deftest parse-filter-test
+  (mt/test-driver :druid
+    (testing "parse-filter should generate the correct filter clauses"
+      (tqpt/with-flattened-dbdef
+        (mt/with-everything-store
+          (tools.macro/macrolet [(parse-filter [filter-clause]
+                                   `(#'druid.qp/parse-filter (mt/$ids ~'checkins ~filter-clause)))]
+            (testing "normal non-compound filters should work as expected"
+              (is (= {:type :selector, :dimension "venue_price", :value 2}
+                     (parse-filter [:= $venue_price [:value 2 {:base_type :type/Integer}]]))))
+            (testing "temporal filters should get stripped out"
+              (is (= nil
+                     (parse-filter [:>= !default.timestamp [:absolute-datetime #t "2015-09-01T00:00Z[UTC]" :default]])))
+              (is (= {:type :selector, :dimension "venue_category_name", :value "Mexican"}
+                     (parse-filter
+                      [:and
+                       [:= $venue_category_name [:value "Mexican" {:base_type :type/Text}]]
+
+                       [:< !default.timestamp [:absolute-datetime #t "2015-10-01T00:00Z[UTC]" :default]]]))))))))))
+
+(deftest multiple-filters-test
+  (mt/test-driver :druid
+    (testing "Should be able to filter by both a temporal and a non-temporal filter (#15903)"
+      (tqpt/with-flattened-dbdef
+        (is (= [4]
+               (mt/first-row
+                (mt/run-mbql-query checkins
+                  {:aggregation [[:count]]
+                   :filter      [:and
+                                 [:= $venue_category_name "Mexican"]
+                                 [:= !month.timestamp "2015-09"]]}))))))))

--- a/test/metabase/query_processor_test.clj
+++ b/test/metabase/query_processor_test.clj
@@ -312,7 +312,6 @@
 
 (defn data
   "Return the result `data` from a successful query run, or throw an Exception if processing failed."
-  {:style/indent 0}
   [results]
   (when (#{:failed "failed"} (:status results))
     (throw (ex-info (str (or (:error results) "Error running query"))
@@ -321,7 +320,6 @@
 
 (defn rows
   "Return the result rows from query `results`, or throw an Exception if they're missing."
-  {:style/indent 0}
   [results]
   (or (some-> (data results) :rows vec)
       (throw (ex-info "Query does not have any :rows in results."
@@ -338,7 +336,6 @@
 
 (defn first-row
   "Return the first row in the `results` of a query, or throw an Exception if they're missing."
-  {:style/indent 0}
   [results]
   (first (rows results)))
 
@@ -349,7 +346,6 @@
 
 (defn cols
   "Return the result `:cols` from query `results`, or throw an Exception if they're missing."
-  {:style/indent 0}
   [results]
   (or (some->> (data results) :cols (mapv #(into {} %)))
       (throw (ex-info "Query does not have any :cols in results." results))))
@@ -358,13 +354,11 @@
   "Return both `:rows` and `:cols` from the results. Equivalent to
 
     {:rows (rows results), :cols (cols results)}"
-  {:style/indent 0}
   [results]
   {:rows (rows results), :cols (cols results)})
 
 (defn rows+column-names
   "Return the result rows and column names from query `results`, or throw an Exception if they're missing."
-  {:style/indent 0}
   [results]
   {:rows (rows results), :columns (map :name (cols results))})
 


### PR DESCRIPTION
Fixes #15903

Temporal filters have to go in `:intervals`, so we have to ignore them out when generating the other filters for the query. There was a bug where we accidentally ignored an entire compound filter clause (e.g. `:and`) if it contained any temporal fields. Fixed so we only ignore the temporal filter clauses in a compound filter clause.