### PR TITLE
Disable sending password reset email when LDAP is active

### DIFF
--- a/frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx
+++ b/frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx
@@ -26,10 +26,12 @@ export default class ForgotPasswordApp extends Component {
     const { location } = this.props;
     const { sentNotification } = this.state;
     const emailConfigured = MetabaseSettings.isEmailConfigured();
+    const ldapEnabled = MetabaseSettings.ldapEnabled();
+    const canResetPassword = emailConfigured && !ldapEnabled;
 
     return (
       <AuthLayout>
-        {!emailConfigured ? (
+        {!canResetPassword ? (
           <div>
             <h3 className="my4">{t`Please contact an administrator to have them reset your password`}</h3>
             <BackToLogin />


### PR DESCRIPTION
Resolves #7670

Low-hanging fruit so I figured I'd fix it. We can't change users' passwords in LDAP so we should direct them to contact an admin, the same as when email is not set up.