### PR TITLE
Add tooltip to question share icon

### DIFF
--- a/frontend/src/metabase/query_builder/containers/QuestionEmbedWidget.jsx
+++ b/frontend/src/metabase/query_builder/containers/QuestionEmbedWidget.jsx
@@ -2,6 +2,8 @@
 import React, { Component } from "react";
 import { connect } from "react-redux";
 
+import { t } from "ttag";
+
 import Icon from "metabase/components/Icon";
 
 import EmbedModalContent from "metabase/public/components/widgets/EmbedModalContent";
@@ -85,6 +87,7 @@ export function QuestionEmbedWidgetTrigger({
   return (
     <Icon
       name="share"
+      tooltip={t`Sharing`}
       className="mx1 hide sm-show text-brand-hover cursor-pointer"
       onClick={() => {
         MetabaseAnalytics.trackEvent(

--- a/frontend/test/metabase/scenarios/question/new.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/new.cy.spec.js
@@ -75,7 +75,7 @@ describe("scenarios > question > new", () => {
     cy.get(".Visualization .bar").should("have.length", 6);
   });
 
-  it.skip("should display a tooltip for CTA icons on an individual question (metabase#16108)", () => {
+  it("should display a tooltip for CTA icons on an individual question (metabase#16108)", () => {
     openOrdersTable();
     cy.icon("download").realHover();
     cy.findByText("Download full results");


### PR DESCRIPTION
Fixes #16108 

## How to Test

1. Settings › Admin › Public Sharing, or http://localhost:3000/admin/settings/public_sharing
2. Enable sharing
3. Exit admin
4. Ask a question
5. Simple Question
6. Sample Dataset
7. Orders

Hovering on bottom-right icon should now show a tooltip saying "Sharing".

<img src="https://user-images.githubusercontent.com/380816/121724529-5eeb2d80-cabe-11eb-8dbf-34b6e6cc768d.png" width=400 />

### Notes

1. Shouldn't this say "Share"? Aware that other icons like this say "Sharing" as well, but shouldn't they all say "Share"?
2. Implementation file touched in this PR has propType eslint disabler. Making a separate PR to add propTypes.
