### PR TITLE
Fix #16131: Refactor "hacky" helper functions

### DIFF
--- a/frontend/test/__support__/e2e/cypress.js
+++ b/frontend/test/__support__/e2e/cypress.js
@@ -101,28 +101,6 @@ export function typeAndBlurUsingLabel(label, value) {
     .blur();
 }
 
-// Unfortunately, cypress `.type()` is currently broken and requires an ugly "hack"
-// it is documented here: https://github.com/cypress-io/cypress/issues/5480
-// `_typeUsingGet()` and `_typeUsingPlacehodler()` are temporary solution
-// please refrain from using them, unless absolutely neccessary!
-export function _typeUsingGet(selector, value, delay = 100) {
-  cy.get(selector)
-    .click()
-    .type(value, { delay })
-    .clear()
-    .click()
-    .type(value, { delay });
-}
-
-export function _typeUsingPlaceholder(selector, value, delay = 100) {
-  cy.findByPlaceholderText(selector)
-    .click()
-    .type(value, { delay })
-    .clear()
-    .click()
-    .type(value, { delay });
-}
-
 Cypress.on("uncaught:exception", (err, runnable) => false);
 
 export function withDatabase(databaseId, f) {

--- a/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
@@ -579,26 +579,6 @@ describe("scenarios > question > custom columns", () => {
   });
 });
 
-// `_typeUsingGet()` and `_typeUsingPlacehodler()` are temporary solution
-// please refrain from using them, unless absolutely neccessary!
-function _typeUsingGet(selector, value, delay = 100) {
-  cy.get(selector)
-    .click()
-    .type(value, { delay })
-    .clear()
-    .click()
-    .type(value, { delay });
-}
-
-function _typeUsingPlaceholder(selector, value, delay = 100) {
-  cy.findByPlaceholderText(selector)
-    .click()
-    .type(value, { delay })
-    .clear()
-    .click()
-    .type(value, { delay });
-}
-
 function enterCustomColumnDetails({ formula, name } = {}) {
   cy.get("[contenteditable='true']")
     .as("formula")

--- a/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
@@ -557,15 +557,11 @@ describe("scenarios > question > custom columns", () => {
 
     openOrdersTable({ mode: "notebook" });
     cy.findByText("Custom column").click();
-    popover().within(() => {
-      cy.get("[contenteditable='true']").type(`isnull([Discount])`, {
-        delay: 100,
-      });
-      cy.findByPlaceholderText("Something nice and descriptive").type(
-        "No discount",
-      );
-      cy.button("Done").click();
+    enterCustomColumnDetails({
+      formula: `isnull([Discount])`,
+      name: "No discount",
     });
+    cy.button("Done").click();
     cy.button("Visualize").click();
     cy.wait("@dataset").then(xhr => {
       expect(xhr.response.body.error).to.not.exist;

--- a/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
@@ -512,13 +512,11 @@ describe("scenarios > question > custom columns", () => {
   it.skip("should maintain data type (metabase#13122)", () => {
     openOrdersTable({ mode: "notebook" });
     cy.findByText("Custom column").click();
-    popover().within(() => {
-      cy.get("[contenteditable='true']")
-        .type("case([Discount] > 0, [Created At], [Product → Created At])")
-        .blur();
-      cy.findByPlaceholderText("Something nice and descriptive").type("13112");
-      cy.button("Done").click();
+    enterCustomColumnDetails({
+      formula: "case([Discount] > 0, [Created At], [Product → Created At])",
+      name: "13112",
     });
+    cy.button("Done").click();
     cy.findByText("Filter").click();
     popover()
       .findByText("13112")

--- a/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
@@ -87,15 +87,12 @@ describe("scenarios > question > custom columns", () => {
     // Add custom column based on previous aggregates
     const columnName = "MegaTotal";
     cy.findByText("Custom column").click();
-    popover().within(() => {
-      cy.get("[contenteditable='true']")
-        .click()
-        .type("[Sum of Subtotal] + [Sum of Total]");
-      cy.findByPlaceholderText("Something nice and descriptive")
-        .click()
-        .type(columnName);
-      cy.findByText("Done").click();
+
+    enterCustomColumnDetails({
+      formula: "[Sum of Subtotal] + [Sum of Total]",
+      name: columnName,
     });
+    cy.button("Done").click();
 
     cy.server();
     cy.route("POST", "/api/dataset").as("dataset");

--- a/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
@@ -25,16 +25,11 @@ describe("scenarios > question > custom columns", () => {
   });
 
   it("can create a custom column (metabase#13241)", () => {
-    const columnName = "Simple Math";
     openOrdersTable({ mode: "notebook" });
     cy.icon("add_data").click();
 
-    popover().within(() => {
-      _typeUsingGet("[contenteditable='true']", "1 + 1", 400);
-      _typeUsingPlaceholder("Something nice and descriptive", columnName);
-
-      cy.findByText("Done").click();
-    });
+    enterCustomColumnDetails({ formula: "1 + 1", name: "Math" });
+    cy.button("Done").click();
 
     cy.server();
     cy.route("POST", "/api/dataset").as("dataset");
@@ -42,7 +37,7 @@ describe("scenarios > question > custom columns", () => {
     cy.button("Visualize").click();
     cy.wait("@dataset");
     cy.findByText("There was a problem with your question").should("not.exist");
-    cy.get(".Visualization").contains(columnName);
+    cy.get(".Visualization").contains("Math");
   });
 
   it("can create a custom column with an existing column name", () => {

--- a/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
@@ -527,13 +527,11 @@ describe("scenarios > question > custom columns", () => {
   it.skip("filter based on `concat` function should not offer numeric options (metabase#13217)", () => {
     openPeopleTable({ mode: "notebook" });
     cy.findByText("Custom column").click();
-    popover().within(() => {
-      cy.get("[contenteditable='true']")
-        .type(`concat("State: ", [State])`)
-        .blur();
-      cy.findByPlaceholderText("Something nice and descriptive").type("13217");
-      cy.button("Done").click();
+    enterCustomColumnDetails({
+      formula: `concat("State: ", [State])`,
+      name: "13217",
     });
+    cy.button("Done").click();
     cy.findByText("Filter").click();
     popover()
       .findByText("13217")

--- a/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
@@ -10,14 +10,6 @@ import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATASET;
 
-const customFormulas = [
-  {
-    customFormula: "[Quantity] * 2",
-    columnName: "Double Qt",
-  },
-  { customFormula: "[Quantity] * [Product.Price]", columnName: "Sum Total" },
-];
-
 describe("scenarios > question > custom columns", () => {
   beforeEach(() => {
     restore();
@@ -41,23 +33,30 @@ describe("scenarios > question > custom columns", () => {
   });
 
   it("can create a custom column with an existing column name", () => {
-    customFormulas.forEach(({ customFormula, columnName }) => {
+    const customFormulas = [
+      {
+        formula: "[Quantity] * 2",
+        name: "Double Qt",
+      },
+      {
+        formula: "[Quantity] * [Product.Price]",
+        name: "Sum Total",
+      },
+    ];
+
+    customFormulas.forEach(({ formula, name }) => {
       openOrdersTable({ mode: "notebook" });
       cy.icon("add_data").click();
 
-      popover().within(() => {
-        _typeUsingGet("[contenteditable='true']", customFormula, 400);
-        _typeUsingPlaceholder("Something nice and descriptive", columnName);
-
-        cy.findByText("Done").click();
-      });
+      enterCustomColumnDetails({ formula, name });
+      cy.button("Done").click();
 
       cy.server();
       cy.route("POST", "/api/dataset").as("dataset");
 
       cy.button("Visualize").click();
       cy.wait("@dataset");
-      cy.get(".Visualization").contains(columnName);
+      cy.get(".Visualization").contains(name);
     });
   });
 

--- a/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
@@ -157,17 +157,8 @@ describe("scenarios > question > custom columns", () => {
 
     // add custom column
     cy.findByText("Custom column").click();
-    popover().within(() => {
-      // Double click at the end of this command is just an ugly hack that seems to reduce the flakiness of this test a lot!
-      // TODO: investigate contenteditable element - it is losing input value and I could reproduce it even locally (outside of Cypress)
-      cy.get("[contenteditable='true']")
-        .type("1+1")
-        .click()
-        .click();
-      cy.findByPlaceholderText("Something nice and descriptive").type("X");
-
-      cy.findByText("Done").click();
-    });
+    enterCustomColumnDetails({ formula: "1 + 1", name: "x" });
+    cy.button("Done").click();
 
     cy.button("Visualize").click();
 
@@ -182,9 +173,7 @@ describe("scenarios > question > custom columns", () => {
     // ID should be "1" but it is picking the product ID and is showing "14"
     cy.get(".TableInteractive-cellWrapper--firstColumn")
       .eq(1) // the second cell from the top in the first column (the first one is a header cell)
-      .within(() => {
-        cy.findByText("1");
-      });
+      .findByText("1");
   });
 
   it.skip("should be able to use custom expression after aggregation (metabase#13857)", () => {

--- a/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
@@ -1,8 +1,6 @@
 import {
   restore,
   popover,
-  _typeUsingGet,
-  _typeUsingPlaceholder,
   openOrdersTable,
   openPeopleTable,
   visitQuestionAdhoc,
@@ -612,3 +610,23 @@ describe("scenarios > question > custom columns", () => {
     cy.findByText("No discount");
   });
 });
+
+// `_typeUsingGet()` and `_typeUsingPlacehodler()` are temporary solution
+// please refrain from using them, unless absolutely neccessary!
+function _typeUsingGet(selector, value, delay = 100) {
+  cy.get(selector)
+    .click()
+    .type(value, { delay })
+    .clear()
+    .click()
+    .type(value, { delay });
+}
+
+function _typeUsingPlaceholder(selector, value, delay = 100) {
+  cy.findByPlaceholderText(selector)
+    .click()
+    .type(value, { delay })
+    .clear()
+    .click()
+    .type(value, { delay });
+}

--- a/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
@@ -469,13 +469,10 @@ describe("scenarios > question > custom columns", () => {
       openOrdersTable({ mode: "notebook" });
       cy.findByText("Custom column").click();
 
-      cy.get("[contenteditable='true']").as("formula");
-
-      popover().within(() => {
-        _typeUsingGet("[contenteditable='true']", "1 + 1", 400);
-        _typeUsingPlaceholder("Something nice and descriptive", "Math");
+      enterCustomColumnDetails({
+        formula: "1+1", // Formula was intentionally written without spaces (important for this repro)!
+        name: "Math",
       });
-
       cy.button("Done").should("not.be.disabled");
     });
 

--- a/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
@@ -456,8 +456,7 @@ describe("scenarios > question > custom columns", () => {
   it.skip("should handle floating point numbers with '0' omitted (metabase#15741)", () => {
     openOrdersTable({ mode: "notebook" });
     cy.findByText("Custom column").click();
-    cy.get("[contenteditable='true']").type(".5 * [Discount]");
-    cy.findByPlaceholderText("Something nice and descriptive").type("Foo");
+    enterCustomColumnDetails({ formula: ".5 * [Discount]", name: "Foo" });
     cy.findByText("Unknown Field: .5").should("not.exist");
     cy.button("Done").should("not.be.disabled");
   });

--- a/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
@@ -630,3 +630,10 @@ function _typeUsingPlaceholder(selector, value, delay = 100) {
     .click()
     .type(value, { delay });
 }
+
+function enterCustomColumnDetails({ formula, name } = {}) {
+  cy.get("[contenteditable='true']")
+    .as("formula")
+    .type(formula);
+  cy.findByPlaceholderText("Something nice and descriptive").type(name);
+}

--- a/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
@@ -106,27 +106,19 @@ describe("scenarios > question > custom columns", () => {
   });
 
   it.skip("should allow 'zoom in' drill-through when grouped by custom column (metabase#13289)", () => {
-    const columnName = "TestColumn";
     openOrdersTable({ mode: "notebook" });
 
     // Add custom column that will be used later in summarize (group by)
     cy.findByText("Custom column").click();
-    popover().within(() => {
-      _typeUsingGet("[contenteditable='true']", "1 + 1", 400);
-      _typeUsingPlaceholder("Something nice and descriptive", columnName);
-
-      cy.findByText("Done").click();
-    });
+    enterCustomColumnDetails({ formula: "1 + 1", name: "Math" });
+    cy.button("Done").click();
 
     cy.findByText("Summarize").click();
-    popover().within(() => {
-      cy.findByText("Count of rows").click();
-    });
-
+    cy.findByText("Count of rows").click();
     cy.findByText("Pick a column to group by").click();
-    popover().within(() => {
-      cy.findByText(columnName).click();
-    });
+    popover()
+      .findByText("Math")
+      .click();
 
     cy.icon("add")
       .last()


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- Fixes #16131 
- Completely removes the need for `_typeUsingGet` and `_typeUsingPlaceholder` helper functions. They were too hacky and way too slow. Fortunately, fix from #16157 removed the need for any type of hack around `.type()` function in `contentEditable` field (`ExpressionWidget` component)
- Introduces a [new helper function](https://github.com/metabase/metabase/pull/16164/commits/a4b3f8f411869c2f12640833aceded40a5283b5a) that greatly simplifies creating reproductions by hiding away cumbersome syntax
```javascript
// instead of this
popover().within(() => {
  cy.get("[contenteditable='true']")
    .click()
    .type(formula);
  cy.findByPlaceholderText("Something nice and descriptive")
    .click()
    .type(name);
});

// use this
enterCustomColumnDetails({ formula, name })
```
- Refactors all related tests - they all now use `enterCustomColumnDetails()`