### PR TITLE
Add clojure -T:prep prep to do all prep steps at once; shave 6 seconds off of CI time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -602,11 +602,8 @@ jobs:
           steps:
             - restore-be-deps-cache
             - run:
-                name: Compile Java source file(s)
-                command: clojure -X:deps prep
-            - run:
-                name: Compile driver AOT namespaces
-                command: cd modules/drivers && clojure -X:deps prep
+                name: Compile Java source file(s) and driver AOT namespaces
+                command: clojure -T:prep prep
             - run:
                 name: Fetch dependencies
                 command: clojure -P -X:dev:ci:ee:ee-dev:drivers:drivers-dev

--- a/bin/build-drivers/deps.edn
+++ b/bin/build-drivers/deps.edn
@@ -8,7 +8,7 @@
   hiccup/hiccup                   {:mvn/version "1.0.5"}
   io.forward/yaml                 {:mvn/version "1.0.9"} ; Don't upgrade yet, new version doesn't support Java 8 (see https://github.com/owainlewis/yaml/issues/37)
   io.github.clojure/tools.build   {:git/tag "v0.1.6", :git/sha "5636e61"}
-  org.clojure/tools.deps.alpha    {:mvn/version "0.12.985"}
+  org.clojure/tools.deps.alpha    {:mvn/version "0.12.1003"}
   org.flatland/ordered            {:mvn/version "1.5.9"} ; used by io.forward/yaml -- need the newer version
   stencil/stencil                 {:mvn/version "0.5.0"}
   ;; local source

--- a/bin/prep.sh
+++ b/bin/prep.sh
@@ -13,48 +13,18 @@ clear_cpcaches() {
     done
 }
 
-compile_java_sources() {
-    cd "$project_root"
-
-    echo "Compile Java source files in $project_root/java if needed..."
-    if [ ! -d "$project_root/java/target/classes" ]; then
-        echo 'Compile Java source files'
-        cd "$project_root"
-        clojure -Sforce -X:deps prep
-    else
-        echo 'Java source files are already compiled'
-    fi
-}
-
-compile_spark_sql_aot_sources() {
-    cd "$project_root"
-
-    echo "Compile Spark SQL AOT source files in $project_root/modules/drivers/sparksql if needed..."
-    if [ ! -d "$project_root/modules/drivers/sparksql/target/classes" ]; then
-        echo 'Compile Spark SQL AOT source files'
-        cd "$project_root/modules/drivers"
-        clojure -Sforce -X:deps prep
-    else
-        echo 'Spark SQL AOT source files are already compiled'
-    fi
+do_prep() {
+    clojure -Sforce -T:prep prep && echo "Sources => READY ✅"
 }
 
 prep_deps() {
-    if compile_java_sources; then
-        echo "Java sources => OK"
-    else
-        echo 'Compilation failed (WHY?!); clearing classpath caches and trying again...'
-        clear_cpcaches
-        compile_java_sources
-    fi
-
-    if compile_spark_sql_aot_sources; then
-        echo "Spark SQL AOT sources => OK"
-    else
-        echo 'Compilation failed (WHY?!); clearing classpath caches and trying again...'
-        clear_cpcaches
-        compile_spark_sql_aot_sources
-    fi
-
     cd "$project_root"
+    if [ ! -d "$project_root/java/target/classes" ] || [ ! -d "$project_root/modules/drivers/sparksql/target/classes" ]; then
+        echo "Compiling Java and AOT sources..."
+        if ! do_prep; then
+            echo "Compilation failed! clearing classpath caches and trying again..."
+            clear_cpcaches
+            do_prep
+        fi
+    fi
 }

--- a/deps.edn
+++ b/deps.edn
@@ -364,6 +364,13 @@
                 metabase/buid-mb                {:local/root "bin/build-mb"}}
    :ns-default build}
 
+  ;; convenience that preps (including aliases) everything in one step. Easier than running `clojure -X:deps prep` twice.
+  ;; clojure -T:prep prep
+  :prep
+  {:deps       {org.clojure/tools.deps.alpha {:mvn/version "0.12.1003"}}
+   :ns-default prep
+   :exec-args  {:aliases #{:drivers}}}
+
 ;;; Other misc convenience aliases
 
   ;; Profile Metabase start time with clojure -M:profile

--- a/prep.clj
+++ b/prep.clj
@@ -1,0 +1,17 @@
+(ns prep
+  (:require [clojure.tools.deps.alpha :as deps]))
+
+(defn edn []
+  (deps/merge-edns ((juxt :root-edn :user-edn :project-edn) (deps/find-edn-maps))))
+
+(defn basis [{:keys [aliases]}]
+  (let [edn            (edn)
+        combined-alias (deps/combine-aliases edn (set aliases))]
+    (deps/calc-basis edn {:resolve-args combined-alias, :classpath-args combined-alias})))
+
+(defn prep* [basis]
+  (deps/prep-libs! (:libs basis) {:action :prep} basis))
+
+(defn prep [{:keys [aliases], :as options}]
+  (println "Prepping deps including aliases" (pr-str aliases) "...")
+  (prep* (basis options)))


### PR DESCRIPTION
Adds a new `-T` command to do all of our prep steps at once. 

```sh
clojure -T:prep prep
```

now does the equivalent of

```sh
clojure -X:deps prep 
cd modules/drivers
clojure -X:deps prep
cd ../..
```

but does it in a single process, so it's a bit faster. 13 seconds instead of 19 in a fresh repo and 3 seconds instead of 7 on subsequent calls on my machine... that's 6 seconds shaved off of the `be-deps` step in CI which blocks basically everything else