### PR TITLE
Add Metabase Cloud link to admin settings for hosted instances

### DIFF
--- a/frontend/src/metabase/admin/settings/components/SettingsCloudStoreLink/SettingsCloudStoreLink.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsCloudStoreLink/SettingsCloudStoreLink.jsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { t } from "ttag";
+import MetabaseSettings from "metabase/lib/settings";
+import { Description, Link, LinkIcon } from "./SettingsCloudStoreLink.styled";
+
+export function SettingsCloudStoreLink() {
+  const url = MetabaseSettings.storeUrl();
+  return (
+    <div>
+      <Description>{t`Manage your Cloud account, including billing preferences and technical settings about this instance in your Metabase Store account.`}</Description>
+      <Link href={url}>
+        {t`Go to the Metabase Store`}
+        <LinkIcon name="external" />
+      </Link>
+    </div>
+  );
+}

--- a/frontend/src/metabase/admin/settings/components/SettingsCloudStoreLink/SettingsCloudStoreLink.styled.js
+++ b/frontend/src/metabase/admin/settings/components/SettingsCloudStoreLink/SettingsCloudStoreLink.styled.js
@@ -1,0 +1,30 @@
+import styled from "styled-components";
+import { color } from "metabase/lib/colors";
+import ExternalLink from "metabase/components/ExternalLink";
+import Icon from "metabase/components/Icon";
+
+export const Description = styled.p`
+  color: ${color("text-dark")};
+  max-width: 360px;
+`;
+
+export const Link = styled(ExternalLink)`
+  display: inline-flex;
+  align-items: center;
+  color: ${color("text-white")};
+  font-weight: bold;
+  background-color: ${color("brand")};
+  padding: 12px 18px;
+  border-radius: 6px;
+
+  &:hover {
+    opacity: 0.88;
+    transition: all 200ms linear;
+  }
+`;
+
+export const LinkIcon = styled(Icon)`
+  color: ${color("text-white")};
+  opacity: 0.6;
+  margin-left: 8px;
+`;

--- a/frontend/src/metabase/admin/settings/components/SettingsCloudStoreLink/index.js
+++ b/frontend/src/metabase/admin/settings/components/SettingsCloudStoreLink/index.js
@@ -1,0 +1,1 @@
+export * from "./SettingsCloudStoreLink";

--- a/frontend/src/metabase/admin/settings/components/widgets/EmbeddingLevel.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/EmbeddingLevel.jsx
@@ -5,9 +5,11 @@ import SettingsInput from "./SettingInput";
 import cx from "classnames";
 
 import ExternalLink from "metabase/components/ExternalLink";
+import MetabaseSettings from "metabase/lib/settings";
 
-const PREMIUM_EMBEDDING_STORE_URL =
-  "https://store.metabase.com/product/embedding";
+const PREMIUM_EMBEDDING_STORE_URL = MetabaseSettings.storeUrl(
+  "product/embedding",
+);
 const PREMIUM_EMBEDDING_SETTING_KEY = "premium-embedding-token";
 
 class PremiumTokenInput extends Component {

--- a/frontend/src/metabase/admin/settings/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors.js
@@ -16,6 +16,7 @@ import EmbeddingLegalese from "./components/widgets/EmbeddingLegalese";
 import EmbeddingLevel from "./components/widgets/EmbeddingLevel";
 import FormattingWidget from "./components/widgets/FormattingWidget";
 
+import { SettingsCloudStoreLink } from "./components/SettingsCloudStoreLink";
 import SettingsUpdatesForm from "./components/SettingsUpdatesForm/SettingsUpdatesForm";
 import SettingsEmailForm from "./components/SettingsEmailForm";
 import SettingsSetupList from "./components/SettingsSetupList";
@@ -391,6 +392,22 @@ const SECTIONS = updateSectionsWithPlugins({
     ],
   },
 });
+
+if (MetabaseSettings.isHosted()) {
+  const allSections = Object.values(SECTIONS);
+  const lastSection = _.max(allSections, "order");
+  SECTIONS.cloud = {
+    name: t`Cloud`,
+    order: lastSection.order + 1,
+    settings: [
+      {
+        key: "store-link",
+        display_name: t`Cloud Settings`,
+        widget: SettingsCloudStoreLink,
+      },
+    ],
+  };
+}
 
 export const getSettings = createSelector(
   state => state.admin.settings.settings,

--- a/frontend/src/metabase/lib/settings.js
+++ b/frontend/src/metabase/lib/settings.js
@@ -157,6 +157,10 @@ class Settings {
     return `https://www.metabase.com/docs/${tag}/${page}${anchor}`;
   }
 
+  storeUrl(path = "") {
+    return `https://store.metabase.com/${path}`;
+  }
+
   newVersionAvailable() {
     const result = MetabaseUtils.compareVersions(
       this.currentVersion(),

--- a/frontend/src/metabase/nav/components/ProfileLink.jsx
+++ b/frontend/src/metabase/nav/components/ProfileLink.jsx
@@ -49,7 +49,7 @@ export default class ProfileLink extends Component {
         admin && [
           {
             title: t`Manage Metabase Cloud`,
-            link: "https://store.metabase.com/login",
+            link: MetabaseSettings.storeUrl("login"),
             event: `Navbar;Profile Dropdown;ManageHosting ${tag}`,
             externalLink: true,
           },

--- a/frontend/test/metabase/scenarios/admin/settings/cloud.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/cloud.cy.spec.js
@@ -1,0 +1,37 @@
+import { restore } from "__support__/e2e/cypress";
+
+describe("Cloud settings section", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should be visible when running Metabase Cloud", () => {
+    setupMetabaseCloud();
+    cy.visit("/admin");
+    cy.get(".AdminList-items")
+      .findByText("Cloud")
+      .click();
+    cy.findByText(/Cloud Settings/i);
+    cy.findByText("Go to the Metabase Store").should(
+      "have.attr",
+      "href",
+      "https://store.metabase.com/",
+    );
+  });
+
+  it("should be invisible when self-hosting", () => {
+    cy.visit("/admin");
+    cy.get(".AdminList-items")
+      .findByText("Cloud")
+      .should("not.exist");
+    cy.visit("/admin/settings/cloud");
+    cy.findByText(/Cloud Settings/i).should("not.exist");
+  });
+});
+
+function setupMetabaseCloud() {
+  cy.request("PUT", "/api/setting/site-url", {
+    value: "https://CYPRESSTESTENVIRONMENT.metabaseapp.com",
+  });
+}


### PR DESCRIPTION
Although we added a Metabase Store link in #14511, people still miss it from time to time. This PR adds a dedicated Cloud settings section with a link to Metabase Store. It's only visible to hosted Metabase instances (running in Metabase Cloud)

### To Verify

The only way to launch Metabase in the "cloud" context I could come out with is to patch the `MetabaseSettings.isHosted` method. So please go to [`frontend/src/metabase/lib/settings.js`](https://github.com/metabase/metabase/blob/b5d48172472c2bd32157e1df088b6504a4f545a0/frontend/src/metabase/lib/settings.js#L91) and replace the body with `return true` 🏴‍☠️

1. Sign in as admin
2. Go to `/admin`
3. In the left sidebar you should see "Cloud" as the last option, click it
4. You should see a page with a button leading to `https://store.metabase.com/`

### Demo

![image](https://user-images.githubusercontent.com/17258145/126370678-3db51f9e-42ae-44f5-bdf3-d33c26e4b29c.png)
