### PR TITLE
Connection pool optimizations

### DIFF
--- a/src/metabase/driver/sql_jdbc/connection.clj
+++ b/src/metabase/driver/sql_jdbc/connection.clj
@@ -78,7 +78,9 @@
    ;; Kill idle connections above the minPoolSize after 5 minutes.
    "maxIdleTimeExcessConnections" (* 5 60)
    ;; Set the data source name so that the c3p0 JMX bean has a useful identifier
-   "dataSourceName"               (format "db-%d-%s-%s" (u/the-id database) (name driver) (-> database :details :db))})
+   "dataSourceName"               (format "db-%d-%s-%s" (u/the-id database) (name driver) (-> database :details :db))
+   "checkoutTimeout"              (or (config/config-int :mb-jdbc-data-warehouse-checkout-timeout)
+                                    5000)}) ; TODO: change to 0 before final checkin, probably
 
 (defn- create-pool!
   "Create a new C3P0 `ComboPooledDataSource` for connecting to the given `database`."


### PR DESCRIPTION
WORK IN PROGRESS

Add c3p0 checkoutTimeout, so that we have an opportunity to "give up" early if the query has been canceled anyway

Update `execute-reducible-query` to try to acquire connection in a loop (instead of waiting "forever"), catching com.mchange.v2.resourcepool.TimeoutException, and exiting the loop in that case
