### PR TITLE
Clean up prop destructuring in Dashboard component file

### DIFF
--- a/frontend/src/metabase/dashboard/components/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard.jsx
@@ -77,21 +77,25 @@ export default class Dashboard extends Component {
   }
 
   async loadDashboard(dashboardId) {
-    this.props.initialize();
-
-    this.props.loadDashboardParams();
-
     const {
       addCardOnLoad,
-      fetchDashboard,
       addCardToDashboard,
-      setErrorPage,
+      fetchDashboard,
+      initialize,
+      loadDashboardParams,
       location,
+      setErrorPage,
     } = this.props;
+
+    initialize();
+
+    loadDashboardParams();
 
     try {
       await fetchDashboard(dashboardId, location.query);
       if (addCardOnLoad != null) {
+        // if we destructure this.props.dashboard, for some reason
+        // if will render dashboards as empty
         this.setEditing(this.props.dashboard);
         addCardToDashboard({ dashId: dashboardId, cardId: addCardOnLoad });
       }

--- a/frontend/src/metabase/dashboard/components/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard.jsx
@@ -77,26 +77,22 @@ export default class Dashboard extends Component {
   }
 
   async loadDashboard(dashboardId) {
+    this.props.initialize();
+
+    this.props.loadDashboardParams();
+
     const {
       addCardOnLoad,
-      addCardToDashboard,
-      dashboard,
       fetchDashboard,
-      initialize,
-      loadDashboardParams,
-      location,
+      addCardToDashboard,
       setErrorPage,
+      location,
     } = this.props;
-
-    initialize();
-
-    loadDashboardParams();
 
     try {
       await fetchDashboard(dashboardId, location.query);
-
       if (addCardOnLoad != null) {
-        this.setEditing(dashboard);
+        this.setEditing(this.props.dashboard);
         addCardToDashboard({ dashId: dashboardId, cardId: addCardOnLoad });
       }
     } catch (error) {
@@ -143,7 +139,6 @@ export default class Dashboard extends Component {
 
   render() {
     const {
-      addParameter,
       dashboard,
       editingParameter,
       hideParameters,
@@ -165,8 +160,9 @@ export default class Dashboard extends Component {
     const { error, showAddQuestionSidebar } = this.state;
     const shouldRenderAsNightMode = isNightMode && isFullscreen;
 
-    const parametersWidget =
-      parameters && parameters.length > 0 ? (
+    let parametersWidget;
+    if (parameters && parameters.length > 0) {
+      parametersWidget = (
         <Parameters
           syncQueryString
           dashboard={dashboard}
@@ -187,7 +183,8 @@ export default class Dashboard extends Component {
           removeParameter={removeParameter}
           setParameterValue={setParameterValue}
         />
-      ) : null;
+      );
+    }
 
     return (
       <LoadingAndErrorWrapper
@@ -210,7 +207,7 @@ export default class Dashboard extends Component {
                 {...this.props}
                 onEditingChange={this.setEditing}
                 setDashboardAttribute={this.setDashboardAttribute}
-                addParameter={addParameter}
+                addParameter={this.props.addParameter}
                 parametersWidget={parametersWidget}
                 onSharingClick={this.onSharingClick}
                 onEmbeddingClick={this.onEmbeddingClick}


### PR DESCRIPTION
⚠️ Please review https://github.com/metabase/metabase/pull/17337 first

<hr />

In preparation for #11187

Let's continue to make this file a little bit better.
As the UI is complicated, this will help crystallize the solution for making the filters sticky.

In this PR we make prop destructuring consistent per function.

Functions that are small and only use up to 3 props continue to use `this.props.propName`.

Functions that use more than 3 props destructure *all* the props that will be used, so no more random calling of destructured prop and `this.prop.propName` inside the same function.

### To Test

Nothing should have changed, just visit your dashboards and they should work as before.