### PR TITLE
Align labels on non-bars in combo charts

### DIFF
--- a/frontend/src/metabase/visualizations/lib/chart_values.js
+++ b/frontend/src/metabase/visualizations/lib/chart_values.js
@@ -161,6 +161,10 @@ export function onRenderValueLabels(
   // Ordinal bar charts and histograms need extra logic to center the label.
   const xShifts = displays.map((display, index) => {
     if (!isBarLike(display)) {
+      if (displays.some(d => isBarLike(d))) {
+        // this aligns labels on non-bars with in the center of the bar group
+        return ((1 + chart._rangeBandPadding()) * xScale.rangeBand()) / 2;
+      }
       return 0;
     }
     const barIndex = displays.slice(0, index).filter(isBarLike).length;


### PR DESCRIPTION
Fixes #16002

This PR doesn't have any tests. As @nemanjaglumac [pointed out](https://github.com/metabase/metabase/issues/16002#issuecomment-838984177), visual tests seem like the right way to test this. Snapshotting the DOM would have about the same effect, but we're getting rid of those tests.

# Before

<img width="1375" alt="before" src="https://user-images.githubusercontent.com/691495/120864344-167dbe00-c55a-11eb-8c7b-b96edd1e71ad.png">


# After
<img width="1375" alt="after" src="https://user-images.githubusercontent.com/691495/120864356-1c739f00-c55a-11eb-8d02-a608ada34452.png">


