### PR TITLE
Add unit tests for syncQueryParamsWithURL

### DIFF
--- a/frontend/test/metabase/parameters/components/Parameters/syncQueryParamsWithURL.unit.spec.js
+++ b/frontend/test/metabase/parameters/components/Parameters/syncQueryParamsWithURL.unit.spec.js
@@ -2,9 +2,215 @@ import Field from "metabase-lib/lib/metadata/Field";
 
 import { ORDERS, PRODUCTS } from "__support__/sample_dataset_fixture";
 
-import { getValueFromFields } from "metabase/parameters/components/Parameters/syncQueryParamsWithURL";
+import {
+  getValueFromFields,
+  syncQueryParamsWithURL,
+} from "metabase/parameters/components/Parameters/syncQueryParamsWithURL";
 
 describe("Parameters", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe("syncQueryParamsWithURL", () => {
+    const setParameterValue = jest.fn();
+
+    describe("for internal questions", () => {
+      describe("when parameters length is 0", () => {
+        const props = {
+          commitImmediately: true,
+          parameters: [],
+          query: {
+            createdAt: "2021",
+          },
+          setParameterValue,
+        };
+
+        it("does not call setParameterValue", () => {
+          syncQueryParamsWithURL(props);
+          expect(setParameterValue).not.toHaveBeenCalled();
+        });
+      });
+
+      describe("when query has no key that matches a parameter slug", () => {
+        const props = {
+          commitImmediately: true,
+          parameters: [
+            {
+              id: "id",
+              slug: "slugNotKeyInQuery",
+            },
+          ],
+          query: {
+            createdAt: "2021",
+          },
+          setParameterValue,
+        };
+
+        it("does not call setParameterValue", () => {
+          syncQueryParamsWithURL(props);
+          expect(setParameterValue).not.toHaveBeenCalled();
+        });
+      });
+
+      describe("when parameters length is 1", () => {
+        const props = {
+          commitImmediately: true,
+          parameters: [
+            {
+              id: "id",
+              slug: "createdAt",
+            },
+          ],
+          query: {
+            createdAt: "2021",
+          },
+          setParameterValue,
+        };
+
+        it("calls setParameterValue once", () => {
+          syncQueryParamsWithURL(props);
+          expect(setParameterValue).toHaveBeenCalledTimes(1);
+        });
+
+        it("calls setParameterValue with parameters.id and the value for query key ", () => {
+          syncQueryParamsWithURL(props);
+          expect(setParameterValue).toHaveBeenCalledWith("id", "2021");
+        });
+      });
+
+      describe("when parameters length is 2", () => {
+        const props = {
+          commitImmediately: true,
+          parameters: [
+            {
+              id: "id1",
+              slug: "createdAt",
+            },
+            {
+              id: "id2",
+              slug: "state",
+            },
+          ],
+
+          query: {
+            createdAt: "2021",
+            state: "CA",
+          },
+          setParameterValue,
+        };
+
+        it("calls setParameterValue twice", () => {
+          syncQueryParamsWithURL(props);
+          expect(setParameterValue).toHaveBeenCalledTimes(2);
+        });
+
+        it("calls setParameterValue each time with parameter.id and parsed paramater as arguments ", () => {
+          syncQueryParamsWithURL(props);
+          expect(setParameterValue).toHaveBeenCalledWith("id1", "2021");
+          expect(setParameterValue).toHaveBeenCalledWith("id2", "CA");
+        });
+      });
+    });
+
+    describe("for public questions", () => {
+      describe("when parameters length is 0", () => {
+        const props = {
+          parameters: [],
+          query: {
+            createdAt: "2021",
+          },
+          setParameterValue,
+        };
+
+        it("calls setParameterValue with empty object as argument", () => {
+          syncQueryParamsWithURL(props);
+          expect(setParameterValue).toHaveBeenCalledTimes(1);
+          expect(setParameterValue).toHaveBeenCalledWith({});
+        });
+      });
+
+      describe("when query has no key that matches a parameter slug", () => {
+        const props = {
+          parameters: [
+            {
+              id: "id",
+              slug: "slugNotKeyInQuery",
+            },
+          ],
+          query: {
+            createdAt: "2021",
+          },
+          setParameterValue,
+        };
+
+        it("calls setParameterValue with empty object as argument", () => {
+          syncQueryParamsWithURL(props);
+          expect(setParameterValue).toHaveBeenCalledWith({});
+        });
+      });
+
+      describe("when parameters length is 1", () => {
+        const props = {
+          parameters: [
+            {
+              id: "id",
+              slug: "createdAt",
+            },
+          ],
+          query: {
+            createdAt: "2021",
+          },
+          setParameterValue,
+        };
+
+        it("calls setParameterValue once", () => {
+          syncQueryParamsWithURL(props);
+          expect(setParameterValue).toHaveBeenCalledTimes(1);
+        });
+
+        it("calls setParameterValue with an object of key parameter.id and value of a parsed query param ", () => {
+          syncQueryParamsWithURL(props);
+          expect(setParameterValue).toHaveBeenCalledWith({ id: "2021" });
+        });
+      });
+
+      describe("when parameters length is 2", () => {
+        const props = {
+          parameters: [
+            {
+              id: "id1",
+              slug: "createdAt",
+            },
+            {
+              id: "id2",
+              slug: "state",
+            },
+          ],
+
+          query: {
+            createdAt: "2021",
+            state: "CA",
+          },
+          setParameterValue,
+        };
+
+        it("calls setParameterValue once", () => {
+          syncQueryParamsWithURL(props);
+          expect(setParameterValue).toHaveBeenCalledTimes(1);
+        });
+
+        it("calls setParameterValue with one object as argument, keys of parameter id and parsed param values", () => {
+          syncQueryParamsWithURL(props);
+          expect(setParameterValue).toHaveBeenCalledWith({
+            id1: "2021",
+            id2: "CA",
+          });
+        });
+      });
+    });
+  });
+
   describe("getValueFromFields", () => {
     it("should parse numbers", () => {
       expect(getValueFromFields("1.23", [ORDERS.TOTAL])).toBe(1.23);

--- a/frontend/test/metabase/parameters/components/Parameters/syncQueryParamsWithURL.unit.spec.js
+++ b/frontend/test/metabase/parameters/components/Parameters/syncQueryParamsWithURL.unit.spec.js
@@ -48,7 +48,7 @@ describe("Parameters", () => {
         const props = buildPropsForInternalQuestion({
           parameters: [
             {
-              id: "id",
+              id: "idForslugNotKeyInQuery",
               slug: "slugNotKeyInQuery",
             },
           ],
@@ -67,7 +67,7 @@ describe("Parameters", () => {
         const props = buildPropsForInternalQuestion({
           parameters: [
             {
-              id: "id",
+              id: "idForCreatedAt",
               slug: "createdAt",
             },
           ],
@@ -83,7 +83,10 @@ describe("Parameters", () => {
 
         it("calls setParameterValue with parameters.id and the value for query key ", () => {
           syncQueryParamsWithURL(props);
-          expect(props.setParameterValue).toHaveBeenCalledWith("id", "2021");
+          expect(props.setParameterValue).toHaveBeenCalledWith(
+            "idForCreatedAt",
+            "2021",
+          );
         });
       });
 
@@ -91,11 +94,11 @@ describe("Parameters", () => {
         const props = buildPropsForInternalQuestion({
           parameters: [
             {
-              id: "id1",
+              id: "idForCreatedAt",
               slug: "createdAt",
             },
             {
-              id: "id2",
+              id: "idForState",
               slug: "state",
             },
           ],
@@ -112,8 +115,14 @@ describe("Parameters", () => {
 
         it("calls setParameterValue each time with parameter.id and parsed paramater as arguments ", () => {
           syncQueryParamsWithURL(props);
-          expect(props.setParameterValue).toHaveBeenCalledWith("id1", "2021");
-          expect(props.setParameterValue).toHaveBeenCalledWith("id2", "CA");
+          expect(props.setParameterValue).toHaveBeenCalledWith(
+            "idForCreatedAt",
+            "2021",
+          );
+          expect(props.setParameterValue).toHaveBeenCalledWith(
+            "idForState",
+            "CA",
+          );
         });
       });
     });
@@ -138,7 +147,7 @@ describe("Parameters", () => {
         const props = buildPropsForPublicQuestion({
           parameters: [
             {
-              id: "id",
+              id: "idForSlugNotKeyInQuery",
               slug: "slugNotKeyInQuery",
             },
           ],
@@ -157,7 +166,7 @@ describe("Parameters", () => {
         const props = buildPropsForPublicQuestion({
           parameters: [
             {
-              id: "id",
+              id: "idForCreatedAt",
               slug: "createdAt",
             },
           ],
@@ -173,7 +182,9 @@ describe("Parameters", () => {
 
         it("calls setParameterValue with an object of key parameter.id and value of a parsed query param ", () => {
           syncQueryParamsWithURL(props);
-          expect(props.setParameterValue).toHaveBeenCalledWith({ id: "2021" });
+          expect(props.setParameterValue).toHaveBeenCalledWith({
+            idForCreatedAt: "2021",
+          });
         });
       });
 
@@ -181,11 +192,11 @@ describe("Parameters", () => {
         const props = buildPropsForPublicQuestion({
           parameters: [
             {
-              id: "id1",
+              id: "idForCreatedAt",
               slug: "createdAt",
             },
             {
-              id: "id2",
+              id: "idForState",
               slug: "state",
             },
           ],
@@ -203,8 +214,8 @@ describe("Parameters", () => {
         it("calls setParameterValue with one object as argument, keys of parameter id and parsed param values", () => {
           syncQueryParamsWithURL(props);
           expect(props.setParameterValue).toHaveBeenCalledWith({
-            id1: "2021",
-            id2: "CA",
+            idForCreatedAt: "2021",
+            idForState: "CA",
           });
         });
       });

--- a/frontend/test/metabase/parameters/components/Parameters/syncQueryParamsWithURL.unit.spec.js
+++ b/frontend/test/metabase/parameters/components/Parameters/syncQueryParamsWithURL.unit.spec.js
@@ -7,34 +7,45 @@ import {
   syncQueryParamsWithURL,
 } from "metabase/parameters/components/Parameters/syncQueryParamsWithURL";
 
+const buildProps = props => ({
+  setParameterValue: jest.fn(),
+  ...props,
+});
+
+const buildPropsForInternalQuestion = props =>
+  buildProps({
+    commitImmediately: true,
+    ...props,
+  });
+
+const buildPropsForPublicQuestion = props =>
+  buildProps({
+    ...props,
+  });
+
 describe("Parameters", () => {
   beforeEach(() => {
     jest.resetAllMocks();
   });
 
   describe("syncQueryParamsWithURL", () => {
-    const setParameterValue = jest.fn();
-
     describe("for internal questions", () => {
       describe("when parameters length is 0", () => {
-        const props = {
-          commitImmediately: true,
+        const props = buildPropsForInternalQuestion({
           parameters: [],
           query: {
             createdAt: "2021",
           },
-          setParameterValue,
-        };
+        });
 
         it("does not call setParameterValue", () => {
           syncQueryParamsWithURL(props);
-          expect(setParameterValue).not.toHaveBeenCalled();
+          expect(props.setParameterValue).not.toHaveBeenCalled();
         });
       });
 
       describe("when query has no key that matches a parameter slug", () => {
-        const props = {
-          commitImmediately: true,
+        const props = buildPropsForInternalQuestion({
           parameters: [
             {
               id: "id",
@@ -44,18 +55,16 @@ describe("Parameters", () => {
           query: {
             createdAt: "2021",
           },
-          setParameterValue,
-        };
+        });
 
         it("does not call setParameterValue", () => {
           syncQueryParamsWithURL(props);
-          expect(setParameterValue).not.toHaveBeenCalled();
+          expect(props.setParameterValue).not.toHaveBeenCalled();
         });
       });
 
       describe("when parameters length is 1", () => {
-        const props = {
-          commitImmediately: true,
+        const props = buildPropsForInternalQuestion({
           parameters: [
             {
               id: "id",
@@ -65,23 +74,21 @@ describe("Parameters", () => {
           query: {
             createdAt: "2021",
           },
-          setParameterValue,
-        };
+        });
 
         it("calls setParameterValue once", () => {
           syncQueryParamsWithURL(props);
-          expect(setParameterValue).toHaveBeenCalledTimes(1);
+          expect(props.setParameterValue).toHaveBeenCalledTimes(1);
         });
 
         it("calls setParameterValue with parameters.id and the value for query key ", () => {
           syncQueryParamsWithURL(props);
-          expect(setParameterValue).toHaveBeenCalledWith("id", "2021");
+          expect(props.setParameterValue).toHaveBeenCalledWith("id", "2021");
         });
       });
 
       describe("when parameters length is 2", () => {
-        const props = {
-          commitImmediately: true,
+        const props = buildPropsForInternalQuestion({
           parameters: [
             {
               id: "id1",
@@ -92,46 +99,43 @@ describe("Parameters", () => {
               slug: "state",
             },
           ],
-
           query: {
             createdAt: "2021",
             state: "CA",
           },
-          setParameterValue,
-        };
+        });
 
         it("calls setParameterValue twice", () => {
           syncQueryParamsWithURL(props);
-          expect(setParameterValue).toHaveBeenCalledTimes(2);
+          expect(props.setParameterValue).toHaveBeenCalledTimes(2);
         });
 
         it("calls setParameterValue each time with parameter.id and parsed paramater as arguments ", () => {
           syncQueryParamsWithURL(props);
-          expect(setParameterValue).toHaveBeenCalledWith("id1", "2021");
-          expect(setParameterValue).toHaveBeenCalledWith("id2", "CA");
+          expect(props.setParameterValue).toHaveBeenCalledWith("id1", "2021");
+          expect(props.setParameterValue).toHaveBeenCalledWith("id2", "CA");
         });
       });
     });
 
     describe("for public questions", () => {
       describe("when parameters length is 0", () => {
-        const props = {
+        const props = buildPropsForPublicQuestion({
           parameters: [],
           query: {
             createdAt: "2021",
           },
-          setParameterValue,
-        };
+        });
 
         it("calls setParameterValue with empty object as argument", () => {
           syncQueryParamsWithURL(props);
-          expect(setParameterValue).toHaveBeenCalledTimes(1);
-          expect(setParameterValue).toHaveBeenCalledWith({});
+          expect(props.setParameterValue).toHaveBeenCalledTimes(1);
+          expect(props.setParameterValue).toHaveBeenCalledWith({});
         });
       });
 
       describe("when query has no key that matches a parameter slug", () => {
-        const props = {
+        const props = buildPropsForPublicQuestion({
           parameters: [
             {
               id: "id",
@@ -141,17 +145,16 @@ describe("Parameters", () => {
           query: {
             createdAt: "2021",
           },
-          setParameterValue,
-        };
+        });
 
         it("calls setParameterValue with empty object as argument", () => {
           syncQueryParamsWithURL(props);
-          expect(setParameterValue).toHaveBeenCalledWith({});
+          expect(props.setParameterValue).toHaveBeenCalledWith({});
         });
       });
 
       describe("when parameters length is 1", () => {
-        const props = {
+        const props = buildPropsForPublicQuestion({
           parameters: [
             {
               id: "id",
@@ -161,22 +164,21 @@ describe("Parameters", () => {
           query: {
             createdAt: "2021",
           },
-          setParameterValue,
-        };
+        });
 
         it("calls setParameterValue once", () => {
           syncQueryParamsWithURL(props);
-          expect(setParameterValue).toHaveBeenCalledTimes(1);
+          expect(props.setParameterValue).toHaveBeenCalledTimes(1);
         });
 
         it("calls setParameterValue with an object of key parameter.id and value of a parsed query param ", () => {
           syncQueryParamsWithURL(props);
-          expect(setParameterValue).toHaveBeenCalledWith({ id: "2021" });
+          expect(props.setParameterValue).toHaveBeenCalledWith({ id: "2021" });
         });
       });
 
       describe("when parameters length is 2", () => {
-        const props = {
+        const props = buildPropsForPublicQuestion({
           parameters: [
             {
               id: "id1",
@@ -187,22 +189,20 @@ describe("Parameters", () => {
               slug: "state",
             },
           ],
-
           query: {
             createdAt: "2021",
             state: "CA",
           },
-          setParameterValue,
-        };
+        });
 
         it("calls setParameterValue once", () => {
           syncQueryParamsWithURL(props);
-          expect(setParameterValue).toHaveBeenCalledTimes(1);
+          expect(props.setParameterValue).toHaveBeenCalledTimes(1);
         });
 
         it("calls setParameterValue with one object as argument, keys of parameter id and parsed param values", () => {
           syncQueryParamsWithURL(props);
-          expect(setParameterValue).toHaveBeenCalledWith({
+          expect(props.setParameterValue).toHaveBeenCalledWith({
             id1: "2021",
             id2: "CA",
           });

--- a/frontend/test/metabase/parameters/components/Parameters/syncQueryParamsWithURL.unit.spec.js
+++ b/frontend/test/metabase/parameters/components/Parameters/syncQueryParamsWithURL.unit.spec.js
@@ -38,7 +38,7 @@ describe("Parameters", () => {
           },
         });
 
-        it("does not call setParameterValue", () => {
+        it("does not try to sync parameters", () => {
           syncQueryParamsWithURL(props);
           expect(props.setParameterValue).not.toHaveBeenCalled();
         });
@@ -57,7 +57,7 @@ describe("Parameters", () => {
           },
         });
 
-        it("does not call setParameterValue", () => {
+        it("does not try to sync parameters", () => {
           syncQueryParamsWithURL(props);
           expect(props.setParameterValue).not.toHaveBeenCalled();
         });
@@ -76,13 +76,9 @@ describe("Parameters", () => {
           },
         });
 
-        it("calls setParameterValue once", () => {
+        it("syncs parameter with query params by slugs in one function call", () => {
           syncQueryParamsWithURL(props);
           expect(props.setParameterValue).toHaveBeenCalledTimes(1);
-        });
-
-        it("calls setParameterValue with parameters.id and the value for query key ", () => {
-          syncQueryParamsWithURL(props);
           expect(props.setParameterValue).toHaveBeenCalledWith(
             "idForCreatedAt",
             "2021",
@@ -108,13 +104,9 @@ describe("Parameters", () => {
           },
         });
 
-        it("calls setParameterValue twice", () => {
+        it("syncs parameter with query params by slugs in as many function calls as there are matching parameters", () => {
           syncQueryParamsWithURL(props);
           expect(props.setParameterValue).toHaveBeenCalledTimes(2);
-        });
-
-        it("calls setParameterValue each time with parameter.id and parsed paramater as arguments ", () => {
-          syncQueryParamsWithURL(props);
           expect(props.setParameterValue).toHaveBeenCalledWith(
             "idForCreatedAt",
             "2021",
@@ -136,7 +128,7 @@ describe("Parameters", () => {
           },
         });
 
-        it("calls setParameterValue with empty object as argument", () => {
+        it("uses empty object as argument when syncing params", () => {
           syncQueryParamsWithURL(props);
           expect(props.setParameterValue).toHaveBeenCalledTimes(1);
           expect(props.setParameterValue).toHaveBeenCalledWith({});
@@ -156,7 +148,7 @@ describe("Parameters", () => {
           },
         });
 
-        it("calls setParameterValue with empty object as argument", () => {
+        it("uses empty object as argument when syncing params", () => {
           syncQueryParamsWithURL(props);
           expect(props.setParameterValue).toHaveBeenCalledWith({});
         });
@@ -175,13 +167,9 @@ describe("Parameters", () => {
           },
         });
 
-        it("calls setParameterValue once", () => {
+        it("syncs parameter with query params by slugs, by passing one object with as many key/value pairs as there are matching parameters, all in a single function call", () => {
           syncQueryParamsWithURL(props);
           expect(props.setParameterValue).toHaveBeenCalledTimes(1);
-        });
-
-        it("calls setParameterValue with an object of key parameter.id and value of a parsed query param ", () => {
-          syncQueryParamsWithURL(props);
           expect(props.setParameterValue).toHaveBeenCalledWith({
             idForCreatedAt: "2021",
           });
@@ -206,13 +194,9 @@ describe("Parameters", () => {
           },
         });
 
-        it("calls setParameterValue once", () => {
+        it("syncs parameter with query params by slugs, by passing one object with as many key/value pairs as there are matching parameters, all in a single function call", () => {
           syncQueryParamsWithURL(props);
           expect(props.setParameterValue).toHaveBeenCalledTimes(1);
-        });
-
-        it("calls setParameterValue with one object as argument, keys of parameter id and parsed param values", () => {
-          syncQueryParamsWithURL(props);
           expect(props.setParameterValue).toHaveBeenCalledWith({
             idForCreatedAt: "2021",
             idForState: "CA",


### PR DESCRIPTION
Follow-up to #16795 

To run tests locally and see coverage: 

```sh
yarn test-unit frontend/test/metabase/parameters/components/Parameters/syncQueryParamsWithURL.unit.spec.js --coverage
```

You will see a line stating coverage at ~91% for the implementation file.

Getting it to 100% will be a mix of:

1. treating the underlying prop architecture in the implementation, or throwing if no `setParameterValue` prop is passed
2. adding coverage to edge cases in the parsing helper function

These started looking like low ROI given the broader context, so I am submitting for review as is.

![image](https://user-images.githubusercontent.com/380816/123882084-6c0c7700-d91c-11eb-9a6e-45c99d2084e0.png)
