### PR TITLE
Improve SettingsUpdatesForm component

### DIFF
--- a/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/SettingsUpdatesForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/SettingsUpdatesForm.jsx
@@ -6,7 +6,7 @@ import { Flex, Box } from "grid-styled";
 import cx from "classnames";
 
 import MetabaseSettings from "metabase/lib/settings";
-import SettingsSetting from "./SettingsSetting";
+import SettingsSetting from "../SettingsSetting";
 
 import HostingInfoLink from "metabase/admin/settings/components/widgets/HostingInfoLink";
 import Icon from "metabase/components/Icon";
@@ -17,72 +17,6 @@ export default class SettingsUpdatesForm extends Component {
   static propTypes = {
     elements: PropTypes.array,
   };
-
-  renderVersionUpdateNotice() {
-    const currentVersion = formatVersion(MetabaseSettings.currentVersion());
-
-    if (MetabaseSettings.isHosted()) {
-      return (
-        <div>{jt`Metabase Cloud keeps your instance up-to-date. You're currently on version ${currentVersion}. Thanks for being a customer!`}</div>
-      );
-    }
-
-    if (MetabaseSettings.versionIsLatest()) {
-      const shouldShowHostedCta = !MetabaseSettings.isEnterprise();
-      return (
-        <div>
-          <div className="p2 bg-brand bordered rounded border-brand text-white text-bold">
-            {jt`You're running Metabase ${currentVersion} which is the latest and greatest!`}
-          </div>
-          {shouldShowHostedCta && <HostingCTA />}
-        </div>
-      );
-    } else if (MetabaseSettings.newVersionAvailable()) {
-      const latestVersion = MetabaseSettings.latestVersion();
-      const versionInfo = MetabaseSettings.versionInfo();
-      return (
-        <div>
-          <div className="p2 bg-green bordered rounded border-success flex flex-row align-center justify-between">
-            <span className="text-white text-bold">
-              {jt`Metabase ${formatVersion(latestVersion)} is available.`}{" "}
-              {jt`You're running ${currentVersion}`}
-            </span>
-            <ExternalLink
-              data-metabase-event={
-                "Updates Settings; Update link clicked; " + latestVersion
-              }
-              className="Button Button--white Button--medium borderless"
-              href={
-                "https://www.metabase.com/docs/" +
-                latestVersion +
-                "/operations-guide/upgrading-metabase.html"
-              }
-            >
-              {t`Update`}
-            </ExternalLink>
-          </div>
-
-          <div
-            className="text-medium bordered rounded p2 mt2 overflow-y-scroll"
-            style={{ height: 330 }}
-          >
-            <h3 className="pb3 text-uppercase">{t`What's Changed:`}</h3>
-
-            <Version version={versionInfo.latest} />
-
-            {versionInfo.older &&
-              versionInfo.older.map((version, index) => (
-                <Version key={index} version={version} />
-              ))}
-          </div>
-
-          {!MetabaseSettings.isHosted() && <HostingCTA />}
-        </div>
-      );
-    } else {
-      return <div>{t`No successful checks yet.`}</div>;
-    }
-  }
 
   render() {
     const { elements, updateSetting } = this.props;
@@ -106,7 +40,7 @@ export default class SettingsUpdatesForm extends Component {
               "border-top": !MetabaseSettings.isHosted(),
             })}
           >
-            {this.renderVersionUpdateNotice()}
+            <VersionUpdateNotice />
           </div>
         </div>
       </div>
@@ -134,6 +68,72 @@ function Version({ version }) {
       </ul>
     </div>
   );
+}
+
+function VersionUpdateNotice() {
+  const currentVersion = formatVersion(MetabaseSettings.currentVersion());
+
+  if (MetabaseSettings.isHosted()) {
+    return (
+      <div>{jt`Metabase Cloud keeps your instance up-to-date. You're currently on version ${currentVersion}. Thanks for being a customer!`}</div>
+    );
+  }
+
+  if (MetabaseSettings.versionIsLatest()) {
+    const shouldShowHostedCta = !MetabaseSettings.isEnterprise();
+    return (
+      <div>
+        <div className="p2 bg-brand bordered rounded border-brand text-white text-bold">
+          {jt`You're running Metabase ${currentVersion} which is the latest and greatest!`}
+        </div>
+        {shouldShowHostedCta && <HostingCTA />}
+      </div>
+    );
+  } else if (MetabaseSettings.newVersionAvailable()) {
+    const latestVersion = MetabaseSettings.latestVersion();
+    const versionInfo = MetabaseSettings.versionInfo();
+    return (
+      <div>
+        <div className="p2 bg-green bordered rounded border-success flex flex-row align-center justify-between">
+          <span className="text-white text-bold">
+            {jt`Metabase ${formatVersion(latestVersion)} is available.`}{" "}
+            {jt`You're running ${currentVersion}`}
+          </span>
+          <ExternalLink
+            data-metabase-event={
+              "Updates Settings; Update link clicked; " + latestVersion
+            }
+            className="Button Button--white Button--medium borderless"
+            href={
+              "https://www.metabase.com/docs/" +
+              latestVersion +
+              "/operations-guide/upgrading-metabase.html"
+            }
+          >
+            {t`Update`}
+          </ExternalLink>
+        </div>
+
+        <div
+          className="text-medium bordered rounded p2 mt2 overflow-y-scroll"
+          style={{ height: 330 }}
+        >
+          <h3 className="pb3 text-uppercase">{t`What's Changed:`}</h3>
+
+          <Version version={versionInfo.latest} />
+
+          {versionInfo.older &&
+            versionInfo.older.map((version, index) => (
+              <Version key={index} version={version} />
+            ))}
+        </div>
+
+        {!MetabaseSettings.isHosted() && <HostingCTA />}
+      </div>
+    );
+  } else {
+    return <div>{t`No successful checks yet.`}</div>;
+  }
 }
 
 function HostingCTA() {

--- a/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/SettingsUpdatesForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/SettingsUpdatesForm.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import cx from "classnames";
@@ -11,6 +10,7 @@ import VersionUpdateNotice from "./VersionUpdateNotice/VersionUpdateNotice";
 export default class SettingsUpdatesForm extends Component {
   static propTypes = {
     elements: PropTypes.array,
+    updateSetting: PropTypes.func.isRequired,
   };
 
   render() {

--- a/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/SettingsUpdatesForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/SettingsUpdatesForm.jsx
@@ -7,38 +7,34 @@ import SettingsSetting from "../SettingsSetting";
 
 import VersionUpdateNotice from "./VersionUpdateNotice/VersionUpdateNotice";
 
-export default class SettingsUpdatesForm extends Component {
-  static propTypes = {
-    elements: PropTypes.array,
-    updateSetting: PropTypes.func.isRequired,
-  };
+export default function SettingsUpdatesForm({ elements, updateSetting }) {
+  const settings = elements.map((setting, index) => (
+    <SettingsSetting
+      key={setting.key}
+      setting={setting}
+      onChange={value => updateSetting(setting, value)}
+      autoFocus={index === 0}
+    />
+  ));
 
-  render() {
-    const { elements, updateSetting } = this.props;
+  return (
+    <div style={{ width: "585px" }}>
+      {!MetabaseSettings.isHosted() && <ul>{settings}</ul>}
 
-    const settings = elements.map((setting, index) => (
-      <SettingsSetting
-        key={setting.key}
-        setting={setting}
-        onChange={value => updateSetting(setting, value)}
-        autoFocus={index === 0}
-      />
-    ));
-
-    return (
-      <div style={{ width: "585px" }}>
-        {!MetabaseSettings.isHosted() && <ul>{settings}</ul>}
-
-        <div className="px2">
-          <div
-            className={cx("pt3", {
-              "border-top": !MetabaseSettings.isHosted(),
-            })}
-          >
-            <VersionUpdateNotice />
-          </div>
+      <div className="px2">
+        <div
+          className={cx("pt3", {
+            "border-top": !MetabaseSettings.isHosted(),
+          })}
+        >
+          <VersionUpdateNotice />
         </div>
       </div>
-    );
-  }
+    </div>
+  );
 }
+
+SettingsUpdatesForm.propTypes = {
+  elements: PropTypes.array,
+  updateSetting: PropTypes.func.isRequired,
+};

--- a/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/SettingsUpdatesForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/SettingsUpdatesForm.jsx
@@ -1,17 +1,12 @@
 /* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import { t, jt } from "ttag";
-import { Flex, Box } from "grid-styled";
 import cx from "classnames";
 
 import MetabaseSettings from "metabase/lib/settings";
 import SettingsSetting from "../SettingsSetting";
 
-import HostingInfoLink from "metabase/admin/settings/components/widgets/HostingInfoLink";
-import Icon from "metabase/components/Icon";
-import Text from "metabase/components/type/Text";
-import ExternalLink from "metabase/components/ExternalLink";
+import VersionUpdateNotice from "./VersionUpdateNotice/VersionUpdateNotice";
 
 export default class SettingsUpdatesForm extends Component {
   static propTypes = {
@@ -46,127 +41,4 @@ export default class SettingsUpdatesForm extends Component {
       </div>
     );
   }
-}
-
-function Version({ version }) {
-  if (!version) {
-    return null;
-  }
-  return (
-    <div className="pb3">
-      <h3 className="text-medium">
-        {formatVersion(version.version)}{" "}
-        {version.patch ? "(" + t`patch release` + ")" : null}
-      </h3>
-      <ul style={{ listStyleType: "disc", listStylePosition: "inside" }}>
-        {version.highlights &&
-          version.highlights.map((highlight, index) => (
-            <li key={index} style={{ lineHeight: "1.5" }} className="pl1">
-              {highlight}
-            </li>
-          ))}
-      </ul>
-    </div>
-  );
-}
-
-function VersionUpdateNotice() {
-  const currentVersion = formatVersion(MetabaseSettings.currentVersion());
-
-  if (MetabaseSettings.isHosted()) {
-    return (
-      <div>{jt`Metabase Cloud keeps your instance up-to-date. You're currently on version ${currentVersion}. Thanks for being a customer!`}</div>
-    );
-  }
-
-  if (MetabaseSettings.versionIsLatest()) {
-    const shouldShowHostedCta = !MetabaseSettings.isEnterprise();
-    return (
-      <div>
-        <div className="p2 bg-brand bordered rounded border-brand text-white text-bold">
-          {jt`You're running Metabase ${currentVersion} which is the latest and greatest!`}
-        </div>
-        {shouldShowHostedCta && <HostingCTA />}
-      </div>
-    );
-  } else if (MetabaseSettings.newVersionAvailable()) {
-    const latestVersion = MetabaseSettings.latestVersion();
-    const versionInfo = MetabaseSettings.versionInfo();
-    return (
-      <div>
-        <div className="p2 bg-green bordered rounded border-success flex flex-row align-center justify-between">
-          <span className="text-white text-bold">
-            {jt`Metabase ${formatVersion(latestVersion)} is available.`}{" "}
-            {jt`You're running ${currentVersion}`}
-          </span>
-          <ExternalLink
-            data-metabase-event={
-              "Updates Settings; Update link clicked; " + latestVersion
-            }
-            className="Button Button--white Button--medium borderless"
-            href={
-              "https://www.metabase.com/docs/" +
-              latestVersion +
-              "/operations-guide/upgrading-metabase.html"
-            }
-          >
-            {t`Update`}
-          </ExternalLink>
-        </div>
-
-        <div
-          className="text-medium bordered rounded p2 mt2 overflow-y-scroll"
-          style={{ height: 330 }}
-        >
-          <h3 className="pb3 text-uppercase">{t`What's Changed:`}</h3>
-
-          <Version version={versionInfo.latest} />
-
-          {versionInfo.older &&
-            versionInfo.older.map((version, index) => (
-              <Version key={index} version={version} />
-            ))}
-        </div>
-
-        {!MetabaseSettings.isHosted() && <HostingCTA />}
-      </div>
-    );
-  } else {
-    return <div>{t`No successful checks yet.`}</div>;
-  }
-}
-
-function HostingCTA() {
-  if (MetabaseSettings.isEnterprise()) {
-    return null;
-  }
-
-  return (
-    <Flex
-      justifyContent="space-between"
-      alignItems="center"
-      className="rounded bg-light mt4 text-brand py2 px1"
-    >
-      <Flex>
-        <Flex
-          className="circular bg-medium align-center justify-center ml1 mr2"
-          h={32}
-          w={52}
-        >
-          <Icon name="cloud" size={24} />
-        </Flex>
-        <div>
-          <Text className="text-brand mb0">{t`Want to have upgrades taken care of for you?`}</Text>
-          <Text className="text-brand text-bold">{t`Migrate to Metabase Cloud.`}</Text>
-        </div>
-      </Flex>
-      <Box className="pr1">
-        <HostingInfoLink text={t`Learn more`} />
-      </Box>
-    </Flex>
-  );
-}
-
-function formatVersion(versionLabel = "") {
-  return versionLabel.replace(/^v/, "");
 }

--- a/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/SettingsUpdatesForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/SettingsUpdatesForm.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React from "react";
 import PropTypes from "prop-types";
 import cx from "classnames";
 
@@ -36,5 +36,5 @@ export default function SettingsUpdatesForm({ elements, updateSetting }) {
 
 SettingsUpdatesForm.propTypes = {
   elements: PropTypes.array,
-  updateSetting: PropTypes.func.isRequired,
+  updateSetting: PropTypes.func,
 };

--- a/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/SettingsUpdatesForm.unit.spec.js
+++ b/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/SettingsUpdatesForm.unit.spec.js
@@ -7,15 +7,12 @@ import SettingsUpdatesForm from "./SettingsUpdatesForm";
 const elements = [
   {
     key: "key",
+    widget: "widget",
   },
 ];
 
-const updateSetting = jest.fn();
-
 const render = () => {
-  renderRTL(
-    <SettingsUpdatesForm elements={elements} updateSetting={updateSetting} />,
-  );
+  renderRTL(<SettingsUpdatesForm elements={elements} />);
 };
 
 describe("SettingsUpdatesForm", () => {

--- a/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/SettingsUpdatesForm.unit.spec.js
+++ b/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/SettingsUpdatesForm.unit.spec.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render as renderRTL, screen } from "@testing-library/react";
 
 import MetabaseSettings from "../../../../../metabase/lib/settings";
 import SettingsUpdatesForm from "./SettingsUpdatesForm";
@@ -10,12 +10,21 @@ const elements = [
   },
 ];
 
+const updateSetting = jest.fn();
+
+const render = () => {
+  renderRTL(
+    <SettingsUpdatesForm elements={elements} updateSetting={updateSetting} />,
+  );
+};
+
 describe("SettingsUpdatesForm", () => {
   it("shows custom message for Cloud installations", () => {
     const isHostedSpy = jest.spyOn(MetabaseSettings, "isHosted");
     isHostedSpy.mockImplementation(() => true);
 
-    render(<SettingsUpdatesForm elements={elements} />);
+    render();
+
     screen.getByText(/Metabase Cloud keeps your instance up-to-date/);
 
     isHostedSpy.mockRestore();
@@ -25,14 +34,14 @@ describe("SettingsUpdatesForm", () => {
     const versionIsLatestSpy = jest.spyOn(MetabaseSettings, "versionIsLatest");
     versionIsLatestSpy.mockImplementation(() => true);
 
-    render(<SettingsUpdatesForm elements={elements} />);
+    render();
     screen.getByText(/which is the latest and greatest/);
 
     versionIsLatestSpy.mockRestore();
   });
 
   it("shows correct message when no version checks have been run", () => {
-    render(<SettingsUpdatesForm elements={elements} />);
+    render();
     screen.getByText("No successful checks yet.");
   });
 
@@ -40,7 +49,7 @@ describe("SettingsUpdatesForm", () => {
     const versionIsLatestSpy = jest.spyOn(MetabaseSettings, "versionIsLatest");
     versionIsLatestSpy.mockImplementation(() => true);
 
-    render(<SettingsUpdatesForm elements={elements} />);
+    render();
     screen.getByText("Migrate to Metabase Cloud.");
 
     versionIsLatestSpy.mockRestore();
@@ -50,7 +59,7 @@ describe("SettingsUpdatesForm", () => {
     const versionIsLatestSpy = jest.spyOn(MetabaseSettings, "versionIsLatest");
     versionIsLatestSpy.mockImplementation(() => false);
 
-    render(<SettingsUpdatesForm elements={elements} />);
+    render();
     expect(screen.queryByText("Migrate to Metabase Cloud.")).toBeNull();
 
     versionIsLatestSpy.mockRestore();

--- a/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/SettingsUpdatesForm.unit.spec.js
+++ b/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/SettingsUpdatesForm.unit.spec.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 
-import MetabaseSettings from "../../../../metabase/lib/settings";
+import MetabaseSettings from "../../../../../metabase/lib/settings";
 import SettingsUpdatesForm from "./SettingsUpdatesForm";
 
 const elements = [

--- a/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/SettingsUpdatesForm.unit.spec.js
+++ b/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/SettingsUpdatesForm.unit.spec.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { render as renderRTL, screen } from "@testing-library/react";
 
-import MetabaseSettings from "../../../../../metabase/lib/settings";
+import MetabaseSettings from "metabase/lib/settings";
 import SettingsUpdatesForm from "./SettingsUpdatesForm";
 
 const elements = [

--- a/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/SettingsUpdatesForm.unit.spec.js
+++ b/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/SettingsUpdatesForm.unit.spec.js
@@ -24,7 +24,6 @@ describe("SettingsUpdatesForm", () => {
     isHostedSpy.mockImplementation(() => true);
 
     render();
-
     screen.getByText(/Metabase Cloud keeps your instance up-to-date/);
 
     isHostedSpy.mockRestore();

--- a/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/VersionUpdateNotice/VersionUpdateNotice.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/VersionUpdateNotice/VersionUpdateNotice.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { t, jt } from "ttag";
+import { t } from "ttag";
 import { Flex, Box } from "grid-styled";
 
 import HostingInfoLink from "metabase/admin/settings/components/widgets/HostingInfoLink";
@@ -31,7 +31,7 @@ export default function VersionUpdateNotice() {
 function CloudCustomers({ currentVersion }) {
   return (
     <div>
-      {jt`Metabase Cloud keeps your instance up-to-date. You're currently on version ${currentVersion}. Thanks for being a customer!`}
+      {t`Metabase Cloud keeps your instance up-to-date. You're currently on version ${currentVersion}. Thanks for being a customer!`}
     </div>
   );
 }
@@ -46,7 +46,7 @@ function OnLatestVersion({ currentVersion }) {
   return (
     <div>
       <div className="p2 bg-brand bordered rounded border-brand text-white text-bold">
-        {jt`You're running Metabase ${currentVersion} which is the latest and greatest!`}
+        {t`You're running Metabase ${currentVersion} which is the latest and greatest!`}
       </div>
       {shouldShowHostedCta && <HostingCTA />}
     </div>
@@ -65,8 +65,8 @@ function NewVersionAvailable({ currentVersion }) {
     <div>
       <div className="p2 bg-green bordered rounded border-success flex flex-row align-center justify-between">
         <span className="text-white text-bold">
-          {jt`Metabase ${formatVersion(latestVersion)} is available.`}{" "}
-          {jt`You're running ${currentVersion}`}
+          {t`Metabase ${formatVersion(latestVersion)} is available.`}{" "}
+          {t`You're running ${currentVersion}`}
         </span>
         <ExternalLink
           data-metabase-event={

--- a/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/VersionUpdateNotice/VersionUpdateNotice.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/VersionUpdateNotice/VersionUpdateNotice.jsx
@@ -1,0 +1,153 @@
+/* eslint-disable react/prop-types */
+import React from "react";
+import { t, jt } from "ttag";
+import { Flex, Box } from "grid-styled";
+
+import HostingInfoLink from "metabase/admin/settings/components/widgets/HostingInfoLink";
+import Icon from "metabase/components/Icon";
+import Text from "metabase/components/type/Text";
+
+import ExternalLink from "metabase/components/ExternalLink";
+import MetabaseSettings from "metabase/lib/settings";
+
+function CloudCustomers({ currentVersion }) {
+  return (
+    <div>
+      {jt`Metabase Cloud keeps your instance up-to-date. You're currently on version ${currentVersion}. Thanks for being a customer!`}
+    </div>
+  );
+}
+
+function OnLatestVersion({ currentVersion }) {
+  const shouldShowHostedCta = !MetabaseSettings.isEnterprise();
+
+  return (
+    <div>
+      <div className="p2 bg-brand bordered rounded border-brand text-white text-bold">
+        {jt`You're running Metabase ${currentVersion} which is the latest and greatest!`}
+      </div>
+      {shouldShowHostedCta && <HostingCTA />}
+    </div>
+  );
+}
+
+function NewVersionAvailable({ currentVersion }) {
+  const latestVersion = MetabaseSettings.latestVersion();
+  const versionInfo = MetabaseSettings.versionInfo();
+
+  return (
+    <div>
+      <div className="p2 bg-green bordered rounded border-success flex flex-row align-center justify-between">
+        <span className="text-white text-bold">
+          {jt`Metabase ${formatVersion(latestVersion)} is available.`}{" "}
+          {jt`You're running ${currentVersion}`}
+        </span>
+        <ExternalLink
+          data-metabase-event={
+            "Updates Settings; Update link clicked; " + latestVersion
+          }
+          className="Button Button--white Button--medium borderless"
+          href={
+            "https://www.metabase.com/docs/" +
+            latestVersion +
+            "/operations-guide/upgrading-metabase.html"
+          }
+        >
+          {t`Update`}
+        </ExternalLink>
+      </div>
+
+      <div
+        className="text-medium bordered rounded p2 mt2 overflow-y-scroll"
+        style={{ height: 330 }}
+      >
+        <h3 className="pb3 text-uppercase">{t`What's Changed:`}</h3>
+
+        <Version version={versionInfo.latest} />
+
+        {versionInfo.older &&
+          versionInfo.older.map((version, index) => (
+            <Version key={index} version={version} />
+          ))}
+      </div>
+
+      {!MetabaseSettings.isHosted() && <HostingCTA />}
+    </div>
+  );
+}
+
+export default function VersionUpdateNotice() {
+  const currentVersion = formatVersion(MetabaseSettings.currentVersion());
+
+  if (MetabaseSettings.isHosted()) {
+    return <CloudCustomers currentVersion={currentVersion} />;
+  }
+
+  if (MetabaseSettings.versionIsLatest()) {
+    return <OnLatestVersion currentVersion={currentVersion} />;
+  }
+
+  if (MetabaseSettings.newVersionAvailable()) {
+    return <NewVersionAvailable currentVersion={currentVersion} />;
+  }
+
+  return <div>{t`No successful checks yet.`}</div>;
+}
+
+function HostingCTA() {
+  if (MetabaseSettings.isEnterprise()) {
+    return null;
+  }
+
+  return (
+    <Flex
+      justifyContent="space-between"
+      alignItems="center"
+      className="rounded bg-light mt4 text-brand py2 px1"
+    >
+      <Flex>
+        <Flex
+          className="circular bg-medium align-center justify-center ml1 mr2"
+          h={32}
+          w={52}
+        >
+          <Icon name="cloud" size={24} />
+        </Flex>
+        <div>
+          <Text className="text-brand mb0">{t`Want to have upgrades taken care of for you?`}</Text>
+          <Text className="text-brand text-bold">{t`Migrate to Metabase Cloud.`}</Text>
+        </div>
+      </Flex>
+      <Box className="pr1">
+        <HostingInfoLink text={t`Learn more`} />
+      </Box>
+    </Flex>
+  );
+}
+
+function Version({ version }) {
+  if (!version) {
+    return null;
+  }
+
+  return (
+    <div className="pb3">
+      <h3 className="text-medium">
+        {formatVersion(version.version)}{" "}
+        {version.patch ? "(" + t`patch release` + ")" : null}
+      </h3>
+      <ul style={{ listStyleType: "disc", listStylePosition: "inside" }}>
+        {version.highlights &&
+          version.highlights.map((highlight, index) => (
+            <li key={index} style={{ lineHeight: "1.5" }} className="pl1">
+              {highlight}
+            </li>
+          ))}
+      </ul>
+    </div>
+  );
+}
+
+function formatVersion(versionLabel = "") {
+  return versionLabel.replace(/^v/, "");
+}

--- a/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/VersionUpdateNotice/VersionUpdateNotice.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/VersionUpdateNotice/VersionUpdateNotice.jsx
@@ -1,5 +1,5 @@
-/* eslint-disable react/prop-types */
 import React from "react";
+import PropTypes from "prop-types";
 import { t, jt } from "ttag";
 import { Flex, Box } from "grid-styled";
 
@@ -10,6 +10,24 @@ import Text from "metabase/components/type/Text";
 import ExternalLink from "metabase/components/ExternalLink";
 import MetabaseSettings from "metabase/lib/settings";
 
+export default function VersionUpdateNotice() {
+  const currentVersion = formatVersion(MetabaseSettings.currentVersion());
+
+  if (MetabaseSettings.isHosted()) {
+    return <CloudCustomers currentVersion={currentVersion} />;
+  }
+
+  if (MetabaseSettings.versionIsLatest()) {
+    return <OnLatestVersion currentVersion={currentVersion} />;
+  }
+
+  if (MetabaseSettings.newVersionAvailable()) {
+    return <NewVersionAvailable currentVersion={currentVersion} />;
+  }
+
+  return <div>{t`No successful checks yet.`}</div>;
+}
+
 function CloudCustomers({ currentVersion }) {
   return (
     <div>
@@ -17,6 +35,10 @@ function CloudCustomers({ currentVersion }) {
     </div>
   );
 }
+
+CloudCustomers.propTypes = {
+  currentVersion: PropTypes.string.isRequired,
+};
 
 function OnLatestVersion({ currentVersion }) {
   const shouldShowHostedCta = !MetabaseSettings.isEnterprise();
@@ -30,6 +52,10 @@ function OnLatestVersion({ currentVersion }) {
     </div>
   );
 }
+
+OnLatestVersion.propTypes = {
+  currentVersion: PropTypes.string.isRequired,
+};
 
 function NewVersionAvailable({ currentVersion }) {
   const latestVersion = MetabaseSettings.latestVersion();
@@ -76,23 +102,9 @@ function NewVersionAvailable({ currentVersion }) {
   );
 }
 
-export default function VersionUpdateNotice() {
-  const currentVersion = formatVersion(MetabaseSettings.currentVersion());
-
-  if (MetabaseSettings.isHosted()) {
-    return <CloudCustomers currentVersion={currentVersion} />;
-  }
-
-  if (MetabaseSettings.versionIsLatest()) {
-    return <OnLatestVersion currentVersion={currentVersion} />;
-  }
-
-  if (MetabaseSettings.newVersionAvailable()) {
-    return <NewVersionAvailable currentVersion={currentVersion} />;
-  }
-
-  return <div>{t`No successful checks yet.`}</div>;
-}
+NewVersionAvailable.propTypes = {
+  currentVersion: PropTypes.string.isRequired,
+};
 
 function HostingCTA() {
   if (MetabaseSettings.isEnterprise()) {
@@ -147,6 +159,10 @@ function Version({ version }) {
     </div>
   );
 }
+
+Version.propTypes = {
+  version: PropTypes.object.isRequired,
+};
 
 function formatVersion(versionLabel = "") {
   return versionLabel.replace(/^v/, "");

--- a/frontend/src/metabase/admin/settings/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors.js
@@ -16,7 +16,7 @@ import EmbeddingLegalese from "./components/widgets/EmbeddingLegalese";
 import EmbeddingLevel from "./components/widgets/EmbeddingLevel";
 import FormattingWidget from "./components/widgets/FormattingWidget";
 
-import SettingsUpdatesForm from "./components/SettingsUpdatesForm";
+import SettingsUpdatesForm from "./components/SettingsUpdatesForm/SettingsUpdatesForm";
 import SettingsEmailForm from "./components/SettingsEmailForm";
 import SettingsSetupList from "./components/SettingsSetupList";
 import SettingsSlackForm from "./components/SettingsSlackForm";


### PR DESCRIPTION
Follow-up to https://github.com/metabase/metabase/pull/16920 and https://github.com/metabase/metabase/pull/16966

This PR:

* breaks down components that were deeply nested.
* adds prop types to them

## How To Test

### Run unit tests

```
yarn test-unit frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.unit.spec.js
```

### Cloud installations

In https://github.com/metabase/metabase/blob/master/frontend/src/metabase/lib/settings.js#L91, introduce an early return forcing `true`:

~~~js
  isHosted() {
    /* eslint-disable */
    return true
    
    // matches <custom>.metabaseapp.com and <custom>.metabaseapp.com/
    return /.+\.metabaseapp.com\/?$/i.test(this.get("site-url"));
  }
~~~

Visit http://localhost:3000/admin/settings/updates

You should see a message about installation being up-to-date. No toggle, no other call-to-action.

<hr />

### Enterprise 

Start application in [Enterprise mode](https://github.com/metabase/metabase/blob/master/enterprise/README.md)

Manually populate `version-info` and `version-info-last-checked` in the `setting` table so that it triggers an update check (I don't know how to do this atm, please show me how).

You should see the screen below, still without a call-to-action to upgrade to Enterprise (just done in https://github.com/metabase/metabase/pull/16920)

<img src="https://user-images.githubusercontent.com/380816/124778783-9d3a0800-df17-11eb-9566-940feab71bf6.png" width=400 />


