### PR TITLE
Entities search: guard against undefined data

### DIFF
--- a/frontend/src/metabase/entities/search.js
+++ b/frontend/src/metabase/entities/search.js
@@ -55,11 +55,13 @@ export default createEntity({
 
         return {
           ...rest,
-          data: data.map(item => ({
-            collection_id: canonicalCollectionId(collection),
-            archived: archived || false,
-            ...item,
-          })),
+          data: data
+            ? data.map(item => ({
+                collection_id: canonicalCollectionId(collection),
+                archived: archived || false,
+                ...item,
+              }))
+            : [],
         };
       } else {
         return searchList(query);


### PR DESCRIPTION

To try it: just check the CI output for front-end Jest unit-tests or run the specific test manually:

```
yarn test-unit frontend/test/metabase/entities/containers/EntityListLoader.unit.spec.js
```

**Before**

 (node:2053) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'map' of undefined
(node:2053) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 8)
 PASS  frontend/test/metabase/entities/containers/EntityListLoader.unit.spec.js

 **After**

No such warning anymore.