### PR TITLE
Regularizing titles of troubleshooting guides

### DIFF
--- a/docs/troubleshooting-guide/application-database.md
+++ b/docs/troubleshooting-guide/application-database.md
@@ -1,8 +1,14 @@
 # Trouble with the Metabase Application Database
 
+<div class='doc-toc' markdown=1>
+- [Metabase fails to start due to database locks](#database-locks)
+- [Metabase H2 application database gets corrupted](#h2-app-db-corrupted)
+- [Metabase fails to connect to H2 Database on Windows 10](#h2-connect-windows-10)
+</div>
+
 Metabase stores information about users, questions, and so on in a database of its own that we call the "application database". The default application database that ships with Metabase is an [H2 database][what-is-h2], which is not recommended for production. To use a production-ready database for you Metabase application database, see [Migrating from H2][migrating]. 
 
-### Metabase fails to start due to database locks
+<h2 id="database-locks">Metabase fails to start due to database locks</h2>
 
 Sometimes Metabase will fail to start up because a database lock did not clear properly. 
 
@@ -20,7 +26,7 @@ java -jar metabase.jar migrate release-locks
 
 This command will manually clear the locks. When it's done, restart your Metabase instance.
 
-### Metabase H2 application database gets corrupted
+<h2 id="h2-app-db-corrupted">Metabase H2 application database gets corrupted</h2>
 
 By default, Metabase uses [H2][what-is-h2] for its application database. Because H2 is an on-disk database, it's sensitive to filesystem errors, such as a drive being corrupted or a file not being flushed properly. In these situations, you'll see errors on startup. 
 
@@ -53,7 +59,7 @@ java -cp target/uberjar/metabase.jar org.h2.tools.RunScript -script metabase.db.
 
 Not all H2 errors are recoverable (which is why if you're using H2, _please_ have a backup strategy for the application database file).
 
-### Metabase fails to connect to H2 Database on Windows 10
+<h2 id="h2-connect-windows-10">Metabase fails to connect to H2 Database on Windows 10</h2>
 
 In some situations on Windows 10, the Metabase JAR needs to have permissions to create local files for the application database. 
 

--- a/docs/troubleshooting-guide/datawarehouse.md
+++ b/docs/troubleshooting-guide/datawarehouse.md
@@ -1,6 +1,12 @@
 # Connecting to data warehouses with Metabase
 
-## Troubleshooting your database connection
+<div class='doc-toc' markdown=1>
+- [The data warehouse server is down](#server-down)
+- [The data warehouse server is denying connections from your IP address](#server-denying-connections)
+- [Incorrect credentials](#incorrect-credentials)
+- [Connection timeout: your question took too long](#connection-timeout-took-too-long)
+- [Connections cannot be acquired from the underlying database](#connections-cannot-be-acquired)
+</div>
 
 If you're having trouble connecting to your data warehouse, run through these steps to identify the problem.
 
@@ -12,15 +18,13 @@ If you're having trouble connecting to your data warehouse, run through these st
 6. Have you run a native `SELECT 1` query to verify the connection to the data warehouse?
 7. If the sync process has completed, can you ask a [native question][native-question] to verify that you are able to use the database?
 
-## Specific Problems
-
-### The data warehouse server is down
+<h2 id="server-down">The data warehouse server is down</h2>
 
 **How to detect this:** Database servers occasionally go down. If you're using a hosted database service, go to its console and verify its status. If you have direct access to a command-line interface, log in and make sure that it's up and running and accepting queries.
 
 **How to fix this:** It's out of the scope of this troubleshooting guide to get your data warehouse server back up---please check with whomever set it up for you.
 
-### The data warehouse server is denying connections from your IP address
+<h2 id="server-denying-connections">The data warehouse server is denying connections from your IP address</h2>
 
 **How to detect this:** If you can access the server from a bastion host or another machine, use the `nc` command (or your operating system's equivalent) to verify that you can connect to the host on a given port. Different databases use different ports; for a default PostgreSQL configuration (which listens on port 5432), the command would be:
 
@@ -30,7 +34,7 @@ nc -v your-db-host 5432
 
 **How to fix this:** It's out of the scope of this troubleshooting guide to change your network configuration---please check with whomever is responsible for the network your data warehouse is running on.
 
-### Incorrect credentials
+<h2 id="incorrect-credentials">Incorrect credentials</h2>
 
 **How to detect this:** If you've verified that you can connect to the data warehouse's host and port, the next step is to check your credentials. Again, connecting to a data warehouse depends on your database server software; for PostgreSQL, a command like the one shown below will do the job:
 
@@ -42,7 +46,7 @@ If your credentials are incorrect, you should see an error message letting you k
 
 **How to fix this:** If the database name or the user/password combination are incorrect, ask the person running your data warehouse for correct credentials.
 
-### Connection timeout: your question took too long
+<h2 id="connection-timeout-took-too-long">Connection timeout: your question took too long</h2>
 
 **How to detect this:** If you see the error message, "Your question took too long," something in your setup timed out. Depending on the specifics of your deployment, the problem could be in:
 
@@ -60,9 +64,9 @@ If your credentials are incorrect, you should see an error message letting you k
 - [Heroku timeouts][heroku-timeout]
 - [App Engine: Dealing with DeadlineExceededErrors][app-engine-timeout]
 
-### Error message: "Connections cannot be acquired from the underlying database!"
+<h2 id="connections-cannot-be-acquired">Connections cannot be acquired from the underlying database</h2>
 
-**How to detect this:** Metabase fails to connect to your data warehouse and the Metabase server logs include the error message `Connections cannot be acquired from the underlying database!`
+**How to detect this:** Metabase fails to connect to your data warehouse and the Metabase server logs include the error message `Connections cannot be acquired from the underlying database!
 
 **How to fix this:** Navigate to the options for your data warehouse and locate the "Additional JDBC Connection Strings" option, then add `trustServerCertificate=true` as an additional string.
 

--- a/docs/troubleshooting-guide/docker.md
+++ b/docs/troubleshooting-guide/docker.md
@@ -1,8 +1,16 @@
 # Running Metabase on Docker
 
-Docker simplifies many aspects of running Metabase, but there are some pitfalls to keep in mind. If you have trouble with Metabase under Docker, try going through the troubleshooting process below, then look below for details about the specific issue you've found.
+<div class='doc-toc' markdown=1>
+- [Metabase container exits without starting the server](#container-exits-without-starting-server)
+- [Metabase container is running but the server is not](#container-running-but-server-is-not)
+- [Not connecting to a remote application database](#not-connecting-to-remote-app-db)
+- [The Metabase server isn't able to connect to a MySQL or PostgreSQL database](#metabase-cant-connect-to-mysql-or-postgresql)
+- [The Metabase application database is not being persisted](#app-db-not-being-persisted)
+- [The internal port isn't being remapped correctly](#internal-port-not-remapped-correctly)
+- [Metabase can't write or read to/from a file or directory](#cant-write-read-file-or-dir)
+</div>
 
-## Troubleshooting Process
+Docker simplifies many aspects of running Metabase, but there are some pitfalls to keep in mind. If you have trouble with Metabase under Docker, try going through the troubleshooting process below, then look below for details about the specific issue you've found.
 
 1. Is the container running?
 2. Is the server running inside the container?
@@ -11,9 +19,19 @@ Docker simplifies many aspects of running Metabase, but there are some pitfalls 
 5. Can you connect to the container from the Docker host?
 6. Can you connect to the server from within the container?
 
-## Specific Problems
+You may find these commands useful along the way. To get to the shell in the Metabase container:
 
-### Metabase container exits without starting the server
+```
+docker exec -ti CONTAINER_NAME bash
+```
+
+And to get the logs for the Metabase container:
+
+```
+docker logs -f CONTAINER_NAME
+```
+
+<h2 id="container-exits-without-starting-server">Metabase container exits without starting the server</h2>
 
 **How to detect this:** Run `docker ps` to see if the Metabase container is currently running. If it is, move on to the next step.
 
@@ -29,7 +47,7 @@ Look for the container that exited most recently and make a note of the containe
 Docker logs CONTAINER_ID
 ```
 
-### Metabase container is running but the server is not
+<h2 id="container-running-but-server-is-not">Metabase container is running but the server is not</h2>
 
 **How to detect this:** Run `docker ps` to make sure the container is running. The server should be logging to the Docker container logs. Check this by running:
 
@@ -70,7 +88,7 @@ If the container is being terminated before it finished starting, the problem co
 
 If the container is _not_ being terminated from the outside, but is failing to start anyway, this problem is probably not specific to Docker. If you're using a Metabase-supplied image, please [open a GitHub issue](https://github.com/metabase/metabase/issues/new/choose).
 
-### Not connecting to a remote application database
+<h2 id="not-connecting-to-remote-app-db">Not connecting to a remote application database</h2>
 
 **How to detect this:** If this is a new Metabase instance, then the database you specified via the environment variables will be empty. If this is an existing Metabase instance with incorrect environment parameters, the server will create a new H2 embedded database to use for application data and you’ll see lines similar to these in the log:
 
@@ -87,7 +105,7 @@ If the container is _not_ being terminated from the outside, but is failing to s
 docker inspect some-postgres -f '{% raw %}{{ .Config.Env }}{% endraw %}'
 ```
 
-### The Metabase server isn't able to connect to a MySQL or PostgreSQL database
+<h2 id="metabase-cant-connect-to-mysql-or-postgresql">The Metabase server isn't able to connect to a MySQL or PostgreSQL database</h2>
 
 **How to detect this:** The logs for the Docker container return an error message after the "Verifying Database Connection" line.
 
@@ -113,13 +131,13 @@ nc -v your-db-host 5432
 
 These steps will help you determine whether this the problem is with the network or with authentication.
 
-### The Metabase application database is not being persisted
+<h2 id="app-db-not-being-persisted">The Metabase application database is not being persisted</h2>
 
 **How to detect this:** This is occurring if you are getting the Setup screen every time you start the application. The most common cause is not giving the Docker container a persistent filesystem mount to put the application database in.
 
 **How to fix this:** Make sure you are giving the container a [persistent volume][persistent-volume].
 
-### The internal port isn't being remapped correctly
+<h2 id="internal-port-not-remapped-correctly">The internal port isn't being remapped correctly</h2>
 
 **How to detect this:** Run `docker ps` and look at the port mapping, then run `curl http://localhost:port-number-here/api/health`. This should return a JSON response that looks like:
 
@@ -129,7 +147,7 @@ These steps will help you determine whether this the problem is with the network
 
 **How to fix this:** Make sure to include `-p 3000:3000` or similar port remapping in the `docker run` command you use to start the Metabase container image.
 
-### Metabase can't write or read to/from a file or directory
+<h2 id="cant-write-read-file-or-dir">Metabase can't write or read to/from a file or directory</h2>
 
 **How to detect this:** A message in the logs will clearly indicate an IOError or "Permission denied" from Java, or errors from SQLite containing `org.sqlite.core.NativeDB._open_utf8`.
 
@@ -139,20 +157,6 @@ These steps will help you determine whether this the problem is with the network
 - If you're running Metabase from the Docker container, make sure you're using the `/metabase.db` directory.
 
 If you're running Metabase from the JAR in any Unix-like operating system, you can see which user is running Metabase by opening a terminal and typing `ps -uA | grep metabase`.
-
-## Helpful tidbits
-
-### How to get to the shell in the Metabase container
-
-```
-docker exec -ti CONTAINER_NAME bash
-```
-
-### How to get the logs for the Metabase container
-
-```
-docker logs -f CONTAINER_NAME
-```
 
 [configuring-application-database]: ../operations-guide/configuring-application-database.html
 [persistent-volume]: ../operations-guide/running-metabase-on-docker.html#mounting-a-mapped-file-storage-volume

--- a/docs/troubleshooting-guide/email.md
+++ b/docs/troubleshooting-guide/email.md
@@ -1,8 +1,10 @@
-# Email
+# Setting up email
 
-Metabase can be configured to send email notifications to get people's attention if and when something requires it.
+<div class='doc-toc' markdown=1>
+- [Metabase can't send email via Office365](#cant-send-office365)
+</div>
 
-## Troubleshooting Process
+Metabase can be configured to send email notifications to get people's attention if and when something requires it. If you are having problems with this, try going through the troubleshooting process below:
 
 1. Are the email account credentials correct?
     a. In the Admin Panel, select "Email Settings", click "Send test email", and verify that the email is delivered to the test account.
@@ -22,9 +24,7 @@ Metabase can be configured to send email notifications to get people's attention
 
 5. Make sure that the HOSTNAME is being set correctly. EC2 instances in particular have those set to the local IP address, and some email delivery services such as GMail will report errors in this situation.
 
-## Specific Problems
-
-### Metabase can't send email via Office365
+<h2 id="cant-send-office365">Metabase can't send email via Office365</h2>
 
 Some people have [reported problems sending email via Office365][office-365-bug]. We recommend using a different email delivery service if you can. 
 

--- a/docs/troubleshooting-guide/ldap.md
+++ b/docs/troubleshooting-guide/ldap.md
@@ -1,8 +1,14 @@
 # LDAP
 
+<div class='doc-toc' markdown=1>
+- [LDAP sample configuration](#ldap-sample-configuration)
+- [Related software for troubleshooting](#related-software-for-troubleshooting)
+- [Current limitations](#current-limitations)
+</div>
+
 Metabase can use LDAP for authentication. [This article][ldap-learn] explains how to set it up, and the guide below will help you troubleshoot if anything goes wrong. You may also want to check [our troubleshooting guide for logging in](./loggingin.html).
 
-## LDAP sample configuration
+<h2 id="ldap-sample-configuration">LDAP sample configuration</h2>
 
 You can test Metabase with LDAP by using this `docker-compose` definition:
 
@@ -63,11 +69,11 @@ If you don't pass environment variables to Metabase and you want to configure th
 
 For the `USER FILTER`, you can leave the default value, which will look for the user ID in both the `uid` or `email` field.
 
-## Related software for troubleshooting
+<h2 id="related-software-for-troubleshooting">Related software for troubleshooting</h2>
 
 If you run into an issue, check that you can login to your LDAP directory and issue queries using software like [Apache Directory Studio][apache-directory-studio]. It will let you see the whole LDAP tree and view the logs of your LDAP application to see queries run.
 
-## Current limitations
+<h2 id="current-limitations">Current limitations</h2>
 
 - When using Metabase Enterprise with a MySQL database and LDAP enabled, make sure that you disable synchronization of binary fields from your LDAP directory by using the `MB_LDAP_SYNC_USER_ATTRIBUTES_BLACKLIST` environment variable. If you do not, you may hit the 60K field size limitation of the text field in MySQL, which will prevent you from creating users or those users from logging in.
 

--- a/docs/troubleshooting-guide/loading-from-h2.md
+++ b/docs/troubleshooting-guide/loading-from-h2.md
@@ -1,4 +1,4 @@
-## Loading exported application database fails 
+# Loading exported application database fails
 
 If you've been using the default H2 application database that ships with Metabase, and want to [migrate from the default H2 application database][migrate] to a production database like [PostgreSQL][postgres] or MySQL/MariaDB, you'll need to use the `load-from-h2` command, which will fail if the database filename is incorrect. 
 

--- a/docs/troubleshooting-guide/loggingin.md
+++ b/docs/troubleshooting-guide/loggingin.md
@@ -1,8 +1,12 @@
 # Logging in
 
-People can log in to Metabase in several different ways, each of which may require different background knowledge or a different line of investigation to fix if there are problems.
+<div class='doc-toc' markdown=1>
+- [Forgotten password](#forgotten-password)
+- [Invalid Google Auth token](#invalid-google-auth-token)
+</div>
 
-## Troubleshooting Process
+
+People can log in to Metabase in several different ways, each of which may require different background knowledge or a different line of investigation to fix if there are problems. If you are having problems, try going through the troubleshooting process below:
 
 1. Try to log in with a local account.
 2. Try to log in with a Google Auth SSO account.
@@ -10,13 +14,11 @@ People can log in to Metabase in several different ways, each of which may requi
 
 You may also want to check [our troubleshooting guide for LDAP](./ldap.html).
 
-## Specific Problems
-
-### Forgotten Password
+<h2 id="forgotten-password">Forgotten password</h2>
 
 [This FAQ][reset-password] will tell you what to do if someone has forgotten their password.
 
-### Invalid Google Auth Token
+<h2 id="invalid-google-auth-token">Invalid Google Auth token</h2>
 
 When you sign in with Google Auth, it creates a token to prove that you have authenticated. If this token becomes invalid for any reason (such as a change in configuration or a timeout) then you won't be able to log in with it.
 

--- a/docs/troubleshooting-guide/performance.md
+++ b/docs/troubleshooting-guide/performance.md
@@ -1,5 +1,16 @@
 # My question or dashboard is slow
 
+<div class='doc-toc' markdown=1>
+- [The Metabase instance is getting so much traffic that loading the HTML page is slow](#high-traffic-loading-page-slow)
+- [The answer you want isn't cached](#answer-isnt-cached)
+- [The database is overloaded by other traffic](#database-overloaded-by-other-traffic)
+- [The question itself is slow](#question-is-slow)
+- [Values are repeatedly being converted on the fly](#values-repeatedly-converted)
+- [Metabase is running on an under-powered machine](#under-powered-machine)
+- [A dashboard contains too many questions](#dashboard-contains-too-many-questions)
+- [The UI appears to freeze when saving a question that has not yet been run](#saving-question-not-yet-run)
+</div>
+
 In order to troubleshoot performance problems, you first need to understand what happens when a question or dashboard is created or updated in Metabase. Before diving into specifics, you may want to read our article on [Metabase at scale][metabase-at-scale].
 
 1. Your browser goes to a web page that shows a Metabase question or dashboard.
@@ -20,11 +31,9 @@ In order to troubleshoot performance problems, you first need to understand what
 
 9. The front end creates the HTML to display the result in your browser.
 
-## Specific Problems
+Each of the steps described above is a potential performance bottleneck; the tips below can help you fix them.
 
-Each of the steps described is a potential performance bottleneck.
-
-### The Metabase instance is getting so much traffic that loading the HTML page is slow
+<h2 id="high-traffic-loading-page-slow">The Metabase instance is getting so much traffic that loading the HTML page is slow</h2>
 
 This is extremely rare, since our front end is not very large and browsers cache our JavaScript, but it's easy to rule out. What is more common is the lack of HTTP/2 or the lack of available connections to the application database; we cover both topics in our article on [Metabase at scale][metabase-at-scale].
 
@@ -36,7 +45,7 @@ This is extremely rare, since our front end is not very large and browsers cache
 2.  Check the server logs for Metabase's application database.
 3.  Look at page load times in the browser console. If it's taking a long time to load our HTML, CSS, or JavaScript, check to see whether a proxy, firewall, or other network component is slowing things down.
 
-### The answer you want isn't cached
+<h2 id="answer-isnt-cached">The answer you want isn't cached</h2>
 
 By default caching is disabled so that we always re-run every question. However, if your data is only being updated every few seconds or minutes, you will improve performance by enabling caching. Note that:
 
@@ -48,7 +57,7 @@ By default caching is disabled so that we always re-run every question. However,
 
 **How to fix this:** [This guide][admin-caching] explains how to change the minimum query duration (we cache anything that takes longer than that to run) and the maximum cache size for each query result. You may need to experiment with these values over several days to find the best balance. If the problem appears to be caused by a high proportion of sandboxed queries, check that the cache is large enough to store all of their results.
 
-### The database is overloaded by other traffic
+<h2 id="database-overloaded-by-other-traffic">The database is overloaded by other traffic</h2>
 
 Metabase is usually not the only application using your database, and you may not be the only person using Metabase. If someone else has opened a dashboard that launches a couple of dozen long-running queries, everyone else may then have to wait until database connections become free. Our article on [Metabase at scale][metabase-at-scale] discusses this in more detail, and our article on [making dashboards faster][faster-dashboards] may help as well.
 
@@ -58,7 +67,7 @@ Metabase is usually not the only application using your database, and you may no
 
 Note: you may also see your database being overloaded if you're using the same database as Metabase's app database and for your own data. We strongly recommend that you don't do this in a production system or if you have more than a handful of users.
 
-### The question itself is slow
+<h2 id="question-is-slow">The question itself is slow</h2>
 
 Joining half a dozen tables, each with a few million rows, simply takes a lot of time. On the other hand, while we do our best to create fully-formed SQL queries from graphical questions, SQL snippets, and questions that use other questions as starting points, it's a hard problem---particularly across as many databases as we support. We also don't take advantage of every quirk of every backend database. For example, Redshift stores values in columns rather than rows: some queries that work well for row-oriented databases are slow on columns and vice versa.
 
@@ -76,7 +85,7 @@ Joining half a dozen tables, each with a few million rows, simply takes a lot of
 2. You can use your SQL in place of the code we generate, and [make its result available][organizing-sql] to people who prefer the Notebook Editor as a starting point for their questions.
 3. And please file a bug report to help us figure out how to generate better SQL.
 
-### Values are repeatedly being converted on the fly
+<h2 id="values-repeatedly-converted">Values are repeatedly being converted on the fly</h2>
 
 Low performance when using Metabase can also be caused by incorrect typing of columns, e.g., by storing a numeric value as a string.  When this happens, the query converts values on the fly each time the query is run.
 
@@ -84,13 +93,13 @@ Low performance when using Metabase can also be caused by incorrect typing of co
 
 **How to fix this:** Amend the database schema to store numbers as numbers, timestamps as timestamps, and so on, rather than as strings or other data types.
 
-### Metabase is running on an under-powered machine
+<h2 id="under-powered-machine">Metabase is running on an under-powered machine</h2>
 
 **How to detect this:** Checking the performance logs for the server where Metabase is running will tell you whether it is hitting CPU or memory limits. However, it's much more likely that the database itself is hitting its limits, so please check it first.
 
 **How to fix this:** Upgrade to a more powerful server or one with more memory. If you would like this taken care of you, along with backups, cache configuration, and so on, please consider using [Metabase Cloud][metabase-start].
 
-### A dashboard contains too many questions
+<h2 id="dashboard-contains-too-many-questions">A dashboard contains too many questions</h2>
 
 When Metabase displays a dashboard, it re-runs all of the questions. We do our best to do this concurrently, and the network layers and the database itself also do what they can, but a dashboard with a hundred cards is going to be slower than a single question. And if your dashboard contains filters, then each time someone changes a filter setting, all of the cards that depend on it have to re-execute. Careful dashboard design can prevent or eliminate these problems.
 
@@ -98,7 +107,7 @@ When Metabase displays a dashboard, it re-runs all of the questions. We do our b
 
 **How to fix this:** See [this article][faster-dashboards] for tips on making dashboards more performant.
 
-### The UI appears to freeze when saving a question that has not yet been run
+<h2 id="saving-question-not-yet-run">The UI appears to freeze when saving a question that has not yet been run</h2>
 
 **How to detect this:** If you save a question that has not been executed, MB runs the question while saving, which can make the UI look frozen.
 

--- a/docs/troubleshooting-guide/proxies.md
+++ b/docs/troubleshooting-guide/proxies.md
@@ -1,5 +1,10 @@
 # Can't save questions or dashboards, or getting a blank page
 
+<div class='doc-toc' markdown=1>
+- [Saving questions or dashboards fails](#saving-questions-or-dashboards-fails)
+- [Seeing a blank page instead of the Metabase interface](#seeing-blank-page)
+</div>
+
 If attempting to save a question or dashboard sometimes fails, or Metabase only loads a blank page, the problem might be the use of a proxy. A proxy could include other functions like a web application firewall (WAF), content optimization, or cache. Examples of proxies that are known to cause issues with Metabase include:
 
 - Cloudflare's Rocket Loader and WAF
@@ -7,9 +12,7 @@ If attempting to save a question or dashboard sometimes fails, or Metabase only 
 - PageSpeed module for Apache
 - Some anti-virus browser extensions or add-ons
 
-## Specific Problems
-
-### Saving questions or dashboards fails
+<h2 id="saving-questions-or-dashboards-fails">Saving questions or dashboards fails</h2>
 
 If saving questions or dashboards fails and the save button displays "Save Failed," or if you get the error, "Sorry you do not have permission to see that," the problem might be with a WAF like Cloudflare or Azure.
 
@@ -22,7 +25,7 @@ Some WAFs have dynamic protection, which means that the problem might only occur
 
 The solution is to disable the WAF for Metabase. Some services will show which rules were triggered, so it might be enough to disable those rules.
 
-### Seeing a blank page instead of the Metabase interface
+<h2 id="seeing-blank-page">Seeing a blank page instead of the Metabase interface</h2>
 
 If Metabase displays a blank page instead of its interface, the problem is usually with content optimization like PageSpeed or Cloudflare's Rocket Loader.
 

--- a/docs/troubleshooting-guide/running.md
+++ b/docs/troubleshooting-guide/running.md
@@ -1,8 +1,14 @@
 # Running Metabase
 
+<div class='doc-toc' markdown=1>
+- [Metabase fails to start due to Heap Space OutOfMemoryErrors](#heap-space-outofmemoryerrors)
+- [Diagnosing memory issues causing OutOfMemoryErrors](#diagnosing-outofmemoryerrors)
+- [Metabase cannot read or write from a file or folder (IOError)](#cannot-read-write-ioerror)
+</div>
+
 Metabase runs on the Java Virtual Machine (JVM), and depending on how it's configured, it may use the server's filesystem to store some information. Problems with either the JVM or the filesystem can therefore prevent Metabase from running.
 
-## Metabase fails to start due to Heap Space OutOfMemoryErrors
+<h2 id="heap-space-outofmemoryerrors">Metabase fails to start due to Heap Space OutOfMemoryErrors</h2>
 
 The JVM can normally figure out how much RAM is available on the system and automatically set a sensible upper bound for heap memory usage. On certain shared hosting environments, however, this doesn't always work as desired. The usual symptom of this is an error message like:
 
@@ -24,7 +30,7 @@ You can also use the environment variable `JAVA_OPTS` to set JVM args instead of
 docker run -d -p 3000:3000 -e "JAVA_OPTS=-Xmx2g" metabase/metabase
 ```
 
-## Diagnosing memory issues causing OutOfMemoryErrors
+<h2 id="diagnosing-outofmemoryerrors">Diagnosing memory issues causing OutOfMemoryErrors</h2>
 
 If the Metabase instance starts and runs for a significant amount of time before running out of memory, there might be a specific event, such as a large query, triggering the `OutOfMemoryError`. One way to diagnose where the memory is being used is to enable heap dumps when an `OutOfMemoryError` is triggered. To enable this, you need to add two flags to the `java` invocation:
 
@@ -34,7 +40,7 @@ java -Xmx2g -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/path/to/a/director
 
 The `-XX:HeapDumpPath` flag specifies where to put the dump---the current directory is the default. When an `OutOfMemoryError` occurs, it will dump an `hprof` file to the directory specified. These can be very large (i.e., the size of the `-Xmx` argument) so ensure your disk has enough space. These `hprof` files can be read with many different tools, such as `jhat` (which is included with the JDK) or the [Eclipse Memory Analyzer Tool][eclipse-memory-analyzer].
 
-## Metabase cannot read or write from a file or folder (IOError)
+<h2 id="cannot-read-write-ioerror">Metabase cannot read or write from a file or folder (IOError)</h2>
 
 If you see an error regarding file permissions, like Metabase being unable to read a SQLite database or a custom GeoJSON map file, check out the section "Metabase can't read to/from a file or directory" in our [Docker troubleshooting guide](./docker.html).
 

--- a/docs/troubleshooting-guide/sandboxing.md
+++ b/docs/troubleshooting-guide/sandboxing.md
@@ -1,5 +1,11 @@
 # Sandboxing
 
+<div class='doc-toc' markdown=1>
+- [People can see data they're not supposed to be able to see](#see-data-not-supposed-to)
+- [People can't see the data they're supposed to be able to see](#cant-see-data-supposed-to)
+- [Someone is in several groups but can't see the sandboxed data](#in-several-groups-cant-see-sandboxed-data)
+</div>
+
 [Sandboxing data][sandboxing-your-data] gives some people access to only a subset of the data. (The term comes from the practice of putting children in a sandbox to play safely.) To implement sandboxing, Metabase runs a query that filters rows and/or selects a subset of columns from a table based on [the person's permissions][permissions]; the user's query then runs on the initial query's result.
 
 Several databases did not support [common table expressions][cte] when sandboxing was added to Metabase, so we implemented it using subqueries. Suppose you use the Notebook Editor to create a query like:
@@ -37,9 +43,7 @@ Metabase creates a unique temporary name like `made_up_name_01` to make sure the
 
 Sandboxing isn't implemented for non-SQL databases like MongoDB, Druid, or Google Analytics. It also isn't implemented for native SQL questions: since we generate the SQL for questions written with the Notebook Editor, we can produce exactly what sandboxing needs, but parsing and modifying an arbitrary query written in SQL is a much (much) bigger challenge. As ar esult, any user with permissions to view the question can see all the results.
 
-## Specific Problems
-
-### People can see data they're not supposed to be able to see
+<h2 id="see-data-not-supposed-to">People can see data they're not supposed to be able to see</h2>
 
 **How to detect this:** People can view data that they shouldn't be able to.
 
@@ -53,7 +57,7 @@ Sandboxing isn't implemented for non-SQL databases like MongoDB, Druid, or Googl
 
 4. If people are logging in with single sign-on, but the expected attributes aren't being saved and made available, sandboxing will deny access. Our article on [Authenticating with SAML][authenticating-with-saml] explains the required setup in detail.
 
-### People can't see the data they're supposed to be able to see
+<h2 id="cant-see-data-supposed-to">People can't see the data they're supposed to be able to see</h2>
 
 **How to detect this:** Someone is supposed to be able to use some of the values in a table in their queries, but are denied access or get an empty set of results where there should be data.
 
@@ -63,7 +67,7 @@ Sandboxing isn't implemented for non-SQL databases like MongoDB, Druid, or Googl
 
 2. Some fields in a table which the person *does* have sandbox access to are using remapping to display information from another table which the person does *not* have sandbox access to. You can check this by going into the Admin Panel and viewing the Data Model for the fields in question.
 
-### Someone is in several groups but can't see the sandboxed data
+<h2 id="in-several-groups-cant-see-sandboxed-data">Someone is in several groups but can't see the sandboxed data</h2>
 
 We only allow [one sandbox per table][one-sandbox-per-table]: if someone is a member of two or more groups with different permissions, every rule for figuring out whether access should be allowed or not is confusing. We therefore only allow one rule.
 

--- a/docs/troubleshooting-guide/sync-fingerprint-scan.md
+++ b/docs/troubleshooting-guide/sync-fingerprint-scan.md
@@ -1,5 +1,12 @@
 # Synchronizing with the database
 
+<div class='doc-toc' markdown=1>
+- [Metabase can't sync, fingerprint, or scan](#cant-sync-fingerprint-scan)
+- [Metabase isn't showing all of the values I expect to see](#not-showing-all-values)
+- [I cannot force Metabase to sync or scan using the API](#cant-force-with-api)
+- [Sync and scan take a very long time to run](#sync-scan-long-time)
+</div>
+
 Metabase needs to know what's in your database in order to show tables and fields, populate dropdown menus, and suggest good visualizations, but loading all the data would be very slow (or simply impossible if you have a lot of data). It therefore does three things:
 
 1. Metabase periodically asks the database what tables are available, then asks which columns are available for each table. We call this *syncing*, and it happens [hourly or daily][sync-frequency] depending on how you've configured it. It's very fast with most relational databases, but can be slower with MongoDB and some [community-built database drivers][community-db-drivers].
@@ -8,9 +15,7 @@ Metabase needs to know what's in your database in order to show tables and field
 
 3. A *scan* is similar to fingerprinting, but is done every 24 hours (unless it's configured to run less often or disabled).  Scanning looks at the first 5000 distinct records ordered ascending, when a field is set to "A list of all values" in the Data Model, which is used to display options in dropdowns. If the textual result of scanning a column is more than 10 kilobytes long, for example, we display a search box instead of a dropdown.
 
-## Specific Problems
-
-### Metabase can't sync, fingerprint, or scan
+<h2 id="cant-sync-fingerprint-scan">Metabase can't sync, fingerprint, or sca</h2>
 
 If the credentials Metabase is using to connect to the database don't give it privileges to read the tables, the first sign will often be a failure to sync, which would then also stop fingerprint and scan.
 
@@ -31,7 +36,7 @@ LIMIT 1
 
 Note that we only get the first 10,000 documents when scanning a MongoDB collection, so if you're not seeing some new fields, those fields might not exist in the documents we looked at. Please see [this discussion][metabase-mongo-missing] for more details.
 
-### Metabase isn't showing all of the values I expect to see
+<h2 id="not-showing-all-values">Metabase isn't showing all of the values I expect to se</h2>
 
 **How to detect this:**
 
@@ -46,7 +51,7 @@ Note that we only get the first 10,000 documents when scanning a MongoDB collect
 4. Set **Field Type** to "Category" and **Filtering on this field** to "A list of all values."
 5. Click the button **Re-scan this field** in the bottom.
 
-### I cannot force Metabase to sync or scan using the API
+<h2 id="cant-force-with-api">I cannot force Metabase to sync or scan using the AP</h2>
 
 Metabase syncs and scans regularly, but if the database administrator has just changed the database schema, or if a lot of data is added automatically at specific times, you may want to write a script that uses the [Metabase API][api-learn] to force sync or scan to take place right away. [Our API][metabase-api] provides two ways to do this:
 
@@ -63,7 +68,7 @@ Metabase syncs and scans regularly, but if the database administrator has just c
 3. Check the error message returned from Metabase.
 4. Check the credentials you're using to authenticate and make sure they identify your script as a user with administrative privileges.
 
-### Sync and scan take a very long time to run
+<h2 id="sync-scan-long-time">Sync and scan take a very long time to ru</h2>
 
 **How to detect this:** Sync and scan take a long time to complete.
 

--- a/docs/troubleshooting-guide/timezones.md
+++ b/docs/troubleshooting-guide/timezones.md
@@ -1,5 +1,11 @@
 # Timezone problems
 
+<div class='doc-toc' markdown=1>
+- [SQL queries are not respecting the Reporting Time Zone setting](#not-respect-time-zone-setting)
+- [Dates without an explicit time zone are being converted to another day](#dates-without-explicit-tz-converted)
+- [Mixing explicit and implicit time zones](#mixing-explicit-implicit)
+</div>
+
 "Wrong" numbers in charts or reports are often a result of an underlying issue with time zones. Problems of this type are extremely common with many analytics tools, and the best way to avoid them in Metabase is by selecting the "Report Time Zone" setting in the "General" tab of the Admin Panel. Doing this ensures that the time zone of query results matches the time zone used by the database for its date calculations.
 
 "Report Time Zone" is currently supported on:
@@ -12,8 +18,6 @@
 - Vertica
 
 If you're using a database that doesn't support a Report Time Zone, the next option is to ensure that the Metabase instance's time zone matches that of the database. The Metabase instance's time zone is the Java Virtual Machine's time zone, typically set via a `-Duser.timezone<..>` parameter or the `JAVA_TIMEZONE` environment variable; exactly how it is set will depend on how you launch Metabase. Note that the Metabase instance's time zone doesn't impact any databases that use a Report Time Zone.
-
-## Troubleshooting Process
 
 If you suspect that you have a time zone issue, these questions may help you resolve it:
 
@@ -42,9 +46,7 @@ Now that you have the time zone adjustment, go back to the earlier list of time 
 
 A few specific problems are described below. If none of them apply, please [open a bug report][metabase-file-bug] with the above information (time zones and the results of the second troubleshooting process) as well as your Metabase, OS, and web browser versions.
 
-## Specific Problems
-
-### SQL queries are not respecting the Reporting Time Zone setting
+<h2 id="not-respect-time-zone-setting">SQL queries are not respecting the Reporting Time Zone setting</h2>
 
 **How to detect this:**
 You are not able to click on a cell in a result table or a chart.
@@ -52,7 +54,7 @@ You are not able to click on a cell in a result table or a chart.
 **How to fix this:**
 We do not currently apply a reporting time zone to the results of SQL queries, so you should set one manually.
 
-### Dates without an explicit time zone are being converted to another day
+<h2 id="dates-without-explicit-tz-converted">Dates without an explicit time zone are being converted to another day</h2>
 
 **How to detect this:**
 This occurs when you are grouping by a date (rather than by a time) that does not have a time zone attached to it. Look at every time field your question uses in the Data Model Reference, and see if any of them are simply a "Date" field.
@@ -60,7 +62,7 @@ This occurs when you are grouping by a date (rather than by a time) that does no
 **How to fix this:**
 Make sure the server time zone reflects the reporting time zone, because when a query is run on Metabase, the server applies the configured time zone to that date.
 
-### Mixing explicit and implicit time zones
+<h2 id="mixing-explicit-implicit">Mixing explicit and implicit time zones</h2>
 
 **How to detect this:**
 This often happens if you compare or perform arithmetic on two dates where one has an explicit time zone and one does not. This typically involves a question that uses multiple fields (e.g., when you filter on one timestamp and group by another). Check the time zones of each of the dates or times you are using in your question.


### PR DESCRIPTION
First pass

- Builds a ToC for (almost) every troubleshooting page.
  - `bugs.md` doesn't have one (no subsections)
  - `index.md` doesn't have one (since it's a big ToC itself)
  - `loading-from-h2.md` doesn't have one (no subsections)
