### PR TITLE
Binned dimension: fix redundant temporal sub-dimensions

### DIFF
--- a/frontend/src/metabase-lib/lib/Dimension.js
+++ b/frontend/src/metabase-lib/lib/Dimension.js
@@ -753,9 +753,10 @@ export class FieldDimension extends Dimension {
 
     // Add temporal dimensions
     if (field.isDate() && !this.isIntegerFieldId()) {
-      const temporalDimensions = DATETIME_UNITS.map(unit =>
-        this.withTemporalUnit(unit),
-      );
+      const temporalDimensions = _.difference(
+        DATETIME_UNITS,
+        dimensions.map(dim => dim.temporalUnit()),
+      ).map(unit => this.withTemporalUnit(unit));
       dimensions = [...dimensions, ...temporalDimensions];
     }
 

--- a/frontend/src/metabase-lib/lib/Dimension.js
+++ b/frontend/src/metabase-lib/lib/Dimension.js
@@ -1,5 +1,6 @@
 import { t, ngettext, msgid } from "ttag";
 import _ from "underscore";
+import { assoc } from "icepick";
 
 import { stripId, FK_SYMBOL } from "metabase/lib/formatting";
 import { TYPE } from "metabase/lib/types";
@@ -816,9 +817,15 @@ export class FieldDimension extends Dimension {
       additionalProperties._subTriggerDisplayName = option.name;
     }
 
+    const { type } = option;
+    const options =
+      type && !dimension.binningOptions()
+        ? assoc(dimension._options || {}, "base-type", type)
+        : dimension._options;
+
     return new FieldDimension(
       dimension._fieldIdOrName,
-      dimension._options,
+      options,
       this._metadata,
       this._query,
       additionalProperties,

--- a/frontend/src/metabase/query_builder/components/DimensionList.jsx
+++ b/frontend/src/metabase/query_builder/components/DimensionList.jsx
@@ -253,13 +253,21 @@ export const DimensionPicker = ({
   dimensions,
   onChangeDimension,
 }) => {
+  let current = dimensions.findIndex(d => d.isEqual(dimension));
+  if (dimension && current < 0) {
+    // In some cases (e.g. from native SQL), the subdimension contains
+    // additional options (usually "base-type") which fail the above exact
+    // match. Thus, try it again with a typeless comparison.
+    const subdim = dimension.withoutOptions(["base-type"]);
+    current = dimensions.findIndex(d => d.isEqual(subdim));
+  }
   return (
     <ul className={cx(className, "px2 py1")} style={style}>
       {dimensions.map((d, index) => (
         <li
           key={index}
           className={cx("List-item", {
-            "List-item--selected": d.isEqual(dimension),
+            "List-item--selected": index === current,
           })}
         >
           <a

--- a/frontend/src/metabase/query_builder/components/DimensionList.jsx
+++ b/frontend/src/metabase/query_builder/components/DimensionList.jsx
@@ -260,6 +260,12 @@ export const DimensionPicker = ({
     // match. Thus, try it again with a typeless comparison.
     const subdim = dimension.withoutOptions(["base-type"]);
     current = dimensions.findIndex(d => d.isEqual(subdim));
+    if (current < 0) {
+      // The other way around, comparing with typeless subdimensions.
+      current = dimensions.findIndex(d =>
+        d.withoutOptions(["base-type"]).isEqual(subdim),
+      );
+    }
   }
   return (
     <ul className={cx(className, "px2 py1")} style={style}>

--- a/frontend/test/metabase/scenarios/native/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/native.cy.spec.js
@@ -665,7 +665,7 @@ describe("scenarios > question > native", () => {
     cy.get("@sidebar").contains(/added/i);
   });
 
-  it.skip("shouldn't render double binning options when question is based on the saved native question (metabase#16327)", () => {
+  it("shouldn't render double binning options when question is based on the saved native question (metabase#16327)", () => {
     cy.createNativeQuestion({
       name: "16327",
       native: { query: "select * from products limit 5" },


### PR DESCRIPTION
This fixes #16327.

Steps to verify (from the said bug, copied here for convenience):
1. Ask a question, Native question
2. Type `select * from products` and save it as Q1
3. Ask a question, Custom question
4. Choose Saved Questions, Q1
5. Summarize: _Count_, by _CREATED_AT_ (click on the binning menu)

**Before**

The pop-up list shows too many items, with duplicated ones.

![image](https://user-images.githubusercontent.com/7288/120876037-6e6cf280-c563-11eb-90ca-cd0449ff06bc.png)

**After**

![image](https://user-images.githubusercontent.com/7288/120876062-8775a380-c563-11eb-87e0-67a877be8595.png)
