### PR TITLE
fix missing singular form for the total people number

### DIFF
--- a/frontend/src/metabase/admin/people/components/PeopleList.jsx
+++ b/frontend/src/metabase/admin/people/components/PeopleList.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
-import { t } from "ttag";
+import { t, ngettext, msgid } from "ttag";
 import moment from "moment";
 import _ from "underscore";
 
@@ -219,7 +219,13 @@ export default class PeopleList extends Component {
 
         {hasUsers && (
           <div className="flex align-center justify-between p2">
-            <div className="text-medium text-bold">{t`${total} people found`}</div>
+            <div className="text-medium text-bold">
+              {ngettext(
+                msgid`${total} person found`,
+                `${total} people found`,
+                total,
+              )}
+            </div>
             <PaginationControls
               page={page}
               pageSize={pageSize}

--- a/frontend/test/metabase/scenarios/admin/people/people.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/people/people.cy.spec.js
@@ -190,7 +190,7 @@ describe("scenarios > admin > people", () => {
       assertTableRowsCount(5);
 
       cy.findByPlaceholderText("Find someone").type("ne");
-      cy.findByText("1 people found");
+      cy.findByText("1 person found");
       assertTableRowsCount(1);
 
       cy.findByPlaceholderText("Find someone").clear();


### PR DESCRIPTION
### Description

Add a singular form for the total people number on the people management page:
<img width="486" alt="Screen Shot 2021-05-28 at 07 07 13" src="https://user-images.githubusercontent.com/14301985/119928004-56094080-bf83-11eb-884a-a2d4a98da1e9.png">

