### PR TITLE
Add "moderation" folder to e2e CI groups

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1249,7 +1249,7 @@ workflows:
           matrix:
             parameters:
               edition: ["ee", "oss"]
-              folder: ["admin", "binning", "collections", "dashboard", "dashboard-filters", "onboarding", "native", "native-filters", "question", "sharing", "smoketest", "visualizations"]
+              folder: ["admin", "binning", "collections", "dashboard", "dashboard-filters", "moderation", "native", "native-filters", "onboarding", "question", "sharing", "smoketest", "visualizations"]
           name: e2e-tests-<< matrix.folder >>-<< matrix.edition >>
           requires:
             - build-uberjar-<< matrix.edition >>

--- a/frontend/test/metabase/scenarios/moderation/question-moderation.cy.spec.js
+++ b/frontend/test/metabase/scenarios/moderation/question-moderation.cy.spec.js
@@ -14,7 +14,7 @@ describeWithToken("scenarios > saved question moderation", () => {
 
       cy.findByTestId("moderation-verify-action").click();
 
-      cy.findByText("You verified this").should("be.visible");
+      cy.findAllByText("You verified this");
 
       cy.findByPlaceholderText("Search…").type("orders{enter}");
       cy.findByText("Orders, Count").icon("verified");
@@ -30,7 +30,7 @@ describeWithToken("scenarios > saved question moderation", () => {
       cy.findByTestId("moderation-verify-action").click();
       cy.findByTestId("moderation-remove-review-action").click();
 
-      cy.findByText("You verified this").should("not.exist");
+      cy.findByText("You verified this").should("not.be.visible");
       cy.findByTestId("saved-question-header-button").click();
 
       cy.icon("verified").should("not.exist");
@@ -52,10 +52,10 @@ describeWithToken("scenarios > saved question moderation", () => {
       cy.findByText("History").click();
 
       cy.findByTestId("moderation-verify-action").click();
-      cy.findByText("You verified this");
+      cy.findAllByText("You verified this").should("be.visible");
 
       cy.findByTestId("moderation-remove-review-action").click();
-      cy.findByText("You unverified this");
+      cy.findByText("You removed verification").should("be.visible");
     });
   });
 
@@ -79,7 +79,7 @@ describeWithToken("scenarios > saved question moderation", () => {
       cy.icon("verified").should("not.exist");
 
       cy.findByTestId("saved-question-header-button").click();
-      cy.findByText("A moderator verified this").should("not.exist");
+      cy.findByText("Bobby Tables verified this").should("not.exist");
 
       cy.findByPlaceholderText("Search…").type("orders{enter}");
       cy.findByText("Orders, Count, Grouped by Created At (year)")
@@ -99,7 +99,7 @@ describeWithToken("scenarios > saved question moderation", () => {
       cy.icon("verified");
 
       cy.findByTestId("saved-question-header-button").click();
-      cy.findByText("A moderator verified this");
+      cy.findAllByText("Bobby Tables verified this");
 
       cy.findByPlaceholderText("Search…").type("orders{enter}");
       cy.findByText("Orders, Count").icon("verified");
@@ -115,7 +115,7 @@ describeWithToken("scenarios > saved question moderation", () => {
       cy.findByTestId("saved-question-header-button").click();
       cy.findByText("History").click();
 
-      cy.findByText("A moderator verified this");
+      cy.findAllByText("Bobby Tables verified this").should("be.visible");
     });
   });
 });


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Enables "moderation" CI group
- Fixes outdated tests in that group

### Context
e2e tests were added in https://github.com/metabase/metabase/pull/17329, but CircleCi config wasn't updated. Thus, those tests haven't been running in the CI environment until now.