### PR TITLE
Render/scalar

### DIFF
--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -56,13 +56,13 @@
                                  (merge {:executed-by pulse-creator-id
                                          :context     :pulse
                                          :card-id     card-id}
-                                        options))))]
-          (let [result (if pulse-creator-id
-                     (session/with-current-user pulse-creator-id
-                       (process-query))
-                     (process-query))]
-            {:card   card
-             :result result})))
+                                        options))))
+              result        (if pulse-creator-id
+                              (session/with-current-user pulse-creator-id
+                                (process-query))
+                              (process-query))]
+          {:card   card
+           :result result}))
       (catch Throwable e
         (log/warn e (trs "Error running query for Card {0}" card-id))))))
 
@@ -123,22 +123,27 @@
   [card-results]
   (let [{channel-id :id} (slack/files-channel)]
     (for [{{card-id :id, card-name :name, :as card} :card, result :result} card-results]
-      {:title                  card-name
-       :attachment-bytes-thunk (fn [] (render/render-pulse-card-to-png (defaulted-timezone card) card result))
-       :title_link             (urls/card-url card-id)
-       :attachment-name        "image.png"
-       :channel-id             channel-id
-       :fallback               card-name})))
+      {:title           card-name
+       :rendered-info   (render/render-pulse-card :inline (defaulted-timezone card) card result)
+       :title_link      (urls/card-url card-id)
+       :attachment-name "image.png"
+       :channel-id      channel-id
+       :fallback        card-name})))
 
 (defn create-and-upload-slack-attachments!
   "Create an attachment in Slack for a given Card by rendering its result into an image and uploading it."
   [attachments]
-  (doall
-   (for [{:keys [attachment-bytes-thunk attachment-name channel-id] :as attachment-data} attachments]
-     (let [slack-file-url (slack/upload-file! (attachment-bytes-thunk) attachment-name channel-id)]
-       (-> attachment-data
-           (select-keys [:title :title_link :fallback])
-           (assoc :image_url slack-file-url))))))
+  (letfn [(f [a] (select-keys a [:title :title_link :fallback]))]
+    (reduce (fn [processed {:keys [rendered-info attachment-name channel-id] :as attachment-data}]
+              (conj processed (if (:render/text rendered-info)
+                                (-> (f attachment-data)
+                                    (assoc :text (:render/text rendered-info)))
+                                (let [image-bytes (render/png-from-render-info rendered-info)
+                                      image-url (slack/upload-file! image-bytes attachment-name channel-id)]
+                                  (-> (f attachment-data)
+                                      (assoc :image_url image-url))))))
+            []
+            attachments)))
 
 (defn- is-card-empty?
   "Check if the card is empty"

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -220,12 +220,14 @@
 
 (s/defmethod render :scalar :- common/RenderedPulseCard
   [_ _ timezone-id card {:keys [cols rows]}]
-  {:attachments
-   nil
+  (let [value (format-cell timezone-id (ffirst rows) (first cols))]
+    {:attachments
+     nil
 
-   :content
-   [:div {:style (style/style (style/scalar-style))}
-    (h (format-cell timezone-id (ffirst rows) (first cols)))]})
+     :content
+     [:div {:style (style/style (style/scalar-style))}
+      (h value)]
+     :render/text (str value)}))
 
 (s/defmethod render :sparkline :- common/RenderedPulseCard
   [_ render-type timezone-id card {:keys [rows cols] :as data}]

--- a/src/metabase/pulse/render/common.clj
+++ b/src/metabase/pulse/render/common.clj
@@ -11,8 +11,9 @@
 
 (def RenderedPulseCard
   "Schema used for functions that operate on pulse card contents and their attachments"
-  {:attachments (s/maybe {s/Str URL})
-   :content     [s/Any]})
+  {:attachments                  (s/maybe {s/Str URL})
+   :content                      [s/Any]
+   (s/optional-key :render/text) (s/maybe s/Str)})
 
 (p.types/defrecord+ NumericWrapper [num-str]
   hutil/ToString

--- a/test/metabase/dashboard_subscription_test.clj
+++ b/test/metabase/dashboard_subscription_test.clj
@@ -170,18 +170,18 @@
       (fn [{:keys [card-id]} [pulse-results]]
         ;; If we don't force the thunk, the rendering code will never execute and attached-results-text won't be
         ;; called
-        (force-bytes-thunk pulse-results)
         (testing "\"more results in attachment\" text should not be present for Slack Pulses"
           (testing "Pulse results"
             (is (= {:channel-id "#general"
                     :message    "Aviary KPIs"
                     :attachments
-                    [{:title                  card-name
-                      :attachment-bytes-thunk true
-                      :title_link             (str "https://metabase.com/testmb/question/" card-id)
-                      :attachment-name        "image.png"
-                      :channel-id             "FOO"
-                      :fallback               card-name}]}
+                    [{:title           card-name
+                      :rendered-info   {:attachments false
+                                        :content     true}
+                      :title_link      (str "https://metabase.com/testmb/question/" card-id)
+                      :attachment-name "image.png"
+                      :channel-id      "FOO"
+                      :fallback        card-name}]}
                    (thunk->boolean pulse-results))))
           (testing "attached-results-text should be invoked exactly once"
             (is (= 1

--- a/test/metabase/pulse/render/body_test.clj
+++ b/test/metabase/pulse/render/body_test.clj
@@ -4,7 +4,8 @@
             [hiccup.core :refer [html]]
             [metabase.pulse.render.body :as body]
             [metabase.pulse.render.common :as common]
-            [metabase.pulse.render.test-util :as render.tu]))
+            [metabase.pulse.render.test-util :as render.tu]
+            [schema.core :as s]))
 
 (def ^:private pacific-tz "America/Los_Angeles")
 
@@ -248,36 +249,49 @@
       :content
       last))
 
-(deftest renders-int
-  (is (= "10"
-         (render-scalar-value {:cols [{:name         "ID",
-                                       :display_name "ID",
-                                       :base_type    :type/BigInteger
-                                       :semantic_type nil}]
-                               :rows [[10]]}))))
-
-(deftest renders-float
-  (is (= "10.12"
-         (render-scalar-value {:cols [{:name         "floatnum",
-                                       :display_name "FLOATNUM",
-                                       :base_type    :type/Float
-                                       :semantic_type nil}]
-                               :rows [[10.12345]]}))))
-
-(deftest renders-string
-  (is (= "foo"
-         (render-scalar-value {:cols [{:name         "stringvalue",
-                                       :display_name "STRINGVALUE",
-                                       :base_type    :type/Text
-                                       :semantic_type nil}]
-                               :rows [["foo"]]}))))
-(deftest renders-date
-  (is (= "Apr 1, 2014"
-         (render-scalar-value {:cols [{:name         "date",
-                                       :display_name "DATE",
-                                       :base_type    :type/DateTime
-                                       :semantic_type nil}]
-                               :rows [["2014-04-01T08:30:00.0000"]]}))))
+(deftest scalar-test
+  (testing "renders int"
+    (is (= "10"
+           (render-scalar-value {:cols [{:name         "ID",
+                                         :display_name "ID",
+                                         :base_type    :type/BigInteger
+                                         :semantic_type nil}]
+                                 :rows [[10]]}))))
+  (testing "renders float"
+    (is (= "10.12"
+           (render-scalar-value {:cols [{:name         "floatnum",
+                                         :display_name "FLOATNUM",
+                                         :base_type    :type/Float
+                                         :semantic_type nil}]
+                                 :rows [[10.12345]]}))))
+  (testing "renders string"
+    (is (= "foo"
+           (render-scalar-value {:cols [{:name         "stringvalue",
+                                         :display_name "STRINGVALUE",
+                                         :base_type    :type/Text
+                                         :semantic_type nil}]
+                                 :rows [["foo"]]}))))
+  (testing "renders date"
+    (is (= "Apr 1, 2014"
+           (render-scalar-value {:cols [{:name         "date",
+                                         :display_name "DATE",
+                                         :base_type    :type/DateTime
+                                         :semantic_type nil}]
+                                 :rows [["2014-04-01T08:30:00.0000"]]}))))
+  (testing "Includes raw text"
+    (let [results {:cols [{:name         "stringvalue",
+                           :display_name "STRINGVALUE",
+                           :base_type    :type/Text
+                           :semantic_type nil}]
+                   :rows [["foo"]]}]
+      (is (= "foo"
+             (:render/text (body/render :scalar nil pacific-tz nil results))))
+      (is (schema= {:attachments (s/eq nil)
+                    :content     [(s/one (s/eq :div) "div tag")
+                                  (s/one {:style s/Str} "style map")
+                              (s/one (s/eq "foo") "content")]
+                    :render/text (s/eq "foo")}
+                   (body/render :scalar nil pacific-tz nil results))))))
 
 (defn- replace-style-maps [hiccup-map]
   (walk/postwalk (fn [maybe-map]

--- a/test/metabase/pulse/test_util.clj
+++ b/test/metabase/pulse/test_util.clj
@@ -1,5 +1,6 @@
 (ns metabase.pulse.test-util
   (:require [clojure.walk :as walk]
+            [medley.core :as m]
             [metabase.integrations.slack :as slack]
             [metabase.models.pulse :as models.pulse :refer [Pulse]]
             [metabase.models.pulse-card :refer [PulseCard]]
@@ -142,4 +143,6 @@
 
 (defn thunk->boolean [{:keys [attachments] :as result}]
   (assoc result :attachments (for [attachment-info attachments]
-                               (update attachment-info :attachment-bytes-thunk fn?))))
+                               (-> attachment-info
+                                   (update :rendered-info (fn [ri]
+                                                            (m/map-vals some? ri)))))))

--- a/test/metabase/pulse/test_util.clj
+++ b/test/metabase/pulse/test_util.clj
@@ -133,14 +133,6 @@
       (invoke [_ x1 x2 x3 x4 x5 x6]
         (invoke-with-wrapping input output func [x1 x2 x3 x4 x5 x6])))))
 
-(defn force-bytes-thunk
-  "Grabs the thunk that produces the image byte array and invokes it"
-  [results]
-  ((-> results
-       :attachments
-       first
-       :attachment-bytes-thunk)))
-
 (defn thunk->boolean [{:keys [attachments] :as result}]
   (assoc result :attachments (for [attachment-info attachments]
                                (-> attachment-info


### PR DESCRIPTION
Updating scalar cards in pulses/subscriptions to be native text in slack

### Before
<img width="505" alt="image" src="https://user-images.githubusercontent.com/6377293/125104034-91c71800-e0a2-11eb-9e9b-dbbecfc9e78d.png">

### After
<img width="448" alt="image" src="https://user-images.githubusercontent.com/6377293/125104066-9b508000-e0a2-11eb-8d15-72c57294535e.png">

Looks much nicer inline with others as well:
<img width="578" alt="image" src="https://user-images.githubusercontent.com/6377293/125104130-aa373280-e0a2-11eb-8a8a-7a57351e5197.png">


Added lots of tests to this as well.