### PR TITLE
auto cherry pick to release branch on merge into master

### DIFF
--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -1,4 +1,5 @@
-name: MetabotCherryPick
+# Creates a pull request with the latest release branch as a target with a cherry-picked commit if an associated pull request has `backport` label
+name: AutoBackport
 
 on:
   push:
@@ -7,16 +8,16 @@ on:
 
 jobs:
   pr_info:
-    name: Check if the commit should be cherry-picked
+    name: Check if the commit should be backported
     runs-on: ubuntu-latest
     outputs:
-      title: ${{ fromJson(steps.get_should_cherry_pick.outputs.result).title }}
-      number: ${{ fromJson(steps.get_should_cherry_pick.outputs.result).pullRequestNumber }}
-      author: ${{ fromJson(steps.get_should_cherry_pick.outputs.result).author }}
-      should_cherry_pick: ${{ fromJson(steps.get_should_cherry_pick.outputs.result).hasCherryPickLabel }}
+      title: ${{ fromJson(steps.collect_pr_info.outputs.result).title }}
+      number: ${{ fromJson(steps.collect_pr_info.outputs.result).pullRequestNumber }}
+      author: ${{ fromJson(steps.collect_pr_info.outputs.result).author }}
+      should_backport: ${{ fromJson(steps.collect_pr_info.outputs.result).hasBackportLabel }}
     steps:
       - uses: actions/github-script@v4
-        id: get_should_cherry_pick
+        id: collect_pr_info
         with:
           script: |
             const commitMessage = context.payload.commits[0].message;
@@ -38,16 +39,16 @@ jobs:
               pull_number: pullRequestNumber
             });
 
-            const hasCherryPickLabel = data.labels.some((label) => label.name === 'cherry-pick');
+            const hasBackportLabel = data.labels.some((label) => label.name === 'backport');
             const { title, user } = data
 
-            console.log(`PR #${pullRequestNumber}: "${title}" hasCherryPickLabel=${hasCherryPickLabel}`)
+            console.log(`PR #${pullRequestNumber}: "${title}" hasBackportLabel=${hasBackportLabel}`)
 
             return {
               author: user.login,
               pullRequestNumber,
               title: data.title,
-              hasCherryPickLabel
+              hasBackportLabel
             }
 
   get_latest_release_branch:
@@ -75,11 +76,11 @@ jobs:
 
             return latestReleaseBranchName;
 
-  create_release_pull_request:
+  create_backport_pull_request:
     runs-on: ubuntu-latest
-    name: Create a PR with the commit
+    name: Create a backport PR with the commit
     needs: [pr_info, get_latest_release_branch]
-    if: ${{ needs.pr_info.outputs.should_cherry_pick == 'true' }}
+    if: ${{ needs.pr_info.outputs.should_backport == 'true' }}
     env:
       RELEASE_BRANCH: ${{ needs.get_latest_release_branch.outputs.branch_name }}
       ORIGINAL_PR_TITLE: ${{ needs.pr_info.outputs.title }}
@@ -93,18 +94,19 @@ jobs:
           git config --global user.email "metabase-github-automation@metabase.com"
           git config --global user.name "$GITHUB_ACTOR"
 
-          PR_BRANCH="cherry-pick-$GITHUB_SHA"
+          PR_BRANCH="backport-$GITHUB_SHA"
 
           git fetch --all
           git checkout -b "${PR_BRANCH}" origin/"${RELEASE_BRANCH}"
           git cherry-pick "${GITHUB_SHA}"
           git push -u origin "${PR_BRANCH}"
 
-          hub pull-request -b "${RELEASE_BRANCH}" -h "${PR_BRANCH}" -l "auto-cherry-picked" -a "${GITHUB_ACTOR}" -m "🍒 \"${ORIGINAL_PR_TITLE}\""
+          hub pull-request -b "${RELEASE_BRANCH}" -h "${PR_BRANCH}" -l "auto-created-backport" -a "${GITHUB_ACTOR}" -m "backported \"${ORIGINAL_PR_TITLE}\""
 
   notify_when_failed:
     runs-on: ubuntu-latest
-    needs: [pr_info, create_release_pull_request]
+    name: Notify about failure
+    needs: [pr_info, create_backport_pull_request]
     if: ${{ failure() }}
     steps:
       - uses: actions/github-script@v4
@@ -114,5 +116,5 @@ jobs:
               issue_number: ${{ needs.pr_info.outputs.number }},
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: '@${{ needs.pr_info.outputs.author }} could not automatically create a release PR 😩'
+              body: '@${{ needs.pr_info.outputs.author }} could not automatically create a backport PR 😩'
             })

--- a/.github/workflows/metabot-cherry-pick.yml
+++ b/.github/workflows/metabot-cherry-pick.yml
@@ -1,0 +1,118 @@
+name: MetabotCherryPick
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  pr_info:
+    name: Check if the commit should be cherry-picked
+    runs-on: ubuntu-latest
+    outputs:
+      title: ${{ fromJson(steps.get_should_cherry_pick.outputs.result).title }}
+      number: ${{ fromJson(steps.get_should_cherry_pick.outputs.result).pullRequestNumber }}
+      author: ${{ fromJson(steps.get_should_cherry_pick.outputs.result).author }}
+      should_cherry_pick: ${{ fromJson(steps.get_should_cherry_pick.outputs.result).hasCherryPickLabel }}
+    steps:
+      - uses: actions/github-script@v4
+        id: get_should_cherry_pick
+        with:
+          script: |
+            const commitMessage = context.payload.commits[0].message;
+            const pullRequestNumbers = Array.from(commitMessage.matchAll(/\(#(.*?)\)/g))
+
+            if (pullRequestNumbers.length === 0) {
+              return;
+            }
+
+            if (pullRequestNumbers > 1) {
+              throw "Multiple PRs are associated with this commit";
+            }
+
+            const pullRequestNumber = pullRequestNumbers[0][1];
+
+            const { data } = await github.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pullRequestNumber
+            });
+
+            const hasCherryPickLabel = data.labels.some((label) => label.name === 'cherry-pick');
+            const { title, user } = data
+
+            console.log(`PR #${pullRequestNumber}: "${title}" hasCherryPickLabel=${hasCherryPickLabel}`)
+
+            return {
+              author: user.login,
+              pullRequestNumber,
+              title: data.title,
+              hasCherryPickLabel
+            }
+
+  get_latest_release_branch:
+    name: Get latest release branch
+    runs-on: ubuntu-latest
+    outputs:
+      branch_name: ${{ steps.get_branch_name.outputs.result }}
+    steps:
+      - uses: actions/github-script@v4
+        id: get_branch_name
+        with:
+          result-encoding: string
+          script: |
+            const releaseBranches = await github.git.listMatchingRefs({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: "heads/release-x.",
+            });
+
+            const getVersionFromBranch = branch => parseInt(branch.match(/release-x\.(.*?)\.x/)[1]);
+            const latestReleaseBranch = releaseBranches.data.reduce((prev, current) => getVersionFromBranch(prev.ref) > getVersionFromBranch(current.ref) ? prev : current);
+            const latestReleaseBranchName = latestReleaseBranch.ref.replace(/^refs\/heads\//, "");
+
+            console.log(`Latest release branch: ${latestReleaseBranchName}`)
+
+            return latestReleaseBranchName;
+
+  create_release_pull_request:
+    runs-on: ubuntu-latest
+    name: Create a PR with the commit
+    needs: [pr_info, get_latest_release_branch]
+    if: ${{ needs.pr_info.outputs.should_cherry_pick == 'true' }}
+    env:
+      RELEASE_BRANCH: ${{ needs.get_latest_release_branch.outputs.branch_name }}
+      ORIGINAL_PR_TITLE: ${{ needs.pr_info.outputs.title }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+        name: Checkout
+        with:
+          fetch-depth: 0
+      - run: |
+          git config --global user.email "metabase-github-automation@metabase.com"
+          git config --global user.name "$GITHUB_ACTOR"
+
+          PR_BRANCH="cherry-pick-$GITHUB_SHA"
+
+          git fetch --all
+          git checkout -b "${PR_BRANCH}" origin/"${RELEASE_BRANCH}"
+          git cherry-pick "${GITHUB_SHA}"
+          git push -u origin "${PR_BRANCH}"
+
+          hub pull-request -b "${RELEASE_BRANCH}" -h "${PR_BRANCH}" -l "auto-cherry-picked" -a "${GITHUB_ACTOR}" -m "🍒 \"${ORIGINAL_PR_TITLE}\""
+
+  notify_when_failed:
+    runs-on: ubuntu-latest
+    needs: [pr_info, create_release_pull_request]
+    if: ${{ failure() }}
+    steps:
+      - uses: actions/github-script@v4
+        with:
+          script: |
+            github.issues.createComment({
+              issue_number: ${{ needs.pr_info.outputs.number }},
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '@${{ needs.pr_info.outputs.author }} could not automatically create a release PR 😩'
+            })


### PR DESCRIPTION
### Description

Once a PR with label `backport` is merged into `master` it creates a PR with a cherry-picked commit into the latest `release-x.x.x` branch. Since we are using squash&merge the workflow finds related PR by a PR number in the commit message. **Use `backport` label only on PRs that you are going to Squash & Merge.**

### Screenshots 
The label has been renamed from `cherry-pick` to `backport` after I took the screenshots

#### An engineer merges a PR that has `backport` label into `master` 
<img width="1278" alt="Screen Shot 2021-07-28 at 18 01 20" src="https://user-images.githubusercontent.com/14301985/127346691-b67ea552-f8e7-4f6b-abb8-3f3703d3c2cd.png">

#### A job that creates a PR with a cherry-picked commit starts
<img width="1434" alt="Screen Shot 2021-07-28 at 18 02 51" src="https://user-images.githubusercontent.com/14301985/127346855-9f04dd09-f38f-4e71-8ddb-1766f71b4d9d.png">

#### If the job finishes successfully, the PR is created
<img width="1254" alt="Screen Shot 2021-07-28 at 18 03 04" src="https://user-images.githubusercontent.com/14301985/127347003-74a36645-03c2-469e-b205-1c84b027eb83.png">

#### If the job failed due to conflicts or anything else it notifies the author of original PR
<img width="952" alt="Screen Shot 2021-07-28 at 18 03 41" src="https://user-images.githubusercontent.com/14301985/127347228-f48cce29-99e1-4dc1-81e3-03433c939867.png">
