### PR TITLE
Upload front-end code coverage to codecov.io

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1014,7 +1014,8 @@ workflows:
           after-steps:
             - run:
                 name: Upload code coverage to codecov.io
-                command: bash <(curl -s https://codecov.io/bash)
+                command: bash <(curl -s https://codecov.io/bash) -F back-end
+
           skip-when-no-change: true
 
       - test-driver:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -95,8 +95,13 @@ jobs:
         path: ~/.cache/yarn
         key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
     - run: yarn install --frozen-lockfile --prefer-offline
-    - run: yarn run test-unit
+    - run: yarn run test-unit --coverage --silent
       name: Run frontend unit tests
+    - name: Upload coverage to codecov.io
+      uses: codecov/codecov-action@v2
+      with:
+        files: ./coverage/lcov.info
+        flags: front-end
 
   fe-tests-timezones:
     runs-on: ubuntu-20.04

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,7 +5,7 @@ codecov:
 coverage:
   status:
     project:
-      default:
+      back-end:
         # Project must always have at least 78% coverage (by line)
         target: 78%
         # Whole-project test coverage is allowed to drop up to 5%. (For situtations where we delete code with full coverage)
@@ -16,7 +16,7 @@ coverage:
         threshold: 5%
 
     patch:
-      default:
+      back-end:
         # Changes must have at least 75% test coverage (by line)
         target: 75%
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,7 +10,15 @@ coverage:
         target: 78%
         # Whole-project test coverage is allowed to drop up to 5%. (For situtations where we delete code with full coverage)
         threshold: 5%
+
+      front-end:
+        target: 35%
+        threshold: 5%
+
     patch:
       default:
         # Changes must have at least 75% test coverage (by line)
         target: 75%
+
+      front-end:
+        target: 35%

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,15 +10,34 @@ coverage:
         target: 78%
         # Whole-project test coverage is allowed to drop up to 5%. (For situtations where we delete code with full coverage)
         threshold: 5%
+        flags:
+          - back-end
 
       front-end:
         target: 35%
         threshold: 5%
+        flags:
+          - front-end
 
     patch:
       back-end:
         # Changes must have at least 75% test coverage (by line)
         target: 75%
+        flags:
+          - back-end
 
       front-end:
         target: 35%
+        flags:
+          - front-end
+
+flags:
+  back-end:
+    paths:
+      - enterprise/backend
+      - shared/src
+      - src/metabase
+
+  front-end:
+    paths:
+      - frontend

--- a/codecov.yml
+++ b/codecov.yml
@@ -40,4 +40,5 @@ flags:
 
   front-end:
     paths:
+      - enterprise/frontend
       - frontend


### PR DESCRIPTION
Once this is merged, we'll see more info on https://app.codecov.io/gh/metabase/metabase, e.g.:

![image](https://user-images.githubusercontent.com/7288/129261436-9ce6bf9f-2d14-492d-8bdc-8bce17cfb2b2.png)

Note that the coverage report was only from the unit-tests, which does increase the CI run for the unit tests a bit (2 minutes, give or take). A possible follow-up is to also gather and merge the coverage from running E2E tests.