### PR TITLE
Pass UTF8 as a literal into grouping by a bytes->temporal column

### DIFF
--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -128,7 +128,7 @@
 (defmethod sql.qp/cast-temporal-byte [:postgres :Coercion/YYYYMMDDHHMMSSBytes->Temporal]
   [driver _coercion-strategy expr]
   (sql.qp/cast-temporal-string driver :Coercion/YYYYMMDDHHMMSSString->Temporal
-                               (hsql/call :convert_from expr "UTF8")))
+                               (hsql/call :convert_from expr (hx/literal "UTF8"))))
 
 (defn- date-trunc [unit expr] (hsql/call :date_trunc (hx/literal unit) (hx/->timestamp expr)))
 (defn- extract    [unit expr] (hsql/call :extract    unit              (hx/->timestamp expr)))


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/16335

Repro:
db setup:

```sql
create table wut2 (t bytea, ts text);
insert into wut2 (t, ts) values ('20210421164300'::bytea, '20210421164300');
```

Mark t as :Coercion/YYYYMMDDHHMMSSBytes->Temporal, ts as
:Coercion/YYYYMMDDHHMMSSString->Temporal

Do a simple query, and then aggregate count by the two dates. ts
should succeed and t fails.

We are passing in the UTF8 as a parameter rather than just emitting a
literal.

Before:

```clojure
{:sql
 "-- Metabase\nSELECT CAST(to_timestamp(convert_from(\"public\".\"wut\".\"t\", ?), 'YYYYMMDDHH24MISS') AS date) AS \"t\", count(*) AS \"count\" FROM \"public\".\"wut\" GROUP BY CAST(to_timestamp(convert_from(\"public\".\"wut\".\"t\", ?), 'YYYYMMDDHH24MISS') AS date) ORDER BY CAST(to_timestamp(convert_from(\"public\".\"wut\".\"t\", ?), 'YYYYMMDDHH24MISS') AS date) ASC",
 :params ("UTF8" "UTF8" "UTF8"),
 :type :invalid-query}
```

After:

```sql
SELECT CAST(to_timestamp(convert_from(\"public\".\"wut\".\"t\", 'UTF8'), 'YYYYMMDDHH24MISS') AS date) AS \"t\",
       count(*) AS \"count\" FROM \"public\".\"wut\"
GROUP BY CAST(to_timestamp(convert_from(\"public\".\"wut\".\"t\", 'UTF8'), 'YYYYMMDDHH24MISS') AS date)
ORDER BY CAST(to_timestamp(convert_from(\"public\".\"wut\".\"t\", 'UTF8'), 'YYYYMMDDHH24MISS') AS date) ASC
```

Note there's a lot of extra casting that perhaps we can clean up