### PR TITLE
[Dashboard filters coverage] Add initial set of tests for dashboard location filters

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-location.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-location.cy.spec.js
@@ -1,0 +1,63 @@
+import {
+  restore,
+  popover,
+  mockSessionProperty,
+  filterWidget,
+  editDashboard,
+  saveDashboard,
+  setFilter,
+} from "__support__/e2e/cypress";
+
+import { DASHBOARD_LOCATION_FILTERS } from "./helpers/e2e-dashboard-filter-data-objects";
+import { addWidgetStringFilter } from "../native-filters/helpers/e2e-field-filter-helpers";
+
+Object.entries(DASHBOARD_LOCATION_FILTERS).forEach(
+  ([filter, { value, representativeResult }]) => {
+    describe("scenarios > dashboard > filters > location", () => {
+      beforeEach(() => {
+        restore();
+        cy.signInAsAdmin();
+
+        mockSessionProperty("field-filter-operators-enabled?", true);
+
+        cy.visit("/dashboard/1");
+
+        editDashboard();
+        setFilter("Location", filter);
+
+        cy.findByText("Column to filter on")
+          .next("a")
+          .click();
+
+        popover()
+          .contains("City")
+          .click();
+      });
+
+      it(`should work for "${filter}" when set through the filter widget`, () => {
+        saveDashboard();
+
+        filterWidget().click();
+        addWidgetStringFilter(value);
+
+        cy.get(".Card").within(() => {
+          cy.contains(representativeResult);
+        });
+      });
+
+      it(`should work for "${filter}" when set as the default filter`, () => {
+        cy.findByText("Default value")
+          .next()
+          .click();
+
+        addWidgetStringFilter(value);
+
+        saveDashboard();
+
+        cy.get(".Card").within(() => {
+          cy.contains(representativeResult);
+        });
+      });
+    });
+  },
+);

--- a/frontend/test/metabase/scenarios/dashboard-filters/helpers/e2e-dashboard-filter-data-objects.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/helpers/e2e-dashboard-filter-data-objects.js
@@ -58,3 +58,30 @@ export const DASHBOARD_NUMBER_FILTERS = {
     representativeResult: "29.8",
   },
 };
+
+export const DASHBOARD_LOCATION_FILTERS = {
+  Dropdown: {
+    value: "Abbeville",
+    representativeResult: "1510",
+  },
+  "Is not": {
+    value: "Abbeville",
+    representativeResult: "37.65",
+  },
+  Contains: {
+    value: "Abb",
+    representativeResult: "1510",
+  },
+  "Does not contain": {
+    value: "Abb",
+    representativeResult: "37.65",
+  },
+  "Starts with": {
+    value: "Abb",
+    representativeResult: "1510",
+  },
+  "Ends with": {
+    value: "y",
+    representativeResult: "115.24",
+  },
+};


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- As an ongoing effort to increase the test coverage of dashboard filters (https://github.com/metabase/metabase/issues/17078), this PR adds basic tests around location filters
    - Make sure filter can be set via filter widget
    - Make sure filter can be set as the default filter
    - It does so using "Orders" table, which means we're filtering on an implicit join

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/126825016-cdc3d7b8-2ae8-4947-8cf0-20d1e5599746.png)

