### PR TITLE
Fix bulk archive broken

### DIFF
--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -66,11 +66,11 @@ function CollectionContent({
 
   const handleBulkArchive = useCallback(async () => {
     try {
-      await Promise.all(selectedItems.map(item => item.setArchived(true)));
+      await Promise.all(selected.map(item => item.setArchived(true)));
     } finally {
       clear();
     }
-  }, [selectedItems, clear]);
+  }, [selected, clear]);
 
   const handleBulkMoveStart = () => {
     setSelectedItems(selected);

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -643,12 +643,12 @@ describe("scenarios > collection_defaults", () => {
           selectItemUsingCheckbox("Orders");
 
           cy.findByTestId("bulk-action-bar")
-            .findByRole("button", { name: "Move" })
+            .button("Move")
             .click();
 
           modal().within(() => {
             cy.findByText("First collection").click();
-            cy.findByRole("button", { name: "Move" }).click();
+            cy.button("Move").click();
           });
 
           cy.findByText("Orders").should("not.exist");

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -622,6 +622,22 @@ describe("scenarios > collection_defaults", () => {
           cy.findByTestId("bulk-action-bar").should("not.be.visible");
         }
       });
+
+      describe("archive", () => {
+        it("should be possible to bulk archive items (metabase#16496)", () => {
+          cy.visit("/collection/root");
+          selectItemUsingCheckbox("Orders");
+          selectItemUsingCheckbox("Orders in a dashboard", "dashboard");
+
+          cy.findByTestId("bulk-action-bar")
+            .findByRole("button", { name: "Archive" })
+            .click();
+
+          cy.findByText("Orders").should("not.exist");
+          cy.findByText("Orders in a dashboard").should("not.exist");
+          cy.findByTestId("bulk-action-bar").should("not.be.visible");
+        });
+      });
     });
   });
 });

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -627,14 +627,12 @@ describe("scenarios > collection_defaults", () => {
         it("should be possible to bulk archive items (metabase#16496)", () => {
           cy.visit("/collection/root");
           selectItemUsingCheckbox("Orders");
-          selectItemUsingCheckbox("Orders in a dashboard", "dashboard");
 
           cy.findByTestId("bulk-action-bar")
-            .findByRole("button", { name: "Archive" })
+            .button("Archive")
             .click();
 
           cy.findByText("Orders").should("not.exist");
-          cy.findByText("Orders in a dashboard").should("not.exist");
           cy.findByTestId("bulk-action-bar").should("not.be.visible");
         });
       });
@@ -643,7 +641,6 @@ describe("scenarios > collection_defaults", () => {
         it("should be possible to bulk move items", () => {
           cy.visit("/collection/root");
           selectItemUsingCheckbox("Orders");
-          selectItemUsingCheckbox("Orders in a dashboard", "dashboard");
 
           cy.findByTestId("bulk-action-bar")
             .findByRole("button", { name: "Move" })
@@ -654,17 +651,14 @@ describe("scenarios > collection_defaults", () => {
             cy.findByRole("button", { name: "Move" }).click();
           });
 
-          // Check exited bulk actions mode
           cy.findByText("Orders").should("not.exist");
-          cy.findByText("Orders in a dashboard").should("not.exist");
           cy.findByTestId("bulk-action-bar").should("not.be.visible");
 
-          // Check items are actually moved
+          // Check that items were actually moved
           sidebar()
             .findByText("First collection")
             .click();
           cy.findByText("Orders");
-          cy.findByText("Orders in a dashboard");
         });
       });
     });

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -638,6 +638,35 @@ describe("scenarios > collection_defaults", () => {
           cy.findByTestId("bulk-action-bar").should("not.be.visible");
         });
       });
+
+      describe("move", () => {
+        it("should be possible to bulk move items", () => {
+          cy.visit("/collection/root");
+          selectItemUsingCheckbox("Orders");
+          selectItemUsingCheckbox("Orders in a dashboard", "dashboard");
+
+          cy.findByTestId("bulk-action-bar")
+            .findByRole("button", { name: "Move" })
+            .click();
+
+          modal().within(() => {
+            cy.findByText("First collection").click();
+            cy.findByRole("button", { name: "Move" }).click();
+          });
+
+          // Check exited bulk actions mode
+          cy.findByText("Orders").should("not.exist");
+          cy.findByText("Orders in a dashboard").should("not.exist");
+          cy.findByTestId("bulk-action-bar").should("not.be.visible");
+
+          // Check items are actually moved
+          sidebar()
+            .findByText("First collection")
+            .click();
+          cy.findByText("Orders");
+          cy.findByText("Orders in a dashboard");
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
It's impossible to bulk archive items on the collection page right now.

The root cause is that we have two different lists of selected items. One is used for bulk operations, and the second one is responsible for single-item actions (move, duplicate, archive). `BulkActions` component renders copy and move modals for both bulk and single-action scenarios. The issue happened because the bulk archive handler was trying to archive items from the list for the single-action item. @alxnddr please correct me if I'm wrong here

I suggest creating a new refactoring issue to split bulk and single-item actions from each other, so they can't affect one another anymore. Having `selected` and `selectedItems` variables in the same component was also a bit confusing.

- Closes #16496
- Adds repro for #16496 together with the fix

Also added a Cypress test for bulk move operation, so we should be safe there as well ✌️ 

### To Verify

1. Open any collection containing > 1 items
2. Hover the item's icon and click the checkbox that appeared
3. Select any number of items in the same way
4. Click the "Archive" button in the bottom bulk actions bar
5. Ensure selected items disappeared
6. Ensure bulk actions bar disappeared
7. Ensure there is a toast message in the bottom left allowing to undo the action

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/121222089-e6525a00-c88e-11eb-8265-2687f415fecd.mov

**After**

https://user-images.githubusercontent.com/17258145/121238239-8f558080-c8a0-11eb-9615-bc6783792217.mov

