### PR TITLE
Fix missing time series footer

### DIFF
--- a/frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx
+++ b/frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx
@@ -75,7 +75,7 @@ export default class TimeseriesFilterWidget extends Component {
       if (filterIndex >= 0) {
         filter = currentFilter = filters[filterIndex];
       } else {
-        filter = ["time-interval", timeField, -30, "day"];
+        filter = ["time-interval", timeField.mbql(), -30, "day"];
       }
 
       // $FlowFixMe

--- a/frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx
+++ b/frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx
@@ -7,12 +7,10 @@ import Button from "metabase/components/Button";
 
 import * as Query from "metabase/lib/query/query";
 import * as Filter from "metabase/lib/query/filter";
-import * as FieldRef from "metabase/lib/query/field_ref";
 import * as Card from "metabase/meta/Card";
 
 import {
   parseFieldTarget,
-  parseFieldTargetId,
   generateTimeFilterValuesDescriptions,
 } from "metabase/lib/query_time";
 
@@ -61,14 +59,13 @@ export default class TimeseriesFilterWidget extends Component {
       const breakouts = Query.getBreakouts(query);
       const filters = Query.getFilters(query);
 
-      const timeFieldId = parseFieldTargetId(breakouts[0]);
       const timeField = parseFieldTarget(breakouts[0]);
 
       const filterIndex = _.findIndex(
         filters,
         filter =>
           Filter.isFieldFilter(filter) &&
-          FieldRef.getFieldTargetId(filter[1]) === timeFieldId,
+          _.isEqual(filter[1], timeField.mbql()),
       );
 
       let filter, currentFilter;

--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -115,7 +115,8 @@ export default class View extends React.Component {
     if (!card || !databases) {
       return <LoadingAndErrorWrapper className={fitClassNames} loading />;
     }
-    const ModeFooter = mode && mode.ModeFooter;
+    const queryMode = mode && mode.queryMode();
+    const ModeFooter = queryMode && queryMode.ModeFooter;
     const isStructured = query instanceof StructuredQuery;
     const isNative = query instanceof NativeQuery;
 

--- a/frontend/test/metabase/scenarios/question/new.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/new.cy.spec.js
@@ -230,7 +230,7 @@ describe("scenarios > question > new", () => {
       cy.findByText("Hour of Day");
     });
 
-    it.skip("should display timeseries filter and granularity widgets at the bottom of the screen (metabase#11183)", () => {
+    it("should display timeseries filter and granularity widgets at the bottom of the screen (metabase#11183)", () => {
       cy.createQuestion({
         name: "11183",
         query: {


### PR DESCRIPTION
This should fix #11183. It is a regression introduced in the refactoring in commit d32039aca (as part of PR #10655). It missed the proper property lookup for the query mode's footer.

Run the E2E tests:
```
yarn test-cypress-no-build --spec frontend/test/metabase/scenarios/question/new.cy.spec.js 
```

Steps to verify manually (copied here from #11183 for convenience):

1. Ask a question, Custom question
2. Sample Dataset, Orders table
3. Summarize by _Sum of Subtotal_, group by _Created At (Monthly)_
4. Visualize

**Before this PR**:

At the bottom, there isn't any drop-down to adjust for filter and granularity.

![image](https://user-images.githubusercontent.com/7288/121095528-54baed80-c7a5-11eb-8d38-9eeb395994a5.png)

**After this PR**:

At the bottom, there are two drop-down for filter and granuality.

![image](https://user-images.githubusercontent.com/7288/121095550-5dabbf00-c7a5-11eb-92d6-778ec8ceb459.png)
