### PR TITLE
Make recently viewed items more accessible

### DIFF
--- a/frontend/src/metabase/entities/index.js
+++ b/frontend/src/metabase/entities/index.js
@@ -19,4 +19,5 @@ export users from "./users";
 export groups from "./groups";
 
 export search from "./search";
+export recents from "./recents";
 export snippets from "./snippets";

--- a/frontend/src/metabase/entities/recents.js
+++ b/frontend/src/metabase/entities/recents.js
@@ -1,0 +1,11 @@
+import { createEntity } from "metabase/lib/entities";
+import { RecentsSchema } from "metabase/schema";
+
+const Recents = createEntity({
+  name: "recents",
+  nameOne: "recent",
+  path: "/api/activity/recent_views",
+  schema: RecentsSchema,
+});
+
+export default Recents;

--- a/frontend/src/metabase/entities/recents.js
+++ b/frontend/src/metabase/entities/recents.js
@@ -1,11 +1,22 @@
 import { createEntity } from "metabase/lib/entities";
-import { RecentsSchema } from "metabase/schema";
+import { RecentsSchema, entityTypeForObject } from "metabase/schema";
 
 const Recents = createEntity({
   name: "recents",
   nameOne: "recent",
   path: "/api/activity/recent_views",
   schema: RecentsSchema,
+  // delegate to the actual object's entity wrapEntity
+  wrapEntity(object, dispatch = null) {
+    const entities = require("metabase/entities");
+    const entity = entities[entityTypeForObject(object)];
+    if (entity) {
+      return entity.wrapEntity(object, dispatch);
+    } else {
+      console.warn("Couldn't find entity for object", object);
+      return object;
+    }
+  },
 });
 
 export default Recents;

--- a/frontend/src/metabase/nav/components/RecentsList.jsx
+++ b/frontend/src/metabase/nav/components/RecentsList.jsx
@@ -18,8 +18,8 @@ export default function RecentsList() {
   return (
     <Recents.ListLoader wrapped reload>
       {({ list }) => (
-        <Card>
-          <Box p={3}>
+        <Card py={1}>
+          <Box px={2} py={1}>
             <h4>{t`Recently viewed`}</h4>
           </Box>
           <ol>

--- a/frontend/src/metabase/nav/components/RecentsList.jsx
+++ b/frontend/src/metabase/nav/components/RecentsList.jsx
@@ -4,8 +4,10 @@ import { Box, Flex } from "grid-styled";
 import Recents from "metabase/entities/recents";
 
 import Card from "metabase/components/Card";
+import Text from "metabase/components/type/Text";
 
 import * as Urls from "metabase/lib/urls";
+import { capitalize } from "metabase/lib/formatting";
 
 import {
   ResultLink,
@@ -30,6 +32,7 @@ export default function RecentsList() {
                     <ItemIcon item={l} type={l.model} />
                     <Box>
                       <Title>{l.model_object.name}</Title>
+                      <Text>{capitalize(l.model === "card" ? `question` : l.model)}</Text>
                     </Box>
                   </Flex>
                 </ResultLink>

--- a/frontend/src/metabase/nav/components/RecentsList.jsx
+++ b/frontend/src/metabase/nav/components/RecentsList.jsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { t } from "ttag";
+import { Box, Flex } from "grid-styled";
+import Recents from "metabase/entities/recents";
+
+import Card from "metabase/components/Card";
+
+import * as Urls from "metabase/lib/urls";
+
+import {
+  ResultLink,
+  Title,
+} from "metabase/search/components/SearchResult.styled";
+
+import { ItemIcon } from "metabase/search/components/SearchResult";
+
+export default function RecentsList() {
+  return (
+    <Recents.ListLoader wrapped reload>
+      {({ list }) => (
+        <Card>
+          <Box p={3}>
+            <h4>{t`Recently viewed`}</h4>
+          </Box>
+          <ol>
+            {list.map(l => (
+              <div key={`${l.model}:${l.model_id}`}>
+                <ResultLink to={Urls.modelToUrl(l)} compact={true}>
+                  <Flex align="start">
+                    <ItemIcon item={l} type={l.model} />
+                    <Box>
+                      <Title>{l.model_object.name}</Title>
+                    </Box>
+                  </Flex>
+                </ResultLink>
+              </div>
+            ))}
+          </ol>
+        </Card>
+      )}
+    </Recents.ListLoader>
+  );
+}

--- a/frontend/src/metabase/nav/components/RecentsList.jsx
+++ b/frontend/src/metabase/nav/components/RecentsList.jsx
@@ -32,7 +32,9 @@ export default function RecentsList() {
                     <ItemIcon item={l} type={l.model} />
                     <Box>
                       <Title>{l.model_object.name}</Title>
-                      <Text>{capitalize(l.model === "card" ? `question` : l.model)}</Text>
+                      <Text>
+                        {capitalize(l.model === "card" ? `question` : l.model)}
+                      </Text>
                     </Box>
                   </Flex>
                 </ResultLink>

--- a/frontend/src/metabase/nav/components/SearchBar.jsx
+++ b/frontend/src/metabase/nav/components/SearchBar.jsx
@@ -1,55 +1,15 @@
-/* eslint-disable react/prop-types */
 import React from "react";
+import PropTypes from "prop-types";
 import ReactDOM from "react-dom";
-import { Flex } from "grid-styled";
-import styled from "styled-components";
-import { space } from "styled-system";
 import { t } from "ttag";
-
-import { color, lighten } from "metabase/lib/colors";
-
-import Card from "metabase/components/Card";
 import Icon from "metabase/components/Icon";
 import OnClickOutsideWrapper from "metabase/components/OnClickOutsideWrapper";
-import SearchResult from "metabase/search/components/SearchResult";
-
-import { DefaultSearchColor } from "metabase/nav/constants";
 import MetabaseSettings from "metabase/lib/settings";
-
-const ActiveSearchColor = lighten(color("nav"), 0.1);
-
-import Search from "metabase/entities/search";
-
-const SearchWrapper = Flex.extend`
-  position: relative;
-  background-color: ${props =>
-    props.active ? ActiveSearchColor : DefaultSearchColor};
-  border-radius: 6px;
-  flex: 1 1 auto;
-  max-width: 50em;
-  align-items: center;
-  color: white;
-  transition: background 300ms ease-in;
-  &:hover {
-    background-color: ${ActiveSearchColor};
-  }
-`;
-
-const SearchInput = styled.input`
-  ${space};
-  background-color: transparent;
-  width: 100%;
-  border: none;
-  color: white;
-  font-size: 1em;
-  font-weight: 700;
-  &:focus {
-    outline: none;
-  }
-  &::placeholder {
-    color: ${color("text-white")};
-  }
-`;
+import SearchResults from "metabase/nav/components/SearchResults";
+import {
+  SearchWrapper,
+  SearchInput,
+} from "metabase/nav/components/SearchBar.styled.jsx";
 
 const ALLOWED_SEARCH_FOCUS_ELEMENTS = new Set(["BODY", "A"]);
 
@@ -94,25 +54,6 @@ export default class SearchBar extends React.Component {
     }
   };
 
-  renderResults(results) {
-    if (results.length === 0) {
-      return (
-        <li className="flex flex-column align-center justify-center p4 text-medium text-centered">
-          <div className="my3">
-            <Icon name="search" mb={1} size={24} />
-            <h3 className="text-light">{t`Didn't find anything`}</h3>
-          </div>
-        </li>
-      );
-    } else {
-      return results.map(l => (
-        <li key={`${l.model}:${l.id}`}>
-          <SearchResult result={l} compact={true} />
-        </li>
-      ));
-    }
-  }
-
   render() {
     const { active, searchText } = this.state;
     return (
@@ -146,23 +87,10 @@ export default class SearchBar extends React.Component {
           {active && MetabaseSettings.searchTypeaheadEnabled() && (
             <div className="absolute left right text-dark" style={{ top: 60 }}>
               {searchText.trim().length > 0 ? (
-                <Card
-                  className="overflow-y-auto"
-                  style={{ maxHeight: 400 }}
-                  py={1}
-                >
-                  <Search.ListLoader
-                    query={{ q: searchText.trim() }}
-                    wrapped
-                    reload
-                    debounced
-                  >
-                    {({ list }) => {
-                      return <ol>{this.renderResults(list)}</ol>;
-                    }}
-                  </Search.ListLoader>
-                </Card>
-              ) : null}
+                <SearchResults searchText={searchText} />
+              ) : (
+                <div>Recents!</div>
+              )}
             </div>
           )}
         </SearchWrapper>
@@ -170,3 +98,7 @@ export default class SearchBar extends React.Component {
     );
   }
 }
+SearchBar.propTypes = {
+  location: PropTypes.object,
+  onChangeLocation: PropTypes.func,
+};

--- a/frontend/src/metabase/nav/components/SearchBar.jsx
+++ b/frontend/src/metabase/nav/components/SearchBar.jsx
@@ -11,6 +11,8 @@ import {
   SearchInput,
 } from "metabase/nav/components/SearchBar.styled.jsx";
 
+import RecentsList from "./RecentsList";
+
 const ALLOWED_SEARCH_FOCUS_ELEMENTS = new Set(["BODY", "A"]);
 
 export default class SearchBar extends React.Component {
@@ -89,7 +91,7 @@ export default class SearchBar extends React.Component {
               {searchText.trim().length > 0 ? (
                 <SearchResults searchText={searchText} />
               ) : (
-                <div>Recents!</div>
+                <RecentsList />
               )}
             </div>
           )}

--- a/frontend/src/metabase/nav/components/SearchBar.styled.jsx
+++ b/frontend/src/metabase/nav/components/SearchBar.styled.jsx
@@ -1,0 +1,38 @@
+import { Flex } from "grid-styled";
+import styled from "styled-components";
+import { space } from "styled-system";
+import { DefaultSearchColor } from "metabase/nav/constants";
+import { color, lighten } from "metabase/lib/colors";
+
+const ActiveSearchColor = lighten(color("nav"), 0.1);
+
+export const SearchWrapper = Flex.extend`
+  position: relative;
+  background-color: ${props =>
+    props.active ? ActiveSearchColor : DefaultSearchColor};
+  border-radius: 6px;
+  flex: 1 1 auto;
+  max-width: 50em;
+  align-items: center;
+  color: white;
+  transition: background 300ms ease-in;
+  &:hover {
+    background-color: ${ActiveSearchColor};
+  }
+`;
+
+export const SearchInput = styled.input`
+  ${space};
+  background-color: transparent;
+  width: 100%;
+  border: none;
+  color: white;
+  font-size: 1em;
+  font-weight: 700;
+  &:focus {
+    outline: none;
+  }
+  &::placeholder {
+    color: ${color("text-white")};
+  }
+`;

--- a/frontend/src/metabase/nav/components/SearchResults.jsx
+++ b/frontend/src/metabase/nav/components/SearchResults.jsx
@@ -1,0 +1,48 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { t } from "ttag";
+
+import Icon from "metabase/components/Icon";
+import Card from "metabase/components/Card";
+import SearchResult from "metabase/search/components/SearchResult";
+import Search from "metabase/entities/search";
+
+function SearchResults({ searchText }) {
+  return (
+    <Card className="overflow-y-auto" style={{ maxHeight: 400 }} py={1}>
+      <Search.ListLoader
+        query={{ q: searchText.trim() }}
+        wrapped
+        reload
+        debounced
+      >
+        {({ list }) => {
+          return (
+            <ol>
+              {list.length === 0 ? (
+                <li className="flex flex-column align-center justify-center p4 text-medium text-centered">
+                  <div className="my3">
+                    <Icon name="search" mb={1} size={24} />
+                    <h3 className="text-light">{t`Didn't find anything`}</h3>
+                  </div>
+                </li>
+              ) : (
+                list.map(l => (
+                  <li key={`${l.model}:${l.id}`}>
+                    <SearchResult result={l} compact={true} />
+                  </li>
+                ))
+              )}
+            </ol>
+          );
+        }}
+      </Search.ListLoader>
+    </Card>
+  );
+}
+
+SearchResults.propTypes = {
+  searchText: PropTypes.string,
+};
+
+export default SearchResults;

--- a/frontend/src/metabase/nav/components/SearchResults.jsx
+++ b/frontend/src/metabase/nav/components/SearchResults.jsx
@@ -3,41 +3,42 @@ import PropTypes from "prop-types";
 import { t } from "ttag";
 
 import Icon from "metabase/components/Icon";
-import Card from "metabase/components/Card";
 import SearchResult from "metabase/search/components/SearchResult";
 import Search from "metabase/entities/search";
 
+import {
+  SearchTypeaheadCard,
+  SearchResultList,
+  NoSearchResults,
+} from "./SearchResults.styled";
+
 function SearchResults({ searchText }) {
   return (
-    <Card className="overflow-y-auto" style={{ maxHeight: 400 }} py={1}>
+    <SearchTypeaheadCard>
       <Search.ListLoader
         query={{ q: searchText.trim() }}
         wrapped
         reload
         debounced
       >
-        {({ list }) => {
-          return (
-            <ol>
-              {list.length === 0 ? (
-                <li className="flex flex-column align-center justify-center p4 text-medium text-centered">
-                  <div className="my3">
-                    <Icon name="search" mb={1} size={24} />
-                    <h3 className="text-light">{t`Didn't find anything`}</h3>
-                  </div>
+        {({ list: results }) => (
+          <SearchResultList>
+            {results.length === 0 ? (
+              <NoSearchResults>
+                <Icon name="search" mb={1} size={24} />
+                <h3 className="text-light">{t`Didn't find anything`}</h3>
+              </NoSearchResults>
+            ) : (
+              results.map(result => (
+                <li key={`${result.model}:${result.id}`}>
+                  <SearchResult result={result} compact={true} />
                 </li>
-              ) : (
-                list.map(l => (
-                  <li key={`${l.model}:${l.id}`}>
-                    <SearchResult result={l} compact={true} />
-                  </li>
-                ))
-              )}
-            </ol>
-          );
-        }}
+              ))
+            )}
+          </SearchResultList>
+        )}
       </Search.ListLoader>
-    </Card>
+    </SearchTypeaheadCard>
   );
 }
 

--- a/frontend/src/metabase/nav/components/SearchResults.styled.jsx
+++ b/frontend/src/metabase/nav/components/SearchResults.styled.jsx
@@ -1,0 +1,21 @@
+import styled from "styled-components";
+import { color } from "metabase/lib/colors";
+import Card from "metabase/components/Card";
+
+export const SearchTypeaheadCard = styled(Card)`
+  max-height: 400px;
+  overflow-y: auto;
+  padding: 0.5rem 0;
+`;
+
+export const SearchResultList = styled.ol``;
+export const NoSearchResults = styled.li`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  color: ${color("text-medium")};
+  text-align: center;
+  margin: 1.5rem 0;
+`;

--- a/frontend/src/metabase/schema.js
+++ b/frontend/src/metabase/schema.js
@@ -104,6 +104,9 @@ export const parseSchemaId = id => String(id || "").split(":");
 export const generateSchemaId = (dbId, schemaName) =>
   `${dbId}:${schemaName || ""}`;
 
+export const RecentsSchema = new schema.Entity("recents", undefined, {
+  idAttribute: ({ model, model_id }) => `${model}:${model_id}`,
+});
 export const LoginHistorySchema = new schema.Entity("loginHistory", undefined, {
   idAttribute: ({ timestamp }) => `${timestamp}`,
 });

--- a/frontend/src/metabase/search/components/InfoText.jsx
+++ b/frontend/src/metabase/search/components/InfoText.jsx
@@ -1,0 +1,94 @@
+import React from "react";
+import PropTypes from "prop-types";
+import Schema from "metabase/entities/schemas";
+import Database from "metabase/entities/databases";
+import Table from "metabase/entities/tables";
+import { t, jt } from "ttag";
+
+import { capitalize } from "metabase/lib/formatting";
+import * as Urls from "metabase/lib/urls";
+import Icon from "metabase/components/Icon";
+import Link from "metabase/components/Link";
+
+import { CollectionLink } from "./SearchResult.styled";
+
+function formatCollection(collection) {
+  return collection.id && <CollectionBadge collection={collection} />;
+}
+
+function CollectionBadge({ collection }) {
+  return (
+    <CollectionLink to={Urls.collection(collection)}>
+      {collection.name}
+    </CollectionLink>
+  );
+}
+
+CollectionBadge.propTypes = {
+  collection: PropTypes.object,
+};
+
+export default function InfoText({ result }) {
+  const collection = result.getCollection();
+  switch (result.model) {
+    case "card":
+      return jt`Saved question in ${formatCollection(collection)}`;
+    case "collection":
+      return t`Collection`;
+    case "database":
+      return t`Database`;
+    case "table":
+      return (
+        <span>
+          {jt`Table in ${(
+            <span>
+              <Database.Link id={result.database_id} />{" "}
+              {result.table_schema && (
+                <Schema.ListLoader
+                  query={{ dbId: result.database_id }}
+                  loadingAndErrorWrapper={false}
+                >
+                  {({ list }) =>
+                    list && list.length > 1 ? (
+                      <span>
+                        <Icon name="chevronright" mx="4px" size={10} />
+                        {/* we have to do some {} manipulation here to make this look like the table object that browseSchema was written for originally */}
+                        <Link
+                          to={Urls.browseSchema({
+                            db: { id: result.database_id },
+                            schema_name: result.table_schema,
+                          })}
+                        >
+                          {result.table_schema}
+                        </Link>
+                      </span>
+                    ) : null
+                  }
+                </Schema.ListLoader>
+              )}
+            </span>
+          )}`}
+        </span>
+      );
+    case "segment":
+    case "metric":
+      return (
+        <span>
+          {result.model === "segment" ? t`Segment of ` : t`Metric for `}
+          <Link to={Urls.tableRowsQuery(result.database_id, result.table_id)}>
+            <Table.Loader id={result.table_id} loadingAndErrorWrapper={false}>
+              {({ table }) =>
+                table ? <span>{table.display_name}</span> : null
+              }
+            </Table.Loader>
+          </Link>
+        </span>
+      );
+    default:
+      return jt`${capitalize(result.model)} in ${formatCollection(collection)}`;
+  }
+}
+
+InfoText.propTypes = {
+  result: PropTypes.object,
+};

--- a/frontend/src/metabase/search/components/SearchResult.jsx
+++ b/frontend/src/metabase/search/components/SearchResult.jsx
@@ -1,91 +1,23 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 import { Box, Flex } from "grid-styled";
-import styled from "styled-components";
-import { t, jt } from "ttag";
 
-import * as Urls from "metabase/lib/urls";
-import { color, lighten } from "metabase/lib/colors";
-import { capitalize } from "metabase/lib/formatting";
+import { color } from "metabase/lib/colors";
 
 import Icon from "metabase/components/Icon";
-import Link from "metabase/components/Link";
 import Text from "metabase/components/type/Text";
 
-import Schema from "metabase/entities/schemas";
-import Database from "metabase/entities/databases";
-import Table from "metabase/entities/tables";
+import InfoText from "./InfoText";
 
-function getColorForIconWrapper(props) {
-  if (props.item.collection_position) {
-    return color("warning");
-  }
-  switch (props.type) {
-    case "collection":
-      return lighten("brand", 0.35);
-    default:
-      return color("brand");
-  }
-}
+import {
+  IconWrapper,
+  Context,
+  ResultLink,
+  Title,
+  Description,
+} from "./SearchResult.styled";
 
-const IconWrapper = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 32px;
-  height: 32px;
-  color: ${getColorForIconWrapper};
-  margin-right: 10px;
-  flex-shrink: 0;
-`;
-
-const ResultLink = styled(Link)`
-  display: block;
-  background-color: transparent;
-  min-height: ${props => (props.compact ? "36px" : "54px")};
-  padding-top: 8px;
-  padding-bottom: 8px;
-  padding-left: 14px;
-  padding-right: ${props => (props.compact ? "20px" : "32px")};
-
-  &:hover {
-    background-color: ${lighten("brand", 0.63)};
-
-    h3 {
-      color: ${color("brand")};
-    }
-  }
-
-  ${Link} {
-    text-underline-position: under;
-    text-decoration: underline ${color("text-light")};
-    text-decoration-style: dashed;
-    &:hover {
-      color: ${color("brand")};
-      text-decoration-color: ${color("brand")};
-    }
-  }
-
-  ${Text} {
-    margin-top: 0;
-    margin-bottom: 0;
-    font-size: 13px;
-    line-height: 19px;
-  }
-
-  h3 {
-    font-size: ${props => (props.compact ? "14px" : "16px")};
-    line-height: 1.2em;
-    word-wrap: break-word;
-    margin-bottom: 0;
-  }
-
-  .Icon-info {
-    color: ${color("text-light")};
-  }
-`;
-
-function ItemIcon({ item, type }) {
+export function ItemIcon({ item, type }) {
   return (
     <IconWrapper item={item} type={type}>
       {type === "table" ? (
@@ -97,35 +29,11 @@ function ItemIcon({ item, type }) {
   );
 }
 
-const CollectionLink = styled(Link)`
-  text-decoration: dashed;
-  &:hover {
-    color: ${color("brand")};
-  }
-`;
-
-function CollectionBadge({ collection }) {
-  return (
-    <CollectionLink to={Urls.collection(collection)}>
-      {collection.name}
-    </CollectionLink>
-  );
-}
-
-const Title = styled("h3")`
-  margin-bottom: 4px;
-`;
-
 function Score({ scores }) {
   return (
     <pre className="hide search-score">{JSON.stringify(scores, null, 2)}</pre>
   );
 }
-const Context = styled("p")`
-  line-height: 1.4em;
-  color: ${color("text-medium")};
-  margin-top: 0;
-`;
 
 function formatContext(context, compact) {
   return (
@@ -137,16 +45,6 @@ function formatContext(context, compact) {
     )
   );
 }
-
-function formatCollection(collection) {
-  return collection.id && <CollectionBadge collection={collection} />;
-}
-
-const Description = styled(Text)`
-  padding-left: 8px;
-  margin-top: 6px !important;
-  border-left: 2px solid ${lighten("brand", 0.45)};
-`;
 
 function contextText(context) {
   return context.map(function({ is_match, text }, i) {
@@ -161,67 +59,6 @@ function contextText(context) {
       return <span key={i}> {text}</span>;
     }
   });
-}
-
-function InfoText({ result }) {
-  const collection = result.getCollection();
-  switch (result.model) {
-    case "card":
-      return jt`Saved question in ${formatCollection(collection)}`;
-    case "collection":
-      return t`Collection`;
-    case "database":
-      return t`Database`;
-    case "table":
-      return (
-        <span>
-          {jt`Table in ${(
-            <span>
-              <Database.Link id={result.database_id} />{" "}
-              {result.table_schema && (
-                <Schema.ListLoader
-                  query={{ dbId: result.database_id }}
-                  loadingAndErrorWrapper={false}
-                >
-                  {({ list }) =>
-                    list && list.length > 1 ? (
-                      <span>
-                        <Icon name="chevronright" mx="4px" size={10} />
-                        {/* we have to do some {} manipulation here to make this look like the table object that browseSchema was written for originally */}
-                        <Link
-                          to={Urls.browseSchema({
-                            db: { id: result.database_id },
-                            schema_name: result.table_schema,
-                          })}
-                        >
-                          {result.table_schema}
-                        </Link>
-                      </span>
-                    ) : null
-                  }
-                </Schema.ListLoader>
-              )}
-            </span>
-          )}`}
-        </span>
-      );
-    case "segment":
-    case "metric":
-      return (
-        <span>
-          {result.model === "segment" ? t`Segment of ` : t`Metric for `}
-          <Link to={Urls.tableRowsQuery(result.database_id, result.table_id)}>
-            <Table.Loader id={result.table_id} loadingAndErrorWrapper={false}>
-              {({ table }) =>
-                table ? <span>{table.display_name}</span> : null
-              }
-            </Table.Loader>
-          </Link>
-        </span>
-      );
-    default:
-      return jt`${capitalize(result.model)} in ${formatCollection(collection)}`;
-  }
 }
 
 export default function SearchResult({ result, compact }) {

--- a/frontend/src/metabase/search/components/SearchResult.styled.jsx
+++ b/frontend/src/metabase/search/components/SearchResult.styled.jsx
@@ -1,0 +1,97 @@
+import styled from "styled-components";
+
+import Link from "metabase/components/Link";
+import Text from "metabase/components/type/Text";
+import { color, lighten } from "metabase/lib/colors";
+
+function getColorForIconWrapper(props) {
+  if (props.item.collection_position) {
+    return color("warning");
+  }
+  switch (props.type) {
+    case "collection":
+      return lighten("brand", 0.35);
+    default:
+      return color("brand");
+  }
+}
+
+export const IconWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  color: ${getColorForIconWrapper};
+  margin-right: 10px;
+  flex-shrink: 0;
+`;
+
+export const ResultLink = styled(Link)`
+  display: block;
+  background-color: transparent;
+  min-height: ${props => (props.compact ? "36px" : "54px")};
+  padding-top: 8px;
+  padding-bottom: 8px;
+  padding-left: 14px;
+  padding-right: ${props => (props.compact ? "20px" : "32px")};
+
+  &:hover {
+    background-color: ${lighten("brand", 0.63)};
+
+    h3 {
+      color: ${color("brand")};
+    }
+  }
+
+  ${Link} {
+    text-underline-position: under;
+    text-decoration: underline ${color("text-light")};
+    text-decoration-style: dashed;
+    &:hover {
+      color: ${color("brand")};
+      text-decoration-color: ${color("brand")};
+    }
+  }
+
+  ${Text} {
+    margin-top: 0;
+    margin-bottom: 0;
+    font-size: 13px;
+    line-height: 19px;
+  }
+
+  h3 {
+    font-size: ${props => (props.compact ? "14px" : "16px")};
+    line-height: 1.2em;
+    word-wrap: break-word;
+    margin-bottom: 0;
+  }
+
+  .Icon-info {
+    color: ${color("text-light")};
+  }
+`;
+
+export const CollectionLink = styled(Link)`
+  text-decoration: dashed;
+  &:hover {
+    color: ${color("brand")};
+  }
+`;
+
+export const Title = styled("h3")`
+  margin-bottom: 4px;
+`;
+
+export const Context = styled("p")`
+  line-height: 1.4em;
+  color: ${color("text-medium")};
+  margin-top: 0;
+`;
+
+export const Description = styled(Text)`
+  padding-left: 8px;
+  margin-top: 6px !important;
+  border-left: 2px solid ${lighten("brand", 0.45)};
+`;


### PR DESCRIPTION
## What this does
Adds a new state to the search input in the main nav that shows me things I've recently looked at until I type an actual search query. The idea here is to help you find things you've recently interacted with at a point at which you might need to have your memory jogged.

## Here's what it looks like in practice

https://user-images.githubusercontent.com/5248953/121247510-569db300-c870-11eb-83d8-a21b0c3bd78c.mov



I tried to refactor what I was touching here as I went to use some of our recently agreed upon conventions in regards to styled components etc, but I'm sure there are some things I could do better so have at it with the style critique to make sure I'm internalizing the right patterns. 

### Caveats
While I'd like these to match the search result info text, I wasn't sure of a way to easily get at the collection info for the recents themselves (that info doesn't come back from the API) and I didn't want to block this improvement on that. I went for the less ideal but I think at least non blocking solution of saying what the thing is (I can also just drop it). If anyone has thoughts on how to easily get at the collection info I'd appreciate the help.