### PR TITLE
Refactor notebook editor's join step

### DIFF
--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -25,6 +25,8 @@ import {
   JoinTypeOptionRoot,
   JoinTypeIcon,
   JoinedTableControlRoot,
+  JoinWhereConditionLabel,
+  JoinOnConditionLabel,
 } from "./JoinStep.styled";
 
 export default function JoinStep({
@@ -112,7 +114,7 @@ class JoinClause extends React.Component {
 
         {joinedTable && (
           <JoinedTableControlRoot>
-            <span className="text-medium text-bold ml1 mr2">where</span>
+            <JoinWhereConditionLabel />
 
             <JoinDimensionPicker
               color={color}
@@ -132,7 +134,7 @@ class JoinClause extends React.Component {
               ref={ref => (this._parentDimensionPicker = ref)}
             />
 
-            <span className="text-medium text-bold mr1">=</span>
+            <JoinOnConditionLabel />
 
             <JoinDimensionPicker
               color={color}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -3,7 +3,6 @@ import React from "react";
 import _ from "underscore";
 import { t } from "ttag";
 
-import Icon from "metabase/components/Icon";
 import PopoverWithTrigger from "metabase/components/PopoverWithTrigger";
 
 import { DatabaseSchemaAndTableDataSelector } from "metabase/query_builder/components/DataSelector";
@@ -27,6 +26,7 @@ import {
   JoinedTableControlRoot,
   JoinWhereConditionLabel,
   JoinOnConditionLabel,
+  RemoveJoinIcon,
 } from "./JoinStep.styled";
 
 export default function JoinStep({
@@ -161,12 +161,7 @@ class JoinClause extends React.Component {
         )}
 
         {showRemove && (
-          <Icon
-            name="close"
-            size={18}
-            className="cursor-pointer text-light text-medium-hover"
-            onClick={() => join.remove().update(updateQuery)}
-          />
+          <RemoveJoinIcon onClick={() => join.remove().update(updateQuery)} />
         )}
       </JoinClauseRoot>
     );

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -19,7 +19,11 @@ import {
   NotebookCellAdd,
 } from "../NotebookCell";
 import FieldsPicker from "./FieldsPicker";
-import { JoinClausesContainer } from "./JoinStep.styled";
+import {
+  JoinClausesContainer,
+  JoinClauseContainer,
+  JoinClauseRoot,
+} from "./JoinStep.styled";
 
 export default function JoinStep({
   color,
@@ -41,17 +45,20 @@ export default function JoinStep({
   return (
     <NotebookCell color={color} flexWrap="nowrap">
       <JoinClausesContainer>
-        {joins.map((join, index) => (
-          <JoinClause
-            mb={index === joins.length - 1 ? 0 : 2}
-            key={index}
-            color={color}
-            join={join}
-            showRemove={joins.length > 1}
-            updateQuery={updateQuery}
-            isLastOpened={isLastOpened && index === join.length - 1}
-          />
-        ))}
+        {joins.map((join, index) => {
+          const isLast = index === joins.length - 1;
+          return (
+            <JoinClauseContainer key={index} isLast={isLast}>
+              <JoinClause
+                join={join}
+                color={color}
+                showRemove={joins.length > 1}
+                updateQuery={updateQuery}
+                isLastOpened={isLastOpened && isLast}
+              />
+            </JoinClauseContainer>
+          );
+        })}
       </JoinClausesContainer>
       {!isSingleJoinStep && valid && (
         <NotebookCellAdd
@@ -68,7 +75,7 @@ export default function JoinStep({
 
 class JoinClause extends React.Component {
   render() {
-    const { color, join, updateQuery, showRemove, ...props } = this.props;
+    const { color, join, updateQuery, showRemove } = this.props;
     const query = join.query();
     if (!query) {
       return null;
@@ -87,7 +94,7 @@ class JoinClause extends React.Component {
     const joinedTable = join.joinedTable();
     const strategyOption = join.strategyOption();
     return (
-      <Flex align="center" flex="1 1 auto" {...props}>
+      <JoinClauseRoot>
         <NotebookCellItem color={color} icon="table2">
           {(lhsTable && lhsTable.displayName()) || `Previous results`}
         </NotebookCellItem>
@@ -214,7 +221,7 @@ class JoinClause extends React.Component {
             onClick={() => join.remove().update(updateQuery)}
           />
         )}
-      </Flex>
+      </JoinClauseRoot>
     );
   }
 }

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -6,18 +6,19 @@ import cx from "classnames";
 import _ from "underscore";
 import { t } from "ttag";
 
-import {
-  NotebookCell,
-  NotebookCellItem,
-  NotebookCellAdd,
-} from "../NotebookCell";
-
 import Icon from "metabase/components/Icon";
 import PopoverWithTrigger from "metabase/components/PopoverWithTrigger";
 
 import { DatabaseSchemaAndTableDataSelector } from "metabase/query_builder/components/DataSelector";
 import FieldList from "metabase/query_builder/components/FieldList";
 import Join from "metabase-lib/lib/queries/structured/Join";
+
+import {
+  NotebookCell,
+  NotebookCellItem,
+  NotebookCellAdd,
+} from "../NotebookCell";
+import FieldsPicker from "./FieldsPicker";
 
 export default function JoinStep({
   color,
@@ -291,8 +292,6 @@ class JoinDimensionPicker extends React.Component {
     );
   }
 }
-
-import FieldsPicker from "./FieldsPicker";
 
 const JoinFieldsPicker = ({ className, join, updateQuery }) => {
   const dimensions = join.joinedDimensions();

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -2,7 +2,6 @@
 import React from "react";
 
 import { Flex } from "grid-styled";
-import cx from "classnames";
 import _ from "underscore";
 import { t } from "ttag";
 
@@ -23,6 +22,10 @@ import {
   JoinClausesContainer,
   JoinClauseContainer,
   JoinClauseRoot,
+  JoinStrategyIcon,
+  JoinTypeSelectRoot,
+  JoinTypeOptionRoot,
+  JoinTypeIcon,
 } from "./JoinStep.styled";
 
 export default function JoinStep({
@@ -202,11 +205,9 @@ function JoinTypePicker({ join, color, updateQuery }) {
     <PopoverWithTrigger
       triggerElement={
         strategyOption ? (
-          <Icon
+          <JoinStrategyIcon
             tooltip={t`Change join type`}
-            className="text-brand mr1"
             name={strategyOption.icon}
-            size={32}
           />
         ) : (
           <NotebookCellItem color={color}>
@@ -234,7 +235,7 @@ function JoinTypePicker({ join, color, updateQuery }) {
 
 function JoinTypeSelect({ value, onChange, options }) {
   return (
-    <div className="px1 pt1">
+    <JoinTypeSelectRoot>
       {options.map(option => (
         <JoinTypeOption
           {...option}
@@ -243,29 +244,16 @@ function JoinTypeSelect({ value, onChange, options }) {
           onChange={onChange}
         />
       ))}
-    </div>
+    </JoinTypeSelectRoot>
   );
 }
 
 function JoinTypeOption({ name, value, icon, selected, onChange }) {
   return (
-    <Flex
-      align="center"
-      className={cx(
-        "p1 mb1 rounded cursor-pointer text-white-hover bg-brand-hover",
-        {
-          "bg-brand text-white": selected,
-        },
-      )}
-      onClick={() => onChange(value)}
-    >
-      <Icon
-        className={cx("mr1", { "text-brand": !selected })}
-        name={icon}
-        size={24}
-      />
+    <JoinTypeOptionRoot isSelected={selected} onClick={() => onChange(value)}>
+      <JoinTypeIcon name={icon} isSelected={selected} />
       {name}
-    </Flex>
+    </JoinTypeOptionRoot>
   );
 }
 

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -1,5 +1,5 @@
-/* eslint-disable react/prop-types */
 import React from "react";
+import PropTypes from "prop-types";
 import _ from "underscore";
 import { t } from "ttag";
 
@@ -28,6 +28,31 @@ import {
   JoinOnConditionLabel,
   RemoveJoinIcon,
 } from "./JoinStep.styled";
+
+const stepShape = {
+  id: PropTypes.string,
+  type: PropTypes.string,
+  query: PropTypes.object,
+  previewQuery: PropTypes.object,
+  valid: PropTypes.bool,
+  visible: PropTypes.bool,
+  stageIndex: PropTypes.number,
+  itemIndex: PropTypes.number,
+  update: PropTypes.func,
+  revert: PropTypes.func,
+  clean: PropTypes.func,
+
+  previous: stepShape,
+  next: stepShape,
+};
+
+const joinStepPropTypes = {
+  query: PropTypes.object.isRequired,
+  step: PropTypes.shape(stepShape).isRequired,
+  color: PropTypes.string,
+  isLastOpened: PropTypes.bool,
+  updateQuery: PropTypes.func.isRequired,
+};
 
 export default function JoinStep({
   color,
@@ -76,6 +101,15 @@ export default function JoinStep({
     </NotebookCell>
   );
 }
+
+JoinStep.propTypes = joinStepPropTypes;
+
+const joinClausePropTypes = {
+  color: PropTypes.string,
+  join: PropTypes.object,
+  updateQuery: PropTypes.func,
+  showRemove: PropTypes.bool,
+};
 
 class JoinClause extends React.Component {
   render() {
@@ -168,6 +202,16 @@ class JoinClause extends React.Component {
   }
 }
 
+JoinClause.propTypes = joinClausePropTypes;
+
+const joinTablePickerPropTypes = {
+  join: PropTypes.object,
+  query: PropTypes.object,
+  joinedTable: PropTypes.object,
+  color: PropTypes.string,
+  updateQuery: PropTypes.func,
+};
+
 function JoinTablePicker({ join, query, joinedTable, color, updateQuery }) {
   return (
     <NotebookCellItem color={color} icon="table2" inactive={!joinedTable}>
@@ -203,6 +247,14 @@ function JoinTablePicker({ join, query, joinedTable, color, updateQuery }) {
   );
 }
 
+JoinTablePicker.propTypes = joinTablePickerPropTypes;
+
+const joinTypePickerPropTypes = {
+  join: PropTypes.object,
+  color: PropTypes.string,
+  updateQuery: PropTypes.func,
+};
+
 function JoinTypePicker({ join, color, updateQuery }) {
   const strategyOption = join.strategyOption();
   return (
@@ -237,6 +289,21 @@ function JoinTypePicker({ join, color, updateQuery }) {
   );
 }
 
+JoinTypePicker.propTypes = joinTypePickerPropTypes;
+
+const joinStrategyOptionShape = {
+  name: PropTypes.string.isRequired,
+  value: PropTypes.string.isRequired,
+  icon: PropTypes.string.isRequired,
+};
+
+const joinTypeSelectPropTypes = {
+  value: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+  options: PropTypes.arrayOf(PropTypes.shape(joinStrategyOptionShape))
+    .isRequired,
+};
+
 function JoinTypeSelect({ value, onChange, options }) {
   return (
     <JoinTypeSelectRoot>
@@ -252,6 +319,14 @@ function JoinTypeSelect({ value, onChange, options }) {
   );
 }
 
+JoinTypeSelect.propTypes = joinTypeSelectPropTypes;
+
+const joinTypeOptionPropTypes = {
+  ...joinStrategyOptionShape,
+  selected: PropTypes.bool.isRequired,
+  onChange: PropTypes.func.isRequired,
+};
+
 function JoinTypeOption({ name, value, icon, selected, onChange }) {
   return (
     <JoinTypeOptionRoot isSelected={selected} onClick={() => onChange(value)}>
@@ -260,6 +335,20 @@ function JoinTypeOption({ name, value, icon, selected, onChange }) {
     </JoinTypeOptionRoot>
   );
 }
+
+JoinTypeOption.propTypes = joinTypeOptionPropTypes;
+
+const joinDimensionPickerPropTypes = {
+  dimension: PropTypes.object.isRequired,
+  onChange: PropTypes.func.isRequired,
+  options: PropTypes.shape({
+    count: PropTypes.number.isRequired,
+    fks: PropTypes.array.isRequired,
+    dimensions: PropTypes.arrayOf(PropTypes.object).isRequired,
+  }).isRequired,
+  query: PropTypes.object.isRequired,
+  color: PropTypes.string,
+};
 
 class JoinDimensionPicker extends React.Component {
   open() {
@@ -297,6 +386,14 @@ class JoinDimensionPicker extends React.Component {
     );
   }
 }
+
+JoinDimensionPicker.propTypes = joinDimensionPickerPropTypes;
+
+const joinFieldsPickerPropTypes = {
+  join: PropTypes.object.isRequired,
+  updateQuery: PropTypes.func.isRequired,
+  className: PropTypes.string,
+};
 
 const JoinFieldsPicker = ({ className, join, updateQuery }) => {
   const dimensions = join.joinedDimensions();
@@ -340,3 +437,5 @@ const JoinFieldsPicker = ({ className, join, updateQuery }) => {
     />
   );
 };
+
+JoinFieldsPicker.propTypes = joinFieldsPickerPropTypes;

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -103,39 +103,12 @@ class JoinClause extends React.Component {
 
         <JoinTypePicker join={join} color={color} updateQuery={updateQuery} />
 
-        <DatabaseSchemaAndTableDataSelector
-          hasTableSearch
-          canChangeDatabase={false}
-          databases={[
-            query.database(),
-            query.database().savedQuestionsDatabase(),
-          ].filter(d => d)}
-          tableFilter={table => table.db_id === query.database().id}
-          selectedDatabaseId={query.databaseId()}
-          selectedTableId={join.joinSourceTableId()}
-          setSourceTableFn={tableId => {
-            const newJoin = join
-              .setJoinSourceTableId(tableId)
-              .setDefaultCondition()
-              .setDefaultAlias();
-            newJoin.parent().update(updateQuery);
-            // _parentDimensionPicker won't be rendered until next update
-            if (!newJoin.parentDimension()) {
-              setTimeout(() => {
-                this._parentDimensionPicker.open();
-              });
-            }
-          }}
-          isInitiallyOpen={join.joinSourceTableId() == null}
-          triggerElement={
-            <NotebookCellItem
-              color={color}
-              icon="table2"
-              inactive={!joinedTable}
-            >
-              {joinedTable ? joinedTable.displayName() : t`Pick a table...`}
-            </NotebookCellItem>
-          }
+        <JoinTablePicker
+          join={join}
+          query={query}
+          joinedTable={joinedTable}
+          color={color}
+          updateQuery={updateQuery}
         />
 
         {joinedTable && (
@@ -197,6 +170,41 @@ class JoinClause extends React.Component {
       </JoinClauseRoot>
     );
   }
+}
+
+function JoinTablePicker({ join, query, joinedTable, color, updateQuery }) {
+  return (
+    <NotebookCellItem color={color} icon="table2" inactive={!joinedTable}>
+      <DatabaseSchemaAndTableDataSelector
+        hasTableSearch
+        canChangeDatabase={false}
+        databases={[
+          query.database(),
+          query.database().savedQuestionsDatabase(),
+        ].filter(d => d)}
+        tableFilter={table => table.db_id === query.database().id}
+        selectedDatabaseId={query.databaseId()}
+        selectedTableId={join.joinSourceTableId()}
+        setSourceTableFn={tableId => {
+          const newJoin = join
+            .setJoinSourceTableId(tableId)
+            .setDefaultCondition()
+            .setDefaultAlias();
+          newJoin.parent().update(updateQuery);
+          // _parentDimensionPicker won't be rendered until next update
+          if (!newJoin.parentDimension()) {
+            setTimeout(() => {
+              this._parentDimensionPicker.open();
+            });
+          }
+        }}
+        isInitiallyOpen={join.joinSourceTableId() == null}
+        triggerElement={
+          joinedTable ? joinedTable.displayName() : t`Pick a table...`
+        }
+      />
+    </NotebookCellItem>
+  );
 }
 
 function JoinTypePicker({ join, color, updateQuery }) {

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -19,6 +19,7 @@ import {
   NotebookCellAdd,
 } from "../NotebookCell";
 import FieldsPicker from "./FieldsPicker";
+import { JoinClausesContainer } from "./JoinStep.styled";
 
 export default function JoinStep({
   color,
@@ -26,7 +27,6 @@ export default function JoinStep({
   step,
   updateQuery,
   isLastOpened,
-  ...props
 }) {
   const isSingleJoinStep = step.itemIndex != null;
   let joins = query.joins();
@@ -40,7 +40,7 @@ export default function JoinStep({
   const valid = _.all(joins, join => join.isValid());
   return (
     <NotebookCell color={color} flexWrap="nowrap">
-      <Flex flexDirection="column" className="flex-full">
+      <JoinClausesContainer>
         {joins.map((join, index) => (
           <JoinClause
             mb={index === joins.length - 1 ? 0 : 2}
@@ -52,7 +52,7 @@ export default function JoinStep({
             isLastOpened={isLastOpened && index === join.length - 1}
           />
         ))}
-      </Flex>
+      </JoinClausesContainer>
       {!isSingleJoinStep && valid && (
         <NotebookCellAdd
           color={color}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -92,43 +92,13 @@ class JoinClause extends React.Component {
     }
 
     const joinedTable = join.joinedTable();
-    const strategyOption = join.strategyOption();
     return (
       <JoinClauseRoot>
         <NotebookCellItem color={color} icon="table2">
           {(lhsTable && lhsTable.displayName()) || `Previous results`}
         </NotebookCellItem>
 
-        <PopoverWithTrigger
-          triggerElement={
-            strategyOption ? (
-              <Icon
-                tooltip={t`Change join type`}
-                className="text-brand mr1"
-                name={strategyOption.icon}
-                size={32}
-              />
-            ) : (
-              <NotebookCellItem color={color}>
-                {`Choose a join type`}
-              </NotebookCellItem>
-            )
-          }
-        >
-          {({ onClose }) => (
-            <JoinTypeSelect
-              value={strategyOption && strategyOption.value}
-              onChange={strategy => {
-                join
-                  .setStrategy(strategy)
-                  .parent()
-                  .update(updateQuery);
-                onClose();
-              }}
-              options={join.strategyOptions()}
-            />
-          )}
-        </PopoverWithTrigger>
+        <JoinTypePicker join={join} color={color} updateQuery={updateQuery} />
 
         <DatabaseSchemaAndTableDataSelector
           hasTableSearch
@@ -224,6 +194,42 @@ class JoinClause extends React.Component {
       </JoinClauseRoot>
     );
   }
+}
+
+function JoinTypePicker({ join, color, updateQuery }) {
+  const strategyOption = join.strategyOption();
+  return (
+    <PopoverWithTrigger
+      triggerElement={
+        strategyOption ? (
+          <Icon
+            tooltip={t`Change join type`}
+            className="text-brand mr1"
+            name={strategyOption.icon}
+            size={32}
+          />
+        ) : (
+          <NotebookCellItem color={color}>
+            {`Choose a join type`}
+          </NotebookCellItem>
+        )
+      }
+    >
+      {({ onClose }) => (
+        <JoinTypeSelect
+          value={strategyOption && strategyOption.value}
+          onChange={strategy => {
+            join
+              .setStrategy(strategy)
+              .parent()
+              .update(updateQuery);
+            onClose();
+          }}
+          options={join.strategyOptions()}
+        />
+      )}
+    </PopoverWithTrigger>
+  );
 }
 
 function JoinTypeSelect({ value, onChange, options }) {

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -1,7 +1,5 @@
 /* eslint-disable react/prop-types */
 import React from "react";
-
-import { Flex } from "grid-styled";
 import _ from "underscore";
 import { t } from "ttag";
 
@@ -26,6 +24,7 @@ import {
   JoinTypeSelectRoot,
   JoinTypeOptionRoot,
   JoinTypeIcon,
+  JoinedTableControlRoot,
 } from "./JoinStep.styled";
 
 export default function JoinStep({
@@ -112,7 +111,7 @@ class JoinClause extends React.Component {
         />
 
         {joinedTable && (
-          <Flex align="center">
+          <JoinedTableControlRoot>
             <span className="text-medium text-bold ml1 mr2">where</span>
 
             <JoinDimensionPicker
@@ -148,7 +147,7 @@ class JoinClause extends React.Component {
               }}
               ref={ref => (this._joinDimensionPicker = ref)}
             />
-          </Flex>
+          </JoinedTableControlRoot>
         )}
 
         {join.isValid() && (

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -30,17 +30,18 @@ import {
 } from "./JoinStep.styled";
 
 const stepShape = {
-  id: PropTypes.string,
-  type: PropTypes.string,
-  query: PropTypes.object,
+  id: PropTypes.string.isRequired,
+  type: PropTypes.string.isRequired,
+  query: PropTypes.object.isRequired,
   previewQuery: PropTypes.object,
-  valid: PropTypes.bool,
-  visible: PropTypes.bool,
-  stageIndex: PropTypes.number,
-  itemIndex: PropTypes.number,
-  update: PropTypes.func,
-  revert: PropTypes.func,
-  clean: PropTypes.func,
+  valid: PropTypes.bool.isRequired,
+  visible: PropTypes.bool.isRequired,
+  stageIndex: PropTypes.number.isRequired,
+  itemIndex: PropTypes.number.isRequired,
+  update: PropTypes.func.isRequired,
+  revert: PropTypes.func.isRequired,
+  clean: PropTypes.func.isRequired,
+  actions: PropTypes.array.isRequired,
 
   previous: stepShape,
   next: stepShape,

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.styled.js
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.styled.js
@@ -5,3 +5,13 @@ export const JoinClausesContainer = styled.div`
   flex-direction: column;
   flex: 1 0 auto;
 `;
+
+export const JoinClauseContainer = styled.div`
+  margin-bottom: ${props => (props.isLast ? 0 : "2px")};
+`;
+
+export const JoinClauseRoot = styled.div`
+  display: flex;
+  align-items: center;
+  flex: 1 1 auto;
+`;

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.styled.js
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.styled.js
@@ -1,4 +1,7 @@
 import styled from "styled-components";
+import { color } from "metabase/lib/colors";
+import { space } from "metabase/styled-components/theme";
+import Icon from "metabase/components/Icon";
 
 export const JoinClausesContainer = styled.div`
   display: flex;
@@ -14,4 +17,39 @@ export const JoinClauseRoot = styled.div`
   display: flex;
   align-items: center;
   flex: 1 1 auto;
+`;
+
+export const JoinStrategyIcon = styled(Icon).attrs({ size: 32 })`
+  color: ${color("brand")};
+  margin-right: ${space(1)};
+`;
+
+export const JoinTypeSelectRoot = styled.div`
+  margin: ${space(1)} ${space(1)} 0 ${space(1)};
+`;
+
+export const JoinTypeOptionRoot = styled.div`
+  display: flex;
+  align-items: center;
+  padding: ${space(1)};
+  margin-bottom: ${space(1)};
+  cursor: pointer;
+  border-radius: ${space(1)};
+
+  color: ${props => props.isSelected && color("text-white")};
+  background-color: ${props => props.isSelected && color("brand")};
+
+  :hover {
+    color: ${color("text-white")};
+    background-color: ${color("brand")};
+
+    .Icon {
+      color: ${color("text-white")};
+    }
+  }
+`;
+
+export const JoinTypeIcon = styled(Icon).attrs({ size: 24 })`
+  margin-right: ${space(1)};
+  color: ${props => (props.isSelected ? color("text-white") : color("brand"))};
 `;

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.styled.js
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.styled.js
@@ -58,3 +58,16 @@ export const JoinedTableControlRoot = styled.div`
   display: flex;
   align-items: center;
 `;
+
+export const JoinWhereConditionLabel = styled.span.attrs({ children: "where" })`
+  color: ${color("text-medium")};
+  font-weight: bold;
+  margin-left: ${space(1)};
+  margin-right: ${space(2)};
+`;
+
+export const JoinOnConditionLabel = styled.span.attrs({ children: "=" })`
+  font-weight: bold;
+  color: ${color("text-medium")};
+  margin-right: 8px;
+`;

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.styled.js
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.styled.js
@@ -53,3 +53,8 @@ export const JoinTypeIcon = styled(Icon).attrs({ size: 24 })`
   margin-right: ${space(1)};
   color: ${props => (props.isSelected ? color("text-white") : color("brand"))};
 `;
+
+export const JoinedTableControlRoot = styled.div`
+  display: flex;
+  align-items: center;
+`;

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.styled.js
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.styled.js
@@ -71,3 +71,12 @@ export const JoinOnConditionLabel = styled.span.attrs({ children: "=" })`
   color: ${color("text-medium")};
   margin-right: 8px;
 `;
+
+export const RemoveJoinIcon = styled(Icon).attrs({ name: "close", size: 18 })`
+  cursor: pointer;
+  color: ${color("text-light")};
+
+  :hover {
+    color: ${color("text-medium")};
+  }
+`;

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.styled.js
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.styled.js
@@ -1,0 +1,7 @@
+import styled from "styled-components";
+
+export const JoinClausesContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex: 1 0 auto;
+`;


### PR DESCRIPTION
This PR refactors notebook editor's join step and should unblock visual regression fixes for #17435.

<img width="926" alt="notebook editor's join step" src="https://user-images.githubusercontent.com/17258145/129348785-f4bf123b-13f4-44c5-ac2d-e896477ec778.png">

No visible changes are expected, except for a small height change. At the moment, the bottom join step's padding is a few pixels bigger than the vertical one. Overall, the PR aligns the JoinStep with our frontend style guide and extracts a few components from a big `render` method, so it's easier to understand. Adding prop-types, extracting styled-components, ditching `grid-styled` components, etc.

### To Verify

1. Ask a question > Custom question
2. Play around with joins, it should work and look as on `master`