### PR TITLE
Fix broken LDAP group lookups for Active Directory

### DIFF
--- a/src/metabase/integrations/ldap/default_implementation.clj
+++ b/src/metabase/integrations/ldap/default_implementation.clj
@@ -57,7 +57,8 @@
     :as   settings} :- i/LDAPSettings]
   (let [{first-name (keyword first-name-attribute)
          last-name  (keyword last-name-attribute)
-         email      (keyword email-attribute)} result]
+         email      (keyword email-attribute)
+         groups     :memberof} result]
     ;; Make sure we got everything as these are all required for new accounts
     (when-not (some empty? [dn first-name last-name email])
       {:dn         dn
@@ -67,7 +68,8 @@
        :groups     (when sync-groups?
                      ;; Active Directory and others (like FreeIPA) will supply a `memberOf` overlay attribute for
                      ;; groups. Otherwise we have to make the inverse query to get them.
-                     (or (:memberof result)
+                     (or (if (string? groups) (list (:memberof result))
+                           (:memberof result))
                          (user-groups ldap-connection dn settings)
                          []))})))
 

--- a/src/metabase/integrations/ldap/default_implementation.clj
+++ b/src/metabase/integrations/ldap/default_implementation.clj
@@ -57,8 +57,7 @@
     :as   settings} :- i/LDAPSettings]
   (let [{first-name (keyword first-name-attribute)
          last-name  (keyword last-name-attribute)
-         email      (keyword email-attribute)
-         groups     :memberof} result]
+         email      (keyword email-attribute)} result]
     ;; Make sure we got everything as these are all required for new accounts
     (when-not (some empty? [dn first-name last-name email])
       {:dn         dn
@@ -68,8 +67,7 @@
        :groups     (when sync-groups?
                      ;; Active Directory and others (like FreeIPA) will supply a `memberOf` overlay attribute for
                      ;; groups. Otherwise we have to make the inverse query to get them.
-                     (or (if (string? groups) (list (:memberof result))
-                           (:memberof result))
+                     (or (u/one-or-many (:memberof result))
                          (user-groups ldap-connection dn settings)
                          []))})))
 

--- a/test/metabase/integrations/ldap_test.clj
+++ b/test/metabase/integrations/ldap_test.clj
@@ -96,7 +96,26 @@
                 :last-name  "Taylor"
                 :email      "fred.taylor@metabase.com"
                 :groups     []}
-               (ldap/find-user "fred.taylor@metabase.com")))))))
+               (ldap/find-user "fred.taylor@metabase.com")))))
+
+    ;; Test group lookups for directory servers that use the memberOf attribute overlay, such as Active Directory
+    (ldap.test/with-active-directory-ldap-server
+      (testing "find user with one group using memberOf attribute"
+        (is (= {:dn         "cn=John Smith,ou=People,dc=metabase,dc=com"
+                :first-name "John"
+                :last-name  "Smith"
+                :email      "John.Smith@metabase.com"
+                :groups     ["cn=Accounting,ou=Groups,dc=metabase,dc=com"]}
+               (ldap/find-user "jsmith1"))))
+
+      (testing "find user with two groups using memberOf attribute"
+        (is (= {:dn         "cn=Sally Brown,ou=People,dc=metabase,dc=com"
+                :first-name "Sally"
+                :last-name  "Brown"
+                :email      "sally.brown@metabase.com"
+                :groups     ["cn=Accounting,ou=Groups,dc=metabase,dc=com",
+                             "cn=Engineering,ou=Groups,dc=metabase,dc=com"]}
+               (ldap/find-user "sbrown20")))))))
 
 (deftest group-matching-test
   (testing "LDAP group matching should identify Metabase groups using DN equality rules"

--- a/test/metabase/test/integrations/ldap.clj
+++ b/test/metabase/test/integrations/ldap.clj
@@ -15,7 +15,6 @@
   (doto (InMemoryDirectoryServerConfig. (into-array String ["dc=metabase,dc=com"]))
     (.addAdditionalBindCredentials "cn=Directory Manager" "password")
     (.setSchema schema)
-    (.setSchema nil)
     (.setListenerConfigs (into-array InMemoryListenerConfig [(InMemoryListenerConfig/createLDAPConfig "LDAP" 0)]))))
 
 (defn- start-ldap-server!

--- a/test/metabase/test/integrations/ldap.clj
+++ b/test/metabase/test/integrations/ldap.clj
@@ -10,18 +10,20 @@
   "An in-memory LDAP testing server."
   nil)
 
-(defn- get-server-config []
+(defn- get-server-config
+  [schema]
   (doto (InMemoryDirectoryServerConfig. (into-array String ["dc=metabase,dc=com"]))
     (.addAdditionalBindCredentials "cn=Directory Manager" "password")
-    (.setSchema (Schema/getDefaultStandardSchema))
+    (.setSchema schema)
+    (.setSchema nil)
     (.setListenerConfigs (into-array InMemoryListenerConfig [(InMemoryListenerConfig/createLDAPConfig "LDAP" 0)]))))
 
-(defn- start-ldap-server! []
-  (with-open [ldif (LDIFReader. (or (io/file (io/resource "ldap.ldif"))
-                                    (io/file "test_resources/ldap.ldif")
+(defn- start-ldap-server!
+  [{:keys [ldif-resource schema]}]
+  (with-open [ldif (LDIFReader. (or (io/file (str "test_resources/" ldif-resource))
                                     (throw
-                                     (FileNotFoundException. "ldap.ldif does not exist!"))))]
-    (doto (InMemoryDirectoryServer. (get-server-config))
+                                     (FileNotFoundException. (str ldif-resource " does not exist!")))))]
+    (doto (InMemoryDirectoryServer. (get-server-config schema))
       (.importFromLDIF true ldif)
       (.startListening))))
 
@@ -30,10 +32,15 @@
   []
   (.getListenPort *ldap-server*))
 
+(defn get-default-schema
+  "Get the default schema for the directory server."
+  []
+  (Schema/getDefaultStandardSchema))
+
 (defn do-with-ldap-server
   "Bind `*ldap-server*` and the relevant settings to an in-memory LDAP testing server and executes `f`."
-  [f]
-  (binding [*ldap-server* (start-ldap-server!)]
+  [f options]
+  (binding [*ldap-server* (start-ldap-server! options)]
     (try
       (tu/with-temporary-setting-values [ldap-enabled    true
                                          ldap-host       "localhost"
@@ -49,4 +56,14 @@
 (defmacro with-ldap-server
   "Bind `*ldap-server*` and the relevant settings to an in-memory LDAP testing server and executes `body`."
   [& body]
-  `(do-with-ldap-server (fn [] ~@body)))
+  `(do-with-ldap-server (fn [] ~@body)
+                        {:ldif-resource "ldap.ldif"
+                         :schema        (get-default-schema)}))
+
+(defmacro with-active-directory-ldap-server
+  "Bind `*ldap-server*` and the relevant settings to an in-memory LDAP testing server and executes `body`.
+  This version of the macro uses options that simulate an Active Directory server with memberOf attributes."
+  [& body]
+  `(do-with-ldap-server (fn [] ~@body)
+                        {:ldif-resource "active_directory.ldif"
+                         :schema        nil}))

--- a/test_resources/active_directory.ldif
+++ b/test_resources/active_directory.ldif
@@ -1,0 +1,56 @@
+dn: dc=metabase,dc=com
+objectClass: top
+objectClass: organization
+objectClass: dcObject
+dc: metabase
+o: Metabase Corporation
+
+dn: ou=People,dc=metabase,dc=com
+objectClass: top
+objectClass: organizationalUnit
+ou: People
+
+dn: cn=John Smith,ou=People,dc=metabase,dc=com
+objectClass: top
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson
+cn: John Smith
+sn: Smith
+givenName: John
+uid: jsmith1
+mail: John.Smith@metabase.com
+userPassword: strongpassword
+memberOf: cn=Accounting,ou=Groups,dc=metabase,dc=com
+
+dn: cn=Sally Brown,ou=People,dc=metabase,dc=com
+objectClass: top
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson
+cn: Sally Brown
+sn: Brown
+givenName: Sally
+uid: sbrown20
+mail: sally.brown@metabase.com
+userPassword: 1234
+memberOf: cn=Accounting,ou=Groups,dc=metabase,dc=com
+memberOf: cn=Engineering,ou=Groups,dc=metabase,dc=com
+
+dn: ou=Groups,dc=metabase,dc=com
+objectClass: top
+objectClass: organizationalUnit
+ou: Groups
+
+dn: cn=Accounting,ou=Groups,dc=metabase,dc=com
+objectClass: top
+objectClass: groupOfNames
+cn: Accounting
+member: cn=John Smith,ou=People,dc=metabase,dc=com
+member: cn=Sally Brown,ou=People,dc=metabase,dc=com
+
+dn: cn=Engineering,ou=Groups,dc=metabase,dc=com
+objectClass: top
+objectClass: groupOfNames
+cn: Accounting
+member: cn=Sally Brown,ou=People,dc=metabase,dc=com


### PR DESCRIPTION
Using the Active Directory `memberOf` attribute to search for groups currently breaks when only a single group is returned, since it's returned as a single string rather than a vector of strings. This PR fixes it by simply calling `u/one-or-many` on the result.

The rest of the changes are to enable testing of `memberOf` group lookups, which previously didn't have any test coverage. I'm doing this by creating a new LDIF file with `memberOf` attributes for users, and then turning off schema validation before  reading it into the testing server. It [doesn't seem recommended](https://github.com/pingidentity/ldapsdk/issues/67#issuecomment-495767323) to try to emulate Active Directory too closely with the UnboundID LDAP SDK so I think turning off schema for this case is the easiest workaround.

I also added an options map as an argument to `do-with-ldap-server`, and created a new macro `with-active-directory-ldap-server` which modifies the LDIF file and schema for these test cases. Not sure if this is the most idiomatic way to do this in Clojure so advice would be appreciated!

Fixes  #15073 and #11172