### PR TITLE
Skip Percy job triggered by comment early

### DIFF
--- a/.github/workflows/percy-issue-comment.yml
+++ b/.github/workflows/percy-issue-comment.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   pr_info:
+    if: github.event.comment.body == '@metabase-bot run visual tests'
     runs-on: ubuntu-20.04
     outputs:
       pull_request_number: ${{ fromJson(steps.fetch_pr.outputs.data).head.number }}
@@ -92,7 +93,6 @@ jobs:
             ./SHA256.sum
 
   percy:
-    if: github.event.comment.body == '@metabase-bot run visual tests'
     timeout-minutes: 30
     needs: [build, pr_info]
     runs-on: ubuntu-20.04


### PR DESCRIPTION
### Description

Github actions do not distinct issue comments and PR comments so the `PercyIssueComment` is triggered on all comments but it stops unless the comment body is '@metabase-bot run visual tests'. I moved `if: github.event.comment.body == '@metabase-bot run visual tests'` check to fail earlier on fetching PR info job.