### PR TITLE
Fix admin setup smoke test

### DIFF
--- a/frontend/test/metabase-smoketest/admin_setup.cy.spec.js
+++ b/frontend/test/metabase-smoketest/admin_setup.cy.spec.js
@@ -951,7 +951,7 @@ describe("smoketest > admin_setup", () => {
       cy.button("Sign in").click();
 
       cy.findByText("Failed");
-      cy.contains("Password: did not match stored password");
+      cy.contains("Your account is disabled.");
     });
   });
 });


### PR DESCRIPTION
I changed the error message in #16685 but didn't realize it broke this smoke test since they're not running in CI