### PR TITLE
Fix can't "Select All" collection items if all items are pinned

### DIFF
--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -166,16 +166,13 @@ function CollectionContent({
                   const showFilters =
                     filter || unpinnedItems.length >= MIN_ITEMS_TO_SHOW_FILTERS;
 
-                  const unselected = unpinnedItems.filter(
+                  const unselected = [...pinnedItems, ...unpinnedItems].filter(
                     item => !getIsSelected(item),
                   );
                   const hasUnselected = unselected.length > 0;
 
                   const handleSelectAll = () => {
-                    const pinnedUnselcted = pinnedItems.filter(
-                      item => !getIsSelected(item),
-                    );
-                    toggleAll([...unselected, ...pinnedUnselcted]);
+                    toggleAll(unselected);
                   };
 
                   return (

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -614,6 +614,29 @@ describe("scenarios > collection_defaults", () => {
         selectItemUsingCheckbox("Orders in a dashboard", "dashboard");
         cy.findByText("1 item selected");
       });
+
+      it("should be possible to select pinned items for bulk operations when all items are pinned (metabase#16497)", () => {
+        // Pinning one more item and moving them to another collection, so they are the only items there
+        openEllipsisMenuFor("Orders");
+        cy.findByText("Pin this item").click();
+        selectItemUsingCheckbox("Orders");
+        selectItemUsingCheckbox("Orders in a dashboard", "dashboard");
+        cy.findByTestId("bulk-action-bar")
+          .findByRole("button", { name: "Move" })
+          .click();
+        modal().within(() => {
+          cy.findByText("First collection").click();
+          cy.findByRole("button", { name: "Move" }).click();
+        });
+        sidebar()
+          .findByText("First collection")
+          .click();
+
+        selectItemUsingCheckbox("Orders");
+        cy.icon("dash").click();
+        cy.icon("dash").should("not.exist");
+        cy.findByText("2 items selected");
+      });
     });
   });
 });

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -594,45 +594,33 @@ describe("scenarios > collection_defaults", () => {
     });
 
     describe("bulk actions", () => {
-      it("should be possible to apply bulk selection to items (metabase#14705)", () => {
-        cy.visit("/collection/root");
-        selectItemUsingCheckbox("Orders");
-        cy.findByText("1 item selected").should("be.visible");
-
-        // Select all
-        cy.icon("dash").click();
-        cy.icon("dash").should("not.exist");
-        cy.findByText("4 items selected");
-
-        // Deselect all
-        cy.findByTestId("bulk-action-bar").within(() => {
-          cy.icon("check").click();
+      describe("selection", () => {
+        it("should be possible to apply bulk selection to all items (metabase#14705)", () => {
+          bulkSelectDeselectWorkflow();
         });
-        cy.icon("check").should("not.exist");
-        cy.findByTestId("bulk-action-bar").should("not.be.visible");
-      });
 
-      it("should be possible to select pinned items for bulk operations when all items are pinned (metabase#16497)", () => {
-        // Pinning one more item and moving them to another collection, so they are the only items there
-        openEllipsisMenuFor("Orders");
-        cy.findByText("Pin this item").click();
-        selectItemUsingCheckbox("Orders");
-        selectItemUsingCheckbox("Orders in a dashboard", "dashboard");
-        cy.findByTestId("bulk-action-bar")
-          .findByRole("button", { name: "Move" })
-          .click();
-        modal().within(() => {
-          cy.findByText("First collection").click();
-          cy.findByRole("button", { name: "Move" }).click();
+        it("should be possible to apply bulk selection when all items are pinned (metabase#16497)", () => {
+          pinAllRootItems();
+          bulkSelectDeselectWorkflow();
         });
-        sidebar()
-          .findByText("First collection")
-          .click();
 
-        selectItemUsingCheckbox("Orders");
-        cy.icon("dash").click();
-        cy.icon("dash").should("not.exist");
-        cy.findByText("2 items selected");
+        function bulkSelectDeselectWorkflow() {
+          cy.visit("/collection/root");
+          selectItemUsingCheckbox("Orders");
+          cy.findByText("1 item selected").should("be.visible");
+
+          // Select all
+          cy.icon("dash").click();
+          cy.icon("dash").should("not.exist");
+          cy.findByText("4 items selected");
+
+          // Deselect all
+          cy.findByTestId("bulk-action-bar").within(() => {
+            cy.icon("check").click();
+          });
+          cy.icon("check").should("not.exist");
+          cy.findByTestId("bulk-action-bar").should("not.be.visible");
+        }
       });
     });
   });

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -584,13 +584,8 @@ describe("scenarios > collection_defaults", () => {
     });
 
     describe("bulk actions", () => {
-      beforeEach(() => {
-        cy.visit("/collection/root");
-        openEllipsisMenuFor("Orders in a dashboard");
-        cy.findByText("Pin this item").click();
-      });
-
       it("should be possible to apply bulk selection to items (metabase#14705)", () => {
+        cy.visit("/collection/root");
         selectItemUsingCheckbox("Orders");
         cy.findByText("1 item selected").should("be.visible");
 
@@ -608,6 +603,10 @@ describe("scenarios > collection_defaults", () => {
       });
 
       it("should be possible to select pinned item using checkbox (metabase#15338)", () => {
+        cy.visit("/collection/root");
+        openEllipsisMenuFor("Orders in a dashboard");
+        cy.findByText("Pin this item").click();
+
         cy.findByText(/Pinned items/i);
         selectItemUsingCheckbox("Orders in a dashboard", "dashboard");
         cy.findByText("1 item selected");

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -593,8 +593,6 @@ describe("scenarios > collection_defaults", () => {
       it("should be possible to apply bulk selection to items (metabase#14705)", () => {
         selectItemUsingCheckbox("Orders");
         cy.findByText("1 item selected").should("be.visible");
-        selectItemUsingCheckbox("Orders in a dashboard", "dashboard");
-        cy.findByText("2 items selected").should("be.visible");
 
         // Select all
         cy.icon("dash").click();

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -583,6 +583,16 @@ describe("scenarios > collection_defaults", () => {
       cy.findByText("First Collection");
     });
 
+    it("should be possible to select pinned item using checkbox (metabase#15338)", () => {
+      cy.visit("/collection/root");
+      openEllipsisMenuFor("Orders in a dashboard");
+      cy.findByText("Pin this item").click();
+
+      cy.findByText(/Pinned items/i);
+      selectItemUsingCheckbox("Orders in a dashboard", "dashboard");
+      cy.findByText("1 item selected");
+    });
+
     describe("bulk actions", () => {
       it("should be possible to apply bulk selection to items (metabase#14705)", () => {
         cy.visit("/collection/root");
@@ -600,16 +610,6 @@ describe("scenarios > collection_defaults", () => {
         });
         cy.icon("check").should("not.exist");
         cy.findByTestId("bulk-action-bar").should("not.be.visible");
-      });
-
-      it("should be possible to select pinned item using checkbox (metabase#15338)", () => {
-        cy.visit("/collection/root");
-        openEllipsisMenuFor("Orders in a dashboard");
-        cy.findByText("Pin this item").click();
-
-        cy.findByText(/Pinned items/i);
-        selectItemUsingCheckbox("Orders in a dashboard", "dashboard");
-        cy.findByText("1 item selected");
       });
 
       it("should be possible to select pinned items for bulk operations when all items are pinned (metabase#16497)", () => {

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -689,3 +689,17 @@ function getSidebarCollectionChildrenFor(item) {
     .parent()
     .parent();
 }
+
+function pinAllRootItems() {
+  cy.request("GET", "/api/collection/root/items").then(resp => {
+    const ALL_ITEMS = resp.body.data;
+
+    ALL_ITEMS.forEach(({ model, id }, index) => {
+      if (model !== "collection") {
+        cy.request("PUT", `/api/${model}/${id}`, {
+          collection_position: index++,
+        });
+      }
+    });
+  });
+}


### PR DESCRIPTION
On the collection page, if a user tries to select all items using the checkbox in the bulk actions bar, the selection doesn't work if _all of the collection items are pinned_.

The issue is the `unchecked` list that influences the bulk operations behavior was created only out of non-pinned items. So if the collection only contains pinned items, you selected one of the items, the `unchecked` appeared to be empty, and the `BulkActions` component was sure there is nothing more to select.

- Closes #16497
- Adds repro for #16497 together with the fix

### To Verify

⚠️ You might try to archive selected items during testing. This behavior is currently broken, the fix is at #16500

1. Open a collection that contains ONLY pinned items
2. Hover the item's icon and click the checkbox that appeared
3. Click the checkbox in the bottom bulk actions bar
4. After clicking a checkbox, all items have to be selected

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/121223188-f1f25080-c88f-11eb-9042-a51a7a56c209.mov

**After**

https://user-images.githubusercontent.com/17258145/121237590-e27b0380-c89f-11eb-90c7-8c302468ca04.mov

