### PR TITLE
Cleanup from dump-load-entities-test

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/serialization/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/load_test.clj
@@ -359,4 +359,4 @@
                     (str " failed " (pr-str entity)))))
             fingerprint))))
     (finally
-      #_(delete-directory! dump-dir))))
+      (delete-directory! dump-dir))))


### PR DESCRIPTION
Updating dump-load-entities-test test so that dump dir is actually deleted at the end
