### PR TITLE
Refactor CollectionBadge component

### DIFF
--- a/frontend/src/metabase/components/Badge.jsx
+++ b/frontend/src/metabase/components/Badge.jsx
@@ -25,4 +25,6 @@ function Badge({ name, icon, iconColor, children, ...props }) {
 
 Badge.propTypes = propTypes;
 
+export { MaybeLink };
+
 export default Badge;

--- a/frontend/src/metabase/components/Badge.jsx
+++ b/frontend/src/metabase/components/Badge.jsx
@@ -1,9 +1,19 @@
-/* eslint-disable react/prop-types */
 import React from "react";
+import PropTypes from "prop-types";
 import cx from "classnames";
 
 import Link from "metabase/components/Link";
 import Icon from "metabase/components/Icon";
+
+const badgePropTypes = {
+  name: PropTypes.string.isRequired,
+  to: PropTypes.string,
+  icon: PropTypes.string,
+  iconColor: PropTypes.string,
+  onClick: PropTypes.func,
+  className: PropTypes.string,
+  children: PropTypes.node,
+};
 
 export default function Badge({
   icon,
@@ -11,6 +21,8 @@ export default function Badge({
   name,
   className,
   children,
+  to,
+  onClick,
   ...props
 }) {
   return (
@@ -19,7 +31,7 @@ export default function Badge({
         className,
         "flex align-center text-small text-bold text-medium",
         {
-          "cursor-pointer text-brand-hover": props.to || props.onClick,
+          "cursor-pointer text-brand-hover": to || onClick,
         },
       )}
       {...props}
@@ -37,5 +49,13 @@ export default function Badge({
   );
 }
 
+Badge.propTypes = badgePropTypes;
+
+const maybeLinkPropTypes = {
+  to: PropTypes.string,
+};
+
 export const MaybeLink = ({ to, ...props }) =>
   to ? <Link to={to} {...props} /> : <span {...props} />;
+
+MaybeLink.propTypes = maybeLinkPropTypes;

--- a/frontend/src/metabase/components/Badge.jsx
+++ b/frontend/src/metabase/components/Badge.jsx
@@ -1,41 +1,22 @@
 import React from "react";
 import PropTypes from "prop-types";
-import cx from "classnames";
 
-import Link from "metabase/components/Link";
 import Icon from "metabase/components/Icon";
 
-const badgePropTypes = {
+import { MaybeLink } from "./Badge.styled";
+
+const propTypes = {
   name: PropTypes.string.isRequired,
   to: PropTypes.string,
   icon: PropTypes.string,
   iconColor: PropTypes.string,
   onClick: PropTypes.func,
-  className: PropTypes.string,
   children: PropTypes.node,
 };
 
-export default function Badge({
-  icon,
-  iconColor,
-  name,
-  className,
-  children,
-  to,
-  onClick,
-  ...props
-}) {
+function Badge({ name, icon, iconColor, children, ...props }) {
   return (
-    <MaybeLink
-      className={cx(
-        className,
-        "flex align-center text-small text-bold text-medium",
-        {
-          "cursor-pointer text-brand-hover": to || onClick,
-        },
-      )}
-      {...props}
-    >
+    <MaybeLink {...props}>
       {icon && (
         <Icon
           name={icon}
@@ -49,13 +30,6 @@ export default function Badge({
   );
 }
 
-Badge.propTypes = badgePropTypes;
+Badge.propTypes = propTypes;
 
-const maybeLinkPropTypes = {
-  to: PropTypes.string,
-};
-
-export const MaybeLink = ({ to, ...props }) =>
-  to ? <Link to={to} {...props} /> : <span {...props} />;
-
-MaybeLink.propTypes = maybeLinkPropTypes;
+export default Badge;

--- a/frontend/src/metabase/components/Badge.jsx
+++ b/frontend/src/metabase/components/Badge.jsx
@@ -1,10 +1,9 @@
 /* eslint-disable react/prop-types */
 import React from "react";
+import cx from "classnames";
 
 import Link from "metabase/components/Link";
 import Icon from "metabase/components/Icon";
-
-import cx from "classnames";
 
 export default function Badge({
   icon,

--- a/frontend/src/metabase/components/Badge.jsx
+++ b/frontend/src/metabase/components/Badge.jsx
@@ -1,9 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-import Icon from "metabase/components/Icon";
-
-import { MaybeLink } from "./Badge.styled";
+import { BadgeIcon, MaybeLink } from "./Badge.styled";
 
 const propTypes = {
   name: PropTypes.string.isRequired,
@@ -18,12 +16,7 @@ function Badge({ name, icon, iconColor, children, ...props }) {
   return (
     <MaybeLink {...props}>
       {icon && (
-        <Icon
-          name={icon}
-          mr={children ? "5px" : null}
-          color={iconColor}
-          size={12}
-        />
+        <BadgeIcon name={icon} color={iconColor} hasMargin={!!children} />
       )}
       {children && <span className="text-wrap">{children}</span>}
     </MaybeLink>

--- a/frontend/src/metabase/components/Badge.styled.jsx
+++ b/frontend/src/metabase/components/Badge.styled.jsx
@@ -1,0 +1,32 @@
+import React from "react";
+import PropTypes from "prop-types";
+import styled, { css } from "styled-components";
+import { color } from "metabase/lib/colors";
+import Link from "metabase/components/Link";
+
+const propTypes = {
+  to: PropTypes.string,
+};
+
+function RawMaybeLink({ to, ...props }) {
+  return to ? <Link to={to} {...props} /> : <span {...props} />;
+}
+
+RawMaybeLink.propTypes = propTypes;
+
+const hoverStyle = css`
+  cursor: pointer;
+  color: ${color("brand")};
+`;
+
+export const MaybeLink = styled(RawMaybeLink)`
+  display: flex;
+  align-items: center;
+  font-size: 0.875em;
+  font-weight: bold;
+  color: ${color("text-medium")};
+
+  :hover {
+    ${props => (props.to || props.onClick) && hoverStyle}
+  }
+`;

--- a/frontend/src/metabase/components/Badge.styled.jsx
+++ b/frontend/src/metabase/components/Badge.styled.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import styled, { css } from "styled-components";
 import { color } from "metabase/lib/colors";
+import Icon from "metabase/components/Icon";
 import Link from "metabase/components/Link";
 
 const propTypes = {
@@ -29,4 +30,8 @@ export const MaybeLink = styled(RawMaybeLink)`
   :hover {
     ${props => (props.to || props.onClick) && hoverStyle}
   }
+`;
+
+export const BadgeIcon = styled(Icon).attrs({ size: 12 })`
+  margin-right: ${props => (props.hasMargin ? "5px" : 0)};
 `;

--- a/frontend/src/metabase/questions/components/CollectionBadge.jsx
+++ b/frontend/src/metabase/questions/components/CollectionBadge.jsx
@@ -1,9 +1,14 @@
-/* eslint-disable react/prop-types */
 import React from "react";
+import PropTypes from "prop-types";
 
 import Badge from "metabase/components/Badge";
 
 import Collection from "metabase/entities/collections";
+
+const propTypes = {
+  collection: PropTypes.object,
+  analyticsContext: PropTypes.string.isRequired,
+};
 
 @Collection.load({
   id: (state, props) => props.collectionId || "root",
@@ -31,5 +36,7 @@ class CollectionBadge extends React.Component {
     );
   }
 }
+
+CollectionBadge.propTypes = propTypes;
 
 export default CollectionBadge;

--- a/frontend/src/metabase/questions/components/CollectionBadge.jsx
+++ b/frontend/src/metabase/questions/components/CollectionBadge.jsx
@@ -10,33 +10,29 @@ const propTypes = {
   analyticsContext: PropTypes.string.isRequired,
 };
 
-@Collection.load({
-  id: (state, props) => props.collectionId || "root",
-  wrapped: true,
-  loadingAndErrorWrapper: false,
-  properties: ["name"],
-})
-class CollectionBadge extends React.Component {
-  render() {
-    const { collection, analyticsContext, ...props } = this.props;
-    if (!collection) {
-      return null;
-    }
-    const icon = collection.getIcon();
-    return (
-      <Badge
-        to={collection.getUrl()}
-        icon={icon.name}
-        iconColor={icon.color}
-        data-metabase-event={`${analyticsContext};Collection Badge Click`}
-        {...props}
-      >
-        {collection.getName()}
-      </Badge>
-    );
+function CollectionBadge({ collection, analyticsContext, ...props }) {
+  if (!collection) {
+    return null;
   }
+  const icon = collection.getIcon();
+  return (
+    <Badge
+      to={collection.getUrl()}
+      icon={icon.name}
+      iconColor={icon.color}
+      data-metabase-event={`${analyticsContext};Collection Badge Click`}
+      {...props}
+    >
+      {collection.getName()}
+    </Badge>
+  );
 }
 
 CollectionBadge.propTypes = propTypes;
 
-export default CollectionBadge;
+export default Collection.load({
+  id: (state, props) => props.collectionId || "root",
+  wrapped: true,
+  loadingAndErrorWrapper: false,
+  properties: ["name"],
+})(CollectionBadge);

--- a/frontend/src/metabase/questions/components/CollectionBadge.jsx
+++ b/frontend/src/metabase/questions/components/CollectionBadge.jsx
@@ -8,9 +8,10 @@ import Collection from "metabase/entities/collections";
 const propTypes = {
   collection: PropTypes.object,
   analyticsContext: PropTypes.string.isRequired,
+  className: PropTypes.string,
 };
 
-function CollectionBadge({ collection, analyticsContext, ...props }) {
+function CollectionBadge({ collection, analyticsContext, className }) {
   if (!collection) {
     return null;
   }
@@ -20,8 +21,8 @@ function CollectionBadge({ collection, analyticsContext, ...props }) {
       to={collection.getUrl()}
       icon={icon.name}
       iconColor={icon.color}
+      className={className}
       data-metabase-event={`${analyticsContext};Collection Badge Click`}
-      {...props}
     >
       {collection.getName()}
     </Badge>


### PR DESCRIPTION
This PR aligns `CollectionBadge` and `Badge` components with our current FE style guide. Needed to unblock a clean fix for one of the #17189 parts

As usual: prop-types, imports, styled-components, functions over classes ✨ 

### To Verify

1. Open any question
2. Ensure the badge looks as before
3. Click the badge and ensure you're navigated to an expected collection
4. Open any dashboard
5. Repeat steps 2 and 3 🙂 

### Demo

**Question**

![CleanShot 2021-08-10 at 16 47 35@2x](https://user-images.githubusercontent.com/17258145/128880688-c60f5b69-60e1-444e-aa9c-733b67770793.png)

**Dashboard**

![CleanShot 2021-08-10 at 16 48 30@2x](https://user-images.githubusercontent.com/17258145/128880671-52930ace-f10f-4623-978a-59096a320a51.png)
