### PR TITLE
Fixing Presto JDBC issues

### DIFF
--- a/modules/drivers/presto-jdbc/resources/metabase-plugin.yaml
+++ b/modules/drivers/presto-jdbc/resources/metabase-plugin.yaml
@@ -18,8 +18,10 @@ driver:
         - dbname
         - name: catalog
           placeholder: hive
+          display-name: Catalog
           required: false
     - name: schema
+      display-name: Schema (optional)
       required: false
     - user
     - password

--- a/modules/drivers/presto-jdbc/src/metabase/driver/presto_jdbc.clj
+++ b/modules/drivers/presto-jdbc/src/metabase/driver/presto_jdbc.clj
@@ -333,9 +333,9 @@
         (log/debug e (trs "Error setting statement fetch direction to FETCH_FORWARD"))))
     stmt))
 
-(defmethod driver/can-connect? :sql-jdbc
+(defmethod driver/can-connect? :presto-jdbc
   [driver details]
-  (sql-jdbc.conn/can-connect? driver details))
+  (sql-jdbc.conn/can-connect? driver (dissoc details :engine)))
 
 (defn- ^PrestoConnection pooled-conn->presto-conn
   "Unwraps the C3P0 `pooled-conn` and returns the underlying `PrestoConnection` it holds."

--- a/modules/drivers/presto-jdbc/test/metabase/driver/presto_jdbc_test.clj
+++ b/modules/drivers/presto-jdbc/test/metabase/driver/presto_jdbc_test.clj
@@ -4,6 +4,7 @@
             [honeysql.core :as hsql]
             [honeysql.format :as hformat]
             [java-time :as t]
+            [metabase.api.database :as database-api]
             [metabase.db.metadata-queries :as metadata-queries]
             [metabase.driver :as driver]
             [metabase.driver.presto-jdbc :as presto-jdbc]
@@ -190,3 +191,8 @@
                    (map #(select-keys % [:name :schema :db_id]) (db/select Table :db_id (mt/id)))))))
         (execute-ddl! [(format "DROP TABLE %s.%s" s t)
                        (format "DROP SCHEMA %s" s)])))))
+
+(deftest test-database-connection-test
+  (mt/test-driver :presto-jdbc
+    (testing "can-test-database-connection works"
+      (is (nil? (database-api/test-database-connection :presto-jdbc (:details (mt/db))))))))


### PR DESCRIPTION
Updating schema connection property to have proper display name

Updating display name for database to be "Schema"

Fixing driver/can-connect? impl in presto_jdbc.clj to actually use the correct driver, and dissoc :engine before calling the sql-jdbc.conn method

Adding test for the `test-database-connection` method, which is what led to the error from the UI
