### PR TITLE
Remove unused code from auth/selectors

### DIFF
--- a/frontend/src/metabase/auth/selectors.js
+++ b/frontend/src/metabase/auth/selectors.js
@@ -6,7 +6,3 @@ export function getAuthProviders(state, props) {
     [],
   );
 }
-
-export const getLoginError = state => state.auth && state.auth.loginError;
-export const getResetError = state => state.auth && state.auth.resetError;
-export const getResetSuccess = state => state.auth && state.auth.resetSuccess;


### PR DESCRIPTION
Currently investigating https://github.com/metabase/metabase/issues/16122.

Tried every which way to find code that uses these functions.

Seems like they are not used, auth code is not straightforward, could use our pruning dead stuff.

## How to Test

Log in, log out, create invalid email/password combinations, reset your password.
Everything should still work.