### PR TITLE
[Cypress runner] Set `HAS_ENTERPRISE_TOKEN` using Configuration API

### DIFF
--- a/frontend/test/__runner__/run_cypress_tests.js
+++ b/frontend/test/__runner__/run_cypress_tests.js
@@ -90,11 +90,6 @@ const init = async () => {
   // See: https://docs.cypress.io/guides/references/configuration#Command-Line
   const commandLineConfig = JSON.stringify(config);
 
-  // These env vars provide the token to the backend.
-  // If they're not present, we skip some tests that depend on a valid token.
-  const hasEnterpriseToken =
-    process.env["ENTERPRISE_TOKEN"] && process.env["MB_EDITION"] === "ee";
-
   const cypressProcess = spawn(
     "yarn",
     [
@@ -112,7 +107,6 @@ const init = async () => {
             "mochaFile=cypress/results/results-[hash].xml",
           ]
         : []),
-      ...(hasEnterpriseToken ? ["--env", "HAS_ENTERPRISE_TOKEN=true"] : []),
     ],
     { stdio: "inherit" },
   );

--- a/frontend/test/__support__/e2e/cypress-plugins.js
+++ b/frontend/test/__support__/e2e/cypress-plugins.js
@@ -1,5 +1,5 @@
 // ***********************************************************
-// This example plugins/index.js can be used to load plugins
+// This file can be used to load plugins and register events.
 //
 // You can change the location of this file or turn off loading
 // the plugins file with the 'pluginsFile' configuration option.
@@ -7,6 +7,15 @@
 // You can read more here:
 // https://on.cypress.io/plugins-guide
 // ***********************************************************
+
+/**
+ * This env var provides the token to the backend.
+ * If it is not present, we skip some tests that depend on a valid token.
+ *
+ * @type {boolean}
+ */
+const hasEnterpriseToken =
+  process.env["ENTERPRISE_TOKEN"] && process.env["MB_EDITION"] === "ee";
 
 // This function is called when a project is opened or re-opened (e.g. due to
 // the project's config changing)
@@ -39,4 +48,12 @@ module.exports = (on, config) => {
       return launchOptions;
     }
   });
+
+  /********************************************************************
+   **                          CONFIG                                **
+   ********************************************************************/
+
+  config.env.HAS_ENTERPRISE_TOKEN = hasEnterpriseToken;
+
+  return config;
 };

--- a/frontend/test/__support__/e2e/cypress-plugins.js
+++ b/frontend/test/__support__/e2e/cypress-plugins.js
@@ -1,5 +1,5 @@
 // ***********************************************************
-// This file can be used to load plugins and register events.
+// This file can be used to load plugins and to register events.
 //
 // You can change the location of this file or turn off loading
 // the plugins file with the 'pluginsFile' configuration option.
@@ -20,6 +20,12 @@ const hasEnterpriseToken =
 // This function is called when a project is opened or re-opened (e.g. due to
 // the project's config changing)
 const webpack = require("@cypress/webpack-preprocessor");
+const { resolve } = require("../../../../webpack.config.js");
+
+const webpackPluginOptions = {
+  webpackOptions: { resolve },
+  watchOptions: {},
+};
 
 module.exports = (on, config) => {
   // `on` is used to hook into various events Cypress emits
@@ -28,13 +34,8 @@ module.exports = (on, config) => {
   /********************************************************************
    **                          WEBPACK                               **
    ********************************************************************/
-  const { resolve } = require("../../../../webpack.config.js");
-  const options = {
-    webpackOptions: { resolve },
-    watchOptions: {},
-  };
 
-  on("file:preprocessor", webpack(options));
+  on("file:preprocessor", webpack(webpackPluginOptions));
 
   /********************************************************************
    **                         BROWSERS                               **


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Moves the logic for setting `HAS_ENTERPRISE_TOKEN` env var out of the runner config to the Cypress plugins file, using the official [Congifuration API](https://docs.cypress.io/api/plugins/configuration-api)
- Annotates `hasEnterpriseToken` variable using JSDoc

> Whenever you return an object from your pluginFile, Cypress will take this and "diff" it against the original configuration and automatically set the resolved values to point to what you returned.

> If you don't return an object, then configuration will not be modified.

### Additional info:
`baseUrl` **should** be set in the same manner, but it requires a `backend.js` file that causes some problems. Plugins file is strictly a node process and relies on node modules. `backend.js` has some ES6 syntax (uses imports instead of requires) and thus breaks this process. The solution could be to re-write `backend.js` as a node script entirely or to use babel to help transpile the syntax.