### PR TITLE
Avoid prop shorthand in the navbar

### DIFF
--- a/frontend/src/metabase/nav/containers/Navbar.jsx
+++ b/frontend/src/metabase/nav/containers/Navbar.jsx
@@ -216,7 +216,7 @@ export default class Navbar extends Component {
           </Link>
         </Flex>
         <Flex className="flex-full z1" pr={2} align="center">
-          <Box w={1} style={{ maxWidth: 500 }}>
+          <Box width={1} style={{ maxWidth: 512 }}>
             <SearchBar
               location={this.props.location}
               onChangeLocation={this.props.onChangeLocation}


### PR DESCRIPTION
This one is easy, just pay attention to the following container:

![image](https://user-images.githubusercontent.com/7288/129430958-81f23ab3-73ef-450b-b814-c2c3560aa78b.png)

Before and after this change, it should look **exactly** the same.
