### PR TITLE
Re-throw error in custom map form so that it appears on frontend

### DIFF
--- a/frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx
@@ -62,6 +62,7 @@ export default class CustomGeoJSONWidget extends Component {
       await this.props.reloadSettings();
     } catch (e) {
       console.warn("Save failed: ", e);
+      throw e;
     }
   };
 

--- a/frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx
@@ -339,7 +339,7 @@ const EditMap = ({
           </SettingContainer>
         </div>
       </div>
-      <div className="flex-full ml4 relative bordered rounded flex my4">
+      <div className="flex-auto ml4 relative bordered rounded flex my4">
         {geoJson || geoJsonLoading || geoJsonError ? (
           <LoadingAndErrorWrapper loading={geoJsonLoading} error={geoJsonError}>
             {() => (


### PR DESCRIPTION
We should re-throw the error in `_saveMap` so that it can be caught again in `_loadGeoJson`, stored in the component state, and displayed on the frontend. Otherwise an error is shown from the subsequent read, which is what causes (some of) the confusing error messages documented in #14635.

I've also changed the flex class so that the long error returned by the backend doesn't overflow the modal horizontally.

<img width="1086" alt="image" src="https://user-images.githubusercontent.com/32746338/121973683-ac6fd080-cd32-11eb-88fa-ee11de9db4ee.png">

The rest of #14635, specifically the issues on multi-instance environments, will require some larger backend refactor that I'll tackle in a subsequent PR.

I also think these errors would be better to display in red under the specific form fields, but that would be a bigger refactor (not for bugfix week).