### PR TITLE
[Dashboard filters coverage] Add initial set of tests for dashboard SQL date filters

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-sql-date.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-sql-date.cy.spec.js
@@ -98,7 +98,7 @@ function getQuestionDetails(filter) {
           "display-name": "Filter",
           type: "dimension",
           dimension: ["field", PEOPLE.CREATED_AT, null],
-          "widget-type": "date/month-year",
+          "widget-type": filter,
         },
       },
     },

--- a/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-sql-date.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-sql-date.cy.spec.js
@@ -1,0 +1,137 @@
+import {
+  restore,
+  popover,
+  mockSessionProperty,
+  filterWidget,
+  editDashboard,
+  saveDashboard,
+  setFilter,
+} from "__support__/e2e/cypress";
+
+import { DASHBOARD_SQL_DATE_FILTERS } from "./helpers/e2e-dashboard-filter-data-objects";
+import * as DateFilter from "../native-filters/helpers/e2e-date-filter-helpers";
+
+import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
+
+const { PEOPLE } = SAMPLE_DATASET;
+
+Object.entries(DASHBOARD_SQL_DATE_FILTERS).forEach(
+  ([filter, { value, representativeResult, sqlFilter }]) => {
+    describe("scenarios > dashboard > filters > SQL > date", () => {
+      beforeEach(() => {
+        restore();
+        cy.signInAsAdmin();
+
+        mockSessionProperty("field-filter-operators-enabled?", true);
+
+        const questionDetails = getQuestionDetails(sqlFilter);
+
+        cy.createNativeQuestionAndDashboard({ questionDetails }).then(
+          ({ body: { id, card_id, dashboard_id } }) => {
+            cy.intercept("POST", `/api/card/${card_id}/query`).as("cardQuery");
+            cy.visit(`/question/${card_id}`);
+
+            // Wait for `result_metadata` to load
+            cy.wait("@cardQuery");
+
+            cy.visit(`/dashboard/${dashboard_id}`);
+          },
+        );
+
+        editDashboard();
+        setFilter("Time", filter);
+
+        cy.findByText("Column to filter on")
+          .next("a")
+          .click();
+
+        popover()
+          .contains("Filter")
+          .click();
+      });
+
+      it(`should work for "${filter}" when set through the filter widget`, () => {
+        saveDashboard();
+
+        filterWidget().click();
+
+        dateFilterSelector({
+          filterType: filter,
+          filterValue: value,
+        });
+
+        cy.get(".Card").within(() => {
+          cy.contains(representativeResult);
+        });
+      });
+
+      it(`should work for "${filter}" when set as the default filter`, () => {
+        cy.findByText("Default value")
+          .next()
+          .click();
+
+        dateFilterSelector({
+          filterType: filter,
+          filterValue: value,
+        });
+
+        saveDashboard();
+
+        cy.get(".Card").within(() => {
+          cy.contains(representativeResult);
+        });
+      });
+    });
+  },
+);
+
+function getQuestionDetails(filter) {
+  return {
+    name: "SQL with Field Filter",
+    native: {
+      query:
+        "select PEOPLE.NAME, PEOPLE.CREATED_AT from people where {{filter}} limit 10",
+      "template-tags": {
+        filter: {
+          id: "7136f057-cfa6-e6fb-40c1-02046a1df9fb",
+          name: "filter",
+          "display-name": "Filter",
+          type: "dimension",
+          dimension: ["field", PEOPLE.CREATED_AT, null],
+          "widget-type": "date/month-year",
+        },
+      },
+    },
+  };
+}
+
+function dateFilterSelector({ filterType, filterValue } = {}) {
+  switch (filterType) {
+    case "Month and Year":
+      DateFilter.setMonthAndYear(filterValue);
+      break;
+
+    case "Quarter and Year":
+      DateFilter.setQuarterAndYear(filterValue);
+      break;
+
+    case "Single Date":
+      DateFilter.setSingleDate(filterValue);
+      break;
+
+    case "Date Range":
+      DateFilter.setDateRange(filterValue);
+      break;
+
+    case "Relative Date":
+      DateFilter.setRelativeDate(filterValue);
+      break;
+
+    case "All Options":
+      DateFilter.setAdHocFilter(filterValue);
+      break;
+
+    default:
+      throw new Error("Wrong filter type!");
+  }
+}

--- a/frontend/test/metabase/scenarios/dashboard-filters/helpers/e2e-dashboard-filter-data-objects.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/helpers/e2e-dashboard-filter-data-objects.js
@@ -206,3 +206,47 @@ export const DASHBOARD_SQL_LOCATION_FILTERS = {
     representativeResult: "Aracely Jenkins",
   },
 };
+
+export const DASHBOARD_SQL_DATE_FILTERS = {
+  "Month and Year": {
+    sqlFilter: "date/month-year",
+    value: {
+      month: "October",
+      year: "2017",
+    },
+    representativeResult: "Hudson Borer",
+  },
+  "Quarter and Year": {
+    sqlFilter: "date/quarter-year",
+    value: {
+      quarter: "Q1",
+      year: "2018",
+    },
+    representativeResult: "Lolita Schaefer",
+  },
+  "Single Date": {
+    sqlFilter: "date/single",
+    value: "15",
+    representativeResult: "No results!",
+  },
+  "Date Range": {
+    sqlFilter: "date/range",
+    value: {
+      startDate: "13",
+      endDate: "15",
+    },
+    representativeResult: "No results!",
+  },
+  "Relative Date": {
+    sqlFilter: "date/relative",
+    value: "Past 7 days",
+    representativeResult: "No results!",
+  },
+  "All Options": {
+    sqlFilter: "date/all-options",
+    value: {
+      timeBucket: "Years",
+    },
+    representativeResult: "Hudson Borer",
+  },
+};


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- As an ongoing effort to increase the test coverage of dashboard filters (https://github.com/metabase/metabase/issues/17078), this PR adds basic tests around date filters applied to the SQL question with the corresponding field filter
    - Make sure filter can be set via filter widget
    - Make sure filter can be set as the default filter

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/129640853-e8f8bc03-1451-47e4-8dcb-9ca143eec493.png)
