### PR TITLE
[Cypress Helpers] Add `filterWidget` helper function

### DIFF
--- a/frontend/test/__support__/e2e/cypress.js
+++ b/frontend/test/__support__/e2e/cypress.js
@@ -41,6 +41,25 @@ export function browse() {
   return cy.get(".Nav .Icon-table_spaced");
 }
 
+/**
+ * Get the `fieldset` HTML element that we use as a filter widget container.
+ *
+ * @returns HTMLFieldSetElement
+ *
+ * @example
+ * // Simple SQL filter widget (works for "Text" and "Number" SQL variable types)
+ * filterWidget().type("123");
+ *
+ * @example
+ * // Filter widget that opens some other type of a filter picker (search, dropdown, input)
+ * filterWidget()
+ *  .contains("Search")
+ *  .click();
+ *
+ * @todo Add the ability to choose between multiple widgets using their index.
+ * @todo Add the ability to alias the chosen filter widget.
+ * @todo Extract into a separate helper file.
+ */
 export function filterWidget() {
   return cy.get("fieldset");
 }

--- a/frontend/test/__support__/e2e/cypress.js
+++ b/frontend/test/__support__/e2e/cypress.js
@@ -41,6 +41,10 @@ export function browse() {
   return cy.get(".Nav .Icon-table_spaced");
 }
 
+export function filterWidget() {
+  return cy.get("fieldset");
+}
+
 // Metabase utility functions for commonly-used patterns
 export function selectDashboardFilter(selection, filterName) {
   selection.contains("Select…").click();

--- a/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
@@ -2,6 +2,7 @@ import {
   restore,
   modal,
   popover,
+  filterWidget,
   createNativeQuestion,
   showDashboardCardActions,
 } from "__support__/e2e/cypress";
@@ -868,7 +869,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
     });
 
     function setFilterValue(filterName) {
-      cy.get("fieldset")
+      filterWidget()
         .contains(filterName)
         .click();
       cy.findByPlaceholderText("Enter an ID").type("1,2,");

--- a/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
@@ -5,6 +5,7 @@ import {
   expectedRouteCalls,
   showDashboardCardActions,
   modal,
+  filterWidget,
 } from "__support__/e2e/cypress";
 
 import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
@@ -424,7 +425,7 @@ describe("scenarios > dashboard", () => {
 
     cy.visit("/dashboard/1");
 
-    cy.get("fieldset")
+    filterWidget()
       .as("filterWidget")
       .click();
 
@@ -487,7 +488,7 @@ describe("scenarios > dashboard", () => {
 
     cy.visit("/dashboard/1");
 
-    cy.get("fieldset")
+    filterWidget()
       .as("filterWidget")
       .click();
     expectedRouteCalls({ route_alias: "fetchFromDB", calls: 1 });
@@ -652,7 +653,7 @@ describe("scenarios > dashboard", () => {
         cy.signIn("nodata");
         cy.visit(`/dashboard/${DASHBOARD_ID}`);
 
-        cy.get("fieldset")
+        filterWidget()
           .contains("Category")
           .click();
         cy.findByPlaceholderText("Search the list").type("Gizmo");
@@ -786,7 +787,7 @@ describe("scenarios > dashboard", () => {
     });
 
     // Check that list filter works
-    cy.get("fieldset")
+    filterWidget()
       .contains("List")
       .click();
 
@@ -796,7 +797,7 @@ describe("scenarios > dashboard", () => {
     cy.button("Add filter").click();
 
     // Check that the search filter works
-    cy.get("fieldset")
+    filterWidget()
       .contains("Search")
       .click();
     cy.findByPlaceholderText("Search by Name").type("Lora Cronin");
@@ -888,7 +889,7 @@ describe("scenarios > dashboard", () => {
       });
     });
 
-    cy.get("fieldset").click();
+    filterWidget().click();
     cy.findByText("AK").click();
     cy.findByText("CA").click();
     cy.icon("close")
@@ -956,7 +957,7 @@ describe("scenarios > dashboard", () => {
         cy.visit(`/dashboard/${DASHBOARD_ID}`);
       });
     });
-    cy.get("fieldset").click();
+    filterWidget().click();
     cy.findByPlaceholderText("Search the list").type("Syner");
     cy.findByText("Synergistic Wool Coat");
   });

--- a/frontend/test/metabase/scenarios/dashboard/dashboard_local-only.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard_local-only.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore } from "__support__/e2e/cypress";
+import { restore, filterWidget } from "__support__/e2e/cypress";
 import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
 
 const { PEOPLE, PEOPLE_ID } = SAMPLE_DATASET;
@@ -69,7 +69,7 @@ describe("LOCAL TESTING ONLY > dashboard", () => {
         });
 
         cy.visit(`/dashboard/${DASHBOARD_ID}?location=AK&location=CA`);
-        cy.get("fieldset")
+        filterWidget()
           .contains(/\{0\}/)
           .should("not.exist");
       });

--- a/frontend/test/metabase/scenarios/dashboard/title-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/title-drill.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore } from "__support__/e2e/cypress";
+import { restore, filterWidget } from "__support__/e2e/cypress";
 import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
 
 const { PRODUCTS } = SAMPLE_DATASET;
@@ -103,10 +103,11 @@ describe("scenarios > dashboard > title drill", () => {
 });
 
 function checkFilterLabelAndValue(label, value) {
-  cy.get("fieldset legend")
+  filterWidget()
+    .find("legend")
     .invoke("text")
     .should("eq", label);
-  cy.get("fieldset").contains(value);
+  filterWidget().contains(value);
 }
 
 function checkScalarResult(result) {

--- a/frontend/test/metabase/scenarios/filters/sql-filters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/sql-filters.cy.spec.js
@@ -3,6 +3,7 @@ import {
   popover,
   mockSessionProperty,
   openNativeEditor,
+  filterWidget,
 } from "__support__/e2e/cypress";
 
 describe("scenarios > filters > sql filters > basic filter types", () => {
@@ -91,7 +92,7 @@ describe("scenarios > filters > sql filters > basic filter types", () => {
     });
 
     it("when set through the filter widget", () => {
-      cy.get("fieldset").click();
+      filterWidget().click();
       // Since we have fixed dates in Sample Dataset (dating back a couple of years), it'd be cumbersome to click back month by month.
       // Instead, let's choose the 15th of the current month and assert that there are no products / no results.
       cy.findByText("15").click();
@@ -145,7 +146,7 @@ function enterNativeQuery(query) {
 }
 
 function setFilterWidgetValue(value) {
-  cy.get("fieldset")
+  filterWidget()
     .click()
     .type(value);
 }

--- a/frontend/test/metabase/scenarios/native/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/native.cy.spec.js
@@ -2,6 +2,7 @@ import {
   restore,
   popover,
   modal,
+  filterWidget,
   visitQuestionAdhoc,
   mockSessionProperty,
   openNativeEditor,
@@ -323,7 +324,7 @@ describe("scenarios > question > native", () => {
     cy.log("Reported failing on v0.35.3");
     cy.get(".ace_content").contains(ORIGINAL_QUERY);
     // Filter dropdown field
-    cy.get("fieldset").contains("Filter");
+    filterWidget().contains("Filter");
   });
 
   it("should reorder template tags by drag and drop (metabase#9357)", () => {
@@ -527,7 +528,7 @@ describe("scenarios > question > native", () => {
     });
 
     // Set the filter value
-    cy.get("fieldset")
+    filterWidget()
       .contains("Category")
       .click();
     popover()
@@ -650,7 +651,7 @@ describe("scenarios > question > native", () => {
             parseSpecialCharSequences: false,
           },
         );
-        cy.get("fieldset").type("Gizmo");
+        filterWidget().type("Gizmo");
         cy.get(".NativeQueryEditor .Icon-play").click();
         cy.wait("@dataset");
         cy.findByText("Rustic Paper Wallet");
@@ -676,7 +677,7 @@ describe("scenarios > question > native", () => {
         popover()
           .contains("Number")
           .click();
-        cy.get("fieldset").type("20");
+        filterWidget().type("20");
         cy.get(".NativeQueryEditor .Icon-play").click();
         cy.wait("@dataset").then(xhr => {
           expect(xhr.response.body.error).not.to.exist;

--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -5,6 +5,7 @@ import {
   openReviewsTable,
   openPeopleTable,
   popover,
+  filterWidget,
   visitQuestionAdhoc,
 } from "__support__/e2e/cypress";
 
@@ -106,7 +107,7 @@ describe("scenarios > question > filter", () => {
         });
       });
 
-      cy.get("fieldset")
+      filterWidget()
         .last()
         .within(() => {
           cy.findByText("Category").click();
@@ -411,7 +412,7 @@ describe("scenarios > question > filter", () => {
         cy.url().should("not.include", "?category=Doohickey");
 
         // Set filter value to the `ID`
-        cy.get("fieldset")
+        filterWidget()
           .contains(/ID/i)
           .click();
         cy.findByPlaceholderText("Enter an ID").type("1");


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Adds new Cypress helper function `fitlerWidget`
- Annotates it using the JSDoc
- Applies it to the related tests

### Why do this?
- It conveys more meaning to the person reading the spec, and makes it easier to write one
- I still remember how confused I was when I first started writing tests for Metabase and saw `fieldset`. It didn't mean anything to me. Just later learned it was related to the filters in some way and just recently it became clear that it's only used as a filter widget container.