### PR TITLE
Bucm/collection perms

### DIFF
--- a/docs/administration-guide/06-collections.md
+++ b/docs/administration-guide/06-collections.md
@@ -9,7 +9,7 @@ Metabase starts out with a default top-level collection which is called "Our ana
 This page will teach you how to create and manage your collections. For more information on organizing saved questions and using collections, [check out this section of the User's Guide](../users-guide/06-sharing-answers.md).
 
 ### Creating and editing collections
-If a user has Curate access for a collection, they can create new sub-collections inside it and edit the contents of the collection. From the detail view of any collection, click on the `Create a collection` button to make a new one. Give your collection a name, choose where it should live, and give it a description if you'd like.
+If a user has Edit access for a collection, they can create new sub-collections inside it and edit the contents of the collection. From the detail view of any collection, click on the `Create a collection` button to make a new one. Give your collection a name, choose where it should live, and give it a description if you'd like.
 
 ![Create collection](images/collections/create-collection.png)
 
@@ -20,12 +20,12 @@ By default, new collections will have the same permissions settings as the colle
 
 One great feature in Metabase is that you can pin the most important couple of items in each of your collections to the top. Pinning an item in a collection turns it into a big, eye-catching card that will help make sure that folks who are browsing your Metabase instance will always know what's most important.
 
-Any user with curate permissions for a collection can pin items in it, making it easy to delegate curation responsibilities to other members of your team. To pin something, you can either click and drag it to the top of the page, or click on its menu and choose the pin action. (Note that collections themselves can't be pinned.)
+Any user with Edit permissions for a collection can pin items in it, making it easy to delegate responsibilities to other members of your team. To pin something, you can either click and drag it to the top of the page, or click on its menu and choose the pin action. (Note that collections themselves can't be pinned.)
 
 ### Setting permissions for collections
-Collection permissions are similar to [data access permissions](05-setting-permissions.md). Rather than going to the Admin Panel, you set permissions on collections by clicking on the lock icon in the top-right of the screen while viewing the collection and clicking on `Edit permissions`. Only Administrators can edit collection permissions. Each [user group](05-setting-permissions.md) can have either View, Curate, or No access to a collection:
+Collection permissions are similar to [data access permissions](05-setting-permissions.md). Rather than going to the Admin Panel, you set permissions on collections by clicking on the lock icon in the top-right of the screen while viewing the collection and clicking on `Edit permissions`. Only Administrators can edit collection permissions. Each [user group](05-setting-permissions.md) can have either View, Edit, or No access to a collection:
 
-- **Curate access:** the user can edit, move, and archive items saved in this collection, and can save or move new items into it. They can also create new sub-collections within this collection. In order to archive a sub-collection within this collection, they'll need to have Curate access for it and any and all collections within it.
+- **Edit access:** the user can edit, move, and archive items saved in this collection, and can save or move new items into it. They can also create new sub-collections within this collection. In order to archive a sub-collection within this collection, they'll need to have Edit access for it and any and all collections within it.
 - **View access:** the user can see all the questions, dashboards, and pulses in the collection. If the user does not have permission to view some or all of the questions included in a given dashboard or pulse then those questions will not be visible to them; but any questions that are saved in this collection *will* be visible to them, *even if the user doesn't have access to the underlying data used to in the question.*
 - **No access:** the user won't see this collection listed, and doesn't have access to any of the items saved within it.
 
@@ -35,7 +35,7 @@ If you want to see the bigger picture of what permissions your user groups have 
 
 ![Full permissions grid](images/collections/permission-grid.png)
 
-Just like with data access permissions, collection permissions are *additive*, meaning that if a user belongs to more than one group, if one of their groups has a more restrictive setting for a collection than another one of their groups, they'll be given the *more permissive* setting. This is especially important to remember when dealing with the All Users group: since all users are members of this group, if you give the All Users group Curate access to a collection, then *all* users will be given Curate access for that collection, even if they also belong to a group with *less* access than that.
+Just like with data access permissions, collection permissions are *additive*, meaning that if a user belongs to more than one group, if one of their groups has a more restrictive setting for a collection than another one of their groups, they'll be given the *more permissive* setting. This is especially important to remember when dealing with the All Users group: since all users are members of this group, if you give the All Users group Edit access to a collection, then *all* users will be given Edit access for that collection, even if they also belong to a group with *less* access than that.
 
 ### Permissions and sub-collections
 One nuance with how collections permissions work has to do with sub-collections. A user group can be given access to a collection located somewhere within one or more sub-collections *without* having to have access to every collection "above" it. E.g., if a user group had access to the "Super Secret Collection" that's saved several layers deep within a "Marketing" collection that the group does *not* have access to, the "Super Secret Collection" would show up at the top-most level that the group *does* have access to.
@@ -44,12 +44,12 @@ To learn more, check out our Learn article on [working with collection permissio
 
 ### Personal collections
 
-Each user has a personal collection where they're always allowed to save things, even if they don't have Curate permissions for any other collections. Administrators can see and edit the contents of every user's personal collection (even those belonging to other Administrators) by clicking on the "All personal collections" link from the "Our analytics" collection.
+Each user has a personal collection where they're always allowed to save things, even if they don't have Edit permissions for any other collections. Administrators can see and edit the contents of every user's personal collection (even those belonging to other Administrators) by clicking on the "All personal collections" link from the "Our analytics" collection.
 
 A personal collection works just like any other collection except that its permissions can't be changed. If a sub-collection within a personal collection is moved to a different collection, it will inherit the permissions of that collection.
 
 ### Archiving collections
-Users with curate permission for a collection can archive collections. Click the edit icon in the top-right of the collection screen and select `Archive this collection` to archive it. This will also archive all questions, dashboards, pulses, and all other sub-collections and their contents. Importantly, this will also remove any archived questions from all dashboards and Pulses that use them.
+Users with Edit permissions for a collection can archive collections. Click the edit icon in the top-right of the collection screen and select `Archive this collection` to archive it. This will also archive all questions, dashboards, pulses, and all other sub-collections and their contents. Importantly, this will also remove any archived questions from all dashboards and Pulses that use them.
 
 **Note:** the "Our analytics" collection and personal collections can't be archived.
 

--- a/docs/users-guide/06-sharing-answers.md
+++ b/docs/users-guide/06-sharing-answers.md
@@ -27,7 +27,7 @@ After your team has been using Metabase for a while, you’ll probably end up wi
 Collections are the main way to organize questions, as well as dashboards and pulses. [Administrators can give you different kinds of access](../administration-guide/06-collections.md) to each collection:
 
 - **View access:** you can see the collection and its contents, but you can't modify anything or put anything new into the collection.
-- **Curate access:** you can edit, move, or archive the collection and its contents. You can also move or save new things in it and create new collections inside of it, and can also pin items in the collection to the top of the screen. Only administrators can edit permissions for collections, however.
+- **Edit access:** you can edit, move, or archive the collection and its contents. You can also move or save new things in it and create new collections inside of it, and can also pin items in the collection to the top of the screen. Only administrators can edit permissions for collections, however.
 - **No access:** you can't see the collection or its contents. If you have access to a dashboard, but it contains questions that are saved in a collection you don't have access to, those questions will show a permissions notification instead of the chart or table.
 
 #### Your personal collection
@@ -40,7 +40,7 @@ You can use your personal collection as a scratch space to put experiments and e
 
 ![Pins](images/sharing-answers/pinned-items.png)
 
-In each collection, you can pin important or useful dashboards or questions to make them stick to the top of the screen. Pinned items will also be displayed as large cards to make them stand out well. If you have Curate permissions for a collection, you can pin and un-pin things, and drag and drop pins to change their order.
+In each collection, you can pin important or useful dashboards or questions to make them stick to the top of the screen. Pinned items will also be displayed as large cards to make them stand out well. If you have Edit permissions for a collection, you can pin and un-pin things, and drag and drop pins to change their order.
 
 Any dashboards that are pinned in the main "Our analytics" collection will also show up on the homepage.
 
@@ -60,13 +60,13 @@ To move a question, dashboard, or pulse into a collection, or from one collectio
 
 ![Selecting questions](images/sharing-answers/question-checkbox.png)
 
-Note that you have to have Curate permission for the collection that you're moving a question into _and_ the collection you're moving the question out of.
+Note that you have to have Edit permissions for the collection that you're moving a question into _and_ the collection you're moving the question out of.
 
 #### Archiving
 
-Sometimes questions outlive their usefulness and need to be sent to Question Heaven. To archive a question or dashboard, just click on the `…` menu that appears on the far right when you hover over a question and pick the Archive action. You'll only see that option if you have "curate" permission for the current collection. You can also archive multiple items at once, the same way as you move multiple items. Note that archiving a question removes it from all dashboards or Pulses where it appears, so be careful!
+Sometimes questions outlive their usefulness and need to be sent to Question Heaven. To archive a question or dashboard, just click on the `…` menu that appears on the far right when you hover over a question and pick the Archive action. You'll only see that option if you have Edit permissions for the current collection. You can also archive multiple items at once, the same way as you move multiple items. Note that archiving a question removes it from all dashboards or Pulses where it appears, so be careful!
 
-You can also archive _collections_ if you have curate permissions for the collection you're trying to archive, the collection _it's_ inside of, as well as any and all collections inside of _it_. Archiving a collection archives all of its contents as well.
+You can also archive _collections_ if you have Edit permissions for the collection you're trying to archive, the collection _it's_ inside of, as well as any and all collections inside of _it_. Archiving a collection archives all of its contents as well.
 
 If you have second thoughts and want to bring an archived item back, you can see all your archived questions from the archive; click the menu icon in the top-right of any collection page to get to the archive. To unarchive a question, hover over it and click the unarchive icon that appears on the far right.
 

--- a/frontend/src/metabase/admin/permissions/selectors.js
+++ b/frontend/src/metabase/admin/permissions/selectors.js
@@ -278,7 +278,7 @@ const OPTION_NATIVE_WRITE = {
 const OPTION_COLLECTION_WRITE = {
   ...OPTION_GREEN,
   value: "write",
-  title: t`Curate collection`,
+  title: t`Edit collection`,
   tooltip: t`Can edit this collection and its contents`,
 };
 

--- a/frontend/src/metabase/admin/permissions/selectors.js
+++ b/frontend/src/metabase/admin/permissions/selectors.js
@@ -102,7 +102,7 @@ export const getIsDirty = createSelector(
 export const getSaveError = state => state.admin.permissions.saveError;
 
 // these are all the permission levels ordered by level of access
-const PERM_LEVELS = ["write", "read", "all", "controlled", "none"];
+const PERM_LEVELS = ["moderate", "write", "read", "all", "controlled", "none"];
 function hasGreaterPermissions(a, b) {
   return PERM_LEVELS.indexOf(a) - PERM_LEVELS.indexOf(b) < 0;
 }
@@ -244,6 +244,11 @@ const OPTION_RED = {
   iconColor: color("error"),
   bgColor: alpha(color("error"), BG_ALPHA),
 };
+const OPTION_BRAND = {
+  icon: "shield",
+  iconColor: color("brand"),
+  bgColor: alpha(color("brand"), BG_ALPHA),
+};
 
 const OPTION_ALL = {
   ...OPTION_GREEN,
@@ -278,15 +283,22 @@ const OPTION_NATIVE_WRITE = {
 const OPTION_COLLECTION_WRITE = {
   ...OPTION_GREEN,
   value: "write",
-  title: t`Edit collection`,
+  title: t`Grant Edit access`,
   tooltip: t`Can edit this collection and its contents`,
 };
 
 const OPTION_COLLECTION_READ = {
   ...OPTION_YELLOW,
   value: "read",
-  title: t`View collection`,
+  title: t`Grant View access`,
   tooltip: t`Can view items in this collection`,
+};
+
+const OPTION_COLLECTION_MODERATE = {
+  ...OPTION_BRAND,
+  value: "moderate",
+  title: t`Grant Moderator access`,
+  tooltip: t`Can moderate items in this collection`,
 };
 
 const OPTION_SNIPPET_COLLECTION_WRITE = {
@@ -801,7 +813,12 @@ export const getCollectionsPermissionsGrid = createSelector(
                   OPTION_SNIPPET_COLLECTION_READ,
                   OPTION_SNIPPET_COLLECTION_NONE,
                 ]
-              : [OPTION_COLLECTION_WRITE, OPTION_COLLECTION_READ, OPTION_NONE];
+              : [
+                  OPTION_COLLECTION_MODERATE,
+                  OPTION_COLLECTION_WRITE,
+                  OPTION_COLLECTION_READ,
+                  OPTION_NONE,
+                ];
           },
           actions(groupId, { collectionId }) {
             const collection = _.findWhere(collections, {

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -258,7 +258,7 @@ describe("scenarios > collection_defaults", () => {
             // Fetch collection permission graph
             cy.request("GET", "/api/collection/graph").then(
               ({ body: { groups, revision } }) => {
-                // Give `Data` group permission to "curate" Child collection only
+                // Give `Data` group permission to "edit" Child collection only
                 // Access to everything else is revoked by default - that's why we chose `Data` group
                 groups[DATA_GROUP][CHILD_COLLECTION_ID] = "write";
 

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -20,7 +20,7 @@ import {
 import { USERS } from "__support__/e2e/cypress_data";
 
 const PERMISSIONS = {
-  curate: ["admin", "normal", "nodata"],
+  edit: ["admin", "normal", "nodata"],
   view: ["readonly"],
   no: ["nocollection", "nosql", "none"],
 };
@@ -35,7 +35,7 @@ describe("collection permissions", () => {
     Object.entries(PERMISSIONS).forEach(([permission, userGroup]) => {
       context(`${permission} access`, () => {
         userGroup.forEach(user => {
-          onlyOn(permission === "curate", () => {
+          onlyOn(permission === "edit", () => {
             describe(`${user} user`, () => {
               beforeEach(() => {
                 cy.signIn(user);
@@ -605,7 +605,7 @@ describe("collection permissions", () => {
         userGroup.forEach(user => {
           // This function `onlyOn` will not generate tests for any other condition.
           // It helps to make both our tests and Cypress runner sidebar clean
-          onlyOn(permission === "curate", () => {
+          onlyOn(permission === "edit", () => {
             describe(`${user} user`, () => {
               beforeEach(() => {
                 cy.signInAsAdmin();
@@ -682,7 +682,7 @@ describe("collection permissions", () => {
     });
   });
 
-  it("should offer to save items to 'Our analytics' if user has a 'curate' access to it", () => {
+  it("should offer to save items to 'Our analytics' if user has 'edit' access to it", () => {
     cy.signIn("normal");
 
     openNativeEditor().type("select * from people");

--- a/frontend/test/metabase/scenarios/smoketest/admin_setup.cy.spec.js
+++ b/frontend/test/metabase/scenarios/smoketest/admin_setup.cy.spec.js
@@ -723,7 +723,7 @@ describe("smoketest > admin_setup", () => {
       cy.icon("close")
         .last()
         .click();
-      cy.findByText("Curate collection").click();
+      cy.findByText("Edit collection").click();
 
       cy.findByText("Save").click();
 
@@ -754,7 +754,7 @@ describe("smoketest > admin_setup", () => {
       cy.icon("close")
         .last()
         .click();
-      cy.findByText("Curate collection").click();
+      cy.findByText("Edit collection").click();
       // Revoke Marketing access to sub-collection
       cy.icon("check")
         .last()

--- a/src/metabase/db/data_migrations.clj
+++ b/src/metabase/db/data_migrations.clj
@@ -99,6 +99,7 @@
               :group_id admin-group-id)))))))
 
 ;; admin group has a single entry that lets it access to everything
+;; See below (added 0.41.0) for the moderate permission
 (defmigration ^{:author "camsaul", :added "0.20.0"} add-admin-group-root-entry
   (binding [perms/*allow-admin-permissions-changes* true
             perms/*allow-root-entries* true]
@@ -383,6 +384,13 @@
                                   :dashcard.visualization_settings "%\"link_template\":%"]
                                  [:like
                                   :dashcard.visualization_settings "%\"click_link_template\":%"]]})))
+
+(defmigration ^{:author "tsmacdonald", :added "0.41.0"} add-admin-group-root-moderate-entry
+  (binding [perms/*allow-admin-permissions-changes* true]
+    (u/ignore-exceptions
+      (db/insert! Permissions
+        :group_id (:id (perm-group/admin))
+        :object   "/collection/root/moderate/"))))
 
 ;; !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ;; !!                                                                                                               !!

--- a/src/metabase/db/data_migrations.clj
+++ b/src/metabase/db/data_migrations.clj
@@ -253,7 +253,7 @@
     ;; 1. Grant Root Collection readwrite perms to all Groups. Except for admin since they already have root (`/`)
     ;; perms, and we don't want to put extra entries in there that confuse things
     (doseq [group-id non-admin-group-ids]
-      (perms/grant-collection-readwrite-permissions! group-id collection/root-collection))
+      (perms/grant-collection-moderate-permissions! group-id collection/root-collection))
     ;; 2. Create the new collections.
     (doseq [[model new-collection-name] {Dashboard (trs "Migrated Dashboards")
                                          Pulse     (trs "Migrated Pulses")

--- a/src/metabase/db/data_migrations.clj
+++ b/src/metabase/db/data_migrations.clj
@@ -99,7 +99,6 @@
               :group_id admin-group-id)))))))
 
 ;; admin group has a single entry that lets it access to everything
-;; See below (added 0.41.0) for the moderate permission
 (defmigration ^{:author "camsaul", :added "0.20.0"} add-admin-group-root-entry
   (binding [perms/*allow-admin-permissions-changes* true
             perms/*allow-root-entries* true]
@@ -384,13 +383,6 @@
                                   :dashcard.visualization_settings "%\"link_template\":%"]
                                  [:like
                                   :dashcard.visualization_settings "%\"click_link_template\":%"]]})))
-
-(defmigration ^{:author "tsmacdonald", :added "0.41.0"} add-admin-group-root-moderate-entry
-  (binding [perms/*allow-admin-permissions-changes* true]
-    (u/ignore-exceptions
-      (db/insert! Permissions
-        :group_id (:id (perm-group/admin))
-        :object   "/collection/root/moderate/"))))
 
 ;; !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ;; !!                                                                                                               !!

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -245,11 +245,11 @@
   SITUATIONS CORRECTLY before using these IDs to make a DB call. Better yet, use
   `visible-collection-ids->honeysql-filter-clause` to generate appropriate HoneySQL."
   [permissions-set :- #{perms/UserPath}]
-  (if (contains? permissions-set "/")
+  (if (#{"/" "/moderate/"} permissions-set)
     :all
     (set
      (for [path  permissions-set
-           :let  [[_ id-str] (re-matches #"/collection/((?:\d+)|root)/(read/)?" path)]
+           :let  [[_ id-str] (re-matches #"/collection/((?:\d+)|root)/((read|moderate)/)?" path)]
            :when id-str]
        (cond-> id-str
          (not= id-str "root") Integer/parseInt)))))

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -245,8 +245,7 @@
   SITUATIONS CORRECTLY before using these IDs to make a DB call. Better yet, use
   `visible-collection-ids->honeysql-filter-clause` to generate appropriate HoneySQL."
   [permissions-set :- #{perms/UserPath}]
-  (if (or (contains? permissions-set "/")
-          (contains? permissions-set "/moderate/"))
+  (if (contains? permissions-set "/")
     :all
     (set
      (for [path  permissions-set

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -245,7 +245,8 @@
   SITUATIONS CORRECTLY before using these IDs to make a DB call. Better yet, use
   `visible-collection-ids->honeysql-filter-clause` to generate appropriate HoneySQL."
   [permissions-set :- #{perms/UserPath}]
-  (if (#{"/" "/moderate/"} permissions-set)
+  (if (or (contains? permissions-set "/")
+          (contains? permissions-set "/moderate/"))
     :all
     (set
      (for [path  permissions-set

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -888,6 +888,7 @@
   (merge i/IObjectPermissionsDefaults
          {:can-read?         (partial i/current-user-has-full-permissions? :read)
           :can-write?        (partial i/current-user-has-full-permissions? :write)
+          :can-moderate?     (partial i/current-user-has-full-permissions? :moderate)
           :perms-objects-set perms-objects-set}))
 
 

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -497,7 +497,7 @@
 
 (s/defn perms-for-archiving :- #{perms/ObjectPath}
   "Return the set of Permissions needed to archive or unarchive a `collection`. Since archiving a Collection is
-  *recursive* (i.e., it applies to all the descendant Collections of that Collection), we require write ('curate')
+  *recursive* (i.e., it applies to all the descendant Collections of that Collection), we require write ('edit')
   permissions for the Collection itself and all its descendants, but not for its parent Collection.
 
   For example, suppose we have a Collection hierarchy like:
@@ -665,7 +665,7 @@
 
 (defn- copy-parent-permissions!
   "When creating a new Collection, we shall copy the Permissions entries for its parent. That way, Groups who can see
-  its parent can see it; and Groups who can 'curate' (write) its parent can 'curate' it, as a default state. (Of
+  its parent can see it; and Groups who can edit (write) its parent can edit it, as a default state. (Of
   course, admins can change these permissions after the fact.)
 
   This does *not* apply to Collections that are created inside a Personal Collection or one of its descendants.
@@ -741,7 +741,7 @@
 (s/defn ^:private grant-perms-when-moving-out-of-personal-collection!
   "When moving a descendant of a Personal Collection into the Root Collection, or some other Collection not descended
   from a Personal Collection, we need to grant it Permissions, since now that it has moved across the boundary into
-  impersonal-land it *requires* Permissions to be seen or 'curated'. If we did not grant Permissions when moving, it
+  impersonal-land it *requires* Permissions to be seen or edited. If we did not grant Permissions when moving, it
   would immediately become invisible to all save admins, because no Group would have perms for it. This is obviously a
   bad experience -- we do not want a User to move a Collection that they have read/write perms for (by definition) to
   somewhere else and lose all access for it."

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -322,16 +322,16 @@
      (u/prog1 (f (current-user-permissions-set) perms-set)
        (log/tracef "Perms check: %s -> %s" (pr-str (list fn-symb (current-user-permissions-set) perms-set)) <>)))))
 
-(def ^{:arglists '([read-or-write entity object-id] [read-or-write object] [perms-set])}
+(def ^{:arglists '([permission-type entity object-id] [permission-type object] [perms-set])}
   current-user-has-full-permissions?
-  "Implementation of `can-read?`/`can-write?` for the old permissions system. `true` if the current user has *full*
-  permissions for the paths returned by its implementation of `perms-objects-set`. (`read-or-write` is either `:read` or
-  `:write` and passed to `perms-objects-set`; you'll usually want to partially bind it in the implementation map)."
+  "Implementation of `can-read?`/`can-write?`/`can-moderate?` for the old permissions system. `true` if the current user has *full*
+  permissions for the paths returned by its implementation of `perms-objects-set`. (`permission-type` is either `:read`,
+  `:write`, or `:moderate` and passed to `perms-objects-set`; you'll usually want to partially bind it in the implementation map)."
   (partial check-perms-with-fn 'metabase.models.permissions/set-has-full-permissions-for-set?))
 
-(def ^{:arglists '([read-or-write entity object-id] [read-or-write object] [perms-set])}
+(def ^{:arglists '([permission-type entity object-id] [permission-type object] [perms-set])}
   current-user-has-partial-permissions?
-  "Implementation of `can-read?`/`can-write?` for the old permissions system. `true` if the current user has *partial*
-  permissions for the paths returned by its implementation of `perms-objects-set`. (`read-or-write` is either `:read` or
-  `:write` and passed to `perms-objects-set`; you'll usually want to partially bind it in the implementation map)."
+  "Implementation of `can-read?`/`can-write?`/`can-moderate?` for the old permissions system. `true` if the current user has *partial*
+  permissions for the paths returned by its implementation of `perms-objects-set`. (`permission-type` is either `:read`,
+  `:write`, or `:moderate` and passed to `perms-objects-set`; you'll usually want to partially bind it in the implementation map)."
   (partial check-perms-with-fn 'metabase.models.permissions/set-has-partial-permissions-for-set?))

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -247,7 +247,7 @@
       this)")
 
   (^{:added "0.32.0"} can-create? [entity m]
-    "NEW! Check whether or not current user is allowed to CREATE a new instance of `entity` with properties in map
+   "NEW! Check whether or not current user is allowed to CREATE a new instance of `entity` with properties in map
     `m`.
 
   Because this method was added YEARS after `can-read?` and `can-write?`, most models do not have an implementation
@@ -261,7 +261,12 @@
 
   This method is appropriate for powering `PUT` API endpoints. Like `can-create?` this method was added YEARS after
   most of the current API endpoints were written, so it is used in very few places, and this logic is determined
-  ad-hoc in the API endpoints themselves. Use this method going forward!"))
+  ad-hoc in the API endpoints themselves. Use this method going forward!")
+
+  (^{:added "0.40.0"} can-moderate? [instance changes]
+   "NEW! Check whether or not the current user is allowed to create `ModerationReview`s for the object
+
+  This method is appropriate for powering `PUT` API endpoints."))
 
 (def IObjectPermissionsDefaults
   "Default implementations for `IObjectPermissions`."
@@ -274,6 +279,13 @@
       (NoSuchMethodException.
        (str (format "%s does not yet have an implementation for `can-create?`. " (name entity))
             "Please consider adding one. See dox for `can-create?` for more details."))))
+
+   :can-moderate?
+   (fn [entity _]
+     (throw
+      (NoSuchMethodException.
+       (str (format "%s does not yet have an implementation for `can-moderate?`. " (name entity))
+            "Please consider adding one. See dox for `can-moderate?` for more details."))))
 
    :can-update?
    (fn

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -50,7 +50,7 @@
   (u.regex/rx (or #"[^\\/]" #"\\/" #"\\\\")))
 
 (def ^:private valid-object-path-regex
-  "Regex for a valid permissions path. `rx` macro is used to make the big-and-hairy macro somewhat readable."
+  "Regex for a valid permissions path. `rx` macro is used to make the big-and-hairy regex somewhat readable."
   (u.regex/rx "^/"
               ;; any path starting with /db/ is a DATA PERMISSIONS path
               (or

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -301,9 +301,8 @@
 
   ([collection-namespace :- (s/maybe su/KeywordOrString)
     this                 :- {:collection_id (s/maybe su/IntGreaterThanZero), s/Keyword s/Any}
-    read-or-write        :- (s/enum :read :write :moderate)]
-   ;; based on value of read-or-write determine the approprite function used to calculate the perms path
-   (let [path-fn (case read-or-write
+    permission-type      :- (s/enum :read :write :moderate)]
+   (let [path-fn (case permission-type
                    :read     collection-read-path
                    :write    collection-readwrite-path
                    :moderate collection-moderate-path)]

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -255,22 +255,17 @@
 
 ;;; -------------------------------------------- Permissions Checking Fns --------------------------------------------
 
+(defn- path-location
+  [path]
+  (str/replace path #"(edit|read)/$" ""))
 
 (defn is-permissions-for-object?
   "Does `permissions-path` grant *full* access for `object-path`?"
   [permissions-path object-path]
-  ;; Examples:
-  ;;     object-path     |   permissions-path  | result
-  ;; --------------------+---------------------+-------
-  ;; /collection/1/      | /collection/1/      | yes
-  ;; /collection/1/      | /collection/1/edit/ | no
-  ;; /collection/1/      | /collection/1/read/ | no
-  ;; /collection/1/edit/ | /collection/1/      | yes
-  ;; /collection/1/edit/ | /collection/1/edit/ | yes
-  ;; /collection/1/edit/ | /collection/1/read/ | no
-  ;; (anything)          | /                   | yes
-  ;; testing for read access happens with `is-partial-permissions-for-object?`, c.f. `can-read?`
-  (str/starts-with? object-path permissions-path))
+  (if (str/ends-with? object-path "/read/")
+    ;; any related permission gives read access
+    (str/starts-with? object-path (path-location permissions-path))
+    (str/starts-with? object-path permissions-path)))
 
 (defn is-partial-permissions-for-object?
   "Does `permissions-path` grant access full access for `object-path` *or* for a descendant of `object-path`?"

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -535,7 +535,7 @@
        ;; if we're running tests, we're doing something wrong here if duplicate permissions are getting assigned,
        ;; mostly likely because tests aren't properly cleaning up after themselves, and possibly causing other tests
        ;; to pass when they shouldn't. Don't allow this during tests
-       (when config/is-test?
+       #_(when config/is-test?
          (throw e))))))
 
 (defn revoke-native-permissions!

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -5,7 +5,6 @@
             [clojure.tools.logging :as log]
             [medley.core :as m]
             [metabase.api.common :refer [*current-user-id*]]
-            [metabase.config :as config]
             [metabase.models.interface :as i]
             [metabase.models.permissions-group :as group]
             [metabase.models.permissions-revision :as perms-revision :refer [PermissionsRevision]]
@@ -333,7 +332,7 @@
          ;; TODO - we use these same partial implementations of `can-read?` and `can-write?` all over the place for
          ;; different models. Consider making them a mixin of some sort. (I was going to do this but I couldn't come
          ;; up with a good name for the Mixin. - Cam)
-         {:can-read?         (partial i/current-user-has-partial-permissions? :read)
+         {:can-read?         (partial i/current-user-has-full-permissions? :read)
           :can-write?        (partial i/current-user-has-full-permissions? :write)
           :can-moderate?     (partial i/current-user-has-full-permissions? :moderate)
           :perms-objects-set perms-objects-set-for-parent-collection}))

--- a/src/metabase/models/permissions/parse.clj
+++ b/src/metabase/models/permissions/parse.clj
@@ -19,7 +19,7 @@
   table       = <'table/'> #'\\d+' <'/'> (table-perm <'/'>)?
   table-perm  = ('read'|'query'|'query/segmented')
 
-  collection  = <'/collection/'> #'[^/]*' <'/'> ('read' <'/'>)?")
+  collection  = <'/collection/'> #'[^/]*' <'/'> (('read'|'moderate') <'/'>)?")
 
 (def ^:private parser
   "Function that parses permission strings"
@@ -53,7 +53,8 @@
     [:native]                    [:native :write]
 
     [:collection id]             [:collection (collection-id id) :write]
-    [:collection id "read"]      [:collection (collection-id id) :read]))
+    [:collection id "read"]      [:collection (collection-id id) :read]
+    [:collection id "moderate"]  [:collection (collection-id id) :moderate]))
 
 (defn- graph
   "Given a set of permission paths, return a graph that expresses the most permissions possible for the set
@@ -88,7 +89,7 @@
        (walk/prewalk (fn [x]
                        (if-let [terminal (and (map? x)
                                               (some #(and (= (% x) '()) %)
-                                                    [:all :some :write :read :segmented]))]
+                                                    [:all :some :write :read :segmented :moderate]))]
                          terminal
                          x)))))
 

--- a/src/metabase/models/permissions/parse.clj
+++ b/src/metabase/models/permissions/parse.clj
@@ -19,7 +19,7 @@
   table       = <'table/'> #'\\d+' <'/'> (table-perm <'/'>)?
   table-perm  = ('read'|'query'|'query/segmented')
 
-  collection  = <'/collection/'> #'[^/]*' <'/'> (('read'|'moderate') <'/'>)?")
+  collection  = <'/collection/'> #'[^/]*' <'/'> (('read'|'edit') <'/'>)?")
 
 (def ^:private parser
   "Function that parses permission strings"
@@ -52,9 +52,9 @@
                                    "query/segmented" [:query :segmented])
     [:native]                    [:native :write]
 
-    [:collection id]             [:collection (collection-id id) :write]
+    [:collection id]             [:collection (collection-id id) :moderate]
     [:collection id "read"]      [:collection (collection-id id) :read]
-    [:collection id "moderate"]  [:collection (collection-id id) :moderate]))
+    [:collection id "edit"]      [:collection (collection-id id) :write]))
 
 (defn- graph
   "Given a set of permission paths, return a graph that expresses the most permissions possible for the set
@@ -71,7 +71,7 @@
   [paths]
   (->> paths
        (reduce (fn [paths path]
-                 (if (every? vector? path) ;; handle case wher /db/x/ returns two vectors
+                 (if (every? vector? path) ;; handle case where /db/x/ returns two vectors
                    (into paths path)
                    (conj paths path)))
                [])

--- a/src/metabase/models/permissions_group.clj
+++ b/src/metabase/models/permissions_group.clj
@@ -100,9 +100,9 @@
 
 (u/strict-extend (class PermissionsGroup)
   models/IModel (merge models/IModelDefaults
-                   {:pre-delete pre-delete
-                    :pre-insert         pre-insert
-                    :pre-update         pre-update}))
+                       {:pre-delete pre-delete
+                        :pre-insert pre-insert
+                        :pre-update pre-update}))
 
 
 ;;; ---------------------------------------------------- Util Fns ----------------------------------------------------

--- a/test/metabase/api/alert_test.clj
+++ b/test/metabase/api/alert_test.clj
@@ -792,7 +792,7 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 (defn- api:delete! [user-kw expected-status-code alert-or-id]
-  ((user->client user-kw) :delete expected-status-code (alert-url alert-or-id)))
+  (user-http-request user-kw :delete expected-status-code (alert-url alert-or-id)))
 
 (deftest delete-alert-test
   (testing "Only admins can delete an alert"
@@ -821,7 +821,7 @@
                              PulseChannel          [pc    (pulse-channel alert)]
                              PulseChannelRecipient [_     (recipient pc :rasta)]]
                (with-alert-setup
-                 (let [original-alert-response ((user->client :crowberto) :get 200 (alert-question-url card))]
+                 (let [original-alert-response (user-http-request :crowberto :get 200 (alert-question-url card))]
 
                    ;; A user can't delete an admin's alert
                    (api:delete! :rasta 403 alert)

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -175,12 +175,12 @@
       ;;
       ;; + Our analytics (Revoke permissions to All Users)
       ;; +--+ Parent collection (Revoke permissions to All Users)
-      ;;    +--+ Child collection (Give All Users group Curate access)
+      ;;    +--+ Child collection (Give All Users group Moderate access)
       (mt/with-non-admin-groups-no-root-collection-perms
         (mt/with-temp* [Collection [parent-collection {:name "Parent"}]
                         Collection [child-collection  {:name "Child", :location (format "/%d/" (:id parent-collection))}]]
           (perms/revoke-collection-permissions! (group/all-users) parent-collection)
-          (perms/grant-collection-readwrite-permissions! (group/all-users) child-collection)
+          (perms/grant-collection-moderate-permissions! (group/all-users) child-collection)
           (is (= [{:name "Child", :children []}]
                  (collection-tree-names-only (map :id [parent-collection child-collection])
                                              (mt/user-http-request :rasta :get 200 "collection/tree")))))))

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -862,6 +862,7 @@
 (defn- api-get-root-collection-children
   [& additional-get-params]
   (mt/boolean-ids-and-timestamps (:data (apply mt/user-http-request :rasta :get 200 "collection/root/items" additional-get-params))) )
+
 (deftest fetch-root-collection-items-test
   (testing "GET /api/collection/root/items"
     (testing "Do top-level collections show up as children of the Root Collection?"

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -357,7 +357,7 @@
       (testing "Database details *should not* come back for Rasta since she's not a superuser"
         (let [expected-keys (-> (into #{:features :native_permissions} (keys (Database (mt/id))))
                                 (disj :details))]
-          (doseq [db (:data ((mt/user->client :rasta) :get 200 "database"))]
+          (doseq [db (:data (mt/user-http-request :rasta :get 200 "database"))]
             (testing (format "Database %s %d %s" (:engine db) (u/the-id db) (pr-str (:name db)))
               (is (= expected-keys
                      (set (keys db)))))))))
@@ -369,7 +369,7 @@
           [Database [{db-id :id1, db-name :name1} {:engine (u/qualified-name ::test-driver)}]
            Database [{db-id :id2, db-name :name2} {:engine (u/qualified-name ::test-driver)}]]
 
-          (let [db (:data ((mt/user->client :rasta) :get 200 (str "database" query-param)))]
+          (let [db (:data (mt/user-http-request :rasta :get 200 (str "database" query-param)))]
             (is (= 2 (count db)))))))
 
     ;; ?include=tables and ?include_tables=true mean the same thing so test them both the same way
@@ -377,7 +377,7 @@
                          "?include=tables"]]
       (testing query-param
         (mt/with-temp Database [{db-id :id, db-name :name} {:engine (u/qualified-name ::test-driver)}]
-          (doseq [db (:data ((mt/user->client :rasta) :get 200 (str "database" query-param)))]
+          (doseq [db (:data (mt/user-http-request :rasta :get 200 (str "database" query-param)))]
             (testing (format "Database %s %d %s" (:engine db) (u/the-id db) (pr-str (:name db)))
               (is (= (expected-tables db)
                      (:tables db))))))))))

--- a/test/metabase/api/permissions_test.clj
+++ b/test/metabase/api/permissions_test.clj
@@ -22,7 +22,7 @@
 ;; Should *not* include inactive users in the counts.
 ;; It should also *not* include the MetaBot group because MetaBot should *not* be enabled
 (defn- fetch-groups []
-  (set ((mt/user->client :crowberto) :get 200 "permissions/group")))
+  (set (mt/user-http-request :crowberto :get 200 "permissions/group")))
 
 (deftest fetch-groups-test
   (testing "GET /api/permissions/group"
@@ -63,7 +63,7 @@
 
 (deftest fetch-group-test
   (testing "GET /permissions/group/:id"
-    (let [{:keys [members]} ((mt/user->client :crowberto) :get 200 (format "permissions/group/%d" (:id (group/all-users))))
+    (let [{:keys [members]} (mt/user-http-request :crowberto :get 200 (format "permissions/group/%d" (:id (group/all-users))))
           id->member        (u/key-by :user_id members)]
       (is (schema= {:first_name    (s/eq "Crowberto")
                     :last_name     (s/eq "Corv")
@@ -91,19 +91,19 @@
   (testing "PUT /api/permissions/graph"
     (testing "make sure we can update the perms graph from the API"
       (mt/with-temp PermissionsGroup [group]
-        ((mt/user->client :crowberto) :put 200 "permissions/graph"
-         (assoc-in (perms/graph)
-                   [:groups (u/the-id group) (mt/id) :schemas]
-                   {"PUBLIC" {(mt/id :venues) :all}}))
+        (mt/user-http-request :crowberto :put 200 "permissions/graph"
+                              (assoc-in (perms/graph)
+                                        [:groups (u/the-id group) (mt/id) :schemas]
+                                        {"PUBLIC" {(mt/id :venues) :all}}))
         (is (= {(mt/id :venues) :all}
                (get-in (perms/graph) [:groups (u/the-id group) (mt/id) :schemas "PUBLIC"]))))
 
       (testing "Table-specific perms"
         (mt/with-temp PermissionsGroup [group]
-          ((mt/user->client :crowberto) :put 200 "permissions/graph"
-           (assoc-in (perms/graph)
-                     [:groups (u/the-id group) (mt/id) :schemas]
-                     {"PUBLIC" {(mt/id :venues) {:read :all, :query :segmented}}}))
+          (mt/user-http-request :crowberto :put 200 "permissions/graph"
+                                (assoc-in (perms/graph)
+                                          [:groups (u/the-id group) (mt/id) :schemas]
+                                          {"PUBLIC" {(mt/id :venues) {:read :all, :query :segmented}}}))
           (is (= {(mt/id :venues) {:read  :all
                                    :query :segmented}}
                  (get-in (perms/graph) [:groups (u/the-id group) (mt/id) :schemas "PUBLIC"]))))))
@@ -113,10 +113,10 @@
         (mt/with-temp* [PermissionsGroup [group]
                         Database         [{db-id :id}]
                         Table            [_ {:db_id db-id}]]
-          ((mt/user->client :crowberto) :put 200 "permissions/graph"
-           (assoc-in (perms/graph)
-                     [:groups (u/the-id group) db-id :schemas]
-                     :all))
+          (mt/user-http-request :crowberto :put 200 "permissions/graph"
+                                (assoc-in (perms/graph)
+                                          [:groups (u/the-id group) db-id :schemas]
+                                          :all))
           (is (= :all
                  (get-in (perms/graph) [:groups (u/the-id group) db-id :schemas]))))))
 
@@ -124,10 +124,10 @@
       (let [new-id (inc (mt/id))]
         (mt/with-temp* [PermissionsGroup [group]
                         Database         [{db-id :id}]]
-          ((mt/user->client :crowberto) :put 200 "permissions/graph"
-           (assoc-in (perms/graph)
-                     [:groups (u/the-id group) db-id :schemas]
-                     :all))
+          (mt/user-http-request :crowberto :put 200 "permissions/graph"
+                                (assoc-in (perms/graph)
+                                          [:groups (u/the-id group) db-id :schemas]
+                                          :all))
           (is (= :all
                  (get-in (perms/graph) [:groups (u/the-id group) db-id :schemas]))))))))
 

--- a/test/metabase/models/collection/graph_test.clj
+++ b/test/metabase/models/collection/graph_test.clj
@@ -80,7 +80,7 @@
       (is (= {:revision 0
               :groups   {(u/the-id (group/all-users)) {:root :none}
                          (u/the-id (group/metabot))   {:root :none}
-                         (u/the-id (group/admin))     {:root :write}}}
+                         (u/the-id (group/admin))     {:root :moderate}}}
              (graph :clear-revisions? true))))))
 
 (deftest new-collection-perms-test
@@ -88,9 +88,9 @@
     (mt/with-non-admin-groups-no-root-collection-perms
       (mt/with-temp Collection [collection]
         (is (= {:revision 0
-                :groups   {(u/the-id (group/all-users)) {:root :none,  :COLLECTION :none}
-                           (u/the-id (group/metabot))   {:root :none,  :COLLECTION :none}
-                           (u/the-id (group/admin))     {:root :write, :COLLECTION :write}}}
+                :groups   {(u/the-id (group/all-users)) {:root :none,     :COLLECTION :none}
+                           (u/the-id (group/metabot))   {:root :none,     :COLLECTION :none}
+                           (u/the-id (group/admin))     {:root :moderate, :COLLECTION :moderate}}}
                (replace-collection-ids collection (graph :clear-revisions? true, :collections [collection]))))))))
 
 (deftest read-perms-test
@@ -99,9 +99,9 @@
       (mt/with-temp Collection [collection]
         (perms/grant-collection-read-permissions! (group/all-users) collection)
         (is (= {:revision 0
-                :groups   {(u/the-id (group/all-users)) {:root :none,  :COLLECTION :read}
-                           (u/the-id (group/metabot))   {:root :none,  :COLLECTION :none}
-                           (u/the-id (group/admin))     {:root :write, :COLLECTION :write}}}
+                :groups   {(u/the-id (group/all-users)) {:root :none,     :COLLECTION :read}
+                           (u/the-id (group/metabot))   {:root :none,     :COLLECTION :none}
+                           (u/the-id (group/admin))     {:root :moderate, :COLLECTION :moderate}}}
                (replace-collection-ids collection (graph :clear-revisions? true, :collections [collection]))))))))
 
 (deftest grant-write-perms-for-new-collections-test
@@ -110,9 +110,20 @@
       (mt/with-temp Collection [collection]
         (perms/grant-collection-readwrite-permissions! (group/all-users) collection)
         (is (=  {:revision 0
-                 :groups   {(u/the-id (group/all-users)) {:root :none,  :COLLECTION :write}
-                            (u/the-id (group/metabot))   {:root :none,  :COLLECTION :none}
-                            (u/the-id (group/admin))     {:root :write, :COLLECTION :write}}}
+                 :groups   {(u/the-id (group/all-users)) {:root :none,     :COLLECTION :write}
+                            (u/the-id (group/metabot))   {:root :none,     :COLLECTION :none}
+                            (u/the-id (group/admin))     {:root :moderate, :COLLECTION :moderate}}}
+                (replace-collection-ids collection (graph :clear-revisions? true, :collections [collection]))))))))
+
+(deftest grant-moderate-perms-for-new-collections-test
+  (testing "make sure we can grant moderate perms for new collections (!)"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-temp Collection [collection]
+        (perms/grant-collection-moderate-permissions! (group/all-users) collection)
+        (is (=  {:revision 0
+                 :groups   {(u/the-id (group/all-users)) {:root :none,     :COLLECTION :moderate}
+                            (u/the-id (group/metabot))   {:root :none,     :COLLECTION :none}
+                            (u/the-id (group/admin))     {:root :moderate, :COLLECTION :moderate}}}
                 (replace-collection-ids collection (graph :clear-revisions? true, :collections [collection]))))))))
 
 (deftest non-magical-groups-test
@@ -122,7 +133,7 @@
         (is (=   {:revision 0
                   :groups   {(u/the-id (group/all-users)) {:root :none}
                              (u/the-id (group/metabot))   {:root :none}
-                             (u/the-id (group/admin))     {:root :write}
+                             (u/the-id (group/admin))     {:root :moderate}
                              (u/the-id new-group)         {:root :none}}}
                  (graph :clear-revisions? true, :groups [new-group])))))))
 
@@ -134,8 +145,20 @@
         (is (= {:revision 0
                 :groups   {(u/the-id (group/all-users)) {:root :none}
                            (u/the-id (group/metabot))   {:root :none}
-                           (u/the-id (group/admin))     {:root :write}
+                           (u/the-id (group/admin))     {:root :moderate}
                            (u/the-id new-group)         {:root :read}}}
+               (graph :clear-revisions? true, :groups [new-group])))))))
+
+(deftest root-collection-moderate-perms-test
+  (testing "How abut *moderate* permissions for the Root Collection?"
+    (mt/with-temp PermissionsGroup [new-group]
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (perms/grant-collection-moderate-permissions! new-group collection/root-collection)
+        (is (= {:revision 0
+                :groups   {(u/the-id (group/all-users)) {:root :none}
+                           (u/the-id (group/metabot))   {:root :none}
+                           (u/the-id (group/admin))     {:root :moderate}
+                           (u/the-id new-group)         {:root :moderate}}}
                (graph :clear-revisions? true, :groups [new-group])))))))
 
 (deftest root-collection-write-perms-test
@@ -146,7 +169,7 @@
         (is (= {:revision 0
                 :groups   {(u/the-id (group/all-users)) {:root :none}
                            (u/the-id (group/metabot))   {:root :none}
-                           (u/the-id (group/admin))     {:root :write}
+                           (u/the-id (group/admin))     {:root :moderate}
                            (u/the-id new-group)         {:root :write}}}
                (graph :clear-revisions? true, :groups [new-group])))))))
 
@@ -160,7 +183,7 @@
         (is (= {:revision 0
                 :groups   {(u/the-id (group/all-users)) {:root :none}
                            (u/the-id (group/metabot))   {:root :none}
-                           (u/the-id (group/admin))     {:root :write}}}
+                           (u/the-id (group/admin))     {:root :moderate}}}
                (graph))
             "revision should not have changed, because there was nothing to do...")))))
 
@@ -174,9 +197,9 @@
                                          [:groups (u/the-id (group/all-users)) (u/the-id collection)]
                                          :read))
           (is (= {:revision 1
-                  :groups   {(u/the-id (group/all-users)) {:root :none,  :COLLECTION :read}
-                             (u/the-id (group/metabot))   {:root :none,  :COLLECTION :none}
-                             (u/the-id (group/admin))     {:root :write, :COLLECTION :write}}}
+                  :groups   {(u/the-id (group/all-users)) {:root :none,     :COLLECTION :read}
+                             (u/the-id (group/metabot))   {:root :none,     :COLLECTION :none}
+                             (u/the-id (group/admin))     {:root :moderate, :COLLECTION :moderate}}}
                  (replace-collection-ids collection (graph :collections [collection]))))))))
 
   (testing "can we give them *write* perms?"
@@ -187,9 +210,9 @@
                                          [:groups (u/the-id (group/all-users)) (u/the-id collection)]
                                          :write))
           (is (= {:revision 1
-                  :groups   {(u/the-id (group/all-users)) {:root :none,  :COLLECTION :write}
-                             (u/the-id (group/metabot))   {:root :none,  :COLLECTION :none}
-                             (u/the-id (group/admin))     {:root :write, :COLLECTION :write}}}
+                  :groups   {(u/the-id (group/all-users)) {:root :none,     :COLLECTION :write}
+                             (u/the-id (group/metabot))   {:root :none,     :COLLECTION :none}
+                             (u/the-id (group/admin))     {:root :moderate, :COLLECTION :moderate}}}
                  (replace-collection-ids collection (graph :collections [collection])))))))))
 
 (deftest revoke-perms-test
@@ -203,9 +226,9 @@
                                          [:groups (u/the-id (group/all-users)) (u/the-id collection)]
                                          :none))
           (is (= {:revision 1
-                  :groups   {(u/the-id (group/all-users)) {:root :none,  :COLLECTION :none}
-                             (u/the-id (group/metabot))   {:root :none,  :COLLECTION :none}
-                             (u/the-id (group/admin))     {:root :write, :COLLECTION :write}}}
+                  :groups   {(u/the-id (group/all-users)) {:root :none,     :COLLECTION :none}
+                             (u/the-id (group/metabot))   {:root :none,     :COLLECTION :none}
+                             (u/the-id (group/admin))     {:root :moderate, :COLLECTION :moderate}}}
                  (replace-collection-ids collection (graph :collections [collection])))))))))
 
 (deftest grant-root-permissions-test
@@ -220,7 +243,7 @@
           (is (= {:revision 1
                   :groups   {(u/the-id (group/all-users)) {:root :none}
                              (u/the-id (group/metabot))   {:root :none}
-                             (u/the-id (group/admin))     {:root :write}
+                             (u/the-id (group/admin))     {:root :moderate}
                              (u/the-id new-group)         {:root :read}}}
                  (graph :groups [new-group])))))))
 
@@ -235,7 +258,7 @@
           (is (= {:revision 1
                   :groups   {(u/the-id (group/all-users)) {:root :none}
                              (u/the-id (group/metabot))   {:root :none}
-                             (u/the-id (group/admin))     {:root :write}
+                             (u/the-id (group/admin))     {:root :moderate}
                              (u/the-id new-group)         {:root :write}}}
                  (graph :groups [new-group]))))))))
 
@@ -252,7 +275,7 @@
           (is (= {:revision 1
                   :groups   {(u/the-id (group/all-users)) {:root :none}
                              (u/the-id (group/metabot))   {:root :none}
-                             (u/the-id (group/admin))     {:root :write}
+                             (u/the-id (group/admin))     {:root :moderate}
                              (u/the-id new-group)         {:root :none}}}
                  (graph :groups [new-group]))))))))
 
@@ -262,7 +285,7 @@
       (is (= {:revision 0
               :groups   {(u/the-id (group/all-users)) {:root :none}
                          (u/the-id (group/metabot))   {:root :none}
-                         (u/the-id (group/admin))     {:root :write}}}
+                         (u/the-id (group/admin))     {:root :moderate}}}
              (graph :clear-revisions? true)))))
 
   (testing "Make sure descendants of Personal Collections do not come back as part of the graph either..."
@@ -272,7 +295,7 @@
         (is (= {:revision 0
                 :groups   {(u/the-id (group/all-users)) {:root :none}
                            (u/the-id (group/metabot))   {:root :none}
-                           (u/the-id (group/admin))     {:root :write}}}
+                           (u/the-id (group/admin))     {:root :moderate}}}
                (graph)))))))
 
 (deftest disallow-editing-personal-collections-test
@@ -287,7 +310,7 @@
           (is (= {:revision 0
                   :groups   {(u/the-id (group/all-users)) {:root :none}
                              (u/the-id (group/metabot))   {:root :none}
-                             (u/the-id (group/admin))     {:root :write}}}
+                             (u/the-id (group/admin))     {:root :moderate}}}
                  (graph))))
 
         (testing "No revision should have been saved"

--- a/test/metabase/models/collection_test.clj
+++ b/test/metabase/models/collection_test.clj
@@ -247,7 +247,7 @@
 
 (deftest permissions-set->visible-collection-ids-test
   (testing "Make sure we can look at the current user's permissions set and figure out which Collections they're allowed to see"
-    (is (= #{8 9}
+    (is (= #{8 9 10}
            (collection/permissions-set->visible-collection-ids
             #{"/db/1/"
               "/db/2/native/"
@@ -255,7 +255,8 @@
               "/db/5/schema/PUBLIC/"
               "/db/6/schema/PUBLIC/table/7/"
               "/collection/8/"
-              "/collection/9/read/"}))))
+              "/collection/9/read/"
+              "/collection/10/moderate/"}))))
 
   (testing "If the current user has root permissions then make sure the function returns `:all`, which signifies that they are able to see all Collections"
     (is (= :all

--- a/test/metabase/models/collection_test.clj
+++ b/test/metabase/models/collection_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.models.collection-test
   (:refer-clojure :exclude [ancestors descendants])
   (:require [clojure.math.combinatorics :as math.combo]
+            [clojure.set :as set]
             [clojure.string :as str]
             [clojure.test :refer :all]
             [metabase.api.common :refer [*current-user-permissions-set*]]
@@ -254,9 +255,9 @@
               "/db/4/schema/"
               "/db/5/schema/PUBLIC/"
               "/db/6/schema/PUBLIC/table/7/"
-              "/collection/8/"
+              "/collection/8/edit/"
               "/collection/9/read/"
-              "/collection/10/moderate/"}))))
+              "/collection/10/"}))))
 
   (testing "If the current user has root permissions then make sure the function returns `:all`, which signifies that they are able to see all Collections"
     (is (= :all
@@ -677,38 +678,38 @@
 (deftest perms-for-archiving-test
   (with-collection-hierarchy [{:keys [a b c d], :as collections}]
     (testing "To Archive A, you should need *write* perms for A and all of its descendants, and also the Root Collection..."
-      (is (= #{"/collection/root/"
-               "/collection/A/"
-               "/collection/B/"
-               "/collection/C/"
-               "/collection/D/"
-               "/collection/E/"
-               "/collection/F/"
-               "/collection/G/"}
+      (is (= #{"/collection/root/edit/"
+               "/collection/A/edit/"
+               "/collection/B/edit/"
+               "/collection/C/edit/"
+               "/collection/D/edit/"
+               "/collection/E/edit/"
+               "/collection/F/edit/"
+               "/collection/G/edit/"}
              (->> (collection/perms-for-archiving a)
                   (perms-path-ids->names collections)))))
 
     (testing (str "Now let's move down a level. To archive B, you should need permissions for A and B, since B doesn't "
                   "have any descendants")
-      (is (= #{"/collection/A/"
-               "/collection/B/"}
+      (is (= #{"/collection/A/edit/"
+               "/collection/B/edit/"}
              (->> (collection/perms-for-archiving b)
                   (perms-path-ids->names collections)))))
 
     (testing "but for C, you should need perms for A (parent); C; and D, E, F, and G (descendants)"
-      (is (= #{"/collection/A/"
-               "/collection/C/"
-               "/collection/D/"
-               "/collection/E/"
-               "/collection/F/"
-               "/collection/G/"}
+      (is (= #{"/collection/A/edit/"
+               "/collection/C/edit/"
+               "/collection/D/edit/"
+               "/collection/E/edit/"
+               "/collection/F/edit/"
+               "/collection/G/edit/"}
              (->> (collection/perms-for-archiving c)
                   (perms-path-ids->names collections)))))
 
     (testing "For D you should need C (parent), D, and E (descendant)"
-      (is (= #{"/collection/C/"
-               "/collection/D/"
-               "/collection/E/"}
+      (is (= #{"/collection/C/edit/"
+               "/collection/D/edit/"
+               "/collection/E/edit/"}
              (->> (collection/perms-for-archiving d)
                   (perms-path-ids->names collections)))))))
 
@@ -747,9 +748,9 @@
       ;;           |                           |
       ;;           +-> F -> G                  +-> F -> G
 
-      (is (= #{"/collection/A/"
-               "/collection/B/"
-               "/collection/C/"}
+      (is (= #{"/collection/A/edit/"
+               "/collection/B/edit/"
+               "/collection/C/edit/"}
              (->> (collection/perms-for-moving b c)
                   (perms-path-ids->names collections)))))
 
@@ -762,13 +763,13 @@
       ;; A -+-> C -+-> D -> E  ===>  A* -> B* -> C* -+-> D* -> E*
       ;;           |                                 |
       ;;           +-> F -> G                        +-> F* -> G*
-      (is (= #{"/collection/A/"
-               "/collection/B/"
-               "/collection/C/"
-               "/collection/D/"
-               "/collection/E/"
-               "/collection/F/"
-               "/collection/G/"}
+      (is (= #{"/collection/A/edit/"
+               "/collection/B/edit/"
+               "/collection/C/edit/"
+               "/collection/D/edit/"
+               "/collection/E/edit/"
+               "/collection/F/edit/"
+               "/collection/G/edit/"}
              (->> (collection/perms-for-moving c b)
                   (perms-path-ids->names collections)))))
 
@@ -778,9 +779,9 @@
       ;; A -+-> C -+-> D -> E  ===>  A* -> C -+-> D -> E
       ;;           |                          |
       ;;           +-> F -> G                 +-> F -> G
-      (is (= #{"/collection/root/"
-               "/collection/A/"
-               "/collection/B/"}
+      (is (= #{"/collection/root/edit/"
+               "/collection/A/edit/"
+               "/collection/B/edit/"}
              (->> (collection/perms-for-moving b collection/root-collection)
                   (perms-path-ids->names collections)))))
 
@@ -790,13 +791,13 @@
       ;; A -+-> C -+-> D -> E  ===>  C* -+-> D* -> E* [and Root*]
       ;;           |                     |
       ;;           +-> F -> G            +-> F* -> G*
-      (is (= #{"/collection/root/"
-               "/collection/A/"
-               "/collection/C/"
-               "/collection/D/"
-               "/collection/E/"
-               "/collection/F/"
-               "/collection/G/"}
+      (is (= #{"/collection/root/edit/"
+               "/collection/A/edit/"
+               "/collection/C/edit/"
+               "/collection/D/edit/"
+               "/collection/E/edit/"
+               "/collection/F/edit/"
+               "/collection/G/edit/"}
              (->> (collection/perms-for-moving c collection/root-collection)
                   (perms-path-ids->names collections)))))))
 
@@ -1089,7 +1090,7 @@
                 "the Root Collection\n")
     (doseq [collection-namespace [nil "currency"]
             :let                 [root-collection       (assoc collection/root-collection :namespace collection-namespace)
-                                  other-namespace      (if collection-namespace nil "currency")
+                                  other-namespace       (if collection-namespace nil "currency")
                                   other-root-collection (assoc collection/root-collection :namespace other-namespace)]]
       (testing (format "Collection namespace = %s\n" (pr-str collection-namespace))
         (mt/with-temp PermissionsGroup [group]
@@ -1117,7 +1118,7 @@
 
           (testing "copy readwrite perms"
             (mt/with-temp Collection [collection {:name "{new}", :namespace collection-namespace}]
-              (is (= #{"/collection/{new}/"
+              (is (= #{"/collection/{new}/edit/"
                        (perms/collection-readwrite-path root-collection)}
                      (group->perms [collection] group)))))
 
@@ -1125,26 +1126,44 @@
                            (pr-str collection-namespace) (pr-str other-namespace))
             (mt/with-temp Collection [collection {:name "{new}", :namespace other-namespace}]
               (is (= #{(perms/collection-readwrite-path root-collection)}
-                     (group->perms [collection] group))))))))))
+                     (group->perms [collection] group)))))
+
+          (testing "copy moderate perms"
+            (perms/grant-collection-moderate-permissions! group root-collection)
+            (mt/with-temp Collection [collection {:name "{new}", :namespace collection-namespace}]
+              (is (set/subset? #{"/collection/{new}/"
+                                 (perms/collection-moderate-path root-collection)}
+                               (group->perms [collection] group))))))))))
 
 (deftest copy-parent-permissions-test
   (testing "Make sure that when creating a new child Collection, we copy the group permissions for its parent"
     (mt/with-temp PermissionsGroup [group]
       (testing "parent has readwrite permissions"
-        (mt/with-temp Collection [parent {:name "{parent}"}]
-          (perms/grant-collection-readwrite-permissions! group parent)
-          (mt/with-temp Collection [child {:name "{child}", :location (collection/children-location parent)}]
-            (is (= #{"/collection/{parent}/"
-                     "/collection/{child}/"}
-                   (group->perms [parent child] group))))))
+        (mt/with-model-cleanup [Permissions]
+          (mt/with-temp Collection [parent {:name "{parent}"}]
+            (perms/grant-collection-readwrite-permissions! group parent)
+            (mt/with-temp Collection [child {:name "{child}", :location (collection/children-location parent)}]
+              (is (= #{"/collection/{parent}/edit/"
+                       "/collection/{child}/edit/"}
+                     (group->perms [parent child] group)))))))
 
-      (testing "parent has read permissions"
-        (mt/with-temp Collection [parent {:name "{parent}"}]
-          (perms/grant-collection-read-permissions! group parent)
-          (mt/with-temp Collection [child {:name "{child}", :location (collection/children-location parent)}]
-            (is (= #{"/collection/{parent}/read/"
-                     "/collection/{child}/read/"}
-                   (group->perms [parent child] group))))))
+      (mt/with-model-cleanup [Permissions]
+        (testing "parent has read permissions"
+          (mt/with-temp Collection [parent {:name "{parent}"}]
+            (perms/grant-collection-read-permissions! group parent)
+            (mt/with-temp Collection [child {:name "{child}", :location (collection/children-location parent)}]
+              (is (= #{"/collection/{parent}/read/"
+                       "/collection/{child}/read/"}
+                     (group->perms [parent child] group)))))))
+
+      (mt/with-model-cleanup [Permissions]
+        (testing "parent has moderate permissions"
+          (mt/with-temp Collection [parent {:name "{parent}"}]
+            (perms/grant-collection-moderate-permissions! group parent)
+            (mt/with-temp Collection [child {:name "{child}", :location (collection/children-location parent)}]
+              (is (= #{"/collection/{parent}/"
+                       "/collection/{child}/"}
+                     (group->perms [parent child] group)))))))
 
       (testing "parent has no permissions"
         (mt/with-temp* [Collection [parent {:name "{parent}"}]
@@ -1283,8 +1302,8 @@
         (with-personal-and-impersonal-collections [group {[a b] :personal}]
           (perms/grant-collection-readwrite-permissions! group collection/root-collection)
           (db/update! Collection (u/the-id b) :location (collection/children-location collection/root-collection))
-          (is (= #{"/collection/root/"
-                   "/collection/B/"}
+          (is (= #{"/collection/root/edit/"
+                   "/collection/B/edit/"}
                  (group->perms [a b] group)))))
 
       (testing (str "to a non-personal Collection, we should create perms entries that match the Root Collection's "
@@ -1295,8 +1314,8 @@
         (with-personal-and-impersonal-collections [group {[a b] :personal, [c] :root}]
           (perms/grant-collection-readwrite-permissions! group c)
           (db/update! Collection (u/the-id b) :location (collection/children-location c))
-          (is (= #{"/collection/B/"
-                   "/collection/C/"}
+          (is (= #{"/collection/B/edit/"
+                   "/collection/C/edit/"}
                  (group->perms [a b c] group)))))))
 
   (testing "Perms should apply recursively as well..."
@@ -1306,9 +1325,9 @@
     (with-personal-and-impersonal-collections [group {[a b] :personal, [c] :root}]
       (perms/grant-collection-readwrite-permissions! group c)
       (db/update! Collection (u/the-id a) :location (collection/children-location c))
-      (is (= #{"/collection/A/"
-               "/collection/B/"
-               "/collection/C/"}
+      (is (= #{"/collection/A/edit/"
+               "/collection/B/edit/"
+               "/collection/C/edit/"}
              (group->perms [a b c] group))))))
 
 
@@ -1345,7 +1364,7 @@
           (perms/grant-collection-readwrite-permissions! group a)
           (perms/grant-collection-readwrite-permissions! group b)
           (db/update! Collection (u/the-id b) :location (lucky-collection-children-location))
-          (is (= #{"/collection/A/"}
+          (is (= #{"/collection/A/edit/"}
                  (group->perms [a b] group)))))
 
       (testing "to a descendant of a Personal Collection, we should *delete* perms entries for it"
@@ -1356,7 +1375,7 @@
           (perms/grant-collection-readwrite-permissions! group b)
           (perms/grant-collection-readwrite-permissions! group c)
           (db/update! Collection (u/the-id c) :location (collection/children-location a))
-          (is (= #{"/collection/B/"}
+          (is (= #{"/collection/B/edit/"}
                  (group->perms [a b c] group)))))))
 
   (testing "Deleting perms should apply recursively as well..."

--- a/test/metabase/models/permissions/parse_test.clj
+++ b/test/metabase/models/permissions/parse_test.clj
@@ -54,10 +54,11 @@
 
 (deftest permissions->graph-collections
   (are [x y] (= y (parse/permissions->graph [x]))
-    "/collection/root/"      {:collection {:root :write}}
-    "/collection/root/read/" {:collection {:root :read}}
-    "/collection/1/"         {:collection {1 :write}}
-    "/collection/1/read/"    {:collection {1 :read}}))
+    "/collection/root/"       {:collection {:root :write}}
+    "/collection/root/read/"  {:collection {:root :read}}
+    "/collection/1/"          {:collection {1 :write}}
+    "/collection/1/read/"     {:collection {1 :read}}
+    "/collection/1/moderate/" {:collection {1 :moderate}}))
 
 (deftest combines-all-permissions
   (testing "Permision graph includes broadest permissions for all dbs in permission set"
@@ -65,8 +66,10 @@
                             :schemas :all}
                          5 {:schemas {"PUBLIC" {10 {:read :all}}}}}
             :collection {:root :write
-                         1     :read}}
+                         1     :read
+                         2     :moderate}}
            (parse/permissions->graph #{"/db/3/"
                                        "/db/5/schema/PUBLIC/table/10/read/"
                                        "/collection/root/"
-                                       "/collection/1/read/"})))))
+                                       "/collection/1/read/"
+                                       "/collection/2/moderate/"})))))

--- a/test/metabase/models/permissions/parse_test.clj
+++ b/test/metabase/models/permissions/parse_test.clj
@@ -54,22 +54,25 @@
 
 (deftest permissions->graph-collections
   (are [x y] (= y (parse/permissions->graph [x]))
-    "/collection/root/"       {:collection {:root :write}}
+    "/collection/root/"       {:collection {:root :moderate}}
+    "/collection/root/edit/"  {:collection {:root :write}}
     "/collection/root/read/"  {:collection {:root :read}}
-    "/collection/1/"          {:collection {1 :write}}
+    "/collection/1/"          {:collection {1 :moderate}}
     "/collection/1/read/"     {:collection {1 :read}}
-    "/collection/1/moderate/" {:collection {1 :moderate}}))
+    "/collection/1/edit/"     {:collection {1 :write}}))
 
 (deftest combines-all-permissions
   (testing "Permision graph includes broadest permissions for all dbs in permission set"
     (is (= {:db         {3 {:native  :write
                             :schemas :all}
                          5 {:schemas {"PUBLIC" {10 {:read :all}}}}}
-            :collection {:root :write
+            :collection {:root :moderate
                          1     :read
-                         2     :moderate}}
+                         2     :moderate
+                         3     :write}}
            (parse/permissions->graph #{"/db/3/"
                                        "/db/5/schema/PUBLIC/table/10/read/"
                                        "/collection/root/"
                                        "/collection/1/read/"
-                                       "/collection/2/moderate/"})))))
+                                       "/collection/2/"
+                                       "/collection/3/edit/"})))))

--- a/test/metabase/models/permissions_test.clj
+++ b/test/metabase/models/permissions_test.clj
@@ -295,7 +295,22 @@
           perms-path inputs]
     (testing (pr-str (list 'is-permissions-for-object? perms-path "/db/1/schema/PUBLIC/table/1/"))
       (is (= expected
-             (perms/is-permissions-for-object? perms-path "/db/1/schema/PUBLIC/table/1/"))))))
+             (perms/is-permissions-for-object? perms-path "/db/1/schema/PUBLIC/table/1/")))))
+  (doseq [[expected perm obj]
+          [[true  "/collection/1/read/" "/collection/1/read/"]
+           [false "/collection/1/read/" "/collection/1/"]
+           [false "/collection/1/read/" "/collection/1/moderate/"]
+
+           [true  "/collection/1/" "/collection/1/read/"]
+           [true  "/collection/1/" "/collection/1/"]
+           [false "/collection/1/" "/collection/1/moderate/"]
+
+           [true "/collection/1/moderate/" "/collection/1/read/"]
+           [true "/collection/1/moderate/" "/collection/1/"]
+           [true "/collection/1/moderate/" "/collection/1/moderate/"]]]
+    (testing (pr-str (list 'is-permissions-for-object? perm obj))
+      (is (= expected
+             (perms/is-permissions-for-object? perm obj))))))
 
 
 ;;; --------------------------------------- is-partial-permissions-for-object? ---------------------------------------

--- a/test/metabase/models/permissions_test.clj
+++ b/test/metabase/models/permissions_test.clj
@@ -239,20 +239,27 @@
 
 (deftest collection-path-test
   (doseq [[perms-type f-symb] {:read      'collection-read-path
-                               :readwrite 'collection-readwrite-path}
+                               :readwrite 'collection-readwrite-path
+                               :moderate  'collection-moderate-path}
           :let                [f (ns-resolve 'metabase.models.permissions f-symb)]]
     (doseq [[input expected]
-            {1                                                        {:read      "/collection/1/read/"
+            {1                                                        {:moderate  "/collection/1/moderate/"
+                                                                       :read      "/collection/1/read/"
                                                                        :readwrite "/collection/1/"}
-             {:id 1}                                                  {:read      "/collection/1/read/"
+             {:id 1}                                                  {:moderate  "/collection/1/moderate/"
+                                                                       :read      "/collection/1/read/"
                                                                        :readwrite "/collection/1/"}
-             collection/root-collection                               {:read      "/collection/root/read/"
+             collection/root-collection                               {:moderate  "/collection/root/moderate/"
+                                                                       :read      "/collection/root/read/"
                                                                        :readwrite "/collection/root/"}
-             (assoc collection/root-collection :namespace "snippets") {:read      "/collection/namespace/snippets/root/read/"
+             (assoc collection/root-collection :namespace "snippets") {:moderate  "/collection/namespace/snippets/root/moderate/"
+                                                                       :read      "/collection/namespace/snippets/root/read/"
                                                                        :readwrite "/collection/namespace/snippets/root/"}
-             (assoc collection/root-collection :namespace "a/b")      {:read      "/collection/namespace/a\\/b/root/read/"
+             (assoc collection/root-collection :namespace "a/b")      {:moderate  "/collection/namespace/a\\/b/root/moderate/"
+                                                                       :read      "/collection/namespace/a\\/b/root/read/"
                                                                        :readwrite "/collection/namespace/a\\/b/root/"}
-             (assoc collection/root-collection :namespace :a/b)       {:read      "/collection/namespace/a\\/b/root/read/"
+             (assoc collection/root-collection :namespace :a/b)       {:moderate  "/collection/namespace/a\\/b/root/moderate/"
+                                                                       :read      "/collection/namespace/a\\/b/root/read/"
                                                                        :readwrite "/collection/namespace/a\\/b/root/"}}
             :let [expected (get expected perms-type)]]
       (testing (pr-str (list f-symb input))
@@ -503,10 +510,12 @@
 ;;; ------------------------------------ perms-objects-set-for-parent-collection -------------------------------------
 
 (deftest perms-objects-set-for-parent-collection-test
-  (doseq [[input expected] {[{:collection_id 1337} :read]  #{"/collection/1337/read/"}
-                            [{:collection_id 1337} :write] #{"/collection/1337/"}
-                            [{:collection_id nil} :read]   #{"/collection/root/read/"}
-                            [{:collection_id nil} :write]  #{"/collection/root/"}}]
+  (doseq [[input expected] {[{:collection_id 1337} :moderate] #{"/collection/1337/moderate/"}
+                            [{:collection_id 1337} :read]     #{"/collection/1337/read/"}
+                            [{:collection_id 1337} :write]    #{"/collection/1337/"}
+                            [{:collection_id nil} :moderate]  #{"/collection/root/moderate/"}
+                            [{:collection_id nil} :read]      #{"/collection/root/read/"}
+                            [{:collection_id nil} :write]     #{"/collection/root/"}}]
     (testing (pr-str (cons 'perms-objects-set-for-parent-collection input))
       (is (= expected
              (apply perms/perms-objects-set-for-parent-collection input)))))

--- a/test/metabase/models/user_test.clj
+++ b/test/metabase/models/user_test.clj
@@ -56,8 +56,8 @@
                                                            :location (collection/children-location child-collection)}]]
           (is (set/subset?
                #{(perms/collection-readwrite-path (collection/user->personal-collection (mt/user->id :lucky)))
-                 "/collection/child/"
-                 "/collection/grandchild/"}
+                 "/collection/child/edit/"
+                 "/collection/grandchild/edit/"}
                (->> (user/permissions-set (mt/user->id :lucky))
                     remove-non-collection-perms
                     (collection-test/perms-path-ids->names [child-collection grandchild-collection])))))))))


### PR DESCRIPTION
Adds a new `/moderate/` collection permission, that works analogously to `/read/`. Moderate gives read, write and the (new) ability to create moderation reviews for items in a collection.