### PR TITLE
New columns picker for notebook editor

### DIFF
--- a/frontend/src/metabase/query_builder/components/notebook/FieldsPickerIcon.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/FieldsPickerIcon.jsx
@@ -19,8 +19,8 @@ export function FieldsPickerIcon() {
 
 export const FIELDS_PICKER_STYLES = {
   notebookItemContainer: {
-    width: 33,
-    height: 33,
+    width: 37,
+    height: 37,
   },
   trigger: {
     marginTop: 1,

--- a/frontend/src/metabase/query_builder/components/notebook/FieldsPickerIcon.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/FieldsPickerIcon.jsx
@@ -1,0 +1,18 @@
+import React from "react";
+import styled from "styled-components";
+import { t } from "ttag";
+
+import Icon from "metabase/components/Icon";
+import Tooltip from "metabase/components/Tooltip";
+
+const StyledIcon = styled(Icon)`
+  opacity: 0.5;
+`;
+
+export function FieldsPickerIcon() {
+  return (
+    <Tooltip tooltip={<span>{t`Pick columns`}</span>}>
+      <StyledIcon name="table" size={14} />
+    </Tooltip>
+  );
+}

--- a/frontend/src/metabase/query_builder/components/notebook/FieldsPickerIcon.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/FieldsPickerIcon.jsx
@@ -16,3 +16,13 @@ export function FieldsPickerIcon() {
     </Tooltip>
   );
 }
+
+export const FIELDS_PICKER_STYLES = {
+  notebookItemContainer: {
+    width: 33,
+    height: 33,
+  },
+  trigger: {
+    marginTop: 1,
+  },
+};

--- a/frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx
@@ -7,15 +7,28 @@ import { DatabaseSchemaAndTableDataSelector } from "metabase/query_builder/compo
 import { getDatabasesList } from "metabase/query_builder/selectors";
 
 import { NotebookCell, NotebookCellItem } from "../NotebookCell";
+import { FieldsPickerIcon, FIELDS_PICKER_STYLES } from "../FieldsPickerIcon";
 import FieldsPicker from "./FieldsPicker";
 
 function DataStep({ color, query, updateQuery }) {
   const table = query.table();
+  const canSelectTableColumns = table && query.isRaw();
   return (
     <NotebookCell color={color}>
       <NotebookCellItem
         color={color}
         inactive={!table}
+        right={
+          canSelectTableColumns && (
+            <DataFieldsPicker
+              query={query}
+              updateQuery={updateQuery}
+              triggerStyle={FIELDS_PICKER_STYLES.trigger}
+              triggerElement={<FieldsPickerIcon />}
+            />
+          )
+        }
+        rightContainerStyle={FIELDS_PICKER_STYLES.notebookItemContainer}
         data-testid="data-step-cell"
       >
         <DatabaseSchemaAndTableDataSelector
@@ -35,13 +48,6 @@ function DataStep({ color, query, updateQuery }) {
           }
         />
       </NotebookCellItem>
-      {table && query.isRaw() && (
-        <DataFieldsPicker
-          className="ml-auto text-bold"
-          query={query}
-          updateQuery={updateQuery}
-        />
-      )}
     </NotebookCell>
   );
 }
@@ -50,14 +56,14 @@ export default connect(state => ({ databases: getDatabasesList(state) }))(
   DataStep,
 );
 
-const DataFieldsPicker = ({ className, query, updateQuery }) => {
+const DataFieldsPicker = ({ query, updateQuery, ...props }) => {
   const dimensions = query.tableDimensions();
   const selectedDimensions = query.columnDimensions();
   const selected = new Set(selectedDimensions.map(d => d.key()));
   const fields = query.fields();
   return (
     <FieldsPicker
-      className={className}
+      {...props}
       dimensions={dimensions}
       selectedDimensions={selectedDimensions}
       isAll={!fields || fields.length === 0}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx
@@ -4,9 +4,10 @@ import { connect } from "react-redux";
 import { t } from "ttag";
 
 import { DatabaseSchemaAndTableDataSelector } from "metabase/query_builder/components/DataSelector";
-import { NotebookCell, NotebookCellItem } from "../NotebookCell";
-
 import { getDatabasesList } from "metabase/query_builder/selectors";
+
+import { NotebookCell, NotebookCellItem } from "../NotebookCell";
+import FieldsPicker from "./FieldsPicker";
 
 function DataStep({ color, query, databases, updateQuery }) {
   const table = query.table();
@@ -50,8 +51,6 @@ function DataStep({ color, query, databases, updateQuery }) {
 export default connect(state => ({ databases: getDatabasesList(state) }))(
   DataStep,
 );
-
-import FieldsPicker from "./FieldsPicker";
 
 const DataFieldsPicker = ({ className, query, updateQuery }) => {
   const dimensions = query.tableDimensions();

--- a/frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx
@@ -13,30 +13,28 @@ function DataStep({ color, query, updateQuery }) {
   const table = query.table();
   return (
     <NotebookCell color={color}>
-      <DatabaseSchemaAndTableDataSelector
-        hasTableSearch
-        databaseQuery={{ saved: true }}
-        selectedDatabaseId={query.databaseId()}
-        selectedTableId={query.tableId()}
-        setSourceTableFn={tableId =>
-          query
-            .setTableId(tableId)
-            .setDefaultQuery()
-            .update(updateQuery)
-        }
-        isInitiallyOpen={!query.tableId()}
-        triggerElement={
-          !query.tableId() ? (
-            <NotebookCellItem color={color} inactive>
-              {t`Pick your starting data`}
-            </NotebookCellItem>
-          ) : (
-            <NotebookCellItem color={color} data-testid="data-step-cell">
-              {table && table.displayName()}
-            </NotebookCellItem>
-          )
-        }
-      />
+      <NotebookCellItem
+        color={color}
+        inactive={!table}
+        data-testid="data-step-cell"
+      >
+        <DatabaseSchemaAndTableDataSelector
+          hasTableSearch
+          databaseQuery={{ saved: true }}
+          selectedDatabaseId={query.databaseId()}
+          selectedTableId={query.tableId()}
+          setSourceTableFn={tableId =>
+            query
+              .setTableId(tableId)
+              .setDefaultQuery()
+              .update(updateQuery)
+          }
+          isInitiallyOpen={!query.tableId()}
+          triggerElement={
+            table ? table.displayName() : t`Pick your starting data`
+          }
+        />
+      </NotebookCellItem>
       {table && query.isRaw() && (
         <DataFieldsPicker
           className="ml-auto text-bold"

--- a/frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx
@@ -9,7 +9,7 @@ import { getDatabasesList } from "metabase/query_builder/selectors";
 import { NotebookCell, NotebookCellItem } from "../NotebookCell";
 import FieldsPicker from "./FieldsPicker";
 
-function DataStep({ color, query, databases, updateQuery }) {
+function DataStep({ color, query, updateQuery }) {
   const table = query.table();
   return (
     <NotebookCell color={color}>

--- a/frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx
@@ -16,13 +16,16 @@ export default function FieldsPicker({
   onSelectAll,
   onSelectNone,
   onToggleDimension,
+  triggerElement = t`Columns`,
+  ...props
 }) {
   const selected = new Set(selectedDimensions.map(d => d.key()));
   return (
     <PopoverWithTrigger
-      triggerElement={t`Columns`}
+      triggerElement={triggerElement}
       triggerClasses={className}
       sizeToFit
+      {...props}
     >
       <ul className="pt1">
         {(onSelectAll || onSelectNone) && (

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -14,6 +14,7 @@ import {
   NotebookCellItem,
   NotebookCellAdd,
 } from "../NotebookCell";
+import { FieldsPickerIcon, FIELDS_PICKER_STYLES } from "../FieldsPickerIcon";
 import FieldsPicker from "./FieldsPicker";
 import {
   JoinClausesContainer,
@@ -211,15 +212,9 @@ function JoinClause({ color, join, updateQuery, showRemove }) {
         </JoinedTableControlRoot>
       )}
 
-      {join.isValid() && (
-        <JoinFieldsPicker
-          className="ml-auto text-bold"
-          join={join}
-          updateQuery={updateQuery}
-        />
+      {showRemove && (
+        <RemoveJoinIcon onClick={() => join.remove().update(updateQuery)} />
       )}
-
-      {showRemove && <RemoveJoinIcon onClick={removeJoin} />}
     </JoinClauseRoot>
   );
 }
@@ -258,7 +253,21 @@ function JoinTablePicker({
   }
 
   return (
-    <NotebookCellItem color={color} inactive={!joinedTable}>
+    <NotebookCellItem
+      color={color}
+      inactive={!joinedTable}
+      right={
+        joinedTable && (
+          <JoinFieldsPicker
+            join={join}
+            updateQuery={updateQuery}
+            triggerElement={<FieldsPickerIcon />}
+            triggerStyle={FIELDS_PICKER_STYLES.trigger}
+          />
+        )
+      }
+      rightContainerStyle={FIELDS_PICKER_STYLES.notebookItemContainer}
+    >
       <DatabaseSchemaAndTableDataSelector
         hasTableSearch
         canChangeDatabase={false}
@@ -429,10 +438,9 @@ JoinDimensionPicker.propTypes = joinDimensionPickerPropTypes;
 const joinFieldsPickerPropTypes = {
   join: PropTypes.object.isRequired,
   updateQuery: PropTypes.func.isRequired,
-  className: PropTypes.string,
 };
 
-const JoinFieldsPicker = ({ className, join, updateQuery }) => {
+const JoinFieldsPicker = ({ join, updateQuery, ...props }) => {
   const dimensions = join.joinedDimensions();
   const selectedDimensions = join.fieldsDimensions();
   const selected = new Set(selectedDimensions.map(d => d.key()));
@@ -470,7 +478,7 @@ const JoinFieldsPicker = ({ className, join, updateQuery }) => {
 
   return (
     <FieldsPicker
-      className={className}
+      {...props}
       dimensions={dimensions}
       selectedDimensions={selectedDimensions}
       isAll={join.fields === "all"}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -212,9 +212,7 @@ function JoinClause({ color, join, updateQuery, showRemove }) {
         </JoinedTableControlRoot>
       )}
 
-      {showRemove && (
-        <RemoveJoinIcon onClick={() => join.remove().update(updateQuery)} />
-      )}
+      {showRemove && <RemoveJoinIcon onClick={removeJoin} />}
     </JoinClauseRoot>
   );
 }

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.unit.spec.js
@@ -271,7 +271,7 @@ describe("Notebook Editor > Join Step", () => {
     const { onQueryChange } = setup();
     await selectTable(/Products/i);
 
-    fireEvent.click(screen.getByText("Columns"));
+    fireEvent.click(screen.getByLabelText("table icon"));
     fireEvent.click(screen.getByText("Select None"));
     fireEvent.click(screen.getByText("Category"));
 


### PR DESCRIPTION
This PR changes the notebook editor's columns picker look. We used to have a "Columns" button on the right side of a data step and a join step. Now there is a neat icon button right in the notebook editor cell itself. The implementation is based on a new `NotebookCellItem` `right` prop from #17435 

### To Verify

1. Ask a question > Custom Question > Sample Dataset > Orders
2. Notice the blue "Orders" cell now has a "table" icon on the right side. Click it, you should see a popover with a list of "Orders" columns. Unselect a few checkboxes, run the query, and make sure the columns are not present in the results
3. Click the blue "Orders" cell, you should see a popover that offers you to change a database and a table. That should just work as it used to
4. Click a "join" icon under the data step, select "Products"
5. Notice the blue "Products" cell now also has a new columns picker control. Repeat the actions from step 2 to validate it works correctly