### PR TITLE
#16555 Repro: Collections appear in items list for user with revoked access to collections

### DIFF
--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -252,6 +252,9 @@ describe("scenarios > collection_defaults", () => {
     });
 
     describe("nested collections with revoked parent access", () => {
+      const { first_name, last_name } = nocollection;
+      const revokedUsersPersonalCollectionName = `${first_name} ${last_name}'s Personal Collection`;
+
       beforeEach(() => {
         // Create Parent collection within `Our analytics`
         cy.request("POST", "/api/collection", {
@@ -289,15 +292,10 @@ describe("scenarios > collection_defaults", () => {
       });
 
       it.skip("should not render collections in items list if user doesn't have collection access (metabase#16555)", () => {
-        const { first_name, last_name } = nocollection;
-
         cy.visit("/collection/root");
         cy.get(".ContentTable")
           .should("not.contain", "Child")
-          .and(
-            "not.contain",
-            `${first_name} ${last_name}'s Personal Collection`,
-          );
+          .and("not.contain", revokedUsersPersonalCollectionName);
       });
 
       it("should see a child collection in a sidebar even with revoked access to its parent (metabase#14114)", () => {
@@ -315,14 +313,10 @@ describe("scenarios > collection_defaults", () => {
       });
 
       it.skip("should be able to choose a child collection when saving a question (metabase#14052)", () => {
-        const { first_name, last_name } = nocollection;
-
         openOrdersTable();
         cy.findByText("Save").click();
         // Click to choose which collection should this question be saved to
-        cy.findByText(
-          `${first_name} ${last_name}'s Personal Collection`,
-        ).click();
+        cy.findByText(revokedUsersPersonalCollectionName).click();
         popover().within(() => {
           cy.findByText(/Our analytics/i);
           cy.findByText(/My personal collection/i);

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -288,6 +288,18 @@ describe("scenarios > collection_defaults", () => {
         cy.signIn("nocollection");
       });
 
+      it.skip("should not render collections in items list if user doesn't have collection access (metabase#16555)", () => {
+        const { first_name, last_name } = nocollection;
+
+        cy.visit("/collection/root");
+        cy.get(".ContentTable")
+          .should("not.contain", "Child")
+          .and(
+            "not.contain",
+            `${first_name} ${last_name}'s Personal Collection`,
+          );
+      });
+
       it("should see a child collection in a sidebar even with revoked access to its parent (metabase#14114)", () => {
         cy.visit("/");
         cy.findByText("Child");

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -293,9 +293,8 @@ describe("scenarios > collection_defaults", () => {
 
       it.skip("should not render collections in items list if user doesn't have collection access (metabase#16555)", () => {
         cy.visit("/collection/root");
-        cy.get(".ContentTable")
-          .should("not.contain", "Child")
-          .and("not.contain", revokedUsersPersonalCollectionName);
+        // Since this user doesn't have access rights to the root collection, it should render empty
+        cy.findByText("Nothing to see yet.");
       });
 
       it("should see a child collection in a sidebar even with revoked access to its parent (metabase#14114)", () => {


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #16555

### How to test this manually?
- `yarn test-cypress-open -- spec frontend/test/metabase/scenarios/collections/collections.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix
- The fix (by @howonlee ) for this issue is currently under under review process in #16562

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/122218271-8f600c80-ceae-11eb-9ebf-3d812b4399a6.png)


