### PR TITLE
VS Code: bind the default build task

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "typescript.tsc.autoDetect": "off",
+    "grunt.autoDetect": "off",
+    "jake.autoDetect": "off",
+    "gulp.autoDetect": "off",
+    "npm.autoDetect": "off"
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,20 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+      {
+        "label": "Run front-end and back-end",
+        "type": "shell",
+        "command": "yarn dev",
+        "presentation": {
+          "reveal": "always"
+        },
+        "problemMatcher": [],
+        "group": {
+          "kind": "build",
+          "isDefault": true
+        }
+      }
+    ]
+  }

--- a/docs/developers-guide-vscode.md
+++ b/docs/developers-guide-vscode.md
@@ -31,6 +31,6 @@ Steps:
 3. From the _View_ menu, choose _Command Palette..._ and then find _Remote-Container: Reopen in Container_. (VS Code may also prompt you to do this with an "Open in container" popup).
 **Note**: VS Code will create the container for the first time and it may take some time. Subsequent loads should be much faster. 
 
-4. Use the menu _Terminal_, _New Terminal_ to open a new embedded terminal. In this terminal, type and run `yarn dev`.
+4. Use the menu _View_, _Command Palette_, search for and choose _Tasks: Run Build Task_ (alternatively, use the shortcut `Ctrl+Shift+B`).
 
 5. After a while (after all JavaScript and Clojure dependencies are completely downloaded), open localhost:3000 with your web browser.


### PR DESCRIPTION
The main use-case for VS Code is to work on the front-end code. Therefore, let the default build task (shortcut: `Ctrl+Shift+B`) be the execution of `yarn dev`.

How to try:
1. Open the working directory with VS Code.
2. Use the menu _View_, _Command Palette_, search for and choose _Tasks: Run Build Task_ (alternatively, use the shortcut `Ctrl+Shift+B`).

The built-in terminal should slide in and start executing `yarn dev`.

![image](https://user-images.githubusercontent.com/7288/120527290-05cd1c80-c38f-11eb-813d-e03e4bfaec86.png)

