### PR TITLE
treat empty string query param as forcefully undefined for defaulted …

### DIFF
--- a/frontend/src/metabase/dashboard/dashboard.js
+++ b/frontend/src/metabase/dashboard/dashboard.js
@@ -715,7 +715,14 @@ export const fetchDashboard = createThunkAction(FETCH_DASHBOARD, function(
     const parameterValues = {};
     if (result.parameters) {
       for (const parameter of result.parameters) {
-        if (queryParams && queryParams[parameter.slug] != null) {
+        const queryParameterValue = queryParams && queryParams[parameter.slug];
+        if (
+          enableDefaultParameters &&
+          parameter.default != null &&
+          queryParameterValue === ""
+        ) {
+          parameterValues[parameter.id] = undefined;
+        } else if (queryParameterValue != null) {
           parameterValues[parameter.id] = queryParams[parameter.slug];
         } else if (enableDefaultParameters && parameter.default != null) {
           parameterValues[parameter.id] = parameter.default;

--- a/frontend/src/metabase/parameters/components/Parameters/Parameters.jsx
+++ b/frontend/src/metabase/parameters/components/Parameters/Parameters.jsx
@@ -30,8 +30,10 @@ export default class Parameters extends Component {
         parameters,
         parameterValues,
       )) {
-        if (parameter.value) {
+        if (parameter.value != null) {
           queryParams[parameter.slug] = parameter.value;
+        } else if (parameter.default != null && parameter.value == null) {
+          queryParams[parameter.slug] = "";
         }
       }
 

--- a/frontend/src/metabase/parameters/components/Parameters/syncQueryParamsWithURL.js
+++ b/frontend/src/metabase/parameters/components/Parameters/syncQueryParamsWithURL.js
@@ -1,6 +1,7 @@
 import Dimension from "metabase-lib/lib/Dimension";
 
 export const syncQueryParamsWithURL = props => {
+  // only true in native query editor and tag editor param?
   props.commitImmediately
     ? syncForInternalQuestion(props)
     : syncForPublicQuestion(props);
@@ -16,7 +17,9 @@ const syncForInternalQuestion = props => {
   for (const parameter of parameters) {
     const queryParam = query && query[parameter.slug];
 
-    if (queryParam != null || parameter.default != null) {
+    if (parameter.default != null && queryParam === "") {
+      setParameterValue(parameter.id, undefined);
+    } else if (queryParam != null || parameter.default != null) {
       const parsedParam = parseQueryParams(queryParam, parameter, metadata);
 
       setParameterValue(parameter.id, parsedParam);
@@ -27,6 +30,7 @@ const syncForInternalQuestion = props => {
 const syncForPublicQuestion = props => {
   const { parameters, setMultipleParameterValues, query, metadata } = props;
 
+  // only exist on embed frame and public question
   if (!setMultipleParameterValues) {
     return;
   }
@@ -34,7 +38,9 @@ const syncForPublicQuestion = props => {
   const parameterValues = parameters.reduce((acc, parameter) => {
     const queryParam = query && query[parameter.slug];
 
-    if (queryParam != null || parameter.default != null) {
+    if (parameter.default != null && queryParam === "") {
+      acc[parameter.id] = undefined;
+    } else if (queryParam != null || parameter.default != null) {
       acc[parameter.id] = parseQueryParams(queryParam, parameter, metadata);
     }
 


### PR DESCRIPTION
#13960 

Very much a prototype.

Demo video -- I am clearing each parameter and then refreshing the page to show that the default values aren't repopulated.

https://user-images.githubusercontent.com/13057258/128068212-6225bd79-1d22-4d0a-bf3c-74c9ac279a07.mov

