### PR TITLE
Restore Custom Expression suggestion highlights

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
@@ -1,11 +1,14 @@
 import React from "react";
 import PropTypes from "prop-types";
-
 import { t } from "ttag";
 import cx from "classnames";
 
 import Popover from "metabase/components/Popover";
-import { SectionTitle, UlStyled } from "./ExpressionEditorSuggestions.styled";
+import {
+  ListItemStyled,
+  SectionTitle,
+  UlStyled,
+} from "./ExpressionEditorSuggestions.styled";
 
 import { isObscured } from "metabase/lib/dom";
 
@@ -92,28 +95,27 @@ export default class ExpressionEditorSuggestions extends React.Component {
 
             const isHighlighted = i === highlightedIndex;
 
-            const listItemClassName = cx(
-              "px2 cursor-pointer text-white-hover bg-brand-hover hover-parent hover--inherit",
-              {
-                "text-white bg-brand": isHighlighted,
-              },
-            );
+            // const listItemClassName = cx(
+            //   "px2 cursor-pointer text-white-hover bg-brand-hover hover-parent hover--inherit",
+            //   {
+            //     "text-white bg-brand": isHighlighted,
+            //   },
+            // );
 
             return (
               <React.Fragment key={`suggestion-${i}`}>
                 {shouldRenderSectionTitle && (
                   <SectionTitle>{sectionTitle}</SectionTitle>
                 )}
-                <li
-                  style={{ paddingTop: 5, paddingBottom: 5 }}
-                  className={listItemClassName}
+                <ListItemStyled
                   onMouseDownCapture={e => this.onSuggestionMouseDown(e, i)}
+                  isHighlighted={isHighlighted}
                 >
                   <SuggestionSpan
                     suggestion={suggestion}
                     isHighlighted={isHighlighted}
                   />
-                </li>
+                </ListItemStyled>
               </React.Fragment>
             );
           })}

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
@@ -5,6 +5,124 @@ import { t } from "ttag";
 import cx from "classnames";
 
 import Popover from "metabase/components/Popover";
+import { UlStyled } from "./ExpressionEditorSuggestions.styled";
+
+import { isObscured } from "metabase/lib/dom";
+
+const SUGGESTION_SECTION_NAMES = {
+  fields: t`Fields`,
+  aggregations: t`Aggregations`,
+  operators: t`Operators`,
+  metrics: t`Metrics`,
+  other: t`Other`,
+};
+
+export default class ExpressionEditorSuggestions extends React.Component {
+  static propTypes = {
+    suggestions: PropTypes.array,
+    onSuggestionMouseDown: PropTypes.func, // signature is f(index)
+    highlightedIndex: PropTypes.number.isRequired,
+  };
+
+  componentDidUpdate(prevProps, prevState) {
+    if (
+      (prevProps && prevProps.highlightedIndex) !== this.props.highlightedIndex
+    ) {
+      if (this._selectedRow && isObscured(this._selectedRow)) {
+        this._selectedRow.scrollIntoView({ block: "nearest" });
+      }
+    }
+  }
+
+  // when a given suggestion is clicked
+  onSuggestionMouseDown(event, index) {
+    event.preventDefault();
+    event.stopPropagation();
+
+    this.props.onSuggestionMouseDown && this.props.onSuggestionMouseDown(index);
+  }
+
+  render() {
+    const { suggestions, highlightedIndex } = this.props;
+
+    if (!suggestions.length) {
+      return null;
+    }
+
+    return (
+      <Popover
+        className="not-rounded border-dark"
+        hasArrow={false}
+        tetherOptions={{
+          attachment: "top left",
+          targetAttachment: "bottom left",
+        }}
+        sizeToFit
+      >
+        <UlStyled>
+          {suggestions.map((suggestion, i) => {
+            const shouldRenderSectionTitle =
+              i === 0 || suggestion.type !== suggestions[i - 1].type;
+
+            // insert section title. assumes they're sorted by type
+            return (
+              <React.Fragment key={i}>
+                {shouldRenderSectionTitle && (
+                  <li className="mx2 h6 text-uppercase text-bold text-medium py1 pt2">
+                    {SUGGESTION_SECTION_NAMES[suggestion.type] ||
+                      suggestion.type}
+                  </li>
+                )}
+                <li
+                  ref={r => {
+                    if (i === highlightedIndex) {
+                      this._selectedRow = r;
+                    }
+                  }}
+                  style={{ paddingTop: 5, paddingBottom: 5 }}
+                  className={cx(
+                    "px2 cursor-pointer text-white-hover bg-brand-hover hover-parent hover--inherit",
+                    {
+                      "text-white bg-brand": i === highlightedIndex,
+                    },
+                  )}
+                  onMouseDownCapture={e => this.onSuggestionMouseDown(e, i)}
+                >
+                  {suggestion.range ? (
+                    <span>
+                      {suggestion.name.slice(0, suggestion.range[0])}
+                      <span
+                        className={cx("text-brand text-bold hover-child", {
+                          "text-white bg-brand": i === highlightedIndex,
+                        })}
+                      >
+                        {suggestion.name.slice(
+                          suggestion.range[0],
+                          suggestion.range[1],
+                        )}
+                      </span>
+                      {suggestion.name.slice(suggestion.range[1])}
+                    </span>
+                  ) : (
+                    suggestion.name
+                  )}
+                </li>
+              </React.Fragment>
+            );
+          })}
+        </UlStyled>
+      </Popover>
+    );
+  }
+}
+/*
+import React from "react";
+import PropTypes from "prop-types";
+
+import { t } from "ttag";
+import cx from "classnames";
+
+import Popover from "metabase/components/Popover";
 import {
   UlStyled,
   LiStyled,
@@ -74,21 +192,20 @@ export default class ExpressionEditorSuggestions extends React.Component {
 
             const isHighlighted = i === highlightedIndex;
 
-            const LiComponent = isHighlighted ? LiStyledHighlighted : LiStyled;
-
             return (
               <React.Fragment key={`suggestion-${i}`}>
                 {shouldRenderSectionTitle && (
                   <SectionTitle>{sectionTitle}</SectionTitle>
                 )}
 
-                <LiComponent
+                <LiStyled
                   ref={r => {
                     if (isHighlighted) {
                       this._selectedRow = r;
                     }
                   }}
                   onMouseDownCapture={e => this.onSuggestionMouseDown(e, i)}
+                  style={{ color: isHighlighted ? "green" : "red" }}
                 >
                   {suggestion.range ? (
                     <span>
@@ -108,7 +225,7 @@ export default class ExpressionEditorSuggestions extends React.Component {
                   ) : (
                     suggestion.name
                   )}
-                </LiComponent>
+                </LiStyled>
               </React.Fragment>
             );
           })}
@@ -117,3 +234,4 @@ export default class ExpressionEditorSuggestions extends React.Component {
     );
   }
 }
+*/

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
@@ -64,18 +64,22 @@ export default class ExpressionEditorSuggestions extends React.Component {
             const shouldRenderSectionTitle =
               i === 0 || suggestion.type !== suggestions[i - 1].type;
 
+            const sectionTitle =
+              SUGGESTION_SECTION_NAMES[suggestion.type] || suggestion.type;
+
+            const isHighlighted = i === highlightedIndex;
+
             // insert section title. assumes they're sorted by type
             return (
               <React.Fragment key={i}>
                 {shouldRenderSectionTitle && (
                   <li className="mx2 h6 text-uppercase text-bold text-medium py1 pt2">
-                    {SUGGESTION_SECTION_NAMES[suggestion.type] ||
-                      suggestion.type}
+                    {sectionTitle}
                   </li>
                 )}
                 <li
                   ref={r => {
-                    if (i === highlightedIndex) {
+                    if (isHighlighted) {
                       this._selectedRow = r;
                     }
                   }}
@@ -83,7 +87,7 @@ export default class ExpressionEditorSuggestions extends React.Component {
                   className={cx(
                     "px2 cursor-pointer text-white-hover bg-brand-hover hover-parent hover--inherit",
                     {
-                      "text-white bg-brand": i === highlightedIndex,
+                      "text-white bg-brand": isHighlighted,
                     },
                   )}
                   onMouseDownCapture={e => this.onSuggestionMouseDown(e, i)}
@@ -93,7 +97,7 @@ export default class ExpressionEditorSuggestions extends React.Component {
                       {suggestion.name.slice(0, suggestion.range[0])}
                       <span
                         className={cx("text-brand text-bold hover-child", {
-                          "text-white bg-brand": i === highlightedIndex,
+                          "text-white bg-brand": isHighlighted,
                         })}
                       >
                         {suggestion.name.slice(

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
@@ -5,7 +5,7 @@ import { t } from "ttag";
 import cx from "classnames";
 
 import Popover from "metabase/components/Popover";
-import { UlStyled } from "./ExpressionEditorSuggestions.styled";
+import { SectionTitle, UlStyled } from "./ExpressionEditorSuggestions.styled";
 
 import { isObscured } from "metabase/lib/dom";
 
@@ -15,6 +15,29 @@ const SUGGESTION_SECTION_NAMES = {
   operators: t`Operators`,
   metrics: t`Metrics`,
   other: t`Other`,
+};
+
+const SuggestionSpan = ({ suggestion, isHighlighted }) => {
+  const className = cx("text-brand text-bold hover-child", {
+    "text-white bg-brand": isHighlighted,
+  });
+
+  return suggestion.range ? (
+    <span>
+      {suggestion.name.slice(0, suggestion.range[0])}
+      <span className={className}>
+        {suggestion.name.slice(suggestion.range[0], suggestion.range[1])}
+      </span>
+      {suggestion.name.slice(suggestion.range[1])}
+    </span>
+  ) : (
+    suggestion.name
+  );
+};
+
+SuggestionSpan.propTypes = {
+  suggestion: PropTypes.object,
+  isHighlighted: PropTypes.bool,
 };
 
 export default class ExpressionEditorSuggestions extends React.Component {
@@ -69,47 +92,27 @@ export default class ExpressionEditorSuggestions extends React.Component {
 
             const isHighlighted = i === highlightedIndex;
 
-            // insert section title. assumes they're sorted by type
+            const listItemClassName = cx(
+              "px2 cursor-pointer text-white-hover bg-brand-hover hover-parent hover--inherit",
+              {
+                "text-white bg-brand": isHighlighted,
+              },
+            );
+
             return (
               <React.Fragment key={i}>
                 {shouldRenderSectionTitle && (
-                  <li className="mx2 h6 text-uppercase text-bold text-medium py1 pt2">
-                    {sectionTitle}
-                  </li>
+                  <SectionTitle>{sectionTitle}</SectionTitle>
                 )}
                 <li
-                  ref={r => {
-                    if (isHighlighted) {
-                      this._selectedRow = r;
-                    }
-                  }}
                   style={{ paddingTop: 5, paddingBottom: 5 }}
-                  className={cx(
-                    "px2 cursor-pointer text-white-hover bg-brand-hover hover-parent hover--inherit",
-                    {
-                      "text-white bg-brand": isHighlighted,
-                    },
-                  )}
+                  className={listItemClassName}
                   onMouseDownCapture={e => this.onSuggestionMouseDown(e, i)}
                 >
-                  {suggestion.range ? (
-                    <span>
-                      {suggestion.name.slice(0, suggestion.range[0])}
-                      <span
-                        className={cx("text-brand text-bold hover-child", {
-                          "text-white bg-brand": isHighlighted,
-                        })}
-                      >
-                        {suggestion.name.slice(
-                          suggestion.range[0],
-                          suggestion.range[1],
-                        )}
-                      </span>
-                      {suggestion.name.slice(suggestion.range[1])}
-                    </span>
-                  ) : (
-                    suggestion.name
-                  )}
+                  <SuggestionSpan
+                    suggestion={suggestion}
+                    isHighlighted={isHighlighted}
+                  />
                 </li>
               </React.Fragment>
             );
@@ -119,123 +122,3 @@ export default class ExpressionEditorSuggestions extends React.Component {
     );
   }
 }
-/*
-import React from "react";
-import PropTypes from "prop-types";
-
-import { t } from "ttag";
-import cx from "classnames";
-
-import Popover from "metabase/components/Popover";
-import {
-  UlStyled,
-  LiStyled,
-  LiStyledHighlighted,
-  SectionTitle,
-} from "./ExpressionEditorSuggestions.styled";
-
-import { isObscured } from "metabase/lib/dom";
-
-const SUGGESTION_SECTION_NAMES = {
-  fields: t`Fields`,
-  aggregations: t`Aggregations`,
-  operators: t`Operators`,
-  metrics: t`Metrics`,
-  other: t`Other`,
-};
-
-export default class ExpressionEditorSuggestions extends React.Component {
-  static propTypes = {
-    suggestions: PropTypes.array,
-    onSuggestionMouseDown: PropTypes.func, // signature is f(index)
-    highlightedIndex: PropTypes.number.isRequired,
-  };
-
-  componentDidUpdate(prevProps, prevState) {
-    if (
-      (prevProps && prevProps.highlightedIndex) !== this.props.highlightedIndex
-    ) {
-      if (this._selectedRow && isObscured(this._selectedRow)) {
-        this._selectedRow.scrollIntoView({ block: "nearest" });
-      }
-    }
-  }
-
-  // when a given suggestion is clicked
-  onSuggestionMouseDown(event, index) {
-    event.preventDefault();
-    event.stopPropagation();
-
-    this.props.onSuggestionMouseDown && this.props.onSuggestionMouseDown(index);
-  }
-
-  render() {
-    const { suggestions, highlightedIndex } = this.props;
-
-    if (!suggestions.length) {
-      return null;
-    }
-
-    return (
-      <Popover
-        className="not-rounded border-dark"
-        hasArrow={false}
-        tetherOptions={{
-          attachment: "top left",
-          targetAttachment: "bottom left",
-        }}
-        sizeToFit
-      >
-        <UlStyled>
-          {suggestions.map((suggestion, i) => {
-            const shouldRenderSectionTitle =
-              i === 0 || suggestion.type !== suggestions[i - 1].type;
-
-            const sectionTitle =
-              SUGGESTION_SECTION_NAMES[suggestion.type] || suggestion.type;
-
-            const isHighlighted = i === highlightedIndex;
-
-            return (
-              <React.Fragment key={`suggestion-${i}`}>
-                {shouldRenderSectionTitle && (
-                  <SectionTitle>{sectionTitle}</SectionTitle>
-                )}
-
-                <LiStyled
-                  ref={r => {
-                    if (isHighlighted) {
-                      this._selectedRow = r;
-                    }
-                  }}
-                  onMouseDownCapture={e => this.onSuggestionMouseDown(e, i)}
-                  style={{ color: isHighlighted ? "green" : "red" }}
-                >
-                  {suggestion.range ? (
-                    <span>
-                      {suggestion.name.slice(0, suggestion.range[0])}
-                      <span
-                        className={cx("text-brand text-bold hover-child", {
-                          "text-white bg-brand": isHighlighted,
-                        })}
-                      >
-                        {suggestion.name.slice(
-                          suggestion.range[0],
-                          suggestion.range[1],
-                        )}
-                      </span>
-                      {suggestion.name.slice(suggestion.range[1])}
-                    </span>
-                  ) : (
-                    suggestion.name
-                  )}
-                </LiStyled>
-              </React.Fragment>
-            );
-          })}
-        </UlStyled>
-      </Popover>
-    );
-  }
-}
-*/

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
@@ -100,7 +100,7 @@ export default class ExpressionEditorSuggestions extends React.Component {
             );
 
             return (
-              <React.Fragment key={i}>
+              <React.Fragment key={`suggestion-${i}`}>
                 {shouldRenderSectionTitle && (
                   <SectionTitle>{sectionTitle}</SectionTitle>
                 )}

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
@@ -95,13 +95,6 @@ export default class ExpressionEditorSuggestions extends React.Component {
 
             const isHighlighted = i === highlightedIndex;
 
-            // const listItemClassName = cx(
-            //   "px2 cursor-pointer text-white-hover bg-brand-hover hover-parent hover--inherit",
-            //   {
-            //     "text-white bg-brand": isHighlighted,
-            //   },
-            // );
-
             return (
               <React.Fragment key={`suggestion-${i}`}>
                 {shouldRenderSectionTitle && (

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.styled.jsx
@@ -10,18 +10,3 @@ const sectionTitleClassName =
 export const SectionTitle = styled.li.attrs({
   className: sectionTitleClassName,
 })``;
-
-const liStyledClassName =
-  "px2 cursor-pointer text-white-hover bg-brand-hover hover-parent hover--inherit";
-export const LiStyled = styled.li.attrs({ className: liStyledClassName })`
-  padding-top: 5px;
-  padding-bottom: 5px;
-  color: red;
-`;
-
-const liStyledHighlightedClassName = liStyledClassName + "text-white bg-brand";
-export const LiStyledHighlighted = styled.li.attrs({
-  className: liStyledHighlightedClassName,
-})`
-  color: green;
-`;

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.styled.jsx
@@ -16,9 +16,12 @@ const liStyledClassName =
 export const LiStyled = styled.li.attrs({ className: liStyledClassName })`
   padding-top: 5px;
   padding-bottom: 5px;
+  color: red;
 `;
 
-const liStyledHighlightedClassName = "text-white bg-brand";
-export const LiStyledHighlighted = styled(LiStyled).attrs({
+const liStyledHighlightedClassName = liStyledClassName + "text-white bg-brand";
+export const LiStyledHighlighted = styled.li.attrs({
   className: liStyledHighlightedClassName,
-});
+})`
+  color: green;
+`;

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.styled.jsx
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+import { color } from "metabase/lib/colors";
 
 export const UlStyled = styled.ul.attrs({ className: "pb1" })`
   min-width: 150px;
@@ -7,6 +8,21 @@ export const UlStyled = styled.ul.attrs({ className: "pb1" })`
 
 const sectionTitleClassName =
   "mx2 h6 text-uppercase text-bold text-medium py1 pt2";
+
 export const SectionTitle = styled.li.attrs({
   className: sectionTitleClassName,
 })``;
+
+const listItemStyledClassName =
+  "px2 cursor-pointer text-white-hover bg-brand-hover hover-parent hover--inherit";
+
+export const ListItemStyled = styled.li.attrs({
+  className: listItemStyledClassName,
+})`
+  color: ${({ isHighlighted }) =>
+    isHighlighted ? color("white") : color("brand")};
+  background-color: ${({ isHighlighted }) =>
+    isHighlighted ? color("brand") : "inherit"};
+  padding-top: 5px;
+  padding-bottom: 5px;
+`;

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.styled.jsx
@@ -19,10 +19,13 @@ const listItemStyledClassName =
 export const ListItemStyled = styled.li.attrs({
   className: listItemStyledClassName,
 })`
-  color: ${({ isHighlighted }) =>
-    isHighlighted ? color("white") : color("brand")};
-  background-color: ${({ isHighlighted }) =>
-    isHighlighted ? color("brand") : "inherit"};
   padding-top: 5px;
   padding-bottom: 5px;
+
+  ${({ isHighlighted }) =>
+    isHighlighted &&
+    `
+      color: ${color("white")};
+      background-color: ${color("brand")};
+  `})}
 `;

--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -648,7 +648,9 @@ describe("scenarios > question > filter", () => {
     popover().contains(/case/i);
   });
 
-  it("should enable highlighting suggestions with keyboard up and down arrows (metabase#16210)", () => {
+  it.only("should enable highlighting suggestions with keyboard up and down arrows (metabase#16210)", () => {
+    const brandColor = "rgb(80, 158, 227)";
+
     openReviewsTable({ mode: "notebook" });
     cy.findByText("Filter").click();
     cy.findByText("Custom Expression").click();
@@ -657,27 +659,24 @@ describe("scenarios > question > filter", () => {
       .click()
       .type("c");
 
-    // First highlighted selection is Created At
-    // "C" is wrapped in a <span>
-    // so we must look for string "reated At"
-    cy.findByText("reated At")
+    cy.contains("Created At")
       .closest("li")
       .should("have.css", "background-color")
-      .and("eq", "rgb(80, 158, 227)");
+      .and("eq", brandColor);
 
     cy.get("[contenteditable='true']")
       .click()
       .type("{downarrow}");
 
-    cy.findByText("reated At")
+    cy.contains("Created At")
       .closest("li")
       .should("have.css", "background-color")
-      .and("not.eq", "rgb(80, 158, 227)");
+      .and("not.eq", brandColor);
 
-    cy.findByText(/ategory/i)
+    cy.contains("Product → Category")
       .closest("li")
       .should("have.css", "background-color")
-      .and("eq", "rgb(80, 158, 227)");
+      .and("eq", brandColor);
   });
 
   it.skip("should provide accurate auto-complete custom-expression suggestions based on the aggregated column name (metabase#14776)", () => {

--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -636,9 +636,8 @@ describe("scenarios > question > filter", () => {
   });
 
   it("should offer case expression in the auto-complete suggestions", () => {
-    openReviewsTable({ mode: "notebook" });
-    cy.findByText("Filter").click();
-    cy.findByText("Custom Expression").click();
+    openExpressionEditorFromFreshlyLoadedPage();
+
     popover().contains(/case/i);
 
     // "case" is still there after typing a bit
@@ -648,25 +647,19 @@ describe("scenarios > question > filter", () => {
     popover().contains(/case/i);
   });
 
-  it.only("should enable highlighting suggestions with keyboard up and down arrows (metabase#16210)", () => {
+  it("should enable highlighting suggestions with keyboard up and down arrows (metabase#16210)", () => {
     const brandColor = "rgb(80, 158, 227)";
 
-    openReviewsTable({ mode: "notebook" });
-    cy.findByText("Filter").click();
-    cy.findByText("Custom Expression").click();
+    openExpressionEditorFromFreshlyLoadedPage();
 
-    cy.get("[contenteditable='true']")
-      .click()
-      .type("c");
+    typeInExpressionEditor("c");
 
     cy.contains("Created At")
       .closest("li")
       .should("have.css", "background-color")
       .and("eq", brandColor);
 
-    cy.get("[contenteditable='true']")
-      .click()
-      .type("{downarrow}");
+    typeInExpressionEditor("{downarrow}");
 
     cy.contains("Created At")
       .closest("li")
@@ -1019,3 +1012,15 @@ describe("scenarios > question > filter", () => {
     cy.button("Add filter").isVisibleInPopover();
   });
 });
+
+function openExpressionEditorFromFreshlyLoadedPage() {
+  openReviewsTable({ mode: "notebook" });
+  cy.findByText("Filter").click();
+  cy.findByText("Custom Expression").click();
+}
+
+function typeInExpressionEditor(string) {
+  cy.get("[contenteditable='true']")
+    .click()
+    .type(string);
+}

--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -640,10 +640,9 @@ describe("scenarios > question > filter", () => {
 
     popover().contains(/case/i);
 
+    typeInExpressionEditor("c");
+
     // "case" is still there after typing a bit
-    cy.get("[contenteditable='true']")
-      .click()
-      .type("c");
     popover().contains(/case/i);
   });
 

--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -648,7 +648,7 @@ describe("scenarios > question > filter", () => {
   });
 
   it("should enable highlighting suggestions with keyboard up and down arrows (metabase#16210)", () => {
-    const brandColor = "rgb(80, 158, 227)";
+    const transparent = "rgba(0, 0, 0, 0)";
 
     openExpressionEditorFromFreshlyLoadedPage();
 
@@ -657,19 +657,19 @@ describe("scenarios > question > filter", () => {
     cy.contains("Created At")
       .closest("li")
       .should("have.css", "background-color")
-      .and("eq", brandColor);
+      .and("not.eq", transparent);
 
     typeInExpressionEditor("{downarrow}");
 
     cy.contains("Created At")
       .closest("li")
       .should("have.css", "background-color")
-      .and("not.eq", brandColor);
+      .and("eq", transparent);
 
     cy.contains("Product → Category")
       .closest("li")
       .should("have.css", "background-color")
-      .and("eq", brandColor);
+      .and("not.eq", transparent);
   });
 
   it.skip("should provide accurate auto-complete custom-expression suggestions based on the aggregated column name (metabase#14776)", () => {

--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -648,6 +648,38 @@ describe("scenarios > question > filter", () => {
     popover().contains(/case/i);
   });
 
+  it("should enable highlighting suggestions with keyboard up and down arrows (metabase#16210)", () => {
+    openReviewsTable({ mode: "notebook" });
+    cy.findByText("Filter").click();
+    cy.findByText("Custom Expression").click();
+
+    cy.get("[contenteditable='true']")
+      .click()
+      .type("c");
+
+    // First highlighted selection is Created At
+    // "C" is wrapped in a <span>
+    // so we must look for string "reated At"
+    cy.findByText("reated At")
+      .closest("li")
+      .should("have.css", "background-color")
+      .and("eq", "rgb(80, 158, 227)");
+
+    cy.get("[contenteditable='true']")
+      .click()
+      .type("{downarrow}");
+
+    cy.findByText("reated At")
+      .closest("li")
+      .should("have.css", "background-color")
+      .and("not.eq", "rgb(80, 158, 227)");
+
+    cy.findByText(/ategory/i)
+      .closest("li")
+      .should("have.css", "background-color")
+      .and("eq", "rgb(80, 158, 227)");
+  });
+
   it.skip("should provide accurate auto-complete custom-expression suggestions based on the aggregated column name (metabase#14776)", () => {
     cy.viewport(1400, 1000); // We need a bit taller window for this repro to see all custom filter options in the popover
     cy.createQuestion({


### PR DESCRIPTION
Fixes #16210

Adds e2e test to cover #16210 (see its description to manually reproduce issue in master branch)

## To Test Manually

1. Ask a question, Custom question
2. Sample Dataset, Orders table
3. Filter, Custom Expression
4. Start typing 'U'

In the popup list, you should again be able to use the up and down arrows of the keyboard to highlight the item.