### PR TITLE
add mod request + removal actions to moderation action menu

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationIssueActionMenu.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationIssueActionMenu.jsx
@@ -12,6 +12,14 @@ import {
 } from "metabase-enterprise/moderation";
 import { getIsModerator } from "metabase-enterprise/moderation/selectors";
 
+const mapStateToProps = (state, props) => {
+  return {
+    userType: getUserTypeTextKey(getIsModerator(state, props)),
+  };
+};
+
+export default connect(mapStateToProps)(ModerationIssueActionMenu);
+
 ModerationIssueActionMenu.propTypes = {
   className: PropTypes.string,
   triggerClassName: PropTypes.string,
@@ -47,14 +55,6 @@ function ModerationIssueActionMenu({
     />
   );
 }
-
-const mapStateToProps = (state, props) => {
-  return {
-    userType: getUserTypeTextKey(getIsModerator(state, props)),
-  };
-};
-
-export default connect(mapStateToProps)(ModerationIssueActionMenu);
 
 function buildActionMenuItems(userType, targetIssueType, onAction) {
   const issueActionTypes = getModerationIssueActionTypes(

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationIssueThread.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationIssueThread.jsx
@@ -144,7 +144,7 @@ export function ModerationIssueThread({
             <ModerationIssueActionMenu
               triggerClassName="text-white text-white-hover bg-brand bg-brand-hover py1"
               onAction={actionType => onModerate(actionType, request)}
-              request={request}
+              targetIssueType={request.type}
             />
           )}
         </div>

--- a/enterprise/frontend/src/metabase-enterprise/moderation/constants.js
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/constants.js
@@ -27,7 +27,7 @@ export const ACTIONS = {
     color: "brand",
   },
   verification_request: {
-    type: "verified",
+    type: "verification_request",
     icon: "verified",
     color: "brand",
   },
@@ -37,7 +37,7 @@ export const ACTIONS = {
     color: "accent5",
   },
   something_wrong: {
-    type: "misleading",
+    type: "something_wrong",
     icon: "warning_colorized",
     color: "accent5",
   },
@@ -47,18 +47,18 @@ export const ACTIONS = {
     color: "accent2",
   },
   confused: {
-    type: "confusing",
+    type: "confused",
     icon: "clarification",
     color: "accent2",
-  },
-  dismiss: {
-    type: "dismiss",
-    icon: "close",
-    color: "medium",
   },
   pending: {
     type: "pending",
     icon: "arrow_left",
+    color: "medium",
+  },
+  dismiss: {
+    type: "dismiss",
+    icon: "close",
     color: "medium",
   },
 };
@@ -136,6 +136,11 @@ export const MODERATION_TEXT = {
   not_misleading: {},
   pending: {
     creationEvent: t`removed the previous review`,
+    action: t`Remove Review`,
+    actionCreationDescription: t`actionCreationDescription`,
+    actionCreationLabel: t`actionCreationLabel`,
+    actionCreationPlaceholder: t`actionCreationPlaceholder`,
+    actionCreationButton: t`actionCreationButton`,
   },
   dismiss: {
     action: t`Dismiss`,
@@ -144,4 +149,9 @@ export const MODERATION_TEXT = {
     actionCreationPlaceholder: t`Explain why you’re dismissing the request`,
     actionCreationButton: t`Dismiss request`,
   },
+};
+
+export const USER_TYPES = {
+  user: "user",
+  moderator: "moderator",
 };

--- a/enterprise/frontend/src/metabase-enterprise/moderation/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/index.js
@@ -73,11 +73,11 @@ function getDismissalAction(targetIssueType) {
   }
 }
 
-function isReviewType(type) {
+export function isReviewType(type) {
   return !!REVIEW_STATUSES[type];
 }
 
-function isRequestType(type) {
+export function isRequestType(type) {
   return !!REQUEST_TYPES[type];
 }
 

--- a/enterprise/frontend/src/metabase-enterprise/moderation/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/index.js
@@ -68,7 +68,9 @@ export function getModerationIssueActionTypes(userType, targetIssueType) {
 function getDismissalAction(targetIssueType) {
   if (isReviewType(targetIssueType)) {
     return [ACTIONS.pending.type];
-  } else if (isRequestType(targetIssueType)) {
+  }
+
+  if (isRequestType(targetIssueType)) {
     return [ACTIONS.dismiss.type];
   }
 }

--- a/enterprise/frontend/src/metabase-enterprise/moderation/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/index.js
@@ -9,10 +9,11 @@ import * as Urls from "metabase/lib/urls";
 
 import {
   ACTIONS,
-  REQUEST_TYPES,
   REQUEST_STATUSES,
-  REVIEW_STATUSES,
   MODERATION_TEXT,
+  USER_TYPES,
+  REQUEST_TYPES,
+  REVIEW_STATUSES,
 } from "metabase-enterprise/moderation/constants";
 import ModerationIssueActionMenu from "metabase-enterprise/moderation/components/ModerationIssueActionMenu";
 import CreateModerationIssuePanel from "metabase-enterprise/moderation/components/CreateModerationIssuePanel";
@@ -32,33 +33,60 @@ Object.assign(PLUGIN_MODERATION_SERVICE, {
   isRequestDismissal,
   getModerationEvents,
   isRequestOpen,
+  getReviewType,
 });
 
-export function getModerationIssueActionTypes(isModerator, moderationRequest) {
-  return isModerator
-    ? getModerationReviewActionTypes(moderationRequest)
-    : getModerationRequestActionTypes();
+export function getModerationIssueActionTypes(userType, targetIssueType) {
+  switch (userType) {
+    case USER_TYPES.user:
+      return [
+        [
+          ACTIONS.verification_request.type,
+          ACTIONS.something_wrong.type,
+          ACTIONS.confused.type,
+        ],
+      ];
+    case USER_TYPES.moderator:
+      return [
+        [
+          ACTIONS.verified.type,
+          ACTIONS.misleading.type,
+          ACTIONS.confusing.type,
+        ],
+        !isRequestType(targetIssueType) && [
+          ACTIONS.verification_request.type,
+          ACTIONS.something_wrong.type,
+          ACTIONS.confused.type,
+        ],
+        getDismissalAction(targetIssueType),
+      ].filter(Boolean);
+    default:
+      return [];
+  }
 }
 
-function getModerationReviewActionTypes(moderationRequest) {
-  return [
-    REVIEW_STATUSES.verified,
-    REVIEW_STATUSES.misleading,
-    REVIEW_STATUSES.confusing,
-    ...(moderationRequest ? ["dismiss"] : []),
-  ];
+function getDismissalAction(targetIssueType) {
+  if (isReviewType(targetIssueType)) {
+    return [ACTIONS.pending.type];
+  } else if (isRequestType(targetIssueType)) {
+    return [ACTIONS.dismiss.type];
+  }
 }
 
-function getModerationRequestActionTypes() {
-  return [
-    REQUEST_TYPES.verification_request,
-    REQUEST_TYPES.something_wrong,
-    REQUEST_TYPES.confused,
-  ];
+function isReviewType(type) {
+  return !!REVIEW_STATUSES[type];
+}
+
+function isRequestType(type) {
+  return !!REQUEST_TYPES[type];
 }
 
 export function getStatusIconForReview(review) {
-  return getModerationStatusIcon(review && review.status);
+  const type = review && review.status;
+
+  return type === REVIEW_STATUSES.pending
+    ? {}
+    : getModerationStatusIcon(review && review.status);
 }
 
 export function getModerationStatusIcon(type, status) {
@@ -71,6 +99,10 @@ export function getModerationStatusIcon(type, status) {
     color,
     filter: isGrayscale ? "grayscale(1)" : "",
   };
+}
+
+export function getReviewType(question) {
+  return (question.getLatestModerationReview() || {}).status;
 }
 
 export function getOpenRequests(question) {
@@ -91,11 +123,11 @@ export function getNumberOfOpenRequests(question) {
 }
 
 export function isRequestDismissal(type) {
-  return type === "dismiss";
+  return type === ACTIONS.dismiss.type;
 }
 
 export function getUserTypeTextKey(isModerator) {
-  return isModerator ? "moderator" : "user";
+  return isModerator ? USER_TYPES.moderator : USER_TYPES.user;
 }
 
 export function getModerationEvents(

--- a/frontend/src/metabase/plugins/index.js
+++ b/frontend/src/metabase/plugins/index.js
@@ -71,6 +71,7 @@ export const PLUGIN_MODERATION_SERVICE = {
   isRequestOpen: _.noop,
   getModerationRequestActionTypes: _.noop,
   getModerationEvents: _.noop,
+  getReviewType: _.noop,
 };
 
 export const PLUGIN_NOTIFICATION_COMPONENTS = {

--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -108,6 +108,7 @@ export default class View extends React.Component {
       onOpenModal,
       createModerationReview,
       createModerationRequest,
+      dismissModerationRequest,
       createModerationRequestComment,
       updateModerationRequest,
     } = this.props;
@@ -169,6 +170,7 @@ export default class View extends React.Component {
         onOpenModal={onOpenModal}
         createModerationReview={createModerationReview}
         createModerationRequest={createModerationRequest}
+        dismissModerationRequest={dismissModerationRequest}
         createModerationRequestComment={createModerationRequestComment}
         updateModerationRequest={updateModerationRequest}
       />

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebar.jsx
@@ -22,6 +22,7 @@ QuestionDetailsSidebar.propTypes = {
   onOpenModal: PropTypes.func.isRequired,
   createModerationReview: PropTypes.func.isRequired,
   createModerationRequest: PropTypes.func.isRequired,
+  dismissModerationRequest: PropTypes.func.isRequired,
   createModerationRequestComment: PropTypes.func.isRequired,
   updateModerationRequest: PropTypes.func.isRequired,
   router: PropTypes.object.isRequired,
@@ -32,6 +33,7 @@ function QuestionDetailsSidebar({
   onOpenModal,
   createModerationReview,
   createModerationRequest,
+  dismissModerationRequest,
   createModerationRequestComment,
   updateModerationRequest,
   router,
@@ -70,6 +72,7 @@ function QuestionDetailsSidebar({
           onReturn={onReturn}
           createModerationReview={createModerationReview}
           createModerationRequest={createModerationRequest}
+          dismissModerationRequest={dismissModerationRequest}
           itemId={id}
         />
       );

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebarPanel.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebarPanel.jsx
@@ -3,7 +3,10 @@ import PropTypes from "prop-types";
 import SidebarContent from "metabase/query_builder/components/SidebarContent";
 import QuestionActionButtons from "metabase/questions/components/QuestionActionButtons";
 import QuestionActivityTimeline from "metabase/questions/components/QuestionActivityTimeline";
-import { PLUGIN_MODERATION_COMPONENTS } from "metabase/plugins";
+import {
+  PLUGIN_MODERATION_COMPONENTS,
+  PLUGIN_MODERATION_SERVICE,
+} from "metabase/plugins";
 import { SIDEBAR_VIEWS } from "./constants";
 import { ClampedDescription } from "metabase/questions/components/ClampedDescription";
 const {
@@ -46,6 +49,7 @@ function QuestionDetailsSidebarPanel({ setView, question, onOpenModal }) {
                 props: { issueType },
               });
             }}
+            targetIssueType={PLUGIN_MODERATION_SERVICE.getReviewType(question)}
           />
           <OpenModerationIssuesButton
             className="mb3"


### PR DESCRIPTION
Ugly, but it gets the job done for now. This PR adds the bottom four items in this menu so that moderators can open moderation requests on questions they themselves moderate. Also lets them "remove" the latest review -- this is done by creating a new review with a status of "pending".

<img width="254" alt="Screen Shot 2021-06-10 at 5 08 42 PM" src="https://user-images.githubusercontent.com/13057258/121613657-d1ea9a80-ca11-11eb-91e7-94ac4da57b5f.png">
