### PR TITLE
Move block of code about getting input placeholder out of render function in FieldValuesWidget component

### DIFF
--- a/frontend/src/metabase/components/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget.jsx
@@ -185,6 +185,40 @@ export class FieldValuesWidget extends Component {
     }
   }
 
+  getTokenFieldPlaceholder() {
+    let { fields, placeholder } = this.props;
+
+    if (!placeholder) {
+      const [field] = fields;
+      if (this.hasList()) {
+        placeholder = t`Search the list`;
+      } else if (this.isSearchable()) {
+        const names = new Set(
+          fields.map(field => stripId(this.searchField(field).display_name)),
+        );
+        if (names.size > 1) {
+          placeholder = t`Search`;
+        } else {
+          const [name] = names;
+          placeholder = t`Search by ${name}`;
+          if (field.isID() && field !== this.searchField(field)) {
+            placeholder += t` or enter an ID`;
+          }
+        }
+      } else {
+        if (field.isID()) {
+          placeholder = t`Enter an ID`;
+        } else if (field.isNumeric()) {
+          placeholder = t`Enter a number`;
+        } else {
+          placeholder = t`Enter some text`;
+        }
+      }
+    }
+
+    return placeholder;
+  }
+
   shouldList() {
     return (
       !this.props.disableSearch &&
@@ -399,34 +433,7 @@ export class FieldValuesWidget extends Component {
     } = this.props;
     const { loadingState } = this.state;
 
-    let { placeholder } = this.props;
-    if (!placeholder) {
-      const [field] = fields;
-      if (this.hasList()) {
-        placeholder = t`Search the list`;
-      } else if (this.isSearchable()) {
-        const names = new Set(
-          fields.map(field => stripId(this.searchField(field).display_name)),
-        );
-        if (names.size > 1) {
-          placeholder = t`Search`;
-        } else {
-          const [name] = names;
-          placeholder = t`Search by ${name}`;
-          if (field.isID() && field !== this.searchField(field)) {
-            placeholder += t` or enter an ID`;
-          }
-        }
-      } else {
-        if (field.isID()) {
-          placeholder = t`Enter an ID`;
-        } else if (field.isNumeric()) {
-          placeholder = t`Enter a number`;
-        } else {
-          placeholder = t`Enter some text`;
-        }
-      }
-    }
+    const placeholder = this.getTokenFieldPlaceholder();
 
     let options = [];
     if (this.hasList() && !this.useChainFilterEndpoints()) {

--- a/frontend/src/metabase/components/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget.jsx
@@ -185,38 +185,52 @@ export class FieldValuesWidget extends Component {
     }
   }
 
-  getTokenFieldPlaceholder() {
-    let { fields, placeholder } = this.props;
+  getSearchableTokenFieldPlaceholder(fields, firstField) {
+    let placeholder;
 
-    if (!placeholder) {
-      const [field] = fields;
-      if (this.hasList()) {
-        placeholder = t`Search the list`;
-      } else if (this.isSearchable()) {
-        const names = new Set(
-          fields.map(field => stripId(this.searchField(field).display_name)),
-        );
-        if (names.size > 1) {
-          placeholder = t`Search`;
-        } else {
-          const [name] = names;
-          placeholder = t`Search by ${name}`;
-          if (field.isID() && field !== this.searchField(field)) {
-            placeholder += t` or enter an ID`;
-          }
-        }
-      } else {
-        if (field.isID()) {
-          placeholder = t`Enter an ID`;
-        } else if (field.isNumeric()) {
-          placeholder = t`Enter a number`;
-        } else {
-          placeholder = t`Enter some text`;
-        }
+    const names = new Set(
+      fields.map(field => stripId(this.searchField(field).display_name)),
+    );
+
+    if (names.size > 1) {
+      placeholder = t`Search`;
+    } else {
+      const [name] = names;
+
+      placeholder = t`Search by ${name}`;
+      if (firstField.isID() && firstField !== this.searchField(firstField)) {
+        placeholder += t` or enter an ID`;
       }
     }
-
     return placeholder;
+  }
+
+  getNonSearchableTokenFieldPlaceholder(firstField) {
+    if (firstField.isID()) {
+      return t`Enter an ID`;
+    } else if (firstField.isNumeric()) {
+      return t`Enter a number`;
+    } else {
+      return t`Enter some text`;
+    }
+  }
+
+  getTokenFieldPlaceholder() {
+    const { fields, placeholder } = this.props;
+
+    if (placeholder) {
+      return placeholder;
+    }
+
+    const [firstField] = fields;
+
+    if (this.hasList()) {
+      return t`Search the list`;
+    } else if (this.isSearchable()) {
+      return this.getSearchableTokenFieldPlaceholder(fields, firstField);
+    } else {
+      return this.getNonSearchableTokenFieldPlaceholder(firstField);
+    }
   }
 
   shouldList() {


### PR DESCRIPTION
While investigating bug https://github.com/metabase/metabase/issues/13235, we come across such fiercely confusing code we might as well clean something up to see if it helps us understand things.

This PR moves a block of code out of the `render` method of this component and breaks it down into chewable sizes.

## How to Check

1. Simple Question
2. Sample Data
3. Products
4. Filter
5. Price

You should see the input with placeholder `Enter a number`.

By changing the fields to filter through, you should see corresponding placeholders.