### PR TITLE
Styling series separate-like #13095

### DIFF
--- a/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
@@ -377,7 +377,7 @@ function onRender(
     xInterval,
     yAxisSplit,
     isStacked,
-    formatYValue,
+    formatYValues,
     datas,
   },
 ) {
@@ -389,7 +389,7 @@ function onRender(
   onRenderEnableDots(chart);
   onRenderVoronoiHover(chart);
   onRenderCleanupGoalAndTrend(chart, onGoalHover, isSplitAxis); // do this before hiding x-axis
-  onRenderValueLabels(chart, { formatYValue, xInterval, yAxisSplit, datas });
+  onRenderValueLabels(chart, { formatYValues, xInterval, yAxisSplit, datas });
   onRenderHideDisabledLabels(chart);
   onRenderHideDisabledAxis(chart);
   onRenderHideBadAxis(chart);

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -899,8 +899,8 @@ export default function lineAreaBar(
     });
   });
 
-  const formatYValues = yAxisProps.yExtents.map(extent =>
-    getYValueFormatter(parent, series, extent),
+  const formatYValues = yAxisProps.yExtents.map((extent, idx) =>
+    getYValueFormatter(parent, series, extent, series[idx].data.cols[1]),
   );
 
   // apply any on-rendering functions (this code lives in `LineAreaBarPostRenderer`)

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -898,7 +898,10 @@ export default function lineAreaBar(
       }
     });
   });
-  console.log(yAxisProps);
+
+  const formatYValues = yAxisProps.yExtents.map(extent =>
+    getYValueFormatter(parent, series, extent),
+  );
 
   // apply any on-rendering functions (this code lives in `LineAreaBarPostRenderer`)
   lineAndBarOnRender(parent, {
@@ -907,9 +910,7 @@ export default function lineAreaBar(
     yAxisSplit: yAxisProps.yAxisSplit,
     xInterval: xAxisProps.xInterval,
     isStacked: isStacked(parent.settings, datas),
-    formatYValues: yAxisProps.yExtents.map(extent =>
-      getYValueFormatter(parent, series, extent),
-    ),
+    formatYValues,
     datas,
   });
 

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -898,6 +898,7 @@ export default function lineAreaBar(
       }
     });
   });
+  console.log(yAxisProps);
 
   // apply any on-rendering functions (this code lives in `LineAreaBarPostRenderer`)
   lineAndBarOnRender(parent, {
@@ -906,7 +907,9 @@ export default function lineAreaBar(
     yAxisSplit: yAxisProps.yAxisSplit,
     xInterval: xAxisProps.xInterval,
     isStacked: isStacked(parent.settings, datas),
-    formatYValue: getYValueFormatter(parent, series, yAxisProps.yExtent),
+    formatYValues: yAxisProps.yExtents.map(extent =>
+      getYValueFormatter(parent, series, extent),
+    ),
     datas,
   });
 

--- a/frontend/src/metabase/visualizations/lib/apply_axis.js
+++ b/frontend/src/metabase/visualizations/lib/apply_axis.js
@@ -381,7 +381,11 @@ export function applyChartYAxis(chart, series, yExtent, axisName) {
   }
 
   if (axis.setting("axis_enabled")) {
-    axis.axis().tickFormat(getYValueFormatter(chart, series, yExtent));
+    axis
+      .axis()
+      .tickFormat(
+        getYValueFormatter(chart, series, yExtent, series[0].data.cols[1]),
+      );
     chart.renderHorizontalGridLines(true);
     adjustYAxisTicksIfNeeded(axis.axis(), chart.height());
   } else {
@@ -469,14 +473,13 @@ export function applyChartYAxis(chart, series, yExtent, axisName) {
   }
 }
 
-export function getYValueFormatter(chart, series, yExtent) {
+export function getYValueFormatter(chart, series, yExtent, metricColumn) {
   // special case for normalized stacked charts
   // for normalized stacked charts the y-axis is a percentage number. In Javascript, 0.07 * 100.0 = 7.000000000000001 (try it) so we
   // round that number to get something nice like "7". Then we append "%" to get a nice tick like "7%"
   if (chart.settings["stackable.stack_type"] === "normalized") {
     return value => Math.round(value * 100) + "%";
   }
-  const metricColumn = series[0].data.cols[1];
   const columnSettings = chart.settings.column(metricColumn);
   return (value, options) => {
     const roundedValue = maybeRoundValueToZero(value, yExtent);

--- a/frontend/src/metabase/visualizations/lib/apply_axis.js
+++ b/frontend/src/metabase/visualizations/lib/apply_axis.js
@@ -343,7 +343,12 @@ export function applyChartOrdinalXAxis(
 // The tolerance is arbitrarily set to one millionth of the yExtent.
 const TOLERANCE_TO_Y_EXTENT = 1e6;
 export function maybeRoundValueToZero(value, [yMin, yMax]) {
-  const tolerance = Math.abs(yMax - yMin) / TOLERANCE_TO_Y_EXTENT;
+  const tolerance = Math.min(
+    0.001,
+    Math.abs(yMax - yMin) / TOLERANCE_TO_Y_EXTENT,
+  );
+  console.log("lol tolerance");
+  console.log(tolerance);
   return Math.abs(value) < tolerance ? 0 : value;
 }
 

--- a/frontend/src/metabase/visualizations/lib/apply_axis.js
+++ b/frontend/src/metabase/visualizations/lib/apply_axis.js
@@ -343,12 +343,7 @@ export function applyChartOrdinalXAxis(
 // The tolerance is arbitrarily set to one millionth of the yExtent.
 const TOLERANCE_TO_Y_EXTENT = 1e6;
 export function maybeRoundValueToZero(value, [yMin, yMax]) {
-  const tolerance = Math.min(
-    0.001,
-    Math.abs(yMax - yMin) / TOLERANCE_TO_Y_EXTENT,
-  );
-  console.log("lol tolerance");
-  console.log(tolerance);
+  const tolerance = Math.abs(yMax - yMin) / TOLERANCE_TO_Y_EXTENT;
   return Math.abs(value) < tolerance ? 0 : value;
 }
 

--- a/frontend/src/metabase/visualizations/lib/chart_values.js
+++ b/frontend/src/metabase/visualizations/lib/chart_values.js
@@ -267,12 +267,14 @@ export function onRenderValueLabels(
         // only create labels for the correct class(es) given the type of label
         .filter(d => !(d.rotated ^ (klass === "value-label-white")))
         .attr("class", klass)
-        .text(({ y, seriesIndex }) =>
-          formatYValue(y, {
+        .text(({ y, seriesIndex }) => {
+          let res = formatYValue(y, {
             negativeInParentheses: displays[seriesIndex] === "waterfall",
             compact: compact === null ? compactForSeries[seriesIndex] : compact,
-          }),
-        ),
+          });
+          console.log(res);
+          return res;
+        }),
     );
   };
 

--- a/frontend/src/metabase/visualizations/lib/chart_values.js
+++ b/frontend/src/metabase/visualizations/lib/chart_values.js
@@ -275,9 +275,9 @@ export function onRenderValueLabels(
     );
   };
   const addLabels = (datas, formatYValues, compact = null) => {
-    // make sure we don't add .value-lables multiple times
+    // make sure we don't add .value-labels multiple times
     parent.select(".value-labels").remove();
-    for (let [idx, data] of datas.entries()) {
+    for (const [idx, data] of datas.entries()) {
       addOneLabelSeries(data, formatYValues[idx], compact);
     }
   };
@@ -352,6 +352,9 @@ export function onRenderValueLabels(
       }
     });
 
+  datas = datas.map(data =>
+    data.filter((d, i) => i % nthForSeries[d.seriesIndex] === 0 && !d.hidden),
+  );
   addLabels(datas, formatYValues);
 
   moveToFront(

--- a/frontend/src/metabase/visualizations/lib/chart_values.js
+++ b/frontend/src/metabase/visualizations/lib/chart_values.js
@@ -234,50 +234,51 @@ export function onRenderValueLabels(
   };
 
   const MIN_ROTATED_HEIGHT = 50;
-  const addLabels = (data, formatYValue, compact = null) => {
+  const addLabels = (datas, formatYValues, compact = null) => {
     // make sure we don't add .value-lables multiple times
     parent.select(".value-labels").remove();
+    for (let [idx, data] of datas.entries()) {
+      data = data
+        .map(d => ({ ...d, ...xyPos(d) }))
+        // remove rotated labels when the bar is too short
+        .filter(d => !(d.rotated && d.yHeight < MIN_ROTATED_HEIGHT));
 
-    data = data
-      .map(d => ({ ...d, ...xyPos(d) }))
-      // remove rotated labels when the bar is too short
-      .filter(d => !(d.rotated && d.yHeight < MIN_ROTATED_HEIGHT));
+      const labelGroups = parent
+        .append("svg:g")
+        .classed("value-labels", true)
+        .selectAll("g")
+        .data(data)
+        .enter()
+        .append("g")
+        .attr("text-anchor", d => (d.rotated ? "end" : "middle"))
+        .attr("transform", d => {
+          const transforms = [`translate(${d.xPos}, ${d.yPos})`];
+          if (d.rotated) {
+            transforms.push("rotate(-90)", `translate(-15, 4)`);
+          }
+          return transforms.join(" ");
+        });
 
-    const labelGroups = parent
-      .append("svg:g")
-      .classed("value-labels", true)
-      .selectAll("g")
-      .data(data)
-      .enter()
-      .append("g")
-      .attr("text-anchor", d => (d.rotated ? "end" : "middle"))
-      .attr("transform", d => {
-        const transforms = [`translate(${d.xPos}, ${d.yPos})`];
-        if (d.rotated) {
-          transforms.push("rotate(-90)", `translate(-15, 4)`);
-        }
-        return transforms.join(" ");
-      });
-
-    // Labels are either white inside the bar or black with white outline.
-    // For outlined labels, Safari had an issue with rendering paint-order: stroke.
-    // To work around that, we create two text labels: one for the the black text
-    // and another for the white outline behind it.
-    ["value-label-outline", "value-label", "value-label-white"].forEach(klass =>
-      labelGroups
-        .append("text")
-        // only create labels for the correct class(es) given the type of label
-        .filter(d => !(d.rotated ^ (klass === "value-label-white")))
-        .attr("class", klass)
-        .text(({ y, seriesIndex }) => {
-          let res = formatYValue(y, {
-            negativeInParentheses: displays[seriesIndex] === "waterfall",
-            compact: compact === null ? compactForSeries[seriesIndex] : compact,
-          });
-          console.log(res);
-          return res;
-        }),
-    );
+      // Labels are either white inside the bar or black with white outline.
+      // For outlined labels, Safari had an issue with rendering paint-order: stroke.
+      // To work around that, we create two text labels: one for the the black text
+      // and another for the white outline behind it.
+      ["value-label-outline", "value-label", "value-label-white"].forEach(
+        klass =>
+          labelGroups
+            .append("text")
+            // only create labels for the correct class(es) given the type of label
+            .filter(d => !(d.rotated ^ (klass === "value-label-white")))
+            .attr("class", klass)
+            .text(({ y, seriesIndex }) => {
+              return formatYValues[idx](y, {
+                negativeInParentheses: displays[seriesIndex] === "waterfall",
+                compact:
+                  compact === null ? compactForSeries[seriesIndex] : compact,
+              });
+            }),
+      );
+    }
   };
 
   const nthForSeries = datas.map((data, index) => {
@@ -292,7 +293,7 @@ export function onRenderValueLabels(
     const MAX_SAMPLE_SIZE = 30;
     const sampleStep = Math.ceil(maxSeriesLength / MAX_SAMPLE_SIZE);
     const sample = data.filter((d, i) => i % sampleStep === 0);
-    addLabels(sample, formatYValues[index], compactForSeries[index]);
+    // addLabels(sample, formatYValues[index], compactForSeries[index]);
     const totalWidth = chart
       .svg()
       .selectAll(".value-label-outline")
@@ -350,7 +351,7 @@ export function onRenderValueLabels(
       }
     });
 
-  datas.map((data, idx) => addLabels(data, formatYValues[idx]));
+  addLabels(datas, formatYValues);
 
   moveToFront(
     chart

--- a/frontend/src/metabase/visualizations/lib/chart_values.js
+++ b/frontend/src/metabase/visualizations/lib/chart_values.js
@@ -165,7 +165,7 @@ export function onRenderValueLabels(
     if (!isBarLike(display)) {
       if (displays.some(d => isBarLike(d))) {
         // this aligns labels on non-bars with in the center of the bar group
-        return ((1 + chart._rangeBandPadding()) * xScale.rangeBand()) / 2;
+        return 1 + chart._rangeBandPadding();
       }
       return 0;
     }

--- a/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
@@ -36,7 +36,7 @@ describe("scenarios > visualizations > line chart", () => {
     cy.get(Y_AXIS_RIGHT_SELECTOR);
   });
 
-  it.only("should be able to format data point values style independently on multi-series chart (metabase#13095)", () => {
+  it("should be able to format data point values style independently on multi-series chart (metabase#13095)", () => {
     visitQuestionAdhoc({
       dataset_query: {
         type: "query",

--- a/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
@@ -36,7 +36,7 @@ describe("scenarios > visualizations > line chart", () => {
     cy.get(Y_AXIS_RIGHT_SELECTOR);
   });
 
-  it.skip("should be able to format data point values style independently on multi-series chart (metabase#13095)", () => {
+  it.only("should be able to format data point values style independently on multi-series chart (metabase#13095)", () => {
     visitQuestionAdhoc({
       dataset_query: {
         type: "query",


### PR DESCRIPTION
Pursuant to #13095. Previously all styling decisions on the little numbers that appear above the line graph points if you set the setting were decided by the first series in the line graph. Now it's per series in the line graph.