### PR TITLE
Question sidebar visual polish

### DIFF
--- a/frontend/src/metabase/components/Button.styled.jsx
+++ b/frontend/src/metabase/components/Button.styled.jsx
@@ -3,13 +3,14 @@ import Button from "metabase/components/Button";
 import { color } from "metabase/lib/colors";
 
 export const TextButton = styled(Button)`
-  color: ${color("text-light")};
+  color: ${color("text-medium")};
+  font-size: ${props => (props.small ? "0.875em" : "1em")};
   border: none;
   padding: 0;
   background-color: transparent;
 
   &:hover {
     background-color: transparent;
-    text-decoration: underline;
+    color: ${color("text-brand")};
   }
 `;

--- a/frontend/src/metabase/components/LastEditInfoLabel.js
+++ b/frontend/src/metabase/components/LastEditInfoLabel.js
@@ -6,7 +6,7 @@ import moment from "moment";
 
 import { getUser } from "metabase/selectors/user";
 
-import { TextButton } from "metabase/components/Button.styled";
+import Badge from "metabase/components/Badge";
 
 function mapStateToProps(state) {
   return {
@@ -45,11 +45,11 @@ function LastEditInfoLabel({ item, user, onClick, ...props }) {
     editorId === user.id ? t`you` : formatEditorName(first_name, last_name);
 
   return (
-    <TextButton
+    <Badge
       onClick={onClick}
       data-testid="revision-history-button"
       {...props}
-    >{t`Edited ${time} by ${editor}`}</TextButton>
+    >{t`Edited ${time} by ${editor}`}</Badge>
   );
 }
 

--- a/frontend/src/metabase/components/LastEditInfoLabel.js
+++ b/frontend/src/metabase/components/LastEditInfoLabel.js
@@ -6,7 +6,7 @@ import moment from "moment";
 
 import { getUser } from "metabase/selectors/user";
 
-import Badge from "metabase/components/Badge";
+import { TextButton } from "metabase/components/Button.styled";
 
 function mapStateToProps(state) {
   return {
@@ -45,11 +45,12 @@ function LastEditInfoLabel({ item, user, onClick, ...props }) {
     editorId === user.id ? t`you` : formatEditorName(first_name, last_name);
 
   return (
-    <Badge
+    <TextButton
+      small
       onClick={onClick}
       data-testid="revision-history-button"
       {...props}
-    >{t`Edited ${time} by ${editor}`}</Badge>
+    >{t`Edited ${time} by ${editor}`}</TextButton>
   );
 }
 

--- a/frontend/src/metabase/query_builder/components/QuestionActionButtons.jsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActionButtons.jsx
@@ -34,63 +34,59 @@ export default QuestionActionButtons;
 function QuestionActionButtons({ canWrite, onOpenModal }) {
   return (
     <Container>
-      <PrimaryButtonContainer>
-        {canWrite && (
-          <Tooltip tooltip={t`Edit details`}>
-            <Button
-              onlyIcon
-              icon="pencil"
-              iconSize={ICON_SIZE}
-              onClick={() => onOpenModal(EDIT_ACTION)}
-              data-testid={EDIT_TESTID}
-            />
-          </Tooltip>
-        )}
-        <Tooltip tooltip={t`Add to dashboard`}>
+      {canWrite && (
+        <Tooltip tooltip={t`Edit details`}>
           <Button
             onlyIcon
-            icon="add_to_dash"
+            icon="pencil"
             iconSize={ICON_SIZE}
-            onClick={() => onOpenModal(ADD_TO_DASH_ACTION)}
-            data-testid={ADD_TO_DASH_TESTID}
+            onClick={() => onOpenModal(EDIT_ACTION)}
+            data-testid={EDIT_TESTID}
           />
         </Tooltip>
-      </PrimaryButtonContainer>
-      <SecondaryButtonContainer>
-        {canWrite && (
-          <Tooltip tooltip={t`Move`}>
-            <Button
-              onlyIcon
-              icon="move"
-              iconSize={ICON_SIZE}
-              onClick={() => onOpenModal(MOVE_ACTION)}
-              data-testid={MOVE_TESTID}
-            />
-          </Tooltip>
-        )}
-        {canWrite && (
-          <Tooltip tooltip={t`Duplicate this question`}>
-            <Button
-              onlyIcon
-              icon="segment"
-              iconSize={ICON_SIZE}
-              onClick={() => onOpenModal(CLONE_ACTION)}
-              data-testid={CLONE_TESTID}
-            />
-          </Tooltip>
-        )}
-        {canWrite && (
-          <Tooltip tooltip={t`Archive`}>
-            <Button
-              onlyIcon
-              icon="archive"
-              iconSize={ICON_SIZE}
-              onClick={() => onOpenModal(ARCHIVE_ACTION)}
-              data-testid={ARCHIVE_TESTID}
-            />
-          </Tooltip>
-        )}
-      </SecondaryButtonContainer>
+      )}
+      <Tooltip tooltip={t`Add to dashboard`}>
+        <Button
+          onlyIcon
+          icon="add_to_dash"
+          iconSize={ICON_SIZE}
+          onClick={() => onOpenModal(ADD_TO_DASH_ACTION)}
+          data-testid={ADD_TO_DASH_TESTID}
+        />
+      </Tooltip>
+      {canWrite && (
+        <Tooltip tooltip={t`Move`}>
+          <Button
+            onlyIcon
+            icon="move"
+            iconSize={ICON_SIZE}
+            onClick={() => onOpenModal(MOVE_ACTION)}
+            data-testid={MOVE_TESTID}
+          />
+        </Tooltip>
+      )}
+      {canWrite && (
+        <Tooltip tooltip={t`Duplicate this question`}>
+          <Button
+            onlyIcon
+            icon="segment"
+            iconSize={ICON_SIZE}
+            onClick={() => onOpenModal(CLONE_ACTION)}
+            data-testid={CLONE_TESTID}
+          />
+        </Tooltip>
+      )}
+      {canWrite && (
+        <Tooltip tooltip={t`Archive`}>
+          <Button
+            onlyIcon
+            icon="archive"
+            iconSize={ICON_SIZE}
+            onClick={() => onOpenModal(ARCHIVE_ACTION)}
+            data-testid={ARCHIVE_TESTID}
+          />
+        </Tooltip>
+      )}
     </Container>
   );
 }

--- a/frontend/src/metabase/query_builder/components/QuestionActionButtons.jsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActionButtons.jsx
@@ -4,11 +4,7 @@ import { t } from "ttag";
 
 import Button from "metabase/components/Button";
 import Tooltip from "metabase/components/Tooltip";
-import {
-  Container,
-  PrimaryButtonContainer,
-  SecondaryButtonContainer,
-} from "./QuestionActionButtons.styled";
+import { Container } from "./QuestionActionButtons.styled";
 
 export const EDIT_TESTID = "edit-details-button";
 export const ADD_TO_DASH_TESTID = "add-to-dashboard-button";

--- a/frontend/src/metabase/query_builder/components/QuestionActionButtons.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActionButtons.styled.jsx
@@ -1,26 +1,8 @@
 import styled from "styled-components";
-import { color } from "metabase/lib/colors";
 
 export const Container = styled.div`
   display: flex;
   align-items: center;
   column-gap: 0.3rem;
   margin-top: 8px;
-`;
-
-export const PrimaryButtonContainer = styled.div`
-  display: flex;
-  column-gap: 0.5rem;
-  padding-right: 1rem;
-  border-right: 1px solid ${color("border")};
-`;
-
-export const SecondaryButtonContainer = styled.div`
-  display: flex;
-  column-gap: 0.5rem;
-  padding-left: 1rem;
-
-  .Icon {
-    color: ${color("text-light")};
-  }
 `;

--- a/frontend/src/metabase/query_builder/components/QuestionActionButtons.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActionButtons.styled.jsx
@@ -4,6 +4,8 @@ import { color } from "metabase/lib/colors";
 export const Container = styled.div`
   display: flex;
   align-items: center;
+  column-gap: 0.3rem;
+  margin-top: 8px;
 `;
 
 export const PrimaryButtonContainer = styled.div`

--- a/frontend/src/metabase/query_builder/components/QuestionActivityTimeline.jsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActivityTimeline.jsx
@@ -67,7 +67,7 @@ export function QuestionActivityTimeline({
 
   return (
     <div className={className}>
-      <SidebarSectionHeader>{t`Activity`}</SidebarSectionHeader>
+      <SidebarSectionHeader>{t`Revision history`}</SidebarSectionHeader>
       <Timeline
         items={revisionEvents}
         renderFooter={item => {

--- a/frontend/src/metabase/query_builder/components/QuestionActivityTimeline.jsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActivityTimeline.jsx
@@ -67,7 +67,7 @@ export function QuestionActivityTimeline({
 
   return (
     <div className={className}>
-      <SidebarSectionHeader>{t`Revision history`}</SidebarSectionHeader>
+      <SidebarSectionHeader>{t`History`}</SidebarSectionHeader>
       <Timeline
         items={revisionEvents}
         renderFooter={item => {

--- a/frontend/src/metabase/query_builder/components/QuestionActivityTimeline.jsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActivityTimeline.jsx
@@ -40,7 +40,7 @@ function RevisionEventFooter({ revision, onRevisionClick }) {
     <div>
       <RevertButton
         actionFn={() => onRevisionClick(revision)}
-        normalText={t`Revert back`}
+        normalText={t`Revert`}
         activeText={t`Reverting…`}
         failedText={t`Revert failed`}
         successText={t`Reverted`}

--- a/frontend/src/metabase/query_builder/components/QuestionActivityTimeline.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActivityTimeline.styled.jsx
@@ -27,7 +27,8 @@ export const RevertButton = styled(ActionButton).attrs({
 })`
   padding: 0;
   border: none;
-  color: ${color("accent3")};
+  color: ${color("text-dark")};
+  font-size: 0.875em;
 
   &:hover {
     background-color: transparent;

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -165,7 +165,7 @@ export class ViewTitleHeader extends React.Component {
                 />
               )}
             </div>
-            <ViewSubHeading className="flex align-center flex-wrap">
+            <ViewSubHeading className="flex align-center flex-wrap pt1">
               <CollectionBadge
                 className="mb1"
                 collectionId={question.collectionId()}

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebarPanel.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebarPanel.jsx
@@ -25,7 +25,10 @@ function QuestionDetailsSidebarPanel({ question, onOpenModal }) {
           visibleLines={8}
           onEdit={() => onOpenModal("edit")}
         />
-        <QuestionActivityTimeline question={question} />
+        <QuestionActivityTimeline
+          className="border-top mt2 pt4"
+          question={question}
+        />
       </SidebarContentContainer>
     </SidebarContent>
   );

--- a/frontend/test/metabase/query_builder/components/QuestionActivityTimeline.unit.spec.jsx
+++ b/frontend/test/metabase/query_builder/components/QuestionActivityTimeline.unit.spec.jsx
@@ -48,7 +48,7 @@ describe("QuestionActivityTimeline", () => {
     });
 
     it("should not render revert action buttons", () => {
-      expect(() => screen.getByText("Revert back")).toThrow();
+      expect(() => screen.getByText("Revert")).toThrow();
     });
   });
 
@@ -68,11 +68,11 @@ describe("QuestionActivityTimeline", () => {
     });
 
     it("should render revert action buttons", () => {
-      expect(screen.getByText("Revert back")).toBeInTheDocument();
+      expect(screen.getByText("Revert")).toBeInTheDocument();
     });
 
-    it("should call revertToRevision when revert back button is clicked", () => {
-      screen.getByText("Revert back").click();
+    it("should call revertToRevision when revert button is clicked", () => {
+      screen.getByText("Revert").click();
       expect(revertToRevision).toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
- Makes the action buttons look a bit nicer
- Nicer spacing between buttons + description vs the activity feed
- Less bold Revert button
- Airier spacing between question title and breadcrumbs
- Last-edited info is now same size and style as data breadcrumbs

Requesting a review from @kdoh because I bet he could dial in the spacing on some of these elements more nicely than I've been able to — I ran into a couple places, like the space betwee the question title and the chevron icon, where I wasn't sure how to tweak spacing with the styled-system approach we're now using.

![image](https://user-images.githubusercontent.com/2223916/124980526-59afce80-dfe9-11eb-9064-f1250e8451a1.png)
