### PR TITLE
Fix flake in repro for #14114

### DIFF
--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -293,9 +293,13 @@ describe("scenarios > collection_defaults", () => {
         cy.findByText("Child");
         cy.findByText("Parent").should("not.exist");
         cy.findByText("Browse all items").click();
-        cy.findByText("Child");
-        cy.findByText("No Collection Tableton").should("not.exist");
-        cy.findByText("Parent").should("not.exist");
+
+        sidebar().within(() => {
+          cy.findByText("Our analytics");
+          cy.findByText("Child");
+          cy.findByText("Parent").should("not.exist");
+          cy.findByText("Your personal collection");
+        });
       });
 
       it.skip("should be able to choose a child collection when saving a question (metabase#14052)", () => {


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Fixes the flake (or rather incorrect) assertion in repro for #14114

Example of this test failing in CI:
https://app.circleci.com/pipelines/github/metabase/metabase/17429/workflows/9fa55eff-16db-424b-86f4-3aa9d5201013/jobs/689853/tests#failed-test-0

### Additional context
There are multiple issues around this.
1. This flake was giving us false positives because it sometimes asserted before the whole page loaded. It should've failed **every single time** because of a regression described in #16555
2. The assertion that was added to guard against that was wrong (see [this](https://github.com/metabase/metabase/pull/16623#discussion_r652617461) comment)

I'll open a follow up PR that specifically reproduces #16555.