### PR TITLE
codecov config: enable carryforward

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -37,8 +37,10 @@ flags:
       - enterprise/backend
       - shared/src
       - src/metabase
+    carryforward: true
 
   front-end:
     paths:
       - enterprise/frontend
       - frontend
+    carryforward: true


### PR DESCRIPTION
With flags, and potentially not all coverage info will be submitted on
every commit, it seems that carryforward is necessary.

https://docs.codecov.com/docs/carryforward-flags
