### PR TITLE
VS Code: Add the tasks to format code and to run linters

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -15,6 +15,27 @@
           "kind": "build",
           "isDefault": true
         }
+      },
+      {
+        "label": "Format front-end code",
+        "type": "shell",
+        "command": "yarn prettier",
+        "presentation": {
+          "reveal": "always",
+          "panel": "dedicated",
+          "clear": true
+        }
+      },
+      {
+        "label": "Run front-end linters",
+        "type": "shell",
+        "command": "yarn lint",
+        "presentation": {
+          "reveal": "always",
+          "panel": "dedicated",
+          "clear": true
+        },
+        "problemMatcher": []
       }
     ]
   }


### PR DESCRIPTION
This is to facilitate better use of VS Code through [ready-to-use tasks](https://code.visualstudio.com/docs/editor/tasks) (continuing from PR #16325).

How to try:
1. Open the working directory with VS Code.
2. Use the menu _View_, _Command Palette_, search for and choose _Tasks: Run Task_ 

Before:

![image](https://user-images.githubusercontent.com/7288/123990399-93942b80-d97e-11eb-933f-8bb77230828c.png)


After:

![image](https://user-images.githubusercontent.com/7288/123990147-60ea3300-d97e-11eb-9016-9ca343ea0da8.png)
