### PR TITLE
#17450 Repro: New databases with "This is a large database ..." still uses the default sync+scan settings

### DIFF
--- a/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
@@ -188,14 +188,7 @@ describe("scenarios > admin > databases > add", () => {
     it("should let you upload the service account json from a file", () => {
       cy.visit("/admin/databases/create");
 
-      // select BigQuery
-      cy.contains("Database type")
-        .parents(".Form-field")
-        .find(".AdminSelect")
-        .click();
-      popover()
-        .contains("BigQuery")
-        .click({ force: true });
+      chooseDatabase("BigQuery");
 
       // enter text
       typeField("Name", "bq db");
@@ -261,13 +254,7 @@ describe("scenarios > admin > databases > add", () => {
   describe("Google Analytics ", () => {
     it("should generate well-formed external auth URLs", () => {
       cy.visit("/admin/databases/create");
-      cy.contains("Database type")
-        .parents(".Form-field")
-        .find(".AdminSelect")
-        .click();
-      popover()
-        .contains("Google Analytics")
-        .click({ force: true });
+      chooseDatabase("Google Analytics");
 
       typeField("Client ID", "   999  ");
 

--- a/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
@@ -281,3 +281,13 @@ describe("scenarios > admin > databases > add", () => {
     });
   });
 });
+
+function chooseDatabase(database) {
+  cy.contains("Database type")
+    .parents(".Form-field")
+    .find(".AdminSelect")
+    .click();
+  popover()
+    .contains(database)
+    .click({ force: true });
+}


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Reproduces #17450 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/129616473-5b104e77-28c4-40e5-a524-070ca4a9ac18.png)

