### PR TITLE
Add ability to make all children collections official or regular

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/collections/components/FormCollectionAuthorityLevel.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/collections/components/FormCollectionAuthorityLevel.jsx
@@ -1,31 +1,64 @@
 import React from "react";
 import PropTypes from "prop-types";
+import { t } from "ttag";
 
+import CheckBox from "metabase/components/CheckBox";
 import {
   SegmentedControl,
   optionShape,
 } from "metabase/components/SegmentedControl";
 
+import { AUTHORITY_LEVELS } from "../constants";
+import { FormFieldRoot, Label } from "./FormCollectionAuthorityLevel.styled";
+
 const propTypes = {
   field: PropTypes.shape({
     value: PropTypes.any,
+    initialValue: PropTypes.any,
     onChange: PropTypes.func.isRequired,
   }).isRequired,
   options: PropTypes.arrayOf(optionShape).isRequired,
   values: PropTypes.shape({
+    id: PropTypes.number,
     authority_level: PropTypes.oneOf(["official"]),
     update_collection_tree_authority_level: PropTypes.bool,
   }),
   onChangeField: PropTypes.func.isRequired,
 };
 
-export function FormCollectionAuthorityLevel({ field, options }) {
+export function FormCollectionAuthorityLevel({
+  field,
+  options,
+  values,
+  onChangeField,
+}) {
+  const isNewCollection = !values.id;
+  const selectedAuthorityLevel =
+    AUTHORITY_LEVELS[field.value] || AUTHORITY_LEVELS.regular;
+  const shouldSuggestToUpdateChildren =
+    !isNewCollection && field.initialValue !== field.value;
   return (
-    <SegmentedControl
-      value={field.value}
-      onChange={field.onChange}
-      options={options}
-    />
+    <FormFieldRoot>
+      <SegmentedControl
+        value={field.value}
+        onChange={field.onChange}
+        options={options}
+      />
+      {shouldSuggestToUpdateChildren && (
+        <CheckBox
+          label={
+            <Label>{t`Make all sub-collections ${selectedAuthorityLevel.name}, too.`}</Label>
+          }
+          checked={values.update_collection_tree_authority_level}
+          onChange={e =>
+            onChangeField(
+              "update_collection_tree_authority_level",
+              e.target.checked,
+            )
+          }
+        />
+      )}
+    </FormFieldRoot>
   );
 }
 

--- a/enterprise/frontend/src/metabase-enterprise/collections/components/FormCollectionAuthorityLevel.styled.js
+++ b/enterprise/frontend/src/metabase-enterprise/collections/components/FormCollectionAuthorityLevel.styled.js
@@ -1,0 +1,16 @@
+import styled from "styled-components";
+import CheckBox from "metabase/components/CheckBox";
+import { color } from "metabase/lib/colors";
+
+export const FormFieldRoot = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+export const Label = styled(CheckBox.Label)`
+  color: ${color("text-dark")};
+  font-size: 1em;
+  font-weight: bold;
+  margin-bottom: 1px;
+`;

--- a/enterprise/frontend/src/metabase-enterprise/collections/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/collections/index.js
@@ -44,6 +44,10 @@ PLUGIN_COLLECTIONS.formFields = [
       },
     ],
   },
+  {
+    name: "update_collection_tree_authority_level",
+    type: "hidden",
+  },
 ];
 
 PLUGIN_FORM_WIDGETS.collectionAuthorityLevel = FormCollectionAuthorityLevel;


### PR DESCRIPTION
We want to be able to change collection type not only for a single collection but for all of its children. This PR adds a "Make children collection Official / Regular too" checkbox to the collection edit modal.

### To Verify

Spin up Metabase Enterprise and sign in as admin

1. Create a few nested _regular_ collections, let's say A > B > C (B is a child of A, C is a child of B)
2. Open collection A, click the pencil icon in the top right (Edit collection)
3. Click "Official", a checkbox with a "Make children Official too" label should appear
4. Click "Regular" back, the checkbox has to disappear
5. Click "Official" again and click the "Update" button
6. Ensure A, B and C became official (you should see a yellow official badge in the sidebar)
7. Click the pencil icon in the top right (Edit collection)
8. Click "Regular", a checkbox with a "Make children Regular too" label should appear
9. Click the "Update" button
10. Ensure A, B and C became regular again (badge icons have to be replaced with regular blue folder icons)
11. Try repeating the steps above for other levels of nesting (e.g. try updating B and its children, collection A has to keep its original type)

### Demo

https://user-images.githubusercontent.com/17258145/126659716-c67bc294-317e-48b6-a8ac-697d0dbd24d6.mov
