### PR TITLE
support date ranges for click behavior that updates dashboard filter parameters

### DIFF
--- a/frontend/src/metabase/lib/click-behavior.js
+++ b/frontend/src/metabase/lib/click-behavior.js
@@ -4,6 +4,7 @@ import { t, ngettext, msgid } from "ttag";
 
 import { isDate } from "metabase/lib/schema_metadata";
 import { parseTimestamp } from "metabase/lib/time";
+import { formatDateTimeForParameter } from "metabase/lib/formatting/date";
 import Question from "metabase-lib/lib/Question";
 import { TemplateTagVariable } from "metabase-lib/lib/Variable";
 import { TemplateTagDimension } from "metabase-lib/lib/Dimension";
@@ -245,7 +246,11 @@ export function formatSourceForTarget(
       // we should serialize differently based on the target parameter type
       const parameter = getParameter(target, { extraData, clickBehavior });
       if (parameter) {
-        return formatDateForParameterType(datum.value, parameter.type);
+        return formatDateForParameterType(
+          datum.value,
+          parameter.type,
+          datum.column.unit,
+        );
       }
     } else {
       // If the target is a dimension or variable,, we serialize as a date to remove the timestamp.
@@ -256,7 +261,7 @@ export function formatSourceForTarget(
   return datum.value;
 }
 
-function formatDateForParameterType(value, parameterType) {
+function formatDateForParameterType(value, parameterType, unit) {
   const m = parseTimestamp(value);
   if (!m.isValid()) {
     return String(value);
@@ -265,11 +270,10 @@ function formatDateForParameterType(value, parameterType) {
     return m.format("YYYY-MM");
   } else if (parameterType === "date/quarter-year") {
     return m.format("[Q]Q-YYYY");
-  } else if (
-    parameterType === "date/single" ||
-    parameterType === "date/all-options"
-  ) {
+  } else if (parameterType === "date/single") {
     return m.format("YYYY-MM-DD");
+  } else if (parameterType === "date/all-options") {
+    return formatDateTimeForParameter(value, unit);
   }
   return value;
 }

--- a/frontend/src/metabase/lib/formatting/date.js
+++ b/frontend/src/metabase/lib/formatting/date.js
@@ -1,3 +1,4 @@
+import { parseTimestamp } from "metabase/lib/time";
 import type { DateSeparator } from "metabase/lib/formatting";
 
 import type { DatetimeUnit } from "metabase-types/types/Query";
@@ -119,5 +120,33 @@ export function getTimeFormatFromStyle(
     return format.replace(/mm/, "mm:ss");
   } else {
     return format;
+  }
+}
+
+export function formatDateTimeForParameter(value, unit) {
+  const m = parseTimestamp(value, unit);
+  if (!m.isValid()) {
+    return String(value);
+  }
+
+  if (unit === "month") {
+    return m.format("YYYY-MM");
+  } else if (unit === "quarter") {
+    return m.format("[Q]Q-YYYY");
+  } else if (unit === "day") {
+    return m.format("YYYY-MM-DD");
+  } else if (unit) {
+    const start = m.clone().startOf(unit);
+    const end = m.clone().endOf(unit);
+
+    if (!start.isValid() || !end.isValid()) {
+      return String(value);
+    }
+
+    const isSameDay = start.isSame(end, "day");
+
+    return isSameDay
+      ? start.format("YYYY-MM-DD")
+      : `${start.format("YYYY-MM-DD")}~${end.format("YYYY-MM-DD")}`;
   }
 }

--- a/frontend/src/metabase/lib/formatting/link.js
+++ b/frontend/src/metabase/lib/formatting/link.js
@@ -1,7 +1,7 @@
 import { isDate } from "metabase/lib/schema_metadata";
 
 import { formatValue } from "metabase/lib/formatting";
-import { parseTimestamp } from "metabase/lib/time";
+import { formatDateTimeForParameter } from "./date";
 
 function formatValueForLinkTemplate(value, column) {
   if (isDate(column) && column.unit) {
@@ -60,26 +60,4 @@ function getValueAndColumnForColumnName(
     }
   }
   return "";
-}
-
-function formatDateTimeForParameter(value, unit) {
-  const m = parseTimestamp(value, unit);
-  if (!m.isValid()) {
-    return String(value);
-  }
-
-  if (unit === "month") {
-    return m.format("YYYY-MM");
-  } else if (unit === "quarter") {
-    return m.format("[Q]Q-YYYY");
-  } else if (unit === "date") {
-    return m.format("YYYY-MM-DD");
-  } else if (unit) {
-    const start = m.clone().startOf(unit);
-    const end = m.clone().endOf(unit);
-    if (start.isValid() && end.isValid()) {
-      return `${start.format("YYYY-MM-DD")}~${end.format("YYYY-MM-DD")}`;
-    }
-    return String(value);
-  }
 }

--- a/frontend/test/metabase/lib/click-behavior.unit.spec.js
+++ b/frontend/test/metabase/lib/click-behavior.unit.spec.js
@@ -404,6 +404,45 @@ describe("metabase/lib/click-behavior", () => {
       expect(value).toEqual("foo");
     });
 
+    describe("should format date/all-options parameters", () => {
+      // TODO: use it.each after jest upgrade
+      const assertFormattedDateByUnit = (unit, expected) => {
+        const source = { type: "column", id: "SOME_DATE" };
+        const target = { type: "parameter", id: "param123" };
+        const data = {
+          column: {
+            some_date: {
+              value: "2020-01-01T00:00:00+05:00",
+              column: { base_type: "type/DateTime", unit },
+            },
+          },
+        };
+        const extraData = {
+          dashboard: {
+            parameters: [{ id: "param123", type: "date/all-options" }],
+          },
+        };
+        const clickBehavior = { type: "crossfilter" };
+        const value = formatSourceForTarget(source, target, {
+          data,
+          extraData,
+          clickBehavior,
+        });
+        expect(value).toEqual(expected);
+      };
+
+      it("should format datetimes for date parameters", () => {
+        assertFormattedDateByUnit("year", "2020-01-01~2020-12-31");
+        assertFormattedDateByUnit("quarter", "Q1-2020");
+        assertFormattedDateByUnit("month", "2020-01");
+        assertFormattedDateByUnit("week", "2019-12-29~2020-01-04");
+        assertFormattedDateByUnit("day", "2020-01-01");
+        assertFormattedDateByUnit("hour", "2020-01-01");
+        assertFormattedDateByUnit("minute", "2020-01-01");
+        assertFormattedDateByUnit("quarter-of-year", "2020-01-01");
+      });
+    });
+
     it("should format datetimes for date parameters", () => {
       const source = { type: "column", id: "SOME_DATE" };
       const target = { type: "parameter", id: "param123" };

--- a/frontend/test/metabase/lib/click-behavior.unit.spec.js
+++ b/frontend/test/metabase/lib/click-behavior.unit.spec.js
@@ -5,6 +5,8 @@ import {
   formatSourceForTarget,
 } from "metabase/lib/click-behavior";
 import { metadata, PRODUCTS } from "__support__/sample_dataset_fixture";
+import * as dateFormatUtils from "metabase/lib/formatting/date";
+
 describe("metabase/lib/click-behavior", () => {
   describe("getDataFromClicked", () => {
     it("should pull out column values from data", () => {
@@ -404,43 +406,39 @@ describe("metabase/lib/click-behavior", () => {
       expect(value).toEqual("foo");
     });
 
-    describe("should format date/all-options parameters", () => {
-      // TODO: use it.each after jest upgrade
-      const assertFormattedDateByUnit = (unit, expected) => {
-        const source = { type: "column", id: "SOME_DATE" };
-        const target = { type: "parameter", id: "param123" };
-        const data = {
-          column: {
-            some_date: {
-              value: "2020-01-01T00:00:00+05:00",
-              column: { base_type: "type/DateTime", unit },
-            },
-          },
-        };
-        const extraData = {
-          dashboard: {
-            parameters: [{ id: "param123", type: "date/all-options" }],
-          },
-        };
-        const clickBehavior = { type: "crossfilter" };
-        const value = formatSourceForTarget(source, target, {
-          data,
-          extraData,
-          clickBehavior,
-        });
-        expect(value).toEqual(expected);
-      };
+    it("should format date/all-options parameters based on unit", () => {
+      const formatDateTimeForParameterSpy = jest.spyOn(
+        dateFormatUtils,
+        "formatDateTimeForParameter",
+      );
 
-      it("should format datetimes for date parameters", () => {
-        assertFormattedDateByUnit("year", "2020-01-01~2020-12-31");
-        assertFormattedDateByUnit("quarter", "Q1-2020");
-        assertFormattedDateByUnit("month", "2020-01");
-        assertFormattedDateByUnit("week", "2019-12-29~2020-01-04");
-        assertFormattedDateByUnit("day", "2020-01-01");
-        assertFormattedDateByUnit("hour", "2020-01-01");
-        assertFormattedDateByUnit("minute", "2020-01-01");
-        assertFormattedDateByUnit("quarter-of-year", "2020-01-01");
+      const source = { type: "column", id: "SOME_DATE" };
+      const target = { type: "parameter", id: "param123" };
+      const data = {
+        column: {
+          some_date: {
+            value: "2020-01-01T00:00:00+05:00",
+            column: { base_type: "type/DateTime", unit: "year" },
+          },
+        },
+      };
+      const extraData = {
+        dashboard: {
+          parameters: [{ id: "param123", type: "date/all-options" }],
+        },
+      };
+      const clickBehavior = { type: "crossfilter" };
+      const value = formatSourceForTarget(source, target, {
+        data,
+        extraData,
+        clickBehavior,
       });
+
+      expect(formatDateTimeForParameterSpy).toHaveBeenCalledWith(
+        "2020-01-01T00:00:00+05:00",
+        "year",
+      );
+      expect(value).toEqual("2020-01-01~2020-12-31");
     });
 
     it("should format datetimes for date parameters", () => {

--- a/frontend/test/metabase/lib/formatting/date.unit.spec.js
+++ b/frontend/test/metabase/lib/formatting/date.unit.spec.js
@@ -1,0 +1,43 @@
+import { formatDateTimeForParameter } from "metabase/lib/formatting/date";
+
+describe("formatDateTimeForParameter", () => {
+  const value = "2020-01-01T00:00:00+05:00";
+
+  it("should format year", () => {
+    expect(formatDateTimeForParameter(value, "year")).toBe(
+      "2020-01-01~2020-12-31",
+    );
+  });
+
+  it("should format quarter", () => {
+    expect(formatDateTimeForParameter(value, "quarter")).toBe("Q1-2020");
+  });
+
+  it("should format month", () => {
+    expect(formatDateTimeForParameter(value, "month")).toBe("2020-01");
+  });
+
+  it("should format week", () => {
+    expect(formatDateTimeForParameter(value, "week")).toBe(
+      "2019-12-29~2020-01-04",
+    );
+  });
+
+  it("should format day", () => {
+    expect(formatDateTimeForParameter(value, "day")).toBe("2020-01-01");
+  });
+
+  it("should format hour as a day", () => {
+    expect(formatDateTimeForParameter(value, "hour")).toBe("2020-01-01");
+  });
+
+  it("should format hour as a day", () => {
+    expect(formatDateTimeForParameter(value, "minute")).toBe("2020-01-01");
+  });
+
+  it("should format quarter-of-year as a day", () => {
+    expect(formatDateTimeForParameter(value, "quarter-of-year")).toBe(
+      "2020-01-01",
+    );
+  });
+});

--- a/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
@@ -394,7 +394,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
     cy.findByText("Fantastic Wool Shirt");
   });
 
-  it.skip("should apply correct date range on a graph drill-through (metabase#13785)", () => {
+  it("should apply correct date range on a graph drill-through (metabase#13785)", () => {
     cy.log("Create a question");
 
     cy.createQuestion({

--- a/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
@@ -478,8 +478,8 @@ describe("scenarios > dashboard > dashboard drill", () => {
           .eq(14) // August 2017 (Total of 12 reviews, 9 unique days)
           .click({ force: true });
 
-        cy.wait("@cardQuery.2");
-        cy.url().should("include", "2017-08-01~2017-08-31");
+        cy.wait("@cardQuery");
+        cy.url().should("include", "2017-08");
         cy.get(".bar").should("have.length", 1);
         // Since hover doesn't work in Cypress we can't assert on the popover that's shown when one hovers the bar
         // But when this issue gets fixed, Y-axis should definitely show "12" (total count of reviews)


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/13785

`"date/all-options"` dashboard filter parameters did not support selecting ranges from click behavior when a bar that represents, for instance, a month has been clicked.

### How to verify

1) Save the following question and add it on a dashboard http://localhost:3000/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJxdWVyeSIsInF1ZXJ5Ijp7InNvdXJjZS10YWJsZSI6MiwiYWdncmVnYXRpb24iOltbImNvdW50Il1dLCJicmVha291dCI6W1siZmllbGQiLDEyLHsidGVtcG9yYWwtdW5pdCI6Im1vbnRoIn1dXX0sImRhdGFiYXNlIjoxfSwiZGlzcGxheSI6ImxpbmUiLCJ2aXN1YWxpemF0aW9uX3NldHRpbmdzIjp7fX0=
2) Create "All Options" date filter
3) Connect click behavior to the filter and save the dashboard
4) Ensure click behavior sets an entire month to the filter
5) Change the question to try other units: year, quarter, week, day, minute, etc
