### PR TITLE
Allow only admins to edit collection types, hide form field for personal collections

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/collections/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/collections/index.js
@@ -23,8 +23,7 @@ PLUGIN_COLLECTIONS.REGULAR_COLLECTION = REGULAR_COLLECTION;
 
 PLUGIN_COLLECTIONS.AUTHORITY_LEVEL = AUTHORITY_LEVELS;
 
-PLUGIN_COLLECTIONS.formFields = [
-  ...PLUGIN_COLLECTIONS.formFields,
+PLUGIN_COLLECTIONS.authorityLevelFormFields = [
   {
     name: "authority_level",
     title: t`Collection type`,

--- a/frontend/src/metabase/collections/containers/CollectionCreate.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionCreate.jsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { connect } from "react-redux";
+import { getValues } from "redux-form";
 import { goBack } from "react-router-redux";
 
 import Collection from "metabase/entities/collections";
@@ -8,12 +9,18 @@ import { PLUGIN_COLLECTIONS } from "metabase/plugins";
 
 const { REGULAR_COLLECTION } = PLUGIN_COLLECTIONS;
 
-const mapStateToProps = (state, props) => ({
-  initialCollectionId: Collection.selectors.getInitialCollectionId(
-    state,
-    props,
-  ),
-});
+const FORM_NAME = "create-collection";
+
+const mapStateToProps = (state, props) => {
+  const formValues = getValues(state.form[FORM_NAME]);
+  return {
+    form: Collection.selectors.getForm(state, { ...props, formValues }),
+    initialCollectionId: Collection.selectors.getInitialCollectionId(
+      state,
+      props,
+    ),
+  };
+};
 
 const mapDispatchToProps = {
   goBack,
@@ -25,9 +32,11 @@ const mapDispatchToProps = {
 )
 export default class CollectionCreate extends Component {
   render() {
-    const { initialCollectionId, goBack } = this.props;
+    const { form, initialCollectionId, goBack } = this.props;
     return (
       <Collection.ModalForm
+        formName={FORM_NAME}
+        form={form}
         collection={{
           parent_id: initialCollectionId,
           authority_level: REGULAR_COLLECTION.type,

--- a/frontend/src/metabase/collections/containers/CollectionEdit.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionEdit.jsx
@@ -7,16 +7,31 @@ import { goBack, push } from "react-router-redux";
 import * as Urls from "metabase/lib/urls";
 import Collection from "metabase/entities/collections";
 
+function mapStateToProps(state, props) {
+  return {
+    form: Collection.selectors.getForm(state, props),
+  };
+}
+
+function CollectionForm({ form, collection, onSave, onClose }) {
+  return (
+    <Collection.ModalForm
+      form={form}
+      collection={collection}
+      onSaved={onSave}
+      onClose={onClose}
+    />
+  );
+}
+
+const UpdateCollectionForm = connect(mapStateToProps)(CollectionForm);
+
 const mapDispatchToProps = {
   push,
   goBack,
 };
 
-@connect(
-  null,
-  mapDispatchToProps,
-)
-export default class CollectionEdit extends Component {
+class CollectionEdit extends Component {
   onSave = updatedCollection => {
     const url = Urls.collection(updatedCollection);
     this.props.push(url);
@@ -27,9 +42,9 @@ export default class CollectionEdit extends Component {
     return (
       <Collection.Loader id={collectionId}>
         {({ collection, update }) => (
-          <Collection.ModalForm
+          <UpdateCollectionForm
             collection={collection}
-            onSaved={this.onSave}
+            onSave={this.onSave}
             onClose={this.props.goBack}
           />
         )}
@@ -37,3 +52,8 @@ export default class CollectionEdit extends Component {
     );
   }
 }
+
+export default connect(
+  null,
+  mapDispatchToProps,
+)(CollectionEdit);

--- a/frontend/src/metabase/entities/collections.js
+++ b/frontend/src/metabase/entities/collections.js
@@ -161,7 +161,7 @@ const Collections = createEntity({
         title: t`Collection it's saved in`,
         type: "collection",
       },
-      ...PLUGIN_COLLECTIONS.formFields,
+      ...PLUGIN_COLLECTIONS.authorityLevelFormFields,
     ],
   },
 

--- a/frontend/src/metabase/entities/collections.js
+++ b/frontend/src/metabase/entities/collections.js
@@ -14,6 +14,7 @@ import { isPersonalCollection } from "metabase/collections/utils";
 import { t } from "ttag";
 
 import { PLUGIN_COLLECTIONS } from "metabase/plugins";
+import { getFormSelector } from "./collections/forms";
 
 const listCollectionsTree = GET("/api/collection/tree");
 const listCollections = GET("/api/collection");
@@ -86,6 +87,7 @@ const Collections = createEntity({
   },
 
   selectors: {
+    getForm: getFormSelector,
     getExpandedCollectionsById: createSelector(
       [
         state => state.entities.collections,
@@ -125,44 +127,6 @@ const Collections = createEntity({
         return canonicalCollectionId(ROOT_COLLECTION.id);
       },
     ),
-  },
-
-  form: {
-    fields: (
-      values = {
-        color: color("brand"),
-      },
-    ) => [
-      {
-        name: "name",
-        title: t`Name`,
-        placeholder: t`My new fantastic collection`,
-        autoFocus: true,
-        validate: name =>
-          (!name && t`Name is required`) ||
-          (name && name.length > 100 && t`Name must be 100 characters or less`),
-      },
-      {
-        name: "description",
-        title: t`Description`,
-        type: "text",
-        placeholder: t`It's optional but oh, so helpful`,
-        normalize: description => description || null, // expected to be nil or non-empty string
-      },
-      {
-        name: "color",
-        title: t`Color`,
-        type: "hidden",
-        initial: () => color("brand"),
-        validate: color => !color && t`Color is required`,
-      },
-      {
-        name: "parent_id",
-        title: t`Collection it's saved in`,
-        type: "collection",
-      },
-      ...PLUGIN_COLLECTIONS.authorityLevelFormFields,
-    ],
   },
 
   getAnalyticsMetadata([object], { action }, getState) {

--- a/frontend/src/metabase/entities/collections/forms.js
+++ b/frontend/src/metabase/entities/collections/forms.js
@@ -1,0 +1,92 @@
+import { createSelector } from "reselect";
+import { t } from "ttag";
+
+import { PLUGIN_COLLECTIONS } from "metabase/plugins";
+import { color } from "metabase/lib/colors";
+import { getUser } from "metabase/selectors/user";
+
+import {
+  isPersonalCollection,
+  isPersonalCollectionChild,
+} from "metabase/collections/utils";
+
+function createForm({ extraFields = [] } = {}) {
+  return {
+    fields: (
+      values = {
+        color: color("brand"),
+      },
+    ) => [
+      {
+        name: "name",
+        title: t`Name`,
+        placeholder: t`My new fantastic collection`,
+        autoFocus: true,
+        validate: name =>
+          (!name && t`Name is required`) ||
+          (name && name.length > 100 && t`Name must be 100 characters or less`),
+      },
+      {
+        name: "description",
+        title: t`Description`,
+        type: "text",
+        placeholder: t`It's optional but oh, so helpful`,
+        normalize: description => description || null, // expected to be nil or non-empty string
+      },
+      {
+        name: "color",
+        title: t`Color`,
+        type: "hidden",
+        initial: () => color("brand"),
+        validate: color => !color && t`Color is required`,
+      },
+      {
+        name: "parent_id",
+        title: t`Collection it's saved in`,
+        type: "collection",
+      },
+      ...extraFields,
+    ],
+  };
+}
+
+function isPersonalOrPersonalChild(collection, collectionList) {
+  if (!collection) {
+    return false;
+  }
+  return (
+    isPersonalCollection(collection) ||
+    isPersonalCollectionChild(collection, collectionList)
+  );
+}
+
+export const getFormSelector = createSelector(
+  [
+    (state, props) => props.collection || {},
+    (state, props) => props.formValues || {},
+    state => state.entities.collections || {},
+    getUser,
+  ],
+  (collection, formValues, allCollections, user) => {
+    const collectionList = Object.values(allCollections);
+    const extraFields = [];
+
+    const creatingNewCollection = !collection.id;
+    const parentId = creatingNewCollection
+      ? formValues.parent_id
+      : collection.parent_id;
+
+    const parentCollection = allCollections[parentId];
+    const canManageAuthorityLevel =
+      user.is_superuser &&
+      !isPersonalCollection(collection) &&
+      !isPersonalOrPersonalChild(parentCollection, collectionList);
+
+    if (canManageAuthorityLevel) {
+      extraFields.push(...PLUGIN_COLLECTIONS.authorityLevelFormFields);
+    }
+
+    const form = createForm({ extraFields });
+    return form;
+  },
+);

--- a/frontend/src/metabase/plugins/index.js
+++ b/frontend/src/metabase/plugins/index.js
@@ -65,7 +65,7 @@ const AUTHORITY_LEVEL_REGULAR = {
 };
 
 export const PLUGIN_COLLECTIONS = {
-  formFields: [],
+  authorityLevelFormFields: [],
   isRegularCollection: () => true,
   REGULAR_COLLECTION: AUTHORITY_LEVEL_REGULAR,
   AUTHORITY_LEVEL: {

--- a/frontend/test/metabase/scenarios/collections/collection-types.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collection-types.cy.spec.js
@@ -20,7 +20,6 @@ const TEST_QUESTION_QUERY = {
 describeWithToken("collections types", () => {
   beforeEach(() => {
     restore();
-    cy.signInAsAdmin();
   });
 
   const TREE_UPDATE_REGULAR_MESSAGE = "Make all sub-collections Regular, too.";
@@ -28,6 +27,7 @@ describeWithToken("collections types", () => {
     "Make all sub-collections Official, too.";
 
   it("should be able to manage collection authority level", () => {
+    cy.signInAsAdmin();
     cy.visit("/collection/root");
 
     createAndOpenOfficialCollection({ name: COLLECTION_NAME });
@@ -44,6 +44,7 @@ describeWithToken("collections types", () => {
   });
 
   it("displays official badge throughout the application", () => {
+    cy.signInAsAdmin();
     testOfficialBadgePresence();
   });
 
@@ -100,6 +101,47 @@ describeWithToken("collections types", () => {
       cy.icon("badge").should("not.exist");
     });
   });
+
+  it("should not see collection type field if not admin", () => {
+    cy.signIn("normal");
+    cy.visit("/collection/root");
+
+    openCollection("First collection");
+
+    cy.icon("new_folder").click();
+    modal().within(() => {
+      assertNoCollectionTypeInput();
+      cy.icon("close").click();
+    });
+
+    editCollection();
+    modal().within(() => {
+      assertNoCollectionTypeInput();
+    });
+  });
+
+  it("should not be able to manage collection authority level for personal collections and their children", () => {
+    cy.signInAsAdmin();
+    cy.visit("/collection/root");
+
+    openCollection("Your personal collection");
+    cy.icon("pencil").should("not.exist");
+
+    cy.icon("new_folder").click();
+    modal().within(() => {
+      assertNoCollectionTypeInput();
+      cy.findByLabelText("Name").type("Personal collection child");
+      cy.button("Create").click();
+    });
+
+    openCollection("Personal collection child");
+
+    cy.icon("new_folder").click();
+    modal().within(() => {
+      assertNoCollectionTypeInput();
+      cy.icon("close").click();
+    });
+  });
 });
 
 describeWithoutToken("collection types", () => {
@@ -117,7 +159,7 @@ describeWithoutToken("collection types", () => {
       cy.icon("close").click();
     });
 
-    cy.findByText("First collection").click();
+    openCollection("First collection");
     editCollection();
     modal().within(() => {
       assertNoCollectionTypeInput();
@@ -213,6 +255,12 @@ function testOfficialQuestionBadgeInRegularDashboard(expectBadge = true) {
   cy.get(".DashboardGrid").within(() => {
     cy.icon("badge").should(expectBadge ? "exist" : "not.exist");
   });
+}
+
+function openCollection(collectionName) {
+  sidebar()
+    .findByText(collectionName)
+    .click();
 }
 
 function editCollection() {

--- a/frontend/test/metabase/scenarios/collections/collection-types.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collection-types.cy.spec.js
@@ -49,10 +49,12 @@ describeWithToken("collections types", () => {
   });
 
   it("should display a badge next to official questions in regular dashboards", () => {
+    cy.signInAsAdmin();
     testOfficialQuestionBadgeInRegularDashboard();
   });
 
   it("should be able to update authority level for collection children", () => {
+    cy.signInAsAdmin();
     cy.visit("/collection/root");
     cy.findByText("First collection").click();
 


### PR DESCRIPTION
This PR changes "Collection Type" form field visibility. First of all, it's now only visible to admin users. Also, it's now hidden from personal collections and their children.

### To Verify

Spin up Metabase Enterprise and sign in as admin

1. Visit `/collection/root`
2. Create an official collection
    * click the "new folder" icon in the top right
    * select "Official" at the bottom of a new collection modal, enter a name, click "Create"
    * it should work as in any other PR from #17072
3. Open your personal collection
4. Click the "new folder" icon in the top right. You shouldn't see a "Collection type" form field
6. Enter a name and create a personal collection anyway. Then open it and click the "pencil" icon in the top right. You shouldn't see a "Collection type" form field
10. Sign out and sign in as a normal user
11. Visit `/collection/root`
12. You should see official collections, but when you're trying to create a new collection or edit an existing one, you shouldn't see a "Collection type" field