### PR TITLE
Missing last letters in troubleshooting guide titles

### DIFF
--- a/docs/troubleshooting-guide/sync-fingerprint-scan.md
+++ b/docs/troubleshooting-guide/sync-fingerprint-scan.md
@@ -15,7 +15,7 @@ Metabase needs to know what's in your database in order to show tables and field
 
 3. A *scan* is similar to fingerprinting, but is done every 24 hours (unless it's configured to run less often or disabled).  Scanning looks at the first 5000 distinct records ordered ascending, when a field is set to "A list of all values" in the Data Model, which is used to display options in dropdowns. If the textual result of scanning a column is more than 10 kilobytes long, for example, we display a search box instead of a dropdown.
 
-<h2 id="cant-sync-fingerprint-scan">Metabase can't sync, fingerprint, or sca</h2>
+<h2 id="cant-sync-fingerprint-scan">Metabase can't sync, fingerprint, or scan</h2>
 
 If the credentials Metabase is using to connect to the database don't give it privileges to read the tables, the first sign will often be a failure to sync, which would then also stop fingerprint and scan.
 
@@ -36,7 +36,7 @@ LIMIT 1
 
 Note that we only get the first 10,000 documents when scanning a MongoDB collection, so if you're not seeing some new fields, those fields might not exist in the documents we looked at. Please see [this discussion][metabase-mongo-missing] for more details.
 
-<h2 id="not-showing-all-values">Metabase isn't showing all of the values I expect to se</h2>
+<h2 id="not-showing-all-values">Metabase isn't showing all of the values I expect to see</h2>
 
 **How to detect this:**
 
@@ -51,7 +51,7 @@ Note that we only get the first 10,000 documents when scanning a MongoDB collect
 4. Set **Field Type** to "Category" and **Filtering on this field** to "A list of all values."
 5. Click the button **Re-scan this field** in the bottom.
 
-<h2 id="cant-force-with-api">I cannot force Metabase to sync or scan using the AP</h2>
+<h2 id="cant-force-with-api">I cannot force Metabase to sync or scan using the API</h2>
 
 Metabase syncs and scans regularly, but if the database administrator has just changed the database schema, or if a lot of data is added automatically at specific times, you may want to write a script that uses the [Metabase API][api-learn] to force sync or scan to take place right away. [Our API][metabase-api] provides two ways to do this:
 
@@ -68,7 +68,7 @@ Metabase syncs and scans regularly, but if the database administrator has just c
 3. Check the error message returned from Metabase.
 4. Check the credentials you're using to authenticate and make sure they identify your script as a user with administrative privileges.
 
-<h2 id="sync-scan-long-time">Sync and scan take a very long time to ru</h2>
+<h2 id="sync-scan-long-time">Sync and scan take a very long time to run</h2>
 
 **How to detect this:** Sync and scan take a long time to complete.
 


### PR DESCRIPTION
Seem to have been destroyed by an editor macro.