### PR TITLE
Fix API endpoints used by LDAP and email settings forms

### DIFF
--- a/frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx
@@ -12,8 +12,6 @@ import DisclosureTriangle from "metabase/components/DisclosureTriangle";
 import MetabaseUtils from "metabase/lib/utils";
 import SettingsSetting from "./SettingsSetting";
 
-import { updateSettings } from "../settings";
-
 const VALIDATIONS = {
   email: {
     validate: value => MetabaseUtils.validEmail(value),
@@ -33,7 +31,10 @@ const SAVE_SETTINGS_BUTTONS_STATES = {
 
 @connect(
   null,
-  { updateSettings },
+  (dispatch, { updateSettings }) => ({
+    updateSettings:
+    updateSettings || (settings => dispatch(updateSettings(settings))),
+  }),
   null,
   { withRef: true }, // HACK: needed so consuming components can call methods on the component :-/
 )

--- a/frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx
@@ -33,7 +33,7 @@ const SAVE_SETTINGS_BUTTONS_STATES = {
   null,
   (dispatch, { updateSettings }) => ({
     updateSettings:
-    updateSettings || (settings => dispatch(updateSettings(settings))),
+      updateSettings || (settings => dispatch(updateSettings(settings))),
   }),
   null,
   { withRef: true }, // HACK: needed so consuming components can call methods on the component :-/

--- a/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
@@ -344,10 +344,16 @@ describe("scenarios > admin > settings", () => {
         .type("localhost")
         .blur();
       cy.findByPlaceholderText("587")
-        .type("1234")
+        .type("25")
+        .blur();
+      cy.findByPlaceholderText("youlooknicetoday")
+        .type("admin")
+        .blur();
+      cy.findByPlaceholderText("Shhh...")
+        .type("admin")
         .blur();
       cy.findByPlaceholderText("metabase@yourcompany.com")
-        .type("admin@metabase.com")
+        .type("mailer@metabase.test")
         .blur();
       cy.findByText("Save changes").click();
 


### PR DESCRIPTION
This PR changes `SettingsBatchForm` to use the passed-in `updateSettings` prop by default, which fixes the API routes used by `SettingsLdapForm` and `SettingsEmailForm` so that they hit their specific endpoints rather than the general settings endpoint. (Thanks @paulrosenzweig for help w/the fix!)

This means that the backend will test the connection to the email/LDAP server when settings are saved, and display an error message if a connection can't be established. This resolves #16173, #11446 and #13313.

I've also updated the relevant Cypress test for email to use valid credentials. It passes on CI but not locally, I guess since I'm not running the mail server?