### PR TITLE
When running <Logs> unit tests, mock XMLHttpRequest

### DIFF
--- a/frontend/test/metabase/admin/tasks/containers/Logs.unit.spec.js
+++ b/frontend/test/metabase/admin/tasks/containers/Logs.unit.spec.js
@@ -1,23 +1,20 @@
 import React from "react";
 import Logs from "metabase/admin/tasks/containers/Logs";
 import { render, screen } from "@testing-library/react";
+import mock from "xhr-mock";
 
 import { UtilApi } from "metabase/services";
 
 describe("Logs", () => {
   describe("log fetching", () => {
-    beforeEach(() => {
-      const xhrMockClass = () => ({
-        open: jest.fn(),
-        send: jest.fn(),
-        setRequestHeader: jest.fn(),
-      });
-
-      window.XMLHttpRequest = jest.fn().mockImplementation(xhrMockClass);
-    });
+    beforeEach(() => mock.setup());
+    afterEach(() => mock.teardown());
 
     it("should call UtilApi.logs after 1 second", () => {
       jest.useFakeTimers();
+      mock.get("/api/util/logs", {
+        body: JSON.stringify([]),
+      });
       render(<Logs />);
       const utilSpy = jest.spyOn(UtilApi, "logs");
 

--- a/frontend/test/metabase/admin/tasks/containers/Logs.unit.spec.js
+++ b/frontend/test/metabase/admin/tasks/containers/Logs.unit.spec.js
@@ -6,6 +6,16 @@ import { UtilApi } from "metabase/services";
 
 describe("Logs", () => {
   describe("log fetching", () => {
+    beforeEach(() => {
+      const xhrMockClass = () => ({
+        open: jest.fn(),
+        send: jest.fn(),
+        setRequestHeader: jest.fn(),
+      });
+
+      window.XMLHttpRequest = jest.fn().mockImplementation(xhrMockClass);
+    });
+
     it("should call UtilApi.logs after 1 second", () => {
       jest.useFakeTimers();
       render(<Logs />);


### PR DESCRIPTION
Since Jest runs with JSDom and JSDom doesn't really implement XHR, provide a mock implementation to avoid a thrown exception.

To try it: just check the CI output for front-end Jest unit-tests or run the specific test manually:
```
yarn test-unit frontend/test/metabase/admin/tasks/containers/Logs.unit.spec.js
```

**Before**

```
(node:1959) UnhandledPromiseRejectionWarning: SyntaxError
    at XMLHttpRequest.open (/home/runner/work/metabase/metabase/node_modules/jsdom/lib/jsdom/living/xmlhttprequest.js:486:15)
    at /home/runner/work/metabase/metabase/frontend/src/metabase/lib/api.js:189:13
    at new Promise (<anonymous>)
    at Api._makeRequest (/home/runner/work/metabase/metabase/frontend/src/metabase/lib/api.js:186:14)
    at Api._callee2$ (/home/runner/work/metabase/metabase/frontend/src/metabase/lib/api.js:163:24)
    at tryCatch (/home/runner/work/metabase/metabase/node_modules/regenerator-runtime/runtime.js:63:40)
    at Generator.invoke [as _invoke] (/home/runner/work/metabase/metabase/node_modules/regenerator-runtime/runtime.js:293:22)
    at Generator.next (/home/runner/work/metabase/metabase/node_modules/regenerator-runtime/runtime.js:118:21)
    at step (/home/runner/work/metabase/metabase/frontend/src/metabase/lib/api.js:6:317)
    at /home/runner/work/metabase/metabase/frontend/src/metabase/lib/api.js:6:547
(node:1959) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 10)
 PASS  frontend/test/metabase/admin/tasks/containers/Logs.unit.spec.js
```

**After**

```
 PASS  frontend/test/metabase/admin/tasks/containers/Logs.unit.spec.js
```
