### PR TITLE
#16789 Repro: Clicking column name when dropdown menu is open should close menu

### DIFF
--- a/frontend/test/metabase/scenarios/visualizations/table.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/table.cy.spec.js
@@ -43,4 +43,25 @@ describe("scenarios > visualizations > table", () => {
       "http://metabase.com/people/1",
     );
   });
+
+  it.skip("should close the colum popover on subsequent click (metabase#16789)", () => {
+    openPeopleTable();
+    cy.wait("@dataset");
+
+    cy.findByText("City").click();
+    popover().within(() => {
+      cy.icon("arrow_up");
+      cy.icon("arrow_down");
+      cy.icon("gear");
+      cy.findByText("Filter by this column");
+      cy.findByText("Distribution");
+      cy.findByText("Distincts");
+    });
+
+    cy.findByText("City").click();
+    // Although arbitrary waiting is considered an anti-pattern and a really bad practice, I couldn't find any other way to reproduce this issue.
+    // Cypress is too fast and is doing the assertions in that split second while popover is reloading which results in a false positive result.
+    cy.wait(100);
+    popover().should("not.exist");
+  });
 });

--- a/frontend/test/metabase/scenarios/visualizations/table.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/table.cy.spec.js
@@ -1,15 +1,4 @@
-import { restore, visitQuestionAdhoc, popover } from "__support__/e2e/cypress";
-import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
-
-const { PEOPLE_ID } = SAMPLE_DATASET;
-
-const testQuery = {
-  database: 1,
-  query: {
-    "source-table": PEOPLE_ID,
-  },
-  type: "query",
-};
+import { restore, openPeopleTable, popover } from "__support__/e2e/cypress";
 
 describe("scenarios > visualizations > table", () => {
   beforeEach(() => {
@@ -19,10 +8,7 @@ describe("scenarios > visualizations > table", () => {
   });
 
   it("should allow to display any column as link with extrapolated url and text", () => {
-    visitQuestionAdhoc({
-      dataset_query: testQuery,
-      display: "table",
-    });
+    openPeopleTable();
     cy.wait("@dataset");
 
     cy.findByText("City").click();


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #16789 

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/visualizations/table.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/123789874-ec5fb780-d8dd-11eb-93c7-e00cfa6fbbd0.png)

Doing this same test without waiting 100ms results in false positive.
![image](https://user-images.githubusercontent.com/31325167/123789940-04cfd200-d8de-11eb-8a88-7ab30385ee87.png)

