### PR TITLE
wait for schemas/tables to load before running permissions grid logic

### DIFF
--- a/frontend/src/metabase/admin/permissions/selectors.js
+++ b/frontend/src/metabase/admin/permissions/selectors.js
@@ -1,5 +1,4 @@
 import { createSelector } from "reselect";
-
 import { push } from "react-router-redux";
 
 import TogglePropagateAction from "./containers/TogglePropagateAction";
@@ -322,8 +321,14 @@ export const getTablesPermissionsGrid = createSelector(
     schemaName: SchemaName,
   ) => {
     const database = metadata.database(databaseId);
+    const isLoading =
+      !groups ||
+      !permissions ||
+      !database ||
+      _.isEmpty(metadata.schemas) ||
+      _.isEmpty(metadata.tables);
 
-    if (!groups || !permissions || !database) {
+    if (isLoading) {
       return null;
     }
 

--- a/frontend/src/metabase/admin/permissions/selectors.js
+++ b/frontend/src/metabase/admin/permissions/selectors.js
@@ -321,18 +321,17 @@ export const getTablesPermissionsGrid = createSelector(
     schemaName: SchemaName,
   ) => {
     const database = metadata.database(databaseId);
-    const isLoading =
-      !groups ||
-      !permissions ||
-      !database ||
-      _.isEmpty(metadata.schemas) ||
-      _.isEmpty(metadata.tables);
-
-    if (isLoading) {
+    if (!groups || !permissions || !database) {
       return null;
     }
 
-    const tables = database.schema(schemaName).tables;
+    const schema = database.schema(schemaName);
+    const tables = schema && schema.tables;
+
+    if (_.isEmpty(tables)) {
+      return null;
+    }
+
     const defaultGroup = _.find(groups, isDefaultGroup);
 
     return {


### PR DESCRIPTION
Fixes #16237 

For whatever reason Database instances are populated before schemas/tables, causing the `getTablesPermissionsGrid` to try to access them before they exist. Adding an `isEmpty` check on the `metadata.schemas` and `metadata.tables` objects fixes this.

Before, refreshing the page over and over, about 50% of which have this race condition error:

https://user-images.githubusercontent.com/13057258/122596153-4dee6f00-d01e-11eb-9e90-21c11ddcc975.mov

After, no errors:

https://user-images.githubusercontent.com/13057258/122596147-4c24ab80-d01e-11eb-9688-e430aed97e17.mov


