### PR TITLE
[Cypress runner] Use Cypress' Module API to generate Cypress snapshots

### DIFF
--- a/frontend/test/__runner__/generate-cypress-snapshots.js
+++ b/frontend/test/__runner__/generate-cypress-snapshots.js
@@ -1,0 +1,37 @@
+const cypress = require("cypress");
+
+const getConfig = baseUrl => {
+  return {
+    configFile: "frontend/test/__support__/e2e/cypress-snapshots.json",
+    config: {
+      baseUrl,
+    },
+  };
+};
+
+const generateSnapshots = async (baseUrl, exitFunction) => {
+  const snapshotConfig = getConfig(baseUrl);
+
+  try {
+    const results = await cypress.run(snapshotConfig);
+
+    // At least one test failed. We can't continue to the next step.
+    // Cypress tests rely on snapshots correctly generated at this stage.
+    if (results.totalFailed > 0) {
+      await exitFunction(1);
+    }
+
+    // Something went wrong and Cypress failed to even run tests
+    if (results.status === "failed" && results.failures) {
+      console.error(results.message);
+
+      await exitFunction(results.failures);
+    }
+  } catch (e) {
+    console.error("Unable to generate snapshots\n", e);
+
+    await exitFunction(1);
+  }
+};
+
+module.exports = generateSnapshots;

--- a/frontend/test/__runner__/run_cypress_tests.js
+++ b/frontend/test/__runner__/run_cypress_tests.js
@@ -1,12 +1,14 @@
 import { spawn } from "child_process";
 
 const getVersion = require("./cypress-runner-get-version");
+const generateSnapshots = require("./generate-cypress-snapshots");
 const { printBold, printYellow } = require("./cypress-runner-utils");
 
 // Use require for BackendResource to run it after the mock afterAll has been set
 const BackendResource = require("./backend.js").BackendResource;
 
 const server = BackendResource.get({ dbKey: "" });
+const baseUrl = server.host;
 
 // We currently accept three (optional) command line arguments
 // --open - Opens the Cypress test browser
@@ -29,7 +31,7 @@ const init = async () => {
   await BackendResource.start(server);
 
   printBold("Generating snapshots");
-  await generateSnapshots();
+  await generateSnapshots(baseUrl, cleanup);
 
   printBold("Starting Cypress");
   if (!isOpenMode) {
@@ -108,22 +110,3 @@ launch();
 
 process.on("SIGTERM", cleanup);
 process.on("SIGINT", cleanup);
-
-async function generateSnapshots() {
-  const cypressProcess = spawn(
-    "yarn",
-    [
-      "cypress",
-      "run",
-      "--config-file",
-      "frontend/test/__support__/e2e/cypress-snapshots.json",
-      "--config",
-      `baseUrl=${server.host}`,
-    ],
-    { stdio: "inherit" },
-  );
-
-  return new Promise((resolve, reject) => {
-    cypressProcess.on("exit", resolve);
-  });
-}


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Extracts the logic of how we generate snapshots from the runner into a separate file
- Replaces our custom Cypress runner with the more suitable [Cypress Module API](https://docs.cypress.io/guides/guides/module-api)
- Adds guards against:
    - Failing tests (we shouldn't even continue forward if **any** snapshot failed)
    - Failing processes (backend not ready, cypress binary doesn't exist, etc.)

### Why this change?
The beauty of this approach is that we now have access to the incredibly rich results object that allows for an infinite number of possibilities, custom plugins, etc.
```javascript
// frontend/test/__runner__/generate-cypress-snapshots.js
const results = await cypress.run(snapshotConfig);
console.log(results); // add this line and wait for the snapshot task to finish
```

<details>
  <summary>Click to expand (warning: the resulting object is HUGE!)</summary>

```javascript
{
  startedTestsAt: '2021-07-14T14:36:37.138Z',
  endedTestsAt: '2021-07-14T14:36:45.184Z',
  totalDuration: 8046,
  totalSuites: 3,
  totalTests: 2,
  totalFailed: 0,
  totalPassed: 2,
  totalPending: 0,
  totalSkipped: 0,
  runs: [
    {
      stats: [Object],
      reporter: 'spec',
      reporterStats: [Object],
      hooks: [Array],
      tests: [Array],
      error: null,
      video: '/path/to/metabase/cypress/videos/snapshot-creators/default.cy.snap.js.mp4',
      spec: [Object],
      shouldUploadVideo: true
    }
  ],
  browserPath: '',
  browserName: 'electron',
  browserVersion: '87.0.4280.141',
  osName: 'darwin',
  osVersion: '20.5.0',
  cypressVersion: '6.8.0',
  config: {
    env: { HAS_ENTERPRISE_TOKEN: true },
    configFile: '/path/to/metabase/frontend/test/__support__/e2e/cypress-snapshots.json',
    version: '6.8.0',
    testFiles: '**/*.cy.snap.js',
    pluginsFile: '/path/to/metabase/frontend/test/__support__/e2e/cypress-plugins.js',
    integrationFolder: '/path/to/metabase/frontend/test',
    supportFile: '/path/to/metabase/frontend/test/__support__/e2e/cypress.js',
    projectRoot: '/path/to/metabase',
    projectName: 'metabase',
    morgan: false,
    isTextTerminal: true,
    socketId: '3ufif',
    report: true,
    browsers: [ [Object], [Object], [Object], [Object] ],
    baseUrl: 'http://localhost:4000',
    animationDistanceThreshold: 5,
    autoOpen: false,
    blockHosts: null,
    chromeWebSecurity: true,
    clientRoute: '/__/',
    componentFolder: '/path/to/metabase/cypress/component',
    defaultCommandTimeout: 4000,
    downloadsFolder: '/path/to/metabase/cypress/downloads',
    execTimeout: 60000,
    experimentalComponentTesting: false,
    experimentalFetchPolyfill: false,
    experimentalSourceRewriting: false,
    experimentalStudio: false,
    fileServerFolder: '/path/to/metabase',
    firefoxGcInterval: { runMode: 1, openMode: null },
    fixturesFolder: '/path/to/metabase/cypress/fixtures',
    hosts: null,
    ignoreTestFiles: '*.hot-update.js',
    includeShadowDom: false,
    javascripts: [],
    modifyObstructiveCode: true,
    namespace: '__cypress',
    nodeVersion: 'default',
    numTestsKeptInMemory: 0,
    pageLoadTimeout: 60000,
    port: 50877,
    projectId: null,
    reporter: 'spec',
    reporterOptions: null,
    reporterRoute: '/__cypress/reporter',
    requestTimeout: 5000,
    responseTimeout: 30000,
    retries: { runMode: 0, openMode: 0 },
    screenshotOnRunFailure: true,
    screenshotsFolder: '/path/to/metabase/cypress/screenshots',
    socketIoRoute: '/__socket.io',
    webpackDevServerPublicPathRoute: '/__cypress/src',
    socketIoCookie: '__socket.io',
    taskTimeout: 60000,
    trashAssetsBeforeRuns: true,
    userAgent: null,
    video: true,
    videoCompression: 32,
    videosFolder: '/path/to/metabase/cypress/videos',
    videoUploadOnPasses: true,
    viewportHeight: 660,
    viewportWidth: 1000,
    waitForAnimations: true,
    scrollBehavior: 'top',
    watchForFileChanges: false,
    xhrRoute: '/xhrs/',
    cypressEnv: 'production',
    resolved: {
      animationDistanceThreshold: [Object],
      baseUrl: [Object],
      blockHosts: [Object],
      browsers: [Object],
      chromeWebSecurity: [Object],
      componentFolder: [Object],
      defaultCommandTimeout: [Object],
      downloadsFolder: [Object],
      env: [Object],
      execTimeout: [Object],
      experimentalComponentTesting: [Object],
      experimentalFetchPolyfill: [Object],
      experimentalSourceRewriting: [Object],
      experimentalStudio: [Object],
      fileServerFolder: [Object],
      firefoxGcInterval: [Object],
      fixturesFolder: [Object],
      hosts: [Object],
      ignoreTestFiles: [Object],
      includeShadowDom: [Object],
      integrationFolder: [Object],
      modifyObstructiveCode: [Object],
      nodeVersion: [Object],
      numTestsKeptInMemory: [Object],
      pageLoadTimeout: [Object],
      pluginsFile: [Object],
      port: [Object],
      projectId: [Object],
      reporter: [Object],
      reporterOptions: [Object],
      requestTimeout: [Object],
      responseTimeout: [Object],
      retries: [Object],
      screenshotOnRunFailure: [Object],
      screenshotsFolder: [Object],
      supportFile: [Object],
      taskTimeout: [Object],
      testFiles: [Object],
      trashAssetsBeforeRuns: [Object],
      userAgent: [Object],
      video: [Object],
      videoCompression: [Object],
      videosFolder: [Object],
      videoUploadOnPasses: [Object],
      viewportHeight: [Object],
      viewportWidth: [Object],
      waitForAnimations: [Object],
      scrollBehavior: [Object],
      watchForFileChanges: [Object],
      configFile: [Object],
      version: [Object]
    },
    parentTestsFolder: '/path/to/metabase/frontend',
    parentTestsFolderDisplay: 'metabase/frontend',
    supportFolder: '/path/to/metabase/frontend/test/__support__/e2e',
    integrationExampleName: 'examples',
    integrationExamplePath: '/path/to/metabase/frontend/test/examples',
    scaffoldedFiles: [ [Object], [Object] ],
    resolvedNodeVersion: '12.18.3',
    state: {},
    proxyUrl: 'http://localhost:50877',
    browserUrl: 'http://localhost:4000/__/',
    reporterUrl: 'http://localhost:4000/__cypress/reporter',
    xhrUrl: '__cypress/xhrs/',
    proxyServer: 'http://localhost:50877'
  },
  status: 'finished'
}
```
</details>

---

### How to verify this works?

### Everything should still work as before (we get this check from the CI as well)

- `yarn test-cypress-open`
- `yarn test-cypress-no-build`

---

### Let's make sure process exits if at least one of the snapshot tests fail
This wasn't the case before, which could lead to wasted time in the CI. Cypress tests absolutely rely on these snapshots. If one fails, there is no way Cypress tests will finish green. So, why wait. It should fail as early as possible.
<details>
  <summary>BEFORE this change. Notice that the `Starting Cypress` task started</summary>

![image](https://user-images.githubusercontent.com/31325167/125630248-23042939-e20a-484c-a922-281621ba28fe.png)
</details>

<details>
  <summary>AFTER this change. Process exists, and the "clean up" job executes leaving everything pristine.</summary>

![image](https://user-images.githubusercontent.com/31325167/125635495-b884a24c-f96e-4912-89bb-950cfbe544f3.png)

</details>

---

### Wrong snapshot config
<details>
  <summary>BEFORE this change. Even though snapshot generation was completely busted, Cypress opened.</summary>

![image](https://user-images.githubusercontent.com/31325167/125629615-d2bfcaa9-4b12-4133-a8cd-2e45fba9de38.png)
</details>

<details>
  <summary>AFTER this change. Process exists, and the "clean up" job executes leaving everything pristine.</summary>

![image](https://user-images.githubusercontent.com/31325167/125636527-57a55ac7-2be0-450e-ba3f-c0ac0a71991f.png)
</details>

---

### Busted backend
<details>
  <summary>BEFORE this change. Even though backend couldn't even start, Cypress opened.</summary>

![image](https://user-images.githubusercontent.com/31325167/125631174-238f0933-2947-4b6e-b35a-f1fb89035804.png)
</details>

<details>
  <summary>AFTER this change. Process exists, and the "clean up" job executes leaving everything pristine.</summary>

![image](https://user-images.githubusercontent.com/31325167/125636080-45d54e87-ab88-493d-b70e-7b40eaa8f40e.png)
</details>
