### PR TITLE
Include authority_level on collections in collection items

### DIFF
--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -167,7 +167,7 @@
 (defmethod post-process-collection-children :pulse
   [_ rows]
   (for [row rows]
-    (dissoc row :description :display)))
+    (dissoc row :description :display :authority_level)))
 
 (defmethod collection-children-query :snippet
   [_ collection {:keys [archived? pinned-state]}]
@@ -180,7 +180,7 @@
 (defmethod post-process-collection-children :snippet
   [_ rows]
   (for [row rows]
-    (dissoc row :description :collection_position :display)))
+    (dissoc row :description :collection_position :display :authority_level)))
 
 (defmethod collection-children-query :card
   [_ collection {:keys [archived? pinned-state]}]
@@ -208,7 +208,7 @@
 
 (defmethod post-process-collection-children :card
   [_ rows]
-  (hydrate rows :favorite))
+  (hydrate (map #(dissoc % :authority_level) rows) :favorite))
 
 (defmethod collection-children-query :dashboard
   [_ collection {:keys [archived? pinned-state]}]
@@ -235,7 +235,7 @@
 
 (defmethod post-process-collection-children :dashboard
   [_ rows]
-  (hydrate (map #(dissoc % :display) rows) :favorite))
+  (hydrate (map #(dissoc % :display :authority_level) rows) :favorite))
 
 (defmethod collection-children-query :collection
   [_ collection {:keys [archived? collection-namespace pinned-state]}]
@@ -248,7 +248,8 @@
              :select [:id
                       :name
                       :description
-                      [(hx/literal "collection") :model]])
+                      [(hx/literal "collection") :model]
+                      :authority_level])
       ;; the nil indicates that collections are never pinned.
       (h/merge-where (pinned-state->clause pinned-state nil))))
 
@@ -317,7 +318,7 @@
   "All columns that need to be present for the union-all. Generated with the comment form below. Non-text columns that
   are optional (not id, but last_edit_user for example) must have a type so that the union-all can unify the nil with
   the correct column type."
-  [:id :name :description :display :model :collection_position
+  [:id :name :description :display :model :collection_position :authority_level
    :last_edit_email :last_edit_first_name :last_edit_last_name
    [:last_edit_user :integer] [:last_edit_timestamp :timestamp]])
 

--- a/src/metabase/models/collection/root.clj
+++ b/src/metabase/models/collection/root.clj
@@ -41,7 +41,7 @@
 
 (def ^RootCollection root-collection
   "Special placeholder object representing the Root Collection, which isn't really a real Collection."
-  (map->RootCollection {::is-root? true}))
+  (map->RootCollection {::is-root? true, :authority_level nil}))
 
 (defn is-root-collection?
   "Is `x` the special placeholder object representing the Root Collection?"

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -49,6 +49,7 @@
                  :effective_ancestors []
                  :can_write           true
                  :name                "Our analytics"
+                 :authority_level     nil
                  :id                  "root"}
                 (assoc (into {} collection) :can_write true)]
                (for [collection (mt/user-http-request :crowberto :get 200 "collection")
@@ -305,15 +306,19 @@
               true))
           items))
 
-(defn- default-item [item-map]
-  (merge {:id true, :collection_position nil} item-map))
+(defn- default-item [{:keys [model] :as item-map}]
+  (merge {:id true, :collection_position nil}
+         (when (= model "collection")
+           {:authority_level nil})
+         item-map))
 
 (defn- collection-item [collection-name & {:as extra-keypairs}]
-  (merge {:id          true
-          :description nil
-          :can_write   (str/ends-with? collection-name "Personal Collection")
-          :model       "collection"
-          :name        collection-name}
+  (merge {:id              true
+          :description     nil
+          :can_write       (str/ends-with? collection-name "Personal Collection")
+          :model           "collection"
+          :authority_level nil
+          :name            collection-name}
          extra-keypairs))
 
 (deftest collection-items-test
@@ -508,7 +513,21 @@
         (is (= ["pass" "pass"]
                (->> (mt/user-http-request :rasta :get 200 (str "collection/" collection-id "/items?models=dashboard&models=card"))
                     :data
-                    (map (comp :last_name :last-edit-info)))))))))
+                    (map (comp :last_name :last-edit-info)))))))
+    (testing "Results include authority_level"
+      (mt/with-temp* [Collection [{collection-id :id} {:name "Collection with Items"}]
+                      Collection [_ {:name "subcollection"
+                                     :location (format "/%d/" collection-id)
+                                     :authority_level "official"}]
+                      Card       [_ {:name "card" :collection_id collection-id}]
+                      Dashboard  [_ {:name "dash" :collection_id collection-id}]]
+        (let [items (->> (mt/user-http-request :rasta :get 200 (str "collection/" collection-id "/items?models=dashboard&models=card&models=collection"))
+                         :data)]
+          (is (= #{{:name "card"}
+                   {:name "dash"}
+                   {:name "subcollection" :authority_level "official"}}
+                 (into #{} (map #(select-keys % [:name :authority_level]))
+                       items))))))))
 
 (deftest children-sort-clause-test
   (testing "Default sort"
@@ -579,7 +598,11 @@
     :can_write           true
     :name                "Lucky Pigeon's Personal Collection"
     :personal_owner_id   (mt/user->id :lucky)
-    :effective_ancestors [{:metabase.models.collection.root/is-root? true, :name "Our analytics", :id "root", :can_write true}]
+    :effective_ancestors [{:metabase.models.collection.root/is-root? true
+                           :name "Our analytics"
+                           :id "root"
+                           :authority_level nil
+                           :can_write true}]
     :effective_location  "/"
     :parent_id           nil
     :id                  (u/the-id (collection/user->personal-collection (mt/user->id :lucky)))
@@ -763,6 +786,7 @@
               :can_write           true
               :effective_location  nil
               :effective_ancestors []
+              :authority_level     nil
               :parent_id           nil}
              (with-some-children-of-collection nil
                (mt/user-http-request :crowberto :get 200 "collection/root")))))
@@ -810,20 +834,22 @@
                          mt/boolean-ids-and-timestamps ))))))))
 
     (testing "So I suppose my Personal Collection should show up when I fetch the Root Collection, shouldn't it..."
-      (is (= [{:name        "Rasta Toucan's Personal Collection"
-               :id          (u/the-id (collection/user->personal-collection (mt/user->id :rasta)))
-               :description nil
-               :model       "collection"
-               :can_write   true}]
+      (is (= [{:name            "Rasta Toucan's Personal Collection"
+               :id              (u/the-id (collection/user->personal-collection (mt/user->id :rasta)))
+               :description     nil
+               :model           "collection"
+               :authority_level nil
+               :can_write       true}]
              (->> (:data (mt/user-http-request :rasta :get 200 "collection/root/items"))
                   (filter #(str/includes? (:name %) "Personal Collection"))))))
 
     (testing "For admins, only return our own Personal Collection (!)"
-      (is (= [{:name        "Crowberto Corv's Personal Collection"
-               :id          (u/the-id (collection/user->personal-collection (mt/user->id :crowberto)))
-               :description nil
-               :model       "collection"
-               :can_write   true}]
+      (is (= [{:name            "Crowberto Corv's Personal Collection"
+               :id              (u/the-id (collection/user->personal-collection (mt/user->id :crowberto)))
+               :description     nil
+               :model           "collection"
+               :authority_level nil
+               :can_write       true}]
              (->> (:data (mt/user-http-request :crowberto :get 200 "collection/root/items"))
                   (filter #(str/includes? (:name %) "Personal Collection")))))
 
@@ -831,11 +857,12 @@
         (mt/with-temp Collection [_ {:name     "Lucky's Sub-Collection"
                                      :location (collection/children-location
                                                 (collection/user->personal-collection (mt/user->id :lucky)))}]
-          (is (= [{:name        "Crowberto Corv's Personal Collection"
-                   :id          (u/the-id (collection/user->personal-collection (mt/user->id :crowberto)))
-                   :description nil
-                   :model       "collection"
-                   :can_write   true}]
+          (is (= [{:name            "Crowberto Corv's Personal Collection"
+                   :id              (u/the-id (collection/user->personal-collection (mt/user->id :crowberto)))
+                   :description     nil
+                   :model           "collection"
+                   :authority_level nil
+                   :can_write       true}]
                  (->> (:data (mt/user-http-request :crowberto :get 200 "collection/root/items"))
                       (filter #(str/includes? (:name %) "Personal Collection"))))))))
 


### PR DESCRIPTION
Fixes 

> Could you please help me with one more thing on collection types? We want to see how would official badges look on the main page (see the screenshot)
It requires a backend change: the GET /api/collection/root/items?models=collection response doesn’t contain authority_level, so I can’t make it right on the frontend. Could you please help me and add the authority_level there? Can be a PR on 0.41-collection-types-fe feature branch
![image](https://user-images.githubusercontent.com/6377293/127029292-5972a588-48a0-4dca-a1be-9d8c1dc08d62.png)


## After the fix

### Information is in the frontend

![image](https://user-images.githubusercontent.com/6377293/127028625-4d5fe0da-7877-4110-9e79-8c884f528987.png)

### Raw API
`http://localhost:3000/api/collection/root/items?models=collection&limit=500`

```javascript
{
  "total": 6,
  "data": [
    {
      "authority_level": null,
      "description": null,
      "can_write": true,
      "name": "Automatically Generated Dashboards",
      "id": 2,
      "model": "collection"
    },
    {
      "authority_level": null,
      "description": null,
      "can_write": true,
      "name": "dan sutton's Personal Collection",
      "id": 1,
      "model": "collection"
    },
    {
      "authority_level": null,
      "description": null,
      "can_write": true,
      "name": "foo",
      "id": 3219,
      "model": "collection"
    },
    {
      "authority_level": null,
      "description": null,
      "can_write": true,
      "name": "foo",
      "id": 3231,
      "model": "collection"
    },
    {
      "authority_level": null,
      "description": null,
      "can_write": true,
      "name": "foo",
      "id": 3243,
      "model": "collection"
    },
    {
      "authority_level": "official",
      "description": null,
      "can_write": true,
      "name": "they go here",
      "id": 2825,
      "model": "collection"
    }
  ],
  "models": [
    "collection"
  ],
  "limit": 500,
  "offset": 0
}
```

## Changes
Includes authority level of collections in the collection items machinery. Adjusted the root-collection psuedo-collection to also include `:authority_level nil` which is fine as we ensure that you cannot set the authority level of the root collection. That property is now on the root so that the shape of the data mimics the rest of the collections but it is essentially read-only nil.