### PR TITLE
#16170 Repro: Line Chart on MongoDB drops all values when using "Replace Missing Values with nothing or zero"

### DIFF
--- a/frontend/test/metabase-db/mongo/line.cy.spec.js
+++ b/frontend/test/metabase-db/mongo/line.cy.spec.js
@@ -1,0 +1,45 @@
+import { restore, addMongoDatabase, popover } from "__support__/e2e/cypress";
+
+const MONGO_DB_NAME = "QA Mongo4";
+
+// Skipping the whole describe block because it contains only one skipped test so far!
+// We don't want to run the whole beforeEeach block in CI only to skip the test afterwards.
+// IMPORTANT: when #16170 gets fixed, unskip both describe block and the test itself!
+describe.skip("mongodb > visualization > line chart", () => {
+  before(() => {
+    restore();
+    cy.signInAsAdmin();
+    addMongoDatabase(MONGO_DB_NAME);
+  });
+
+  it.skip("should correctly replace only the missing values with zero (metabase#16170)", () => {
+    cy.visit("/question/new");
+    cy.findByText("Simple question").click();
+    cy.findByText(MONGO_DB_NAME).click();
+    cy.findByText("Orders").click();
+    cy.findAllByRole("button")
+      .contains("Summarize")
+      .click();
+    cy.findByTestId("sidebar-right")
+      .findByText("Created At")
+      .click();
+    assertOnTheYAxis();
+    cy.findAllByRole("button")
+      .contains("Settings")
+      .click();
+    cy.findByTestId("sidebar-left")
+      .findByText("Linear Interpolated")
+      .click();
+    popover()
+      .findByText("Zero")
+      .click();
+    assertOnTheYAxis();
+
+    function assertOnTheYAxis() {
+      cy.get(".y-axis-label").findByText("Count");
+      cy.get(".axis.y .tick")
+        .should("have.length.gt", 10)
+        .and("contain", "200");
+    }
+  });
+});

--- a/frontend/test/metabase-db/mongo/native.cy.spec.js
+++ b/frontend/test/metabase-db/mongo/native.cy.spec.js
@@ -2,7 +2,10 @@ import { restore, addMongoDatabase, modal } from "__support__/e2e/cypress";
 
 const MONGO_DB_NAME = "QA Mongo4";
 
-describe("mongodb > native query", () => {
+// Skipping the whole describe block because it contains only one skipped test so far!
+// We don't want to run the whole beforeEeach block in CI only to skip the test afterwards.
+// IMPORTANT: when #15946 gets fixed, unskip both describe block and the test itself!
+describe.skip("mongodb > native query", () => {
   before(() => {
     restore();
     cy.signInAsAdmin();

--- a/frontend/test/metabase-db/postgres/native.cy.spec.js
+++ b/frontend/test/metabase-db/postgres/native.cy.spec.js
@@ -2,7 +2,10 @@ import { restore, addPostgresDatabase, modal } from "__support__/e2e/cypress";
 
 const PG_DB_NAME = "QA Postgres12";
 
-describe("postgres > question > native", () => {
+// Skipping the whole describe block because it contains only one skipped test so far!
+// We don't want to run the whole beforeEeach block in CI only to skip the test afterwards.
+// IMPORTANT: when #14957 gets fixed, unskip both describe block and the test itself!
+describe.skip("postgres > question > native", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #16170

### How to test this manually?
- `yarn test-cypress-open --folder frontend/test/metabase-db/ --spec frontend/test/metabase-db/mongo/line.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/119136443-f28d8900-ba3f-11eb-9620-1a4d3b95097e.png)

