### PR TITLE
Prevent infinite re-rendering when the scroll bar appears/disappears

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
@@ -169,6 +169,18 @@ export default class DashboardGrid extends Component {
     return { desktop, mobile };
   }
 
+  getRowHeight() {
+    const { width } = this.props;
+
+    const hasScroll = window.innerWidth > document.documentElement.offsetWidth;
+    const aspectHeight = width / GRID_WIDTH / GRID_ASPECT_RATIO;
+    const actualHeight = Math.max(aspectHeight, MIN_ROW_HEIGHT);
+
+    // prevent infinite re-rendering when the scroll bar appears/disappears
+    // https://github.com/metabase/metabase/issues/17229
+    return hasScroll ? Math.ceil(actualHeight) : Math.floor(actualHeight);
+  }
+
   renderRemoveModal() {
     // can't use PopoverWithTrigger due to strange interaction with ReactGridLayout
     const isOpen = this.state.removeModalDashCard != null;
@@ -304,10 +316,7 @@ export default class DashboardGrid extends Component {
   renderGrid() {
     const { dashboard, width } = this.props;
     const { layouts } = this.state;
-    const rowHeight = Math.max(
-      Math.floor(width / GRID_WIDTH / GRID_ASPECT_RATIO),
-      MIN_ROW_HEIGHT,
-    );
+    const rowHeight = this.getRowHeight();
     return (
       <GridLayout
         className={cx("DashboardGrid", {


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/17229

The idea is to make row heights a little bit bigger when there is a scroll bar to prevent it from disappearing in edge cases.