### PR TITLE
Fix drilldown on multi-series chart

### DIFF
--- a/frontend/src/metabase/visualizations/components/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization.jsx
@@ -276,14 +276,10 @@ export default class Visualization extends React.PureComponent {
     if (!clicked) {
       return [];
     }
-    const {
-      rawSeries,
-      metadata,
-      getExtraDataForClick = () => ({}),
-    } = this.props;
+    const { metadata, getExtraDataForClick = () => ({}) } = this.props;
     // TODO: push this logic into Question?
     const seriesIndex = clicked.seriesIndex || 0;
-    const card = rawSeries[seriesIndex].card;
+    const card = this.state.series[seriesIndex].card;
     const question = this._getQuestionForCardCached(metadata, card);
     const mode = this.props.mode
       ? question && new Mode(question, this.props.mode)

--- a/frontend/src/metabase/visualizations/lib/apply_tooltips.js
+++ b/frontend/src/metabase/visualizations/lib/apply_tooltips.js
@@ -185,6 +185,7 @@ export function getClickHoverObject(
     value,
     column,
     settings,
+    seriesIndex,
   };
 }
 

--- a/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
@@ -70,6 +70,85 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
     });
   });
 
+  it("should correctly drill through on a card with multiple series (metabase#11442)", () => {
+    cy.createQuestion({
+      name: "11442_Q1",
+      query: {
+        "source-table": ORDERS_ID,
+        aggregation: [["count"]],
+        breakout: [["field", ORDERS.CREATED_AT, { "temporal-unit": "year" }]],
+      },
+      display: "line",
+    }).then(({ body: { id: Q1_ID } }) => {
+      cy.createQuestion({
+        name: "11442_Q2",
+        query: {
+          "source-table": PRODUCTS_ID,
+          aggregation: [["count"]],
+          breakout: [
+            ["field", PRODUCTS.CREATED_AT, { "temporal-unit": "year" }],
+          ],
+        },
+        display: "line",
+      }).then(({ body: { id: Q2_ID } }) => {
+        cy.createDashboard("11442D").then(({ body: { id: DASHBOARD_ID } }) => {
+          cy.log("Add the first question to the dashboard");
+
+          cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
+            cardId: Q1_ID,
+          }).then(({ body: { id: DASH_CARD_ID } }) => {
+            cy.log(
+              "Add additional series combining it with the second question",
+            );
+
+            cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}/cards`, {
+              cards: [
+                {
+                  id: DASH_CARD_ID,
+                  card_id: Q1_ID,
+                  row: 0,
+                  col: 0,
+                  sizeX: 16,
+                  sizeY: 12,
+                  series: [
+                    {
+                      id: Q2_ID,
+                      model: "card",
+                    },
+                  ],
+                  visualization_settings: {},
+                  parameter_mappings: [],
+                },
+              ],
+            });
+          });
+
+          cy.visit(`/dashboard/${DASHBOARD_ID}`);
+
+          cy.log("The first series line");
+          cy.get(".sub.enable-dots._0")
+            .find(".dot")
+            .eq(0)
+            .click({ force: true });
+          cy.findByText(/Zoom in/i);
+          cy.findByText(/View these Orders/i);
+
+          // Click anywhere else to close the first action panel
+          cy.findByText("11442D").click();
+
+          // Second line from the second question
+          cy.log("The second series line");
+          cy.get(".sub.enable-dots._1")
+            .find(".dot")
+            .eq(0)
+            .click({ force: true });
+          cy.findByText(/Zoom in/i);
+          cy.findByText(/View these Products/i);
+        });
+      });
+    });
+  });
+
   it("should allow drill-through on combined cards with different amount of series (metabase#13457)", () => {
     cy.createQuestion({
       name: "13457_Q1",

--- a/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
@@ -70,7 +70,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
     });
   });
 
-  it.skip("should allow drill-through on combined cards with different amount of series (metabase#13457)", () => {
+  it("should allow drill-through on combined cards with different amount of series (metabase#13457)", () => {
     cy.createQuestion({
       name: "13457_Q1",
       query: {


### PR DESCRIPTION
Reproduces #11442
Fixes #11442
Fixes #13457

Two issues here:

1. we left `seriesIndex` off the `clicked` object so it is always `undefined` when it reaches `handleVisualizationClick` in the `Visualization` component
2. in `Visualization` we were looking at `rawSeries` instead of the transformed `series` list which lists out all series in a flat list

Before -- this is actually a People series but it shows Product because the first series in the chart is a Product series
<img width="690" alt="Screen Shot 2021-06-15 at 3 54 00 PM" src="https://user-images.githubusercontent.com/13057258/122134015-a93c1980-cdf2-11eb-8994-d7faa45eb461.png">
Drilldown does not work (clicked on "View these Products"):
<img width="708" alt="Screen Shot 2021-06-15 at 3 54 13 PM" src="https://user-images.githubusercontent.com/13057258/122134020-ad683700-cdf2-11eb-838e-dccd21f9ea2b.png">

After:
<img width="690" alt="Screen Shot 2021-06-15 at 3 54 42 PM" src="https://user-images.githubusercontent.com/13057258/122134101-d2f54080-cdf2-11eb-82bc-2d6762f7d4dc.png">
<img width="719" alt="Screen Shot 2021-06-15 at 3 54 49 PM" src="https://user-images.githubusercontent.com/13057258/122134107-d4bf0400-cdf2-11eb-8a82-db55307fc0dd.png">

