### PR TITLE
Change default for currency style to code if symbol not supported

### DIFF
--- a/frontend/src/metabase/visualizations/lib/settings/column.js
+++ b/frontend/src/metabase/visualizations/lib/settings/column.js
@@ -354,7 +354,12 @@ export const NUMBER_COLUMN_SETTINGS = {
         ],
       };
     },
-    default: "symbol",
+    getDefault: (column: Column, settings: ColumnSettings) => {
+      const c = settings["currency"] || "USD";
+      return getCurrency(c, "symbol") !== getCurrency(c, "code")
+        ? "symbol"
+        : "code";
+    },
     getHidden: (column: Column, settings: ColumnSettings) =>
       settings["number_style"] !== "currency",
     readDependencies: ["number_style"],


### PR DESCRIPTION
Quick follow-up to #17240 -- I realized we also need to change the default to "code" if we've disabled the "symbol" option.