### PR TITLE
#17212 Repro: Not possible to apply dashboard ID filter to a nested QB question

### DIFF
--- a/frontend/test/__support__/e2e/commands/api/composite/createQuestionAndDashboard.js
+++ b/frontend/test/__support__/e2e/commands/api/composite/createQuestionAndDashboard.js
@@ -6,6 +6,9 @@ Cypress.Commands.add(
         ({ body: { id: dashboardId } }) => {
           cy.request("POST", `/api/dashboard/${dashboardId}/cards`, {
             cardId: questionId,
+            // Add sane defaults for the dashboard card size
+            sizeX: 8,
+            sizeY: 6,
           });
         },
       );

--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/17212.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/17212.cy.spec.js
@@ -1,0 +1,53 @@
+import {
+  restore,
+  editDashboard,
+  setFilter,
+  popover,
+} from "__support__/e2e/cypress";
+
+import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
+
+const { PRODUCTS_ID } = SAMPLE_DATASET;
+
+const baseQuestion = {
+  query: { "source-table": PRODUCTS_ID },
+};
+
+describe.skip("issue 17212", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.createQuestion(baseQuestion).then(({ body: { id: baseQuestionId } }) => {
+      const questionDetails = {
+        query: { "source-table": `card__${baseQuestionId}` },
+      };
+
+      cy.createQuestionAndDashboard({ questionDetails }).then(
+        ({ body: { card_id, dashboard_id } }) => {
+          cy.intercept("POST", `/api/card/${card_id}/query`).as("cardQuery");
+
+          cy.visit(`/dashboard/${dashboard_id}`);
+
+          cy.wait("@cardQuery");
+        },
+      );
+    });
+  });
+
+  it("should be able to add ID dashboard filter to the nested question (metabase#17212)", () => {
+    editDashboard();
+
+    setFilter("ID");
+
+    cy.findByText("No valid fields").should("not.exist");
+
+    cy.findByText("Column to filter on")
+      .next("a")
+      .click();
+
+    popover()
+      .contains("ID")
+      .click();
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #17212

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/dashboard-filters/reproductions/17212.cy.spec.js`
- Unskip the test
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/128438067-4b4ae911-e3e1-49f6-844c-580fe63cc9a5.png)

