### PR TITLE
#16671 Repro: Auto-binning on time series field is different for SQL than it is for QB

### DIFF
--- a/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
@@ -164,16 +164,16 @@ describe("binning related reproductions", () => {
       });
 
       cy.intercept("POST", "/api/dataset").as("dataset");
-    });
 
-    it.skip("should render number auto binning correctly (metabase#16670)", () => {
       cy.visit("/question/new");
       cy.findByText("Simple question").click();
       cy.findByText("Saved Questions").click();
       cy.findByText("SQL Binning").click();
       cy.findByText("Summarize").click();
       cy.wait("@dataset");
+    });
 
+    it.skip("should render number auto binning correctly (metabase#16670)", () => {
       cy.findByTestId("sidebar-right").within(() => {
         cy.findByText("TOTAL").click();
       });
@@ -184,6 +184,14 @@ describe("binning related reproductions", () => {
       cy.get(".bar").should("have.length.of.at.most", 10);
 
       cy.findByText("-60");
+    });
+
+    it.skip("should render time series auto binning default bucket correctly (metabase#16671)", () => {
+      cy.findByTestId("sidebar-right").within(() => {
+        cy.findByText("CREATED_AT")
+          .closest(".List-item")
+          .should("contain", "by month");
+      });
     });
   });
 });


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #16671 

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/123115473-6b697180-d440-11eb-952e-491ae14c307d.png)

