### PR TITLE
Fix Card async-metadata running query even when metadata can be deter…

### DIFF
--- a/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
@@ -148,6 +148,12 @@ describe("binning related reproductions", () => {
           aggregation: [["avg", ["field", ORDERS.SUBTOTAL, null]]],
           breakout: [["field", ORDERS.USER_ID, null]],
         },
+      }).then(({ body }) => {
+        cy.intercept("POST", `/api/card/${body.id}/query`).as("cardQuery");
+        cy.visit(`/question/${body.id}`);
+
+        // Wait for `result_metadata` to load
+        cy.wait("@cardQuery");
       });
     });
 
@@ -161,7 +167,7 @@ describe("binning related reproductions", () => {
       });
 
       popover().within(() => {
-        cy.findByText("50 bins").click();
+        cy.findByText("10 bins").click();
       });
 
       cy.get(".bar");
@@ -184,7 +190,7 @@ describe("binning related reproductions", () => {
       popover()
         .last()
         .within(() => {
-          cy.findByText("50 bins").click();
+          cy.findByText("10 bins").click();
         });
 
       cy.button("Visualize").click();

--- a/frontend/test/metabase/scenarios/question/nested.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nested.cy.spec.js
@@ -25,6 +25,12 @@ describe("scenarios > question > nested (metabase#12568)", () => {
         breakout: [["field", ORDERS.CREATED_AT, { "temporal-unit": "week" }]],
       },
       display: "line",
+    }).then(({ body }) => {
+      cy.intercept("POST", `/api/card/${body.id}/query`).as("cardMetadata");
+
+      cy.visit(`/question/${body.id}`);
+      // We have to wait for the metadata to load
+      cy.wait("@cardMetadata");
     });
 
     // Create a native question of orders by day
@@ -35,6 +41,12 @@ describe("scenarios > question > nested (metabase#12568)", () => {
           "SELECT date_trunc('day', CREATED_AT) as date, COUNT(*) as count FROM ORDERS GROUP BY date_trunc('day', CREATED_AT)",
       },
       display: "scalar",
+    }).then(({ body }) => {
+      cy.intercept("POST", `/api/card/${body.id}/query`).as("nativeMetadata");
+
+      cy.visit(`/question/${body.id}`);
+      // We have to wait for the metadata to load
+      cy.wait("@nativeMetadata");
     });
 
     // [quarantine] The whole CI was timing out
@@ -80,7 +92,7 @@ describe("scenarios > question > nested (metabase#12568)", () => {
     cy.contains("Count").click();
     cy.contains("Distribution").click();
     cy.contains("Count by Count: Auto binned");
-    cy.get(".bar").should("have.length.of.at.least", 10);
+    cy.get(".bar").should("have.length.of.at.least", 8);
   });
 
   it("should allow Sum over time on a Saved Simple Question", () => {
@@ -102,7 +114,7 @@ describe("scenarios > question > nested (metabase#12568)", () => {
     cy.contains("COUNT").click();
     cy.contains("Distribution").click();
     cy.contains("Count by COUNT: Auto binned");
-    cy.get(".bar").should("have.length.of.at.least", 10);
+    cy.get(".bar").should("have.length.of.at.least", 8);
   });
 
   // [quarantine] The whole CI was timing out

--- a/src/metabase/query_processor/async.clj
+++ b/src/metabase/query_processor/async.clj
@@ -46,8 +46,9 @@
     (if-let [inferred-columns (not-empty (u/ignore-exceptions (qp/query->expected-cols query)))]
       (let [chan (a/promise-chan)]
         (a/>!! chan inferred-columns)
-        (a/close! chan)))
-    ;; for *native* queries we actually have to run it.
-    (let [query (query-for-result-metadata query)]
-      (qp/process-query-async query {:reducedf async-result-metadata-reducedf
-                                     :raisef   async-result-metdata-raisef}))))
+        (a/close! chan)
+        chan)
+      ;; for *native* queries we actually have to run it.
+      (let [query (query-for-result-metadata query)]
+        (qp/process-query-async query {:reducedf async-result-metadata-reducedf
+                                       :raisef   async-result-metdata-raisef})))))

--- a/test/metabase/query_processor/async_test.clj
+++ b/test/metabase/query_processor/async_test.clj
@@ -11,19 +11,25 @@
                                                 :type     :query
                                                 :query    {:source-table (mt/id :venues)
                                                            :fields       [[:field (mt/id :venues :name) nil]]}})]
-      (is (= [{:name         "NAME"
-               :display_name "Name"
-               :base_type    :type/Text
+      (is (= [{:name              "NAME"
+               :display_name      "Name"
+               :base_type         :type/Text
                :coercion_strategy nil
                :effective_type    :type/Text
-               :semantic_type :type/Name
-               :fingerprint  {:global {:distinct-count 100, :nil% 0.0},
-                              :type   #:type {:Text
-                                              {:percent-json   0.0,
-                                               :percent-url    0.0,
-                                               :percent-email  0.0,
-                                               :percent-state  0.0,
-                                               :average-length 15.63}}}
-               :id           (mt/id :venues :name)
-               :field_ref    [:field (mt/id :venues :name) nil]}]
+               :semantic_type     :type/Name
+               :fingerprint       {:global {:distinct-count 100, :nil% 0.0},
+                                   :type   #:type {:Text
+                                                   {:percent-json   0.0,
+                                                    :percent-url    0.0,
+                                                    :percent-email  0.0,
+                                                    :percent-state  0.0,
+                                                    :average-length 15.63}}}
+               :description       nil
+               :table_id          (mt/id :venues)
+               :settings          nil
+               :source            :fields
+               :parent_id         nil
+               :visibility_type   :normal
+               :id                (mt/id :venues :name)
+               :field_ref         [:field (mt/id :venues :name) nil]}]
              (mt/wait-for-result result-chan 1000))))))


### PR DESCRIPTION
`result-metadata-for-card-async` is only supposed to run a query to determine results metadata for a Card if a) we don't already results metadata (normally we should) and b) the Card's query is a native query. For MBQL, we can determine the results metadata (e.g. column types) programmatically based on the MBQL.

There was a bug in the code where what was supposed to be the else-clause of an `if-let` was actually at the same level which meant we always ran the query to get metadata whether it was native or MBQL. This PR fixes that and adjusts a few tests since the programmatic metadata doesn't include fingerprint info.

Caught this while working on #16726

