### PR TITLE
XLSX auto-sized columns, frozen header and auto-filters

### DIFF
--- a/src/metabase/query_processor/streaming.clj
+++ b/src/metabase/query_processor/streaming.clj
@@ -76,7 +76,7 @@
                             (for [i output-order] (v i)))
                           deduped-cols)
           viz-settings' (assoc viz-settings :output-order output-order)
-          row-count       (volatile! 0)]
+          row-count     (volatile! 0)]
       (fn
         ([]
          (i/begin! results-writer

--- a/src/metabase/query_processor/streaming.clj
+++ b/src/metabase/query_processor/streaming.clj
@@ -76,7 +76,7 @@
                             (for [i output-order] (v i)))
                           deduped-cols)
           viz-settings' (assoc viz-settings :output-order output-order)
-          row-count     (volatile! 0)]
+          row-count       (volatile! 0)]
       (fn
         ([]
          (i/begin! results-writer

--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -415,17 +415,17 @@
   "Adjusts each column to fit its largest value, plus a constant amount of extra padding."
   [sheet col-count]
   (doseq [i (range col-count)]
-    (.autoSizeColumn sheet i)
-    (.setColumnWidth sheet i (+ (.getColumnWidth sheet i) extra-column-width))
-    (.untrackColumnForAutoSizing sheet i)))
+    (.autoSizeColumn ^Sheet sheet i)
+    (.setColumnWidth ^Sheet sheet i (+ (.getColumnWidth sheet i) extra-column-width))
+    (.untrackColumnForAutoSizing ^Sheet sheet i)))
 
 (defn- setup-header-row!
   "Turns on auto-filter for the header row, which adds a button to each header cell that allows columns to be
   filtered and sorted. Also freezes the header row so that it floats above the data."
   [sheet col-count]
   (when (> col-count 0)
-    (.setAutoFilter sheet (new CellRangeAddress 0 0 0 (dec col-count)))
-    (.createFreezePane sheet 0 1)))
+    (.setAutoFilter ^Sheet sheet (new CellRangeAddress 0 0 0 (dec col-count)))
+    (.createFreezePane ^Sheet sheet 0 1)))
 
 (defmethod i/streaming-results-writer :xlsx
   [_ ^OutputStream os]

--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -450,8 +450,8 @@
             (autosize-columns! sheet (count row)))))
 
       (finish! [_ {:keys [row_count data]}]
-        (when (<= row_count auto-sizing-threshold)
-          ;; Auto-size columns if we never hit the row threshold
+        (when (or (nil? row_count) (<= row_count auto-sizing-threshold))
+          ;; Auto-size columns if we never hit the row threshold, or a final row count was not provided
           (autosize-columns! sheet (count (:cols data))))
         (spreadsheet/save-workbook-into-stream! os workbook)
         (.dispose workbook)

--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -14,6 +14,7 @@
   (:import java.io.OutputStream
            [java.time LocalDate LocalDateTime LocalTime OffsetDateTime OffsetTime ZonedDateTime]
            [org.apache.poi.ss.usermodel Cell DataFormat DateUtil Sheet Workbook]
+           org.apache.poi.ss.util.CellRangeAddress
            org.apache.poi.xssf.streaming.SXSSFWorkbook))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -400,15 +401,43 @@
         (str column-title " (" (currency-identifier merged-settings) ")")
         column-title))))
 
+(def ^:private auto-sizing-threshold
+  "The number of rows used for auto-sizing columns. If this number is too large, exports of large datasets
+  will be prohibitively slow."
+  1000)
+
+(def ^:private extra-column-width
+  "The extra width applied to columns after they have been auto-sized, in units of 1/256 of a character width.
+  This ensures the cells in the header row have enough room for the filter dropdown icon."
+  (* 4 256))
+
+(defn- autosize-columns!
+  "Adjusts each column to fit its largest value, plus a constant amount of extra padding."
+  [sheet col-count]
+  (doseq [i (range col-count)]
+    (.autoSizeColumn sheet i)
+    (.setColumnWidth sheet i (+ (.getColumnWidth sheet i) extra-column-width))
+    (.untrackColumnForAutoSizing sheet i)))
+
+(defn- setup-header-row!
+  "Turns on auto-filter for the header row, which adds a button to each header cell that allows columns to be
+  filtered and sorted. Also freezes the header row so that it floats above the data."
+  [sheet col-count]
+  (when (> col-count 0)
+    (.setAutoFilter sheet (new CellRangeAddress 0 0 0 (dec col-count)))
+    (.createFreezePane sheet 0 1)))
+
 (defmethod i/streaming-results-writer :xlsx
   [_ ^OutputStream os]
   (let [workbook            (SXSSFWorkbook.)
         sheet               (spreadsheet/add-sheet! workbook (tru "Query result"))]
     (reify i/StreamingResultsWriter
       (begin! [_ {{:keys [ordered-cols]} :data} {col-settings ::mb.viz/column-settings}]
+        (.trackAllColumnsForAutoSizing sheet)
+        (setup-header-row! sheet (count ordered-cols))
         (spreadsheet/add-row! sheet (column-titles ordered-cols col-settings)))
 
-      (write-row! [_ row _ ordered-cols {:keys [output-order] :as viz-settings}]
+      (write-row! [_ row row-count ordered-cols {:keys [output-order] :as viz-settings}]
         (let [ordered-row  (if output-order
                              (let [row-v (into [] row)]
                                (for [i output-order] (row-v i)))
@@ -416,9 +445,14 @@
               col-settings (::mb.viz/column-settings viz-settings)
               cell-styles  (cell-style-delays workbook ordered-cols col-settings)]
           (binding [*cell-styles* cell-styles]
-            (add-row! sheet ordered-row ordered-cols col-settings))))
+            (add-row! sheet ordered-row ordered-cols col-settings))
+          (when (= row-count auto-sizing-threshold)
+            (autosize-columns! sheet (count row)))))
 
-      (finish! [_ _]
+      (finish! [_ {:keys [row_count data]}]
+        (when (<= row_count auto-sizing-threshold)
+          ;; Auto-size columns if we never hit the row threshold
+          (autosize-columns! sheet (count (:cols data))))
         (spreadsheet/save-workbook-into-stream! os workbook)
         (.dispose workbook)
         (.close os)))))

--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -15,7 +15,7 @@
            [java.time LocalDate LocalDateTime LocalTime OffsetDateTime OffsetTime ZonedDateTime]
            [org.apache.poi.ss.usermodel Cell DataFormat DateUtil Workbook]
            org.apache.poi.ss.util.CellRangeAddress
-           [org.apache.poi.xssf.streaming SXSSFSheet SXSSFRow SXSSFWorkbook]))
+           [org.apache.poi.xssf.streaming SXSSFRow SXSSFSheet SXSSFWorkbook]))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                         Format string generation                                               |
@@ -414,10 +414,10 @@
 (defn- autosize-columns!
   "Adjusts each column to fit its largest value, plus a constant amount of extra padding."
   [sheet]
-  (doseq [i (.getTrackedColumnsForAutoSizing sheet)]
+  (doseq [i (.getTrackedColumnsForAutoSizing ^SXSSFSheet sheet)]
     (.autoSizeColumn ^SXSSFSheet sheet i)
     (.setColumnWidth ^SXSSFSheet sheet i (+ (.getColumnWidth ^SXSSFSheet sheet i) extra-column-width))
-    (.untrackColumnForAutoSizing sheet i)))
+    (.untrackColumnForAutoSizing ^SXSSFSheet sheet i)))
 
 (defn- setup-header-row!
   "Turns on auto-filter for the header row, which adds a button to each header cell that allows columns to be
@@ -434,7 +434,7 @@
     (reify i/StreamingResultsWriter
       (begin! [_ {{:keys [ordered-cols]} :data} {col-settings ::mb.viz/column-settings}]
         (doseq [i (range (count ordered-cols))]
-          (.trackColumnForAutoSizing sheet i))
+          (.trackColumnForAutoSizing ^SXSSFSheet sheet i))
         (setup-header-row! sheet (count ordered-cols))
         (spreadsheet/add-row! sheet (column-titles ordered-cols col-settings)))
 

--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -451,7 +451,7 @@
             (autosize-columns! sheet))))
 
       (finish! [_ {:keys [row_count]}]
-        (when (or (nil? row_count) (< row_count auto-sizing-threshold))
+        (when (or (nil? row_count) (< row_count *auto-sizing-threshold*))
           ;; Auto-size columns if we never hit the row threshold, or a final row count was not provided
           (autosize-columns! sheet))
         (spreadsheet/save-workbook-into-stream! os workbook)

--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -15,7 +15,7 @@
            [java.time LocalDate LocalDateTime LocalTime OffsetDateTime OffsetTime ZonedDateTime]
            [org.apache.poi.ss.usermodel Cell DataFormat DateUtil Workbook]
            org.apache.poi.ss.util.CellRangeAddress
-           [org.apache.poi.xssf.streaming SXSSFSheet SXSSFWorkbook]))
+           [org.apache.poi.xssf.streaming SXSSFSheet SXSSFRow SXSSFWorkbook]))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                         Format string generation                                               |
@@ -379,7 +379,7 @@
             scaled-val (if (and value (::mb.viz/scale settings))
                          (* value (::mb.viz/scale settings))
                          value)]
-        (set-cell! (.createCell row index) scaled-val id-or-name)))
+        (set-cell! (.createCell ^SXSSFRow row ^Integer index) scaled-val id-or-name)))
     row))
 
 (defn- column-titles

--- a/test/metabase/query_processor/streaming/xlsx_test.clj
+++ b/test/metabase/query_processor/streaming/xlsx_test.clj
@@ -426,20 +426,22 @@
 
 (deftest auto-sizing-test
   (testing "Columns in export are autosized to fit their content"
-    (is (= [2336 8001]
-           (second (xlsx-export [{:id 0, :name "Col1"} {:id 1, :name "Col2"}]
-                                {}
-                                [["a" "abcdefghijklmnopqrstuvwxyz"]]
-                                parse-column-width)))))
+    (let [[col1-width col2-width] (second (xlsx-export [{:id 0, :name "Col1"} {:id 1, :name "Col2"}]
+                                                       {}
+                                                       [["a" "abcdefghijklmnopqrstuvwxyz"]]
+                                                       parse-column-width))]
+      ;; Provide a marign for error since width measurements end up being slightly different on CI
+      (is (<= 2300 col1-width 2400))
+      (is (<= 7950 col2-width 8200))))
   (testing "Auto-sizing works when the number of rows is at or above the auto-sizing threshold"
     (binding [xlsx/*auto-sizing-threshold* 2]
-      (is (= [2815]
-             (second (xlsx-export [{:id 0, :name "Col1"}]
-                                  {}
-                                  [["abcdef"] ["abcedf"]]
-                                  parse-column-width))))
-      (is (= [2815]
-             (second (xlsx-export [{:id 0, :name "Col1"}]
-                                  {}
-                                  [["abcdef"] ["abcdef"] ["abcdef"]]
-                                  parse-column-width)))))))
+      (let [[col-width] (second (xlsx-export [{:id 0, :name "Col1"}]
+                                             {}
+                                             [["abcdef"] ["abcedf"]]
+                                             parse-column-width))]
+        (is (<= 2800 col-width 2850)))
+      (let [[col-width] (second (xlsx-export [{:id 0, :name "Col1"}]
+                                             {}
+                                             [["abcdef"] ["abcedf"] ["abcdef"]]
+                                             parse-column-width))]
+        (is (<= 2800 col-width 2850))))))

--- a/test/metabase/query_processor/streaming/xlsx_test.clj
+++ b/test/metabase/query_processor/streaming/xlsx_test.clj
@@ -439,9 +439,9 @@
                                              {}
                                              [["abcdef"] ["abcedf"]]
                                              parse-column-width))]
-        (is (<= 2800 col-width 2850)))
+        (is (<= 2800 col-width 2900)))
       (let [[col-width] (second (xlsx-export [{:id 0, :name "Col1"}]
                                              {}
                                              [["abcdef"] ["abcedf"] ["abcdef"]]
                                              parse-column-width))]
-        (is (<= 2800 col-width 2850))))))
+        (is (<= 2800 col-width 2900))))))

--- a/test/metabase/query_processor/streaming/xlsx_test.clj
+++ b/test/metabase/query_processor/streaming/xlsx_test.clj
@@ -414,3 +414,11 @@
            (second (xlsx-export [{:name "val1"} {:name "val2"}]
                                 {}
                                 [[(SampleNastyClass. "Hello XLSX World!") (AnotherNastyClass. "No Encoder")]]))))))
+
+(deftest auto-sizing-threshold-test
+  (testing "Export still works when the number of rows is equal to or above the auto-sizing threshold"
+    (with-redefs [xlsx/auto-sizing-threshold 2]
+      (is (= [[1.0] [2.0]]
+             (rest (xlsx-export [{:id 0, :name "Col1"}] {} [[1.0] [2.0]]))))
+      (is (= [[1.0] [2.0] [3.0]]
+             (rest (xlsx-export [{:id 0, :name "Col1"}] {} [[1.0] [2.0] [3.0]])))))))


### PR DESCRIPTION
Auto-sizes columns in XLSX export, freezes header row so that it floats above data, and adds auto-filter menus for the header row so that columns can be sorted and filtered.

Uses a constant number of rows for auto-sizing (currently set to 1000) since otherwise it makes exports of large datasets very slow.

Resolves #9251