### PR TITLE
Bump depstar version to prevent annoying messages about having multiple SLF4J bindings

### DIFF
--- a/bin/build-drivers/deps.edn
+++ b/bin/build-drivers/deps.edn
@@ -2,7 +2,7 @@
 
  :deps
  {common/common                   {:local/root "../common"}
-  com.github.seancorfield/depstar {:git/tag "v2.1.267", :git/sha "1a45f79"}
+  com.github.seancorfield/depstar {:mvn/version "2.1.278"}
   cheshire/cheshire               {:mvn/version "5.8.1"}
   commons-codec/commons-codec     {:mvn/version "1.14"}
   hiccup/hiccup                   {:mvn/version "1.0.5"}

--- a/deps.edn
+++ b/deps.edn
@@ -359,7 +359,7 @@
   ;; clojure -T:build uberjar :edition :ee
   :build
   {:deps       {io.github.clojure/tools.build   {:git/tag "v0.1.6", :git/sha "5636e61"}
-                com.github.seancorfield/depstar {:tag "v2.1.267", :sha "1a45f79"}
+                com.github.seancorfield/depstar {:mvn/version "2.1.278"}
                 metabase/build.common           {:local/root "bin/common"}
                 metabase/buid-mb                {:local/root "bin/build-mb"}}
    :ns-default build}


### PR DESCRIPTION
If you're using the `:build` alias it would complain on launch because it includes Depstar as a dep and SLF4J-simple and SLF4J-noop as transitive deps. This was fixed upstream in Depstar. Now we don't have multiple SLF4J bindings/messages