### PR TITLE
Warn if .lein-env is present on launch (dev-only)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 /*.trace.db
 /.babel_cache
 /.env
+/.lein-env
 /.lein-failures
 /.lein-plugins
 /.lein-repl-history

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,6 @@
 /*.trace.db
 /.babel_cache
 /.env
-/.lein-env
 /.lein-failures
 /.lein-plugins
 /.lein-repl-history

--- a/src/metabase/config.clj
+++ b/src/metabase/config.clj
@@ -1,6 +1,7 @@
 (ns metabase.config
   (:require [clojure.java.io :as io]
             [clojure.string :as str]
+            [clojure.tools.logging :as log]
             [environ.core :as environ]
             [metabase.plugins.classloader :as classloader])
   (:import clojure.lang.Keyword
@@ -127,3 +128,18 @@
 (def ^Keyword mb-session-cookie-samesite
   "Value for session cookie's `SameSite` directive. Must be one of \"none\", \"lax\", or \"strict\" (case insensitive)."
   (mb-session-cookie-samesite*))
+
+;; In 0.40.0 we switched from Leiningen to deps.edn. This warning here to keep people from being bitten in the ass by
+;; the little gotcha described below.
+;;
+;; TODO -- after we've shipped 0.42.0, remove this warning. At that point, the last three shipped major releases will
+;; all be deps.edn based.
+(when-not is-prod?
+  (when (.exists (io/file ".lein-env"))
+    ;; don't need to i18n since this is a dev-only warning.
+    (log/warn
+     (str "Found .lein-env in the project root directory.\n"
+          "This file was previously created automatically by the Leiningen lein-env plugin.\n"
+          "Environ will use values from it in preference to env var or Java system properties you've specified.\n"
+          "You should delete it; it will be recreated as needed when switching to a branch still using Leinigen.\n"
+          "See https://github.com/metabase/metabase/wiki/Migrating-from-Leiningen-to-tools.deps#custom-env-var-values for more details."))))

--- a/src/metabase/config.clj
+++ b/src/metabase/config.clj
@@ -129,10 +129,10 @@
   "Value for session cookie's `SameSite` directive. Must be one of \"none\", \"lax\", or \"strict\" (case insensitive)."
   (mb-session-cookie-samesite*))
 
-;; In 0.40.0 we switched from Leiningen to deps.edn. This warning here to keep people from being bitten in the ass by
+;; In 0.41.0 we switched from Leiningen to deps.edn. This warning here to keep people from being bitten in the ass by
 ;; the little gotcha described below.
 ;;
-;; TODO -- after we've shipped 0.42.0, remove this warning. At that point, the last three shipped major releases will
+;; TODO -- after we've shipped 0.43.0, remove this warning. At that point, the last three shipped major releases will
 ;; all be deps.edn based.
 (when (and (not is-prod?)
            (.exists (io/file ".lein-env")))

--- a/src/metabase/config.clj
+++ b/src/metabase/config.clj
@@ -134,12 +134,12 @@
 ;;
 ;; TODO -- after we've shipped 0.42.0, remove this warning. At that point, the last three shipped major releases will
 ;; all be deps.edn based.
-(when-not is-prod?
-  (when (.exists (io/file ".lein-env"))
-    ;; don't need to i18n since this is a dev-only warning.
-    (log/warn
-     (str "Found .lein-env in the project root directory.\n"
-          "This file was previously created automatically by the Leiningen lein-env plugin.\n"
-          "Environ will use values from it in preference to env var or Java system properties you've specified.\n"
-          "You should delete it; it will be recreated as needed when switching to a branch still using Leinigen.\n"
-          "See https://github.com/metabase/metabase/wiki/Migrating-from-Leiningen-to-tools.deps#custom-env-var-values for more details."))))
+(when (and (not is-prod?)
+           (.exists (io/file ".lein-env")))
+  ;; don't need to i18n since this is a dev-only warning.
+  (log/warn
+   (str "Found .lein-env in the project root directory.\n"
+        "This file was previously created automatically by the Leiningen lein-env plugin.\n"
+        "Environ will use values from it in preference to env var or Java system properties you've specified.\n"
+        "You should delete it; it will be recreated as needed when switching to a branch still using Leiningen.\n"
+        "See https://github.com/metabase/metabase/wiki/Migrating-from-Leiningen-to-tools.deps#custom-env-var-values for more details.")))

--- a/test/metabase/api/session_test.clj
+++ b/test/metabase/api/session_test.clj
@@ -154,9 +154,9 @@
                         :body
                         json/parse-string
                         (get-in ["errors" "username"])))]
-        (is (re= #"^Too many attempts! You must wait 1\d seconds before trying again\.$"
+        (is (re= #"^Too many attempts! You must wait \d+ seconds before trying again\.$"
                  (error)))
-        (is (re= #"^Too many attempts! You must wait 4\d seconds before trying again\.$"
+        (is (re= #"^Too many attempts! You must wait \d+ seconds before trying again\.$"
                  (error)))))))
 
 (deftest failure-threshold-per-request-source


### PR DESCRIPTION
From https://github.com/metabase/metabase/wiki/Migrating-from-Leiningen-to-tools.deps#custom-env-var-values:

>  Environ will attempt to read the `.lein-env` file (Git-ignored by default) if one is present and prefer its values to the JVM system properties you've specified this way. `lein-environ` plugin will have created this file previously if you've ran with `lein` before. Be sure to delete this file if present so it doesn't ignore the properties you specify.

This PR is an attempt to fix this little gotcha so it stops biting people in the ass.

1. Warn on startup if `.lein-env` is found in the project root directory
2. ~~Remove `.lein-env` from `.gitignore` so people will notice it and remove it.~~ (update: not doing this anymore since it could be risky, see https://github.com/metabase/metabase/pull/17477#issuecomment-899756042)