### PR TITLE
Fix babel loader when the cache is not desired

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,7 +29,7 @@ const devMode = NODE_ENV !== "production";
 
 // Babel:
 const BABEL_CONFIG = {
-  cacheDirectory: process.env.BABEL_DISABLE_CACHE ? null : ".babel_cache",
+  cacheDirectory: process.env.BABEL_DISABLE_CACHE ? false : ".babel_cache",
 };
 
 const CSS_CONFIG = {


### PR DESCRIPTION
https://webpack.js.org/loaders/babel-loader/#options

**How to verify**

Run without cache, e.g. `env BABEL_DISABLE_CACHE=true yarn build-hot`.

**Before this PR**

```
[js] ValidationError: Invalid configuration object. Babel loader has been initialized using a configuration object that does not match the API schema.
[js]  - configuration.cacheDirectory should be one of these:
[js]    boolean | string
[js]    Details:
[js]     * configuration.cacheDirectory should be a boolean.
[js]     * configuration.cacheDirectory should be a string.
[js]     at validate
```

**After this PR**

Successful build with no error.