### PR TITLE
Do not change route in case collection archiving is cancelled

### DIFF
--- a/frontend/src/metabase/components/ArchiveCollectionModal.jsx
+++ b/frontend/src/metabase/components/ArchiveCollectionModal.jsx
@@ -35,11 +35,14 @@ class ArchiveCollectionModal extends React.Component {
   close = () => {
     const { onClose, object, push } = this.props;
     onClose();
-    const parent =
-      object.effective_ancestors.length > 0
-        ? object.effective_ancestors.pop()
-        : null;
-    push(Urls.collection(parent));
+
+    if (object.archived) {
+      const parent =
+        object.effective_ancestors.length > 0
+          ? object.effective_ancestors.pop()
+          : null;
+      push(Urls.collection(parent));
+    }
   };
 
   render() {

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -264,7 +264,7 @@ describe("collection permissions", () => {
                     // });
                   });
 
-                  it.skip("abandoning archive process should keep you in the same collection (metabase#15289)", () => {
+                  it("abandoning archive process should keep you in the same collection (metabase#15289)", () => {
                     cy.request("GET", "/api/collection").then(xhr => {
                       const { id: THIRD_COLLECTION_ID } = xhr.body.find(
                         collection => collection.slug === "third_collection",
@@ -277,7 +277,7 @@ describe("collection permissions", () => {
                         .click();
                       cy.location("pathname").should(
                         "eq",
-                        `/collection/${THIRD_COLLECTION_ID}`,
+                        `/collection/${THIRD_COLLECTION_ID}-third-collection`,
                       );
                       cy.get("[class*=PageHeading]")
                         .as("title")


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/15289

The issue was that the dialog always changed the route when it was closed. I made the change in the same as it is in `ArchiveDashboardModal`.