### PR TITLE
offset is a reserved word in mariadb as of 10.6

### DIFF
--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -133,7 +133,7 @@
                                                     "      now(), convert_tz(now(), @@GLOBAL.time_zone, '+00:00')"
                                                     "   ),"
                                                     "   '%H:%i'"
-                                                    " ) AS offset;")
+                                                    " ) AS 'offset';")
         [{:keys [global_tz system_tz offset]}] (jdbc/query spec sql)
         the-valid-id                           (fn [zone-id]
                                                  (when zone-id


### PR DESCRIPTION
- https://mariadb.com/kb/en/reserved-words/
- https://github.com/MariaDB/server/commit/299b935320

I think it is related to https://jira.mariadb.org/browse/MDEV-23908
"Implement SELECT ... OFFSET ... FETCH ..."

Was in getting the timezone information for the db

Before:
```
MariaDB [(none)]> SELECT @@GLOBAL.time_zone AS global_tz,
    ->        @@system_time_zone AS system_tz,
    ->        time_format(timediff(now(), convert_tz(now(), @@GLOBAL.time_zone, '+00:00')),'%H:%i') as  offset;
ERROR 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'offset' at line 3
MariaDB [(none)]>
```

after
```sql
MariaDB [(none)]> SELECT @@GLOBAL.time_zone AS global_tz,
    ->        @@system_time_zone AS system_tz,
    ->        time_format(timediff(now(), convert_tz(now(), @@GLOBAL.time_zone, '+00:00')),'%H:%i') as  'offset';
+-----------+-----------+--------+
| global_tz | system_tz | offset |
+-----------+-----------+--------+
| SYSTEM    | UTC       | 00:00  |
+-----------+-----------+--------+
1 row in set (0.000 sec)
```

Only difference is `offset` -> `'offset'`