### PR TITLE
Support multiple domains for Google Auth in EE

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/enhancements/integrations/google.clj
+++ b/enterprise/backend/src/metabase_enterprise/enhancements/integrations/google.clj
@@ -1,10 +1,7 @@
 (ns metabase.integrations.google
-  (:require [metabase.models.setting.multi-setting :refer [define-multi-setting-impl]]))
+  (:require [metabase.models.setting :as setting]
+            [metabase.models.setting.multi-setting :refer [define-multi-setting-impl]]))
 
-; (define-multi-setting-impl google-auth-auto-create-accounts-domain :ee)
-; (define-multi-setting-impl google-auth-auto-create-accounts-domain :ee
-;   :setter (fn [domain]
-;               (when (str/includes? domain ",")
-;                 ;; Multiple comma-separated domains is EE-only feature
-;                 (throw (ex-info (tru "Invalid domain") {:status-code 400})))
-;               (setting/set-string! :google-auth-auto-create-accounts-domain domain)))
+(define-multi-setting-impl google-auth-auto-create-accounts-domain :ee
+  :getter (fn [] (setting/get-string :google-auth-auto-create-accounts-domain))
+  :setter (fn [domain] (setting/set-string! :google-auth-auto-create-accounts-domain domain)))

--- a/enterprise/backend/src/metabase_enterprise/enhancements/integrations/google.clj
+++ b/enterprise/backend/src/metabase_enterprise/enhancements/integrations/google.clj
@@ -1,4 +1,4 @@
-(ns metabase.integrations.google
+(ns metabase-enterprise.enhancements.integrations.google
   (:require [metabase.models.setting :as setting]
             [metabase.models.setting.multi-setting :refer [define-multi-setting-impl]]))
 

--- a/enterprise/backend/src/metabase_enterprise/enhancements/integrations/google.clj
+++ b/enterprise/backend/src/metabase_enterprise/enhancements/integrations/google.clj
@@ -1,7 +1,8 @@
 (ns metabase-enterprise.enhancements.integrations.google
-  (:require [metabase.models.setting :as setting]
+  (:require [metabase.integrations.google.interface :as google.i]
+            [metabase.models.setting :as setting]
             [metabase.models.setting.multi-setting :refer [define-multi-setting-impl]]))
 
-(define-multi-setting-impl google-auth-auto-create-accounts-domain :ee
+(define-multi-setting-impl google.i/google-auth-auto-create-accounts-domain :ee
   :getter (fn [] (setting/get-string :google-auth-auto-create-accounts-domain))
   :setter (fn [domain] (setting/set-string! :google-auth-auto-create-accounts-domain domain)))

--- a/enterprise/backend/src/metabase_enterprise/enhancements/integrations/google.clj
+++ b/enterprise/backend/src/metabase_enterprise/enhancements/integrations/google.clj
@@ -1,0 +1,10 @@
+(ns metabase.integrations.google
+  (:require [metabase.models.setting.multi-setting :refer [define-multi-setting-impl]]))
+
+; (define-multi-setting-impl google-auth-auto-create-accounts-domain :ee)
+; (define-multi-setting-impl google-auth-auto-create-accounts-domain :ee
+;   :setter (fn [domain]
+;               (when (str/includes? domain ",")
+;                 ;; Multiple comma-separated domains is EE-only feature
+;                 (throw (ex-info (tru "Invalid domain") {:status-code 400})))
+;               (setting/set-string! :google-auth-auto-create-accounts-domain domain)))

--- a/enterprise/backend/test/metabase_enterprise/enhancements/integrations/google_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/enhancements/integrations/google_test.clj
@@ -1,0 +1,17 @@
+(ns metabase-enterprise.enhancements.integrations.google-test
+  (:require [clojure.test :refer :all]
+            [metabase.integrations.google :as google]
+            [metabase.models.user :as user :refer [User]]
+            [metabase.public-settings.metastore :as metastore]
+            [metabase.test :as mt]))
+
+(deftest google-auth-create-new-user!-test
+  (with-redefs [metastore/enable-sso? (constantly true)]
+    (testing "should support multiple domains (#5218)"
+      (mt/with-temporary-setting-values [google-auth-auto-create-accounts-domain "metabase.com,example.com"]
+        (mt/with-model-cleanup [User]
+          (let [user (#'google/google-auth-create-new-user! {:first_name "Cam"
+                                                             :last_name  "Era"
+                                                             :email      "camera@metabase.com"})]
+            (is (= {:first_name "Cam", :last_name "Era", :email "camera@metabase.com"}
+                   (select-keys user [:first_name :last_name :email])))))))))

--- a/enterprise/frontend/src/metabase-enterprise/auth/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/auth/index.js
@@ -16,6 +16,7 @@ import AuthenticationOption from "metabase/admin/settings/components/widgets/Aut
 import GroupMappingsWidget from "metabase/admin/settings/components/widgets/GroupMappingsWidget";
 import SecretKeyWidget from "metabase/admin/settings/components/widgets/SecretKeyWidget";
 
+import SettingsGoogleForm from "metabase/admin/settings/components/SettingsGoogleForm";
 import SettingsSAMLForm from "./components/SettingsSAMLForm";
 import SettingsJWTForm from "./components/SettingsJWTForm";
 
@@ -284,3 +285,27 @@ PLUGIN_ADMIN_SETTINGS_UPDATES.push(sections =>
     },
   ]),
 );
+
+PLUGIN_ADMIN_SETTINGS_UPDATES.push(sections => ({
+  ...sections,
+  "authentication/google": {
+    component: SettingsGoogleForm,
+    sidebar: false,
+    settings: [
+      {
+        key: "google-auth-client-id",
+      },
+      {
+        // Default to OSS fields if enterprise SSO is not enabled
+        ...sections["authentication/google"].settings.find(
+          setting => setting.key === "google-auth-auto-create-accounts-domain",
+        ),
+        ...(hasPremiumFeature("sso") && {
+          placeholder: "mycompany.com, example.com.br, otherdomain.co.uk",
+          description:
+            "Allow users to sign up on their own if their Google account email address is from one of the domains you specify here:",
+        }),
+      },
+    ],
+  },
+}));

--- a/src/metabase/config.clj
+++ b/src/metabase/config.clj
@@ -6,6 +6,14 @@
   (:import clojure.lang.Keyword
            java.util.UUID))
 
+;; this existed long before 0.39.0, but that's when it was made public
+(def ^{:doc "Indicates whether Enterprise Edition extensions are available" :added "0.39.0"} ee-available?
+  (try
+    (classloader/require 'metabase-enterprise.core)
+    true
+    (catch Throwable _
+      false)))
+
 (def ^Boolean is-windows?
   "Are we running on a Windows machine?"
   (str/includes? (str/lower-case (System/getProperty "os.name")) "win"))

--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -21,14 +21,6 @@
             [metabase.util.i18n :refer [deferred-trs trs]]
             [toucan.db :as db]))
 
-;; this existed long before 0.39.0, but that's when it was made public
-(def ^{:doc "Indicates whether Enterprise Edition extensions are available" :added "0.39.0"} ee-available?
-  (try
-    (classloader/require 'metabase-enterprise.core)
-    true
-    (catch Throwable _
-      false)))
-
 ;; don't i18n this, it's legalese
 (log/info
  (format "\nMetabase %s" config/mb-version-string)
@@ -36,7 +28,7 @@
  (format "\n\nCopyright © %d Metabase, Inc." (.getYear (java.time.LocalDate/now)))
 
  (str "\n\n"
-      (if ee-available?
+      (if config/ee-available?
         (str (deferred-trs "Metabase Enterprise Edition extensions are PRESENT.")
              "\n\n"
              (deferred-trs "Usage of Metabase Enterprise Edition features are subject to the Metabase Commercial License.")

--- a/src/metabase/integrations/google.clj
+++ b/src/metabase/integrations/google.clj
@@ -28,7 +28,7 @@
 (define-multi-setting-impl google-auth-auto-create-accounts-domain :oss
   :getter (fn [] (setting/get-string :google-auth-auto-create-accounts-domain))
   :setter (fn [domain]
-              (when (str/includes? domain ",")
+              (when (and domain (str/includes? domain ","))
                 ;; Multiple comma-separated domains is EE-only feature
                 (throw (ex-info (tru "Invalid domain") {:status-code 400})))
               (setting/set-string! :google-auth-auto-create-accounts-domain domain)))

--- a/src/metabase/integrations/google/interface.clj
+++ b/src/metabase/integrations/google/interface.clj
@@ -1,0 +1,8 @@
+(ns metabase.integrations.google.interface
+  (:require [metabase.models.setting.multi-setting :refer [define-multi-setting]]
+            [metabase.public-settings.metastore :as metastore]
+            [metabase.util.i18n :refer [deferred-tru]]))
+
+(define-multi-setting google-auth-auto-create-accounts-domain
+  (deferred-tru "When set, allow users to sign up on their own if their Google account email address is from this domain.")
+  (fn [] (if (metastore/enable-sso?) :ee :oss)))

--- a/src/metabase/integrations/google/interface.clj
+++ b/src/metabase/integrations/google/interface.clj
@@ -1,6 +1,5 @@
 (ns metabase.integrations.google.interface
-  (:require [metabase.config :as config]
-            [metabase.models.setting.multi-setting :refer [define-multi-setting]]
+  (:require [metabase.models.setting.multi-setting :refer [define-multi-setting]]
             [metabase.public-settings.metastore :as metastore]
             [metabase.util.i18n :refer [deferred-tru]]))
 

--- a/src/metabase/integrations/google/interface.clj
+++ b/src/metabase/integrations/google/interface.clj
@@ -1,5 +1,6 @@
 (ns metabase.integrations.google.interface
-  (:require [metabase.models.setting.multi-setting :refer [define-multi-setting]]
+  (:require [metabase.config :as config]
+            [metabase.models.setting.multi-setting :refer [define-multi-setting]]
             [metabase.public-settings.metastore :as metastore]
             [metabase.util.i18n :refer [deferred-tru]]))
 

--- a/src/metabase/models/setting/multi_setting.clj
+++ b/src/metabase/models/setting/multi_setting.clj
@@ -63,7 +63,7 @@
 
   See `define-multi-setting` for more details."
   [setting-symbol dispatch-value & {:keys [getter setter]}]
-  (let [setting-key    (keyword setting-symbol)
+  (let [setting-key    (keyword (name setting-symbol))
         dispatch-value (keyword dispatch-value)]
     `(do
        ~(when getter

--- a/src/metabase/public_settings/metastore.clj
+++ b/src/metabase/public_settings/metastore.clj
@@ -154,35 +154,35 @@
   :type       :boolean
   :visibility :public
   :setter     :none
-  :getter     (fn [] (boolean ((token-features) "embedding"))))
+  :getter     (fn [] (and config/ee-available? (boolean ((token-features) "embedding")))))
 
 (defsetting enable-whitelabeling?
   "Should we allow full whitelabel embedding (reskinning the entire interface?)"
   :type       :boolean
   :visibility :public
   :setter     :none
-  :getter     (fn [] (boolean ((token-features) "whitelabel"))))
+  :getter     (fn [] (and config/ee-available? (boolean ((token-features) "whitelabel")))))
 
 (defsetting enable-audit-app?
   "Should we allow use of the audit app?"
   :type       :boolean
   :visibility :public
   :setter     :none
-  :getter     (fn [] (boolean ((token-features) "audit-app"))))
+  :getter     (fn [] (and config/ee-available? (boolean ((token-features) "audit-app")))))
 
 (defsetting enable-sandboxes?
   "Should we enable data sandboxes (row and column-level permissions?"
   :type       :boolean
   :visibility :public
   :setter     :none
-  :getter     (fn [] (boolean ((token-features) "sandboxes"))))
+  :getter     (fn [] (and config/ee-available? (boolean ((token-features) "sandboxes")))))
 
 (defsetting enable-sso?
   "Should we enable SAML/JWT sign-in?"
   :type       :boolean
   :visibility :public
   :setter     :none
-  :getter     (fn [] (boolean ((token-features) "sso"))))
+  :getter     (fn [] (and config/ee-available? (boolean ((token-features) "sso")))))
 
 ;; `enhancements` are not currently a specific "feature" that EE tokens can have or not have. Instead, it's a
 ;; catch-all term for various bits of EE functionality that we assume all EE licenses include. (This may change in the
@@ -195,4 +195,4 @@
   :type       :boolean
   :visibility :public
   :setter     :none
-  :getter     (fn [] (boolean (seq (token-features)))))
+  :getter     (fn [] (and config/ee-available? (boolean (seq (token-features))))))

--- a/src/metabase/public_settings/metastore.clj
+++ b/src/metabase/public_settings/metastore.clj
@@ -154,7 +154,7 @@
   :type       :boolean
   :visibility :public
   :setter     :none
-  :getter     (fn [] (and config/ee-available? (boolean ((token-features) "embedding")))))
+  :getter     (fn [] (boolean ((token-features) "embedding"))))
 
 (defsetting enable-whitelabeling?
   "Should we allow full whitelabel embedding (reskinning the entire interface?)"

--- a/src/metabase/task/upgrade_checks.clj
+++ b/src/metabase/task/upgrade_checks.clj
@@ -8,13 +8,12 @@
             [clojurewerkz.quartzite.triggers :as triggers]
             [java-time :as t]
             [metabase.config :as config]
-            [metabase.core :as mbc]
             [metabase.public-settings :as public-settings]
             [metabase.task :as task]
             [metabase.util.i18n :refer [trs]]))
 
 (defn- get-version-info []
-  (let [version-info-url-key  (if mbc/ee-available? :mb-version-info-ee-url :mb-version-info-url)
+  (let [version-info-url-key  (if config/ee-available? :mb-version-info-ee-url :mb-version-info-url)
         version-info-url      (config/config-str version-info-url-key)
         {:keys [status body]} (http/get version-info-url {:content-type "application/json"})]
     (when (not= status 200)

--- a/test/metabase/integrations/google_test.clj
+++ b/test/metabase/integrations/google_test.clj
@@ -9,7 +9,6 @@
             [schema.core :as s]
             [toucan.db :as db]))
 
-;;; tests for email->domain
 (deftest email->domain-test
   (are [domain email] (is (= domain
                              (#'google/email->domain email))
@@ -18,7 +17,6 @@
     "metabase.co.uk" "cam@metabase.co.uk"
     "metabase.com"   "cam.saul+1@metabase.com"))
 
-;;; tests for email-in-domain?
 (deftest email-in-domain-test
   (are [in-domain? email domain] (is (= in-domain?
                                         (#'google/email-in-domain? email domain))
@@ -27,7 +25,6 @@
     false "cam.saul+1@metabase.co.uk" "metabase.com"
     true  "cam.saul+1@metabase.com"   "metabase.com"))
 
-;;; tests for autocreate-user-allowed-for-email?
 (deftest allow-autocreation-test
   (with-redefs [metastore/enable-sso? (constantly false)]
     (mt/with-temporary-setting-values [google-auth-auto-create-accounts-domain "metabase.com"]
@@ -36,6 +33,13 @@
                                 (format "Can we autocreate an account for email '%s'?" email))
         true  "cam@metabase.com"
         false "cam@expa.com"))))
+
+(deftest google-auth-auto-create-accounts-domain-test
+  (testing "multiple domains cannot be set if EE SSO is not enabled"
+    (with-redefs [metastore/enable-sso? (constantly false)]
+      (is (thrown?
+           clojure.lang.ExceptionInfo
+           (google/google-auth-auto-create-accounts-domain "metabase.com, example.com"))))))
 
 (deftest google-auth-create-new-user!-test
   (with-redefs [metastore/enable-sso? (constantly false)]

--- a/test/metabase/integrations/google_test.clj
+++ b/test/metabase/integrations/google_test.clj
@@ -125,7 +125,7 @@
                           "Cam" "Saul" "cam@sf-toucannery.com")))))))
 
     (testing "test that a user that doesn't exist with a *different* domain than the auto-create accounts domain gets an exception"
-      (mt/with-temporary-setting-values [google-auth-auto-create-accounts-domain "metabase.com"
+      (mt/with-temporary-setting-values [google-auth-auto-create-accounts-domain nil
                                          admin-email                             "rasta@toucans.com"]
         (is (thrown?
              clojure.lang.ExceptionInfo

--- a/test/metabase/integrations/google_test.clj
+++ b/test/metabase/integrations/google_test.clj
@@ -45,7 +45,7 @@
              clojure.lang.ExceptionInfo
              (#'google/google-auth-create-new-user! {:first_name "Rasta"
                                                      :last_name  "Toucan"
-                                                     :email      "rasta@metabase.com"}))))
+                                                     :email      "rasta@metabase.com"})))))
 
       (testing "should totally work if the email domains match up"
         (et/with-fake-inbox
@@ -58,7 +58,7 @@
                 (is (= {:first_name "Rasta", :last_name "Toucan", :email "rasta@sf-toucannery.com"}
                        (select-keys user [:first_name :last_name :email]))))
               (finally
-                (db/delete! User :email "rasta@sf-toucannery.com")))))))))
+                (db/delete! User :email "rasta@sf-toucannery.com"))))))))
 
 
 ;;; --------------------------------------------- google-auth-token-info ---------------------------------------------

--- a/test/metabase/integrations/google_test.clj
+++ b/test/metabase/integrations/google_test.clj
@@ -3,6 +3,7 @@
             [clojure.test :refer :all]
             [metabase.email-test :as et]
             [metabase.integrations.google :as google]
+            [metabase.integrations.google.interface :as google.i]
             [metabase.models.user :refer [User]]
             [metabase.public-settings.metastore :as metastore]
             [metabase.test :as mt]
@@ -39,7 +40,7 @@
     (with-redefs [metastore/enable-sso? (constantly false)]
       (is (thrown?
            clojure.lang.ExceptionInfo
-           (google/google-auth-auto-create-accounts-domain "metabase.com, example.com"))))))
+           (google.i/google-auth-auto-create-accounts-domain "metabase.com, example.com"))))))
 
 (deftest google-auth-create-new-user!-test
   (with-redefs [metastore/enable-sso? (constantly false)]

--- a/test/metabase/integrations/google_test.clj
+++ b/test/metabase/integrations/google_test.clj
@@ -1,10 +1,10 @@
 (ns metabase.integrations.google-test
-  (:require
-            [clj-http.client :as http]
+  (:require [clj-http.client :as http]
             [clojure.test :refer :all]
             [metabase.email-test :as et]
             [metabase.integrations.google :as google]
             [metabase.models.user :refer [User]]
+            [metabase.public-settings.metastore :as metastore]
             [metabase.test :as mt]
             [schema.core :as s]
             [toucan.db :as db]))
@@ -29,34 +29,36 @@
 
 ;;; tests for autocreate-user-allowed-for-email?
 (deftest allow-autocreation-test
-  (mt/with-temporary-setting-values [google-auth-auto-create-accounts-domain "metabase.com"]
-    (are [allowed? email] (is (= allowed?
-                                 (#'google/autocreate-user-allowed-for-email? email))
-                              (format "Can we autocreate an account for email '%s'?" email))
-      true  "cam@metabase.com"
-      false "cam@expa.com")))
+  (with-redefs [metastore/enable-sso? (constantly false)]
+    (mt/with-temporary-setting-values [google-auth-auto-create-accounts-domain "metabase.com"]
+      (are [allowed? email] (is (= allowed?
+                                   (#'google/autocreate-user-allowed-for-email? email))
+                                (format "Can we autocreate an account for email '%s'?" email))
+        true  "cam@metabase.com"
+        false "cam@expa.com"))))
 
 (deftest google-auth-create-new-user!-test
-  (testing "shouldn't be allowed to create a new user via Google Auth if their email doesn't match the auto-create accounts domain"
-    (mt/with-temporary-setting-values [google-auth-auto-create-accounts-domain "sf-toucannery.com"]
-      (is (thrown?
-           clojure.lang.ExceptionInfo
-           (#'google/google-auth-create-new-user! {:first_name "Rasta"
-                                                        :last_name  "Toucan"
-                                                        :email      "rasta@metabase.com"})))))
+  (with-redefs [metastore/enable-sso? (constantly false)]
+    (testing "shouldn't be allowed to create a new user via Google Auth if their email doesn't match the auto-create accounts domain"
+      (mt/with-temporary-setting-values [google-auth-auto-create-accounts-domain "sf-toucannery.com"]
+        (is (thrown?
+             clojure.lang.ExceptionInfo
+             (#'google/google-auth-create-new-user! {:first_name "Rasta"
+                                                     :last_name  "Toucan"
+                                                     :email      "rasta@metabase.com"}))))
 
-  (testing "should totally work if the email domains match up"
-    (et/with-fake-inbox
-      (mt/with-temporary-setting-values [google-auth-auto-create-accounts-domain "sf-toucannery.com"
-                                         admin-email                             "rasta@toucans.com"]
-        (try
-          (let [user (#'google/google-auth-create-new-user! {:first_name "Rasta"
-                                                                  :last_name  "Toucan"
-                                                                  :email      "rasta@sf-toucannery.com"})]
-            (is (= {:first_name "Rasta", :last_name "Toucan", :email "rasta@sf-toucannery.com"}
-                   (select-keys user [:first_name :last_name :email]))))
-          (finally
-            (db/delete! User :email "rasta@sf-toucannery.com")))))))
+      (testing "should totally work if the email domains match up"
+        (et/with-fake-inbox
+          (mt/with-temporary-setting-values [google-auth-auto-create-accounts-domain "sf-toucannery.com"
+                                             admin-email                             "rasta@toucans.com"]
+            (try
+              (let [user (#'google/google-auth-create-new-user! {:first_name "Rasta"
+                                                                 :last_name  "Toucan"
+                                                                 :email      "rasta@sf-toucannery.com"})]
+                (is (= {:first_name "Rasta", :last_name "Toucan", :email "rasta@sf-toucannery.com"}
+                       (select-keys user [:first_name :last_name :email]))))
+              (finally
+                (db/delete! User :email "rasta@sf-toucannery.com")))))))))
 
 
 ;;; --------------------------------------------- google-auth-token-info ---------------------------------------------
@@ -113,29 +115,30 @@
 ;;; --------------------------------------- google-auth-fetch-or-create-user! ----------------------------------------
 
 (deftest google-auth-fetch-or-create-user!-test
-  (testing "test that an existing user can log in with Google auth even if the auto-create accounts domain is different from"
-    (mt/with-temp User [user {:email "cam@sf-toucannery.com"}]
-      (mt/with-temporary-setting-values [google-auth-auto-create-accounts-domain "metabase.com"]
-        (testing "their account should return a UserInstance"
-          (is (schema= metabase.models.user.UserInstance
-                       (#'google/google-auth-fetch-or-create-user!
-                        "Cam" "Saul" "cam@sf-toucannery.com")))))))
+  (with-redefs [metastore/enable-sso? (constantly false)]
+    (testing "test that an existing user can log in with Google auth even if the auto-create accounts domain is different from"
+      (mt/with-temp User [user {:email "cam@sf-toucannery.com"}]
+        (mt/with-temporary-setting-values [google-auth-auto-create-accounts-domain "metabase.com"]
+          (testing "their account should return a UserInstance"
+            (is (schema= metabase.models.user.UserInstance
+                         (#'google/google-auth-fetch-or-create-user!
+                          "Cam" "Saul" "cam@sf-toucannery.com")))))))
 
-  (testing "test that a user that doesn't exist with a *different* domain than the auto-create accounts domain gets an exception"
-    (mt/with-temporary-setting-values [google-auth-auto-create-accounts-domain nil
-                                       admin-email                             "rasta@toucans.com"]
-      (is (thrown?
-           clojure.lang.ExceptionInfo
-           (#'google/google-auth-fetch-or-create-user!
-            "Rasta" "Can" "rasta@sf-toucannery.com")))))
-
-  (testing "test that a user that doesn't exist with the *same* domain as the auto-create accounts domain means a new user gets created"
-    (et/with-fake-inbox
-      (mt/with-temporary-setting-values [google-auth-auto-create-accounts-domain "sf-toucannery.com"
+    (testing "test that a user that doesn't exist with a *different* domain than the auto-create accounts domain gets an exception"
+      (mt/with-temporary-setting-values [google-auth-auto-create-accounts-domain "metabase.com"
                                          admin-email                             "rasta@toucans.com"]
-        (try
-          (is (schema= metabase.models.user.UserInstance
-                       (#'google/google-auth-fetch-or-create-user!
-                        "Rasta" "Toucan" "rasta@sf-toucannery.com")))
-          (finally
-            (db/delete! User :email "rasta@sf-toucannery.com")))))))
+        (is (thrown?
+             clojure.lang.ExceptionInfo
+             (#'google/google-auth-fetch-or-create-user!
+              "Rasta" "Can" "rasta@sf-toucannery.com")))))
+
+    (testing "test that a user that doesn't exist with the *same* domain as the auto-create accounts domain means a new user gets created"
+      (et/with-fake-inbox
+        (mt/with-temporary-setting-values [google-auth-auto-create-accounts-domain "sf-toucannery.com"
+                                           admin-email                             "rasta@toucans.com"]
+          (try
+            (is (schema= metabase.models.user.UserInstance
+                         (#'google/google-auth-fetch-or-create-user!
+                          "Rasta" "Toucan" "rasta@sf-toucannery.com")))
+            (finally
+              (db/delete! User :email "rasta@sf-toucannery.com"))))))))


### PR DESCRIPTION
This PR builds on the work in #15820 to add support for multiple email domains allowed for registration via Google sign-in, but makes this an EE-only feature. It's additionally restricted to only users with an SSO token but this could be changed later on to be available to all EE instances (c.f. #16526).

New UI (when enhanced SSO is enabled):
<img width="571" alt="image" src="https://user-images.githubusercontent.com/32746338/121631952-ed1ad180-ca34-11eb-9299-4a27f6177e1d.png">


I was trying to have a namespace `metabase.integrations.google.interface` that would contain the `define-multi-setting` call, but I couldn't get that working due to cyclic dependencies, so this is what I was able to get functional. I'm probably overlooking something so advice here would be appreciated.