### PR TITLE
#17186 Repro: People search dropdown goes outside of the screen

### DIFF
--- a/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
@@ -81,6 +81,15 @@ describe("scenarios > dashboard > subscriptions", () => {
         createEmailSubscription();
         cy.findByText("Emailed daily at 8:00 AM");
       });
+
+      it.skip("should not render people dropdown outside of the borders of the screen (metabase#17186)", () => {
+        openDashboardSubscriptions();
+
+        cy.findByText("Email it").click();
+        cy.findByPlaceholderText("Enter user names or email addresses").click();
+
+        popover().isRenderedWithinViewport();
+      });
     });
 
     describe("with existing subscriptions", () => {


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #17186 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/127003761-85d3eab8-ded9-442c-aa5b-0723484ca57b.png)

