### PR TITLE
Allow displaying info tooltips on FormFields

### DIFF
--- a/frontend/src/metabase/components/form/FormField.jsx
+++ b/frontend/src/metabase/components/form/FormField.jsx
@@ -1,8 +1,11 @@
 /* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-
 import cx from "classnames";
+
+import Tooltip from "metabase/components/Tooltip";
+
+import { FieldRow, Label, InfoIcon } from "./FormField.styled";
 
 export default class FormField extends Component {
   static propTypes = {
@@ -18,6 +21,7 @@ export default class FormField extends Component {
     hidden: PropTypes.bool,
     title: PropTypes.string,
     description: PropTypes.string,
+    info: PropTypes.string,
 
     children: PropTypes.oneOfType([
       PropTypes.arrayOf(PropTypes.node),
@@ -31,6 +35,7 @@ export default class FormField extends Component {
       formField,
       title = formField && formField.title,
       description = formField && formField.description,
+      info = formField && formField.info,
       hidden = formField &&
         (formField.hidden != null
           ? formField.hidden
@@ -66,16 +71,23 @@ export default class FormField extends Component {
       >
         {(title || description) && (
           <div>
-            {title && (
-              <label
-                className={cx("Form-label", { "mr-auto": horizontal })}
-                htmlFor={name}
-                id={`${name}-label`}
-              >
-                {title}
-                {error && <span className="text-error">: {error}</span>}
-              </label>
-            )}
+            <FieldRow>
+              {title && (
+                <Label
+                  className={cx("Form-label", { "mr-auto": horizontal })}
+                  htmlFor={name}
+                  id={`${name}-label`}
+                >
+                  {title}
+                  {error && <span className="text-error">: {error}</span>}
+                </Label>
+              )}
+              {info && (
+                <Tooltip tooltip={info}>
+                  <InfoIcon />
+                </Tooltip>
+              )}
+            </FieldRow>
             {description && <div className="mb1">{description}</div>}
           </div>
         )}

--- a/frontend/src/metabase/components/form/FormField.styled.js
+++ b/frontend/src/metabase/components/form/FormField.styled.js
@@ -1,0 +1,23 @@
+import styled from "styled-components";
+import Icon from "metabase/components/Icon";
+
+import { color } from "metabase/lib/colors";
+
+export const FieldRow = styled.div`
+  display: flex;
+  align-items: center;
+  margin-bottom: 0.5em;
+`;
+
+export const Label = styled.label`
+  margin-bottom: 0;
+`;
+
+export const InfoIcon = styled(Icon).attrs({ name: "info", size: 12 })`
+  margin-left: 8px;
+  color: ${color("bg-dark")};
+
+  &:hover {
+    color: ${color("brand")};
+  }
+`;


### PR DESCRIPTION
Adds a string `info` prop to the `FormField` component. If `info` is present, `FormField` will display an info icon to the right from the label. Hovering the info icon will show a tooltip displaying some helpful text.

Would be happy to follow up with a refactoring PR

### Demo

<img width="666" alt="CleanShot 2021-07-15 at 19 46 58@2x" src="https://user-images.githubusercontent.com/17258145/125826514-c9744de6-dea1-49ff-ad9b-de0671172280.png">
