### PR TITLE
Fix native question looses visualisation settings if query fails

### DIFF
--- a/frontend/src/metabase-lib/lib/Question.js
+++ b/frontend/src/metabase-lib/lib/Question.js
@@ -645,7 +645,8 @@ export default class Question {
 
   syncColumnsAndSettings(previous, queryResults) {
     const query = this.query();
-    if (query instanceof NativeQuery && queryResults) {
+    const isQueryResultValid = queryResults && !queryResults.error;
+    if (query instanceof NativeQuery && isQueryResultValid) {
       return this._syncNativeQuerySettings(queryResults);
     }
     const previousQuery = previous && previous.query();

--- a/frontend/src/metabase/query_builder/components/view/ViewFooter.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewFooter.jsx
@@ -191,14 +191,28 @@ const VizTypeButton = ({ question, result, ...props }) => {
   const icon = visualization && visualization.iconName;
 
   return (
-    <ViewButton medium p={[2, 1]} icon={icon} labelBreakpoint="sm" {...props}>
+    <ViewButton
+      medium
+      p={[2, 1]}
+      icon={icon}
+      labelBreakpoint="sm"
+      data-testid="viz-type-button"
+      {...props}
+    >
       {t`Visualization`}
     </ViewButton>
   );
 };
 
 const VizSettingsButton = ({ ...props }) => (
-  <ViewButton medium p={[2, 1]} icon="gear" labelBreakpoint="sm" {...props}>
+  <ViewButton
+    medium
+    p={[2, 1]}
+    icon="gear"
+    labelBreakpoint="sm"
+    data-testid="viz-settings-button"
+    {...props}
+  >
     {t`Settings`}
   </ViewButton>
 );

--- a/frontend/test/__support__/e2e/helpers/e2e-misc-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-misc-helpers.js
@@ -28,3 +28,14 @@ export function openNativeEditor(alias = "editor") {
     .as(alias)
     .should("be.visible");
 }
+
+/**
+ * Executes native query and waits for the results to load.
+ * Makes sure that the question is not "dirty" after the query successfully ran.
+ * @param {string} [xhrAlias ="dataset"]
+ */
+export function runNativeQuery(xhrAlias = "dataset") {
+  cy.get(".NativeQueryEditor .Icon-play").click();
+  cy.wait("@" + xhrAlias);
+  cy.icon("play").should("not.exist");
+}

--- a/frontend/test/metabase/scenarios/native/reproductions/16914.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/reproductions/16914.cy.spec.js
@@ -1,0 +1,44 @@
+import {
+  restore,
+  openNativeEditor,
+  runNativeQuery,
+} from "__support__/e2e/cypress";
+
+describe("issue 16914", () => {
+  beforeEach(() => {
+    restore();
+    cy.intercept("POST", "api/dataset").as("dataset");
+    cy.signInAsAdmin();
+  });
+
+  it("should recover visualization settings after a failed query (metabase#16914)", () => {
+    const FAILING_PIECE = " foo";
+    const highlightSelectedText = "{shift}{leftarrow}".repeat(
+      FAILING_PIECE.length,
+    );
+
+    openNativeEditor().type("SELECT 'a' as hidden, 'b' as visible");
+    runNativeQuery();
+
+    cy.findByTestId("viz-settings-button").click();
+    cy.findByTestId("sidebar-left")
+      .contains(/hidden/i)
+      .siblings(".Icon-close")
+      .click();
+    cy.button("Done").click();
+
+    cy.get("@editor").type(FAILING_PIECE);
+    runNativeQuery();
+
+    cy.get("@editor").type(
+      "{movetoend}" + highlightSelectedText + "{backspace}",
+    );
+    runNativeQuery();
+
+    cy.get(".Visualization").within(() => {
+      cy.findByText("Every field is hidden right now").should("not.exist");
+      cy.findByText("VISIBLE");
+      cy.findByText("HIDDEN").should("not.exist");
+    });
+  });
+});


### PR DESCRIPTION
A regression caused by #16761 (Fix newly added columns don't appear after some columns are hidden
Fixes #16914

**Explanation**

From #16761 PR doc:

> Each question has a `table.columns` property in `visualization_settings`; it defines which columns are visible and which are hidden. For structured queries (simple and custom questions), the `table.columns` property is synced with the query itself. So if a new column is added or an existing one is removed, visualization settings stay in sync. It's impossible to do for native queries as Metabase doesn't parse SQL. This PR adds columns sync for native queries based on query _results_, rather than the query.

So, #16761 introduced a way to sync columns and viz settings for native questions based on `queryResults`.
The problem is it didn't handle a scenario when `queryResults` were actually an error. So it tried to sync columns and viz settings based on a failed query result, found no columns and just cleared the question's visualization settings.

Fixed by skipping columns and viz settings sync in case a query failed.

### To Verify

Huge thanks to @lukeman for making perfect repro steps 🙌 

1. Ask a question > Native Question > Sample Dataset
2. Enter `SELECT 'a' as a, 'b' as b`
3. Click the play icon to run the query
4. Click the "Settings" button in the bottom left
5. In the left sidebar hide column `a` and click "Done"
6. Add `foo` to the end of the query, so it looks like  `SELECT 'a' as a, 'b' as b foo`
7. Run the query to trigger a SQL error response
8. Remove the errant text, so the query looks like `SELECT 'a' as a, 'b' as b` again
9. Run the query
10. Ensure there is no "Every field is hidden right now" message; you should see column `B`, and no column `A`.

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/125466981-1e8c4d8c-895a-45d4-9d1e-667a0a831d45.mov

**After**

https://user-images.githubusercontent.com/17258145/125466999-8c06e85f-7ec3-4e08-96fd-e7b280a55ca3.mov

