### PR TITLE
Fix database schemas browsing

### DIFF
--- a/frontend/src/metabase/browse/containers/TableBrowser.jsx
+++ b/frontend/src/metabase/browse/containers/TableBrowser.jsx
@@ -23,6 +23,28 @@ import Link from "metabase/components/Link";
 import BrowseHeader from "metabase/browse/components/BrowseHeader";
 import { ANALYTICS_CONTEXT, ITEM_WIDTHS } from "metabase/browse/constants";
 
+function getDatabaseId(props) {
+  const { params } = props;
+  const dbId =
+    parseInt(props.dbId) ||
+    parseInt(params.dbId) ||
+    Urls.extractEntityId(params.slug);
+  return Number.isSafeInteger(dbId) ? dbId : undefined;
+}
+
+function getSchemaName(props) {
+  return props.schemaName || props.params.schemaName;
+}
+
+function mapStateToProps(state, props) {
+  return {
+    dbId: getDatabaseId(props),
+    schemaName: getSchemaName(props),
+    metadata: getMetadata(state),
+    xraysEnabled: getXraysEnabled(state),
+  };
+}
+
 function TableBrowser(props) {
   const {
     tables,
@@ -119,13 +141,8 @@ function TableBrowser(props) {
 }
 
 export default Table.loadList({
-  query: (state, { dbId, schemaName }) => ({
-    dbId,
-    schemaName,
+  query: (state, props) => ({
+    dbId: getDatabaseId(props),
+    schemaName: getSchemaName(props),
   }),
-})(
-  connect(state => ({
-    metadata: getMetadata(state),
-    xraysEnabled: getXraysEnabled(state),
-  }))(TableBrowser),
-);
+})(connect(mapStateToProps)(TableBrowser));


### PR DESCRIPTION
#15989 (Add slugs to URLs to make them friendlier) broke the database schema and table browsing

The issue reproduced on `/browse/:databaseId/schema/:schemaName` pages. The app renders the `TableBrowser` component for this route.

`TableBrowser` has to receive the `dbId` and `schemaName` to request a list of tables from the backend. The tricky thing is that [it's also rendered by the `SchemaBrowser`](https://github.com/metabase/metabase/blob/9ea3518ab9fed61918eea7c89891d2effa1352be/frontend/src/metabase/browse/containers/SchemaBrowser.jsx#L29) component if the database has only one schema. In one case, `dbId` and `schemaName` have to be parsed from the URL path. In another case, they are received directly as props. Fixed by checking both URL path and props for the required params.

**To Verify**
1. Connect a database with multiple schemas
2. Go to `/browse/:databaseId/schema/:schemaName`
3. Ensure the app displays only tables belonging to the opened schema
4. Ensure the breadcrumbs are correct (has to be "Our Data" —> Database Name —> Schema Name)

Fixes #16087 