### PR TITLE
🍒 Fix image is rendered as url when there is a click behavior for the column

### DIFF
--- a/frontend/src/metabase/lib/formatting.js
+++ b/frontend/src/metabase/lib/formatting.js
@@ -775,6 +775,7 @@ export function formatValueRaw(value: Value, options: FormattingOptions = {}) {
   } else if (value == null) {
     return null;
   } else if (
+    options.view_as !== "image" &&
     options.click_behavior &&
     clickBehaviorIsValid(options.click_behavior) &&
     options.jsx

--- a/frontend/test/metabase/lib/formatting.unit.spec.js
+++ b/frontend/test/metabase/lib/formatting.unit.spec.js
@@ -223,6 +223,21 @@ describe("formatting", () => {
       // but it's formatted as a link
       expect(formatted.props.className).toEqual("link link--wrappable");
     });
+    it("should render image with a click behavior in jsx + rich mode (metabase#17161)", () => {
+      const formatted = formatValue("http://metabase.com/logo.png", {
+        jsx: true,
+        rich: true,
+        view_as: "image",
+        click_behavior: {
+          linkTemplate: "foo",
+          linkType: "url",
+          type: "link",
+        },
+        clicked: {},
+      });
+      expect(formatted.type).toEqual("img");
+      expect(formatted.props.src).toEqual("http://metabase.com/logo.png");
+    });
     it("should return a component for email addresses in jsx + rich mode", () => {
       expect(
         isElementOfType(


### PR DESCRIPTION
Cherry-pick https://github.com/metabase/metabase/pull/17219