### PR TITLE
#16322 Repro: "Custom mapping" is only available, when "A list of all values" is set (and after a browser refresh)

### DIFF
--- a/frontend/test/metabase/scenarios/admin/datamodel/metadata.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/metadata.cy.spec.js
@@ -6,7 +6,7 @@ import {
 } from "__support__/e2e/cypress";
 import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
 
-const { ORDERS, ORDERS_ID, REVIEWS } = SAMPLE_DATASET;
+const { ORDERS, ORDERS_ID, REVIEWS, REVIEWS_ID } = SAMPLE_DATASET;
 
 describe("scenarios > admin > datamodel > metadata", () => {
   beforeEach(() => {
@@ -125,4 +125,27 @@ describe("scenarios > admin > datamodel > metadata", () => {
       .contains("Created At")
       .should("have.length", 1);
   });
+
+  it.skip("display value 'custom mapping' should be available regardless of the chosen filtering type (metabase#16322)", () => {
+    cy.visit(
+      `/admin/datamodel/database/1/table/${REVIEWS_ID}/${REVIEWS.RATING}/general`,
+    );
+
+    openOptionsForSection("Filtering on this field");
+    popover()
+      .findByText("Search box")
+      .click();
+
+    cy.reload();
+
+    openOptionsForSection("Display values");
+    popover().findByText("Custom mapping");
+  });
 });
+
+function openOptionsForSection(sectionName) {
+  cy.findByText(sectionName)
+    .closest("section")
+    .find(".AdminSelect")
+    .click();
+}


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #16322 

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/admin/datamodel/metadata.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/120831660-0ff24500-c560-11eb-93b6-704c4e2a8829.png)

