### PR TITLE
Visual test: consistent baseline with no randomization

### DIFF
--- a/frontend/test/metabase-visual/onboarding/urls.cy.spec.js
+++ b/frontend/test/metabase-visual/onboarding/urls.cy.spec.js
@@ -8,7 +8,13 @@ describe("visual tests > onboarding > URLs", () => {
 
   it("home", () => {
     cy.intercept("GET", `/api/automagic-dashboards`).as("automagic-dashboards");
-    cy.visit("/");
+
+    cy.visit("/", {
+      // to give predictable messages based on randomization
+      onBeforeLoad(win) {
+        cy.stub(win.Math, "random").returns(0.42);
+      },
+    });
 
     cy.wait("@automagic-dashboards");
 


### PR DESCRIPTION
Some messages in the UI are randomized, e.g. "Greetings, Robert", "Good to see you, Robert". In order to enforce a predictable baseline for the visual test which involves that message, we change `Math.random` to return a constant.

How to verify:
1. `yarn dev`
2. `yarn test-visual-open`
3. Choose `url.cy.spec.js`, then _home_
4. The greeting should be always "How's it going, Robert"
5. Repeat 2-3 and 4 should be still fulfilled (no randomization)