### PR TITLE
Add `addFilterToDashboard` Cypress custom command

### DIFF
--- a/frontend/test/__support__/e2e/commands.js
+++ b/frontend/test/__support__/e2e/commands.js
@@ -3,6 +3,7 @@ import "./commands/ui/icon";
 
 import "./commands/api/question";
 import "./commands/api/dashboard";
+import "./commands/api/dashboardFilters";
 
 import "./commands/api/composite/createQuestionAndDashboard";
 

--- a/frontend/test/__support__/e2e/commands/api/dashboardFilters.js
+++ b/frontend/test/__support__/e2e/commands/api/dashboardFilters.js
@@ -1,0 +1,10 @@
+Cypress.Commands.add(
+  "addFilterToDashboard",
+  ({ filter, dashboard_id } = {}) => {
+    cy.log(`Add filter to the dashboard`);
+
+    cy.request("PUT", `/api/dashboard/${dashboard_id}`, {
+      parameters: [filter],
+    });
+  },
+);

--- a/frontend/test/metabase/scenarios/dashboard/parameters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/parameters.cy.spec.js
@@ -368,10 +368,7 @@ describe("scenarios > dashboard > parameters", () => {
         cy.request("POST", `/api/dashboard/${dashboard_id}/cards`, {
           cardId: card_id,
         }).then(({ body: { id } }) => {
-          // Add filter to the dashboard
-          cy.request("PUT", `/api/dashboard/${dashboard_id}`, {
-            parameters: [filter],
-          });
+          cy.addFilterToDashboard({ filter, dashboard_id });
 
           cy.request("PUT", `/api/dashboard/${dashboard_id}/cards`, {
             cards: [

--- a/frontend/test/metabase/scenarios/dashboard/title-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/title-drill.cy.spec.js
@@ -54,10 +54,7 @@ describe("scenarios > dashboard > title drill", () => {
         cy.request("POST", `/api/dashboard/${dashboard_id}/cards`, {
           cardId: card_id,
         }).then(({ body: { id } }) => {
-          // Add filter to the dashboard
-          cy.request("PUT", `/api/dashboard/${dashboard_id}`, {
-            parameters: [filter],
-          });
+          cy.addFilterToDashboard({ filter, dashboard_id });
 
           cy.request("PUT", `/api/dashboard/${dashboard_id}/cards`, {
             cards: [

--- a/frontend/test/metabase/scenarios/filters/reproductions/15163.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/reproductions/15163.cy.spec.js
@@ -42,10 +42,7 @@ const dashboardFilter = {
 
       cy.createNativeQuestion(nativeQuery).then(({ body: { id: card_id } }) => {
         cy.createDashboard("15163D").then(({ body: { id: dashboard_id } }) => {
-          // Add filter to the dashboard
-          cy.request("PUT", `/api/dashboard/${dashboard_id}`, {
-            parameters: [dashboardFilter],
-          });
+          cy.addFilterToDashboard({ filter: dashboardFilter, dashboard_id });
 
           // Add previously created question to the dashboard
           cy.request("POST", `/api/dashboard/${dashboard_id}/cards`, {


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Adds a new Cypress custom command `addFilterToDashboard` that simply adds a single filter to the dashboard (as the name implies)
- This pattern is used in many of our tests
- Applies that command to a few tests as an example