### PR TITLE
Do not break waterfall when there is 0 in the series

### DIFF
--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -893,7 +893,7 @@ export default function lineAreaBar(
 
   datas.map(data => {
     data.map(d => {
-      if (typeof d._waterfallValue === "number") {
+      if (isFinite(d._waterfallValue)) {
         d[1] = d._waterfallValue;
       }
     });

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -893,7 +893,7 @@ export default function lineAreaBar(
 
   datas.map(data => {
     data.map(d => {
-      if (d._waterfallValue) {
+      if (typeof d._waterfallValue === "number") {
         d[1] = d._waterfallValue;
       }
     });

--- a/frontend/src/metabase/visualizations/lib/chart_values.js
+++ b/frontend/src/metabase/visualizations/lib/chart_values.js
@@ -99,7 +99,7 @@ export function onRenderValueLabels(
           !showAll && barCount > 1 && isBarLike(display) && barWidth < 20;
         return { x, y, showLabelBelow, seriesIndex, rotated, hidden };
       })
-      .filter(d => !(isBarLike(display) && d.y === 0));
+      .filter(d => !(display === "bar" && d.y === 0));
 
     if (display === "waterfall" && data.length > 0) {
       let total = 0;

--- a/frontend/test/metabase/scenarios/visualizations/waterfall.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/waterfall.cy.spec.js
@@ -181,6 +181,35 @@ describe("scenarios > visualizations > waterfall", () => {
       .should("eq", "0.1");
   });
 
+  it("should display correct values when one of them is null (metabase#16246)", () => {
+    visitQuestionAdhoc({
+      dataset_query: {
+        type: "native",
+        native: {
+          query:
+            "SELECT * FROM (\nVALUES \n('a',2),\n('b',1),\n('c',-0.5),\n('d',-0.5),\n('e',0.1),\n('f',null),\n('g', -2)\n)\n",
+          "template-tags": {},
+        },
+        database: 1,
+      },
+      display: "waterfall",
+      visualization_settings: {
+        "graph.show_values": true,
+      },
+    });
+
+    cy.get(".value-label")
+      .as("labels")
+      .eq(-3)
+      .invoke("text")
+      .should("eq", "0");
+
+    cy.get("@labels")
+      .last()
+      .invoke("text")
+      .should("eq", "0.1");
+  });
+
   describe("scenarios > visualizations > waterfall settings", () => {
     beforeEach(() => {
       restore();

--- a/frontend/test/metabase/scenarios/visualizations/waterfall.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/waterfall.cy.spec.js
@@ -152,7 +152,7 @@ describe("scenarios > visualizations > waterfall", () => {
     cy.get(".Visualization .bar");
   });
 
-  it.skip("should display correct values when one of them is 0 (metabase#16246)", () => {
+  it("should display correct values when one of them is 0 (metabase#16246)", () => {
     visitQuestionAdhoc({
       dataset_query: {
         type: "native",


### PR DESCRIPTION
This shall fix #16246.

Run the E2E tests:
```
yarn test-cypress-no-build --spec frontend/test/metabase/scenarios/visualizations/waterfall.cy.spec.js
```

Manual steps to try (copied from #16246):
1. Ask a question, Native query
2. Type the following SQL query and then Run query (Ctrl+Enter):
```
SELECT * FROM (
VALUES 
('a',2),
('b',1),
('c',-0.5),
('d',-0.5),
('e',0.1),
('f',0),
('g', -2)
)
```
3. Visualization, Waterfall
4. Settings, Display, Show values on data points

**Before this PR**

![image](https://user-images.githubusercontent.com/7288/122623696-f833ba00-d051-11eb-8008-f4a272de2706.png)

**After this PR**

![image](https://user-images.githubusercontent.com/7288/122623697-fcf86e00-d051-11eb-958a-da55b0c038c2.png)


