### PR TITLE
Don't use prop shorthands for some home containers

### DIFF
--- a/frontend/src/metabase/home/containers/ArchiveApp.jsx
+++ b/frontend/src/metabase/home/containers/ArchiveApp.jsx
@@ -50,7 +50,7 @@ export default class ArchiveApp extends Component {
         <Box mt={2} py={2}>
           <PageHeading>{t`Archive`}</PageHeading>
         </Box>
-        <Box w={2 / 3}>
+        <Box width={2 / 3}>
           <Card
             style={{
               height: list.length > 0 ? ROW_HEIGHT * list.length : "auto",

--- a/frontend/src/metabase/home/containers/HomepageApp.jsx
+++ b/frontend/src/metabase/home/containers/HomepageApp.jsx
@@ -54,12 +54,12 @@ export default class HomepageApp extends Component {
           <Subhead>{t`Activity`}</Subhead>
         </Box>
         <Flex>
-          <Box w={2 / 3}>
+          <Box width={2 / 3}>
             <Card px={1}>
               <Activity {...this.props} />
             </Card>
           </Box>
-          <Box w={1 / 3}>
+          <Box width={1 / 3}>
             <NextStep />
             <RecentViews {...this.props} />
           </Box>

--- a/frontend/src/metabase/home/containers/SearchApp.jsx
+++ b/frontend/src/metabase/home/containers/SearchApp.jsx
@@ -97,7 +97,7 @@ export default function SearchApp({ location }) {
           {({ list, metadata }) => {
             if (list.length === 0) {
               return (
-                <Box w={2 / 3}>
+                <Box width={2 / 3}>
                   <Card>
                     <EmptyState
                       title={t`Didn't find anything`}
@@ -117,7 +117,7 @@ export default function SearchApp({ location }) {
 
             return (
               <Flex align="top">
-                <Box w={2 / 3}>
+                <Box width={2 / 3}>
                   <React.Fragment>
                     <SearchResultSection items={list} />
                     <div className="flex justify-end my2">


### PR DESCRIPTION
Go to `/archive`, `/activity`, and perform a search. Pay attention to the following containers:

![image](https://user-images.githubusercontent.com/7288/129398003-5019875a-158f-4665-8161-e9f2d149064b.png)

![image](https://user-images.githubusercontent.com/7288/129398044-6b240bf2-6cb1-4145-9b5e-79f9da0ba0f6.png)

![image](https://user-images.githubusercontent.com/7288/129398080-f4072f15-7f32-495a-aba5-7c7bcb28966a.png)

Before and after this change, each one should look **exactly** the same.