### PR TITLE
Fix admin setup test by adjusting the expected message

### DIFF
--- a/frontend/test/metabase-smoketest/admin_setup.cy.spec.js
+++ b/frontend/test/metabase-smoketest/admin_setup.cy.spec.js
@@ -963,7 +963,7 @@ describe("smoketest > admin_setup", () => {
       cy.contains(normal.first_name).should("not.exist");
       cy.findByText("Our Analytics").should("not.exist");
       cy.findByText("Failed");
-      cy.contains("Password : did not match stored password");
+      cy.contains("Password: did not match stored password");
     });
   });
 });


### PR DESCRIPTION
The message was adjusted in PR #16057.

To verify, run
```
yarn test-cypress-open --folder frontend/test/metabase-smoketest
```

Before this PR: one test fails.

After this PR: all tests pass.