### PR TITLE
Fix "Edit collection permissions" button disappeared

### DIFF
--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -3,9 +3,12 @@ import React, { useState, useCallback } from "react";
 import { Box } from "grid-styled";
 import _ from "underscore";
 import { withRouter } from "react-router";
+import { connect } from "react-redux";
 
 import Collection from "metabase/entities/collections";
 import Search from "metabase/entities/search";
+
+import { getUserIsAdmin } from "metabase/selectors/user";
 
 import BulkActions from "metabase/collections/components/BulkActions";
 import Header from "metabase/collections/components/Header";
@@ -33,6 +36,12 @@ const getModelsByFilter = filter => {
 };
 
 const itemKeyFn = item => `${item.id}:${item.model}`;
+
+function mapStateToProps(state) {
+  return {
+    isAdmin: getUserIsAdmin(state),
+  };
+}
 
 function CollectionContent({
   collection,
@@ -230,5 +239,6 @@ export default _.compose(
     id: (_, props) => props.collectionId,
     reload: true,
   }),
+  connect(mapStateToProps),
   withRouter,
 )(CollectionContent);


### PR DESCRIPTION
Fixes #16329

Fixes "Edit collection permissions" button disappeared from the collection page. This button is displayed if the signed-in user is an admin AND the opened collection _is not personal_. Looks like at some point when the collection page was changed, we forgot to connect it to the Redux store again, so the component can retrieve the `isAdmin` status. This ended up with the Collection page component not knowing about the user's admin status, so the button disappeared.


### To Verify

1. Sign in as admin
2. Open any _non-personal_ collection
3. You should see a lock icon in the top right
4. Click it, you should see a collection permissions management popup

### Screenshots

**Before**

<img width="1432" alt="before" src="https://user-images.githubusercontent.com/17258145/120677073-5e8bda80-c49f-11eb-98d4-8905551ea04e.png">

**After**

<img width="1430" alt="after" src="https://user-images.githubusercontent.com/17258145/120677067-5d5aad80-c49f-11eb-8744-8f697ba48d71.png">
