### PR TITLE
[Dashboard filters coverage] Add initial set of tests for dashboard SQL text/category filters

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-sql.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-sql.cy.spec.js
@@ -1,0 +1,98 @@
+import {
+  restore,
+  popover,
+  mockSessionProperty,
+  filterWidget,
+  editDashboard,
+  saveDashboard,
+  setFilter,
+} from "__support__/e2e/cypress";
+
+import { DASHBOARD_SQL_TEXT_FILTERS } from "./helpers/e2e-dashboard-filter-data-objects";
+import { addWidgetStringFilter } from "../native-filters/helpers/e2e-field-filter-helpers";
+
+import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
+
+const { PRODUCTS } = SAMPLE_DATASET;
+
+Object.entries(DASHBOARD_SQL_TEXT_FILTERS).forEach(
+  ([filter, { value, representativeResult, sqlFilter }]) => {
+    describe("scenarios > dashboard > filters > SQL > text/category", () => {
+      beforeEach(() => {
+        restore();
+        cy.signInAsAdmin();
+
+        mockSessionProperty("field-filter-operators-enabled?", true);
+
+        const questionDetails = getQuestionDetails(sqlFilter);
+
+        cy.createNativeQuestionAndDashboard({ questionDetails }).then(
+          ({ body: { id, card_id, dashboard_id } }) => {
+            cy.intercept("POST", `/api/card/${card_id}/query`).as("cardQuery");
+            cy.visit(`/question/${card_id}`);
+
+            // Wait for `result_metadata` to load
+            cy.wait("@cardQuery");
+
+            cy.visit(`/dashboard/${dashboard_id}`);
+          },
+        );
+
+        editDashboard();
+        setFilter("Text or Category", filter);
+
+        cy.findByText("Column to filter on")
+          .next("a")
+          .click();
+
+        popover()
+          .contains("Filter")
+          .click();
+      });
+
+      it(`should work for "${filter}" when set through the filter widget`, () => {
+        saveDashboard();
+
+        filterWidget().click();
+        addWidgetStringFilter(value);
+
+        cy.get(".Card").within(() => {
+          cy.contains(representativeResult);
+        });
+      });
+
+      it(`should work for "${filter}" when set as the default filter`, () => {
+        cy.findByText("Default value")
+          .next()
+          .click();
+
+        addWidgetStringFilter(value);
+
+        saveDashboard();
+
+        cy.get(".Card").within(() => {
+          cy.contains(representativeResult);
+        });
+      });
+    });
+  },
+);
+
+function getQuestionDetails(filter) {
+  return {
+    name: "SQL with Field Filter",
+    native: {
+      query: "select * from PRODUCTS where {{filter}}",
+      "template-tags": {
+        filter: {
+          id: "e05b9e58-3c51-676d-7334-4c2543709094",
+          name: "filter",
+          "display-name": "Filter",
+          type: "dimension",
+          dimension: ["field", PRODUCTS.CATEGORY, null],
+          "widget-type": filter,
+        },
+      },
+    },
+  };
+}

--- a/frontend/test/metabase/scenarios/dashboard-filters/helpers/e2e-dashboard-filter-data-objects.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/helpers/e2e-dashboard-filter-data-objects.js
@@ -112,3 +112,36 @@ export const DASHBOARD_TEXT_FILTERS = {
     representativeResult: "47.68",
   },
 };
+
+export const DASHBOARD_SQL_TEXT_FILTERS = {
+  Dropdown: {
+    sqlFilter: "string/=",
+    value: "Gizmo",
+    representativeResult: "Rustic Paper Wallet",
+  },
+  "Is not": {
+    sqlFilter: "string/!=",
+    value: "Gadget",
+    representativeResult: "Rustic Paper Wallet",
+  },
+  Contains: {
+    sqlFilter: "string/contains",
+    value: "oo",
+    representativeResult: "Small Marble Shoes",
+  },
+  "Does not contain": {
+    sqlFilter: "string/does-not-contain",
+    value: "oo",
+    representativeResult: "Rustic Paper Wallet",
+  },
+  "Starts with": {
+    sqlFilter: "string/starts-with",
+    value: "G",
+    representativeResult: "Rustic Paper Wallet",
+  },
+  "Ends with": {
+    sqlFilter: "string/ends-with",
+    value: "y",
+    representativeResult: "Small Marble Shoes",
+  },
+};


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- As an ongoing effort to increase the test coverage of dashboard filters (https://github.com/metabase/metabase/issues/17078), this PR adds basic tests around text/category filters applied to the SQL question with the corresponding field filter
    - Make sure filter can be set via filter widget
    - Make sure filter can be set as the default filter

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/128772845-545d9fb6-1692-4d55-852f-56e39e29e4b9.png)



