### PR TITLE
Fix "Run selected text" removes everything but the selected text from the query

### DIFF
--- a/frontend/src/metabase/query_builder/reducers.js
+++ b/frontend/src/metabase/query_builder/reducers.js
@@ -229,7 +229,13 @@ export const card = handleActions(
 
     [UPDATE_QUESTION]: (state, { payload: { card } }) => card,
 
-    [QUERY_COMPLETED]: (state, { payload: { card } }) => card,
+    [QUERY_COMPLETED]: {
+      next: (state, { payload: { card } }) => ({
+        ...state,
+        display: card.display,
+        visualization_settings: card.visualization_settings,
+      }),
+    },
 
     [CREATE_PUBLIC_LINK]: {
       next: (state, { payload }) => ({ ...state, public_uuid: payload.uuid }),

--- a/frontend/test/metabase/scenarios/native/reproductions/16886.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/reproductions/16886.cy.spec.js
@@ -8,7 +8,7 @@ const highlightSelectedText = "{shift}{rightarrow}".repeat(
   SELECTED_TEXT.length,
 );
 
-describe.skip("issue 16886", () => {
+describe("issue 16886", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();


### PR DESCRIPTION
A regression caused by #16761 (Fix newly added columns don't appear after some columns are hidden)

**Explanation:**

In order to run a query, the frontend dispatches the `runQuery` thunk action. When running only a specific part of a query, the frontend generates a new card and dispatches the action with the `overrideWithCard` parameter. Once the query is completed, the handler dispatches the `QUERY_COMPLETED` action with a `card` in its payload. The trick is that the reducer was meant to ignore the card's `dataset_query` object. #16761 changed the reducer, so it just replaced the card with a new one (because we also had to update `visualization_settings` to fix #15393). That also meant that a new SQL text from `dataset_query` would replace the previous one. As a result, when we were running only a selected part of the query, it would erase non-selected text.

Fixed by updating the reducer, so `dataset_query` is not overwritten on `QUERY_COMPLETED`

Fixes #16886 

### To Verify

1. Ask a question > Native Question > Sample Dataset
2. Enter `select 1 from ORDERS`
3. Run the query
4. Select the `select 1` part, run the query
5. Ensure the query text is still `select 1 from ORDERS`, but the result is still `1`

### Demo

**Before**
![before](https://user-images.githubusercontent.com/17258145/124751983-f01fb980-df2f-11eb-9c1d-3ef5038038d9.gif)


**After**
![after](https://user-images.githubusercontent.com/17258145/124751985-f150e680-df2f-11eb-9d5a-73b0331d1804.gif)

