### PR TITLE
Confirm whole date does not appear when aggregating by hour of day when field semantic type is null

### DIFF
--- a/frontend/test/metabase/scenarios/admin/datamodel/metadata.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/metadata.cy.spec.js
@@ -80,7 +80,7 @@ describe("scenarios > admin > datamodel > metadata", () => {
     });
   });
 
-  it.skip("should not include date when metric is binned by hour of day (metabase#14124)", () => {
+  it("should not include date when metric is binned by hour of day (metabase#14124)", () => {
     cy.request("PUT", `/api/field/${ORDERS.CREATED_AT}`, {
       semantic_type: null,
     });
@@ -91,7 +91,7 @@ describe("scenarios > admin > datamodel > metadata", () => {
         "source-table": ORDERS_ID,
         aggregation: [["count"]],
         breakout: [
-          ["field", ORDERS.CREATED_AT.id, { "temporal-unit": "hour-of-day" }],
+          ["field", ORDERS.CREATED_AT, { "temporal-unit": "hour-of-day" }],
         ],
       },
     }).then(({ body: { id: QUESTION_ID } }) => {


### PR DESCRIPTION
Pursuant to #14124. Apparently the magic fairy dust got in there and fixed it between v0.37 and v0.40 and I'm just enabling the test and fixing a bug in the tests