### PR TITLE
#16670 Repro: Auto-binning on number field is different for SQL than it is for QB

### DIFF
--- a/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
@@ -146,6 +146,46 @@ describe("binning related reproductions", () => {
       cy.get(".bar");
     });
   });
+
+  describe("result metadata issues", () => {
+    /**
+     * Issues that arise only when we save SQL question without running it first.
+     * It doesn't load the necessary metadata, which results in the wrong binning results.
+     */
+
+    beforeEach(() => {
+      // This query is the equivalent of saving the question without running it first.
+      cy.createNativeQuestion({
+        name: "SQL Binning",
+        native: {
+          query:
+            "SELECT ORDERS.CREATED_AT, ORDERS.TOTAL, PEOPLE.LONGITUDE FROM ORDERS JOIN PEOPLE ON orders.user_id = people.id",
+        },
+      });
+
+      cy.intercept("POST", "/api/dataset").as("dataset");
+    });
+
+    it.skip("should render number auto binning correctly (metabase#16670)", () => {
+      cy.visit("/question/new");
+      cy.findByText("Simple question").click();
+      cy.findByText("Saved Questions").click();
+      cy.findByText("SQL Binning").click();
+      cy.findByText("Summarize").click();
+      cy.wait("@dataset");
+
+      cy.findByTestId("sidebar-right").within(() => {
+        cy.findByText("TOTAL").click();
+      });
+
+      cy.wait("@dataset");
+
+      cy.findByText("Count by TOTAL: Auto binned");
+      cy.get(".bar").should("have.length.of.at.most", 10);
+
+      cy.findByText("-60");
+    });
+  });
 });
 
 function openSummarizeOptions(questionType) {


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #16670 

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/123112674-2f351180-d43e-11eb-9534-331bcd09e201.png)

