### PR TITLE
Switch to column settings when sidebar is already open

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChartSettings.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings.jsx
@@ -64,6 +64,16 @@ class ChartSettings extends Component {
     };
   }
 
+  componentDidUpdate(prevProps) {
+    const { initial } = this.props;
+    if (!_.isEqual(initial, prevProps.initial)) {
+      this.setState({
+        currentSection: (initial && initial.section) || null,
+        currentWidget: (initial && initial.widget) || null,
+      });
+    }
+  }
+
   handleShowSection = section => {
     this.setState({ currentSection: section, currentWidget: null });
   };

--- a/frontend/test/metabase/scenarios/question/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/settings.cy.spec.js
@@ -3,6 +3,7 @@ import {
   restore,
   openOrdersTable,
   visitQuestionAdhoc,
+  popover,
 } from "__support__/e2e/cypress";
 
 import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
@@ -144,6 +145,26 @@ describe("scenarios > question > settings", () => {
           .eq(index)
           .contains(column_name);
       }
+    });
+
+    it("should change to column formatting when sidebar is already open (metabase#16043)", () => {
+      visitQuestionAdhoc({
+        dataset_query: {
+          type: "query",
+          query: { "source-table": ORDERS_ID },
+          database: 1,
+        },
+      });
+
+      cy.findByText("Settings").click(); // open settings sidebar
+      cy.findByText("Table options"); // confirm it's open
+      cy.get(".TableInteractive")
+        .findByText("Subtotal")
+        .click(); // open subtotal column header actions
+      popover().within(() => cy.icon("gear").click()); // open subtotal column settings
+
+      cy.findByText("Table options").should("not.exist"); // no longer displaying the top level settings
+      cy.findByText("Column title"); // shows subtotal column settings
     });
   });
 


### PR DESCRIPTION
Fixes #16043

The change is pretty straightforward. The "initial" value was, as the name would imply, only used during instantiation. I updated the behavior to reset state it whenever the prop is updated.

There's probably a better name than "initial" given the new behavior, but something like "current" seemed more confusing since the state doesn't always match this prop. I left it as "initial". 🤷 