### PR TITLE
Fixes valid-bigquery-identifier regex

### DIFF
--- a/modules/drivers/bigquery/src/metabase/driver/bigquery/query_processor.clj
+++ b/modules/drivers/bigquery/src/metabase/driver/bigquery/query_processor.clj
@@ -31,14 +31,15 @@
 
 ;; TODO -- I think this only applied to Fields now -- see
 ;; https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language. It definitely doesn't apply
-;; to Tables. Not sure about project/dataset identifiers.
+;; to Tables. Datasets can be passed as `dataset-id` or `project-id`.`dataset-id`.
+;; TODO -- Needs to change frontend too
 (defn- valid-bigquery-identifier?
   "Is String `s` a valid BigQuery identifier? Identifiers are only allowed to contain letters, numbers, and underscores;
   cannot start with a number; and can be at most 128 characters long."
   [s]
   (boolean
    (and (string? s)
-        (re-matches #"^([a-zA-Z_][a-zA-Z_0-9]*){1,128}$" s))))
+        (re-matches #"^([a-zA-Z_\-.][a-zA-Z_0-9]*){1,128}$" s))))
 
 (def ^:private BigQueryIdentifierString
   (s/pred valid-bigquery-identifier? "Valid BigQuery identifier"))

--- a/modules/drivers/bigquery/src/metabase/driver/bigquery/query_processor.clj
+++ b/modules/drivers/bigquery/src/metabase/driver/bigquery/query_processor.clj
@@ -39,7 +39,7 @@
   [s]
   (boolean
    (and (string? s)
-        (re-matches #"^([a-zA-Z_\-.][a-zA-Z_0-9]*){1,128}$" s))))
+        (re-matches #"^([a-zA-Z_\-\.][a-zA-Z_0-9]*){1,128}$" s))))
 
 (def ^:private BigQueryIdentifierString
   (s/pred valid-bigquery-identifier? "Valid BigQuery identifier"))

--- a/modules/drivers/bigquery/src/metabase/driver/bigquery/query_processor.clj
+++ b/modules/drivers/bigquery/src/metabase/driver/bigquery/query_processor.clj
@@ -35,11 +35,11 @@
 ;; TODO -- Needs to change frontend too
 (defn- valid-bigquery-identifier?
   "Is String `s` a valid BigQuery identifier? Identifiers are only allowed to contain letters, numbers, and underscores;
-  cannot start with a number; and can be at most 128 characters long."
+  cannot start with a number; and can be at most 1054 characters long (30 for maximum lenght of project names and 1024 for dataset)."
   [s]
   (boolean
    (and (string? s)
-        (re-matches #"^([a-zA-Z_\-\.][a-zA-Z_0-9]*){1,128}$" s))))
+        (re-matches #"^[a-zA-Z_0-9\.\-]{1,1054}$" s))))
 
 (def ^:private BigQueryIdentifierString
   (s/pred valid-bigquery-identifier? "Valid BigQuery identifier"))

--- a/modules/drivers/bigquery/test/metabase/driver/bigquery/query_processor_test.clj
+++ b/modules/drivers/bigquery/test/metabase/driver/bigquery/query_processor_test.clj
@@ -701,6 +701,24 @@
                                   "WHERE `v3_test_data.venues`.`name` = ?")
                      :params ["x\\\\' OR 1 = 1 -- "]})))))))))
 
+(deftest acceptable-dataset-test
+  (mt/test-driver :bigquery
+    (testing "Make sure validation of dataset's name works correctly"
+      (testing "acceptable names"
+        (are [name] (= true (#'bigquery.qp/valid-bigquery-identifier? name))
+              "0"
+              "a"
+              "_"
+              "apple"
+              "banana.apple"
+              "my-fruits.orange"
+              (apply str (repeat 1054 "a"))))
+      (testing "rejected names"
+        (are [name] (= false (#'bigquery.qp/valid-bigquery-identifier? name))
+              "have:dataset"
+              ""
+              (apply str (repeat 129 "a")))))))
+
 (deftest ->valid-field-identifier-test
   (testing "`->valid-field-identifier` should generate valid field identifiers"
     (testing "no need to change anything"

--- a/modules/drivers/bigquery/test/metabase/driver/bigquery/query_processor_test.clj
+++ b/modules/drivers/bigquery/test/metabase/driver/bigquery/query_processor_test.clj
@@ -717,7 +717,7 @@
         (are [name] (= false (#'bigquery.qp/valid-bigquery-identifier? name))
               "have:dataset"
               ""
-              (apply str (repeat 129 "a")))))))
+              (apply str (repeat 1055 "a")))))))
 
 (deftest ->valid-field-identifier-test
   (testing "`->valid-field-identifier` should generate valid field identifiers"


### PR DESCRIPTION
Fixes regex that checks if a dataset-id is valid or not. Adds dot and hyphen as allowed characters so datasets from others projects can be passed.

With it datasets can be passed as `project-id.dataset-id` or `dataset-id`, which allows datasets from other project to be accessed.

###### Before submitting the PR, please make sure you do the following

- [ ] If you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.

### Tests

- [x] Run the frontend and Cypress end-to-end tests with `yarn lint && yarn test`)
- [x] If there are changes to the backend codebase, run the backend tests with `lein test && lein lint && ./bin/reflection-linter`

- [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
      (unless it's a tiny documentation change).
