### PR TITLE
Block permissions backend

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/enhancements/models/permissions/block_permissions.clj
+++ b/enterprise/backend/src/metabase_enterprise/enhancements/models/permissions/block_permissions.clj
@@ -1,0 +1,41 @@
+(ns metabase-enterprise.enhancements.models.permissions.block-permissions
+  (:require [metabase.api.common :as api]
+            [metabase.models.permissions :as perms]
+            [metabase.models.query.permissions :as query.perms]
+            [metabase.public-settings.metastore :as settings.metastore]
+            [metabase.query-processor.error-type :as qp.error-type]
+            [metabase.util.i18n :refer [tru]]))
+
+(defn- current-user-has-block-permissions-for-database?
+  [database-or-id]
+  (contains? @api/*current-user-permissions-set* (perms/database-block-perms-path database-or-id)))
+
+(defn- has-data-perms? [query]
+  (perms/set-has-full-permissions-for-set?
+   @api/*current-user-permissions-set*
+   (query.perms/perms-set query, :already-preprocessed? true)))
+
+(defn check-block-permissions
+  "Assert that block permissions are not in effect for Database for a query that's only allowed to run because of
+  Collection perms; throw an Exception if they are. Otherwise returns a keyword explaining why the check
+  succeeded (this is mostly for test/debug purposes). The query is still allowed to run if the current User has
+  appropriate data permissions from another Group. See the namespace documentation for [[metabase.models.collection]]
+  for more details.
+
+  Note that this feature is Metabase© Enterprise Edition™ only and only enabled if we have a valid Enterprise Edition™
+  token. [[metabase.query-processor.middleware.permissions/check-block-permissions]] invokes this function if it
+  exists."
+  [{database-id :database, :as query}]
+  (cond
+    (not (settings.metastore/enable-enhancements?))
+    ::enhancements-not-enabled
+
+    (not (current-user-has-block-permissions-for-database? database-id))
+    ::no-block-permissions-for-db
+
+    :else
+    ;; TODO -- come up with a better error message.
+    (throw (ex-info (tru "Blocked: you are not allowed to run queries against Database {0}." database-id)
+                    {:type               qp.error-type/missing-required-permissions
+                     :actual-permissions @api/*current-user-permissions-set*
+                     :permissions-error? true}))))

--- a/enterprise/backend/src/metabase_enterprise/enhancements/models/permissions/block_permissions.clj
+++ b/enterprise/backend/src/metabase_enterprise/enhancements/models/permissions/block_permissions.clj
@@ -1,7 +1,6 @@
 (ns metabase-enterprise.enhancements.models.permissions.block-permissions
   (:require [metabase.api.common :as api]
             [metabase.models.permissions :as perms]
-            [metabase.models.query.permissions :as query.perms]
             [metabase.public-settings.metastore :as settings.metastore]
             [metabase.query-processor.error-type :as qp.error-type]
             [metabase.util.i18n :refer [tru]]))
@@ -9,11 +8,6 @@
 (defn- current-user-has-block-permissions-for-database?
   [database-or-id]
   (contains? @api/*current-user-permissions-set* (perms/database-block-perms-path database-or-id)))
-
-(defn- has-data-perms? [query]
-  (perms/set-has-full-permissions-for-set?
-   @api/*current-user-permissions-set*
-   (query.perms/perms-set query, :already-preprocessed? true)))
 
 (defn check-block-permissions
   "Assert that block permissions are not in effect for Database for a query that's only allowed to run because of

--- a/enterprise/backend/src/metabase_enterprise/sandbox/api/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/api/util.clj
@@ -15,4 +15,4 @@
        ;; access they shouldn't have. If we don't have permissions, we can't determine whether they are segmented, so
        ;; throw.
        (throw (ex-info (str (tru "No permissions found for current user"))
-                {:status-code 403}))))))
+                       {:status-code 403}))))))

--- a/enterprise/backend/src/metabase_enterprise/sandbox/models/group_table_access_policy.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/models/group_table_access_policy.clj
@@ -1,7 +1,9 @@
 (ns metabase-enterprise.sandbox.models.group-table-access-policy
   "Model definition for Group Table Access Policy, aka GTAP. A GTAP is useed to control access to a certain Table for a
   certain PermissionsGroup. Whenever a member of that group attempts to query the Table in question, a Saved Question
-  specified by the GTAP is instead used as the source of the query."
+  specified by the GTAP is instead used as the source of the query.
+
+  See documentation in [[metabase.models.permissions]] for more information about the Metabase permissions system."
   (:require [clojure.tools.logging :as log]
             [medley.core :as m]
             [metabase.mbql.normalize :as normalize]

--- a/enterprise/backend/src/metabase_enterprise/sandbox/models/permissions/delete_sandboxes.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/models/permissions/delete_sandboxes.clj
@@ -90,19 +90,17 @@
 
 (defn- delete-gtaps-for-group-database! [{:keys [group-id database-id], :as context} changes]
   (log/debugf "Deleting unneeded GTAPs for Group %d for Database %d. Graph changes: %s"
-             group-id database-id (pr-str changes))
-  (cond
-    (= changes :none)
+              group-id database-id (pr-str changes))
+  (if (#{:none :all :block} changes)
     (do
-      (log/debugf "Group %d no longer has any perms for Database %d, deleting all GTAPs for this DB" group-id database-id)
+      (log/debugf "Group %d %s for Database %d, deleting all GTAPs for this DB"
+                  group-id
+                  (case changes
+                    :none  "no longer has any perms"
+                    :all   "now has full data perms"
+                    :block "is now BLOCKED from all non-data-perms access")
+                  database-id)
       (delete-gtaps-with-condition! group-id [:= :table.db_id database-id]))
-
-    (= changes :all)
-    (do
-      (log/debugf "Group %d now has full data perms for Database %d, deleting all GTAPs for this DB" group-id database-id)
-      (delete-gtaps-with-condition! group-id [:= :table.db_id database-id]))
-
-    :else
     (doseq [schema-name (set (keys changes))]
       (delete-gtaps-for-group-schema!
        (assoc context :schema-name schema-name)

--- a/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions.clj
@@ -1,4 +1,7 @@
 (ns metabase-enterprise.sandbox.query-processor.middleware.row-level-restrictions
+  "Apply segmented a.k.a. sandboxing anti-permissions to the query, i.e. replace sandboxed Tables with the
+  appropriate [[metabase-enterprise.sandbox.models.group-table-access-policy]]s (GTAPs). See dox
+  for [[metabase.models.permissions]] for a high-level overview of the Metabase permissions system."
   (:require [clojure.core.memoize :as memoize]
             [clojure.tools.logging :as log]
             [metabase-enterprise.sandbox.models.group-table-access-policy :as gtap :refer [GroupTableAccessPolicy]]
@@ -236,7 +239,7 @@
       preprocess-source-query
       (source-query-form-ensure-metadata table-id card-id)))
 
-(s/defn ^:private gtap->perms-set :- #{perms/ObjectPath}
+(s/defn ^:private gtap->perms-set :- #{perms/Path}
   "Calculate the set of permissions needed to run the query associated with a GTAP; this set of permissions is excluded
   during the normal QP perms check.
 

--- a/enterprise/backend/test/metabase_enterprise/enhancements/models/permissions/block_permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/enhancements/models/permissions/block_permissions_test.clj
@@ -136,8 +136,6 @@
                   (check-block-perms []
                     (mt/with-current-user user-id
                       (#'qp.perms/check-block-permissions query)))]
-            ;; TODO -- figure out how to test the :metabase.query-processor.middleware.permissions/ee-not-present case
-            ;; revoke all data perms for the DB.
             (testing "sanity check: should not be able to run ad-hoc query"
               (is (not (contains? @api/*current-user-permissions-set*
                                   (perms/data-perms-path (mt/id)))))

--- a/enterprise/backend/test/metabase_enterprise/enhancements/models/permissions/block_permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/enhancements/models/permissions/block_permissions_test.clj
@@ -165,15 +165,14 @@
               (testing "\nAllow running if current User has data permissions from another group."
                 (mt/with-temp* [PermissionsGroup           [{group-2-id :id}]
                                 PermissionsGroupMembership [_ {:group_id group-2-id, :user_id user-id}]]
-                  (comment
-                    (doseq [[message perms] {"with full DB perms"                   (perms/data-perms-path (mt/id))
-                                             "with perms for the Table in question" (perms/table-query-path (mt/id :venues))}]
-                      (mt/with-temp Permissions [_ {:group_id group-2-id, :object perms}]
-                        (testing "Should be able to run the query"
-                          (doseq [[message f] {"ad-hoc queries"  run-ad-hoc-query
-                                               "Saved Questions" run-saved-question}]
-                            (testing message
-                              (is (f))))))))
+                  (doseq [[message perms] {"with full DB perms"                   (perms/data-perms-path (mt/id))
+                                           "with perms for the Table in question" (perms/table-query-path (mt/id :venues))}]
+                    (mt/with-temp Permissions [_ {:group_id group-2-id, :object perms}]
+                      (testing "Should be able to run the query"
+                        (doseq [[message f] {"ad-hoc queries"  run-ad-hoc-query
+                                             "Saved Questions" run-saved-question}]
+                          (testing message
+                            (is (f)))))))
                   (testing "\nSandboxed permissions"
                     (metastore-test/with-metastore-token-features #{:enhancements :sandboxing}
                       (mt/with-temp* [Permissions            [_ {:group_id group-2-id

--- a/enterprise/backend/test/metabase_enterprise/enhancements/models/permissions/block_permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/enhancements/models/permissions/block_permissions_test.clj
@@ -1,0 +1,188 @@
+(ns metabase-enterprise.enhancements.models.permissions.block-permissions-test
+  (:require [clojure.test :refer :all]
+            [metabase-enterprise.enhancements.models.permissions.block-permissions :as block-perms]
+            [metabase-enterprise.sandbox.models.group-table-access-policy :refer [GroupTableAccessPolicy]]
+            [metabase.api.common :as api]
+            [metabase.models :refer [Card Collection Database Permissions PermissionsGroup PermissionsGroupMembership User]]
+            [metabase.models.permissions :as perms]
+            [metabase.models.permissions-group :as group]
+            [metabase.public-settings.metastore-test :as metastore-test]
+            [metabase.query-processor :as qp]
+            [metabase.query-processor.middleware.permissions :as qp.perms]
+            [metabase.test :as mt]
+            [metabase.util :as u]
+            [toucan.db :as db]))
+
+;;;; Graph-related stuff
+
+(defn- test-db-perms [group-id]
+  (get-in (perms/data-perms-graph) [:groups group-id (mt/id)]))
+
+(deftest graph-test
+  (testing "block permissions should come back from the graph function"
+    (mt/with-temp* [PermissionsGroup [{group-id :id}]
+                    Permissions      [_ {:group_id group-id
+                                         :object   (perms/database-block-perms-path (mt/id))}]]
+      (is (= {:schemas :block}
+             (test-db-perms group-id)))
+      (testing (str "\nBlock perms and data perms shouldn't exist together at the same time, but if they do for some "
+                    "reason, then the graph endpoint should ignore the data perms.")
+        (doseq [path [(perms/data-perms-path (mt/id))
+                      (perms/data-perms-path (mt/id) "public")
+                      (perms/data-perms-path (mt/id) "public" (mt/id :venues))]]
+          (testing (format "\nPath = %s" (pr-str path))
+            (mt/with-temp* [Permissions [_ {:group_id group-id
+                                            :object   path}]]
+              (is (= (merge {:schemas :block}
+                            ;; block perms won't affect the value of `:native`; if a given group has both
+                            ;; `/db/1/` and `/block/db/1/` then the graph will come back with `:native
+                            ;; :write` and `:schemas :block`. This state isn't normally allowed, but the
+                            ;; graph code doesn't currently correct it if it happens. Not sure it's worth
+                            ;; the extra code complexity since it should never happen in the first place.
+                            (when (= path (perms/data-perms-path (mt/id)))
+                              {:native :write}))
+                     (test-db-perms group-id))))))))))
+
+(defn- grant-block-perms! [group-id]
+  (perms/update-data-perms-graph! [group-id (mt/id)] {:schemas :block}))
+
+(deftest update-graph-test
+  (testing "Should be able to set block permissions with the graph update function"
+    (mt/with-temp PermissionsGroup [{group-id :id}]
+      (testing "Group should have no perms upon creation"
+        (is (= nil
+               (test-db-perms group-id))))
+      (testing "group has no existing permissions"
+        (mt/with-model-cleanup [Permissions]
+          (grant-block-perms! group-id)
+          (is (= {:schemas :block}
+                 (test-db-perms group-id)))))
+      (testing "group has existing data permissions... :block should remove them"
+        (mt/with-model-cleanup [Permissions]
+          (perms/grant-full-db-permissions! group-id (mt/id))
+          (grant-block-perms! group-id)
+          (is (= {:schemas :block}
+                 (test-db-perms group-id)))
+          (is (= #{(perms/database-block-perms-path (mt/id))}
+                 (db/select-field :object Permissions :group_id group-id))))))))
+
+(deftest update-graph-delete-sandboxes-test
+  (testing "When setting `:block` permissions any GTAP rows for that Group/Database should get deleted."
+    (metastore-test/with-metastore-token-features #{:sandboxes}
+      (mt/with-model-cleanup [Permissions]
+        (mt/with-temp* [PermissionsGroup       [{group-id :id}]
+                        GroupTableAccessPolicy [_ {:table_id (mt/id :venues)
+                                                   :group_id group-id}]]
+          (grant-block-perms! group-id)
+          (is (= {:schemas :block}
+                 (test-db-perms group-id)))
+          (is (not (db/exists? GroupTableAccessPolicy :group_id group-id))))))))
+
+(deftest update-graph-data-perms-should-delete-block-perms-test
+  (testing "granting data permissions should delete existing block permissions"
+    (mt/with-temp* [PermissionsGroup [{group-id :id}]
+                    Permissions      [_ {:group_id group-id, :object (perms/database-block-perms-path (mt/id))}]]
+      (is (= {:schemas :block}
+             (test-db-perms group-id)))
+      (perms/update-data-perms-graph! [group-id (mt/id) :schemas] {"public" {(mt/id :venues) {:read :all}}})
+      (is (= {:schemas {"public" {(mt/id :venues) {:read :all}}}}
+             (test-db-perms group-id))))))
+
+(deftest update-graph-disallow-native-query-perms-test
+  (testing "Disallow block permissions + native query permissions"
+    (mt/with-temp* [PermissionsGroup [{group-id :id}]
+                    Permissions      [_ {:group_id group-id, :object (perms/data-perms-path (mt/id))}]]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           ;; TODO -- this error message is totally garbage, fix this
+           #"DB permissions with a valid combination of values for :native and :schemas"
+           (perms/update-data-perms-graph! [group-id (mt/id) :schemas] :block))))))
+
+(deftest delete-database-delete-block-perms-test
+  (testing "If a Database gets DELETED, any block permissions for it should get deleted too."
+    (mt/with-temp* [Database    [{db-id :id}]
+                    Permissions [_ {:group_id (u/the-id (group/all-users))
+                                    :object   (perms/database-block-perms-path db-id)}]]
+      (letfn [(perms-exist? []
+                (db/exists? Permissions :object (perms/database-block-perms-path db-id)))]
+        (is (perms-exist?))
+        (db/delete! Database :id db-id)
+        (is (not (perms-exist?)))))))
+
+;;;; QP perms-check related stuff.
+
+(deftest qp-block-permissions-test
+  (mt/with-temp-copy-of-db
+    (let [query {:database (mt/id)
+                 :type     :query
+                 :query    {:source-table (mt/id :venues)
+                            :limit        1}}]
+      (mt/with-temp* [User                       [{user-id :id}]
+                      PermissionsGroup           [{group-id :id}]
+                      PermissionsGroupMembership [_ {:group_id group-id, :user_id user-id}]
+                      Collection                 [{collection-id :id}]
+                      Card                       [{card-id :id} {:collection_id collection-id
+                                                                 :dataset_query query}]
+                      Permissions                [_ {:group_id group-id, :object (perms/collection-read-path collection-id)}]]
+        (metastore-test/with-metastore-token-features #{:enhancements}
+          (perms/revoke-data-perms! (group/all-users) (mt/id))
+          (perms/revoke-data-perms! group-id (mt/id))
+          (letfn [(run-ad-hoc-query []
+                    (mt/with-current-user user-id
+                      (qp/process-query query)))
+                  (run-saved-question []
+                    (binding [qp.perms/*card-id* card-id]
+                      (run-ad-hoc-query)))
+                  (check-block-perms []
+                    (mt/with-current-user user-id
+                      (#'qp.perms/check-block-permissions query)))]
+            ;; TODO -- figure out how to test the :metabase.query-processor.middleware.permissions/ee-not-present case
+            ;; revoke all data perms for the DB.
+            (testing "sanity check: should not be able to run ad-hoc query"
+              (is (not (contains? @api/*current-user-permissions-set*
+                                  (perms/data-perms-path (mt/id)))))
+              (is (thrown-with-msg?
+                   clojure.lang.ExceptionInfo
+                   #"You do not have permissions to run this query"
+                   (run-ad-hoc-query))))
+            (testing "sanity check: should be able to run query as saved Question before block perms are set."
+              (is (run-saved-question))
+              (is (= ::block-perms/no-block-permissions-for-db
+                     (check-block-perms))))
+            ;; 'grant' the block permissions.
+            (mt/with-temp Permissions [_ {:group_id group-id, :object (perms/database-block-perms-path (mt/id))}]
+              (testing "if EE token does not have the `:enhancements` feature: should not do check"
+                (metastore-test/with-metastore-token-features #{}
+                  (is (= ::block-perms/enhancements-not-enabled
+                         (check-block-perms)))))
+              (testing "disallow running the query"
+                (is (thrown-with-msg?
+                     clojure.lang.ExceptionInfo
+                     #"Blocked: you are not allowed to run queries against Database \d+"
+                     (check-block-perms)))
+                (is (thrown-with-msg?
+                     clojure.lang.ExceptionInfo
+                     #"Blocked: you are not allowed to run queries against Database \d+"
+                     (run-saved-question))))
+              (testing "\nAllow running if current User has data permissions from another group."
+                (mt/with-temp* [PermissionsGroup           [{group-2-id :id}]
+                                PermissionsGroupMembership [_ {:group_id group-2-id, :user_id user-id}]]
+                  (comment
+                    (doseq [[message perms] {"with full DB perms"                   (perms/data-perms-path (mt/id))
+                                             "with perms for the Table in question" (perms/table-query-path (mt/id :venues))}]
+                      (mt/with-temp Permissions [_ {:group_id group-2-id, :object perms}]
+                        (testing "Should be able to run the query"
+                          (doseq [[message f] {"ad-hoc queries"  run-ad-hoc-query
+                                               "Saved Questions" run-saved-question}]
+                            (testing message
+                              (is (f))))))))
+                  (testing "\nSandboxed permissions"
+                    (metastore-test/with-metastore-token-features #{:enhancements :sandboxing}
+                      (mt/with-temp* [Permissions            [_ {:group_id group-2-id
+                                                                 :object   (perms/table-segmented-query-path (mt/id :venues))}]
+                                      GroupTableAccessPolicy [_ {:table_id (mt/id :venues), :group_id group-id}]]
+                        (testing "Should be able to run the query"
+                          (doseq [[message f] {"ad-hoc queries"  run-ad-hoc-query
+                                               "Saved Questions" run-saved-question}]
+                            (testing message
+                              (is (f)))))))))))))))))

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/card_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/card_test.clj
@@ -18,7 +18,7 @@
                         PermissionsGroupMembership [_ {:user_id (mt/user->id :rasta)
                                                        :group_id (u/the-id group)}]]
           (mt/with-db db
-            (perms/revoke-permissions! (perms-group/all-users) db)
+            (perms/revoke-data-perms! (perms-group/all-users) db)
             (perms/grant-permissions! group (perms/table-segmented-query-path table))
             (perms/grant-collection-readwrite-permissions! group collection)
             (is (some? ((mt/user->client :rasta) :post 202 "card"
@@ -36,7 +36,7 @@
                         Card                       [card {:name "Some Name"
                                                           :collection_id (u/the-id collection)}]]
           (mt/with-db db
-            (perms/revoke-permissions! (perms-group/all-users) db)
+            (perms/revoke-data-perms! (perms-group/all-users) db)
             (perms/grant-permissions! group (perms/table-segmented-query-path table))
             (perms/grant-collection-readwrite-permissions! group collection)
             (is (= "Another Name"

--- a/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions_test.clj
@@ -295,7 +295,7 @@
         (mt/with-temp* [Collection [collection]
                         Card       [card        {:collection_id (u/the-id collection)}]]
           (mt/with-group [group]
-            (perms/revoke-permissions! (perms-group/all-users) (mt/id))
+            (perms/revoke-data-perms! (perms-group/all-users) (mt/id))
             (perms/grant-collection-read-permissions! group collection)
             (mt/with-test-user :rasta
               (binding [qp.perms/*card-id* (u/the-id card)]
@@ -677,7 +677,7 @@
                        {:gtaps      {:reviews {:remappings {"user_id" [:dimension $product_id]}}}
                         :attributes {"user_id" 1}})
         ;; grant full data perms for products
-        (perms/grant-permissions! (perms-group/all-users) (perms/object-path
+        (perms/grant-permissions! (perms-group/all-users) (perms/data-perms-path
                                                            (mt/id)
                                                            (db/select-one-field :schema Table :id (mt/id :products))
                                                            (mt/id :products)))
@@ -801,7 +801,7 @@
                        {:gtaps      {:orders {:remappings {:user_id [:dimension $orders.user_id]}}}
                         :attributes {:user_id "1"}})
         ;; make sure the sandboxed group can still access the Products table, which is referenced below.
-        (perms/grant-permissions! &group (perms/object-path (mt/id) "PUBLIC" (mt/id :products)))
+        (perms/grant-permissions! &group (perms/data-perms-path (mt/id) "PUBLIC" (mt/id :products)))
         (letfn [(do-tests []
                   ;; create a query based on the sandboxed Table
                   (testing "should be able to run the query. Results should come back with correct metadata"

--- a/enterprise/backend/test/metabase_enterprise/sandbox/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/test_util.clj
@@ -62,7 +62,7 @@
 (defn do-with-gtaps-for-user [args-fn test-user-name-or-user-id f]
   (letfn [(thunk []
             ;; remove perms for All Users group
-            (perms/revoke-permissions! (perms-group/all-users) (data/db))
+            (perms/revoke-data-perms! (perms-group/all-users) (data/db))
             ;; create new perms group
             (users/with-group-for-user [group test-user-name-or-user-id]
               (let [{:keys [gtaps attributes]} (s/validate WithGTAPsArgs (args-fn))]

--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -34,7 +34,8 @@
   false)
 
 (def ^:dynamic *current-user-permissions-set*
-  "Delay to the set of permissions granted to the current user."
+  "Delay to the set of permissions granted to the current user. See documentation in [[metabase.models.permissions]] for
+  more information about the Metabase permissions system."
   (atom #{}))
 
 

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -684,7 +684,7 @@
   at least some of its tables?)"
   [database-id schema-name]
   (perms/set-has-partial-permissions? @api/*current-user-permissions-set*
-                                      (perms/object-path database-id schema-name)))
+                                      (perms/data-perms-path database-id schema-name)))
 
 (api/defendpoint GET "/:id/schemas"
   "Returns a list of all the schemas found for the database `id`"

--- a/src/metabase/api/permission_graph.clj
+++ b/src/metabase/api/permission_graph.clj
@@ -7,7 +7,7 @@
             [clojure.spec.gen.alpha :as gen]
             [clojure.walk :as walk]))
 
-(defmulti convert
+(defmulti ^:private convert
   "convert values from the naively converted json to what we REALLY WANT"
   first)
 
@@ -40,7 +40,7 @@
 (s/def ::native (s/or :str->kw #{"write" "none"}
                       :nil->none nil?))
 
-;;; --------------------------------------------------- Data Permissions ----------------------------------------------------
+;;; ------------------------------------------------ Data Permissions ------------------------------------------------
 
 (s/def ::schema-name (s/or :kw->str keyword?))
 
@@ -82,8 +82,7 @@
 (s/def ::data-permissions-graph
   (s/keys :req-un [:metabase.api.permission-graph.data/groups]))
 
-
-;;; --------------------------------------------------- Collection Permissions ----------------------------------------------------
+;;; --------------------------------------------- Collection Permissions ---------------------------------------------
 
 (s/def ::collections
   (s/map-of (s/or :identity ::id

--- a/src/metabase/api/permissions.clj
+++ b/src/metabase/api/permissions.clj
@@ -24,7 +24,7 @@
   "Fetch a graph of all Permissions."
   []
   (api/check-superuser)
-  (perms/graph))
+  (perms/data-perms-graph))
 
 (api/defendpoint PUT "/graph"
   "Do a batch update of Permissions by passing in a modified graph. This should return the same graph, in the same
@@ -38,8 +38,8 @@
   [:as {body :body}]
   {body su/Map}
   (api/check-superuser)
-  (perms/update-graph! (pg/converted-json->graph ::pg/data-permissions-graph body))
-  (perms/graph))
+  (perms/update-data-perms-graph! (pg/converted-json->graph ::pg/data-permissions-graph body))
+  (perms/data-perms-graph))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -32,7 +32,7 @@
   "Map with the various allowed search parameters, used to construct the SQL query"
   {:search-string                (s/maybe su/NonBlankString)
    :archived?                    s/Bool
-   :current-user-perms           #{perms/UserPath}
+   :current-user-perms           #{perms/Path}
    (s/optional-key :models)      (s/maybe #{su/NonBlankString})
    (s/optional-key :table-db-id) (s/maybe s/Int)
    (s/optional-key :limit-int)   (s/maybe s/Int)

--- a/src/metabase/api/transform.clj
+++ b/src/metabase/api/transform.clj
@@ -10,7 +10,7 @@
   "Look up a database schema transform"
   [db-id schema transform-name]
   (api/check-403 (perms/set-has-full-permissions? @api/*current-user-permissions-set*
-                   (perms/object-path db-id schema)))
+                   (perms/data-perms-path db-id schema)))
   (->> @transform.specs/transform-specs
        (m/find-first (comp #{transform-name} :name))
        (transform/apply-transform! db-id schema)))

--- a/src/metabase/db/data_migrations.clj
+++ b/src/metabase/db/data_migrations.clj
@@ -116,7 +116,7 @@
             database-id    db-ids]
       (u/ignore-exceptions
         (db/insert! Permissions
-          :object   (perms/object-path database-id)
+          :object   (perms/data-perms-path database-id)
           :group_id group-id)))))
 
 ;; Copy the value of the old setting `-site-url` to the new `site-url` if applicable.  (`site-url` used to be stored

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -236,15 +236,15 @@
   You probably don't want to consume the results of this function directly -- most of the time, the reason you are
   calling this function in the first place is because you want add a `FILTER` clause to an application DB query (e.g.
   to only fetch Cards that belong to Collections visible to the current User). Use
-  `visible-collection-ids->honeysql-filter-clause` to generate a filter clause that handles all possible outputs of
+  [[visible-collection-ids->honeysql-filter-clause]] to generate a filter clause that handles all possible outputs of
   this function correctly.
 
   !!! IMPORTANT NOTE !!!
 
   Because the result may include `nil` for the Root Collection, or may be `:all`, MAKE SURE YOU HANDLE THOSE
   SITUATIONS CORRECTLY before using these IDs to make a DB call. Better yet, use
-  `visible-collection-ids->honeysql-filter-clause` to generate appropriate HoneySQL."
-  [permissions-set :- #{perms/UserPath}]
+  [[visible-collection-ids->honeysql-filter-clause]] to generate appropriate HoneySQL."
+  [permissions-set :- #{perms/Path}]
   (if (contains? permissions-set "/")
     :all
     (set
@@ -497,7 +497,7 @@
 ;;; |                                    Recursive Operations: Moving & Archiving                                    |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(s/defn perms-for-archiving :- #{perms/ObjectPath}
+(s/defn perms-for-archiving :- #{perms/Path}
   "Return the set of Permissions needed to archive or unarchive a `collection`. Since archiving a Collection is
   *recursive* (i.e., it applies to all the descendant Collections of that Collection), we require write ('curate')
   permissions for the Collection itself and all its descendants, but not for its parent Collection.
@@ -526,7 +526,7 @@
                             (db/select-ids Collection :location [:like (str (children-location collection) "%")])))]
      (perms/collection-readwrite-path collection-or-id))))
 
-(s/defn perms-for-moving :- #{perms/ObjectPath}
+(s/defn perms-for-moving :- #{perms/Path}
   "Return the set of Permissions needed to move a `collection`. Like archiving, moving is recursive, so we require
   perms for both the Collection and its descendants; we additionally require permissions for its new parent Collection.
 

--- a/src/metabase/models/collection/graph.clj
+++ b/src/metabase/models/collection/graph.clj
@@ -1,4 +1,6 @@
 (ns metabase.models.collection.graph
+  "Code for generating and updating the Collection permissions graph. See [[metabase.models.permissions]] for more
+  details and for the code for generating and updating the *data* permissions graph."
   (:require [clojure.data :as data]
             [metabase.api.common :as api :refer [*current-user-id*]]
             [metabase.models.collection :as collection :refer [Collection]]

--- a/src/metabase/models/field.clj
+++ b/src/metabase/models/field.clj
@@ -128,7 +128,7 @@
   (memoize/ttl
    (fn [table-id]
      (let [{schema :schema, database-id :db_id} (db/select-one ['Table :schema :db_id] :id table-id)]
-       #{(perms/object-path database-id schema table-id)}))
+       #{(perms/data-perms-path database-id schema table-id)}))
    :ttl/threshold 5000))
 
 (defn- perms-objects-set
@@ -138,7 +138,7 @@
   {:arglists '([field read-or-write])}
   (if db-id
     ;; if Field already has a hydrated `:table`, then just use that to generate perms set (no DB calls required)
-    #{(perms/object-path db-id schema table-id)}
+    #{(perms/data-perms-path db-id schema table-id)}
     ;; otherwise we need to fetch additional info about Field's Table. This is cached for 5 seconds (see above)
     (perms-objects-set* table-id)))
 

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -220,7 +220,8 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 (p.types/defprotocol+ IObjectPermissions
-  "Methods for determining whether the current user has read/write permissions for a given object."
+  "Methods for determining whether the current user has read/write permissions for a given object. See documentation
+  for [[metabase.models.permissions]] for a high-level overview of the Metabase permissions system."
 
   (perms-objects-set [instance ^clojure.lang.Keyword read-or-write]
     "Return a set of permissions object paths that a user must have access to in order to access this object. This

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -1,4 +1,173 @@
 (ns metabase.models.permissions
+  "Low-level Metabase permissions system definition and utility functions.
+
+  The Metabase permissions system is based around permissions *paths* that are granted to individual
+  [[metabase.models.permissions-group]]s.
+
+  ### Core concepts
+
+  Permissions are granted to individual [[metabase.models.permissions-group]]s, and Users are members of one or more
+  Permissions Groups. Permissions Groups are like 'roles' in other permissions systems. There are a few 'magic'
+  Permissions Groups: the [[metabase.models.permissions-group/all-users]] Group, of which every User is a member and
+  cannot be removed; the [[metabase.models.permissions-group/admin]] Group, of which every superuser (i.e., every User
+  with `is_superuser`) is a member; and the [[metabase.models.permissions-group/metabot]] Group, which defines
+  permissions for the MetaBot.
+
+  The permissions needed to perform an action are represented as path strings. Permissions paths are slash-delimited
+  strings such as `/db/1/schema/PUBLIC/`. Each slash represents a different part of the permissions path, and each
+  permissions path must start and end with a slash. Permissions use the same path representation for both the
+  permissions required to perform an action and the permissions that get granted to individual Groups.
+
+  Permissions paths use a prefix system where a User is normally allowed to perform any action if one of their Groups
+  has *any* permissions entry that is a prefix for the permission required to perform that action. For example, if
+  reading Database 1 requires the permission `/db/1/read/`, then the current User may perform that action if they have
+  `/db/1/read/` permissions, or if they have `/db/1/`, or even full `/` superuser permissions.
+
+  This prefix system allows us to easily and efficiently query the application database to find relevant matching
+  permissions matching an path or path using `LIKE`; see [[metabase.models.database/pre-delete]] for
+  an example of the sort of efficient queries the prefix system facilitates.
+
+  The union of all permissions the current User's permissions gets from all groups of which they are a member are
+  automatically bound to [[metabase.api.common/*current-user-permissions-set*]]
+  by [[metabase.server.middleware.session/bind-current-user]] for every REST API request, and by others when queries
+  are ran in a non-API thread (e.g. for MetaBot or scheduled Dashboard Subscriptions).
+
+  ### Different types of permissions
+
+  There are two main types of permissions:
+
+  * _data permissions_ -- permissions to view, update, or run ad-hoc or SQL queries against a Database or Table.
+
+  * _Collection permissions_ -- permissions to view/curate/etc. an individual [[metabase.models.collection]] and the
+    items inside it. Collection permissions apply to individual Collections and to any non-Collection items inside that
+    Collection. Child Collections get their own permissions. Many objects such as Cards (a.k.a. *Saved Questions*) and
+    Dashboards get their permissions from the Collection in which they live.
+
+  ### Enterprise-only permissions and \"anti-permissions\"
+
+  In addition to data permissions and Collection permissions, a User can also be granted three additional types of
+  permissions. Some of these types are referred to as \"anti-permissions\" because they are subtractive grants that
+  take away permissions from what the User would otherwise have.
+
+  * _root permissions_ -- permissions for `/`, i.e. full access for everything. Automatically granted to
+    the [[metabase.models.permissions-group/admin]] group that gets created on first launch. Because `/` is a prefix
+    for every permissions path, admins have permissions to do everything.
+
+  * _segmented permissions_ -- a special grant for a Table that applies sandboxing, a.k.a. row-level permissions,
+    a.k.a. segmented permissions, to any queries ran by the User when that User does not have full data permissions.
+    Segmented permissions allow a User to run ad-hoc MBQL queries against the Table in question; regardless of whether
+    they have relevant Collection permissions, queries against the sandboxed Table are rewritten to replace the Table
+    itself with a special type of nested query called a
+    [[metabase-enterprise.sandbox.models.group-table-access-policy]], or _GTAP_. Note that segmented permissions are
+    both additive and subtractive -- they are additive because they grant (sandboxed) ad-hoc query access for a Table,
+    but subtractive in that any access thru a Saved Question will now be sandboxed as well.
+
+    Additional things to know:
+
+    * Sandboxes permissions are only available in Metabase® Enterprise Edition™.
+
+    * Only one GTAP may defined per-Group per-Table (this is an application-DB-level constraint). A User may have
+      multiple applicable GTAPs if they are members of multiple groups that have sandboxed anti-perms for that Table; in
+      that case, the QP signals an error if multiple GTAPs apply to a given Table for the current User (see
+      [[metabase-enterprise.sandbox.query-processor.middleware.row-level-restrictions/assert-one-gtap-per-table]]).
+
+    * Segmented (sandboxing) anti-permissions and GTAPs are tied together, and a Group should be given both (or both
+      should be deleted) at the same time. This is *not* currently enforced as a hard application DB constraint, but is
+      done in the respective Toucan pre-delete actions. The QP will signal an error if the current user has segmented
+      permissions but no matching GTAP exists.
+
+    * Segmented permissions can also be used to enforce column-level permissions -- any column not returned by the
+      underlying GTAP query is not allowed to be references by the parent query thru other means such as filter clauses.
+      See [[metabase-enterprise.sandbox.query-processor.middleware.column-level-perms-check]].
+
+    * GTAPs are not allowed to add columns not present in the original Table, or change their effective type to
+      something incompatible (this constraint is in place so we other things continue to work transparently regardless
+      of whether the Table is swapped out.)
+
+  * *block anti-permissions* are per-Group, per-Table grants that tell Metabase to disallow running Saved
+    Questions unless the User has data permissions (in other words, disregard Collection permissions). See the
+    `Determining query permissions` section below for more details. As with segmented anti-permissions, block
+    anti-permissions are only available in Metabase® Enterprise Edition™.
+
+  ### Determining CRUD permissions in the REST API
+
+  REST API permissions checks are generally done in various `metabase.api.*` namespaces. Methods for determine whether
+  the current User can perform various CRUD actions are defined by
+  the [[metabase.models.interface/IObjectPermissions]] protocol; this protocol
+  defines [[metabase.models.interface/can-read?]] (in the API sense, not in the run-query sense)
+  and [[metabase.models.interface/can-write?]] as well as the newer [[metabase.models.interface/can-create?]] and
+  [[metabase.models.interface/can-update?]] methods. Implementations for these methods live in `metabase.model.*`
+  namespaces.
+
+  The implementation of these methods is up to individual models. The majority of implementations check whether
+  [[metabase.api.common/*current-user-permissions-set*]] includes permissions for a given path (action)
+  using [[set-has-full-permissions?]], or for a set of paths using [[set-has-full-permissions-for-set?]].
+
+  Other implementations check whether a user has _partial permissions_ for a path or set
+  using [[set-has-partial-permissions?]] or [[set-has-partial-permissions-for-set?]]. Partial permissions means that
+  the User has permissions for some subpath of the path in question, e.g. `/db/1/read/` is considered to be partial
+  permissions for `/db/1/`. For example the [[metabase.models.interface/can-read?]] implementation for Database checks
+  whether the current User has *any* permissions for that Database; a User can fetch Database 1 from API
+  endpoints (\"read\" it) if they have any permissions starting with `/db/1/`, for example `/db/1/` itself (full
+  permissions) `/db/1/native/` (ad-hoc SQL query permissions) or permissions, or
+  `/db/1/schema/PUBLIC/table/2/query/` (run ad-hoc queries against Table 2 permissions).
+
+  See documentation for [[metabase.models.interface/IObjectPermissions]] for more details.
+
+  ### Determining query permissions
+
+  Normally, a User is allowed to view (i.e., run the query for) a Saved Question if they have read permissions for the
+  Collection in which Saved Question lives, **or** if they have data permissions for the Database and Table(s) the
+  Question accesses. The main idea here is that some Users with more permissions can go create a curated set of Saved
+  Questions they deem appropriate for less-privileged Users to see, and put them in a Collection they can see. These
+  Users would still be prevented from poking around things on their own, however.
+
+  The Query Processor middleware in [[metabase.query-processor.middleware.permissions]],
+  [[metabase-enterprise.sandbox.query-processor.middleware.row-level-restrictions]], and
+  [[metabase-enterprise.forthcoming-block-permissions-middleware-namespace]] determines whether the current
+  User has permissions to run the current query. Permissions are as follows:
+
+  | Data perms? | Coll perms? | Block? | Segmented? | Can run? |
+  | ----------- | ----------- | ------ | ---------- | -------- |
+  |          no |          no |     no |         no |       ⛔ |
+  |          no |          no |     no |        yes |       ⚠ |
+  |          no |          no |    yes |         no |       ⛔ |
+  |          no |          no |    yes |        yes |       ⚠ |
+  |          no |         yes |     no |         no |       ✅ |
+  |          no |         yes |     no |        yes |       ⚠ |
+  |          no |         yes |    yes |         no |       ⛔ |
+  |          no |         yes |    yes |        yes |       ⚠ |
+  |         yes |          no |     no |         no |       ✅ |
+  |         yes |          no |     no |        yes |       ✅ |
+  |         yes |          no |    yes |         no |       ✅ |
+  |         yes |          no |    yes |        yes |       ✅ |
+  |         yes |         yes |     no |         no |       ✅ |
+  |         yes |         yes |     no |        yes |       ✅ |
+  |         yes |         yes |    yes |         no |       ✅ |
+  |         yes |         yes |    yes |        yes |       ✅ |
+
+  (`⚠` = runs in sandboxed mode)
+
+  ### Known Permissions Paths
+
+  See [[path-regex]] for an always-up-to-date list of permissions paths.
+
+    /collection/:id/                                ; read-write perms for a Coll and its non-Coll children
+    /collection/:id/read/                           ; read-only  perms for a Coll and its non-Coll children
+    /collection/root/                               ; read-write perms for the Root Coll and its non-Coll children
+    /colllection/root/read/                         ; read-only  perms for the Root Coll and its non-Coll children
+    /collection/namespace/:namespace/root/          ; read-write perms for the Root Coll of a non-default namespace (e.g. SQL Snippets)
+    /collection/namespace/:namespace/root/read/     ; read-only  perms for the Root Coll of a non-default namespace (e.g. SQL Snippets)
+    /db/:id/                                        ; full perms for a Database
+    /db/:id/native/                                 ; ad-hoc native query perms for a Database
+    /db/:id/schema/                                 ; ad-hoc MBQL query perms for all schemas in DB (does not include native queries)
+    /db/:id/schema/:name/                           ; ad-hoc MBQL query perms for a specific schema
+    /db/:id/schema/:name/table/:id/                 ; full perms for a Table
+    /db/:id/schema/:name/table/:id/read/            ; perms to fetch info about this Table from the DB
+    /db/:id/schema/:name/table/:id/query/           ; ad-hoc MBQL query perms for a Table
+    /db/:id/schema/:name/table/:id/query/segmented/ ; [GRANT ONLY] allow ad-hoc MBQL queries. Sandbox all queries against this Table.
+    /block/db/:id/                                  ; [GRANT ONLY] disallow queries against this DB unless User has data perms.
+    /                                               ; [GRANT ONLY] full root perms"
   (:require [clojure.core.match :refer [match]]
             [clojure.data :as data]
             [clojure.string :as str]
@@ -49,8 +218,9 @@
   3. A backslash escaped by a backslash: `\\\\`"
   (u.regex/rx (or #"[^\\/]" #"\\/" #"\\\\")))
 
-(def ^:private valid-object-path-regex
-  "Regex for a valid permissions path. `rx` macro is used to make the big-and-hairy macro somewhat readable."
+(def ^:private path-regex
+  "Regex for a valid permissions path. The [[metabase.util.regex/rx]] macro is used to make the big-and-hairy macro
+  somewhat readable."
   (u.regex/rx "^/"
               ;; any path starting with /db/ is a DATA PERMISSIONS path
               (or
@@ -89,11 +259,18 @@
                      (and "namespace/" path-char "+/root/"
                           ;; /collection/namespace/:namespace/root/read/ -> read perms for 'Root' Collection in
                           ;; non-default namespace
-                          (opt "read/")))))
+                          (opt "read/"))))
+               ;; any path starting with /block/ is for BLOCK anti-permissions.
+               ;; currently only supported at the DB level, e.g. /block/db/1/ => block collection-based access to
+               ;; Database 1
+               #"block/db/\d+/"
+               ;; root permissions, i.e. for admin
+               "")
               "$"))
 
 (def segmented-perm-regex
-  "Regex that matches a segmented permission"
+  "Regex that matches a segmented permission. Used internally for some EE stuff
+  e.g. [[metabase-enterprise.sandbox.api.util/segmented-user?]]."
   (re-pattern (str #"^/db/\d+/schema/" path-char "*" #"/table/\d+/query/segmented/$")))
 
 (defn- escape-path-component
@@ -106,23 +283,16 @@
           (str/replace #"\\" "\\\\\\\\")   ; \ -> \\
           (str/replace #"/" "\\\\/"))) ; / -> \/
 
-(defn valid-object-path?
-  "Does `object-path` follow a known, allowed format to an *object*? (The root path, \"/\", is not considered an object;
-  this returns `false` for it)."
-  ^Boolean [^String object-path]
-  (boolean (when (and (string? object-path)
-                      (seq object-path))
-             (re-matches valid-object-path-regex object-path))))
+(defn valid-path?
+  "Is `path` a valid, known permissions path?"
+  ^Boolean [^String path]
+  (boolean (when (and (string? path)
+                      (seq path))
+             (re-matches path-regex path))))
 
-(def ObjectPath
-  "Schema for a valid permissions path to an object."
-  (s/pred valid-object-path? "Valid permissions object path."))
-
-(def UserPath
-  "Schema for a valid permissions path that a user might possess in their `*current-user-permissions-set*`. This is the
-  same as what's allowed for `ObjectPath` but also includes root permissions, which admins will have."
-  (s/pred #(or (= % "/") (valid-object-path? %))
-          "Valid user permissions path."))
+(def Path
+  "Schema for a valid permissions path."
+  (s/pred valid-path? "Valid permissions path"))
 
 (defn- assert-not-admin-group
   "Check to make sure the `:group_id` for `permissions` entry isn't the admin group."
@@ -136,7 +306,7 @@
   "Check to make sure the value of `:object` for `permissions` entry is valid."
   [{:keys [object]}]
   (when (and object
-             (not (valid-object-path? object))
+             (not (valid-path? object))
              (or (not= object "/")
                  (not *allow-root-entries*)))
     (throw (ex-info (tru "Invalid permissions object path: ''{0}''." object)
@@ -166,31 +336,31 @@
 (def ^:private MapOrID
   (s/cond-pre su/Map su/IntGreaterThanZero))
 
-(s/defn object-path :- ObjectPath
+(s/defn data-perms-path :- Path
   "Return the [readwrite] permissions path for a Database, schema, or Table. (At the time of this writing, DBs and
   schemas don't have separate `read/` and write permissions; you either have 'data access' permissions for them, or
   you don't. Tables, however, have separate read and write perms.)"
   ([database-or-id :- MapOrID]
    (str "/db/" (u/the-id database-or-id) "/"))
 
-  ([database-or-id :- MapOrID, schema-name :- (s/maybe s/Str)]
-   (str (object-path database-or-id) "schema/" (escape-path-component schema-name) "/"))
+  ([database-or-id :- MapOrID schema-name :- (s/maybe s/Str)]
+   (str (data-perms-path database-or-id) "schema/" (escape-path-component schema-name) "/"))
 
-  ([database-or-id :- MapOrID, schema-name :- (s/maybe s/Str), table-or-id :- MapOrID]
-   (str (object-path database-or-id schema-name) "table/" (u/the-id table-or-id) "/")))
+  ([database-or-id :- MapOrID schema-name :- (s/maybe s/Str) table-or-id :- MapOrID]
+   (str (data-perms-path database-or-id schema-name) "table/" (u/the-id table-or-id) "/")))
 
-(s/defn adhoc-native-query-path :- ObjectPath
+(s/defn adhoc-native-query-path :- Path
   "Return the native query read/write permissions path for a database.
    This grants you permissions to run arbitary native queries."
   [database-or-id :- MapOrID]
-  (str (object-path database-or-id) "native/"))
+  (str (data-perms-path database-or-id) "native/"))
 
-(s/defn all-schemas-path :- ObjectPath
+(s/defn all-schemas-path :- Path
   "Return the permissions path for a database that grants full access to all schemas."
   [database-or-id :- MapOrID]
-  (str (object-path database-or-id) "schema/"))
+  (str (data-perms-path database-or-id) "schema/"))
 
-(s/defn collection-readwrite-path :- ObjectPath
+(s/defn collection-readwrite-path :- Path
   "Return the permissions path for *readwrite* access for a `collection-or-id`."
   [collection-or-id :- MapOrID]
   (if-not (get collection-or-id :metabase.models.collection.root/is-root?)
@@ -199,52 +369,65 @@
       (format "/collection/namespace/%s/root/" (escape-path-component (u/qualified-name collection-namespace)))
       "/collection/root/")))
 
-(s/defn collection-read-path :- ObjectPath
+(s/defn collection-read-path :- Path
   "Return the permissions path for *read* access for a `collection-or-id`."
   [collection-or-id :- MapOrID]
   (str (collection-readwrite-path collection-or-id) "read/"))
 
-(s/defn table-read-path :- ObjectPath
+(s/defn table-read-path :- Path
   "Return the permissions path required to fetch the Metadata for a Table."
-  ([table]
-   (table-read-path (:db_id table) (:schema table) table))
+  ([table-or-id]
+   (if (integer? table-or-id)
+     (recur (db/select-one ['Table :db_id :schema :id] :id table-or-id))
+     (table-read-path (:db_id table-or-id) (:schema table-or-id) table-or-id)))
 
   ([database-or-id schema-name table-or-id]
-   {:post [(valid-object-path? %)]}
-   (str (object-path (u/the-id database-or-id) schema-name (u/the-id table-or-id)) "read/")))
+   {:post [(valid-path? %)]}
+   (str (data-perms-path (u/the-id database-or-id) schema-name (u/the-id table-or-id)) "read/")))
 
-(s/defn table-query-path :- ObjectPath
+(s/defn table-query-path :- Path
   "Return the permissions path for *full* query access for a Table. Full query access means you can run any (MBQL) query
   you wish against a given Table, with no GTAP-specified mandatory query alterations."
-  ([table]
-   (table-query-path (:db_id table) (:schema table) table))
+  ([table-or-id]
+   (if (integer? table-or-id)
+     (recur (db/select-one ['Table :db_id :schema :id] :id table-or-id))
+     (table-query-path (:db_id table-or-id) (:schema table-or-id) table-or-id)))
 
   ([database-or-id schema-name table-or-id]
-   (str (object-path (u/the-id database-or-id) schema-name (u/the-id table-or-id)) "query/")))
+   (str (data-perms-path (u/the-id database-or-id) schema-name (u/the-id table-or-id)) "query/")))
 
-(s/defn table-segmented-query-path :- ObjectPath
+(s/defn table-segmented-query-path :- Path
   "Return the permissions path for *segmented* query access for a Table. Segmented access means running queries against
   the Table will automatically replace the Table with a GTAP-specified question as the new source of the query,
   obstensibly limiting access to the results."
-  ([table]
-   (table-segmented-query-path (:db_id table) (:schema table) table))
+  ([table-or-id]
+   (if (integer? table-or-id)
+     (recur (db/select-one ['Table :db_id :schema :id] :id table-or-id))
+     (table-segmented-query-path (:db_id table-or-id) (:schema table-or-id) table-or-id)))
 
   ([database-or-id schema-name table-or-id]
-   (str (object-path (u/the-id database-or-id) schema-name (u/the-id table-or-id)) "query/segmented/")))
+   (str (data-perms-path (u/the-id database-or-id) schema-name (u/the-id table-or-id)) "query/segmented/")))
+
+(s/defn database-block-perms-path :- Path
+  "Return the permissions path for the Block 'anti-permissions'. Block anti-permissions means a User cannot run a query
+  against a Database unless they have data permissions, regardless of whether segmented permissions would normally give
+  them access or not."
+  [database-or-id :- MapOrID]
+  (str "/block" (data-perms-path database-or-id)))
 
 
 ;;; -------------------------------------------- Permissions Checking Fns --------------------------------------------
 
 (defn is-permissions-for-object?
-  "Does `permissions-path` grant *full* access for `object-path`?"
-  [permissions-path object-path]
-  (str/starts-with? object-path permissions-path))
+  "Does `permissions-path` grant *full* access for `path`?"
+  [permissions-path path]
+  (str/starts-with? path permissions-path))
 
 (defn is-partial-permissions-for-object?
-  "Does `permissions-path` grant access full access for `object-path` *or* for a descendant of `object-path`?"
-  [permissions-path object-path]
-  (or (is-permissions-for-object? permissions-path object-path)
-      (str/starts-with? permissions-path object-path)))
+  "Does `permissions-path` grant access full access for `path` *or* for a descendant of `path`?"
+  [permissions-path path]
+  (or (is-permissions-for-object? permissions-path path)
+      (str/starts-with? permissions-path path)))
 
 (defn is-permissions-set?
   "Is `permissions-set` a valid set of permissions object paths?"
@@ -252,7 +435,7 @@
   (and (set? permissions-set)
        (every? (fn [path]
                  (or (= path "/")
-                     (valid-object-path? path)))
+                     (valid-path? path)))
                permissions-set)))
 
 (defn set-has-full-permissions?
@@ -266,27 +449,27 @@
   (boolean (some #(is-partial-permissions-for-object? % path) permissions-set)))
 
 (s/defn set-has-full-permissions-for-set? :- s/Bool
-  "Do the permissions paths in `permissions-set` grant *full* access to all the object paths in `object-paths-set`?"
-  [permissions-set :- #{UserPath} object-paths-set :- #{ObjectPath}]
+  "Do the permissions paths in `permissions-set` grant *full* access to all the object paths in `paths-set`?"
+  [permissions-set :- #{Path} paths-set :- #{Path}]
   (every? (partial set-has-full-permissions? permissions-set)
-          object-paths-set))
+          paths-set))
 
 (s/defn set-has-partial-permissions-for-set? :- s/Bool
-  "Do the permissions paths in `permissions-set` grant *partial* access to all the object paths in `object-paths-set`?
-   (`permissions-set` must grant partial access to *every* object in `object-paths-set` set)."
-  [permissions-set :- #{UserPath}, object-paths-set :- #{ObjectPath}]
+  "Do the permissions paths in `permissions-set` grant *partial* access to all the object paths in `paths-set`?
+   (`permissions-set` must grant partial access to *every* object in `paths-set` set)."
+  [permissions-set :- #{Path}, paths-set :- #{Path}]
   (every? (partial set-has-partial-permissions? permissions-set)
-          object-paths-set))
+          paths-set))
 
-(s/defn perms-objects-set-for-parent-collection :- #{ObjectPath}
+(s/defn perms-objects-set-for-parent-collection :- #{Path}
   "Implementation of `IModel` `perms-objects-set` for models with a `collection_id`, such as Card, Dashboard, or Pulse.
-  This simply returns the `perms-objects-set` of the parent Collection (based on `collection_id`), or for the Root
+  This simply returns the `perms-objects-set` of the parent Collection (based on `collection_id`) or for the Root
   Collection if `collection_id` is `nil`."
   ([this read-or-write]
    (perms-objects-set-for-parent-collection nil this read-or-write))
 
   ([collection-namespace :- (s/maybe su/KeywordOrString)
-    this                 :- {:collection_id (s/maybe su/IntGreaterThanZero), s/Keyword s/Any}
+    this                 :- {:collection_id (s/maybe su/IntGreaterThanZero) s/Keyword s/Any}
     read-or-write        :- (s/enum :read :write)]
    ;; based on value of read-or-write determine the approprite function used to calculate the perms path
    (let [path-fn (case read-or-write
@@ -320,39 +503,46 @@
 (defn- pre-insert [permissions]
   (u/prog1 permissions
     (assert-valid permissions)
-    (log/debug (u/colorize 'green (trs "Granting permissions for group {0}: {1}" (:group_id permissions) (:object permissions))))))
+    (log/debug (u/colorize 'green (trs "Granting permissions for group {0}: {1}"
+                                       (:group_id permissions)
+                                       (:object permissions))))))
 
 (defn- pre-update [_]
   (throw (Exception. (str (deferred-tru "You cannot update a permissions entry!")
                           (deferred-tru "Delete it and create a new one.")))))
 
 (defn- pre-delete [permissions]
-  (log/debug (u/colorize 'red (trs "Revoking permissions for group {0}: {1}" (:group_id permissions) (:object permissions))))
+  (log/debug (u/colorize 'red (trs "Revoking permissions for group {0}: {1}"
+                                   (:group_id permissions)
+                                   (:object permissions))))
   (assert-not-admin-group permissions))
 
 (u/strict-extend (class Permissions)
   models/IModel (merge models/IModelDefaults
-                   {:pre-insert         pre-insert
-                    :pre-update         pre-update
-                    :pre-delete pre-delete}))
+                       {:pre-insert pre-insert
+                        :pre-update pre-update
+                        :pre-delete pre-delete}))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                                  GRAPH SCHEMA                                                  |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
+;; The stuff below is all for the *data* permissions graph. We have a separate graph for Collection permissions, and
+;; code to work with it lives in [[metabase.models.collection.graph]].
+
 ;; TODO - there is so much stuff related to the perms graph I think we should really move it into a separate
 ;; `metabase.models.permissions.graph.data` namespace or something and move the collections graph from
-;; `metabase.models.collection` to `metabase.models.permissions.graph.collection` (?)
+;; [[metabase.models.collection.graph]] to `metabase.models.permissions.graph.collection` (?)
 
 (def ^:private TablePermissionsGraph
   (s/named
-    (s/cond-pre (s/enum :none :all)
-                (s/constrained
-                  {(s/optional-key :read)  (s/enum :all :none)
-                   (s/optional-key :query) (s/enum :all :segmented :none)}
-                  not-empty))
-    "Valid perms graph for a Table"))
+   (s/cond-pre (s/enum :none :all)
+               (s/constrained
+                {(s/optional-key :read)  (s/enum :all :none)
+                 (s/optional-key :query) (s/enum :all :segmented :none)}
+                not-empty))
+   "Valid perms graph for a Table"))
 
 (def ^:private SchemaPermissionsGraph
   (s/named
@@ -368,35 +558,28 @@
 (def ^:private DBPermissionsGraph
   (s/named
    {(s/optional-key :native)  NativePermissionsGraph
-    (s/optional-key :schemas) (s/cond-pre (s/enum :all :none)
+    (s/optional-key :schemas) (s/cond-pre (s/enum :all :none :block)
                                           {s/Str SchemaPermissionsGraph})}
    "Valid perms graph for a Database"))
-
-(def ^:private GroupPermissionsGraph
-  (s/named
-   {su/IntGreaterThanZero DBPermissionsGraph}
-   "Valid perms graph for a PermissionsGroup"))
-
-(def ^:private PermissionsGraph
-  (s/named
-   {:revision s/Int
-    :groups   {su/IntGreaterThanZero GroupPermissionsGraph}}
-   "Valid perms graph"))
 
 ;; The "Strict" versions of the various graphs below are intended for schema checking when *updating* the permissions
 ;; graph. In other words, we shouldn't be stopped from returning the graph if it violates the "strict" rules, but we
 ;; *should* refuse to update the graph unless it matches the strict schema.
 ;;
 ;; TODO - It might be possible at some point in the future to just use the strict versions everywhere
-
+;;
+;; TODO -- instead of doing schema validation, why don't we just throw an Exception so the API responses are actually
+;; somewhat useful?
 (defn- check-native-and-schemas-permissions-allowed-together [{:keys [native schemas]}]
   ;; Only do the check when we have both, e.g. when the entire graph is coming in
   (if-not (and native schemas)
     :ok
     (match [native schemas]
       [:write :all]  :ok
-      [:write _]     (log/warn "Invalid DB permissions: if you have write access for native queries, you must have full data access.")
-      [:read  :none] (log/warn "Invalid DB permissions: if you have readonly native query access, you must also have data access.")
+      [:write _]      (log/warn "Invalid DB permissions: if you have write access for native queries, you must have full data access.")
+      [:read  :none]  (log/warn "Invalid DB permissions: if you have readonly native query access, you must also have data access.")
+      ;; TODO -- log a warning if we end up keeping this code.
+      [_      :block] false
       [_      _]     :ok)))
 
 (def ^:private StrictDBPermissionsGraph
@@ -416,7 +599,7 @@
 ;;; |                                                  GRAPH FETCH                                                   |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(defn all-permissions
+(defn- all-permissions
   "Handle '/' permission"
   [db-ids]
   (reduce (fn [g db-id]
@@ -425,20 +608,32 @@
           {}
           db-ids))
 
-(s/defn graph :- PermissionsGraph
-  "Fetch a graph representing the current permissions status for every Group and all permissioned databases."
+(s/defn data-perms-graph
+  "Fetch a graph representing the current *data* permissions status for every Group and all permissioned databases.
+  See [[metabase.models.collection.graph]] for the Collection permissions graph code."
   []
-  (let [permissions (db/select [Permissions :group_id :object], :group_id [:not= (:id (group/metabot))])
-        db-ids      (db/select-ids 'Database)]
-    {:revision (perms-revision/latest-id)
-     :groups   (->> permissions
-                    (filter (comp #(re-find #"(^/db|^/$)" %) :object))
-                    (group-by :group_id)
-                    (m/map-vals (fn [group-permissions]
-                                  (let [permissions-graph (perms-parse/permissions->graph (map :object group-permissions))]
-                                    (if (= :all permissions-graph)
-                                      (all-permissions db-ids)
-                                      (:db permissions-graph))))))}))
+  (let [permissions (db/select [Permissions [:group_id :group-id] [:object :path]]
+                      {:where [:and
+                               [:not= :group_id (:id (group/metabot))]
+                               [:or
+                                [:= :object (hx/literal "/")]
+                                [:like :object (hx/literal "/db/%")]
+                                [:like :object (hx/literal "/block/db/%")]]]})
+        db-ids      (delay (db/select-ids 'Database))]
+    (let [group-id->paths (reduce
+                           (fn [m {:keys [group-id path]}]
+                             (update m group-id conj path))
+                           {}
+                           permissions)
+          group-id->graph (m/map-vals
+                           (fn [paths]
+                             (let [permissions-graph (perms-parse/permissions->graph paths)]
+                               (if (= :all permissions-graph)
+                                 (all-permissions @db-ids)
+                                 (:db permissions-graph))))
+                           group-id->paths)]
+      {:revision (perms-revision/latest-id)
+       :groups   group-id->graph})))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -448,12 +643,10 @@
 ;;; --------------------------------------------------- Helper Fns ---------------------------------------------------
 
 (s/defn ^:private delete-related-permissions!
-  "This is somewhat hard to explain, but I will do my best:
-
-  Delete all 'related' permissions for `group-or-id` (i.e., perms that grant you full or partial access to `path`).
+  "Delete all 'related' permissions for `group-or-id` (i.e., perms that grant you full or partial access to `path`).
   This includes *both* ancestor and descendant paths. For example:
 
-  Suppose we asked this functions to delete related permssions for `/db/1/schema/PUBLIC/`. Dependning on the
+  Suppose we asked this functions to delete related permssions for `/db/1/schema/PUBLIC/`. Depending on the
   permissions the group has, it could end up doing something like:
 
     *  deleting `/db/1/` permissions (because the ancestor perms implicity grant you full perms for `schema/PUBLIC`)
@@ -466,9 +659,9 @@
   deleted.
 
   NOTE: This function is meant for internal usage in this namespace only; use one of the other functions like
-  `revoke-permissions!` elsewhere instead of calling this directly."
+  `revoke-data-perms!` elsewhere instead of calling this directly."
   {:style/indent 2}
-  [group-or-id :- (s/cond-pre su/Map su/IntGreaterThanZero), path :- ObjectPath, & other-conditions]
+  [group-or-id :- (s/cond-pre su/Map su/IntGreaterThanZero) path :- Path & other-conditions]
   (let [where {:where (apply list
                              :and
                              [:= :group_id (u/the-id group-or-id)]
@@ -480,22 +673,24 @@
       (log/debug (u/format-color 'red "Revoking permissions for group %d: %s" (u/the-id group-or-id) revoked))
       (db/delete! Permissions where))))
 
-(defn revoke-permissions!
+(defn revoke-data-perms!
   "Revoke all permissions for `group-or-id` to object with `path-components`, *including* related permissions (i.e,
   permissions that grant full or partial access to the object in question).
 
 
-    (revoke-permissions! my-group my-db)"
-  {:arglists '([group-id database-or-id]
-               [group-id database-or-id schema-name]
-               [group-id database-or-id schema-name table-or-id])}
+    (revoke-data-perms! my-group my-db)"
+  {:arglists '([group-or-id database-or-id]
+               [group-or-id database-or-id schema-name]
+               [group-or-id database-or-id schema-name table-or-id])}
   [group-or-id & path-components]
-  (delete-related-permissions! group-or-id (apply object-path path-components)))
+  (delete-related-permissions! group-or-id (apply data-perms-path path-components)))
 
 (defn grant-permissions!
-  "Grant permissions to `group-or-id` to an object."
+  "Grant permissions for `group-or-id`. Two-arity grants any arbitrary Permissions `path`. With > 2 args, grants the
+  data permissions from calling [[data-perms-path]]."
   ([group-or-id db-id schema & more]
-   (grant-permissions! group-or-id (apply object-path db-id schema more)))
+   (grant-permissions! group-or-id (apply data-perms-path db-id schema more)))
+
   ([group-or-id path]
    (try
      (db/insert! Permissions
@@ -525,7 +720,7 @@
    This does *not* revoke native permissions; use `revoke-native-permssions!` to do that."
   [group-or-id database-or-id]
   ;; TODO - if permissions for this DB are DB root entries like `/db/1/` won't this end up removing our native perms?
-  (delete-related-permissions! group-or-id (object-path database-or-id)
+  (delete-related-permissions! group-or-id (data-perms-path database-or-id)
     [:not= :object (adhoc-native-query-path database-or-id)]))
 
 (defn grant-permissions-for-all-schemas!
@@ -537,7 +732,7 @@
 (defn grant-full-db-permissions!
   "Grant full access to the database, including all schemas and readwrite native access."
   [group-or-id database-or-id]
-  (grant-permissions! group-or-id (object-path database-or-id)))
+  (grant-permissions! group-or-id (data-perms-path database-or-id)))
 
 (defn- is-personal-collection-or-descendant-of-one? [collection]
   (classloader/require 'metabase.models.collection)
@@ -588,7 +783,7 @@
    new-read-perms :- (s/enum :all :none)]
   ((case new-read-perms
      :all  grant-permissions!
-     :none revoke-permissions!) group-id (table-read-path db-id schema table-id)))
+     :none revoke-data-perms!) group-id (table-read-path db-id schema table-id)))
 
 (s/defn ^:private update-table-query-perms!
   [group-id        :- su/IntGreaterThanZero
@@ -599,7 +794,7 @@
   (case new-query-perms
     :all       (grant-permissions!  group-id (table-query-path           db-id schema table-id))
     :segmented (grant-permissions!  group-id (table-segmented-query-path db-id schema table-id))
-    :none      (revoke-permissions! group-id (table-query-path           db-id schema table-id))))
+    :none      (revoke-data-perms! group-id (table-query-path           db-id schema table-id))))
 
 (s/defn ^:private update-table-perms!
   [group-id        :- su/IntGreaterThanZero
@@ -612,12 +807,12 @@
     (grant-permissions! group-id db-id schema table-id)
 
     (= new-table-perms :none)
-    (revoke-permissions! group-id db-id schema table-id)
+    (revoke-data-perms! group-id db-id schema table-id)
 
     (map? new-table-perms)
     (let [{new-read-perms :read, new-query-perms :query} new-table-perms]
       ;; clear out any existing permissions
-      (revoke-permissions! group-id db-id schema table-id)
+      (revoke-data-perms! group-id db-id schema table-id)
       ;; then grant/revoke read and query perms as appropriate
       (when new-read-perms  (update-table-read-perms!  group-id db-id schema table-id new-read-perms))
       (when new-query-perms (update-table-query-perms! group-id db-id schema table-id new-query-perms)))))
@@ -628,18 +823,18 @@
    schema           :- s/Str
    new-schema-perms :- SchemaPermissionsGraph]
   (cond
-    (= new-schema-perms :all)  (do (revoke-permissions! group-id db-id schema)  ; clear out any existing related permissions
+    (= new-schema-perms :all)  (do (revoke-data-perms! group-id db-id schema)  ; clear out any existing related permissions
                                    (grant-permissions!  group-id db-id schema)) ; then grant full perms for the schema
-    (= new-schema-perms :none) (revoke-permissions! group-id db-id schema)
+    (= new-schema-perms :none) (revoke-data-perms! group-id db-id schema)
     (map? new-schema-perms)    (doseq [[table-id table-perms] new-schema-perms]
                                  (update-table-perms! group-id db-id schema table-id table-perms))))
 
 (s/defn ^:private update-native-permissions!
-  [group-id :- su/IntGreaterThanZero, db-id :- su/IntGreaterThanZero, new-native-perms :- NativePermissionsGraph]
+  [group-id :- su/IntGreaterThanZero db-id :- su/IntGreaterThanZero new-native-perms :- NativePermissionsGraph]
   ;; revoke-native-permissions! will delete all entires that would give permissions for native access. Thus if you had
   ;; a root DB entry like `/db/11/` this will delete that too. In that case we want to create a new full schemas entry
   ;; so you don't lose access to all schemas when we modify native access.
-  (let [has-full-access? (db/exists? Permissions :group_id group-id, :object (object-path db-id))]
+  (let [has-full-access? (db/exists? Permissions :group_id group-id, :object (data-perms-path db-id))]
     (revoke-native-permissions! group-id db-id)
     (when has-full-access?
       (grant-permissions-for-all-schemas! group-id db-id)))
@@ -647,30 +842,42 @@
     :write (grant-native-readwrite-permissions! group-id db-id)
     :none  nil))
 
-
 (s/defn ^:private update-db-permissions!
-  [group-id :- su/IntGreaterThanZero, db-id :- su/IntGreaterThanZero, new-db-perms :- StrictDBPermissionsGraph]
+  [group-id :- su/IntGreaterThanZero db-id :- su/IntGreaterThanZero new-db-perms :- StrictDBPermissionsGraph]
   (when-let [new-native-perms (:native new-db-perms)]
     (update-native-permissions! group-id db-id new-native-perms))
   (when-let [schemas (:schemas new-db-perms)]
-    (cond
-      (= schemas :all)  (do (revoke-db-schema-permissions! group-id db-id)
-                            (grant-permissions-for-all-schemas! group-id db-id))
-      (= schemas :none) (revoke-db-schema-permissions! group-id db-id)
-      (map? schemas)    (doseq [schema (keys schemas)]
-                          (update-schema-perms! group-id db-id schema (get-in new-db-perms [:schemas schema]))))))
+    ;; TODO -- consider whether `delete-block-perms-for-this-db!` should be enterprise-only... not sure how to make it
+    ;; work, especially if you downgraded from enterprise... FWIW the sandboxing code (for updating the graph) is not enterprise only.
+    (letfn [(delete-block-perms-for-this-db! []
+              (log/trace "Deleting block permissions entries for Group %d for Database %d" group-id db-id)
+              (db/delete! Permissions :group_id group-id, :object (database-block-perms-path db-id)))]
+      (condp = schemas
+        :all (do
+               (revoke-db-schema-permissions! group-id db-id)
+               (delete-block-perms-for-this-db!)
+               (grant-permissions-for-all-schemas! group-id db-id))
+        :none  (do
+                 (revoke-db-schema-permissions! group-id db-id)
+                 (delete-block-perms-for-this-db!))
+        ;; TODO -- should this code be enterprise only?
+        :block (do
+                 (revoke-data-perms! group-id db-id)
+                 (grant-permissions! group-id (database-block-perms-path db-id)))
+        (when (map? schemas)
+          (delete-block-perms-for-this-db!)
+          (doseq [schema (keys schemas)]
+            (update-schema-perms! group-id db-id schema (get-in new-db-perms [:schemas schema]))))))))
 
 (s/defn ^:private update-group-permissions!
-  [group-id :- su/IntGreaterThanZero, new-group-perms :- StrictGroupPermissionsGraph]
+  [group-id :- su/IntGreaterThanZero new-group-perms :- StrictGroupPermissionsGraph]
   (doseq [[db-id new-db-perms] new-group-perms]
     (update-db-permissions! group-id db-id new-db-perms)))
 
-
 (defn check-revision-numbers
-  "Check that the revision number coming in as part of NEW-GRAPH matches the one from OLD-GRAPH.
-   This way we can make sure people don't submit a new graph based on something out of date,
-   which would otherwise stomp over changes made in the interim.
-   Return a 409 (Conflict) if the numbers don't match up."
+  "Check that the revision number coming in as part of `new-graph` matches the one from `old-graph`. This way we can
+  make sure people don't submit a new graph based on something out of date, which would otherwise stomp over changes
+  made in the interim. Return a 409 (Conflict) if the numbers don't match up."
   [old-graph new-graph]
   (when (not= (:revision old-graph) (:revision new-graph))
     (throw (ex-info (str (deferred-tru "Looks like someone else edited the permissions and your data is out of date.")
@@ -699,14 +906,16 @@
    "\n" (trs "FROM:") (u/pprint-to-str 'magenta old)
    "\n" (trs "TO:")   (u/pprint-to-str 'blue    new)))
 
-(s/defn update-graph!
-  "Update the permissions graph, making any changes necessary to make it match NEW-GRAPH.
+(s/defn update-data-perms-graph!
+  "Update the *data* permissions graph, making any changes necessary to make it match NEW-GRAPH.
    This should take in a graph that is exactly the same as the one obtained by `graph` with any changes made as
    needed. The graph is revisioned, so if it has been updated by a third party since you fetched it this function will
    fail and return a 409 (Conflict) exception. If nothing needs to be done, this function returns `nil`; otherwise it
-   returns the newly created `PermissionsRevision` entry."
+   returns the newly created `PermissionsRevision` entry.
+
+  Code for updating the Collection permissions graph is in [[metabase.models.collection.graph]]."
   ([new-graph :- StrictPermissionsGraph]
-   (let [old-graph (graph)
+   (let [old-graph (data-perms-graph)
          [old new] (data/diff (:groups old-graph) (:groups new-graph))
          old       (or old {})]
      (when (or (seq old) (seq new))
@@ -719,5 +928,5 @@
          (delete-sandboxes/delete-gtaps-if-needed-after-permissions-change! new)))))
 
   ;; The following arity is provided soley for convenience for tests/REPL usage
-  ([ks :- [s/Any], new-value]
-   (update-graph! (assoc-in (graph) (cons :groups ks) new-value))))
+  ([ks :- [s/Any] new-value]
+   (update-data-perms-graph! (assoc-in (data-perms-graph) (cons :groups ks) new-value))))

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -165,9 +165,9 @@
     /db/:id/schema/:name/table/:id/                 ; full perms for a Table
     /db/:id/schema/:name/table/:id/read/            ; perms to fetch info about this Table from the DB
     /db/:id/schema/:name/table/:id/query/           ; ad-hoc MBQL query perms for a Table
-    /db/:id/schema/:name/table/:id/query/segmented/ ; [GRANT ONLY] allow ad-hoc MBQL queries. Sandbox all queries against this Table.
-    /block/db/:id/                                  ; [GRANT ONLY] disallow queries against this DB unless User has data perms.
-    /                                               ; [GRANT ONLY] full root perms"
+    /db/:id/schema/:name/table/:id/query/segmented/ ; allow ad-hoc MBQL queries. Sandbox all queries against this Table.
+    /block/db/:id/                                  ; disallow queries against this DB unless User has data perms.
+    /                                               ; full root perms"
   (:require [clojure.core.match :refer [match]]
             [clojure.data :as data]
             [clojure.string :as str]
@@ -219,7 +219,7 @@
   (u.regex/rx (or #"[^\\/]" #"\\/" #"\\\\")))
 
 (def ^:private path-regex
-  "Regex for a valid permissions path. The [[metabase.util.regex/rx]] macro is used to make the big-and-hairy macro
+  "Regex for a valid permissions path. The [[metabase.util.regex/rx]] macro is used to make the big-and-hairy regex
   somewhat readable."
   (u.regex/rx "^/"
               ;; any path starting with /db/ is a DATA PERMISSIONS path

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -13,10 +13,10 @@
   with `is_superuser`) is a member; and the [[metabase.models.permissions-group/metabot]] Group, which defines
   permissions for the MetaBot.
 
-  The permissions needed to perform an action are represented as path strings. Permissions paths are slash-delimited
-  strings such as `/db/1/schema/PUBLIC/`. Each slash represents a different part of the permissions path, and each
-  permissions path must start and end with a slash. Permissions use the same path representation for both the
-  permissions required to perform an action and the permissions that get granted to individual Groups.
+  The permissions needed to perform an action are represented as slash-delimited path strings, for example
+  `/db/1/schema/PUBLIC/`. Each slash represents a different part of the permissions path, and each permissions path
+  must start and end with a slash. Permissions use the same path representation for both the permissions required to
+  perform an action and the permissions granted to individual Groups.
 
   Permissions paths use a prefix system where a User is normally allowed to perform any action if one of their Groups
   has *any* permissions entry that is a prefix for the permission required to perform that action. For example, if
@@ -27,10 +27,10 @@
   permissions matching an path or path using `LIKE`; see [[metabase.models.database/pre-delete]] for
   an example of the sort of efficient queries the prefix system facilitates.
 
-  The union of all permissions the current User's permissions gets from all groups of which they are a member are
-  automatically bound to [[metabase.api.common/*current-user-permissions-set*]]
-  by [[metabase.server.middleware.session/bind-current-user]] for every REST API request, and by others when queries
-  are ran in a non-API thread (e.g. for MetaBot or scheduled Dashboard Subscriptions).
+  The union of all permissions the current User's gets from all groups of which they are a member are automatically
+  bound to [[metabase.api.common/*current-user-permissions-set*]] by
+  [[metabase.server.middleware.session/bind-current-user]] for every REST API request, and in other places when
+  queries are ran in a non-API thread (e.g. for MetaBot or scheduled Dashboard Subscriptions).
 
   ### Different types of permissions
 
@@ -46,8 +46,7 @@
   ### Enterprise-only permissions and \"anti-permissions\"
 
   In addition to data permissions and Collection permissions, a User can also be granted three additional types of
-  permissions. Some of these types are referred to as \"anti-permissions\" because they are subtractive grants that
-  take away permissions from what the User would otherwise have.
+  permissions.
 
   * _root permissions_ -- permissions for `/`, i.e. full access for everything. Automatically granted to
     the [[metabase.models.permissions-group/admin]] group that gets created on first launch. Because `/` is a prefix
@@ -64,14 +63,14 @@
 
     Additional things to know:
 
-    * Sandboxes permissions are only available in Metabase® Enterprise Edition™.
+    * Sandboxed permissions are only available in Metabase® Enterprise Edition™.
 
     * Only one GTAP may defined per-Group per-Table (this is an application-DB-level constraint). A User may have
       multiple applicable GTAPs if they are members of multiple groups that have sandboxed anti-perms for that Table; in
       that case, the QP signals an error if multiple GTAPs apply to a given Table for the current User (see
       [[metabase-enterprise.sandbox.query-processor.middleware.row-level-restrictions/assert-one-gtap-per-table]]).
 
-    * Segmented (sandboxing) anti-permissions and GTAPs are tied together, and a Group should be given both (or both
+    * Segmented (sandboxing) permissions and GTAPs are tied together, and a Group should be given both (or both
       should be deleted) at the same time. This is *not* currently enforced as a hard application DB constraint, but is
       done in the respective Toucan pre-delete actions. The QP will signal an error if the current user has segmented
       permissions but no matching GTAP exists.
@@ -82,12 +81,14 @@
 
     * GTAPs are not allowed to add columns not present in the original Table, or change their effective type to
       something incompatible (this constraint is in place so we other things continue to work transparently regardless
-      of whether the Table is swapped out.)
+      of whether the Table is swapped out.) See
+      [[metabase-enterprise.sandbox.models.group-table-access-policy/check-columns-match-table]]
 
-  * *block anti-permissions* are per-Group, per-Table grants that tell Metabase to disallow running Saved
-    Questions unless the User has data permissions (in other words, disregard Collection permissions). See the
-    `Determining query permissions` section below for more details. As with segmented anti-permissions, block
-    anti-permissions are only available in Metabase® Enterprise Edition™.
+  * *block \"anti-permissions\"* are per-Group, per-Table grants that tell Metabase to disallow running Saved
+    Questions unless the User has data permissions (in other words, disregard Collection permissions). These are
+    referred to as \"anti-permissions\" because they are subtractive grants that take away permissions from what the
+    User would otherwise have. See the `Determining query permissions` section below for more details. As with
+    segmented permissions, block anti-permissions are only available in Metabase® Enterprise Edition™.
 
   ### Determining CRUD permissions in the REST API
 
@@ -124,7 +125,7 @@
 
   The Query Processor middleware in [[metabase.query-processor.middleware.permissions]],
   [[metabase-enterprise.sandbox.query-processor.middleware.row-level-restrictions]], and
-  [[metabase-enterprise.forthcoming-block-permissions-middleware-namespace]] determines whether the current
+  [[metabase-enterprise.enhancements.models.permissions.block-permissions]] determines whether the current
   User has permissions to run the current query. Permissions are as follows:
 
   | Data perms? | Coll perms? | Block? | Segmented? | Can run? |

--- a/src/metabase/models/permissions/delete_sandboxes.clj
+++ b/src/metabase/models/permissions/delete_sandboxes.clj
@@ -8,7 +8,7 @@
   "Protocol for Sandbox deletion behavior when permissions are granted or revoked."
   (delete-gtaps-if-needed-after-permissions-change!* [this changes]
     "For use only inside `metabase.models.permissions`; don't call this elsewhere. Delete GTAPs that are no longer
-needed after the permissions graph is updated. See docstring for `delete-gtaps-if-needed-after-permissions-change!` for
+ needed after the permissions graph is updated. See docstring for `delete-gtaps-if-needed-after-permissions-change!` for
  more information."))
 
 (def oss-default-impl

--- a/src/metabase/models/permissions/parse.clj
+++ b/src/metabase/models/permissions/parse.clj
@@ -5,12 +5,14 @@
   - Convert parse tree to path, e.g. ['3' :all] or ['3' :schemas :all]
   - Convert set of paths to a map, the permission graph"
   (:require [clojure.core.match :as match]
+            [clojure.tools.logging :as log]
             [clojure.walk :as walk]
-            [instaparse.core :as insta]))
+            [instaparse.core :as insta]
+            [metabase.util.i18n :refer [trs]]))
 
 (def ^:private grammar
   "Describes permission strings like /db/3/ or /collection/root/read/"
-  "permission = ( all | db | collection )
+  "permission = ( all | db | collection | block )
   all         = <'/'>
   db          = <'/db/'> #'\\d+' <'/'> ( native | schemas )?
   native      = <'native/'>
@@ -19,41 +21,46 @@
   table       = <'table/'> #'\\d+' <'/'> (table-perm <'/'>)?
   table-perm  = ('read'|'query'|'query/segmented')
 
-  collection  = <'/collection/'> #'[^/]*' <'/'> ('read' <'/'>)?")
+  collection  = <'/collection/'> #'[^/]*' <'/'> ('read' <'/'>)?
 
-(def ^:private parser
+  block       = <'/block/db/'> #'\\d+' <'/'>")
+
+(def ^:private ^{:arglists '([s])} parser
   "Function that parses permission strings"
   (insta/parser grammar))
 
 (defn- collection-id
   [id]
-  (if (= id "root") :root (Integer/parseInt id)))
+  (if (= id "root") :root (Long/parseUnsignedLong id)))
 
 (defn- path
   "Recursively build permission path from parse tree"
   [tree]
   (match/match tree
+    (_ :guard insta/failure?)    (log/error (trs "Error parsing permissions tree {0}" (pr-str tree)))
     [:permission t]              (path t)
-    [:all]                       [:all] ;; admin permissions
-    [:db db-id]                  (let [db-id (Integer/parseInt db-id)]
+    [:all]                       [:all] ; admin permissions
+    [:db db-id]                  (let [db-id (Long/parseUnsignedLong db-id)]
                                    [[:db db-id :native :write]
                                     [:db db-id :schemas :all]])
-    [:db db-id db-node]          (let [db-id (Integer/parseInt db-id)]
+    [:db db-id db-node]          (let [db-id (Long/parseUnsignedLong db-id)]
                                    (into [:db db-id] (path db-node)))
     [:schemas]                   [:schemas :all]
     [:schemas schema]            (into [:schemas] (path schema))
     [:schema schema-name]        [schema-name :all]
     [:schema schema-name table]  (into [schema-name] (path table))
-    [:table table-id]            [(Integer/parseInt table-id) :all]
-    [:table table-id table-perm] (into [(Integer/parseInt table-id)] (path table-perm))
-    [:table-perm perm]           (case perm
-                                   "read"            [:read :all]
-                                   "query"           [:query :all]
-                                   "query/segmented" [:query :segmented])
+    [:table table-id]            [(Long/parseUnsignedLong table-id) :all]
+    [:table table-id table-perm] (into [(Long/parseUnsignedLong table-id)] (path table-perm))
+    [:table-perm perm]            (case perm
+                                    "read"            [:read :all]
+                                    "query"           [:query :all]
+                                    "query/segmented" [:query :segmented])
     [:native]                    [:native :write]
-
+    ;; collection perms
     [:collection id]             [:collection (collection-id id) :write]
-    [:collection id "read"]      [:collection (collection-id id) :read]))
+    [:collection id "read"]      [:collection (collection-id id) :read]
+    ;; block perms. Parse something like /block/db/1/ to {:db {1 {:schemas :block}}}
+    [:block db-id]               [:db (Long/parseUnsignedLong db-id) :schemas :block]))
 
 (defn- graph
   "Given a set of permission paths, return a graph that expresses the most permissions possible for the set
@@ -86,15 +93,14 @@
                                          {}))
                          x)))
        (walk/prewalk (fn [x]
-                       (if-let [terminal (and (map? x)
-                                              (some #(and (= (% x) '()) %)
-                                                    [:all :some :write :read :segmented]))]
-                         terminal
-                         x)))))
+                       (or (when (map? x)
+                             (some #(and (= (% x) '()) %)
+                                   [:block :all :some :write :read :segmented]))
+                           x)))))
 
 (defn permissions->graph
   "Given a set of permission strings, return a graph that expresses the most permissions possible for the set"
   [permissions]
   (->> permissions
        (map (comp path parser))
-       (graph)))
+       graph))

--- a/src/metabase/models/permissions_group.clj
+++ b/src/metabase/models/permissions_group.clj
@@ -2,10 +2,12 @@
   "A `PermissionsGroup` is a group (or role) that can be assigned certain permissions. Users can be members of one or
   more of these groups.
 
-  A few 'magic' groups exist: `all-users`, which predicably contains All Users; `admin`, which contains all
-  superusers, and `metabot`, which is used to set permissions for the MetaBot. These groups are 'magic' in the sense
+  A few 'magic' groups exist: [[all-users]], which predicably contains All Users; [[admin]], which contains all
+  superusers, and [[metabot]], which is used to set permissions for the MetaBot. These groups are 'magic' in the sense
   that you cannot add users to them yourself, nor can you delete them; they are created automatically. You can,
-  however, set permissions for them. "
+  however, set permissions for them.
+
+  See documentation in [[metabase.models.permissions]] for more information about the Metabase permissions system."
   (:require [clojure.string :as str]
             [clojure.tools.logging :as log]
             [metabase.db.connection :as mdb.connection]

--- a/src/metabase/models/query/permissions.clj
+++ b/src/metabase/models/query/permissions.clj
@@ -66,7 +66,7 @@
    (s/eq ::native)
    su/IntGreaterThanZero))
 
-(s/defn ^:private tables->permissions-path-set :- #{perms/ObjectPath}
+(s/defn ^:private tables->permissions-path-set :- #{perms/Path}
   "Given a sequence of `tables-or-ids` referenced by a query, return a set of required permissions. A truthy value for
   `segmented-perms?` will return segmented permissions for the table rather that full table permissions."
   [database-or-id             :- (s/cond-pre su/IntGreaterThanZero su/Map)
@@ -90,7 +90,7 @@
                              (table-or-id->schema table-or-id)
                              (u/the-id table-or-id)))))))
 
-(s/defn ^:private source-card-read-perms :- #{perms/ObjectPath}
+(s/defn ^:private source-card-read-perms :- #{perms/Path}
   "Calculate the permissions needed to run an ad-hoc query that uses a Card with `source-card-id` as its source
   query."
   [source-card-id :- su/IntGreaterThanZero]
@@ -105,7 +105,7 @@
   (binding [api/*current-user-id* nil]
     ((resolve 'metabase.query-processor/query->preprocessed) query)))
 
-(s/defn ^:private mbql-permissions-path-set :- #{perms/ObjectPath}
+(s/defn ^:private mbql-permissions-path-set :- #{perms/Path}
   "Return the set of required permissions needed to run an adhoc `query`.
 
   Also optionally specify `throw-exceptions?` -- normally this function avoids throwing Exceptions to avoid breaking
@@ -135,7 +135,7 @@
         (log/error e))
       #{"/db/0/"})))                    ; DB 0 will never exist
 
-(s/defn ^:private perms-set* :- #{perms/ObjectPath}
+(s/defn ^:private perms-set* :- #{perms/Path}
   "Does the heavy lifting of creating the perms set. `opts` will indicate whether exceptions should be thrown and
   whether full or segmented table permissions should be returned."
   [{query-type :type, database :database, :as query} perms-opts :- PermsOptions]

--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -42,14 +42,14 @@
     (merge defaults table)))
 
 (defn- pre-delete [{:keys [db_id schema id]}]
-  (db/delete! Permissions :object [:like (str (perms/object-path db_id schema id) "%")]))
+  (db/delete! Permissions :object [:like (str (perms/data-perms-path db_id schema id) "%")]))
 
 (defn- perms-objects-set [table read-or-write]
   ;; To read (e.g., fetch metadata) a Table you (predictably) have read permissions; to write a Table (e.g. update its
   ;; metadata) you must have *full* permissions.
   #{(case read-or-write
       :read  (perms/table-read-path table)
-      :write (perms/object-path (:db_id table) (:schema table) (:id table)))})
+      :write (perms/data-perms-path (:db_id table) (:schema table) (:id table)))})
 
 (u/strict-extend (class Table)
   models/IModel

--- a/test/metabase/api/automagic_dashboards_test.clj
+++ b/test/metabase/api/automagic_dashboards_test.clj
@@ -32,13 +32,13 @@
          (when (and result
                     (try
                       (testing "Endpoint should return 403 if user does not have permissions"
-                        (perms/revoke-permissions! (perms-group/all-users) (mt/id))
+                        (perms/revoke-data-perms! (perms-group/all-users) (mt/id))
                         (revoke-fn)
                         (let [result (mt/user-http-request :rasta :get 403 api-endpoint)]
                           (is (= "You don't have permissions to do that."
                                  result))))
                       (finally
-                        (perms/grant-permissions! (perms-group/all-users) (perms/object-path (mt/id))))))
+                        (perms/grant-permissions! (perms-group/all-users) (perms/data-perms-path (mt/id))))))
            result))))))
 
 

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -527,7 +527,7 @@
     ;; create a copy of the test data warehouse DB, then revoke permissions to it for All Users. Only admins should be
     ;; able to ad-hoc query it now.
     (mt/with-temp-copy-of-db
-      (perms/revoke-permissions! (perms-group/all-users) (mt/db))
+      (perms/revoke-data-perms! (perms-group/all-users) (mt/db))
       (let [query        (mt/mbql-query :venues)
             create-card! (fn [test-user expected-status-code]
                            (mt/with-model-cleanup [Card]
@@ -539,8 +539,8 @@
           (testing "Permissions errors should be meaningful and include info for debugging (#14931)"
             (is (schema= {:message        (s/eq "You cannot save this Question because you do not have permissions to run its query.")
                           :query          (s/eq (mt/obj->json->obj query))
-                          :required-perms [perms/ObjectPath]
-                          :actual-perms   [perms/UserPath]
+                          :required-perms [perms/Path]
+                          :actual-perms   [perms/Path]
                           :trace          [s/Any]
                           s/Keyword       s/Any}
                          (create-card! :rasta 403)))))))))
@@ -998,7 +998,7 @@
     ;; create a copy of the test data warehouse DB, then revoke permissions to it for All Users. Only admins should be
     ;; able to ad-hoc query it now.
     (mt/with-temp-copy-of-db
-      (perms/revoke-permissions! (perms-group/all-users) (mt/db))
+      (perms/revoke-data-perms! (perms-group/all-users) (mt/db))
       (mt/with-temp Card [{card-id :id} {:dataset_query (mt/mbql-query :venues)}]
         (let [update-card! (fn [test-user expected-status-code request-body]
                              (mt/user-http-request test-user :put expected-status-code (format "card/%d" card-id)
@@ -1021,8 +1021,8 @@
               (testing "Permissions errors should be meaningful and include info for debugging (#14931)"
                 (is (schema= {:message        (s/eq "You cannot save this Question because you do not have permissions to run its query.")
                               :query          (s/eq (mt/obj->json->obj (mt/mbql-query :users)))
-                              :required-perms [perms/ObjectPath]
-                              :actual-perms   [perms/UserPath]
+                              :required-perms [perms/Path]
+                              :actual-perms   [perms/Path]
                               :trace          [s/Any]
                               s/Keyword       s/Any}
                              (update-card! :rasta 403 {:dataset_query (mt/mbql-query :users)}))))
@@ -1479,7 +1479,7 @@
                     Table      [table      {:db_id (u/the-id database)}]
                     Card       [card-1     {:dataset_query (mbql-count-query (u/the-id database) (u/the-id table))}]
                     Card       [card-2     {:dataset_query (mbql-count-query (u/the-id database) (u/the-id table))}]]
-      (perms/revoke-permissions! (perms-group/all-users) (u/the-id database))
+      (perms/revoke-data-perms! (perms-group/all-users) (u/the-id database))
       (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection)
       (is (= {:response    "You don't have permissions to do that."
               :collections [nil nil]}

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -316,7 +316,7 @@
 (deftest param-values-test
   (testing "Don't return `param_values` for Fields for which the current User has no data perms."
     (mt/with-temp-copy-of-db
-      (perms/revoke-permissions! (group/all-users) (mt/id))
+      (perms/revoke-data-perms! (group/all-users) (mt/id))
       (perms/grant-permissions! (group/all-users) (perms/table-read-path (Table (mt/id :venues))))
       (mt/with-temp* [Dashboard     [{dashboard-id :id} {:name "Test Dashboard"}]
                       Card          [{card-id :id}      {:name "Dashboard Test Card"}]
@@ -1315,7 +1315,7 @@
     (testing "should check perms for the Fields in question"
       (mt/with-temp-copy-of-db
         (with-chain-filter-fixtures [{:keys [dashboard param-keys]}]
-          (perms/revoke-permissions! (group/all-users) (mt/id))
+          (perms/revoke-data-perms! (group/all-users) (mt/id))
           (is (= "You don't have permissions to do that."
                  (mt/user-http-request :rasta :get 403 (chain-filter-values-url (:id dashboard) (:category-name param-keys))))))))))
 
@@ -1470,6 +1470,6 @@
       (testing "should check perms for the Fields in question"
         (with-chain-filter-fixtures [{{dashboard-id :id} :dashboard}]
           (mt/with-temp-copy-of-db
-            (perms/revoke-permissions! (group/all-users) (mt/id))
+            (perms/revoke-data-perms! (group/all-users) (mt/id))
             (is (= "You don't have permissions to do that."
                    (mt/user-http-request :rasta :get 403 (mt/$ids (url [%venues.price] [%categories.name])))))))))))

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -780,14 +780,14 @@
                  ((mt/user->client :rasta) :get 200 (format "database/%d/schemas" db-id)))))
 
         (testing "...or full schema perms..."
-          (perms/revoke-permissions! (perms-group/all-users) db-id)
+          (perms/revoke-data-perms! (perms-group/all-users) db-id)
           (perms/grant-permissions!  (perms-group/all-users) db-id "schema1")
           (is (= ["schema1"]
                  ((mt/user->client :rasta) :get 200 (format "database/%d/schemas" db-id)))))
 
         (testing "...or just table read perms..."
-          (perms/revoke-permissions! (perms-group/all-users) db-id)
-          (perms/revoke-permissions! (perms-group/all-users) db-id "schema1")
+          (perms/revoke-data-perms! (perms-group/all-users) db-id)
+          (perms/revoke-data-perms! (perms-group/all-users) db-id "schema1")
           (perms/grant-permissions!  (perms-group/all-users) db-id "schema1" t1)
           (perms/grant-permissions!  (perms-group/all-users) db-id "schema1" t2)
           (is (= ["schema1"]
@@ -836,14 +836,14 @@
                  (map :name ((mt/user->client :rasta) :get 200 (format "database/%d/schema/%s" db-id "schema1"))))))
 
         (testing "if we have full schema perms"
-          (perms/revoke-permissions! (perms-group/all-users) db-id)
+          (perms/revoke-data-perms! (perms-group/all-users) db-id)
           (perms/grant-permissions!  (perms-group/all-users) db-id "schema1")
           (is (= ["t1" "t3"]
                  (map :name ((mt/user->client :rasta) :get 200 (format "database/%d/schema/%s" db-id "schema1"))))))
 
         (testing "if we have full Table perms"
-          (perms/revoke-permissions! (perms-group/all-users) db-id)
-          (perms/revoke-permissions! (perms-group/all-users) db-id "schema1")
+          (perms/revoke-data-perms! (perms-group/all-users) db-id)
+          (perms/revoke-data-perms! (perms-group/all-users) db-id "schema1")
           (perms/grant-permissions!  (perms-group/all-users) db-id "schema1" t1)
           (perms/grant-permissions!  (perms-group/all-users) db-id "schema1" t3)
           (is (= ["t1" "t3"]
@@ -852,7 +852,7 @@
     (testing "should return a 403 for a user that doesn't have read permissions"
       (mt/with-temp* [Database [{database-id :id}]
                       Table    [_ {:db_id database-id, :schema "test"}]]
-        (perms/revoke-permissions! (perms-group/all-users) database-id)
+        (perms/revoke-data-perms! (perms-group/all-users) database-id)
         (is (= "You don't have permissions to do that."
                ((mt/user->client :rasta) :get 403 (format "database/%s/schemas" database-id))))))
 
@@ -860,7 +860,7 @@
       (mt/with-temp* [Database [{database-id :id}]
                       Table    [_ {:db_id database-id, :schema "schema-with-perms"}]
                       Table    [_ {:db_id database-id, :schema "schema-without-perms"}]]
-        (perms/revoke-permissions! (perms-group/all-users) database-id)
+        (perms/revoke-data-perms! (perms-group/all-users) database-id)
         (perms/grant-permissions!  (perms-group/all-users) database-id "schema-with-perms")
         (is (= ["schema-with-perms"]
                ((mt/user->client :rasta) :get 200 (format "database/%s/schemas" database-id))))))
@@ -869,7 +869,7 @@
       (testing "for the DB"
         (mt/with-temp* [Database [{database-id :id}]
                         Table    [{table-id :id} {:db_id database-id, :schema "test"}]]
-          (perms/revoke-permissions! (perms-group/all-users) database-id)
+          (perms/revoke-data-perms! (perms-group/all-users) database-id)
           (is (= "You don't have permissions to do that."
                  ((mt/user->client :rasta) :get 403 (format "database/%s/schema/%s" database-id "test"))))))
 
@@ -877,7 +877,7 @@
         (mt/with-temp* [Database [{database-id :id}]
                         Table    [_ {:db_id database-id, :schema "schema-with-perms"}]
                         Table    [_ {:db_id database-id, :schema "schema-without-perms"}]]
-          (perms/revoke-permissions! (perms-group/all-users) database-id)
+          (perms/revoke-data-perms! (perms-group/all-users) database-id)
           (perms/grant-permissions!  (perms-group/all-users) database-id "schema-with-perms")
           (is (= "You don't have permissions to do that."
                  ((mt/user->client :rasta) :get 403 (format "database/%s/schema/%s" database-id "schema-without-perms")))))))
@@ -892,7 +892,7 @@
       (mt/with-temp* [Database [{database-id :id}]
                       Table    [table-with-perms {:db_id database-id, :schema "public", :name "table-with-perms"}]
                       Table    [_                {:db_id database-id, :schema "public", :name "table-without-perms"}]]
-        (perms/revoke-permissions! (perms-group/all-users) database-id)
+        (perms/revoke-data-perms! (perms-group/all-users) database-id)
         (perms/grant-permissions!  (perms-group/all-users) database-id "public" table-with-perms)
         (is (= ["table-with-perms"]
                (map :name ((mt/user->client :rasta) :get 200 (format "database/%s/schema/%s" database-id "public")))))))

--- a/test/metabase/api/dataset_test.clj
+++ b/test/metabase/api/dataset_test.clj
@@ -206,7 +206,7 @@
         (testing "with data perms"
           (do-test))
         (testing "with collection perms only"
-          (perms/revoke-permissions! (group/all-users) (mt/db))
+          (perms/revoke-data-perms! (group/all-users) (mt/db))
           (do-test))))))
 
 (deftest formatted-results-ignore-query-constraints
@@ -245,7 +245,7 @@
     (mt/with-temp-copy-of-db
       ;; give all-users *partial* permissions for the DB, so we know we're checking more than just read permissions for
       ;; the Database
-      (perms/revoke-permissions! (group/all-users) (mt/id))
+      (perms/revoke-data-perms! (group/all-users) (mt/id))
       (perms/grant-permissions! (group/all-users) (mt/id) "schema_that_does_not_exist")
       (is (schema= {:status   (s/eq "failed")
                     :error    (s/eq "You do not have permissions to run this query.")
@@ -280,7 +280,7 @@
         (mt/suppress-output
           (mt/with-temp-copy-of-db
             ;; Give All Users permissions to see the `venues` Table, but not ad-hoc native perms
-            (perms/revoke-permissions! (group/all-users) (mt/id))
+            (perms/revoke-data-perms! (group/all-users) (mt/id))
             (perms/grant-permissions! (group/all-users) (mt/id) "PUBLIC" (mt/id :venues))
             (is (schema= {:permissions-error? (s/eq true)
                           :message            (s/eq "You do not have permissions to run this query.")

--- a/test/metabase/api/embed_test.clj
+++ b/test/metabase/api/embed_test.clj
@@ -803,7 +803,7 @@
 (deftest chain-filter-ignore-current-user-permissions-test
   (testing "Should not fail if request is authenticated but current user does not have data permissions"
     (mt/with-temp-copy-of-db
-      (perms/revoke-permissions! (group/all-users) (mt/db))
+      (perms/revoke-data-perms! (group/all-users) (mt/db))
       (with-chain-filter-fixtures [{:keys [dashboard param-keys values-url search-url]}]
         (db/update! Dashboard (:id dashboard)
           :embedding_params {"category_id" "enabled", "category_name" "enabled", "price" "enabled"})

--- a/test/metabase/api/metric_test.clj
+++ b/test/metabase/api/metric_test.clj
@@ -219,7 +219,7 @@
       (mt/with-temp* [Database [db]
                       Table    [table  {:db_id (u/the-id db)}]
                       Metric   [metric {:table_id (u/the-id table)}]]
-        (perms/revoke-permissions! (group/all-users) db)
+        (perms/revoke-data-perms! (group/all-users) db)
         (is (= "You don't have permissions to do that."
                (mt/user-http-request :rasta :get 403 (str "metric/" (u/the-id metric)))))))
 
@@ -242,7 +242,7 @@
       (mt/with-temp* [Database [db]
                       Table    [table  {:db_id (u/the-id db)}]
                       Metric   [metric {:table_id (u/the-id table)}]]
-        (perms/revoke-permissions! (group/all-users) db)
+        (perms/revoke-data-perms! (group/all-users) db)
         (is (= "You don't have permissions to do that."
                (mt/user-http-request :rasta :get 403 (format "metric/%d/revisions" (u/the-id metric)))))))
 

--- a/test/metabase/api/public_test.clj
+++ b/test/metabase/api/public_test.clj
@@ -1016,7 +1016,7 @@
 (deftest chain-filter-ignore-current-user-permissions-test
   (testing "Should not fail if request is authenticated but current user does not have data permissions"
     (mt/with-temp-copy-of-db
-      (perms/revoke-permissions! (group/all-users) (mt/db))
+      (perms/revoke-data-perms! (group/all-users) (mt/db))
       (mt/with-temporary-setting-values [enable-public-sharing true]
         (dashboard-api-test/with-chain-filter-fixtures [{:keys [dashboard param-keys]}]
           (let [uuid (str (UUID/randomUUID))]

--- a/test/metabase/api/pulse_test.clj
+++ b/test/metabase/api/pulse_test.clj
@@ -744,7 +744,7 @@
                         PulseCard [_     {:pulse_id (u/the-id pulse), :card_id (u/the-id card)}]]
           (with-pulses-in-readable-collection [pulse]
             ;; revoke permissions for default group to this database
-            (perms/revoke-permissions! (perms-group/all-users) (mt/id))
+            (perms/revoke-data-perms! (perms-group/all-users) (mt/id))
             ;; now a user without permissions to the Card in question should *not* be allowed to delete the pulse
             (is (= "You don't have permissions to do that."
                    (mt/user-http-request :rasta :delete 403 (format "pulse/%d" (u/the-id pulse)))))))))))

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -360,7 +360,7 @@
                                               :schema nil}]
                     Metric   [_ {:table_id table-id
                                  :name     "test metric"}]]
-      (perms/revoke-permissions! (group/all-users) db-id)
+      (perms/revoke-data-perms! (group/all-users) db-id)
       (is (= []
              (search-request-data :rasta :q "test")))))
 
@@ -370,7 +370,7 @@
                                               :schema nil}]
                     Segment  [_ {:table_id table-id
                                  :name     "test segment"}]]
-      (perms/revoke-permissions! (group/all-users) db-id)
+      (perms/revoke-data-perms! (group/all-users) db-id)
       (is (= []
              (search-request-data :rasta :q "test"))))))
 
@@ -502,7 +502,7 @@
   (testing "you should not be able to see a Table if the current user doesn't have permissions for that Table"
     (mt/with-temp* [Database [{db-id :id}]
                     Table    [table {:db_id db-id}]]
-      (perms/revoke-permissions! (group/all-users) db-id)
+      (perms/revoke-data-perms! (group/all-users) db-id)
       (is (= []
              (binding [*search-request-results-database-id* db-id]
                (search-request-data :rasta :q (:name table))))))))
@@ -514,7 +514,7 @@
                     Table                      [table {:name "Round Table", :db_id db-id}]
                     PermissionsGroup           [{group-id :id}]
                     PermissionsGroupMembership [_ {:group_id group-id, :user_id (mt/user->id :rasta)}]]
-      (perms/revoke-permissions! (group/all-users) db-id (:schema table) (:id table))
+      (perms/revoke-data-perms! (group/all-users) db-id (:schema table) (:id table))
       (perms/grant-permissions! group-id (perms/table-read-path table))
       (do-test-users [user [:crowberto :rasta]]
         (is (= [(default-table-search-row "Round Table")]
@@ -525,7 +525,7 @@
   (testing "If the All Users group doesn't have perms to view a Table they sholdn't see it (#16855)"
     (mt/with-temp* [Database                   [{db-id :id}]
                     Table                      [table {:name "Round Table", :db_id db-id}]]
-      (perms/revoke-permissions! (group/all-users) db-id (:schema table) (:id table))
+      (perms/revoke-data-perms! (group/all-users) db-id (:schema table) (:id table))
       (is (= []
              (filter #(= (:name %) "Round Table")
                      (binding [*search-request-results-database-id* db-id]

--- a/test/metabase/api/segment_test.clj
+++ b/test/metabase/api/segment_test.clj
@@ -231,7 +231,7 @@
       (mt/with-temp* [Database [db]
                       Table    [table   {:db_id (u/the-id db)}]
                       Segment  [segment {:table_id (u/the-id table)}]]
-        (perms/revoke-permissions! (group/all-users) db)
+        (perms/revoke-data-perms! (group/all-users) db)
         (is (= "You don't have permissions to do that."
                (mt/user-http-request :rasta :get 403 (str "segment/" (u/the-id segment)))))))))
 
@@ -266,7 +266,7 @@
       (mt/with-temp* [Database [db]
                       Table    [table   {:db_id (u/the-id db)}]
                       Segment  [segment {:table_id (u/the-id table)}]]
-        (perms/revoke-permissions! (group/all-users) db)
+        (perms/revoke-data-perms! (group/all-users) db)
         (is (= "You don't have permissions to do that."
                (mt/user-http-request :rasta :get 403 (format "segment/%d/revisions" (u/the-id segment)))))))))
 

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -119,7 +119,7 @@
     (testing " should return a 403 for a user that doesn't have read permissions for the table"
       (mt/with-temp* [Database [{database-id :id}]
                       Table    [{table-id :id}    {:db_id database-id}]]
-        (perms/revoke-permissions! (perms-group/all-users) database-id)
+        (perms/revoke-data-perms! (perms-group/all-users) database-id)
         (is (= "You don't have permissions to do that."
                (mt/user-http-request :rasta :get 403 (str "table/" table-id))))))))
 
@@ -255,7 +255,7 @@
                       Field    [table-2-id {:table_id (u/the-id table-2), :name "id", :base_type :type/Integer, :semantic_type :type/PK}]
                       Field    [table-2-fk {:table_id (u/the-id table-2), :name "fk", :base_type :type/Integer, :semantic_type :type/FK, :fk_target_field_id (u/the-id table-1-id)}]]
         ;; grant permissions only to table-2
-        (perms/revoke-permissions! (perms-group/all-users) (u/the-id db))
+        (perms/revoke-data-perms! (perms-group/all-users) (u/the-id db))
         (perms/grant-permissions! (perms-group/all-users) (u/the-id db) (:schema table-2) (u/the-id table-2))
         ;; metadata for table-2 should show all fields for table-2, but the FK target info shouldn't be hydrated
         (is (= #{{:name "id", :target false}

--- a/test/metabase/api/transform_test.clj
+++ b/test/metabase/api/transform_test.clj
@@ -35,8 +35,8 @@
   (testing "GET /api/transform/:db-id/:schema/:transform-name"
     (testing "Do we correctly check for permissions?"
       (try
-        (perms/revoke-permissions! (perms-group/all-users) (mt/id))
+        (perms/revoke-data-perms! (perms-group/all-users) (mt/id))
         (is (= "You don't have permissions to do that."
                (mt/user-http-request :rasta :get 403 (test-endpoint))))
         (finally
-          (perms/grant-permissions! (perms-group/all-users) (perms/object-path (mt/id))))))))
+          (perms/grant-permissions! (perms-group/all-users) (perms/data-perms-path (mt/id))))))))

--- a/test/metabase/driver/common/parameters/values_test.clj
+++ b/test/metabase/driver/common/parameters/values_test.clj
@@ -292,7 +292,7 @@
   (testing "We should be able to run a query referenced via a template tag if we have perms for the Card in question (#12354)"
     (mt/with-non-admin-groups-no-root-collection-perms
       (mt/with-temp-copy-of-db
-        (perms/revoke-permissions! (group/all-users) (mt/id))
+        (perms/revoke-data-perms! (group/all-users) (mt/id))
         (mt/with-temp* [Collection [collection]
                         Card       [{card-1-id :id, :as card-1} {:collection_id (u/the-id collection)
                                                                  :dataset_query (mt/mbql-query venues

--- a/test/metabase/models/dashboard_test.clj
+++ b/test/metabase/models/dashboard_test.clj
@@ -228,7 +228,7 @@
     (testing (str "Check that if a Dashboard is in a Collection, someone who would otherwise be able to see it under "
                   "the old artifact-permissions regime will *NOT* be able to see it if they don't have permissions for "
                   "that Collection"))
-    (binding [api/*current-user-permissions-set* (atom #{(perms/object-path (u/the-id db))})]
+    (binding [api/*current-user-permissions-set* (atom #{(perms/data-perms-path (u/the-id db))})]
       (is (= false
              (mi/can-read? dash))))
 

--- a/test/metabase/models/database_test.clj
+++ b/test/metabase/models/database_test.clj
@@ -26,7 +26,7 @@
     (mt/with-temp Database [db]
       (is (= true
              (perms/set-has-full-permissions? (user/permissions-set (mt/user->id :rasta))
-                                              (perms/object-path db)))))))
+                                              (perms/data-perms-path db)))))))
 
 (deftest tasks-test
   (testing "Sync tasks should get scheduled for a newly created Database"

--- a/test/metabase/models/permissions_test.clj
+++ b/test/metabase/models/permissions_test.clj
@@ -12,9 +12,9 @@
 
 (use-fixtures :once (fixtures/initialize :test-users-personal-collections))
 
-;;; ----------------------------------------------- valid-object-path? -----------------------------------------------
+;;; ----------------------------------------------- valid-path? -----------------------------------------------
 
-(deftest valid-object-path-test
+(deftest valid-path-test
   (testing "valid paths"
     (doseq [path
             ["/db/1/"
@@ -32,10 +32,15 @@
              "/db/1/schema//table/1/"
              "/db/1/schema/1234/table/1/"
              "/db/1/schema/PUBLIC/table/1/query/"
-             "/db/1/schema/PUBLIC/table/1/query/segmented/"]]
+             "/db/1/schema/PUBLIC/table/1/query/segmented/"
+             ;; block permissions
+             "/block/db/1/"
+             "/block/db/1000/"
+             ;; full admin (everything) root permissions
+             "/"]]
       (testing (pr-str path)
         (is (= true
-               (perms/valid-object-path? path)))))
+               (perms/valid-path? path)))))
 
     (testing "\nWe should allow slashes in permissions paths? (#8693, #13263)\n"
       (doseq [path [ ;; COMPANY-NET\ should get escaped to COMPANY-NET\\
@@ -50,7 +55,7 @@
                     "/db/1/schema/my\\/schema/table/1/"]]
         (testing (pr-str path)
           (is (= true
-                 (perms/valid-object-path? path)))))))
+                 (perms/valid-path? path)))))))
 
   (testing "invalid paths"
     (doseq [[reason paths]
@@ -85,8 +90,7 @@
               "/db/1/schema//db/1/table/2//"]
 
              "not referencing a specific object. These might be valid permissions paths but not valid paths to objects"
-             ["/"
-              "/db/"
+             ["/db/"
               "/db/1/schema/public/db/"
               "/db/1/schema/public/db/1/table/"]
 
@@ -144,14 +148,22 @@
               "/db/1/schema/my\\\\\\schema/table/1/"]
 
              "forward slash must be escaped by a backslash" ; e.g. / -> \/
-             ["/db/1/schema/my/schema/table/1/"]}]
+             ["/db/1/schema/my/schema/table/1/"]
+
+             "block permissions are currently allowed for Databases only."
+             ["/block/"
+              "/block/db/1/schema/"
+              "/block/db/1/schema/PUBLIC/"
+              "/block/db/1/schema/PUBLIC/table/"
+              "/block/db/1/schema/PUBLIC/table/2/"
+              "/block/collection/1/"]}]
       (testing reason
         (doseq [path paths]
           (testing (str "\n" (pr-str path))
             (is (= false
-                   (perms/valid-object-path? path)))))))))
+                   (perms/valid-path? path)))))))))
 
-(deftest valid-object-path-backslashes-test
+(deftest valid-path-backslashes-test
   (testing "Only even numbers of backslashes should be valid (backslash must be escaped by another backslash)"
     (doseq [[num-backslashes expected schema-name] [[0 true "PUBLIC"]
                                                     [0 true  "my_schema"]
@@ -163,19 +175,19 @@
                     (format "/db/1/schema/%s/table/2/query/" schema-name)]]
         (testing (str "\n" (pr-str path))
           (is (= expected
-                 (perms/valid-object-path? path))))))))
+                 (perms/valid-path? path))))))))
 
 
-;;; -------------------------------------------------- object-path ---------------------------------------------------
+;;; -------------------------------------------------- data-perms-path ---------------------------------------------------
 
-(deftest object-path-test
+(deftest data-perms-path-test
   (testing "valid paths"
     (doseq [[expected args] {"/db/1/"                       [1]
                              "/db/1/schema/public/"         [1 "public"]
                              "/db/1/schema/public/table/2/" [1 "public" 2]}]
-      (testing (pr-str (cons 'perms/object-path args))
+      (testing (pr-str (cons 'perms/data-perms-path args))
         (is (= expected
-               (apply perms/object-path args))))))
+               (apply perms/data-perms-path args))))))
 
   (testing "invalid paths"
     (testing "invalid input should throw an exception"
@@ -201,12 +213,12 @@
                     [1 "public" false]
                     [1 "public" {}]
                     [1 "public" []]]]
-        (testing (pr-str (cons 'perms/object-path args))
+        (testing (pr-str (cons 'perms/data-perms-path args))
           (is (thrown?
                Exception
-               (apply perms/object-path args))))))))
+               (apply perms/data-perms-path args))))))))
 
-(deftest object-path-escape-slashes-test
+(deftest data-perms-path-escape-slashes-test
   (doseq [{:keys [slash-direction schema-name expected-escaped]} [{:slash-direction  "back (#8693)"
                                                                    :schema-name      "my\\schema"
                                                                    :expected-escaped "my\\\\schema"}
@@ -224,15 +236,15 @@
                                                                    :expected-escaped "my\\\\\\\\\\/schema"}]]
     (testing (format "We should handle slashes in permissions paths\nDirection = %s\nSchema = %s\n"
                      slash-direction (pr-str schema-name))
-      (testing (pr-str (list 'object-path {:id 1}))
+      (testing (pr-str (list 'data-perms-path {:id 1}))
         (is (= "/db/1/"
-               (perms/object-path {:id 1}))))
-      (testing (pr-str (list 'object-path {:id 1} schema-name))
+               (perms/data-perms-path {:id 1}))))
+      (testing (pr-str (list 'data-perms-path {:id 1} schema-name))
         (is (= (format "/db/1/schema/%s/" expected-escaped)
-               (perms/object-path {:id 1} schema-name))))
-      (testing (pr-str (list 'object-path {:id 1} schema-name {:id 2}))
+               (perms/data-perms-path {:id 1} schema-name))))
+      (testing (pr-str (list 'data-perms-path {:id 1} schema-name {:id 2}))
         (is (= (format "/db/1/schema/%s/table/2/" expected-escaped)
-               (perms/object-path {:id 1} schema-name {:id 2})))))))
+               (perms/data-perms-path {:id 1} schema-name {:id 2})))))))
 
 
 ;;; ---------------------------------- Generating permissions paths for Collections ----------------------------------
@@ -534,20 +546,20 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 (defn- test-data-graph [group]
-  (get-in (perms/graph) [:groups (u/the-id group) (mt/id) :schemas "PUBLIC"]))
+  (get-in (perms/data-perms-graph) [:groups (u/the-id group) (mt/id) :schemas "PUBLIC"]))
 
 (deftest graph-set-partial-permissions-for-table-test
   (testing "Test that setting partial permissions for a table retains permissions for other tables -- #3888"
     (mt/with-temp PermissionsGroup [group]
       (testing "before"
         ;; first, graph permissions only for VENUES
-        (perms/grant-permissions! group (perms/object-path (mt/id) "PUBLIC" (mt/id :venues)))
+        (perms/grant-permissions! group (perms/data-perms-path (mt/id) "PUBLIC" (mt/id :venues)))
         (is (= {(mt/id :venues) :all}
                (test-data-graph group))))
       (testing "after"
         ;; next, grant permissions via `update-graph!` for CATEGORIES as well. Make sure permissions for VENUES are
         ;; retained (#3888)
-        (perms/update-graph! [(u/the-id group) (mt/id) :schemas "PUBLIC" (mt/id :categories)] :all)
+        (perms/update-data-perms-graph! [(u/the-id group) (mt/id) :schemas "PUBLIC" (mt/id :categories)] :all)
         (is (= {(mt/id :categories) :all, (mt/id :venues) :all}
                (test-data-graph group)))))))
 
@@ -557,11 +569,11 @@
                     Database         [database]
                     Table            [table    {:db_id (u/the-id database)}]]
       ;; try to grant idential permissions to the table twice
-      (perms/update-graph! [(u/the-id group) (u/the-id database) :schemas] {"" {(u/the-id table) :all}})
-      (perms/update-graph! [(u/the-id group) (u/the-id database) :schemas] {"" {(u/the-id table) :all}})
+      (perms/update-data-perms-graph! [(u/the-id group) (u/the-id database) :schemas] {"" {(u/the-id table) :all}})
+      (perms/update-data-perms-graph! [(u/the-id group) (u/the-id database) :schemas] {"" {(u/the-id table) :all}})
       ;; now fetch the perms that have been granted
       (is (= {"" {(u/the-id table) :all}}
-             (get-in (perms/graph) [:groups (u/the-id group) (u/the-id database) :schemas]))))))
+             (get-in (perms/data-perms-graph) [:groups (u/the-id group) (u/the-id database) :schemas]))))))
 
 (deftest metabot-graph-test
   (testing (str "The data permissions graph should never return permissions for the MetaBot, because the MetaBot can "
@@ -569,9 +581,9 @@
     ;; need to swap out the perms check function because otherwise we couldn't even insert the object we want to insert
     (with-redefs [perms/assert-valid-metabot-permissions (constantly nil)]
       (mt/with-temp* [Database    [db]
-                      Permissions [perms {:group_id (u/the-id (group/metabot)), :object (perms/object-path db)}]]
+                      Permissions [perms {:group_id (u/the-id (group/metabot)), :object (perms/data-perms-path db)}]]
         (is (= false
-               (contains? (:groups (perms/graph)) (u/the-id (group/metabot)))))))))
+               (contains? (:groups (perms/data-perms-graph)) (u/the-id (group/metabot)))))))))
 
 (deftest broken-out-read-query-perms-in-graph-test
   (testing "Make sure we can set the new broken-out read/query perms for a Table and the graph works as we'd expect"
@@ -586,12 +598,12 @@
              (test-data-graph group))))
 
     (mt/with-temp PermissionsGroup [group]
-      (perms/update-graph! [(u/the-id group) (mt/id) :schemas]
-                           {"PUBLIC"
-                            {(mt/id :venues)
-                             {:read :all, :query :segmented}}})
+      (perms/update-data-perms-graph! [(u/the-id group) (mt/id) :schemas]
+                                      {"PUBLIC"
+                                       {(mt/id :venues)
+                                        {:read :all, :query :segmented}}})
       (is (= {(mt/id :venues) {:read  :all
-                                 :query :segmented}}
+                               :query :segmented}}
              (test-data-graph group))))))
 
 (deftest root-permissions-graph-test
@@ -600,7 +612,7 @@
       (let [{:keys [group_id]} (db/select-one 'Permissions {:object "/"})]
         (is (= {db_id {:native  :write
                        :schemas :all}}
-               (-> (perms/graph)
+               (-> (perms/data-perms-graph)
                    (get-in [:groups group_id])
                    (select-keys [db_id]))))))))
 

--- a/test/metabase/models/pulse_test.clj
+++ b/test/metabase/models/pulse_test.clj
@@ -310,7 +310,7 @@
 (deftest no-permissions-test
   (is (= false
          (with-pulse-in-collection [db _ pulse]
-           (binding [api/*current-user-permissions-set* (atom #{(perms/object-path (u/the-id db))})]
+           (binding [api/*current-user-permissions-set* (atom #{(perms/data-perms-path (u/the-id db))})]
              (mi/can-read? pulse))))))
 
 (deftest validate-collection-namespace-test

--- a/test/metabase/models/query/permissions_test.clj
+++ b/test/metabase/models/query/permissions_test.clj
@@ -124,7 +124,7 @@
     (mt/with-temp* [Database [db]
                     Table    [table {:db_id (u/the-id db), :schema nil}]
                     Field    [_     {:table_id (u/the-id table)}]]
-      (perms/revoke-permissions! (perms-group/all-users) db)
+      (perms/revoke-data-perms! (perms-group/all-users) db)
       (binding [*current-user-permissions-set* (atom nil)
                 *current-user-id*              (mt/user->id :rasta)]
         (is (= #{(perms/table-query-path db nil table)}

--- a/test/metabase/models/user_test.clj
+++ b/test/metabase/models/user_test.clj
@@ -68,7 +68,7 @@
                     Table                      [table {:name "Round Table", :db_id db-id}]
                     PermissionsGroup           [{group-id :id}]
                     PermissionsGroupMembership [_ {:group_id group-id, :user_id (mt/user->id :rasta)}]]
-      (perms/revoke-permissions! (group/all-users) db-id (:schema table) (:id table))
+      (perms/revoke-data-perms! (group/all-users) db-id (:schema table) (:id table))
       (perms/grant-permissions! group-id (perms/table-read-path table))
       (is (set/subset?
            #{(perms/table-read-path table)}

--- a/test/metabase/query_processor/middleware/cache_test.clj
+++ b/test/metabase/query_processor/middleware/cache_test.clj
@@ -440,7 +440,7 @@
 (deftest perms-checks-should-still-apply-test
   (testing "Double-check that perms checks still happen even for cached results"
     (mt/with-temp-copy-of-db
-      (perms/revoke-permissions! (group/all-users) (mt/db))
+      (perms/revoke-data-perms! (group/all-users) (mt/db))
       (mt/with-test-user :rasta
         (with-mock-cache [save-chan]
           (letfn [(run-forbidden-query []

--- a/test/metabase/query_processor/middleware/catch_exceptions_test.clj
+++ b/test/metabase/query_processor/middleware/catch_exceptions_test.clj
@@ -126,7 +126,7 @@
 
 (deftest permissions-test
   (data/with-temp-copy-of-db
-    (perms/revoke-permissions! (group/all-users) (data/id))
+    (perms/revoke-data-perms! (group/all-users) (data/id))
     (perms/grant-permissions! (group/all-users) (data/id) "PUBLIC" (data/id :venues))
     (testing (str "If someone doesn't have native query execution permissions, they shouldn't see the native version of "
                   "the query in the error response")

--- a/test/metabase/query_processor/middleware/permissions_test.clj
+++ b/test/metabase/query_processor/middleware/permissions_test.clj
@@ -55,7 +55,7 @@
           (mt/with-temp* [Database [db]
                           Table    [table {:db_id (u/the-id db)}]]
             ;; All users get perms for all new DBs by default
-            (perms/revoke-permissions! (perms-group/all-users) (u/the-id db))
+            (perms/revoke-data-perms! (perms-group/all-users) (u/the-id db))
             (check-perms-for-rasta
              {:database (u/the-id db)
               :type     :query
@@ -98,7 +98,7 @@
           (mt/with-temp* [Database [db]
                           Table    [table {:db_id (u/the-id db)}]]
             ;; All users get perms for all new DBs by default
-            (perms/revoke-permissions! (perms-group/all-users) (u/the-id db))
+            (perms/revoke-data-perms! (perms-group/all-users) (u/the-id db))
             (check-perms-for-rasta
              {:database (u/the-id db)
               :type     :query
@@ -124,7 +124,7 @@
                           Card     [card    {:dataset_query {:database (u/the-id db), :type :query,
                                                              :query {:source-table (u/the-id table-2)}}}]]
             ;; All users get perms for all new DBs by default
-            (perms/revoke-permissions! (perms-group/all-users) (u/the-id db) nil (u/the-id table-2))
+            (perms/revoke-data-perms! (perms-group/all-users) (u/the-id db) nil (u/the-id table-2))
             (let [card-id  (:id card)
                   tag-name (str "#" card-id)]
               (check-perms-for-rasta
@@ -165,7 +165,7 @@
                                           {:database (u/the-id db), :type :native,
                                            :native {:query "SELECT 1 AS \"foo\", 2 AS \"bar\", 3 AS \"baz\""}}}]]
             ;; All users get perms for all new DBs by default
-            (perms/revoke-permissions! (perms-group/all-users) (u/the-id db))
+            (perms/revoke-data-perms! (perms-group/all-users) (u/the-id db))
             (let [card-id  (:id card)
                   tag-name (str "#" card-id)]
               (check-perms-for-rasta
@@ -223,7 +223,7 @@
   (testing "Make sure permissions are calculated for Card -> Card -> Source Query (#12354)"
     (mt/with-non-admin-groups-no-root-collection-perms
       (mt/with-temp-copy-of-db
-        (perms/revoke-permissions! (perms-group/all-users) (mt/id))
+        (perms/revoke-data-perms! (perms-group/all-users) (mt/id))
         (mt/with-temp Collection [collection]
           (perms/grant-collection-read-permissions! (perms-group/all-users) collection)
           (doseq [[card-1-query-type card-1-query] {"MBQL"   (mt/mbql-query venues
@@ -278,7 +278,7 @@
 (deftest e2e-ignore-user-supplied-card-ids-test
   (testing "You shouldn't be able to bypass security restrictions by passing `[:info :card-id]` in the query."
     (mt/with-temp-copy-of-db
-      (perms/revoke-permissions! (perms-group/all-users) (mt/id))
+      (perms/revoke-data-perms! (perms-group/all-users) (mt/id))
       (mt/with-temp* [Collection [collection]
                       Card       [card {:collection_id (u/the-id collection)
                                         :dataset_query (mt/mbql-query venues {:fields [$id], :order-by [[:asc $id]], :limit 2})}]]

--- a/test/metabase/query_processor/pivot_test.clj
+++ b/test/metabase/query_processor/pivot_test.clj
@@ -278,7 +278,7 @@
         (let [query (mt/mbql-query orders
                       {:aggregation [[:count]]
                        :breakout    [$product_id->products.category $user_id->people.source]})]
-          (perms/revoke-permissions! (group/all-users) (mt/db))
+          (perms/revoke-data-perms! (group/all-users) (mt/db))
           (testing "User without perms shouldn't be able to run the query normally"
             (is (thrown-with-msg?
                  clojure.lang.ExceptionInfo

--- a/test/metabase/query_processor_test/nested_queries_test.clj
+++ b/test/metabase/query_processor_test/nested_queries_test.clj
@@ -508,7 +508,7 @@
     (testing "You should be able to read a Card with a source Card if you can read that Card and their Collections (#12354)\n"
       (mt/with-non-admin-groups-no-root-collection-perms
         (mt/with-temp-copy-of-db
-          (perms/revoke-permissions! (group/all-users) (mt/id))
+          (perms/revoke-data-perms! (group/all-users) (mt/id))
           (mt/with-temp* [Collection [collection]
                           Card       [card-1 {:collection_id (u/the-id collection)
                                               :dataset_query (mt/mbql-query venues {:order-by [[:asc $id]], :limit 2})}]

--- a/test/metabase/query_processor_test/query_to_native_test.clj
+++ b/test/metabase/query_processor_test/query_to_native_test.clj
@@ -39,7 +39,7 @@
   (try
     (binding [api/*current-user-id*              Integer/MAX_VALUE
               api/*current-user-permissions-set* (delay (cond-> #{}
-                                                          object-perms? (conj (perms/object-path database-id "PUBLIC" source-table-id))
+                                                          object-perms? (conj (perms/data-perms-path database-id "PUBLIC" source-table-id))
                                                           native-perms? (conj (perms/adhoc-native-query-path database-id))))]
       (qp/query->native query))
     (catch clojure.lang.ExceptionInfo e


### PR DESCRIPTION
Adds the new `:block` "anti-permissions" option. Normally you are allowed to run a Saved Question (aka Card) query if you have data permissions for the Database/Tables it accesses, *or* if you have Collection permissions for the Collection in which a Card belongs. `:block` permissions act like a special flag you can set for a group that disable the Collection option, i.e. it will require any members of that group to have appropriate ad-hoc data permissions to run a question. 

This was the request of one of our customers. 

Permissions graph functions updated to handle it. Since this is an EE-only feature, all block permissions tests are in `metabase-enterprise.enhancements.models.permissions.block-permissions-test`... block permissions checking code is in `metabase-enterprise.enhancements.models.permissions.block-permissions`. There is some block perms parsing/CRUD code in `metabase.models.permissions` but I think moving it into the EE namespace would make things too fragile (FWIW there is some segmented perms parsing code in the OSS namespace as well, because it would be too brittle and break things if you downgraded from EE -> OSS otherwise)

This PR also does a little bit of refactoring in `metabase.models.permissions`... the main changes are renaming things like `object-path` and `graph` to `data-perms-path` and `data-perms-graph` respectively. A lot of functions there were named before Collection permissions even existed, and now that they do the names deserve to be updated to clarify that these things are for data permissions and not for Collection permissions. After a bit of reflection I also consolidated the concept of perms "object paths" and "user paths" into just "paths" since the distinction wasn't really important and made things more complicated than they needed to be.

See the mega-writeup in the `metabase.models.permissions` namespace docstring for more info 