### PR TITLE
Fix serialization: Visualization column settings lost

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/load.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/load.clj
@@ -384,13 +384,22 @@
       (pull-unresolved-names-up vs-norm [::mb.viz/click-behavior] resolved-cb))
     vs-norm))
 
-(defn- resolve-column-settings [vs-norm]
+(defn- resolve-column-settings
+  "Resolve the entries in a :column_settings map (which is under a :visualization_settings map). These map entries
+  may contain fully qualified field names, or even other cards. In case of an unresolved name (i.e. a card that hasn't
+  yet been loaded), we will track it under ::unresolved-names and revisit on the next pass."
+  [vs-norm]
   (if-let [col-settings (::mb.viz/column-settings vs-norm)]
     (let [resolved-cs (reduce-kv accumulate-converted-column-settings {} col-settings)]
       (pull-unresolved-names-up vs-norm [::mb.viz/column-settings] resolved-cs))
     vs-norm))
 
-(defn- resolve-table-columns [vs-norm]
+(defn- resolve-table-columns
+  "Resolve the :table.columns key from a :visualization_settings map, which may contain fully qualified field names.
+  Such fully qualified names will be converted to the numeric field ID before being filled into the loaded card. Only
+  other field names (not cards, or other collection based entity types) should be referenced here, so there is no need
+  to detect or track ::unresolved-names."
+  [vs-norm]
   (if (::mb.viz/table-columns vs-norm)
     (letfn [(resolve-table-column-field-ref [[f-type f-str f-md]]
               (if (names/fully-qualified-field-name? f-str)
@@ -403,6 +412,12 @@
     vs-norm))
 
 (defn- resolve-visualization-settings
+  "Resolve all references from a :visualization_settings map, the various submaps of which may contain:
+    - fully qualified field names
+    - fully qualified card or dashboard names
+
+  Any unresolved entities from this resolution process will be tracked via ::unresolved-named so that the card or
+  dashboard card holding these visualization settings can be revisited in a future pass."
   [entity]
   (if-let [viz-settings (:visualization_settings entity)]
     (let [resolved-vs (-> (mb.viz/db->norm viz-settings)

--- a/enterprise/backend/src/metabase_enterprise/serialization/serialize.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/serialize.clj
@@ -208,7 +208,8 @@
   [card]
   (-> card
       (m/update-existing :table_id (partial fully-qualified-name Table))
-      (update :database_id (partial fully-qualified-name Database))))
+      (update :database_id (partial fully-qualified-name Database))
+      (m/update-existing :visualization_settings convert-viz-settings)))
 
 (defmethod serialize-one (type Pulse)
   [pulse]

--- a/enterprise/backend/test/metabase_enterprise/serialization/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/test_util.clj
@@ -146,7 +146,16 @@
                                 :collection_id ~'collection-id
                                 :dataset_query {:type :query
                                                 :database ~'db-id
-                                                :query {:source-table (str "card__" ~'card-id)}}}]
+                                                :query {:source-table (str "card__" ~'card-id)}}
+                                :visualization_settings
+                                {:table.columns [{:name "Venue Category"
+                                                  :fieldRef [:field ~'category-field-id nil]
+                                                  :enabled true}]
+                                 :column_settings {(keyword (format
+                                                             "[\"ref\",[\"field\",%d,null]]"
+                                                              ~'latitude-field-id))
+                                                   {:show_mini_bar true
+                                                    :column_title "Parallel"}}}}]
                    Card       [{~'card-id-nested-query :id}
                                {:table_id ~'table-id
                                 :name "My Nested Query Card"

--- a/shared/src/metabase/shared/models/visualization_settings.cljc
+++ b/shared/src/metabase/shared/models/visualization_settings.cljc
@@ -53,9 +53,11 @@
 (s/def ::click-behavior (s/keys))
 (s/def ::visualization-settings (s/keys :opt [::column-settings ::click-behavior]))
 
-(s/def ::db-column-ref-vec (s/or :field (s/tuple (partial = "ref") (s/tuple (partial = "field")
-                                                                            (s/or :field-id int? :field-str string?)
-                                                                            (s/or :field-metadata map? :nil nil?)))
+(s/def ::field-id-vec (s/tuple (partial = "ref") (s/tuple (partial = "field")
+                                                   (s/or :field-id int? :field-str string?)
+                                                   (s/or :field-metadata map? :nil nil?))))
+
+(s/def ::db-column-ref-vec (s/or :field ::field-id-vec
                                  :column-name (s/tuple (partial = "name") string?)))
 
 (s/def ::click-behavior-type keyword? #_(s/or :cross-filter ::cross-filter
@@ -285,7 +287,6 @@
            ::link-target-id      entity-id}
           (some? parameter-mapping) (assoc ::parameter-mapping parameter-mapping)))
 
-
 (s/fdef entity-click-action
   :args (s/cat :entity-type ::entity-type :entity-id int? :parameter-mapping ::parameter-mapping)
   :ret  ::click-behavior)
@@ -322,7 +323,7 @@
                :from-field-id     int?
                :to-entity-type    ::entity-type
                :to-entity-id      int?
-               :parameter-mapping (s/? ::parameter-mapping) )
+               :parameter-mapping (s/? ::parameter-mapping))
   :ret  ::click-behavior)
 
 (defn fk-parameter-mapping
@@ -382,7 +383,8 @@
    :prefix            ::prefix
    :suffix            ::suffix
    :view_as           ::view-as
-   :link_text         ::link-text})
+   :link_text         ::link-text
+   :show_mini_bar     ::show-mini-barchart})
 
 (def ^:private norm->db-column-settings-keys
   (set/map-invert db->norm-column-settings-keys))
@@ -403,6 +405,17 @@
 
 (def ^:private norm->db-param-ref-keys
   (set/map-invert db->norm-param-ref-keys))
+
+(def ^:private db->norm-table-columns-keys
+  {:name     ::table-column-name
+   ; for now, do not translate the value of this key (the field vector)
+   :fieldRef ::table-column-field-ref
+   :enabled  ::table-column-enabled})
+
+(def ^:private norm->db-table-columns-keys
+  (set/map-invert db->norm-table-columns-keys))
+
+(s/def ::table-column-field-ref ::field-id-vec)
 
 (defn- db->norm-param-ref [parsed-id param-ref]
   (cond-> (set/rename-keys param-ref db->norm-param-ref-keys)
@@ -493,6 +506,13 @@
       (dissoc :parameterMapping)
       (set/rename-keys db->norm-click-behavior-keys)))
 
+(defn- db->norm-table-columns [v]
+  (-> v
+    (assoc ::table-columns (mapv (fn [tbl-col]
+                                   (set/rename-keys tbl-col db->norm-table-columns-keys))
+                             (:table.columns v)))
+    (dissoc :table.columns)))
+
 (defn- db->norm-column-settings-entry
   "Converts a :column_settings DB form to qualified form. Does the opposite of
   `norm->db-column-settings-entry`."
@@ -520,6 +540,9 @@
           ;; click behavior key at top level; ex: non-table card
           (:click_behavior vs)
           (assoc ::click-behavior (db->norm-click-behavior (:click_behavior vs)))
+
+          (:table.columns vs)
+          db->norm-table-columns
 
           :always
           (dissoc :column_settings :click_behavior)))
@@ -574,6 +597,15 @@
        (m/map-kv (fn [k v]
                    [(norm->db-column-ref k) (reduce-kv norm->db-column-settings-entry {} v)]))))
 
+(defn- norm->db-table-columns [v]
+  (cond-> v
+    (some? (::table-columns v))
+    (assoc :table.columns (mapv (fn [tbl-col]
+                                  (set/rename-keys tbl-col norm->db-table-columns-keys))
+                            (::table-columns v)))
+    :always
+    (dissoc ::table-columns)))
+
 (defn norm->db
   "Converts the normalized form of visualization settings (i.e. a map having
   `::column-settings` into the equivalent DB form (i.e. a map having `:column_settings`).
@@ -587,4 +619,5 @@
                                      (dissoc ::column-settings))
     (::click-behavior settings)  (-> ; from cond->
                                      (assoc :click_behavior (norm->db-click-behavior-value (::click-behavior settings)))
-                                     (dissoc ::click-behavior))))
+                                     (dissoc ::click-behavior))
+    (::table-columns settings)   norm->db-table-columns))

--- a/shared/test/metabase/shared/models/visualization_settings_test.cljc
+++ b/shared/test/metabase/shared/models/visualization_settings_test.cljc
@@ -61,17 +61,33 @@
                                :parameterMapping {}
                                :targetId         target-id}
           db-click-bhv-map    {:click_behavior db-click-behavior}
+          col-nm-map          {:show_mini_bar true
+                               :column_title "Name Column"}
           db-col-settings     {(fmt "[\"ref\",[\"field\",%d,{\"base-type\":\"type/Integer\"}]]" f-id) db-click-bhv-map
-                               (fmt "[\"name\",\"%s\"]" col-name)                                     db-click-bhv-map}
-          db-viz-settings     {:column_settings db-col-settings}
+                               (fmt "[\"name\",\"%s\"]" col-name)                                     col-nm-map}
+          db-viz-settings     {:column_settings db-col-settings
+                               :table.columns   [{:name     "ID"
+                                                  :fieldRef [:field f-id nil]
+                                                  :enabled  true}
+                                                 {:name     "Name"
+                                                  :fieldRef [:expression col-name]
+                                                  :enabled  true}]}
           norm-click-behavior {::mb.viz/click-behavior-type ::mb.viz/link
                                ::mb.viz/link-type           ::mb.viz/card
                                ::mb.viz/parameter-mapping   {}
                                ::mb.viz/link-target-id      target-id}
+          norm-col-nm         {::mb.viz/column-title       "Name Column"
+                               ::mb.viz/show-mini-barchart true}
           norm-click-bhvr-map {::mb.viz/click-behavior norm-click-behavior}
           norm-col-settings {(mb.viz/field-id->column-ref f-id {"base-type" "type/Integer"}) norm-click-bhvr-map
-                             (mb.viz/column-name->column-ref col-name)                       norm-click-bhvr-map}
-          norm-viz-settings   {::mb.viz/column-settings norm-col-settings}]
+                             (mb.viz/column-name->column-ref col-name)                       norm-col-nm}
+          norm-viz-settings   {::mb.viz/column-settings norm-col-settings
+                               ::mb.viz/table-columns [{::mb.viz/table-column-name      "ID"
+                                                        ::mb.viz/table-column-field-ref [:field f-id nil]
+                                                        ::mb.viz/table-column-enabled   true}
+                                                       {::mb.viz/table-column-name      "Name"
+                                                        ::mb.viz/table-column-field-ref [:expression col-name]
+                                                        ::mb.viz/table-column-enabled   true}]}]
       (doseq [[db-form norm-form] [[db-viz-settings norm-viz-settings]]]
         (let [to-norm (mb.viz/db->norm db-form)]
           (t/is (= norm-form to-norm))


### PR DESCRIPTION
Update visualization_settings.cljc to handle the table.columns submap

Update dump and load to handle :visualization_settings on a Card (basically identically to how they are handled for a DashboardCard)

Updating test to have a card include :visualization_settings and ensure they fields are properly handled

Updating visualization_settings test case to incorporate table.columns as well as :show_mini_bar (under :column_settings)
