### PR TITLE
Correct static interop

### DIFF
--- a/bin/build-mb/src/build/licenses.clj
+++ b/bin/build-mb/src/build/licenses.clj
@@ -137,11 +137,12 @@
   "Returns a tuple of [jar-filename {:coords :license [:error]}. Error is optional. License will be a string of license
   text, coords a map with group and artifact."
   [^String jar-filename backfill]
-  (let [jar-path (Paths/get jar-filename path-options)]
+  (let [jar-path ^Path (Paths/get jar-filename path-options)
+        classloader ^ClassLoader (ClassLoader/getSystemClassLoader)]
     (if-not (Files/exists jar-path link-options)
       [jar-filename {:error "Jar does not exist"}]
       (try
-        (with-open [jar-fs (FileSystems/newFileSystem jar-path nil)]
+        (with-open [jar-fs (FileSystems/newFileSystem jar-path classloader)]
           (let [pom-path             (determine-pom jar-filename jar-fs)
                 license-path         (license-from-jar jar-fs)
                 [coords pom-license] (do-with-path-is pom-path


### PR DESCRIPTION
on java 16 there's a handy (newFilesystem path) but i don't think we
want to require java 16 yet. On previous versions we can use
(newFileSystem Path ClassLoader) which is what it was before. Really
just need to typehint the nil, but nils don't carry
metadata (sensibly) so would have to introduce a local binding

```clojure
(let [^ClassLoader cl nil]
  (FileSystems/newFileSystem jar-path cl))
```

feels a bit weird, so just send the proper classloader through.

javadocs:
16: https://docs.oracle.com/en/java/javase/16/docs/api/java.base/java/nio/file/FileSystems.html
8: https://docs.oracle.com/javase/8/docs/api/java/nio/file/FileSystems.html