### PR TITLE
Update logic and labels for settings updates preferences in Cloud and Enterprise

### DIFF
--- a/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx
@@ -83,7 +83,10 @@ export default class SettingsUpdatesForm extends Component {
         </div>
       );
     } else {
-      return <div>{t`No successful checks yet.`}</div>;
+      return (
+        <div>{t`Sorry, we were unable to check for updates at this time. Last successful check was
+         ${MetabaseSettings.versionInfoLastChecked()}.`}</div>
+      );
     }
   }
 

--- a/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx
@@ -81,10 +81,7 @@ export default class SettingsUpdatesForm extends Component {
         </div>
       );
     } else {
-      return (
-        <div>{t`Sorry, we were unable to check for updates at this time. Last successful check was
-         ${MetabaseSettings.versionInfoLastChecked()}.`}</div>
-      );
+      return <div>{t`No successful checks yet.`}</div>;
     }
   }
 

--- a/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx
@@ -99,7 +99,7 @@ export default class SettingsUpdatesForm extends Component {
 
     return (
       <div style={{ width: "585px" }}>
-        <ul>{settings}</ul>
+        {!MetabaseSettings.isHosted() && <ul>{settings}</ul>}
 
         <div className="px2">
           <div className="pt3 border-top">

--- a/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx
@@ -19,20 +19,19 @@ export default class SettingsUpdatesForm extends Component {
   };
 
   renderVersionUpdateNotice() {
+    const currentVersion = formatVersion(MetabaseSettings.currentVersion());
+
     if (MetabaseSettings.isHosted()) {
       return (
-        <div>{t`Metabase Cloud keeps your instance up to date. Thanks for being a customer!`}</div>
+        <div>{t`Metabase Cloud keeps your instance up-to-date. You're currently on version ${currentVersion}. Thanks for being a customer!`}</div>
       );
     }
 
     if (MetabaseSettings.versionIsLatest()) {
-      const currentVersion = MetabaseSettings.currentVersion();
       return (
         <div>
           <div className="p2 bg-brand bordered rounded border-brand text-white text-bold">
-            {jt`You're running Metabase ${formatVersion(
-              currentVersion,
-            )} which is the latest and greatest!`}
+            {jt`You're running Metabase ${currentVersion} which is the latest and greatest!`}
           </div>
           {!MetabaseSettings.isHosted() && !MetabaseSettings.isEnterprise() && (
             <HostingCTA />
@@ -40,7 +39,6 @@ export default class SettingsUpdatesForm extends Component {
         </div>
       );
     } else if (MetabaseSettings.newVersionAvailable()) {
-      const currentVersion = MetabaseSettings.currentVersion();
       const latestVersion = MetabaseSettings.latestVersion();
       const versionInfo = MetabaseSettings.versionInfo();
       return (
@@ -48,7 +46,7 @@ export default class SettingsUpdatesForm extends Component {
           <div className="p2 bg-green bordered rounded border-success flex flex-row align-center justify-between">
             <span className="text-white text-bold">
               {jt`Metabase ${formatVersion(latestVersion)} is available.`}{" "}
-              {jt`You're running ${formatVersion(currentVersion)}`}
+              {jt`You're running ${currentVersion}`}
             </span>
             <ExternalLink
               data-metabase-event={

--- a/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx
@@ -3,6 +3,8 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { t, jt } from "ttag";
 import { Flex, Box } from "grid-styled";
+import cx from "classnames";
+
 import MetabaseSettings from "metabase/lib/settings";
 import SettingsSetting from "./SettingsSetting";
 
@@ -102,7 +104,11 @@ export default class SettingsUpdatesForm extends Component {
         {!MetabaseSettings.isHosted() && <ul>{settings}</ul>}
 
         <div className="px2">
-          <div className="pt3 border-top">
+          <div
+            className={cx("pt3", {
+              "border-top": !MetabaseSettings.isHosted(),
+            })}
+          >
             {this.renderVersionUpdateNotice()}
           </div>
         </div>

--- a/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx
@@ -28,14 +28,13 @@ export default class SettingsUpdatesForm extends Component {
     }
 
     if (MetabaseSettings.versionIsLatest()) {
+      const shouldShowHostedCta = !MetabaseSettings.isEnterprise();
       return (
         <div>
           <div className="p2 bg-brand bordered rounded border-brand text-white text-bold">
             {jt`You're running Metabase ${currentVersion} which is the latest and greatest!`}
           </div>
-          {!MetabaseSettings.isHosted() && !MetabaseSettings.isEnterprise() && (
-            <HostingCTA />
-          )}
+          {shouldShowHostedCta && <HostingCTA />}
         </div>
       );
     } else if (MetabaseSettings.newVersionAvailable()) {

--- a/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx
@@ -17,6 +17,12 @@ export default class SettingsUpdatesForm extends Component {
   };
 
   renderVersionUpdateNotice() {
+    if (MetabaseSettings.isHosted()) {
+      return (
+        <div>{t`Metabase Cloud keeps your instance up to date. Thanks for being a customer!`}</div>
+      );
+    }
+
     if (MetabaseSettings.versionIsLatest()) {
       const currentVersion = MetabaseSettings.currentVersion();
       return (
@@ -75,10 +81,7 @@ export default class SettingsUpdatesForm extends Component {
         </div>
       );
     } else {
-      return (
-        <div>{t`Sorry, we were unable to check for updates at this time. Last successful check was
-         ${MetabaseSettings.versionInfoLastChecked()}.`}</div>
-      );
+      return <div>{t`No successful checks yet.`}</div>;
     }
   }
 
@@ -131,6 +134,10 @@ function Version({ version }) {
 }
 
 function HostingCTA() {
+  if (MetabaseSettings.isEnterprise()) {
+    return null;
+  }
+
   return (
     <Flex
       justifyContent="space-between"

--- a/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx
@@ -23,7 +23,7 @@ export default class SettingsUpdatesForm extends Component {
 
     if (MetabaseSettings.isHosted()) {
       return (
-        <div>{t`Metabase Cloud keeps your instance up-to-date. You're currently on version ${currentVersion}. Thanks for being a customer!`}</div>
+        <div>{jt`Metabase Cloud keeps your instance up-to-date. You're currently on version ${currentVersion}. Thanks for being a customer!`}</div>
       );
     }
 

--- a/frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx
+++ b/frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx
@@ -192,18 +192,14 @@ export default class SettingsEditorApp extends Component {
           newVersionAvailable &&
           !MetabaseSettings.isHosted();
 
-        let newVersionIndicator;
-
-        if (shouldDisplayNewVersionIndicator) {
-          newVersionIndicator = (
-            <span
-              style={{ padding: "4px 8px 4px 8px" }}
-              className="bg-brand rounded text-white text-bold h6"
-            >
-              1
-            </span>
-          );
-        }
+        const newVersionIndicator = shouldDisplayNewVersionIndicator ? (
+          <span
+            style={{ padding: "4px 8px 4px 8px" }}
+            className="bg-brand rounded text-white text-bold h6"
+          >
+            1
+          </span>
+        ) : null;
 
         return (
           <li key={slug}>

--- a/frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx
+++ b/frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx
@@ -3,9 +3,11 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { Link } from "react-router";
 import { connect } from "react-redux";
+import { t } from "ttag";
+
 import title from "metabase/hoc/Title";
 import MetabaseAnalytics from "metabase/lib/analytics";
-import { t } from "ttag";
+import MetabaseSettings from "metabase/lib/settings";
 import AdminLayout from "metabase/components/AdminLayout";
 import { NotFound } from "metabase/containers/ErrorPages";
 
@@ -161,6 +163,7 @@ export default class SettingsEditorApp extends Component {
 
   renderSettingsSections() {
     const { sections, activeSectionName, newVersionAvailable } = this.props;
+    console.log("🚀", this.props);
 
     const renderedSections = Object.entries(sections).map(
       ([slug, section], idx) => {
@@ -185,8 +188,14 @@ export default class SettingsEditorApp extends Component {
         );
 
         // if this is the Updates section && there is a new version then lets add a little indicator
+        const shouldDisplayNewVersionIndicator =
+          slug === "updates" &&
+          newVersionAvailable &&
+          !MetabaseSettings.isHosted();
+
         let newVersionIndicator;
-        if (slug === "updates" && newVersionAvailable) {
+
+        if (shouldDisplayNewVersionIndicator) {
           newVersionIndicator = (
             <span
               style={{ padding: "4px 8px 4px 8px" }}

--- a/frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx
+++ b/frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx
@@ -163,7 +163,6 @@ export default class SettingsEditorApp extends Component {
 
   renderSettingsSections() {
     const { sections, activeSectionName, newVersionAvailable } = this.props;
-    console.log("🚀", this.props);
 
     const renderedSections = Object.entries(sections).map(
       ([slug, section], idx) => {


### PR DESCRIPTION
Fixes #16792

Intend to follow-up with e2e test PR.

## How To Test

### Cloud installations

In https://github.com/metabase/metabase/blob/master/frontend/src/metabase/lib/settings.js#L91, introduce an early return forcing `true`:

~~~js
  isHosted() {
    /* eslint-disable */
    return true
    
    // matches <custom>.metabaseapp.com and <custom>.metabaseapp.com/
    return /.+\.metabaseapp.com\/?$/i.test(this.get("site-url"));
  }
~~~

Visit http://localhost:3000/admin/settings/updates

You should:

1. no longer see a toggle to enable/disable updates
2. no longer see a number 1 beside "Updates" in the left menu, as a counter of available updates.
2. see the message `Metabase Cloud keeps your instance up to date. Thanks for being a customer!`

<img src="https://user-images.githubusercontent.com/380816/124791786-c0b68000-df22-11eb-9f97-6e4486822a87.png" width=400 />

<hr />

### Enterprise 

Start application in [Enterprise mode](https://github.com/metabase/metabase/blob/master/enterprise/README.md)

Manually populate `version-info` and `version-info-last-checked` in the `setting` table so that it triggers an update check (I don't know how to do this atm, please show me how).

You should no longer see a call to action about upgrading to Enterprise.

<img src="https://user-images.githubusercontent.com/380816/124778783-9d3a0800-df17-11eb-9566-940feab71bf6.png" width=400 />


