### PR TITLE
Fix JS error on JWT settings form

### DIFF
--- a/frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx
@@ -12,6 +12,8 @@ import DisclosureTriangle from "metabase/components/DisclosureTriangle";
 import MetabaseUtils from "metabase/lib/utils";
 import SettingsSetting from "./SettingsSetting";
 
+import { updateSettings as defaultUpdateSettings } from "../settings";
+
 const VALIDATIONS = {
   email: {
     validate: value => MetabaseUtils.validEmail(value),
@@ -33,7 +35,7 @@ const SAVE_SETTINGS_BUTTONS_STATES = {
   null,
   (dispatch, { updateSettings }) => ({
     updateSettings:
-      updateSettings || (settings => dispatch(updateSettings(settings))),
+      updateSettings || (settings => dispatch(defaultUpdateSettings(settings))),
   }),
   null,
   { withRef: true }, // HACK: needed so consuming components can call methods on the component :-/

--- a/frontend/test/metabase/scenarios/admin/settings/sso.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/sso.cy.spec.js
@@ -80,7 +80,7 @@ describe("scenarios > admin > settings > SSO", () => {
       cy.visit("/admin/settings/authentication/jwt");
     });
 
-    it.skip("should save JWT without an error (metabase#16378)", () => {
+    it("should save JWT without an error (metabase#16378)", () => {
       cy.intercept("PUT", "/api/**").as("update");
 
       cy.findByText("JWT Authentication")


### PR DESCRIPTION
Fixes regression introduced by #16187. I had removed the `updateSettings` import because I was seeing an `unused import` error, but that was just because the name was being shadowed by the argument to `mapDispatchToProps` in the `@connect` decorator. Didn't catch the mistake since we didn't have a test for JWT settings. Re-adding the import with an aliased name fixes this.