### PR TITLE
Add support for driver deprecation

### DIFF
--- a/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx
@@ -15,6 +15,7 @@ import ActionButton from "metabase/components/ActionButton";
 import AddDatabaseHelpCard from "metabase/components/AddDatabaseHelpCard";
 import Button from "metabase/components/Button";
 import Breadcrumbs from "metabase/components/Breadcrumbs";
+import DriverWarning from "metabase/components/DriverWarning/DriverWarning";
 import Radio from "metabase/components/Radio";
 import ModalWithTrigger from "metabase/components/ModalWithTrigger";
 
@@ -210,15 +211,20 @@ export default class DatabaseEditApp extends Component {
                     )}
                   </LoadingAndErrorWrapper>
                 </Box>
-                {addingNewDatabase && (
-                  <Box>
+                <Box>
+                  <DriverWarning
+                    engine={selectedEngine}
+                    ml={26}
+                    data-testid={"database-setup-driver-warning"}
+                  />
+                  {addingNewDatabase && (
                     <AddDatabaseHelpCard
                       engine={selectedEngine}
                       ml={26}
                       data-testid="database-setup-help-card"
                     />
-                  </Box>
-                )}
+                  )}
+                </Box>
               </Flex>
             </div>
           </Box>

--- a/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx
@@ -150,8 +150,6 @@ export default class DatabaseEditApp extends Component {
 
     const showTabs = editingExistingDatabase && letUserControlSchedulingSaved;
 
-    const { selectEngine } = this.props;
-
     return (
       <Box px={[3, 4, 5]} mt={[1, 2, 3]}>
         <Breadcrumbs
@@ -216,10 +214,6 @@ export default class DatabaseEditApp extends Component {
                 <Box>
                   <DriverWarning
                     engine={selectedEngine}
-                    onEngineChange={engine => {
-                      console.log("onEngineChange: " + engine);
-                      selectEngine(engine);
-                    }}
                     ml={26}
                     data-testid="database-setup-driver-warning"
                   />

--- a/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx
@@ -215,7 +215,7 @@ export default class DatabaseEditApp extends Component {
                   <DriverWarning
                     engine={selectedEngine}
                     ml={26}
-                    data-testid={"database-setup-driver-warning"}
+                    data-testid="database-setup-driver-warning"
                   />
                   {addingNewDatabase && (
                     <AddDatabaseHelpCard

--- a/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx
@@ -150,6 +150,8 @@ export default class DatabaseEditApp extends Component {
 
     const showTabs = editingExistingDatabase && letUserControlSchedulingSaved;
 
+    const { selectEngine } = this.props;
+
     return (
       <Box px={[3, 4, 5]} mt={[1, 2, 3]}>
         <Breadcrumbs
@@ -214,6 +216,10 @@ export default class DatabaseEditApp extends Component {
                 <Box>
                   <DriverWarning
                     engine={selectedEngine}
+                    onEngineChange={engine => {
+                      console.log("onEngineChange: " + engine);
+                      selectEngine(engine);
+                    }}
                     ml={26}
                     data-testid="database-setup-driver-warning"
                   />

--- a/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx
@@ -15,7 +15,7 @@ import ActionButton from "metabase/components/ActionButton";
 import AddDatabaseHelpCard from "metabase/components/AddDatabaseHelpCard";
 import Button from "metabase/components/Button";
 import Breadcrumbs from "metabase/components/Breadcrumbs";
-import DriverWarning from "metabase/components/DriverWarning/DriverWarning";
+import DriverWarning from "metabase/components/DriverWarning";
 import Radio from "metabase/components/Radio";
 import ModalWithTrigger from "metabase/components/ModalWithTrigger";
 

--- a/frontend/src/metabase/components/DriverWarning/DriverWarning.jsx
+++ b/frontend/src/metabase/components/DriverWarning/DriverWarning.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-import { t } from "ttag";
+import { jt, t } from "ttag";
 
 import {
   allEngines,
@@ -20,25 +20,31 @@ import MetabaseSettings from "metabase/lib/settings";
 
 const propTypes = {
   engine: PropTypes.string.isRequired,
+  onEngineChange: PropTypes.func.isRequired,
 };
 
 const driverUpgradeHelpLink = MetabaseSettings.docsUrl(
   "administration-guide/99-upgrading-drivers",
 );
 
-function getSupersedesWarningContent(newDriver, supersedesDriver) {
+function getSupersedesWarningContent(
+  newDriver,
+  supersedesDriver,
+  onEngineChange,
+) {
   return (
     <div>
       <p className="text-medium m0">
         {t`This is our new ${
           allEngines[newDriver]["driver-name"]
-        } driver, which is faster and
-      more reliable.`}
+        } driver, which is faster and more reliable.`}
       </p>
-      <p>{t`The old driver has been deprecated and will be removed in the next release. If you really
-      need to use it, you can select ${
-        allEngines[supersedesDriver]["driver-name"]
-      } now.`}</p>
+      <p>{jt`The old driver has been deprecated and will be removed in the next release. If you really
+      need to use it, you can ${(
+        <a className="link" onClick={() => onEngineChange(supersedesDriver)}>
+          find it here
+        </a>
+      )}.`}</p>
     </div>
   );
 }
@@ -52,8 +58,7 @@ function getSupersededByWarningContent(engine) {
       <p className="text-medium m0">
         {t`We recommend that you upgrade to the new ${
           allEngines[engine]["driver-name"]
-        } driver, which is faster and more
-         reliable.`}
+        } driver, which is faster and more reliable.`}
       </p>
       <ExternalLink
         href={driverUpgradeHelpLink}
@@ -65,7 +70,7 @@ function getSupersededByWarningContent(engine) {
   );
 }
 
-function DriverWarning({ engine, ...props }) {
+function DriverWarning({ engine, onEngineChange, ...props }) {
   const supersededBy = engineSupersedesMap["superseded_by"][engine];
   const supersedes = engineSupersedesMap["supersedes"][engine];
 
@@ -75,7 +80,7 @@ function DriverWarning({ engine, ...props }) {
 
   const tooltipWarning = supersedes ? t`New driver` : t`Driver deprecated`;
   const warningContent = supersedes
-    ? getSupersedesWarningContent(engine, supersedes)
+    ? getSupersedesWarningContent(engine, supersedes, onEngineChange)
     : getSupersededByWarningContent(supersededBy);
 
   return (

--- a/frontend/src/metabase/components/DriverWarning/DriverWarning.jsx
+++ b/frontend/src/metabase/components/DriverWarning/DriverWarning.jsx
@@ -15,24 +15,54 @@ import {
   DriverWarningContainer,
   IconContainer,
 } from "./DriverWarning.styled";
+import ExternalLink from "metabase/components/ExternalLink";
+import MetabaseSettings from "metabase/lib/settings";
 
 const propTypes = {
   engine: PropTypes.string.isRequired,
 };
 
-function getSupersedesFor(engine) {
-  return t`This driver replaces the legacy version, which is called ${
-    allEngines[engine]["driver-name"]
-  }.  If you need
-    to use the legacy driver, you can select it now.  Please let us know if you have any issues with this new driver.`;
+const driverUpgradeHelpLink = MetabaseSettings.docsUrl(
+  "administration-guide/99-upgrading-drivers",
+);
+
+function getSupersedesWarningContent(newDriver, supersedesDriver) {
+  return (
+    <div>
+      <p className="text-medium m0">
+        {t`This is our new ${
+          allEngines[newDriver]["driver-name"]
+        } driver, which is faster and
+      more reliable.`}
+      </p>
+      <p>{t`The old driver has been deprecated and will be removed in the next release. If you really
+      need to use it, you can select ${
+        allEngines[supersedesDriver]["driver-name"]
+      } now.`}</p>
+    </div>
+  );
 }
 
-function getSupersededByMessageFor(engine) {
-  return t`This driver is a legacy driver, and will eventually be removed from Metabase.  Please use the newer version,
-    which is called ${
-      allEngines[engine]["driver-name"]
-    }. Please let us know if you have any issues with this new
-    driver.`;
+function getSupersededByWarningContent(engine) {
+  return (
+    <div>
+      <p className="text-medium m0">
+        {t`This driver has been deprecated and will be removed in the next release.`}
+      </p>
+      <p className="text-medium m0">
+        {t`We recommend that you upgrade to the new ${
+          allEngines[engine]["driver-name"]
+        } driver, which is faster and more
+         reliable.`}
+      </p>
+      <ExternalLink
+        href={driverUpgradeHelpLink}
+        className="text-brand text-bold"
+      >
+        {t`How to upgrade a driver (TODO: fix link)`}
+      </ExternalLink>
+    </div>
+  );
 }
 
 function DriverWarning({ engine, ...props }) {
@@ -44,9 +74,9 @@ function DriverWarning({ engine, ...props }) {
   }
 
   const tooltipWarning = supersedes ? t`New driver` : t`Driver deprecated`;
-  const message = supersedes
-    ? getSupersedesFor(supersedes)
-    : getSupersededByMessageFor(supersededBy);
+  const warningContent = supersedes
+    ? getSupersedesWarningContent(engine, supersedes)
+    : getSupersededByWarningContent(supersededBy);
 
   return (
     <DriverWarningContainer p={2} {...props}>
@@ -58,9 +88,7 @@ function DriverWarning({ engine, ...props }) {
         />
       </IconContainer>
       <CardContent flexDirection="column" justify="center" className="ml2">
-        <div>
-          <p className="text-medium m0">{message}</p>
-        </div>
+        {warningContent}
       </CardContent>
     </DriverWarningContainer>
   );

--- a/frontend/src/metabase/components/DriverWarning/DriverWarning.jsx
+++ b/frontend/src/metabase/components/DriverWarning/DriverWarning.jsx
@@ -1,0 +1,74 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+import { t } from "ttag";
+
+// TODO: is this really the best way?
+import {
+  allEngines,
+  engineSupersedesMap,
+} from "../../entities/databases/forms";
+
+import { CardContent, DriverWarningContainer } from "./DriverWarning.styled";
+
+import Warnings from "metabase/query_builder/components/Warnings";
+
+const propTypes = {
+  engine: PropTypes.string.isRequired,
+};
+
+function DriverWarning({ engine, ...props }) {
+  const supersededBy = engineSupersedesMap["superseded_by"][engine];
+  const supersedes = engineSupersedesMap["supersedes"][engine];
+
+  if (supersedes) {
+    return (
+      <DriverWarningContainer p={2} {...props}>
+        <Warnings
+          className="mx2 align-self-end text-gold"
+          warnings={[t`New driver`]}
+          size={20}
+        />
+
+        <CardContent flexDirection="column" justify="center" className="ml2">
+          <div>
+            <p className="text-medium m0">
+              {t`This driver replaces the legacy version, which is called ${
+                allEngines[supersedes]["driver-name"]
+              }.
+                If you need to use the legacy driver, you can select it now.  Please let us know if you have any issues
+                with this new driver.`}
+            </p>
+          </div>
+        </CardContent>
+      </DriverWarningContainer>
+    );
+  } else if (supersededBy) {
+    return (
+      <DriverWarningContainer p={2} {...props}>
+        <Warnings
+          className="mx2 align-self-end text-gold"
+          warnings={[t`Driver deprecated`]}
+          size={20}
+        />
+        <CardContent flexDirection="column" justify="center" className="ml2">
+          <div>
+            <p className="text-medium m0">
+              {t`This driver is a legacy driver, and will eventually be removed from Metabase.  Please use the newer
+                version, which is called ${
+                  allEngines[supersededBy]["driver-name"]
+                }. Please let us know if you have any
+                issues with this new driver.`}
+            </p>
+          </div>
+        </CardContent>
+      </DriverWarningContainer>
+    );
+  } else {
+    return null;
+  }
+}
+
+DriverWarning.propTypes = propTypes;
+
+export default DriverWarning;

--- a/frontend/src/metabase/components/DriverWarning/DriverWarning.jsx
+++ b/frontend/src/metabase/components/DriverWarning/DriverWarning.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-import { jt, t } from "ttag";
+import { t } from "ttag";
 
 import {
   allEngines,
@@ -20,31 +20,25 @@ import MetabaseSettings from "metabase/lib/settings";
 
 const propTypes = {
   engine: PropTypes.string.isRequired,
-  onEngineChange: PropTypes.func.isRequired,
 };
 
 const driverUpgradeHelpLink = MetabaseSettings.docsUrl(
   "administration-guide/99-upgrading-drivers",
 );
 
-function getSupersedesWarningContent(
-  newDriver,
-  supersedesDriver,
-  onEngineChange,
-) {
+function getSupersedesWarningContent(newDriver, supersedesDriver) {
   return (
     <div>
       <p className="text-medium m0">
         {t`This is our new ${
           allEngines[newDriver]["driver-name"]
-        } driver, which is faster and more reliable.`}
+        } driver, which is faster and
+      more reliable.`}
       </p>
-      <p>{jt`The old driver has been deprecated and will be removed in the next release. If you really
-      need to use it, you can ${(
-        <a className="link" onClick={() => onEngineChange(supersedesDriver)}>
-          find it here
-        </a>
-      )}.`}</p>
+      <p>{t`The old driver has been deprecated and will be removed in the next release. If you really
+      need to use it, you can select ${
+        allEngines[supersedesDriver]["driver-name"]
+      } now.`}</p>
     </div>
   );
 }
@@ -58,7 +52,8 @@ function getSupersededByWarningContent(engine) {
       <p className="text-medium m0">
         {t`We recommend that you upgrade to the new ${
           allEngines[engine]["driver-name"]
-        } driver, which is faster and more reliable.`}
+        } driver, which is faster and more
+         reliable.`}
       </p>
       <ExternalLink
         href={driverUpgradeHelpLink}
@@ -70,7 +65,7 @@ function getSupersededByWarningContent(engine) {
   );
 }
 
-function DriverWarning({ engine, onEngineChange, ...props }) {
+function DriverWarning({ engine, ...props }) {
   const supersededBy = engineSupersedesMap["superseded_by"][engine];
   const supersedes = engineSupersedesMap["supersedes"][engine];
 
@@ -80,7 +75,7 @@ function DriverWarning({ engine, onEngineChange, ...props }) {
 
   const tooltipWarning = supersedes ? t`New driver` : t`Driver deprecated`;
   const warningContent = supersedes
-    ? getSupersedesWarningContent(engine, supersedes, onEngineChange)
+    ? getSupersedesWarningContent(engine, supersedes)
     : getSupersededByWarningContent(supersededBy);
 
   return (

--- a/frontend/src/metabase/components/DriverWarning/DriverWarning.jsx
+++ b/frontend/src/metabase/components/DriverWarning/DriverWarning.jsx
@@ -10,7 +10,11 @@ import {
 
 import Warnings from "metabase/query_builder/components/Warnings";
 
-import { CardContent, DriverWarningContainer } from "./DriverWarning.styled";
+import {
+  CardContent,
+  DriverWarningContainer,
+  IconContainer,
+} from "./DriverWarning.styled";
 
 const propTypes = {
   engine: PropTypes.string.isRequired,
@@ -46,11 +50,13 @@ function DriverWarning({ engine, ...props }) {
 
   return (
     <DriverWarningContainer p={2} {...props}>
-      <Warnings
-        className="mx2 align-self-end text-gold"
-        warnings={[tooltipWarning]}
-        size={20}
-      />
+      <IconContainer>
+        <Warnings
+          className="mx2 text-gold"
+          warnings={[tooltipWarning]}
+          size={20}
+        />
+      </IconContainer>
       <CardContent flexDirection="column" justify="center" className="ml2">
         <div>
           <p className="text-medium m0">{message}</p>

--- a/frontend/src/metabase/components/DriverWarning/DriverWarning.jsx
+++ b/frontend/src/metabase/components/DriverWarning/DriverWarning.jsx
@@ -23,7 +23,7 @@ const propTypes = {
 };
 
 const driverUpgradeHelpLink = MetabaseSettings.docsUrl(
-  "administration-guide/99-upgrading-drivers",
+  "administration-guide/01-managing-databases",
 );
 
 function getSupersedesWarningContent(newDriver, supersedesDriver) {
@@ -32,8 +32,7 @@ function getSupersedesWarningContent(newDriver, supersedesDriver) {
       <p className="text-medium m0">
         {t`This is our new ${
           allEngines[newDriver]["driver-name"]
-        } driver, which is faster and
-      more reliable.`}
+        } driver, which is faster and more reliable.`}
       </p>
       <p>{t`The old driver has been deprecated and will be removed in the next release. If you really
       need to use it, you can select ${
@@ -52,14 +51,13 @@ function getSupersededByWarningContent(engine) {
       <p className="text-medium m0">
         {t`We recommend that you upgrade to the new ${
           allEngines[engine]["driver-name"]
-        } driver, which is faster and more
-         reliable.`}
+        } driver, which is faster and more reliable.`}
       </p>
       <ExternalLink
         href={driverUpgradeHelpLink}
         className="text-brand text-bold"
       >
-        {t`How to upgrade a driver (TODO: fix link)`}
+        {t`How to upgrade a driver`}
       </ExternalLink>
     </div>
   );

--- a/frontend/src/metabase/components/DriverWarning/DriverWarning.jsx
+++ b/frontend/src/metabase/components/DriverWarning/DriverWarning.jsx
@@ -3,70 +3,61 @@ import PropTypes from "prop-types";
 
 import { t } from "ttag";
 
-// TODO: is this really the best way?
 import {
   allEngines,
   engineSupersedesMap,
-} from "../../entities/databases/forms";
-
-import { CardContent, DriverWarningContainer } from "./DriverWarning.styled";
+} from "metabase/entities/databases/forms";
 
 import Warnings from "metabase/query_builder/components/Warnings";
+
+import { CardContent, DriverWarningContainer } from "./DriverWarning.styled";
 
 const propTypes = {
   engine: PropTypes.string.isRequired,
 };
 
+function getSupersedesFor(engine) {
+  return t`This driver replaces the legacy version, which is called ${
+    allEngines[engine]["driver-name"]
+  }.  If you need
+    to use the legacy driver, you can select it now.  Please let us know if you have any issues with this new driver.`;
+}
+
+function getSupersededByMessageFor(engine) {
+  return t`This driver is a legacy driver, and will eventually be removed from Metabase.  Please use the newer version,
+    which is called ${
+      allEngines[engine]["driver-name"]
+    }. Please let us know if you have any issues with this new
+    driver.`;
+}
+
 function DriverWarning({ engine, ...props }) {
   const supersededBy = engineSupersedesMap["superseded_by"][engine];
   const supersedes = engineSupersedesMap["supersedes"][engine];
 
-  if (supersedes) {
-    return (
-      <DriverWarningContainer p={2} {...props}>
-        <Warnings
-          className="mx2 align-self-end text-gold"
-          warnings={[t`New driver`]}
-          size={20}
-        />
-
-        <CardContent flexDirection="column" justify="center" className="ml2">
-          <div>
-            <p className="text-medium m0">
-              {t`This driver replaces the legacy version, which is called ${
-                allEngines[supersedes]["driver-name"]
-              }.
-                If you need to use the legacy driver, you can select it now.  Please let us know if you have any issues
-                with this new driver.`}
-            </p>
-          </div>
-        </CardContent>
-      </DriverWarningContainer>
-    );
-  } else if (supersededBy) {
-    return (
-      <DriverWarningContainer p={2} {...props}>
-        <Warnings
-          className="mx2 align-self-end text-gold"
-          warnings={[t`Driver deprecated`]}
-          size={20}
-        />
-        <CardContent flexDirection="column" justify="center" className="ml2">
-          <div>
-            <p className="text-medium m0">
-              {t`This driver is a legacy driver, and will eventually be removed from Metabase.  Please use the newer
-                version, which is called ${
-                  allEngines[supersededBy]["driver-name"]
-                }. Please let us know if you have any
-                issues with this new driver.`}
-            </p>
-          </div>
-        </CardContent>
-      </DriverWarningContainer>
-    );
-  } else {
+  if (!supersedes && !supersededBy) {
     return null;
   }
+
+  const tooltipWarning = supersedes ? t`New driver` : t`Driver deprecated`;
+  const message = supersedes
+    ? getSupersedesFor(supersedes)
+    : getSupersededByMessageFor(supersededBy);
+
+  return (
+    <DriverWarningContainer p={2} {...props}>
+      <Warnings
+        className="mx2 align-self-end text-gold"
+        warnings={[tooltipWarning]}
+        size={20}
+      />
+      <CardContent flexDirection="column" justify="center" className="ml2">
+        <div>
+          <p className="text-medium m0">{message}</p>
+        </div>
+      </CardContent>
+    </DriverWarningContainer>
+  );
 }
 
 DriverWarning.propTypes = propTypes;

--- a/frontend/src/metabase/components/DriverWarning/DriverWarning.styled.js
+++ b/frontend/src/metabase/components/DriverWarning/DriverWarning.styled.js
@@ -9,9 +9,3 @@ export const DriverWarningContainer = styled(Flex)`
   width: 300px;
   margin-bottom: 8px;
 `;
-
-export const IconContainer = styled(Flex)`
-  width: 32px;
-  height: 32px;
-  background-color: "transparent";
-`;

--- a/frontend/src/metabase/components/DriverWarning/DriverWarning.styled.js
+++ b/frontend/src/metabase/components/DriverWarning/DriverWarning.styled.js
@@ -3,6 +3,12 @@ import { Flex } from "grid-styled";
 
 export const CardContent = styled(Flex)``;
 
+export const IconContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
 export const DriverWarningContainer = styled(Flex)`
   background-color: #f9fbfb;
   border-radius: 10px;

--- a/frontend/src/metabase/components/DriverWarning/DriverWarning.styled.js
+++ b/frontend/src/metabase/components/DriverWarning/DriverWarning.styled.js
@@ -1,0 +1,17 @@
+import styled from "styled-components";
+import { Flex } from "grid-styled";
+
+export const CardContent = styled(Flex)``;
+
+export const DriverWarningContainer = styled(Flex)`
+  background-color: #f9fbfb;
+  border-radius: 10px;
+  width: 300px;
+  margin-bottom: 8px;
+`;
+
+export const IconContainer = styled(Flex)`
+  width: 32px;
+  height: 32px;
+  background-color: "transparent";
+`;

--- a/frontend/src/metabase/components/DriverWarning/index.js
+++ b/frontend/src/metabase/components/DriverWarning/index.js
@@ -1,0 +1,1 @@
+export * from "./DriverWarning";

--- a/frontend/src/metabase/components/DriverWarning/index.js
+++ b/frontend/src/metabase/components/DriverWarning/index.js
@@ -1,1 +1,1 @@
-export * from "./DriverWarning";
+export { default } from "./DriverWarning";

--- a/frontend/src/metabase/entities/databases/forms.js
+++ b/frontend/src/metabase/entities/databases/forms.js
@@ -278,12 +278,50 @@ function getEngineFormFields(engine, details, id) {
     });
 }
 
-const ENGINE_OPTIONS = Object.entries(MetabaseSettings.get("engines") || {})
+const ENGINES = MetabaseSettings.get("engines");
+const ENGINE_OPTIONS = Object.entries(ENGINES || {})
   .map(([engine, info]) => ({
     name: info["driver-name"],
     value: engine,
   }))
   .sort((a, b) => a.name.localeCompare(b.name));
+
+// use top level constant for engines so we only need to compute these maps once
+const ENGINE_SUPERSEDES_MAPS = Object.keys(ENGINES || {}).reduce(
+  (acc, engine) => {
+    const newEngine = ENGINES[engine]["superseded-by"];
+    if (newEngine) {
+      acc.supersedes[newEngine] = engine;
+      acc.superseded_by[engine] = newEngine;
+    }
+    return acc;
+  },
+  { supersedes: {}, superseded_by: {} },
+);
+
+/**
+ * Returns the options to show in the engines selection widget. An engine is available to be selected if either
+ *  - it is not superseded by any other engine
+ *  - it is the selected engine (i.e. someone is already using it)
+ *  - it is superseded by some engine, which happens to be the currently selected one
+ *
+ * The idea behind this behavior is to only show someone a "legacy" driver if they have at least selected the one that
+ * will replace it first, at which point they can "fall back" on the legacy one if needed.
+ *
+ * @param currentEngine the current (selected engine)
+ * @returns the filtered engine options to be shown in the selection widget
+ */
+function getEngineOptions(currentEngine) {
+  return ENGINE_OPTIONS.filter(engine => {
+    const engineName = engine.value;
+    const newDriver = ENGINE_SUPERSEDES_MAPS["superseded_by"][engineName];
+    return (
+      typeof newDriver === "undefined" ||
+      newDriver === currentEngine ||
+      engineName === currentEngine
+    );
+  });
+}
 
 const forms = {
   details: {
@@ -292,7 +330,7 @@ const forms = {
         name: "engine",
         title: t`Database type`,
         type: "select",
-        options: ENGINE_OPTIONS,
+        options: getEngineOptions(engine),
         placeholder: t`Select a database`,
       },
       {
@@ -382,3 +420,5 @@ const SCHEDULING_FIELDS = new Set([
 ]);
 
 export default forms;
+export const engineSupersedesMap = ENGINE_SUPERSEDES_MAPS;
+export const allEngines = ENGINES;

--- a/frontend/src/metabase/entities/databases/forms.js
+++ b/frontend/src/metabase/entities/databases/forms.js
@@ -278,8 +278,8 @@ function getEngineFormFields(engine, details, id) {
     });
 }
 
-const ENGINES = MetabaseSettings.get("engines");
-const ENGINE_OPTIONS = Object.entries(ENGINES || {})
+const ENGINES = MetabaseSettings.get("engines", {});
+const ENGINE_OPTIONS = Object.entries(ENGINES)
   .map(([engine, info]) => ({
     name: info["driver-name"],
     value: engine,
@@ -287,7 +287,7 @@ const ENGINE_OPTIONS = Object.entries(ENGINES || {})
   .sort((a, b) => a.name.localeCompare(b.name));
 
 // use top level constant for engines so we only need to compute these maps once
-const ENGINE_SUPERSEDES_MAPS = Object.keys(ENGINES || {}).reduce(
+const ENGINE_SUPERSEDES_MAPS = Object.keys(ENGINES).reduce(
   (acc, engine) => {
     const newEngine = ENGINES[engine]["superseded-by"];
     if (newEngine) {

--- a/frontend/src/metabase/setup/components/Setup.jsx
+++ b/frontend/src/metabase/setup/components/Setup.jsx
@@ -203,13 +203,12 @@ export default class Setup extends Component {
             </div>
           </div>
 
-          <DriverWarning
-            engine={selectedDatabaseEngine}
-            ml={26}
-            style={{ marginBottom: "8px" }}
-            data-testid={"database-setup-driver-warning"}
-          />
           <AddDatabaseHelpCardHolder isVisible={isDatabaseHelpCardVisible}>
+            <DriverWarning
+              engine={selectedDatabaseEngine}
+              ml={26}
+              data-testid="database-setup-driver-warning"
+            />
             <AddDatabaseHelpCard
               engine={selectedDatabaseEngine}
               hasCircle={false}

--- a/frontend/src/metabase/setup/components/Setup.jsx
+++ b/frontend/src/metabase/setup/components/Setup.jsx
@@ -8,6 +8,7 @@ import MetabaseAnalytics from "metabase/lib/analytics";
 import MetabaseSettings from "metabase/lib/settings";
 
 import AddDatabaseHelpCard from "metabase/components/AddDatabaseHelpCard";
+import DriverWarning from "metabase/components/DriverWarning/DriverWarning";
 import ExternalLink from "metabase/components/ExternalLink";
 import LogoIcon from "metabase/components/LogoIcon";
 import NewsletterForm from "metabase/components/NewsletterForm";
@@ -202,6 +203,12 @@ export default class Setup extends Component {
             </div>
           </div>
 
+          <DriverWarning
+            engine={selectedDatabaseEngine}
+            ml={26}
+            style={{ marginBottom: "8px" }}
+            data-testid={"database-setup-driver-warning"}
+          />
           <AddDatabaseHelpCardHolder isVisible={isDatabaseHelpCardVisible}>
             <AddDatabaseHelpCard
               engine={selectedDatabaseEngine}

--- a/frontend/src/metabase/setup/components/Setup.jsx
+++ b/frontend/src/metabase/setup/components/Setup.jsx
@@ -8,7 +8,7 @@ import MetabaseAnalytics from "metabase/lib/analytics";
 import MetabaseSettings from "metabase/lib/settings";
 
 import AddDatabaseHelpCard from "metabase/components/AddDatabaseHelpCard";
-import DriverWarning from "metabase/components/DriverWarning/DriverWarning";
+import DriverWarning from "metabase/components/DriverWarning";
 import ExternalLink from "metabase/components/ExternalLink";
 import LogoIcon from "metabase/components/LogoIcon";
 import NewsletterForm from "metabase/components/NewsletterForm";

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -617,3 +617,17 @@
   [_ db-details]
   ;; no normalization by default
   db-details)
+
+(defmulti superseded-by
+  "Returns the driver that supersedes the given `driver`.  A non-nil return value means that the given `driver` is
+  deprecated in Metabase and will eventually be replaced by the returned driver, in some future version (at which point
+  any databases using it will be migrated to the new one).
+
+  This is only used on the frontend for the purpose of showing/hiding deprecated drivers."
+  {:arglists '([driver])}
+  dispatch-on-uninitialized-driver
+  :hierarchy #'hierarchy)
+
+(defmethod superseded-by :default
+  [_]
+  nil)

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -623,8 +623,10 @@
   deprecated in Metabase and will eventually be replaced by the returned driver, in some future version (at which point
   any databases using it will be migrated to the new one).
 
-  This is only used on the frontend for the purpose of showing/hiding deprecated drivers."
-  {:arglists '([driver])}
+  This is currently only used on the frontend for the purpose of showing/hiding deprecated drivers. A driver can make
+  use of this facility by adding a top-level `superseded-by` key to its plugin manifest YAML file, or (less preferred)
+  overriding this multimethod directly."
+  {:added "0.41.0" :arglists '([driver])}
   dispatch-on-uninitialized-driver
   :hierarchy #'hierarchy)
 

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -100,7 +100,8 @@
                  :when  props]
              ;; TODO - maybe we should rename `details-fields` -> `connection-properties` on the FE as well?
              [driver {:details-fields props
-                      :driver-name    (driver/display-name driver)}])))
+                      :driver-name    (driver/display-name driver)
+                      :superseded-by  (driver/superseded-by driver)}])))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                             TLS Helpers                                                        |

--- a/src/metabase/plugins/initialize.clj
+++ b/src/metabase/plugins/initialize.clj
@@ -45,7 +45,7 @@
   (@initialized-plugin-names plugin-name))
 
 (s/defn init-plugin-with-info!
-  "Initiaize plugin using parsed info from a plugin maifest. Returns truthy if plugin was successfully initialized;
+  "Initialize plugin using parsed info from a plugin manifest. Returns truthy if plugin was successfully initialized;
   falsey otherwise."
   [info :- {:info     {:name s/Str, :version s/Str, s/Keyword s/Any}
             s/Keyword s/Any}]

--- a/src/metabase/plugins/lazy_loaded_driver.clj
+++ b/src/metabase/plugins/lazy_loaded_driver.clj
@@ -63,6 +63,7 @@
   "Register a basic shell of a Metabase driver using the information from its Metabase plugin"
   [{:keys                                                                                            [add-to-classpath!]
     init-steps                                                                                       :init
+    superseded-by                                                                                    :superseded-by
     {driver-name :name, :keys [abstract display-name parent], :or {abstract false}, :as driver-info} :driver}]
   {:pre [(map? driver-info)]}
   (let [driver           (keyword driver-name)
@@ -81,7 +82,8 @@
     (doseq [[^MultiFn multifn, f]
             {driver/initialize!           (make-initialize! driver add-to-classpath! init-steps)
              driver/display-name          (when display-name (constantly display-name))
-             driver/connection-properties (constantly connection-props)}]
+             driver/connection-properties (constantly connection-props)
+             driver/superseded-by         (constantly (keyword superseded-by))}]
       (when f
         (.addMethod multifn driver f)))
     ;; finally, register the Metabase driver

--- a/test/metabase/driver/driver_deprecation_test_legacy.clj
+++ b/test/metabase/driver/driver_deprecation_test_legacy.clj
@@ -1,0 +1,5 @@
+(ns metabase.driver.driver-deprecation-test-legacy
+  "Dummy driver for driver deprecation testing (legacy driver)"
+  (:require [metabase.driver :as driver]))
+
+(driver/register! :driver-deprecation-test-legacy, :parent :sql)

--- a/test/metabase/driver/driver_deprecation_test_new.clj
+++ b/test/metabase/driver/driver_deprecation_test_new.clj
@@ -1,0 +1,5 @@
+(ns metabase.driver.driver-deprecation-test-new
+  "Dummy driver for driver deprecation testing (new driver)"
+  (:require [metabase.driver :as driver]))
+
+(driver/register! :driver-deprecation-test-new, :parent :sql)

--- a/test/metabase/plugins/driver_deprecation_test.clj
+++ b/test/metabase/plugins/driver_deprecation_test.clj
@@ -1,0 +1,13 @@
+(ns metabase.plugins.driver-deprecation-test
+  (:require [clojure.test :refer :all]
+            [metabase.models.setting :as setting]
+            [metabase.test :as mt]
+            [metabase.test.fixtures :as fixtures]
+            [metabase.util.i18n :as i18n :refer [tru]]))
+
+(use-fixtures :once (fixtures/initialize :plugins))
+
+(deftest driver-deprecation-test
+  (mt/test-driver :driver-deprecation-test-legacy
+    (is (= :driver-deprecation-test-new
+           (get-in (setting/properties :public) [:engines :driver-deprecation-test-legacy :superseded-by])))))

--- a/test/metabase/test/data/driver_deprecation_test_legacy.clj
+++ b/test/metabase/test/data/driver_deprecation_test_legacy.clj
@@ -1,0 +1,5 @@
+(ns metabase.test.data.driver-deprecation-test-legacy
+  "Dummy namespace for driver deprecation testing \"legacy\" driver, test data."
+  (:require [metabase.test.data.sql :as sql.tx]))
+
+(sql.tx/add-test-extensions! :driver-deprecation-test-legacy)

--- a/test/metabase/test/data/driver_deprecation_test_new.clj
+++ b/test/metabase/test/data/driver_deprecation_test_new.clj
@@ -1,0 +1,5 @@
+(ns metabase.test.data.driver-deprecation-test-new
+  "Dummy namespace for driver deprecation testing \"new\" driver, test data."
+  (:require [metabase.test.data.sql :as sql.tx]))
+
+(sql.tx/add-test-extensions! :driver-deprecation-test-new)

--- a/test_modules/drivers/driver-deprecation-test-legacy/resources/metabase-plugin.yaml
+++ b/test_modules/drivers/driver-deprecation-test-legacy/resources/metabase-plugin.yaml
@@ -1,0 +1,16 @@
+info:
+  name: Legacy Driver
+  version: 0.0.0-SNAPSHOT
+  description: Test plugin for driver deprecation (legacy)
+driver:
+  name: driver-deprecation-test-legacy
+  display-name: Driver Deprecation Test Plugin (Legacy)
+  lazy-load: true
+  parent: sql
+  connection-properties:
+    - host
+    - port
+superseded-by: driver-deprecation-test-new
+init:
+  - step: load-namespace
+    namespace: metabase.driver.driver-deprecation-test-legacy

--- a/test_modules/drivers/driver-deprecation-test-new/resources/metabase-plugin.yaml
+++ b/test_modules/drivers/driver-deprecation-test-new/resources/metabase-plugin.yaml
@@ -1,0 +1,15 @@
+info:
+  name: New Driver
+  version: 0.0.0-SNAPSHOT
+  description: Test plugin for driver deprecation (new)
+driver:
+  name: driver-deprecation-test-new
+  display-name: Driver Deprecation Test Plugin (New)
+  lazy-load: true
+  parent: sql
+  connection-properties:
+    - host
+    - port
+init:
+  - step: load-namespace
+    namespace: metabase.driver.driver-deprecation-test-new


### PR DESCRIPTION
Introducing new superseded-by property to plugin manifest YAML, which will indicate the driver that is to eventually replace this one (and will drive UI/UX behavior)

Adding top level test_modules directory (with the same structure as modules) for the sole purpose of module/plugin testing

Updating driver-plugin-manifest to look for the new test_modules directory in addition to modules, when loading the driver manifest

