### PR TITLE
#17139 Repro: Clicking on cancel edit dashboard without any changes removes the dashboard filter

### DIFF
--- a/frontend/test/__support__/e2e/helpers/e2e-dashboard-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-dashboard-helpers.js
@@ -13,3 +13,26 @@ export function showDashboardCardActions(index = 0) {
     .eq(index)
     .realHover();
 }
+
+export function editDashboard() {
+  cy.icon("pencil").click();
+}
+
+export function cancelEditingDashboard() {
+  cy.findByText("Cancel").click();
+  cy.findByText("You're editing this dashboard.").should("not.exist");
+}
+
+export function saveDashboard() {
+  cy.findByText("Save").click();
+  cy.findByText("You're editing this dashboard.").should("not.exist");
+}
+
+export function checkFilterLabelAndValue(label, value) {
+  cy.get("fieldset")
+    .find("legend")
+    .invoke("text")
+    .should("eq", label);
+
+  cy.get("fieldset").contains(value);
+}

--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/17139.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/17139.cy.spec.js
@@ -1,0 +1,56 @@
+import {
+  restore,
+  popover,
+  mockSessionProperty,
+  filterWidget,
+  editDashboard,
+  cancelEditingDashboard,
+  saveDashboard,
+  checkFilterLabelAndValue,
+} from "__support__/e2e/cypress";
+
+import { setMonthAndYear } from "../../native-filters/helpers/e2e-date-filter-helpers";
+
+describe.skip("issue 17139", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+    mockSessionProperty("field-filter-operators-enabled?", true);
+
+    cy.visit("/dashboard/1");
+
+    editDashboard();
+
+    cy.icon("filter").click();
+    popover().within(() => {
+      cy.findByText("What do you want to filter?");
+      cy.findByText("Time").click();
+      cy.findByText("Month and Year").click();
+    });
+
+    cy.findByText("Select…").click();
+    popover()
+      .contains("Created At")
+      .first()
+      .click();
+
+    saveDashboard();
+  });
+
+  it("should not reset previously defined filters when exiting 'edit' mode without making any changes (metabase#17139)", () => {
+    filterWidget()
+      .contains("Month and Year")
+      .click();
+
+    setMonthAndYear({ month: "November", year: "2016" });
+
+    cy.url().should("contain", "?month_and_year=2016-11");
+    checkFilterLabelAndValue("Month and Year", "November, 2016");
+
+    editDashboard();
+    cancelEditingDashboard();
+
+    cy.url().should("contain", "?month_and_year=2016-11");
+    checkFilterLabelAndValue("Month and Year", "November, 2016");
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #17139 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/dashboard-filters/reproductions/17139.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/126394641-6aeeed71-83e1-4cc0-ad98-8bcefae1ec69.png)

