### PR TITLE
Add hourly option for email scheduling

### DIFF
--- a/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
@@ -433,7 +433,7 @@ function mockSlackConfigured() {
         name: "Email",
         allows_recipients: false,
         recipients: ["user", "email"],
-        schedules: ["daily", "weekly", "monthly"],
+        schedules: ["hourly", "daily", "weekly", "monthly"],
         configured: false,
       },
       slack: {

--- a/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
@@ -127,7 +127,7 @@ describe("scenarios > dashboard > subscriptions", () => {
       assignRecipient();
       cy.findByText("To:").click();
       cy.get(".AdminSelect")
-        .contains("Daily")
+        .contains("Hourly")
         .click();
       cy.findByText("Monthly").click();
       cy.get(".AdminSelect")

--- a/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
@@ -79,7 +79,7 @@ describe("scenarios > dashboard > subscriptions", () => {
     describe("with no existing subscriptions", () => {
       it("should allow creation of a new email subscription", () => {
         createEmailSubscription();
-        cy.findByText("Emailed daily at 8:00 AM");
+        cy.findByText("Emailed hourly");
       });
 
       it("should not render people dropdown outside of the borders of the screen (metabase#17186)", () => {
@@ -96,7 +96,7 @@ describe("scenarios > dashboard > subscriptions", () => {
       beforeEach(createEmailSubscription);
       it("should show existing dashboard subscriptions", () => {
         openDashboardSubscriptions();
-        cy.findByText("Emailed daily at 8:00 AM");
+        cy.findByText("Emailed hourly");
       });
     });
 
@@ -113,7 +113,7 @@ describe("scenarios > dashboard > subscriptions", () => {
       cy.findByText("Questions to attach").click();
       clickButton("Done");
       cy.findByText("Subscriptions");
-      cy.findByText("Emailed daily at 8:00 AM").click();
+      cy.findByText("Emailed hourly").click();
       cy.findByText("Delete this subscription").scrollIntoView();
       cy.findByText("Questions to attach");
       cy.findAllByRole("listitem")
@@ -319,7 +319,7 @@ describe("scenarios > dashboard > subscriptions", () => {
         assignRecipient();
         clickButton("Done");
 
-        cy.findByText("Emailed daily at 8:00 AM").click();
+        cy.findByText("Emailed hourly").click();
 
         cy.findAllByText("Corbin Mertz")
           .last()

--- a/src/metabase/models/pulse_channel.clj
+++ b/src/metabase/models/pulse_channel.clj
@@ -84,7 +84,7 @@
            :name              "Email"
            :allows_recipients true
            :recipients        ["user", "email"]
-           :schedules         [:daily :weekly :monthly]}
+           :schedules         [:hourly :daily :weekly :monthly]}
    :slack {:type              "slack"
            :name              "Slack"
            :allows_recipients false


### PR DESCRIPTION
Adds `:hourly` to the email scheduling options for pulses and dashboard subscriptions, and updates Cypress tests accordingly. This automatically makes `hourly` the default value for the email scheduling form (similar to Slack scheduling).

The actual hourly scheduling logic is already covered by backend tests, but I also tested it manually and confirmed that an email was sent on the hour.

Resolves #11029