### PR TITLE
When running some Jest unit tests, use a MutationObserver shim

### DIFF
--- a/frontend/test/metabase/components/FieldValuesWidget.unit.spec.js
+++ b/frontend/test/metabase/components/FieldValuesWidget.unit.spec.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
+import "mutationobserver-shim";
 
 import { ORDERS, PRODUCTS, PEOPLE } from "__support__/sample_dataset_fixture";
 import { FieldValuesWidget } from "metabase/components/FieldValuesWidget";

--- a/frontend/test/metabase/containers/Overworld.unit.spec.js
+++ b/frontend/test/metabase/containers/Overworld.unit.spec.js
@@ -6,6 +6,7 @@ import {
 
 import "@testing-library/jest-dom/extend-expect";
 import { fireEvent, render, screen } from "@testing-library/react";
+import "mutationobserver-shim";
 
 const PIN_MESSAGE_DESCRIPTION = "Your team's most important dashboards go here";
 const PIN_MESSAGE_HINT =

--- a/frontend/test/metabase/entities/containers/EntityListLoader.unit.spec.js
+++ b/frontend/test/metabase/entities/containers/EntityListLoader.unit.spec.js
@@ -2,6 +2,7 @@
 import React from "react";
 
 import { render } from "@testing-library/react";
+import "mutationobserver-shim";
 import EntityListLoader from "metabase/entities/containers/EntityListLoader";
 import { Provider } from "react-redux";
 

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "jsonwebtoken": "^7.2.1",
     "lint-staged": "^3.3.1",
     "mockdate": "^2.0.2",
+    "mutationobserver-shim": "^0.3.7",
     "postcss-cssnext": "^2.4.0",
     "postcss-import": "^9.0.0",
     "postcss-loader": "^2.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9175,6 +9175,11 @@ mustache@^2.3.2:
   resolved "https://registry.yarnpkg.com/mustache/-/mustache-2.3.2.tgz#a6d4d9c3f91d13359ab889a812954f9230a3d0c5"
   integrity sha512-KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ==
 
+mutationobserver-shim@^0.3.7:
+  version "0.3.7"
+  resolved "https://registry.yarnpkg.com/mutationobserver-shim/-/mutationobserver-shim-0.3.7.tgz#8bf633b0c0b0291a1107255ed32c13088a8c5bf3"
+  integrity sha512-oRIDTyZQU96nAiz2AQyngwx1e89iApl2hN5AOYwyxLUB47UYsU3Wv9lJWqH5y/QdiYkc5HQLi23ZNB3fELdHcQ==
+
 mz@^2.6.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/mz/-/mz-2.7.0.tgz#95008057a56cafadc2bc63dde7f9ff6955948e32"


### PR DESCRIPTION
Once we have an updated Jest that likely includes a newer version of JSDOM (e.g. v13 or later seems to support MutationObserver), then we can get rid of the shim.

To try it: just check the CI output for front-end Jest unit-tests or run the specific test manually:
```
yarn test-unit frontend/test/metabase/components/FieldValuesWidget.unit.spec.js
```


**Before**

(node:1966) UnhandledPromiseRejectionWarning: TypeError: MutationObserver is not a constructor
(node:1966) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 15)
 PASS  frontend/test/metabase/components/FieldValuesWidget.unit.spec.js

 **After**
 PASS  frontend/test/metabase/components/FieldValuesWidget.unit.spec.js