### PR TITLE
Refactor entity `getIcon` to return icon props

### DIFF
--- a/frontend/src/metabase/admin/datamodel/components/MetricItem.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/MetricItem.jsx
@@ -24,11 +24,7 @@ export default class MetricItem extends Component {
       <tr>
         <td className="px1 py1 text-wrap">
           <span className="flex align-center">
-            <Icon
-              size={12}
-              name={metric.getIcon()}
-              className="mr1 text-medium"
-            />
+            <Icon {...metric.getIcon()} size={12} className="mr1 text-medium" />
             <span className="text-dark text-bold">{metric.name}</span>
           </span>
         </td>

--- a/frontend/src/metabase/admin/datamodel/components/SegmentItem.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/SegmentItem.jsx
@@ -25,8 +25,8 @@ export default class SegmentItem extends Component {
         <td className="px1 py1 text-wrap">
           <span className="flex align-center">
             <Icon
+              {...segment.getIcon()}
               size={12}
-              name={segment.getIcon()}
               className="mr1 text-medium"
             />
             <span className="text-dark text-bold">{segment.name}</span>

--- a/frontend/src/metabase/collections/components/BaseTableItem.jsx
+++ b/frontend/src/metabase/collections/components/BaseTableItem.jsx
@@ -89,7 +89,7 @@ export function BaseTableItem({
           <EntityIconCheckBox
             item={item}
             variant="list"
-            iconName={item.getIcon()}
+            iconName={item.getIcon().name}
             pinned={isPinned}
             selectable={canSelect}
             selected={isSelected}

--- a/frontend/src/metabase/containers/ItemPicker.jsx
+++ b/frontend/src/metabase/containers/ItemPicker.jsx
@@ -253,7 +253,7 @@ export default class ItemPicker extends React.Component {
                             item={item}
                             name={item.getName()}
                             color={item.getColor()}
-                            icon={item.getIcon()}
+                            icon={item.getIcon().name}
                             selected={isSelected(item)}
                             canSelect={hasPermission}
                             onChange={onChange}

--- a/frontend/src/metabase/dashboard/components/add-card-sidebar/QuestionList.jsx
+++ b/frontend/src/metabase/dashboard/components/add-card-sidebar/QuestionList.jsx
@@ -58,7 +58,7 @@ export function QuestionList({
                 key={item.id}
                 id={item.id}
                 name={item.getName()}
-                icon={item.getIcon()}
+                icon={item.getIcon().name}
                 onSelect={onSelect}
               />
             ))}

--- a/frontend/src/metabase/entities/collections.js
+++ b/frontend/src/metabase/entities/collections.js
@@ -79,7 +79,7 @@ const Collections = createEntity({
   objectSelectors: {
     getName: collection => collection && collection.name,
     getUrl: collection => Urls.collection(collection),
-    getIcon: collection => "folder",
+    getIcon: collection => ({ name: "folder" }),
   },
 
   selectors: {

--- a/frontend/src/metabase/entities/dashboards.js
+++ b/frontend/src/metabase/entities/dashboards.js
@@ -133,7 +133,7 @@ const Dashboards = createEntity({
     getUrl: dashboard => dashboard && Urls.dashboard(dashboard),
     getCollection: dashboard =>
       dashboard && normalizedCollection(dashboard.collection),
-    getIcon: dashboard => "dashboard",
+    getIcon: dashboard => ({ name: "dashboard" }),
     getColor: () => color("dashboard"),
   },
 

--- a/frontend/src/metabase/entities/databases.js
+++ b/frontend/src/metabase/entities/databases.js
@@ -66,7 +66,7 @@ const Databases = createEntity({
   objectSelectors: {
     getName: db => db && db.name,
     getUrl: db => db && Urls.browseDatabase(db),
-    getIcon: db => "database",
+    getIcon: db => ({ name: "database" }),
     getColor: db => color("database"),
   },
 

--- a/frontend/src/metabase/entities/metrics.js
+++ b/frontend/src/metabase/entities/metrics.js
@@ -28,7 +28,7 @@ const Metrics = createEntity({
     getUrl: metric =>
       Urls.tableRowsQuery(metric.database_id, metric.table_id, metric.id),
     getColor: metric => color("accent1"),
-    getIcon: metric => "sum",
+    getIcon: metric => ({ name: "sum" }),
   },
 
   selectors: {

--- a/frontend/src/metabase/entities/pulses.js
+++ b/frontend/src/metabase/entities/pulses.js
@@ -40,7 +40,7 @@ const Pulses = createEntity({
   objectSelectors: {
     getName: pulse => pulse && pulse.name,
     getUrl: pulse => pulse && Urls.pulse(pulse.id),
-    getIcon: pulse => "pulse",
+    getIcon: pulse => ({ name: "pulse" }),
     getColor: pulse => color("pulse"),
   },
 

--- a/frontend/src/metabase/entities/questions.js
+++ b/frontend/src/metabase/entities/questions.js
@@ -68,9 +68,11 @@ const Questions = createEntity({
     getColor: () => color("text-medium"),
     getCollection: question =>
       question && normalizedCollection(question.collection),
-    getIcon: question =>
-      (require("metabase/visualizations").default.get(question.display) || {})
-        .iconName || "beaker",
+    getIcon: question => ({
+      name:
+        (require("metabase/visualizations").default.get(question.display) || {})
+          .iconName || "beaker",
+    }),
   },
 
   reducer: (state = {}, { type, payload, error }) => {

--- a/frontend/src/metabase/entities/segments.js
+++ b/frontend/src/metabase/entities/segments.js
@@ -37,7 +37,7 @@ const Segments = createEntity({
         segment.id,
       ),
     getColor: segment => color("accent7"),
-    getIcon: segment => "segment",
+    getIcon: segment => ({ name: "segment" }),
   },
 
   form: {

--- a/frontend/src/metabase/entities/snippet-collections.js
+++ b/frontend/src/metabase/entities/snippet-collections.js
@@ -63,7 +63,7 @@ const SnippetCollections = createEntity({
   }),
 
   objectSelectors: {
-    getIcon: collection => "folder",
+    getIcon: collection => ({ name: "folder" }),
   },
 
   form: {

--- a/frontend/src/metabase/entities/tables.js
+++ b/frontend/src/metabase/entities/tables.js
@@ -180,7 +180,7 @@ const Tables = createEntity({
   objectSelectors: {
     getUrl: table =>
       Urls.tableRowsQuery(table.database_id, table.table_id, null),
-    getIcon: table => "table",
+    getIcon: table => ({ name: "table" }),
     getColor: table => color("accent2"),
   },
 

--- a/frontend/src/metabase/home/containers/ArchiveApp.jsx
+++ b/frontend/src/metabase/home/containers/ArchiveApp.jsx
@@ -64,7 +64,7 @@ export default class ArchiveApp extends Component {
                   <ArchivedItem
                     type={item.type}
                     name={item.getName()}
-                    icon={item.getIcon()}
+                    icon={item.getIcon().name}
                     color={item.getColor()}
                     isAdmin={isAdmin}
                     onUnarchive={

--- a/frontend/src/metabase/lib/entities.js
+++ b/frontend/src/metabase/lib/entities.js
@@ -571,7 +571,7 @@ export function createEntity(def: EntityDefinition): Entity {
       return object.name;
     },
     getIcon(object) {
-      return "unknown";
+      return { name: "unknown" };
     },
     getColor(object) {
       return undefined;

--- a/frontend/src/metabase/questions/components/CollectionBadge.jsx
+++ b/frontend/src/metabase/questions/components/CollectionBadge.jsx
@@ -20,7 +20,7 @@ class CollectionBadge extends React.Component {
     return (
       <Badge
         to={collection.getUrl()}
-        icon={collection.getIcon()}
+        icon={collection.getIcon().name}
         data-metabase-event={`${analyticsContext};Collection Badge Click`}
         {...props}
       >

--- a/frontend/src/metabase/search/components/SearchResult.info.js
+++ b/frontend/src/metabase/search/components/SearchResult.info.js
@@ -9,7 +9,7 @@ const COLLECTION_EXAMPLE = {
   model: "collection",
   id: 1,
   name: "Revenue",
-  getIcon: () => "folder",
+  getIcon: () => ({ name: "folder" }),
 };
 
 const DASHBOARD_EXAMPLE = {
@@ -22,7 +22,7 @@ const DASHBOARD_EXAMPLE = {
     id: "root",
     name: "Our analytics",
   },
-  getIcon: () => "dashboard",
+  getIcon: () => ({ name: "dashboard" }),
 };
 
 const QUESTION_EXAMPLE = {
@@ -30,7 +30,7 @@ const QUESTION_EXAMPLE = {
   id: 1,
   name: "Revenue by region",
   collection: COLLECTION_EXAMPLE,
-  getIcon: () => "table",
+  getIcon: () => ({ name: "table" }),
 };
 
 const LONG_TITLE_DASHBOARD_EXAMPLE = {

--- a/frontend/src/metabase/search/components/SearchResult.jsx
+++ b/frontend/src/metabase/search/components/SearchResult.jsx
@@ -91,7 +91,7 @@ function ItemIcon({ item, type }) {
       {type === "table" ? (
         <Icon name="database" />
       ) : (
-        <Icon name={item.getIcon()} size={20} />
+        <Icon {...item.getIcon()} size={20} />
       )}
     </IconWrapper>
   );

--- a/frontend/test/metabase/collections/BaseItemsTable.unit.spec.js
+++ b/frontend/test/metabase/collections/BaseItemsTable.unit.spec.js
@@ -27,7 +27,7 @@ describe("Collections BaseItemsTable", () => {
       last_name: "Doe",
       timestamp: timestamp,
     },
-    getIcon: () => "dashboard",
+    getIcon: () => ({ name: "dashboard" }),
     getUrl: () => "/dashboard/1",
   };
 


### PR DESCRIPTION
Entities have the `getIcon` method returning an icon name. E.g. collections have `folder`, dashboards have `dashboard`, question's icon depends on the visualization type, etc.

We're going to introduce official collections (#17072). If a collection is official, its icon has to be yellow. Official collection icon is going to be displayed in a lot of places: search results, collection, question, dashboard, and pages. Having to put `color={isCollectionOfficial(collection) ? "yellow" : "default"}` anywhere we display an icon seems to be fragile.

This PR updates the `getIcon` method, so it now returns an object with potential props, instead of just an icon name. So now it will be possible to also specify a preferred color. There has to be no visible changes in this PR, pure refactoring

```js
// API before
collection.getIcon() // --> "folder"
<Icon name={collection.getIcon()} />

// API after
collection.getIcon() // --> { name: "folder" }
<Icon {...collection.getIcon() />
```