### PR TITLE
Data selector: avoid toggling popover when it's not ready

### DIFF
--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -461,7 +461,7 @@ export class UnconnectedDataSelector extends Component {
     const nextStep = this.getNextStep();
     if (!nextStep) {
       await this.setStateWithComputedState(stateChange);
-      this.popover.current.toggle();
+      this.popover.current && this.popover.current.toggle();
     } else {
       await this.switchToStep(nextStep, stateChange, skipSteps);
     }


### PR DESCRIPTION
To try it: just check the CI output for front-end Jest unit-tests or run the specific test manually:

```
yarn test-unit frontend/test/metabase/query_builder/components/DataSelector.unit.spec.js
```

**Before**

(node:42827) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'toggle' of null
(Use `node --trace-warnings ...` to show where the warning was created)
(node:42827) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)

**After**

No such warning anymore.