### PR TITLE
#16693 Repro: Binning from a column popover (distribution) on explicitly joined field renders incorrect title

### DIFF
--- a/frontend/test/metabase/scenarios/binning/qb-explicit-joins.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/qb-explicit-joins.cy.spec.js
@@ -195,7 +195,19 @@ describe("scenarios > binning > from a saved QB question with explicit joins", (
      * Please see: https://github.com/metabase/metabase/issues/16693.
      *
      *  1. Todo: unskip the titles in this block once #16693 gets fixed.
+     *  2. Unskip the repro for metabase#16693 which was conviniently created in this same file.
+     *
+     * Note: after #16693 gets fixed, it might even make sense to completly remove the related repro,
+     * since all other tests within this `context` will already cover that implicitly and will guard against a regression.
      */
+
+    it.skip("should render the correct title (metabase#16693)", () => {
+      cy.findByText("People → Birth Date").click();
+      cy.findByText("Distribution").click();
+
+      cy.findByText("Count by People → Birth Date: Month");
+    });
+
     it("should work for time series", () => {
       cy.findByText("People → Birth Date").click();
       cy.findByText("Distribution").click();


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #16693

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/binning/qb-explicit-joins.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/122810755-00992880-d2d0-11eb-83fd-975b73900742.png)

