### PR TITLE
Add "Send to Slack now" button

### DIFF
--- a/frontend/src/metabase/components/SendTestPulse.jsx
+++ b/frontend/src/metabase/components/SendTestPulse.jsx
@@ -32,7 +32,7 @@ export default class SendTestPulse extends Component {
     return (
       <ActionButton
         actionFn={this.onTestPulseChannel}
-        disabled={ disabled }
+        disabled={disabled}
         normalText={normalText}
         activeText={t`Sending…`}
         failedText={t`Sending failed`}

--- a/frontend/src/metabase/components/SendTestPulse.jsx
+++ b/frontend/src/metabase/components/SendTestPulse.jsx
@@ -9,6 +9,7 @@ export default class SendTestPulse extends Component {
     channel: PropTypes.object.isRequired,
     pulse: PropTypes.object.isRequired,
     testPulse: PropTypes.func.isRequired,
+    disabled: PropTypes.bool.isRequired,
     normalText: PropTypes.string.isRequired,
     successText: PropTypes.string.isRequired,
   };
@@ -20,14 +21,7 @@ export default class SendTestPulse extends Component {
   };
 
   render() {
-    const { channel, normalText, successText } = this.props;
-
-    let disabled;
-    if (channel.channel_type === "email") {
-      disabled = channel.recipients.length === 0;
-    } else if (channel.channel_type === "slack") {
-      disabled = channel.details.channel === undefined;
-    }
+    const { disabled, normalText, successText } = this.props;
 
     return (
       <ActionButton

--- a/frontend/src/metabase/components/SendTestPulse.jsx
+++ b/frontend/src/metabase/components/SendTestPulse.jsx
@@ -4,11 +4,13 @@ import { t } from "ttag";
 
 import ActionButton from "metabase/components/ActionButton";
 
-export default class SendTestEmail extends Component {
+export default class SendTestPulse extends Component {
   static propTypes = {
     channel: PropTypes.object.isRequired,
     pulse: PropTypes.object.isRequired,
     testPulse: PropTypes.func.isRequired,
+    normalText: PropTypes.string.isRequired,
+    successText: PropTypes.string.isRequired,
   };
   static defaultProps = {};
 
@@ -18,17 +20,23 @@ export default class SendTestEmail extends Component {
   };
 
   render() {
-    const { channel } = this.props;
+    const { channel, normalText, successText } = this.props;
+
+    let disabled;
+    if (channel.channel_type === "email") {
+      disabled = channel.recipients.length === 0;
+    } else if (channel.channel_type === "slack") {
+      disabled = channel.details.channel === undefined;
+    }
+
     return (
       <ActionButton
         actionFn={this.onTestPulseChannel}
-        disabled={
-          channel.channel_type === "email" && channel.recipients.length === 0
-        }
-        normalText={t`Send email now`}
+        disabled={ disabled }
+        normalText={normalText}
         activeText={t`Sending…`}
         failedText={t`Sending failed`}
-        successText={t`Email sent`}
+        successText={successText}
         forceActiveStyle={true}
       />
     );

--- a/frontend/src/metabase/sharing/components/AddEditSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/AddEditSidebar.jsx
@@ -15,7 +15,7 @@ import Text from "metabase/components/type/Text";
 import ModalWithTrigger from "metabase/components/ModalWithTrigger";
 import RecipientPicker from "metabase/pulse/components/RecipientPicker";
 import SchedulePicker from "metabase/components/SchedulePicker";
-import SendTestEmail from "metabase/components/SendTestEmail";
+import SendTestPulse from "metabase/components/SendTestPulse";
 import Sidebar from "metabase/dashboard/components/Sidebar";
 import Toggle from "metabase/components/Toggle";
 import Select, { Option } from "metabase/components/Select";
@@ -125,10 +125,12 @@ function _AddEditEmailSidebar({
           }
         />
         <div className="pt2 pb1">
-          <SendTestEmail
+          <SendTestPulse
             channel={channel}
             pulse={pulse}
             testPulse={testPulse}
+            normalText={t`Send email now`}
+            successText={t`Email sent`}
           />
         </div>
         {PLUGIN_DASHBOARD_SUBSCRIPTION_PARAMETERS_SECTION_OVERRIDE.Component ? (
@@ -276,6 +278,7 @@ function _AddEditSlackSidebar({
   onCancel,
   onChannelPropertyChange,
   onChannelScheduleChange,
+  testPulse,
   toggleSkipIfEmpty,
   handleArchive,
   setPulseParameters,
@@ -317,6 +320,15 @@ function _AddEditSlackSidebar({
             onChannelScheduleChange(newSchedule, changedProp)
           }
         />
+        <div className="pt2 pb1">
+          <SendTestPulse
+            channel={channel}
+            pulse={pulse}
+            testPulse={testPulse}
+            normalText={t`Send Slack now`}
+            successText={t`Slack sent`}
+          />
+        </div>
         {PLUGIN_DASHBOARD_SUBSCRIPTION_PARAMETERS_SECTION_OVERRIDE.Component ? (
           <PLUGIN_DASHBOARD_SUBSCRIPTION_PARAMETERS_SECTION_OVERRIDE.Component
             className="py3 mt2 border-top"
@@ -364,6 +376,7 @@ _AddEditSlackSidebar.propTypes = {
   onCancel: PropTypes.func.isRequired,
   onChannelPropertyChange: PropTypes.func.isRequired,
   onChannelScheduleChange: PropTypes.func.isRequired,
+  testPulse: PropTypes.func.isRequired,
   toggleSkipIfEmpty: PropTypes.func.isRequired,
   handleArchive: PropTypes.func.isRequired,
   setPulseParameters: PropTypes.func.isRequired,

--- a/frontend/src/metabase/sharing/components/AddEditSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/AddEditSidebar.jsx
@@ -325,7 +325,7 @@ function _AddEditSlackSidebar({
             channel={channel}
             pulse={pulse}
             testPulse={testPulse}
-            normalText={t`Send Slack now`}
+            normalText={t`Send to Slack now`}
             successText={t`Slack sent`}
           />
         </div>

--- a/frontend/src/metabase/sharing/components/AddEditSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/AddEditSidebar.jsx
@@ -131,6 +131,7 @@ function _AddEditEmailSidebar({
             testPulse={testPulse}
             normalText={t`Send email now`}
             successText={t`Email sent`}
+            disabled={channel.recipients.length === 0}
           />
         </div>
         {PLUGIN_DASHBOARD_SUBSCRIPTION_PARAMETERS_SECTION_OVERRIDE.Component ? (
@@ -327,6 +328,7 @@ function _AddEditSlackSidebar({
             testPulse={testPulse}
             normalText={t`Send to Slack now`}
             successText={t`Slack sent`}
+            disabled={channel.details.channel === undefined}
           />
         </div>
         {PLUGIN_DASHBOARD_SUBSCRIPTION_PARAMETERS_SECTION_OVERRIDE.Component ? (

--- a/frontend/src/metabase/sharing/components/SharingSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/SharingSidebar.jsx
@@ -390,6 +390,7 @@ class SharingSidebar extends React.Component {
             this.onChannelScheduleChange,
             index,
           )}
+          testPulse={testPulse}
           toggleSkipIfEmpty={this.toggleSkipIfEmpty}
           handleArchive={this.handleArchive}
           dashboard={dashboard}

--- a/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
@@ -254,7 +254,7 @@ describe("scenarios > dashboard > subscriptions", () => {
       cy.findAllByRole("button", { name: "Done" }).should("not.be.disabled");
     });
 
-    it.skip("should have 'Send to Slack now' button (metabase#14515)", () => {
+    it("should have 'Send to Slack now' button (metabase#14515)", () => {
       cy.findAllByRole("button", { name: "Send to Slack now" }).should(
         "be.disabled",
       );


### PR DESCRIPTION
Refactors the `SendTestEmail` component to be a platform-agnostic `SendTestPulse`, and adds it to the Slack settings form (used by both pulses and dashboard subscriptions).

I've enabled the Cypress test that checks that the button is there, and I've manually tested that a Slack is sent successfully when the button is clicked.

<img width="364" alt="Screen Shot 2021-08-12 at 11 06 39 AM" src="https://user-images.githubusercontent.com/32746338/129247474-529eeaa6-235c-4f4a-8c0a-9b40f41805f6.png">

Resolves #14515
