### PR TITLE
add moderation events to question timeline

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationActions/ModerationActions.styled.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationActions/ModerationActions.styled.jsx
@@ -1,9 +1,14 @@
 import styled from "styled-components";
 
 import { color } from "metabase/lib/colors";
-import { getVerifiedIcon } from "metabase-enterprise/moderation/service";
+import {
+  MODERATION_STATUS,
+  getStatusIcon,
+} from "metabase-enterprise/moderation/service";
 
-const { name: verifiedIconName, color: verifiedIconColor } = getVerifiedIcon();
+const { name: verifiedIconName, color: verifiedIconColor } = getStatusIcon(
+  MODERATION_STATUS.verified,
+);
 
 import Button from "metabase/components/Button";
 

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationReviewBanner/ModerationReviewBanner.unit.spec.js
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationReviewBanner/ModerationReviewBanner.unit.spec.js
@@ -10,8 +10,8 @@ const moderationReview = {
   moderator_id: 1,
   created_at: Date.now(),
 };
-const moderator = { id: 1, display_name: "Foo" };
-const currentUser = { id: 2, display_name: "Bar" };
+const moderator = { id: 1, common_name: "Foo" };
+const currentUser = { id: 2, common_name: "Bar" };
 
 describe("ModerationReviewBanner", () => {
   it("should show text concerning the given review", () => {

--- a/enterprise/frontend/src/metabase-enterprise/moderation/constants.js
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/constants.js
@@ -1,3 +1,7 @@
+export const MODERATION_STATUS = {
+  verified: "verified",
+};
+
 export const ACTIONS = {
   verified: {
     type: "verified",

--- a/enterprise/frontend/src/metabase-enterprise/moderation/constants.js
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/constants.js
@@ -2,19 +2,13 @@ export const MODERATION_STATUS = {
   verified: "verified",
 };
 
-export const ACTIONS = {
+export const MODERATION_STATUS_ICONS = {
   verified: {
-    type: "verified",
-    icon: {
-      name: "verified",
-      color: "brand",
-    },
+    name: "verified",
+    color: "brand",
   },
   null: {
-    type: "null",
-    icon: {
-      name: "close",
-      color: "text-light",
-    },
+    name: "close",
+    color: "text-light",
   },
 };

--- a/enterprise/frontend/src/metabase-enterprise/moderation/constants.js
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/constants.js
@@ -8,7 +8,9 @@ export const ACTIONS = {
   },
   null: {
     type: "null",
-    icon: "close",
-    color: "text-light",
+    icon: {
+      name: "close",
+      color: "text-light",
+    },
   },
 };

--- a/enterprise/frontend/src/metabase-enterprise/moderation/constants.js
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/constants.js
@@ -6,4 +6,9 @@ export const ACTIONS = {
       color: "brand",
     },
   },
+  null: {
+    type: "null",
+    icon: "close",
+    color: "text-light",
+  },
 };

--- a/enterprise/frontend/src/metabase-enterprise/moderation/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/index.js
@@ -2,11 +2,16 @@ import { PLUGIN_MODERATION } from "metabase/plugins";
 import QuestionModerationSection from "./components/QuestionModerationSection/QuestionModerationSection";
 import ModerationStatusIcon from "./components/ModerationStatusIcon/ModerationStatusIcon";
 
-import { getStatusIconForQuestion, getStatusIcon } from "./service";
+import {
+  getStatusIconForQuestion,
+  getStatusIcon,
+  getModerationTimelineEvents,
+} from "./service";
 
 Object.assign(PLUGIN_MODERATION, {
   QuestionModerationSection,
   ModerationStatusIcon,
   getStatusIconForQuestion,
   getStatusIcon,
+  getModerationTimelineEvents,
 });

--- a/enterprise/frontend/src/metabase-enterprise/moderation/service.js
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/service.js
@@ -21,18 +21,22 @@ export function removeReview({ itemId, itemType }) {
   });
 }
 
-const defaultIcon = {};
-export function getStatusIcon(status) {
+const noIcon = {};
+export function getStatusIcon(status, { enableNull = false } = {}) {
+  if (status === null && !enableNull) {
+    return noIcon;
+  }
+
   const action = ACTIONS[status] || {};
-  return action.icon || defaultIcon;
+  return action.icon || noIcon;
 }
 
 export function getVerifiedIcon() {
   return getStatusIcon("verified");
 }
 
-export function getIconForReview(review) {
-  return getStatusIcon(review?.status);
+export function getIconForReview(review, options) {
+  return getStatusIcon(review?.status, options);
 }
 
 export function getTextForReviewBanner(
@@ -105,7 +109,7 @@ export function getModerationTimelineEvents(reviews, usersById, currentUser) {
       currentUser,
     );
     const text = getModerationReviewEventText(review, moderatorDisplayName);
-    const icon = getIconForReview(review);
+    const icon = getIconForReview(review, { enableNull: true });
 
     return {
       timestamp: new Date(review.created_at).valueOf(),

--- a/enterprise/frontend/src/metabase-enterprise/moderation/service.js
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/service.js
@@ -53,13 +53,13 @@ export function getTextForReviewBanner(
 }
 
 function getModeratorDisplayName(user, currentUser) {
-  const { id: userId, display_name } = user || {};
+  const { id: userId, common_name } = user || {};
   const { id: currentUserId } = currentUser || {};
 
   if (currentUserId != null && userId === currentUserId) {
     return t`You`;
   } else if (userId != null) {
-    return display_name;
+    return common_name;
   } else {
     return t`A moderator`;
   }
@@ -84,4 +84,33 @@ export function getStatusIconForQuestion(question) {
   const reviews = question.getModerationReviews();
   const review = getLatestModerationReview(reviews);
   return getIconForReview(review);
+}
+
+function getModerationReviewEventText(review, moderatorDisplayName) {
+  switch (review.status) {
+    case "verified":
+      return t`${moderatorDisplayName} verified this`;
+    case null:
+      return t`${moderatorDisplayName} removed verification`;
+    default:
+      return t`${moderatorDisplayName} changed status to ${review.status}`;
+  }
+}
+
+export function getModerationTimelineEvents(reviews, usersById, currentUser) {
+  return reviews.map((review, index) => {
+    const moderator = usersById[review.moderator_id];
+    const moderatorDisplayName = getModeratorDisplayName(
+      moderator,
+      currentUser,
+    );
+    const text = getModerationReviewEventText(review, moderatorDisplayName);
+    const icon = getIconForReview(review);
+
+    return {
+      timestamp: new Date(review.created_at).valueOf(),
+      icon,
+      title: text,
+    };
+  });
 }

--- a/enterprise/frontend/src/metabase-enterprise/moderation/service.unit.spec.js
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/service.unit.spec.js
@@ -1,7 +1,6 @@
 import {
   verifyItem,
   removeReview,
-  getVerifiedIcon,
   getIconForReview,
   getTextForReviewBanner,
   isItemVerified,
@@ -60,11 +59,27 @@ describe("moderation/service", () => {
     });
   });
 
-  describe("getVerifiedIcon", () => {
-    it("should return verified icon name/color", () => {
-      expect(getVerifiedIcon()).toEqual({
+  describe("getStatusIcon", () => {
+    it("should return an empty icon if there is no matching status", () => {
+      expect(getStatusIcon("foo")).toEqual({});
+    });
+
+    it("should return an icon if there is a matching status", () => {
+      expect(getStatusIcon("verified")).toEqual({
         name: "verified",
         color: "brand",
+      });
+    });
+
+    it("should not return an icon for a status of null", () => {
+      expect(getStatusIcon(null)).toEqual({});
+      expect(getStatusIcon("null")).toEqual({});
+    });
+
+    it("should return an icon for a status of null is `enableNull` is passed in the config object arg", () => {
+      expect(getStatusIcon("null", { enableNull: true })).toEqual({
+        name: "close",
+        color: "text-light",
       });
     });
   });
@@ -72,7 +87,7 @@ describe("moderation/service", () => {
   describe("getIconForReview", () => {
     it("should return icon name/color for given review", () => {
       expect(getIconForReview({ status: "verified" })).toEqual(
-        getVerifiedIcon(),
+        getStatusIcon("verified"),
       );
     });
   });
@@ -180,7 +195,7 @@ describe("moderation/service", () => {
       };
 
       expect(getStatusIconForQuestion(questionWithReviews)).toEqual(
-        getVerifiedIcon(),
+        getStatusIcon("verified"),
       );
     });
 
@@ -244,7 +259,7 @@ describe("moderation/service", () => {
         },
         {
           timestamp: expect.any(Number),
-          icon: getStatusIcon(null),
+          icon: getStatusIcon(null, { enableNull: true }),
           title: "A moderator removed verification",
         },
       ]);

--- a/enterprise/frontend/src/metabase-enterprise/moderation/service.unit.spec.js
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/service.unit.spec.js
@@ -8,6 +8,7 @@ import {
   getStatusIconForQuestion,
   getModerationTimelineEvents,
   getStatusIcon,
+  getRemovedReviewStatusIcon,
 } from "./service";
 
 jest.mock("metabase/services", () => ({
@@ -71,13 +72,19 @@ describe("moderation/service", () => {
       });
     });
 
-    it("should not return an icon for a status of null", () => {
-      expect(getStatusIcon(null)).toEqual({});
-      expect(getStatusIcon("null")).toEqual({});
+    it("should not return an icon for a status of null, which represents the removal of a review and is a special case", () => {
+      const removedReviewStatus = null;
+      const accidentallyStringCoercedRemvovedReviewStatus = "null";
+      expect(getStatusIcon(removedReviewStatus)).toEqual({});
+      expect(
+        getStatusIcon(accidentallyStringCoercedRemvovedReviewStatus),
+      ).toEqual({});
     });
+  });
 
-    it("should return an icon for a status of null is `enableNull` is passed in the config object arg", () => {
-      expect(getStatusIcon("null", { enableNull: true })).toEqual({
+  describe("getRemovedReviewStatusIcon", () => {
+    it("should return an icon for a removed review", () => {
+      expect(getRemovedReviewStatusIcon()).toEqual({
         name: "close",
         color: "text-light",
       });
@@ -259,7 +266,7 @@ describe("moderation/service", () => {
         },
         {
           timestamp: expect.any(Number),
-          icon: getStatusIcon(null, { enableNull: true }),
+          icon: getRemovedReviewStatusIcon(),
           title: "A moderator removed verification",
         },
       ]);

--- a/frontend/src/metabase/components/DrawerSection/DrawerSection.info.js
+++ b/frontend/src/metabase/components/DrawerSection/DrawerSection.info.js
@@ -1,0 +1,86 @@
+import React from "react";
+import DrawerSection from "./DrawerSection";
+
+import moment from "moment";
+import styled from "styled-components";
+import Timeline from "metabase/components/Timeline";
+import { color } from "metabase/lib/colors";
+
+export const component = DrawerSection;
+export const category = "layout";
+export const description = `
+  This component is similar to the CollapseSection component,
+  but instead of expanding downward, it expands upward.
+  The header situates itself at the bottom of the remaining space
+  in a parent component and when opened fills the remaining space
+  with what child components you have given it.
+
+  For this to work properly, the containing element (here, Container)
+  must handle overflow when the DrawerSection is open and have a display
+  of "flex" (plus a flex-direction of "column") so that the DrawerSection
+  can properly use the remaining space in the Container component.
+`;
+
+const Container = styled.div`
+  line-height: 1.5;
+  width: 350px;
+  border: 1px dashed ${color("bg-dark")};
+  border-radius: 0.5rem;
+  padding: 1rem;
+  height: 32rem;
+
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+`;
+
+const TextArea = styled.textarea`
+  width: 100%;
+  flex-shrink: 0;
+`;
+
+const items = [
+  {
+    icon: "verified",
+    title: "John Someone verified this",
+    description: "idk lol",
+    timestamp: moment()
+      .subtract(1, "day")
+      .valueOf(),
+    numComments: 5,
+  },
+  {
+    icon: "pencil",
+    title: "Foo edited this",
+    description: "Did a thing.",
+    timestamp: moment()
+      .subtract(1, "week")
+      .valueOf(),
+  },
+  {
+    icon: "close",
+    title: "foo foo foo",
+    timestamp: moment()
+      .subtract(2, "month")
+      .valueOf(),
+  },
+  {
+    icon: "number",
+    title: "bar bar bar",
+    timestamp: moment()
+      .subtract(1, "year")
+      .valueOf(),
+    numComments: 123,
+  },
+];
+
+export const examples = {
+  "Constrained container": (
+    <Container>
+      <TextArea placeholder="an element with variable height" />
+      <DrawerSection header="foo">
+        <Timeline items={items} />
+      </DrawerSection>
+    </Container>
+  ),
+};

--- a/frontend/src/metabase/components/DrawerSection/DrawerSection.jsx
+++ b/frontend/src/metabase/components/DrawerSection/DrawerSection.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import PropTypes from "prop-types";
+import _ from "underscore";
 
 import Icon from "metabase/components/Icon";
 import {
@@ -9,22 +10,79 @@ import {
   Header,
 } from "./DrawerSection.styled";
 
+export const STATES = {
+  closed: "closed",
+  open: "open",
+};
+
 DrawerSection.propTypes = {
   header: PropTypes.node.isRequired,
   children: PropTypes.node,
-  initialState: PropTypes.oneOf(["closed", "open"]),
+  state: PropTypes.oneOf([STATES.closed, STATES.open]),
+  onStateChange: PropTypes.func,
 };
 
-function DrawerSection({ header, children, initialState = "closed" }) {
-  const [isOpen, setIsOpen] = useState(initialState === "open");
+function DrawerSection({ header, children, state, onStateChange }) {
+  return _.isFunction(onStateChange) ? (
+    <ControlledDrawerSection
+      header={header}
+      state={state}
+      onStateChange={onStateChange}
+    >
+      {children}
+    </ControlledDrawerSection>
+  ) : (
+    <UncontrolledDrawerSection header={header} initialState={state}>
+      {children}
+    </UncontrolledDrawerSection>
+  );
+}
+
+UncontrolledDrawerSection.propTypes = {
+  header: PropTypes.node.isRequired,
+  children: PropTypes.node,
+  initialState: PropTypes.oneOf([STATES.closed, STATES.open]),
+};
+
+function UncontrolledDrawerSection({ header, children, initialState }) {
+  const [state, setState] = useState(initialState);
+
+  return (
+    <ControlledDrawerSection
+      header={header}
+      state={state}
+      onStateChange={setState}
+    >
+      {children}
+    </ControlledDrawerSection>
+  );
+}
+
+ControlledDrawerSection.propTypes = {
+  header: PropTypes.node.isRequired,
+  children: PropTypes.node,
+  state: PropTypes.oneOf([STATES.closed, STATES.open]),
+  onStateChange: PropTypes.func.isRequired,
+};
+
+function ControlledDrawerSection({ header, children, state, onStateChange }) {
+  const isOpen = state === STATES.open;
+
+  const toggleState = () => {
+    if (state === STATES.open) {
+      onStateChange(STATES.closed);
+    } else {
+      onStateChange(STATES.open);
+    }
+  };
 
   return (
     <Container isOpen={isOpen}>
       <Transformer isOpen={isOpen}>
         <Header
           isOpen={isOpen}
-          onClick={() => setIsOpen(isOpen => !isOpen)}
-          onKeyDown={e => e.key === "Enter" && setIsOpen(isOpen => !isOpen)}
+          onClick={toggleState}
+          onKeyDown={e => e.key === "Enter" && toggleState()}
         >
           {header}
           <Icon

--- a/frontend/src/metabase/components/DrawerSection/DrawerSection.jsx
+++ b/frontend/src/metabase/components/DrawerSection/DrawerSection.jsx
@@ -1,0 +1,42 @@
+import React, { useState } from "react";
+import PropTypes from "prop-types";
+
+import Icon from "metabase/components/Icon";
+import {
+  Container,
+  Transformer,
+  Children,
+  Header,
+} from "./DrawerSection.styled";
+
+DrawerSection.propTypes = {
+  header: PropTypes.node.isRequired,
+  children: PropTypes.node,
+  initialState: PropTypes.oneOf(["closed", "open"]),
+};
+
+function DrawerSection({ header, children, initialState = "closed" }) {
+  const [isOpen, setIsOpen] = useState(initialState === "open");
+
+  return (
+    <Container isOpen={isOpen}>
+      <Transformer isOpen={isOpen}>
+        <Header
+          isOpen={isOpen}
+          onClick={() => setIsOpen(isOpen => !isOpen)}
+          onKeyDown={e => e.key === "Enter" && setIsOpen(isOpen => !isOpen)}
+        >
+          {header}
+          <Icon
+            className="mr1"
+            name={isOpen ? "chevrondown" : "chevronup"}
+            size={12}
+          />
+        </Header>
+        <Children isOpen={isOpen}>{children}</Children>
+      </Transformer>
+    </Container>
+  );
+}
+
+export default DrawerSection;

--- a/frontend/src/metabase/components/DrawerSection/DrawerSection.styled.js
+++ b/frontend/src/metabase/components/DrawerSection/DrawerSection.styled.js
@@ -2,7 +2,7 @@ import styled from "styled-components";
 
 import { color } from "metabase/lib/colors";
 
-const HEADER_HEIGHT = "56px";
+const HEADER_HEIGHT = "49px";
 
 export const Container = styled.div`
   min-height: ${HEADER_HEIGHT};

--- a/frontend/src/metabase/components/DrawerSection/DrawerSection.styled.js
+++ b/frontend/src/metabase/components/DrawerSection/DrawerSection.styled.js
@@ -1,0 +1,49 @@
+import styled from "styled-components";
+
+import { color } from "metabase/lib/colors";
+
+const HEADER_HEIGHT = "56px";
+
+export const Container = styled.div`
+  min-height: ${HEADER_HEIGHT};
+  height: ${props => (props.isOpen ? "auto" : "100%")};
+  overflow: ${props => (props.isOpen ? "unset" : "hidden")};
+  position: relative;
+  width: 100%;
+`;
+
+export const Transformer = styled.div`
+  height: 100%;
+  position: relative;
+  width: 100%;
+
+  will-change: transform;
+  transform: ${props =>
+    props.isOpen
+      ? "translateY(0)"
+      : `translateY(calc(100% - ${HEADER_HEIGHT}))`};
+  transition: transform 0.2s ease-in-out;
+`;
+
+export const Children = styled.div`
+  display: ${props => (props.isOpen ? "block" : "none")};
+  padding: 0 1.5rem;
+`;
+
+export const Header = styled.div.attrs({
+  role: "button",
+  tabIndex: "0",
+})`
+  height: ${HEADER_HEIGHT};
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-top: 1px solid ${color("border")};
+  font-weight: 700;
+  padding: 0 1.5rem;
+
+  &:hover {
+    color: ${color("brand")};
+  }
+`;

--- a/frontend/src/metabase/components/Timeline.jsx
+++ b/frontend/src/metabase/components/Timeline.jsx
@@ -19,7 +19,8 @@ Timeline.propTypes = {
   items: PropTypes.arrayOf(
     PropTypes.shape({
       timestamp: PropTypes.number.isRequired,
-      icon: PropTypes.string.isRequired,
+      icon: PropTypes.oneOfType([PropTypes.string, PropTypes.object])
+        .isRequired,
       title: PropTypes.string.isRequired,
       description: PropTypes.string,
       renderFooter: PropTypes.bool,
@@ -61,11 +62,16 @@ function Timeline({ className, items = [], renderFooter }) {
         } = item;
         const key = item.key == null ? index : item.key;
         const isNotLastEvent = index !== sortedFormattedItems.length - 1;
+        const iconProps = _.isObject(icon)
+          ? icon
+          : {
+              name: icon,
+            };
 
         return (
           <TimelineItem key={key} leftShift={halfIconSize}>
             {isNotLastEvent && <Border borderShift={halfIconSize} />}
-            <ItemIcon name={icon} size={iconSize} />
+            <ItemIcon {...iconProps} size={iconSize} />
             <ItemBody>
               <ItemHeader>{title}</ItemHeader>
               <Timestamp datetime={timestamp}>{formattedTimestamp}</Timestamp>

--- a/frontend/src/metabase/components/Timeline.styled.jsx
+++ b/frontend/src/metabase/components/Timeline.styled.jsx
@@ -20,7 +20,7 @@ export const TimelineItem = styled.div`
 
 export const ItemIcon = styled(Icon)`
   position: relative;
-  color: ${color("text-light")};
+  color: ${props => (props.color ? color(props.color) : color("text-light"))};
 `;
 
 export const ItemBody = styled.div`

--- a/frontend/src/metabase/plugins/index.js
+++ b/frontend/src/metabase/plugins/index.js
@@ -3,6 +3,7 @@ import PluginPlaceholder from "metabase/plugins/components/PluginPlaceholder";
 
 // Plugin integration points. All exports must be objects or arrays so they can be mutated by plugins.
 const object = () => ({});
+const array = () => [];
 
 // functions called when the application is started
 export const PLUGIN_APP_INIT_FUCTIONS = [];
@@ -84,4 +85,5 @@ export const PLUGIN_MODERATION = {
   ModerationStatusIcon: PluginPlaceholder,
   getStatusIconForQuestion: object,
   getStatusIcon: object,
+  getModerationTimelineEvents: array,
 };

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -129,6 +129,12 @@ export const onOpenQuestionDetails = createAction(
 export const onCloseQuestionDetails = createAction(
   "metabase/qb/CLOSE_QUESTION_DETAILS",
 );
+export const onOpenQuestionHistory = createAction(
+  "metabase/qb/OPEN_QUESTION_HISTORY",
+);
+export const onCloseQuestionHistory = createAction(
+  "metabase/qb/CLOSE_QUESTION_HISTORY",
+);
 
 export const onCloseChartType = createAction("metabase/qb/CLOSE_CHART_TYPE");
 export const onCloseSidebars = createAction("metabase/qb/CLOSE_SIDEBARS");

--- a/frontend/src/metabase/query_builder/components/QuestionActivityTimeline.jsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActivityTimeline.jsx
@@ -6,23 +6,34 @@ import _ from "underscore";
 
 import { PLUGIN_MODERATION } from "metabase/plugins";
 import { getRevisionEventsForTimeline } from "metabase/lib/revisions";
-import { revertToRevision } from "metabase/query_builder/actions";
+import {
+  revertToRevision,
+  onOpenQuestionHistory,
+  onCloseQuestionHistory,
+} from "metabase/query_builder/actions";
 import { getUser } from "metabase/selectors/user";
+import { getQuestionDetailsTimelineDrawerState } from "metabase/query_builder/selectors";
 
 import Revision from "metabase/entities/revisions";
 import User from "metabase/entities/users";
 import Timeline from "metabase/components/Timeline";
-import DrawerSection from "metabase/components/DrawerSection/DrawerSection";
-import {
-  SidebarSectionHeader,
-  RevertButton,
-} from "./QuestionActivityTimeline.styled";
+import DrawerSection, {
+  STATES as DRAWER_STATES,
+} from "metabase/components/DrawerSection/DrawerSection";
+import { RevertButton } from "./QuestionActivityTimeline.styled";
 
 const { getModerationTimelineEvents } = PLUGIN_MODERATION;
 
 const mapStateToProps = (state, props) => ({
   currentUser: getUser(state),
+  drawerState: getQuestionDetailsTimelineDrawerState(state, props),
 });
+
+const mapDispatchToProps = {
+  revertToRevision,
+  onOpenQuestionHistory,
+  onCloseQuestionHistory,
+};
 
 export default _.compose(
   User.loadList({
@@ -37,9 +48,7 @@ export default _.compose(
   }),
   connect(
     mapStateToProps,
-    {
-      revertToRevision,
-    },
+    mapDispatchToProps,
   ),
 )(QuestionActivityTimeline);
 
@@ -64,20 +73,24 @@ function RevisionEventFooter({ revision, onRevisionClick }) {
 
 QuestionActivityTimeline.propTypes = {
   question: PropTypes.object.isRequired,
-  className: PropTypes.string,
   revisions: PropTypes.array,
   users: PropTypes.array,
   currentUser: PropTypes.object.isRequired,
   revertToRevision: PropTypes.func.isRequired,
+  drawerState: PropTypes.oneOf([DRAWER_STATES.open, DRAWER_STATES.closed]),
+  onOpenQuestionHistory: PropTypes.func.isRequired,
+  onCloseQuestionHistory: PropTypes.func.isRequired,
 };
 
 export function QuestionActivityTimeline({
   question,
-  className,
   revisions,
   users,
   currentUser,
   revertToRevision,
+  drawerState,
+  onOpenQuestionHistory,
+  onCloseQuestionHistory,
 }) {
   const usersById = useMemo(() => _.indexBy(users, "id"), [users]);
   const canWrite = question.canWrite();
@@ -93,8 +106,20 @@ export function QuestionActivityTimeline({
     return [...revisionEvents, ...moderationEvents];
   }, [canWrite, moderationReviews, revisions, usersById, currentUser]);
 
+  const onDrawerStateChange = state => {
+    if (state === DRAWER_STATES.open) {
+      onOpenQuestionHistory();
+    } else {
+      onCloseQuestionHistory();
+    }
+  };
+
   return (
-    <DrawerSection header={t`History`} className={className}>
+    <DrawerSection
+      header={t`History`}
+      state={drawerState}
+      onStateChange={onDrawerStateChange}
+    >
       <Timeline
         items={events}
         renderFooter={item => {

--- a/frontend/src/metabase/query_builder/components/QuestionActivityTimeline.jsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActivityTimeline.jsx
@@ -1,20 +1,33 @@
-import React from "react";
+import React, { useMemo } from "react";
 import PropTypes from "prop-types";
 import { t } from "ttag";
 import { connect } from "react-redux";
 import _ from "underscore";
 
+import { PLUGIN_MODERATION } from "metabase/plugins";
 import { getRevisionEventsForTimeline } from "metabase/lib/revisions";
 import { revertToRevision } from "metabase/query_builder/actions";
+import { getUser } from "metabase/selectors/user";
 
 import Revision from "metabase/entities/revisions";
+import User from "metabase/entities/users";
 import Timeline from "metabase/components/Timeline";
+import DrawerSection from "metabase/components/DrawerSection/DrawerSection";
 import {
   SidebarSectionHeader,
   RevertButton,
 } from "./QuestionActivityTimeline.styled";
 
+const { getModerationTimelineEvents } = PLUGIN_MODERATION;
+
+const mapStateToProps = (state, props) => ({
+  currentUser: getUser(state),
+});
+
 export default _.compose(
+  User.loadList({
+    loadingAndErrorWrapper: false,
+  }),
   Revision.loadList({
     query: (state, props) => ({
       model_type: "card",
@@ -23,7 +36,7 @@ export default _.compose(
     wrapped: true,
   }),
   connect(
-    null,
+    mapStateToProps,
     {
       revertToRevision,
     },
@@ -53,6 +66,8 @@ QuestionActivityTimeline.propTypes = {
   question: PropTypes.object.isRequired,
   className: PropTypes.string,
   revisions: PropTypes.array,
+  users: PropTypes.array,
+  currentUser: PropTypes.object.isRequired,
   revertToRevision: PropTypes.func.isRequired,
 };
 
@@ -60,16 +75,28 @@ export function QuestionActivityTimeline({
   question,
   className,
   revisions,
+  users,
+  currentUser,
   revertToRevision,
 }) {
+  const usersById = useMemo(() => _.indexBy(users, "id"), [users]);
   const canWrite = question.canWrite();
-  const revisionEvents = getRevisionEventsForTimeline(revisions, canWrite);
+  const moderationReviews = question.getModerationReviews();
+
+  const events = useMemo(() => {
+    const moderationEvents = getModerationTimelineEvents(
+      moderationReviews,
+      usersById,
+      currentUser,
+    );
+    const revisionEvents = getRevisionEventsForTimeline(revisions, canWrite);
+    return [...revisionEvents, ...moderationEvents];
+  }, [canWrite, moderationReviews, revisions, usersById, currentUser]);
 
   return (
-    <div className={className}>
-      <SidebarSectionHeader>{t`History`}</SidebarSectionHeader>
+    <DrawerSection header={t`History`} className={className}>
       <Timeline
-        items={revisionEvents}
+        items={events}
         renderFooter={item => {
           const { isRevertable, revision } = item;
           if (isRevertable) {
@@ -82,6 +109,6 @@ export function QuestionActivityTimeline({
           }
         }}
       />
-    </div>
+    </DrawerSection>
   );
 }

--- a/frontend/src/metabase/query_builder/components/QuestionActivityTimeline.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActivityTimeline.styled.jsx
@@ -1,25 +1,6 @@
 import styled from "styled-components";
 import { color } from "metabase/lib/colors";
 import ActionButton from "metabase/components/ActionButton";
-import Button from "metabase/components/Button";
-
-export const SidebarSectionHeader = styled.div`
-  color: ${color("text-medium")};
-  font-weight: bold;
-  padding-bottom: 1rem;
-`;
-
-export const RequestButton = styled(Button)`
-  padding: 0;
-  border: none;
-  color: ${props => color(props.color)};
-
-  &:hover {
-    text-decoration: underline;
-    background-color: transparent;
-    color: ${props => color(props.color)};
-  }
-`;
 
 export const RevertButton = styled(ActionButton).attrs({
   successClassName: "",

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -55,6 +55,7 @@ const viewTitleHeaderPropTypes = {
   onCloseFilter: PropTypes.func,
   onOpenQuestionDetails: PropTypes.func,
   onCloseQuestionDetails: PropTypes.func,
+  onOpenQuestionHistory: PropTypes.func,
 
   isPreviewable: PropTypes.bool,
   isPreviewing: PropTypes.bool,
@@ -119,6 +120,7 @@ export class ViewTitleHeader extends React.Component {
       isShowingQuestionDetailsSidebar,
       onOpenQuestionDetails,
       onCloseQuestionDetails,
+      onOpenQuestionHistory,
     } = this.props;
     const { isFiltersExpanded } = this.state;
     const isShowingNotebook = queryBuilderMode === "notebook";
@@ -161,7 +163,7 @@ export class ViewTitleHeader extends React.Component {
                 <LastEditInfoLabel
                   className="ml1 text-light"
                   item={question.card()}
-                  onClick={() => onOpenModal("history")}
+                  onClick={onOpenQuestionHistory}
                 />
               )}
             </div>

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebarPanel.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebarPanel.jsx
@@ -1,7 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-import SidebarContent from "metabase/query_builder/components/SidebarContent";
 import QuestionActionButtons from "metabase/query_builder/components/QuestionActionButtons";
 import { ClampedDescription } from "metabase/query_builder/components/ClampedDescription";
 import {

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebarPanel.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebarPanel.jsx
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 import QuestionActionButtons from "metabase/query_builder/components/QuestionActionButtons";
 import { ClampedDescription } from "metabase/query_builder/components/ClampedDescription";
 import {
-  PreventOverflowHeight,
+  Container,
   SidebarPaddedContent,
 } from "./QuestionDetailsSidebarPanel.styled";
 import QuestionActivityTimeline from "metabase/query_builder/components/QuestionActivityTimeline";
@@ -34,7 +34,7 @@ function QuestionDetailsSidebarPanel({
     : undefined;
 
   return (
-    <PreventOverflowHeight>
+    <Container>
       <SidebarPaddedContent>
         <QuestionActionButtons canWrite={canWrite} onOpenModal={onOpenModal} />
         <ClampedDescription
@@ -46,6 +46,6 @@ function QuestionDetailsSidebarPanel({
         <PLUGIN_MODERATION.QuestionModerationSection question={question} />
       </SidebarPaddedContent>
       <QuestionActivityTimeline question={question} />
-    </PreventOverflowHeight>
+    </Container>
   );
 }

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebarPanel.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebarPanel.jsx
@@ -5,9 +5,11 @@ import SidebarContent from "metabase/query_builder/components/SidebarContent";
 import QuestionActionButtons from "metabase/query_builder/components/QuestionActionButtons";
 import { ClampedDescription } from "metabase/query_builder/components/ClampedDescription";
 import {
-  SidebarContentContainer,
-  BorderedQuestionActivityTimeline,
+  PreventOverflowHeight,
+  SidebarPaddedContent,
 } from "./QuestionDetailsSidebarPanel.styled";
+import QuestionActivityTimeline from "metabase/query_builder/components/QuestionActivityTimeline";
+
 import { PLUGIN_MODERATION } from "metabase/plugins";
 
 export default QuestionDetailsSidebarPanel;
@@ -33,8 +35,8 @@ function QuestionDetailsSidebarPanel({
     : undefined;
 
   return (
-    <SidebarContent>
-      <SidebarContentContainer>
+    <PreventOverflowHeight>
+      <SidebarPaddedContent>
         <QuestionActionButtons canWrite={canWrite} onOpenModal={onOpenModal} />
         <ClampedDescription
           className="pb2"
@@ -43,8 +45,8 @@ function QuestionDetailsSidebarPanel({
           onEdit={onDescriptionEdit}
         />
         <PLUGIN_MODERATION.QuestionModerationSection question={question} />
-        <BorderedQuestionActivityTimeline question={question} />
-      </SidebarContentContainer>
-    </SidebarContent>
+      </SidebarPaddedContent>
+      <QuestionActivityTimeline question={question} />
+    </PreventOverflowHeight>
   );
 }

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebarPanel.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebarPanel.styled.jsx
@@ -1,21 +1,15 @@
 import styled from "styled-components";
-import { color } from "metabase/lib/colors";
-import QuestionActivityTimeline from "metabase/query_builder/components/QuestionActivityTimeline";
 
-export const SidebarContentContainer = styled.div`
+export const PreventOverflowHeight = styled.div`
+  height: 100%;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+`;
+
+export const SidebarPaddedContent = styled.div`
   display: flex;
   flex-direction: column;
   row-gap: 1rem;
-  padding: 0.5rem 1.5rem;
-`;
-
-export const PanelSection = styled.div`
-  border-top: 1px solid ${color("border")};
-`;
-
-export const BorderedQuestionActivityTimeline = styled(
-  QuestionActivityTimeline,
-)`
-  border-top: 1px solid ${color("border")};
-  padding-top: 1rem;
+  padding: 0.5rem 1.5rem 1rem 1.5rem;
 `;

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebarPanel.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebarPanel.styled.jsx
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
-export const PreventOverflowHeight = styled.div`
+export const Container = styled.div`
   height: 100%;
   overflow-y: auto;
   display: flex;

--- a/frontend/src/metabase/query_builder/reducers.js
+++ b/frontend/src/metabase/query_builder/reducers.js
@@ -47,6 +47,8 @@ import {
   onCloseSidebars,
   onOpenQuestionDetails,
   onCloseQuestionDetails,
+  onOpenQuestionHistory,
+  onCloseQuestionHistory,
 } from "./actions";
 
 const DEFAULT_UI_CONTROLS = {
@@ -216,10 +218,24 @@ export const uiControls = handleActions(
       ...state,
       ...UI_CONTROLS_SIDEBAR_DEFAULTS,
       isShowingQuestionDetailsSidebar: true,
+      questionDetailsTimelineDrawerState: undefined,
     }),
     [onCloseQuestionDetails]: state => ({
       ...state,
       ...UI_CONTROLS_SIDEBAR_DEFAULTS,
+      questionDetailsTimelineDrawerState: undefined,
+    }),
+    [onOpenQuestionHistory]: state => ({
+      ...state,
+      ...UI_CONTROLS_SIDEBAR_DEFAULTS,
+      isShowingQuestionDetailsSidebar: true,
+      questionDetailsTimelineDrawerState: "open",
+    }),
+    [onCloseQuestionHistory]: state => ({
+      ...state,
+      ...UI_CONTROLS_SIDEBAR_DEFAULTS,
+      isShowingQuestionDetailsSidebar: true,
+      questionDetailsTimelineDrawerState: "closed",
     }),
     [onCloseSidebars]: state => ({
       ...state,

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -462,3 +462,8 @@ export const getIsLiveResizable = createSelector(
     }
   },
 );
+
+export const getQuestionDetailsTimelineDrawerState = createSelector(
+  [getUiControls],
+  uiControls => uiControls && uiControls.questionDetailsTimelineDrawerState,
+);

--- a/frontend/test/metabase/query_builder/selectors.unit.spec.js
+++ b/frontend/test/metabase/query_builder/selectors.unit.spec.js
@@ -2,6 +2,7 @@ import {
   getIsResultDirty,
   getNativeEditorCursorOffset,
   getNativeEditorSelectedText,
+  getQuestionDetailsTimelineDrawerState,
 } from "metabase/query_builder/selectors";
 import { state as sampleState } from "__support__/sample_dataset_fixture";
 
@@ -139,5 +140,18 @@ describe("getIsResultDirty", () => {
         }),
       );
     });
+  });
+});
+
+describe("getQuestionDetailsTimelineDrawerState", () => {
+  it("should return a string representing the state of the question history timeline drawer", () => {
+    const state = {
+      qb: {
+        uiControls: {
+          questionDetailsTimelineDrawerState: "foo",
+        },
+      },
+    };
+    expect(getQuestionDetailsTimelineDrawerState(state)).toBe("foo");
   });
 });

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -672,19 +672,17 @@ describe("collection permissions", () => {
                 cy.findByText("This dashboard is looking empty.");
               });
 
-              it("should be able to revert the question via the revision history modal", () => {
-                // It's possible that the mechanics of who should be able to revert the question will change (see https://github.com/metabase/metabase/issues/15131)
-                // For now that's not possible for user without data access (likely it will be again when #11719 is fixed)
+              it("should be able to access the question's revision history via the revision history button in the header of the query builder", () => {
                 cy.skipOn(user === "nodata");
+
                 cy.visit("/question/1");
                 cy.findByTestId("revision-history-button").click();
+                cy.findByText("Revert").click();
 
-                clickRevert("First revision.");
                 cy.wait("@revert").then(xhr => {
                   expect(xhr.status).to.eq(200);
                   expect(xhr.cause).not.to.exist;
                 });
-                cy.findAllByText(/Revert/).should("not.exist");
 
                 cy.contains(/^Orders$/);
               });
@@ -694,6 +692,7 @@ describe("collection permissions", () => {
 
                 cy.visit("/question/1");
                 cy.findByTestId("saved-question-header-button").click();
+                cy.findByText("History").click();
                 cy.findByText("Revert").click();
 
                 cy.wait("@revert").then(xhr => {

--- a/frontend/test/metabase/scenarios/moderation/question-moderation.cy.spec.js
+++ b/frontend/test/metabase/scenarios/moderation/question-moderation.cy.spec.js
@@ -50,6 +50,17 @@ describeWithToken("scenarios > saved question moderation", () => {
         .find(".Icon-verified")
         .should("not.exist");
     });
+
+    it("should be able to see evidence of verification/unverification in the question's timeline", () => {
+      cy.findByTestId("saved-question-header-button").click();
+      cy.findByText("History").click();
+
+      cy.findByTestId("moderation-verify-action").click();
+      cy.findByText("You verified this").should("exist");
+
+      cy.findByTestId("moderation-remove-review-action").click();
+      cy.findByText("You unverified this").should("exist");
+    });
   });
 
   describe("as a non-admin user", () => {
@@ -104,6 +115,15 @@ describeWithToken("scenarios > saved question moderation", () => {
       cy.findByText("Orders, Count")
         .icon("verified")
         .should("exist");
+    });
+
+    it("should be able to see the question verification in the question's timeline", () => {
+      cy.visit("/question/2");
+
+      cy.findByTestId("saved-question-header-button").click();
+      cy.findByText("History").click();
+
+      cy.findByText("A moderator verified this").should("exist");
     });
   });
 });

--- a/frontend/test/metabase/scenarios/moderation/question-moderation.cy.spec.js
+++ b/frontend/test/metabase/scenarios/moderation/question-moderation.cy.spec.js
@@ -17,15 +17,11 @@ describeWithToken("scenarios > saved question moderation", () => {
       cy.findByText("You verified this").should("be.visible");
 
       cy.findByPlaceholderText("Search…").type("orders{enter}");
-      cy.findByText("Orders, Count")
-        .icon("verified")
-        .should("exist");
+      cy.findByText("Orders, Count").icon("verified");
 
       cy.visit("/collection/root");
 
-      cy.findByText("Orders, Count")
-        .icon("verified")
-        .should("exist");
+      cy.findByText("Orders, Count").icon("verified");
     });
 
     it("should be able to unverify a verified saved question", () => {
@@ -56,10 +52,10 @@ describeWithToken("scenarios > saved question moderation", () => {
       cy.findByText("History").click();
 
       cy.findByTestId("moderation-verify-action").click();
-      cy.findByText("You verified this").should("exist");
+      cy.findByText("You verified this");
 
       cy.findByTestId("moderation-remove-review-action").click();
-      cy.findByText("You unverified this").should("exist");
+      cy.findByText("You unverified this");
     });
   });
 
@@ -100,21 +96,17 @@ describeWithToken("scenarios > saved question moderation", () => {
     it("should be able to see that a question has been verified", () => {
       cy.visit("/question/2");
 
-      cy.icon("verified").should("exist");
+      cy.icon("verified");
 
       cy.findByTestId("saved-question-header-button").click();
-      cy.findByText("A moderator verified this").should("exist");
+      cy.findByText("A moderator verified this");
 
       cy.findByPlaceholderText("Search…").type("orders{enter}");
-      cy.findByText("Orders, Count")
-        .icon("verified")
-        .should("exist");
+      cy.findByText("Orders, Count").icon("verified");
 
       cy.visit("/collection/root");
 
-      cy.findByText("Orders, Count")
-        .icon("verified")
-        .should("exist");
+      cy.findByText("Orders, Count").icon("verified");
     });
 
     it("should be able to see the question verification in the question's timeline", () => {
@@ -123,7 +115,7 @@ describeWithToken("scenarios > saved question moderation", () => {
       cy.findByTestId("saved-question-header-button").click();
       cy.findByText("History").click();
 
-      cy.findByText("A moderator verified this").should("exist");
+      cy.findByText("A moderator verified this");
     });
   });
 });


### PR DESCRIPTION
1. Hides the question history timeline in a little drawer. Created a `DrawerSection` for this. The implementation is a bit specific to a sidebar and can only be used for a single, final section of a sidebar, but we can improve the implementation later if necessary.
2. Added moderation events (verification) to the timeline


https://user-images.githubusercontent.com/13057258/129126089-9ceb62e7-2f15-464b-a923-75f6ff011f47.mov

