### PR TITLE
[Dashboard filters coverage] Add initial set of tests for dashboard SQL number filters

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-sql-number.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-sql-number.cy.spec.js
@@ -1,0 +1,99 @@
+import {
+  restore,
+  popover,
+  mockSessionProperty,
+  filterWidget,
+  editDashboard,
+  saveDashboard,
+  setFilter,
+} from "__support__/e2e/cypress";
+
+import { DASHBOARD_SQL_NUMBER_FILTERS } from "./helpers/e2e-dashboard-filter-data-objects";
+import { addWidgetNumberFilter } from "../native-filters/helpers/e2e-field-filter-helpers";
+
+import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
+
+const { PRODUCTS } = SAMPLE_DATASET;
+
+Object.entries(DASHBOARD_SQL_NUMBER_FILTERS).forEach(
+  ([filter, { value, representativeResult, sqlFilter }]) => {
+    describe("scenarios > dashboard > filters > SQL > text/category", () => {
+      beforeEach(() => {
+        restore();
+        cy.signInAsAdmin();
+
+        mockSessionProperty("field-filter-operators-enabled?", true);
+
+        const questionDetails = getQuestionDetails(sqlFilter);
+
+        cy.createNativeQuestionAndDashboard({ questionDetails }).then(
+          ({ body: { id, card_id, dashboard_id } }) => {
+            cy.intercept("POST", `/api/card/${card_id}/query`).as("cardQuery");
+            cy.visit(`/question/${card_id}`);
+
+            // Wait for `result_metadata` to load
+            cy.wait("@cardQuery");
+
+            cy.visit(`/dashboard/${dashboard_id}`);
+          },
+        );
+
+        editDashboard();
+        setFilter("Number", filter);
+
+        cy.findByText("Column to filter on")
+          .next("a")
+          .click();
+
+        popover()
+          .contains("Filter")
+          .click();
+      });
+
+      it(`should work for "${filter}" when set through the filter widget`, () => {
+        saveDashboard();
+
+        filterWidget().click();
+        addWidgetNumberFilter(value);
+
+        cy.get(".Card").within(() => {
+          cy.contains(representativeResult);
+        });
+      });
+
+      it(`should work for "${filter}" when set as the default filter`, () => {
+        cy.findByText("Default value")
+          .next()
+          .click();
+
+        addWidgetNumberFilter(value);
+
+        saveDashboard();
+
+        cy.get(".Card").within(() => {
+          cy.contains(representativeResult);
+        });
+      });
+    });
+  },
+);
+
+function getQuestionDetails(filter) {
+  return {
+    name: "SQL with number filter",
+    native: {
+      query:
+        "select PRODUCTS.TITLE, PRODUCTS.RATING from PRODUCTS where {{filter}} limit 10",
+      "template-tags": {
+        filter: {
+          id: "1c46dd00-3f32-9328-f663-71f98c5d7953",
+          name: "filter",
+          "display-name": "Filter",
+          type: "dimension",
+          dimension: ["field", PRODUCTS.RATING, null],
+          "widget-type": filter,
+        },
+      },
+    },
+  };
+}

--- a/frontend/test/metabase/scenarios/dashboard-filters/helpers/e2e-dashboard-filter-data-objects.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/helpers/e2e-dashboard-filter-data-objects.js
@@ -145,3 +145,31 @@ export const DASHBOARD_SQL_TEXT_FILTERS = {
     representativeResult: "Small Marble Shoes",
   },
 };
+
+export const DASHBOARD_SQL_NUMBER_FILTERS = {
+  "Equal to": {
+    sqlFilter: "number/=",
+    value: "3.8",
+    representativeResult: "Small Marble Hat",
+  },
+  "Not equal to": {
+    sqlFilter: "number/!=",
+    value: "2.07",
+    representativeResult: "Rustic Paper Wallet",
+  },
+  Between: {
+    sqlFilter: "number/between",
+    value: ["3", "4"],
+    representativeResult: "Small Marble Hat",
+  },
+  "Greater than or equal to": {
+    sqlFilter: "number/>=",
+    value: "4.3",
+    representativeResult: "Aerodynamic Linen Coat",
+  },
+  "Less than or equal to": {
+    sqlFilter: "number/<=",
+    value: "3",
+    representativeResult: "Enormous Aluminum Shirt",
+  },
+};


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- As an ongoing effort to increase the test coverage of dashboard filters (https://github.com/metabase/metabase/issues/17078), this PR adds basic tests around number filters applied to the SQL question with the corresponding field filter
    - Make sure filter can be set via filter widget
    - Make sure filter can be set as the default filter

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/128885850-75e6821d-5368-47da-a0cf-9f74afd8da56.png)



