### PR TITLE
Fix a regression in getting subdimensions

### DIFF
--- a/frontend/src/metabase-lib/lib/Dimension.js
+++ b/frontend/src/metabase-lib/lib/Dimension.js
@@ -755,6 +755,13 @@ export class FieldDimension extends Dimension {
       dimensions = [...dimensions, ...temporalDimensions];
     }
 
+    const baseType = this.getOption("base-type");
+    if (baseType) {
+      dimensions = dimensions.map(dimension =>
+        dimension.withOption("base-type", baseType),
+      );
+    }
+
     return dimensions;
   }
 

--- a/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
@@ -298,7 +298,10 @@ describe("Dimension", () => {
           expect(dimension.dimensions()[1].mbql()).toEqual([
             "field",
             ORDERS.TOTAL.id,
-            { binning: { strategy: "num-bins", "num-bins": 10 } },
+            {
+              "base-type": "type/Float",
+              binning: { strategy: "num-bins", "num-bins": 10 },
+            },
           ]);
         });
       });

--- a/frontend/test/metabase/scenarios/binning/sql.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/sql.cy.spec.js
@@ -83,7 +83,7 @@ describe("scenarios > binning > from a saved sql question", () => {
     });
   });
 
-  context.skip("via custom question", () => {
+  context("via custom question", () => {
     beforeEach(() => {
       cy.visit("/question/new");
       cy.findByText("Custom question").click();
@@ -96,7 +96,7 @@ describe("scenarios > binning > from a saved sql question", () => {
       cy.findByText("Pick a column to group by").click();
     });
 
-    it("should work for time series", () => {
+    it.skip("should work for time series", () => {
       popover().within(() => {
         openPopoverFromDefaultBucketSize("CREATED_AT", "by minute");
       });
@@ -113,16 +113,16 @@ describe("scenarios > binning > from a saved sql question", () => {
       popover().within(() => {
         openPopoverFromDefaultBucketSize("TOTAL", "Auto binned");
       });
-      cy.findByText("100 bins").click();
+      cy.findByText("50 bins").click();
 
-      cy.findByText("Count by TOTAL: 100 bins");
+      cy.findByText("Count by TOTAL: 50 bins");
       cy.button("Visualize").click();
 
       waitAndAssertOnRequest("@dataset");
       cy.get(".bar");
     });
 
-    it("should work for longitude", () => {
+    it.skip("should work for longitude", () => {
       popover().within(() => {
         openPopoverFromDefaultBucketSize("LONGITUDE", "Auto binned");
       });

--- a/frontend/test/metabase/scenarios/binning/sql.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/sql.cy.spec.js
@@ -60,12 +60,12 @@ describe("scenarios > binning > from a saved sql question", () => {
       });
 
       popover().within(() => {
-        cy.findByText("100 bins").click();
+        cy.findByText("50 bins").click();
       });
 
       waitAndAssertOnRequest("@dataset");
 
-      cy.findByText("Count by TOTAL: 100 bins");
+      cy.findByText("Count by TOTAL: 50 bins");
       cy.get(".bar");
     });
 

--- a/frontend/test/metabase/scenarios/binning/sql.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/sql.cy.spec.js
@@ -162,19 +162,12 @@ describe("scenarios > binning > from a saved sql question", () => {
       cy.findByText("Q1 - 2017");
     });
 
-    it("should work for number (metabase##16670)", () => {
+    it("should work for number", () => {
       cy.findByText("TOTAL").click();
       cy.findByText("Distribution").click();
 
       assertOnXYAxisLabels({ xLabel: "TOTAL", yLabel: "Count" });
       cy.findByText("Count by TOTAL: Auto binned");
-      /*
-       * Auto binning result is much more granular than it is for QB Questions.
-       * Please, see https://github.com/metabase/metabase/issues/16670
-       *
-       * However, this is not the scope of this particular test.
-       * The explicit repro will be added later in the separate file.
-       */
       cy.get(".bar");
     });
 

--- a/frontend/test/metabase/scenarios/binning/sql.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/sql.cy.spec.js
@@ -15,7 +15,7 @@ describe("scenarios > binning > from a saved sql question", () => {
     cy.intercept("POST", "/api/dataset").as("dataset");
   });
 
-  context.skip("via simple question", () => {
+  context("via simple question", () => {
     beforeEach(() => {
       cy.visit("/question/new");
       cy.findByText("Simple question").click();
@@ -25,7 +25,7 @@ describe("scenarios > binning > from a saved sql question", () => {
       cy.wait("@dataset");
     });
 
-    it("should work for time series", () => {
+    it.skip("should work for time series", () => {
       cy.findByTestId("sidebar-right").within(() => {
         /*
          * This basic/default bucket size seems wrong.
@@ -61,7 +61,7 @@ describe("scenarios > binning > from a saved sql question", () => {
       cy.get(".bar");
     });
 
-    it("should work for longitude", () => {
+    it.skip("should work for longitude", () => {
       cy.findByTestId("sidebar-right").within(() => {
         openPopoverFromDefaultBucketSize("LONGITUDE", "Auto binned");
       });

--- a/frontend/test/metabase/scenarios/binning/sql.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/sql.cy.spec.js
@@ -2,6 +2,9 @@ import { restore, popover } from "__support__/e2e/cypress";
 
 describe("scenarios > binning > from a saved sql question", () => {
   beforeEach(() => {
+    cy.intercept("POST", "/api/card/*/query").as("cardQuery");
+    cy.intercept("POST", "/api/dataset").as("dataset");
+
     restore();
     cy.signInAsAdmin();
     cy.createNativeQuestion({
@@ -10,9 +13,14 @@ describe("scenarios > binning > from a saved sql question", () => {
         query:
           "SELECT ORDERS.CREATED_AT, ORDERS.TOTAL, PEOPLE.LONGITUDE FROM ORDERS JOIN PEOPLE ON orders.user_id = people.id",
       },
+    }).then(({ body }) => {
+      /**
+       * We need to visit the question and to wait for the result metadata to load first.
+       * Please see: https://github.com/metabase/metabase/pull/16707#issuecomment-866126310
+       */
+      cy.visit(`/question/${body.id}`);
+      cy.wait("@cardQuery");
     });
-
-    cy.intercept("POST", "/api/dataset").as("dataset");
   });
 
   context("via simple question", () => {

--- a/frontend/test/metabase/scenarios/binning/sql.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/sql.cy.spec.js
@@ -171,7 +171,7 @@ describe("scenarios > binning > from a saved sql question", () => {
       cy.get(".bar");
     });
 
-    it.skip("should work for longitude (metabase#16672)", () => {
+    it("should work for longitude", () => {
       cy.findByText("LONGITUDE").click();
       cy.findByText("Distribution").click();
 

--- a/frontend/test/metabase/scenarios/binning/sql.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/sql.cy.spec.js
@@ -36,12 +36,10 @@ describe("scenarios > binning > from a saved sql question", () => {
     it.skip("should work for time series", () => {
       cy.findByTestId("sidebar-right").within(() => {
         /*
-         * This basic/default bucket size seems wrong.
-         * For every other scenario, the default bucket for time series is "by month".
-         *
-         * TODO: update to "by month" once (metabase#16671) gets fixed.
+         * If `result_metadata` is not loaded (SQL question is not run before saving),
+         * the granularity is much finer and one can see "by minute" as the default bucket (metabase#16671).
          */
-        openPopoverFromDefaultBucketSize("CREATED_AT", "by minute");
+        openPopoverFromDefaultBucketSize("CREATED_AT", "by month");
       });
 
       popover().within(() => {

--- a/frontend/test/metabase/scenarios/binning/sql.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/sql.cy.spec.js
@@ -67,13 +67,20 @@ describe("scenarios > binning > from a saved sql question", () => {
       cy.get(".bar");
     });
 
-    it.skip("should work for longitude", () => {
+    it("should work for longitude", () => {
       cy.findByTestId("sidebar-right").within(() => {
         openPopoverFromDefaultBucketSize("LONGITUDE", "Auto binned");
       });
 
       popover().within(() => {
-        cy.findByText("Bin every 10 degrees").click();
+        /**
+         * The correct option should say "Bin every 10 degrees", but this is out of the scope of this test.
+         * It was covered in `frontend/test/metabase/scenarios/binning/binning-options.cy.spec.js`
+         * Please see: https://github.com/metabase/metabase/issues/16675.
+         *
+         * TODO: Change back to "Bin every 10 degrees" once metabase#16675 gets fixed.
+         */
+        cy.findByText("10°").click();
       });
 
       waitAndAssertOnRequest("@dataset");
@@ -122,11 +129,18 @@ describe("scenarios > binning > from a saved sql question", () => {
       cy.get(".bar");
     });
 
-    it.skip("should work for longitude", () => {
+    it("should work for longitude", () => {
       popover().within(() => {
         openPopoverFromDefaultBucketSize("LONGITUDE", "Auto binned");
       });
-      cy.findByText("Bin every 10 degrees").click();
+      /**
+       * The correct option should say "Bin every 10 degrees", but this is out of the scope of this test.
+       * It was covered in `frontend/test/metabase/scenarios/binning/binning-options.cy.spec.js`
+       * Please see: https://github.com/metabase/metabase/issues/16675
+       *
+       * TODO: Change back to "Bin every 10 degrees" once metabase#16675 gets fixed.
+       */
+      cy.findByText("10°").click();
 
       cy.findByText("Count by LONGITUDE: 10°");
       cy.button("Visualize").click();


### PR DESCRIPTION
This is basically the next logical step after PR #16140, the fix is very similar.

To verify (copied from `scenarios/binning/sql.cy.spec.js` for convenience);

1. Ask a question, Native question
2. Type the following and saved as _SQL for binning_
```sql
SELECT ORDERS.CREATED_AT, ORDERS.TOTAL, PEOPLE.LONGITUDE
FROM ORDERS
JOIN PEOPLE ON orders.user_id = people.id
```
3. Ask a question, Simple question
4. Choose _SQL for binning_ from Saved Questions
5. Summarize, Group by TOTAL, 10 bins

**Before this PR**

Failed with an error: `Value does not match schema: {:query {:breakout [(named (not (":field clauses using a string field name must specify :base-type." a-clojure.lang.PersistentVector)) "Must be a valid instance of one of these clauses: :expression, :field")]}}`

![image](https://user-images.githubusercontent.com/7288/122848662-e145cf80-d2be-11eb-9d54-bd8d1b5f380d.png)

**After this PR**

The query is successful:

![image](https://user-images.githubusercontent.com/7288/122848669-e7d44700-d2be-11eb-830a-7a9e64293430.png)
