### PR TITLE
Display official collection tooltips

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/collections/components/CollectionAuthorityLevelIcon.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/collections/components/CollectionAuthorityLevelIcon.jsx
@@ -7,12 +7,17 @@ import { color } from "metabase/lib/colors";
 import { AUTHORITY_LEVELS, REGULAR_COLLECTION } from "../constants";
 
 const propTypes = {
+  tooltip: PropTypes.string,
   collection: PropTypes.shape({
     authority_level: PropTypes.oneOf(["official"]),
   }),
 };
 
-export function CollectionAuthorityLevelIcon({ collection, ...iconProps }) {
+export function CollectionAuthorityLevelIcon({
+  collection,
+  tooltip = "default",
+  ...iconProps
+}) {
   const level = AUTHORITY_LEVELS[collection.authority_level];
   if (!level || level.type === REGULAR_COLLECTION.type) {
     return null;
@@ -21,6 +26,7 @@ export function CollectionAuthorityLevelIcon({ collection, ...iconProps }) {
     <Icon
       {...iconProps}
       name={level.icon}
+      tooltip={level.tooltips?.[tooltip] || tooltip}
       style={{ color: color(level.color) }}
       data-testid={`${level.type}-collection-marker`}
     />

--- a/enterprise/frontend/src/metabase-enterprise/collections/components/CollectionAuthorityLevelIcon.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/collections/components/CollectionAuthorityLevelIcon.jsx
@@ -4,7 +4,8 @@ import PropTypes from "prop-types";
 import Icon from "metabase/components/Icon";
 import { color } from "metabase/lib/colors";
 
-import { AUTHORITY_LEVELS, REGULAR_COLLECTION } from "../constants";
+import { AUTHORITY_LEVELS } from "../constants";
+import { isRegularCollection } from "../utils";
 
 const propTypes = {
   tooltip: PropTypes.string,
@@ -18,10 +19,10 @@ export function CollectionAuthorityLevelIcon({
   tooltip = "default",
   ...iconProps
 }) {
-  const level = AUTHORITY_LEVELS[collection.authority_level];
-  if (!level || level.type === REGULAR_COLLECTION.type) {
+  if (isRegularCollection(collection)) {
     return null;
   }
+  const level = AUTHORITY_LEVELS[collection.authority_level];
   return (
     <Icon
       {...iconProps}

--- a/enterprise/frontend/src/metabase-enterprise/collections/components/CollectionAuthorityLevelIcon.unit.spec.js
+++ b/enterprise/frontend/src/metabase-enterprise/collections/components/CollectionAuthorityLevelIcon.unit.spec.js
@@ -1,0 +1,78 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { CollectionAuthorityLevelIcon } from "./CollectionAuthorityLevelIcon";
+
+describe("CollectionAuthorityLevelIcon", () => {
+  describe("regular collections", () => {
+    [
+      {
+        name: "collection without authority level",
+        collection: {},
+      },
+      {
+        name: "regular collection",
+        collection: {
+          authority_level: null,
+        },
+      },
+    ].forEach(({ collection, name }) => {
+      it(`doesn't render for ${name}`, () => {
+        render(<CollectionAuthorityLevelIcon collection={collection} />);
+        expect(screen.queryByLabelText("folder icon")).toBeNull();
+      });
+    });
+  });
+
+  describe("official collections", () => {
+    const OFFICIAL_COLLECTION = {
+      authority_level: "official",
+    };
+
+    function renderOfficialCollection({
+      collection = OFFICIAL_COLLECTION,
+      ...props
+    } = {}) {
+      render(
+        <CollectionAuthorityLevelIcon collection={collection} {...props} />,
+      );
+    }
+
+    function queryOfficialIcon() {
+      return screen.queryByLabelText("badge icon");
+    }
+
+    it(`renders correctly`, () => {
+      renderOfficialCollection();
+      expect(queryOfficialIcon()).toBeInTheDocument();
+    });
+
+    it(`displays a tooltip by default`, () => {
+      renderOfficialCollection();
+      userEvent.hover(queryOfficialIcon());
+      expect(screen.getByRole("tooltip")).toHaveTextContent(
+        "Official collection",
+      );
+    });
+
+    it(`can display different tooltip`, () => {
+      renderOfficialCollection({ tooltip: "belonging" });
+      userEvent.hover(queryOfficialIcon());
+      expect(screen.getByRole("tooltip")).toHaveTextContent(
+        "Belongs to an Official collection",
+      );
+    });
+
+    it(`can display custom tooltip text`, () => {
+      renderOfficialCollection({ tooltip: "Hello" });
+      userEvent.hover(queryOfficialIcon());
+      expect(screen.getByRole("tooltip")).toHaveTextContent("Hello");
+    });
+
+    it(`can hide tooltip`, () => {
+      renderOfficialCollection({ tooltip: null });
+      userEvent.hover(queryOfficialIcon());
+      expect(screen.queryByLabelText("tooltip")).toBeNull();
+    });
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/collections/constants.js
+++ b/enterprise/frontend/src/metabase-enterprise/collections/constants.js
@@ -11,6 +11,9 @@ export const OFFICIAL_COLLECTION = {
   name: t`Official`,
   icon: "badge",
   color: "saturated-yellow",
+  tooltips: {
+    default: t`Official collection`,
+  },
 };
 
 export const AUTHORITY_LEVELS = {

--- a/enterprise/frontend/src/metabase-enterprise/collections/constants.js
+++ b/enterprise/frontend/src/metabase-enterprise/collections/constants.js
@@ -13,6 +13,7 @@ export const OFFICIAL_COLLECTION = {
   color: "saturated-yellow",
   tooltips: {
     default: t`Official collection`,
+    belonging: t`Belongs to an Official collection`,
   },
 };
 

--- a/enterprise/frontend/src/metabase-enterprise/collections/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/collections/index.js
@@ -11,11 +11,7 @@ import {
   REGULAR_COLLECTION,
   OFFICIAL_COLLECTION,
 } from "./constants";
-
-function isRegularCollection({ authority_level }) {
-  // Root, personal collections don't have `authority_level`
-  return !authority_level || authority_level === REGULAR_COLLECTION.type;
-}
+import { isRegularCollection } from "./utils";
 
 PLUGIN_COLLECTIONS.isRegularCollection = isRegularCollection;
 

--- a/enterprise/frontend/src/metabase-enterprise/collections/utils.js
+++ b/enterprise/frontend/src/metabase-enterprise/collections/utils.js
@@ -1,0 +1,6 @@
+import { REGULAR_COLLECTION } from "./constants";
+
+export function isRegularCollection({ authority_level }) {
+  // Root, personal collections don't have `authority_level`
+  return !authority_level || authority_level === REGULAR_COLLECTION.type;
+}

--- a/enterprise/frontend/src/metabase-enterprise/collections/utils.unit.spec.js
+++ b/enterprise/frontend/src/metabase-enterprise/collections/utils.unit.spec.js
@@ -1,0 +1,33 @@
+import { isRegularCollection } from "./utils";
+
+describe("Collections plugin utils", () => {
+  const COLLECTION = {
+    NO_AUTHORITY_LEVEL: {
+      id: "root",
+      name: "Our analytics",
+    },
+    REGULAR: {
+      authority_level: null,
+    },
+    OFFICIAL: {
+      authority_level: "official",
+    },
+  };
+
+  describe("isRegularCollection", () => {
+    it("returns 'true' if collection is missing an authority level", () => {
+      const collection = COLLECTION.NO_AUTHORITY_LEVEL;
+      expect(isRegularCollection(collection)).toBe(true);
+    });
+
+    it("returns 'true' for regular collections", () => {
+      const collection = COLLECTION.REGULAR;
+      expect(isRegularCollection(collection)).toBe(true);
+    });
+
+    it("returns 'false' for official collections", () => {
+      const collection = COLLECTION.OFFICIAL;
+      expect(isRegularCollection(collection)).toBe(false);
+    });
+  });
+});

--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.jsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.jsx
@@ -20,13 +20,15 @@ import {
   ToggleMobileSidebarIcon,
 } from "./CollectionHeader.styled";
 
-const { CollectionAuthorityLevelIcon } = PLUGIN_COLLECTION_COMPONENTS;
-
 function Title({ collection, handleToggleMobileSidebar }) {
   return (
     <Flex align="center">
       <ToggleMobileSidebarIcon onClick={handleToggleMobileSidebar} />
-      <CollectionAuthorityLevelIcon collection={collection} mr={1} size={24} />
+      <PLUGIN_COLLECTION_COMPONENTS.CollectionAuthorityLevelIcon
+        collection={collection}
+        mr={1}
+        size={24}
+      />
       <PageHeading className="text-wrap">{collection.name}</PageHeading>
       {collection.description && (
         <Tooltip tooltip={collection.description}>

--- a/frontend/src/metabase/collections/components/CollectionIcon.jsx
+++ b/frontend/src/metabase/collections/components/CollectionIcon.jsx
@@ -11,8 +11,8 @@ const propTypes = {
 };
 
 export function CollectionIcon({ collection, ...props }) {
-  const { name, color } = getCollectionIcon(collection);
-  return <Icon name={name} color={color} {...props} />;
+  const icon = getCollectionIcon(collection);
+  return <Icon {...icon} {...props} />;
 }
 
 CollectionIcon.propTypes = propTypes;

--- a/frontend/src/metabase/collections/containers/CollectionSidebar/Collections/CollectionsList/CollectionsList.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/Collections/CollectionsList/CollectionsList.jsx
@@ -17,7 +17,7 @@ import CollectionDropTarget from "metabase/containers/dnd/CollectionDropTarget";
 
 import { PLUGIN_COLLECTIONS } from "metabase/plugins";
 
-const { isRegularCollection } = PLUGIN_COLLECTIONS;
+const IRREGULAR_COLLECTION_ICON_SIZE = 14;
 
 function ToggleChildCollectionButton({ action, collectionId, isOpen }) {
   const iconName = isOpen ? "chevrondown" : "chevronright";
@@ -35,11 +35,16 @@ function ToggleChildCollectionButton({ action, collectionId, isOpen }) {
   );
 }
 
-function Label({ action, collection, initialIcon, isOpen }) {
+function Label({ action, depth, collection, isOpen }) {
   const { children, id, name } = collection;
 
+  const isRegular = PLUGIN_COLLECTIONS.isRegularCollection(collection);
   const hasChildren =
     Array.isArray(children) && children.some(child => !child.archived);
+
+  // Workaround: collection icons on the first tree level incorrect offset out of the box
+  const targetOffsetX =
+    !isRegular && depth === 1 ? IRREGULAR_COLLECTION_ICON_SIZE : 0;
 
   return (
     <LabelContainer>
@@ -51,7 +56,10 @@ function Label({ action, collection, initialIcon, isOpen }) {
         />
       )}
 
-      <CollectionListIcon collection={collection} />
+      <CollectionListIcon
+        collection={collection}
+        targetOffsetX={targetOffsetX}
+      />
       {name}
     </LabelContainer>
   );
@@ -78,7 +86,7 @@ function Collection({
         {({ highlighted, hovered }) => {
           const url = Urls.collection(collection);
           const selected = id === currentCollection;
-          const dimmedIcon = isRegularCollection(collection);
+          const dimmedIcon = PLUGIN_COLLECTIONS.isRegularCollection(collection);
 
           // when we click on a link, if there are children,
           // expand to show sub collections
@@ -103,6 +111,7 @@ function Collection({
                 collection={collection}
                 initialIcon={initialIcon}
                 isOpen={isOpen}
+                depth={depth}
               />
             </CollectionLink>
           );

--- a/frontend/src/metabase/collections/containers/CollectionSidebar/Collections/CollectionsList/CollectionsList.unit.spec.js
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/Collections/CollectionsList/CollectionsList.unit.spec.js
@@ -9,64 +9,66 @@ const filter = () => true;
 
 const openCollections = [];
 
-it("renders a basic collection", () => {
-  const collections = [
-    {
+describe("CollectionsList", () => {
+  it("renders a basic collection", () => {
+    const collections = [
+      {
+        archived: false,
+        children: [],
+        id: 1,
+        location: "/",
+        name: "Collection name",
+      },
+    ];
+
+    render(
+      <DragDropContextProvider backend={HTML5Backend}>
+        <CollectionsList
+          collections={collections}
+          filter={filter}
+          openCollections={openCollections}
+        />
+      </DragDropContextProvider>,
+    );
+
+    screen.getByText("Collection name");
+  });
+
+  it("opens child collection when user clicks on chevron button", () => {
+    const parentCollection = {
       archived: false,
       children: [],
       id: 1,
       location: "/",
-      name: "Collection name",
-    },
-  ];
+      name: "Parent collection name",
+    };
 
-  render(
-    <DragDropContextProvider backend={HTML5Backend}>
-      <CollectionsList
-        collections={collections}
-        filter={filter}
-        openCollections={openCollections}
-      />
-    </DragDropContextProvider>,
-  );
+    const childCollection = {
+      archived: false,
+      children: [],
+      id: 2,
+      location: "/2/",
+      name: "Child collection name",
+    };
 
-  screen.getByText("Collection name");
-});
+    parentCollection.children = [childCollection];
 
-it("opens child collection when user clicks on chevron button", () => {
-  const parentCollection = {
-    archived: false,
-    children: [],
-    id: 1,
-    location: "/",
-    name: "Parent collection name",
-  };
+    const onOpen = jest.fn();
 
-  const childCollection = {
-    archived: false,
-    children: [],
-    id: 2,
-    location: "/2/",
-    name: "Child collection name",
-  };
+    render(
+      <DragDropContextProvider backend={HTML5Backend}>
+        <CollectionsList
+          collections={[parentCollection]}
+          filter={filter}
+          onOpen={onOpen}
+          openCollections={openCollections}
+        />
+      </DragDropContextProvider>,
+    );
 
-  parentCollection.children = [childCollection];
+    const chevronButton = screen.getByLabelText("chevronright icon");
+    fireEvent.click(chevronButton);
 
-  const onOpen = jest.fn();
-
-  render(
-    <DragDropContextProvider backend={HTML5Backend}>
-      <CollectionsList
-        collections={[parentCollection]}
-        filter={filter}
-        onOpen={onOpen}
-        openCollections={openCollections}
-      />
-    </DragDropContextProvider>,
-  );
-
-  const chevronButton = screen.getByLabelText("chevronright icon");
-  fireEvent.click(chevronButton);
-
-  expect(onOpen).toHaveBeenCalled();
+    expect(onOpen).toHaveBeenCalled();
+  });
 });

--- a/frontend/src/metabase/components/CollectionItem.jsx
+++ b/frontend/src/metabase/components/CollectionItem.jsx
@@ -25,7 +25,7 @@ const CollectionItem = ({ collection, event }) => {
       <Card hoverable>
         <CardContent>
           <IconContainer color={icon.color}>
-            <CollectionIcon name={icon.name} />
+            <CollectionIcon name={icon.name} tooltip={icon.tooltip} />
           </IconContainer>
           <h4 className="overflow-hidden">
             <Ellipsified>{collection.name}</Ellipsified>

--- a/frontend/src/metabase/components/select-list/SelectListItem.jsx
+++ b/frontend/src/metabase/components/select-list/SelectListItem.jsx
@@ -2,13 +2,15 @@ import React from "react";
 import PropTypes from "prop-types";
 import _ from "underscore";
 
-import { ItemRoot, ItemIcon, ItemTitle } from "./SelectListItem.styled";
+import { iconPropTypes } from "metabase/components/Icon";
 import { useScrollOnMount } from "metabase/hooks/use-scroll-on-mount";
+
+import { ItemRoot, ItemIcon, ItemTitle } from "./SelectListItem.styled";
 
 const propTypes = {
   id: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
-  icon: PropTypes.string.isRequired,
+  icon: PropTypes.oneOfType([PropTypes.string, iconPropTypes]).isRequired,
   iconColor: PropTypes.string,
   onSelect: PropTypes.func.isRequired,
   isSelected: PropTypes.bool,
@@ -26,7 +28,6 @@ export function SelectListItem({
   id,
   name,
   icon,
-  iconColor = "brand",
   onSelect,
   isSelected = false,
   rightIcon,
@@ -35,6 +36,7 @@ export function SelectListItem({
 }) {
   const ref = useScrollOnMount();
 
+  const iconProps = _.isObject(icon) ? icon : { name: icon };
   const rightIconProps = _.isObject(rightIcon)
     ? rightIcon
     : { name: rightIcon };
@@ -50,7 +52,7 @@ export function SelectListItem({
       onKeyDown={e => e.key === "Enter" && onSelect(id)}
       className={className}
     >
-      <ItemIcon name={icon} color={iconColor} />
+      <ItemIcon color="brand" {...iconProps} />
       <ItemTitle>{name}</ItemTitle>
       {rightIconProps.name && <ItemIcon {...rightIconProps} />}
     </ItemRoot>

--- a/frontend/src/metabase/components/select-list/SelectListItem.jsx
+++ b/frontend/src/metabase/components/select-list/SelectListItem.jsx
@@ -10,7 +10,8 @@ import { ItemRoot, ItemIcon, ItemTitle } from "./SelectListItem.styled";
 const propTypes = {
   id: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
-  icon: PropTypes.oneOfType([PropTypes.string, iconPropTypes]).isRequired,
+  icon: PropTypes.oneOfType([PropTypes.string, PropTypes.shape(iconPropTypes)])
+    .isRequired,
   iconColor: PropTypes.string,
   onSelect: PropTypes.func.isRequired,
   isSelected: PropTypes.bool,

--- a/frontend/src/metabase/components/tree/TreeNode.jsx
+++ b/frontend/src/metabase/components/tree/TreeNode.jsx
@@ -1,5 +1,9 @@
 import React from "react";
 import PropTypes from "prop-types";
+import _ from "underscore";
+
+import Icon, { iconPropTypes } from "metabase/components/Icon";
+
 import {
   TreeNodeRoot,
   ExpandToggleButton,
@@ -8,8 +12,6 @@ import {
   IconContainer,
   RightArrowContainer,
 } from "./TreeNode.styled";
-
-import Icon from "metabase/components/Icon";
 
 const propTypes = {
   isExpanded: PropTypes.bool.isRequired,
@@ -20,8 +22,7 @@ const propTypes = {
   depth: PropTypes.number.isRequired,
   item: PropTypes.shape({
     name: PropTypes.string.isRequired,
-    icon: PropTypes.string,
-    iconColor: PropTypes.string,
+    icon: PropTypes.oneOfType([PropTypes.string, iconPropTypes]),
     hasRightArrow: PropTypes.string,
     id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   }).isRequired,
@@ -43,7 +44,9 @@ export const TreeNode = React.memo(
     },
     ref,
   ) {
-    const { name, icon, iconColor, hasRightArrow, id } = item;
+    const { name, icon, hasRightArrow, id } = item;
+
+    const iconProps = _.isObject(icon) ? icon : { name: icon };
 
     const handleSelect = () => {
       onSelect(item);
@@ -81,7 +84,7 @@ export const TreeNode = React.memo(
 
         {icon && (
           <IconContainer variant={variant}>
-            <Icon name={icon} color={iconColor} />
+            <Icon {...iconProps} />
           </IconContainer>
         )}
         <NameContainer>{name}</NameContainer>

--- a/frontend/src/metabase/components/tree/TreeNode.jsx
+++ b/frontend/src/metabase/components/tree/TreeNode.jsx
@@ -22,7 +22,10 @@ const propTypes = {
   depth: PropTypes.number.isRequired,
   item: PropTypes.shape({
     name: PropTypes.string.isRequired,
-    icon: PropTypes.oneOfType([PropTypes.string, iconPropTypes]),
+    icon: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.shape(iconPropTypes),
+    ]),
     hasRightArrow: PropTypes.string,
     id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   }).isRequired,

--- a/frontend/src/metabase/containers/ItemPicker.jsx
+++ b/frontend/src/metabase/containers/ItemPicker.jsx
@@ -4,6 +4,7 @@ import PropTypes from "prop-types";
 import cx from "classnames";
 
 import { t } from "ttag";
+import _ from "underscore";
 import { Flex, Box } from "grid-styled";
 import Icon from "metabase/components/Icon";
 import Breadcrumbs from "metabase/components/Breadcrumbs";
@@ -209,7 +210,7 @@ export default class ItemPicker extends React.Component {
                       item={collection}
                       name={collection.name}
                       color={color(icon.color) || COLLECTION_ICON_COLOR}
-                      icon={icon.name}
+                      icon={icon}
                       selected={canSelect && isSelected(collection)}
                       canSelect={canSelect}
                       hasChildren={hasChildren}
@@ -286,41 +287,44 @@ const Item = ({
   hasChildren,
   onChange,
   onChangeParentId,
-}) => (
-  <Box
-    mt={1}
-    p={1}
-    onClick={
-      canSelect
-        ? () => onChange(item)
-        : hasChildren
-        ? () => onChangeParentId(item.id)
-        : null
-    }
-    className={cx("rounded", {
-      "bg-brand text-white": selected,
-      "bg-brand-hover text-white-hover cursor-pointer":
-        canSelect || hasChildren,
-    })}
-  >
-    <Flex align="center">
-      <Icon name={icon} color={selected ? "white" : color} size={22} />
-      <h4 className="mx1">{name}</h4>
-      {hasChildren && (
-        <Icon
-          name="chevronright"
-          className={cx(
-            "p1 ml-auto circular text-light border-grey-2 bordered bg-white-hover cursor-pointer",
-            {
-              "bg-brand-hover": !canSelect,
-            },
-          )}
-          onClick={e => {
-            e.stopPropagation();
-            onChangeParentId(item.id);
-          }}
-        />
-      )}
-    </Flex>
-  </Box>
-);
+}) => {
+  const iconProps = _.isObject(icon) ? icon : { name: icon };
+  return (
+    <Box
+      mt={1}
+      p={1}
+      onClick={
+        canSelect
+          ? () => onChange(item)
+          : hasChildren
+          ? () => onChangeParentId(item.id)
+          : null
+      }
+      className={cx("rounded", {
+        "bg-brand text-white": selected,
+        "bg-brand-hover text-white-hover cursor-pointer":
+          canSelect || hasChildren,
+      })}
+    >
+      <Flex align="center">
+        <Icon size={22} {...iconProps} color={selected ? "white" : color} />
+        <h4 className="mx1">{name}</h4>
+        {hasChildren && (
+          <Icon
+            name="chevronright"
+            className={cx(
+              "p1 ml-auto circular text-light border-grey-2 bordered bg-white-hover cursor-pointer",
+              {
+                "bg-brand-hover": !canSelect,
+              },
+            )}
+            onClick={e => {
+              e.stopPropagation();
+              onChangeParentId(item.id);
+            }}
+          />
+        )}
+      </Flex>
+    </Box>
+  );
+};

--- a/frontend/src/metabase/containers/ItemPicker.jsx
+++ b/frontend/src/metabase/containers/ItemPicker.jsx
@@ -53,7 +53,7 @@ export default class ItemPicker extends React.Component {
     // number = non-root collection id
     value: PropTypes.number,
     types: PropTypes.array,
-    showSearch: PropTypes.boolean,
+    showSearch: PropTypes.bool,
   };
 
   // returns a list of "crumbs" starting with the "root" collection

--- a/frontend/src/metabase/containers/ItemPicker.jsx
+++ b/frontend/src/metabase/containers/ItemPicker.jsx
@@ -152,7 +152,11 @@ export default class ItemPicker extends React.Component {
 
     return (
       <LoadingAndErrorWrapper loading={!collectionsById} className="scroll-y">
-        <Box style={style} className={cx(className, "scroll-y")}>
+        <Box
+          style={style}
+          className={cx(className, "scroll-y")}
+          data-testid="item-picker-header"
+        >
           {searchMode ? (
             <Box pb={1} mb={2} className="border-bottom flex align-center">
               <input
@@ -186,7 +190,7 @@ export default class ItemPicker extends React.Component {
               )}
             </Box>
           )}
-          <Box className="scroll-y">
+          <Box className="scroll-y" data-testid="item-picker-list">
             {!searchString
               ? allCollections.map(collection => {
                   const hasChildren =
@@ -305,6 +309,7 @@ const Item = ({
         "bg-brand-hover text-white-hover cursor-pointer":
           canSelect || hasChildren,
       })}
+      data-testid="item-picker-item"
     >
       <Flex align="center">
         <Icon size={22} {...iconProps} color={selected ? "white" : color} />

--- a/frontend/src/metabase/containers/ItemPicker.jsx
+++ b/frontend/src/metabase/containers/ItemPicker.jsx
@@ -152,13 +152,14 @@ export default class ItemPicker extends React.Component {
 
     return (
       <LoadingAndErrorWrapper loading={!collectionsById} className="scroll-y">
-        <Box
-          style={style}
-          className={cx(className, "scroll-y")}
-          data-testid="item-picker-header"
-        >
+        <Box style={style} className={cx(className, "scroll-y")}>
           {searchMode ? (
-            <Box pb={1} mb={2} className="border-bottom flex align-center">
+            <Box
+              pb={1}
+              mb={2}
+              className="border-bottom flex align-center"
+              data-testid="item-picker-header"
+            >
               <input
                 type="search"
                 className="input rounded flex-full"
@@ -179,7 +180,12 @@ export default class ItemPicker extends React.Component {
               />
             </Box>
           ) : (
-            <Box pb={1} mb={2} className="border-bottom flex align-center">
+            <Box
+              pb={1}
+              mb={2}
+              className="border-bottom flex align-center"
+              data-testid="item-picker-header"
+            >
               <Breadcrumbs crumbs={crumbs} />
               {showSearch && (
                 <Icon

--- a/frontend/src/metabase/containers/ItemPicker.unit.spec.js
+++ b/frontend/src/metabase/containers/ItemPicker.unit.spec.js
@@ -67,10 +67,6 @@ const DASHBOARD = {
   REGULAR: dashboard({ id: 1, name: "Regular dashboard" }),
 };
 
-const store = getStore({
-  currentUser: () => CURRENT_USER,
-});
-
 function mockCollectionEndpoint() {
   xhrMock.get("/api/collection", {
     body: JSON.stringify(Object.values(COLLECTION)),
@@ -112,6 +108,10 @@ async function setup({ models = ["dashboard"], ...props } = {}) {
   mockCollectionItemsEndpoint();
 
   const onChange = jest.fn();
+
+  const store = getStore({
+    currentUser: () => CURRENT_USER,
+  });
 
   render(
     <Provider store={store}>

--- a/frontend/src/metabase/containers/ItemPicker.unit.spec.js
+++ b/frontend/src/metabase/containers/ItemPicker.unit.spec.js
@@ -65,6 +65,12 @@ COLLECTION.REGULAR_CHILD = collection({
   location: `/${COLLECTION.REGULAR.id}/`,
 });
 
+const COLLECTION_READ_ONLY_CHILD_WRITABLE = collection({
+  id: 4,
+  name: "Read-only collection's child (writable)",
+  location: `/${COLLECTION.READ_ONLY.id}/`,
+});
+
 const DASHBOARD = {
   REGULAR: dashboard({ id: 1, name: "Regular dashboard" }),
   REGULAR_CHILD: dashboard({
@@ -74,9 +80,10 @@ const DASHBOARD = {
   }),
 };
 
-function mockCollectionEndpoint() {
+function mockCollectionEndpoint({ extraCollections = [] } = {}) {
+  const collections = [...Object.values(COLLECTION), ...extraCollections];
   xhrMock.get("/api/collection", {
-    body: JSON.stringify(Object.values(COLLECTION)),
+    body: JSON.stringify(collections),
   });
 }
 
@@ -113,8 +120,12 @@ function mockCollectionItemsEndpoint() {
   });
 }
 
-async function setup({ models = ["dashboard"], ...props } = {}) {
-  mockCollectionEndpoint();
+async function setup({
+  models = ["dashboard"],
+  extraCollections = [],
+  ...props
+} = {}) {
+  mockCollectionEndpoint({ extraCollections });
   mockCollectionItemsEndpoint();
 
   const onChange = jest.fn();
@@ -179,6 +190,11 @@ describe("ItemPicker", () => {
   it("does not display read-only collections", async () => {
     await setup();
     expect(screen.queryByText(COLLECTION.READ_ONLY.name)).toBeNull();
+  });
+
+  it("displays read-only collections if they have writable children", async () => {
+    await setup({ extraCollections: [COLLECTION_READ_ONLY_CHILD_WRITABLE] });
+    expect(screen.queryByText(COLLECTION.READ_ONLY.name)).toBeInTheDocument();
   });
 
   it("can open nested collection", async () => {

--- a/frontend/src/metabase/containers/ItemPicker.unit.spec.js
+++ b/frontend/src/metabase/containers/ItemPicker.unit.spec.js
@@ -50,6 +50,11 @@ const COLLECTION = {
     personal_owner_id: CURRENT_USER.id,
   }),
   REGULAR: collection({ id: 1, name: "Regular collection" }),
+  READ_ONLY: collection({
+    id: 2,
+    name: "Read only collection",
+    can_write: false,
+  }),
 };
 
 COLLECTION.REGULAR_CHILD = collection({
@@ -131,5 +136,10 @@ describe("ItemPicker", () => {
     expect(screen.queryByText(DASHBOARD.REGULAR.name)).toBeInTheDocument();
     expect(screen.queryByText(COLLECTION.REGULAR.name)).toBeInTheDocument();
     expect(screen.queryByText(COLLECTION.PERSONAL.name)).toBeInTheDocument();
+  });
+
+  it("does not display read-only collections", async () => {
+    await setup();
+    expect(screen.queryByText(COLLECTION.READ_ONLY.name)).toBeNull();
   });
 });

--- a/frontend/src/metabase/containers/ItemPicker.unit.spec.js
+++ b/frontend/src/metabase/containers/ItemPicker.unit.spec.js
@@ -71,6 +71,12 @@ const COLLECTION_READ_ONLY_CHILD_WRITABLE = collection({
   location: `/${COLLECTION.READ_ONLY.id}/`,
 });
 
+const COLLECTION_OTHER_USERS = collection({
+  id: 5,
+  name: "John Lennon's personal collection",
+  personal_owner_id: CURRENT_USER.id + 1,
+});
+
 const DASHBOARD = {
   REGULAR: dashboard({ id: 1, name: "Regular dashboard" }),
   REGULAR_CHILD: dashboard({
@@ -255,5 +261,16 @@ describe("ItemPicker", () => {
     const { onChange } = await setup();
     userEvent.click(screen.getByText(COLLECTION.REGULAR.name));
     expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("groups personal collections into single folder if there are more than one", async () => {
+    await setup({ extraCollections: [COLLECTION_OTHER_USERS] });
+
+    userEvent.click(screen.queryByText(/All personal collections/i));
+
+    const list = getItemPickerList();
+    expect(list.queryByText(COLLECTION_OTHER_USERS.name)).toBeInTheDocument();
+    expect(list.queryByText(COLLECTION.PERSONAL.name)).toBeInTheDocument();
+    expect(list.queryAllByTestId("item-picker-item")).toHaveLength(2);
   });
 });

--- a/frontend/src/metabase/containers/ItemPicker.unit.spec.js
+++ b/frontend/src/metabase/containers/ItemPicker.unit.spec.js
@@ -193,6 +193,7 @@ describe("ItemPicker", () => {
     expect(screen.queryByText(DASHBOARD.REGULAR.name)).toBeInTheDocument();
     expect(screen.queryByText(COLLECTION.REGULAR.name)).toBeInTheDocument();
     expect(screen.queryByText(COLLECTION.PERSONAL.name)).toBeInTheDocument();
+    expect(screen.queryAllByTestId("item-picker-item")).toHaveLength(3);
   });
 
   it("does not display read-only collections", async () => {
@@ -220,10 +221,7 @@ describe("ItemPicker", () => {
     // Content
     expect(list.queryByText(COLLECTION.REGULAR_CHILD.name)).toBeInTheDocument();
     expect(list.queryByText(DASHBOARD.REGULAR_CHILD.name)).toBeInTheDocument();
-
-    expect(list.queryByText(DASHBOARD.REGULAR.name)).toBeNull();
-    expect(list.queryByText(COLLECTION.REGULAR.name)).toBeNull();
-    expect(list.queryByText(COLLECTION.PERSONAL.name)).toBeNull();
+    expect(list.queryAllByTestId("item-picker-item")).toHaveLength(2);
   });
 
   it("can navigate back from a currently open nested collection", async () => {
@@ -241,9 +239,7 @@ describe("ItemPicker", () => {
     expect(list.queryByText(DASHBOARD.REGULAR.name)).toBeInTheDocument();
     expect(list.queryByText(COLLECTION.REGULAR.name)).toBeInTheDocument();
     expect(list.queryByText(COLLECTION.PERSONAL.name)).toBeInTheDocument();
-
-    expect(list.queryByText(COLLECTION.REGULAR_CHILD.name)).toBeNull();
-    expect(list.queryByText(DASHBOARD.REGULAR_CHILD.name)).toBeNull();
+    expect(list.queryAllByTestId("item-picker-item")).toHaveLength(3);
   });
 
   it("calls onChange when selecting an item", async () => {

--- a/frontend/src/metabase/containers/ItemPicker.unit.spec.js
+++ b/frontend/src/metabase/containers/ItemPicker.unit.spec.js
@@ -141,6 +141,8 @@ async function setup({
   );
 
   await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
+
+  return { onChange };
 }
 
 function getItemPickerHeader() {
@@ -216,5 +218,22 @@ describe("ItemPicker", () => {
     expect(list.queryByText(DASHBOARD.REGULAR.name)).toBeNull();
     expect(list.queryByText(COLLECTION.REGULAR.name)).toBeNull();
     expect(list.queryByText(COLLECTION.PERSONAL.name)).toBeNull();
+  });
+
+  it("calls onChange when selecting an item", async () => {
+    const { onChange } = await setup();
+
+    userEvent.click(screen.getByText(DASHBOARD.REGULAR.name));
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining(DASHBOARD.REGULAR),
+    );
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("doesn't call onChange if it's not a collection picker", async () => {
+    const { onChange } = await setup();
+    userEvent.click(screen.getByText(COLLECTION.REGULAR.name));
+    expect(onChange).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/metabase/containers/ItemPicker.unit.spec.js
+++ b/frontend/src/metabase/containers/ItemPicker.unit.spec.js
@@ -1,0 +1,135 @@
+import React from "react";
+import { Provider } from "react-redux";
+import {
+  render,
+  screen,
+  waitForElementToBeRemoved,
+} from "@testing-library/react";
+import xhrMock from "xhr-mock";
+import { getStore } from "__support__/entities-store";
+import ItemPicker from "./ItemPicker";
+
+function collection({
+  id,
+  name,
+  location = "/",
+  personal_owner_id = null,
+  can_write = true,
+}) {
+  return {
+    id,
+    name,
+    location,
+    personal_owner_id,
+    can_write,
+    archived: false,
+  };
+}
+
+function dashboard({ id, name, collection_id = null }) {
+  return {
+    id,
+    name,
+    collection_id,
+    archived: false,
+    model: "dashboard",
+  };
+}
+
+const CURRENT_USER = {
+  id: 1,
+  personal_collection_id: 100,
+  is_superuser: true,
+};
+
+const COLLECTION = {
+  ROOT: collection({ id: "root", name: "Our analytics", location: null }),
+  PERSONAL: collection({
+    id: CURRENT_USER.personal_collection_id,
+    name: "My personal collection",
+    personal_owner_id: CURRENT_USER.id,
+  }),
+  REGULAR: collection({ id: 1, name: "Regular collection" }),
+};
+
+COLLECTION.REGULAR_CHILD = collection({
+  id: 3,
+  name: "Read-only collection's child (writable)",
+  location: `/${COLLECTION.REGULAR.id}/`,
+});
+
+const DASHBOARD = {
+  REGULAR: dashboard({ id: 1, name: "Regular dashboard" }),
+};
+
+const store = getStore({
+  currentUser: () => CURRENT_USER,
+});
+
+function mockCollectionEndpoint() {
+  xhrMock.get("/api/collection", {
+    body: JSON.stringify(Object.values(COLLECTION)),
+  });
+}
+
+function mockCollectionItemsEndpoint() {
+  xhrMock.get("/api/collection/root/items?models=dashboard", (req, res) => {
+    const dashboards = Object.values(DASHBOARD).filter(
+      dashboard => dashboard.collection_id === null,
+    );
+    return res.status(200).body(
+      JSON.stringify({
+        total: dashboards.length,
+        data: dashboards,
+      }),
+    );
+  });
+
+  xhrMock.get("/api/collection/root/items", (req, res) => {
+    const dashboards = Object.values(DASHBOARD).filter(
+      dashboard => dashboard.collection_id === null,
+    );
+    const collections = Object.values(COLLECTION).filter(
+      collection => collection.location !== "/",
+    );
+    const data = [...dashboards, ...collections];
+    return res.status(200).body(
+      JSON.stringify({
+        total: data.length,
+        data,
+      }),
+    );
+  });
+}
+
+async function setup({ models = ["dashboard"], ...props } = {}) {
+  mockCollectionEndpoint();
+  mockCollectionItemsEndpoint();
+
+  const onChange = jest.fn();
+
+  render(
+    <Provider store={store}>
+      <ItemPicker models={models} onChange={onChange} {...props} />
+    </Provider>,
+  );
+
+  await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
+}
+
+describe("ItemPicker", () => {
+  beforeEach(() => {
+    xhrMock.setup();
+  });
+
+  afterEach(() => {
+    xhrMock.teardown();
+  });
+
+  it("displays items from the root collection by default", async () => {
+    await setup();
+    expect(screen.queryByText(DASHBOARD.REGULAR.name)).toBeInTheDocument();
+    expect(screen.queryByText(COLLECTION.REGULAR.name)).toBeInTheDocument();
+    expect(screen.queryByText(COLLECTION.PERSONAL.name)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/containers/ItemPicker.unit.spec.js
+++ b/frontend/src/metabase/containers/ItemPicker.unit.spec.js
@@ -220,6 +220,26 @@ describe("ItemPicker", () => {
     expect(list.queryByText(COLLECTION.PERSONAL.name)).toBeNull();
   });
 
+  it("can navigate back from a currently open nested collection", async () => {
+    await setup();
+    await openCollection(COLLECTION.REGULAR.name);
+    let header = getItemPickerHeader();
+
+    userEvent.click(header.getByText(/Our analytics/i));
+
+    header = getItemPickerHeader();
+    const list = getItemPickerList();
+
+    expect(header.queryByText(COLLECTION.REGULAR.name)).toBeNull();
+
+    expect(list.queryByText(DASHBOARD.REGULAR.name)).toBeInTheDocument();
+    expect(list.queryByText(COLLECTION.REGULAR.name)).toBeInTheDocument();
+    expect(list.queryByText(COLLECTION.PERSONAL.name)).toBeInTheDocument();
+
+    expect(list.queryByText(COLLECTION.REGULAR_CHILD.name)).toBeNull();
+    expect(list.queryByText(DASHBOARD.REGULAR_CHILD.name)).toBeNull();
+  });
+
   it("calls onChange when selecting an item", async () => {
     const { onChange } = await setup();
 

--- a/frontend/src/metabase/containers/ItemPicker.unit.spec.js
+++ b/frontend/src/metabase/containers/ItemPicker.unit.spec.js
@@ -164,6 +164,13 @@ describe("ItemPicker", () => {
 
   it("displays items from the root collection by default", async () => {
     await setup();
+
+    // Breadcrumbs
+    expect(
+      getItemPickerHeader().queryByText(/Our analytics/i),
+    ).toBeInTheDocument();
+
+    // Content
     expect(screen.queryByText(DASHBOARD.REGULAR.name)).toBeInTheDocument();
     expect(screen.queryByText(COLLECTION.REGULAR.name)).toBeInTheDocument();
     expect(screen.queryByText(COLLECTION.PERSONAL.name)).toBeInTheDocument();

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
@@ -239,7 +239,12 @@ export default class DashboardGrid extends Component {
     if (isRegularDashboard && !isRegularQuestion) {
       const authorityLevel = dashCard.collection_authority_level;
       const opts = PLUGIN_COLLECTIONS.AUTHORITY_LEVEL[authorityLevel];
-      return { name: opts.icon, color: color(opts.color), size: 14 };
+      return {
+        name: opts.icon,
+        color: color(opts.color),
+        tooltip: opts.tooltips?.belonging,
+        size: 14,
+      };
     }
   };
 

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
@@ -239,11 +239,15 @@ export default class DashboardGrid extends Component {
     if (isRegularDashboard && !isRegularQuestion) {
       const authorityLevel = dashCard.collection_authority_level;
       const opts = PLUGIN_COLLECTIONS.AUTHORITY_LEVEL[authorityLevel];
+      const iconSize = 14;
       return {
         name: opts.icon,
         color: color(opts.color),
         tooltip: opts.tooltips?.belonging,
-        size: 14,
+        size: iconSize,
+
+        // Workaround: headerIcon on cards in a first column have incorrect offset out of the box
+        targetOffsetX: dashCard.col === 0 ? iconSize : 0,
       };
     }
   };

--- a/frontend/src/metabase/dashboard/components/add-card-sidebar/QuestionPicker.jsx
+++ b/frontend/src/metabase/dashboard/components/add-card-sidebar/QuestionPicker.jsx
@@ -84,16 +84,19 @@ function QuestionPicker({
           <SelectList>
             {collections.map(collection => {
               const icon = getCollectionIcon(collection);
+              const iconColor = isRegularCollection(collection)
+                ? "text-light"
+                : icon.color;
               return (
                 <SelectList.Item
-                  rightIcon="chevronright"
                   key={collection.id}
                   id={collection.id}
                   name={collection.name}
-                  icon={icon.name}
-                  iconColor={
-                    isRegularCollection(collection) ? "text-light" : icon.color
-                  }
+                  icon={{
+                    ...icon,
+                    color: iconColor,
+                  }}
+                  rightIcon="chevronright"
                   onSelect={collectionId =>
                     setCurrentCollectionId(collectionId)
                   }

--- a/frontend/src/metabase/entities/collections.js
+++ b/frontend/src/metabase/entities/collections.js
@@ -137,7 +137,7 @@ const Collections = createEntity({
 
 export default Collections;
 
-export function getCollectionIcon(collection) {
+export function getCollectionIcon(collection, { tooltip = "default" } = {}) {
   if (collection.id === PERSONAL_COLLECTIONS.id) {
     return { name: "group" };
   }
@@ -147,7 +147,11 @@ export function getCollectionIcon(collection) {
   const authorityLevel =
     PLUGIN_COLLECTIONS.AUTHORITY_LEVEL[collection.authority_level];
   return authorityLevel
-    ? { name: authorityLevel.icon, color: color(authorityLevel.color) }
+    ? {
+        name: authorityLevel.icon,
+        color: color(authorityLevel.color),
+        tooltip: authorityLevel.tooltips?.[tooltip],
+      }
     : { name: "folder" };
 }
 

--- a/frontend/src/metabase/entities/collections.js
+++ b/frontend/src/metabase/entities/collections.js
@@ -83,7 +83,10 @@ const Collections = createEntity({
   objectSelectors: {
     getName: collection => collection && collection.name,
     getUrl: collection => Urls.collection(collection),
-    getIcon: getCollectionIcon,
+    getIcon: (collection, opts) => {
+      const wrappedCollection = collection.collection;
+      return getCollectionIcon(wrappedCollection || collection, opts);
+    },
   },
 
   selectors: {

--- a/frontend/src/metabase/hoc/Tooltipify.jsx
+++ b/frontend/src/metabase/hoc/Tooltipify.jsx
@@ -10,10 +10,10 @@ const Tooltipify = ComposedComponent =>
       (ComposedComponent.displayName || ComposedComponent.name) +
       "]";
     render() {
-      const { tooltip, ...props } = this.props;
+      const { tooltip, targetOffsetX, ...props } = this.props;
       if (tooltip) {
         return (
-          <Tooltip tooltip={tooltip}>
+          <Tooltip tooltip={tooltip} targetOffsetX={targetOffsetX}>
             <ComposedComponent {...props} />
           </Tooltip>
         );

--- a/frontend/src/metabase/query_builder/components/saved-question-picker/utils.js
+++ b/frontend/src/metabase/query_builder/components/saved-question-picker/utils.js
@@ -4,17 +4,13 @@ export function buildCollectionTree(collections) {
   if (collections == null) {
     return [];
   }
-  return collections.map(collection => {
-    const icon = getCollectionIcon(collection);
-    return {
-      id: collection.id,
-      name: collection.name,
-      schemaName: collection.originalName || collection.name,
-      icon: icon.name,
-      iconColor: icon.color,
-      children: buildCollectionTree(collection.children),
-    };
-  });
+  return collections.map(collection => ({
+    id: collection.id,
+    name: collection.name,
+    schemaName: collection.originalName || collection.name,
+    icon: getCollectionIcon(collection),
+    children: buildCollectionTree(collection.children),
+  }));
 }
 
 export const findCollectionByName = (collections, name) => {

--- a/frontend/src/metabase/questions/components/CollectionBadge.jsx
+++ b/frontend/src/metabase/questions/components/CollectionBadge.jsx
@@ -12,6 +12,15 @@ const propTypes = {
   className: PropTypes.string,
 };
 
+const IRREGULAR_ICON_WIDTH = 14;
+const IRREGULAR_ICON_PROPS = {
+  width: IRREGULAR_ICON_WIDTH,
+  height: 16,
+
+  // Workaround: if a CollectionBadge icon has a tooltip, the default offset x is incorrect
+  targetOffsetX: IRREGULAR_ICON_WIDTH,
+};
+
 function CollectionBadge({ collection, analyticsContext, className }) {
   if (!collection) {
     return null;
@@ -19,7 +28,7 @@ function CollectionBadge({ collection, analyticsContext, className }) {
   const isRegular = PLUGIN_COLLECTIONS.isRegularCollection(collection);
   const icon = {
     ...collection.getIcon(),
-    ...(isRegular ? { size: 12 } : { width: 14, height: 16 }),
+    ...(isRegular ? { size: 12 } : IRREGULAR_ICON_PROPS),
   };
   return (
     <Badge

--- a/frontend/src/metabase/search/components/SearchResult.info.js
+++ b/frontend/src/metabase/search/components/SearchResult.info.js
@@ -14,6 +14,7 @@ const COLLECTION_EXAMPLE = {
   getIcon: () => ({ name: "folder" }),
   getUrl: () => DEMO_URL,
   getCollection: () => {},
+  collection: {},
 };
 
 const DASHBOARD_EXAMPLE = {

--- a/frontend/src/metabase/search/components/SearchResult.jsx
+++ b/frontend/src/metabase/search/components/SearchResult.jsx
@@ -113,7 +113,7 @@ function CollectionIcon({ item }) {
     iconProps.width = 20;
     iconProps.height = 24;
   }
-  return <Icon {...iconProps} />;
+  return <Icon {...iconProps} tooltip={null} />;
 }
 
 const ModelIconComponentMap = {

--- a/frontend/src/metabase/search/components/SearchResult.jsx
+++ b/frontend/src/metabase/search/components/SearchResult.jsx
@@ -215,13 +215,21 @@ function contextText(context) {
   });
 }
 
+function getCollectionInfoText(collection) {
+  if (PLUGIN_COLLECTIONS.isRegularCollection(collection)) {
+    return t`Collection`;
+  }
+  const level = PLUGIN_COLLECTIONS.AUTHORITY_LEVEL[collection.authority_level];
+  return `${level.name} ${t`Collection`}`;
+}
+
 function InfoText({ result }) {
   const collection = result.getCollection();
   switch (result.model) {
     case "card":
       return jt`Saved question in ${formatCollection(collection)}`;
     case "collection":
-      return t`Collection`;
+      return getCollectionInfoText(result.collection);
     case "database":
       return t`Database`;
     case "table":

--- a/frontend/src/metabase/search/components/SearchResult.jsx
+++ b/frontend/src/metabase/search/components/SearchResult.jsx
@@ -106,7 +106,7 @@ function TableIcon() {
 
 function CollectionIcon({ item }) {
   const iconProps = { ...item.getIcon() };
-  const isRegular = PLUGIN_COLLECTIONS.isRegularCollection(item);
+  const isRegular = PLUGIN_COLLECTIONS.isRegularCollection(item.collection);
   if (isRegular) {
     iconProps.size = DEFAULT_ICON_SIZE;
   } else {

--- a/frontend/src/metabase/search/components/SearchResult.unit.spec.js
+++ b/frontend/src/metabase/search/components/SearchResult.unit.spec.js
@@ -1,0 +1,95 @@
+/* eslint-disable react/prop-types */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { PLUGIN_COLLECTIONS } from "metabase/plugins";
+import SearchResult from "./SearchResult";
+
+function collection({
+  id = 1,
+  name = "Marketing",
+  authority_level = null,
+  getIcon = () => ({ name: "folder" }),
+  getUrl = () => `/collection/${id}`,
+  getCollection = () => {},
+} = {}) {
+  const collection = {
+    id,
+    name,
+    authority_level,
+    getIcon,
+    getUrl,
+    getCollection,
+    model: "collection",
+  };
+  collection.collection = collection;
+  return collection;
+}
+
+describe("SearchResult > Collections", () => {
+  const regularCollection = collection();
+
+  describe("OSS", () => {
+    const officialCollection = collection({
+      authority_level: "official",
+    });
+
+    it("renders regular collection correctly", () => {
+      render(<SearchResult result={regularCollection} />);
+      expect(screen.queryByText(regularCollection.name)).toBeInTheDocument();
+      expect(screen.queryByText("Collection")).toBeInTheDocument();
+      expect(screen.queryByLabelText("folder icon")).toBeInTheDocument();
+      expect(screen.queryByLabelText("badge icon")).toBeNull();
+    });
+
+    it("renders official collections as regular", () => {
+      render(<SearchResult result={officialCollection} />);
+      expect(screen.queryByText(regularCollection.name)).toBeInTheDocument();
+      expect(screen.queryByText("Collection")).toBeInTheDocument();
+      expect(screen.queryByLabelText("folder icon")).toBeInTheDocument();
+      expect(screen.queryByLabelText("badge icon")).toBeNull();
+    });
+  });
+
+  describe("EE", () => {
+    const officialCollection = collection({
+      authority_level: "official",
+      getIcon: () => ({ name: "badge" }),
+    });
+
+    const ORIGINAL_COLLECTIONS_PLUGIN = { ...PLUGIN_COLLECTIONS };
+
+    beforeAll(() => {
+      PLUGIN_COLLECTIONS.isRegularCollection = c => !c.authority_level;
+      PLUGIN_COLLECTIONS.AUTHORITY_LEVEL = {
+        ...ORIGINAL_COLLECTIONS_PLUGIN.AUTHORITY_LEVEL,
+        official: {
+          name: "Official",
+          icon: "badge",
+        },
+      };
+    });
+
+    afterAll(() => {
+      PLUGIN_COLLECTIONS.isRegularCollection =
+        ORIGINAL_COLLECTIONS_PLUGIN.isRegularCollection;
+      PLUGIN_COLLECTIONS.AUTHORITY_LEVEL =
+        ORIGINAL_COLLECTIONS_PLUGIN.AUTHORITY_LEVEL;
+    });
+
+    it("renders regular collection correctly", () => {
+      render(<SearchResult result={regularCollection} />);
+      expect(screen.queryByText(regularCollection.name)).toBeInTheDocument();
+      expect(screen.queryByText("Collection")).toBeInTheDocument();
+      expect(screen.queryByLabelText("folder icon")).toBeInTheDocument();
+      expect(screen.queryByLabelText("badge icon")).toBeNull();
+    });
+
+    it("renders official collections correctly", () => {
+      render(<SearchResult result={officialCollection} />);
+      expect(screen.queryByText(regularCollection.name)).toBeInTheDocument();
+      expect(screen.queryByText("Official Collection")).toBeInTheDocument();
+      expect(screen.queryByLabelText("badge icon")).toBeInTheDocument();
+      expect(screen.queryByLabelText("folder icon")).toBeNull();
+    });
+  });
+});

--- a/frontend/src/metabase/visualizations/components/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization.jsx
@@ -68,6 +68,7 @@ type Props = {
     name: string,
     color?: string,
     size?: Number,
+    tooltip?: string,
   },
 
   actionButtons: React.Element<any>,

--- a/frontend/test/metabase/entities/collections/getCollectionIcon.unit.spec.js
+++ b/frontend/test/metabase/entities/collections/getCollectionIcon.unit.spec.js
@@ -1,13 +1,15 @@
+import { PLUGIN_COLLECTIONS } from "metabase/plugins";
 import {
   getCollectionIcon,
   ROOT_COLLECTION,
   PERSONAL_COLLECTIONS as ALL_PERSONAL_COLLECTIONS_VIRTUAL,
 } from "metabase/entities/collections";
 
-// NOTE: getCollectionIcon behaves differently in EE
-// e.g. it should not return 'folder' for official collections
-
 describe("getCollectionIcon", () => {
+  const ORIGINAL_AUTHORITY_LEVELS = {
+    ...PLUGIN_COLLECTIONS.AUTHORITY_LEVEL,
+  };
+
   function collection({
     id = 10,
     personal_owner_id = null,
@@ -20,7 +22,7 @@ describe("getCollectionIcon", () => {
     };
   }
 
-  const testCases = [
+  const commonTestCases = [
     {
       name: "Our analytics",
       collection: ROOT_COLLECTION,
@@ -41,18 +43,64 @@ describe("getCollectionIcon", () => {
       collection: collection({ personal_owner_id: 4 }),
       expectedIcon: "person",
     },
+  ];
+
+  const OFFICIAL_COLLECTION = collection({ authority_level: "official" });
+
+  const testCasesOSS = [
+    ...commonTestCases,
     {
       name: "Official collection",
-      collection: collection({ authority_level: "official" }),
+      collection: OFFICIAL_COLLECTION,
       expectedIcon: "folder",
     },
   ];
 
-  testCases.forEach(testCase => {
-    const { name, collection, expectedIcon } = testCase;
-    it(`returns '${expectedIcon}' for '${name}'`, () => {
-      expect(getCollectionIcon(collection)).toMatchObject({
-        name: expectedIcon,
+  const testCasesEE = [
+    ...commonTestCases,
+    {
+      name: "Official collection",
+      collection: OFFICIAL_COLLECTION,
+      expectedIcon: "badge",
+    },
+  ];
+
+  describe("OSS", () => {
+    testCasesOSS.forEach(testCase => {
+      const { name, collection, expectedIcon } = testCase;
+      it(`returns '${expectedIcon}' for '${name}'`, () => {
+        expect(getCollectionIcon(collection)).toMatchObject({
+          name: expectedIcon,
+        });
+      });
+    });
+  });
+
+  describe("EE", () => {
+    beforeEach(() => {
+      PLUGIN_COLLECTIONS.AUTHORITY_LEVEL = {
+        ...ORIGINAL_AUTHORITY_LEVELS,
+        official: {
+          type: "official",
+          icon: "badge",
+          color: "yellow",
+          tooltips: {
+            default: "Official Collection",
+          },
+        },
+      };
+    });
+
+    afterEach(() => {
+      PLUGIN_COLLECTIONS.AUTHORITY_LEVEL = ORIGINAL_AUTHORITY_LEVELS;
+    });
+
+    testCasesEE.forEach(testCase => {
+      const { name, collection, expectedIcon } = testCase;
+      it(`returns '${expectedIcon}' for '${name}'`, () => {
+        expect(getCollectionIcon(collection)).toMatchObject({
+          name: expectedIcon,
+        });
       });
     });
   });


### PR DESCRIPTION
This PR adds a tooltip to any official collection's "ribbon" icon in Metabase.

### To Verify

1. Spin up Metabase Enterprise and sign in as admin
2. Go through #17125 steps, hover "ribbon" icons, you should see "Official collection" tooltips
3. Go through #17167 steps, hover "ribbon" icons, you should see "Belongs to an Official collection" tooltips

### Demo

<img width="566" alt="CleanShot 2021-08-13 at 22 12 04@2x" src="https://user-images.githubusercontent.com/17258145/129407732-57f490e6-0f80-4c97-a99e-af859330e6c8.png">

Slightly different text in the tooltip for a card from an official collection included in an unofficial dashboard:

![CleanShot 2021-08-13 at 22 13 15@2x](https://user-images.githubusercontent.com/17258145/129407893-7345b183-d252-476c-912e-1a79ad797e69.png)
