### PR TITLE
Fix incorrect props are passed to CollectionPermissionModal when used for snippets folders

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/snippets/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/snippets/index.js
@@ -51,7 +51,7 @@ PLUGIN_SNIPPET_SIDEBAR_MODALS.push(
       >
         <CollectionPermissionsModal
           params={{
-            collectionId: snippetSidebar.state.permissionsModalCollectionId,
+            slug: snippetSidebar.state.permissionsModalCollectionId,
           }}
           onClose={() =>
             snippetSidebar.setState({ permissionsModalCollectionId: null })

--- a/frontend/test/metabase/scenarios/native/snippets/snippet-permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/snippets/snippet-permissions.cy.spec.js
@@ -179,7 +179,7 @@ describeWithToken("scenarios > question > snippets", () => {
       cy.findByText("Snippet Folder").should("not.exist");
     });
 
-    it.skip("shouldn't update root permissions when changing permissions on a created folder (metabase#17268)", () => {
+    it("shouldn't update root permissions when changing permissions on a created folder (metabase#17268)", () => {
       cy.intercept("PUT", "/api/collection/graph").as("updatePermissions");
 
       openNativeEditor();


### PR DESCRIPTION
### Description

When `CollectionPermissionsModal` is used for snippets folders it receives manually passed params that are not from the router. Since we [swapped ids with slugs](https://github.com/metabase/metabase/pull/15989/files#diff-f5f9aab139a295df6f135ece9ff9d0c95a222f72c22a071738cc8e3343e98f62R28) it stopped working.

Closes https://github.com/metabase/metabase/issues/17268