### PR TITLE
Fix can't unarchive question without data access

### DIFF
--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -137,7 +137,6 @@ describe("collection permissions", () => {
 
               describe("archive", () => {
                 it("should be able to archive/unarchive question (metabase#15253)", () => {
-                  cy.skipOn(user === "nodata");
                   archiveUnarchive("Orders");
                 });
 

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -286,13 +286,6 @@
     (when (api/column-will-change? :dataset_query card-before-updates card-updates)
       (check-data-permissions-for-query (:dataset_query card-updates)))))
 
-(defn- check-allowed-to-unarchive
-  "When unarchiving a Card, make sure we have data permissions for the Card query before doing so."
-  [card-before-updates card-updates]
-  (when (and (api/column-will-change? :archived card-before-updates card-updates)
-             (:archived card-before-updates))
-    (check-data-permissions-for-query (:dataset_query card-before-updates))))
-
 (defn- check-allowed-to-change-embedding
   "You must be a superuser to change the value of `enable_embedding` or `embedding_params`. Embedding must be
   enabled."
@@ -458,7 +451,6 @@
     ;; Do various permissions checks
     (collection/check-allowed-to-change-collection card-before-update card-updates)
     (check-allowed-to-modify-query                 card-before-update card-updates)
-    (check-allowed-to-unarchive                    card-before-update card-updates)
     (check-allowed-to-change-embedding             card-before-update card-updates)
     ;; make sure we have the correct `result_metadata`
     (let [result-metadata-chan (result-metadata-for-updating-async

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -635,13 +635,21 @@
         (is (= false
                (set-archived! false)))))))
 
-(deftest we-shouldn-t-be-able-to-update-archived-status-if-we-don-t-have-collection--write--perms
+(deftest we-shouldn-t-be-able-to-archive-cards-if-we-don-t-have-collection--write--perms
   (mt/with-non-admin-groups-no-root-collection-perms
     (mt/with-temp* [Collection [collection]
                     Card       [card {:collection_id (u/the-id collection)}]]
       (perms/grant-collection-read-permissions! (perms-group/all-users) collection)
       (is (= "You don't have permissions to do that."
              (mt/user-http-request :rasta :put 403 (str "card/" (u/the-id card)) {:archived true}))))))
+
+(deftest we-shouldn-t-be-able-to-unarchive-cards-if-we-don-t-have-collection--write--perms
+  (mt/with-non-admin-groups-no-root-collection-perms
+    (mt/with-temp* [Collection [collection]
+                    Card       [card {:collection_id (u/the-id collection) :archived true}]]
+      (perms/grant-collection-read-permissions! (perms-group/all-users) collection)
+      (is (= "You don't have permissions to do that."
+              (mt/user-http-request :rasta :put 403 (str "card/" (u/the-id card)) {:archived false}))))))
 
 (deftest clear-description-test
   (testing "Can we clear the description of a Card? (#4738)"


### PR DESCRIPTION
Users with collection curate permissions and no data permissions can archive a question from any collection, but when they click on "Undo" they are greeted with "Sorry, you don’t have permission to see that." screen. Note that this doesn't happen for dashboards.

The fix is done purely on the backend. Looks pretty straightforward, but I can easily miss something as it's my first time opening a backend PR

Closes #15253

### To Verify

1. Log in as a non-admin user with collection curate access and no data permissions
2. Go to `/collection/root/` or to the user's personal collection
3. Click the ellipsis icon next to any question
4. Choose "Archive this item"
5. Notice bubble in the lower-left corner saying "Item archived - Undo"
6. Click "Undo"
7. The item has to return back to the list

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/122096323-1cf01d80-ce17-11eb-849e-44bf58a691fd.mov

**After**

https://user-images.githubusercontent.com/17258145/122096334-1eb9e100-ce17-11eb-9ef5-c52ffa0a8443.mov
