### PR TITLE
#15993 Repro: Click behavior with filter pass-thru does not show filters defined on question

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard/click-behavior.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/click-behavior.cy.spec.js
@@ -1,0 +1,95 @@
+import { restore } from "__support__/e2e/cypress";
+import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
+
+const { ORDERS, ORDERS_ID } = SAMPLE_DATASET;
+
+describe("scenarios > dashboard > dashboard cards > click behavior", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it.skip("should show filters defined on a question with filter pass-thru (metabase#15993)", () => {
+    cy.createQuestion({
+      name: "15993",
+      query: {
+        "source-table": ORDERS_ID,
+      },
+    }).then(({ body: { id: question1Id } }) => {
+      cy.createNativeQuestion({ native: { query: "select 0" } }).then(
+        ({ body: { id: nativeId } }) => {
+          cy.createDashboard("15993D").then(({ body: { id: dashboardId } }) => {
+            // Add native question to the dashboard
+            cy.request("POST", `/api/dashboard/${dashboardId}/cards`, {
+              cardId: nativeId,
+            }).then(({ body: { id: dashCardId } }) => {
+              // Add click behavior to the dashboard card and point it to the question 1
+              cy.request("PUT", `/api/dashboard/${dashboardId}/cards`, {
+                cards: [
+                  {
+                    id: dashCardId,
+                    card_id: nativeId,
+                    row: 0,
+                    col: 0,
+                    sizeX: 12,
+                    sizeY: 10,
+                    visualization_settings: getVisualizationSettings(
+                      question1Id,
+                    ),
+                  },
+                ],
+              });
+
+              cy.visit(`/dashboard/${dashboardId}`);
+
+              cy.intercept("POST", `/api/card/${question1Id}/query`).as(
+                "cardQuery",
+              );
+
+              cy.intercept("POST", `/api/card/${nativeId}/query`).as(
+                "nativeQuery",
+              );
+            });
+          });
+        },
+      );
+    });
+
+    // Drill-through
+    cy.wait("@nativeQuery");
+    cy.get(".cellData .link")
+      .contains("0")
+      .realClick();
+
+    cy.wait("@cardQuery");
+    cy.contains("117.03").should("not.exist"); // Total for the order in which quantity wasn't 0
+    cy.findByText("Quantity is equal to 0");
+
+    const getVisualizationSettings = targetId => ({
+      column_settings: {
+        '["name","0"]': {
+          click_behavior: {
+            targetId,
+            parameterMapping: {
+              [`["dimension",["field",${ORDERS.QUANTITY},null]]`]: {
+                source: {
+                  type: "column",
+                  id: "0",
+                  name: "0",
+                },
+                target: {
+                  type: "dimension",
+                  id: [`["dimension",["field",${ORDERS.QUANTITY},null]]`],
+                  dimension: ["dimension", ["field", ORDERS.QUANTITY, null]],
+                },
+                id: [`["dimension",["field",${ORDERS.QUANTITY},null]]`],
+              },
+            },
+            linkType: "question",
+            type: "link",
+          },
+        },
+      },
+    });
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #15993

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/dashboard/click-behavior.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/120713656-83457980-c4c2-11eb-9610-6a9ea37e81c8.png)


