### PR TITLE
Disable LDAP form fields when auth is disabled

### DIFF
--- a/frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx
@@ -16,11 +16,11 @@ import { updateSettings as defaultUpdateSettings } from "../settings";
 
 const VALIDATIONS = {
   email: {
-    validate: value => MetabaseUtils.validEmail(value),
+    validate: value => MetabaseUtils.isEmail(value),
     message: t`That's not a valid email address`,
   },
   integer: {
-    validate: value => !isNaN(parseInt(value)),
+    validate: value => MetabaseUtils.isInteger(value),
     message: t`That's not a valid integer`,
   },
 };

--- a/frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx
@@ -224,7 +224,7 @@ export default class SettingsBatchForm extends Component {
   };
 
   render() {
-    const { elements, settingValues } = this.props;
+    const { elements, settingValues, enabledKey } = this.props;
     const {
       formData,
       formErrors,
@@ -254,15 +254,18 @@ export default class SettingsBatchForm extends Component {
         formData[element.key] == null
           ? element.defaultValue
           : formData[element.key];
+      const disabled =
+        enabledKey && key !== enabledKey && !formData[enabledKey];
 
       return (
         <SettingsSetting
           key={element.key}
           setting={{ ...element, value }}
-          onChange={value => this.handleChangeEvent(element.key, value)}
           settingValues={settingValues}
-          onChangeSetting={(key, value) => this.handleChangeEvent(key, value)}
+          disabled={disabled}
           errorMessage={errorMessage}
+          onChange={value => this.handleChangeEvent(element.key, value)}
+          onChangeSetting={(key, value) => this.handleChangeEvent(key, value)}
           fireOnChange
         />
       );

--- a/frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx
@@ -71,7 +71,7 @@ export default class SettingsSlackForm extends Component {
 
     switch (validationType) {
       case "email":
-        return !MetabaseUtils.validEmail(value)
+        return !MetabaseUtils.isEmail(value)
           ? validationMessage || t`That's not a valid email address`
           : null;
       case "integer":

--- a/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx
@@ -22,6 +22,7 @@ type Props = {
   mappingSetting: string,
   groupHeading: string,
   groupPlaceholder: string,
+  disabled?: boolean,
 };
 
 type State = {
@@ -133,6 +134,7 @@ export default class GroupMappingsWidget extends React.Component {
   };
 
   render() {
+    const { disabled } = this.props;
     const {
       showEditModal,
       showAddRow,
@@ -149,6 +151,7 @@ export default class GroupMappingsWidget extends React.Component {
             type="button"
             className="ml1"
             medium
+            disabled={disabled}
             onClick={this._showEditModal}
           >{t`Edit Mappings`}</Button>
         </div>

--- a/frontend/src/metabase/admin/settings/components/widgets/SettingInput.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/SettingInput.jsx
@@ -22,6 +22,7 @@ const SettingInput = ({
     type={type}
     value={setting.value || ""}
     placeholder={setting.placeholder}
+    disabled={disabled}
     onChange={fireOnChange ? e => onChange(e.target.value) : null}
     onBlurChange={!fireOnChange ? e => onChange(e.target.value) : null}
     autoFocus={autoFocus}

--- a/frontend/src/metabase/admin/settings/components/widgets/SettingText.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/SettingText.jsx
@@ -17,6 +17,7 @@ const SettingText = ({
     })}
     defaultValue={setting.value || ""}
     placeholder={setting.placeholder}
+    disabled={disabled}
     onChange={fireOnChange ? e => onChange(e.target.value) : null}
     onBlur={!fireOnChange ? e => onChange(e.target.value) : null}
     autoFocus={autoFocus}

--- a/frontend/src/metabase/auth/components/LdapAndEmailForm.jsx
+++ b/frontend/src/metabase/auth/components/LdapAndEmailForm.jsx
@@ -71,7 +71,7 @@ const ForgotPasswordLink = ({ credentials = {} }) => (
   <Link
     to={
       "/auth/forgot_password" +
-      (Utils.validEmail(credentials.username)
+      (Utils.isEmail(credentials.username)
         ? "?email=" + encodeURIComponent(credentials.username)
         : "")
     }

--- a/frontend/src/metabase/lib/utils.js
+++ b/frontend/src/metabase/lib/utils.js
@@ -143,9 +143,13 @@ const MetabaseUtils = {
     );
   },
 
-  validEmail(email) {
+  isEmail(email) {
     const re = /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
     return re.test(email);
+  },
+
+  isInteger(string) {
+    return /^\d+$/.test(string);
   },
 
   equals(a, b) {

--- a/frontend/src/metabase/lib/validate.js
+++ b/frontend/src/metabase/lib/validate.js
@@ -5,7 +5,7 @@ import Settings from "metabase/lib/settings";
 export const validators = {
   required: () => value => !value && t`required`,
   email: () => value =>
-    !Utils.validEmail(value) && t`must be a valid email address`,
+    !Utils.isEmail(value) && t`must be a valid email address`,
   maxLength: max => value =>
     value && value.length > max && t`must be ${max} characters or less`,
   passwordComplexity: () => value =>

--- a/frontend/test/metabase/scenarios/admin/settings/sso/ldap.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/sso/ldap.cy.spec.js
@@ -7,15 +7,34 @@ describe("scenarios > admin > settings > SSO > LDAP", () => {
     cy.visit("/admin/settings/authentication/ldap");
   });
 
+  it("should be possible to save correct settings", () => {
+    cy.intercept("PUT", "/api/**").as("update");
+
+    findToggleByLabel("LDAP authentication").click();
+    findInputByLabel("LDAP host").type("example.com");
+    findInputByLabel("LDAP port").type("390");
+    findInputByLabel("User search base").type("example");
+
+    findButtonByText("Save changes").click();
+    cy.wait("@update");
+    cy.findByText(/An error occurred while attempting to connect/);
+  });
+
   it("shouldn't be possible to save non-numeric port (#13313)", () => {
     findToggleByLabel("LDAP authentication").click();
-
     findInputByLabel("LDAP host").type("example.com");
     findInputByLabel("LDAP port").type("21.3");
     findInputByLabel("User search base").type("example");
 
-    cy.findByText("That's not a valid port number").should("exist");
-    cy.findByRole("button", { name: "Save changes" }).should("be.disabled");
+    cy.findByText("That's not a valid port number");
+    findButtonByText("Save changes").should("be.disabled");
+  });
+
+  it("shouldn't be possible to change settings when disabled", () => {
+    findInputByLabel("LDAP host").should("be.disabled");
+    findInputByLabel("LDAP port").should("be.disabled");
+    findInputByLabel("User search base").should("be.disabled");
+    findButtonByText("Save changes").should("be.disabled");
   });
 });
 
@@ -33,4 +52,8 @@ function findToggleByLabel(text) {
 
 function findInputByLabel(text) {
   return findByLabel(text, "input");
+}
+
+function findButtonByText(text) {
+  return cy.findByRole("button", { name: text });
 }

--- a/frontend/test/metabase/scenarios/admin/settings/sso/ldap.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/sso/ldap.cy.spec.js
@@ -1,8 +1,5 @@
 import { restore } from "__support__/e2e/cypress";
 
-// Space after "123 " is crucial for #13313
-const INVALID_PORTS = ["21.3", "asd", "123 "];
-
 describe("scenarios > admin > settings > SSO > LDAP", () => {
   beforeEach(() => {
     restore();
@@ -10,54 +7,30 @@ describe("scenarios > admin > settings > SSO > LDAP", () => {
     cy.visit("/admin/settings/authentication/ldap");
   });
 
-  /**
-   * IMPORTANT:
-   * These repros currently rely on the broken behavior. It is possible to save settings without authentication turned on.
-   * See: https://github.com/metabase/metabase/issues/16225
-   * It is possible related repros will have to be rewritten/adjusted once #16255 gets fixed!
-   */
+  it("shouldn't be possible to save non-numeric port (#13313)", () => {
+    findToggleByLabel("LDAP authentication").click();
 
-  INVALID_PORTS.forEach(port => {
-    it("shouldn't be possible to save non-numeric port (#13313)", () => {
-      // The real endpoint is `/api/ldap/settings` but I had to use this ambiguous one for this repro because of #16173
-      // Although the endpoint was fixed, we want to always be able to test these issues separately and independently of each other.
-      cy.intercept("PUT", "/api/**").as("update");
+    findInputByLabel("LDAP host").type("example.com");
+    findInputByLabel("LDAP port").type("21.3");
+    findInputByLabel("User search base").type("example");
 
-      cy.findByPlaceholderText("ldap.yourdomain.org").type("foobar");
-      cy.findByPlaceholderText("389").type(port);
-      cy.button("Save changes").click();
-      cy.wait("@update").then(interception => {
-        expect(interception.response.statusCode).to.eq(500);
-        expect(interception.response.body.cause).to.include(port);
-      });
-    });
-  });
-
-  it("should use the correct endpoint (metabase#16173)", () => {
-    cy.intercept("PUT", "/api/ldap/settings").as("ldapUpdate");
-    cy.findByPlaceholderText("ldap.yourdomain.org").type("foobar");
-    cy.findByPlaceholderText("389").type("888");
-    cy.findByText(/Username or DN/i)
-      .closest("li")
-      .find("input")
-      .type("John");
-    cy.findByText("The password to bind with for the lookup user.")
-      .closest("li")
-      .find("input")
-      .type("Smith");
-    cy.button("Save changes").click();
-    cy.wait("@ldapUpdate").then(interception => {
-      expect(interception.response.statusCode).to.eq(200);
-    });
-    cy.button("Changes saved!");
-  });
-
-  it("should not reset previously populated fields when validation fails for just one of them (metabase#16226)", () => {
-    cy.findByPlaceholderText("ldap.yourdomain.org").type("foobar");
-    cy.findByPlaceholderText("389").type("baz");
-    cy.button("Save changes").click();
-
-    cy.findByText('For input string: "baz"'); // The error message
-    cy.findByDisplayValue("foobar");
+    cy.findByText("That's not a valid port number").should("exist");
+    cy.findByRole("button", { name: "Save changes" }).should("be.disabled");
   });
 });
+
+function findByLabel(text, selector) {
+  return cy
+    .contains(text, { matchCase: false })
+    .parent()
+    .parent()
+    .find(selector);
+}
+
+function findToggleByLabel(text) {
+  return findByLabel(text, "a");
+}
+
+function findInputByLabel(text) {
+  return findByLabel(text, "input");
+}


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/16225

Among expected behaviours from the issue:
1. Either completely disable all input fields until toggle (authentication) is enabled, or
2. Remove the toggle or
3. Don't offer to save field values until toggle (authentication) is enabled

I've chosen the 1st one because it seems the most straightforward solution. The 2nd option would require changes on BE and UX. The 3rd option would make it even harder to understand - why can I edit values but not save them?
