### PR TITLE
add autofocus to some of inputs

### DIFF
--- a/frontend/src/metabase/components/form/widgets/FormTextAreaWidget.jsx
+++ b/frontend/src/metabase/components/form/widgets/FormTextAreaWidget.jsx
@@ -4,8 +4,15 @@ import cx from "classnames";
 
 import { formDomOnlyProps } from "metabase/lib/redux";
 
-const FormTextAreaWidget = ({ placeholder, field, className, rows }) => (
+const FormTextAreaWidget = ({
+  placeholder,
+  field,
+  className,
+  rows,
+  autoFocus,
+}) => (
   <textarea
+    autoFocus={autoFocus}
     className={cx(className, "Form-input full")}
     rows={rows}
     placeholder={placeholder}

--- a/frontend/src/metabase/containers/SaveQuestionModal.jsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal.jsx
@@ -129,6 +129,7 @@ export default class SaveQuestionModal extends Component {
                 {values.saveType === "create" && (
                   <div className="saveQuestionModalFields">
                     <FormField
+                      autoFocus
                       name="name"
                       title={t`Name`}
                       placeholder={t`What is the name of your card?`}

--- a/frontend/src/metabase/dashboard/components/add-card-sidebar/QuestionPicker.jsx
+++ b/frontend/src/metabase/dashboard/components/add-card-sidebar/QuestionPicker.jsx
@@ -63,6 +63,7 @@ function QuestionPicker({
   return (
     <Box p={2}>
       <SearchInput
+        autoFocus
         hasClearButton
         placeholder={t`Search…`}
         value={searchText}

--- a/frontend/src/metabase/entities/collections.js
+++ b/frontend/src/metabase/entities/collections.js
@@ -133,6 +133,7 @@ const Collections = createEntity({
         name: "name",
         title: t`Name`,
         placeholder: t`My new fantastic collection`,
+        autoFocus: true,
         validate: name =>
           (!name && t`Name is required`) ||
           (name && name.length > 100 && t`Name must be 100 characters or less`),

--- a/frontend/src/metabase/entities/dashboards.js
+++ b/frontend/src/metabase/entities/dashboards.js
@@ -143,6 +143,7 @@ const Dashboards = createEntity({
         name: "name",
         title: t`Name`,
         placeholder: t`What is the name of your dashboard?`,
+        autoFocus: true,
         validate: name => (!name ? "Name is required" : null),
       },
       {

--- a/frontend/src/metabase/entities/snippets.js
+++ b/frontend/src/metabase/entities/snippets.js
@@ -13,6 +13,7 @@ const formFields = [
     className:
       "Form-input full text-monospace text-normal text-small bg-light text-spaced",
     rows: 4,
+    autoFocus: true,
     validate: validate.required().maxLength(10000),
   },
   {

--- a/frontend/src/metabase/entities/users/forms.js
+++ b/frontend/src/metabase/entities/users/forms.js
@@ -13,6 +13,7 @@ const DETAILS_FORM_FIELDS: () => FormFieldDefinition[] = () => [
     name: "first_name",
     title: t`First name`,
     placeholder: "Johnny",
+    autoFocus: true,
     validate: validate.required().maxLength(100),
   },
   {


### PR DESCRIPTION
### Description

It would be more convenient to have more autofocused fields to avoid the need to manually click on inputs in some cases.

#### Save question form
<img width="718" alt="Screen Shot 2021-07-03 at 00 21 45" src="https://user-images.githubusercontent.com/14301985/124330017-43db7d00-db95-11eb-965f-63c12799141b.png">

#### New dashboard form
<img width="670" alt="Screen Shot 2021-07-03 at 00 21 56" src="https://user-images.githubusercontent.com/14301985/124330032-4ccc4e80-db95-11eb-93ab-a4d9ca16eef7.png">

#### Add a question on a dashboard sidebar
<img width="483" alt="Screen Shot 2021-07-03 at 00 22 32" src="https://user-images.githubusercontent.com/14301985/124330245-aaf93180-db95-11eb-88be-3c0ea02ea225.png">

#### Invite user form
<img width="659" alt="Screen Shot 2021-07-03 at 00 22 56" src="https://user-images.githubusercontent.com/14301985/124330285-be0c0180-db95-11eb-9610-78b4bf799597.png">

#### New collection form
<img width="671" alt="Screen Shot 2021-07-03 at 00 23 14" src="https://user-images.githubusercontent.com/14301985/124330306-c95f2d00-db95-11eb-94f5-1411cec1bbbc.png">

Any other places I missed?