### PR TITLE
fix trend visualization is not visible if the first column is not date

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx
@@ -4,6 +4,7 @@ import { Box, Flex } from "grid-styled";
 import { t, jt } from "ttag";
 import _ from "underscore";
 
+import { isDate } from "metabase/lib/schema_metadata";
 import { formatNumber, formatValue } from "metabase/lib/formatting";
 import { color } from "metabase/lib/colors";
 
@@ -93,8 +94,8 @@ export default class Smart extends React.Component {
       rawSeries,
     } = this.props;
 
-    const metricIndex = 1;
-    const dimensionIndex = 0;
+    const metricIndex = _.findIndex(cols, col => !isDate(col));
+    const dimensionIndex = _.findIndex(cols, isDate);
 
     const lastRow = rows[rows.length - 1];
     const value = lastRow && lastRow[metricIndex];

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx
@@ -94,8 +94,8 @@ export default class Smart extends React.Component {
       rawSeries,
     } = this.props;
 
-    const metricIndex = _.findIndex(cols, col => !isDate(col));
-    const dimensionIndex = _.findIndex(cols, isDate);
+    const metricIndex = cols.findIndex(col => !isDate(col));
+    const dimensionIndex = cols.findIndex(col => isDate(col));
 
     const lastRow = rows[rows.length - 1];
     const value = lastRow && lastRow[metricIndex];

--- a/frontend/test/metabase/scenarios/question/new.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/new.cy.spec.js
@@ -397,7 +397,7 @@ describe("scenarios > question > new", () => {
       cy.findByText("Hour of day").click();
     });
 
-    it("trend visualization should work regardless of column order (metabase#13710)", () => {
+    it.skip("trend visualization should work regardless of column order (metabase#13710)", () => {
       cy.server();
       cy.createQuestion({
         name: "13710",

--- a/frontend/test/metabase/scenarios/question/new.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/new.cy.spec.js
@@ -397,7 +397,7 @@ describe("scenarios > question > new", () => {
       cy.findByText("Hour of day").click();
     });
 
-    it.skip("trend visualization should work regardless of column order (metabase#13710)", () => {
+    it("trend visualization should work regardless of column order (metabase#13710)", () => {
       cy.server();
       cy.createQuestion({
         name: "13710",


### PR DESCRIPTION
Partial fix for https://github.com/metabase/metabase/issues/13710

Check the original issue for repro.
Trend visualization assumed that the dimension column index (date column) should be `0` and the metric column index should be `1`. I changed this by finding the first date column to be dimension and the first non-date column to be metric.

This PR partially fixes the issue: the chart is rendered, however, it renders incorrect data returned from the BE in the `insights` prop. That is the reason why spec is still skipped.