### PR TITLE
Small fix and refactor for ExpressionEditorSuggestions component

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import styled from "styled-components";
 
 import { t } from "ttag";
 import cx from "classnames";
@@ -15,6 +16,26 @@ const SUGGESTION_SECTION_NAMES = {
   metrics: t`Metrics`,
   other: t`Other`,
 };
+
+const UlStyled = styled.ul.attrs({ className: "pb1" })`
+  min-width: 150px;
+  overflow-y: auto;
+`;
+
+const liTitleClassName = "mx2 h6 text-uppercase text-bold text-medium py1 pt2";
+const LiTitle = styled.li.attrs({ className: liTitleClassName });
+
+const liStyledClassName =
+  "px2 cursor-pointer text-white-hover bg-brand-hover hover-parent hover--inherit";
+const LiStyled = styled.li.attrs({ className: liStyledClassName })`
+  padding-top: 5px;
+  padding-bottom: 5px;
+`;
+
+const liStyledHighlightedClassName = "text-white bg-brand";
+const LiStyledHighlighted = styled(LiStyled).attrs({
+  className: liStyledHighlightedClassName,
+});
 
 export default class ExpressionEditorSuggestions extends React.Component {
   static propTypes = {
@@ -58,52 +79,52 @@ export default class ExpressionEditorSuggestions extends React.Component {
         }}
         sizeToFit
       >
-        <ul className="pb1" style={{ minWidth: 150, overflowY: "auto" }}>
-          {suggestions.map((suggestion, i) =>
-            // insert section title. assumes they're sorted by type
-            [
-              (i === 0 || suggestion.type !== suggestions[i - 1].type) && (
-                <li className="mx2 h6 text-uppercase text-bold text-medium py1 pt2">
-                  {SUGGESTION_SECTION_NAMES[suggestion.type] || suggestion.type}
-                </li>
-              ),
-              <li
-                ref={r => {
-                  if (i === highlightedIndex) {
-                    this._selectedRow = r;
-                  }
-                }}
-                style={{ paddingTop: 5, paddingBottom: 5 }}
-                className={cx(
-                  "px2 cursor-pointer text-white-hover bg-brand-hover hover-parent hover--inherit",
-                  {
-                    "text-white bg-brand": i === highlightedIndex,
-                  },
-                )}
-                onMouseDownCapture={e => this.onSuggestionMouseDown(e, i)}
-              >
-                {suggestion.range ? (
-                  <span>
-                    {suggestion.name.slice(0, suggestion.range[0])}
-                    <span
-                      className={cx("text-brand text-bold hover-child", {
-                        "text-white bg-brand": i === highlightedIndex,
-                      })}
-                    >
-                      {suggestion.name.slice(
-                        suggestion.range[0],
-                        suggestion.range[1],
-                      )}
+        <UlStyled>
+          {suggestions.map((suggestion, i) => {
+            const shouldRenderSectionTitle =
+              i === 0 || suggestion.type !== suggestions[i - 1].type;
+
+            const sectionTitle =
+              SUGGESTION_SECTION_NAMES[suggestion.type] || suggestion.type;
+
+            const isHighlighted = i === highlightedIndex;
+
+            const LiComponent = isHighlighted ? LiStyledHighlighted : LiStyled;
+
+            return (
+              <React.Fragment key={`suggestion-${i}`}>
+                {shouldRenderSectionTitle && <LiTitle>{sectionTitle}</LiTitle>}
+                <LiComponent
+                  ref={r => {
+                    if (isHighlighted) {
+                      this._selectedRow = r;
+                    }
+                  }}
+                  onMouseDownCapture={e => this.onSuggestionMouseDown(e, i)}
+                >
+                  {suggestion.range ? (
+                    <span>
+                      {suggestion.name.slice(0, suggestion.range[0])}
+                      <span
+                        className={cx("text-brand text-bold hover-child", {
+                          "text-white bg-brand": isHighlighted,
+                        })}
+                      >
+                        {suggestion.name.slice(
+                          suggestion.range[0],
+                          suggestion.range[1],
+                        )}
+                      </span>
+                      {suggestion.name.slice(suggestion.range[1])}
                     </span>
-                    {suggestion.name.slice(suggestion.range[1])}
-                  </span>
-                ) : (
-                  suggestion.name
-                )}
-              </li>,
-            ],
-          )}
-        </ul>
+                  ) : (
+                    suggestion.name
+                  )}
+                </LiComponent>
+              </React.Fragment>
+            );
+          })}
+        </UlStyled>
       </Popover>
     );
   }

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
@@ -1,11 +1,16 @@
 import React from "react";
 import PropTypes from "prop-types";
-import styled from "styled-components";
 
 import { t } from "ttag";
 import cx from "classnames";
 
 import Popover from "metabase/components/Popover";
+import {
+  UlStyled,
+  LiStyled,
+  LiStyledHighlighted,
+  LiTitle,
+} from "./ExpressionEditorSuggestions.styled";
 
 import { isObscured } from "metabase/lib/dom";
 
@@ -16,26 +21,6 @@ const SUGGESTION_SECTION_NAMES = {
   metrics: t`Metrics`,
   other: t`Other`,
 };
-
-const UlStyled = styled.ul.attrs({ className: "pb1" })`
-  min-width: 150px;
-  overflow-y: auto;
-`;
-
-const liTitleClassName = "mx2 h6 text-uppercase text-bold text-medium py1 pt2";
-const LiTitle = styled.li.attrs({ className: liTitleClassName });
-
-const liStyledClassName =
-  "px2 cursor-pointer text-white-hover bg-brand-hover hover-parent hover--inherit";
-const LiStyled = styled.li.attrs({ className: liStyledClassName })`
-  padding-top: 5px;
-  padding-bottom: 5px;
-`;
-
-const liStyledHighlightedClassName = "text-white bg-brand";
-const LiStyledHighlighted = styled(LiStyled).attrs({
-  className: liStyledHighlightedClassName,
-});
 
 export default class ExpressionEditorSuggestions extends React.Component {
   static propTypes = {

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
@@ -9,7 +9,7 @@ import {
   UlStyled,
   LiStyled,
   LiStyledHighlighted,
-  LiTitle,
+  SectionTitle,
 } from "./ExpressionEditorSuggestions.styled";
 
 import { isObscured } from "metabase/lib/dom";
@@ -78,7 +78,10 @@ export default class ExpressionEditorSuggestions extends React.Component {
 
             return (
               <React.Fragment key={`suggestion-${i}`}>
-                {shouldRenderSectionTitle && <LiTitle>{sectionTitle}</LiTitle>}
+                {shouldRenderSectionTitle && (
+                  <SectionTitle>{sectionTitle}</SectionTitle>
+                )}
+
                 <LiComponent
                   ref={r => {
                     if (isHighlighted) {

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.styled.jsx
@@ -1,0 +1,21 @@
+import styled from "styled-components";
+
+export const UlStyled = styled.ul.attrs({ className: "pb1" })`
+  min-width: 150px;
+  overflow-y: auto;
+`;
+
+const liTitleClassName = "mx2 h6 text-uppercase text-bold text-medium py1 pt2";
+export const LiTitle = styled.li.attrs({ className: liTitleClassName });
+
+const liStyledClassName =
+  "px2 cursor-pointer text-white-hover bg-brand-hover hover-parent hover--inherit";
+export const LiStyled = styled.li.attrs({ className: liStyledClassName })`
+  padding-top: 5px;
+  padding-bottom: 5px;
+`;
+
+const liStyledHighlightedClassName = "text-white bg-brand";
+export const LiStyledHighlighted = styled(LiStyled).attrs({
+  className: liStyledHighlightedClassName,
+});

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.styled.jsx
@@ -5,8 +5,11 @@ export const UlStyled = styled.ul.attrs({ className: "pb1" })`
   overflow-y: auto;
 `;
 
-const liTitleClassName = "mx2 h6 text-uppercase text-bold text-medium py1 pt2";
-export const LiTitle = styled.li.attrs({ className: liTitleClassName });
+const sectionTitleClassName =
+  "mx2 h6 text-uppercase text-bold text-medium py1 pt2";
+export const SectionTitle = styled.li.attrs({
+  className: sectionTitleClassName,
+})``;
 
 const liStyledClassName =
   "px2 cursor-pointer text-white-hover bg-brand-hover hover-parent hover--inherit";


### PR DESCRIPTION
Clearing the way to fix #15734 

Before I found the culprit I investigated here. Changes were quite encapsulated, so here's a simpler PR to review.

Intentions:

* fix a sneaky `unique key prop` warning due to using arrays instead of React.Fragment in this case
* decouple styles from markup
* decouple evaluating conditionals from using them to render or not things, and how
* in general to make the whole a bit more declarative and quickly understandable

## How to Test

Use the repro steps in #15734