### PR TITLE
Filter nulls out of histograms

### DIFF
--- a/frontend/src/metabase/visualizations/lib/renderer_utils.js
+++ b/frontend/src/metabase/visualizations/lib/renderer_utils.js
@@ -142,8 +142,12 @@ function getParseOptions({ settings, data }) {
   };
 }
 
+function canDisplayNull(settings) {
+  // histograms are converted to ordinal scales, so we need this ugly logic as a workaround
+  return !isOrdinal(settings) || isHistogram(settings);
+}
+
 export function getDatas({ settings, series }, warn) {
-  const isNotOrdinal = !isOrdinal(settings);
   return series.map(({ data }) => {
     const parseOptions = getParseOptions({ settings, data });
 
@@ -151,7 +155,7 @@ export function getDatas({ settings, series }, warn) {
 
     // non-ordinal dimensions can't display null values,
     // so we filter them out and display a warning
-    if (isNotOrdinal) {
+    if (canDisplayNull(settings)) {
       rows = data.rows.filter(([x]) => x !== null);
     } else if (parseOptions.isNumeric) {
       rows = data.rows.map(row => {
@@ -178,7 +182,6 @@ export function getDatas({ settings, series }, warn) {
 export function getXValues({ settings, series }) {
   // if _raw isn't set then we already have the raw series
   const { _raw: rawSeries = series } = series;
-  const isNotOrdinal = !isOrdinal(settings);
   const warn = () => {}; // no op since warning in handled by getDatas
   const uniqueValues = new Set();
   let isAscending = true;
@@ -192,7 +195,7 @@ export function getXValues({ settings, series }) {
     let lastValue;
     for (const row of data.rows) {
       // non ordinal dimensions can't display null values, so we exclude them from xValues
-      if (isNotOrdinal && row[columnIndex] === null) {
+      if (canDisplayNull(settings) && row[columnIndex] === null) {
         continue;
       }
       const value = parseXValue(row[columnIndex], parseOptions, warn);

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -402,7 +402,6 @@ export const GRAPH_AXIS_SETTINGS = {
     section: t`Axes`,
     title: t`X-axis scale`,
     widget: "select",
-    default: "ordinal",
     readDependencies: [
       "graph.x_axis._is_timeseries",
       "graph.x_axis._is_numeric",

--- a/frontend/test/metabase/scenarios/visualizations/bar_chart.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/bar_chart.cy.spec.js
@@ -1,4 +1,7 @@
 import { restore, visitQuestionAdhoc } from "__support__/e2e/cypress";
+import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
+
+const { ORDERS, ORDERS_ID } = SAMPLE_DATASET;
 
 describe("scenarios > visualizations > bar chart", () => {
   beforeEach(() => {
@@ -49,6 +52,28 @@ describe("scenarios > visualizations > bar chart", () => {
 
       cy.wait("@dataset");
       cy.findByText("(empty)");
+    });
+  });
+
+  describe("with binned dimension (histogram)", () => {
+    it("should filter out null values (metabase#16049)", () => {
+      visitQuestionAdhoc({
+        dataset_query: {
+          type: "query",
+          query: {
+            "source-table": ORDERS_ID,
+            aggregation: [["count"]],
+            breakout: [
+              ["field", ORDERS.DISCOUNT, { binning: { strategy: "default" } }],
+            ],
+          },
+          database: 1,
+        },
+      });
+
+      cy.get(".bar").should("have.length", 5); // there are six bars when null isn't filtered
+      cy.findByText("1,800"); // correct data has this on the y-axis
+      cy.findByText("16,000").should("not.exist"); // If nulls are included the y-axis stretches much higher
     });
   });
 });


### PR DESCRIPTION
Fixes #16049

Due to some visualization setting hackery, histograms were showing bars for nulls. Only ordinal charts should do that. I worked around the issue.