### PR TITLE
Use `jest-dom/extend-expect` library globally

### DIFF
--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.unit.spec.js
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.unit.spec.js
@@ -1,5 +1,4 @@
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
 import { render, screen } from "@testing-library/react";
 
 import Header from "./CollectionHeader";

--- a/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebarFooter/CollectionSidebarFooter.unit.spec.js
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebarFooter/CollectionSidebarFooter.unit.spec.js
@@ -1,5 +1,4 @@
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
 import { render, screen } from "@testing-library/react";
 
 import CollectionSidebarFooter from "./CollectionSidebarFooter";

--- a/frontend/src/metabase/query_builder/components/SavedQuestionHeaderButton/SavedQuestionHeaderButton.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/SavedQuestionHeaderButton/SavedQuestionHeaderButton.unit.spec.js
@@ -1,6 +1,4 @@
 import React from "react";
-
-import "@testing-library/jest-dom/extend-expect";
 import { render, screen } from "@testing-library/react";
 
 import SavedQuestionHeaderButton from "./SavedQuestionHeaderButton";

--- a/frontend/test/metabase/collections/BaseItemsTable.unit.spec.js
+++ b/frontend/test/metabase/collections/BaseItemsTable.unit.spec.js
@@ -1,5 +1,4 @@
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
 import { render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import moment from "moment";

--- a/frontend/test/metabase/components/AccordionList.unit.spec.js
+++ b/frontend/test/metabase/components/AccordionList.unit.spec.js
@@ -1,5 +1,4 @@
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
 import { render, screen, fireEvent } from "@testing-library/react";
 
 import AccordionList from "metabase/components/AccordionList";

--- a/frontend/test/metabase/components/AddDatabaseHelpCard.unit.spec.js
+++ b/frontend/test/metabase/components/AddDatabaseHelpCard.unit.spec.js
@@ -1,5 +1,4 @@
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
 import { render } from "@testing-library/react";
 
 import MetabaseSettings from "metabase/lib/settings";

--- a/frontend/test/metabase/components/Button.unit.spec.js
+++ b/frontend/test/metabase/components/Button.unit.spec.js
@@ -1,5 +1,4 @@
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
 import { render, screen } from "@testing-library/react";
 
 import Button from "metabase/components/Button";

--- a/frontend/test/metabase/components/ClampedText.unit.spec.js
+++ b/frontend/test/metabase/components/ClampedText.unit.spec.js
@@ -1,6 +1,5 @@
 import React from "react";
 
-import "@testing-library/jest-dom/extend-expect";
 import { render, screen } from "@testing-library/react";
 
 import ClampedText from "metabase/components/ClampedText";

--- a/frontend/test/metabase/components/DateTime.unit.spec.js
+++ b/frontend/test/metabase/components/DateTime.unit.spec.js
@@ -1,6 +1,5 @@
 import React from "react";
 import { render } from "@testing-library/react";
-import "@testing-library/jest-dom/extend-expect";
 import moment from "moment";
 
 import {

--- a/frontend/test/metabase/components/EntityMenuItem.unit.spec.js
+++ b/frontend/test/metabase/components/EntityMenuItem.unit.spec.js
@@ -1,5 +1,4 @@
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
 import { fireEvent, render, screen } from "@testing-library/react";
 
 import EntityMenuItem from "metabase/components/EntityMenuItem";

--- a/frontend/test/metabase/components/Icon.unit.spec.js
+++ b/frontend/test/metabase/components/Icon.unit.spec.js
@@ -1,5 +1,4 @@
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
 import { render, screen } from "@testing-library/react";
 
 import { ICON_PATHS, loadIcon, parseViewBox } from "metabase/icon_paths";

--- a/frontend/test/metabase/components/LastEditInfoLabel.unit.spec.js
+++ b/frontend/test/metabase/components/LastEditInfoLabel.unit.spec.js
@@ -1,6 +1,5 @@
 import React from "react";
 import { render } from "@testing-library/react";
-import "@testing-library/jest-dom/extend-expect";
 import mockDate from "mockdate";
 
 import moment from "moment";

--- a/frontend/test/metabase/components/PaginationControls.unit.spec.js
+++ b/frontend/test/metabase/components/PaginationControls.unit.spec.js
@@ -1,4 +1,3 @@
-import "@testing-library/jest-dom/extend-expect";
 import React from "react";
 import { render, fireEvent } from "@testing-library/react";
 

--- a/frontend/test/metabase/components/Tree.unit.spec.js
+++ b/frontend/test/metabase/components/Tree.unit.spec.js
@@ -1,5 +1,4 @@
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
 import { render, fireEvent } from "@testing-library/react";
 
 import { Tree } from "metabase/components/tree";

--- a/frontend/test/metabase/containers/Overworld.unit.spec.js
+++ b/frontend/test/metabase/containers/Overworld.unit.spec.js
@@ -4,7 +4,6 @@ import {
   PIN_MESSAGE_STORAGE_KEY,
 } from "metabase/containers/Overworld";
 
-import "@testing-library/jest-dom/extend-expect";
 import { fireEvent, render, screen } from "@testing-library/react";
 import "mutationobserver-shim";
 

--- a/frontend/test/metabase/query_builder/components/ClampedDescription.unit.spec.js
+++ b/frontend/test/metabase/query_builder/components/ClampedDescription.unit.spec.js
@@ -1,6 +1,4 @@
 import React from "react";
-
-import "@testing-library/jest-dom/extend-expect";
 import { render, screen } from "@testing-library/react";
 
 import { ClampedDescription } from "metabase/query_builder/components/ClampedDescription";

--- a/frontend/test/metabase/query_builder/components/QuestionActionButtons.unit.spec.js
+++ b/frontend/test/metabase/query_builder/components/QuestionActionButtons.unit.spec.js
@@ -1,6 +1,4 @@
 import React from "react";
-
-import "@testing-library/jest-dom/extend-expect";
 import { render, screen } from "@testing-library/react";
 
 import { MODAL_TYPES } from "metabase/query_builder/constants";

--- a/frontend/test/metabase/query_builder/components/QuestionActivityTimeline.unit.spec.jsx
+++ b/frontend/test/metabase/query_builder/components/QuestionActivityTimeline.unit.spec.jsx
@@ -1,6 +1,4 @@
 import React from "react";
-
-import "@testing-library/jest-dom/extend-expect";
 import { render, screen } from "@testing-library/react";
 
 import { QuestionActivityTimeline } from "metabase/query_builder/components/QuestionActivityTimeline";

--- a/frontend/test/metabase/visualizations/components/ChartSettings.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/ChartSettings.unit.spec.js
@@ -1,5 +1,4 @@
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
 import { render, fireEvent } from "@testing-library/react";
 
 import ChartSettings from "metabase/visualizations/components/ChartSettings";

--- a/frontend/test/metabase/visualizations/components/settings/ChartNestedSettingsSeries.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/settings/ChartNestedSettingsSeries.unit.spec.js
@@ -1,5 +1,4 @@
 import React from "react";
-import "@testing-library/jest-dom/extend-expect";
 import { render } from "@testing-library/react";
 
 // these tests use ChartSettings directly, but logic we're testing lives in ChartNestedSettingSeries

--- a/jest.unit.conf.json
+++ b/jest.unit.conf.json
@@ -17,6 +17,7 @@
     "<rootDir>/frontend/test/metabase-bootstrap.js",
     "<rootDir>/frontend/test/register-visualizations.js"
   ],
+  "setupFilesAfterEnv": ["@testing-library/jest-dom/extend-expect"],
   "globals": {
     "ace": {},
     "ga": {},


### PR DESCRIPTION
Now that we updated Jest, we have [`setupFilesAfterEnv`](https://jestjs.io/docs/configuration#setupfilesafterenv-array) option at our disposal.

> A list of paths to modules that run some code to configure or set up the testing framework before each test file in the suite is executed.

No need to manually `import "@testing-library/jest-dom/extend-expect"` anymore. :)

Do we need to update the documentation somewhere to alert people about this change?