### PR TITLE
Polish CollectionBadge for official items

### DIFF
--- a/frontend/src/metabase/components/Badge.jsx
+++ b/frontend/src/metabase/components/Badge.jsx
@@ -1,18 +1,14 @@
 import React from "react";
 import PropTypes from "prop-types";
 
+import { iconPropTypes } from "metabase/components/Icon";
+
 import { BadgeIcon, MaybeLink } from "./Badge.styled";
 
 const propTypes = {
   name: PropTypes.string.isRequired,
   to: PropTypes.string,
-  icon: PropTypes.shape({
-    name: PropTypes.string.isRequired,
-    color: PropTypes.string,
-    width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-    height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-    size: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-  }),
+  icon: PropTypes.shape(iconPropTypes),
   activeColor: PropTypes.string,
   onClick: PropTypes.func,
   children: PropTypes.node,

--- a/frontend/src/metabase/components/Badge.jsx
+++ b/frontend/src/metabase/components/Badge.jsx
@@ -13,19 +13,20 @@ const propTypes = {
     height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     size: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   }),
+  activeColor: PropTypes.string,
   onClick: PropTypes.func,
   children: PropTypes.node,
 };
 
 const DEFAULT_ICON_SIZE = 12;
 
-function Badge({ name, icon, children, ...props }) {
+function Badge({ name, icon, activeColor = "brand", children, ...props }) {
   const extraIconProps = {};
   if (icon && !icon.size && !icon.width && !icon.height) {
     extraIconProps.size = DEFAULT_ICON_SIZE;
   }
   return (
-    <MaybeLink {...props}>
+    <MaybeLink activeColor={activeColor} {...props}>
       {icon && (
         <BadgeIcon {...icon} {...extraIconProps} hasMargin={!!children} />
       )}

--- a/frontend/src/metabase/components/Badge.jsx
+++ b/frontend/src/metabase/components/Badge.jsx
@@ -6,17 +6,28 @@ import { BadgeIcon, MaybeLink } from "./Badge.styled";
 const propTypes = {
   name: PropTypes.string.isRequired,
   to: PropTypes.string,
-  icon: PropTypes.string,
-  iconColor: PropTypes.string,
+  icon: PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    color: PropTypes.string,
+    width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    size: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  }),
   onClick: PropTypes.func,
   children: PropTypes.node,
 };
 
-function Badge({ name, icon, iconColor, children, ...props }) {
+const DEFAULT_ICON_SIZE = 12;
+
+function Badge({ name, icon, children, ...props }) {
+  const extraIconProps = {};
+  if (icon && !icon.size && !icon.width && !icon.height) {
+    extraIconProps.size = DEFAULT_ICON_SIZE;
+  }
   return (
     <MaybeLink {...props}>
       {icon && (
-        <BadgeIcon name={icon} color={iconColor} hasMargin={!!children} />
+        <BadgeIcon {...icon} {...extraIconProps} hasMargin={!!children} />
       )}
       {children && <span className="text-wrap">{children}</span>}
     </MaybeLink>

--- a/frontend/src/metabase/components/Badge.styled.jsx
+++ b/frontend/src/metabase/components/Badge.styled.jsx
@@ -17,7 +17,7 @@ RawMaybeLink.propTypes = propTypes;
 
 const hoverStyle = css`
   cursor: pointer;
-  color: ${color("brand")};
+  color: ${props => color(props.activeColor)};
 `;
 
 export const MaybeLink = styled(RawMaybeLink)`

--- a/frontend/src/metabase/components/Badge.styled.jsx
+++ b/frontend/src/metabase/components/Badge.styled.jsx
@@ -32,6 +32,6 @@ export const MaybeLink = styled(RawMaybeLink)`
   }
 `;
 
-export const BadgeIcon = styled(Icon).attrs({ size: 12 })`
+export const BadgeIcon = styled(Icon)`
   margin-right: ${props => (props.hasMargin ? "5px" : 0)};
 `;

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
@@ -88,7 +88,7 @@ const SubHeadBreadcrumbs = ({ parts, className, ...props }) => (
   <span {...props} className={className}>
     <span className="flex align-center flex-wrap mbn1">
       {parts.map(({ name, icon, href }, index) => (
-        <Badge key={index} className="mr2 mb1" icon={icon} to={href}>
+        <Badge key={index} className="mr2 mb1" icon={{ name: icon }} to={href}>
           {name}
         </Badge>
       ))}

--- a/frontend/src/metabase/questions/components/CollectionBadge.jsx
+++ b/frontend/src/metabase/questions/components/CollectionBadge.jsx
@@ -4,6 +4,7 @@ import PropTypes from "prop-types";
 import Badge from "metabase/components/Badge";
 
 import Collection from "metabase/entities/collections";
+import { PLUGIN_COLLECTIONS } from "metabase/plugins";
 
 const propTypes = {
   collection: PropTypes.object,
@@ -15,11 +16,18 @@ function CollectionBadge({ collection, analyticsContext, className }) {
   if (!collection) {
     return null;
   }
+  const isRegular = PLUGIN_COLLECTIONS.isRegularCollection(collection);
   const icon = collection.getIcon();
   const iconProps = {
     name: icon.name,
     color: icon.color,
   };
+  if (!isRegular) {
+    iconProps.width = 14;
+    iconProps.height = 16;
+  } else {
+    iconProps.size = 12;
+  }
   return (
     <Badge
       to={collection.getUrl()}
@@ -39,5 +47,5 @@ export default Collection.load({
   id: (state, props) => props.collectionId || "root",
   wrapped: true,
   loadingAndErrorWrapper: false,
-  properties: ["name"],
+  properties: ["name", "authority_level"],
 })(CollectionBadge);

--- a/frontend/src/metabase/questions/components/CollectionBadge.jsx
+++ b/frontend/src/metabase/questions/components/CollectionBadge.jsx
@@ -16,11 +16,14 @@ function CollectionBadge({ collection, analyticsContext, className }) {
     return null;
   }
   const icon = collection.getIcon();
+  const iconProps = {
+    name: icon.name,
+    color: icon.color,
+  };
   return (
     <Badge
       to={collection.getUrl()}
-      icon={icon.name}
-      iconColor={icon.color}
+      icon={iconProps}
       className={className}
       data-metabase-event={`${analyticsContext};Collection Badge Click`}
     >

--- a/frontend/src/metabase/questions/components/CollectionBadge.jsx
+++ b/frontend/src/metabase/questions/components/CollectionBadge.jsx
@@ -24,6 +24,7 @@ function CollectionBadge({ collection, analyticsContext, className }) {
     <Badge
       to={collection.getUrl()}
       icon={iconProps}
+      activeColor={icon.color}
       className={className}
       data-metabase-event={`${analyticsContext};Collection Badge Click`}
     >

--- a/frontend/src/metabase/questions/components/CollectionBadge.jsx
+++ b/frontend/src/metabase/questions/components/CollectionBadge.jsx
@@ -17,21 +17,14 @@ function CollectionBadge({ collection, analyticsContext, className }) {
     return null;
   }
   const isRegular = PLUGIN_COLLECTIONS.isRegularCollection(collection);
-  const icon = collection.getIcon();
-  const iconProps = {
-    name: icon.name,
-    color: icon.color,
+  const icon = {
+    ...collection.getIcon(),
+    ...(isRegular ? { size: 12 } : { width: 14, height: 16 }),
   };
-  if (!isRegular) {
-    iconProps.width = 14;
-    iconProps.height = 16;
-  } else {
-    iconProps.size = 12;
-  }
   return (
     <Badge
       to={collection.getUrl()}
-      icon={iconProps}
+      icon={icon}
       activeColor={icon.color}
       className={className}
       data-metabase-event={`${analyticsContext};Collection Badge Click`}


### PR DESCRIPTION
Slightly updates the CollectionBadge component for official items according to feedback from #17336

* increases official "ribbon" icon size (no changes for regular items icon)
* change badge's label hover text color to yellow (no changes for regular items icon)

### To Verify

1. Spin up Metabase Enterprise and sign in as admin
2. Create an official collection
    - Go to `/collection/root`
    - Click the "new folder" icon in the top right
    - Fill in a new collection name and select "Official" from the picker
    - Click "Create"
3. Put a question and a dashboard inside the official collection, open both of them
4. Hover the CollectionBadge component (icon and collection name in the top left). Make sure the hovered text color is yellow. Click the badge and make sure you're navigated to the specified collection
5. Open a question and a dashboard living inside a _regular_ collection (e.g. personal collection or Our Analytics)
6. Make sure the Collection Badge looks as it used to, make sure the hover text color is blue (`brand`)

### Demo

**Before**

![question-before](https://user-images.githubusercontent.com/17258145/129034800-5babace7-f8dc-49d2-bcdb-6a4326627b1f.gif)

![dashboard-before](https://user-images.githubusercontent.com/17258145/129034793-1d5be431-ab06-40a8-8175-6e30896ba921.gif)

**After**

![question-after](https://user-images.githubusercontent.com/17258145/129034797-01ea6e03-2914-40fa-8089-51731e44b8d0.gif)

![dashboard-after](https://user-images.githubusercontent.com/17258145/129034789-d05a629a-c612-4a94-aa8f-d61a328f15e9.gif)
