### PR TITLE
Fix console warn in unit test of SettingsUpdatesForm

### DIFF
--- a/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.unit.spec.js
+++ b/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.unit.spec.js
@@ -7,6 +7,7 @@ import SettingsUpdatesForm from "./SettingsUpdatesForm";
 const elements = [
   {
     key: "key",
+    widget: "widget",
   },
 ];
 


### PR DESCRIPTION
To verify, run

```
yarn test-unit frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.unit.spec.js --watchAll
```

You should no longer see text below in cli output:

```
console.warn frontend/src/metabase/admin/settings/components/SettingsSetting.jsx:53
    No render method for setting type undefined, defaulting to string input.
```