### PR TITLE
Hit new API for reading GeoJSON data in custom map settings form

### DIFF
--- a/frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx
@@ -82,7 +82,6 @@ export default class CustomGeoJSONWidget extends Component {
     await this._saveMap(map.id, null);
   };
 
-  // This is a bit of a hack, but the /api/geojson endpoint only works if the map is saved in the custom-geojson setting
   _loadGeoJson = async () => {
     try {
       const { map } = this.state;
@@ -91,8 +90,9 @@ export default class CustomGeoJSONWidget extends Component {
         geoJsonLoading: true,
         geoJsonError: null,
       });
-      await this._saveMap(map.id, map);
-      const geoJson = await GeoJSONApi.get({ id: map.id });
+      const geoJson = await GeoJSONApi.load({
+        url: encodeURIComponent(map.url),
+      });
       this.setState({
         geoJson: geoJson,
         geoJsonLoading: false,

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -412,6 +412,7 @@ export const UtilApi = {
 };
 
 export const GeoJSONApi = {
+  load: GET("/api/geojson"),
   get: GET("/api/geojson/:id"),
 };
 

--- a/frontend/test/metabase/scenarios/admin/settings/maps.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/maps.cy.spec.js
@@ -1,0 +1,53 @@
+import { restore } from "__support__/e2e/cypress";
+
+describe("scenarios > admin > settings > map settings", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should be able to load and save a custom map", () => {
+    cy.visit("/admin/settings/maps");
+    cy.findByText("Add a map").click();
+    cy.findByPlaceholderText("e.g. United Kingdom, Brazil, Mars").type(
+      "Test Map",
+    );
+    cy.findByPlaceholderText(
+      "Like https://my-mb-server.com/maps/my-map.json",
+    ).type(
+      "https://raw.githubusercontent.com/metabase/metabase/master/resources/frontend_client/app/assets/geojson/world.json",
+    );
+    cy.findByText("Load").click();
+    cy.wait(2000)
+      .findAllByText("Select…")
+      .first()
+      .click();
+    cy.findByText("NAME").click();
+    cy.findAllByText("Select…")
+      .last()
+      .click();
+    cy.findAllByText("NAME")
+      .last()
+      .click();
+    cy.findByText("Add map").click();
+    cy.wait(3000)
+      .findByText("NAME")
+      .should("not.exist");
+    cy.findByText("Test Map");
+  });
+
+  it("should be able to load a custom map even if a name has not been added yet (#14635)", () => {
+    cy.intercept("GET", "/api/geojson").as("load");
+    cy.visit("/admin/settings/maps");
+    cy.findByText("Add a map").click();
+    cy.findByPlaceholderText(
+      "Like https://my-mb-server.com/maps/my-map.json",
+    ).type(
+      "https://raw.githubusercontent.com/metabase/metabase/master/resources/frontend_client/app/assets/geojson/world.json",
+    );
+    cy.findByText("Load").click();
+    cy.wait("@load").then(interception => {
+      expect(interception.response.statusCode).to.eq(200);
+    });
+  });
+});

--- a/frontend/test/metabase/scenarios/admin/settings/maps.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/maps.cy.spec.js
@@ -50,4 +50,17 @@ describe("scenarios > admin > settings > map settings", () => {
       expect(interception.response.statusCode).to.eq(200);
     });
   });
+
+  it("should show an informative error when adding an invalid URL", () => {
+    cy.visit("/admin/settings/maps");
+    cy.findByText("Add a map").click();
+    cy.findByPlaceholderText(
+      "Like https://my-mb-server.com/maps/my-map.json",
+    ).type("bad-url");
+    cy.findByText("Load").click();
+    cy.findByText(
+      "Invalid GeoJSON file location: must either start with http:// or https:// or be a relative path to a file on the classpath. " +
+        "URLs referring to hosts that supply internal hosting metadata are prohibited.",
+    );
+  });
 });

--- a/src/metabase/api/geojson.clj
+++ b/src/metabase/api/geojson.clj
@@ -107,6 +107,9 @@
   [{{:keys [url]} :body} respond raise]
   {url su/NonBlankString}
   (try
+    (or
+     (io/resource url)
+     (valid-url? url))
     (with-open [reader (io/reader (or (io/resource url)
                                       url))
                 is     (ReaderInputStream. reader)]

--- a/src/metabase/api/geojson.clj
+++ b/src/metabase/api/geojson.clj
@@ -70,7 +70,7 @@
   (try
     (s/validate CustomGeoJSON geojson)
     (catch Throwable e
-      (throw (ex-info (tru "Invalid custom GeoJSON.") {:status-code 400} e))))
+      (throw (ex-info (tru "Invalid custom GeoJSON") {:status-code 400} e))))
   (or (valid-geojson-url? geojson)
       (throw (ex-info (invalid-location-msg) {:status-code 400}))))
 
@@ -98,7 +98,7 @@
         (respond (-> (rr/response is)
                      (rr/content-type "application/json"))))
       (catch Throwable e
-        (raise (ex-info (tru "Invalid custom GeoJSON.") {:status-code 400}))))
+        (raise (ex-info (tru "GeoJSON URL failed to load") {:status-code 400}))))
     (raise (ex-info (tru "Invalid custom GeoJSON key: {0}" key) {:status-code 400}))))
 
 (api/defendpoint-async GET "/"
@@ -113,6 +113,6 @@
       (respond (-> (rr/response is)
                    (rr/content-type "application/json"))))
     (catch Throwable e
-      (raise (ex-info (tru "Invalid custom GeoJSON.") {:status-code 400})))))
+      (raise (ex-info (tru "GeoJSON URL failed to load") {:status-code 400})))))
 
 (api/define-routes)

--- a/src/metabase/api/geojson.clj
+++ b/src/metabase/api/geojson.clj
@@ -107,16 +107,16 @@
   This behaves similarly to /api/geojson/:key but doesn't require the custom map to be saved to the DB first."
   [{{:keys [url]} :params} respond raise]
   {url su/NonBlankString}
-  (try
-    (let [decoded-url (rc/url-decode url)]
-      (or (io/resource decoded-url)
-          (valid-url? decoded-url))
+  (let [decoded-url (rc/url-decode url)]
+    (or (io/resource decoded-url)
+        (valid-url? decoded-url))
+    (try
       (with-open [reader (io/reader (or (io/resource decoded-url)
                                         decoded-url))
                   is     (ReaderInputStream. reader)]
         (respond (-> (rr/response is)
-                     (rr/content-type "application/json")))))
-    (catch Throwable e
-      (raise (ex-info (tru "GeoJSON URL failed to load") {:status-code 400})))))
+                     (rr/content-type "application/json"))))
+      (catch Throwable e
+        (raise (ex-info (tru "GeoJSON URL failed to load") {:status-code 400}))))))
 
 (api/define-routes)

--- a/src/metabase/api/geojson.clj
+++ b/src/metabase/api/geojson.clj
@@ -85,19 +85,34 @@
              (setting/set-json! :custom-geojson new-value))
   :visibility :public)
 
-
 (api/defendpoint-async GET "/:key"
   "Fetch a custom GeoJSON file as defined in the `custom-geojson` setting. (This just acts as a simple proxy for the
   file specified for `key`)."
   [{{:keys [key]} :params} respond raise]
   {key su/NonBlankString}
   (if-let [url (get-in (custom-geojson) [(keyword key) :url])]
+    (try
+      (with-open [reader (io/reader (or (io/resource url)
+                                        url))
+                  is     (ReaderInputStream. reader)]
+        (respond (-> (rr/response is)
+                     (rr/content-type "application/json"))))
+      (catch Throwable e
+        (raise (ex-info (tru "Invalid custom GeoJSON.") {:status-code 400}))))
+    (raise (ex-info (tru "Invalid custom GeoJSON key: {0}" key) {:status-code 400}))))
+
+(api/defendpoint-async GET "/"
+  "Load a custom GeoJSON file based on a URL or file path provided in the request body.
+  This behaves similarly to /api/geojson/:key but doesn't require the custom map to be saved to the DB first."
+  [{{:keys [url]} :body} respond raise]
+  {url su/NonBlankString}
+  (try
     (with-open [reader (io/reader (or (io/resource url)
                                       url))
                 is     (ReaderInputStream. reader)]
       (respond (-> (rr/response is)
                    (rr/content-type "application/json"))))
-    (raise (ex-info (tru "Invalid custom GeoJSON key: {0}" key)
-             {:status-code 400}))))
+    (catch Throwable e
+      (raise (ex-info (tru "Invalid custom GeoJSON.") {:status-code 400})))))
 
 (api/define-routes)

--- a/test/metabase/api/geojson_test.clj
+++ b/test/metabase/api/geojson_test.clj
@@ -11,6 +11,10 @@
   "URL of a GeoJSON file used for test purposes."
   "https://raw.githubusercontent.com/metabase/metabase/master/test_resources/test.geojson")
 
+(def ^:private ^String test-broken-geojson-url
+  "URL of a GeoJSON file that is a valid URL but which cannot be connected to."
+  "https://raw.githubusercontent.com/metabase/metabase/master/test_resources/broken.geojson")
+
 (def ^:private test-custom-geojson
   {:middle-earth {:name        "Middle Earth"
                   :url         test-geojson-url
@@ -18,13 +22,12 @@
                   :region_key  nil
                   :region_name nil}})
 
-(def ^:private test-geojson-value
-  {:type "FeatureCollection"
-   :features [{:type "Feature"
-               :geometry {:type "Point",
-                          :coordinates [55.948609737988384
-                                        -3.1919722001105044]}
-               :properties []}]})
+(def ^:private test-broken-custom-geojson
+  {:middle-earth {:name        "Middle Earth"
+                  :url         test-broken-geojson-url
+                  :builtin     true
+                  :region_key  nil
+                  :region_name nil}})
 
 (deftest geojson-schema-test
   (is (= true
@@ -57,8 +60,8 @@
           valid?   #'geojson-api/validate-geojson]
       (doseq [[url should-pass?] examples]
         (let [geojson {:deadb33f {:name        "Rivendell"
-                                   :url         url
-                                   :region_key  nil
+                                  :url         url
+                                  :region_key  nil
                                   :region_name nil}}]
           (if should-pass?
             (is (valid? geojson) url)
@@ -96,8 +99,11 @@
   (testing "GET /api/geojson"
     (testing "test the endpoint that fetches JSON files given a URL"
       (is (= {:type        "Point"
-                :coordinates [37.77986 -122.429]}
-               ((mt/user->client :rasta) :get 200 {:url test-geojson-url}))))))
+              :coordinates [37.77986 -122.429]}
+             ((mt/user->client :rasta) :get 200 "geojson" {:url test-geojson-url}))))
+    (testing "error is returned if URL connection fails"
+      (is (= "GeoJSON URL failed to load"
+             ((mt/user->client :rasta) :get 400 "geojson" {:url test-broken-geojson-url}))))))
 
 (deftest key-proxy-endpoint-test
   (testing "GET /api/geojson/:key"
@@ -114,7 +120,10 @@
         (is (= {:type        "Point"
                 :coordinates [37.77986 -122.429]}
                (client/client :get 200 "geojson/middle-earth"))))
-      (testing "error conditions"
         (testing "try fetching an invalid key; should fail"
           (is (= "Invalid custom GeoJSON key: invalid-key"
-                 ((mt/user->client :rasta) :get 400 "geojson/invalid-key"))))))))
+                 ((mt/user->client :rasta) :get 400 "geojson/invalid-key")))))
+    (mt/with-temporary-setting-values [custom-geojson test-broken-custom-geojson]
+      (testing "fetching a broken URL should fail"
+        (is (= "GeoJSON URL failed to load"
+               ((mt/user->client :rasta) :get 400 "geojson/middle-earth")))))))

--- a/test/metabase/api/geojson_test.clj
+++ b/test/metabase/api/geojson_test.clj
@@ -100,10 +100,10 @@
     (testing "test the endpoint that fetches JSON files given a URL"
       (is (= {:type        "Point"
               :coordinates [37.77986 -122.429]}
-             ((mt/user->client :rasta) :get 200 "geojson" {:url test-geojson-url}))))
+             ((mt/user->client :rasta) :get 200 "geojson" :url test-geojson-url))))
     (testing "error is returned if URL connection fails"
       (is (= "GeoJSON URL failed to load"
-             ((mt/user->client :rasta) :get 400 "geojson" {:url test-broken-geojson-url}))))))
+             ((mt/user->client :rasta) :get 400 "geojson" :url test-broken-geojson-url))))))
 
 (deftest key-proxy-endpoint-test
   (testing "GET /api/geojson/:key"

--- a/test/metabase/api/geojson_test.clj
+++ b/test/metabase/api/geojson_test.clj
@@ -108,7 +108,7 @@
 (deftest key-proxy-endpoint-test
   (testing "GET /api/geojson/:key"
     (mt/with-temporary-setting-values [custom-geojson test-custom-geojson]
-      (testing "test the endpoint fetches JSON files given a GeoJSON key"
+      (testing "test the endpoint that fetches JSON files given a GeoJSON key"
         (is (= {:type        "Point"
                 :coordinates [37.77986 -122.429]}
                ((mt/user->client :rasta) :get 200 "geojson/middle-earth"))))

--- a/test/metabase/api/geojson_test.clj
+++ b/test/metabase/api/geojson_test.clj
@@ -92,10 +92,17 @@
                     {:value resource-geojson})
                    ((mt/user->client :crowberto) :get 200 "setting/custom-geojson")))))))))
 
-(deftest proxy-endpoint-test
+(deftest url-proxy-endpoint-test
+  (testing "GET /api/geojson"
+    (testing "test the endpoint that fetches JSON files given a URL"
+      (is (= {:type        "Point"
+                :coordinates [37.77986 -122.429]}
+               ((mt/user->client :rasta) :get 200 {:url test-geojson-url}))))))
+
+(deftest key-proxy-endpoint-test
   (testing "GET /api/geojson/:key"
     (mt/with-temporary-setting-values [custom-geojson test-custom-geojson]
-      (testing "test the endpoint that acts as a proxy for JSON files"
+      (testing "test the endpoint fetches JSON files given a GeoJSON key"
         (is (= {:type        "Point"
                 :coordinates [37.77986 -122.429]}
                ((mt/user->client :rasta) :get 200 "geojson/middle-earth"))))


### PR DESCRIPTION
See #16607 for more context about the issue and the new API. This PR just changes the `Load` button to hit the new load API which doesn't require writing the custom map to settings first.

Also added a new Cypress file for map settings, with a few initial tests.

Resolves #14635 