### PR TITLE
Make mobile Collections Sidebar hidden on page load

### DIFF
--- a/frontend/src/metabase/collections/components/Header/Header.jsx
+++ b/frontend/src/metabase/collections/components/Header/Header.jsx
@@ -31,7 +31,6 @@ export default function Header({
             mr={2}
             mt="4px"
             color={color("text-dark")}
-            hover={{ color: color("brand") }}
             size={20}
           />
           {collection.name}

--- a/frontend/src/metabase/collections/components/Header/Header.jsx
+++ b/frontend/src/metabase/collections/components/Header/Header.jsx
@@ -6,6 +6,7 @@ import { t } from "ttag";
 import * as Urls from "metabase/lib/urls";
 import { color } from "metabase/lib/colors";
 import Icon, { IconWrapper } from "metabase/components/Icon";
+import { ToggleMobileSidebarIcon } from "./Header.styled";
 import Link from "metabase/components/Link";
 import PageHeading from "metabase/components/type/PageHeading";
 import Tooltip from "metabase/components/Tooltip";
@@ -17,11 +18,24 @@ export default function Header({
   isRoot,
   isPersonalCollectionChild,
   collectionId,
+  handleToggleMobileSidebar,
 }) {
   return (
     <Flex align="center" py={3}>
       <Flex align="center">
-        <PageHeading className="text-wrap">{collection.name}</PageHeading>
+        <PageHeading className="text-wrap">
+          <ToggleMobileSidebarIcon
+            name="burger"
+            onClick={handleToggleMobileSidebar}
+            ml={1}
+            mr={2}
+            mt="4px"
+            color={color("text-dark")}
+            hover={{ color: color("brand") }}
+            size={20}
+          />
+          {collection.name}
+        </PageHeading>
         {collection.description && (
           <Tooltip tooltip={collection.description}>
             <Icon

--- a/frontend/src/metabase/collections/components/Header/Header.jsx
+++ b/frontend/src/metabase/collections/components/Header/Header.jsx
@@ -24,15 +24,7 @@ export default function Header({
     <Flex align="center" py={3}>
       <Flex align="center">
         <PageHeading className="text-wrap">
-          <ToggleMobileSidebarIcon
-            name="burger"
-            onClick={handleToggleMobileSidebar}
-            ml={1}
-            mr={2}
-            mt="4px"
-            color={color("text-dark")}
-            size={20}
-          />
+          <ToggleMobileSidebarIcon onClick={handleToggleMobileSidebar} />
           {collection.name}
         </PageHeading>
         {collection.description && (

--- a/frontend/src/metabase/collections/components/Header/Header.jsx
+++ b/frontend/src/metabase/collections/components/Header/Header.jsx
@@ -6,11 +6,12 @@ import { t } from "ttag";
 import * as Urls from "metabase/lib/urls";
 import { color } from "metabase/lib/colors";
 import Icon, { IconWrapper } from "metabase/components/Icon";
-import { ToggleMobileSidebarIcon } from "./Header.styled";
 import Link from "metabase/components/Link";
 import PageHeading from "metabase/components/type/PageHeading";
 import Tooltip from "metabase/components/Tooltip";
 import CollectionEditMenu from "metabase/collections/components/CollectionEditMenu";
+
+import { ToggleMobileSidebarIcon } from "./Header.styled";
 
 export default function Header({
   collection,

--- a/frontend/src/metabase/collections/components/Header/Header.styled.js
+++ b/frontend/src/metabase/collections/components/Header/Header.styled.js
@@ -3,6 +3,7 @@ import styled from "styled-components";
 import Icon from "metabase/components/Icon";
 
 export const ToggleMobileSidebarIcon = styled(Icon)`
+  cursor: pointer;
   @media screen and (min-width: 768px) {
     display: none;
   }

--- a/frontend/src/metabase/collections/components/Header/Header.styled.js
+++ b/frontend/src/metabase/collections/components/Header/Header.styled.js
@@ -1,6 +1,7 @@
 import styled from "styled-components";
 
 import Icon from "metabase/components/Icon";
+import { breakpointMinSmall } from "metabase/styled-components/theme/media-queries";
 
 export const ToggleMobileSidebarIcon = styled(Icon).attrs({
   ml: 1,
@@ -9,10 +10,9 @@ export const ToggleMobileSidebarIcon = styled(Icon).attrs({
   name: "burger",
   size: 20,
 })`
-  color: {color("text-dark")};
   cursor: pointer;
 
-  @media screen and (min-width: 40em) {
+  ${breakpointMinSmall} {
     display: none;
   }
 `;

--- a/frontend/src/metabase/collections/components/Header/Header.styled.js
+++ b/frontend/src/metabase/collections/components/Header/Header.styled.js
@@ -1,0 +1,9 @@
+import styled from "styled-components";
+
+import Icon from "metabase/components/Icon";
+
+export const ToggleMobileSidebarIcon = styled(Icon)`
+  @media screen and (min-width: 768px) {
+    display: none;
+  }
+`;

--- a/frontend/src/metabase/collections/components/Header/Header.styled.js
+++ b/frontend/src/metabase/collections/components/Header/Header.styled.js
@@ -2,8 +2,16 @@ import styled from "styled-components";
 
 import Icon from "metabase/components/Icon";
 
-export const ToggleMobileSidebarIcon = styled(Icon)`
+export const ToggleMobileSidebarIcon = styled(Icon).attrs({
+  ml: 1,
+  mr: 2,
+  mt: "4px",
+  name: "burger",
+  size: 20,
+})`
+  color: {color("text-dark")};
   cursor: pointer;
+
   @media screen and (min-width: 768px) {
     display: none;
   }

--- a/frontend/src/metabase/collections/components/Header/Header.styled.js
+++ b/frontend/src/metabase/collections/components/Header/Header.styled.js
@@ -12,7 +12,7 @@ export const ToggleMobileSidebarIcon = styled(Icon).attrs({
   color: {color("text-dark")};
   cursor: pointer;
 
-  @media screen and (min-width: 768px) {
+  @media screen and (min-width: 40em) {
     display: none;
   }
 `;

--- a/frontend/src/metabase/collections/constants.js
+++ b/frontend/src/metabase/collections/constants.js
@@ -1,3 +1,4 @@
 // unit to use for calculating collection sidebar spacing (in px)
 export const SIDEBAR_SPACER = 18;
+export const SIDEBAR_WIDTH = "340px";
 export const ANALYTICS_CONTEXT = "Collection Landing";

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -41,7 +41,7 @@ function CollectionContent({
   isAdmin,
   isRoot,
   handleToggleMobileSidebar,
-  showMobileSidebar,
+  shouldDisplayMobileSidebar,
 }) {
   const [selectedItems, setSelectedItems] = useState(null);
   const [selectedAction, setSelectedAction] = useState(null);

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -11,7 +11,7 @@ import { getUserIsAdmin } from "metabase/selectors/user";
 
 import BulkActions from "metabase/collections/components/BulkActions";
 import CollectionEmptyState from "metabase/components/CollectionEmptyState";
-import Header from "metabase/collections/components/Header";
+import Header from "metabase/collections/components/Header/Header";
 import ItemsTable from "metabase/collections/components/ItemsTable";
 import PinnedItemsTable from "metabase/collections/components/PinnedItemsTable";
 import { isPersonalCollectionChild } from "metabase/collections/utils";
@@ -40,6 +40,8 @@ function CollectionContent({
   collectionId,
   isAdmin,
   isRoot,
+  handleToggleMobileSidebar,
+  showMobileSidebar,
 }) {
   const [selectedItems, setSelectedItems] = useState(null);
   const [selectedAction, setSelectedAction] = useState(null);
@@ -151,6 +153,7 @@ function CollectionContent({
                   collection,
                   collectionList,
                 )}
+                handleToggleMobileSidebar={handleToggleMobileSidebar}
               />
 
               <PinnedItemsTable

--- a/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebar.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebar.jsx
@@ -3,7 +3,6 @@ import React from "react";
 import { connect } from "react-redux";
 import { Box } from "grid-styled";
 import { t } from "ttag";
-import styled from "styled-components";
 
 import * as Urls from "metabase/lib/urls";
 
@@ -11,6 +10,7 @@ import Collection from "metabase/entities/collections";
 
 import CollectionDropTarget from "metabase/containers/dnd/CollectionDropTarget";
 
+import { Sidebar } from "./CollectionSidebar.styled";
 import Icon from "metabase/components/Icon";
 import Link from "metabase/components/Link";
 import LoadingSpinner from "metabase/components/LoadingSpinner";
@@ -28,22 +28,6 @@ import {
 const getCurrentUser = ({ currentUser }) => ({ currentUser });
 
 // TODO - what's different about this from another sidebar component?
-const Sidebar = styled(Box.withComponent("aside"))`
-  bottom: 0;
-  display: flex;
-  flex-direction: column;
-  left: 0;
-  overflow-x: hidden;
-  overflow-y: auto;
-  padding-top: 32px;
-  position: fixed;
-  top: 65px;
-  width: ${props => props.width};
-
-  @media screen and (max-width: 768px) {
-    width: 50px;
-  }
-`;
 
 @Collection.loadList({
   /* pass "tree" here so that the collection entity knows to use the /tree endpoint and send children in the response

--- a/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebar.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebar.jsx
@@ -10,7 +10,7 @@ import Collection from "metabase/entities/collections";
 
 import CollectionDropTarget from "metabase/containers/dnd/CollectionDropTarget";
 
-import { Sidebar } from "./CollectionSidebar.styled";
+import { Sidebar, ToggleMobileSidebarIcon } from "./CollectionSidebar.styled";
 import Icon from "metabase/components/Icon";
 import Link from "metabase/components/Link";
 import LoadingSpinner from "metabase/components/LoadingSpinner";
@@ -71,9 +71,16 @@ class CollectionSidebar extends React.Component {
   filterPersonalCollections = collection => !collection.archived;
 
   renderContent = () => {
-    const { currentUser, isRoot, collectionId, list } = this.props;
+    const {
+      currentUser,
+      handleToggleMobileSidebar,
+      isRoot,
+      collectionId,
+      list,
+    } = this.props;
     return (
       <React.Fragment>
+        <ToggleMobileSidebarIcon onClick={handleToggleMobileSidebar} />
         <Collection.Loader id="root">
           {({ collection: root }) => (
             <Box mb={1} mt={2}>

--- a/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebar.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebar.jsx
@@ -147,14 +147,10 @@ class CollectionSidebar extends React.Component {
   };
 
   render() {
-    const { allFetched, width } = this.props;
+    const { allFetched } = this.props;
 
     return (
-      <Sidebar
-        role="tree"
-        width={width}
-        showMobileSidebar={this.props.showMobileSidebar}
-      >
+      <Sidebar role="tree" showMobileSidebar={this.props.showMobileSidebar}>
         {allFetched ? (
           this.renderContent()
         ) : (

--- a/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebar.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebar.jsx
@@ -29,14 +29,16 @@ const getCurrentUser = ({ currentUser }) => ({ currentUser });
 
 // TODO - what's different about this from another sidebar component?
 const Sidebar = styled(Box.withComponent("aside"))`
-  position: fixed;
-  left: 0;
   bottom: 0;
-  top: 65px;
-  overflow-x: hidden;
-  overflow-y: auto;
   display: flex;
   flex-direction: column;
+  left: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  padding-top: 32px;
+  position: fixed;
+  top: 65px;
+  width: ${props => props.width};
 `;
 
 @Collection.loadList({
@@ -150,10 +152,10 @@ class CollectionSidebar extends React.Component {
   };
 
   render() {
-    const { allFetched } = this.props;
+    const { allFetched, width } = this.props;
 
     return (
-      <Sidebar w={340} pt={3} role="tree">
+      <Sidebar role="tree" width={width}>
         {allFetched ? (
           this.renderContent()
         ) : (

--- a/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebar.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebar.jsx
@@ -27,8 +27,6 @@ import {
 
 const getCurrentUser = ({ currentUser }) => ({ currentUser });
 
-// TODO - what's different about this from another sidebar component?
-
 @Collection.loadList({
   /* pass "tree" here so that the collection entity knows to use the /tree endpoint and send children in the response
     we should eventually refactor code elsewhere in the app to use this by default instead of determining the relationships clientside, but this works in the interim
@@ -150,7 +148,10 @@ class CollectionSidebar extends React.Component {
     const { allFetched } = this.props;
 
     return (
-      <Sidebar role="tree" showMobileSidebar={this.props.showMobileSidebar}>
+      <Sidebar
+        role="tree"
+        shouldDisplayMobileSidebar={this.props.shouldDisplayMobileSidebar}
+      >
         {allFetched ? (
           this.renderContent()
         ) : (

--- a/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebar.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebar.jsx
@@ -39,6 +39,10 @@ const Sidebar = styled(Box.withComponent("aside"))`
   position: fixed;
   top: 65px;
   width: ${props => props.width};
+
+  @media screen and (max-width: 768px) {
+    width: 50px;
+  }
 `;
 
 @Collection.loadList({

--- a/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebar.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebar.jsx
@@ -143,7 +143,11 @@ class CollectionSidebar extends React.Component {
     const { allFetched, width } = this.props;
 
     return (
-      <Sidebar role="tree" width={width}>
+      <Sidebar
+        role="tree"
+        width={width}
+        showMobileSidebar={this.props.showMobileSidebar}
+      >
         {allFetched ? (
           this.renderContent()
         ) : (

--- a/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebar.styled.js
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebar.styled.js
@@ -3,6 +3,7 @@ import { Box } from "grid-styled";
 
 import { color } from "metabase/lib/colors";
 import Icon from "metabase/components/Icon";
+import { breakpointMinSmall } from "metabase/styled-components/theme/media-queries";
 
 import { SIDEBAR_WIDTH } from "metabase/collections/constants";
 
@@ -16,9 +17,9 @@ export const Sidebar = styled(Box.withComponent("aside"))`
   padding-top: 32px;
   position: fixed;
   top: 65px;
-  width: ${props => (props.showMobileSidebar ? "100vw" : 0)};
+  width: ${props => (props.shouldDisplayMobileSidebar ? "100vw" : 0)};
 
-  @media screen and (min-width: 40em) {
+  ${breakpointMinSmall} {
     width: ${SIDEBAR_WIDTH};
   }
 `;
@@ -32,7 +33,7 @@ export const ToggleMobileSidebarIcon = styled(Icon).attrs({
 })`
   color: ${color("brand")};
 
-  @media screen and (min-width: 40em) {
+  ${breakpointMinSmall} {
     cursor: pointer;
     display: none;
   }

--- a/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebar.styled.js
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebar.styled.js
@@ -1,6 +1,8 @@
 import styled from "styled-components";
 import { Box } from "grid-styled";
 
+import { SIDEBAR_WIDTH } from "metabase/collections/constants";
+
 export const Sidebar = styled(Box.withComponent("aside"))`
   bottom: 0;
   display: flex;
@@ -11,7 +13,7 @@ export const Sidebar = styled(Box.withComponent("aside"))`
   padding-top: 32px;
   position: fixed;
   top: 65px;
-  width: ${props => props.width};
+  width: ${SIDEBAR_WIDTH};
 
   @media screen and (max-width: 768px) {
     width: 50px;

--- a/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebar.styled.js
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebar.styled.js
@@ -13,9 +13,9 @@ export const Sidebar = styled(Box.withComponent("aside"))`
   padding-top: 32px;
   position: fixed;
   top: 65px;
-  width: ${SIDEBAR_WIDTH};
+  width: ${props => (props.showMobileSidebar ? SIDEBAR_WIDTH : 0)};
 
-  @media screen and (max-width: 768px) {
-    width: 50px;
+  @media screen and (min-width: 768px) {
+    width: ${SIDEBAR_WIDTH};
   }
 `;

--- a/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebar.styled.js
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebar.styled.js
@@ -1,0 +1,19 @@
+import styled from "styled-components";
+import { Box } from "grid-styled";
+
+export const Sidebar = styled(Box.withComponent("aside"))`
+  bottom: 0;
+  display: flex;
+  flex-direction: column;
+  left: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  padding-top: 32px;
+  position: fixed;
+  top: 65px;
+  width: ${props => props.width};
+
+  @media screen and (max-width: 768px) {
+    width: 50px;
+  }
+`;

--- a/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebar.styled.js
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebar.styled.js
@@ -18,7 +18,7 @@ export const Sidebar = styled(Box.withComponent("aside"))`
   top: 65px;
   width: ${props => (props.showMobileSidebar ? "100vw" : 0)};
 
-  @media screen and (min-width: 768px) {
+  @media screen and (min-width: 40em) {
     width: ${SIDEBAR_WIDTH};
   }
 `;
@@ -32,7 +32,7 @@ export const ToggleMobileSidebarIcon = styled(Icon).attrs({
 })`
   color: ${color("brand")};
 
-  @media screen and (min-width: 768px) {
+  @media screen and (min-width: 40em) {
     cursor: pointer;
     display: none;
   }

--- a/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebar.styled.js
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebar.styled.js
@@ -1,6 +1,9 @@
 import styled from "styled-components";
 import { Box } from "grid-styled";
 
+import { color } from "metabase/lib/colors";
+import Icon from "metabase/components/Icon";
+
 import { SIDEBAR_WIDTH } from "metabase/collections/constants";
 
 export const Sidebar = styled(Box.withComponent("aside"))`
@@ -13,9 +16,24 @@ export const Sidebar = styled(Box.withComponent("aside"))`
   padding-top: 32px;
   position: fixed;
   top: 65px;
-  width: ${props => (props.showMobileSidebar ? SIDEBAR_WIDTH : 0)};
+  width: ${props => (props.showMobileSidebar ? "100vw" : 0)};
 
   @media screen and (min-width: 768px) {
     width: ${SIDEBAR_WIDTH};
+  }
+`;
+
+export const ToggleMobileSidebarIcon = styled(Icon).attrs({
+  ml: 3,
+  mr: 2,
+  mt: "4px",
+  name: "close",
+  size: 20,
+})`
+  color: ${color("brand")};
+
+  @media screen and (min-width: 768px) {
+    cursor: pointer;
+    display: none;
   }
 `;

--- a/frontend/src/metabase/components/CollectionLanding.jsx
+++ b/frontend/src/metabase/components/CollectionLanding.jsx
@@ -1,13 +1,24 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 import { Box } from "grid-styled";
+import styled from "styled-components";
 
 import CollectionContent from "metabase/collections/containers/CollectionContent";
-import CollectionSidebar from "metabase/collections/containers/CollectionSidebar";
+import CollectionSidebar from "metabase/collections/containers/CollectionSidebar/CollectionSidebar";
 
 import * as Urls from "metabase/lib/urls";
 
 import { PageWrapper } from "metabase/collections/components/Layout";
+
+const sidebarWidth = "340px";
+
+const ContentBox = styled(Box)`
+  background-color: white;
+  height: 100%;
+  margin-left: ${sidebarWidth};
+  overflow-y: auto;
+  padding-bottom: 64px;
+`;
 
 const CollectionLanding = ({ params: { slug }, children }) => {
   const collectionId = Urls.extractCollectionId(slug);
@@ -15,19 +26,17 @@ const CollectionLanding = ({ params: { slug }, children }) => {
 
   return (
     <PageWrapper>
-      <CollectionSidebar isRoot={isRoot} collectionId={collectionId} />
+      <CollectionSidebar
+        isRoot={isRoot}
+        collectionId={collectionId}
+        width={sidebarWidth}
+      />
       {/* For now I'm wrapping this here so that we could potentially reuse CollectionContent without
         having the specific page margin and layout concerns, TBD whether that's a good idea or needed
         */}
-      <Box
-        bg="white"
-        className="border-left full-height"
-        style={{ overflowY: "auto" }}
-        ml={340}
-        pb={4}
-      >
+      <ContentBox className="border-left">
         <CollectionContent isRoot={isRoot} collectionId={collectionId} />
-      </Box>
+      </ContentBox>
       {
         // Need to have this here so the child modals will show up
         children

--- a/frontend/src/metabase/components/CollectionLanding/CollectionLanding.jsx
+++ b/frontend/src/metabase/components/CollectionLanding/CollectionLanding.jsx
@@ -21,6 +21,7 @@ const CollectionLanding = ({ params: { slug }, children }) => {
     <PageWrapper>
       <CollectionSidebar
         isRoot={isRoot}
+        handleToggleMobileSidebar={handleToggleMobileSidebar}
         collectionId={collectionId}
         showMobileSidebar={showMobileSidebar}
       />

--- a/frontend/src/metabase/components/CollectionLanding/CollectionLanding.jsx
+++ b/frontend/src/metabase/components/CollectionLanding/CollectionLanding.jsx
@@ -1,24 +1,12 @@
 /* eslint-disable react/prop-types */
 import React from "react";
-import { Box } from "grid-styled";
-import styled from "styled-components";
-
-import CollectionContent from "metabase/collections/containers/CollectionContent";
-import CollectionSidebar from "metabase/collections/containers/CollectionSidebar/CollectionSidebar";
 
 import * as Urls from "metabase/lib/urls";
 
 import { PageWrapper } from "metabase/collections/components/Layout";
-
-const sidebarWidth = "340px";
-
-const ContentBox = styled(Box)`
-  background-color: white;
-  height: 100%;
-  margin-left: ${sidebarWidth};
-  overflow-y: auto;
-  padding-bottom: 64px;
-`;
+import CollectionContent from "metabase/collections/containers/CollectionContent";
+import CollectionSidebar from "metabase/collections/containers/CollectionSidebar/CollectionSidebar";
+import { ContentBox } from "./CollectionLanding.styled";
 
 const CollectionLanding = ({ params: { slug }, children }) => {
   const collectionId = Urls.extractCollectionId(slug);
@@ -26,11 +14,7 @@ const CollectionLanding = ({ params: { slug }, children }) => {
 
   return (
     <PageWrapper>
-      <CollectionSidebar
-        isRoot={isRoot}
-        collectionId={collectionId}
-        width={sidebarWidth}
-      />
+      <CollectionSidebar isRoot={isRoot} collectionId={collectionId} />
       {/* For now I'm wrapping this here so that we could potentially reuse CollectionContent without
         having the specific page margin and layout concerns, TBD whether that's a good idea or needed
         */}

--- a/frontend/src/metabase/components/CollectionLanding/CollectionLanding.jsx
+++ b/frontend/src/metabase/components/CollectionLanding/CollectionLanding.jsx
@@ -9,7 +9,7 @@ import CollectionSidebar from "metabase/collections/containers/CollectionSidebar
 import { ContentBox } from "./CollectionLanding.styled";
 
 const CollectionLanding = ({ params: { slug }, children }) => {
-  const [showMobileSidebar, setShowMobileSidebar] = useState(true);
+  const [showMobileSidebar, setShowMobileSidebar] = useState(false);
 
   const handleToggleMobileSidebar = () =>
     setShowMobileSidebar(!showMobileSidebar);

--- a/frontend/src/metabase/components/CollectionLanding/CollectionLanding.jsx
+++ b/frontend/src/metabase/components/CollectionLanding/CollectionLanding.jsx
@@ -9,10 +9,12 @@ import CollectionSidebar from "metabase/collections/containers/CollectionSidebar
 import { ContentBox } from "./CollectionLanding.styled";
 
 const CollectionLanding = ({ params: { slug }, children }) => {
-  const [showMobileSidebar, setShowMobileSidebar] = useState(false);
+  const [shouldDisplayMobileSidebar, setShouldDisplayMobileSidebar] = useState(
+    false,
+  );
 
   const handleToggleMobileSidebar = () =>
-    setShowMobileSidebar(!showMobileSidebar);
+    setShouldDisplayMobileSidebar(!shouldDisplayMobileSidebar);
 
   const collectionId = Urls.extractCollectionId(slug);
   const isRoot = collectionId === "root";
@@ -23,17 +25,20 @@ const CollectionLanding = ({ params: { slug }, children }) => {
         isRoot={isRoot}
         handleToggleMobileSidebar={handleToggleMobileSidebar}
         collectionId={collectionId}
-        showMobileSidebar={showMobileSidebar}
+        shouldDisplayMobileSidebar={shouldDisplayMobileSidebar}
       />
       {/* For now I'm wrapping this here so that we could potentially reuse CollectionContent without
         having the specific page margin and layout concerns, TBD whether that's a good idea or needed
         */}
-      <ContentBox className="border-left" showMobileSidebar={showMobileSidebar}>
+      <ContentBox
+        className="border-left"
+        shouldDisplayMobileSidebar={shouldDisplayMobileSidebar}
+      >
         <CollectionContent
           isRoot={isRoot}
           collectionId={collectionId}
           handleToggleMobileSidebar={handleToggleMobileSidebar}
-          showMobileSidebar={showMobileSidebar}
+          shouldDisplayMobileSidebar={shouldDisplayMobileSidebar}
         />
       </ContentBox>
       {

--- a/frontend/src/metabase/components/CollectionLanding/CollectionLanding.jsx
+++ b/frontend/src/metabase/components/CollectionLanding/CollectionLanding.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import React from "react";
+import React, { useState } from "react";
 
 import * as Urls from "metabase/lib/urls";
 
@@ -9,17 +9,31 @@ import CollectionSidebar from "metabase/collections/containers/CollectionSidebar
 import { ContentBox } from "./CollectionLanding.styled";
 
 const CollectionLanding = ({ params: { slug }, children }) => {
+  const [showMobileSidebar, setShowMobileSidebar] = useState(true);
+
+  const handleToggleMobileSidebar = () =>
+    setShowMobileSidebar(!showMobileSidebar);
+
   const collectionId = Urls.extractCollectionId(slug);
   const isRoot = collectionId === "root";
 
   return (
     <PageWrapper>
-      <CollectionSidebar isRoot={isRoot} collectionId={collectionId} />
+      <CollectionSidebar
+        isRoot={isRoot}
+        collectionId={collectionId}
+        showMobileSidebar={showMobileSidebar}
+      />
       {/* For now I'm wrapping this here so that we could potentially reuse CollectionContent without
         having the specific page margin and layout concerns, TBD whether that's a good idea or needed
         */}
-      <ContentBox className="border-left">
-        <CollectionContent isRoot={isRoot} collectionId={collectionId} />
+      <ContentBox className="border-left" showMobileSidebar={showMobileSidebar}>
+        <CollectionContent
+          isRoot={isRoot}
+          collectionId={collectionId}
+          handleToggleMobileSidebar={handleToggleMobileSidebar}
+          showMobileSidebar={showMobileSidebar}
+        />
       </ContentBox>
       {
         // Need to have this here so the child modals will show up

--- a/frontend/src/metabase/components/CollectionLanding/CollectionLanding.styled.js
+++ b/frontend/src/metabase/components/CollectionLanding/CollectionLanding.styled.js
@@ -6,7 +6,11 @@ import { SIDEBAR_WIDTH } from "metabase/collections/constants";
 export const ContentBox = styled(Box)`
   background-color: white;
   height: 100%;
-  margin-left: ${SIDEBAR_WIDTH};
+  margin-left: ${props => (props.showMobileSidebar ? SIDEBAR_WIDTH : 0)};
   overflow-y: auto;
   padding-bottom: 64px;
+
+  @media screen and (min-width: 768px) {
+    margin-left: ${SIDEBAR_WIDTH};
+  }
 `;

--- a/frontend/src/metabase/components/CollectionLanding/CollectionLanding.styled.js
+++ b/frontend/src/metabase/components/CollectionLanding/CollectionLanding.styled.js
@@ -2,16 +2,18 @@ import { Box } from "grid-styled";
 import styled from "styled-components";
 
 import { SIDEBAR_WIDTH } from "metabase/collections/constants";
+import { breakpointMinSmall } from "metabase/styled-components/theme/media-queries";
 
 export const ContentBox = styled(Box)`
   background-color: white;
-  display: ${props => (props.showMobileSidebar ? "none" : "block")};
+  display: ${props => (props.shouldDisplayMobileSidebar ? "none" : "block")};
   height: 100%;
-  margin-left: ${props => (props.showMobileSidebar ? SIDEBAR_WIDTH : 0)};
+  margin-left: ${props =>
+    props.shouldDisplayMobileSidebar ? SIDEBAR_WIDTH : 0};
   overflow-y: auto;
   padding-bottom: 64px;
 
-  @media screen and (min-width: 40em) {
+  ${breakpointMinSmall} {
     display: block;
     margin-left: ${SIDEBAR_WIDTH};
   }

--- a/frontend/src/metabase/components/CollectionLanding/CollectionLanding.styled.js
+++ b/frontend/src/metabase/components/CollectionLanding/CollectionLanding.styled.js
@@ -11,7 +11,7 @@ export const ContentBox = styled(Box)`
   overflow-y: auto;
   padding-bottom: 64px;
 
-  @media screen and (min-width: 768px) {
+  @media screen and (min-width: 40em) {
     display: block;
     margin-left: ${SIDEBAR_WIDTH};
   }

--- a/frontend/src/metabase/components/CollectionLanding/CollectionLanding.styled.js
+++ b/frontend/src/metabase/components/CollectionLanding/CollectionLanding.styled.js
@@ -5,12 +5,14 @@ import { SIDEBAR_WIDTH } from "metabase/collections/constants";
 
 export const ContentBox = styled(Box)`
   background-color: white;
+  display: ${props => (props.showMobileSidebar ? "none" : "block")};
   height: 100%;
   margin-left: ${props => (props.showMobileSidebar ? SIDEBAR_WIDTH : 0)};
   overflow-y: auto;
   padding-bottom: 64px;
 
   @media screen and (min-width: 768px) {
+    display: block;
     margin-left: ${SIDEBAR_WIDTH};
   }
 `;

--- a/frontend/src/metabase/components/CollectionLanding/CollectionLanding.styled.js
+++ b/frontend/src/metabase/components/CollectionLanding/CollectionLanding.styled.js
@@ -1,0 +1,12 @@
+import { Box } from "grid-styled";
+import styled from "styled-components";
+
+import { SIDEBAR_WIDTH } from "metabase/collections/constants";
+
+export const ContentBox = styled(Box)`
+  background-color: white;
+  height: 100%;
+  margin-left: ${SIDEBAR_WIDTH};
+  overflow-y: auto;
+  padding-bottom: 64px;
+`;

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -83,7 +83,7 @@ import DashboardCopyModal from "metabase/dashboard/components/DashboardCopyModal
 import DashboardDetailsModal from "metabase/dashboard/components/DashboardDetailsModal";
 import { ModalRoute } from "metabase/hoc/ModalRoute";
 
-import CollectionLanding from "metabase/components/CollectionLanding";
+import CollectionLanding from "metabase/components/CollectionLanding/CollectionLanding";
 import Overworld from "metabase/containers/Overworld";
 
 import ArchiveApp from "metabase/home/containers/ArchiveApp";

--- a/frontend/src/metabase/styled-components/theme/media-queries.js
+++ b/frontend/src/metabase/styled-components/theme/media-queries.js
@@ -1,0 +1,11 @@
+export const breakpointMinExtraSmall = "@media screen and (min-width: 23em)";
+export const breakpointMinSmall = "@media screen and (min-width: 40em)";
+export const breakpointMinMedium = "@media screen and (min-width: 60em)";
+export const breakpointMinLarge = "@media screen and (min-width: 80em)";
+export const breakpointMinExtraLarge = "@media screen and (min-width: 120em)";
+
+export const breakpointMaxExtraSmall = "@media screen and (max-width: 23em)";
+export const breakpointMaxSmall = "@media screen and (max-width: 40em)";
+export const breakpointMaxMedium = "@media screen and (max-width: 60em)";
+export const breakpointMaxLarge = "@media screen and (max-width: 80em)";
+export const breakpointMaxExtraLarge = "@media screen and (max-width: 120em)";


### PR DESCRIPTION
Fixes #15006

⚠️ This PR is a minimal fix.
As the bug completely breaks the collections UX in mobile devices, submitting this as step 1.

**Next steps:**

1. e2e tests
2. UI tweaks from [new layout](https://www.figma.com/file/dyN71v3AI1GutWOaSLoxT6/Collections-Mobile-Layout?node-id=0%3A1&viewport=-194%2C254%2C0.4838546812534332)
3. transition animations
4. some code improvements around it

## How to Test

1. Simulate a mobile device in portrait orientation
2. Go to root collection page: http://localhost:3000/collection/root

You should not see the sidebar. 
You should see the collection content as below.

<img src="https://user-images.githubusercontent.com/380816/124323695-1f14e480-db58-11eb-83d9-d3a8639d2886.png" width=140 />

You should be able to click the burger icon to the left of the collection title.
This should open the sidebar.
You should be able to click the × icon to the top/left of the sidebar to close it.