### PR TITLE
#16246 Repro: Incorrect values on data points for waterfall charts when one of the values is 0

### DIFF
--- a/frontend/test/metabase/scenarios/visualizations/waterfall.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/waterfall.cy.spec.js
@@ -152,6 +152,35 @@ describe("scenarios > visualizations > waterfall", () => {
     cy.get(".Visualization .bar");
   });
 
+  it.skip("should display correct values when one of them is 0 (metabase#16246)", () => {
+    visitQuestionAdhoc({
+      dataset_query: {
+        type: "native",
+        native: {
+          query:
+            "SELECT * FROM (\nVALUES \n('a',2),\n('b',1),\n('c',-0.5),\n('d',-0.5),\n('e',0.1),\n('f',0),\n('g', -2)\n)\n",
+          "template-tags": {},
+        },
+        database: 1,
+      },
+      display: "waterfall",
+      visualization_settings: {
+        "graph.show_values": true,
+      },
+    });
+
+    cy.get(".value-label")
+      .as("labels")
+      .eq(-3)
+      .invoke("text")
+      .should("eq", "0");
+
+    cy.get("@labels")
+      .last()
+      .invoke("text")
+      .should("eq", "0.1");
+  });
+
   describe("scenarios > visualizations > waterfall settings", () => {
     beforeEach(() => {
       restore();


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #16246 

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/visualizations/waterfall.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/119859533-c5484b80-bf15-11eb-9b1f-d1b9ef451e29.png)

