### PR TITLE
#16886 Repro: "Run selected text" removes everything but the selected text from the query

### DIFF
--- a/frontend/test/metabase/scenarios/native/reproductions/16886.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/reproductions/16886.cy.spec.js
@@ -1,0 +1,31 @@
+import { restore, openNativeEditor } from "__support__/e2e/cypress";
+
+const ORIGINAL_QUERY = "select 1 from orders";
+const SELECTED_TEXT = "select 1";
+
+const moveCursorToBeginning = "{selectall}{leftarrow}";
+const highlightSelectedText = "{shift}{rightarrow}".repeat(
+  SELECTED_TEXT.length,
+);
+
+describe.skip("issue 16886", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it(`shouldn't remove parts of the query when choosing "Run selected text" (metabase#16886)`, () => {
+    openNativeEditor().type(
+      ORIGINAL_QUERY + moveCursorToBeginning + highlightSelectedText,
+      { delay: 50 },
+    );
+
+    cy.get(".NativeQueryEditor .Icon-play").click();
+
+    cy.get(".ScalarValue")
+      .invoke("text")
+      .should("eq", "1");
+
+    cy.get("@editor").contains(ORIGINAL_QUERY);
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #16886 

### How to test this manually?
- `yarn test-cypress-open`
- Unskip the test
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/124643955-ff502a00-de91-11eb-828a-963b5967dc76.png)

