### PR TITLE
#16249 Repro: Tooltip of combined dashboard cards does not show the correct column title

### DIFF
--- a/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
@@ -165,7 +165,7 @@ describe("scenarios > visualizations > line chart", () => {
             "source-table": PRODUCTS_ID,
             aggregation: [["sum", ["field", PRODUCTS.PRICE, null]]],
             breakout: [
-              ["field", PRODUCTS.CREATED_AT, { "temporal-unit": "month" }],
+              ["field", PRODUCTS.CREATED_AT, { "temporal-unit": "year" }],
             ],
           },
           display: "line",
@@ -189,8 +189,8 @@ describe("scenarios > visualizations > line chart", () => {
 
             showTooltipForFirstCircleInSeries(1);
             popover().within(() => {
-              testPairedTooltipValues("Created At", "April, 2016");
-              testPairedTooltipValues("Bar", "136.83");
+              testPairedTooltipValues("Created At", "2016");
+              testPairedTooltipValues("Bar", "2,829.03");
             });
           });
         });

--- a/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
@@ -106,6 +106,9 @@ describe("scenarios > visualizations > line chart", () => {
   });
 
   describe.skip("tooltip of combined dashboard cards (multi-series) should show the correct column title (metabase#16249", () => {
+    const RENAMED_FIRST_SERIES = "Foo";
+    const RENAMED_SECOND_SERIES = "Bar";
+
     it("custom expression names (metabase#16249-1)", () => {
       createOrdersQuestionWithAggregation({
         name: "16249_Q1",
@@ -136,18 +139,24 @@ describe("scenarios > visualizations > line chart", () => {
             cy.visit(`/dashboard/${dashboardId}`);
 
             // Rename both series
-            renameSeries([["16249_Q1", "Foo"], ["16249_Q2", "Bar"]]);
+            renameSeries([
+              ["16249_Q1", RENAMED_FIRST_SERIES],
+              ["16249_Q2", RENAMED_SECOND_SERIES],
+            ]);
+
+            assertOnLegendItemsValues();
+            assertOnYAxisValues();
 
             showTooltipForFirstCircleInSeries(0);
             popover().within(() => {
               testPairedTooltipValues("Created At", "2016");
-              testPairedTooltipValues("Foo", "42,156.87");
+              testPairedTooltipValues(RENAMED_FIRST_SERIES, "42,156.87");
             });
 
             showTooltipForFirstCircleInSeries(1);
             popover().within(() => {
               testPairedTooltipValues("Created At", "2016");
-              testPairedTooltipValues("Bar", "54.44");
+              testPairedTooltipValues(RENAMED_SECOND_SERIES, "54.44");
             });
           });
         });
@@ -179,18 +188,24 @@ describe("scenarios > visualizations > line chart", () => {
 
             cy.visit(`/dashboard/${dashboardId}`);
 
-            renameSeries([["16249_Q3", "Foo"], ["16249_Q4", "Bar"]]);
+            renameSeries([
+              ["16249_Q3", RENAMED_FIRST_SERIES],
+              ["16249_Q4", RENAMED_SECOND_SERIES],
+            ]);
+
+            assertOnLegendItemsValues();
+            assertOnYAxisValues();
 
             showTooltipForFirstCircleInSeries(0);
             popover().within(() => {
               testPairedTooltipValues("Created At", "2016");
-              testPairedTooltipValues("Foo", "42,156.87");
+              testPairedTooltipValues(RENAMED_FIRST_SERIES, "42,156.87");
             });
 
             showTooltipForFirstCircleInSeries(1);
             popover().within(() => {
               testPairedTooltipValues("Created At", "2016");
-              testPairedTooltipValues("Bar", "2,829.03");
+              testPairedTooltipValues(RENAMED_SECOND_SERIES, "2,829.03");
             });
           });
         });
@@ -267,6 +282,18 @@ describe("scenarios > visualizations > line chart", () => {
         });
       cy.button("Save").click();
       cy.findByText("You're editing this dashboard.").should("not.exist");
+    }
+
+    function assertOnLegendItemsValues() {
+      cy.get(".LegendItem")
+        .should("contain", RENAMED_FIRST_SERIES)
+        .and("contain", RENAMED_SECOND_SERIES);
+    }
+
+    function assertOnYAxisValues() {
+      cy.get(".y-axis-label")
+        .should("contain", RENAMED_FIRST_SERIES)
+        .and("contain", RENAMED_SECOND_SERIES);
     }
   });
 });

--- a/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
@@ -1,7 +1,7 @@
 import { restore, visitQuestionAdhoc, popover } from "__support__/e2e/cypress";
 import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
 
-const { ORDERS, ORDERS_ID, PRODUCTS } = SAMPLE_DATASET;
+const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATASET;
 
 const Y_AXIS_RIGHT_SELECTOR = ".axis.yr";
 
@@ -104,6 +104,171 @@ describe("scenarios > visualizations > line chart", () => {
       testPairedTooltipValues("Average of Quantity", "4");
     });
   });
+
+  describe.skip("tooltip of combined dashboard cards (multi-series) should show the correct column title (metabase#16249", () => {
+    it("custom expression names (metabase#16249-1)", () => {
+      createOrdersQuestionWithAggregation({
+        name: "16249_Q1",
+        aggregation: [
+          [
+            "aggregation-options",
+            ["sum", ["field", ORDERS.TOTAL, null]],
+            { "display-name": "CE" },
+          ],
+        ],
+      }).then(({ body: { id: question1Id } }) => {
+        createOrdersQuestionWithAggregation({
+          name: "16249_Q2",
+          aggregation: [
+            [
+              "aggregation-options",
+              ["avg", ["field", ORDERS.SUBTOTAL, null]],
+              { "display-name": "CE" },
+            ],
+          ],
+        }).then(({ body: { id: question2Id } }) => {
+          cy.createDashboard("16249D").then(({ body: { id: dashboardId } }) => {
+            addBothSeriesToDashboard({
+              dashboardId,
+              firstCardId: question1Id,
+              secondCardId: question2Id,
+            });
+            cy.visit(`/dashboard/${dashboardId}`);
+
+            // Rename both series
+            renameSeries([["16249_Q1", "Foo"], ["16249_Q2", "Bar"]]);
+
+            showTooltipForFirstCircleInSeries(0);
+            popover().within(() => {
+              testPairedTooltipValues("Created At", "2016");
+              testPairedTooltipValues("Foo", "42,156.87");
+            });
+
+            showTooltipForFirstCircleInSeries(1);
+            popover().within(() => {
+              testPairedTooltipValues("Created At", "2016");
+              testPairedTooltipValues("Bar", "54.44");
+            });
+          });
+        });
+      });
+    });
+
+    it("regular column names (metabase#16249-2)", () => {
+      createOrdersQuestionWithAggregation({
+        name: "16249_Q3",
+        aggregation: [["sum", ["field", ORDERS.TOTAL, null]]],
+      }).then(({ body: { id: question1Id } }) => {
+        cy.createQuestion({
+          name: "16249_Q4",
+          query: {
+            "source-table": PRODUCTS_ID,
+            aggregation: [["sum", ["field", PRODUCTS.PRICE, null]]],
+            breakout: [
+              ["field", PRODUCTS.CREATED_AT, { "temporal-unit": "month" }],
+            ],
+          },
+          display: "line",
+        }).then(({ body: { id: question2Id } }) => {
+          cy.createDashboard("16249D").then(({ body: { id: dashboardId } }) => {
+            addBothSeriesToDashboard({
+              dashboardId,
+              firstCardId: question1Id,
+              secondCardId: question2Id,
+            });
+
+            cy.visit(`/dashboard/${dashboardId}`);
+
+            renameSeries([["16249_Q3", "Foo"], ["16249_Q4", "Bar"]]);
+
+            showTooltipForFirstCircleInSeries(0);
+            popover().within(() => {
+              testPairedTooltipValues("Created At", "2016");
+              testPairedTooltipValues("Foo", "42,156.87");
+            });
+
+            showTooltipForFirstCircleInSeries(1);
+            popover().within(() => {
+              testPairedTooltipValues("Created At", "April, 2016");
+              testPairedTooltipValues("Bar", "136.83");
+            });
+          });
+        });
+      });
+    });
+
+    /**
+     * Helper functions related to repros around 16249 only!
+     * Note:
+     *  - This might be too abstract and highly specific.
+     *  - That's true in general sense, but that's the reason we're not using them anywhere else than here.
+     *  - Without these abstractions, both tests would be MUCH longer and harder to review.
+     */
+
+    function addBothSeriesToDashboard({
+      dashboardId,
+      firstCardId,
+      secondCardId,
+    } = {}) {
+      // Add the first question to the dashboard
+      cy.request("POST", `/api/dashboard/${dashboardId}/cards`, {
+        cardId: firstCardId,
+      }).then(({ body: { id: dashCardId } }) => {
+        // Combine the second question with the first one as the second series
+        cy.request("PUT", `/api/dashboard/${dashboardId}/cards`, {
+          cards: [
+            {
+              id: dashCardId,
+              card_id: firstCardId,
+              row: 0,
+              col: 0,
+              sizeX: 18,
+              sizeY: 12,
+              series: [
+                {
+                  id: secondCardId,
+                },
+              ],
+              parameter_mappings: [],
+            },
+          ],
+        });
+      });
+    }
+
+    function createOrdersQuestionWithAggregation({ name, aggregation } = {}) {
+      return cy.createQuestion({
+        name,
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation,
+          breakout: [["field", ORDERS.CREATED_AT, { "temporal-unit": "year" }]],
+        },
+        display: "line",
+      });
+    }
+
+    function renameSeries(series) {
+      cy.icon("pencil").click();
+      cy.get(".Card").realHover();
+      cy.icon("palette").click();
+      series.forEach(serie => {
+        const [old_name, new_name] = serie;
+
+        cy.findByDisplayValue(old_name)
+          .clear()
+          .type(new_name);
+      });
+
+      cy.get(".Modal")
+        .as("modal")
+        .within(() => {
+          cy.button("Done").click();
+        });
+      cy.button("Save").click();
+      cy.findByText("You're editing this dashboard.").should("not.exist");
+    }
+  });
 });
 
 function testPairedTooltipValues(val1, val2) {
@@ -111,4 +276,12 @@ function testPairedTooltipValues(val1, val2) {
     .closest("td")
     .siblings("td")
     .findByText(val2);
+}
+
+function showTooltipForFirstCircleInSeries(series_index) {
+  cy.get(`.sub._${series_index}`)
+    .as("firstSeries")
+    .find("circle")
+    .first()
+    .realHover();
 }


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #16249 (covers both cases)
    - case 1: combine cards Q1 & Q2
    - case 2: combine cards Q3 & Q4

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js`
- Replace `describe.skip()` with `describe.only()` to run both tests in isolation
- Both tests should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip completely)
- Make sure both tests are passing and
- Merge this together with the fix

### Screenshots:
Case 1
![image](https://user-images.githubusercontent.com/31325167/119838593-d4260280-bf03-11eb-91af-cb03f215c8ee.png)

Case 2
![image](https://user-images.githubusercontent.com/31325167/119847800-93ca8280-bf0b-11eb-8f27-48442c0ed1d8.png)
