### PR TITLE
Hide currency symbol option if not supported

### DIFF
--- a/frontend/src/metabase/visualizations/lib/settings/column.js
+++ b/frontend/src/metabase/visualizations/lib/settings/column.js
@@ -335,11 +335,14 @@ export const NUMBER_COLUMN_SETTINGS = {
       const name = getCurrency(c, "name");
       return {
         options: [
-          ... symbol !== code ?
-          [{
-            name: t`Symbol` + ` ` + `(${symbol})`,
-            value: "symbol",
-          }] : [],
+          ...(symbol !== code
+            ? [
+                {
+                  name: t`Symbol` + ` ` + `(${symbol})`,
+                  value: "symbol",
+                },
+              ]
+            : []),
           {
             name: t`Code` + ` ` + `(${code})`,
             value: "code",

--- a/frontend/src/metabase/visualizations/lib/settings/column.js
+++ b/frontend/src/metabase/visualizations/lib/settings/column.js
@@ -330,18 +330,22 @@ export const NUMBER_COLUMN_SETTINGS = {
     widget: "radio",
     getProps: (column: Column, settings: ColumnSettings) => {
       const c = settings["currency"] || "USD";
+      const symbol = getCurrency(c, "symbol");
+      const code = getCurrency(c, "code");
+      const name = getCurrency(c, "name");
       return {
         options: [
-          {
-            name: t`Symbol` + ` ` + `(${getCurrency(c, "symbol")})`,
+          ... symbol !== code ?
+          [{
+            name: t`Symbol` + ` ` + `(${symbol})`,
             value: "symbol",
-          },
+          }] : [],
           {
-            name: t`Code` + ` ` + `(${getCurrency(c, "code")})`,
+            name: t`Code` + ` ` + `(${code})`,
             value: "code",
           },
           {
-            name: t`Name` + ` ` + `(${getCurrency(c, "name")})`,
+            name: t`Name` + ` ` + `(${name})`,
             value: "name",
           },
         ],


### PR DESCRIPTION
For most currencies, we don't actually support using the native currency symbol for number formatting. This is because we're passing the `en` language code to the `Intl.NumberFormat` object for all currencies, which seems to fall back to the ISO 4217 currency codes for most languages. #10785 is currently open to improve currency formatting for these cases.

Until that happens, this PR hides the "symbol" option if it isn't supported (i.e. if the symbol is the same as the currency code).

Before             |  After
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/32746338/127386602-cdc90911-60bf-4730-89bc-906d2ad3957b.png)  |  ![](https://user-images.githubusercontent.com/32746338/127386521-75667532-5897-4412-8f16-16aba1e77d50.png)

For reference, here is the list of currencies where the symbol is currently supported:
```
US dollar
Canadian dollar
Euro
Australian dollar
Brazilian real
Chinese yuan
British pound
Hong Kong dollar
Israeli new shekel
Indian rupee
Japanese yen
South Korean won
Mexican Peso
New Zealand dollar
New Taiwan dollar
Vietnamese dong
```