### PR TITLE
Un-skip #16617 repro (Archive page is broken for the "nodata" user)

### DIFF
--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -163,7 +163,6 @@ describe("collection permissions", () => {
 
                 describe("archive page", () => {
                   it("should show archived items (metabase#15080, metabase#16617)", () => {
-                    cy.skipOn(user === "nodata");
                     cy.visit("collection/root");
                     openEllipsisMenuFor("Orders");
                     cy.findByText("Archive this item").click();


### PR DESCRIPTION
Apparently, it had the same root cause as #16855 (Search does not work for users without Data access) and was fixed together with this issue by #16925

This PR unksips the repro and closes #16617

**To Verify**
Green tests should be solid proof it works, but you can also check manually:

1. Log in as a non-admin user with collection curate access and no data permissions (a.k.a "nodata@metabase.test" user)
2. Go to `/collection/archive/`
3. There has to be no errors, the page should either be empty or display archived items