### PR TITLE
hide pagination controls when there is only one page, increase page sizes for people management pages

### DIFF
--- a/frontend/src/metabase/admin/people/components/PeopleList.jsx
+++ b/frontend/src/metabase/admin/people/components/PeopleList.jsx
@@ -219,7 +219,7 @@ export default class PeopleList extends Component {
 
         {hasUsers && (
           <div className="flex align-center justify-between p2">
-            <div className="text-medium text-underline text-bold">{t`${total} people found`}</div>
+            <div className="text-medium text-bold">{t`${total} people found`}</div>
             <PaginationControls
               page={page}
               pageSize={pageSize}

--- a/frontend/src/metabase/admin/people/components/group-members/GroupMembersTable.jsx
+++ b/frontend/src/metabase/admin/people/components/group-members/GroupMembersTable.jsx
@@ -35,7 +35,7 @@ export default function GroupMembersTable({
   const entityQuery = { group_id: group.id };
 
   return (
-    <User.ListLoader pageSize={15} entityQuery={entityQuery}>
+    <User.ListLoader pageSize={25} entityQuery={entityQuery}>
       {({ list, page, pageSize, onNextPage, onPreviousPage, reload }) => {
         const hasMembers = members.length !== 0;
 

--- a/frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx
+++ b/frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx
@@ -12,7 +12,7 @@ import PeopleList from "../components/PeopleList";
 import { USER_STATUS } from "../constants";
 import { usePeopleQuery } from "../hooks/use-people-query";
 
-const PAGE_SIZE = 10;
+const PAGE_SIZE = 25;
 
 export default function PeopleListingApp({ children }) {
   const {

--- a/frontend/src/metabase/components/PaginationControls.jsx
+++ b/frontend/src/metabase/components/PaginationControls.jsx
@@ -14,6 +14,12 @@ export default function PaginationControls({
   onNextPage,
   onPreviousPage,
 }) {
+  const isSinglePage = total !== undefined && total <= pageSize;
+
+  if (isSinglePage) {
+    return null;
+  }
+
   const isPreviousDisabled = page === 0;
   const isNextDisabled =
     total != null ? isLastPage(page, pageSize, total) : !onNextPage;

--- a/frontend/test/metabase/components/PaginationControls.unit.spec.js
+++ b/frontend/test/metabase/components/PaginationControls.unit.spec.js
@@ -13,12 +13,12 @@ const DEFAULT_PROPS = {
 };
 
 const setup = props => {
-  const { container, getByTestId } = render(
+  const { container, queryByTestId } = render(
     <PaginationControls {...DEFAULT_PROPS} {...props} />,
   );
 
-  const previousPageButton = getByTestId("previous-page-btn");
-  const nextPageButton = getByTestId("next-page-btn");
+  const previousPageButton = queryByTestId("previous-page-btn");
+  const nextPageButton = queryByTestId("next-page-btn");
 
   return {
     container,
@@ -59,6 +59,17 @@ describe("PaginationControls", () => {
 
     expect(previousPageButton).not.toBeDisabled();
     expect(nextPageButton).toBeDisabled();
+  });
+
+  it("should return null when total is provided and it is less than page size", () => {
+    const { container } = setup({
+      total: 25,
+      pageSize: 50,
+      onNextPage: () => {},
+      onPreviousPage: () => {},
+    });
+
+    expect(container).toBeEmpty();
   });
 
   it("should call pagination callbacks when buttons clicked", () => {

--- a/frontend/test/metabase/scenarios/admin/people/people.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/people/people.cy.spec.js
@@ -199,7 +199,7 @@ describe("scenarios > admin > people", () => {
     });
 
     describe("pagination", () => {
-      const NEW_USERS = 8;
+      const NEW_USERS = 18;
       const NEW_TOTAL_USERS = TOTAL_USERS + NEW_USERS;
 
       beforeEach(() => {
@@ -207,7 +207,7 @@ describe("scenarios > admin > people", () => {
       });
 
       it("should allow paginating people forward and backward", () => {
-        const PAGE_SIZE = 10;
+        const PAGE_SIZE = 25;
 
         cy.visit("/admin/people");
 
@@ -234,7 +234,7 @@ describe("scenarios > admin > people", () => {
       });
 
       it("should allow paginating group members forward and backward", () => {
-        const PAGE_SIZE = 15;
+        const PAGE_SIZE = 25;
         cy.visit("admin/people/groups/1");
 
         // Total


### PR DESCRIPTION
### Description

During the latest bug bash, several small changes were suggested:
1) Hide pagination controls when there is only one page
2) Remove underline style from the total people number

Before:
<img width="824" alt="Screen Shot 2021-05-14 at 21 18 08" src="https://user-images.githubusercontent.com/14301985/118312367-e5c9dc00-b4f9-11eb-88b3-e26aa0ffab2a.png">

After:
<img width="1185" alt="Screen Shot 2021-05-14 at 21 02 11" src="https://user-images.githubusercontent.com/14301985/118312224-b4e9a700-b4f9-11eb-93f2-a610e7613ad7.png">

3) Increase page sizes for people management page (10 to 25) and group members page (15 to 25)
