### PR TITLE
Fix data picker initial state

### DIFF
--- a/frontend/src/metabase/components/select-list/SelectList.jsx
+++ b/frontend/src/metabase/components/select-list/SelectList.jsx
@@ -10,7 +10,7 @@ const propTypes = {
 
 export function SelectList({ children, className }) {
   return (
-    <ul role="menu" className={className}>
+    <ul role="menu" className={className} data-testid="select-list">
       {children}
     </ul>
   );

--- a/frontend/src/metabase/components/select-list/SelectListItem.styled.jsx
+++ b/frontend/src/metabase/components/select-list/SelectListItem.styled.jsx
@@ -35,6 +35,12 @@ export const ItemRoot = styled.li`
   cursor: pointer;
   padding: ${props => VERTICAL_PADDING_BY_SIZE[props.size]} 0.5rem;
   border-radius: 6px;
+  margin-bottom: 2px;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+
   ${props => props.isSelected && activeItemCss}
 
   &:hover {

--- a/frontend/src/metabase/components/tree/Tree.jsx
+++ b/frontend/src/metabase/components/tree/Tree.jsx
@@ -2,6 +2,7 @@ import React, { useState, useCallback } from "react";
 import PropTypes from "prop-types";
 import { TreeNodeList } from "./TreeNodeList";
 import { TreeNode } from "./TreeNode";
+import { getInitialExpandedIds } from "./utils";
 
 const propTypes = {
   TreeNodeComponent: PropTypes.object,
@@ -18,7 +19,9 @@ export function Tree({
   selectedId,
   variant = "default",
 }) {
-  const [expandedIds, setExpandedIds] = useState(new Set());
+  const [expandedIds, setExpandedIds] = useState(
+    new Set(selectedId != null ? getInitialExpandedIds(selectedId, data) : []),
+  );
 
   const handleToggleExpand = useCallback(
     itemId => {

--- a/frontend/src/metabase/components/tree/utils.jsx
+++ b/frontend/src/metabase/components/tree/utils.jsx
@@ -1,0 +1,13 @@
+export const getInitialExpandedIds = (selectedId, nodes) =>
+  nodes
+    .map(node => {
+      if (node.id === selectedId) {
+        return [node.id];
+      }
+
+      if (node.children) {
+        const path = getInitialExpandedIds(selectedId, node.children);
+        return path.length > 0 ? [node.id, ...path] : [];
+      }
+    })
+    .flat();

--- a/frontend/src/metabase/query_builder/components/data-search/utils.js
+++ b/frontend/src/metabase/query_builder/components/data-search/utils.js
@@ -15,7 +15,6 @@ export function convertSearchResultToTableLikeItem(searchResultItem) {
 
 export function isSavedQuestion(tableId) {
   return (
-    typeof tableId === "string" &&
-    tableId.indexOf(SAVED_QUESTION_ID_PREFIX) === 0
+    typeof tableId === "string" && tableId.startsWith(SAVED_QUESTION_ID_PREFIX)
   );
 }

--- a/frontend/src/metabase/query_builder/components/data-search/utils.js
+++ b/frontend/src/metabase/query_builder/components/data-search/utils.js
@@ -12,3 +12,10 @@ export function convertSearchResultToTableLikeItem(searchResultItem) {
 
   return searchResultItem;
 }
+
+export function isSavedQuestion(tableId) {
+  return (
+    typeof tableId === "string" &&
+    tableId.indexOf(SAVED_QUESTION_ID_PREFIX) === 0
+  );
+}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx
@@ -30,7 +30,11 @@ function DataStep({ color, query, databases, updateQuery }) {
               {t`Pick your starting data`}
             </NotebookCellItem>
           ) : (
-            <NotebookCellItem color={color} icon="table2">
+            <NotebookCellItem
+              color={color}
+              icon="table2"
+              data-testid="data-step-cell"
+            >
               {table && table.displayName()}
             </NotebookCellItem>
           )

--- a/frontend/src/metabase/query_builder/components/saved-question-picker/SavedQuestionList.jsx
+++ b/frontend/src/metabase/query_builder/components/saved-question-picker/SavedQuestionList.jsx
@@ -18,7 +18,7 @@ const propTypes = {
   onSelect: PropTypes.func.isRequired,
   selectedId: PropTypes.string,
   collection: PropTypes.shape({
-    id: PropTypes.oneOf([
+    id: PropTypes.oneOfType([
       PropTypes.string.isRequired,
       PropTypes.number.isRequired,
     ]),

--- a/frontend/src/metabase/query_builder/components/saved-question-picker/SavedQuestionPicker.jsx
+++ b/frontend/src/metabase/query_builder/components/saved-question-picker/SavedQuestionPicker.jsx
@@ -23,7 +23,7 @@ import {
   CollectionsContainer,
   BackButton,
 } from "./SavedQuestionPicker.styled";
-import { buildCollectionTree } from "./utils";
+import { buildCollectionTree, findCollectionByName } from "./utils";
 
 const propTypes = {
   onSelect: PropTypes.func.isRequired,
@@ -32,6 +32,7 @@ const propTypes = {
   currentUser: PropTypes.object.isRequired,
   databaseId: PropTypes.string,
   tableId: PropTypes.string,
+  collectionName: PropTypes.string,
 };
 
 const OUR_ANALYTICS_COLLECTION = {
@@ -51,18 +52,8 @@ function SavedQuestionPicker({
   currentUser,
   databaseId,
   tableId,
+  collectionName,
 }) {
-  const [selectedCollection, setSelectedCollection] = useState(
-    OUR_ANALYTICS_COLLECTION,
-  );
-
-  const handleSelect = useCallback(collection => {
-    if (collection.id === PERSONAL_COLLECTIONS.id) {
-      return;
-    }
-    setSelectedCollection(collection);
-  }, []);
-
   const collectionTree = useMemo(() => {
     const preparedCollections = [];
     const userPersonalCollections = currentUserPersonalCollections(
@@ -96,6 +87,23 @@ function SavedQuestionPicker({
       ...buildCollectionTree(preparedCollections),
     ];
   }, [collections, currentUser]);
+
+  const initialCollection = useMemo(
+    () => findCollectionByName(collectionTree, collectionName),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+
+  const [selectedCollection, setSelectedCollection] = useState(
+    initialCollection || OUR_ANALYTICS_COLLECTION,
+  );
+
+  const handleSelect = useCallback(collection => {
+    if (collection.id === PERSONAL_COLLECTIONS.id) {
+      return;
+    }
+    setSelectedCollection(collection);
+  }, []);
 
   return (
     <SavedQuestionPickerRoot>

--- a/frontend/src/metabase/query_builder/components/saved-question-picker/utils.js
+++ b/frontend/src/metabase/query_builder/components/saved-question-picker/utils.js
@@ -22,3 +22,23 @@ export function buildCollectionTree(collections) {
     children: buildCollectionTree(collection.children),
   }));
 }
+
+export const findCollectionByName = (collections, name) => {
+  if (!collections || collections.length === 0) {
+    return null;
+  }
+
+  const collection = collections.find(c => c.schemaName === name);
+
+  if (collection) {
+    return collection;
+  }
+
+  return findCollectionByName(
+    collections
+      .map(c => c.children)
+      .filter(Boolean)
+      .flat(),
+    name,
+  );
+};

--- a/frontend/src/metabase/schema.js
+++ b/frontend/src/metabase/schema.js
@@ -101,6 +101,7 @@ CollectionSchema.define({
 });
 
 export const parseSchemaId = id => String(id || "").split(":");
+export const getSchemaName = id => parseSchemaId(id)[1];
 export const generateSchemaId = (dbId, schemaName) =>
   `${dbId}:${schemaName || ""}`;
 

--- a/frontend/test/metabase/components/Tree.unit.spec.js
+++ b/frontend/test/metabase/components/Tree.unit.spec.js
@@ -25,7 +25,7 @@ const data = [
 ];
 
 describe("Tree", () => {
-  it("should render items", () => {
+  it("should render collapsed items when selectedId is not specified", () => {
     const { getAllByRole, queryByText } = render(
       <Tree data={data} onSelect={jest.fn()} />,
     );
@@ -33,6 +33,16 @@ describe("Tree", () => {
     expect(queryByText("Item 1")).not.toBeNull();
     expect(queryByText("Item 2")).not.toBeNull();
     expect(queryByText("Item 3")).toBeNull();
+  });
+
+  it("expands tree to the selected item", () => {
+    const { getAllByRole, queryByText } = render(
+      <Tree data={data} onSelect={jest.fn()} selectedId={3} />,
+    );
+    expect(getAllByRole("menuitem")).toHaveLength(3);
+    expect(queryByText("Item 1")).not.toBeNull();
+    expect(queryByText("Item 2")).not.toBeNull();
+    expect(queryByText("Item 3")).not.toBeNull();
   });
 
   it("should render expand and collapse items with children", () => {

--- a/frontend/test/metabase/scenarios/question/new.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/new.cy.spec.js
@@ -225,6 +225,17 @@ describe("scenarios > question > new", () => {
         cy.button("Visualize").click();
         cy.findByText("2018");
       });
+
+      it("should reopen saved question picker after returning back to editor mode", () => {
+        cy.findByText("Orders, Count, Grouped by Created At (year)").click();
+        cy.button("Visualize").click();
+        cy.icon("notebook").click();
+        cy.findByTestId("data-step-cell").click();
+
+        cy.findByTestId("select-list").within(() => {
+          cy.findByText("Orders, Count, Grouped by Created At (year)");
+        });
+      });
     });
   });
 


### PR DESCRIPTION
### Description

The issue existed even before the newly added saved question picker.

#### Steps to reproduce:
- Ask a simple question
- Select any saved question
- After the visualization is rendered press "Show editor"
<img width="421" alt="Screen Shot 2021-07-06 at 00 25 30" src="https://user-images.githubusercontent.com/14301985/124518985-ae3c2980-ddf0-11eb-92c7-2e6beb4b84fd.png">
- Open the data picker again

Before this PR:
It opened the list of tables from the database is used in the selected saved question

After this PR:
It opens the saved question picker with the question selected
