### PR TITLE
don't prefetch data for the data selector

### DIFF
--- a/frontend/src/metabase/new_query/containers/NewQueryOptions.jsx
+++ b/frontend/src/metabase/new_query/containers/NewQueryOptions.jsx
@@ -21,15 +21,11 @@ import {
   getHasNativeWrite,
 } from "metabase/new_query/selectors";
 
-import Database from "metabase/entities/databases";
-
 import type { NestedObjectKey } from "metabase/visualizations/lib/settings/nested";
 
 type Props = {
   hasDataAccess: Boolean,
   hasNativeWrite: Boolean,
-  prefetchTables: any,
-  prefetchDatabases: any,
   initialKey?: NestedObjectKey,
 };
 
@@ -39,8 +35,6 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = {
-  prefetchTables: () => Database.actions.fetchList({ include: "tables" }),
-  prefetchDatabases: () => Database.actions.fetchList({ saved: true }),
   push,
 };
 
@@ -55,8 +49,6 @@ export default class NewQueryOptions extends Component {
   props: Props;
 
   UNSAFE_componentWillMount(props) {
-    this.props.prefetchTables();
-    this.props.prefetchDatabases();
     const { location, push } = this.props;
     if (Object.keys(location.query).length > 0) {
       const { database, table, ...options } = location.query;

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -319,10 +319,6 @@ export const initializeQB = (location, params) => {
     dispatch(resetQB());
     dispatch(cancelQuery());
 
-    // preload metadata that's used in DataSelector
-    dispatch(Databases.actions.fetchList({ include: "tables" }));
-    dispatch(Databases.actions.fetchList({ saved: true }));
-
     const { currentUser } = getState();
 
     const cardId = Urls.extractEntityId(params.slug);

--- a/frontend/test/metabase-db/mongo/query.cy.spec.js
+++ b/frontend/test/metabase-db/mongo/query.cy.spec.js
@@ -97,6 +97,9 @@ function writeNativeMongoQuery() {
   cy.findByText("Native query").click();
   cy.findByText(MONGO_DB_NAME).click();
 
+  cy.findByText("Select a table").click();
+  cy.findByText("Orders").click();
+
   cy.get(".ace_content").type(`[ { $count: "Total" } ]`, {
     parseSpecialCharSequences: false,
   });

--- a/frontend/test/metabase/scenarios/question/loading.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/loading.cy.spec.js
@@ -6,29 +6,7 @@ describe("scenarios > question > loading behavior", () => {
     cy.signInAsAdmin();
   });
 
-  it("should preload tables on the new question page", () => {
-    cy.server();
-    cy.visit("/question/new");
-
-    cy.route({ url: "/api/database?include=tables" }).as("preload1");
-    cy.route({ url: "/api/database?saved=true" }).as("preload2");
-    cy.route({ url: "/api/database/1/schemas" }).as("fetch1");
-    cy.route({ url: "/api/database/1/schema/PUBLIC" }).as("fetch2");
-
-    // preload calls should have already happened before picking question type
-    cy.wait("@preload1");
-    cy.wait("@preload2");
-
-    cy.contains("Simple question").click();
-    cy.contains("Sample Dataset").click();
-    cy.contains("Orders");
-
-    // confirm that neither fetch happened after seeing data in UI
-    cy.get("@fetch1").should("not.exist");
-    cy.get("@fetch2").should("not.exist");
-  });
-
-  it("should incrementally load data if not preloaded", () => {
+  it("should incrementally load data", () => {
     cy.server();
     // stub out the preload call to fetch all tables
     cy.route({


### PR DESCRIPTION
Related to #11806 

We prefetch some data in order to populate the data selector on `/question/new` faster, but as mentioned in #11806 this does not scale well with instances that have thousands of tables -- the `/api/database?include=tables` call balloons to several megabytes and can freeze the application and browser.

We're going to remove the prefetch calls to see how things feel on `master` without them. If the data selector feels slow, we can probably add conditional prefetching for smaller instances using some heuristics of the instance.