### PR TITLE
Use lower-case email to look up user when logging in with LDAP

### DIFF
--- a/src/metabase/integrations/ldap/default_implementation.clj
+++ b/src/metabase/integrations/ldap/default_implementation.clj
@@ -94,7 +94,7 @@
 (s/defn ^:private fetch-or-create-user!* :- (class User)
   [{:keys [first-name last-name email groups]} :- i/UserInfo
    {:keys [sync-groups?], :as settings}        :- i/LDAPSettings]
-  (let [user (or (db/select-one [User :id :last_login] :email email)
+  (let [user (or (db/select-one [User :id :last_login] :email (u/lower-case-en email))
                  (user/create-new-ldap-auth-user!
                   {:first_name first-name
                    :last_name  last-name

--- a/test/metabase/api/session_test.clj
+++ b/test/metabase/api/session_test.clj
@@ -564,4 +564,16 @@
         (is (schema= SessionResponse
                      (mt/client :post 200 "session" {:username "sbrown20", :password "1234"})))
         (finally
-          (db/delete! User :email "sally.brown@metabase.com"))))))
+          (db/delete! User :email "sally.brown@metabase.com"))))
+
+    (testing "Test that we can login with LDAP multiple times if the email stored in LDAP contains upper-case
+             characters (#13739)"
+      (try
+        (is (schema=
+             SessionResponse
+             (mt/client :post 200 "session" {:username "John.Smith@metabase.com", :password "strongpassword"})))
+        (is (schema=
+             SessionResponse
+             (mt/client :post 200 "session" {:username "John.Smith@metabase.com", :password "strongpassword"})))
+        (finally
+          (db/delete! User :email "John.Smith@metabase.com"))))))


### PR DESCRIPTION
This PR fixes the specific issue in #13739 and adds a relevant test.

The underlying issue is that the Postgres JDBC driver casts strings to `varchar` by default which results in case-sensitive lookups even though the type of the email column is `citext`. This can be fixed by setting the `stringtype` connection property to `unspecified`, but it seems like doing this breaks a couple of tests, so I'll do it in a separate PR from this one.

Resolves #13739 