### PR TITLE
Create license files for deps

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -21,6 +21,7 @@
                               (let-404)
                               (macros/case 0)
                               (match 1)
+                              (c/step 1)
                               (mbql.match/match 1)
                               (mt/test-drivers 1)
                               (mt/query 1)

--- a/bin/build-mb/test/build/licenses_test.clj
+++ b/bin/build-mb/test/build/licenses_test.clj
@@ -207,28 +207,26 @@
 
 (deftest all-deps-have-licenses
   (testing "All deps on the classpath have licenses"
-    (loop-until-success #(u/sh {:dir u/project-root-directory} "lein" "with-profile" "+include-all-drivers,+oss,+ee" "deps") 3 "download deps")
-    (doseq [edition [:oss :ee]]
-      (let [classpath (u/sh {:dir    u/project-root-directory
-                             :quiet? true}
-                            "lein"
-                            "with-profile" (str \- "dev"
-                                                (str \, \+ (name edition))
-                                                \,"+include-all-drivers")
-                            "classpath")
-            classpath-entries (->> (str/split (last classpath) (re-pattern lic/classpath-separator))
-                                   (filter lic/jar-file?))]
-        (let [results (lic/process* {:classpath-entries classpath-entries
-                                     :backfill  (edn/read-string
-                                                 (slurp (io/resource "overrides.edn")))})]
-          (is (nil? (:without-license results))
-              (str "Deps without license information:\n"
-                   (str/join "\n" (map first (:without-license results)))))
-          (is (= (set classpath-entries)
-                 (into #{} (->> results :with-license (map first))))))
-        (is (some? (:without-license
-                    (lic/process* {:classpath-entries classpath-entries
-                                   :backfill  {}}))))))))
+    (loop-until-success #(u/sh {:dir u/project-root-directory} "clojure" "-A:ee" "-P") 3 "download deps")
+    (let [edition :ee
+          classpath (u/sh {:dir    u/project-root-directory
+                           :quiet? true}
+                          "clojure"
+                          "-A:ee"
+                          "-Spath")
+          classpath-entries (->> (str/split (last classpath) (re-pattern lic/classpath-separator))
+                                 (filter lic/jar-file?))]
+      (let [results (lic/process* {:classpath-entries classpath-entries
+                                   :backfill  (edn/read-string
+                                                (slurp (io/resource "overrides.edn")))})]
+        (is (nil? (:without-license results))
+            (str "Deps without license information:\n"
+                 (str/join "\n" (map first (:without-license results)))))
+        (is (= (set classpath-entries)
+               (into #{} (->> results :with-license (map first))))))
+      (is (some? (:without-license
+                  (lic/process* {:classpath-entries classpath-entries
+                                 :backfill  {}})))))))
 (comment
   (run-tests)
   (binding [clojure.test/*test-out* *out*] (run-tests))

--- a/build.clj
+++ b/build.clj
@@ -167,7 +167,7 @@
       (clean!)
       (let [basis (create-basis edition)]
         (compile-sources! basis)
-        (copy-resources! basis)
+        (copy-resources! edition basis)
         (create-uberjar! basis)
         (update-manifest!))
       (c/announce "Built target/uberjar/metabase.jar in %.1f seconds."

--- a/build.clj
+++ b/build.clj
@@ -7,6 +7,7 @@
             [clojure.tools.namespace.dependency :as ns.deps]
             [clojure.tools.namespace.find :as ns.find]
             [clojure.tools.namespace.parse :as ns.parse]
+            [hf.depstar.api :as d]
             [metabuild-common.core :as c])
   (:import java.io.OutputStream
            java.net.URI
@@ -113,7 +114,7 @@
 (defn create-uberjar! [basis]
   (c/step "Create uberjar"
     (with-duration-ms [duration-ms]
-      (b/uber {:class-dir class-dir
+      (d/uber {:class-dir class-dir
                :uber-file uberjar-filename
                :basis     basis})
       (c/announce "Created uberjar in %.1f seconds." (/ duration-ms 1000.0)))))

--- a/build.clj
+++ b/build.clj
@@ -88,14 +88,16 @@
   (c/step "Create license information"
     (let [backend-path "license-backend-third-party.txt"
           frontend-path "license-frontend-third-party.txt"]
-     (license/generate {:classpath-entries (keys (:classpath basis))
-                        :backfill          "overrides.edn"
-                        :output-filename   backend-path
-                        :report?           false})
-     (let [license-text (str/join \newline
-                                  (c/sh {:quiet? true}
-                                        "yarn" "licenses" "generate-disclaimer"))]
-       (spit frontend-path license-text))
+      (c/step "Generate backend license information from jar files"
+        (license/generate {:classpath-entries (keys (:classpath basis))
+                           :backfill          "overrides.edn"
+                           :output-filename   backend-path
+                           :report?           false}))
+      (c/step "Run `yarn licenses generate-disclaimer`"
+        (let [license-text (str/join \newline
+                                     (c/sh {:quiet? true}
+                                           "yarn" "licenses" "generate-disclaimer"))]
+          (spit frontend-path license-text)))
      (b/copy-file {:src frontend-path :target (str class-dir "/" frontend-path)})
      (b/copy-file {:src backend-path :target (str class-dir "/" backend-path)})
      (b/copy-file {:src (case edition

--- a/build.clj
+++ b/build.clj
@@ -1,5 +1,5 @@
 (ns build
-  (:require [build.licenses :as licenses]
+  (:require [build.licenses :as license]
             [clojure.java.io :as io]
             [clojure.string :as str]
             [clojure.tools.build.api :as b]

--- a/deps.edn
+++ b/deps.edn
@@ -354,8 +354,9 @@
   ;; clojure -T:build uberjar :edition :ee
   :build
   {:deps       {io.github.clojure/tools.build {:git/tag "v0.1.6" :git/sha "5636e61"}
-                metabase/build.common         {:local/root "bin/common"}
-                metabase/buid-mb              {:local/root "bin/build-mb"}}
+                com.github.seancorfield/depstar {:tag "v2.1.267" :sha "1a45f79"}
+                metabase/build.common           {:local/root "bin/common"}
+                metabase/buid-mb                {:local/root "bin/build-mb"}}
    :ns-default build}
 
   ;; for working on the code in `build.clj`

--- a/deps.edn
+++ b/deps.edn
@@ -353,7 +353,7 @@
   ;; clojure -T:build uberjar
   ;; clojure -T:build uberjar :edition :ee
   :build
-  {:deps       {io.github.clojure/tools.build {:git/tag "v0.1.6" :git/sha "5636e61"}
+  {:deps       {io.github.clojure/tools.build   {:git/tag "v0.1.6" :git/sha "5636e61"}
                 com.github.seancorfield/depstar {:tag "v2.1.267" :sha "1a45f79"}
                 metabase/build.common           {:local/root "bin/common"}
                 metabase/buid-mb                {:local/root "bin/build-mb"}}
@@ -361,7 +361,7 @@
 
   ;; for working on the code in `build.clj`
   :build-dev
-  {:extra-deps {io.github.clojure/tools.build {:git/tag "v0.1.6" :git/sha "5636e61"}
+  {:extra-deps {io.github.clojure/tools.build   {:git/tag "v0.1.6" :git/sha "5636e61"}
                 com.github.seancorfield/depstar {:tag "v2.1.267" :sha "1a45f79"}
                 metabase/build.common           {:local/root "bin/common"}
                 metabase/buid-mb                {:local/root "bin/build-mb"}}}

--- a/deps.edn
+++ b/deps.edn
@@ -354,7 +354,8 @@
   ;; clojure -T:build uberjar :edition :ee
   :build
   {:deps       {io.github.clojure/tools.build {:git/tag "v0.1.6" :git/sha "5636e61"}
-                metabase/build.common         {:local/root "bin/common"}}
+                metabase/build.common         {:local/root "bin/common"}
+                metabase/buid-mb              {:local/root "bin/build-mb"}}
    :ns-default build}
 
   ;; for working on the code in `build.clj`

--- a/deps.edn
+++ b/deps.edn
@@ -362,7 +362,9 @@
   ;; for working on the code in `build.clj`
   :build-dev
   {:extra-deps {io.github.clojure/tools.build {:git/tag "v0.1.6" :git/sha "5636e61"}
-                metabase/build.common         {:local/root "bin/common"}}}
+                com.github.seancorfield/depstar {:tag "v2.1.267" :sha "1a45f79"}
+                metabase/build.common           {:local/root "bin/common"}
+                metabase/buid-mb                {:local/root "bin/build-mb"}}}
 
 ;;; Other misc convenience aliases
 


### PR DESCRIPTION
Let me know if this isn't what you had in mind. I wasn't sure if you wanted to just call into build-mb but i saw that it wasn't on the classpath. I added it so i could use the license.clj file as a resource. But if i'm reading correctly, the whole build-mb goes away, and we can just put the license.clj file wherever makes the most sense. But this gets our licenses created for us.