### PR TITLE
Use ExternalLink to automatically use noopener/noreferrer

### DIFF
--- a/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx
@@ -43,7 +43,7 @@ export default class SettingsUpdatesForm extends Component {
               {jt`You're running ${formatVersion(currentVersion)}`}
             </span>
             <ExternalLink
-              dataMetabaseEvent={
+              data-metabase-event={
                 "Updates Settings; Update link clicked; " + latestVersion
               }
               className="Button Button--white Button--medium borderless"
@@ -52,7 +52,6 @@ export default class SettingsUpdatesForm extends Component {
                 latestVersion +
                 "/operations-guide/upgrading-metabase.html"
               }
-              target="_blank"
             >
               {t`Update`}
             </ExternalLink>

--- a/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx
@@ -9,6 +9,7 @@ import SettingsSetting from "./SettingsSetting";
 import HostingInfoLink from "metabase/admin/settings/components/widgets/HostingInfoLink";
 import Icon from "metabase/components/Icon";
 import Text from "metabase/components/type/Text";
+import ExternalLink from "metabase/components/ExternalLink";
 
 export default class SettingsUpdatesForm extends Component {
   static propTypes = {
@@ -41,8 +42,8 @@ export default class SettingsUpdatesForm extends Component {
               {jt`Metabase ${formatVersion(latestVersion)} is available.`}{" "}
               {jt`You're running ${formatVersion(currentVersion)}`}
             </span>
-            <a
-              data-metabase-event={
+            <ExternalLink
+              dataMetabaseEvent={
                 "Updates Settings; Update link clicked; " + latestVersion
               }
               className="Button Button--white Button--medium borderless"
@@ -54,7 +55,7 @@ export default class SettingsUpdatesForm extends Component {
               target="_blank"
             >
               {t`Update`}
-            </a>
+            </ExternalLink>
           </div>
 
           <div


### PR DESCRIPTION
This is to tweak the version update message so as to resolve the code scanning warning: https://github.com/metabase/metabase/security/code-scanning/11