### PR TITLE
Fix SQL saved question reference to Saved Questions with parameters

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -153,7 +153,7 @@
    [org.threeten/threeten-extra "1.5.0"]                               ; extra Java 8 java.time classes like DayOfMonth and Quarter
    [org.yaml/snakeyaml "1.23"]                                        ; YAML parser (required by liquibase)
    [potemkin "0.4.5" :exclusions [riddley]]                           ; utility macros & fns
-   [pretty "1.0.4"]                                                   ; protocol for defining how custom types should be pretty printed
+   [pretty "1.0.5"]                                                   ; protocol for defining how custom types should be pretty printed
    [prismatic/schema "1.1.12"]                                        ; Data schema declaration and validation library
    [redux "0.1.4"]                                                    ; Utility functions for building and composing transducers
    [riddley "0.2.0"]                                                  ; code walking lib -- used interally by Potemkin, manifold, etc.

--- a/src/metabase/driver/common/parameters.clj
+++ b/src/metabase/driver/common/parameters.clj
@@ -5,7 +5,7 @@
             [metabase.util.i18n :as i18n :refer [deferred-tru tru]]
             [metabase.util.schema :as su]
             [potemkin.types :as p.types]
-            [pretty.core :refer [PrettyPrintable]]
+            [pretty.core :as pretty]
             [schema.core :as s]))
 
 (defsetting field-filter-operators-enabled?
@@ -39,9 +39,9 @@
 ;;
 ;; *  A vector of maps like the one above (for multiple values)
 (p.types/defrecord+ FieldFilter [field value]
-  PrettyPrintable
+  pretty/PrettyPrintable
   (pretty [this]
-    `(map->FieldFilter ~(into {} this))))
+    (list (pretty/qualify-symbol-for-*ns* `map->FieldFilter) (into {} this))))
 
 (defn FieldFilter?
   "Is `x` an instance of the `FieldFilter` record type?"
@@ -53,10 +53,13 @@
 ;; `card-id` is the ID of the Card instance whose query is the value for this parameter.
 ;;
 ;; `query` is the native query as stored in the Card
-(p.types/defrecord+ ReferencedCardQuery [card-id query]
-  PrettyPrintable
+;;
+;; `parameters` are positional parameters for a parameterized native query e.g. the JDBC parameters corresponding to
+;; `?` placeholders
+(p.types/defrecord+ ReferencedCardQuery [card-id query params]
+  pretty/PrettyPrintable
   (pretty [this]
-    `(map->ReferencedCardQuery ~(into {} this))))
+    (list (pretty/qualify-symbol-for-*ns* `map->ReferencedCardQuery) (into {} this))))
 
 (defn ReferencedCardQuery?
   "Is `x` an instance of the `ReferencedCardQuery` record type?"
@@ -70,9 +73,9 @@
 ;;
 ;; `content` is the raw query snippet which will be replaced, verbatim, for this template tag.
 (p.types/defrecord+ ReferencedQuerySnippet [snippet-id content]
-  PrettyPrintable
+  pretty/PrettyPrintable
   (pretty [this]
-    `(map->ReferencedQuerySnippet ~(into {} this))))
+    (list (pretty/qualify-symbol-for-*ns* `map->ReferencedQuerySnippet) (into {} this))))
 
 (defn ReferencedQuerySnippet?
   "Is `x` an instance of the `ReferencedQuerySnippet` record type?"
@@ -83,14 +86,14 @@
 ;;
 ;; TODO - why don't we just parse this into a Temporal type and let drivers handle it.
 (p.types/defrecord+ Date [^String s]
-  PrettyPrintable
+  pretty/PrettyPrintable
   (pretty [_]
-    `(Date. ~s)))
+    (list (pretty/qualify-symbol-for-*ns* `->Date) s)))
 
 (p.types/defrecord+ DateRange [start end]
-  PrettyPrintable
+  pretty/PrettyPrintable
   (pretty [_]
-    `(DateRange. ~start ~end)))
+    (list (pretty/qualify-symbol-for-*ns* `->DateRange) start end)))
 
 ;; List of numbers to faciliate things like using params in a SQL `IN` clause. This is supported by both regular
 ;; filter clauses (e.g. `IN ({{ids}})` and in field filters. Field filters also support sequences of values other than
@@ -99,9 +102,9 @@
 ;;
 ;; `numbers` are a sequence of `[java.lang.Number]`
 (p.types/defrecord+ CommaSeparatedNumbers [numbers]
-  PrettyPrintable
+  pretty/PrettyPrintable
   (pretty [_]
-    `(CommaSeperatedNumbers. ~numbers)))
+    (list (pretty/qualify-symbol-for-*ns* `->CommaSeparatedNumbers) numbers)))
 
 (def no-value
   "Convenience for representing an *optional* parameter present in a query but whose value is unspecified in the param
@@ -136,19 +139,19 @@
 ;; Sequence of multiple values for generating a SQL IN() clause. vales
 ;; `values` are a sequence of `[SingleValue]`
 (p.types/defrecord+ MultipleValues [values]
-  PrettyPrintable
+  pretty/PrettyPrintable
   (pretty [_]
-    `(MultipleValues. ~values)))
+    (list (pretty/qualify-symbol-for-*ns* `->MultipleValues) values)))
 
 (p.types/defrecord+ Param [k]
-  PrettyPrintable
+  pretty/PrettyPrintable
   (pretty [_]
-    (list 'param k)))
+    (list (pretty/qualify-symbol-for-*ns* `->Param) k)))
 
 (p.types/defrecord+ Optional [args]
-  PrettyPrintable
+  pretty/PrettyPrintable
   (pretty [_]
-    (cons 'optional args)))
+    (cons (pretty/qualify-symbol-for-*ns* `->Optional) args)))
 
 ;; `Param?` and `Optional?` exist mostly so you don't have to try to import the classes from this namespace which can
 ;; cause problems if the ns isn't loaded first

--- a/src/metabase/driver/common/parameters/values.clj
+++ b/src/metabase/driver/common/parameters/values.clj
@@ -328,7 +328,7 @@
   (try
     (parse-value-for-type (:type tag) (parse-tag tag params))
     (catch Throwable e
-      (throw (ex-info (tru "Error determining value for parameter")
+      (throw (ex-info (tru "Error determining value for parameter: {0}" (ex-message e))
                       {:tag  tag
                        :type (or (:type (ex-data e)) qp.error-type/invalid-parameter)}
                       e)))))
@@ -351,7 +351,7 @@
                  (log/tracef "Value for tag %s %s -> %s" (pr-str k) (pr-str tag) (pr-str v))
                  {k v})))
     (catch Throwable e
-      (throw (ex-info (tru "Error building query parameter map")
+      (throw (ex-info (tru "Error building query parameter map: {0}" (ex-message e))
                       {:type   (or (:type (ex-data e)) qp.error-type/invalid-parameter)
                        :tags   tags
                        :params params}

--- a/src/metabase/driver/common/parameters/values.clj
+++ b/src/metabase/driver/common/parameters/values.clj
@@ -149,7 +149,7 @@
                i/no-value)}))
 
 (s/defmethod parse-tag :card :- ReferencedCardQuery
-  [{:keys [card-id], :as tag} :- TagParam, params :- (s/maybe [i/ParamValue])]
+  [{:keys [card-id], :as tag} :- TagParam params :- (s/maybe [i/ParamValue])]
   (when-not card-id
     (throw (ex-info (tru "Invalid :card parameter: missing `:card-id`")
                     {:tag tag, :type qp.error-type/invalid-parameter})))
@@ -158,8 +158,8 @@
                                   {:card-id card-id, :tag tag, :type qp.error-type/invalid-parameter})))]
     (try
       (i/map->ReferencedCardQuery
-       {:card-id card-id
-        :query   (:query (qp/query->native (assoc query :parameters params, :info {:card-id card-id})))})
+       (merge {:card-id card-id}
+              (qp/query->native (assoc query :parameters params, :info {:card-id card-id}))))
       (catch ExceptionInfo e
         (throw (ex-info
                 (tru "The sub-query from referenced question #{0} failed with the following error: {1}"

--- a/src/metabase/driver/sql.clj
+++ b/src/metabase/driver/sql.clj
@@ -7,7 +7,9 @@
             [metabase.driver.sql.parameters.substitution :as param-substitution]
             [metabase.driver.sql.query-processor :as sql.qp]
             [metabase.driver.sql.util.unprepare :as unprepare]
-            [potemkin :as p]))
+            [metabase.util.schema :as su]
+            [potemkin :as p]
+            [schema.core :as s]))
 
 (comment param-substitution/keep-me) ; this is so `cljr-clean-ns` and the liner don't remove the `:require`
 
@@ -37,8 +39,8 @@
   [driver query]
   (sql.qp/mbql->native driver query))
 
-(defmethod driver/substitute-native-parameters :sql
-  [_ {:keys [query] :as inner-query}]
+(s/defmethod driver/substitute-native-parameters :sql
+  [_ {:keys [query] :as inner-query} :- {:query su/NonBlankString, s/Keyword s/Any}]
   (let [[query params] (-> query
                            params.parse/parse
                            (params.substitute/substitute (params.values/query->params-map inner-query)))]

--- a/src/metabase/driver/sql/parameters/substitute.clj
+++ b/src/metabase/driver/sql/parameters/substitute.clj
@@ -15,8 +15,8 @@
       [(str sql replacement-snippet) (concat args prepared-statement-args) missing])))
 
 (defn- substitute-card-query [[sql args missing] v]
-  (let [{:keys [replacement-snippet]} (substitution/->replacement-snippet-info driver/*driver* v)]
-    [(str sql replacement-snippet) args missing]))
+  (let [{:keys [replacement-snippet prepared-statement-args]} (substitution/->replacement-snippet-info driver/*driver* v)]
+    [(str sql replacement-snippet) (concat args prepared-statement-args) missing]))
 
 (defn- substitute-native-query-snippet [[sql args missing] v]
    (let [{:keys [replacement-snippet]} (substitution/->replacement-snippet-info driver/*driver* v)]

--- a/src/metabase/driver/sql/parameters/substitution.clj
+++ b/src/metabase/driver/sql/parameters/substitution.clj
@@ -287,8 +287,8 @@
 ;;; ------------------------------------ Referenced Card replacement snippet info ------------------------------------
 
 (defmethod ->replacement-snippet-info [:sql ReferencedCardQuery]
-  [_ {:keys [query]}]
-  {:prepared-statement-args nil
+  [_ {:keys [query params]}]
+  {:prepared-statement-args (not-empty params)
    :replacement-snippet     (str "(" query ")")})
 
 

--- a/src/metabase/query_processor/middleware/parameters.clj
+++ b/src/metabase/query_processor/middleware/parameters.clj
@@ -30,7 +30,7 @@
       (-> (update-in join [:source-query :filter] mbql.u/combine-filter-clauses filter-clause)
           (dissoc :filter)))))
 
-(defn- expand-mbql-params [outer-query {:keys [parameters] :as m}]
+(defn- expand-mbql-params [outer-query {:keys [parameters], :as m}]
   ;; HACK `params.mbql/expand` assumes it's operating on an outer query so wrap `m` to look like an outer query. TODO
   ;; - fix `params.mbql` to operate on abitrary maps instead of only on top-level queries.
   (let [wrapped           (assoc outer-query :query m)

--- a/test/metabase/driver/common/parameters/values_test.clj
+++ b/test/metabase/driver/common/parameters/values_test.clj
@@ -7,9 +7,11 @@
             [metabase.models.permissions :as perms]
             [metabase.models.permissions-group :as group]
             [metabase.query-processor :as qp]
+            [metabase.query-processor.middleware.permissions :as qp.perms]
             [metabase.test :as mt]
             [metabase.util :as u]
-            [metabase.query-processor.middleware.permissions :as qp.perms])
+            [metabase.util.schema :as su]
+            [schema.core :as s])
   (:import clojure.lang.ExceptionInfo))
 
 (deftest variable-value-test
@@ -215,7 +217,7 @@
       (mt/with-temp Card [card {:dataset_query {:database (mt/id)
                                                 :type     "native"
                                                 :native   {:query test-query}}}]
-        (is (= (i/->ReferencedCardQuery (:id card) test-query)
+        (is (= (i/map->ReferencedCardQuery {:card-id (u/the-id card), :query test-query})
                (#'values/value-for-tag
                 {:name         "card-template-tag-test"
                  :display-name "Card template tag test"
@@ -240,7 +242,7 @@
                                 "WHERE \"PUBLIC\".\"VENUES\".\"PRICE\" < 3 "
                                 "LIMIT 1048575")]
           (mt/with-temp Card [card {:dataset_query mbql-query}]
-            (is (= (i/->ReferencedCardQuery (:id card) expected-sql)
+            (is (= (i/map->ReferencedCardQuery {:card-id (u/the-id card), :query expected-sql})
                    (#'values/value-for-tag
                     {:name         "card-template-tag-test"
                      :display-name "Card template tag test"
@@ -389,3 +391,25 @@
                   :target              [:variable [:template-tag "id"]]
                   :value               "2"
                   :filteringParameters "222b245f"}])))))))
+
+(deftest parse-card-include-parameters-test
+  (testing "Parsing a Card reference should return a `ReferencedCardQuery` record that includes its parameters (#12236)"
+    (mt/dataset sample-dataset
+      (mt/with-temp Card [card {:dataset_query (mt/mbql-query orders
+                                                 {:filter      [:between $total 30 60]
+                                                  :aggregation [[:aggregation-options
+                                                                 [:count-where [:starts-with $product_id->products.category "G"]]
+                                                                 {:name "G Monies", :display-name "G Monies"}]]
+                                                  :breakout    [!month.created_at]})}]
+        (let [card-tag (str "#" (u/the-id card))]
+          (is (schema= {:card-id  (s/eq (u/the-id card))
+                        :query    su/NonBlankString
+                        :params   (s/eq ["G%"])
+                        s/Keyword s/Any}
+                       (#'values/parse-tag
+                        {:id           "5aa37572-058f-14f6-179d-a158ad6c029d"
+                         :name         card-tag
+                         :display-name card-tag
+                         :type         :card
+                         :card-id      (u/the-id card)}
+                        nil))))))))

--- a/test/metabase/driver/sql/parameters/substitute_test.clj
+++ b/test/metabase/driver/sql/parameters/substitute_test.clj
@@ -185,7 +185,7 @@
   (testing "Referenced card query substitution"
     (let [query ["SELECT * FROM " (param "#123")]]
       (is (= ["SELECT * FROM (SELECT 1 `x`)" nil]
-             (substitute query {"#123" (i/->ReferencedCardQuery 123 "SELECT 1 `x`")}))))))
+             (substitute query {"#123" (i/map->ReferencedCardQuery {:card-id 123, :query "SELECT 1 `x`"})}))))))
 
 
 ;;; --------------------------------------------- Native Query Snippets ----------------------------------------------
@@ -774,9 +774,6 @@
                                                     :default      "Fred 62"}}}
                 :parameters []}))))))
 
-
-;;; ------------------------------- Multiple Value Support (comma-separated or array) --------------------------------
-
 (deftest multiple-value-test
   (testing "Make sure using commas in numeric params treats them as separate IDs (#5457)"
     (is (= "SELECT * FROM USERS where id IN (1, 2, 3)"
@@ -814,3 +811,16 @@
              :parameters [{:type   :text
                            :target [:dimension [:template-tag "names_list"]]
                            :value  ["BBQ", "Bakery", "Bar"]}]})))))
+
+(deftest include-card-parameters-test
+  (testing "Make sure Card params are preserved when expanding a Card reference (#12236)"
+    (binding [driver/*driver* :h2]
+      (is (= ["SELECT * FROM (SELECT * FROM table WHERE x LIKE ?)"
+              ["G%"]]
+             (substitute/substitute
+              ["SELECT * FROM " (i/->Param "#1")]
+              {"#1"
+               (i/map->ReferencedCardQuery
+                {:card-id 1
+                 :query   "SELECT * FROM table WHERE x LIKE ?"
+                 :params  ["G%"]})}))))))

--- a/test/metabase/driver/sql/parameters/substitute_test.clj
+++ b/test/metabase/driver/sql/parameters/substitute_test.clj
@@ -184,7 +184,7 @@
 (deftest substitute-referenced-card-query-test
   (testing "Referenced card query substitution"
     (let [query ["SELECT * FROM " (param "#123")]]
-      (is (= ["SELECT * FROM (SELECT 1 `x`)" nil]
+      (is (= ["SELECT * FROM (SELECT 1 `x`)" []]
              (substitute query {"#123" (i/map->ReferencedCardQuery {:card-id 123, :query "SELECT 1 `x`"})}))))))
 
 

--- a/test/metabase/driver/sql/parameters/substitution_test.clj
+++ b/test/metabase/driver/sql/parameters/substitution_test.clj
@@ -2,6 +2,7 @@
   "Most of the code in `metabase.driver.sql.parameters.substitution` is actually tested by
   `metabase.driver.sql.parameters.substitute-test`."
   (:require [clojure.test :refer :all]
+            [metabase.driver.common.parameters :as i]
             [metabase.driver.sql.parameters.substitution :as substitution]
             [metabase.models :refer [Field]]
             [metabase.test :as mt]))
@@ -21,3 +22,14 @@
             {:field (Field (mt/id :venues :name))
              :value {:type  :string/=
                      :value ["Doohickey"]}})))))
+
+(deftest card-with-params->replacement-snippet-test
+  (testing "Make sure Card params are preserved when expanding a Card reference (#12236)"
+    (is (= {:replacement-snippet     "(SELECT * FROM table WHERE x LIKE ?)"
+            :prepared-statement-args ["G%"]}
+           (substitution/->replacement-snippet-info
+            :h2
+            (i/map->ReferencedCardQuery
+             {:card-id 1
+              :query   "SELECT * FROM table WHERE x LIKE ?"
+              :params  ["G%"]}))))))

--- a/test/metabase/query_processor/middleware/parameters/native_test.clj
+++ b/test/metabase/query_processor/middleware/parameters/native_test.clj
@@ -1,0 +1,32 @@
+(ns metabase.query-processor.middleware.parameters.native-test
+  (:require [clojure.test :refer :all]
+            [metabase.driver :as driver]
+            [metabase.models.card :refer [Card]]
+            [metabase.query-processor.middleware.parameters.native :as params.native]
+            [metabase.test :as mt]
+            [metabase.util :as u]
+            [metabase.util.schema :as su]
+            [schema.core :as s]))
+
+(deftest include-card-parameters-test
+  (testing "Expanding a Card reference in a native query should include its parameters (#12236)"
+    (mt/dataset sample-dataset
+      (mt/with-temp Card [card {:dataset_query (mt/mbql-query orders
+                                                 {:filter      [:between $total 30 60]
+                                                  :aggregation [[:aggregation-options
+                                                                 [:count-where [:starts-with $product_id->products.category "G"]]
+                                                                 {:name "G Monies", :display-name "G Monies"}]]
+                                                  :breakout    [!month.created_at]})}]
+        (let [card-tag (str "#" (u/the-id card))
+              query    {:native        (format "SELECT * FROM {{%s}}" card-tag)
+                        :template-tags {card-tag
+                                        {:id           "5aa37572-058f-14f6-179d-a158ad6c029d"
+                                         :name         card-tag
+                                         :display-name card-tag
+                                         :type         :card
+                                         :card-id      (u/the-id card)}}}]
+          (binding [driver/*driver* :h2]
+            (is (schema= {:native   su/NonBlankString
+                          :params   (s/eq ["G%"])
+                          s/Keyword s/Any}
+                         (params.native/expand-inner query)))))))))

--- a/test/metabase/query_processor/middleware/parameters_test.clj
+++ b/test/metabase/query_processor/middleware/parameters_test.clj
@@ -163,7 +163,7 @@
       (let [card-1-id  (:id card-1)
             card-2-id  (:id card-2)]
         (is (= (mt/native-query
-                {:query "SELECT COUNT(*) FROM (SELECT 1) AS c1, (SELECT 2) AS c2" :params nil})
+                {:query "SELECT COUNT(*) FROM (SELECT 1) AS c1, (SELECT 2) AS c2", :params []})
                (substitute-params
                 (mt/native-query
                  {:query         (str "SELECT COUNT(*) FROM {{#" card-1-id "}} AS c1, {{#" card-2-id "}} AS c2")
@@ -175,7 +175,7 @@
       (let [card-1-id  (:id card-1)
             card-2-id  (:id card-2)]
         (is (= (mt/native-query
-                {:query "WITH c1 AS (SELECT 1), c2 AS (SELECT 2) SELECT COUNT(*) FROM c1, c2" :params nil})
+                {:query "WITH c1 AS (SELECT 1), c2 AS (SELECT 2) SELECT COUNT(*) FROM c1, c2", :params []})
                (substitute-params
                 (mt/native-query
                  {:query         (str "WITH c1 AS {{#" card-1-id "}}, "
@@ -190,7 +190,7 @@
       (let [card-1-id  (:id card-1)
             card-2-id  (:id card-2)]
         (is (= (mt/native-query
-                {:query "SELECT COUNT(*) FROM (SELECT * FROM (SELECT 1) AS c1) AS c2" :params nil})
+                {:query "SELECT COUNT(*) FROM (SELECT * FROM (SELECT 1) AS c1) AS c2", :params []})
                (substitute-params
                 (mt/native-query
                  {:query         (str "SELECT COUNT(*) FROM {{#" card-2-id "}} AS c2")
@@ -213,7 +213,7 @@
                                  "FROM \"PUBLIC\".\"VENUES\" "
                                  "LIMIT 1048575")]
         (is (= (mt/native-query
-                {:query (str "SELECT COUNT(*) FROM (SELECT * FROM (" card-1-subquery ") AS c1) AS c2") :params nil})
+                {:query (str "SELECT COUNT(*) FROM (SELECT * FROM (" card-1-subquery ") AS c1) AS c2") :params []})
                (substitute-params
                 (mt/native-query
                  {:query         (str "SELECT COUNT(*) FROM {{#" card-2-id "}} AS c2")
@@ -227,7 +227,7 @@
                                                                      {:id "x", :name "x", :display-name "Number x",
                                                                       :type :number, :default "1", :required true}}})}]
       (is (= (mt/native-query
-              {:query "SELECT * FROM (SELECT 1) AS x" :params nil})
+              {:query "SELECT * FROM (SELECT 1) AS x", :params []})
              (substitute-params
               (mt/native-query
                {:query         (str "SELECT * FROM {{#" (:id param-card) "}} AS x")
@@ -278,7 +278,7 @@
 
     (testing "multiple snippets are expanded from saved sub-query"
       (is (= (mt/native-query
-               {:query "SELECT * FROM (SELECT name, price FROM venues WHERE price > 2) AS x", :params nil})
+               {:query "SELECT * FROM (SELECT name, price FROM venues WHERE price > 2) AS x", :params []})
              (substitute-params
               (mt/native-query
                 {:query         (str "SELECT * FROM {{#" (:id card) "}} AS x")

--- a/test/metabase/query_processor_test/nested_queries_test.clj
+++ b/test/metabase/query_processor_test/nested_queries_test.clj
@@ -1198,7 +1198,7 @@
                                                     :breakout    [!month.created_at]})}]
           (let [card-tag (str "#" (u/the-id card))
                 query    (mt/native-query
-                           {:query         (format "SELECT * FROM {{%s}} LIMIT 2" card-tag)
+                           {:query         (format "SELECT * FROM {{%s}} x LIMIT 2" card-tag)
                             :template-tags {card-tag
                                             {:id           "5aa37572-058f-14f6-179d-a158ad6c029d"
                                              :name         card-tag

--- a/test/metabase/query_processor_test/nested_queries_test.clj
+++ b/test/metabase/query_processor_test/nested_queries_test.clj
@@ -1183,7 +1183,12 @@
 (deftest nested-query-with-expressions-test
   (testing "Nested queries with expressions should work in top-level native queries (#12236)"
     ;; sample-dataset doesn't work on Redshift yet -- see #14784
-    (mt/test-drivers (disj (mt/normal-drivers-with-feature :nested-queries :expression-aggregations) :redshift)
+    (mt/test-drivers (disj (mt/normal-drivers-with-feature
+                            :nested-queries
+                            :basic-aggregations
+                            :expression-aggregations
+                            :foreign-keys)
+                           :redshift)
       (mt/dataset sample-dataset
         (mt/with-temp Card [card {:dataset_query (mt/mbql-query orders
                                                    {:filter      [:between $total 30 60]


### PR DESCRIPTION
It turned out we weren't passing along the `:params` we got from converting a referenced query to native when we spliced it in to a native query.

The fix itself was pretty simple, but I wrote tests for every step along the way which it why the PR is a little bigger.

Fixes #12236

