### PR TITLE
#16273 Repro: Relative date filter applied to the custom column doesn't work

### DIFF
--- a/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
@@ -692,4 +692,34 @@ describe("scenarios > question > custom columns", () => {
     cy.contains("37.65");
     cy.findByText("No discount");
   });
+
+  it.skip("should work with relative date filter applied to a custom column (metabase#16273)", () => {
+    cy.intercept("POST", "/api/dataset").as("dataset");
+
+    openOrdersTable({ mode: "notebook" });
+    cy.findByText("Custom column").click();
+    popover().within(() => {
+      cy.get("[contenteditable='true']")
+        .type("case([Discount] >0, [Created At], [Product → Created At])")
+        .blur();
+      cy.findByPlaceholderText("Something nice and descriptive").type(
+        "MiscDate",
+      );
+      cy.button("Done").click();
+    });
+    cy.findByText("Filter").click();
+    popover()
+      .contains("MiscDate")
+      .click();
+    // The popover shows up with the default value selected - previous 30 days.
+    // Since we don't have any orders in the Sample Dataset for that period, we have to change it to the previous 30 years.
+    cy.findByText("Days").click();
+    cy.findByText("Years").click();
+    cy.button("Add filter").click();
+    cy.button("Visualize").click();
+    cy.wait("@dataset").then(interception => {
+      expect(interception.response.body.error).not.to.exist;
+    });
+    cy.findByText("MiscDate");
+  });
 });


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #16273 

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/question/custom_column.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/119988654-9dfd8700-bfc6-11eb-9d2c-d65a3ee3337f.png)

