### PR TITLE
correct moderation review hydration

### DIFF
--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -208,7 +208,7 @@
       ;; i'm a bit worried that this is an n+1 situation here. The cards can be batch hydrated i think because they
       ;; have a hydration key and an id. moderation_reviews currently aren't batch hydrated but i'm worried they
       ;; cannot be in this situation
-      (hydrate [:ordered_cards [:card :moderation_reviews] :series] :collection_authority_level :can_write :param_fields :param_values)
+      (hydrate [:ordered_cards :card :series] :collection_authority_level :can_write :param_fields :param_values)
       api/read-check
       api/check-not-archived
       hide-unreadable-cards

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -208,7 +208,7 @@
       ;; i'm a bit worried that this is an n+1 situation here. The cards can be batch hydrated i think because they
       ;; have a hydration key and an id. moderation_reviews currently aren't batch hydrated but i'm worried they
       ;; cannot be in this situation
-      (hydrate [:ordered_cards :card :series] :collection_authority_level :can_write :param_fields :param_values)
+      (hydrate [:ordered_cards [:card :moderation_reviews] :series] :collection_authority_level :can_write :param_fields :param_values)
       api/read-check
       api/check-not-archived
       hide-unreadable-cards


### PR DESCRIPTION
Restore hydration of moderation_reviews and handle correctly

nested hydration is (i think) positional. So if you get something
handed to you you must return something in that position. Prevoiusly
was removing nils and then returning a smaller collection of hydrated
items (cards here). But this meant input might look like this

[card1 nil card2] and return [card1-with-moderation-reviews card2-with-moderation-reviews]
 and in the nested hierarchy things didn't get matched up correctly.

In the real world application it might look like this:

```clojure
{:ordered-cards
 [{:card-id 1}
  {:card-id nil
   :viz-settings {info-for text-card}}
  {:card-id 2}]}
```

And the nil card comes into this function and we return them in a
strange manner things get wonky
