### PR TITLE
#13136 dynamically determining supporting features by database instance

### DIFF
--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -404,7 +404,7 @@
   Note that it's the same set of `driver-features` with respect to
   both database-supports? and supports?)
 
-  (supports? :mongo :set-timezone mongo-db) ; -> true"
+    (supports? :mongo :set-timezone mongo-db) ; -> true"
   {:arglists '([driver feature database])}
   (fn [driver feature database]
     (when-not (driver-features feature)
@@ -412,8 +412,9 @@
     [(dispatch-on-initialized-driver driver) feature])
   :hierarchy #'hierarchy)
 
+(defmethod database-supports? :default [driver feature _] (supports? driver feature))
 
-(defmulti supports?
+(defmulti ^:deprecated supports?
   "Does this driver support a certain `feature`? (A feature is a keyword, and can be any of the ones listed above in
   `driver-features`.)
 
@@ -426,7 +427,6 @@
   :hierarchy #'hierarchy)
 
 (defmethod supports? :default [_ _] false)
-(defmethod database-supports? :default [driver feature _] (supports? driver feature))
 
 (defmethod supports? [::driver :basic-aggregations] [_ _] true)
 (defmethod supports? [::driver :case-sensitivity-string-filter-options] [_ _] true)

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -425,6 +425,14 @@
 
   Database is guaranteed to be a Database instance.
 
+  Most drivers can always return true or always return false for a given feature
+  (e.g., :left-join is not supported by any version of Mongo DB).
+
+  In some cases, a feature may only be supported by certain versions of the database engine.
+  In this case, after implementing `:version` in `describe-database` for the driver,
+  you can check in `(get-in db [:details :version])` and determine
+  whether a feature is supported for this particular database.
+
     (database-supports? :mongo :set-timezone mongo-db) ; -> true"
   {:arglists '([driver feature database])}
   (fn [driver feature database]

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -404,8 +404,7 @@
 
     (supports? :postgres :set-timezone) ; -> true
 
-  deprecated — [[database-supports?]] is intended to replace this method, implement it instead.
-  this method will be removed in a future release."
+  deprecated — [[database-supports?]] is intended to replace this method. However, it driver authors should continue _implementing_ `supports?` for the time being until we get a chance to migrate all our usages."
   {:arglists '([driver feature])}
   (fn [driver feature]
     (when-not (driver-features feature)
@@ -426,7 +425,7 @@
 
   Database is guaranteed to be a Database instance.
 
-    (supports? :mongo :set-timezone mongo-db) ; -> true"
+    (database-supports? :mongo :set-timezone mongo-db) ; -> true"
   {:arglists '([driver feature database])}
   (fn [driver feature database]
     (when-not (driver-features feature)

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -400,7 +400,9 @@
 
 (defmulti database-supports?
   "Does this driver and specific instance of a database support a certain `feature`?
-  (A feature is a keyword, and can be any of the ones listed above in `driver-features`.)
+  (A feature is a keyword, and can be any of the ones listed above in `driver-features`.
+  Note that it's the same set of `driver-features` with respect to
+  both database-supports? and supports?)
 
   (supports? :mongo :set-timezone mongo-db) ; -> true"
   {:arglists '([driver feature database])}

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -400,11 +400,11 @@
 
 (defmulti ^:deprecated supports?
   "Does this driver support a certain `feature`? (A feature is a keyword, and can be any of the ones listed above in
-  `driver-features`.)
+  [[driver-features]].)
 
     (supports? :postgres :set-timezone) ; -> true
 
-  deprecated — `database-supports?` is intended to replace this method, implement it instead.
+  deprecated — [[database-supports?]] is intended to replace this method, implement it instead.
   this method will be removed in a future release."
   {:arglists '([driver feature])}
   (fn [driver feature]
@@ -422,7 +422,7 @@
   "Does this driver and specific instance of a database support a certain `feature`?
   (A feature is a keyword, and can be any of the ones listed above in `driver-features`.
   Note that it's the same set of `driver-features` with respect to
-  both database-supports? and supports?)
+  both database-supports? and [[supports?]])
 
   Database is guaranteed to be a Database instance.
 

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -398,27 +398,14 @@
     ;; Does the driver support percentile calculations (including median)
     :percentile-aggregations})
 
-(defmulti database-supports?
-  "Does this driver and specific instance of a database support a certain `feature`?
-  (A feature is a keyword, and can be any of the ones listed above in `driver-features`.
-  Note that it's the same set of `driver-features` with respect to
-  both database-supports? and supports?)
-
-    (supports? :mongo :set-timezone mongo-db) ; -> true"
-  {:arglists '([driver feature database])}
-  (fn [driver feature database]
-    (when-not (driver-features feature)
-      (throw (Exception. (tru "Invalid driver feature: {0}" feature))))
-    [(dispatch-on-initialized-driver driver) feature])
-  :hierarchy #'hierarchy)
-
-(defmethod database-supports? :default [driver feature _] (supports? driver feature))
-
 (defmulti ^:deprecated supports?
   "Does this driver support a certain `feature`? (A feature is a keyword, and can be any of the ones listed above in
   `driver-features`.)
 
-    (supports? :postgres :set-timezone) ; -> true"
+    (supports? :postgres :set-timezone) ; -> true
+
+  deprecated — `database-supports?` is intended to replace this method, implement it instead.
+  this method will be removed in a future release."
   {:arglists '([driver feature])}
   (fn [driver feature]
     (when-not (driver-features feature)
@@ -430,6 +417,24 @@
 
 (defmethod supports? [::driver :basic-aggregations] [_ _] true)
 (defmethod supports? [::driver :case-sensitivity-string-filter-options] [_ _] true)
+
+(defmulti database-supports?
+  "Does this driver and specific instance of a database support a certain `feature`?
+  (A feature is a keyword, and can be any of the ones listed above in `driver-features`.
+  Note that it's the same set of `driver-features` with respect to
+  both database-supports? and supports?)
+
+  Database is guaranteed to be a Database instance.
+
+    (supports? :mongo :set-timezone mongo-db) ; -> true"
+  {:arglists '([driver feature database])}
+  (fn [driver feature database]
+    (when-not (driver-features feature)
+      (throw (Exception. (tru "Invalid driver feature: {0}" feature))))
+    [(dispatch-on-initialized-driver driver) feature])
+  :hierarchy #'hierarchy)
+
+(defmethod database-supports? :default [driver feature _] (supports? driver feature))
 
 (defmulti ^:deprecated format-custom-field-name
   "Prior to Metabase 0.33.0, you could specifiy custom names for aggregations in MBQL by wrapping the clause in a
@@ -569,8 +574,8 @@
   "Return the current time and timezone from the perspective of `database`. You can use
   `metabase.driver.common/current-db-time` to implement this. This should return a Joda-Time `DateTime`.
 
-  DEPRECATED — the only thing this method is ultimately used for is to determine the DB's system timezone.
-  `db-default-timezone` has been introduced as an intended replacement for this method; implement it instead. This
+  deprecated — the only thing this method is ultimately used for is to determine the db's system timezone.
+  `db-default-timezone` has been introduced as an intended replacement for this method; implement it instead. this
   method will be removed in a future release."
   {:deprecated "0.34.0", :arglists '(^org.joda.time.DateTime [driver database])}
   dispatch-on-initialized-driver

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -398,6 +398,19 @@
     ;; Does the driver support percentile calculations (including median)
     :percentile-aggregations})
 
+(defmulti database-supports?
+  "Does this driver and specific instance of a database support a certain `feature`?
+  (A feature is a keyword, and can be any of the ones listed above in `driver-features`.)
+
+  (supports? :mongo :set-timezone mongo-db) ; -> true"
+  {:arglists '([driver feature database])}
+  (fn [driver feature database]
+    (when-not (driver-features feature)
+      (throw (Exception. (tru "Invalid driver feature: {0}" feature))))
+    [(dispatch-on-initialized-driver driver) feature])
+  :hierarchy #'hierarchy)
+
+
 (defmulti supports?
   "Does this driver support a certain `feature`? (A feature is a keyword, and can be any of the ones listed above in
   `driver-features`.)
@@ -411,6 +424,7 @@
   :hierarchy #'hierarchy)
 
 (defmethod supports? :default [_ _] false)
+(defmethod database-supports? :default [driver feature _] (supports? driver feature))
 
 (defmethod supports? [::driver :basic-aggregations] [_ _] true)
 (defmethod supports? [::driver :case-sensitivity-string-filter-options] [_ _] true)

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -76,9 +76,9 @@
 
 (defn features
   "Return a set of all features supported by `driver`."
-  [driver]
+  [driver database]
   (set (for [feature driver/driver-features
-             :when (driver/supports? driver feature)]
+             :when (driver/database-supports? driver feature database)]
          feature)))
 
 (defn available-drivers

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -75,7 +75,7 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 (defn features
-  "Return a set of all features supported by `driver`."
+  "Return a set of all features supported by `driver` with respect to `database`."
   [driver database]
   (set (for [feature driver/driver-features
              :when (driver/database-supports? driver feature database)]

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -53,7 +53,7 @@
     (driver/initialized? driver)
     ;; TODO - this is only really needed for API responses. This should be a `hydrate` thing instead!
     (as-> db* ; database from outer cond->
-        (assoc db* :features (driver.u/features driver))
+        (assoc db* :features (driver.u/features driver database))
         (if (:details db*)
           (driver/normalize-db-details driver db*)
           db*))))

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -51,7 +51,7 @@
     (mt/object-defaults Database)
     (select-keys db [:created_at :id :details :updated_at :timezone :name])
     {:engine   (u/qualified-name (:engine db))
-     :features (map u/qualified-name (driver.u/features driver))})))
+     :features (map u/qualified-name (driver.u/features driver nil))})))
 
 (defn- table-details [table]
   (-> (merge (mt/obj->json->obj (mt/object-defaults Table))
@@ -148,7 +148,7 @@
                      :details    (s/eq {:db "my_db"})
                      :updated_at java.time.temporal.Temporal
                      :name       su/NonBlankString
-                     :features   (s/eq (driver.u/features ::test-driver))})
+                     :features   (s/eq (driver.u/features ::test-driver nil))})
                    (create-db-via-api!))))
 
     (testing "can we set `is_full_sync` to `false` when we create the Database?"
@@ -201,7 +201,7 @@
                       :engine       :h2
                       :name         "Cam's Awesome Toucan Database"
                       :is_full_sync false
-                      :features     (driver.u/features :h2)}
+                      :features     (driver.u/features :h2 nil)}
                      (into {} (db/select-one [Database :name :engine :details :is_full_sync], :id db-id)))))))))
 
     (mt/with-log-level :info
@@ -222,7 +222,7 @@
                   (select-keys (mt/db) [:created_at :id :updated_at :timezone])
                   {:engine        "h2"
                    :name          "test-data"
-                   :features      (map u/qualified-name (driver.u/features :h2))
+                   :features      (map u/qualified-name (driver.u/features :h2 nil))
                    :tables        [(merge
                                     (mt/obj->json->obj (mt/object-defaults Table))
                                     (db/select-one [Table :created_at :updated_at] :id (mt/id :categories))

--- a/test/metabase/api/field_test.clj
+++ b/test/metabase/api/field_test.clj
@@ -23,7 +23,7 @@
    (dissoc (mt/object-defaults Database) :details)
    {:engine        "h2"
     :name          "test-data"
-    :features      (mapv u/qualified-name (driver.u/features :h2))
+    :features      (mapv u/qualified-name (driver.u/features :h2 nil))
     :timezone      "UTC"}))
 
 (deftest get-field-test

--- a/test/metabase/api/field_test.clj
+++ b/test/metabase/api/field_test.clj
@@ -23,7 +23,7 @@
    (dissoc (mt/object-defaults Database) :details)
    {:engine        "h2"
     :name          "test-data"
-    :features      (mapv u/qualified-name (driver.u/features :h2 nil))
+    :features      (mapv u/qualified-name (driver.u/features :h2 (mt/db)))
     :timezone      "UTC"}))
 
 (deftest get-field-test

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -41,7 +41,7 @@
     :description                 nil
     :caveats                     nil
     :points_of_interest          nil
-    :features                    (mapv u/qualified-name (driver.u/features :h2 nil))
+    :features                    (mapv u/qualified-name (driver.u/features :h2 (mt/db)))
     :cache_field_values_schedule "0 50 0 * * ? *"
     :metadata_sync_schedule      "0 50 * * * ? *"
     :options                     nil

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -41,7 +41,7 @@
     :description                 nil
     :caveats                     nil
     :points_of_interest          nil
-    :features                    (mapv u/qualified-name (driver.u/features :h2))
+    :features                    (mapv u/qualified-name (driver.u/features :h2 nil))
     :cache_field_values_schedule "0 50 0 * * ? *"
     :metadata_sync_schedule      "0 50 * * * ? *"
     :options                     nil

--- a/test/metabase/driver_test.clj
+++ b/test/metabase/driver_test.clj
@@ -7,12 +7,21 @@
 (driver/register! ::test-driver, :abstract? true)
 
 (defmethod driver/supports? [::test-driver :foreign-keys] [_ _] true)
+(defmethod driver/database-supports? [::test-driver :foreign-keys] [_ _ db] (= db "dummy"))
 
 (deftest driver-supports?-test
   (is (= true
          (driver/supports? ::test-driver :foreign-keys)))
   (is (= false
          (driver/supports? ::test-driver :expressions))))
+
+(deftest database-supports?-test
+  (is (= true
+         (driver/database-supports? ::test-driver :foreign-keys "dummy")))
+  (is (= false
+         (driver/database-supports? ::test-driver :foreign-keys "not-dummy")))
+  (is (= false
+         (driver/database-supports? ::test-driver :expressions "dummy"))))
 
 (deftest the-driver-test
   (testing (str "calling `the-driver` should set the context classloader, important because driver plugin code exists "

--- a/test/metabase/driver_test.clj
+++ b/test/metabase/driver_test.clj
@@ -11,21 +11,16 @@
 
 
 (deftest driver-supports?-test
-  (is (= true
-         (driver/supports? ::test-driver :foreign-keys)))
-  (is (= false
-         (driver/supports? ::test-driver :expressions)))
-  (is (thrown? java.lang.Exception
+  (is (driver/supports? ::test-driver :foreign-keys))
+  (is (not (driver/supports? ::test-driver :expressions)))
+  (is (thrown-with-msg? java.lang.Exception #"Invalid driver feature: .*"
                (driver/supports? ::test-driver :some-made-up-thing))))
 
 (deftest database-supports?-test
-  (is (= true
-         (driver/database-supports? ::test-driver :foreign-keys "dummy")))
-  (is (= false
-         (driver/database-supports? ::test-driver :foreign-keys "not-dummy")))
-  (is (= false
-         (driver/database-supports? ::test-driver :expressions "dummy")))
-  (is (thrown? java.lang.Exception
+  (is (driver/database-supports? ::test-driver :foreign-keys "dummy"))
+  (is (not (driver/database-supports? ::test-driver :foreign-keys "not-dummy")))
+  (is (not (driver/database-supports? ::test-driver :expressions "dummy")))
+  (is (thrown-with-msg? java.lang.Exception #"Invalid driver feature: .*"
                (driver/database-supports? ::test-driver :some-made-up-thing "dummy"))))
 
 (deftest the-driver-test
@@ -38,8 +33,6 @@
 
 (deftest available?-test
   (with-redefs [impl/concrete? (constantly true)]
-    (is (= true
-           (driver/available? ::test-driver)))
-    (is (= true
-           (driver/available? "metabase.driver-test/test-driver"))
+    (is (driver/available? ::test-driver))
+    (is (driver/available? "metabase.driver-test/test-driver")
         "`driver/available?` should work for if `driver` is a string -- see #10135")))

--- a/test/metabase/driver_test.clj
+++ b/test/metabase/driver_test.clj
@@ -9,11 +9,14 @@
 (defmethod driver/supports? [::test-driver :foreign-keys] [_ _] true)
 (defmethod driver/database-supports? [::test-driver :foreign-keys] [_ _ db] (= db "dummy"))
 
+
 (deftest driver-supports?-test
   (is (= true
          (driver/supports? ::test-driver :foreign-keys)))
   (is (= false
-         (driver/supports? ::test-driver :expressions))))
+         (driver/supports? ::test-driver :expressions)))
+  (is (thrown? java.lang.Exception
+               (driver/supports? ::test-driver :some-made-up-thing))))
 
 (deftest database-supports?-test
   (is (= true
@@ -21,7 +24,9 @@
   (is (= false
          (driver/database-supports? ::test-driver :foreign-keys "not-dummy")))
   (is (= false
-         (driver/database-supports? ::test-driver :expressions "dummy"))))
+         (driver/database-supports? ::test-driver :expressions "dummy")))
+  (is (thrown? java.lang.Exception
+               (driver/database-supports? ::test-driver :some-made-up-thing "dummy"))))
 
 (deftest the-driver-test
   (testing (str "calling `the-driver` should set the context classloader, important because driver plugin code exists "

--- a/test/metabase/query_processor_test.clj
+++ b/test/metabase/query_processor_test.clj
@@ -13,7 +13,6 @@
             [metabase.query-processor :as qp]
             [metabase.query-processor.middleware.add-implicit-joins :as joins]
             [metabase.test-runner.init :as test-runner.init]
-            [metabase.test :as mt]
             [metabase.test.data :as data]
             [metabase.test.data.env :as tx.env]
             [metabase.test.data.interface :as tx]
@@ -43,7 +42,7 @@
   (let [features (set (cons feature more-features))]
     (set (for [driver (normal-drivers)
                :let   [driver (tx/the-driver-with-test-extensions driver)]
-               :when  (set/subset? features (driver.u/features driver (mt/db)))]
+               :when  (set/subset? features (driver.u/features driver (data/db)))]
            driver))))
 
 (alter-meta! #'normal-drivers-with-feature assoc :arglists (list (into ['&] (sort driver/driver-features))))

--- a/test/metabase/query_processor_test.clj
+++ b/test/metabase/query_processor_test.clj
@@ -42,7 +42,7 @@
   (let [features (set (cons feature more-features))]
     (set (for [driver (normal-drivers)
                :let   [driver (tx/the-driver-with-test-extensions driver)]
-               :when  (set/subset? features (driver.u/features driver))]
+               :when  (set/subset? features (driver.u/features driver nil))]
            driver))))
 
 (alter-meta! #'normal-drivers-with-feature assoc :arglists (list (into ['&] (sort driver/driver-features))))

--- a/test/metabase/query_processor_test.clj
+++ b/test/metabase/query_processor_test.clj
@@ -13,6 +13,7 @@
             [metabase.query-processor :as qp]
             [metabase.query-processor.middleware.add-implicit-joins :as joins]
             [metabase.test-runner.init :as test-runner.init]
+            [metabase.test :as mt]
             [metabase.test.data :as data]
             [metabase.test.data.env :as tx.env]
             [metabase.test.data.interface :as tx]
@@ -42,7 +43,7 @@
   (let [features (set (cons feature more-features))]
     (set (for [driver (normal-drivers)
                :let   [driver (tx/the-driver-with-test-extensions driver)]
-               :when  (set/subset? features (driver.u/features driver nil))]
+               :when  (set/subset? features (driver.u/features driver (mt/db)))]
            driver))))
 
 (alter-meta! #'normal-drivers-with-feature assoc :arglists (list (into ['&] (sort driver/driver-features))))


### PR DESCRIPTION
Whacks #13136 in least code possible, I think, but I'm still convinced that we're never gonna actually feasibly deprecate `supports?`, so I didn't add deprecation keyword