### PR TITLE
Dashboard: do not break filter dropdown

### DIFF
--- a/frontend/src/metabase/components/TokenField.jsx
+++ b/frontend/src/metabase/components/TokenField.jsx
@@ -172,7 +172,7 @@ export default class TokenField extends Component {
   }
 
   _updateFilteredValues = (props: Props) => {
-    let { options, value, removeSelected, filterOption } = props;
+    let { options = [], value, removeSelected, filterOption } = props;
     let { searchValue, selectedOptionValue } = this.state;
     const selectedValues = new Set(value.map(v => JSON.stringify(v)));
 


### PR DESCRIPTION
Guard against undefined `options` passed from FieldValuesWidget to the TokenField component, which happens in some cases (introduced in PR #13481).

This should fix #16112.

To reproduce, follow the steps in #16112 (copied here for convenient) while opening the Dev Tools:

1. Admin > Data Model > Sample Dataset > Reviews > Reviewer > set as Category and "A list of all values"
Do the same for Rating field
2. Admin > People > create a user "U1"
3. Admin > Permissions > Sample Dataset > revoke permissions for Reviews
4. Simple question > Sample Dataset > Reviews - save as "Q1" and add to dashboard
5. On dashboard, create a category filter and link to "Q1".Reviewer and another category for "Q1".Rating - save dashboard - test that it works as admin
6. Login as "U1" - go to dashboard - clicking Reviewer filter.

**Before**

The dropdown flickers in a lot, it's practically unusable. This is due to an uncaught JavaScript exception.

![image](https://user-images.githubusercontent.com/7288/118561452-da57fa00-b71f-11eb-955f-1cf7f0c73faa.png)

**After**

![image](https://user-images.githubusercontent.com/7288/118561510-ef348d80-b71f-11eb-8ee9-41f2f14a2cac.png)
