### PR TITLE
Fix the display name of fields in a filter

### DIFF
--- a/frontend/src/metabase-lib/lib/queries/structured/Filter.js
+++ b/frontend/src/metabase-lib/lib/queries/structured/Filter.js
@@ -1,5 +1,7 @@
 import MBQLClause from "./MBQLClause";
 
+import { FieldDimension } from "metabase-lib/lib/Dimension";
+
 import type {
   Filter as FilterObject,
   FieldFilter,
@@ -288,16 +290,15 @@ export default class Filter extends MBQLClause {
     ) {
       return generateTimeFilterValuesDescriptions(this);
     } else {
+      const metadata = this.metadata();
       return args
         .map((value, index) => [
           value,
           getFilterArgumentFormatOptions(operator, index),
         ])
         .filter(([value, options]) => value !== undefined && !options.hide)
-        .map(
-          ([value, options], index) =>
-            // FIXME: remapping
-            value,
+        .map(([value, options], index) => {
+          // FIXME: remapping
           // <Value
           //   key={index}
           //   value={value}
@@ -305,7 +306,14 @@ export default class Filter extends MBQLClause {
           //   remap
           //   {...options}
           // />
-        );
+          if (FieldDimension.isFieldClause(value)) {
+            const fieldDimension = FieldDimension.parseMBQL(value, metadata);
+            if (fieldDimension) {
+              return fieldDimension.displayName();
+            }
+          }
+          return value;
+        });
     }
   }
 

--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -908,7 +908,7 @@ describe("scenarios > question > filter", () => {
     cy.findByText("Gizmo").should("not.exist");
   });
 
-  it.skip("custom expression filter should reference fields by their name, not by their id (metabase#15748)", () => {
+  it("custom expression filter should reference fields by their name, not by their id (metabase#15748)", () => {
     openOrdersTable({ mode: "notebook" });
     cy.findByText("Filter").click();
     cy.findByText("Custom Expression").click();


### PR DESCRIPTION
When rendering the full display name of a filter, take into account that the right-hand side of a standard filter (i.e. Y in the "X > Y" form) can be also a field reference and not merely a constant.

This should fix #15748.

Run the unit tests:
```
yarn test-unit frontend/test/metabase-lib/lib/Dimension.unit.spec.js
```
and E2E tests:
```
yarn test-cypress-no-build --spec frontend/test/metabase/scenarios/question/filter.cy.spec.js
```

Manual steps to try:

1. Ask a question, Simple question
2. Sample Dataset, Orders
3. Filter, Custom Expression, type `[Tax] < [Discount]` and click Done

**Before this PR**
![image](https://user-images.githubusercontent.com/7288/119015404-b974ec00-b94d-11eb-8a32-a234b32a9aa5.png)

**After this PR**
![image](https://user-images.githubusercontent.com/7288/119015390-b7129200-b94d-11eb-98e0-fcd724f9211d.png)
