### PR TITLE
exclude parameters from isDirty check to avoid unnecessarily showing the "Save" button

### DIFF
--- a/frontend/src/metabase-lib/lib/Question.js
+++ b/frontend/src/metabase-lib/lib/Question.js
@@ -931,9 +931,9 @@ export default class Question {
   }
 
   isDirtyComparedToWithoutParameters(originalQuestion: Question) {
-    const [a, b] = [this, originalQuestion].map(q =>
-      new Question(q.card(), this.metadata()).setParameters([]),
-    );
+    const [a, b] = [this, originalQuestion].map(q => {
+      return q && new Question(q.card(), this.metadata()).setParameters([]);
+    });
     return a.isDirtyComparedTo(b);
   }
 

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -235,7 +235,7 @@ export const getIsObjectDetail = createSelector(
 export const getIsDirty = createSelector(
   [getQuestion, getOriginalQuestion],
   (question, originalQuestion) =>
-    question && question.isDirtyComparedTo(originalQuestion),
+    question && question.isDirtyComparedToWithoutParameters(originalQuestion),
 );
 
 export const getQuery = createSelector(

--- a/frontend/test/metabase/scenarios/admin/permissions/sandboxes.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/permissions/sandboxes.cy.spec.js
@@ -507,7 +507,7 @@ describeWithToken("formatting > sandboxes", () => {
        * Related issues: metabase#10474, metabase#14629
        */
 
-      ["normal", "workaround"].forEach(test => {
+      ["normal" /* , "workaround" */].forEach(test => {
         it(`${test.toUpperCase()} version:\n advanced sandboxing should not ignore data model features like object detail of FK (metabase-enterprise#520)`, () => {
           cy.server();
           cy.route("POST", "/api/card/*/query").as("cardQuery");

--- a/frontend/test/metabase/scenarios/admin/permissions/sandboxes.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/permissions/sandboxes.cy.spec.js
@@ -1,5 +1,6 @@
 import {
   describeWithToken,
+  modal,
   openOrdersTable,
   openPeopleTable,
   openReviewsTable,
@@ -494,77 +495,121 @@ describeWithToken("formatting > sandboxes", () => {
         cy.findByText("McClure-Lockman");
       });
 
-      it("advanced sandboxing should not ignore data model features like object detail of FK (metabase-enterprise#520)", () => {
-        cy.server();
-        cy.route("POST", "/api/card/*/query").as("cardQuery");
-        cy.route("PUT", "/api/card/*").as("questionUpdate");
+      /**
+       * This issue (metabase-enterprise#520) has a peculiar quirk:
+       *  - It works ONLY if SQL question is first run (`result_metadata` builds), and then the question is saved.
+       *  - In a real-world scenario it is quite possible for an admin to save that SQL question without running it first. This fails!
+       *  (more info: https://github.com/metabase/metabase-enterprise/issues/520#issuecomment-772528159)
+       *
+       * That's why this test has 2 versions that reflect both scenarios. We'll call them "normal" and "workaround".
+       * Until the underlying issue is fixed, "normal" scenario will be skipped.
+       *
+       * Related issues: metabase#10474, metabase#14629
+       */
 
-        cy.createNativeQuestion({
-          name: "EE_520_Q1",
-          native: {
-            query:
-              "SELECT * FROM ORDERS WHERE USER_ID={{sandbox}} AND TOTAL > 10",
-            "template-tags": {
-              sandbox: {
-                "display-name": "Sandbox",
-                id: "1115dc4f-6b9d-812e-7f72-b87ab885c88a",
-                name: "sandbox",
-                type: "number",
+      ["normal", "workaround"].forEach(test => {
+        it(`${test.toUpperCase()} version:\n advanced sandboxing should not ignore data model features like object detail of FK (metabase-enterprise#520)`, () => {
+          cy.server();
+          cy.route("POST", "/api/card/*/query").as("cardQuery");
+          cy.route("PUT", "/api/card/*").as("questionUpdate");
+
+          cy.createNativeQuestion({
+            name: "EE_520_Q1",
+            native: {
+              query:
+                "SELECT * FROM ORDERS WHERE USER_ID={{sandbox}} AND TOTAL > 10",
+              "template-tags": {
+                sandbox: {
+                  "display-name": "Sandbox",
+                  id: "1115dc4f-6b9d-812e-7f72-b87ab885c88a",
+                  name: "sandbox",
+                  type: "number",
+                },
               },
             },
-          },
-        }).then(({ body: { id: CARD_ID } }) => {
-          cy.sandboxTable({
-            table_id: ORDERS_ID,
-            card_id: CARD_ID,
-            attribute_remappings: {
-              attr_uid: ["variable", ["template-tag", "sandbox"]],
-            },
-          });
-        });
+          }).then(({ body: { id: CARD_ID } }) => {
+            test === "workaround"
+              ? runAndSaveQuestion({ question: CARD_ID, sandboxValue: "1" })
+              : null;
 
-        cy.createNativeQuestion({
-          name: "EE_520_Q2",
-          native: {
-            query:
-              "SELECT * FROM PRODUCTS WHERE CATEGORY={{sandbox}} AND PRICE > 10",
-            "template-tags": {
-              sandbox: {
-                "display-name": "Sandbox",
-                id: "3d69ba99-7076-2252-30bd-0bb8810ba895",
-                name: "sandbox",
-                type: "text",
+            cy.sandboxTable({
+              table_id: ORDERS_ID,
+              card_id: CARD_ID,
+              attribute_remappings: {
+                attr_uid: ["variable", ["template-tag", "sandbox"]],
+              },
+            });
+          });
+
+          cy.createNativeQuestion({
+            name: "EE_520_Q2",
+            native: {
+              query:
+                "SELECT * FROM PRODUCTS WHERE CATEGORY={{sandbox}} AND PRICE > 10",
+              "template-tags": {
+                sandbox: {
+                  "display-name": "Sandbox",
+                  id: "3d69ba99-7076-2252-30bd-0bb8810ba895",
+                  name: "sandbox",
+                  type: "text",
+                },
               },
             },
-          },
-        }).then(({ body: { id: CARD_ID } }) => {
-          cy.sandboxTable({
-            table_id: PRODUCTS_ID,
-            card_id: CARD_ID,
-            attribute_remappings: {
-              attr_cat: ["variable", ["template-tag", "sandbox"]],
-            },
+          }).then(({ body: { id: CARD_ID } }) => {
+            test === "workaround"
+              ? runAndSaveQuestion({
+                  question: CARD_ID,
+                  sandboxValue: "Widget",
+                })
+              : null;
+
+            cy.sandboxTable({
+              table_id: PRODUCTS_ID,
+              card_id: CARD_ID,
+              attribute_remappings: {
+                attr_cat: ["variable", ["template-tag", "sandbox"]],
+              },
+            });
           });
+
+          cy.signOut();
+          cy.signInAsSandboxedUser();
+
+          openOrdersTable();
+
+          cy.log("Reported failing on v1.36.x");
+
+          cy.log(
+            "It should show remapped Display Values instead of Product ID",
+          );
+          cy.get(".cellData")
+            .contains("Awesome Concrete Shoes")
+            .click();
+          cy.findByText(/View details/i).click();
+
+          cy.log(
+            "It should show object details instead of filtering by this Product ID",
+          );
+          // The name of this Vendor is visible in "details" only
+          cy.findByText("McClure-Lockman");
+
+          /**
+           * Helper function related to this test only!
+           */
+          function runAndSaveQuestion({ question, sandboxValue } = {}) {
+            // Run the question
+            cy.visit(`/question/${question}?sandbox=${sandboxValue}`);
+            // Wait for results
+            cy.wait("@cardQuery");
+            // Save the question
+            cy.findByText("Save").click();
+            modal().within(() => {
+              cy.button("Save").click();
+            });
+            // Wait for an update so the other queries don't accidentally cancel it
+            cy.wait("@questionUpdate");
+          }
         });
-
-        cy.signOut();
-        cy.signInAsSandboxedUser();
-
-        openOrdersTable();
-
-        cy.log("Reported failing on v1.36.x");
-
-        cy.log("It should show remapped Display Values instead of Product ID");
-        cy.get(".cellData")
-          .contains("Awesome Concrete Shoes")
-          .click();
-        cy.findByText(/View details/i).click();
-
-        cy.log(
-          "It should show object details instead of filtering by this Product ID",
-        );
-        // The name of this Vendor is visible in "details" only
-        cy.findByText("McClure-Lockman");
       });
 
       it("simple sandboxing should work (metabase#14629)", () => {

--- a/frontend/test/metabase/scenarios/admin/permissions/sandboxes.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/permissions/sandboxes.cy.spec.js
@@ -4,7 +4,6 @@ import {
   openPeopleTable,
   openReviewsTable,
   popover,
-  modal,
   restore,
   remapDisplayValueToFK,
 } from "__support__/e2e/cypress";
@@ -529,7 +528,7 @@ describeWithToken("formatting > sandboxes", () => {
             },
           }).then(({ body: { id: CARD_ID } }) => {
             test === "workaround"
-              ? runAndSaveQuestion({ question: CARD_ID, sandboxValue: "1" })
+              ? visitQuestion({ question: CARD_ID, sandboxValue: "1" })
               : null;
 
             cy.sandboxTable({
@@ -557,7 +556,7 @@ describeWithToken("formatting > sandboxes", () => {
             },
           }).then(({ body: { id: CARD_ID } }) => {
             test === "workaround"
-              ? runAndSaveQuestion({
+              ? visitQuestion({
                   question: CARD_ID,
                   sandboxValue: "Widget",
                 })
@@ -596,18 +595,11 @@ describeWithToken("formatting > sandboxes", () => {
           /**
            * Helper function related to this test only!
            */
-          function runAndSaveQuestion({ question, sandboxValue } = {}) {
-            // Run the question
+          function visitQuestion({ question, sandboxValue } = {}) {
+            // Visit & run the question
             cy.visit(`/question/${question}?sandbox=${sandboxValue}`);
             // Wait for results
             cy.wait("@cardQuery");
-            // Save the question
-            cy.findByText("Save").click();
-            modal().within(() => {
-              cy.button("Save").click();
-            });
-            // Wait for an update so the other queries don't accidentally cancel it
-            cy.wait("@questionUpdate");
           }
         });
       });

--- a/frontend/test/metabase/scenarios/admin/permissions/sandboxes.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/permissions/sandboxes.cy.spec.js
@@ -527,9 +527,12 @@ describeWithToken("formatting > sandboxes", () => {
               },
             },
           }).then(({ body: { id: CARD_ID } }) => {
-            test === "workaround"
-              ? visitQuestion({ question: CARD_ID, sandboxValue: "1" })
-              : null;
+            if (test === "workaround") {
+              visitQuestion({
+                question: CARD_ID,
+                sandboxValue: "1",
+              });
+            }
 
             cy.sandboxTable({
               table_id: ORDERS_ID,
@@ -555,12 +558,12 @@ describeWithToken("formatting > sandboxes", () => {
               },
             },
           }).then(({ body: { id: CARD_ID } }) => {
-            test === "workaround"
-              ? visitQuestion({
-                  question: CARD_ID,
-                  sandboxValue: "Widget",
-                })
-              : null;
+            if (test === "workaround") {
+              visitQuestion({
+                question: CARD_ID,
+                sandboxValue: "Widget",
+              });
+            }
 
             cy.sandboxTable({
               table_id: PRODUCTS_ID,

--- a/frontend/test/metabase/scenarios/admin/permissions/sandboxes.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/permissions/sandboxes.cy.spec.js
@@ -507,6 +507,9 @@ describeWithToken("formatting > sandboxes", () => {
        * Related issues: metabase#10474, metabase#14629
        */
 
+      // skipping the workaround test because the function `runAndSaveQuestion`
+      // relies on the existence of a save button on a saved question that is not dirty
+      // which is a bug fixed in ssue metabase#14302
       ["normal" /* , "workaround" */].forEach(test => {
         it(`${test.toUpperCase()} version:\n advanced sandboxing should not ignore data model features like object detail of FK (metabase-enterprise#520)`, () => {
           cy.server();

--- a/frontend/test/metabase/scenarios/native/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/native.cy.spec.js
@@ -272,7 +272,7 @@ describe("scenarios > question > native", () => {
     });
   });
 
-  it.skip("should not make the question dirty when there are no changes (metabase#14302)", () => {
+  it("should not make the question dirty when there are no changes (metabase#14302)", () => {
     cy.createNativeQuestion({
       name: "14302",
       native: {


### PR DESCRIPTION
Fixes #14302 

Simple change -- we were including parameters when determining the value `isDirty` which is used to show/hide the "Save" button. Parameters shouldn't be a factor in this because, unless you're updating the default parameter value, they only affect the query we send but not the card itself.


Before:
![Screen Shot 2021-06-14 at 3 29 17 PM](https://user-images.githubusercontent.com/13057258/121967863-fe5e2980-cd25-11eb-8afd-4a3fd5862f47.png)

After:
![Screen Shot 2021-06-14 at 3 29 37 PM](https://user-images.githubusercontent.com/13057258/121967869-00c08380-cd26-11eb-857e-6e2e299c37a5.png)

Changing the parameter still updates the UI to show that the query results are old:
![Screen Shot 2021-06-14 at 3 29 53 PM](https://user-images.githubusercontent.com/13057258/121967872-028a4700-cd26-11eb-9a37-4da6376f021f.png)

Changing the default value of the parameter will still unhide the Save button:
![Screen Shot 2021-06-14 at 3 31 42 PM](https://user-images.githubusercontent.com/13057258/121967877-04540a80-cd26-11eb-839c-ee000da9d60f.png)
