### PR TITLE
Fix #15998: Tooltip only shows first Y-axis value when X-axis is nume…

### DIFF
--- a/frontend/src/metabase/visualizations/lib/renderer_utils.js
+++ b/frontend/src/metabase/visualizations/lib/renderer_utils.js
@@ -154,11 +154,13 @@ export function getDatas({ settings, series }, warn) {
       rows = data.rows.filter(([x]) => x !== null);
     } else if (parseOptions.isNumeric) {
       rows = data.rows.map((row) => {
-        if(row.length > 0) {
-          row[0] = replaceNullValuesForOrdinal(row[0]);
-        }
-        
-        return row;
+        const [x, ...rest] = row;
+        const newRow = [
+          replaceNullValuesForOrdinal(x),
+          ...rest,
+        ]
+        newRow._origin = row._origin;
+        return newRow;
       });
     }
 

--- a/frontend/src/metabase/visualizations/lib/renderer_utils.js
+++ b/frontend/src/metabase/visualizations/lib/renderer_utils.js
@@ -153,10 +153,13 @@ export function getDatas({ settings, series }, warn) {
     if (isNotOrdinal) {
       rows = data.rows.filter(([x]) => x !== null);
     } else if (parseOptions.isNumeric) {
-      rows = data.rows.map(([x, ...rest]) => [
-        replaceNullValuesForOrdinal(x),
-        ...rest,
-      ]);
+      rows = data.rows.map((row) => {
+        if(row.length > 0) {
+          row[0] = replaceNullValuesForOrdinal(row[0]);
+        }
+        
+        return row;
+      });
     }
 
     if (rows.length < data.rows.length) {

--- a/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
@@ -68,7 +68,7 @@ describe("scenarios > visualizations > line chart", () => {
     cy.get(".value-labels").contains("30%");
   });
 
-  it.skip("should correctly display tooltip values when X-axis is numeric and style is 'Ordinal' (metabase#15998)", () => {
+  it("should correctly display tooltip values when X-axis is numeric and style is 'Ordinal' (metabase#15998)", () => {
     visitQuestionAdhoc({
       dataset_query: {
         database: 1,


### PR DESCRIPTION
Fix for https://github.com/metabase/metabase/issues/15998 
Unskipped cypress test passed locally

`[x, ...rest]` from the master will NOT work with arrays with custom fields (e.g. _origin) as the result we will lose it during array destructuration. Without it we can't render some data properly e.g. tooltip
