### PR TITLE
Do not use prop shortands in the database edit

### DIFF
--- a/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx
@@ -173,7 +173,7 @@ export default class DatabaseEditApp extends Component {
                 </div>
               )}
               <Flex>
-                <Box w={620}>
+                <Box width={620}>
                   <LoadingAndErrorWrapper
                     loading={!database}
                     error={initializeError}
@@ -231,7 +231,7 @@ export default class DatabaseEditApp extends Component {
 
           {/* Sidebar Actions */}
           {editingExistingDatabase && (
-            <Box ml={[2, 3]} w={420}>
+            <Box ml={[2, 3]} width={420}>
               <div className="Actions bg-light rounded p3">
                 <div className="Actions-group">
                   <label className="Actions-groupLabel block text-bold">{t`Actions`}</label>


### PR DESCRIPTION
**How to verify**: go to Admin, Databases and press "Add database".

Pay attention to the container of the form:

![image](https://user-images.githubusercontent.com/7288/129105143-1a6d3b5f-b8c9-41e3-a603-8f3e75132c59.png)

as well as the sidebar (whenever there is an existing database):

![image](https://user-images.githubusercontent.com/7288/129105409-06938a1c-e55d-4f83-b101-c64eade6a30c.png)

Before and after this change, they should look **exactly** the same.
