### PR TITLE
Fix partial commits

### DIFF
--- a/package.json
+++ b/package.json
@@ -206,8 +206,7 @@
   },
   "lint-staged": {
     "frontend/**/*.{js,jsx,css}": [
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ]
   },
   "resolutions": {


### PR DESCRIPTION
When `git commit -p` was used `lint-staged` staged the entire files mistakenly