### PR TITLE
[Dashboard filters coverage] Add initial set of tests for dashboard SQL location filters

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-sql-location.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-sql-location.cy.spec.js
@@ -1,0 +1,99 @@
+import {
+  restore,
+  popover,
+  mockSessionProperty,
+  filterWidget,
+  editDashboard,
+  saveDashboard,
+  setFilter,
+} from "__support__/e2e/cypress";
+
+import { DASHBOARD_SQL_LOCATION_FILTERS } from "./helpers/e2e-dashboard-filter-data-objects";
+import { addWidgetStringFilter } from "../native-filters/helpers/e2e-field-filter-helpers";
+
+import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
+
+const { PEOPLE } = SAMPLE_DATASET;
+
+Object.entries(DASHBOARD_SQL_LOCATION_FILTERS).forEach(
+  ([filter, { value, representativeResult, sqlFilter }]) => {
+    describe("scenarios > dashboard > filters > location", () => {
+      beforeEach(() => {
+        restore();
+        cy.signInAsAdmin();
+
+        mockSessionProperty("field-filter-operators-enabled?", true);
+
+        const questionDetails = getQuestionDetails(sqlFilter);
+
+        cy.createNativeQuestionAndDashboard({ questionDetails }).then(
+          ({ body: { id, card_id, dashboard_id } }) => {
+            cy.intercept("POST", `/api/card/${card_id}/query`).as("cardQuery");
+            cy.visit(`/question/${card_id}`);
+
+            // Wait for `result_metadata` to load
+            cy.wait("@cardQuery");
+
+            cy.visit(`/dashboard/${dashboard_id}`);
+          },
+        );
+
+        editDashboard();
+        setFilter("Location", filter);
+
+        cy.findByText("Column to filter on")
+          .next("a")
+          .click();
+
+        popover()
+          .contains("Filter")
+          .click();
+      });
+
+      it(`should work for "${filter}" when set through the filter widget`, () => {
+        saveDashboard();
+
+        filterWidget().click();
+        addWidgetStringFilter(value);
+
+        cy.get(".Card").within(() => {
+          cy.contains(representativeResult);
+        });
+      });
+
+      it(`should work for "${filter}" when set as the default filter`, () => {
+        cy.findByText("Default value")
+          .next()
+          .click();
+
+        addWidgetStringFilter(value);
+
+        saveDashboard();
+
+        cy.get(".Card").within(() => {
+          cy.contains(representativeResult);
+        });
+      });
+    });
+  },
+);
+
+function getQuestionDetails(filter) {
+  return {
+    name: "SQL with Field Filter",
+    native: {
+      query:
+        "select PEOPLE.NAME, PEOPLE.CITY from people where {{filter}} limit 10",
+      "template-tags": {
+        filter: {
+          id: "0388fcd0-55cd-ca2a-5113-1bbceafc6047",
+          name: "filter",
+          "display-name": "Filter",
+          type: "dimension",
+          dimension: ["field", PEOPLE.CITY, null],
+          "widget-type": filter,
+        },
+      },
+    },
+  };
+}

--- a/frontend/test/metabase/scenarios/dashboard-filters/helpers/e2e-dashboard-filter-data-objects.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/helpers/e2e-dashboard-filter-data-objects.js
@@ -173,3 +173,36 @@ export const DASHBOARD_SQL_NUMBER_FILTERS = {
     representativeResult: "Enormous Aluminum Shirt",
   },
 };
+
+export const DASHBOARD_SQL_LOCATION_FILTERS = {
+  Dropdown: {
+    sqlFilter: "string/=",
+    value: "Rye",
+    representativeResult: "Arnold Adams",
+  },
+  "Is not": {
+    sqlFilter: "string/!=",
+    value: "Rye",
+    representativeResult: "Hudson Borer",
+  },
+  Contains: {
+    sqlFilter: "string/contains",
+    value: "oo",
+    representativeResult: "Hudson Borer",
+  },
+  "Does not contain": {
+    sqlFilter: "string/does-not-contain",
+    value: "oo",
+    representativeResult: "Domenica Williamson",
+  },
+  "Starts with": {
+    sqlFilter: "string/starts-with",
+    value: "W",
+    representativeResult: "Hudson Borer",
+  },
+  "Ends with": {
+    sqlFilter: "string/ends-with",
+    value: "g",
+    representativeResult: "Aracely Jenkins",
+  },
+};


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- As an ongoing effort to increase the test coverage of dashboard filters (https://github.com/metabase/metabase/issues/17078), this PR adds basic tests around location filters applied to the SQL question with the corresponding field filter
    - Make sure filter can be set via filter widget
    - Make sure filter can be set as the default filter

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/129108882-c73d1c87-3c66-4277-baed-340cc85cf1e1.png)




