### PR TITLE
Add Cypress helper function `openNativeEditor`

### DIFF
--- a/frontend/test/__support__/e2e/cypress.js
+++ b/frontend/test/__support__/e2e/cypress.js
@@ -332,3 +332,19 @@ export function generateUsers(count, groupIds) {
 export function enableSharingQuestion(id) {
   cy.request("POST", `/api/card/${id}/public_link`);
 }
+
+/**
+ * Open native (SQL) editor and alias it.
+ *
+ * @param {string} alias - The alias that can be used later in the test as `cy.get("@" + alias)`.
+ * @example
+ * openNativeEditor().type("SELECT 123");
+ */
+export function openNativeEditor(alias = "editor") {
+  cy.visit("/");
+  cy.icon("sql").click();
+  return cy
+    .get(".ace_content")
+    .as(alias)
+    .should("be.visible");
+}

--- a/frontend/test/metabase/scenarios/admin/audit/ad-hoc.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/audit/ad-hoc.cy.spec.js
@@ -1,4 +1,8 @@
-import { restore, describeWithToken } from "__support__/e2e/cypress";
+import {
+  restore,
+  describeWithToken,
+  openNativeEditor,
+} from "__support__/e2e/cypress";
 
 describeWithToken("audit > ad-hoc", () => {
   describe("native query with JOIN", () => {
@@ -7,9 +11,8 @@ describeWithToken("audit > ad-hoc", () => {
 
       cy.log("Run ad hoc native query as normal user");
       cy.signInAsNormalUser();
-      cy.visit("/question/new");
-      cy.findByText("Native query").click();
-      cy.get(".ace_content").type("SELECT 123");
+
+      openNativeEditor().type("SELECT 123");
       cy.icon("play")
         .first()
         .click();

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -11,7 +11,12 @@
  */
 
 import { onlyOn } from "@cypress/skip-test";
-import { restore, popover, sidebar } from "__support__/e2e/cypress";
+import {
+  restore,
+  popover,
+  sidebar,
+  openNativeEditor,
+} from "__support__/e2e/cypress";
 import { USERS } from "__support__/e2e/cypress_data";
 
 const PERMISSIONS = {
@@ -674,9 +679,7 @@ describe("collection permissions", () => {
   it("should offer to save items to 'Our analytics' if user has a 'curate' access to it", () => {
     cy.signIn("normal");
 
-    cy.visit("/question/new");
-    cy.findByText("Native query").click();
-    cy.get(".ace_content").type("select * from people");
+    openNativeEditor().type("select * from people");
     cy.findByText("Save").click();
 
     cy.get(".AdminSelect").findByText("Our analytics");

--- a/frontend/test/metabase/scenarios/dashboard/parameters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/parameters.cy.spec.js
@@ -1,4 +1,9 @@
-import { sidebar, popover, restore } from "__support__/e2e/cypress";
+import {
+  sidebar,
+  popover,
+  restore,
+  openNativeEditor,
+} from "__support__/e2e/cypress";
 import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
 
 // NOTE: some overlap with parameters-embedded.cy.spec.js
@@ -255,15 +260,9 @@ describe("scenarios > dashboard > parameters", () => {
   });
 
   it("should allow linked question to be changed without breaking (metabase#9299)", () => {
-    cy.visit("/");
-    cy.findByText("Ask a question").click();
-    cy.findByText("Native query").click();
-    cy.get(".ace_content")
-      .as("editor")
-      .click()
-      .type("SELECT * FROM ORDERS WHERE {{filter}}", {
-        parseSpecialCharSequences: false,
-      });
+    openNativeEditor().type("SELECT * FROM ORDERS WHERE {{filter}}", {
+      parseSpecialCharSequences: false,
+    });
     // make {{filter}} a "Field Filter" connected to `Orders > Created At`
     cy.get(".AdminSelect")
       .contains("Text")

--- a/frontend/test/metabase/scenarios/filters/sql-filters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/sql-filters.cy.spec.js
@@ -1,4 +1,9 @@
-import { restore, popover, mockSessionProperty } from "__support__/e2e/cypress";
+import {
+  restore,
+  popover,
+  mockSessionProperty,
+  openNativeEditor,
+} from "__support__/e2e/cypress";
 
 describe("scenarios > filters > sql filters > basic filter types", () => {
   beforeEach(() => {
@@ -9,11 +14,7 @@ describe("scenarios > filters > sql filters > basic filter types", () => {
     // Make sure feature flag is on regardles of the environment where this is running.
     mockSessionProperty("field-filter-operators-enabled?", true);
 
-    cy.visit("/");
-    cy.icon("sql").click();
-    cy.get(".ace_content")
-      .as("editor")
-      .should("be.visible");
+    openNativeEditor();
   });
 
   describe("should work for text", () => {

--- a/frontend/test/metabase/scenarios/native/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/native.cy.spec.js
@@ -4,6 +4,7 @@ import {
   modal,
   visitQuestionAdhoc,
   mockSessionProperty,
+  openNativeEditor,
 } from "__support__/e2e/cypress";
 import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
 import { USER_GROUPS } from "__support__/e2e/cypress_data";
@@ -18,25 +19,19 @@ describe("scenarios > question > native", () => {
   });
 
   it("lets you create and run a SQL question", () => {
-    cy.visit("/question/new");
-    cy.contains("Native query").click();
-    cy.get(".ace_content").type("select count(*) from orders");
+    openNativeEditor().type("select count(*) from orders");
     cy.get(".NativeQueryEditor .Icon-play").click();
     cy.contains("18,760");
   });
 
   it("displays an error", () => {
-    cy.visit("/question/new");
-    cy.contains("Native query").click();
-    cy.get(".ace_content").type("select * from not_a_table");
+    openNativeEditor().type("select * from not_a_table");
     cy.get(".NativeQueryEditor .Icon-play").click();
     cy.contains('Table "NOT_A_TABLE" not found');
   });
 
   it("displays an error when running selected text", () => {
-    cy.visit("/question/new");
-    cy.contains("Native query").click();
-    cy.get(".ace_content").type(
+    openNativeEditor().type(
       "select * from orders" +
       "{leftarrow}".repeat(3) + // move left three
         "{shift}{leftarrow}".repeat(19), // highlight back to the front
@@ -46,13 +41,11 @@ describe("scenarios > question > native", () => {
   });
 
   it("clears a template tag's default when the type changes", () => {
-    cy.visit("/question/new");
-    cy.contains("Native query").click();
-
-    // Write a query with parameter x. It defaults to a text parameter.
-    cy.get(".ace_content").type("select * from orders where total = {{x}}", {
-      parseSpecialCharSequences: false,
-    });
+    openNativeEditor()
+      // Write a query with parameter x. It defaults to a text parameter.
+      .type("select * from orders where total = {{x}}", {
+        parseSpecialCharSequences: false,
+      });
 
     // Mark field as required and add a default text value.
     cy.contains("Required?")
@@ -81,13 +74,8 @@ describe("scenarios > question > native", () => {
   });
 
   it("doesn't reorder template tags when updated", () => {
-    cy.visit("/question/new");
-    cy.contains("Native query").click();
-
-    // Write a query with parameter x. It defaults to a text parameter.
-    cy.get(".ace_content").type("{{foo}} {{bar}}", {
+    openNativeEditor().type("{{foo}} {{bar}}", {
       parseSpecialCharSequences: false,
-      delay: 0,
     });
 
     cy.contains("Variables")
@@ -123,14 +111,11 @@ describe("scenarios > question > native", () => {
   });
 
   it("should show referenced cards in the template tag sidebar", () => {
-    cy.visit("/question/new");
-    cy.contains("Native query").click();
-
-    // start typing a question referenced
-    cy.get(".ace_content").type("select * from {{#}}", {
-      parseSpecialCharSequences: false,
-      delay: 0,
-    });
+    openNativeEditor()
+      // start typing a question referenced
+      .type("select * from {{#}}", {
+        parseSpecialCharSequences: false,
+      });
 
     cy.contains("Question #…")
       .parent()
@@ -188,9 +173,7 @@ describe("scenarios > question > native", () => {
   });
 
   it("can save a question with no rows", () => {
-    cy.visit("/question/new");
-    cy.contains("Native query").click();
-    cy.get(".ace_content").type("select * from people where false");
+    openNativeEditor().type("select * from people where false");
     cy.get(".NativeQueryEditor .Icon-play").click();
     cy.contains("No results!");
     cy.icon("contract").click();
@@ -209,13 +192,9 @@ describe("scenarios > question > native", () => {
     const FILTERS = ["Is not", "Does not contain"];
     const QUESTION = "QQ";
 
-    cy.visit("/question/new");
-    cy.contains("Native query").click();
-    cy.get(".ace_content")
-      .should("be.visible")
-      .type(
-        `SELECT null AS "V", 1 as "N" UNION ALL SELECT 'This has a value' AS "V", 2 as "N"`,
-      );
+    openNativeEditor().type(
+      `SELECT null AS "V", 1 as "N" UNION ALL SELECT 'This has a value' AS "V", 2 as "N"`,
+    );
     cy.findByText("Save").click();
 
     modal().within(() => {
@@ -348,15 +327,10 @@ describe("scenarios > question > native", () => {
   });
 
   it("should reorder template tags by drag and drop (metabase#9357)", () => {
-    cy.visit("/question/new");
-    cy.contains("Native query").click();
-
-    // Write a query with parameter firstparameter,nextparameter,lastparameter.
-    cy.get(".ace_content").type(
+    openNativeEditor().type(
       "{{firstparameter}} {{nextparameter}} {{lastparameter}}",
       {
         parseSpecialCharSequences: false,
-        delay: 0,
       },
     );
 
@@ -572,9 +546,7 @@ describe("scenarios > question > native", () => {
   it("should run with the default field filter set (metabase#15444)", () => {
     cy.intercept("POST", "/api/dataset").as("dataset");
 
-    cy.visit("/");
-    cy.icon("sql").click();
-    cy.get(".ace_content").type("select * from products where {{category}}", {
+    openNativeEditor().type("select * from products where {{category}}", {
       parseSpecialCharSequences: false,
     });
     // Change filter type from "Text" to Field Filter
@@ -614,9 +586,7 @@ describe("scenarios > question > native", () => {
       }
       const widgetType = test === "old" ? "Category" : "String";
 
-      cy.visit("/");
-      cy.icon("sql").click();
-      cy.get(".ace_content").type("{{filter}}", {
+      openNativeEditor().type("{{filter}}", {
         parseSpecialCharSequences: false,
       });
       cy.findByText("Variable type")
@@ -645,11 +615,7 @@ describe("scenarios > question > native", () => {
   });
 
   it("should be able to add new columns after hiding some (metabase#15393)", () => {
-    cy.visit("/");
-    cy.icon("sql").click();
-    cy.get(".ace_content")
-      .as("editor")
-      .type("select 1 as visible, 2 as hidden");
+    openNativeEditor().type("select 1 as visible, 2 as hidden");
     cy.get(".NativeQueryEditor .Icon-play")
       .as("runQuery")
       .click();
@@ -674,15 +640,11 @@ describe("scenarios > question > native", () => {
           isFeatureFlagTurnedOn,
         );
 
-        cy.visit("/");
-        cy.icon("sql").click();
-        cy.get(".ace_content").as("editor");
-
         cy.intercept("POST", "/api/dataset").as("dataset");
       });
 
       it(`text filter should work with the feature flag turned ${testCase}`, () => {
-        cy.get("@editor").type(
+        openNativeEditor().type(
           "select * from PRODUCTS where CATEGORY = {{text_filter}}",
           {
             parseSpecialCharSequences: false,
@@ -698,7 +660,7 @@ describe("scenarios > question > native", () => {
       });
 
       it(`number filter should work with the feature flag turned ${testCase}`, () => {
-        cy.get("@editor").type(
+        openNativeEditor().type(
           "select * from ORDERS where QUANTITY = {{number_filter}}",
           {
             parseSpecialCharSequences: false,
@@ -765,9 +727,7 @@ describe("scenarios > question > native", () => {
       name: "test-question",
       native: { query: 'select 1 as "a", 2 as "b"' },
     }).then(({ body: { id: questionId } }) => {
-      cy.visit("/");
-      cy.icon("sql").click();
-      cy.get(".ace_content").type(`{{#${questionId}}}`, {
+      openNativeEditor().type(`{{#${questionId}}}`, {
         parseSpecialCharSequences: false,
       });
       cy.get(".NativeQueryEditor .Icon-play").click();

--- a/frontend/test/metabase/scenarios/native/snippets/snippets.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/snippets/snippets.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, modal } from "__support__/e2e/cypress";
+import { restore, modal, openNativeEditor } from "__support__/e2e/cypress";
 
 // HACK which lets us type (even very long words) without losing focus
 // this is needed for fields where autocomplete suggestions are enabled
@@ -24,12 +24,8 @@ describe("scenarios > question > snippets", () => {
   });
 
   it("should let you create and use a snippet", () => {
-    cy.visit("/question/new");
-    cy.contains("Native query").click();
-
-    // Type a query and highlight some of the text
-    cy.get(".ace_content").as("editor");
-    cy.get("@editor").type(
+    openNativeEditor().type(
+      // Type a query and highlight some of the text
       "select 'stuff'" + "{shift}{leftarrow}".repeat("'stuff'".length),
     );
 
@@ -57,13 +53,9 @@ describe("scenarios > question > snippets", () => {
       content: "stuff",
     });
 
-    cy.visit("/question/new");
-    cy.findByText("Native query").click();
-
     // Populate the native editor first
     // 1. select
-    cy.get(".ace_content").as("editor");
-    cy.get("@editor").type("select ");
+    openNativeEditor().type("select ");
     // 2. snippet
     cy.icon("snippet").click();
     cy.findByText("stuff-snippet").click();

--- a/frontend/test/metabase/scenarios/visualizations/maps.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/maps.cy.spec.js
@@ -1,4 +1,9 @@
-import { restore, popover, visitQuestionAdhoc } from "__support__/e2e/cypress";
+import {
+  restore,
+  popover,
+  visitQuestionAdhoc,
+  openNativeEditor,
+} from "__support__/e2e/cypress";
 import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
 
 const { PEOPLE, PEOPLE_ID } = SAMPLE_DATASET;
@@ -12,9 +17,7 @@ describe("scenarios > visualizations > maps", () => {
   it("should display a pin map for a native query", () => {
     cy.signInAsNormalUser();
     // create a native query with lng/lat fields
-    cy.visit("/question/new");
-    cy.contains("Native query").click();
-    cy.get(".ace_content").type(
+    openNativeEditor().type(
       "select -80 as lng, 40 as lat union all select -120 as lng, 40 as lat",
     );
     cy.get(".NativeQueryEditor .Icon-play").click();

--- a/frontend/test/metabase/scenarios/visualizations/waterfall.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/waterfall.cy.spec.js
@@ -2,6 +2,7 @@ import {
   openOrdersTable,
   restore,
   visitQuestionAdhoc,
+  openNativeEditor,
 } from "__support__/e2e/cypress";
 import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
 
@@ -39,9 +40,7 @@ describe("scenarios > visualizations > waterfall", () => {
   }
 
   it("should work with ordinal series", () => {
-    cy.visit("/question/new");
-    cy.contains("Native query").click();
-    cy.get(".ace_content").type(
+    openNativeEditor().type(
       "select 'A' as product, 10 as profit union select 'B' as product, -4 as profit",
     );
     cy.get(".NativeQueryEditor .Icon-play").click();
@@ -52,9 +51,7 @@ describe("scenarios > visualizations > waterfall", () => {
   });
 
   it("should work with quantitative series", () => {
-    cy.visit("/question/new");
-    cy.contains("Native query").click();
-    cy.get(".ace_content").type(
+    openNativeEditor().type(
       "select 1 as xx, 10 as yy union select 2 as xx, -2 as yy",
     );
     cy.get(".NativeQueryEditor .Icon-play").click();
@@ -214,9 +211,8 @@ describe("scenarios > visualizations > waterfall", () => {
     beforeEach(() => {
       restore();
       cy.signInAsNormalUser();
-      cy.visit("/question/new");
-      cy.contains("Native query").click();
-      cy.get(".ace_content").type("select 'A' as X, -4.56 as Y");
+
+      openNativeEditor().type("select 'A' as X, -4.56 as Y");
       cy.get(".NativeQueryEditor .Icon-play").click();
       cy.contains("Visualization").click();
       cy.icon("waterfall").click();


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Adds a new Cypress helper function called `openNativeEditor` which abstracts the flow of opening SQL editor using UI
- Documents the function using JSDoc
- Updates related tests

### What it doesn't do?
- It doesn't account for the scenarios where we can have multiple databases yet.
- Will be expanded/added later when the number of tests that require it grows a bit.

### Additional context:
The function abstracts the following code:
```javascript
cy.visit("/");
cy.icon("sql").click();
cy.get(".ace-content").as("editor");

// or the alternative
cy.visit("/question/new");
cy.findByText("Native query").click();
cy.get(".ace-content").as("editor");
```

### Screenshots
VSCode utilizes JSDocs
![image](https://user-images.githubusercontent.com/31325167/124107662-c36a2e80-da65-11eb-9461-838c185cc5de.png)
