### PR TITLE
[SQL filters coverage] Group reproductions

### DIFF
--- a/frontend/test/metabase/scenarios/filters/reproductions/11480.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/reproductions/11480.cy.spec.js
@@ -1,0 +1,38 @@
+import { restore, openNativeEditor } from "__support__/e2e/cypress";
+
+import * as SQLFilter from "../helpers/e2e-sql-filter-helpers";
+
+describe("issue 11480", () => {
+  beforeEach(() => {
+    cy.intercept("POST", "/api/dataset").as("dataset");
+
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should clear a template tag's default value when the type changes (metabase#11480)", () => {
+    openNativeEditor();
+    // Parameter `x` defaults to a text parameter.
+    SQLFilter.enterParameterizedQuery(
+      "select * from orders where total = {{x}}",
+    );
+
+    // Mark field as required and add a default text value.
+    SQLFilter.toggleRequired();
+    SQLFilter.setDefaultValue("some text");
+
+    // Run the query and see an error.
+    SQLFilter.runQuery();
+    cy.contains(`Data conversion error converting "some text"`);
+
+    // Oh wait! That doesn't match the total column, so we'll change the parameter to a number.
+    SQLFilter.openTypePickerFromDefaultFilterType();
+    SQLFilter.chooseType("Number");
+
+    // When we run it again, the default has been cleared out so we get the right error.
+    SQLFilter.runQuery();
+    cy.contains(
+      "You'll need to pick a value for 'X' before this query can run.",
+    );
+  });
+});

--- a/frontend/test/metabase/scenarios/filters/reproductions/11580.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/reproductions/11580.cy.spec.js
@@ -1,0 +1,44 @@
+import { restore, openNativeEditor } from "__support__/e2e/cypress";
+
+import * as SQLFilter from "../helpers/e2e-sql-filter-helpers";
+
+describe("issue 11580", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("shouldn't reorder template tags when updated (metabase#11580)", () => {
+    openNativeEditor();
+    SQLFilter.enterParameterizedQuery("{{foo}} {{bar}}");
+
+    cy.findByTestId("sidebar-right")
+      .find(".text-brand")
+      .as("variableLabels");
+
+    // ensure they're in the right order to start
+    assertVariablesOrder();
+
+    // change the parameter to a number.
+    cy.contains("Variable type")
+      .first()
+      .next()
+      .as("variableType")
+      .click();
+    SQLFilter.chooseType("Number");
+
+    cy.get("@variableType").should("have.text", "Number");
+
+    // ensure they're still in the right order
+    assertVariablesOrder();
+  });
+});
+
+function assertVariablesOrder() {
+  cy.get("@variableLabels")
+    .first()
+    .should("have.text", "foo");
+  cy.get("@variableLabels")
+    .last()
+    .should("have.text", "bar");
+}

--- a/frontend/test/metabase/scenarios/filters/reproductions/12228.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/reproductions/12228.cy.spec.js
@@ -1,0 +1,38 @@
+import { restore } from "__support__/e2e/cypress";
+import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
+
+const { ORDERS } = SAMPLE_DATASET;
+
+const filter = {
+  id: "6b8b10ef-0104-1047-1e1b-2492d5954322",
+  name: "created_at",
+  "display-name": "Created at",
+  type: "dimension",
+  dimension: ["field", ORDERS.CREATED_AT, null],
+  "widget-type": "date/month-year",
+};
+
+const nativeQuery = {
+  name: "12228",
+  native: {
+    query: "select count(*) from orders where {{created_at}}",
+    "template-tags": {
+      created_at: filter,
+    },
+  },
+  display: "scalar",
+};
+
+describe("issue 12228", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("can load a question with a date filter (metabase#12228)", () => {
+    cy.createNativeQuestion(nativeQuery).then(response => {
+      cy.visit(`/question/${response.body.id}?created_at=2020-01`);
+      cy.contains("580");
+    });
+  });
+});

--- a/frontend/test/metabase/scenarios/filters/reproductions/12581.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/reproductions/12581.cy.spec.js
@@ -1,0 +1,72 @@
+import { restore, modal, filterWidget } from "__support__/e2e/cypress";
+import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
+
+const { ORDERS } = SAMPLE_DATASET;
+
+const ORIGINAL_QUERY = "SELECT * FROM ORDERS WHERE {{filter}} LIMIT 2";
+
+const filter = {
+  id: "a3b95feb-b6d2-33b6-660b-bb656f59b1d7",
+  name: "filter",
+  "display-name": "Filter",
+  type: "dimension",
+  dimension: ["field", ORDERS.CREATED_AT, null],
+  "widget-type": "date/month-year",
+  default: null,
+};
+
+const nativeQuery = {
+  name: "12581",
+  native: {
+    query: ORIGINAL_QUERY,
+    "template-tags": {
+      filter,
+    },
+  },
+};
+
+describe("issue 12581", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.createNativeQuestion(nativeQuery).then(({ body }) => {
+      cy.visit(`/question/${body.id}`);
+    });
+  });
+
+  it("should correctly display a revision state after a restore (metabase#12581)", () => {
+    // Start with the original version of the question made with API
+    cy.findByText(/Open Editor/i).click();
+    cy.findByText(/Open Editor/i).should("not.exist");
+
+    // Both delay and a repeated sequence of `{selectall}{backspace}` are there to prevent typing flakes
+    // Without them at least 1 in 10 test runs locally didn't fully clear the field or type correctly
+    cy.get(".ace_content")
+      .as("editor")
+      .click()
+      .type("{selectall}{backspace}", { delay: 50 });
+    cy.get("@editor")
+      .click()
+      .type("{selectall}{backspace}SELECT * FROM ORDERS");
+
+    cy.findByText("Save").click();
+    modal().within(() => {
+      cy.button("Save").click();
+    });
+
+    cy.reload();
+
+    cy.icon("pencil").click();
+    cy.findByText(/View revision history/i).click();
+    cy.findByText(/Revert/i).click(); // Revert to the first revision
+    cy.findByText(/Open Editor/i).click();
+
+    cy.log("Reported failing on v0.35.3");
+    cy.get("@editor")
+      .should("be.visible")
+      .contains(ORIGINAL_QUERY);
+    // Filter dropdown field
+    filterWidget().contains("Filter");
+  });
+});

--- a/frontend/test/metabase/scenarios/filters/reproductions/13961.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/reproductions/13961.cy.spec.js
@@ -1,0 +1,78 @@
+import { restore } from "__support__/e2e/cypress";
+import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
+
+const { PRODUCTS } = SAMPLE_DATASET;
+
+const categoryFilter = {
+  id: "00315d5e-4a41-99da-1a41-e5254dacff9d",
+  name: "category",
+  "display-name": "Category",
+  type: "dimension",
+  default: "Doohickey",
+  dimension: ["field", PRODUCTS.CATEGORY, null],
+  "widget-type": "category",
+};
+
+const productIdFilter = {
+  id: "4775bccc-e82a-4069-fc6b-2acc90aadb8b",
+  name: "prodid",
+  "display-name": "ProdId",
+  type: "number",
+  default: null,
+};
+
+const nativeQuery = {
+  name: "13961",
+  native: {
+    query:
+      "SELECT * FROM PRODUCTS WHERE 1=1 AND {{category}} [[AND ID={{prodid}}]]",
+    "template-tags": {
+      category: categoryFilter,
+      prodid: productIdFilter,
+    },
+  },
+};
+
+describe.skip("issue 13961", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.createNativeQuestion(nativeQuery).then(({ body }) => {
+      cy.intercept("POST", `/api/card/${body.id}/query`).as("cardQuery");
+
+      cy.visit(`/question/${body.id}`);
+      cy.wait("@cardQuery");
+    });
+  });
+
+  it("should clear default filter value in native questions (metabase#13961)", () => {
+    cy.findAllByText("Small Marble Shoes"); // Product ID 2, Doohickey
+
+    cy.location("search").should("eq", "?category=Doohickey");
+
+    // Remove default filter (category)
+    cy.get("fieldset .Icon-close").click();
+
+    cy.icon("play")
+      .first()
+      .should("be.visible")
+      .as("rerunQuestion")
+      .click();
+    cy.wait("@cardQuery");
+
+    cy.url().should("not.include", "?category=Doohickey");
+
+    // Add value `1` to the ID filter
+    cy.findByPlaceholderText(productIdFilter["display-name"]).type("1");
+
+    cy.get("@rerunQuestion").click();
+    cy.wait("@cardQuery");
+
+    cy.log("Reported tested and failing on v0.34.3 through v0.37.3");
+    cy.log("URL is correct at this point, but there are no results");
+
+    cy.location("search").should("eq", `?${productIdFilter.name}=1`);
+    cy.findByText("Rustic Paper Wallet"); // Product ID 1, Gizmo
+  });
+});

--- a/frontend/test/metabase/scenarios/filters/reproductions/14145.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/reproductions/14145.cy.spec.js
@@ -1,0 +1,71 @@
+import { restore } from "__support__/e2e/cypress";
+import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
+
+const { PRODUCTS } = SAMPLE_DATASET;
+
+const filter = {
+  id: "774521fb-e03f-3df1-f2ae-e952c97035e3",
+  name: "FILTER",
+  "display-name": "Filter",
+  type: "dimension",
+  dimension: ["field-id", PRODUCTS.CATEGORY],
+  "widget-type": "category",
+  default: null,
+};
+
+const nativeQuery = {
+  name: "14145",
+  native: {
+    query: "SELECT COUNT(*) FROM products WHERE {{filter}}",
+    "template-tags": {
+      filter,
+    },
+  },
+};
+
+describe.skip("issue 14145", () => {
+  beforeEach(() => {
+    cy.intercept("POST", "/api/dataset").as("dataset");
+
+    restore();
+    cy.signInAsAdmin();
+
+    cy.addH2SampleDataset({
+      name: "Sample2",
+      auto_run_queries: true,
+      is_full_sync: true,
+    });
+
+    cy.createNativeQuestion(nativeQuery).then(({ body }) => {
+      cy.visit(`/question/${body.id}`);
+    });
+  });
+
+  it("`field-id` should update when database source is changed (metabase#14145)", () => {
+    // Change the source from "Sample Dataset" to the other database
+    cy.findByText(/Open Editor/i).click();
+
+    cy.get(".GuiBuilder-data")
+      .as("source")
+      .contains("Sample Dataset")
+      .click();
+    cy.findByText("Sample2").click();
+
+    // First assert on the UI
+    cy.icon("variable").click();
+    cy.findByText(/Field to map to/)
+      .siblings("a")
+      .contains("Category");
+
+    // Rerun the query and assert on the dimension (field-id) that didn't change
+    cy.get(".NativeQueryEditor .Icon-play").click();
+
+    cy.wait("@dataset").then(xhr => {
+      const { dimension } = xhr.response.body.json_query.native[
+        "template-tags"
+      ].FILTER;
+
+      expect(dimension).not.to.contain(PRODUCTS.CATEGORY);
+    });
+  });
+});

--- a/frontend/test/metabase/scenarios/filters/reproductions/14302.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/reproductions/14302.cy.spec.js
@@ -1,0 +1,41 @@
+import { restore } from "__support__/e2e/cypress";
+
+const priceFilter = {
+  id: "39b51ccd-47a7-9df6-a1c5-371918352c79",
+  name: "PRICE",
+  "display-name": "Price",
+  type: "number",
+  default: "10",
+  required: true,
+};
+
+const nativeQuery = {
+  name: "14302",
+  native: {
+    query:
+      'SELECT "CATEGORY", COUNT(*)\nFROM "PRODUCTS"\nWHERE "PRICE" > {{PRICE}}\nGROUP BY "CATEGORY"',
+    "template-tags": {
+      PRICE: priceFilter,
+    },
+  },
+};
+
+describe("issue 14302", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.createNativeQuestion(nativeQuery).then(({ body }) => {
+      cy.intercept("POST", `/api/card/${body.id}/query`).as("cardQuery");
+
+      cy.visit(`/question/${body.id}`);
+      cy.wait("@cardQuery");
+    });
+  });
+
+  it("should not make the question dirty when there are no changes (metabase#14302)", () => {
+    cy.log("Reported on v0.37.5 - Regression since v0.37.0");
+
+    cy.findByText("Save").should("not.exist");
+  });
+});

--- a/frontend/test/metabase/scenarios/filters/reproductions/15163.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/reproductions/15163.cy.spec.js
@@ -1,0 +1,107 @@
+import { restore } from "__support__/e2e/cypress";
+import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
+import { USER_GROUPS } from "__support__/e2e/cypress_data";
+
+const { PRODUCTS } = SAMPLE_DATASET;
+const { COLLECTION_GROUP } = USER_GROUPS;
+
+const nativeFilter = {
+  id: "dd7f3e66-b659-7d1c-87b3-ab627317581c",
+  name: "cat",
+  "display-name": "Cat",
+  type: "dimension",
+  dimension: ["field-id", PRODUCTS.CATEGORY],
+  "widget-type": "category",
+  default: null,
+};
+
+const nativeQuery = {
+  name: "15163",
+  native: {
+    query: 'SELECT COUNT(*) FROM "PRODUCTS" WHERE {{cat}}',
+    "template-tags": {
+      cat: nativeFilter,
+    },
+  },
+};
+
+const dashboardFilter = {
+  name: "Category",
+  slug: "category",
+  id: "fd723065",
+  type: "category",
+};
+
+["nodata+nosql", "nosql"].forEach(test => {
+  describe.skip("issue 14302", () => {
+    beforeEach(() => {
+      cy.intercept("POST", "/api/dataset").as("dataset");
+
+      restore();
+      cy.signInAsAdmin();
+
+      cy.createNativeQuestion(nativeQuery).then(({ body: { id: card_id } }) => {
+        cy.createDashboard("15163D").then(({ body: { id: dashboard_id } }) => {
+          // Add filter to the dashboard
+          cy.request("PUT", `/api/dashboard/${dashboard_id}`, {
+            parameters: [dashboardFilter],
+          });
+
+          // Add previously created question to the dashboard
+          cy.request("POST", `/api/dashboard/${dashboard_id}/cards`, {
+            cardId: card_id,
+          }).then(({ body: { id } }) => {
+            // Connect filter to that question
+            cy.request("PUT", `/api/dashboard/${dashboard_id}/cards`, {
+              cards: [
+                {
+                  id,
+                  card_id,
+                  row: 0,
+                  col: 0,
+                  sizeX: 10,
+                  sizeY: 8,
+                  series: [],
+                  visualization_settings: {
+                    "card.title": "New Title",
+                  },
+                  parameter_mappings: [
+                    {
+                      parameter_id: dashboardFilter.id,
+                      card_id,
+                      target: ["dimension", ["template-tag", "cat"]],
+                    },
+                  ],
+                },
+              ],
+            });
+          });
+
+          if (test === "nosql") {
+            cy.updatePermissionsGraph({
+              [COLLECTION_GROUP]: {
+                "1": { schemas: "all", native: "none" },
+              },
+            });
+          }
+
+          cy.signIn("nodata");
+
+          // Visit dashboard and set the filter through URL
+          cy.visit(`/dashboard/${dashboard_id}?category=Gizmo`);
+        });
+      });
+    });
+
+    it(`${test.toUpperCase()} version:\n should be able to view SQL question when accessing via dashboard with filters connected to modified card without SQL permissions (metabase#15163)`, () => {
+      cy.findByText("New Title").click();
+
+      cy.wait("@dataset", { timeout: 5000 }).then(xhr => {
+        expect(xhr.response.body.error).not.to.exist;
+      });
+
+      cy.get(".ace_content").should("not.exist");
+      cy.findByText("Showing 1 row");
+    });
+  });
+});

--- a/frontend/test/metabase/scenarios/filters/reproductions/15444.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/reproductions/15444.cy.spec.js
@@ -1,0 +1,45 @@
+import { restore, openNativeEditor, popover } from "__support__/e2e/cypress";
+
+import * as SQLFilter from "../helpers/e2e-sql-filter-helpers";
+import * as FieldFilter from "../helpers/e2e-field-filter-helpers";
+
+describe("issue 15444", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.intercept("POST", "/api/dataset").as("dataset");
+  });
+
+  it("should run with the default field filter set (metabase#15444)", () => {
+    openNativeEditor();
+    SQLFilter.enterParameterizedQuery(
+      "select * from products where {{category}}",
+    );
+
+    SQLFilter.openTypePickerFromDefaultFilterType();
+    SQLFilter.chooseType("Field Filter");
+
+    FieldFilter.mapTo({
+      table: "Products",
+      field: "Category",
+    });
+
+    SQLFilter.toggleRequired();
+
+    FieldFilter.openEntryForm({ isFilterRequired: true });
+    // We could've used `FieldFilter.addDefaultStringFilter("Doohickey")` but that's been covered already in the filter test matrix.
+    // This flow tests the ability to pick the filter from a dropdown when there are not too many results (easy to choose from).
+    popover().within(() => {
+      cy.findByText("Doohickey").click();
+      cy.button("Add filter").click();
+    });
+
+    SQLFilter.runQuery();
+
+    cy.get(".Visualization").within(() => {
+      cy.findAllByText("Doohickey");
+      cy.findAllByText("Gizmo").should("not.exist");
+    });
+  });
+});

--- a/frontend/test/metabase/scenarios/filters/reproductions/15460.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/reproductions/15460.cy.spec.js
@@ -1,0 +1,67 @@
+import {
+  restore,
+  popover,
+  filterWidget,
+  visitQuestionAdhoc,
+} from "__support__/e2e/cypress";
+
+import * as SQLFilter from "../helpers/e2e-sql-filter-helpers";
+
+import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
+
+const { PRODUCTS } = SAMPLE_DATASET;
+
+const filter = {
+  id: "d98c3875-e0f1-9270-d36a-5b729eef938e",
+  name: "category",
+  "display-name": "Category",
+  type: "dimension",
+  dimension: ["field", PRODUCTS.CATEGORY, null],
+  "widget-type": "category/=",
+  default: null,
+};
+
+const questionQuery = {
+  dataset_query: {
+    database: 1,
+    native: {
+      query:
+        "select p.created_at, products.category\nfrom products\nleft join products p on p.id=products.id\nwhere {{category}}\n",
+      "template-tags": {
+        category: filter,
+      },
+    },
+    type: "native",
+  },
+};
+
+describe("issue 15460", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.intercept("POST", "/api/dataset").as("dataset");
+
+    visitQuestionAdhoc(questionQuery);
+    cy.wait("@dataset");
+  });
+
+  it("should be possible to use field filter on a query with joins where tables have similar columns (metabase#15460)", () => {
+    // Set the filter value by picking the value from the dropdown
+    filterWidget()
+      .contains(filter["display-name"])
+      .click();
+
+    popover().within(() => {
+      cy.findByText("Doohickey").click();
+      cy.button("Add filter").click();
+    });
+
+    SQLFilter.runQuery();
+
+    cy.get(".Visualization").within(() => {
+      cy.findAllByText("Doohickey");
+      cy.findAllByText("Gizmo").should("not.exist");
+    });
+  });
+});

--- a/frontend/test/metabase/scenarios/filters/reproductions/15700.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/reproductions/15700.cy.spec.js
@@ -1,0 +1,40 @@
+import {
+  restore,
+  mockSessionProperty,
+  openNativeEditor,
+} from "__support__/e2e/cypress";
+
+import * as SQLFilter from "../helpers/e2e-sql-filter-helpers";
+import * as FieldFilter from "../helpers/e2e-field-filter-helpers";
+
+["old", "new"].forEach(test => {
+  const isFeatureFlagTurnedOn = test === "old" ? false : true;
+  const widgetType = test === "old" ? "Category" : "String is not";
+
+  describe("issue 15700", () => {
+    beforeEach(() => {
+      restore();
+      cy.signInAsAdmin();
+
+      mockSessionProperty(
+        "field-filter-operators-enabled?",
+        isFeatureFlagTurnedOn,
+      );
+    });
+
+    it(`${test} syntax:\n should be able to select "Field Filter" category in native query (metabase#15700)`, () => {
+      openNativeEditor();
+      SQLFilter.enterParameterizedQuery("{{filter}}");
+
+      SQLFilter.openTypePickerFromDefaultFilterType();
+      SQLFilter.chooseType("Field Filter");
+
+      FieldFilter.mapTo({
+        table: "Products",
+        field: "Category",
+      });
+
+      FieldFilter.setWidgetType(widgetType);
+    });
+  });
+});

--- a/frontend/test/metabase/scenarios/filters/reproductions/15981.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/reproductions/15981.cy.spec.js
@@ -1,0 +1,58 @@
+import {
+  restore,
+  mockSessionProperty,
+  openNativeEditor,
+} from "__support__/e2e/cypress";
+
+import * as SQLFilter from "../helpers/e2e-sql-filter-helpers";
+
+["off", "on"].forEach(testCase => {
+  const isFeatureFlagTurnedOn = testCase === "off" ? false : true;
+
+  describe("issue 15981", () => {
+    beforeEach(() => {
+      restore();
+      cy.signInAsAdmin();
+
+      mockSessionProperty(
+        "field-filter-operators-enabled?",
+        isFeatureFlagTurnedOn,
+      );
+
+      openNativeEditor();
+
+      cy.intercept("POST", "/api/dataset").as("dataset");
+    });
+
+    it(`"Text" filter should work with the feature flag turned ${testCase} (metabase#15981-1)`, () => {
+      SQLFilter.enterParameterizedQuery(
+        "select * from PRODUCTS where CATEGORY = {{text_filter}}",
+      );
+
+      SQLFilter.setWidgetValue("Gizmo");
+
+      SQLFilter.runQuery();
+
+      cy.get(".Visualization").contains("Rustic Paper Wallet");
+
+      cy.icon("contract").click();
+      cy.findByText("Showing 51 rows");
+      cy.icon("play").should("not.exist");
+    });
+
+    it(`"Number" filter should work with the feature flag turned ${testCase} (metabase#15981-2)`, () => {
+      SQLFilter.enterParameterizedQuery(
+        "select * from ORDERS where QUANTITY = {{number_filter}}",
+      );
+
+      SQLFilter.openTypePickerFromDefaultFilterType();
+      SQLFilter.chooseType("Number");
+
+      SQLFilter.setWidgetValue("20");
+
+      SQLFilter.runQuery();
+
+      cy.get(".Visualization").contains("23.54");
+    });
+  });
+});

--- a/frontend/test/metabase/scenarios/filters/reproductions/16739.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/reproductions/16739.cy.spec.js
@@ -1,0 +1,47 @@
+import { restore, mockSessionProperty } from "__support__/e2e/cypress";
+import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
+
+const { PRODUCTS } = SAMPLE_DATASET;
+
+const filter = {
+  id: "7795c137-a46c-3db9-1930-1d690c8dbc03",
+  name: "filter",
+  "display-name": "Filter",
+  type: "dimension",
+  dimension: ["field", PRODUCTS.CATEGORY, null],
+  "widget-type": "string/=",
+  default: null,
+};
+
+describe("issue 16739", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    mockSessionProperty("field-filter-operators-enabled?", true);
+  });
+
+  ["normal", "nodata"].forEach(user => {
+    //Very related to the metabase#15981, only this time the issue happens with the "Field Filter" without the value being set.
+    it(`filter feature flag shouldn't cause run-overlay of results in native editor for ${user} user (metabase#16739)`, () => {
+      cy.createNativeQuestion({
+        native: {
+          query: "select * from PRODUCTS where {{ filter }}",
+          "template-tags": { filter },
+        },
+      }).then(({ body: { id } }) => {
+        cy.intercept("POST", `/api/card/${id}/query`).as("cardQuery");
+
+        if (user === "nodata") {
+          cy.signOut();
+          cy.signIn(user);
+        }
+
+        cy.visit(`/question/${id}`);
+        cy.wait("@cardQuery");
+      });
+
+      cy.icon("play").should("not.exist");
+    });
+  });
+});

--- a/frontend/test/metabase/scenarios/filters/reproductions/9357.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/reproductions/9357.cy.spec.js
@@ -1,0 +1,37 @@
+import { restore, openNativeEditor } from "__support__/e2e/cypress";
+import * as SQLFilter from "../helpers/e2e-sql-filter-helpers";
+
+describe("issue 9357", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should reorder template tags by drag and drop (metabase#9357)", () => {
+    openNativeEditor();
+    SQLFilter.enterParameterizedQuery(
+      "{{firstparameter}} {{nextparameter}} {{lastparameter}}",
+    );
+
+    // Drag the firstparameter to last position
+    cy.get("fieldset .Icon-empty")
+      .first()
+      .trigger("mousedown", 0, 0, { force: true })
+      .trigger("mousemove", 5, 5, { force: true })
+      .trigger("mousemove", 430, 0, { force: true })
+      .trigger("mouseup", 430, 0, { force: true });
+
+    // Ensure they're in the right order
+    cy.findAllByText("Variable name")
+      .parent()
+      .as("variableField");
+
+    cy.get("@variableField")
+      .first()
+      .findByText("nextparameter");
+
+    cy.get("@variableField")
+      .last()
+      .findByText("firstparameter");
+  });
+});

--- a/frontend/test/metabase/scenarios/native/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/native.cy.spec.js
@@ -151,36 +151,6 @@ describe("scenarios > question > native", () => {
     });
   });
 
-  it("should reorder template tags by drag and drop (metabase#9357)", () => {
-    openNativeEditor().type(
-      "{{firstparameter}} {{nextparameter}} {{lastparameter}}",
-      {
-        parseSpecialCharSequences: false,
-      },
-    );
-
-    // Drag the firstparameter to last position
-    cy.get("fieldset .Icon-empty")
-      .first()
-      .trigger("mousedown", 0, 0, { force: true })
-      .trigger("mousemove", 5, 5, { force: true })
-      .trigger("mousemove", 430, 0, { force: true })
-      .trigger("mouseup", 430, 0, { force: true });
-
-    // Ensure they're in the right order
-    cy.findAllByText("Variable name")
-      .parent()
-      .as("variableField");
-
-    cy.get("@variableField")
-      .first()
-      .findByText("nextparameter");
-
-    cy.get("@variableField")
-      .last()
-      .findByText("firstparameter");
-  });
-
   it("should be able to add new columns after hiding some (metabase#15393)", () => {
     openNativeEditor().type("select 1 as visible, 2 as hidden");
     cy.get(".NativeQueryEditor .Icon-play")

--- a/frontend/test/metabase/scenarios/native/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/native.cy.spec.js
@@ -521,42 +521,6 @@ describe("scenarios > question > native", () => {
     });
   });
 
-  it("should run with the default field filter set (metabase#15444)", () => {
-    cy.intercept("POST", "/api/dataset").as("dataset");
-
-    openNativeEditor().type("select * from products where {{category}}", {
-      parseSpecialCharSequences: false,
-    });
-    // Change filter type from "Text" to Field Filter
-    cy.get(".AdminSelect")
-      .contains("Text")
-      .click();
-    popover()
-      .findByText("Field Filter")
-      .click();
-    popover()
-      .findByText("Products")
-      .click();
-    popover()
-      .findByText("Category")
-      .click();
-    cy.findByText("Required?").scrollIntoView();
-    // Add the default value
-    cy.findByText("Enter a default value...").click();
-    popover()
-      .findByText("Doohickey")
-      .click();
-    cy.button("Add filter").click();
-    cy.get(".NativeQueryEditor .Icon-play").click();
-    cy.wait("@dataset").then(xhr => {
-      expect(xhr.response.body.error).not.to.exist;
-    });
-    cy.get(".Visualization").within(() => {
-      cy.findAllByText("Doohickey");
-      cy.findAllByText("Gizmo").should("not.exist");
-    });
-  });
-
   ["old", "new"].forEach(test => {
     it(`${test} syntax:\n should be able to select category Field Filter in Native query (metabase#15700)`, () => {
       if (test === "old") {

--- a/frontend/test/metabase/scenarios/native/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/native.cy.spec.js
@@ -33,39 +33,6 @@ describe("scenarios > question > native", () => {
     cy.contains('Table "ORD" not found');
   });
 
-  it("clears a template tag's default when the type changes", () => {
-    openNativeEditor()
-      // Write a query with parameter x. It defaults to a text parameter.
-      .type("select * from orders where total = {{x}}", {
-        parseSpecialCharSequences: false,
-      });
-
-    // Mark field as required and add a default text value.
-    cy.contains("Required?")
-      .next()
-      .click();
-    cy.contains("Default filter widget value")
-      .next()
-      .find("input")
-      .type("some text");
-
-    // Run the query and see an error.
-    cy.get(".NativeQueryEditor .Icon-play").click();
-    cy.contains(`Data conversion error converting "some text"`);
-
-    // Oh wait! That doesn't match the total column, so we'll change the parameter to a number.
-    cy.contains("Variable type")
-      .next()
-      .click();
-    cy.contains("Number").click();
-
-    // When we run it again, the default has been cleared out so we get the right error.
-    cy.get(".NativeQueryEditor .Icon-play").click();
-    cy.contains(
-      "You'll need to pick a value for 'X' before this query can run.",
-    );
-  });
-
   it("should show referenced cards in the template tag sidebar", () => {
     openNativeEditor()
       // start typing a question referenced

--- a/frontend/test/metabase/scenarios/native/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/native.cy.spec.js
@@ -419,64 +419,6 @@ describe("scenarios > question > native", () => {
     });
   });
 
-  it.skip("field id should update when database source is changed (metabase#14145)", () => {
-    cy.server();
-    cy.route("POST", "/api/dataset").as("dataset");
-    cy.signInAsAdmin();
-    // Add another H2 sample dataset DB
-    cy.request("POST", "/api/database", {
-      engine: "h2",
-      name: "Sample2",
-      details: {
-        db:
-          "zip:./target/uberjar/metabase.jar!/sample-dataset.db;USER=GUEST;PASSWORD=guest",
-      },
-      auto_run_queries: true,
-      is_full_sync: true,
-      schedules: {},
-    });
-
-    cy.createNativeQuestion({
-      name: "14145",
-      native: {
-        query: "SELECT COUNT(*) FROM PRODUCTS WHERE {{FILTER}}",
-        "template-tags": {
-          FILTER: {
-            id: "774521fb-e03f-3df1-f2ae-e952c97035e3",
-            name: "FILTER",
-            "display-name": "Filter",
-            type: "dimension",
-            dimension: ["field-id", PRODUCTS.CATEGORY],
-            "widget-type": "category",
-            default: null,
-          },
-        },
-      },
-    }).then(({ body: { id: QUESTION_ID } }) => {
-      cy.visit(`/question/${QUESTION_ID}`);
-    });
-    // Change the source from "Sample Dataset" to the other database
-    cy.findByText(/Open Editor/i).click();
-    cy.get(".GuiBuilder-data")
-      .as("source")
-      .contains("Sample Dataset")
-      .click();
-    cy.findByText("Sample2").click();
-    // First assert on the UI
-    cy.icon("variable").click();
-    cy.findByText(/Field to map to/)
-      .siblings("a")
-      .contains("Category");
-    // Rerun the query and assert on the dimension (field-id) that didn't change
-    cy.get(".NativeQueryEditor .Icon-play").click();
-    cy.wait("@dataset").then(xhr => {
-      const { dimension } = xhr.response.body.json_query.native[
-        "template-tags"
-      ].FILTER;
-      expect(dimension).not.to.contain(PRODUCTS.CATEGORY);
-    });
-  });
-
   it("should be able to add new columns after hiding some (metabase#15393)", () => {
     openNativeEditor().type("select 1 as visible, 2 as hidden");
     cy.get(".NativeQueryEditor .Icon-play")

--- a/frontend/test/metabase/scenarios/native/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/native.cy.spec.js
@@ -66,43 +66,6 @@ describe("scenarios > question > native", () => {
     );
   });
 
-  it("doesn't reorder template tags when updated", () => {
-    openNativeEditor().type("{{foo}} {{bar}}", {
-      parseSpecialCharSequences: false,
-    });
-
-    cy.contains("Variables")
-      .parent()
-      .parent()
-      .find(".text-brand")
-      .as("variableLabels");
-
-    // ensure they're in the right order to start
-    cy.get("@variableLabels")
-      .first()
-      .should("have.text", "foo");
-    cy.get("@variableLabels")
-      .last()
-      .should("have.text", "bar");
-
-    // change the parameter to a number.
-    cy.contains("Variable type")
-      .first()
-      .next()
-      .as("variableType");
-    cy.get("@variableType").click();
-    cy.contains("Number").click();
-    cy.get("@variableType").should("have.text", "Number");
-
-    // ensure they're still in the right order
-    cy.get("@variableLabels")
-      .first()
-      .should("have.text", "foo");
-    cy.get("@variableLabels")
-      .last()
-      .should("have.text", "bar");
-  });
-
   it("should show referenced cards in the template tag sidebar", () => {
     openNativeEditor()
       // start typing a question referenced

--- a/frontend/test/metabase/scenarios/native/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/native.cy.spec.js
@@ -3,7 +3,6 @@ import {
   popover,
   modal,
   filterWidget,
-  visitQuestionAdhoc,
   mockSessionProperty,
   openNativeEditor,
 } from "__support__/e2e/cypress";
@@ -476,41 +475,6 @@ describe("scenarios > question > native", () => {
         "template-tags"
       ].FILTER;
       expect(dimension).not.to.contain(PRODUCTS.CATEGORY);
-    });
-  });
-
-  ["old", "new"].forEach(test => {
-    it(`${test} syntax:\n should be able to select category Field Filter in Native query (metabase#15700)`, () => {
-      if (test === "old") {
-        mockSessionProperty("field-filter-operators-enabled?", false);
-      }
-      const widgetType = test === "old" ? "Category" : "String";
-
-      openNativeEditor().type("{{filter}}", {
-        parseSpecialCharSequences: false,
-      });
-      cy.findByText("Variable type")
-        .parent()
-        .findByText("Text")
-        .click();
-      popover()
-        .findByText("Field Filter")
-        .click();
-      popover().within(() => {
-        cy.findByText("Sample Dataset");
-        cy.findByText("Products").click();
-      });
-      popover()
-        .findByText("Category")
-        .click();
-      cy.findByText("Filter widget type")
-        .parent()
-        .find(".AdminSelect")
-        .findByText(widgetType)
-        .click();
-      popover()
-        .find(".List-section")
-        .should("have.length.gt", 1);
     });
   });
 

--- a/frontend/test/metabase/scenarios/native/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/native.cy.spec.js
@@ -252,56 +252,6 @@ describe("scenarios > question > native", () => {
     });
   });
 
-  it("should correctly display a revision state after a restore (metabase#12581)", () => {
-    const ORIGINAL_QUERY = "SELECT * FROM ORDERS WHERE {{filter}} LIMIT 2";
-
-    // Start with the original version of the question made with API
-    cy.createNativeQuestion({
-      name: "12581",
-      native: {
-        query: ORIGINAL_QUERY,
-        "template-tags": {
-          filter: {
-            id: "a3b95feb-b6d2-33b6-660b-bb656f59b1d7",
-            name: "filter",
-            "display-name": "Filter",
-            type: "dimension",
-            dimension: ["field", ORDERS.CREATED_AT, null],
-            "widget-type": "date/month-year",
-            default: null,
-          },
-        },
-      },
-    }).then(({ body: { id: QUESTION_ID } }) => {
-      cy.visit(`/question/${QUESTION_ID}`);
-    });
-    cy.findByText(/Open Editor/i).click();
-    cy.findByText(/Open Editor/i).should("not.exist");
-    // Both delay and a repeated sequence of `{selectall}{backspace}` are there to prevent typing flakes
-    // Without them at least 1 in 10 test runs locally didn't fully clear the field or type correctly
-    cy.get(".ace_content")
-      .click()
-      .type("{selectall}{backspace}", { delay: 50 });
-    cy.get(".ace_content")
-      .click()
-      .type("{selectall}{backspace}SELECT * FROM ORDERS");
-    cy.findByText("Save").click();
-    modal().within(() => {
-      cy.findByText("Save").click();
-    });
-
-    cy.reload();
-    cy.icon("pencil").click();
-    cy.findByText(/View revision history/i).click();
-    cy.findByText(/Revert/i).click(); // Revert to the first revision
-    cy.findByText(/Open Editor/i).click();
-
-    cy.log("Reported failing on v0.35.3");
-    cy.get(".ace_content").contains(ORIGINAL_QUERY);
-    // Filter dropdown field
-    filterWidget().contains("Filter");
-  });
-
   it("should reorder template tags by drag and drop (metabase#9357)", () => {
     openNativeEditor().type(
       "{{firstparameter}} {{nextparameter}} {{lastparameter}}",

--- a/frontend/test/metabase/scenarios/native/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/native.cy.spec.js
@@ -2,14 +2,8 @@ import {
   restore,
   popover,
   modal,
-  filterWidget,
   openNativeEditor,
 } from "__support__/e2e/cypress";
-import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
-import { USER_GROUPS } from "__support__/e2e/cypress_data";
-
-const { ORDERS, PRODUCTS } = SAMPLE_DATASET;
-const { COLLECTION_GROUP } = USER_GROUPS;
 
 describe("scenarios > question > native", () => {
   beforeEach(() => {
@@ -255,93 +249,6 @@ describe("scenarios > question > native", () => {
     cy.get("@variableField")
       .last()
       .findByText("firstparameter");
-  });
-
-  ["nodata+nosql", "nosql"].forEach(test => {
-    it.skip(`${test.toUpperCase()} version:\n should be able to view SQL question when accessing via dashboard with filters connected to modified card without SQL permissions (metabase#15163)`, () => {
-      cy.server();
-      cy.route("POST", "/api/dataset").as("dataset");
-
-      cy.signInAsAdmin();
-      cy.createNativeQuestion({
-        name: "15163",
-        native: {
-          query: 'SELECT COUNT(*) FROM "PRODUCTS" WHERE {{cat}}',
-          "template-tags": {
-            cat: {
-              id: "dd7f3e66-b659-7d1c-87b3-ab627317581c",
-              name: "cat",
-              "display-name": "Cat",
-              type: "dimension",
-              dimension: ["field-id", PRODUCTS.CATEGORY],
-              "widget-type": "category",
-              default: null,
-            },
-          },
-        },
-      }).then(({ body: { id: QUESTION_ID } }) => {
-        cy.createDashboard("15163D").then(({ body: { id: DASHBOARD_ID } }) => {
-          // Add filter to the dashboard
-          cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}`, {
-            parameters: [
-              {
-                name: "Category",
-                slug: "category",
-                id: "fd723065",
-                type: "category",
-              },
-            ],
-          });
-
-          // Add previously created question to the dashboard
-          cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
-            cardId: QUESTION_ID,
-          }).then(({ body: { id: DASH_CARD_ID } }) => {
-            // Connect filter to that question
-            cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}/cards`, {
-              cards: [
-                {
-                  id: DASH_CARD_ID,
-                  card_id: QUESTION_ID,
-                  row: 0,
-                  col: 0,
-                  sizeX: 10,
-                  sizeY: 8,
-                  series: [],
-                  visualization_settings: {
-                    "card.title": "New Title",
-                  },
-                  parameter_mappings: [
-                    {
-                      parameter_id: "fd723065",
-                      card_id: QUESTION_ID,
-                      target: ["dimension", ["template-tag", "cat"]],
-                    },
-                  ],
-                },
-              ],
-            });
-          });
-
-          if (test === "nosql") {
-            cy.updatePermissionsGraph({
-              [COLLECTION_GROUP]: { "1": { schemas: "all", native: "none" } },
-            });
-          }
-
-          cy.signIn("nodata");
-
-          // Visit dashboard and set the filter through URL
-          cy.visit(`/dashboard/${DASHBOARD_ID}?category=Gizmo`);
-          cy.findByText("New Title").click();
-          cy.wait("@dataset", { timeout: 5000 }).then(xhr => {
-            expect(xhr.response.body.error).not.to.exist;
-          });
-          cy.get(".ace_content").should("not.exist");
-          cy.findByText("Showing 1 row");
-        });
-      });
-    });
   });
 
   it("should be able to add new columns after hiding some (metabase#15393)", () => {

--- a/frontend/test/metabase/scenarios/native/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/native.cy.spec.js
@@ -150,29 +150,6 @@ describe("scenarios > question > native", () => {
     cy.contains("18,760");
   });
 
-  it("can load a question with a date filter (from issue metabase#12228)", () => {
-    cy.createNativeQuestion({
-      name: "Test Question",
-      native: {
-        query: "select count(*) from orders where {{created_at}}",
-        "template-tags": {
-          created_at: {
-            id: "6b8b10ef-0104-1047-1e1b-2492d5954322",
-            name: "created_at",
-            "display-name": "Created at",
-            type: "dimension",
-            dimension: ["field", ORDERS.CREATED_AT, null],
-            "widget-type": "date/month-year",
-          },
-        },
-      },
-      display: "scalar",
-    }).then(response => {
-      cy.visit(`/question/${response.body.id}?created_at=2020-01`);
-      cy.contains("580");
-    });
-  });
-
   it("can save a question with no rows", () => {
     openNativeEditor().type("select * from people where false");
     cy.get(".NativeQueryEditor .Icon-play").click();

--- a/frontend/test/metabase/scenarios/native/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/native.cy.spec.js
@@ -3,7 +3,6 @@ import {
   popover,
   modal,
   filterWidget,
-  mockSessionProperty,
   openNativeEditor,
 } from "__support__/e2e/cypress";
 import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
@@ -492,62 +491,6 @@ describe("scenarios > question > native", () => {
     cy.get("@editor").type("{movetoend}, 3 as added");
     cy.get("@runQuery").click();
     cy.get("@sidebar").contains(/added/i);
-  });
-
-  ["off", "on"].forEach(testCase => {
-    const isFeatureFlagTurnedOn = testCase === "off" ? false : true;
-
-    describe("Feature flag causes problems with Text and Number filters in Native query (metabase#15981)", () => {
-      beforeEach(() => {
-        mockSessionProperty(
-          "field-filter-operators-enabled?",
-          isFeatureFlagTurnedOn,
-        );
-
-        cy.intercept("POST", "/api/dataset").as("dataset");
-      });
-
-      it(`text filter should work with the feature flag turned ${testCase}`, () => {
-        openNativeEditor().type(
-          "select * from PRODUCTS where CATEGORY = {{text_filter}}",
-          {
-            parseSpecialCharSequences: false,
-          },
-        );
-        filterWidget().type("Gizmo");
-        cy.get(".NativeQueryEditor .Icon-play").click();
-        cy.wait("@dataset");
-        cy.findByText("Rustic Paper Wallet");
-        cy.icon("contract").click();
-        cy.findByText("Showing 51 rows");
-        cy.icon("play").should("not.exist");
-      });
-
-      it(`number filter should work with the feature flag turned ${testCase}`, () => {
-        openNativeEditor().type(
-          "select * from ORDERS where QUANTITY = {{number_filter}}",
-          {
-            parseSpecialCharSequences: false,
-          },
-        );
-        cy.findByTestId("sidebar-right")
-          .as("sidebar")
-          .within(() => {
-            cy.get(".AdminSelect")
-              .contains("Text")
-              .click();
-          });
-        popover()
-          .contains("Number")
-          .click();
-        filterWidget().type("20");
-        cy.get(".NativeQueryEditor .Icon-play").click();
-        cy.wait("@dataset").then(xhr => {
-          expect(xhr.response.body.error).not.to.exist;
-        });
-        cy.get(".Visualization").contains("23.54");
-      });
-    });
   });
 
   ["normal", "nodata"].forEach(user => {

--- a/frontend/test/metabase/scenarios/native/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/native.cy.spec.js
@@ -493,42 +493,6 @@ describe("scenarios > question > native", () => {
     cy.get("@sidebar").contains(/added/i);
   });
 
-  ["normal", "nodata"].forEach(user => {
-    //Very related to the metabase#15981, only this time the issue happens with the Field Filter without the value being set.
-    it(`filter feature flag shouldn't cause run-overlay of results in native editor for ${user} user (metabase#16739)`, () => {
-      const filter = {
-        id: "7795c137-a46c-3db9-1930-1d690c8dbc03",
-        name: "filter",
-        "display-name": "Filter",
-        type: "dimension",
-        dimension: ["field", PRODUCTS.CATEGORY, null],
-        "widget-type": "string/=",
-        default: null,
-      };
-
-      mockSessionProperty("field-filter-operators-enabled?", true);
-
-      cy.createNativeQuestion({
-        native: {
-          query: "select * from PRODUCTS where {{ filter }}",
-          "template-tags": { filter },
-        },
-      }).then(({ body: { id } }) => {
-        cy.intercept("POST", `/api/card/${id}/query`).as("cardQuery");
-
-        if (user === "nodata") {
-          cy.signOut();
-          cy.signIn(user);
-        }
-
-        cy.visit(`/question/${id}`);
-        cy.wait("@cardQuery");
-      });
-
-      cy.icon("play").should("not.exist");
-    });
-  });
-
   it("should link correctly from the variables sidebar (metabase#16212)", () => {
     cy.createNativeQuestion({
       name: "test-question",

--- a/frontend/test/metabase/scenarios/native/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/native.cy.spec.js
@@ -227,31 +227,6 @@ describe("scenarios > question > native", () => {
     });
   });
 
-  it("should not make the question dirty when there are no changes (metabase#14302)", () => {
-    cy.createNativeQuestion({
-      name: "14302",
-      native: {
-        query:
-          'SELECT "CATEGORY", COUNT(*)\nFROM "PRODUCTS"\nWHERE "PRICE" > {{PRICE}}\nGROUP BY "CATEGORY"',
-        "template-tags": {
-          PRICE: {
-            id: "39b51ccd-47a7-9df6-a1c5-371918352c79",
-            name: "PRICE",
-            "display-name": "Price",
-            type: "number",
-            default: "10",
-            required: true,
-          },
-        },
-      },
-    }).then(({ body: { id: QUESTION_ID } }) => {
-      cy.visit(`/question/${QUESTION_ID}`);
-      cy.findByText("14302");
-      cy.log("Reported on v0.37.5 - Regression since v0.37.0");
-      cy.findByText("Save").should("not.exist");
-    });
-  });
-
   it("should reorder template tags by drag and drop (metabase#9357)", () => {
     openNativeEditor().type(
       "{{firstparameter}} {{nextparameter}} {{lastparameter}}",

--- a/frontend/test/metabase/scenarios/native/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/native.cy.spec.js
@@ -479,48 +479,6 @@ describe("scenarios > question > native", () => {
     });
   });
 
-  it("should be possible to use field filter on a query with joins where tables have similar columns (metabase#15460)", () => {
-    cy.intercept("POST", "/api/dataset").as("dataset");
-    visitQuestionAdhoc({
-      name: "15460",
-      dataset_query: {
-        database: 1,
-        native: {
-          query:
-            "select p.created_at, products.category\nfrom products\nleft join products p on p.id=products.id\nwhere {{category}}\n",
-          "template-tags": {
-            category: {
-              id: "d98c3875-e0f1-9270-d36a-5b729eef938e",
-              name: "category",
-              "display-name": "Category",
-              type: "dimension",
-              dimension: ["field", PRODUCTS.CATEGORY, null],
-              "widget-type": "category/=",
-              default: null,
-            },
-          },
-        },
-        type: "native",
-      },
-    });
-
-    // Set the filter value
-    filterWidget()
-      .contains("Category")
-      .click();
-    popover()
-      .findByText("Doohickey")
-      .click();
-    cy.button("Add filter").click();
-    // Rerun the query
-    cy.get(".NativeQueryEditor .Icon-play").click();
-    cy.wait("@dataset").wait("@dataset");
-    cy.get(".Visualization").within(() => {
-      cy.findAllByText("Doohickey");
-      cy.findAllByText("Gizmo").should("not.exist");
-    });
-  });
-
   ["old", "new"].forEach(test => {
     it(`${test} syntax:\n should be able to select category Field Filter in Native query (metabase#15700)`, () => {
       if (test === "old") {

--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -433,68 +433,6 @@ describe("scenarios > question > filter", () => {
     });
   });
 
-  it.skip("should clear default filter value in native questions (metabase#13961)", () => {
-    const QUESTION_NAME = "13961";
-    const [CATEGORY_FILTER, ID_FILTER] = [
-      { name: "category", display_name: "Category", type: "dimension" },
-      { name: "prodid", display_name: "ProdId", type: "number" },
-    ];
-
-    cy.createNativeQuestion({
-      name: QUESTION_NAME,
-      native: {
-        query:
-          "SELECT * FROM PRODUCTS WHERE 1=1 AND {{category}} [[AND ID={{prodid}}]]",
-        "template-tags": {
-          [CATEGORY_FILTER.name]: {
-            id: "00315d5e-4a41-99da-1a41-e5254dacff9d",
-            name: CATEGORY_FILTER.name,
-            "display-name": CATEGORY_FILTER.display_name,
-            type: CATEGORY_FILTER.type,
-            default: "Doohickey",
-            dimension: ["field", PRODUCTS.CATEGORY, null],
-            "widget-type": "category",
-          },
-          [ID_FILTER.name]: {
-            id: "4775bccc-e82a-4069-fc6b-2acc90aadb8b",
-            name: ID_FILTER.name,
-            "display-name": ID_FILTER.display_name,
-            type: ID_FILTER.type,
-            default: null,
-          },
-        },
-      },
-    }).then(({ body: { id: QUESTION_ID } }) => {
-      cy.visit(`/question/${QUESTION_ID}`);
-
-      cy.findByText(QUESTION_NAME);
-      cy.findAllByText("Small Marble Shoes"); // Product ID 2, Doohickey
-
-      cy.location("search").should("eq", "?category=Doohickey");
-
-      // Remove default filter (category)
-      cy.get("fieldset .Icon-close").click();
-
-      cy.icon("play")
-        .first()
-        .should("be.visible")
-        .as("rerunQuestion");
-
-      cy.get("@rerunQuestion").click();
-      cy.url().should("not.include", "?category=Doohickey");
-
-      // Add value `1` to the ID filter
-      cy.findByPlaceholderText(ID_FILTER.display_name).type("1");
-
-      cy.get("@rerunQuestion").click();
-
-      cy.log("Reported tested and failing on v0.34.3 through v0.37.3");
-      cy.log("URL is correct at this point, but there are no results");
-      cy.location("search").should("eq", `?${ID_FILTER.name}=1`);
-      cy.findByText("Rustic Paper Wallet"); // Product ID 1, Gizmo
-    });
-  });
-
   it.skip("should not drop aggregated filters (metabase#11957)", () => {
     const AGGREGATED_FILTER = "Count is less than or equal to 20";
 

--- a/frontend/test/metabase/scenarios/question/public/question.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/public/question.cy.spec.js
@@ -4,7 +4,7 @@ import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
 const { PEOPLE } = SAMPLE_DATASET;
 
 const questionData = {
-  name: "15460",
+  name: "7210",
   native: {
     query: "SELECT * FROM PEOPLE WHERE {{birthdate}} AND {{source}}",
     "template-tags": {


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Groups SQL filter related reproductions under one folder
- Separates each of the repros into individual files (1 file per repro)
    - This makes it much easier to grep/find and to read/review

### Questions:
- Some of these repros are now covered by the SQL filters test matrix. Do we still want to keep the individual repros, anyway?