### PR TITLE
Add backward compatibility for friendly field name

### DIFF
--- a/src/metabase/models/humanization.clj
+++ b/src/metabase/models/humanization.clj
@@ -54,6 +54,11 @@
                          :when (not (str/blank? part))]
                      (capitalize-word part))))))
 
+;; actual advanced method has been excised. this one just calls out to simple
+(defmethod name->human-readable-name :advanced
+  ([s] (name->human-readable-name :simple s))
+  ([_, ^String s] (name->human-readable-name :simple s)))
+
 ;; :none is just an identity implementation
 (defmethod name->human-readable-name :none
   ([s]   s)

--- a/test/metabase/models/humanization_test.clj
+++ b/test/metabase/models/humanization_test.clj
@@ -34,7 +34,11 @@
                             "usersocialauth"            "Usersocialauth"}]
     (testing (pr-str (list 'name->human-readable-name :simple input))
       (is (= expected
-             (humanization/name->human-readable-name :simple input))))))
+             (humanization/name->human-readable-name :simple input))))
+    ;; there used to be an advanced mode but it should just act as simple mode now
+    (testing (pr-str (list 'name->human-readable-name :advanced input))
+      (is (= expected
+             (humanization/name->human-readable-name :advanced input))))))
 
 (deftest none-humanization-test
   (doseq [input [nil
@@ -91,8 +95,10 @@
 (deftest humanized-display-name-test
   (testing "check that we get the expected :display_name with humanization *enabled*"
     (doseq [[input strategy->expected] {"toucansare_cool"     {"simple"   "Toucansare Cool"
+                                                               "advanced" "Toucansare Cool"
                                                                "none"     "toucansare_cool"}
                                         "fussybird_sightings" {"simple"   "Fussybird Sightings"
+                                                               "advanced" "Fussybird Sightings"
                                                                "none"     "fussybird_sightings"}}
             [strategy expected]        strategy->expected]
       (testing (pr-str (list 'get-humanized-display-name input strategy))


### PR DESCRIPTION
Despite the liquibase migration and all, the `advanced` FFN setting is not going away in some folks' DB's, see https://github.com/metabase/metabase/issues/16859. As a last resort make the advanced thing backward compatible so it just displays results of `simple`