### PR TITLE
When used in data picker, Popover's children is actually an array

### DIFF
--- a/frontend/src/metabase/components/Popover.jsx
+++ b/frontend/src/metabase/components/Popover.jsx
@@ -57,7 +57,11 @@ export default class Popover extends Component {
     onClose: PropTypes.func,
     className: PropTypes.string,
     style: PropTypes.object,
-    children: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
+    children: PropTypes.oneOfType([
+      PropTypes.element,
+      PropTypes.func,
+      PropTypes.array,
+    ]),
     dismissOnClickOutside: PropTypes.func,
     dismissOnEscape: PropTypes.func,
     target: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),


### PR DESCRIPTION
Open the browser console then go to Ask a question, Custom Question.

**Before this PR**
Warning: Failed prop type: Invalid prop `children` supplied to `Popover`.

![image](https://user-images.githubusercontent.com/7288/124239060-2a233280-dace-11eb-850e-16053b0e9d07.png)

**After this PR**
No such message.