### PR TITLE
Smartscalars

### DIFF
--- a/src/metabase/pulse/render.clj
+++ b/src/metabase/pulse/render.clj
@@ -49,7 +49,7 @@
 
 (defn detect-pulse-chart-type
   "Determine the pulse (visualization) type of a `card`, e.g. `:scalar` or `:bar`."
-  [{display-type :display, card-name :name, :as card} {:keys [cols rows], :as data}]
+  [{display-type :display, card-name :name, :as card} {:keys [cols rows insights], :as data}]
   (let [col-sample-count          (delay (count (take 3 cols)))
         row-sample-count          (delay (count (take 2 rows)))
         [col-1-rowfn col-2-rowfn] (common/graphing-column-row-fns card data)
@@ -72,6 +72,11 @@
 
         (= @col-sample-count @row-sample-count 1)
         (chart-type :scalar "result has one row and one column")
+
+        (and (= display-type :smartscalar)
+             (= @col-sample-count 2)
+             (seq insights))
+        (chart-type :smartscalar "result has two columns and insights")
 
         (and (= @col-sample-count 2)
              (> @row-sample-count 1)

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -11,21 +11,22 @@
             [metabase.pulse.render.style :as style]
             [metabase.pulse.render.table :as table]
             [metabase.types :as types]
-            [metabase.util.i18n :refer [tru trs]]
+            [metabase.util.i18n :refer [trs tru]]
             [schema.core :as s])
   (:import java.text.DecimalFormat))
 
 (def error-rendered-info
-  {:attachments
-   nil
+  "Default rendered-info map when there is an error displaying a card. Is a delay due to the call to `trs`."
+  (delay {:attachments
+          nil
 
-   :content
-   [:div {:style (style/style
-                  (style/font-style)
-                  {:color       style/color-error
-                   :font-weight 700
-                   :padding     :16px})}
-    (trs "An error occurred while displaying this card.")]})
+          :content
+          [:div {:style (style/style
+                         (style/font-style)
+                         {:color       style/color-error
+                          :font-weight 700
+                          :padding     :16px})}
+           (trs "An error occurred while displaying this card.")]}))
 
 (def rows-limit
   "Maximum number of rows to render in a Pulse image."
@@ -275,7 +276,7 @@
            :render/text (str value "\n"
                              adj " " (percentage last-change) "."
                              " Was " previous " last " (format-unit unit))})
-        error-rendered-info))))
+        @error-rendered-info))))
 
 (s/defmethod render :sparkline :- common/RenderedPulseCard
   [_ render-type timezone-id card {:keys [rows cols] :as data}]
@@ -365,4 +366,4 @@
 
 (s/defmethod render :error :- common/RenderedPulseCard
   [_ _ _ _ _]
-  error-rendered-info)
+  @error-rendered-info)

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -263,9 +263,14 @@
               previous (format-cell timezone-id previous-value metric-col)
               adj      (if (pos? last-change) (tru "Up") (tru "Down"))]
           {:attachments nil
-           :content     [:div {:style (style/style (style/scalar-style))}
-                         (h value)
-                         [:p adj " " (percentage last-change) "."
+           :content     [:div
+                         [:div {:style (style/style (style/scalar-style))}
+                          (h value)]
+                         [:p {:style (style/style {:color         style/color-text-medium
+                                                   :font-size     :16px
+                                                   :font-weight   700
+                                                   :padding-right :16px})}
+                          adj " " (percentage last-change) "."
                           " Was " previous " last " (format-unit unit)]]
            :render/text (str value "\n"
                              adj " " (percentage last-change) "."

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -1,5 +1,6 @@
 (ns metabase.pulse.render.body
   (:require [cheshire.core :as json]
+            [clojure.string :as str]
             [hiccup.core :refer [h]]
             [medley.core :as m]
             [metabase.pulse.render.color :as color]
@@ -10,8 +11,21 @@
             [metabase.pulse.render.style :as style]
             [metabase.pulse.render.table :as table]
             [metabase.types :as types]
-            [metabase.util.i18n :refer [trs]]
-            [schema.core :as s]))
+            [metabase.util.i18n :refer [tru trs]]
+            [schema.core :as s])
+  (:import java.text.DecimalFormat))
+
+(def error-rendered-info
+  {:attachments
+   nil
+
+   :content
+   [:div {:style (style/style
+                  (style/font-style)
+                  {:color       style/color-error
+                   :font-weight 700
+                   :padding     :16px})}
+    (trs "An error occurred while displaying this card.")]})
 
 (def rows-limit
   "Maximum number of rows to render in a Pulse image."
@@ -229,6 +243,35 @@
       (h value)]
      :render/text (str value)}))
 
+(s/defmethod render :smartscalar :- common/RenderedPulseCard
+  [_ _ timezone-id _card {:keys [cols rows insights]}]
+  (letfn [(col-of-type [t c] (or (isa? (:effective_type c) t)
+                                 ;; computed and agg columns don't have an effective type
+                                 (isa? (:base_type c) t)))
+          (where [f coll] (some #(when (f %) %) coll))
+          (percentage [arg] (if (number? arg)
+                              (let [f (DecimalFormat. "###,###.##%")]
+                                (.format f (double arg)))
+                              " - "))
+          (format-unit [unit] (str/replace (name unit) "-" " "))]
+    (let [[_time-col metric-col] (if (col-of-type :type/Temporal (first cols)) cols (reverse cols))
+
+          {:keys [last-value previous-value unit last-change] :as _insight}
+          (where (comp #{(:name metric-col)} :col) insights)]
+      (if (and last-value previous-value unit last-change)
+        (let [value    (format-cell timezone-id last-value metric-col)
+              previous (format-cell timezone-id previous-value metric-col)
+              adj      (if (pos? last-change) (tru "Up") (tru "Down"))]
+          {:attachments nil
+           :content     [:div {:style (style/style (style/scalar-style))}
+                         (h value)
+                         [:p adj " " (percentage last-change) "."
+                          " Was " previous " last " (format-unit unit)]]
+           :render/text (str value "\n"
+                             adj " " (percentage last-change) "."
+                             " Was " previous " last " (format-unit unit))})
+        error-rendered-info))))
+
 (s/defmethod render :sparkline :- common/RenderedPulseCard
   [_ render-type timezone-id card {:keys [rows cols] :as data}]
   (let [[x-axis-rowfn
@@ -317,13 +360,4 @@
 
 (s/defmethod render :error :- common/RenderedPulseCard
   [_ _ _ _ _]
-  {:attachments
-   nil
-
-   :content
-   [:div {:style (style/style
-                  (style/font-style)
-                  {:color       style/color-error
-                   :font-weight 700
-                   :padding     :16px})}
-    (trs "An error occurred while displaying this card.")]})
+  error-rendered-info)

--- a/test/metabase/pulse/render/body_test.clj
+++ b/test/metabase/pulse/render/body_test.clj
@@ -279,19 +279,42 @@
                                          :semantic_type nil}]
                                  :rows [["2014-04-01T08:30:00.0000"]]}))))
   (testing "Includes raw text"
-    (let [results {:cols [{:name         "stringvalue",
-                           :display_name "STRINGVALUE",
-                           :base_type    :type/Text
-                           :semantic_type nil}]
-                   :rows [["foo"]]}]
-      (is (= "foo"
-             (:render/text (body/render :scalar nil pacific-tz nil results))))
-      (is (schema= {:attachments (s/eq nil)
-                    :content     [(s/one (s/eq :div) "div tag")
-                                  (s/one {:style s/Str} "style map")
-                              (s/one (s/eq "foo") "content")]
-                    :render/text (s/eq "foo")}
-                   (body/render :scalar nil pacific-tz nil results))))))
+    (testing "for scalars"
+      (let [results {:cols [{:name         "stringvalue",
+                             :display_name "STRINGVALUE",
+                             :base_type    :type/Text
+                             :semantic_type nil}]
+                     :rows [["foo"]]}]
+        (is (= "foo"
+               (:render/text (body/render :scalar nil pacific-tz nil results))))
+        (is (schema= {:attachments (s/eq nil)
+                      :content     [(s/one (s/eq :div) "div tag")
+                                    (s/one {:style s/Str} "style map")
+                                    (s/one (s/eq "foo") "content")]
+                      :render/text (s/eq "foo")}
+                     (body/render :scalar nil pacific-tz nil results)))))
+    (testing "for smartscalars"
+      (let [results {:cols [{:name         "value",
+                             :display_name "VALUE",
+                             :base_type    :type/Decimal}
+                            {:name           "time",
+                             :display_name   "TIME",
+                             :base_type      :type/DateTime
+                             :effective_type :type/DateTime}]
+                     :rows [[40.0 :this-month]
+                            [30.0 :last-month]
+                            [20.0 :month-before]]
+                     :insights [{:previous-value 30.0
+                                 :unit :month
+                                 :last-change 1.333333
+                                 :col "value"
+                                 :last-value 40.0}]}]
+        (is (= "40.00\nUp 133.33%. Was 30.00 last month"
+               (:render/text (body/render :smartscalar nil pacific-tz nil results))))
+        (is (schema= {:attachments (s/eq nil)
+                      :content     (s/pred vector? "hiccup vector")
+                      :render/text (s/eq "40.00\nUp 133.33%. Was 30.00 last month")}
+                     (body/render :smartscalar nil pacific-tz nil results)))))))
 
 (defn- replace-style-maps [hiccup-map]
   (walk/postwalk (fn [maybe-map]


### PR DESCRIPTION
Support for smartscalars.

### Existing behavior in GUI:
<img width="531" alt="image" src="https://user-images.githubusercontent.com/6377293/125487126-1dbedc51-3f04-4762-ad27-7525c81ad3ee.png">

### Existing pulse behavior:

None. These were not supported and it would fall back to a sparkline (line plot)

### New Slack behavior:
<img width="653" alt="image" src="https://user-images.githubusercontent.com/6377293/125487246-1735c548-01cd-42c5-923b-e5a35395b9e9.png">

### If rendered as an image:
This screenshot is what we would have sent to slack previously and is just a render of the html we output. So emails should look identical or substantially the same, depending on client.
<img width="664" alt="image" src="https://user-images.githubusercontent.com/6377293/125490177-47fe5fc6-508e-4836-86c1-104e6c017d3d.png">
