### PR TITLE
Add new executors in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -939,7 +939,7 @@ workflows:
             - checkout
 
       - lein:
-          name: be-tests-java-8-<< matrix.edition >>
+          name: be-tests-<< matrix.edition >>
           requires:
             - be-deps
           e: java-8
@@ -988,26 +988,26 @@ workflows:
       - test-driver:
           name: be-tests-bigquery-ee
           requires:
-            - be-tests-java-8-ee
+            - be-tests-ee
           driver: bigquery
 
       - test-driver:
           name: be-tests-druid-ee
           requires:
-            - be-tests-java-8-ee
+            - be-tests-ee
           e: druid
           driver: druid
 
       - test-driver:
           name: be-tests-googleanalytics-ee
           requires:
-            - be-tests-java-8-ee
+            - be-tests-ee
           driver: googleanalytics
 
       - test-driver:
           name: be-tests-mongo-ee
           requires:
-            - be-tests-java-8-ee
+            - be-tests-ee
           e: mongo
           driver: mongo
 
@@ -1015,7 +1015,7 @@ workflows:
           name: be-tests-mysql-ee
           description: "(MySQL 5.7)"
           requires:
-            - be-tests-java-8-ee
+            - be-tests-ee
           e:
             name: mysql-5-7
           driver: mysql
@@ -1024,7 +1024,7 @@ workflows:
           name: be-tests-mysql-latest-ee
           description: "(MySQL latest)"
           requires:
-            - be-tests-java-8-ee
+            - be-tests-ee
           e:
             name: mysql-latest
           driver: mysql
@@ -1045,7 +1045,7 @@ workflows:
           name: be-tests-mariadb-ee
           description: "(MariaDB 10.2)"
           requires:
-            - be-tests-java-8-ee
+            - be-tests-ee
           e:
             name: mariadb-10-2
           driver: mysql
@@ -1054,7 +1054,7 @@ workflows:
           name: be-tests-mariadb-latest-ee
           description: "(MariaDB latest)"
           requires:
-            - be-tests-java-8-ee
+            - be-tests-ee
           e:
             name: mariadb-latest
           driver: mysql
@@ -1062,7 +1062,7 @@ workflows:
       - test-driver:
           name: be-tests-oracle-ee
           requires:
-            - be-tests-java-8-ee
+            - be-tests-ee
           before-steps:
             - fetch-jdbc-driver:
                 source: ORACLE_JDBC_JAR
@@ -1079,7 +1079,7 @@ workflows:
           name: be-tests-postgres-ee
           description: "(9.6)"
           requires:
-            - be-tests-java-8-ee
+            - be-tests-ee
           e: postgres-9-6
           driver: postgres
 
@@ -1087,14 +1087,14 @@ workflows:
           name: be-tests-postgres-latest-ee
           description: "(Latest)"
           requires:
-            - be-tests-java-8-ee
+            - be-tests-ee
           e: postgres-latest
           driver: postgres
 
       - test-driver:
           name: be-tests-presto-ee
           requires:
-            - be-tests-java-8-ee
+            - be-tests-ee
           e: presto
           before-steps:
             - wait-for-port:
@@ -1104,21 +1104,21 @@ workflows:
       - test-driver:
           name: be-tests-redshift-ee
           requires:
-            - be-tests-java-8-ee
+            - be-tests-ee
           driver: redshift
           timeout: 15m
 
       - test-driver:
           name: be-tests-snowflake-ee
           requires:
-            - be-tests-java-8-ee
+            - be-tests-ee
           driver: snowflake
           timeout: 115m
 
       - test-driver:
           name: be-tests-sparksql-ee
           requires:
-            - be-tests-java-8-ee
+            - be-tests-ee
           e: sparksql
           before-steps:
             - wait-for-port:
@@ -1128,20 +1128,20 @@ workflows:
       - test-driver:
           name: be-tests-sqlite-ee
           requires:
-            - be-tests-java-8-ee
+            - be-tests-ee
           driver: sqlite
 
       - test-driver:
           name: be-tests-sqlserver-ee
           requires:
-            - be-tests-java-8-ee
+            - be-tests-ee
           e: sqlserver
           driver: sqlserver
 
       - test-driver:
           name: be-tests-vertica-ee
           requires:
-            - be-tests-java-8-ee
+            - be-tests-ee
           e: vertica
           before-steps:
             - fetch-jdbc-driver:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,22 +14,23 @@ executors:
   java-8:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: circleci/clojure:openjdk-8-lein-2.9.6
+      - image: circleci/clojure:openjdk-8-lein-2.9.6-buster
   
   java-11:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: circleci/clojure:openjdk-11-lein-2.9.6
+      - image: circleci/clojure:openjdk-11-lein-2.9.6-buster
   
+  # there is no common image for this one, only debian buster
   java-16:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: circleci/clojure:openjdk-16-lein-2.9.6
+      - image: circleci/clojure:openjdk-16-lein-2.9.6-buster
   
   clojure-and-node-and-browsers:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: circleci/clojure:lein-2.9.6-node-browsers
+      - image: circleci/clojure:lein-2.9.6-buster-node-browsers
 
   java-11-ek:
     working_directory: /home/circleci/metabase/metabase/
@@ -185,19 +186,19 @@ executors:
   fe-mongo-4:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: circleci/clojure:lein-2.9.6-node-browsers
+      - image: circleci/clojure:lein-2.9.6-buster-node-browsers
       - image: metabase/qa-databases:mongo-sample-4.0
 
   fe-postgres-12:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: circleci/clojure:lein-2.9.6-node-browsers
+      - image: circleci/clojure:lein-2.9.6-buster-node-browsers
       - image: metabase/qa-databases:postgres-sample-12
 
   fe-mysql-8:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: circleci/clojure:lein-2.9.6-node-browsers
+      - image: circleci/clojure:lein-2.9.6-buster-node-browsers
       - image: metabase/qa-databases:mysql-sample-8
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -987,26 +987,26 @@ workflows:
       - test-driver:
           name: be-tests-bigquery-ee
           requires:
-            - be-tests-ee
+            - be-tests-java-8-ee
           driver: bigquery
 
       - test-driver:
           name: be-tests-druid-ee
           requires:
-            - be-tests-ee
+            - be-tests-java-8-ee
           e: druid
           driver: druid
 
       - test-driver:
           name: be-tests-googleanalytics-ee
           requires:
-            - be-tests-ee
+            - be-tests-java-8-ee
           driver: googleanalytics
 
       - test-driver:
           name: be-tests-mongo-ee
           requires:
-            - be-tests-ee
+            - be-tests-java-8-ee
           e: mongo
           driver: mongo
 
@@ -1014,7 +1014,7 @@ workflows:
           name: be-tests-mysql-ee
           description: "(MySQL 5.7)"
           requires:
-            - be-tests-ee
+            - be-tests-java-8-ee
           e:
             name: mysql-5-7
           driver: mysql
@@ -1023,7 +1023,7 @@ workflows:
           name: be-tests-mysql-latest-ee
           description: "(MySQL latest)"
           requires:
-            - be-tests-ee
+            - be-tests-java-8-ee
           e:
             name: mysql-latest
           driver: mysql
@@ -1044,7 +1044,7 @@ workflows:
           name: be-tests-mariadb-ee
           description: "(MariaDB 10.2)"
           requires:
-            - be-tests-ee
+            - be-tests-java-8-ee
           e:
             name: mariadb-10-2
           driver: mysql
@@ -1053,7 +1053,7 @@ workflows:
           name: be-tests-mariadb-latest-ee
           description: "(MariaDB latest)"
           requires:
-            - be-tests-ee
+            - be-tests-java-8-ee
           e:
             name: mariadb-latest
           driver: mysql
@@ -1061,7 +1061,7 @@ workflows:
       - test-driver:
           name: be-tests-oracle-ee
           requires:
-            - be-tests-ee
+            - be-tests-java-8-ee
           before-steps:
             - fetch-jdbc-driver:
                 source: ORACLE_JDBC_JAR
@@ -1078,7 +1078,7 @@ workflows:
           name: be-tests-postgres-ee
           description: "(9.6)"
           requires:
-            - be-tests-ee
+            - be-tests-java-8-ee
           e: postgres-9-6
           driver: postgres
 
@@ -1086,14 +1086,14 @@ workflows:
           name: be-tests-postgres-latest-ee
           description: "(Latest)"
           requires:
-            - be-tests-ee
+            - be-tests-java-8-ee
           e: postgres-latest
           driver: postgres
 
       - test-driver:
           name: be-tests-presto-ee
           requires:
-            - be-tests-ee
+            - be-tests-java-8-ee
           e: presto
           before-steps:
             - wait-for-port:
@@ -1103,21 +1103,21 @@ workflows:
       - test-driver:
           name: be-tests-redshift-ee
           requires:
-            - be-tests-ee
+            - be-tests-java-8-ee
           driver: redshift
           timeout: 15m
 
       - test-driver:
           name: be-tests-snowflake-ee
           requires:
-            - be-tests-ee
+            - be-tests-java-8-ee
           driver: snowflake
           timeout: 115m
 
       - test-driver:
           name: be-tests-sparksql-ee
           requires:
-            - be-tests-ee
+            - be-tests-java-8-ee
           e: sparksql
           before-steps:
             - wait-for-port:
@@ -1127,20 +1127,20 @@ workflows:
       - test-driver:
           name: be-tests-sqlite-ee
           requires:
-            - be-tests-ee
+            - be-tests-java-8-ee
           driver: sqlite
 
       - test-driver:
           name: be-tests-sqlserver-ee
           requires:
-            - be-tests-ee
+            - be-tests-java-8-ee
           e: sqlserver
           driver: sqlserver
 
       - test-driver:
           name: be-tests-vertica-ee
           requires:
-            - be-tests-ee
+            - be-tests-java-8-ee
           e: vertica
           before-steps:
             - fetch-jdbc-driver:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -938,7 +938,7 @@ workflows:
             - checkout
 
       - lein:
-          name: be-tests-<< matrix.edition >>
+          name: be-tests-java-8-<< matrix.edition >>
           requires:
             - be-deps
           e: java-8
@@ -956,7 +956,7 @@ workflows:
           <<: *Matrix
 
       - lein:
-          name: be-tests-java-11-<< matrix.edition >>
+          name: be-tests-java-11-<< matrix.edition >>-encryption-key
           requires:
             - be-deps
           e: java-11-ek

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,44 +5,43 @@ version: 2.1
 ########################################################################################################################
 
 executors:
-  # Our brand new builder
-  clojure-and-node:
+  
+  metabase-ci:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:lein-2.9.5-clojure-1.10.3.814
-
-  # CircleCI base (Lein 2.9.5) + Node + Headless browsers + Clojure CLI - big one
-  # Maildev runs by default with all Cypress tests
-  clojure-and-node-and-browsers:
-    working_directory: /home/circleci/metabase/metabase/
-    docker:
-      - image: circleci/clojure:lein-2.9.5-node-browsers
-      - image: maildev/maildev
+      - image: metabase/ci:circleci-java-11-lein-2.9.6-clj-1.10.3.855-07-1-2021
 
   java-8:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: circleci/clojure:openjdk-8-lein-2.9.5-buster
-
-  # Java 11 tests also test Metabase with the at-rest encryption enabled. See
-  # https://metabase.com/docs/latest/operations-guide/encrypting-database-details-at-rest.html for an explanation of
-  # what this means.
+      - image: circleci/clojure:openjdk-8-lein-2.9.6
+  
   java-11:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:lein-2.9.5-clojure-1.10.3.814
-        environment:
-          MB_ENCRYPTION_SECRET_KEY: Orw0AAyzkO/kPTLJRxiyKoBHXa/d6ZcO+p+gpZO/wSQ=
-
+      - image: circleci/clojure:openjdk-11-lein-2.9.6
+  
   java-16:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: circleci/clojure:openjdk-16-lein-2.9.5-buster
+      - image: circleci/clojure:openjdk-16-lein-2.9.6
+  
+  clojure-and-node-and-browsers:
+    working_directory: /home/circleci/metabase/metabase/
+    docker:
+      - image: circleci/clojure:lein-2.9.6-node-browsers
+
+  java-11-ek:
+    working_directory: /home/circleci/metabase/metabase/
+    docker:
+      - image: metabase/ci:circleci-java-11-lein-2.9.6-clj-1.10.3.855-07-1-2021
+        environment:
+          MB_ENCRYPTION_SECRET_KEY: Orw0AAyzkO/kPTLJRxiyKoBHXa/d6ZcO+p+gpZO/wSQ=
 
   postgres-9-6:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:lein-2.9.5-clojure-1.10.3.814
+      - image: metabase/ci:circleci-java-11-lein-2.9.6-clj-1.10.3.855-07-1-2021
         environment:
           MB_DB_TYPE: postgres
           MB_DB_PORT: 5432
@@ -58,7 +57,7 @@ executors:
   postgres-latest:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:lein-2.9.5-clojure-1.10.3.814
+      - image: metabase/ci:circleci-java-11-lein-2.9.6-clj-1.10.3.855-07-1-2021
         environment:
           MB_DB_TYPE: postgres
           MB_DB_PORT: 5432
@@ -75,7 +74,7 @@ executors:
   mysql-5-7:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:lein-2.9.5-clojure-1.10.3.814
+      - image: metabase/ci:circleci-java-11-lein-2.9.6-clj-1.10.3.855-07-1-2021
         environment:
           MB_DB_TYPE: mysql
           MB_DB_HOST: localhost
@@ -88,7 +87,7 @@ executors:
   mysql-latest:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:lein-2.9.5-clojure-1.10.3.814
+      - image: metabase/ci:circleci-java-11-lein-2.9.6-clj-1.10.3.855-07-1-2021
         environment:
           MB_DB_TYPE: mysql
           MB_DB_HOST: localhost
@@ -101,7 +100,7 @@ executors:
   mariadb-10-2:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:lein-2.9.5-clojure-1.10.3.814
+      - image: metabase/ci:circleci-java-11-lein-2.9.6-clj-1.10.3.855-07-1-2021
         environment:
           MB_DB_TYPE: mysql
           MB_DB_HOST: localhost
@@ -114,7 +113,7 @@ executors:
   mariadb-latest:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:lein-2.9.5-clojure-1.10.3.814
+      - image: metabase/ci:circleci-java-11-lein-2.9.6-clj-1.10.3.855-07-1-2021
         environment:
           MB_DB_TYPE: mysql
           MB_DB_HOST: localhost
@@ -131,13 +130,13 @@ executors:
   mongo:
      working_directory: /home/circleci/metabase/metabase/
      docker:
-       - image: metabase/ci:lein-2.9.5-clojure-1.10.3.814
+       - image: metabase/ci:circleci-java-11-lein-2.9.6-clj-1.10.3.855-07-1-2021
        - image: circleci/mongo:4.0
 
   presto:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:lein-2.9.5-clojure-1.10.3.814
+      - image: metabase/ci:circleci-java-11-lein-2.9.6-clj-1.10.3.855-07-1-2021
       - image: metabase/presto-mb-ci:0.186
         environment:
           JAVA_TOOL_OPTIONS: "-Xmx2g"
@@ -148,19 +147,19 @@ executors:
   sparksql:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:lein-2.9.5-clojure-1.10.3.814
+      - image: metabase/ci:circleci-java-11-lein-2.9.6-clj-1.10.3.855-07-1-2021
       - image: metabase/spark:2.1.1
 
   vertica:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:lein-2.9.5-clojure-1.10.3.814
+      - image: metabase/ci:circleci-java-11-lein-2.9.6-clj-1.10.3.855-07-1-2021
       - image: sumitchawla/vertica
 
   sqlserver:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:lein-2.9.5-clojure-1.10.3.814
+      - image: metabase/ci:circleci-java-11-lein-2.9.6-clj-1.10.3.855-07-1-2021
         environment:
           MB_SQLSERVER_TEST_HOST: localhost
           MB_SQLSERVER_TEST_PASSWORD: 'P@ssw0rd'
@@ -174,7 +173,7 @@ executors:
   druid:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:lein-2.9.5-clojure-1.10.3.814
+      - image: metabase/ci:circleci-java-11-lein-2.9.6-clj-1.10.3.855-07-1-2021
       - image: metabase/druid:0.20.2
         environment:
           CLUSTER_SIZE: nano-quickstart
@@ -186,19 +185,19 @@ executors:
   fe-mongo-4:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: circleci/clojure:lein-2.9.5-node-browsers
+      - image: circleci/clojure:lein-2.9.6-node-browsers
       - image: metabase/qa-databases:mongo-sample-4.0
 
   fe-postgres-12:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: circleci/clojure:lein-2.9.5-node-browsers
+      - image: circleci/clojure:lein-2.9.6-node-browsers
       - image: metabase/qa-databases:postgres-sample-12
 
   fe-mysql-8:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: circleci/clojure:lein-2.9.5-node-browsers
+      - image: circleci/clojure:lein-2.9.6-node-browsers
       - image: metabase/qa-databases:mysql-sample-8
 
 
@@ -494,7 +493,7 @@ jobs:
 ########################################################################################################################
 
   checkout:
-    executor: clojure-and-node
+    executor: metabase-ci
     steps:
       - checkout
       # .BACKEND-CHECKSUMS is every Clojure source file as well as dependency files like deps.edn and plugin manifests
@@ -543,7 +542,7 @@ jobs:
 
   check-migrations:
     executor:
-      clojure-and-node
+      metabase-ci
     steps:
       - attach-workspace
       - create-checksum-file:
@@ -566,7 +565,7 @@ jobs:
 ########################################################################################################################
 
   be-deps:
-    executor: clojure-and-node
+    executor: metabase-ci
     parameters:
       <<: *Params
     steps:
@@ -590,7 +589,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: clojure-and-node
+        default: metabase-ci
       before-steps:
         type: steps
         default: []
@@ -627,7 +626,7 @@ jobs:
                 edition: << parameters.edition >>
 
   be-linter-reflection-warnings:
-    executor: clojure-and-node
+    executor: metabase-ci
     steps:
       - attach-workspace
       - run-on-change:
@@ -643,7 +642,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: clojure-and-node
+        default: metabase-ci
       driver:
         type: string
       timeout:
@@ -677,7 +676,7 @@ jobs:
                 path: /home/circleci/metabase/metabase/target/junit
 
   test-build-scripts:
-    executor: clojure-and-node
+    executor: metabase-ci
     steps:
       - attach-workspace
       - run-on-change:
@@ -721,7 +720,7 @@ jobs:
 ########################################################################################################################
 
   fe-deps:
-    executor: clojure-and-node
+    executor: metabase-ci
     steps:
       - attach-workspace
       # This step is *really* slow, so we can skip it if yarn.lock hasn't changed since last time we ran it
@@ -743,7 +742,7 @@ jobs:
                   - /home/circleci/.cache/Cypress
 
   shared-tests-cljs:
-    executor: clojure-and-node
+    executor: metabase-ci
     steps:
       - run-yarn-command:
           command-name: Run Cljs tests for shared/ code
@@ -753,7 +752,7 @@ jobs:
   # Unlike the other build-uberjar steps, this step should be run once overall and the results can be shared between
   # OSS and EE uberjars.
   build-uberjar-drivers:
-    executor: clojure-and-node
+    executor: metabase-ci
     parameters:
       <<: *Params
     steps:
@@ -805,7 +804,7 @@ jobs:
   build-uberjar-frontend:
     parameters:
       <<: *Params
-    executor: clojure-and-node
+    executor: metabase-ci
     steps:
       - attach-workspace
       - run-on-change:
@@ -829,7 +828,7 @@ jobs:
   build-uberjar:
     parameters:
       <<: *Params
-    executor: clojure-and-node
+    executor: metabase-ci
     steps:
       - attach-workspace
       - run-on-change:
@@ -951,6 +950,15 @@ workflows:
           requires:
             - be-deps
           e: java-11
+          lein-command: with-profile +junit test
+          skip-when-no-change: true
+          <<: *Matrix
+
+      - lein:
+          name: be-tests-java-11-<< matrix.edition >>
+          requires:
+            - be-deps
+          e: java-11-ek
           lein-command: with-profile +junit test
           skip-when-no-change: true
           <<: *Matrix

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,7 @@ executors:
     working_directory: /home/circleci/metabase/metabase/
     docker:
       - image: circleci/clojure:lein-2.9.6-buster-node-browsers
+      - image: maildev/maildev
 
   java-11-ek:
     working_directory: /home/circleci/metabase/metabase/


### PR DESCRIPTION
Let me tell you the story of trying to use a 100% alpine based CI which finished with this PR:
1) we had our alpine based builder which was using a pinned down docker image, this ended up persisting BE and FE cache into a /root/ folder and CircleCI based images could not get this cache as these images work on the /home/circleci folder, and it even returned errors since you can't persist in the root folder in a container where you're not root.
2) also, you can't make alpine based containers for cypress, since you need packages that are glib-based and not musl based (https://docs.cypress.io/guides/getting-started/installing-cypress), so the only option was to build our container from scratch (debian based + node + browsers) or use the one that is cypress based (which we will have to add layers as they don't have java installed)
3) at this point I ended up adding a circleci user to our own containers so everything can be cached to that folder and then the circleci based containers that use cypress can pull this cache, but this ended up in permission errors which I couldn't debug (java permission errors that never happen locally but happen in CircleCI for unknown reasons)
4) I ended up rebuilding a debian buster circleci based image with latest leinengen + latest LTS node + clojure cli tools, which is a sub-optimal solution but this should accelerate everything because of caching.

The final solution should be to fix the permission errors in our custom builder so we used that image along all building process + try to build a debian based cypress image as well to be agnostic of the CI