### PR TITLE
Add support for responsive dashboard layouts

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
@@ -79,9 +79,15 @@ export default class DashboardGrid extends Component {
     });
   }
 
-  onLayoutChange = layout => {
-    const { dashboard, setMultipleDashCardAttributes } = this.props;
+  onLayoutChange = ({ layout, breakpoint }) => {
+    // We allow moving and resizing cards only on the desktop
+    // Ensures onLayoutChange triggered by window resize,
+    // won't break the main layout
+    if (breakpoint !== "lg") {
+      return;
+    }
 
+    const { dashboard, setMultipleDashCardAttributes } = this.props;
     const changes = [];
 
     layout.forEach(layoutItem => {

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
@@ -16,6 +16,7 @@ import {
   GRID_COLUMNS,
   DEFAULT_CARD_SIZE,
   MIN_ROW_HEIGHT,
+  isMobileBreakpoint,
 } from "metabase/lib/dashboard_grid";
 
 import _ from "underscore";
@@ -296,7 +297,7 @@ export default class DashboardGrid extends Component {
       onTouchStartCapture={this.onDashCardMouseDown}
     >
       {this.renderDashCard(dc, {
-        isMobile: breakpoint === "sm",
+        isMobile: isMobileBreakpoint(breakpoint),
         gridItemWidth,
       })}
     </div>

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
@@ -16,7 +16,6 @@ import {
   GRID_COLUMNS,
   DEFAULT_CARD_SIZE,
   MIN_ROW_HEIGHT,
-  isMobileBreakpoint,
 } from "metabase/lib/dashboard_grid";
 
 import _ from "underscore";
@@ -78,7 +77,7 @@ export default class DashboardGrid extends Component {
     // We allow moving and resizing cards only on the desktop
     // Ensures onLayoutChange triggered by window resize,
     // won't break the main layout
-    if (breakpoint !== "lg") {
+    if (breakpoint !== "desktop") {
       return;
     }
 
@@ -150,27 +149,16 @@ export default class DashboardGrid extends Component {
   }
 
   getLayouts({ dashboard }) {
-    const lg = dashboard.ordered_cards.map(this.getLayoutForDashCard);
-    const layout = { lg };
-
-    layout.md = adaptLayoutForBreakpoint({
+    const desktop = dashboard.ordered_cards.map(this.getLayoutForDashCard);
+    const layout = { desktop };
+    layout.mobile = adaptLayoutForBreakpoint({
       layout,
       breakpoints: GRID_BREAKPOINTS,
-      targetBreakpoint: "md",
-      closestBreakpoint: "lg",
-      columns: GRID_COLUMNS.md,
+      targetBreakpoint: "mobile",
+      closestBreakpoint: "desktop",
+      columns: GRID_COLUMNS.mobile,
       compactType: "vertical",
     });
-
-    layout.sm = adaptLayoutForBreakpoint({
-      layout,
-      breakpoints: GRID_BREAKPOINTS,
-      targetBreakpoint: "sm",
-      closestBreakpoint: "md",
-      columns: GRID_COLUMNS.sm,
-      compactType: "vertical",
-    });
-
     return layout;
   }
 
@@ -283,7 +271,7 @@ export default class DashboardGrid extends Component {
   renderGridItem = ({ item: dc, breakpoint, gridItemWidth }) => (
     <div key={String(dc.id)} className="DashCard">
       {this.renderDashCard(dc, {
-        isMobile: isMobileBreakpoint(breakpoint),
+        isMobile: breakpoint === "mobile",
         gridItemWidth,
       })}
     </div>
@@ -306,7 +294,7 @@ export default class DashboardGrid extends Component {
         breakpoints={GRID_BREAKPOINTS}
         cols={GRID_COLUMNS}
         width={width}
-        margin={{ lg: [6, 6], md: [6, 6], sm: [6, 10] }}
+        margin={{ desktop: [6, 6], mobile: [6, 10] }}
         containerPadding={[0, 0]}
         rowHeight={rowHeight}
         onLayoutChange={this.onLayoutChange}

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
@@ -354,14 +354,17 @@ export default class DashboardGrid extends Component {
         isEditing={this.isEditingLayout}
         compactType="vertical"
         items={dashboard.ordered_cards}
-        itemRenderer={({ item: dc, gridItemWidth }) => (
+        itemRenderer={({ item: dc, breakpoint, gridItemWidth }) => (
           <div
             key={String(dc.id)}
             className="DashCard"
             onMouseDownCapture={this.onDashCardMouseDown}
             onTouchStartCapture={this.onDashCardMouseDown}
           >
-            {this.renderDashCard(dc, { isMobile: false, gridItemWidth })}
+            {this.renderDashCard(dc, {
+              isMobile: breakpoint === "sm",
+              gridItemWidth,
+            })}
           </div>
         )}
       />

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
@@ -40,8 +40,6 @@ export default class DashboardGrid extends Component {
       addSeriesModalDashCard: null,
       isDragging: false,
     };
-
-    _.bindAll(this, "onDashCardMouseDown");
   }
 
   static propTypes = {
@@ -226,13 +224,6 @@ export default class DashboardGrid extends Component {
     this.setState({ isDragging: false });
   };
 
-  // we use onMouseDownCapture to prevent dragging due to react-grid-layout bug referenced below
-  onDashCardMouseDown(e) {
-    if (!this.props.isEditing) {
-      e.stopPropagation();
-    }
-  }
-
   onDashCardRemove(dc) {
     this.setState({ removeModalDashCard: dc });
   }
@@ -290,12 +281,7 @@ export default class DashboardGrid extends Component {
   }
 
   renderGridItem = ({ item: dc, breakpoint, gridItemWidth }) => (
-    <div
-      key={String(dc.id)}
-      className="DashCard"
-      onMouseDownCapture={this.onDashCardMouseDown}
-      onTouchStartCapture={this.onDashCardMouseDown}
-    >
+    <div key={String(dc.id)} className="DashCard">
       {this.renderDashCard(dc, {
         isMobile: isMobileBreakpoint(breakpoint),
         gridItemWidth,

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
@@ -22,7 +22,7 @@ import _ from "underscore";
 import cx from "classnames";
 
 import GridLayout from "./grid/GridLayout";
-import { adaptLayoutForBreakpoint } from "./grid/utils";
+import { generateMobileLayout } from "./grid/utils";
 import AddSeriesModal from "./AddSeriesModal";
 import RemoveFromDashboardModal from "./RemoveFromDashboardModal";
 import DashCard from "./DashCard";
@@ -150,16 +150,18 @@ export default class DashboardGrid extends Component {
 
   getLayouts({ dashboard }) {
     const desktop = dashboard.ordered_cards.map(this.getLayoutForDashCard);
-    const layout = { desktop };
-    layout.mobile = adaptLayoutForBreakpoint({
-      layout,
-      breakpoints: GRID_BREAKPOINTS,
-      targetBreakpoint: "mobile",
-      closestBreakpoint: "desktop",
-      columns: GRID_COLUMNS.mobile,
-      compactType: "vertical",
+    const mobile = generateMobileLayout({
+      desktopLayout: desktop,
+      // We want to keep the heights for all visualizations equal not to break the visual rhythm
+      // Exceptions are text cards (can take too much vertical space)
+      // and scalar value cards (basically a number and some text on a big card)
+      heightByDisplayType: {
+        text: 2,
+        scalar: 4,
+      },
+      defaultCardHeight: 6,
     });
-    return layout;
+    return { desktop, mobile };
   }
 
   renderRemoveModal() {

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
@@ -12,7 +12,6 @@ import MetabaseAnalytics from "metabase/lib/analytics";
 import {
   GRID_WIDTH,
   GRID_ASPECT_RATIO,
-  GRID_MARGIN,
   GRID_BREAKPOINTS,
   GRID_COLUMNS,
   DEFAULT_CARD_SIZE,
@@ -27,9 +26,6 @@ import { adaptLayoutForBreakpoint } from "./grid/utils";
 import AddSeriesModal from "./AddSeriesModal";
 import RemoveFromDashboardModal from "./RemoveFromDashboardModal";
 import DashCard from "./DashCard";
-
-const MOBILE_ASPECT_RATIO = 3 / 2;
-const MOBILE_TEXT_CARD_ROW_HEIGHT = 60;
 
 @ExplicitSize()
 export default class DashboardGrid extends Component {
@@ -289,42 +285,6 @@ export default class DashboardGrid extends Component {
     } = this.props;
     return (
       isEditing && !isEditingParameter && clickBehaviorSidebarDashcard == null
-    );
-  }
-
-  renderMobile() {
-    const { width } = this.props;
-    const { dashcards } = this.state;
-    return (
-      <div
-        className={cx("DashboardGrid", {
-          "Dash--editing": this.isEditingLayout,
-          "Dash--dragging": this.state.isDragging,
-        })}
-      >
-        {dashcards &&
-          dashcards.map(dc => (
-            <div
-              key={dc.id}
-              className="DashCard"
-              style={{
-                width: width,
-                marginTop: 10,
-                marginBottom: 10,
-                height:
-                  // "text" cards should get a height based on their dc sizeY
-                  dc.card.display === "text"
-                    ? MOBILE_TEXT_CARD_ROW_HEIGHT * dc.sizeY
-                    : width / MOBILE_ASPECT_RATIO,
-              }}
-            >
-              {this.renderDashCard(dc, {
-                isMobile: true,
-                gridItemWidth: width,
-              })}
-            </div>
-          ))}
-      </div>
     );
   }
 

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
@@ -328,6 +328,20 @@ export default class DashboardGrid extends Component {
     );
   }
 
+  renderGridItem = ({ item: dc, breakpoint, gridItemWidth }) => (
+    <div
+      key={String(dc.id)}
+      className="DashCard"
+      onMouseDownCapture={this.onDashCardMouseDown}
+      onTouchStartCapture={this.onDashCardMouseDown}
+    >
+      {this.renderDashCard(dc, {
+        isMobile: breakpoint === "sm",
+        gridItemWidth,
+      })}
+    </div>
+  );
+
   renderGrid() {
     const { dashboard, width } = this.props;
     const { layouts } = this.state;
@@ -354,19 +368,7 @@ export default class DashboardGrid extends Component {
         isEditing={this.isEditingLayout}
         compactType="vertical"
         items={dashboard.ordered_cards}
-        itemRenderer={({ item: dc, breakpoint, gridItemWidth }) => (
-          <div
-            key={String(dc.id)}
-            className="DashCard"
-            onMouseDownCapture={this.onDashCardMouseDown}
-            onTouchStartCapture={this.onDashCardMouseDown}
-          >
-            {this.renderDashCard(dc, {
-              isMobile: breakpoint === "sm",
-              gridItemWidth,
-            })}
-          </div>
-        )}
+        itemRenderer={this.renderGridItem}
       />
     );
   }

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
@@ -359,7 +359,7 @@ export default class DashboardGrid extends Component {
         breakpoints={GRID_BREAKPOINTS}
         cols={GRID_COLUMNS}
         width={width}
-        margin={GRID_MARGIN}
+        margin={{ lg: [6, 6], md: [6, 6], sm: [6, 10] }}
         containerPadding={[0, 0]}
         rowHeight={rowHeight}
         onLayoutChange={this.onLayoutChange}

--- a/frontend/src/metabase/dashboard/components/grid/GridLayout.jsx
+++ b/frontend/src/metabase/dashboard/components/grid/GridLayout.jsx
@@ -31,13 +31,13 @@ function GridLayout({
   const renderItem = useCallback(
     item => {
       const itemLayout = layout.find(l => String(l.i) === String(item.id));
-      const gridItemWidth = cellSize.width * itemLayout.w - margin;
+      const gridItemWidth = cellSize.width * itemLayout.w;
       return itemRenderer({
         item,
         gridItemWidth,
       });
     },
-    [layout, cellSize, margin, itemRenderer],
+    [layout, cellSize, itemRenderer],
   );
 
   const height = useMemo(() => {

--- a/frontend/src/metabase/dashboard/components/grid/GridLayout.jsx
+++ b/frontend/src/metabase/dashboard/components/grid/GridLayout.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
-import React, { useCallback, useMemo } from "react";
-import ReactGridLayout from "react-grid-layout";
+import React, { useCallback, useMemo, useState } from "react";
+import { Responsive as ReactGridLayout } from "react-grid-layout";
 
 import "react-grid-layout/css/styles.css";
 import "react-resizable/css/styles.css";
@@ -10,14 +10,33 @@ import { generateGridBackground } from "./utils";
 function GridLayout({
   items,
   itemRenderer,
-  layout,
-  cols,
+  breakpoints,
+  layouts,
+  cols: columnsMap,
   width: gridWidth,
   margin,
   rowHeight,
   isEditing,
   ...props
 }) {
+  const [currentBreakpoint, setCurrentBreakpoint] = useState(
+    ReactGridLayout.utils.getBreakpointFromWidth(breakpoints, gridWidth),
+  );
+
+  const onBreakpointChange = useCallback(newBreakpoint => {
+    setCurrentBreakpoint(newBreakpoint);
+  }, []);
+
+  const layout = useMemo(() => layouts[currentBreakpoint] || layouts["lg"], [
+    layouts,
+    currentBreakpoint,
+  ]);
+
+  const cols = useMemo(() => columnsMap[currentBreakpoint], [
+    columnsMap,
+    currentBreakpoint,
+  ]);
+
   const cellSize = useMemo(() => {
     const marginSlotsCount = cols - 1;
     const totalHorizontalMargin = marginSlotsCount * margin;
@@ -67,8 +86,9 @@ function GridLayout({
 
   return (
     <ReactGridLayout
-      cols={cols}
-      layout={layout}
+      breakpoints={breakpoints}
+      cols={columnsMap}
+      layouts={layouts}
       width={gridWidth}
       margin={[margin, margin]}
       rowHeight={rowHeight}
@@ -76,6 +96,7 @@ function GridLayout({
       isResizable={isEditing}
       {...props}
       autoSize={false}
+      onBreakpointChange={onBreakpointChange}
       style={style}
     >
       {children}

--- a/frontend/src/metabase/dashboard/components/grid/GridLayout.jsx
+++ b/frontend/src/metabase/dashboard/components/grid/GridLayout.jsx
@@ -14,7 +14,7 @@ function GridLayout({
   layouts,
   cols: columnsMap,
   width: gridWidth,
-  margin,
+  margin: marginMap,
   rowHeight,
   isEditing,
   onLayoutChange,
@@ -44,7 +44,12 @@ function GridLayout({
     setCurrentBreakpoint(newBreakpoint);
   }, []);
 
-  const layout = useMemo(() => layouts[currentBreakpoint] || layouts["lg"], [
+  const margin = useMemo(() => marginMap[currentBreakpoint], [
+    marginMap,
+    currentBreakpoint,
+  ]);
+
+  const layout = useMemo(() => layouts[currentBreakpoint], [
     layouts,
     currentBreakpoint,
   ]);
@@ -56,7 +61,8 @@ function GridLayout({
 
   const cellSize = useMemo(() => {
     const marginSlotsCount = cols - 1;
-    const totalHorizontalMargin = marginSlotsCount * margin;
+    const [horizontalMargin] = margin;
+    const totalHorizontalMargin = marginSlotsCount * horizontalMargin;
     const freeSpace = gridWidth - totalHorizontalMargin;
     return {
       width: freeSpace / cols,
@@ -82,7 +88,9 @@ function GridLayout({
     if (isEditing) {
       lowestLayoutCellPoint += Math.ceil(window.innerHeight / cellSize.height);
     }
-    return (cellSize.height + margin) * lowestLayoutCellPoint;
+    // eslint-disable-next-line no-unused-vars
+    const [horizontalMargin, verticalMargin] = margin;
+    return (cellSize.height + verticalMargin) * lowestLayoutCellPoint;
   }, [cellSize.height, layout, margin, isEditing]);
 
   const background = useMemo(
@@ -108,7 +116,7 @@ function GridLayout({
       cols={columnsMap}
       layouts={layouts}
       width={gridWidth}
-      margin={[margin, margin]}
+      margin={margin}
       rowHeight={rowHeight}
       isDraggable={isEditing}
       isResizable={isEditing}

--- a/frontend/src/metabase/dashboard/components/grid/GridLayout.jsx
+++ b/frontend/src/metabase/dashboard/components/grid/GridLayout.jsx
@@ -17,10 +17,27 @@ function GridLayout({
   margin,
   rowHeight,
   isEditing,
+  onLayoutChange,
   ...props
 }) {
   const [currentBreakpoint, setCurrentBreakpoint] = useState(
     ReactGridLayout.utils.getBreakpointFromWidth(breakpoints, gridWidth),
+  );
+
+  const onLayoutChangeWrapped = useCallback(
+    nextLayout => {
+      onLayoutChange({
+        layout: nextLayout,
+        // Calculating the breakpoint right here,
+        // so we're definitely passing the most recent one
+        // Workaround for https://github.com/react-grid-layout/react-grid-layout/issues/889
+        breakpoint: ReactGridLayout.utils.getBreakpointFromWidth(
+          breakpoints,
+          gridWidth,
+        ),
+      });
+    },
+    [onLayoutChange, breakpoints, gridWidth],
   );
 
   const onBreakpointChange = useCallback(newBreakpoint => {
@@ -96,6 +113,7 @@ function GridLayout({
       isResizable={isEditing}
       {...props}
       autoSize={false}
+      onLayoutChange={onLayoutChangeWrapped}
       onBreakpointChange={onBreakpointChange}
       style={style}
     >

--- a/frontend/src/metabase/dashboard/components/grid/GridLayout.jsx
+++ b/frontend/src/metabase/dashboard/components/grid/GridLayout.jsx
@@ -2,6 +2,8 @@
 import React, { useCallback, useMemo, useState } from "react";
 import { Responsive as ReactGridLayout } from "react-grid-layout";
 
+import { isMobileBreakpoint } from "metabase/lib/dashboard_grid";
+
 import "react-grid-layout/css/styles.css";
 import "react-resizable/css/styles.css";
 
@@ -107,6 +109,8 @@ function GridLayout({
     [gridWidth, height, background, isEditing],
   );
 
+  const isMobile = isMobileBreakpoint(currentBreakpoint);
+
   // https://github.com/react-grid-layout/react-grid-layout#performance
   const children = useMemo(() => items.map(renderItem), [items, renderItem]);
 
@@ -118,8 +122,8 @@ function GridLayout({
       width={gridWidth}
       margin={margin}
       rowHeight={rowHeight}
-      isDraggable={isEditing}
-      isResizable={isEditing}
+      isDraggable={isEditing && !isMobile}
+      isResizable={isEditing && !isMobile}
       {...props}
       autoSize={false}
       onLayoutChange={onLayoutChangeWrapped}

--- a/frontend/src/metabase/dashboard/components/grid/GridLayout.jsx
+++ b/frontend/src/metabase/dashboard/components/grid/GridLayout.jsx
@@ -71,9 +71,10 @@ function GridLayout({
       return itemRenderer({
         item,
         gridItemWidth,
+        breakpoint: currentBreakpoint,
       });
     },
-    [layout, cellSize, itemRenderer],
+    [layout, cellSize, itemRenderer, currentBreakpoint],
   );
 
   const height = useMemo(() => {

--- a/frontend/src/metabase/dashboard/components/grid/GridLayout.jsx
+++ b/frontend/src/metabase/dashboard/components/grid/GridLayout.jsx
@@ -62,6 +62,9 @@ function GridLayout({
     [gridWidth, height, background, isEditing],
   );
 
+  // https://github.com/react-grid-layout/react-grid-layout#performance
+  const children = useMemo(() => items.map(renderItem), [items, renderItem]);
+
   return (
     <ReactGridLayout
       cols={cols}
@@ -75,7 +78,7 @@ function GridLayout({
       autoSize={false}
       style={style}
     >
-      {items.map(renderItem)}
+      {children}
     </ReactGridLayout>
   );
 }

--- a/frontend/src/metabase/dashboard/components/grid/GridLayout.jsx
+++ b/frontend/src/metabase/dashboard/components/grid/GridLayout.jsx
@@ -2,8 +2,6 @@
 import React, { useCallback, useMemo, useState } from "react";
 import { Responsive as ReactGridLayout } from "react-grid-layout";
 
-import { isMobileBreakpoint } from "metabase/lib/dashboard_grid";
-
 import "react-grid-layout/css/styles.css";
 import "react-resizable/css/styles.css";
 
@@ -109,7 +107,7 @@ function GridLayout({
     [gridWidth, height, background, isEditing],
   );
 
-  const isMobile = isMobileBreakpoint(currentBreakpoint);
+  const isMobile = currentBreakpoint === "mobile";
 
   // https://github.com/react-grid-layout/react-grid-layout#performance
   const children = useMemo(() => items.map(renderItem), [items, renderItem]);

--- a/frontend/src/metabase/dashboard/components/grid/utils.js
+++ b/frontend/src/metabase/dashboard/components/grid/utils.js
@@ -1,5 +1,24 @@
 import _ from "underscore";
+import { Responsive as ResponsiveGrid } from "react-grid-layout";
 import { color } from "metabase/lib/colors";
+
+export function adaptLayoutForBreakpoint({
+  layout,
+  breakpoints,
+  targetBreakpoint,
+  closestBreakpoint,
+  columns,
+  compactType,
+}) {
+  return ResponsiveGrid.utils.findOrGenerateResponsiveLayout(
+    layout,
+    breakpoints,
+    targetBreakpoint,
+    closestBreakpoint,
+    columns,
+    compactType,
+  );
+}
 
 export function generateGridBackground({ cellSize, margin, cols, gridWidth }) {
   const XMLNS = "http://www.w3.org/2000/svg";

--- a/frontend/src/metabase/dashboard/components/grid/utils.js
+++ b/frontend/src/metabase/dashboard/components/grid/utils.js
@@ -20,6 +20,30 @@ export function adaptLayoutForBreakpoint({
   );
 }
 
+function sumVerticalSpace(layout) {
+  return layout.reduce((sum, current) => sum + current.h, 0);
+}
+
+export function generateMobileLayout({
+  desktopLayout,
+  defaultCardHeight,
+  heightByDisplayType = {},
+}) {
+  const mobile = [];
+  desktopLayout.forEach(item => {
+    const card = item.dashcard.card;
+    const height = heightByDisplayType[card.display] || defaultCardHeight;
+    mobile.push({
+      ...item,
+      x: 0,
+      y: sumVerticalSpace(mobile),
+      h: height,
+      w: 1,
+    });
+  });
+  return mobile;
+}
+
 export function generateGridBackground({ cellSize, margin, cols, gridWidth }) {
   const XMLNS = "http://www.w3.org/2000/svg";
   const [horizontalMargin, verticalMargin] = margin;

--- a/frontend/src/metabase/dashboard/components/grid/utils.js
+++ b/frontend/src/metabase/dashboard/components/grid/utils.js
@@ -22,7 +22,8 @@ export function adaptLayoutForBreakpoint({
 
 export function generateGridBackground({ cellSize, margin, cols, gridWidth }) {
   const XMLNS = "http://www.w3.org/2000/svg";
-  const rowHeight = cellSize.height + margin;
+  const [horizontalMargin, verticalMargin] = margin;
+  const rowHeight = cellSize.height + verticalMargin;
   const cellStrokeColor = color("border");
 
   const y = 0;
@@ -30,7 +31,7 @@ export function generateGridBackground({ cellSize, margin, cols, gridWidth }) {
   const h = cellSize.height;
 
   const rectangles = _(cols).times(i => {
-    const x = i * (cellSize.width + margin);
+    const x = i * (cellSize.width + horizontalMargin);
     return `<rect stroke='${cellStrokeColor}' stroke-width='1' fill='none' x='${x}' y='${y}' width='${w}' height='${h}'/>`;
   });
 

--- a/frontend/src/metabase/lib/dashboard_grid.js
+++ b/frontend/src/metabase/lib/dashboard_grid.js
@@ -4,6 +4,18 @@ export const GRID_WIDTH = 18;
 export const GRID_ASPECT_RATIO = 4 / 3;
 export const GRID_MARGIN = 6;
 
+export const GRID_BREAKPOINTS = {
+  lg: 1200,
+  md: 996,
+  sm: 752,
+};
+
+export const GRID_COLUMNS = {
+  lg: 18,
+  md: 12,
+  sm: 1,
+};
+
 export const DEFAULT_CARD_SIZE = { width: 4, height: 4 };
 
 export const MIN_ROW_HEIGHT = 54;

--- a/frontend/src/metabase/lib/dashboard_grid.js
+++ b/frontend/src/metabase/lib/dashboard_grid.js
@@ -6,21 +6,19 @@ export const GRID_ASPECT_RATIO = 4 / 3;
 const MOBILE_BREAKPOINT = 752;
 
 export const GRID_BREAKPOINTS = {
-  lg: 1200,
-  md: 996,
-  sm: MOBILE_BREAKPOINT,
+  desktop: MOBILE_BREAKPOINT + 1,
+  mobile: MOBILE_BREAKPOINT,
+};
+
+export const GRID_COLUMNS = {
+  desktop: GRID_WIDTH,
+  mobile: 1,
 };
 
 export function isMobileBreakpoint(breakpoint) {
   const width = GRID_BREAKPOINTS[breakpoint];
   return width <= MOBILE_BREAKPOINT;
 }
-
-export const GRID_COLUMNS = {
-  lg: 18,
-  md: 12,
-  sm: 1,
-};
 
 export const DEFAULT_CARD_SIZE = { width: 4, height: 4 };
 

--- a/frontend/src/metabase/lib/dashboard_grid.js
+++ b/frontend/src/metabase/lib/dashboard_grid.js
@@ -2,7 +2,6 @@ import type { DashCard } from "metabase-types/types/Dashboard";
 
 export const GRID_WIDTH = 18;
 export const GRID_ASPECT_RATIO = 4 / 3;
-export const GRID_MARGIN = 6;
 
 export const GRID_BREAKPOINTS = {
   lg: 1200,

--- a/frontend/src/metabase/lib/dashboard_grid.js
+++ b/frontend/src/metabase/lib/dashboard_grid.js
@@ -3,11 +3,18 @@ import type { DashCard } from "metabase-types/types/Dashboard";
 export const GRID_WIDTH = 18;
 export const GRID_ASPECT_RATIO = 4 / 3;
 
+const MOBILE_BREAKPOINT = 752;
+
 export const GRID_BREAKPOINTS = {
   lg: 1200,
   md: 996,
-  sm: 752,
+  sm: MOBILE_BREAKPOINT,
 };
+
+export function isMobileBreakpoint(breakpoint) {
+  const width = GRID_BREAKPOINTS[breakpoint];
+  return width <= MOBILE_BREAKPOINT;
+}
 
 export const GRID_COLUMNS = {
   lg: 18,


### PR DESCRIPTION
This PR is subsequent to #16167 (switching dashboard grid to `react-grid-layout`). ⚠️ It also targets the `feat/dashboard-rgl` branch instead of `master`, so it's easier to review.

This is the groundwork for making dashboards more responsive to window resizing. Earlier, we used two different components (`renderGrid` and `renderMobile` methods at `DashboardGrid` component) to render desktop 18-columns wide and mobile single column dashboards. The transition between these two states was instant and not very nice. The desktop grid was not that responsive to window resizing as well.

This PR removes the original `renderMobile` method and makes `react-grid-layout` handle both desktop and mobile layouts with the [`ResponsiveGridLayout` component](https://github.com/react-grid-layout/react-grid-layout#responsive-usage).

We can still improve the dashboard's responsiveness a lot. Visualizations rerendering can make it feel janky, but it can be a subsequent improvement on top of responsive `react-grid-layout`.

No changes in the functionality here. Cards are still movable and resizable only on the desktop layout.

### To Verify

1. Open any dashboard
2. Resize the window here and there, play around with a mobile view

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/119551827-bb520b80-bda2-11eb-9d16-8a0ff6347c8e.mov

**After**

https://user-images.githubusercontent.com/17258145/119551875-c6a53700-bda2-11eb-8eae-813d41c6da95.mov

