### PR TITLE
Paginated collection metadata

### DIFF
--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -402,8 +402,8 @@
                          {:models       model-kwds
                           :archived?    (Boolean/parseBoolean archived)
                           :pinned-state (keyword pinned_state)
-                          :sort-info    [(normalize-sort-choice sort_column)
-                                         (normalize-sort-choice sort_direction)]})))
+                          :sort-info    [(or (some-> sort_column normalize-sort-choice) :name)
+                                         (or (some-> sort_direction normalize-sort-choice) :asc)]})))
 
 
 ;;; -------------------------------------------- GET /api/collection/root --------------------------------------------
@@ -449,8 +449,8 @@
       {:models       model-kwds
        :archived?    (Boolean/parseBoolean archived)
        :pinned-state (keyword pinned_state)
-       :sort-info    [(normalize-sort-choice sort_column)
-                      (normalize-sort-choice sort_direction)]})))
+       :sort-info    [(or (some-> sort_column normalize-sort-choice) :name)
+                      (or (some-> sort_direction normalize-sort-choice) :asc)]})))
 
 
 ;;; ----------------------------------------- Creating/Editing a Collection ------------------------------------------

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -201,6 +201,10 @@
                    [:= :archived (boolean archived?)]]}
       (h/merge-where (pinned-state->clause pinned-state))))
 
+(defmethod post-process-collection-children :card
+  [_ rows]
+  (hydrate rows :favorite))
+
 (defmethod collection-children-query :dashboard
   [_ collection {:keys [archived? pinned-state]}]
   (-> {:select    [:d.id :d.name :d.description :d.collection_position [(hx/literal "dashboard") :model]
@@ -226,7 +230,7 @@
 
 (defmethod post-process-collection-children :dashboard
   [_ rows]
-  (hydrate rows :favorite))
+  (hydrate (map #(dissoc % :display) rows) :favorite))
 
 (defmethod collection-children-query :collection
   [_ collection {:keys [archived? collection-namespace pinned-state]}]

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -10,6 +10,7 @@
             [medley.core :as m]
             [metabase.api.card :as card-api]
             [metabase.api.common :as api]
+            [metabase.db.env :as mdb.env]
             [metabase.models.card :refer [Card]]
             [metabase.models.collection :as collection :refer [Collection]]
             [metabase.models.collection.graph :as collection.graph]
@@ -317,7 +318,7 @@
   (let [columns (m/index-by select-name select-columns)]
     (map (fn [col]
            (let [[col-name typpe] (u/one-or-many col)]
-             (get columns col-name (if typpe
+             (get columns col-name (if (and typpe (= @mdb.env/db-type :postgres))
                                      [(hx/cast typpe nil) col-name]
                                      [nil col-name]))))
          necessary-columns)))

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -341,8 +341,10 @@
                       nil                  [[:%lower.name :asc]]
                       [:name :asc]         [[:%lower.name :asc]]
                       [:name :desc]        [[:%lower.name :desc]]
-                      [:last-edited :asc]  [[:last_edit_timestamp :asc]]
-                      [:last-edited :desc] [[:last_edit_timestamp :desc]]
+                      [:last-edited :asc]  [[:last_edit_timestamp :asc]
+                                            [:%lower.name :asc]]
+                      [:last-edited :desc] [[:last_edit_timestamp :desc]
+                                            [:%lower.name :asc]]
                       [:model :asc]        [[:model :asc]  [:%lower.name :asc]]
                       [:model :desc]       [[:model :desc] [:%lower.name :asc]])
         models      (sort (map keyword models))

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -6,6 +6,7 @@
   `?namespace=snippet`)."
   (:require [clojure.string :as str]
             [compojure.core :refer [GET POST PUT]]
+            [honeysql.core :as hsql]
             [honeysql.helpers :as h]
             [medley.core :as m]
             [metabase.api.card :as card-api]
@@ -341,10 +342,14 @@
                       nil                  [[:%lower.name :asc]]
                       [:name :asc]         [[:%lower.name :asc]]
                       [:name :desc]        [[:%lower.name :desc]]
-                      [:last-edited :asc]  [[:last_edit_timestamp :nulls-last]
+                      [:last-edited :asc]  [(if (= @mdb.env/db-type :mysql)
+                                              [(hsql/call :ISNULL :last_edit_timestamp)]
+                                              [:last_edit_timestamp :nulls-last])
                                             [:last_edit_timestamp :asc]
                                             [:%lower.name :asc]]
-                      [:last-edited :desc] [[:last_edit_timestamp :nulls-last]
+                      [:last-edited :desc] [(if (= @mdb.env/db-type :mysql)
+                                              [(hsql/call :ISNULL :last_edit_timestamp)]
+                                              [:last_edit_timestamp :nulls-last])
                                             [:last_edit_timestamp :desc]
                                             [:%lower.name :asc]]
                       [:model :asc]        [[:model :asc]  [:%lower.name :asc]]

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -174,12 +174,16 @@
                    [:r.timestamp :last_edit_timestamp]]
        :from      [[Card :c]]
        ;; todo: should there be a flag, or a realized view?
-       :left-join [[{:select   [[:%max.id :id] :model_id]
-                     :from     [[:revision :rev_latest]]
-                     :where    [:and
-                                [:= :rev_latest.model (hx/literal "Card")]]
-                     :group-by [:model_id]} :r_latest] [:= :r_latest.model_id :c.id]
-                   [:revision :r] [:= :r.id :r_latest.id]
+       :left-join [[{:select [:r1.*]
+                     :from [[:revision :r1]]
+                     :left-join [[:revision :r2] [:and
+                                                  [:= :r1.model_id :r2.model_id]
+                                                  [:= :r1.model :r2.model]
+                                                  [:> :r1.id :r2.id]]]
+                     :where [:and
+                             [:= :r2.id nil]
+                             [:= :r1.model (hx/literal "Card")]]} :r]
+                   [:= :r.model_id :c.id]
                    [:core_user :u] [:= :u.id :r.user_id]]
        :where     [:and
                    [:= :collection_id (:id collection)]
@@ -193,12 +197,16 @@
                    [:u.first_name :last_edit_first_name] [:u.last_name :last_edit_last_name]
                    [:r.timestamp :last_edit_timestamp]]
        :from      [[Dashboard :d]]
-       :left-join [[{:select   [[:%max.id :id] :model_id]
-                     :from     [[:revision :rev_latest]]
-                     :where    [:and
-                                [:= :rev_latest.model (hx/literal "Dashboard")]]
-                     :group-by [:model_id]} :r_latest] [:= :r_latest.model_id :d.id]
-                   [:revision :r] [:= :r.id :r_latest.id]
+       :left-join [[{:select [:r1.*]
+                     :from [[:revision :r1]]
+                     :left-join [[:revision :r2] [:and
+                                                  [:= :r1.model_id :r2.model_id]
+                                                  [:= :r1.model :r2.model]
+                                                  [:> :r1.id :r2.id]]]
+                     :where [:and
+                             [:= :r2.id nil]
+                             [:= :r1.model (hx/literal "Dashboard")]]} :r]
+                   [:= :r.model_id :d.id]
                    [:core_user :u] [:= :u.id :r.user_id]]
        :where     [:and
                    [:= :collection_id (:id collection)]

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -347,11 +347,16 @@
                                               [:last_edit_timestamp :nulls-last])
                                             [:last_edit_timestamp :asc]
                                             [:%lower.name :asc]]
-                      [:last-edited :desc] [(if (= @mdb.env/db-type :mysql)
-                                              [(hsql/call :ISNULL :last_edit_timestamp)]
-                                              [:last_edit_timestamp :nulls-last])
-                                            [:last_edit_timestamp :desc]
-                                            [:%lower.name :asc]]
+                      [:last-edited :desc] (into
+                                            (case @mdb.env/db-type
+                                              :mysql
+                                              [[(hsql/call :ISNULL :last_edit_timestamp)]]
+                                              :postgres
+                                              [[(hsql/raw "last_edit_timestamp DESC NULLS LAST")]]
+                                              :h2
+                                              [])
+                                            [[:last_edit_timestamp :desc]
+                                             [:%lower.name :asc]])
                       [:model :asc]        [[:model :asc]  [:%lower.name :asc]]
                       [:model :desc]       [[:model :desc] [:%lower.name :asc]])
         models      (sort (map keyword models))

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -341,9 +341,11 @@
                       nil                  [[:%lower.name :asc]]
                       [:name :asc]         [[:%lower.name :asc]]
                       [:name :desc]        [[:%lower.name :desc]]
-                      [:last-edited :asc]  [[:last_edit_timestamp :asc]
+                      [:last-edited :asc]  [[:last_edit_timestamp :nulls-last]
+                                            [:last_edit_timestamp :asc]
                                             [:%lower.name :asc]]
-                      [:last-edited :desc] [[:last_edit_timestamp :desc]
+                      [:last-edited :desc] [[:last_edit_timestamp :nulls-last]
+                                            [:last_edit_timestamp :desc]
                                             [:%lower.name :asc]]
                       [:model :asc]        [[:model :asc]  [:%lower.name :asc]]
                       [:model :desc]       [[:model :desc] [:%lower.name :asc]])

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -422,12 +422,12 @@
                         Pulse      [_ {:name "ZZ" :collection_id collection-id}]
                         Pulse      [_ {:name "AA" :collection_id collection-id}]]
           (testing "sort direction asc"
-            (is (= [["card" "AA"] ["card" "ZZ"] ["dashboard" "AA"] ["dashboard" "ZZ"] ["pulse" "AA"] ["pulse" "ZZ"]]
+            (is (= [["dashboard" "AA"] ["dashboard" "ZZ"] ["pulse" "AA"] ["pulse" "ZZ"] ["card" "AA"] ["card" "ZZ"]]
                    (->> (mt/user-http-request :rasta :get 200 (str "collection/" collection-id "/items?sort_column=model&sort_direction=asc"))
                         :data
                         (map (juxt :model :name))))))
           (testing "sort direction desc"
-            (is (= [["pulse" "AA"] ["pulse" "ZZ"] ["dashboard" "AA"] ["dashboard" "ZZ"] ["card" "AA"] ["card" "ZZ"]]
+            (is (= [["card" "AA"] ["card" "ZZ"] ["pulse" "AA"] ["pulse" "ZZ"] ["dashboard" "AA"] ["dashboard" "ZZ"]]
                    (->> (mt/user-http-request :rasta :get 200 (str "collection/" collection-id "/items?sort_column=model&sort_direction=desc"))
                         :data
                         (map (juxt :model :name)))))))))))

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -379,7 +379,7 @@
       ;; need different timestamps and Revision has a pre-update to throw as they aren't editable
       (db/execute! {:update :revision
                     ;; in the past
-                    :set {:timestamp "2021-05-01T12:34:56"}
+                    :set {:timestamp (.minusHours (java.time.OffsetDateTime/now) 2)}
                     :where [:= :id (:id _revision1)]})
       (testing "Results include last edited information from the `Revision` table"
         (is (= [{:name "AA"}

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -331,9 +331,9 @@
         (perms/grant-collection-read-permissions! (group/all-users) collection)
         (with-some-children-of-collection collection
           (is (= (map default-item [{:name "Acme Products", :model "pulse"}
-                                    {:name "Electro-Magnetic Pulse", :model "pulse"}
                                     {:name "Birthday Card", :description nil, :favorite false, :model "card", :display "table"}
-                                    {:name "Dine & Dashboard", :description nil, :favorite false, :model "dashboard"}])
+                                    {:name "Dine & Dashboard", :description nil, :favorite false, :model "dashboard"}
+                                    {:name "Electro-Magnetic Pulse", :model "pulse"}])
                  (mt/boolean-ids-and-timestamps
                   (:data (mt/user-http-request :rasta :get 200 (str "collection/" (u/the-id collection) "/items"))))))))
 
@@ -601,11 +601,11 @@
              (with-some-children-of-collection nil
                (mt/user-http-request :crowberto :get 200 "collection/root")))))
     (testing "Make sure you can see everything for Users that can see everything"
-      (is (= [(default-item {:name "Electro-Magnetic Pulse", :model "pulse"})
-              (default-item {:name "Birthday Card", :description nil, :favorite false, :model "card", :display "table"})
+      (is (= [(default-item {:name "Birthday Card", :description nil, :favorite false, :model "card", :display "table"})
               (collection-item "Crowberto Corv's Personal Collection")
               (default-item {:name "Dine & Dashboard",
-                             :favorite false, :description nil, :model "dashboard"}) ]
+                             :favorite false, :description nil, :model "dashboard"})
+              (default-item {:name "Electro-Magnetic Pulse", :model "pulse"}) ]
              (with-some-children-of-collection nil
                (-> (:data (mt/user-http-request :crowberto :get 200 "collection/root/items"))
                    (remove-non-test-items &ids)
@@ -635,9 +635,9 @@
             (mt/with-temp* [PermissionsGroup           [group]
                             PermissionsGroupMembership [_ {:user_id (mt/user->id :rasta), :group_id (u/the-id group)}]]
               (perms/grant-permissions! group (perms/collection-read-path {:metabase.models.collection.root/is-root? true}))
-              (is (= [(default-item {:name "Electro-Magnetic Pulse", :model "pulse"})
-                      (default-item {:name "Birthday Card", :description nil, :favorite false, :model "card", :display "table"})
+              (is (= [(default-item {:name "Birthday Card", :description nil, :favorite false, :model "card", :display "table"})
                       (default-item {:name "Dine & Dashboard", :description nil, :favorite false, :model "dashboard"})
+                      (default-item {:name "Electro-Magnetic Pulse", :model "pulse"})
                       (collection-item "Rasta Toucan's Personal Collection")]
                      (-> (:data (mt/user-http-request :rasta :get 200 "collection/root/items"))
                          (remove-non-test-items &ids)

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -1,7 +1,6 @@
 (ns metabase.api.collection-test
   "Tests for /api/collection endpoints."
-  (:require [clj-time.core :as time]
-            [clojure.string :as str]
+  (:require [clojure.string :as str]
             [clojure.test :refer :all]
             [metabase.models :refer [Card Collection Dashboard DashboardCard NativeQuerySnippet PermissionsGroup
                                      PermissionsGroupMembership Pulse PulseCard PulseChannel PulseChannelRecipient
@@ -17,7 +16,8 @@
             [metabase.test.fixtures :as fixtures]
             [metabase.util :as u]
             [schema.core :as s]
-            [toucan.db :as db]))
+            [toucan.db :as db])
+  (:import [java.time ZonedDateTime ZoneId]))
 
 (use-fixtures :once (fixtures/initialize :test-users-personal-collections))
 
@@ -374,12 +374,11 @@
                     Revision   [_revision2 {:model    "Card"
                                             :model_id card2-id
                                             :user_id  user-id
-                                            :timestamp (time/from-now (time/days -2))
                                             :object   (revision/serialize-instance card2 card2-id card2)}]]
       ;; need different timestamps and Revision has a pre-update to throw as they aren't editable
       (db/execute! {:update :revision
                     ;; in the past
-                    :set {:timestamp (.minusHours (java.time.OffsetDateTime/now) 24)}
+                    :set {:timestamp (.minusHours (ZonedDateTime/now (ZoneId/of "UTC")) 2)}
                     :where [:= :id (:id _revision1)]})
       (testing "Results include last edited information from the `Revision` table"
         (is (= [{:name "AA"}

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -361,17 +361,29 @@
                   (:data (mt/user-http-request :rasta :get 200 (str "collection/" (u/the-id collection) "/items?archived=true")))))))))
     (mt/with-temp* [Collection [{collection-id :id} {:name "Collection with Items"}]
                     User       [{user-id :id} {:first_name "Test" :last_name "User" :email "testuser@example.com"}]
-                    Card       [{card-id :id :as card}
-                                {:name "Card with history" :collection_id collection-id}]
+                    Card       [{card1-id :id :as card1}
+                                {:name "Card with history 1" :collection_id collection-id}]
+                    Card       [{card2-id :id :as card2}
+                                {:name "Card with history 2" :collection_id collection-id}]
                     Card       [_ {:name "ZZ" :collection_id collection-id}]
                     Card       [_ {:name "AA" :collection_id collection-id}]
-                    Revision   [_revision {:model    "Card"
-                                           :model_id card-id
-                                           :user_id  user-id
-                                           :object   (revision/serialize-instance card card-id card)}]]
+                    Revision   [_revision1 {:model    "Card"
+                                            :model_id card1-id
+                                            :user_id  user-id
+                                            :object   (revision/serialize-instance card1 card1-id card1)}]
+                    Revision   [_revision2 {:model    "Card"
+                                            :model_id card2-id
+                                            :user_id  user-id
+                                            :timestamp (time/from-now (time/days -2))
+                                            :object   (revision/serialize-instance card2 card2-id card2)}]]
+      ;; need different timestamps and Revision has a pre-update to throw as they aren't editable
+      (db/execute! {:update :revision
+                    ;; in the past
+                    :set {:timestamp "2021-05-01T12:34:56"}
+                    :where [:= :id (:id _revision1)]})
       (testing "Results include last edited information from the `Revision` table"
         (is (= [{:name "AA"}
-                {:name "Card with history",
+                {:name "Card with history 1",
                  :last-edit-info
                  {:id         true,
                   :email      "testuser@example.com",
@@ -379,15 +391,28 @@
                   :last_name  "User",
                   ;; timestamp collapsed to true, ordinarily a OffsetDateTime
                   :timestamp  true}}
+                {:name "Card with history 2",
+                 :last-edit-info
+                 {:id         true,
+                  :email      "testuser@example.com",
+                  :first_name "Test",
+                  :last_name  "User",
+                  :timestamp  true}}
                 {:name "ZZ"}]
                (->> (:data (mt/user-http-request :rasta :get 200 (str "collection/" collection-id "/items")))
                     mt/boolean-ids-and-timestamps
                     (map #(select-keys % [:name :last-edit-info]))))))
       (testing "Results can be ordered by last-edited"
-        (is (= ["Card with history" "AA" "ZZ"]
-               (->> (mt/user-http-request :rasta :get 200 (str "collection/" collection-id "/items?sort_column=last_edited&sort_direction=asc"))
-                    :data
-                    (map :name)))))
+        (testing "ascending"
+          (is (= ["Card with history 1" "Card with history 2" "AA" "ZZ"]
+                 (->> (mt/user-http-request :rasta :get 200 (str "collection/" collection-id "/items?sort_column=last_edited&sort_direction=asc"))
+                      :data
+                      (map :name)))))
+        (testing "descending"
+          (is (= ["Card with history 2" "Card with history 1" "AA" "ZZ"]
+                 (->> (mt/user-http-request :rasta :get 200 (str "collection/" collection-id "/items?sort_column=last_edited&sort_direction=desc"))
+                      :data
+                      (map :name))))))
       (testing "Results can be ordered by model"
         (mt/with-temp* [Collection [{collection-id :id} {:name "Collection with Items"}]
                         Card       [_ {:name "ZZ" :collection_id collection-id}]

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -379,7 +379,7 @@
       ;; need different timestamps and Revision has a pre-update to throw as they aren't editable
       (db/execute! {:update :revision
                     ;; in the past
-                    :set {:timestamp (.minusHours (java.time.OffsetDateTime/now) 2)}
+                    :set {:timestamp (.minusHours (java.time.OffsetDateTime/now) 24)}
                     :where [:= :id (:id _revision1)]})
       (testing "Results include last edited information from the `Revision` table"
         (is (= [{:name "AA"}


### PR DESCRIPTION
Collection pagination:

Metadata was already exposed but we needed to extend the paginated response of collection items to be able to:
- order by last-edited. This was added onto the results after the query for collection children so those fields had to be added into the query so they could be ordered on
- take in sort columns and sort directions. Previously was hard-coded to `:%lower.name :asc`, now the frontend can request `:last_edited :desc`, etc

Continuing backend work for https://github.com/metabase/metabase/issues/15773

Builds on top of https://github.com/metabase/metabase/pull/15718

### Frontend visible changes:

New Parameters:
- `sort_column`: one of `["name", "last_edited", "model"]`
- `sort_direction`: one of `["asc", "desc"]`

<details><summary>GET /api/collection/root/items?models=dashboard&models=card&models=snippet&models=pulse&pinned_state=is_not_pinned&limit=4&offset=0&sort_column=last_edited&sort_direction=asc</summary>

This example uses a page size of 4 to keep it small

```js
{
  "total": 18,
  "data": [
    {
      "description": null,
      "collection_position": null,
      "name": "Orders",
      "id": 9,
      "display": "table",
      "last-edit-info": {
        "id": 1,
        "last_name": "sutton",
        "first_name": "dan",
        "email": "dan@metabase.com",
        "timestamp": "2021-03-16T19:52:53.797014Z"
      },
      "model": "card"
    },
    {
      "description": null,
      "collection_position": null,
      "name": "Orders indeed",
      "id": 10,
      "display": "table",
      "last-edit-info": {
        "id": 1,
        "last_name": "sutton",
        "first_name": "dan",
        "email": "dan@metabase.com",
        "timestamp": "2021-03-16T21:27:24.343321Z"
      },
      "model": "card"
    },
    {
      "description": null,
      "collection_position": null,
      "name": "Orders, Count, Grouped by Created At (month)",
      "id": 11,
      "display": "line",
      "last-edit-info": {
        "id": 1,
        "last_name": "sutton",
        "first_name": "dan",
        "email": "dan@metabase.com",
        "timestamp": "2021-03-18T14:33:02.335656Z"
      },
      "model": "card"
    },
    {
      "description": null,
      "collection_position": null,
      "name": "Products",
      "id": 14,
      "display": "table",
      "last-edit-info": {
        "id": 1,
        "last_name": "sutton",
        "first_name": "dan",
        "email": "dan@metabase.com",
        "timestamp": "2021-03-22T20:30:40.962413Z"
      },
      "model": "card"
    }
  ],
  "limit": 4,
  "offset": 0,
  "models": [
    "card",
    "dashboard",
    "pulse"
  ]
}
```
</details>

I suspect we may need to change a bit of how the columns and sort direction are specified but this lets us unblock the FE work.

## Backend changes

- Had to move all of the post-processed last-edit-info columns into the `collection-children-query`
- removed all of the "backfilled" columns from all of the queries; those child queries only need to select the queries they care about
- automatically backfill the columns necessary into all queries so the union can succeed and you don't have to do it manually
- comment form that computes the columns to backfill, and those are a literal. Don't want to throw an error during reading that computes those.
- have to include type information on the non-text columns. Mysql and h2 can union `select 1, null union select null "text"` figuring out (or not caring?) what the type of the nulls are. Postgres needs this type. This means that `metabase.db.env/db-type` leaks into this namespace so we can optionally add these casts
- We need to do batch post-processing so the group-by is necessary but this scrambles our sort order. Annotate before grouping with index so we can maintain the database sorting