### PR TITLE
Enable clj-kondo failures on missing docstring; remove bikeshed

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -26,22 +26,6 @@ jobs:
     - name: Run clj-kondo
       run: docker run -v $PWD:/work --rm cljkondo/clj-kondo clj-kondo --config /work/lint-config.edn --lint /work/src /work/enterprise/backend/src /work/backend/mbql/src /work/shared/src
 
-  be-linter-bikeshed:
-    runs-on: ubuntu-20.04
-    timeout-minutes: 10
-    steps:
-    - uses: actions/checkout@v2
-    - name: Prepare JDK 11
-      uses: actions/setup-java@v1
-      with:
-        java-version: 11
-    - name: Get M2 cache
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-bikeshed-${{ hashFiles('**/project.clj') }}
-    - run: lein with-profile +ci bikeshed
-
   be-linter-eastwood:
     runs-on: ubuntu-20.04
     timeout-minutes: 10
@@ -57,22 +41,6 @@ jobs:
         path: ~/.m2
         key: ${{ runner.os }}-eastwood-${{ hashFiles('**/project.clj') }}
     - run: lein with-profile +ci eastwood
-
-  be-linter-docstring-checker:
-    runs-on: ubuntu-20.04
-    timeout-minutes: 10
-    steps:
-    - uses: actions/checkout@v2
-    - name: Prepare JDK 11
-      uses: actions/setup-java@v1
-      with:
-        java-version: 11
-    - name: Get M2 cache
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-docstring-checker-${{ hashFiles('**/project.clj') }}
-    - run: lein with-profile +ci docstring-checker
 
   be-linter-namespace-decls:
     runs-on: ubuntu-20.04

--- a/enterprise/backend/src/metabase_enterprise/audit/pages/dashboard_detail.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit/pages/dashboard_detail.clj
@@ -13,21 +13,23 @@
   (card-and-dash-detail/views-by-time "dashboard" dashboard-id datetime-unit))
 
 (s/defn ^:internal-query-fn revision-history
+  "Revision history for a specific Dashboard."
   [dashboard-id :- su/IntGreaterThanZero]
   (card-and-dash-detail/revision-history Dashboard dashboard-id))
 
 (s/defn ^:internal-query-fn audit-log
+  "View log for a specific Dashboard."
   [dashboard-id :- su/IntGreaterThanZero]
   (card-and-dash-detail/audit-log "dashboard" dashboard-id))
 
-
 (s/defn ^:internal-query-fn cards
+  "Information about the Saved Questions (Cards) in this instance."
   [dashboard-id :- su/IntGreaterThanZero]
   {:metadata [[:card_id             {:display_name "Card ID",              :base_type :type/Integer, :remapped_to   :card_name}]
               [:card_name           {:display_name "Title",                :base_type :type/Name,    :remapped_from :card_id}]
               [:collection_id       {:display_name "Collection ID",        :base_type :type/Integer, :remapped_to   :collection_name}]
               [:collection_name     {:display_name "Collection",           :base_type :type/Text,    :remapped_from :collection_id}]
-              [:created_at          {:display_name  "Created At",          :base_type :type/DateTime}]
+              [:created_at          {:display_name "Created At",           :base_type :type/DateTime}]
               [:database_id         {:display_name "Database ID",          :base_type :type/Integer, :remapped_to   :database_name}]
               [:database_name       {:display_name "Database",             :base_type :type/Text,    :remapped_from :database_id}]
               [:table_id            {:display_name "Table ID",             :base_type :type/Integer, :remapped_to   :table_name}]

--- a/enterprise/backend/src/metabase_enterprise/audit/pages/database_detail.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit/pages/database_detail.clj
@@ -5,6 +5,7 @@
             [schema.core :as s]))
 
 (s/defn ^:internal-query-fn audit-log
+  "Query execution history for queries against this Database."
   [database-id :- su/IntGreaterThanZero]
   {:metadata [[:started_at {:display_name "Viewed on",  :base_type :type/DateTime}]
               [:card_id    {:display_name "Card ID",    :base_type :type/Integer, :remapped_to   :query}]

--- a/enterprise/backend/src/metabase_enterprise/audit/pages/databases.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit/pages/databases.clj
@@ -70,6 +70,7 @@
 
 
 (s/defn ^:internal-query-fn table
+  "Table with information and statistics about all the data warehouse Databases in this Metabase instance."
   ([]
    (table nil))
   ([query-string :- (s/maybe s/Str)]

--- a/enterprise/backend/src/metabase_enterprise/audit/pages/query_detail.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit/pages/query_detail.clj
@@ -7,6 +7,7 @@
             [schema.core :as s]))
 
 (s/defn ^:internal-query-fn details
+  "Details about a specific query (currently just average execution time)."
   [query-hash :- su/NonBlankString]
   {:metadata [[:query                  {:display_name "Query",                :base_type :type/Dictionary}]
               [:average_execution_time {:display_name "Avg. Exec. Time (ms)", :base_type :type/Number}]]

--- a/enterprise/backend/src/metabase_enterprise/audit/pages/table_detail.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit/pages/table_detail.clj
@@ -5,6 +5,7 @@
             [schema.core :as s]))
 
 (s/defn ^:internal-query-fn audit-log
+  "View log for a specific Table."
   [table-id :- su/IntGreaterThanZero]
   {:metadata [[:started_at {:display_name "Viewed on",  :base_type :type/DateTime}]
               [:card_id    {:display_name "Card ID",    :base_type :type/Integer, :remapped_to   :query}]

--- a/enterprise/backend/src/metabase_enterprise/audit/pages/user_detail.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit/pages/user_detail.clj
@@ -113,6 +113,7 @@
                :limit     10})})
 
 (s/defn ^:internal-query-fn query-views
+  "Query views by a specific User."
   [user-id :- su/IntGreaterThanZero]
   {:metadata [[:viewed_on     {:display_name "Viewed On",      :base_type :type/DateTime}]
               [:card_id       {:display_name "Card ID"         :base_type :type/Integer, :remapped_to   :card_name}]
@@ -152,6 +153,7 @@
    :xform    (map #(update (vec %) 3 codec/base64-encode))})
 
 (s/defn ^:internal-query-fn dashboard-views
+  "Dashboard views by a specific User."
   [user-id :- su/IntGreaterThanZero]
   {:metadata [[:timestamp       {:display_name "Viewed on",     :base_type :type/DateTime}]
               [:dashboard_id    {:display_name "Dashboard ID",  :base_type :type/Integer, :remapped_to   :dashboard_name}]
@@ -188,12 +190,14 @@
               :order-by [[(common/grouped-datetime datetime-unit :timestamp) :asc]]})})
 
 (s/defn ^:internal-query-fn created-dashboards
+  "Dashboards created by a specific User."
   ([user-id]
    (created-dashboards user-id nil))
   ([user-id :- su/IntGreaterThanZero, query-string :- (s/maybe s/Str)]
    (dashboards/table query-string [:= :u.id user-id])))
 
 (s/defn ^:internal-query-fn created-questions
+  "Questions created by a specific User."
   [user-id :- su/IntGreaterThanZero]
   {:metadata [[:card_id             {:display_name "Card ID",              :base_type :type/Integer, :remapped_to   :card_name}]
               [:card_name           {:display_name "Title",                :base_type :type/Name,    :remapped_from :card_id}]

--- a/enterprise/backend/src/metabase_enterprise/audit/pages/users.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit/pages/users.clj
@@ -142,6 +142,7 @@
                 :limit     10})})
 
 (s/defn ^:internal-query-fn table
+  "A table of all the Users for this instance, and various statistics about them (see metadata below)."
   ([]
    (table nil))
 

--- a/lint-config.edn
+++ b/lint-config.edn
@@ -2,7 +2,7 @@
 {:linters {:missing-else-branch          {:level :warn}
            :misplaced-docstring          {:level :warn}
            :missing-body-in-when         {:level :warn}
-           :missing-docstring            {:level :warn}
+           :missing-docstring            {:level :warning}
            :refer-all                    {:level   :warn
                                           :exclude [clojure.test]}
            :unsorted-required-namespaces {:level :warn}

--- a/project.clj
+++ b/project.clj
@@ -23,17 +23,12 @@
    ;; "ring-ee"                           ["with-profile" "+ring,+ee" "ring"]
    "test"                              ["with-profile" "+test" "test"]
    "test-ee"                           ["with-profile" "+test,+ee" "test"]
-   "bikeshed"                          ["with-profile" "+bikeshed" "bikeshed"
-                                        "--max-line-length" "205"
-                                        ;; see https://github.com/dakrone/lein-bikeshed/issues/41
-                                        "--exclude-profiles" "dev"]
    "check-namespace-decls"             ["with-profile" "+check-namespace-decls" "check-namespace-decls"]
    "eastwood"                          ["with-profile" "+eastwood" "eastwood"]
    "check-reflection-warnings"         ["with-profile" "+reflection-warnings" "check"]
-   "docstring-checker"                 ["with-profile" "+docstring-checker" "docstring-checker"]
    "cloverage"                         ["with-profile" "+cloverage" "cloverage"]
    ;; `lein lint` will run all linters
-   "lint"                              ["do" ["eastwood"] ["bikeshed"] ["check-namespace-decls"] ["docstring-checker"] ["cloverage"]]
+   "lint"                              ["do" ["eastwood"] ["check-namespace-decls"] ["cloverage"]]
    "repl"                              ["with-profile" "+repl" "repl"]
    "repl-ee"                           ["with-profile" "+repl,+ee" "repl"]
    "uberjar"                           ["uberjar"]
@@ -368,11 +363,6 @@
     ;; always use in-memory H2 database for linters
     {:env {:mb-db-type "h2"}}]
 
-   :bikeshed
-   [:linters-common
-    {:plugins
-     [[lein-bikeshed "0.5.2"]]}]
-
    :eastwood
    [:linters-common
     {:plugins
@@ -404,17 +394,6 @@
    [:include-all-drivers
     :ee
     {:global-vars {*warn-on-reflection* true}}]
-
-   ;; Check that all public vars have docstrings. Run with 'lein docstring-checker'
-   :docstring-checker
-   [:linters-common
-    {:plugins
-     [[docstring-checker "1.1.0"]]
-
-     :docstring-checker
-     {:include [#"^metabase"]
-      :exclude [#"test"
-                #"^metabase\.http-client$"]}}]
 
    :check-namespace-decls
    [:linters-common

--- a/shared/src/metabase/mbql/util.cljc
+++ b/shared/src/metabase/mbql/util.cljc
@@ -121,6 +121,8 @@
   (simplify-compound-filter (cons :and (cons filter-clause more-filter-clauses))))
 
 (s/defn add-filter-clause-to-inner-query :- mbql.s/MBQLQuery
+  "Add a additional filter clause to an *inner* MBQL query, merging with the existing filter clause with `:and` if
+  needed."
   [inner-query :- mbql.s/MBQLQuery new-clause :- (s/maybe mbql.s/Filter)]
   (if-not new-clause
     inner-query

--- a/shared/src/metabase/shared/util/i18n.cljs
+++ b/shared/src/metabase/shared/util/i18n.cljs
@@ -5,6 +5,7 @@
 (comment metabase.shared.util.i18n/keep-me
          ttag/keep-me)
 
-;; TODO -- this definitely isn't working right.
-(defn js-i18n [format-string & args]
+(defn js-i18n
+  "Format an i18n `format-string` with `args` with a translated string in the user locale."
+  [format-string & args]
   (apply ttag/gettext format-string args))

--- a/shared/src/metabase/shared/util/log.cljs
+++ b/shared/src/metabase/shared/util/log.cljs
@@ -13,19 +13,28 @@
 (glogi-console/install!)
 (log/set-levels {:glogi/root :info})
 
-(defn- log-message [& args]
+(defn log-message
+  "Part of the impl for [[metabase.shared.util.log/js-logp]]."
+  [& args]
   (if (> (count args) 1)
     (vec args)
     (first args)))
 
-(defn- logf-message [format-string & args]
+(defn logf-message
+  "Part of the impl for [[metabase.shared.util.log/js-logf]]."
+  [format-string & args]
   (apply gstring/format format-string args))
 
-(defn log* [msg-fn logger-name level & args]
+(defn log*
+  "Cljs impl for the logging macros in the shared code. You shouldn't need to use this directly; use the macros
+  in [[metabase.shared.util.log]] instead."
+  [msg-fn logger-name level & args]
   (if (instance? js/Error (first args))
     (let [[e & more] args]
       (log/log logger-name level (apply msg-fn more) e))
     (log/log logger-name level (apply msg-fn args))))
 
-(defn- is-loggable? [logger-name level]
+(defn is-loggable?
+  "Part of the impl for [[metabase.shared.util.log/js-logp]] and [[metabase.shared.util.log/js-logf]]."
+  [logger-name level]
   (.isLoggable ^Logger (log/logger logger-name) ^Level (log/levels level)))

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -485,6 +485,8 @@
    :where  (apply effective-children-where-clause collection additional-honeysql-where-clauses)})
 
 (s/defn effective-children :- #{CollectionInstance}
+  "Get the descendant Collections of `collection` that should be presented to the current User as direct children of
+  this Collection. See documentation for [[metabase.models.collection/effective-children-query]] for more details."
   {:hydrate :effective_children}
   [collection :- CollectionWithLocationAndIDOrRoot & additional-honeysql-where-clauses]
   (set (db/select [Collection :id :name :description]
@@ -940,6 +942,9 @@
     (format-personal-collection-name first-name last-name)))
 
 (s/defn user->existing-personal-collection :- (s/maybe CollectionInstance)
+  "For a `user-or-id`, return their personal Collection, if it already exists.
+  Use [[metabase.models.collection/user->personal-collection]] to fetch their personal Collection *and* create it if
+  needed."
   [user-or-id]
   (db/select-one Collection :personal_owner_id (u/the-id user-or-id)))
 

--- a/src/metabase/pulse/render.clj
+++ b/src/metabase/pulse/render.clj
@@ -170,5 +170,6 @@
   (png/render-html-to-png (render-pulse-card :inline timezone-id pulse-card result) card-width))
 
 (s/defn png-from-render-info :- bytes
+  "Create a PNG file (as a byte array) from rendering info."
   [rendered-info :- common/RenderedPulseCard]
   (png/render-html-to-png rendered-info card-width))

--- a/src/metabase/search/scoring.clj
+++ b/src/metabase/search/scoring.clj
@@ -12,6 +12,7 @@
 ;;; Utility functions
 
 (s/defn normalize :- s/Str
+  "Normalize a `query` to lower-case."
   [query :- s/Str]
   (str/lower-case query))
 


### PR DESCRIPTION
Split off from #16749 and #16726.

Use `clj-kondo`'s build-in linter that fails if docstrings are missing; remove the deprecated docstring checker Lein plugin. Also, remove Bikeshed (doesn't work with `tools.deps`, so we were planning on removing it anyway -- it doesn't do much for us that's not already covered by Kondo + Eastwood).