### PR TITLE
Namespace for extensions to clojure.test

### DIFF
--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -51,32 +51,6 @@
   with-log-messages
   with-log-messages-for-level])
 
-(defmethod assert-expr 're= [msg [_ pattern actual]]
-  `(let [pattern#  ~pattern
-         actual#   ~actual
-         matches?# (some->> actual# (re-matches pattern#))]
-     (assert (instance? java.util.regex.Pattern pattern#))
-     (do-report
-      {:type     (if matches?# :pass :fail)
-       :message  ~msg
-       :expected pattern#
-       :actual   actual#
-       :diffs    (when-not matches?#
-                   [[actual# [pattern# nil]]])})))
-
-(defmethod assert-expr 'schema=
-  [message [_ schema actual]]
-  `(let [schema# ~schema
-         actual# ~actual
-         pass?#  (nil? (s/check schema# actual#))]
-     (do-report
-      {:type     (if pass?# :pass :fail)
-       :message  ~message
-       :expected (s/explain schema#)
-       :actual   actual#
-       :diffs    (when-not pass?#
-                   [[actual# [(s/check schema# actual#) nil]]])})))
-
 (defn- random-uppercase-letter []
   (char (+ (int \A) (rand-int 26))))
 

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -21,6 +21,7 @@
             [metabase.models.setting.cache :as setting.cache]
             [metabase.plugins.classloader :as classloader]
             [metabase.task :as task]
+            [metabase.test-runner.effects :as effects]
             [metabase.test-runner.parallel :as test-runner.parallel]
             [metabase.test.data :as data]
             [metabase.test.fixtures :as fixtures]
@@ -29,7 +30,6 @@
             [metabase.util :as u]
             [metabase.util.files :as u.files]
             [potemkin :as p]
-            [schema.core :as s]
             [toucan.db :as db]
             [toucan.models :as t.models]
             [toucan.util.test :as tt])
@@ -38,7 +38,8 @@
            java.util.Locale
            [org.quartz CronTrigger JobDetail JobKey Scheduler Trigger]))
 
-(comment tu.log/keep-me)
+(comment tu.log/keep-me
+         effects/keep-me)
 
 (use-fixtures :once (fixtures/initialize :db))
 

--- a/test/metabase/test_runner.clj
+++ b/test/metabase/test_runner.clj
@@ -11,6 +11,7 @@
             eftest.runner
             [environ.core :as env]
             [metabase.config :as config]
+            [metabase.test-runner.effects :as effects]
             [metabase.test-runner.init :as init]
             [metabase.test-runner.junit :as junit]
             [metabase.test-runner.parallel :as parallel]
@@ -23,7 +24,8 @@
 
 ;; Load redefinitions of stuff like `tt/with-temp` and `with-redefs` that throw an Exception when they are used inside
 ;; parallel tests.
-(comment metabase.test.redefs/keep-me)
+(comment metabase.test.redefs/keep-me
+         effects/keep-me)
 
 ;;;; Finding tests
 

--- a/test/metabase/test_runner/effects.clj
+++ b/test/metabase/test_runner/effects.clj
@@ -1,0 +1,37 @@
+(ns metabase.test-runner.effects
+  "A namespace for side-effecting test utilities to ensure we can always run subselections of tests. There should be no
+  macros in here. Those should go in the other test namespaces. This is to ensure that any helpers like `schema=` are
+  present since this defmethod isn't required in the namespaces where it is used.
+
+  Ex:
+  clojure -X:dev:test :only '\"test/metabase/pulse/render\"'
+
+  This would not have had the random namespace that requires these helpers and the run fails.
+  "
+  (:require [clojure.test :as t]))
+
+(defmethod t/assert-expr 're= [msg [_ pattern actual]]
+  `(let [pattern#  ~pattern
+         actual#   ~actual
+         matches?# (some->> actual# (re-matches pattern#))]
+     (assert (instance? java.util.regex.Pattern pattern#))
+     (do-report
+      {:type     (if matches?# :pass :fail)
+       :message  ~msg
+       :expected pattern#
+       :actual   actual#
+       :diffs    (when-not matches?#
+                   [[actual# [pattern# nil]]])})))
+
+(defmethod t/assert-expr 'schema=
+  [message [_ schema actual]]
+  `(let [schema# ~schema
+         actual# ~actual
+         pass?#  (nil? (s/check schema# actual#))]
+     (do-report
+      {:type     (if pass?# :pass :fail)
+       :message  ~message
+       :expected (s/explain schema#)
+       :actual   actual#
+       :diffs    (when-not pass?#
+                   [[actual# [(s/check schema# actual#) nil]]])})))

--- a/test/metabase/test_runner/effects.clj
+++ b/test/metabase/test_runner/effects.clj
@@ -8,14 +8,15 @@
 
   This would not have had the random namespace that requires these helpers and the run fails.
   "
-  (:require [clojure.test :as t]))
+  (:require [clojure.test :as t]
+            [schema.core :as s]))
 
 (defmethod t/assert-expr 're= [msg [_ pattern actual]]
   `(let [pattern#  ~pattern
          actual#   ~actual
          matches?# (some->> actual# (re-matches pattern#))]
      (assert (instance? java.util.regex.Pattern pattern#))
-     (do-report
+     (t/do-report
       {:type     (if matches?# :pass :fail)
        :message  ~msg
        :expected pattern#
@@ -28,7 +29,7 @@
   `(let [schema# ~schema
          actual# ~actual
          pass?#  (nil? (s/check schema# actual#))]
-     (do-report
+     (t/do-report
       {:type     (if pass?# :pass :fail)
        :message  ~message
        :expected (s/explain schema#)


### PR DESCRIPTION
if you do a subselection of tests, you might not get the `schema=`
defmethods and then your tests won't compile. Ns docstring to keep the
namespace simple and targeted to global effects. we don't want to load
models and do extra work, just install some test utilities that aren't
ever required directly

for instance,
```shell
clojure -X:dev:test :only '"test/metabase/pulse/render"'

Running tests in "test/metabase/pulse/render"
Looking for test namespaces in directory test/metabase/pulse/render
Syntax error compiling at (metabase/pulse/render/body_test.clj:290:13).
Unable to resolve symbol: schema= in this context

Full report at:
/var/folders/_h/3fpgc8pj4fb2_w3mfqfl59fr0000gn/T/clojure-16531873303347798524.edn
```

