### PR TITLE
Fix line charts with only one row in the results

### DIFF
--- a/frontend/src/metabase/visualizations/components/LegendHeader.jsx
+++ b/frontend/src/metabase/visualizations/components/LegendHeader.jsx
@@ -83,7 +83,6 @@ export default class LegendHeader extends Component {
             description={description}
             color={colors[index % colors.length]}
             className={cx({ "text-brand-hover": !isBreakoutSeries })}
-            showDot
             showTitle={!isNarrow}
             isMuted={
               hovered && hovered.index != null && index !== hovered.index

--- a/frontend/src/metabase/visualizations/components/LegendHeader.jsx
+++ b/frontend/src/metabase/visualizations/components/LegendHeader.jsx
@@ -58,7 +58,6 @@ export default class LegendHeader extends Component {
       : this.props;
 
     const isNarrow = width < MIN_WIDTH_PER_SERIES * series.length;
-    const showTitles = !isNarrow;
 
     const seriesSettings =
       settings.series && series.map(single => settings.series(single));
@@ -85,7 +84,7 @@ export default class LegendHeader extends Component {
             color={colors[index % colors.length]}
             className={cx({ "text-brand-hover": !isBreakoutSeries })}
             showDot
-            showTitle={showTitles}
+            showTitle={!isNarrow}
             isMuted={
               hovered && hovered.index != null && index !== hovered.index
             }

--- a/frontend/src/metabase/visualizations/components/LegendHeader.jsx
+++ b/frontend/src/metabase/visualizations/components/LegendHeader.jsx
@@ -57,9 +57,8 @@ export default class LegendHeader extends Component {
       ? {}
       : this.props;
 
-    const showDots = !!onAddSeries || series.length > 1;
     const isNarrow = width < MIN_WIDTH_PER_SERIES * series.length;
-    const showTitles = !showDots || !isNarrow;
+    const showTitles = !isNarrow;
 
     const seriesSettings =
       settings.series && series.map(single => settings.series(single));
@@ -85,7 +84,7 @@ export default class LegendHeader extends Component {
             description={description}
             color={colors[index % colors.length]}
             className={cx({ "text-brand-hover": !isBreakoutSeries })}
-            showDot={showDots}
+            showDot
             showTitle={showTitles}
             isMuted={
               hovered && hovered.index != null && index !== hovered.index

--- a/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
+++ b/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
@@ -270,23 +270,7 @@ export default class LineAreaBarChart extends Component {
     } = this.props;
 
     const settings = this.getSettings();
-
-    const hasMultiSeriesHeaderSeries = !!(
-      series.length > 1 ||
-      onAddSeries ||
-      onEditSeries ||
-      onRemoveSeries
-    );
-
     const hasTitle = showTitle && settings["card.title"];
-
-    const defaultSeries = [
-      {
-        card: {
-          name: " ",
-        },
-      },
-    ];
 
     return (
       <div
@@ -304,22 +288,20 @@ export default class LineAreaBarChart extends Component {
             actionButtons={actionButtons}
           />
         )}
-        {hasMultiSeriesHeaderSeries || (!hasTitle && actionButtons) ? ( // always show action buttons if we have them
-          <LegendHeader
-            className="flex-no-shrink"
-            series={hasMultiSeriesHeaderSeries ? series : defaultSeries}
-            settings={settings}
-            hovered={hovered}
-            onHoverChange={this.props.onHoverChange}
-            actionButtons={!hasTitle ? actionButtons : null}
-            onChangeCardAndRun={onChangeCardAndRun}
-            onVisualizationClick={onVisualizationClick}
-            visualizationIsClickable={visualizationIsClickable}
-            onAddSeries={onAddSeries}
-            onEditSeries={onEditSeries}
-            onRemoveSeries={onRemoveSeries}
-          />
-        ) : null}
+        <LegendHeader
+          className="flex-no-shrink"
+          series={series}
+          settings={settings}
+          hovered={hovered}
+          onHoverChange={this.props.onHoverChange}
+          actionButtons={!hasTitle ? actionButtons : null}
+          onChangeCardAndRun={onChangeCardAndRun}
+          onVisualizationClick={onVisualizationClick}
+          visualizationIsClickable={visualizationIsClickable}
+          onAddSeries={onAddSeries}
+          onEditSeries={onEditSeries}
+          onRemoveSeries={onRemoveSeries}
+        />
         <CardRenderer
           {...this.props}
           series={series}

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -551,9 +551,6 @@ export const GRAPH_AXIS_SETTINGS = {
     getHidden: (series, vizSettings) =>
       vizSettings["graph.y_axis.labels_enabled"] === false,
     getDefault: (series, vizSettings) => {
-      if (series.length === 1) {
-        return vizSettings.series(series[0]).title;
-      }
       // If there are multiple series, we check if the metric names match.
       // If they do, we use that as the default y axis label.
       const [metric] = vizSettings["graph.metrics"];

--- a/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
@@ -339,7 +339,7 @@ describe("scenarios > visualizations > line chart", () => {
     }
   });
 
-  describe.skip("problems with the labels when showing only one row in the results (metabase#12782, metabase#4995)", () => {
+  describe("problems with the labels when showing only one row in the results (metabase#12782, metabase#4995)", () => {
     beforeEach(() => {
       visitQuestionAdhoc({
         dataset_query: {

--- a/frontend/test/metabase/visualizations/lib/settings/visualization.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/settings/visualization.unit.spec.js
@@ -69,20 +69,11 @@ describe("visualization_settings", () => {
         ],
         rows: [[0, 0]],
       };
-      it("should use the card name if there's one series", () => {
-        const card = {
-          visualization_settings: {},
-          display: "bar",
-          name: "card name",
-        };
-        const settings = getComputedSettingsForSeries([{ card, data }]);
-        expect(settings["graph.y_axis.title_text"]).toBe("card name");
-      });
 
       it("should use the series title if set", () => {
         const card = {
           visualization_settings: {
-            series_settings: { foo: { title: "some title" } },
+            "graph.y_axis.title_text": "some title",
           },
           display: "bar",
           name: "foo",


### PR DESCRIPTION
There are two issues with line charts when there is only one row in the results (meaning there is only one line).
Please check issues below for details:

* #12782 Wrong Label on Y-Axis When Filtering the Grouped Data to One of the GroupedBy Values
* #4995 Legends disappear when there is only one row in the results

Fixes #12782, fixes #4995

### To Verify

1. Ask a question → Custom Question → Products
2. Summarize by Average of Price
3. Break down by Created At [Year] and Category
4. Filter by Category = Doohickey
5. Click Visualize, select Line Chart if it's not shown automatically
6. The y-axis has to be "Average of Price", the x-axis has to be "Created At"
7. There has to be a chart legend under the header. A legend in our case is a horizontal list of product categories. Each legend item has to display its corresponding color

### Demo

**Before**

<img width="1462" alt="Screenshot 2021-06-21 at 18 26 19" src="https://user-images.githubusercontent.com/17258145/122788699-48638400-d2bf-11eb-9a11-1a51c88bd5ac.png">

**After**

<img width="1462" alt="Screenshot 2021-06-21 at 18 25 12" src="https://user-images.githubusercontent.com/17258145/122788717-4d283800-d2bf-11eb-973c-8b0d1b9fb745.png">
