### PR TITLE
Clean up Radio component

### DIFF
--- a/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx
@@ -167,7 +167,7 @@ export default class DatabaseEditApp extends Component {
                     value={currentTab}
                     options={TABS}
                     onChange={currentTab => this.setState({ currentTab })}
-                    underlined
+                    variant="underlined"
                   />
                 </div>
               )}

--- a/frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/DataModelApp.jsx
@@ -32,7 +32,7 @@ export default class DataModelApp extends React.Component {
       <div>
         <div className="px3 border-bottom">
           <Radio
-            underlined
+            variant="underlined"
             value={value}
             options={[
               { name: t`Data`, value: "database" },

--- a/frontend/src/metabase/admin/permissions/components/PermissionsTabs.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsTabs.jsx
@@ -14,7 +14,7 @@ const PermissionsTabs = ({ tab, onChangeTab }) => (
         { name: t`Collection permissions`, value: `collections` },
       ]}
       onChange={onChangeTab}
-      underlined
+      variant="underlined"
       py={2}
     />
   </div>

--- a/frontend/src/metabase/components/Radio.info.js
+++ b/frontend/src/metabase/components/Radio.info.js
@@ -15,8 +15,8 @@ const PROPS = {
 
 export const examples = {
   default: <Radio {...PROPS} />,
-  underlined: <Radio {...PROPS} underlined />,
+  underlined: <Radio {...PROPS} variant="underlined" />,
   "show buttons": <Radio {...PROPS} showButtons />,
   vertical: <Radio {...PROPS} vertical />,
-  bubble: <Radio {...PROPS} bubble />,
+  bubble: <Radio {...PROPS} variant="bubble" />,
 };

--- a/frontend/src/metabase/components/Radio.jsx
+++ b/frontend/src/metabase/components/Radio.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 
@@ -13,25 +12,31 @@ import cx from "classnames";
 
 export default class Radio extends Component {
   static propTypes = {
+    name: PropTypes.string,
     value: PropTypes.any,
     options: PropTypes.array.isRequired,
     onChange: PropTypes.func,
     optionNameFn: PropTypes.func,
     optionValueFn: PropTypes.func,
     optionKeyFn: PropTypes.func,
+    showButtons: PropTypes.bool,
+    xspace: PropTypes.number,
+    yspace: PropTypes.number,
+    py: PropTypes.number,
+
+    // Modes
+    bubble: PropTypes.bool,
     vertical: PropTypes.bool,
     underlined: PropTypes.bool,
-    showButtons: PropTypes.bool,
-    py: PropTypes.number,
   };
 
   static defaultProps = {
     optionNameFn: option => option.name,
     optionValueFn: option => option.value,
     optionKeyFn: option => option.value,
+    bubble: false,
     vertical: false,
     underlined: false,
-    bubble: false,
   };
 
   constructor(props, context) {

--- a/frontend/src/metabase/components/Radio.jsx
+++ b/frontend/src/metabase/components/Radio.jsx
@@ -12,10 +12,20 @@ import {
   UnderlinedItem,
 } from "./Radio.styled";
 
+const optionShape = PropTypes.shape({
+  name: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.element,
+    PropTypes.node,
+  ]).isRequired,
+  value: PropTypes.any.isRequired,
+  icon: PropTypes.string,
+});
+
 const propTypes = {
   name: PropTypes.string,
   value: PropTypes.any,
-  options: PropTypes.array.isRequired,
+  options: PropTypes.arrayOf(optionShape).isRequired,
   onChange: PropTypes.func,
   optionNameFn: PropTypes.func,
   optionValueFn: PropTypes.func,

--- a/frontend/src/metabase/components/Radio.jsx
+++ b/frontend/src/metabase/components/Radio.jsx
@@ -137,7 +137,7 @@ BaseItem.defaultProps = {
 
 // NORMAL
 const NormalList = styled(BaseList).attrs({
-  className: props => cx(props.className, { "text-bold": !props.showButtons }), // TODO: better way to merge classname?
+  className: props => cx(props.className, { "text-bold": !props.showButtons }),
 })``;
 const NormalItem = styled(BaseItem)`
   color: ${props => (props.selected ? color("brand") : null)};

--- a/frontend/src/metabase/components/Radio.jsx
+++ b/frontend/src/metabase/components/Radio.jsx
@@ -1,14 +1,12 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-
+import _ from "underscore";
+import cx from "classnames";
 import styled from "styled-components";
 import { space } from "styled-system";
 
-import Icon from "metabase/components/Icon";
 import { color, lighten } from "metabase/lib/colors";
-
-import _ from "underscore";
-import cx from "classnames";
+import Icon from "metabase/components/Icon";
 
 export default class Radio extends Component {
   static propTypes = {

--- a/frontend/src/metabase/components/Radio.jsx
+++ b/frontend/src/metabase/components/Radio.jsx
@@ -1,12 +1,16 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import _ from "underscore";
-import cx from "classnames";
-import styled from "styled-components";
-import { space } from "styled-system";
 
-import { color, lighten } from "metabase/lib/colors";
 import Icon from "metabase/components/Icon";
+import {
+  BubbleList,
+  BubbleItem,
+  NormalList,
+  NormalItem,
+  UnderlinedList,
+  UnderlinedItem,
+} from "./Radio.styled";
 
 const propTypes = {
   name: PropTypes.string,
@@ -115,64 +119,3 @@ Radio.propTypes = propTypes;
 Radio.defaultProps = defaultProps;
 
 export default Radio;
-
-// BASE components all variants inherit from
-const BaseList = styled.ul`
-  display: flex;
-  flex-direction: ${props => (props.vertical ? "column" : "row")};
-`;
-const BaseItem = styled.li.attrs({
-  mr: props => (!props.vertical && !props.last ? props.xspace : null),
-  mb: props => (props.vertical && !props.last ? props.yspace : null),
-  "aria-selected": props => props.selected,
-})`
-  ${space}
-  display: flex;
-  align-items: center;
-  cursor: pointer;
-  :hover {
-    color: ${props =>
-      !props.showButtons && !props.selected ? color("brand") : null};
-  }
-`;
-BaseItem.defaultProps = {
-  xspace: 3,
-  yspace: 1,
-};
-
-// NORMAL
-const NormalList = styled(BaseList).attrs({
-  className: props => cx(props.className, { "text-bold": !props.showButtons }),
-})``;
-const NormalItem = styled(BaseItem)`
-  color: ${props => (props.selected ? color("brand") : null)};
-`;
-
-// UNDERLINE
-const UnderlinedList = styled(NormalList)``;
-const UnderlinedItem = styled(NormalItem)`
-  border-bottom: 3px solid transparent;
-  border-color: ${props => (props.selected ? color("brand") : null)};
-`;
-UnderlinedItem.defaultProps = {
-  py: 2,
-};
-
-// BUBBLE
-const BubbleList = styled(BaseList)``;
-const BubbleItem = styled(BaseItem)`
-  font-weight: 700;
-  border-radius: 99px;
-  color: ${props => (props.selected ? color("white") : color("brand"))};
-  background-color: ${props =>
-    props.selected ? color("brand") : lighten("brand")};
-  :hover {
-    background-color: ${props => !props.selected && lighten("brand", 0.38)};
-    transition: background 300ms linear;
-  }
-`;
-BubbleItem.defaultProps = {
-  xspace: 1,
-  py: 1,
-  px: 2,
-};

--- a/frontend/src/metabase/components/Radio.jsx
+++ b/frontend/src/metabase/components/Radio.jsx
@@ -8,35 +8,35 @@ import { space } from "styled-system";
 import { color, lighten } from "metabase/lib/colors";
 import Icon from "metabase/components/Icon";
 
-export default class Radio extends Component {
-  static propTypes = {
-    name: PropTypes.string,
-    value: PropTypes.any,
-    options: PropTypes.array.isRequired,
-    onChange: PropTypes.func,
-    optionNameFn: PropTypes.func,
-    optionValueFn: PropTypes.func,
-    optionKeyFn: PropTypes.func,
-    showButtons: PropTypes.bool,
-    xspace: PropTypes.number,
-    yspace: PropTypes.number,
-    py: PropTypes.number,
+const propTypes = {
+  name: PropTypes.string,
+  value: PropTypes.any,
+  options: PropTypes.array.isRequired,
+  onChange: PropTypes.func,
+  optionNameFn: PropTypes.func,
+  optionValueFn: PropTypes.func,
+  optionKeyFn: PropTypes.func,
+  showButtons: PropTypes.bool,
+  xspace: PropTypes.number,
+  yspace: PropTypes.number,
+  py: PropTypes.number,
 
-    // Modes
-    bubble: PropTypes.bool,
-    vertical: PropTypes.bool,
-    underlined: PropTypes.bool,
-  };
+  // Modes
+  bubble: PropTypes.bool,
+  vertical: PropTypes.bool,
+  underlined: PropTypes.bool,
+};
 
-  static defaultProps = {
-    optionNameFn: option => option.name,
-    optionValueFn: option => option.value,
-    optionKeyFn: option => option.value,
-    bubble: false,
-    vertical: false,
-    underlined: false,
-  };
+const defaultProps = {
+  optionNameFn: option => option.name,
+  optionValueFn: option => option.value,
+  optionKeyFn: option => option.value,
+  bubble: false,
+  vertical: false,
+  underlined: false,
+};
 
+class Radio extends Component {
   constructor(props, context) {
     super(props, context);
     this._id = _.uniqueId("radio-");
@@ -110,6 +110,11 @@ export default class Radio extends Component {
     );
   }
 }
+
+Radio.propTypes = propTypes;
+Radio.defaultProps = defaultProps;
+
+export default Radio;
 
 // BASE components all variants inherit from
 const BaseList = styled.ul`

--- a/frontend/src/metabase/components/Radio.jsx
+++ b/frontend/src/metabase/components/Radio.jsx
@@ -43,6 +43,12 @@ const propTypes = {
 const defaultNameGetter = option => option.name;
 const defaultValueGetter = option => option.value;
 
+const VARIANTS = {
+  normal: [NormalList, NormalItem],
+  bubble: [BubbleList, BubbleItem],
+  underlined: [UnderlinedList, UnderlinedItem],
+};
+
 function Radio({
   name: nameFromProps,
   value,
@@ -62,11 +68,7 @@ function Radio({
   const id = useMemo(() => _.uniqueId("radio-"), []);
   const name = nameFromProps || id;
 
-  const [List = NormalList, Item = NormalItem] = {
-    normal: [NormalList, NormalItem],
-    bubble: [BubbleList, BubbleItem],
-    underlined: [UnderlinedList, UnderlinedItem],
-  }[variant];
+  const [List, Item] = VARIANTS[variant] || VARIANTS.normal;
 
   if (variant === "underlined" && value === undefined) {
     console.warn(

--- a/frontend/src/metabase/components/Radio.jsx
+++ b/frontend/src/metabase/components/Radio.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React, { useMemo } from "react";
 import PropTypes from "prop-types";
 import _ from "underscore";
 
@@ -30,89 +30,77 @@ const propTypes = {
   vertical: PropTypes.bool,
 };
 
-const defaultProps = {
-  optionNameFn: option => option.name,
-  optionValueFn: option => option.value,
-  optionKeyFn: option => option.value,
-  variant: "normal",
-  vertical: false,
-};
+const defaultNameGetter = option => option.name;
+const defaultValueGetter = option => option.value;
 
-class Radio extends Component {
-  constructor(props, context) {
-    super(props, context);
-    this._id = _.uniqueId("radio-");
-  }
+function Radio({
+  name: nameFromProps,
+  value,
+  options,
+  onChange,
+  optionNameFn = defaultNameGetter,
+  optionValueFn = defaultValueGetter,
+  optionKeyFn = defaultValueGetter,
+  variant = "normal",
+  vertical = false,
+  xspace,
+  yspace,
+  py,
+  showButtons = vertical && variant !== "bubble",
+  ...props
+}) {
+  const id = useMemo(() => _.uniqueId("radio-"), []);
+  const name = nameFromProps || id;
 
-  render() {
-    const {
-      name = this._id,
-      value,
-      options,
-      onChange,
-      optionNameFn,
-      optionValueFn,
-      optionKeyFn,
-      variant,
-      vertical,
-      xspace,
-      yspace,
-      py,
-      showButtons = vertical && variant !== "bubble", // show buttons for vertical only by default
-      ...props
-    } = this.props;
+  const [List = NormalList, Item = NormalItem] = {
+    normal: [NormalList, NormalItem],
+    bubble: [BubbleList, BubbleItem],
+    underlined: [UnderlinedList, UnderlinedItem],
+  }[variant];
 
-    const [List = NormalList, Item = NormalItem] = {
-      normal: [NormalList, NormalItem],
-      bubble: [BubbleList, BubbleItem],
-      underlined: [UnderlinedList, UnderlinedItem],
-    }[variant];
-
-    if (variant === "underlined" && value === undefined) {
-      console.warn(
-        "Radio can't underline selected option when no value is given.",
-      );
-    }
-
-    return (
-      <List {...props} vertical={vertical} showButtons={showButtons}>
-        {options.map((option, index) => {
-          const selected = value === optionValueFn(option);
-          const last = index === options.length - 1;
-          return (
-            <Item
-              key={optionKeyFn(option)}
-              selected={selected}
-              last={last}
-              vertical={vertical}
-              showButtons={showButtons}
-              py={py}
-              xspace={xspace}
-              yspace={yspace}
-              onClick={e => onChange(optionValueFn(option))}
-            >
-              {option.icon && <Icon name={option.icon} mr={1} />}
-              <input
-                className="Form-radio"
-                type="radio"
-                name={name}
-                value={optionValueFn(option)}
-                checked={selected}
-                id={name + "-" + optionKeyFn(option)}
-              />
-              {showButtons && (
-                <label htmlFor={name + "-" + optionKeyFn(option)} />
-              )}
-              <span>{optionNameFn(option)}</span>
-            </Item>
-          );
-        })}
-      </List>
+  if (variant === "underlined" && value === undefined) {
+    console.warn(
+      "Radio can't underline selected option when no value is given.",
     );
   }
+
+  return (
+    <List {...props} vertical={vertical} showButtons={showButtons}>
+      {options.map((option, index) => {
+        const selected = value === optionValueFn(option);
+        const last = index === options.length - 1;
+        return (
+          <Item
+            key={optionKeyFn(option)}
+            selected={selected}
+            last={last}
+            vertical={vertical}
+            showButtons={showButtons}
+            py={py}
+            xspace={xspace}
+            yspace={yspace}
+            onClick={e => onChange(optionValueFn(option))}
+          >
+            {option.icon && <Icon name={option.icon} mr={1} />}
+            <input
+              className="Form-radio"
+              type="radio"
+              name={name}
+              value={optionValueFn(option)}
+              checked={selected}
+              id={name + "-" + optionKeyFn(option)}
+            />
+            {showButtons && (
+              <label htmlFor={name + "-" + optionKeyFn(option)} />
+            )}
+            <span>{optionNameFn(option)}</span>
+          </Item>
+        );
+      })}
+    </List>
+  );
 }
 
 Radio.propTypes = propTypes;
-Radio.defaultProps = defaultProps;
 
 export default Radio;

--- a/frontend/src/metabase/components/Radio.jsx
+++ b/frontend/src/metabase/components/Radio.jsx
@@ -26,18 +26,16 @@ const propTypes = {
   py: PropTypes.number,
 
   // Modes
-  bubble: PropTypes.bool,
+  variant: PropTypes.oneOf(["bubble", "normal", "underlined"]),
   vertical: PropTypes.bool,
-  underlined: PropTypes.bool,
 };
 
 const defaultProps = {
   optionNameFn: option => option.name,
   optionValueFn: option => option.value,
   optionKeyFn: option => option.value,
-  bubble: false,
+  variant: "normal",
   vertical: false,
-  underlined: false,
 };
 
 class Radio extends Component {
@@ -55,23 +53,22 @@ class Radio extends Component {
       optionNameFn,
       optionValueFn,
       optionKeyFn,
+      variant,
       vertical,
-      underlined,
-      bubble,
       xspace,
       yspace,
       py,
-      showButtons = vertical && !bubble, // show buttons for vertical only by default
+      showButtons = vertical && variant !== "bubble", // show buttons for vertical only by default
       ...props
     } = this.props;
 
-    const [List, Item] = bubble
-      ? [BubbleList, BubbleItem]
-      : underlined
-      ? [UnderlinedList, UnderlinedItem]
-      : [NormalList, NormalItem];
+    const [List = NormalList, Item = NormalItem] = {
+      normal: [NormalList, NormalItem],
+      bubble: [BubbleList, BubbleItem],
+      underlined: [UnderlinedList, UnderlinedItem],
+    }[variant];
 
-    if (underlined && value === undefined) {
+    if (variant === "underlined" && value === undefined) {
       console.warn(
         "Radio can't underline selected option when no value is given.",
       );

--- a/frontend/src/metabase/components/Radio.styled.js
+++ b/frontend/src/metabase/components/Radio.styled.js
@@ -1,0 +1,73 @@
+import cx from "classnames";
+import styled from "styled-components";
+import { space } from "styled-system";
+
+import { color, lighten } from "metabase/lib/colors";
+
+// BASE
+const BaseList = styled.ul`
+  display: flex;
+  flex-direction: ${props => (props.vertical ? "column" : "row")};
+`;
+
+const BaseItem = styled.li.attrs({
+  mr: props => (!props.vertical && !props.last ? props.xspace : null),
+  mb: props => (props.vertical && !props.last ? props.yspace : null),
+  "aria-selected": props => props.selected,
+})`
+  ${space}
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  :hover {
+    color: ${props =>
+      !props.showButtons && !props.selected ? color("brand") : null};
+  }
+`;
+
+BaseItem.defaultProps = {
+  xspace: 3,
+  yspace: 1,
+};
+
+// BUBBLE
+export const BubbleList = styled(BaseList)``;
+
+export const BubbleItem = styled(BaseItem)`
+  font-weight: 700;
+  border-radius: 99px;
+  color: ${props => (props.selected ? color("white") : color("brand"))};
+  background-color: ${props =>
+    props.selected ? color("brand") : lighten("brand")};
+  :hover {
+    background-color: ${props => !props.selected && lighten("brand", 0.38)};
+    transition: background 300ms linear;
+  }
+`;
+
+BubbleItem.defaultProps = {
+  xspace: 1,
+  py: 1,
+  px: 2,
+};
+
+// NORMAL
+export const NormalList = styled(BaseList).attrs({
+  className: props => cx(props.className, { "text-bold": !props.showButtons }),
+})``;
+
+export const NormalItem = styled(BaseItem)`
+  color: ${props => (props.selected ? color("brand") : null)};
+`;
+
+// UNDERLINE
+export const UnderlinedList = styled(NormalList)``;
+
+export const UnderlinedItem = styled(NormalItem)`
+  border-bottom: 3px solid transparent;
+  border-color: ${props => (props.selected ? color("brand") : null)};
+`;
+
+UnderlinedItem.defaultProps = {
+  py: 2,
+};

--- a/frontend/src/metabase/parameters/components/ParameterSidebar.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterSidebar.jsx
@@ -56,7 +56,7 @@ class ParameterSidebar extends React.Component {
         <div className="flex justify-evenly border-bottom">
           <Radio
             options={tabs}
-            underlined
+            variant="underlined"
             value={currentTab}
             onChange={value => this.setState({ currentTab: value })}
           />

--- a/frontend/src/metabase/user/components/UserSettings.jsx
+++ b/frontend/src/metabase/user/components/UserSettings.jsx
@@ -58,7 +58,7 @@ export default class UserSettings extends Component {
           </Flex>
           <Radio
             value={tab}
-            underlined={true}
+            variant="underlined"
             options={[
               { name: t`Profile`, value: "details" },
               ...(showChangePassword

--- a/frontend/src/metabase/visualizations/components/ChartSettings.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings.jsx
@@ -247,7 +247,7 @@ class ChartSettings extends Component {
         options={sectionNames}
         optionNameFn={v => v}
         optionValueFn={v => v}
-        bubble
+        variant="bubble"
       />
     );
 


### PR DESCRIPTION
Going to extend the Radio component a little bit for the collection types project I'm working on.
This PR cleans up the component, without any changes in functionality

Might be easier to review commit-by-commit

* adds missing prop-types and enables back prop-types eslint rule ([commit](https://github.com/metabase/metabase/commit/1db3a1821f528ad98c48794fffb3e096f87023d8))
* reorders import to match our current guidelines ([commit](https://github.com/metabase/metabase/commit/aca4cb7852e8781015bc5bdfcb16f2d521530db6))
* moves `propTypes` and `defaultProps` to the top of the file ([commit](https://github.com/metabase/metabase/commit/6cd34cc3884821309aa4a8e665b9893cfca8a471))
* moves styled components to `Radio.styled.js` file ([commit](https://github.com/metabase/metabase/commit/eba542970b3745b6ef7dc5438efde99fb41a99e1))
* replaces `bubble` and `underlined` boolean props with a single `variant` prop ([commit](https://github.com/metabase/metabase/commit/3b9ccd7619b659a0495ad54a150c4b6e67422288)). Variant can be `bubble`, `underlined` and `normal` (default) ([commit](https://github.com/metabase/metabase/commit/3b9ccd7619b659a0495ad54a150c4b6e67422288))
* transforms Radio into a functional component ([commit](https://github.com/metabase/metabase/commit/5359f353020ce1f9c389a0a38a16d85d85dce234))