### PR TITLE
fix inability to change series settings when its title is an empty string

### DIFF
--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingNestedSettings.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingNestedSettings.jsx
@@ -105,7 +105,7 @@ const chartSettingNestedSettings = ({
       newSettings: Settings,
     ) => {
       const objectKey = getObjectKey(object);
-      if (objectKey) {
+      if (objectKey != null) {
         this.handleChangeSettingsForObjectKey(objectKey, newSettings);
       }
     };

--- a/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
@@ -105,7 +105,7 @@ describe("scenarios > visualizations > line chart", () => {
     });
   });
 
-  it.skip("should be possible to update/change label for an empty row value (metabase#12128)", () => {
+  it("should be possible to update/change label for an empty row value (metabase#12128)", () => {
     visitQuestionAdhoc({
       dataset_query: {
         type: "native",


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/12128

Check the original issue for repro steps.