### PR TITLE
Repro for #17339: collection tree should expand/collapse on parent collection name click

### DIFF
--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -132,6 +132,21 @@ describe("scenarios > collection_defaults", () => {
         //
       });
 
+      it.skip("should expand/collapse collection tree by clicking on parent collection name (metabse#17339)", () => {
+        cy.visit("/collection/root");
+
+        sidebar().within(() => {
+          cy.findByText("First collection").click();
+          cy.findByText("Second collection");
+          cy.findByText("Third collection");
+
+          // Warning: There have been some race conditions with the re-rendering in the collection sidebar observed previously.
+          //          Double check that this test works as expected when the underlying issue is fixed. Update as needed.
+          cy.findByText("First collection").click();
+          cy.findByText("Second collection").should("not.exist");
+        });
+      });
+
       describe("deeply nested collection navigation", () => {
         it("should correctly display deep nested collections", () => {
           cy.request("GET", "/api/collection").then(xhr => {


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #17339 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/collections/collections.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/128439893-8f388034-00e4-496f-9933-5bcd88a5187d.png)

