### PR TITLE
Fix Oracle filtering against empty strings

### DIFF
--- a/modules/drivers/oracle/src/metabase/driver/oracle.clj
+++ b/modules/drivers/oracle/src/metabase/driver/oracle.clj
@@ -12,6 +12,7 @@
             [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
             [metabase.driver.sql-jdbc.sync :as sql-jdbc.sync]
             [metabase.driver.sql.query-processor :as sql.qp]
+            [metabase.driver.sql.query-processor.empty-string-is-null :as sql.qp.empty-string-is-null]
             [metabase.driver.sql.util :as sql.u]
             [metabase.driver.sql.util.unprepare :as unprepare]
             [metabase.util :as u]
@@ -25,7 +26,7 @@
            [oracle.jdbc OracleConnection OracleTypes]
            oracle.sql.TIMESTAMPTZ))
 
-(driver/register! :oracle, :parent :sql-jdbc)
+(driver/register! :oracle, :parent #{:sql-jdbc ::sql.qp.empty-string-is-null/empty-string-is-null})
 
 (def ^:private database-type->base-type
   (sql-jdbc.sync/pattern-based-database-type->base-type
@@ -85,7 +86,7 @@
       :or   {host "localhost", port 1521}
       :as   details}]
   (assert (or sid service-name))
-  (let [spec      {:classname "oracle.jdbc.OracleDriver" :subprotocol "oracle:thin"}
+  (let [spec      {:classname "oracle.jdbc.OracleDriver", :subprotocol "oracle:thin"}
         finish-fn (if (:ssl details) ssl-spec non-ssl-spec)]
     (-> (merge spec details)
         (dissoc :host :port :sid :service-name :ssl)

--- a/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
+++ b/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
@@ -227,7 +227,7 @@
                     :fields       [$id $name $category_id $latitude $longitude $price]
                     :limit        100
                     :joins        [{:source-table $$categories
-                                    :alias        "test_data_categories__via__cat",
+                                    :alias        "test_data_categories__via__cat"
                                     :strategy     :left-join
                                     :condition    [:=
                                                    $category_id
@@ -245,3 +245,11 @@
                                "Skipping %s because %s env var is not set"
                                "oracle-connect-with-ssl-test"
                                "MB_ORACLE_SSL_TEST_SSL")))))
+
+(deftest text-equals-empty-string-test
+  (mt/test-driver :oracle
+    (testing ":= with empty string should work correctly (#13158)"
+      (mt/dataset airports
+        (is (= [1M]
+               (mt/first-row
+                (mt/run-mbql-query airport {:aggregation [:count], :filter [:= $code ""]}))))))))

--- a/modules/drivers/oracle/test/metabase/test/data/oracle.clj
+++ b/modules/drivers/oracle/test/metabase/test/data/oracle.clj
@@ -148,7 +148,8 @@
 (defn- execute! [format-string & args]
   (let [sql (apply format format-string args)]
     (println (u/format-color 'blue "[oracle] %s" sql))
-    (jdbc/execute! (dbspec) sql))
+    (jdbc/execute! (dbspec) sql)
+    (println (u/format-color 'green "    [ok]")))
   (println (u/format-color 'blue "[ok]")))
 
 (defn- clean-session-schemas! []

--- a/modules/drivers/oracle/test/metabase/test/data/oracle.clj
+++ b/modules/drivers/oracle/test/metabase/test/data/oracle.clj
@@ -148,8 +148,7 @@
 (defn- execute! [format-string & args]
   (let [sql (apply format format-string args)]
     (println (u/format-color 'blue "[oracle] %s" sql))
-    (jdbc/execute! (dbspec) sql)
-    (println (u/format-color 'green "    [ok]")))
+    (jdbc/execute! (dbspec) sql))
   (println (u/format-color 'blue "[ok]")))
 
 (defn- clean-session-schemas! []

--- a/modules/drivers/vertica/src/metabase/driver/vertica.clj
+++ b/modules/drivers/vertica/src/metabase/driver/vertica.clj
@@ -12,12 +12,15 @@
             [metabase.driver.sql-jdbc.execute.legacy-impl :as legacy]
             [metabase.driver.sql-jdbc.sync :as sql-jdbc.sync]
             [metabase.driver.sql.query-processor :as sql.qp]
+            [metabase.driver.sql.query-processor.empty-string-is-null :as sql.qp.empty-string-is-null]
             [metabase.util.date-2 :as u.date]
             [metabase.util.honeysql-extensions :as hx]
             [metabase.util.i18n :refer [trs]])
   (:import [java.sql ResultSet Types]))
 
-(driver/register! :vertica, :parent #{:sql-jdbc ::legacy/use-legacy-classes-for-read-and-set})
+(driver/register! :vertica, :parent #{:sql-jdbc
+                                      ::legacy/use-legacy-classes-for-read-and-set
+                                      ::sql.qp.empty-string-is-null/empty-string-is-null})
 
 (defmethod driver/supports? [:vertica :percentile-aggregations] [_ _] false)
 

--- a/src/metabase/driver/sql/query_processor/empty_string_is_null.clj
+++ b/src/metabase/driver/sql/query_processor/empty_string_is_null.clj
@@ -1,0 +1,19 @@
+(ns metabase.driver.sql.query-processor.empty-string-is-null
+  "In Oracle and some other databases, empty strings are considered to be `NULL`, so `WHERE field = ''` is effectively
+  the same as writing `WHERE field = NULL`, which of course is never true. This impl replaces empty-string values with
+  `nil` so we generate correct SQL e.g. `WHERE field IS NOT NULL`. (See #13158)
+
+  Drivers can derive from this abstract driver to use an alternate implementation(s) of SQL QP method(s) that treat
+  empty strings as `nil`."
+  (:require [metabase.driver :as driver]
+            [metabase.driver.sql.query-processor :as sql.qp]))
+
+(driver/register! ::empty-string-is-null, :abstract? true)
+
+(defmethod sql.qp/->honeysql [::empty-string-is-null :value]
+  [driver [_ value info]]
+  (let [value (when-not (= value "")
+                value)]
+    ((get-method sql.qp/->honeysql [:sql :value]) driver [:value value info])))
+
+(prefer-method sql.qp/->honeysql [::empty-string-is-null :value] [:sql :value])

--- a/test/metabase/driver/sql/query_processor/empty_string_is_null_test.clj
+++ b/test/metabase/driver/sql/query_processor/empty_string_is_null_test.clj
@@ -1,0 +1,16 @@
+(ns metabase.driver.sql.query-processor.empty-string-is-null-test
+  (:require [clojure.test :refer :all]
+            [metabase.driver :as driver]
+            [metabase.driver.sql.query-processor :as sql.qp]
+            [metabase.driver.sql.query-processor.empty-string-is-null :as sql.qp.empty-string-is-null]))
+
+(driver/register! ::test-driver, :parent #{::sql.qp.empty-string-is-null/empty-string-is-null :sql})
+
+(deftest empty-string-is-null-test
+  (are [s expected] (= expected
+                       (sql.qp/->honeysql ::test-driver [:value s {}]))
+    nil nil
+    ""  nil
+    ;; BLANK string = not nil
+    " " " "
+    "a" "a"))

--- a/test/metabase/query_processor_test/filter_test.clj
+++ b/test/metabase/query_processor_test/filter_test.clj
@@ -447,3 +447,55 @@
       (testing "String parameter to an Integer Field"
         (is (= (mt/rows (mt/run-mbql-query venues {:filter [:= $price 4]}))
                (mt/rows (mt/run-mbql-query venues {:filter [:= $price "4"]}))))))))
+
+;; For the tests below:
+;;
+;; - there are 415 regions, and 8 have a `nil` name; 407 have non-empty, non-nil names
+;; - there are 601 airports, and 1 has a `""` code; 600 have non-empty, non-nil codes
+
+(deftest text-equals-nil-empty-string-test
+  (mt/test-drivers (mt/normal-drivers)
+    (mt/dataset airports
+      (testing ":= against a text column should match the correct columns when value is"
+        (testing "nil"
+          (is (= [[8]]
+                 (mt/formatted-rows [int]
+                   (mt/run-mbql-query region {:aggregation [:count], :filter [:= $name nil]}))))
+          (testing "an empty string (#13158)"
+            (is (= [[1]]
+                   (mt/formatted-rows [int]
+                     (mt/run-mbql-query airport {:aggregation [:count], :filter [:= $code ""]}))))))))))
+
+(deftest text-not-equals-nil-test
+  (mt/test-drivers (mt/normal-drivers)
+    (mt/dataset airports
+      (testing ":!= against a nil/NULL in a text column should be truthy"
+        (testing "should match non-nil, non-empty strings"
+          (is (= [[414]]
+                 (mt/formatted-rows [int]
+                   (mt/run-mbql-query region {:aggregation [:count], :filter [:!= $name "California"]}))))
+          (is (= [[600]]
+                 (mt/formatted-rows [int]
+                   (mt/run-mbql-query airport {:aggregation [:count], :filter [:!= $code "SFO"]})))))))))
+
+(deftest is-empty-not-empty-test
+  (mt/test-drivers (mt/normal-drivers)
+    (mt/dataset airports
+      (testing ":is-empty and :not-empty filters should work correctly (#13158)"
+        (testing :is-empty
+          (testing "should match nil strings"
+            (is (= [[8]]
+                   (mt/formatted-rows [int]
+                     (mt/run-mbql-query region {:aggregation [:count], :filter [:is-empty $name]})))))
+          (testing "should match EMPTY strings"
+            (is (= [[1]]
+                   (mt/formatted-rows [int]
+                     (mt/run-mbql-query airport {:aggregation [:count], :filter [:is-empty $code]}))))))
+        (testing :not-empty
+          (testing "should match non-nil, non-empty strings"
+            (is (= [[407]]
+                   (mt/formatted-rows [int]
+                     (mt/run-mbql-query region {:aggregation [:count], :filter [:not-empty $name]}))))
+            (is (= [[600]]
+                   (mt/formatted-rows [int]
+                     (mt/run-mbql-query airport {:aggregation [:count], :filter [:not-empty $code]}))))))))))

--- a/test/metabase/test/data/dataset_definitions.clj
+++ b/test/metabase/test/data/dataset_definitions.clj
@@ -56,7 +56,10 @@
 
     Continent > Country > Region (e.g. State) > Municipality (e.g. City) > Airport
 
-  This makes this dataset ideal for testing things where we must join multiple levels of tables.")
+  This makes this dataset ideal for testing things where we must join multiple levels of tables.
+
+  There are some `nil` `:name` strings in the `region` and `municipality` tables. `airport` has a row with an airport
+  whose `:code` is an empty string.")
 
 (tx/defdataset-edn sample-dataset
   "The sample dataset that ships with Metabase, but converted to an EDN dataset definition so it can be used in tests.
@@ -89,7 +92,6 @@
       OffsetTime     t
       OffsetDateTime (t/offset-time t)
       ZonedDateTime  (t/offset-time t))))
-
 
 (defonce ^{:doc "The main `test-data` dataset, but only the `users` table, and with `last_login_date` and
   `last_login_time` instead of `last_login`."}


### PR DESCRIPTION
In Oracle empty strings are considered to be `NULL`, so `WHERE field = ''` is effectively the same as writing
`WHERE field = NULL`, which of course is never true. Replace empty-string values with `nil` for Oracle so we generate correct
SQL e.g. `WHERE field IS NOT NULL`. 

We actually didn't have general multi-DB tests around `:is-empty` and `:is-null` specifically or tests with `:=` and `:!=` with nil and empty strings, so I added those as well

Fixes #13158