### PR TITLE
minimal hack fix search results being below the data picker

### DIFF
--- a/frontend/src/metabase/components/Popover.jsx
+++ b/frontend/src/metabase/components/Popover.jsx
@@ -55,6 +55,7 @@ export default class Popover extends Component {
     targetOffsetX: PropTypes.number,
     targetOffsetY: PropTypes.number,
     onClose: PropTypes.func,
+    containerClassName: PropTypes.string,
     className: PropTypes.string,
     style: PropTypes.object,
     children: PropTypes.oneOfType([
@@ -82,12 +83,13 @@ export default class Popover extends Component {
     sizeToFit: false,
     autoWidth: false,
     noOnClickOutsideWrapper: false,
+    containerClassName: "",
   };
 
   _getPopoverElement(isOpen) {
     if (!this._popoverElement && isOpen) {
       this._popoverElement = document.createElement("span");
-      this._popoverElement.className = "PopoverContainer";
+      this._popoverElement.className = `PopoverContainer ${this.props.containerClassName}`;
       document.body.appendChild(this._popoverElement);
       this._timer = setInterval(() => {
         const { width, height } = this._popoverElement.getBoundingClientRect();

--- a/frontend/src/metabase/query_builder/components/DataSelector.css
+++ b/frontend/src/metabase/query_builder/components/DataSelector.css
@@ -1,0 +1,4 @@
+/* HACK: DataPopover should be below the search box */
+.DataPopoverContainer {
+  z-index: 2;
+}

--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -28,6 +28,8 @@ import SavedQuestionPicker from "./saved-question-picker/SavedQuestionPicker";
 import { getMetadata } from "metabase/selectors/metadata";
 import { getSchemaName } from "metabase/schema";
 
+import "./DataSelector.css";
+
 const MIN_SEARCH_LENGTH = 2;
 
 // chooses a database
@@ -764,6 +766,7 @@ export class UnconnectedDataSelector extends Component {
     return (
       <PopoverWithTrigger
         id="DataPopover"
+        containerClassName="DataPopoverContainer"
         autoWidth
         ref={this.popover}
         isInitiallyOpen={this.props.isInitiallyOpen}


### PR DESCRIPTION
### Description

Search results were below the data picker. This is a possible minimal fix of the issue that makes z-index of the data picker `PopoverContainer` element lower than z-index of the page header which contains the search results. Increasing z-index of the header will make it above modals. Not sure if this is the best quick fix available, please suggest other options if any.

Before:
<img width="660" alt="Screen Shot 2021-07-13 at 01 25 54" src="https://user-images.githubusercontent.com/14301985/125363434-4601c080-e379-11eb-8773-ae0818d4e44c.png">

After:
<img width="704" alt="Screen Shot 2021-07-13 at 01 19 08" src="https://user-images.githubusercontent.com/14301985/125362890-55343e80-e378-11eb-81aa-305bf763277d.png">

Closes https://github.com/metabase/metabase/issues/16897