### PR TITLE
[Binning e2e coverage] Group existing binning repros together

### DIFF
--- a/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
@@ -1,0 +1,96 @@
+import { restore, popover, openOrdersTable } from "__support__/e2e/cypress";
+import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
+
+const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATASET;
+
+describe("binning related reproductions", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  // This is basically covered with tests in `frontend/test/metabase/scenarios/binning/binning-options.cy.spec.js`
+  it("should not render duplicated values in date binning popover (metabase#15574)", () => {
+    openOrdersTable({ mode: "notebook" });
+    cy.findByText("Summarize").click();
+    cy.findByText("Pick a column to group by").click();
+    popover()
+      .findByText("Created At")
+      .closest(".List-item")
+      .findByText("by month")
+      .click({ force: true });
+    cy.findByText("Minute");
+  });
+
+  it("binning for a date column on a joined table should offer only a single set of values (metabase#15446)", () => {
+    cy.createQuestion({
+      name: "15446",
+      query: {
+        "source-table": ORDERS_ID,
+        joins: [
+          {
+            fields: "all",
+            "source-table": PRODUCTS_ID,
+            condition: [
+              "=",
+              ["field", ORDERS.PRODUCT_ID, null],
+              [
+                "field",
+                PRODUCTS.ID,
+                {
+                  "join-alias": "Products",
+                },
+              ],
+            ],
+            alias: "Products",
+          },
+        ],
+        aggregation: [["sum", ["field", ORDERS.TOTAL, null]]],
+      },
+    }).then(({ body: { id: QUESTION_ID } }) => {
+      cy.visit(`/question/${QUESTION_ID}/notebook`);
+    });
+    cy.findByText("Pick a column to group by").click();
+    // In the first popover we'll choose the breakout method
+    popover().within(() => {
+      cy.findByText("User").click();
+      cy.findByPlaceholderText("Find...").type("cr");
+      cy.findByText("Created At")
+        .closest(".List-item")
+        .findByText("by month")
+        .click({ force: true });
+    });
+    // The second popover shows up and offers binning options
+    popover()
+      .last()
+      .within(() => {
+        cy.findByText("Hour of day").scrollIntoView();
+        // This is an implicit assertion - test fails when there is more than one string when using `findByText` instead of `findAllByText`
+        cy.findByText("Minute").click();
+      });
+    // Given that the previous step passes, we should now see this in the UI
+    cy.findByText("User → Created At: Minute");
+  });
+});
+
+it.skip("shouldn't render double binning options when question is based on the saved native question (metabase#16327)", () => {
+  cy.createNativeQuestion({
+    name: "16327",
+    native: { query: "select * from products limit 5" },
+  });
+
+  cy.visit("/question/new");
+  cy.findByText("Custom question").click();
+  cy.findByText("Saved Questions").click();
+  cy.findByText("16327").click();
+
+  cy.findByText("Pick the metric you want to see").click();
+  cy.findByText("Count of rows").click();
+
+  cy.findByText("Pick a column to group by").click();
+  cy.findByText(/CREATED_AT/i).realHover();
+  cy.findByText("by minute").click({ force: true });
+
+  // Implicit assertion - it fails if there is more than one instance of the string, which is exactly what we need for this repro
+  cy.findByText("Month");
+});

--- a/frontend/test/metabase/scenarios/native/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/native.cy.spec.js
@@ -664,28 +664,6 @@ describe("scenarios > question > native", () => {
     cy.get("@sidebar").contains(/added/i);
   });
 
-  it.skip("shouldn't render double binning options when question is based on the saved native question (metabase#16327)", () => {
-    cy.createNativeQuestion({
-      name: "16327",
-      native: { query: "select * from products limit 5" },
-    });
-
-    cy.visit("/question/new");
-    cy.findByText("Custom question").click();
-    cy.findByText("Saved Questions").click();
-    cy.findByText("16327").click();
-
-    cy.findByText("Pick the metric you want to see").click();
-    cy.findByText("Count of rows").click();
-
-    cy.findByText("Pick a column to group by").click();
-    cy.findByText(/CREATED_AT/i).realHover();
-    cy.findByText("by minute").click({ force: true });
-
-    // Implicit assertion - it fails if there is more than one instance of the string, which is exactly what we need for this repro
-    cy.findByText("Month");
-  });
-
   ["off", "on"].forEach(testCase => {
     const isFeatureFlagTurnedOn = testCase === "off" ? false : true;
 

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -549,56 +549,6 @@ describe("scenarios > question > notebook", () => {
       cy.get(".DashCard");
     });
 
-    it("binning for a date column on a joined table should offer only a single set of values (metabase#15446)", () => {
-      cy.createQuestion({
-        name: "15446",
-        query: {
-          "source-table": ORDERS_ID,
-          joins: [
-            {
-              fields: "all",
-              "source-table": PRODUCTS_ID,
-              condition: [
-                "=",
-                ["field", ORDERS.PRODUCT_ID, null],
-                [
-                  "field",
-                  PRODUCTS.ID,
-                  {
-                    "join-alias": "Products",
-                  },
-                ],
-              ],
-              alias: "Products",
-            },
-          ],
-          aggregation: [["sum", ["field", ORDERS.TOTAL, null]]],
-        },
-      }).then(({ body: { id: QUESTION_ID } }) => {
-        cy.visit(`/question/${QUESTION_ID}/notebook`);
-      });
-      cy.findByText("Pick a column to group by").click();
-      // In the first popover we'll choose the breakout method
-      popover().within(() => {
-        cy.findByText("User").click();
-        cy.findByPlaceholderText("Find...").type("cr");
-        cy.findByText("Created At")
-          .closest(".List-item")
-          .findByText("by month")
-          .click({ force: true });
-      });
-      // The second popover shows up and offers binning options
-      popover()
-        .last()
-        .within(() => {
-          cy.findByText("Hour of day").scrollIntoView();
-          // This is an implicit assertion - test fails when there is more than one string when using `findByText` instead of `findAllByText`
-          cy.findByText("Minute").click();
-        });
-      // Given that the previous step passes, we should now see this in the UI
-      cy.findByText("User → Created At: Minute");
-    });
-
     it("should handle ad-hoc question with old syntax (metabase#15372)", () => {
       visitQuestionAdhoc({
         dataset_query: {
@@ -668,18 +618,6 @@ describe("scenarios > question > notebook", () => {
       cy.button("Add filter")
         .should("not.be.disabled")
         .click();
-    });
-
-    it("should not render duplicated values in date binning popover (metabase#15574)", () => {
-      openOrdersTable({ mode: "notebook" });
-      cy.findByText("Summarize").click();
-      cy.findByText("Pick a column to group by").click();
-      popover()
-        .findByText("Created At")
-        .closest(".List-item")
-        .findByText("by month")
-        .click({ force: true });
-      cy.findByText("Minute");
     });
   });
 


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Reorganizes the existing binning repros
- Groups them together in a single file under the newly created 'binning' CI e2e folder

### Why do this?
Making an extensive binning coverage is an ongoing process (#16387.). It is much easier to track all related tests if they "live" close to each other.
it gives better overview and reveals possible duplication in coverage.