### PR TITLE
Remove .git directory in .dockerignore so version can build correctly

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,7 +10,6 @@ target/*
 .lsp
 .shadow-cljs
 .github
-.git
 .vscode
 hooks/*
 test/*
@@ -18,7 +17,6 @@ test_config/*
 test_modules/*
 test_resources/*
 node_modules
-
 **metabase.jar
 
 *.db


### PR DESCRIPTION
I accidentally excluded the .git directory on the builds to make the builds a bit faster (so we didn't copy git history). I wasn't aware that the version step was using this for the version.properties, so this change should solve that

tested and works fine