### PR TITLE
Add test that LDAP validation works for passwords containing $

### DIFF
--- a/test/metabase/integrations/ldap_test.clj
+++ b/test/metabase/integrations/ldap_test.clj
@@ -64,7 +64,11 @@
 
     (testing "fail regular user login with bad password"
       (is (= false
-             (ldap/verify-password "cn=Sally Brown,ou=People,dc=metabase,dc=com" "password"))))))
+             (ldap/verify-password "cn=Sally Brown,ou=People,dc=metabase,dc=com" "password"))))
+
+    (testing "password containing dollar signs succeeds (#15145)"
+      (is (= true
+             (ldap/verify-password "cn=Fred Taylor,ou=People,dc=metabase,dc=com", "pa$$word"))))))
 
 (deftest find-test
   ;; there are EE-specific versions of this test in `metabase-enterprise.enhancements.integrations.ldap-test`

--- a/test_resources/ldap.ldif
+++ b/test_resources/ldap.ldif
@@ -44,7 +44,7 @@ sN: Taylor
 givenname: Fred
 uid: ftaylor300
 mAiL: fred.taylor@metabase.com
-userpassword: unh4ck4bl3
+userpassword: pa$$word
 
 dn: ou=Birds,dc=metabase,dc=com
 objectClass: top


### PR DESCRIPTION
Couldn't repro, but now we have a basic test covering this case.

Resolves #15145