### PR TITLE
Fix Elastic Beanstalk deployment in v40

### DIFF
--- a/bin/release/src/release/elastic_beanstalk.clj
+++ b/bin/release/src/release/elastic_beanstalk.clj
@@ -26,6 +26,10 @@
   "Source location of the .ebextensions directory"
   (u/assert-file-exists (u/filename c/root-directory "bin" "release" "src" "release" "elastic_beanstalk" ".ebextensions")))
 
+(def ^:private eb-platform-source
+  "Source location of the .ebextensions directory"
+  (u/assert-file-exists (u/filename c/root-directory "bin" "release" "src" "release" "elastic_beanstalk" ".platform")))
+
 (def ^:private archive-temp-dir
   "Path where we'll put the contents of the ZIP file before we create it."
   "/tmp/metabase-aws-eb")
@@ -75,6 +79,8 @@
             (json/generate-string (dockerrun-json-content) {:pretty true})))
     (u/step "Copy .ebextensions"
       (u/copy-file! eb-extensions-source (u/filename archive-temp-dir ".ebextensions")))
+    (u/step "Copy .platform"
+      (u/copy-file! eb-platform-source (u/filename archive-temp-dir ".platform")))
     (u/step "Create metabase-aws-eb.zip"
       (u/delete-file-if-exists! archive-path)
       (u/sh {:dir archive-temp-dir} "zip" "--recurse-paths" archive-path ".")

--- a/bin/release/src/release/elastic_beanstalk/.ebextensions/01_metabase.config
+++ b/bin/release/src/release/elastic_beanstalk/.ebextensions/01_metabase.config
@@ -4,59 +4,34 @@
 # Comment out a variable to disable a feature
 #####
 
-files:
-    "/tmp/install" :
-        mode: "000755"
-        owner: root
-        group: root
-        source: https://inspector-agent.amazonaws.com/linux/latest/install
-
 container_commands:
-    # do server_https first to avoid overwriting other config changes
-    01_server_https:
-        command: ".ebextensions/metabase_config/metabase-setup.sh server_https"
-        ignoreErrors: true
+    01-persist_env_vars:
+        command: ".ebextensions/metabase_config/metabase-setup.sh set_up_env_vars"
+        ignoreErrors: false
 
-    02_log_x_real_ip:
-        command: ".ebextensions/metabase_config/metabase-setup.sh log_x_real_ip"
-        ignoreErrors: true
-
-    03_install_papertrail:
+    02_install_papertrail:
         command: ".ebextensions/metabase_config/metabase-setup.sh install_papertrail"
         test: test $PAPERTRAIL_HOST
         ignoreErrors: true
 
-    04_try_papertrail:
+    03_try_papertrail:
         command: "/sbin/service remote_syslog restart"
         test: test -e /etc/log_files.yml
         ignoreErrors: true
-
-    05_try_nginx:
-        command: "/sbin/service nginx restart"
-        test: nginx -t
-        ignoreErrors: false
     
-    06-install_inspector:
-        command: bash -x install -u false
-        cwd: /tmp/
-
-    07-install_cloudwatch_agent:
-        command: sudo yum install amazon-cloudwatch-agent -y
-
-    08-run_cloudwatch_agent:
-        command: sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:.ebextensions/metabase_config/cloudwatch/config.json -s
-
-    09-persist_env_vars:
-        command: /opt/elasticbeanstalk/bin/get-config environment | jq -r 'to_entries | .[] | "export \(.key)=\"\(.value)\""' > /etc/profile.d/sh.local
-    
-    10_set_up_env_vars:
-        command: ".ebextensions/metabase_config/metabase-setup.sh set_up_env_vars"
+    04_install_inspector:
+        command: yum -q list installed AwsAgent &>/dev/null && echo "Inspector installed, nothing to do here" || curl -O https://inspector-agent.amazonaws.com/linux/latest/install | sudo bash
         ignoreErrors: true
 
+    05-install_cloudwatch_agent:
+        command: sudo yum update && sudo yum upgrade -y && yum -q list installed amazon-cloudwatch-agent &>/dev/null && echo "Cloudwatch agent installed, nothing to do here" || sudo yum -y install https://s3.amazonaws.com/amazoncloudwatch-agent/amazon_linux/amd64/latest/amazon-cloudwatch-agent.rpm
+        ignoreErrors: true
+
+    06-run_cloudwatch_agent:
+        command: sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:.ebextensions/metabase_config/cloudwatch/config.json -s
+        ignoreErrors: true
+
+# NGINX will be disabled in future releases, this will make the trick 
 #option_settings:
-#    aws:elasticbeanstalk:application:environment
-#        NGINX_FORCE_SSL=1
-#        PAPERTRAIL_HOSTNAME=$HOSTNAME
-#        PAPERTRAIL_HOST=foobar.papertrailapp.com
-#        PAPERTRAIL_PORT=12345
-#        PAPERTRAIL_FILES=/var/log/nginx/access.log /var/log/nginx/error.log
+#    aws:elasticbeanstalk:environment:proxy:
+#        ProxyServer: "none"

--- a/bin/release/src/release/elastic_beanstalk/.ebextensions/metabase_config/metabase-setup.sh
+++ b/bin/release/src/release/elastic_beanstalk/.ebextensions/metabase_config/metabase-setup.sh
@@ -5,6 +5,52 @@
 # Unset a variable to disable a feature
 ####
 
+set_up_env_vars () {
+    # /opt/elasticbeanstalk/bin/get-config environment | jq -r 'to_entries | .[] | "export \(.key)=\"\(.value)\""' > /etc/profile.d/sh.local
+    if grep -q "Amazon Linux 2" /etc/os-release; then 
+        if [ ! -z "$RDS_HOSTNAME" ]; then 
+            # sed -i 's/RDS_HOSTNAME/MB_DB_HOST/' /etc/profile.d/sh.local
+            sed -i 's/RDS_HOSTNAME/MB_DB_HOST/' /opt/elasticbeanstalk/deployment/env.list
+            # sed -i 's/RDS_USERNAME/MB_DB_USER/' /etc/profile.d/sh.local
+            sed -i 's/RDS_USERNAME/MB_DB_USER/' /opt/elasticbeanstalk/deployment/env.list
+            # sed -i 's/RDS_PASSWORD/MB_DB_PASS/' /etc/profile.d/sh.local
+            sed -i 's/RDS_PASSWORD/MB_DB_PASS/' /opt/elasticbeanstalk/deployment/env.list
+            # sed -i 's/RDS_PORT/MB_DB_PORT/' /etc/profile.d/sh.local 
+            sed -i 's/RDS_PORT/MB_DB_PORT/' /opt/elasticbeanstalk/deployment/env.list
+            # sed -i 's/RDS_DB_NAME/MB_DB_DBNAME/' /etc/profile.d/sh.local 
+            sed -i 's/RDS_DB_NAME/MB_DB_DBNAME/' /opt/elasticbeanstalk/deployment/env.list
+            if [ "$RDS_PORT" == "3306" ]; then 
+                # echo 'export MB_DB_TYPE="mysql"' >> /etc/profile.d/sh.local
+                echo 'MB_DB_TYPE=mysql' >> /opt/elasticbeanstalk/deployment/env.list
+            else 
+                # echo 'export MB_DB_TYPE="postgres"' >> /etc/profile.d/sh.local
+                echo 'MB_DB_TYPE=postgres' >> /opt/elasticbeanstalk/deployment/env.list
+            fi 
+        fi
+    else
+        if [ ! -z "$RDS_HOSTNAME" ]; then 
+            # sed -i 's/RDS_HOSTNAME/MB_DB_HOST/' /etc/profile.d/sh.local
+            sed -i 's/RDS_HOSTNAME/MB_DB_HOST/' /opt/elasticbeanstalk/deploy/configuration/containerconfiguration
+            # sed -i 's/RDS_USERNAME/MB_DB_USER/' /etc/profile.d/sh.local
+            sed -i 's/RDS_USERNAME/MB_DB_USER/' /opt/elasticbeanstalk/deploy/configuration/containerconfiguration
+            # sed -i 's/RDS_PASSWORD/MB_DB_PASS/' /etc/profile.d/sh.local
+            sed -i 's/RDS_PASSWORD/MB_DB_PASS/' /opt/elasticbeanstalk/deploy/configuration/containerconfiguration
+            # sed -i 's/RDS_PORT/MB_DB_PORT/' /etc/profile.d/sh.local 
+            sed -i 's/RDS_PORT/MB_DB_PORT/' /opt/elasticbeanstalk/deploy/configuration/containerconfiguration
+            # sed -i 's/RDS_DB_NAME/MB_DB_DBNAME/' /etc/profile.d/sh.local 
+            sed -i 's/RDS_DB_NAME/MB_DB_DBNAME/' /opt/elasticbeanstalk/deploy/configuration/containerconfiguration
+            if [ "$RDS_PORT" == "3306" ]; then 
+                # echo 'export MB_DB_TYPE="mysql"' >> /etc/profile.d/sh.local
+                sed -i 's/}}}}/,"MB_DB_TYPE":"mysql"}}}}/' /opt/elasticbeanstalk/deploy/configuration/containerconfiguration
+            else 
+                # echo 'export MB_DB_TYPE="postgres"' >> /etc/profile.d/sh.local
+                sed -i 's/}}}}/,"MB_DB_TYPE":"postgres"}}}}/' /opt/elasticbeanstalk/deploy/configuration/containerconfiguration
+            fi 
+        fi
+    fi
+    
+}
+
 # add files to papertrail
 pt_files () {
     sed -i '/  - .*/d' /etc/log_files.yml
@@ -31,118 +77,12 @@ pt_local_host () {
     sed -i "s/.*hostname:.*/hostname: $PAPERTRAIL_HOSTNAME/" /etc/log_files.yml
 }
 
-# enable https redirect
-server_https () {
-    cd /etc/nginx/sites-available/
-    if [[ "x$NGINX_FORCE_SSL" == "x1" ]] # && ! grep -q https elasticbeanstalk-nginx-docker-proxy.conf ;
-    then
-        cat << 'EOF' > elasticbeanstalk-nginx-docker-proxy.conf
-map $http_upgrade $connection_upgrade {
-    default        "upgrade";
-    ""            "";
-}
-
-server {
-    listen 80;
-
-    gzip on;
-        gzip_comp_level 4;
-        gzip_types text/html text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
-
-    if ($time_iso8601 ~ "^(\d{4})-(\d{2})-(\d{2})T(\d{2})") {
-        set $year $1;
-        set $month $2;
-        set $day $3;
-        set $hour $4;
-    }
-
-    access_log    /var/log/nginx/access.log;
-
-    location /api/health {
-        proxy_pass            http://docker;
-        proxy_http_version    1.1;
-
-        proxy_set_header    Connection            $connection_upgrade;
-        proxy_set_header    Upgrade                $http_upgrade;
-        proxy_set_header    Host                $host;
-        proxy_set_header    X-Real-IP            $remote_addr;
-        proxy_set_header    X-Forwarded-For        $proxy_add_x_forwarded_for;
-        proxy_connect_timeout 600;
-        proxy_send_timeout 600;
-        proxy_read_timeout 600;
-        send_timeout 600;
-
-    }
-
-
-    location / {
-        if ($http_x_forwarded_proto != "https") {
-                rewrite ^ https://$host$request_uri? permanent;
-        }
-
-        proxy_pass            http://docker;
-        proxy_http_version    1.1;
-
-        proxy_set_header    Connection            $connection_upgrade;
-        proxy_set_header    Upgrade                $http_upgrade;
-        proxy_set_header    Host                $host;
-        proxy_set_header    X-Real-IP            $remote_addr;
-        proxy_set_header    X-Forwarded-For        $proxy_add_x_forwarded_for;
-        proxy_connect_timeout 600;
-        proxy_send_timeout 600;
-        proxy_read_timeout 600;
-        send_timeout 600;
-    }
-}
-EOF
-    else
-        cat << 'EOF' > elasticbeanstalk-nginx-docker-proxy.conf
-map $http_upgrade $connection_upgrade {
-    default        "upgrade";
-    ""            "";
-}
-
-server {
-    listen 80;
-
-    gzip on;
-        gzip_comp_level 4;
-        gzip_types text/html text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
-
-    if ($time_iso8601 ~ "^(\d{4})-(\d{2})-(\d{2})T(\d{2})") {
-        set $year $1;
-        set $month $2;
-        set $day $3;
-        set $hour $4;
-    }
-
-    access_log    /var/log/nginx/access.log;
-
-    location / {
-        proxy_pass            http://docker;
-        proxy_http_version    1.1;
-
-        proxy_set_header    Connection            $connection_upgrade;
-        proxy_set_header    Upgrade                $http_upgrade;
-        proxy_set_header    Host                $host;
-        proxy_set_header    X-Real-IP            $remote_addr;
-        proxy_set_header    X-Forwarded-For        $proxy_add_x_forwarded_for;
-        proxy_connect_timeout 600;
-        proxy_send_timeout 600;
-        proxy_read_timeout 600;
-        send_timeout 600;
-    }
-}
-EOF
-    fi
-}
-
 # download, install and configure papertrail
 install_papertrail () {
     cp .ebextensions/metabase_config/papertrail/log_files.yml /etc/log_files.yml && chmod 644 /etc/log_files.yml
     cp .ebextensions/metabase_config/papertrail/remote_syslog /etc/init.d/remote_syslog && chmod 555 /etc/init.d/remote_syslog
     cd /tmp/
-    wget -q "https://github.com/papertrail/remote_syslog2/releases/download/v0.14/remote_syslog_linux_amd64.tar.gz" &&
+    wget -q "https://github.com/papertrail/remote_syslog2/releases/download/v0.20/remote_syslog_linux_amd64.tar.gz" &&
         tar xzf remote_syslog_linux_amd64.tar.gz
     /sbin/service remote_syslog stop
     mv /tmp/remote_syslog/remote_syslog /usr/local/bin/
@@ -154,43 +94,11 @@ install_papertrail () {
     [[ "$PAPERTRAIL_HOSTNAME" ]] && pt_local_host
 }
 
-# update nginx logging to include x_real_ip
-log_x_real_ip () {
-    cp .ebextensions/metabase_config/nginx/log_x_real_ip.conf /etc/nginx/conf.d/log_x_real_ip.conf
-    cd  /etc/nginx/sites-available
-    if ! grep -q access_log *-proxy.conf ; then
-        sed -i 's|location \/ {|location \/ {\n\n        access_log \/var\/log\/nginx\/access.log log_x_real_ip;\n|' *-proxy.conf
-    fi
-}
-
-set_up_env_vars () {
-    if [ ! -z "$RDS_HOSTNAME" ]; then
-    # EEK: this is a bit fragile.  if user picks a non-standard port for their db we are screwed :(
-        if [ "$RDS_PORT" == "3306" ]; then
-            export MB_DB_TYPE=mysql
-        else
-            export MB_DB_TYPE=postgres
-        fi
-
-        export MB_DB_DBNAME=$RDS_DB_NAME
-        export MB_DB_USER=$RDS_USERNAME
-        export MB_DB_PASS=$RDS_PASSWORD
-        export MB_DB_HOST=$RDS_HOSTNAME
-        export MB_DB_PORT=$RDS_PORT
-    fi
-}
-
 case $1 in
 set_up_env_vars)
     set_up_env_vars
     ;;
-server_https)
-    server_https
-    ;;
 install_papertrail)
     install_papertrail
-    ;;
-log_x_real_ip)
-    log_x_real_ip
     ;;
 esac

--- a/bin/release/src/release/elastic_beanstalk/.ebextensions/metabase_config/nginx/log_x_real_ip.conf
+++ b/bin/release/src/release/elastic_beanstalk/.ebextensions/metabase_config/nginx/log_x_real_ip.conf
@@ -1,4 +1,0 @@
-# /etc/nginx/conf.d/log_x_real_ip.conf
-log_format log_x_real_ip '$proxy_add_x_forwarded_for - [$time_local] '
-                      '$request $status $body_bytes_sent '
-                      '$http_referer $http_user_agent';

--- a/bin/release/src/release/elastic_beanstalk/.platform/confighooks/postdeploy/config_nginx.sh
+++ b/bin/release/src/release/elastic_beanstalk/.platform/confighooks/postdeploy/config_nginx.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+if [[ "x$NGINX_FORCE_SSL" == "x1" ]]; then
+    cp .platform/nginx/nginx-ssl.conf /etc/nginx/nginx.conf && nginx -t && /sbin/service nginx restart
+else
+    cp .platform/nginx/nginx.conf /etc/nginx/nginx.conf && nginx -t && /sbin/service nginx restart
+fi

--- a/bin/release/src/release/elastic_beanstalk/.platform/hooks/postdeploy/config_nginx.sh
+++ b/bin/release/src/release/elastic_beanstalk/.platform/hooks/postdeploy/config_nginx.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+if [[ "x$NGINX_FORCE_SSL" == "x1" ]]; then
+    cp .platform/nginx/nginx-ssl.conf /etc/nginx/nginx.conf && nginx -t && /sbin/service nginx restart
+else
+    cp .platform/nginx/nginx.conf /etc/nginx/nginx.conf && nginx -t && /sbin/service nginx restart
+fi

--- a/bin/release/src/release/elastic_beanstalk/.platform/nginx/nginx-ssl.conf
+++ b/bin/release/src/release/elastic_beanstalk/.platform/nginx/nginx-ssl.conf
@@ -1,0 +1,58 @@
+user  nginx;
+worker_processes  auto;
+error_log  /var/log/nginx/error.log;
+pid        /var/run/nginx.pid;
+worker_rlimit_nofile    65936;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    access_log    /var/log/nginx/access.log;
+
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                          '$status $body_bytes_sent "$http_referer" '
+                          '"$http_user_agent" "$http_x_forwarded_for"';
+
+    include  conf.d/*.conf;
+
+    map $http_upgrade $connection_upgrade {
+            default       "upgrade";
+    }
+
+    server {
+        listen 80 default_server;
+        gzip on;
+        gzip_comp_level 4;
+        gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+
+        access_log    /var/log/nginx/access.log main;
+ 
+        location / {
+            if ($http_x_forwarded_proto != "https") {
+                rewrite ^ https://$host$request_uri? permanent;
+            }
+
+            proxy_pass            http://docker;
+            proxy_http_version    1.1;
+
+            proxy_set_header    Connection             $connection_upgrade;
+            proxy_set_header    Upgrade                $http_upgrade;
+            proxy_set_header    Host                   $host;
+            proxy_set_header    X-Real-IP              $remote_addr;
+            proxy_set_header    X-Forwarded-For        $proxy_add_x_forwarded_for;
+            proxy_connect_timeout 600;
+            proxy_send_timeout 600;
+            proxy_read_timeout 600;
+            send_timeout 600;
+        }
+
+        # Include the Elastic Beanstalk generated locations
+        include conf.d/elasticbeanstalk/*.conf;
+    }
+}

--- a/bin/release/src/release/elastic_beanstalk/.platform/nginx/nginx.conf
+++ b/bin/release/src/release/elastic_beanstalk/.platform/nginx/nginx.conf
@@ -1,0 +1,54 @@
+user  nginx;
+worker_processes  auto;
+error_log  /var/log/nginx/error.log;
+pid        /var/run/nginx.pid;
+worker_rlimit_nofile    65936;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    access_log    /var/log/nginx/access.log;
+
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                          '$status $body_bytes_sent "$http_referer" '
+                          '"$http_user_agent" "$http_x_forwarded_for"';
+
+    include  conf.d/*.conf;
+
+    map $http_upgrade $connection_upgrade {
+            default       "upgrade";
+    }
+
+    server {
+        listen 80 default_server;
+        gzip on;
+        gzip_comp_level 4;
+        gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+
+        access_log    /var/log/nginx/access.log main;
+
+        location / {
+            proxy_pass            http://docker;
+            proxy_http_version    1.1;
+
+            proxy_set_header    Connection             $connection_upgrade;
+            proxy_set_header    Upgrade                $http_upgrade;
+            proxy_set_header    Host                   $host;
+            proxy_set_header    X-Real-IP              $remote_addr;
+            proxy_set_header    X-Forwarded-For        $proxy_add_x_forwarded_for;
+            proxy_connect_timeout 600;
+            proxy_send_timeout 600;
+            proxy_read_timeout 600;
+            send_timeout 600;
+        }
+
+        # Include the Elastic Beanstalk generated locations
+        include conf.d/elasticbeanstalk/*.conf;
+    }
+}


### PR DESCRIPTION
This PR tends to solve the following issues:
1) failure in the upgrade to v40 due to the fact that cloudwatch agent is not available in yum repositories in Amazon Linux (introduced in https://github.com/metabase/metabase/pull/14718)
2) failure in AWS inspector not being available in some regions (introduced in https://github.com/metabase/metabase/pull/14718)
3) Metabase not connecting to the Application Database in COUPLED RDS's as the environment variables are named RDS_ (introduced in https://github.com/metabase/metabase/pull/14718), as we were detecting this in the shell script that we were including in the Docker image (so all Dockers had this detection of RDS_ variables which were only applicable to Elastic Beanstalk)
4) steps failing and then crashing the whole deployment (introduced in https://github.com/metabase/metabase/pull/14718)
5) Nginx not having custom confs (this one has been there for a lot of time)

This PR intends to to the following
1) simplify the deployment script (less steps)
2) Nginx now deploys only the files that are in a post deployment step (simpler to understand, simpler to modify in case someone does that)
3) detection of which platform the user is running to replace ENV VARS according to the version of the OS
4) Cloudwatch agent now pulls the file from AWS source instead of getting it from the yum repo
5) steps don't crash the deployment fails (unless the env vars don't work, as we don't want to do that because the container won't connect to the coupled RDS)

This PR also leaves the papertrail steps which were not working before, but as we didn't have any reports of this, it might be something we remove in the next versions, along with the removal of NGINX (as it makes sense to expose Jetty to an external load balancer instead of using nginx as a sidecar to the web server)