### PR TITLE
Replace real TLDs with `.test` in frontend tests

### DIFF
--- a/frontend/test/__support__/e2e/cypress_data.js
+++ b/frontend/test/__support__/e2e/cypress_data.js
@@ -20,13 +20,13 @@ export const USERS = {
   admin: {
     first_name: "Bobby",
     last_name: "Tables",
-    email: "admin@metabase.com",
+    email: "admin@metabase.test",
     password: "12341234",
   },
   normal: {
     first_name: "Robert",
     last_name: "Tableton",
-    email: "normal@metabase.com",
+    email: "normal@metabase.test",
     password: "12341234",
     group_ids: [ALL_USERS_GROUP, COLLECTION_GROUP, DATA_GROUP],
   },
@@ -34,7 +34,7 @@ export const USERS = {
   nodata: {
     first_name: "No Data",
     last_name: "Tableton",
-    email: "nodata@metabase.com",
+    email: "nodata@metabase.test",
     password: "12341234",
     group_ids: [ALL_USERS_GROUP, COLLECTION_GROUP],
   },
@@ -52,7 +52,7 @@ export const USERS = {
   readonly: {
     first_name: "Read Only",
     last_name: "Tableton",
-    email: "readonly@metabase.com",
+    email: "readonly@metabase.test",
     password: "12341234",
     group_ids: [ALL_USERS_GROUP, READONLY_GROUP],
   },
@@ -60,14 +60,14 @@ export const USERS = {
   nocollection: {
     first_name: "No Collection",
     last_name: "Tableton",
-    email: "nocollection@metabase.com",
+    email: "nocollection@metabase.test",
     password: "12341234",
     group_ids: [ALL_USERS_GROUP, DATA_GROUP],
   },
   nosql: {
     first_name: "No SQL",
     last_name: "Tableton",
-    email: "nosql@metabase.com",
+    email: "nosql@metabase.test",
     password: "12341234",
     group_ids: [ALL_USERS_GROUP, NOSQL_GROUP],
   },
@@ -75,7 +75,7 @@ export const USERS = {
   none: {
     first_name: "None",
     last_name: "Tableton",
-    email: "none@metabase.com",
+    email: "none@metabase.test",
     password: "12341234",
     group_ids: [ALL_USERS_GROUP],
   },

--- a/frontend/test/metabase-smoketest/admin.cy.spec.js
+++ b/frontend/test/metabase-smoketest/admin.cy.spec.js
@@ -6,7 +6,7 @@ const { admin } = USERS;
 const new_user = {
   first_name: "Barb",
   last_name: "Tabley",
-  email: "new@metabase.com",
+  email: "new@metabase.test",
 };
 
 describe("metabase-smoketest > admin", () => {

--- a/frontend/test/metabase-smoketest/admin_setup.cy.spec.js
+++ b/frontend/test/metabase-smoketest/admin_setup.cy.spec.js
@@ -10,7 +10,7 @@ const { admin, normal, nocollection, nodata } = USERS;
 const new_user = {
   first_name: "Barb",
   last_name: "Tabley",
-  email: "new@metabase.com",
+  email: "new@metabase.test",
 };
 
 describe("smoketest > admin_setup", () => {
@@ -85,7 +85,6 @@ describe("smoketest > admin_setup", () => {
       cy.findByText("Slack").click();
 
       cy.findByText("Answers sent right to your Slack #channels");
-      cy.findByText("metabase@metabase.com").should("not.exist");
 
       cy.findByText("Create a Slack Bot User for MetaBot");
       cy.contains(

--- a/frontend/test/metabase-smoketest/admin_setup.cy.spec.js
+++ b/frontend/test/metabase-smoketest/admin_setup.cy.spec.js
@@ -929,40 +929,38 @@ describe("smoketest > admin_setup", () => {
       cy.findByText("Sorry, you don’t have permission to see that.");
     });
 
-    it("should deactivate a user admin and subsequently user should be unable to login", () => {
-      // Admin deactiviates user
+    it("user should not be able to login after admin deactivated them", () => {
+      const FULL_NAME = normal.first_name + " " + normal.last_name;
 
       cy.signOut();
       cy.signInAsAdmin();
-      cy.visit("/admin/settings/setup");
 
+      cy.visit("/admin/settings/setup");
       cy.findByText("People").click();
-      cy.icon("ellipsis")
-        .eq(-2)
-        .click();
+
+      openEllipsisMenuForUser(FULL_NAME);
       cy.findByText("Deactivate user").click();
 
-      cy.findByText("Robert Tableton won't be able to log in anymore.");
-
-      cy.findByText("Deactivate").click();
-
-      cy.findByText(normal.first_name + " " + normal.last_name).should(
-        "not.exist",
-      );
-      cy.findByText(new_user.first_name + " " + new_user.last_name);
+      cy.findByText(`${FULL_NAME} won't be able to log in anymore.`);
+      cy.button("Deactivate").click();
+      cy.findByText(FULL_NAME).should("not.exist");
 
       // User tries to log in
-
       cy.signOut();
       cy.visit("/");
       cy.findByLabelText("Email address").type(normal.email);
       cy.findByLabelText("Password").type(normal.password);
-      cy.findByText("Sign in").click();
+      cy.button("Sign in").click();
 
-      cy.contains(normal.first_name).should("not.exist");
-      cy.findByText("Our Analytics").should("not.exist");
       cy.findByText("Failed");
-      cy.contains("Password : did not match stored password");
+      cy.contains("Password: did not match stored password");
     });
   });
 });
+
+function openEllipsisMenuForUser(user) {
+  cy.findByText(user)
+    .closest("tr")
+    .find(".Icon-ellipsis")
+    .click();
+}

--- a/frontend/test/metabase/lib/formatting.unit.spec.js
+++ b/frontend/test/metabase/lib/formatting.unit.spec.js
@@ -226,19 +226,19 @@ describe("formatting", () => {
     it("should return a component for email addresses in jsx + rich mode", () => {
       expect(
         isElementOfType(
-          formatValue("tom@metabase.com", { jsx: true, rich: true }),
+          formatValue("tom@metabase.test", { jsx: true, rich: true }),
           ExternalLink,
         ),
       ).toEqual(true);
     });
     it("should not add mailto prefix if there's a different semantic type", () => {
       expect(
-        formatValue("foobar@example.com", {
+        formatValue("foobar@example.test", {
           jsx: true,
           rich: true,
           column: { semantic_type: "type/PK" },
         }),
-      ).toEqual("foobar@example.com");
+      ).toEqual("foobar@example.test");
     });
     it("should display hour-of-day with 12 hour clock", () => {
       expect(
@@ -287,7 +287,7 @@ describe("formatting", () => {
       ).toEqual(true);
       expect(
         isElementOfType(
-          formatUrl("mailto:tom@metabase.com", { jsx: true, rich: true }),
+          formatUrl("mailto:tom@metabase.test", { jsx: true, rich: true }),
           ExternalLink,
         ),
       ).toEqual(true);

--- a/frontend/test/metabase/scenarios/admin/people/people.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/people/people.cy.spec.js
@@ -17,7 +17,7 @@ describe("scenarios > admin > people", () => {
   const TEST_USER = {
     first_name: "Testy",
     last_name: "McTestface",
-    email: `testy${Math.round(Math.random() * 100000)}@metabase.com`,
+    email: `testy${Math.round(Math.random() * 100000)}@metabase.test`,
     password: "12341234",
   };
 

--- a/frontend/test/metabase/scenarios/admin/settings/email.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/email.cy.spec.js
@@ -29,7 +29,7 @@ describe("scenarios > admin > settings > email settings", () => {
   it("should show an error if test email fails", () => {
     // Reuse Email setup without relying on the previous test
     cy.request("PUT", "/api/setting", {
-      "email-from-address": "admin@metabase.com",
+      "email-from-address": "admin@metabase.test",
       "email-smtp-host": "localhost",
       "email-smtp-password": null,
       "email-smtp-port": "1234",

--- a/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
@@ -97,18 +97,13 @@ describe("scenarios > admin > settings", () => {
       .type("abc", { delay: 50 })
       .clear()
       .click()
-      .type("other.email@metabase.com")
+      .type("other.email@metabase.test")
       .blur();
     cy.wait("@saveSettings");
 
     cy.visit("/admin/settings/general");
     // after we refreshed, the field should still be "other.email"
-    emailInput().should("have.value", "other.email@metabase.com");
-
-    // reset the email
-    cy.request("PUT", "/api/setting/admin-email", {
-      value: "bob@metabase.com",
-    });
+    emailInput().should("have.value", "other.email@metabase.test");
   });
 
   it("should check for working https before enabling a redirect", () => {

--- a/frontend/test/metabase/scenarios/admin/settings/whitelabel.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/whitelabel.cy.spec.js
@@ -152,7 +152,7 @@ describeWithToken("formatting > whitelabel", () => {
         `rgb(${colors.primary.rgb.join(", ")})`,
       );
 
-      cy.findByLabelText("Email address").type("some@email.com");
+      cy.findByLabelText("Email address").type("some@email.test");
       cy.findByLabelText("Password").type("1234");
       cy.get(".Button--primary").should(
         "have.css",

--- a/frontend/test/metabase/scenarios/onboarding/setup/setup.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/setup/setup.cy.spec.js
@@ -44,7 +44,7 @@ describe("scenarios > setup", () => {
 
       cy.findByLabelText("First name").type("Testy");
       cy.findByLabelText("Last name").type("McTestface");
-      cy.findByLabelText("Email").type("testy@metabase.com");
+      cy.findByLabelText("Email").type("testy@metabase.test");
       cy.findByLabelText("Your company or team name").type("Epic Team");
 
       // test first with a weak password
@@ -92,7 +92,7 @@ describe("scenarios > setup", () => {
 
       // test that you can return to user settings if you want
       cy.findByText("Hi, Testy. Nice to meet you!").click();
-      cy.findByLabelText("Email").should("have.value", "testy@metabase.com");
+      cy.findByLabelText("Email").should("have.value", "testy@metabase.test");
 
       // now back to database setting
       cy.findByText("Next").click();

--- a/frontend/test/metabase/scenarios/onboarding/setup/user_settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/setup/user_settings.cy.spec.js
@@ -4,7 +4,7 @@ import { USERS } from "__support__/e2e/cypress_data";
 const { first_name, last_name, email } = USERS.normal;
 
 const CURRENT_USER = {
-  email: "normal@metabase.com",
+  email: "normal@metabase.test",
   ldap_auth: false,
   first_name: "Robert",
   locale: null,

--- a/frontend/test/metabase/visualizations/components/LineAreaBarChart.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/LineAreaBarChart.unit.spec.js
@@ -27,7 +27,7 @@ const millisecondCard = {
       },
     ],
     creator: {
-      email: "atte@metabase.com",
+      email: "atte@metabase.test",
       first_name: "Atte",
       last_login: "2017-07-21T17:51:23.181Z",
       is_qbnewb: false,
@@ -157,7 +157,7 @@ const dateTimeCard = {
       },
     ],
     creator: {
-      email: "atte@metabase.com",
+      email: "atte@metabase.test",
       first_name: "Atte",
       last_login: "2017-07-21T17:51:23.181Z",
       is_qbnewb: false,
@@ -334,7 +334,7 @@ const numberCard = {
       },
     ],
     creator: {
-      email: "atte@metabase.com",
+      email: "atte@metabase.test",
       first_name: "Atte",
       last_login: "2017-07-21T17:51:23.181Z",
       is_qbnewb: false,


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- Replaces real TLDs with the reserved TLD `.test` for e2e and unit tests.
- Closes #16310

### How to verify this works?
- All tests should pass in CI
- Please, also make sure smoke tests are passing by running
`yarn test-cypress-no-build --folder frontend/test/metabase-smoketest/`

### What can be done additionally in a follow up PR?
- Use reserved `.example` tld for documentation
- Use reserved `.test` tld for backend tests and for fixtures