### PR TITLE
Repro for missing value labels on combo charts

### DIFF
--- a/frontend/test/metabase/scenarios/visualizations/combo.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/combo.cy.spec.js
@@ -1,0 +1,40 @@
+import { restore, visitQuestionAdhoc } from "__support__/e2e/cypress";
+import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
+
+const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATASET;
+
+describe("scenarios > visualizations > combo", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it(`should render values on data points`, () => {
+    visitQuestionAdhoc({
+      dataset_query: {
+        database: 1,
+        query: {
+          "source-table": PRODUCTS_ID,
+          aggregation: [["count"], ["sum", ["field", PRODUCTS.PRICE, null]]],
+          breakout: [
+            [
+              "field",
+              PRODUCTS.CREATED_AT,
+              {
+                "temporal-unit": "month",
+              },
+            ],
+          ],
+        },
+        type: "query",
+      },
+      display: "combo",
+      displayIsLocked: true,
+      visualization_settings: {
+        "graph.show_values": true,
+      },
+    });
+    // First value label on the chart
+    cy.findAllByText("136.83");
+  });
+});


### PR DESCRIPTION
Reproduces a bug introduced in https://github.com/metabase/metabase/pull/16369 fixed by https://github.com/metabase/metabase/pull/16488
