### PR TITLE
Fix can't select markdown card text when editing a dashboard

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/Text.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Text.jsx
@@ -98,6 +98,8 @@ export default class Text extends Component {
     this.props.onUpdateVisualizationSettings({ text: text });
   }
 
+  preventDragging = e => e.stopPropagation();
+
   render() {
     const { className, gridSize, settings, isEditing } = this.props;
     const isSingleRow = gridSize && gridSize.height === 1;
@@ -125,6 +127,9 @@ export default class Text extends Component {
               placeholder={t`Write here, and use Markdown if you'd like`}
               value={settings.text}
               onChange={e => this.handleTextChange(e.target.value)}
+              // Prevents text cards from dragging when you actually want to select text
+              // See: https://github.com/metabase/metabase/issues/17039
+              onMouseDown={this.preventDragging}
             />
           )}
         </div>


### PR DESCRIPTION
After dashboards' drag-n-drop upgrade at #16255, we lost the ability to select markdown cards' text using a mouse (keyboard selection still works). Any time you try to select the text, the moving gesture is captured and you end up dragging the card.

Any dashboard card consists of a "visualization" (a chart, a table, or a text block for markdown cards), and a "container" that holds the visualization. It's They can be seen very clearly in text cards. The area with a blue border is the "visualization", and the surrounding white area is the "container"

<img src="https://user-images.githubusercontent.com/17258145/126333581-639b4a34-30b1-4f36-a28c-b5e4b52affba.png" alt="Text card screenshot" width="300px" />

Currently, the moving gesture is captured once you start dragging either a container or a visualization. The fix is that for text cards we now disable some mouse events propagation if they're happening with the visualization. In that way, the text card's `textarea` captures mouse events and you can select the text as expected. The "container" area still propagates events, so you can still drag a text card.

Fixes #17039

### To Verify
1. Open any dashboard or open an existing one
2. Click the pencil icon in the top right to switch into dashboard editing mode
3. Click the `Aa` icon (add text box)
4. Fill in some text into a new card
5. Try selecting some text with your mouse / trackpad
6. The text should be selected, the card has to stay at its original place
7. Try moving and resizing the text card by dragging the white container area

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/126327761-b73587f8-5152-407d-9be1-9648dd0fbe3c.mov

**After**

https://user-images.githubusercontent.com/17258145/126327772-638711c9-38b7-4d83-879c-c60b1d8c8a45.mov

