### PR TITLE
Fix `POST /api/collection` ignores authority_level

### DIFF
--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -566,6 +566,7 @@
      {:name        name
       :color       color
       :description description
+      :authority_level authority_level
       :namespace   namespace}
      (when parent_id
        {:location (collection/children-location (db/select-one [Collection :location :id] :id parent_id))}))))

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -1046,7 +1046,7 @@
                         :color (s/eq "#f38630")
                         :name (s/eq "foo")
                         :personal_owner_id (s/eq nil)
-                        :authority_level (s/eq nil)
+                        :authority_level (s/eq "official")
                         :id s/Int
                         :location (s/eq "/")
                         :namespace (s/eq nil)}


### PR DESCRIPTION
Currently, when the backend receives a `POST /api/collection` request with `:authority_level "official"`, the property gets ignored and a regular collection is created (`:authority_level nil`)