### PR TITLE
Don't cast in the outer select when inner select will

### DIFF
--- a/test/metabase/driver/sql/query_processor_test.clj
+++ b/test/metabase/driver/sql/query_processor_test.clj
@@ -489,5 +489,7 @@
                                    s/Str
                                    (s/pred #(instance? java.time.temporal.Temporal %)))
                                  "date")
-                          (s/one s/Int "expression")]
+                          (s/one (if (#{:oracle} driver/*driver*)
+                                   (s/pred decimal? 'decimal) ;; oracle returns 1M annoyingly
+                                   s/Int) "expression")]
                          (-> results :data :rows first)))))))))

--- a/test/metabase/driver/sql/query_processor_test.clj
+++ b/test/metabase/driver/sql/query_processor_test.clj
@@ -472,7 +472,7 @@
                :limit       3}))))))
 
 (deftest expressions-and-coercions-test
-  (mt/test-drivers (sql-jdbc.tu/sql-jdbc-drivers)
+  (mt/test-drivers (conj (sql-jdbc.tu/sql-jdbc-drivers) :bigquery)
     (testing "Don't cast in both inner select and outer select when expression (#12430)"
       (mt/with-temp-copy-of-db
         (let [price-field-id (data/id :venues :price)]

--- a/test/metabase/driver/sql/query_processor_test.clj
+++ b/test/metabase/driver/sql/query_processor_test.clj
@@ -482,7 +482,6 @@
                                                         :fields       [[:field price-field-id nil]
                                                                        [:expression "test"]]}
                                            :type       "query"})]
-            ;; middleware turns date objects into strings, so just make sure they are "date" strings
-            (is (schema= [(s/one (s/pred #(re-matches #"1970-.*Z" %)) "date")
-                          (s/one s/Int "expression")]
+            (is (schema= [(s/one s/Str "date")
+                          (s/one s/Num "expression")]
                          (-> results mt/rows first)))))))))


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/12430

Expressions create subselects

```clojure
(-> {:database 1,
     :query {:source-table 2
             :expressions {:test ["*" 1 1]}  ;; simple expression
             :fields [[:field 2 nil]  ;; orders.quantity with Coercion/UNIXSeconds->DateTime
                      [:expression "test"]]}
     :type "query"
     :parameters []}
    qp/process-query
    (update-in [:data :rows] count)
    pprint)
```

```sql
SELECT "source"."QUANTITY" AS "QUANTITY",
       "source"."test" AS "test"
FROM (SELECT timestampadd('second', "PUBLIC"."ORDERS"."QUANTITY", timestamp '1970-01-01T00:00:00Z')
     AS "QUANTITY",
     (1 * 1) AS "test"
     FROM "PUBLIC"."ORDERS") "source"
LIMIT 1048575
```

The bug was that source quantity was marked as a coerced integer to
timestamp, and it coerced in both the inner and outer select.

There's of course a few ways to solve this:
- the easiest way is when fetching the field information, throw away
the coercion strategy. Didn't want to do this as less information gets
confusing. Preferred to add information about _why_ it should be
ignored rather than just suppressing information.
- (solution here) add a marker to just not coerce on the outer
select.

The metadata is a bit strange to me. I'm honestly not sure what it
should be. What is the base type, effective type, and coercion
strategies of the things returned? At the moment they are:

```clojure
{:semantic_type :type/Quantity,
 :coercion_strategy :Coercion/UNIXSeconds->DateTime,
 :name "QUANTITY",
 :field_ref [:field 2 nil],
 :effective_type :type/Instant
 :base_type :type/DateTime}
```

Should this still have coercion information and a base type of
integer (ie, promote the inner field type's information to the
toplevel) or is this properly the type information now?

Draft until i add some tests.