### PR TITLE
Improve saved question sidebar empty states and styling

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/OpenModerationIssuesButton.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/OpenModerationIssuesButton.jsx
@@ -19,8 +19,10 @@ export function OpenModerationIssuesButton({ question, className, onClick }) {
       borderless
       className={cx(
         className,
-        "py1 text-brand text-brand-hover align-center",
-        numOpenIssues === 0 && "text-light text-light-hover",
+        "py1 align-center",
+        numOpenIssues === 0 &&
+          "text-light text-light-hover bg-transparent-hover",
+        numOpenIssues > 0 && "text-brand text-brand-hover",
       )}
       onClick={onClick}
       disabled={numOpenIssues === 0}

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/OpenModerationIssuesButton.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/OpenModerationIssuesButton.jsx
@@ -17,8 +17,13 @@ export function OpenModerationIssuesButton({ question, className, onClick }) {
   return (
     <Button
       borderless
-      className={cx(className, "py1 text-brand text-brand-hover align-center")}
+      className={cx(
+        className,
+        "py1 text-brand text-brand-hover align-center",
+        numOpenIssues === 0 && "text-light text-light-hover",
+      )}
       onClick={onClick}
+      disabled={numOpenIssues === 0}
     >
       {ngettext(
         msgid`${numOpenIssues} open issue`,

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/OpenModerationIssuesButton.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/OpenModerationIssuesButton.jsx
@@ -14,8 +14,7 @@ OpenModerationIssuesButton.propTypes = {
 
 export function OpenModerationIssuesButton({ question, className, onClick }) {
   const numOpenIssues = getNumberOfOpenRequests(question);
-
-  return numOpenIssues > 0 ? (
+  return (
     <Button
       borderless
       className={cx(className, "py1 text-brand text-brand-hover align-center")}
@@ -27,5 +26,5 @@ export function OpenModerationIssuesButton({ question, className, onClick }) {
         numOpenIssues,
       )}
     </Button>
-  ) : null;
+  );
 }

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/OpenModerationIssuesPanel.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/OpenModerationIssuesPanel.jsx
@@ -63,16 +63,20 @@ function OpenModerationIssuesPanel({
         >{t`Open issues`}</Button>
       </div>
       <div className="px2">
-        {requestsWithMetadata.map(request => {
-          return (
-            <ModerationIssueThread
-              key={request.id}
-              className="py2 border-row-divider"
-              request={request}
-              onModerate={isModerator && onModerate}
-            />
-          );
-        })}
+        {requestsWithMetadata.length > 0 ? (
+          requestsWithMetadata.map(request => {
+            return (
+              <ModerationIssueThread
+                key={request.id}
+                className="py2 border-row-divider"
+                request={request}
+                onModerate={isModerator && onModerate}
+              />
+            );
+          })
+        ) : (
+          <div className="text-body text-medium p1">{t`No open issues`}</div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/metabase/components/Timeline.jsx
+++ b/frontend/src/metabase/components/Timeline.jsx
@@ -34,7 +34,7 @@ const Border = styled.div`
 `;
 
 const Timeline = ({ className, items = [], renderFooter }) => {
-  const iconSize = 20;
+  const iconSize = 16;
   const halfIconSize = iconSize / 2;
 
   const sortedFormattedItems = useMemo(() => {
@@ -65,7 +65,9 @@ const Timeline = ({ className, items = [], renderFooter }) => {
             <Icon className="relative text-light" name={icon} size={iconSize} />
             <div className="ml1 flex-1">
               <div className="text-bold">{title}</div>
-              <div className="text-medium text-small">{formattedTimestamp}</div>
+              <div className="text-medium text-small pb1">
+                {formattedTimestamp}
+              </div>
               <div>{description}</div>
               {_.isFunction(renderFooter) && <div>{renderFooter(item)}</div>}
             </div>

--- a/frontend/src/metabase/lib/revisions.js
+++ b/frontend/src/metabase/lib/revisions.js
@@ -2,7 +2,7 @@ import { t } from "ttag";
 
 export function getRevisionDescription(revision) {
   if (revision.is_creation) {
-    return t`First revision.`;
+    return undefined;
   } else if (revision.is_reversion) {
     return t`Reverted to an earlier revision and ${revision.description}`;
   } else {

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebarPanel.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebarPanel.jsx
@@ -2,11 +2,10 @@ import React from "react";
 import PropTypes from "prop-types";
 import SidebarContent from "metabase/query_builder/components/SidebarContent";
 import QuestionActionButtons from "metabase/questions/components/QuestionActionButtons";
-import ClampedText from "metabase/components/ClampedText";
 import QuestionActivityTimeline from "metabase/questions/components/QuestionActivityTimeline";
 import { PLUGIN_MODERATION_COMPONENTS } from "metabase/plugins";
 import { SIDEBAR_VIEWS } from "./constants";
-
+import { ClampedDescription } from "metabase/questions/components/ClampedDescription";
 const {
   ModerationIssueActionMenu,
   OpenModerationIssuesButton,
@@ -31,7 +30,12 @@ function QuestionDetailsSidebarPanel({ setView, question, onOpenModal }) {
             onOpenModal={onOpenModal}
           />
         </div>
-        <ClampedText className="px3 pb2" text={description} visibleLines={8} />
+        <ClampedDescription
+          className="px3 pb2"
+          text={description}
+          visibleLines={8}
+          onEdit={() => onOpenModal("edit")}
+        />
         <div className="mx1 pb2 flex justify-between border-row-divider">
           <ModerationIssueActionMenu
             triggerClassName="Button--round text-brand border-brand py1"

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebarPanel.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebarPanel.jsx
@@ -31,12 +31,12 @@ function QuestionDetailsSidebarPanel({ setView, question, onOpenModal }) {
           />
         </div>
         <ClampedDescription
-          className="px3 pb1"
+          className="px3 pb3"
           description={description}
           visibleLines={8}
           onEdit={() => onOpenModal("edit")}
         />
-        <div className="mx1 pb2 flex justify-between border-row-divider">
+        <div className="ml3 mr2 py3 flex justify-between border-row-divider">
           <ModerationIssueActionMenu
             triggerClassName="Button--round text-brand border-brand py1"
             onAction={issueType => {
@@ -55,7 +55,7 @@ function QuestionDetailsSidebarPanel({ setView, question, onOpenModal }) {
             }}
           />
         </div>
-        <QuestionActivityTimeline className="px2 pt2" question={question} />
+        <QuestionActivityTimeline className="pl3 pr2 pt3" question={question} />
       </div>
     </SidebarContent>
   );

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebarPanel.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebarPanel.jsx
@@ -31,8 +31,8 @@ function QuestionDetailsSidebarPanel({ setView, question, onOpenModal }) {
           />
         </div>
         <ClampedDescription
-          className="px3 pb2"
-          text={description}
+          className="px3 pb1"
+          description={description}
           visibleLines={8}
           onEdit={() => onOpenModal("edit")}
         />

--- a/frontend/src/metabase/questions/components/ClampedDescription.jsx
+++ b/frontend/src/metabase/questions/components/ClampedDescription.jsx
@@ -1,0 +1,28 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { t } from "ttag";
+
+import ClampedText from "metabase/components/ClampedText";
+import Button from "metabase/components/Button";
+
+ClampedDescription.propTypes = {
+  className: PropTypes.string,
+  description: PropTypes.string,
+  onEdit: PropTypes.func.isRequired,
+};
+
+export function ClampedDescription({ className, description, onEdit }) {
+  return (
+    <div className={className}>
+      {description ? (
+        <ClampedText text={description} visibleLines={8} />
+      ) : (
+        <Button
+          onClick={onEdit}
+          link
+          className="text-medium p0 py1 bg-transparent bg-transparent-hover borderless text-underline-hover"
+        >{t`Add a description`}</Button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/metabase/questions/components/ClampedDescription.jsx
+++ b/frontend/src/metabase/questions/components/ClampedDescription.jsx
@@ -20,7 +20,7 @@ export function ClampedDescription({ className, description, onEdit }) {
         <Button
           onClick={onEdit}
           link
-          className="text-medium p0 py1 bg-transparent bg-transparent-hover borderless text-underline-hover"
+          className="text-light p0 bg-transparent bg-transparent-hover borderless text-underline-hover"
         >{t`Add a description`}</Button>
       )}
     </div>

--- a/frontend/src/metabase/questions/components/QuestionActivityTimeline.jsx
+++ b/frontend/src/metabase/questions/components/QuestionActivityTimeline.jsx
@@ -26,10 +26,13 @@ function QuestionActivityTimeline({
 }) {
   const events = revisions.map((revision, index) => {
     // const canRevert = question.canWrite();
+    const username = revision.user.common_name;
     return {
       timestamp: revision.timestamp,
       icon: "pencil",
-      title: t`${revision.user.common_name} edited this`,
+      title: revision.is_creation
+        ? t`${username} created this`
+        : t`${username} edited this`,
       description: getRevisionDescription(revision),
       // showFooter: index !== 0 && canRevert,
       showFooter: false,

--- a/frontend/src/metabase/questions/components/SavedQuestionHeaderButton.jsx
+++ b/frontend/src/metabase/questions/components/SavedQuestionHeaderButton.jsx
@@ -6,7 +6,7 @@ import cx from "classnames";
 import Button from "metabase/components/Button";
 
 import { PLUGIN_MODERATION_SERVICE } from "metabase/plugins";
-const { getStatusIconForReview, getColorForReview } = PLUGIN_MODERATION_SERVICE;
+const { getStatusIconForReview } = PLUGIN_MODERATION_SERVICE;
 
 const StyledButton = styled(Button)`
   font-size: 1.25rem;
@@ -14,23 +14,22 @@ const StyledButton = styled(Button)`
   padding: 0.25rem 0.25rem;
 
   .Icon-chevrondown {
-    height: 24px;
+    height: 13px;
   }
 `;
 
 function SavedQuestionHeaderButton({ className, question, onClick, active }) {
   const latestModerationReview = question.getLatestModerationReview();
-  const color = getColorForReview(latestModerationReview);
   const icon = getStatusIconForReview(latestModerationReview);
 
   return (
     <StyledButton
-      className={cx(className, color && `text-${color}`)}
+      className={cx(className)}
       onClick={onClick}
       iconRight="chevrondown"
       icon={icon}
       active={active}
-      iconSize={13}
+      iconSize={20}
       data-testid="saved-question-header-button"
     >
       {question.displayName()}

--- a/frontend/test/metabase/internal/__snapshots__/components.unit.spec.js.snap
+++ b/frontend/test/metabase/internal/__snapshots__/components.unit.spec.js.snap
@@ -1921,13 +1921,13 @@ exports[`Timeline should render "Constrained width" correctly 1`] = `
   className="Timelineinfo__Container-g32h45-0 hGzZmq"
 >
   <div
-    className="Timeline__TimelineContainer-sc-1c86koa-0 cNPqnV"
+    className="Timeline__TimelineContainer-sc-1c86koa-0 eoIDuV"
   >
     <div
-      className="Timeline__TimelineItem-sc-1c86koa-1 cQntrv"
+      className="Timeline__TimelineItem-sc-1c86koa-1 iXVYJI"
     >
       <div
-        className="Timeline__Border-sc-1c86koa-2 leQHpA"
+        className="Timeline__Border-sc-1c86koa-2 fcrCJp"
       />
       <svg
         aria-label="verified icon"
@@ -1938,10 +1938,10 @@ exports[`Timeline should render "Constrained width" correctly 1`] = `
           }
         }
         fill="currentcolor"
-        height={20}
+        height={16}
         role="img"
         viewBox="0 0 32 32"
-        width={20}
+        width={16}
       />
       <div
         className="ml1 flex-1"
@@ -1952,7 +1952,7 @@ exports[`Timeline should render "Constrained width" correctly 1`] = `
           John Someone verified this
         </div>
         <div
-          className="text-medium text-small"
+          className="text-medium text-small pb1"
         >
           mocked relative timestamp
         </div>
@@ -1962,19 +1962,19 @@ exports[`Timeline should render "Constrained width" correctly 1`] = `
       </div>
     </div>
     <div
-      className="Timeline__TimelineItem-sc-1c86koa-1 cQntrv"
+      className="Timeline__TimelineItem-sc-1c86koa-1 iXVYJI"
     >
       <div
-        className="Timeline__Border-sc-1c86koa-2 leQHpA"
+        className="Timeline__Border-sc-1c86koa-2 fcrCJp"
       />
       <svg
         aria-label="pencil icon"
         className="Icon Icon-pencil relative text-light Icon-sc-1x67v3y-1 hFNRPZ"
         fill="currentcolor"
-        height={20}
+        height={16}
         role="img"
         viewBox="0 0 32 32"
-        width={20}
+        width={16}
       >
         <path
           d="M21.187 4.359L24.71.835c1.363-1.362 3.912-1.022 5.694.76 1.783 1.783 2.123 4.332.761 5.695l-3.523 3.523-6.455-6.454zM19.425 6.12L1.455 24.091C.091 25.453-.47 30.625.452 31.547c.922.922 6.094.361 7.456-1.001l17.97-17.971-6.454-6.455z"
@@ -1989,7 +1989,7 @@ exports[`Timeline should render "Constrained width" correctly 1`] = `
           Foo edited this
         </div>
         <div
-          className="text-medium text-small"
+          className="text-medium text-small pb1"
         >
           mocked relative timestamp
         </div>
@@ -1999,10 +1999,10 @@ exports[`Timeline should render "Constrained width" correctly 1`] = `
       </div>
     </div>
     <div
-      className="Timeline__TimelineItem-sc-1c86koa-1 cQntrv"
+      className="Timeline__TimelineItem-sc-1c86koa-1 iXVYJI"
     >
       <div
-        className="Timeline__Border-sc-1c86koa-2 leQHpA"
+        className="Timeline__Border-sc-1c86koa-2 fcrCJp"
       />
       <svg
         aria-label="warning_colorized icon"
@@ -2013,10 +2013,10 @@ exports[`Timeline should render "Constrained width" correctly 1`] = `
           }
         }
         fill="currentcolor"
-        height={20}
+        height={16}
         role="img"
         viewBox="0 0 32 32"
-        width={20}
+        width={16}
       />
       <div
         className="ml1 flex-1"
@@ -2027,7 +2027,7 @@ exports[`Timeline should render "Constrained width" correctly 1`] = `
           Someone McSomeone thinks something looks wrong
         </div>
         <div
-          className="text-medium text-small"
+          className="text-medium text-small pb1"
         >
           mocked relative timestamp
         </div>
@@ -2046,7 +2046,7 @@ exports[`Timeline should render "Constrained width" correctly 1`] = `
       </div>
     </div>
     <div
-      className="Timeline__TimelineItem-sc-1c86koa-1 cQntrv"
+      className="Timeline__TimelineItem-sc-1c86koa-1 iXVYJI"
     >
       <svg
         aria-label="clarification icon"
@@ -2057,10 +2057,10 @@ exports[`Timeline should render "Constrained width" correctly 1`] = `
           }
         }
         fill="currentcolor"
-        height={20}
+        height={16}
         role="img"
         viewBox="0 0 32 32"
-        width={20}
+        width={16}
       />
       <div
         className="ml1 flex-1"
@@ -2071,7 +2071,7 @@ exports[`Timeline should render "Constrained width" correctly 1`] = `
           Someone is confused
         </div>
         <div
-          className="text-medium text-small"
+          className="text-medium text-small pb1"
         >
           mocked relative timestamp
         </div>
@@ -2086,13 +2086,13 @@ exports[`Timeline should render "Constrained width" correctly 1`] = `
 
 exports[`Timeline should render "Optional footer" correctly 1`] = `
 <div
-  className="Timeline__TimelineContainer-sc-1c86koa-0 cNPqnV"
+  className="Timeline__TimelineContainer-sc-1c86koa-0 eoIDuV"
 >
   <div
-    className="Timeline__TimelineItem-sc-1c86koa-1 cQntrv"
+    className="Timeline__TimelineItem-sc-1c86koa-1 iXVYJI"
   >
     <div
-      className="Timeline__Border-sc-1c86koa-2 leQHpA"
+      className="Timeline__Border-sc-1c86koa-2 fcrCJp"
     />
     <svg
       aria-label="verified icon"
@@ -2103,10 +2103,10 @@ exports[`Timeline should render "Optional footer" correctly 1`] = `
         }
       }
       fill="currentcolor"
-      height={20}
+      height={16}
       role="img"
       viewBox="0 0 32 32"
-      width={20}
+      width={16}
     />
     <div
       className="ml1 flex-1"
@@ -2117,7 +2117,7 @@ exports[`Timeline should render "Optional footer" correctly 1`] = `
         John Someone verified this
       </div>
       <div
-        className="text-medium text-small"
+        className="text-medium text-small pb1"
       >
         mocked relative timestamp
       </div>
@@ -2135,19 +2135,19 @@ exports[`Timeline should render "Optional footer" correctly 1`] = `
     </div>
   </div>
   <div
-    className="Timeline__TimelineItem-sc-1c86koa-1 cQntrv"
+    className="Timeline__TimelineItem-sc-1c86koa-1 iXVYJI"
   >
     <div
-      className="Timeline__Border-sc-1c86koa-2 leQHpA"
+      className="Timeline__Border-sc-1c86koa-2 fcrCJp"
     />
     <svg
       aria-label="pencil icon"
       className="Icon Icon-pencil relative text-light Icon-sc-1x67v3y-1 hFNRPZ"
       fill="currentcolor"
-      height={20}
+      height={16}
       role="img"
       viewBox="0 0 32 32"
-      width={20}
+      width={16}
     >
       <path
         d="M21.187 4.359L24.71.835c1.363-1.362 3.912-1.022 5.694.76 1.783 1.783 2.123 4.332.761 5.695l-3.523 3.523-6.455-6.454zM19.425 6.12L1.455 24.091C.091 25.453-.47 30.625.452 31.547c.922.922 6.094.361 7.456-1.001l17.97-17.971-6.454-6.455z"
@@ -2162,7 +2162,7 @@ exports[`Timeline should render "Optional footer" correctly 1`] = `
         Foo edited this
       </div>
       <div
-        className="text-medium text-small"
+        className="text-medium text-small pb1"
       >
         mocked relative timestamp
       </div>
@@ -2175,10 +2175,10 @@ exports[`Timeline should render "Optional footer" correctly 1`] = `
     </div>
   </div>
   <div
-    className="Timeline__TimelineItem-sc-1c86koa-1 cQntrv"
+    className="Timeline__TimelineItem-sc-1c86koa-1 iXVYJI"
   >
     <div
-      className="Timeline__Border-sc-1c86koa-2 leQHpA"
+      className="Timeline__Border-sc-1c86koa-2 fcrCJp"
     />
     <svg
       aria-label="warning_colorized icon"
@@ -2189,10 +2189,10 @@ exports[`Timeline should render "Optional footer" correctly 1`] = `
         }
       }
       fill="currentcolor"
-      height={20}
+      height={16}
       role="img"
       viewBox="0 0 32 32"
-      width={20}
+      width={16}
     />
     <div
       className="ml1 flex-1"
@@ -2203,7 +2203,7 @@ exports[`Timeline should render "Optional footer" correctly 1`] = `
         Someone McSomeone thinks something looks wrong
       </div>
       <div
-        className="text-medium text-small"
+        className="text-medium text-small pb1"
       >
         mocked relative timestamp
       </div>
@@ -2225,7 +2225,7 @@ exports[`Timeline should render "Optional footer" correctly 1`] = `
     </div>
   </div>
   <div
-    className="Timeline__TimelineItem-sc-1c86koa-1 cQntrv"
+    className="Timeline__TimelineItem-sc-1c86koa-1 iXVYJI"
   >
     <svg
       aria-label="clarification icon"
@@ -2236,10 +2236,10 @@ exports[`Timeline should render "Optional footer" correctly 1`] = `
         }
       }
       fill="currentcolor"
-      height={20}
+      height={16}
       role="img"
       viewBox="0 0 32 32"
-      width={20}
+      width={16}
     />
     <div
       className="ml1 flex-1"
@@ -2250,7 +2250,7 @@ exports[`Timeline should render "Optional footer" correctly 1`] = `
         Someone is confused
       </div>
       <div
-        className="text-medium text-small"
+        className="text-medium text-small pb1"
       >
         mocked relative timestamp
       </div>


### PR DESCRIPTION
These changes come from https://www.figma.com/file/tbeJttwLzFWE4MrB4aTz1B/Bottoms-up-Content-Moderation?node-id=862%3A2086 mostly. From top to bottom:

1. removed text coloring of saved question name in header when there's a mod 
1. made the mod review icon in the header a little bigger
1. added an empty state to the description. the "add a description" button currently just opens the "edit" modal like the edit action, but that can be changed if desired
1. added an empty state to the open issues panel. I'd like to add routes like `/question/1/details/open-issues` or whatever, so having this will be necessary if someone decides to go to that directly on a saved question with no open issues.
1. updated the text of the creation event in the timeline to match mocks


<img width="1552" alt="Screen Shot 2021-05-20 at 2 14 00 PM" src="https://user-images.githubusercontent.com/13057258/119049712-b988e200-b975-11eb-935c-8d9127730b4a.png">
<img width="1552" alt="Screen Shot 2021-05-20 at 2 14 09 PM" src="https://user-images.githubusercontent.com/13057258/119049717-bbeb3c00-b975-11eb-8e9b-e690549cab39.png">
<img width="358" alt="Screen Shot 2021-05-20 at 2 14 28 PM" src="https://user-images.githubusercontent.com/13057258/119049725-bdb4ff80-b975-11eb-8ef3-252ef96f0ed9.png">

