### PR TITLE
Let users create moderation requests and let admins create moderation reviews (on questions)

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/CreateModerationIssuePanel.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/CreateModerationIssuePanel.jsx
@@ -50,7 +50,7 @@ function CreateModerationIssuePanel({
 
   const isPending = isModerationRequestPending || isModerationReviewPending;
 
-  const onCreateModerationReview = async e => {
+  const onCreateModerationIssue = async e => {
     e.preventDefault();
 
     if (isModerator) {
@@ -75,7 +75,7 @@ function CreateModerationIssuePanel({
 
   return (
     <form
-      onSubmit={onCreateModerationReview}
+      onSubmit={onCreateModerationIssue}
       className="p2 flex flex-column row-gap-2"
     >
       <div className={cx(textColorClass, "flex align-center")}>

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/CreateModerationIssuePanel.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/CreateModerationIssuePanel.jsx
@@ -63,7 +63,11 @@ function CreateModerationIssuePanel({
         moderationRequest,
       });
     } else {
-      await createModerationRequest({});
+      await createModerationRequest({
+        type: issueType,
+        cardId: itemId,
+        description,
+      });
     }
 
     onReturn();

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationIssueActionMenu.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationIssueActionMenu.jsx
@@ -28,7 +28,7 @@ function ModerationIssueActionMenu({
   isModerator,
 }) {
   const userType = getUserTypeTextKey(isModerator);
-  const types = getModerationIssueActionTypes(userType, request);
+  const issueTypes = getModerationIssueActionTypes(userType, request);
   return (
     <EntityMenu
       triggerChildren={MODERATION_TEXT[userType].action}
@@ -37,15 +37,15 @@ function ModerationIssueActionMenu({
         className: triggerClassName,
       }}
       className={className}
-      items={types.map(type => {
-        const color = getColor(type);
-        const icon = getModerationStatusIcon(type);
+      items={issueTypes.map(issueType => {
+        const color = getColor(issueType);
+        const icon = getModerationStatusIcon(issueType);
         return {
           icon,
           iconSize: 18,
           className: `text-${color}`,
-          action: () => onAction(type),
-          title: MODERATION_TEXT[userType][type].action,
+          action: () => onAction(issueType),
+          title: MODERATION_TEXT[userType][issueType].action,
         };
       })}
     />

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationIssueActionMenu.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationIssueActionMenu.jsx
@@ -28,7 +28,8 @@ function ModerationIssueActionMenu({
   isModerator,
 }) {
   const userType = getUserTypeTextKey(isModerator);
-  const issueTypes = getModerationIssueActionTypes(userType, request);
+  const issueTypes = getModerationIssueActionTypes(isModerator, request);
+
   return (
     <EntityMenu
       triggerChildren={MODERATION_TEXT[userType].action}

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationIssueActionMenu.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationIssueActionMenu.jsx
@@ -4,25 +4,34 @@ import PropTypes from "prop-types";
 import EntityMenu from "metabase/components/EntityMenu";
 import { MODERATION_TEXT } from "metabase-enterprise/moderation/constants";
 import {
-  getModerationIssueTypes,
+  getModerationReviewActionTypes,
   getModerationRequestActionTypes,
   getColor,
   getModerationStatusIcon,
 } from "metabase-enterprise/moderation";
 
+ModerationIssueActionMenu.propTypes = {
+  className: PropTypes.string,
+  triggerClassName: PropTypes.string,
+  onAction: PropTypes.func,
+  request: PropTypes.object,
+  isAdmin: PropTypes.bool.isRequired,
+};
+
 function ModerationIssueActionMenu({
   className,
   triggerClassName,
   onAction,
-  issue,
+  request,
+  isAdmin,
 }) {
-  const types = issue
-    ? getModerationRequestActionTypes()
-    : getModerationIssueTypes();
-
+  const types = isAdmin
+    ? getModerationReviewActionTypes(request)
+    : getModerationRequestActionTypes();
+  const userType = isAdmin ? "moderator" : "user";
   return (
     <EntityMenu
-      triggerChildren={MODERATION_TEXT.moderator.action}
+      triggerChildren={MODERATION_TEXT[userType].action}
       triggerProps={{
         iconRight: "chevrondown",
         className: triggerClassName,
@@ -36,18 +45,11 @@ function ModerationIssueActionMenu({
           iconSize: 18,
           className: `text-${color}`,
           action: () => onAction(type),
-          title: MODERATION_TEXT.moderator[type].action,
+          title: MODERATION_TEXT[userType][type].action,
         };
       })}
     />
   );
 }
-
-ModerationIssueActionMenu.propTypes = {
-  className: PropTypes.string,
-  triggerClassName: PropTypes.string,
-  onAction: PropTypes.func,
-  issue: PropTypes.object,
-};
 
 export default ModerationIssueActionMenu;

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationIssueActionMenu.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationIssueActionMenu.jsx
@@ -1,21 +1,23 @@
 import React from "react";
 import PropTypes from "prop-types";
+import { connect } from "react-redux";
 
 import EntityMenu from "metabase/components/EntityMenu";
 import { MODERATION_TEXT } from "metabase-enterprise/moderation/constants";
 import {
-  getModerationReviewActionTypes,
-  getModerationRequestActionTypes,
+  getModerationIssueActionTypes,
   getColor,
   getModerationStatusIcon,
+  getUserTypeTextKey,
 } from "metabase-enterprise/moderation";
+import { getIsModerator } from "metabase-enterprise/moderation/selectors";
 
 ModerationIssueActionMenu.propTypes = {
   className: PropTypes.string,
   triggerClassName: PropTypes.string,
-  onAction: PropTypes.func,
+  isModerator: PropTypes.bool.isRequired,
+  onAction: PropTypes.func.isRequired,
   request: PropTypes.object,
-  isAdmin: PropTypes.bool.isRequired,
 };
 
 function ModerationIssueActionMenu({
@@ -23,12 +25,10 @@ function ModerationIssueActionMenu({
   triggerClassName,
   onAction,
   request,
-  isAdmin,
+  isModerator,
 }) {
-  const types = isAdmin
-    ? getModerationReviewActionTypes(request)
-    : getModerationRequestActionTypes();
-  const userType = isAdmin ? "moderator" : "user";
+  const userType = getUserTypeTextKey(isModerator);
+  const types = getModerationIssueActionTypes(userType, request);
   return (
     <EntityMenu
       triggerChildren={MODERATION_TEXT[userType].action}
@@ -52,4 +52,8 @@ function ModerationIssueActionMenu({
   );
 }
 
-export default ModerationIssueActionMenu;
+const mapStateToProps = (state, props) => ({
+  isModerator: getIsModerator(state, props),
+});
+
+export default connect(mapStateToProps)(ModerationIssueActionMenu);

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationIssueThread.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationIssueThread.jsx
@@ -15,37 +15,41 @@ import ModerationIssueActionMenu from "metabase-enterprise/moderation/components
 
 ModerationIssueThread.propTypes = {
   className: PropTypes.string,
-  issue: PropTypes.object.isRequired,
+  request: PropTypes.object.isRequired,
+  comments: PropTypes.array,
   onComment: PropTypes.func,
-  onResolve: PropTypes.func,
+  onModerate: PropTypes.func,
+  isAdmin: PropTypes.bool.isRequired,
 };
 
 const COMMMENT_VISIBLE_LINES = 3;
 
 export function ModerationIssueThread({
   className,
-  issue,
+  request,
+  comments = [],
   onComment,
-  onResolve,
+  onModerate,
+  isAdmin,
 }) {
-  const color = getColor(issue.type);
-  const icon = getModerationStatusIcon(issue.type);
-  const hasButtonBar = !!(onComment || onResolve);
+  const color = getColor(request.type);
+  const icon = getModerationStatusIcon(request.type);
+  const hasButtonBar = !!(onComment || onModerate);
 
   return (
     <div className={cx(className, "")}>
       <div className={`flex align-center text-${color} text-bold`}>
         <Icon name={icon} className="mr1" />
-        {MODERATION_TEXT.user[issue.type].action}
+        {MODERATION_TEXT.user[request.type].action}
       </div>
       <Comment
         className="pt1"
-        title={issue.title}
-        text={issue.text}
-        timestamp={issue.timestamp}
+        title={request.requesterDisplayName}
+        text={request.text}
+        timestamp={request.created_at}
         visibleLines={COMMMENT_VISIBLE_LINES}
       />
-      {issue.comments.map(comment => {
+      {comments.map(comment => {
         return (
           <Comment
             className="pt2"
@@ -63,11 +67,12 @@ export function ModerationIssueThread({
           {onComment && (
             <Button className="py1" onClick={onComment}>{t`Comment`}</Button>
           )}
-          {onResolve && (
+          {onModerate && (
             <ModerationIssueActionMenu
               triggerClassName="text-white text-white-hover bg-brand bg-brand-hover py1"
-              onAction={onResolve}
-              issue={issue}
+              onAction={actionType => onModerate(actionType, request)}
+              request={request}
+              isAdmin={isAdmin}
             />
           )}
         </div>

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationIssueThread.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationIssueThread.jsx
@@ -19,7 +19,6 @@ ModerationIssueThread.propTypes = {
   comments: PropTypes.array,
   onComment: PropTypes.func,
   onModerate: PropTypes.func,
-  isAdmin: PropTypes.bool.isRequired,
 };
 
 const COMMMENT_VISIBLE_LINES = 3;
@@ -30,7 +29,6 @@ export function ModerationIssueThread({
   comments = [],
   onComment,
   onModerate,
-  isAdmin,
 }) {
   const color = getColor(request.type);
   const icon = getModerationStatusIcon(request.type);
@@ -72,7 +70,6 @@ export function ModerationIssueThread({
               triggerClassName="text-white text-white-hover bg-brand bg-brand-hover py1"
               onAction={actionType => onModerate(actionType, request)}
               request={request}
-              isAdmin={isAdmin}
             />
           )}
         </div>

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/OpenModerationIssuesButton.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/OpenModerationIssuesButton.jsx
@@ -2,20 +2,19 @@ import React from "react";
 import PropTypes from "prop-types";
 import { ngettext, msgid } from "ttag";
 import cx from "classnames";
+import { getNumberOfOpenRequests } from "metabase-enterprise/moderation";
 
 import Button from "metabase/components/Button";
 
 OpenModerationIssuesButton.propTypes = {
-  numOpenIssues: PropTypes.number.isRequired,
+  question: PropTypes.object.isRequired,
   className: PropTypes.string,
   onClick: PropTypes.func.isRequired,
 };
 
-export function OpenModerationIssuesButton({
-  numOpenIssues,
-  className,
-  onClick,
-}) {
+export function OpenModerationIssuesButton({ question, className, onClick }) {
+  const numOpenIssues = getNumberOfOpenRequests(question);
+
   return numOpenIssues > 0 ? (
     <Button
       borderless

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/OpenModerationIssuesButton.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/OpenModerationIssuesButton.jsx
@@ -3,17 +3,19 @@ import PropTypes from "prop-types";
 import { ngettext, msgid } from "ttag";
 import cx from "classnames";
 
-import { getOpenIssues } from "metabase-enterprise/moderation";
-
 import Button from "metabase/components/Button";
 
 OpenModerationIssuesButton.propTypes = {
+  numOpenIssues: PropTypes.number.isRequired,
   className: PropTypes.string,
   onClick: PropTypes.func.isRequired,
 };
 
-export function OpenModerationIssuesButton({ className, onClick }) {
-  const numOpenIssues = getOpenIssues().length;
+export function OpenModerationIssuesButton({
+  numOpenIssues,
+  className,
+  onClick,
+}) {
   return numOpenIssues > 0 ? (
     <Button
       borderless

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/OpenModerationIssuesPanel.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/OpenModerationIssuesPanel.jsx
@@ -1,17 +1,56 @@
 import React from "react";
+import { connect } from "react-redux";
 import PropTypes from "prop-types";
 import { t } from "ttag";
+import _ from "underscore";
 
-import { getOpenIssues } from "metabase-enterprise/moderation";
+import User from "metabase/entities/users";
+import { getUser } from "metabase/selectors/user";
+
 import Button from "metabase/components/Button";
 import { ModerationIssueThread } from "metabase-enterprise/moderation/components/ModerationIssueThread";
 
+import { SIDEBAR_VIEWS } from "metabase/query_builder/components/view/sidebars/constants";
+
 OpenModerationIssuesPanel.propTypes = {
+  setView: PropTypes.func.isRequired,
+  requests: PropTypes.array.isRequired,
   onReturn: PropTypes.func.isRequired,
+  users: PropTypes.array,
+  isAdmin: PropTypes.bool.isRequired,
+  currentUser: PropTypes.object,
 };
 
-export function OpenModerationIssuesPanel({ onReturn }) {
-  const issues = getOpenIssues();
+function OpenModerationIssuesPanel({
+  setView,
+  requests,
+  onReturn,
+  users,
+  isAdmin,
+  currentUser,
+}) {
+  const usersById = users.reduce((map, user) => {
+    map[user.id] = user;
+    return map;
+  }, {});
+
+  const requestsWithMetadata = requests.map(request => {
+    const user = usersById[request.requester_id];
+    const requesterDisplayName = user && user.common_name;
+    return {
+      ...request,
+      requesterDisplayName,
+    };
+  });
+
+  const onModerate = async (moderationReviewType, moderationRequest) => {
+    setView({
+      name: SIDEBAR_VIEWS.CREATE_ISSUE_PANEL,
+      props: { issueType: moderationReviewType, moderationRequest },
+      previousView: SIDEBAR_VIEWS.OPEN_ISSUES_PANEL,
+    });
+  };
+
   return (
     <div className="px1">
       <div className="pt1">
@@ -23,14 +62,14 @@ export function OpenModerationIssuesPanel({ onReturn }) {
         >{t`Open issues`}</Button>
       </div>
       <div className="px2">
-        {issues.map(issue => {
+        {requestsWithMetadata.map(request => {
           return (
             <ModerationIssueThread
-              key={issue.id}
+              key={request.id}
               className="py2 border-row-divider"
-              issue={issue}
-              onComment={() => {}}
-              onResolve={() => {}}
+              request={request}
+              onModerate={isAdmin && onModerate}
+              isAdmin={isAdmin}
             />
           );
         })}
@@ -38,3 +77,13 @@ export function OpenModerationIssuesPanel({ onReturn }) {
     </div>
   );
 }
+
+export default _.compose(
+  User.loadList(),
+  connect(
+    state => ({
+      currentUser: getUser(state),
+    }),
+    null, //
+  ),
+)(OpenModerationIssuesPanel);

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/OpenModerationIssuesPanel.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/OpenModerationIssuesPanel.jsx
@@ -10,6 +10,7 @@ import { getUser } from "metabase/selectors/user";
 import Button from "metabase/components/Button";
 import { ModerationIssueThread } from "metabase-enterprise/moderation/components/ModerationIssueThread";
 
+import { getIsModerator } from "metabase-enterprise/moderation/selectors";
 import { SIDEBAR_VIEWS } from "metabase/query_builder/components/view/sidebars/constants";
 
 OpenModerationIssuesPanel.propTypes = {
@@ -17,7 +18,7 @@ OpenModerationIssuesPanel.propTypes = {
   requests: PropTypes.array.isRequired,
   onReturn: PropTypes.func.isRequired,
   users: PropTypes.array,
-  isAdmin: PropTypes.bool.isRequired,
+  isModerator: PropTypes.bool.isRequired,
   currentUser: PropTypes.object,
 };
 
@@ -26,7 +27,7 @@ function OpenModerationIssuesPanel({
   requests,
   onReturn,
   users,
-  isAdmin,
+  isModerator,
   currentUser,
 }) {
   const usersById = users.reduce((map, user) => {
@@ -68,8 +69,7 @@ function OpenModerationIssuesPanel({
               key={request.id}
               className="py2 border-row-divider"
               request={request}
-              onModerate={isAdmin && onModerate}
-              isAdmin={isAdmin}
+              onModerate={isModerator && onModerate}
             />
           );
         })}
@@ -78,12 +78,12 @@ function OpenModerationIssuesPanel({
   );
 }
 
+const mapStateToProps = (state, props) => ({
+  currentUser: getUser(state),
+  isModerator: getIsModerator(state, props),
+});
+
 export default _.compose(
   User.loadList(),
-  connect(
-    state => ({
-      currentUser: getUser(state),
-    }),
-    null, //
-  ),
+  connect(mapStateToProps),
 )(OpenModerationIssuesPanel);

--- a/enterprise/frontend/src/metabase-enterprise/moderation/constants.js
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/constants.js
@@ -1,7 +1,32 @@
 import { t } from "ttag";
 
+export const REQUEST_STATUSES = {
+  open: "open",
+  resolved: "resolved",
+  dismissed: "dismissed",
+};
+
+export const REQUEST_TYPES = {
+  verification_request: "verification_request",
+  something_wrong: "something_wrong",
+  confused: "confused",
+};
+
+export const REVIEW_STATUSES = {
+  verified: "verified",
+  misleading: "misleading",
+  confusing: "confusing",
+  not_misleading: "not_misleading",
+  pending: "pending",
+};
+
 export const ACTIONS = {
   verified: {
+    type: "verified",
+    icon: "verified",
+    color: "brand",
+  },
+  verification_request: {
     type: "verified",
     icon: "verified",
     color: "brand",
@@ -11,11 +36,20 @@ export const ACTIONS = {
     icon: "warning_colorized",
     color: "accent5",
   },
+  something_wrong: {
+    type: "misleading",
+    icon: "warning_colorized",
+    color: "accent5",
+  },
   confusing: {
     type: "confusing",
     icon: "clarification",
     color: "accent2",
-    moderationReviewStatus: "confusing",
+  },
+  confused: {
+    type: "confusing",
+    icon: "clarification",
+    color: "accent2",
   },
   dismiss: {
     type: "dismiss",
@@ -28,14 +62,24 @@ export const MODERATION_TEXT = {
   cancel: t`Cancel`,
   actionCreationPlaceholder: t`You can add details if you'd like`,
   user: {
-    verified: {
+    action: t`user action`,
+    verification_request: {
       action: t`Verify this`,
+      actionCreationDescription: t`verified actionCreationDescription`,
+      actionCreationLabel: t`verified actionCreationLabel`,
+      actionCreationButton: t`verified actionCreationButton`,
     },
-    misleading: {
+    something_wrong: {
       action: t`Something's wrong`,
+      actionCreationDescription: t` misleading actionCreationDescription`,
+      actionCreationLabel: t`misleading actionCreationLabel`,
+      actionCreationButton: t`misleading actionCreationButton`,
     },
-    confusing: {
+    confused: {
       action: t`I'm confused`,
+      actionCreationDescription: t`confusing actionCreationDescription`,
+      actionCreationLabel: t`confusing actionCreationLabel`,
+      actionCreationButton: t`confusing actionCreationButton`,
     },
   },
   moderator: {
@@ -60,6 +104,10 @@ export const MODERATION_TEXT = {
     },
     dismiss: {
       action: t`Dismiss`,
+      actionCreationDescription:
+        "You can let the requester know why you're dismissing their request.",
+      actionCreationLabel: "Add a note if you'd like",
+      actionCreationButton: "Dismiss request",
     },
   },
 };

--- a/enterprise/frontend/src/metabase-enterprise/moderation/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/index.js
@@ -34,10 +34,6 @@ export function getModerationIssueActionTypes(isModerator, moderationRequest) {
     : getModerationRequestActionTypes();
 }
 
-// todo -- update this to pass in the `issue` and filter out the action with the same "type"
-// ("type" may now mean "status"...)
-// because the primary action of the button will be the given issue type (see updated mocks).
-// second TODO -- I'm not sure how to reconcile the fact that "dismissed" is not really a review TYPE
 function getModerationReviewActionTypes(moderationRequest) {
   return [
     REVIEW_STATUSES.verified,

--- a/enterprise/frontend/src/metabase-enterprise/moderation/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/index.js
@@ -76,6 +76,10 @@ function isRequestOpen(request) {
   return request.status === REQUEST_STATUSES.open;
 }
 
+export function getNumberOfOpenRequests(question) {
+  return getOpenRequests(question).length;
+}
+
 export function isRequestDismissal(type) {
   return type === "dismiss";
 }

--- a/enterprise/frontend/src/metabase-enterprise/moderation/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/index.js
@@ -6,6 +6,7 @@ import {
 import {
   ACTIONS,
   REQUEST_TYPES,
+  REQUEST_STATUSES,
   REVIEW_STATUSES,
 } from "metabase-enterprise/moderation/constants";
 import ModerationIssueActionMenu from "metabase-enterprise/moderation/components/ModerationIssueActionMenu";
@@ -66,48 +67,11 @@ export function getColor(type) {
 
 export function getOpenRequests(question) {
   const moderationRequests = question.getModerationRequests();
-  return moderationRequests.filter(request => {
-    return request.status === "open";
-  });
+  return moderationRequests.filter(isRequestOpen);
+}
 
-  // return [
-  //   {
-  //     id: 1,
-  //     type: "verified",
-  //     title: "User 2",
-  //     text: "1\n2\n3\n4\n5\n6",
-  //     timestamp: Date.now(),
-  //     comments: [],
-  //   },
-  //   {
-  //     id: 2,
-  //     type: "misleading",
-  //     title: "User 2",
-  //     text:
-  //       "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras sit amet sagittis dui. Morbi in odio laoreet, finibus erat vitae, sagittis dui. Ut at mauris eget ligula volutpat pellentesque. Integer non faucibus urna. Maecenas faucibus ornare gravida. Aliquam orci tortor, ullamcorper et vehicula accumsan, malesuada in ipsum. Nullam auctor, justo et mattis fringilla, enim ipsum aliquet nunc, quis posuere odio erat in nulla. Suspendisse elementum, est et rutrum volutpat, purus mi placerat odio, sit amet blandit nulla diam at lectus. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Ut ultricies placerat mollis.",
-  //     timestamp: Date.now(),
-  //     comments: [
-  //       {
-  //         id: 1,
-  //         title: "Moderator",
-  //         isModerator: true,
-  //         text: "Nulla nec est eu est condimentum facilisis sit amet et ex.",
-  //         timestamp: Date.now(),
-  //       },
-  //     ],
-  //   },
-  // ];
-
-  // closed_by_id: null
-  // created_at: "2021-05-17T14:38:38.87-07:00"
-  // id: 1
-  // moderated_item_id: 1
-  // moderated_item_type: "card"
-  // requester_id: 1
-  // status: "open"
-  // text: "asdasdasdasdsadsd"
-  // type: "verification_request"
-  // updated_at: "2021-05-17T14:38:38.87-07:00"
+function isRequestOpen(request) {
+  return request.status === REQUEST_STATUSES.open;
 }
 
 export function isRequestDismissal(type) {

--- a/enterprise/frontend/src/metabase-enterprise/moderation/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/index.js
@@ -3,11 +3,15 @@ import {
   PLUGIN_MODERATION_COMPONENTS,
   PLUGIN_MODERATION_SERVICE,
 } from "metabase/plugins";
-import { ACTIONS } from "metabase-enterprise/moderation/constants";
+import {
+  ACTIONS,
+  REQUEST_TYPES,
+  REVIEW_STATUSES,
+} from "metabase-enterprise/moderation/constants";
 import ModerationIssueActionMenu from "metabase-enterprise/moderation/components/ModerationIssueActionMenu";
 import CreateModerationIssuePanel from "metabase-enterprise/moderation/components/CreateModerationIssuePanel";
 import { OpenModerationIssuesButton } from "metabase-enterprise/moderation/components/OpenModerationIssuesButton";
-import { OpenModerationIssuesPanel } from "metabase-enterprise/moderation/components/OpenModerationIssuesPanel";
+import OpenModerationIssuesPanel from "metabase-enterprise/moderation/components/OpenModerationIssuesPanel";
 
 Object.assign(PLUGIN_MODERATION_COMPONENTS, {
   ModerationIssueActionMenu,
@@ -19,14 +23,29 @@ Object.assign(PLUGIN_MODERATION_COMPONENTS, {
 Object.assign(PLUGIN_MODERATION_SERVICE, {
   getStatusIconForReview,
   getColorForReview,
+  getOpenRequests,
+  isRequestDismissal,
 });
 
-export function getModerationIssueTypes() {
-  return ["verified", "misleading", "confusing"];
+// todo -- update this to pass in the `issue` and filter out the action with the same "type"
+// ("type" may now mean "status"...)
+// because the primary action of the button will be the given issue type (see updated mocks).
+// second TODO -- I'm not sure how to reconcile the fact that "dismissed" is not really a review TYPE
+export function getModerationReviewActionTypes(moderationRequest) {
+  return [
+    REVIEW_STATUSES.verified,
+    REVIEW_STATUSES.misleading,
+    REVIEW_STATUSES.confusing,
+    ...(moderationRequest ? ["dismiss"] : []),
+  ];
 }
 
 export function getModerationRequestActionTypes() {
-  return [...getModerationIssueTypes(), "dismiss"];
+  return [
+    REQUEST_TYPES.verification_request,
+    REQUEST_TYPES.something_wrong,
+    REQUEST_TYPES.confused,
+  ];
 }
 
 export function getStatusIconForReview(review) {
@@ -45,32 +64,52 @@ export function getColor(type) {
   return getIn(ACTIONS, [type, "color"]);
 }
 
-export function getOpenIssues() {
-  return [
-    {
-      id: 1,
-      type: "verified",
-      title: "User 2",
-      text: "1\n2\n3\n4\n5\n6",
-      timestamp: Date.now(),
-      comments: [],
-    },
-    {
-      id: 2,
-      type: "misleading",
-      title: "User 2",
-      text:
-        "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras sit amet sagittis dui. Morbi in odio laoreet, finibus erat vitae, sagittis dui. Ut at mauris eget ligula volutpat pellentesque. Integer non faucibus urna. Maecenas faucibus ornare gravida. Aliquam orci tortor, ullamcorper et vehicula accumsan, malesuada in ipsum. Nullam auctor, justo et mattis fringilla, enim ipsum aliquet nunc, quis posuere odio erat in nulla. Suspendisse elementum, est et rutrum volutpat, purus mi placerat odio, sit amet blandit nulla diam at lectus. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Ut ultricies placerat mollis.",
-      timestamp: Date.now(),
-      comments: [
-        {
-          id: 1,
-          title: "Moderator",
-          isModerator: true,
-          text: "Nulla nec est eu est condimentum facilisis sit amet et ex.",
-          timestamp: Date.now(),
-        },
-      ],
-    },
-  ];
+export function getOpenRequests(question) {
+  const moderationRequests = question.getModerationRequests();
+  return moderationRequests.filter(request => {
+    return request.status === "open";
+  });
+
+  // return [
+  //   {
+  //     id: 1,
+  //     type: "verified",
+  //     title: "User 2",
+  //     text: "1\n2\n3\n4\n5\n6",
+  //     timestamp: Date.now(),
+  //     comments: [],
+  //   },
+  //   {
+  //     id: 2,
+  //     type: "misleading",
+  //     title: "User 2",
+  //     text:
+  //       "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras sit amet sagittis dui. Morbi in odio laoreet, finibus erat vitae, sagittis dui. Ut at mauris eget ligula volutpat pellentesque. Integer non faucibus urna. Maecenas faucibus ornare gravida. Aliquam orci tortor, ullamcorper et vehicula accumsan, malesuada in ipsum. Nullam auctor, justo et mattis fringilla, enim ipsum aliquet nunc, quis posuere odio erat in nulla. Suspendisse elementum, est et rutrum volutpat, purus mi placerat odio, sit amet blandit nulla diam at lectus. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Ut ultricies placerat mollis.",
+  //     timestamp: Date.now(),
+  //     comments: [
+  //       {
+  //         id: 1,
+  //         title: "Moderator",
+  //         isModerator: true,
+  //         text: "Nulla nec est eu est condimentum facilisis sit amet et ex.",
+  //         timestamp: Date.now(),
+  //       },
+  //     ],
+  //   },
+  // ];
+
+  // closed_by_id: null
+  // created_at: "2021-05-17T14:38:38.87-07:00"
+  // id: 1
+  // moderated_item_id: 1
+  // moderated_item_type: "card"
+  // requester_id: 1
+  // status: "open"
+  // text: "asdasdasdasdsadsd"
+  // type: "verification_request"
+  // updated_at: "2021-05-17T14:38:38.87-07:00"
+}
+
+export function isRequestDismissal(type) {
+  return type === "dismiss";
 }

--- a/enterprise/frontend/src/metabase-enterprise/moderation/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/index.js
@@ -28,11 +28,17 @@ Object.assign(PLUGIN_MODERATION_SERVICE, {
   isRequestDismissal,
 });
 
+export function getModerationIssueActionTypes(isModerator, moderationRequest) {
+  return isModerator
+    ? getModerationReviewActionTypes(moderationRequest)
+    : getModerationRequestActionTypes();
+}
+
 // todo -- update this to pass in the `issue` and filter out the action with the same "type"
 // ("type" may now mean "status"...)
 // because the primary action of the button will be the given issue type (see updated mocks).
 // second TODO -- I'm not sure how to reconcile the fact that "dismissed" is not really a review TYPE
-export function getModerationReviewActionTypes(moderationRequest) {
+function getModerationReviewActionTypes(moderationRequest) {
   return [
     REVIEW_STATUSES.verified,
     REVIEW_STATUSES.misleading,
@@ -41,7 +47,7 @@ export function getModerationReviewActionTypes(moderationRequest) {
   ];
 }
 
-export function getModerationRequestActionTypes() {
+function getModerationRequestActionTypes() {
   return [
     REQUEST_TYPES.verification_request,
     REQUEST_TYPES.something_wrong,
@@ -76,4 +82,8 @@ function isRequestOpen(request) {
 
 export function isRequestDismissal(type) {
   return type === "dismiss";
+}
+
+export function getUserTypeTextKey(isModerator) {
+  return isModerator ? "moderator" : "user";
 }

--- a/enterprise/frontend/src/metabase-enterprise/moderation/selectors.js
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/selectors.js
@@ -1,0 +1,5 @@
+import { getUserIsAdmin } from "metabase/selectors/user";
+
+export const getIsModerator = (state, props) => {
+  return getUserIsAdmin(state, props);
+};

--- a/frontend/src/metabase-lib/lib/Question.js
+++ b/frontend/src/metabase-lib/lib/Question.js
@@ -988,6 +988,10 @@ export default class Question {
   getLatestModerationReview() {
     return _.last(this.getModerationReviews());
   }
+
+  getModerationRequests() {
+    return getIn(this, ["_card", "moderation_requests"], []);
+  }
 }
 
 window.Question = Question;

--- a/frontend/src/metabase-lib/lib/Question.js
+++ b/frontend/src/metabase-lib/lib/Question.js
@@ -982,7 +982,7 @@ export default class Question {
   }
 
   getModerationReviews() {
-    return getIn(this, ["_card", "moderation_reviews"]);
+    return getIn(this, ["_card", "moderation_reviews"]) || [];
   }
 
   getLatestModerationReview() {
@@ -990,7 +990,7 @@ export default class Question {
   }
 
   getModerationRequests() {
-    return getIn(this, ["_card", "moderation_requests"], []);
+    return getIn(this, ["_card", "moderation_requests"]) || [];
   }
 }
 

--- a/frontend/src/metabase/entities/containers/EntityListLoader.jsx
+++ b/frontend/src/metabase/entities/containers/EntityListLoader.jsx
@@ -162,6 +162,7 @@ export default class EntityListLoader extends React.Component {
   renderChildren = () => {
     let { children, entityDef, wrapped, list, reload, ...props } = this.props; // eslint-disable-line no-unused-vars
 
+    // "wrapped" means the list of entities are instantiated into instances of `EntityWrapper`
     if (wrapped) {
       list = this._getWrappedList(this.props);
     }

--- a/frontend/src/metabase/plugins/index.js
+++ b/frontend/src/metabase/plugins/index.js
@@ -67,4 +67,6 @@ export const PLUGIN_MODERATION_COMPONENTS = {
 export const PLUGIN_MODERATION_SERVICE = {
   getStatusIconForReview: _.noop,
   getColorForReview: _.noop,
+  getOpenRequests: _.noop,
+  isRequestDismissal: _.noop,
 };

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -58,6 +58,7 @@ import {
   CardApi,
   UserApi,
   ModerationReviewApi,
+  ModerationRequestApi,
 } from "metabase/services";
 
 import { parse as urlParse } from "url";
@@ -74,9 +75,13 @@ import Questions from "metabase/entities/questions";
 import Snippets from "metabase/entities/snippets";
 
 import { getMetadata } from "metabase/selectors/metadata";
+import { getUser } from "metabase/selectors/user";
 import { setRequestUnloaded } from "metabase/redux/requests";
 
 import type { Card } from "metabase-types/types/Card";
+import { PLUGIN_MODERATION_SERVICE } from "metabase/plugins";
+
+const { isRequestDismissal } = PLUGIN_MODERATION_SERVICE;
 
 type UiControls = {
   isEditing?: boolean,
@@ -1370,8 +1375,49 @@ export const showChartSettings = createAction(SHOW_CHART_SETTINGS);
 export const onUpdateVisualizationSettings = updateCardVisualizationSettings;
 export const onReplaceAllVisualizationSettings = replaceAllCardVisualizationSettings;
 
-export async function createModerationReview(reviewParams) {
-  await ModerationReviewApi.create(reviewParams);
+export const CREATE_MODERATION_REVIEW = "metabase/qb/CREATE_MODERATION_REVIEW";
+export const createModerationReview = createThunkAction(
+  CREATE_MODERATION_REVIEW,
+  ({ moderationReview, moderationRequest }) => async (dispatch, getState) => {
+    const currentUser = getUser(getState());
+    const moderatorId = currentUser.id;
+    const { type, cardId, description } = moderationReview;
+    if (isRequestDismissal(type)) {
+      if (!moderationRequest) {
+        throw new Error("Missing moderation request -- unable to dismiss.");
+      }
+
+      await ModerationRequestApi.update({
+        id: moderationRequest.id,
+        status: "dismissed", // todo
+        closed_by_id: moderatorId,
+      });
+    } else {
+      const reviewPromise = ModerationReviewApi.create({
+        status: type,
+        moderated_item_id: cardId,
+        moderated_item_type: "card",
+        text: description,
+      });
+
+      let requestPromise;
+      if (moderationRequest) {
+        requestPromise = ModerationRequestApi.update({
+          id: moderationRequest.id,
+          status: "resolved", // todo
+          closed_by_id: moderatorId,
+        });
+      }
+
+      await Promise.all([reviewPromise, requestPromise]);
+    }
+
+    return dispatch(softReloadCard());
+  },
+);
+
+export async function createModerationRequest(requestParams) {
+  await ModerationRequestApi.create({ requestParams });
   return softReloadCard();
 }
 

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -1416,8 +1416,13 @@ export const createModerationReview = createThunkAction(
   },
 );
 
-export async function createModerationRequest(requestParams) {
-  await ModerationRequestApi.create({ requestParams });
+export async function createModerationRequest({ type, cardId, description }) {
+  await ModerationRequestApi.create({
+    type,
+    moderated_item_id: cardId,
+    moderated_item_type: "card",
+    text: description,
+  });
   return softReloadCard();
 }
 

--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -107,6 +107,8 @@ export default class View extends React.Component {
       height,
       onOpenModal,
       createModerationReview,
+      createModerationRequest,
+      isAdmin,
     } = this.props;
     const {
       aggregationIndex,
@@ -165,6 +167,8 @@ export default class View extends React.Component {
         question={question}
         onOpenModal={onOpenModal}
         createModerationReview={createModerationReview}
+        createModerationRequest={createModerationRequest}
+        isAdmin={isAdmin}
       />
     ) : null;
 

--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -108,7 +108,6 @@ export default class View extends React.Component {
       onOpenModal,
       createModerationReview,
       createModerationRequest,
-      isAdmin,
     } = this.props;
     const {
       aggregationIndex,
@@ -168,7 +167,6 @@ export default class View extends React.Component {
         onOpenModal={onOpenModal}
         createModerationReview={createModerationReview}
         createModerationRequest={createModerationRequest}
-        isAdmin={isAdmin}
       />
     ) : null;
 

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -125,6 +125,7 @@ export class ViewTitleHeader extends React.Component {
                 />
               </SavedQuestionHeaderButtonContainer>
               <HistoryButton
+                className="pl1"
                 onClick={() => onOpenModal("history")}
                 modelType="card"
                 modelId={question.id()}

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebar.jsx
@@ -1,32 +1,44 @@
 import React, { useState } from "react";
 import PropTypes from "prop-types";
 import QuestionDetailsSidebarPanel from "metabase/query_builder/components/view/sidebars/QuestionDetailsSidebarPanel";
-import { PLUGIN_MODERATION_COMPONENTS } from "metabase/plugins";
+import {
+  PLUGIN_MODERATION_COMPONENTS,
+  PLUGIN_MODERATION_SERVICE,
+} from "metabase/plugins";
 import { SIDEBAR_VIEWS } from "./constants";
 const {
   CreateModerationIssuePanel,
   OpenModerationIssuesPanel,
 } = PLUGIN_MODERATION_COMPONENTS;
 
+const { getOpenRequests } = PLUGIN_MODERATION_SERVICE;
+
 QuestionDetailsSidebar.propTypes = {
   question: PropTypes.object.isRequired,
   onOpenModal: PropTypes.func.isRequired,
   createModerationReview: PropTypes.func.isRequired,
+  createModerationRequest: PropTypes.func.isRequired,
+  isAdmin: PropTypes.bool.isRequired,
 };
 
 function QuestionDetailsSidebar({
   question,
   onOpenModal,
   createModerationReview,
+  createModerationRequest,
+  isAdmin,
 }) {
   const [view, setView] = useState({
     name: undefined,
     props: undefined,
+    previousView: undefined,
   });
   const { name, props: viewProps } = view;
   const id = question.id();
-
-  const setBaseView = () => setView({ name: SIDEBAR_VIEWS.DETAILS });
+  const setBaseView = () =>
+    setView(({ previousView }) => ({
+      name: previousView || SIDEBAR_VIEWS.DETAILS,
+    }));
 
   switch (name) {
     case SIDEBAR_VIEWS.CREATE_ISSUE_PANEL:
@@ -35,12 +47,21 @@ function QuestionDetailsSidebar({
           {...viewProps}
           onReturn={setBaseView}
           createModerationReview={createModerationReview}
+          createModerationRequest={createModerationRequest}
           itemId={id}
           itemType="card"
+          isAdmin={isAdmin}
         />
       );
     case SIDEBAR_VIEWS.OPEN_ISSUES_PANEL:
-      return <OpenModerationIssuesPanel onReturn={setBaseView} />;
+      return (
+        <OpenModerationIssuesPanel
+          setView={setView}
+          requests={getOpenRequests(question)}
+          onReturn={setBaseView}
+          isAdmin={isAdmin}
+        />
+      );
     case SIDEBAR_VIEWS.DETAILS:
     default:
       return (
@@ -48,6 +69,7 @@ function QuestionDetailsSidebar({
           setView={setView}
           question={question}
           onOpenModal={onOpenModal}
+          isAdmin={isAdmin}
         />
       );
   }

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebar.jsx
@@ -18,7 +18,6 @@ QuestionDetailsSidebar.propTypes = {
   onOpenModal: PropTypes.func.isRequired,
   createModerationReview: PropTypes.func.isRequired,
   createModerationRequest: PropTypes.func.isRequired,
-  isAdmin: PropTypes.bool.isRequired,
 };
 
 function QuestionDetailsSidebar({
@@ -26,7 +25,6 @@ function QuestionDetailsSidebar({
   onOpenModal,
   createModerationReview,
   createModerationRequest,
-  isAdmin,
 }) {
   const [view, setView] = useState({
     name: undefined,
@@ -49,8 +47,6 @@ function QuestionDetailsSidebar({
           createModerationReview={createModerationReview}
           createModerationRequest={createModerationRequest}
           itemId={id}
-          itemType="card"
-          isAdmin={isAdmin}
         />
       );
     case SIDEBAR_VIEWS.OPEN_ISSUES_PANEL:
@@ -59,7 +55,6 @@ function QuestionDetailsSidebar({
           setView={setView}
           requests={getOpenRequests(question)}
           onReturn={setBaseView}
-          isAdmin={isAdmin}
         />
       );
     case SIDEBAR_VIEWS.DETAILS:
@@ -69,7 +64,6 @@ function QuestionDetailsSidebar({
           setView={setView}
           question={question}
           onOpenModal={onOpenModal}
-          isAdmin={isAdmin}
         />
       );
   }

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebarPanel.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebarPanel.jsx
@@ -4,7 +4,10 @@ import SidebarContent from "metabase/query_builder/components/SidebarContent";
 import QuestionActionButtons from "metabase/questions/components/QuestionActionButtons";
 import ClampedText from "metabase/components/ClampedText";
 import QuestionActivityTimeline from "metabase/questions/components/QuestionActivityTimeline";
-import { PLUGIN_MODERATION_COMPONENTS } from "metabase/plugins";
+import {
+  PLUGIN_MODERATION_COMPONENTS,
+  PLUGIN_MODERATION_SERVICE,
+} from "metabase/plugins";
 import { SIDEBAR_VIEWS } from "./constants";
 
 const {
@@ -12,9 +15,24 @@ const {
   OpenModerationIssuesButton,
 } = PLUGIN_MODERATION_COMPONENTS;
 
-function QuestionDetailsSidebarPanel({ setView, question, onOpenModal }) {
+const { getOpenRequests } = PLUGIN_MODERATION_SERVICE;
+
+QuestionDetailsSidebarPanel.propTypes = {
+  setView: PropTypes.func.isRequired,
+  question: PropTypes.object.isRequired,
+  onOpenModal: PropTypes.func.isRequired,
+  isAdmin: PropTypes.bool.isRequired,
+};
+
+function QuestionDetailsSidebarPanel({
+  setView,
+  question,
+  onOpenModal,
+  isAdmin,
+}) {
   const canWrite = question.canWrite();
   const description = question.description();
+  const numOpenIssues = getOpenRequests(question).length;
 
   return (
     <SidebarContent className="full-height px1">
@@ -28,6 +46,7 @@ function QuestionDetailsSidebarPanel({ setView, question, onOpenModal }) {
         <ClampedText className="px3 pb2" text={description} visibleLines={8} />
         <div className="mx1 pb2 flex justify-between border-row-divider">
           <ModerationIssueActionMenu
+            isAdmin={isAdmin}
             triggerClassName="Button--round text-brand border-brand py1"
             onAction={issueType => {
               setView({
@@ -37,6 +56,8 @@ function QuestionDetailsSidebarPanel({ setView, question, onOpenModal }) {
             }}
           />
           <OpenModerationIssuesButton
+            isAdmin={isAdmin}
+            numOpenIssues={numOpenIssues}
             onClick={() => {
               setView({
                 name: SIDEBAR_VIEWS.OPEN_ISSUES_PANEL,
@@ -49,11 +70,5 @@ function QuestionDetailsSidebarPanel({ setView, question, onOpenModal }) {
     </SidebarContent>
   );
 }
-
-QuestionDetailsSidebarPanel.propTypes = {
-  setView: PropTypes.func.isRequired,
-  question: PropTypes.object.isRequired,
-  onOpenModal: PropTypes.func.isRequired,
-};
 
 export default QuestionDetailsSidebarPanel;

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebarPanel.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebarPanel.jsx
@@ -4,18 +4,13 @@ import SidebarContent from "metabase/query_builder/components/SidebarContent";
 import QuestionActionButtons from "metabase/questions/components/QuestionActionButtons";
 import ClampedText from "metabase/components/ClampedText";
 import QuestionActivityTimeline from "metabase/questions/components/QuestionActivityTimeline";
-import {
-  PLUGIN_MODERATION_COMPONENTS,
-  PLUGIN_MODERATION_SERVICE,
-} from "metabase/plugins";
+import { PLUGIN_MODERATION_COMPONENTS } from "metabase/plugins";
 import { SIDEBAR_VIEWS } from "./constants";
 
 const {
   ModerationIssueActionMenu,
   OpenModerationIssuesButton,
 } = PLUGIN_MODERATION_COMPONENTS;
-
-const { getOpenRequests } = PLUGIN_MODERATION_SERVICE;
 
 QuestionDetailsSidebarPanel.propTypes = {
   setView: PropTypes.func.isRequired,
@@ -26,7 +21,6 @@ QuestionDetailsSidebarPanel.propTypes = {
 function QuestionDetailsSidebarPanel({ setView, question, onOpenModal }) {
   const canWrite = question.canWrite();
   const description = question.description();
-  const numOpenIssues = getOpenRequests(question).length;
 
   return (
     <SidebarContent className="full-height px1">
@@ -49,7 +43,7 @@ function QuestionDetailsSidebarPanel({ setView, question, onOpenModal }) {
             }}
           />
           <OpenModerationIssuesButton
-            numOpenIssues={numOpenIssues}
+            question={question}
             onClick={() => {
               setView({
                 name: SIDEBAR_VIEWS.OPEN_ISSUES_PANEL,

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebarPanel.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebarPanel.jsx
@@ -21,15 +21,9 @@ QuestionDetailsSidebarPanel.propTypes = {
   setView: PropTypes.func.isRequired,
   question: PropTypes.object.isRequired,
   onOpenModal: PropTypes.func.isRequired,
-  isAdmin: PropTypes.bool.isRequired,
 };
 
-function QuestionDetailsSidebarPanel({
-  setView,
-  question,
-  onOpenModal,
-  isAdmin,
-}) {
+function QuestionDetailsSidebarPanel({ setView, question, onOpenModal }) {
   const canWrite = question.canWrite();
   const description = question.description();
   const numOpenIssues = getOpenRequests(question).length;
@@ -46,7 +40,6 @@ function QuestionDetailsSidebarPanel({
         <ClampedText className="px3 pb2" text={description} visibleLines={8} />
         <div className="mx1 pb2 flex justify-between border-row-divider">
           <ModerationIssueActionMenu
-            isAdmin={isAdmin}
             triggerClassName="Button--round text-brand border-brand py1"
             onAction={issueType => {
               setView({
@@ -56,7 +49,6 @@ function QuestionDetailsSidebarPanel({
             }}
           />
           <OpenModerationIssuesButton
-            isAdmin={isAdmin}
             numOpenIssues={numOpenIssues}
             onClick={() => {
               setView({

--- a/frontend/src/metabase/questions/components/HistoryButton.jsx
+++ b/frontend/src/metabase/questions/components/HistoryButton.jsx
@@ -3,18 +3,24 @@ import PropTypes from "prop-types";
 import _ from "underscore";
 import moment from "moment";
 import { t } from "ttag";
-import Revision from "metabase/entities/revisions";
-import Link from "metabase/components/Link";
+import cx from "classnames";
 
-function HistoryButton({ onClick, revisions }) {
+import Revision from "metabase/entities/revisions";
+import Button from "metabase/components/Button";
+
+function HistoryButton({ className, onClick, revisions }) {
   const mostRecentRevision = _.first(revisions);
   return mostRecentRevision ? (
-    <Link
-      className="pl1 text-bold text-light text-small text-brand-hover"
+    <Button
+      className={cx(
+        className,
+        "p0 borderless text-bold text-light text-small text-brand-hover bg-transparent-hover",
+      )}
       onClick={onClick}
+      data-testid="history-button"
     >
       {t`Edited ${moment(mostRecentRevision.timestamp).fromNow()}`}
-    </Link>
+    </Button>
   ) : null;
 }
 
@@ -28,6 +34,7 @@ export default Revision.loadList({
 })(HistoryButton);
 
 HistoryButton.propTypes = {
+  className: PropTypes.string,
   onClick: PropTypes.func.isRequired,
   revisions: PropTypes.array,
 };

--- a/frontend/src/metabase/questions/components/QuestionActionButtons.jsx
+++ b/frontend/src/metabase/questions/components/QuestionActionButtons.jsx
@@ -17,6 +17,7 @@ function QuestionActionButtons({ canWrite, onOpenModal }) {
               icon="pencil"
               iconSize={18}
               onClick={() => onOpenModal("edit")}
+              data-testid="edit-details-button"
             />
           </Tooltip>
         )}
@@ -26,6 +27,7 @@ function QuestionActionButtons({ canWrite, onOpenModal }) {
             icon="add_to_dash"
             iconSize={18}
             onClick={() => onOpenModal("add-to-dashboard")}
+            data-testid="add-to-dashboard-button"
           />
         </Tooltip>
       </div>
@@ -38,6 +40,7 @@ function QuestionActionButtons({ canWrite, onOpenModal }) {
               icon="move"
               iconSize={18}
               onClick={() => onOpenModal("move")}
+              data-testid="move-button"
             />
           </Tooltip>
         )}
@@ -49,6 +52,7 @@ function QuestionActionButtons({ canWrite, onOpenModal }) {
               icon="segment"
               iconSize={18}
               onClick={() => onOpenModal("clone")}
+              data-testid="clone-button"
             />
           </Tooltip>
         )}
@@ -60,6 +64,7 @@ function QuestionActionButtons({ canWrite, onOpenModal }) {
               icon="archive"
               iconSize={18}
               onClick={() => onOpenModal("archive")}
+              data-testid="archive-button"
             />
           </Tooltip>
         )}

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -309,6 +309,12 @@ export const MetabaseApi = {
 
 export const ModerationReviewApi = {
   create: POST("/api/moderation-review"),
+  update: PUT("/api/moderation-review/:id"),
+};
+
+export const ModerationRequestApi = {
+  create: POST("/api/moderation-request"),
+  update: PUT("/api/moderation-request/:id"),
 };
 
 export const PulseApi = {

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -280,12 +280,14 @@ describe("collection permissions", () => {
                 beforeEach(() => {
                   cy.route("PUT", "/api/card/1").as("updateQuestion");
                   cy.visit("/question/1");
-                  cy.findByRole("button", { name: /Orders/ }).click();
+                  cy.findByTestId("saved-question-header-button").click({
+                    force: true,
+                  });
                 });
 
                 it("should be able to edit question details (metabase#11719-1)", () => {
                   cy.skipOn(user === "nodata");
-                  cy.icon("edit_document").click();
+                  cy.findByTestId("edit-details-button").click();
                   cy.findByLabelText("Name")
                     .click()
                     .type("1");
@@ -296,7 +298,7 @@ describe("collection permissions", () => {
 
                 it("should be able to move the question (metabase#11719-2)", () => {
                   cy.skipOn(user === "nodata");
-                  cy.icon("move").click();
+                  cy.findByTestId("move-button").click();
                   cy.findByText("My personal collection").click();
                   clickButton("Move");
                   assertOnRequest("updateQuestion");
@@ -304,7 +306,7 @@ describe("collection permissions", () => {
                 });
 
                 it("should be able to archive the question (metabase#11719-3)", () => {
-                  cy.icon("archive").click();
+                  cy.findByTestId("archive-button").click();
                   clickButton("Archive");
                   assertOnRequest("updateQuestion");
                   cy.location("pathname").should("eq", "/collection/root");
@@ -312,9 +314,7 @@ describe("collection permissions", () => {
                 });
 
                 it("should be able to add question to dashboard", () => {
-                  popover()
-                    .findByText("Add to dashboard")
-                    .click();
+                  cy.findByTestId("add-to-dashboard-button").click();
 
                   cy.get(".Modal")
                     .as("modal")
@@ -450,10 +450,8 @@ describe("collection permissions", () => {
             describe("managing question from the question's edit dropdown", () => {
               it("should not be offered to add question to dashboard inside a collection they have `read` access to", () => {
                 cy.visit("/question/1");
-                cy.icon("pencil").click();
-                popover()
-                  .findByText("Add to dashboard")
-                  .click();
+                cy.findByTestId("saved-question-header-button").click();
+                cy.findByTestId("add-to-dashboard-button").click();
 
                 cy.get(".Modal").within(() => {
                   cy.findByText("Orders in a dashboard").should("not.exist");
@@ -469,10 +467,8 @@ describe("collection permissions", () => {
                 const { first_name, last_name } = USERS[user];
                 const personalCollection = `${first_name} ${last_name}'s Personal Collection`;
                 cy.visit("/question/1");
-                cy.icon("pencil").click();
-                popover()
-                  .findByText("Add to dashboard")
-                  .click();
+                cy.findByTestId("saved-question-header-button").click();
+                cy.findByTestId("add-to-dashboard-button").click();
 
                 cy.get(".Modal").within(() => {
                   cy.findByText("Create a new dashboard").click();

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -611,7 +611,7 @@ describe("collection permissions", () => {
                 // For now that's not possible for user without data access (likely it will be again when #11719 is fixed)
                 cy.skipOn(user === "nodata");
                 cy.visit("/question/1");
-                cy.findByRole("button", { name: /Edited .*/ }).click();
+                cy.findByTestId("history-button").click();
                 clickRevert("First revision.");
                 cy.wait("@revert").then(xhr => {
                   expect(xhr.status).to.eq(200);

--- a/frontend/test/metabase/scenarios/question/saved.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/saved.cy.spec.js
@@ -95,7 +95,7 @@ describe("scenarios > question > saved", () => {
     cy.wait("@query");
 
     cy.findByTestId("saved-question-header-button").click();
-    cy.icon("clone").click();
+    cy.icon("segment").click();
 
     modal().within(() => {
       cy.findByLabelText("Name").should("have.value", "Orders - Duplicate");


### PR DESCRIPTION
This PR adds the ability for normal users (not admins) to create moderation requests on saved questions. Once a BE bug has been dealt with admins will also be able to close moderation requests opened by users.

Steps to test:
1. If you don't have one on hand, create a non-admin user via http://localhost:3000/admin/people
2. Using your new user, navigate to a pre-existing saved question
3. Click on the header of the question to open up the details sidebar
4. Click on the "user action" dropdown button (real text tbd) and select one of the options
5. You should've been navigated to a form with a single textarea input. Fill it in or don't fill it in.
6. Click the blue save button
7. You should see a button in the details sidebar that shows how many open moderation requests exist for a given question (assuming this is a new question, there should now be one, the one you just created).
8. Click on the button and you should be navigated to an "open issues" view of the sidebar that shows the moderation request you just created.

Things to note:
1. I'm punting on adding real text so you may see placeholders like in the video below
2. I'm also punting on adding tests since we're still technically in a "prototype" phase on this project.

Here's a video showing a user creating a moderation request:

https://user-images.githubusercontent.com/13057258/118905690-14b4c900-b8d1-11eb-8d71-791752c8f62f.mov

