### PR TITLE
[SQL filters coverage] Basic SQL filter types

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1213,6 +1213,16 @@ workflows:
           matrix:
             parameters:
               edition: ["ee", "oss"]
+          name: e2e-tests-filters-<< matrix.edition >>
+          requires:
+            - build-uberjar-<< matrix.edition >>
+          cypress-group: "filters-<< matrix.edition >>"
+          source-folder: frontend/test/metabase/scenarios/filters
+
+      - fe-tests-cypress:
+          matrix:
+            parameters:
+              edition: ["ee", "oss"]
           name: e2e-tests-onboarding-<< matrix.edition >>
           requires:
             - build-uberjar-<< matrix.edition >>

--- a/frontend/test/metabase/scenarios/filters/sql-filters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/sql-filters.cy.spec.js
@@ -1,0 +1,162 @@
+import { restore, popover, mockSessionProperty } from "__support__/e2e/cypress";
+
+describe("scenarios > filters > sql filters > basic filter types", () => {
+  beforeEach(() => {
+    restore();
+    cy.intercept("POST", "api/dataset").as("dataset");
+
+    cy.signInAsAdmin();
+    // Make sure feature flag is on regardles of the environment where this is running.
+    mockSessionProperty("field-filter-operators-enabled?", true);
+
+    cy.visit("/");
+    cy.icon("sql").click();
+    cy.get(".ace_content")
+      .as("editor")
+      .should("be.visible");
+  });
+
+  describe("should work for text", () => {
+    beforeEach(() => {
+      enterNativeQuery(
+        "SELECT * FROM products WHERE products.category = {{textFilter}}",
+      );
+    });
+
+    it("when set through the filter widget", () => {
+      setFilterWidgetValue("Gizmo");
+
+      runQuery();
+
+      cy.get(".Visualization").within(() => {
+        cy.findByText("Rustic Paper Wallet");
+        cy.findAllByText("Doohickey").should("not.exist");
+      });
+    });
+
+    it("when set as the default value for a required filter", () => {
+      setRequiredFilterDefaultValue("Gizmo");
+
+      runQuery();
+
+      cy.get(".Visualization").within(() => {
+        cy.findByText("Rustic Paper Wallet");
+        cy.findAllByText("Doohickey").should("not.exist");
+      });
+    });
+  });
+
+  describe("should work for number", () => {
+    beforeEach(() => {
+      enterNativeQuery(
+        "SELECT * FROM products WHERE products.rating = {{numberFilter}}",
+      );
+
+      openPopoverFromDefaultFilterType();
+      setFilterType("Number");
+    });
+
+    it("when set through the filter widget", () => {
+      setFilterWidgetValue("4.3");
+
+      runQuery();
+
+      cy.get(".Visualization").within(() => {
+        cy.findByText("Aerodynamic Linen Coat");
+        cy.findAllByText("4.3");
+      });
+    });
+
+    it.skip("when set as the default value for a required filter (metabase#16811)", () => {
+      setRequiredFilterDefaultValue("4.3");
+
+      runQuery();
+
+      cy.get(".Visualization").within(() => {
+        cy.findByText("Aerodynamic Linen Coat");
+        cy.findAllByText("4.3");
+      });
+    });
+  });
+
+  describe("should work for date", () => {
+    beforeEach(() => {
+      enterNativeQuery(
+        "SELECT * FROM products WHERE products.created_at = {{dateFilter}}",
+      );
+
+      openPopoverFromDefaultFilterType();
+      setFilterType("Date");
+    });
+
+    it("when set through the filter widget", () => {
+      cy.get("fieldset").click();
+      // Since we have fixed dates in Sample Dataset (dating back a couple of years), it'd be cumbersome to click back month by month.
+      // Instead, let's choose the 15th of the current month and assert that there are no products / no results.
+      cy.findByText("15").click();
+
+      runQuery();
+
+      cy.get(".Visualization").within(() => {
+        cy.findByText("No results!");
+      });
+    });
+
+    it("when set as the default value for a required filter", () => {
+      toggleRequiredFilter();
+
+      cy.findByText("Select a default value…").click();
+      cy.findByText("15").click();
+
+      runQuery();
+
+      cy.get(".Visualization").within(() => {
+        cy.findByText("No results!");
+      });
+    });
+  });
+});
+
+function openPopoverFromSelectedFilterType(filterType) {
+  cy.get(".AdminSelect-content")
+    .contains(filterType)
+    .click();
+}
+
+function openPopoverFromDefaultFilterType() {
+  openPopoverFromSelectedFilterType("Text");
+}
+
+function setFilterType(filterType) {
+  popover().within(() => {
+    cy.findByText(filterType).click();
+  });
+}
+
+function runQuery(xhrAlias = "dataset") {
+  cy.get(".NativeQueryEditor .Icon-play").click();
+  cy.wait("@" + xhrAlias);
+  cy.icon("play").should("not.exist");
+}
+
+function enterNativeQuery(query) {
+  cy.get("@editor").type(query, { parseSpecialCharSequences: false });
+}
+
+function setFilterWidgetValue(value) {
+  cy.get("fieldset")
+    .click()
+    .type(value);
+}
+
+function toggleRequiredFilter() {
+  cy.findByText("Required?")
+    .parent()
+    .find("a")
+    .click();
+}
+
+function setRequiredFilterDefaultValue(value) {
+  toggleRequiredFilter();
+  cy.findByPlaceholderText("Enter a default value...").type(value);
+}


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- Adds a new CI e2e group called `Filters`
- Adds an initial series of tests around SQL filters for basic filter types (text, number, date) with the feature flag turned on
- Reproduces #16811 

- Makes sure all filters work when their value is being set:
    - Explicitly through the filter widget
    - Implicitly as the default value when the filter is required

This PR is part of the series of tests we are trying to add, as explained in #16759.

### Screenshots
Writing this series of tests revealed the problem with the number filter when it is required, and the default value is set (covered in 16811)
![image](https://user-images.githubusercontent.com/31325167/123852418-9100ea00-d91c-11eb-90c1-14a9b5ac5717.png)

The current state of tests
![image](https://user-images.githubusercontent.com/31325167/123852692-e3daa180-d91c-11eb-9ed2-66109d4fe9cb.png)
