### PR TITLE
Fix internal SearchResult styleguide page broken

### DIFF
--- a/frontend/src/metabase/search/components/SearchResult.info.js
+++ b/frontend/src/metabase/search/components/SearchResult.info.js
@@ -5,11 +5,15 @@ export const category = "search";
 
 export const description = `Displays search results w/ optional context in typeahead and on the search results page`;
 
+const DEMO_URL = "/_internal/components/searchresult";
+
 const COLLECTION_EXAMPLE = {
   model: "collection",
   id: 1,
   name: "Revenue",
   getIcon: () => ({ name: "folder" }),
+  getUrl: () => DEMO_URL,
+  getCollection: () => {},
 };
 
 const DASHBOARD_EXAMPLE = {
@@ -23,6 +27,8 @@ const DASHBOARD_EXAMPLE = {
     name: "Our analytics",
   },
   getIcon: () => ({ name: "dashboard" }),
+  getUrl: () => DEMO_URL,
+  getCollection: () => COLLECTION_EXAMPLE,
 };
 
 const QUESTION_EXAMPLE = {
@@ -31,6 +37,8 @@ const QUESTION_EXAMPLE = {
   name: "Revenue by region",
   collection: COLLECTION_EXAMPLE,
   getIcon: () => ({ name: "table" }),
+  getUrl: () => DEMO_URL,
+  getCollection: () => COLLECTION_EXAMPLE,
 };
 
 const LONG_TITLE_DASHBOARD_EXAMPLE = {
@@ -41,10 +49,12 @@ const LONG_TITLE_DASHBOARD_EXAMPLE = {
 const QUESTION_CONTEXT_EXAMPLE = {
   ...QUESTION_EXAMPLE,
   name: "Poorly named item",
-  context: {
-    match: "description",
-    content: "This is actually about Revenue",
-  },
+  context: [
+    {
+      match: "description",
+      content: "This is actually about Revenue",
+    },
+  ],
 };
 
 export const examples = {


### PR DESCRIPTION
Fixes a blank screen when opening `/_internal/components/searchresult` it shows a blank screen, because some props are missing. This PR adds missing props, so we can now browse `SearchResult` component's examples again