### PR TITLE
Repro for #15342: The order of join-type causes query fail

### DIFF
--- a/frontend/test/metabase-db/mysql/reproductions/15342.cy.spec.js
+++ b/frontend/test/metabase-db/mysql/reproductions/15342.cy.spec.js
@@ -1,0 +1,82 @@
+import { restore, popover, addMySQLDatabase } from "__support__/e2e/cypress";
+
+const MYSQL_DB_NAME = "QA MySQL8";
+
+describe("15342", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+    cy.viewport(4000, 1200); // huge width required so three joined tables can fit
+    addMySQLDatabase(MYSQL_DB_NAME);
+  });
+
+  it("should correctly order joins for MySQL queries", () => {
+    cy.intercept("POST", "/api/dataset").as("query");
+
+    cy.visit("/question/new");
+    cy.findByText("Custom question").click();
+    cy.findByText(MYSQL_DB_NAME).click();
+    cy.findByText("People").click();
+
+    addJoin({
+      leftColumn: "ID",
+      rightTable: "Orders",
+      rightColumn: "Product ID",
+    });
+
+    addJoin({
+      leftTable: "Orders",
+      leftColumn: "Product ID",
+      rightTable: "Products",
+      rightColumn: "ID",
+      joinType: "inner",
+    });
+
+    cy.button("Visualize").click();
+    cy.wait("@query");
+    cy.get(".Visualization").within(() => {
+      cy.findByText("Email"); // from People table
+      cy.findByText("Orders → ID"); // joined Orders table columns
+      cy.findByText("Products → ID"); // joined Products table columns
+    });
+  });
+});
+
+function selectFromDropdown(itemName) {
+  return popover().findByText(itemName);
+}
+
+const JOIN_LABEL = {
+  left: "Left outer join",
+  right: "Right outer join",
+  inner: "Inner join",
+};
+
+function addJoin({
+  leftTable,
+  leftColumn,
+  rightTable,
+  rightColumn,
+  joinType = "left",
+} = {}) {
+  cy.icon("join_left_outer")
+    .last()
+    .click();
+
+  selectFromDropdown(rightTable).click();
+
+  if (leftTable) {
+    selectFromDropdown(leftTable).click();
+  }
+
+  selectFromDropdown(leftColumn).click();
+  selectFromDropdown(rightColumn).click();
+
+  cy.findAllByText("Join data")
+    .last()
+    .next()
+    .within(() => {
+      cy.icon("join_left_outer").click();
+    });
+  selectFromDropdown(JOIN_LABEL[joinType]).click();
+}

--- a/frontend/test/metabase-db/mysql/reproductions/15342.cy.spec.js
+++ b/frontend/test/metabase-db/mysql/reproductions/15342.cy.spec.js
@@ -2,7 +2,7 @@ import { restore, popover, addMySQLDatabase } from "__support__/e2e/cypress";
 
 const MYSQL_DB_NAME = "QA MySQL8";
 
-describe("15342", () => {
+describe.skip("15342", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();


### PR DESCRIPTION
Reproduces #15342 (The order of join-type causes query fail because of incorrect SQL - inner join is always placed before other joins)

The issue doesn't reproduce on the default H2 dataset, but it does on the MySQL QA database. So the repro test is added to `metabase-db/mysql` tests.

### Demo

![15342 -- should correctly order joins for MySQL queries (failed) (attempt 2)](https://user-images.githubusercontent.com/17258145/126989181-eb99527a-0991-4d2d-bef3-bfe52926a422.png)
