### PR TITLE
Handle mutation of vizSetting column when syncing columns in a native question

### DIFF
--- a/frontend/src/metabase-lib/lib/Question.js
+++ b/frontend/src/metabase-lib/lib/Question.js
@@ -624,8 +624,11 @@ export default class Question {
 
     const validVizSettings = vizSettings.filter(colSetting => {
       const hasColumn = findColumnIndexForColumnSetting(cols, colSetting) >= 0;
-      return hasColumn;
+      const isMutatingColumn =
+        findColumnIndexForColumnSetting(addedColumns, colSetting) >= 0;
+      return hasColumn && !isMutatingColumn;
     });
+
     const noColumnsRemoved = validVizSettings.length === vizSettings.length;
 
     if (noColumnsRemoved && addedColumns.length === 0) {


### PR DESCRIPTION
Fixes #17060 

When calling Question's _syncNativeQuerySettings method we need to treat
existing, mutated columns as invalid so that they are filtered out and a
new column takes the existing column's place.

The function we use to find valid columns, findColumnIndexForColumnSetting,
will return true if it finds a matching field_ref OR a matching name, so we
also need to check the addedColumns array we just created in order to remove
any columns from vizSettings that also exist there, since we combine the two
at the end of this method.

Here are some screen recordings of the fix using the alternative way to repro found in this comment https://github.com/metabase/metabase/issues/17060#issuecomment-886655622

Before:

https://user-images.githubusercontent.com/13057258/127927025-7fa0a112-25c0-4ba5-ad2a-8e1e4f679357.mov

After:

https://user-images.githubusercontent.com/13057258/127927037-0fefcbf0-06a4-428c-a6c8-b54f3545a45a.mov

