### PR TITLE
Search: do not complain on empty string

### DIFF
--- a/frontend/src/metabase/nav/components/SearchBar.jsx
+++ b/frontend/src/metabase/nav/components/SearchBar.jsx
@@ -138,21 +138,21 @@ export default class SearchBar extends React.Component {
               if (e.key === "Enter" && (searchText || "").trim().length > 0) {
                 this.props.onChangeLocation({
                   pathname: "search",
-                  query: { q: searchText },
+                  query: { q: searchText.trim() },
                 });
               }
             }}
           />
           {active && MetabaseSettings.searchTypeaheadEnabled() && (
             <div className="absolute left right text-dark" style={{ top: 60 }}>
-              {searchText.length > 0 ? (
+              {searchText.trim().length > 0 ? (
                 <Card
                   className="overflow-y-auto"
                   style={{ maxHeight: 400 }}
                   py={1}
                 >
                   <Search.ListLoader
-                    query={{ q: searchText }}
+                    query={{ q: searchText.trim() }}
                     wrapped
                     reload
                     debounced

--- a/frontend/test/metabase/scenarios/search/search.cy.spec.js
+++ b/frontend/test/metabase/scenarios/search/search.cy.spec.js
@@ -13,6 +13,14 @@ describe("scenarios > search", () => {
     cy.signInAsAdmin();
   });
 
+  it("should not search on an empty string", () => {
+    cy.intercept("/api/search", req => {
+      expect("Unexpected call to /api/search").to.be.false;
+    });
+    cy.visit("/");
+    cy.findByPlaceholderText("Search…").type(" ");
+  });
+
   it("should allow users to paginate results", () => {
     generateQuestions(TOTAL_ITEMS);
 


### PR DESCRIPTION
Accidentally pressing space on the search bar shouldn't trigger an API call, let alone an error.

Steps to reproduce:
1. Click on the search bar on the top navigation
2. Press space (one time or a few time)
3. Wait half a second

**Before this PR**

![image](https://user-images.githubusercontent.com/7288/119698763-6ba52b80-be06-11eb-966b-32f8a3000702.png)

**After this PR**

Nothing happens, since the search term is still effectively empty.
