### PR TITLE
use target of 'web' when using webpack-dev-server

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -174,6 +174,7 @@ const config = (module.exports = {
 });
 
 if (NODE_ENV === "hot") {
+  config.target = "web";
   // suffixing with ".hot" allows us to run both `yarn run build-hot` and `yarn run test` or `yarn run test-watch` simultaneously
   config.output.filename = "[name].hot.bundle.js?[contenthash]";
 


### PR DESCRIPTION
Fixes #17332

Please test this out locally to verify that it works for you.

For whatever reason there seems to be an issue with webpack refreshing itself when using a `browserslist`. The solution I found in some random github issues is to use `target: "web"` when running dev.