### PR TITLE
Include card names in export filenames

### DIFF
--- a/shared/src/metabase/mbql/schema.cljc
+++ b/shared/src/metabase/mbql/schema.cljc
@@ -1155,6 +1155,7 @@
    (s/optional-key :context)      (s/maybe Context)
    (s/optional-key :executed-by)  (s/maybe helpers/IntGreaterThanZero)
    (s/optional-key :card-id)      (s/maybe helpers/IntGreaterThanZero)
+   (s/optional-key :card-name)    (s/maybe helpers/NonBlankString)
    (s/optional-key :dashboard-id) (s/maybe helpers/IntGreaterThanZero)
    (s/optional-key :pulse-id)     (s/maybe helpers/IntGreaterThanZero)
    (s/optional-key :nested?)      (s/maybe s/Bool)

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -622,10 +622,10 @@
   (let [run   (or run
                   ;; param `run` can be used to control how the query is ran, e.g. if you need to
                   ;; customize the `context` passed to the QP
-                  (^:once fn* [query info]
-                   (qp.streaming/streaming-response [context export-format (u/slugify (:card-name info))]
+                  (^:once fn* [query info card-name]
+                   (qp.streaming/streaming-response [context export-format (u/slugify card-name)]
                      (binding [qp.perms/*card-id* card-id]
-                       (qp-runner query (dissoc info :card-name) context)))))
+                       (qp-runner query info context)))))
         card  (api/read-check (db/select-one [Card :name :dataset_query :cache_ttl :collection_id] :id card-id))
         query (-> (assoc (query-for-card card parameters constraints middleware)
                          :async? true)
@@ -634,10 +634,9 @@
         info  {:executed-by  api/*current-user-id*
                :context      context
                :card-id      card-id
-               :card-name    (:name card)
                :dashboard-id dashboard-id}]
     (api/check-not-archived card)
-    (run query info)))
+    (run query info (:name card))))
 
 (api/defendpoint ^:streaming POST "/:card-id/query"
   "Run the query associated with a Card."

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -627,7 +627,7 @@
                          (binding [qp.perms/*card-id* card-id]
                            (qp-runner query info context)))))
         card      (api/read-check (db/select-one [Card :name :dataset_query :cache_ttl :collection_id] :id card-id))
-        card-name (:name (db/select-one [Card :name] :id card-id))
+        card-name (:name card)
         query     (-> (assoc (query-for-card card parameters constraints middleware)
                              :async? true)
                       (update :middleware merge {:js-int-to-string?      true

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -622,10 +622,10 @@
   (let [run   (or run
                   ;; param `run` can be used to control how the query is ran, e.g. if you need to
                   ;; customize the `context` passed to the QP
-                  (^:once fn* [query info card-name]
-                   (qp.streaming/streaming-response [context export-format (u/slugify card-name)]
+                  (^:once fn* [query info]
+                   (qp.streaming/streaming-response [context export-format (u/slugify (:card-name info))]
                      (binding [qp.perms/*card-id* card-id]
-                       (qp-runner query info context)))))
+                       (qp-runner query (dissoc info :card-name) context)))))
         card  (api/read-check (db/select-one [Card :name :dataset_query :cache_ttl :collection_id] :id card-id))
         query (-> (assoc (query-for-card card parameters constraints middleware)
                          :async? true)
@@ -634,9 +634,10 @@
         info  {:executed-by  api/*current-user-id*
                :context      context
                :card-id      card-id
+               :card-name    (:name card)
                :dashboard-id dashboard-id}]
     (api/check-not-archived card)
-    (run query info (:name card))))
+    (run query info)))
 
 (api/defendpoint ^:streaming POST "/:card-id/query"
   "Run the query associated with a Card."

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -622,11 +622,11 @@
   (let [run   (or run
                   ;; param `run` can be used to control how the query is ran, e.g. if you need to
                   ;; customize the `context` passed to the QP
-                  (^:once fn* [query info]
-                   (qp.streaming/streaming-response [context export-format]
+                  (^:once fn* [query info card-name]
+                   (qp.streaming/streaming-response [context export-format (u/slugify card-name)]
                      (binding [qp.perms/*card-id* card-id]
                        (qp-runner query info context)))))
-        card  (api/read-check (Card card-id))
+        card  (api/read-check (db/select-one [Card :name :dataset_query :cache_ttl :collection_id] :id card-id))
         query (-> (assoc (query-for-card card parameters constraints middleware)
                          :async? true)
                   (update :middleware merge {:js-int-to-string?      true
@@ -636,7 +636,7 @@
                :card-id      card-id
                :dashboard-id dashboard-id}]
     (api/check-not-archived card)
-    (run query info)))
+    (run query info (:name card))))
 
 (api/defendpoint ^:streaming POST "/:card-id/query"
   "Run the query associated with a Card."

--- a/src/metabase/api/public.clj
+++ b/src/metabase/api/public.clj
@@ -113,14 +113,15 @@
     (m/mapply card-api/run-query-for-card-async card-id export-format
               :parameters parameters
               :context    :public-question
-              :run        (fn [query info]
-                            (qp.streaming/streaming-response [{:keys [reducedf], :as context} export-format]
-                              (let [context  (assoc context :reducedf (public-reducedf reducedf))
-                                    in-chan  (binding [api/*current-user-permissions-set* (atom #{"/"})]
-                                               (qp-runner query info context))
-                                    out-chan (a/promise-chan (map transform-results))]
-                                (async.u/promise-pipe in-chan out-chan)
-                                out-chan)))
+              :run        (fn [query info card-name]
+                            (qp.streaming/streaming-response
+                             [{:keys [reducedf], :as context} export-format (u/slugify card-name)]
+                             (let [context  (assoc context :reducedf (public-reducedf reducedf))
+                                   in-chan  (binding [api/*current-user-permissions-set* (atom #{"/"})]
+                                              (qp-runner query info context))
+                                   out-chan (a/promise-chan (map transform-results))]
+                               (async.u/promise-pipe in-chan out-chan)
+                               out-chan)))
               options)))
 
 (s/defn ^:private run-query-for-card-with-public-uuid-async

--- a/src/metabase/api/public.clj
+++ b/src/metabase/api/public.clj
@@ -113,9 +113,9 @@
     (m/mapply card-api/run-query-for-card-async card-id export-format
               :parameters parameters
               :context    :public-question
-              :run        (fn [query info card-name]
+              :run        (fn [query info]
                             (qp.streaming/streaming-response
-                             [{:keys [reducedf], :as context} export-format (u/slugify card-name)]
+                             [{:keys [reducedf], :as context} export-format (u/slugify (:card-name info))]
                              (let [context  (assoc context :reducedf (public-reducedf reducedf))
                                    in-chan  (binding [api/*current-user-permissions-set* (atom #{"/"})]
                                               (qp-runner query info context))

--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -84,8 +84,8 @@
                     :context       :pulse ; TODO - we should support for `:dashboard-subscription` and use that to differentiate the two
                     :export-format :api
                     :parameters    params
-                    :run (fn [query & args]
-                           (apply qp/process-query-and-save-with-max-results-constraints! (assoc query :async? false) args))))]
+                    :run (fn [query info _]
+                           (apply qp/process-query-and-save-with-max-results-constraints! (assoc query :async? false) info))))]
       {:card card
        :result result})
     (catch Throwable e

--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -85,7 +85,7 @@
                     :export-format :api
                     :parameters    params
                     :run (fn [query info _]
-                           (apply qp/process-query-and-save-with-max-results-constraints! (assoc query :async? false) info))))]
+                           (qp/process-query-and-save-with-max-results-constraints! (assoc query :async? false) info))))]
       {:card card
        :result result})
     (catch Throwable e

--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -84,7 +84,7 @@
                     :context       :pulse ; TODO - we should support for `:dashboard-subscription` and use that to differentiate the two
                     :export-format :api
                     :parameters    params
-                    :run (fn [query info _]
+                    :run (fn [query info]
                            (qp/process-query-and-save-with-max-results-constraints! (assoc query :async? false) info))))]
       {:card card
        :result result})

--- a/src/metabase/query_processor/streaming.clj
+++ b/src/metabase/query_processor/streaming.clj
@@ -103,8 +103,8 @@
 
 (defn streaming-response*
   "Impl for `streaming-response`."
-  ^StreamingResponse [export-format f]
-  (streaming-response/streaming-response (i/stream-options export-format) [os canceled-chan]
+  ^StreamingResponse [export-format filename-prefix f]
+  (streaming-response/streaming-response (i/stream-options export-format filename-prefix) [os canceled-chan]
     (let [result (try
                    (f (streaming-context export-format os canceled-chan))
                    (catch Throwable e
@@ -130,8 +130,8 @@
   Handles either async or sync QP results, but you should prefer returning sync results so we can handle query
   cancelations properly."
   {:style/indent 1}
-  [[context-binding export-format] & body]
-  `(streaming-response* ~export-format (fn [~context-binding] ~@body)))
+  [[context-binding export-format filename-prefix] & body]
+  `(streaming-response* ~export-format ~filename-prefix (fn [~context-binding] ~@body)))
 
 (defn export-formats
   "Set of valid streaming response formats. Currently, `:json`, `:csv`, `:xlsx`, and `:api` (normal JSON API results

--- a/src/metabase/query_processor/streaming/csv.clj
+++ b/src/metabase/query_processor/streaming/csv.clj
@@ -8,13 +8,15 @@
            java.nio.charset.StandardCharsets))
 
 (defmethod i/stream-options :csv
-  [_ filename-prefix]
-  {:content-type              "text/csv"
-   :status                    200
-   :headers                   {"Content-Disposition" (format "attachment; filename=\"%s_%s.csv\""
-                                                             (or filename-prefix "query_result")
-                                                             (u.date/format (t/zoned-date-time)))}
-   :write-keepalive-newlines? false})
+  ([_]
+   (i/stream-options :csv "query_result"))
+  ([_ filename-prefix]
+   {:content-type              "text/csv"
+    :status                    200
+    :headers                   {"Content-Disposition" (format "attachment; filename=\"%s_%s.csv\""
+                                                              (or filename-prefix "query_result")
+                                                              (u.date/format (t/zoned-date-time)))}
+    :write-keepalive-newlines? false}))
 
 (defmethod i/streaming-results-writer :csv
   [_ ^OutputStream os]

--- a/src/metabase/query_processor/streaming/csv.clj
+++ b/src/metabase/query_processor/streaming/csv.clj
@@ -8,10 +8,11 @@
            java.nio.charset.StandardCharsets))
 
 (defmethod i/stream-options :csv
-  [_]
+  [_ filename-prefix]
   {:content-type              "text/csv"
    :status                    200
-   :headers                   {"Content-Disposition" (format "attachment; filename=\"query_result_%s.csv\""
+   :headers                   {"Content-Disposition" (format "attachment; filename=\"%s_%s.csv\""
+                                                             (or filename-prefix "query_result")
                                                              (u.date/format (t/zoned-date-time)))}
    :write-keepalive-newlines? false})
 

--- a/src/metabase/query_processor/streaming/interface.clj
+++ b/src/metabase/query_processor/streaming/interface.clj
@@ -1,11 +1,10 @@
 (ns metabase.query-processor.streaming.interface
   (:require [potemkin.types :as p.types]))
-
 (defmulti stream-options
   "Options for the streaming response for this specific stream type. See `metabase.async.streaming-response` for all
   available options."
   {:arglists '([export-format] [export-format filename-prefix])}
-  (fn [export-format _] (keyword export-format)))
+  (fn ([export-format & _] (keyword export-format))))
 
 (p.types/defprotocol+ StreamingResultsWriter
   "Protocol for the methods needed to write streaming QP results. This protocol is a higher-level interface to intended

--- a/src/metabase/query_processor/streaming/interface.clj
+++ b/src/metabase/query_processor/streaming/interface.clj
@@ -4,8 +4,8 @@
 (defmulti stream-options
   "Options for the streaming response for this specific stream type. See `metabase.async.streaming-response` for all
   available options."
-  {:arglists '([export-format])}
-  keyword)
+  {:arglists '([export-format] [export-format filename-prefix])}
+  (fn [export-format _] (keyword export-format)))
 
 (p.types/defprotocol+ StreamingResultsWriter
   "Protocol for the methods needed to write streaming QP results. This protocol is a higher-level interface to intended

--- a/src/metabase/query_processor/streaming/json.clj
+++ b/src/metabase/query_processor/streaming/json.clj
@@ -10,10 +10,11 @@
            java.nio.charset.StandardCharsets))
 
 (defmethod i/stream-options :json
-  [_]
+  [_ filename-prefix]
   {:content-type "application/json; charset=utf-8"
    :status       200
-   :headers      {"Content-Disposition" (format "attachment; filename=\"query_result_%s.json\""
+   :headers      {"Content-Disposition" (format "attachment; filename=\"%s_%s.json\""
+                                                (or filename-prefix "query_result")
                                                 (u.date/format (t/zoned-date-time)))}})
 
 (defmethod i/streaming-results-writer :json
@@ -45,7 +46,7 @@
         (.close writer)))))
 
 (defmethod i/stream-options :api
-  [stream-type]
+  [_ _]
   {:content-type "application/json; charset=utf-8"})
 
 (defn- map->serialized-json-kvs

--- a/src/metabase/query_processor/streaming/json.clj
+++ b/src/metabase/query_processor/streaming/json.clj
@@ -10,12 +10,14 @@
            java.nio.charset.StandardCharsets))
 
 (defmethod i/stream-options :json
-  [_ filename-prefix]
-  {:content-type "application/json; charset=utf-8"
-   :status       200
-   :headers      {"Content-Disposition" (format "attachment; filename=\"%s_%s.json\""
-                                                (or filename-prefix "query_result")
-                                                (u.date/format (t/zoned-date-time)))}})
+  ([_]
+   (i/stream-options :json "query_result"))
+  ([_ filename-prefix]
+   {:content-type "application/json; charset=utf-8"
+    :status       200
+    :headers      {"Content-Disposition" (format "attachment; filename=\"%s_%s.json\""
+                                                 (or filename-prefix "query_result")
+                                                 (u.date/format (t/zoned-date-time)))}}))
 
 (defmethod i/streaming-results-writer :json
   [_ ^OutputStream os]
@@ -46,8 +48,8 @@
         (.close writer)))))
 
 (defmethod i/stream-options :api
-  [_ _]
-  {:content-type "application/json; charset=utf-8"})
+  ([_]   (i/stream-options :api nil))
+  ([_ _] {:content-type "application/json; charset=utf-8"}))
 
 (defn- map->serialized-json-kvs
   "{:a 100, :b 200} ; -> \"a\":100,\"b\":200"

--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -13,13 +13,15 @@
            org.apache.poi.xssf.streaming.SXSSFWorkbook))
 
 (defmethod i/stream-options :xlsx
-  [_ filename-prefix]
-  {:content-type              "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-   :write-keepalive-newlines? false
-   :status                    200
-   :headers                   {"Content-Disposition" (format "attachment; filename=\"%s_%s.xlsx\""
-                                                             (or filename-prefix "query_result")
-                                                             (u.date/format (t/zoned-date-time)))}})
+  ([_]
+   (i/stream-options :xlsx "query_result"))
+  ([_ filename-prefix]
+   {:content-type              "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    :write-keepalive-newlines? false
+    :status                    200
+    :headers                   {"Content-Disposition" (format "attachment; filename=\"%s_%s.xlsx\""
+                                                              (or filename-prefix "query_result")
+                                                              (u.date/format (t/zoned-date-time)))}}))
 
 (def ^:dynamic *cell-styles*
   "Holds the CellStyle values used within a spreadsheet so that they can be reused. Excel has a limit

--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -13,11 +13,12 @@
            org.apache.poi.xssf.streaming.SXSSFWorkbook))
 
 (defmethod i/stream-options :xlsx
-  [_]
+  [_ filename-prefix]
   {:content-type              "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
    :write-keepalive-newlines? false
    :status                    200
-   :headers                   {"Content-Disposition" (format "attachment; filename=\"query_result_%s.xlsx\""
+   :headers                   {"Content-Disposition" (format "attachment; filename=\"%s_%s.xlsx\""
+                                                             (or filename-prefix "query_result")
                                                              (u.date/format (t/zoned-date-time)))}})
 
 (def ^:dynamic *cell-styles*

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -596,7 +596,7 @@
                        mt/boolean-ids-and-timestamps
                        :last-edit-info)))))
         (testing "Card should include moderation reviews"
-          (letfn [(clean [mr] (select-keys [mr] [:status :text])) ]
+          (letfn [(clean [mr] (select-keys [mr] [:status :text]))]
             (mt/with-temp* [ModerationReview [review {:moderated_item_id (:id card)
                                                       :moderated_item_type "card"
                                                       :moderator_id (mt/user->id :rasta)

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -10,8 +10,20 @@
             [metabase.api.pivots :as pivots]
             [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
             [metabase.http-client :as http]
-            [metabase.models :refer [Card CardFavorite Collection Dashboard Database ModerationReview
-                                     Pulse PulseCard PulseChannel PulseChannelRecipient Table ViewLog]]
+            [metabase.models
+             :refer
+             [Card
+              CardFavorite
+              Collection
+              Dashboard
+              Database
+              ModerationReview
+              Pulse
+              PulseCard
+              PulseChannel
+              PulseChannelRecipient
+              Table
+              ViewLog]]
             [metabase.models.permissions :as perms]
             [metabase.models.permissions-group :as perms-group]
             [metabase.models.revision :as revision :refer [Revision]]
@@ -22,11 +34,11 @@
             [metabase.query-processor.middleware.results-metadata :as results-metadata]
             [metabase.server.middleware.util :as middleware.u]
             [metabase.test :as mt]
+            [metabase.test.data.users :as test-users]
             [metabase.util :as u]
             [metabase.util.schema :as su]
             [schema.core :as s]
-            [toucan.db :as db]
-            [metabase.test.data.users :as test-users])
+            [toucan.db :as db])
   (:import java.io.ByteArrayInputStream
            java.util.UUID))
 

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -1281,7 +1281,7 @@
       (let [orig card-api/run-query-for-card-async]
         (with-redefs [card-api/run-query-for-card-async (fn [card-id export-format & options]
                                                           (apply orig card-id export-format
-                                                                 :run (fn [{:keys [constraints]} _]
+                                                                 :run (fn [{:keys [constraints]} _ _]
                                                                         {:constraints constraints})
                                                                  options))]
           (testing "Sanity check: this CSV download should not be subject to C O N S T R A I N T S"

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -10,20 +10,8 @@
             [metabase.api.pivots :as pivots]
             [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
             [metabase.http-client :as http]
-            [metabase.models
-             :refer
-             [Card
-              CardFavorite
-              Collection
-              Dashboard
-              Database
-              ModerationReview
-              Pulse
-              PulseCard
-              PulseChannel
-              PulseChannelRecipient
-              Table
-              ViewLog]]
+            [metabase.models :refer [Card CardFavorite Collection Dashboard Database ModerationReview
+                                     Pulse PulseCard PulseChannel PulseChannelRecipient Table ViewLog]]
             [metabase.models.permissions :as perms]
             [metabase.models.permissions-group :as perms-group]
             [metabase.models.revision :as revision :refer [Revision]]
@@ -1294,7 +1282,7 @@
       (let [orig card-api/run-query-for-card-async]
         (with-redefs [card-api/run-query-for-card-async (fn [card-id export-format & options]
                                                           (apply orig card-id export-format
-                                                                 :run (fn [{:keys [constraints]} _ _]
+                                                                 :run (fn [{:keys [constraints]} _]
                                                                         {:constraints constraints})
                                                                  options))]
           (testing "Sanity check: this CSV download should not be subject to C O N S T R A I N T S"

--- a/test/metabase/api/dataset_test.clj
+++ b/test/metabase/api/dataset_test.clj
@@ -157,6 +157,16 @@
                         s/Keyword     s/Any}
                        (most-recent-query-execution-for-query query))))))))
 
+(defn- test-download-response-headers
+  [url]
+  (-> (http-client/client-full-response (test-users/username->token :rasta)
+                                        :post 200 url
+                                        :query (json/generate-string (mt/mbql-query checkins {:limit 1})))
+      :headers
+      (select-keys ["Cache-Control" "Content-Disposition" "Content-Type" "Expires" "X-Accel-Buffering"])
+      (update "Content-Disposition" #(some-> % (str/replace #"query_result_.+(\.\w+)"
+                                                            "query_result_<timestamp>$1")))))
+
 (deftest download-response-headers-test
   (testing "Make sure CSV/etc. download requests come back with the correct headers"
     (is (= {"Cache-Control"       "max-age=0, no-cache, must-revalidate, proxy-revalidate"
@@ -164,13 +174,19 @@
             "Content-Type"        "text/csv"
             "Expires"             "Tue, 03 Jul 2001 06:00:00 GMT"
             "X-Accel-Buffering"   "no"}
-           (-> (http-client/client-full-response (test-users/username->token :rasta)
-                                                 :post 200 "dataset/csv"
-                                                 :query (json/generate-string (mt/mbql-query checkins {:limit 1})))
-               :headers
-               (select-keys ["Cache-Control" "Content-Disposition" "Content-Type" "Expires" "X-Accel-Buffering"])
-               (update "Content-Disposition" #(some-> % (str/replace #"query_result_.+(\.\w+)"
-                                                                                   "query_result_<timestamp>$1"))))))))
+           (test-download-response-headers "dataset/csv")))
+    (is (= {"Cache-Control"       "max-age=0, no-cache, must-revalidate, proxy-revalidate"
+            "Content-Disposition" "attachment; filename=\"query_result_<timestamp>.json\""
+            "Content-Type"        "application/json;charset=utf-8"
+            "Expires"             "Tue, 03 Jul 2001 06:00:00 GMT"
+            "X-Accel-Buffering"   "no"}
+           (test-download-response-headers "dataset/json")))
+    (is (= {"Cache-Control"       "max-age=0, no-cache, must-revalidate, proxy-revalidate"
+            "Content-Disposition" "attachment; filename=\"query_result_<timestamp>.xlsx\""
+            "Content-Type"        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+            "Expires"             "Tue, 03 Jul 2001 06:00:00 GMT"
+            "X-Accel-Buffering"   "no"}
+           (test-download-response-headers "dataset/xlsx")))))
 
 (deftest check-that-we-can-export-the-results-of-a-nested-query
   (mt/with-temp-copy-of-db


### PR DESCRIPTION
Includes slugs of card names as the prefix for export filenames, like `my_awesome_card_<timestamp>` rather than `query_result_<timestamp>`.

Doesn't change anything for unsaved cards since there's no clear name to use. Also doesn't include the filters in the filename, as @paoliniluis requested on the issue. We should include filters in the export at some point, but that's being tracked by #7157. 

Resolves #8280