### PR TITLE
Avoid prop shorthand in collections

### DIFF
--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -143,7 +143,7 @@ function CollectionContent({
 
         return (
           <Box pt={2}>
-            <Box w="90%" ml="auto" mr="auto">
+            <Box width="90%" ml="auto" mr="auto">
               <Header
                 isRoot={isRoot}
                 isAdmin={isAdmin}


### PR DESCRIPTION
Go to `/collection/root` and pay attention to the following container:

![image](https://user-images.githubusercontent.com/7288/130144908-9b4fda00-09c9-44f5-af3d-33832d8e482d.png)


Before and after this change, it should look **exactly** the same.