### PR TITLE
Fix Popover proptypes

### DIFF
--- a/frontend/src/metabase/components/Popover.jsx
+++ b/frontend/src/metabase/components/Popover.jsx
@@ -31,7 +31,6 @@ export default class Popover extends Component {
     isOpen: PropTypes.bool,
     hasArrow: PropTypes.bool,
     hasBackground: PropTypes.bool,
-    // target: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
     tetherOptions: PropTypes.object,
     // used to prevent popovers from being taller than the screen
     sizeToFit: PropTypes.bool,
@@ -58,10 +57,10 @@ export default class Popover extends Component {
     onClose: PropTypes.func,
     className: PropTypes.string,
     style: PropTypes.object,
-    children: PropTypes.element,
+    children: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
     dismissOnClickOutside: PropTypes.func,
     dismissOnEscape: PropTypes.func,
-    target: PropTypes.object,
+    target: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
     targetEvent: PropTypes.object,
   };
 


### PR DESCRIPTION
Corrects two propTypes that generated warnings in question page.

## How to Test

Have browser console tab open.

1. Ask a question
2. Simple Question
3. Sample Dataset
4. Orders

You should not see any console warning about `propTypes` and `Popover`.