### PR TITLE
fix percy bot command

### DIFF
--- a/.github/workflows/percy-issue-comment.yml
+++ b/.github/workflows/percy-issue-comment.yml
@@ -54,8 +54,8 @@ jobs:
           java-version: 8
       - name: Install Clojure CLI
         run: |
-          curl -O https://download.clojure.org/install/linux-install-1.10.1.708.sh &&
-          sudo bash ./linux-install-1.10.1.708.sh
+          curl -O https://download.clojure.org/install/linux-install-1.10.3.933.sh &&
+          sudo bash ./linux-install-1.10.3.933.sh
       - name: Check versions
         run: |
           echo "Node.js `node --version`"
@@ -112,8 +112,8 @@ jobs:
           java-version: 8
       - name: Install Clojure CLI
         run: |
-          curl -O https://download.clojure.org/install/linux-install-1.10.1.708.sh &&
-          sudo bash ./linux-install-1.10.1.708.sh
+          curl -O https://download.clojure.org/install/linux-install-1.10.3.933.sh &&
+          sudo bash ./linux-install-1.10.3.933.sh
       - name: Check versions
         run: |
           echo "Node.js `node --version`"


### PR DESCRIPTION
### Description

After moving away from `lein` it looks like PercyIssueComment job is broken. We have to update Clojure CLI version.