### PR TITLE
Add `right` prop to NotebookCellItem

### DIFF
--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -1009,7 +1009,10 @@ const TablePicker = ({
       },
     ];
     return (
-      <div style={{ width: 300, overflowY: "auto" }}>
+      <div
+        style={{ width: 300, overflowY: "auto" }}
+        data-testid="data-selector"
+      >
         <AccordionList
           id="TablePicker"
           key="tablePicker"

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookCell.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookCell.jsx
@@ -2,7 +2,7 @@
 import React from "react";
 
 import { Flex } from "grid-styled";
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 
 import Icon from "metabase/components/Icon";
 
@@ -24,31 +24,100 @@ NotebookCell.defaultProps = {
 
 NotebookCell.displayName = "NotebookCell";
 
-export const NotebookCellItem = styled(Flex).attrs({
-  align: "center",
-})`
+const NotebookCellItemContainer = styled(Flex).attrs({ align: "center" })`
   font-weight: bold;
-  border: 2px solid transparent;
-  border-radius: 6px;
   color: ${props => (props.inactive ? props.color : "white")};
-  background-color: ${props => (props.inactive ? "transparent" : props.color)};
+  border-radius: 6px;
+
+  border: 2px solid transparent;
   border-color: ${props =>
     props.inactive ? alpha(props.color, 0.25) : "transparent"};
+
   &:hover {
-    background-color: ${props => !props.inactive && alpha(props.color, 0.8)};
     border-color: ${props => props.inactive && alpha(props.color, 0.8)};
   }
-  transition: background 300ms linear, border 300ms linear;
+
+  transition: border 300ms linear;
+
   > .Icon {
     opacity: 0.6;
   }
 `;
 
-NotebookCellItem.defaultProps = {
-  p: 1,
+NotebookCellItemContainer.defaultProps = {
   mr: 1,
   mb: 1,
 };
+
+const NotebookCellItemContentContainer = styled.div`
+  display: flex;
+  align-items: center;
+  padding: 8px;
+  background-color: ${props => (props.inactive ? "transparent" : props.color)};
+
+  &:hover {
+    background-color: ${props => !props.inactive && alpha(props.color, 0.8)};
+  }
+
+  ${props =>
+    !!props.border &&
+    css`
+    border-${props.border}: 1px solid ${alpha("white", 0.25)};
+  `}
+
+  ${props =>
+    props.roundedCorners.includes("left") &&
+    css`
+      border-top-left-radius: 6px;
+      border-bottom-left-radius: 6px;
+    `}
+
+  ${props =>
+    props.roundedCorners.includes("right") &&
+    css`
+      border-top-right-radius: 6px;
+      border-bottom-right-radius: 6px;
+    `}
+
+  transition: background 300ms linear;
+`;
+
+export function NotebookCellItem({
+  inactive,
+  color,
+  right,
+  rightContainerStyle,
+  children,
+  ...props
+}) {
+  const hasRightSide = React.isValidElement(right);
+  const mainContentRoundedCorners = ["left"];
+  if (!hasRightSide) {
+    mainContentRoundedCorners.push("right");
+  }
+  return (
+    <NotebookCellItemContainer inactive={inactive} color={color} {...props}>
+      <NotebookCellItemContentContainer
+        inactive={inactive}
+        color={color}
+        roundedCorners={mainContentRoundedCorners}
+      >
+        {children}
+      </NotebookCellItemContentContainer>
+      {hasRightSide && (
+        <NotebookCellItemContentContainer
+          inactive={inactive}
+          color={color}
+          border="left"
+          roundedCorners={["right"]}
+          style={rightContainerStyle}
+        >
+          {right}
+        </NotebookCellItemContentContainer>
+      )}
+    </NotebookCellItemContainer>
+  );
+}
 
 NotebookCellItem.displayName = "NotebookCellItem";
 

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookCell.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookCell.jsx
@@ -26,10 +26,6 @@ NotebookCell.displayName = "NotebookCell";
 
 export const NotebookCellItem = styled(Flex).attrs({
   align: "center",
-  children: ({ icon, children }) => [
-    icon && <Icon className="mr1" name={icon} size={10} />,
-    children,
-  ],
 })`
   font-weight: bold;
   border: 2px solid transparent;

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookCell.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookCell.jsx
@@ -39,7 +39,7 @@ const NotebookCellItemContainer = styled(Flex).attrs({ align: "center" })`
 
   transition: border 300ms linear;
 
-  > .Icon {
+  .Icon-close {
     opacity: 0.6;
   }
 `;
@@ -126,11 +126,7 @@ export const NotebookCellAdd = styled(NotebookCellItem).attrs({
   // eslint-disable-next-line react/display-name
   children: ({ initialAddText }) =>
     initialAddText || <Icon name="add" className="text-white" />,
-})`
-  > .Icon {
-    opacity: 1;
-  }
-`;
+})``;
 
 NotebookCellAdd.defaultProps = {
   mb: 1,

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookCell.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookCell.jsx
@@ -14,13 +14,8 @@ export const NotebookCell = styled(Flex).attrs({
 })`
   border-radius: 8px;
   background-color: ${props => alpha(props.color, 0.1)};
+  padding: 14px;
 `;
-
-NotebookCell.defaultProps = {
-  px: 2,
-  pt: 2,
-  pb: 1,
-};
 
 NotebookCell.displayName = "NotebookCell";
 
@@ -28,6 +23,7 @@ const NotebookCellItemContainer = styled(Flex).attrs({ align: "center" })`
   font-weight: bold;
   color: ${props => (props.inactive ? props.color : "white")};
   border-radius: 6px;
+  margin-right: 4px;
 
   border: 2px solid transparent;
   border-color: ${props =>
@@ -44,15 +40,10 @@ const NotebookCellItemContainer = styled(Flex).attrs({ align: "center" })`
   }
 `;
 
-NotebookCellItemContainer.defaultProps = {
-  mr: 1,
-  mb: 1,
-};
-
 const NotebookCellItemContentContainer = styled.div`
   display: flex;
   align-items: center;
-  padding: 8px;
+  padding: 10px;
   background-color: ${props => (props.inactive ? "transparent" : props.color)};
 
   &:hover {
@@ -127,9 +118,5 @@ export const NotebookCellAdd = styled(NotebookCellItem).attrs({
   children: ({ initialAddText }) =>
     initialAddText || <Icon name="add" className="text-white" />,
 })``;
-
-NotebookCellAdd.defaultProps = {
-  mb: 1,
-};
 
 NotebookCellAdd.displayName = "NotebookCellAdd";

--- a/frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx
@@ -30,11 +30,7 @@ function DataStep({ color, query, databases, updateQuery }) {
               {t`Pick your starting data`}
             </NotebookCellItem>
           ) : (
-            <NotebookCellItem
-              color={color}
-              icon="table2"
-              data-testid="data-step-cell"
-            >
+            <NotebookCellItem color={color} data-testid="data-step-cell">
               {table && table.displayName()}
             </NotebookCellItem>
           )

--- a/frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx
@@ -38,7 +38,7 @@ function DataStep({ color, query, databases, updateQuery }) {
       />
       {table && query.isRaw() && (
         <DataFieldsPicker
-          className="ml-auto mb1 text-bold"
+          className="ml-auto text-bold"
           query={query}
           updateQuery={updateQuery}
         />

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -211,7 +211,7 @@ function JoinClause({ color, join, updateQuery, showRemove }) {
 
       {join.isValid() && (
         <JoinFieldsPicker
-          className="mb1 ml-auto text-bold"
+          className="ml-auto text-bold"
           join={join}
           updateQuery={updateQuery}
         />

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -168,7 +168,7 @@ function JoinClause({ color, join, updateQuery, showRemove }) {
 
   return (
     <JoinClauseRoot>
-      <NotebookCellItem color={color} icon="table2">
+      <NotebookCellItem color={color}>
         {(lhsTable && lhsTable.displayName()) || `Previous results`}
       </NotebookCellItem>
 
@@ -256,7 +256,7 @@ function JoinTablePicker({
   }
 
   return (
-    <NotebookCellItem color={color} icon="table2" inactive={!joinedTable}>
+    <NotebookCellItem color={color} inactive={!joinedTable}>
       <DatabaseSchemaAndTableDataSelector
         hasTableSearch
         canChangeDatabase={false}
@@ -392,11 +392,7 @@ class JoinDimensionPicker extends React.Component {
       <PopoverWithTrigger
         ref={ref => (this._popover = ref)}
         triggerElement={
-          <NotebookCellItem
-            color={color}
-            icon={dimension && dimension.icon()}
-            inactive={!dimension}
-          >
+          <NotebookCellItem color={color} inactive={!dimension}>
             {dimension ? dimension.displayName() : `Pick a column...`}
           </NotebookCellItem>
         }

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -194,6 +194,7 @@ function JoinClause({ color, join, updateQuery, showRemove }) {
             options={join.parentDimensionOptions()}
             onChange={onParentDimensionChange}
             ref={parentDimensionPickerRef}
+            data-testid="parent-dimension"
           />
 
           <JoinOnConditionLabel />
@@ -205,6 +206,7 @@ function JoinClause({ color, join, updateQuery, showRemove }) {
             options={join.joinDimensionOptions()}
             onChange={onJoinDimensionChange}
             ref={joinDimensionPickerRef}
+            data-testid="join-dimension"
           />
         </JoinedTableControlRoot>
       )}
@@ -380,6 +382,7 @@ const joinDimensionPickerPropTypes = {
   }).isRequired,
   query: PropTypes.object.isRequired,
   color: PropTypes.string,
+  "data-testid": PropTypes.string,
 };
 
 class JoinDimensionPicker extends React.Component {
@@ -388,11 +391,16 @@ class JoinDimensionPicker extends React.Component {
   }
   render() {
     const { dimension, onChange, options, query, color } = this.props;
+    const testID = this.props["data-testid"] || "join-dimension";
     return (
       <PopoverWithTrigger
         ref={ref => (this._popover = ref)}
         triggerElement={
-          <NotebookCellItem color={color} inactive={!dimension}>
+          <NotebookCellItem
+            color={color}
+            inactive={!dimension}
+            data-testid={testID}
+          >
             {dimension ? dimension.displayName() : `Pick a column...`}
           </NotebookCellItem>
         }
@@ -408,6 +416,7 @@ class JoinDimensionPicker extends React.Component {
               onChange(field);
               onClose();
             }}
+            data-testid={`${testID}-picker`}
           />
         )}
       </PopoverWithTrigger>

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.styled.js
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.styled.js
@@ -21,7 +21,9 @@ export const JoinClauseRoot = styled.div`
 
 export const JoinStrategyIcon = styled(Icon).attrs({ size: 32 })`
   color: ${color("brand")};
-  margin-right: ${space(1)};
+  margin-right: 6px;
+  margin-left: 2px;
+  margin-top: 6px;
 `;
 
 export const JoinTypeSelectRoot = styled.div`
@@ -62,14 +64,17 @@ export const JoinedTableControlRoot = styled.div`
 export const JoinWhereConditionLabel = styled.span.attrs({ children: "where" })`
   color: ${color("text-medium")};
   font-weight: bold;
-  margin-left: ${space(1)};
-  margin-right: ${space(2)};
+  margin-top: 6px;
+  margin-left: 10px;
+  margin-right: 14px;
 `;
 
 export const JoinOnConditionLabel = styled.span.attrs({ children: "=" })`
   font-weight: bold;
   color: ${color("text-medium")};
-  margin-right: 8px;
+  margin-left: 2px;
+  margin-right: 6px;
+  margin-top: 6px;
 `;
 
 export const RemoveJoinIcon = styled(Icon).attrs({ name: "close", size: 18 })`

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.unit.spec.js
@@ -79,7 +79,7 @@ describe("Notebook Editor > Join Step", () => {
     xhrMock.get("/api/database", {
       body: JSON.stringify({
         total: 1,
-        data: [SAMPLE_DATASET._plainObject],
+        data: [SAMPLE_DATASET.getPlainObject()],
       }),
     });
     xhrMock.get("/api/database/1/schemas", {

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.unit.spec.js
@@ -64,6 +64,16 @@ describe("Notebook Editor > Join Step", () => {
     );
   }
 
+  async function selectTable(tableName) {
+    fireEvent.click(screen.queryByText(/Sample Dataset/i));
+    const dataSelector = await screen.findByTestId("data-selector");
+    fireEvent.click(within(dataSelector).queryByText(tableName));
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTestId("data-selector"),
+    );
+  }
+
   beforeEach(() => {
     xhrMock.setup();
     xhrMock.get("/api/database", {
@@ -107,13 +117,7 @@ describe("Notebook Editor > Join Step", () => {
   it("automatically sets join fields if possible", async () => {
     setup();
 
-    fireEvent.click(screen.queryByText(/Sample Dataset/i));
-    const dataSelector = await screen.findByTestId("data-selector");
-    fireEvent.click(within(dataSelector).queryByText(/Products/i));
-
-    await waitForElementToBeRemoved(() =>
-      screen.queryByTestId("data-selector"),
-    );
+    await selectTable(/Products/i);
 
     expect(screen.getByTestId("parent-dimension")).toHaveTextContent(
       /Product ID/i,

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.unit.spec.js
@@ -114,6 +114,12 @@ describe("Notebook Editor > Join Step", () => {
     );
   }
 
+  function openDimensionPicker(type) {
+    const openPickerButton = screen.getByTestId(`${type}-dimension`);
+    fireEvent.click(openPickerButton);
+    return screen.findByRole("rowgroup");
+  }
+
   beforeEach(() => {
     xhrMock.setup();
     xhrMock.get("/api/database", {
@@ -172,7 +178,7 @@ describe("Notebook Editor > Join Step", () => {
     );
   });
 
-  it("can change parent dimension's join field", async () => {
+  it("shows a parent dimension's join field picker", async () => {
     const ordersFields = Object.values(ORDERS.fieldsLookup());
     setup();
     await selectTable(/Products/i);
@@ -190,7 +196,23 @@ describe("Notebook Editor > Join Step", () => {
     });
   });
 
-  it("can change join dimension's field", async () => {
+  it("can change parent dimension's join field", async () => {
+    const { onQueryChange } = setup();
+    await selectTable(/Products/i);
+    const picker = await openDimensionPicker("parent");
+
+    fireEvent.click(within(picker).getByText("Tax"));
+
+    expect(onQueryChange).toHaveBeenLastCalledWith(
+      expectedJoin({
+        joinedTable: PRODUCTS,
+        leftField: ORDERS.TAX,
+        rightField: PRODUCTS.ID,
+      }),
+    );
+  });
+
+  it("shows a join dimension's field picker", async () => {
     const productsFields = Object.values(PRODUCTS.fieldsLookup());
     setup();
     await selectTable(/Products/i);
@@ -206,6 +228,22 @@ describe("Notebook Editor > Join Step", () => {
         within(picker).queryByText(field.display_name),
       ).toBeInTheDocument();
     });
+  });
+
+  it("can change join dimension's field", async () => {
+    const { onQueryChange } = setup();
+    await selectTable(/Products/i);
+    const picker = await openDimensionPicker("join");
+
+    fireEvent.click(within(picker).getByText("Category"));
+
+    expect(onQueryChange).toHaveBeenLastCalledWith(
+      expectedJoin({
+        joinedTable: PRODUCTS,
+        leftField: ORDERS.PRODUCT_ID,
+        rightField: PRODUCTS.CATEGORY,
+      }),
+    );
   });
 
   it("automatically opens dimensions picker if can't automatically set join fields", async () => {

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.unit.spec.js
@@ -14,6 +14,7 @@ import { getStore } from "__support__/entities-store";
 import {
   state,
   ORDERS,
+  PRODUCTS,
   SAMPLE_DATASET,
 } from "__support__/sample_dataset_fixture";
 import JoinStep from "./JoinStep";
@@ -123,5 +124,52 @@ describe("Notebook Editor > Join Step", () => {
       /Product ID/i,
     );
     expect(screen.getByTestId("join-dimension")).toHaveTextContent(/ID/i);
+  });
+
+  it("can change parent dimension's join field", async () => {
+    const ordersFields = Object.values(ORDERS.fieldsLookup());
+    setup();
+    await selectTable(/Products/i);
+
+    fireEvent.click(screen.getByTestId("parent-dimension"));
+
+    const picker = await screen.findByRole("rowgroup");
+    expect(picker).toBeInTheDocument();
+    expect(picker).toBeVisible();
+    expect(within(picker).queryByText("Order")).toBeInTheDocument();
+    ordersFields.forEach(field => {
+      expect(
+        within(picker).queryByText(field.display_name),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("can change join dimension's field", async () => {
+    const productsFields = Object.values(PRODUCTS.fieldsLookup());
+    setup();
+    await selectTable(/Products/i);
+
+    fireEvent.click(screen.getByTestId("join-dimension"));
+
+    const picker = await screen.findByRole("rowgroup");
+    expect(picker).toBeInTheDocument();
+    expect(picker).toBeVisible();
+    expect(within(picker).queryByText("Product")).toBeInTheDocument();
+    productsFields.forEach(field => {
+      expect(
+        within(picker).queryByText(field.display_name),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("automatically opens dimensions picker if can't automatically set join fields", async () => {
+    setup();
+
+    await selectTable(/Reviews/i);
+
+    const picker = await screen.findByRole("rowgroup");
+    expect(picker).toBeInTheDocument();
+    expect(picker).toBeVisible();
+    expect(within(picker).queryByText("Order")).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.unit.spec.js
@@ -168,7 +168,8 @@ describe("Notebook Editor > Join Step", () => {
     });
   });
 
-  it("automatically sets join fields if possible", async () => {
+  // Fails on CI because of waitFor / findBy query
+  it.skip("automatically sets join fields if possible", async () => {
     const { onQueryChange } = setup();
 
     await selectTable(/Products/i);

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.unit.spec.js
@@ -19,6 +19,8 @@ import {
 } from "__support__/sample_dataset_fixture";
 import JoinStep from "./JoinStep";
 
+jest.setTimeout(10000);
+
 describe("Notebook Editor > Join Step", () => {
   const TEST_QUERY = {
     type: "query",
@@ -168,8 +170,7 @@ describe("Notebook Editor > Join Step", () => {
     });
   });
 
-  // Fails on CI because of waitFor / findBy query
-  it.skip("automatically sets join fields if possible", async () => {
+  it("automatically sets join fields if possible", async () => {
     const { onQueryChange } = setup();
 
     await selectTable(/Products/i);

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.unit.spec.js
@@ -1,0 +1,98 @@
+import React from "react";
+import { Provider } from "react-redux";
+import {
+  render,
+  screen,
+  fireEvent,
+  within,
+  waitForElementToBeRemoved,
+} from "@testing-library/react";
+import xhrMock from "xhr-mock";
+import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
+import { getStore } from "__support__/entities-store";
+import {
+  state,
+  ORDERS,
+  SAMPLE_DATASET,
+} from "__support__/sample_dataset_fixture";
+import JoinStep from "./JoinStep";
+import { jest } from "@jest/globals";
+
+describe("Notebook Editor > Join Step", () => {
+  const TEST_QUERY = new StructuredQuery(ORDERS.question(), {
+    type: "query",
+    database: SAMPLE_DATASET.id,
+    query: {
+      "source-table": ORDERS.id,
+    },
+  });
+
+  const TEST_STEP = {
+    id: "0:join",
+    type: "join",
+    itemIndex: 0,
+    stageIndex: 0,
+    query: TEST_QUERY,
+    valid: true,
+    visible: true,
+    active: true,
+    actions: [],
+    update: jest.fn(),
+    clean: jest.fn(),
+    revert: jest.fn(),
+  };
+
+  function setup() {
+    const updateQuery = jest.fn();
+    render(
+      <Provider store={getStore({}, state)}>
+        <JoinStep
+          query={TEST_QUERY}
+          step={TEST_STEP}
+          updateQuery={updateQuery}
+        />
+      </Provider>,
+    );
+    return { updateQuery };
+  }
+
+  beforeEach(() => {
+    xhrMock.setup();
+    xhrMock.get("/api/database", {
+      body: JSON.stringify({
+        total: 1,
+        data: [SAMPLE_DATASET._plainObject],
+      }),
+    });
+    xhrMock.get("/api/database/1/schemas", {
+      body: JSON.stringify(["PUBLIC"]),
+    });
+    xhrMock.get("/api/database/1/schema/PUBLIC", {
+      body: JSON.stringify(
+        SAMPLE_DATASET.tables.filter(table => table.schema === "PUBLIC"),
+      ),
+    });
+  });
+
+  afterEach(() => {
+    xhrMock.teardown();
+  });
+
+  it("displays a source table and suggests to pick a join table", () => {
+    setup();
+    expect(screen.queryByText("Orders")).toBeInTheDocument();
+    expect(screen.queryByText("Pick a table...")).toBeInTheDocument();
+  });
+
+  it("opens a schema browser by default", async () => {
+    setup();
+
+    fireEvent.click(screen.queryByText(/Sample Dataset/i));
+    const dataSelector = await screen.findByTestId("data-selector");
+
+    SAMPLE_DATASET.tables.forEach(table => {
+      const tableName = new RegExp(table.display_name, "i");
+      expect(within(dataSelector).queryByText(tableName)).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/metabase/reference/databases/FieldList.jsx
+++ b/frontend/src/metabase/reference/databases/FieldList.jsx
@@ -91,6 +91,7 @@ export default class FieldList extends Component {
     loadingError: PropTypes.object,
     submitting: PropTypes.bool,
     resetForm: PropTypes.func,
+    "data-testid": PropTypes.string,
   };
 
   render() {
@@ -123,6 +124,7 @@ export default class FieldList extends Component {
               this.props,
             ),
         )}
+        testID={this.props["data-testid"]}
       >
         {isEditing && (
           <EditHeader

--- a/frontend/test/__support__/entities-store.js
+++ b/frontend/test/__support__/entities-store.js
@@ -5,15 +5,13 @@ import promise from "redux-promise";
 import { thunkWithDispatchAction } from "metabase/store";
 import * as entities from "metabase/redux/entities";
 
-export function getStore(reducers = {}) {
+export function getStore(reducers = {}, initialState = {}) {
   const reducer = combineReducers({
     entities: entities.reducer,
     requests: (state, action) =>
       requestsReducer(entities.requestsReducer(state, action), action),
     ...reducers,
   });
-
-  const initialState = {};
 
   return createStore(
     reducer,

--- a/frontend/test/metabase/scenarios/question/new.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/new.cy.spec.js
@@ -208,7 +208,7 @@ describe("scenarios > question > new", () => {
         cy.findByText("Orders, Count").click();
 
         // Try to choose a different saved question
-        cy.get("[icon=table2]").click();
+        cy.findByTestId("data-step-cell").click();
 
         cy.findByText("Our analytics");
         cy.findByText("Orders");


### PR DESCRIPTION
This PR refactors `NotebookCellItem` component and adds a new `right` prop (`PropTypes.node`) to it.
No visual changes are expected, #17432 should catch visual regressions

### Motivation

This change is required for a new column picker UI for the notebook editor. At the moment, the "Data" and "Join" steps have a "Columns" button on the left side. When you click it, a popover with a list of table columns appears. Screenshot:

![CleanShot 2021-08-12 at 18 40 40@2x](https://user-images.githubusercontent.com/17258145/129226342-d8223098-b865-489e-93ee-68555417850b.png)

To free up some space for a new join step UI, we want "attach" the columns picker to table's notebook cell, like that:

<img width="715" alt="CleanShot 2021-08-12 at 18 47 08@2x" src="https://user-images.githubusercontent.com/17258145/129227367-4065e805-3d52-4bc4-b2c9-d2d11ab35ca7.png">

The columns picker would appear after clicking the table icon in the right part of the notebook cell. Clicking the table name would still open the database-table browser.

### Implementation

This PR refactors the styled `NotebookCellItem` component, so it now accepts a `right` prop. Also, `NotebookCellItem` will add a semi-transparent vertical line between the "main" part and the right side. Example:

```jsx
<NotebookCell right={<Icon name="table" />}>
   {table.name}
</NotebookCell>
```

### To Verify

1. Ask a question > Custom Question
2. Create a question using the notebook editor
3. Everything should work & look as on `master`