### PR TITLE
Fix UI flash when sorting collection items

### DIFF
--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -196,12 +196,10 @@ function CollectionContent({ collection, collectionId, isAdmin, isRoot }) {
                   };
 
                   const loading = loadingPinnedItems || loadingUnpinnedItems;
+                  const isEmpty =
+                    !loading && !hasPinnedItems && unpinnedItems.length === 0;
 
-                  if (
-                    !loading &&
-                    !hasPinnedItems &&
-                    unpinnedItems.length === 0
-                  ) {
+                  if (isEmpty) {
                     return (
                       <Box mt="120px">
                         <CollectionEmptyState />

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -126,7 +126,7 @@ function CollectionContent({ collection, collectionId, isAdmin, isRoot }) {
     <Search.ListLoader
       query={pinnedQuery}
       loadingAndErrorWrapper={false}
-      keepPreviousList
+      keepListWhileLoading
       wrapped
     >
       {({
@@ -168,7 +168,7 @@ function CollectionContent({ collection, collectionId, isAdmin, isRoot }) {
               <Search.ListLoader
                 query={unpinnedQuery}
                 loadingAndErrorWrapper={false}
-                keepPreviousList
+                keepListWhileLoading
                 wrapped
               >
                 {({

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -123,8 +123,22 @@ function CollectionContent({ collection, collectionId, isAdmin, isRoot }) {
   };
 
   return (
-    <Search.ListLoader query={pinnedQuery} wrapped>
-      {({ list: pinnedItems }) => {
+    <Search.ListLoader
+      query={pinnedQuery}
+      loadingAndErrorWrapper={false}
+      keepPreviousList
+      wrapped
+    >
+      {({
+        list: pinnedItemsList = [],
+        previousList: previousPinnedItemsList = [],
+      }) => {
+        // Prevents table UI flashing while performing a GET request
+        // (e.g. for sorting)
+        const pinnedItems =
+          pinnedItemsList.length > 0
+            ? pinnedItemsList
+            : previousPinnedItemsList;
         const hasPinnedItems = pinnedItems.length > 0;
 
         return (
@@ -150,8 +164,24 @@ function CollectionContent({ collection, collectionId, isAdmin, isRoot }) {
                 onCopy={handleCopy}
               />
 
-              <Search.ListLoader query={unpinnedQuery} wrapped>
-                {({ list: unpinnedItems, metadata }) => {
+              <Search.ListLoader
+                query={unpinnedQuery}
+                loadingAndErrorWrapper={false}
+                keepPreviousList
+                wrapped
+              >
+                {({
+                  list: unpinnedItemsList = [],
+                  previousList: previousUnpinnedItemsList = [],
+                  metadata = {},
+                }) => {
+                  // Prevents table UI flashing while performing a GET request
+                  // (e.g. for pagination or sorting)
+                  const unpinnedItems =
+                    unpinnedItemsList.length > 0
+                      ? unpinnedItemsList
+                      : previousUnpinnedItemsList;
+
                   const hasPagination = metadata.total > PAGE_SIZE;
 
                   const unselected = [...pinnedItems, ...unpinnedItems].filter(

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -129,17 +129,7 @@ function CollectionContent({ collection, collectionId, isAdmin, isRoot }) {
       keepListWhileLoading
       wrapped
     >
-      {({
-        list: pinnedItemsList = [],
-        previousList: previousPinnedItemsList = [],
-        loading: loadingPinnedItems,
-      }) => {
-        // Prevents table UI flashing while performing a GET request
-        // (e.g. for sorting)
-        const pinnedItems =
-          pinnedItemsList.length > 0
-            ? pinnedItemsList
-            : previousPinnedItemsList;
+      {({ list: pinnedItems = [], loading: loadingPinnedItems }) => {
         const hasPinnedItems = pinnedItems.length > 0;
 
         return (
@@ -172,18 +162,10 @@ function CollectionContent({ collection, collectionId, isAdmin, isRoot }) {
                 wrapped
               >
                 {({
-                  list: unpinnedItemsList = [],
-                  previousList: previousUnpinnedItemsList = [],
+                  list: unpinnedItems = [],
                   metadata = {},
                   loading: loadingUnpinnedItems,
                 }) => {
-                  // Prevents table UI flashing while performing a GET request
-                  // (e.g. for pagination or sorting)
-                  const unpinnedItems =
-                    unpinnedItemsList.length > 0
-                      ? unpinnedItemsList
-                      : previousUnpinnedItemsList;
-
                   const hasPagination = metadata.total > PAGE_SIZE;
 
                   const unselected = [...pinnedItems, ...unpinnedItems].filter(

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -132,6 +132,7 @@ function CollectionContent({ collection, collectionId, isAdmin, isRoot }) {
       {({
         list: pinnedItemsList = [],
         previousList: previousPinnedItemsList = [],
+        loading: loadingPinnedItems,
       }) => {
         // Prevents table UI flashing while performing a GET request
         // (e.g. for sorting)
@@ -174,6 +175,7 @@ function CollectionContent({ collection, collectionId, isAdmin, isRoot }) {
                   list: unpinnedItemsList = [],
                   previousList: previousUnpinnedItemsList = [],
                   metadata = {},
+                  loading: loadingUnpinnedItems,
                 }) => {
                   // Prevents table UI flashing while performing a GET request
                   // (e.g. for pagination or sorting)
@@ -193,7 +195,13 @@ function CollectionContent({ collection, collectionId, isAdmin, isRoot }) {
                     toggleAll(unselected);
                   };
 
-                  if (!hasPinnedItems && unpinnedItems.length === 0) {
+                  const loading = loadingPinnedItems || loadingUnpinnedItems;
+
+                  if (
+                    !loading &&
+                    !hasPinnedItems &&
+                    unpinnedItems.length === 0
+                  ) {
                     return (
                       <Box mt="120px">
                         <CollectionEmptyState />

--- a/frontend/src/metabase/entities/containers/EntityListLoader.jsx
+++ b/frontend/src/metabase/entities/containers/EntityListLoader.jsx
@@ -176,7 +176,7 @@ class EntityListLoader extends React.Component {
     const shouldUpdatePrevList =
       keepListWhileLoading &&
       Array.isArray(prevProps.list) &&
-      !_.isEqual(previousList, prevProps.list);
+      previousList !== prevProps.list;
 
     if (shouldUpdatePrevList) {
       this.setState({ previousList: prevProps.list });

--- a/frontend/src/metabase/entities/containers/EntityListLoader.jsx
+++ b/frontend/src/metabase/entities/containers/EntityListLoader.jsx
@@ -238,11 +238,9 @@ EntityListLoader.defaultProps = defaultProps;
 
 export default EntityListLoader;
 
-export const entityListLoader = ellProps =>
-  // eslint-disable-line react/display-name
-  ComposedComponent =>
-    // eslint-disable-next-line react/display-name
-    props => (
+export const entityListLoader = ellProps => ComposedComponent => {
+  function WrappedComponent(props) {
+    return (
       <EntityListLoader {...props} {...ellProps}>
         {childProps => (
           <ComposedComponent
@@ -252,3 +250,7 @@ export const entityListLoader = ellProps =>
         )}
       </EntityListLoader>
     );
+  }
+  WrappedComponent.displayName = ComposedComponent.displayName;
+  return WrappedComponent;
+};

--- a/frontend/src/metabase/entities/containers/EntityListLoader.jsx
+++ b/frontend/src/metabase/entities/containers/EntityListLoader.jsx
@@ -184,36 +184,33 @@ class EntityListLoader extends React.Component {
   }
 
   renderChildren = () => {
-    let {
+    const {
       children,
       entityDef,
       wrapped,
-      list,
+      list: currentList,
+      loading,
       reload, // eslint-disable-line no-unused-vars
       keepListWhileLoading,
       ...props
     } = this.props;
     const { previousList } = this.state;
 
-    if (wrapped) {
-      list = this._getWrappedList(this.props);
-    }
+    const finalList =
+      keepListWhileLoading && loading ? previousList : currentList;
 
-    const childProps = {
+    const list = wrapped
+      ? this._getWrappedList({ ...this.props, list: finalList })
+      : finalList;
+
+    return children({
       ..._.omit(props, ...CONSUMED_PROPS),
       list,
+      loading,
       // alias the entities name:
       [entityDef.nameMany]: list,
       reload: this.reload,
-    };
-
-    if (keepListWhileLoading) {
-      childProps.previousList = wrapped
-        ? this._getWrappedList({ ...this.props, list: previousList })
-        : previousList;
-    }
-
-    return children(childProps);
+    });
   };
 
   render() {

--- a/frontend/src/metabase/entities/containers/EntityListLoader.jsx
+++ b/frontend/src/metabase/entities/containers/EntityListLoader.jsx
@@ -16,7 +16,7 @@ const propTypes = {
   wrapped: PropTypes.bool,
   debounced: PropTypes.bool,
   loadingAndErrorWrapper: PropTypes.bool,
-  keepPreviousList: PropTypes.bool,
+  keepListWhileLoading: PropTypes.bool,
   selectorName: PropTypes.string,
   children: PropTypes.func,
 
@@ -39,7 +39,7 @@ const propTypes = {
 
 const defaultProps = {
   loadingAndErrorWrapper: true,
-  keepPreviousList: false,
+  keepListWhileLoading: false,
   reload: false,
   wrapped: false,
   debounced: false,
@@ -170,11 +170,11 @@ class EntityListLoader extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { keepPreviousList } = this.props;
+    const { keepListWhileLoading } = this.props;
     const { previousList } = this.state;
 
     const shouldUpdatePrevList =
-      keepPreviousList &&
+      keepListWhileLoading &&
       Array.isArray(prevProps.list) &&
       !_.isEqual(previousList, prevProps.list);
 
@@ -190,7 +190,7 @@ class EntityListLoader extends React.Component {
       wrapped,
       list,
       reload, // eslint-disable-line no-unused-vars
-      keepPreviousList,
+      keepListWhileLoading,
       ...props
     } = this.props;
     const { previousList } = this.state;
@@ -207,7 +207,7 @@ class EntityListLoader extends React.Component {
       reload: this.reload,
     };
 
-    if (keepPreviousList) {
+    if (keepListWhileLoading) {
       childProps.previousList = wrapped
         ? this._getWrappedList({ ...this.props, list: previousList })
         : previousList;

--- a/frontend/src/metabase/entities/containers/EntityListLoader.jsx
+++ b/frontend/src/metabase/entities/containers/EntityListLoader.jsx
@@ -172,14 +172,13 @@ class EntityListLoader extends React.Component {
   componentDidUpdate(prevProps) {
     const { keepPreviousList } = this.props;
     const { previousList } = this.state;
-    if (!keepPreviousList) {
-      return;
-    }
 
-    if (
+    const shouldUpdatePrevList =
+      keepPreviousList &&
       Array.isArray(prevProps.list) &&
-      !_.isEqual(previousList, prevProps.list)
-    ) {
+      !_.isEqual(previousList, prevProps.list);
+
+    if (shouldUpdatePrevList) {
       this.setState({ previousList: prevProps.list });
     }
   }


### PR DESCRIPTION
This PR fixes collection items table UI flashing each time we send a new GET request i.e. for changing sorting or moving between item pages. This is done by displaying the most recent data until a new GET request is done.

`CollectionContent` container uses `EntityListLoader`, so the first idea was to disable `loadingAndErrorWrapper`. But it was not enough, as our entity loader framework sets the entity list value to `[]` once a new request is sent. Was thinking about changing reducers logic a bit, so the previous list stays in the store until a request is done, but I suppose there might be a lot of unexpected consequences 😄 

So, there were just two possible scenarios:

* if `LoadingAndErrorWrapper` is used, the whole `CollectionContent` would flash and replaced by a spinner until the request is done
* if `LoadingAndErrorWrapper` is disabled, there would be a moment when both pinned and unpinned item tables receive an empty list and the UI would also flash

The solution is to extend `EntityListLoader`, so it can keep the most recent data in between GET requests. This is an optional behavior, that can be enabled by passing the `keepPreviousList` prop to `EntityListLoader`. Then the wrapped component would receive the `previousList` prop. This can potentially improve UX in different areas of the app where search, pagination, filtering, sorting is used together with `EntityListLoader` (e.g. admin People table)

I was thinking if we should just swap EntityListLoader's `list` props with `previousList` if there is an ongoing GET request, so wrapped components don't have to do stuff like `const items = list.length > 0 ? list : prevList`, but was not sure. Please share your feedback on that

This PR also refactors `EntityListLoader` a bit:

* flow types are replaced with `prop-types`
* `propTypes` and `defaultProps` definitions moved to the top
* removed flow types (mostly `any` here and there, not very helpful)

### To Verify

1. Open any collection, the more items it contains, the better
2. Try sorting items and moving between item pages
3. There should be no visible UI flashes

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/120652942-e74b4c00-c488-11eb-98f8-7d576381a3aa.mov

**After**


https://user-images.githubusercontent.com/17258145/121322453-a71c1b80-c917-11eb-823e-3db8afe23852.mov

