### PR TITLE
Pass along `redirect` URL search parameter in Google auth to email/password form

### DIFF
--- a/frontend/src/metabase/auth/containers/LoginApp.jsx
+++ b/frontend/src/metabase/auth/containers/LoginApp.jsx
@@ -9,6 +9,9 @@ import AuthLayout from "metabase/auth/components/AuthLayout";
 
 import { getAuthProviders } from "../selectors";
 
+const buildLinkURL = ({ Panel, name }) =>
+  Panel && `/auth/login/${name}${location.search}`;
+
 const mapStateToProps = (state, props) => ({
   providers: getAuthProviders(state, props),
 });
@@ -33,7 +36,7 @@ export default class LoginApp extends Component {
             {visibleProviders.map(provider => (
               <Link
                 key={provider.name}
-                to={provider.Panel ? `/auth/login/${provider.name}` : null}
+                to={buildLinkURL(provider)}
                 className="mt2 block"
               >
                 <provider.Button {...this.props} />

--- a/frontend/test/metabase/scenarios/onboarding/auth/sso.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/auth/sso.cy.spec.js
@@ -3,6 +3,9 @@ import {
   restore,
   mockCurrentUserProperty,
 } from "__support__/e2e/cypress";
+import { USERS } from "__support__/e2e/cypress_data";
+
+const { admin } = USERS;
 
 describe("scenarios > auth > signin > SSO", () => {
   beforeEach(() => {
@@ -48,6 +51,16 @@ describe("scenarios > auth > signin > SSO", () => {
       cy.button("Sign in").click();
       cy.contains("Password: did not match stored password");
     });
+
+    it("should pass `redirect` search params from Google button screen to email/password screen (metabase#16216)", () => {
+      const loginProtectedURL = "/admin/permissions/databases";
+
+      cy.visit(loginProtectedURL);
+      cy.findByText("Sign in with email").click();
+      fillInAuthForm();
+
+      cy.url().should("include", loginProtectedURL);
+    });
   });
 
   describeWithToken("EE", () => {
@@ -66,3 +79,9 @@ describe("scenarios > auth > signin > SSO", () => {
     });
   });
 });
+
+const fillInAuthForm = () => {
+  cy.findByLabelText("Email address").type(admin.email);
+  cy.findByLabelText("Password").type(admin.password);
+  cy.findByText("Sign in").click();
+};


### PR DESCRIPTION
Fixes #16216 

Assumption: SSO is enabled.

## How to Test

#### Preparation

1. Copy the URL of any auth-protected page in our app to your clipboard — for example, a question, dashboard, or collection.

#### Enable SSO authentication

1. Go to Admin
2. On the left menu, click `Authentication`
3. In the section titled `Sign in with Google`, click `Configure`
4. Add any string to the `Client ID` input
5. Click `Save Changes`

#### Sign out and sign in using the redirect search parameter

1. Sign Out of Metabase
2. Try to go to the URL you have on your clipboard
3. You should now see the Google authentication button
4. Note that the URL has a query parameter: `?redirect=……`
5. Click on `Sign in with email`
6. Note that URL keeps the `redirect` query param.
7. Now if you log in, you will land in the URL you wanted initially.

