### PR TITLE
Fix invalid calculation of chart dimensions caused collapsing

### DIFF
--- a/frontend/src/metabase/visualizations/lib/RowRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/RowRenderer.js
@@ -166,8 +166,8 @@ export default function rowRenderer(
   chart.cap(cap);
 
   if (barHeight > ROW_MAX_HEIGHT) {
-    const reasolableMaxGap = boundsHeight / 3;
-    chart.gap(Math.min(barHeight / 2, reasolableMaxGap));
+    const reasonableMaxGap = boundsHeight / 3;
+    chart.gap(Math.min(barHeight / 2, reasonableMaxGap));
   }
 
   chart.render();

--- a/frontend/src/metabase/visualizations/lib/RowRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/RowRenderer.js
@@ -120,7 +120,6 @@ export default function rowRenderer(
     .ordering(d => d.index);
 
   const labelPadHorizontal = 5;
-  const labelPadVertical = 1;
   let labelsOutside = false;
 
   chart.on("renderlet.bar-labels", chart => {
@@ -159,24 +158,15 @@ export default function rowRenderer(
     chart.margins().bottom += axisLabelHeight;
   }
 
-  // cap number of rows to fit
-  const rects = chart.selectAll(".row rect")[0];
-  const containerHeight =
-    rects[rects.length - 1].getBoundingClientRect().bottom -
-    rects[0].getBoundingClientRect().top;
-  const maxTextHeight = Math.max(
-    ...chart
-      .selectAll("g.row text")[0]
-      .map(e => e.getBoundingClientRect().height),
-  );
-  const rowHeight = maxTextHeight + chart.gap() + labelPadVertical * 2;
-  const cap = Math.max(1, Math.floor(containerHeight / rowHeight));
+  const { top, bottom } = chart.margins();
+  const boundsHeight = chart.height() - top - bottom;
+  const rowHeight = (boundsHeight - chart.gap()) / group.size();
+  const barHeight = rowHeight - chart.gap();
+  const cap = Math.max(1, Math.floor(boundsHeight / ROW_MAX_HEIGHT));
   chart.cap(cap);
 
-  // assume all bars are same height?
-  const barHeight = chart.select("g.row")[0][0].getBoundingClientRect().height;
   if (barHeight > ROW_MAX_HEIGHT) {
-    const reasolableMaxGap = containerHeight / 3;
+    const reasolableMaxGap = boundsHeight / 3;
     chart.gap(Math.min(barHeight / 2, reasolableMaxGap));
   }
 

--- a/frontend/test/metabase/scenarios/visualizations/rows.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/rows.cy.spec.js
@@ -8,27 +8,38 @@ describe("scenarios > visualizations > rows", () => {
 
   // Until we enable multi-browser support, this repro will be skipped by Cypress in CI
   // Issue was specific to Firefox only - it is still possible to test it locally
-  it(
-    "should not collapse rows when last value is 0 (metabase#14285)",
-    { browser: "firefox" },
-    () => {
-      cy.createNativeQuestion({
-        name: "14285",
-        native: {
-          query:
-            "with temp as (\n select 'a' col1, 25 col2\n union all \n select 'b', 10\n union all \n select 'c', 15\n union all \n select 'd', 0\n union all\n select 'e', 30\n union all \n select 'f', 35\n)\nselect * from temp\norder by 2 desc",
-          "template-tags": {},
-        },
-        display: "row",
-      }).then(({ body: { id: QUESTION_ID } }) => {
-        cy.visit(`/question/${QUESTION_ID}`);
-      });
-
-      cy.get(".Visualization").within(() => {
-        ["a", "b", "c", "d", "e", "f"].forEach(letter => {
-          cy.findByText(letter);
+  ["0", "null"].forEach(testValue => {
+    it(
+      `should not collapse rows when last value is ${testValue} (metabase#14285)`,
+      { browser: "firefox" },
+      () => {
+        cy.createNativeQuestion({
+          name: "14285",
+          native: {
+            query: `
+              with temp as (
+                select 'a' col1, 25 col2 union all
+                select 'b', 10 union all
+                select 'c', 15 union all
+                select 'd', ${testValue} union all
+                select 'e', 30 union all
+                select 'f', 35
+              ) select * from temp
+              order by 2 desc
+            `,
+            "template-tags": {},
+          },
+          display: "row",
+        }).then(({ body: { id: QUESTION_ID } }) => {
+          cy.visit(`/question/${QUESTION_ID}`);
         });
-      });
-    },
-  );
+
+        cy.get(".Visualization").within(() => {
+          ["a", "b", "c", "d", "e", "f"].forEach(letter => {
+            cy.findByText(letter);
+          });
+        });
+      },
+    );
+  });
 });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/14285

Fix invalid calculations of bounds height, row height.

## Screenshots

### First value is `0`
```sql
select 'a' c1 , 0 c2
union all 
select 'b' c1 , 2 c2
```

**Before (Both browsers)**
<img width="1438" alt="Screen Shot 2021-06-22 at 20 52 49" src="https://user-images.githubusercontent.com/14301985/122975487-107e3e80-d39c-11eb-9904-e0c9b6361ef7.png">

**After (both browsers)**
<img width="1440" alt="Screen Shot 2021-06-22 at 18 54 05" src="https://user-images.githubusercontent.com/14301985/122958101-39e29e80-d38b-11eb-89db-fd715c7781e4.png">

### Last value is `0`
```sql
select 'a' c1 , 2 c2
union all 
select 'b' c1 , 0 c2
```

**Before (Firefox only)**

<img width="1423" alt="Screen Shot 2021-06-22 at 20 53 14" src="https://user-images.githubusercontent.com/14301985/122975622-37d50b80-d39c-11eb-9be5-10cc4a1c43c5.png">

**After (both browsers)**
<img width="1437" alt="Screen Shot 2021-06-22 at 18 52 43" src="https://user-images.githubusercontent.com/14301985/122958264-5e3e7b00-d38b-11eb-8c47-d040c0a5ed03.png">
