### PR TITLE
GeoJSON validation and support for `Feature` type

### DIFF
--- a/frontend/src/metabase/visualizations/components/LeafletChoropleth.jsx
+++ b/frontend/src/metabase/visualizations/components/LeafletChoropleth.jsx
@@ -14,7 +14,7 @@ import { computeMinimalBounds } from "metabase/visualizations/lib/mapping";
 const LeafletChoropleth = ({
   series,
   geoJson,
-  minimalBounds = computeMinimalBounds(geoJson.features),
+  minimalBounds = computeMinimalBounds(geoJson.features || [geoJson]),
   getColor = () => color("brand"),
   onHoverFeature = () => {},
   onClickFeature = () => {},

--- a/frontend/test/metabase/scenarios/admin/settings/maps.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/maps.cy.spec.js
@@ -63,4 +63,25 @@ describe("scenarios > admin > settings > map settings", () => {
         "URLs referring to hosts that supply internal hosting metadata are prohibited.",
     );
   });
+
+  it("should show an informative error when adding a valid URL that does not contain GeoJSON, or is missing required fields", () => {
+    cy.visit("/admin/settings/maps");
+    cy.findByText("Add a map").click();
+
+    // Not GeoJSON
+    cy.findByPlaceholderText(
+      "Like https://my-mb-server.com/maps/my-map.json",
+    ).type("https://metabase.com");
+    cy.findByText("Load").click();
+    cy.findByText("Invalid custom GeoJSON: does not contain features");
+
+    // GeoJSON with an unsupported format (not a Feature or FeatureCollection)
+    cy.findByPlaceholderText(
+      "Like https://my-mb-server.com/maps/my-map.json",
+    ).type(
+      "https://raw.githubusercontent.com/metabase/metabase/master/test_resources/test.geojson",
+    );
+    cy.findByText("Load").click();
+    cy.findByText("Invalid custom GeoJSON: does not contain features");
+  });
 });

--- a/frontend/test/metabase/scenarios/admin/settings/maps.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/maps.cy.spec.js
@@ -76,11 +76,11 @@ describe("scenarios > admin > settings > map settings", () => {
     cy.findByText("Invalid custom GeoJSON: does not contain features");
 
     // GeoJSON with an unsupported format (not a Feature or FeatureCollection)
-    cy.findByPlaceholderText(
-      "Like https://my-mb-server.com/maps/my-map.json",
-    ).type(
-      "https://raw.githubusercontent.com/metabase/metabase/master/test_resources/test.geojson",
-    );
+    cy.findByPlaceholderText("Like https://my-mb-server.com/maps/my-map.json")
+      .clear()
+      .type(
+        "https://raw.githubusercontent.com/metabase/metabase/master/test_resources/test.geojson",
+      );
     cy.findByText("Load").click();
     cy.findByText("Invalid custom GeoJSON: does not contain features");
   });


### PR DESCRIPTION
This PR adds a `_validateGeoJson` method that is called after geoJSON is loaded, which checks whether all the necessary fields are present (at least one feature, and a `properties` field on each feature) and throws an error if not. This resolves #16611 and #16613.

I've also added support for geoJSON that contains a top-level `Feature` type, rather than a `FeatureCollection`, since there's no reason a single feature shouldn't work, and it's a pretty simple change. For example: https://gist.githubusercontent.com/noahmoss/bd48ac2efbd3fd1f5bc233feb308ac32/raw/9c2cd0b8a6fae8a2b53e720fb836526e315babfe/gistfile1.txt