### PR TITLE
Editing FAQ.

### DIFF
--- a/docs/faq/general/can-i-request-a-new-feature.md
+++ b/docs/faq/general/can-i-request-a-new-feature.md
@@ -1,3 +1,5 @@
 # Can I request a new feature?
 
-Absolutely! New features can be added as issues in our [Github repo](https://github.com/metabase/metabase/issues). Before filing, take a minute to search and see if your feature has already been requested. If it has, it’s better to leave a thumbs up reaction on the existing issue than to file a new one. We use the thumbs up to measure how interested our community is in new features, so it’s better to have all of the thumbs ups captured on one issue.
+Absolutely! New features can be added as [issues in our Github repo][github-issues]. Before filing, please take a minute to search and see if your feature has already been requested. If it has, it's better to add a thumbs up on the existing issue than to file a new one. (We use thumbs up to measure how interested our community is in new features, so it's better to have them all in one place.)
+
+[github-issues]: https://github.com/metabase/metabase/issues

--- a/docs/faq/general/do-we-need-a-data-processing-agreement.md
+++ b/docs/faq/general/do-we-need-a-data-processing-agreement.md
@@ -1,3 +1,5 @@
 # Do we need a Data Processing Agreement with Metabase to comply with GDPR?
 
-Metabase is a self-hosted application, and as such we have no access to any data on your instance. We only collect [anonymized usage stats](../../information-collection.md) if you opted-in during installation, but even in that case, we see no personally identifiable data. As such, we are not a data processor for the purposes of GDPR.
+Metabase is a self-hosted application, and as such we have no access to any data on your instance. We only collect [anonymized usage stats][information-collection] if you opted-in during installation, but even in that case, we do not gather any personally-identifiable data. As such, we are not a data processor for the purposes of GDPR.
+
+[information-collection]: ../../information-collection.md

--- a/docs/faq/general/does-metabase-do-x.md
+++ b/docs/faq/general/does-metabase-do-x.md
@@ -1,3 +1,5 @@
 # Does Metabase do X?
 
-If you’re not sure if Metabase has the capability you’re looking for, we would recommend asking in [Discourse](https://discourse.metabase.com/). If it’s something we don’t do, our friendly community may be able to point you towards a workaround, or the Github issue where the feature has been requested.
+If you're not sure whether Metabase can do something you need, please ask about it in [Discourse][discourse]. If it's something we don't do, our community may be able to point you at a workaround or at a Github issue where the feature has been requested.
+
+[discourse]: https://discourse.metabase.com/

--- a/docs/faq/general/does-metabase-have-access-to-my-companys-data.md
+++ b/docs/faq/general/does-metabase-have-access-to-my-companys-data.md
@@ -1,5 +1,5 @@
 # Does Metabase have access to my company's data?
 
-If you run Metabase as a self-hosted instance, none of your data is collected or stored on Metabase servers.
+If you run Metabase as a self-hosted instance, none of your data is collected or stored on Metabase servers. That said, you *can* opt in to share anonymous usage data with us, which helps us make decisions about product improvements. You can read more about it [here][data-collection].
 
-There is the option to opt-in to sharing anonymous usage data with us, which we use to make decisions about product improvements. You can read more about it [here](../../information-collection.md).
+[data-collection]: ../../information-collection.md

--- a/docs/faq/general/how-do-i-ask-for-help.md
+++ b/docs/faq/general/how-do-i-ask-for-help.md
@@ -1,7 +1,9 @@
 # How do I ask for help?
 
-The best place to start when asking for help are our [Troubleshooting guides](../../troubleshooting-guide/index.md). We’ve compiled a list of common problems that users experience, along with common symptoms and error messages to help you self-diagnose and resolve your issues.
+The best place to start when asking for help are our [Troubleshooting guides][troubleshooting]. We've compiled a list of common problems that users experience, along with common symptoms and error messages to help you diagnose and resolve your issues.
 
-As hard as we’ve tried to make the documentation as complete as possible, we know that you might need additional help or have a general question about Metabase not answered here. The best way to get help in these cases is to post on our [Discourse](https://discourse.metabase.com/) and harness the power of our community to get your question answered.
+As hard as we've tried to make the documentation as complete as possible, we know that you might need additional help or have a general question about Metabase not answered here. If you're using the Enterprise Edition, please contact support via email or use the [contact form][contact]. If you're using the Open Source Edition, the best way to get help is to post on our [Discourse][discourse] and harness the power of our community.
 
-If you're using the Enterprise Edition, then please contact support via email or use the [contact form](https://www.metabase.com/contact/).
+[contact]: https://www.metabase.com/contact/
+[discourse]: https://discourse.metabase.com/
+[troubleshooting]: ../../troubleshooting-guide/index.md

--- a/docs/faq/general/is-metabase-508-compliant.md
+++ b/docs/faq/general/is-metabase-508-compliant.md
@@ -1,11 +1,16 @@
 # Is Metabase accessible or 508 compliant?
 
-Metabase strives for accessibility, but is not yet fully 508 compliant. Here is a quick summary of the specific areas where Metabase is not yet entirely compliant:
+Metabase strives to be accessible, but is not yet fully compliant with [the US federal government's Section 508 standard][508-accessibility]. Some specific areas where Metabase we still have work to do include:
 
-- The app does not have a method to allow screen readers to skip over repetitive navigation elements.
-- Metabase is extremely close but not 100% compliant at providing text equivalents for all non-text elements in the app.
-- Not all, but most, of the app's form elements are selectable by tabbing through elements.
-- Metabase has minimal transition animations in it, but we have not yet conducted testing to determine the range of flickering to verify if it is always between 2 and 55 hertz.
-- The app's data tables do not have row and column headers identified in markup.
+- Metabase does not have a method to allow screen readers to skip over repetitive navigation elements.
+- Metabase is extremely close but not 100% compliant at providing text equivalents for all non-text elements.
+- Most but not all of our form elements are selectable by tabbing through elements.
+- Metabase has minimal transition animations in it, but we have not yet tested whether the range of flickering is always between 2 and 55 Hertz.
+- Metabase's data tables do not have row and column headers identified in markup.
 - We do not yet have a published description of our accessibility and compatibility features.
-- Also note that Metabase is a React-based web application, and cannot function without scripting (i.e., JavaScript) turned on.
+- Since Metabase is a React-based web application, it cannot function without scripting (i.e., JavaScript) turned on.
+
+If you would like to help us address these, please see [our developers' guide][developers-guide].
+
+[508-accessibility]: https://section508.gov/
+[developers-guide]: /docs/latest/developers-guide.html

--- a/docs/faq/general/supported-browsers.md
+++ b/docs/faq/general/supported-browsers.md
@@ -1,14 +1,11 @@
-## Browser Support
+## What browsers does Metabase support?
 
-### Which browsers does Metabase support?
+We try our best to make sure Metabase works in as many browsers as possible, but as this is the Internet, there may be little quirks from time to time in different settings. We believe Metabase works on these versions of these browsers and will attempt to fix specific bugs if any are found:
 
-We try our best to make sure Metabase works in as many browsers as possible but as this is the internet, there may be little quirks from time to time in different settings. Here are the browsers and major supported versions we know Metabase will work on (and will attempt to fix browser specific bugs on if found).
-
-- Chrome (v 70+)
-- Internet Explorer 11. (Note: we'll be dropping support for IE11 in Metabase 0.40. It'll likely still work, but you may see some unexpected behavior.)
+- Chrome (v70+)
 - Firefox (v68+)
-- Microsoft Edge (17+)
+- Microsoft Edge (v17+)
 - Safari (v11+)
+- Internet Explorer 11 (We ended support for IE11 in Metabase 0.40; it mostly still works, but you may see some unexpected behavior)
 
-Metabase _may_ run perfectly fine on older versions of your browser of choice or a specific browser not listed above, but your mileage may vary. We always recommend you use the most up to date browser you can.
-
+Metabase may run perfectly well on older versions of these browsers or on specific browsers not listed above, but your mileage may vary. We always recommend you use the most up to date browser you can.

--- a/docs/faq/general/what-if-i-find-a-bug.md
+++ b/docs/faq/general/what-if-i-find-a-bug.md
@@ -1,3 +1,5 @@
 # What if I find a bug?
 
-If you think something isn’t working the way it’s supposed to, take a look at our [bug filing](../../troubleshooting-guide/bugs.md) guide.
+If you think something isn't working the way it's supposed to, please [file a bug report][filing-bugs].
+
+[filing-bugs]: ../../troubleshooting-guide/bugs.md

--- a/docs/faq/general/what-languages-can-be-used-with-metabase.md
+++ b/docs/faq/general/what-languages-can-be-used-with-metabase.md
@@ -1,16 +1,16 @@
 # What languages can be used with Metabase?
 
-Thanks to our amazing user community, Metabase has been translated into a variety of languages. Due to the nature of how we collect translations (more on that in a minute), available languages may be added or removed during major releases, depending on the translation coverage.
+Thanks to our amazing user community, Metabase has been translated into many different languages. Due to [the way we collect translations](#policy-for-adding-and-removing-translations), languages may be added or removed during major releases depending on translation coverage.
 
-## Currently available languages
+### Currently available languages
 
-The languages you can currently pick from in Metabase are:
+The languages you can currently pick from are:
 
 - English (default)
 - Bulgarian
 - Catalan
-- Chinese, simplified
-- Chinese, traditional
+- Chinese (simplified)
+- Chinese (traditional)
 - Czech
 - Dutch
 - Farsi/Persian
@@ -30,12 +30,14 @@ The languages you can currently pick from in Metabase are:
 - Ukrainian
 - Vietnamese
 
-## Policy for adding and removing translations
+### Policy for adding and removing translations
 
-The community contributes to Metabase translations on our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh). If you're a fan of Metabase and would like to see it made available in a language you're fluent in, we'd love your help!
+Our community contributes to Metabase translations on our [POEditor project][metabase-poe]. If you'd like to help make Metabase available in a language you're fluent in, we'd love your help!
 
-For new translations to be added to Metabase they must reach 100%. Once they have, we'll add them in the next major or minor release of Metabase. All _existing_ translations in Metabase _must stay at 100%_ to continue being included in the next _major_ version of Metabase. This is to ensure that no one encounters a confusing mishmash of English and another language when using Metabase.
+For a new translation to be added to Metabase it must reach 100%. Once it does, we add it in the next major or minor release of Metabase. All _existing_ translations in Metabase _must stay at 100%_ to continue being included in the next _major_ version of Metabase. This is to ensure that no one encounters a confusing mishmash of English and another language when using Metabase.
 
-We understand that this is a high bar, so we commit to making sure that before each major release, any additions or changes to text in the product will be completed at least 10 calendar days before the final release ships, at which point we notify all translators that a new release will be happening soon.
+We understand that this is a high bar, so we commit to making sure that before each major release, any additions or changes to text in the product are completed at least 10 calendar days before the release ships, at which point we notify all translators that a new release will be happening soon.
 
-Note that while we will only remove languages in major releases, we will add them back in for minor releases — so it's always a good time to jump in and start translating!
+Note that while we only remove languages in major releases, we are happy to add them back for minor releases, so it's always a good time to jump in and start translating.
+
+[metabase-poe]: https://poeditor.com/join/project/ynjQmwSsGh

--- a/docs/faq/setup/how-do-i-integrate-with-sso.md
+++ b/docs/faq/setup/how-do-i-integrate-with-sso.md
@@ -1,3 +1,8 @@
 # How do I integrate Metabase and our single-sign on (SSO) option?
 
-The open-source edition of Metabase allows you to [integrate with LDAP or Google sign-in](../../administration-guide/10-single-sign-on.md). If you’re using a [SAML](../../enterprise-guide/authenticating-with-saml.md) or [JWT](../../enterprise-guide/authenticating-with-jwt.md) SSO solution, you will need the [Enterprise Edition](https://www.metabase.com/enterprise/).
+The Open Source Edition of Metabase allows you to [integrate with LDAP or Google sign-in][single-sign-on]. If you're using [SAML][saml-auth] or [JWT][jwt-auth] for SSO, you will need the [Enterprise Edition][enterprise-edition].
+
+[enterprise-edition]: /enterprise/
+[jwt-auth]: ../../enterprise-guide/authenticating-with-jwt.md
+[saml-auth]: ../../enterprise-guide/authenticating-with-saml.md
+[single-sign-on]: ../../administration-guide/10-single-sign-on.md

--- a/docs/faq/setup/i-am-having-trouble-running-metabase.md
+++ b/docs/faq/setup/i-am-having-trouble-running-metabase.md
@@ -1,3 +1,6 @@
 # I'm having trouble running Metabase.
 
-If you’re having trouble running Metabase, we recommend starting with our [troubleshooting guides](../../troubleshooting-guide/index.md).
+We have tried to make it easy to set up and run Metabase, but it does need to interact with other systems. If you're having trouble running it, please take a look at our [troubleshooting guides][troubleshooting-guides] and our [tutorial articles][learn].
+
+[learn]: /learn/
+[troubleshooting-guides]: ../../troubleshooting-guide/index.md

--- a/docs/faq/setup/what-is-h2.md
+++ b/docs/faq/setup/what-is-h2.md
@@ -1,3 +1,5 @@
 # What's H2?
 
-H2 is the underlying application database that’s packaged with Metabase. H2 is a lightweight, in-memory database: perfect for getting spun up quickly, not so perfect for long-term usage. We recommend that you [migrate away from H2](../../operations-guide/migrating-from-h2.md) for production instances of Metabase.
+H2 is a lightweight, in-memory database; it's perfect for getting spun up quickly, but not so good for long-term usage. By default, Metabase uses H2 to store its internal data; we recommend that you [migrate off H2][migrate-off-h2] for production instances.
+
+[migrate-off-h2]: ../../operations-guide/migrating-from-h2.md

--- a/docs/faq/setup/when-should-i-migrate-h2.md
+++ b/docs/faq/setup/when-should-i-migrate-h2.md
@@ -1,3 +1,5 @@
-# When should I migrate H2 to mySQL or Postgres?
+# When should I migrate from H2 to MySQL or Postgres?
 
-As soon as you’re planning on using Metabase for anything other than testing. H2 is fairly easily corruptible, so it’s better to be safe than sorry when running Metabase in production. The migration is fairly simple, and [full instructions](../../operations-guide/migrating-from-h2.md) are available.
+As soon as you plan to use Metabase for anything other than testing: H2 is neither as fast or as robust as production database systems. The migration is fairly simple; please see [this guide][migrate-off-h2] for instructions.
+
+[migrate-off-h2]: ../../operations-guide/migrating-from-h2.md

--- a/docs/faq/setup/which-databases-does-metabase-support.md
+++ b/docs/faq/setup/which-databases-does-metabase-support.md
@@ -1,5 +1,6 @@
 # Which databases does Metabase support?
 
-See [our list of officially supported databases](../../administration-guide/01-managing-databases.md#officially-supported-databases).
+Please see [our list of officially supported databases][supported-databases]. There are also [community-built database drivers][community-drivers] for databases that we do not currently support, and you are always welcome to build your own.
 
-You may find some [community-built database drivers](../../developers-guide-drivers.md) for databases that we do not currently support - and you are always welcome to build your own!
+[community-drivers]: ../../developers-guide-drivers.md
+[supported-databases]: ../../administration-guide/01-managing-databases.md#officially-supported-databases

--- a/docs/faq/start.md
+++ b/docs/faq/start.md
@@ -19,14 +19,14 @@ Here is a list of some frequently asked questions about Metabase.
 - [Which databases does Metabase support?](setup/which-databases-does-metabase-support.md)
 - [I'm having trouble running Metabase.](setup/i-am-having-trouble-running-metabase.md)
 - [What's H2?](setup/what-is-h2.md)
-- [When should I migrate H2 to MySQL or Postgres?](setup/when-should-i-migrate-h2.md)
+- [When should I migrate from H2 to MySQL or Postgres?](setup/when-should-i-migrate-h2.md)
 - [How do I integrate Metabase and our single-sign on (SSO) solution?](setup/how-do-i-integrate-with-sso.md)
 
 ## Using Metabase
 
 - [How do I reset my password?](using-metabase/how-do-i-reset-my-password.md)
-- [How do I ask questions about my data?](using-metabase/how-do-i-ask-questions.md)
-- [I'm not getting the email notifications I expect to!](using-metabase/i-am-not-getting-email-notifications.md)
+- [How do I ask questions about my organization's data?](using-metabase/how-do-i-ask-questions.md)
+- [I'm not getting the email notifications I expect to.](using-metabase/i-am-not-getting-email-notifications.md)
 - [How do I answer questions about data that lives in multiple databases?](using-metabase/how-do-i-answer-questions-when-data-is-in-multiple-databases.md)
 - [How do I answer questions where I need to join tables together?](using-metabase/how-do-i-answer-questions-with-joins.md)
-- [I’m trying to ask a question, but it looks like I can’t access some of the data I need.](using-metabase/cant-access-data-i-need.md)
+- [I'm trying to ask a question, but it looks like I can't access some of the data I need.](using-metabase/cant-access-data-i-need.md)

--- a/docs/faq/using-metabase/cant-access-data-i-need.md
+++ b/docs/faq/using-metabase/cant-access-data-i-need.md
@@ -1,12 +1,14 @@
-# I’m trying to ask a question, but it looks like I can’t access some of the data I need.
+# I'm trying to ask a question, but it looks like I can't access some of the data I need.
 
-There are a few reasons that this may be occurring:
+This can occur for several reasons:
 
-- The data source containing the data may not be connected to Metabase. If you are an administrator, you can see a list of all of your connected data sources by clicking the gear icon, navigating to the Admin Panel, then clicking Databases in the top navigation. 
-- You may not have permission to access the data in question. Your administrator may need to [adjust your access](../../administration-guide/05-setting-permissions.md) by changing or modifying your user group.
-- The data may live in a different table other than the one you selected to begin the question. 
- - If you are using a Metabase version earlier than 0.33, you will need to either write a SQL query that contains joins, or have your Metabase administrator [set up foreign keys](../../administration-guide/03-metadata-editing.md)). 
- - If you are using Metabase 0.33 or above, you can perform joins using the Notebook editor. Note that you will need to choose a field to join on, or link, the two tables together. For instance, if you want to combine a Customer table with an Order table, you might select the ID field in the Customer table and link it to the customer_id field in the order table.
+- *The data source containing the data may not be connected to Metabase.* If you are an administrator, you can see a list of all of your connected data sources by clicking the gear icon, navigating to the Admin Panel, then clicking Databases in the top navigation.
+
+- *You may not have permission to access the data in question.* Your administrator may need to [adjust your permissions][setting-permissions] by changing or modifying your user group.
+
+- *The data may live in a different table other than the one you began the question with.*
+ - If you are using Metabase version 0.32 or earlier, you will need to either write a SQL query that contains joins, or have your Metabase administrator [set up foreign keys][editing-metadata].
+ - If you are using Metabase version 0.33 or above, you can perform joins using the Notebook Editor.
  
-* The data may live in a different database than the one you selected to begin the question. Metabase does not currently support joining across multiple databases. Generally, it is better to bring related data into the same database.
-
+[editing-metadata]: ../../administration-guide/03-metadata-editing.md
+[setting-permissions]: ../../administration-guide/05-setting-permissions.md

--- a/docs/faq/using-metabase/how-do-i-answer-questions-when-data-is-in-multiple-databases.md
+++ b/docs/faq/using-metabase/how-do-i-answer-questions-when-data-is-in-multiple-databases.md
@@ -1,3 +1,3 @@
 # How do I answer questions about data that lives in multiple databases?
 
-Metabase does not currently support joining across multiple databases. Generally, it is better to bring related data into the same database.
+Metabase does not currently support joining tables across multiple databases. It is generally better to bring related data into a single database.

--- a/docs/faq/using-metabase/how-do-i-answer-questions-with-joins.md
+++ b/docs/faq/using-metabase/how-do-i-answer-questions-with-joins.md
@@ -1,5 +1,8 @@
 # How do I answer questions where I need to join tables together?
 
-If you are using a Metabase version earlier than 0.33, you will need to either write a SQL query that contains joins, or have your Metabase administrator set up foreign keys (they can read more about that [here](../../administration-guide/03-metadata-editing.md)).
+If you are using Metabase version 0.32 or earlier, you will need to either write a SQL query that contains joins or have your Metabase administrator set up foreign keys: they can read more about that [here][editing-metadata].
 
-If you are using Metabase 0.33 or above, you can [perform joins using the Notebook editor](https://www.metabase.com/blog/joining-tables/index.html).
+If you are using Metabase 0.33 or above, you can [perform joins using the Notebook editor][notebook-editor-joins], but you should probably upgrade anyway.
+
+[editing-metadata]: ../../administration-guide/03-metadata-editing.md
+[notebook-editor-joins]: /learn/questions/joins-in-metabase.html

--- a/docs/faq/using-metabase/how-do-i-ask-questions.md
+++ b/docs/faq/using-metabase/how-do-i-ask-questions.md
@@ -1,3 +1,5 @@
 # How do I ask questions about my organization's data?
 
-Metabase provides a variety of ways to ask questions about your organization’s data, from using our GUI interface to construct a question, to writing a SQL query from scratch. Read all about how to ask questions [here](../../users-guide/04-asking-questions.md).
+Metabase provides many ways to ask questions about your organization's data, from our GUI interface to to writing a SQL query from scratch. Read all about how to ask questions in [our users' guide][users-guide-asking-questions].
+
+[users-guide-asking-questions]: ../../users-guide/04-asking-questions.md

--- a/docs/faq/using-metabase/how-do-i-reset-my-password.md
+++ b/docs/faq/using-metabase/how-do-i-reset-my-password.md
@@ -2,21 +2,21 @@
 
 ### Using the Mac App
 
-If you're running the MacOS application on your laptop, you can click on the Help menu item and click `Reset Password`.
+If you're running the MacOS application on your laptop, click on the Help menu item and select `Reset Password`.
 
 ### Using the web app as a normal user
 
-If you're having trouble logging in due to a forgotten password, click the link that reads, "I seem to have forgotten my password" in the lower-right of the log-in screen. If your Metabase administrator has already [configured your email settings](../../administration-guide/02-setting-up-email.md), you'll receive a password reset email. If email has not been configured, you will need to contact a Metabase admin to perform a password reset via Admin Panel > People.
+Click the link in the lower-right of the login screen that reads, "I seem to have forgotten my password". If your Metabase administrator has already [set up email][setting-up-email] you will receive a password reset email. If email has not been configured, you will need to contact a Metabase admin to perform a password reset, which they can do by going to the Admin Panel and selecting the People tab.
 
 ### Using the web app as an administrator
 
-If you're the administrator of Metabase and have access to the server console, but have forgotten the password for your admin account, then you can get a reset token, which can be used to setup a new password.
+If you're the administrator of Metabase and have access to the server console, but have forgotten the password for your admin account, you can get Metabase to send you a password reset token. To do this, stop the running Metabase application, then start Metabase with the parameters `reset-password email@example.com` (where "email@example.com" is the email associated with the admin account).
 
-To get the token, stop the running Metabase application, then start Metabase with the parameters `reset-password email@example.com` (where "email@example.com" is the email associated with the admin account).
+```
+java -jar metabase.jar reset-password email@example.com
+```
 
-Example: `java -jar metabase.jar reset-password email@example.com`
-
-This will return a token and stop Metabase again, like this:
+This will return a token. Stop Metabase again like this:
 
 ```
 ...
@@ -25,8 +25,12 @@ Resetting password for email@example.com...
 OK [[[1_7db2b600-d538-4aeb-b4f7-0cf5b1970d89]]]
 ```
 
-Now start Metabase normally again and navigate to the URL where you're running it, with the following path appended: `/auth/reset_password/:token`, where ":token" is the token that was generated from the step above.
+Now start Metabase normally again and navigate to it in your browser, using the path `/auth/reset_password/:token`, where ":token" is the token that was generated from the step above. The full URL should look like this:
 
-Example: `https://metabase.example.com/auth/reset_password/1_7db2b600-d538-4aeb-b4f7-0cf5b1970d89`
+```
+https://metabase.example.com/auth/reset_password/1_7db2b600-d538-4aeb-b4f7-0cf5b1970d89
+```
 
 You should now see a page where you can input a new password for the admin account.
+
+[setting-up-email]: ../../administration-guide/02-setting-up-email.md

--- a/docs/faq/using-metabase/i-am-not-getting-email-notifications.md
+++ b/docs/faq/using-metabase/i-am-not-getting-email-notifications.md
@@ -1,3 +1,5 @@
-# I’m not getting the email notifications I expect to!
+# I'm not getting the email notifications I expect to.
 
-Since Metabase is a self-hosted tool, things like email notifications are configured by someone within your organization — if you reach out to them, they should be able to check the configuration settings and make sure everything is set up correctly. It may help to point them to [this guide](../../administration-guide/02-setting-up-email.md) on enabling email functionality.
+Since Metabase is a self-hosted tool, email notifications must be configured by someone in your organization. They should be able to check the configuration settings and make sure everything is set up correctly; it may help to point them to [this guide][setting-up-email].
+
+[setting-up-email]: ../../administration-guide/02-setting-up-email.md


### PR DESCRIPTION
- Minor updates to wording.
- Changed a couple of links to point at /learn articles.
- Moved all out-of-page links into page foot to simplify consistency checking.

Have not validated by building locally - we really should make that easier.