### PR TITLE
#16672 Repro: Implicit binning on longitude from SQL question results in error

### DIFF
--- a/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
@@ -193,6 +193,19 @@ describe("binning related reproductions", () => {
           .should("contain", "by month");
       });
     });
+
+    it.skip("should work for longitude (metabase#16672)", () => {
+      cy.findByTestId("sidebar-right").within(() => {
+        cy.findByText("LONGITUDE").click();
+      });
+
+      cy.wait("@dataset").then(xhr => {
+        expect(xhr.response.body.error).not.to.exist;
+      });
+
+      cy.findByText("Count by LONGITUDE: Auto binned");
+      cy.findByText("170° W");
+    });
   });
 });
 

--- a/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
@@ -147,10 +147,13 @@ describe("binning related reproductions", () => {
     });
   });
 
-  describe("result metadata issues", () => {
+  describe.skip("result metadata issues", () => {
     /**
      * Issues that arise only when we save SQL question without running it first.
      * It doesn't load the necessary metadata, which results in the wrong binning results.
+     *
+     * Fixing the underlying issue with `result_metadata` will most likely fix all three issues reproduced here.
+     * Unskip the whole `describe` block once the fix is ready.
      */
 
     beforeEach(() => {
@@ -173,7 +176,7 @@ describe("binning related reproductions", () => {
       cy.wait("@dataset");
     });
 
-    it.skip("should render number auto binning correctly (metabase#16670)", () => {
+    it("should render number auto binning correctly (metabase#16670)", () => {
       cy.findByTestId("sidebar-right").within(() => {
         cy.findByText("TOTAL").click();
       });
@@ -186,7 +189,7 @@ describe("binning related reproductions", () => {
       cy.findByText("-60");
     });
 
-    it.skip("should render time series auto binning default bucket correctly (metabase#16671)", () => {
+    it("should render time series auto binning default bucket correctly (metabase#16671)", () => {
       cy.findByTestId("sidebar-right").within(() => {
         cy.findByText("CREATED_AT")
           .closest(".List-item")
@@ -194,7 +197,7 @@ describe("binning related reproductions", () => {
       });
     });
 
-    it.skip("should work for longitude (metabase#16672)", () => {
+    it("should work for longitude (metabase#16672)", () => {
       cy.findByTestId("sidebar-right").within(() => {
         cy.findByText("LONGITUDE").click();
       });


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #16672

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js`
- Replace `describe.skip()` with `describe.only()` to run the whole block in isolation
- Then run only the longitude test
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed it is very likely that all three related issues will be fixed
- Please remove the `.skip` part (unskip the whole `describe` block completely)
- Make sure all tests are passing and
- Merge them together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/123119891-2f381000-d444-11eb-86d7-a40c1bef89a2.png)

