### PR TITLE
Update H2 from 1.4.197 to 1.4.200

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -91,7 +91,7 @@
                  it.unimi.dsi/fastutil]]
    [com.draines/postal "2.0.3"]                                       ; SMTP library
    [com.google.guava/guava "28.2-jre"]                                ; dep for BigQuery, Spark, and GA. Require here rather than letting different dep versions stomp on each other — see comments on #9697
-   [com.h2database/h2 "1.4.197"]                                      ; embedded SQL database
+   [com.h2database/h2 "1.4.200"]                                      ; embedded SQL database
    [com.taoensso/nippy "2.14.0"]                                      ; Fast serialization (i.e., GZIP) library for Clojure
    [commons-codec/commons-codec "1.15"]                               ; Apache Commons -- useful codec util fns
    [commons-io/commons-io "2.8.0"]                                    ; Apache Commons -- useful IO util fns


### PR DESCRIPTION
Hundreds of bugs have been fixed:
 https://h2database.com/html/changelog.html
