### PR TITLE
Do not use Flex prop shorthands in version notice

### DIFF
--- a/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/VersionUpdateNotice/VersionUpdateNotice.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/VersionUpdateNotice/VersionUpdateNotice.jsx
@@ -120,8 +120,8 @@ function HostingCTA() {
       <Flex>
         <Flex
           className="circular bg-medium align-center justify-center ml1 mr2"
-          h={32}
-          w={52}
+          width={52}
+          height={32}
         >
           <Icon name="cloud" size={24} />
         </Flex>


### PR DESCRIPTION
**How to verify**: go to Admin, Updates.

If necessary (e.g. via debugger), change `shouldShowHostedCta` to true (in `VersionUpdateNotice.jsx`).

Pay attention to the container enclosing the cloud icon:

![image](https://user-images.githubusercontent.com/7288/129068129-e205203e-d42a-4ed5-a6a7-9f20d06000a1.png)

Before and after this change, it should look **exactly** the same.