### PR TITLE
Remove Multi-Release from manifest

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -173,9 +173,7 @@
   :main ^:skip-aot metabase.core
 
   :manifest
-  {;; log4j is multi-release and lein uberjar doesn't set this correctly in the manifest
-   "Multi-Release" true
-   ;; Liquibase uses this manifest parameter to dynamically find extensions at startup (via classpath scanning, etc)
+  {;; Liquibase uses this manifest parameter to dynamically find extensions at startup (via classpath scanning, etc)
    "Liquibase-Package"
    #= (eval
        (str "liquibase.change,liquibase.changelog,liquibase.database,liquibase.parser,liquibase.precondition,"


### PR DESCRIPTION
Undoes #16005, because performance was significantly impacted; see issue #16380
