### PR TITLE
BUCM Notifications

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -8471,6 +8471,61 @@ databaseChangeLog:
               WHERE base_type IN ('ArrayField', 'BigIntegerField', 'BooleanField', 'CharField', 'DateField',
                                   'DateTimeField', 'DecimalField', 'DictionaryField', 'FloatField', 'IntegerField',
                                   'TextField', 'TimeField', 'UUIDField', 'UnknownField');
+  - changeSet:
+      id: 306
+      author: tsmacdonald
+      comment: Added 0.41.0
+      changes:
+        - createTable:
+            tableName: notification
+            remarks: "Notifications (comments and other moderation-related matters)"
+            columns:
+              - column:
+                  name: id
+                  type: int
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: ${timestamp_type}
+                  defaultValueComputed: current_timestamp
+                  remarks: "most recent modification time"
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: ${timestamp_type}
+                  defaultValueComputed: current_timestamp
+                  remarks: "creation time"
+                  constraints:
+                    nullable: false
+              - column:
+                  name: notifier_id
+                  type: int
+                  remarks: "The item to which the notification refers"
+                  constraints:
+                    nullable: false
+              - column:
+                  name: notifier_type
+                  type: varchar(255)
+                  remarks: "See enum in model file"
+                  constraints:
+                    nullable: false
+              - column:
+                  name: user_id
+                  type: int
+                  remarks: "The recipient of the notification"
+                  constraints:
+                    nullable: false
+              - column:
+                  name: read
+                  type: boolean
+                  remarks: "Whether the notification has been dismissed (read) by the user"
+                  defaultValue: false
+                  constraints:
+                    nullable: false
 
   - changeSet:
       id: 307

--- a/src/metabase/api/notification.clj
+++ b/src/metabase/api/notification.clj
@@ -1,0 +1,14 @@
+(ns metabase.api.notification
+  (:require [compojure.core :refer [POST]]
+            [metabase.api.common :as api]
+            [metabase.models.notification :as notification]
+            [metabase.util.schema :as su]
+            [schema.core :as s]
+            [toucan.hydrate :as hydrate]))
+
+(api/defendpoint GET "/"
+  "All notifications for the current user"
+  []
+  (hydrate/hydrate (notification/for-user api/*current-user-id*) [:notifier :moderated_item]))
+
+(api/define-routes)

--- a/src/metabase/api/notification.clj
+++ b/src/metabase/api/notification.clj
@@ -1,9 +1,7 @@
 (ns metabase.api.notification
-  (:require [compojure.core :refer [POST]]
+  (:require [compojure.core :refer [GET]]
             [metabase.api.common :as api]
             [metabase.models.notification :as notification]
-            [metabase.util.schema :as su]
-            [schema.core :as s]
             [toucan.hydrate :as hydrate]))
 
 (api/defendpoint GET "/"

--- a/src/metabase/api/routes.clj
+++ b/src/metabase/api/routes.clj
@@ -21,6 +21,7 @@
             [metabase.api.moderation-request :as moderation-request]
             [metabase.api.moderation-review :as moderation-review]
             [metabase.api.native-query-snippet :as native-query-snippet]
+            [metabase.api.notification :as notification]
             [metabase.api.notify :as notify]
             [metabase.api.permissions :as permissions]
             [metabase.api.preview-embed :as preview-embed]
@@ -91,6 +92,7 @@
   (context "/moderation-request"   [] (+auth moderation-request/routes))
   (context "/moderation-review"    [] (+auth moderation-review/routes))
   (context "/native-query-snippet" [] (+auth native-query-snippet/routes))
+  (context "/notification"         [] (+auth notification/routes))
   (context "/notify"               [] (+apikey notify/routes))
   (context "/permissions"          [] (+auth permissions/routes))
   (context "/preview_embed"        [] (+auth preview-embed/routes))

--- a/src/metabase/cmd/copy.clj
+++ b/src/metabase/cmd/copy.clj
@@ -12,7 +12,7 @@
             [metabase.models :refer [Activity Card CardFavorite Collection CollectionPermissionGraphRevision Comment
                                      Dashboard DashboardCard DashboardCardSeries DashboardFavorite Database Dependency
                                      Dimension Field FieldValues LoginHistory Metric MetricImportantField
-                                     ModerationRequest ModerationReview NativeQuerySnippet Permissions
+                                     ModerationRequest ModerationReview NativeQuerySnippet Notification Permissions
                                      PermissionsGroup PermissionsGroupMembership PermissionsRevision Pulse PulseCard
                                      PulseChannel PulseChannelRecipient Revision Segment Session Setting Table User
                                      ViewLog]]
@@ -81,6 +81,7 @@
    ModerationReview
    ModerationRequest
    Comment
+   Notification
    ;; migrate the list of finished DataMigrations as the very last thing (all models to copy over should be listed
    ;; above this line)
    DataMigrations])

--- a/src/metabase/models.clj
+++ b/src/metabase/models.clj
@@ -20,6 +20,7 @@
             [metabase.models.moderation-request :as moderation-request]
             [metabase.models.moderation-review :as moderation-review]
             [metabase.models.native-query-snippet :as native-query-snippet]
+            [metabase.models.notification :as notification]
             [metabase.models.permissions :as permissions]
             [metabase.models.permissions-group :as permissions-group]
             [metabase.models.permissions-group-membership :as permissions-group-membership]
@@ -61,6 +62,7 @@
          metric-important-field/keep-me
          moderation-request/keep-me
          moderation-review/keep-me
+         notification/keep-me
          native-query-snippet/keep-me
          permissions/keep-me
          permissions-group/keep-me
@@ -103,6 +105,7 @@
  [moderation-request ModerationRequest]
  [moderation-review ModerationReview]
  [native-query-snippet NativeQuerySnippet]
+ [notification Notification]
  [permissions Permissions]
  [permissions-group PermissionsGroup]
  [permissions-group-membership PermissionsGroupMembership]

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -127,7 +127,7 @@
   "Check that a `card`, if it is using another Card as its source, does not have circular references between source
   Cards. (e.g. Card A cannot use itself as a source, or if A uses Card B as a source, Card B cannot use Card A, and so
   forth.)"
-  [{query :dataset_query, id :id}]      ; don't use `u/get-id` here so that we can use this with `pre-insert` too
+  [{query :dataset_query, id :id}]      ; don't use `u/the-id` here so that we can use this with `pre-insert` too
   (loop [query query, ids-already-seen #{id}]
     (let [source-card-id (qputil/query->source-card-id query)]
       (cond

--- a/src/metabase/models/comment.clj
+++ b/src/metabase/models/comment.clj
@@ -1,5 +1,6 @@
 (ns metabase.models.comment
   (:require [metabase.models.interface :as i]
+            [metabase.models.notification :as notification]
             [metabase.models.permissions :as perms]
             [metabase.util :as u]
             [metabase.util.schema :as su]
@@ -11,13 +12,43 @@
   "Schema enum of the acceptable values for the `commented_item_type` column"
   (s/enum "moderation_request" "moderation_review"))
 
+(def commented-item->model
+  "Maps DB name of the commented item type to the model symbol (used for db/select and such)"
+  {"moderation_request" 'ModerationRequest
+   :moderation_request  'ModerationRequest
+   "moderation_review"  'ModerationReview
+   :moderation_review   'ModerationReview})
+
+(defn- commented-item
+  [{:keys [commented_item_id commented_item_type]}]
+  (db/select-one (commented-item->model commented_item_type) :id commented_item_id))
+
+(defn- author-for
+  [{:keys [moderator_id requester_id]}]
+  (or moderator_id requester_id))
+
+(defn- create-notifications!
+  [{:keys [commented_item_id commented_item_type author_id id] :as comment}]
+  (u/prog1 comment
+    (let [user-ids (disj (set (conj (db/select-field :author_id 'Comment
+                                      :commented_item_type (name commented_item_type)
+                                      :commented_item_id commented_item_id)
+                                    (author-for (commented-item comment))))
+                         author_id)]
+      (notification/create-notifications!
+       (map (fn [user-id] {:notifier_id id
+                           :notifier_type "comment"
+                           :user_id user-id})
+            user-ids)))))
+
 (models/defmodel Comment :comment)
 
 (u/strict-extend (class Comment)
   models/IModel
   (merge models/IModelDefaults
          {:properties (constantly {:timestamped? true})
-          :types      (constantly {:commented_item_type :keyword})})
+          :types      (constantly {:commented_item_type :keyword})
+          :post-insert create-notifications!})
 
   ;; Todo: this is wrong, but what should it be?
   i/IObjectPermissions

--- a/src/metabase/models/notification.clj
+++ b/src/metabase/models/notification.clj
@@ -2,6 +2,7 @@
   (:require [metabase.models.permissions :as perms]
             [metabase.moderation :as moderation]
             [metabase.util :as u]
+            [metabase.util.schema :as su]
             [schema.core :as s]
             [toucan.db :as db]
             [toucan.models :as models]))
@@ -46,3 +47,10 @@
   [user-id]
   (db/select Notification :user_id user-id, :read false,
              {:order-by [[:created_at :desc]]}))
+
+(s/defn create-notifications!
+  [row-maps :-
+   [{:notifier_id   su/IntGreaterThanZero
+     :notifier_type notifier-types
+     :user_id       su/IntGreaterThanZero}]]
+  (db/insert-many! Notification row-maps))

--- a/src/metabase/models/notification.clj
+++ b/src/metabase/models/notification.clj
@@ -1,0 +1,48 @@
+(ns metabase.models.notification
+  (:require [metabase.models.permissions :as perms]
+            [metabase.moderation :as moderation]
+            [metabase.util :as u]
+            [schema.core :as s]
+            [toucan.db :as db]
+            [toucan.models :as models]))
+
+(def notifier-types
+  "Schema enum of the acceptable values for the `notifier_type` column"
+  (s/enum "comment" "moderation_review"))
+
+(def notifier->model
+  "Maps DB name of notifier to the model symbol (used for db/select and such)"
+  {"comment"           'Comment
+   "moderation_review" 'ModerationReview})
+
+(models/defmodel Notification :notification)
+(u/strict-extend (class Notification)
+  models/IModel
+  (merge models/IModelDefaults
+         {:properties (constantly {:timestamped? true})}))
+
+(defn- in-clause
+  [ids]
+  (if ids
+    [:in :id (distinct ids)]
+    [:= 0 1]))
+
+(defn hydrate-notifiers
+  {:batched-hydrate :notifier}
+  [notifications]
+  (when (seq notifications)
+    (let [notifiers (->> notifications
+                         (group-by :notifier_type)
+                         (mapcat (fn [[type notifications]]
+                                   (map #(assoc % :type type)
+                                        (db/select (notifier->model type)
+                                          {:where
+                                           (in-clause (map :notifier_id notifications))}))))
+                         (group-by (juxt :id :type)))]
+      (for [{:keys [notifier_id notifier_type] :as notification} notifications]
+        (assoc notification :notifier (first (get notifiers [notifier_id notifier_type])))))))
+
+(defn for-user
+  [user-id]
+  (db/select Notification :user_id user-id, :read false,
+             {:order-by [[:created_at :desc]]}))

--- a/src/metabase/models/notification.clj
+++ b/src/metabase/models/notification.clj
@@ -1,7 +1,5 @@
 (ns metabase.models.notification
-  (:require [metabase.models.permissions :as perms]
-            [metabase.moderation :as moderation]
-            [metabase.util :as u]
+  (:require [metabase.util :as u]
             [metabase.util.schema :as su]
             [schema.core :as s]
             [toucan.db :as db]
@@ -24,11 +22,12 @@
 
 (defn- in-clause
   [ids]
-  (if ids
+  (if (seq ids)
     [:in :id (distinct ids)]
     [:= 0 1]))
 
 (defn hydrate-notifiers
+  "The comments / moderation reviews associated with these notifications"
   {:batched-hydrate :notifier}
   [notifications]
   (when (seq notifications)
@@ -44,9 +43,9 @@
         (assoc notification :notifier (first (get notifiers [notifier_id notifier_type])))))))
 
 (defn for-user
+  "Seq of notifications for the given user"
   [user-id]
-  (db/select Notification :user_id user-id, :read false,
-             {:order-by [[:created_at :desc]]}))
+  (db/select Notification :user_id user-id, :read false, {:order-by [[:created_at :desc]]}))
 
 (s/defn create-notifications!
   [row-maps :-

--- a/src/metabase/moderation.clj
+++ b/src/metabase/moderation.clj
@@ -9,6 +9,13 @@
   "Schema enum of the acceptable values for the `moderated_item_type` column"
   (s/enum "card" "dashboard" :card :dashboard))
 
+(def moderated-item-type->model
+  "Maps DB name of the moderated item type to the model symbol (used for db/select and such)"
+  {"card" 'Card
+   :card 'Card
+   "dashboard" 'Dashboard
+   :dashboard 'Dashboard})
+
 (defn- object->type
   "Convert a moderated item instance to the keyword stored in the database"
   [moderated-item]
@@ -30,6 +37,13 @@
   {:hydrate :moderation_reviews}
   [moderated-item]
   (m/mapply db/select 'ModerationReview (moderation-selection-args moderated-item)))
+
+(defn moderated-item
+  "The moderated item for a given request or review"
+  {:hydrate :moderated_item}
+  [{:keys [moderated_item_id moderated_item_type]}]
+  (when (and moderated_item_type moderated_item_id)
+    (db/select-one (moderated-item-type->model moderated_item_type) :id moderated_item_id)))
 
 (defn- in-clause
   [ids]

--- a/src/metabase/moderation.clj
+++ b/src/metabase/moderation.clj
@@ -11,10 +11,10 @@
 
 (def moderated-item-type->model
   "Maps DB name of the moderated item type to the model symbol (used for db/select and such)"
-  {"card" 'Card
-   :card 'Card
+  {"card"      'Card
+   :card       'Card
    "dashboard" 'Dashboard
-   :dashboard 'Dashboard})
+   :dashboard  'Dashboard})
 
 (defn- object->type
   "Convert a moderated item instance to the keyword stored in the database"

--- a/test/metabase/api/comment_test.clj
+++ b/test/metabase/api/comment_test.clj
@@ -4,7 +4,8 @@
             [metabase.models.card :refer [Card]]
             [metabase.models.comment :refer [Comment]]
             [metabase.models.moderation-request :refer [ModerationRequest]]
-            [metabase.test :as mt]))
+            [metabase.test :as mt]
+            [toucan.db :as db]))
 
 (defn- normalized-response
   [moderation-request]
@@ -13,15 +14,25 @@
 (deftest create-test
   (testing "POST /api/comment"
     (mt/with-temp* [Card              [{card-id :id :as card} {:name "Test Card"}]
-                    ModerationRequest [{request-id :id :as request} {:moderated_item_type "card" :moderated_item_id card-id}]]
+                    ModerationRequest [{request-id :id :as request} {:moderated_item_type "card"
+                                                                     :moderated_item_id   card-id
+                                                                     :requester_id        (mt/user->id :crowberto)}]]
       (mt/with-model-cleanup [Comment]
-        (is (= {:text                "first!!!"
-                :commented_item_id   request-id
-                :commented_item_type "moderation_request"
-                :author_id        (mt/user->id :rasta)}
-               (normalized-response
-                (mt/user-http-request :rasta :post 200 "comment" {:text                "first!!!"
-                                                                  :commented_item_id   request-id
-                                                                  :commented_item_type "moderation_request"}))))
+        (let [raw-response (mt/user-http-request :rasta :post 200 "comment" {:text                "first!!!"
+                                                                             :commented_item_id   request-id
+                                                                             :commented_item_type "moderation_request"})]
+          (is (= {:text                "first!!!"
+                  :commented_item_id   request-id
+                  :commented_item_type "moderation_request"
+                  :author_id        (mt/user->id :rasta)}
+                 (normalized-response raw-response)))
+          (is (= {:notifier_id   (:id raw-response)
+                  :notifier_type "comment"
+                  :user_id       (mt/user->id :crowberto)
+                  :read          false}
+                 (select-keys
+                  (db/select-one 'Notification {:order-by [[:id :desc]]})
+                  [:notifier_id :notifier_type :user_id :read]))))
+
         ;; TODO: test for missing keys, invalid enums
         ))))

--- a/test/metabase/api/comment_test.clj
+++ b/test/metabase/api/comment_test.clj
@@ -4,6 +4,7 @@
             [metabase.models.card :refer [Card]]
             [metabase.models.comment :refer [Comment]]
             [metabase.models.moderation-request :refer [ModerationRequest]]
+            [metabase.models.notification :refer [Notification]]
             [metabase.test :as mt]
             [toucan.db :as db]))
 
@@ -17,7 +18,7 @@
                     ModerationRequest [{request-id :id :as request} {:moderated_item_type "card"
                                                                      :moderated_item_id   card-id
                                                                      :requester_id        (mt/user->id :crowberto)}]]
-      (mt/with-model-cleanup [Comment]
+      (mt/with-model-cleanup [Comment Notification]
         (let [raw-response (mt/user-http-request :rasta :post 200 "comment" {:text                "first!!!"
                                                                              :commented_item_id   request-id
                                                                              :commented_item_type "moderation_request"})]
@@ -31,7 +32,7 @@
                   :user_id       (mt/user->id :crowberto)
                   :read          false}
                  (select-keys
-                  (db/select-one 'Notification {:order-by [[:id :desc]]})
+                  (db/select-one Notification {:order-by [[:id :desc]]})
                   [:notifier_id :notifier_type :user_id :read]))))
 
         ;; TODO: test for missing keys, invalid enums

--- a/test/metabase/api/moderation_review_test.clj
+++ b/test/metabase/api/moderation_review_test.clj
@@ -5,6 +5,7 @@
             [metabase.models.dashboard :refer [Dashboard]]
             [metabase.models.moderation-request :refer [ModerationRequest]]
             [metabase.models.moderation-review :refer [ModerationReview]]
+            [metabase.models.notification :refer [Notification]]
             [metabase.test :as mt]
             [toucan.db :as db]))
 
@@ -14,8 +15,12 @@
 
 (deftest create-test
   (testing "POST /api/moderation-review"
-    (mt/with-temp* [Card [{card-id :id :as card} {:name "Test Card"}]]
-      (mt/with-model-cleanup [ModerationReview]
+    (mt/with-temp* [Card [{card-id :id :as card} {:name "Test Card"}]
+                    ModerationRequest [_         {:moderated_item_id   card-id
+                                                  :moderated_item_type "card"
+                                                  :requester_id        (mt/user->id :crowberto)}]
+                    ]
+      (mt/with-model-cleanup [ModerationReview Notification]
         (is (= {:text                "Looks good to me"
                 :moderated_item_id   card-id
                 :moderated_item_type "card"
@@ -25,16 +30,23 @@
                 (mt/user-http-request :rasta :post 200 "moderation-review" {:text                "Looks good to me"
                                                                             :moderated_item_id   card-id
                                                                             :moderated_item_type "card"}))))
-        (is (= {:text                "Looks good to me"
-                :moderated_item_id   card-id
-                :moderated_item_type "card"
-                :moderator_id        (mt/user->id :rasta)
-                :status              "verified"}
-               (normalized-response
-                (mt/user-http-request :rasta :post 200 "moderation-review" {:text                "Looks good to me"
-                                                                            :moderated_item_id   card-id
-                                                                            :moderated_item_type "card"
-                                                                            :status              "verified"}))))))))
+        (let [raw-response (mt/user-http-request :rasta :post 200 "moderation-review" {:text                "Looks good to me"
+                                                                                       :moderated_item_id   card-id
+                                                                                       :moderated_item_type "card"
+                                                                                       :status              "verified"})]
+          (is (= {:text                "Looks good to me"
+                  :moderated_item_id   card-id
+                  :moderated_item_type "card"
+                  :moderator_id        (mt/user->id :rasta)
+                  :status              "verified"}
+                 (normalized-response raw-response)))
+          (is (= {:notifier_id   (:id raw-response)
+                  :notifier_type "moderation_review"
+                  :user_id       (mt/user->id :crowberto)
+                  :read          false}
+                 (select-keys
+                  (db/select-one Notification {:order-by [[:id :desc]]})
+                  [:notifier_id :notifier_type :user_id :read]))))))))
 
 (defn- update!
   [id params]

--- a/test/metabase/api/notification_test.clj
+++ b/test/metabase/api/notification_test.clj
@@ -1,0 +1,50 @@
+(ns metabase.api.notification-test
+  (:require [clojure.test :refer :all]
+            [java-time :as t]
+            [metabase.api.notification :as notification-api]
+            [metabase.models.card :refer [Card]]
+            [metabase.models.comment :refer [Comment]]
+            [metabase.models.moderation-review :refer [ModerationReview]]
+            [metabase.models.notification :refer [Notification]]
+            [metabase.test :as mt]))
+
+(defn- minutes-ago
+  [minutes]
+  (t/minus (t/zoned-date-time)
+           (t/minutes minutes)))
+
+(deftest get-test
+  (testing "GET /api/notification"
+    (mt/with-temp* [Card             [{card-id :id}            {:name "The Card"}]
+                    ModerationReview [{review-id :id}          {:moderated_item_id   card-id
+                                                                :moderated_item_type "card"
+                                                                :text                "Looks good"}]
+                    Comment          [{comment-id :id}         {:commented_item_id   review-id
+                                                                :commented_item_type "moderation_review"
+                                                                :text                "I love toucans"}]
+                    Notification     [{a-id :id}               {:notifier_id   review-id
+                                                                :notifier_type "moderation_review"
+                                                                :user_id       (mt/user->id :rasta)}]
+                    Notification     [{b-id :id}               {:notifier_id   comment-id
+                                                                :notifier_type "comment"
+                                                                :user_id       (mt/user->id :rasta)}]
+                    Notification     [{c-id :id}               {:notifier_id   review-id
+                                                                :notifier_type "moderation_review"
+                                                                :user_id       (mt/user->id :rasta)}]
+                    Notification     [{wrong-user-id :id}      {:notifier_id   review-id
+                                                                :notifier_type "moderation_review"
+                                                                :user_id       (mt/user->id :crowberto)}]
+                    Notification     [{read-id :id}            {:notifier_id   review-id
+                                                                :notifier_type "moderation_review"
+                                                                :user_id       (mt/user->id :rasta)
+                                                                :read          true}]]
+      (let [notifications (mt/user-http-request :rasta :get 200 "notification")
+            review        (-> notifications first :notifier)
+            comment       (-> notifications second :notifier)]
+        (def zzn notifications)
+        (is (= [c-id b-id a-id]
+               (map :id notifications)))
+        (is (>= (map :created_at notifications)))
+        (is (= "Looks good"     (-> review :text)))
+        (is (= "The Card"       (-> review :moderated_item :name)))
+        (is (= "I love toucans" (-> comment :text)))))))

--- a/test/metabase/api/notification_test.clj
+++ b/test/metabase/api/notification_test.clj
@@ -41,9 +41,8 @@
       (let [notifications (mt/user-http-request :rasta :get 200 "notification")
             review        (-> notifications first :notifier)
             comment       (-> notifications second :notifier)]
-        (def zzn notifications)
         (is (= [c-id b-id a-id]
-               (map :id notifications)))
+               (map :id (take 3 notifications))))
         (is (>= (map :created_at notifications)))
         (is (= "Looks good"     (-> review :text)))
         (is (= "The Card"       (-> review :moderated_item :name)))

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -13,8 +13,8 @@
             [metabase.driver :as driver]
             [metabase.models :refer [Card Collection Comment Dashboard DashboardCardSeries Database Dimension Field
                                      FieldValues LoginHistory Metric ModerationRequest ModerationReview
-                                     NativeQuerySnippet Permissions PermissionsGroup Pulse PulseCard PulseChannel
-                                     Revision Segment Table TaskHistory User]]
+                                     NativeQuerySnippet Notification Permissions PermissionsGroup Pulse PulseCard
+                                     PulseChannel Revision Segment Table TaskHistory User]]
             [metabase.models.collection :as collection]
             [metabase.models.permissions :as perms]
             [metabase.models.permissions-group :as group]
@@ -192,6 +192,9 @@
    (fn [_] {:creator_id (user-id :crowberto)
             :name       (random-name)
             :content    "1 = 1"})
+
+   Notification
+   (fn [_] {:user_id (user-id :crowberto)})
 
    PermissionsGroup
    (fn [_] {:name (random-name)})


### PR DESCRIPTION
There are two notification-type things for BUCM:

1) The "work queue" for moderators, which is open requests (`ModerationRequest`) that need attention. This PR does not address that.

2) Social media-style notifications, which alert users of any stripe that something they care about happened. This PR is the backend for that.

Currently, notifications can be triggered by one of four conditions:

1) Someone comments on a moderation request that you created
2) Someone comments on a moderation review that you created
3) Someone comments on something you commented on
4) Someone reviews an item that you have an open request for

Cases 1-3 are handled by the big post-insert hook in the Comment model file, case 4 is handled by the post-insert hook in the ModerationReview model file.

In the future there may be notifications for other things, but…not right now.