### PR TITLE
Update criterion for checking language in onboarding setup e2e test

### DIFF
--- a/frontend/src/metabase/setup/components/LanguageStep.jsx
+++ b/frontend/src/metabase/setup/components/LanguageStep.jsx
@@ -67,7 +67,7 @@ export default class LanguageStep extends React.Component {
               ).map(([code, name]) => (
                 <li
                   key={code}
-                  aria-language={code}
+                  data-testid={`language-option-${code}`}
                   className={cx(
                     "p1 rounded bg-brand-hover text-white-hover cursor-pointer",
                     {

--- a/frontend/src/metabase/setup/components/LanguageStep.jsx
+++ b/frontend/src/metabase/setup/components/LanguageStep.jsx
@@ -67,6 +67,7 @@ export default class LanguageStep extends React.Component {
               ).map(([code, name]) => (
                 <li
                   key={code}
+                  aria-language={code}
                   className={cx(
                     "p1 rounded bg-brand-hover text-white-hover cursor-pointer",
                     {

--- a/frontend/test/metabase/scenarios/onboarding/setup/setup.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/setup/setup.cy.spec.js
@@ -28,7 +28,12 @@ describe("scenarios > setup", () => {
       // ========
 
       cy.findByText("What's your preferred language?");
-      cy.findByText("English").click();
+
+      // We use aria here because, if we did `cy.findByText("English")`,
+      // local runs of this test in computers not using English as their
+      // main language will show the language names in other languages.
+      // That is, if your computer is in French, it would show "Anglais",
+      cy.get(`[aria-language="en"]`).click();
       cy.findByText("Next").click();
 
       // ====

--- a/frontend/test/metabase/scenarios/onboarding/setup/setup.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/setup/setup.cy.spec.js
@@ -28,12 +28,7 @@ describe("scenarios > setup", () => {
       // ========
 
       cy.findByText("What's your preferred language?");
-
-      // We use aria here because, if we did `cy.findByText("English")`,
-      // local runs of this test in computers not using English as their
-      // main language will show the language names in other languages.
-      // That is, if your computer is in French, it would show "Anglais",
-      cy.get(`[aria-language="en"]`).click();
+      cy.findByTestId("language-option-en");
       cy.findByText("Next").click();
 
       // ====


### PR DESCRIPTION
Fixes #16392

Solves issue where e2e tests running in local machine will fail if computer is set to a language other than English by default.

When we are working on code with side-effects, it's often useful to run the full test suite locally and be able to catch unexpected fails.
And if we have fails that are unrelated to our work, this can slow progress.

Please note how in e2e tests the language list is not in English (machine is set to Italian in this case).

![image](https://user-images.githubusercontent.com/380816/121213728-e0d81e00-c854-11eb-98b8-f6cc0a20d6f8.png)



