### PR TITLE
X-axis: just use (approx) 5 ticks to avoid overlapping labels

### DIFF
--- a/frontend/src/metabase/static-viz/timeseries/bar.js
+++ b/frontend/src/metabase/static-viz/timeseries/bar.js
@@ -69,7 +69,8 @@ export default function TimeseriesBar(
         tickLabelProps={() => leftAxisTickStyles(layout)}
       />
       <AxisBottom
-        hideTicks
+        hideTicks={false}
+        numTicks={5}
         top={layout.yMax}
         tickFormat={d => new Date(d).toLocaleDateString("en")}
         scale={xAxisScale}

--- a/frontend/src/metabase/static-viz/timeseries/line.js
+++ b/frontend/src/metabase/static-viz/timeseries/line.js
@@ -19,6 +19,7 @@ export default function TimeseriesLine(
     ],
     range: [40, layout.xMax],
   });
+
   // Y scale
   const yAxisScale = yScaleType({
     domain: [0, Math.max(...data.map(accessors.y))],
@@ -76,7 +77,8 @@ export default function TimeseriesLine(
       />
       <AxisBottom
         label={"Time"}
-        hideTicks
+        hideTicks={false}
+        numTicks={5}
         top={layout.yMax}
         stroke={layout.colors.axis.stroke}
         tickFormat={d => new Date(d).toLocaleDateString("en")}


### PR DESCRIPTION
The default axis implementation seems to be designed for a much wider chart. For our chart, let's keep it minimum.

**Before this PR**

![image](https://user-images.githubusercontent.com/7288/127941037-c20f3fa3-22b0-4dff-bf2b-d6d0a299ccd3.png)

**After this PR**

![image](https://user-images.githubusercontent.com/7288/127941065-27f71f7c-f0e4-49b0-aee8-94585ba27cc6.png)

