### PR TITLE
Update collection type input

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/collections/components/FormCollectionAuthorityLevel.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/collections/components/FormCollectionAuthorityLevel.jsx
@@ -43,6 +43,8 @@ export function FormCollectionAuthorityLevel({
         value={field.value}
         onChange={field.onChange}
         options={options}
+        variant="fill-background"
+        inactiveColor="text-dark"
       />
       {shouldSuggestToUpdateChildren && (
         <CheckBox

--- a/frontend/src/metabase/components/SegmentedControl.info.js
+++ b/frontend/src/metabase/components/SegmentedControl.info.js
@@ -49,6 +49,16 @@ function SegmentedControlDemo(props) {
 
 export const examples = {
   default: <SegmentedControlDemo options={SIMPLE_OPTIONS} />,
+  variants: (
+    <React.Fragment>
+      <SegmentedControlDemo options={SIMPLE_OPTIONS} variant="fill-text" />
+      <br />
+      <SegmentedControlDemo
+        options={SIMPLE_OPTIONS}
+        variant="fill-background"
+      />
+    </React.Fragment>
+  ),
   icons: <SegmentedControlDemo options={OPTIONS_WITH_ICONS} />,
   iconsOnly: <SegmentedControlDemo options={OPTIONS_ICONS_ONLY} />,
   colored: <SegmentedControlDemo options={OPTIONS_WITH_COLORS} />,

--- a/frontend/src/metabase/components/SegmentedControl.jsx
+++ b/frontend/src/metabase/components/SegmentedControl.jsx
@@ -25,6 +25,7 @@ const propTypes = {
   name: PropTypes.string,
   value: PropTypes.any,
   options: PropTypes.arrayOf(optionShape).isRequired,
+  variant: PropTypes.oneOf(["fill-text", "fill-background"]),
   inactiveColor: PropTypes.string,
   onChange: PropTypes.func,
   fullWidth: PropTypes.bool,
@@ -39,6 +40,7 @@ export function SegmentedControl({
   onChange,
   fullWidth = false,
   inactiveColor = "text-medium",
+  variant = "fill-text",
   ...props
 }) {
   const id = useMemo(() => _.uniqueId("radio-"), []);
@@ -52,17 +54,22 @@ export function SegmentedControl({
         const id = `${name}-${option.value}`;
         const labelId = `${name}-${option.value}`;
         const iconOnly = !option.name;
+        const selectedColor = option.selectedColor || "brand";
         return (
           <SegmentedItem
             key={option.value}
+            isSelected={isSelected}
             isFirst={isFirst}
             isLast={isLast}
             fullWidth={fullWidth}
+            variant={variant}
+            selectedColor={selectedColor}
           >
             <SegmentedItemLabel
               id={labelId}
               isSelected={isSelected}
-              selectedColor={option.selectedColor || "brand"}
+              variant={variant}
+              selectedColor={selectedColor}
               inactiveColor={inactiveColor}
               compact={iconOnly}
             >

--- a/frontend/src/metabase/components/SegmentedControl.styled.js
+++ b/frontend/src/metabase/components/SegmentedControl.styled.js
@@ -2,7 +2,7 @@ import React from "react";
 import styled from "styled-components";
 import _ from "underscore";
 import Icon from "metabase/components/Icon";
-import { color } from "metabase/lib/colors";
+import { color, darken } from "metabase/lib/colors";
 
 const BORDER_RADIUS = "8px";
 
@@ -11,11 +11,22 @@ export const SegmentedList = styled.ul`
   width: ${props => (props.fullWidth ? 1 : 0)};
 `;
 
+function getSegmentedItemColor(props, fallbackColor) {
+  if (props.variant === "fill-text") {
+    return fallbackColor;
+  }
+  return props.isSelected ? color(props.selectedColor) : fallbackColor;
+}
+
 export const SegmentedItem = styled.li`
   display: flex;
   flex-grow: ${props => (props.fullWidth ? 1 : 0)};
 
-  border: 1px solid ${color("border")};
+  background-color: ${props => getSegmentedItemColor(props, "transparent")};
+
+  border: 1px solid
+    ${props => getSegmentedItemColor(props, darken(color("border"), 0.1))};
+
   border-right-width: ${props => (props.isLast ? "1px" : 0)};
   border-top-left-radius: ${props => (props.isFirst ? BORDER_RADIUS : 0)};
   border-bottom-left-radius: ${props => (props.isFirst ? BORDER_RADIUS : 0)};
@@ -30,8 +41,12 @@ export const SegmentedItemLabel = styled.label`
   justify-content: center;
   position: relative;
   font-weight: bold;
-  color: ${props =>
-    props.isSelected ? color(props.selectedColor) : color(props.inactiveColor)};
+  color: ${props => {
+    const selectedColor = color(
+      props.variant === "fill-text" ? props.selectedColor : "white",
+    );
+    return props.isSelected ? selectedColor : color(props.inactiveColor);
+  }};
   padding: ${props => (props.compact ? "8px" : "8px 12px")};
   cursor: pointer;
 


### PR DESCRIPTION
This PR updates "Collection type" input according to feedback from #17336

* selected collection type is now highlighted via options background color instead of text color. Details: collection type input uses a `SegmentedControl` component. This PR adds a `variant` prop for it (can be `fill-text` or `fill-background; `fill-text` is a default one)
* makes the border color match the inputs: #CED3D7
* makes the unselected toggle text color text-dark

### To Verify

1. Spin up Metabase Enterprise and sign in as admin
2. Go to `/collection/root`
3. Click the "new folder" icon in the top right
4. Make sure the "Collection type" field widget now looks differently

### Demo

**Before**

![2021-08-11 15 14 31](https://user-images.githubusercontent.com/17258145/129027584-05af631d-1ca3-423c-988f-d69dbbd01aad.gif)

**After**

![2021-08-11 15 16 35](https://user-images.githubusercontent.com/17258145/129027598-c2690502-2fe2-4a65-bb67-a18efe01cbe8.gif)
