### PR TITLE
add open moderation request action menu

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationIssueThread.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationIssueThread.jsx
@@ -38,6 +38,11 @@ export function ModerationIssueThread({
   const hasButtonBarActions = !!(onComment || onModerate);
   const showButtonBar = !isEditingText && hasButtonBarActions;
 
+  const closeAllForms = () => {
+    setShowRequestTextForm(false);
+    setShowCommentForm(false);
+  };
+
   const onCommentSubmit = async comment => {
     setIsCommentPending(true);
     try {
@@ -69,6 +74,7 @@ export function ModerationIssueThread({
         icon: "pencil",
         title: t`Edit Text`,
         action: () => {
+          closeAllForms();
           setShowRequestTextForm(true);
         },
       },
@@ -118,7 +124,10 @@ export function ModerationIssueThread({
         <CommentForm
           className="pt1"
           onSubmit={onCommentSubmit}
-          onCancel={() => setShowCommentForm(false)}
+          onCancel={() => {
+            closeAllForms();
+            setShowCommentForm(false);
+          }}
           isPending={isCommentPending}
         />
       )}

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationIssueThread.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationIssueThread.jsx
@@ -2,6 +2,8 @@ import React, { useState } from "react";
 import PropTypes from "prop-types";
 import { t } from "ttag";
 
+import { useAsyncFunction } from "metabase/lib/hooks";
+
 import Button from "metabase/components/Button";
 import Comment from "metabase/components/Comment";
 import ModerationIssueActionMenu from "metabase-enterprise/moderation/components/ModerationIssueActionMenu";
@@ -30,8 +32,11 @@ export function ModerationIssueThread({
 }) {
   const [showRequestTextForm, setShowRequestTextForm] = useState(false);
   const [showCommentForm, setShowCommentForm] = useState(false);
-  const [isCommentPending, setIsCommentPending] = useState(false);
-  const [isRequestPending, setIsRequestPending] = useState(false);
+
+  const [safeOnComment, isCommentPending] = useAsyncFunction(onComment);
+  const [safeOnUpdateRequestText, isRequestPending] = useAsyncFunction(
+    onUpdateRequestText,
+  );
 
   const hasRequestActions = !!(onUpdateRequestText || onResolveOwnRequest);
   const isEditingText = showCommentForm || showRequestTextForm;
@@ -44,26 +49,22 @@ export function ModerationIssueThread({
   };
 
   const onCommentSubmit = async comment => {
-    setIsCommentPending(true);
     try {
-      await onComment(comment, request);
+      await safeOnComment(comment, request);
     } catch (error) {
       console.error(error);
     } finally {
       setShowCommentForm(false);
-      setIsCommentPending(false);
     }
   };
 
   const onEditRequestSubmit = async text => {
-    setIsRequestPending(true);
     try {
-      await onUpdateRequestText(text, request);
+      await safeOnUpdateRequestText(text, request);
     } catch (error) {
       console.error(error);
     } finally {
       setShowRequestTextForm(false);
-      setIsRequestPending(false);
     }
   };
 

--- a/frontend/src/metabase/components/Timeline.jsx
+++ b/frontend/src/metabase/components/Timeline.jsx
@@ -68,7 +68,9 @@ const Timeline = ({ className, items = [], renderFooter }) => {
               <div className="text-medium text-small pb1">
                 {formattedTimestamp}
               </div>
-              <div>{description}</div>
+              <div className={renderFooter && description && "mb1"}>
+                {description}
+              </div>
               {_.isFunction(renderFooter) && <div>{renderFooter(item)}</div>}
             </div>
           </TimelineItem>

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -1434,3 +1434,15 @@ export async function createModerationRequestComment({
   });
   return softReloadCard();
 }
+
+export async function updateModerationRequest({ id, ...rest }) {
+  if (id == null) {
+    throw new Error("Missing moderation request id");
+  }
+
+  await ModerationRequestApi.update({
+    id,
+    ...rest,
+  });
+  return softReloadCard();
+}

--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -109,6 +109,7 @@ export default class View extends React.Component {
       createModerationReview,
       createModerationRequest,
       createModerationRequestComment,
+      updateModerationRequest,
     } = this.props;
     const {
       aggregationIndex,
@@ -169,6 +170,7 @@ export default class View extends React.Component {
         createModerationReview={createModerationReview}
         createModerationRequest={createModerationRequest}
         createModerationRequestComment={createModerationRequestComment}
+        updateModerationRequest={updateModerationRequest}
       />
     ) : null;
 

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebarPanel.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebarPanel.jsx
@@ -63,7 +63,7 @@ function QuestionDetailsSidebarPanel({ setView, question, onOpenModal }) {
           onRequestClick={request => {
             setView({
               name: SIDEBAR_VIEWS.MODERATION_REQUEST_PANEL,
-              props: { requests: [request] },
+              props: { requestId: request.id },
             });
           }}
         />

--- a/frontend/src/metabase/questions/components/QuestionActivityTimeline.styled.jsx
+++ b/frontend/src/metabase/questions/components/QuestionActivityTimeline.styled.jsx
@@ -1,0 +1,36 @@
+import styled from "styled-components";
+import { color } from "metabase/lib/colors";
+import ActionButton from "metabase/components/ActionButton";
+import Button from "metabase/components/Button";
+
+export const SidebarSectionHeader = styled.div`
+  color: ${color("text-medium")};
+  font-weight: bold;
+  padding-bottom: 1rem;
+`;
+
+export const RequestButton = styled(Button)`
+  padding: 0;
+  border: none;
+  color: ${props => color(props.color)};
+
+  &:hover {
+    text-decoration: underline;
+    background-color: transparent;
+    color: ${props => color(props.color)};
+  }
+`;
+
+export const RevertButton = styled(ActionButton).attrs({
+  successClassName: "",
+  failedClassName: "",
+})`
+  padding: 0;
+  border: none;
+  color: ${color("accent3")};
+
+  &:hover {
+    background-color: transparent;
+    color: ${color("accent3")};
+  }
+`;


### PR DESCRIPTION
This PR adds an action menu to a user's moderation requests to let them edit the request's `text` or to change the request's status to `resolved`. I also added request close events to the question timeline. 

The menu:
<img width="525" alt="Screen Shot 2021-06-10 at 5 05 13 PM" src="https://user-images.githubusercontent.com/13057258/121612121-a0240480-ca0e-11eb-983b-97d3d20cd193.png">

The form for changing a request's `text`:
<img width="345" alt="Screen Shot 2021-06-10 at 5 05 20 PM" src="https://user-images.githubusercontent.com/13057258/121612126-a2865e80-ca0e-11eb-993a-ca071cbf8501.png">

A timeline close event:
<img width="281" alt="Screen Shot 2021-06-10 at 5 05 04 PM" src="https://user-images.githubusercontent.com/13057258/121612132-a4502200-ca0e-11eb-91b8-a69e5d676391.png">
