### PR TITLE
#15959 Repro: Adding cards to dashboard via search can cause the card to show spinner until browser refresh

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
@@ -5,6 +5,7 @@ import {
   restore,
   selectDashboardFilter,
   expectedRouteCalls,
+  modal,
 } from "__support__/e2e/cypress";
 
 import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
@@ -892,6 +893,36 @@ describe("scenarios > dashboard", () => {
     cy.get("fieldset").click();
     cy.findByPlaceholderText("Search the list").type("Syner");
     cy.findByText("Synergistic Wool Coat");
+  });
+
+  it.skip("should show values of added dashboard card via search immediately (metabase#15959)", () => {
+    /**
+     * For the reason I don't udnerstand, I could reproduce this issue ONLY if I use these specific functions in this order:
+     *  1. realType()
+     *  2. type()
+     */
+    cy.visit("/dashboard/1");
+    cy.icon("pencil").click();
+    cy.icon("add")
+      .last()
+      .as("addQuestion")
+      .click();
+    cy.icon("search")
+      .last()
+      .as("searchModal")
+      .click();
+    cy.findByPlaceholderText("Search").realType("Orders{enter}"); /* [1] */
+    modal()
+      .findByText("Orders, Count")
+      .realClick();
+    cy.get("@addQuestion").click();
+    cy.get("@searchModal").click();
+    cy.findByPlaceholderText("Search").type("Orders{enter}"); /* [2] */
+    modal()
+      .findByText("Orders, Count")
+      .realClick();
+    cy.get(".LoadingSpinner").should("not.exist");
+    cy.findAllByText("18,760").should("have.length", 2);
   });
 });
 


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #15959

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/118140393-9ce62a80-b408-11eb-9d5a-2211d059bee1.png)

