### PR TITLE
Fix error when opening a public question with filters having default parameters

### DIFF
--- a/frontend/src/metabase/public/containers/PublicQuestion.jsx
+++ b/frontend/src/metabase/public/containers/PublicQuestion.jsx
@@ -77,6 +77,7 @@ export default class PublicQuestion extends Component {
     this.state = {
       card: null,
       result: null,
+      initialized: false,
       parameterValues: {},
     };
   }
@@ -116,7 +117,10 @@ export default class PublicQuestion extends Component {
         parameterValues[String(parameter.id)] = query[parameter.slug];
       }
 
-      this.setState({ card, parameterValues }, this.run);
+      this.setState({ card, parameterValues }, async () => {
+        await this.run();
+        this.setState({ initialized: true });
+      });
     } catch (error) {
       console.error("error", error);
       setErrorPage(error);
@@ -180,7 +184,7 @@ export default class PublicQuestion extends Component {
     const {
       params: { uuid, token },
     } = this.props;
-    const { card, result, parameterValues } = this.state;
+    const { card, result, initialized, parameterValues } = this.state;
 
     const actionButtons = result && (
       <QueryDownloadWidget
@@ -197,14 +201,14 @@ export default class PublicQuestion extends Component {
       <EmbedFrame
         name={card && card.name}
         description={card && card.description}
-        parameters={parameters}
+        parameters={initialized ? parameters : []}
         actionButtons={actionButtons}
         parameterValues={parameterValues}
         setParameterValue={this.setParameterValue}
       >
         <LoadingAndErrorWrapper
           className="flex-full"
-          loading={!result}
+          loading={!result || !initialized}
           error={typeof result === "string" ? result : null}
           noWrapper
         >


### PR DESCRIPTION
When opening a public question that has filters with default values, you see the results, but in a couple of seconds they're replaced with the "An error occurred while running the query" message. Fixes #17033

There is a race condition. Because of it, the results can be overwritten by a query without default parameters applied. Steps:

1. You open a URL like `/public/question/:guid`. There are no query parameters that are usually in sync with filters. So when the page mounts
2. [`PublicQuestion`](https://github.com/metabase/metabase/blob/v0.40.0/frontend/src/metabase/public/containers/PublicQuestion.jsx) mounts
3. The query run is triggered inside [`UNSAFE_componentWillMount`](https://github.com/metabase/metabase/blob/961caedc9983dfef7e25dfdfb0e18c9bde02dca4/frontend/src/metabase/public/containers/PublicQuestion.jsx#L119) _without_ parameters
4. `PublicQuestion` [renders `EmbedFrame`](https://github.com/metabase/metabase/blob/961caedc9983dfef7e25dfdfb0e18c9bde02dca4/frontend/src/metabase/public/containers/PublicQuestion.jsx#L197), `EmbedFrame` [renders `Parameters`](https://github.com/metabase/metabase/blob/v0.40.0/frontend/src/metabase/public/components/EmbedFrame.jsx)
5. `Parameters` [start syncing parameters with query parameters](https://github.com/metabase/metabase/blob/980518f2f488a7bf5d5c8637f57038708145d97c/frontend/src/metabase/parameters/components/Parameters/Parameters.jsx#L20). At the end, it should take parameters' default values and append them to the URL as query parameters
6. `Parameters` trigger the `setParameterValue` call, so the URL can be updated and we can run the query. `setParameterQuery` [triggers a new query run](https://github.com/metabase/metabase/blob/980518f2f488a7bf5d5c8637f57038708145d97c/frontend/src/metabase/public/containers/PublicQuestion.jsx#L134), now with default parameters applied
7. The trick is steps 3-6 happen simultaneously, and sometimes (however I can reproduce that every time), the result without filters is applied _later_, and you can see an error

Fixed by ensuring that the query with parameters is triggered only after the initial one from `componentWillMount`. Not the best solution out there, but it's the safest I guess. A better solution would be to move [`syncQueryParamsWithURL`](https://github.com/metabase/metabase/blob/980518f2f488a7bf5d5c8637f57038708145d97c/frontend/src/metabase/parameters/components/Parameters/Parameters.jsx#L20) from `Parameters` to the `PublicQuestion`, so the initial query would also contain default filter parameters.

Tried to add some e2e coverage here, but wasn't very successful. Tried intercepting and waiting for `GET /api/public/card/*/query`, but it catches only one request and I couldn't assert there is no error. Opened to ideas here 

### To Verify

1. Enable public sharing in admin
2. Ask a question > Native question > Sample Dataset
3. Enter `SELECT * FROM PEOPLE WHERE {{birthdate}} AND {{source}}`
4. Configure filters via the right sidebar:
    * `{{ birthdate }}` as a Field Filter mapped to People > BirthDate with a default of "Past 30 Years"
    * `{{ source }}` as a Field Filter mapped to  People > Source with default a of "Affiliate"
5. Save question
6. In the bottom right corner, click the "Sharing" icon (an arrow)
7. Open the share URL
8. You should see the results, without any error messages

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/125566975-27bae888-a512-43e4-880a-dcba8d9d1f2b.mov

**After**

https://user-images.githubusercontent.com/17258145/125567015-7d9eea71-b3df-43a2-81ba-eb6df34f43ff.mov
