### PR TITLE
[Dashboard filters coverage] Add initial set of tests for dashboard ID filter

### DIFF
--- a/frontend/test/__support__/e2e/helpers/e2e-dashboard-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-dashboard-helpers.js
@@ -44,6 +44,9 @@ export function setFilter(type, subType) {
 
   popover().within(() => {
     cy.findByText(type).click();
-    cy.findByText(subType).click();
+
+    if (subType) {
+      cy.findByText(subType).click();
+    }
   });
 }

--- a/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-id.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-id.cy.spec.js
@@ -1,0 +1,133 @@
+import {
+  restore,
+  popover,
+  mockSessionProperty,
+  filterWidget,
+  editDashboard,
+  saveDashboard,
+  setFilter,
+  checkFilterLabelAndValue,
+} from "__support__/e2e/cypress";
+
+import { addWidgetStringFilter } from "../native-filters/helpers/e2e-field-filter-helpers";
+
+describe("scenarios > dashboard > filters > ID", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    mockSessionProperty("field-filter-operators-enabled?", true);
+
+    cy.visit("/dashboard/1");
+
+    editDashboard();
+    setFilter("ID");
+
+    cy.findByText("Column to filter on")
+      .next("a")
+      .click();
+  });
+
+  describe("should work for the primary key", () => {
+    beforeEach(() => {
+      popover()
+        .contains("ID")
+        .first()
+        .click();
+    });
+
+    it("when set through the filter widget", () => {
+      saveDashboard();
+
+      filterWidget().click();
+      addWidgetStringFilter("15");
+
+      cy.get(".Card").within(() => {
+        cy.findByText("114.42");
+      });
+    });
+
+    it("when set as the default filter", () => {
+      cy.findByText("Default value")
+        .next()
+        .click();
+      addWidgetStringFilter("15");
+
+      saveDashboard();
+
+      cy.get(".Card").within(() => {
+        cy.findByText("114.42");
+      });
+    });
+  });
+
+  describe("should work for the foreign key", () => {
+    beforeEach(() => {
+      popover()
+        .contains("User ID")
+        .click();
+    });
+
+    it("when set through the filter widget", () => {
+      saveDashboard();
+
+      filterWidget().click();
+      addWidgetStringFilter("4");
+
+      cy.get(".Card").within(() => {
+        cy.findByText("47.68");
+      });
+
+      checkFilterLabelAndValue("ID", "Arnold Adams - 4");
+    });
+
+    it("when set as the default filter", () => {
+      cy.findByText("Default value")
+        .next()
+        .click();
+      addWidgetStringFilter("4");
+
+      saveDashboard();
+
+      cy.get(".Card").within(() => {
+        cy.findByText("47.68");
+      });
+
+      checkFilterLabelAndValue("ID", "Arnold Adams - 4");
+    });
+  });
+
+  describe("should work on the implicit join", () => {
+    beforeEach(() => {
+      popover().within(() => {
+        cy.findAllByText("ID")
+          .last()
+          .click();
+      });
+    });
+
+    it("when set through the filter widget", () => {
+      saveDashboard();
+
+      filterWidget().click();
+      addWidgetStringFilter("10");
+
+      cy.get(".Card").within(() => {
+        cy.findByText("6.75");
+      });
+    });
+
+    it("when set as the default filter", () => {
+      cy.findByText("Default value")
+        .next()
+        .click();
+      addWidgetStringFilter("10");
+
+      saveDashboard();
+
+      cy.get(".Card").within(() => {
+        cy.findByText("6.75");
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- As an ongoing effort to increase the test coverage of dashboard filters (https://github.com/metabase/metabase/issues/17078), this PR adds basic tests around ID filter
    - Make sure filter can be set via filter widget
    - Make sure filter can be set as the default filter
- Checked paths:
    - primary key
    - foreign key
    - implicit join field

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/126820952-f50e57ab-432a-4419-9d25-f98672d8d225.png)


