### PR TITLE
Migrate friendly names

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -8377,7 +8377,7 @@ databaseChangeLog:
       comment: Added 0.40.0 Migrate friendly field names
       changes:
         - update:
-            tableName: settings
+            tableName: setting
             columns:
               - column:
                   name: value

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -8369,6 +8369,20 @@ databaseChangeLog:
                   remarks: 'Nullable column to incidate collection''s authority level. Initially values are "official" and nil.'
                   constraints:
                     nullable: true
+
+
+  - changeSet:
+      id: 310
+      author: howonlee
+      comment: Added 0.40.0 Migrate friendly field names
+      changes:
+        - update:
+            tableName: settings
+            columns:
+              - column:
+                  name: value
+                  value: 'simple'
+            where: key='humanization-strategy' and value='advanced'
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -8382,7 +8382,7 @@ databaseChangeLog:
               - column:
                   name: value
                   value: 'simple'
-            where: 'key'='humanization-strategy' AND value='advanced'
+            where: "'key'='humanization-strategy' AND value='advanced'"
 
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -8382,7 +8382,7 @@ databaseChangeLog:
               - column:
                   name: value
                   value: 'simple'
-            where: key='humanization-strategy' AND value='advanced';
+            where: 'key'='humanization-strategy' AND value='advanced'
 
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -8382,7 +8382,8 @@ databaseChangeLog:
               - column:
                   name: value
                   value: 'simple'
-            where: key='humanization-strategy' and value='advanced'
+            where: key='humanization-strategy' AND value='advanced';
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/db/data_migrations.clj
+++ b/src/metabase/db/data_migrations.clj
@@ -384,12 +384,6 @@
                                  [:like
                                   :dashcard.visualization_settings "%\"click_link_template\":%"]]})))
 
-;; We whacked the overly-friendly field names because nobody wanted them
-;; If we have them in settings, default to the simple field names. Otherwise do nothing
-(defmigration ^{:author "howonlee", :added "0.40.0"} reduce-field-name-friendliness
-  (when (= "advanced" (setting/get "humanization-strategy"))
-    (setting/set! "humanization-strategy" :simple)))
-
 ;; !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ;; !!                                                                                                               !!
 ;; !!    Please seriously consider whether any new migrations you write here could be written as Liquibase ones     !!

--- a/src/metabase/db/data_migrations.clj
+++ b/src/metabase/db/data_migrations.clj
@@ -384,6 +384,12 @@
                                  [:like
                                   :dashcard.visualization_settings "%\"click_link_template\":%"]]})))
 
+;; We whacked the overly-friendly field names because nobody wanted them
+;; If we have them in settings, default to the simple field names. Otherwise do nothing
+(defmigration ^{:author "howonlee", :added "0.40.0"} reduce-field-name-friendliness
+  (when (= "advanced" (setting/get "humanization-strategy"))
+    (setting/set! "humanization-strategy" :simple)))
+
 ;; !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ;; !!                                                                                                               !!
 ;; !!    Please seriously consider whether any new migrations you write here could be written as Liquibase ones     !!


### PR DESCRIPTION
Bad things happen without the explicit data migration, turns out