### PR TITLE
Fix propType warning for `RawMaybeLink`

### DIFF
--- a/frontend/src/metabase/components/Badge.styled.jsx
+++ b/frontend/src/metabase/components/Badge.styled.jsx
@@ -6,7 +6,7 @@ import Icon from "metabase/components/Icon";
 import Link from "metabase/components/Link";
 
 const propTypes = {
-  to: PropTypes.string,
+  to: PropTypes.oneOfType([PropTypes.string, PropTypes.boolean]),
 };
 
 function RawMaybeLink({ to, ...props }) {


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Fixes a wrong `propType` warning for `RawMaybeLink` component
- `to` prop was defined as a string, but it also resolves to `false`
    - I've updated the prop type to accept both `string` and `boolean`

### How to verify
- Ask new question
- Simple/Custom - doesn't matter
- Sample Dataset
- Choose any table
- Look at the console and search for "rawmaybe"

#### Before
![image](https://user-images.githubusercontent.com/31325167/129571358-acce7fde-1d7a-4880-9569-a3b0c63f7031.png)

#### After
There is no error

    