### PR TITLE
Do not reset filters when saving, cancelling, refreshing dashboards periodically

### DIFF
--- a/frontend/src/metabase/dashboard/actions.js
+++ b/frontend/src/metabase/dashboard/actions.js
@@ -21,6 +21,7 @@ import {
   getParameterValuesBySlug,
   getParameterValuesByIdFromQueryParams,
   removeDefaultedParametersWithEmptyStringValue,
+  getParameterValuesByIdFromPreviousValues,
 } from "metabase/meta/Parameter";
 import * as Urls from "metabase/lib/urls";
 
@@ -596,6 +597,7 @@ export const markCardAsSlow = createAction(MARK_CARD_AS_SLOW, card => ({
 export const fetchDashboard = createThunkAction(FETCH_DASHBOARD, function(
   dashId,
   queryParams,
+  preserveParameters,
 ) {
   let result;
   return async function(dispatch, getState) {
@@ -665,11 +667,16 @@ export const fetchDashboard = createThunkAction(FETCH_DASHBOARD, function(
       dispatch(addFields(result.param_fields));
     }
 
-    const parameterValuesById = getParameterValuesByIdFromQueryParams(
-      result.parameters,
-      queryParams,
-      removeDefaultedParametersWithEmptyStringValue,
-    );
+    const parameterValuesById = preserveParameters
+      ? getParameterValuesByIdFromPreviousValues(
+          result.parameters,
+          getParameterValues(getState()),
+        )
+      : getParameterValuesByIdFromQueryParams(
+          result.parameters,
+          queryParams,
+          removeDefaultedParametersWithEmptyStringValue,
+        );
 
     return {
       ...normalize(result, dashboard), // includes `result` and `entities`

--- a/frontend/src/metabase/dashboard/actions.js
+++ b/frontend/src/metabase/dashboard/actions.js
@@ -383,7 +383,7 @@ export const saveDashboardAndCards = createThunkAction(
       await dispatch(Dashboards.actions.update(dashboard));
 
       // make sure that we've fully cleared out any dirty state from editing (this is overkill, but simple)
-      dispatch(fetchDashboard(dashboard.id, null, true)); // disable using query parameters when saving
+      dispatch(fetchDashboard(dashboard.id, null)); // disable using query parameters when saving
     };
   },
 );

--- a/frontend/src/metabase/dashboard/components/DashboardHeader.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader.jsx
@@ -128,6 +128,7 @@ export default class DashboardHeader extends Component {
     this.props.fetchDashboard(
       this.props.dashboard.id,
       this.props.location.query,
+      true,
     );
   }
 

--- a/frontend/src/metabase/dashboard/hoc/DashboardControls.jsx
+++ b/frontend/src/metabase/dashboard/hoc/DashboardControls.jsx
@@ -189,6 +189,7 @@ export default (ComposedComponent: React.Class) =>
           await this.props.fetchDashboard(
             this.props.dashboardId,
             this.props.location.query,
+            true,
           );
           this.props.fetchDashboardCardData({
             reload: true,

--- a/frontend/src/metabase/meta/Parameter.js
+++ b/frontend/src/metabase/meta/Parameter.js
@@ -698,6 +698,17 @@ export function getParameterValuesByIdFromQueryParams(
   return Object.fromEntries(idValuePairs);
 }
 
+export function getParameterValuesByIdFromPreviousValues(
+  parameters,
+  parameterValues,
+) {
+  const parameterEntries = parameters
+    .map(p => [p.id, parameterValues[p.id]])
+    .filter(([id, value]) => value != null);
+
+  return Object.fromEntries(parameterEntries);
+}
+
 export function getParameterValuesBySlug(
   parameters,
   parameterValuesById,


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/5332

Preserves filters in mentioned cases and validates they still exist.

How test test manually:
1. Go to any dashboard that already has the dashboard filter connected to any of the fields
2. Set the filter value if it already wasn't set
3. Note that the url changes and it now includes the filter and its value (correct behavior)
4. Click on the pencil icon to enter Dashboard edit mode
5. Click on "Cancel" button
6. The filter should not be changed