### PR TITLE
Update lein references in scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -194,7 +194,6 @@
     "build-stats": "yarn && webpack --json > stats.json",
     "build-shared": "yarn && webpack --config webpack.shared.config.js",
     "build-static-viz": "yarn && webpack --config webpack.static-viz.config.js",
-    "start": "yarn build && lein ring server",
     "precommit": "lint-staged",
     "preinstall": "echo $npm_execpath | grep -q yarn || echo '\\033[0;33mSorry, npm is not supported. Please use Yarn (https://yarnpkg.com/).\\033[0m'",
     "prettier": "prettier --write '{enterprise/,}frontend/**/*.{js,jsx,css}'",

--- a/package.json
+++ b/package.json
@@ -201,7 +201,7 @@
     "docs": "documentation serve --watch frontend/src/metabase-lib/lib/**",
     "ci": "yarn ci-frontend && yarn ci-backend",
     "ci-frontend": "yarn lint && yarn test",
-    "ci-backend": "lein docstring-checker && lein bikeshed && lein eastwood && lein test",
+    "ci-backend": "lein eastwood && lein test",
     "test-cypress": "yarn build && ./bin/build-for-test && yarn test-cypress-no-build",
     "test-cypress-open": "./bin/build-for-test && yarn test-cypress-no-build --open",
     "test-cypress-open-no-backend": "E2E_HOST='http://localhost:3000' yarn test-cypress-no-build --open",

--- a/package.json
+++ b/package.json
@@ -201,7 +201,7 @@
     "docs": "documentation serve --watch frontend/src/metabase-lib/lib/**",
     "ci": "yarn ci-frontend && yarn ci-backend",
     "ci-frontend": "yarn lint && yarn test",
-    "ci-backend": "lein eastwood && lein test",
+    "ci-backend": "clojure -X:dev:ee:ee-dev:drivers:drivers-dev:eastwood && clojure -X:dev:test",
     "test-cypress": "yarn build && ./bin/build-for-test && yarn test-cypress-no-build",
     "test-cypress-open": "./bin/build-for-test && yarn test-cypress-no-build --open",
     "test-cypress-open-no-backend": "E2E_HOST='http://localhost:3000' yarn test-cypress-no-build --open",


### PR DESCRIPTION
#16749 removed Leiningen from the build process, but left some of the `lein` references in the `package.json` scripts intact. This PR:
- Removes obsolete scripts
- Updates the `lein` scripts with their equivalent according to [this table](https://github.com/metabase/metabase/wiki/Migrating-from-Leiningen-to-tools.deps#running-commands).