### PR TITLE
docs: indicate that variable names must be alphanumeric

### DIFF
--- a/docs/users-guide/13-sql-parameters.md
+++ b/docs/users-guide/13-sql-parameters.md
@@ -10,7 +10,7 @@ Options and settings for your variables will appear in the `Variables` side pane
 
 ### Defining Variables
 
-Typing `{% raw %}{{variable_name}}{% endraw %}` in your native query creates a variable called `variable_name`. Variables can be given types in the side panel, which changes their behavior. All variable types other than "Field Filter" will cause a filter widget to be placed on this question corresponding to the chosen variable type. When a value is selected via a filter widget, that value replaces the corresponding variable in the SQL template, wherever it appears. If you have multiple filter widgets, you can click and drag on any of them to move and reorder them.
+Typing `{% raw %}{{variable_name}}{% endraw %}` in your native query creates a variable called `variable_name`. Only alphanumeric characters are allowed in the variable name. Variables can be given types in the side panel, which changes their behavior. All variable types other than "Field Filter" will cause a filter widget to be placed on this question corresponding to the chosen variable type. When a value is selected via a filter widget, that value replaces the corresponding variable in the SQL template, wherever it appears. If you have multiple filter widgets, you can click and drag on any of them to move and reorder them.
 
 This example defines a variable called `cat`, allowing you to dynamically change the `WHERE` clause in this query:
 


### PR DESCRIPTION
If you use a non-alphanumeric variable name like `variable_name` the variable does not appear in the side bar which is quite confusing. There is a comment in the code that indicates only alphanumeric values are accepted, so I added this line in the docs to reflect that. https://github.com/metabase/metabase/blob/master/frontend/src/metabase-lib/lib/queries/NativeQuery.js#L378

It also says another form is allowed, but I'm not sure that it should be in the documentation.

###### Before submitting the PR, please make sure you do the following

- [ ] If you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.

### Tests

- [ ] Run the frontend and Cypress end-to-end tests with `yarn lint && yarn test`)
- [ ] If there are changes to the backend codebase, run the backend tests with `lein test && lein lint && ./bin/reflection-linter`

- [ ] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
      (unless it's a tiny documentation change).
