### PR TITLE
[Dashboard filters coverage] Add initial set of tests for dashboard text/category filters

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-text-category.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-text-category.cy.spec.js
@@ -1,0 +1,63 @@
+import {
+  restore,
+  popover,
+  mockSessionProperty,
+  filterWidget,
+  editDashboard,
+  saveDashboard,
+  setFilter,
+} from "__support__/e2e/cypress";
+
+import { DASHBOARD_TEXT_FILTERS } from "./helpers/e2e-dashboard-filter-data-objects";
+import { addWidgetStringFilter } from "../native-filters/helpers/e2e-field-filter-helpers";
+
+Object.entries(DASHBOARD_TEXT_FILTERS).forEach(
+  ([filter, { value, representativeResult }]) => {
+    describe("scenarios > dashboard > filters > text/category", () => {
+      beforeEach(() => {
+        restore();
+        cy.signInAsAdmin();
+
+        mockSessionProperty("field-filter-operators-enabled?", true);
+
+        cy.visit("/dashboard/1");
+
+        editDashboard();
+        setFilter("Text or Category", filter);
+
+        cy.findByText("Column to filter on")
+          .next("a")
+          .click();
+
+        popover()
+          .contains("Source")
+          .click();
+      });
+
+      it(`should work for "${filter}" when set through the filter widget`, () => {
+        saveDashboard();
+
+        filterWidget().click();
+        addWidgetStringFilter(value);
+
+        cy.get(".Card").within(() => {
+          cy.contains(representativeResult);
+        });
+      });
+
+      it(`should work for "${filter}" when set as the default filter`, () => {
+        cy.findByText("Default value")
+          .next()
+          .click();
+
+        addWidgetStringFilter(value);
+
+        saveDashboard();
+
+        cy.get(".Card").within(() => {
+          cy.contains(representativeResult);
+        });
+      });
+    });
+  },
+);

--- a/frontend/test/metabase/scenarios/dashboard-filters/helpers/e2e-dashboard-filter-data-objects.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/helpers/e2e-dashboard-filter-data-objects.js
@@ -85,3 +85,30 @@ export const DASHBOARD_LOCATION_FILTERS = {
     representativeResult: "115.24",
   },
 };
+
+export const DASHBOARD_TEXT_FILTERS = {
+  Dropdown: {
+    value: "Organic",
+    representativeResult: "39.58",
+  },
+  "Is not": {
+    value: "Organic",
+    representativeResult: "37.65",
+  },
+  Contains: {
+    value: "oo",
+    representativeResult: "148.23",
+  },
+  "Does not contain": {
+    value: "oo",
+    representativeResult: "37.65",
+  },
+  "Starts with": {
+    value: "A",
+    representativeResult: "85.72",
+  },
+  "Ends with": {
+    value: "e",
+    representativeResult: "47.68",
+  },
+};


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- As an ongoing effort to increase the test coverage of dashboard filters (https://github.com/metabase/metabase/issues/17078), this PR adds basic tests around text/category filters
    - Make sure filter can be set via filter widget
    - Make sure filter can be set as the default filter
    - It does so using "Orders" table, which means we're filtering on an implicit join

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/126830075-c93b3b48-630f-4536-9d4b-f8586fef19b3.png)


