### PR TITLE
Expand PK/FK filter operators to cover some more comparisons

### DIFF
--- a/frontend/src/metabase/lib/schema_metadata.js
+++ b/frontend/src/metabase/lib/schema_metadata.js
@@ -395,6 +395,18 @@ const DEFAULT_FILTER_OPERATORS = [
   { name: "not-null", verboseName: t`Not empty` },
 ];
 
+const KEY_FILTER_OPERATORS = [
+  { name: "=", verboseName: t`Is` },
+  { name: "!=", verboseName: t`Is not` },
+  { name: ">", verboseName: t`Greater than` },
+  { name: "<", verboseName: t`Less than` },
+  { name: "between", verboseName: t`Between` },
+  { name: ">=", verboseName: t`Greater than or equal to` },
+  { name: "<=", verboseName: t`Less than or equal to` },
+  { name: "is-null", verboseName: t`Is empty` },
+  { name: "not-null", verboseName: t`Not empty` },
+];
+
 // ordered list of operators and metadata per type
 const FILTER_OPERATORS_BY_TYPE_ORDERED = {
   [NUMBER]: [
@@ -456,8 +468,8 @@ const FILTER_OPERATORS_BY_TYPE_ORDERED = {
     { name: "is-null", verboseName: t`Is empty` },
     { name: "not-null", verboseName: t`Not empty` },
   ],
-  [FOREIGN_KEY]: DEFAULT_FILTER_OPERATORS,
-  [PRIMARY_KEY]: DEFAULT_FILTER_OPERATORS,
+  [FOREIGN_KEY]: KEY_FILTER_OPERATORS,
+  [PRIMARY_KEY]: KEY_FILTER_OPERATORS,
   [UNKNOWN]: DEFAULT_FILTER_OPERATORS,
 };
 

--- a/frontend/src/metabase/lib/schema_metadata.js
+++ b/frontend/src/metabase/lib/schema_metadata.js
@@ -509,7 +509,16 @@ export function getOperatorByTypeAndName(type, name) {
 }
 
 export function getFilterOperators(field, table, selected) {
-  const type = getFieldType(field) || UNKNOWN;
+  const fieldType = getFieldType(field) || UNKNOWN;
+  let type = fieldType;
+  if (type === PRIMARY_KEY || type === FOREIGN_KEY) {
+    if (isFieldType(STRING, field)) {
+      type = STRING;
+    } else if (isFieldType(STRING_LIKE, field)) {
+      type = STRING_LIKE;
+    }
+  }
+
   return FILTER_OPERATORS_BY_TYPE_ORDERED[type]
     .map(operatorForType => {
       const operator = FIELD_FILTER_OPERATORS[operatorForType.name];

--- a/frontend/test/metabase/lib/schema_metadata.unit.spec.js
+++ b/frontend/test/metabase/lib/schema_metadata.unit.spec.js
@@ -13,6 +13,7 @@ import {
   isEqualsOperator,
   doesOperatorExist,
   getOperatorByTypeAndName,
+  getFilterOperators,
   isFuzzyOperator,
 } from "metabase/lib/schema_metadata";
 
@@ -155,6 +156,54 @@ describe("schema_metadata", () => {
         validArgumentsFilters: [expect.any(Function), expect.any(Function)],
         verboseName: "Between",
       });
+    });
+  });
+
+  describe("getFilterOperators", () => {
+    it("should return proper filter operators for text/Integer primary key", () => {
+      expect(
+        getFilterOperators({
+          effective_type: TYPE.Integer,
+          semantic_type: TYPE.PK,
+        }).map(op => op.name),
+      ).toEqual([
+        "=",
+        "!=",
+        ">",
+        "<",
+        "between",
+        ">=",
+        "<=",
+        "is-null",
+        "not-null",
+      ]);
+    });
+    it("should return proper filter operators for type/Text primary key", () => {
+      expect(
+        getFilterOperators({
+          effective_type: TYPE.Text,
+          semantic_type: TYPE.PK,
+        }).map(op => op.name),
+      ).toEqual([
+        "=",
+        "!=",
+        "contains",
+        "does-not-contain",
+        "is-null",
+        "not-null",
+        "is-empty",
+        "not-empty",
+        "starts-with",
+        "ends-with",
+      ]);
+    });
+    it("should return proper filter operators for type/TextLike foreign key", () => {
+      expect(
+        getFilterOperators({
+          effective_type: TYPE.TextLike,
+          semantic_type: TYPE.FK,
+        }).map(op => op.name),
+      ).toEqual(["=", "!=", "is-null", "not-null", "is-empty", "not-empty"]);
     });
   });
 

--- a/frontend/test/metabase/lib/schema_metadata.unit.spec.js
+++ b/frontend/test/metabase/lib/schema_metadata.unit.spec.js
@@ -8,6 +8,7 @@ import {
   LOCATION,
   COORDINATE,
   PRIMARY_KEY,
+  FOREIGN_KEY,
   foreignKeyCountsByOriginTable,
   isEqualsOperator,
   doesOperatorExist,
@@ -130,6 +131,25 @@ describe("schema_metadata", () => {
 
     it("should return a metadata object for specific operator type/name", () => {
       expect(getOperatorByTypeAndName(NUMBER, "between")).toEqual({
+        name: "between",
+        numFields: 2,
+        validArgumentsFilters: [expect.any(Function), expect.any(Function)],
+        verboseName: "Between",
+      });
+    });
+
+    it("should return a metadata object for primary key", () => {
+      expect(getOperatorByTypeAndName(PRIMARY_KEY, "=")).toEqual({
+        multi: true,
+        name: "=",
+        numFields: 1,
+        validArgumentsFilters: [expect.any(Function)],
+        verboseName: "Is",
+      });
+    });
+
+    it("should return a metadata object for foreign key", () => {
+      expect(getOperatorByTypeAndName(FOREIGN_KEY, "between")).toEqual({
         name: "between",
         numFields: 2,
         validArgumentsFilters: [expect.any(Function), expect.any(Function)],

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -70,7 +70,7 @@ describe("scenarios > question > notebook", () => {
     cy.contains("Showing 1 row"); // ensure only one user was returned
   });
 
-  it.skip("should show the original custom expression filter field on subsequent click (metabase#14726)", () => {
+  it("should show the original custom expression filter field on subsequent click (metabase#14726)", () => {
     cy.server();
     cy.route("POST", "/api/dataset").as("dataset");
 
@@ -87,8 +87,13 @@ describe("scenarios > question > notebook", () => {
     });
 
     cy.wait("@dataset");
-    cy.findByText("ID 96 97").click();
-    cy.get("[contenteditable='true']").contains("between([ID], 96, 97)");
+    cy.findByText("ID between 96 97").click();
+    cy.findByText("Between").click();
+    popover().within(() => {
+      cy.contains("Is not");
+      cy.contains("Greater than");
+      cy.contains("Less than");
+    });
   });
 
   it("should show the correct number of function arguments in a custom expression", () => {


### PR DESCRIPTION
...since the back-end is already capable of handling those.

This fixes, among others, #14726.

Run the unit tests:
```
yarn test-unit frontend/test/metabase/lib/schema_metadata.unit.spec.js
```
and the E2E tests:
```
yarn test-cypress-open --spec frontend/test/metabase/scenarios/question/notebook.cy.spec.js
```
Steps to reproduce:
1. Ask a question, Custom question
2. Sample Dataset, People table
3. Filter, choose `ID`

**Before this PR**

There are only 4 possible comparisons for `ID`:

![image](https://user-images.githubusercontent.com/7288/119568938-f3d1f500-bd62-11eb-86c9-1d6c4dbbe527.png)

However, switching to Custom Expression allows us to filter `ID` using the function `between` (and this works, the result is correct):

![image](https://user-images.githubusercontent.com/7288/119569019-077d5b80-bd63-11eb-9cb5-396c658c2e3b.png)

Yet when clicking on that newly created filter (note the confusing display name `ID 1 100`), only shows this non-sensible drop-down:

![image](https://user-images.githubusercontent.com/7288/119569091-1e23b280-bd63-11eb-9f95-ed0f97715638.png)

**After this PR**

Choose between a number of different ways to filter `ID`:

![image](https://user-images.githubusercontent.com/7288/119569489-a609bc80-bd63-11eb-8877-aaac6cdadc3c.png)

including `between` (shown here using the drop-down, but equivalent with a custom expression):

![image](https://user-images.githubusercontent.com/7288/119569529-b326ab80-bd63-11eb-9cad-58c6b2d16b44.png)

and clicking the newly created filter (displayed appropriately as `ID between 1 100`) shows the drop-down to facilitate any modifcation: 

![image](https://user-images.githubusercontent.com/7288/119569576-c5a0e500-bd63-11eb-959c-4d2956219b90.png)
