### PR TITLE
#16334 Repro: Click Behavior targeting a question with filter mapped causes the visualization type to change

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard/click-behavior.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/click-behavior.cy.spec.js
@@ -146,8 +146,14 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
       .first()
       .click();
 
+    // Make sure filter is set
     cy.findByText("Rating is equal to 5");
-    cy.findAllByTestId("slice"); // Pie slices
+
+    // Make sure it's connected to the original question
+    cy.contains("Started from 16334");
+
+    // Make sure the original visualization didn't change
+    cy.findAllByTestId("slice");
 
     const getVisualizationSettings = targetId => ({
       column_settings: {


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #16334 

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/dashboard/click-behavior.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/120715146-7b86d480-c4c4-11eb-8021-e78bef421897.png)

