### PR TITLE
Update docs on disqualifying column names in custom questions

### DIFF
--- a/docs/users-guide/custom-questions.md
+++ b/docs/users-guide/custom-questions.md
@@ -22,7 +22,7 @@ There are some kinds of saved questions that can't be used as source data:
 - Google Analytics questions
 - Mongo questions
 - questions that use `Cumulative Sum` or `Cumulative Count` aggregations
-- questions that have columns that are named the same or similar thing, like `Count` and `Count 2`
+- questions that have columns which names end with `_2` (etc.)
 
 #### Filtering
 


### PR DESCRIPTION
Cards that have columns with the same name can still be used as a source for custom questions, same for „similar” columns like `Count 1`, `Count 2`. Disqualified are columns ending with `_2`. The code doesn’t actually ban suffixes with any other digits, but I’m guessing that they shouldn’t be used for the same reason. [Relevant source code](https://github.com/metabase/metabase/blob/master/src/metabase/api/database.clj#L80)
