### PR TITLE
Reimplement subdimensions menu in the time-series footer

### DIFF
--- a/frontend/src/metabase-lib/lib/Dimension.js
+++ b/frontend/src/metabase-lib/lib/Dimension.js
@@ -749,9 +749,10 @@ export class FieldDimension extends Dimension {
 
     // Add temporal dimensions
     if (field.isDate() && !this.isIntegerFieldId()) {
-      const temporalDimensions = DATETIME_UNITS.map(unit =>
-        this.withTemporalUnit(unit),
-      );
+      const temporalDimensions = _.difference(
+        DATETIME_UNITS,
+        dimensions.map(dim => dim.temporalUnit()),
+      ).map(unit => this.withTemporalUnit(unit));
       dimensions = [...dimensions, ...temporalDimensions];
     }
 

--- a/frontend/src/metabase/modes/components/TimeseriesGroupingWidget.jsx
+++ b/frontend/src/metabase/modes/components/TimeseriesGroupingWidget.jsx
@@ -1,80 +1,65 @@
 import React, { Component } from "react";
+import PropTypes from "prop-types";
+
+import _ from "underscore";
+
+import { isStructured } from "metabase/lib/query";
 
 import TimeGroupingPopover from "metabase/query_builder/components/TimeGroupingPopover";
 import PopoverWithTrigger from "metabase/components/PopoverWithTrigger";
 import SelectButton from "metabase/components/SelectButton";
 
-import * as Query from "metabase/lib/query/query";
-import * as Card from "metabase/meta/Card";
-
-import { parseFieldBucketing, formatBucketing } from "metabase/lib/query_time";
-
-import type {
-  Card as CardObject,
-  StructuredDatasetQuery,
-} from "metabase-types/types/Card";
-
-type Props = {
-  card: CardObject,
-  setDatasetQuery: (
-    datasetQuery: StructuredDatasetQuery,
-    options: { run: boolean },
-  ) => void,
-};
+// set the display automatically then run
+function updateAndRun(query) {
+  query
+    .question()
+    .setDefaultDisplay()
+    .update(null, { run: true });
+}
 
 export default class TimeseriesGroupingWidget extends Component {
-  props: Props;
+  static propTypes = {
+    query: PropTypes.object.isRequired,
+  };
 
   _popover: ?any;
 
   render() {
-    const { card, setDatasetQuery } = this.props;
+    const { query } = this.props;
 
-    if (Card.isStructured(card)) {
-      const query = Card.getQuery(card);
-      const breakouts = query && Query.getBreakouts(query);
-
+    if (isStructured(query.datasetQuery())) {
+      const breakouts = query.breakouts();
       if (!breakouts || breakouts.length === 0) {
         return null;
       }
+      const dimensions = breakouts.map(b => b.dimension());
+      const dimension = dimensions[0];
 
       return (
         <PopoverWithTrigger
           triggerElement={
-            <SelectButton hasValue>
-              {formatBucketing(parseFieldBucketing(breakouts[0]))}
-            </SelectButton>
+            <SelectButton hasValue>{dimension.subDisplayName()}</SelectButton>
           }
           triggerClasses="my2"
           ref={ref => (this._popover = ref)}
         >
           <TimeGroupingPopover
+            title={null}
             className="text-brand"
-            field={breakouts[0]}
-            onFieldChange={breakout => {
-              let query = Card.getQuery(card);
-              if (query) {
-                query = Query.updateBreakout(query, 0, breakout);
-                const datasetQuery: StructuredDatasetQuery = {
-                  ...card.dataset_query,
-                  query,
-                };
-                setDatasetQuery(datasetQuery, { run: true });
-                if (this._popover) {
-                  this._popover.close();
-                }
+            dimension={dimension}
+            onChangeDimension={dimension => {
+              const index = _.findIndex(dimensions, d =>
+                d.isSameBaseDimension(dimension),
+              );
+              if (index >= 0) {
+                updateAndRun(query.updateBreakout(index, dimension.mbql()));
+              } else {
+                updateAndRun(query.clearBreakouts().breakout(dimension.mbql()));
+              }
+              if (this._popover) {
+                this._popover.close();
               }
             }}
-            title={null}
-            groupingOptions={[
-              "minute",
-              "hour",
-              "day",
-              "week",
-              "month",
-              "quarter",
-              "year",
-            ]}
           />
         </PopoverWithTrigger>
       );

--- a/frontend/src/metabase/query_builder/components/TimeGroupingPopover.jsx
+++ b/frontend/src/metabase/query_builder/components/TimeGroupingPopover.jsx
@@ -1,24 +1,25 @@
-/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 
 import { t } from "ttag";
 import cx from "classnames";
 
+const timeGroupingPopoverPropTypes = {
+  title: PropTypes.string,
+  className: PropTypes.string,
+  dimension: PropTypes.object.isRequired,
+  onChangeDimension: PropTypes.func.isRequired,
+};
+
+const timeGroupingPopoverDefaultProps = {
+  title: t`Group time by`,
+};
+
 export default class TimeGroupingPopover extends Component {
   constructor(props, context) {
     super(props, context);
     this.state = {};
   }
-
-  static propTypes = {
-    dimension: PropTypes.object.isRequired,
-    onChangeDimension: PropTypes.func.isRequired,
-  };
-
-  static defaultProps = {
-    title: t`Group time by`,
-  };
 
   render() {
     const { title, className, dimension, onChangeDimension } = this.props;
@@ -47,3 +48,6 @@ export default class TimeGroupingPopover extends Component {
     );
   }
 }
+
+TimeGroupingPopover.propTypes = timeGroupingPopoverPropTypes;
+TimeGroupingPopover.defaultProps = timeGroupingPopoverDefaultProps;

--- a/frontend/src/metabase/query_builder/components/TimeGroupingPopover.jsx
+++ b/frontend/src/metabase/query_builder/components/TimeGroupingPopover.jsx
@@ -2,30 +2,8 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 
-import { parseFieldBucketing, formatBucketing } from "metabase/lib/query_time";
-import { FieldDimension } from "metabase-lib/lib/Dimension";
 import { t } from "ttag";
 import cx from "classnames";
-
-const BUCKETINGS = [
-  "default",
-  "minute",
-  "hour",
-  "day",
-  "week",
-  "month",
-  "quarter",
-  "year",
-  null,
-  "minute-of-hour",
-  "hour-of-day",
-  "day-of-week",
-  "day-of-month",
-  "day-of-year",
-  "week-of-year",
-  "month-of-year",
-  "quarter-of-year",
-];
 
 export default class TimeGroupingPopover extends Component {
   constructor(props, context) {
@@ -34,68 +12,36 @@ export default class TimeGroupingPopover extends Component {
   }
 
   static propTypes = {
-    field: PropTypes.oneOfType([PropTypes.array]), // field Ref
-    onFieldChange: PropTypes.func.isRequired,
+    dimension: PropTypes.object.isRequired,
+    onChangeDimension: PropTypes.func.isRequired,
   };
 
   static defaultProps = {
     title: t`Group time by`,
-    groupingOptions: [
-      // "default",
-      "minute",
-      "hour",
-      "day",
-      "week",
-      "month",
-      "quarter",
-      "year",
-      // "minute-of-hour",
-      "hour-of-day",
-      "day-of-week",
-      "day-of-month",
-      // "day-of-year",
-      "week-of-year",
-      "month-of-year",
-      "quarter-of-year",
-    ],
   };
 
-  setField(bucketing) {
-    const dimension = FieldDimension.parseMBQLOrWarn(this.props.field);
-    if (dimension) {
-      const mbql = dimension.withTemporalUnit(bucketing).mbql();
-      this.props.onFieldChange(mbql);
-    }
-  }
-
   render() {
-    const { title, field, className, groupingOptions } = this.props;
-    const enabledOptions = new Set(groupingOptions);
+    const { title, className, dimension, onChangeDimension } = this.props;
+    const subDimensions = dimension.dimensions();
     return (
       <div className={cx(className, "px2 py1")} style={{ width: "250px" }}>
         {title && <h3 className="List-section-header pt1 mx2">{title}</h3>}
         <ul className="py1">
-          {BUCKETINGS.filter(o => o == null || enabledOptions.has(o)).map(
-            (bucketing, bucketingIndex) =>
-              bucketing == null ? (
-                <hr key={bucketingIndex} style={{ border: "none" }} />
-              ) : (
-                <li
-                  key={bucketingIndex}
-                  className={cx("List-item", {
-                    "List-item--selected":
-                      parseFieldBucketing(field) === bucketing,
-                  })}
-                >
-                  <a
-                    className="List-item-title full px2 py1 cursor-pointer"
-                    onClick={this.setField.bind(this, bucketing)}
-                  >
-                    {formatBucketing(bucketing)}
-                  </a>
-                </li>
-              ),
-          )}
+          {subDimensions.map((subDimension, index) => (
+            <li
+              key={index}
+              className={cx("List-item", {
+                "List-item--selected": subDimension.isEqual(dimension),
+              })}
+            >
+              <a
+                className="List-item-title full px2 py1 cursor-pointer"
+                onClick={() => onChangeDimension(subDimension)}
+              >
+                {subDimension.subDisplayName()}
+              </a>
+            </li>
+          ))}
         </ul>
       </div>
     );

--- a/frontend/test/metabase/scenarios/binning/binning-options.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/binning-options.cy.spec.js
@@ -177,7 +177,7 @@ describe("scenarios > binning > binning options", () => {
     });
   });
 
-  context.skip("via time series footer", () => {
+  context("via time series footer", () => {
     it("should render time series binning options correctly", () => {
       openTable({ table: ORDERS_ID });
       cy.findByText("Created At").click();

--- a/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
@@ -72,7 +72,7 @@ describe("binning related reproductions", () => {
     cy.findByText("User → Created At: Minute");
   });
 
-  it.skip("shouldn't render double binning options when question is based on the saved native question (metabase#16327)", () => {
+  it("shouldn't render double binning options when question is based on the saved native question (metabase#16327)", () => {
     cy.createNativeQuestion({
       name: "16327",
       native: { query: "select * from products limit 5" },

--- a/frontend/test/metabase/scenarios/binning/sql.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/sql.cy.spec.js
@@ -103,9 +103,9 @@ describe("scenarios > binning > from a saved sql question", () => {
       cy.findByText("Pick a column to group by").click();
     });
 
-    it.skip("should work for time series", () => {
+    it("should work for time series", () => {
       popover().within(() => {
-        openPopoverFromDefaultBucketSize("CREATED_AT", "by minute");
+        openPopoverFromDefaultBucketSize("CREATED_AT", "by month");
       });
       cy.findByText("Year").click();
 

--- a/frontend/test/metabase/scenarios/binning/sql.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/sql.cy.spec.js
@@ -33,7 +33,7 @@ describe("scenarios > binning > from a saved sql question", () => {
       cy.wait("@dataset");
     });
 
-    it.skip("should work for time series", () => {
+    it("should work for time series", () => {
       cy.findByTestId("sidebar-right").within(() => {
         /*
          * If `result_metadata` is not loaded (SQL question is not run before saving),


### PR DESCRIPTION
The temporal units for the time-series footer were hardcoded. This is now changed to stay consistent with the e.g. the query builder and the summary sidebar, i.e. by getting it from the breakouts dimension itself.

Steps to verify:
1. Ask a question, Simple question
2. Sample Dataset, People table
3. Summarize, group by Created At: Month of Year, Done
4. Look at the time-series footer at the bottom of the chart

**Before this PR**

The time-series footer says "Month of Year", but when clicking that to open the pop-over, that selected subdimension isn't even listed. In fact, there are only 7 possible subdimensions ("Minute" to "Year"), whereas the Summarize sidebar allows the selecting Created At to 15 different subdimensions ("Minute" to "Quarter of Year")

![image](https://user-images.githubusercontent.com/7288/123371226-2b84b600-d536-11eb-9b1f-bd945e1da6ea.png)

**After this PR**

The subdimension choices in the time-series footer match those of the summarize sidebar.

![image](https://user-images.githubusercontent.com/7288/123371232-2fb0d380-d536-11eb-89f5-4d7966bc1e88.png)
