### PR TITLE
fix click behavior on pie charts

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/PieChart.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart.jsx
@@ -383,7 +383,7 @@ export default class PieChart extends Component {
 
     const getSliceClickObject = index => {
       const slice = slices[index];
-      const sliceRows = slice.rowIndex && rows[slice.rowIndex];
+      const sliceRows = slice.rowIndex != null && rows[slice.rowIndex];
       const data =
         sliceRows &&
         sliceRows.map((value, index) => ({
@@ -439,6 +439,7 @@ export default class PieChart extends Component {
           </div>
           <div className={cx(styles.Chart, "layout-centered")}>
             <svg
+              data-testid="pie-chart"
               className={cx(styles.Donut, "m1")}
               viewBox="0 0 100 100"
               style={{ maxWidth: MAX_PIE_SIZE, maxHeight: MAX_PIE_SIZE }}

--- a/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
@@ -414,7 +414,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
     cy.findByText("Showing 85 rows");
   });
 
-  it.skip("should parse value on click through on the first row of pie chart (metabase#15250)", () => {
+  it("should parse value on click through on the first row of pie chart (metabase#15250)", () => {
     cy.createQuestion({
       name: "15250",
       query: {
@@ -456,7 +456,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
       });
     });
 
-    cy.get("[class*=PieChart__Donut]")
+    cy.findByTestId("pie-chart")
       .find("path")
       .first()
       .as("doohickeyChart")


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/15250

Please check the original issue for repro steps. The reason is an incorrect implicit boolean conversion of `0` — that is why it did not work only for the first row.