### PR TITLE
Increase official collection badge size in search results

### DIFF
--- a/frontend/src/metabase/search/components/SearchResult.jsx
+++ b/frontend/src/metabase/search/components/SearchResult.jsx
@@ -13,6 +13,7 @@ import Link from "metabase/components/Link";
 import Text from "metabase/components/type/Text";
 
 import {
+  PLUGIN_COLLECTIONS,
   PLUGIN_COLLECTION_COMPONENTS,
   PLUGIN_MODERATION,
 } from "metabase/plugins";
@@ -98,15 +99,38 @@ const TitleWrapper = styled.div`
   grid-gap: 0.25rem;
   align-items: center;
 `;
+const DEFAULT_ICON_SIZE = 20;
+
+function TableIcon() {
+  return <Icon name="database" />;
+}
+
+function CollectionIcon({ item }) {
+  const iconProps = { ...item.getIcon() };
+  const isRegular = PLUGIN_COLLECTIONS.isRegularCollection(item);
+  if (isRegular) {
+    iconProps.size = DEFAULT_ICON_SIZE;
+  } else {
+    iconProps.width = 20;
+    iconProps.height = 24;
+  }
+  return <Icon {...iconProps} />;
+}
+
+const ModelIconComponentMap = {
+  table: TableIcon,
+  collection: CollectionIcon,
+};
+
+function DefaultIcon({ item }) {
+  return <Icon {...item.getIcon()} size={DEFAULT_ICON_SIZE} />;
+}
 
 function ItemIcon({ item, type }) {
+  const IconComponent = ModelIconComponentMap[type] || DefaultIcon;
   return (
     <IconWrapper item={item} type={type}>
-      {type === "table" ? (
-        <Icon name="database" />
-      ) : (
-        <Icon {...item.getIcon()} size={20} />
-      )}
+      <IconComponent item={item} />
     </IconWrapper>
   );
 }


### PR DESCRIPTION
Increases official collection icon size in search results according to feedback from #17336

### To Verify

1. Spin up Metabase Enterprise and sign in as admin
2. Create an official collection
    - Go to `/collection/root`
    - Click the "new folder" icon in the top right
    - Fill in a new collection name and select "Official" from the picker
    - Click "Create"
3. Search for your new collection by name using the search bar in the top left
4. Make sure the official collection icon size is increased to 20x24px

### Demo

**Before**

![before](https://user-images.githubusercontent.com/17258145/129035960-6be3f356-93ef-4270-baed-f6d16ed4ae4e.png)

**After**

![after](https://user-images.githubusercontent.com/17258145/129035977-e61f669d-ec36-45d4-a192-8ec9907bff12.png)
