### PR TITLE
Add PropTypes to TokenizeInput

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/TokenizedInput.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/TokenizedInput.jsx
@@ -1,7 +1,7 @@
-/* eslint-disable react/prop-types */
 import React, { Component, forwardRef } from "react";
 import ReactDOM from "react-dom";
 import ReactDOMServer from "react-dom/server";
+import PropTypes from "prop-types";
 
 import TokenizedExpression from "./TokenizedExpression";
 
@@ -10,11 +10,6 @@ import {
   saveSelection,
   getSelectionPosition,
 } from "metabase/lib/dom";
-
-const KEYCODE_BACKSPACE = 8;
-const KEYCODE_LEFT = 37;
-const KEYCODE_RIGHT = 39;
-const KEYCODE_FORWARD_DELETE = 46;
 
 class TokenizedInput extends Component {
   constructor(props) {
@@ -78,8 +73,7 @@ class TokenizedInput extends Component {
     // isTyping signals whether the user is typing characters (keyCode >= 65) vs. deleting / navigating with arrows / clicking to select
     const isTyping = this._isTyping;
     // also keep isTyping same when deleting
-    this._isTyping =
-      e.keyCode >= 65 || (e.keyCode === KEYCODE_BACKSPACE && isTyping);
+    this._isTyping = e.keyCode >= 65 || (e.key === "Backspace" && isTyping);
 
     const input = ReactDOM.findDOMNode(this);
 
@@ -103,8 +97,7 @@ class TokenizedInput extends Component {
         if (
           !isSelected &&
           !isTyping &&
-          ((atEnd && e.keyCode === KEYCODE_BACKSPACE) ||
-            (atStart && e.keyCode === KEYCODE_FORWARD_DELETE))
+          ((atEnd && e.key === "Backspace") || (atStart && e.key === "Delete"))
         ) {
           // not selected, not "typging", and hit backspace, so mark as "selected"
           element.classList.add("Expression-selected");
@@ -113,8 +106,7 @@ class TokenizedInput extends Component {
           return;
         } else if (
           isSelected &&
-          ((atEnd && e.keyCode === KEYCODE_BACKSPACE) ||
-            (atStart && e.keyCode === KEYCODE_FORWARD_DELETE))
+          ((atEnd && e.key === "Backspace") || (atStart && e.key === "Delete"))
         ) {
           // selected and hit backspace, so delete it
           element.parentNode.removeChild(element);
@@ -124,8 +116,8 @@ class TokenizedInput extends Component {
           return;
         } else if (
           isSelected &&
-          ((atEnd && e.keyCode === KEYCODE_LEFT) ||
-            (atStart && e.keyCode === KEYCODE_RIGHT))
+          ((atEnd && e.key === "ArrowLeft") ||
+            (atStart && e.key === "ArrowRight"))
         ) {
           // selected and hit left arrow, so enter "typing" mode and unselect it
           element.classList.remove("Expression-selected");
@@ -186,3 +178,17 @@ class TokenizedInput extends Component {
 export default forwardRef(function TokenizedInputWithForwardedRef(props, ref) {
   return <TokenizedInput forwardedRef={ref} {...props} />;
 });
+
+TokenizedInput.propTypes = {
+  className: PropTypes.string,
+  onBlur: PropTypes.func,
+  onChange: PropTypes.func,
+  onClick: PropTypes.func,
+  onFocus: PropTypes.func,
+  onKeyDown: PropTypes.func,
+  parserOptions: PropTypes.object,
+  style: PropTypes.object,
+  syntaxTree: PropTypes.object,
+  tokenizedEditing: PropTypes.bool,
+  value: PropTypes.string,
+};

--- a/frontend/src/metabase/query_builder/components/expressions/TokenizedInput.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/TokenizedInput.jsx
@@ -181,6 +181,10 @@ export default forwardRef(function TokenizedInputWithForwardedRef(props, ref) {
 
 TokenizedInput.propTypes = {
   className: PropTypes.string,
+  forwardedRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.any }),
+  ]),
   onBlur: PropTypes.func,
   onChange: PropTypes.func,
   onClick: PropTypes.func,


### PR DESCRIPTION
Fixes #16161 

Also slightly refactors the conditionals using keydown `.key`  (user typing on the keyboard) event data for a more declarative api.