### PR TITLE
Remove `recompose`

### DIFF
--- a/frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx
@@ -18,8 +18,6 @@ import cx from "classnames";
 
 import LeafletChoropleth from "metabase/visualizations/components/LeafletChoropleth";
 
-import pure from "recompose/pure";
-
 export default class CustomGeoJSONWidget extends Component {
   constructor(props, context) {
     super(props, context);
@@ -411,6 +409,6 @@ const EditMap = ({
   </div>
 );
 
-const ChoroplethPreview = pure(({ geoJson }) => (
+const ChoroplethPreview = React.memo(({ geoJson }) => (
   <LeafletChoropleth geoJson={geoJson} />
 ));

--- a/frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx
@@ -412,3 +412,5 @@ const EditMap = ({
 const ChoroplethPreview = React.memo(({ geoJson }) => (
   <LeafletChoropleth geoJson={geoJson} />
 ));
+
+ChoroplethPreview.displayName = "ChoroplethPreview";

--- a/frontend/src/metabase/components/List.jsx
+++ b/frontend/src/metabase/components/List.jsx
@@ -3,7 +3,6 @@ import React from "react";
 import PropTypes from "prop-types";
 
 import S from "./List.css";
-import pure from "recompose/pure";
 
 const List = ({ children }) => <ul className={S.list}>{children}</ul>;
 
@@ -11,4 +10,4 @@ List.propTypes = {
   children: PropTypes.any.isRequired,
 };
 
-export default pure(List);
+export default React.memo(List);

--- a/frontend/src/metabase/components/ListItem.jsx
+++ b/frontend/src/metabase/components/ListItem.jsx
@@ -7,7 +7,6 @@ import Icon from "./Icon";
 import Ellipsified from "./Ellipsified";
 
 import cx from "classnames";
-import pure from "recompose/pure";
 import Card from "metabase/components/Card";
 
 //TODO: extend this to support functionality required for questions
@@ -50,4 +49,4 @@ ListItem.propTypes = {
   field: PropTypes.object,
 };
 
-export default pure(ListItem);
+export default React.memo(ListItem);

--- a/frontend/src/metabase/components/QueryButton.jsx
+++ b/frontend/src/metabase/components/QueryButton.jsx
@@ -1,7 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Link } from "react-router";
-import pure from "recompose/pure";
 import cx from "classnames";
 
 import S from "./QueryButton.css";
@@ -29,4 +28,4 @@ QueryButton.propTypes = {
   link: PropTypes.string,
 };
 
-export default pure(QueryButton);
+export default React.memo(QueryButton);

--- a/frontend/src/metabase/components/SidebarItem.jsx
+++ b/frontend/src/metabase/components/SidebarItem.jsx
@@ -6,8 +6,6 @@ import S from "./Sidebar.css";
 
 import LabelIcon from "./LabelIcon";
 
-import pure from "recompose/pure";
-
 const SidebarItem = ({ name, sidebar, icon, href }) => (
   <li>
     <Link to={href} className={S.item} activeClassName={S.selected}>
@@ -24,4 +22,4 @@ SidebarItem.propTypes = {
   href: PropTypes.string.isRequired,
 };
 
-export default pure(SidebarItem);
+export default React.memo(SidebarItem);

--- a/frontend/src/metabase/components/TitleAndDescription.jsx
+++ b/frontend/src/metabase/components/TitleAndDescription.jsx
@@ -1,6 +1,5 @@
 import React from "react";
 import cx from "classnames";
-import pure from "recompose/pure";
 
 import Icon from "metabase/components/Icon";
 import Tooltip from "metabase/components/Tooltip";
@@ -21,4 +20,4 @@ const TitleAndDescription = ({ title, description, className }: Attributes) => (
   </div>
 );
 
-export default pure(TitleAndDescription);
+export default React.memo(TitleAndDescription);

--- a/frontend/src/metabase/components/TooltipPopover.jsx
+++ b/frontend/src/metabase/components/TooltipPopover.jsx
@@ -1,6 +1,5 @@
 /* eslint-disable react/prop-types */
 import React from "react";
-import pure from "recompose/pure";
 import cx from "classnames";
 
 import Popover from "./Popover";
@@ -38,4 +37,4 @@ TooltipPopover.defaultProps = {
   constrainedWidth: true,
 };
 
-export default pure(TooltipPopover);
+export default React.memo(TooltipPopover);

--- a/frontend/src/metabase/reference/components/Detail.jsx
+++ b/frontend/src/metabase/reference/components/Detail.jsx
@@ -5,7 +5,6 @@ import { Link } from "react-router";
 import S from "./Detail.css";
 import { t } from "ttag";
 import cx from "classnames";
-import pure from "recompose/pure";
 
 const Detail = ({
   name,
@@ -64,4 +63,4 @@ Detail.propTypes = {
   field: PropTypes.object,
 };
 
-export default pure(Detail);
+export default React.memo(Detail);

--- a/frontend/src/metabase/reference/components/EditHeader.jsx
+++ b/frontend/src/metabase/reference/components/EditHeader.jsx
@@ -1,7 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
 import cx from "classnames";
-import pure from "recompose/pure";
 import { t } from "ttag";
 import S from "./EditHeader.css";
 
@@ -81,4 +80,4 @@ EditHeader.propTypes = {
   revisionMessageFormField: PropTypes.object,
 };
 
-export default pure(EditHeader);
+export default React.memo(EditHeader);

--- a/frontend/src/metabase/reference/components/EditableReferenceHeader.jsx
+++ b/frontend/src/metabase/reference/components/EditableReferenceHeader.jsx
@@ -2,7 +2,6 @@ import React from "react";
 import PropTypes from "prop-types";
 import { Link } from "react-router";
 import cx from "classnames";
-import pure from "recompose/pure";
 import { t } from "ttag";
 import S from "./ReferenceHeader.css";
 import L from "metabase/components/List.css";
@@ -110,4 +109,4 @@ EditableReferenceHeader.propTypes = {
   nameFormField: PropTypes.object,
 };
 
-export default pure(EditableReferenceHeader);
+export default React.memo(EditableReferenceHeader);

--- a/frontend/src/metabase/reference/components/Field.jsx
+++ b/frontend/src/metabase/reference/components/Field.jsx
@@ -15,7 +15,6 @@ import Select from "metabase/components/Select";
 import Icon from "metabase/components/Icon";
 
 import cx from "classnames";
-import pure from "recompose/pure";
 
 const Field = ({ field, foreignKeys, url, icon, isEditing, formField }) => (
   <div className={cx(S.item, "pt1", "border-top")}>
@@ -127,4 +126,4 @@ Field.propTypes = {
   formField: PropTypes.object,
 };
 
-export default pure(Field);
+export default React.memo(Field);

--- a/frontend/src/metabase/reference/components/FieldToGroupBy.jsx
+++ b/frontend/src/metabase/reference/components/FieldToGroupBy.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 import PropTypes from "prop-types";
-import pure from "recompose/pure";
 import { t } from "ttag";
 import cx from "classnames";
 import S from "./FieldToGroupBy.css";
@@ -42,4 +41,4 @@ FieldToGroupBy.propTypes = {
   secondaryOnClick: PropTypes.func,
 };
 
-export default pure(FieldToGroupBy);
+export default React.memo(FieldToGroupBy);

--- a/frontend/src/metabase/reference/components/FieldTypeDetail.jsx
+++ b/frontend/src/metabase/reference/components/FieldTypeDetail.jsx
@@ -2,7 +2,6 @@ import React from "react";
 import PropTypes from "prop-types";
 import cx from "classnames";
 import { getIn } from "icepick";
-import pure from "recompose/pure";
 import { t } from "ttag";
 import * as MetabaseCore from "metabase/lib/core";
 import { isNumericBaseType } from "metabase/lib/schema_metadata";
@@ -88,4 +87,4 @@ FieldTypeDetail.propTypes = {
   isEditing: PropTypes.bool.isRequired,
 };
 
-export default pure(FieldTypeDetail);
+export default React.memo(FieldTypeDetail);

--- a/frontend/src/metabase/reference/components/ReferenceHeader.jsx
+++ b/frontend/src/metabase/reference/components/ReferenceHeader.jsx
@@ -2,7 +2,6 @@ import React from "react";
 import PropTypes from "prop-types";
 import { Link } from "react-router";
 import cx from "classnames";
-import pure from "recompose/pure";
 
 import S from "./ReferenceHeader.css";
 import L from "metabase/components/List.css";
@@ -61,4 +60,4 @@ ReferenceHeader.propTypes = {
   headerLink: PropTypes.string,
 };
 
-export default pure(ReferenceHeader);
+export default React.memo(ReferenceHeader);

--- a/frontend/src/metabase/reference/components/UsefulQuestions.jsx
+++ b/frontend/src/metabase/reference/components/UsefulQuestions.jsx
@@ -1,6 +1,5 @@
 import React from "react";
 import PropTypes from "prop-types";
-import pure from "recompose/pure";
 import { t } from "ttag";
 import S from "./UsefulQuestions.css";
 import D from "metabase/reference/components/Detail.css";
@@ -25,4 +24,4 @@ UsefulQuestions.propTypes = {
   questions: PropTypes.array.isRequired,
 };
 
-export default pure(UsefulQuestions);
+export default React.memo(UsefulQuestions);

--- a/frontend/src/metabase/reference/databases/DatabaseSidebar.jsx
+++ b/frontend/src/metabase/reference/databases/DatabaseSidebar.jsx
@@ -7,7 +7,6 @@ import Breadcrumbs from "metabase/components/Breadcrumbs";
 import SidebarItem from "metabase/components/SidebarItem";
 
 import cx from "classnames";
-import pure from "recompose/pure";
 
 const DatabaseSidebar = ({ database, style, className }) => (
   <div className={cx(S.sidebar, className)} style={style}>
@@ -43,4 +42,4 @@ DatabaseSidebar.propTypes = {
   style: PropTypes.object,
 };
 
-export default pure(DatabaseSidebar);
+export default React.memo(DatabaseSidebar);

--- a/frontend/src/metabase/reference/databases/FieldSidebar.jsx
+++ b/frontend/src/metabase/reference/databases/FieldSidebar.jsx
@@ -3,7 +3,6 @@ import React from "react";
 import PropTypes from "prop-types";
 import { t } from "ttag";
 import cx from "classnames";
-import pure from "recompose/pure";
 
 import MetabaseSettings from "metabase/lib/settings";
 
@@ -59,4 +58,4 @@ FieldSidebar.propTypes = {
   style: PropTypes.object,
 };
 
-export default pure(FieldSidebar);
+export default React.memo(FieldSidebar);

--- a/frontend/src/metabase/reference/databases/TableSidebar.jsx
+++ b/frontend/src/metabase/reference/databases/TableSidebar.jsx
@@ -3,7 +3,6 @@ import React from "react";
 import PropTypes from "prop-types";
 import { t } from "ttag";
 import cx from "classnames";
-import pure from "recompose/pure";
 
 import MetabaseSettings from "metabase/lib/settings";
 
@@ -64,4 +63,4 @@ TableSidebar.propTypes = {
   style: PropTypes.object,
 };
 
-export default pure(TableSidebar);
+export default React.memo(TableSidebar);

--- a/frontend/src/metabase/reference/guide/BaseSidebar.jsx
+++ b/frontend/src/metabase/reference/guide/BaseSidebar.jsx
@@ -7,7 +7,6 @@ import Breadcrumbs from "metabase/components/Breadcrumbs";
 import SidebarItem from "metabase/components/SidebarItem";
 
 import cx from "classnames";
-import pure from "recompose/pure";
 
 const BaseSidebar = ({ style, className }) => (
   <div className={cx(S.sidebar, className)} style={style}>
@@ -47,4 +46,4 @@ BaseSidebar.propTypes = {
   style: PropTypes.object,
 };
 
-export default pure(BaseSidebar);
+export default React.memo(BaseSidebar);

--- a/frontend/src/metabase/reference/metrics/MetricSidebar.jsx
+++ b/frontend/src/metabase/reference/metrics/MetricSidebar.jsx
@@ -3,7 +3,6 @@ import React from "react";
 import PropTypes from "prop-types";
 import { t } from "ttag";
 import cx from "classnames";
-import pure from "recompose/pure";
 
 import MetabaseSettings from "metabase/lib/settings";
 
@@ -64,4 +63,4 @@ MetricSidebar.propTypes = {
   style: PropTypes.object,
 };
 
-export default pure(MetricSidebar);
+export default React.memo(MetricSidebar);

--- a/frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx
+++ b/frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx
@@ -7,7 +7,6 @@ import Breadcrumbs from "metabase/components/Breadcrumbs";
 import SidebarItem from "metabase/components/SidebarItem";
 
 import cx from "classnames";
-import pure from "recompose/pure";
 
 const SegmentFieldSidebar = ({ segment, field, style, className }) => (
   <div className={cx(S.sidebar, className)} style={style}>
@@ -41,4 +40,4 @@ SegmentFieldSidebar.propTypes = {
   style: PropTypes.object,
 };
 
-export default pure(SegmentFieldSidebar);
+export default React.memo(SegmentFieldSidebar);

--- a/frontend/src/metabase/reference/segments/SegmentSidebar.jsx
+++ b/frontend/src/metabase/reference/segments/SegmentSidebar.jsx
@@ -3,7 +3,6 @@ import React from "react";
 import PropTypes from "prop-types";
 import { t } from "ttag";
 import cx from "classnames";
-import pure from "recompose/pure";
 
 import MetabaseSettings from "metabase/lib/settings";
 
@@ -70,4 +69,4 @@ SegmentSidebar.propTypes = {
   style: PropTypes.object,
 };
 
-export default pure(SegmentSidebar);
+export default React.memo(SegmentSidebar);

--- a/frontend/src/metabase/selectors/metadata.js
+++ b/frontend/src/metabase/selectors/metadata.js
@@ -13,7 +13,7 @@ import Metric from "metabase-lib/lib/metadata/Metric";
 import Segment from "metabase-lib/lib/metadata/Segment";
 
 import _ from "underscore";
-import { shallowEqual } from "recompose";
+import shallowEqual from "./shallowEqual";
 import { getFieldValues, getRemappings } from "metabase/lib/query/field";
 
 import { getIn } from "icepick";

--- a/frontend/src/metabase/selectors/shallowEqual.js
+++ b/frontend/src/metabase/selectors/shallowEqual.js
@@ -1,0 +1,76 @@
+/**
+ * NOTE:
+ * Copied directly from `https://github.com/acdlite/recompose/blob/master/src/packages/recompose/shallowEqual.js`
+ * as a temporary solution until we find an alternative to this utility. It was the only thing blocking the complete removal of `recompose` lib.
+ *
+ * Please see: https://github.com/metabase/metabase/pull/16829.
+ *
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @providesModule shallowEqual
+ * @typechecks
+ */
+
+/* eslint-disable no-self-compare */
+
+const hasOwnProperty = Object.prototype.hasOwnProperty;
+
+/**
+ * inlined Object.is polyfill to avoid requiring consumers ship their own
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is
+ */
+function is(x, y) {
+  // SameValue algorithm
+  if (x === y) {
+    // Steps 1-5, 7-10
+    // Steps 6.b-6.e: +0 != -0
+    // Added the nonzero y check to make Flow happy, but it is redundant
+    return x !== 0 || y !== 0 || 1 / x === 1 / y;
+  }
+  // Step 6.a: NaN == NaN
+  return x !== x && y !== y;
+}
+
+/**
+ * Performs equality by iterating through keys on an object and returning false
+ * when any key has values which are not strictly equal between the arguments.
+ * Returns true when the values of all keys are strictly equal.
+ */
+function shallowEqual(objA, objB) {
+  if (is(objA, objB)) {
+    return true;
+  }
+
+  if (
+    typeof objA !== "object" ||
+    objA === null ||
+    typeof objB !== "object" ||
+    objB === null
+  ) {
+    return false;
+  }
+
+  const keysA = Object.keys(objA);
+  const keysB = Object.keys(objB);
+
+  if (keysA.length !== keysB.length) {
+    return false;
+  }
+
+  // Test for A's keys different from B.
+  for (let i = 0; i < keysA.length; i++) {
+    if (
+      !hasOwnProperty.call(objB, keysA[i]) ||
+      !is(objA[keysA[i]], objB[keysA[i]])
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+export default shallowEqual;

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "react-textarea-autosize": "^5.2.1",
     "react-transition-group": "1",
     "react-virtualized": "^9.7.2",
-    "recompose": "^0.30.0",
     "redux": "^3.5.2",
     "redux-actions": "^2.0.1",
     "redux-auth-wrapper": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -822,13 +822,6 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0":
-  version "7.14.0"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.0.tgz#46794bc20b612c5f75e62dd071e24dfd95f1cbe6"
-  integrity sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==
-  dependencies:
-    regenerator-runtime "^0.13.4"
-
 "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.11.2", "@babel/runtime@^7.5.1", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.1.tgz#b4116a6b6711d010b2dad3b7b6e43bf1b9954740"
@@ -3350,11 +3343,6 @@ chalk@^4.0.0, chalk@^4.1.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-change-emitter@^0.1.2:
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/change-emitter/-/change-emitter-0.1.6.tgz#e8b2fe3d7f1ab7d69a32199aff91ea6931409515"
-  integrity sha1-6LL+PX8at9aaMhma/5HqaTFAlRU=
-
 character-entities-html4@^1.0.0:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/character-entities-html4/-/character-entities-html4-1.1.4.tgz#0e64b0a3753ddbf1fdc044c5fd01d0199a02e125"
@@ -5751,7 +5739,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
-fbjs@^0.8.1, fbjs@^0.8.16, fbjs@^0.8.9:
+fbjs@^0.8.16, fbjs@^0.8.9:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
   integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
@@ -11205,7 +11193,7 @@ react-lazy-cache@^3.0.1:
   dependencies:
     deep-equal "^1.0.1"
 
-react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.2, react-lifecycles-compat@^3.0.4:
+react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
@@ -11489,18 +11477,6 @@ rechoir@^0.6.2:
   integrity sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=
   dependencies:
     resolve "^1.1.6"
-
-recompose@^0.30.0:
-  version "0.30.0"
-  resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.30.0.tgz#82773641b3927e8c7d24a0d87d65aeeba18aabd0"
-  integrity sha512-ZTrzzUDa9AqUIhRk4KmVFihH0rapdCSMFXjhHbNrjAWxBuUD/guYlyysMnuHjlZC/KRiOKRtB4jf96yYSkKE8w==
-  dependencies:
-    "@babel/runtime" "^7.0.0"
-    change-emitter "^0.1.2"
-    fbjs "^0.8.1"
-    hoist-non-react-statics "^2.3.1"
-    react-lifecycles-compat "^3.0.2"
-    symbol-observable "^1.0.4"
 
 redent@^1.0.0:
   version "1.0.0"
@@ -13103,7 +13079,7 @@ symbol-observable@1.0.1:
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"
   integrity sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=
 
-symbol-observable@^1.0.3, symbol-observable@^1.0.4, symbol-observable@^1.1.0, symbol-observable@^1.2.0:
+symbol-observable@^1.0.3, symbol-observable@^1.1.0, symbol-observable@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
   integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

- [x] Replace recompose `pure` with `React.memo` in functional components
- [x] Find a replacement for recompose `shallowEqual` in `frontend/src/metabase/selectors/metadata.js`

- Closes #16042
- Closes #16082