### PR TITLE
🍒 Cherry pick bug fixes from master into release-x.40.x for the 40.2 release

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/serialize.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/serialize.clj
@@ -208,7 +208,8 @@
   [card]
   (-> card
       (m/update-existing :table_id (partial fully-qualified-name Table))
-      (update :database_id (partial fully-qualified-name Database))))
+      (update :database_id (partial fully-qualified-name Database))
+      (m/update-existing :visualization_settings convert-viz-settings)))
 
 (defmethod serialize-one (type Pulse)
   [pulse]

--- a/enterprise/backend/test/metabase_enterprise/serialization/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/test_util.clj
@@ -146,7 +146,16 @@
                                 :collection_id ~'collection-id
                                 :dataset_query {:type :query
                                                 :database ~'db-id
-                                                :query {:source-table (str "card__" ~'card-id)}}}]
+                                                :query {:source-table (str "card__" ~'card-id)}}
+                                :visualization_settings
+                                {:table.columns [{:name "Venue Category"
+                                                  :fieldRef [:field ~'category-field-id nil]
+                                                  :enabled true}]
+                                 :column_settings {(keyword (format
+                                                             "[\"ref\",[\"field\",%d,null]]"
+                                                              ~'latitude-field-id))
+                                                   {:show_mini_bar true
+                                                    :column_title "Parallel"}}}}]
                    Card       [{~'card-id-nested-query :id}
                                {:table_id ~'table-id
                                 :name "My Nested Query Card"

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditContent.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditContent.jsx
@@ -17,9 +17,9 @@ export default class AuditContent extends React.Component {
         {tabs && (
           <div className="border-bottom px4 mt1">
             <Radio
-              underlined
+              variant="underlined"
               value={this.props.router.location.pathname}
-              options={tabs.filter(tab => tab.component)} // hide tabs that aren't implemented
+              options={tabs.filter(tab => tab.component)} // hide tabs that are not implemented
               optionValueFn={tab => `${pagePath}/${tab.path}`}
               optionNameFn={tab => tab.title}
               optionKeyFn={tab => tab.path}

--- a/frontend/test/metabase/scenarios/admin/people/people.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/people/people.cy.spec.js
@@ -203,6 +203,14 @@ describe("scenarios > admin > people", () => {
       assertTableRowsCount(TOTAL_USERS);
     });
 
+    it("should display more than 50 groups (metabase#17200)", () => {
+      generateGroups(51);
+
+      cy.visit("/admin/people/groups");
+      cy.scrollTo("bottom");
+      cy.findByText("readonly");
+    });
+
     describe("pagination", () => {
       const NEW_USERS = 18;
       const NEW_TOTAL_USERS = TOTAL_USERS + NEW_USERS;

--- a/frontend/test/metabase/scenarios/admin/people/people.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/people/people.cy.spec.js
@@ -208,6 +208,7 @@ describe("scenarios > admin > people", () => {
 
       cy.visit("/admin/people/groups");
       cy.scrollTo("bottom");
+
       cy.findByText("readonly");
     });
 
@@ -305,4 +306,10 @@ function generateUsers(count, groupIds) {
   users.forEach(u => cy.createUserFromRawData(u));
 
   return users;
+}
+
+function generateGroups(count) {
+  _.range(count).map(index => {
+    cy.request("POST", "api/permissions/group", { name: "Group" + index });
+  });
 }

--- a/modules/drivers/snowflake/resources/metabase-plugin.yaml
+++ b/modules/drivers/snowflake/resources/metabase-plugin.yaml
@@ -25,9 +25,6 @@ driver:
         - name: db
           required: true
           display-name: Database name (case sensitive)
-    - name: regionid
-      display-name: Region ID
-      placeholder: my_region
     - name: schema
       display-name: Schema
       placeholder: my_schema

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -6,6 +6,7 @@
             [clojure.tools.logging :as log]
             [honeysql.core :as hsql]
             [java-time :as t]
+            [medley.core :as m]
             [metabase.driver :as driver]
             [metabase.driver.common :as driver.common]
             [metabase.driver.sql-jdbc :as sql-jdbc]
@@ -42,16 +43,13 @@
   :sunday)
 
 (defmethod sql-jdbc.conn/connection-details->spec :snowflake
-  [_ {:keys [account regionid], :as opts}]
-  (let [host (if regionid
-               (str account "." regionid)
-               account)
-        upcase-not-nil (fn [s] (when s (u/upper-case-en s)))]
+  [_ {:keys [account], :as opts}]
+  (let [upcase-not-nil (fn [s] (when s (u/upper-case-en s)))]
     ;; it appears to be the case that their JDBC driver ignores `db` -- see my bug report at
     ;; https://support.snowflake.net/s/question/0D50Z00008WTOMCSA5/
     (-> (merge {:classname                                  "net.snowflake.client.jdbc.SnowflakeDriver"
                 :subprotocol                                "snowflake"
-                :subname                                    (str "//" host ".snowflakecomputing.com/")
+                :subname                                    (str "//" account ".snowflakecomputing.com/")
                 :client_metadata_request_use_connection_ctx true
                 :ssl                                        true
                 ;; keep open connections open indefinitely instead of closing them. See #9674 and
@@ -305,6 +303,13 @@
              sql  (format "SHOW OBJECTS IN DATABASE \"%s\";" db)]
          (jdbc/query spec sql)
          true)))
+
+(defmethod driver/normalize-db-details :snowflake
+  [_ database]
+  (if-not (str/blank? (-> database :details :regionid))
+    (-> (update-in database [:details :account] #(str/join "." [% (-> database :details :regionid)]))
+      (m/dissoc-in [:details :regionid]))
+    database))
 
 (defmethod unprepare/unprepare-value [:snowflake OffsetDateTime]
   [_ t]

--- a/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
+++ b/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
@@ -178,3 +178,13 @@
                   ["2014-08-02T00:00:00-07:00" "2014-08-02T02:30:00-07:00"]]
                  (mt/with-temporary-setting-values [report-timezone "US/Pacific"]
                    (run-query)))))))))
+
+(deftest normalize-test
+  (mt/test-driver :snowflake
+    (testing "details should be normalized coming out of the DB"
+      (mt/with-temp Database [db {:name    "Legacy Snowflake DB"
+                                  :engine  :snowflake,
+                                  :details {:account  "my-instance"
+                                            :regionid "us-west-1"}}]
+                             (is (= {:account "my-instance.us-west-1"}
+                                    (:details db)))))))

--- a/shared/src/metabase/shared/models/visualization_settings.cljc
+++ b/shared/src/metabase/shared/models/visualization_settings.cljc
@@ -53,9 +53,11 @@
 (s/def ::click-behavior (s/keys))
 (s/def ::visualization-settings (s/keys :opt [::column-settings ::click-behavior]))
 
-(s/def ::db-column-ref-vec (s/or :field (s/tuple (partial = "ref") (s/tuple (partial = "field")
-                                                                            (s/or :field-id int? :field-str string?)
-                                                                            (s/or :field-metadata map? :nil nil?)))
+(s/def ::field-id-vec (s/tuple (partial = "ref") (s/tuple (partial = "field")
+                                                   (s/or :field-id int? :field-str string?)
+                                                   (s/or :field-metadata map? :nil nil?))))
+
+(s/def ::db-column-ref-vec (s/or :field ::field-id-vec
                                  :column-name (s/tuple (partial = "name") string?)))
 
 (s/def ::click-behavior-type keyword? #_(s/or :cross-filter ::cross-filter
@@ -285,7 +287,6 @@
            ::link-target-id      entity-id}
           (some? parameter-mapping) (assoc ::parameter-mapping parameter-mapping)))
 
-
 (s/fdef entity-click-action
   :args (s/cat :entity-type ::entity-type :entity-id int? :parameter-mapping ::parameter-mapping)
   :ret  ::click-behavior)
@@ -322,7 +323,7 @@
                :from-field-id     int?
                :to-entity-type    ::entity-type
                :to-entity-id      int?
-               :parameter-mapping (s/? ::parameter-mapping) )
+               :parameter-mapping (s/? ::parameter-mapping))
   :ret  ::click-behavior)
 
 (defn fk-parameter-mapping
@@ -382,7 +383,8 @@
    :prefix            ::prefix
    :suffix            ::suffix
    :view_as           ::view-as
-   :link_text         ::link-text})
+   :link_text         ::link-text
+   :show_mini_bar     ::show-mini-barchart})
 
 (def ^:private norm->db-column-settings-keys
   (set/map-invert db->norm-column-settings-keys))
@@ -403,6 +405,17 @@
 
 (def ^:private norm->db-param-ref-keys
   (set/map-invert db->norm-param-ref-keys))
+
+(def ^:private db->norm-table-columns-keys
+  {:name     ::table-column-name
+   ; for now, do not translate the value of this key (the field vector)
+   :fieldRef ::table-column-field-ref
+   :enabled  ::table-column-enabled})
+
+(def ^:private norm->db-table-columns-keys
+  (set/map-invert db->norm-table-columns-keys))
+
+(s/def ::table-column-field-ref ::field-id-vec)
 
 (defn- db->norm-param-ref [parsed-id param-ref]
   (cond-> (set/rename-keys param-ref db->norm-param-ref-keys)
@@ -493,6 +506,13 @@
       (dissoc :parameterMapping)
       (set/rename-keys db->norm-click-behavior-keys)))
 
+(defn- db->norm-table-columns [v]
+  (-> v
+    (assoc ::table-columns (mapv (fn [tbl-col]
+                                   (set/rename-keys tbl-col db->norm-table-columns-keys))
+                             (:table.columns v)))
+    (dissoc :table.columns)))
+
 (defn- db->norm-column-settings-entry
   "Converts a :column_settings DB form to qualified form. Does the opposite of
   `norm->db-column-settings-entry`."
@@ -520,6 +540,9 @@
           ;; click behavior key at top level; ex: non-table card
           (:click_behavior vs)
           (assoc ::click-behavior (db->norm-click-behavior (:click_behavior vs)))
+
+          (:table.columns vs)
+          db->norm-table-columns
 
           :always
           (dissoc :column_settings :click_behavior)))
@@ -574,6 +597,15 @@
        (m/map-kv (fn [k v]
                    [(norm->db-column-ref k) (reduce-kv norm->db-column-settings-entry {} v)]))))
 
+(defn- norm->db-table-columns [v]
+  (cond-> v
+    (some? (::table-columns v))
+    (assoc :table.columns (mapv (fn [tbl-col]
+                                  (set/rename-keys tbl-col norm->db-table-columns-keys))
+                            (::table-columns v)))
+    :always
+    (dissoc ::table-columns)))
+
 (defn norm->db
   "Converts the normalized form of visualization settings (i.e. a map having
   `::column-settings` into the equivalent DB form (i.e. a map having `:column_settings`).
@@ -587,4 +619,5 @@
                                      (dissoc ::column-settings))
     (::click-behavior settings)  (-> ; from cond->
                                      (assoc :click_behavior (norm->db-click-behavior-value (::click-behavior settings)))
-                                     (dissoc ::click-behavior))))
+                                     (dissoc ::click-behavior))
+    (::table-columns settings)   norm->db-table-columns))

--- a/shared/test/metabase/shared/models/visualization_settings_test.cljc
+++ b/shared/test/metabase/shared/models/visualization_settings_test.cljc
@@ -61,17 +61,33 @@
                                :parameterMapping {}
                                :targetId         target-id}
           db-click-bhv-map    {:click_behavior db-click-behavior}
+          col-nm-map          {:show_mini_bar true
+                               :column_title "Name Column"}
           db-col-settings     {(fmt "[\"ref\",[\"field\",%d,{\"base-type\":\"type/Integer\"}]]" f-id) db-click-bhv-map
-                               (fmt "[\"name\",\"%s\"]" col-name)                                     db-click-bhv-map}
-          db-viz-settings     {:column_settings db-col-settings}
+                               (fmt "[\"name\",\"%s\"]" col-name)                                     col-nm-map}
+          db-viz-settings     {:column_settings db-col-settings
+                               :table.columns   [{:name     "ID"
+                                                  :fieldRef [:field f-id nil]
+                                                  :enabled  true}
+                                                 {:name     "Name"
+                                                  :fieldRef [:expression col-name]
+                                                  :enabled  true}]}
           norm-click-behavior {::mb.viz/click-behavior-type ::mb.viz/link
                                ::mb.viz/link-type           ::mb.viz/card
                                ::mb.viz/parameter-mapping   {}
                                ::mb.viz/link-target-id      target-id}
+          norm-col-nm         {::mb.viz/column-title       "Name Column"
+                               ::mb.viz/show-mini-barchart true}
           norm-click-bhvr-map {::mb.viz/click-behavior norm-click-behavior}
           norm-col-settings {(mb.viz/field-id->column-ref f-id {"base-type" "type/Integer"}) norm-click-bhvr-map
-                             (mb.viz/column-name->column-ref col-name)                       norm-click-bhvr-map}
-          norm-viz-settings   {::mb.viz/column-settings norm-col-settings}]
+                             (mb.viz/column-name->column-ref col-name)                       norm-col-nm}
+          norm-viz-settings   {::mb.viz/column-settings norm-col-settings
+                               ::mb.viz/table-columns [{::mb.viz/table-column-name      "ID"
+                                                        ::mb.viz/table-column-field-ref [:field f-id nil]
+                                                        ::mb.viz/table-column-enabled   true}
+                                                       {::mb.viz/table-column-name      "Name"
+                                                        ::mb.viz/table-column-field-ref [:expression col-name]
+                                                        ::mb.viz/table-column-enabled   true}]}]
       (doseq [[db-form norm-form] [[db-viz-settings norm-viz-settings]]]
         (let [to-norm (mb.viz/db->norm db-form)]
           (t/is (= norm-form to-norm))

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -409,7 +409,10 @@
                      :order-by sql-order}
         ;; We didn't implement collection pagination for snippets namespace for root/items
         ;; Rip out the limit for now and put it back in when we want it
-        limit-query (if (= (:collection-namespace options) "snippets")
+        limit-query (if (or
+                          (nil? offset-paging/*limit*)
+                          (nil? offset-paging/*offset*)
+                          (= (:collection-namespace options) "snippets"))
                       rows-query
                       (assoc rows-query
                              :limit  offset-paging/*limit*

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -602,3 +602,18 @@
   {:added "0.39.0" :arglists '([driver db-details])}
   dispatch-on-uninitialized-driver
   :hierarchy #'hierarchy)
+
+(defmulti normalize-db-details
+  "Normalizes db-details for the given driver. This is to handle migrations that are too difficult to perform via
+  regular Liquibase queries. This multimethod will be called from a `:post-select` handler within the database model.
+  The full `database` model object is passed as the 2nd parameter, and the multimethod implementation is expected to
+  update the value for `:details`. The default implementation is essentially `identity` (i.e returns `database`
+  unchanged). This multimethod will only be called if `:details` is actually present in the `database` map."
+  {:added "0.41.0" :arglists '([driver database])}
+  dispatch-on-initialized-driver
+  :hierarchy #'hierarchy)
+
+(defmethod normalize-db-details ::driver
+  [_ db-details]
+  ;; no normalization by default
+  db-details)

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -49,9 +49,14 @@
     (schedule-tasks! database)))
 
 (defn- post-select [{driver :engine, :as database}]
-  ;; TODO - this is only really needed for API responses. This should be a `hydrate` thing instead!
   (cond-> database
-    (driver/initialized? driver) (assoc :features (driver.u/features driver))))
+    (driver/initialized? driver)
+    ;; TODO - this is only really needed for API responses. This should be a `hydrate` thing instead!
+    (as-> db* ; database from outer cond->
+        (assoc db* :features (driver.u/features driver))
+        (if (:details db*)
+          (driver/normalize-db-details driver db*)
+          db*))))
 
 (defn- pre-delete [{id :id, driver :engine, :as database}]
   (unschedule-tasks! database)

--- a/src/metabase/server/middleware/offset_paging.clj
+++ b/src/metabase/server/middleware/offset_paging.clj
@@ -3,14 +3,11 @@
             [metabase.server.middleware.security :as mw.security ]
             [metabase.util.i18n :refer [tru]]))
 
+(def ^:dynamic *limit* "Limit for offset-limit paging." nil)
 (def ^:private default-limit 50)
 
-(def ^:dynamic *limit*
-  "Limit for offset-limit paging.
-  Default set by default-limit in offset paging middleware."
-  default-limit)
-
-(def ^:dynamic *offset* "Offset for offset-limit paging. Default is no offset." 0)
+(def ^:dynamic *offset* "Offset for offset-limit paging." nil)
+(def ^:private default-offset 0)
 
 (def ^:dynamic *paged?*
   "Bool for whether a request is paged or not.
@@ -24,7 +21,7 @@
   (let [limit  (or (some-> limit Integer/parseUnsignedInt)
                    default-limit)
         offset (or (some-> offset Integer/parseUnsignedInt)
-                   0)]
+                   default-offset)]
     {:limit limit, :offset offset}))
 
 (defn- with-paging-params [request {:keys [limit offset]}]
@@ -56,7 +53,7 @@
                                  {:message (tru "Error parsing paging parameters: {0}" (ex-message e))})}))
           (let [{:keys [limit offset]} paging-params
                 request                (with-paging-params request paging-params)]
-            (binding [*limit*         limit
-                      *offset*        offset
+            (binding [*limit*  limit
+                      *offset* offset
                       *paged?* true]
               (handler request respond raise))))))))

--- a/test/metabase/server/middleware/misc_test.clj
+++ b/test/metabase/server/middleware/misc_test.clj
@@ -33,9 +33,14 @@
                  (public-settings/site-url)))))))
   (testing "Site URL should not be inferred from healthcheck requests"
     (mt/with-temporary-setting-values [site-url nil]
-      (let [request (ring.mock/request :get "/api/health")]
+      (let [request (mock-request "/api/health" "https://mb1.example.com" nil nil)]
         (maybe-set-site-url request)
         (is (nil? (public-settings/site-url))))))
+  (testing "Site URL should not be inferred if already set in DB"
+    (mt/with-temporary-setting-values [site-url "https://mb1.example.com"]
+        (let [request (mock-request "/" "https://mb2.example.com" nil nil)]
+          (maybe-set-site-url request)
+          (is (= "https://mb1.example.com" (public-settings/site-url))))))
   (testing "Site URL should not be inferred if already set by env variable"
     (mt/with-temporary-setting-values [site-url nil]
       (mt/with-temp-env-var-value [mb-site-url "https://mb1.example.com"]

--- a/test/metabase/server/middleware/misc_test.clj
+++ b/test/metabase/server/middleware/misc_test.clj
@@ -6,21 +6,39 @@
             [metabase.test :as mt]
             [ring.mock.request :as ring.mock]))
 
+(defn- maybe-set-site-url
+  [request]
+  ((mw.misc/maybe-set-site-url (fn [request respond _] (respond request)))
+   request
+   identity
+   (fn [e] (throw e))))
+
+(defn- mock-request
+  [uri origin-header x-forwarded-host-header host-header]
+  (cond-> (m/dissoc-in (ring.mock/request :get uri) [:headers "host"])
+    origin-header           (ring.mock/header "Origin" origin-header)
+    x-forwarded-host-header (ring.mock/header "X-Forwarded-Host" x-forwarded-host-header)
+    host-header             (ring.mock/header "Host" host-header)))
+
 (deftest maybe-set-site-url-test
   (testing "Make sure `maybe-set-site-url` middleware looks at the correct headers in the correct order (#12528)"
-    (let [handler            (fn [request respond _]
-                               (respond request))
-          maybe-set-site-url (fn [request]
-                               ((mw.misc/maybe-set-site-url handler) request identity (fn [e] (throw e))))]
-      (doseq [origin-header           ["https://mb1.example.com" nil]
-              x-forwarded-host-header ["https://mb2.example.com" nil]
-              host-header             ["https://mb3.example.com" nil]
-              :let                    [request (cond-> (m/dissoc-in (ring.mock/request :get "/") [:headers "host"])
-                                                 origin-header           (ring.mock/header "Origin" origin-header)
-                                                 x-forwarded-host-header (ring.mock/header "X-Forwarded-Host" x-forwarded-host-header)
-                                                 host-header             (ring.mock/header "Host" host-header))]]
-        (testing (format "headers = %s" (pr-str (:headers request)))
-          (mt/with-temporary-setting-values [site-url nil]
-            (maybe-set-site-url request)
-            (is (= (or origin-header x-forwarded-host-header host-header)
-                   (public-settings/site-url)))))))))
+    (doseq [origin-header           ["https://mb1.example.com" nil]
+            x-forwarded-host-header ["https://mb2.example.com" nil]
+            host-header             ["https://mb3.example.com" nil]
+            :let                    [request (mock-request "/" origin-header x-forwarded-host-header host-header)]]
+      (testing (format "headers = %s" (pr-str (:headers request)))
+        (mt/with-temporary-setting-values [site-url nil]
+          (maybe-set-site-url request)
+          (is (= (or origin-header x-forwarded-host-header host-header)
+                 (public-settings/site-url)))))))
+  (testing "Site URL should not be inferred from healthcheck requests"
+    (mt/with-temporary-setting-values [site-url nil]
+      (let [request (ring.mock/request :get "/api/health")]
+        (maybe-set-site-url request)
+        (is (nil? (public-settings/site-url))))))
+  (testing "Site URL should not be inferred if already set by env variable"
+    (mt/with-temporary-setting-values [site-url nil]
+      (mt/with-temp-env-var-value [mb-site-url "https://mb1.example.com"]
+        (let [request (mock-request "/" "https://mb2.example.com" nil nil)]
+          (maybe-set-site-url request)
+          (is (= "https://mb1.example.com" (public-settings/site-url))))))))

--- a/test/metabase/server/middleware/offset_paging_test.clj
+++ b/test/metabase/server/middleware/offset_paging_test.clj
@@ -24,8 +24,8 @@
   (testing "no paging params"
     (is (= {:status  200
             :headers {}
-            :body    {:limit  @#'mw.offset-paging/default-limit
-                      :offset 0
+            :body    {:limit  nil
+                      :offset nil
                       :paged? false
                       :params {}}}
            (handler (ring.mock/request :get "/")))))


### PR DESCRIPTION
Cherry pick the following from master that didn't get applied to `release-x.40.x`:
- 65cfb4ef10ac08de60cc98cfc3054cd0910f5180
- 0691bfbfb7512a7f40f3bae4b1f4ee2c114a436f
- 39e87603aca31b1d06383fecb7316123a67874a4
- 940154d9a5f9da5745d5259de1dff4eb266a9901
- eb59ab27a7de40227f0ee13185ba530dc23ddc81
- cadd71015baf2ebfcf21a37b9945c74d8a52f712

A reminder that after https://github.com/metabase/metabase/pull/17225 in master we can add the `backport` label to a PR and a cherry-pick PR will automatically be created so you don't have to do it manually.
