### PR TITLE
Bump backend dependencies

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -6,18 +6,18 @@
  ;; !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
  {aleph/aleph                               {:mvn/version "0.4.6"               ; Async HTTP library; WebSockets
                                              :exclusions  [org.clojure/tools.logging]}
-  amalloy/ring-buffer                       {:mvn/version "1.2.2"               ; fixed length queue implementation, used in log buffering
+  amalloy/ring-buffer                       {:mvn/version "1.3.1"               ; fixed length queue implementation, used in log buffering
                                              :exclusions  [org.clojure/clojure
                                                            org.clojure/clojurescript]}
   amalloy/ring-gzip-middleware              {:mvn/version "0.1.4"}              ; Ring middleware to GZIP responses if client can handle it
   bigml/histogram                           {:mvn/version "4.1.3"}              ; Histogram data structure
-  buddy/buddy-core                          {:mvn/version "1.5.0"               ; various cryptograhpic functions
+  buddy/buddy-core                          {:mvn/version "1.10.1"              ; various cryptograhpic functions
                                              :exclusions  [commons-codec/commons-codec
                                                            org.bouncycastle/bcpkix-jdk15on
                                                            org.bouncycastle/bcprov-jdk15on]}
-  buddy/buddy-sign                          {:mvn/version "3.0.0"}              ; JSON Web Tokens; High-Level message signing library
-  cheshire/cheshire                         {:mvn/version "5.10.0"}             ; fast JSON encoding (used by Ring JSON middleware)
-  clj-http/clj-http                         {:mvn/version "3.10.3"              ; HTTP client
+  buddy/buddy-sign                          {:mvn/version "3.4.1"}              ; JSON Web Tokens; High-Level message signing library
+  cheshire/cheshire                         {:mvn/version "5.10.1"}             ; fast JSON encoding (used by Ring JSON middleware)
+  clj-http/clj-http                         {:mvn/version "3.12.3"              ; HTTP client
                                              :exclusions  [commons-codec/commons-codec
                                                            commons-io/commons-io
                                                            slingshot/slingshot]}
@@ -31,23 +31,23 @@
                                                            org.apache.httpcomponents/httpclient
                                                            ring/ring-core
                                                            slingshot/slingshot]}
-  com.clearspring.analytics/stream          {:mvn/version "2.9.6"               ; Various sketching algorithms
+  com.clearspring.analytics/stream          {:mvn/version "2.9.8"               ; Various sketching algorithms
                                              :exclusions  [it.unimi.dsi/fastutil
                                                            org.slf4j/slf4j-api]}
-  com.draines/postal                        {:mvn/version "2.0.3"}              ; SMTP library
-  com.google.guava/guava                    {:mvn/version "28.2-jre"}           ; dep for BigQuery, Spark, and GA. Require here rather than letting different dep versions stomp on each other — see comments on #9697
-  com.h2database/h2                         {:mvn/version "1.4.197"}            ; embedded SQL database
-  com.taoensso/nippy                        {:mvn/version "2.14.0"}             ; Fast serialization (i.e., GZIP) library for Clojure
+  com.draines/postal                        {:mvn/version "2.0.4"}              ; SMTP library
+  com.google.guava/guava                    {:mvn/version "30.1.1-jre"}         ; dep for BigQuery, Spark, and GA. Require here rather than letting different dep versions stomp on each other — see comments on #9697
+  com.h2database/h2                         {:mvn/version "1.4.200"}            ; embedded SQL database
+  com.taoensso/nippy                        {:mvn/version "3.1.1"}              ; Fast serialization (i.e., GZIP) library for Clojure
   commons-codec/commons-codec               {:mvn/version "1.15"}               ; Apache Commons -- useful codec util fns
-  commons-io/commons-io                     {:mvn/version "2.8.0"}              ; Apache Commons -- useful IO util fns
-  commons-validator/commons-validator       {:mvn/version "1.6"                 ; Apache Commons -- useful validation util fns
+  commons-io/commons-io                     {:mvn/version "2.11.0"}             ; Apache Commons -- useful IO util fns
+  commons-validator/commons-validator       {:mvn/version "1.7"                 ; Apache Commons -- useful validation util fns
                                              :exclusions  [commons-beanutils/commons-beanutils
                                                            commons-digester/commons-digester
                                                            commons-logging/commons-logging]}
-  compojure/compojure                       {:mvn/version "1.6.1"               ; HTTP Routing library built on Ring
+  compojure/compojure                       {:mvn/version "1.6.2"               ; HTTP Routing library built on Ring
                                              :exclusions  [ring/ring-codec]}
-  crypto-random/crypto-random               {:mvn/version "1.2.0"}              ; library for generating cryptographically secure random bytes and strings
-  dk.ative/docjure                          {:mvn/version "1.14.0"              ; excel export
+  crypto-random/crypto-random               {:mvn/version "1.2.1"}              ; library for generating cryptographically secure random bytes and strings
+  dk.ative/docjure                          {:mvn/version "1.16.0"              ; excel export
                                              :exclusions  [org.apache.poi/poi
                                                            org.apache.poi/poi-ooxml]}
   environ/environ                           {:mvn/version "1.2.0"}              ; env vars/Java properties abstraction
@@ -55,13 +55,13 @@
   honeysql/honeysql                         {:mvn/version "1.0.461"             ; Transform Clojure data structures to SQL
                                              :exclusions  [org.clojure/clojurescript]}
   instaparse/instaparse                     {:mvn/version "1.4.10"}             ; Make your own parser
-  io.forward/yaml                           {:mvn/version "1.0.9"               ; Clojure wrapper for YAML library SnakeYAML (which we already use for liquibase)
+  io.forward/yaml                           {:mvn/version "1.0.10"              ; Clojure wrapper for YAML library SnakeYAML (which we already use for liquibase)
                                              :exclusions  [org.clojure/clojure
                                                            org.flatland/ordered
                                                            org.yaml/snakeyaml]}
   javax.xml.bind/jaxb-api                   {:mvn/version "2.4.0-b180830.0359"} ; add the `javax.xml.bind` classes which we're still using but were removed in Java 11
-  joda-time/joda-time                       {:mvn/version "2.10.8"}
-  kixi/stats                                {:mvn/version "0.4.4"               ; Various statistic measures implemented as transducers
+  joda-time/joda-time                       {:mvn/version "2.10.10"}
+  kixi/stats                                {:mvn/version "0.5.4"               ; Various statistic measures implemented as transducers
                                              :exclusions  [org.clojure/data.avl]}
   me.raynes/fs                              {:mvn/version "1.4.6"               ; Filesystem tools
                                              :exclusions  [org.apache.commons/commons-compress]}
@@ -70,68 +70,68 @@
   metabase/saml20-clj                       {:mvn/version "2.0.0"}              ; EE SAML integration
   metabase/throttle                         {:mvn/version "1.0.2"}              ; Tools for throttling access to API endpoints and other code pathways
   net.cgrand/macrovich                      {:mvn/version "0.2.1"}              ; utils for writing macros for both Clojure & ClojureScript
-  net.redhogs.cronparser/cron-parser-core   {:mvn/version "3.4"                 ; describe Cron schedule in human-readable language
+  net.redhogs.cronparser/cron-parser-core   {:mvn/version "3.5"                 ; describe Cron schedule in human-readable language
                                              :exclusions  [joda-time/joda-time  ; exclude joda time 2.3 which has outdated timezone information
                                                            org.slf4j/slf4j-api]}
-  net.sf.cssbox/cssbox                      {:mvn/version "4.12"                ; HTML / CSS rendering
+  net.sf.cssbox/cssbox                      {:mvn/version "5.0.0"               ; HTML / CSS rendering
                                              :exclusions  [org.slf4j/slf4j-api]}
-  org.apache.commons/commons-compress       {:mvn/version "1.20"}               ; compression utils
-  org.apache.commons/commons-lang3          {:mvn/version "3.10"}               ; helper methods for working with java.lang stuff
-  org.apache.logging.log4j/log4j-1.2-api    {:mvn/version "2.13.3"}             ; apache logging framework
-  org.apache.logging.log4j/log4j-api        {:mvn/version "2.13.3"}             ; add compatibility with log4j 1.2
-  org.apache.logging.log4j/log4j-core       {:mvn/version "2.13.3"}             ; apache logging framework
-  org.apache.logging.log4j/log4j-jcl        {:mvn/version "2.13.3"}             ; allows the commons-logging API to work with log4j 2
-  org.apache.logging.log4j/log4j-liquibase  {:mvn/version "2.13.3"}             ; liquibase logging via log4j 2
-  org.apache.logging.log4j/log4j-slf4j-impl {:mvn/version "2.13.3"}             ; allows the slf4j API to work with log4j 2
+  org.apache.commons/commons-compress       {:mvn/version "1.21"}               ; compression utils
+  org.apache.commons/commons-lang3          {:mvn/version "3.12.0"}             ; helper methods for working with java.lang stuff
+  org.apache.logging.log4j/log4j-1.2-api    {:mvn/version "2.14.1"}             ; apache logging framework
+  org.apache.logging.log4j/log4j-api        {:mvn/version "2.14.1"}             ; add compatibility with log4j 1.2
+  org.apache.logging.log4j/log4j-core       {:mvn/version "2.14.1"}             ; apache logging framework
+  org.apache.logging.log4j/log4j-jcl        {:mvn/version "2.14.1"}             ; allows the commons-logging API to work with log4j 2
+  org.apache.logging.log4j/log4j-liquibase  {:mvn/version "2.14.1"}             ; liquibase logging via log4j 2
+  org.apache.logging.log4j/log4j-slf4j-impl {:mvn/version "2.14.1"}             ; allows the slf4j API to work with log4j 2
   org.apache.poi/poi                        {:mvn/version "5.0.0"}              ; Work with Office documents (e.g. Excel spreadsheets) -- newer version than one specified by Docjure
   org.apache.poi/poi-ooxml                  {:mvn/version "5.0.0"
                                              :exclusions  [org.bouncycastle/bcpkix-jdk15on
                                                            org.bouncycastle/bcprov-jdk15on]}
-  org.apache.sshd/sshd-core                 {:mvn/version "2.4.0"}              ; ssh tunneling and test server
-  org.bouncycastle/bcpkix-jdk15on           {:mvn/version "1.68"}               ; Bouncy Castle crypto library -- explicit version of BC specified to resolve illegal reflective access errors
-  org.bouncycastle/bcprov-jdk15on           {:mvn/version "1.68"}
-  org.clojars.pntblnk/clj-ldap              {:mvn/version "0.0.16"}             ; LDAP client
+  org.apache.sshd/sshd-core                 {:mvn/version "2.7.0"}              ; ssh tunneling and test server
+  org.bouncycastle/bcpkix-jdk15on           {:mvn/version "1.69"}               ; Bouncy Castle crypto library -- explicit version of BC specified to resolve illegal reflective access errors
+  org.bouncycastle/bcprov-jdk15on           {:mvn/version "1.69"}
+  org.clojars.pntblnk/clj-ldap              {:mvn/version "0.0.17"}             ; LDAP client
   org.clojure/clojure                       {:mvn/version "1.10.3"}
-  org.clojure/core.async                    {:mvn/version "0.4.500"
+  org.clojure/core.async                    {:mvn/version "1.3.618"
                                              :exclusions  [org.clojure/tools.reader]}
   org.clojure/core.logic                    {:mvn/version "1.0.0"}              ; optimized pattern matching library for Clojure
-  org.clojure/core.match                    {:mvn/version "0.3.0"}
-  org.clojure/core.memoize                  {:mvn/version "1.0.236"}            ; useful FIFO, LRU, etc. caching mechanisms
-  org.clojure/data.csv                      {:mvn/version "0.1.4"}              ; CSV parsing / generation
+  org.clojure/core.match                    {:mvn/version "1.0.0"}
+  org.clojure/core.memoize                  {:mvn/version "1.0.250"}            ; useful FIFO, LRU, etc. caching mechanisms
+  org.clojure/data.csv                      {:mvn/version "1.0.0"}              ; CSV parsing / generation
   org.clojure/java.classpath                {:mvn/version "1.0.0"}              ; examine the Java classpath from Clojure programs
-  org.clojure/java.jdbc                     {:mvn/version "0.7.11"}             ; basic JDBC access from Clojure
+  org.clojure/java.jdbc                     {:mvn/version "0.7.12"}             ; basic JDBC access from Clojure
   org.clojure/java.jmx                      {:mvn/version "1.0.0"}              ; JMX bean library, for exporting diagnostic info
-  org.clojure/math.combinatorics            {:mvn/version "0.1.4"}              ; combinatorics functions
+  org.clojure/math.combinatorics            {:mvn/version "0.1.6"}              ; combinatorics functions
   org.clojure/math.numeric-tower            {:mvn/version "0.0.4"}              ; math functions like `ceil`
   org.clojure/tools.logging                 {:mvn/version "1.1.0"}              ; logging framework
-  org.clojure/tools.namespace               {:mvn/version "1.0.0"}
+  org.clojure/tools.namespace               {:mvn/version "1.1.0"}
   org.clojure/tools.reader                  {:mvn/version "1.3.6"}
-  org.clojure/tools.trace                   {:mvn/version "0.7.10"}             ; function tracing
-  org.eclipse.jetty/jetty-server            {:mvn/version "9.4.32.v20200930"}   ; We require JDK 8 which allows us to run Jetty 9.4, ring-jetty-adapter runs on 1.7 which forces an older version
+  org.clojure/tools.trace                   {:mvn/version "0.7.11"}             ; function tracing
+  org.eclipse.jetty/jetty-server            {:mvn/version "11.0.6"}             ; We require JDK 8 which allows us to run Jetty 9.4, ring-jetty-adapter runs on 1.7 which forces an older version
   org.flatland/ordered                      {:mvn/version "1.5.9"}              ; ordered maps & sets
-  org.graalvm.js/js                         {:mvn/version "21.0.0.2"}           ; JavaScript engine
-  org.graalvm.js/js-scriptengine            {:mvn/version "21.0.0.2"}
-  org.liquibase/liquibase-core              {:mvn/version "3.6.3"               ; migration management (Java lib)
+  org.graalvm.js/js                         {:mvn/version "21.2.0"}             ; JavaScript engine
+  org.graalvm.js/js-scriptengine            {:mvn/version "21.2.0"}
+  org.liquibase/liquibase-core              {:mvn/version "4.4.2"               ; migration management (Java lib)
                                              :exclusions  [ch.qos.logback/logback-classic]}
-  org.mariadb.jdbc/mariadb-java-client      {:mvn/version "2.6.2"}              ; MySQL/MariaDB driver
-  org.postgresql/postgresql                 {:mvn/version "42.2.18"}            ; Postgres driver
-  org.slf4j/slf4j-api                       {:mvn/version "1.7.30"}             ; abstraction for logging frameworks -- allows end user to plug in desired logging framework at deployment time
+  org.mariadb.jdbc/mariadb-java-client      {:mvn/version "2.7.3"}              ; MySQL/MariaDB driver
+  org.postgresql/postgresql                 {:mvn/version "42.2.23"}            ; Postgres driver
+  org.slf4j/slf4j-api                       {:mvn/version "1.7.32"}             ; abstraction for logging frameworks -- allows end user to plug in desired logging framework at deployment time
   org.tcrawley/dynapath                     {:mvn/version "1.1.0"}              ; Dynamically add Jars (e.g. Oracle or Vertica) to classpath
-  org.threeten/threeten-extra               {:mvn/version "1.5.0"}              ; extra Java 8 java.time classes like DayOfMonth and Quarter
-  org.yaml/snakeyaml                        {:mvn/version "1.23"}               ; YAML parser (required by liquibase)
+  org.threeten/threeten-extra               {:mvn/version "1.7.0"}              ; extra Java 8 java.time classes like DayOfMonth and Quarter
+  org.yaml/snakeyaml                        {:mvn/version "1.29"}               ; YAML parser (required by liquibase)
   potemkin/potemkin                         {:mvn/version "0.4.5"               ; utility macros & fns
                                              :exclusions  [riddley/riddley]}
   pretty/pretty                             {:mvn/version "1.0.5"}              ; protocol for defining how custom types should be pretty printed
   prismatic/schema                          {:mvn/version "1.1.12"}             ; Data schema declaration and validation library
   redux/redux                               {:mvn/version "0.1.4"}              ; Utility functions for building and composing transducers
   riddley/riddley                           {:mvn/version "0.2.0"}              ; code walking lib -- used interally by Potemkin, manifold, etc.
-  ring/ring-core                            {:mvn/version "1.8.1"}              ; web server (Jetty wrapper)
-  ring/ring-jetty-adapter                   {:mvn/version "1.8.1"}              ; Ring adapter using Jetty webserver
-  ring/ring-json                            {:mvn/version "0.5.0"}              ; Ring middleware for reading/writing JSON automatically
+  ring/ring-core                            {:mvn/version "1.9.4"}              ; web server (Jetty wrapper)
+  ring/ring-jetty-adapter                   {:mvn/version "1.9.4"}              ; Ring adapter using Jetty webserver
+  ring/ring-json                            {:mvn/version "0.5.1"}              ; Ring middleware for reading/writing JSON automatically
   robdaemon/clojure.java-time               {:mvn/version "0.3.3-SNAPSHOT"}     ; Java 8 java.time wrapper. Fork to address #13102 - see upstream PR: https://github.com/dm3/clojure.java-time/pull/60
   slingshot/slingshot                       {:mvn/version "0.12.2"}             ; enhanced throw/catch, used by other deps
   stencil/stencil                           {:mvn/version "0.5.0"}              ; Mustache templates for Clojure
-  toucan/toucan                             {:mvn/version "1.15.3"              ; Model layer, hydration, and DB utilities
+  toucan/toucan                             {:mvn/version "1.15.4"              ; Model layer, hydration, and DB utilities
                                              :exclusions  [honeysql/honeysql
                                                            org.clojure/java.jdbc
                                                            org.clojure/tools.logging
@@ -170,7 +170,7 @@
                                                            :exclusions  [slingshot/slingshot]}
     cloverage/cloverage                                   {:mvn/version "1.2.2"}
     eftest/eftest                                         {:mvn/version "0.5.9"}
-    jonase/eastwood                                       {:mvn/version "0.9.4"}
+    jonase/eastwood                                       {:mvn/version "0.9.6"}
     lein-check-namespace-decls/lein-check-namespace-decls {:mvn/version "1.0.4"} ; misnomer since this works on Clojure CLI now too
     pjstadig/humane-test-output                           {:mvn/version "0.11.0"}
     reifyhealth/specmonstah                               {:mvn/version "2.0.0"}

--- a/deps.edn
+++ b/deps.edn
@@ -73,7 +73,7 @@
   net.redhogs.cronparser/cron-parser-core   {:mvn/version "3.5"                 ; describe Cron schedule in human-readable language
                                              :exclusions  [joda-time/joda-time  ; exclude joda time 2.3 which has outdated timezone information
                                                            org.slf4j/slf4j-api]}
-  net.sf.cssbox/cssbox                      {:mvn/version "5.0.0"               ; HTML / CSS rendering
+  net.sf.cssbox/cssbox                      {:mvn/version "4.17"                ; HTML / CSS rendering
                                              :exclusions  [org.slf4j/slf4j-api]}
   org.apache.commons/commons-compress       {:mvn/version "1.21"}               ; compression utils
   org.apache.commons/commons-lang3          {:mvn/version "3.12.0"}             ; helper methods for working with java.lang stuff
@@ -107,7 +107,7 @@
   org.clojure/tools.namespace               {:mvn/version "1.1.0"}
   org.clojure/tools.reader                  {:mvn/version "1.3.6"}
   org.clojure/tools.trace                   {:mvn/version "0.7.11"}             ; function tracing
-  org.eclipse.jetty/jetty-server            {:mvn/version "11.0.6"}             ; We require JDK 8 which allows us to run Jetty 9.4, ring-jetty-adapter runs on 1.7 which forces an older version
+  org.eclipse.jetty/jetty-server            {:mvn/version "9.4.43.v20210629"}   ; web server
   org.flatland/ordered                      {:mvn/version "1.5.9"}              ; ordered maps & sets
   org.graalvm.js/js                         {:mvn/version "21.2.0"}             ; JavaScript engine
   org.graalvm.js/js-scriptengine            {:mvn/version "21.2.0"}

--- a/modules/drivers/bigquery/deps.edn
+++ b/modules/drivers/bigquery/deps.edn
@@ -2,6 +2,6 @@
  ["src" "resources"]
 
  :deps
- {com.google.apis/google-api-services-bigquery {:mvn/version "v2-rev20200523-1.30.9"}}
+ {com.google.apis/google-api-services-bigquery {:mvn/version "v2-rev20210726-1.32.1"}}
 
  :metabase.build-driver/parents #{:google}}

--- a/modules/drivers/google/deps.edn
+++ b/modules/drivers/google/deps.edn
@@ -2,4 +2,4 @@
  ["src" "resources"]
 
  :deps
- {com.google.api-client/google-api-client {:mvn/version "1.30.7"}}}
+ {com.google.api-client/google-api-client {:mvn/version "1.32.1"}}}

--- a/modules/drivers/redshift/deps.edn
+++ b/modules/drivers/redshift/deps.edn
@@ -5,4 +5,4 @@
  {"redshift" {:url "https://s3.amazonaws.com/redshift-maven-repository/release"}}
 
  :deps
- {com.amazon.redshift/redshift-jdbc42 {:mvn/version "2.0.0.3"}}}
+ {com.amazon.redshift/redshift-jdbc42 {:mvn/version "2.0.0.7"}}}

--- a/modules/drivers/snowflake/deps.edn
+++ b/modules/drivers/snowflake/deps.edn
@@ -2,4 +2,4 @@
  ["src" "resources"]
 
  :deps
- {net.snowflake/snowflake-jdbc {:mvn/version "3.12.13"}}}
+ {net.snowflake/snowflake-jdbc {:mvn/version "3.13.6"}}}

--- a/modules/drivers/sqlite/deps.edn
+++ b/modules/drivers/sqlite/deps.edn
@@ -2,4 +2,4 @@
  ["src" "resources"]
 
  :deps
- {org.xerial/sqlite-jdbc {:mvn/version "3.25.2"}}}
+ {org.xerial/sqlite-jdbc {:mvn/version "3.36.0.1"}}}

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -5,13 +5,13 @@
 
  ;; TODO -- share deps with project.clj -- see https://shadow-cljs.github.io/docs/UsersGuide.html#Leiningen
  :dependencies
- [[org.clojure/core.match "0.3.0"]
+ [[org.clojure/core.match "1.0.0"]
   [medley "1.3.0"]
   [net.cgrand/macrovich "0.2.1"]
   [prismatic/schema "1.1.12"]
 
   ;; new stuff
-  [lambdaisland/glogi "1.0.83"]]
+  [lambdaisland/glogi "1.0.106"]]
 
  :nrepl
  {:middleware


### PR DESCRIPTION
Routine bump of backend dependencies. This will let us get the latest upstream bug fixes and security fixes. Some of these aren't working so I'll have to revert a few of them probably