### PR TITLE
Build drivers only active 40

### DIFF
--- a/bin/build-drivers/src/build_drivers.clj
+++ b/bin/build-drivers/src/build_drivers.clj
@@ -2,11 +2,16 @@
   "Entrypoint for `bin/build-drivers.sh`. Builds all drivers, if needed."
   (:require [build-drivers.build-driver :as build-driver]
             [clojure.java.io :as io]
-            [metabuild-common.core :as u]))
+            [metabuild-common.core :as u])
+  (:import java.io.File))
 
 (defn- all-drivers []
   (->> (.listFiles (io/file (u/filename u/project-root-directory "modules" "drivers")))
-       (filter #(.isDirectory %)) ;; watch for errant DS_Store files on os_x
+       (filter (fn [^File d]
+                 (and (.isDirectory d) ;; watch for errant DS_Store files on os_x
+                   ;; only consider a directory to be a driver if it contains a lein or deps build file
+                   (first (filter true? (map (fn [f]
+                                               (.exists (io/file d f))) ["project.clj" "deps.edn"]))))))
        (map (comp keyword #(.getName %)))))
 
 (defn build-drivers! [edition]

--- a/bin/build-drivers/src/build_drivers.clj
+++ b/bin/build-drivers/src/build_drivers.clj
@@ -10,8 +10,8 @@
        (filter (fn [^File d]
                  (and (.isDirectory d) ;; watch for errant DS_Store files on os_x
                    ;; only consider a directory to be a driver if it contains a lein or deps build file
-                   (first (filter true? (map (fn [f]
-                                               (.exists (io/file d f))) ["project.clj" "deps.edn"]))))))
+                   (some true? (map (fn [f]
+                                      (.exists (io/file d f))) ["project.clj" "deps.edn"])))))
        (map (comp keyword #(.getName %)))))
 
 (defn build-drivers! [edition]

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -133,7 +133,7 @@
                                                     "      now(), convert_tz(now(), @@GLOBAL.time_zone, '+00:00')"
                                                     "   ),"
                                                     "   '%H:%i'"
-                                                    " ) AS offset;")
+                                                    " ) AS 'offset';")
         [{:keys [global_tz system_tz offset]}] (jdbc/query spec sql)
         the-valid-id                           (fn [zone-id]
                                                  (when zone-id


### PR DESCRIPTION
Cherry pick of #17262 for `release-x.40.x`

Also cherry pick #17101 for `release-x.40.x`.

Chicken and egg problem: this fix had failing tests on maria latest, the branch to cherry pick the maria fix had failing tests in building drivers. Just combine them and let's see all green.