### PR TITLE
Fix autobackport job fails because of branches like release-x.39.4-something

### DIFF
--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -68,8 +68,13 @@ jobs:
               ref: "heads/release-x.",
             });
 
-            const getVersionFromBranch = branch => parseInt(branch.match(/release-x\.(.*?)\.x/)[1]);
-            const latestReleaseBranch = releaseBranches.data.reduce((prev, current) => getVersionFromBranch(prev.ref) > getVersionFromBranch(current.ref) ? prev : current);
+            const getVersionFromBranch = branch => {
+              const match = branch.match(/release-x\.(.*?)\.x/);
+              return match && parseInt(match[1])
+            };
+            const latestReleaseBranch = releaseBranches.data
+              .filter(branch => getVersionFromBranch(branch.ref) !== null)
+              .reduce((prev, current) => getVersionFromBranch(prev.ref) > getVersionFromBranch(current.ref) ? prev : current);
             const latestReleaseBranchName = latestReleaseBranch.ref.replace(/^refs\/heads\//, "");
 
             console.log(`Latest release branch: ${latestReleaseBranchName}`)


### PR DESCRIPTION
Existing branches like `release-x.39.4-something` cause exceptions due to a bug in the `AutoBackport` job which leads to unwanted failure comments. This PR fixes it.