### PR TITLE
Fix database docs card style, add in-out animation

### DIFF
--- a/frontend/src/metabase/components/AddDatabaseHelpCard.jsx
+++ b/frontend/src/metabase/components/AddDatabaseHelpCard.jsx
@@ -38,7 +38,7 @@ const defaultProps = {
   style: {},
 };
 
-function AddDatabaseHelpCard({ engine, hasCircle, style, ...props }) {
+function AddDatabaseHelpCard({ engine, hasCircle, ...props }) {
   const displayName = useMemo(() => {
     const hasEngineDoc = !!ENGINE_DOCS[engine];
     if (!hasEngineDoc) {

--- a/frontend/src/metabase/components/AddDatabaseHelpCard.jsx
+++ b/frontend/src/metabase/components/AddDatabaseHelpCard.jsx
@@ -34,15 +34,9 @@ export const CLOUD_HELP_URL = "https://www.metabase.com/help/cloud";
 const propTypes = {
   engine: PropTypes.string.isRequired,
   hasCircle: PropTypes.bool,
-  style: PropTypes.object,
 };
 
-const defaultProps = {
-  hasCircle: true,
-  style: {},
-};
-
-function AddDatabaseHelpCard({ engine, hasCircle, ...props }) {
+function AddDatabaseHelpCard({ engine, hasCircle = true, ...props }) {
   const displayName = useMemo(() => {
     const hasEngineDoc = !!ENGINE_DOCS[engine];
     if (!hasEngineDoc) {
@@ -96,6 +90,5 @@ function AddDatabaseHelpCard({ engine, hasCircle, ...props }) {
 }
 
 AddDatabaseHelpCard.propTypes = propTypes;
-AddDatabaseHelpCard.defaultProps = defaultProps;
 
 export default AddDatabaseHelpCard;

--- a/frontend/src/metabase/components/AddDatabaseHelpCard.jsx
+++ b/frontend/src/metabase/components/AddDatabaseHelpCard.jsx
@@ -1,7 +1,5 @@
 import React, { useMemo } from "react";
 import PropTypes from "prop-types";
-import styled from "styled-components";
-import { Flex } from "grid-styled";
 
 import { t, jt } from "ttag";
 
@@ -9,6 +7,12 @@ import MetabaseSettings from "metabase/lib/settings";
 
 import ExternalLink from "metabase/components/ExternalLink";
 import Icon from "metabase/components/Icon";
+
+import {
+  CardContent,
+  HelpCardContainer,
+  IconContainer,
+} from "./AddDatabaseHelpCard.styled";
 
 export const ENGINE_DOCS = {
   bigquery: MetabaseSettings.docsUrl("administration-guide/databases/bigquery"),
@@ -93,21 +97,5 @@ function AddDatabaseHelpCard({ engine, hasCircle, ...props }) {
 
 AddDatabaseHelpCard.propTypes = propTypes;
 AddDatabaseHelpCard.defaultProps = defaultProps;
-
-const HelpCardContainer = styled(Flex)`
-  background-color: #f9fbfb;
-  border-radius: 10px;
-  min-width: 300px;
-`;
-
-const IconContainer = styled(Flex)`
-  width: ${props => (props.hasCircle ? "52px" : "32px")};
-  height: ${props => (props.hasCircle ? "52px" : "32px")};
-  background-color: ${props => (props.hasCircle ? "#EEF2F5" : "transparent")};
-`;
-
-const CardContent = styled(Flex)`
-  margin-top: ${props => (props.shouldDisplayHelpLink ? "8px" : 0)};
-`;
 
 export default AddDatabaseHelpCard;

--- a/frontend/src/metabase/components/AddDatabaseHelpCard.styled.js
+++ b/frontend/src/metabase/components/AddDatabaseHelpCard.styled.js
@@ -1,0 +1,18 @@
+import styled from "styled-components";
+import { Flex } from "grid-styled";
+
+export const CardContent = styled(Flex)`
+  margin-top: ${props => (props.shouldDisplayHelpLink ? "8px" : 0)};
+`;
+
+export const HelpCardContainer = styled(Flex)`
+  background-color: #f9fbfb;
+  border-radius: 10px;
+  min-width: 300px;
+`;
+
+export const IconContainer = styled(Flex)`
+  width: ${props => (props.hasCircle ? "52px" : "32px")};
+  height: ${props => (props.hasCircle ? "52px" : "32px")};
+  background-color: ${props => (props.hasCircle ? "#EEF2F5" : "transparent")};
+`;

--- a/frontend/src/metabase/setup/components/Setup.jsx
+++ b/frontend/src/metabase/setup/components/Setup.jsx
@@ -18,7 +18,7 @@ import LanguageStep from "./LanguageStep";
 import UserStep from "./UserStep";
 import DatabaseConnectionStep from "./DatabaseConnectionStep";
 import PreferencesStep from "./PreferencesStep";
-import {AddDatabaseHelpCardHolder} from "./Setup.styled"
+import { AddDatabaseHelpCardHolder } from "./Setup.styled";
 
 const WELCOME_STEP_NUMBER = 0;
 const LANGUAGE_STEP_NUMBER = 1;

--- a/frontend/src/metabase/setup/components/Setup.jsx
+++ b/frontend/src/metabase/setup/components/Setup.jsx
@@ -2,7 +2,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { t } from "ttag";
-import styled from "styled-components";
 
 import { color } from "metabase/lib/colors";
 import MetabaseAnalytics from "metabase/lib/analytics";
@@ -13,11 +12,13 @@ import ExternalLink from "metabase/components/ExternalLink";
 import LogoIcon from "metabase/components/LogoIcon";
 import NewsletterForm from "metabase/components/NewsletterForm";
 
+import DatabaseSchedulingStep from "metabase/setup/components/DatabaseSchedulingStep";
+
 import LanguageStep from "./LanguageStep";
 import UserStep from "./UserStep";
 import DatabaseConnectionStep from "./DatabaseConnectionStep";
 import PreferencesStep from "./PreferencesStep";
-import DatabaseSchedulingStep from "metabase/setup/components/DatabaseSchedulingStep";
+import {AddDatabaseHelpCardHolder} from "./Setup.styled"
 
 const WELCOME_STEP_NUMBER = 0;
 const LANGUAGE_STEP_NUMBER = 1;
@@ -25,15 +26,6 @@ const USER_STEP_NUMBER = 2;
 const DATABASE_CONNECTION_STEP_NUMBER = 3;
 const DATABASE_SCHEDULING_STEP_NUMBER = 4;
 const PREFERENCES_STEP_NUMBER = 5;
-
-const AddDatabaseHelpCardHolder = styled.div`
-  position: fixed;
-  left: 1em;
-  bottom: 1em;
-  transform: translateY(200%);
-  transition: all 0.4s;
-  ${props => (props.isVisible ? "transform: translateY(0);" : "")}
-`;
 
 export default class Setup extends Component {
   static propTypes = {

--- a/frontend/src/metabase/setup/components/Setup.jsx
+++ b/frontend/src/metabase/setup/components/Setup.jsx
@@ -2,6 +2,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { t } from "ttag";
+import styled from "styled-components";
 
 import { color } from "metabase/lib/colors";
 import MetabaseAnalytics from "metabase/lib/analytics";
@@ -24,6 +25,12 @@ const USER_STEP_NUMBER = 2;
 const DATABASE_CONNECTION_STEP_NUMBER = 3;
 const DATABASE_SCHEDULING_STEP_NUMBER = 4;
 const PREFERENCES_STEP_NUMBER = 5;
+
+const AddDatabaseHelpCardHolder = styled.div`
+  position: fixed;
+  left: 1em;
+  bottom: 1em;
+`;
 
 export default class Setup extends Component {
   static propTypes = {
@@ -199,13 +206,7 @@ export default class Setup extends Component {
 
           {selectedDatabaseEngine &&
             activeStep === DATABASE_CONNECTION_STEP_NUMBER && (
-              <div
-                style={{
-                  position: "fixed",
-                  left: "1em",
-                  bottom: "1em",
-                }}
-              >
+              <AddDatabaseHelpCardHolder>
                 <AddDatabaseHelpCard
                   engine={selectedDatabaseEngine}
                   hasCircle={false}
@@ -215,7 +216,7 @@ export default class Setup extends Component {
                     backgroundColor: color("white"),
                   }}
                 />
-              </div>
+              </AddDatabaseHelpCardHolder>
             )}
         </div>
       );

--- a/frontend/src/metabase/setup/components/Setup.jsx
+++ b/frontend/src/metabase/setup/components/Setup.jsx
@@ -3,6 +3,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { t } from "ttag";
 
+import { color } from "metabase/lib/colors";
 import MetabaseAnalytics from "metabase/lib/analytics";
 import MetabaseSettings from "metabase/lib/settings";
 
@@ -210,8 +211,8 @@ export default class Setup extends Component {
                   hasCircle={false}
                   data-testid="database-setup-help-card"
                   style={{
-                    border: "1px solid #F0F0F0",
-                    backgroundColor: "#FFF",
+                    border: `1px solid ${color("border")}`,
+                    backgroundColor: color("white"),
                   }}
                 />
               </div>

--- a/frontend/src/metabase/setup/components/Setup.jsx
+++ b/frontend/src/metabase/setup/components/Setup.jsx
@@ -30,6 +30,9 @@ const AddDatabaseHelpCardHolder = styled.div`
   position: fixed;
   left: 1em;
   bottom: 1em;
+  transform: translateY(200%);
+  transition: all 0.4s;
+  ${props => (props.isVisible ? "transform: translateY(0);" : "")}
 `;
 
 export default class Setup extends Component {
@@ -116,6 +119,9 @@ export default class Setup extends Component {
       selectedDatabaseEngine,
       userDetails,
     } = this.props;
+
+    const isDatabaseHelpCardVisible =
+      selectedDatabaseEngine && activeStep === DATABASE_CONNECTION_STEP_NUMBER;
 
     if (activeStep === WELCOME_STEP_NUMBER) {
       return (
@@ -204,20 +210,17 @@ export default class Setup extends Component {
             </div>
           </div>
 
-          {selectedDatabaseEngine &&
-            activeStep === DATABASE_CONNECTION_STEP_NUMBER && (
-              <AddDatabaseHelpCardHolder>
-                <AddDatabaseHelpCard
-                  engine={selectedDatabaseEngine}
-                  hasCircle={false}
-                  data-testid="database-setup-help-card"
-                  style={{
-                    border: `1px solid ${color("border")}`,
-                    backgroundColor: color("white"),
-                  }}
-                />
-              </AddDatabaseHelpCardHolder>
-            )}
+          <AddDatabaseHelpCardHolder isVisible={isDatabaseHelpCardVisible}>
+            <AddDatabaseHelpCard
+              engine={selectedDatabaseEngine}
+              hasCircle={false}
+              data-testid="database-setup-help-card"
+              style={{
+                border: `1px solid ${color("border")}`,
+                backgroundColor: color("white"),
+              }}
+            />
+          </AddDatabaseHelpCardHolder>
         </div>
       );
     }

--- a/frontend/src/metabase/setup/components/Setup.styled.js
+++ b/frontend/src/metabase/setup/components/Setup.styled.js
@@ -1,0 +1,10 @@
+import styled from "styled-components";
+
+export const AddDatabaseHelpCardHolder = styled.div`
+  position: fixed;
+  left: 1em;
+  bottom: 1em;
+  transform: translateY(200%);
+  transition: all 0.4s;
+  ${props => (props.isVisible ? "transform: translateY(0);" : "")}
+`;

--- a/frontend/test/metabase/scenarios/onboarding/setup/setup.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/setup/setup.cy.spec.js
@@ -91,14 +91,14 @@ describe("scenarios > setup", () => {
       });
 
       // test database setup help card is NOT displayed before DB is selected
-      cy.findByTestId("database-setup-help-card").should("not.exist");
+      cy.findByTestId("database-setup-help-card").should("not.be.visible");
 
       // test that you can return to user settings if you want
       cy.findByText("Hi, Testy. Nice to meet you!").click();
       cy.findByLabelText("Email").should("have.value", "testy@metabase.com");
 
       // test database setup help card is NOT displayed on other steps
-      cy.findByTestId("database-setup-help-card").should("not.exist");
+      cy.findByTestId("database-setup-help-card").should("not.be.visible");
 
       // now back to database setting
       cy.findByText("Next").click();

--- a/frontend/test/metabase/scenarios/onboarding/setup/setup.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/setup/setup.cy.spec.js
@@ -151,6 +151,9 @@ describe("scenarios > setup", () => {
       cy.findByText("Never, I'll do this manually if I need to").click();
       cy.findByText("Next").click();
 
+      // test database setup help card is hidden on the next step
+      cy.findByTestId("database-setup-help-card").should("not.be.visible");
+
       // ================
       // Data Preferences
       // ================


### PR DESCRIPTION
This PR fixes the incorrect style of a card linking to the database adding docs we display during the initial Metabase setup (added at #16018). Also, adds a nice slide in-out animation for the card on the Setup page.

### To Verify
1. Launch clean Metabase instance
2. Select language, fill in user account info
3. Select database engine
4. Ensure the card slides in from the bottom and has a white background
5. Return to the previous step or proceed to the next one
6. Ensure the card slides out to the bottom

### Demo

**Before**

No animation here, notice card's background is the same as the whole background
<img width="1500" alt="Screenshot 2021-06-01 at 13 16 01" src="https://user-images.githubusercontent.com/17258145/120307996-491a8300-c2dc-11eb-8a15-b084a5cedec3.png">

**After**

https://user-images.githubusercontent.com/17258145/120308201-7ff09900-c2dc-11eb-9541-92294be70ee9.mov
