### PR TITLE
Hide permission controls for personal collection's sub-collections

### DIFF
--- a/frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx
+++ b/frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx
@@ -4,15 +4,19 @@ import { connect } from "react-redux";
 import { t } from "ttag";
 import _ from "underscore";
 
+import * as Urls from "metabase/lib/urls";
+import { CollectionsApi } from "metabase/services";
+
+import Collections from "metabase/entities/collections";
+import SnippetCollections from "metabase/entities/snippet-collections";
+
+import { isPersonalCollectionChild } from "metabase/collections/utils";
+
 import ModalContent from "metabase/components/ModalContent";
 import Button from "metabase/components/Button";
 import Link from "metabase/components/Link";
-import PermissionsGrid from "../components/PermissionsGrid";
 
-import * as Urls from "metabase/lib/urls";
-import { CollectionsApi } from "metabase/services";
-import Collections from "metabase/entities/collections";
-import SnippetCollections from "metabase/entities/snippet-collections";
+import PermissionsGrid from "../components/PermissionsGrid";
 
 import {
   getCollectionsPermissionsGrid,
@@ -37,6 +41,7 @@ const mapStateToProps = (state, props) => {
     collection: getCollectionEntity(props).selectors.getObject(state, {
       entityId: collectionId,
     }),
+    collectionsList: getCollectionEntity(props).selectors.getList(state, props),
   };
 };
 
@@ -64,6 +69,21 @@ export default class CollectionPermissionsModal extends Component {
     );
     loadCollections();
   }
+
+  componentDidUpdate() {
+    const { collection, collectionsList, onClose } = this.props;
+
+    const loadedPersonalCollection =
+      collection &&
+      Array.isArray(collectionsList) &&
+      (collection.personal_owner_id ||
+        isPersonalCollectionChild(collection, collectionsList));
+
+    if (loadedPersonalCollection) {
+      onClose();
+    }
+  }
+
   render() {
     const {
       grid,

--- a/frontend/src/metabase/collections/components/Header.jsx
+++ b/frontend/src/metabase/collections/components/Header.jsx
@@ -11,7 +11,13 @@ import PageHeading from "metabase/components/type/PageHeading";
 import Tooltip from "metabase/components/Tooltip";
 import CollectionEditMenu from "metabase/collections/components/CollectionEditMenu";
 
-export default function Header({ collection, isAdmin, isRoot, collectionId }) {
+export default function Header({
+  collection,
+  isAdmin,
+  isRoot,
+  isPersonalCollectionChild,
+  collectionId,
+}) {
   return (
     <Flex align="center" py={3}>
       <Flex align="center">
@@ -30,15 +36,17 @@ export default function Header({ collection, isAdmin, isRoot, collectionId }) {
       </Flex>
 
       <Flex ml="auto">
-        {isAdmin && !collection.personal_owner_id && (
-          <Tooltip tooltip={t`Edit the permissions for this collection`}>
-            <Link to={`${Urls.collection(collection)}/permissions`}>
-              <IconWrapper>
-                <Icon name="lock" />
-              </IconWrapper>
-            </Link>
-          </Tooltip>
-        )}
+        {isAdmin &&
+          !collection.personal_owner_id &&
+          !isPersonalCollectionChild && (
+            <Tooltip tooltip={t`Edit the permissions for this collection`}>
+              <Link to={`${Urls.collection(collection)}/permissions`}>
+                <IconWrapper>
+                  <Icon name="lock" />
+                </IconWrapper>
+              </Link>
+            </Tooltip>
+          )}
         {collection &&
           collection.can_write &&
           !collection.personal_owner_id && (

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -14,6 +14,7 @@ import CollectionEmptyState from "metabase/components/CollectionEmptyState";
 import Header from "metabase/collections/components/Header";
 import ItemsTable from "metabase/collections/components/ItemsTable";
 import PinnedItemsTable from "metabase/collections/components/PinnedItemsTable";
+import { isPersonalCollectionChild } from "metabase/collections/utils";
 
 import ItemsDragLayer from "metabase/containers/dnd/ItemsDragLayer";
 import PaginationControls from "metabase/components/PaginationControls";
@@ -33,7 +34,13 @@ function mapStateToProps(state) {
   };
 }
 
-function CollectionContent({ collection, collectionId, isAdmin, isRoot }) {
+function CollectionContent({
+  collection,
+  collections: collectionList = [],
+  collectionId,
+  isAdmin,
+  isRoot,
+}) {
   const [selectedItems, setSelectedItems] = useState(null);
   const [selectedAction, setSelectedAction] = useState(null);
   const [unpinnedItemsSorting, setUnpinnedItemsSorting] = useState({
@@ -140,6 +147,10 @@ function CollectionContent({ collection, collectionId, isAdmin, isRoot }) {
                 isAdmin={isAdmin}
                 collectionId={collectionId}
                 collection={collection}
+                isPersonalCollectionChild={isPersonalCollectionChild(
+                  collection,
+                  collectionList,
+                )}
               />
 
               <PinnedItemsTable
@@ -248,6 +259,10 @@ function CollectionContent({ collection, collectionId, isAdmin, isRoot }) {
 }
 
 export default _.compose(
+  Collection.loadList({
+    query: () => ({ tree: true }),
+    loadingAndErrorWrapper: false,
+  }),
   Collection.load({
     id: (_, props) => props.collectionId,
     reload: true,

--- a/frontend/src/metabase/collections/utils.js
+++ b/frontend/src/metabase/collections/utils.js
@@ -41,3 +41,13 @@ export function getParentPath(collections, targetId) {
   }
   return null; // didn't find it under any collection
 }
+
+export function isPersonalCollectionChild(collection, collectionList) {
+  // eslint-disable-next-line no-unused-vars
+  const [root, nonRootParent] = collection.effective_ancestors;
+  if (!nonRootParent) {
+    return false;
+  }
+  const parentCollection = collectionList.find(c => c.id === nonRootParent.id);
+  return parentCollection && !!parentCollection.personal_owner_id;
+}

--- a/frontend/test/metabase/scenarios/collections/personal-collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/personal-collections.cy.spec.js
@@ -41,7 +41,7 @@ describe("personal collections", () => {
       cy.icon("pencil").should("not.exist");
     });
 
-    it.skip("shouldn't be able to change permission levels for sub-collections in personal collections (metabase#8406)", () => {
+    it("shouldn't be able to change permission levels for sub-collections in personal collections (metabase#8406)", () => {
       cy.visit("/collection/root");
       cy.findByText("Your personal collection").click();
       // Create new collection inside admin's personal collection and navigate to it

--- a/frontend/test/metabase/scenarios/collections/personal-collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/personal-collections.cy.spec.js
@@ -52,6 +52,24 @@ describe("personal collections", () => {
       cy.icon("new_folder");
       cy.icon("pencil");
       cy.icon("lock").should("not.exist");
+
+      // Check can't open permissions modal via URL for personal collection
+      cy.findByText("Your personal collection").click();
+      cy.location().then(location => {
+        cy.visit(`${location}/permissions`);
+        cy.get(".Modal").should("not.exist");
+        cy.url().should("eq", String(location));
+
+        // Check can't open permissions modal via URL for personal collection child
+        cy.get("[class*=CollectionSidebar]")
+          .findByText("Foo")
+          .click();
+        cy.location().then(location => {
+          cy.visit(`${location}/permissions`);
+          cy.get(".Modal").should("not.exist");
+          cy.url().should("eq", String(location));
+        });
+      });
     });
 
     it.skip("should be able view other users' personal sub-collections (metabase#15339)", () => {

--- a/frontend/test/metabase/scenarios/collections/personal-collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/personal-collections.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, popover, modal } from "__support__/e2e/cypress";
+import { restore, popover, modal, sidebar } from "__support__/e2e/cypress";
 import { USERS } from "__support__/e2e/cypress_data";
 
 describe("personal collections", () => {
@@ -46,7 +46,7 @@ describe("personal collections", () => {
       cy.findByText("Your personal collection").click();
       // Create new collection inside admin's personal collection and navigate to it
       addNewCollection("Foo");
-      cy.get("[class*=CollectionSidebar]")
+      sidebar()
         .findByText("Foo")
         .click();
       cy.icon("new_folder");
@@ -61,7 +61,7 @@ describe("personal collections", () => {
         cy.url().should("eq", String(location));
 
         // Check can't open permissions modal via URL for personal collection child
-        cy.get("[class*=CollectionSidebar]")
+        sidebar()
           .findByText("Foo")
           .click();
         cy.location().then(location => {
@@ -78,7 +78,7 @@ describe("personal collections", () => {
       cy.findByLabelText("Name").type("Foo");
       cy.findByText("Create").click();
       // This repro could possibly change depending on the design decision for this feature implementation
-      cy.get("[class*=CollectionSidebar]").findByText("Foo");
+      sidebar().findByText("Foo");
     });
   });
 
@@ -91,7 +91,7 @@ describe("personal collections", () => {
           cy.findByText("Your personal collection").click();
           // Create initial collection inside the personal collection and navigate inside it
           addNewCollection("Foo");
-          cy.get("[class*=CollectionSidebar]")
+          sidebar()
             .as("sidebar")
             .findByText("Foo")
             .click();


### PR DESCRIPTION
According to our [docs](https://www.metabase.com/docs/latest/administration-guide/06-collections.html#personal-collections): "A personal collection works just like any other collection except that its permissions can’t be changed". The issue is that we still display a link to the collection permissions modal for personal sub-collections. This PR makes sure the modal won't be shown for personal collections and their sub-collections via UI and via `/permissions` URL

Closes #8406

### To Verify

1. Open your personal collection
2. Ensure there is no link to the collection permission modal (lock icon)
3. Create a collection inside your personal collection
4. Ensure there is no link to the collection permission modal (lock icon)
5. Try opening the modal by adding `/permissions` to an end of a URL. You have to be navigated back to `/collection/:id` page

### Demo

https://user-images.githubusercontent.com/17258145/122540129-fc9bab00-d030-11eb-9fbb-31daa31ae08b.mov
