### PR TITLE
#15558 Repro: Login History tab not available for LDAP/Google logins

### DIFF
--- a/frontend/test/__support__/e2e/cypress.js
+++ b/frontend/test/__support__/e2e/cypress.js
@@ -309,8 +309,8 @@ export function getIframeBody(selector = "iframe") {
     .then(cy.wrap);
 }
 
-export function mockSessionProperty(propertyOrObject, value) {
-  cy.intercept("GET", "/api/session/properties", req => {
+function mockProperty(propertyOrObject, value, url) {
+  cy.intercept("GET", url, req => {
     req.reply(res => {
       if (typeof propertyOrObject === "object") {
         Object.assign(res.body, propertyOrObject);
@@ -320,4 +320,12 @@ export function mockSessionProperty(propertyOrObject, value) {
       }
     });
   });
+}
+
+export function mockSessionProperty(propertyOrObject, value) {
+  mockProperty(propertyOrObject, value, "/api/session/properties");
+}
+
+export function mockCurrentUserProperty(propertyOrObject, value) {
+  mockProperty(propertyOrObject, value, "/api/user/current");
 }

--- a/frontend/test/metabase/scenarios/onboarding/auth/sso.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/auth/sso.cy.spec.js
@@ -1,4 +1,8 @@
-import { describeWithToken, restore } from "__support__/e2e/cypress";
+import {
+  describeWithToken,
+  restore,
+  mockCurrentUserProperty,
+} from "__support__/e2e/cypress";
 
 describe("scenarios > auth > signin > SSO", () => {
   beforeEach(() => {
@@ -7,6 +11,14 @@ describe("scenarios > auth > signin > SSO", () => {
     // Set fake Google client ID
     cy.request("PUT", "/api/setting/google-auth-client-id", {
       value: "123",
+    });
+  });
+
+  ["ldap_auth", "google_auth"].forEach(auth => {
+    it.skip(`login history tab should be available with ${auth} enabled (metabase#15558)`, () => {
+      mockCurrentUserProperty(auth, true);
+      cy.visit("/user/edit_current");
+      cy.findByText("Login History");
     });
   });
 


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #15558 

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/onboarding/auth/sso.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/118827030-496a5580-b8bc-11eb-889a-6507eabda2d8.png)

![image](https://user-images.githubusercontent.com/31325167/118826861-22138880-b8bc-11eb-8dfc-d5bdba4f21e1.png)

