### PR TITLE
refactor/move parameter object transformations to one place

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/sharing/components/MutableParametersSection.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/sharing/components/MutableParametersSection.jsx
@@ -10,7 +10,7 @@ import { t } from "ttag";
 import CollapseSection from "metabase/components/CollapseSection";
 import ParametersList from "metabase/parameters/components/ParametersList";
 
-import { collateParametersWithValues } from "metabase/meta/Parameter";
+import { getValuePopulatedParameters } from "metabase/meta/Parameter";
 import {
   getPulseParameters,
   getActivePulseParameters,
@@ -31,7 +31,7 @@ function MutableParametersSection({
     return map;
   }, {});
 
-  const collatedParameters = collateParametersWithValues(
+  const valuePopulatedParameters = getValuePopulatedParameters(
     parameters,
     pulseParamValuesById,
   );
@@ -63,7 +63,7 @@ function MutableParametersSection({
         className="align-stretch row-gap-1"
         vertical
         dashboard={dashboard}
-        parameters={collatedParameters}
+        parameters={valuePopulatedParameters}
         setParameterValue={setParameterValue}
       />
     </CollapseSection>

--- a/frontend/src/metabase-lib/lib/Question.js
+++ b/frontend/src/metabase-lib/lib/Question.js
@@ -35,7 +35,10 @@ import {
   findColumnIndexForColumnSetting,
   syncTableColumnsToQuery,
 } from "metabase/lib/dataset";
-import { getParametersWithExtras, isTransientId } from "metabase/meta/Card";
+import {
+  getValueAndFieldIdPopulatedParametersFromCard,
+  isTransientId,
+} from "metabase/meta/Card";
 import {
   parameterToMBQLFilter,
   normalizeParameterValue,
@@ -969,7 +972,10 @@ export default class Question {
 
   // TODO: Fix incorrect Flow signature
   parameters(): ParameterObject[] {
-    return getParametersWithExtras(this.card(), this._parameterValues);
+    return getValueAndFieldIdPopulatedParametersFromCard(
+      this.card(),
+      this._parameterValues,
+    );
   }
 
   parametersList(): ParameterObject[] {

--- a/frontend/src/metabase/dashboard/components/DashCard.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard.jsx
@@ -29,7 +29,7 @@ import { getClickBehaviorDescription } from "metabase/lib/click-behavior";
 import cx from "classnames";
 import _ from "underscore";
 import { getIn } from "icepick";
-import { getParametersBySlug } from "metabase/meta/Parameter";
+import { getParameterValuesBySlug } from "metabase/meta/Parameter";
 import Utils from "metabase/lib/utils";
 
 const DATASET_USUALLY_FAST_THRESHOLD = 15 * 1000;
@@ -159,7 +159,10 @@ export default class DashCard extends Component {
       errorIcon = "warning";
     }
 
-    const params = getParametersBySlug(dashboard.parameters, parameterValues);
+    const parameterValuesBySlug = getParameterValuesBySlug(
+      dashboard.parameters,
+      parameterValues,
+    );
 
     const hideBackground =
       !isEditing &&
@@ -217,7 +220,7 @@ export default class DashCard extends Component {
           isDashboard
           dispatch={this.props.dispatch}
           dashboard={dashboard}
-          parameterValuesBySlug={params}
+          parameterValuesBySlug={parameterValuesBySlug}
           isEditing={isEditing}
           isPreviewing={this.state.isPreviewingCard}
           gridSize={
@@ -231,7 +234,7 @@ export default class DashCard extends Component {
                 className="m1 text-brand-hover text-light"
                 classNameClose="hover-child"
                 card={dashcard.card}
-                params={params}
+                params={parameterValuesBySlug}
                 dashcardId={dashcard.id}
                 token={dashcard.dashboard_id}
                 icon="download"

--- a/frontend/src/metabase/dashboard/components/Dashboard/ParametersWidget/ParametersWidget.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/ParametersWidget/ParametersWidget.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 
+import { getValuePopulatedParameters } from "metabase/meta/Parameter";
 import Parameters from "metabase/parameters/components/Parameters/Parameters";
 
 const propTypes = {
@@ -46,10 +47,7 @@ const ParametersWidget = ({
       isFullscreen={isFullscreen}
       isNightMode={shouldRenderAsNightMode}
       hideParameters={hideParameters}
-      parameters={parameters.map(p => ({
-        ...p,
-        value: parameterValues[p.id],
-      }))}
+      parameters={getValuePopulatedParameters(parameters, parameterValues)}
       query={location.query}
       editingParameter={editingParameter}
       setEditingParameter={setEditingParameter}

--- a/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx
+++ b/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx
@@ -8,6 +8,7 @@ import cx from "classnames";
 import title from "metabase/hoc/Title";
 import withToast from "metabase/hoc/Toast";
 import DashboardData from "metabase/dashboard/hoc/DashboardData";
+import { getValuePopulatedParameters } from "metabase/meta/Parameter";
 
 import ActionButton from "metabase/components/ActionButton";
 import Button from "metabase/components/Button";
@@ -144,10 +145,10 @@ class AutomaticDashboardApp extends React.Component {
             {parameters && parameters.length > 0 && (
               <div className="px1 pt1">
                 <Parameters
-                  parameters={parameters.map(p => ({
-                    ...p,
-                    value: parameterValues && parameterValues[p.id],
-                  }))}
+                  parameters={getValuePopulatedParameters(
+                    parameters,
+                    parameterValues,
+                  )}
                   query={location.query}
                   setParameterValue={setParameterValue}
                   syncQueryString

--- a/frontend/src/metabase/dashboard/dashboard.js
+++ b/frontend/src/metabase/dashboard/dashboard.js
@@ -666,7 +666,6 @@ function expandInlineCard(card) {
 export const fetchDashboard = createThunkAction(FETCH_DASHBOARD, function(
   dashId,
   queryParams,
-  enableDefaultParameters = true,
 ) {
   let result;
   return async function(dispatch, getState) {

--- a/frontend/src/metabase/lib/pulse.js
+++ b/frontend/src/metabase/lib/pulse.js
@@ -136,7 +136,7 @@ export function getActivePulseParameters(pulse, parameters) {
 
       return {
         ...parameter,
-        value: hasParameterValue(pulseParameter)
+        value: hasParameterValue(pulseParameter?.value)
           ? pulseParameter.value
           : parameter.default,
       };

--- a/frontend/src/metabase/meta/Card.js
+++ b/frontend/src/metabase/meta/Card.js
@@ -3,6 +3,7 @@ import {
   getParameterTargetFieldId,
   parameterToMBQLFilter,
   normalizeParameterValue,
+  getValuePopulatedParameters,
 } from "metabase/meta/Parameter";
 
 import * as Query from "metabase/lib/query/query";
@@ -125,7 +126,7 @@ export function getTemplateTagsForParameters(card: ?Card): Array<TemplateTag> {
   );
 }
 
-export function getParameters(card: ?Card): Parameter[] {
+export function getParametersFromCard(card: ?Card): Parameter[] {
   if (card && card.parameters) {
     return card.parameters;
   }
@@ -134,15 +135,17 @@ export function getParameters(card: ?Card): Parameter[] {
   return getTemplateTagParameters(tags);
 }
 
-export function getParametersWithExtras(
+export function getValueAndFieldIdPopulatedParametersFromCard(
   card: Card,
   parameterValues?: ParameterValues,
 ): Parameter[] {
-  return getParameters(card).map(parameter => {
-    // if we have a parameter value for this parameter, set "value"
-    if (parameterValues && parameter.id in parameterValues) {
-      parameter = assoc(parameter, "value", parameterValues[parameter.id]);
-    }
+  const parameters = getParametersFromCard(card);
+  const valuePopulatedParameters = getValuePopulatedParameters(
+    parameters,
+    parameterValues,
+  );
+
+  return valuePopulatedParameters.map(parameter => {
     // if we have a field id for this parameter, set "field_id"
     const fieldId = getParameterTargetFieldId(
       parameter.target,
@@ -232,7 +235,7 @@ export function questionUrlWithParameters(
 
   card = Utils.copy(card);
 
-  const cardParameters = getParameters(card);
+  const cardParameters = getParametersFromCard(card);
   const datasetQuery = applyParameters(
     card,
     parameters,

--- a/frontend/src/metabase/meta/Parameter.js
+++ b/frontend/src/metabase/meta/Parameter.js
@@ -622,14 +622,16 @@ export function hasDefaultParameterValue(parameter) {
   return parameter.default != null;
 }
 
-export function hasParameterValue(parameter) {
-  return parameter && parameter.value != null;
+export function hasParameterValue(value) {
+  return value != null;
 }
 
 export function getParameterValueFromQueryParams(parameter, queryParams) {
   queryParams = queryParams || {};
   const maybeParameterValue = queryParams[parameter.slug];
-  return maybeParameterValue == null ? parameter.default : maybeParameterValue;
+  return hasParameterValue(maybeParameterValue)
+    ? maybeParameterValue
+    : parameter.default;
 }
 
 export function getParameterValuePairsFromQueryParams(parameters, queryParams) {
@@ -638,7 +640,7 @@ export function getParameterValuePairsFromQueryParams(parameters, queryParams) {
       parameter,
       getParameterValueFromQueryParams(parameter, queryParams),
     ])
-    .filter(([, value]) => value != null);
+    .filter(([, value]) => hasParameterValue(value));
 }
 
 export function getParameterValuesByIdFromQueryParams(parameters, queryParams) {
@@ -657,7 +659,7 @@ export function getParameterValuesBySlug(parameters, parameterValuesById) {
       parameter.slug,
       parameter.value || parameterValuesById[parameter.id],
     ])
-    .filter(([, value]) => value != null);
+    .filter(([, value]) => hasParameterValue(value));
 
   return Object.fromEntries(slugValuePairs);
 }

--- a/frontend/src/metabase/parameters/components/Parameters/Parameters.jsx
+++ b/frontend/src/metabase/parameters/components/Parameters/Parameters.jsx
@@ -5,7 +5,7 @@ import querystring from "querystring";
 
 import ParametersList from "metabase/parameters/components/ParametersList";
 import { syncQueryParamsWithURL } from "./syncQueryParamsWithURL";
-import { collateParametersWithValues } from "metabase/meta/Parameter";
+import { getParameterValuesBySlug } from "metabase/meta/Parameter";
 import { getMetadata } from "metabase/selectors/metadata";
 
 @connect(state => ({ metadata: getMetadata(state) }))
@@ -25,17 +25,12 @@ export default class Parameters extends Component {
 
     if (this.props.syncQueryString) {
       // sync parameters to URL query string
-      const queryParams = {};
-      for (const parameter of collateParametersWithValues(
+      const parameterValuesBySlug = getParameterValuesBySlug(
         parameters,
         parameterValues,
-      )) {
-        if (parameter.value) {
-          queryParams[parameter.slug] = parameter.value;
-        }
-      }
+      );
 
-      let search = querystring.stringify(queryParams);
+      let search = querystring.stringify(parameterValuesBySlug);
       search = search ? "?" + search : "";
 
       if (search !== window.location.search) {

--- a/frontend/src/metabase/parameters/components/Parameters/syncQueryParamsWithURL.js
+++ b/frontend/src/metabase/parameters/components/Parameters/syncQueryParamsWithURL.js
@@ -2,6 +2,7 @@ import Dimension from "metabase-lib/lib/Dimension";
 import {
   getParameterValueFromQueryParams,
   getParameterValuePairsFromQueryParams,
+  hasParameterValue,
 } from "metabase/meta/Parameter";
 
 export const syncQueryParamsWithURL = props => {
@@ -20,7 +21,7 @@ const syncForInternalQuestion = props => {
   parameters.forEach(parameter => {
     const parameterValue = getParameterValueFromQueryParams(parameter, query);
 
-    if (parameterValue != null) {
+    if (hasParameterValue(parameterValue)) {
       const parsedParameterValue = parseQueryParams(
         parameterValue,
         parameter,

--- a/frontend/src/metabase/parameters/components/ParametersList.jsx
+++ b/frontend/src/metabase/parameters/components/ParametersList.jsx
@@ -9,7 +9,10 @@ import cx from "classnames";
 
 import StaticParameterWidget from "./ParameterWidget";
 import Icon from "metabase/components/Icon";
-import { collateParametersWithValues } from "metabase/meta/Parameter";
+import {
+  getValuePopulatedParameters,
+  getVisibleParameters,
+} from "metabase/meta/Parameter";
 
 import type {
   ParameterId,
@@ -105,13 +108,14 @@ function ParametersList({
     }
   };
 
-  const hiddenParameters =
-    typeof hideParameters === "string"
-      ? new Set(hideParameters.split(","))
-      : new Set();
-  const collatedParameters = collateParametersWithValues(
+  const valuePopulatedParameters = getValuePopulatedParameters(
     parameters,
     parameterValues,
+  );
+
+  const visibleValuePopulatedParameters = getVisibleParameters(
+    valuePopulatedParameters,
+    hideParameters,
   );
 
   let ParameterWidget;
@@ -137,41 +141,42 @@ function ParametersList({
       onSortStart={handleSortStart}
       onSortEnd={handleSortEnd}
     >
-      {collatedParameters
-        .filter(p => !hiddenParameters.has(p.slug))
-        .map((parameter, index) => (
-          <ParameterWidget
-            key={parameter.id}
-            className={cx({ mb2: vertical })}
-            isEditing={isEditing}
-            isFullscreen={isFullscreen}
-            isNightMode={isNightMode}
-            parameter={parameter}
-            parameters={collatedParameters}
-            dashboard={dashboard}
-            editingParameter={editingParameter}
-            setEditingParameter={setEditingParameter}
-            index={index}
-            setName={
-              setParameterName && (name => setParameterName(parameter.id, name))
-            }
-            setValue={
-              setParameterValue &&
-              (value => setParameterValue(parameter.id, value))
-            }
-            setDefaultValue={
-              setParameterDefaultValue &&
-              (value => setParameterDefaultValue(parameter.id, value))
-            }
-            remove={removeParameter && (() => removeParameter(parameter.id))}
-            commitImmediately={commitImmediately}
-            dragHandle={
-              isEditing && setParameterIndex ? (
-                <SortableParameterHandle />
-              ) : null
-            }
-          />
-        ))}
+      {visibleValuePopulatedParameters.map((valuePopulatedParameter, index) => (
+        <ParameterWidget
+          key={valuePopulatedParameter.id}
+          className={cx({ mb2: vertical })}
+          isEditing={isEditing}
+          isFullscreen={isFullscreen}
+          isNightMode={isNightMode}
+          parameter={valuePopulatedParameter}
+          parameters={valuePopulatedParameters}
+          dashboard={dashboard}
+          editingParameter={editingParameter}
+          setEditingParameter={setEditingParameter}
+          index={index}
+          setName={
+            setParameterName &&
+            (name => setParameterName(valuePopulatedParameter.id, name))
+          }
+          setValue={
+            setParameterValue &&
+            (value => setParameterValue(valuePopulatedParameter.id, value))
+          }
+          setDefaultValue={
+            setParameterDefaultValue &&
+            (value =>
+              setParameterDefaultValue(valuePopulatedParameter.id, value))
+          }
+          remove={
+            removeParameter &&
+            (() => removeParameter(valuePopulatedParameter.id))
+          }
+          commitImmediately={commitImmediately}
+          dragHandle={
+            isEditing && setParameterIndex ? <SortableParameterHandle /> : null
+          }
+        />
+      ))}
     </ParameterWidgetList>
   );
 }

--- a/frontend/src/metabase/public/components/EmbedFrame.jsx
+++ b/frontend/src/metabase/public/components/EmbedFrame.jsx
@@ -5,6 +5,7 @@ import { IFRAMED, initializeIframeResizer } from "metabase/lib/dom";
 import { parseHashOptions } from "metabase/lib/browser";
 
 import MetabaseSettings from "metabase/lib/settings";
+import { getValuePopulatedParameters } from "metabase/meta/Parameter";
 
 import TitleAndDescription from "metabase/components/TitleAndDescription";
 import Parameters from "metabase/parameters/components/Parameters/Parameters";
@@ -98,10 +99,10 @@ export default class EmbedFrame extends Component {
                 <div className="flex ml-auto">
                   <Parameters
                     dashboard={this.props.dashboard}
-                    parameters={parameters.map(p => ({
-                      ...p,
-                      value: parameterValues && parameterValues[p.id],
-                    }))}
+                    parameters={getValuePopulatedParameters(
+                      parameters,
+                      parameterValues,
+                    )}
                     query={location.query}
                     setParameterValue={setParameterValue}
                     setMultipleParameterValues={setMultipleParameterValues}

--- a/frontend/src/metabase/query_builder/containers/QuestionEmbedWidget.jsx
+++ b/frontend/src/metabase/query_builder/containers/QuestionEmbedWidget.jsx
@@ -12,7 +12,7 @@ import * as Urls from "metabase/lib/urls";
 import MetabaseSettings from "metabase/lib/settings";
 import MetabaseAnalytics from "metabase/lib/analytics";
 
-import { getParameters } from "metabase/meta/Card";
+import { getParametersFromCard } from "metabase/meta/Card";
 import {
   createPublicLink,
   deletePublicLink,
@@ -61,7 +61,7 @@ export default class QuestionEmbedWidget extends Component {
         className={className}
         resource={card}
         resourceType="question"
-        resourceParameters={getParameters(card)}
+        resourceParameters={getParametersFromCard(card)}
         onCreatePublicLink={() => createPublicLink(card)}
         onDisablePublicLink={() => deletePublicLink(card)}
         onUpdateEnableEmbedding={enableEmbedding =>

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -13,7 +13,7 @@ import {
   getVisualizationTransformed,
 } from "metabase/visualizations";
 import { getComputedSettingsForSeries } from "metabase/visualizations/lib/settings/visualization";
-import { getParametersWithExtras } from "metabase/meta/Card";
+import { getValueAndFieldIdPopulatedParametersFromCard } from "metabase/meta/Card";
 import { normalizeParameterValue } from "metabase/meta/Parameter";
 
 import Utils from "metabase/lib/utils";
@@ -118,7 +118,8 @@ export const getDatabaseFields = createSelector(
 
 export const getParameters = createSelector(
   [getCard, getParameterValues],
-  (card, parameterValues) => getParametersWithExtras(card, parameterValues),
+  (card, parameterValues) =>
+    getValueAndFieldIdPopulatedParametersFromCard(card, parameterValues),
 );
 
 const getLastRunDatasetQuery = createSelector(

--- a/frontend/test/metabase/meta/Parameter.unit.spec.js
+++ b/frontend/test/metabase/meta/Parameter.unit.spec.js
@@ -4,10 +4,16 @@ import {
   stringParameterValueToMBQL,
   numberParameterValueToMBQL,
   parameterOptionsForField,
-  getParametersBySlug,
   normalizeParameterValue,
   deriveFieldOperatorFromParameter,
   getTemplateTagParameters,
+  getValuePopulatedParameters,
+  getParameterValueFromQueryParams,
+  getParameterValuePairsFromQueryParams,
+  getParameterValuesByIdFromQueryParams,
+  getParameterValuesBySlug,
+  buildHiddenParametersSlugSet,
+  getVisibleParameters,
 } from "metabase/meta/Parameter";
 
 MetabaseSettings.get = jest.fn();
@@ -209,25 +215,6 @@ describe("metabase/meta/Parameter", () => {
         availableOptions.length > 0 &&
           availableOptions.every(option => option.type.startsWith("id")),
       ).toBe(true);
-    });
-  });
-
-  describe("getParameterBySlug", () => {
-    it("should return an object mapping slug to parameter value", () => {
-      const parameters = [
-        { id: "foo", slug: "bar" },
-        { id: "aaa", slug: "bbb" },
-        { id: "cat", slug: "dog" },
-      ];
-      const parameterValuesById = {
-        foo: 123,
-        aaa: "ccc",
-        something: true,
-      };
-      expect(getParametersBySlug(parameters, parameterValuesById)).toEqual({
-        bar: 123,
-        bbb: "ccc",
-      });
     });
   });
 
@@ -444,6 +431,227 @@ describe("metabase/meta/Parameter", () => {
         ];
         expect(getTemplateTagParameters(tags)).toEqual(parameters);
       });
+    });
+  });
+
+  describe("parameter collection-building utils", () => {
+    // found in queryParams and not defaulted
+    const parameter1 = {
+      id: 1,
+      slug: "foo",
+    };
+    // found in queryParams and defaulted
+    const parameter2 = {
+      id: 2,
+      slug: "bar",
+      default: "parameter2 default value",
+    };
+    // not found in queryParams and defaulted
+    const parameter3 = {
+      id: 3,
+      slug: "baz",
+      default: "parameter3 default value",
+    };
+    // not found in queryParams and not defaulted
+    const parameter4 = {
+      id: 4,
+      slug: "qux",
+    };
+    const parameters = [parameter1, parameter2, parameter3, parameter4];
+    const queryParams = {
+      foo: "parameter1 queryParam value",
+      bar: "parameter2 queryParam value",
+      valueNotFoundInParameters: "nonexistent parameter queryParam value",
+    };
+
+    const parameterValues = getParameterValuesByIdFromQueryParams(
+      parameters,
+      queryParams,
+    );
+
+    describe("getValuePopulatedParameters", () => {
+      it("should return an array of parameter objects with the `value` property set if it exists in the given `parameterValues` id, value map", () => {
+        expect(
+          getValuePopulatedParameters(parameters, {
+            [parameter1.id]: "parameter1 value",
+            [parameter2.id]: "parameter2 value",
+          }),
+        ).toEqual([
+          {
+            ...parameter1,
+            value: "parameter1 value",
+          },
+          {
+            ...parameter2,
+            value: "parameter2 value",
+          },
+          parameter3,
+          parameter4,
+        ]);
+      });
+
+      it("should handle there being an undefined or null parameterValues object", () => {
+        expect(getValuePopulatedParameters(parameters, undefined)).toEqual(
+          parameters,
+        );
+        expect(getValuePopulatedParameters(parameters, null)).toEqual(
+          parameters,
+        );
+      });
+    });
+
+    describe("getParameterValueFromQueryParams", () => {
+      it("should return undefined when given an undefined queryParams arg", () => {
+        expect(getParameterValueFromQueryParams(parameter1)).toBe(undefined);
+      });
+
+      it("should return the parameter's default value when given an undefined queryParams arg", () => {
+        expect(getParameterValueFromQueryParams(parameter2)).toBe(
+          "parameter2 default value",
+        );
+      });
+
+      it("should return the parameter's default value when the parameter value is not found in queryParams", () => {
+        expect(getParameterValueFromQueryParams(parameter3, queryParams)).toBe(
+          "parameter3 default value",
+        );
+      });
+
+      it("should return the parameter value found in the queryParams object", () => {
+        expect(getParameterValueFromQueryParams(parameter1, queryParams)).toBe(
+          "parameter1 queryParam value",
+        );
+      });
+
+      it("should ignore the parameter's default value when the parameter value is found in queryParams", () => {
+        expect(getParameterValueFromQueryParams(parameter2, queryParams)).toBe(
+          "parameter2 queryParam value",
+        );
+      });
+    });
+
+    describe("getParameterValuePairsFromQueryParams", () => {
+      it("should build a list of parameter and parameter value pairs", () => {
+        expect(
+          getParameterValuePairsFromQueryParams(parameters, queryParams),
+        ).toEqual([
+          [parameter1, "parameter1 queryParam value"],
+          [parameter2, "parameter2 queryParam value"],
+          [parameter3, "parameter3 default value"],
+        ]);
+      });
+
+      it("should handle undefined queryParams", () => {
+        expect(getParameterValuePairsFromQueryParams(parameters)).toEqual([
+          [parameter2, "parameter2 default value"],
+          [parameter3, "parameter3 default value"],
+        ]);
+      });
+    });
+
+    describe("getParameterValuesByIdFromQueryParams", () => {
+      it("should generate a map of parameter values found in the queryParams or with default values", () => {
+        expect(
+          getParameterValuesByIdFromQueryParams(parameters, queryParams),
+        ).toEqual({
+          [parameter1.id]: "parameter1 queryParam value",
+          [parameter2.id]: "parameter2 queryParam value",
+          [parameter3.id]: "parameter3 default value",
+        });
+      });
+
+      it("should handle an undefined queryParams", () => {
+        expect(getParameterValuesByIdFromQueryParams(parameters)).toEqual({
+          [parameter2.id]: "parameter2 default value",
+          [parameter3.id]: "parameter3 default value",
+        });
+      });
+    });
+
+    describe("getParameterValuesBySlug", () => {
+      it("should return a map of defined parameter values keyed by the parameter's slug", () => {
+        expect(getParameterValuesBySlug(parameters, parameterValues)).toEqual({
+          [parameter1.slug]: "parameter1 queryParam value",
+          [parameter2.slug]: "parameter2 queryParam value",
+          [parameter3.slug]: "parameter3 default value",
+        });
+      });
+
+      it("should prioritize values found on the parameter object over the parameterValues map", () => {
+        const valuePopulatedParameter1 = {
+          ...parameter1,
+          value: "parameter1 value prop",
+        };
+        const parameters = [valuePopulatedParameter1, parameter2];
+
+        expect(getParameterValuesBySlug(parameters, parameterValues)).toEqual({
+          [parameter1.slug]: "parameter1 value prop",
+          [parameter2.slug]: "parameter2 queryParam value",
+        });
+      });
+
+      it("should handle an undefined parameterValues map", () => {
+        expect(getParameterValuesBySlug(parameters, undefined)).toEqual({});
+        expect(
+          getParameterValuesBySlug([
+            {
+              ...parameter1,
+              value: "parameter1 value prop",
+            },
+          ]),
+        ).toEqual({
+          [parameter1.slug]: "parameter1 value prop",
+        });
+      });
+    });
+  });
+
+  describe("buildHiddenParametersSlugSet", () => {
+    it("should turn the given string of slugs separated by commas into a set of slug strings", () => {
+      expect(buildHiddenParametersSlugSet("a,b,c")).toEqual(
+        new Set(["a", "b", "c"]),
+      );
+    });
+
+    it("should return an empty set for any input that is not a string", () => {
+      expect(buildHiddenParametersSlugSet(undefined)).toEqual(new Set());
+      expect(buildHiddenParametersSlugSet(111111)).toEqual(new Set());
+    });
+  });
+
+  describe("getVisibleParameters", () => {
+    const parameters = [
+      {
+        id: 1,
+        slug: "foo",
+      },
+      {
+        id: 2,
+        slug: "bar",
+      },
+      {
+        id: 3,
+        slug: "baz",
+      },
+      {
+        id: 4,
+        slug: "qux",
+      },
+    ];
+
+    const hiddenParameterSlugs = "bar,baz";
+
+    it("should return the parameters that are not hidden", () => {
+      expect(getVisibleParameters(parameters, hiddenParameterSlugs)).toEqual([
+        {
+          id: 1,
+          slug: "foo",
+        },
+        {
+          id: 4,
+          slug: "qux",
+        },
+      ]);
     });
   });
 });


### PR DESCRIPTION
There are a lot of things about our parameters code that make it complex, one of them being the numerous transformations involved in creating lists of parameters, maps of parameter objects, query parameters, and so on. There's redundant logic for handling these transformations, and it is spread all over the place. In this PR I'm trying to centralize this logic in `metabase/meta/Parameter.js` without impacting what these data structures look like (... for the most part).

In addition to that, because I find Parameters code so hard to understand, I've tried to name the new functions in this PR super explicitly, and I've also renamed some existing functions to make them more explicit. For example, `getParametersWithExtras` is now `getValueAndFieldIdPopulatedParametersFromCard`.

I think in the long run staying very explicit about what functions and data transformations do will help us beat down the complexity of parameters.

There's plenty of additional work left to be done here...
- there's plenty of parameter transformation logic still left in pulses code and in `EmbedModalContent` and elsewhere that I'm not totally dealing with to avoid the added risk.
- the transformation functions I'm adding to `metabase/meta/Parameter.js` can definitely be improved upon. It'd be nice to handle parameter value transformations better but for now that code remains sort of scattered as well, in places like `metabase/parameters/components/Parameters/syncQueryParamsWithURL.js`.
- On the topic of `value` -- the presence of the property vs. and `undefined` property is handled differently in a few different places. Need to continue some digging on that.

This is a precursor to #13960 so that I can avoid spreading and duplicating more business logic -- hopefully I'll just need to tweak some things in `metabase/meta/Parameter.js` after this PR.