### PR TITLE
Include moderated status on virtual db/table information

### DIFF
--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -461,6 +461,7 @@
                   :schema            "Everything else"
                   :db_id             (:database_id card)
                   :id                card-virtual-table-id
+                  :moderated_status  nil
                   :description       nil
                   :dimension_options (default-dimension-options)
                   :fields            (map (comp #(merge (default-card-field-for-venues card-virtual-table-id) %)
@@ -516,6 +517,7 @@
                     :db_id             (:database_id card)
                     :id                card-virtual-table-id
                     :description       nil
+                    :moderated_status  nil
                     :dimension_options (default-dimension-options)
                     :fields            [{:name                     "NAME"
                                          :display_name             "NAME"


### PR DESCRIPTION
Adds moderated_status to cards when used as a datasource for queries.

![image](https://user-images.githubusercontent.com/6377293/128432114-6d9d0dc8-a3b6-4657-be70-6d048c7a73a1.png)
