### PR TITLE
filter possible native question mapping options by parameter operator

### DIFF
--- a/frontend/src/metabase-lib/lib/queries/NativeQuery.js
+++ b/frontend/src/metabase-lib/lib/queries/NativeQuery.js
@@ -296,12 +296,14 @@ export default class NativeQuery extends AtomicQuery {
   }
 
   dimensionOptions(
-    dimensionFilter: DimensionFilter = () => true,
+    dimensionFilter: DimensionFilter = _.identity,
+    operatorFilter = _.identity,
   ): DimensionOptions {
     const dimensions = this.templateTags()
-      .filter(tag => tag.type === "dimension")
+      .filter(tag => tag.type === "dimension" && operatorFilter(tag))
       .map(tag => new TemplateTagDimension(tag.name, this.metadata(), this))
-      .filter(dimensionFilter);
+      .filter(dimension => dimensionFilter(dimension));
+
     return new DimensionOptions({
       dimensions: dimensions,
       count: dimensions.length,

--- a/frontend/src/metabase/meta/Dashboard.js
+++ b/frontend/src/metabase/meta/Dashboard.js
@@ -12,6 +12,7 @@ import type {
 
 import {
   dimensionFilterForParameter,
+  getTagOperatorFilterForParameter,
   variableFilterForParameter,
   getParameterOptions,
   PARAMETER_OPERATOR_TYPES,
@@ -184,6 +185,7 @@ export function getParameterMappingOptions(
       ...query
         .dimensionOptions(
           parameter ? dimensionFilterForParameter(parameter) : undefined,
+          parameter ? getTagOperatorFilterForParameter(parameter) : undefined,
         )
         .sections()
         .flatMap(section =>

--- a/frontend/src/metabase/meta/Parameter.js
+++ b/frontend/src/metabase/meta/Parameter.js
@@ -285,6 +285,19 @@ export function dimensionFilterForParameter(
   return dimension => fieldFilter(dimension.field());
 }
 
+export function getTagOperatorFilterForParameter(parameter) {
+  const subtype = getParameterSubType(parameter);
+  const parameterOperatorName = getParameterOperatorName(subtype);
+
+  return tag => {
+    const { "widget-type": widgetType } = tag;
+    const subtype = getParameterSubType(widgetType);
+    const tagOperatorName = getParameterOperatorName(subtype);
+
+    return parameterOperatorName === tagOperatorName;
+  };
+}
+
 export function variableFilterForParameter(
   parameter: Parameter,
 ): VariableFilter {

--- a/frontend/test/metabase/scenarios/dashboard/parameters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/parameters.cy.spec.js
@@ -1,5 +1,9 @@
 import { sidebar, popover, restore } from "__support__/e2e/cypress";
+import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
+
 // NOTE: some overlap with parameters-embedded.cy.spec.js
+
+const { PRODUCTS } = SAMPLE_DATASET;
 
 describe("scenarios > dashboard > parameters", () => {
   beforeEach(() => {
@@ -331,6 +335,74 @@ describe("scenarios > dashboard > parameters", () => {
     cy.contains(/is undefined$/).should("not.exist");
     cy.findByText("Orders in a dashboard");
     cy.findByText("DashQ");
+  });
+
+  it("should not having any mapping options if the native question field filter and parameter type differ (metabase#16181)", () => {
+    const filter = {
+      name: "Text contains",
+      slug: "text_contains",
+      id: "98289b9b",
+      type: "string/contains",
+      sectionId: "string",
+    };
+
+    cy.createNativeQuestion({
+      name: "16181",
+      native: {
+        query: "select count(*) from products where {{filter}}",
+        "template-tags": {
+          filter: {
+            id: "0b004110-d64a-a413-5aa2-5a5314fc8fec",
+            name: "filter",
+            "display-name": "Filter",
+            type: "dimension",
+            dimension: ["field", PRODUCTS.TITLE, null],
+            "widget-type": "string/=",
+            default: null,
+          },
+        },
+      },
+      display: "scalar",
+    }).then(({ body: { id: card_id } }) => {
+      cy.createDashboard("16181D").then(({ body: { id: dashboard_id } }) => {
+        // Add previously created question to the dashboard
+        cy.request("POST", `/api/dashboard/${dashboard_id}/cards`, {
+          cardId: card_id,
+        }).then(({ body: { id } }) => {
+          // Add filter to the dashboard
+          cy.request("PUT", `/api/dashboard/${dashboard_id}`, {
+            parameters: [filter],
+          });
+
+          cy.request("PUT", `/api/dashboard/${dashboard_id}/cards`, {
+            cards: [
+              {
+                id,
+                card_id,
+                row: 0,
+                col: 0,
+                sizeX: 8,
+                sizeY: 6,
+                parameter_mappings: [
+                  {
+                    parameter_id: filter.id,
+                    card_id,
+                    target: ["dimension", ["template-tag", "filter"]],
+                  },
+                ],
+              },
+            ],
+          });
+        });
+
+        cy.visit(`/dashboard/${dashboard_id}`);
+      });
+    });
+
+    // confirm you can't map the parameter on the dashboard to the native question's field filter
+    cy.icon("pencil").click();
+    cy.findByText("Text contains").click();
+    cy.findByText("No valid fields");
   });
 });
 

--- a/frontend/test/metabase/scenarios/dashboard/title-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/title-drill.cy.spec.js
@@ -22,7 +22,7 @@ describe("scenarios > dashboard > title drill", () => {
     });
   });
 
-  it.skip("'contains' filter should still work after title drill through (metabase#16181)", () => {
+  it("'contains' filter should still work after title drill through IF the native question field filter's type matches exactly (metabase#16181)", () => {
     const filter = {
       name: "Text contains",
       slug: "text_contains",
@@ -42,7 +42,7 @@ describe("scenarios > dashboard > title drill", () => {
             "display-name": "Filter",
             type: "dimension",
             dimension: ["field", PRODUCTS.TITLE, null],
-            "widget-type": "string/=",
+            "widget-type": "string/contains",
             default: null,
           },
         },


### PR DESCRIPTION
Resolves #16181 
Reproduces #16181 

If your native question has a `string` tag and your dashboard has a `string/contains` parameter, you should not be to map the parameter to the tag. Currently, you're able to. This PR fixes that by adding an additional filter based on the parsed operator name of the tag and the parameter.

Recording of the fix:

https://user-images.githubusercontent.com/13057258/123175334-7fa87100-d436-11eb-95fd-e63dd04dd263.mov

