### PR TITLE
#16226 Repro: LDAP/Email settings gets cleared if validation fails

### DIFF
--- a/frontend/test/metabase/scenarios/admin/settings/email.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/email.cy.spec.js
@@ -1,0 +1,84 @@
+import { restore, setupDummySMTP } from "__support__/e2e/cypress";
+
+describe("scenarios > admin > settings > email settings", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+  it("should be able to save email settings", () => {
+    cy.visit("/admin/settings/email");
+    cy.findByPlaceholderText("smtp.yourservice.com")
+      .type("localhost")
+      .blur();
+    cy.findByPlaceholderText("587")
+      .type("25")
+      .blur();
+    cy.findByPlaceholderText("youlooknicetoday")
+      .type("admin")
+      .blur();
+    cy.findByPlaceholderText("Shhh...")
+      .type("admin")
+      .blur();
+    cy.findByPlaceholderText("metabase@yourcompany.com")
+      .type("mailer@metabase.test")
+      .blur();
+    cy.findByText("Save changes").click();
+
+    cy.findByText("Changes saved!");
+  });
+  it("should show an error if test email fails", () => {
+    // Reuse Email setup without relying on the previous test
+    cy.request("PUT", "/api/setting", {
+      "email-from-address": "admin@metabase.com",
+      "email-smtp-host": "localhost",
+      "email-smtp-password": null,
+      "email-smtp-port": "1234",
+      "email-smtp-security": "none",
+      "email-smtp-username": null,
+    });
+    cy.visit("/admin/settings/email");
+    cy.findByText("Send test email").click();
+    cy.findByText("Sorry, something went wrong. Please try again.");
+  });
+
+  it("should send a test email for a valid SMTP configuration", () => {
+    // We must clear maildev inbox before each run - this will be extracted and automated
+    cy.request("DELETE", "http://localhost:80/email/all");
+    cy.request("PUT", "/api/setting", {
+      "email-smtp-host": "localhost",
+      "email-smtp-port": "25",
+      "email-smtp-username": "admin",
+      "email-smtp-password": "admin",
+      "email-smtp-security": "none",
+      "email-from-address": "mailer@metabase.test",
+    });
+    cy.visit("/admin/settings/email");
+    cy.findByText("Send test email").click();
+    cy.findByText("Sent!");
+    cy.request("GET", "http://localhost:80/email").then(({ body }) => {
+      const emailBody = body[0].text;
+      expect(emailBody).to.include("Your Metabase emails are working");
+    });
+  });
+
+  it("should be able to clear email settings", () => {
+    cy.visit("/admin/settings/email");
+    cy.findByText("Clear").click();
+    cy.findByPlaceholderText("smtp.yourservice.com").should("have.value", "");
+    cy.findByPlaceholderText("587").should("have.value", "");
+    cy.findByPlaceholderText("metabase@yourcompany.com").should(
+      "have.value",
+      "",
+    );
+  });
+
+  it("should not offer to save email changes when there aren't any (metabase#14749)", () => {
+    // Make sure some settings are already there
+    setupDummySMTP();
+
+    cy.visit("/admin/settings/email");
+    cy.findByText("Send test email").scrollIntoView();
+    // Needed to scroll the page down first to be able to use findByRole() - it fails otherwise
+    cy.button("Save changes").should("be.disabled");
+  });
+});

--- a/frontend/test/metabase/scenarios/admin/settings/email.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/email.cy.spec.js
@@ -81,4 +81,32 @@ describe("scenarios > admin > settings > email settings", () => {
     // Needed to scroll the page down first to be able to use findByRole() - it fails otherwise
     cy.button("Save changes").should("be.disabled");
   });
+
+  it.skip("should not reset previously populated fields when validation fails for just one of them (metabase#16226)", () => {
+    cy.visit("/admin/settings/email");
+
+    // First we fill out wrong settings
+    cy.findByPlaceholderText("smtp.yourservice.com")
+      .type("foo") // Invalid SMTP host
+      .blur();
+    cy.findByPlaceholderText("587")
+      .type("25")
+      .blur();
+    cy.findByPlaceholderText("youlooknicetoday")
+      .type("admin")
+      .blur();
+    cy.findByPlaceholderText("Shhh...")
+      .type("admin")
+      .blur();
+    cy.findByPlaceholderText("metabase@yourcompany.com")
+      .type("mailer@metabase.test")
+      .blur();
+
+    // Trying to save will trigger the error (as it should)
+    cy.button("Save changes").click();
+    cy.findByText("Sorry, something went wrong. Please try again.");
+
+    // But it shouldn't delete field values
+    cy.findByDisplayValue("mailer@metabase.test");
+  });
 });

--- a/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
@@ -3,7 +3,6 @@ import {
   openOrdersTable,
   version,
   popover,
-  setupDummySMTP,
 } from "__support__/e2e/cypress";
 
 describe("scenarios > admin > settings", () => {
@@ -335,85 +334,6 @@ describe("scenarios > admin > settings", () => {
     cy.get("@settingsOptions")
       .last()
       .contains(lastItem);
-  });
-
-  describe(" > email settings", () => {
-    it("should be able to save email settings", () => {
-      cy.visit("/admin/settings/email");
-      cy.findByPlaceholderText("smtp.yourservice.com")
-        .type("localhost")
-        .blur();
-      cy.findByPlaceholderText("587")
-        .type("25")
-        .blur();
-      cy.findByPlaceholderText("youlooknicetoday")
-        .type("admin")
-        .blur();
-      cy.findByPlaceholderText("Shhh...")
-        .type("admin")
-        .blur();
-      cy.findByPlaceholderText("metabase@yourcompany.com")
-        .type("mailer@metabase.test")
-        .blur();
-      cy.findByText("Save changes").click();
-
-      cy.findByText("Changes saved!");
-    });
-    it("should show an error if test email fails", () => {
-      // Reuse Email setup without relying on the previous test
-      cy.request("PUT", "/api/setting", {
-        "email-from-address": "admin@metabase.com",
-        "email-smtp-host": "localhost",
-        "email-smtp-password": null,
-        "email-smtp-port": "1234",
-        "email-smtp-security": "none",
-        "email-smtp-username": null,
-      });
-      cy.visit("/admin/settings/email");
-      cy.findByText("Send test email").click();
-      cy.findByText("Sorry, something went wrong. Please try again.");
-    });
-
-    it("should send a test email for a valid SMTP configuration", () => {
-      // We must clear maildev inbox before each run - this will be extracted and automated
-      cy.request("DELETE", "http://localhost:80/email/all");
-      cy.request("PUT", "/api/setting", {
-        "email-smtp-host": "localhost",
-        "email-smtp-port": "25",
-        "email-smtp-username": "admin",
-        "email-smtp-password": "admin",
-        "email-smtp-security": "none",
-        "email-from-address": "mailer@metabase.test",
-      });
-      cy.visit("/admin/settings/email");
-      cy.findByText("Send test email").click();
-      cy.findByText("Sent!");
-      cy.request("GET", "http://localhost:80/email").then(({ body }) => {
-        const emailBody = body[0].text;
-        expect(emailBody).to.include("Your Metabase emails are working");
-      });
-    });
-
-    it("should be able to clear email settings", () => {
-      cy.visit("/admin/settings/email");
-      cy.findByText("Clear").click();
-      cy.findByPlaceholderText("smtp.yourservice.com").should("have.value", "");
-      cy.findByPlaceholderText("587").should("have.value", "");
-      cy.findByPlaceholderText("metabase@yourcompany.com").should(
-        "have.value",
-        "",
-      );
-    });
-
-    it("should not offer to save email changes when there aren't any (metabase#14749)", () => {
-      // Make sure some settings are already there
-      setupDummySMTP();
-
-      cy.visit("/admin/settings/email");
-      cy.findByText("Send test email").scrollIntoView();
-      // Needed to scroll the page down first to be able to use findByRole() - it fails otherwise
-      cy.button("Save changes").should("be.disabled");
-    });
   });
 
   describe(" > slack settings", () => {

--- a/frontend/test/metabase/scenarios/admin/settings/sso.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/sso.cy.spec.js
@@ -64,6 +64,15 @@ describe("scenarios > admin > settings > SSO", () => {
       });
       cy.button("Changes saved!");
     });
+
+    it.skip("should not reset previously populated fields when validation fails for just one of them (metabase#16226)", () => {
+      cy.findByPlaceholderText("ldap.yourdomain.org").type("foobar");
+      cy.findByPlaceholderText("389").type("baz");
+      cy.button("Save changes").click();
+
+      cy.findByText('For input string: "baz"'); // The error message
+      cy.findByDisplayValue("foobar");
+    });
   });
 });
 


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Reproduces #16226

### How to test this manually?
For LDAP repro
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/admin/settings/sso.cy.spec.js`

For Email repro
- `yarn test-cypress-open frontend/test/metabase/scenarios/admin/settings/email.cy.spec.js`

- Replace `it.skip()` with `it.only()` to run tests in isolation
- Tests should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
LDAP
![image](https://user-images.githubusercontent.com/31325167/120847889-649fbb00-c574-11eb-982e-e3ef45dcf862.png)

Email
![image](https://user-images.githubusercontent.com/31325167/120847669-18ed1180-c574-11eb-80a5-9c6da961b620.png)

