### PR TITLE
Fix dashboard card hovering buttons drag behaviour

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard.jsx
@@ -92,6 +92,10 @@ export default class DashCard extends Component {
     }));
   };
 
+  preventDragging = e => {
+    e.stopPropagation();
+  };
+
   render() {
     const {
       dashcard,
@@ -177,7 +181,7 @@ export default class DashCard extends Component {
         }
       >
         {isEditingDashboardLayout ? (
-          <DashboardCardActionsPanel className="drag-disabled">
+          <DashboardCardActionsPanel onMouseDown={this.preventDragging}>
             <DashCardActionButtons
               series={series}
               hasError={!!errorMessage}


### PR DESCRIPTION
After dashboards' drag-n-drop upgrade at #16255, clicking dashboard cards' hover action buttons is sometimes treated as a beginning of a drag gesture. This PR fixes that by disabling mouse event propagations from the buttons component.

### To Verify

Could be tricky to reproduce, take a look the the "before" demo video to get an idea

1. Open any dashboard with cards
2. Click the pencil icon in the header to switch to editing mode
3. Hover any card, a panel with action buttons will appear in the top left
4. Try clicking the buttons, it should not lead to card dragging

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/126361460-50ca682e-d35c-42dd-a8b5-ff62b1a8dd94.mov

**After**

https://user-images.githubusercontent.com/17258145/126361573-18b78735-144b-414f-b090-3d1d357f6d4f.mov
