### PR TITLE
#16122 Repro: Normal login errors are not surfaced if SSO is also active

### DIFF
--- a/frontend/test/metabase/scenarios/onboarding/auth/sso.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/auth/sso.cy.spec.js
@@ -13,23 +13,28 @@ describe("scenarios > auth > signin > SSO", () => {
   describe("OSS", () => {
     beforeEach(() => {
       cy.signOut();
+      cy.visit("/");
     });
 
     it("should show SSO button", () => {
-      cy.visit("/");
       cy.findByText("Sign in with Google");
       cy.findByText("Sign in with email");
     });
 
     it("should show login form when directed to sign in with email", () => {
-      cy.visit("/");
       cy.findByText("Sign in with email").click();
       cy.findByLabelText("Email address");
       cy.findByLabelText("Password");
-      cy.findByText("Sign in")
-        .closest("button")
-        .should("be.disabled");
+      cy.button("Sign in").should("be.disabled");
       cy.findByText("Sign in with Google").should("not.exist");
+    });
+
+    it.skip("should surface login errors with Google sign in enabled (metabase#16122)", () => {
+      cy.findByText("Sign in with email").click();
+      cy.findByLabelText("Email address").type("foo@bar.test");
+      cy.findByLabelText("Password").type("123");
+      cy.button("Sign in").click();
+      cy.contains("Password: did not match stored password");
     });
   });
 


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #16122

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/onboarding/auth/sso.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/118680249-de0e7e00-b7fe-11eb-9ab0-05d93ad0d91d.png)

Sanity check: test passing for SSO turned off
![image](https://user-images.githubusercontent.com/31325167/118680617-304f9f00-b7ff-11eb-85e5-84ce465ae246.png)


