### PR TITLE
Detect if file is blank or bad for SQLite DB connection

### DIFF
--- a/modules/drivers/sqlite/src/metabase/driver/sqlite.clj
+++ b/modules/drivers/sqlite/src/metabase/driver/sqlite.clj
@@ -42,14 +42,19 @@
 ;; Every SQLite3 file starts with "SQLite Format 3"
 ;; or "** This file contains an SQLite
 ;; There is also SQLite2 but last 2 version was 2005
-(defmethod driver/can-connect? :sqlite
-  [driver details]
-  (with-open [reader (io/input-stream (:db details))]
+(defn- confirm-file-is-sqlite [filename]
+  (with-open [reader (io/input-stream filename)]
     (let [outarr (byte-array 50)]
       (.read reader outarr)
       (let [line (String. outarr)]
         (or (str/includes? line "SQLite format 3")
             (str/includes? line "This file contains an SQLite"))))))
+
+(defmethod driver/can-connect? :sqlite
+  [driver details]
+  (if (confirm-file-is-sqlite (:db details))
+    (sql-jdbc.conn/can-connect? driver details)
+    false ))
 
 (defmethod driver/db-start-of-week :sqlite
   [_]


### PR DESCRIPTION
Pursuant to #16199
Problem
- If you put in a filename for a nonexistent file in the SQLite filename connection, MB will happily eat it up until you try to issue queries, whereupon which it will explode

Solution
- Don't let user do that. Check if db file exists straight up and if it's a proper SQLite file