### PR TITLE
Fix dashboards layout issues

### DIFF
--- a/frontend/src/metabase/dashboard/components/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard.jsx
@@ -285,7 +285,7 @@ export default class Dashboard extends Component {
         className={cx("Dashboard flex-full", {
           "Dashboard--fullscreen": isFullscreen,
           "Dashboard--night": isNightMode,
-          "full-height": isSharing, // prevents header from scrolling so we can have a fixed sidebar
+          "full-height": isEditing || isSharing, // prevents header from scrolling so we can have a fixed sidebar
         })}
         loading={!dashboard}
         error={error}
@@ -308,7 +308,7 @@ export default class Dashboard extends Component {
             </header>
             <div
               className={cx("flex shrink-below-content-size flex-full", {
-                "flex-basis-none": isSharing,
+                "flex-basis-none": isEditing || isSharing,
               })}
             >
               <div className="flex-auto overflow-x-hidden">

--- a/frontend/src/metabase/lib/dashboard_grid.js
+++ b/frontend/src/metabase/lib/dashboard_grid.js
@@ -6,7 +6,7 @@ export const GRID_MARGIN = 6;
 
 export const DEFAULT_CARD_SIZE = { width: 4, height: 4 };
 
-export const MIN_ROW_HEIGHT = 60;
+export const MIN_ROW_HEIGHT = 54;
 
 type DashCardPosition = {
   col: number,


### PR DESCRIPTION
This PR is related to #16167 (switching dashboards grid to `react-grid-layout` project). The PR does two things:

* returns the fixed dashboard header in editing mode back (turned off at #16167). For some reason, I thought it wasn't an expected behavior, but it was a mistake, so I'm putting it back
* fixes an E2E test failing (see [CircleCI log](https://app.circleci.com/pipelines/github/metabase/metabase/16393/workflows/47156c73-4d57-490c-b002-aa1e8ab35f8f/jobs/636516) for PR #16167)

**Note on the fix for failing tests** 

The failing test renders a dashboard with a table question. Everything worked fine until the very latest [`cy.contains(/Rows \d-\d of 96/)` assertion](https://github.com/metabase/metabase/blob/67bcfdd0233407b628ce138a3f33ccee8f0856ef/frontend/test/metabase/scenarios/dashboard/dashboard_data_permissions.cy.spec.js#L23). The test expects the table's pagination control to be something like "Rows 1-9 of 96" (digit-digit), but on the RGL branches it's something like "Rows 1-11 our of 96" (digit-digit+digit)

The problem was that the height of the RGL cards was bigger for the same grid configuration. Fixed by decreasing minimum row height from 60 to 54. In that way, RGL's and previous grid's cards have the same dimensions.

**Screenshots**

Before (cards are a bit toller)

<img width="1498" alt="dashboard-rgl-wrong" src="https://user-images.githubusercontent.com/17258145/119535099-5988a600-bd90-11eb-9f0d-c6c205ec49dc.png">

After (cards are lower)

<img width="1498" alt="dashboard-rgl-fixed" src="https://user-images.githubusercontent.com/17258145/119535164-67d6c200-bd90-11eb-9069-cb1b20e9f2b7.png">

