### PR TITLE
Set program name on Oracle connections

### DIFF
--- a/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
+++ b/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
@@ -5,6 +5,7 @@
             [clojure.test :refer :all]
             [honeysql.core :as hsql]
             [metabase.driver :as driver]
+            [metabase.driver.oracle :as oracle]
             [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
             [metabase.driver.sql-jdbc.sync :as sql-jdbc.sync]
             [metabase.driver.sql.query-processor :as sql.qp]
@@ -58,9 +59,14 @@
              :service-name            "MyCoolService"
              :sid                     "ORCL"
              :ssl                     true}]]]
-    (is (= expected-spec
-           (sql-jdbc.conn/connection-details->spec :oracle details))
-        message)))
+    (let [actual-spec (sql-jdbc.conn/connection-details->spec :oracle details)
+          prog-prop   (deref #'oracle/prog-name-property)]
+      (is (= (dissoc expected-spec prog-prop)
+             (dissoc actual-spec prog-prop))
+          message)
+      ;; check our truncated Oracle version of the version/UUID string
+      ;; in some test cases, the version info isn't set, to the string "null" is the value
+      (is (re-matches #"MB (?:null|v(?:.*)) [\-a-f0-9]*" (get actual-spec prog-prop))))))
 
 (deftest require-sid-or-service-name-test
   (testing "no SID and no Service Name should throw an exception"


### PR DESCRIPTION
Update Oracle driver to set the v$session.program property on the connection, which appears in the PROGRAM column of the v$session table

Update tests accordingly
