### PR TITLE
Fix missing value labels on timeseries

### DIFF
--- a/frontend/src/metabase/visualizations/lib/chart_values.js
+++ b/frontend/src/metabase/visualizations/lib/chart_values.js
@@ -161,7 +161,9 @@ export function onRenderValueLabels(
   // Ordinal bar charts and histograms need extra logic to center the label.
   const xShifts = displays.map((display, index) => {
     if (!isBarLike(display)) {
-      if (displays.some(d => isBarLike(d))) {
+      const shouldCenterValueLabel =
+        xScale.rangeBand && displays.some(d => isBarLike(d));
+      if (shouldCenterValueLabel) {
         // this aligns labels on non-bars with in the center of the bar group
         return ((1 + chart._rangeBandPadding()) * xScale.rangeBand()) / 2;
       }


### PR DESCRIPTION
### Description

Show value labels in combo charts with time series
Fixes a bug introduced in: https://github.com/metabase/metabase/pull/16369

Before:
<img width="1439" alt="Screen Shot 2021-06-08 at 16 35 58" src="https://user-images.githubusercontent.com/14301985/121197520-0c213400-c87a-11eb-88f8-b0197914daef.png">

After:
<img width="1438" alt="Screen Shot 2021-06-08 at 16 35 20" src="https://user-images.githubusercontent.com/14301985/121197611-1e02d700-c87a-11eb-9e9f-9cc19a34325c.png">
