### PR TITLE
Continuously check when Metabase is ready, instead of waiting 3 mins

### DIFF
--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -92,9 +92,9 @@ jobs:
         name: metabase-${{ matrix.edition }}-uberjar
 
     - name: Launch uberjar
-      run: |
-        java -jar ./target/uberjar/metabase.jar &
-        sleep 180
+      run: java -jar ./target/uberjar/metabase.jar &
+    - name: Wait for Metabase to start
+      run: while ! curl -s localhost:3000/api/health; do sleep 1; done
       timeout-minutes: 5
 
     - name: Check API health


### PR DESCRIPTION
It should shave off <3 mins from the check-java CI runs.

Also, we already use this approach for`docker.yml`, so let's be consistent.

**Before this PR**

![image](https://user-images.githubusercontent.com/7288/128585357-7653fb90-5dea-4202-93cb-ea40266c81b5.png)

**After this PR**
 
![image](https://user-images.githubusercontent.com/7288/128585340-a1b64390-2ac6-48c5-a9d8-504f6da2a814.png)
