### PR TITLE
#16784 Repro: The list of collections available on homepage "Our analytics" depends on the name of the first 50 objects

### DIFF
--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -6,6 +6,7 @@ import {
   openOrdersTable,
   sidebar,
 } from "__support__/e2e/cypress";
+import _ from "underscore";
 import { USERS, USER_GROUPS } from "__support__/e2e/cypress_data";
 
 const { nocollection } = USERS;
@@ -577,6 +578,16 @@ describe("scenarios > collection_defaults", () => {
           cy.findByText("Orders");
         });
       });
+    });
+
+    it.skip("collections list on the home page shouldn't depend on the name of the first 50 objects (metabase#16784)", () => {
+      // Although there are already some objects in the default snapshot (3 questions, 1 dashboard, 3 collections),
+      // let's create 50 more dashboards with the letter of alphabet `D` coming before the first letter of the existing collection `F`.
+      _.times(50, i => cy.createDashboard(`Dashboard ${i}`));
+
+      cy.visit("/");
+      // There is already a collection named "First collection" in the default snapshot
+      cy.findByText("First collection");
     });
   });
 });


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #16784 

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/collections/collections.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/123771916-bca7b400-d8cb-11eb-89d0-0153435d9d0c.png)

