### PR TITLE
Driver deprecation icon fix

### DIFF
--- a/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx
@@ -15,7 +15,7 @@ import ActionButton from "metabase/components/ActionButton";
 import AddDatabaseHelpCard from "metabase/components/AddDatabaseHelpCard";
 import Button from "metabase/components/Button";
 import Breadcrumbs from "metabase/components/Breadcrumbs";
-import DriverWarning from "metabase/components/DriverWarning/DriverWarning";
+import DriverWarning from "metabase/components/DriverWarning";
 import Radio from "metabase/components/Radio";
 import ModalWithTrigger from "metabase/components/ModalWithTrigger";
 

--- a/frontend/src/metabase/components/DriverWarning/DriverWarning.jsx
+++ b/frontend/src/metabase/components/DriverWarning/DriverWarning.jsx
@@ -10,7 +10,11 @@ import {
 
 import Warnings from "metabase/query_builder/components/Warnings";
 
-import { CardContent, DriverWarningContainer } from "./DriverWarning.styled";
+import {
+  CardContent,
+  DriverWarningContainer,
+  IconContainer,
+} from "./DriverWarning.styled";
 
 const propTypes = {
   engine: PropTypes.string.isRequired,
@@ -46,11 +50,13 @@ function DriverWarning({ engine, ...props }) {
 
   return (
     <DriverWarningContainer p={2} {...props}>
-      <Warnings
-        className="mx2 align-self-end text-gold"
-        warnings={[tooltipWarning]}
-        size={20}
-      />
+      <IconContainer>
+        <Warnings
+          className="mx2 text-gold"
+          warnings={[tooltipWarning]}
+          size={20}
+        />
+      </IconContainer>
       <CardContent flexDirection="column" justify="center" className="ml2">
         <div>
           <p className="text-medium m0">{message}</p>

--- a/frontend/src/metabase/components/DriverWarning/DriverWarning.styled.js
+++ b/frontend/src/metabase/components/DriverWarning/DriverWarning.styled.js
@@ -3,6 +3,12 @@ import { Flex } from "grid-styled";
 
 export const CardContent = styled(Flex)``;
 
+export const IconContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
 export const DriverWarningContainer = styled(Flex)`
   background-color: #f9fbfb;
   border-radius: 10px;

--- a/frontend/src/metabase/components/DriverWarning/index.js
+++ b/frontend/src/metabase/components/DriverWarning/index.js
@@ -1,1 +1,1 @@
-export * from "./DriverWarning";
+export { default } from "./DriverWarning";

--- a/frontend/src/metabase/setup/components/Setup.jsx
+++ b/frontend/src/metabase/setup/components/Setup.jsx
@@ -8,7 +8,7 @@ import MetabaseAnalytics from "metabase/lib/analytics";
 import MetabaseSettings from "metabase/lib/settings";
 
 import AddDatabaseHelpCard from "metabase/components/AddDatabaseHelpCard";
-import DriverWarning from "metabase/components/DriverWarning/DriverWarning";
+import DriverWarning from "metabase/components/DriverWarning";
 import ExternalLink from "metabase/components/ExternalLink";
 import LogoIcon from "metabase/components/LogoIcon";
 import NewsletterForm from "metabase/components/NewsletterForm";


### PR DESCRIPTION
Centers warning icon vertically and fixes how `DriverWarning` is imported, so we don't need to `import from ".../DriverWarning/DriverWarning` and so we don't get warnings about not used `DriverWarning/index.js` file

### Demo

**Before**

<img width="321" alt="CleanShot 2021-07-23 at 15 08 17@2x" src="https://user-images.githubusercontent.com/17258145/126779639-e1353858-49e5-4a4a-b68d-7fbf49043276.png">

**After**

<img width="328" alt="CleanShot 2021-07-23 at 15 08 06@2x" src="https://user-images.githubusercontent.com/17258145/126779644-cacb2ee5-9a78-4e9c-89da-a03a02bd342b.png">
