### PR TITLE
Fix typo in lint-config

### DIFF
--- a/lint-config.edn
+++ b/lint-config.edn
@@ -1,9 +1,9 @@
 ^:replace
-{:linters {:missing-else-branch         {:level :warn}
-           :misplaced-docstring         {:level :warn}
-           :missing-body-in-when        {:level :warn}
-           :missing-docstring           {:level :warn}
-           :refer-all                   {:level   :warn
-                                         :exclude [clojure.test]}
-           :unsorted-required-namespace {:level :warn}
-           :use                         {:level :warn}}}
+{:linters {:missing-else-branch          {:level :warn}
+           :misplaced-docstring          {:level :warn}
+           :missing-body-in-when         {:level :warn}
+           :missing-docstring            {:level :warn}
+           :refer-all                    {:level   :warn
+                                          :exclude [clojure.test]}
+           :unsorted-required-namespaces {:level :warn}
+           :use                          {:level :warn}}}


### PR DESCRIPTION
It's actually `:unsorted-required-namespaces`: 
https://cljdoc.org/d/clj-kondo/clj-kondo/2020.07.29/doc/configuration#enable-optional-linters

Discovered this while setting up local linting for my editor :)