### PR TITLE
Do not track testing coverage for styled.js* files

### DIFF
--- a/jest.unit.conf.json
+++ b/jest.unit.conf.json
@@ -4,7 +4,10 @@
     "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/frontend/test/__mocks__/fileMock.js",
     "^promise-loader\\?global\\!metabase\\/lib\\/ga-metadata$": "<rootDir>/frontend/src/metabase/lib/ga-metadata.js"
   },
-  "testPathIgnorePatterns": ["<rootDir>/frontend/test/.*/.*.tz.unit.spec.js"],
+  "testPathIgnorePatterns": [
+    "<rootDir>/frontend/test/.*/.*.tz.unit.spec.js",
+    "<rootDir>/frontend/test/.*/.*.styled.js*"
+  ],
   "testMatch": ["<rootDir>/**/*.unit.spec.js"],
   "modulePaths": [
     "<rootDir>/frontend/test",
@@ -35,7 +38,9 @@
     "/frontend/src/metabase/visualizations/lib/errors.js",
     "/frontend/src/cljs/",
     "/frontend/src/metabase/internal/",
-    "/frontend/test/"
+    "/frontend/test/",
+    ".styled.js",
+    ".styled.jsx"
   ],
   "testEnvironment": "jsdom"
 }

--- a/jest.unit.conf.json
+++ b/jest.unit.conf.json
@@ -4,10 +4,7 @@
     "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/frontend/test/__mocks__/fileMock.js",
     "^promise-loader\\?global\\!metabase\\/lib\\/ga-metadata$": "<rootDir>/frontend/src/metabase/lib/ga-metadata.js"
   },
-  "testPathIgnorePatterns": [
-    "<rootDir>/frontend/test/.*/.*.tz.unit.spec.js",
-    "<rootDir>/frontend/test/.*/.*.styled.js*"
-  ],
+  "testPathIgnorePatterns": ["<rootDir>/frontend/test/.*/.*.tz.unit.spec.js"],
   "testMatch": ["<rootDir>/**/*.unit.spec.js"],
   "modulePaths": [
     "<rootDir>/frontend/test",


### PR DESCRIPTION
Excludes .styled.jsx (and .styled.js for now, we have not yet converged on just one suffix) from coverage reports.

### How to test

Run tests: `yarn test-unit --coverage` 

Open lcov report: `open coverage/lcov-report/index.html`

Go to coverage for any directory that includes a styled component, for example:

http://……/frontend/src/metabase/components/DrawerSection/index.html

Now there should be no styled.js{x} file in the coverage report.