### PR TITLE
Minor color alias change

### DIFF
--- a/frontend/src/metabase/search/components/SearchResult.jsx
+++ b/frontend/src/metabase/search/components/SearchResult.jsx
@@ -18,7 +18,7 @@ import Table from "metabase/entities/tables";
 
 function getColorForIconWrapper(props) {
   if (props.item.collection_position) {
-    return color("warning");
+    return color("saturated-yellow");
   }
   switch (props.type) {
     case "collection":


### PR DESCRIPTION
`SearchResult` uses 'warning' color alias for displaying pinned items. 'Warning' could sound like something is wrong, however, we just want a yellow color. This PR replaces it with 'saturated-yellow', which has the same color code