### PR TITLE
#15211 Repro: Pivot table don't show stand-alone values on the upper level grouping

### DIFF
--- a/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -750,6 +750,66 @@ describe("scenarios > visualizations > pivot tables", () => {
       cy.findByText("Grand totals");
     });
   });
+
+  it.skip("should show stand-alone row values in grouping when rows are collapsed (metabase#15211)", () => {
+    visitQuestionAdhoc({
+      dataset_query: {
+        type: "query",
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: [["sum", ["field", ORDERS.DISCOUNT, null]], ["count"]],
+          breakout: [
+            ["field", ORDERS.CREATED_AT, { "temporal-unit": "day" }],
+            ["field", ORDERS.PRODUCT_ID, null],
+          ],
+          filter: [
+            "and",
+            [
+              "between",
+              ["field", ORDERS.CREATED_AT, null],
+              "2016-11-09",
+              "2016-11-11",
+            ],
+            ["!=", ["field", ORDERS.PRODUCT_ID, null], 146],
+          ],
+        },
+        database: 1,
+      },
+      display: "pivot",
+      visualization_settings: {
+        "pivot_table.column_split": {
+          rows: [
+            ["field", ORDERS.CREATED_AT, { "temporal-unit": "day" }],
+            ["field", ORDERS.PRODUCT_ID, null],
+          ],
+          columns: [],
+          values: [["aggregation", 0], ["aggregation", 1]],
+        },
+        "pivot_table.collapsed_rows": {
+          value: [],
+          rows: [
+            ["field", ORDERS.CREATED_AT, { "temporal-unit": "day" }],
+            ["field", ORDERS.PRODUCT_ID, null],
+          ],
+        },
+      },
+    });
+
+    cy.findByText("November 9, 2016");
+    cy.findByText("November 10, 2016");
+    cy.findByText("November 11, 2016");
+    collapseRowsFor("Created At: Day");
+    cy.findByText("Totals for November 9, 2016");
+    cy.findByText("Totals for November 10, 2016");
+    cy.findByText("Totals for November 11, 2016");
+
+    function collapseRowsFor(column_name) {
+      cy.findByText(column_name)
+        .parent()
+        .find(".Icon-dash")
+        .click();
+    }
+  });
 });
 
 const testQuery = {


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #15211

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/118839518-d6b2a780-b8c6-11eb-9c2b-a731e1784826.png)

