### PR TITLE
Do not reload settings on error when explicit Save is used

### DIFF
--- a/frontend/src/metabase/admin/settings/settings.js
+++ b/frontend/src/metabase/admin/settings/settings.js
@@ -87,8 +87,6 @@ export const updateEmailSettings = createThunkAction(
       } catch (error) {
         console.log("error updating email settings", settings, error);
         throw error;
-      } finally {
-        await dispatch(reloadSettings());
       }
     };
   },
@@ -124,8 +122,6 @@ export const updateSlackSettings = createThunkAction(
       } catch (error) {
         console.log("error updating slack settings", settings, error);
         throw error;
-      } finally {
-        await dispatch(reloadSettings());
       }
     };
   },
@@ -143,8 +139,6 @@ export const updateLdapSettings = createThunkAction(
       } catch (error) {
         console.log("error updating LDAP settings", settings, error);
         throw error;
-      } finally {
-        await dispatch(reloadSettings());
       }
     };
   },

--- a/frontend/test/metabase/scenarios/admin/settings/sso/ldap.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/sso/ldap.cy.spec.js
@@ -52,7 +52,7 @@ describe("scenarios > admin > settings > SSO > LDAP", () => {
     cy.button("Changes saved!");
   });
 
-  it.skip("should not reset previously populated fields when validation fails for just one of them (metabase#16226)", () => {
+  it("should not reset previously populated fields when validation fails for just one of them (metabase#16226)", () => {
     cy.findByPlaceholderText("ldap.yourdomain.org").type("foobar");
     cy.findByPlaceholderText("389").type("baz");
     cy.button("Save changes").click();


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/16226. The issue is in there are 3 pages with settings and `Save` button:
1. Email
2. Slack
3. Ldap

When there is an error on save, settings were reloaded and user input got lost. This PR fixes the issue by not reloading the settings in this case. I think that the issue came from copy-paste from the code for other settings pages where settings are saved immediately, one-by-one.

How to test manually:
1. Open Ldap settings
2. Enter some data and incorrect port, e.g. `123a`.
3. Click `Save changes`
4. The data should not be lost.