### PR TITLE
Change clj-kondo linter levels from :warn to :warning so it exits with nonzero status

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
@@ -55,7 +55,7 @@
                           (load/load-settings path context)
                           (load/load-dependencies path context)]
               reload-fns (filter fn? all-res)]
-          (when-not (empty? reload-fns)
+          (when (seq reload-fns)
             (log/info (trs "Finished first pass of load; now performing second pass"))
             (doseq [reload-fn reload-fns]
               (reload-fn)))

--- a/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
@@ -55,10 +55,10 @@
                           (load/load-settings path context)
                           (load/load-dependencies path context)]
               reload-fns (filter fn? all-res)]
-          (if-not (empty? reload-fns)
-            (do (log/info (trs "Finished first pass of load; now performing second pass"))
-                (doseq [reload-fn reload-fns]
-                  (reload-fn))))
+          (when-not (empty? reload-fns)
+            (log/info (trs "Finished first pass of load; now performing second pass"))
+            (doseq [reload-fn reload-fns]
+              (reload-fn)))
           (log/info (trs "END LOAD from {0} with context {1}" path context))))
       (catch Throwable e
         (log/error e (trs "ERROR LOAD from {0}: {1}" path (.getMessage e)))))))

--- a/enterprise/backend/src/metabase_enterprise/serialization/load.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/load.clj
@@ -193,8 +193,8 @@
    (unresolved-names->string entity nil))
   ([entity insert-id]
    (str
-    (if-let [nm (:name entity)] (str "\"" nm "\""))
-    (if insert-id (format " (inserted as ID %d) " insert-id))
+    (when-let [nm (:name entity)] (str "\"" nm "\""))
+    (when insert-id (format " (inserted as ID %d) " insert-id))
     "missing:\n  "
     (str/join
      "\n  "
@@ -346,17 +346,17 @@
   (-> (if-let [link-type (::mb.viz/link-type click-behavior)]
         (case link-type
           ::mb.viz/card (let [card-id (::mb.viz/link-target-id click-behavior)]
-                          (if (string? card-id)
+                          (when (string? card-id)
                             (update-existing-in-capture-missing
                              click-behavior
                              [::mb.viz/link-target-id]
                              (comp :card fully-qualified-name->context))))
           ::mb.viz/dashboard (let [dashboard-id (::mb.viz/link-target-id click-behavior)]
-                              (if (string? dashboard-id)
-                                (update-existing-in-capture-missing
-                                 click-behavior
-                                 [::mb.viz/link-target-id]
-                                 (comp :dashboard fully-qualified-name->context))))
+                               (when (string? dashboard-id)
+                                 (update-existing-in-capture-missing
+                                  click-behavior
+                                  [::mb.viz/link-target-id]
+                                  (comp :dashboard fully-qualified-name->context))))
           click-behavior)
         click-behavior)
       (m/update-existing ::mb.viz/parameter-mapping resolve-click-behavior-parameter-mapping)))
@@ -433,11 +433,11 @@
   {:added "0.40.0"}
   [context dashboards]
   (let [dashboard-ids   (maybe-upsert-many! context Dashboard
-                          (for [dashboard dashboards]
-                            (-> dashboard
-                                (dissoc :dashboard_cards)
-                                (assoc :collection_id (:collection context)
-                                       :creator_id    @default-user))))
+                                            (for [dashboard dashboards]
+                                              (-> dashboard
+                                                  (dissoc :dashboard_cards)
+                                                  (assoc :collection_id (:collection context)
+                                                         :creator_id    @default-user))))
         dashboard-cards (map :dashboard_cards dashboards)
         ;; a function that prepares a dash card for insertion, while also validating to ensure the underlying
         ;; card_id could be resolved from the fully qualified name
@@ -454,12 +454,12 @@
                               (let [add-keys         [:dashboard_cards card-idx :visualization_settings]
                                     fixed-names      (m/map-vals #(concat add-keys %) unresolved)
                                     with-fixed-names (assoc with-viz ::unresolved-names fixed-names)]
-                               (-> acc
-                                   (update ::revisit (fn [revisit-map]
-                                                       (update revisit-map dash-idx #(cons with-fixed-names %))))
-                                   ;; index means something different here than in the Card case (it's actually the index
-                                   ;; of the dashboard)
-                                   (update ::revisit-index #(conj % dash-idx))))
+                                (-> acc
+                                    (update ::revisit (fn [revisit-map]
+                                                        (update revisit-map dash-idx #(cons with-fixed-names %))))
+                                    ;; index means something different here than in the Card case (it's actually the index
+                                    ;; of the dashboard)
+                                    (update ::revisit-index #(conj % dash-idx))))
                               (update acc ::process #(conj % with-viz)))))
         prep-init-acc   {::process [] ::revisit-index #{} ::revisit {}}
         filtered-cards  (reduce-kv
@@ -475,14 +475,14 @@
         dashcard-ids    (maybe-upsert-many! context DashboardCard (map #(dissoc % :series) proceed-cards))
         series-pairs    (map vector (map :series proceed-cards) dashcard-ids)]
     (maybe-upsert-many! context DashboardCardSeries
-      (for [[series dashboard-card-id] series-pairs
-            dashboard-card-series      series
-            :when (and dashboard-card-series dashboard-card-id)]
-        (-> dashboard-card-series
-            (assoc :dashboardcard_id dashboard-card-id)
-            (update :card_id fully-qualified-name->card-id))))
+                        (for [[series dashboard-card-id] series-pairs
+                              dashboard-card-series      series
+                              :when (and dashboard-card-series dashboard-card-id)]
+                          (-> dashboard-card-series
+                              (assoc :dashboardcard_id dashboard-card-id)
+                              (update :card_id fully-qualified-name->card-id))))
     (let [revisit-dashboards (map (partial nth dashboards) revisit-indexes)]
-      (if-not (empty? revisit-dashboards)
+      (when (seq revisit-dashboards)
         (let [revisit-map    (::revisit filtered-cards)
               revisit-inf-fn (fn [[dash-idx dashcards]]
                                (format
@@ -532,7 +532,7 @@
             channel             channels
             :when pulse-id]
         (assoc channel :pulse_id pulse-id)))
-    (if-not (empty? revisit)
+    (when (seq revisit)
       (let [revisit-info-map (group-by ::pulse-name revisit)]
         (log/infof "Unresolved references for pulses in collection %s; will reload after first pass complete:%n%s%n"
                    (or (:collection context) "root")
@@ -649,7 +649,7 @@
      (for [card (slurp-many paths)] (resolve-card card (assoc context :mode :update)))
      touched-card-ids)
 
-    (if dummy-insert-cards
+    (when dummy-insert-cards
       (let [dummy-inserted-ids (maybe-upsert-many!
                                 context
                                 Card
@@ -686,7 +686,7 @@
 
 (defn- make-reload-fn [all-results]
   (let [all-fns (filter fn? all-results)]
-    (if-not (empty? all-fns)
+    (when (seq all-fns)
       (let [new-fns (doall all-fns)]
         (fn []
           (make-reload-fn (for [reload-fn new-fns]

--- a/enterprise/backend/src/metabase_enterprise/serialization/names.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/names.clj
@@ -72,7 +72,7 @@
   (str (->> segment :table_id (fully-qualified-name Table)) "/segments/" (safe-name segment)))
 
 (defn- local-collection-name [collection]
-  (let [ns-part (if-let [coll-ns (:namespace collection)]
+  (let [ns-part (when-let [coll-ns (:namespace collection)]
                   (str ":" (if (keyword? coll-ns) (name coll-ns) coll-ns) "/"))]
     (str "/collections/" ns-part (safe-name collection))))
 

--- a/lint-config.edn
+++ b/lint-config.edn
@@ -1,9 +1,19 @@
+;; Run clj-kondo with something like
+;;
+;;    clj-kondo --parallel --lint src/ shared/src enterprise/backend/src --config lint-config.edn
+;;
+;; To find the warnings that are actually causing the linter to fail:
+;;
+;;    clj-kondo ... | grep warning
+;;
+;; `:warn`    => Print a warning but don't fail
+;; `:warning` => Print a warning and DO fail
 ^:replace
-{:linters {:missing-else-branch          {:level :warn}
-           :misplaced-docstring          {:level :warn}
-           :missing-body-in-when         {:level :warn}
+{:linters {:missing-else-branch          {:level :warning}
+           :misplaced-docstring          {:level :warning}
+           :missing-body-in-when         {:level :warning}
            :missing-docstring            {:level :warning}
-           :refer-all                    {:level   :warn
+           :refer-all                    {:level   :warning
                                           :exclude [clojure.test]}
-           :unsorted-required-namespaces {:level :warn}
-           :use                          {:level :warn}}}
+           :unsorted-required-namespaces {:level :warning}
+           :use                          {:level :warning}}}

--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -5,7 +5,8 @@
             [compojure.core :as compojure]
             [honeysql.types :as htypes]
             [medley.core :as m]
-            [metabase.api.common.internal :refer :all]
+            [metabase.api.common.internal :refer [add-route-param-regexes auto-parse route-dox route-fn-name
+                                                  validate-params wrap-response-if-needed]]
             [metabase.models.interface :as mi]
             [metabase.public-settings :as public-settings]
             [metabase.util :as u]

--- a/src/metabase/automagic_dashboards/filters.clj
+++ b/src/metabase/automagic_dashboards/filters.clj
@@ -48,7 +48,7 @@
 (defn- interleave-all
   [& colls]
   (lazy-seq
-   (when-not (empty? colls)
+   (when (seq colls)
      (concat (map first colls) (apply interleave-all (keep (comp seq rest) colls))))))
 
 (defn- sort-by-interestingness

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -49,7 +49,7 @@
   [driver]
   (when (driver/supports? driver :set-timezone)
     (let [report-tz (driver/report-timezone)]
-      (when-not (empty? report-tz)
+      (when (seq report-tz)
         report-tz))))
 
 

--- a/src/metabase/email.clj
+++ b/src/metabase/email.clj
@@ -179,11 +179,10 @@
   [details]
   (let [inital-attempt (run-smtp-test details)
         it-worked?     (= :SUCCESS (:error inital-attempt))
-        attempted-fix  (if (not it-worked?)
+        attempted-fix  (when-not it-worked?
                          (guess-smtp-security details))
-        we-fixed-it?     (= :SUCCESS (:error attempted-fix))]
-    (if it-worked?
-      inital-attempt
-      (if we-fixed-it?
-        attempted-fix
-        inital-attempt))))
+        we-fixed-it?   (= :SUCCESS (:error attempted-fix))]
+    (cond
+      it-worked?   inital-attempt
+      we-fixed-it? attempted-fix
+      :else        inital-attempt)))

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -368,7 +368,7 @@
   "Get the immediate parent `collection` id, if set."
   {:hydrate :parent_id}
   [{:keys [location]} :- CollectionWithLocationOrRoot]
-  (if location (location-path->parent-id location)))
+  (some-> location location-path->parent-id))
 
 (s/defn children-location :- LocationPath
   "Given a `collection` return a location path that should match the `:location` value of all the children of the

--- a/src/metabase/server/middleware/log.clj
+++ b/src/metabase/server/middleware/log.clj
@@ -67,7 +67,7 @@
    " "
    (trs "({0} queued)" (streaming-response.thread-pool/queued-thread-count))
    (when diag-info-fn
-     (if-let [diag-info (not-empty (diag-info-fn))]
+     (when-let [diag-info (not-empty (diag-info-fn))]
        (format
         "; %s DB %s connections: %d/%d (%d threads blocked)"
         (some-> diag-info ::sql-jdbc.execute.diagnostic/driver name)


### PR DESCRIPTION
Previously all of our Clj-Kondo linters other than missing docstrings were set to `:warn` rather than `:warning`. `:warn` logs a message at the `WARN` level (i.e. `log/warn`) but does not cause `clj-kondo` to exit with a nonzero status. `:warning` issues an actual linter warning that will cause the process to fail

This PR changes our configuration to use `:warning` for everything we've configured and fixes a handful of errors 