### PR TITLE
Remove flow types from Dashboard component

### DIFF
--- a/frontend/src/metabase/dashboard/components/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard.jsx
@@ -3,11 +3,11 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { Box } from "grid-styled";
+import { t } from "ttag";
 
 import DashboardHeader from "./DashboardHeader";
 import DashboardGrid from "./DashboardGrid";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
-import { t } from "ttag";
 import Parameters from "metabase/parameters/components/Parameters/Parameters";
 import EmptyState from "metabase/components/EmptyState";
 import { DashboardSidebars } from "./DashboardSidebars";
@@ -17,120 +17,10 @@ import DashboardControls from "../hoc/DashboardControls";
 import _ from "underscore";
 import cx from "classnames";
 
-import type {
-  LocationDescriptor,
-  ApiError,
-  QueryParams,
-} from "metabase-types/types";
-
-import type { CardId, VisualizationSettings } from "metabase-types/types/Card";
-import type {
-  DashboardWithCards,
-  DashboardId,
-  DashCardId,
-} from "metabase-types/types/Dashboard";
-import type { Revision } from "metabase-types/types/Revision";
-import type {
-  Parameter,
-  ParameterId,
-  ParameterValues,
-  ParameterOption,
-} from "metabase-types/types/Parameter";
-
-type Props = {
-  location: LocationDescriptor,
-
-  dashboardId: DashboardId,
-  dashboard: DashboardWithCards,
-  dashboardBeforeEditing: ?DashboardWithCards,
-  revisions: { [key: string]: Revision[] },
-
-  isAdmin: boolean,
-  isEditable: boolean,
-  isEditing: boolean,
-  isEditingParameter: boolean,
-  isSharing: boolean,
-
-  parameters: Parameter[],
-  parameterValues: ParameterValues,
-
-  addCardOnLoad: DashboardId,
-
-  initialize: () => Promise<void>,
-  addCardToDashboard: ({ dashId: DashCardId, cardId: CardId }) => void,
-  addTextDashCardToDashboard: ({ dashId: DashCardId }) => void,
-  archiveDashboard: (dashboardId: DashboardId) => void,
-  fetchDashboard: (dashboardId: DashboardId, queryParams: ?QueryParams) => void,
-  saveDashboardAndCards: () => Promise<void>,
-  setDashboardAttributes: ({ [attribute: string]: any }) => void,
-  fetchDashboardCardData: (options: {
-    reload: boolean,
-    clear: boolean,
-  }) => Promise<void>,
-  cancelFetchDashboardCardData: () => Promise<void>,
-
-  setEditingParameter: (parameterId: ?ParameterId) => void,
-  setEditingDashboard: (isEditing: false | DashboardWithCards) => void,
-  setSharing: (isSharing: boolean) => void,
-
-  addParameter: (option: ParameterOption) => Promise<Parameter>,
-  removeParameter: (parameterId: ParameterId) => void,
-  setParameterName: (parameterId: ParameterId, name: string) => void,
-  setParameterValue: (parameterId: ParameterId, value: string) => void,
-  setParameterDefaultValue: (
-    parameterId: ParameterId,
-    defaultValue: string,
-  ) => void,
-  setParameterIndex: (parameterId: ParameterId, index: number) => void,
-  isAddParameterPopoverOpen: boolean,
-  showAddParameterPopover: () => void,
-  hideAddParameterPopover: () => void,
-
-  editingParameter: ?Parameter,
-
-  refreshPeriod: number,
-  setRefreshElapsedHook: Function,
-  isFullscreen: boolean,
-  isNightMode: boolean,
-  hideParameters: ?string,
-
-  onRefreshPeriodChange: (?number) => void,
-  onNightModeChange: boolean => void,
-  onFullscreenChange: boolean => void,
-
-  loadDashboardParams: () => void,
-
-  onReplaceAllDashCardVisualizationSettings: (
-    dashcardId: DashCardId,
-    settings: VisualizationSettings,
-  ) => void,
-  onUpdateDashCardVisualizationSettings: (
-    dashcardId: DashCardId,
-    settings: VisualizationSettings,
-  ) => void,
-  onUpdateDashCardColumnSettings: (
-    dashcardId: DashCardId,
-    column: any,
-    settings: VisualizationSettings,
-  ) => void,
-
-  onChangeLocation: string => void,
-  setErrorPage: (error: ApiError) => void,
-
-  onCancel: () => void,
-  onSharingClick: () => void,
-  onEmbeddingClick: () => void,
-};
-
-type State = {
-  error: ?ApiError,
-};
-
 // NOTE: move DashboardControls HoC to container
 @DashboardControls
 export default class Dashboard extends Component {
-  props: Props;
-  state: State = {
+  state = {
     error: null,
     showAddQuestionSidebar: false,
   };
@@ -172,7 +62,7 @@ export default class Dashboard extends Component {
     this.loadDashboard(this.props.dashboardId);
   }
 
-  UNSAFE_componentWillReceiveProps(nextProps: Props) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (this.props.dashboardId !== nextProps.dashboardId) {
       this.loadDashboard(nextProps.dashboardId);
     } else if (
@@ -187,10 +77,11 @@ export default class Dashboard extends Component {
     this.props.cancelFetchDashboardCardData();
   }
 
-  async loadDashboard(dashboardId: DashboardId) {
+  async loadDashboard(dashboardId) {
     this.props.initialize();
 
     this.props.loadDashboardParams();
+
     const {
       addCardOnLoad,
       fetchDashboard,
@@ -215,7 +106,7 @@ export default class Dashboard extends Component {
     }
   }
 
-  setEditing = (isEditing: false | DashboardWithCards) => {
+  setEditing = isEditing => {
     this.props.onRefreshPeriodChange(null);
     this.props.setEditingDashboard(isEditing);
 
@@ -224,7 +115,7 @@ export default class Dashboard extends Component {
     });
   };
 
-  setDashboardAttribute = (attribute: string, value: any) => {
+  setDashboardAttribute = (attribute, value) => {
     this.props.setDashboardAttributes({
       id: this.props.dashboard.id,
       attributes: { [attribute]: value },
@@ -260,6 +151,7 @@ export default class Dashboard extends Component {
       isSharing,
       hideParameters,
     } = this.props;
+
     const { error, showAddQuestionSidebar } = this.state;
     isNightMode = isNightMode && isFullscreen;
 
@@ -294,7 +186,8 @@ export default class Dashboard extends Component {
         className={cx("Dashboard flex-full", {
           "Dashboard--fullscreen": isFullscreen,
           "Dashboard--night": isNightMode,
-          "full-height": isEditing || isSharing, // prevents header from scrolling so we can have a fixed sidebar
+          // prevents header from scrolling so we can have a fixed sidebar
+          "full-height": isEditing || isSharing,
         })}
         loading={!dashboard}
         error={error}


### PR DESCRIPTION
In preparation for #11187

Let's make this file a little bit better.
As the UI is complicated, this will help crystallize the solution for making the filters sticky.

### To Test

Nothing should have changed, just visit a Dashboard and it should work as before.