### PR TITLE
[Dashboard filters coverage] Add initial set of tests for dashboard number filters

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-date.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-date.cy.spec.js
@@ -13,7 +13,7 @@ import * as DateFilter from "../native-filters/helpers/e2e-date-filter-helpers";
 
 Object.entries(DASHBOARD_DATE_FILTERS).forEach(
   ([filter, { value, representativeResult }]) => {
-    describe(`should work for ${filter}`, () => {
+    describe("scenarios > dashboard > filters > date", () => {
       beforeEach(() => {
         cy.intercept("GET", "/api/table/*/query_metadata").as("metadata");
 
@@ -61,6 +61,7 @@ Object.entries(DASHBOARD_DATE_FILTERS).forEach(
           filterType: filter,
           filterValue: value,
         });
+
         saveDashboard();
 
         cy.get(".Card").within(() => {

--- a/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-number.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-number.cy.spec.js
@@ -1,0 +1,65 @@
+import {
+  restore,
+  popover,
+  mockSessionProperty,
+  filterWidget,
+  editDashboard,
+  saveDashboard,
+  setFilter,
+} from "__support__/e2e/cypress";
+
+import { DASHBOARD_NUMBER_FILTERS } from "./helpers/e2e-dashboard-filter-data-objects";
+import { addWidgetNumberFilter } from "../native-filters/helpers/e2e-field-filter-helpers";
+
+Object.entries(DASHBOARD_NUMBER_FILTERS).forEach(
+  ([filter, { value, representativeResult }]) => {
+    describe("scenarios > dashboard > filters > number", () => {
+      beforeEach(() => {
+        cy.intercept("GET", "/api/table/*/query_metadata").as("metadata");
+
+        restore();
+        cy.signInAsAdmin();
+
+        mockSessionProperty("field-filter-operators-enabled?", true);
+
+        cy.visit("/dashboard/1");
+
+        editDashboard();
+        setFilter("Number", filter);
+
+        cy.findByText("Column to filter on")
+          .next("a")
+          .click();
+
+        popover()
+          .contains("Tax")
+          .click();
+      });
+
+      it(`should work for "${filter}" when set through the filter widget`, () => {
+        saveDashboard();
+
+        filterWidget().click();
+        addWidgetNumberFilter(value);
+
+        cy.get(".Card").within(() => {
+          cy.findByText(representativeResult);
+        });
+      });
+
+      it(`should work for "${filter}" when set as the default filter`, () => {
+        cy.findByText("Default value")
+          .next()
+          .click();
+
+        addWidgetNumberFilter(value);
+
+        saveDashboard();
+
+        cy.get(".Card").within(() => {
+          cy.findByText(representativeResult);
+        });
+      });
+    });
+  },
+);

--- a/frontend/test/metabase/scenarios/dashboard-filters/helpers/e2e-dashboard-filter-data-objects.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/helpers/e2e-dashboard-filter-data-objects.js
@@ -35,3 +35,26 @@ export const DASHBOARD_DATE_FILTERS = {
     representativeResult: "37.65",
   },
 };
+
+export const DASHBOARD_NUMBER_FILTERS = {
+  "Equal to": {
+    value: "2.07",
+    representativeResult: "37.65",
+  },
+  "Not equal to": {
+    value: "2.07",
+    representativeResult: "110.93",
+  },
+  Between: {
+    value: ["3", "5"],
+    representativeResult: "68.23",
+  },
+  "Greater than or equal to": {
+    value: "6.01",
+    representativeResult: "110.93",
+  },
+  "Less than or equal to": {
+    value: "2",
+    representativeResult: "29.8",
+  },
+};


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- As an ongoing effort to increase the test coverage of dashboard filters (https://github.com/metabase/metabase/issues/17078), this PR adds basic tests around number filters
    - Make sure filter can be set via filter widget
    - Make sure filter can be set as the default filter

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/126815402-11af0877-d586-4e7b-8a02-5d3fa3ac3a0b.png)

