### PR TITLE
Let VS Code recognize decorators

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -14,6 +14,7 @@
         "./enterprise/frontend/src/*",
         "./enterprise/frontend/test/*"
       ]
-    }
+    },
+    "experimentalDecorators": true
   }
 }


### PR DESCRIPTION
https://www.typescriptlang.org/tsconfig#experimentalDecorators

How to try: open a .js file that has decorator, e.g. `frontend/src/metabase-lib/lib/metadata/Field.js`.

**Before this PR**

VS Code shows red squiggly lines on the decorated function:

![image](https://user-images.githubusercontent.com/7288/127601411-6ade3380-0024-44c4-9b5d-3e1e5961d560.png)

**After this PR**

![image](https://user-images.githubusercontent.com/7288/127601473-8da25075-53f6-4b4f-8ae8-80831b779f72.png)
