### PR TITLE
Include datetime time portion even if 00:00.00

### DIFF
--- a/src/metabase/query_processor/streaming/common.clj
+++ b/src/metabase/query_processor/streaming/common.clj
@@ -35,9 +35,7 @@
 
   LocalDateTime
   (format-value [t]
-    (if (= (t/local-time t) (t/local-time 0))
-      (format-value (t/local-date t))
-      (u.date/format t)))
+    (u.date/format t))
 
   LocalTime
   (format-value [t]

--- a/test/metabase/query_processor/streaming/csv_test.clj
+++ b/test/metabase/query_processor/streaming/csv_test.clj
@@ -56,13 +56,16 @@
             ["5" "Quentin Sören"       "2014-10-03T17:30:00"]]
            (parse-and-sort-csv result))))
   (testing "Even if they are at 00:00.00 timestamp (#14504)"
-    (let [result (csv/read-csv
+    (let [query  (str "SELECT CAST(TIMESTAMP '2020-01-01 00:00:00' AS TIMESTAMP(0)) AS \"DATETIME\", "
+                      "       CAST(TIMESTAMP '2020-01-01 00:00:00' AS DATE) AS \"DATE\" "
+                      "UNION ALL "
+                      "SELECT CAST(TIMESTAMP '2020-01-02 00:00:22' AS TIMESTAMP(0)), "
+                      "       CAST(TIMESTAMP '2020-01-02 00:00:22' AS DATE)")
+          result (csv/read-csv
                   (mt/user-http-request :rasta :post 200 "dataset/csv" :query
                                         (json/generate-string
-                                         {:type "native"
-                                          :native
-                                          {:query
-                                           "SELECT CAST(TIMESTAMP '2020-01-01 00:00:00' AS TIMESTAMP(0)) AS \"DATETIME\", CAST(TIMESTAMP '2020-01-01 00:00:00' AS DATE) AS \"DATE\"\nUNION ALL \nSELECT CAST(TIMESTAMP '2020-01-02 00:00:22' AS TIMESTAMP(0)), CAST(TIMESTAMP '2020-01-02 00:00:22' AS DATE)"}
+                                         {:type     "native"
+                                          :native   {:query query}
                                           :database 1})))]
       (is (= [["DATETIME"            "DATE"]
               ["2020-01-01T00:00:00" "2020-01-01"]

--- a/test/metabase/query_processor/streaming/csv_test.clj
+++ b/test/metabase/query_processor/streaming/csv_test.clj
@@ -54,4 +54,17 @@
             ["3" "Kaneonuskatew Eiran" "2014-11-06T16:15:00"]
             ["4" "Simcha Yan"          "2014-01-01T08:30:00"]
             ["5" "Quentin Sören"       "2014-10-03T17:30:00"]]
-           (parse-and-sort-csv result)))))
+           (parse-and-sort-csv result))))
+  (testing "Even if they are at 00:00.00 timestamp (#14504)"
+    (let [result (csv/read-csv
+                  (mt/user-http-request :rasta :post 200 "dataset/csv" :query
+                                        (json/generate-string
+                                         {:type "native"
+                                          :native
+                                          {:query
+                                           "SELECT CAST(TIMESTAMP '2020-01-01 00:00:00' AS TIMESTAMP(0)) AS \"DATETIME\", CAST(TIMESTAMP '2020-01-01 00:00:00' AS DATE) AS \"DATE\"\nUNION ALL \nSELECT CAST(TIMESTAMP '2020-01-02 00:00:22' AS TIMESTAMP(0)), CAST(TIMESTAMP '2020-01-02 00:00:22' AS DATE)"}
+                                          :database 1})))]
+      (is (= [["DATETIME"            "DATE"]
+              ["2020-01-01T00:00:00" "2020-01-01"]
+              ["2020-01-02T00:00:22" "2020-01-02"]]
+             result)))))

--- a/test/metabase/query_processor_test/date_field_test.clj
+++ b/test/metabase/query_processor_test/date_field_test.clj
@@ -1,0 +1,16 @@
+(ns metabase.query-processor-test.date-field-test
+  (:require [clojure.test :refer :all]
+            [metabase.query-processor :as qp]
+            [metabase.test :as mt]))
+
+(deftest dates-should-be-dates-test
+  (testing "DATES should come back as LocalDates (#14504)"
+    (mt/test-drivers (mt/normal-drivers)
+      (is (instance?
+           java.time.LocalDate
+           (first
+            (mt/first-row
+             (qp/process-query
+              (mt/query checkins
+                {:query      {:fields [$date], :limit 1}
+                 :middleware {:format-rows? false}})))))))))


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/14504

Remove check that truncated times from LocalDateTime when time was equal to `00:00.00` Seems outdated. Dates end up in `LocalDate` and already don't have timestamps on them.
