### PR TITLE
Allow moving items to root collection via drag-n-drop

### DIFF
--- a/frontend/src/metabase/collections/containers/CollectionSidebar.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar.jsx
@@ -9,6 +9,8 @@ import * as Urls from "metabase/lib/urls";
 
 import Collection from "metabase/entities/collections";
 
+import CollectionDropTarget from "metabase/containers/dnd/CollectionDropTarget";
+
 import Icon from "metabase/components/Icon";
 import Link from "metabase/components/Link";
 import LoadingSpinner from "metabase/components/LoadingSpinner";
@@ -82,15 +84,25 @@ class CollectionSidebar extends React.Component {
     const { currentUser, isRoot, collectionId, list } = this.props;
     return (
       <React.Fragment>
-        <CollectionLink
-          to={Urls.collection({ id: "root" })}
-          selected={isRoot}
-          mb={1}
-          mt={2}
-        >
-          <Icon name="folder" mr={1} />
-          {t`Our analytics`}
-        </CollectionLink>
+        <Collection.Loader id="root">
+          {({ collection: root }) => (
+            <Box mb={1} mt={2}>
+              <CollectionDropTarget collection={root}>
+                {({ highlighted, hovered }) => (
+                  <CollectionLink
+                    to={Urls.collection({ id: "root" })}
+                    selected={isRoot}
+                    highlighted={highlighted}
+                    hovered={hovered}
+                  >
+                    {t`Our analytics`}
+                  </CollectionLink>
+                )}
+              </CollectionDropTarget>
+            </Box>
+          )}
+        </Collection.Loader>
+
         <Box pb={4}>
           <CollectionsList
             openCollections={this.state.openCollections}


### PR DESCRIPTION
Metabase allows moving items between collections via drag-n-drop. However, it's impossible to move an item to "Our analytics" in the same way. Closes #16498

### To Verify

**With _write_ permissions to root**

1. Sign in as a user with _write_ permission to "Our analytics"
2. Open any non-root collection
3. Try moving an item from the collection to "Our analytics" using drag-n-drop
4. An item should move to "Our analytics"

**With _read_ permissions to root**

1. Sign in as a user with _read_ permission to "Our analytics"
2. Open any non-root collection
3. Try moving an item from the collection to "Our analytics" using drag-n-drop
4. It shouldn't be possible to drop an item onto "Our analytics"

### Demo

**With _write_ permissions to root**

https://user-images.githubusercontent.com/17258145/121242183-efe6bc80-c8a4-11eb-8af8-69ad9e4ad238.mov

**With _read_ permissions to root**

https://user-images.githubusercontent.com/17258145/121242214-f7a66100-c8a4-11eb-871a-30481f2a01b2.mov

