### PR TITLE
[Cypress runner] Get version

### DIFF
--- a/frontend/test/__runner__/cypress-runner-get-version.js
+++ b/frontend/test/__runner__/cypress-runner-get-version.js
@@ -1,0 +1,24 @@
+const { printBold, printCyan, readFile } = require("./cypress-runner-utils.js");
+
+const getVersion = async () => {
+  try {
+    const version = await readFile(
+      __dirname + "/../../../resources/version.properties",
+    );
+
+    printBold("Running e2e test runner with this build:");
+    printCyan(version);
+
+    printBold(
+      "If that version seems too old, please run `./bin/build version uberjar`.",
+    );
+  } catch (e) {
+    printBold(
+      "No version file found. Please run `./bin/build version uberjar`.",
+    );
+
+    process.exit(1);
+  }
+};
+
+module.exports = getVersion;

--- a/frontend/test/__runner__/cypress-runner-utils.js
+++ b/frontend/test/__runner__/cypress-runner-utils.js
@@ -1,3 +1,4 @@
+const fs = require("fs");
 const chalk = require("chalk");
 
 function printBold(message) {
@@ -12,4 +13,15 @@ function printCyan(message) {
   console.log(chalk.cyan(message));
 }
 
-module.exports = { printBold, printYellow, printCyan };
+const readFile = fileName => {
+  return new Promise(function(resolve, reject) {
+    fs.readFile(fileName, "utf8", (err, data) => {
+      if (err) {
+        reject(err);
+      }
+      resolve(data);
+    });
+  });
+};
+
+module.exports = { printBold, printYellow, printCyan, readFile };

--- a/frontend/test/__runner__/run_cypress_tests.js
+++ b/frontend/test/__runner__/run_cypress_tests.js
@@ -1,6 +1,7 @@
 import { spawn } from "child_process";
-import fs from "fs";
-const { printBold, printYellow, printCyan } = require("./cypress-runner-utils");
+
+const getVersion = require("./cypress-runner-get-version");
+const { printBold, printYellow, readFile } = require("./cypress-runner-utils");
 
 // Use require for BackendResource to run it after the mock afterAll has been set
 const BackendResource = require("./backend.js").BackendResource;
@@ -19,17 +20,6 @@ const sourceFolderLocation = userArgs[userArgs.indexOf("--folder") + 1];
 const specs = userArgs[userArgs.indexOf("--spec") + 1];
 const isSingleSpec = !specs || !specs.match(/,/);
 const testFiles = isSingleSpec ? specs : specs.split(",");
-
-function readFile(fileName) {
-  return new Promise(function(resolve, reject) {
-    fs.readFile(fileName, "utf8", (err, data) => {
-      if (err) {
-        reject(err);
-      }
-      resolve(data);
-    });
-  });
-}
 
 const init = async () => {
   try {

--- a/frontend/test/__runner__/run_cypress_tests.js
+++ b/frontend/test/__runner__/run_cypress_tests.js
@@ -1,7 +1,7 @@
 import { spawn } from "child_process";
 
 const getVersion = require("./cypress-runner-get-version");
-const { printBold, printYellow, readFile } = require("./cypress-runner-utils");
+const { printBold, printYellow } = require("./cypress-runner-utils");
 
 // Use require for BackendResource to run it after the mock afterAll has been set
 const BackendResource = require("./backend.js").BackendResource;
@@ -22,22 +22,8 @@ const isSingleSpec = !specs || !specs.match(/,/);
 const testFiles = isSingleSpec ? specs : specs.split(",");
 
 const init = async () => {
-  try {
-    const version = await readFile(
-      __dirname + "/../../../resources/version.properties",
-    );
-    printBold("Running e2e test runner with this build:");
-    printCyan(version);
-
-    printBold(
-      "If that version seems too old, please run `./bin/build version uberjar`.\n",
-    );
-  } catch (e) {
-    printBold(
-      "No version file found. Please run `./bin/build version uberjar`.",
-    );
-    process.exit(1);
-  }
+  printBold("Metabase version info");
+  await getVersion();
 
   printBold("Starting backend");
   await BackendResource.start(server);


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Extracts the logic for version checking into a separate file, and imports it into the Cypress runner

**Before**
```
Running '--open' // this is actually a broken logic that I didn't notice before. Will be fixed with this new approach.
Running e2e test runner with this build:
tag=v1.41.0-SNAPSHOT
hash=6db73b0
branch=master
date=2021-07-13
src_hash=92db48cc9cb46aa781ad433fc6e6fa6bbb747e44
If that version seems too old, please run `./bin/build version uberjar`.

Starting backend
...
```

**After**
```
Metabase version info
Running e2e test runner with this build:
tag=v1.40.1-SNAPSHOT
hash=c6b3086
branch=cypress-runner/generate-snapshots
date=2021-07-13
src_hash=b4c55a95af4057dadf89e6cdbc71b88429584fc6

If that version seems too old, please run `./bin/build version uberjar`.
Starting backend
...
```