### PR TITLE
Aggregation query should always specify name (#16259)

### DIFF
--- a/frontend/src/metabase/lib/query/aggregation.js
+++ b/frontend/src/metabase/lib/query/aggregation.js
@@ -136,7 +136,7 @@ export function setName(
   return [
     "aggregation-options",
     getContent(aggregation),
-    { "display-name": name, ...getOptions(aggregation) },
+    { name, "display-name": name, ...getOptions(aggregation) },
   ];
 }
 export function setContent(

--- a/frontend/test/metabase/lib/query/aggregation.unit.spec.js
+++ b/frontend/test/metabase/lib/query/aggregation.unit.spec.js
@@ -1,4 +1,4 @@
-import { getName } from "metabase/lib/query/aggregation";
+import { getName, setName } from "metabase/lib/query/aggregation";
 
 describe("getName", () => {
   it("should work with blank display name", () => {
@@ -6,5 +6,17 @@ describe("getName", () => {
     expect(getName(["aggregation-options", ["+", ["count"], 3], null])).toEqual(
       undefined,
     );
+  });
+});
+
+describe("setName", () => {
+  it("should set the name and display-name", () => {
+    const expr = ["*", ["count"], 2];
+    const aggregation = ["aggregation-options", ["*", ["count"], 2], null];
+    expect(setName(aggregation, "DoubleCount")).toEqual([
+      "aggregation-options",
+      expr,
+      { "display-name": "DoubleCount", name: "DoubleCount" },
+    ]);
   });
 });

--- a/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
@@ -176,7 +176,7 @@ describe("scenarios > question > custom columns", () => {
       .findByText("1");
   });
 
-  it.skip("should be able to use custom expression after aggregation (metabase#13857)", () => {
+  it("should be able to use custom expression after aggregation (metabase#13857)", () => {
     const CE_NAME = "13857_CE";
     const CC_NAME = "13857_CC";
 
@@ -190,7 +190,11 @@ describe("scenarios > question > custom columns", () => {
         },
         "source-query": {
           aggregation: [
-            ["aggregation-options", ["*", 1, 1], { "display-name": CE_NAME }],
+            [
+              "aggregation-options",
+              ["*", 1, 1],
+              { name: CE_NAME, "display-name": CE_NAME },
+            ],
           ],
           breakout: [
             ["datetime-field", ["field-id", ORDERS.CREATED_AT], "month"],

--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -301,7 +301,7 @@ describe("scenarios > question > filter", () => {
     cy.findAllByText("Fantastic Wool Shirt").should("not.exist");
   });
 
-  it.skip("should filter using Custom Expression from aggregated results (metabase#12839)", () => {
+  it("should filter using Custom Expression from aggregated results (metabase#12839)", () => {
     const CE_NAME = "Simple Math";
 
     cy.createQuestion({
@@ -310,7 +310,11 @@ describe("scenarios > question > filter", () => {
         filter: [">", ["field", CE_NAME, { "base-type": "type/Float" }], 0],
         "source-query": {
           aggregation: [
-            ["aggregation-options", ["+", 1, 1], { "display-name": CE_NAME }],
+            [
+              "aggregation-options",
+              ["+", 1, 1],
+              { name: CE_NAME, "display-name": CE_NAME },
+            ],
           ],
           breakout: [["field", PRODUCTS.CATEGORY, null]],
           "source-table": PRODUCTS_ID,

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -456,7 +456,7 @@ describe("scenarios > question > notebook", () => {
       });
     });
 
-    it.skip("should be able to do subsequent aggregation on a custom expression (metabase#14649)", () => {
+    it("should be able to do subsequent aggregation on a custom expression (metabase#14649)", () => {
       cy.createQuestion({
         name: "14649_min",
         query: {
@@ -466,7 +466,7 @@ describe("scenarios > question > notebook", () => {
               [
                 "aggregation-options",
                 ["sum", ["field", ORDERS.SUBTOTAL, null]],
-                { "display-name": "Revenue" },
+                { name: "Revenue", "display-name": "Revenue" },
               ],
             ],
             breakout: [


### PR DESCRIPTION
This is a backport of PR 16259 for 39 branch. It fixes #12839, #13857, and #14649 (probably a few more related).

Steps to reproduce:

1. Ask a question, Custom question
2. Sample Dataset, Products
3. Summarize "Average of Price" and (Custom Expression) `CountIf(interval([Created At], -3, "year"))` as "Last3Years", by "Category"
4. Filter by "Last3Years > 15"

**Before this PR**

Can't do that, throws an error:

![image](https://user-images.githubusercontent.com/7288/121456955-b91fad80-c95b-11eb-9247-0bfa1465a86f.png)

**After this PR**

Works as expected:
![image](https://user-images.githubusercontent.com/7288/121456970-c0df5200-c95b-11eb-9eb7-5fb1b3dac524.png)
