### PR TITLE
Fix Presto JDBC connection error

### DIFF
--- a/modules/drivers/presto-jdbc/src/metabase/driver/presto_jdbc.clj
+++ b/modules/drivers/presto-jdbc/src/metabase/driver/presto_jdbc.clj
@@ -224,7 +224,9 @@
                                   (Integer/parseInt port)
                                   port)))
                 (assoc :SSL ssl?)
-                (dissoc :ssl))]
+                ;; remove Metabase specific properties that are not recognized by the PrestoDB JDBC driver, which is
+                ;; very picky about properties (throwing an error if any are unrecognized)
+                (dissoc :ssl :engine :let-user-control-scheduling))]
     (jdbc-spec props)))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -332,10 +334,6 @@
       (catch Throwable e
         (log/debug e (trs "Error setting statement fetch direction to FETCH_FORWARD"))))
     stmt))
-
-(defmethod driver/can-connect? :presto-jdbc
-  [driver details]
-  (sql-jdbc.conn/can-connect? driver (dissoc details :engine)))
 
 (defn- ^PrestoConnection pooled-conn->presto-conn
   "Unwraps the C3P0 `pooled-conn` and returns the underlying `PrestoConnection` it holds."

--- a/modules/drivers/presto-jdbc/src/metabase/driver/presto_jdbc.clj
+++ b/modules/drivers/presto-jdbc/src/metabase/driver/presto_jdbc.clj
@@ -224,9 +224,17 @@
                                   (Integer/parseInt port)
                                   port)))
                 (assoc :SSL ssl?)
-                ;; remove Metabase specific properties that are not recognized by the PrestoDB JDBC driver, which is
+                ;; remove any Metabase specific properties that are not recognized by the PrestoDB JDBC driver, which is
                 ;; very picky about properties (throwing an error if any are unrecognized)
-                (dissoc :ssl :engine :let-user-control-scheduling))]
+                ;; all valid properties can be found in the JDBC Driver source here:
+                ;; https://github.com/prestodb/presto/blob/master/presto-jdbc/src/main/java/com/facebook/presto/jdbc/ConnectionProperties.java
+                (select-keys [:host :port :catalog :schema :additional-options ; needed for [jdbc-spec]
+                              ;; JDBC driver specific properties
+                              :user :password :socksProxy :httpProxy :applicationNamePrefix :disableCompression :SSL
+                              :SSLKeyStorePath :SSLKeyStorePassword :SSLTrustStorePath :SSLTrustStorePassword
+                              :KerberosRemoteServiceName :KerberosPrincipal :KerberosUseCanonicalHostname
+                              :KerberosConfigPath :KerberosKeytabPath :KerberosCredentialCachePath :accessToken
+                              :extraCredentials :sessionProperties :protocols :queryInterceptors]))]
     (jdbc-spec props)))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/modules/drivers/presto-jdbc/test/metabase/driver/presto_jdbc_test.clj
+++ b/modules/drivers/presto-jdbc/test/metabase/driver/presto_jdbc_test.clj
@@ -194,5 +194,9 @@
 
 (deftest test-database-connection-test
   (mt/test-driver :presto-jdbc
-    (testing "can-test-database-connection works"
-      (is (nil? (database-api/test-database-connection :presto-jdbc (:details (mt/db))))))))
+    (testing "can-test-database-connection works properly"
+      ;; for whatever reason, :let-user-control-scheduling is the only "always available" option that goes into details
+      ;; the others (ex: :auto_run_queries and :refingerprint) are one level up (fields in the model, not in the details
+      ;; JSON blob)
+      (let [db-details (assoc (:details (mt/db)) :let-user-control-scheduling false)]
+        (is (nil? (database-api/test-database-connection :presto-jdbc db-details)))))))


### PR DESCRIPTION
Remove the `driver/can-connect?` implementation and move the dissoc logic instead to the existing place in `sql-jdbc.conn/connection-details->spec`

Update test to also include the `:let-user-control-scheduling` details entry
