### PR TITLE
[SQL filters coverage] Simplify `openEntryForm` function

### DIFF
--- a/frontend/test/metabase/scenarios/filters/helpers/e2e-field-filter-helpers.js
+++ b/frontend/test/metabase/scenarios/filters/helpers/e2e-field-filter-helpers.js
@@ -1,5 +1,4 @@
 import { filterWidget, popover } from "__support__/e2e/cypress";
-import { toggleRequired } from "./e2e-sql-filter-helpers";
 
 // FILTER WIDGET TYPE
 
@@ -87,13 +86,12 @@ export function mapTo({ table, field } = {}) {
 }
 
 /**
- * Opens a field filter entry form. Entry type (input, picker) depends on the underlying field filter type.
+ * Opens a field filter entry form.
+ * Entry type that it opens (input, picker) depends on the underlying field filter type.
  *
  * @param {boolean} isFilterRequired
  */
 export function openEntryForm(isFilterRequired) {
-  isFilterRequired && toggleRequired();
-
   const selector = isFilterRequired
     ? cy.findByText("Enter a default value...")
     : filterWidget();


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Simplifies `openEntryForm` helper function
- Fixes `frontend/test/metabase/scenarios/filters/sql-field-filter-string.cy.spec.js` and `frontend/test/metabase/scenarios/filters/sql-field-filter-number.cy.spec.js`

### Additional context:
This function was toggling the required filter once again, turning it off.

```javascript
SQLFilter.toggleRequired(); // toggle required on

FieldFilter.openEntryForm({ isFilterRequired: true }); // now this function simply opens the entry form as its name suggests, without messing with the required filter toggle
```