### PR TITLE
#16229 Repro: Drag functionality not working in dashboard visualization options modal

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChartSettings.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings.jsx
@@ -285,7 +285,10 @@ class ChartSettings extends Component {
           </div>
         ) : (
           <div className="Grid flex-full">
-            <div className="Grid-cell Cell--1of3 scroll-y scroll-show border-right py4">
+            <div
+              className="Grid-cell Cell--1of3 scroll-y scroll-show border-right py4"
+              data-testid={"chartsettings-sidebar"}
+            >
               {widgetList}
             </div>
             <div className="Grid-cell flex flex-column pt2">

--- a/frontend/test/metabase/scenarios/dashboard/visualizaiton-options.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/visualizaiton-options.cy.spec.js
@@ -1,0 +1,38 @@
+import { restore } from "__support__/e2e/cypress";
+
+describe("scenarios > dashboard > visualization options", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it.skip("column reordering should work (metabase#16229)", () => {
+    cy.visit("/dashboard/1");
+    cy.icon("pencil").click();
+    cy.get(".Card").realHover();
+    cy.icon("palette").click();
+    cy.findByTestId("chartsettings-sidebar").within(() => {
+      cy.findByText("ID")
+        .closest(".cursor-grab")
+        .trigger("mousedown", 0, 0, { force: true })
+        .trigger("mousemove", 5, 5, { force: true })
+        .trigger("mousemove", 0, 100, { force: true })
+        .trigger("mouseup", 0, 100, { force: true });
+
+      /**
+       * When this issue gets fixed, it should be safe to uncomment the following assertion.
+       * It currently doesn't work in UI at all, but Cypress somehow manages to move the "ID" column.
+       * However, it leaves an empty column in its place (thus, making it impossible to use this assertion).
+       */
+      // cy.get(".cursor-grab")
+      //   .as("sidebarColumns") // Out of all the columns in the sidebar...
+      //   .first() // ...pick the fist one and make sure it's not "ID" anymore
+      //   .should("contain", "User ID");
+    });
+
+    // The table preview should get updated immediately, reflecting the changes in columns ordering.
+    cy.get(".Modal .cellData")
+      .first()
+      .contains("User ID");
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #16229 

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/dashboard/visualizaiton-options.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/119703573-f4e44e80-be56-11eb-9d72-f33cdc7f1d91.png)

