### PR TITLE
Add propTypes to PasswordResetApp component

### DIFF
--- a/frontend/src/metabase/auth/containers/PasswordResetApp.jsx
+++ b/frontend/src/metabase/auth/containers/PasswordResetApp.jsx
@@ -1,5 +1,5 @@
-/* eslint-disable react/prop-types */
 import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { Link } from "react-router";
 import { t, jt } from "ttag";
@@ -116,3 +116,8 @@ export default class PasswordResetApp extends Component {
     );
   }
 }
+
+PasswordResetApp.propTypes = {
+  token: PropTypes.string.isRequired,
+  newUserJoining: PropTypes.bool.isRequired,
+};


### PR DESCRIPTION
Related to #16122 
Follow up to #16593

I confess not knowing how to check this page in localhost.

Going to the reset password screen shows the following message:

```
Please contact an administrator to have them reset your password
```

The changes here should be almost self-evident from the following block in the component file:

~~~js
const mapStateToProps = (state, props) => {
  return {
    token: props.params.token,
    newUserJoining: props.location.hash === "#new",
  };
};
~~~