### PR TITLE
Add sorting to collection items

### DIFF
--- a/frontend/src/metabase/collections/components/BaseItemsTable.jsx
+++ b/frontend/src/metabase/collections/components/BaseItemsTable.jsx
@@ -144,7 +144,7 @@ function BaseItemsTable({
             </SortableColumnHeader>
             <ColumnHeader>{t`Last edited by`}</ColumnHeader>
             <SortableColumnHeader
-              name="last_edited"
+              name="last_edited_at"
               sortingOptions={sortingOptions}
               onSortingOptionsChange={onSortingOptionsChange}
             >

--- a/frontend/src/metabase/collections/components/BaseItemsTable.jsx
+++ b/frontend/src/metabase/collections/components/BaseItemsTable.jsx
@@ -142,7 +142,13 @@ function BaseItemsTable({
             >
               {t`Name`}
             </SortableColumnHeader>
-            <ColumnHeader>{t`Last edited by`}</ColumnHeader>
+            <SortableColumnHeader
+              name="last_edited_by"
+              sortingOptions={sortingOptions}
+              onSortingOptionsChange={onSortingOptionsChange}
+            >
+              {t`Last edited by`}
+            </SortableColumnHeader>
             <SortableColumnHeader
               name="last_edited_at"
               sortingOptions={sortingOptions}

--- a/frontend/src/metabase/collections/components/BaseItemsTable.jsx
+++ b/frontend/src/metabase/collections/components/BaseItemsTable.jsx
@@ -3,6 +3,58 @@ import PropTypes from "prop-types";
 import { t } from "ttag";
 
 import BaseTableItem from "./BaseTableItem";
+import {
+  ColumnHeader,
+  SortingIcon,
+  SortingControlContainer,
+} from "./BaseItemsTable.styled";
+
+const sortingOptsShape = PropTypes.shape({
+  sort_column: PropTypes.string.isRequired,
+  sort_direction: PropTypes.oneOf(["asc", "desc"]).isRequired,
+});
+
+SortableColumnHeader.propTypes = {
+  name: PropTypes.string.isRequired,
+  sortingOptions: sortingOptsShape.isRequired,
+  onSortingOptionsChange: PropTypes.func.isRequired,
+  children: PropTypes.node,
+};
+
+function SortableColumnHeader({
+  name,
+  sortingOptions,
+  onSortingOptionsChange,
+  children,
+  ...props
+}) {
+  const isSortingThisColumn = sortingOptions.sort_column === name;
+  const direction = isSortingThisColumn
+    ? sortingOptions.sort_direction
+    : "desc";
+
+  const onSortingControlClick = () => {
+    const nextDirection = direction === "asc" ? "desc" : "asc";
+    onSortingOptionsChange({
+      sort_column: name,
+      sort_direction: nextDirection,
+    });
+  };
+
+  return (
+    <ColumnHeader>
+      <SortingControlContainer
+        {...props}
+        isActive={isSortingThisColumn}
+        onClick={onSortingControlClick}
+        role="button"
+      >
+        {children}
+        <SortingIcon name={direction === "asc" ? "chevronup" : "chevrondown"} />
+      </SortingControlContainer>
+    </ColumnHeader>
+  );
+}
 
 BaseItemsTable.Item = BaseTableItem;
 
@@ -12,6 +64,8 @@ BaseItemsTable.propTypes = {
   selectedItems: PropTypes.arrayOf(PropTypes.object),
   isPinned: PropTypes.bool,
   renderItem: PropTypes.func,
+  sortingOptions: sortingOptsShape,
+  onSortingOptionsChange: PropTypes.func,
   onToggleSelected: PropTypes.func,
   onCopy: PropTypes.func,
   onMove: PropTypes.func,
@@ -37,6 +91,8 @@ function BaseItemsTable({
   onCopy,
   onMove,
   onDrop,
+  sortingOptions,
+  onSortingOptionsChange,
   onToggleSelected,
   getIsSelected = () => false,
   headless = false,
@@ -67,10 +123,29 @@ function BaseItemsTable({
       {!headless && (
         <thead>
           <tr>
-            <th className="text-centered">{t`Type`}</th>
-            <th>{t`Name`}</th>
-            <th>{t`Last edited by`}</th>
-            <th>{t`Last edited at`}</th>
+            <SortableColumnHeader
+              name="model"
+              sortingOptions={sortingOptions}
+              onSortingOptionsChange={onSortingOptionsChange}
+              style={{ marginLeft: 6 }}
+            >
+              {t`Type`}
+            </SortableColumnHeader>
+            <SortableColumnHeader
+              name="name"
+              sortingOptions={sortingOptions}
+              onSortingOptionsChange={onSortingOptionsChange}
+            >
+              {t`Name`}
+            </SortableColumnHeader>
+            <ColumnHeader>{t`Last edited by`}</ColumnHeader>
+            <SortableColumnHeader
+              name="last_edited"
+              sortingOptions={sortingOptions}
+              onSortingOptionsChange={onSortingOptionsChange}
+            >
+              {t`Last edited at`}
+            </SortableColumnHeader>
             <th></th>
           </tr>
         </thead>

--- a/frontend/src/metabase/collections/components/BaseItemsTable.jsx
+++ b/frontend/src/metabase/collections/components/BaseItemsTable.jsx
@@ -121,7 +121,11 @@ function BaseItemsTable({
         <col span="1" style={{ width: "2%" }} />
       </colgroup>
       {!headless && (
-        <thead>
+        <thead
+          data-testid={
+            isPinned ? "pinned-items-table-head" : "items-table-head"
+          }
+        >
           <tr>
             <SortableColumnHeader
               name="model"

--- a/frontend/src/metabase/collections/components/BaseItemsTable.styled.jsx
+++ b/frontend/src/metabase/collections/components/BaseItemsTable.styled.jsx
@@ -3,7 +3,13 @@ import styled from "styled-components";
 import { color } from "metabase/lib/colors";
 
 import EntityItem from "metabase/components/EntityItem";
+import Icon from "metabase/components/Icon";
 import Link from "metabase/components/Link";
+
+export const ColumnHeader = styled.th`
+  font-weight: bold;
+  color: ${color("text-light")};
+`;
 
 export const EntityIconCheckBox = styled(EntityItem.IconCheckBox)`
   width: 3em;
@@ -13,6 +19,29 @@ export const EntityIconCheckBox = styled(EntityItem.IconCheckBox)`
 export const ItemLink = styled(Link)`
   &:hover {
     color: ${color("brand")};
+  }
+`;
+
+export const SortingIcon = styled(Icon).attrs({
+  size: 8,
+})`
+  margin-left: 4px;
+`;
+
+export const SortingControlContainer = styled.div`
+  display: flex;
+  align-items: center;
+  color: ${props => (props.isActive ? color("text-dark") : "")};
+  cursor: pointer;
+  user-select: none;
+  .Icon {
+    visibility: ${props => (props.isActive ? "visible" : "hidden")};
+  }
+  &:hover {
+    color: ${color("text-dark")};
+    .Icon {
+      visibility: visible;
+    }
   }
 `;
 

--- a/frontend/src/metabase/collections/components/BaseTableItem.jsx
+++ b/frontend/src/metabase/collections/components/BaseTableItem.jsx
@@ -85,7 +85,7 @@ export function BaseTableItem({
     // So styled-components can't be used here
     return (
       <tr key={item.id} data-testid={testId} style={trStyles}>
-        <td>
+        <td data-testid={`${testId}-type`}>
           <EntityIconCheckBox
             item={item}
             variant="list"
@@ -96,15 +96,15 @@ export function BaseTableItem({
             onToggleSelected={handleSelectionToggled}
           />
         </td>
-        <td>
+        <td data-testid={`${testId}-name`}>
           <ItemLink {...linkProps} to={item.getUrl()}>
             <EntityItem.Name name={item.name} />
           </ItemLink>
         </td>
-        <td>
+        <td data-testid={`${testId}-last-edited-by`}>
           <TableItemSecondaryField>{lastEditedBy}</TableItemSecondaryField>
         </td>
-        <td>
+        <td data-testid={`${testId}-last-edited-at`}>
           {lastEditInfo && (
             <Tooltip tooltip={<DateTime value={lastEditInfo.timestamp} />}>
               <TableItemSecondaryField>{lastEditedAt}</TableItemSecondaryField>

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -36,6 +36,14 @@ function mapStateToProps(state) {
 function CollectionContent({ collection, collectionId, isAdmin, isRoot }) {
   const [selectedItems, setSelectedItems] = useState(null);
   const [selectedAction, setSelectedAction] = useState(null);
+  const [unpinnedItemsSorting] = useState({
+    sort_column: "name",
+    sort_direction: "asc",
+  });
+  const [pinnedItemsSorting] = useState({
+    sort_column: "name",
+    sort_direction: "asc",
+  });
   const { handleNextPage, handlePreviousPage, page } = usePagination();
   const {
     selected,
@@ -93,11 +101,13 @@ function CollectionContent({ collection, collectionId, isAdmin, isRoot }) {
     limit: PAGE_SIZE,
     offset: PAGE_SIZE * page,
     pinned_state: "is_not_pinned",
+    ...unpinnedItemsSorting,
   };
 
   const pinnedQuery = {
     collection: collectionId,
     pinned_state: "is_pinned",
+    ...pinnedItemsSorting,
   };
 
   return (

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -36,15 +36,15 @@ function mapStateToProps(state) {
 function CollectionContent({ collection, collectionId, isAdmin, isRoot }) {
   const [selectedItems, setSelectedItems] = useState(null);
   const [selectedAction, setSelectedAction] = useState(null);
-  const [unpinnedItemsSorting] = useState({
+  const [unpinnedItemsSorting, setUnpinnedItemsSorting] = useState({
     sort_column: "name",
     sort_direction: "asc",
   });
-  const [pinnedItemsSorting] = useState({
+  const [pinnedItemsSorting, setPinnedItemsSorting] = useState({
     sort_column: "name",
     sort_direction: "asc",
   });
-  const { handleNextPage, handlePreviousPage, page } = usePagination();
+  const { handleNextPage, handlePreviousPage, setPage, page } = usePagination();
   const {
     selected,
     toggleItem,
@@ -79,6 +79,18 @@ function CollectionContent({ collection, collectionId, isAdmin, isRoot }) {
     },
     [selectedItems, clear],
   );
+
+  const handleUnpinnedItemsSortingChange = useCallback(
+    sortingOpts => {
+      setUnpinnedItemsSorting(sortingOpts);
+      setPage(0);
+    },
+    [setPage],
+  );
+
+  const handlePinnedItemsSortingChange = useCallback(sortingOpts => {
+    setPinnedItemsSorting(sortingOpts);
+  }, []);
 
   const handleCloseModal = () => {
     setSelectedItems(null);
@@ -128,10 +140,12 @@ function CollectionContent({ collection, collectionId, isAdmin, isRoot }) {
               <PinnedItemsTable
                 items={pinnedItems}
                 collection={collection}
+                sortingOptions={pinnedItemsSorting}
+                onSortingOptionsChange={handlePinnedItemsSortingChange}
                 selectedItems={selected}
                 getIsSelected={getIsSelected}
-                onDrop={clear}
                 onToggleSelected={toggleItem}
+                onDrop={clear}
                 onMove={handleMove}
                 onCopy={handleCopy}
               />
@@ -161,9 +175,13 @@ function CollectionContent({ collection, collectionId, isAdmin, isRoot }) {
                     <Box mt={hasPinnedItems ? 3 : 0}>
                       <ItemsTable
                         items={unpinnedItems}
+                        collection={collection}
+                        sortingOptions={unpinnedItemsSorting}
+                        onSortingOptionsChange={
+                          handleUnpinnedItemsSortingChange
+                        }
                         selectedItems={selected}
                         getIsSelected={getIsSelected}
-                        collection={collection}
                         onToggleSelected={toggleItem}
                         onDrop={clear}
                         onMove={handleMove}

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -103,10 +103,6 @@ function CollectionContent({ collection, collectionId, isAdmin, isRoot }) {
   return (
     <Search.ListLoader query={pinnedQuery} wrapped>
       {({ list: pinnedItems }) => {
-        const sortedPinnedItems = pinnedItems.sort(
-          (a, b) => a.collection_position - b.collection_position,
-        );
-
         const hasPinnedItems = pinnedItems.length > 0;
 
         return (
@@ -120,7 +116,7 @@ function CollectionContent({ collection, collectionId, isAdmin, isRoot }) {
               />
 
               <PinnedItemsTable
-                items={sortedPinnedItems}
+                items={pinnedItems}
                 collection={collection}
                 selectedItems={selected}
                 getIsSelected={getIsSelected}

--- a/frontend/src/metabase/entities/search.js
+++ b/frontend/src/metabase/entities/search.js
@@ -30,6 +30,8 @@ export default createEntity({
           pinned_state,
           limit,
           offset,
+          sort_column,
+          sort_direction,
           ...unsupported
         } = query;
         if (Object.keys(unsupported).length > 0) {
@@ -47,6 +49,8 @@ export default createEntity({
           pinned_state,
           limit,
           offset,
+          sort_column,
+          sort_direction,
         });
 
         return {

--- a/frontend/test/__support__/e2e/commands.js
+++ b/frontend/test/__support__/e2e/commands.js
@@ -43,10 +43,16 @@ Cypress.Commands.add("button", button_name => {
   cy.findByRole("button", { name: button_name });
 });
 
-Cypress.Commands.add("createDashboard", name => {
-  cy.log(`Create a dashboard: ${name}`);
-  cy.request("POST", "/api/dashboard", { name });
-});
+Cypress.Commands.add(
+  "createDashboard",
+  (name, { collection_position = null } = {}) => {
+    cy.log(`Create a dashboard: ${name}`);
+    cy.request("POST", "/api/dashboard", {
+      name,
+      collection_position,
+    });
+  },
+);
 
 Cypress.Commands.add(
   "createQuestion",
@@ -56,6 +62,7 @@ Cypress.Commands.add(
     display = "table",
     database = 1,
     visualization_settings = {},
+    collection_position = null,
   } = {}) => {
     cy.log(`Create a question: ${name}`);
     cy.request("POST", "/api/card", {
@@ -67,6 +74,7 @@ Cypress.Commands.add(
       },
       display,
       visualization_settings,
+      collection_position,
     });
   },
 );

--- a/frontend/test/metabase/collections/BaseItemsTable.unit.spec.js
+++ b/frontend/test/metabase/collections/BaseItemsTable.unit.spec.js
@@ -34,7 +34,12 @@ describe("Collections BaseItemsTable", () => {
   function setup({ items = [ITEM], ...props } = {}) {
     return render(
       <DragDropContextProvider backend={HTML5Backend}>
-        <BaseItemsTable items={items} {...props} />
+        <BaseItemsTable
+          items={items}
+          sortingOptions={{ sort_column: "name", sort_direction: "asc" }}
+          onSortingOptionsChange={jest.fn()}
+          {...props}
+        />
       </DragDropContextProvider>,
     );
   }

--- a/frontend/test/metabase/scenarios/collections/collection-items-listing.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collection-items-listing.cy.spec.js
@@ -103,6 +103,10 @@ describe("scenarios > collection items listing", () => {
             collection_position: pinned ? i + 1 : null,
           });
 
+          // Signing in as a different users, so we have different names in "Last edited by"
+          // In that way we can test sorting by this column correctly
+          cy.signIn("normal");
+
           cy.createQuestion({
             name: `${letter} Question`,
             collection_position: pinned ? i + 1 : null,
@@ -162,6 +166,30 @@ describe("scenarios > collection items listing", () => {
             );
           },
         );
+
+        const lastEditedByColumnTestId = pinned
+          ? "pinned-collection-entry-last-edited-by"
+          : "collection-entry-last-edited-by";
+
+        toggleSortingFor(/Last edited by/i, { pinned });
+        cy.findAllByTestId(lastEditedByColumnTestId).then(nodes => {
+          const actualNames = _.map(nodes, "innerText");
+          const sortedNames = _.sortBy(actualNames);
+          expect(
+            actualNames,
+            "sorted by last editor name alphabetically",
+          ).to.deep.equal(sortedNames);
+        });
+
+        toggleSortingFor(/Last edited by/i, { pinned });
+        cy.findAllByTestId(lastEditedByColumnTestId).then(nodes => {
+          const actualNames = _.map(nodes, "innerText");
+          const sortedNames = _.sortBy(actualNames);
+          expect(
+            actualNames,
+            "sorted by last editor name alphabetically reversed",
+          ).to.deep.equal(sortedNames.reverse());
+        });
 
         toggleSortingFor(/Last edited at/i, { pinned });
         getAllCollectionItemNames({ pinned }).then(

--- a/frontend/test/metabase/scenarios/collections/collection-items-listing.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collection-items-listing.cy.spec.js
@@ -1,0 +1,62 @@
+import _ from "underscore";
+import { restore } from "__support__/e2e/cypress";
+import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
+
+const { ORDERS, ORDERS_ID } = SAMPLE_DATASET;
+
+describe("scenarios > collection items listing", () => {
+  describe("pagination", () => {
+    const PAGE_SIZE = 25;
+    const ADDED_QUESTIONS = 13;
+    const ADDED_DASHBOARDS = 12;
+    const PRE_EXISTED_ITEMS = 4;
+
+    const TOTAL_ITEMS = ADDED_DASHBOARDS + ADDED_QUESTIONS + PRE_EXISTED_ITEMS;
+
+    beforeEach(() => {
+      restore();
+      cy.signInAsAdmin();
+
+      _.times(12, i => cy.createDashboard(`dashboard ${i}`));
+      _.times(13, i =>
+        cy.createQuestion({
+          name: `generated question ${i}`,
+          query: {
+            "source-table": ORDERS_ID,
+            aggregation: [["count"]],
+            breakout: [
+              ["field", ORDERS.CREATED_AT, { "temporal-unit": "hour-of-day" }],
+            ],
+          },
+        }),
+      );
+    });
+
+    it("should allow to navigate back and forth", () => {
+      cy.visit("/collection/root");
+
+      // First page
+      cy.findByText(`1 - ${PAGE_SIZE}`);
+      cy.findByTestId("pagination-total").should("have.text", TOTAL_ITEMS);
+      cy.findAllByTestId("collection-entry").should("have.length", PAGE_SIZE);
+
+      cy.findByTestId("next-page-btn").click();
+
+      // Second page
+      cy.findByText(`${PAGE_SIZE + 1} - ${TOTAL_ITEMS}`);
+      cy.findByTestId("pagination-total").should("have.text", TOTAL_ITEMS);
+      cy.findAllByTestId("collection-entry").should(
+        "have.length",
+        TOTAL_ITEMS - PAGE_SIZE,
+      );
+      cy.findByTestId("next-page-btn").should("be.disabled");
+
+      cy.findByTestId("previous-page-btn").click();
+
+      // First page
+      cy.findByText(`1 - ${PAGE_SIZE}`);
+      cy.findByTestId("pagination-total").should("have.text", TOTAL_ITEMS);
+      cy.findAllByTestId("collection-entry").should("have.length", PAGE_SIZE);
+    });
+  });
+});

--- a/frontend/test/metabase/scenarios/collections/collection-items-listing.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collection-items-listing.cy.spec.js
@@ -73,4 +73,197 @@ describe("scenarios > collection items listing", () => {
       cy.findAllByTestId("collection-entry").should("have.length", PAGE_SIZE);
     });
   });
+
+  describe("sorting", () => {
+    beforeEach(() => {
+      restore();
+      cy.signInAsAdmin();
+
+      // Removes questions and dashboards included in a default dataset,
+      // so it's easier to test sorting
+      cy.request("GET", "/api/collection/root/items").then(response => {
+        response.body.data.forEach(({ model, id }) => {
+          if (model !== "collection") {
+            cy.request("PUT", `/api/${model}/${id}`, {
+              archived: true,
+            });
+          }
+        });
+      });
+    });
+
+    [true, false].forEach(pinned => {
+      const testName = pinned
+        ? "should allow to sort pinned items by columns asc and desc"
+        : "should allow to sort items by columns asc and desc";
+
+      it(testName, () => {
+        ["A", "B", "C"].forEach((letter, i) => {
+          cy.createDashboard(`${letter} Dashboard`, {
+            collection_position: pinned ? i + 1 : null,
+          });
+
+          cy.createQuestion({
+            name: `${letter} Question`,
+            collection_position: pinned ? i + 1 : null,
+            query: TEST_QUESTION_QUERY,
+          });
+        });
+
+        cy.visit("/collection/root");
+
+        getAllCollectionItemNames({ pinned }).then(
+          ({ actualNames, sortedNames }) => {
+            expect(
+              actualNames,
+              "sorted alphabetically by default",
+            ).to.deep.equal(sortedNames);
+          },
+        );
+
+        toggleSortingFor(/Name/i, { pinned });
+        getAllCollectionItemNames({ pinned }).then(
+          ({ actualNames, sortedNames }) => {
+            expect(actualNames, "sorted alphabetically reversed").to.deep.equal(
+              sortedNames.reverse(),
+            );
+          },
+        );
+
+        toggleSortingFor(/Name/i, { pinned });
+        getAllCollectionItemNames({ pinned }).then(
+          ({ actualNames, sortedNames }) => {
+            expect(actualNames, "sorted alphabetically").to.deep.equal(
+              sortedNames,
+            );
+          },
+        );
+
+        toggleSortingFor(/Type/i, { pinned });
+        getAllCollectionItemNames({ pinned }).then(
+          ({ actualNames, sortedNames }) => {
+            const dashboardsFirst = _.sortBy(sortedNames, name =>
+              name.toLowerCase().includes("question"),
+            );
+            expect(actualNames, "sorted dashboards first").to.deep.equal(
+              dashboardsFirst,
+            );
+          },
+        );
+
+        toggleSortingFor(/Type/i, { pinned });
+        getAllCollectionItemNames({ pinned }).then(
+          ({ actualNames, sortedNames }) => {
+            const questionsFirst = _.sortBy(sortedNames, name =>
+              name.toLowerCase().includes("dashboard"),
+            );
+            expect(actualNames, "sorted questions first").to.deep.equal(
+              questionsFirst,
+            );
+          },
+        );
+
+        toggleSortingFor(/Last edited at/i, { pinned });
+        getAllCollectionItemNames({ pinned }).then(
+          ({ actualNames, sortedNames }) => {
+            expect(actualNames, "sorted newest last").to.deep.equal(
+              sortedNames,
+            );
+          },
+        );
+
+        toggleSortingFor(/Last edited at/i, { pinned });
+        getAllCollectionItemNames({ pinned }).then(
+          ({ actualNames, sortedNames }) => {
+            expect(actualNames, "sorted newest first").to.deep.equal(
+              sortedNames.reverse(),
+            );
+          },
+        );
+      });
+    });
+
+    it("should allow to separately sort pinned and not pinned items", () => {
+      ["A", "B", "C"].forEach((letter, i) => {
+        cy.createDashboard(`${letter} Dashboard`);
+
+        cy.createDashboard(`${letter} Dashboard (pinned)`, {
+          collection_position: i + 1,
+        });
+
+        cy.createQuestion({
+          name: `${letter} Question`,
+          collection_position: null,
+          query: TEST_QUESTION_QUERY,
+        });
+
+        cy.createQuestion({
+          name: `${letter} Question (pinned)`,
+          collection_position: i + 1,
+          query: TEST_QUESTION_QUERY,
+        });
+      });
+
+      cy.visit("/collection/root");
+
+      toggleSortingFor(/Type/i, { pinned: true });
+      toggleSortingFor(/Name/, { pinned: false });
+
+      getAllCollectionItemNames({ pinned: true }).then(
+        ({ actualNames, sortedNames }) => {
+          const dashboardsFirst = _.sortBy(sortedNames, name =>
+            name.toLowerCase().includes("question"),
+          );
+          expect(actualNames, "sorted dashboards first").to.deep.equal(
+            dashboardsFirst,
+          );
+        },
+      );
+
+      getAllCollectionItemNames({ pinned: false }).then(
+        ({ actualNames, sortedNames }) => {
+          expect(actualNames, "sorted alphabetically reversed").to.deep.equal(
+            sortedNames.reverse(),
+          );
+        },
+      );
+    });
+
+    it("should reset pagination if sorting applied on not first page", () => {
+      _.times(15, i => cy.createDashboard(`dashboard ${i}`));
+      _.times(15, i =>
+        cy.createQuestion({
+          name: `generated question ${i}`,
+          query: TEST_QUESTION_QUERY,
+        }),
+      );
+
+      cy.visit("/collection/root");
+
+      cy.findByText(`1 - ${PAGE_SIZE}`);
+      cy.findByTestId("next-page-btn").click();
+
+      toggleSortingFor(/Last edited at/i);
+
+      cy.findByText(`1 - ${PAGE_SIZE}`);
+    });
+  });
 });
+
+function toggleSortingFor(columnName, { pinned = false } = {}) {
+  const testId = pinned ? "pinned-items-table-head" : "items-table-head";
+  cy.findByTestId(testId)
+    .findByText(columnName)
+    .click();
+}
+
+function getAllCollectionItemNames({ pinned = false } = {}) {
+  const testId = pinned
+    ? "pinned-collection-entry-name"
+    : "collection-entry-name";
+  return cy.findAllByTestId(testId).then(nodes => {
+    const actualNames = _.map(nodes, "innerText");
+    const sortedNames = _.sortBy(actualNames);
+    return { actualNames, sortedNames };
+  });
+}

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -1,4 +1,3 @@
-import _ from "underscore";
 import {
   restore,
   setupLocalHostEmail,
@@ -7,10 +6,8 @@ import {
   openOrdersTable,
   sidebar,
 } from "__support__/e2e/cypress";
-import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
 import { USERS, USER_GROUPS } from "__support__/e2e/cypress_data";
 
-const { ORDERS, ORDERS_ID } = SAMPLE_DATASET;
 const { nocollection } = USERS;
 const { DATA_GROUP } = USER_GROUPS;
 
@@ -245,61 +242,6 @@ describe("scenarios > collection_defaults", () => {
         cy.visit("/collection/root");
         cy.findByText(dashboard_name);
       });
-    });
-  });
-
-  describe("pagination", () => {
-    const PAGE_SIZE = 25;
-    const ADDED_QUESTIONS = 13;
-    const ADDED_DASHBOARDS = 12;
-    const PRE_EXISTED_ITEMS = 4;
-
-    const TOTAL_ITEMS = ADDED_DASHBOARDS + ADDED_QUESTIONS + PRE_EXISTED_ITEMS;
-
-    beforeEach(() => {
-      restore();
-      cy.signInAsAdmin();
-
-      _.times(12, i => cy.createDashboard(`dashboard ${i}`));
-      _.times(13, i =>
-        cy.createQuestion({
-          name: `generated question ${i}`,
-          query: {
-            "source-table": ORDERS_ID,
-            aggregation: [["count"]],
-            breakout: [
-              ["field", ORDERS.CREATED_AT, { "temporal-unit": "hour-of-day" }],
-            ],
-          },
-        }),
-      );
-    });
-
-    it("should allow to navigate back and forth", () => {
-      cy.visit("/collection/root");
-
-      // First page
-      cy.findByText(`1 - ${PAGE_SIZE}`);
-      cy.findByTestId("pagination-total").should("have.text", TOTAL_ITEMS);
-      cy.findAllByTestId("collection-entry").should("have.length", PAGE_SIZE);
-
-      cy.findByTestId("next-page-btn").click();
-
-      // Second page
-      cy.findByText(`${PAGE_SIZE + 1} - ${TOTAL_ITEMS}`);
-      cy.findByTestId("pagination-total").should("have.text", TOTAL_ITEMS);
-      cy.findAllByTestId("collection-entry").should(
-        "have.length",
-        TOTAL_ITEMS - PAGE_SIZE,
-      );
-      cy.findByTestId("next-page-btn").should("be.disabled");
-
-      cy.findByTestId("previous-page-btn").click();
-
-      // First page
-      cy.findByText(`1 - ${PAGE_SIZE}`);
-      cy.findByTestId("pagination-total").should("have.text", TOTAL_ITEMS);
-      cy.findAllByTestId("collection-entry").should("have.length", PAGE_SIZE);
     });
   });
 


### PR DESCRIPTION
This PR is subsequent to #16357 and #16360 and makes it possible to sort collection items by their type, name, and last edit info.

Notes:

* pinned items' `collection_position` field won't affect their position in the list anymore
* items filtering by their type is replaced with sorting (questions first, dashboards first)
* created [`collections/collection-items-listing.cy.spec.js`](https://github.com/metabase/metabase/blob/7562f21d516871d417d67483132bfd9e92783dd6/frontend/test/metabase/scenarios/collections/collection-items-listing.cy.spec.js) test file containing pagination and sorting test. So don't be surprised if you see pagination E2E tests are removed from collections.cy.spec.js, they're just moved :D
* closes #13435

### To Verify

⚠️ You might notice UI flashes when you change sorting for the first time on a page. This PR is fixing that #16511

1. Open a collection. The more different items it contains, the better
2. Ensure both pinned and not pinned tables are sorted alphabetically by name as a default
3. Click the "Name" column, the list has to be sorted in reversed alphabetical order
4. Click the "Type" column; the items have to be sorted in Dashboards-Pulses-Questions order
5. Click the "Type" column one more time; the items have to be sorted in Questions-Pulses-Dashboards order
6. Click the "Last edited at" column; the items have to be sorted by that column now
7. Try applying different sortings to pinned and not pinned tables. They have to be separately sortable and not affect one another

### Demo

https://user-images.githubusercontent.com/17258145/120652942-e74b4c00-c488-11eb-98f8-7d576381a3aa.mov