### PR TITLE
adjust row bar chart appearance

### DIFF
--- a/frontend/src/metabase/visualizations/lib/RowRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/RowRenderer.js
@@ -176,7 +176,8 @@ export default function rowRenderer(
   // assume all bars are same height?
   const barHeight = chart.select("g.row")[0][0].getBoundingClientRect().height;
   if (barHeight > ROW_MAX_HEIGHT) {
-    chart.fixedBarHeight(ROW_MAX_HEIGHT);
+    const reasolableMaxGap = containerHeight / 3;
+    chart.gap(Math.min(barHeight / 2, reasolableMaxGap));
   }
 
   chart.render();


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/13769

Row bar chart limits max bar height to `30px` which leads to a lot of empty space on charts with just a few bars:
<img width="1399" alt="before" src="https://user-images.githubusercontent.com/15974735/98995558-59a51080-24e6-11eb-80ba-bb3511b7573d.png">

Important discussion from the previous attempt to fix: https://github.com/metabase/metabase/pull/14104#discussion_r544723674

We do not want much empty space or thick bars. Because of that I just adjusted the gap so that it looks proportional with the bar height.

**After:**
5 rows:
<img width="1399" alt="Screen Shot 2021-06-17 at 22 18 41" src="https://user-images.githubusercontent.com/14301985/122460514-de936380-cfba-11eb-843d-26bfbb77f002.png">

4 rows:
<img width="1414" alt="Screen Shot 2021-06-17 at 22 18 58" src="https://user-images.githubusercontent.com/14301985/122460571-f10d9d00-cfba-11eb-888b-941dcfcb5a95.png">

3 rows:
<img width="1429" alt="Screen Shot 2021-06-17 at 22 19 10" src="https://user-images.githubusercontent.com/14301985/122460600-fb2f9b80-cfba-11eb-8b99-531d4192abe3.png">

2 rows:
<img width="1414" alt="Screen Shot 2021-06-17 at 22 19 22" src="https://user-images.githubusercontent.com/14301985/122460607-fff44f80-cfba-11eb-962d-6e8681df2572.png">

1 row:
<img width="1437" alt="Screen Shot 2021-06-17 at 22 21 31" src="https://user-images.githubusercontent.com/14301985/122460631-084c8a80-cfbb-11eb-9075-342b4cfdfeb3.png">

