### PR TITLE
Fix collection sidebar chevron icons vertical alignment

### DIFF
--- a/frontend/src/metabase/collections/containers/CollectionSidebar/Collections/CollectionsList/CollectionsList.styled.js
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/Collections/CollectionsList/CollectionsList.styled.js
@@ -44,5 +44,6 @@ export const ExpandCollectionButton = styled(IconButtonWrapper)`
 
 export const LabelContainer = styled.div`
   display: flex;
+  align-items: center;
   position: relative;
 `;


### PR DESCRIPTION
Currently, chevron icons in the collection sidebar are not centered vertically, so they don't look as expected

### To Verify

1. Go to `/collection/root`
2. Make sure chevrons in any state (collapsed and expanded) are centered vertically

### Demo

**Before**

<img width="338" alt="before" src="https://user-images.githubusercontent.com/17258145/129023444-b0bfb069-420a-45ff-9966-802894609344.png">


**After**

<img width="339" alt="after" src="https://user-images.githubusercontent.com/17258145/129023405-1913f253-6b1b-4596-8768-9e089db0414d.png">
