### PR TITLE
Remove some superfluous return types in the metadata code

### DIFF
--- a/frontend/src/metabase-lib/lib/metadata/Database.js
+++ b/frontend/src/metabase-lib/lib/metadata/Database.js
@@ -57,9 +57,7 @@ export default class Database extends Base {
 
   // FEATURES
 
-  hasFeature(
-    feature: null | DatabaseFeature | VirtualDatabaseFeature,
-  ): boolean {
+  hasFeature(feature: null | DatabaseFeature | VirtualDatabaseFeature) {
     if (!feature) {
       return true;
     }

--- a/frontend/src/metabase-lib/lib/metadata/Field.js
+++ b/frontend/src/metabase-lib/lib/metadata/Field.js
@@ -322,7 +322,7 @@ export default class Field extends Base {
   /**
    * Returns true if this field can be searched, e.x. in filter or parameter widgets
    */
-  isSearchable(): boolean {
+  isSearchable() {
     // TODO: ...?
     return this.isString();
   }

--- a/frontend/src/metabase-lib/lib/metadata/Metric.js
+++ b/frontend/src/metabase-lib/lib/metadata/Metric.js
@@ -49,7 +49,7 @@ export default class Metric extends Base {
     }
   }
 
-  isActive(): boolean {
+  isActive() {
     return !this.archived;
   }
 }

--- a/frontend/src/metabase-lib/lib/metadata/Segment.js
+++ b/frontend/src/metabase-lib/lib/metadata/Segment.js
@@ -21,7 +21,7 @@ export default class Segment extends Base {
     return ["segment", this.id];
   }
 
-  isActive(): boolean {
+  isActive() {
     return !this.archived;
   }
 }

--- a/frontend/src/metabase-lib/lib/metadata/Table.js
+++ b/frontend/src/metabase-lib/lib/metadata/Table.js
@@ -31,7 +31,7 @@ export default class Table extends Base {
 
   entity_type: ?EntityType;
 
-  hasSchema(): boolean {
+  hasSchema() {
     return (this.schema_name && this.db && this.db.schemas.length > 1) || false;
   }
 
@@ -54,7 +54,7 @@ export default class Table extends Base {
     });
   }
 
-  isSavedQuestion(): boolean {
+  isSavedQuestion() {
     return this.savedQuestionId() !== null;
   }
 


### PR DESCRIPTION
Type inference can already correctly infer those return types, no need to explicit anymore.

To verify, open e.g. `frontend/src/metabase-lib/lib/DimensionOptions.js` and find an occurence of `table.isSavedQuestion`:

![image](https://user-images.githubusercontent.com/7288/130147859-ff205d1b-4647-4ba6-99d9-4fdd1754d217.png)

**Before** and **after** this PR, the function hint should still indicate that it returns a boolean, even after the explicit type annotation of`boolean` is removed.