### PR TITLE
Improve Collection Sidebar UI for mobile

### DIFF
--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.jsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.jsx
@@ -12,7 +12,9 @@ import Tooltip from "metabase/components/Tooltip";
 import CollectionEditMenu from "metabase/collections/components/CollectionEditMenu";
 
 import {
+  Container,
   DescriptionTooltipIcon,
+  MenuContainer,
   ToggleMobileSidebarIcon,
 } from "./CollectionHeader.styled";
 
@@ -101,11 +103,11 @@ function CreateCollectionLink({
 
 function Menu(props) {
   return (
-    <Flex ml="auto">
-      <PermissionsLink {...props} />
+    <MenuContainer>
       <EditMenu {...props} />
       <CreateCollectionLink {...props} />
-    </Flex>
+      <PermissionsLink {...props} />
+    </MenuContainer>
   );
 }
 
@@ -115,13 +117,13 @@ export default function CollectionHeader(props) {
   const hasWritePermission = collection && collection.can_write;
 
   return (
-    <Flex align="center" py={3}>
+    <Container>
       <Title {...props} />
       <Menu
         {...props}
         isPersonal={isPersonal}
         hasWritePermission={hasWritePermission}
       />
-    </Flex>
+    </Container>
   );
 }

--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.styled.js
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.styled.js
@@ -1,9 +1,26 @@
 import styled from "styled-components";
-import { color } from "metabase/lib/colors";
+import { Flex } from "grid-styled";
 
+import { color } from "metabase/lib/colors";
 import { breakpointMinSmall, space } from "metabase/styled-components/theme";
 
 import Icon from "metabase/components/Icon";
+
+export const Container = styled(Flex)`
+  justify-content: space-between;
+  flex-direction: column;
+  padding-top: ${space(0)};
+
+  ${breakpointMinSmall} {
+    align-items: center;
+    flex-direction: row;
+    padding-top: ${space(3)};
+  }
+`;
+
+export const MenuContainer = styled(Flex)`
+  margin-top: ${space(1)};
+`;
 
 export const ToggleMobileSidebarIcon = styled(Icon).attrs({
   name: "burger",

--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.styled.js
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.styled.js
@@ -9,6 +9,7 @@ import Icon from "metabase/components/Icon";
 export const Container = styled(Flex)`
   justify-content: space-between;
   flex-direction: column;
+  margin-bottom: ${space(3)};
   padding-top: ${space(0)};
 
   ${breakpointMinSmall} {

--- a/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebar.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebar.jsx
@@ -60,6 +60,11 @@ class CollectionSidebar extends React.Component {
     });
   };
 
+<<<<<<< HEAD
+=======
+  // TODO Should we update the API to filter archived collections?
+
+>>>>>>> a28a75352 (Extract Collections component)
   renderContent = () => {
     const {
       currentUser,
@@ -93,28 +98,14 @@ class CollectionSidebar extends React.Component {
           {({ collection: root }) => <Header isRoot={isRoot} root={root} />}
         </Collection.Loader>
 
-        <Box pb={4}>
-          <CollectionsList
-            openCollections={this.state.openCollections}
-            onClose={this.onClose}
-            onOpen={this.onOpen}
-            collections={list}
-            filter={nonPersonalOrArchivedCollection}
-            currentCollection={collectionId}
-          />
-
-          <Box>
-            <CollectionsList
-              openCollections={this.state.openCollections}
-              onClose={this.onClose}
-              onOpen={this.onOpen}
-              collections={currentUserPersonalCollections(list, currentUser.id)}
-              initialIcon="person"
-              filter={this.filterPersonalCollections}
-              currentCollection={collectionId}
-            />
-          </Box>
-        </Box>
+        <Collections
+          collectionId={collectionId}
+          currentUserId={currentUser.id}
+          list={list}
+          onClose={this.onClose}
+          onOpen={this.onOpen}
+          openCollections={this.state.openCollections}
+        />
 
         <Footer isSuperUser={currentUser.is_superuser} />
 >>>>>>> fc641cba8 (Extract Header into component)

--- a/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebar.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebar.jsx
@@ -60,11 +60,6 @@ class CollectionSidebar extends React.Component {
     });
   };
 
-<<<<<<< HEAD
-=======
-  // TODO Should we update the API to filter archived collections?
-
->>>>>>> a28a75352 (Extract Collections component)
   renderContent = () => {
     const {
       currentUser,
@@ -78,7 +73,6 @@ class CollectionSidebar extends React.Component {
         <ToggleMobileSidebarIcon onClick={handleToggleMobileSidebar} />
 
         <Collection.Loader id="root">
-<<<<<<< HEAD
           {({ collection: root }) => (
             <RootCollectionLink isRoot={isRoot} root={root} />
           )}
@@ -94,21 +88,6 @@ class CollectionSidebar extends React.Component {
         />
 
         <Footer isAdmin={currentUser.is_superuser} />
-=======
-          {({ collection: root }) => <Header isRoot={isRoot} root={root} />}
-        </Collection.Loader>
-
-        <Collections
-          collectionId={collectionId}
-          currentUserId={currentUser.id}
-          list={list}
-          onClose={this.onClose}
-          onOpen={this.onOpen}
-          openCollections={this.state.openCollections}
-        />
-
-        <Footer isSuperUser={currentUser.is_superuser} />
->>>>>>> fc641cba8 (Extract Header into component)
       </React.Fragment>
     );
   };

--- a/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebar.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebar.jsx
@@ -15,7 +15,6 @@ import {
 import RootCollectionLink from "./RootCollectionLink/RootCollectionLink";
 import Footer from "./CollectionSidebarFooter/CollectionSidebarFooter";
 import Collections from "./Collections/Collections";
-
 import LoadingSpinner from "metabase/components/LoadingSpinner";
 
 import { getParentPath } from "metabase/collections/utils";

--- a/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebar.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebar.jsx
@@ -73,6 +73,7 @@ class CollectionSidebar extends React.Component {
         <ToggleMobileSidebarIcon onClick={handleToggleMobileSidebar} />
 
         <Collection.Loader id="root">
+<<<<<<< HEAD
           {({ collection: root }) => (
             <RootCollectionLink isRoot={isRoot} root={root} />
           )}
@@ -88,6 +89,35 @@ class CollectionSidebar extends React.Component {
         />
 
         <Footer isAdmin={currentUser.is_superuser} />
+=======
+          {({ collection: root }) => <Header isRoot={isRoot} root={root} />}
+        </Collection.Loader>
+
+        <Box pb={4}>
+          <CollectionsList
+            openCollections={this.state.openCollections}
+            onClose={this.onClose}
+            onOpen={this.onOpen}
+            collections={list}
+            filter={nonPersonalOrArchivedCollection}
+            currentCollection={collectionId}
+          />
+
+          <Box>
+            <CollectionsList
+              openCollections={this.state.openCollections}
+              onClose={this.onClose}
+              onOpen={this.onOpen}
+              collections={currentUserPersonalCollections(list, currentUser.id)}
+              initialIcon="person"
+              filter={this.filterPersonalCollections}
+              currentCollection={collectionId}
+            />
+          </Box>
+        </Box>
+
+        <Footer isSuperUser={currentUser.is_superuser} />
+>>>>>>> fc641cba8 (Extract Header into component)
       </React.Fragment>
     );
   };

--- a/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebar.styled.js
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebar.styled.js
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 import { Box } from "grid-styled";
 
 import { space } from "metabase/styled-components/theme";
@@ -29,7 +29,15 @@ export const Sidebar = styled(Box.withComponent("aside"))`
   padding-top: ${space(3)};
   position: fixed;
   top: 65px;
-  width: ${props => (props.shouldDisplayMobileSidebar ? "100vw" : 0)};
+  width: 0;
+
+  ${props =>
+    props.shouldDisplayMobileSidebar &&
+    css`
+      box-shadow: 5px 0px 8px rgba(0, 0, 0, 0.35),
+        40px 0px rgba(5, 14, 31, 0.32);
+      width: calc(100vw - 40px);
+    `}
 
   ${breakpointMinSmall} {
     width: ${SIDEBAR_WIDTH};
@@ -41,7 +49,11 @@ export const ToggleMobileSidebarIcon = styled(Icon).attrs({
   size: 20,
 })`
   color: ${color("brand")};
-  margin: 0 ${space(2)} 0 ${space(3)}};
+  // margin sizes hard-coded
+  // for icon to land on
+  // same position as burger icon
+  // when sidebar is hidden in mobile
+  margin: -4px ${space(2)} 0 30px};
 
   ${breakpointMinSmall} {
     cursor: pointer;

--- a/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebar.styled.js
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebar.styled.js
@@ -41,7 +41,7 @@ export const ToggleMobileSidebarIcon = styled(Icon).attrs({
   size: 20,
 })`
   color: ${color("brand")};
-  margin: ${space(0)} ${space(2)} 0 ${space(3)}};
+  margin: 0 ${space(2)} 0 ${space(3)}};
 
   ${breakpointMinSmall} {
     cursor: pointer;

--- a/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebarHeader/CollectionSidebarHeader.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebarHeader/CollectionSidebarHeader.jsx
@@ -1,0 +1,36 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { t } from "ttag";
+
+import * as Urls from "metabase/lib/urls";
+
+import CollectionDropTarget from "metabase/containers/dnd/CollectionDropTarget";
+import CollectionLink from "metabase/collections/components/CollectionLink";
+
+import { Container } from "./CollectionSidebarHeader.styled";
+
+const propTypes = {
+  isRoot: PropTypes.bool.isRequired,
+  root: PropTypes.object.isRequired,
+};
+
+export default function CollectionSidebarHeader({ isRoot, root }) {
+  return (
+    <Container>
+      <CollectionDropTarget collection={root}>
+        {({ highlighted, hovered }) => (
+          <CollectionLink
+            to={Urls.collection({ id: "root" })}
+            selected={isRoot}
+            highlighted={highlighted}
+            hovered={hovered}
+          >
+            {t`Our analytics`}
+          </CollectionLink>
+        )}
+      </CollectionDropTarget>
+    </Container>
+  );
+}
+
+CollectionSidebarHeader.propTypes = propTypes;

--- a/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebarHeader/CollectionSidebarHeader.styled.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebarHeader/CollectionSidebarHeader.styled.jsx
@@ -1,0 +1,9 @@
+import styled from "styled-components";
+import { Box } from "grid-styled";
+
+import { space } from "metabase/styled-components/theme";
+
+export const Container = styled(Box)`
+  margin-bottom: ${space(1)};
+  margin-top: ${space(2)};
+`;

--- a/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebarHeader/CollectionSidebarHeader.unit.spec.js
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebarHeader/CollectionSidebarHeader.unit.spec.js
@@ -1,0 +1,19 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { DragDropContextProvider } from "react-dnd";
+import HTML5Backend from "react-dnd-html5-backend";
+
+import CollectionSidebarHeader from "./CollectionSidebarHeader";
+
+it("displays link to main collection: Our Analytics", () => {
+  render(
+    <DragDropContextProvider backend={HTML5Backend}>
+      <CollectionSidebarHeader
+        isRoot={false}
+        root={{ name: "name", id: "root" }}
+      />
+    </DragDropContextProvider>,
+  );
+
+  screen.getByText("Our analytics");
+});


### PR DESCRIPTION
A 1-minute demo of the UI adjustments in this PR:
https://www.loom.com/share/c098a4b9608d4b3ab05d26b37ce550be

#### Next Up:

* Clicking a collection in the sidebar will make the sidebar close if we're in mobile.
* Maybe animations and more design tweaks, let's see how we prioritize these against other initiatives.

### Design: 

https://www.figma.com/file/dyN71v3AI1GutWOaSLoxT6/Collections-Mobile-Layout?node-id=0%3A1&viewport=-194%2C254%2C0.4838546812534332

### Prototype: 

https://www.figma.com/proto/dyN71v3AI1GutWOaSLoxT6/Collections-Mobile-Layout?page-id=0%3A1&node-id=1%3A88&viewport=-249%2C618%2C1&scaling=min-zoom