### PR TITLE
Fix waterfall visualization with ordinal and numeric X-axis

### DIFF
--- a/frontend/src/metabase/lib/constants.js
+++ b/frontend/src/metabase/lib/constants.js
@@ -8,4 +8,9 @@ export const NULL_NUMERIC_VALUE = -Infinity;
 
 export const NULL_DISPLAY_VALUE = t`(empty)`;
 
+// Hack to work with numeric and string x values in waterfall charts
+// Must be a unique string which can be converted to a number since
+// crossfilter converts strings to numbers when grouping starts with numeric data
+export const TOTAL_ORDINAL_VALUE = "Infinity";
+
 export const SAVED_QUESTIONS_VIRTUAL_DB_ID = -1337;

--- a/frontend/src/metabase/visualizations/lib/apply_axis.js
+++ b/frontend/src/metabase/visualizations/lib/apply_axis.js
@@ -278,7 +278,6 @@ export function applyChartQuantitativeXAxis(
     ) {
       throw "X-axis must not cross 0 when using log scale.";
     }
-    ``;
   } else {
     scale = d3.scale.linear();
   }

--- a/frontend/src/metabase/visualizations/lib/apply_axis.js
+++ b/frontend/src/metabase/visualizations/lib/apply_axis.js
@@ -278,6 +278,7 @@ export function applyChartQuantitativeXAxis(
     ) {
       throw "X-axis must not cross 0 when using log scale.";
     }
+    ``;
   } else {
     scale = d3.scale.linear();
   }
@@ -301,6 +302,12 @@ export function applyChartOrdinalXAxis(
 
   const dimensionColumn = firstSeries.data.cols[0];
 
+  const waterfallTotalX =
+    firstSeries.card.display === "waterfall" &&
+    chart.settings["waterfall.show_total"]
+      ? xValues[xValues.length - 1]
+      : null;
+
   if (chart.settings["graph.x_axis.labels_enabled"]) {
     chart.xAxisLabel(
       chart.settings["graph.x_axis.title_text"] ||
@@ -315,14 +322,18 @@ export function applyChartOrdinalXAxis(
     chart.xAxis().ticks(xValues.length);
     adjustXAxisTicksIfNeeded(chart.xAxis(), chart.width(), xValues);
 
-    chart.xAxis().tickFormat(d =>
-      formatValue(d, {
+    chart.xAxis().tickFormat(d => {
+      if (waterfallTotalX && waterfallTotalX === d) {
+        return t`Total`;
+      }
+
+      return formatValue(d, {
         ...chart.settings.column(dimensionColumn),
         type: "axis",
         compact: chart.settings["graph.x_axis.labels_enabled"] === "compact",
         noRange: isHistogramBar,
-      }),
-    );
+      });
+    });
   } else {
     chart.xAxis().ticks(0);
     chart.xAxis().tickFormat("");

--- a/frontend/src/metabase/visualizations/lib/renderer_utils.js
+++ b/frontend/src/metabase/visualizations/lib/renderer_utils.js
@@ -347,9 +347,9 @@ export function xValueForWaterfallTotal({ settings, series }) {
   } else if (isQuantitative(settings) || isHistogram(settings)) {
     const lastXValue = xValues[xValues.length - 1];
     return lastXValue + xInterval;
-  } else if (series.every(({ data }) => dimensionIsNumeric(data))) {
-    const lastXValue = xValues[xValues.length - 1];
-    return lastXValue + 1;
+  } else if (isOrdinal(settings)) {
+    const maxXValue = xValues.reduce((a, b) => (a > b ? a : b), xValues[0]);
+    return maxXValue + 1;
   }
 
   return "Total";

--- a/frontend/src/metabase/visualizations/lib/renderer_utils.js
+++ b/frontend/src/metabase/visualizations/lib/renderer_utils.js
@@ -349,7 +349,7 @@ export function xValueForWaterfallTotal({ settings, series }) {
     return xValues[xValues.length - 1] + xInterval;
   }
 
-  return t`Total`;
+  return "Infinity";
 }
 
 /************************************************************ PROPERTIES ************************************************************/

--- a/frontend/src/metabase/visualizations/lib/renderer_utils.js
+++ b/frontend/src/metabase/visualizations/lib/renderer_utils.js
@@ -347,7 +347,7 @@ export function xValueForWaterfallTotal({ settings, series }) {
   } else if (isQuantitative(settings) || isHistogram(settings)) {
     const lastXValue = xValues[xValues.length - 1];
     return lastXValue + xInterval;
-  } else if (typeof xValues[0] === "number") {
+  } else if (series.every(({ data }) => dimensionIsNumeric(data))) {
     const lastXValue = xValues[xValues.length - 1];
     return lastXValue + 1;
   }

--- a/frontend/src/metabase/visualizations/lib/renderer_utils.js
+++ b/frontend/src/metabase/visualizations/lib/renderer_utils.js
@@ -345,15 +345,14 @@ export function xValueForWaterfallTotal({ settings, series }) {
     const lastXValue = xValues[xValues.length - 1];
     return lastXValue.clone().add(count, interval);
   } else if (isQuantitative(settings) || isHistogram(settings)) {
-    return xValues[xValues.length - 1] + xInterval;
+    const lastXValue = xValues[xValues.length - 1];
+    return lastXValue + xInterval;
+  } else if (typeof xValues[0] === "number") {
+    const lastXValue = xValues[xValues.length - 1];
+    return lastXValue + 1;
   }
 
-  // The exact value is not important, but:
-  // * it must be unique among xValues
-  // * if xValues are numbers, it must be a number or a numeric string
-  // * if xValues are strings, it must be a string
-  // Infinity satisfies conditions above
-  return "Infinity";
+  return "Total";
 }
 
 /************************************************************ PROPERTIES ************************************************************/

--- a/frontend/src/metabase/visualizations/lib/renderer_utils.js
+++ b/frontend/src/metabase/visualizations/lib/renderer_utils.js
@@ -5,7 +5,11 @@ import { getIn } from "icepick";
 
 import { datasetContainsNoResults } from "metabase/lib/dataset";
 import { parseTimestamp } from "metabase/lib/time";
-import { NULL_DISPLAY_VALUE, NULL_NUMERIC_VALUE } from "metabase/lib/constants";
+import {
+  NULL_DISPLAY_VALUE,
+  NULL_NUMERIC_VALUE,
+  TOTAL_ORDINAL_VALUE,
+} from "metabase/lib/constants";
 
 import {
   computeTimeseriesDataInverval,
@@ -345,14 +349,11 @@ export function xValueForWaterfallTotal({ settings, series }) {
     const lastXValue = xValues[xValues.length - 1];
     return lastXValue.clone().add(count, interval);
   } else if (isQuantitative(settings) || isHistogram(settings)) {
-    const lastXValue = xValues[xValues.length - 1];
-    return lastXValue + xInterval;
-  } else if (isOrdinal(settings)) {
-    const maxXValue = xValues.reduce((a, b) => (a > b ? a : b), xValues[0]);
-    return maxXValue + 1;
+    const maxXValue = _.max(xValues);
+    return maxXValue + xInterval;
   }
 
-  return "Total";
+  return TOTAL_ORDINAL_VALUE;
 }
 
 /************************************************************ PROPERTIES ************************************************************/

--- a/frontend/src/metabase/visualizations/lib/renderer_utils.js
+++ b/frontend/src/metabase/visualizations/lib/renderer_utils.js
@@ -349,6 +349,11 @@ export function xValueForWaterfallTotal({ settings, series }) {
     return xValues[xValues.length - 1] + xInterval;
   }
 
+  // The exact value is not important, but:
+  // * it must be unique among xValues
+  // * if xValues are numbers, it must be a number or a numeric string
+  // * if xValues are strings, it must be a string
+  // Infinity satisfies conditions above
   return "Infinity";
 }
 

--- a/frontend/src/metabase/visualizations/lib/renderer_utils.js
+++ b/frontend/src/metabase/visualizations/lib/renderer_utils.js
@@ -2,7 +2,6 @@
 
 import _ from "underscore";
 import { getIn } from "icepick";
-import { t } from "ttag";
 
 import { datasetContainsNoResults } from "metabase/lib/dataset";
 import { parseTimestamp } from "metabase/lib/time";

--- a/frontend/test/metabase/scenarios/visualizations/waterfall.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/waterfall.cy.spec.js
@@ -50,9 +50,9 @@ describe("scenarios > visualizations > waterfall", () => {
     verifyWaterfallRendering("PRODUCT", "PROFIT");
   });
 
-  it("should work with quantitative series", () => {
+  it("should work with ordinal series with numeric X-axis (metabase#15550)", () => {
     openNativeEditor().type(
-      "select 1 as xx, 10 as yy union select 2 as xx, -2 as yy",
+      "select 1 as X, 2 as Y union select -1 as X, -2 as Y",
     );
     cy.get(".NativeQueryEditor .Icon-play").click();
     cy.contains("Visualization").click();
@@ -60,12 +60,32 @@ describe("scenarios > visualizations > waterfall", () => {
 
     cy.contains("Select a field").click();
     cy.get(".List-item")
-      .first()
-      .click(); // X
+      .contains("X")
+      .click();
     cy.contains("Select a field").click();
     cy.get(".List-item")
-      .last()
-      .click(); // Y
+      .contains("Y")
+      .click();
+
+    verifyWaterfallRendering("X", "Y");
+  });
+
+  it("should work with quantitative series", () => {
+    openNativeEditor().type(
+      "select 1 as X, 10 as Y union select 2 as X, -2 as Y",
+    );
+    cy.get(".NativeQueryEditor .Icon-play").click();
+    cy.contains("Visualization").click();
+    cy.icon("waterfall").click();
+
+    cy.contains("Select a field").click();
+    cy.get(".List-item")
+      .contains("X")
+      .click();
+    cy.contains("Select a field").click();
+    cy.get(".List-item")
+      .contains("Y")
+      .click();
 
     verifyWaterfallRendering("XX", "YY");
   });

--- a/frontend/test/metabase/scenarios/visualizations/waterfall.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/waterfall.cy.spec.js
@@ -87,7 +87,7 @@ describe("scenarios > visualizations > waterfall", () => {
       .contains("Y")
       .click();
 
-    verifyWaterfallRendering("XX", "YY");
+    verifyWaterfallRendering("X", "Y");
   });
 
   it("should work with time-series data", () => {

--- a/frontend/test/metabase/scenarios/visualizations/waterfall.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/waterfall.cy.spec.js
@@ -52,8 +52,9 @@ describe("scenarios > visualizations > waterfall", () => {
 
   it("should work with ordinal series and numeric X-axis (metabase#15550)", () => {
     openNativeEditor().type(
-      "select 1 as X, 2 as Y union select -1 as X, -2 as Y",
+      "select 1 as X, 20 as Y union select 2 as X, -10 as Y",
     );
+
     cy.get(".NativeQueryEditor .Icon-play").click();
     cy.contains("Visualization").click();
     cy.icon("waterfall").click();
@@ -62,9 +63,17 @@ describe("scenarios > visualizations > waterfall", () => {
     cy.get(".List-item")
       .contains("X")
       .click();
+
     cy.contains("Select a field").click();
     cy.get(".List-item")
       .contains("Y")
+      .click();
+
+    cy.contains("Axes").click();
+
+    cy.contains("Linear").click();
+    cy.get(".List-item")
+      .contains("Ordinal")
       .click();
 
     verifyWaterfallRendering("X", "Y");

--- a/frontend/test/metabase/scenarios/visualizations/waterfall.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/waterfall.cy.spec.js
@@ -50,7 +50,7 @@ describe("scenarios > visualizations > waterfall", () => {
     verifyWaterfallRendering("PRODUCT", "PROFIT");
   });
 
-  it("should work with ordinal series with numeric X-axis (metabase#15550)", () => {
+  it("should work with ordinal series and numeric X-axis (metabase#15550)", () => {
     openNativeEditor().type(
       "select 1 as X, 2 as Y union select -1 as X, -2 as Y",
     );


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/15550

**Problem**
Waterfall visualization does not work with ordinal and numeric X-axis.

**Root cause**
Total values are used with `crossfilter`'s  `dimension` and `group` methods.  `dimension` has limitations https://github.com/square/crossfilter/wiki/API-Reference#dimension, most notably issues with mixed types, and the previous solution with static `Total` string didn't work when `xValues` were numeric. It made `group` treat `Total` as the last numeric value in the series, but `Total` should be a unique column by itself.

**Solution**
To not change the whole processing logic, we need to come with a unique value that will satisfy limitations of `dimension`. The exact value is not important, but:
1. It must be unique among `xValues`
2. If `xValues` are numbers, it must be a number or a numeric string
3. If `xValues` are strings, it must be a string

This fix:
1. Finds the max value for `xValues` in way that works both for numbers and strings
2. Adds `1` to the value, which would work correctly for a number or a string
3. Please note that `xValues` can be unsorted, so using the last value is incorrect.

**How to test manually**
1. Go to Native query question page
2. Run the following query:
```
select 0 as "a", 1 as "b" union all
select 1 as "a", 2 as "b" union all
select 5 as "a", 3 as "b"
```
3. Select Waterfall visualization mode and specify X-axis to be `a` and Y-axis to be `b`
4. Go to Axes -> X-axis scale: change it to Ordinal

**Notes**
The total behavior for `quantitative` and `histogram` waterfall charts are also broken, I'm going to fix it separately. 