### PR TITLE
[SQL filters coverage] Add initial set of e2e tests around SQL field filter type of ID

### DIFF
--- a/frontend/test/metabase/scenarios/filters/sql-field-filter-id.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/sql-field-filter-id.cy.spec.js
@@ -1,0 +1,56 @@
+import {
+  restore,
+  mockSessionProperty,
+  openNativeEditor,
+} from "__support__/e2e/cypress";
+
+import * as SQLFilter from "./helpers/e2e-sql-filter-helpers";
+import * as FieldFilter from "./helpers/e2e-field-filter-helpers";
+
+describe("scenarios > filters > sql filters > field filter > ID", () => {
+  beforeEach(() => {
+    restore();
+    cy.intercept("POST", "api/dataset").as("dataset");
+
+    cy.signInAsAdmin();
+    // Make sure feature flag is on regardles of the environment where this is running.
+    mockSessionProperty("field-filter-operators-enabled?", true);
+
+    openNativeEditor();
+    SQLFilter.enterParameterizedQuery(
+      "SELECT * FROM products WHERE {{filter}}",
+    );
+
+    SQLFilter.openTypePickerFromDefaultFilterType();
+    SQLFilter.chooseType("Field Filter");
+
+    FieldFilter.mapTo({
+      table: "Products",
+      field: "ID",
+    });
+
+    FieldFilter.setWidgetType("ID");
+  });
+
+  it("should work when set initially as default value and then through the filter widget", () => {
+    SQLFilter.toggleRequired();
+
+    FieldFilter.openEntryForm({ isFilterRequired: true });
+    FieldFilter.addDefaultStringFilter("2");
+
+    SQLFilter.runQuery();
+
+    cy.get(".Visualization").within(() => {
+      cy.findByText("Small Marble Shoes");
+    });
+
+    FieldFilter.openEntryForm();
+    FieldFilter.addWidgetStringFilter("1");
+
+    SQLFilter.runQuery();
+
+    cy.get(".Visualization").within(() => {
+      cy.findByText("Rustic Paper Wallet");
+    });
+  });
+});

--- a/frontend/test/metabase/scenarios/filters/sql-field-filter-id.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/sql-field-filter-id.cy.spec.js
@@ -13,7 +13,7 @@ describe("scenarios > filters > sql filters > field filter > ID", () => {
     cy.intercept("POST", "api/dataset").as("dataset");
 
     cy.signInAsAdmin();
-    // Make sure feature flag is on regardles of the environment where this is running.
+    // Make sure feature flag is on regardless of the environment where this is running
     mockSessionProperty("field-filter-operators-enabled?", true);
 
     openNativeEditor();


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Adds an initial test flow around SQL filters for field filter type "ID" with the feature flag turned on
- Makes sure that it can be set implicitly as a default value on a required filter
- Makes sure that the explicitly set value through the filter widget overrides the default value

This PR is part of the series of tests we are trying to add, as explained in #16759.

### Screenshots
![image](https://user-images.githubusercontent.com/31325167/124810690-eb73f900-df61-11eb-8450-d12a7a0419cd.png)

