### PR TITLE
Fix can't archive a question from the Question page

### DIFF
--- a/frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx
+++ b/frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx
@@ -10,13 +10,15 @@ import ArchiveModal from "metabase/components/ArchiveModal";
 import * as Urls from "metabase/lib/urls";
 import Questions from "metabase/entities/questions";
 
-const mapDispatchToProps = { archive: Questions.actions.setArchived };
+const mapDispatchToProps = {
+  archive: id => Questions.actions.setArchived({ id }, true),
+};
 
 class ArchiveQuestionModal extends Component {
   onArchive = () => {
     const { question, archive, router } = this.props;
     const card = question.card();
-    archive({ id: card.id });
+    archive(card.id);
     router.push(Urls.collection(card.collection));
   };
 

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -302,9 +302,14 @@ describe("collection permissions", () => {
                 });
 
                 it("should be able to archive the question (metabase#11719-3)", () => {
+                  cy.intercept("GET", "/api/collection/root/items**").as(
+                    "getItems",
+                  );
                   cy.findByText("Archive").click();
                   clickButton("Archive");
                   assertOnRequest("updateQuestion");
+                  cy.wait("@getItems"); // pinned items
+                  cy.wait("@getItems"); // unpinned items
                   cy.location("pathname").should("eq", "/collection/root");
                   cy.findByText("Orders").should("not.exist");
                 });

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -301,7 +301,7 @@ describe("collection permissions", () => {
                   cy.contains("37.65");
                 });
 
-                it("should be able to archive the question (metabase#11719-3)", () => {
+                it("should be able to archive the question (metabase#11719-3, metabase#16512)", () => {
                   cy.intercept("GET", "/api/collection/root/items**").as(
                     "getItems",
                   );


### PR DESCRIPTION
When archiving a question from the question page, it navigates you to the collection as expected, but the item isn't achieved and there is a message saying "Unarchived the item". Fixes #16512, reproduces #16512

There is [a test](https://github.com/metabase/metabase/blob/207cd9bce9e2399ffc6d5cfdc3d1db1f72b84d37/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js#L304) that had to catch that. Looks like it was asserting the archived item is gone while the collection content was not loaded. There is a spinner in place of item lists, so the "not.exist" assertion was successful. Could make it work by explicitly waiting until collection items GET requests are done (there are two of them: one for pinned items and one for unpinned). Not sure if it's the best possible fix here

### To Verify

1. Open any question
2. Click the pencil icon near the question's name
3. Click archive and confirm the action
6. Ensure the question disappeared from the list and the toast message says "Archived the item", instead of "Unarchived"

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/121331325-717b3080-c91f-11eb-9e84-cecdb7c0dc7d.mov

**After**

https://user-images.githubusercontent.com/17258145/121341746-a3919000-c929-11eb-8ac2-cc99eaad9ac6.mov
