### PR TITLE
change iframe-resizer height calculation method to max

### DIFF
--- a/frontend/src/metabase/lib/dom.js
+++ b/frontend/src/metabase/lib/dom.js
@@ -396,7 +396,7 @@ export function initializeIframeResizer(readyCallback = () => {}) {
   } else {
     window.iFrameResizer = {
       autoResize: true,
-      heightCalculationMethod: "bodyScroll",
+      heightCalculationMethod: "max",
       readyCallback: readyCallback,
     };
 


### PR DESCRIPTION
### Description
`iframe-resizer` incorrectly shrank embedded new question page. Even If pass `heightCalculationMethod="max"` prop to `IframeResizer` it was still overridden with `bodyScroll` value.

#### Before 
<img width="2304" alt="Screen Shot 2021-07-21 at 23 15 29" src="https://user-images.githubusercontent.com/14301985/126554089-7d4e44ea-4cb3-4227-9675-a2c9ac740f64.png">

#### After
<img width="2302" alt="Screen Shot 2021-07-21 at 23 09 46" src="https://user-images.githubusercontent.com/14301985/126554082-cd6c7840-14d4-421f-bdb3-0dacb1c7025a.png">

### How to verify
- Run Metabase EE and enable premium embedding in the admin settings
- Clone https://github.com/metabase/sso-examples and checkout `iframe-resizer-example`
- In the `sso-examples` repo start `app-embed-example` using `cd app-embed-example && npm i && npm run dev`
- Open directly `http://localhost:3001/analytics/question/new`
- Ensure the iframe is resized properly to fit the content

It is important to open this page directly, because if you open `http://localhost:3001/analytics` and then `http://localhost:3001/analytics/question/new` it will not be collapsed