### PR TITLE
Refactor FormField component

### DIFF
--- a/frontend/src/metabase/components/form/FormField.jsx
+++ b/frontend/src/metabase/components/form/FormField.jsx
@@ -58,7 +58,7 @@ function FormField(props) {
     ...props,
   };
 
-  if (visited === false || active === true) {
+  if (!visited || active) {
     // if the field hasn't been visited or is currently active then don't show the error
     error = null;
   }

--- a/frontend/src/metabase/components/form/FormField.jsx
+++ b/frontend/src/metabase/components/form/FormField.jsx
@@ -4,7 +4,7 @@ import cx from "classnames";
 
 import Tooltip from "metabase/components/Tooltip";
 
-import { FieldRow, Label, InfoIcon } from "./FormField.styled";
+import { FieldRow, Label, InfoIcon, InputContainer } from "./FormField.styled";
 
 const formFieldCommon = {
   title: PropTypes.string,
@@ -93,9 +93,7 @@ function FormField(props) {
           {description && <div className="mb1">{description}</div>}
         </div>
       )}
-      <div className={cx("flex-no-shrink", { "ml-auto": horizontal })}>
-        {children}
-      </div>
+      <InputContainer horizontal={horizontal}>{children}</InputContainer>
     </div>
   );
 }

--- a/frontend/src/metabase/components/form/FormField.jsx
+++ b/frontend/src/metabase/components/form/FormField.jsx
@@ -43,14 +43,9 @@ function FormField(props) {
     title = formField && formField.title,
     description = formField && formField.description,
     info = formField && formField.info,
-    hidden = formField &&
-      (formField.hidden != null
-        ? formField.hidden
-        : formField.type === "hidden"),
+    hidden = formField && (formField.hidden || formField.type === "hidden"),
     horizontal = formField &&
-      (formField.horizontal != null
-        ? formField.horizontal
-        : formField.type === "boolean"),
+      (formField.horizontal || formField.type === "boolean"),
     children,
   } = props;
 

--- a/frontend/src/metabase/components/form/FormField.jsx
+++ b/frontend/src/metabase/components/form/FormField.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import cx from "classnames";
@@ -7,28 +6,36 @@ import Tooltip from "metabase/components/Tooltip";
 
 import { FieldRow, Label, InfoIcon } from "./FormField.styled";
 
+const formFieldCommon = {
+  title: PropTypes.string,
+  description: PropTypes.string,
+  info: PropTypes.string,
+  hidden: PropTypes.bool,
+  horizontal: PropTypes.bool,
+};
+
+const propTypes = {
+  ...formFieldCommon,
+
+  formField: PropTypes.shape({
+    ...formFieldCommon,
+    type: PropTypes.string,
+  }),
+
+  // redux-form compatible:
+  name: PropTypes.string,
+  error: PropTypes.any,
+  visited: PropTypes.bool,
+  active: PropTypes.bool,
+
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]),
+  className: PropTypes.string,
+};
+
 export default class FormField extends Component {
-  static propTypes = {
-    field: PropTypes.object,
-    formField: PropTypes.object,
-
-    // redux-form compatible:
-    name: PropTypes.string,
-    error: PropTypes.any,
-    visited: PropTypes.bool,
-    active: PropTypes.bool,
-
-    hidden: PropTypes.bool,
-    title: PropTypes.string,
-    description: PropTypes.string,
-    info: PropTypes.string,
-
-    children: PropTypes.oneOfType([
-      PropTypes.arrayOf(PropTypes.node),
-      PropTypes.node,
-    ]),
-  };
-
   render() {
     const {
       className,
@@ -98,3 +105,5 @@ export default class FormField extends Component {
     );
   }
 }
+
+FormField.propTypes = propTypes;

--- a/frontend/src/metabase/components/form/FormField.jsx
+++ b/frontend/src/metabase/components/form/FormField.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React from "react";
 import PropTypes from "prop-types";
 import cx from "classnames";
 
@@ -17,6 +17,7 @@ const formFieldCommon = {
 const propTypes = {
   ...formFieldCommon,
 
+  field: PropTypes.object,
   formField: PropTypes.shape({
     ...formFieldCommon,
     type: PropTypes.string,
@@ -35,75 +36,75 @@ const propTypes = {
   className: PropTypes.string,
 };
 
-export default class FormField extends Component {
-  render() {
-    const {
-      className,
-      formField,
-      title = formField && formField.title,
-      description = formField && formField.description,
-      info = formField && formField.info,
-      hidden = formField &&
-        (formField.hidden != null
-          ? formField.hidden
-          : formField.type === "hidden"),
-      horizontal = formField &&
-        (formField.horizontal != null
-          ? formField.horizontal
-          : formField.type === "boolean"),
-      children,
-    } = this.props;
+function FormField(props) {
+  const {
+    className,
+    formField,
+    title = formField && formField.title,
+    description = formField && formField.description,
+    info = formField && formField.info,
+    hidden = formField &&
+      (formField.hidden != null
+        ? formField.hidden
+        : formField.type === "hidden"),
+    horizontal = formField &&
+      (formField.horizontal != null
+        ? formField.horizontal
+        : formField.type === "boolean"),
+    children,
+  } = props;
 
-    if (hidden) {
-      return null;
-    }
-
-    let { name, error, visited, active } = {
-      ...(this.props.field || {}),
-      ...this.props,
-    };
-
-    if (visited === false || active === true) {
-      // if the field hasn't been visited or is currently active then don't show the error
-      error = null;
-    }
-
-    return (
-      <div
-        className={cx("Form-field", className, {
-          "Form--fieldError": !!error,
-          flex: horizontal,
-        })}
-        id={`formField-${name.replace(/\./g, "-")}`}
-      >
-        {(title || description) && (
-          <div>
-            <FieldRow>
-              {title && (
-                <Label
-                  className={cx("Form-label", { "mr-auto": horizontal })}
-                  htmlFor={name}
-                  id={`${name}-label`}
-                >
-                  {title}
-                  {error && <span className="text-error">: {error}</span>}
-                </Label>
-              )}
-              {info && (
-                <Tooltip tooltip={info}>
-                  <InfoIcon />
-                </Tooltip>
-              )}
-            </FieldRow>
-            {description && <div className="mb1">{description}</div>}
-          </div>
-        )}
-        <div className={cx("flex-no-shrink", { "ml-auto": horizontal })}>
-          {children}
-        </div>
-      </div>
-    );
+  if (hidden) {
+    return null;
   }
+
+  let { name, error, visited, active } = {
+    ...(props.field || {}),
+    ...props,
+  };
+
+  if (visited === false || active === true) {
+    // if the field hasn't been visited or is currently active then don't show the error
+    error = null;
+  }
+
+  return (
+    <div
+      className={cx("Form-field", className, {
+        "Form--fieldError": !!error,
+        flex: horizontal,
+      })}
+      id={`formField-${name.replace(/\./g, "-")}`}
+    >
+      {(title || description) && (
+        <div>
+          <FieldRow>
+            {title && (
+              <Label
+                className={cx("Form-label", { "mr-auto": horizontal })}
+                htmlFor={name}
+                id={`${name}-label`}
+              >
+                {title}
+                {error && <span className="text-error">: {error}</span>}
+              </Label>
+            )}
+            {info && (
+              <Tooltip tooltip={info}>
+                <InfoIcon />
+              </Tooltip>
+            )}
+          </FieldRow>
+          {description && <div className="mb1">{description}</div>}
+        </div>
+      )}
+      <div className={cx("flex-no-shrink", { "ml-auto": horizontal })}>
+        {children}
+      </div>
+    </div>
+  );
 }
 
 FormField.propTypes = propTypes;
+
+export default FormField;

--- a/frontend/src/metabase/components/form/FormField.jsx
+++ b/frontend/src/metabase/components/form/FormField.jsx
@@ -67,14 +67,13 @@ function FormField(props) {
     error = null;
   }
 
+  const rootClassNames = cx("Form-field", className, {
+    "Form--fieldError": !!error,
+    flex: horizontal,
+  });
+
   return (
-    <div
-      id={formFieldId}
-      className={cx("Form-field", className, {
-        "Form--fieldError": !!error,
-        flex: horizontal,
-      })}
-    >
+    <div id={formFieldId} className={rootClassNames}>
       {(title || description) && (
         <div>
           <FieldRow>

--- a/frontend/src/metabase/components/form/FormField.jsx
+++ b/frontend/src/metabase/components/form/FormField.jsx
@@ -55,12 +55,12 @@ function FormField(props) {
     return null;
   }
 
-  const formFieldId = `formField-${name.replace(ALL_DOT_CHARS, "-")}`;
-
   let { name, error, visited, active } = {
     ...(props.field || {}),
     ...props,
   };
+
+  const formFieldId = `formField-${name.replace(ALL_DOT_CHARS, "-")}`;
 
   if (!visited || active) {
     // if the field hasn't been visited or is currently active then don't show the error

--- a/frontend/src/metabase/components/form/FormField.jsx
+++ b/frontend/src/metabase/components/form/FormField.jsx
@@ -36,6 +36,8 @@ const propTypes = {
   className: PropTypes.string,
 };
 
+const ALL_DOT_CHARS = /\./g;
+
 function FormField(props) {
   const {
     className,
@@ -53,6 +55,8 @@ function FormField(props) {
     return null;
   }
 
+  const formFieldId = `formField-${name.replace(ALL_DOT_CHARS, "-")}`;
+
   let { name, error, visited, active } = {
     ...(props.field || {}),
     ...props,
@@ -65,11 +69,11 @@ function FormField(props) {
 
   return (
     <div
+      id={formFieldId}
       className={cx("Form-field", className, {
         "Form--fieldError": !!error,
         flex: horizontal,
       })}
-      id={`formField-${name.replace(/\./g, "-")}`}
     >
       {(title || description) && (
         <div>

--- a/frontend/src/metabase/components/form/FormField.jsx
+++ b/frontend/src/metabase/components/form/FormField.jsx
@@ -20,7 +20,7 @@ const propTypes = {
   field: PropTypes.object,
   formField: PropTypes.shape({
     ...formFieldCommon,
-    type: PropTypes.string,
+    type: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   }),
 
   // redux-form compatible:

--- a/frontend/src/metabase/components/form/FormField.jsx
+++ b/frontend/src/metabase/components/form/FormField.jsx
@@ -79,11 +79,7 @@ function FormField(props) {
         <div>
           <FieldRow>
             {title && (
-              <Label
-                className={cx("Form-label", { "mr-auto": horizontal })}
-                htmlFor={name}
-                id={`${name}-label`}
-              >
+              <Label id={`${name}-label`} htmlFor={name} horizontal>
                 {title}
                 {error && <span className="text-error">: {error}</span>}
               </Label>

--- a/frontend/src/metabase/components/form/FormField.styled.js
+++ b/frontend/src/metabase/components/form/FormField.styled.js
@@ -3,8 +3,6 @@ import Icon from "metabase/components/Icon";
 
 import { color } from "metabase/lib/colors";
 
-export const FormFieldRoot = styled.div.attrs({});
-
 export const FieldRow = styled.div`
   display: flex;
   align-items: center;

--- a/frontend/src/metabase/components/form/FormField.styled.js
+++ b/frontend/src/metabase/components/form/FormField.styled.js
@@ -1,7 +1,9 @@
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 import Icon from "metabase/components/Icon";
 
 import { color } from "metabase/lib/colors";
+
+export const FormFieldRoot = styled.div.attrs({});
 
 export const FieldRow = styled.div`
   display: flex;
@@ -20,4 +22,13 @@ export const InfoIcon = styled(Icon).attrs({ name: "info", size: 12 })`
   &:hover {
     color: ${color("brand")};
   }
+`;
+
+export const InputContainer = styled.div`
+  flex-shrink: 0;
+  ${props =>
+    props.horizontal &&
+    css`
+      margin-left: auto;
+    `}
 `;

--- a/frontend/src/metabase/components/form/FormField.styled.js
+++ b/frontend/src/metabase/components/form/FormField.styled.js
@@ -11,8 +11,13 @@ export const FieldRow = styled.div`
   margin-bottom: 0.5em;
 `;
 
-export const Label = styled.label`
+export const Label = styled.label.attrs({ className: "Form-label" })`
   margin-bottom: 0;
+  ${props =>
+    props.horizontal &&
+    css`
+      margin-right: auto;
+    `}
 `;
 
 export const InfoIcon = styled(Icon).attrs({ name: "info", size: 12 })`


### PR DESCRIPTION
This is a boy-scout rule driver refactoring after #17073. Aligns the `FormField` component with our coding style guide. `FormField` is Metabase's own form libraries UI building block. It displays the field's title, description, errors, and the input itself. No visible changes are expected.

* updated prop-types, disabled eslint-ignore for prop-types
* class component → functional component
* more styled-components
* a pinch of readability improvements (hopefully)

**To Verify**

Go through different Metabase forms (e.g. new user, database, collection, question, etc.) and ensure there are no visible differences.

![CleanShot 2021-07-16 at 12 25 17@2x](https://user-images.githubusercontent.com/17258145/125926489-cf4c3961-762e-4f6e-84b5-29ac65f10f9a.png)
