### PR TITLE
Tree component for new Permissions Page

### DIFF
--- a/frontend/src/metabase/admin/permissions/components/sidebar/Sidebar.jsx
+++ b/frontend/src/metabase/admin/permissions/components/sidebar/Sidebar.jsx
@@ -1,0 +1,18 @@
+import styled from "styled-components";
+import { color } from "metabase/lib/colors";
+
+export const Sidebar = styled.aside`
+  width: 300px;
+  height: 100%;
+  border-right: 1px solid ${color("border")};
+`;
+
+Sidebar.Header = styled.div`
+  padding: 1rem;
+  border-bottom: 1px solid ${color("border")};
+`;
+
+Sidebar.Content = styled.div`
+  padding: 1rem 0;
+  overflow-y: auto;
+`;

--- a/frontend/src/metabase/admin/permissions/components/sidebar/index.js
+++ b/frontend/src/metabase/admin/permissions/components/sidebar/index.js
@@ -1,0 +1,1 @@
+export * from "./Sidebar";

--- a/frontend/src/metabase/admin/permissions/components/tree/Tree.jsx
+++ b/frontend/src/metabase/admin/permissions/components/tree/Tree.jsx
@@ -1,0 +1,50 @@
+import React, { useState, useCallback } from "react";
+import PropTypes from "prop-types";
+import { TreeNodeList } from "./TreeNodeList";
+import { TreeNode } from "./TreeNode";
+
+const propTypes = {
+  TreeNodeComponent: PropTypes.object,
+  data: PropTypes.array.isRequired,
+  onSelect: PropTypes.func.isRequired,
+};
+
+export function Tree({ TreeNodeComponent = TreeNode, data, onSelect }) {
+  const [expandedIds, setExpandedIds] = useState(new Set());
+  const [selectedId, setSelectedId] = useState(null);
+
+  const handleToggleExpand = useCallback(
+    itemId => {
+      if (expandedIds.has(itemId)) {
+        setExpandedIds(prev => new Set([...prev].filter(id => id !== itemId)));
+      } else {
+        setExpandedIds(prev => new Set([...prev, itemId]));
+      }
+    },
+    [expandedIds],
+  );
+
+  const handleSelect = useCallback(
+    itemId => {
+      setSelectedId(itemId);
+      onSelect(itemId);
+    },
+    [onSelect],
+  );
+
+  return (
+    <div>
+      <TreeNodeList
+        TreeNodeComponent={TreeNodeComponent}
+        items={data}
+        onSelect={handleSelect}
+        onToggleExpand={handleToggleExpand}
+        expandedIds={expandedIds}
+        selectedId={selectedId}
+        depth={0}
+      />
+    </div>
+  );
+}
+
+Tree.propTypes = propTypes;

--- a/frontend/src/metabase/admin/permissions/components/tree/TreeNode.jsx
+++ b/frontend/src/metabase/admin/permissions/components/tree/TreeNode.jsx
@@ -1,0 +1,92 @@
+import React from "react";
+import PropTypes from "prop-types";
+import {
+  TreeNodeRoot,
+  ExpandToggleButton,
+  ExpandToggleIcon,
+  NameContainer,
+  IconContainer,
+  RightArrowContainer,
+} from "./TreeNode.styled";
+
+import Icon from "metabase/components/Icon";
+
+const propTypes = {
+  isExpanded: PropTypes.bool.isRequired,
+  isSelected: PropTypes.bool.isRequired,
+  hasChildren: PropTypes.bool.isRequired,
+  onToggleExpand: PropTypes.func,
+  onSelect: PropTypes.func.isRequired,
+  depth: PropTypes.number.isRequired,
+  item: PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    icon: PropTypes.string,
+    hasRightArrow: PropTypes.string,
+    id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  }).isRequired,
+};
+
+export const TreeNode = React.memo(function TreeNode({
+  isExpanded,
+  isSelected,
+  hasChildren,
+  onToggleExpand,
+  onSelect,
+  depth,
+  item,
+}) {
+  const { name, icon, hasRightArrow, id } = item;
+
+  const handleExpand = e => {
+    e.stopPropagation();
+    onToggleExpand(id);
+  };
+
+  const handleSelect = () => onSelect(id);
+
+  const handleKeyDown = ({ key }) => {
+    switch (key) {
+      case "Enter":
+        onSelect(id);
+        break;
+      case "ArrowRight":
+        !isExpanded && onToggleExpand(id);
+        break;
+      case "ArrowLeft":
+        isExpanded && onToggleExpand(id);
+        break;
+    }
+  };
+
+  return (
+    <TreeNodeRoot
+      role="menuitem"
+      tabIndex={0}
+      depth={depth}
+      onClick={handleSelect}
+      isSelected={isSelected}
+      onKeyDown={handleKeyDown}
+    >
+      {hasChildren && (
+        <ExpandToggleButton onClick={handleExpand}>
+          <ExpandToggleIcon isExpanded={isExpanded} />
+        </ExpandToggleButton>
+      )}
+
+      {icon && (
+        <IconContainer>
+          <Icon name="icon" />
+        </IconContainer>
+      )}
+      <NameContainer>{name}</NameContainer>
+
+      {hasRightArrow && (
+        <RightArrowContainer isSelected={isSelected}>
+          <Icon name="chevronright" size={14} />
+        </RightArrowContainer>
+      )}
+    </TreeNodeRoot>
+  );
+});
+
+TreeNode.propTypes = propTypes;

--- a/frontend/src/metabase/admin/permissions/components/tree/TreeNode.jsx
+++ b/frontend/src/metabase/admin/permissions/components/tree/TreeNode.jsx
@@ -75,7 +75,7 @@ export const TreeNode = React.memo(function TreeNode({
 
       {icon && (
         <IconContainer>
-          <Icon name="icon" />
+          <Icon name={icon} />
         </IconContainer>
       )}
       <NameContainer>{name}</NameContainer>

--- a/frontend/src/metabase/admin/permissions/components/tree/TreeNode.styled.jsx
+++ b/frontend/src/metabase/admin/permissions/components/tree/TreeNode.styled.jsx
@@ -1,5 +1,5 @@
 import styled, { css } from "styled-components";
-import colors from "metabase/lib/colors";
+import colors, { lighten } from "metabase/lib/colors";
 import Icon from "metabase/components/Icon";
 
 export const TreeNodeRoot = styled.li`
@@ -16,7 +16,7 @@ export const TreeNodeRoot = styled.li`
 
   &:hover {
     background-color: ${props =>
-      props.isSelected ? colors["accent7"] : `#e7e6f1`};
+      props.isSelected ? colors["accent7"] : lighten(colors["accent7"], 0.65)};
   }
 `;
 

--- a/frontend/src/metabase/admin/permissions/components/tree/TreeNode.styled.jsx
+++ b/frontend/src/metabase/admin/permissions/components/tree/TreeNode.styled.jsx
@@ -1,0 +1,60 @@
+import styled, { css } from "styled-components";
+import colors from "metabase/lib/colors";
+import Icon from "metabase/components/Icon";
+
+export const TreeNodeRoot = styled.li`
+  display: flex;
+  align-items: center;
+  color: ${props =>
+    props.isSelected ? colors["white"] : colors["text-medium"]};
+  background-color: ${props =>
+    props.isSelected ? colors["accent7"] : "unset"};
+  padding-left: ${props => props.depth + 1}rem;
+  padding-right: 0.5rem;
+  cursor: pointer;
+  font-weight: 700;
+
+  &:hover {
+    background-color: ${props =>
+      props.isSelected ? colors["accent7"] : `#e7e6f1`};
+  }
+`;
+
+export const ExpandToggleButton = styled.button`
+  display: flex;
+  cursor: pointer;
+  padding: 0.5rem 0.25rem 0.5rem 0.25rem;
+  display: block;
+  color: inherit;
+`;
+
+export const ExpandToggleIcon = styled(Icon).attrs({
+  name: "chevronright",
+  size: 12,
+})`
+  transition: transform 200ms;
+
+  ${props =>
+    props.isExpanded &&
+    css`
+      transform: rotate(90deg);
+    `}
+`;
+
+export const NameContainer = styled.div`
+  padding: 0.5rem 0.5rem 0.5rem 0.25rem;
+  flex: 1;
+`;
+
+export const IconContainer = styled.div`
+  display: flex;
+  align-items: center;
+  padding: 0.25rem;
+`;
+
+export const RightArrowContainer = styled.div`
+  display: flex;
+  align-items: center;
+  color: ${props =>
+    props.isSelected ? colors["white"] : colors["text-light"]};
+`;

--- a/frontend/src/metabase/admin/permissions/components/tree/TreeNodeList.jsx
+++ b/frontend/src/metabase/admin/permissions/components/tree/TreeNodeList.jsx
@@ -1,0 +1,60 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+const propTypes = {
+  TreeNodeComponent: PropTypes.object.isRequired,
+  items: PropTypes.array.isRequired,
+  onToggleExpand: PropTypes.func,
+  onSelect: PropTypes.func.isRequired,
+  expandedIds: PropTypes.instanceOf(Set),
+  selectedId: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  depth: PropTypes.number.isRequired,
+};
+
+export function TreeNodeList({
+  TreeNodeComponent,
+  items,
+  onToggleExpand,
+  onSelect,
+  expandedIds,
+  selectedId,
+  depth,
+}) {
+  return (
+    <ul role="menu">
+      {items.map(item => {
+        const isSelected = selectedId === item.id;
+        const hasChildren =
+          Array.isArray(item.children) && item.children.length > 0;
+        const isExpanded = hasChildren && expandedIds.has(item.id);
+
+        return (
+          <React.Fragment key={item.id}>
+            <TreeNodeComponent
+              item={item}
+              onToggleExpand={onToggleExpand}
+              onSelect={onSelect}
+              isSelected={isSelected}
+              isExpanded={isExpanded}
+              hasChildren={hasChildren}
+              depth={depth}
+            />
+            {isExpanded && (
+              <TreeNodeList
+                TreeNodeComponent={TreeNodeComponent}
+                items={item.children}
+                onToggleExpand={onToggleExpand}
+                onSelect={onSelect}
+                expandedIds={expandedIds}
+                selectedId={selectedId}
+                depth={depth + 1}
+              />
+            )}
+          </React.Fragment>
+        );
+      })}
+    </ul>
+  );
+}
+
+TreeNodeList.propTypes = propTypes;

--- a/frontend/src/metabase/admin/permissions/components/tree/index.js
+++ b/frontend/src/metabase/admin/permissions/components/tree/index.js
@@ -1,0 +1,1 @@
+export * from "./Tree";

--- a/frontend/src/metabase/admin/permissions/containers/NewDataPermissionsPage.jsx
+++ b/frontend/src/metabase/admin/permissions/containers/NewDataPermissionsPage.jsx
@@ -1,0 +1,76 @@
+import React from "react";
+
+import { Tree } from "../components/tree";
+import { Sidebar } from "../components/sidebar";
+import TextInput from "metabase/components/TextInput";
+import Icon from "metabase/components/Icon";
+
+export function NewDataPermissionsPage() {
+  const data = [
+    {
+      id: 1,
+      name: "Item with icon",
+      icon: "group",
+    },
+    {
+      id: 2,
+      name: "Item with children",
+      icon: "group",
+      children: [
+        {
+          id: 3,
+          name: "children",
+        },
+        {
+          id: 10,
+          name: "children",
+        },
+      ],
+    },
+    {
+      id: 4,
+      name: "Item without an icon",
+    },
+    {
+      id: 5,
+      name: "Item with children",
+      icon: "group",
+      children: [
+        {
+          id: 6,
+          icon: "group",
+          name: "children",
+        },
+        {
+          id: 7,
+          name: "children with children",
+          children: [
+            {
+              id: 8,
+              icon: "group",
+              name: "children",
+            },
+          ],
+        },
+      ],
+    },
+  ];
+  return (
+    <Sidebar>
+      <Sidebar.Header>
+        <TextInput
+          variant="admin"
+          onChange={() => {}}
+          padding="sm"
+          borderRadius="md"
+          icon={<Icon name="search" size={16} />}
+        />
+      </Sidebar.Header>
+      <Sidebar.Content>
+        <Tree data={data} />
+      </Sidebar.Content>
+    </Sidebar>
+  );
+}
+
+export default NewDataPermissionsPage;

--- a/frontend/src/metabase/admin/permissions/routes.jsx
+++ b/frontend/src/metabase/admin/permissions/routes.jsx
@@ -8,12 +8,17 @@ import DatabasesPermissionsApp from "./containers/DatabasesPermissionsApp";
 import SchemasPermissionsApp from "./containers/SchemasPermissionsApp";
 import TablesPermissionsApp from "./containers/TablesPermissionsApp";
 import CollectionPermissions from "./containers/CollectionsPermissionsApp";
+import NewDataPermissionsPage from "./containers/NewDataPermissionsPage";
 
 import { PLUGIN_ADMIN_PERMISSIONS_TABLE_ROUTES } from "metabase/plugins";
 
 const getRoutes = store => (
   <Route title={t`Permissions`} path="permissions">
     <IndexRedirect to="databases" />
+
+    <Route title="Revamped Permissions" path="new">
+      <Route path="databases" component={NewDataPermissionsPage}></Route>
+    </Route>
 
     {/* "DATABASES" a.k.a. "data" section */}
     <Route path="databases" component={DataPermissionsApp}>

--- a/frontend/test/metabase/admin/permissions/Tree.unit.spec.js
+++ b/frontend/test/metabase/admin/permissions/Tree.unit.spec.js
@@ -1,0 +1,62 @@
+import React from "react";
+import "@testing-library/jest-dom/extend-expect";
+import { render, fireEvent } from "@testing-library/react";
+
+import { Tree } from "metabase/admin/permissions/components/tree";
+
+const data = [
+  {
+    id: 1,
+    name: "Item 1",
+    icon: "group",
+  },
+  {
+    id: 2,
+    name: "Item 2",
+    icon: "group",
+    children: [
+      {
+        id: 3,
+        name: "Item 3",
+        icon: "group",
+      },
+    ],
+  },
+];
+
+describe("Tree", () => {
+  it("should render items", () => {
+    const { getAllByRole, queryByText } = render(
+      <Tree data={data} onSelect={jest.fn()} />,
+    );
+    expect(getAllByRole("menuitem")).toHaveLength(2);
+    expect(queryByText("Item 1")).not.toBeNull();
+    expect(queryByText("Item 2")).not.toBeNull();
+    expect(queryByText("Item 3")).toBeNull();
+  });
+
+  it("should render expand and collapse items with children", () => {
+    const { getAllByRole, queryByText, getByRole } = render(
+      <Tree data={data} onSelect={jest.fn()} />,
+    );
+
+    fireEvent.click(getByRole("button"));
+
+    expect(getAllByRole("menuitem")).toHaveLength(3);
+    expect(queryByText("Item 3")).not.toBeNull();
+
+    fireEvent.click(getByRole("button"));
+    expect(getAllByRole("menuitem")).toHaveLength(2);
+    expect(queryByText("Item 3")).toBeNull();
+  });
+
+  it("should allow to select items", () => {
+    const onSelectMock = jest.fn();
+    const { getAllByRole } = render(
+      <Tree data={data} onSelect={onSelectMock} />,
+    );
+
+    fireEvent.click(getAllByRole("menuitem")[0]);
+    expect(onSelectMock).toHaveBeenCalledWith(1);
+  });
+});


### PR DESCRIPTION
### Description

I started extracting individual components for [the Permissions Page revamping](https://www.notion.so/Let-the-Permissions-page-scale-51a4a21940924ab0b841e8b772d0237c) to make review easier.
This PR contains purely UI tree component. Please, ignore the rest, I just needed to render it on some page.

It is temporarily rendered on http://localhost:3000/admin/permissions/new/databases

### Screenshot
<img width="384" alt="Screen Shot 2021-06-09 at 00 46 51" src="https://user-images.githubusercontent.com/14301985/121262091-3eec1c00-c8bc-11eb-9380-09540f106068.png">
