### PR TITLE
add unit tests for (most) metabase-lib/metadata classes

### DIFF
--- a/frontend/src/metabase-lib/lib/metadata/Base.unit.spec.js
+++ b/frontend/src/metabase-lib/lib/metadata/Base.unit.spec.js
@@ -1,0 +1,53 @@
+import Base from "./Base";
+
+describe("Base", () => {
+  describe("instantiation", () => {
+    it("should set properties from `object` on the Base instance", () => {
+      const instance = new Base({ abc: 123 });
+      expect(instance.abc).toEqual(123);
+    });
+
+    it("should set ALL enumerable properties of `object`, including properties down the prototype chain", () => {
+      const object = {
+        abc: 123,
+      };
+
+      Object.defineProperty(object, "anEnumerableProperty", {
+        enumerable: false,
+        value: false,
+      });
+
+      object.__proto__ = {
+        secretPrototypeValue: true,
+      };
+
+      const instance = new Base(object);
+
+      expect(instance.abc).toEqual(123);
+      expect(instance.secretPrototypeValue).toBe(true);
+      expect(instance.anEnumerableProperty).toBeUndefined();
+    });
+  });
+
+  describe("getPlainObject", () => {
+    it("returns whatever `object` was provided during instantiation", () => {
+      const obj = {
+        abc: 123,
+      };
+
+      const instance = new Base(obj);
+
+      expect(instance.getPlainObject()).toBe(obj);
+    });
+
+    it("returns whatever `_plainObject` is set to", () => {
+      const obj1 = {};
+      const obj2 = {};
+
+      const instance = new Base(obj1);
+      instance._plainObject = obj2;
+
+      expect(instance.getPlainObject()).toBe(obj2);
+    });
+  });
+});

--- a/frontend/src/metabase-lib/lib/metadata/Database.unit.spec.js
+++ b/frontend/src/metabase-lib/lib/metadata/Database.unit.spec.js
@@ -1,0 +1,247 @@
+import Database from "./Database";
+import Schema from "./Schema";
+import Metadata from "./Metadata";
+import Table from "./Table";
+import Base from "./Base";
+import Question from "../Question";
+
+describe("Database", () => {
+  describe("instantiation", () => {
+    it("should create an instance of Schema", () => {
+      expect(new Database()).toBeInstanceOf(Database);
+    });
+
+    it("should add `object` props to the instance (because it extends Base)", () => {
+      expect(new Database()).toBeInstanceOf(Base);
+      expect(new Database({ foo: "bar" })).toHaveProperty("foo", "bar");
+    });
+  });
+
+  describe("displayName", () => {
+    it("should return the name prop", () => {
+      expect(new Database({ name: "foo" }).displayName()).toBe("foo");
+    });
+  });
+
+  describe("schema", () => {
+    let schema;
+    let database;
+    beforeEach(() => {
+      schema = new Schema({ id: "123:foo" });
+      const metadata = new Metadata({
+        schemas: {
+          "123:foo": schema,
+        },
+      });
+      database = new Database({
+        id: 123,
+        metadata,
+      });
+    });
+
+    it("should return the schema with the given name", () => {
+      expect(database.schema("foo")).toBe(schema);
+    });
+
+    it("should return null when the given schema name doesn not match a schema", () => {
+      expect(database.schema("bar")).toBe(null);
+    });
+  });
+
+  describe("schemaNames", () => {
+    it("should return a list of schemaNames", () => {
+      const database = new Database({
+        id: 123,
+        schemas: [
+          new Schema({ id: "123:foo", name: "foo" }),
+          new Schema({ id: "123:bar", name: "bar" }),
+        ],
+      });
+      expect(database.schemaNames()).toEqual(["bar", "foo"]);
+    });
+  });
+
+  describe("tablesLookup", () => {
+    it("should return a map of tables keyed by id", () => {
+      const table1 = new Table({ id: 1 });
+      const table2 = new Table({ id: 2 });
+
+      expect(
+        new Database({
+          tables: [],
+        }).tablesLookup(),
+      ).toEqual({});
+
+      expect(
+        new Database({
+          tables: [table1, table2],
+        }).tablesLookup(),
+      ).toEqual({
+        1: table1,
+        2: table2,
+      });
+    });
+  });
+
+  describe("hasFeature", () => {
+    beforeEach(() => {});
+
+    it("returns true when given a falsy `feature`", () => {
+      expect(new Database({}).hasFeature(null)).toBe(true);
+      expect(new Database({}).hasFeature("")).toBe(true);
+    });
+
+    it("should return true when given `feature` is found within the `features` on the instance", () => {
+      expect(new Database({ features: ["foo"] }).hasFeature("foo")).toBe(true);
+    });
+
+    it("should return false when given `feature` is not found within the `features` on the instance", () => {
+      expect(new Database({ features: ["foo"] }).hasFeature("bar")).toBe(false);
+    });
+
+    it("should return false for 'join' even when it exists in `features`", () => {
+      expect(new Database({ features: ["join"] }).hasFeature("join")).toBe(
+        false,
+      );
+    });
+
+    it("should return true for 'join' for a set of other values", () => {
+      ["left-join", "right-join", "inner-join", "full-join"].forEach(
+        feature => {
+          expect(new Database({ features: [feature] }).hasFeature("join")).toBe(
+            true,
+          );
+        },
+      );
+    });
+  });
+
+  describe("supportsPivots", () => {
+    it("returns true when `expressions` and `left-join` exist in `features`", () => {
+      expect(
+        new Database({
+          features: ["foo", "left-join"],
+        }).supportsPivots(),
+      ).toBe(false);
+
+      expect(
+        new Database({
+          features: ["expressions", "right-join"],
+        }).supportsPivots(),
+      ).toBe(false);
+
+      expect(
+        new Database({
+          features: ["expressions", "left-join"],
+        }).supportsPivots(),
+      ).toBe(true);
+    });
+  });
+
+  describe("question", () => {
+    it("should create a question using the `metadata` found on the Database instance", () => {
+      const metadata = new Metadata();
+      const database = new Database({
+        metadata,
+      });
+      const question = database.question();
+      expect(question.metadata()).toBe(metadata);
+    });
+
+    it("should create a question using the given Database instance's id in the question's query", () => {
+      const database = new Database({
+        id: 123,
+      });
+
+      expect(database.question().datasetQuery()).toEqual({
+        database: 123,
+        query: {
+          "source-table": null,
+        },
+        type: "query",
+      });
+
+      expect(database.question({ foo: "bar" }).datasetQuery()).toEqual({
+        database: 123,
+        query: {
+          foo: "bar",
+        },
+        type: "query",
+      });
+    });
+  });
+
+  describe("nativeQuestion", () => {
+    it("should create a native question using the `metadata` found on the Database instance", () => {
+      const metadata = new Metadata();
+      const database = new Database({
+        metadata,
+      });
+      const question = database.nativeQuestion();
+      expect(question.metadata()).toBe(metadata);
+    });
+
+    it("should create a native question using the given Database instance's id in the question's query", () => {
+      const database = new Database({
+        id: 123,
+      });
+
+      expect(database.nativeQuestion().datasetQuery()).toEqual({
+        database: 123,
+        native: {
+          query: "",
+          "template-tags": {},
+        },
+        type: "native",
+      });
+
+      expect(database.nativeQuestion({ foo: "bar" }).datasetQuery()).toEqual({
+        database: 123,
+        native: {
+          query: "",
+          "template-tags": {},
+          foo: "bar",
+        },
+        type: "native",
+      });
+    });
+  });
+
+  describe("newQuestion", () => {
+    it("should return new question with defaulted query and display", () => {
+      const database = new Database({
+        id: 123,
+      });
+
+      Question.prototype.setDefaultQuery = jest.fn(function() {
+        return this;
+      });
+      Question.prototype.setDefaultDisplay = jest.fn(function() {
+        return this;
+      });
+
+      const question = database.newQuestion();
+
+      expect(question).toBeInstanceOf(Question);
+      expect(Question.prototype.setDefaultDisplay).toHaveBeenCalled();
+      expect(Question.prototype.setDefaultQuery).toHaveBeenCalled();
+    });
+  });
+
+  describe("savedQuestionsDatabase", () => {
+    it("should return the 'fake' saved questions database", () => {
+      const database1 = new Database({ id: 1 });
+      const database2 = new Database({ id: 2, is_saved_questions: true });
+      const metadata = new Metadata({
+        databases: {
+          1: database1,
+          2: database2,
+        },
+      });
+
+      database1.metadata = metadata;
+
+      expect(database1.savedQuestionsDatabase()).toBe(database2);
+    });
+  });
+});

--- a/frontend/src/metabase-lib/lib/metadata/Field.unit.spec.js
+++ b/frontend/src/metabase-lib/lib/metadata/Field.unit.spec.js
@@ -1,0 +1,363 @@
+import Field from "./Field";
+import Table from "./Table";
+import Schema from "./Schema";
+import Metadata from "./Metadata";
+import Base from "./Base";
+import Dimension from "../Dimension";
+
+describe("Field", () => {
+  describe("instantiation", () => {
+    it("should create an instance of Schema", () => {
+      expect(new Field()).toBeInstanceOf(Field);
+    });
+
+    it("should add `object` props to the instance (because it extends Base)", () => {
+      expect(new Field()).toBeInstanceOf(Base);
+      expect(new Field({ foo: "bar" })).toHaveProperty("foo", "bar");
+    });
+  });
+
+  describe("parent", () => {
+    it("should return null when `metadata` does not exist on instance", () => {
+      expect(new Field().parent()).toBeNull();
+    });
+
+    it("should return the field that matches the instance's `parent_id` when `metadata` exists on the instance", () => {
+      const parentField = new Field({
+        id: 1,
+      });
+
+      const metadata = new Metadata({
+        fields: {
+          1: parentField,
+        },
+      });
+
+      const field = new Field({
+        parent_id: 1,
+        id: 2,
+        metadata,
+      });
+
+      expect(field.parent()).toBe(parentField);
+    });
+  });
+
+  describe("path", () => {
+    it("should return list of fields starting with instance, ending with root parent", () => {
+      const rootField = new Field({
+        id: 1,
+      });
+
+      const parentField = new Field({
+        id: 2,
+        parent_id: 1,
+      });
+
+      const metadata = new Metadata({
+        fields: {
+          1: rootField,
+          2: parentField,
+        },
+      });
+
+      parentField.metadata = metadata;
+      rootField.metadata = metadata;
+
+      const field = new Field({
+        parent_id: 2,
+        id: 3,
+        metadata,
+      });
+
+      expect(field.path()).toEqual([rootField, parentField, field]);
+    });
+  });
+
+  describe("displayName", () => {
+    it("should return a field's display name", () => {
+      expect(new Field({ name: "foo" }).displayName()).toBe("foo");
+    });
+
+    it("should prioritize the `display_name` field over `name`", () => {
+      expect(
+        new Field({ display_name: "bar", name: "foo" }).displayName(),
+      ).toBe("bar");
+    });
+
+    it("should prioritize the name in the field's `dimensions` property if it has one", () => {
+      const field = new Field({
+        dimensions: { name: "dimensions" },
+        display_name: "display",
+      });
+
+      expect(field.displayName()).toBe("dimensions");
+    });
+
+    describe("includePath flag", () => {
+      let field;
+      beforeEach(() => {
+        const rootField = new Field({
+          id: 1,
+          name: "rootField",
+        });
+
+        const parentField = new Field({
+          id: 2,
+          parent_id: 1,
+          name: "parentField",
+        });
+
+        const metadata = new Metadata({
+          fields: {
+            1: rootField,
+            2: parentField,
+          },
+        });
+
+        parentField.metadata = metadata;
+        rootField.metadata = metadata;
+
+        field = new Field({
+          parent_id: 2,
+          id: 3,
+          metadata,
+          name: "field",
+        });
+      });
+
+      it("should add parent field display names to the field's display name when enabled", () => {
+        expect(field.displayName({ includePath: true })).toBe(
+          "rootField: parentField: field",
+        );
+      });
+
+      it("should be enabled by default", () => {
+        expect(field.displayName({ includePath: true })).toBe(
+          field.displayName(),
+        );
+      });
+
+      it("should exclude parent field display names when disabled", () => {
+        expect(field.displayName({ includePath: false })).toBe("field");
+      });
+    });
+
+    describe("includeTable flag", () => {
+      let field;
+      beforeEach(() => {
+        field = new Field({
+          id: 1,
+          name: "field",
+        });
+      });
+
+      it("should do nothing when there is no table on the field instance", () => {
+        expect(field.displayName({ includeTable: true })).toBe("field");
+      });
+
+      it("should add the table name to the start of the field name", () => {
+        field.table = new Table({
+          display_name: "table",
+        });
+
+        expect(field.displayName({ includeTable: true })).toBe("table → field");
+      });
+    });
+
+    describe("includeSchema flag", () => {
+      let field;
+      beforeEach(() => {
+        field = new Field({
+          id: 1,
+          name: "field",
+        });
+      });
+
+      it("won't do anything if enabled and includeTable is not enabled", () => {
+        expect(field.displayName({ includeSchema: true })).toBe("field");
+      });
+
+      it("should add a combined schema + table display name to the start of the field name", () => {
+        field.table = new Table({
+          display_name: "table",
+          schema: new Schema({
+            name: "schema",
+          }),
+        });
+
+        expect(
+          field.displayName({ includeTable: true, includeSchema: true }),
+        ).toBe("Schema.table → field");
+      });
+    });
+  });
+
+  describe("targetObjectName", () => {
+    it("should return the display name of the field stripped of an appended id", () => {
+      const field = new Field({
+        name: "field id",
+      });
+
+      expect(field.targetObjectName()).toBe("field");
+    });
+  });
+
+  describe("dimension", () => {
+    it("should return the field's dimension when the id is an mbql field", () => {
+      const field = new Field({
+        id: ["field", 123, null],
+      });
+
+      const dimension = field.dimension();
+
+      expect(dimension).toBeInstanceOf(Dimension);
+      expect(dimension.fieldIdOrName()).toBe(123);
+    });
+
+    it("should return the field's dimension when the id is not an mbql field", () => {
+      const field = new Field({
+        id: 123,
+      });
+
+      const dimension = field.dimension();
+
+      expect(dimension).toBeInstanceOf(Dimension);
+      expect(dimension.fieldIdOrName()).toBe(123);
+    });
+  });
+
+  describe("getDefaultDateTimeUnit", () => {
+    describe("when the field is of type `type/DateTime`", () => {
+      it("should return 'day'", () => {
+        const field = new Field({
+          fingerprint: {
+            type: {
+              "type/Number": {},
+            },
+          },
+        });
+
+        expect(field.getDefaultDateTimeUnit()).toBe("day");
+      });
+    });
+  });
+
+  describe("when field is of type `type/DateTime`", () => {
+    it("should return a time unit depending on the number of days in the 'fingerprint'", () => {
+      const field = new Field({
+        fingerprint: {
+          type: {
+            "type/DateTime": {
+              earliest: "2019-03-01T00:00:00Z",
+              latest: "2021-01-01T00:00:00Z",
+            },
+          },
+        },
+      });
+
+      expect(field.getDefaultDateTimeUnit()).toBe("month");
+    });
+  });
+
+  describe("remappedField", () => {
+    it("should return the 'human readable' field tied to the field's dimension", () => {
+      const field1 = new Field({ id: 1 });
+      const field2 = new Field({ id: 2 });
+      const metadata = new Metadata({
+        fields: {
+          1: field1,
+          2: field2,
+        },
+      });
+
+      const field = new Field({
+        id: 3,
+        dimensions: {
+          human_readable_field_id: 1,
+        },
+      });
+      field.metadata = metadata;
+
+      expect(field.remappedField()).toBe(field1);
+    });
+
+    it("should return the field's name_field", () => {
+      const nameField = new Field();
+      const field = new Field({
+        id: 3,
+        name_field: nameField,
+      });
+
+      expect(field.remappedField()).toBe(nameField);
+    });
+
+    it("should return null when the field has no name_field or no dimension with a 'human readable' field", () => {
+      expect(new Field().remappedField()).toBe(null);
+    });
+  });
+
+  describe("remappedValue", () => {
+    it("should call a given value using the instance's remapping property", () => {
+      const field = new Field({
+        remapping: {
+          get: () => 1,
+        },
+      });
+
+      expect(field.remappedValue(2)).toBe(1);
+    });
+
+    it("should convert a numeric field into a number if it is not a number", () => {
+      const field = new Field({
+        isNumeric: () => true,
+        remapping: {
+          get: num => num,
+        },
+      });
+
+      expect(field.remappedValue("2.5rem")).toBe(2.5);
+    });
+  });
+
+  describe("hasRemappedValue", () => {
+    it("should call a given value using the instance's remapping property", () => {
+      const field = new Field({
+        remapping: {
+          has: () => true,
+        },
+      });
+
+      expect(field.hasRemappedValue(2)).toBe(true);
+    });
+
+    it("should convert a numeric field into a number if it is not a number", () => {
+      const field = new Field({
+        isNumeric: () => true,
+        remapping: {
+          has: num => typeof num === "number",
+        },
+      });
+
+      expect(field.hasRemappedValue("2.5rem")).toBe(true);
+    });
+  });
+
+  describe("isSearchable", () => {
+    it("should be true when the field is a string", () => {
+      const field = new Field({
+        isString: () => true,
+      });
+
+      expect(field.isSearchable()).toBe(true);
+    });
+
+    it("should be false when the field is not a string", () => {
+      const field = new Field({
+        isString: () => false,
+      });
+
+      expect(field.isSearchable()).toBe(false);
+    });
+  });
+});

--- a/frontend/src/metabase-lib/lib/metadata/Metadata.unit.spec.js
+++ b/frontend/src/metabase-lib/lib/metadata/Metadata.unit.spec.js
@@ -1,0 +1,185 @@
+import Metadata from "./Metadata";
+import Base from "./Base";
+
+import Database from "./Database";
+import Table from "./Table";
+import Schema from "./Schema";
+import Field from "./Field";
+import Segment from "./Segment";
+import Metric from "./Metric";
+import Question from "../Question";
+
+describe("Metdata", () => {
+  describe("instantiation", () => {
+    it("should create an instance of Metadata", () => {
+      expect(new Metadata()).toBeInstanceOf(Metadata);
+    });
+
+    it("should add `object` props to the instance (because it extends Base)", () => {
+      expect(new Metadata()).toBeInstanceOf(Base);
+      expect(new Metadata({ foo: "bar" })).toHaveProperty("foo", "bar");
+    });
+  });
+
+  describe("databasesList (deprecated)", () => {
+    let databases;
+    let databaseA;
+    let databaseB;
+    let databaseC;
+
+    beforeEach(() => {
+      databaseA = new Database({ id: 2, name: "A", is_saved_questions: true });
+      databaseB = new Database({ id: 3, name: "B" });
+      databaseC = new Database({ id: 1, name: "C" });
+
+      databases = {
+        1: databaseC,
+        2: databaseA,
+        3: databaseB,
+      };
+    });
+
+    it("should return a sorted list of database objects found on the metadata instance", () => {
+      const metadata = new Metadata({
+        databases,
+      });
+
+      expect(metadata.databasesList()).toEqual([
+        databaseA,
+        databaseB,
+        databaseC,
+      ]);
+    });
+
+    it("should return all databases when the `savedQuestions` flag is true", () => {
+      const metadata = new Metadata({
+        databases,
+      });
+
+      expect(
+        metadata.databasesList({
+          savedQuestions: true,
+        }),
+      ).toEqual(metadata.databasesList());
+    });
+
+    it("should exclude the 'is_saved_questions' db when the `savedQuestions` flag is false", () => {
+      const metadata = new Metadata({
+        databases,
+      });
+
+      expect(
+        metadata.databasesList({
+          savedQuestions: false,
+        }),
+      ).toEqual([databaseB, databaseC]);
+    });
+  });
+
+  describe("tablesList (deprecated)", () => {
+    it("should return a list of table objects found on the instance", () => {
+      const tableA = new Table({ id: 1, name: "A" });
+      const tableB = new Table({ id: 2, name: "B" });
+
+      const tables = {
+        1: tableA,
+        2: tableB,
+      };
+
+      const metadata = new Metadata({
+        tables,
+      });
+
+      expect(metadata.tablesList()).toEqual([tableA, tableB]);
+    });
+  });
+
+  describe("metricsList (deprecated)", () => {
+    it("should return a list of metric objects found on the instance", () => {
+      const metricA = new Metric({ id: 1, name: "A" });
+      const metricB = new Metric({ id: 2, name: "B" });
+
+      const metrics = {
+        1: metricA,
+        2: metricB,
+      };
+
+      const metadata = new Metadata({
+        metrics,
+      });
+
+      expect(metadata.metricsList()).toEqual([metricA, metricB]);
+    });
+  });
+
+  describe("segmentsList (deprecated)", () => {
+    it("should return a list of segment objects found on the instance", () => {
+      const segmentA = new Segment({ id: 1, name: "A" });
+      const segmentB = new Segment({ id: 2, name: "B" });
+
+      const segments = {
+        1: segmentA,
+        2: segmentB,
+      };
+
+      const metadata = new Metadata({
+        segments,
+      });
+
+      expect(metadata.segmentsList()).toEqual([segmentA, segmentB]);
+    });
+  });
+
+  describe("question", () => {
+    it("should return a new question using the metadata instance", () => {
+      const card = { name: "Question", id: 1 };
+      const metadata = new Metadata();
+      const question = metadata.question(card);
+
+      expect(question).toBeInstanceOf(Question);
+      expect(question.card()).toBe(card);
+      expect(question.metadata()).toBe(metadata);
+    });
+  });
+
+  [
+    ["segment", obj => new Segment(obj)],
+    ["metric", obj => new Metric(obj)],
+    ["database", obj => new Database(obj)],
+    ["schema", obj => new Schema(obj)],
+    ["table", obj => new Table(obj)],
+    ["field", obj => new Field(obj)],
+  ].forEach(([fnName, instantiate]) => {
+    describe(fnName, () => {
+      let instanceA;
+      let instanceB;
+      let metadata;
+      beforeEach(() => {
+        instanceA = instantiate({ id: 1, name: "A" });
+        instanceB = instantiate({ id: 2, name: "B" });
+
+        const instances = {
+          1: instanceA,
+          2: instanceB,
+        };
+
+        metadata = new Metadata({
+          [`${fnName}s`]: instances,
+        });
+      });
+
+      it(`should retun the ${fnName} with the given id`, () => {
+        expect(metadata[fnName](1)).toBe(instanceA);
+        expect(metadata[fnName](2)).toBe(instanceB);
+      });
+
+      it("should return null when the id matches nothing", () => {
+        expect(metadata[fnName](3)).toBeNull();
+      });
+
+      it("should return null when the id is nil", () => {
+        expect(metadata[fnName]()).toBeNull();
+      });
+    });
+  });
+});

--- a/frontend/src/metabase-lib/lib/metadata/Metadata.unit.spec.js
+++ b/frontend/src/metabase-lib/lib/metadata/Metadata.unit.spec.js
@@ -9,7 +9,7 @@ import Segment from "./Segment";
 import Metric from "./Metric";
 import Question from "../Question";
 
-describe("Metdata", () => {
+describe("Metadata", () => {
   describe("instantiation", () => {
     it("should create an instance of Metadata", () => {
       expect(new Metadata()).toBeInstanceOf(Metadata);

--- a/frontend/src/metabase-lib/lib/metadata/Schema.unit.spec.js
+++ b/frontend/src/metabase-lib/lib/metadata/Schema.unit.spec.js
@@ -1,0 +1,22 @@
+import Schema from "./Schema";
+import Base from "./Base";
+
+describe("Schema", () => {
+  describe("instantiation", () => {
+    it("should create an instance of Schema", () => {
+      expect(new Schema()).toBeInstanceOf(Schema);
+    });
+
+    it("should add `object` props to the instance (because it extends Base)", () => {
+      expect(new Schema()).toBeInstanceOf(Base);
+      expect(new Schema({ foo: "bar" })).toHaveProperty("foo", "bar");
+    });
+  });
+
+  describe("displayName", () => {
+    it("should return a formatted `name` string", () => {
+      const schema = new Schema({ name: "foo_bar" });
+      expect(schema.displayName()).toBe("Foo Bar");
+    });
+  });
+});

--- a/frontend/src/metabase-lib/lib/metadata/Segment.unit.spec.js
+++ b/frontend/src/metabase-lib/lib/metadata/Segment.unit.spec.js
@@ -1,0 +1,37 @@
+import Segment from "./Segment";
+import Base from "./Base";
+
+describe("Segment", () => {
+  describe("instantiation", () => {
+    it("should create an instance of Segment", () => {
+      expect(new Segment()).toBeInstanceOf(Segment);
+    });
+
+    it("should add `object` props to the instance (because it extends Base)", () => {
+      expect(new Segment()).toBeInstanceOf(Base);
+      expect(new Segment({ foo: "bar" })).toHaveProperty("foo", "bar");
+    });
+  });
+
+  describe("displayName", () => {
+    it("should return the `name` property found on the instance", () => {
+      expect(new Segment({ name: "foo" }).displayName()).toBe("foo");
+    });
+  });
+
+  describe("filterClause", () => {
+    it("should return a filter clause", () => {
+      expect(new Segment({ id: 123 }).filterClause()).toEqual(["segment", 123]);
+    });
+  });
+
+  describe("isActive", () => {
+    it("should return true if the segment is not archived", () => {
+      expect(new Segment({ archived: false }).isActive()).toBe(true);
+    });
+
+    it("should return false if the segment is archived", () => {
+      expect(new Segment({ archived: true }).isActive()).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Haven't covered EVERYTHING (for example, lots of methods on `Field` are pass-through to `schema_metadata` functions), but I think this covers a lot of things. I tried to take a fairly literal approach to this code. Feel free to suggest better alternatives, though!