### PR TITLE
Fix can't share dashboard containing only text cards

### DIFF
--- a/frontend/src/metabase/components/Triggerable.jsx
+++ b/frontend/src/metabase/components/Triggerable.jsx
@@ -149,6 +149,7 @@ export default ComposedComponent =>
               "cursor-default": this.props.disabled,
             },
           )}
+          aria-disabled={this.props.disabled}
           style={triggerStyle}
         >
           {triggerElement}

--- a/frontend/src/metabase/dashboard/components/DashboardActions.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardActions.jsx
@@ -37,7 +37,8 @@ export const getDashboardActions = (
 
   const buttons = [];
 
-  const canShareDashboard = dashboard.ordered_cards.length > 0;
+  const isLoaded = !!dashboard;
+  const canShareDashboard = isLoaded && dashboard.ordered_cards.length > 0;
 
   if (!isEditing && !isEmpty && !isPublic) {
     const extraButtonClassNames =

--- a/frontend/src/metabase/dashboard/components/DashboardActions.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardActions.jsx
@@ -38,67 +38,115 @@ export const getDashboardActions = (
   const buttons = [];
 
   const isLoaded = !!dashboard;
-  const canShareDashboard = isLoaded && dashboard.ordered_cards.length > 0;
+  const hasCards = isLoaded && dashboard.ordered_cards.length > 0;
+
+  // dashcardData only contains question cards, text ones don't appear here
+  const hasDataCards =
+    hasCards &&
+    dashboard.ordered_cards.some(dashCard => dashCard.card.display !== "text");
+
+  const canShareDashboard = hasCards;
+
+  // Getting notifications with static text-only cards doesn't make a lot of sense
+  const canSubscribeToDashboard = hasDataCards;
 
   if (!isEditing && !isEmpty && !isPublic) {
     const extraButtonClassNames =
       "bg-brand-hover text-white-hover py2 px3 text-bold block cursor-pointer";
 
-    buttons.push(
-      <PopoverWithTrigger
-        ref="popover"
-        disabled={!canShareDashboard}
-        triggerElement={
-          <Tooltip
-            tooltip={
-              canShareDashboard
-                ? t`Sharing`
-                : t`Add data to share this dashboard`
-            }
-          >
-            <DashboardHeaderButton>
-              <Icon
-                name="share"
-                className={cx({
-                  "text-brand-hover": canShareDashboard,
-                  "text-light": !canShareDashboard,
-                })}
-              />
-            </DashboardHeaderButton>
-          </Tooltip>
-        }
-      >
-        <div className="py1">
-          <div>
-            <a
-              className={extraButtonClassNames}
-              data-metabase-event={"Dashboard;Subscriptions"}
-              onClick={() => {
-                self.refs.popover.close();
-                onSharingClick();
-              }}
-            >
-              {t`Dashboard subscriptions`}
-            </a>
-          </div>
-          <div>
-            <DashboardSharingEmbeddingModal
-              additionalClickActions={() => self.refs.popover.close()}
-              dashboard={dashboard}
-              enabled={
-                !isEditing &&
-                !isFullscreen &&
-                ((isPublicLinksEnabled && (isAdmin || dashboard.public_uuid)) ||
-                  (isEmbeddingEnabled && isAdmin))
+    if (canSubscribeToDashboard) {
+      buttons.push(
+        <PopoverWithTrigger
+          ref="popover"
+          disabled={!canShareDashboard}
+          triggerElement={
+            <Tooltip
+              tooltip={
+                canShareDashboard
+                  ? t`Sharing`
+                  : t`Add data to share this dashboard`
               }
-              linkClassNames={extraButtonClassNames}
-              linkText={t`Sharing and embedding`}
-              key="dashboard-embed"
-            />
+            >
+              <DashboardHeaderButton>
+                <Icon
+                  name="share"
+                  className={cx({
+                    "text-brand-hover": canShareDashboard,
+                    "text-light": !canShareDashboard,
+                  })}
+                />
+              </DashboardHeaderButton>
+            </Tooltip>
+          }
+        >
+          <div className="py1">
+            <div>
+              <a
+                className={extraButtonClassNames}
+                data-metabase-event={"Dashboard;Subscriptions"}
+                onClick={() => {
+                  self.refs.popover.close();
+                  onSharingClick();
+                }}
+              >
+                {t`Dashboard subscriptions`}
+              </a>
+            </div>
+            <div>
+              <DashboardSharingEmbeddingModal
+                additionalClickActions={() => self.refs.popover.close()}
+                dashboard={dashboard}
+                enabled={
+                  !isEditing &&
+                  !isFullscreen &&
+                  ((isPublicLinksEnabled &&
+                    (isAdmin || dashboard.public_uuid)) ||
+                    (isEmbeddingEnabled && isAdmin))
+                }
+                linkClassNames={extraButtonClassNames}
+                linkText={t`Sharing and embedding`}
+                key="dashboard-embed"
+              />
+            </div>
           </div>
-        </div>
-      </PopoverWithTrigger>,
-    );
+        </PopoverWithTrigger>,
+      );
+    } else {
+      buttons.push(
+        <DashboardSharingEmbeddingModal
+          key="dashboard-embed"
+          additionalClickActions={() => self.refs.popover.close()}
+          dashboard={dashboard}
+          enabled={
+            !isEditing &&
+            !isFullscreen &&
+            ((isPublicLinksEnabled && (isAdmin || dashboard.public_uuid)) ||
+              (isEmbeddingEnabled && isAdmin))
+          }
+          isLinkEnabled={canShareDashboard}
+          linkText={
+            <Tooltip
+              isLinkEnabled={canShareDashboard}
+              tooltip={
+                canShareDashboard
+                  ? t`Sharing`
+                  : t`Add data to share this dashboard`
+              }
+            >
+              <DashboardHeaderButton>
+                <Icon
+                  name="share"
+                  className={cx({
+                    "text-brand-hover": canShareDashboard,
+                    "text-light": !canShareDashboard,
+                  })}
+                />
+              </DashboardHeaderButton>
+            </Tooltip>
+          }
+        />,
+      );
+    }
   }
 
   if (!isEditing && !isEmpty) {

--- a/frontend/src/metabase/dashboard/components/DashboardActions.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardActions.jsx
@@ -30,8 +30,6 @@ export const getDashboardActions = (
     setRefreshElapsedHook,
     onRefreshPeriodChange,
     onSharingClick,
-    onEmbeddingClick,
-    dashcardData,
   },
 ) => {
   const isPublicLinksEnabled = MetabaseSettings.get("enable-public-sharing");
@@ -39,10 +37,7 @@ export const getDashboardActions = (
 
   const buttons = [];
 
-  /* we consider the dashboard to be shareable if there is at least one card with data in it on the dashboard
-    markdown cards don't appear in dashcardData so we check to see if there is at least one value
-  */
-  const canShareDashboard = Object.keys(dashcardData).length > 0;
+  const canShareDashboard = dashboard.ordered_cards.length > 0;
 
   if (!isEditing && !isEmpty && !isPublic) {
     const extraButtonClassNames =

--- a/frontend/src/metabase/dashboard/containers/DashboardSharingEmbeddingModal.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardSharingEmbeddingModal.jsx
@@ -17,6 +17,10 @@ import {
   updateEmbeddingParams,
 } from "../dashboard";
 
+const defaultProps = {
+  isLinkEnabled: true,
+};
+
 const mapDispatchToProps = {
   createPublicLink,
   deletePublicLink,
@@ -24,11 +28,7 @@ const mapDispatchToProps = {
   updateEmbeddingParams,
 };
 
-@connect(
-  null,
-  mapDispatchToProps,
-)
-export default class DashboardSharingEmbeddingModal extends Component {
+class DashboardSharingEmbeddingModal extends Component {
   _modal: ?ModalWithTrigger;
 
   render() {
@@ -41,6 +41,7 @@ export default class DashboardSharingEmbeddingModal extends Component {
       enabled,
       linkClassNames,
       linkText,
+      isLinkEnabled,
       updateEnableEmbedding,
       updateEmbeddingParams,
       ...props
@@ -52,15 +53,19 @@ export default class DashboardSharingEmbeddingModal extends Component {
       <ModalWithTrigger
         ref={m => (this._modal = m)}
         full
+        disabled={!isLinkEnabled}
         triggerElement={
           <a
             className={linkClassNames}
+            aria-disabled={!isLinkEnabled}
             onClick={() => {
-              MetabaseAnalytics.trackEvent(
-                "Sharing / Embedding",
-                "dashboard",
-                "Sharing Link Clicked",
-              );
+              if (isLinkEnabled) {
+                MetabaseAnalytics.trackEvent(
+                  "Sharing / Embedding",
+                  "dashboard",
+                  "Sharing Link Clicked",
+                );
+              }
             }}
           >
             {linkText}
@@ -93,3 +98,10 @@ export default class DashboardSharingEmbeddingModal extends Component {
     );
   }
 }
+
+DashboardSharingEmbeddingModal.defaultProps = defaultProps;
+
+export default connect(
+  null,
+  mapDispatchToProps,
+)(DashboardSharingEmbeddingModal);

--- a/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
@@ -14,18 +14,6 @@ describe("scenarios > dashboard > subscriptions", () => {
     cy.signInAsAdmin();
   });
 
-  it("should not allow creation if there are no dashboard cards", () => {
-    cy.createDashboard("Empty Dashboard").then(
-      ({ body: { id: DASHBOARD_ID } }) => {
-        cy.visit(`/dashboard/${DASHBOARD_ID}`);
-      },
-    );
-    // It would be great if we can use either aria-attributes or better class naming to suggest when icons are disabled
-    cy.icon("share")
-      .closest("a")
-      .should("have.class", "cursor-default");
-  });
-
   it("should not allow sharing if there are no dashboard cards", () => {
     cy.createDashboard("15077D").then(({ body: { id: DASHBOARD_ID } }) => {
       cy.visit(`/dashboard/${DASHBOARD_ID}`);

--- a/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
@@ -22,7 +22,7 @@ describe("scenarios > dashboard > subscriptions", () => {
 
     cy.icon("share")
       .closest("a")
-      .should("have.class", "cursor-default");
+      .should("have.attr", "aria-disabled", "true");
   });
 
   it("should allow sharing if dashboard contains only text cards (metabase#15077)", () => {

--- a/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
@@ -26,6 +26,17 @@ describe("scenarios > dashboard > subscriptions", () => {
       .should("have.class", "cursor-default");
   });
 
+  it("should not allow sharing if there are no dashboard cards", () => {
+    cy.createDashboard("15077D").then(({ body: { id: DASHBOARD_ID } }) => {
+      cy.visit(`/dashboard/${DASHBOARD_ID}`);
+    });
+    cy.findByText("This dashboard is looking empty.");
+
+    cy.icon("share")
+      .closest("a")
+      .should("have.class", "cursor-default");
+  });
+
   it.skip("should allow sharing if dashboard contains only text cards (metabase#15077)", () => {
     cy.createDashboard("15077D").then(({ body: { id: DASHBOARD_ID } }) => {
       cy.visit(`/dashboard/${DASHBOARD_ID}`);

--- a/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
@@ -37,7 +37,7 @@ describe("scenarios > dashboard > subscriptions", () => {
       .should("have.class", "cursor-default");
   });
 
-  it.skip("should allow sharing if dashboard contains only text cards (metabase#15077)", () => {
+  it("should allow sharing if dashboard contains only text cards (metabase#15077)", () => {
     cy.createDashboard("15077D").then(({ body: { id: DASHBOARD_ID } }) => {
       cy.visit(`/dashboard/${DASHBOARD_ID}`);
     });
@@ -50,7 +50,6 @@ describe("scenarios > dashboard > subscriptions", () => {
     cy.findByText("You're editing this dashboard.").should("not.exist");
     cy.icon("share")
       .closest("a")
-      .should("have.class", "cursor-pointer")
       .click();
     cy.findByText("Dashboard subscriptions").click();
   });

--- a/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
@@ -22,7 +22,12 @@ describe("scenarios > dashboard > subscriptions", () => {
 
     cy.icon("share")
       .closest("a")
-      .should("have.attr", "aria-disabled", "true");
+      .should("have.attr", "aria-disabled", "true")
+      .click();
+
+    cy.findByText("Dashboard subscriptions").should("not.exist");
+    cy.findByText("Sharing and embedding").should("not.exist");
+    cy.findByText(/Share this dashboard with people *./i).should("not.exist");
   });
 
   it("should allow sharing if dashboard contains only text cards (metabase#15077)", () => {
@@ -39,7 +44,14 @@ describe("scenarios > dashboard > subscriptions", () => {
     cy.icon("share")
       .closest("a")
       .click();
-    cy.findByText("Dashboard subscriptions").click();
+
+    // Ensure clicking share icon opens sharing and embedding modal directly,
+    // without a menu with sharing and dashboard subscription options.
+    // Dashboard subscriptions are not shown because
+    // getting notifications with static text-only cards doesn't make a lot of sense
+    cy.findByText("Dashboard subscriptions").should("not.exist");
+    cy.findByText("Sharing and embedding").should("not.exist");
+    cy.findByText(/Share this dashboard with people *./i);
   });
 
   describe("with no channels set up", () => {


### PR DESCRIPTION
#14266 solved #14264 by disabling sharing of dashboards without data, but it disabled the ability to share markdown only cards. This PR allows sharing dashboard with text-cards only, and also adds an E2E test ensuring it won't be possible to share empty dashboard (no cards at all)

Fixes #15077

### To Verify

1. Create a new dashboard
2. Ensure sharing icon in the header is disabled
3. Click the pencil icon in the header
4. Click the `Aa` icon (add text box)
5. Fill in any text inside a new card, click "Save"
6. Ensure sharing icon is now enabled

### Demo

**Before**

<img width="776" alt="before" src="https://user-images.githubusercontent.com/17258145/122054607-814bb680-cdf0-11eb-8cfa-7fef1da0eb25.png">

**After**

<img width="776" alt="after" src="https://user-images.githubusercontent.com/17258145/122054613-827ce380-cdf0-11eb-8d07-322583a62bb2.png">