### PR TITLE
Close Custom Expression Helper after blurring from input at any caret position

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -239,7 +239,10 @@ export default class ExpressionEditorTextfield extends React.Component {
   onInputBlur = () => {
     this.clearSuggestions();
     const { compileError } = this.state;
-    this.setState({ displayCompileError: compileError });
+    this.setState({
+      displayCompileError: compileError,
+      helpText: null,
+    });
 
     // whenever our input blurs we push the updated expression to our parent if valid
     if (this.state.expression) {

--- a/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
@@ -539,7 +539,7 @@ describe("scenarios > question > custom columns", () => {
     cy.findByPlaceholderText("Enter a number").should("not.exist");
   });
 
-  it.skip("custom expression helper shouldn't be visible when formula field is not in focus (metabase#15891)", () => {
+  it("custom expression helper shouldn't be visible when formula field is not in focus (metabase#15891)", () => {
     openPeopleTable({ mode: "notebook" });
     cy.findByText("Custom column").click();
     popover().within(() => {


### PR DESCRIPTION
Fixes #15891

**To Reproduce**
1. Custom question > Sample Dataset > Orders
2. Custom Column > type `rou` and press enter to autocomplete to `round(|)` and finish it by typing `1.5`, so it looks like this:

![image](https://user-images.githubusercontent.com/1447303/116776392-77503d00-aa68-11eb-97bf-d69e9c9eaac7.png)

3. Click outside the input.

**After:**

Helper component disappears.

**Before:**

Helper component would not disappear.
