### PR TITLE
Symlink the BE and FE cache dirs to the home folder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ executors:
   clojure-and-node-and-browsers:
     working_directory: ~/metabase/metabase/
     docker:
-      - image: circleci/clojure:lein-2.9.5-node-browsers
+      - image: cypress/browsers:node12.18.3-chrome89-ff86
       - image: maildev/maildev
 
   java-8:
@@ -895,6 +895,9 @@ jobs:
       DISPLAY: ""
     steps:
       - attach-workspace
+      - run:
+          name: "Install cypress"
+          command: yarn install cypress@6.8.0 -g
       - run-on-change:
           checksum: '{{ checksum ".BACKEND-CHECKSUMS" }}-{{ checksum ".FRONTEND-CHECKSUMS" }}-{{ checksum ".E2E-TESTS-CHECKSUMS" }}'
           steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -895,26 +895,20 @@ jobs:
       DISPLAY: ""
     steps:
       - attach-workspace
-      - run:
-          name: "Install cypress"
-          command: yarn install cypress@6.8.0 -g
-      - run-on-change:
-          checksum: '{{ checksum ".BACKEND-CHECKSUMS" }}-{{ checksum ".FRONTEND-CHECKSUMS" }}-{{ checksum ".E2E-TESTS-CHECKSUMS" }}'
-          steps:
-            - run-yarn-command:
-                command-name: Run Cypress tests
-                before-steps:
-                  - restore_cache:
-                      name: Restore cached uberjar built in previous step
-                      <<: *CacheKeyUberjar
-                  - steps: << parameters.before-steps >>
-                command: |
-                  run test-cypress-no-build <<# parameters.test-files >> --spec << parameters.test-files >> <</ parameters.test-files >> --folder << parameters.source-folder >>
-                after-steps:
-                  - store_artifacts:
-                      path: ~/metabase/metabase/cypress
-                  - store_test_results:
-                      path: cypress/results
+      - run-yarn-command:
+          command-name: Run Cypress tests
+          before-steps:
+            - restore_cache:
+                name: Restore cached uberjar built in previous step
+                <<: *CacheKeyUberjar
+            - steps: << parameters.before-steps >>
+          command: |
+            run test-cypress-no-build <<# parameters.test-files >> --spec << parameters.test-files >> <</ parameters.test-files >> --folder << parameters.source-folder >>
+          after-steps:
+            - store_artifacts:
+                path: ~/metabase/metabase/cypress
+            - store_test_results:
+                path: cypress/results
 
 
 ########################################################################################################################

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -497,6 +497,9 @@ jobs:
     executor: clojure-and-node
     steps:
       - checkout
+      - run:
+          name: Symlink dirs for caches
+          command: ln -s /home/circleci/.m2 ~/.m2 && ln -s /home/circleci/.yarn ~/.yarn && ln -s /home/circleci/.yarn-cache ~/.yarn-cache && ln -s /home/circleci/.cache ~/.cache
       # .BACKEND-CHECKSUMS is every Clojure source file as well as dependency files like deps.edn and plugin manifests
       - create-checksum-file:
           filename: .BACKEND-CHECKSUMS
@@ -768,7 +771,7 @@ jobs:
           # need to rebuild them.
           checksum: '{{ checksum ".MODULES-CHECKSUMS" }}-{{ checksum ".BACKEND-CHECKSUMS" }}'
           steps:
-            - restore-be-deps-cache            #
+            - restore-be-deps-cache
             - restore_cache:
                 <<: *CacheKeyMetabaseCore
             - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ version: 2.1
 ########################################################################################################################
 
 executors:
-  # Our brand new builder
+  # Our brand new builder - Java 11
   clojure-and-node:
     working_directory: ~/metabase/metabase/
     docker:
@@ -22,7 +22,7 @@ executors:
   java-8:
     working_directory: ~/metabase/metabase/
     docker:
-      - image: circleci/clojure:openjdk-8-lein-2.9.5-buster
+      - image: metabase/ci:java-8-lein-2.9.6-clj-1.10.3.822-04-22-2021
 
   # Java 11 tests also test Metabase with the at-rest encryption enabled. See
   # https://metabase.com/docs/latest/operations-guide/encrypting-database-details-at-rest.html for an explanation of
@@ -37,7 +37,7 @@ executors:
   java-16:
     working_directory: ~/metabase/metabase/
     docker:
-      - image: circleci/clojure:openjdk-16-lein-2.9.5-buster
+      - image: metabase/ci:java-16-lein-2.9.6-clj-1.10.3.822-04-22-2021
 
   postgres-9-6:
     working_directory: ~/metabase/metabase/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,20 +7,20 @@ version: 2.1
 executors:
   # Our brand new builder
   clojure-and-node:
-    working_directory: /home/circleci/metabase/metabase/
+    working_directory: ~/metabase/metabase/
     docker:
       - image: metabase/ci:lein-2.9.5-clojure-1.10.3.814
 
   # CircleCI base (Lein 2.9.5) + Node + Headless browsers + Clojure CLI - big one
   # Maildev runs by default with all Cypress tests
   clojure-and-node-and-browsers:
-    working_directory: /home/circleci/metabase/metabase/
+    working_directory: ~/metabase/metabase/
     docker:
       - image: circleci/clojure:lein-2.9.5-node-browsers
       - image: maildev/maildev
 
   java-8:
-    working_directory: /home/circleci/metabase/metabase/
+    working_directory: ~/metabase/metabase/
     docker:
       - image: circleci/clojure:openjdk-8-lein-2.9.5-buster
 
@@ -28,19 +28,19 @@ executors:
   # https://metabase.com/docs/latest/operations-guide/encrypting-database-details-at-rest.html for an explanation of
   # what this means.
   java-11:
-    working_directory: /home/circleci/metabase/metabase/
+    working_directory: ~/metabase/metabase/
     docker:
       - image: metabase/ci:lein-2.9.5-clojure-1.10.3.814
         environment:
           MB_ENCRYPTION_SECRET_KEY: Orw0AAyzkO/kPTLJRxiyKoBHXa/d6ZcO+p+gpZO/wSQ=
 
   java-16:
-    working_directory: /home/circleci/metabase/metabase/
+    working_directory: ~/metabase/metabase/
     docker:
       - image: circleci/clojure:openjdk-16-lein-2.9.5-buster
 
   postgres-9-6:
-    working_directory: /home/circleci/metabase/metabase/
+    working_directory: ~/metabase/metabase/
     docker:
       - image: metabase/ci:lein-2.9.5-clojure-1.10.3.814
         environment:
@@ -56,7 +56,7 @@ executors:
           POSTGRES_DB: circle_test
 
   postgres-latest:
-    working_directory: /home/circleci/metabase/metabase/
+    working_directory: ~/metabase/metabase/
     docker:
       - image: metabase/ci:lein-2.9.5-clojure-1.10.3.814
         environment:
@@ -73,7 +73,7 @@ executors:
           POSTGRES_HOST_AUTH_METHOD: trust
 
   mysql-5-7:
-    working_directory: /home/circleci/metabase/metabase/
+    working_directory: ~/metabase/metabase/
     docker:
       - image: metabase/ci:lein-2.9.5-clojure-1.10.3.814
         environment:
@@ -86,7 +86,7 @@ executors:
       - image: circleci/mysql:5.7.23
 
   mysql-latest:
-    working_directory: /home/circleci/metabase/metabase/
+    working_directory: ~/metabase/metabase/
     docker:
       - image: metabase/ci:lein-2.9.5-clojure-1.10.3.814
         environment:
@@ -99,7 +99,7 @@ executors:
       - image: circleci/mysql:latest
 
   mariadb-10-2:
-    working_directory: /home/circleci/metabase/metabase/
+    working_directory: ~/metabase/metabase/
     docker:
       - image: metabase/ci:lein-2.9.5-clojure-1.10.3.814
         environment:
@@ -112,7 +112,7 @@ executors:
       - image: circleci/mariadb:10.2.23
 
   mariadb-latest:
-    working_directory: /home/circleci/metabase/metabase/
+    working_directory: ~/metabase/metabase/
     docker:
       - image: metabase/ci:lein-2.9.5-clojure-1.10.3.814
         environment:
@@ -129,13 +129,13 @@ executors:
           # MYSQL_ALLOW_EMPTY_PASSWORD: yes
 
   mongo:
-     working_directory: /home/circleci/metabase/metabase/
+     working_directory: ~/metabase/metabase/
      docker:
        - image: metabase/ci:lein-2.9.5-clojure-1.10.3.814
        - image: circleci/mongo:4.0
 
   presto:
-    working_directory: /home/circleci/metabase/metabase/
+    working_directory: ~/metabase/metabase/
     docker:
       - image: metabase/ci:lein-2.9.5-clojure-1.10.3.814
       - image: metabase/presto-mb-ci:0.186
@@ -146,19 +146,19 @@ executors:
     resource_class: large
 
   sparksql:
-    working_directory: /home/circleci/metabase/metabase/
+    working_directory: ~/metabase/metabase/
     docker:
       - image: metabase/ci:lein-2.9.5-clojure-1.10.3.814
       - image: metabase/spark:2.1.1
 
   vertica:
-    working_directory: /home/circleci/metabase/metabase/
+    working_directory: ~/metabase/metabase/
     docker:
       - image: metabase/ci:lein-2.9.5-clojure-1.10.3.814
       - image: sumitchawla/vertica
 
   sqlserver:
-    working_directory: /home/circleci/metabase/metabase/
+    working_directory: ~/metabase/metabase/
     docker:
       - image: metabase/ci:lein-2.9.5-clojure-1.10.3.814
         environment:
@@ -172,7 +172,7 @@ executors:
           MSSQL_MEMORY_LIMIT_MB: 1024
 
   druid:
-    working_directory: /home/circleci/metabase/metabase/
+    working_directory: ~/metabase/metabase/
     docker:
       - image: metabase/ci:lein-2.9.5-clojure-1.10.3.814
       - image: metabase/druid:0.20.2
@@ -184,19 +184,19 @@ executors:
 
 
   fe-mongo-4:
-    working_directory: /home/circleci/metabase/metabase/
+    working_directory: ~/metabase/metabase/
     docker:
       - image: circleci/clojure:lein-2.9.5-node-browsers
       - image: metabase/qa-databases:mongo-sample-4.0
 
   fe-postgres-12:
-    working_directory: /home/circleci/metabase/metabase/
+    working_directory: ~/metabase/metabase/
     docker:
       - image: circleci/clojure:lein-2.9.5-node-browsers
       - image: metabase/qa-databases:postgres-sample-12
 
   fe-mysql-8:
-    working_directory: /home/circleci/metabase/metabase/
+    working_directory: ~/metabase/metabase/
     docker:
       - image: circleci/clojure:lein-2.9.5-node-browsers
       - image: metabase/qa-databases:mysql-sample-8
@@ -271,7 +271,7 @@ commands:
   attach-workspace:
     steps:
       - attach_workspace:
-          at: /home/circleci/
+          at: ~/
 
   # For the restore-deps-cache commands below, only restore the cache if there's an exact match. This means whatever
   # is in the cache will be exactly what's used and the cache won't keep growing uncontrollably going forward.
@@ -370,10 +370,10 @@ commands:
           name: Persist dummy file .SUCCESS to cache with key << parameters.checksum >>
           <<: *CacheKeyRunOnChange
           paths:
-            - /home/circleci/metabase/metabase/.SUCCESS
+            - ~/metabase/metabase/.SUCCESS
       - run:
           name: Delete dummy file .SUCCESS so subsequent steps don't see it
-          command: rm /home/circleci/metabase/metabase/.SUCCESS
+          command: rm ~/metabase/metabase/.SUCCESS
 
   # Creates a file that contains checksums for all the files found using the find command with supplied arguments.
   # You can use a checksum of the checksum file for cache keys including run-on-change cache keys.
@@ -417,7 +417,7 @@ commands:
           no_output_timeout: 15m
       - steps: << parameters.after-steps >>
       - store_test_results:
-          path: /home/circleci/metabase/metabase/target/junit
+          path: ~/metabase/metabase/target/junit
 
   run-yarn-command:
     parameters:
@@ -480,7 +480,7 @@ commands:
     steps:
       - run:
           name: Make plugins dir
-          command: mkdir /home/circleci/metabase/metabase/plugins
+          command: mkdir ~/metabase/metabase/plugins
       - run:
           name: Download JDBC driver JAR << parameters.dest >>
           command: |
@@ -497,9 +497,6 @@ jobs:
     executor: clojure-and-node
     steps:
       - checkout
-      - run:
-          name: Symlink dirs for caches
-          command: ln -s /home/circleci/.m2 ~/.m2 && ln -s /home/circleci/.yarn ~/.yarn && ln -s /home/circleci/.yarn-cache ~/.yarn-cache && ln -s /home/circleci/.cache ~/.cache
       # .BACKEND-CHECKSUMS is every Clojure source file as well as dependency files like deps.edn and plugin manifests
       - create-checksum-file:
           filename: .BACKEND-CHECKSUMS
@@ -525,10 +522,10 @@ jobs:
           command: git log -1 > .COMMIT
       - run:
           name: Remove .git directory (not needed for tests)
-          command: rm -rf /home/circleci/metabase/metabase/.git
+          command: rm -rf ~/metabase/metabase/.git
       - run:
           name: Remove ./OSX directory (not needed for tests)
-          command: rm -rf /home/circleci/metabase/metabase/OSX
+          command: rm -rf ~/metabase/metabase/OSX
       # .CACHE-PREFIX is described above in the Cache Keys section of this file
       - run:
           name: 'Create cache key prefix .CACHE-PREFIX to bust caches if commit message includes [ci nocache]'
@@ -540,7 +537,7 @@ jobs:
                echo '' > .CACHE-PREFIX
             fi
       - persist_to_workspace:
-          root: /home/circleci/
+          root: ~/
           paths:
             - metabase/metabase
 
@@ -582,12 +579,12 @@ jobs:
             - restore-be-deps-cache
             - run: lein with-profile +include-all-drivers,+cloverage,+junit,+dev,+<< parameters.edition >> deps
             - run: |
-                cd /home/circleci/metabase/metabase/bin/build-mb && clojure -P
+                cd ~/metabase/metabase/bin/build-mb && clojure -P
             - save_cache:
                 name: Cache backend dependencies
                 <<: *CacheKeyBackendDeps
                 paths:
-                  - /home/circleci/.m2
+                  - ~/.m2
 
   lein:
     parameters:
@@ -677,7 +674,7 @@ jobs:
                 command: << parameters.extra-env >> lein with-profile +ci,+junit,+ee test
                 no_output_timeout: << parameters.timeout >>
             - store_test_results:
-                path: /home/circleci/metabase/metabase/target/junit
+                path: ~/metabase/metabase/target/junit
 
   test-build-scripts:
     executor: clojure-and-node
@@ -690,32 +687,32 @@ jobs:
             - run:
                 name: Run metabuild-common build script tests
                 command: |
-                  cd /home/circleci/metabase/metabase/bin/common && clojure -M:test
+                  cd ~/metabase/metabase/bin/common && clojure -M:test
                 no_output_timeout: 15m
             - run:
                 name: Run build-drivers build script tests
                 command: |
-                  cd /home/circleci/metabase/metabase/bin/build-drivers && clojure -M:test
+                  cd ~/metabase/metabase/bin/build-drivers && clojure -M:test
                 no_output_timeout: 15m
             - run:
                 name: Run i18n script tests
                 command: |
-                  cd /home/circleci/metabase/metabase/bin/i18n && clojure -M:test
+                  cd ~/metabase/metabase/bin/i18n && clojure -M:test
                 no_output_timeout: 15m
             - run:
                 name: Run build-mb build script tests
                 command: |
-                  cd /home/circleci/metabase/metabase/bin/build-mb && clojure -M:test
+                  cd ~/metabase/metabase/bin/build-mb && clojure -M:test
                 no_output_timeout: 15m
             - run:
                 name: Run release script tests
                 command: |
-                  cd /home/circleci/metabase/metabase/bin/release && clojure -M:test
+                  cd ~/metabase/metabase/bin/release && clojure -M:test
                 no_output_timeout: 15m
             - run:
                 name: Run Liquibase migrations linter tests
                 command: |
-                  cd /home/circleci/metabase/metabase/bin/lint-migrations-file && clojure -M:test
+                  cd ~/metabase/metabase/bin/lint-migrations-file && clojure -M:test
                 no_output_timeout: 15m
 
 
@@ -740,10 +737,11 @@ jobs:
                 name: Cache frontend dependencies
                 <<: *CacheKeyFrontendDeps
                 paths:
-                  - /home/circleci/.yarn
-                  - /home/circleci/.yarn-cache
-                  - /home/circleci/metabase/metabase/node_modules
-                  - /home/circleci/.cache/Cypress
+                  - ~/.yarn
+                  - ~/.yarn-cache
+                  - ~/.cache
+                  - ~/metabase/metabase/node_modules
+                  - ~/.cache/Cypress
 
   shared-tests-cljs:
     executor: clojure-and-node
@@ -785,24 +783,24 @@ jobs:
                 name: Cache local Maven installation of metabase-core
                 <<: *CacheKeyMetabaseCore
                 paths:
-                  - /home/circleci/.m2/repository/metabase-core
+                  - ~/.m2/repository/metabase-core
             - save_cache:
                 name: Cache the built drivers
                 <<: *CacheKeyDrivers
                 paths:
-                  - /home/circleci/metabase/metabase/modules/drivers/bigquery/target
-                  - /home/circleci/metabase/metabase/modules/drivers/druid/target
-                  - /home/circleci/metabase/metabase/modules/drivers/google/target
-                  - /home/circleci/metabase/metabase/modules/drivers/googleanalytics/target
-                  - /home/circleci/metabase/metabase/modules/drivers/mongo/target
-                  - /home/circleci/metabase/metabase/modules/drivers/oracle/target
-                  - /home/circleci/metabase/metabase/modules/drivers/presto/target
-                  - /home/circleci/metabase/metabase/modules/drivers/redshift/target
-                  - /home/circleci/metabase/metabase/modules/drivers/snowflake/target
-                  - /home/circleci/metabase/metabase/modules/drivers/sparksql/target
-                  - /home/circleci/metabase/metabase/modules/drivers/sqlite/target
-                  - /home/circleci/metabase/metabase/modules/drivers/sqlserver/target
-                  - /home/circleci/metabase/metabase/modules/drivers/vertica/target
+                  - ~/metabase/metabase/modules/drivers/bigquery/target
+                  - ~/metabase/metabase/modules/drivers/druid/target
+                  - ~/metabase/metabase/modules/drivers/google/target
+                  - ~/metabase/metabase/modules/drivers/googleanalytics/target
+                  - ~/metabase/metabase/modules/drivers/mongo/target
+                  - ~/metabase/metabase/modules/drivers/oracle/target
+                  - ~/metabase/metabase/modules/drivers/presto/target
+                  - ~/metabase/metabase/modules/drivers/redshift/target
+                  - ~/metabase/metabase/modules/drivers/snowflake/target
+                  - ~/metabase/metabase/modules/drivers/sparksql/target
+                  - ~/metabase/metabase/modules/drivers/sqlite/target
+                  - ~/metabase/metabase/modules/drivers/sqlserver/target
+                  - ~/metabase/metabase/modules/drivers/vertica/target
 
   # Build the frontend client. parameters.edition determines whether we build the OSS or EE version.
   build-uberjar-frontend:
@@ -826,7 +824,7 @@ jobs:
                 name: Cache the built frontend
                 <<: *CacheKeyFrontend
                 paths:
-                  - /home/circleci/metabase/metabase/resources/frontend_client
+                  - ~/metabase/metabase/resources/frontend_client
 
   # Build the uberjar. parmeters.edition determines whether we build the OSS or EE version.
   build-uberjar:
@@ -863,15 +861,15 @@ jobs:
                 command: ./bin/build version drivers uberjar
                 no_output_timeout: 15m
             - store_artifacts:
-                path: /home/circleci/metabase/metabase/target/uberjar/metabase.jar
+                path: ~/metabase/metabase/target/uberjar/metabase.jar
             - store_artifacts:
-                path: /home/circleci/metabase/metabase/resources/version.properties
+                path: ~/metabase/metabase/resources/version.properties
             - save_cache:
                 name: Cache the built uberjar & version.properties
                 <<: *CacheKeyUberjar
                 paths:
-                  - /home/circleci/metabase/metabase/target/uberjar/metabase.jar
-                  - /home/circleci/metabase/metabase/resources/version.properties
+                  - ~/metabase/metabase/target/uberjar/metabase.jar
+                  - ~/metabase/metabase/resources/version.properties
 
   fe-tests-cypress:
     parameters:
@@ -911,7 +909,7 @@ jobs:
                   run test-cypress-no-build <<# parameters.test-files >> --spec << parameters.test-files >> <</ parameters.test-files >> --folder << parameters.source-folder >>
                 after-steps:
                   - store_artifacts:
-                      path: /home/circleci/metabase/metabase/cypress
+                      path: ~/metabase/metabase/cypress
                   - store_test_results:
                       path: cypress/results
 
@@ -1030,7 +1028,7 @@ workflows:
             MB_MYSQL_SSL_TEST_HOST=$MYSQL_RDS_SSL_INSTANCE_HOST
             MB_MYSQL_SSL_TEST_SSL=true
             MB_MYSQL_SSL_TEST_ADDITIONAL_OPTIONS='verifyServerCertificate=true'
-            MB_MYSQL_SSL_TEST_SSL_CERT="$(cat /home/circleci/metabase/metabase/resources/certificates/rds-combined-ca-bundle.pem)"
+            MB_MYSQL_SSL_TEST_SSL_CERT="$(cat ~/metabase/metabase/resources/certificates/rds-combined-ca-bundle.pem)"
             MB_MYSQL_SSL_TEST_USER=metabase
             MB_MYSQL_SSL_TEST_PASSWORD=$MYSQL_RDS_SSL_INSTANCE_PASSWORD
 
@@ -1064,7 +1062,7 @@ workflows:
           extra-env: >-
             MB_ORACLE_SSL_TEST_SSL=true
             MB_ORACLE_SSL_TEST_PORT=2484
-            JVM_OPTS="-Djavax.net.ssl.trustStore=/home/circleci/metabase/metabase/resources/certificates/cacerts_with_RDS_root_ca.jks
+            JVM_OPTS="-Djavax.net.ssl.trustStore=~/metabase/metabase/resources/certificates/cacerts_with_RDS_root_ca.jks
                       -Djavax.net.ssl.trustStoreType=JKS
                       -Djavax.net.ssl.trustStorePassword=metabase $JAVA_OPTS"
 


### PR DESCRIPTION
This PR intends to separate #16691 into 3

- Add new executors (moving CircleCI java 8 and java 16 to metabase:ci alpine images) (PR https://github.com/metabase/metabase/pull/16823)
- Symlink the ~/ directory to /home/circleci/ where the FE and BE cache persist - this PR
- Slash a few lines of the file so we DRO ("don't repeat ourselves"?)