### PR TITLE
In notebook: clicking Visualize should only offer to save question if there are changes

### DIFF
--- a/frontend/src/metabase/query_builder/components/notebook/Notebook.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/Notebook.jsx
@@ -18,6 +18,26 @@ export default function Notebook({ className, ...props }) {
     runQuestionQuery,
     setQueryBuilderMode,
   } = props;
+
+  // When switching out of the notebook editor, cleanupQuestion accounts for
+  // post aggregation filters and otherwise nested queries with duplicate column names.
+  async function cleanupQuestion() {
+    // Only update the question if it's dirty, otherwise Metabase
+    // will incorrectly display the Save button, even though there are no changes to save.
+    if (isDirty) {
+      let cleanQuestion = question.setQuery(question.query().clean());
+      if (cleanQuestion.display() === "table") {
+        cleanQuestion = cleanQuestion.setDefaultDisplay();
+      }
+      await cleanQuestion.update();
+      // switch mode before running otherwise URL update may cause it to switch back to notebook mode
+    }
+    await setQueryBuilderMode("view");
+    if (isResultDirty) {
+      await runQuestionQuery();
+    }
+  }
+
   return (
     <Box className={cx(className, "relative mb4")} px={[2, 3]}>
       <NotebookSteps {...props} />
@@ -26,24 +46,7 @@ export default function Notebook({ className, ...props }) {
           medium
           primary
           style={{ minWidth: 220 }}
-          onClick={async () => {
-            // Only update the question if it's dirty, otherwise Metabase
-            // will incorrectly display the Save button, even though there are no changes to save.
-            if (isDirty) {
-              // Cleaning the question here accounts for post aggregation filters and otherwise nested queries
-              // with duplicate column names when switching out of the notebook editor.
-              let cleanQuestion = question.setQuery(question.query().clean());
-              if (cleanQuestion.display() === "table") {
-                cleanQuestion = cleanQuestion.setDefaultDisplay();
-              }
-              await cleanQuestion.update();
-              // switch mode before running otherwise URL update may cause it to switch back to notebook mode
-            }
-            await setQueryBuilderMode("view");
-            if (isResultDirty) {
-              await runQuestionQuery();
-            }
-          }}
+          onClick={cleanupQuestion}
         >
           {t`Visualize`}
         </Button>

--- a/frontend/src/metabase/query_builder/components/notebook/Notebook.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/Notebook.jsx
@@ -22,16 +22,21 @@ export default function Notebook({ className, ...props }) {
   // When switching out of the notebook editor, cleanupQuestion accounts for
   // post aggregation filters and otherwise nested queries with duplicate column names.
   async function cleanupQuestion() {
-    // Only update the question if it's dirty, otherwise Metabase
+    let cleanQuestion = question.setQuery(question.query().clean());
+    if (cleanQuestion.display() === "table") {
+      cleanQuestion = cleanQuestion.setDefaultDisplay();
+    }
+    await cleanQuestion.update();
+  }
+
+  // vizualize switches the view to the question's visualization.
+  async function visualize() {
+    // Only cleanup the question if it's dirty, otherwise Metabase
     // will incorrectly display the Save button, even though there are no changes to save.
     if (isDirty) {
-      let cleanQuestion = question.setQuery(question.query().clean());
-      if (cleanQuestion.display() === "table") {
-        cleanQuestion = cleanQuestion.setDefaultDisplay();
-      }
-      await cleanQuestion.update();
-      // switch mode before running otherwise URL update may cause it to switch back to notebook mode
+      cleanupQuestion();
     }
+    // switch mode before running otherwise URL update may cause it to switch back to notebook mode
     await setQueryBuilderMode("view");
     if (isResultDirty) {
       await runQuestionQuery();
@@ -42,12 +47,7 @@ export default function Notebook({ className, ...props }) {
     <Box className={cx(className, "relative mb4")} px={[2, 3]}>
       <NotebookSteps {...props} />
       {isRunnable && (
-        <Button
-          medium
-          primary
-          style={{ minWidth: 220 }}
-          onClick={cleanupQuestion}
-        >
+        <Button medium primary style={{ minWidth: 220 }} onClick={visualize}>
           {t`Visualize`}
         </Button>
       )}

--- a/frontend/src/metabase/query_builder/components/notebook/Notebook.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/Notebook.jsx
@@ -12,6 +12,7 @@ import NotebookSteps from "./NotebookSteps";
 export default function Notebook({ className, ...props }) {
   const {
     question,
+    isDirty,
     isRunnable,
     isResultDirty,
     runQuestionQuery,
@@ -26,12 +27,16 @@ export default function Notebook({ className, ...props }) {
           primary
           style={{ minWidth: 220 }}
           onClick={async () => {
-            let cleanQuestion = question.setQuery(question.query().clean());
-            if (cleanQuestion.display() === "table") {
-              cleanQuestion = cleanQuestion.setDefaultDisplay();
+            // Only update the question if it's dirty, otherwise Metabase
+            // will incorrectly display the Save button, even though there are no changes to save (#13470).
+            if (isDirty) {
+              let cleanQuestion = question.setQuery(question.query().clean());
+              if (cleanQuestion.display() === "table") {
+                cleanQuestion = cleanQuestion.setDefaultDisplay();
+              }
+              await cleanQuestion.update();
+              // switch mode before running otherwise URL update may cause it to switch back to notebook mode
             }
-            await cleanQuestion.update();
-            // switch mode before running otherwise URL update may cause it to switch back to notebook mode
             await setQueryBuilderMode("view");
             if (isResultDirty) {
               await runQuestionQuery();

--- a/frontend/src/metabase/query_builder/components/notebook/Notebook.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/Notebook.jsx
@@ -28,8 +28,10 @@ export default function Notebook({ className, ...props }) {
           style={{ minWidth: 220 }}
           onClick={async () => {
             // Only update the question if it's dirty, otherwise Metabase
-            // will incorrectly display the Save button, even though there are no changes to save (#13470).
+            // will incorrectly display the Save button, even though there are no changes to save.
             if (isDirty) {
+              // Cleaning the question here accounts for post aggregation filters and otherwise nested queries
+              // with duplicate column names when switching out of the notebook editor.
               let cleanQuestion = question.setQuery(question.query().clean());
               if (cleanQuestion.display() === "table") {
                 cleanQuestion = cleanQuestion.setDefaultDisplay();

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -27,7 +27,7 @@ describe("scenarios > question > notebook", () => {
     cy.signInAsAdmin();
   });
 
-  it.skip("shouldn't offer to save the question when there were no changes (metabase#13470)", () => {
+  it("shouldn't offer to save the question when there were no changes (metabase#13470)", () => {
     openOrdersTable();
     // save question initially
     cy.findByText("Save").click();


### PR DESCRIPTION
Fixes #13470: "Metabase shouldn't offer to save the question when there were no changes (metabase#13470)".

