### PR TITLE
Remove extra space before colon in form validation errors

### DIFF
--- a/frontend/src/metabase/components/form/FormField.jsx
+++ b/frontend/src/metabase/components/form/FormField.jsx
@@ -72,7 +72,8 @@ export default class FormField extends Component {
                 htmlFor={name}
                 id={`${name}-label`}
               >
-                {title}{error && <span className="text-error">: {error}</span>}
+                {title}
+                {error && <span className="text-error">: {error}</span>}
               </label>
             )}
             {description && <div className="mb1">{description}</div>}

--- a/frontend/src/metabase/components/form/FormField.jsx
+++ b/frontend/src/metabase/components/form/FormField.jsx
@@ -72,7 +72,7 @@ export default class FormField extends Component {
                 htmlFor={name}
                 id={`${name}-label`}
               >
-                {title} {error && <span className="text-error">: {error}</span>}
+                {title}{error && <span className="text-error">: {error}</span>}
               </label>
             )}
             {description && <div className="mb1">{description}</div>}


### PR DESCRIPTION
This was grating on me a bit while working on auth stuff so I figured I'd fix it :) 

Before:
<img width="397" alt="Screen Shot 2021-05-13 at 5 40 45 PM" src="https://user-images.githubusercontent.com/32746338/118204210-8f35a280-b412-11eb-8982-004ef1456934.png">

After:
<img width="389" alt="Screen Shot 2021-05-13 at 5 39 56 PM" src="https://user-images.githubusercontent.com/32746338/118204216-92c92980-b412-11eb-98b5-7f71b0280f80.png">

