### PR TITLE
Fix #16299 MongoDB empty results when filtering against array

### DIFF
--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -320,7 +320,8 @@
 (defn- filter-expr [operator field value]
   (let [field-rvalue (->rvalue field)
         value-rvalue (->rvalue value)]
-    (if (simple-rvalue? field-rvalue)
+    (if (and (simple-rvalue? field-rvalue)
+             (simple-rvalue? value-rvalue))
       ;; if we don't need to do anything fancy with field we can generate a clause like
       ;;
       ;;    {field {$eq 100}}

--- a/modules/drivers/mongo/test/metabase/driver/array-fields.json
+++ b/modules/drivers/mongo/test/metabase/driver/array-fields.json
@@ -1,0 +1,119 @@
+[
+  {
+    "json_field": {
+      "key_1": "value_jf_a",
+      "key_2": "value_jf_z"
+    },
+    "list_field": [
+      "value_lf_a",
+      "value_lf_b"
+    ],
+    "metas": {
+      "group_field": "value_gf_a"
+    }
+  },
+  {
+    "json_field": {
+      "key_1": "value_jf_b",
+      "key_2": "value_jf_z"
+    },
+    "list_field": [
+      "value_lf_a",
+      "value_lf_b"
+    ],
+    "metas": {
+      "group_field": "value_gf_b"
+    }
+  },
+  {
+    "json_field": {
+      "key_1": "value_jf_c",
+      "key_2": "value_jf_z"
+    },
+    "list_field": [
+      "value_lf_a",
+      "value_lf_b"
+    ],
+    "metas": {
+      "group_field": "value_gf_c"
+    }
+  },
+  {
+    "json_field": {
+      "key_1": "value_jf_a",
+      "key_2": "value_jf_z"
+    },
+    "list_field": [
+      "value_lf_c",
+      "value_lf_d"
+    ],
+    "metas": {
+      "group_field": "value_gf_a"
+    }
+  },
+  {
+    "json_field": {
+      "key_1": "value_jf_b",
+      "key_2": "value_jf_z"
+    },
+    "list_field": [
+      "value_lf_c",
+      "value_lf_d"
+    ],
+    "metas": {
+      "group_field": "value_gf_b"
+    }
+  },
+  {
+    "json_field": {
+      "key_1": "value_jf_c",
+      "key_2": "value_jf_z"
+    },
+    "list_field": [
+      "value_lf_c",
+      "value_lf_d"
+    ],
+    "metas": {
+      "group_field": "value_gf_c"
+    }
+  },
+  {
+    "json_field": {
+      "key_1": "value_jf_a",
+      "key_2": "value_jf_z"
+    },
+    "list_field": [
+      "value_lf_c",
+      "value_lf_d"
+    ],
+    "metas": {
+      "group_field": "value_gf_a"
+    }
+  },
+  {
+    "json_field": {
+      "key_1": "value_jf_b",
+      "key_2": "value_jf_z"
+    },
+    "list_field": [
+      "value_lf_c",
+      "value_lf_d"
+    ],
+    "metas": {
+      "group_field": "value_gf_b"
+    }
+  },
+  {
+    "json_field": {
+      "key_1": "value_jf_c",
+      "key_2": "value_jf_z"
+    },
+    "list_field": [
+      "value_lf_c",
+      "value_lf_d"
+    ],
+    "metas": {
+      "group_field": "value_gf_c"
+    }
+  }
+]

--- a/modules/drivers/mongo/test/metabase/driver/mongo/query_processor_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/query_processor_test.clj
@@ -112,7 +112,7 @@
       (mt/dataset geographical-tips
         (mt/with-everything-store
           (is (= {:projections ["count"]
-                  :query       [{"$match" {"source.username" {"$eq" "tupac"}}}
+                  :query       [{"$match" {"source.username" "tupac"}}
                                 {"$group" {"_id" nil, "count" {"$sum" 1}}}
                                 {"$sort" {"_id" 1}}
                                 {"$project" {"_id" false, "count" true}}],

--- a/modules/drivers/mongo/test/metabase/test/data/mongo.clj
+++ b/modules/drivers/mongo/test/metabase/test/data/mongo.clj
@@ -31,7 +31,7 @@
       (let [field-names (for [field-definition field-definitions]
                           (keyword (:field-name field-definition)))]
         ;; Use map-indexed so we can get an ID for each row (index + 1)
-        (doseq [[i row] (map-indexed (partial vector) rows)]
+        (doseq [[i row] (map-indexed vector rows)]
           (try
             ;; Insert each row
             (mc/insert mongo-db (name table-name) (into {:_id (inc i)}

--- a/test/metabase/query_processor_test/date_bucketing_test.clj
+++ b/test/metabase/query_processor_test/date_bucketing_test.clj
@@ -957,16 +957,18 @@
     (testing "Syntactic sugar (`:time-interval` clause)"
       (mt/dataset checkins:1-per-day
         (is (= 1
-               (-> (mt/run-mbql-query checkins
-                     {:aggregation [[:count]]
-                      :filter      [:time-interval $timestamp :current :day]})
-                   mt/first-row first int)))
+               (ffirst
+                (mt/formatted-rows [int]
+                  (mt/run-mbql-query checkins
+                    {:aggregation [[:count]]
+                     :filter      [:time-interval $timestamp :current :day]})))))
 
         (is (= 7
-               (-> (mt/run-mbql-query checkins
-                     {:aggregation [[:count]]
-                      :filter      [:time-interval $timestamp :last :week]})
-                   mt/first-row first int)))))))
+               (ffirst
+                (mt/formatted-rows [int]
+                  (mt/run-mbql-query checkins
+                    {:aggregation [[:count]]
+                     :filter      [:time-interval $timestamp :last :week]})))))))))
 
 ;; Make sure that when referencing the same field multiple times with different units we return the one that actually
 ;; reflects the units the results are in. eg when we breakout by one unit and filter by another, make sure the results

--- a/test/metabase/test/data/impl.clj
+++ b/test/metabase/test/data/impl.clj
@@ -6,7 +6,6 @@
             [metabase.config :as config]
             [metabase.driver :as driver]
             [metabase.models :refer [Database Field FieldValues Table]]
-            [metabase.models.field :as field]
             [metabase.plugins.classloader :as classloader]
             [metabase.sync :as sync]
             [metabase.test.data.dataset-definitions :as defs]
@@ -195,16 +194,32 @@
                                (pr-str table-name) driver db-id (pr-str db-name)
                                (u/pprint-to-str (db/select-id->field :name Table, :db_id db-id, :active true)))))))))
 
+(defn- qualified-field-name [{parent-id :parent_id, field-name :name}]
+  (if parent-id
+    (str (qualified-field-name (db/select-one Field :id parent-id))
+         \.
+         field-name)
+    field-name))
+
+(defn- all-field-names [table-id]
+  (into {} (for [field (db/select Field :active true, :table_id table-id)]
+             [(u/the-id field) (qualified-field-name field)])))
+
 (defn- the-field-id* [table-id field-name & {:keys [parent-id]}]
   (or (db/select-one-id Field, :active true, :table_id table-id, :name field-name, :parent_id parent-id)
       (let [{db-id :db_id, table-name :name} (db/select-one [Table :name :db_id] :id table-id)
             {driver :engine, db-name :name}  (db/select-one [Database :engine :name] :id db-id)
-            field-name                       (str \' field-name \' (when parent-id
-                                                                     (format " (parent: %d)" parent-id)))]
+            field-name                       (qualified-field-name {:parent_id parent-id, :name field-name})
+            all-field-names                  (all-field-names table-id)]
         (throw
-         (Exception. (format "Couldn't find Field %s for Table %d '%s' (%s Database %d '%s') .\nFound: %s"
-                             field-name table-id table-name driver db-id db-name
-                             (u/pprint-to-str (db/select-id->field :name Field, :active true, :table_id table-id))))))))
+         (ex-info (format "Couldn't find Field %s for Table %s.\nFound:\n%s"
+                          (pr-str field-name) (pr-str table-name) (u/pprint-to-str all-field-names))
+                  {:field-name  field-name
+                   :table       table-name
+                   :table-id    table-id
+                   :database    db-name
+                   :database-id db-id
+                   :all-fields  all-field-names})))))
 
 (defn the-field-id
   "Internal impl of `(data/id table field)`."


### PR DESCRIPTION
The optimized code from 39 generated 

```clj
{$expr {$eq [$list_field "value_lf_a"]}}
```

where we used to generate 

```clj
{list_field {$eq "value_lf_a"}}
```

Even tho they're both `list_field == value_lf_a`, they have different behaviors for fields whose value is an array. This PR adds tests for `:=` filters against array fields and tweaks the Mongo QP to generate the latter again.

Actually... for `$eq` we can generate

```clj
{list_field "value_lf_a"}
```

(small tweak to make resulting query more idiomatic/concise)

Fixes #16299