### PR TITLE
Java + Spark SQL prep steps should delete target dir on failure

### DIFF
--- a/java/build.clj
+++ b/java/build.clj
@@ -1,9 +1,19 @@
 (ns build
-  (:require [clojure.tools.build.api :as b]))
+  (:require [clojure.pprint :as pprint]
+            [clojure.tools.build.api :as b]))
+
+(def target-dir "target/classes")
 
 (defn compile-java [_]
-  (b/javac
-   {:src-dirs   ["."]
-    :class-dir  "target/classes"
-    :basis      (b/create-basis {:aliases #{:compilation-basis}})
-    :javac-opts ["-source" "8", "-target" "8"]}))
+  (b/delete {:path target-dir})
+  (try
+    (b/javac
+     {:src-dirs   ["."]
+      :class-dir  target-dir
+      :basis      (b/create-basis {:aliases #{:compilation-basis}})
+      :javac-opts ["-source" "8", "-target" "8"]})
+    (catch Throwable e
+      (println "Error compiling Java sources:" (ex-message e))
+      (pprint/pprint (Throwable->map e))
+      (b/delete {:path target-dir})
+      (throw e))))

--- a/modules/drivers/sparksql/build.clj
+++ b/modules/drivers/sparksql/build.clj
@@ -2,15 +2,19 @@
   (:require [clojure.pprint :as pprint]
             [clojure.tools.build.api :as b]))
 
+(def target-dir "target/classes")
+
 (defn aot [_]
+  (b/delete {:path target-dir})
   (try
     (b/compile-clj
      {:src-dirs   ["src"]
-      :class-dir  "target/classes"
+      :class-dir  target-dir
       :basis      (b/create-basis {:aliases #{:compilation-basis}})
       :ns-compile '[metabase.driver.FixedHiveConnection
                     metabase.driver.FixedHiveDriver]})
     (catch Throwable e
       (println "Error AOT compiling Spark SQL namespaces:" (ex-message e))
       (pprint/pprint (Throwable->map e))
+      (b/delete {:path target-dir})
       (throw e))))


### PR DESCRIPTION
`clojure -X:deps prep` checks for the presence of a certain target directory to decide if it needs to run -- if it's present, there's nothing to do. If for some reason Java source compilation or Spark SQL AOT namespace compilation fails _after_ it creates the target directory, `clojure -X:deps prep` can incorrectly think everything is g2g, which can lead to pretty confusing errors (@howonlee ran in to this earlier this week).

This PR wraps the compilation steps in a try-catch and deletes the target dir if an Exception gets thrown. This will prevent the `prep` step from thinking it succeeded on subsequent runs