### PR TITLE
[Binning e2e coverage] Asserting on the bins from the saved QB question using implicit joins

### DIFF
--- a/frontend/test/metabase/scenarios/binning/qb-implicit-joins.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/qb-implicit-joins.cy.spec.js
@@ -1,0 +1,86 @@
+import { restore, popover } from "__support__/e2e/cypress";
+
+describe("scenarios > binning > from a saved QB question using implicit joins", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.intercept("POST", "/api/dataset").as("dataset");
+  });
+
+  context("via simple question", () => {
+    beforeEach(() => {
+      cy.visit("/question/1");
+      cy.findByText("Summarize").click();
+    });
+
+    it("should work for time series", () => {
+      cy.findByTestId("sidebar-right").within(() => {
+        openPopoverFromDefaultBucketSize("Birth Date", "by month");
+      });
+
+      popover().within(() => {
+        cy.findByText("Year").click();
+      });
+
+      waitAndAssertOnRequest("@dataset");
+
+      cy.findByText("Count by User → Birth Date: Year");
+
+      // The default chosen "visualization" is table
+      cy.findByText("1958");
+      cy.findByText("313");
+    });
+
+    it("should work for number", () => {
+      cy.findByTestId("sidebar-right").within(() => {
+        openPopoverFromDefaultBucketSize("Price", "Auto bin");
+      });
+
+      popover().within(() => {
+        cy.findByText("10 bins").click();
+      });
+
+      waitAndAssertOnRequest("@dataset");
+
+      cy.findByText("Count by Product → Price: 10 bins");
+      cy.findByText("196");
+    });
+
+    it.skip("should work for longitude", () => {
+      cy.findByTestId("sidebar-right").within(() => {
+        openPopoverFromDefaultBucketSize("Longitude", "Auto bin");
+      });
+
+      popover().within(() => {
+        // Test fails at this point (UI inconsistency).
+        // It simply gives `10°` as the option, which is different than in any other longitude binning scenario.
+        cy.findByText("Bin every 10 degrees").click();
+      });
+
+      waitAndAssertOnRequest("@dataset");
+
+      cy.findByText("Count by User → Longitude: 10°");
+      cy.findByText("170° W  –  160° W");
+      cy.findByText("75");
+    });
+  });
+});
+
+function openPopoverFromDefaultBucketSize(column, bucket) {
+  cy.findByText(column)
+    .closest(".List-item")
+    .as("targetListItem");
+
+  cy.get("@targetListItem")
+    .find(".Field-extra")
+    .as("listItemSelectedBinning")
+    .should("contain", bucket)
+    .click();
+}
+
+function waitAndAssertOnRequest(requestAlias) {
+  cy.wait(requestAlias).then(xhr => {
+    expect(xhr.response.body.error).to.not.exist;
+  });
+}

--- a/frontend/test/metabase/scenarios/binning/qb-implicit-joins.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/qb-implicit-joins.cy.spec.js
@@ -22,7 +22,6 @@ describe("scenarios > binning > from a saved QB question using implicit joins", 
       chooseBucketAndAssert({
         bucketSize: "Year",
         title: "Count by User → Birth Date: Year",
-
         values: ["1958", "313"],
       });
 

--- a/frontend/test/metabase/scenarios/binning/qb-implicit-joins.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/qb-implicit-joins.cy.spec.js
@@ -63,6 +63,69 @@ describe("scenarios > binning > from a saved QB question using implicit joins", 
       });
     });
   });
+
+  context("via custom question", () => {
+    beforeEach(() => {
+      cy.visit("/question/1/notebook");
+      cy.findByText("Summarize").click();
+      cy.findByText("Count of rows").click();
+      cy.findByText("Pick a column to group by").click();
+      // Click "Order" accordion to collapse it and expose the other tables
+      cy.findByText("Order").click();
+    });
+
+    it("should work for time series", () => {
+      cy.findByText("User").click();
+      cy.findByPlaceholderText("Find...").type("birth");
+      openPopoverFromDefaultBucketSize("Birth Date", "by month");
+
+      chooseBucketAndAssert({
+        bucketSize: "Year",
+        title: "Count by User → Birth Date: Year",
+        mode: "notebook",
+        values: ["1958", "313"],
+      });
+
+      // Make sure time series chooseBucketAndAssertter works as well
+      cy.get(".AdminSelect-content")
+        .contains("Year")
+        .click();
+      cy.findByText("Month").click();
+
+      cy.get(".cellData")
+        .should("contain", "April, 1958")
+        .and("contain", "37");
+    });
+
+    it("should work for number", () => {
+      cy.findByText("Product").click();
+
+      openPopoverFromDefaultBucketSize("Price", "Auto bin");
+
+      chooseBucketAndAssert({
+        bucketSize: "50 bins",
+        title: "Count by Product → Price: 50 bins",
+        mode: "notebook",
+        values: ["14  –  16", "96"],
+      });
+    });
+
+    it("should work for longitude", () => {
+      cy.findByText("User").click();
+      cy.findByPlaceholderText("Find...").type("longitude");
+
+      openPopoverFromDefaultBucketSize("Longitude", "Auto bin");
+
+      chooseBucketAndAssert({
+        // Test is currently incorrect in that it displays wrong binning options (please see: https://github.com/metabase/metabase/issues/16674)
+        // Once #16674 gets fixed, update the following line to say: `bucketSize: "Bin every 20 degrees"`
+        bucketSize: "20°",
+        title: "Count by User → Longitude: 20°",
+        mode: "notebook",
+        values: ["180° W  –  160° W", "75"],
+      });
+    });
+  });
 });
 
 function openPopoverFromDefaultBucketSize(column, bucket) {


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- Adds set of tests around binning on implicitly joined columns

### Important notes:
- Tests for longitude are currently made to pass, although the binning options displayed are wrong (#16674).
    - Please see [this discussion](https://github.com/metabase/metabase/pull/16662#discussion_r654910731) for more info.
- The values used for the assertion could possibly change in the future, when we fix 'correctness' issues around binning
    - Please see comments in #16640 for more info.

### Screenshots
![image](https://user-images.githubusercontent.com/31325167/122751768-77aecc80-d290-11eb-9171-4ca7dec4501f.png)

