### PR TITLE
[Binning e2e coverage] Asserting on the saved SQL question

### DIFF
--- a/frontend/test/metabase/scenarios/binning/sql.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/sql.cy.spec.js
@@ -27,8 +27,12 @@ describe("scenarios > binning > from a saved sql question", () => {
 
     it("should work for time series", () => {
       cy.findByTestId("sidebar-right").within(() => {
-        // This basic/default bucket seems wrong.
-        // For every other scenario, the default bucker for time is "by month"
+        /*
+         * This basic/default bucket size seems wrong.
+         * For every other scenario, the default bucket for time series is "by month".
+         *
+         * TODO: update to "by month" once (metabase#16671) gets fixed.
+         */
         openPopoverFromDefaultBucketSize("CREATED_AT", "by minute");
       });
 
@@ -152,24 +156,30 @@ describe("scenarios > binning > from a saved sql question", () => {
       cy.findByText("Q1 - 2017");
     });
 
-    it("should work for number", () => {
+    it("should work for number (metabase##16670)", () => {
       cy.findByText("TOTAL").click();
       cy.findByText("Distribution").click();
 
       assertOnXYAxisLabels({ xLabel: "TOTAL", yLabel: "Count" });
       cy.findByText("Count by TOTAL: Auto binned");
-      // Auto bin is much more granular than it is for QB questions
+      /*
+       * Auto binning result is much more granular than it is for QB Questions.
+       * Please, see https://github.com/metabase/metabase/issues/16670
+       *
+       * However, this is not the scope of this particular test.
+       * The explicit repro will be added later in the separate file.
+       */
       cy.get(".bar");
     });
 
-    it.skip("should work for longitude", () => {
+    it.skip("should work for longitude (metabase#16672)", () => {
       cy.findByText("LONGITUDE").click();
       cy.findByText("Distribution").click();
 
       assertOnXYAxisLabels({ xLabel: "LONGITUDE", yLabel: "Count" });
       cy.findByText("Count by LONGITUDE: Auto binned");
-      // Auto bin is much more granular than it is for QB questions
       cy.get(".bar");
+      cy.findByText("170° W");
     });
   });
 });

--- a/frontend/test/metabase/scenarios/binning/sql.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/sql.cy.spec.js
@@ -8,7 +8,7 @@ describe("scenarios > binning > from a saved sql question", () => {
       name: "SQL Binning",
       native: {
         query:
-          "SELECT ORDERS.CREATED_AT, ORDERS.TOTAL, PEOPLE.BIRTH_DATE, PEOPLE.LONGITUDE FROM ORDERS JOIN PEOPLE ON orders.user_id = people.id",
+          "SELECT ORDERS.CREATED_AT, ORDERS.TOTAL, PEOPLE.LONGITUDE FROM ORDERS JOIN PEOPLE ON orders.user_id = people.id",
       },
     });
 

--- a/frontend/test/metabase/scenarios/binning/sql.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/sql.cy.spec.js
@@ -125,6 +125,53 @@ describe("scenarios > binning > from a saved sql question", () => {
       cy.get(".bar");
     });
   });
+
+  context("via column popover", () => {
+    beforeEach(() => {
+      cy.visit("/question/new");
+      cy.findByText("Simple question").click();
+      cy.findByText("Saved Questions").click();
+      cy.findByText("SQL Binning").click();
+    });
+
+    it("should work for time series", () => {
+      cy.findByText("CREATED_AT").click();
+      cy.findByText("Distribution").click();
+
+      assertOnXYAxisLabels({ xLabel: "CREATED_AT", yLabel: "Count" });
+      cy.findByText("Count by CREATED_AT: Month");
+      cy.get("circle");
+
+      // Open a popover with bucket options from the time series footer
+      cy.get(".AdminSelect-content")
+        .contains("Month")
+        .click();
+      cy.findByText("Quarter").click();
+
+      cy.findByText("Count by CREATED_AT: Quarter");
+      cy.findByText("Q1 - 2017");
+    });
+
+    it("should work for number", () => {
+      cy.findByText("TOTAL").click();
+      cy.findByText("Distribution").click();
+
+      assertOnXYAxisLabels({ xLabel: "TOTAL", yLabel: "Count" });
+      cy.findByText("Count by TOTAL: Auto binned");
+      // Auto bin is much more granular than it is for QB questions
+      cy.get(".bar");
+    });
+
+    it.skip("should work for longitude", () => {
+      cy.findByText("LONGITUDE").click();
+      cy.findByText("Distribution").click();
+
+      assertOnXYAxisLabels({ xLabel: "LONGITUDE", yLabel: "Count" });
+      cy.findByText("Count by LONGITUDE: Auto binned");
+      // Auto bin is much more granular than it is for QB questions
+      cy.get(".bar");
+    });
+  });
 });
 
 function openPopoverFromDefaultBucketSize(column, bucket) {
@@ -138,6 +185,16 @@ function openPopoverFromDefaultBucketSize(column, bucket) {
     .as("listItemSelectedBinning")
     .should("contain", bucket)
     .click();
+}
+
+function assertOnXYAxisLabels({ xLabel, yLabel } = {}) {
+  cy.get(".x-axis-label")
+    .invoke("text")
+    .should("eq", xLabel);
+
+  cy.get(".y-axis-label")
+    .invoke("text")
+    .should("eq", yLabel);
 }
 
 function waitAndAssertOnRequest(requestAlias) {

--- a/frontend/test/metabase/scenarios/binning/sql.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/sql.cy.spec.js
@@ -1,0 +1,94 @@
+import { restore, popover } from "__support__/e2e/cypress";
+
+describe("scenarios > binning > from a saved sql question", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+    cy.createNativeQuestion({
+      name: "SQL Binning",
+      native: {
+        query:
+          "SELECT ORDERS.CREATED_AT, ORDERS.TOTAL, PEOPLE.BIRTH_DATE, PEOPLE.LONGITUDE FROM ORDERS JOIN PEOPLE ON orders.user_id = people.id",
+      },
+    });
+
+    cy.intercept("POST", "/api/dataset").as("dataset");
+  });
+
+  context.skip("via simple question", () => {
+    beforeEach(() => {
+      cy.visit("/question/new");
+      cy.findByText("Simple question").click();
+      cy.findByText("Saved Questions").click();
+      cy.findByText("SQL Binning").click();
+      cy.findByText("Summarize").click();
+      cy.wait("@dataset");
+    });
+
+    it("should work for time series", () => {
+      cy.findByTestId("sidebar-right").within(() => {
+        // This basic/default bucket seems wrong.
+        // For every other scenario, the default bucker for time is "by month"
+        openPopoverFromDefaultBucketSize("CREATED_AT", "by minute");
+      });
+
+      popover().within(() => {
+        cy.findByText("Year").click();
+      });
+
+      waitAndAssertOnRequest("@dataset");
+
+      cy.findByText("Count by CREATED_AT: Year");
+      cy.get("circle");
+    });
+
+    it("should work for number", () => {
+      cy.findByTestId("sidebar-right").within(() => {
+        openPopoverFromDefaultBucketSize("TOTAL", "Auto binned");
+      });
+
+      popover().within(() => {
+        cy.findByText("100 bins").click();
+      });
+
+      waitAndAssertOnRequest("@dataset");
+
+      cy.findByText("Count by TOTAL: 100 bins");
+      cy.get(".bar");
+    });
+
+    it("should work for longitude", () => {
+      cy.findByTestId("sidebar-right").within(() => {
+        openPopoverFromDefaultBucketSize("LONGITUDE", "Auto binned");
+      });
+
+      popover().within(() => {
+        cy.findByText("Bin every 10 degrees").click();
+      });
+
+      waitAndAssertOnRequest("@dataset");
+
+      cy.findByText("Count by LONGITUDE: 10°");
+      cy.get(".bar");
+    });
+  });
+});
+
+function openPopoverFromDefaultBucketSize(column, bucket) {
+  cy.findByText(column)
+    .closest(".List-item")
+    .should("be.visible")
+    .as("targetListItem");
+
+  cy.get("@targetListItem")
+    .find(".Field-extra")
+    .as("listItemSelectedBinning")
+    .should("contain", bucket)
+    .click();
+}
+
+function waitAndAssertOnRequest(requestAlias) {
+  cy.wait(requestAlias).then(xhr => {
+    expect(xhr.response.body.error).to.not.exist;
+  });
+}

--- a/frontend/test/metabase/scenarios/binning/sql.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/sql.cy.spec.js
@@ -72,6 +72,59 @@ describe("scenarios > binning > from a saved sql question", () => {
       cy.get(".bar");
     });
   });
+
+  context.skip("via custom question", () => {
+    beforeEach(() => {
+      cy.visit("/question/new");
+      cy.findByText("Custom question").click();
+      cy.findByText("Saved Questions").click();
+      cy.findByText("SQL Binning").click();
+
+      cy.findByText("Summarize").click();
+      cy.findByText("Pick the metric you want to see").click();
+      cy.findByText("Count of rows").click();
+      cy.findByText("Pick a column to group by").click();
+    });
+
+    it("should work for time series", () => {
+      popover().within(() => {
+        openPopoverFromDefaultBucketSize("CREATED_AT", "by minute");
+      });
+      cy.findByText("Year").click();
+
+      cy.findByText("Count by CREATED_AT: Year");
+      cy.button("Visualize").click();
+
+      waitAndAssertOnRequest("@dataset");
+      cy.get(".bar");
+    });
+
+    it("should work for number", () => {
+      popover().within(() => {
+        openPopoverFromDefaultBucketSize("TOTAL", "Auto binned");
+      });
+      cy.findByText("100 bins").click();
+
+      cy.findByText("Count by TOTAL: 100 bins");
+      cy.button("Visualize").click();
+
+      waitAndAssertOnRequest("@dataset");
+      cy.get(".bar");
+    });
+
+    it("should work for longitude", () => {
+      popover().within(() => {
+        openPopoverFromDefaultBucketSize("LONGITUDE", "Auto binned");
+      });
+      cy.findByText("Bin every 10 degrees").click();
+
+      cy.findByText("Count by LONGITUDE: 10°");
+      cy.button("Visualize").click();
+
+      waitAndAssertOnRequest("@dataset");
+      cy.get(".bar");
+    });
+  });
 });
 
 function openPopoverFromDefaultBucketSize(column, bucket) {

--- a/frontend/test/metabase/scenarios/binning/sql.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/sql.cy.spec.js
@@ -96,7 +96,7 @@ describe("scenarios > binning > from a saved sql question", () => {
       cy.button("Visualize").click();
 
       waitAndAssertOnRequest("@dataset");
-      cy.get(".bar");
+      cy.get("circle");
     });
 
     it("should work for number", () => {


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- Adds initial set of tests around binning, related to starting the new query based on the saved SQL question

### Screenshots
The current state of tests
![image](https://user-images.githubusercontent.com/31325167/122468459-06cf9200-cfbc-11eb-8a10-3ec6b203ce30.png)

It _seems_ that the distribution from the column popover is working for time series and for number, but even that comes with its own quirks. Please see: #16670 and #16671.


#### Please click the details to expand and see more screenshots/logs
<details>
  <summary>Time series fails because of the double binning options rendered for both simple and custom questions</summary>

Simple question
![image](https://user-images.githubusercontent.com/31325167/122468785-7180cd80-cfbc-11eb-9296-dab9280bf045.png)

Custom question
![image](https://user-images.githubusercontent.com/31325167/122468858-878e8e00-cfbc-11eb-99a4-ef4de5f8f0c6.png)
</details>

<details>
  <summary>SIMPLE question: Number and Longitude fail because of a wrong query generated</summary>

```
Value does not match schema: {
  :query {
    :breakout [(named (not (":field clauses using a string field name must specify :base-type." a-clojure.lang.PersistentVector)) "Must be a valid instance of one of these clauses: :expression, :field")]
  }
} 
```
</details>

<details>
  <summary>CUSTOM question: Number and Longitude fail because "group by" column is dropped</summary>

![image](https://user-images.githubusercontent.com/31325167/122469724-8f9afd80-cfbd-11eb-9541-81e33ce07fc3.png)

</details>

<details>
  <summary>DISTRIBUTION via column popover fails for Longitude with an error (#16672)</summary>

```
not,Integer greater than zero,0
```

![image](https://user-images.githubusercontent.com/31325167/122470232-1a7bf800-cfbe-11eb-986c-7bfed0f967ae.png)


</details>