### PR TITLE
Data picker search: do not complain on empty string

### DIFF
--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -709,7 +709,7 @@ export class UnconnectedDataSelector extends Component {
     const { canChangeDatabase, selectedDatabaseId } = this.props;
     const searchDatabaseId = canChangeDatabase ? null : selectedDatabaseId;
 
-    const isSearchActive = searchText.length >= MIN_SEARCH_LENGTH;
+    const isSearchActive = searchText.trim().length >= MIN_SEARCH_LENGTH;
 
     return (
       <PopoverWithTrigger
@@ -737,7 +737,7 @@ export class UnconnectedDataSelector extends Component {
         )}
         {isSearchActive && (
           <SearchResults
-            searchQuery={searchText}
+            searchQuery={searchText.trim()}
             databaseId={searchDatabaseId}
             onSelect={this.handleSearchItemSelect}
           />

--- a/frontend/test/metabase/scenarios/question/new.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/new.cy.spec.js
@@ -146,6 +146,14 @@ describe("scenarios > question > new", () => {
         cy.findByText("Orders");
       });
     });
+
+    it("should ignore an empty search string", () => {
+      cy.intercept("/api/search", req => {
+        expect("Unexpected call to /api/search").to.be.false;
+      });
+      cy.findByText("Custom question").click();
+      cy.findByPlaceholderText("Search for a table...").type("  ");
+    });
   });
 
   describe("ask a (simple) question", () => {


### PR DESCRIPTION
Prevent a confusing error message when the search term is empty. See also PR ##16251.

Steps to try:
1. Ask a question, Simple or Custom question
2. In the field (_Search for a table_), press spacebar at least 2x

**Before this PR**

![image](https://user-images.githubusercontent.com/7288/122297834-d7802e80-ceb0-11eb-8672-0b158a98178b.png)

**After this PR**

No search happens, since practically the search term is empty.

![image](https://user-images.githubusercontent.com/7288/122297842-da7b1f00-ceb0-11eb-988d-fc0130fcc6f0.png)

