### PR TITLE
Visual tests for some important URLs post on-boarding

### DIFF
--- a/frontend/test/metabase-visual/onboarding/urls.cy.spec.js
+++ b/frontend/test/metabase-visual/onboarding/urls.cy.spec.js
@@ -7,22 +7,50 @@ describe("visual tests > onboarding > URLs", () => {
   });
 
   it("home", () => {
+    cy.intercept("GET", `/api/automagic-dashboards`).as("automagic-dashboards");
     cy.visit("/");
+
+    cy.wait("@automagic-dashboards");
+
+    cy.findByText("Reviews table");
+    cy.findByText("First collection");
+    cy.findByText("Sample Dataset");
+
     cy.percySnapshot();
   });
 
   it("root collection", () => {
+    cy.intercept("GET", `api/collection/root/items`).as("collection-items");
     cy.visit("/collection/root");
+
+    // Twice, one for pinned items and another for dashboard
+    cy.wait("@collection-items");
+    cy.wait("@collection-items");
+
+    cy.findByText("First collection");
+    cy.findByText("Your personal collection");
+
     cy.percySnapshot();
   });
 
   it("browse", () => {
+    cy.intercept("GET", `api/database`).as("database");
     cy.visit("/browse/");
+
+    cy.wait("@database");
+    cy.findByText("Sample Dataset");
+
     cy.percySnapshot();
   });
 
   it("browse/1 (Sample Dataset)", () => {
+    cy.intercept("GET", `api/database/1/schemas`).as("schemas");
     cy.visit("/browse/1");
+
+    cy.wait("@schemas");
+    cy.findByText("Sample Dataset");
+    cy.findByText("Reviews");
+
     cy.percySnapshot();
   });
 });

--- a/frontend/test/metabase-visual/onboarding/urls.cy.spec.js
+++ b/frontend/test/metabase-visual/onboarding/urls.cy.spec.js
@@ -1,0 +1,28 @@
+import { restore } from "__support__/e2e/cypress";
+
+describe("visual tests > onboarding > URLs", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsNormalUser();
+  });
+
+  it("home", () => {
+    cy.visit("/");
+    cy.percySnapshot();
+  });
+
+  it("root collection", () => {
+    cy.visit("/collection/root");
+    cy.percySnapshot();
+  });
+
+  it("browse", () => {
+    cy.visit("/browse/");
+    cy.percySnapshot();
+  });
+
+  it("browse/1 (Sample Dataset)", () => {
+    cy.visit("/browse/1");
+    cy.percySnapshot();
+  });
+});


### PR DESCRIPTION
This is to establish the visual baseline before the forthcoming Flex/Box tweaks (see #17345).

To check locally, run `yarn test-visual-open`and choose the new spec.

Note that I picked `frontend/test/metabase-visual/onboarding/urls.cy.spec.js` as the spec filename to stay consistent with the E2E (but non-visual) tests in `frontend/test/metabase/scenarios/onboarding/urls.cy.spec.js`. But, if there's a better idea for the naming, I'm all ears.