### PR TITLE
Fix Data Model page blank if database doesn't exist

### DIFF
--- a/frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx
@@ -53,13 +53,14 @@ const mapDispatchToProps = {
     Metrics.actions.setArchived({ id }, true, rest),
 };
 
-@Databases.load({
-  id: (state, props) => props.databaseId,
-})
 @connect(
   mapStateToProps,
   mapDispatchToProps,
 )
+@Databases.load({
+  id: (state, props) => props.databaseId,
+  loadingAndErrorWrapper: false,
+})
 class MetadataEditor extends Component {
   constructor(props, context) {
     super(props, context);

--- a/frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx
@@ -17,6 +17,18 @@ import {
   fields as Fields,
 } from "metabase/entities";
 
+const propTypes = {
+  databaseId: PropTypes.number,
+  database: PropTypes.object,
+  loading: PropTypes.bool,
+  tableId: PropTypes.number,
+  selectDatabase: PropTypes.func.isRequired,
+  selectTable: PropTypes.func.isRequired,
+  idfields: PropTypes.array,
+  updateField: PropTypes.func.isRequired,
+  onRetireMetric: PropTypes.func.isRequired,
+};
+
 const mapStateToProps = (state, { params }) => {
   const databaseId = params.databaseId
     ? parseInt(params.databaseId)
@@ -48,7 +60,7 @@ const mapDispatchToProps = {
   mapStateToProps,
   mapDispatchToProps,
 )
-export default class MetadataEditor extends Component {
+class MetadataEditor extends Component {
   constructor(props, context) {
     super(props, context);
     this.toggleShowSchema = this.toggleShowSchema.bind(this);
@@ -57,18 +69,6 @@ export default class MetadataEditor extends Component {
       isShowingSchema: false,
     };
   }
-
-  static propTypes = {
-    databaseId: PropTypes.number,
-    database: PropTypes.object,
-    loading: PropTypes.bool,
-    tableId: PropTypes.number,
-    selectDatabase: PropTypes.func.isRequired,
-    selectTable: PropTypes.func.isRequired,
-    idfields: PropTypes.array,
-    updateField: PropTypes.func.isRequired,
-    onRetireMetric: PropTypes.func.isRequired,
-  };
 
   toggleShowSchema() {
     this.setState({ isShowingSchema: !this.state.isShowingSchema });
@@ -131,3 +131,7 @@ export default class MetadataEditor extends Component {
     );
   }
 }
+
+MetadataEditor.propTypes = propTypes;
+
+export default MetadataEditor;

--- a/frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx
@@ -41,6 +41,9 @@ const mapDispatchToProps = {
     Metrics.actions.setArchived({ id }, true, rest),
 };
 
+@Databases.load({
+  id: (state, props) => props.databaseId,
+})
 @connect(
   mapStateToProps,
   mapDispatchToProps,
@@ -57,6 +60,8 @@ export default class MetadataEditor extends Component {
 
   static propTypes = {
     databaseId: PropTypes.number,
+    database: PropTypes.object,
+    loading: PropTypes.bool,
     tableId: PropTypes.number,
     selectDatabase: PropTypes.func.isRequired,
     selectTable: PropTypes.func.isRequired,
@@ -75,7 +80,8 @@ export default class MetadataEditor extends Component {
   }
 
   render() {
-    const { databaseId, tableId } = this.props;
+    const { databaseId, tableId, database, loading } = this.props;
+    const hasLoadedDatabase = !loading && database;
     return (
       <div className="p4">
         <MetadataHeader
@@ -88,7 +94,7 @@ export default class MetadataEditor extends Component {
           style={{ minHeight: "60vh" }}
           className="flex flex-row flex-full mt2 full-height"
         >
-          {databaseId && (
+          {hasLoadedDatabase && (
             <MetadataTablePicker
               tableId={tableId}
               databaseId={databaseId}
@@ -109,9 +115,15 @@ export default class MetadataEditor extends Component {
             )
           ) : (
             <div style={{ paddingTop: "10rem" }} className="full text-centered">
-              <AdminEmptyText
-                message={t`Select any table to see its schema and add or edit metadata.`}
-              />
+              {!loading && (
+                <AdminEmptyText
+                  message={
+                    hasLoadedDatabase
+                      ? t`Select any table to see its schema and add or edit metadata.`
+                      : t`The page you asked for couldn't be found.`
+                  }
+                />
+              )}
             </div>
           )}
         </div>

--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -234,7 +234,7 @@ export class UnconnectedDataSelector extends Component {
       if (!schemas && database) {
         schemas = database.schemas;
       }
-      if (!tables && schemas.length === 1) {
+      if (!tables && Array.isArray(schemas) && schemas.length === 1) {
         tables = schemas[0].tables;
       }
     }

--- a/frontend/test/metabase/scenarios/admin/datamodel/table.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/table.cy.spec.js
@@ -30,6 +30,13 @@ describe("scenarios > admin > databases > table", () => {
     );
   });
 
+  it("should show 404 if database does not exist (metabase#14652)", () => {
+    cy.visit("/admin/datamodel/database/54321");
+    cy.get(".AdminList-item").should("have.length", 0);
+    cy.findByText("The page you asked for couldn't be found.");
+    cy.findByText("Select a database");
+  });
+
   describe("in orders table", () => {
     beforeEach(() => {
       cy.visit("/admin/datamodel/database/1/table/2");


### PR DESCRIPTION
When you try to open a database that doesn't exist on the Data Model page, it crashes and just shows a blank screen.

Reproduces #14652, fixes #14652

### To Verify

1. Sign in as admin
2. Go to `/admin/datamodel/database/:db-id-that-does-not-exist`
3. You should see a page saying "The page you asked for couldn't be found." and a database selector in the top left

### Screenshot

<img width="1433" alt="Screenshot 2021-06-21 at 17 26 38" src="https://user-images.githubusercontent.com/17258145/122780564-a0968800-d2b7-11eb-91c3-fafbcf3d651c.png">
