### PR TITLE
Don't use extend with styled-components anymore

### DIFF
--- a/frontend/src/metabase/components/BulkActionBar.jsx
+++ b/frontend/src/metabase/components/BulkActionBar.jsx
@@ -1,10 +1,11 @@
 /* eslint-disable react/prop-types */
 import React from "react";
+import styled from "styled-components";
 import { Box } from "grid-styled";
 import Card from "metabase/components/Card";
 import { Motion, spring } from "react-motion";
 
-const FixedBottomBar = Box.extend`
+const FixedBottomBar = styled(Box)`
   position: fixed;
   bottom: 0;
   left: 0;

--- a/frontend/src/metabase/components/EntityItem.styled.js
+++ b/frontend/src/metabase/components/EntityItem.styled.js
@@ -37,7 +37,7 @@ export const EntityIconWrapper = styled(IconButtonWrapper)`
       : getBackground(props.model)};
 `;
 
-export const EntityItemWrapper = Flex.extend`
+export const EntityItemWrapper = styled(Flex)`
   border-bottom: 1px solid ${color("bg-medium")};
   align-items: center;
   &:hover {

--- a/frontend/src/metabase/components/IconWrapper.jsx
+++ b/frontend/src/metabase/components/IconWrapper.jsx
@@ -1,8 +1,9 @@
+import styled from "styled-components";
 import { Flex } from "grid-styled";
 import { color } from "styled-system";
 import { color as metabaseColors } from "metabase/lib/colors";
 
-const IconWrapper = Flex.extend`
+const IconWrapper = styled(Flex)`
   ${color};
   border-radius: ${props => props.borderRadius};
 `;

--- a/frontend/src/metabase/components/PaginationControls.jsx
+++ b/frontend/src/metabase/components/PaginationControls.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { t } from "ttag";
+import styled from "styled-components";
 
 import colors from "metabase/lib/colors";
 import Icon, { IconWrapper } from "metabase/components/Icon";
@@ -54,7 +55,7 @@ export default function PaginationControls({
   );
 }
 
-const PaginationButton = IconWrapper.withComponent("button").extend`
+const PaginationButton = styled(IconWrapper.withComponent("button"))`
   &:disabled {
     background-color: transparent;
     color: ${colors["text-light"]};

--- a/frontend/src/metabase/components/Position.js
+++ b/frontend/src/metabase/components/Position.js
@@ -15,24 +15,24 @@ export const Position = styled(Box)`
 
 Position.displayName = "Position";
 
-export const Relative = Position.extend`
+export const Relative = styled(Position)`
   position: relative;
 `;
 
 Relative.displayName = "Relative";
 
-export const Absolute = Position.extend`
+export const Absolute = styled(Position)`
   position: absolute;
 `;
 
 Absolute.displayName = "Absolute";
 
-export const Fixed = Position.extend`
+export const Fixed = styled(Position)`
   position: fixed;
 `;
 
 Fixed.displayName = "Fixed";
 
-export const Sticky = Position.extend`
+export const Sticky = styled(Position)`
   position: sticky;
 `;

--- a/frontend/src/metabase/nav/components/SearchBar.jsx
+++ b/frontend/src/metabase/nav/components/SearchBar.jsx
@@ -20,7 +20,7 @@ const ActiveSearchColor = lighten(color("nav"), 0.1);
 
 import Search from "metabase/entities/search";
 
-const SearchWrapper = Flex.extend`
+const SearchWrapper = styled(Flex)`
   position: relative;
   background-color: ${props =>
     props.active ? ActiveSearchColor : DefaultSearchColor};

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx
@@ -4,6 +4,8 @@ import React from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
+import styled from "styled-components";
+
 import { color as c, lighten, darken } from "metabase/lib/colors";
 
 import Tooltip from "metabase/components/Tooltip";
@@ -205,7 +207,7 @@ export default class NotebookStep extends React.Component {
   }
 }
 
-const ColorButton = Button.extend`
+const ColorButton = styled(Button)`
   border: none;
   color: ${({ color }) => (color ? color : c("text-medium"))}
   background-color: ${({ color }) => (color ? lighten(color, 0.61) : null)};


### PR DESCRIPTION
It's deprecated and thus removed in v4: https://styled-components.com/docs/api#deprecated-extend.

For some context, this is to prepare to the upgrade of `styled-components` dependency.

To try it, run all the unit tests and they all must continue to pass. If you want to run a specific one:
```
yarn test-unit frontend/test/metabase/components/PaginationControls.unit.spec.js
```