### PR TITLE
Saved question picker bug bash

### DIFF
--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -899,7 +899,7 @@ const DatabaseSchemaPicker = ({
   }
 
   const sections = databases.map(database => ({
-    name: database.name,
+    name: database.is_saved_questions ? t`Saved Questions` : database.name,
     items:
       !database.is_saved_questions && database.schemas.length > 1
         ? database.schemas.map(schema => ({

--- a/frontend/src/metabase/query_builder/components/saved-question-picker/SavedQuestionPicker.jsx
+++ b/frontend/src/metabase/query_builder/components/saved-question-picker/SavedQuestionPicker.jsx
@@ -110,7 +110,7 @@ function SavedQuestionPicker({
       <CollectionsContainer>
         <BackButton onClick={onBack}>
           <Icon name="chevronleft" className="mr1" />
-          {t`Saved questions`}
+          {t`Saved Questions`}
         </BackButton>
         <Box my={1}>
           <Tree

--- a/frontend/src/metabase/query_builder/components/saved-question-picker/SavedQuestionPicker.jsx
+++ b/frontend/src/metabase/query_builder/components/saved-question-picker/SavedQuestionPicker.jsx
@@ -37,7 +37,7 @@ const propTypes = {
 
 const OUR_ANALYTICS_COLLECTION = {
   ...ROOT_COLLECTION,
-  schemaName: "Everything else",
+  schemaName: t`Everything else`,
   icon: "folder",
 };
 

--- a/frontend/src/metabase/query_builder/components/view/NewQuestionHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/NewQuestionHeader.jsx
@@ -1,11 +1,12 @@
 import React from "react";
+import { t } from "ttag";
 
 import ViewSection, { ViewHeading } from "./ViewSection";
 
 export default function NewQuestionHeader(props) {
   return (
     <ViewSection {...props}>
-      <ViewHeading>{`Pick your starting data`}</ViewHeading>
+      <ViewHeading>{t`Pick your starting data`}</ViewHeading>
     </ViewSection>
   );
 }

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -153,7 +153,7 @@
 
 (defn- saved-cards-virtual-db-metadata [& {:keys [include-tables? include-fields?]}]
   (when (public-settings/enable-nested-queries)
-    (cond-> {:name               "Saved Questions"
+    (cond-> {:name               (trs "Saved Questions")
              :id                 mbql.s/saved-questions-virtual-database-id
              :features           #{:basic-aggregations}
              :is_saved_questions true}


### PR DESCRIPTION
### Description

1) Fixes "Saved question" string not being translated
We have "Saved **Q**uestion" translated string

2) Fixes "Our analytics" folder is not showing items on different locales
When a user changes locale we should use translated "Everything else" schema name in requests

`http://localhost:3000/api/database/-1337/schema/Everything%20esle` — does not work

`http://localhost:3000/api/database/-1337/schema/Все%20остальное` — works

<img width="688" alt="Screen Shot 2021-07-08 at 21 01 26" src="https://user-images.githubusercontent.com/14301985/124969676-ab7b4780-e02f-11eb-9977-b3b3b6cbf04a.png">
