### PR TITLE
Adjust CSP header to make React Dev Tools work on Firefox

### DIFF
--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -50,8 +50,8 @@
   {"Strict-Transport-Security" "max-age=31536000"})
 
 (defn- content-security-policy-header
-  []
   "`Content-Security-Policy` header. See https://content-security-policy.com for more details."
+  []
   {"Content-Security-Policy"
    (str/join
     (for [[k vs] {:default-src  ["'none'"]

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -49,7 +49,8 @@
   the original request was HTTPS; if sent in response to an HTTP request, this is simply ignored)"
   {"Strict-Transport-Security" "max-age=31536000"})
 
-(def ^:private content-security-policy-header
+(defn- content-security-policy-header
+  []
   "`Content-Security-Policy` header. See https://content-security-policy.com for more details."
   {"Content-Security-Policy"
    (str/join
@@ -96,7 +97,7 @@
 
 (defn- content-security-policy-header-with-frame-ancestors
   [allow-iframes?]
-  (update content-security-policy-header
+  (update (content-security-policy-header)
           "Content-Security-Policy"
           #(format "%s frame-ancestors %s;" % (if allow-iframes? "*" (or (embedding-app-origin) "'none'")))))
 

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -64,8 +64,13 @@
                                    "*.gstatic.com"
                                    ;; for webpack hot reloading
                                    (when config/is-dev?
-                                     "localhost:8080")]
-                                  (map (partial format "'sha256-%s'") inline-js-hashes))
+                                     "localhost:8080")
+                                   ;; for react dev tools to work in Firefox until resolution of
+                                   ;; https://github.com/facebook/react/issues/17997
+                                   (when config/is-dev?
+                                     "'unsafe-inline'")]
+                                   (when-not config/is-dev?
+                                     (map (partial format "'sha256-%s'") inline-js-hashes)))
                   :child-src    ["'self'"
                                  ;; TODO - double check that we actually need this for Google Auth
                                  "https://accounts.google.com"]

--- a/test/metabase/api/common_test.clj
+++ b/test/metabase/api/common_test.clj
@@ -15,7 +15,7 @@
   {:status  404
    :body    "Not found."
    :headers {"Cache-Control"                     "max-age=0, no-cache, must-revalidate, proxy-revalidate"
-             "Content-Security-Policy"           (str (-> @#'mw.security/content-security-policy-header vals first)
+             "Content-Security-Policy"           (str (-> (@#'mw.security/content-security-policy-header) vals first)
                                                       " frame-ancestors 'none';")
              "Content-Type"                      "text/plain"
              "Expires"                           "Tue, 03 Jul 2001 06:00:00 GMT"

--- a/test/metabase/server/middleware/security_test.clj
+++ b/test/metabase/server/middleware/security_test.clj
@@ -1,20 +1,32 @@
 (ns metabase.server.middleware.security-test
   (:require [clojure.string :as str]
             [clojure.test :refer :all]
+            [metabase.config :as config]
             [metabase.server.middleware.security :as mw.security]
             [metabase.test.util :as tu]))
 
-(defn- csp-frame-ancestors-directive
-  []
+(defn- csp-directive
+  [directive]
   (-> (mw.security/security-headers)
       (get "Content-Security-Policy")
       (str/split #"; *")
-      (as-> xs (filter #(str/starts-with? % "frame-ancestors ") xs))
+      (as-> xs (filter #(str/starts-with? % (str directive " ")) xs))
       first))
 
 (defn- x-frame-options-header
   []
   (get (mw.security/security-headers) "X-Frame-Options"))
+
+(deftest csp-header-script-src-tests
+  (testing "Inline scripts use hash-based allowlist in prod environment"
+    (with-redefs [config/is-dev? false]
+      (is (str/includes? (csp-directive "script-src") "sha256"))
+      (is (not (str/includes? (csp-directive "script-src") "'unsafe-inline'")))))
+
+  (testing "Any inline scripts are allowed in dev environment (#16375)"
+    (with-redefs [config/is-dev? true]
+      (is (not (str/includes? (csp-directive "script-src") "sha256")))
+      (is (str/includes? (csp-directive "script-src") "'unsafe-inline'")))))
 
 (deftest csp-header-frame-ancestor-tests
   (testing "Frame ancestors from `embedding-app-origin` setting"
@@ -22,19 +34,19 @@
       (tu/with-temporary-setting-values [enable-embedding     true
                                          embedding-app-origin multiple-ancestors]
         (is (= (str "frame-ancestors " multiple-ancestors)
-               (csp-frame-ancestors-directive))))))
+               (csp-directive "frame-ancestors"))))))
 
   (testing "Frame ancestors is 'none' for nil `embedding-app-origin`"
     (tu/with-temporary-setting-values [enable-embedding     true
                                        embedding-app-origin nil]
       (is (= "frame-ancestors 'none'"
-             (csp-frame-ancestors-directive)))))
+             (csp-directive "frame-ancestors")))))
 
   (testing "Frame ancestors is 'none' if embedding is disabled"
     (tu/with-temporary-setting-values [enable-embedding     false
                                        embedding-app-origin "https: http:"]
       (is (= "frame-ancestors 'none'"
-          (csp-frame-ancestors-directive))))))
+          (csp-directive "frame-ancestors"))))))
 
 (deftest xframeoptions-header-tests
   (testing "`DENY` when embedding is disabled"


### PR DESCRIPTION
React Dev Tools currently doesn't work on Firefox because it tries to inject a script which is blocked by the `script-src` directive in the content-security-policy header. This is a known issue with the extension: https://github.com/facebook/react/issues/17997

Until this is fixed in the extension, a workaround for local development is to allow all inline scripts and turn off hash-based whitelisting. I can't think of any risks for making this change in dev environments, but let me know if I'm overlooking something.
Before             |  After
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/32746338/121081401-89bd4500-c791-11eb-8a8c-236ae21b0bb0.png)  |  ![](https://user-images.githubusercontent.com/32746338/121081239-4bc02100-c791-11eb-802f-ce4b049703a6.png)

