### PR TITLE
expose error in UI when database GET fails

### DIFF
--- a/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx
@@ -20,7 +20,11 @@ import ModalWithTrigger from "metabase/components/ModalWithTrigger";
 
 import Databases from "metabase/entities/databases";
 
-import { getEditingDatabase, getDatabaseCreationStep } from "../selectors";
+import {
+  getEditingDatabase,
+  getDatabaseCreationStep,
+  getInitializeError,
+} from "../selectors";
 
 import {
   reset,
@@ -51,6 +55,7 @@ const mapStateToProps = (state, props) => {
     selectedEngine: formValues ? formValues.engine : undefined,
     letUserControlSchedulingSaved: getLetUserControlScheduling(database),
     letUserControlSchedulingForm: getLetUserControlScheduling(formValues),
+    initializeError: getInitializeError(state),
   };
 };
 
@@ -136,6 +141,7 @@ export default class DatabaseEditApp extends Component {
       selectedEngine,
       letUserControlSchedulingSaved,
       letUserControlSchedulingForm,
+      initializeError,
     } = this.props;
     const { currentTab } = this.state;
     const editingExistingDatabase = database && database.id != null;
@@ -167,7 +173,10 @@ export default class DatabaseEditApp extends Component {
               )}
               <Flex>
                 <Box w={620}>
-                  <LoadingAndErrorWrapper loading={!database} error={null}>
+                  <LoadingAndErrorWrapper
+                    loading={!database}
+                    error={initializeError}
+                  >
                     {() => (
                       <Databases.Form
                         database={database}

--- a/frontend/src/metabase/admin/databases/database.js
+++ b/frontend/src/metabase/admin/databases/database.js
@@ -70,7 +70,10 @@ export const DELETE_DATABASE_FAILED =
   "metabase/admin/databases/DELETE_DATABASE_FAILED";
 export const MIGRATE_TO_NEW_SCHEDULING_SETTINGS =
   "metabase/admin/databases/MIGRATE_TO_NEW_SCHEDULING_SETTINGS";
-
+export const INITIALIZE_DATABASE_ERROR =
+  "metabase/admin/databases/INITIALIZE_DATABASE_ERROR";
+export const CLEAR_INITIALIZE_DATABASE_ERROR =
+  "metabase/admin/databases/CLEAR_INITIALIZE_DATABASE_ERROR";
 // NOTE: some but not all of these actions have been migrated to use metabase/entities/databases
 
 export const reset = createAction(RESET);
@@ -103,6 +106,8 @@ const migrateDatabaseToNewSchedulingSettings = database => {
 // initializeDatabase
 export const initializeDatabase = function(databaseId) {
   return async function(dispatch, getState) {
+    dispatch.action(CLEAR_INITIALIZE_DATABASE_ERROR);
+
     if (databaseId) {
       try {
         const action = await dispatch(
@@ -116,11 +121,8 @@ export const initializeDatabase = function(databaseId) {
           dispatch(migrateDatabaseToNewSchedulingSettings(database));
         }
       } catch (error) {
-        if (error.status === 404) {
-          //$location.path('/admin/databases/');
-        } else {
-          console.error("error fetching database", databaseId, error);
-        }
+        console.error("error fetching database", databaseId, error);
+        dispatch.action(INITIALIZE_DATABASE_ERROR, error);
       }
     } else {
       const newDatabase = {
@@ -326,6 +328,14 @@ const editingDatabase = handleActions(
   null,
 );
 
+const initializeError = handleActions(
+  {
+    [INITIALIZE_DATABASE_ERROR]: (state, { payload }) => payload,
+    [CLEAR_INITIALIZE_DATABASE_ERROR]: () => null,
+  },
+  null,
+);
+
 const deletes = handleActions(
   {
     [DELETE_DATABASE_STARTED]: (state, { payload: { databaseId } }) =>
@@ -364,6 +374,7 @@ const sampleDataset = handleActions(
 
 export default combineReducers({
   editingDatabase,
+  initializeError,
   deletionError,
   databaseCreationStep,
   deletes,

--- a/frontend/src/metabase/admin/databases/selectors.js
+++ b/frontend/src/metabase/admin/databases/selectors.js
@@ -12,3 +12,6 @@ export const getIsAddingSampleDataset = state =>
   state.admin.databases.sampleDataset.loading;
 export const getAddSampleDatasetError = state =>
   state.admin.databases.sampleDataset.error;
+
+export const getInitializeError = state =>
+  state.admin.databases.initializeError;


### PR DESCRIPTION
Fixes #11037 

I'm using Requestly to quickly repro this by redirecting the `/api/database/1` request to an endpoint that does not exist.

Here's a vid showing how to use requestly + the fix

https://user-images.githubusercontent.com/13057258/122304754-95f48100-ceba-11eb-9243-68baa14c01b1.mov

