### PR TITLE
Refactor CheckBox and StackedCheckBox components

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -58,13 +58,5 @@
     "ecmaFeatures": {
       "legacyDecorators": true
     }
-  },
-  "overrides": [
-    {
-      "files": ["**.info.js", "**.info.jsx"],
-      "rules": {
-        "react/prop-types": 0
-      }
-    }
-  ]
+  }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -58,5 +58,13 @@
     "ecmaFeatures": {
       "legacyDecorators": true
     }
-  }
+  },
+  "overrides": [
+    {
+      "files": ["**.info.js", "**.info.jsx"],
+      "rules": {
+        "react/prop-types": 0
+      }
+    }
+  ]
 }

--- a/frontend/src/metabase/components/CheckBox.info.js
+++ b/frontend/src/metabase/components/CheckBox.info.js
@@ -28,6 +28,14 @@ const rowStyle = {
 export const examples = {
   Default: <CheckBoxDemo />,
   Label: <CheckBoxDemo label="Confirm Stuff" />,
+  Label: (
+    <div>
+      <CheckBoxDemo label="Confirm Stuff" />
+      <CheckBoxDemo
+        label={<h3 style={{ marginLeft: "8px" }}>Custom element label</h3>}
+      />
+    </div>
+  ),
   Sizing: (
     <div style={rowStyle}>
       {[10, 12, 14, 16, 18, 20, 24].map(size => (

--- a/frontend/src/metabase/components/CheckBox.info.js
+++ b/frontend/src/metabase/components/CheckBox.info.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import CheckBox from "metabase/components/CheckBox";
 
 export const component = CheckBox;
@@ -8,11 +8,38 @@ export const description = `
 A standard checkbox.
 `;
 
+function CheckBoxDemo({ checked: isCheckedInitially = false, ...props } = {}) {
+  const [checked, setChecked] = useState(isCheckedInitially);
+  return (
+    <CheckBox
+      {...props}
+      checked={checked}
+      onChange={e => setChecked(e.target.checked)}
+    />
+  );
+}
+
+const rowStyle = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-around",
+};
+
 export const examples = {
-  "Default - Off": <CheckBox />,
-  "On - Default blue": <CheckBox checked />,
-  Purple: <CheckBox checked color="purple" />,
-  Yellow: <CheckBox checked color="yellow" />,
-  Red: <CheckBox checked color="red" />,
-  Green: <CheckBox checked color="green" />,
+  Default: <CheckBoxDemo />,
+  Label: <CheckBoxDemo label="Confirm Stuff" />,
+  Sizing: (
+    <div style={rowStyle}>
+      {[10, 12, 14, 16, 18, 20, 24].map(size => (
+        <CheckBoxDemo key={size} checked size={size} />
+      ))}
+    </div>
+  ),
+  Colors: (
+    <div style={rowStyle}>
+      {["accent1", "accent2", "accent3", "accent4"].map(color => (
+        <CheckBoxDemo key={color} checked checkedColor={color} />
+      ))}
+    </div>
+  ),
 };

--- a/frontend/src/metabase/components/CheckBox.info.js
+++ b/frontend/src/metabase/components/CheckBox.info.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { useState } from "react";
 import CheckBox from "metabase/components/CheckBox";
 

--- a/frontend/src/metabase/components/CheckBox.info.js
+++ b/frontend/src/metabase/components/CheckBox.info.js
@@ -27,13 +27,18 @@ const rowStyle = {
 
 export const examples = {
   Default: <CheckBoxDemo />,
-  Label: <CheckBoxDemo label="Confirm Stuff" />,
   Label: (
     <div>
       <CheckBoxDemo label="Confirm Stuff" />
       <CheckBoxDemo
         label={<h3 style={{ marginLeft: "8px" }}>Custom element label</h3>}
       />
+    </div>
+  ),
+  Disabled: (
+    <div>
+      <CheckBoxDemo disabled />
+      <CheckBoxDemo label="Confirm Stuff" disabled checked />
     </div>
   ),
   Sizing: (

--- a/frontend/src/metabase/components/CheckBox.jsx
+++ b/frontend/src/metabase/components/CheckBox.jsx
@@ -93,7 +93,11 @@ function Checkbox({
   }, [label]);
 
   return (
-    <CheckboxRoot className={className} disabled={disabled}>
+    <CheckboxRoot
+      className={className}
+      disabled={disabled}
+      data-testid="checkbox-root"
+    >
       <Container>
         <VisibleBox
           checked={checked}

--- a/frontend/src/metabase/components/CheckBox.jsx
+++ b/frontend/src/metabase/components/CheckBox.jsx
@@ -24,7 +24,6 @@ const propTypes = {
   autoFocus: PropTypes.bool,
 
   className: PropTypes.string,
-  style: PropTypes.object,
 };
 
 export const DEFAULT_CHECKED_COLOR = "brand";

--- a/frontend/src/metabase/components/CheckBox.jsx
+++ b/frontend/src/metabase/components/CheckBox.jsx
@@ -9,7 +9,7 @@ import { color } from "metabase/lib/colors";
 const propTypes = {
   checked: PropTypes.bool,
   indeterminate: PropTypes.bool,
-  label: PropTypes.string,
+  label: PropTypes.node,
   disabled: PropTypes.bool,
   onChange: PropTypes.func,
   onFocus: PropTypes.func,

--- a/frontend/src/metabase/components/CheckBox.jsx
+++ b/frontend/src/metabase/components/CheckBox.jsx
@@ -142,11 +142,9 @@ const VisibleBox = styled.span`
 
   ${props =>
     props.isFocused &&
+    !props.checked &&
     css`
-      outline: 1px auto
-        ${props.checked
-          ? color(darken(props.checkedColor))
-          : color(props.checkedColor)};
+      outline: 1px auto ${color(props.checkedColor)};
     `}
 `;
 

--- a/frontend/src/metabase/components/CheckBox.jsx
+++ b/frontend/src/metabase/components/CheckBox.jsx
@@ -10,6 +10,7 @@ const propTypes = {
   checked: PropTypes.bool,
   indeterminate: PropTypes.bool,
   label: PropTypes.string,
+  disabled: PropTypes.bool,
   onChange: PropTypes.func,
   onFocus: PropTypes.func,
   onBlur: PropTypes.func,
@@ -36,6 +37,7 @@ function Checkbox({
   label,
   checked,
   indeterminate,
+  disabled = false,
   onChange,
   onFocus,
   onBlur,
@@ -88,7 +90,7 @@ function Checkbox({
   }, [label]);
 
   return (
-    <CheckboxRoot className={className}>
+    <CheckboxRoot className={className} disabled={disabled}>
       <Container>
         <VisibleBox
           checked={checked}
@@ -100,6 +102,7 @@ function Checkbox({
           <Input
             {...props}
             checked={checked}
+            disabled={disabled}
             onChange={onChange}
             onFocus={handleFocus}
             onBlur={handleBlur}
@@ -123,6 +126,13 @@ function Checkbox({
 const CheckboxRoot = styled.label`
   display: block;
   cursor: pointer;
+
+  ${props =>
+    props.disabled &&
+    css`
+      opacity: 0.4;
+      pointer-events: none;
+    `}
 `;
 
 const Container = styled.div`

--- a/frontend/src/metabase/components/CheckBox.jsx
+++ b/frontend/src/metabase/components/CheckBox.jsx
@@ -22,6 +22,10 @@ const propTypes = {
   style: PropTypes.object,
 };
 
+export const DEFAULT_CHECKED_COLOR = "brand";
+export const DEFAULT_UNCHECKED_COLOR = "text-light";
+export const DEFAULT_SIZE = 16;
+
 const ICON_PADDING = 4;
 
 function Checkbox({
@@ -31,9 +35,9 @@ function Checkbox({
   onChange,
   onFocus,
   onBlur,
-  checkedColor = "brand",
-  uncheckedColor = "text-light",
-  size = 16,
+  checkedColor = DEFAULT_CHECKED_COLOR,
+  uncheckedColor = DEFAULT_UNCHECKED_COLOR,
+  size = DEFAULT_SIZE,
   autoFocus = false,
   className,
   ...props

--- a/frontend/src/metabase/components/CheckBox.jsx
+++ b/frontend/src/metabase/components/CheckBox.jsx
@@ -13,8 +13,13 @@ const propTypes = {
   onChange: PropTypes.func,
   onFocus: PropTypes.func,
   onBlur: PropTypes.func,
+
+  // Expect color aliases, literals
+  // Example: brand, accent1, success
+  // Won't work: red, #000, rgb(0, 0, 0)
   checkedColor: PropTypes.string,
   uncheckedColor: PropTypes.string,
+
   size: PropTypes.number,
   autoFocus: PropTypes.bool,
 

--- a/frontend/src/metabase/components/CheckBox.jsx
+++ b/frontend/src/metabase/components/CheckBox.jsx
@@ -4,7 +4,7 @@ import styled, { css } from "styled-components";
 
 import Icon from "metabase/components/Icon";
 
-import { color, darken } from "metabase/lib/colors";
+import { color } from "metabase/lib/colors";
 
 const propTypes = {
   checked: PropTypes.bool,
@@ -80,6 +80,13 @@ function Checkbox({
     [checked, onChange],
   );
 
+  const renderLabel = useCallback(() => {
+    if (label == null) {
+      return null;
+    }
+    return React.isValidElement(label) ? label : <LabelText>{label}</LabelText>;
+  }, [label]);
+
   return (
     <CheckboxRoot className={className}>
       <Container>
@@ -107,7 +114,7 @@ function Checkbox({
             />
           )}
         </VisibleBox>
-        {label && <LabelText>{label}</LabelText>}
+        {renderLabel()}
       </Container>
     </CheckboxRoot>
   );
@@ -172,5 +179,6 @@ const LabelText = styled.span`
 `;
 
 Checkbox.propTypes = propTypes;
+Checkbox.Label = LabelText;
 
 export default Checkbox;

--- a/frontend/src/metabase/components/CheckBox.jsx
+++ b/frontend/src/metabase/components/CheckBox.jsx
@@ -1,10 +1,13 @@
 import React, { useCallback, useState } from "react";
 import PropTypes from "prop-types";
-import styled, { css } from "styled-components";
-
-import Icon from "metabase/components/Icon";
-
-import { color } from "metabase/lib/colors";
+import {
+  CheckboxRoot,
+  Container,
+  VisibleBox,
+  Input,
+  CheckboxIcon,
+  LabelText,
+} from "./CheckBox.styled";
 
 const propTypes = {
   checked: PropTypes.bool,
@@ -122,71 +125,6 @@ function Checkbox({
     </CheckboxRoot>
   );
 }
-
-const CheckboxRoot = styled.label`
-  display: block;
-  cursor: pointer;
-
-  ${props =>
-    props.disabled &&
-    css`
-      opacity: 0.4;
-      pointer-events: none;
-    `}
-`;
-
-const Container = styled.div`
-  display: flex;
-  align-items: center;
-`;
-
-const VisibleBox = styled.span`
-  display: flex;
-  align-items: center;
-  justify-center: center;
-  position: relative;
-  width: ${props => `${props.size}px`};
-  height: ${props => `${props.size}px`};
-
-  background-color: ${props =>
-    props.checked ? color(props.checkedColor) : color("bg-white")};
-
-  border: 2px solid
-    ${props =>
-      props.checked ? color(props.checkedColor) : color(props.uncheckedColor)};
-
-  border-radius: 4px;
-
-  ${props =>
-    props.isFocused &&
-    !props.checked &&
-    css`
-      outline: 1px auto ${color(props.checkedColor)};
-    `}
-`;
-
-const Input = styled.input.attrs({ type: "checkbox" })`
-  cursor: inherit;
-  position: absolute;
-  opacity: 0;
-  width: 100%;
-  height: 100%;
-  top: 0;
-  left: 0;
-  margin: 0;
-  padding: 0;
-  z-index: 1;
-`;
-
-const CheckboxIcon = styled(Icon)`
-  position: absolute;
-  color: ${props =>
-    props.checked ? color("white") : color(props.uncheckedColor)};
-`;
-
-const LabelText = styled.span`
-  margin-left: 8px;
-`;
 
 Checkbox.propTypes = propTypes;
 Checkbox.Label = LabelText;

--- a/frontend/src/metabase/components/CheckBox.styled.js
+++ b/frontend/src/metabase/components/CheckBox.styled.js
@@ -2,7 +2,7 @@ import React from "react";
 import styled, { css } from "styled-components";
 import _ from "underscore";
 import Icon from "metabase/components/Icon";
-import { color } from "metabase/lib/colors";
+import { color, darken } from "metabase/lib/colors";
 
 export const CheckboxRoot = styled.label`
   display: block;
@@ -40,9 +40,12 @@ export const VisibleBox = styled.span`
 
   ${props =>
     props.isFocused &&
-    !props.checked &&
     css`
-      outline: 1px auto ${color(props.checkedColor)};
+      outline: 1px auto
+        ${props.checked
+          ? darken(color(props.checkedColor))
+          : color(props.checkedColor)};
+      outline-offset: 1px;
     `}
 `;
 

--- a/frontend/src/metabase/components/CheckBox.styled.js
+++ b/frontend/src/metabase/components/CheckBox.styled.js
@@ -1,0 +1,68 @@
+import styled, { css } from "styled-components";
+import Icon from "metabase/components/Icon";
+import { color } from "metabase/lib/colors";
+
+export const CheckboxRoot = styled.label`
+  display: block;
+  cursor: pointer;
+
+  ${props =>
+    props.disabled &&
+    css`
+      opacity: 0.4;
+      pointer-events: none;
+    `}
+`;
+
+export const Container = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+export const VisibleBox = styled.span`
+  display: flex;
+  align-items: center;
+  justify-center: center;
+  position: relative;
+  width: ${props => `${props.size}px`};
+  height: ${props => `${props.size}px`};
+
+  background-color: ${props =>
+    props.checked ? color(props.checkedColor) : color("bg-white")};
+
+  border: 2px solid
+    ${props =>
+      props.checked ? color(props.checkedColor) : color(props.uncheckedColor)};
+
+  border-radius: 4px;
+
+  ${props =>
+    props.isFocused &&
+    !props.checked &&
+    css`
+      outline: 1px auto ${color(props.checkedColor)};
+    `}
+`;
+
+export const Input = styled.input.attrs({ type: "checkbox" })`
+  cursor: inherit;
+  position: absolute;
+  opacity: 0;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  margin: 0;
+  padding: 0;
+  z-index: 1;
+`;
+
+export const CheckboxIcon = styled(Icon)`
+  position: absolute;
+  color: ${props =>
+    props.checked ? color("white") : color(props.uncheckedColor)};
+`;
+
+export const LabelText = styled.span`
+  margin-left: 8px;
+`;

--- a/frontend/src/metabase/components/CheckBox.styled.js
+++ b/frontend/src/metabase/components/CheckBox.styled.js
@@ -1,4 +1,6 @@
+import React from "react";
 import styled, { css } from "styled-components";
+import _ from "underscore";
 import Icon from "metabase/components/Icon";
 import { color } from "metabase/lib/colors";
 
@@ -57,7 +59,12 @@ export const Input = styled.input.attrs({ type: "checkbox" })`
   z-index: 1;
 `;
 
-export const CheckboxIcon = styled(Icon)`
+function IconWrapped(props) {
+  const iconProps = _.omit(props, "uncheckedColor");
+  return <Icon {...iconProps} />;
+}
+
+export const CheckboxIcon = styled(IconWrapped)`
   position: absolute;
   color: ${props =>
     props.checked ? color("white") : color(props.uncheckedColor)};

--- a/frontend/src/metabase/components/DeleteModalWithConfirm.jsx
+++ b/frontend/src/metabase/components/DeleteModalWithConfirm.jsx
@@ -1,11 +1,13 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-
-import ModalContent from "metabase/components/ModalContent";
-import CheckBox from "metabase/components/CheckBox";
 import { t } from "ttag";
 import cx from "classnames";
 import _ from "underscore";
+
+import ModalContent from "metabase/components/ModalContent";
+import CheckBox from "metabase/components/CheckBox";
+
+import { CheckboxLabel } from "./DeleteModalWithConfirm.styled";
 
 export default class DeleteModalWithConfirm extends Component {
   constructor(props, context) {
@@ -47,18 +49,18 @@ export default class DeleteModalWithConfirm extends Component {
                 key={index}
                 className="pb2 mb2 border-row-divider flex align-center"
               >
-                <span className="text-error">
-                  <CheckBox
-                    size={20}
-                    checked={checked[index]}
-                    onChange={e =>
-                      this.setState({
-                        checked: { ...checked, [index]: e.target.checked },
-                      })
-                    }
-                  />
-                </span>
-                <span className="ml1 h4">{item}</span>
+                <CheckBox
+                  label={<CheckboxLabel>{item}</CheckboxLabel>}
+                  size={20}
+                  checkedColor="danger"
+                  uncheckedColor="danger"
+                  checked={checked[index]}
+                  onChange={e =>
+                    this.setState({
+                      checked: { ...checked, [index]: e.target.checked },
+                    })
+                  }
+                />
               </li>
             ))}
           </ul>

--- a/frontend/src/metabase/components/DeleteModalWithConfirm.jsx
+++ b/frontend/src/metabase/components/DeleteModalWithConfirm.jsx
@@ -49,8 +49,6 @@ export default class DeleteModalWithConfirm extends Component {
               >
                 <span className="text-error">
                   <CheckBox
-                    checkColor="currentColor"
-                    borderColor={checked[index] ? "currentColor" : undefined}
                     size={20}
                     checked={checked[index]}
                     onChange={e =>

--- a/frontend/src/metabase/components/DeleteModalWithConfirm.styled.js
+++ b/frontend/src/metabase/components/DeleteModalWithConfirm.styled.js
@@ -1,0 +1,9 @@
+import styled from "styled-components";
+import CheckBox from "metabase/components/CheckBox";
+
+import { color } from "metabase/lib/colors";
+
+export const CheckboxLabel = styled(CheckBox.Label)`
+  color: ${color("danger")};
+  font-size: 1.12em;
+`;

--- a/frontend/src/metabase/components/StackedCheckBox.info.js
+++ b/frontend/src/metabase/components/StackedCheckBox.info.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import StackedCheckBox from "metabase/components/StackedCheckBox";
 
 export const component = StackedCheckBox;
@@ -8,8 +8,40 @@ export const description = `
 A stacked checkbox, representing "all" items.
 `;
 
+function StackedCheckBoxDemo({
+  checked: isCheckedInitially = false,
+  ...props
+}) {
+  const [checked, setChecked] = useState(isCheckedInitially);
+  return (
+    <StackedCheckBox
+      {...props}
+      checked={checked}
+      onChange={e => setChecked(e.target.checked)}
+    />
+  );
+}
+
+const rowStyle = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-around",
+};
+
 export const examples = {
-  "Off - Default": <StackedCheckBox />,
-  Checked: <StackedCheckBox checked />,
-  "Checked with color": <StackedCheckBox checked color="purple" />,
+  Default: <StackedCheckBoxDemo />,
+  Sizing: (
+    <div style={rowStyle}>
+      {[10, 12, 14, 16, 18, 20, 24].map(size => (
+        <StackedCheckBoxDemo key={size} checked size={size} />
+      ))}
+    </div>
+  ),
+  Colors: (
+    <div style={rowStyle}>
+      {["accent1", "accent2", "accent3", "accent4"].map(color => (
+        <StackedCheckBoxDemo key={color} checked checkedColor={color} />
+      ))}
+    </div>
+  ),
 };

--- a/frontend/src/metabase/components/StackedCheckBox.info.js
+++ b/frontend/src/metabase/components/StackedCheckBox.info.js
@@ -38,6 +38,13 @@ export const examples = {
       />
     </div>
   ),
+  Disabled: (
+    <div>
+      <StackedCheckBoxDemo disabled />
+      <br />
+      <StackedCheckBoxDemo label="Confirm Stuff" disabled checked />
+    </div>
+  ),
   Sizing: (
     <div style={rowStyle}>
       {[10, 12, 14, 16, 18, 20, 24].map(size => (

--- a/frontend/src/metabase/components/StackedCheckBox.info.js
+++ b/frontend/src/metabase/components/StackedCheckBox.info.js
@@ -33,9 +33,8 @@ export const examples = {
   Label: (
     <div>
       <StackedCheckBoxDemo label="Confirm Stuff" />
-      <StackedCheckBoxDemo
-        label={<h3 style={{ marginLeft: "8px" }}>Custom element label</h3>}
-      />
+      <br />
+      <StackedCheckBoxDemo label={<h3>Custom element label</h3>} />
     </div>
   ),
   Disabled: (

--- a/frontend/src/metabase/components/StackedCheckBox.info.js
+++ b/frontend/src/metabase/components/StackedCheckBox.info.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { useState } from "react";
 import StackedCheckBox from "metabase/components/StackedCheckBox";
 

--- a/frontend/src/metabase/components/StackedCheckBox.info.js
+++ b/frontend/src/metabase/components/StackedCheckBox.info.js
@@ -30,6 +30,14 @@ const rowStyle = {
 
 export const examples = {
   Default: <StackedCheckBoxDemo />,
+  Label: (
+    <div>
+      <StackedCheckBoxDemo label="Confirm Stuff" />
+      <StackedCheckBoxDemo
+        label={<h3 style={{ marginLeft: "8px" }}>Custom element label</h3>}
+      />
+    </div>
+  ),
   Sizing: (
     <div style={rowStyle}>
       {[10, 12, 14, 16, 18, 20, 24].map(size => (

--- a/frontend/src/metabase/components/StackedCheckBox.jsx
+++ b/frontend/src/metabase/components/StackedCheckBox.jsx
@@ -1,13 +1,18 @@
 import React, { useCallback } from "react";
 import PropTypes from "prop-types";
-import styled from "styled-components";
 
-import CheckBox, {
+import {
   DEFAULT_CHECKED_COLOR,
   DEFAULT_UNCHECKED_COLOR,
   DEFAULT_SIZE,
 } from "metabase/components/CheckBox";
-import { color } from "metabase/lib/colors";
+
+import {
+  StackedCheckBoxRoot,
+  OpaqueCheckBox,
+  StackedBackground,
+  Label,
+} from "./StackedCheckBox.styled";
 
 const propTypes = {
   label: PropTypes.node,
@@ -57,39 +62,6 @@ function StackedCheckBox({
     </StackedCheckBoxRoot>
   );
 }
-
-const StackedCheckBoxRoot = styled.div`
-  position: relative;
-  transform: scale(1);
-  opacity: ${props => (props.disabled ? 0.4 : 1)};
-`;
-
-const OpaqueCheckBox = styled(CheckBox)`
-  opacity: 1;
-`;
-
-const StackedBackground = styled.div`
-  width: ${props => `${props.size}px`};
-  height: ${props => `${props.size}px`};
-  border-radius: 4px;
-  position: absolute;
-  display: inline-block;
-
-  z-index: -1;
-  top: -3px;
-  left: 3px;
-
-  background: ${props =>
-    props.checked ? color(props.checkedColor) : color("bg-white")};
-
-  border: 2px solid
-    ${props =>
-      props.checked ? color(props.checkedColor) : color(props.uncheckedColor)};
-`;
-
-const Label = styled(CheckBox.Label)`
-  margin-top: -2px;
-`;
 
 StackedCheckBox.propTypes = propTypes;
 StackedCheckBox.Label = Label;

--- a/frontend/src/metabase/components/StackedCheckBox.jsx
+++ b/frontend/src/metabase/components/StackedCheckBox.jsx
@@ -37,7 +37,7 @@ function StackedCheckBox({
   }, [label]);
 
   return (
-    <StackedCheckBoxRoot className={className}>
+    <StackedCheckBoxRoot className={className} disabled={disabled}>
       <OpaqueCheckBox
         label={renderLabel()}
         checked={checked}
@@ -61,6 +61,11 @@ function StackedCheckBox({
 const StackedCheckBoxRoot = styled.div`
   position: relative;
   transform: scale(1);
+  opacity: ${props => (props.disabled ? 0.4 : 1)};
+`;
+
+const OpaqueCheckBox = styled(CheckBox)`
+  opacity: 1;
 `;
 
 const StackedBackground = styled.div`

--- a/frontend/src/metabase/components/StackedCheckBox.jsx
+++ b/frontend/src/metabase/components/StackedCheckBox.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback } from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 
@@ -29,10 +29,17 @@ function StackedCheckBox({
   className,
   ...props
 }) {
+  const renderLabel = useCallback(() => {
+    if (label == null) {
+      return null;
+    }
+    return <Label>{label}</Label>;
+  }, [label]);
+
   return (
     <StackedCheckBoxRoot className={className}>
-      <CheckBox
-        label={label}
+      <OpaqueCheckBox
+        label={renderLabel()}
         checked={checked}
         disabled={disabled}
         checkedColor={checkedColor}
@@ -73,11 +80,13 @@ const StackedBackground = styled.div`
   border: 2px solid
     ${props =>
       props.checked ? color(props.checkedColor) : color(props.uncheckedColor)};
+`;
 
-  opacity: ${props => (props.disabled ? 0.4 : 1)};
+const Label = styled(CheckBox.Label)`
+  margin-top: -2px;
 `;
 
 StackedCheckBox.propTypes = propTypes;
-StackedCheckBox.Label = CheckBox.Label;
+StackedCheckBox.Label = Label;
 
 export default StackedCheckBox;

--- a/frontend/src/metabase/components/StackedCheckBox.jsx
+++ b/frontend/src/metabase/components/StackedCheckBox.jsx
@@ -1,25 +1,73 @@
-/* eslint-disable react/prop-types */
 import React from "react";
-import cx from "classnames";
+import PropTypes from "prop-types";
+import styled from "styled-components";
 
-import CheckBox from "metabase/components/CheckBox";
+import CheckBox, {
+  DEFAULT_CHECKED_COLOR,
+  DEFAULT_UNCHECKED_COLOR,
+  DEFAULT_SIZE,
+} from "metabase/components/CheckBox";
+import { color } from "metabase/lib/colors";
 
-const OFFSET = 3;
+const propTypes = {
+  checked: PropTypes.bool,
+  checkedColor: PropTypes.string,
+  uncheckedColor: PropTypes.string,
+  size: PropTypes.number,
+  className: PropTypes.string,
+};
 
-const StackedCheckBox = ({ className, ...props }) => (
-  <div className={cx(className, "relative")} style={{ transform: "scale(1)" }}>
-    <CheckBox {...props} />
-    <CheckBox
-      className="absolute"
-      style={{
-        top: -OFFSET,
-        left: OFFSET,
-        zIndex: -1,
-      }}
-      {...props}
-      noIcon
-    />
-  </div>
-);
+function StackedCheckBox({
+  checked,
+  checkedColor = DEFAULT_CHECKED_COLOR,
+  uncheckedColor = DEFAULT_UNCHECKED_COLOR,
+  size = DEFAULT_SIZE,
+  className,
+  ...props
+}) {
+  return (
+    <StackedCheckBoxRoot className={className}>
+      <CheckBox
+        checked={checked}
+        checkedColor={checkedColor}
+        uncheckedColor={uncheckedColor}
+        size={size}
+        {...props}
+      />
+      <StackedBackground
+        checked={checked}
+        checkedColor={checkedColor}
+        uncheckedColor={uncheckedColor}
+        size={size}
+      />
+    </StackedCheckBoxRoot>
+  );
+}
+
+const StackedCheckBoxRoot = styled.div`
+  position: relative;
+  transform: scale(1);
+`;
+
+const StackedBackground = styled.div`
+  width: ${props => `${props.size}px`};
+  height: ${props => `${props.size}px`};
+  border-radius: 4px;
+  position: absolute;
+  display: inline-block;
+
+  z-index: -1;
+  top: -3px;
+  left: 3px;
+
+  background: ${props =>
+    props.checked ? color(props.checkedColor) : color("bg-white")};
+
+  border: 2px solid
+    ${props =>
+      props.checked ? color(props.checkedColor) : color(props.uncheckedColor)};
+`;
+
+StackedCheckBox.propTypes = propTypes;
 
 export default StackedCheckBox;

--- a/frontend/src/metabase/components/StackedCheckBox.jsx
+++ b/frontend/src/metabase/components/StackedCheckBox.jsx
@@ -69,5 +69,6 @@ const StackedBackground = styled.div`
 `;
 
 StackedCheckBox.propTypes = propTypes;
+StackedCheckBox.Label = CheckBox.Label;
 
 export default StackedCheckBox;

--- a/frontend/src/metabase/components/StackedCheckBox.jsx
+++ b/frontend/src/metabase/components/StackedCheckBox.jsx
@@ -10,7 +10,7 @@ import CheckBox, {
 import { color } from "metabase/lib/colors";
 
 const propTypes = {
-  label: PropTypes.string,
+  label: PropTypes.node,
   checked: PropTypes.bool,
   disabled: PropTypes.bool,
   checkedColor: PropTypes.string,

--- a/frontend/src/metabase/components/StackedCheckBox.jsx
+++ b/frontend/src/metabase/components/StackedCheckBox.jsx
@@ -45,7 +45,6 @@ function StackedCheckBox({
         disabled={disabled}
         checkedColor={checkedColor}
         uncheckedColor={uncheckedColor}
-        hasLabel={!!label}
         size={size}
       />
     </StackedCheckBoxRoot>
@@ -65,7 +64,7 @@ const StackedBackground = styled.div`
   display: inline-block;
 
   z-index: -1;
-  top: ${props => (props.hasLabel ? 0 : "-3px")};
+  top: -3px;
   left: 3px;
 
   background: ${props =>

--- a/frontend/src/metabase/components/StackedCheckBox.jsx
+++ b/frontend/src/metabase/components/StackedCheckBox.jsx
@@ -10,7 +10,9 @@ import CheckBox, {
 import { color } from "metabase/lib/colors";
 
 const propTypes = {
+  label: PropTypes.string,
   checked: PropTypes.bool,
+  disabled: PropTypes.bool,
   checkedColor: PropTypes.string,
   uncheckedColor: PropTypes.string,
   size: PropTypes.number,
@@ -18,7 +20,9 @@ const propTypes = {
 };
 
 function StackedCheckBox({
+  label,
   checked,
+  disabled = false,
   checkedColor = DEFAULT_CHECKED_COLOR,
   uncheckedColor = DEFAULT_UNCHECKED_COLOR,
   size = DEFAULT_SIZE,
@@ -28,7 +32,9 @@ function StackedCheckBox({
   return (
     <StackedCheckBoxRoot className={className}>
       <CheckBox
+        label={label}
         checked={checked}
+        disabled={disabled}
         checkedColor={checkedColor}
         uncheckedColor={uncheckedColor}
         size={size}
@@ -36,8 +42,10 @@ function StackedCheckBox({
       />
       <StackedBackground
         checked={checked}
+        disabled={disabled}
         checkedColor={checkedColor}
         uncheckedColor={uncheckedColor}
+        hasLabel={!!label}
         size={size}
       />
     </StackedCheckBoxRoot>
@@ -57,7 +65,7 @@ const StackedBackground = styled.div`
   display: inline-block;
 
   z-index: -1;
-  top: -3px;
+  top: ${props => (props.hasLabel ? 0 : "-3px")};
   left: 3px;
 
   background: ${props =>
@@ -66,6 +74,8 @@ const StackedBackground = styled.div`
   border: 2px solid
     ${props =>
       props.checked ? color(props.checkedColor) : color(props.uncheckedColor)};
+
+  opacity: ${props => (props.disabled ? 0.4 : 1)};
 `;
 
 StackedCheckBox.propTypes = propTypes;

--- a/frontend/src/metabase/components/StackedCheckBox.styled.js
+++ b/frontend/src/metabase/components/StackedCheckBox.styled.js
@@ -1,0 +1,36 @@
+import styled from "styled-components";
+import CheckBox from "metabase/components/CheckBox";
+import { color } from "metabase/lib/colors";
+
+export const StackedCheckBoxRoot = styled.div`
+  position: relative;
+  transform: scale(1);
+  opacity: ${props => (props.disabled ? 0.4 : 1)};
+`;
+
+export const OpaqueCheckBox = styled(CheckBox)`
+  opacity: 1;
+`;
+
+export const StackedBackground = styled.div`
+  width: ${props => `${props.size}px`};
+  height: ${props => `${props.size}px`};
+  border-radius: 4px;
+  position: absolute;
+  display: inline-block;
+
+  z-index: -1;
+  top: -3px;
+  left: 3px;
+
+  background: ${props =>
+    props.checked ? color(props.checkedColor) : color("bg-white")};
+
+  border: 2px solid
+    ${props =>
+      props.checked ? color(props.checkedColor) : color(props.uncheckedColor)};
+`;
+
+export const Label = styled(CheckBox.Label)`
+  margin-top: -2px;
+`;

--- a/frontend/src/metabase/dashboard/components/AddSeriesModal.jsx
+++ b/frontend/src/metabase/dashboard/components/AddSeriesModal.jsx
@@ -329,6 +329,7 @@ export default class AddSeriesModal extends Component {
                   >
                     <span className="px1 flex-no-shrink">
                       <CheckBox
+                        label={question.displayName()}
                         checked={enabledQuestions[question.id()]}
                         onChange={e =>
                           this.handleQuestionSelectedChange(
@@ -338,7 +339,6 @@ export default class AddSeriesModal extends Component {
                         }
                       />
                     </span>
-                    <span className="px1">{question.displayName()}</span>
                     {!question.isStructured() && (
                       <Tooltip
                         tooltip={t`We're not sure if this question is compatible`}

--- a/frontend/src/metabase/internal/components/ScratchApp.jsx
+++ b/frontend/src/metabase/internal/components/ScratchApp.jsx
@@ -103,8 +103,8 @@ export default class ScratchApp extends React.Component {
           onChange={this.handleChange}
         />
         <div className="absolute bottom right flex align-center p1">
-          <span className="mr1">Centered:</span>
           <CheckBox
+            label="Centered"
             checked={centered}
             onChange={e => this.setState({ centered: !centered })}
           />

--- a/frontend/src/metabase/lib/colors.js
+++ b/frontend/src/metabase/lib/colors.js
@@ -25,6 +25,7 @@ const colors = {
   white: "#FFFFFF",
   black: "#2E353B",
   success: "#84BB4C",
+  danger: "#ED6E6E",
   error: "#ED6E6E",
   warning: "#F9CF48",
   "text-dark": "#4C5773",

--- a/frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx
+++ b/frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx
@@ -24,6 +24,7 @@ const DisplayOptionsPane = ({
   <div className={className}>
     <div className="flex align-center my1">
       <CheckBox
+        label={t`Border`}
         checked={displayOptions.bordered}
         onChange={e =>
           onChangeDisplayOptions({
@@ -32,10 +33,10 @@ const DisplayOptionsPane = ({
           })
         }
       />
-      <span className="ml1">{t`Border`}</span>
     </div>
     <div className="flex align-center my1">
       <CheckBox
+        label={t`Title`}
         checked={displayOptions.titled}
         onChange={e =>
           onChangeDisplayOptions({
@@ -44,7 +45,6 @@ const DisplayOptionsPane = ({
           })
         }
       />
-      <span className="ml1">{t`Title`}</span>
     </div>
     <EmbedSelect
       value={displayOptions.theme}

--- a/frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx
@@ -94,17 +94,13 @@ export default class FilterOptions extends Component {
     return (
       <div className="flex align-center">
         {options.map(([name, option]) => (
-          <div
-            key={name}
-            className="flex align-center"
-            onClick={() => this.toggleOptionValue(name)}
-          >
+          <div key={name} className="flex align-center">
             <CheckBox
+              label={this.getOptionName(name)}
               checkedColor="accent2"
               checked={this.getOptionValue(name)}
               onChange={() => this.toggleOptionValue(name)}
             />
-            <label className="ml1">{this.getOptionName(name)}</label>
           </div>
         ))}
       </div>

--- a/frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx
@@ -100,7 +100,7 @@ export default class FilterOptions extends Component {
             onClick={() => this.toggleOptionValue(name)}
           >
             <CheckBox
-              color="purple"
+              checkedColor="accent2"
               checked={this.getOptionValue(name)}
               onChange={() => this.toggleOptionValue(name)}
             />

--- a/frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx
@@ -137,7 +137,7 @@ export default class SelectPicker extends Component {
                   >
                     <CheckBox
                       checked={checked.has(option.key)}
-                      color="purple"
+                      checkedColor="accent2"
                     />
                     <h4 className="ml1">{this.nameForOption(option)}</h4>
                   </label>

--- a/frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx
@@ -2,7 +2,6 @@
 import React from "react";
 
 import { t } from "ttag";
-import cx from "classnames";
 
 import PopoverWithTrigger from "metabase/components/PopoverWithTrigger";
 import CheckBox from "metabase/components/CheckBox";
@@ -27,32 +26,25 @@ export default function FieldsPicker({
     >
       <ul className="pt1">
         {(onSelectAll || onSelectNone) && (
-          <li
-            className={cx(
-              "px1 pb1 flex align-center cursor-pointer border-bottom mb1",
-              { disabled: isAll && !onSelectNone },
-            )}
-            onClick={() => {
-              if (isAll) {
-                onSelectNone();
-              } else {
-                onSelectAll();
-              }
-            }}
-          >
+          <li className="px1 pb1 flex align-center border-bottom mb1">
             <StackedCheckBox
+              label={isAll && onSelectNone ? t`Select None` : t`Select All`}
               checked={isAll}
               indeterminate={!isAll && !isNone}
+              disabled={isAll && !onSelectNone}
+              onChange={() => {
+                if (isAll) {
+                  onSelectNone();
+                } else {
+                  onSelectAll();
+                }
+              }}
               className="mr1"
             />
-            {isAll && onSelectNone ? t`Select None` : t`Select All`}
           </li>
         )}
         {dimensions.map(dimension => (
-          <li
-            key={dimension.key()}
-            className="px1 pb1 flex align-center cursor-pointer"
-          >
+          <li key={dimension.key()} className="px1 pb1 flex align-center">
             <CheckBox
               checked={selected.has(dimension.key())}
               label={dimension.displayName()}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx
@@ -52,12 +52,15 @@ export default function FieldsPicker({
           <li
             key={dimension.key()}
             className="px1 pb1 flex align-center cursor-pointer"
-            onClick={() => {
-              onToggleDimension(dimension, !selected.has(dimension.key()));
-            }}
           >
-            <CheckBox checked={selected.has(dimension.key())} className="mr1" />
-            {dimension.displayName()}
+            <CheckBox
+              checked={selected.has(dimension.key())}
+              label={dimension.displayName()}
+              onChange={() => {
+                onToggleDimension(dimension, !selected.has(dimension.key()));
+              }}
+              className="mr1"
+            />
           </li>
         ))}
       </ul>

--- a/frontend/src/metabase/sharing/components/EmailAttachmentPicker.jsx
+++ b/frontend/src/metabase/sharing/components/EmailAttachmentPicker.jsx
@@ -208,15 +208,15 @@ export default class EmailAttachmentPicker extends Component {
                   <li
                     key={card.id}
                     className="pb2 flex align-center cursor-pointer"
-                    onClick={() => {
-                      this.onToggleCard(card);
-                    }}
                   >
                     <CheckBox
                       checked={selectedCardIds.has(card.id)}
+                      label={card.name}
+                      onChange={() => {
+                        this.onToggleCard(card);
+                      }}
                       className="mr1"
                     />
-                    {card.name}
                   </li>
                 ))}
               </ul>

--- a/frontend/src/metabase/sharing/components/EmailAttachmentPicker.jsx
+++ b/frontend/src/metabase/sharing/components/EmailAttachmentPicker.jsx
@@ -6,7 +6,6 @@ import { t } from "ttag";
 
 import ButtonGroup from "metabase/components/ButtonGroup";
 import CheckBox from "metabase/components/CheckBox";
-import Text from "metabase/components/type/Text";
 import Label from "metabase/components/type/Label";
 import StackedCheckBox from "metabase/components/StackedCheckBox";
 import Toggle from "metabase/components/Toggle";
@@ -190,19 +189,17 @@ export default class EmailAttachmentPicker extends Component {
               />
             </div>
             <div className="text-bold pt1 pb2 flex justify-between align-center">
-              <ul>
-                <li
-                  className="mb2 flex align-center cursor-pointer border-bottom"
-                  onClick={this.onToggleAll}
-                >
+              <ul className="full">
+                <li className="mb2 pb1 flex align-center cursor-pointer border-bottom">
                   <StackedCheckBox
+                    label={t`Questions to attach`}
                     checked={this.areAllSelected(cards, selectedCardIds)}
                     indeterminate={this.areOnlySomeSelected(
                       cards,
                       selectedCardIds,
                     )}
+                    onChange={this.onToggleAll}
                   />
-                  <Text ml={1}>{t`Questions to attach`}</Text>
                 </li>
                 {cards.map(card => (
                   <li

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -526,14 +526,15 @@ describe("scenarios > collection_defaults", () => {
           selectItemUsingCheckbox("Orders");
           cy.findByText("1 item selected").should("be.visible");
 
-          // Select all
-          cy.icon("dash").click();
-          cy.icon("dash").should("not.exist");
-          cy.findByText("4 items selected");
-
-          // Deselect all
           cy.findByTestId("bulk-action-bar").within(() => {
-            cy.icon("check").click();
+            // Select all
+            cy.findByTestId("checkbox-root").should("be.visible");
+            cy.icon("dash").click({ force: true });
+            cy.icon("dash").should("not.exist");
+            cy.findByText("4 items selected");
+
+            // Deselect all
+            cy.icon("check").click({ force: true });
           });
           cy.icon("check").should("not.exist");
           cy.findByTestId("bulk-action-bar").should("not.be.visible");
@@ -630,8 +631,9 @@ function selectItemUsingCheckbox(item, icon = "table") {
     .closest("tr")
     .within(() => {
       cy.icon(icon).trigger("mouseover");
-      cy.findByRole("checkbox")
+      cy.findByTestId("checkbox-root")
         .should("be.visible")
+        .findByRole("checkbox")
         .click();
     });
 }

--- a/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
@@ -603,7 +603,7 @@ describe("scenarios > dashboard", () => {
     // which is actually "Include" followed by "this minute" wrapped in <strong>, so has to be clicked this way
     cy.contains("Include this minute").click();
     // make sure the checkbox was checked
-    cy.findByRole("checkbox").should("have.attr", "aria-checked", "true");
+    cy.findByRole("checkbox").should("be.checked");
   });
 
   it("user without data permissions should be able to use dashboard filter (metabase#15119)", () => {

--- a/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
@@ -110,7 +110,7 @@ describe("scenarios > dashboard > subscriptions", () => {
       cy.findAllByRole("listitem")
         .contains("Orders") // yields the whole <li> element
         .within(() => {
-          cy.findByRole("checkbox").should("have.attr", "aria-checked", "true");
+          cy.findByRole("checkbox").should("be.checked");
         });
     });
 


### PR DESCRIPTION
This PR refactors `CheckBox` and `StackedCheckBox` components. The main motivation is to fix a11y issues, but it also aligns components with our current code style.

* refactors `CheckBox` to use `<input type="checkbox" />` under the hood. Currently it's just a div with `role="checkbox"` and click handlers
* refactors `StackedCheckBox` to use only one `CheckBox` input, and to render a stacked background as a different component. Currently, it just renders two checkboxes, so if you tab through the page, you'd focus on both of them which is pretty unexpected
* extends both components with a `label` prop. Now you can pass a string or a custom React component to display a label on the right side (clicking a label would lead to a `checked` change as if you click the checkbox itself)
* refactors `CheckBox` not to use deprecated color names
* code style: migrated to styled-components, prop-types position, .etc

### To Verify

1. Open `/_internal/components/checkbox` and `/_internal/components/stackedcheckbox`
2. Ensure every demo makes sense

Note: `StackedCheckBox` with a label renders weirdly in the StyleGuide, but looks as expected in the app itself. You can check a `FieldsPicker` example

1. Ask a question > Custom Question > Sample Dataset > Any Table
2. Click a "Columns" button on the right side of the "Data" panel (the one with a data source)
3. A popup with a list of table columns opens, look on the "Select All" checkbox in the top