### PR TITLE
Fix add map padding issue

### DIFF
--- a/frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx
@@ -140,11 +140,11 @@ export default class CustomGeoJSONWidget extends Component {
 
     return (
       <div className="flex-full">
-        <div className="flex">
+        <div className="flex justify-between">
           <SettingHeader setting={setting} />
           {!this.state.map && (
             <button
-              className="Button Button--primary flex-align-right"
+              className="Button Button--primary ml1"
               onClick={() =>
                 this.setState({
                   map: {


### PR DESCRIPTION
Fix padding for `Add a map` button in Admin settings:

<img width="602" alt="Screen Shot 2021-07-20 at 3 00 24 pm" src="https://user-images.githubusercontent.com/8542534/126320283-94b0d104-939d-4672-952b-d996712e5b40.png">

<img width="866" alt="Screen Shot 2021-07-20 at 3 00 36 pm" src="https://user-images.githubusercontent.com/8542534/126320262-245901d9-6442-4955-b6cc-803d7c785171.png">

`ml1` is used for the button when there are maps, so I assumed we wanted to have the same padding when there are no maps. Fixes https://github.com/metabase/metabase/issues/16612
