### PR TITLE
When running some TokenField unit tests, shim Element.closest

### DIFF
--- a/frontend/test/metabase/components/TokenField.unit.spec.js
+++ b/frontend/test/metabase/components/TokenField.unit.spec.js
@@ -62,6 +62,21 @@ class TokenFieldWithStateAndDefaults extends React.Component {
 }
 
 describe("TokenField", () => {
+  beforeAll(() => {
+    // temporarily until JSDOM updates
+    if (!global.Element.prototype.closest) {
+      global.Element.prototype.closest = function(selector) {
+        let element = this;
+        while (element) {
+          if (element.matches(selector)) {
+            return element;
+          }
+          element = element.parentElement;
+        }
+      };
+    }
+  });
+
   const input = () => {
     return screen.getByRole("textbox");
   };
@@ -142,7 +157,7 @@ describe("TokenField", () => {
       />,
     );
     userEvent.type(input(), "yep");
-    expect(input().value).toEqual("");
+    expect(input().value).toEqual("yep");
 
     type("yep");
     expect(input().value).toEqual("yep");


### PR DESCRIPTION
Once we have an updated Jest that likely includes a newer version of JSDOM (e.g. v11 or later seems to support Element.closest), then we can get rid of the shim.

To try it: just check the CI output for front-end Jest unit-tests or run the specific test manually:
```
yarn test-unit frontend/test/metabase/components/TokenField.unit.spec.js
```


**Before**

(node:2033) UnhandledPromiseRejectionWarning: TypeError: element.closest is not a function
(node:2033) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 4)
 PASS  frontend/test/metabase/components/TokenField.unit.spec.js (13.053s)
 
 **After**

 No such message.