### PR TITLE
offset is a reserved word in mariadb as of 10.6 (#17101)

### DIFF
--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -133,7 +133,7 @@
                                                     "      now(), convert_tz(now(), @@GLOBAL.time_zone, '+00:00')"
                                                     "   ),"
                                                     "   '%H:%i'"
-                                                    " ) AS offset;")
+                                                    " ) AS 'offset';")
         [{:keys [global_tz system_tz offset]}] (jdbc/query spec sql)
         the-valid-id                           (fn [zone-id]
                                                  (when zone-id


### PR DESCRIPTION
* offset is a reserved word in mariadb as of 10.6

- https://mariadb.com/kb/en/reserved-words/
- https://github.com/MariaDB/server/commit/299b935320

I think it is related to https://jira.mariadb.org/browse/MDEV-23908
"Implement SELECT ... OFFSET ... FETCH ..."

* Handle new names for utf8 in mariadb

https://mariadb.com/kb/en/unicode/

- utf8: Until MariaDB 10.5, this was a UTF-8 encoding using one to
three bytes per character. Basic Latin letters, numbers and
punctuation use one byte. European and Middle East letters mostly fit
into 2 bytes. Korean, Chinese, and Japanese ideographs use 3-bytes. No
supplementary characters are stored. From MariaDB 10.6, utf8 is an
alias for utf8mb3, but this can changed to ut8mb4 by changing the
default value of the old_mode system variable.

- utf8mb3: UTF-8 encoding using one to three bytes per
character. Basic Latin letters, numbers and punctuation use one
byte. European and Middle East letters mostly fit into 2
bytes. Korean, Chinese, and Japanese ideographs use 3-bytes. No
supplementary characters are stored. Until MariaDB 10.5, this was an
alias for utf8. From MariaDB 10.6, utf8 is by default an alias for
utf8mb3, but this can changed to ut8mb4 by changing the default value
of the old_mode system variable.

###### Before submitting the PR, please make sure you do the following

- [ ] If you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.

### Tests

- [ ] Run the frontend and Cypress end-to-end tests with `yarn lint && yarn test`)
- [ ] If there are changes to the backend codebase, run the backend tests with `clojure -X:dev:test`
- [ ] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
      (unless it's a tiny documentation change).
