### PR TITLE
Fix "Zoom in" and "View these X" drilldown actions for charts based on custom columns

### DIFF
--- a/frontend/src/metabase/modes/components/drill/AutomaticDashboardDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/AutomaticDashboardDrill.jsx
@@ -17,7 +17,7 @@ export default ({ question, clicked }: ClickActionProps): ClickAction[] => {
   // questions with a breakout
   const dimensions = (clicked && clicked.dimensions) || [];
 
-  // these don't seem to work
+  // ExpressionDimensions don't work right now (see metabase#16680)
   const includesExpressionDimensions = dimensions.some(dimension => {
     return isExpressionField(dimension.column.field_ref);
   });

--- a/frontend/src/metabase/modes/components/drill/AutomaticDashboardDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/AutomaticDashboardDrill.jsx
@@ -22,12 +22,13 @@ export default ({ question, clicked }: ClickActionProps): ClickAction[] => {
     return isExpressionField(dimension.column.field_ref);
   });
 
-  if (
+  const isUnsupportedDrill =
     !clicked ||
     dimensions.length === 0 ||
     !MetabaseSettings.get("enable-xrays") ||
-    includesExpressionDimensions
-  ) {
+    includesExpressionDimensions;
+
+  if (isUnsupportedDrill) {
     return [];
   }
 

--- a/frontend/src/metabase/modes/components/drill/AutomaticDashboardDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/AutomaticDashboardDrill.jsx
@@ -4,6 +4,7 @@ import type {
   ClickAction,
   ClickActionProps,
 } from "metabase-types/types/Visualization";
+import { isExpressionField } from "metabase/lib/query/field_ref";
 
 import MetabaseSettings from "metabase/lib/settings";
 
@@ -15,10 +16,17 @@ export default ({ question, clicked }: ClickActionProps): ClickAction[] => {
 
   // questions with a breakout
   const dimensions = (clicked && clicked.dimensions) || [];
+
+  // these don't seem to work
+  const includesExpressionDimensions = dimensions.some(dimension => {
+    return isExpressionField(dimension.column.field_ref);
+  });
+
   if (
     !clicked ||
     dimensions.length === 0 ||
-    !MetabaseSettings.get("enable-xrays")
+    !MetabaseSettings.get("enable-xrays") ||
+    includesExpressionDimensions
   ) {
     return [];
   }

--- a/frontend/src/metabase/modes/components/drill/CompareToRestDrill.js
+++ b/frontend/src/metabase/modes/components/drill/CompareToRestDrill.js
@@ -17,7 +17,7 @@ export default ({ question, clicked }: ClickActionProps): ClickAction[] => {
   // questions with a breakout
   const dimensions = (clicked && clicked.dimensions) || [];
 
-  // these don't seem to work
+  // ExpressionDimensions don't work right now (see metabase#16680)
   const includesExpressionDimensions = dimensions.some(dimension => {
     return isExpressionField(dimension.column.field_ref);
   });

--- a/frontend/src/metabase/modes/components/drill/CompareToRestDrill.js
+++ b/frontend/src/metabase/modes/components/drill/CompareToRestDrill.js
@@ -22,13 +22,14 @@ export default ({ question, clicked }: ClickActionProps): ClickAction[] => {
     return isExpressionField(dimension.column.field_ref);
   });
 
-  if (
+  const isUnsupportedDrill =
     !clicked ||
     dimensions.length === 0 ||
     // xrays must be enabled for this to work
     !MetabaseSettings.get("enable-xrays") ||
-    includesExpressionDimensions
-  ) {
+    includesExpressionDimensions;
+
+  if (isUnsupportedDrill) {
     return [];
   }
 

--- a/frontend/src/metabase/modes/components/drill/CompareToRestDrill.js
+++ b/frontend/src/metabase/modes/components/drill/CompareToRestDrill.js
@@ -5,6 +5,7 @@ import type {
   ClickActionProps,
 } from "metabase-types/types/Visualization";
 
+import { isExpressionField } from "metabase/lib/query/field_ref";
 import MetabaseSettings from "metabase/lib/settings";
 
 export default ({ question, clicked }: ClickActionProps): ClickAction[] => {
@@ -15,11 +16,18 @@ export default ({ question, clicked }: ClickActionProps): ClickAction[] => {
 
   // questions with a breakout
   const dimensions = (clicked && clicked.dimensions) || [];
+
+  // these don't seem to work
+  const includesExpressionDimensions = dimensions.some(dimension => {
+    return isExpressionField(dimension.column.field_ref);
+  });
+
   if (
     !clicked ||
     dimensions.length === 0 ||
     // xrays must be enabled for this to work
-    !MetabaseSettings.get("enable-xrays")
+    !MetabaseSettings.get("enable-xrays") ||
+    includesExpressionDimensions
   ) {
     return [];
   }

--- a/frontend/src/metabase/modes/lib/drilldown.js
+++ b/frontend/src/metabase/modes/lib/drilldown.js
@@ -3,11 +3,8 @@ import { isLatitude, isLongitude, isDate } from "metabase/lib/schema_metadata";
 
 import _ from "underscore";
 
-import {
-  FieldDimension,
-  ExpressionDimension,
-} from "metabase-lib/lib/Dimension";
-import { isLocalField, isExpressionField } from "metabase/lib/query/field_ref";
+import { FieldDimension } from "metabase-lib/lib/Dimension";
+import { isLocalField } from "metabase/lib/query/field_ref";
 // Drill-down progressions are defined as a series of steps, where each step has one or more dimension <-> breakout
 // transforms.
 //

--- a/frontend/src/metabase/modes/lib/drilldown.js
+++ b/frontend/src/metabase/modes/lib/drilldown.js
@@ -4,7 +4,7 @@ import { isLatitude, isLongitude, isDate } from "metabase/lib/schema_metadata";
 import _ from "underscore";
 
 import { FieldDimension } from "metabase-lib/lib/Dimension";
-import { isLocalField } from "metabase/lib/query/field_ref";
+import { isExpressionField } from "metabase/lib/query/field_ref";
 // Drill-down progressions are defined as a series of steps, where each step has one or more dimension <-> breakout
 // transforms.
 //
@@ -387,9 +387,13 @@ function matchingProgression(dimensions) {
 }
 
 function nextBreakouts(dimensionMaps, metadata) {
-  const dimensions = dimensionMaps
-    .map(d => columnToFieldDimension(d.column, metadata))
-    .filter(Boolean);
+  const columns = dimensionMaps.map(d => d.column);
+  const dimensions = columnsToFieldDimensions(columns, metadata);
+
+  const [firstDimension] = dimensions;
+  if (!firstDimension) {
+    return null;
+  }
 
   const [progression, currentStepNumber] = matchingProgression(
     dimensions,
@@ -401,15 +405,9 @@ function nextBreakouts(dimensionMaps, metadata) {
   }
   const nextStepNumber = currentStepNumber + 1;
 
-  const [firstDimension] = dimensions;
-  if (!firstDimension) {
-    return null;
-  }
-
   const table = metadata && firstDimension.field().table;
-  const tableDimensions = table.fields.map(field =>
-    columnToFieldDimension(field, metadata),
-  );
+  const tableDimensions = columnsToFieldDimensions(table.fields, metadata);
+
   const allDimensions = [...dimensions, ...tableDimensions];
 
   const nextStep = progression[nextStepNumber];
@@ -437,30 +435,38 @@ export function drillDownForDimensions(dimensions: any, metadata: any) {
   };
 }
 
+function columnsToFieldDimensions(columns, metadata) {
+  return columns
+    .map(column => columnToFieldDimension(column, metadata))
+    .filter(Boolean);
+}
+
 function columnToFieldDimension(column, metadata) {
-  if (isLocalField(column.field_ref)) {
-    const dimension = new FieldDimension(column.id, null, metadata);
-
-    if (column.unit) {
-      return dimension.withTemporalUnit(column.unit);
-    }
-
-    if (column.binning_info) {
-      const binningStrategy = column.binning_info.binning_strategy;
-      switch (binningStrategy) {
-        case "bin-width":
-          return dimension.withBinningOptions({
-            strategy: "bin-width",
-            "bin-width": column.binning_info.bin_width,
-          });
-        case "num-bins":
-          return dimension.withBinningOptions({
-            strategy: "num-bins",
-            "num-bins": column.binning_info.num_bins,
-          });
-      }
-    }
-
-    return dimension;
+  if (isExpressionField(column.field_ref)) {
+    return;
   }
+
+  const dimension = new FieldDimension(column.id, null, metadata);
+
+  if (column.unit) {
+    return dimension.withTemporalUnit(column.unit);
+  }
+
+  if (column.binning_info) {
+    const binningStrategy = column.binning_info.binning_strategy;
+    switch (binningStrategy) {
+      case "bin-width":
+        return dimension.withBinningOptions({
+          strategy: "bin-width",
+          "bin-width": column.binning_info.bin_width,
+        });
+      case "num-bins":
+        return dimension.withBinningOptions({
+          strategy: "num-bins",
+          "num-bins": column.binning_info.num_bins,
+        });
+    }
+  }
+
+  return dimension;
 }

--- a/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { connect } from "react-redux";
+import { t } from "ttag";
 
 import { Link } from "react-router";
 import Icon from "metabase/components/Icon";
@@ -220,19 +221,19 @@ export default class ChartClickActions extends Component {
                 )}
               >
                 {SECTIONS[key].icon === "sum" && (
-                  <p className="mt0 text-medium text-small">Summarize</p>
+                  <p className="mt0 text-medium text-small">{t`Summarize`}</p>
                 )}
                 {SECTIONS[key].icon === "breakout" && (
-                  <p className="my1 text-medium text-small">Break out by a…</p>
+                  <p className="my1 text-medium text-small">{t`Break out by a…`}</p>
                 )}
                 {SECTIONS[key].icon === "bolt" && (
                   <p className="mt2 text-medium text-small">
-                    Automatic explorations
+                    {t`Automatic explorations`}
                   </p>
                 )}
                 {SECTIONS[key].icon === "funnel_outline" && (
                   <p className="mt0 text-dark text-small">
-                    Filter by this value
+                    {t`Filter by this value`}
                   </p>
                 )}
 

--- a/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
@@ -726,6 +726,57 @@ describe("scenarios > dashboard > dashboard drill", () => {
     });
   });
 
+  it("should drill-through on chart based on a custom column (metabase#13289)", () => {
+    cy.server();
+    cy.route("POST", "/api/dataset").as("dataset");
+
+    cy.createQuestion({
+      name: "13289Q",
+      display: "line",
+      query: {
+        "source-table": ORDERS_ID,
+        expressions: {
+          two: ["+", 1, 1],
+        },
+        aggregation: [["count"]],
+        breakout: [
+          ["expression", "two"],
+          [
+            "field",
+            ORDERS.CREATED_AT,
+            {
+              "temporal-unit": "month",
+            },
+          ],
+        ],
+      },
+    }).then(({ body: { id: QUESTION_ID } }) => {
+      cy.createDashboard("13289D").then(({ body: { id: DASHBOARD_ID } }) => {
+        // Add question to the dashboard
+        cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
+          cardId: QUESTION_ID,
+          row: 0,
+          col: 0,
+          sizeX: 12,
+          sizeY: 8,
+        });
+
+        cy.visit(`/dashboard/${DASHBOARD_ID}`);
+      });
+    });
+
+    cy.get(".Card circle")
+      .eq(1)
+      .click({ force: true });
+
+    cy.findByText("Zoom in").click();
+
+    cy.wait("@dataset");
+
+    cy.findByText("two is equal to 2");
+    cy.findByText("Created At is May, 2016");
+  });
+
   describe("should preserve dashboard filter and apply it to the question on a drill-through (metabase#11503)", () => {
     const ordersIdFilter = {
       name: "Orders ID",


### PR DESCRIPTION
Fixes #13289 

Fixes the "View these X" and "Zoom" drilldown actions. As part of this I am hiding two "Automatic exploration" actions that should show, because they are still broken (see bug https://github.com/metabase/metabase/issues/16680)

Here's a recording of how to create the proper line chart and proof of fix:

https://user-images.githubusercontent.com/13057258/122608129-91ea6f80-d030-11eb-88ee-29e91a28760a.mov

