### PR TITLE
Fix image is rendered as url when there is a click behavior for the column

### DIFF
--- a/frontend/src/metabase/lib/formatting.js
+++ b/frontend/src/metabase/lib/formatting.js
@@ -779,6 +779,7 @@ export function formatValueRaw(value: Value, options: FormattingOptions = {}) {
   } else if (value == null) {
     return null;
   } else if (
+    options.view_as !== "image" &&
     options.click_behavior &&
     clickBehaviorIsValid(options.click_behavior) &&
     options.jsx

--- a/frontend/test/metabase/lib/formatting.unit.spec.js
+++ b/frontend/test/metabase/lib/formatting.unit.spec.js
@@ -223,6 +223,21 @@ describe("formatting", () => {
       // but it's formatted as a link
       expect(formatted.props.className).toEqual("link link--wrappable");
     });
+    it("should render image with a click behavior in jsx + rich mode (metabase#17161)", () => {
+      const formatted = formatValue("http://metabase.com/logo.png", {
+        jsx: true,
+        rich: true,
+        view_as: "image",
+        click_behavior: {
+          linkTemplate: "foo",
+          linkType: "url",
+          type: "link",
+        },
+        clicked: {},
+      });
+      expect(formatted.type).toEqual("img");
+      expect(formatted.props.src).toEqual("http://metabase.com/logo.png");
+    });
     it("should return a component for email addresses in jsx + rich mode", () => {
       expect(
         isElementOfType(


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/17161

### How to verify
  1) Create a native question with the following query ```select 'https://user-images.githubusercontent.com/41020387/126559911-9550c7c6-ed6e-4890-9db9-3d270152e1ec.png' as a```
  2) Open the column settings and make it an image 
<img width="352" alt="Screen Shot 2021-07-27 at 17 55 09" src="https://user-images.githubusercontent.com/14301985/127176873-198744b9-64bf-4588-aef2-96ff2ec16dd7.png">
  3) Add the question on a dashboard and add a click behavior for the column

### Screenshots

#### Before
<img width="684" alt="Screen Shot 2021-07-27 at 17 19 58" src="https://user-images.githubusercontent.com/14301985/127177072-e0f8e340-d243-4c02-a759-b335c5e0a34d.png">

#### After
<img width="330" alt="Screen Shot 2021-07-27 at 17 19 43" src="https://user-images.githubusercontent.com/14301985/127177090-cc2462c0-a0df-40ff-8eef-913c892e0822.png">
