### PR TITLE
Aggregation query should always specify name

### DIFF
--- a/frontend/src/metabase/lib/query/aggregation.js
+++ b/frontend/src/metabase/lib/query/aggregation.js
@@ -136,7 +136,7 @@ export function setName(
   return [
     "aggregation-options",
     getContent(aggregation),
-    { "display-name": name, ...getOptions(aggregation) },
+    { name, "display-name": name, ...getOptions(aggregation) },
   ];
 }
 export function setContent(

--- a/frontend/test/metabase/lib/query/aggregation.unit.spec.js
+++ b/frontend/test/metabase/lib/query/aggregation.unit.spec.js
@@ -1,4 +1,4 @@
-import { getName } from "metabase/lib/query/aggregation";
+import { getName, setName } from "metabase/lib/query/aggregation";
 
 describe("getName", () => {
   it("should work with blank display name", () => {
@@ -6,5 +6,17 @@ describe("getName", () => {
     expect(getName(["aggregation-options", ["+", ["count"], 3], null])).toEqual(
       undefined,
     );
+  });
+});
+
+describe("setName", () => {
+  it("should set the name and display-name", () => {
+    const expr = ["*", ["count"], 2];
+    const aggregation = ["aggregation-options", ["*", ["count"], 2], null];
+    expect(setName(aggregation, "DoubleCount")).toEqual([
+      "aggregation-options",
+      expr,
+      { "display-name": "DoubleCount", name: "DoubleCount" },
+    ]);
   });
 });

--- a/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
@@ -207,7 +207,7 @@ describe("scenarios > question > custom columns", () => {
       });
   });
 
-  it.skip("should be able to use custom expression after aggregation (metabase#13857)", () => {
+  it("should be able to use custom expression after aggregation (metabase#13857)", () => {
     const CE_NAME = "13857_CE";
     const CC_NAME = "13857_CC";
 
@@ -221,7 +221,11 @@ describe("scenarios > question > custom columns", () => {
         },
         "source-query": {
           aggregation: [
-            ["aggregation-options", ["*", 1, 1], { "display-name": CE_NAME }],
+            [
+              "aggregation-options",
+              ["*", 1, 1],
+              { name: CE_NAME, "display-name": CE_NAME },
+            ],
           ],
           breakout: [
             ["datetime-field", ["field-id", ORDERS.CREATED_AT], "month"],

--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -301,7 +301,7 @@ describe("scenarios > question > filter", () => {
     cy.findAllByText("Fantastic Wool Shirt").should("not.exist");
   });
 
-  it.skip("should filter using Custom Expression from aggregated results (metabase#12839)", () => {
+  it("should filter using Custom Expression from aggregated results (metabase#12839)", () => {
     const CE_NAME = "Simple Math";
 
     cy.createQuestion({
@@ -310,7 +310,11 @@ describe("scenarios > question > filter", () => {
         filter: [">", ["field", CE_NAME, { "base-type": "type/Float" }], 0],
         "source-query": {
           aggregation: [
-            ["aggregation-options", ["+", 1, 1], { "display-name": CE_NAME }],
+            [
+              "aggregation-options",
+              ["+", 1, 1],
+              { name: CE_NAME, "display-name": CE_NAME },
+            ],
           ],
           breakout: [["field", PRODUCTS.CATEGORY, null]],
           "source-table": PRODUCTS_ID,

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -456,7 +456,7 @@ describe("scenarios > question > notebook", () => {
       });
     });
 
-    it.skip("should be able to do subsequent aggregation on a custom expression (metabase#14649)", () => {
+    it("should be able to do subsequent aggregation on a custom expression (metabase#14649)", () => {
       cy.createQuestion({
         name: "14649_min",
         query: {
@@ -466,7 +466,7 @@ describe("scenarios > question > notebook", () => {
               [
                 "aggregation-options",
                 ["sum", ["field", ORDERS.SUBTOTAL, null]],
-                { "display-name": "Revenue" },
+                { name: "Revenue", "display-name": "Revenue" },
               ],
             ],
             breakout: [


### PR DESCRIPTION
This should fix, among others, #12839, #13857, and #14649.

Run the unit tests:
```
yarn test-unit frontend/test/metabase/lib/query/aggregation.unit.spec.js 
```
also the entire E2E tests (a few are skipped due to the passing status).

Steps to reproduce:

1. Ask a question, Custom question
2. Sample Dataset, Order
3. Summary: `Sum([Subtotal])` as Revenue, Created At:Month
4. Filter `[Revenue] > 1000`

Basically doing this on the notebook:

![image](https://user-images.githubusercontent.com/7288/119749815-c1042b80-be4c-11eb-963e-718fcf30f93e.png)

**Before this PR**

The query will fail with the message `Column "source.Revenue" not found`.

![image](https://user-images.githubusercontent.com/7288/119749843-d0837480-be4c-11eb-8b3e-bb6edea267b4.png)

**After this PR**

It should work as expected:

![image](https://user-images.githubusercontent.com/7288/119750010-366ffc00-be4d-11eb-8fc0-626126a92dea.png)


