### PR TITLE
Localization also works already without reference to null semantic type, here is test to memorialize this

### DIFF
--- a/frontend/test/metabase/scenarios/admin/settings/localization.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/localization.cy.spec.js
@@ -3,7 +3,7 @@ import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATASET;
 
-describe("scenarios > admin > permissions", () => {
+describe("scenarios > admin > localization", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();

--- a/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
@@ -4,6 +4,9 @@ import {
   version,
   popover,
 } from "__support__/e2e/cypress";
+import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
+
+const { ORDERS } = SAMPLE_DATASET;
 
 describe("scenarios > admin > settings", () => {
   beforeEach(() => {
@@ -182,6 +185,29 @@ describe("scenarios > admin > settings", () => {
     // check the reset formatting in a question
     openOrdersTable();
     cy.contains(/^February 11, 2019, 9:40 PM$/);
+  });
+
+  it.only("should correctly apply the globalized date formats (metabase#11394)", () => {
+    cy.server();
+    cy.route("PUT", "**/custom-formatting").as("saveFormatting");
+
+    cy.request("PUT", `/api/field/${ORDERS.CREATED_AT}`, {
+      semantic_type: null,
+    });
+
+    cy.visit("/admin/settings/localization");
+
+    cy.contains("Date style")
+      .closest("li")
+      .find(".AdminSelect")
+      .first()
+      .click();
+    cy.findByText("2018/1/7").click();
+    cy.contains("17:24 (24-hour clock)").click();
+    cy.wait("@saveFormatting");
+
+    openOrdersTable();
+    cy.contains(/^2019\/2\/11, 21:40$/);
   });
 
   it("should search for and select a new timezone", () => {

--- a/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
@@ -187,7 +187,7 @@ describe("scenarios > admin > settings", () => {
     cy.contains(/^February 11, 2019, 9:40 PM$/);
   });
 
-  it.only("should correctly apply the globalized date formats (metabase#11394)", () => {
+  it("should correctly apply the globalized date formats (metabase#11394)", () => {
     cy.server();
     cy.route("PUT", "**/custom-formatting").as("saveFormatting");
 


### PR DESCRIPTION
Pursuant to #11394. It seems that #11394 was fixed also in 0.39 without anyone noting it in the issue tracker just like #14124, so I guess at least here's a test to memorialize this and prevent regressions. It was noted also previously that 24-hour format doesn't work but I cannot repro and the test passes.