### PR TITLE
#13313 Repro: It shouldn't be possible to save invalid (non-numeric) LDAP port

### DIFF
--- a/frontend/test/metabase/scenarios/admin/settings/sso.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/sso.cy.spec.js
@@ -16,6 +16,13 @@ describe("scenarios > admin > settings > SSO", () => {
   });
 
   describe("LDAP", () => {
+    /**
+     * IMPORTANT:
+     * These repros currently rely on the broken behavior. It is possible to save settings without authentication turned on.
+     * See: https://github.com/metabase/metabase/issues/16225
+     * It is possible related repros will have to be rewritten/adjusted once #16255 gets fixed!
+     */
+
     beforeEach(() => {
       cy.visit("/admin/settings/authentication/ldap");
     });
@@ -33,7 +40,6 @@ describe("scenarios > admin > settings > SSO", () => {
         cy.findByPlaceholderText("389").type(port);
         cy.button("Save changes").click();
         cy.wait("@update").then(interception => {
-          console.log(interception);
           expect(interception.response.statusCode).to.eq(500);
           expect(interception.response.body.cause).to.include(port);
         });

--- a/frontend/test/metabase/scenarios/admin/settings/sso.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/sso.cy.spec.js
@@ -14,6 +14,32 @@ describe("scenarios > admin > settings > SSO", () => {
     cy.findByDisplayValue("123").type("456");
     saveSettings();
   });
+
+  describe("LDAP", () => {
+    beforeEach(() => {
+      cy.visit("/admin/settings/authentication/ldap");
+    });
+
+    // Space after "123 " is crucial for #13313
+    const INVALID_PORTS = ["21.3", "asd", "123 "];
+
+    INVALID_PORTS.forEach(port => {
+      it("shouldn't be possible to save non-numeric port (#13313)", () => {
+        // The real endpoint is `/api/ldap/settings` but I had to use this ambiguous one for this repro because of #16173
+        // Although the endpoint was fixed, we want to always be able to test these issues separately and independently of each other.
+        cy.intercept("PUT", "/api/**").as("update");
+
+        cy.findByPlaceholderText("ldap.yourdomain.org").type("foobar");
+        cy.findByPlaceholderText("389").type(port);
+        cy.button("Save changes").click();
+        cy.wait("@update").then(interception => {
+          console.log(interception);
+          expect(interception.response.statusCode).to.eq(500);
+          expect(interception.response.body.cause).to.include(port);
+        });
+      });
+    });
+  });
 });
 
 function saveSettings() {


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #13313

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/admin/settings/sso.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- All tests should pass

### Additional notes:
- The issue was fixed in #16187
- Merge this repro into `release-x.39.x` only after #16187 is fully merged

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/119331379-9321ba00-bc87-11eb-8008-069aa28f1b1a.png)

