### PR TITLE
Only build currently active drivers

### DIFF
--- a/bin/build-drivers/src/build_drivers.clj
+++ b/bin/build-drivers/src/build_drivers.clj
@@ -2,11 +2,16 @@
   "Entrypoint for `bin/build-drivers.sh`. Builds all drivers, if needed."
   (:require [build-drivers.build-driver :as build-driver]
             [clojure.java.io :as io]
-            [metabuild-common.core :as u]))
+            [metabuild-common.core :as u])
+  (:import java.io.File))
 
 (defn- all-drivers []
   (->> (.listFiles (io/file (u/filename u/project-root-directory "modules" "drivers")))
-       (filter #(.isDirectory %)) ;; watch for errant DS_Store files on os_x
+       (filter (fn [^File d]
+                 (and (.isDirectory d) ;; watch for errant DS_Store files on os_x
+                   ;; only consider a directory to be a driver if it contains a lein or deps build file
+                   (first (filter true? (map (fn [f]
+                                               (.exists (io/file d f))) ["project.clj" "deps.edn"]))))))
        (map (comp keyword #(.getName %)))))
 
 (defn build-drivers! [edition]

--- a/bin/build-drivers/src/build_drivers.clj
+++ b/bin/build-drivers/src/build_drivers.clj
@@ -10,8 +10,8 @@
        (filter (fn [^File d]
                  (and (.isDirectory d) ;; watch for errant DS_Store files on os_x
                    ;; only consider a directory to be a driver if it contains a lein or deps build file
-                   (first (filter true? (map (fn [f]
-                                               (.exists (io/file d f))) ["project.clj" "deps.edn"]))))))
+                   (some true? (map (fn [f]
+                                      (.exists (io/file d f))) ["project.clj" "deps.edn"])))))
        (map (comp keyword #(.getName %)))))
 
 (defn build-drivers! [edition]


### PR DESCRIPTION
Update `all-drivers` fn so that it only "finds" drivers that have either a `project.clj` or `deps.edn` file (i.e. some build file), and ignores the directory otherwise. This is to deal with cached artifacts hanging around between builds in a shared executor type environment (ex: CircleCI), where even though the checkout won't bring in some driver directory that doesn't exist on the target branch, some other files (such as `pom.xml` or a `target` directory), might still be hanging around
