### PR TITLE
Keep click behavior when reset settings

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChartSettings.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings.jsx
@@ -18,7 +18,10 @@ import {
   getVisualizationTransformed,
   extractRemappings,
 } from "metabase/visualizations";
-import { updateSettings } from "metabase/visualizations/lib/settings";
+import {
+  updateSettings,
+  getClickBehaviorSettings,
+} from "metabase/visualizations/lib/settings";
 
 // section names are localized
 const DEFAULT_TAB_PRIORITY = [t`Display`];
@@ -90,7 +93,9 @@ class ChartSettings extends Component {
 
   handleResetSettings = () => {
     MetabaseAnalytics.trackEvent("Chart Settings", "Reset Settings");
-    this.props.onChange({});
+
+    const settings = getClickBehaviorSettings(this._getSettings());
+    this.props.onChange(settings);
   };
 
   handleChangeSettings = changedSettings => {

--- a/frontend/src/metabase/visualizations/lib/settings.js
+++ b/frontend/src/metabase/visualizations/lib/settings.js
@@ -295,18 +295,27 @@ export function getClickBehaviorSettings(settings) {
     newSettings.click_behavior = settings.click_behavior;
   }
 
-  if (settings.column_settings) {
-    Object.entries(settings.column_settings).forEach(([key, fieldSettings]) => {
-      if (fieldSettings.click_behavior == null) {
-        return;
-      }
-
-      newSettings.column_settings = newSettings.column_settings || {};
-      newSettings.column_settings[key] = {
-        click_behavior: fieldSettings.click_behavior,
-      };
-    });
+  const columnSettings = getColumnClickBehavior(settings.column_settings);
+  if (columnSettings) {
+    newSettings.column_settings = columnSettings;
   }
 
   return newSettings;
+}
+
+function getColumnClickBehavior(columnSettings) {
+  if (columnSettings == null) {
+    return null;
+  }
+
+  return Object.entries(columnSettings)
+    .filter(([_, fieldSettings]) => fieldSettings.click_behavior != null)
+    .reduce((acc, [key, fieldSettings]) => {
+      return {
+        ...acc,
+        [key]: {
+          click_behavior: fieldSettings.click_behavior,
+        },
+      };
+    }, null);
 }

--- a/frontend/src/metabase/visualizations/lib/settings.js
+++ b/frontend/src/metabase/visualizations/lib/settings.js
@@ -287,3 +287,26 @@ export function mergeSettings(first: Settings = {}, second: Settings = {}) {
   }
   return merged;
 }
+
+export function getClickBehaviorSettings(settings) {
+  const newSettings = {};
+
+  if (settings.click_behavior) {
+    newSettings.click_behavior = settings.click_behavior;
+  }
+
+  if (settings.column_settings) {
+    Object.entries(settings.column_settings).forEach(([key, fieldSettings]) => {
+      if (fieldSettings.click_behavior == null) {
+        return;
+      }
+
+      newSettings.column_settings = newSettings.column_settings || {};
+      newSettings.column_settings[key] = {
+        click_behavior: fieldSettings.click_behavior,
+      };
+    });
+  }
+
+  return newSettings;
+}

--- a/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
@@ -523,7 +523,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
     cy.location("pathname").should("eq", "/it/worked");
   });
 
-  it.skip("should not remove click behavior on 'reset to defaults' (metabase#14919)", () => {
+  it("should not remove click behavior on 'reset to defaults' (metabase#14919)", () => {
     const LINK_NAME = "Home";
 
     cy.createQuestion({

--- a/frontend/test/metabase/visualizations/lib/settings.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/settings.unit.spec.js
@@ -5,6 +5,7 @@ import {
   getComputedSettings,
   getSettingsWidgets,
   mergeSettings,
+  getClickBehaviorSettings,
 } from "metabase/visualizations/lib/settings";
 
 describe("settings framework", () => {
@@ -215,6 +216,47 @@ describe("settings framework", () => {
       expect(
         mergeSettings({}, { column_settings: { col1: { set1: "val" } } }),
       ).toEqual({ column_settings: { col1: { set1: "val" } } });
+    });
+  });
+
+  describe("getClickBehaviorSettings", () => {
+    it("should clone only click_behavior from column_settings", () => {
+      expect(
+        getClickBehaviorSettings({
+          column_settings: {
+            col1: {
+              click_behavior: { type: "stub" },
+              not_click_behavior: { type: "another stub" },
+            },
+          },
+        }),
+      ).toEqual({
+        column_settings: { col1: { click_behavior: { type: "stub" } } },
+      });
+    });
+
+    it("should clone only click_behavior from root settings", () => {
+      expect(
+        getClickBehaviorSettings({
+          click_behavior: { type: "stub" },
+          not_click_behavior: { type: "another stub" },
+        }),
+      ).toEqual({
+        click_behavior: { type: "stub" },
+      });
+    });
+
+    it("should return an empty object if there are no click behaviors set", () => {
+      expect(
+        getClickBehaviorSettings({
+          not_click_behavior: { type: "stub" },
+          column_settings: {
+            col1: {
+              not_click_behavior: { type: "stub" },
+            },
+          },
+        }),
+      ).toEqual({});
     });
   });
 });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/14919

Check the original issue for repro steps.
The fix is pretty straightforward: keep `click_behavior` settings when reset to defaults.
`click_behavior` setting can exist on the card level as well as on the column level for table visualizations.