### PR TITLE
Fix native editor is covered with run-overlay if filter is empty

### DIFF
--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -146,6 +146,12 @@ const getNextRunParameterValues = createSelector(
   [getParameters],
   parameters =>
     parameters
+      .filter(
+        // parameters with an empty value get filtered out before a query run,
+        // so in order to compare current parameters to previously-used parameters we need
+        // to filter them here as well
+        parameter => parameter.value != null,
+      )
       .map(parameter =>
         // parameters are "normalized" immediately before a query run, so in order
         // to compare current parameters to previously-used parameters we need

--- a/frontend/test/metabase/scenarios/filters/sql-filters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/sql-filters.cy.spec.js
@@ -67,7 +67,7 @@ describe("scenarios > filters > sql filters > basic filter types", () => {
       });
     });
 
-    it.skip("when set as the default value for a required filter (metabase#16811)", () => {
+    it("when set as the default value for a required filter (metabase#16811)", () => {
       setRequiredFilterDefaultValue("4.3");
 
       runQuery();

--- a/frontend/test/metabase/scenarios/native/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/native.cy.spec.js
@@ -726,7 +726,7 @@ describe("scenarios > question > native", () => {
 
   ["normal", "nodata"].forEach(user => {
     //Very related to the metabase#15981, only this time the issue happens with the Field Filter without the value being set.
-    it.skip(`filter feature flag shouldn't cause run-overlay of results in native editor for ${user} user (metabase#16739)`, () => {
+    it(`filter feature flag shouldn't cause run-overlay of results in native editor for ${user} user (metabase#16739)`, () => {
       const filter = {
         id: "7795c137-a46c-3db9-1930-1d690c8dbc03",
         name: "filter",


### PR DESCRIPTION
The issue happens on the native question page when the editor is collapsed (seeing results, query editor hidden), the `field-filter-operators-enabled` feature flag has to be enabled. Backstory: each time a query becomes dirty, e.g., when some of its parameters change, the results are covered with an overlay with a run button, so its clear results are not fresh. The issue is if there is a parameter that has a default value, the overlay doesn't disappear after a query is completed.

Fixes #16739, fixes #16811, and most likely [this](https://github.com/metabase/metabase/pull/16851/files#diff-343f26651add1ad21c0b13b522204471779e9f2ba277fd70ad23d52ba5b4e2dbR72)

### To Verify

Follow repro steps from #16739 and #16811, copying from #16811:

1. Native query > Sample Dataset > `select * from PRODUCTS where {{filter}}`
2. Set variable as Field Filter of Products.Category and filter type to "String"
3. Click the "run" button
7. Ensure the "run" button icon is replaced with "rerun"
8. Collapse the editor, ensure there is no overlay covering the results

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/124135843-de9c6480-da8c-11eb-880e-8975a9489b09.mov

**After**

https://user-images.githubusercontent.com/17258145/124135856-e0662800-da8c-11eb-9fb4-1443596967ed.mov
