### PR TITLE
add commenting to moderation requests

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationIssueThread.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationIssueThread.jsx
@@ -104,6 +104,7 @@ CommentForm.propTypes = {
 
 function CommentForm({ className, onSubmit, onCancel, isPending }) {
   const [value, setValue] = useState("");
+  const isEmpty = value.trim().length === 0;
   return (
     <form className={className} onSubmit={onSubmit}>
       <textarea
@@ -121,7 +122,12 @@ function CommentForm({ className, onSubmit, onCancel, isPending }) {
         >
           {t`Cancel`}
         </Button>
-        <Button className="py1" disabled={isPending} type="submit" primary>
+        <Button
+          className="py1"
+          disabled={isPending || isEmpty}
+          type="submit"
+          primary
+        >
           {t`Done`}
         </Button>
       </div>

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationIssueThread.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationIssueThread.jsx
@@ -1,6 +1,5 @@
-import React, { useState } from "react";
+import React, { useState, useRef, useEffect } from "react";
 import PropTypes from "prop-types";
-import cx from "classnames";
 import { t } from "ttag";
 
 import {
@@ -49,7 +48,7 @@ export function ModerationIssueThread({
   };
 
   return (
-    <div className={cx(className, "")}>
+    <div className={className}>
       <div
         className={`flex align-center text-${color} text-${color}-hover text-bold`}
       >
@@ -113,8 +112,16 @@ CommentForm.propTypes = {
 };
 
 function CommentForm({ className, onSubmit, onCancel, isPending }) {
+  const textAreaRef = useRef();
   const [value, setValue] = useState("");
   const isEmpty = value.trim().length === 0;
+
+  useEffect(() => {
+    const textAreaEl = textAreaRef.current;
+    if (textAreaEl) {
+      textAreaEl.focus();
+    }
+  }, []);
 
   return (
     <form
@@ -129,6 +136,7 @@ function CommentForm({ className, onSubmit, onCancel, isPending }) {
         value={value}
         onChange={e => setValue(e.target.value)}
         name="comment"
+        ref={textAreaRef}
       />
       <div className="pt1 flex column-gap-1 justify-end">
         <Button

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationIssueThread.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationIssueThread.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from "react";
+import React, { useState } from "react";
 import PropTypes from "prop-types";
 import { t } from "ttag";
 
@@ -112,16 +112,8 @@ CommentForm.propTypes = {
 };
 
 function CommentForm({ className, onSubmit, onCancel, isPending }) {
-  const textAreaRef = useRef();
   const [value, setValue] = useState("");
   const isEmpty = value.trim().length === 0;
-
-  useEffect(() => {
-    const textAreaEl = textAreaRef.current;
-    if (textAreaEl) {
-      textAreaEl.focus();
-    }
-  }, []);
 
   return (
     <form
@@ -136,7 +128,7 @@ function CommentForm({ className, onSubmit, onCancel, isPending }) {
         value={value}
         onChange={e => setValue(e.target.value)}
         name="comment"
-        ref={textAreaRef}
+        autoFocus
       />
       <div className="pt1 flex column-gap-1 justify-end">
         <Button

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationIssueThread.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationIssueThread.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import PropTypes from "prop-types";
 import cx from "classnames";
 import { t } from "ttag";
@@ -30,9 +30,14 @@ export function ModerationIssueThread({
   onComment,
   onModerate,
 }) {
+  const [showCommentForm, setShowCommentForm] = useState(false);
   const color = getColor(request.type);
   const icon = getModerationStatusIcon(request.type);
-  const hasButtonBar = !!(onComment || onModerate);
+  const showButtonBar = !showCommentForm && !!(onComment || onModerate);
+
+  const onSubmit = e => {
+    e.preventDefault();
+  };
 
   return (
     <div className={cx(className, "")}>
@@ -62,10 +67,20 @@ export function ModerationIssueThread({
           />
         );
       })}
-      {hasButtonBar && (
+      {showCommentForm && (
+        <CommentForm
+          className="pt1"
+          onSubmit={onSubmit}
+          onCancel={() => setShowCommentForm(false)}
+        />
+      )}
+      {showButtonBar && (
         <div className="flex justify-end column-gap-1 pt1">
           {onComment && (
-            <Button className="py1" onClick={onComment}>{t`Comment`}</Button>
+            <Button
+              className="py1"
+              onClick={() => setShowCommentForm(true)}
+            >{t`Comment`}</Button>
           )}
           {onModerate && (
             <ModerationIssueActionMenu
@@ -77,5 +92,39 @@ export function ModerationIssueThread({
         </div>
       )}
     </div>
+  );
+}
+
+CommentForm.propTypes = {
+  className: PropTypes.string,
+  onSubmit: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+  isPending: PropTypes.bool,
+};
+
+function CommentForm({ className, onSubmit, onCancel, isPending }) {
+  const [value, setValue] = useState("");
+  return (
+    <form className={className} onSubmit={onSubmit}>
+      <textarea
+        className="input full max-w-full min-w-full"
+        value={value}
+        onChange={e => setValue(e.target.value)}
+        name="comment"
+      />
+      <div className="pt1 flex column-gap-1 justify-end">
+        <Button
+          className="py1"
+          disabled={isPending}
+          type="button"
+          onClick={onCancel}
+        >
+          {t`Cancel`}
+        </Button>
+        <Button className="py1" disabled={isPending} type="submit" primary>
+          {t`Done`}
+        </Button>
+      </div>
+    </form>
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationIssueThread.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationIssueThread.jsx
@@ -128,7 +128,7 @@ function CommentForm({ className, onSubmit, onCancel, isPending }) {
       className={className}
       onSubmit={e => {
         e.preventDefault();
-        onSubmit(value);
+        onSubmit(value.trim());
       }}
     >
       <textarea

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationRequestsPanel.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationRequestsPanel.jsx
@@ -15,7 +15,9 @@ import { getIsModerator } from "metabase-enterprise/moderation/selectors";
 
 ModerationRequestsPanel.propTypes = {
   onModerate: PropTypes.func.isRequired,
+  onComment: PropTypes.func.isRequired,
   requests: PropTypes.array.isRequired,
+  comments: PropTypes.array.isRequired,
   onReturn: PropTypes.func.isRequired,
   users: PropTypes.array,
   isModerator: PropTypes.bool.isRequired,
@@ -25,26 +27,43 @@ ModerationRequestsPanel.propTypes = {
 
 function ModerationRequestsPanel({
   onModerate,
+  onComment,
   requests,
+  comments,
   onReturn,
   users,
   isModerator,
   currentUser,
   returnText,
 }) {
-  const usersById = users.reduce((map, user) => {
-    map[user.id] = user;
-    return map;
-  }, {});
+  const usersById = _.indexBy(users, "id");
 
   const requestsWithMetadata = requests.map(request => {
     const user = usersById[request.requester_id];
     const requesterDisplayName = user && user.common_name;
     return {
       ...request,
-      requesterDisplayName,
+      title: requesterDisplayName,
+      timestamp: new Date(request.created_at).valueOf(),
     };
   });
+
+  const commentsWithMetadata = comments.map(comment => {
+    const user = usersById[comment.author_id];
+    console.log(user);
+    const authorDisplayName = user && user.common_name;
+    return {
+      ...comment,
+      title: authorDisplayName,
+      timestamp: new Date(comment.created_at).valueOf(),
+      isModerator: true,
+    };
+  });
+
+  const commentsByRequestId = _.groupBy(
+    commentsWithMetadata,
+    "commented_item_id",
+  );
 
   return (
     <SidebarContent className="full-height px1">
@@ -61,13 +80,17 @@ function ModerationRequestsPanel({
       <div className="px2">
         {requestsWithMetadata.length > 0 ? (
           requestsWithMetadata.map(request => {
+            const canComment =
+              isModerator || request.requester_id === currentUser.id;
+            const comments = commentsByRequestId[request.id];
             return (
               <ModerationIssueThread
                 key={request.id}
                 className="py2 border-row-divider"
                 request={request}
+                comments={comments}
                 onModerate={isModerator && onModerate}
-                onComment={() => {}}
+                onComment={canComment && onComment}
               />
             );
           })

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationRequestsPanel.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationRequestsPanel.jsx
@@ -10,6 +10,7 @@ import { getUser } from "metabase/selectors/user";
 import Button from "metabase/components/Button";
 import SidebarContent from "metabase/query_builder/components/SidebarContent";
 import { ModerationIssueThread } from "metabase-enterprise/moderation/components/ModerationIssueThread";
+import { isUserModerator } from "metabase-enterprise/moderation";
 
 import { getIsModerator } from "metabase-enterprise/moderation/selectors";
 
@@ -50,13 +51,12 @@ function ModerationRequestsPanel({
 
   const commentsWithMetadata = comments.map(comment => {
     const user = usersById[comment.author_id];
-    console.log(user);
     const authorDisplayName = user && user.common_name;
     return {
       ...comment,
       title: authorDisplayName,
       timestamp: new Date(comment.created_at).valueOf(),
-      isModerator: true,
+      isModerator: isUserModerator(user),
     };
   });
 

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationRequestsPanel.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationRequestsPanel.jsx
@@ -67,6 +67,7 @@ function ModerationRequestsPanel({
                 className="py2 border-row-divider"
                 request={request}
                 onModerate={isModerator && onModerate}
+                onComment={() => {}}
               />
             );
           })

--- a/enterprise/frontend/src/metabase-enterprise/moderation/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/index.js
@@ -124,3 +124,7 @@ export function getModerationEvents(question, usersById) {
 
   return [...requests, ...reviews];
 }
+
+export function isUserModerator(user) {
+  return user.id === 1;
+}

--- a/frontend/src/metabase-lib/lib/Question.js
+++ b/frontend/src/metabase-lib/lib/Question.js
@@ -992,6 +992,10 @@ export default class Question {
   getModerationRequests() {
     return getIn(this, ["_card", "moderation_requests"]) || [];
   }
+
+  getComments() {
+    return getIn(this, ["_card", "comments"]) || [];
+  }
 }
 
 window.Question = Question;

--- a/frontend/src/metabase/components/CommentHeader.jsx
+++ b/frontend/src/metabase/components/CommentHeader.jsx
@@ -38,7 +38,7 @@ function CommentHeader({ className, icon, title, timestamp, actions = [] }) {
   return (
     <div className={cx("flex justify-between align-center", className)}>
       <div className="flex align-center">
-        {icon && <StyledIcon name={icon} />}
+        {icon && <StyledIcon name={icon} size={12} />}
         <span className="text-bold">{title}</span>
         {timestamp && (
           <time className="pl1 text-light" dateTime={timestamp}>

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -57,6 +57,7 @@ import {
   UserApi,
   ModerationReviewApi,
   ModerationRequestApi,
+  ModerationCommentApi,
 } from "metabase/services";
 
 import { parse as urlParse } from "url";
@@ -1416,3 +1417,18 @@ export const revertToRevision = createThunkAction(
     };
   },
 );
+
+export async function createModerationRequestComment({
+  text,
+  cardId,
+  moderationRequestId,
+}) {
+  // something like this
+  // await ModerationCommentApi.create({
+  //   text,
+  //   commented_item_id: cardId,
+  //   commented_item_type: "card",
+  //   moderationRequestId // this prop doesn't exist yet and obv won't be named this exactly
+  // })
+  return reloadCard();
+}

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -1420,15 +1420,12 @@ export const revertToRevision = createThunkAction(
 
 export async function createModerationRequestComment({
   text,
-  cardId,
   moderationRequestId,
 }) {
-  // something like this
-  // await ModerationCommentApi.create({
-  //   text,
-  //   commented_item_id: cardId,
-  //   commented_item_type: "card",
-  //   moderationRequestId // this prop doesn't exist yet and obv won't be named this exactly
-  // })
+  await ModerationCommentApi.create({
+    text,
+    commented_item_id: moderationRequestId,
+    commented_item_type: "moderation_request",
+  });
   return reloadCard();
 }

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -1427,5 +1427,5 @@ export async function createModerationRequestComment({
     commented_item_id: moderationRequestId,
     commented_item_type: "moderation_request",
   });
-  return reloadCard();
+  return softReloadCard();
 }

--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -108,6 +108,7 @@ export default class View extends React.Component {
       onOpenModal,
       createModerationReview,
       createModerationRequest,
+      createModerationRequestComment,
     } = this.props;
     const {
       aggregationIndex,
@@ -167,6 +168,7 @@ export default class View extends React.Component {
         onOpenModal={onOpenModal}
         createModerationReview={createModerationReview}
         createModerationRequest={createModerationRequest}
+        createModerationRequestComment={createModerationRequestComment}
       />
     ) : null;
 

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebar.jsx
@@ -20,6 +20,7 @@ QuestionDetailsSidebar.propTypes = {
   onOpenModal: PropTypes.func.isRequired,
   createModerationReview: PropTypes.func.isRequired,
   createModerationRequest: PropTypes.func.isRequired,
+  createModerationRequestComment: PropTypes.func.isRequired,
 };
 
 function QuestionDetailsSidebar({
@@ -27,6 +28,7 @@ function QuestionDetailsSidebar({
   onOpenModal,
   createModerationReview,
   createModerationRequest,
+  createModerationRequestComment,
 }) {
   const [view, setView] = useState({
     name: undefined,
@@ -35,6 +37,7 @@ function QuestionDetailsSidebar({
   });
   const { name, props: viewProps } = view;
   const id = question.id();
+  const comments = question.getComments();
 
   const onReturn = () =>
     setView(({ previousView }) => ({
@@ -46,6 +49,13 @@ function QuestionDetailsSidebar({
       name: SIDEBAR_VIEWS.CREATE_ISSUE_PANEL,
       props: { issueType: moderationReviewType, moderationRequest },
       previousView: SIDEBAR_VIEWS.OPEN_ISSUES_PANEL,
+    });
+  };
+
+  const onComment = (text, moderationRequest) => {
+    return createModerationRequestComment({
+      text,
+      moderationRequestId: moderationRequest.id,
     });
   };
 
@@ -65,12 +75,22 @@ function QuestionDetailsSidebar({
         <ModerationRequestsPanel
           returnText={t`Open issues`}
           requests={getOpenRequests(question)}
+          comments={comments}
           onModerate={onModerate}
+          onComment={onComment}
           onReturn={onReturn}
         />
       );
     case SIDEBAR_VIEWS.MODERATION_REQUEST_PANEL:
-      return <ModerationRequestsPanel {...viewProps} onReturn={onReturn} />;
+      return (
+        <ModerationRequestsPanel
+          {...viewProps}
+          comments={comments}
+          onReturn={onReturn}
+          onModerate={onModerate}
+          onComment={onComment}
+        />
+      );
     case SIDEBAR_VIEWS.DETAILS:
     default:
       return (

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -317,6 +317,10 @@ export const ModerationRequestApi = {
   update: PUT("/api/moderation-request/:id"),
 };
 
+export const ModerationCommentApi = {
+  create: POST("/api/comment"),
+};
+
 export const PulseApi = {
   list: GET("/api/pulse"),
   create: POST("/api/pulse"),


### PR DESCRIPTION
Adds the ability to comment on moderation requests when viewing a `ModerationRequestsPanel`. Metabase form code is a bit byzantine so I'm creating a new `CommentForm` to try to keep things simple.

Steps to view:
1. Create a saved question
2. Access the saved question using a non-admin user
3. Create a new moderation request on the question
4. View the "Open Issues" panel (by clicking the open issues button in the left side panel) and see that there is a comment button on the newly created request. You should be able to comment on your own requests.
5. Log in with an admin user and navigate to the same moderation request. You should also be able to comment using the admin user. Note that the actions in the dropdown you see as an admin don't quite work just yet.

https://user-images.githubusercontent.com/13057258/119590173-1bd44f00-bd89-11eb-9b99-7ce58aa2af19.mov

