### PR TITLE
Enable proper type inference for call, bind, and apply

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -15,6 +15,7 @@
         "./enterprise/frontend/test/*"
       ]
     },
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
+    "strictBindCallApply": true
   }
 }


### PR DESCRIPTION
https://www.typescriptlang.org/tsconfig#strictBindCallApply

This helps with editing when using an editor with JavaScript LSP (e.g. VS Code, etc).

How to verify? Open `frontend/src/metabase/lib/schema_metadata.js` and find `isString` definition.

When asking for the function documentation for `isFieldType` (e.g. illustrated here with Vim/Neovim and LSP, but works well with VS Code as well), the popup correctly informs that this function returns a boolean value:

![image](https://user-images.githubusercontent.com/7288/130146245-a86e9ace-986b-42a1-8b36-19743783bfde.png)

Now, do the same for `isString` instead.

**Before this PR**
The popup indicates that the function returns a generic value, `any`.

![image](https://user-images.githubusercontent.com/7288/130146446-196b8e06-476d-426b-9cfc-969790ee6890.png)

**After this PR**

![image](https://user-images.githubusercontent.com/7288/130146489-f3853e14-2241-4d93-9d62-24762bcc38cd.png)

The popup indicates that `isString` return boolean, because LSP now understand the semantics of [Function.bind](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_objects/Function/bind).
