### PR TITLE
Remove Flex/Box prop shorthand in metabase/components

### DIFF
--- a/frontend/src/metabase/components/CollectionEmptyState.jsx
+++ b/frontend/src/metabase/components/CollectionEmptyState.jsx
@@ -21,17 +21,19 @@ const Element = ({
     className="bg-white rounded"
     align="center"
     p={2}
-    w={"300px"}
     mb={1}
-    style={{ boxShadow: `0 1px 4px 1px rgba(0, 0, 0, 0.08)` }}
+    style={{ width: 300, boxShadow: `0 1px 4px 1px rgba(0, 0, 0, 0.08)` }}
   >
     <IconWrapper borderRadius={"99px"} bg={iconBackgroundColor} p={1} mr={1}>
       <Icon name={iconName} color="white" />
     </IconWrapper>
     <Box
-      w={textWidth}
-      bg={color("brand-light")}
-      style={{ height: 8, borderRadius: 99 }}
+      style={{
+        width: textWidth,
+        height: 8,
+        borderRadius: 99,
+        backgroundColor: color("brand-light"),
+      }}
     />
   </Flex>
 );

--- a/frontend/src/metabase/components/ExplorePane.jsx
+++ b/frontend/src/metabase/components/ExplorePane.jsx
@@ -160,9 +160,12 @@ export const ExploreOption = ({ option }: { option: Candidate }) => (
     <Flex
       align="center"
       justify="center"
-      bg={color("accent4")}
-      w="42px"
-      style={{ borderRadius: 6, height: 42 }}
+      style={{
+        backgroundColor: color("accent4"),
+        borderRadius: 6,
+        width: 42,
+        height: 42,
+      }}
       mr={1}
     >
       <Icon name="bolt" size={20} className="flex-no-shrink text-white" />

--- a/frontend/src/metabase/components/Grid.jsx
+++ b/frontend/src/metabase/components/Grid.jsx
@@ -3,7 +3,7 @@ import React from "react";
 import { Box, Flex } from "grid-styled";
 
 export const GridItem = ({ children, w, px, py, ...props }) => (
-  <Box px={px} py={py} {...props} style={{ width: w }}>
+  <Box px={px} py={py} {...props} width={w}>
     {children}
   </Box>
 );

--- a/frontend/src/metabase/components/Grid.jsx
+++ b/frontend/src/metabase/components/Grid.jsx
@@ -3,7 +3,7 @@ import React from "react";
 import { Box, Flex } from "grid-styled";
 
 export const GridItem = ({ children, w, px, py, ...props }) => (
-  <Box w={w} px={px} py={py} {...props}>
+  <Box px={px} py={py} {...props} style={{ width: w }}>
     {children}
   </Box>
 );


### PR DESCRIPTION
This is the prerequisite before we can upgrade styled-components (see #17056).

Old code pattern (note the use of `w` as a shorthand for `width`)
```jsx
<Flex w="42px" style={{ borderRadius: 6, height: 42 }}>
```

which needs to be converted to the new code pattern:
```jsx
<Flex style={{ borderRadius: 6, width: 42, height: 42 }}>
```

*except* when the prop is array, denoting the [responsive styles](https://styled-system.com/responsive-styles/):
```jsx
const ITEM_WIDTHS = [1, 1 / 2, 1 / 3];
<Flex width={ITEM_WIDTHS} style={{ borderRadius: 6, height: 42 }}>
```

*How to verify*

1. Login to Metabase
2. Go to `/`
3. Go to `/collection/root`

With 2 and 3 above, the UI should look exactly like how it was before (in terms of spacing and padding). The modified components are being used in those two routes.

Percy-based visual tests: see #17358.




