### PR TITLE
Build static viz in the dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ ARG MB_EDITION=oss
 WORKDIR /home/circleci
 
 COPY --chown=circleci . .
-RUN NODE_ENV=production MB_EDITION=$MB_EDITION yarn --frozen-lockfile && yarn build && bin/i18n/build-translation-resources
+RUN NODE_ENV=production MB_EDITION=$MB_EDITION yarn --frozen-lockfile && \
+    yarn build && yarn build-static-viz && bin/i18n/build-translation-resources
 
 ###################
 # STAGE 1.4: main builder


### PR DESCRIPTION
Dockerfile needs to build the static viz js bundle.

There's a decent argument that this should be in the backend building code since this is a dependency of the backend, not the frontend. But leaving it here for now. If anyone knows of another place where we build assets I need to add it in there as well.