### PR TITLE
#16739 Repro: Filter feature flag causes Run-overlay of results in Native editor unless editor is expanded

### DIFF
--- a/frontend/test/metabase/scenarios/native/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/native.cy.spec.js
@@ -756,7 +756,6 @@ describe("scenarios > question > native", () => {
         cy.wait("@cardQuery");
       });
 
-      cy.icon("expand").click();
       cy.icon("play").should("not.exist");
     });
   });

--- a/frontend/test/metabase/scenarios/native/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/native.cy.spec.js
@@ -732,7 +732,7 @@ describe("scenarios > question > native", () => {
         name: "filter",
         "display-name": "Filter",
         type: "dimension",
-        dimension: ["field", 4, null],
+        dimension: ["field", PRODUCTS.CATEGORY, null],
         "widget-type": "string/=",
         default: null,
       };


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #16739

### How to test this manually?
- `yarn test-cypress-open -- spec frontend/test/metabase/scenarios/native/native.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail for both users until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:

"Normal" user
![image](https://user-images.githubusercontent.com/31325167/123274039-73d6b080-d503-11eb-93c7-3a353009d28d.png)

"Nodata" user (cannot even expand the editor and get rid of the overlay)
![image](https://user-images.githubusercontent.com/31325167/123274166-91a41580-d503-11eb-8e17-34c5b4d58964.png)

