### PR TITLE
Consistent request timing for login and password reset endpoints

### DIFF
--- a/src/metabase/api/session.clj
+++ b/src/metabase/api/session.clj
@@ -201,6 +201,7 @@
   (let [request-source (request.u/ip-address request)]
     (throttle-check (forgot-password-throttlers :ip-address) request-source))
   (throttle-check (forgot-password-throttlers :email)      email)
+  ;; Look up user and send email off-thread to avoid leaking user existence in request timing
   (future
     (when-let [{user-id :id, google-auth? :google_auth, is-active? :is_active}
                (db/select-one [User :id :google_auth :is_active] :%lower.email (u/lower-case-en email))]

--- a/src/metabase/api/session.clj
+++ b/src/metabase/api/session.clj
@@ -81,7 +81,7 @@
 (def ^:private disabled-account-message (deferred-tru "Your account is disabled. Please contact your administrator."))
 (def ^:private disabled-account-snippet (deferred-tru "Your account is disabled."))
 
-;; Fake salt & hash used to run BCrypt if user doesn't exist, to avoid timing attacks (Metaboat #134)
+;; Fake salt & hash used to run bcrypt hash if user doesn't exist, to avoid timing attacks (Metaboat #134)
 (def ^:private fake-salt (str (UUID/randomUUID)))
 (def ^:private fake-hashed-password (creds/hash-bcrypt (str fake-salt "fake-password")))
 

--- a/test/metabase/api/session_test.clj
+++ b/test/metabase/api/session_test.clj
@@ -212,8 +212,10 @@
 
 (deftest forgot-password-test
   (testing "POST /api/session/forgot_password"
-    (with-redefs [session-api/forgot-password-impl (let [orig @#'session-api/forgot-password-impl]
-                                                      (fn [& args] @(apply orig args)))]
+    ;; deref forgot-password-impl for the tests since it returns a future
+    (with-redefs [session-api/forgot-password-impl
+                  (let [orig @#'session-api/forgot-password-impl]
+                     (fn [& args] (u/deref-with-timeout (apply orig args) 1000)))]
       (testing "Test that we can initiate password reset"
         (et/with-fake-inbox
           (letfn [(reset-fields-set? []

--- a/test/metabase/api/session_test.clj
+++ b/test/metabase/api/session_test.clj
@@ -35,11 +35,6 @@
                         (reset! (:attempts throttler) nil))
                       (thunk)))
 
-(def ^:private mock-device-info
-  {:device_id          "129d39d1-6758-4d2c-a751-35b860007002"
-   :device_description "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.72 Safari/537.36"
-   :ip_address         "0:0:0:0:0:0:0:1"})
-
 (def ^:private SessionResponse
   {:id (s/pred mt/is-uuid-string? "session")})
 
@@ -73,16 +68,16 @@
       (let [body (assoc (mt/user->credentials :rasta) :remember false)
             response (mt/client-full-response :post 200 "session" body)]
         (is (nil? (get-in response [:cookies session-cookie :expires]))))))
-    (testing "failure should log an error(#14317)"
-      (mt/with-temp User [user]
-        (is (schema= [(s/one (s/eq :error)
-                             "log type")
-                      (s/one clojure.lang.ExceptionInfo
-                             "exception")
-                      (s/one (s/eq "Authentication endpoint error")
-                             "log message")]
-                     (first (mt/with-log-messages-for-level :error
-                              (mt/client :post 400 "session" {:email (:email user), :password "wooo"}))))))))
+  (testing "failure should log an error(#14317)"
+    (mt/with-temp User [user]
+      (is (schema= [(s/one (s/eq :error)
+                           "log type")
+                    (s/one clojure.lang.ExceptionInfo
+                           "exception")
+                    (s/one (s/eq "Authentication endpoint error")
+                           "log message")]
+                   (first (mt/with-log-messages-for-level :error
+                            (mt/client :post 400 "session" {:email (:email user), :password "wooo"}))))))))
 
 (deftest login-validation-test
   (testing "POST /api/session"
@@ -217,33 +212,35 @@
 
 (deftest forgot-password-test
   (testing "POST /api/session/forgot_password"
-    (testing "Test that we can initiate password reset"
-      (et/with-fake-inbox
-        (letfn [(reset-fields-set? []
-                  (let [{:keys [reset_token reset_triggered]} (db/select-one [User :reset_token :reset_triggered]
-                                                                :id (mt/user->id :rasta))]
-                    (boolean (and reset_token reset_triggered))))]
-          ;; make sure user is starting with no values
-          (db/update! User (mt/user->id :rasta), :reset_token nil, :reset_triggered nil)
-          (assert (not (reset-fields-set?)))
-          ;; issue reset request (token & timestamp should be saved)
-          (is (= nil
-                 (mt/user-http-request :rasta :post 204 "session/forgot_password" {:email (:username (mt/user->credentials :rasta))}))
-              "Request should return no content")
-          (is (= true
-                 (reset-fields-set?))
-              "User `:reset_token` and `:reset_triggered` should be updated")
-          (is (= "[Metabase] Password Reset Request"
-                 (-> @et/inbox (get "rasta@metabase.com") first :subject))
-              "User should get a password reset email"))))
+    (with-redefs [session-api/forgot-password-impl (let [orig @#'session-api/forgot-password-impl]
+                                                      (fn [& args] @(apply orig args)))]
+      (testing "Test that we can initiate password reset"
+        (et/with-fake-inbox
+          (letfn [(reset-fields-set? []
+                    (let [{:keys [reset_token reset_triggered]} (db/select-one [User :reset_token :reset_triggered]
+                                                                  :id (mt/user->id :rasta))]
+                      (boolean (and reset_token reset_triggered))))]
+            ;; make sure user is starting with no values
+            (db/update! User (mt/user->id :rasta), :reset_token nil, :reset_triggered nil)
+            (assert (not (reset-fields-set?)))
+            ;; issue reset request (token & timestamp should be saved)
+            (is (= nil
+                   (mt/user-http-request :rasta :post 204 "session/forgot_password" {:email (:username (mt/user->credentials :rasta))}))
+                "Request should return no content")
+            (is (= true
+                   (reset-fields-set?))
+                "User `:reset_token` and `:reset_triggered` should be updated")
+            (is (= "[Metabase] Password Reset Request"
+                   (-> @et/inbox (get "rasta@metabase.com") first :subject))
+                "User should get a password reset email"))))
 
-    (testing "test that email is required"
-      (is (= {:errors {:email "value must be a valid email address."}}
-             (mt/client :post 400 "session/forgot_password" {}))))
+      (testing "test that email is required"
+        (is (= {:errors {:email "value must be a valid email address."}}
+               (mt/client :post 400 "session/forgot_password" {}))))
 
-    (testing "Test that email not found also gives 200 as to not leak existence of user"
-      (is (= nil
-             (mt/client :post 204 "session/forgot_password" {:email "not-found@metabase.com"}))))))
+      (testing "Test that email not found also gives 200 as to not leak existence of user"
+        (is (= nil
+               (mt/client :post 204 "session/forgot_password" {:email "not-found@metabase.com"})))))))
 
 (deftest forgot-password-throttling-test
   (testing "Test that email based throttling kicks in after the login failure threshold (10) has been reached"
@@ -283,7 +280,7 @@
                 (is (schema= {:session_id (s/pred mt/is-uuid-string? "session")
                               :success    (s/eq true)}
                              (mt/client :post 200 "session/reset_password" {:token    token
-                                                                         :password (:new password)}))))
+                                                                            :password (:new password)}))))
               (testing "Old creds should no longer work"
                 (is (= {:errors {:password "did not match stored password"}}
                        (mt/client :post 401 "session" (:old creds)))))
@@ -306,19 +303,19 @@
     (testing "Test that malformed token returns 400"
       (is (= {:errors {:password "Invalid reset token"}}
              (mt/client :post 400 "session/reset_password" {:token    "not-found"
-                                                         :password "whateverUP12!!"}))))
+                                                            :password "whateverUP12!!"}))))
 
     (testing "Test that invalid token returns 400"
       (is (= {:errors {:password "Invalid reset token"}}
              (mt/client :post 400 "session/reset_password" {:token    "1_not-found"
-                                                         :password "whateverUP12!!"}))))
+                                                            :password "whateverUP12!!"}))))
 
     (testing "Test that an expired token doesn't work"
       (let [token (str (mt/user->id :rasta) "_" (UUID/randomUUID))]
         (db/update! User (mt/user->id :rasta), :reset_token token, :reset_triggered 0)
         (is (= {:errors {:password "Invalid reset token"}}
                (mt/client :post 400 "session/reset_password" {:token    token
-                                                           :password "whateverUP12!!"})))))))
+                                                              :password "whateverUP12!!"})))))))
 
 (deftest check-reset-token-valid-test
   (testing "GET /session/password_reset_token_valid"
@@ -382,15 +379,15 @@
             (is (schema= SessionResponse
                          (mt/client :post 200 "session/google_auth" {:token "foo"}))))))
       (testing "Google auth throws exception for a disabled account"
-      (mt/with-temp User [user {:email "test@metabase.com" :is_active false}]
-        (with-redefs [http/post (fn [url] {:status 200
-                                           :body   (str "{\"aud\":\"PRETEND-GOOD-GOOGLE-CLIENT-ID\","
-                                                        "\"email_verified\":\"true\","
-                                                        "\"first_name\":\"test\","
-                                                        "\"last_name\":\"user\","
-                                                        "\"email\":\"test@metabase.com\"}")})]
-          (is (= {:errors {:account "Your account is disabled."}}
-                         (mt/client :post 401 "session/google_auth" {:token "foo"})))))))))
+       (mt/with-temp User [user {:email "test@metabase.com" :is_active false}]
+         (with-redefs [http/post (fn [url] {:status 200
+                                            :body   (str "{\"aud\":\"PRETEND-GOOD-GOOGLE-CLIENT-ID\","
+                                                         "\"email_verified\":\"true\","
+                                                         "\"first_name\":\"test\","
+                                                         "\"last_name\":\"user\","
+                                                         "\"email\":\"test@metabase.com\"}")})]
+           (is (= {:errors {:account "Your account is disabled."}}
+                  (mt/client :post 401 "session/google_auth" {:token "foo"})))))))))
 
 ;;; ------------------------------------------- TESTS FOR LDAP AUTH STUFF --------------------------------------------
 

--- a/test/metabase/api/session_test.clj
+++ b/test/metabase/api/session_test.clj
@@ -381,15 +381,15 @@
             (is (schema= SessionResponse
                          (mt/client :post 200 "session/google_auth" {:token "foo"}))))))
       (testing "Google auth throws exception for a disabled account"
-       (mt/with-temp User [user {:email "test@metabase.com" :is_active false}]
-         (with-redefs [http/post (fn [url] {:status 200
-                                            :body   (str "{\"aud\":\"PRETEND-GOOD-GOOGLE-CLIENT-ID\","
-                                                         "\"email_verified\":\"true\","
-                                                         "\"first_name\":\"test\","
-                                                         "\"last_name\":\"user\","
-                                                         "\"email\":\"test@metabase.com\"}")})]
-           (is (= {:errors {:account "Your account is disabled."}}
-                  (mt/client :post 401 "session/google_auth" {:token "foo"})))))))))
+        (mt/with-temp User [user {:email "test@metabase.com" :is_active false}]
+          (with-redefs [http/post (fn [url] {:status 200
+                                             :body   (str "{\"aud\":\"PRETEND-GOOD-GOOGLE-CLIENT-ID\","
+                                                          "\"email_verified\":\"true\","
+                                                          "\"first_name\":\"test\","
+                                                          "\"last_name\":\"user\","
+                                                          "\"email\":\"test@metabase.com\"}")})]
+            (is (= {:errors {:account "Your account is disabled."}}
+                   (mt/client :post 401 "session/google_auth" {:token "foo"})))))))))
 
 ;;; ------------------------------------------- TESTS FOR LDAP AUTH STUFF --------------------------------------------
 


### PR DESCRIPTION
* On login, if user doesn't exist, do password validation anyway with a fake salt & hashed password.
* On password reset request, spin off a new thread for creating password reset token and sending email.

Both these changes ensure that we don't leak user existence via request time (https://github.com/metabase/metaboat/issues/134)

I experimented a bit with writing tests that do quick benchmarks of these APIs and check that the timing is within a margin of error for existing vs non-existing users. Ultimately it seems that using `time` isn't reliable at all, and benchmarking libraries like https://github.com/hugoduncan/criterium are very slow and can't be easily configured to just run the function a few times. Let me know if anyone has suggestions, but otherwise I'll skip this idea for now.

Also fixed some indentation in the existing tests.