### PR TITLE
CI GitHub Actions: Cache JARs for Shadow CLJS

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -49,6 +49,11 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: 14.x
+    - name: Get M2 cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-cljs-${{ hashFiles('**/shadow-cljs.edn') }}
     - name: Get yarn cache
       uses: actions/cache@v2
       with:
@@ -85,6 +90,11 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: 14.x
+    - name: Get M2 cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-cljs-${{ hashFiles('**/shadow-cljs.edn') }}
     - name: Get yarn cache
       uses: actions/cache@v2
       with:
@@ -103,6 +113,11 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: 14.x
+    - name: Get M2 cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-cljs-${{ hashFiles('**/shadow-cljs.edn') }}
     - name: Get yarn cache
       uses: actions/cache@v2
       with:


### PR DESCRIPTION
Some front-end tasks require Shadow CLJS to compile files into JavaScript, therefore let's cache the JARs which it needs.

This also reduces the burden to Clojars, Maven Central, etc. In addition, it isolates our build in the rare event those sites aren't functional.

**Before**
The ESLint run looks like this:

![image](https://user-images.githubusercontent.com/7288/125134203-e2973a80-e0bb-11eb-8f89-a2ad24d47253.png)


**After**

![image](https://user-images.githubusercontent.com/7288/125134086-b1b70580-e0bb-11eb-8501-924d49b2ac62.png)

