### PR TITLE
Fix questions used in SQL query aren't linked correctly from variables sidebar

### DIFF
--- a/frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx
@@ -27,6 +27,11 @@ export default class CardTagEditor extends Component {
     this._popover && this._popover.close();
   };
 
+  getQuestionUrl() {
+    const { tag, question } = this.props;
+    return Urls.question(question || { id: tag["card-id"] });
+  }
+
   errorMessage() {
     const { error, question, query } = this.props;
 
@@ -78,9 +83,7 @@ export default class CardTagEditor extends Component {
           {cardId == null ? (
             t`Question #…`
           ) : (
-            <Link
-              to={Urls.question(question ? question : { id: cardId })}
-            >{t`Question #${cardId}`}</Link>
+            <Link to={this.getQuestionUrl()}>{t`Question #${cardId}`}</Link>
           )}
         </h3>
         {loading ? (

--- a/frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx
@@ -10,7 +10,7 @@ import SelectButton from "metabase/components/SelectButton";
 import LoadingSpinner from "metabase/components/LoadingSpinner";
 
 import Questions from "metabase/entities/questions";
-import { question as questionUrl } from "metabase/lib/urls";
+import * as Urls from "metabase/lib/urls";
 import { formatDateTimeWithUnit } from "metabase/lib/formatting";
 import MetabaseSettings from "metabase/lib/settings";
 
@@ -78,7 +78,9 @@ export default class CardTagEditor extends Component {
           {cardId == null ? (
             t`Question #…`
           ) : (
-            <Link to={questionUrl(cardId)}>{t`Question #${cardId}`}</Link>
+            <Link
+              to={Urls.question(question ? question : { id: cardId })}
+            >{t`Question #${cardId}`}</Link>
           )}
         </h3>
         {loading ? (

--- a/frontend/test/metabase/scenarios/native/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/native.cy.spec.js
@@ -724,9 +724,9 @@ describe("scenarios > question > native", () => {
     });
   });
 
-  it.skip("should link correctly from the variables sidebar (metabase#16212)", () => {
+  it("should link correctly from the variables sidebar (metabase#16212)", () => {
     cy.createNativeQuestion({
-      name: "16212",
+      name: "test-question",
       native: { query: 'select 1 as "a", 2 as "b"' },
     }).then(({ body: { id: questionId } }) => {
       cy.visit("/");
@@ -743,7 +743,7 @@ describe("scenarios > question > native", () => {
       });
       cy.findByRole("link", { name: `Question #${questionId}` })
         .should("have.attr", "href")
-        .and("eq", `/question/${questionId}`);
+        .and("eq", `/question/${questionId}-test-question`);
     });
   });
 });


### PR DESCRIPTION
Users can reference another question inside a SQL query like `{{ #4 }}`, where `4` is the question's ID. Native query editor has a sidebar displaying a list of referenced questions. The problem is we don't display correct links for them. E.g. a link to question with ID = 4 points to `/question`, however `/question-4` is expected

It's a regression appeared after implementing entity URL slugs (#15989)

Closes #16212

### To Verify

1. Create a native question like `select 1 as "a", 2 as "b"` and remember its ID. Let's say it's `4`
2. Create a new native question, paste `{{ #4 }}` inside the editor, and click "Visualize"
3. Click the "X" icon in the right part of the SQL editor
4. Click "Question #4"
5. You should be navigated to `/question/4` (with a slugified question name in the URL)

### Demo


https://user-images.githubusercontent.com/17258145/122422509-dffe6500-cf95-11eb-9dbd-cdb72141ee57.mov

