### PR TITLE
#17211 Repro: No matching dashboard filter found when it clearly has been found 

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/17211.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/17211.cy.spec.js
@@ -1,0 +1,74 @@
+import { restore, filterWidget } from "__support__/e2e/cypress";
+
+import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
+
+const { ORDERS, ORDERS_ID, PEOPLE } = SAMPLE_DATASET;
+
+const questionDetails = {
+  query: {
+    "source-table": ORDERS_ID,
+  },
+};
+
+const filter = {
+  name: "Location",
+  slug: "location",
+  id: "96917420",
+  type: "string/=",
+  sectionId: "location",
+};
+
+describe.skip("issue 17211", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.createQuestionAndDashboard({ questionDetails }).then(
+      ({ body: { id, card_id, dashboard_id } }) => {
+        cy.addFilterToDashboard({ filter, dashboard_id });
+
+        cy.request("PUT", `/api/dashboard/${dashboard_id}/cards`, {
+          cards: [
+            {
+              id,
+              card_id,
+              row: 0,
+              col: 0,
+              sizeX: 8,
+              sizeY: 6,
+              series: [],
+              visualization_settings: {},
+              parameter_mappings: [
+                {
+                  parameter_id: filter.id,
+                  card_id,
+                  target: [
+                    "dimension",
+                    [
+                      "field",
+                      PEOPLE.CITY,
+                      {
+                        "source-field": ORDERS.USER_ID,
+                      },
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+        });
+
+        cy.visit(`/dashboard/${dashboard_id}`);
+      },
+    );
+  });
+
+  it("should not falsely alert that no matching dashboard filter has been found (metabase#17211)", () => {
+    filterWidget().click();
+
+    cy.findByPlaceholderText("Search by City").type("abb");
+    cy.findByText("Abbeville").click();
+
+    cy.contains("No matching City found").should("not.exist");
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #17211

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/dashboard-filters/reproductions/17211.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/128580041-bbdb748c-2615-459f-aff1-86e811855eee.png)

