### PR TITLE
[Dashboard filters coverage] Add initial set of tests for dashboard date filters

### DIFF
--- a/frontend/test/__support__/e2e/helpers/e2e-dashboard-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-dashboard-helpers.js
@@ -36,3 +36,14 @@ export function checkFilterLabelAndValue(label, value) {
 
   cy.get("fieldset").contains(value);
 }
+
+export function setFilter(type, subType) {
+  cy.icon("filter").click();
+
+  cy.findByText("What do you want to filter?");
+
+  popover().within(() => {
+    cy.findByText(type).click();
+    cy.findByText(subType).click();
+  });
+}

--- a/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-date.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-date.cy.spec.js
@@ -1,0 +1,103 @@
+import {
+  restore,
+  popover,
+  mockSessionProperty,
+  filterWidget,
+  editDashboard,
+  saveDashboard,
+  setFilter,
+} from "__support__/e2e/cypress";
+
+import { DASHBOARD_DATE_FILTERS } from "./helpers/e2e-dashboard-filter-data-objects";
+import * as DateFilter from "../native-filters/helpers/e2e-date-filter-helpers";
+
+Object.entries(DASHBOARD_DATE_FILTERS).forEach(
+  ([filter, { value, representativeResult }]) => {
+    describe(`should work for ${filter}`, () => {
+      beforeEach(() => {
+        cy.intercept("GET", "/api/table/*/query_metadata").as("metadata");
+
+        restore();
+        cy.signInAsAdmin();
+
+        mockSessionProperty("field-filter-operators-enabled?", true);
+
+        cy.visit("/dashboard/1");
+
+        editDashboard();
+        setFilter("Time", filter);
+
+        cy.findByText("Column to filter on")
+          .next("a")
+          .click();
+
+        popover()
+          .contains("Created At")
+          .first()
+          .click();
+      });
+
+      it(`should work for "${filter}" when set through the filter widget`, () => {
+        saveDashboard();
+
+        filterWidget().click();
+
+        dateFilterSelector({
+          filterType: filter,
+          filterValue: value,
+        });
+
+        cy.get(".Card").within(() => {
+          cy.findByText(representativeResult);
+        });
+      });
+
+      it(`should work for "${filter}" when set as the default filter`, () => {
+        cy.findByText("Default value")
+          .next()
+          .click();
+
+        dateFilterSelector({
+          filterType: filter,
+          filterValue: value,
+        });
+        saveDashboard();
+
+        cy.get(".Card").within(() => {
+          cy.findByText(representativeResult);
+        });
+      });
+    });
+  },
+);
+
+function dateFilterSelector({ filterType, filterValue } = {}) {
+  switch (filterType) {
+    case "Month and Year":
+      DateFilter.setMonthAndYear(filterValue);
+      break;
+
+    case "Quarter and Year":
+      DateFilter.setQuarterAndYear(filterValue);
+      break;
+
+    case "Single Date":
+      DateFilter.setSingleDate(filterValue);
+      break;
+
+    case "Date Range":
+      DateFilter.setDateRange(filterValue);
+      break;
+
+    case "Relative Date":
+      DateFilter.setRelativeDate(filterValue);
+      break;
+
+    case "All Options":
+      DateFilter.setAdHocFilter(filterValue);
+      break;
+
+    default:
+      throw new Error("Wrong filter type!");
+  }
+}

--- a/frontend/test/metabase/scenarios/dashboard-filters/helpers/e2e-dashboard-filter-data-objects.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/helpers/e2e-dashboard-filter-data-objects.js
@@ -1,0 +1,37 @@
+export const DASHBOARD_DATE_FILTERS = {
+  "Month and Year": {
+    value: {
+      month: "November",
+      year: "2016",
+    },
+    representativeResult: "85.88",
+  },
+  "Quarter and Year": {
+    value: {
+      quarter: "Q2",
+      year: "2016",
+    },
+    representativeResult: "44.43",
+  },
+  "Single Date": {
+    value: "15",
+    representativeResult: "No results!",
+  },
+  "Date Range": {
+    value: {
+      startDate: "13",
+      endDate: "15",
+    },
+    representativeResult: "No results!",
+  },
+  "Relative Date": {
+    value: "Past 7 days",
+    representativeResult: "No results!",
+  },
+  "All Options": {
+    value: {
+      timeBucket: "Years",
+    },
+    representativeResult: "37.65",
+  },
+};


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- As an ongoing effort to increase the test coverage of dashboard filters (https://github.com/metabase/metabase/issues/17078), this PR adds basic tests around date filters
    - Make sure filter can be set via filter widget
    - Make sure filter can be set as the default filter

