### PR TITLE
Unskip repro for #15397

### DIFF
--- a/frontend/test/metabase/scenarios/question/nested.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nested.cy.spec.js
@@ -416,7 +416,7 @@ describe("scenarios > question > nested", () => {
   });
 
   ["count", "average"].forEach(test => {
-    it.skip(`${test.toUpperCase()}:\n should be able to use aggregation functions on saved native question (metabase#15397)`, () => {
+    it(`${test.toUpperCase()}:\n should be able to use aggregation functions on saved native question (metabase#15397)`, () => {
       cy.server();
       cy.route("POST", "/api/dataset").as("dataset");
 

--- a/frontend/test/metabase/scenarios/question/nested.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nested.cy.spec.js
@@ -4,7 +4,6 @@ import {
   createNativeQuestion,
   openOrdersTable,
   remapDisplayValueToFK,
-  sidebar,
   visitQuestionAdhoc,
 } from "__support__/e2e/cypress";
 
@@ -417,8 +416,7 @@ describe("scenarios > question > nested", () => {
 
   ["count", "average"].forEach(test => {
     it(`${test.toUpperCase()}:\n should be able to use aggregation functions on saved native question (metabase#15397)`, () => {
-      cy.server();
-      cy.route("POST", "/api/dataset").as("dataset");
+      cy.intercept("POST", "/api/dataset").as("dataset");
 
       cy.createNativeQuestion({
         name: "15397",
@@ -426,19 +424,28 @@ describe("scenarios > question > nested", () => {
           query:
             "select count(*), orders.product_id from orders group by orders.product_id;",
         },
+      }).then(({ body: { id } }) => {
+        cy.intercept("POST", `/api/card/${id}/query`).as("cardQuery");
+
+        // Visit the question to load the `result_metadata`
+        cy.visit(`/question/${id}`);
+        cy.wait("@cardQuery");
       });
+
       cy.visit("/question/new");
       cy.findByText("Simple question").click();
       cy.findByText("Saved Questions").click();
       cy.findByText("15397").click();
+
       cy.wait("@dataset");
       cy.findAllByText("Summarize")
         .first()
         .click();
+
       if (test === "average") {
-        sidebar()
-          .findByText("Count")
+        cy.findByTestId("sidebar-right")
           .should("be.visible")
+          .findByText("Count")
           .click();
         cy.findByText("Average of ...").click();
         popover()
@@ -446,6 +453,7 @@ describe("scenarios > question > nested", () => {
           .click();
         cy.wait("@dataset");
       }
+
       cy.findByText("Group by")
         .parent()
         .findByText("COUNT(*)")
@@ -454,7 +462,7 @@ describe("scenarios > question > nested", () => {
       cy.wait("@dataset").then(xhr => {
         expect(xhr.response.body.error).not.to.exist;
       });
-      cy.get(".bar").should("have.length.of.at.least", 20);
+      cy.get(".bar").should("have.length.of.at.least", 5);
     });
   });
 


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Unskips the repro for the issue #15397 that was fixed in the `release-x.39.x` branch by https://github.com/metabase/metabase/pull/16140, but the repro was on `master`.

### Note:
- The original repro didn't account for the `result_metadata` loading. This version fixes that.