### PR TITLE
docs - fix pulse link [closes #16953]

### DIFF
--- a/docs/faq/general/what-languages-can-be-used-with-metabase.md
+++ b/docs/faq/general/what-languages-can-be-used-with-metabase.md
@@ -22,6 +22,7 @@ The languages you can currently pick from in Metabase are:
 - Polish
 - Portuguese
 - Russian
+- Serbian
 - Slovak
 - Spanish
 - Swedish

--- a/docs/users-guide/07-dashboards.md
+++ b/docs/users-guide/07-dashboards.md
@@ -2,6 +2,13 @@
 
 ![Interactive dashboard](images/dashboards/interactive-dashboard.png)
 
+Quick links:
+
+- [Dashboard filters](08-dashboard-filters.md)
+- [Dashboard subscriptions](dashboard-subscriptions.md)
+- [Make your dashboards interactive](interactive-dashboards.md)
+- [Learn how to build great dashboards](https://www.metabase.com/learn/dashboards/index.html)
+
 ### What is a dashboard?
 
 **Dashboards** group questions and present them on a single page. You can think of dashboards as shareable reports that feature a set of related questions.

--- a/frontend/src/metabase/pulse/components/PulseEdit.jsx
+++ b/frontend/src/metabase/pulse/components/PulseEdit.jsx
@@ -146,7 +146,7 @@ export default class PulseEdit extends Component {
     const link = (
       <a
         className="link"
-        href={MetabaseSettings.docsUrl("users-guide/07-dashboards")}
+        href={MetabaseSettings.docsUrl("users-guide/dashboard-subscriptions")}
       >{t`dashboard subscriptions`}</a>
     );
     return (


### PR DESCRIPTION
- updates a link in the app about pulses to point to a better docs page (dashboards -> dashboard subscriptions).
- adds some quick links to the Dashboard docs page.
- adds Serbian to the list of languages in docs.