### PR TITLE
Clean up styles on password reset button

### DIFF
--- a/src/metabase/email/password_reset.mustache
+++ b/src/metabase/email/password_reset.mustache
@@ -7,7 +7,7 @@
     {{^sso}}
     <div style="text-align: center">
       <p>Click the button below to reset the password for your {{applicationName}} account at {{hostname}}.</p>
-      <a style="display: inline-block; box-sizing: border-box; text-decoration: none; font-size: 1.063rem; padding: 0.5rem 1.375rem; background: #FBFCFD; border: 1px solid #ddd; color: #444; cursor: pointer; text-decoration: none; border-radius: 4px; background-color: #4990E2; border-color: #4990E2; color: #fff;" href="{{passwordResetUrl}}">Reset password</a>
+      <a style="display: inline-block; box-sizing: border-box; font-size: 1.063rem; padding: 0.5rem 1.375rem; cursor: pointer; text-decoration: none; border-radius: 4px; background-color: #4990E2; border-color: #4990E2; color: #fff;" href="{{passwordResetUrl}}">Reset password</a>
       <p style="padding-top: 2em; font-size: small;">Didn't request this password reset? It's safe to ignore it.</p>
     </div>
     {{/sso}}

--- a/src/metabase/email/password_reset.mustache
+++ b/src/metabase/email/password_reset.mustache
@@ -7,7 +7,7 @@
     {{^sso}}
     <div style="text-align: center">
       <p>Click the button below to reset the password for your {{applicationName}} account at {{hostname}}.</p>
-      <a style="display: inline-block; box-sizing: border-box; font-size: 1.063rem; padding: 0.5rem 1.375rem; cursor: pointer; text-decoration: none; border-radius: 4px; background-color: #4990E2; border-color: #4990E2; color: #fff;" href="{{passwordResetUrl}}">Reset password</a>
+      <a style="display: inline-block; box-sizing: border-box; font-size: 18px; padding: 8px 22px; cursor: pointer; text-decoration: none; border-radius: 4px; background-color: #4990E2; border-color: #4990E2; color: #fff;" href="{{passwordResetUrl}}">Reset password</a>
       <p style="padding-top: 2em; font-size: small;">Didn't request this password reset? It's safe to ignore it.</p>
     </div>
     {{/sso}}


### PR DESCRIPTION
I can't repro #13998, so I'm not 100% sure this fixes that specific issue, but the styles on the password reset button were pretty messy so I've removed the ones that are unnecessary or were being overridden by another style.

Tested in Maildev and outlook.live.com, and the button appears the same as before:

<img width="617" alt="image" src="https://user-images.githubusercontent.com/32746338/122985075-bd8c9300-d36b-11eb-8118-d1539b5bf9d8.png">
