### PR TITLE
Display last edit info in Question and Dashboard headers

### DIFF
--- a/frontend/src/metabase-lib/lib/Question.js
+++ b/frontend/src/metabase-lib/lib/Question.js
@@ -689,6 +689,10 @@ export default class Question {
     return this._card && this._card.description;
   }
 
+  lastEditInfo() {
+    return this._card && this._card["last-edit-info"];
+  }
+
   isSaved(): boolean {
     return !!this.id();
   }

--- a/frontend/src/metabase/components/Header.jsx
+++ b/frontend/src/metabase/components/Header.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 import React, { Component } from "react";
-import { Box } from "grid-styled";
+import { Box, Flex } from "grid-styled";
 import { t } from "ttag";
 
 import { getScrollY } from "metabase/lib/dom";
@@ -9,6 +9,7 @@ import CollectionBadge from "metabase/questions/components/CollectionBadge";
 import EditBar from "metabase/components/EditBar";
 import EditWarning from "metabase/components/EditWarning";
 import HeaderModal from "metabase/components/HeaderModal";
+import LastEditInfoLabel from "metabase/components/LastEditInfoLabel";
 import TitleAndDescription from "metabase/components/TitleAndDescription";
 
 export default class Header extends Component {
@@ -87,7 +88,9 @@ export default class Header extends Component {
   }
 
   render() {
-    const { item } = this.props;
+    const { item, showBadge } = this.props;
+    const hasLastEditInfo = !!item["last-edit-info"];
+
     let titleAndDescription;
     if (this.props.item && this.props.item.id != null) {
       titleAndDescription = (
@@ -147,12 +150,18 @@ export default class Header extends Component {
           <Box py={2}>
             <span className="inline-block mb1">{titleAndDescription}</span>
             {attribution}
-            {this.props.showBadge && (
-              <CollectionBadge
-                collectionId={item.collection_id}
-                analyticsContext={this.props.analyticsContext}
-              />
-            )}
+            <Flex direction="row" align="center">
+              {showBadge && (
+                <CollectionBadge
+                  collectionId={item.collection_id}
+                  analyticsContext={this.props.analyticsContext}
+                />
+              )}
+              {showBadge && hasLastEditInfo && (
+                <span className="mx1 text-light text-smaller">•</span>
+              )}
+              {hasLastEditInfo && <LastEditInfoLabel item={item} />}
+            </Flex>
           </Box>
 
           <div

--- a/frontend/src/metabase/components/Header.jsx
+++ b/frontend/src/metabase/components/Header.jsx
@@ -1,5 +1,5 @@
-/* eslint-disable react/prop-types */
 import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Box, Flex } from "grid-styled";
 import { t } from "ttag";
 
@@ -12,15 +12,35 @@ import HeaderModal from "metabase/components/HeaderModal";
 import LastEditInfoLabel from "metabase/components/LastEditInfoLabel";
 import TitleAndDescription from "metabase/components/TitleAndDescription";
 
-export default class Header extends Component {
-  static defaultProps = {
-    headerButtons: [],
-    editingTitle: "",
-    editingSubtitle: "",
-    editingButtons: [],
-    headerClassName: "py1 lg-py2 xl-py3 wrapper",
-  };
+const propTypes = {
+  analyticsContext: PropTypes.string,
+  editingTitle: PropTypes.string,
+  editingSubtitle: PropTypes.string,
+  editingButtons: PropTypes.arrayOf(PropTypes.node),
+  editWarning: PropTypes.string,
+  headerButtons: PropTypes.arrayOf(PropTypes.node),
+  headerClassName: PropTypes.string,
+  headerModalMessage: PropTypes.string,
+  isEditing: PropTypes.bool,
+  isEditingInfo: PropTypes.bool,
+  item: PropTypes.object.isRequired,
+  objectType: PropTypes.string.isRequired,
+  showBadge: PropTypes.bool,
+  children: PropTypes.node,
+  setItemAttributeFn: PropTypes.func,
+  onHeaderModalDone: PropTypes.func,
+  onHeaderModalCancel: PropTypes.func,
+};
 
+const defaultProps = {
+  headerButtons: [],
+  editingTitle: "",
+  editingSubtitle: "",
+  editingButtons: [],
+  headerClassName: "py1 lg-py2 xl-py3 wrapper",
+};
+
+class Header extends Component {
   constructor(props, context) {
     super(props, context);
 
@@ -176,3 +196,8 @@ export default class Header extends Component {
     );
   }
 }
+
+Header.propTypes = propTypes;
+Header.defaultProps = defaultProps;
+
+export default Header;

--- a/frontend/src/metabase/components/Header.jsx
+++ b/frontend/src/metabase/components/Header.jsx
@@ -3,12 +3,13 @@ import React, { Component } from "react";
 import { Box } from "grid-styled";
 import { t } from "ttag";
 
+import { getScrollY } from "metabase/lib/dom";
+
 import CollectionBadge from "metabase/questions/components/CollectionBadge";
-import HeaderModal from "metabase/components/HeaderModal";
-import TitleAndDescription from "metabase/components/TitleAndDescription";
 import EditBar from "metabase/components/EditBar";
 import EditWarning from "metabase/components/EditWarning";
-import { getScrollY } from "metabase/lib/dom";
+import HeaderModal from "metabase/components/HeaderModal";
+import TitleAndDescription from "metabase/components/TitleAndDescription";
 
 export default class Header extends Component {
   static defaultProps = {

--- a/frontend/src/metabase/components/LastEditInfoLabel.js
+++ b/frontend/src/metabase/components/LastEditInfoLabel.js
@@ -1,0 +1,34 @@
+import React from "react";
+import PropTypes from "prop-types";
+import styled from "styled-components";
+import { t } from "ttag";
+import moment from "moment";
+
+import { color } from "metabase/lib/colors";
+
+const Label = styled.span`
+  font-weight: bold;
+  color: ${color("text-medium")};
+`;
+
+LastEditInfoLabel.propTypes = {
+  item: PropTypes.shape({
+    "last-edit-info": PropTypes.shape({
+      id: PropTypes.number.isRequired,
+      email: PropTypes.string.isRequired,
+      first_name: PropTypes.string.isRequired,
+      last_name: PropTypes.string.isRequired,
+      timestamp: PropTypes.string.isRequired,
+    }).isRequired,
+  }),
+};
+
+function LastEditInfoLabel({ item, ...props }) {
+  const { first_name, last_name, timestamp } = item["last-edit-info"];
+  const time = moment(timestamp).fromNow();
+  const lastNameFirstLetter = last_name.charAt(0);
+  const editor = `${first_name} ${lastNameFirstLetter}.`;
+  return <Label {...props}>{t`Edited ${time} by ${editor}`}</Label>;
+}
+
+export default LastEditInfoLabel;

--- a/frontend/src/metabase/components/LastEditInfoLabel.js
+++ b/frontend/src/metabase/components/LastEditInfoLabel.js
@@ -1,15 +1,24 @@
 import React from "react";
 import PropTypes from "prop-types";
+import { connect } from "react-redux";
 import styled from "styled-components";
 import { t } from "ttag";
 import moment from "moment";
 
 import { color } from "metabase/lib/colors";
 
+import { getUser } from "metabase/selectors/user";
+
 const Label = styled.span`
   font-weight: bold;
   color: ${color("text-medium")};
 `;
+
+function mapStateToProps(state) {
+  return {
+    user: getUser(state),
+  };
+}
 
 LastEditInfoLabel.propTypes = {
   item: PropTypes.shape({
@@ -21,14 +30,26 @@ LastEditInfoLabel.propTypes = {
       timestamp: PropTypes.string.isRequired,
     }).isRequired,
   }),
+  user: PropTypes.shape({
+    id: PropTypes.number,
+  }).isRequired,
 };
 
-function LastEditInfoLabel({ item, ...props }) {
-  const { first_name, last_name, timestamp } = item["last-edit-info"];
+function formatEditorName(firstName, lastName) {
+  const lastNameFirstLetter = lastName.charAt(0);
+  return `${firstName} ${lastNameFirstLetter}.`;
+}
+
+function LastEditInfoLabel({ item, user, ...props }) {
+  const { first_name, last_name, id: editorId, timestamp } = item[
+    "last-edit-info"
+  ];
   const time = moment(timestamp).fromNow();
-  const lastNameFirstLetter = last_name.charAt(0);
-  const editor = `${first_name} ${lastNameFirstLetter}.`;
+
+  const editor =
+    editorId === user.id ? "you" : formatEditorName(first_name, last_name);
+
   return <Label {...props}>{t`Edited ${time} by ${editor}`}</Label>;
 }
 
-export default LastEditInfoLabel;
+export default connect(mapStateToProps)(LastEditInfoLabel);

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -1,5 +1,5 @@
-/* eslint-disable react/prop-types */
 import React from "react";
+import PropTypes from "prop-types";
 import { t } from "ttag";
 import cx from "classnames";
 import { Box } from "grid-styled";
@@ -27,6 +27,40 @@ import NativeQueryButton from "./NativeQueryButton";
 import RunButtonWithTooltip from "../RunButtonWithTooltip";
 
 import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
+
+const viewTitleHeaderPropTypes = {
+  question: PropTypes.object.isRequired,
+  originalQuestion: PropTypes.object,
+
+  queryBuilderMode: PropTypes.oneOf(["view", "notebook"]),
+  setQueryBuilderMode: PropTypes.func,
+
+  result: PropTypes.object,
+
+  isDirty: PropTypes.bool,
+  isRunnable: PropTypes.bool,
+  isRunning: PropTypes.bool,
+  isResultDirty: PropTypes.bool,
+  isNativeEditorOpen: PropTypes.bool,
+  isShowingFilterSidebar: PropTypes.bool,
+  isShowingSummarySidebar: PropTypes.bool,
+
+  runQuestionQuery: PropTypes.func,
+  cancelQuery: PropTypes.func,
+
+  onOpenModal: PropTypes.func,
+  onEditSummary: PropTypes.func,
+  onCloseSummary: PropTypes.func,
+  onAddFilter: PropTypes.func,
+  onCloseFilter: PropTypes.func,
+
+  isPreviewable: PropTypes.bool,
+  isPreviewing: PropTypes.bool,
+  setIsPreviewing: PropTypes.func,
+
+  className: PropTypes.string,
+  style: PropTypes.object,
+};
 
 export class ViewTitleHeader extends React.Component {
   constructor(props) {
@@ -307,6 +341,14 @@ export class ViewTitleHeader extends React.Component {
   }
 }
 
+ViewTitleHeader.propTypes = viewTitleHeaderPropTypes;
+
+const viewSubHeaderPropTypes = {
+  isPreviewable: PropTypes.bool,
+  isPreviewing: PropTypes.bool,
+  setIsPreviewing: PropTypes.func,
+};
+
 export class ViewSubHeader extends React.Component {
   render() {
     const { isPreviewable, isPreviewing, setIsPreviewing } = this.props;
@@ -338,3 +380,5 @@ export class ViewSubHeader extends React.Component {
     ) : null;
   }
 }
+
+ViewSubHeader.propTypes = viewSubHeaderPropTypes;

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -8,6 +8,7 @@ import Icon from "metabase/components/Icon";
 import Link from "metabase/components/Link";
 import ButtonBar from "metabase/components/ButtonBar";
 import CollectionBadge from "metabase/questions/components/CollectionBadge";
+import LastEditInfoLabel from "metabase/components/LastEditInfoLabel";
 
 import ViewSection, { ViewHeading, ViewSubHeading } from "./ViewSection";
 import ViewButton from "metabase/query_builder/components/view/ViewButton";
@@ -83,6 +84,7 @@ export class ViewTitleHeader extends React.Component {
     const { isFiltersExpanded } = this.state;
     const isShowingNotebook = queryBuilderMode === "notebook";
     const description = question.description();
+    const lastEditInfo = question.lastEditInfo();
 
     const isStructured = question.isStructured();
     const isNative = question.isNative();
@@ -121,6 +123,12 @@ export class ViewTitleHeader extends React.Component {
                 question={question}
                 onOpenModal={onOpenModal}
               />
+              {lastEditInfo && (
+                <LastEditInfoLabel
+                  className="ml1 text-light"
+                  item={question.card()}
+                />
+              )}
             </div>
             <ViewSubHeading className="flex align-center flex-wrap">
               <CollectionBadge


### PR DESCRIPTION
It's really hard to know in Metabase right now who made or has been recently working with a given dashboard, question, or collection. This PR adds notes about the last edit to the dashboard and saved question page headers

Extracted from #16295

### To Verify

1. Open a dashboard
2. Ensure there is a note about the last edit to the left of the _collection_ name
3. Open a question
4. Ensure there is a note about the last edit to the left of the _question_ name

### Screenshots


## Demo

### Before

**Dashboard Header**

<img width="569" alt="Dashboar header (before)" src="https://user-images.githubusercontent.com/17258145/120652489-7efc6a80-c488-11eb-880f-9ff5d6c117f6.png">

**Question Header**

<img width="434" alt="Question header (before)" src="https://user-images.githubusercontent.com/17258145/120652493-7f950100-c488-11eb-86f9-5aeab0077dcc.png">


### After

**Dashboard Header**

<img width="573" alt="Dashboar header (after)" src="https://user-images.githubusercontent.com/17258145/120652957-ea463c80-c488-11eb-8e87-8b65ce60d05b.png">

**Question Header**

<img width="598" alt="Question header (after)" src="https://user-images.githubusercontent.com/17258145/120652963-ec100000-c488-11eb-8590-5c361dbe60bf.png">
