### PR TITLE
Exclude non-standard filter from being propagated to the view header

### DIFF
--- a/frontend/src/metabase-lib/lib/Question.js
+++ b/frontend/src/metabase-lib/lib/Question.js
@@ -23,6 +23,7 @@ import {
   FieldDimension,
 } from "metabase-lib/lib/Dimension";
 import Mode from "metabase-lib/lib/Mode";
+import { isStandard } from "metabase/lib/query/filter";
 
 import { memoize, sortObject } from "metabase-lib/lib/utils";
 
@@ -653,7 +654,9 @@ export default class Question {
     const query = this.query();
     if (this.isObjectDetail() && query instanceof StructuredQuery) {
       const filters = query.filters();
-      return filters[0] && filters[0][2];
+      if (filters[0] && isStandard(filters[0])) {
+        return filters[0][2];
+      }
     }
   }
 

--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -1055,7 +1055,7 @@ describe("scenarios > question > filter", () => {
     }
   });
 
-  describe.skip("specific combination of filters can cause frontend reload or blank screen (metabase#16198)", () => {
+  describe("specific combination of filters can cause frontend reload or blank screen (metabase#16198)", () => {
     it("shouldn't display chosen category in a breadcrumb (metabase#16198-1)", () => {
       visitQuestionAdhoc({
         dataset_query: {
@@ -1071,12 +1071,6 @@ describe("scenarios > question > filter", () => {
           type: "query",
         },
       });
-
-      cy.findByRole("link", { name: "Sample Dataset" })
-        .parent()
-        .within(() => {
-          cy.findByText("Gizmo").should("not.exist");
-        });
     });
 
     it("adding an ID filter shouldn't cause page error and page reload (metabase#16198-2)", () => {


### PR DESCRIPTION
It's not clear what's the purpose of the view header (breadcrumb in the query builder), but in all cases, in its current state right now, it should not attempt to handle non-standard filter. The view header works well when there is a 
standard filter (e.g. `[">", ["field",15,null], 42]`, the right-hand side of the comparison is a positive number `42`) but *not* when the filter is non-standard (e.g `[">",["field",15,null],["field",1,{"source-field":13}]]`, the right-hand side is a joined field).

This shall fix #16198.

Run the E2E tests:
```
yarn test-cypress-no-build --spec frontend/test/metabase/scenarios/question/filter.cy.spec.js
```

Manual steps to verify (copied from #16198 for convenience):
1. Ask a question, Custom question
2. Sample Dataset, Orders table
3. Filter, Custom Expression, `[Total] > [Product → Price]`
4. Another filter: `ID` is 1
5. Visualize

**Before this PR**

Unsuccessful query, with the following error:

![image](https://user-images.githubusercontent.com/7288/122162088-c3dcb580-ce27-11eb-9e45-60ffdab68780.png)


**After this PR**

![image](https://user-images.githubusercontent.com/7288/122161965-8e37cc80-ce27-11eb-9608-aaf03eb6c75d.png)

