### PR TITLE
Avoid prop shorthand in chart sidebar

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx
@@ -87,7 +87,7 @@ const ChartTypeOption = ({
 }) => (
   <Box
     p={1}
-    w={1 / 3}
+    width={1 / 3}
     className="text-centered"
     style={{ opacity: !isSensible ? 0.25 : 1 }}
   >


### PR DESCRIPTION
Create any chart and open its visualization setting to choose a chart type. Pay attention to the container for each chart icon (1/3 width):

![image](https://user-images.githubusercontent.com/7288/129619053-e703ee46-98eb-4cd2-bf7d-bfc70111aaf4.png)


Before and after this change, it should look **exactly** the same.