### PR TITLE
Update `project.clj` references

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -596,7 +596,7 @@ jobs:
       <<: *Params
     steps:
       - attach-workspace
-      # This step is pretty slow, even with the cache, so only run it if project.clj has changed
+      # This step is pretty slow, even with the cache, so only run it if deps.edn has changed
       - run-on-change:
           checksum: 'v5-{{ checksum "deps.edn" }}-{{ checksum ".SCRIPTS-DEPS-CHECKSUMS" }}'
           steps:

--- a/.github/workflows/percy-issue-comment.yml
+++ b/.github/workflows/percy-issue-comment.yml
@@ -72,7 +72,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/project.clj') }}-${{ hashFiles('**/deps.edn') }}
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/deps.edn') }}
 
       - run: yarn install --frozen-lockfile --prefer-offline
       - run: ./bin/build

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/project.clj') }}-${{ hashFiles('**/deps.edn') }}
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/deps.edn') }}
 
       - run: yarn install --frozen-lockfile --prefer-offline
       - run: ./bin/build

--- a/bin/build-for-test
+++ b/bin/build-for-test
@@ -7,7 +7,7 @@ VERSION_PROPERTY_NAME="src_hash"
 source-hash() {
   # hash all the files that might change a backend-only uberjar build (for integration tests)
   (
-    find src project.clj resources/sample-dataset.db.mv.db -type f -print0 | xargs -0 shasum ;
+    find src deps.edn resources/sample-dataset.db.mv.db -type f -print0 | xargs -0 shasum ;
     find resources -type f \( -iname \*.clj -o -iname \*.edn -o -iname \*.yaml -o -iname \*.properties -o -iname \*.html \) -not -name "version.properties" -print0 | xargs -0 shasum ;
   ) | shasum | awk '{ print $1 }'
 }


### PR DESCRIPTION
#16749 removed `project.clj` from the project, but left some of the references to that file intact. This PR updates those references and replaces them with the `deps.edn`.

One major flaw was that Cypress relied on the non-existing file for calculating the cache. It uses it to determine whether to build new uberjar or not. This PR fixes that by including `deps.edn` in that hash calculation.

Note:
There are two more references to the `project.clj` left in the project. @dpsutton will address those in a separate PR.