### PR TITLE
Do not let boolean literals break standard filter

### DIFF
--- a/frontend/src/metabase/lib/query/filter.js
+++ b/frontend/src/metabase/lib/query/filter.js
@@ -78,8 +78,10 @@ export function isStandard(filter: FilterClause): boolean {
     return false;
   }
 
+  const isStandardLiteral = arg => isLiteral(arg) || typeof arg === "boolean";
+
   // undefined args represents an incomplete filter (still standard, but not valid)
-  const isLiteralOrUndefined = arg => (arg ? isLiteral(arg) : true);
+  const isLiteralOrUndefined = arg => (arg ? isStandardLiteral(arg) : true);
 
   const [op, field, ...args] = filter;
 

--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -1134,7 +1134,7 @@ describe("scenarios > question > filter", () => {
     // We must use and return strings instead of boolean and numbers
     const integerAssociatedWithCondition = condition === "true" ? "0" : "1";
 
-    describe.skip(`should be able to filter on the boolean column ${condition.toUpperCase()} (metabase#16386)`, () => {
+    describe(`should be able to filter on the boolean column ${condition.toUpperCase()} (metabase#16386)`, () => {
       beforeEach(() => {
         cy.createNativeQuestion({
           name: "16386",


### PR DESCRIPTION
This shall fix #16386, as restoring the behavior of 39.

Strictly speaking we do not support boolean literals in custom expressions. However, standard filters should be still working, e.g. to filter on a column of the type boolean.

Run the E2E tests:
```
yarn test-cypress-no-build --spec frontend/test/metabase/scenarios/question/filter.cy.spec.js
```

Steps to try:
1. Ask a question, Native question
2. In the SQL editor, type the following:
```
select 0::integer as "integer", true::boolean AS "boolean"
union all
select 1::integer as "integer", false::boolean AS "boolean"
union all
select null as "integer", true::boolean AS "boolean"
union all
select -1::integer as "integer", null AS "boolean"
```
3. Click _Explore results_ button (top right)
4. Click on the _boolean_ column, choose Filter by this Column

**Before this PR**

Nothing happens. Upon inspecting browser console, there is this error:
```
format.js:60 Uncaught Error: Unknown MBQL clause true
```

**After this PR**

![image](https://user-images.githubusercontent.com/7288/122453374-22587f80-cf5f-11eb-88bc-1aeb49f5d7ef.png)


Just like in 39, the popup should facilitate True vs False filtering. Note the incorrect/cut-off render, I believe it's a separate issue (and I will track it down).





