### PR TITLE
Fix a regression in getting the default dimension

### DIFF
--- a/frontend/src/metabase-lib/lib/Dimension.js
+++ b/frontend/src/metabase-lib/lib/Dimension.js
@@ -784,6 +784,11 @@ export class FieldDimension extends Dimension {
       dimension = dimension.withJoinAlias(joinAlias);
     }
 
+    const baseType = this.getOption("base-type");
+    if (baseType) {
+      dimension = dimension.withOption("base-type", baseType);
+    }
+
     return dimension;
   }
 

--- a/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
@@ -266,7 +266,7 @@ describe("Dimension", () => {
 
   // TODO -- there are some tests against fields that can be binned above -- we should merge them in with these ones
   describe("Numeric Field that can be binned", () => {
-    const mbql = ["field", ORDERS.TOTAL.id, null];
+    const mbql = ["field", ORDERS.TOTAL.id, { "base-type": "type/Float" }];
     const dimension = Dimension.parseMBQL(mbql, metadata);
 
     describe("INSTANCE METHODS", () => {
@@ -284,6 +284,7 @@ describe("Dimension", () => {
             "field",
             ORDERS.TOTAL.id,
             {
+              "base-type": "type/Float",
               binning: {
                 strategy: "default",
               },

--- a/frontend/test/metabase/scenarios/question/nested.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nested.cy.spec.js
@@ -528,7 +528,7 @@ describe("scenarios > question > nested", () => {
     }
   });
 
-  describe.skip("should not remove user defined metric when summarizing based on saved question (metabase#15725)", () => {
+  describe("should not remove user defined metric when summarizing based on saved question (metabase#15725)", () => {
     beforeEach(() => {
       cy.intercept("POST", "/api/dataset").as("dataset");
       cy.createNativeQuestion({


### PR DESCRIPTION
Restore the behavior back when BinnedDimension still existed (before the MBQL field refactoring): keep the base type in the default dimension. This should fix #15725.

Run the unit test:
```
yarn test-unit frontend/test/metabase-lib/lib/Dimension.unit.spec.js
```

and the E2E test:
```
yarn test-cypress-no-build --spec frontend/test/metabase/scenarios/question/nested.cy.spec.js
```

For manual repro, following the steps in #15725 (copied here for convenient):

1. Ask a question, Native query
2. Type `select 'A' as cat, 5 as val` and run it and save it as _SQL1_
3. Ask a question, simple question.
4. From Saved Question, choose _SQL1_
5. Summarize, Add a metric, Sum of `VAL`
6. Group by `CAT`, Done

**Before this PR**

It's impossible to complete because half-way, there is an error:

![image](https://user-images.githubusercontent.com/7288/118739438-545eb080-b7fe-11eb-8ea0-2290edce5123.png)

**After this PR**

![image](https://user-images.githubusercontent.com/7288/118739499-7bb57d80-b7fe-11eb-9cfd-713fae99ae9b.png)
