### PR TITLE
fix map visualization is not suggested with first numeric column

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
+++ b/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-color-literals */
 /* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { t } from "ttag";
@@ -104,8 +103,8 @@ export default class ChoroplethMap extends Component {
 
   static minSize = { width: 4, height: 4 };
 
-  static isSensible({ cols, rows }) {
-    return cols.length > 1 && isString(cols[0]);
+  static isSensible({ cols }) {
+    return cols.length > 1;
   }
 
   static checkRenderable([

--- a/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
+++ b/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
@@ -3,7 +3,7 @@ import React, { Component } from "react";
 import { t } from "ttag";
 import LoadingSpinner from "metabase/components/LoadingSpinner";
 
-import { isString } from "metabase/lib/schema_metadata";
+import { isMetric } from "metabase/lib/schema_metadata";
 import { MinColumnsError } from "metabase/visualizations/lib/errors";
 import MetabaseSettings from "metabase/lib/settings";
 
@@ -104,7 +104,7 @@ export default class ChoroplethMap extends Component {
   static minSize = { width: 4, height: 4 };
 
   static isSensible({ cols }) {
-    return cols.length > 1;
+    return cols.length > 1 && cols.filter(isMetric).length > 0;
   }
 
   static checkRenderable([

--- a/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
+++ b/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
@@ -3,7 +3,7 @@ import React, { Component } from "react";
 import { t } from "ttag";
 import LoadingSpinner from "metabase/components/LoadingSpinner";
 
-import { isMetric } from "metabase/lib/schema_metadata";
+import { isMetric, isString } from "metabase/lib/schema_metadata";
 import { MinColumnsError } from "metabase/visualizations/lib/errors";
 import MetabaseSettings from "metabase/lib/settings";
 
@@ -104,7 +104,7 @@ export default class ChoroplethMap extends Component {
   static minSize = { width: 4, height: 4 };
 
   static isSensible({ cols }) {
-    return cols.length > 1 && cols.filter(isMetric).length > 0;
+    return cols.filter(isString).length > 0 && cols.filter(isMetric).length > 0;
   }
 
   static checkRenderable([

--- a/frontend/test/metabase/scenarios/visualizations/maps.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/maps.cy.spec.js
@@ -55,7 +55,7 @@ describe("scenarios > visualizations > maps", () => {
     cy.get(".leaflet-container");
   });
 
-  it.skip("should suggest map visualization regardless of the first column type (metabase#14254)", () => {
+  it("should suggest map visualization regardless of the first column type (metabase#14254)", () => {
     cy.createNativeQuestion({
       name: "14254",
       native: {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/14254

Suggest Choropleth map visualization when there are at least one string column and one metric column.

Before:

<img width="574" alt="Screen Shot 2021-06-22 at 00 03 09" src="https://user-images.githubusercontent.com/14301985/122827809-89728d00-d2ed-11eb-816b-c2633d1287e5.png">

After:

<img width="562" alt="Screen Shot 2021-06-22 at 00 03 50" src="https://user-images.githubusercontent.com/14301985/122827821-90010480-d2ed-11eb-9d62-d22ac52a9091.png">
