### PR TITLE
#16327 Repro: Double binning menu for date fields when using Saved Question (Native)

### DIFF
--- a/frontend/test/metabase/scenarios/native/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/native.cy.spec.js
@@ -665,6 +665,28 @@ describe("scenarios > question > native", () => {
     cy.get("@sidebar").contains(/added/i);
   });
 
+  it.skip("shouldn't render double binning options when question is based on the saved native question (metabase#16327)", () => {
+    cy.createNativeQuestion({
+      name: "16327",
+      native: { query: "select * from products limit 5" },
+    });
+
+    cy.visit("/question/new");
+    cy.findByText("Custom question").click();
+    cy.findByText("Saved Questions").click();
+    cy.findByText("16327").click();
+
+    cy.findByText("Pick the metric you want to see").click();
+    cy.findByText("Count of rows").click();
+
+    cy.findByText("Pick a column to group by").click();
+    cy.findByText(/CREATED_AT/i).realHover();
+    cy.findByText("by minute").click({ force: true });
+
+    // Implicit assertion - it fails if there is more than one instance of the string, which is exactly what we need for this repro
+    cy.findByText("Month");
+  });
+
   ["off", "on"].forEach(testCase => {
     const isFeatureFlagTurnedOn = testCase === "off" ? false : true;
 


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #16327

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/native/native.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/120825676-e8987980-c559-11eb-9d59-0d9d072c118a.png)

