### PR TITLE
Fix AccordionList PropType

### DIFF
--- a/frontend/src/metabase/components/AccordionList.jsx
+++ b/frontend/src/metabase/components/AccordionList.jsx
@@ -1,5 +1,3 @@
-/* eslint "react/prop-types": "warn" */
-
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 
@@ -51,7 +49,9 @@ export default class AccordionList extends Component {
     className: PropTypes.string,
     id: PropTypes.string,
 
-    width: PropTypes.number,
+    // TODO: pass width to this component as solely number or string if possible
+    // currently prop is number on initialization, then string afterwards
+    width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     maxHeight: PropTypes.number,
 
     sections: PropTypes.array.isRequired,


### PR DESCRIPTION
Fixes #16159 

## How to Test

1. Open orders table from a custom question
2. Click on the small grid icon to create custom column
3. Filter console for `AccordionList`

You should see no warning.