### PR TITLE
Fix home page our analytics

### DIFF
--- a/frontend/src/metabase/containers/CollectionItemsLoader.jsx
+++ b/frontend/src/metabase/containers/CollectionItemsLoader.jsx
@@ -13,7 +13,14 @@ const CollectionItemsLoader = ({ collectionId, children, ...props }: Props) => (
     {({ object }) => (
       <Search.ListLoader
         {...props}
-        query={{ collection: collectionId }}
+        query={{
+          collection: collectionId,
+          pinned_state: "is_pinned",
+          sort_column: "name",
+          sort_direction: "asc",
+          models: "dashboard",
+          limit: 200,
+        }}
         wrapped
       >
         {({ list }) =>

--- a/frontend/src/metabase/containers/CollectionItemsLoader.jsx
+++ b/frontend/src/metabase/containers/CollectionItemsLoader.jsx
@@ -3,6 +3,8 @@ import React from "react";
 import Collection from "metabase/entities/collections";
 import Search from "metabase/entities/search";
 
+const PINNED_DASHBOARDS_LOAD_LIMIT = 500;
+
 type Props = {
   collectionId: number,
   children: () => void,
@@ -19,7 +21,7 @@ const CollectionItemsLoader = ({ collectionId, children, ...props }: Props) => (
           sort_column: "name",
           sort_direction: "asc",
           models: "dashboard",
-          limit: 200,
+          limit: PINNED_DASHBOARDS_LOAD_LIMIT,
         }}
         wrapped
       >

--- a/frontend/src/metabase/containers/Overworld.jsx
+++ b/frontend/src/metabase/containers/Overworld.jsx
@@ -1,6 +1,5 @@
 /* eslint-disable react/prop-types */
 import React from "react";
-import _ from "underscore";
 import { Box, Flex } from "grid-styled";
 import { connect } from "react-redux";
 import { t, jt } from "ttag";
@@ -39,29 +38,6 @@ import {
 
 const PAGE_PADDING = [1, 2, 4];
 
-// use reselect select to avoid re-render if list doesn't change
-const getParitionedCollections = createSelector(
-  [(state, props) => props.list],
-  list => {
-    const [collections, items] = _.partition(
-      list,
-      item => item.model === "collection",
-    );
-    const [pinned, unpinned] = _.partition(
-      items,
-      item => item.collection_position != null,
-    );
-
-    // sort the pinned items by collection_position
-    pinned.sort((a, b) => a.collection_position - b.collection_position);
-    return {
-      collections,
-      pinned,
-      unpinned,
-    };
-  },
-);
-
 const getGreeting = createSelector(
   [getUser],
   user => Greeting.sayHello(user.first_name),
@@ -69,13 +45,11 @@ const getGreeting = createSelector(
 
 //class Overworld extends Zelda
 @Search.loadList({
-  query: { collection: "root" },
+  query: { collection: "root", models: "collection" },
   wrapped: true,
 })
 @connect(
   (state, props) => ({
-    // split out collections, pinned, and unpinned since bulk actions only apply to unpinned
-    ...getParitionedCollections(state, props),
     user: getUser(state, props),
     showHomepageData: getShowHomepageData(state),
     showHomepageXrays: getShowHomepageXrays(state),
@@ -104,11 +78,7 @@ class Overworld extends React.Component {
         </Flex>
         <CollectionItemsLoader collectionId="root">
           {({ items }) => {
-            const pinnedDashboards = items.filter(
-              d => d.model === "dashboard" && d.collection_position != null,
-            );
-
-            if (showHomepageXrays && !pinnedDashboards.length > 0) {
+            if (showHomepageXrays && !items.length > 0) {
               return (
                 <CandidateListLoader>
                   {({ candidates, sampleCandidates, isSample }) => {
@@ -178,7 +148,7 @@ class Overworld extends React.Component {
               );
             }
 
-            if (pinnedDashboards.length === 0) {
+            if (items.length === 0) {
               return null;
             }
 
@@ -186,7 +156,7 @@ class Overworld extends React.Component {
               <Box px={PAGE_PADDING} mt={2}>
                 <SectionHeading>{t`Start here`}</SectionHeading>
                 <Grid>
-                  {pinnedDashboards.map(pin => {
+                  {items.map(pin => {
                     return (
                       <GridItem
                         w={[1, 1 / 2, 1 / 3]}
@@ -220,11 +190,10 @@ class Overworld extends React.Component {
         <Box px={PAGE_PADDING} my={3}>
           <SectionHeading>{ROOT_COLLECTION.name}</SectionHeading>
           <Box p={[1, 2]} mt={2} bg={color("bg-medium")}>
-            {this.props.collections.filter(
-              c => c.id !== user.personal_collection_id,
-            ).length > 0 ? (
+            {this.props.list.filter(c => c.id !== user.personal_collection_id)
+              .length > 0 ? (
               <CollectionList
-                collections={this.props.collections}
+                collections={this.props.list}
                 analyticsContext="Homepage"
                 asCards={true}
               />

--- a/frontend/src/metabase/containers/Overworld.jsx
+++ b/frontend/src/metabase/containers/Overworld.jsx
@@ -37,6 +37,7 @@ import {
 } from "metabase/selectors/settings";
 
 const PAGE_PADDING = [1, 2, 4];
+const ROOT_COLLECTIONS_LOAD_LIMIT = 500;
 
 const getGreeting = createSelector(
   [getUser],
@@ -45,7 +46,11 @@ const getGreeting = createSelector(
 
 //class Overworld extends Zelda
 @Search.loadList({
-  query: { collection: "root", models: "collection" },
+  query: {
+    collection: "root",
+    models: "collection",
+    limit: ROOT_COLLECTIONS_LOAD_LIMIT,
+  },
   wrapped: true,
 })
 @connect(

--- a/frontend/src/metabase/entities/containers/EntityObjectLoader.jsx
+++ b/frontend/src/metabase/entities/containers/EntityObjectLoader.jsx
@@ -106,7 +106,7 @@ export default class EntityObjectLoader extends React.Component {
   UNSAFE_componentWillReceiveProps(nextProps: Props) {
     if (
       nextProps.entityId !== this.props.entityId &&
-      this.props.entityId != null
+      nextProps.entityId != null
     ) {
       nextProps.fetch(
         { id: nextProps.entityId },

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx
@@ -161,7 +161,7 @@ const SettingsPane = ({
 );
 
 SettingsPane.propTypes = {
-  tags: PropTypes.object.isRequired,
+  tags: PropTypes.array.isRequired,
   onUpdate: PropTypes.func.isRequired,
   setDatasetQuery: PropTypes.func.isRequired,
   query: NativeQuery,

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -1,3 +1,4 @@
+import _ from "underscore";
 import {
   restore,
   setupLocalHostEmail,
@@ -6,7 +7,6 @@ import {
   openOrdersTable,
   sidebar,
 } from "__support__/e2e/cypress";
-import _ from "underscore";
 import { USERS, USER_GROUPS } from "__support__/e2e/cypress_data";
 
 const { nocollection } = USERS;
@@ -580,7 +580,7 @@ describe("scenarios > collection_defaults", () => {
       });
     });
 
-    it.skip("collections list on the home page shouldn't depend on the name of the first 50 objects (metabase#16784)", () => {
+    it("collections list on the home page shouldn't depend on the name of the first 50 objects (metabase#16784)", () => {
       // Although there are already some objects in the default snapshot (3 questions, 1 dashboard, 3 collections),
       // let's create 50 more dashboards with the letter of alphabet `D` coming before the first letter of the existing collection `F`.
       _.times(50, i => cy.createDashboard(`Dashboard ${i}`));


### PR DESCRIPTION
### Description

#### Home page does not show all folders under `Our analytics` on the home page:
<img width="1358" alt="Screen Shot 2021-07-07 at 16 37 09" src="https://user-images.githubusercontent.com/14301985/124768737-9627ef80-df41-11eb-92bd-0b1371d9b569.png">

Reason: we added pagination `http://localhost:3000/api/collection/root/items` endpoint but previously it loaded all the items and filtered collections on the client-side. I replaced it with `http://localhost:3000/api/collection/root/items?models=collection` query to fetch only collections

#### Home page does not show pinned dashboards under `Start here` on the home page:
<img width="1355" alt="Screen Shot 2021-07-07 at 16 40 05" src="https://user-images.githubusercontent.com/14301985/124769258-fdde3a80-df41-11eb-9175-77624f601952.png">

Reason: we added pagination to `http://localhost:3000/api/collection/root/items` endpoint but previously it loaded all the items and filtered pinned dashboards on the client-side. Now we can do this on the back end using new query params:
`http://localhost:3000/api/collection/root/items?models=dashboard&pinned_state=is_pinned&limit=200&sort_column=name&sort_direction=asc`

Fixes https://github.com/metabase/metabase/issues/16784
Fixes https://github.com/metabase/metabase/issues/16869