### PR TITLE
[SQL filters coverage] Extract and apply SQL field filter helpers

### DIFF
--- a/frontend/test/metabase/scenarios/filters/helpers/e2e-field-filter-helpers.js
+++ b/frontend/test/metabase/scenarios/filters/helpers/e2e-field-filter-helpers.js
@@ -1,0 +1,149 @@
+import { filterWidget, popover } from "__support__/e2e/cypress";
+import { toggleRequired } from "./e2e-sql-filter-helpers";
+
+// FILTER WIDGET TYPE
+
+/**
+ * Sets a field filter widget type. Depends on the field that field filter is mapped to.
+ *
+ * @param {string} type
+ */
+export function setWidgetType(type) {
+  cy.findByText("Filter widget type")
+    .parent()
+    .find(".AdminSelect")
+    .click();
+
+  popover()
+    .findByText(type)
+    .click();
+}
+
+// FIELD FILTER STRING FILTERS
+
+/**
+ * Adds string filter value explicitly through the filter widget.
+ *
+ * @param {string} value
+ */
+export function addWidgetStringFilter(value) {
+  popover()
+    .find("input")
+    .type(value);
+  cy.button("Add filter").click();
+}
+
+/**
+ * Adds default string filter value when the filter is marked as required.
+ *
+ * @param {string} value
+ */
+export function addDefaultStringFilter(value) {
+  enterDefaultValue(value);
+}
+
+// FIELD FILTER NUMBER FILTERS
+
+/**
+ * Adds number filter value explicitly through the filter widget.
+ *
+ * @param {string} value
+ * @return {function}
+ */
+export function addWidgetNumberFilter(value) {
+  return isBetweenFilter(value)
+    ? addBetweenFilter(value)
+    : addSimpleNumberFilter(value);
+}
+
+/**
+ *
+ * @param {array|string} value
+ * @return {function}
+ */
+export function addDefaultNumberFilter(value) {
+  return isBetweenFilter(value)
+    ? addBetweenFilter(value)
+    : enterDefaultValue(value);
+}
+
+// UI PATTERNS
+
+/**
+ * Maps a field filter to some particular table field.
+ *
+ * @param {Object} options
+ * @param {string} options.table
+ * @param {string} options.field
+ */
+export function mapTo({ table, field } = {}) {
+  popover()
+    .contains(table)
+    .click();
+
+  popover()
+    .contains(field)
+    .click();
+}
+
+/**
+ * Opens a field filter entry form. Entry type (input, picker) depends on the underlying field filter type.
+ *
+ * @param {boolean} isFilterRequired
+ */
+export function openEntryForm(isFilterRequired) {
+  isFilterRequired && toggleRequired();
+
+  const selector = isFilterRequired
+    ? cy.findByText("Enter a default value...")
+    : filterWidget();
+
+  selector.click();
+}
+
+// LOCAL SCOPE
+
+/**
+ *
+ * @param {Array.<string>} options
+ */
+function addBetweenFilter([low, high] = []) {
+  popover().within(() => {
+    cy.get("input")
+      .first()
+      .type(low);
+
+    cy.get("input")
+      .last()
+      .type(high);
+  });
+
+  cy.button("Add filter").click();
+}
+
+/**
+ *
+ * @param {string} value
+ */
+function addSimpleNumberFilter(value) {
+  cy.findByPlaceholderText("Enter a number").type(value);
+  cy.button("Add filter").click();
+}
+
+/**
+ *
+ * @param {string} value
+ */
+function enterDefaultValue(value) {
+  cy.findByPlaceholderText("Enter a default value...").type(value);
+  cy.button("Add filter").click();
+}
+
+/**
+ *
+ * @param {string|Array.<string>} value
+ * @returns {boolean}
+ */
+function isBetweenFilter(value) {
+  return Array.isArray(value) && value.length === 2;
+}

--- a/frontend/test/metabase/scenarios/filters/sql-field-filter-date.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/sql-field-filter-date.cy.spec.js
@@ -6,6 +6,7 @@ import {
 } from "__support__/e2e/cypress";
 
 import * as SQLFilter from "./helpers/e2e-sql-filter-helpers";
+import * as FieldFilter from "./helpers/e2e-field-filter-helpers";
 
 const currentYearString = new Date().getFullYear().toString();
 
@@ -64,7 +65,7 @@ describe("scenarios > filters > sql filters > field filter > Date", () => {
     SQLFilter.openTypePickerFromDefaultFilterType();
     SQLFilter.chooseType("Field Filter");
 
-    mapFieldFilterTo({
+    FieldFilter.mapTo({
       table: "Products",
       field: "Created At",
     });
@@ -74,7 +75,7 @@ describe("scenarios > filters > sql filters > field filter > Date", () => {
     ([subType, { value, representativeResult }]) => {
       describe(`should work for ${subType}`, () => {
         beforeEach(() => {
-          setFilterWidgetType(subType);
+          FieldFilter.setWidgetType(subType);
         });
 
         it("when set through the filter widget", () => {
@@ -104,34 +105,6 @@ describe("scenarios > filters > sql filters > field filter > Date", () => {
     },
   );
 });
-
-function mapFieldFilterTo({ table, field } = {}) {
-  popover()
-    .contains(table)
-    .click();
-  popover()
-    .contains(field)
-    .click();
-}
-
-/**
- * Set the type for the filter widget.
- *
- * @param {("Text"|"Number"|"Date"|"Field Filter")} type - The allowed strings for the type param.
- *
- * @example
- * setFilterWidgetType("Number");
- */
-function setFilterWidgetType(type) {
-  cy.findByText("Filter widget type")
-    .parent()
-    .find(".AdminSelect")
-    .click();
-
-  popover()
-    .findByText(type)
-    .click();
-}
 
 function setMonthAndYearFilter({ month, year } = {}) {
   cy.findByText(currentYearString).click();

--- a/frontend/test/metabase/scenarios/filters/sql-field-filter-number.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/sql-field-filter-number.cy.spec.js
@@ -2,10 +2,10 @@ import {
   restore,
   mockSessionProperty,
   openNativeEditor,
-  popover,
 } from "__support__/e2e/cypress";
 
 import * as SQLFilter from "./helpers/e2e-sql-filter-helpers";
+import * as FieldFilter from "./helpers/e2e-field-filter-helpers";
 
 const NUMBER_FILTER_SUBTYPES = {
   "Equal to": {
@@ -47,7 +47,7 @@ describe("scenarios > filters > sql filters > field filter > Number", () => {
     SQLFilter.openTypePickerFromDefaultFilterType();
     SQLFilter.chooseType("Field Filter");
 
-    mapFieldFilterTo({
+    FieldFilter.mapTo({
       table: "Products",
       field: "Rating",
     });
@@ -57,9 +57,10 @@ describe("scenarios > filters > sql filters > field filter > Number", () => {
     ([subType, { term, representativeResult }]) => {
       describe(`should work for ${subType}`, () => {
         it("when set through the filter widget", () => {
-          setFilterWidgetType(subType);
+          FieldFilter.setWidgetType(subType);
 
-          setFieldFilterWidgetValue(term);
+          FieldFilter.openEntryForm();
+          FieldFilter.addWidgetNumberFilter(term);
 
           SQLFilter.runQuery();
 
@@ -69,10 +70,12 @@ describe("scenarios > filters > sql filters > field filter > Number", () => {
         });
 
         it("when set as the default value for a required filter", () => {
-          setFilterWidgetType(subType);
+          FieldFilter.setWidgetType(subType);
 
           SQLFilter.toggleRequired();
-          setRequiredFieldFilterDefaultValue(term);
+
+          FieldFilter.openEntryForm({ isFilterRequired: true });
+          FieldFilter.addDefaultNumberFilter(term);
 
           SQLFilter.runQuery();
 
@@ -84,58 +87,3 @@ describe("scenarios > filters > sql filters > field filter > Number", () => {
     },
   );
 });
-
-function setRequiredFieldFilterDefaultValue(value) {
-  cy.findByText("Enter a default value...").click();
-
-  if (Array.isArray(value)) {
-    setBetweenFilterValue(value);
-  } else {
-    cy.findByPlaceholderText("Enter a default value...").type(value);
-    cy.button("Add filter").click();
-  }
-}
-
-function mapFieldFilterTo({ table, field } = {}) {
-  popover()
-    .contains(table)
-    .click();
-  popover()
-    .contains(field)
-    .click();
-}
-
-function setFilterWidgetType(type) {
-  cy.findByText("Filter widget type")
-    .parent()
-    .find(".AdminSelect")
-    .click();
-  popover()
-    .findByText(type)
-    .click();
-}
-
-function setFieldFilterWidgetValue(value) {
-  cy.get("fieldset").click();
-
-  if (Array.isArray(value)) {
-    setBetweenFilterValue(value);
-  } else {
-    popover()
-      .find("input")
-      .type(value);
-    cy.button("Add filter").click();
-  }
-}
-
-function setBetweenFilterValue([low, high] = []) {
-  popover().within(() => {
-    cy.get("input")
-      .first()
-      .type(low);
-    cy.get("input")
-      .last()
-      .type(high);
-  });
-  cy.button("Add filter").click();
-}

--- a/frontend/test/metabase/scenarios/filters/sql-field-filter-string.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/sql-field-filter-string.cy.spec.js
@@ -1,11 +1,11 @@
 import {
   restore,
-  popover,
   mockSessionProperty,
   openNativeEditor,
 } from "__support__/e2e/cypress";
 
 import * as SQLFilter from "./helpers/e2e-sql-filter-helpers";
+import * as FieldFilter from "./helpers/e2e-field-filter-helpers";
 
 const STRING_FILTER_SUBTYPES = {
   String: {
@@ -51,7 +51,7 @@ describe("scenarios > filters > sql filters > field filter > String", () => {
     SQLFilter.openTypePickerFromDefaultFilterType();
     SQLFilter.chooseType("Field Filter");
 
-    mapFieldFilterTo({
+    FieldFilter.mapTo({
       table: "Products",
       field: "Title",
     });
@@ -61,9 +61,10 @@ describe("scenarios > filters > sql filters > field filter > String", () => {
     ([subType, { term, representativeResult }]) => {
       describe(`should work for ${subType}`, () => {
         it("when set through the filter widget", () => {
-          setFilterWidgetType(subType);
+          FieldFilter.setWidgetType(subType);
 
-          setFieldFilterWidgetValue(term);
+          FieldFilter.openEntryForm();
+          FieldFilter.addWidgetStringFilter(term);
 
           SQLFilter.runQuery();
 
@@ -73,10 +74,12 @@ describe("scenarios > filters > sql filters > field filter > String", () => {
         });
 
         it("when set as the default value for a required filter", () => {
-          setFilterWidgetType(subType);
+          FieldFilter.setWidgetType(subType);
 
           SQLFilter.toggleRequired();
-          setRequiredFieldFilterDefaultValue(term);
+
+          FieldFilter.openEntryForm({ isFilterRequired: true });
+          FieldFilter.addDefaultStringFilter(term);
 
           SQLFilter.runQuery();
 
@@ -88,36 +91,3 @@ describe("scenarios > filters > sql filters > field filter > String", () => {
     },
   );
 });
-
-function setRequiredFieldFilterDefaultValue(value) {
-  cy.findByText("Enter a default value...").click();
-  cy.findByPlaceholderText("Enter a default value...").type(value);
-  cy.button("Add filter").click();
-}
-
-function mapFieldFilterTo({ table, field } = {}) {
-  popover()
-    .contains(table)
-    .click();
-  popover()
-    .contains(field)
-    .click();
-}
-
-function setFilterWidgetType(type) {
-  cy.findByText("Filter widget type")
-    .parent()
-    .find(".AdminSelect")
-    .click();
-  popover()
-    .findByText(type)
-    .click();
-}
-
-function setFieldFilterWidgetValue(string) {
-  cy.get("fieldset").click();
-  popover()
-    .find("input")
-    .type(string);
-  cy.button("Add filter").click();
-}


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Extracts SQL field filter helpers into a separate file according to [this doc](https://www.notion.so/Proposal-Folder-level-Helper-Functions-e923ea2ea7ab4746bd67c24f06eb0494)
- Annotates them using JSDoc
- Imports said filters namespaced as `FieldFilter`
- Applies said filters to the related specs

### Non-goals
- Remaining helper functions that are related to the "date filters".
    - Those will be tackled in the follow-up PR

