### PR TITLE
Cherry pick ExpressionEditorTextfield from release branch

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -265,7 +265,7 @@ export default class ExpressionEditorTextfield extends React.Component {
         displayError.push(compileError);
       }
     }
-    this.setState({ displayError });
+    this.setState({ displayError, helpText: null });
 
     // whenever our input blurs we push the updated expression to our parent if valid
     if (this.state.expression) {

--- a/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
@@ -624,7 +624,7 @@ describe("scenarios > question > custom columns", () => {
     cy.findByPlaceholderText("Enter a number").should("not.exist");
   });
 
-  it.skip("custom expression helper shouldn't be visible when formula field is not in focus (metabase#15891)", () => {
+  it("custom expression helper shouldn't be visible when formula field is not in focus (metabase#15891)", () => {
     openPeopleTable({ mode: "notebook" });
     cy.findByText("Custom column").click();
     popover().within(() => {


### PR DESCRIPTION
Cherry picks the ExpressionEditorTextfield changes (65e76a39fae592d0f574872e37fc21faf86f9a43) to avoid merge conflicts from `release` → `master`.