### PR TITLE
Ignore unmapped groups during SSO group syncs

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/enhancements/integrations/ldap.clj
+++ b/enterprise/backend/src/metabase_enterprise/enhancements/integrations/ldap.clj
@@ -68,8 +68,12 @@
                    :login_attributes attributes}))]
     (u/prog1 user
       (when sync-groups?
-        (let [group-ids (default-impl/ldap-groups->mb-group-ids groups settings)]
-          (integrations.common/sync-group-memberships! user group-ids (ldap-sync-admin-group)))))))
+        (let [group-ids            (default-impl/ldap-groups->mb-group-ids groups settings)
+              all-mapped-group-ids (default-impl/all-mapped-group-ids settings)]
+          (integrations.common/sync-group-memberships! user
+                                                       group-ids
+                                                       all-mapped-group-ids
+                                                       (ldap-sync-admin-group)))))))
 
 (def ^:private impl
   (reify

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
@@ -50,7 +50,7 @@
   (when (sso-settings/jwt-group-sync)
     (when-let [groups-attribute (jwt-attribute-groups)]
       (when-let [group-names (get jwt-data (jwt-attribute-groups))]
-        (integrations.common/sync-group-memberships! user (group-names->ids group-names) false)))))
+        (integrations.common/sync-group-memberships! user (group-names->ids group-names) #{} false)))))
 
 (defn- login-jwt-user
   [jwt {{redirect :return_to} :params, :as request}]

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
@@ -56,8 +56,9 @@
       flatten
       set))
 
-(defn- sync-groups! [user jwt-data]
+(defn- sync-groups!
   "Sync a user's groups based on mappings configured in the JWT settings"
+  [user jwt-data]
   (when (sso-settings/jwt-group-sync)
     (when-let [groups-attribute (jwt-attribute-groups)]
       (when-let [group-names (get jwt-data (jwt-attribute-groups))]

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
@@ -42,15 +42,29 @@
 ;; used by Zendesk for their JWT SSO, so it seemed like a good place for us to start
 (def ^:private ^:const three-minutes-in-seconds 180)
 
-(defn- group-names->ids [group-names]
+(defn- group-names->ids
+  "Translate a user's group names to a set of MB group IDs using the configured mappings"
+  [group-names]
   (set (mapcat (sso-settings/jwt-group-mappings)
                (map keyword group-names))))
 
+(defn- all-mapped-group-ids
+  "Returns the set of all MB group IDs that have configured mappings"
+  []
+  (-> (sso-settings/jwt-group-mappings)
+      vals
+      flatten
+      set))
+
 (defn- sync-groups! [user jwt-data]
+  "Sync a user's groups based on mappings configured in the JWT settings"
   (when (sso-settings/jwt-group-sync)
     (when-let [groups-attribute (jwt-attribute-groups)]
       (when-let [group-names (get jwt-data (jwt-attribute-groups))]
-        (integrations.common/sync-group-memberships! user (group-names->ids group-names) #{} false)))))
+        (integrations.common/sync-group-memberships! user
+                                                     (group-names->ids group-names)
+                                                     (all-mapped-group-ids)
+                                                     false)))))
 
 (defn- login-jwt-user
   [jwt {{redirect :return_to} :params, :as request}]

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
@@ -53,8 +53,9 @@
       flatten
       set))
 
-(defn- sync-groups! [user group-names]
+(defn- sync-groups!
   "Sync a user's groups based on mappings configured in the SAML settings"
+  [user group-names]
   (when (sso-settings/saml-group-sync)
     (when group-names
       (integrations.common/sync-group-memberships! user

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
@@ -46,7 +46,7 @@
 (defn- sync-groups! [user group-names]
   (when (sso-settings/saml-group-sync)
     (when group-names
-      (integrations.common/sync-group-memberships! user (group-names->ids group-names) false))))
+      (integrations.common/sync-group-memberships! user (group-names->ids group-names) #{} false))))
 
 (s/defn ^:private fetch-or-create-user! :- (s/maybe {:id UUID, s/Keyword s/Any})
   "Returns a Session for the given `email`. Will create the user if needed."

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
@@ -37,16 +37,30 @@
             [schema.core :as s])
   (:import java.util.UUID))
 
-(defn- group-names->ids [group-names]
+(defn- group-names->ids
+  "Translate a user's group names to a set of MB group IDs using the configured mappings"
+  [group-names]
   (->> (cond-> group-names (string? group-names) vector)
        (map keyword)
        (mapcat (sso-settings/saml-group-mappings))
        set))
 
+(defn- all-mapped-group-ids
+  "Returns the set of all MB group IDs that have configured mappings"
+  []
+  (-> (sso-settings/saml-group-mappings)
+      vals
+      flatten
+      set))
+
 (defn- sync-groups! [user group-names]
+  "Sync a user's groups based on mappings configured in the SAML settings"
   (when (sso-settings/saml-group-sync)
     (when group-names
-      (integrations.common/sync-group-memberships! user (group-names->ids group-names) #{} false))))
+      (integrations.common/sync-group-memberships! user
+                                                   (group-names->ids group-names)
+                                                   (all-mapped-group-ids)
+                                                   false))))
 
 (s/defn ^:private fetch-or-create-user! :- (s/maybe {:id UUID, s/Keyword s/Any})
   "Returns a Session for the given `email`. Will create the user if needed."

--- a/src/metabase/integrations/common.clj
+++ b/src/metabase/integrations/common.clj
@@ -24,8 +24,8 @@
                                             ;; Add nil to included group ids to ensure valid SQL if set is empty
                                             :group_id [:in (conj included-group-ids nil)]
                                             :group_id [:not-in excluded-group-ids])
-        new-group-ids      (set/intersection (set (map u/the-id mapped-groups-or-ids))
-                                             (set (map u/the-id new-groups-or-ids)))
+        new-group-ids      (set/intersection (set (map u/the-id new-groups-or-ids))
+                                             included-group-ids)
         ;; determine what's different between current mapped groups and new mapped groups
         [to-remove to-add] (data/diff current-group-ids new-group-ids)]
     ;; remove membership from any groups as needed

--- a/src/metabase/integrations/common.clj
+++ b/src/metabase/integrations/common.clj
@@ -19,11 +19,12 @@
                              (not sync-admin-group?) (conj (u/the-id (group/admin))))
         user-id            (u/the-id user-or-id)
         ;; Get a set of mapped Group IDs the user currently belongs to
-        current-group-ids  (db/select-field :group_id PermissionsGroupMembership
-                                            :user_id  user-id
-                                            ;; Add nil to included group ids to ensure valid SQL if set is empty
-                                            :group_id [:in (conj included-group-ids nil)]
-                                            :group_id [:not-in excluded-group-ids])
+        current-group-ids  (when (seq included-group-ids)
+                             (db/select-field :group_id PermissionsGroupMembership
+                                              :user_id  user-id
+                                              ;; Add nil to included group ids to ensure valid SQL if set is empty
+                                              :group_id [:in included-group-ids]
+                                              :group_id [:not-in excluded-group-ids]))
         new-group-ids      (set/intersection (set (map u/the-id new-groups-or-ids))
                                              included-group-ids)
         ;; determine what's different between current mapped groups and new mapped groups

--- a/src/metabase/integrations/common.clj
+++ b/src/metabase/integrations/common.clj
@@ -1,6 +1,7 @@
 (ns metabase.integrations.common
   "Shared functionality used by different integrations."
   (:require [clojure.data :as data]
+            [clojure.set :as set]
             [clojure.tools.logging :as log]
             [metabase.models.permissions-group :as group]
             [metabase.models.permissions-group-membership :refer [PermissionsGroupMembership]]
@@ -9,21 +10,23 @@
             [toucan.db :as db]))
 
 (defn sync-group-memberships!
-  "Update the PermissionsGroups a User belongs to, adding or deleting membership entries as needed so that Users is only
-  in `new-groups-or-ids`. Ignores special groups like `all-users`."
-  [user-or-id new-groups-or-ids sync-admin-group?]
-  ;; if you AREN'T syncing the admin group, it's a "special group", which means it's excluded from being added
-  ;; or removed from a user
-  (let [special-group-ids  (if (false? sync-admin-group?)
-                             #{(u/the-id (group/admin)) (u/the-id (group/all-users))}
-                             #{(u/the-id (group/all-users))})
-        user-id            (u/the-id user-or-id)
-        ;; Get a set of Group IDs the user currently belongs to
-        current-group-ids  (db/select-field :group_id PermissionsGroupMembership
-                                            :user_id  user-id
-                                            :group_id [:not-in special-group-ids])
-        new-group-ids      (set (map u/the-id new-groups-or-ids))
-        ;; determine what's different between current groups and new groups
+  "Update the PermissionsGroups a User belongs to, adding or deleting membership entries as needed so that Users is
+  only in `new-groups-or-ids`. Ignores special groups like `all-users`, and only touches groups with mappings set."
+  [user-or-id new-groups-or-ids mapped-groups-or-ids sync-admin-group?]
+  (let [excluded-group-ids        (cond-> #{(u/the-id (group/all-users))}
+                                    (not sync-admin-group?) (conj (u/the-id (group/admin))))
+        included-group-ids        (cond-> (set (map u/the-id mapped-groups-or-ids))
+                                    sync-admin-group? (conj (u/the-id (group/admin))))
+        user-id                  (u/the-id user-or-id)
+        ;; Get a set of mapped Group IDs the user currently belongs to
+        current-group-ids        (db/select-field :group_id PermissionsGroupMembership
+                                                  :user_id  user-id
+                                                  :group_id [:not-in excluded-group-ids]
+                                                  ;; Add nil to included group ids to ensure valid SQL if set is empty
+                                                  :group_id [:in (conj included-group-ids nil)])
+        new-group-ids     (set/intersection (set (map u/the-id mapped-groups-or-ids))
+                                            (set (map u/the-id new-groups-or-ids)))
+        ;; determine what's different between current mapped groups and new mapped groups
         [to-remove to-add] (data/diff current-group-ids new-group-ids)]
     ;; remove membership from any groups as needed
     (when (seq to-remove)
@@ -31,7 +34,7 @@
       (db/delete! PermissionsGroupMembership :group_id [:in to-remove], :user_id user-id))
     ;; add new memberships for any groups as needed
     (doseq [id    to-add
-            :when (not (special-group-ids id))]
+            :when (not (excluded-group-ids id))]
       (log/debugf "Adding user %s to group %s" user-id id)
       ;; if adding membership fails for one reason or another (i.e. if the group doesn't exist) log the error add the
       ;; user to the other groups rather than failing entirely

--- a/src/metabase/integrations/ldap/default_implementation.clj
+++ b/src/metabase/integrations/ldap/default_implementation.clj
@@ -82,11 +82,19 @@
 ;;; --------------------------------------------- fetch-or-create-user! ----------------------------------------------
 
 (s/defn ldap-groups->mb-group-ids :- #{su/IntGreaterThanZero}
-  "Translate a set of DNs to a set of MB group IDs using the configured mappings."
+  "Translate a set of a user's group DNs to a set of MB group IDs using the configured mappings."
   [ldap-groups              :- (s/maybe [su/NonBlankString])
    {:keys [group-mappings]} :- (select-keys i/LDAPSettings [:group-mappings s/Keyword])]
   (-> group-mappings
       (select-keys (map #(DN. (str %)) ldap-groups))
+      vals
+      flatten
+      set))
+
+(s/defn all-mapped-group-ids :- #{su?IntGreaterThanZero}
+  "Returns the set of all MB group IDs that have configured mappings."
+  [{:keys [group-mappings]} :- (select-keys i/LDAPSettings [:group-mappings s/Keyword])]
+  (-> group-mappings
       vals
       flatten
       set))
@@ -101,9 +109,9 @@
                    :email      email}))]
     (u/prog1 user
       (when sync-groups?
-        (let [group-ids (ldap-groups->mb-group-ids groups settings)]
-          (integrations.common/sync-group-memberships! user group-ids false))))))
-
+        (let [group-ids   (ldap-groups->mb-group-ids groups settings)
+              all-mapped-group-ids (all-mapped-group-ids settings)]
+          (integrations.common/sync-group-memberships! user group-ids all-mapped-group-ids false))))))
 
 ;;; ------------------------------------------------------ impl ------------------------------------------------------
 

--- a/src/metabase/integrations/ldap/default_implementation.clj
+++ b/src/metabase/integrations/ldap/default_implementation.clj
@@ -91,7 +91,7 @@
       flatten
       set))
 
-(s/defn all-mapped-group-ids :- #{su?IntGreaterThanZero}
+(s/defn all-mapped-group-ids :- #{su/IntGreaterThanZero}
   "Returns the set of all MB group IDs that have configured mappings."
   [{:keys [group-mappings]} :- (select-keys i/LDAPSettings [:group-mappings s/Keyword])]
   (-> group-mappings

--- a/test/metabase/integrations/common_test.clj
+++ b/test/metabase/integrations/common_test.clj
@@ -126,19 +126,19 @@
 
       (testing "are administrators removed appropriately?"
         (with-user-in-groups [user [(group/admin)]]
-          (integrations.common/sync-group-memberships! user [] true)
+          (integrations.common/sync-group-memberships! user [] #{} true)
           (is (= #{"All Users"}
                  (group-memberships user)))))))
 
   (testing "with admin group sync disabled"
     (testing "are admins synced?"
       (with-user-in-groups [user]
-        (integrations.common/sync-group-memberships! user [(group/admin)] false)
+        (integrations.common/sync-group-memberships! user [(group/admin)] #{} false)
         (is (= #{"All Users"}
                (group-memberships user)))))
 
     (testing "are administrators removed appropriately?"
       (with-user-in-groups [user [(group/admin)]]
-        (integrations.common/sync-group-memberships! user [] false)
+        (integrations.common/sync-group-memberships! user [] #{} false)
         (is (= #{"Administrators" "All Users"}
                (group-memberships user)))))))


### PR DESCRIPTION
This PR modifies the behavior of group sync to only ever touch groups that have mappings set up for the relevant SSO provider. Metabase groups that are not mapped to SSO groups will not be modified by group sync. This is done by passing in a new argument `mapped-groups-or-ids` to `sync-group-memberships!` which restricts the set of groups that sync can modify. 

The current behavior is that users are always removed from unmapped groups on login, so these groups eventually become empty and are unusable. I thought about preserving this behavior as the default and introducing this change as a "partial group sync" setting, but after some thought and discussion with @brunobergher I realized it wouldn't make sense for an admin to create a new group but not set up a mapping for it if they expected it to still be included in group sync. So I think it should be OK to modify this behavior for all users.

Resolves #7571  