### PR TITLE
Link to MB docs from Google Sign-In admin page instead of Google docs

### DIFF
--- a/frontend/src/metabase/admin/settings/components/SettingsGoogleForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsGoogleForm.jsx
@@ -14,6 +14,7 @@ import { updateSettings } from "metabase/admin/settings/settings";
 import { settingToFormField } from "metabase/admin/settings/utils";
 import Breadcrumbs from "metabase/components/Breadcrumbs";
 import ExternalLink from "metabase/components/ExternalLink";
+import MetabaseSettings from "metabase/lib/settings";
 
 const settingsGoogleFormPropTypes = {
   elements: PropTypes.array,
@@ -56,7 +57,10 @@ export default class SettingsGoogleForm extends Component {
         <p className="text-medium">
           {jt`To allow users to sign in with Google you'll need to give Metabase a Google Developers console application client ID. It only takes a few steps and instructions on how to create a key can be found ${(
             <ExternalLink
-              href="https://developers.google.com/identity/sign-in/web/devconsole-project"
+              href={MetabaseSettings.docsUrl(
+                "administration-guide/10-single-sign-on",
+                "enabling-google-sign-in",
+              )}
               target="_blank"
             >
               {t`here`}


### PR DESCRIPTION
Changes the link to point to the Metabase docs for setting up Google Sign-in, rather than linking directly to Google's docs. The MB docs have a couple of extra important details (like how to fill in the `Authorized JavaScript origins` section) so we should make sure users see them first.

I stumbled on this when I was trying to set up Google auth again to repro an issue, so I'm sure actual users would too.