### PR TITLE
Xray joins 14793 mk3

### DIFF
--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -497,10 +497,10 @@ describe("scenarios > question > notebook", () => {
       });
     });
 
-    it.skip("x-rays should work on explicit joins when metric is for the joined table (metabase#14793)", () => {
+    it("x-rays should work on explicit joins when metric is for the joined table (metabase#14793)", () => {
       cy.server();
       cy.route("POST", "/api/dataset").as("dataset");
-      cy.route("GET", "/api/automagic-dashboards/adhoc/").as("xray");
+      cy.route("GET", "/api/automagic-dashboards/adhoc/**").as("xray");
 
       visitQuestionAdhoc({
         dataset_query: {

--- a/src/metabase/automagic_dashboards/core.clj
+++ b/src/metabase/automagic_dashboards/core.clj
@@ -1165,18 +1165,19 @@
                  (tru "where {0}" (humanize-filter-value root cell-query))]))
 
 (defn- key-in?
-  "Recursively finds key in coll, returns true or nil"
+  "Recursively finds key in coll, returns true or false"
   [coll k]
-  (let [coll-zip (zip/zipper coll? #(if (map? %) (vals %) %) nil coll)]
+  (boolean (let [coll-zip (zip/zipper coll? #(if (map? %) (vals %) %) nil coll)]
     (loop [x coll-zip]
       (when-not (zip/end? x)
-        (if-let [v (k (zip/node x))] true (recur (zip/next x)))))))
+        (if-let [v (k (zip/node x))] true (recur (zip/next x))))))))
 
 (defn- splice-in
   [join-statement card-member]
   (let [query (get-in card-member [:card :dataset_query :query])]
     (if (key-in? query :join-alias)
-      (assoc query :join-alias join-statement)
+      ;; Always in the top level even if the join-alias is found deep in there
+      (assoc query :joins join-statement)
       query)))
 
 (defn- maybe-enrich-joins

--- a/src/metabase/automagic_dashboards/core.clj
+++ b/src/metabase/automagic_dashboards/core.clj
@@ -1177,13 +1177,13 @@
   (let [query (get-in card-member [:card :dataset_query :query])]
     (if (key-in? query :join-alias)
       ;; Always in the top level even if the join-alias is found deep in there
-      (assoc query :joins join-statement)
-      query)))
+      (assoc-in card-member [:card :dataset_query :query :joins] join-statement)
+      card-member)))
 
 (defn- maybe-enrich-joins
   "Hack to shove back in joins when they get automagically stripped out by the question decomposition into metrics"
   [entity dashboard]
-  (if-let [join-statement (get-in entity [:entity :dataset_query :query :joins])]
+  (if-let [join-statement (get-in entity [:dataset_query :query :joins])]
     (update dashboard :ordered_cards #(map (partial splice-in join-statement) %))
     dashboard))
 

--- a/src/metabase/automagic_dashboards/core.clj
+++ b/src/metabase/automagic_dashboards/core.clj
@@ -7,6 +7,7 @@
             [clojure.string :as str]
             [clojure.tools.logging :as log]
             [clojure.walk :as walk]
+            [clojure.zip :as zip]
             [java-time :as t]
             [kixi.stats.core :as stats]
             [kixi.stats.math :as math]
@@ -1163,7 +1164,20 @@
                    (:full-name root))
                  (tru "where {0}" (humanize-filter-value root cell-query))]))
 
-(defn- splice-in [join-statement card-member] some shit here)
+(defn- key-in?
+  "Recursively finds key in coll, returns true or nil"
+  [coll k]
+  (let [coll-zip (zip/zipper coll? #(if (map? %) (vals %) %) nil coll)]
+    (loop [x coll-zip]
+      (when-not (zip/end? x)
+        (if-let [v (k (zip/node x))] true (recur (zip/next x)))))))
+
+(defn- splice-in
+  [join-statement card-member]
+  (let [query (get-in card-member [:card :dataset_query :query])]
+    (if (key-in? query :join-alias)
+      (assoc query :join-alias join-statement)
+      query)))
 
 (defn- maybe-enrich-joins
   "Hack to shove back in joins when they get automagically stripped out by the question decomposition into metrics"

--- a/test/metabase/automagic_dashboards/core_test.clj
+++ b/test/metabase/automagic_dashboards/core_test.clj
@@ -68,6 +68,8 @@
    (testing (u/pprint-to-str (list 'automagic-analysis entity {:cell-query cell-query, :show 1}))
      (automagic-dashboards.test/test-dashboard-is-valid (magic/automagic-analysis entity {:cell-query cell-query, :show 1})))))
 
+;; These test names were named by staring at them for a while, so they may be misleading
+
 (deftest automagic-analysis-test
   (mt/with-test-user :rasta
     (automagic-dashboards.test/with-dashboard-cleanup
@@ -81,17 +83,14 @@
                   (filter :card)
                   count))))))
 
-(deftest wierd-characters-in-names-test
+(deftest weird-characters-in-names-test
   (mt/with-test-user :rasta
     (automagic-dashboards.test/with-dashboard-cleanup
       (-> (Table (mt/id :venues))
           (assoc :display_name "%Venues")
           test-automagic-analysis))))
 
-;; TODO -- Not sure what most of the tests below are for, so they just have numbers for names right now. Give them
-;; better names if you can figure out what they test.
-
-(deftest test-1
+(deftest visibility-type-test
   (mt/with-test-user :rasta
     (automagic-dashboards.test/with-dashboard-cleanup
       (doseq [field (db/select Field
@@ -106,21 +105,21 @@
       (automagic-dashboards.test/with-dashboard-cleanup
         (test-automagic-analysis metric)))))
 
-(deftest test-2
+(deftest complicated-card-test
   (mt/with-non-admin-groups-no-root-collection-perms
     (mt/with-temp* [Collection [{collection-id :id}]
                     Card [{card-id :id} {:table_id      (mt/id :venues)
                                          :collection_id collection-id
-                                         :dataset_query {:query {:filter [:> [:field (mt/id :venues :price) nil] 10]
-                                                                 :source-table (mt/id :venues)}
-                                                         :type :query
+                                         :dataset_query {:query    {:filter [:> [:field (mt/id :venues :price) nil] 10]
+                                                                    :source-table (mt/id :venues)}
+                                                         :type     :query
                                                          :database (mt/id)}}]]
       (mt/with-test-user :rasta
         (automagic-dashboards.test/with-dashboard-cleanup
           (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection-id)
           (test-automagic-analysis (Card card-id)))))))
 
-(deftest test-3
+(deftest query-breakout-test
   (mt/with-non-admin-groups-no-root-collection-perms
     (mt/with-temp* [Collection [{collection-id :id}]
                     Card [{card-id :id} {:table_id      (mt/id :venues)
@@ -134,7 +133,7 @@
         (automagic-dashboards.test/with-dashboard-cleanup
           (test-automagic-analysis (Card card-id)))))))
 
-(deftest test-4
+(deftest native-query-test
   (mt/with-non-admin-groups-no-root-collection-perms
     (mt/with-temp* [Collection [{collection-id :id}]
                     Card [{card-id :id} {:table_id      nil
@@ -153,7 +152,7 @@
     [(qp.async/result-metadata-for-query-async query)
      (a/timeout 1000)])))
 
-(deftest test-6
+(deftest explicit-filter-test
   (mt/with-non-admin-groups-no-root-collection-perms
     (let [source-query {:query    {:source-table (mt/id :venues)}
                         :type     :query
@@ -174,21 +173,7 @@
             (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection-id)
             (test-automagic-analysis (Card card-id))))))))
 
-(deftest test-7
-  (mt/with-non-admin-groups-no-root-collection-perms
-    (mt/with-temp* [Collection [{collection-id :id}]
-                    Card [{card-id :id} {:table_id      (mt/id :venues)
-                                         :collection_id collection-id
-                                         :dataset_query {:query    {:filter       [:> [:field (mt/id :venues :price) nil] 10]
-                                                                    :source-table (mt/id :venues)}
-                                                         :type     :query
-                                                         :database (mt/id)}}]]
-      (mt/with-test-user :rasta
-        (automagic-dashboards.test/with-dashboard-cleanup
-          (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection-id)
-          (test-automagic-analysis (Card card-id)))))))
-
-(deftest test-8
+(deftest native-query-with-cards-test
   (mt/with-non-admin-groups-no-root-collection-perms
     (let [source-query {:native   {:query "select * from venues"}
                         :type     :native
@@ -209,7 +194,7 @@
             (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection-id)
             (test-automagic-analysis (Card card-id))))))))
 
-(deftest test-9
+(deftest card-breakout-test
   (mt/with-non-admin-groups-no-root-collection-perms
     (mt/with-temp* [Collection [{collection-id :id}]
                     Card [{card-id :id} {:table_id      (mt/id :venues)
@@ -224,7 +209,7 @@
           (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection-id)
           (test-automagic-analysis (Card card-id)))))))
 
-(deftest test-10
+(deftest figure-out-table-id-test
   (mt/with-non-admin-groups-no-root-collection-perms
     (mt/with-temp* [Collection [{collection-id :id}]
                     Card [{card-id :id} {:table_id      nil
@@ -237,20 +222,7 @@
           (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection-id)
           (test-automagic-analysis (Card card-id)))))))
 
-(deftest test-11
-  (mt/with-non-admin-groups-no-root-collection-perms
-    (mt/with-temp* [Collection [{collection-id :id}]
-                    Card [{card-id :id} {:table_id      nil
-                                         :collection_id collection-id
-                                         :dataset_query {:native   {:query "select * from users"}
-                                                         :type     :native
-                                                         :database (mt/id)}}]]
-      (mt/with-test-user :rasta
-        (automagic-dashboards.test/with-dashboard-cleanup
-          (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection-id)
-          (test-automagic-analysis (Card card-id)))))))
-
-(deftest test-12
+(deftest card-cell-test
   (mt/with-non-admin-groups-no-root-collection-perms
     (mt/with-temp* [Collection [{collection-id :id}]
                     Card [{card-id :id} {:table_id      (mt/id :venues)
@@ -267,7 +239,7 @@
               (test-automagic-analysis [:= [:field (mt/id :venues :category_id) nil] 2])))))))
 
 
-(deftest test-13
+(deftest complicated-card-cell-test
   (mt/with-non-admin-groups-no-root-collection-perms
     (mt/with-temp* [Collection [{collection-id :id}]
                     Card [{card-id :id} {:table_id      (mt/id :venues)
@@ -284,7 +256,7 @@
               (test-automagic-analysis [:= [:field (mt/id :venues :category_id) nil] 2])))))))
 
 
-(deftest test-14
+(deftest adhoc-filter-test
   (mt/with-test-user :rasta
     (automagic-dashboards.test/with-dashboard-cleanup
       (let [q (query/adhoc-query {:query {:filter [:> [:field (mt/id :venues :price) nil] 10]
@@ -293,7 +265,7 @@
                                   :database (mt/id)})]
         (test-automagic-analysis q)))))
 
-(deftest test-15
+(deftest adhoc-count-test
   (mt/with-test-user :rasta
     (automagic-dashboards.test/with-dashboard-cleanup
       (let [q (query/adhoc-query {:query {:aggregation [[:count]]
@@ -303,7 +275,7 @@
                                   :database (mt/id)})]
         (test-automagic-analysis q)))))
 
-(deftest test-16
+(deftest adhoc-fk-breakout-test
   (mt/with-test-user :rasta
     (automagic-dashboards.test/with-dashboard-cleanup
       (let [q (query/adhoc-query {:query {:aggregation [[:count]]
@@ -313,7 +285,7 @@
                                   :database (mt/id)})]
         (test-automagic-analysis q)))))
 
-(deftest test-17
+(deftest adhoc-filter-cell-test
   (mt/with-test-user :rasta
     (automagic-dashboards.test/with-dashboard-cleanup
       (let [q (query/adhoc-query {:query {:filter [:> [:field (mt/id :venues :price) nil] 10]

--- a/test/metabase/automagic_dashboards/core_test.clj
+++ b/test/metabase/automagic_dashboards/core_test.clj
@@ -10,7 +10,7 @@
             [metabase.models.field :as field]
             [metabase.models.permissions :as perms]
             [metabase.models.permissions-group :as perms-group]
-            [metabase.models.query :as query]
+            [metabase.models.query :as query :refer [Query]]
             [metabase.query-processor.async :as qp.async]
             [metabase.test :as mt]
             [metabase.test.automagic-dashboards :as automagic-dashboards.test]
@@ -65,9 +65,11 @@
    ;; that size limiting works.
    (testing (u/pprint-to-str (list 'automagic-analysis entity {:cell-query cell-query, :show :all}))
      (automagic-dashboards.test/test-dashboard-is-valid (magic/automagic-analysis entity {:cell-query cell-query, :show :all}) card-count))
-   (testing (u/pprint-to-str (list 'automagic-analysis entity {:cell-query cell-query, :show 1}))
-     ;; 1 for the actual card returned + 1 for the visual display card = 2
-     (automagic-dashboards.test/test-dashboard-is-valid (magic/automagic-analysis entity {:cell-query cell-query, :show 1}) 2))))
+   (when (or (nil? (#{(type Query) (type Card)} (type entity)))
+             (#'magic/table-like? entity))
+     (testing (u/pprint-to-str (list 'automagic-analysis entity {:cell-query cell-query, :show 1}))
+       ;; 1 for the actual card returned + 1 for the visual display card = 2
+       (automagic-dashboards.test/test-dashboard-is-valid (magic/automagic-analysis entity {:cell-query cell-query, :show 1}) 2)))))
 
 ;; These test names were named by staring at them for a while, so they may be misleading
 

--- a/test/metabase/automagic_dashboards/core_test.clj
+++ b/test/metabase/automagic_dashboards/core_test.clj
@@ -95,19 +95,16 @@
           (assoc :display_name "%Venues")
           (test-automagic-analysis 7)))))
 
-;; There's weird stuff with regards to drivers up in fields, so these tests on different drivers have different cardinalities
+;; Cardinality of cards genned from fields is much more labile than anything else
+;; Not just with respect to drivers, but all sorts of other stuff that makes it chaotic
 (deftest mass-field-test
-  (mt/test-drivers
-    #{:h2 :sqlite :sqlserver :oracle}
     (mt/with-test-user :rasta
       (automagic-dashboards.test/with-dashboard-cleanup
-        (doseq [[field cardinality] (map vector
-                                         (db/select Field
-                                                    :table_id [:in (db/select-field :id Table :db_id (mt/id))]
-                                                    :visibility_type "normal"
-                                                    {:order-by [[:id :asc]]})
-                                         [8 7 6 8 7 7 10])]
-          (test-automagic-analysis field cardinality))))))
+        (doseq [field (db/select Field
+                                 :table_id [:in (db/select-field :id Table :db_id (mt/id))]
+                                 :visibility_type "normal"
+                                 {:order-by [[:id :asc]]})]
+          (is (pos? (count (:ordered_cards (magic/automagic-analysis field {})))))))))
 
 (deftest mass-field-test-different-drivers
   (mt/test-drivers

--- a/test/metabase/automagic_dashboards/core_test.clj
+++ b/test/metabase/automagic_dashboards/core_test.clj
@@ -111,7 +111,7 @@
 
 (deftest mass-field-test-different-drivers
   (mt/test-drivers
-    #{:h2 :sqlite :sqlserver :oracle}
+    #{:postgres :mysql}
     (mt/with-test-user :rasta
       (automagic-dashboards.test/with-dashboard-cleanup
         (doseq [[field cardinality] (map vector

--- a/test/metabase/automagic_dashboards/core_test.clj
+++ b/test/metabase/automagic_dashboards/core_test.clj
@@ -106,19 +106,6 @@
                                  {:order-by [[:id :asc]]})]
           (is (pos? (count (:ordered_cards (magic/automagic-analysis field {})))))))))
 
-(deftest mass-field-test-different-drivers
-  (mt/test-drivers
-    #{:postgres :mysql}
-    (mt/with-test-user :rasta
-      (automagic-dashboards.test/with-dashboard-cleanup
-        (doseq [[field cardinality] (map vector
-                                         (db/select Field
-                                                    :table_id [:in (db/select-field :id Table :db_id (mt/id))]
-                                                    :visibility_type "normal"
-                                                    {:order-by [[:id :asc]]})
-                                         [5 5 7 7 7 7 10])]
-          (test-automagic-analysis field cardinality))))))
-
 (deftest metric-test
   (mt/with-temp Metric [metric {:table_id (mt/id :venues)
                                 :definition {:aggregation [[:count]]}}]

--- a/test/metabase/automagic_dashboards/core_test.clj
+++ b/test/metabase/automagic_dashboards/core_test.clj
@@ -95,16 +95,32 @@
           (assoc :display_name "%Venues")
           (test-automagic-analysis 7)))))
 
+;; There's weird stuff with regards to drivers up in fields, so these tests on different drivers have different cardinalities
 (deftest mass-field-test
-  (mt/with-test-user :rasta
-    (automagic-dashboards.test/with-dashboard-cleanup
-      (doseq [[field cardinality] (map vector
-                                       (db/select Field
-                                                  :table_id [:in (db/select-field :id Table :db_id (mt/id))]
-                                                  :visibility_type "normal"
-                                                  {:order-by [[:id :asc]]})
-                                       [8 7 6 8 7 7 10])]
-        (test-automagic-analysis field cardinality)))))
+  (mt/test-drivers
+    #{:h2 :sqlite :sqlserver :oracle}
+    (mt/with-test-user :rasta
+      (automagic-dashboards.test/with-dashboard-cleanup
+        (doseq [[field cardinality] (map vector
+                                         (db/select Field
+                                                    :table_id [:in (db/select-field :id Table :db_id (mt/id))]
+                                                    :visibility_type "normal"
+                                                    {:order-by [[:id :asc]]})
+                                         [8 7 6 8 7 7 10])]
+          (test-automagic-analysis field cardinality))))))
+
+(deftest mass-field-test-different-drivers
+  (mt/test-drivers
+    #{:h2 :sqlite :sqlserver :oracle}
+    (mt/with-test-user :rasta
+      (automagic-dashboards.test/with-dashboard-cleanup
+        (doseq [[field cardinality] (map vector
+                                         (db/select Field
+                                                    :table_id [:in (db/select-field :id Table :db_id (mt/id))]
+                                                    :visibility_type "normal"
+                                                    {:order-by [[:id :asc]]})
+                                         [5 5 7 7 7 7 10])]
+          (test-automagic-analysis field cardinality))))))
 
 (deftest metric-test
   (mt/with-temp Metric [metric {:table_id (mt/id :venues)

--- a/test/metabase/automagic_dashboards/core_test.clj
+++ b/test/metabase/automagic_dashboards/core_test.clj
@@ -77,7 +77,7 @@
   (mt/with-test-user :rasta
     (automagic-dashboards.test/with-dashboard-cleanup
       (doseq [[table cardinality] (map vector
-                                       (db/select Table :db_id (mt/id) {:order-by [[:id]]})
+                                       (db/select Table :db_id (mt/id) {:order-by [[:id :asc]]})
                                        [7 5 8 2])]
         (test-automagic-analysis table cardinality)))
 
@@ -102,7 +102,7 @@
                                        (db/select Field
                                                   :table_id [:in (db/select-field :id Table :db_id (mt/id))]
                                                   :visibility_type "normal"
-                                                  {:order-by [[:id]]})
+                                                  {:order-by [[:id :asc]]})
                                        [8 7 6 8 7 7 10])]
         (test-automagic-analysis field cardinality)))))
 

--- a/test/metabase/test/automagic_dashboards.clj
+++ b/test/metabase/test/automagic_dashboards.clj
@@ -41,15 +41,15 @@
 
 (defn test-dashboard-is-valid
   "Is generated dashboard valid?
-   Tests that the dashboard has cards, the queries for those cards are valid, all related URLs are
-   valid, and that it has correct metadata."
-  [dashboard]
+   Tests that the dashboard has (the correct number of) cards, the queries for those cards are valid,
+   all related URLs are valid, and that it has correct metadata."
+  [dashboard cardinality]
   (testing (format "Dashboard should be valid")
     (testing (format "\nDashboard =\n%s\n" (u/pprint-to-str dashboard))
       (testing "Dashboard should have a name"
         (is (some? (:name dashboard))))
-      (testing "Cards should have at least one Card"
-        (is (-> dashboard :ordered_cards count pos?)))
+      (testing "Cards should have correct cardinality"
+        (is (= cardinality (-> dashboard :ordered_cards count))))
       (testing "URLs should be valid"
         (test-urls-are-valid dashboard))
       (testing "Dashboard's cards should be valid"


### PR DESCRIPTION
Pursuant to #14793. This splices in the joins automagically post-hoc. I attempted a way to change the root so it stored join data and put them in that way but it turned into a boiling-the-ocean task. This method seems to work. No separation into parts, just one PR that makes the thing work

Also there was a bug in the cypress test itself, lol

Also I was curious as to whether it would mutate any of the other example runs of the xrays and it seems no.