### PR TITLE
Prepare Jest config for FE code coverage

### DIFF
--- a/jest.unit.conf.json
+++ b/jest.unit.conf.json
@@ -22,13 +22,15 @@
     "ga": {},
     "document": {}
   },
-  "coverageDirectory": "./",
-  "coverageReporters": ["text", "json-summary"],
+  "coverageDirectory": "./coverage",
+  "coverageReporters": ["text", "html", "lcov"],
   "collectCoverageFrom": ["frontend/src/**/*.js", "frontend/src/**/*.jsx"],
   "coveragePathIgnorePatterns": [
     "/node_modules/",
     "/frontend/src/metabase/visualizations/lib/errors.js",
-    "/frontend/src/cljs/"
+    "/frontend/src/cljs/",
+    "/frontend/src/metabase/internal/",
+    "/frontend/test/"
   ],
   "testEnvironment": "jsdom"
 }


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- Enables detailed html code coverage report (local only for now)

### How to test this?
- `yarn test-unit --coverage --silent`
- wait until all tests finish
- check your `./coverage` folder
- or simply in your terminal `open ./coverage/index.html`