### PR TITLE
Fix Collection Sidebar style bug

### DIFF
--- a/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebar.styled.js
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebar.styled.js
@@ -37,6 +37,11 @@ export const Sidebar = styled(Box.withComponent("aside"))`
       box-shadow: 5px 0px 8px rgba(0, 0, 0, 0.35),
         40px 0px rgba(5, 14, 31, 0.32);
       width: calc(100vw - 40px);
+
+      ${breakpointMinSmall} {
+        box-shadow: none;
+        width: ${SIDEBAR_WIDTH};
+      }
     `}
 
   ${breakpointMinSmall} {


### PR DESCRIPTION
⚠️ Please review https://github.com/metabase/metabase/pull/17194 first

<hr />

Fixes issue that happens when user is in desktop, goes to mobile, opens sidebar and then goes back to desktop.

## To test manually

1. Be in desktop mode in the browser
2. Go to http://localhost:3000/collection/root
3. Make browser display as a mobile device
4. Click on burger icon to display collections sidebar
5. Make browser display as desktop


### Demo

https://user-images.githubusercontent.com/380816/127352037-3fab7022-2941-4101-9d54-1117712667ec.mov

## After

![image](https://user-images.githubusercontent.com/380816/127352238-9935f7c1-bbc6-45d1-af54-0dbd30e7bfa9.png)

## Before

![image](https://user-images.githubusercontent.com/380816/127352448-3922507a-c15e-484f-b0e4-10533fbc84af.png)
