### PR TITLE
[SQL filters coverage] Extract and apply date filter helpers

### DIFF
--- a/frontend/test/metabase/scenarios/filters/helpers/e2e-date-filter-helpers.js
+++ b/frontend/test/metabase/scenarios/filters/helpers/e2e-date-filter-helpers.js
@@ -1,0 +1,62 @@
+import { popover } from "__support__/e2e/cypress";
+
+const currentYearString = new Date().getFullYear().toString();
+
+export function setMonthAndYear({ month, year } = {}) {
+  cy.findByText(currentYearString).click();
+
+  cy.findByText(year).click();
+  cy.findByText(month).click();
+}
+
+export function setQuarterAndYear({ quarter, year } = {}) {
+  cy.findByText(currentYearString).click();
+
+  cy.findByText(year).click();
+  cy.findByText(quarter).click();
+}
+
+export function setSingleDate(day) {
+  cy.findByText(day).click();
+}
+
+export function setDateRange({ startDate, endDate } = {}) {
+  cy.findByText(startDate).click();
+  cy.findByText(endDate).click();
+}
+
+export function setRelativeDate(term) {
+  cy.findByText(term).click();
+}
+
+export function setAdHocFilter({ condition, quantity, timeBucket } = {}) {
+  if (condition) {
+    cy.get(".AdminSelect")
+      .contains("Previous")
+      .click();
+
+    popover()
+      .last()
+      .contains(condition)
+      .click();
+  }
+
+  if (quantity) {
+    cy.findByPlaceholderText("30")
+      .clear()
+      .type(quantity);
+  }
+
+  if (timeBucket) {
+    cy.get(".AdminSelect")
+      .contains("Days")
+      .click();
+
+    popover()
+      .last()
+      .contains(timeBucket)
+      .click();
+  }
+
+  cy.button("Update filter").click();
+}

--- a/frontend/test/metabase/scenarios/filters/sql-field-filter-date.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/sql-field-filter-date.cy.spec.js
@@ -87,6 +87,8 @@ describe("scenarios > filters > sql filters > field filter > Date", () => {
         });
 
         it("when set as the default value for a required filter", () => {
+          SQLFilter.toggleRequired();
+
           dateFilterSelector({
             filterType: subType,
             filterValue: value,
@@ -105,8 +107,6 @@ describe("scenarios > filters > sql filters > field filter > Date", () => {
 });
 
 function openDateFilterPicker(isFilterRequired) {
-  isFilterRequired && SQLFilter.toggleRequired();
-
   const selector = isFilterRequired
     ? cy.findByText("Select a default value…")
     : cy.get("fieldset");

--- a/frontend/test/metabase/scenarios/filters/sql-field-filter-date.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/sql-field-filter-date.cy.spec.js
@@ -2,13 +2,11 @@ import {
   restore,
   mockSessionProperty,
   openNativeEditor,
-  popover,
 } from "__support__/e2e/cypress";
 
 import * as SQLFilter from "./helpers/e2e-sql-filter-helpers";
 import * as FieldFilter from "./helpers/e2e-field-filter-helpers";
-
-const currentYearString = new Date().getFullYear().toString();
+import * as DateFilter from "./helpers/e2e-date-filter-helpers";
 
 const DATE_FILTER_SUBTYPES = {
   "Month and Year": {
@@ -106,61 +104,6 @@ describe("scenarios > filters > sql filters > field filter > Date", () => {
   );
 });
 
-function setMonthAndYearFilter({ month, year } = {}) {
-  cy.findByText(currentYearString).click();
-  cy.findByText(year).click();
-  cy.findByText(month).click();
-}
-
-function setQuarterAndYearFilter({ quarter, year } = {}) {
-  cy.findByText(currentYearString).click();
-  cy.findByText(year).click();
-  cy.findByText(quarter).click();
-}
-
-function setSingleDateFilter(day) {
-  cy.findByText(day).click();
-}
-
-function setDateRangeFilter({ startDate, endDate } = {}) {
-  cy.findByText(startDate).click();
-  cy.findByText(endDate).click();
-}
-
-function setRelativeDateFilter(term) {
-  cy.findByText(term).click();
-}
-
-function setDateFilter({ condition, quantity, timeBucket } = {}) {
-  if (condition) {
-    cy.get(".AdminSelect")
-      .contains("Previous")
-      .click();
-    popover()
-      .last()
-      .contains(condition)
-      .click();
-  }
-
-  if (quantity) {
-    cy.findByPlaceholderText("30")
-      .clear()
-      .type(quantity);
-  }
-
-  if (timeBucket) {
-    cy.get(".AdminSelect")
-      .contains("Days")
-      .click();
-    popover()
-      .last()
-      .contains(timeBucket)
-      .click();
-  }
-
-  cy.button("Update filter").click();
-}
-
 function openDateFilterPicker(isFilterRequired) {
   isFilterRequired && SQLFilter.toggleRequired();
 
@@ -180,27 +123,27 @@ function dateFilterSelector({
 
   switch (filterType) {
     case "Month and Year":
-      setMonthAndYearFilter(filterValue);
+      DateFilter.setMonthAndYear(filterValue);
       break;
 
     case "Quarter and Year":
-      setQuarterAndYearFilter(filterValue);
+      DateFilter.setQuarterAndYear(filterValue);
       break;
 
     case "Single Date":
-      setSingleDateFilter(filterValue);
+      DateFilter.setSingleDate(filterValue);
       break;
 
     case "Date Range":
-      setDateRangeFilter(filterValue);
+      DateFilter.setDateRange(filterValue);
       break;
 
     case "Relative Date":
-      setRelativeDateFilter(filterValue);
+      DateFilter.setRelativeDate(filterValue);
       break;
 
     case "Date Filter":
-      setDateFilter(filterValue);
+      DateFilter.setAdHocFilter(filterValue);
       break;
 
     default:


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Extracts basic SQL field filter **date** helpers into a separate file according to [this doc](https://www.notion.so/Proposal-Folder-level-Helper-Functions-e923ea2ea7ab4746bd67c24f06eb0494)
- Annotates them using JSDoc
- Imports said filters namespaced as `DateFilter`
- Applies said filters to the related specs

