### PR TITLE
Fix standard filter detection

### DIFF
--- a/frontend/src/metabase/lib/query/filter.js
+++ b/frontend/src/metabase/lib/query/filter.js
@@ -78,11 +78,20 @@ export function isStandard(filter: FilterClause): boolean {
   const field = filter[1];
   if (FILTER_OPERATORS.has(op)) {
     // only allows constant right-hand side, e.g. ["<", field, 42]
-    return isValidField(field) && isLiteral(filter[2]);
+    // undefined rhs represents incomplete filter (still standard, but not valid)
+    const rhs = filter[2];
+    return isValidField(field) && (rhs ? isLiteral(rhs) : true);
   }
   if (op === "between") {
     // only allows constant ranges, e.g. ["between", field, 0, 4]
-    return isValidField(field) && isLiteral(filter[2]) && isLiteral(filter[3]);
+    // undefined range represents incomplete filter (still standard, but not valid)
+    const start = filter[2];
+    const end = filter[3];
+    return (
+      isValidField(field) &&
+      (start ? isLiteral(start) : true) &&
+      (end ? isLiteral(end) : true)
+    );
   }
 
   return (

--- a/frontend/src/metabase/lib/query/filter.js
+++ b/frontend/src/metabase/lib/query/filter.js
@@ -81,9 +81,7 @@ export function isStandard(filter: FilterClause): boolean {
   // undefined args represents an incomplete filter (still standard, but not valid)
   const isLiteralOrUndefined = arg => (arg ? isLiteral(arg) : true);
 
-  const op = filter[0];
-  const field = filter[1];
-  const args = filter.slice(2);
+  const [op, field, ...args] = filter;
 
   if (FILTER_OPERATORS.has(op) || op === "between") {
     // only allows constant argument(s), e.g. 42 in ["<", field, 42]

--- a/frontend/src/metabase/lib/query/filter.js
+++ b/frontend/src/metabase/lib/query/filter.js
@@ -6,6 +6,10 @@ import {
   isLiteral,
 } from "metabase/lib/expressions";
 
+import { STRING, getOperatorByTypeAndName } from "metabase/lib/schema_metadata";
+
+import _ from "underscore";
+
 import type {
   FilterClause,
   Filter,
@@ -74,23 +78,25 @@ export function isStandard(filter: FilterClause): boolean {
     return false;
   }
 
+  // undefined args represents an incomplete filter (still standard, but not valid)
+  const isLiteralOrUndefined = arg => (arg ? isLiteral(arg) : true);
+
   const op = filter[0];
   const field = filter[1];
-  if (FILTER_OPERATORS.has(op)) {
-    // only allows constant right-hand side, e.g. ["<", field, 42]
-    // undefined rhs represents incomplete filter (still standard, but not valid)
-    const rhs = filter[2];
-    return isValidField(field) && (rhs ? isLiteral(rhs) : true);
+  const args = filter.slice(2);
+
+  if (FILTER_OPERATORS.has(op) || op === "between") {
+    // only allows constant argument(s), e.g. 42 in ["<", field, 42]
+    return isValidField(field) && _.all(args, arg => isLiteralOrUndefined(arg));
   }
-  if (op === "between") {
-    // only allows constant ranges, e.g. ["between", field, 0, 4]
-    // undefined range represents incomplete filter (still standard, but not valid)
-    const start = filter[2];
-    const end = filter[3];
+  const stringOp = getOperatorByTypeAndName(STRING, op);
+  if (stringOp) {
+    // do not check filter option, e.g. "case-sensitive" for "contains"
+    const optionNames = _.keys(stringOp.options);
+    const isOptionName = arg => _.contains(optionNames, _.first(_.keys(arg)));
+    const valueArgs = _.filter(args, arg => !isOptionName(arg));
     return (
-      isValidField(field) &&
-      (start ? isLiteral(start) : true) &&
-      (end ? isLiteral(end) : true)
+      isValidField(field) && _.all(valueArgs, arg => isLiteralOrUndefined(arg))
     );
   }
 

--- a/frontend/test/metabase-lib/lib/queries/structured/Filter.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/structured/Filter.unit.spec.js
@@ -92,10 +92,13 @@ describe("Filter", () => {
   });
 
   const CASES = [
-    ["isStandard", ["=", ["field", 1, null]]],
+    ["isStandard", ["=", ["field", 1, null], 42]],
     ["isStandard", [null, ["field", 1, null]]], // assume null operator is standard
+    ["isStandard", ["between", ["field", 1, null], 1, 4]],
     ["isSegment", ["segment", 1]],
     ["isCustom", ["or", ["=", ["field", 1, null], 42]]],
+    ["isCustom", ["=", ["field", 1, null], ["field", 2, null]]],
+    ["isCustom", ["between", ["field", 1, null], 1, ["field", 2, null]]],
   ];
   for (const method of ["isStandard", "isSegment", "isCustom"]) {
     describe(method, () => {

--- a/frontend/test/metabase-lib/lib/queries/structured/Filter.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/structured/Filter.unit.spec.js
@@ -95,6 +95,8 @@ describe("Filter", () => {
     ["isStandard", ["=", ["field", 1, null], 42]],
     ["isStandard", [null, ["field", 1, null]]], // assume null operator is standard
     ["isStandard", ["between", ["field", 1, null], 1, 4]],
+    ["isStandard", ["=", ["field", 1, null], undefined]], // standard but invalid
+    ["isStandard", ["between", ["field", 1, null], undefined, 4]], // standard but invalid
     ["isSegment", ["segment", 1]],
     ["isCustom", ["or", ["=", ["field", 1, null], 42]]],
     ["isCustom", ["=", ["field", 1, null], ["field", 2, null]]],

--- a/frontend/test/metabase-lib/lib/queries/structured/Filter.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/structured/Filter.unit.spec.js
@@ -95,12 +95,21 @@ describe("Filter", () => {
     ["isStandard", ["=", ["field", 1, null], 42]],
     ["isStandard", [null, ["field", 1, null]]], // assume null operator is standard
     ["isStandard", ["between", ["field", 1, null], 1, 4]],
+    ["isStandard", ["contains", ["field", 1, null], "river"]],
+    ["isStandard", ["is-empty", ["field", 1, null]]],
+    ["isStandard", ["starts-with", ["field", 1, null], "X"]],
+    ["isStandard", ["ends-with", ["field", 1, null], "Y"]],
     ["isStandard", ["=", ["field", 1, null], undefined]], // standard but invalid
     ["isStandard", ["between", ["field", 1, null], undefined, 4]], // standard but invalid
     ["isSegment", ["segment", 1]],
     ["isCustom", ["or", ["=", ["field", 1, null], 42]]],
     ["isCustom", ["=", ["field", 1, null], ["field", 2, null]]],
     ["isCustom", ["between", ["field", 1, null], 1, ["field", 2, null]]],
+    ["isCustom", ["between", ["field", 1, null], ["field", 2, null], 3]],
+    ["isCustom", ["between", ["field", 1, null], ["field", 7], ["field", 9]]],
+    ["isCustom", ["contains", ["field", 8], ["upper", "cat"]]],
+    ["isCustom", ["starts-with", ["field", 1, null], ["lower", "X"]]],
+    ["isCustom", ["ends-with", ["field", 1, null], ["trim", "Y"]]],
   ];
   for (const method of ["isStandard", "isSegment", "isCustom"]) {
     describe(method, () => {

--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -908,13 +908,13 @@ describe("scenarios > question > filter", () => {
     cy.findByText("Gizmo").should("not.exist");
   });
 
-  it.skip("custom expression filter should reference fields by their name, not by their id (metabase#15748)", () => {
+  it("custom expression filter should reference fields by their name, not by their id (metabase#15748)", () => {
     openOrdersTable({ mode: "notebook" });
     cy.findByText("Filter").click();
     cy.findByText("Custom Expression").click();
     cy.get("[contenteditable=true]").type("[Total] < [Subtotal]");
     cy.button("Done").click();
-    cy.findByText("Total is less than Subtotal");
+    cy.findByText("Total < Subtotal");
   });
 
   it("custom expression filter should allow the use of parentheses in combination with logical operators (metabase#15754)", () => {


### PR DESCRIPTION
When attempting to convert a filter, check first if the filter is a comparison against a constant. Otherwise, preserve the filter is in its custom expression (MBQL) form.

Each in the following list can be converted into a standard filter (since the simple UI for the standard filter only allows literal comparison):

```
  [Total] < 300
  between([Discount], 5, 15)
  [Name] = "Joe"
```

but none of these should be converted

```
  [Discount] <= [Tax]
  between([Rating], 0, [MaxRating])
  [Reviewer] != UPPER([Name])
```

This fixes, among others, issue #15748.

Run the unit tests:
```
yarn test-unit frontend/test/metabase-lib/lib/queries/structured/Filter.unit.spec.js
```
and the E2E tests:
```
yarn test-cypress-open --spec frontend/test/metabase/scenarios/question/filter.cy.spec.js
```

Manual steps to try:

1. Ask a question, Simple question
2. Sample Dataset, Orders
3. Filter, Custom Expression, type `[Tax] < [Discount]` and click Done

**Before this PR**
![image](https://user-images.githubusercontent.com/7288/119015404-b974ec00-b94d-11eb-8a32-a234b32a9aa5.png)

**After this PR**

![image](https://user-images.githubusercontent.com/7288/119062755-60787880-b98c-11eb-9821-799d5267a0af.png)

Also clicking on that "Tax < Discount" will open a custom expression editor (not the filter drop-down):

![image](https://user-images.githubusercontent.com/7288/119062889-a46b7d80-b98c-11eb-854e-dcb4ab7687f9.png)
