### PR TITLE
#15882 Repro: Only retains first 2 data series when saving chart with custom expressions

### DIFF
--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -987,4 +987,45 @@ describe("scenarios > question > filter", () => {
     cy.findByText("AL").click();
     cy.button("Add filter").isVisibleInPopover();
   });
+
+  it.skip("shoud retain all data series after saving a question where custom expression formula is the first metric (metabase#15882)", () => {
+    visitQuestionAdhoc({
+      dataset_query: {
+        database: 1,
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: [
+            [
+              "aggregation-options",
+              [
+                "/",
+                ["sum", ["field", ORDERS.DISCOUNT, null]],
+                ["sum", ["field", ORDERS.SUBTOTAL, null]],
+              ],
+              { "display-name": "Discount %" },
+            ],
+            ["count"],
+            ["avg", ["field", ORDERS.TOTAL, null]],
+          ],
+          breakout: [
+            ["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }],
+          ],
+        },
+        type: "query",
+      },
+      display: "line",
+    });
+    assertOnLegendLabels();
+    cy.findByText("Save").click();
+    cy.button("Save").click();
+    cy.button("Not now").click();
+    assertOnLegendLabels();
+
+    function assertOnLegendLabels() {
+      cy.get(".Card-title")
+        .should("contain", "Discount %")
+        .and("contain", "Count")
+        .and("contain", "Average of Total");
+    }
+  });
 });

--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -1016,10 +1016,12 @@ describe("scenarios > question > filter", () => {
       display: "line",
     });
     assertOnLegendLabels();
+    cy.get(".line").should("have.length", 3);
     cy.findByText("Save").click();
     cy.button("Save").click();
     cy.button("Not now").click();
     assertOnLegendLabels();
+    cy.get(".line").should("have.length", 3);
 
     function assertOnLegendLabels() {
       cy.get(".Card-title")


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #15882

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/question/filter.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/118799813-752b1280-b89f-11eb-84d9-4cde9b6e8570.png)

