### PR TITLE
[SQL filters coverage] Add initial set of e2e tests around SQL field filter type of "None"

### DIFF
--- a/frontend/test/metabase/scenarios/filters/sql-field-filter-none.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/sql-field-filter-none.cy.spec.js
@@ -44,4 +44,17 @@ describe("scenarios > filters > sql filters > field filter > None", () => {
 
     cy.findByText("Showing 200 rows");
   });
+
+  it.skip("should let you change the field filter type to something else and restore the filter widget (metabase#13825)", () => {
+    FieldFilter.setWidgetType("String contains");
+
+    FieldFilter.openEntryForm();
+    FieldFilter.addWidgetStringFilter("zm");
+
+    SQLFilter.runQuery();
+
+    cy.get(".Visualization").within(() => {
+      cy.findByText("Rustic Paper Wallet");
+    });
+  });
 });

--- a/frontend/test/metabase/scenarios/filters/sql-field-filter-none.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/sql-field-filter-none.cy.spec.js
@@ -14,7 +14,7 @@ describe("scenarios > filters > sql filters > field filter > None", () => {
     cy.intercept("POST", "api/dataset").as("dataset");
 
     cy.signInAsAdmin();
-    // Make sure feature flag is on regardles of the environment where this is running.
+    // Make sure feature flag is on regardless of the environment where this is running
     mockSessionProperty("field-filter-operators-enabled?", true);
 
     openNativeEditor();

--- a/frontend/test/metabase/scenarios/filters/sql-field-filter-none.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/sql-field-filter-none.cy.spec.js
@@ -1,0 +1,47 @@
+import {
+  restore,
+  mockSessionProperty,
+  openNativeEditor,
+  filterWidget,
+} from "__support__/e2e/cypress";
+
+import * as SQLFilter from "./helpers/e2e-sql-filter-helpers";
+import * as FieldFilter from "./helpers/e2e-field-filter-helpers";
+
+describe("scenarios > filters > sql filters > field filter > None", () => {
+  beforeEach(() => {
+    restore();
+    cy.intercept("POST", "api/dataset").as("dataset");
+
+    cy.signInAsAdmin();
+    // Make sure feature flag is on regardles of the environment where this is running.
+    mockSessionProperty("field-filter-operators-enabled?", true);
+
+    openNativeEditor();
+    SQLFilter.enterParameterizedQuery(
+      "SELECT * FROM products WHERE {{filter}}",
+    );
+
+    SQLFilter.openTypePickerFromDefaultFilterType();
+    SQLFilter.chooseType("Field Filter");
+
+    FieldFilter.mapTo({
+      table: "Products",
+      field: "Category",
+    });
+
+    FieldFilter.setWidgetType("None");
+
+    filterWidget().should("not.exist");
+  });
+
+  it("should successfully run the query and show all results", () => {
+    SQLFilter.runQuery();
+
+    cy.get(".Visualization").within(() => {
+      cy.findByText("Rustic Paper Wallet");
+    });
+
+    cy.findByText("Showing 200 rows");
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Adds an initial test flow around SQL filters for field filter type "None" with the feature flag turned on
- Makes sure that the query can be run
- Adds the repro for #13825 

This PR is part of the series of tests we are trying to add, as explained in #16759.

### Screenshots
![image](https://user-images.githubusercontent.com/31325167/124817705-6ccf8980-df6a-11eb-83eb-9177b59268e4.png)

If we isolate and run repro for 13825 only, this is where it fails
![image](https://user-images.githubusercontent.com/31325167/124818221-0dbe4480-df6b-11eb-810c-b7cb5146b879.png)

