### PR TITLE
FK table search on data model admin screen

### DIFF
--- a/frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx
@@ -257,7 +257,11 @@ export class SemanticTypeAndTargetPicker extends Component {
               className,
             )}
             placeholder={t`Select a target`}
-            searchProp="table.name"
+            searchProp={[
+              "display_name",
+              "table.display_name",
+              "table.schema_name",
+            ]}
             value={field.fk_target_field_id}
             onChange={this.handleChangeTarget}
             options={idfields}

--- a/frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx
@@ -257,7 +257,7 @@ export class SemanticTypeAndTargetPicker extends Component {
               className,
             )}
             placeholder={t`Select a target`}
-            searchProp="name"
+            searchProp="table.name"
             value={field.fk_target_field_id}
             onChange={this.handleChangeTarget}
             options={idfields}

--- a/frontend/src/metabase/components/AccordionList.jsx
+++ b/frontend/src/metabase/components/AccordionList.jsx
@@ -252,9 +252,8 @@ export default class AccordionList extends Component {
     let searchFilter = () => true;
     if (searchText) {
       searchFilter = item => {
-        let itemText = searchProp.includes(".")
-          ? String(getIn(item, searchProp.split(".")) || "")
-          : String(item[searchProp] || "");
+        const path = searchProp.split(".");
+        let itemText = String(getIn(item, path) || "");
         if (searchCaseInsensitive) {
           itemText = itemText.toLowerCase();
           searchText = searchText.toLowerCase();

--- a/frontend/src/metabase/components/AccordionList.jsx
+++ b/frontend/src/metabase/components/AccordionList.jsx
@@ -224,10 +224,10 @@ export default class AccordionList extends Component {
     this.setState({ searchText });
   };
 
-  searchPredicate = item => {
-    const { searchProp, searchCaseInsensitive, searchFuzzy } = this.props;
-    const { searchText } = this.state;
-    const path = searchProp.split(".");
+  searchPredicate = (item, searchPropMember) => {
+    const { searchCaseInsensitive, searchFuzzy } = this.props;
+    let { searchText } = this.state;
+    const path = searchPropMember.split(".");
     let itemText = String(getIn(item, path) || "");
     if (searchCaseInsensitive) {
       itemText = itemText.toLowerCase();
@@ -247,8 +247,6 @@ export default class AccordionList extends Component {
       className,
       searchable,
       searchProp,
-      searchCaseInsensitive,
-      searchFuzzy,
       sections,
       alwaysTogglable,
       alwaysExpanded,
@@ -272,7 +270,7 @@ export default class AccordionList extends Component {
           return this.searchPredicate(item);
         } else if (Array.isArray(searchProp)) {
           const searchResults = searchProp.map(member =>
-            this.searchPredicate(item),
+            this.searchPredicate(item, member),
           );
           return searchResults.reduce((acc, curr) => acc || curr);
         }

--- a/frontend/src/metabase/components/AccordionList.jsx
+++ b/frontend/src/metabase/components/AccordionList.jsx
@@ -224,13 +224,9 @@ export default class AccordionList extends Component {
     this.setState({ searchText });
   };
 
-  searchPred = (
-    item,
-    searchText,
-    searchProp,
-    searchCaseInsensitive,
-    searchFuzzy,
-  ) => {
+  searchPredicate = item => {
+    const { searchProp, searchCaseInsensitive, searchFuzzy } = this.props;
+    const { searchText } = this.state;
     const path = searchProp.split(".");
     let itemText = String(getIn(item, path) || "");
     if (searchCaseInsensitive) {
@@ -273,22 +269,10 @@ export default class AccordionList extends Component {
     if (searchText) {
       searchFilter = item => {
         if (typeof searchProp === "string") {
-          return this.searchPred(
-            item,
-            searchText,
-            searchProp,
-            searchCaseInsensitive,
-            searchFuzzy,
-          );
-        } else if (searchProp.constructor === Array) {
+          return this.searchPredicate(item);
+        } else if (Array.isArray(searchProp)) {
           const searchResults = searchProp.map(member =>
-            this.searchPred(
-              item,
-              searchText,
-              member,
-              searchCaseInsensitive,
-              searchFuzzy,
-            ),
+            this.searchPredicate(item),
           );
           return searchResults.reduce((acc, curr) => acc || curr);
         }

--- a/frontend/src/metabase/components/AccordionList.jsx
+++ b/frontend/src/metabase/components/AccordionList.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 
 import cx from "classnames";
 import _ from "underscore";
+import { getIn } from "icepick";
 import { color } from "metabase/lib/colors";
 
 import Icon from "metabase/components/Icon";
@@ -223,17 +224,6 @@ export default class AccordionList extends Component {
     this.setState({ searchText });
   };
 
-  getInItem = (item, searchProp) => {
-    const props = searchProp.split(".");
-    let res = null;
-    let currItem = item;
-    for (const prop of props) {
-      res = currItem[prop];
-      currItem = currItem[prop];
-    }
-    return String(res || "");
-  };
-
   render() {
     const {
       id,
@@ -263,7 +253,7 @@ export default class AccordionList extends Component {
     if (searchText) {
       searchFilter = item => {
         let itemText = searchProp.includes(".")
-          ? this.getInItem(item, searchProp)
+          ? String(getIn(item, searchProp.split(".")) || "")
           : String(item[searchProp] || "");
         if (searchCaseInsensitive) {
           itemText = itemText.toLowerCase();

--- a/frontend/src/metabase/components/AccordionList.jsx
+++ b/frontend/src/metabase/components/AccordionList.jsx
@@ -267,7 +267,7 @@ export default class AccordionList extends Component {
     if (searchText) {
       searchFilter = item => {
         if (typeof searchProp === "string") {
-          return this.searchPredicate(item);
+          return this.searchPredicate(item, searchProp);
         } else if (Array.isArray(searchProp)) {
           const searchResults = searchProp.map(member =>
             this.searchPredicate(item, member),

--- a/frontend/src/metabase/components/AccordionList.jsx
+++ b/frontend/src/metabase/components/AccordionList.jsx
@@ -223,6 +223,17 @@ export default class AccordionList extends Component {
     this.setState({ searchText });
   };
 
+  getInItem = (item, searchProp) => {
+    const props = searchProp.split(".");
+    let res = null;
+    let currItem = item;
+    for (const prop of props) {
+      res = currItem[prop];
+      currItem = currItem[prop];
+    }
+    return String(res || "");
+  };
+
   render() {
     const {
       id,
@@ -251,7 +262,9 @@ export default class AccordionList extends Component {
     let searchFilter = () => true;
     if (searchText) {
       searchFilter = item => {
-        let itemText = String(item[searchProp] || "");
+        let itemText = searchProp.includes(".")
+          ? this.getInItem(item, searchProp)
+          : String(item[searchProp] || "");
         if (searchCaseInsensitive) {
           itemText = itemText.toLowerCase();
           searchText = searchText.toLowerCase();


### PR DESCRIPTION
Pursuant to #13025.

Annoying thing that prevents you from just setting a param and being done with it is that the searches couldn't reach in deep within items in accordionlist search. So now they can also do that, and _then_ I just set a param and be done with it