### PR TITLE
CI GitHub Actions: recycle previously built front-end & drivers

### DIFF
--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -56,12 +56,6 @@ jobs:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/project.clj') }}-${{ hashFiles('**/deps.edn') }}
 
-    - run: yarn install --frozen-lockfile --prefer-offline
-    - run: lein with-profile +include-all-drivers,+cloverage,+junit,+${{ matrix.edition }} deps
-
-    - run: ./bin/build version
-    - run: ./bin/build translations
-
     - name: Grab previously built front-end (if equivalent)
       if: "!contains(github.event.head_commit.message, '[ci nocache]')"
       id: frontend-cache
@@ -77,6 +71,12 @@ jobs:
       with:
         path: ./modules/drivers/**/target
         key: buildcache-${{ matrix.edition }}-drivers-${{ hashFiles('**/modules/**/*.clj', '**/metabase-plugin.yaml') }}
+
+    - run: yarn install --frozen-lockfile --prefer-offline
+    - run: lein with-profile +include-all-drivers,+cloverage,+junit,+${{ matrix.edition }} deps
+
+    - run: ./bin/build version
+    - run: ./bin/build translations
 
     - run: ./bin/build frontend
       if: steps.frontend-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -58,7 +58,35 @@ jobs:
 
     - run: yarn install --frozen-lockfile --prefer-offline
     - run: lein with-profile +include-all-drivers,+cloverage,+junit,+${{ matrix.edition }} deps
-    - run: ./bin/build
+
+    - run: ./bin/build version
+    - run: ./bin/build translations
+
+    - name: Grab previously built front-end (if equivalent)
+      if: "!contains(github.event.head_commit.message, '[ci nocache]')"
+      id: frontend-cache
+      uses: actions/cache@v2
+      with:
+        path: ./resources/frontend_client/
+        key: buildcache-${{ matrix.edition }}-frontend-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.cljc', '**/*.cljs', '**/*.json', '**/yarn.lock', '**/sample-dataset.db.mv.db', '!**/frontend/test/') }}
+
+    - name: Grab previously built drivers (if equivalent)
+      if: "!contains(github.event.head_commit.message, '[ci nocache]')"
+      id: drivers-cache
+      uses: actions/cache@v2
+      with:
+        path: ./modules/drivers/**/target
+        key: buildcache-${{ matrix.edition }}-drivers-${{ hashFiles('**/modules/**/*.clj', '**/metabase-plugin.yaml') }}
+
+    - run: ./bin/build frontend
+      if: steps.frontend-cache.outputs.cache-hit != 'true'
+
+    - run: ./bin/build drivers
+      if: steps.drivers-cache.outputs.cache-hit != 'true'
+
+    - run: ./bin/build backend-licenses
+    - run: ./bin/build frontend-licenses
+    - run: ./bin/build uberjar
 
     - name: Mark with the commit hash
       run:  git rev-parse --short HEAD > COMMIT-ID


### PR DESCRIPTION
For our JAR sanity check post-merge (launch and see if it works with Java 8/11/16), the Uberjar build could enjoy a shortcircuiting, similar although not as complete as the build cache logic in CircleCI. This shorten the JAR build from 20 minutes to 7 minutes, give or take.

Before:

![image](https://user-images.githubusercontent.com/7288/125009935-639df580-e01a-11eb-82b7-f7f6b8475e33.png)

After:

![image](https://user-images.githubusercontent.com/7288/125009847-32252a00-e01a-11eb-8854-60b8cdd8c980.png)
