### PR TITLE
[P0] Fix filters don't work for public and embedded questions

### DIFF
--- a/frontend/src/metabase/parameters/components/Parameters/syncQueryParamsWithURL.js
+++ b/frontend/src/metabase/parameters/components/Parameters/syncQueryParamsWithURL.js
@@ -25,9 +25,9 @@ const syncForInternalQuestion = props => {
 };
 
 const syncForPublicQuestion = props => {
-  const { parameters, setParameterValue, query, metadata } = props;
+  const { parameters, setMultipleParameterValues, query, metadata } = props;
 
-  if (!setParameterValue) {
+  if (!setMultipleParameterValues) {
     return;
   }
 
@@ -41,7 +41,7 @@ const syncForPublicQuestion = props => {
     return acc;
   }, {});
 
-  setParameterValue(parameterValues);
+  setMultipleParameterValues(parameterValues);
 };
 
 const parseQueryParams = (queryParam, parameter, metadata) => {

--- a/frontend/src/metabase/public/components/EmbedFrame.jsx
+++ b/frontend/src/metabase/public/components/EmbedFrame.jsx
@@ -33,6 +33,9 @@ type Props = {
   parameters?: Parameter[],
   parameterValues?: { [key: string]: string },
   setParameterValue: (id: string, value: string) => void,
+  setMultipleParameterValues: (parameterValues: {
+    [key: string]: string,
+  }) => void,
 };
 
 type State = {
@@ -60,6 +63,7 @@ export default class EmbedFrame extends Component {
       parameters,
       parameterValues,
       setParameterValue,
+      setMultipleParameterValues,
     } = this.props;
     const { innerScroll } = this.state;
 
@@ -100,6 +104,7 @@ export default class EmbedFrame extends Component {
                     }))}
                     query={location.query}
                     setParameterValue={setParameterValue}
+                    setMultipleParameterValues={setMultipleParameterValues}
                     syncQueryString
                     hideParameters={hide_parameters}
                     isQB

--- a/frontend/src/metabase/public/containers/PublicQuestion.jsx
+++ b/frontend/src/metabase/public/containers/PublicQuestion.jsx
@@ -123,7 +123,19 @@ export default class PublicQuestion extends Component {
     }
   }
 
-  setParameterValue = parameterValues => {
+  setParameterValue = (parameterId, value) => {
+    this.setState(
+      {
+        parameterValues: {
+          ...this.state.parameterValues,
+          [parameterId]: value,
+        },
+      },
+      this.run,
+    );
+  };
+
+  setMultipleParameterValues = parameterValues => {
     this.setState(
       {
         parameterValues: {
@@ -201,6 +213,7 @@ export default class PublicQuestion extends Component {
         actionButtons={actionButtons}
         parameterValues={parameterValues}
         setParameterValue={this.setParameterValue}
+        setMultipleParameterValues={this.setMultipleParameterValues}
       >
         <LoadingAndErrorWrapper
           className="flex-full"

--- a/frontend/test/metabase/parameters/components/Parameters/syncQueryParamsWithURL.unit.spec.js
+++ b/frontend/test/metabase/parameters/components/Parameters/syncQueryParamsWithURL.unit.spec.js
@@ -20,6 +20,7 @@ const buildPropsForInternalQuestion = props =>
 
 const buildPropsForPublicQuestion = props =>
   buildProps({
+    setMultipleParameterValues: jest.fn(),
     ...props,
   });
 
@@ -130,8 +131,8 @@ describe("Parameters", () => {
 
         it("uses empty object as argument when syncing params", () => {
           syncQueryParamsWithURL(props);
-          expect(props.setParameterValue).toHaveBeenCalledTimes(1);
-          expect(props.setParameterValue).toHaveBeenCalledWith({});
+          expect(props.setMultipleParameterValues).toHaveBeenCalledTimes(1);
+          expect(props.setMultipleParameterValues).toHaveBeenCalledWith({});
         });
       });
 
@@ -150,7 +151,7 @@ describe("Parameters", () => {
 
         it("uses empty object as argument when syncing params", () => {
           syncQueryParamsWithURL(props);
-          expect(props.setParameterValue).toHaveBeenCalledWith({});
+          expect(props.setMultipleParameterValues).toHaveBeenCalledWith({});
         });
       });
 
@@ -169,8 +170,8 @@ describe("Parameters", () => {
 
         it("syncs parameter with query params by slugs, by passing one object with as many key/value pairs as there are matching parameters, all in a single function call", () => {
           syncQueryParamsWithURL(props);
-          expect(props.setParameterValue).toHaveBeenCalledTimes(1);
-          expect(props.setParameterValue).toHaveBeenCalledWith({
+          expect(props.setMultipleParameterValues).toHaveBeenCalledTimes(1);
+          expect(props.setMultipleParameterValues).toHaveBeenCalledWith({
             idForCreatedAt: "2021",
           });
         });
@@ -196,8 +197,8 @@ describe("Parameters", () => {
 
         it("syncs parameter with query params by slugs, by passing one object with as many key/value pairs as there are matching parameters, all in a single function call", () => {
           syncQueryParamsWithURL(props);
-          expect(props.setParameterValue).toHaveBeenCalledTimes(1);
-          expect(props.setParameterValue).toHaveBeenCalledWith({
+          expect(props.setMultipleParameterValues).toHaveBeenCalledTimes(1);
+          expect(props.setMultipleParameterValues).toHaveBeenCalledWith({
             idForCreatedAt: "2021",
             idForState: "CA",
           });

--- a/frontend/test/metabase/scenarios/filters/reproductions/17019.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/reproductions/17019.cy.spec.js
@@ -16,7 +16,7 @@ const question = {
   display: "scalar",
 };
 
-describe.skip("issue 17019", () => {
+describe("issue 17019", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();


### PR DESCRIPTION
Fixes #17019, a regression caused by #16765 and #16795 (fixed missing default parameters for public questions)

**Explanation**
When a public / embedded question page opens, it retrieves info about parameters and their default values. Once this info is fetched, we apply default parameter values and rerun the query.

Earlier, `PublicQuestion` had a [`setParameterValue` method](https://github.com/metabase/metabase/blob/f538050317f999c5d7be4413985ffd389a83fd76/frontend/src/metabase/public/containers/PublicQuestion.jsx#L126) accepting `parameterId` and `parameterValue`. It was updating a dictionary with an updated parameter and instantly triggered a new query run, so we display relevant data.

Looks like it didn't work quite well with many parameters. My guess is that there was a race condition. Let's say we have two parameters: "Country" and "Source". They would call `setParameterValue` twice and there is no guarantee, the second call will use a parameter from the first one. Example:

1. `setParameterValue` is called with "Country" filter arguments
2. React`setState` is called with "Country" filter arguments
2. `setParameterValue` is called with "Source" at the same time
3. React`setState` is called with "Source" filter arguments
4. One of the `setState` calls probably overwrites another one (see screenshots from #7120)

So `setParameterValue` method [was refactored](https://github.com/metabase/metabase/blob/961caedc9983dfef7e25dfdfb0e18c9bde02dca4/frontend/src/metabase/public/containers/PublicQuestion.jsx#L126) to update all the filters in a single batch.

The problem is that when parameters are updated individually, i.e. when you click them, it still uses the `setParameterValue(id, value)` notation, so we can't set filter value appropriately.

This PR fixes the issue in the most straightforward way I found: by adding an extra `setMultipleParameterValues` method and reverting `setParameterValue` to its previous state (I guess you wouldn't expect `setParameterValue` to handle > 1 parameter anyway, as the name is in the singular form). Also, `setParameterValue` accepts `parameterId` and `parameterValue` for internal questions, so I think it's better to keep things more consistent.

### To Verify

1. Ask a question > Native Question > Sample Dataset
2. Enter `select * from PRODUCTS where {{filter}}`
3. In the right sidebar, set `{{ filter }}` to be "Field Filter" and map it to Products > Category
4. Save question
5. In the bottom right corner, click the "Sharing" icon (an arrow)
6. Open the share URL
7. Try to change the filters. Each time you change a filter, it should be properly represented on the UI and the query has to rerun with the new filters applied

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/125565666-6c57584a-7635-44ef-9ae9-07be88f41a0f.mov

**After**

https://user-images.githubusercontent.com/17258145/125565709-5b4ff582-61bf-43c6-bb51-d856517e3a76.mov
