### PR TITLE
Remove Number from semantic types

### DIFF
--- a/frontend/src/metabase/lib/core.js
+++ b/frontend/src/metabase/lib/core.js
@@ -39,11 +39,6 @@ export const field_semantic_types = [
     section: t`Common`,
   },
   {
-    id: TYPE.Number,
-    name: t`Number`,
-    section: t`Common`,
-  },
-  {
     id: TYPE.Title,
     name: t`Title`,
     section: t`Common`,

--- a/frontend/test/metabase/scenarios/admin/datamodel/field-type.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/field-type.cy.spec.js
@@ -48,16 +48,10 @@ describe("scenarios > admin > datamodel > field > field type", () => {
     getFKTargetField("Products → ID");
   });
 
-  it.skip("should let you change the type to 'Number' (metabase#16781)", () => {
+  it("should not let you change the type to 'Number' (metabase#16781)", () => {
     visitAlias("@ORDERS_PRODUCT_ID_URL");
 
-    setFieldType({ oldValue: "Foreign Key", newValue: "Number" });
-
-    waitAndAssertOnResponse("fieldUpdate");
-
-    cy.reload();
-
-    getFieldType("Number");
+    checkNoFieldType({ oldValue: "Foreign Key", newValue: "Number" });
   });
 });
 
@@ -77,13 +71,25 @@ function getFieldType(type) {
 
 function setFieldType({ oldValue, newValue } = {}) {
   getFieldType(oldValue).click();
+
   popover().within(() => {
-    cy.get(".ReactVirtualized__Grid").scrollTo(0, 0); // HACK: scroll to the top of the list. Ideally we should probably disable AccordionList virtualization
-    cy.findByPlaceholderText("Find...").type(newValue);
-    cy.get(".List-item")
-      .contains(newValue)
-      .click();
+    searchFieldType(newValue);
+    cy.findByText(newValue).click();
   });
+}
+
+function checkNoFieldType({ oldValue, newValue } = {}) {
+  getFieldType(oldValue).click();
+
+  popover().within(() => {
+    searchFieldType(newValue);
+    cy.queryByText(newValue).should("not.exist");
+  });
+}
+
+function searchFieldType(type) {
+  cy.get(".ReactVirtualized__Grid").scrollTo(0, 0); // HACK: scroll to the top of the list. Ideally we should probably disable AccordionList virtualization
+  cy.findByPlaceholderText("Find...").type(type);
 }
 
 function getFKTargetField(targetField) {


### PR DESCRIPTION
Based on https://github.com/metabase/metabase/issues/16781 and the comment https://github.com/metabase/metabase/issues/16781#issuecomment-869825671. The goal is to remove `Number` from semantic types as it is not supported by backend anymore.

How to test manually:

- Go to Admin -> Data model
- Go to a table in any database
- Try to change the type of a column to `Number`
- There should be no `Number` option available.

Closes https://github.com/metabase/metabase/issues/16781.