### PR TITLE
#16918 Repro: Pulse fails when question has date field with "Month of Year"

### DIFF
--- a/frontend/test/metabase/scenarios/sharing/reproductions/16918.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/reproductions/16918.cy.spec.js
@@ -1,0 +1,44 @@
+import { restore } from "__support__/e2e/cypress";
+import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
+
+const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATASET;
+
+const questionDetails = {
+  name: "16918",
+  query: {
+    "source-table": PRODUCTS_ID,
+    aggregation: [["count"]],
+    breakout: [
+      ["field", PRODUCTS.CREATED_AT, { "temporal-unit": "month-of-year" }],
+      ["field", PRODUCTS.CATEGORY, null],
+    ],
+  },
+  display: "line",
+};
+
+describe.skip("issue 16918", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.createQuestion(questionDetails).then(({ body }) => {
+      cy.intercept("GET", `/api/pulse/preview_card_info/${body.id}`).as(
+        "cardPreview",
+      );
+    });
+  });
+
+  it(`should load question binned by "Month of Year" or similar granularity (metabase#16918)`, () => {
+    cy.visit("/pulse/create");
+
+    cy.findByText("Select a question").click();
+    cy.findByText("16918").click();
+
+    cy.wait("@cardPreview").then(xhr => {
+      expect(xhr.response.statusCode).not.to.eq(500);
+    });
+
+    // Cypress should be able to find question title in the card preview
+    cy.findByText("16918");
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #16918

### How to test this manually?
- `yarn test-cypress-open --spec frontend/test/metabase/scenarios/sharing/reproductions/16918.cy.spec.js`
- Unskip test
- It should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/124776081-7263aa00-df3f-11eb-8ec3-2ad258b07128.png)

