### PR TITLE
#16379 Repro: Selecting bin count on intermediate data question fails

### DIFF
--- a/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
@@ -71,26 +71,26 @@ describe("binning related reproductions", () => {
     // Given that the previous step passes, we should now see this in the UI
     cy.findByText("User → Created At: Minute");
   });
-});
 
-it.skip("shouldn't render double binning options when question is based on the saved native question (metabase#16327)", () => {
-  cy.createNativeQuestion({
-    name: "16327",
-    native: { query: "select * from products limit 5" },
+  it.skip("shouldn't render double binning options when question is based on the saved native question (metabase#16327)", () => {
+    cy.createNativeQuestion({
+      name: "16327",
+      native: { query: "select * from products limit 5" },
+    });
+
+    cy.visit("/question/new");
+    cy.findByText("Custom question").click();
+    cy.findByText("Saved Questions").click();
+    cy.findByText("16327").click();
+
+    cy.findByText("Pick the metric you want to see").click();
+    cy.findByText("Count of rows").click();
+
+    cy.findByText("Pick a column to group by").click();
+    cy.findByText(/CREATED_AT/i).realHover();
+    cy.findByText("by minute").click({ force: true });
+
+    // Implicit assertion - it fails if there is more than one instance of the string, which is exactly what we need for this repro
+    cy.findByText("Month");
   });
-
-  cy.visit("/question/new");
-  cy.findByText("Custom question").click();
-  cy.findByText("Saved Questions").click();
-  cy.findByText("16327").click();
-
-  cy.findByText("Pick the metric you want to see").click();
-  cy.findByText("Count of rows").click();
-
-  cy.findByText("Pick a column to group by").click();
-  cy.findByText(/CREATED_AT/i).realHover();
-  cy.findByText("by minute").click({ force: true });
-
-  // Implicit assertion - it fails if there is more than one instance of the string, which is exactly what we need for this repro
-  cy.findByText("Month");
 });


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #16379 

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js`
- Replace `describe.skip()` with `describe.only()` to run tests in isolation
- Both tests should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure both tests are passing and
- Merge it together with the fix

### Screenshots:

Simple question
![image](https://user-images.githubusercontent.com/31325167/122267953-c4368880-cedb-11eb-8dec-71523de423d1.png)

Custom question
![image](https://user-images.githubusercontent.com/31325167/122267890-b4b73f80-cedb-11eb-869e-926ae1c85f36.png)

