### PR TITLE
Supress invalid props to a div element

### DIFF
--- a/frontend/src/metabase/parameters/components/ParametersList.jsx
+++ b/frontend/src/metabase/parameters/components/ParametersList.jsx
@@ -45,7 +45,12 @@ type Props = {
   setEditingParameter?: (parameterId: ParameterId) => void,
 };
 
-const StaticParameterWidgetList = ({ children, ...props }) => {
+const StaticParameterWidgetList = ({
+  children,
+  onSortStart,
+  onSortEnd,
+  ...props
+}) => {
   return <div {...props}>{children}</div>;
 };
 


### PR DESCRIPTION
This happens because StaticParameterWidgetList is used an alternative to SortableParameterWidget. The sorting handlers make sense for the latter but not for the former.

To verify:
1. Login
2. Open DevTools/browser console
3. Click on the X-Ray "A look at your People table"

**Before this PR**

There is this warning:

![image](https://user-images.githubusercontent.com/7288/124053565-58711700-d9d5-11eb-90fa-6cf34b1943fc.png)

**After this PR**

The above warning should not appear.