### PR TITLE
Collections paging backend PoC

### DIFF
--- a/src/metabase/server/handler.clj
+++ b/src/metabase/server/handler.clj
@@ -8,6 +8,7 @@
             [metabase.server.middleware.json :as mw.json]
             [metabase.server.middleware.log :as mw.log]
             [metabase.server.middleware.misc :as mw.misc]
+            [metabase.server.middleware.paging :as mw.paging]
             [metabase.server.middleware.security :as mw.security]
             [metabase.server.middleware.session :as mw.session]
             [metabase.server.middleware.ssl :as mw.ssl]
@@ -30,6 +31,7 @@
    #'mw.security/add-security-headers        ; Add HTTP headers to API responses to prevent them from being cached
    #'mw.json/wrap-json-body                  ; extracts json POST body and makes it avaliable on request
    #'mw.json/wrap-streamed-json-response     ; middleware to automatically serialize suitable objects as JSON in responses
+   #'mw.paging/handle-paging
    #'wrap-keyword-params                     ; converts string keys in :params to keyword keys
    #'wrap-params                             ; parses GET and POST params as :query-params/:form-params and both as :params
    #'mw.misc/maybe-set-site-url              ; set the value of `site-url` if it hasn't been set yet

--- a/src/metabase/server/middleware/paging.clj
+++ b/src/metabase/server/middleware/paging.clj
@@ -1,0 +1,53 @@
+(ns metabase.server.middleware.paging
+  (:require [medley.core :as m]
+            [metabase.util.i18n :refer [tru]]))
+
+(def ^:private default-limit 50)
+
+(def ^:dynamic *limit* default-limit)
+
+(def ^:dynamic *offset* 0)
+
+(def ^:dynamic *paged?* false)
+
+(defn- paged? [{{:strs [page limit]} :query-params}]
+  (or page limit))
+
+(defn- parse-paging-params [{{:strs [limit offset]} :query-params}]
+  (let [limit (or (some-> limit Integer/parseUnsignedInt)
+                  default-limit)
+        offset  (or (some-> offset Integer/parseUnsignedInt)
+                    0)]
+    {:limit limit, :offset offset}))
+
+(defn- with-paging-params [request {:keys [limit offset]}]
+  (-> request
+      (assoc ::limit limit, ::offset offset)
+      (m/dissoc-in [:query-params "offset"])
+      (m/dissoc-in [:query-params "limit"])
+      (m/dissoc-in [:params :offset])
+      (m/dissoc-in [:params :limit])))
+
+(defn handle-paging
+  [handler]
+  (fn [request respond raise]
+    (if-not (paged? request)
+      (handler request respond raise)
+      (let [paging-params (try
+                            (parse-paging-params request)
+                            (catch Throwable e
+                              e))]
+        (if (instance? Throwable paging-params)
+          (let [^Throwable e paging-params]
+            (respond {:status  400
+                      :headers (mw.security/security-headers)
+                      :body    (merge
+                                (Throwable->map e)
+                                {:message (tru "Error parsing paging parameters: {0}" (ex-message e))})}))
+          (let [{:keys [limit offset]} paging-params
+                request                (with-paging-params request paging-params)]
+            (binding [*limit*  limit
+                      *offset* offset
+                      *paged?* true]
+              (println "Request is paged! LIMIT =" limit "OFFSET = " offset) ; NOCOMMIT
+              (handler request respond raise))))))))

--- a/test/metabase/server/middleware/paging_test.clj
+++ b/test/metabase/server/middleware/paging_test.clj
@@ -1,0 +1,44 @@
+(ns metabase.server.middleware.paging-test
+  (:require [clojure.test :refer :all]
+            [metabase.server.middleware.paging :as mw.paging]
+            [ring.middleware.keyword-params :refer [wrap-keyword-params]]
+            [ring.middleware.params :refer [wrap-params]]
+            [ring.mock.request :as ring.mock]
+            [ring.util.response :as response]
+            [schema.core :as s]))
+
+(defn- handler [request]
+  (let [handler (-> (fn [request respond _]
+                      (respond (response/response {:limit  mw.paging/*limit*
+                                                   :offset mw.paging/*offset*
+                                                   :paged? mw.paging/*paged?*
+                                                   :params (:params request)})))
+                    mw.paging/handle-paging
+                    wrap-keyword-params
+                    wrap-params)
+        respond identity
+        raise   (fn [e] (throw e))]
+    (handler request respond raise)))
+
+(deftest paging-test
+  (testing "no paging params"
+    (is (= {:status  200
+            :headers {}
+            :body    {:limit  @#'mw.paging/default-limit
+                      :offset 0
+                      :paged? false
+                      :params {}}}
+           (handler (ring.mock/request :get "/")))))
+  (testing "w/ paging params"
+    (is (= {:status  200
+            :headers {}
+            :body    {:limit  100
+                      :offset 200
+                      :paged? true
+                      :params {:whatever "true"}}}
+           (handler (ring.mock/request :get "/" {:offset "200", :limit "100", :whatever "true"})))))
+  (testing "invalid params"
+    (is (schema= {:status  (s/eq 400)
+                  :headers s/Any
+                  :body {:message #"Error parsing paging parameters.*" s/Keyword s/Any}}
+                 (handler (ring.mock/request :get "/" {:offset "abc", :limit "100"}))))))


### PR DESCRIPTION
Demo/PoC for implementing Collections paging where we don't have to do limit and offset in-memory in Clojure land.

```clj
(binding [paging/*limit* 5
          paging/*offset* 5]
  (collection-children collection/root-collection {:models [:card :dashboard]}))

;; =>
{:total 16,
 :rows
 ({:id 9478,
   :name "Birthday Card",
   :description nil,
   :collection_position nil,
   :display "table",
   :model "card",
   :favorite false}
  {:id 8157,
   :name "COUUDXXHOJEXVZGQJRCY",
   :description nil,
   :collection_position nil,
   :display "table",
   :model "card",
   :favorite false}
  {:id 8158,
   :name "EPWVOFWLMUWSZTVNZUHF",
   :description nil,
   :collection_position nil,
   :display "table",
   :model "card",
   :favorite false}
  {:id 2171, :name "Dine & Dashboard", :description nil, :collection_position nil, :model "dashboard"}
  {:id 480, :name "FSAUFFKHCQDRRMBVEUQJ", :description nil, :collection_position nil, :model "dashboard"}),
 :limit 5,
 :offset 5,
 :models (:card :dashboard)}
```

I didn't document the `paging` middleware, but otherwise it's pretty close to complete -- I wrote tests for it here. The Collections children implementation isn't complete -- I only implemented `:card` and `:dashboard` -- but it's enough to demo the basic pattern to follow to get it working.
