### PR TITLE
Fix random collection is suggested when saving a new dashboard

### DIFF
--- a/frontend/src/metabase/entities/collections.js
+++ b/frontend/src/metabase/entities/collections.js
@@ -104,8 +104,10 @@ const Collections = createEntity({
         // these are listed in order of priority
         (state, { collectionId }) => collectionId,
         (state, { params }) => (params ? params.collectionId : undefined),
-        (state, { params }) =>
-          params ? Urls.extractCollectionId(params.slug) : undefined,
+        (state, { params, location }) =>
+          params && location && Urls.isCollectionPath(location.pathname)
+            ? Urls.extractCollectionId(params.slug)
+            : undefined,
         (state, { location }) =>
           location && location.query ? location.query.collectionId : undefined,
         () => ROOT_COLLECTION.id,

--- a/frontend/src/metabase/lib/urls.js
+++ b/frontend/src/metabase/lib/urls.js
@@ -166,7 +166,7 @@ export function collection(collection) {
 }
 
 export function isCollectionPath(path) {
-  return /\/collection\/.*/.test(path);
+  return /collection\/.*/.test(path);
 }
 
 export function label(label) {

--- a/frontend/src/metabase/lib/urls.js
+++ b/frontend/src/metabase/lib/urls.js
@@ -165,6 +165,10 @@ export function collection(collection) {
   return appendSlug(`/collection/${collection.id}`, slug);
 }
 
+export function isCollectionPath(path) {
+  return /\/collection\/.*/.test(path);
+}
+
 export function label(label) {
   return `/questions/search?label=${encodeURIComponent(label.slug)}`;
 }

--- a/frontend/test/metabase/lib/urls.unit.spec.js
+++ b/frontend/test/metabase/lib/urls.unit.spec.js
@@ -6,6 +6,7 @@ import {
   extractQueryParams,
   extractEntityId,
   extractCollectionId,
+  isCollectionPath,
 } from "metabase/lib/urls";
 
 describe("urls", () => {
@@ -155,6 +156,28 @@ describe("urls", () => {
     testCases.forEach(({ slug, id }) => {
       it(`should return "${id}" id if slug is "${slug}"`, () => {
         expect(extractCollectionId(slug)).toBe(id);
+      });
+    });
+  });
+
+  describe("isCollectionPath", () => {
+    const testCases = [
+      { path: "/collection/1", expected: true },
+      { path: "/collection/123", expected: true },
+      { path: "/collection/1-stats", expected: true },
+      { path: "/collection/123-stats-stats", expected: true },
+      { path: "/collection/root", expected: true },
+      { path: "/collection/users", expected: true },
+      { path: "/dashboard/1", expected: false },
+      { path: "/dashboard/12-orders", expected: false },
+      { path: "/browse/1", expected: false },
+      { path: "/browse/12-shop", expected: false },
+      { path: "/question/1-orders", expected: false },
+    ];
+
+    testCases.forEach(({ path, expected }) => {
+      it(`returns ${expected} for ${path}`, () => {
+        expect(isCollectionPath(path)).toBe(expected);
       });
     });
   });

--- a/frontend/test/metabase/lib/urls.unit.spec.js
+++ b/frontend/test/metabase/lib/urls.unit.spec.js
@@ -162,12 +162,19 @@ describe("urls", () => {
 
   describe("isCollectionPath", () => {
     const testCases = [
+      { path: "collection/1", expected: true },
+      { path: "collection/123", expected: true },
       { path: "/collection/1", expected: true },
       { path: "/collection/123", expected: true },
       { path: "/collection/1-stats", expected: true },
       { path: "/collection/123-stats-stats", expected: true },
+      { path: "/collection/1-stats/new", expected: true },
+      { path: "/collection/1-stats/nested/url", expected: true },
+      { path: "/collection/1-stats/new_collection", expected: true },
       { path: "/collection/root", expected: true },
       { path: "/collection/users", expected: true },
+
+      { path: "dashboard/1", expected: false },
       { path: "/dashboard/1", expected: false },
       { path: "/dashboard/12-orders", expected: false },
       { path: "/browse/1", expected: false },

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -52,6 +52,18 @@ describe("collection permissions", () => {
                   cy.findByText("New dashboard").click();
                   cy.get(".AdminSelect").findByText("Second collection");
                 });
+
+                onlyOn(user === "admin", () => {
+                  it("should offer to save dashboard to root collection from a dashboard page (metabase#16832)", () => {
+                    cy.visit("/collection/root");
+                    cy.findByText("Orders in a dashboard").click();
+                    cy.icon("add").click();
+                    popover()
+                      .findByText("New dashboard")
+                      .click();
+                    cy.get(".AdminSelect").findByText("Our analytics");
+                  });
+                });
               });
 
               describe("pin", () => {


### PR DESCRIPTION
Creating a new dashboard from an already open dashboard page suggests a random user's personal collection.
It's a regression caused by the URL slugs PR (#15989).

The slug PR extended `getInitialCollectionId` selector that defines which collection should be offered as a save destination. It added a [step](https://github.com/metabase/metabase/blob/61d0ccdd51953035899cbed03028c8aad2a1df02/frontend/src/metabase/entities/collections.js#L108) extracting collection ID from a URL slug. So if a user is on `/collection/3-marketing-stuff`, `getInitialCollectionId` would pick `3` from the slug and it will be suggested to the user. The trick is it didn't check if we're actually on the collection page. So if a user tried to create a dashboard from `/dashboard/1`, a collection with `id: 1` would be suggested (however `1` is a dashboard ID, so the suggested collection will be truly random). Fixed by ensuring we're parsing a slug only for collection routes.

Reproduces #16832, fixes #16832

### To Verify

1. Sign in as admin
2. Open any dashboard
3. Click the `+` icon in the navigation header > New dashboard
4. Ensure the popup suggests saving dashboard to "Our analytics" by default

### Demo

**Before**

![123969762-d115aa80-d9b8-11eb-8910-d90e39451e67](https://user-images.githubusercontent.com/17258145/124152385-25de2180-da9c-11eb-9311-d497f0a3b83c.png)

**After**

<img width="1071" alt="after" src="https://user-images.githubusercontent.com/17258145/124152392-27a7e500-da9c-11eb-8833-c1d64cf874ef.png">
