### PR TITLE
don't apply parameter filters to object queries

### DIFF
--- a/frontend/src/metabase/lib/urls.js
+++ b/frontend/src/metabase/lib/urls.js
@@ -49,6 +49,10 @@ export function question(card, hash = "", query = "") {
   return `${path}${query}${hash}`;
 }
 
+export function serializedQuestion(card) {
+  return question(null, card);
+}
+
 export const extractQueryParams = (query: Object): Array => {
   return [].concat(...Object.entries(query).map(flattenParam));
 };

--- a/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
@@ -334,7 +334,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
     });
   });
 
-  it.skip("should drill-through on a foreign key (metabase#8055)", () => {
+  it("should drill-through on a foreign key (metabase#8055)", () => {
     // In this test we're using already present dashboard ("Orders in a dashboard")
     const FILTER_ID = "7c9ege62";
 

--- a/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
@@ -582,7 +582,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
     });
   });
 
-  it.skip('should drill-through on PK/FK to the "object detail" when filtered by explicit joined column (metabase#15331)', () => {
+  it('should drill-through on PK/FK to the "object detail" when filtered by explicit joined column (metabase#15331)', () => {
     cy.server();
     cy.route("POST", "/api/dataset").as("dataset");
 


### PR DESCRIPTION
Fixes #15331
Fixes #8055 

Added logic to stop applying parameter filters to queries where we'll be navigating to a details view. The param filters break the query.

vid of the fix:

https://user-images.githubusercontent.com/13057258/122285075-1dce9100-cea3-11eb-95f4-eff80f6298d1.mov


