### PR TITLE
Fix missing collection icons in collection picker and question picker

### DIFF
--- a/frontend/src/metabase/containers/ItemPicker.jsx
+++ b/frontend/src/metabase/containers/ItemPicker.jsx
@@ -206,7 +206,7 @@ export default class ItemPicker extends React.Component {
                       item={collection}
                       name={collection.name}
                       color={COLLECTION_ICON_COLOR}
-                      icon={getCollectionIcon(collection)}
+                      icon={getCollectionIcon(collection).name}
                       selected={canSelect && isSelected(collection)}
                       canSelect={canSelect}
                       hasChildren={hasChildren}

--- a/frontend/src/metabase/dashboard/components/add-card-sidebar/QuestionPicker.jsx
+++ b/frontend/src/metabase/dashboard/components/add-card-sidebar/QuestionPicker.jsx
@@ -84,7 +84,7 @@ function QuestionPicker({
                 key={collection.id}
                 id={collection.id}
                 name={collection.name}
-                icon={getCollectionIcon(collection)}
+                icon={getCollectionIcon(collection).name}
                 onSelect={collectionId => setCurrentCollectionId(collectionId)}
               />
             ))}


### PR DESCRIPTION
This PR fixes `ItemPicker` and `QuestionPicker` were not displaying collection icons. That's a missed part from entities `getIcon` refactoring #17074. Fixes #17087

### To Verify

**Item Picker**

1. Click the plus icon in the navigation header
2. Click "New dashboard"
3. Click a dropdown under "Which collection should it go in?"
4. The picker should display "folder" icons for collection list items

**Question Picker**

1. Open any dashboard
2. Click the pencil icon to edit the dashboard
3. Click an appeared plus icon to add a question to the dashboard
4. The picker should display "folder" icons for collection list items

### Demo

**Before**

<img width="1434" alt="CleanShot 2021-07-16 at 11 44 05@2x" src="https://user-images.githubusercontent.com/17258145/125920451-8b656bbe-6829-417f-ad5a-71c5e317f305.png">

![CleanShot 2021-07-16 at 11 49 21@2x](https://user-images.githubusercontent.com/17258145/125920640-d4bf840f-c2e3-4ae3-81dd-467a8870f57b.png)

**After**

<img width="673" alt="CleanShot 2021-07-16 at 11 52 07@2x" src="https://user-images.githubusercontent.com/17258145/125921307-5e2676c1-235b-45e0-b346-b28d4017b110.png">

<img width="1435" alt="CleanShot 2021-07-16 at 11 51 53@2x" src="https://user-images.githubusercontent.com/17258145/125921318-1bf5aff8-be1c-4b3d-a88d-57b8e4826348.png">
