### PR TITLE
User details on moderation review

### DIFF
--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -165,7 +165,7 @@
   "Get `Card` with ID."
   [id]
   (u/prog1 (-> (Card id)
-               (hydrate :creator :dashboard_count :can_write :collection :moderation_reviews)
+               (hydrate :creator :dashboard_count :can_write :collection [:moderation_reviews :moderator_details])
                api/read-check
                (last-edit/with-last-edit-info :card))
     (events/publish-event! :card-read (assoc <> :actor_id api/*current-user-id*))))
@@ -228,7 +228,7 @@
       ;; include same information returned by GET /api/card/:id since frontend replaces the Card it
       ;; currently has with returned one -- See #4283
       (-> card
-          (hydrate :creator :dashboard_count :can_write :collection :moderation_reviews)
+          (hydrate :creator :dashboard_count :can_write :collection [:moderation_reviews :moderator_details])
           (assoc :last-edit-info (last-edit/edit-information-for-user user))))))
 
 (defn- create-card-async!
@@ -426,7 +426,7 @@
       ;; include same information returned by GET /api/card/:id since frontend replaces the Card it currently
       ;; has with returned one -- See #4142
       (-> card
-          (hydrate :creator :dashboard_count :can_write :collection :moderation_reviews)
+          (hydrate :creator :dashboard_count :can_write :collection [:moderation_reviews :moderator_details])
           (assoc :last-edit-info (last-edit/edit-information-for-user @api/*current-user*))))))
 
 (api/defendpoint ^:returns-chan PUT "/:id"

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -208,7 +208,7 @@
       ;; i'm a bit worried that this is an n+1 situation here. The cards can be batch hydrated i think because they
       ;; have a hydration key and an id. moderation_reviews currently aren't batch hydrated but i'm worried they
       ;; cannot be in this situation
-      (hydrate [:ordered_cards [:card :moderation_reviews] :series] :collection_authority_level :can_write :param_fields :param_values)
+      (hydrate [:ordered_cards [:card [:moderation_reviews :moderator_details]] :series] :collection_authority_level :can_write :param_fields :param_values)
       api/read-check
       api/check-not-archived
       hide-unreadable-cards

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -597,14 +597,16 @@
                        mt/boolean-ids-and-timestamps
                        :last-edit-info)))))
         (testing "Card should include moderation reviews"
-          (letfn [(clean [mr] (select-keys [mr] [:status :text]))]
+          (letfn [(clean [mr] (-> mr
+                                  (update :user #(select-keys % [:id]))
+                                  (select-keys [:status :text :user])))]
             (mt/with-temp* [ModerationReview [review {:moderated_item_id (:id card)
                                                       :moderated_item_type "card"
                                                       :moderator_id (mt/user->id :rasta)
                                                       :most_recent true
                                                       :status "verified"
                                                       :text "lookin good"}]]
-              (is (= [(clean review)]
+              (is (= [(clean (assoc review :user {:id true}))]
                      (->> (mt/user-http-request :rasta :get 200 (str "card/" (u/the-id card)))
                           mt/boolean-ids-and-timestamps
                           :moderation_reviews


### PR DESCRIPTION
Include user details in moderation reviews

The nestedness is getting a bit out of hand. Luckily there are only a few places that we hydrate but it is pretty deep:
```clojure
;; card api
(-> card
     (hydrate :creator :dashboard_count :can_write :collection [:moderation_reviews :moderator_details])
     (assoc :last-edit-info (last-edit/edit-information-for-user user)))

;; dashboards
                                 ;; four levels deep for moderator details
(hydrate [:ordered_cards [:card [:moderation_reviews :moderator_details]] :series] :collection_authority_level :can_write :param_fields :param_values)
```

```bash

% curl 'http://localhost:3000/api/card/760' -H <stuff omitted> | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2003    0  2003    0     0   102k      0 --:--:-- --:--:-- --:--:--  102k
{
  "description": null,
  "archived": false,
  "collection_position": null,
  "table_id": 2,
  "creator_id": 1,
  "moderation_reviews": [
    {
      "most_recent": true,
      "moderator_id": 1,
      "updated_at": "2021-08-16T21:30:00.665952Z",
      "status": "verified",
      "id": 1026,
      "user": {   // <------------------- new user info
        "email": "dan@metabase.com",
        "first_name": "dan",
        "last_login": "2021-08-10T21:17:35.366176Z",
        "is_qbnewb": false,
        "is_superuser": true,
        "id": 1,
        "last_name": "sutton",
        "date_joined": "2021-03-15T20:42:55.751834Z",
        "common_name": "dan sutton"
      },
      "moderated_item_id": 760,
      "created_at": "2021-08-16T21:30:00.665952Z",
      "moderated_item_type": "card",
      "text": null
    }
  ],
  "dataset_query": {
    "database": 1,
    "query": {
      "source-table": 2
    },
    "type": "query"
  },
  "id": 760,
  "display": "table",
  "last-edit-info": {
    "id": 1,
    "email": "dan@metabase.com",
    "first_name": "dan",
    "last_name": "sutton",
    "timestamp": "2021-05-12T22:04:57.205978Z"
  },
  ...
}
```

