### PR TITLE
#17019 Repro: Question filters don't for for embed/public scenarios

### DIFF
--- a/frontend/test/metabase/scenarios/filters/reproductions/17019.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/reproductions/17019.cy.spec.js
@@ -1,0 +1,51 @@
+import { restore } from "__support__/e2e/cypress";
+
+const question = {
+  name: "17019",
+  native: {
+    query: "select {{foo}}",
+    "template-tags": {
+      foo: {
+        id: "08edf340-3d89-cfb1-b7f0-073b9eca6a32",
+        name: "filter",
+        "display-name": "Filter",
+        type: "text",
+      },
+    },
+  },
+  display: "scalar",
+};
+
+describe.skip("issue 17019", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.createNativeQuestion(question).then(({ body: { id } }) => {
+      cy.intercept("POST", `/api/card/${id}/query`).as("cardQuery");
+
+      // Enable sharing
+      cy.request("POST", `/api/card/${id}/public_link`);
+
+      cy.visit(`/question/${id}`);
+      cy.wait("@cardQuery");
+    });
+  });
+
+  it("question filters should work for embedding/public sharing scenario (metabase#17019)", () => {
+    cy.icon("share").click();
+
+    cy.findByDisplayValue(/^http/)
+      .invoke("val")
+      .then(publicURL => {
+        cy.visit(publicURL);
+      });
+
+    cy.findByPlaceholderText("Filter").type("456{enter}");
+
+    // We should see the result as a scalar
+    cy.get(".ScalarValue").contains("456");
+    // But let's also check that the filter widget has that same value still displayed
+    cy.findByDisplayValue("456");
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #17019 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/filters/reproductions/17019.cy.spec.js`
- Replace `.skip()` with `.only()` to run the test in isolation

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/125510242-f0a4e9a4-1f68-4e43-88c3-3e5637b25d93.png)

