### PR TITLE
Webpack prod build: exclude ESLint loader

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -259,6 +259,12 @@ if (NODE_ENV !== "production") {
     }),
   );
 } else {
+
+  // Don't bother with ESLint for CI/production (we catch linting errors with another CI run)
+  config.module.rules = config.module.rules.filter(rule => {
+    return Array.isArray(rule.use) ? rule.use[0].loader != "eslint-loader" : true
+  });
+
   config.plugins.push(
     new TerserPlugin({ parallel: true, test: /\.jsx?($|\?)/i }),
   );


### PR DESCRIPTION
There's no point of processing files via ESLint loader when building for production. If there's any linting issue at all, it should be caught with a different CI run.

This shave off >2 minutes from Uberjar build (front-end step).

Development/hot-reload isn't affected at all.

**How to verify**

1. Run`yarn dev`. Nothing should change, i.e. same exact experience.
2. Build the Uberjar from a clean slate. The entire run should be 2 minutes faster (typically).