### PR TITLE
Close moderation requests when a review is verified

### DIFF
--- a/src/metabase/api/comment.clj
+++ b/src/metabase/api/comment.clj
@@ -8,9 +8,9 @@
 (api/defendpoint POST "/"
   "Create a new `Comment`."
   [:as {{:keys [text commented_item_id commented_item_type]} :body}]
-  {text                s/Str
-   commented_item_id   su/IntGreaterThanZero
-   commented_item_type comment/commented-item-types}
+  {:text                s/Str
+   :commented_item_id   su/IntGreaterThanZero
+   :commented_item_type comment/commented-item-types}
   (let [comment-data {:text                text
                       :commented_item_id   commented_item_id
                       :commented_item_type commented_item_type

--- a/src/metabase/api/moderation_request.clj
+++ b/src/metabase/api/moderation_request.clj
@@ -9,11 +9,11 @@
 (api/defendpoint POST "/"
   "Create a new `ModerationRequest`."
   [:as {{:keys [text type moderated_item_id moderated_item_type status]} :body}]
-  {text                    (s/maybe s/Str)
-   type                    moderation-request/types
-   moderated_item_id       su/IntGreaterThanZero
-   moderated_item_type     moderation/moderated-item-types
-   (s/optional-key status) moderation-request/statuses}
+  {:text                    (s/maybe s/Str)
+   :type                    moderation-request/types
+   :moderated_item_id       su/IntGreaterThanZero
+   :moderated_item_type     moderation/moderated-item-types
+   (s/optional-key :status) moderation-request/statuses}
   (let [request-data (merge {:text                text
                              :type                type
                              :moderated_item_id   moderated_item_id
@@ -26,12 +26,12 @@
 
 (api/defendpoint PUT "/:id"
   [id :as {{:keys [text type moderated_item_id moderated_item_type status closed_by_id] :as request-updates} :body}]
-  {(s/optional-key text)                (s/maybe s/Str)
-   (s/optional-key type)                moderation-request/types
-   (s/optional-key moderated_item_id)   su/IntGreaterThanZero
-   (s/optional-key moderated_item_type) moderation/moderated-item-types
-   (s/optional-key status)              moderation-request/statuses
-   (s/optional-key closed_by_id)        su/IntGreaterThanZero}
+  {(s/optional-key :text)                (s/maybe s/Str)
+   (s/optional-key :type)                moderation-request/types
+   (s/optional-key :moderated_item_id)   su/IntGreaterThanZero
+   (s/optional-key :moderated_item_type) moderation/moderated-item-types
+   (s/optional-key :status)              moderation-request/statuses
+   (s/optional-key :closed_by_id)        su/IntGreaterThanZero}
   ;; TODO permissions
   (moderation-request/update-request!
    (assoc (select-keys request-updates [:text :type :moderated_item_id :moderated_item_type :status :closed_by_id])

--- a/src/metabase/api/moderation_review.clj
+++ b/src/metabase/api/moderation_review.clj
@@ -29,8 +29,9 @@
    (s/optional-key :moderated_item_type) moderation/moderated-item-types
    (s/optional-key :status)              moderation-review/statuses}
   ;; TODO permissions
-  (moderation-review/update-review!
-   (assoc (select-keys review-updates [:text :moderated_item_id :moderated_item_type :status])
-          :id id)))
+  (api/check-500
+   (moderation-review/update-review!
+    (assoc (select-keys review-updates [:text :moderated_item_id :moderated_item_type :status])
+           :id id))))
 
 (api/define-routes)

--- a/src/metabase/api/moderation_review.clj
+++ b/src/metabase/api/moderation_review.clj
@@ -9,10 +9,10 @@
 (api/defendpoint POST "/"
   "Create a new `ModerationReview`."
   [:as {{:keys [text moderated_item_id moderated_item_type status]} :body}]
-  {text                    (s/maybe s/Str)
-   moderated_item_id       su/IntGreaterThanZero
-   moderated_item_type     moderation/moderated-item-types
-   (s/optional-key status) moderation-review/statuses}
+  {:text                    (s/maybe s/Str)
+   :moderated_item_id       su/IntGreaterThanZero
+   :moderated_item_type     moderation/moderated-item-types
+   (s/optional-key :status) moderation-review/statuses}
   (let [review-data (merge {:text                text
                             :moderated_item_id   moderated_item_id
                             :moderated_item_type moderated_item_type
@@ -24,11 +24,12 @@
 
 (api/defendpoint PUT "/:id"
   [id :as {{:keys [text moderated_item_id moderated_item_type status] :as review-updates} :body}]
-  {(s/optional-key text)                (s/maybe s/Str)
-   (s/optional-key moderated_item_id)   su/IntGreaterThanZero
-   (s/optional-key moderated_item_type) moderation/moderated-item-types
-   (s/optional-key status)              moderation-review/statuses}
+  {(s/optional-key :text)                (s/maybe s/Str)
+   (s/optional-key :moderated_item_id)   su/IntGreaterThanZero
+   (s/optional-key :moderated_item_type) moderation/moderated-item-types
+   (s/optional-key :status)              moderation-review/statuses}
   ;; TODO permissions
+  (println "here we go")
   (moderation-review/update-review!
    (assoc (select-keys review-updates [:text :moderated_item_id :moderated_item_type :status])
           :id id)))

--- a/src/metabase/api/moderation_review.clj
+++ b/src/metabase/api/moderation_review.clj
@@ -29,7 +29,6 @@
    (s/optional-key :moderated_item_type) moderation/moderated-item-types
    (s/optional-key :status)              moderation-review/statuses}
   ;; TODO permissions
-  (println "here we go")
   (moderation-review/update-review!
    (assoc (select-keys review-updates [:text :moderated_item_id :moderated_item_type :status])
           :id id)))

--- a/src/metabase/models/moderation_review.clj
+++ b/src/metabase/models/moderation_review.clj
@@ -12,6 +12,15 @@
   "Schema enum of the acceptable values for the `status` column"
   (s/enum "verified" "misleading" "confusing" "not_misleading" "pending"))
 
+(def ReviewChanges
+  "Schema for a ModerationReview that's being updated (so most keys are optional)"
+  {(s/optional-key :id)                  su/IntGreaterThanZero
+   (s/optional-key :moderated_item_id)   su/IntGreaterThanZero
+   (s/optional-key :moderated_item_type) moderation/moderated-item-types
+   (s/optional-key :status)              statuses
+   (s/optional-key :text)                (s/maybe s/Str)
+   s/Any                                 s/Any})
+
 (models/defmodel ModerationReview :moderation_review)
 
 (u/strict-extend (class ModerationReview)
@@ -35,13 +44,32 @@
     (s/optional-key :text)   (s/maybe s/Str)}]
   (db/insert! ModerationReview params))
 
+(defn- newly-verified?
+  [old-status new-status]
+  (and
+   (not= "verified" old-status)
+   (= "verified" new-status)))
+
+(defn- resolve-requests!
+  "All open moderation requests for verification connected to the same question/dashboard should be closed"
+  [{:keys [moderated_item_id moderated_item_type]}]
+  (db/update-where! 'ModerationRequest {:moderated_item_id   moderated_item_id
+                                        :moderated_item_type (name moderated_item_type)
+                                        :type                "verification_request"
+                                        :status              "open"}
+    :status "resolved"))
+
+(s/defn post-update
+  [old-review :- ReviewChanges, new-review :- ReviewChanges]
+  (when (newly-verified? (:status old-review) (:status new-review))
+    (resolve-requests! new-review)))
+
 (s/defn update-review!
   "Update the given keys for an existing ModerationReview with the given `:id`"
-  [review :-
-   {:id                                   su/IntGreaterThanZero
-    (s/optional-key :moderated_item_id)   su/IntGreaterThanZero
-    (s/optional-key :moderated_item_type) moderation/moderated-item-types
-    (s/optional-key :status)              statuses
-    (s/optional-key :text)                (s/maybe s/Str)}]
-  (when (db/update! ModerationReview (u/the-id review) (dissoc review :id))
-    (ModerationReview (u/the-id review))))
+  [review :- ReviewChanges]
+  (let [id         (u/the-id review)
+        old-review (ModerationReview id)]
+    (when-let [new-review (and (db/update! ModerationReview id review)
+                               (ModerationReview id))]
+      (post-update old-review new-review)
+      new-review)))

--- a/src/metabase/moderation.clj
+++ b/src/metabase/moderation.clj
@@ -7,7 +7,7 @@
 
 (def moderated-item-types
   "Schema enum of the acceptable values for the `moderated_item_type` column"
-  (s/enum "card" "dashboard"))
+  (s/enum "card" "dashboard" :card :dashboard))
 
 (defn- object->type
   "Convert a moderated item instance to the keyword stored in the database"


### PR DESCRIPTION
When a moderator marks a question or dashboard as verified, misleading, or confusing, all of the associated moderation requests should be closed.