### PR TITLE
User of Docker Secrets

### DIFF
--- a/docs/operations-guide/running-metabase-on-docker.md
+++ b/docs/operations-guide/running-metabase-on-docker.md
@@ -193,9 +193,9 @@ services:
     container_name: postgres-secrets
     hostname: postgres-secrets
     environment:
-      POSTGRES_USER: /run/secrets/db_user
+      POSTGRES_USER_FILE: /run/secrets/db_user
       POSTGRES_DB: metabase
-      POSTGRES_PASSWORD: /run/secrets/db_password
+      POSTGRES_PASSWORD_FILE: /run/secrets/db_password
     networks: 
       - metanet1-secrets
     secrets:


### PR DESCRIPTION
Shouldn't the Postgres ENV variables that reference secrets files be suffixed by `_FILE`? As per "Docker Secrets". section https://hub.docker.com/_/postgres .  TBH I never did get this `docker-compose` file working with either method of Docker secrets so I just fell back to ENV variables from `.env` file.

###### Before submitting the PR, please make sure you do the following

- [ ] If you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.

### Tests

- [ ] Run the frontend and Cypress end-to-end tests with `yarn lint && yarn test`)
- [ ] If there are changes to the backend codebase, run the backend tests with `lein test && lein lint && ./bin/reflection-linter`

- [ ] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
      (unless it's a tiny documentation change).
