### PR TITLE
hide snippets folders from the collections sidebar

### DIFF
--- a/frontend/test/metabase/scenarios/native/snippets/snippet-permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/snippets/snippet-permissions.cy.spec.js
@@ -158,7 +158,7 @@ describeWithToken("scenarios > question > snippets", () => {
     cy.findByText("snippet 1");
   });
 
-  it.skip("should not display snippet folder as part of collections (metabase#14907)", () => {
+  it("should not display snippet folder as part of collections (metabase#14907)", () => {
     cy.server();
     cy.route("GET", "/api/collection/root").as("collections");
 

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -71,12 +71,15 @@
                              {:name     \"F\"
                               :children [{:name \"G\"}]}]}]}
      {:name \"H\"}]"
-  []
+  [namespace]
+  {namespace (s/maybe su/NonBlankString)}
   (collection/collections->tree
    (db/select Collection
-     {:where (collection/visible-collection-ids->honeysql-filter-clause
-              :id
-              (collection/permissions-set->visible-collection-ids @api/*current-user-permissions-set*))})))
+     {:where [:and
+              [:= :namespace namespace]
+              (collection/visible-collection-ids->honeysql-filter-clause
+               :id
+               (collection/permissions-set->visible-collection-ids @api/*current-user-permissions-set*))]})))
 
 
 ;;; --------------------------------- Fetching a single Collection & its 'children' ----------------------------------
@@ -343,8 +346,8 @@
   (into []
         (comp cat (map select-name) (distinct))
         (for [model [:card :dashboard :snippet :pulse :collection]]
-          (:select (collection-children-query model {:id 1 :location "/"} nil))))
-  )
+          (:select (collection-children-query model {:id 1 :location "/"} nil)))))
+
 
 (defn- collection-children*
   [collection models {:keys [sort-info] :as options}]


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/14907

Make sure you run EE version since creating folders for snippets is not available in the OSS edition. Please check the repro steps in the issue.

`/api/collection` endpoint returns folders without a namespace by default. However, it can be specified like `/api/collection?namespace=snippets`.
I added the same `namespace` parameter to the `/api/collection/tree` endpoint.