### PR TITLE
Fix UX bugs in ExpressionWidget

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx
@@ -2,6 +2,8 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import cx from "classnames";
 import { t } from "ttag";
+import _ from "underscore";
+
 import ExpressionEditorTextfield from "./ExpressionEditorTextfield";
 import { isExpression } from "metabase/lib/expressions";
 import MetabaseSettings from "metabase/lib/settings";
@@ -29,10 +31,12 @@ export default class ExpressionWidget extends Component {
   }
 
   UNSAFE_componentWillReceiveProps(newProps) {
-    this.setState({
-      name: newProps.name,
-      expression: newProps.expression,
-    });
+    if (!this.state || !_.isEqual(this.props.expression, newProps.expression)) {
+      this.setState({
+        name: newProps.name,
+        expression: newProps.expression,
+      });
+    }
   }
 
   isValid() {

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx
@@ -18,7 +18,7 @@ export default class ExpressionWidget extends Component {
     query: PropTypes.object.isRequired,
     onChangeExpression: PropTypes.func.isRequired,
     onRemoveExpression: PropTypes.func,
-    onClose: PropTypes.func.isRequired,
+    onClose: PropTypes.func,
   };
 
   static defaultProps = {

--- a/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
@@ -492,24 +492,25 @@ describe("scenarios > question > custom columns", () => {
     cy.button("Done").should("not.be.disabled");
   });
 
-  describe.skip("contentedtable field (metabase#15734)", () => {
+  describe("ExpressionEditorTextfield", () => {
     beforeEach(() => {
       // This is the default screen size but we need it explicitly set for this test because of the resize later on
       cy.viewport(1280, 800);
 
       openOrdersTable({ mode: "notebook" });
       cy.findByText("Custom column").click();
+
+      cy.get("[contenteditable='true']").as("formula");
+
       popover().within(() => {
-        cy.get("[contenteditable='true']")
-          .as("formula")
-          .type("1+1")
-          .blur();
+        _typeUsingGet("[contenteditable='true']", "1 + 1", 400);
+        _typeUsingPlaceholder("Something nice and descriptive", "Math");
       });
-      cy.findByPlaceholderText("Something nice and descriptive").type("Math");
+
       cy.button("Done").should("not.be.disabled");
     });
 
-    it("should not accidentally delete CC formula value and/or CC name (metabase#15734-1)", () => {
+    it("should not accidentally delete Custom Column formula value and/or Custom Column name (metabase#15734)", () => {
       cy.get("@formula")
         .click()
         .type("{movetoend}{leftarrow}{movetostart}{rightarrow}{rightarrow}")
@@ -520,23 +521,23 @@ describe("scenarios > question > custom columns", () => {
 
     /**
      * 1. Explanation for `cy.get("@formula").click();`
-     *  - Without it, test runner is too fast and the test resutls in false positive.
+     *  - Without it, test runner is too fast and the test results in false positive.
      *  - This gives it enough time to update the DOM. The same result can be achieved with `cy.wait(1)`
      */
-    it("should not erase CC formula and CC name when expression is incomplete (metabase#15734-2)", () => {
+    it("should not erase Custom column formula and Custom column name when expression is incomplete (metabase#16126)", () => {
       cy.get("@formula")
         .click()
         .type("{movetoend}{backspace}")
         .blur();
       cy.findByText("Expected expression");
       cy.button("Done").should("be.disabled");
-      cy.get("@formula").click(); /* [1] */
+      cy.get("@formula").click(); /* See comment (1) above */
       cy.findByDisplayValue("Math");
     });
 
-    it("should not erase CC formula and CC name on window resize (metabase#15734-3)", () => {
+    it("should not erase Custom Column formula and Custom Column name on window resize (metabase#16127)", () => {
       cy.viewport(1260, 800);
-      cy.get("@formula").click(); /* [1] */
+      cy.get("@formula").click(); /* See comment (1) above */
       cy.findByDisplayValue("Math");
       cy.button("Done").should("not.be.disabled");
     });


### PR DESCRIPTION
Fixes #16126
Fixes #16127

## To Reproduce #16126

Issue: ExpressionEditor lost value when user clicked away from associated name input

1. Open orders table from a custom question
2. Click on the small grid icon to create custom column
3. Modal will appear and "Field formula" is `contenteditable` field
4. Type `1+1` (without spaces) as a field formula
5. Click on the description field (notice `1+1` got formatted as `1 + 1`) and type "Math" as description
6. Go back to the formula and delete the last digit `1` leaving the field as `1 + `
7. Click the name again (let's say you wanted to edit a typo or something)
8. Note that formula got erased together with the name of the Custom column

**Updated behavior**

Value is preserved when blurring from name input.

## To Reproduce #16127

Issue: ExpressionEditor lost value when user resizes browser window

1. Open orders table from a custom question
2. Click on the small grid icon to create custom column
3. Modal will appear and "Field formula" is `contenteditable` field
4. Type `1+1` (without spaces) as a field formula
5. Click on the description field (notice `1+1` got formatted as `1 + 1`) and type "Math" as description
6. Resize the window or open the dev tools
7. All your changes are now gone

**Updated behavior**

Both inputs' values be preserved when window is resized.

**Screenshot:**

![ ](https://p58.f1.n0.cdn.getcloudapp.com/items/qGuE7wk1/babc991e-3429-4b23-9753-7b5d0ac065e3.gif?source=viewer&v=17e697a509ce20d8663a64679d6fb191)