### PR TITLE
Display official collection badge on the homepage

### DIFF
--- a/frontend/src/metabase/components/CollectionItem.jsx
+++ b/frontend/src/metabase/components/CollectionItem.jsx
@@ -1,13 +1,15 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { Flex } from "grid-styled";
 
 import Card from "metabase/components/Card";
 import Ellipsified from "metabase/components/Ellipsified";
-import Icon from "metabase/components/Icon";
-import Link from "metabase/components/Link";
 
-import { color } from "metabase/lib/colors";
+import {
+  ItemLink,
+  IconContainer,
+  CardContent,
+  CollectionIcon,
+} from "./CollectionItem.styled";
 
 const propTypes = {
   collection: PropTypes.object.isRequired,
@@ -17,32 +19,18 @@ const propTypes = {
 
 const CollectionItem = ({ collection, event, iconName }) => {
   return (
-    <Link
-      to={collection.getUrl()}
-      bg={color("bg-medium")}
-      color={color("text-medium")}
-      className="block rounded relative text-brand-hover"
-      data-metabase-event={event}
-      hover={{ color: color("brand") }}
-    >
+    <ItemLink to={collection.getUrl()} data-metabase-event={event}>
       <Card hoverable>
-        <Flex align="center" py={1} px={1} key={`collection-${collection.id}`}>
-          <Flex
-            align="center"
-            justify="center"
-            w="42px"
-            bg={color("bg-dark")}
-            style={{ height: 42, borderRadius: 6, flexShrink: 0 }}
-            mr={1}
-          >
-            <Icon name={iconName} color={color("white")} />
-          </Flex>
+        <CardContent>
+          <IconContainer>
+            <CollectionIcon name={iconName} />
+          </IconContainer>
           <h4 className="overflow-hidden">
             <Ellipsified>{collection.name}</Ellipsified>
           </h4>
-        </Flex>
+        </CardContent>
       </Card>
-    </Link>
+    </ItemLink>
   );
 };
 

--- a/frontend/src/metabase/components/CollectionItem.jsx
+++ b/frontend/src/metabase/components/CollectionItem.jsx
@@ -1,5 +1,5 @@
-/* eslint-disable react/prop-types */
 import React from "react";
+import PropTypes from "prop-types";
 import { Flex } from "grid-styled";
 
 import Card from "metabase/components/Card";
@@ -9,35 +9,24 @@ import Link from "metabase/components/Link";
 
 import { color } from "metabase/lib/colors";
 
-const ItemLink = ({ collection, event, children }) => (
-  <Link
-    to={collection.getUrl()}
-    bg={color("bg-medium")}
-    color={color("text-medium")}
-    className="block rounded relative text-brand-hover"
-    data-metabase-event={event}
-    hover={{ color: color("brand") }}
-  >
-    {children}
-  </Link>
-);
+const propTypes = {
+  collection: PropTypes.object.isRequired,
+  iconName: PropTypes.string,
+  event: PropTypes.string,
+};
 
-const ItemInfo = props => (
-  <h4 className="overflow-hidden">
-    <Ellipsified>{props.collection.name}</Ellipsified>
-  </h4>
-);
-
-const CollectionItem = props => {
+const CollectionItem = ({ collection, event, iconName }) => {
   return (
-    <ItemLink {...props}>
+    <Link
+      to={collection.getUrl()}
+      bg={color("bg-medium")}
+      color={color("text-medium")}
+      className="block rounded relative text-brand-hover"
+      data-metabase-event={event}
+      hover={{ color: color("brand") }}
+    >
       <Card hoverable>
-        <Flex
-          align="center"
-          py={1}
-          px={1}
-          key={`collection-${props.collection.id}`}
-        >
+        <Flex align="center" py={1} px={1} key={`collection-${collection.id}`}>
           <Flex
             align="center"
             justify="center"
@@ -46,14 +35,18 @@ const CollectionItem = props => {
             style={{ height: 42, borderRadius: 6, flexShrink: 0 }}
             mr={1}
           >
-            <Icon name={props.iconName} color={color("white")} />
+            <Icon name={iconName} color={color("white")} />
           </Flex>
-          <ItemInfo {...props} />
+          <h4 className="overflow-hidden">
+            <Ellipsified>{collection.name}</Ellipsified>
+          </h4>
         </Flex>
       </Card>
-    </ItemLink>
+    </Link>
   );
 };
+
+CollectionItem.propTypes = propTypes;
 
 CollectionItem.defaultProps = {
   iconName: "folder",

--- a/frontend/src/metabase/components/CollectionItem.jsx
+++ b/frontend/src/metabase/components/CollectionItem.jsx
@@ -44,41 +44,28 @@ const ItemInfo = props => (
 );
 
 const CollectionItem = props => {
-  const icon = (
-    <Icon
-      name={props.iconName}
-      mx={props.asCard ? 0 : 1}
-      color={props.asCard ? "white" : color("bg-dark")}
-    />
-  );
-
-  const content = (
-    <Flex
-      align="center"
-      py={props.asCard ? 1 : 2}
-      px={props.asCard ? 1 : 0}
-      key={`collection-${props.collection.id}`}
-    >
-      {props.asCard ? (
-        <Flex
-          align="center"
-          justify="center"
-          w="42px"
-          bg={color("bg-dark")}
-          style={{ height: 42, borderRadius: 6, flexShrink: 0 }}
-          mr={1}
-        >
-          {icon}
-        </Flex>
-      ) : (
-        icon
-      )}
-      <ItemInfo {...props} />
-    </Flex>
-  );
   return (
     <ItemLink {...props}>
-      {props.asCard ? <Card hoverable>{content}</Card> : content}
+      <Card hoverable>
+        <Flex
+          align="center"
+          py={1}
+          px={1}
+          key={`collection-${props.collection.id}`}
+        >
+          <Flex
+            align="center"
+            justify="center"
+            w="42px"
+            bg={color("bg-dark")}
+            style={{ height: 42, borderRadius: 6, flexShrink: 0 }}
+            mr={1}
+          >
+            <Icon name={props.iconName} color={color("white")} />
+          </Flex>
+          <ItemInfo {...props} />
+        </Flex>
+      </Card>
     </ItemLink>
   );
 };

--- a/frontend/src/metabase/components/CollectionItem.jsx
+++ b/frontend/src/metabase/components/CollectionItem.jsx
@@ -9,28 +9,13 @@ import Link from "metabase/components/Link";
 
 import { color } from "metabase/lib/colors";
 
-const ItemLink = ({ collection, hovered, highlighted, event, children }) => (
+const ItemLink = ({ collection, event, children }) => (
   <Link
     to={collection.getUrl()}
-    bg={
-      hovered
-        ? color("brand")
-        : highlighted
-        ? color("bg-light")
-        : color("bg-medium")
-    }
-    color={hovered ? "white" : color("text-medium")}
+    bg={color("bg-medium")}
+    color={color("text-medium")}
     className="block rounded relative text-brand-hover"
     data-metabase-event={event}
-    style={{
-      borderSize: 1,
-      borderColor: hovered
-        ? color("brand")
-        : highlighted
-        ? color("bg-medium")
-        : "transparent",
-      borderStyle: hovered ? "solid" : highlighted ? "dotted" : "solid",
-    }}
     hover={{ color: color("brand") }}
   >
     {children}

--- a/frontend/src/metabase/components/CollectionItem.jsx
+++ b/frontend/src/metabase/components/CollectionItem.jsx
@@ -4,6 +4,8 @@ import PropTypes from "prop-types";
 import Card from "metabase/components/Card";
 import Ellipsified from "metabase/components/Ellipsified";
 
+import { getCollectionIcon } from "metabase/entities/collections";
+
 import {
   ItemLink,
   IconContainer,
@@ -13,17 +15,17 @@ import {
 
 const propTypes = {
   collection: PropTypes.object.isRequired,
-  iconName: PropTypes.string,
   event: PropTypes.string,
 };
 
-const CollectionItem = ({ collection, event, iconName }) => {
+const CollectionItem = ({ collection, event }) => {
+  const icon = getCollectionIcon(collection);
   return (
     <ItemLink to={collection.getUrl()} data-metabase-event={event}>
       <Card hoverable>
         <CardContent>
           <IconContainer>
-            <CollectionIcon name={iconName} />
+            <CollectionIcon name={icon.name} />
           </IconContainer>
           <h4 className="overflow-hidden">
             <Ellipsified>{collection.name}</Ellipsified>
@@ -35,9 +37,5 @@ const CollectionItem = ({ collection, event, iconName }) => {
 };
 
 CollectionItem.propTypes = propTypes;
-
-CollectionItem.defaultProps = {
-  iconName: "folder",
-};
 
 export default CollectionItem;

--- a/frontend/src/metabase/components/CollectionItem.styled.js
+++ b/frontend/src/metabase/components/CollectionItem.styled.js
@@ -1,0 +1,38 @@
+import styled from "styled-components";
+import Icon from "metabase/components/Icon";
+import Link from "metabase/components/Link";
+import { space } from "metabase/styled-components/theme";
+import { color } from "metabase/lib/colors";
+
+export const ItemLink = styled(Link)`
+  display: block;
+  background-color: ${color("bg-medium")};
+  color: ${color("text-medium")};
+  border-radius: 8px;
+
+  &:hover {
+    color: ${color("brand")};
+  }
+`;
+
+export const IconContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  height: 42px;
+  width: 42px;
+  background-color: ${color("bg-dark")};
+  margin-right: ${space(1)};
+  border-radius: 6px;
+`;
+
+export const CardContent = styled.div`
+  display: flex;
+  align-items: center;
+  padding: ${space(1)};
+`;
+
+export const CollectionIcon = styled(Icon)`
+  color: ${color("white")};
+`;

--- a/frontend/src/metabase/components/CollectionList.jsx
+++ b/frontend/src/metabase/components/CollectionList.jsx
@@ -6,6 +6,8 @@ import { connect } from "react-redux";
 import CollectionItem from "metabase/components/CollectionItem";
 import { Grid, GridItem } from "metabase/components/Grid";
 
+import { getUser } from "metabase/selectors/user";
+
 const propTypes = {
   collections: PropTypes.arrayOf(PropTypes.object).isRequired,
   currentUser: PropTypes.shape({
@@ -15,36 +17,36 @@ const propTypes = {
   analyticsContext: PropTypes.string,
 };
 
-@connect(
-  ({ currentUser }) => ({ currentUser }),
-  null,
-)
-class CollectionList extends React.Component {
-  render() {
-    const { analyticsContext, collections, currentUser, w } = this.props;
-    return (
-      <Box className="relative">
-        <Grid>
-          {collections
-            .filter(c => c.id !== currentUser.personal_collection_id)
-            .map(collection => (
-              <GridItem w={w} key={collection.id}>
-                <CollectionItem
-                  collection={collection}
-                  event={`${analyticsContext};Collection List;Collection click`}
-                />
-              </GridItem>
-            ))}
-        </Grid>
-      </Box>
-    );
-  }
+function mapStateToProps(state) {
+  return {
+    currentUser: getUser(state),
+  };
+}
+
+function CollectionList({
+  collections,
+  currentUser,
+  w = [1, 1 / 2, 1 / 4],
+  analyticsContext,
+}) {
+  return (
+    <Box className="relative">
+      <Grid>
+        {collections
+          .filter(c => c.id !== currentUser.personal_collection_id)
+          .map(collection => (
+            <GridItem w={w} key={collection.id}>
+              <CollectionItem
+                collection={collection}
+                event={`${analyticsContext};Collection List;Collection click`}
+              />
+            </GridItem>
+          ))}
+      </Grid>
+    </Box>
+  );
 }
 
 CollectionList.propTypes = propTypes;
 
-CollectionList.defaultProps = {
-  w: [1, 1 / 2, 1 / 4],
-};
-
-export default CollectionList;
+export default connect(mapStateToProps)(CollectionList);

--- a/frontend/src/metabase/components/CollectionList.jsx
+++ b/frontend/src/metabase/components/CollectionList.jsx
@@ -6,9 +6,6 @@ import { connect } from "react-redux";
 import CollectionItem from "metabase/components/CollectionItem";
 import { Grid, GridItem } from "metabase/components/Grid";
 
-import CollectionDropTarget from "metabase/containers/dnd/CollectionDropTarget";
-import ItemDragSource from "metabase/containers/dnd/ItemDragSource";
-
 @connect(
   ({ currentUser }) => ({ currentUser }),
   null,
@@ -19,7 +16,6 @@ class CollectionList extends React.Component {
       analyticsContext,
       collections,
       currentUser,
-      currentCollection,
       w,
       asCards,
     } = this.props;
@@ -30,24 +26,11 @@ class CollectionList extends React.Component {
             .filter(c => c.id !== currentUser.personal_collection_id)
             .map(collection => (
               <GridItem w={w} key={collection.id}>
-                <CollectionDropTarget collection={collection}>
-                  {({ highlighted, hovered }) => (
-                    <ItemDragSource
-                      item={collection}
-                      collection={currentCollection}
-                    >
-                      <div>
-                        <CollectionItem
-                          collection={collection}
-                          highlighted={highlighted}
-                          hovered={hovered}
-                          event={`${analyticsContext};Collection List;Collection click`}
-                          asCard={asCards}
-                        />
-                      </div>
-                    </ItemDragSource>
-                  )}
-                </CollectionDropTarget>
+                <CollectionItem
+                  collection={collection}
+                  event={`${analyticsContext};Collection List;Collection click`}
+                  asCard={asCards}
+                />
               </GridItem>
             ))}
         </Grid>

--- a/frontend/src/metabase/components/CollectionList.jsx
+++ b/frontend/src/metabase/components/CollectionList.jsx
@@ -1,6 +1,5 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { Box } from "grid-styled";
 import { connect } from "react-redux";
 
 import CollectionItem from "metabase/components/CollectionItem";
@@ -30,20 +29,18 @@ function CollectionList({
   analyticsContext,
 }) {
   return (
-    <Box className="relative">
-      <Grid>
-        {collections
-          .filter(c => c.id !== currentUser.personal_collection_id)
-          .map(collection => (
-            <GridItem w={w} key={collection.id}>
-              <CollectionItem
-                collection={collection}
-                event={`${analyticsContext};Collection List;Collection click`}
-              />
-            </GridItem>
-          ))}
-      </Grid>
-    </Box>
+    <Grid>
+      {collections
+        .filter(c => c.id !== currentUser.personal_collection_id)
+        .map(collection => (
+          <GridItem w={w} key={collection.id}>
+            <CollectionItem
+              collection={collection}
+              event={`${analyticsContext};Collection List;Collection click`}
+            />
+          </GridItem>
+        ))}
+    </Grid>
   );
 }
 

--- a/frontend/src/metabase/components/CollectionList.jsx
+++ b/frontend/src/metabase/components/CollectionList.jsx
@@ -1,21 +1,13 @@
 /* eslint-disable react/prop-types */
 import React from "react";
-import { t } from "ttag";
-import { Box, Flex } from "grid-styled";
+import { Box } from "grid-styled";
 import { connect } from "react-redux";
 
-import * as Urls from "metabase/lib/urls";
-
 import CollectionItem from "metabase/components/CollectionItem";
-import { color } from "metabase/lib/colors";
 import { Grid, GridItem } from "metabase/components/Grid";
-import Icon from "metabase/components/Icon";
-import Link from "metabase/components/Link";
 
 import CollectionDropTarget from "metabase/containers/dnd/CollectionDropTarget";
 import ItemDragSource from "metabase/containers/dnd/ItemDragSource";
-
-import { PERSONAL_COLLECTIONS } from "metabase/entities/collections";
 
 @connect(
   ({ currentUser }) => ({ currentUser }),
@@ -28,7 +20,6 @@ class CollectionList extends React.Component {
       collections,
       currentUser,
       currentCollection,
-      isRoot,
       w,
       asCards,
     } = this.props;
@@ -59,59 +50,6 @@ class CollectionList extends React.Component {
                 </CollectionDropTarget>
               </GridItem>
             ))}
-          {isRoot && (
-            <GridItem w={w} className="relative">
-              <CollectionDropTarget
-                collection={{ id: currentUser.personal_collection_id }}
-              >
-                {({ highlighted, hovered }) => (
-                  <CollectionItem
-                    collection={{
-                      name: t`My personal collection`,
-                      id: currentUser.personal_collection_id,
-                    }}
-                    iconName="star"
-                    highlighted={highlighted}
-                    hovered={hovered}
-                    event={`${analyticsContext};Collection List;Personal collection click`}
-                    asCard={asCards}
-                  />
-                )}
-              </CollectionDropTarget>
-            </GridItem>
-          )}
-          {isRoot && currentUser.is_superuser && (
-            <GridItem w={w}>
-              <CollectionItem
-                collection={{
-                  name: PERSONAL_COLLECTIONS.name,
-                  // Bit of a hack. The route /collection/users lists
-                  // user collections but is not itself a colllection,
-                  // but using the fake id users here works
-                  id: "users",
-                }}
-                iconName="person"
-                event={`${analyticsContext};Collection List;All user collections click`}
-                asCard={asCards}
-              />
-            </GridItem>
-          )}
-          {currentCollection && currentCollection.can_write && (
-            <GridItem w={w}>
-              <Link
-                to={Urls.newCollection(currentCollection.id)}
-                color={color("text-medium")}
-                hover={{ color: color("brand") }}
-                p={w === 1 ? [1, 2] : 0}
-                data-metabase-event={`${analyticsContext};Collection List; New Collection Click`}
-              >
-                <Flex align="center" py={1}>
-                  <Icon name="add" mr={1} bordered />
-                  <h4>{t`New collection`}</h4>
-                </Flex>
-              </Link>
-            </GridItem>
-          )}
         </Grid>
       </Box>
     );

--- a/frontend/src/metabase/components/CollectionList.jsx
+++ b/frontend/src/metabase/components/CollectionList.jsx
@@ -1,10 +1,19 @@
-/* eslint-disable react/prop-types */
 import React from "react";
+import PropTypes from "prop-types";
 import { Box } from "grid-styled";
 import { connect } from "react-redux";
 
 import CollectionItem from "metabase/components/CollectionItem";
 import { Grid, GridItem } from "metabase/components/Grid";
+
+const propTypes = {
+  collections: PropTypes.arrayOf(PropTypes.object).isRequired,
+  currentUser: PropTypes.shape({
+    personal_collection_id: PropTypes.number,
+  }),
+  w: PropTypes.arrayOf(PropTypes.number),
+  analyticsContext: PropTypes.string,
+};
 
 @connect(
   ({ currentUser }) => ({ currentUser }),
@@ -31,6 +40,8 @@ class CollectionList extends React.Component {
     );
   }
 }
+
+CollectionList.propTypes = propTypes;
 
 CollectionList.defaultProps = {
   w: [1, 1 / 2, 1 / 4],

--- a/frontend/src/metabase/components/CollectionList.jsx
+++ b/frontend/src/metabase/components/CollectionList.jsx
@@ -12,13 +12,7 @@ import { Grid, GridItem } from "metabase/components/Grid";
 )
 class CollectionList extends React.Component {
   render() {
-    const {
-      analyticsContext,
-      collections,
-      currentUser,
-      w,
-      asCards,
-    } = this.props;
+    const { analyticsContext, collections, currentUser, w } = this.props;
     return (
       <Box className="relative">
         <Grid>
@@ -29,7 +23,6 @@ class CollectionList extends React.Component {
                 <CollectionItem
                   collection={collection}
                   event={`${analyticsContext};Collection List;Collection click`}
-                  asCard={asCards}
                 />
               </GridItem>
             ))}
@@ -41,7 +34,6 @@ class CollectionList extends React.Component {
 
 CollectionList.defaultProps = {
   w: [1, 1 / 2, 1 / 4],
-  asCards: false,
 };
 
 export default CollectionList;

--- a/frontend/src/metabase/containers/Overworld.jsx
+++ b/frontend/src/metabase/containers/Overworld.jsx
@@ -200,7 +200,6 @@ class Overworld extends React.Component {
               <CollectionList
                 collections={this.props.list}
                 analyticsContext="Homepage"
-                asCards={true}
               />
             ) : (
               <Box className="text-centered">


### PR DESCRIPTION
Updates homepage's collection list to display official collection badges. Moreover, refactors `CollectionList` and `CollectionItem` components to match our current FE code style and guidelines.

Also, this PR removes a bunch of stuff from `CollectionList` and `CollectionItem`. Looks like these components were used with a previous collection pages layout, so they still have code handling drag-n-drop, navigation between collections, etc. Now they're only used on the homepage, where it's just a collection links grid.

<details>
<summary>See old collections page layout</summary>

<img width="1373" alt="old-collections-layout" src="https://user-images.githubusercontent.com/17258145/127139559-3f82bba3-a259-40a1-a219-6423ee040181.png">
</details>

### How to Review

Most likely it will be easier to review commit-by-commit:

* [removed conditional rendering blocks from `CollectionList` that will never render](https://github.com/metabase/metabase/commit/4a50430a345df96491bd3bd3afdb6b68eafef0e0) (mostly collection navigation)
* [removed drag-n-drop related code from `CollectionList`](https://github.com/metabase/metabase/commit/1ed3ad008f961ff1cf36066e2d9c30900cd2d09c)
* [removed `asCard` prop from `CollectionList`](https://github.com/metabase/metabase/commit/db38b8c680246b13214c92451621f33721297720) (`CollectionList` is used only once at the homepage, and `asCard={true}` is passed, so `asCard={false}` is not needed anywhere)
* [removed drag-n-drop driven styling from `CollectionItem`](https://github.com/metabase/metabase/commit/4ecd48533bf5aeaecb2f8ae45b2820cf45a41db2)
* [sweet prop-types](https://github.com/metabase/metabase/commit/5389c6665899276b4b9457089a25db0e5c0255a5)
* [refactored `CollectionList` to be a functional component](https://github.com/metabase/metabase/commit/5253c2423cf1a58646b6537ce065af52059582e1)
* [styled components ✨ ](https://github.com/metabase/metabase/commit/2d73e51a67b7f60fe68baaf90053757aed7b0ff4)

And [this commit](https://github.com/metabase/metabase/commit/7ef0cb21c9237a1a21147bf82f16fd9a075f8144) makes sure we display an official badge for official collections

### To Verify

Spin up Metabase Enterprise and sign in as admin

1. Create an official collection
    * open `/collection/root`
    * click "new folder" icon in the top right
    * enter a name for a new collection, select "Official" collection type, click the "Create" button
2. Open the homepage
3. Ensure an official collection has a ribbon icon instead of a folder
4. Ensure other collections still have a folder icon
5. Ensure there are no other visible changes on the homepage

### Demo

**Before**

![before](https://user-images.githubusercontent.com/17258145/127140785-894f8a03-a1a1-43a3-9fa2-17c1e69c2857.png)

**After**

![after](https://user-images.githubusercontent.com/17258145/127140806-ef6ca846-aa6d-48b3-b9f8-6294da896b04.png)
