### PR TITLE
use is-null filter when value is null when drilling down on null bin

### DIFF
--- a/frontend/src/metabase/modes/lib/actions.js
+++ b/frontend/src/metabase/modes/lib/actions.js
@@ -152,8 +152,10 @@ export function drillFilter(
     const range = rangeForValue(value, column);
     if (range) {
       filter = ["between", fieldRefForColumn(column), range[0], range[1]];
-    } else {
+    } else if (value != null) {
       filter = ["=", fieldRefForColumn(column), value];
+    } else {
+      filter = ["is-null", fieldRefForColumn(column)];
     }
   }
 

--- a/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
@@ -414,6 +414,35 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
     cy.findByText("Showing 85 rows");
   });
 
+  it("should drill through on a bin of null values (#11345)", () => {
+    visitQuestionAdhoc({
+      name: "11345",
+      dataset_query: {
+        database: 1,
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: [["count"]],
+          breakout: [
+            ["field", ORDERS.DISCOUNT, { binning: { strategy: "default" } }],
+          ],
+        },
+        type: "query",
+      },
+      display: "table",
+    });
+
+    // click on the Count column cell showing the count of null rows
+    cy.findByText("16,845").click();
+    cy.findByText("View these Orders").click();
+
+    // count number of distinct values in the Discount column
+    cy.findByText("Discount ($)").click();
+    cy.findByText("Distincts").click();
+
+    // there should be 0 distinct values since they are all null
+    cy.get(".TableInteractive-cellWrapper").contains("0");
+  });
+
   it("should parse value on click through on the first row of pie chart (metabase#15250)", () => {
     cy.createQuestion({
       name: "15250",


### PR DESCRIPTION
Fixes #11345

Just a matter of applying the correct filter to the query. There was no logic to account for a `null` value. Previously, a filter of `["=", field, null]` was applied when drilling down but for whatever reason the question would lose this filter. Adding logic to add a filter of `is-null` fixes things.

Here's a video where I drill down on a bin of null values. I then create a distinct values summary on the Discount column to show that there are no other values in the column:


https://user-images.githubusercontent.com/13057258/122116791-e2688f80-cdda-11eb-8433-36b440f10612.mov

