### PR TITLE
Add `editDashboardCard` Cypress custom command

### DIFF
--- a/frontend/test/__support__/e2e/commands.js
+++ b/frontend/test/__support__/e2e/commands.js
@@ -3,6 +3,7 @@ import "./commands/ui/icon";
 
 import "./commands/api/question";
 import "./commands/api/dashboard";
+import "./commands/api/dashboardCard";
 import "./commands/api/dashboardFilters";
 import "./commands/api/collection";
 import "./commands/api/moderation";

--- a/frontend/test/__support__/e2e/commands/api/dashboardCard.js
+++ b/frontend/test/__support__/e2e/commands/api/dashboardCard.js
@@ -1,0 +1,25 @@
+import _ from "underscore";
+
+Cypress.Commands.add("editDashboardCard", (oldCard, newCard) => {
+  const { id, dashboard_id } = oldCard;
+
+  const cleanOldCard = sanitizeCard(oldCard);
+
+  const updatedCard = Object.assign({}, cleanOldCard, newCard);
+
+  cy.log(`Edit dashboard card ${id}`);
+  cy.request("PUT", `/api/dashboard/${dashboard_id}/cards`, {
+    cards: [updatedCard],
+  });
+});
+
+/**
+ * Remove `created_at` and `updated_at` fields from the dashboard card that was previously added to the dashboard.
+ * We don't want to hard code these fields in the next request that we'll pass the card object to.
+ *
+ * @param {Object} card - "Old", or the existing dashboard card.
+ * @returns {Object}
+ */
+function sanitizeCard(card) {
+  return _.omit(card, ["created_at", "updated_at"]);
+}


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Adds a new Cypress custom command that abstracts away often times long XHRs needed to update the dashboard card.

The neat thing about adding a card to the dashboard is that the `response.body` is actually what we need to pass to this custom command in order to update it.
```javascript
// response body from `POST /api/dashboard/:dashboard_id/cards`
{
  sizeX: 2,
  series: [],
  updated_at: "2021-08-17T22:37:15.4",
  col: 0,
  id: 34,
  parameter_mappings: [],
  card_id: 13,
  visualization_settings: {},
  dashboard_id: 25,
  created_at: "2021-08-17T22:37:15.4",
  sizeY: 2,
  row: 0,
}
```
We must make sure to remove `updated_at` and `created_at` before we pass this object to the new XHR. That is exactly what `sanitizeCard` helper function is doing.

### Examples

The easiest possible example would be updating card's size.
```javascript
const updatedSize = {
  sizeX: 16,
  sizeY: 12,
};

cy.editDashboardCard(oldCard, updatedSize);
```

If we only care about connecting the filter to the card and are not concerned about its size, we can simplify this request:
```javascript
// Connect filter to the card
cy.request("PUT", `/api/dashboard/${dashboard_id}/cards`, {
  cards: [
    {
      id,
      card_id,
      row: 0,
      col: 0,
      sizeX: 12,
      sizeY: 9,
      visualization_settings: {},
      parameter_mappings: [
        {
          parameter_id: filter.id,
          card_id,
          target: ["dimension", ["field", PRODUCTS.TITLE, null]],
        },
      ],
    },
  ],
});
```

into this:
```javascript
const parameter_mappings: [
  {
    parameter_id: filter.id,
    card_id,
    target: ["dimension", ["field", PRODUCTS.TITLE, null]],
  },
];

cy.editDashboardCard(oldCard, {parameter_mappings});
```