### PR TITLE
[Binning e2e coverage] Number Correctness

### DIFF
--- a/frontend/test/metabase/scenarios/binning/correctness/number.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/correctness/number.cy.spec.js
@@ -1,0 +1,94 @@
+import { restore, popover, openOrdersTable } from "__support__/e2e/cypress";
+
+const foo = {
+  "Auto bin": {
+    selected: "Auto binned",
+    representativeValues: ["-60", "0", "20", "40", "100", "160"],
+  },
+  "10 bins": {
+    selected: "10 bins",
+    representativeValues: ["-50", "-40", "-10", "0", "10", "100", "150", "160"],
+  },
+  "50 bins": {
+    selected: "50 bins",
+    representativeValues: ["-50", "0", "50", "100", "150", "200"],
+  },
+  "100 bins": {
+    selected: "100 bins",
+    representativeValues: ["-100", "0", "100", "200"],
+  },
+};
+
+describe("scenarios > binning > correctness > number", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+    openOrdersTable();
+    cy.findByText("Summarize").click();
+    openPopoverFromSelectedBinningOption("Total", "Auto bin");
+  });
+
+  Object.entries(foo).forEach(
+    ([bucketSize, { selected, representativeValues }]) => {
+      it(`should return correct values for ${bucketSize}`, () => {
+        // Wrong values are returned for everything except "auto bin", and even that is questionable how it should work
+        cy.onlyOn(bucketSize === "Auto bin");
+
+        popover().within(() => {
+          cy.findByText(bucketSize).click();
+        });
+
+        getTitle(`Count by Total: ${selected}`);
+        cy.get(".bar");
+
+        assertOnXYAxisLabels();
+
+        cy.get(".axis.x").within(() => {
+          representativeValues.forEach(value => {
+            cy.findByText(value);
+          });
+        });
+      });
+    },
+  );
+
+  it("Don't bin", () => {
+    popover().within(() => {
+      cy.findByText("Don't bin").click();
+    });
+    getTitle("Count by Total");
+
+    cy.get(".cellData")
+      .should("contain", "Total")
+      .and("contain", "Count")
+      .and("contain", "-45.47");
+  });
+});
+
+function openPopoverFromSelectedBinningOption(column, binning) {
+  cy.findByTestId("sidebar-right")
+    .contains(column)
+    .first()
+    .closest(".List-item")
+    .should("be.visible")
+    .as("targetListItem");
+
+  cy.get("@targetListItem")
+    .find(".Field-extra")
+    .as("listItemSelectedBinning")
+    .should("contain", binning)
+    .click();
+}
+
+function getTitle(title) {
+  cy.findByText(title);
+}
+
+function assertOnXYAxisLabels() {
+  cy.get(".y-axis-label")
+    .invoke("text")
+    .should("eq", "Count");
+  cy.get(".x-axis-label")
+    .invoke("text")
+    .should("eq", "Total");
+}

--- a/frontend/test/metabase/scenarios/binning/correctness/number.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/correctness/number.cy.spec.js
@@ -1,6 +1,17 @@
 import { restore, popover, openOrdersTable } from "__support__/e2e/cypress";
 
-const foo = {
+/**
+ * We're going to use Orders `Total` column for this test.
+ *
+ * Values for this column range from:
+ *  MIN: `-45.47` to
+ *  MAX: `159.35`
+ *
+ * This is important info for determining the minimum and the maximum values for x-axis.
+ * That, of course, depends on the chosen bucket size.
+ */
+
+const NUMBER_OPTIONS = {
   "Auto bin": {
     selected: "Auto binned",
     representativeValues: ["-60", "0", "20", "40", "100", "160"],
@@ -28,10 +39,11 @@ describe("scenarios > binning > correctness > number", () => {
     openPopoverFromSelectedBinningOption("Total", "Auto bin");
   });
 
-  Object.entries(foo).forEach(
+  Object.entries(NUMBER_OPTIONS).forEach(
     ([bucketSize, { selected, representativeValues }]) => {
       it(`should return correct values for ${bucketSize}`, () => {
-        // Wrong values are returned for everything except "auto bin", and even that is questionable how it should work
+        // Wrong values are returned for everything except "Auto bin", and even that is questionable how it should work.
+        // Delete the following conditional logic when the related issue gets fixed.
         cy.onlyOn(bucketSize === "Auto bin");
 
         popover().within(() => {


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Adds PoC for the set of tests that make sure correct values are rendered for number binning

### Screenshots

The current state of tests
![image](https://user-images.githubusercontent.com/31325167/122295842-fe168780-cef9-11eb-8a47-abcb43d1ed71.png)

Auto bin (can't really make an educated assertion on this because it's "auto", but it feels wrong that we have `-60`, and then jump straight to `0`)
![image](https://user-images.githubusercontent.com/31325167/122295899-0e2e6700-cefa-11eb-883d-cfaa01abee4e.png)

10 bins (renders completely incorrectly - renders buckets in increments of 20)
![image](https://user-images.githubusercontent.com/31325167/122296017-30c08000-cefa-11eb-9c22-9f3e7622cdde.png)

50 bins (goes even more granular than the 10 bins and renders buckets in increments of 5)
![image](https://user-images.githubusercontent.com/31325167/122296103-4fbf1200-cefa-11eb-9b3b-0f0062999ad3.png)

100 bins (renders buckets in increment of 2)
![image](https://user-images.githubusercontent.com/31325167/122296352-990f6180-cefa-11eb-97c4-6bd1d7de0932.png)

Don't bin (seems to be the only one that renders correctly)
![image](https://user-images.githubusercontent.com/31325167/122296426-acbac800-cefa-11eb-9cef-f6e6aef31f04.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/16640)
<!-- Reviewable:end -->
