### PR TITLE
codecov config: disable patch checking

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -19,17 +19,7 @@ coverage:
         flags:
           - front-end
 
-    patch:
-      back-end:
-        # Changes must have at least 75% test coverage (by line)
-        target: 75%
-        flags:
-          - back-end
-
-      front-end:
-        target: 35%
-        flags:
-          - front-end
+    patch: off
 
 flags:
   back-end:


### PR DESCRIPTION
codecov patch calculation is incorrect. Thus, let's rely only on the
whole-project calculation and threshold (which is working fine).
