### PR TITLE
Fix people dropdown goes outside of the screen

### DIFF
--- a/frontend/src/metabase/components/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget.jsx
@@ -93,7 +93,6 @@ type Props = {
   formatOptions?: FormattingOptions,
   maxWidth?: number,
   minWidth?: number,
-  optionsMaxHeight?: Number,
   alwaysShowOptions?: boolean,
   disableSearch?: boolean,
 
@@ -443,7 +442,7 @@ export class FieldValuesWidget extends Component {
       color,
       className,
       style,
-      optionsMaxHeight,
+      parameter,
     } = this.props;
     const { loadingState } = this.state;
 
@@ -482,11 +481,7 @@ export class FieldValuesWidget extends Component {
           style={style}
           className={className}
           parameter={this.props.parameter}
-          optionsStyle={
-            optionsMaxHeight !== undefined
-              ? { maxHeight: optionsMaxHeight }
-              : {}
-          }
+          optionsStyle={!parameter ? { maxHeight: "none" } : {}}
           // end forwarded props
           options={options}
           valueKey={0}

--- a/frontend/src/metabase/components/TokenField.jsx
+++ b/frontend/src/metabase/components/TokenField.jsx
@@ -590,10 +590,7 @@ export default class TokenField extends Component {
       filteredOptions.length === 0 ? null : (
         <ul
           className={cx(optionsClassName, "overflow-auto pl1 my1 scroll-hide")}
-          style={{
-            ...optionsStyle,
-            maxHeight: this.props.parameter ? 300 : "none",
-          }}
+          style={{ maxHeight: 300, ...optionsStyle }}
           onMouseEnter={() => this.setState({ listIsHovered: true })}
           onMouseLeave={() => this.setState({ listIsHovered: false })}
         >
@@ -637,10 +634,6 @@ export default class TokenField extends Component {
     });
   }
 }
-
-TokenField.propTypes = {
-  parameter: PropTypes.object,
-};
 
 const dedup = array => Array.from(new Set(array));
 

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DefaultPicker.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DefaultPicker.jsx
@@ -111,7 +111,6 @@ export default function DefaultPicker({
             disableSearch={disableSearch}
             minWidth={minWidth}
             maxWidth={maxWidth}
-            optionsMaxHeight={isSidebar ? null : undefined}
           />
         );
       } else if (operatorField.type === "text") {

--- a/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
@@ -82,7 +82,7 @@ describe("scenarios > dashboard > subscriptions", () => {
         cy.findByText("Emailed daily at 8:00 AM");
       });
 
-      it.skip("should not render people dropdown outside of the borders of the screen (metabase#17186)", () => {
+      it("should not render people dropdown outside of the borders of the screen (metabase#17186)", () => {
         openDashboardSubscriptions();
 
         cy.findByText("Email it").click();


### PR DESCRIPTION
### Description

Fixes people dropdown does out of the screen. Closes https://github.com/metabase/metabase/issues/17186 — check out repro steps there
Caused by https://github.com/metabase/metabase/pull/16308 so I reverted the way styles are being set to the `frontend/src/metabase/components/TokenField.jsx`

### Screenshots

#### Before
<img width="421" alt="Screen Shot 2021-07-27 at 16 34 19" src="https://user-images.githubusercontent.com/14301985/127163849-7d1bdfb5-1a11-427f-bc8a-5099b7485fe5.png">

#### After
<img width="474" alt="Screen Shot 2021-07-27 at 16 33 38" src="https://user-images.githubusercontent.com/14301985/127163903-7b449f5f-16bf-422f-b52c-5f8d3722f434.png">

