### PR TITLE
Fix use of deprecated Liquibase.listUnrunChangeSets

### DIFF
--- a/src/metabase/db/liquibase.clj
+++ b/src/metabase/db/liquibase.clj
@@ -6,7 +6,7 @@
             [metabase.util :as u]
             [metabase.util.i18n :refer [trs]])
   (:import java.io.StringWriter
-           [liquibase Contexts Liquibase]
+           [liquibase Contexts LabelExpression Liquibase]
            [liquibase.database Database DatabaseFactory]
            liquibase.database.jvm.JdbcConnection
            liquibase.exception.LockException
@@ -90,7 +90,7 @@
   (I'm not 100% sure whether `Liquibase.update()` still acquires locks if the database is already up-to-date, but
   `migrations-lines` certainly does; duplicating the skipping logic doesn't hurt anything.)"
   ^Boolean [^Liquibase liquibase]
-  (boolean (seq (.listUnrunChangeSets liquibase nil))))
+  (boolean (seq (.listUnrunChangeSets liquibase nil (LabelExpression.)))))
 
 (defn- migration-lock-exists?
   "Is a migration lock in place for `liquibase`?"


### PR DESCRIPTION
Liquibase 3.3.0 deprecated [1,2] (not listed in the changelog [3] for
that version) the overload of `Liquibase.listUnrunChangeSets` without
a `LabelExpression`.

Fix usage of that deprecated method by using the non-deprecated method
with an empty `LabelExpression`, just as the deprecated method does.

[1]: https://www.javadoc.io/doc/org.liquibase/liquibase-core/3.2.3/liquibase/Liquibase.html#listUnrunChangeSets(liquibase.Contexts)
[2]: https://www.javadoc.io/doc/org.liquibase/liquibase-core/3.3.0/liquibase/Liquibase.html#listUnrunChangeSets(liquibase.Contexts)
[3]: https://github.com/liquibase/liquibase/releases/tag/liquibase-parent-3.3.0
