### PR TITLE
Fix UX bugs in ExpressionWidget

### DIFF
--- a/frontend/src/metabase/components/AccordionList.jsx
+++ b/frontend/src/metabase/components/AccordionList.jsx
@@ -51,7 +51,9 @@ export default class AccordionList extends Component {
     className: PropTypes.string,
     id: PropTypes.string,
 
-    width: PropTypes.number,
+    // TODO: pass width to this component as solely number or string if possible
+    // currently prop is number on initialization, then string afterwards
+    width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     maxHeight: PropTypes.number,
 
     sections: PropTypes.array.isRequired,
@@ -348,9 +350,10 @@ export default class AccordionList extends Component {
             ...style,
           }}
         >
-          {rows.map(row => (
+          {rows.map((row, index) => (
             <AccordionListCell
               {...this.props}
+              key={`accordion-list-cell-${index}`}
               row={row}
               sections={sections}
               onChange={this.handleChange}
@@ -486,8 +489,9 @@ const AccordionListCell = ({
             },
           )}
           onClick={
-            sectionIsTogglable(sectionIndex) &&
-            (() => toggleSection(sectionIndex))
+            sectionIsTogglable(sectionIndex)
+              ? () => toggleSection(sectionIndex)
+              : undefined
           }
         >
           {icon && (

--- a/frontend/src/metabase/components/Popover.jsx
+++ b/frontend/src/metabase/components/Popover.jsx
@@ -128,7 +128,7 @@ export default class Popover extends Component {
 
   _popoverComponent() {
     const childProps = {
-      maxHeight: this._getMaxHeight(),
+      "max-height": this._getMaxHeight(),
     };
     const content = (
       <div

--- a/frontend/src/metabase/components/TooltipPopover.jsx
+++ b/frontend/src/metabase/components/TooltipPopover.jsx
@@ -22,8 +22,8 @@ const TooltipPopover = ({ children, constrainedWidth, ...props }) => {
       targetOffsetY={10}
       hasArrow
       horizontalAttachments={["center", "left", "right"]}
-      // OnClickOutsideWrapper is unecessary and causes existing popovers not to
-      // be dismissed if a tooltip is visisble, so pass noOnClickOutsideWrapper
+      // OnClickOutsideWrapper is unnecessary and causes existing popovers to
+      // not be dismissed if a tooltip is visible, so pass noOnClickOutsideWrapper
       noOnClickOutsideWrapper
       {...props}
     >
@@ -33,7 +33,7 @@ const TooltipPopover = ({ children, constrainedWidth, ...props }) => {
 };
 
 TooltipPopover.defaultProps = {
-  // default to having a constrained toolip, which limits the width so longer strings wrap.
+  // default to having a constrained tooltip, which limits the width so longer strings wrap
   constrainedWidth: true,
 };
 

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -99,7 +99,7 @@ export default class ExpressionEditorTextfield extends React.Component {
     super();
     // memoize processSource for performance when editing previously seen source/targetOffset
     this._processSource = memoize(processSource, ({ source, targetOffset }) =>
-      // resovle should include anything that affect the results of processSource
+      // resolve should include anything that affects the results of processSource
       // except currently we exclude `startRule` and `query` since they shouldn't change
       [source, targetOffset].join(","),
     );

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx
@@ -16,7 +16,7 @@ export default class ExpressionWidget extends Component {
     query: PropTypes.object.isRequired,
     onChangeExpression: PropTypes.func.isRequired,
     onRemoveExpression: PropTypes.func,
-    onClose: PropTypes.func.isRequired,
+    onClose: PropTypes.func,
   };
 
   static defaultProps = {

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx
@@ -2,6 +2,8 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import cx from "classnames";
 import { t } from "ttag";
+import _ from "underscore";
+
 import ExpressionEditorTextfield from "./ExpressionEditorTextfield";
 import { isExpression } from "metabase/lib/expressions";
 import MetabaseSettings from "metabase/lib/settings";
@@ -29,10 +31,13 @@ export default class ExpressionWidget extends Component {
   }
 
   UNSAFE_componentWillReceiveProps(newProps) {
-    this.setState({
-      name: newProps.name,
-      expression: newProps.expression,
-    });
+    // we only refresh our state if we had no previous state OR if our expression changed
+    if (!this.state || !_.isEqual(this.props.expression, newProps.expression)) {
+      this.setState({
+        name: newProps.name,
+        expression: newProps.expression,
+      });
+    }
   }
 
   isValid() {

--- a/frontend/src/metabase/query_builder/components/expressions/TokenizedInput.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/TokenizedInput.jsx
@@ -11,11 +11,6 @@ import {
   getSelectionPosition,
 } from "metabase/lib/dom";
 
-const KEYCODE_BACKSPACE = 8;
-const KEYCODE_LEFT = 37;
-const KEYCODE_RIGHT = 39;
-const KEYCODE_FORWARD_DELETE = 46;
-
 export default class TokenizedInput extends Component {
   constructor(props) {
     super(props);
@@ -36,6 +31,7 @@ export default class TokenizedInput extends Component {
       return this.state.value;
     }
   }
+
   _setValue(value) {
     ReactDOM.findDOMNode(this).value = value;
     if (typeof this.props.onChange === "function") {
@@ -78,8 +74,7 @@ export default class TokenizedInput extends Component {
     // isTyping signals whether the user is typing characters (keyCode >= 65) vs. deleting / navigating with arrows / clicking to select
     const isTyping = this._isTyping;
     // also keep isTyping same when deleting
-    this._isTyping =
-      e.keyCode >= 65 || (e.keyCode === KEYCODE_BACKSPACE && isTyping);
+    this._isTyping = e.keyCode >= 65 || (e.key === "Backspace" && isTyping);
 
     const input = ReactDOM.findDOMNode(this);
 
@@ -103,8 +98,7 @@ export default class TokenizedInput extends Component {
         if (
           !isSelected &&
           !isTyping &&
-          ((atEnd && e.keyCode === KEYCODE_BACKSPACE) ||
-            (atStart && e.keyCode === KEYCODE_FORWARD_DELETE))
+          ((atEnd && e.key === "Backspace") || (atStart && e.key === "Delete"))
         ) {
           // not selected, not "typging", and hit backspace, so mark as "selected"
           element.classList.add("Expression-selected");
@@ -113,8 +107,7 @@ export default class TokenizedInput extends Component {
           return;
         } else if (
           isSelected &&
-          ((atEnd && e.keyCode === KEYCODE_BACKSPACE) ||
-            (atStart && e.keyCode === KEYCODE_FORWARD_DELETE))
+          ((atEnd && e.key === "Backspace") || (atStart && e.key === "Delete"))
         ) {
           // selected and hit backspace, so delete it
           element.parentNode.removeChild(element);
@@ -124,8 +117,8 @@ export default class TokenizedInput extends Component {
           return;
         } else if (
           isSelected &&
-          ((atEnd && e.keyCode === KEYCODE_LEFT) ||
-            (atStart && e.keyCode === KEYCODE_RIGHT))
+          ((atEnd && e.key === "ArrowLeft") ||
+            (atStart && e.key === "ArrowRight"))
         ) {
           // selected and hit left arrow, so enter "typing" mode and unselect it
           element.classList.remove("Expression-selected");

--- a/frontend/src/metabase/query_builder/components/expressions/TokenizedInput.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/TokenizedInput.jsx
@@ -1,7 +1,7 @@
-/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import ReactDOM from "react-dom";
 import ReactDOMServer from "react-dom/server";
+import PropTypes from "prop-types";
 
 import TokenizedExpression from "./TokenizedExpression";
 
@@ -181,3 +181,17 @@ export default class TokenizedInput extends Component {
     );
   }
 }
+
+TokenizedInput.propTypes = {
+  className: PropTypes.string,
+  onBlur: PropTypes.func,
+  onChange: PropTypes.func,
+  onClick: PropTypes.func,
+  onFocus: PropTypes.func,
+  onKeyDown: PropTypes.func,
+  parserOptions: PropTypes.object,
+  style: PropTypes.object,
+  syntaxTree: PropTypes.object,
+  tokenizedEditing: PropTypes.bool,
+  value: PropTypes.string,
+};

--- a/frontend/src/metabase/query_builder/components/notebook/Notebook.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/Notebook.jsx
@@ -9,7 +9,7 @@ import Button from "metabase/components/Button";
 
 import NotebookSteps from "./NotebookSteps";
 
-const getCleanQuestion = (question) => {
+const getCleanQuestion = question => {
   const cleanQuery = question.query().clean();
 
   let cleanQuestion = question.setQuery(cleanQuery);
@@ -18,7 +18,7 @@ const getCleanQuestion = (question) => {
   }
 
   return cleanQuestion;
-}
+};
 
 export default function Notebook({ className, ...props }) {
   const {
@@ -40,18 +40,13 @@ export default function Notebook({ className, ...props }) {
     if (isResultDirty) {
       await runQuestionQuery();
     }
-  }
+  };
 
   return (
     <Box className={cx(className, "relative mb4")} px={[2, 3]}>
       <NotebookSteps {...props} />
       {isRunnable && (
-        <Button
-          medium
-          primary
-          style={{ minWidth: 220 }}
-          onClick={handleClick}
-        >
+        <Button medium primary style={{ minWidth: 220 }} onClick={handleClick}>
           {t`Visualize`}
         </Button>
       )}
@@ -66,4 +61,4 @@ Notebook.propTypes = {
   isResultDirty: PropTypes.bool.isRequired,
   runQuestionQuery: PropTypes.func.isRequired,
   setQueryBuilderMode: PropTypes.func.isRequired,
-}
+};

--- a/frontend/src/metabase/query_builder/components/notebook/Notebook.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/Notebook.jsx
@@ -1,5 +1,5 @@
-/* eslint-disable react/prop-types */
 import React from "react";
+import PropTypes from "prop-types";
 
 import { t } from "ttag";
 import cx from "classnames";
@@ -9,6 +9,17 @@ import Button from "metabase/components/Button";
 
 import NotebookSteps from "./NotebookSteps";
 
+const getCleanQuestion = (question) => {
+  const cleanQuery = question.query().clean();
+
+  let cleanQuestion = question.setQuery(cleanQuery);
+  if (cleanQuestion.display() === "table") {
+    cleanQuestion = cleanQuestion.setDefaultDisplay();
+  }
+
+  return cleanQuestion;
+}
+
 export default function Notebook({ className, ...props }) {
   const {
     question,
@@ -17,6 +28,20 @@ export default function Notebook({ className, ...props }) {
     runQuestionQuery,
     setQueryBuilderMode,
   } = props;
+
+  const handleClick = async () => {
+    const cleanQuestion = getCleanQuestion(question);
+
+    await cleanQuestion.update();
+
+    // switch mode before running otherwise URL update may cause it to switch back to notebook mode
+    await setQueryBuilderMode("view");
+
+    if (isResultDirty) {
+      await runQuestionQuery();
+    }
+  }
+
   return (
     <Box className={cx(className, "relative mb4")} px={[2, 3]}>
       <NotebookSteps {...props} />
@@ -25,22 +50,20 @@ export default function Notebook({ className, ...props }) {
           medium
           primary
           style={{ minWidth: 220 }}
-          onClick={async () => {
-            let cleanQuestion = question.setQuery(question.query().clean());
-            if (cleanQuestion.display() === "table") {
-              cleanQuestion = cleanQuestion.setDefaultDisplay();
-            }
-            await cleanQuestion.update();
-            // switch mode before running otherwise URL update may cause it to switch back to notebook mode
-            await setQueryBuilderMode("view");
-            if (isResultDirty) {
-              await runQuestionQuery();
-            }
-          }}
+          onClick={handleClick}
         >
           {t`Visualize`}
         </Button>
       )}
     </Box>
   );
+}
+
+Notebook.propTypes = {
+  className: PropTypes.string,
+  question: PropTypes.object,
+  isRunnable: PropTypes.bool.isRequired,
+  isResultDirty: PropTypes.bool.isRequired,
+  runQuestionQuery: PropTypes.func.isRequired,
+  setQueryBuilderMode: PropTypes.func.isRequired,
 }

--- a/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
@@ -492,20 +492,22 @@ describe("scenarios > question > custom columns", () => {
     cy.button("Done").should("not.be.disabled");
   });
 
-  describe.skip("contentedtable field (metabase#15734)", () => {
+  describe("contentedtable field (metabase#15734)", () => {
     beforeEach(() => {
       // This is the default screen size but we need it explicitly set for this test because of the resize later on
       cy.viewport(1280, 800);
 
       openOrdersTable({ mode: "notebook" });
       cy.findByText("Custom column").click();
-      popover().within(() => {
-        cy.get("[contenteditable='true']")
+
+      cy.get("[contenteditable='true']")
           .as("formula")
-          .type("1+1")
-          .blur();
+
+      popover().within(() => {
+        _typeUsingGet("[contenteditable='true']", "1 + 1", 400);
+        _typeUsingPlaceholder("Something nice and descriptive", "Math");
       });
-      cy.findByPlaceholderText("Something nice and descriptive").type("Math");
+
       cy.button("Done").should("not.be.disabled");
     });
 
@@ -523,7 +525,7 @@ describe("scenarios > question > custom columns", () => {
      *  - Without it, test runner is too fast and the test resutls in false positive.
      *  - This gives it enough time to update the DOM. The same result can be achieved with `cy.wait(1)`
      */
-    it("should not erase CC formula and CC name when expression is incomplete (metabase#15734-2)", () => {
+    it.only("should not erase CC formula and CC name when expression is incomplete (metabase#15734-2)", () => {
       cy.get("@formula")
         .click()
         .type("{movetoend}{backspace}")

--- a/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
@@ -524,7 +524,7 @@ describe("scenarios > question > custom columns", () => {
      *  - Without it, test runner is too fast and the test results in false positive.
      *  - This gives it enough time to update the DOM. The same result can be achieved with `cy.wait(1)`
      */
-    it.skip("should not erase Custom column formula and Custom column name when expression is incomplete (metabase#16126)", () => {
+    it("should not erase Custom column formula and Custom column name when expression is incomplete (metabase#16126)", () => {
       cy.get("@formula")
         .click()
         .type("{movetoend}{backspace}")
@@ -535,7 +535,7 @@ describe("scenarios > question > custom columns", () => {
       cy.findByDisplayValue("Math");
     });
 
-    it.skip("should not erase Custom Column formula and Custom Column name on window resize (metabase#16127)", () => {
+    it("should not erase Custom Column formula and Custom Column name on window resize (metabase#16127)", () => {
       cy.viewport(1260, 800);
       cy.get("@formula").click(); /* See comment (1) above */
       cy.findByDisplayValue("Math");

--- a/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
@@ -536,7 +536,7 @@ describe("scenarios > question > custom columns", () => {
       cy.findByDisplayValue("Math");
     });
 
-    it.only("should not erase Custom Column formula and Custom Column name on window resize (metabase#16127)", () => {
+    it.skip("should not erase Custom Column formula and Custom Column name on window resize (metabase#16127)", () => {
       cy.viewport(1260, 800);
       cy.get("@formula").click(); /* See comment (1) above */
       cy.findByDisplayValue("Math");

--- a/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
@@ -500,8 +500,7 @@ describe("scenarios > question > custom columns", () => {
       openOrdersTable({ mode: "notebook" });
       cy.findByText("Custom column").click();
 
-      cy.get("[contenteditable='true']")
-          .as("formula")
+      cy.get("[contenteditable='true']").as("formula");
 
       popover().within(() => {
         _typeUsingGet("[contenteditable='true']", "1 + 1", 400);

--- a/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
@@ -492,7 +492,7 @@ describe("scenarios > question > custom columns", () => {
     cy.button("Done").should("not.be.disabled");
   });
 
-  describe("contentedtable field (metabase#15734)", () => {
+  describe("ExpressionEditorTextfield", () => {
     beforeEach(() => {
       // This is the default screen size but we need it explicitly set for this test because of the resize later on
       cy.viewport(1280, 800);
@@ -511,7 +511,7 @@ describe("scenarios > question > custom columns", () => {
       cy.button("Done").should("not.be.disabled");
     });
 
-    it("should not accidentally delete Custom Column formula value and/or Custom Column name (metabase#15734-1)", () => {
+    it("should not accidentally delete Custom Column formula value and/or Custom Column name (metabase#15734)", () => {
       cy.get("@formula")
         .click()
         .type("{movetoend}{leftarrow}{movetostart}{rightarrow}{rightarrow}")
@@ -525,7 +525,7 @@ describe("scenarios > question > custom columns", () => {
      *  - Without it, test runner is too fast and the test results in false positive.
      *  - This gives it enough time to update the DOM. The same result can be achieved with `cy.wait(1)`
      */
-    it.skip("should not erase Custom column formula and Custom column name when expression is incomplete (metabase#15734-2)", () => {
+    it.skip("should not erase Custom column formula and Custom column name when expression is incomplete (metabase#16126)", () => {
       cy.get("@formula")
         .click()
         .type("{movetoend}{backspace}")
@@ -536,7 +536,7 @@ describe("scenarios > question > custom columns", () => {
       cy.findByDisplayValue("Math");
     });
 
-    it.only("should not erase Custom Column formula and Custom Column name on window resize (metabase#15734-3)", () => {
+    it.only("should not erase Custom Column formula and Custom Column name on window resize (metabase#16127)", () => {
       cy.viewport(1260, 800);
       cy.get("@formula").click(); /* See comment (1) above */
       cy.findByDisplayValue("Math");

--- a/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
@@ -511,7 +511,7 @@ describe("scenarios > question > custom columns", () => {
       cy.button("Done").should("not.be.disabled");
     });
 
-    it("should not accidentally delete CC formula value and/or CC name (metabase#15734-1)", () => {
+    it("should not accidentally delete Custom Column formula value and/or Custom Column name (metabase#15734-1)", () => {
       cy.get("@formula")
         .click()
         .type("{movetoend}{leftarrow}{movetostart}{rightarrow}{rightarrow}")
@@ -522,23 +522,23 @@ describe("scenarios > question > custom columns", () => {
 
     /**
      * 1. Explanation for `cy.get("@formula").click();`
-     *  - Without it, test runner is too fast and the test resutls in false positive.
+     *  - Without it, test runner is too fast and the test results in false positive.
      *  - This gives it enough time to update the DOM. The same result can be achieved with `cy.wait(1)`
      */
-    it.only("should not erase CC formula and CC name when expression is incomplete (metabase#15734-2)", () => {
+    it.skip("should not erase Custom column formula and Custom column name when expression is incomplete (metabase#15734-2)", () => {
       cy.get("@formula")
         .click()
         .type("{movetoend}{backspace}")
         .blur();
       cy.findByText("Expected expression");
       cy.button("Done").should("be.disabled");
-      cy.get("@formula").click(); /* [1] */
+      cy.get("@formula").click(); /* See comment (1) above */
       cy.findByDisplayValue("Math");
     });
 
-    it("should not erase CC formula and CC name on window resize (metabase#15734-3)", () => {
+    it.only("should not erase Custom Column formula and Custom Column name on window resize (metabase#15734-3)", () => {
       cy.viewport(1260, 800);
-      cy.get("@formula").click(); /* [1] */
+      cy.get("@formula").click(); /* See comment (1) above */
       cy.findByDisplayValue("Math");
       cy.button("Done").should("not.be.disabled");
     });


### PR DESCRIPTION
⚠️ Will split this PR into one specifically about fixing the issues below, and another about secondary fixes and refactor.

Fixes #16126
Fixes #16127

Also fixes a few:

* `PropTypes`
* `unique key` react messages
* assorted warnings, such as one about `&&` in execution of `onClick` handler

## To Reproduce #16126

Issue: ExpressionEditor lost value when user clicked away from associated name input

1. Open orders table from a custom question
2. Click on the small grid icon to create custom column
3. Modal will appear and "Field formula" is `contenteditable` field
4. Type `1+1` (without spaces) as a field formula
5. Click on the description field (notice `1+1` got formatted as `1 + 1`) and type "Math" as description
6. Go back to the formula and delete the last digit `1` leaving the field as `1 + `
7. Click the name again (let's say you wanted to edit a typo or something)
8. Note that formula got erased together with the name of the CC

**Updated behavior**

Value is preserved when blurring from name input.

## To Reproduce #16127

Issue: ExpressionEditor lost value when user resizes browser window

1. Open orders table from a custom question
2. Click on the small grid icon to create custom column
3. Modal will appear and "Field formula" is `contenteditable` field
4. Type `1+1` (without spaces) as a field formula
5. Click on the description field (notice `1+1` got formatted as `1 + 1`) and type "Math" as description
6. Resize the window or open the dev tools
7. All your changes are now gone

**Updated behavior**

Both inputs' values be preserved when window is resized.

**Screenshot:**

![ ](https://p58.f1.n0.cdn.getcloudapp.com/items/qGuE7wk1/babc991e-3429-4b23-9753-7b5d0ac065e3.gif?source=viewer&v=17e697a509ce20d8663a64679d6fb191)