### PR TITLE
🍒 Fix can't select markdown card text when editing a dashboard

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/Text.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Text.jsx
@@ -98,6 +98,8 @@ export default class Text extends Component {
     this.props.onUpdateVisualizationSettings({ text: text });
   }
 
+  preventDragging = e => e.stopPropagation();
+
   render() {
     const { className, gridSize, settings, isEditing } = this.props;
     const isSingleRow = gridSize && gridSize.height === 1;
@@ -124,6 +126,9 @@ export default class Text extends Component {
               placeholder={t`Write here, and use Markdown if you'd like`}
               value={settings.text}
               onChange={e => this.handleTextChange(e.target.value)}
+              // Prevents text cards from dragging when you actually want to select text
+              // See: https://github.com/metabase/metabase/issues/17039
+              onMouseDown={this.preventDragging}
             />
           )}
         </div>


### PR DESCRIPTION
Cherry-picked #17124 targeting `release-x.40.x`