### PR TITLE
fix ModalRoute close removes last segment instead of navigating to the parent path

### DIFF
--- a/frontend/src/metabase/hoc/ModalRoute.jsx
+++ b/frontend/src/metabase/hoc/ModalRoute.jsx
@@ -5,6 +5,15 @@ import { push } from "react-router-redux";
 import { connect } from "react-redux";
 import Modal from "metabase/components/Modal";
 
+export const getParentPath = (route, location) => {
+  const fullPathSegments = location.pathname.split("/");
+  const routeSegments = route.path.split("/");
+
+  fullPathSegments.splice(-routeSegments.length);
+
+  return fullPathSegments.join("/");
+};
+
 const ModalWithRoute = (ComposedModal, modalProps = {}) =>
   connect(
     null,
@@ -15,14 +24,10 @@ const ModalWithRoute = (ComposedModal, modalProps = {}) =>
         ComposedModal.name}]`;
 
       onClose = () => {
-        const {
-          location: { pathname },
-        } = this.props;
-        const urlWithoutLastSegment = pathname.substring(
-          0,
-          pathname.lastIndexOf("/"),
-        );
-        this.props.onChangeLocation(urlWithoutLastSegment);
+        const { location, route } = this.props;
+
+        const parentPath = getParentPath(route, location);
+        this.props.onChangeLocation(parentPath);
       };
 
       render() {


### PR DESCRIPTION
### Description

When ModalRoute closes it removes only the last segment from the URL. It is not correct when a modal route has [multiple segments](https://github.com/metabase/metabase/pull/17328/files#diff-c2a5fc3c387b86994c3d1eaea9d0da47237a810be761d9d41ab207b6ef2dee70R71)

### How to verify
Closing existing modal routes works the same as before (etc add/edit user modals)

Fixes https://github.com/metabase/metabase/issues/14671