### PR TITLE
Add repro for #16617: archive page shows error for users with collection curate permissions and no data permissions

### DIFF
--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -162,20 +162,6 @@ describe("scenarios > collection_defaults", () => {
       });
     });
 
-    describe("archive", () => {
-      it("should show archived items (metabase#15080)", () => {
-        cy.visit("collection/root");
-        openEllipsisMenuFor("Orders");
-        cy.findByText("Archive this item").click();
-        cy.findByText("Archived question")
-          .siblings(".Icon-close")
-          .click();
-        cy.findByText("View archive").click();
-        cy.location("pathname").should("eq", "/archive");
-        cy.findByText("Orders");
-      });
-    });
-
     // [quarantine]: cannot run tests that rely on email setup in CI (yet)
     describe.skip("a new pulse", () => {
       it("should be in the root collection", () => {

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -145,6 +145,21 @@ describe("collection permissions", () => {
                   archiveUnarchive("Orders in a dashboard");
                 });
 
+                describe("archive page", () => {
+                  it("should show archived items (metabase#15080, metabase#16617)", () => {
+                    cy.skipOn(user === "nodata");
+                    cy.visit("collection/root");
+                    openEllipsisMenuFor("Orders");
+                    cy.findByText("Archive this item").click();
+                    cy.findByText("Archived question")
+                      .siblings(".Icon-close")
+                      .click();
+                    cy.findByText("View archive").click();
+                    cy.location("pathname").should("eq", "/archive");
+                    cy.findByText("Orders");
+                  });
+                });
+
                 describe("collections", () => {
                   it("shouldn't be able to archive/edit root or personal collection", () => {
                     cy.visit("/collection/root");


### PR DESCRIPTION
Reproduces #16617 (Archive page shows error for users with collection curate permissions and no data permissions)

There was an E2E test for the archive page, but it was running only against admin users. I think we should better move it to the `permissions` suite, so we can cover different permission groups. However, this PR only covers users with collection curate permissions. I'm not sure how the archive should work for other user groups, so `readonly`, `nocollection`, `nosql` and `none` users are not covered for now.

**To Verify**
1. `yarn test-cypress-open --spec frontend/test/metabase/scenarios/collections/permissions.cy.spec.js`
2. Find `describe("archive page"` section, and replace it with `describe.only("archive page"` (permissions tests can take some time to run)
3. Remove `cy.skipOn(user === "nodata");` in the test block
4. The test should fail when run against the `nodata` user

**Screenshots**

![image](https://user-images.githubusercontent.com/17258145/122193398-1efcbf80-ce9d-11eb-950b-79ba618e798e.png)
