### PR TITLE
Repros for #12782 and #4995: Problems with the labels when showing only one row in the results

### DIFF
--- a/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
@@ -370,7 +370,7 @@ describe("scenarios > visualizations > line chart", () => {
         .should("eq", "Created At");
       cy.get(".y-axis-label")
         .invoke("text")
-        .should("eq", "Average of price");
+        .should("eq", "Average of Price");
     });
   });
 });

--- a/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
@@ -338,6 +338,32 @@ describe("scenarios > visualizations > line chart", () => {
         .and("contain", RENAMED_SECOND_SERIES);
     }
   });
+
+  describe.skip("problems with the labels when showing only one row in the results (metabase#12782, metabase#4995)", () => {
+    beforeEach(() => {
+      visitQuestionAdhoc({
+        dataset_query: {
+          database: 1,
+          query: {
+            "source-table": PRODUCTS_ID,
+            aggregation: [["avg", ["field", PRODUCTS.PRICE, null]]],
+            breakout: [
+              ["field", PRODUCTS.CREATED_AT, { "temporal-unit": "year" }],
+              ["field", PRODUCTS.CATEGORY, null],
+            ],
+            filter: ["=", ["field", PRODUCTS.CATEGORY, null], "Doohickey"],
+          },
+          type: "query",
+        },
+        display: "line",
+      });
+      cy.findByText("Category is Doohickey");
+    });
+
+    it("should not drop the chart legend (metabase#4995)", () => {
+      cy.get(".LegendItem").should("contain", "Doohickey");
+    });
+  });
 });
 
 function testPairedTooltipValues(val1, val2) {

--- a/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
@@ -363,6 +363,15 @@ describe("scenarios > visualizations > line chart", () => {
     it("should not drop the chart legend (metabase#4995)", () => {
       cy.get(".LegendItem").should("contain", "Doohickey");
     });
+
+    it("should display correct axis labels (metabase#12782)", () => {
+      cy.get(".x-axis-label")
+        .invoke("text")
+        .should("eq", "Created At");
+      cy.get(".y-axis-label")
+        .invoke("text")
+        .should("eq", "Average of price");
+    });
   });
 });
 


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #12782
- Reproduces #4995

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js`
- Replace `describe.skip()` with `describe.only()` to run tests in isolation
- Both tests should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure both tests are passing and
- Merge the unskipped describe block together with the fix

### Screenshots:
Dropped legend
![image](https://user-images.githubusercontent.com/31325167/122052755-5197b100-cde6-11eb-98a1-0e36c22cf0b7.png)

Wrong Y-axis label
![image](https://user-images.githubusercontent.com/31325167/122052799-61af9080-cde6-11eb-84fb-c04a4431836b.png)

