### PR TITLE
add missing prop-types to question audit

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditParameters.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditParameters.jsx
@@ -1,29 +1,22 @@
 import React from "react";
+import PropTypes from "prop-types";
 
 import _ from "underscore";
 
 const DEBOUNCE_PERIOD = 300;
 
-type AuditParameter = {
-  key: string,
-  placeholder: string,
-};
-
-type Props = {
-  parameters: AuditParameter[],
-  children?: (committedValues: { [key: string]: string }) => React.Element,
-};
-
-type State = {
-  inputValues: { [key: string]: string },
-  committedValues: { [key: string]: string },
+const propTypes = {
+  parameters: PropTypes.arrayOf(
+    PropTypes.shape({
+      key: PropTypes.string.isRequired,
+      placeholder: PropTypes.string.isRequired,
+    }),
+  ),
+  children: PropTypes.func,
 };
 
 export default class AuditParameters extends React.Component {
-  props: Props;
-  state: State;
-
-  constructor(props: Props) {
+  constructor(props) {
     super(props);
     this.state = {
       inputValues: {},
@@ -68,3 +61,5 @@ export default class AuditParameters extends React.Component {
     );
   }
 }
+
+AuditParameters.propTypes = propTypes;

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTableVisualization.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTableVisualization.jsx
@@ -1,5 +1,5 @@
-/* eslint-disable react/prop-types */
 import React from "react";
+import PropTypes from "prop-types";
 
 import { registerVisualization } from "metabase/visualizations/index";
 
@@ -19,6 +19,19 @@ import _ from "underscore";
 import cx from "classnames";
 
 const getColumnName = column => column.remapped_to || column.name;
+
+const propTypes = {
+  series: PropTypes.array,
+  visualizationIsClickable: PropTypes.func,
+  onVisualizationClick: PropTypes.func,
+  onSortingChange: PropTypes.func,
+  settings: PropTypes.object,
+  isSortable: PropTypes.bool,
+  sorting: PropTypes.shape({
+    column: PropTypes.string.isRequired,
+    isAscending: PropTypes.bool.isRequired,
+  }),
+};
 
 export default class AuditTableVisualization extends React.Component {
   static identifier = "audit-table";
@@ -141,5 +154,7 @@ export default class AuditTableVisualization extends React.Component {
     );
   }
 }
+
+AuditTableVisualization.propTypes = propTypes;
 
 registerVisualization(AuditTableVisualization);

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/pages/AuditQuestionDetail.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/pages/AuditQuestionDetail.jsx
@@ -13,12 +13,10 @@ import * as Urls from "metabase/lib/urls";
 
 import * as QuestionDetailCards from "../lib/cards/question_detail";
 
-const tabPropTypes = {
-  questionId: PropTypes.number.isRequired,
-};
-
-AuditQuestionDetail.propTypes = {
-  params: PropTypes.shape(tabPropTypes),
+const pagePropTypes = {
+  params: PropTypes.shape({
+    questionId: PropTypes.string,
+  }),
 };
 
 function AuditQuestionDetail({ params, ...props }) {
@@ -38,7 +36,11 @@ function AuditQuestionDetail({ params, ...props }) {
   );
 }
 
-AuditQuestionActivityTab.propTypes = tabPropTypes;
+AuditQuestionDetail.propTypes = pagePropTypes;
+
+const tabPropTypes = {
+  questionId: PropTypes.number,
+};
 
 function AuditQuestionActivityTab({ questionId }) {
   return (
@@ -57,17 +59,19 @@ function AuditQuestionActivityTab({ questionId }) {
   );
 }
 
-AuditQuestionRevisionsTab.propTypes = tabPropTypes;
+AuditQuestionActivityTab.propTypes = tabPropTypes;
 
 function AuditQuestionRevisionsTab({ questionId }) {
   return <AuditTable table={QuestionDetailCards.revisionHistory(questionId)} />;
 }
 
-AuditQuestionAuditLogTab.propTypes = tabPropTypes;
+AuditQuestionRevisionsTab.propTypes = tabPropTypes;
 
 function AuditQuestionAuditLogTab({ questionId }) {
   return <AuditTable table={QuestionDetailCards.auditLog(questionId)} />;
 }
+
+AuditQuestionAuditLogTab.propTypes = tabPropTypes;
 
 AuditQuestionDetail.tabs = [
   { path: "activity", title: "Activity", component: AuditQuestionActivityTab },


### PR DESCRIPTION
Added propTypes I missed for https://github.com/metabase/metabase/pull/16138

How to test:
- Run the app in EE mode
- Ensure there are no related errors for http://localhost:3000/admin/audit/questions/all and http://localhost:3000/admin/audit/question/*question_id*/activity (but there will be a bunch of other errors :() 