### PR TITLE
#15974 / #11659 Repro: Google sign-in client ID setting fails to save on subsequent tries

### DIFF
--- a/frontend/test/metabase/scenarios/admin/settings/sso.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/sso.cy.spec.js
@@ -1,0 +1,22 @@
+import { restore } from "__support__/e2e/cypress";
+
+describe("scenarios > admin > settings > SSO", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it.skip("Google sign-in client ID should save on subsequent tries (metabase#15974)", () => {
+    cy.visit("/admin/settings/authentication/google");
+    cy.findByPlaceholderText("Your Google client ID").type("123");
+    saveSettings();
+
+    cy.findByDisplayValue("123").type("456");
+    saveSettings();
+  });
+});
+
+function saveSettings() {
+  cy.button("Save Changes").click();
+  cy.findByText("Saved");
+}


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #11659 and #15974 "indirectly"
    - 15974 is reproducible only on Firefox (which we don't run in CI)
    - both issues have [the same cause](https://github.com/metabase/metabase/pull/16142#issuecomment-843990869)

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/admin/settings/sso.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/118793460-e9ae8300-b898-11eb-9e31-f08c465be57e.png)

Sanity check:
If we add a page reload between these settings updates, it saves without a problem (local testing purposes only)
![image](https://user-images.githubusercontent.com/31325167/118793891-54f85500-b899-11eb-8e4c-73a42570ef43.png)
