### PR TITLE
Fix Popover Footer placement when filter is not equalOps

### DIFF
--- a/frontend/src/metabase/components/Popover.css
+++ b/frontend/src/metabase/components/Popover.css
@@ -140,6 +140,13 @@
   z-index: 1;
 }
 
+.PopoverBody--withBackground .PopoverFooterWhenIsNotEqualOps {
+  bottom: 0;
+  padding-bottom: 12px;
+  padding-top: 10px;
+  width: calc(100% - 26px);
+}
+
 .PopoverParameterFieldWidgetFooter {
   position: fixed;
   bottom: -7px;

--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx
@@ -130,7 +130,7 @@ export default class ParameterFieldWidget extends Component<*, Props, State> {
 
     const footerClassName = cx(
       "flex mt1 px1 pb1 PopoverFooter PopoverParameterFieldWidgetFooter",
-      isEqualsOp && "mr1 mb1",
+      isEqualsOp ? "mr1 mb1" : "PopoverFooterWhenIsNotEqualOps",
     );
 
     const placeholder = isEditing


### PR DESCRIPTION
Fixes #16830

## To Test

1. Ask question › Native
2. Enter `SELECT * FROM products where {{ filter }}`
3. In the right sidebar, choose Field Filter type and map it to Products.Category
![image](https://user-images.githubusercontent.com/31325167/123962798-200c1180-d9b2-11eb-9f57-7b2f0668b27e.png)
4. For the filter widget type choose anything except `None` or simple `String`. For example, `String contains` will do.
5. Save question
6. Click on the filter widget (left, near the top, by "Sample Dataset" text, and notice the footer is displaced and is flowing outside of the boundaries of the popover.

### After

![image](https://user-images.githubusercontent.com/380816/125836757-3585b304-87c2-4671-93ee-5094a2847a75.png)

### Before 
![image](https://user-images.githubusercontent.com/31325167/123961575-c9ea9e80-d9b0-11eb-8904-6adc578519b7.png)
