### PR TITLE
#16674 Repro: UI inconsistencies for bucket display on tables from implicitly joined tables

### DIFF
--- a/frontend/test/metabase/scenarios/binning/binning-options.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/binning-options.cy.spec.js
@@ -50,7 +50,6 @@ describe("scenarios > binning > binning options", () => {
     cy.signInAsAdmin();
   });
 
-  // Tests are currently failing because the selected option is not highlighted in the popover
   context("via simple question", () => {
     it("should render number binning options correctly", () => {
       chooseInitialBinningOption({ table: ORDERS_ID, column: "Total" });
@@ -137,6 +136,38 @@ describe("scenarios > binning > binning options", () => {
         .contains("Month")
         .click();
       getAllOptions({ options: TIME_BUCKETS, isSelected: "Month" });
+    });
+  });
+
+  context.skip("implicit joins (metabase#16674)", () => {
+    it("should work for time series", () => {
+      chooseInitialBinningOption({
+        table: ORDERS_ID,
+        column: "Birth Date",
+      });
+
+      openPopoverFromSelectedBinningOption("Birth Date", "by month");
+      getAllOptions({ options: TIME_BUCKETS, isSelected: "Month" });
+    });
+
+    it("should work for number", () => {
+      chooseInitialBinningOption({
+        table: ORDERS_ID,
+        column: "Price",
+      });
+
+      openPopoverFromSelectedBinningOption("Price", "Auto binned");
+      getAllOptions({ options: NUMBER_BUCKETS, isSelected: "Auto bin" });
+    });
+
+    it("should work for longitude", () => {
+      chooseInitialBinningOption({
+        table: ORDERS_ID,
+        column: "Longitude",
+      });
+
+      openPopoverFromSelectedBinningOption("Longitude", "Auto binned");
+      getAllOptions({ options: LONGITUDE_BUCKETS, isSelected: "Auto bin" });
     });
   });
 });


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #16674

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/binning/binning-options.cy.spec.js`
- Replace `context.skip()` with `context.only()` to run tests in isolation
- All tests should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure all tests are passing and
- Merge it together with the fix

### Screenshots:

Time series (fails for extended options because of the casing)
![image](https://user-images.githubusercontent.com/31325167/122789717-e3f0f680-d2b7-11eb-949e-04aac7d0aae4.png)

Number
![image](https://user-images.githubusercontent.com/31325167/122789822-01be5b80-d2b8-11eb-92fb-3bcd5077e29e.png)

Longitude
![image](https://user-images.githubusercontent.com/31325167/122789916-17338580-d2b8-11eb-9ad0-8d2118b2a318.png)

