### PR TITLE
#17200 Repro: Only the first 50 user groups are displayed

### DIFF
--- a/frontend/test/metabase/scenarios/admin/people/people.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/people/people.cy.spec.js
@@ -203,6 +203,16 @@ describe("scenarios > admin > people", () => {
       assertTableRowsCount(TOTAL_USERS);
     });
 
+    it.skip("should display more than 50 groups (metabase#17200)", () => {
+      generateGroups(50);
+
+      cy.visit("/admin/people/groups");
+      // The assertion depends on the way we'll implement this.
+      // a) if we go with the pagination, the assertion will have to be updated
+      // b) if we remove the limit, the current assertion will work
+      cy.findByText("readonly");
+    });
+
     describe("pagination", () => {
       const NEW_USERS = 18;
       const NEW_TOTAL_USERS = TOTAL_USERS + NEW_USERS;
@@ -297,4 +307,10 @@ function generateUsers(count, groupIds) {
   users.forEach(u => cy.createUserFromRawData(u));
 
   return users;
+}
+
+function generateGroups(count) {
+  _.range(count).map(index => {
+    cy.request("POST", "api/permissions/group", { name: "Group" + index });
+  });
 }


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #17200

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/admin/people/people.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/126995853-c24bcb94-78c9-4a35-b9fd-0c7a16dffed6.png)

