### PR TITLE
New endpoint for fetching geojson from URL

### DIFF
--- a/src/metabase/api/geojson.clj
+++ b/src/metabase/api/geojson.clj
@@ -107,6 +107,9 @@
   [{{:keys [url]} :body} respond raise]
   {url su/NonBlankString}
   (try
+    (or
+     (io/resource url)
+     (valid-url? url))
     (with-open [reader (io/reader (or (io/resource url)
                                       url))
                 is     (ReaderInputStream. reader)]

--- a/src/metabase/api/geojson.clj
+++ b/src/metabase/api/geojson.clj
@@ -70,7 +70,7 @@
   (try
     (s/validate CustomGeoJSON geojson)
     (catch Throwable e
-      (throw (ex-info (tru "Invalid custom GeoJSON.") {:status-code 400} e))))
+      (throw (ex-info (tru "Invalid custom GeoJSON") {:status-code 400} e))))
   (or (valid-geojson-url? geojson)
       (throw (ex-info (invalid-location-msg) {:status-code 400}))))
 
@@ -98,7 +98,7 @@
         (respond (-> (rr/response is)
                      (rr/content-type "application/json"))))
       (catch Throwable e
-        (raise (ex-info (tru "Invalid custom GeoJSON.") {:status-code 400}))))
+        (raise (ex-info (tru "GeoJSON URL failed to load") {:status-code 400}))))
     (raise (ex-info (tru "Invalid custom GeoJSON key: {0}" key) {:status-code 400}))))
 
 (api/defendpoint-async GET "/"
@@ -113,6 +113,6 @@
       (respond (-> (rr/response is)
                    (rr/content-type "application/json"))))
     (catch Throwable e
-      (raise (ex-info (tru "Invalid custom GeoJSON.") {:status-code 400})))))
+      (raise (ex-info (tru "GeoJSON URL failed to load") {:status-code 400})))))
 
 (api/define-routes)

--- a/src/metabase/api/geojson.clj
+++ b/src/metabase/api/geojson.clj
@@ -107,16 +107,16 @@
   This behaves similarly to /api/geojson/:key but doesn't require the custom map to be saved to the DB first."
   [{{:keys [url]} :params} respond raise]
   {url su/NonBlankString}
-  (try
-    (let [decoded-url (rc/url-decode url)]
-      (or (io/resource decoded-url)
-          (valid-url? decoded-url))
+  (let [decoded-url (rc/url-decode url)]
+    (or (io/resource decoded-url)
+        (valid-url? decoded-url))
+    (try
       (with-open [reader (io/reader (or (io/resource decoded-url)
                                         decoded-url))
                   is     (ReaderInputStream. reader)]
         (respond (-> (rr/response is)
-                     (rr/content-type "application/json")))))
-    (catch Throwable e
-      (raise (ex-info (tru "GeoJSON URL failed to load") {:status-code 400})))))
+                     (rr/content-type "application/json"))))
+      (catch Throwable e
+        (raise (ex-info (tru "GeoJSON URL failed to load") {:status-code 400}))))))
 
 (api/define-routes)

--- a/src/metabase/api/geojson.clj
+++ b/src/metabase/api/geojson.clj
@@ -85,19 +85,34 @@
              (setting/set-json! :custom-geojson new-value))
   :visibility :public)
 
-
 (api/defendpoint-async GET "/:key"
   "Fetch a custom GeoJSON file as defined in the `custom-geojson` setting. (This just acts as a simple proxy for the
   file specified for `key`)."
   [{{:keys [key]} :params} respond raise]
   {key su/NonBlankString}
   (if-let [url (get-in (custom-geojson) [(keyword key) :url])]
+    (try
+      (with-open [reader (io/reader (or (io/resource url)
+                                        url))
+                  is     (ReaderInputStream. reader)]
+        (respond (-> (rr/response is)
+                     (rr/content-type "application/json"))))
+      (catch Throwable e
+        (raise (ex-info (tru "Invalid custom GeoJSON.") {:status-code 400}))))
+    (raise (ex-info (tru "Invalid custom GeoJSON key: {0}" key) {:status-code 400}))))
+
+(api/defendpoint-async GET "/"
+  "Load a custom GeoJSON file based on a URL or file path provided in the request body.
+  This behaves similarly to /api/geojson/:key but doesn't require the custom map to be saved to the DB first."
+  [{{:keys [url]} :body} respond raise]
+  {url su/NonBlankString}
+  (try
     (with-open [reader (io/reader (or (io/resource url)
                                       url))
                 is     (ReaderInputStream. reader)]
       (respond (-> (rr/response is)
                    (rr/content-type "application/json"))))
-    (raise (ex-info (tru "Invalid custom GeoJSON key: {0}" key)
-             {:status-code 400}))))
+    (catch Throwable e
+      (raise (ex-info (tru "Invalid custom GeoJSON.") {:status-code 400})))))
 
 (api/define-routes)

--- a/test/metabase/api/geojson_test.clj
+++ b/test/metabase/api/geojson_test.clj
@@ -11,6 +11,10 @@
   "URL of a GeoJSON file used for test purposes."
   "https://raw.githubusercontent.com/metabase/metabase/master/test_resources/test.geojson")
 
+(def ^:private ^String test-broken-geojson-url
+  "URL of a GeoJSON file that is a valid URL but which cannot be connected to."
+  "https://raw.githubusercontent.com/metabase/metabase/master/test_resources/broken.geojson")
+
 (def ^:private test-custom-geojson
   {:middle-earth {:name        "Middle Earth"
                   :url         test-geojson-url
@@ -18,13 +22,12 @@
                   :region_key  nil
                   :region_name nil}})
 
-(def ^:private test-geojson-value
-  {:type "FeatureCollection"
-   :features [{:type "Feature"
-               :geometry {:type "Point",
-                          :coordinates [55.948609737988384
-                                        -3.1919722001105044]}
-               :properties []}]})
+(def ^:private test-broken-custom-geojson
+  {:middle-earth {:name        "Middle Earth"
+                  :url         test-broken-geojson-url
+                  :builtin     true
+                  :region_key  nil
+                  :region_name nil}})
 
 (deftest geojson-schema-test
   (is (= true
@@ -57,8 +60,8 @@
           valid?   #'geojson-api/validate-geojson]
       (doseq [[url should-pass?] examples]
         (let [geojson {:deadb33f {:name        "Rivendell"
-                                   :url         url
-                                   :region_key  nil
+                                  :url         url
+                                  :region_key  nil
                                   :region_name nil}}]
           (if should-pass?
             (is (valid? geojson) url)
@@ -96,8 +99,11 @@
   (testing "GET /api/geojson"
     (testing "test the endpoint that fetches JSON files given a URL"
       (is (= {:type        "Point"
-                :coordinates [37.77986 -122.429]}
-               ((mt/user->client :rasta) :get 200 {:url test-geojson-url}))))))
+              :coordinates [37.77986 -122.429]}
+             ((mt/user->client :rasta) :get 200 "geojson" {:url test-geojson-url}))))
+    (testing "error is returned if URL connection fails"
+      (is (= "GeoJSON URL failed to load"
+             ((mt/user->client :rasta) :get 400 "geojson" {:url test-broken-geojson-url}))))))
 
 (deftest key-proxy-endpoint-test
   (testing "GET /api/geojson/:key"
@@ -114,7 +120,10 @@
         (is (= {:type        "Point"
                 :coordinates [37.77986 -122.429]}
                (client/client :get 200 "geojson/middle-earth"))))
-      (testing "error conditions"
         (testing "try fetching an invalid key; should fail"
           (is (= "Invalid custom GeoJSON key: invalid-key"
-                 ((mt/user->client :rasta) :get 400 "geojson/invalid-key"))))))))
+                 ((mt/user->client :rasta) :get 400 "geojson/invalid-key")))))
+    (mt/with-temporary-setting-values [custom-geojson test-broken-custom-geojson]
+      (testing "fetching a broken URL should fail"
+        (is (= "GeoJSON URL failed to load"
+               ((mt/user->client :rasta) :get 400 "geojson/middle-earth")))))))

--- a/test/metabase/api/geojson_test.clj
+++ b/test/metabase/api/geojson_test.clj
@@ -100,10 +100,10 @@
     (testing "test the endpoint that fetches JSON files given a URL"
       (is (= {:type        "Point"
               :coordinates [37.77986 -122.429]}
-             ((mt/user->client :rasta) :get 200 "geojson" {:url test-geojson-url}))))
+             ((mt/user->client :rasta) :get 200 "geojson" :url test-geojson-url))))
     (testing "error is returned if URL connection fails"
       (is (= "GeoJSON URL failed to load"
-             ((mt/user->client :rasta) :get 400 "geojson" {:url test-broken-geojson-url}))))))
+             ((mt/user->client :rasta) :get 400 "geojson" :url test-broken-geojson-url))))))
 
 (deftest key-proxy-endpoint-test
   (testing "GET /api/geojson/:key"

--- a/test/metabase/api/geojson_test.clj
+++ b/test/metabase/api/geojson_test.clj
@@ -108,7 +108,7 @@
 (deftest key-proxy-endpoint-test
   (testing "GET /api/geojson/:key"
     (mt/with-temporary-setting-values [custom-geojson test-custom-geojson]
-      (testing "test the endpoint fetches JSON files given a GeoJSON key"
+      (testing "test the endpoint that fetches JSON files given a GeoJSON key"
         (is (= {:type        "Point"
                 :coordinates [37.77986 -122.429]}
                ((mt/user->client :rasta) :get 200 "geojson/middle-earth"))))

--- a/test/metabase/api/geojson_test.clj
+++ b/test/metabase/api/geojson_test.clj
@@ -92,10 +92,17 @@
                     {:value resource-geojson})
                    ((mt/user->client :crowberto) :get 200 "setting/custom-geojson")))))))))
 
-(deftest proxy-endpoint-test
+(deftest url-proxy-endpoint-test
+  (testing "GET /api/geojson"
+    (testing "test the endpoint that fetches JSON files given a URL"
+      (is (= {:type        "Point"
+                :coordinates [37.77986 -122.429]}
+               ((mt/user->client :rasta) :get 200 {:url test-geojson-url}))))))
+
+(deftest key-proxy-endpoint-test
   (testing "GET /api/geojson/:key"
     (mt/with-temporary-setting-values [custom-geojson test-custom-geojson]
-      (testing "test the endpoint that acts as a proxy for JSON files"
+      (testing "test the endpoint fetches JSON files given a GeoJSON key"
         (is (= {:type        "Point"
                 :coordinates [37.77986 -122.429]}
                ((mt/user->client :rasta) :get 200 "geojson/middle-earth"))))


### PR DESCRIPTION
There are two main issues remaining in #14635: an unhelpful error is shown if you try to load a map without putting in a name first, and loading maps often won't work properly in multi-instance environments.

Both issues are because of the write-before-read pattern being used by the custom map settings form. When you click "load", the new map is saved to the DB in the `custom-geojson` setting with a randomly generated UUID key, and then the GeoJSON data is fetched using the key, with the backend acting as a proxy for the stored URL. If you don't put in a name, the write to the setting fails schema validation. If you have MB running behind a load balancer, the read might go to a different replica than the write and not find the saved map.

My proposal is to simply expose a new API that exposes the proxy functionality for a URL provided as a query param, rather than requiring it to be stored first on the server. This can be hit from the frontend when clicking the "load" button so so that it's totally decoupled from persisting the setting to the server, which will happen only when clicking "Add map". I've put the current UI below for reference.

<img width="1085" alt="image" src="https://user-images.githubusercontent.com/32746338/122132899-89a3f180-cdf0-11eb-8beb-36c8d1e16d53.png">


For ease of code review this PR only adds the new API on the backend. I'll do the corresponding frontend changes in the next PR.