### PR TITLE
Don't use extend for PaddedTextButton

### DIFF
--- a/frontend/src/metabase/components/ClampedText.jsx
+++ b/frontend/src/metabase/components/ClampedText.jsx
@@ -3,10 +3,11 @@ import PropTypes from "prop-types";
 import cx from "classnames";
 import { t } from "ttag";
 
+import styled from "styled-components";
 import { ClampedDiv } from "./ClampedText.styled";
 import { TextButton } from "metabase/components/Button.styled";
 
-const PaddedTextButton = TextButton.extend`
+const PaddedTextButton = styled(TextButton)`
   margin: 0.5rem 0;
 `;
 


### PR DESCRIPTION
extend is deprecated, see the previous PR #17048.
