### PR TITLE
Show email/password login errors when SSO is active

### DIFF
--- a/frontend/src/metabase/app-main.js
+++ b/frontend/src/metabase/app-main.js
@@ -1,4 +1,5 @@
 import { push } from "react-router-redux";
+import _ from "underscore";
 
 import { init } from "metabase/app";
 import { getRoutes } from "metabase/routes";
@@ -29,7 +30,7 @@ init(reducers, getRoutes, store => {
     // is `/auth/login/password` instead of `/auth/login`.
     // So if call to api when signing in fails, let’s stay in the current page.
     // Otherwise it will always redirect us to the Google auth interaction.
-    if (url === "/api/session") {
+    if (_.contains(["/api/session", "/api/session/"], url)) {
       return;
     }
 

--- a/frontend/src/metabase/app-main.js
+++ b/frontend/src/metabase/app-main.js
@@ -25,10 +25,10 @@ init(reducers, getRoutes, store => {
       return;
     }
 
-    // If SSO is enabled, url for login with email and password
+    // If SSO is enabled, page url for login with email and password
     // is `/auth/login/password` instead of `/auth/login`.
-    // So if call to api when signing in fails, let’s stay in this url.
-    // Otherwise it will redirect us to the Google auth interaction.
+    // So if call to api when signing in fails, let’s stay in the current page.
+    // Otherwise it will always redirect us to the Google auth interaction.
     if (url === "/api/session") {
       return;
     }

--- a/frontend/src/metabase/app-main.js
+++ b/frontend/src/metabase/app-main.js
@@ -24,6 +24,15 @@ init(reducers, getRoutes, store => {
     if (url.indexOf("/api/user/current") >= 0) {
       return;
     }
+
+    // If SSO is enabled, url for login with email and password
+    // is `/auth/login/password` instead of `/auth/login`.
+    // So if call to api when signing in fails, let’s stay in this url.
+    // Otherwise it will redirect us to the Google auth interaction.
+    if (url === "/api/session") {
+      return;
+    }
+
     store.dispatch(clearCurrentUser());
     store.dispatch(push("/auth/login"));
   });

--- a/frontend/src/metabase/lib/validate.js
+++ b/frontend/src/metabase/lib/validate.js
@@ -14,6 +14,7 @@ export const validators = {
 
 function makeValidate(steps = []) {
   function validate(...args) {
+    console.log("🚀", { args, steps });
     return steps.reduce((error, step) => error || step(...args), false);
   }
   function all(...args) {

--- a/frontend/src/metabase/lib/validate.js
+++ b/frontend/src/metabase/lib/validate.js
@@ -14,7 +14,6 @@ export const validators = {
 
 function makeValidate(steps = []) {
   function validate(...args) {
-    console.log("🚀", { args, steps });
     return steps.reduce((error, step) => error || step(...args), false);
   }
   function all(...args) {

--- a/frontend/test/metabase/scenarios/onboarding/auth/sso.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/auth/sso.cy.spec.js
@@ -41,7 +41,7 @@ describe("scenarios > auth > signin > SSO", () => {
       cy.findByText("Sign in with Google").should("not.exist");
     });
 
-    it.skip("should surface login errors with Google sign in enabled (metabase#16122)", () => {
+    it("should surface login errors with Google sign in enabled (metabase#16122)", () => {
       cy.findByText("Sign in with email").click();
       cy.findByLabelText("Email address").type("foo@bar.test");
       cy.findByLabelText("Password").type("123");


### PR DESCRIPTION
Fixes #16122 

## How to Test

1. Go to Admin
2. On left menu, click `Authentication`
3. In section titled `Sign in with Google`, click `Configure`
4. Add any string to `Client ID` input
5. Click `Save Changes`
6. Sign Out of Metabase
7. Click on `Sign in with email`
8. Add a correct email but wrong password, or other login mistakes
9. Click `Sign in`

### After

Form shows error messages.

<img src="https://user-images.githubusercontent.com/380816/122097894-902d6b80-cde6-11eb-947f-b40b5c53d9bf.png" width=300 />

### Before

Page showed Google authentication button

<img src="https://user-images.githubusercontent.com/380816/122097960-a1767800-cde6-11eb-8f5a-f32ac734da67.png" width=300 />
