### PR TITLE
Fix precondition of change set 97

### DIFF
--- a/bin/lint-migrations-file/src/change_set/common.clj
+++ b/bin/lint-migrations-file/src/change_set/common.clj
@@ -14,5 +14,15 @@
 
 (s/def ::author string?)
 
+(s/def ::preConditions
+  (s/coll-of ::pre-condition))
+
+(s/def ::pre-condition
+  (s/keys :opt-un [::dbms]))
+
+(s/def ::dbms
+  (s/keys :req-un [::type]))
+
 (s/def ::change-set
-  (s/keys :req-un [::id ::author]))
+  (s/keys :req-un [::id ::author]
+          :opt-un [::preConditions]))

--- a/bin/lint-migrations-file/src/change_set/common.clj
+++ b/bin/lint-migrations-file/src/change_set/common.clj
@@ -1,5 +1,6 @@
 (ns change-set.common
-  (:require [clojure.spec.alpha :as s]))
+  (:require [clojure.spec.alpha :as s]
+            [clojure.string :as str]))
 
 (s/def ::id
   (s/or
@@ -22,6 +23,14 @@
 
 (s/def ::dbms
   (s/keys :req-un [::type]))
+
+(s/def ::type (s/and string? ::valid-dbs))
+
+(s/def ::valid-dbs
+  (fn [s]
+    (let [dbs (into #{} (map str/trim) (str/split s #","))]
+      (and (seq dbs)
+           (every? #{"h2" "mysql" "mariadb" "postgresql"} dbs)))))
 
 (s/def ::change-set
   (s/keys :req-un [::id ::author]

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -5341,7 +5341,8 @@ databaseChangeLog:
       comment: 'Added 0.32.0'
       preConditions:
         - onFail: MARK_RAN
-        - dbms: mysql, mariadb
+        - dbms:
+            type: mysql,mariadb
       changes:
         - modifyDataType:
             tableName: query_cache


### PR DESCRIPTION
Without the `type` and with the space Liquibase is unable to parse this
precondition.

During `lein test` it outputs:
```
[clojure-agent-send-off-pool-0] DEBUG liquibase.changelog - Running Changeset:migrations/000_migrations.yaml::97::senior
[clojure-agent-send-off-pool-0] DEBUG liquibase.executor - Changeset migrations/000_migrations.yaml::97::senior
[clojure-agent-send-off-pool-0] DEBUG liquibase.executor - Added 0.32.0
[clojure-agent-send-off-pool-0] INFO  liquibase.changelog - Marking ChangeSet: migrations/000_migrations.yaml::97::senior ran despite precondition failure due to onFail='MARK_RAN':
          liquibase.yaml : DBMS Precondition failed: expected null, got h2

[clojure-agent-send-off-pool-0] DEBUG liquibase.changelog - Skipping ChangeSet: migrations/000_migrations.yaml::97::senior
[clojure-agent-send-off-pool-0] DEBUG liquibase.executor - Executing with the 'jdbc' executor
[clojure-agent-send-off-pool-0] DEBUG liquibase.executor - 1 row(s) affected
```

After this change the output changes to:
```
[clojure-agent-send-off-pool-0] DEBUG liquibase.changelog - Running Changeset:migrations/000_migrations.yaml::97::senior
[clojure-agent-send-off-pool-0] DEBUG liquibase.executor - Changeset migrations/000_migrations.yaml::97::senior
[clojure-agent-send-off-pool-0] DEBUG liquibase.executor - Added 0.32.0
[clojure-agent-send-off-pool-0] INFO  liquibase.changelog - Marking ChangeSet: migrations/000_migrations.yaml::97::senior ran despite precondition failure due to onFail='MARK_RAN':
          liquibase.yaml : DBMS Precondition failed: expected mysql,mariadb, got h2

[clojure-agent-send-off-pool-0] DEBUG liquibase.changelog - Skipping ChangeSet: migrations/000_migrations.yaml::97::senior
[clojure-agent-send-off-pool-0] DEBUG liquibase.executor - Executing with the 'jdbc' executor
[clojure-agent-send-off-pool-0] DEBUG liquibase.executor - 1 row(s) affected
```

For documentation of the syntax cf.
 https://docs.liquibase.com/concepts/advanced/preconditions.html
