### PR TITLE
[Binning e2e coverage] Asserting on the bins from the regular QB table

### DIFF
--- a/frontend/test/metabase/scenarios/binning/qb-regular-table.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/qb-regular-table.cy.spec.js
@@ -52,6 +52,54 @@ describe("scenarios > binning > binning options", () => {
       cy.findByText("180° W");
     });
   });
+
+  context("via custom question", () => {
+    it("should work for number", () => {
+      chooseInitialBinningOption({
+        table: ORDERS_ID,
+        column: "Total",
+        defaultBucket: "Auto bin",
+        bucketSize: "50 bins",
+        mode: "notebook",
+      });
+
+      getTitle("Count by Total: 50 bins");
+
+      cy.get(".bar");
+      cy.findByText("70");
+    });
+
+    it("should work for time series", () => {
+      chooseInitialBinningOption({
+        table: ORDERS_ID,
+        column: "Created At",
+        defaultBucket: "by month",
+        bucketSize: "Quarter",
+        mode: "notebook",
+      });
+
+      getTitle("Count by Created At: Quarter");
+
+      cy.get("circle");
+      cy.findByText("Q1 - 2017");
+    });
+
+    it("should work for longitude/latitude", () => {
+      chooseInitialBinningOption({
+        table: PEOPLE_ID,
+        column: "Longitude",
+        defaultBucket: "Auto bin",
+        bucketSize: "Bin every 20 degrees",
+        mode: "notebook",
+      });
+
+      getTitle("Count by Longitude: 20°");
+
+      cy.get(".bar");
+      cy.findByText("180° W");
+    });
+  });
+
 });
 
 function chooseInitialBinningOption({
@@ -67,7 +115,19 @@ function chooseInitialBinningOption({
   if (mode === "notebook") {
     cy.findByText("Count of rows").click();
     cy.findByText("Pick a column to group by").click();
-    cy.findByText(column).click();
+    cy.findByText(column)
+      .first()
+      .closest(".List-item")
+      .as("targetListItem");
+
+    cy.get("@targetListItem")
+      .find(".Field-extra")
+      .as("listItemSelectedBinning")
+      .should("contain", defaultBucket)
+      .click();
+
+    cy.findByText(bucketSize).click();
+    cy.button("Visualize").click();
   } else {
     cy.findByTestId("sidebar-right")
       .contains(column)

--- a/frontend/test/metabase/scenarios/binning/qb-regular-table.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/qb-regular-table.cy.spec.js
@@ -1,0 +1,90 @@
+import { restore, openTable } from "__support__/e2e/cypress";
+import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
+
+const { ORDERS_ID, PEOPLE_ID } = SAMPLE_DATASET;
+
+describe("scenarios > binning > binning options", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  context("via simple question", () => {
+    it("should work for number", () => {
+      chooseInitialBinningOption({
+        table: ORDERS_ID,
+        column: "Total",
+        defaultBucket: "Auto bin",
+        bucketSize: "50 bins",
+      });
+
+      getTitle("Count by Total: 50 bins");
+
+      cy.get(".bar");
+      cy.findByText("70");
+    });
+
+    it("should work for time series", () => {
+      chooseInitialBinningOption({
+        table: ORDERS_ID,
+        column: "Created At",
+        defaultBucket: "by month",
+        bucketSize: "Quarter",
+      });
+
+      getTitle("Count by Created At: Quarter");
+
+      cy.get("circle");
+      cy.findByText("Q1 - 2017");
+    });
+
+    it("should work for longitude/latitude", () => {
+      chooseInitialBinningOption({
+        table: PEOPLE_ID,
+        column: "Longitude",
+        defaultBucket: "Auto bin",
+        bucketSize: "Bin every 20 degrees",
+      });
+
+      getTitle("Count by Longitude: 20°");
+
+      cy.get(".bar");
+      cy.findByText("180° W");
+    });
+  });
+});
+
+function chooseInitialBinningOption({
+  table,
+  column,
+  defaultBucket,
+  bucketSize,
+  mode = null,
+} = {}) {
+  openTable({ table, mode });
+  cy.findByText("Summarize").click();
+
+  if (mode === "notebook") {
+    cy.findByText("Count of rows").click();
+    cy.findByText("Pick a column to group by").click();
+    cy.findByText(column).click();
+  } else {
+    cy.findByTestId("sidebar-right")
+      .contains(column)
+      .first()
+      .closest(".List-item")
+      .as("targetListItem");
+
+    cy.get("@targetListItem")
+      .find(".Field-extra")
+      .as("listItemSelectedBinning")
+      .should("contain", defaultBucket)
+      .click();
+
+    cy.findByText(bucketSize).click();
+  }
+}
+
+function getTitle(title) {
+  cy.findByText(title);
+}

--- a/frontend/test/metabase/scenarios/binning/qb-regular-table.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/qb-regular-table.cy.spec.js
@@ -100,6 +100,40 @@ describe("scenarios > binning > binning options", () => {
     });
   });
 
+  context("via column popover", () => {
+    it("should work for number", () => {
+      openTable({ table: ORDERS_ID });
+      cy.findByText("Total").click();
+      cy.findByText("Distribution").click();
+
+      getTitle("Count by Total: Auto binned");
+
+      cy.get(".bar");
+      cy.findByText("60");
+    });
+
+    it("should work for time series", () => {
+      openTable({ table: ORDERS_ID });
+      cy.findByText("Created At").click();
+      cy.findByText("Distribution").click();
+
+      getTitle("Count by Created At: Month");
+
+      cy.get("circle");
+      cy.findByText("January, 2017");
+    });
+
+    it("should work for longitude/latitude", () => {
+      openTable({ table: PEOPLE_ID });
+      cy.findByText("Longitude").click();
+      cy.findByText("Distribution").click();
+
+      getTitle("Count by Longitude: Auto binned");
+
+      cy.get(".bar");
+      cy.findByText("170° W");
+    });
+  });
 });
 
 function chooseInitialBinningOption({


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Adds set of tests around binning on the regular QB table (which is the equivalent of that same table saved as a question)
- Adds the last of the specs that check for the **core** binning functionality, according to the #16387

### Screenshots
![image](https://user-images.githubusercontent.com/31325167/122921632-fd02b180-d362-11eb-9729-45152704955c.png)
