### PR TITLE
Chain filters cpu utilization

### DIFF
--- a/src/metabase/models/params/chain_filter.clj
+++ b/src/metabase/models/params/chain_filter.clj
@@ -218,7 +218,7 @@
   (letfn [(transform [path] (let [edges (partition 2 1 path)]
                               (not-empty (vec (mapcat (fn [[x y]] (get-in graph [x y])) edges)))))]
     (loop [paths      (conj clojure.lang.PersistentQueue/EMPTY [start])
-           seen-edges #{}]
+           seen #{start}]
       (let [path (peek paths)
             node (peek path)]
         (cond (nil? node)
@@ -226,16 +226,16 @@
               ;; found a path, bfs finds shortest first
               (= node end)
               (transform path)
-              ;; abandon this path
+              ;; abandon this path. A bit hazy on how seen and max depth interact.
               (= (count path) max-depth)
-              (recur (pop paths) seen-edges)
+              (recur (pop paths) seen)
               ;; probe further and throw them on the queue
               :else
               (let [next-nodes (->> (get graph node)
                                     keys
-                                    (remove (fn [n] (contains? seen-edges [node n]))))]
+                                    (remove seen))]
                 (recur (into (pop paths) (for [n next-nodes] (conj path n)))
-                       (set/union seen-edges (into #{} (map (fn [n] [node n])) next-nodes)))))))))
+                       (set/union seen (set next-nodes)))))))))
 
 (def ^:private max-traversal-depth 5)
 

--- a/src/metabase/models/params/chain_filter.clj
+++ b/src/metabase/models/params/chain_filter.clj
@@ -217,8 +217,8 @@
   [graph start end max-depth]
   (letfn [(transform [path] (let [edges (partition 2 1 path)]
                               (not-empty (vec (mapcat (fn [[x y]] (get-in graph [x y])) edges)))))]
-    (loop [paths      (conj clojure.lang.PersistentQueue/EMPTY [start])
-           seen #{start}]
+    (loop [paths (conj clojure.lang.PersistentQueue/EMPTY [start])
+           seen  #{start}]
       (let [path (peek paths)
             node (peek path)]
         (cond (nil? node)

--- a/src/metabase/models/params/chain_filter.clj
+++ b/src/metabase/models/params/chain_filter.clj
@@ -211,6 +211,26 @@
   the implementation of `find-joins` below."
   (memoize/ttl database-fk-relationships* :ttl/threshold find-joins-cache-duration-ms))
 
+(defn- traverse-graph
+  "A breadth first traversal of graph, not probing any paths that are over `max-depth` in length."
+  [graph start end max-depth]
+  (letfn [(transform [path] (let [edges (partition 2 1 path)]
+                              (not-empty (vec (mapcat (fn [[x y]] (get-in graph [x y])) edges)))))
+          (too-long? [path] (> (count path) max-depth))]
+    (loop [paths (conj clojure.lang.PersistentQueue/EMPTY [start])]
+      (let [path (peek paths)
+            node (peek path)]
+        (cond (nil? node)
+              nil
+              (= node end)
+              (transform path)
+              :else
+              (let [advance (for [node (keys (get graph node))]
+                              (conj path node))]
+                (recur (into (pop paths) (remove too-long? advance)))))))))
+
+(def ^:private max-traversal-depth 5)
+
 (defn- find-joins* [database-id source-table-id other-table-id enable-reverse-joins?]
   (let [fk-relationships (database-fk-relationships database-id enable-reverse-joins?)]
     ;; find series of joins needed to get from LHS -> RHS. `path` is the tables we're already joining against when
@@ -218,30 +238,9 @@
     ;;
     ;; the general idea here is to see if LHS can join directly against RHS, otherwise recursively try all of the
     ;; tables LHS can join against and see if we can find a path that way.
-    (letfn [(find-relationship [lhs-table-id rhs-table-id path]
-              (log/tracef "Find FK relationship for %s -> %s\n"
-                          (name-for-logging Table lhs-table-id)
-                          (name-for-logging Table rhs-table-id))
-              ;; get the tables LHS can join directly against.
-              (when-let [direct-joins (not-empty (get fk-relationships lhs-table-id))]
-                (log/tracef "%s can join against %s"
-                            (name-for-logging Table lhs-table-id)
-                            (str/join " or " (mapv (partial name-for-logging Table)
-                                                   (keys direct-joins))))
-                ;; first, see if there is a direct relationship between LHS and RHS. If so, use that.
-                (or (get direct-joins rhs-table-id)
-                    ;; if not, see if we can find an indirect path by recursing on the directly joined tables
-                    (some not-empty
-                          (for [[joined-id join-info] direct-joins
-                                :when                 (and (not= joined-id lhs-table-id)
-                                                           (not (contains? (set path) joined-id)))
-                                :let                  [recursive-joins (find-relationship joined-id rhs-table-id
-                                                                                          (conj path lhs-table-id))]
-                                :when                 recursive-joins]
-                            (concat join-info recursive-joins))))))]
-      (u/prog1 (find-relationship source-table-id other-table-id [])
-        (when (seq <>)
-          (log/tracef (format-joins-for-logging <>)))))))
+    (u/prog1 (traverse-graph fk-relationships source-table-id other-table-id max-traversal-depth)
+      (when (seq <>)
+        (log/tracef (format-joins-for-logging <>))))))
 
 (def ^:private ^{:arglists '([database-id source-table-id other-table-id]
                              [database-id source-table-id other-table-id enable-reverse-joins?])} find-joins

--- a/test/metabase/models/params/chain_filter_test.clj
+++ b/test/metabase/models/params/chain_filter_test.clj
@@ -112,7 +112,19 @@
                    ;; no way to get to 3
                    3      {4 [[3 4]]}
                    4      {:end [[4 :end]]}}]
-        (is (nil? (#'chain-filter/traverse-graph graph :start :end 5)))))))
+        (is (nil? (#'chain-filter/traverse-graph graph :start :end 5)))))
+    (testing "Not fooled by loops"
+      (let [graph {:start {:a [:start->a]}
+                   :a     {:b [:a->b]
+                           :a [:b->a]}
+                   :b     {:c [:b->c]
+                           :a [:c->a]
+                           :b [:c->b]}
+                   :c     {:end [:c->end]}}]
+        (is (= [:start->a :a->b :b->c :c->end]
+               (#'chain-filter/traverse-graph graph :start :end 5)))
+        (testing "But will not exceed the max depth"
+          (is (nil? (#'chain-filter/traverse-graph graph :start :end 2))))))))
 
 (deftest find-joins-test
   (mt/dataset airports

--- a/test/metabase/models/params/chain_filter_test.clj
+++ b/test/metabase/models/params/chain_filter_test.clj
@@ -69,6 +69,51 @@
              (chain-filter venues.price {categories.name ["Bakery" "BBQ"]
                                          users.id        [1 2 3]}))))))
 
+(def megagraph
+  "A large graph that is hugely interconnected. All nodes can get to 50 and 50 has an edge to :end. But the fastest
+  route is [[:start 50] [50 :end]] and we should quickly identify this last route. Basically handy to demonstrate that
+  we are doing breadth first search rather than depth first search. Depth first would identify 1 -> 2 -> 3 ... 49 ->
+  50 -> end"
+  (let [big 50]
+    (merge-with merge
+                (reduce (fn [m [x y]] (assoc-in m [x y] [[x y]]))
+                        {}
+                        (for [x     (range (inc big))
+                              y     (range (inc big))
+                              :when (not= x y)]
+                          [x y]))
+                {:start (reduce (fn [m x] (assoc m x [[:start x]]))
+                                {}
+                                (range (inc big)))}
+                {big    {:end [[big :end]]}})))
+
+(deftest traverse-graph-test
+  (testing "If no need to join, returns immediately"
+    (is (nil? (#'chain-filter/traverse-graph {} :start :start 5))))
+  (testing "Finds a simple hop"
+    (let [graph {:start {:end [:start->end]}}]
+      (is (= [:start->end]
+             (#'chain-filter/traverse-graph graph :start :end 5))))
+    (testing "Finds over a few hops"
+      (let [graph {:start {:a [:start->a]}
+                   :a     {:b [:a->b]}
+                   :b     {:c [:b->c]}
+                   :c     {:end [:c->end]}}]
+        (is (= [:start->a :a->b :b->c :c->end]
+               (#'chain-filter/traverse-graph graph :start :end 5)))
+        (testing "But will not exceed the max depth"
+          (is (nil? (#'chain-filter/traverse-graph graph :start :end 2))))))
+    (testing "Can find a path in a dense and large graph"
+      (is (= [[:start 50] [50 :end]]
+             (#'chain-filter/traverse-graph megagraph :start :end 5))))
+    (testing "Returns nil if there is no path"
+      (let [graph {:start {1 [[:start 1]]}
+                   1      {2 [[1 2]]}
+                   ;; no way to get to 3
+                   3      {4 [[3 4]]}
+                   4      {:end [[4 :end]]}}]
+        (is (nil? (#'chain-filter/traverse-graph graph :start :end 5)))))))
+
 (deftest find-joins-test
   (mt/dataset airports
     (mt/$ids nil


### PR DESCRIPTION
Fixes reports of high cpu usage traced to chain filters.

Bug: when getting filter values for the UI dropdowns, takes in account of other current filters and tries to give possible values for the dropdown given the constraints of the others. The way it accomplishes this is to create a join on the underlying tables with those fields, and search for values of field X (the dropdown filter field) where fields Y,Z,... are values of the constraints.

In order to find these joins, we load up all of the join information for the db, and then attempt to get from one table to another. This was doing a depth first search of the entire FK relationship graph. On a large production database this could take an enormous amount of time and ~~energy~~ space:

```clojure
;; NB: some logging omitted
(defn- find-joins* [database-id source-table-id other-table-id enable-reverse-joins?]
  (let [fk-relationships (database-fk-relationships database-id enable-reverse-joins?)]
    (letfn [(find-relationship [lhs-table-id rhs-table-id path]
              ;; get the tables LHS can join directly against.
              (when-let [direct-joins (not-empty (get fk-relationships lhs-table-id))]
                ;; first, see if there is a direct relationship between LHS and RHS. If so, use that.
                (or (get direct-joins rhs-table-id)
                    ;; if not, see if we can find an indirect path by recursing on the directly joined tables
                    (some not-empty
                          (for [[joined-id join-info] direct-joins
                                :when                 (and (not= joined-id lhs-table-id)
                                                           ;; only checks against cycles in the path, not if already visited node
                                                           (not (contains? (set path) joined-id)))
                                ;; depth first recursive call with a stack
                                :let                  [recursive-joins (find-relationship joined-id rhs-table-id
                                                                                          (conj path lhs-table-id))]
                                :when                 recursive-joins]
                            (concat join-info recursive-joins))))))]
      (find-relationship source-table-id other-table-id []))))
```

Newer version is a breadth-first search through the FK relationship graph that won't revisit any nodes, not just watching for circular paths, and gives up after a certain path length (currently 5):

```clojure
(defn- traverse-graph
  "A breadth first traversal of graph, not probing any paths that are over `max-depth` in length."
  [graph start end max-depth]
  (letfn [(transform [path] (let [edges (partition 2 1 path)]
                              (not-empty (vec (mapcat (fn [[x y]] (get-in graph [x y])) edges)))))]
    (loop [paths (conj clojure.lang.PersistentQueue/EMPTY [start])
           seen  #{start}]
      (let [path (peek paths)
            node (peek path)]
        (cond (nil? node)
              nil
              ;; found a path, bfs finds shortest first
              (= node end)
              (transform path)
              ;; abandon this path.
              (= (count path) max-depth)
              (recur (pop paths) seen)
              ;; probe further and throw them on the queue
              :else
              (let [next-nodes (->> (get graph node)
                                    keys
                                    (remove seen))]
                (recur (into (pop paths) (for [n next-nodes] (conj path n)))
                       (set/union seen (set next-nodes)))))))))
```

These optimizations and algo change allows us to find a path through some really nasty graphs. In the tests are `megagraph` and `megagraph-single-path`

### Megagraph
This graph has a structure
```clojure
{:start {links to 1-50}
 1      {links to 1-50 except 1}
 2      {links to 1-50 except 2}
 ...
 49     {links to 1-50 except 49}
 50     {links to 1-50 except 50
         link to :end}}
```
Many traversals exist, and doing a depth-first would find `[:start 1 2 ... 49 50 :end]` but this is horrific. The far easier path, and the one found here is 
```clojure
      (is (= [[:start 50] [50 :end]]
             (#'chain-filter/traverse-graph megagraph :start :end 5)))
```

It should arrive at this after 50 checks thanks to the `seen` optimization.


### megagraph-single-path
This graph has the shape
```clojure
{:start {links to 1-199}
 1      {links to 1-199 except 1}
 2      {links to 1-199 except 2}
 ...
 90     {links to 1-199
         link to 200}
 91     {links to 1-199 except 2}
 ...
 198    {links to 1-199 except 198}
 199    {links to 1-199 except 199}
 200    {link to :end}}
```
Which has only a single path to the end, `[:start 90 200 :end]`. This test will OOM and/or take an enormous amount of time in a depth first search, or even in a breadth first search without recording the nodes we've already seen. However, with the optimizations we can achieve this traversal in
```clojure
(time (#'chain-filter/traverse-graph megagraph-single-path :start :end 5))
"Elapsed time: 9.881863 msecs"
[[:start 90] [90 200] [200 :end]]
```

## Actual FK relationship graph
These tests make it easy to test horrific versions (we could even test the horror show schema if it had fk's in it). The actual shape of the graph that we are using in the real code path looks like the following:
```clojure
chain-filter=> (pprint
                 (let [enable-reverse-joins? true
                       database-id 1 #_ sample-db]
                   (database-fk-relationships database-id enable-reverse-joins?)))
{2
 {3 [{:lhs {:table 2, :field 3}, :rhs {:table 3, :field 22}}],
  1 [{:lhs {:table 2, :field 5}, :rhs {:table 1, :field 30}}],
  4 [{:lhs {:table 2, :field 4}, :rhs {:table 4, :field 34}}]},
 3 {2 [{:lhs {:table 3, :field 22}, :rhs {:table 2, :field 3}}]},
 1
 {2 [{:lhs {:table 1, :field 30}, :rhs {:table 2, :field 5}}],
  4 [{:lhs {:table 1, :field 30}, :rhs {:table 4, :field 33}}]},
 4
 {2 [{:lhs {:table 4, :field 34}, :rhs {:table 2, :field 4}}],
  1 [{:lhs {:table 4, :field 33}, :rhs {:table 1, :field 30}}]}}
```
Which is a map of table-id->reachable-table->join-info.

This is the graph we are searching through to find how to construct the joins to satisfy the queries for one field given constraints on other fields.