### PR TITLE
Fix line chart's y-axis for filtered multi-series charts

### DIFF
--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -551,9 +551,6 @@ export const GRAPH_AXIS_SETTINGS = {
     getHidden: (series, vizSettings) =>
       vizSettings["graph.y_axis.labels_enabled"] === false,
     getDefault: (series, vizSettings) => {
-      if (series.length === 1) {
-        return vizSettings.series(series[0]).title;
-      }
       // If there are multiple series, we check if the metric names match.
       // If they do, we use that as the default y axis label.
       const [metric] = vizSettings["graph.metrics"];

--- a/frontend/test/metabase/scenarios/dashboard/chained-filters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/chained-filters.cy.spec.js
@@ -227,7 +227,7 @@ describe("scenarios > dashboard > chained filter", () => {
       cy.findByText("Anchorage").click();
       cy.findByText("Add filter").click();
     });
-    cy.get(".y-label").contains("Count");
+    cy.get(".y-label").contains("count");
 
     // Then we make sure it works in pseudo-embedded mode.
     cy.visit(`/embed/dashboard/${DASHBOARD_JWT_TOKEN}`);
@@ -244,7 +244,7 @@ describe("scenarios > dashboard > chained filter", () => {
       cy.findByText("Add filter").click();
     });
 
-    cy.get(".y-label").contains("Count");
+    cy.get(".y-label").contains("count");
     cy.findByText("There was a problem displaying this chart.").should(
       "not.exist",
     );

--- a/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
@@ -339,7 +339,7 @@ describe("scenarios > visualizations > line chart", () => {
     }
   });
 
-  describe.skip("problems with the labels when showing only one row in the results (metabase#12782, metabase#4995)", () => {
+  describe("problems with the labels when showing only one row in the results (metabase#12782, metabase#4995)", () => {
     beforeEach(() => {
       visitQuestionAdhoc({
         dataset_query: {
@@ -360,7 +360,7 @@ describe("scenarios > visualizations > line chart", () => {
       cy.findByText("Category is Doohickey");
     });
 
-    it("should not drop the chart legend (metabase#4995)", () => {
+    it.skip("should not drop the chart legend (metabase#4995)", () => {
       cy.get(".LegendItem").should("contain", "Doohickey");
     });
 

--- a/frontend/test/metabase/visualizations/lib/settings/visualization.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/settings/visualization.unit.spec.js
@@ -69,20 +69,11 @@ describe("visualization_settings", () => {
         ],
         rows: [[0, 0]],
       };
-      it("should use the card name if there's one series", () => {
-        const card = {
-          visualization_settings: {},
-          display: "bar",
-          name: "card name",
-        };
-        const settings = getComputedSettingsForSeries([{ card, data }]);
-        expect(settings["graph.y_axis.title_text"]).toBe("card name");
-      });
 
       it("should use the series title if set", () => {
         const card = {
           visualization_settings: {
-            series_settings: { foo: { title: "some title" } },
+            "graph.y_axis.title_text": "some title",
           },
           display: "bar",
           name: "foo",


### PR DESCRIPTION
If we have a multi-series line-chart and apply some filter that leaves only one line, the y-axis label is wrong
You can find an example at #12782

Fixes #12782

### To Verify

1. Ask a question → Custom Question → Products
2. Summarize by Average of Price
3. Break down by Created At [Year] and Category
5. Click Visualize, select Line Chart if it's not shown automatically
6. Notice the y-axis is "Average of Price"
7. Filter by Category = Doohickey
8. The y-axis should still be "Average of Price"

### Demo

**Before**

<img width="1462" alt="Screenshot 2021-06-21 at 18 26 19" src="https://user-images.githubusercontent.com/17258145/122788699-48638400-d2bf-11eb-9a11-1a51c88bd5ac.png">

**After**

<img width="1439" alt="Screenshot 2021-06-22 at 17 12 35" src="https://user-images.githubusercontent.com/17258145/122940352-11ec3e80-d37d-11eb-83ae-d78ec1cb54ab.png">

