### PR TITLE
correct typo in driver prestor -> presto

### DIFF
--- a/modules/drivers/presto/test/metabase/driver/presto_test.clj
+++ b/modules/drivers/presto/test/metabase/driver/presto_test.clj
@@ -118,7 +118,7 @@
            (driver/describe-table :presto (mt/db) (db/select-one 'Table :id (mt/id :venues)))))))
 
 (deftest table-rows-sample-test
-  (mt/test-driver :prestor
+  (mt/test-driver :presto
     (is (= [["Red Medicine"]
             ["Stout Burgers & Beers"]
             ["The Apple Pan"]


### PR DESCRIPTION
`(mt/test-driver :prestor` -> `(mt/test-driver :presto`