### PR TITLE
fix inability to use hidden columns for click behavior

### DIFF
--- a/frontend/src/metabase/visualizations/components/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive.jsx
@@ -14,6 +14,7 @@ import { memoize } from "metabase-lib/lib/utils";
 import {
   getTableCellClickedObject,
   getTableHeaderClickedObject,
+  getTableClickedObjectRowData,
   isColumnRightAligned,
 } from "metabase/visualizations/lib/table";
 import { getColumnExtent } from "metabase/visualizations/lib/utils";
@@ -339,6 +340,7 @@ export default class TableInteractive extends Component {
         rowIndex,
         columnIndex,
         this.props.isPivoted,
+        this.props.series,
       );
     } catch (e) {
       console.error(e);
@@ -347,18 +349,21 @@ export default class TableInteractive extends Component {
   // NOTE: all arguments must be passed to the memoized method, not taken from this.props etc
   @memoize
   _getCellClickedObjectCached(
-    data: DatasetData,
-    settings: VisualizationSettings,
-    rowIndex: number,
-    columnIndex: number,
-    isPivoted: boolean,
+    data,
+    settings,
+    rowIndex,
+    columnIndex,
+    isPivoted,
+    series,
   ) {
+    const clickedRowData = getTableClickedObjectRowData(series, rowIndex);
     return getTableCellClickedObject(
       data,
       settings,
       rowIndex,
       columnIndex,
       isPivoted,
+      clickedRowData,
     );
   }
 

--- a/frontend/src/metabase/visualizations/components/TableSimple.jsx
+++ b/frontend/src/metabase/visualizations/components/TableSimple.jsx
@@ -14,6 +14,7 @@ import ExternalLink from "metabase/components/ExternalLink";
 import { formatValue } from "metabase/lib/formatting";
 import {
   getTableCellClickedObject,
+  getTableClickedObjectRowData,
   isColumnRightAligned,
 } from "metabase/visualizations/lib/table";
 import { getColumnExtent } from "metabase/visualizations/lib/utils";
@@ -116,6 +117,7 @@ export default class TableSimple extends Component {
       settings,
       getColumnTitle,
       card,
+      series,
     } = this.props;
     const { rows, cols } = data;
     const limit = getIn(card, ["dataset_query", "query", "limit"]) || undefined;
@@ -203,6 +205,10 @@ export default class TableSimple extends Component {
                     data-testid="table-row"
                   >
                     {rows[rowIndex].map((value, columnIndex) => {
+                      const clickedRowData = getTableClickedObjectRowData(
+                        series,
+                        rowIndex,
+                      );
                       const column = cols[columnIndex];
                       const clicked = getTableCellClickedObject(
                         data,
@@ -210,6 +216,7 @@ export default class TableSimple extends Component {
                         rowIndex,
                         columnIndex,
                         isPivoted,
+                        clickedRowData,
                       );
                       const columnSettings = settings.column(column);
 

--- a/frontend/src/metabase/visualizations/lib/table.js
+++ b/frontend/src/metabase/visualizations/lib/table.js
@@ -1,21 +1,29 @@
 import type { DatasetData, Column } from "metabase-types/types/Dataset";
 import type { ClickObject } from "metabase-types/types/Visualization";
-import type { VisualizationSettings } from "metabase-types/types/Card";
 import { isNumber, isCoordinate } from "metabase/lib/schema_metadata";
 
+export function getTableClickedObjectRowData([series], rowIndex) {
+  const { rows, cols } = series.data;
+
+  return rows[rowIndex].map((value, index) => ({
+    value,
+    col: cols[index],
+  }));
+}
+
 export function getTableCellClickedObject(
-  data: DatasetData,
-  settings: VisualizationSettings,
-  rowIndex: number,
-  columnIndex: number,
-  isPivoted: boolean,
-): ClickObject {
+  data,
+  settings,
+  rowIndex,
+  columnIndex,
+  isPivoted,
+  clickedRowData,
+) {
   const { rows, cols } = data;
 
   const column = cols[columnIndex];
   const row = rows[rowIndex];
   const value = row[columnIndex];
-  const dataForClick = row.map((value, index) => ({ value, col: cols[index] }));
 
   if (isPivoted) {
     // if it's a pivot table, the first column is
@@ -27,7 +35,7 @@ export function getTableCellClickedObject(
         column,
         settings,
         dimensions: [row._dimension, column._dimension],
-        data: dataForClick,
+        data: clickedRowData,
       };
     }
   } else if (column.source === "aggregation") {
@@ -39,7 +47,7 @@ export function getTableCellClickedObject(
         .map((column, index) => ({ value: row[index], column }))
         .filter(dimension => dimension.column.source === "breakout"),
       origin: { rowIndex, row, cols },
-      data: dataForClick,
+      data: clickedRowData,
     };
   } else {
     return {
@@ -47,7 +55,7 @@ export function getTableCellClickedObject(
       column,
       settings,
       origin: { rowIndex, row, cols },
-      data: dataForClick,
+      data: clickedRowData,
     };
   }
 }

--- a/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
@@ -63,7 +63,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
     cy.location("pathname").should("eq", "/foo/111/param-value");
   });
 
-  it.skip("should insert values from hidden column on custom destination URL click through (metabase#13927)", () => {
+  it("should insert values from hidden column on custom destination URL click through (metabase#13927)", () => {
     cy.log("Create a question");
 
     createNativeQuestion(

--- a/frontend/test/metabase/visualizations/lib/table.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/table.unit.spec.js
@@ -1,5 +1,6 @@
 import {
   getTableCellClickedObject,
+  getTableClickedObjectRowData,
   isColumnRightAligned,
 } from "metabase/visualizations/lib/table";
 import { TYPE } from "metabase/lib/types";
@@ -15,7 +16,29 @@ const DIMENSION_COLUMN = {
 };
 
 describe("metabase/visualization/lib/table", () => {
+  describe("getTableClickedObjectRowData", () => {
+    it("should get row data from series", () => {
+      const series = [
+        {
+          data: {
+            rows: [[1, 2, 3]],
+            cols: [DIMENSION_COLUMN, METRIC_COLUMN, RAW_COLUMN],
+          },
+        },
+      ];
+      const rowIndex = 0;
+
+      expect(getTableClickedObjectRowData(series, rowIndex)).toEqual([
+        { col: { source: "breakout" }, value: 1 },
+        { col: { source: "aggregation" }, value: 2 },
+        { col: { source: "fields" }, value: 3 },
+      ]);
+    });
+  });
+
   describe("getTableCellClickedObject", () => {
+    const rowData = ["row data"];
+
     describe("normal table", () => {
       it("should work with a raw data cell", () => {
         expect(
@@ -25,6 +48,7 @@ describe("metabase/visualization/lib/table", () => {
             0,
             0,
             false,
+            rowData,
           ),
         ).toEqual({
           value: 0,
@@ -35,7 +59,7 @@ describe("metabase/visualization/lib/table", () => {
             row: [0],
             rowIndex: 0,
           },
-          data: [{ col: { source: "fields" }, value: 0 }],
+          data: rowData,
         });
       });
       it("should work with a dimension cell", () => {
@@ -46,6 +70,7 @@ describe("metabase/visualization/lib/table", () => {
             0,
             0,
             false,
+            rowData,
           ),
         ).toEqual({
           value: 1,
@@ -56,10 +81,7 @@ describe("metabase/visualization/lib/table", () => {
             rowIndex: 0,
           },
           settings: {},
-          data: [
-            { col: { source: "breakout" }, value: 1 },
-            { col: { source: "aggregation" }, value: 2 },
-          ],
+          data: rowData,
         });
       });
       it("should work with a metric cell", () => {
@@ -70,6 +92,7 @@ describe("metabase/visualization/lib/table", () => {
             0,
             1,
             false,
+            rowData,
           ),
         ).toEqual({
           value: 2,
@@ -86,10 +109,7 @@ describe("metabase/visualization/lib/table", () => {
             rowIndex: 0,
           },
           settings: {},
-          data: [
-            { col: { source: "breakout" }, value: 1 },
-            { col: { source: "aggregation" }, value: 2 },
-          ],
+          data: rowData,
         });
       });
     });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/13927

Check the original issue for repro steps.
Table components receive `data` prop with data only for visible columns. The full data can be received from the `series` prop. In this PR I get clicked row data from `series` instead of `data`.