### PR TITLE
fix stacked buttons on embedded dashboards

### DIFF
--- a/frontend/src/metabase/public/containers/PublicDashboard.jsx
+++ b/frontend/src/metabase/public/containers/PublicDashboard.jsx
@@ -151,15 +151,7 @@ export default class PublicDashboard extends Component {
         parameterValues={parameterValues}
         setParameterValue={this.props.setParameterValue}
         actionButtons={
-          buttons.length > 0 && (
-            <div>
-              {buttons.map((button, index) => (
-                <span key={index} className="m1">
-                  {button}
-                </span>
-              ))}
-            </div>
-          )
+          buttons.length > 0 && <div className="flex">{buttons}</div>
         }
       >
         <LoadingAndErrorWrapper


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/16798

### How to verify
- Create a dashboard with at least one question
- Enable sharing and open the public link in a new tab
- Ensure buttons in the footer are not stacked

Before:
<img width="888" alt="Screen Shot 2021-07-20 at 18 01 17" src="https://user-images.githubusercontent.com/14301985/126347407-4ecc8fad-0f5a-4e29-af1b-711a3be72a21.png">

After:
<img width="1161" alt="Screen Shot 2021-07-20 at 17 59 03" src="https://user-images.githubusercontent.com/14301985/126346985-f0b6d477-beec-49f0-9add-c08b2d892962.png">
