### PR TITLE
refetch card on qb/RELOAD_CARD action

### DIFF
--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -721,19 +721,21 @@ export const setParameterValue = createAction(
   },
 );
 
-// reloadCard
 export const RELOAD_CARD = "metabase/qb/RELOAD_CARD";
 export const reloadCard = createThunkAction(RELOAD_CARD, () => {
   return async (dispatch, getState) => {
-    // clone
-    const card = Utils.copy(getOriginalCard(getState()));
-
+    const outdatedCard = getState().qb.card;
+    const card = await loadCard(outdatedCard.id);
     dispatch(loadMetadataForCard(card));
 
-    // we do this to force the indication of the fact that the card should not be considered dirty when the url is updated
     dispatch(
-      runQuestionQuery({ overrideWithCard: card, shouldUpdateUrl: false }),
+      runQuestionQuery({
+        overrideWithCard: card,
+        shouldUpdateUrl: false,
+      }),
     );
+
+    // if the name of the card changed this will update the url slug
     dispatch(updateUrl(card, { dirty: false }));
 
     return card;

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -36,7 +36,6 @@ import {
   getCard,
   getQuestion,
   getOriginalQuestion,
-  getOriginalCard,
   getIsEditing,
   getTransformedSeries,
   getRawSeries,
@@ -64,6 +63,7 @@ import { getCardAfterVisualizationClick } from "metabase/visualizations/lib/util
 import { getPersistableDefaultSettingsForSeries } from "metabase/visualizations/lib/settings/visualization";
 
 import Databases from "metabase/entities/databases";
+import Questions from "metabase/entities/questions";
 import Snippets from "metabase/entities/snippets";
 
 import { getMetadata } from "metabase/selectors/metadata";
@@ -725,7 +725,11 @@ export const RELOAD_CARD = "metabase/qb/RELOAD_CARD";
 export const reloadCard = createThunkAction(RELOAD_CARD, () => {
   return async (dispatch, getState) => {
     const outdatedCard = getState().qb.card;
-    const card = await loadCard(outdatedCard.id);
+    const action = await dispatch(
+      Questions.actions.fetch({ id: outdatedCard.id }, { reload: true }),
+    );
+    const card = Questions.HACK_getObjectFromAction(action);
+
     dispatch(loadMetadataForCard(card));
 
     dispatch(

--- a/frontend/test/metabase/scenarios/native/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/native.cy.spec.js
@@ -297,7 +297,7 @@ describe("scenarios > question > native", () => {
     });
   });
 
-  it.skip("should correctly display a revision state after a restore (metabase#12581)", () => {
+  it("should correctly display a revision state after a restore (metabase#12581)", () => {
     const ORIGINAL_QUERY = "SELECT * FROM ORDERS WHERE {{filter}} LIMIT 2";
 
     // Start with the original version of the question made with API
@@ -342,7 +342,7 @@ describe("scenarios > question > native", () => {
     cy.findByText(/Open Editor/i).click();
 
     cy.log("Reported failing on v0.35.3");
-    cy.findByText(ORIGINAL_QUERY);
+    cy.get(".ace_content").contains(ORIGINAL_QUERY);
     // Filter dropdown field
     cy.get("fieldset").contains("Filter");
   });


### PR DESCRIPTION
Fixes #12581 

The `RELOAD_CARD` action is currently only used when reverting cards to a prior version, so the logic within the action is incorrect in that it does not re-GET the card before triggering a re-run of the card's query.

There is a `loadCard` function used within the `query_builder/actions` file already, but I am choosing to use the Question entity so that the entity cache is updated. This fixes an issue where adding a card that has been reverted to a dashboard will show the previous version of the card in the dashboard until reload.


https://user-images.githubusercontent.com/13057258/121942849-cba43900-cd05-11eb-8d9b-9a76b71f3a5f.mov

