### PR TITLE
Fix warning about maxHeight in Popover

### DIFF
--- a/frontend/src/metabase/components/Popover.jsx
+++ b/frontend/src/metabase/components/Popover.jsx
@@ -128,7 +128,7 @@ export default class Popover extends Component {
 
   _popoverComponent() {
     const childProps = {
-      maxHeight: this._getMaxHeight(),
+      "max-height": this._getMaxHeight(),
     };
     const content = (
       <div

--- a/frontend/src/metabase/components/Popover.jsx
+++ b/frontend/src/metabase/components/Popover.jsx
@@ -11,8 +11,6 @@ import "./Popover.css";
 
 // space we should leave berween page edge and popover edge
 const PAGE_PADDING = 10;
-// Popover padding and border
-const POPOVER_BODY_PADDING = 2;
 
 export default class Popover extends Component {
   constructor(props, context) {
@@ -185,30 +183,6 @@ export default class Popover extends Component {
     } else {
       this._tether = new Tether(tetherOptions);
     }
-  }
-
-  _getMaxHeight() {
-    const { top, bottom } = this._getTargetElement().getBoundingClientRect();
-
-    let attachments;
-    if (this.props.pinInitialAttachment && this._best) {
-      // if we have a pinned attachment only use that
-      attachments = [this._best.attachmentY];
-    } else {
-      // otherwise use the verticalAttachments prop
-      attachments = this.props.verticalAttachments;
-    }
-
-    const availableHeights = attachments.map(attachmentY =>
-      attachmentY === "top"
-        ? window.innerHeight - bottom - this.props.targetOffsetY - PAGE_PADDING
-        : attachmentY === "bottom"
-        ? top - this.props.targetOffsetY - PAGE_PADDING
-        : 0,
-    );
-
-    // get the largest available height, then subtract .PopoverBody's border and padding
-    return Math.max(...availableHeights) - POPOVER_BODY_PADDING;
   }
 
   _getBestAttachmentOptions(

--- a/frontend/src/metabase/components/Popover.jsx
+++ b/frontend/src/metabase/components/Popover.jsx
@@ -127,9 +127,7 @@ export default class Popover extends Component {
   }
 
   _popoverComponent() {
-    const childProps = {
-      "max-height": this._getMaxHeight(),
-    };
+    const childProps = {};
     const content = (
       <div
         id={this.props.id}

--- a/frontend/src/metabase/components/TooltipPopover.jsx
+++ b/frontend/src/metabase/components/TooltipPopover.jsx
@@ -22,8 +22,8 @@ const TooltipPopover = ({ children, constrainedWidth, ...props }) => {
       targetOffsetY={10}
       hasArrow
       horizontalAttachments={["center", "left", "right"]}
-      // OnClickOutsideWrapper is unecessary and causes existing popovers not to
-      // be dismissed if a tooltip is visisble, so pass noOnClickOutsideWrapper
+      // OnClickOutsideWrapper is unnecessary and causes existing popovers to
+      // not be dismissed if a tooltip is visible, so pass noOnClickOutsideWrapper
       noOnClickOutsideWrapper
       {...props}
     >
@@ -33,7 +33,7 @@ const TooltipPopover = ({ children, constrainedWidth, ...props }) => {
 };
 
 TooltipPopover.defaultProps = {
-  // default to having a constrained toolip, which limits the width so longer strings wrap.
+  // default to having a constrained tooltip, which limits the width so longer strings wrap.
   constrainedWidth: true,
 };
 


### PR DESCRIPTION
Fixes #16165

Also corrects a few typos in TooltipPopover comments.

**How to test**

1. Open orders table from a custom question
2. Click on the small grid icon to create Custom column
3. Focus on the "Formula" input, the topmost in the popup
4. Filter console by `Popover`

You should see no warning.