### PR TITLE
Form: guard against undefined submit function

### DIFF
--- a/frontend/src/metabase/containers/Form.jsx
+++ b/frontend/src/metabase/containers/Form.jsx
@@ -322,7 +322,9 @@ export default class Form extends React.Component {
   };
 
   _handleSubmitSuccess = async (action: any) => {
-    await this.props.onSubmitSuccess(action);
+    if (this.props.onSubmitSuccess) {
+      await this.props.onSubmitSuccess(action);
+    }
     this.props.dispatch(
       initialize(this.props.formName, this.props.values, this._getFieldNames()),
     );


### PR DESCRIPTION
To try it: just check the CI output for front-end Jest unit-tests or run the specific test manually:
```
yarn test-unit frontend/test/metabase/containers/SaveQuestionModal.unit.spec.js
```

**Before**

(node:2222) UnhandledPromiseRejectionWarning: TypeError: _this2.props.onSubmitSuccess is not a function
(node:2222) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 3)
 PASS  frontend/test/metabase/containers/SaveQuestionModal.unit.spec.js
 
**After**

No such message.