### PR TITLE
Synchronize `ExternalLink` component with the `release-x.39.x`

### DIFF
--- a/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx
@@ -43,7 +43,7 @@ export default class SettingsUpdatesForm extends Component {
               {jt`You're running ${formatVersion(currentVersion)}`}
             </span>
             <ExternalLink
-              dataMetabaseEvent={
+              data-metabase-event={
                 "Updates Settings; Update link clicked; " + latestVersion
               }
               className="Button Button--white Button--medium borderless"

--- a/frontend/src/metabase/components/ExternalLink.jsx
+++ b/frontend/src/metabase/components/ExternalLink.jsx
@@ -7,14 +7,12 @@ const ExternalLink = ({
   href,
   target = getUrlTarget(href),
   className,
-  dataMetabaseEvent,
   children,
   ...props
 }) => (
   <a
     href={href}
     className={className || "link"}
-    data-metabase-event={dataMetabaseEvent}
     target={target}
     // prevent malicious pages from navigating us away
     rel="noopener noreferrer"

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx
@@ -299,7 +299,7 @@ const TagEditorHelp = ({
         <ExternalLink
           href={MetabaseSettings.docsUrl("users-guide/13-sql-parameters")}
           target="_blank"
-          dataMetabaseEvent="QueryBuilder;Template Tag Documentation Click"
+          data-metabase-event={"QueryBuilder;Template Tag Documentation Click"}
         >{t`Read the full documentation`}</ExternalLink>
       </p>
     </div>


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Synchronizes the `ExternalLink` component with its state as it is on `release-x.39.x` branch as per [this](https://github.com/metabase/metabase/pull/16111#issuecomment-844076665) comment