### PR TITLE
Remove db paging

### DIFF
--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -212,12 +212,13 @@
         include-saved-questions-tables? (when include-saved-questions-db?
                                           (if (seq include_cards)
                                             true
-                                            include-tables?))]
-    {:data  (or (dbs-list :include-tables?                  include-tables?
-                          :include-saved-questions-db?      include-saved-questions-db?
-                          :include-saved-questions-tables?  include-saved-questions-tables?)
-                [])
-     :total  (db/count Database)}))
+                                            include-tables?))
+        db-list-res                     (or (dbs-list :include-tables?                  include-tables?
+                                                      :include-saved-questions-db?      include-saved-questions-db?
+                                                      :include-saved-questions-tables?  include-saved-questions-tables?)
+                                            [])]
+    {:data  db-list-res
+     :total (count db-list-res)}))
 
 
 ;;; --------------------------------------------- GET /api/database/:id ----------------------------------------------

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -167,13 +167,9 @@
 
 (defn- dbs-list [& {:keys [include-tables?
                            include-saved-questions-db?
-                           include-saved-questions-tables?
-                           limit
-                           offset]}]
+                           include-saved-questions-tables?]}]
   (when-let [dbs (seq (filter mi/can-read? (db/select Database
-                                                      {:order-by [:%lower.name :%lower.engine]
-                                                       :limit limit
-                                                       :offset offset})))]
+                                                      {:order-by [:%lower.name :%lower.engine]})))]
     (cond-> (add-native-perms-info dbs)
       include-tables?             add-tables
       include-saved-questions-db? (add-saved-questions-virtual-database :include-tables? include-saved-questions-tables?))))

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -22,7 +22,6 @@
             [metabase.models.table :refer [Table]]
             [metabase.public-settings :as public-settings]
             [metabase.sample-data :as sample-data]
-            [metabase.server.middleware.offset-paging :as offset-paging]
             [metabase.sync.analyze :as analyze]
             [metabase.sync.field-values :as sync-field-values]
             [metabase.sync.schedules :as sync.schedules]
@@ -220,12 +219,8 @@
                                             include-tables?))]
     {:data  (or (dbs-list :include-tables?                  include-tables?
                           :include-saved-questions-db?      include-saved-questions-db?
-                          :include-saved-questions-tables?  include-saved-questions-tables?
-                          :limit                            offset-paging/*limit*
-                          :offset                           offset-paging/*offset*)
+                          :include-saved-questions-tables?  include-saved-questions-tables?)
                 [])
-     :limit  offset-paging/*limit*
-     :offset offset-paging/*offset*
      :total  (db/count Database)}))
 
 

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -920,11 +920,13 @@
   (testing "GET /api/collection/root/items?namespace=snippets"
     (testing "\nNative query snippets should come back when fetching the items in the root Collection of the `:snippets` namespace"
       (mt/with-temp* [NativeQuerySnippet [{snippet-id :id}   {:name "My Snippet"}]
+                      NativeQuerySnippet [{snippet-id-2 :id}   {:name "My Snippet 2"}]
                       NativeQuerySnippet [{archived-id :id}  {:name "Archived Snippet", :archived true}]
                       Dashboard          [{dashboard-id :id} {:name "My Dashboard"}]]
         (letfn [(only-test-items [results]
                   (if (sequential? results)
                     (filter #(#{["snippet" snippet-id]
+                                ["snippet" snippet-id-2]
                                 ["snippet" archived-id]
                                 ["dashboard" dashboard-id]} ((juxt :model :id) %))
                             results)
@@ -936,12 +938,19 @@
                       items)))]
           (is (= [{:id    snippet-id
                    :name  "My Snippet"
+                   :model "snippet"}
+                  {:id    snippet-id-2
+                   :name  "My Snippet 2"
                    :model "snippet"}]
                  (only-test-items (:data (mt/user-http-request :rasta :get 200 "collection/root/items?namespace=snippets")))))
 
           (testing "\nSnippets should not come back for the default namespace"
             (is (= ["My Dashboard"]
                    (only-test-item-names (:data (mt/user-http-request :rasta :get 200 "collection/root/items"))))))
+          
+          (testing "\nSnippets shouldn't be paginated, because FE is not ready for it yet and default pagination behavior is bad"
+            (is (= ["My Snippet", "My Snippet 2"]
+                   (only-test-item-names (:data (mt/user-http-request :rasta :get 200 "collection/root/items?namespace=snippets&limit=1&offset=0"))))))
 
           (testing "\nShould be able to fetch archived Snippets"
             (is (= ["Archived Snippet"]
@@ -949,7 +958,7 @@
                                                                "collection/root/items?namespace=snippets&archived=true"))))))
 
           (testing "\nShould be able to pass ?model=snippet, even though it makes no difference in this case"
-            (is (= ["My Snippet"]
+            (is (= ["My Snippet", "My Snippet 2"]
                    (only-test-item-names (:data (mt/user-http-request :rasta :get 200
                                                                "collection/root/items?namespace=snippets&model=snippet")))))))))))
 

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -920,7 +920,7 @@
   (testing "GET /api/collection/root/items?namespace=snippets"
     (testing "\nNative query snippets should come back when fetching the items in the root Collection of the `:snippets` namespace"
       (mt/with-temp* [NativeQuerySnippet [{snippet-id :id}   {:name "My Snippet"}]
-                      NativeQuerySnippet [{snippet-id-2 :id}   {:name "My Snippet 2"}]
+                      NativeQuerySnippet [{snippet-id-2 :id} {:name "My Snippet 2"}]
                       NativeQuerySnippet [{archived-id :id}  {:name "Archived Snippet", :archived true}]
                       Dashboard          [{dashboard-id :id} {:name "My Dashboard"}]]
         (letfn [(only-test-items [results]

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -947,7 +947,7 @@
           (testing "\nSnippets should not come back for the default namespace"
             (is (= ["My Dashboard"]
                    (only-test-item-names (:data (mt/user-http-request :rasta :get 200 "collection/root/items"))))))
-          
+
           (testing "\nSnippets shouldn't be paginated, because FE is not ready for it yet and default pagination behavior is bad"
             (is (= ["My Snippet", "My Snippet 2"]
                    (only-test-item-names (:data (mt/user-http-request :rasta :get 200 "collection/root/items?namespace=snippets&limit=1&offset=0"))))))

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -362,15 +362,6 @@
               (is (= expected-keys
                      (set (keys db)))))))))
 
-    (doseq [query-param ["?limit=2"
-                         "?limit=2&offset=1"]]
-      (testing query-param
-        (mt/with-temp*
-          [Database [{db-id :id1, db-name :name1} {:engine (u/qualified-name ::test-driver)}]
-           Database [{db-id :id2, db-name :name2} {:engine (u/qualified-name ::test-driver)}]]
-
-          (let [db (:data ((mt/user->client :rasta) :get 200 (str "database" query-param)))]
-            (is (= 2 (count db)))))))
 
     ;; ?include=tables and ?include_tables=true mean the same thing so test them both the same way
     (doseq [query-param ["?include_tables=true"

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -360,7 +360,12 @@
           (doseq [db (:data ((mt/user->client :rasta) :get 200 "database"))]
             (testing (format "Database %s %d %s" (:engine db) (u/the-id db) (pr-str (:name db)))
               (is (= expected-keys
-                     (set (keys db)))))))))
+                     (set (keys db))))))))
+      (testing "Make sure databases don't paginate"
+        (mt/with-temp* [Database [{db-id-1 :id} {:engine ::test-driver}]
+                        Database [{db-id-2 :id} {:engine ::test-driver}]
+                        Database [{db-id-3 :id} {:engine ::test-driver}]]
+          (is (< 1 (count (:data ((mt/user->client :rasta) :get 200 "database" :limit 1 :offset 0))))))))
 
 
     ;; ?include=tables and ?include_tables=true mean the same thing so test them both the same way


### PR DESCRIPTION
Pursuant to 16983. Default behavior is actually paging with limit 50, not unlimited like I thought, so it wasn't safe to just shove in paging willy-nilly. All the actual work is done, just splice this back in whenever we're ready to actually page