### PR TITLE
Adjust affected repros by waiting for the metadata to load

### DIFF
--- a/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
@@ -167,7 +167,7 @@ describe("binning related reproductions", () => {
       });
 
       popover().within(() => {
-        cy.findByText("50 bins").click();
+        cy.findByText("10 bins").click();
       });
 
       cy.get(".bar");
@@ -190,7 +190,7 @@ describe("binning related reproductions", () => {
       popover()
         .last()
         .within(() => {
-          cy.findByText("50 bins").click();
+          cy.findByText("10 bins").click();
         });
 
       cy.button("Visualize").click();

--- a/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
@@ -148,6 +148,12 @@ describe("binning related reproductions", () => {
           aggregation: [["avg", ["field", ORDERS.SUBTOTAL, null]]],
           breakout: [["field", ORDERS.USER_ID, null]],
         },
+      }).then(({ body }) => {
+        cy.intercept("POST", `/api/card/${body.id}/query`).as("cardQuery");
+        cy.visit(`/question/${body.id}`);
+
+        // Wait for `result_metadata` to load
+        cy.wait("@cardQuery");
       });
     });
 

--- a/frontend/test/metabase/scenarios/question/nested.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nested.cy.spec.js
@@ -25,6 +25,12 @@ describe("scenarios > question > nested (metabase#12568)", () => {
         breakout: [["field", ORDERS.CREATED_AT, { "temporal-unit": "week" }]],
       },
       display: "line",
+    }).then(({ body }) => {
+      cy.intercept("POST", `/api/card/${body.id}/query`).as("cardMetadata");
+
+      cy.visit(`/question/${body.id}`);
+      // We have to wait for the metadata to load
+      cy.wait("@cardMetadata");
     });
 
     // Create a native question of orders by day
@@ -35,6 +41,12 @@ describe("scenarios > question > nested (metabase#12568)", () => {
           "SELECT date_trunc('day', CREATED_AT) as date, COUNT(*) as count FROM ORDERS GROUP BY date_trunc('day', CREATED_AT)",
       },
       display: "scalar",
+    }).then(({ body }) => {
+      cy.intercept("POST", `/api/card/${body.id}/query`).as("nativeMetadata");
+
+      cy.visit(`/question/${body.id}`);
+      // We have to wait for the metadata to load
+      cy.wait("@nativeMetadata");
     });
 
     // [quarantine] The whole CI was timing out
@@ -80,7 +92,7 @@ describe("scenarios > question > nested (metabase#12568)", () => {
     cy.contains("Count").click();
     cy.contains("Distribution").click();
     cy.contains("Count by Count: Auto binned");
-    cy.get(".bar").should("have.length.of.at.least", 10);
+    cy.get(".bar").should("have.length.of.at.least", 8);
   });
 
   it("should allow Sum over time on a Saved Simple Question", () => {
@@ -102,7 +114,7 @@ describe("scenarios > question > nested (metabase#12568)", () => {
     cy.contains("COUNT").click();
     cy.contains("Distribution").click();
     cy.contains("Count by COUNT: Auto binned");
-    cy.get(".bar").should("have.length.of.at.least", 10);
+    cy.get(".bar").should("have.length.of.at.least", 8);
   });
 
   // [quarantine] The whole CI was timing out


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
Adjusts / fixes a repro for #16379, so that it waits for the `results_metadata` to load before the test can continue. This flow is closer to the real life scenario and removes an issue @camsaul ran into while working on a fix for an unrelated issue.

### Screenshots
![image](https://user-images.githubusercontent.com/31325167/125794490-12513287-af7d-49a7-bf61-de998541c28e.png)
