### PR TITLE
Fix order of cards in dashboard subscriptions

### DIFF
--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -91,12 +91,22 @@
     (catch Throwable e
         (log/warn e (trs "Error running query for Card {0}" card-or-id)))))
 
+(defn- dashcard-layout-comparator
+  "Comparator that determines which of two dashcards comes first in the layout order used for pulses.
+  This is the same order used on the frontend for the mobile layout. Orders cards left-to-right, then top-to-bottom"
+  [dashcard-1 dashcard-2]
+  (if-not (= (:row dashcard-1) (:row dashcard-2))
+    (compare (:row dashcard-1) (:row dashcard-2))
+    (compare (:col dashcard-1) (:col dashcard-2))))
+
 (defn execute-dashboard
   "Execute all the cards in a dashboard for a Pulse"
   [{pulse-creator-id :creator_id, :as pulse} dashboard-or-id & {:as options}]
   (let [dashboard-id (u/the-id dashboard-or-id)
-        dashboard (Dashboard :id dashboard-id)]
-    (for [dashcard (db/select DashboardCard :dashboard_id dashboard-id, :card_id [:not= nil])]
+        dashboard (Dashboard :id dashboard-id)
+        dashcards         (db/select DashboardCard :dashboard_id dashboard-id, :card_id [:not= nil])
+        ordered-dashcards (sort dashcard-layout-comparator dashcards)]
+    (for [dashcard ordered-dashcards]
       (execute-dashboard-subscription-card pulse-creator-id dashboard dashcard (:card_id dashcard) (i/the-parameters parameters-impl pulse dashboard)))))
 
 (defn- database-id [card]

--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -102,8 +102,8 @@
 (defn execute-dashboard
   "Execute all the cards in a dashboard for a Pulse"
   [{pulse-creator-id :creator_id, :as pulse} dashboard-or-id & {:as options}]
-  (let [dashboard-id (u/the-id dashboard-or-id)
-        dashboard (Dashboard :id dashboard-id)
+  (let [dashboard-id      (u/the-id dashboard-or-id)
+        dashboard         (Dashboard :id dashboard-id)
         dashcards         (db/select DashboardCard :dashboard_id dashboard-id, :card_id [:not= nil])
         ordered-dashcards (sort dashcard-comparator dashcards)]
     (for [dashcard ordered-dashcards]

--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -91,7 +91,7 @@
     (catch Throwable e
         (log/warn e (trs "Error running query for Card {0}" card-or-id)))))
 
-(defn- dashcard-layout-comparator
+(defn- dashcard-comparator
   "Comparator that determines which of two dashcards comes first in the layout order used for pulses.
   This is the same order used on the frontend for the mobile layout. Orders cards left-to-right, then top-to-bottom"
   [dashcard-1 dashcard-2]
@@ -105,7 +105,7 @@
   (let [dashboard-id (u/the-id dashboard-or-id)
         dashboard (Dashboard :id dashboard-id)
         dashcards         (db/select DashboardCard :dashboard_id dashboard-id, :card_id [:not= nil])
-        ordered-dashcards (sort dashcard-layout-comparator dashcards)]
+        ordered-dashcards (sort dashcard-comparator dashcards)]
     (for [dashcard ordered-dashcards]
       (execute-dashboard-subscription-card pulse-creator-id dashboard dashcard (:card_id dashcard) (i/the-parameters parameters-impl pulse dashboard)))))
 

--- a/test/metabase/api/alert_test.clj
+++ b/test/metabase/api/alert_test.clj
@@ -740,7 +740,7 @@
                                 (assoc-in (default-alert-req card pc-1) [:channels 0 :enabled] false)))
                              (api:alert-question-count :crowberto card))
                   :emails  (et/regex-email-bodies #"https://metabase.com/testmb"
-                                                  #"letting you know that Crowberto Corv" ))))))))
+                                                  #"letting you know that Crowberto Corv"))))))))
 
   (testing "Re-enabling email should send users a subscribe notification"
     (is (= {:count-1 1
@@ -764,7 +764,7 @@
                                 (assoc-in (default-alert-req card pc-1) [:channels 0 :enabled] true)))
                              (api:alert-question-count :crowberto card))
                   :emails  (et/regex-email-bodies #"https://metabase.com/testmb"
-                                                  #"now getting alerts about .*Foo" ))))))))
+                                                  #"now getting alerts about .*Foo"))))))))
 
   (testing "Alert should not be deleted if the unsubscriber isn't the creator"
     (is (= {:count-1 1

--- a/test/metabase/dashboard_subscription_test.clj
+++ b/test/metabase/dashboard_subscription_test.clj
@@ -134,7 +134,19 @@
         (is (= (count result) 2))
         (is (schema= [{:card   (s/pred map?)
                        :result (s/pred map?)}]
-                     result))))))
+                     result)))))
+  (testing "dashboard cards are ordered correctly -- by rows, and then by columns (#17419)"
+    (mt/with-temp* [Card          [{card-id-1 :id}]
+                    Card          [{card-id-2 :id}]
+                    Card          [{card-id-3 :id}]
+                    Dashboard     [{dashboard-id :id} {:name "Birdfeed Usage"}]
+                    DashboardCard [dashcard-1 {:dashboard_id dashboard-id :card_id card-id-1 :row 1 :col 0}]
+                    DashboardCard [dashcard-2 {:dashboard_id dashboard-id :card_id card-id-2 :row 0 :col 1}]
+                    DashboardCard [dashcard-3 {:dashboard_id dashboard-id :card_id card-id-3 :row 0 :col 0}]
+                    User [{user-id :id}]]
+      (let [result (pulse/execute-dashboard {:creator_id user-id} dashboard-id)]
+        (is (= [card-id-3 card-id-2 card-id-1]
+               (map #(-> % :card :id) result)))))))
 
 (deftest basic-table-test
   (tests {:pulse {:skip_if_empty false}}


### PR DESCRIPTION
Sorts dashcards by `:row` and then by `:col` which is the same ordering used by the frontend for mobile layouts: https://github.com/metabase/metabase/blob/master/frontend/src/metabase/dashboard/components/DashboardGrid.jsx#L119-L138

Also minor reformatting that my editor did automatically in `alert_test.clj`

Resolves #15030