### PR TITLE
Fix tracking and reporting front-end coverage for EE

### DIFF
--- a/jest.unit.conf.json
+++ b/jest.unit.conf.json
@@ -9,7 +9,6 @@
   "modulePaths": [
     "<rootDir>/frontend/test",
     "<rootDir>/frontend/src",
-    "<rootDir>/enterprise/frontend/test",
     "<rootDir>/enterprise/frontend/src"
   ],
   "setupFiles": [
@@ -25,7 +24,12 @@
   },
   "coverageDirectory": "./coverage",
   "coverageReporters": ["text", "html", "lcov"],
-  "collectCoverageFrom": ["frontend/src/**/*.js", "frontend/src/**/*.jsx"],
+  "collectCoverageFrom": [
+    "frontend/src/**/*.js",
+    "frontend/src/**/*.jsx",
+    "enterprise/frontend/src/**/*.js",
+    "enterprise/frontend/src/**/*.jsx"
+  ],
   "coveragePathIgnorePatterns": [
     "/node_modules/",
     "/frontend/src/metabase/visualizations/lib/errors.js",


### PR DESCRIPTION
Thanks to @kulyk who pointed out the missing `enterprise/frontend/src/` in the config.

**After** this PR is merged, we will see the EE coverage at https://codecov.io/gh/metabase/metabase/tree/master/,