### PR TITLE
Fix column settings button if column settings side bar is already open

### DIFF
--- a/frontend/src/metabase/query_builder/reducers.js
+++ b/frontend/src/metabase/query_builder/reducers.js
@@ -169,6 +169,7 @@ export const uiControls = handleActions(
     [SHOW_CHART_SETTINGS]: {
       next: (state, { payload }) => ({
         ...state,
+        ...UI_CONTROLS_SIDEBAR_DEFAULTS,
         isShowingChartSettingsSidebar: true,
         initialChartSetting: payload,
       }),

--- a/frontend/src/metabase/visualizations/components/settings/ChartNestedSettingColumns.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartNestedSettingColumns.jsx
@@ -56,6 +56,27 @@ class ColumnWidgets extends React.Component {
     }
   }
 
+  componentDidUpdate(prevProps) {
+    const {
+      setSidebarPropsOverride,
+      object,
+      onEndShowWidget,
+      currentSectionHasColumnSettings,
+    } = this.props;
+
+    if (
+      displayNameForColumn(object) !== displayNameForColumn(prevProps.object) ||
+      onEndShowWidget !== prevProps.onEndShowWidget
+    ) {
+      if (setSidebarPropsOverride && !currentSectionHasColumnSettings) {
+        setSidebarPropsOverride({
+          title: displayNameForColumn(object),
+          onBack: onEndShowWidget,
+        });
+      }
+    }
+  }
+
   componentWillUnmount() {
     const { setSidebarPropsOverride } = this.props;
     if (setSidebarPropsOverride) {

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingNestedSettings.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingNestedSettings.jsx
@@ -64,29 +64,9 @@ const chartSettingNestedSettings = ({
 
     constructor(props: Props) {
       super(props);
-      this.state = {
-        editingObjectKey:
-          props.initialKey ||
-          (props.objects.length === 1 ? getObjectKey(props.objects[0]) : null),
-      };
-    }
-
-    UNSAFE_componentWillReceiveProps(nextProps: Props) {
-      // reset editingObjectKey if there's only one object
-      if (
-        nextProps.objects.length === 1 &&
-        this.state.editingObjectKey !== getObjectKey(nextProps.objects[0])
-      ) {
-        this.setState({
-          editingObjectKey: getObjectKey(nextProps.objects[0]),
-        });
-      }
     }
 
     handleChangeEditingObject = (editingObject: ?NestedObject) => {
-      this.setState({
-        editingObjectKey: editingObject ? getObjectKey(editingObject) : null,
-      });
       // special prop to notify ChartSettings it should unswap replaced widget
       if (!editingObject && this.props.onEndShowWidget) {
         this.props.onEndShowWidget();
@@ -94,9 +74,11 @@ const chartSettingNestedSettings = ({
     };
 
     handleChangeSettingsForEditingObject = (newSettings: Settings) => {
-      const { editingObjectKey } = this.state;
-      if (editingObjectKey) {
-        this.handleChangeSettingsForObjectKey(editingObjectKey, newSettings);
+      if (this.props.initialKey) {
+        this.handleChangeSettingsForObjectKey(
+          this.props.initialKey,
+          newSettings,
+        );
       }
     };
 
@@ -126,7 +108,7 @@ const chartSettingNestedSettings = ({
 
     render() {
       const { series, objects, extra } = this.props;
-      const { editingObjectKey } = this.state;
+      const editingObjectKey = this.props.initialKey;
 
       if (editingObjectKey) {
         const editingObject = _.find(

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingNestedSettings.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingNestedSettings.jsx
@@ -66,6 +66,15 @@ const chartSettingNestedSettings = ({
       super(props);
     }
 
+    getEditingObjectKey = () => {
+      return (
+        this.props.initialKey ||
+        (this.props.objects.length === 1
+          ? getObjectKey(this.props.objects[0])
+          : null)
+      );
+    };
+
     handleChangeEditingObject = (editingObject: ?NestedObject) => {
       // special prop to notify ChartSettings it should unswap replaced widget
       if (!editingObject && this.props.onEndShowWidget) {
@@ -74,7 +83,7 @@ const chartSettingNestedSettings = ({
     };
 
     handleChangeSettingsForEditingObject = (newSettings: Settings) => {
-      if (this.props.initialKey) {
+      if (this.getEditingObjectKey()) {
         this.handleChangeSettingsForObjectKey(
           this.props.initialKey,
           newSettings,
@@ -108,11 +117,7 @@ const chartSettingNestedSettings = ({
 
     render() {
       const { series, objects, extra } = this.props;
-      const editingObjectKey =
-        this.props.initialKey ||
-        (this.props.objects.length === 1
-          ? getObjectKey(this.props.objects[0])
-          : null);
+      const editingObjectKey = this.getEditingObjectKey();
       if (editingObjectKey) {
         const editingObject = _.find(
           objects,

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingNestedSettings.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingNestedSettings.jsx
@@ -108,8 +108,11 @@ const chartSettingNestedSettings = ({
 
     render() {
       const { series, objects, extra } = this.props;
-      const editingObjectKey = this.props.initialKey ||
-        (this.props.objects.length === 1 ? getObjectKey(this.props.objects[0]) : null)
+      const editingObjectKey =
+        this.props.initialKey ||
+        (this.props.objects.length === 1
+          ? getObjectKey(this.props.objects[0])
+          : null);
       if (editingObjectKey) {
         const editingObject = _.find(
           objects,

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingNestedSettings.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingNestedSettings.jsx
@@ -108,8 +108,8 @@ const chartSettingNestedSettings = ({
 
     render() {
       const { series, objects, extra } = this.props;
-      const editingObjectKey = this.props.initialKey;
-
+      const editingObjectKey = this.props.initialKey ||
+        (this.props.objects.length === 1 ? getObjectKey(this.props.objects[0]) : null)
       if (editingObjectKey) {
         const editingObject = _.find(
           objects,

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingNestedSettings.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingNestedSettings.jsx
@@ -83,11 +83,9 @@ const chartSettingNestedSettings = ({
     };
 
     handleChangeSettingsForEditingObject = (newSettings: Settings) => {
-      if (this.getEditingObjectKey()) {
-        this.handleChangeSettingsForObjectKey(
-          this.props.initialKey,
-          newSettings,
-        );
+      const editingObjectKey = this.getEditingObjectKey();
+      if (editingObjectKey) {
+        this.handleChangeSettingsForObjectKey(editingObjectKey, newSettings);
       }
     };
 

--- a/frontend/test/metabase/scenarios/question/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/settings.cy.spec.js
@@ -164,7 +164,13 @@ describe("scenarios > question > settings", () => {
       popover().within(() => cy.icon("gear").click()); // open subtotal column settings
 
       cy.findByText("Table options").should("not.exist"); // no longer displaying the top level settings
-      cy.findByText("Column title"); // shows subtotal column settings
+      cy.findByText("Separator style"); // shows subtotal column settings
+
+      cy.get(".TableInteractive")
+        .findByText("Created At")
+        .click(); // open created_at column header actions
+      popover().within(() => cy.icon("gear").click()); // open created_at column settings
+      cy.findByText("Date style"); // shows created_at column settings
     });
   });
 


### PR DESCRIPTION
I kept running into this issue while working on export formatting so I figured I'd try to fix it.

* Changed `ChartSettingNestedSettings` into a fully controlled component rather than storing `editingObjectKey` in the state
* Added a `componentDidUpdate` method on `ChartNestedSettingsColumn` to update sidebar setting title and `onBack` link when the open column is changed
* Added defaults to the `SHOW_CHART_SETTINGS` reducer -- this fixes scenario 3 in [this comment](https://github.com/metabase/metabase/issues/16043#issuecomment-855229092)

Resolves #16043 