### PR TITLE
Add SegmentedControl component

### DIFF
--- a/frontend/src/metabase/components/Radio.jsx
+++ b/frontend/src/metabase/components/Radio.jsx
@@ -92,6 +92,7 @@ function Radio({
             xspace={xspace}
             yspace={yspace}
             onClick={e => onChange(optionValueFn(option))}
+            aria-selected={selected}
           >
             {option.icon && <Icon name={option.icon} mr={1} />}
             <input

--- a/frontend/src/metabase/components/Radio.styled.js
+++ b/frontend/src/metabase/components/Radio.styled.js
@@ -13,7 +13,6 @@ const BaseList = styled.ul`
 const BaseItem = styled.li.attrs({
   mr: props => (!props.vertical && !props.last ? props.xspace : null),
   mb: props => (props.vertical && !props.last ? props.yspace : null),
-  "aria-selected": props => props.selected,
 })`
   ${space}
   display: flex;

--- a/frontend/src/metabase/components/SegmentedControl.info.js
+++ b/frontend/src/metabase/components/SegmentedControl.info.js
@@ -19,6 +19,17 @@ const OPTIONS_WITH_ICONS = [
   { name: "Doohickey", value: 2, icon: "insight" },
 ];
 
+const OPTIONS_WITH_COLORS = [
+  {
+    name: "Gadget",
+    value: 0,
+    icon: "lightbulb",
+    selectedColor: "accent1",
+  },
+  { name: "Gizmo", value: 1, icon: "folder", selectedColor: "accent2" },
+  { name: "Doohickey", value: 2, icon: "insight" },
+];
+
 function SegmentedControlDemo(props) {
   const [value, setValue] = useState(0);
   return (
@@ -33,4 +44,5 @@ function SegmentedControlDemo(props) {
 export const examples = {
   default: <SegmentedControlDemo options={SIMPLE_OPTIONS} />,
   icons: <SegmentedControlDemo options={OPTIONS_WITH_ICONS} />,
+  colored: <SegmentedControlDemo options={OPTIONS_WITH_COLORS} />,
 };

--- a/frontend/src/metabase/components/SegmentedControl.info.js
+++ b/frontend/src/metabase/components/SegmentedControl.info.js
@@ -1,0 +1,36 @@
+import React, { useState } from "react";
+import { SegmentedControl } from "metabase/components/SegmentedControl";
+
+export const component = SegmentedControl;
+export const category = "input";
+
+export const description = `
+Radio-like segmented control input
+`;
+
+const SIMPLE_OPTIONS = [
+  { name: "Gadget", value: 0 },
+  { name: "Gizmo", value: 1 },
+];
+
+const OPTIONS_WITH_ICONS = [
+  { name: "Gadget", value: 0, icon: "lightbulb" },
+  { name: "Gizmo", value: 1, icon: "folder" },
+  { name: "Doohickey", value: 2, icon: "insight" },
+];
+
+function SegmentedControlDemo(props) {
+  const [value, setValue] = useState(0);
+  return (
+    <SegmentedControl
+      {...props}
+      value={value}
+      onChange={val => setValue(val)}
+    />
+  );
+}
+
+export const examples = {
+  default: <SegmentedControlDemo options={SIMPLE_OPTIONS} />,
+  icons: <SegmentedControlDemo options={OPTIONS_WITH_ICONS} />,
+};

--- a/frontend/src/metabase/components/SegmentedControl.jsx
+++ b/frontend/src/metabase/components/SegmentedControl.jsx
@@ -5,11 +5,7 @@ import Icon from "metabase/components/Icon";
 import { SegmentedList, SegmentedItem } from "./SegmentedControl.styled";
 
 const optionShape = PropTypes.shape({
-  name: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.element,
-    PropTypes.node,
-  ]).isRequired,
+  name: PropTypes.node.isRequired,
   value: PropTypes.any.isRequired,
   icon: PropTypes.string,
 

--- a/frontend/src/metabase/components/SegmentedControl.jsx
+++ b/frontend/src/metabase/components/SegmentedControl.jsx
@@ -12,6 +12,11 @@ const optionShape = PropTypes.shape({
   ]).isRequired,
   value: PropTypes.any.isRequired,
   icon: PropTypes.string,
+
+  // Expects a color alias, not a color code
+  // Example: brand, accent1, success
+  // Won't work: red, #000, rgb(0, 0, 0)
+  selectedColor: PropTypes.string,
 });
 
 const propTypes = {
@@ -43,6 +48,7 @@ export function SegmentedControl({
             isFirst={isFirst}
             isLast={isLast}
             onClick={e => onChange(option.value)}
+            selectedColor={option.selectedColor || "brand"}
           >
             {option.icon && <Icon name={option.icon} mr={1} />}
             <input

--- a/frontend/src/metabase/components/SegmentedControl.jsx
+++ b/frontend/src/metabase/components/SegmentedControl.jsx
@@ -1,0 +1,64 @@
+import React, { useMemo } from "react";
+import PropTypes from "prop-types";
+import _ from "underscore";
+import Icon from "metabase/components/Icon";
+import { SegmentedList, SegmentedItem } from "./SegmentedControl.styled";
+
+const optionShape = PropTypes.shape({
+  name: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.element,
+    PropTypes.node,
+  ]).isRequired,
+  value: PropTypes.any.isRequired,
+  icon: PropTypes.string,
+});
+
+const propTypes = {
+  name: PropTypes.string,
+  value: PropTypes.any,
+  options: PropTypes.arrayOf(optionShape).isRequired,
+  onChange: PropTypes.func,
+};
+
+export function SegmentedControl({
+  name: nameFromProps,
+  value,
+  options,
+  onChange,
+  ...props
+}) {
+  const id = useMemo(() => _.uniqueId("radio-"), []);
+  const name = nameFromProps || id;
+  return (
+    <SegmentedList {...props}>
+      {options.map((option, index) => {
+        const isSelected = option.value === value;
+        const isFirst = index === 0;
+        const isLast = index === options.length - 1;
+        return (
+          <SegmentedItem
+            key={option.value}
+            isSelected={isSelected}
+            isFirst={isFirst}
+            isLast={isLast}
+            onClick={e => onChange(option.value)}
+          >
+            {option.icon && <Icon name={option.icon} mr={1} />}
+            <input
+              id={`${name}-${option.value}`}
+              className="Form-radio"
+              type="radio"
+              name={name}
+              value={option.value}
+              checked={isSelected}
+            />
+            <span>{option.name}</span>
+          </SegmentedItem>
+        );
+      })}
+    </SegmentedList>
+  );
+}
+
+SegmentedControl.propTypes = propTypes;

--- a/frontend/src/metabase/components/SegmentedControl.styled.js
+++ b/frontend/src/metabase/components/SegmentedControl.styled.js
@@ -12,7 +12,7 @@ export const SegmentedItem = styled.li`
   align-items: center;
   font-weight: bold;
   cursor: pointer;
-  color: ${props => (props.isSelected ? color("brand") : null)};
+  color: ${props => (props.isSelected ? color(props.selectedColor) : null)};
   padding: 4px 12px;
 
   border: 1px solid ${color("border")};
@@ -25,6 +25,6 @@ export const SegmentedItem = styled.li`
   aria-selected: ${props => props.isSelected};
 
   :hover {
-    color: ${props => (!props.isSelected ? color("brand") : null)};
+    color: ${props => (!props.isSelected ? color(props.selectedColor) : null)};
   }
 `;

--- a/frontend/src/metabase/components/SegmentedControl.styled.js
+++ b/frontend/src/metabase/components/SegmentedControl.styled.js
@@ -13,7 +13,7 @@ export const SegmentedItem = styled.li`
   font-weight: bold;
   cursor: pointer;
   color: ${props => (props.isSelected ? color(props.selectedColor) : null)};
-  padding: 4px 12px;
+  padding: 6px 12px;
 
   border: 1px solid ${color("border")};
   border-right-width: ${props => (props.isLast ? "1px" : 0)};

--- a/frontend/src/metabase/components/SegmentedControl.styled.js
+++ b/frontend/src/metabase/components/SegmentedControl.styled.js
@@ -22,8 +22,6 @@ export const SegmentedItem = styled.li`
   border-top-right-radius: ${props => (props.isLast ? BORDER_RADIUS : 0)};
   border-bottom-right-radius: ${props => (props.isLast ? BORDER_RADIUS : 0)};
 
-  aria-selected: ${props => props.isSelected};
-
   :hover {
     color: ${props => (!props.isSelected ? color(props.selectedColor) : null)};
   }

--- a/frontend/src/metabase/components/SegmentedControl.styled.js
+++ b/frontend/src/metabase/components/SegmentedControl.styled.js
@@ -1,0 +1,30 @@
+import styled from "styled-components";
+import { color } from "metabase/lib/colors";
+
+const BORDER_RADIUS = "8px";
+
+export const SegmentedList = styled.ul`
+  display: flex;
+`;
+
+export const SegmentedItem = styled.li`
+  display: flex;
+  align-items: center;
+  font-weight: bold;
+  cursor: pointer;
+  color: ${props => (props.isSelected ? color("brand") : null)};
+  padding: 4px 12px;
+
+  border: 1px solid ${color("border")};
+  border-right-width: ${props => (props.isLast ? "1px" : 0)};
+  border-top-left-radius: ${props => (props.isFirst ? BORDER_RADIUS : 0)};
+  border-bottom-left-radius: ${props => (props.isFirst ? BORDER_RADIUS : 0)};
+  border-top-right-radius: ${props => (props.isLast ? BORDER_RADIUS : 0)};
+  border-bottom-right-radius: ${props => (props.isLast ? BORDER_RADIUS : 0)};
+
+  aria-selected: ${props => props.isSelected};
+
+  :hover {
+    color: ${props => (!props.isSelected ? color("brand") : null)};
+  }
+`;


### PR DESCRIPTION
Adds a radio-like input component (needed for collection types project). Was going to just add one more `variant` to `Radio`, but it also has a vertical display and an option to display default HTML radio buttons, which don't make a lot of sense for the segmented control.

### To Verify
1. Open `_internal/components/segmentedcontrol`
2. Ensure every example makes sense

### Demo

**Default**
![default](https://user-images.githubusercontent.com/17258145/124457586-a189e800-dd94-11eb-8743-e0748d32f9c6.gif)

**Icons**
![icons](https://user-images.githubusercontent.com/17258145/124457603-a5b60580-dd94-11eb-8014-1e288c84dd8c.gif)

**Colors**
![colors](https://user-images.githubusercontent.com/17258145/124457616-a8b0f600-dd94-11eb-86fb-ce002e9946b3.gif)

