### PR TITLE
Fix console errors for Radio and SegmentedControl

### DIFF
--- a/frontend/src/metabase/admin/permissions/components/PermissionsTabs.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsTabs.jsx
@@ -13,7 +13,7 @@ const PermissionsTabs = ({ tab, onChangeTab }) => (
         { name: t`Data permissions`, value: `databases` },
         { name: t`Collection permissions`, value: `collections` },
       ]}
-      onChange={onChangeTab}
+      onOptionClick={onChangeTab}
       variant="underlined"
       py={2}
     />

--- a/frontend/src/metabase/components/Radio.info.js
+++ b/frontend/src/metabase/components/Radio.info.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import Radio from "metabase/components/Radio";
 
 export const component = Radio;
@@ -8,15 +8,24 @@ export const description = `
 A standard radio button group.
 `;
 
-const PROPS = {
-  value: 0,
-  options: [{ name: "Gadget", value: 0 }, { name: "Gizmo", value: 1 }],
-};
+const OPTIONS = [{ name: "Gadget", value: 0 }, { name: "Gizmo", value: 1 }];
+
+function RadioDemo(props) {
+  const [value, setValue] = useState(0);
+  return (
+    <Radio
+      {...props}
+      options={OPTIONS}
+      value={value}
+      onChange={nextValue => setValue(nextValue)}
+    />
+  );
+}
 
 export const examples = {
-  default: <Radio {...PROPS} />,
-  underlined: <Radio {...PROPS} variant="underlined" />,
-  "show buttons": <Radio {...PROPS} showButtons />,
-  vertical: <Radio {...PROPS} vertical />,
-  bubble: <Radio {...PROPS} variant="bubble" />,
+  default: <RadioDemo />,
+  underlined: <RadioDemo variant="underlined" />,
+  "show buttons": <RadioDemo showButtons />,
+  vertical: <RadioDemo vertical />,
+  bubble: <RadioDemo variant="bubble" />,
 };

--- a/frontend/src/metabase/components/Radio.jsx
+++ b/frontend/src/metabase/components/Radio.jsx
@@ -56,7 +56,7 @@ const VARIANTS = {
 
 function Radio({
   name: nameFromProps,
-  value,
+  value: currentValue,
   options,
   onChange,
   optionNameFn = defaultNameGetter,
@@ -75,7 +75,7 @@ function Radio({
 
   const [List, Item] = VARIANTS[variant] || VARIANTS.normal;
 
-  if (variant === "underlined" && value === undefined) {
+  if (variant === "underlined" && currentValue === undefined) {
     console.warn(
       "Radio can't underline selected option when no value is given.",
     );
@@ -84,38 +84,39 @@ function Radio({
   return (
     <List {...props} vertical={vertical} showButtons={showButtons}>
       {options.map((option, index) => {
-        const selected = value === optionValueFn(option);
+        const value = optionValueFn(option);
+        const selected = currentValue === value;
         const last = index === options.length - 1;
         const key = optionKeyFn(option);
         const id = `${name}-${key}`;
         const labelId = `${id}-label`;
         return (
-          <Item
-            key={key}
-            selected={selected}
-            last={last}
-            vertical={vertical}
-            showButtons={showButtons}
-            py={py}
-            xspace={xspace}
-            yspace={yspace}
-          >
-            {option.icon && <Icon name={option.icon} mr={1} />}
-            <RadioInput
-              id={id}
-              name={name}
-              value={optionValueFn(option)}
-              checked={selected}
-              onChange={() => onChange(optionValueFn(option))}
-              // Workaround for https://github.com/testing-library/dom-testing-library/issues/877
-              // TODO Try removing once jest upgraded
-              aria-labelledby={labelId}
-            />
-            {showButtons && <RadioButton checked={selected} />}
-            <label id={labelId} htmlFor={id}>
+          <li key={key}>
+            <Item
+              id={labelId}
+              htmlFor={id}
+              selected={selected}
+              last={last}
+              vertical={vertical}
+              showButtons={showButtons}
+              py={py}
+              xspace={xspace}
+              yspace={yspace}
+            >
+              {option.icon && <Icon name={option.icon} mr={1} />}
+              <RadioInput
+                id={id}
+                name={name}
+                value={value}
+                checked={selected}
+                onChange={() => onChange(value)}
+                // Workaround for https://github.com/testing-library/dom-testing-library/issues/877
+                aria-labelledby={labelId}
+              />
+              {showButtons && <RadioButton checked={selected} />}
               {optionNameFn(option)}
-            </label>
-          </Item>
+            </Item>
+          </li>
         );
       })}
     </List>

--- a/frontend/src/metabase/components/Radio.jsx
+++ b/frontend/src/metabase/components/Radio.jsx
@@ -4,6 +4,7 @@ import _ from "underscore";
 
 import Icon from "metabase/components/Icon";
 import {
+  RadioInput,
   BubbleList,
   BubbleItem,
   NormalList,
@@ -91,17 +92,15 @@ function Radio({
             py={py}
             xspace={xspace}
             yspace={yspace}
-            onClick={e => onChange(optionValueFn(option))}
             aria-selected={selected}
           >
             {option.icon && <Icon name={option.icon} mr={1} />}
-            <input
-              className="Form-radio"
-              type="radio"
+            <RadioInput
               name={name}
               value={optionValueFn(option)}
               checked={selected}
               id={name + "-" + optionKeyFn(option)}
+              onChange={() => onChange(optionValueFn(option))}
             />
             {showButtons && (
               <label htmlFor={name + "-" + optionKeyFn(option)} />

--- a/frontend/src/metabase/components/Radio.jsx
+++ b/frontend/src/metabase/components/Radio.jsx
@@ -85,6 +85,7 @@ function Radio({
         const last = index === options.length - 1;
         const key = optionKeyFn(option);
         const id = `${name}-${key}`;
+        const labelId = `${id}-label`;
         return (
           <Item
             key={key}
@@ -95,7 +96,6 @@ function Radio({
             py={py}
             xspace={xspace}
             yspace={yspace}
-            aria-selected={selected}
           >
             {option.icon && <Icon name={option.icon} mr={1} />}
             <RadioInput
@@ -104,9 +104,14 @@ function Radio({
               value={optionValueFn(option)}
               checked={selected}
               onChange={() => onChange(optionValueFn(option))}
+              // Workaround for https://github.com/testing-library/dom-testing-library/issues/877
+              // TODO Try removing once jest upgraded
+              aria-labelledby={labelId}
             />
             {showButtons && <RadioButton checked={selected} />}
-            <label htmlFor={id}>{optionNameFn(option)}</label>
+            <label id={labelId} htmlFor={id}>
+              {optionNameFn(option)}
+            </label>
           </Item>
         );
       })}

--- a/frontend/src/metabase/components/Radio.jsx
+++ b/frontend/src/metabase/components/Radio.jsx
@@ -5,6 +5,7 @@ import _ from "underscore";
 import Icon from "metabase/components/Icon";
 import {
   RadioInput,
+  RadioButton,
   BubbleList,
   BubbleItem,
   NormalList,
@@ -82,9 +83,11 @@ function Radio({
       {options.map((option, index) => {
         const selected = value === optionValueFn(option);
         const last = index === options.length - 1;
+        const key = optionKeyFn(option);
+        const id = `${name}-${key}`;
         return (
           <Item
-            key={optionKeyFn(option)}
+            key={key}
             selected={selected}
             last={last}
             vertical={vertical}
@@ -96,16 +99,14 @@ function Radio({
           >
             {option.icon && <Icon name={option.icon} mr={1} />}
             <RadioInput
+              id={id}
               name={name}
               value={optionValueFn(option)}
               checked={selected}
-              id={name + "-" + optionKeyFn(option)}
               onChange={() => onChange(optionValueFn(option))}
             />
-            {showButtons && (
-              <label htmlFor={name + "-" + optionKeyFn(option)} />
-            )}
-            <span>{optionNameFn(option)}</span>
+            {showButtons && <RadioButton checked={selected} />}
+            <label htmlFor={id}>{optionNameFn(option)}</label>
           </Item>
         );
       })}

--- a/frontend/src/metabase/components/Radio.jsx
+++ b/frontend/src/metabase/components/Radio.jsx
@@ -27,7 +27,10 @@ const optionShape = PropTypes.shape({
 const propTypes = {
   name: PropTypes.string,
   value: PropTypes.any,
-  options: PropTypes.arrayOf(optionShape).isRequired,
+  options: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.string),
+    PropTypes.arrayOf(optionShape),
+  ]).isRequired,
   onChange: PropTypes.func,
   optionNameFn: PropTypes.func,
   optionValueFn: PropTypes.func,

--- a/frontend/src/metabase/components/Radio.jsx
+++ b/frontend/src/metabase/components/Radio.jsx
@@ -32,6 +32,7 @@ const propTypes = {
     PropTypes.arrayOf(optionShape),
   ]).isRequired,
   onChange: PropTypes.func,
+  onOptionClick: PropTypes.func,
   optionNameFn: PropTypes.func,
   optionValueFn: PropTypes.func,
   optionKeyFn: PropTypes.func,
@@ -58,7 +59,13 @@ function Radio({
   name: nameFromProps,
   value: currentValue,
   options,
+
+  // onChange won't fire when you click an already checked item
+  // onOptionClick will fire in any case
+  // onOptionClick can be used for e.g. tab navigation like on the admin Permissions page)
+  onOptionClick,
   onChange,
+
   optionNameFn = defaultNameGetter,
   optionValueFn = defaultValueGetter,
   optionKeyFn = defaultValueGetter,
@@ -102,6 +109,11 @@ function Radio({
               py={py}
               xspace={xspace}
               yspace={yspace}
+              onClick={() => {
+                if (typeof onOptionClick === "function") {
+                  onOptionClick(value);
+                }
+              }}
             >
               {option.icon && <Icon name={option.icon} mr={1} />}
               <RadioInput
@@ -109,7 +121,11 @@ function Radio({
                 name={name}
                 value={value}
                 checked={selected}
-                onChange={() => onChange(value)}
+                onChange={() => {
+                  if (typeof onChange === "function") {
+                    onChange(value);
+                  }
+                }}
                 // Workaround for https://github.com/testing-library/dom-testing-library/issues/877
                 aria-labelledby={labelId}
               />

--- a/frontend/src/metabase/components/Radio.styled.js
+++ b/frontend/src/metabase/components/Radio.styled.js
@@ -8,8 +8,8 @@ export const RadioInput = styled.input.attrs({ type: "radio" })`
   cursor: inherit;
   position: absolute;
   opacity: 0;
-  width: 100%;
-  height: 100%;
+  width: 0;
+  height: 0;
   top: 0;
   left: 0;
   margin: 0;
@@ -38,7 +38,7 @@ const BaseList = styled.ul`
   flex-direction: ${props => (props.vertical ? "column" : "row")};
 `;
 
-const BaseItem = styled.li.attrs({
+const BaseItem = styled.label.attrs({
   mr: props => (!props.vertical && !props.last ? props.xspace : null),
   mb: props => (props.vertical && !props.last ? props.yspace : null),
 })`

--- a/frontend/src/metabase/components/Radio.styled.js
+++ b/frontend/src/metabase/components/Radio.styled.js
@@ -4,6 +4,37 @@ import { space } from "styled-system";
 
 import { color, lighten } from "metabase/lib/colors";
 
+export const RadioInput = styled.input.attrs({ type: "radio" })`
+  cursor: inherit;
+  position: absolute;
+  opacity: 0;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  margin: 0;
+  padding: 0;
+  z-index: 1;
+
+  & + label {
+    cursor: pointer;
+    display: inline-block;
+    flex: 0 0 auto;
+    position: relative;
+    margin-right: 0.5rem;
+    width: 8px;
+    height: 8px;
+    border: 2px solid white;
+    box-shadow: 0 0 0 2px ${color("shadow")};
+    border-radius: 8px;
+  }
+
+  &:checked + label {
+    box-shadow: 0 0 0 2px ${color("shadow")};
+    background-color: ${color("brand")};
+  }
+`;
+
 // BASE
 const BaseList = styled.ul`
   display: flex;
@@ -15,6 +46,7 @@ const BaseItem = styled.li.attrs({
   mb: props => (props.vertical && !props.last ? props.yspace : null),
 })`
   ${space}
+  position: relative;
   display: flex;
   align-items: center;
   cursor: pointer;

--- a/frontend/src/metabase/components/Radio.styled.js
+++ b/frontend/src/metabase/components/Radio.styled.js
@@ -15,24 +15,21 @@ export const RadioInput = styled.input.attrs({ type: "radio" })`
   margin: 0;
   padding: 0;
   z-index: 1;
+`;
 
-  & + label {
-    cursor: pointer;
-    display: inline-block;
-    flex: 0 0 auto;
-    position: relative;
-    margin-right: 0.5rem;
-    width: 8px;
-    height: 8px;
-    border: 2px solid white;
-    box-shadow: 0 0 0 2px ${color("shadow")};
-    border-radius: 8px;
-  }
-
-  &:checked + label {
-    box-shadow: 0 0 0 2px ${color("shadow")};
-    background-color: ${color("brand")};
-  }
+export const RadioButton = styled.div`
+  cursor: pointer;
+  display: inline-block;
+  flex: 0 0 auto;
+  position: relative;
+  margin-right: 0.5rem;
+  width: 12px;
+  height: 12px;
+  border: 2px solid white;
+  box-shadow: 0 0 0 2px ${color("shadow")};
+  border-radius: 12px;
+  background-color: ${props =>
+    props.checked ? color("brand") : "transparent"};
 `;
 
 // BASE

--- a/frontend/src/metabase/components/SegmentedControl.jsx
+++ b/frontend/src/metabase/components/SegmentedControl.jsx
@@ -2,7 +2,11 @@ import React, { useMemo } from "react";
 import PropTypes from "prop-types";
 import _ from "underscore";
 import Icon from "metabase/components/Icon";
-import { SegmentedList, SegmentedItem } from "./SegmentedControl.styled";
+import {
+  SegmentedList,
+  SegmentedItem,
+  SegmentedControlRadio,
+} from "./SegmentedControl.styled";
 
 const optionShape = PropTypes.shape({
   name: PropTypes.node.isRequired,
@@ -43,17 +47,15 @@ export function SegmentedControl({
             isSelected={isSelected}
             isFirst={isFirst}
             isLast={isLast}
-            onClick={e => onChange(option.value)}
             selectedColor={option.selectedColor || "brand"}
           >
             {option.icon && <Icon name={option.icon} mr={1} />}
-            <input
+            <SegmentedControlRadio
               id={`${name}-${option.value}`}
-              className="Form-radio"
-              type="radio"
               name={name}
               value={option.value}
               checked={isSelected}
+              onChange={() => onChange(option.value)}
             />
             <span>{option.name}</span>
           </SegmentedItem>

--- a/frontend/src/metabase/components/SegmentedControl.jsx
+++ b/frontend/src/metabase/components/SegmentedControl.jsx
@@ -41,24 +41,30 @@ export function SegmentedControl({
         const isSelected = option.value === value;
         const isFirst = index === 0;
         const isLast = index === options.length - 1;
+        const id = `${name}-${option.value}`;
+        const labelId = `${name}-${option.value}`;
         return (
-          <SegmentedItem
-            key={option.value}
-            isSelected={isSelected}
-            isFirst={isFirst}
-            isLast={isLast}
-            selectedColor={option.selectedColor || "brand"}
-          >
-            {option.icon && <Icon name={option.icon} mr={1} />}
-            <SegmentedControlRadio
-              id={`${name}-${option.value}`}
-              name={name}
-              value={option.value}
-              checked={isSelected}
-              onChange={() => onChange(option.value)}
-            />
-            <span>{option.name}</span>
-          </SegmentedItem>
+          <li key={option.value}>
+            <SegmentedItem
+              id={labelId}
+              isSelected={isSelected}
+              isFirst={isFirst}
+              isLast={isLast}
+              selectedColor={option.selectedColor || "brand"}
+            >
+              {option.icon && <Icon name={option.icon} mr={1} />}
+              <SegmentedControlRadio
+                id={id}
+                name={name}
+                value={option.value}
+                checked={isSelected}
+                onChange={() => onChange(option.value)}
+                // Workaround for https://github.com/testing-library/dom-testing-library/issues/877
+                aria-labelledby={labelId}
+              />
+              {option.name}
+            </SegmentedItem>
+          </li>
         );
       })}
     </SegmentedList>

--- a/frontend/src/metabase/components/SegmentedControl.styled.js
+++ b/frontend/src/metabase/components/SegmentedControl.styled.js
@@ -8,6 +8,7 @@ export const SegmentedList = styled.ul`
 `;
 
 export const SegmentedItem = styled.li`
+  position: relative;
   display: flex;
   align-items: center;
   font-weight: bold;
@@ -25,4 +26,17 @@ export const SegmentedItem = styled.li`
   :hover {
     color: ${props => (!props.isSelected ? color(props.selectedColor) : null)};
   }
+`;
+
+export const SegmentedControlRadio = styled.input.attrs({ type: "radio" })`
+  cursor: inherit;
+  position: absolute;
+  opacity: 0;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  margin: 0;
+  padding: 0;
+  z-index: 1;
 `;

--- a/frontend/src/metabase/components/SegmentedControl.styled.js
+++ b/frontend/src/metabase/components/SegmentedControl.styled.js
@@ -7,7 +7,7 @@ export const SegmentedList = styled.ul`
   display: flex;
 `;
 
-export const SegmentedItem = styled.li`
+export const SegmentedItem = styled.label`
   position: relative;
   display: flex;
   align-items: center;
@@ -32,8 +32,8 @@ export const SegmentedControlRadio = styled.input.attrs({ type: "radio" })`
   cursor: inherit;
   position: absolute;
   opacity: 0;
-  width: 100%;
-  height: 100%;
+  width: 0;
+  height: 0;
   top: 0;
   left: 0;
   margin: 0;

--- a/frontend/src/metabase/css/components/form.css
+++ b/frontend/src/metabase/css/components/form.css
@@ -104,28 +104,6 @@
   transition: border 300ms ease-in-out;
 }
 
-.Form-radio {
-  display: none;
-}
-
-.Form-radio + label {
-  cursor: pointer;
-  display: inline-block;
-  flex: 0 0 auto;
-  position: relative;
-  margin-right: var(--margin-1);
-  width: 8px;
-  height: 8px;
-  border: 2px solid white;
-  box-shadow: 0 0 0 2px var(--color-shadow);
-  border-radius: 8px;
-}
-
-.Form-radio:checked + label {
-  box-shadow: 0 0 0 2px var(--color-shadow);
-  background-color: var(--color-brand);
-}
-
 .Form-field .AdminSelect {
   border-color: var(--form-field-border-color);
 }

--- a/frontend/src/metabase/visualizations/components/ChartSettings.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings.jsx
@@ -247,6 +247,7 @@ class ChartSettings extends Component {
         options={sectionNames}
         optionNameFn={v => v}
         optionValueFn={v => v}
+        optionKeyFn={v => v}
         variant="bubble"
       />
     );

--- a/frontend/test/metabase/visualizations/components/ChartSettings.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/ChartSettings.unit.spec.js
@@ -20,10 +20,6 @@ function widget(widget = {}) {
   };
 }
 
-function expectTabSelected(node, value) {
-  expect(node.parentNode.getAttribute("aria-selected")).toBe(String(value));
-}
-
 describe("ChartSettings", () => {
   it("should not crash if there are no widgets", () => {
     render(<ChartSettings {...DEFAULT_PROPS} widgets={[]} />);
@@ -38,17 +34,17 @@ describe("ChartSettings", () => {
     );
   });
   it("should default to the first section (if no section in DEFAULT_TAB_PRIORITY)", () => {
-    const { getByText } = render(
+    const { getByLabelText } = render(
       <ChartSettings
         {...DEFAULT_PROPS}
         widgets={[widget({ section: "Foo" }), widget({ section: "Bar" })]}
       />,
     );
-    expectTabSelected(getByText("Foo"), true);
-    expectTabSelected(getByText("Bar"), false);
+    expect(getByLabelText("Foo")).toBeChecked();
+    expect(getByLabelText("Bar")).not.toBeChecked();
   });
   it("should default to the DEFAULT_TAB_PRIORITY", () => {
-    const { getByText } = render(
+    const { getByLabelText } = render(
       <ChartSettings
         {...DEFAULT_PROPS}
         widgets={[
@@ -57,21 +53,21 @@ describe("ChartSettings", () => {
         ]}
       />,
     );
-    expectTabSelected(getByText("Foo"), false);
-    expectTabSelected(getByText("Display"), true);
+    expect(getByLabelText("Foo")).not.toBeChecked();
+    expect(getByLabelText("Display")).toBeChecked();
   });
   it("should be able to switch sections", () => {
-    const { getByText } = render(
+    const { getByText, getByLabelText } = render(
       <ChartSettings
         {...DEFAULT_PROPS}
         widgets={[widget({ section: "Foo" }), widget({ section: "Bar" })]}
       />,
     );
-    expectTabSelected(getByText("Foo"), true);
-    expectTabSelected(getByText("Bar"), false);
+    expect(getByLabelText("Foo")).toBeChecked();
+    expect(getByLabelText("Bar")).not.toBeChecked();
     fireEvent.click(getByText("Bar"));
-    expectTabSelected(getByText("Foo"), false);
-    expectTabSelected(getByText("Bar"), true);
+    expect(getByLabelText("Foo")).not.toBeChecked();
+    expect(getByLabelText("Bar")).toBeChecked();
   });
 
   it("should show widget names", () => {


### PR DESCRIPTION
Both `Radio` and `SegmentedControl` use `<input type="radio" />` and pass the `checked` prop, but no `onChange` callback. This leads to a consol error: 

```
Failed prop type: You provided a `checked` prop to a form field without an `onChange` handler.
This will render a read-only field. If the field should be mutable use `defaultChecked`.
Otherwise, set either `onChange` or `readOnly`.
```

This happens because clicks are actually handled by input's parent elements (just styled divs). This PR moves the `onChange` from these divs to inputs. Also, it styles the HTML inputs to be invisible, so we can also keep inputs' custom look

**To Verify**

1. Open `_internal/components/radio` and `_internal/components/segmentedcontrol`
2. Ensure there are no console errors about their props
3. Ensure components there are no visual regressions
4. Select different options for every example and ensure there are no issues