### PR TITLE
Default pagination #17200

### DIFF
--- a/frontend/test/metabase/scenarios/admin/people/people.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/people/people.cy.spec.js
@@ -203,14 +203,11 @@ describe("scenarios > admin > people", () => {
       assertTableRowsCount(TOTAL_USERS);
     });
 
-    it.skip("should display more than 50 groups (metabase#17200)", () => {
-      generateGroups(50);
+    it("should display more than 50 groups (metabase#17200)", () => {
+      generateGroups(60);
 
       cy.visit("/admin/people/groups");
-      // The assertion depends on the way we'll implement this.
-      // a) if we go with the pagination, the assertion will have to be updated
-      // b) if we remove the limit, the current assertion will work
-      cy.findByText("readonly");
+      cy.findByText("Group 59");
     });
 
     describe("pagination", () => {

--- a/frontend/test/metabase/scenarios/admin/people/people.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/people/people.cy.spec.js
@@ -207,7 +207,7 @@ describe("scenarios > admin > people", () => {
       generateGroups(60);
 
       cy.visit("/admin/people/groups");
-      cy.findByText("Group 59");
+      cy.findByText("59");
     });
 
     describe("pagination", () => {

--- a/frontend/test/metabase/scenarios/admin/people/people.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/people/people.cy.spec.js
@@ -204,11 +204,11 @@ describe("scenarios > admin > people", () => {
     });
 
     it("should display more than 50 groups (metabase#17200)", () => {
-      generateGroups(60);
+      generateGroups(51);
 
       cy.visit("/admin/people/groups");
       cy.scrollTo("bottom");
-      cy.findByText("59");
+      cy.findByText("readonly");
     });
 
     describe("pagination", () => {

--- a/frontend/test/metabase/scenarios/admin/people/people.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/people/people.cy.spec.js
@@ -207,6 +207,7 @@ describe("scenarios > admin > people", () => {
       generateGroups(60);
 
       cy.visit("/admin/people/groups");
+      cy.scrollTo("bottom");
       cy.findByText("59");
     });
 

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -409,7 +409,10 @@
                      :order-by sql-order}
         ;; We didn't implement collection pagination for snippets namespace for root/items
         ;; Rip out the limit for now and put it back in when we want it
-        limit-query (if (= (:collection-namespace options) "snippets")
+        limit-query (if (or
+                          (nil? offset-paging/*limit*)
+                          (nil? offset-paging/*offset*)
+                          (= (:collection-namespace options) "snippets"))
                       rows-query
                       (assoc rows-query
                              :limit  offset-paging/*limit*

--- a/src/metabase/server/middleware/offset_paging.clj
+++ b/src/metabase/server/middleware/offset_paging.clj
@@ -3,14 +3,11 @@
             [metabase.server.middleware.security :as mw.security ]
             [metabase.util.i18n :refer [tru]]))
 
+(def ^:dynamic *limit* "Limit for offset-limit paging." nil)
 (def ^:private default-limit 50)
 
-(def ^:dynamic *limit*
-  "Limit for offset-limit paging.
-  Default set by default-limit in offset paging middleware."
-  default-limit)
-
-(def ^:dynamic *offset* "Offset for offset-limit paging. Default is no offset." 0)
+(def ^:dynamic *offset* "Offset for offset-limit paging." nil)
+(def ^:private default-offset 0)
 
 (def ^:dynamic *paged?*
   "Bool for whether a request is paged or not.
@@ -24,7 +21,7 @@
   (let [limit  (or (some-> limit Integer/parseUnsignedInt)
                    default-limit)
         offset (or (some-> offset Integer/parseUnsignedInt)
-                   0)]
+                   default-offset)]
     {:limit limit, :offset offset}))
 
 (defn- with-paging-params [request {:keys [limit offset]}]
@@ -56,7 +53,7 @@
                                  {:message (tru "Error parsing paging parameters: {0}" (ex-message e))})}))
           (let [{:keys [limit offset]} paging-params
                 request                (with-paging-params request paging-params)]
-            (binding [*limit*         limit
-                      *offset*        offset
+            (binding [*limit*  limit
+                      *offset* offset
                       *paged?* true]
               (handler request respond raise))))))))

--- a/test/metabase/server/middleware/offset_paging_test.clj
+++ b/test/metabase/server/middleware/offset_paging_test.clj
@@ -24,8 +24,8 @@
   (testing "no paging params"
     (is (= {:status  200
             :headers {}
-            :body    {:limit  @#'mw.offset-paging/default-limit
-                      :offset 0
+            :body    {:limit  nil
+                      :offset nil
                       :paged? false
                       :params {}}}
            (handler (ring.mock/request :get "/")))))


### PR DESCRIPTION
#17200 is the second bug where the empirical fact that the default behavior was pagination was a thing. Underlying problem is that we reach into the mutable variable and I didn't realize that the pre-param setting mutable variables are still set by default. Nil them out and the nil pagination behavior that I put in everywhere actually happens