### PR TITLE
Add propTypes to LoginApp component

### DIFF
--- a/frontend/src/metabase/auth/containers/LoginApp.jsx
+++ b/frontend/src/metabase/auth/containers/LoginApp.jsx
@@ -1,5 +1,5 @@
-/* eslint-disable react/prop-types */
 import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import { connect } from "react-redux";
 import { t } from "ttag";
@@ -45,3 +45,8 @@ export default class LoginApp extends Component {
     );
   }
 }
+
+LoginApp.propTypes = {
+  providers: PropTypes.array,
+  params: PropTypes.object.isRequired,
+};


### PR DESCRIPTION
Related to #16122 
Follow up to #16593

## How to Test

1. Have browser console tab open.
2. Go to login page

You should not see any console warning about `propTypes` and `LoginApp`.