### PR TITLE
Add propTypes to LogoutApp component

### DIFF
--- a/frontend/src/metabase/auth/containers/LogoutApp.jsx
+++ b/frontend/src/metabase/auth/containers/LogoutApp.jsx
@@ -1,5 +1,5 @@
-/* eslint-disable react/prop-types */
 import { Component } from "react";
+import PropTypes from "prop-types";
 import { connect } from "react-redux";
 
 import { logout } from "../auth";
@@ -23,3 +23,7 @@ export default class LogoutApp extends Component {
     return null;
   }
 }
+
+LogoutApp.propTypes = {
+  logout: PropTypes.func.isRequired,
+};


### PR DESCRIPTION
Related to #16122 
Follow up to #16593

## How to Test

1. Have browser console tab open.
2. Log in
3. Sign out

You should not see any console warning about `propTypes` and `LogoutApp`.