### PR TITLE
Fix #15980: Refresh on hover

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChartTooltip.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartTooltip.jsx
@@ -22,7 +22,7 @@ export default class ChartTooltip extends Component {
       // Array of key, value, col: { data: [{ key, value, col }], element, event }
       return hovered.data.map(d => ({
         ...d,
-        key: d.key || getFriendlyName(d.col),
+        key: d.key || (d.col && getFriendlyName(d.col)),
       }));
     } else if (hovered.value !== undefined || hovered.dimensions) {
       // ClickObject: { value, column, dimensions: [{ value, column }], element, event }


### PR DESCRIPTION
Fix for https://github.com/metabase/metabase/issues/15980 introduced in https://github.com/metabase/metabase/pull/14688

For the Gauge visualization data column may not exist, an attempt to access it when it is absent results in an error
