### PR TITLE
GitHub Actions: correct the way yarn is supposed to pull the deps

### DIFF
--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -56,7 +56,7 @@ jobs:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/project.clj') }}-${{ hashFiles('**/deps.edn') }}
 
-    - run: yarn install --lockfile
+    - run: yarn install --frozen-lockfile --prefer-offline
     - run: lein with-profile +include-all-drivers,+cloverage,+junit,+${{ matrix.edition }} deps
     - run: ./bin/build
 


### PR DESCRIPTION
There's no `--lockfile` option, the valid one is `--frozen-lockfile`.

https://classic.yarnpkg.com/en/docs/cli/install/#toc-yarn-install-frozen-lockfile

