### PR TITLE
Percy GitHub Actions: shortcut the process to get the version

### DIFF
--- a/.github/workflows/percy-issue-comment.yml
+++ b/.github/workflows/percy-issue-comment.yml
@@ -125,12 +125,14 @@ jobs:
           path: ~/.cache/yarn
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
 
-      - run: ./bin/build version
-
       - uses: actions/download-artifact@v2
         name: Retrieve uberjar artifact
         with:
           name: metabase-oss-uberjar
+      - name: Get the version info
+        run: |
+          jar xf target/uberjar/metabase.jar version.properties
+          mv version.properties resources/
 
       - name: Percy Test
         uses: percy/exec-action@v0.3.1

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -99,12 +99,14 @@ jobs:
           path: ~/.cache/yarn
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
 
-      - run: ./bin/build version
-
       - uses: actions/download-artifact@v2
         name: Retrieve uberjar artifact
         with:
           name: metabase-oss-uberjar
+      - name: Get the version info
+        run: |
+          jar xf target/uberjar/metabase.jar version.properties
+          mv version.properties resources/
 
       - name: Percy Test
         uses: percy/exec-action@v0.3.1


### PR DESCRIPTION
Since it needs to grab the built JAR anyway, it's faster to obtain the
version.properties from the JAR.

This shaves off approx. 1 minute from Percy CI run.

**Before this PR**

Look at the duration of `./bin/build version`
 
![image](https://user-images.githubusercontent.com/7288/128616302-750fbbf3-3aa6-4d50-b507-1b75b105beab.png)

**After this PR**

should be near instant:

![image](https://user-images.githubusercontent.com/7288/128616327-dbe6e8ce-eee2-462c-88be-6cffdb90ce5f.png)

