### PR TITLE
Avoid prop shorthand in _internal

### DIFF
--- a/frontend/src/metabase/internal/components/Example.jsx
+++ b/frontend/src/metabase/internal/components/Example.jsx
@@ -11,7 +11,7 @@ import Card from "metabase/components/Card";
 const Example = ({ children }) => {
   const code = reactElementToJSXString(children);
   return (
-    <Box my={3} w="100%">
+    <Box my={3} width={"100%"}>
       <Label color="medium">Example</Label>
       <Card>
         <Box p={2} className="border-bottom">

--- a/frontend/src/metabase/internal/pages/ModalsPage.jsx
+++ b/frontend/src/metabase/internal/pages/ModalsPage.jsx
@@ -7,7 +7,7 @@ import ModalContent from "metabase/components/ModalContent";
 import DeleteModalWithConfirm from "metabase/components/DeleteModalWithConfirm";
 
 const Section = ({ children }) => (
-  <Box className="bordered shadowed rounded" my={3} w={520}>
+  <Box className="bordered shadowed rounded" my={3} width={520}>
     {children}
   </Box>
 );


### PR DESCRIPTION
How to verify: go to `/_internal/type` and `/_internal/modals` and pay attention to the following containers:

![image](https://user-images.githubusercontent.com/7288/129590684-87d4f501-a571-446f-9b5a-8e1ed2d9a7a9.png)

![image](https://user-images.githubusercontent.com/7288/129590629-c85c921c-7484-4e13-9f84-a946a9b85c9e.png)

Before and after this change, each one should look **exactly** the same.