### PR TITLE
Display official question's badge when it's in regular dashboard

### DIFF
--- a/frontend/src/metabase/components/Icon.jsx
+++ b/frontend/src/metabase/components/Icon.jsx
@@ -1,6 +1,6 @@
 /*eslint-disable react/no-danger */
-/* eslint-disable react/prop-types */
 import React, { Component } from "react";
+import PropTypes from "prop-types";
 import styled from "styled-components";
 import { color, space, hover } from "styled-system";
 import cx from "classnames";
@@ -38,20 +38,27 @@ IconWrapper.defaultProps = {
   },
 };
 
+const stringOrNumberPropType = PropTypes.oneOfType([
+  PropTypes.number,
+  PropTypes.string,
+]);
+
+export const iconPropTypes = {
+  name: PropTypes.string.isRequired,
+  size: stringOrNumberPropType,
+  width: stringOrNumberPropType,
+  height: stringOrNumberPropType,
+  scale: stringOrNumberPropType,
+  tooltip: PropTypes.string,
+  defaultName: PropTypes.string,
+  className: PropTypes.string,
+};
+
+const defaultProps = {
+  defaultName: "unknown",
+};
+
 class BaseIcon extends Component {
-  static props: {
-    name: string,
-    size?: string | number,
-    width?: string | number,
-    height?: string | number,
-    scale?: string | number,
-    tooltip?: string, // using Tooltipify
-  };
-
-  static defaultProps = {
-    defaultName: "unknown",
-  };
-
   render() {
     const { name, defaultName, className, ...rest } = this.props;
 
@@ -111,10 +118,14 @@ class BaseIcon extends Component {
   }
 }
 
+BaseIcon.propTypes = iconPropTypes;
+BaseIcon.defaultProps = defaultProps;
+
 const Icon = styled(BaseIcon)`
   ${space}
   ${color}
   ${hover}
   flex-shrink: 0
 `;
+
 export default Tooltipify(Icon);

--- a/frontend/src/metabase/dashboard/components/DashCard.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard.jsx
@@ -17,7 +17,7 @@ import ModalWithTrigger from "metabase/components/ModalWithTrigger";
 import { ChartSettingsWithState } from "metabase/visualizations/components/ChartSettings";
 import WithVizSettingsData from "metabase/visualizations/hoc/WithVizSettingsData";
 
-import Icon from "metabase/components/Icon";
+import Icon, { iconPropTypes } from "metabase/components/Icon";
 import Tooltip from "metabase/components/Tooltip";
 
 import { isVirtualDashCard } from "metabase/dashboard/dashboard";
@@ -59,11 +59,7 @@ export default class DashCard extends Component {
     markNewCardSeen: PropTypes.func.isRequired,
     fetchCardData: PropTypes.func.isRequired,
     navigateToNewCardFromDashboard: PropTypes.func.isRequired,
-    headerIcon: PropTypes.shape({
-      name: PropTypes.string.isRequired,
-      color: PropTypes.string,
-      size: PropTypes.number,
-    }),
+    headerIcon: PropTypes.shape(iconPropTypes),
   };
 
   constructor(props) {

--- a/frontend/src/metabase/dashboard/components/DashCard.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard.jsx
@@ -59,6 +59,11 @@ export default class DashCard extends Component {
     markNewCardSeen: PropTypes.func.isRequired,
     fetchCardData: PropTypes.func.isRequired,
     navigateToNewCardFromDashboard: PropTypes.func.isRequired,
+    headerIcon: PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      color: PropTypes.string,
+      size: PropTypes.number,
+    }),
   };
 
   constructor(props) {
@@ -112,6 +117,7 @@ export default class DashCard extends Component {
       dashboard,
       parameterValues,
       mode,
+      headerIcon,
     } = this.props;
 
     const mainCard = {
@@ -205,6 +211,7 @@ export default class DashCard extends Component {
           })}
           classNameWidgets={isEmbed && "text-light text-medium-hover"}
           error={errorMessage}
+          headerIcon={headerIcon}
           errorIcon={errorIcon}
           isSlow={isSlow}
           expectedDuration={expectedDuration}

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
@@ -6,8 +6,11 @@ import ExplicitSize from "metabase/components/ExplicitSize";
 
 import Modal from "metabase/components/Modal";
 
+import { PLUGIN_COLLECTIONS } from "metabase/plugins";
+
 import { getVisualizationRaw } from "metabase/visualizations";
 import MetabaseAnalytics from "metabase/lib/analytics";
+import { color } from "metabase/lib/colors";
 
 import {
   GRID_WIDTH,
@@ -224,10 +227,27 @@ export default class DashboardGrid extends Component {
     this.setState({ addSeriesModalDashCard: dc });
   }
 
+  getDashboardCardIcon = dashCard => {
+    const { isRegularCollection } = PLUGIN_COLLECTIONS;
+    const { dashboard } = this.props;
+    const isRegularQuestion = isRegularCollection({
+      authority_level: dashCard.collection_authority_level,
+    });
+    const isRegularDashboard = isRegularCollection({
+      authority_level: dashboard.collection_authority_level,
+    });
+    if (isRegularDashboard && !isRegularQuestion) {
+      const authorityLevel = dashCard.collection_authority_level;
+      const opts = PLUGIN_COLLECTIONS.AUTHORITY_LEVEL[authorityLevel];
+      return { name: opts.icon, color: color(opts.color), size: 14 };
+    }
+  };
+
   renderDashCard(dc, { isMobile, gridItemWidth }) {
     return (
       <DashCard
         dashcard={dc}
+        headerIcon={this.getDashboardCardIcon(dc)}
         dashcardData={this.props.dashcardData}
         parameterValues={this.props.parameterValues}
         slowCards={this.props.slowCards}

--- a/frontend/src/metabase/visualizations/components/LegendHeader.jsx
+++ b/frontend/src/metabase/visualizations/components/LegendHeader.jsx
@@ -26,6 +26,11 @@ export default class LegendHeader extends Component {
     actionButtons: PropTypes.node,
     description: PropTypes.string,
     classNameWidgets: PropTypes.string,
+    icon: PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      color: PropTypes.string,
+      size: PropTypes.number,
+    }),
   };
 
   static defaultProps = {
@@ -40,6 +45,7 @@ export default class LegendHeader extends Component {
       hovered,
 
       actionButtons,
+      icon,
       onHoverChange,
       onChangeCardAndRun,
       settings,
@@ -82,6 +88,7 @@ export default class LegendHeader extends Component {
           <LegendItem
             key={index}
             title={titles[index]}
+            icon={icon}
             description={description}
             color={colors[index % colors.length]}
             className={cx({ "text-brand-hover": !isBreakoutSeries })}

--- a/frontend/src/metabase/visualizations/components/LegendHeader.jsx
+++ b/frontend/src/metabase/visualizations/components/LegendHeader.jsx
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 import styles from "./Legend.css";
 
 import ExplicitSize from "../../components/ExplicitSize";
-import Icon from "metabase/components/Icon";
+import Icon, { iconPropTypes } from "metabase/components/Icon";
 import LegendItem from "./LegendItem";
 
 import cx from "classnames";
@@ -26,11 +26,7 @@ export default class LegendHeader extends Component {
     actionButtons: PropTypes.node,
     description: PropTypes.string,
     classNameWidgets: PropTypes.string,
-    icon: PropTypes.shape({
-      name: PropTypes.string.isRequired,
-      color: PropTypes.string,
-      size: PropTypes.number,
-    }),
+    icon: PropTypes.shape(iconPropTypes),
   };
 
   static defaultProps = {

--- a/frontend/src/metabase/visualizations/components/LegendItem.jsx
+++ b/frontend/src/metabase/visualizations/components/LegendItem.jsx
@@ -1,5 +1,6 @@
 /* eslint-disable react/prop-types */
 import React, { Component } from "react";
+import PropTypes from "prop-types";
 
 import Icon from "metabase/components/Icon";
 import Tooltip from "metabase/components/Tooltip";
@@ -7,13 +8,22 @@ import Ellipsified from "metabase/components/Ellipsified";
 
 import cx from "classnames";
 
+import { IconContainer } from "./LegendItem.styled";
+
+const propTypes = {
+  icon: PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    color: PropTypes.string,
+    size: PropTypes.number,
+  }),
+};
+
 export default class LegendItem extends Component {
   constructor(props, context) {
     super(props, context);
     this.state = {};
   }
 
-  static propTypes = {};
   static defaultProps = {
     showDot: true,
     showTitle: true,
@@ -26,6 +36,7 @@ export default class LegendItem extends Component {
     const {
       title,
       color,
+      icon,
       showDot,
       showTitle,
       isMuted,
@@ -56,6 +67,11 @@ export default class LegendItem extends Component {
         onMouseLeave={onMouseLeave}
         onClick={onClick}
       >
+        {icon && (
+          <IconContainer>
+            <Icon {...icon} />
+          </IconContainer>
+        )}
         {showDot && (
           <Tooltip tooltip={title} isEnabled={showTooltip && showDotTooltip}>
             <div
@@ -86,3 +102,5 @@ export default class LegendItem extends Component {
     );
   }
 }
+
+LegendItem.propTypes = propTypes;

--- a/frontend/src/metabase/visualizations/components/LegendItem.jsx
+++ b/frontend/src/metabase/visualizations/components/LegendItem.jsx
@@ -2,7 +2,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 
-import Icon from "metabase/components/Icon";
+import Icon, { iconPropTypes } from "metabase/components/Icon";
 import Tooltip from "metabase/components/Tooltip";
 import Ellipsified from "metabase/components/Ellipsified";
 
@@ -11,11 +11,7 @@ import cx from "classnames";
 import { IconContainer } from "./LegendItem.styled";
 
 const propTypes = {
-  icon: PropTypes.shape({
-    name: PropTypes.string.isRequired,
-    color: PropTypes.string,
-    size: PropTypes.number,
-  }),
+  icon: PropTypes.shape(iconPropTypes),
 };
 
 export default class LegendItem extends Component {

--- a/frontend/src/metabase/visualizations/components/LegendItem.styled.js
+++ b/frontend/src/metabase/visualizations/components/LegendItem.styled.js
@@ -1,0 +1,6 @@
+import styled from "styled-components";
+import { space } from "metabase/styled-components/theme";
+
+export const IconContainer = styled.div`
+  padding-right: ${space(0)};
+`;

--- a/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
+++ b/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
@@ -2,6 +2,9 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { t } from "ttag";
+
+import { iconPropTypes } from "metabase/components/Icon";
+
 import CardRenderer from "./CardRenderer";
 import LegendHeader from "./LegendHeader";
 import TitleLegendHeader from "./TitleLegendHeader";
@@ -193,11 +196,7 @@ export default class LineAreaBarChart extends Component {
     actionButtons: PropTypes.node,
     showTitle: PropTypes.bool,
     isDashboard: PropTypes.bool,
-    headerIcon: PropTypes.shape({
-      name: PropTypes.string.isRequired,
-      color: PropTypes.string,
-      size: PropTypes.number,
-    }),
+    headerIcon: PropTypes.shape(iconPropTypes),
   };
 
   static defaultProps = {};

--- a/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
+++ b/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
@@ -193,6 +193,11 @@ export default class LineAreaBarChart extends Component {
     actionButtons: PropTypes.node,
     showTitle: PropTypes.bool,
     isDashboard: PropTypes.bool,
+    headerIcon: PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      color: PropTypes.string,
+      size: PropTypes.number,
+    }),
   };
 
   static defaultProps = {};
@@ -260,6 +265,7 @@ export default class LineAreaBarChart extends Component {
       series,
       hovered,
       showTitle,
+      headerIcon,
       actionButtons,
       onChangeCardAndRun,
       onVisualizationClick,
@@ -302,6 +308,7 @@ export default class LineAreaBarChart extends Component {
             settings={settings}
             onChangeCardAndRun={onChangeCardAndRun}
             actionButtons={actionButtons}
+            icon={headerIcon}
           />
         )}
         {hasMultiSeriesHeaderSeries || (!hasTitle && actionButtons) ? ( // always show action buttons if we have them

--- a/frontend/src/metabase/visualizations/components/TitleLegendHeader.jsx
+++ b/frontend/src/metabase/visualizations/components/TitleLegendHeader.jsx
@@ -1,15 +1,25 @@
 /* eslint-disable react/prop-types */
 import React from "react";
+import PropTypes from "prop-types";
 import _ from "underscore";
 import { getIn } from "icepick";
 
 import LegendHeader from "./LegendHeader";
+
+const propTypes = {
+  icon: PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    color: PropTypes.string,
+    size: PropTypes.number,
+  }),
+};
 
 export default function TitleLegendHeader({
   series,
   settings,
   onChangeCardAndRun,
   actionButtons,
+  icon,
 }) {
   const originalSeries = series._raw || series;
   const cardIds = _.uniq(originalSeries.map(s => s.card.id));
@@ -38,6 +48,7 @@ export default function TitleLegendHeader({
         series={titleHeaderSeries}
         description={settings["card.description"]}
         actionButtons={actionButtons}
+        icon={icon}
         // If a dashboard card is composed of multiple questions, its custom card title
         // shouldn't act as a link as it's ambiguous that which question it should open
         onChangeCardAndRun={
@@ -50,3 +61,5 @@ export default function TitleLegendHeader({
     return null;
   }
 }
+
+TitleLegendHeader.propTypes = propTypes;

--- a/frontend/src/metabase/visualizations/components/TitleLegendHeader.jsx
+++ b/frontend/src/metabase/visualizations/components/TitleLegendHeader.jsx
@@ -4,14 +4,12 @@ import PropTypes from "prop-types";
 import _ from "underscore";
 import { getIn } from "icepick";
 
+import { iconPropTypes } from "metabase/components/Icon";
+
 import LegendHeader from "./LegendHeader";
 
 const propTypes = {
-  icon: PropTypes.shape({
-    name: PropTypes.string.isRequired,
-    color: PropTypes.string,
-    size: PropTypes.number,
-  }),
+  icon: PropTypes.shape(iconPropTypes),
 };
 
 export default function TitleLegendHeader({

--- a/frontend/src/metabase/visualizations/components/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization.jsx
@@ -598,6 +598,7 @@ export default class Visualization extends React.PureComponent {
             card={series[0].card} // convenience for single-series visualizations
             data={series[0].data} // convenience for single-series visualizations
             hovered={hovered}
+            headerIcon={hasLegendHeader ? null : headerIcon}
             onHoverChange={this.handleHoverChange}
             onVisualizationClick={this.handleVisualizationClick}
             visualizationIsClickable={this.visualizationIsClickable}

--- a/frontend/src/metabase/visualizations/components/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization.jsx
@@ -64,6 +64,12 @@ type Props = {
   isEditing: boolean,
   isSettings: boolean,
 
+  headerIcon?: {
+    name: string,
+    color?: string,
+    size?: Number,
+  },
+
   actionButtons: React.Element<any>,
 
   // errors
@@ -372,6 +378,7 @@ export default class Visualization extends React.PureComponent {
       isDashboard,
       width,
       height,
+      headerIcon,
       errorIcon,
       isSlow,
       expectedDuration,
@@ -516,6 +523,7 @@ export default class Visualization extends React.PureComponent {
               actionButtons={extra}
               description={settings["card.description"]}
               settings={settings}
+              icon={headerIcon}
               onChangeCardAndRun={
                 this.props.onChangeCardAndRun && !replacementContent
                   ? this.handleOnChangeCardAndRun

--- a/frontend/src/metabase/visualizations/components/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization.jsx
@@ -504,18 +504,22 @@ export default class Visualization extends React.PureComponent {
 
     const CardVisualization = visualization;
 
+    const title = settings["card.title"];
+    const hasHeaderContent = title || extra;
+    const isHeaderEnabled = !(visualization && visualization.noHeader);
+
+    const hasLegendHeader =
+      (showTitle &&
+        hasHeaderContent &&
+        (loading || error || noResults || isHeaderEnabled)) ||
+      replacementContent;
+
     return (
       <div
         className={cx(className, "flex flex-column full-height")}
         style={style}
       >
-        {(showTitle &&
-          (settings["card.title"] || extra) &&
-          (loading ||
-            error ||
-            noResults ||
-            !(visualization && visualization.noHeader))) ||
-        replacementContent ? (
+        {!!hasLegendHeader && (
           <div className="p1 flex-no-shrink">
             <TitleLegendHeader
               classNameWidgets={classNameWidgets}
@@ -531,7 +535,7 @@ export default class Visualization extends React.PureComponent {
               }
             />
           </div>
-        ) : null}
+        )}
         {replacementContent ? (
           replacementContent
         ) : // on dashboards we should show the "No results!" warning if there are no rows or there's a MinRowsError and actualRows === 0

--- a/frontend/src/metabase/visualizations/visualizations/Funnel.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Funnel.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { t } from "ttag";
 import {
   MinRowsError,
@@ -23,6 +24,14 @@ import cx from "classnames";
 
 import type { VisualizationProps } from "metabase-types/types/Visualization";
 import TitleLegendHeader from "metabase/visualizations/components/TitleLegendHeader";
+
+const propTypes = {
+  headerIcon: PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    color: PropTypes.string,
+    size: PropTypes.number,
+  }),
+};
 
 export default class Funnel extends Component {
   props: VisualizationProps;
@@ -172,7 +181,7 @@ export default class Funnel extends Component {
   }
 
   render() {
-    const { settings } = this.props;
+    const { headerIcon, settings } = this.props;
 
     const hasTitle = settings["card.title"];
 
@@ -193,6 +202,7 @@ export default class Funnel extends Component {
               settings={settings}
               onChangeCardAndRun={onChangeCardAndRun}
               actionButtons={actionButtons}
+              icon={headerIcon}
             />
           )}
           {!hasTitle &&
@@ -210,3 +220,5 @@ export default class Funnel extends Component {
     }
   }
 }
+
+Funnel.propTypes = propTypes;

--- a/frontend/src/metabase/visualizations/visualizations/Funnel.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Funnel.jsx
@@ -6,6 +6,8 @@ import {
   ChartSettingsError,
 } from "metabase/visualizations/lib/errors";
 
+import { iconPropTypes } from "metabase/components/Icon";
+
 import { formatValue } from "metabase/lib/formatting";
 
 import { getComputedSettingsForSeries } from "metabase/visualizations/lib/settings/visualization";
@@ -26,11 +28,7 @@ import type { VisualizationProps } from "metabase-types/types/Visualization";
 import TitleLegendHeader from "metabase/visualizations/components/TitleLegendHeader";
 
 const propTypes = {
-  headerIcon: PropTypes.shape({
-    name: PropTypes.string.isRequired,
-    color: PropTypes.string,
-    size: PropTypes.number,
-  }),
+  headerIcon: PropTypes.shape(iconPropTypes),
 };
 
 export default class Funnel extends Component {

--- a/frontend/test/metabase/scenarios/collections/collection-types.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collection-types.cy.spec.js
@@ -99,6 +99,7 @@ describeWithToken("collections types", () => {
       cy.icon("folder").should("have.length", 3);
       cy.icon("badge").should("not.exist");
     });
+  });
 });
 
 describeWithoutToken("collection types", () => {

--- a/frontend/test/metabase/scenarios/collections/collection-types.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collection-types.cy.spec.js
@@ -47,6 +47,10 @@ describeWithToken("collections types", () => {
     testOfficialBadgePresence();
   });
 
+  it("should display a badge next to official questions in regular dashboards", () => {
+    testOfficialQuestionBadgeInRegularDashboard();
+  });
+
   it("should be able to update authority level for collection children", () => {
     cy.visit("/collection/root");
     cy.findByText("First collection").click();
@@ -95,7 +99,6 @@ describeWithToken("collections types", () => {
       cy.icon("folder").should("have.length", 3);
       cy.icon("badge").should("not.exist");
     });
-  });
 });
 
 describeWithoutToken("collection types", () => {
@@ -122,6 +125,10 @@ describeWithoutToken("collection types", () => {
 
   it("should not display official collection icon", () => {
     testOfficialBadgePresence(false);
+  });
+
+  it("should display official questions as regular in regular dashboards", () => {
+    testOfficialQuestionBadgeInRegularDashboard(false);
   });
 });
 
@@ -180,6 +187,30 @@ function testOfficialBadgeInSearch({
     });
     assertSearchResultBadge(question, { expectBadge });
     assertSearchResultBadge(dashboard, { expectBadge });
+  });
+}
+
+function testOfficialQuestionBadgeInRegularDashboard(expectBadge = true) {
+  cy.createCollection({
+    name: COLLECTION_NAME,
+    authority_level: "official",
+  }).then(response => {
+    const { id: collectionId } = response.body;
+    cy.createQuestionAndDashboard({
+      questionDetails: {
+        name: "Official Question",
+        collection_id: collectionId,
+        query: TEST_QUESTION_QUERY,
+      },
+      dashboardName: "Regular Dashboard",
+    });
+  });
+
+  cy.visit("/collection/root");
+  cy.findByText("Regular Dashboard").click();
+
+  cy.get(".DashboardGrid").within(() => {
+    cy.icon("badge").should(expectBadge ? "exist" : "not.exist");
   });
 }
 


### PR DESCRIPTION
If an official question is included in a regular dashboard, we want Metabase to display an official badge icon next to the question's name to indicate that it has "verified" data.

The whole PR is mostly about new `icon` prop journey (`DashboardGrid` > `DashCard` > `Visualization` > `TitleAndLegendHeader` > `LegendHeader` > `LegendItem`). All the visualizations have a common header component displaying their title, except Funnel and Line Chart, so I had to pass the `icon` prop individually.

### To Verify

Spin up Metabase Enterprise and sign in as admin

1. Create a question (the query doesn't really matter) and save it to "Our analytics"
2. Create a dashboard, add the new question to it and save it to "Our analytics"
3. Ensure the question card is displayed as it would `master`
4. Move the question from step 1 to an official collection
5. Open the dashboard from step 2
6. Ensure the question has an official badge next to its name
7. Move the dashboard to an official collection
8. Ensure the question's official badge disappeared

### Demo

https://user-images.githubusercontent.com/17258145/126655655-5ecb3122-7823-4c72-b916-868b9469e397.mov
