### PR TITLE
Don't fetch field (values) when in a dashboard

### DIFF
--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
@@ -115,9 +115,16 @@ export default class ParameterValueWidget extends Component {
   }
 
   updateFieldValues(props) {
-    for (const id of getFieldIds(props.parameter)) {
-      props.fetchField(id);
-      props.fetchFieldValues(id);
+    // in a dashboard? the field values will be fetched via
+    // DashboardApi.parameterValues instead and thus, no need to
+    // manually update field values
+    const { dashboard } = props;
+    const useChainFilter = dashboard && dashboard.id;
+    if (!useChainFilter) {
+      for (const id of getFieldIds(props.parameter)) {
+        props.fetchField(id);
+        props.fetchFieldValues(id);
+      }
     }
   }
 


### PR DESCRIPTION
For the use in a dashboard, there is already a logic in FieldValuesWidget to retrieve the parameter values from the dashboard API, and not the field API. The change in this PR is to make sure that ParameterValueWidget also stays consistent with that, and therefore it does not unnecessarily use the field API (for which the user might not have the permission anyway).

For a bigger context, see [issue #15119](https://github.com/metabase/metabase/issues/15119#issuecomment-840533015).

To try it out, follow the steps in that bug (copied here for convenience) while paying attention to the Network panel in the DevTools:

1. Admin > People > create user "U1"
2. Admin > Permissions > revoke Data access for Sample Dataset, and allow collection view/curate on Our Analytics
3. Simple question > Sample Dataset > Products - save as "Q1"
4. Add "Q1" to dashboard "D1" and add a filter Categories and connect to "Q1" Product.Category
5. Login as "U1" and go to dashboard "D1"

**Before this PR**

There are XHRs to `/api/field/4` and `/api/field/4/values`  (both returning HTTP 403):

![image](https://user-images.githubusercontent.com/7288/118337855-86ec6e80-b4c9-11eb-9836-e135fa33382e.png)

**After this PR**

No more XHRs to `/api/field/4` and `/api/field/4/values`.

![image](https://user-images.githubusercontent.com/7288/118339276-31b25c00-b4cd-11eb-9fab-d64b5051e359.png)
