### PR TITLE
Fix long titles in collections push out the last-edited-by and last-edited-at columns

### DIFF
--- a/frontend/src/metabase/collections/components/BaseItemsTable.jsx
+++ b/frontend/src/metabase/collections/components/BaseItemsTable.jsx
@@ -115,7 +115,7 @@ function BaseItemsTable({
   return (
     <Table {...props}>
       <colgroup>
-        <col style={{ width: "60px" }} />
+        <col style={{ width: "70px" }} />
         <col style={{ width: "60%" }} />
         <col style={{ width: "15%" }} />
         <col style={{ width: "15%" }} />

--- a/frontend/src/metabase/collections/components/BaseItemsTable.jsx
+++ b/frontend/src/metabase/collections/components/BaseItemsTable.jsx
@@ -5,6 +5,7 @@ import { t } from "ttag";
 import BaseTableItem from "./BaseTableItem";
 import {
   ColumnHeader,
+  Table,
   SortingIcon,
   SortingControlContainer,
 } from "./BaseItemsTable.styled";
@@ -112,13 +113,13 @@ function BaseItemsTable({
     });
 
   return (
-    <table className="ContentTable" {...props}>
+    <Table {...props}>
       <colgroup>
-        <col span="1" style={{ width: "5%" }} />
-        <col span="1" style={{ width: "64%" }} />
+        <col span="1" style={{ width: "60px" }} />
+        <col span="1" style={{ width: "60%" }} />
         <col span="1" style={{ width: "15%" }} />
-        <col span="1" style={{ width: "14%" }} />
-        <col span="1" style={{ width: "2%" }} />
+        <col span="1" style={{ width: "15%" }} />
+        <col span="1" style={{ width: "60px" }} />
       </colgroup>
       {!headless && (
         <thead
@@ -161,7 +162,7 @@ function BaseItemsTable({
         </thead>
       )}
       <tbody>{items.map(itemRenderer)}</tbody>
-    </table>
+    </Table>
   );
 }
 

--- a/frontend/src/metabase/collections/components/BaseItemsTable.jsx
+++ b/frontend/src/metabase/collections/components/BaseItemsTable.jsx
@@ -116,9 +116,9 @@ function BaseItemsTable({
     <Table {...props}>
       <colgroup>
         <col style={{ width: "70px" }} />
-        <col style={{ width: "60%" }} />
-        <col style={{ width: "15%" }} />
-        <col style={{ width: "15%" }} />
+        <col />
+        <col style={{ width: "140px" }} />
+        <col style={{ width: "140px" }} />
         <col style={{ width: "60px" }} />
       </colgroup>
       {!headless && (

--- a/frontend/src/metabase/collections/components/BaseItemsTable.jsx
+++ b/frontend/src/metabase/collections/components/BaseItemsTable.jsx
@@ -115,11 +115,11 @@ function BaseItemsTable({
   return (
     <Table {...props}>
       <colgroup>
-        <col span="1" style={{ width: "60px" }} />
-        <col span="1" style={{ width: "60%" }} />
-        <col span="1" style={{ width: "15%" }} />
-        <col span="1" style={{ width: "15%" }} />
-        <col span="1" style={{ width: "60px" }} />
+        <col style={{ width: "60px" }} />
+        <col style={{ width: "60%" }} />
+        <col style={{ width: "15%" }} />
+        <col style={{ width: "15%" }} />
+        <col style={{ width: "60px" }} />
       </colgroup>
       {!headless && (
         <thead

--- a/frontend/src/metabase/collections/components/BaseItemsTable.styled.jsx
+++ b/frontend/src/metabase/collections/components/BaseItemsTable.styled.jsx
@@ -6,6 +6,10 @@ import EntityItem from "metabase/components/EntityItem";
 import Icon from "metabase/components/Icon";
 import Link from "metabase/components/Link";
 
+export const Table = styled.table.attrs({ className: "ContentTable" })`
+  table-layout: fixed;
+`;
+
 export const ColumnHeader = styled.th`
   font-weight: bold;
   color: ${color("text-light")};

--- a/frontend/src/metabase/collections/components/BaseItemsTable.styled.jsx
+++ b/frontend/src/metabase/collections/components/BaseItemsTable.styled.jsx
@@ -1,13 +1,28 @@
 import styled from "styled-components";
 
 import { color } from "metabase/lib/colors";
+import { breakpointMaxMedium } from "metabase/styled-components/theme/media-queries";
 
 import EntityItem from "metabase/components/EntityItem";
 import Icon from "metabase/components/Icon";
 import Link from "metabase/components/Link";
 
+const LAST_EDITED_BY_INDEX = 3;
+const LAST_EDITED_AT_INDEX = 4;
+
 export const Table = styled.table.attrs({ className: "ContentTable" })`
   table-layout: fixed;
+
+  ${breakpointMaxMedium} {
+    & td:nth-child(${LAST_EDITED_BY_INDEX}),
+    th:nth-child(${LAST_EDITED_BY_INDEX}),
+    col:nth-child(${LAST_EDITED_BY_INDEX}),
+    td:nth-child(${LAST_EDITED_AT_INDEX}),
+    th:nth-child(${LAST_EDITED_AT_INDEX}),
+    col:nth-child(${LAST_EDITED_AT_INDEX}) {
+      display: none;
+    }
+  }
 `;
 
 export const ColumnHeader = styled.th`

--- a/frontend/src/metabase/components/EntityItem.jsx
+++ b/frontend/src/metabase/components/EntityItem.jsx
@@ -65,6 +65,7 @@ function EntityItemMenu({
   onMove,
   onCopy,
   onArchive,
+  className,
   analyticsContext,
 }) {
   const actions = useMemo(
@@ -105,7 +106,7 @@ function EntityItemMenu({
   }
   return (
     <EntityMenu
-      className="ml1 hover-child"
+      className={cx(className, "hover-child")}
       triggerIcon="ellipsis"
       items={actions}
     />
@@ -182,6 +183,7 @@ const EntityItem = ({
           onMove={onMove}
           onCopy={onCopy}
           onArchive={onArchive}
+          className="ml1"
           analyticsContext={analyticsContext}
         />
       </Flex>


### PR DESCRIPTION
Fixes #16991

### To Verify

1. Create a question or a dashboard with a long name. Example `this question has a very very very very very very very very very very very looooooooooooooooooooong name`
2. Go to `/collection/root` (or a collection a new item is saved to)
3. Make sure the table has a fixed width and the long title is truncated

### Demo

**Before**

<img width="1436" alt="CleanShot 2021-07-12 at 21 39 42@2x" src="https://user-images.githubusercontent.com/17258145/125339640-2ad38880-e35a-11eb-943f-580f79560716.png">

**After**

https://user-images.githubusercontent.com/17258145/125340169-d11f8e00-e35a-11eb-906e-5adf08130ca7.mov
