### PR TITLE
Fix duplicated temporal subdimensions

### DIFF
--- a/frontend/src/metabase-lib/lib/Dimension.js
+++ b/frontend/src/metabase-lib/lib/Dimension.js
@@ -749,9 +749,10 @@ export class FieldDimension extends Dimension {
 
     // Add temporal dimensions
     if (field.isDate() && !this.isIntegerFieldId()) {
-      const temporalDimensions = DATETIME_UNITS.map(unit =>
-        this.withTemporalUnit(unit),
-      );
+      const temporalDimensions = _.difference(
+        DATETIME_UNITS,
+        dimensions.map(dim => dim.temporalUnit()),
+      ).map(unit => this.withTemporalUnit(unit));
       dimensions = [...dimensions, ...temporalDimensions];
     }
 

--- a/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
@@ -72,7 +72,7 @@ describe("binning related reproductions", () => {
     cy.findByText("User → Created At: Minute");
   });
 
-  it.skip("shouldn't render double binning options when question is based on the saved native question (metabase#16327)", () => {
+  it("shouldn't render double binning options when question is based on the saved native question (metabase#16327)", () => {
     cy.createNativeQuestion({
       name: "16327",
       native: { query: "select * from products limit 5" },

--- a/frontend/test/metabase/scenarios/binning/sql.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/sql.cy.spec.js
@@ -103,9 +103,9 @@ describe("scenarios > binning > from a saved sql question", () => {
       cy.findByText("Pick a column to group by").click();
     });
 
-    it.skip("should work for time series", () => {
+    it("should work for time series", () => {
       popover().within(() => {
-        openPopoverFromDefaultBucketSize("CREATED_AT", "by minute");
+        openPopoverFromDefaultBucketSize("CREATED_AT", "by month");
       });
       cy.findByText("Year").click();
 

--- a/frontend/test/metabase/scenarios/binning/sql.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/sql.cy.spec.js
@@ -33,7 +33,7 @@ describe("scenarios > binning > from a saved sql question", () => {
       cy.wait("@dataset");
     });
 
-    it.skip("should work for time series", () => {
+    it("should work for time series", () => {
       cy.findByTestId("sidebar-right").within(() => {
         /*
          * If `result_metadata` is not loaded (SQL question is not run before saving),


### PR DESCRIPTION
This should fix #16327. The fix is made easier after the previous PR #16707.

Steps to verify (from the said bug, copied here for convenience):
1. Ask a question, Native question
2. Type `select * from products` and save it as Q1
3. Ask a question, Custom question
4. Choose Saved Questions, Q1
5. Summarize: _Count_, by _CREATED_AT_ (click on the binning menu)

**Before**

The pop-up list shows too many items, with duplicated ones.

![image](https://user-images.githubusercontent.com/7288/120876037-6e6cf280-c563-11eb-90ca-cd0449ff06bc.png)

**After**

![image](https://user-images.githubusercontent.com/7288/120876062-8775a380-c563-11eb-87e0-67a877be8595.png)