### PR TITLE
Create composite Cypress custom command `cy.createQuestionAndDashboard`

### DIFF
--- a/frontend/test/__support__/e2e/commands.js
+++ b/frontend/test/__support__/e2e/commands.js
@@ -4,6 +4,8 @@ import "./commands/ui/icon";
 import "./commands/api/question";
 import "./commands/api/dashboard";
 
+import "./commands/api/composite/createQuestionAndDashboard";
+
 import "./commands/user/createUser";
 import "./commands/user/authentication";
 

--- a/frontend/test/__support__/e2e/commands/api/composite/createQuestionAndDashboard.js
+++ b/frontend/test/__support__/e2e/commands/api/composite/createQuestionAndDashboard.js
@@ -1,0 +1,14 @@
+Cypress.Commands.add(
+  "createQuestionAndDashboard",
+  ({ questionDetails, dashboardName = "Custom dashboard" } = {}) => {
+    cy.createQuestion(questionDetails).then(({ body: { id: questionId } }) => {
+      cy.createDashboard(dashboardName).then(
+        ({ body: { id: dashboardId } }) => {
+          cy.request("POST", `/api/dashboard/${dashboardId}/cards`, {
+            cardId: questionId,
+          });
+        },
+      );
+    });
+  },
+);

--- a/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
@@ -321,6 +321,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
       cy.findByText("Rating is equal to 2 selections");
       cy.contains("Reprehenderit non error"); // xavier's review
     });
+
     it("when clicking on the card title (metabase#13062-2)", () => {
       cy.findByText(questionDetails.name).click();
       cy.findByText("Rating is equal to 2 selections");

--- a/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
@@ -257,26 +257,26 @@ describe("scenarios > dashboard > dashboard drill", () => {
       .within(() => cy.findByText("foo"));
   });
 
-  ["field value", "card title"].forEach(testCase => {
-    it(`should pass multiple filters for numeric column on drill-through the ${testCase} (metabase#13062)`, () => {
+  describe("should pass multiple filters for numeric column on drill-through (metabase#13062)", () => {
+    const questionDetails = {
+      name: "13062Q",
+      query: {
+        "source-table": REVIEWS_ID,
+      },
+    };
+
+    const filter = {
+      id: "18024e69",
+      name: "Category",
+      slug: "category",
+      type: "category",
+    };
+
+    beforeEach(() => {
       // Set "Rating" Field type to: "Category"
       cy.request("PUT", `/api/field/${REVIEWS.RATING}`, {
         semantic_type: "type/Category",
       });
-
-      const questionDetails = {
-        name: "13062Q",
-        query: {
-          "source-table": REVIEWS_ID,
-        },
-      };
-
-      const filter = {
-        id: "18024e69",
-        name: "Category",
-        slug: "category",
-        type: "category",
-      };
 
       cy.createQuestionAndDashboard({ questionDetails }).then(
         ({ body: { id, card_id, dashboard_id } }) => {
@@ -311,22 +311,20 @@ describe("scenarios > dashboard > dashboard drill", () => {
           cy.findByText("2 selections");
         },
       );
+    });
 
-      // Drill-throughs for each of the cases
-      if (testCase === "field value") {
-        cy.findByText("xavier").click();
-        cy.findByText("=").click();
+    it("when clicking on the field value (metabase#13062-1)", () => {
+      cy.findByText("xavier").click();
+      cy.findByText("=").click();
 
-        cy.findByText("Reviewer is xavier");
-        cy.findByText("Rating is equal to 2 selections");
-        cy.contains("Reprehenderit non error"); // xavier's review
-      }
-
-      if (testCase === "card title") {
-        cy.findByText(questionDetails.name).click();
-        cy.findByText("Rating is equal to 2 selections");
-        cy.contains("Ad perspiciatis quis et consectetur."); // 5 star review
-      }
+      cy.findByText("Reviewer is xavier");
+      cy.findByText("Rating is equal to 2 selections");
+      cy.contains("Reprehenderit non error"); // xavier's review
+    });
+    it("when clicking on the card title (metabase#13062-2)", () => {
+      cy.findByText(questionDetails.name).click();
+      cy.findByText("Rating is equal to 2 selections");
+      cy.contains("Ad perspiciatis quis et consectetur."); // 5 star review
     });
   });
 

--- a/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
@@ -257,89 +257,76 @@ describe("scenarios > dashboard > dashboard drill", () => {
       .within(() => cy.findByText("foo"));
   });
 
-  it("should pass multiple filters for numeric column on drill-through (metabase#13062)", () => {
-    // Preparation for the test: "Arrange and Act phase" - see repro steps in #13062
-    // 1. set "Rating" Field type to: "Category"
+  ["field value", "card title"].forEach(testCase => {
+    it(`should pass multiple filters for numeric column on drill-through the ${testCase} (metabase#13062)`, () => {
+      // Set "Rating" Field type to: "Category"
+      cy.request("PUT", `/api/field/${REVIEWS.RATING}`, {
+        semantic_type: "type/Category",
+      });
 
-    cy.request("PUT", `/api/field/${REVIEWS.RATING}`, {
-      semantic_type: "type/Category",
-    });
-    // 2. create a question based on Reviews
-    cy.request("POST", `/api/card`, {
-      name: "13062Q",
-      dataset_query: {
-        database: 1,
+      const questionDetails = {
+        name: "13062Q",
         query: {
           "source-table": REVIEWS_ID,
         },
-        type: "query",
-      },
-      display: "table",
-      visualization_settings: {},
-    }).then(({ body: { id: questionId } }) => {
-      cy.createDashboard("13062D").then(({ body: { id: dashboardId } }) => {
-        // add filter to the dashboard
-        cy.request("PUT", `/api/dashboard/${dashboardId}`, {
-          parameters: [
-            {
-              id: "18024e69",
-              name: "Category",
-              slug: "category",
-              type: "category",
-            },
-          ],
-        });
+      };
 
-        // add previously created question to the dashboard
-        cy.request("POST", `/api/dashboard/${dashboardId}/cards`, {
-          cardId: questionId,
-        }).then(({ body: { id: dashCardId } }) => {
-          // connect filter to that question
-          cy.request("PUT", `/api/dashboard/${dashboardId}/cards`, {
+      const filter = {
+        id: "18024e69",
+        name: "Category",
+        slug: "category",
+        type: "category",
+      };
+
+      cy.createQuestionAndDashboard({ questionDetails }).then(
+        ({ body: { id, card_id, dashboard_id } }) => {
+          // Add filter to the dashboard
+          cy.request("PUT", `/api/dashboard/${dashboard_id}`, {
+            parameters: [filter],
+          });
+
+          // Connect filter to the dashboard card
+          cy.request("PUT", `/api/dashboard/${dashboard_id}/cards`, {
             cards: [
               {
-                id: dashCardId,
-                card_id: questionId,
+                id,
+                card_id,
                 row: 0,
                 col: 0,
                 sizeX: 8,
                 sizeY: 6,
                 parameter_mappings: [
                   {
-                    parameter_id: "18024e69",
-                    card_id: questionId,
+                    parameter_id: filter.id,
+                    card_id,
                     target: ["dimension", ["field", REVIEWS.RATING, null]],
                   },
                 ],
               },
             ],
           });
-        });
 
-        // NOTE: The actual "Assertion" phase begins here
-        cy.log("Reported failing on Metabase 1.34.3 and 0.36.2");
+          // set filter values (ratings 5 and 4) directly through the URL
+          cy.visit(`/dashboard/${dashboard_id}?category=5&category=4`);
+          cy.findByText("2 selections");
+        },
+      );
 
-        cy.log("The first case");
-        // set filter values (ratings 5 and 4) directly through the URL
-        cy.visit(`/dashboard/${dashboardId}?category=5&category=4`);
-
-        // drill-through
+      // Drill-throughs for each of the cases
+      if (testCase === "field value") {
         cy.findByText("xavier").click();
         cy.findByText("=").click();
 
         cy.findByText("Reviewer is xavier");
         cy.findByText("Rating is equal to 2 selections");
         cy.contains("Reprehenderit non error"); // xavier's review
+      }
 
-        cy.log("The second case");
-        // go back to the dashboard
-        cy.visit(`/dashboard/${dashboardId}?category=5&category=4`);
-        cy.findByText("2 selections");
-
-        cy.findByText("13062Q").click(); // the card title
+      if (testCase === "card title") {
+        cy.findByText(questionDetails.name).click();
         cy.findByText("Rating is equal to 2 selections");
         cy.contains("Ad perspiciatis quis et consectetur."); // 5 star review
-      });
+      }
     });
   });
 

--- a/frontend/test/metabase/scenarios/visualizations/gauge.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/gauge.cy.spec.js
@@ -7,42 +7,39 @@ describe("scenarios > visualizations > gauge chart", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
-    cy.intercept("POST", "/api/dataset").as("dataset");
+    cy.intercept(`/api/card/*/query`).as("cardQuery");
   });
 
   it("should not rerender on gauge arc hover (metabase#15980)", () => {
-    cy.createQuestion({
+    const questionDetails = {
       name: "15980",
       query: { "source-table": ORDERS_ID, aggregation: [["count"]] },
       display: "gauge",
-    }).then(({ body: { id: questionId } }) => {
-      cy.createDashboard("15980D").then(({ body: { id: dashboardId } }) => {
-        // Add previously created question to the dashboard
-        cy.request("POST", `/api/dashboard/${dashboardId}/cards`, {
-          cardId: questionId,
-        }).then(({ body: { id: dashCardId } }) => {
-          // Make dashboard card really small (necessary for this repro as it doesn't show any labels)
-          cy.request("PUT", `/api/dashboard/${dashboardId}/cards`, {
-            cards: [
-              {
-                id: dashCardId,
-                card_id: questionId,
-                row: 0,
-                col: 0,
-                sizeX: 4,
-                sizeY: 4,
-                parameter_mappings: [],
-              },
-            ],
-          });
-        });
-        cy.intercept(`/api/card/${questionId}/query`).as("cardQuery");
+    };
 
-        cy.visit(`/dashboard/${dashboardId}`);
-        cy.wait("@cardQuery");
-        cy.findByTestId("gauge-arc-1").trigger("mousemove");
-        cy.findByText("Something went wrong").should("not.exist");
-      });
-    });
+    cy.createQuestionAndDashboard({ questionDetails }).then(
+      ({ body: { id, card_id, dashboard_id } }) => {
+        // Make dashboard card really small (necessary for this repro as it doesn't show any labels)
+        cy.request("PUT", `/api/dashboard/${dashboard_id}/cards`, {
+          cards: [
+            {
+              id,
+              card_id,
+              row: 0,
+              col: 0,
+              sizeX: 4,
+              sizeY: 4,
+              parameter_mappings: [],
+            },
+          ],
+        });
+
+        cy.visit(`/dashboard/${dashboard_id}`);
+      },
+    );
+
+    cy.wait("@cardQuery");
+    cy.findByTestId("gauge-arc-1").trigger("mousemove");
+    cy.findByText("Something went wrong").should("not.exist");
   });
 });


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Abstracts away 3 chained API calls that need to happen around creating new question, new dashboard and initially* adding previously created question to the dashboard
- Refactors one existing [simpler](https://github.com/metabase/metabase/pull/16294/commits/7ead7fecf04f322fd0e0487fe50cf8314c3b203f) test using this hew command to show how it's used and (more importantly) to show the command is working as intended
- Refactors one more [complex](https://github.com/metabase/metabase/pull/16294/commits/2e53df9c57fd92d3513092457db7a37ee3f44ad1) existing test using this command

### How to verify this is working?
- All tests should pass in CI

### Additional info
- In the simplest possible form, you can safely pass only the question details to this command (the same ones you'd pass to the `cy.createQuestion`)
- This command is "thenable". The response body contains all ids and info we need for any of the tests (for any of the subsequent requests)
```javascript
// The simplest possible scenario (adding "Orders" saved as question to the dashboard)
const questionDetails = {
  query: { "source-table": ORDERS_ID },
};

cy.createQuestionAndDashboard({ questionDetails }).then(({ body }) => {
  console.log(body);
});

// response body will look like this:
{
  card_id: 4, // question's id
  col: 0,
  created_at: "2021-05-31T09:31:48.586",
  dashboard_id: 2,
  id: 2, // dashboard card's id
  parameter_mappings: [],
  row: 0,
  series: [],
  sizeX: 2, // see: https://github.com/metabase/metabase/issues/16293
  sizeY: 2,
  updated_at: "2021-05-31T09:31:48.586",
  visualization_settings: {},
}

// knowing this, we can easily desctructure the response body to be able to use these ids in the rest of the test
cy.createQuestionAndDashboard({ questionDetails }).then(
  ({ body: { id, card_id, dashboard_id } }) => {
    // the rest of the test
  });
});

```
### Quirks / notes

*Why I used the word initially? The UI equivalent of this would be:
1. create new dashboard, save it
2. create new question, save it
3. edit the dashboard
4. choose previously created question and add it to the dashboard **without saving the dashboard** (that part happens in the completely separate request)

- The name of the function is a bit misleading, because we're not _fully_ adding the question to the dashboard. There needs to be one more step to "finalize" that process (dashboard needs to be saved). That happens in the `PUT` request after this command. However, I believe it's good enough for now. Things might change depending on how #16293 gets resolved.
- Ideally, this custom command (these 3 requests) will actually save added question in the future. 