### PR TITLE
Upgrade devcontainer to Java 11

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/vscode/devcontainers/java:0-8
+FROM mcr.microsoft.com/vscode/devcontainers/java:11
 
 RUN apt-key adv --refresh-keys --keyserver keyserver.ubuntu.com\
   && apt-get update && export DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
Upgrading to have the same Java version for development among all Dockerfiles