### PR TITLE
Include more documentation on "Smart" column ordering

### DIFF
--- a/docs/administration-guide/03-metadata-editing.md
+++ b/docs/administration-guide/03-metadata-editing.md
@@ -218,7 +218,7 @@ You can also select from several options:
 - **Database.** (Default) The order of columns as they appear in the database.
 - **Alphabetical.** A, B, C... however the alphabet works.
 - **Custom.** You choose the order. Metabase will automatically switch to custom if you rearrange any of the columns.
-- **Smart.** Metabase chooses for you.
+- **Smart.** Metabase chooses for you, ordering foreign keys first, followed by `:type/Name`s, then `:type/Temporal`s, and from there on in alphabetical order.
 
 ---
 


### PR DESCRIPTION
In an attempt to discover how "smart" ordering worked and whether we wanted to use it, I had to find the relevant comment in the code itself:
https://github.com/metabase/metabase/blob/f3847cb8fd9025f20f39822a073a8c9bf7db3373/src/metabase/models/table.clj#L29-L30

Instead of this, we can add the same information to the documentation. Feel free to modify the copy as preferred.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/16788)
<!-- Reviewable:end -->
