### PR TITLE
Minor test runner/config fixes

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -40,7 +40,7 @@
                               (qp.streaming/streaming-response 1)
                               (prop/for-all 1)
                               (tools.macro/macrolet '(1 (:defn))))))
-                  (cider-clojure-cli-aliases . "dev:drivers:drivers-dev:ee:ee-dev:build:user")
+                  (cider-clojure-cli-aliases . "dev:drivers:drivers-dev:ee:ee-dev:user")
                   (clojure-indent-style . always-align)
                   ;; if you're using clj-refactor (highly recommended!)
                   (cljr-favor-prefix-notation . nil)

--- a/test/metabase/test_runner.clj
+++ b/test/metabase/test_runner.clj
@@ -116,22 +116,25 @@
   "Run `test-vars` with `options`, which are passed directly to [[eftest.runner/run-tests]].
 
     ;; run tests in a single namespace
-    (run (find-tests 'metabase.bad-test) nil)
+    (run (find-tests 'metabase.bad-test))
 
     ;; run tests in a directory
-    (run (find-tests \"test/metabase/query_processor_test\") nil)"
-  [test-vars options]
-  ;; don't randomize test order for now please, thanks anyway
-  (with-redefs [eftest.runner/deterministic-shuffle (fn [_ test-vars] test-vars)]
-    (eftest.runner/run-tests
-     test-vars
-     (merge
-      {:capture-output? false
-       ;; parallel tests disabled for the time being -- some tests randomly fail if the data warehouse connection pool
-       ;; gets nuked by a different thread. Once we fix that we can re-enable parallel tests.
-       :multithread?    false #_:vars
-       :report          (reporter)}
-      options))))
+    (run (find-tests \"test/metabase/query_processor_test\"))"
+  ([test-vars]
+   (run test-vars nil))
+
+  ([test-vars options]
+   ;; don't randomize test order for now please, thanks anyway
+   (with-redefs [eftest.runner/deterministic-shuffle (fn [_ test-vars] test-vars)]
+     (eftest.runner/run-tests
+      test-vars
+      (merge
+       {:capture-output? false
+        ;; parallel tests disabled for the time being -- some tests randomly fail if the data warehouse connection pool
+        ;; gets nuked by a different thread. Once we fix that we can re-enable parallel tests.
+        :multithread?    false #_:vars
+        :report          (reporter)}
+       options)))))
 
 ;;;; `clojure -X` entrypoint
 

--- a/test/metabase/test_runner.clj
+++ b/test/metabase/test_runner.clj
@@ -16,7 +16,6 @@
             [metabase.test-runner.parallel :as parallel]
             [metabase.test.data.env :as tx.env]
             metabase.test.redefs
-            [metabase.util :as u]
             [pjstadig.humane-test-output :as humane-test-output]))
 
 ;; initialize Humane Test Output if it's not already initialized.
@@ -86,7 +85,7 @@
 (defn tests [{:keys [only]}]
   (when only
     (println "Running tests in" (pr-str only)))
-  (let [tests (u/profile "Find tests" (find-tests only))]
+  (let [tests (find-tests only)]
     (println "Running" (count tests) "tests")
     tests))
 

--- a/test/metabase/test_runner/junit/write.clj
+++ b/test/metabase/test_runner/junit/write.clj
@@ -42,9 +42,9 @@
 (defn- print-result-description [{:keys [file line message testing-contexts], :as result}]
   (println (format "%s:%d" file line))
   (doseq [s (reverse testing-contexts)]
-    (println (str/trim (escape-unprintable-characters s))))
+    (println (str/trim (decolorize-and-escape s))))
   (when message
-    (println (escape-unprintable-characters message))))
+    (println (decolorize-and-escape message))))
 
 (defn- print-expected [expected actual]
   (p/rprint "expected: ")


### PR DESCRIPTION
- Fix bug where `metabase.test-runner/find-tests` did not work correctly with a namespace-qualified symbol e.g. `my.namespace-test/my-test`
- Add 1-arity version of `metabase.test-runner/run`
- I was accidentally not using the function to strip out ANSI color codes in JUnit output that I had written just for that purpose
- Remove `:build` alias from default CIDER aliases. It turns out both `tools.build` and `depstar` include the SLF4J `nop` impl (meaning the errors I thought I fixed in #17309 are still showing up) and I don't want to break stuff by adding exclusions all over the place (we're not providing Log4j2 as a SLF4J backend when running the build scripts or `build.clj` on their own, so we'd have no SLF4J backend at all in that situation)