### PR TITLE
Add visual smoke test for notebook editor

### DIFF
--- a/frontend/test/metabase-visual/notebook/notebook.cy.spec.js
+++ b/frontend/test/metabase-visual/notebook/notebook.cy.spec.js
@@ -1,0 +1,92 @@
+import { restore, popover } from "__support__/e2e/cypress";
+
+describe("visual tests > dashboard > filter sidebar", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+    cy.viewport(2200, 1200);
+  });
+
+  it("renders correctly", () => {
+    cy.visit("/question/new");
+    cy.findByText("Custom question").click();
+    cy.findByText("Sample Dataset").click();
+    cy.findByText("Orders").click();
+
+    addJoin({
+      rightTable: "Products",
+    });
+
+    addCustomColumn({
+      name: "Total square root (no reason)",
+      formula: "sqrt([Total])",
+    });
+
+    addSingleValueFilter({
+      field: "Total",
+      filterType: "Greater than",
+      filterValue: "10",
+    });
+
+    summarize({ metric: "Average of ...", field: "Quantity" });
+    groupBy({ field: "User ID" });
+
+    addSorting({ field: "Average of Quantity" });
+    setRowLimit(500);
+
+    cy.percySnapshot();
+  });
+});
+
+function selectFromDropdown(itemName) {
+  return popover().findByText(itemName);
+}
+
+function addJoin({ rightTable }) {
+  cy.icon("join_left_outer")
+    .last()
+    .click();
+
+  selectFromDropdown(rightTable).click();
+}
+
+function addCustomColumn({ name, formula }) {
+  cy.icon("add_data").click();
+  cy.focused().type(formula);
+  cy.findAllByPlaceholderText("Something nice and descriptive").type(name);
+  cy.button("Done").click();
+}
+
+function addSingleValueFilter({ field, filterType, filterValue }) {
+  cy.findByText("Add filters to narrow your answer").click();
+  selectFromDropdown(field).click();
+  popover()
+    .get(".AdminSelect")
+    .click();
+  selectFromDropdown(filterType).click();
+  popover().within(() => {
+    cy.get("input").type(filterValue);
+    cy.button("Add filter").click();
+  });
+}
+
+function summarize({ metric, field }) {
+  cy.findByText("Pick the metric you want to see").click();
+  selectFromDropdown(metric).click();
+  selectFromDropdown(field).click();
+}
+
+function groupBy({ field }) {
+  cy.findByText("Pick a column to group by").click();
+  selectFromDropdown(field).click();
+}
+
+function addSorting({ field }) {
+  cy.findByText("Sort").click();
+  selectFromDropdown(field).click();
+}
+
+function setRowLimit(rowLimit) {
+  cy.findByText("Row limit").click();
+  cy.findByPlaceholderText("Enter a limit").type(String(rowLimit));
+}

--- a/frontend/test/metabase-visual/notebook/notebook.cy.spec.js
+++ b/frontend/test/metabase-visual/notebook/notebook.cy.spec.js
@@ -1,10 +1,13 @@
 import { restore, popover } from "__support__/e2e/cypress";
 
 describe("visual tests > notebook > major UI elements", () => {
+  const VIEWPORT_WIDTH = 2200;
+  const VIEWPORT_HEIGHT = 1200;
+
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
-    cy.viewport(2200, 1200);
+    cy.viewport(VIEWPORT_WIDTH, VIEWPORT_HEIGHT);
   });
 
   it("renders correctly", () => {
@@ -34,7 +37,12 @@ describe("visual tests > notebook > major UI elements", () => {
     addSorting({ field: "Average of Quantity" });
     setRowLimit(500);
 
-    cy.percySnapshot();
+    cy.percySnapshot(
+      "visual tests > notebook > major UI elements renders correctly",
+      {
+        minHeight: VIEWPORT_HEIGHT,
+      },
+    );
   });
 });
 

--- a/frontend/test/metabase-visual/notebook/notebook.cy.spec.js
+++ b/frontend/test/metabase-visual/notebook/notebook.cy.spec.js
@@ -1,6 +1,6 @@
 import { restore, popover } from "__support__/e2e/cypress";
 
-describe("visual tests > dashboard > filter sidebar", () => {
+describe("visual tests > notebook > major UI elements", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();


### PR DESCRIPTION
This PR adds a visual smoke test for the notebook editor. The test constructs a question using different notebook features, so we can test the overall look of the page

### Demo

<img width="1988" alt="Screenshot 2021-08-12 at 15 58 43" src="https://user-images.githubusercontent.com/17258145/129201418-37eff616-4c4c-4b58-9675-06576f8b4122.png">
