### PR TITLE
Order by _revision_ id, not _user_ id

### DIFF
--- a/src/metabase/models/revision/last_edit.clj
+++ b/src/metabase/models/revision/last_edit.clj
@@ -42,7 +42,7 @@
                                           :where [:and
                                                   [:= :r.model (model->db-model model)]
                                                   [:= :r.model_id id]]
-                                          :order-by [[:u.id :desc]]
+                                          :order-by [[:r.id :desc]]
                                           :limit 1}))]
     (assoc item :last-edit-info updated-info)
     item))


### PR DESCRIPTION
Title explains it all. In the bulk query (when fetching `api/card/` or `api/dashboard/`) do the correct thing, as well as the paginated collection endpoint. However, this query was run on individuals when seeing a single card or dashboard. The order clause was accidentally ordering by the `u.id` rather than `r.id`. Since revisions are immutable and added with the current timestamp, the ids and the timestamps increase together. Accidentally was ordering by the wrong id column.