### PR TITLE
Update homepage official collection display

### DIFF
--- a/frontend/src/metabase/components/CollectionItem.jsx
+++ b/frontend/src/metabase/components/CollectionItem.jsx
@@ -24,7 +24,7 @@ const CollectionItem = ({ collection, event }) => {
     <ItemLink to={collection.getUrl()} data-metabase-event={event}>
       <Card hoverable>
         <CardContent>
-          <IconContainer>
+          <IconContainer color={icon.color}>
             <CollectionIcon name={icon.name} />
           </IconContainer>
           <h4 className="overflow-hidden">

--- a/frontend/src/metabase/components/CollectionItem.styled.js
+++ b/frontend/src/metabase/components/CollectionItem.styled.js
@@ -22,7 +22,7 @@ export const IconContainer = styled.div`
   flex-shrink: 0;
   height: 42px;
   width: 42px;
-  background-color: ${color("bg-dark")};
+  background-color: ${props => color(props.color || "bg-dark")};
   margin-right: ${space(1)};
   border-radius: 6px;
 `;


### PR DESCRIPTION
Slightly changes how we present official collections on the homepage. The icon is now white, but the background is yellow

### To Verify

1. Spin up Metabase Enterprise and sign in as admin
2. Create an official collection
    - Go to `/collection/root`
    - Click the "new folder" icon in the top right
    - Fill in a new collection name and select "Official" from the picker
    - Click "Create"
3. Go to `/`
4. Make sure the official collection is displayed, the icon has to be white and the "icon container" background has to be yellow
5. Make sure regular collections look as they're used to

 ### Demo

**Before**

![CleanShot 2021-08-11 at 14 50 13@2x](https://user-images.githubusercontent.com/17258145/129024446-e2f0edfc-852a-4272-8d6a-5e9cd669793f.png)

**After**

![CleanShot 2021-08-11 at 14 52 03@2x](https://user-images.githubusercontent.com/17258145/129024475-233fafd0-d73f-4e48-8182-77a5794efd88.png)
