### PR TITLE
GitHub Actions: remove the check for Clojure version

### DIFF
--- a/.github/workflows/percy-issue-comment.yml
+++ b/.github/workflows/percy-issue-comment.yml
@@ -61,7 +61,6 @@ jobs:
           echo "Node.js `node --version`"
           echo "yarn `yarn --version`"
           java -version
-          echo "Clojure `clojure -e "(println (clojure-version))"`"
 
       - name: Get yarn cache
         uses: actions/cache@v2
@@ -120,7 +119,6 @@ jobs:
           echo "Node.js `node --version`"
           echo "yarn `yarn --version`"
           java -version
-          echo "Clojure `clojure -e "(println (clojure-version))"`"
       - name: Get yarn cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -42,7 +42,6 @@ jobs:
           echo "Node.js `node --version`"
           echo "yarn `yarn --version`"
           java -version
-          echo "Clojure `clojure -e "(println (clojure-version))"`"
 
       - name: Get yarn cache
         uses: actions/cache@v2
@@ -94,7 +93,6 @@ jobs:
           echo "Node.js `node --version`"
           echo "yarn `yarn --version`"
           java -version
-          echo "Clojure `clojure -e "(println (clojure-version))"`"
       - name: Get yarn cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -39,8 +39,6 @@ jobs:
         echo "Node.js `node --version`"
         echo "yarn `yarn --version`"
         java -version
-        echo "Clojure `clojure -e "(println (clojure-version))"`"
-        clojure --help | grep Version
 
     - name: Get yarn cache
       uses: actions/cache@v2


### PR DESCRIPTION
It's redundant since the job explicitly installs the proper version in the previous step, and also running that prematurely pulls a bunch of JARs from Maven Central.

This should shave 20 seconds from the CI runs.
