### PR TITLE
Fix expansion of :metric macros inside nested queries

### DIFF
--- a/frontend/test/metabase/scenarios/question/nested.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nested.cy.spec.js
@@ -223,7 +223,7 @@ describe("scenarios > question > nested", () => {
     });
   });
 
-  it.skip("should apply metrics including filter to the nested question (metabase#12507)", () => {
+  it("should apply metrics including filter to the nested question (metabase#12507)", () => {
     const METRIC_NAME = "Discount Applied";
 
     cy.log("Create a metric with a filter");

--- a/frontend/test/metabase/scenarios/question/nested.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nested.cy.spec.js
@@ -5,6 +5,7 @@ import {
   openOrdersTable,
   remapDisplayValueToFK,
   sidebar,
+  visitQuestionAdhoc,
 } from "__support__/e2e/cypress";
 
 import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
@@ -224,67 +225,53 @@ describe("scenarios > question > nested", () => {
   });
 
   it("should apply metrics including filter to the nested question (metabase#12507)", () => {
-    const METRIC_NAME = "Discount Applied";
+    const METRIC_NAME = "Sum of discounts";
 
     cy.log("Create a metric with a filter");
-
     cy.request("POST", "/api/metric", {
       name: METRIC_NAME,
       description: "Discounted orders.",
-      definition: {
-        aggregation: [["count"]],
-        filter: ["not-null", ["field", ORDERS.DISCOUNT, null]],
-        "source-table": ORDERS_ID,
-      },
       table_id: ORDERS_ID,
-    }).then(({ body: { id: METRIC_ID } }) => {
+      definition: {
+        "source-table": ORDERS_ID,
+        aggregation: [["count"]],
+        filter: ["!=", ["field", ORDERS.DISCOUNT, null], 0],
+      },
+    }).then(({ body: { id: metricId } }) => {
       // "capture" the original query because we will need to re-use it later in a nested question as "source-query"
       const ORIGINAL_QUERY = {
-        aggregation: ["metric", METRIC_ID],
+        "source-table": ORDERS_ID,
+        aggregation: [["metric", metricId]],
         breakout: [
           ["field", ORDERS.TOTAL, { binning: { strategy: "default" } }],
         ],
-        "source-table": ORDERS_ID,
       };
 
       // Create new question which uses previously defined metric
       cy.createQuestion({
-        name: "Orders with discount applied",
+        name: "12507",
         query: ORIGINAL_QUERY,
-        display: "bar",
-        visualization_settings: {
-          "graph.dimension": ["TOTAL"],
-          "graph.metrics": [METRIC_NAME],
-        },
-      }).then(({ body: { id: QUESTION_ID } }) => {
-        cy.server();
-        cy.route("POST", `/api/card/${QUESTION_ID}/query`).as("cardQuery");
+      }).then(({ body: { id: questionId } }) => {
+        cy.intercept("POST", `/api/card/${questionId}/query`).as("cardQuery");
 
-        cy.log("Create a nested question based on the previous one");
-
-        // we're adding filter and saving/overwriting the original question, keeping the same ID
-        cy.request("PUT", `/api/card/${QUESTION_ID}`, {
+        cy.log("Create and visit a nested question based on the previous one");
+        visitQuestionAdhoc({
           dataset_query: {
-            database: 1,
-            query: {
-              filter: [
-                ">",
-                ["field", "TOTAL", { "base-type": "type/Float" }],
-                50,
-              ],
-              "source-query": ORIGINAL_QUERY,
-            },
             type: "query",
+            query: {
+              "source-table": `card__${questionId}`,
+              filter: [">", ["field", ORDERS.TOTAL, null], 50],
+            },
+            database: 1,
           },
         });
 
         cy.log("Reported failing since v0.35.2");
-        cy.visit(`/question/${QUESTION_ID}`);
+        cy.visit(`/question/${questionId}`);
         cy.wait("@cardQuery").then(xhr => {
           expect(xhr.response.body.error).not.to.exist;
         });
-        cy.findByText(METRIC_NAME);
-        cy.get(".bar");
+        cy.get(".cellData").contains(METRIC_NAME);
       });
     });
   });

--- a/shared/.dir-locals.el
+++ b/shared/.dir-locals.el
@@ -1,1 +1,4 @@
-((clojure-mode . ((cider-preferred-build-tool . shadow-cljs))))
+((nil . ((ftf-project-finders . (ftf-get-top-git-dir)))) ; tell find-things-fast not assume this folder is the project root.
+ (clojure-mode . ((cider-default-cljs-repl . shadow-select)
+                  (cider-shadow-default-options . "node-repl")
+                  (cider-preferred-build-tool . shadow-cljs))))

--- a/shared/src/metabase/mbql/schema.cljc
+++ b/shared/src/metabase/mbql/schema.cljc
@@ -988,7 +988,7 @@
     (every-pred
      (some-fn :source-table :source-query)
      (complement (every-pred :source-table :source-query)))
-    "Joins can must have either a `source-table` or `source-query`, but not both.")))
+    "Joins must have either a `source-table` or `source-query`, but not both.")))
 
 (def Joins
   "Schema for a valid sequence of `Join`s. Must be a non-empty sequence, and `:alias`, if specified, must be unique."

--- a/shared/src/metabase/mbql/util.cljc
+++ b/shared/src/metabase/mbql/util.cljc
@@ -129,7 +129,7 @@
 (s/defn add-filter-clause :- mbql.s/Query
   "Add an additional filter clause to an `outer-query`. If `new-clause` is `nil` this is a no-op."
   [outer-query :- mbql.s/Query new-clause :- (s/maybe mbql.s/Filter)]
-  (update outer-query :filter add-filter-clause-to-inner-query new-clause))
+  (update outer-query :query add-filter-clause-to-inner-query new-clause))
 
 (defn desugar-inside
   "Rewrite `:inside` filter clauses as a pair of `:between` clauses."

--- a/shared/src/metabase/mbql/util.cljc
+++ b/shared/src/metabase/mbql/util.cljc
@@ -120,12 +120,16 @@
   [filter-clause & more-filter-clauses]
   (simplify-compound-filter (cons :and (cons filter-clause more-filter-clauses))))
 
+(s/defn add-filter-clause-to-inner-query :- mbql.s/MBQLQuery
+  [inner-query :- mbql.s/MBQLQuery new-clause :- (s/maybe mbql.s/Filter)]
+  (if-not new-clause
+    inner-query
+    (update inner-query :filter combine-filter-clauses new-clause)))
+
 (s/defn add-filter-clause :- mbql.s/Query
   "Add an additional filter clause to an `outer-query`. If `new-clause` is `nil` this is a no-op."
-  [outer-query :- mbql.s/Query, new-clause :- (s/maybe mbql.s/Filter)]
-  (if-not new-clause
-    outer-query
-    (update-in outer-query [:query :filter] combine-filter-clauses new-clause)))
+  [outer-query :- mbql.s/Query new-clause :- (s/maybe mbql.s/Filter)]
+  (update outer-query :filter add-filter-clause-to-inner-query new-clause))
 
 (defn desugar-inside
   "Rewrite `:inside` filter clauses as a pair of `:between` clauses."

--- a/src/metabase/query_processor/middleware/expand_macros.clj
+++ b/src/metabase/query_processor/middleware/expand_macros.clj
@@ -67,11 +67,12 @@
                         :when  (not errors)]
                     metric))))
 
-(defn- add-metrics-filters-this-level [m this-level-metric-id->info]
+(s/defn ^:private add-metrics-filters-this-level :- mbql.s/MBQLQuery
+  [inner-query :- mbql.s/MBQLQuery this-level-metric-id->info :- {su/IntGreaterThanZero MetricInfo}]
   (let [filters (for [{{filter-clause :filter} :definition} (vals this-level-metric-id->info)
                       :when filter-clause]
                   filter-clause)]
-    (reduce mbql.u/add-filter-clause-to-inner-query m filters)))
+    (reduce mbql.u/add-filter-clause-to-inner-query inner-query filters)))
 
 (s/defn ^:private metric-info->ag-clause :- mbql.s/Aggregation
   "Return an appropriate aggregation clause from `metric-info`."
@@ -91,14 +92,15 @@
       _
       [:aggregation-options &match {:display-name metric-name}])))
 
-(defn- replace-metrics-aggregations-this-level [query metric-id->info]
+(s/defn ^:private replace-metrics-aggregations-this-level :- mbql.s/MBQLQuery
+  [inner-query :- mbql.s/MBQLQuery this-level-metric-id->info :- {su/IntGreaterThanZero MetricInfo}]
   (letfn [(metric [metric-id]
-            (or (get metric-id->info metric-id)
+            (or (get this-level-metric-id->info metric-id)
                 (throw (ex-info (tru "Metric {0} does not exist, or is invalid." metric-id)
                                 {:type   :invalid-query
                                  :metric metric-id
-                                 :query  query}))))]
-    (mbql.u/replace-in query [:aggregation]
+                                 :query  inner-query}))))]
+    (mbql.u/replace-in inner-query [:aggregation]
       ;; if metric is wrapped in aggregation options that give it a display name, expand the metric but do not name it
       [:aggregation-options [:metric (metric-id :guard (complement mbql.u/ga-id?))] (options :guard :display-name)]
       [:aggregation-options
@@ -129,26 +131,26 @@
                                                         mbql.s/MBQLQuery
                                                         (complement metric-ids-this-level)
                                                         "Inner MBQL query with no :metric clauses at this level")
-  [m metric-id->info]
-  (let [this-level-metric-ids      (metric-ids-this-level m)
+  [inner-query :- mbql.s/MBQLQuery metric-id->info :- {su/IntGreaterThanZero MetricInfo}]
+  (let [this-level-metric-ids      (metric-ids-this-level inner-query)
         this-level-metric-id->info (select-keys metric-id->info this-level-metric-ids)]
-    (-> m
+    (-> inner-query
         (add-metrics-filters-this-level this-level-metric-id->info)
         (replace-metrics-aggregations-this-level this-level-metric-id->info))))
 
-(defn- expand-metrics-clauses
+(s/defn ^:private expand-metrics-clauses :- su/Map
   "Add appropriate `filter` and `aggregation` clauses for a sequence of Metrics.
 
     (expand-metrics-clauses {:query {}} [[:metric 10]])
     ;; -> {:query {:aggregation [[:count]], :filter [:= [:field-id 10] 20]}}"
-  [query metric-id->info]
+  [query :- su/Map metric-id->info :- (su/non-empty {su/IntGreaterThanZero MetricInfo})]
   (mbql.u/replace query
     (m :guard metric-ids-this-level)
-    (->
-     ;; expand this this level...
-     (expand-metrics-clauses-this-level m metric-id->info)
-     ;; then recursively expand things at any other levels.
-     (expand-metrics-clauses metric-id->info))))
+    (-> m
+        ;; expand this this level...
+        (expand-metrics-clauses-this-level metric-id->info)
+        ;; then recursively expand things at any other levels.
+        (expand-metrics-clauses metric-id->info))))
 
 (s/defn ^:private expand-metrics :- mbql.s/Query
   [query :- mbql.s/Query]

--- a/src/metabase/query_processor/middleware/expand_macros.clj
+++ b/src/metabase/query_processor/middleware/expand_macros.clj
@@ -67,11 +67,11 @@
                         :when  (not errors)]
                     metric))))
 
-(defn- add-metrics-filters [query metric-id->info]
-  (let [filters (for [{{filter-clause :filter} :definition} (vals metric-id->info)
+(defn- add-metrics-filters-this-level [m this-level-metric-id->info]
+  (let [filters (for [{{filter-clause :filter} :definition} (vals this-level-metric-id->info)
                       :when filter-clause]
                   filter-clause)]
-    (reduce mbql.u/add-filter-clause query filters)))
+    (reduce mbql.u/add-filter-clause-to-inner-query m filters)))
 
 (s/defn ^:private metric-info->ag-clause :- mbql.s/Aggregation
   "Return an appropriate aggregation clause from `metric-info`."
@@ -91,12 +91,14 @@
       _
       [:aggregation-options &match {:display-name metric-name}])))
 
-(defn- replace-metrics-aggregations [query metric-id->info]
-  (let [metric (fn [metric-id]
-                 (or (get metric-id->info metric-id)
-                     (throw (ex-info (tru "Metric {0} does not exist, or is invalid." metric-id)
-                              {:type :invalid-query, :metric metric-id}))))]
-    (mbql.u/replace-in query [:query]
+(defn- replace-metrics-aggregations-this-level [query metric-id->info]
+  (letfn [(metric [metric-id]
+            (or (get metric-id->info metric-id)
+                (throw (ex-info (tru "Metric {0} does not exist, or is invalid." metric-id)
+                                {:type   :invalid-query
+                                 :metric metric-id
+                                 :query  query}))))]
+    (mbql.u/replace-in query [:aggregation]
       ;; if metric is wrapped in aggregation options that give it a display name, expand the metric but do not name it
       [:aggregation-options [:metric (metric-id :guard (complement mbql.u/ga-id?))] (options :guard :display-name)]
       [:aggregation-options
@@ -113,20 +115,45 @@
       [:metric (metric-id :guard (complement mbql.u/ga-id?))]
       (metric-info->ag-clause (metric metric-id) {:use-metric-name-as-display-name? true}))))
 
-(defn- add-metrics-clauses
+(s/defn ^:private metric-ids-this-level :- (s/maybe #{su/IntGreaterThanZero})
+  [inner-query]
+  (when (map? inner-query)
+    (when-let [aggregations (:aggregation inner-query)]
+      (not-empty
+       (set
+        (mbql.u/match aggregations
+          [:metric (metric-id :guard (complement mbql.u/ga-id?))]
+          metric-id))))))
+
+(s/defn ^:private expand-metrics-clauses-this-level :- (s/constrained
+                                                        mbql.s/MBQLQuery
+                                                        (complement metric-ids-this-level)
+                                                        "Inner MBQL query with no :metric clauses at this level")
+  [m metric-id->info]
+  (let [this-level-metric-ids      (metric-ids-this-level m)
+        this-level-metric-id->info (select-keys metric-id->info this-level-metric-ids)]
+    (-> m
+        (add-metrics-filters-this-level this-level-metric-id->info)
+        (replace-metrics-aggregations-this-level this-level-metric-id->info))))
+
+(defn- expand-metrics-clauses
   "Add appropriate `filter` and `aggregation` clauses for a sequence of Metrics.
 
-    (add-metrics-clauses {:query {}} [[:metric 10]])
+    (expand-metrics-clauses {:query {}} [[:metric 10]])
     ;; -> {:query {:aggregation [[:count]], :filter [:= [:field-id 10] 20]}}"
   [query metric-id->info]
-  (-> query
-      (add-metrics-filters metric-id->info)
-      (replace-metrics-aggregations metric-id->info)))
+  (mbql.u/replace query
+    (m :guard metric-ids-this-level)
+    (->
+     ;; expand this this level...
+     (expand-metrics-clauses-this-level m metric-id->info)
+     ;; then recursively expand things at any other levels.
+     (expand-metrics-clauses metric-id->info))))
 
 (s/defn ^:private expand-metrics :- mbql.s/Query
   [query :- mbql.s/Query]
   (if-let [metrics (metrics query)]
-    (add-metrics-clauses query (metric-clauses->id->info metrics))
+    (expand-metrics-clauses query (metric-clauses->id->info metrics))
     query))
 
 


### PR DESCRIPTION
When MBQL `:metric` macros were expanded inside of MBQL queries the QP was incorrectly splicing in the `:filter` clause in to the top level regardless of what level the `:metric` macro occurred in. This PR makes sure the `:filter` clauses are spliced into the same level as the original `:metric` macro.

Fixes #12507.