### PR TITLE
Expand the supported filters for coordinate type

### DIFF
--- a/frontend/src/metabase/lib/schema_metadata.js
+++ b/frontend/src/metabase/lib/schema_metadata.js
@@ -462,6 +462,11 @@ const FILTER_OPERATORS_BY_TYPE_ORDERED = {
     { name: "=", verboseName: t`Is` },
     { name: "!=", verboseName: t`Is not` },
     { name: "inside", verboseName: t`Inside` },
+    { name: ">", verboseName: t`Greater than` },
+    { name: "<", verboseName: t`Less than` },
+    { name: "between", verboseName: t`Between` },
+    { name: ">=", verboseName: t`Greater than or equal to` },
+    { name: "<=", verboseName: t`Less than or equal to` },
   ],
   [BOOLEAN]: [
     { name: "=", verboseName: t`Is`, multi: false },

--- a/frontend/test/metabase/lib/schema_metadata.unit.spec.js
+++ b/frontend/test/metabase/lib/schema_metadata.unit.spec.js
@@ -139,6 +139,15 @@ describe("schema_metadata", () => {
       });
     });
 
+    it("should have 'between' filter operator for the coordinate type", () => {
+      expect(getOperatorByTypeAndName(COORDINATE, "between")).toEqual({
+        name: "between",
+        numFields: 2,
+        validArgumentsFilters: [expect.any(Function), expect.any(Function)],
+        verboseName: "Between",
+      });
+    });
+
     it("should return a metadata object for primary key", () => {
       expect(getOperatorByTypeAndName(PRIMARY_KEY, "=")).toEqual({
         multi: true,


### PR DESCRIPTION
This should solve #16291 and also #16679.

Steps to try (copied from  #16679):
1. Ask a question, Simple question
2. Sample Dataset, People
3. Summarize, Group by Longitude: Bin every 10 degrees, Done
4. Click on any bar, choose Zoom in
5. Click on the new Longitude filter

**Before this PR**

![image](https://user-images.githubusercontent.com/7288/123014621-7f976b00-d37b-11eb-9510-f8498656067e.png)

**After this PR**

![image](https://user-images.githubusercontent.com/7288/123014590-6db5c800-d37b-11eb-91a2-9a4b8c484ddc.png)
