### PR TITLE
Avoid nested <a>

### DIFF
--- a/frontend/src/metabase/containers/Overworld.jsx
+++ b/frontend/src/metabase/containers/Overworld.jsx
@@ -339,14 +339,10 @@ class Overworld extends React.Component {
                                     <Tooltip
                                       tooltip={t`Learn about this database`}
                                     >
-                                      <Link
-                                        to={`reference/databases/${database.id}`}
-                                      >
-                                        <Icon
-                                          name="reference"
-                                          color={color("text-light")}
-                                        />
-                                      </Link>
+                                      <Icon
+                                        name="reference"
+                                        color={color("text-light")}
+                                      />
                                     </Tooltip>
                                   </Flex>
                                 </Box>


### PR DESCRIPTION
There is no need to wrap the icon as a link, since each grid item (which encloses the icon) is already a link.

To give a try, just login and then open the browser console.

**Before this PR**
Warning: validateDOMNesting(...): <a> cannot appear as a descendant of <a>.
![image](https://user-images.githubusercontent.com/7288/124235399-06f68400-daca-11eb-815c-c09339b453d4.png)


**After this PR**
No such message.