### PR TITLE
Update Liquibase from 3.6.3 to 4.5.0

### DIFF
--- a/bin/start
+++ b/bin/start
@@ -101,6 +101,7 @@ fi
 JAVA_OPTS="$JAVA_OPTS -XX:+IgnoreUnrecognizedVMOptions" # Don't barf if we see an option we don't understand (e.g. Java 9 option on Java 7/8)
 JAVA_OPTS="$JAVA_OPTS -Djava.awt.headless=true"         # don't try to start AWT. Not sure this does anything but better safe than wasting memory
 JAVA_OPTS="$JAVA_OPTS -Dfile.encoding=UTF-8"            # Use UTF-8
+JAVA_OPTS="$JAVA_OPTS -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager" # java.util.logging via log4j: https://logging.apache.org/log4j/2.x/log4j-jul/
 
 echo "Using these JAVA_OPTS: ${JAVA_OPTS}"
 

--- a/build.clj
+++ b/build.clj
@@ -103,25 +103,7 @@
   {"Manifest-Version" "1.0"
    "Created-By"       "Metabase build.clj"
    "Build-Jdk-Spec"   (System/getProperty "java.specification.version")
-   "Main-Class"       "metabase.core"
-   "Liquibase-Package" (str/join ","
-                                 ["liquibase.change"
-                                  "liquibase.changelog"
-                                  "liquibase.database"
-                                  "liquibase.datatype"
-                                  "liquibase.diff"
-                                  "liquibase.executor"
-                                  "liquibase.ext"
-                                  "liquibase.lockservice"
-                                  "liquibase.logging"
-                                  "liquibase.parser"
-                                  "liquibase.precondition"
-                                  "liquibase.sdk"
-                                  "liquibase.serializer"
-                                  "liquibase.snapshot"
-                                  "liquibase.sqlgenerator"
-                                  "liquibase.structure"
-                                  "liquibase.structurecompare"])})
+   "Main-Class"       "metabase.core"})
 
 (defn manifest ^Manifest []
   (doto (Manifest.)

--- a/deps.edn
+++ b/deps.edn
@@ -82,7 +82,7 @@
   org.apache.logging.log4j/log4j-api        {:mvn/version "2.14.1"}             ; add compatibility with log4j 1.2
   org.apache.logging.log4j/log4j-core       {:mvn/version "2.14.1"}             ; apache logging framework
   org.apache.logging.log4j/log4j-jcl        {:mvn/version "2.14.1"}             ; allows the commons-logging API to work with log4j 2
-  org.apache.logging.log4j/log4j-liquibase  {:mvn/version "2.14.1"}             ; liquibase logging via log4j 2
+  org.apache.logging.log4j/log4j-jul        {:mvn/version "2.14.1"}             ; java.util.logging via log4j 2
   org.apache.logging.log4j/log4j-slf4j-impl {:mvn/version "2.14.1"}             ; allows the slf4j API to work with log4j 2
   org.apache.poi/poi                        {:mvn/version "5.0.0"}              ; Work with Office documents (e.g. Excel spreadsheets) -- newer version than one specified by Docjure
   org.apache.poi/poi-ooxml                  {:mvn/version "5.0.0"
@@ -112,8 +112,7 @@
   org.eclipse.jetty/jetty-server            {:mvn/version "9.4.43.v20210629"}   ; web server
   org.flatland/ordered                      {:mvn/version "1.5.9"}              ; ordered maps & sets
   org.graalvm.js/js                         {:mvn/version "21.2.0"}           ; JavaScript engine
-  org.liquibase/liquibase-core              {:mvn/version "3.6.3"               ; migration management (Java lib)
-                                             :exclusions  [ch.qos.logback/logback-classic]}
+  org.liquibase/liquibase-core              {:mvn/version "4.5.0"}              ; migration management (Java lib)
   org.mariadb.jdbc/mariadb-java-client      {:mvn/version "2.6.2"}              ; MySQL/MariaDB driver
   org.postgresql/postgresql                 {:mvn/version "42.2.23"}            ; Postgres driver
   org.slf4j/slf4j-api                       {:mvn/version "1.7.32"}             ; abstraction for logging frameworks -- allows end user to plug in desired logging framework at deployment time
@@ -190,7 +189,9 @@
                  ;; locally -- prefer debuggability over performance for local dev work.
                  "-XX:-OmitStackTraceInFastThrow"
                  ;; prevent Java icon from randomly popping up in macOS dock
-                 "-Djava.awt.headless=true"]}
+                 "-Djava.awt.headless=true"
+                 ;; java.util.logging via log4j: https://logging.apache.org/log4j/2.x/log4j-jul/
+                 "-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager"]}
 
   ;; includes test code as source paths. Run tests with clojure -X:dev:test
   :test
@@ -213,6 +214,8 @@
   {:main-opts ["-m" "metabase.core"]
    :jvm-opts  ["-Dmb.run.mode=dev"
                "-Djava.awt.headless=true"                   ; prevent Java icon from randomly popping up in macOS dock
+               ;; java.util.logging via log4j: https://logging.apache.org/log4j/2.x/log4j-jul/
+               "-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager"]}
                "-Dmb.jetty.port=3000"]}
 
   ;; alias for CI-specific options.

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -1605,8 +1605,17 @@ databaseChangeLog:
       id: 11
       author: agilliland
       changes:
-        - sql:
-            sql: update report_dashboard set public_perms = 2 where public_perms = 1
+        - update:
+            columns:
+              - column:
+                  name: public_perms
+                  valueNumeric: 2
+            tableName: report_dashboard
+            where: :name=:value
+            whereParams:
+              - param:
+                  name: public_perms
+                  valueNumeric: 1
   - changeSet:
       id: 12
       author: agilliland
@@ -2343,8 +2352,12 @@ databaseChangeLog:
                   defaultValueBoolean: true
                   constraints:
                     nullable: false
-        - sql:
-            sql: update metabase_database set is_full_sync = true
+        - update:
+            columns:
+              - column:
+                  name: is_full_sync
+                  valueBoolean: true
+            tableName: metabase_database
   - changeSet:
       id: 27
       author: agilliland
@@ -4565,12 +4578,10 @@ databaseChangeLog:
             newColumnName: slug
             columnDataType: varchar(254)
         # Let's try to make sure the comments on the name column of Collection actually reflect reality
-        - sql:
-            dbms: postgresql,h2
-            sql: "COMMENT ON COLUMN collection.name IS 'The user-facing name of this Collection.'"
-        - sql:
-            dbms: mysql,mariadb
-            sql: "ALTER TABLE `collection` CHANGE `name` `name` TEXT NOT NULL COMMENT 'The user-facing name of this Collection.'"
+        - setColumnRemarks:
+            columnName: name
+            remarks: The user-facing name of this Collection.
+            tableName: collection
 
 # In 0.30.0 we finally removed the long-deprecated native read permissions. Since they're no longer considered valid by
 # our permissions code, remove any entries for them so they don't cause problems.
@@ -8048,44 +8059,38 @@ databaseChangeLog:
       author: camsaul
       comment: Added 0.39.0
       changes:
-        - sql:
-            dbms: h2
-            sql: |
-              ALTER TABLE task_history
-              ALTER COLUMN started_at timestamp with time zone DEFAULT current_timestamp NOT NULL;
-        - sql:
-            dbms: postgresql
-            sql: |
-              ALTER TABLE task_history
-              ALTER COLUMN started_at TYPE timestamp with time zone,
-              ALTER COLUMN started_at SET DEFAULT current_timestamp;
-        - sql:
-            dbms: mysql,mariadb
-            sql: |
-              ALTER TABLE task_history
-              MODIFY started_at timestamp(6) DEFAULT current_timestamp(6) NOT NULL;
+        - modifyDataType:
+            columnName: started_at
+            newDataType: ${timestamp_type}
+            tableName: task_history
+        - addDefaultValue:
+            columnDataType: ${timestamp_type}
+            columnName: started_at
+            defaultValueComputed: current_timestamp
+            tableName: task_history
+        - addNotNullConstraint:
+            columnDataType: ${timestamp_type}
+            columnName: started_at
+            tableName: task_history
 
   - changeSet:
       id: 283
       author: camsaul
       comment: Added 0.39.0
       changes:
-        - sql:
-            dbms: h2
-            sql: |
-              ALTER TABLE task_history
-              ALTER COLUMN ended_at timestamp with time zone DEFAULT current_timestamp NOT NULL;
-        - sql:
-            dbms: postgresql
-            sql: |
-              ALTER TABLE task_history
-              ALTER COLUMN ended_at TYPE timestamp with time zone,
-              ALTER COLUMN ended_at SET DEFAULT current_timestamp;
-        - sql:
-            dbms: mysql,mariadb
-            sql: |
-              ALTER TABLE task_history
-              MODIFY ended_at timestamp(6) DEFAULT current_timestamp(6) NOT NULL;
+        - modifyDataType:
+            columnName: ended_at
+            newDataType: ${timestamp_type}
+            tableName: task_history
+        - addDefaultValue:
+            columnDataType: ${timestamp_type}
+            columnName: ended_at
+            defaultValueComputed: current_timestamp
+            tableName: task_history
+        - addNotNullConstraint:
+            columnDataType: ${timestamp_type}
+            columnName: ended_at
+            tableName: task_history
   - changeSet:
       id: 284
       author: dpsutton

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -20,11 +20,11 @@ databaseChangeLog:
       name: timestamp_type
       value: timestamp(6)
       dbms: mysql,mariadb
+  - objectQuotingStrategy: ${quote_strategy}
 
   - changeSet:
       id: '1'
       author: agilliland
-      objectQuotingStrategy: ${quote_strategy}
       changes:
       - createTable:
           columns:
@@ -1811,7 +1811,6 @@ databaseChangeLog:
   - changeSet:
       id: 15
       author: agilliland
-      objectQuotingStrategy: ${quote_strategy}
       changes:
         - addColumn:
             tableName: revision
@@ -2183,7 +2182,6 @@ databaseChangeLog:
   - changeSet:
       id: 23
       author: agilliland
-      objectQuotingStrategy: ${quote_strategy}
       changes:
         - modifyDataType:
             tableName: metabase_table
@@ -3333,7 +3331,6 @@ databaseChangeLog:
   - changeSet:
       id: 46
       author: camsaul
-      objectQuotingStrategy: ${quote_strategy}
       changes:
         - addNotNullConstraint:
             tableName: report_dashboardcard
@@ -6701,7 +6698,6 @@ databaseChangeLog:
       id: 169
       author: camsaul
       comment: Added 0.36.0
-      objectQuotingStrategy: ${quote_strategy}
       changes:
         - dropColumn:
             tableName: metabase_table

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -3,6 +3,7 @@ databaseChangeLog:
   # Liquibase not knowing about all of the new reserved words in MySQL 8+. Using a column name that is a reserved word
   # causes a failure. Quoting all objects breaks H2 support though as it will quote table names but not quote that
   # same table name in a foreign key reference which will cause a failure when trying to initially setup the database.
+  # cf. https://github.com/liquibase/liquibase/issues/1810
   - property:
       name: quote_strategy
       value: QUOTE_ALL_OBJECTS
@@ -145,7 +146,8 @@ databaseChangeLog:
                 foreignKeyName: fk_userorgperm_ref_user_id
                 initiallyDeferred: false
                 nullable: false
-                references: core_user(id)
+                referencedTableName: core_user
+                referencedColumnNames: id
               name: user_id
               type: int
           - column:
@@ -154,7 +156,8 @@ databaseChangeLog:
                 foreignKeyName: fk_userorgperm_ref_organization_id
                 initiallyDeferred: false
                 nullable: false
-                references: core_organization(id)
+                referencedTableName: core_organization
+                referencedColumnNames: id
               name: organization_id
               type: int
           tableName: core_userorgperm
@@ -201,7 +204,8 @@ databaseChangeLog:
                 foreignKeyName: fk_permissionviolation_ref_user_id
                 initiallyDeferred: false
                 nullable: false
-                references: core_user(id)
+                referencedTableName: core_user
+                referencedColumnNames: id
               name: user_id
               type: int
           tableName: core_permissionsviolation
@@ -245,7 +249,8 @@ databaseChangeLog:
                 foreignKeyName: fk_database_ref_organization_id
                 initiallyDeferred: false
                 nullable: false
-                references: core_organization(id)
+                referencedTableName: core_organization
+                referencedColumnNames: id
               name: organization_id
               type: int
           - column:
@@ -317,7 +322,8 @@ databaseChangeLog:
                 foreignKeyName: fk_table_ref_database_id
                 initiallyDeferred: false
                 nullable: false
-                references: metabase_database(id)
+                referencedTableName: metabase_database
+                referencedColumnNames: id
               name: db_id
               type: int
           tableName: metabase_table
@@ -383,7 +389,8 @@ databaseChangeLog:
                 foreignKeyName: fk_field_ref_table_id
                 initiallyDeferred: false
                 nullable: false
-                references: metabase_table(id)
+                referencedTableName: metabase_table
+                referencedColumnNames: id
               name: table_id
               type: int
           - column:
@@ -428,7 +435,8 @@ databaseChangeLog:
                 foreignKeyName: fk_foreignkey_dest_ref_field_id
                 initiallyDeferred: false
                 nullable: false
-                references: metabase_field(id)
+                referencedTableName: metabase_field
+                referencedColumnNames: id
               name: destination_id
               type: int
           - column:
@@ -437,7 +445,8 @@ databaseChangeLog:
                 foreignKeyName: fk_foreignkey_origin_ref_field_id
                 initiallyDeferred: false
                 nullable: false
-                references: metabase_field(id)
+                referencedTableName: metabase_field
+                referencedColumnNames: id
               name: origin_id
               type: int
           tableName: metabase_foreignkey
@@ -491,7 +500,8 @@ databaseChangeLog:
                 foreignKeyName: fk_fieldvalues_ref_field_id
                 initiallyDeferred: false
                 nullable: false
-                references: metabase_field(id)
+                referencedTableName: metabase_field
+                referencedColumnNames: id
               name: field_id
               type: int
           tableName: metabase_fieldvalues
@@ -531,7 +541,8 @@ databaseChangeLog:
                 foreignKeyName: fk_tablesegment_ref_table_id
                 initiallyDeferred: false
                 nullable: false
-                references: metabase_table(id)
+                referencedTableName: metabase_table
+                referencedColumnNames: id
               name: table_id
               type: int
           - column:
@@ -596,7 +607,8 @@ databaseChangeLog:
                 foreignKeyName: fk_query_ref_user_id
                 initiallyDeferred: false
                 nullable: false
-                references: core_user(id)
+                referencedTableName: core_user
+                referencedColumnNames: id
               name: creator_id
               type: int
           - column:
@@ -605,7 +617,8 @@ databaseChangeLog:
                 foreignKeyName: fk_query_ref_database_id
                 initiallyDeferred: false
                 nullable: false
-                references: metabase_database(id)
+                referencedTableName: metabase_database
+                referencedColumnNames: id
               name: database_id
               type: int
           tableName: query_query
@@ -695,7 +708,8 @@ databaseChangeLog:
                 foreignKeyName: fk_queryexecution_ref_query_id
                 initiallyDeferred: false
                 nullable: true
-                references: query_query(id)
+                referencedTableName: query_query
+                referencedColumnNames: id
               name: query_id
               type: int
           - column:
@@ -709,7 +723,8 @@ databaseChangeLog:
                 foreignKeyName: fk_queryexecution_ref_user_id
                 initiallyDeferred: false
                 nullable: false
-                references: core_user(id)
+                referencedTableName: core_user
+                referencedColumnNames: id
               name: executor_id
               type: int
           tableName: query_queryexecution
@@ -778,7 +793,8 @@ databaseChangeLog:
                 foreignKeyName: fk_card_ref_user_id
                 initiallyDeferred: false
                 nullable: false
-                references: core_user(id)
+                referencedTableName: core_user
+                referencedColumnNames: id
               name: creator_id
               type: int
           - column:
@@ -787,7 +803,8 @@ databaseChangeLog:
                 foreignKeyName: fk_card_ref_organization_id
                 initiallyDeferred: false
                 nullable: false
-                references: core_organization(id)
+                referencedTableName: core_organization
+                referencedColumnNames: id
               name: organization_id
               type: int
           tableName: report_card
@@ -828,7 +845,8 @@ databaseChangeLog:
                 foreignKeyName: fk_cardfavorite_ref_card_id
                 initiallyDeferred: false
                 nullable: false
-                references: report_card(id)
+                referencedTableName: report_card
+                referencedColumnNames: id
               name: card_id
               type: int
           - column:
@@ -837,7 +855,8 @@ databaseChangeLog:
                 foreignKeyName: fk_cardfavorite_ref_user_id
                 initiallyDeferred: false
                 nullable: false
-                references: core_user(id)
+                referencedTableName: core_user
+                referencedColumnNames: id
               name: owner_id
               type: int
           tableName: report_cardfavorite
@@ -895,7 +914,8 @@ databaseChangeLog:
                 foreignKeyName: fk_dashboard_ref_user_id
                 initiallyDeferred: false
                 nullable: false
-                references: core_user(id)
+                referencedTableName: core_user
+                referencedColumnNames: id
               name: creator_id
               type: int
           - column:
@@ -904,7 +924,8 @@ databaseChangeLog:
                 foreignKeyName: fk_dashboard_ref_organization_id
                 initiallyDeferred: false
                 nullable: false
-                references: core_organization(id)
+                referencedTableName: core_organization
+                referencedColumnNames: id
               name: organization_id
               type: int
           tableName: report_dashboard
@@ -968,7 +989,8 @@ databaseChangeLog:
                 foreignKeyName: fk_dashboardcard_ref_card_id
                 initiallyDeferred: false
                 nullable: false
-                references: report_card(id)
+                referencedTableName: report_card
+                referencedColumnNames: id
               name: card_id
               type: int
           - column:
@@ -977,7 +999,8 @@ databaseChangeLog:
                 foreignKeyName: fk_dashboardcard_ref_dashboard_id
                 initiallyDeferred: false
                 nullable: false
-                references: report_dashboard(id)
+                referencedTableName: report_dashboard
+                referencedColumnNames: id
               name: dashboard_id
               type: int
           tableName: report_dashboardcard
@@ -1008,7 +1031,8 @@ databaseChangeLog:
                 foreignKeyName: fk_dashboardsubscription_ref_dashboard_id
                 initiallyDeferred: false
                 nullable: false
-                references: report_dashboard(id)
+                referencedTableName: report_dashboard
+                referencedColumnNames: id
               name: dashboard_id
               type: int
           - column:
@@ -1017,7 +1041,8 @@ databaseChangeLog:
                 foreignKeyName: fk_dashboardsubscription_ref_user_id
                 initiallyDeferred: false
                 nullable: false
-                references: core_user(id)
+                referencedTableName: core_user
+                referencedColumnNames: id
               name: user_id
               type: int
           tableName: report_dashboardsubscription
@@ -1093,7 +1118,8 @@ databaseChangeLog:
                 foreignKeyName: fk_emailreport_ref_user_id
                 initiallyDeferred: false
                 nullable: false
-                references: core_user(id)
+                referencedTableName: core_user
+                referencedColumnNames: id
               name: creator_id
               type: int
           - column:
@@ -1102,7 +1128,8 @@ databaseChangeLog:
                 foreignKeyName: fk_emailreport_ref_organization_id
                 initiallyDeferred: false
                 nullable: false
-                references: core_organization(id)
+                referencedTableName: core_organization
+                referencedColumnNames: id
               name: organization_id
               type: int
           - column:
@@ -1138,7 +1165,8 @@ databaseChangeLog:
                 foreignKeyName: fk_emailreport_recipients_ref_emailreport_id
                 initiallyDeferred: false
                 nullable: false
-                references: report_emailreport(id)
+                referencedTableName: report_emailreport
+                referencedColumnNames: id
               name: emailreport_id
               type: int
           - column:
@@ -1147,7 +1175,8 @@ databaseChangeLog:
                 foreignKeyName: fk_emailreport_recipients_ref_user_id
                 initiallyDeferred: false
                 nullable: false
-                references: core_user(id)
+                referencedTableName: core_user
+                referencedColumnNames: id
               name: user_id
               type: int
           tableName: report_emailreport_recipients
@@ -1213,7 +1242,8 @@ databaseChangeLog:
                 foreignKeyName: fk_emailreportexecutions_ref_organization_id
                 initiallyDeferred: false
                 nullable: false
-                references: core_organization(id)
+                referencedTableName: core_organization
+                referencedColumnNames: id
               name: organization_id
               type: int
           - column:
@@ -1222,7 +1252,8 @@ databaseChangeLog:
                 foreignKeyName: fk_emailreportexecutions_ref_report_id
                 initiallyDeferred: false
                 nullable: true
-                references: report_emailreport(id)
+                referencedTableName: report_emailreport
+                referencedColumnNames: id
               name: report_id
               type: int
           tableName: report_emailreportexecutions
@@ -1301,7 +1332,8 @@ databaseChangeLog:
                 foreignKeyName: fk_annotation_ref_user_id
                 initiallyDeferred: false
                 nullable: false
-                references: core_user(id)
+                referencedTableName: core_user
+                referencedColumnNames: id
               name: author_id
               type: int
           - column:
@@ -1310,7 +1342,8 @@ databaseChangeLog:
                 foreignKeyName: fk_annotation_ref_organization_id
                 initiallyDeferred: false
                 nullable: false
-                references: core_organization(id)
+                referencedTableName: core_organization
+                referencedColumnNames: id
               name: organization_id
               type: int
           tableName: annotation_annotation
@@ -1361,7 +1394,8 @@ databaseChangeLog:
                 foreignKeyName: fk_session_ref_user_id
                 initiallyDeferred: false
                 nullable: false
-                references: core_user(id)
+                referencedTableName: core_user
+                referencedColumnNames: id
               name: user_id
               type: int
           - column:
@@ -1459,7 +1493,8 @@ databaseChangeLog:
               constraints:
                 foreignKeyName: fk_field_parent_ref_field_id
                 nullable: true
-                references: metabase_field(id)
+                referencedTableName: metabase_field
+                referencedColumnNames: id
               name: parent_id
               type: int
           tableName: metabase_field
@@ -1527,7 +1562,8 @@ databaseChangeLog:
                   type: int
                   constraints:
                     nullable: false
-                    references: core_user(id)
+                    referencedTableName: core_user
+                    referencedColumnNames: id
                     foreignKeyName: fk_revision_ref_user_id
                     deferrable: false
                     initiallyDeferred: false
@@ -1586,7 +1622,8 @@ databaseChangeLog:
                   type: int
                   constraints:
                     nullable: true
-                    references: metabase_database(id)
+                    referencedTableName: metabase_database
+                    referencedColumnNames: id
                     foreignKeyName: fk_report_card_ref_database_id
                     deferrable: false
                     initiallyDeferred: false
@@ -1598,7 +1635,8 @@ databaseChangeLog:
                   type: int
                   constraints:
                     nullable: true
-                    references: metabase_table(id)
+                    referencedTableName: metabase_table
+                    referencedColumnNames: id
                     foreignKeyName: fk_report_card_ref_table_id
                     deferrable: false
                     initiallyDeferred: false
@@ -1642,7 +1680,8 @@ databaseChangeLog:
                   type: int
                   constraints:
                     nullable: true
-                    references: core_user(id)
+                    referencedTableName: core_user
+                    referencedColumnNames: id
                     foreignKeyName: fk_activity_ref_user_id
                     deferrable: false
                     initiallyDeferred: false
@@ -1723,7 +1762,8 @@ databaseChangeLog:
                   type: int
                   constraints:
                     nullable: true
-                    references: core_user(id)
+                    referencedTableName: core_user
+                    referencedColumnNames: id
                     foreignKeyName: fk_view_log_ref_user_id
                     deferrable: false
                     initiallyDeferred: false
@@ -1857,7 +1897,8 @@ databaseChangeLog:
                   type: int
                   constraints:
                     nullable: false
-                    references: core_user(id)
+                    referencedTableName: core_user
+                    referencedColumnNames: id
                     foreignKeyName: fk_pulse_ref_creator_id
                     deferrable: false
                     initiallyDeferred: false
@@ -1902,7 +1943,8 @@ databaseChangeLog:
                   type: int
                   constraints:
                     nullable: false
-                    references: pulse(id)
+                    referencedTableName: pulse
+                    referencedColumnNames: id
                     foreignKeyName: fk_pulse_card_ref_pulse_id
                     deferrable: false
                     initiallyDeferred: false
@@ -1911,7 +1953,8 @@ databaseChangeLog:
                   type: int
                   constraints:
                     nullable: false
-                    references: report_card(id)
+                    referencedTableName: report_card
+                    referencedColumnNames: id
                     foreignKeyName: fk_pulse_card_ref_card_id
                     deferrable: false
                     initiallyDeferred: false
@@ -1947,7 +1990,8 @@ databaseChangeLog:
                   type: int
                   constraints:
                     nullable: false
-                    references: pulse(id)
+                    referencedTableName: pulse
+                    referencedColumnNames: id
                     foreignKeyName: fk_pulse_channel_ref_pulse_id
                     deferrable: false
                     initiallyDeferred: false
@@ -2013,7 +2057,8 @@ databaseChangeLog:
                   type: int
                   constraints:
                     nullable: false
-                    references: pulse_channel(id)
+                    referencedTableName: pulse_channel
+                    referencedColumnNames: id
                     foreignKeyName: fk_pulse_channel_recipient_ref_pulse_channel_id
                     deferrable: false
                     initiallyDeferred: false
@@ -2022,7 +2067,8 @@ databaseChangeLog:
                   type: int
                   constraints:
                     nullable: false
-                    references: core_user(id)
+                    referencedTableName: core_user
+                    referencedColumnNames: id
                     foreignKeyName: fk_pulse_channel_recipient_ref_user_id
                     deferrable: false
                     initiallyDeferred: false
@@ -2050,7 +2096,8 @@ databaseChangeLog:
                   type: int
                   constraints:
                     nullable: false
-                    references: metabase_table(id)
+                    referencedTableName: metabase_table
+                    referencedColumnNames: id
                     foreignKeyName: fk_segment_ref_table_id
                     deferrable: false
                     initiallyDeferred: false
@@ -2059,7 +2106,8 @@ databaseChangeLog:
                   type: int
                   constraints:
                     nullable: false
-                    references: core_user(id)
+                    referencedTableName: core_user
+                    referencedColumnNames: id
                     foreignKeyName: fk_segment_ref_creator_id
                     deferrable: false
                     initiallyDeferred: false
@@ -2219,7 +2267,8 @@ databaseChangeLog:
                   type: int
                   constraints:
                     nullable: false
-                    references: metabase_table(id)
+                    referencedTableName: metabase_table
+                    referencedColumnNames: id
                     foreignKeyName: fk_metric_ref_table_id
                     deferrable: false
                     initiallyDeferred: false
@@ -2228,7 +2277,8 @@ databaseChangeLog:
                   type: int
                   constraints:
                     nullable: false
-                    references: core_user(id)
+                    referencedTableName: core_user
+                    referencedColumnNames: id
                     foreignKeyName: fk_metric_ref_creator_id
                     deferrable: false
                     initiallyDeferred: false
@@ -2314,7 +2364,8 @@ databaseChangeLog:
                   type: int
                   constraints:
                     nullable: false
-                    references: report_dashboardcard(id)
+                    referencedTableName: report_dashboardcard
+                    referencedColumnNames: id
                     foreignKeyName: fk_dashboardcard_series_ref_dashboardcard_id
                     deferrable: false
                     initiallyDeferred: false
@@ -2323,7 +2374,8 @@ databaseChangeLog:
                   type: int
                   constraints:
                     nullable: false
-                    references: report_card(id)
+                    referencedTableName: report_card
+                    referencedColumnNames: id
                     foreignKeyName: fk_dashboardcard_series_ref_card_id
                     deferrable: false
                     initiallyDeferred: false
@@ -2458,7 +2510,8 @@ databaseChangeLog:
                   type: int
                   constraints:
                     nullable: false
-                    references: report_card(id)
+                    referencedTableName: report_card
+                    referencedColumnNames: id
                     foreignKeyName: fk_card_label_ref_card_id
                     deferrable: false
                     initiallyDeferred: false
@@ -2467,7 +2520,8 @@ databaseChangeLog:
                   type: int
                   constraints:
                     nullable: false
-                    references: label(id)
+                    referencedTableName: label
+                    referencedColumnNames: id
                     foreignKeyName: fk_card_label_ref_label_id
                     deferrable: false
                     initiallyDeferred: false
@@ -2516,7 +2570,8 @@ databaseChangeLog:
                   type: int
                   constraints:
                     nullable: false
-                    references: metabase_database(id)
+                    referencedTableName: metabase_database
+                    referencedColumnNames: id
                     foreignKeyName: fk_rawtable_ref_database
                     deferrable: false
                     initiallyDeferred: false
@@ -2575,7 +2630,8 @@ databaseChangeLog:
                   type: int
                   constraints:
                     nullable: false
-                    references: raw_table(id)
+                    referencedTableName: raw_table
+                    referencedColumnNames: id
                     foreignKeyName: fk_rawcolumn_tableid_ref_rawtable
                     deferrable: false
                     initiallyDeferred: false
@@ -2604,7 +2660,8 @@ databaseChangeLog:
                   type: int
                   constraints:
                     nullable: true
-                    references: raw_column(id)
+                    referencedTableName: raw_column
+                    referencedColumnNames: id
                     foreignKeyName: fk_rawcolumn_fktarget_ref_rawcolumn
                     deferrable: false
                     initiallyDeferred: false
@@ -2921,14 +2978,16 @@ databaseChangeLog:
                   type: int
                   constraints:
                     nullable: false
-                    references: metric(id)
+                    referencedTableName: metric
+                    referencedColumnNames: id
                     foreignKeyName: fk_metric_important_field_metric_id
               - column:
                   name: field_id
                   type: int
                   constraints:
                     nullable: false
-                    references: metabase_field(id)
+                    referencedTableName: metabase_field
+                    referencedColumnNames: id
                     foreignKeyName: fk_metric_important_field_metabase_field_id
         - addUniqueConstraint:
             tableName: metric_important_field
@@ -3007,14 +3066,16 @@ databaseChangeLog:
                   type: int
                   constraints:
                     nullable: false
-                    references: core_user(id)
+                    referencedTableName: core_user
+                    referencedColumnNames: id
                     foreignKeyName: fk_permissions_group_membership_user_id
               - column:
                   name: group_id
                   type: int
                   constraints:
                     nullable: false
-                    references: permissions_group(id)
+                    referencedTableName: permissions_group
+                    referencedColumnNames: id
                     foreignKeyName: fk_permissions_group_group_id
         - addUniqueConstraint:
             tableName: permissions_group_membership
@@ -3064,7 +3125,8 @@ databaseChangeLog:
                   type: int
                   constraints:
                     nullable: false
-                    references: permissions_group(id)
+                    referencedTableName: permissions_group
+                    referencedColumnNames: id
                     foreignKeyName: fk_permissions_group_id
         - createIndex:
             tableName: permissions
@@ -3214,7 +3276,8 @@ databaseChangeLog:
                   remarks: 'The ID of the admin who made this set of changes.'
                   constraints:
                     nullable: false
-                    references: core_user(id)
+                    referencedTableName: core_user
+                    referencedColumnNames: id
                     foreignKeyName: fk_permissions_revision_user_id
               - column:
                   name: created_at
@@ -3338,7 +3401,8 @@ databaseChangeLog:
                   type: int
                   remarks: 'Optional ID of Collection this Card belongs to.'
                   constraints:
-                    references: collection(id)
+                    referencedTableName: collection
+                    referencedColumnNames: id
                     foreignKeyName: fk_card_collection_id
         - createIndex:
             tableName: report_card
@@ -3379,7 +3443,8 @@ databaseChangeLog:
                   remarks: 'The ID of the admin who made this set of changes.'
                   constraints:
                     nullable: false
-                    references: core_user(id)
+                    referencedTableName: core_user
+                    referencedColumnNames: id
                     foreignKeyName: fk_collection_revision_user_id
               - column:
                   name: created_at
@@ -3416,7 +3481,8 @@ databaseChangeLog:
                   type: int
                   remarks: 'The ID of the User who first publically shared this Card.'
                   constraints:
-                    references: core_user(id)
+                    referencedTableName: core_user
+                    referencedColumnNames: id
                     foreignKeyName: fk_card_made_public_by_id
         - createIndex:
             tableName: report_card
@@ -3442,7 +3508,8 @@ databaseChangeLog:
                   type: int
                   remarks: 'The ID of the User who first publically shared this Dashboard.'
                   constraints:
-                    references: core_user(id)
+                    referencedTableName: core_user
+                    referencedColumnNames: id
                     foreignKeyName: fk_dashboard_made_public_by_id
         - createIndex:
             tableName: report_dashboard
@@ -3718,7 +3785,8 @@ databaseChangeLog:
                   remarks: 'ID of the User who favorited the Dashboard.'
                   constraints:
                     nullable: false
-                    references: core_user(id)
+                    referencedTableName: core_user
+                    referencedColumnNames: id
                     foreignKeyName: fk_dashboard_favorite_user_id
                     deleteCascade: true
               - column:
@@ -3727,7 +3795,8 @@ databaseChangeLog:
                   remarks: 'ID of the Dashboard favorited by the User.'
                   constraints:
                     nullable: false
-                    references: report_dashboard(id)
+                    referencedTableName: report_dashboard
+                    referencedColumnNames: id
                     foreignKeyName: fk_dashboard_favorite_dashboard_id
                     deleteCascade: true
         - addUniqueConstraint:
@@ -3797,7 +3866,8 @@ databaseChangeLog:
                     foreignKeyName: fk_dimension_ref_field_id
                     initiallyDeferred: false
                     nullable: false
-                    references: metabase_field(id)
+                    referencedTableName: metabase_field
+                    referencedColumnNames: id
                     deleteCascade: true
               - column:
                   name: name
@@ -3820,7 +3890,8 @@ databaseChangeLog:
                     foreignKeyName: fk_dimension_displayfk_ref_field_id
                     initiallyDeferred: false
                     nullable: true
-                    references: metabase_field(id)
+                    referencedTableName: metabase_field
+                    referencedColumnNames: id
                     deleteCascade: true
               - column:
                   name: created_at
@@ -3972,7 +4043,8 @@ databaseChangeLog:
                     deferrable: false
                     foreignKeyName: fk_computation_job_ref_user_id
                     initiallyDeferred: false
-                    references: core_user(id)
+                    referencedTableName: core_user
+                    referencedColumnNames: id
                   name: creator_id
                   type: int
               - column:
@@ -4012,7 +4084,8 @@ databaseChangeLog:
                     foreignKeyName: fk_computation_result_ref_job_id
                     initiallyDeferred: false
                     nullable: false
-                    references: computation_job(id)
+                    referencedTableName: computation_job
+                    referencedColumnNames: id
                   name: job_id
                   type: int
               - column:
@@ -4232,7 +4305,8 @@ databaseChangeLog:
                   remarks: 'ID of the Permissions Group this policy affects.'
                   constraints:
                     nullable: false
-                    references: permissions_group(id)
+                    referencedTableName: permissions_group
+                    referencedColumnNames: id
                     foreignKeyName: fk_gtap_group_id
                     deleteCascade: true
               - column:
@@ -4241,7 +4315,8 @@ databaseChangeLog:
                   remarks: 'ID of the Table that should get automatically replaced as query source for the Permissions Group.'
                   constraints:
                     nullable: false
-                    references: metabase_table(id)
+                    referencedTableName: metabase_table
+                    referencedColumnNames: id
                     foreignKeyName: fk_gtap_table_id
                     deleteCascade: true
               - column:
@@ -4250,7 +4325,8 @@ databaseChangeLog:
                   remarks: 'ID of the Card (Question) to be used to replace the Table.'
                   constraints:
                     nullable: false
-                    references: report_card(id)
+                    referencedTableName: report_card
+                    referencedColumnNames: id
                     foreignKeyName: fk_gtap_card_id
               - column:
                   name: attribute_remappings
@@ -4288,7 +4364,8 @@ databaseChangeLog:
                   type: int
                   remarks: 'Optional ID of Collection this Dashboard belongs to.'
                   constraints:
-                    references: collection(id)
+                    referencedTableName: collection
+                    referencedColumnNames: id
                     foreignKeyName: fk_dashboard_collection_id
               # TODO - if someone deletes a collection, what should happen to the Dashboards that are in it? Should they
               # get deleted as well? Or should collection_id be cleared, effectively putting them in the so-called
@@ -4307,7 +4384,8 @@ databaseChangeLog:
                   type: int
                   remarks: 'Options ID of Collection this Pulse belongs to.'
                   constraints:
-                    references: collection(id)
+                    referencedTableName: collection
+                    referencedColumnNames: id
                     foreignKeyName: fk_pulse_collection_id
         - createIndex:
             tableName: pulse
@@ -4441,7 +4519,8 @@ databaseChangeLog:
                   type: int
                   remarks: 'If set, this Collection is a personal Collection, for exclusive use of the User with this ID.'
                   constraints:
-                    references: core_user(id)
+                    referencedTableName: core_user
+                    referencedColumnNames: id
                     foreignKeyName: fk_collection_personal_owner_id
                     unique: true
                     uniqueConstraintName: unique_collection_personal_owner_id
@@ -6555,7 +6634,8 @@ databaseChangeLog:
                   type: int
                   constraints:
                     nullable: false
-                    references: core_user(id)
+                    referencedTableName: core_user
+                    referencedColumnNames: id
                     foreignKeyName: fk_snippet_creator_id
                     # This primarily affects tests because under normal
                     # circumstances we don't delete Users, we just archive them
@@ -6645,7 +6725,8 @@ databaseChangeLog:
                   remarks: 'ID of the Snippet Folder (Collection) this Snippet is in, if any'
                   constraints:
                     nullable: true
-                    references: collection(id)
+                    referencedTableName: collection
+                    referencedColumnNames: id
                     foreignKeyName: fk_snippet_collection_id
                     deleteCascade: true
         - createIndex:
@@ -7887,7 +7968,8 @@ databaseChangeLog:
                 remarks: 'If this Pulse is a Dashboard subscription, the ID of the DashboardCard that corresponds to this PulseCard.'
                 constraints:
                   nullable: true
-                  references: report_dashboardcard(id)
+                  referencedTableName: report_dashboardcard
+                  referencedColumnNames: id
                   foreignKeyName: fk_pulse_card_ref_pulse_card_id
                   deferrable: false
                   initiallyDeferred: false
@@ -8148,7 +8230,8 @@ databaseChangeLog:
                   remarks: "ID of the User that logged in."
                   constraints:
                     foreignKeyName: fk_login_history_user_id
-                    references: core_user(id)
+                    referencedTableName: core_user
+                    referencedColumnNames: id
                     nullable: false
                     deleteCascade: true
               # FK constraint is created later, because we can't create it inline with ON DELETE SET NULL

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -5425,7 +5425,7 @@ databaseChangeLog:
             sql: SELECT count(*) FROM (SELECT count(*) FROM DATABASECHANGELOG GROUP BY ID, AUTHOR, FILENAME HAVING count(*) > 1) t1
       changes:
         - addUniqueConstraint:
-            columnNames: id, author, filename
+            columnNames: ID, AUTHOR, FILENAME
             constraintName: idx_databasechangelog_id_author_filename
             tableName: DATABASECHANGELOG
 #

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -288,7 +288,14 @@ databaseChangeLog:
               name: name
               type: varchar(254)
           - column:
-              name: rows
+              # liquibase.database.core.H2Database will quote this, because
+              # it is a H2 keyword, which prevents automatic uppercasing by
+              # H2.  So make it uppercase from the start.
+              # An alternative would be to globally set `objectQuotingStrategy`
+              # to `QUOTE_ALL_OBJECTS`, but that will trip the rest of the
+              # Metabase code, because table and column names will then
+              # all be lowercase.
+              name: ROWS
               type: int
           - column:
               name: description
@@ -466,7 +473,14 @@ databaseChangeLog:
               name: updated_at
               type: DATETIME
           - column:
-              name: values
+              # liquibase.database.core.H2Database will quote this, because
+              # it is a H2 keyword, which prevents automatic uppercasing by
+              # H2.  So make it uppercase from the start.
+              # An alternative would be to globally set `objectQuotingStrategy`
+              # to `QUOTE_ALL_OBJECTS`, but that will trip the rest of the
+              # Metabase code, because table and column names will then
+              # all be lowercase.
+              name: VALUES
               type: text
           - column:
               name: human_readable_values
@@ -936,7 +950,14 @@ databaseChangeLog:
               name: sizeY
               type: int
           - column:
-              name: row
+              # liquibase.database.core.H2Database will quote this, because
+              # it is a H2 keyword, which prevents automatic uppercasing by
+              # H2.  So make it uppercase from the start.
+              # An alternative would be to globally set `objectQuotingStrategy`
+              # to `QUOTE_ALL_OBJECTS`, but that will trip the rest of the
+              # Metabase code, because table and column names will then
+              # all be lowercase.
+              name: ROW
               type: int
           - column:
               name: col
@@ -2109,7 +2130,7 @@ databaseChangeLog:
       changes:
         - modifyDataType:
             tableName: metabase_table
-            columnName: rows
+            columnName: ROWS
             newDataType: BIGINT
   - changeSet:
       id: 24
@@ -3240,7 +3261,7 @@ databaseChangeLog:
       changes:
         - addNotNullConstraint:
             tableName: report_dashboardcard
-            columnName: row
+            columnName: ROW
             columnDataType: integer
             defaultNullValue: 0
         - addNotNullConstraint:
@@ -3250,7 +3271,7 @@ databaseChangeLog:
             defaultNullValue: 0
         - addDefaultValue:
             tableName: report_dashboardcard
-            columnName: row
+            columnName: ROW
             defaultValueNumeric: 0
         - addDefaultValue:
             tableName: report_dashboardcard
@@ -6593,7 +6614,7 @@ databaseChangeLog:
       changes:
         - dropColumn:
             tableName: metabase_table
-            columnName: rows
+            columnName: ROWS
 
 # Remove fields_hash from Table model, as we no longer skip sync steps if metadata
 # hash hasn't changed.

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -7866,8 +7866,8 @@ databaseChangeLog:
       author: rlotun
       comment: Added 0.37.0  # set email values to lower(email) but do so defensively and in a way that works on postgres and mysql - skip over those that would introduce duplicates (e.g. Reza@email.com and reza@email.com)
       changes:
-        - sql :
-            sql : UPDATE core_user SET email = lower(email) WHERE lower(email) NOT IN (SELECT * FROM (SELECT lower(email) FROM core_user GROUP BY lower(email) HAVING count(email) > 1) as e)
+        - sql:
+            sql: UPDATE core_user SET email = lower(email) WHERE lower(email) NOT IN (SELECT * FROM (SELECT lower(email) FROM core_user GROUP BY lower(email) HAVING count(email) > 1) as e)
   - changeSet:
       id: 270
       author: rlotun
@@ -7879,8 +7879,8 @@ databaseChangeLog:
             - dbms:
                 type: postgresql
       changes:
-        - sql :
-            sql : CREATE EXTENSION IF NOT EXISTS citext
+        - sql:
+            sql: CREATE EXTENSION IF NOT EXISTS citext
   - changeSet:
       id: 271
       author: rlotun
@@ -8157,21 +8157,21 @@ databaseChangeLog:
         - 8:943c6dd0c9339729fefcee9207227849
       changes:
         - sql:
-              sql: >-
-                UPDATE metabase_field
-                set effective_type    = 'type/Instant',
-                    coercion_strategy = (case semantic_type
-                                          WHEN 'type/UNIXTimestampSeconds'      THEN 'Coercion/UNIXSeconds->DateTime'
-                                          WHEN 'timestamp_seconds'              THEN 'Coercion/UNIXSeconds->DateTime'
-                                          WHEN 'type/UNIXTimestampMilliSeconds' THEN 'Coercion/UNIXMilliSeconds->DateTime'
-                                          WHEN 'timestamp_milliseconds'         THEN 'Coercion/UNIXMilliSeconds->DateTime'
-                                          WHEN 'type/UNIXTimestampMicroSeconds' THEN 'Coercion/UNIXMicroSeconds->DateTime'
-                                         END)
-                WHERE semantic_type IN ('type/UNIXTimestampSeconds',
-                                        'type/UNIXTimestampMilliSeconds',
-                                        'type/UNIXTimestampMicroSeconds',
-                                        'timestamp_seconds',
-                                        'timestamp_milliseconds');
+            sql: >-
+              UPDATE metabase_field
+              set effective_type    = 'type/Instant',
+                  coercion_strategy = (case semantic_type
+                                        WHEN 'type/UNIXTimestampSeconds'      THEN 'Coercion/UNIXSeconds->DateTime'
+                                        WHEN 'timestamp_seconds'              THEN 'Coercion/UNIXSeconds->DateTime'
+                                        WHEN 'type/UNIXTimestampMilliSeconds' THEN 'Coercion/UNIXMilliSeconds->DateTime'
+                                        WHEN 'timestamp_milliseconds'         THEN 'Coercion/UNIXMilliSeconds->DateTime'
+                                        WHEN 'type/UNIXTimestampMicroSeconds' THEN 'Coercion/UNIXMicroSeconds->DateTime'
+                                       END)
+              WHERE semantic_type IN ('type/UNIXTimestampSeconds',
+                                      'type/UNIXTimestampMilliSeconds',
+                                      'type/UNIXTimestampMicroSeconds',
+                                      'timestamp_seconds',
+                                      'timestamp_milliseconds');
 
   - changeSet:
       id: 289
@@ -8182,15 +8182,15 @@ databaseChangeLog:
         - 8:9f7f2e9bbf3236f204c644dc8ea7abef
       changes:
         - sql:
-              sql: >-
-                UPDATE metabase_field
-                set effective_type    = 'type/Instant',
-                    coercion_strategy = (case semantic_type
-                                          WHEN 'type/UNIXTimestampMilliseconds' THEN 'Coercion/UNIXMilliSeconds->DateTime'
-                                          WHEN 'type/UNIXTimestampMicroseconds' THEN 'Coercion/UNIXMicroSeconds->DateTime'
-                                         END)
-                WHERE semantic_type IN ('type/UNIXTimestampMilliseconds',
-                                        'type/UNIXTimestampMicroseconds')
+            sql: >-
+              UPDATE metabase_field
+              set effective_type    = 'type/Instant',
+                  coercion_strategy = (case semantic_type
+                                        WHEN 'type/UNIXTimestampMilliseconds' THEN 'Coercion/UNIXMilliSeconds->DateTime'
+                                        WHEN 'type/UNIXTimestampMicroseconds' THEN 'Coercion/UNIXMicroSeconds->DateTime'
+                                       END)
+              WHERE semantic_type IN ('type/UNIXTimestampMilliseconds',
+                                      'type/UNIXTimestampMicroseconds')
 
   - changeSet:
       id: 290
@@ -8198,7 +8198,7 @@ databaseChangeLog:
       comment: Added 0.39 - Semantic type system - Clobber semantic_type where there was a coercion
       changes:
         - sql:
-              sql: UPDATE metabase_field set semantic_type = null where coercion_strategy is not null
+            sql: UPDATE metabase_field set semantic_type = null where coercion_strategy is not null
 
 # 291-297 create the new login history Table
 
@@ -8457,29 +8457,29 @@ databaseChangeLog:
       comment: Added 0.40.0 (replaces a data migration dating back to 0.20.0)
       changes:
         - sql:
-              sql: >-
-                UPDATE metabase_field
-                SET semantic_type = (CASE semantic_type
-                                      WHEN 'avatar'    THEN 'type/AvatarURL'
-                                      WHEN 'category'  THEN 'type/Category'
-                                      WHEN 'city'      THEN 'type/City'
-                                      WHEN 'country'   THEN 'type/Country'
-                                      WHEN 'desc'      THEN 'type/Description'
-                                      WHEN 'fk'        THEN 'type/FK'
-                                      WHEN 'id'        THEN 'type/PK'
-                                      WHEN 'image'     THEN 'type/ImageURL'
-                                      WHEN 'json'      THEN 'type/SerializedJSON'
-                                      WHEN 'latitude'  THEN 'type/Latitude'
-                                      WHEN 'longitude' THEN 'type/Longitude'
-                                      WHEN 'name'      THEN 'type/Name'
-                                      WHEN 'number'    THEN 'type/Number'
-                                      WHEN 'state'     THEN 'type/State'
-                                      WHEN 'url'       THEN 'type/URL'
-                                      WHEN 'zip_code'  THEN 'type/ZipCode'
-                                     END)
-                WHERE semantic_type IN ('avatar', 'category', 'city', 'country', 'desc', 'fk', 'id', 'image',
-                                        'json', 'latitude', 'longitude', 'name', 'number', 'state', 'url',
-                                        'zip_code');
+            sql: >-
+              UPDATE metabase_field
+              SET semantic_type = (CASE semantic_type
+                                    WHEN 'avatar'    THEN 'type/AvatarURL'
+                                    WHEN 'category'  THEN 'type/Category'
+                                    WHEN 'city'      THEN 'type/City'
+                                    WHEN 'country'   THEN 'type/Country'
+                                    WHEN 'desc'      THEN 'type/Description'
+                                    WHEN 'fk'        THEN 'type/FK'
+                                    WHEN 'id'        THEN 'type/PK'
+                                    WHEN 'image'     THEN 'type/ImageURL'
+                                    WHEN 'json'      THEN 'type/SerializedJSON'
+                                    WHEN 'latitude'  THEN 'type/Latitude'
+                                    WHEN 'longitude' THEN 'type/Longitude'
+                                    WHEN 'name'      THEN 'type/Name'
+                                    WHEN 'number'    THEN 'type/Number'
+                                    WHEN 'state'     THEN 'type/State'
+                                    WHEN 'url'       THEN 'type/URL'
+                                    WHEN 'zip_code'  THEN 'type/ZipCode'
+                                   END)
+              WHERE semantic_type IN ('avatar', 'category', 'city', 'country', 'desc', 'fk', 'id', 'image',
+                                      'json', 'latitude', 'longitude', 'name', 'number', 'state', 'url',
+                                      'zip_code');
 
   - changeSet:
       id: 305


### PR DESCRIPTION
Release notes: https://docs.liquibase.com/release-notes/home.html

Most important is probably 4.0.0-beta1 [1] which contains two breaking
changes that "will affect anyone using extensions":

> * Extension classes are now loaded via the java.util.ServiceLoader system
>   rather than the custom class finding logic we had before
> * Logging is now based on java.util.Logging with a cleaned up API

The first change does not appear to affect Metabase, but the 2nd likely does.

Hence I followed the log4j JUL adapter guide [2] to bridge
`java.util.logging` (used by Liquibase) to log4j (used by Metabase).
In particular, I switched from log4j-liquibase to log4j-jul and added the
system property `java.util.logging.manager` to the JVM options.

[1]: https://github.com/liquibase/liquibase/releases/tag/v4.0.0-beta1
[2]: https://logging.apache.org/log4j/2.x/log4j-jul/
