### PR TITLE
Edit Cypress custom command `cy.createDashboard()`

### DIFF
--- a/frontend/test/__support__/e2e/commands/api/composite/createNativeQuestionAndDashboard.js
+++ b/frontend/test/__support__/e2e/commands/api/composite/createNativeQuestionAndDashboard.js
@@ -1,9 +1,9 @@
 Cypress.Commands.add(
   "createNativeQuestionAndDashboard",
-  ({ questionDetails, dashboardName = "Custom dashboard" } = {}) => {
+  ({ questionDetails, dashboardDetails } = {}) => {
     cy.createNativeQuestion(questionDetails).then(
       ({ body: { id: questionId } }) => {
-        cy.createDashboard(dashboardName).then(
+        cy.createDashboard(dashboardDetails).then(
           ({ body: { id: dashboardId } }) => {
             cy.request("POST", `/api/dashboard/${dashboardId}/cards`, {
               cardId: questionId,

--- a/frontend/test/__support__/e2e/commands/api/composite/createQuestionAndDashboard.js
+++ b/frontend/test/__support__/e2e/commands/api/composite/createQuestionAndDashboard.js
@@ -1,8 +1,8 @@
 Cypress.Commands.add(
   "createQuestionAndDashboard",
-  ({ questionDetails, dashboardName = "Custom dashboard" } = {}) => {
+  ({ questionDetails, dashboardDetails } = {}) => {
     cy.createQuestion(questionDetails).then(({ body: { id: questionId } }) => {
-      cy.createDashboard(dashboardName).then(
+      cy.createDashboard(dashboardDetails).then(
         ({ body: { id: dashboardId } }) => {
           cy.request("POST", `/api/dashboard/${dashboardId}/cards`, {
             cardId: questionId,

--- a/frontend/test/__support__/e2e/commands/api/dashboard.js
+++ b/frontend/test/__support__/e2e/commands/api/dashboard.js
@@ -1,11 +1,9 @@
 Cypress.Commands.add(
   "createDashboard",
-  (name, { collection_position = null, collection_id = null } = {}) => {
+  ({ name = "Test Dashboard", ...dashboardDetails } = {}) => {
     cy.log(`Create a dashboard: ${name}`);
-    cy.request("POST", "/api/dashboard", {
-      name,
-      collection_position,
-      collection_id,
-    });
+
+    // For all the possible keys, refer to `src/metabase/api/dashboard.clj`
+    cy.request("POST", "/api/dashboard", { name, ...dashboardDetails });
   },
 );

--- a/frontend/test/metabase/scenarios/admin/audit/auditing.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/audit/auditing.cy.spec.js
@@ -29,7 +29,7 @@ function generateQuestions(user) {
 }
 
 function generateDashboards(user) {
-  cy.createDashboard(`${user} dashboard`);
+  cy.createDashboard({ name: `${user} dashboard` });
 }
 
 describeWithToken("audit > auditing", () => {

--- a/frontend/test/metabase/scenarios/collections/collection-items-listing.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collection-items-listing.cy.spec.js
@@ -37,7 +37,9 @@ describe("scenarios > collection items listing", () => {
         });
       });
 
-      _.times(ADDED_DASHBOARDS, i => cy.createDashboard(`dashboard ${i}`));
+      _.times(ADDED_DASHBOARDS, i =>
+        cy.createDashboard({ name: `dashboard ${i}` }),
+      );
       _.times(ADDED_QUESTIONS, i =>
         cy.createQuestion({
           name: `generated question ${i}`,
@@ -99,7 +101,8 @@ describe("scenarios > collection items listing", () => {
 
       it(testName, () => {
         ["A", "B", "C"].forEach((letter, i) => {
-          cy.createDashboard(`${letter} Dashboard`, {
+          cy.createDashboard({
+            name: `${letter} Dashboard`,
             collection_position: pinned ? i + 1 : null,
           });
 
@@ -213,9 +216,10 @@ describe("scenarios > collection items listing", () => {
 
     it("should allow to separately sort pinned and not pinned items", () => {
       ["A", "B", "C"].forEach((letter, i) => {
-        cy.createDashboard(`${letter} Dashboard`);
+        cy.createDashboard({ name: `${letter} Dashboard` });
 
-        cy.createDashboard(`${letter} Dashboard (pinned)`, {
+        cy.createDashboard({
+          name: `${letter} Dashboard (pinned)`,
           collection_position: i + 1,
         });
 

--- a/frontend/test/metabase/scenarios/collections/collection-types.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collection-types.cy.spec.js
@@ -188,7 +188,10 @@ function testOfficialBadgePresence(expectBadge = true) {
       collection_id: collectionId,
       query: TEST_QUESTION_QUERY,
     });
-    cy.createDashboard("Official Dashboard", { collection_id: collectionId });
+    cy.createDashboard({
+      name: "Official Dashboard",
+      collection_id: collectionId,
+    });
     cy.visit(`/collection/${collectionId}`);
   });
 
@@ -247,7 +250,7 @@ function testOfficialQuestionBadgeInRegularDashboard(expectBadge = true) {
         collection_id: collectionId,
         query: TEST_QUESTION_QUERY,
       },
-      dashboardName: "Regular Dashboard",
+      dashboardDetails: { name: "Regular Dashboard" },
     });
   });
 

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -205,7 +205,7 @@ describe("scenarios > collection_defaults", () => {
     describe("a new dashboard", () => {
       it("should be in the root collection", () => {
         // Make new dashboard and check collection name
-        cy.createDashboard(dashboard_name);
+        cy.createDashboard({ name: dashboard_name });
 
         cy.visit("/collection/root");
         cy.findByText(dashboard_name);
@@ -240,7 +240,7 @@ describe("scenarios > collection_defaults", () => {
     describe("a new dashboard", () => {
       it("should be in the root collection", () => {
         // Make new dashboard and check collection name
-        cy.createDashboard(dashboard_name);
+        cy.createDashboard({ name: dashboard_name });
 
         cy.visit("/collection/root");
         cy.findByText(dashboard_name);
@@ -600,7 +600,7 @@ describe("scenarios > collection_defaults", () => {
     it("collections list on the home page shouldn't depend on the name of the first 50 objects (metabase#16784)", () => {
       // Although there are already some objects in the default snapshot (3 questions, 1 dashboard, 3 collections),
       // let's create 50 more dashboards with the letter of alphabet `D` coming before the first letter of the existing collection `F`.
-      _.times(50, i => cy.createDashboard(`Dashboard ${i}`));
+      _.times(50, i => cy.createDashboard({ name: `Dashboard ${i}` }));
 
       cy.visit("/");
       // There is already a collection named "First collection" in the default snapshot

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -595,7 +595,7 @@ describe("collection permissions", () => {
 
       it("shouldn't render revision history steps when there was no diff (metabase#1926)", () => {
         cy.signInAsAdmin();
-        cy.createDashboard("foo").then(({ body }) => {
+        cy.createDashboard().then(({ body }) => {
           visitAndEditDashboard(body.id);
         });
 

--- a/frontend/test/metabase/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -57,7 +57,7 @@ describe("scenarios > dashboard > parameters", () => {
   });
 
   it("should search across multiple fields", () => {
-    cy.createDashboard("my dash");
+    cy.createDashboard({ name: "my dash" });
 
     cy.visit("/collection/root");
     cy.findByText("my dash").click();
@@ -117,7 +117,7 @@ describe("scenarios > dashboard > parameters", () => {
   });
 
   it("should query with a 2 argument parameter", () => {
-    cy.createDashboard("my dash");
+    cy.createDashboard({ name: "my dash" });
 
     cy.visit("/collection/root");
     cy.findByText("my dash").click();
@@ -363,7 +363,7 @@ describe("scenarios > dashboard > parameters", () => {
       },
       display: "scalar",
     }).then(({ body: { id: card_id } }) => {
-      cy.createDashboard("16181D").then(({ body: { id: dashboard_id } }) => {
+      cy.createDashboard().then(({ body: { id: dashboard_id } }) => {
         // Add previously created question to the dashboard
         cy.request("POST", `/api/dashboard/${dashboard_id}/cards`, {
           cardId: card_id,

--- a/frontend/test/metabase/scenarios/dashboard/chained-filters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/chained-filters.cy.spec.js
@@ -59,56 +59,58 @@ function createQuestion(options, callback) {
 // Once created, add the provided questionId to the dashboard and then
 // map the city/state filters to the template-tags in the native query.
 function createDashboard({ dashboardName, questionId }, callback) {
-  cy.createDashboard(dashboardName).then(({ body: { id: dashboardId } }) => {
-    cy.request("PUT", `/api/dashboard/${dashboardId}`, {
-      parameters: [
-        {
-          name: "State",
-          slug: "state",
-          id: "e8f79be9",
-          type: "location/state",
-        },
-        {
-          name: "City",
-          slug: "city",
-          id: "170b8e99",
-          type: "location/city",
-          filteringParameters: ["e8f79be9"],
-        },
-      ],
-    });
-
-    cy.request("POST", `/api/dashboard/${dashboardId}/cards`, {
-      cardId: questionId,
-    }).then(({ body: { id: dashCardId } }) => {
-      cy.request("PUT", `/api/dashboard/${dashboardId}/cards`, {
-        cards: [
+  cy.createDashboard({ name: dashboardName }).then(
+    ({ body: { id: dashboardId } }) => {
+      cy.request("PUT", `/api/dashboard/${dashboardId}`, {
+        parameters: [
           {
-            id: dashCardId,
-            card_id: questionId,
-            row: 0,
-            col: 0,
-            sizeX: 10,
-            sizeY: 10,
-            parameter_mappings: [
-              {
-                parameter_id: "e8f79be9",
-                card_id: questionId,
-                target: ["dimension", ["template-tag", "state"]],
-              },
-              {
-                parameter_id: "170b8e99",
-                card_id: questionId,
-                target: ["dimension", ["template-tag", "city"]],
-              },
-            ],
+            name: "State",
+            slug: "state",
+            id: "e8f79be9",
+            type: "location/state",
+          },
+          {
+            name: "City",
+            slug: "city",
+            id: "170b8e99",
+            type: "location/city",
+            filteringParameters: ["e8f79be9"],
           },
         ],
       });
 
-      callback(dashboardId);
-    });
-  });
+      cy.request("POST", `/api/dashboard/${dashboardId}/cards`, {
+        cardId: questionId,
+      }).then(({ body: { id: dashCardId } }) => {
+        cy.request("PUT", `/api/dashboard/${dashboardId}/cards`, {
+          cards: [
+            {
+              id: dashCardId,
+              card_id: questionId,
+              row: 0,
+              col: 0,
+              sizeX: 10,
+              sizeY: 10,
+              parameter_mappings: [
+                {
+                  parameter_id: "e8f79be9",
+                  card_id: questionId,
+                  target: ["dimension", ["template-tag", "state"]],
+                },
+                {
+                  parameter_id: "170b8e99",
+                  card_id: questionId,
+                  target: ["dimension", ["template-tag", "city"]],
+                },
+              ],
+            },
+          ],
+        });
+
+        callback(dashboardId);
+      });
+    },
+  );
 }
 
 describe("scenarios > dashboard > chained filter", () => {
@@ -264,7 +266,7 @@ describe("scenarios > dashboard > chained filter", () => {
       name: "15170",
       query: { "source-table": PRODUCTS_ID },
     }).then(({ body: { id: QUESTION_ID } }) => {
-      cy.createDashboard("15170D").then(({ body: { id: DASHBOARD_ID } }) => {
+      cy.createDashboard().then(({ body: { id: DASHBOARD_ID } }) => {
         // Add filter to the dashboard
         cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}`, {
           parameters: [

--- a/frontend/test/metabase/scenarios/dashboard/click-behavior.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/click-behavior.cy.spec.js
@@ -25,7 +25,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
     }).then(({ body: { id: question1Id } }) => {
       cy.createNativeQuestion({ native: { query: "select 0" } }).then(
         ({ body: { id: nativeId } }) => {
-          cy.createDashboard("15993D").then(({ body: { id: dashboardId } }) => {
+          cy.createDashboard().then(({ body: { id: dashboardId } }) => {
             // Add native question to the dashboard
             cy.request("POST", `/api/dashboard/${dashboardId}/cards`, {
               cardId: nativeId,

--- a/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
@@ -71,7 +71,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
       "13927",
       `SELECT PEOPLE.STATE, PEOPLE.CITY from PEOPLE;`,
     ).then(({ body: { id: QUESTION_ID } }) => {
-      cy.createDashboard("13927D").then(({ body: { id: DASHBOARD_ID } }) => {
+      cy.createDashboard().then(({ body: { id: DASHBOARD_ID } }) => {
         cy.log("Add question to the dashboard");
 
         cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
@@ -407,7 +407,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
       },
       display: "bar",
     }).then(({ body: { id: QUESTION_ID } }) => {
-      cy.createDashboard("13785D").then(({ body: { id: DASHBOARD_ID } }) => {
+      cy.createDashboard().then(({ body: { id: DASHBOARD_ID } }) => {
         cy.log("Add filter to the dashboard");
 
         cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}`, {
@@ -531,7 +531,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
       name: "14919",
       query: { "source-table": PRODUCTS_ID },
     }).then(({ body: { id: QUESTION_ID } }) => {
-      cy.createDashboard("14919D").then(({ body: { id: DASHBOARD_ID } }) => {
+      cy.createDashboard().then(({ body: { id: DASHBOARD_ID } }) => {
         // Add previously added question to the dashboard
         cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
           cardId: QUESTION_ID,
@@ -605,7 +605,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
         ],
       },
     }).then(({ body: { id: QUESTION_ID } }) => {
-      cy.createDashboard("15331D").then(({ body: { id: DASHBOARD_ID } }) => {
+      cy.createDashboard().then(({ body: { id: DASHBOARD_ID } }) => {
         // Add filter to the dashboard
         cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}`, {
           parameters: [
@@ -687,7 +687,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
           "graph.metrics": ["VALUE"],
         },
       }).then(({ body: { id: QUESTION2_ID } }) => {
-        cy.createDashboard("15612D").then(({ body: { id: DASHBOARD_ID } }) => {
+        cy.createDashboard().then(({ body: { id: DASHBOARD_ID } }) => {
           // Add the first question to the dashboard
           cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
             cardId: QUESTION1_ID,
@@ -752,7 +752,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
         ],
       },
     }).then(({ body: { id: QUESTION_ID } }) => {
-      cy.createDashboard("13289D").then(({ body: { id: DASHBOARD_ID } }) => {
+      cy.createDashboard().then(({ body: { id: DASHBOARD_ID } }) => {
         // Add question to the dashboard
         cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
           cardId: QUESTION_ID,
@@ -919,45 +919,47 @@ function createDashboard(
   { dashboardName = "dashboard", questionId, visualization_settings },
   callback,
 ) {
-  cy.createDashboard(dashboardName).then(({ body: { id: dashboardId } }) => {
-    cy.request("PUT", `/api/dashboard/${dashboardId}`, {
-      parameters: [
-        {
-          name: "My Param",
-          slug: "my_param",
-          id: "e8f79be9",
-          type: "category",
-        },
-      ],
-    });
-
-    cy.request("POST", `/api/dashboard/${dashboardId}/cards`, {
-      cardId: questionId,
-    }).then(({ body: { id: dashCardId } }) => {
-      cy.request("PUT", `/api/dashboard/${dashboardId}/cards`, {
-        cards: [
+  cy.createDashboard({ name: dashboardName }).then(
+    ({ body: { id: dashboardId } }) => {
+      cy.request("PUT", `/api/dashboard/${dashboardId}`, {
+        parameters: [
           {
-            id: dashCardId,
-            card_id: questionId,
-            row: 0,
-            col: 0,
-            sizeX: 6,
-            sizeY: 6,
-            parameter_mappings: [
-              {
-                parameter_id: "e8f79be9",
-                card_id: questionId,
-                target: ["dimension", ["field", 22, { "source-field": 11 }]],
-              },
-            ],
-            visualization_settings,
+            name: "My Param",
+            slug: "my_param",
+            id: "e8f79be9",
+            type: "category",
           },
         ],
       });
 
-      callback(dashboardId);
-    });
-  });
+      cy.request("POST", `/api/dashboard/${dashboardId}/cards`, {
+        cardId: questionId,
+      }).then(({ body: { id: dashCardId } }) => {
+        cy.request("PUT", `/api/dashboard/${dashboardId}/cards`, {
+          cards: [
+            {
+              id: dashCardId,
+              card_id: questionId,
+              row: 0,
+              col: 0,
+              sizeX: 6,
+              sizeY: 6,
+              parameter_mappings: [
+                {
+                  parameter_id: "e8f79be9",
+                  card_id: questionId,
+                  target: ["dimension", ["field", 22, { "source-field": 11 }]],
+                },
+              ],
+              visualization_settings,
+            },
+          ],
+        });
+
+        callback(dashboardId);
+      });
+    },
+  );
 }
 
 function setParamValue(paramName, text) {

--- a/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
@@ -97,7 +97,7 @@ describe("scenarios > dashboard", () => {
       visualization_settings: {},
     });
 
-    cy.createDashboard("dash:11007");
+    cy.createDashboard({ name: "dash:11007" });
 
     cy.visit("/collection/root");
     // enter newly created dashboard
@@ -149,7 +149,7 @@ describe("scenarios > dashboard", () => {
       },
       display: "map",
     }).then(({ body: { id: questionId } }) => {
-      cy.createDashboard("13597D").then(({ body: { id: dashboardId } }) => {
+      cy.createDashboard().then(({ body: { id: dashboardId } }) => {
         // add filter (ID) to the dashboard
         cy.request("PUT", `/api/dashboard/${dashboardId}`, {
           parameters: [
@@ -220,7 +220,7 @@ describe("scenarios > dashboard", () => {
       name: "14473",
       native: { query: "SELECT COUNT(*) FROM PRODUCTS", "template-tags": {} },
     }).then(({ body: { id: QUESTION_ID } }) => {
-      cy.createDashboard("14473D").then(({ body: { id: DASHBOARD_ID } }) => {
+      cy.createDashboard().then(({ body: { id: DASHBOARD_ID } }) => {
         cy.log("Add 4 filters to the dashboard");
 
         cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}`, {

--- a/frontend/test/metabase/scenarios/dashboard/dashboard_local-only.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard_local-only.cy.spec.js
@@ -28,7 +28,7 @@ describe("LOCAL TESTING ONLY > dashboard", () => {
       name: "15694",
       query: { "source-table": PEOPLE_ID },
     }).then(({ body: { id: QUESTION_ID } }) => {
-      cy.createDashboard("15694D").then(({ body: { id: DASHBOARD_ID } }) => {
+      cy.createDashboard().then(({ body: { id: DASHBOARD_ID } }) => {
         // Add filter to the dashboard
         cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}`, {
           parameters: [

--- a/frontend/test/metabase/scenarios/dashboard/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/permissions.cy.spec.js
@@ -61,7 +61,7 @@ describe("scenarios > dashboard > permissions", () => {
       }).then(({ body: { id } }) => (secondQuestionId = id));
     });
 
-    cy.createDashboard("dashboard").then(({ body: { id: dashId } }) => {
+    cy.createDashboard().then(({ body: { id: dashId } }) => {
       cy.request("POST", `/api/dashboard/${dashId}/cards`, {
         cardId: firstQuestionId,
       }).then(({ body: { id: dashCardIdA } }) => {

--- a/frontend/test/metabase/scenarios/dashboard/text-box.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/text-box.cy.spec.js
@@ -50,13 +50,15 @@ describe("scenarios > dashboard > text-box", () => {
   describe("when text-box is the only element on the dashboard", () => {
     beforeEach(() => {
       cy.server();
-      cy.createDashboard("Test Dashboard");
+      cy.createDashboard().then(({ body: { id } }) => {
+        cy.intercept("PUT", `/api/dashboard/${id}`).as("dashboardUpdated");
+
+        cy.visit(`/dashboard/${id}`);
+      });
     });
 
     // fixed in metabase#11358
     it("should load after save/refresh (metabase#12873)", () => {
-      cy.visit(`/dashboard/2`);
-
       cy.findByText("Test Dashboard");
       cy.findByText("This dashboard is looking empty.");
 
@@ -80,10 +82,6 @@ describe("scenarios > dashboard > text-box", () => {
     });
 
     it("should have a scroll bar for long text (metabase#8333)", () => {
-      cy.intercept("PUT", "/api/dashboard/2").as("dashboardUpdated");
-
-      cy.visit(`/dashboard/2`);
-
       addTextBox(
         "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
       );

--- a/frontend/test/metabase/scenarios/native-filters/reproductions/15163.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native-filters/reproductions/15163.cy.spec.js
@@ -33,7 +33,7 @@ const dashboardFilter = {
 };
 
 ["nodata+nosql", "nosql"].forEach(test => {
-  describe.skip("issue 14302", () => {
+  describe.skip("issue 15163", () => {
     beforeEach(() => {
       cy.intercept("POST", "/api/dataset").as("dataset");
 
@@ -41,7 +41,7 @@ const dashboardFilter = {
       cy.signInAsAdmin();
 
       cy.createNativeQuestion(nativeQuery).then(({ body: { id: card_id } }) => {
-        cy.createDashboard("15163D").then(({ body: { id: dashboard_id } }) => {
+        cy.createDashboard().then(({ body: { id: dashboard_id } }) => {
           cy.addFilterToDashboard({ filter: dashboardFilter, dashboard_id });
 
           // Add previously created question to the dashboard

--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -39,71 +39,69 @@ describe("scenarios > question > filter", () => {
           name: "Q2",
           query: { "source-table": `card__${Q1_ID}` },
         }).then(({ body: { id: Q2_ID } }) => {
-          cy.createDashboard("12985D").then(
-            ({ body: { id: DASHBOARD_ID } }) => {
-              cy.log("Add 2 filters to the dashboard");
+          cy.createDashboard().then(({ body: { id: DASHBOARD_ID } }) => {
+            cy.log("Add 2 filters to the dashboard");
 
-              cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}`, {
-                parameters: [
+            cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}`, {
+              parameters: [
+                {
+                  name: "Date Filter",
+                  slug: "date_filter",
+                  id: "78d4ba0b",
+                  type: "date/all-options",
+                },
+                {
+                  name: "Category",
+                  slug: "category",
+                  id: "20976cce",
+                  type: "category",
+                },
+              ],
+            });
+
+            cy.log("Add nested card to the dashboard");
+
+            cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
+              cardId: Q2_ID,
+            }).then(({ body: { id: DASH_CARD_ID } }) => {
+              cy.log("Connect dashboard filters to the nested card");
+
+              cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}/cards`, {
+                cards: [
                   {
-                    name: "Date Filter",
-                    slug: "date_filter",
-                    id: "78d4ba0b",
-                    type: "date/all-options",
-                  },
-                  {
-                    name: "Category",
-                    slug: "category",
-                    id: "20976cce",
-                    type: "category",
+                    id: DASH_CARD_ID,
+                    card_id: Q2_ID,
+                    row: 0,
+                    col: 0,
+                    sizeX: 10,
+                    sizeY: 8,
+                    series: [],
+                    visualization_settings: {},
+                    // Connect both filters and to the card
+                    parameter_mappings: [
+                      {
+                        parameter_id: "78d4ba0b",
+                        card_id: Q2_ID,
+                        target: [
+                          "dimension",
+                          ["field", PRODUCTS.CREATED_AT, null],
+                        ],
+                      },
+                      {
+                        parameter_id: "20976cce",
+                        card_id: Q2_ID,
+                        target: [
+                          "dimension",
+                          ["field", PRODUCTS.CATEGORY, null],
+                        ],
+                      },
+                    ],
                   },
                 ],
               });
-
-              cy.log("Add nested card to the dashboard");
-
-              cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
-                cardId: Q2_ID,
-              }).then(({ body: { id: DASH_CARD_ID } }) => {
-                cy.log("Connect dashboard filters to the nested card");
-
-                cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}/cards`, {
-                  cards: [
-                    {
-                      id: DASH_CARD_ID,
-                      card_id: Q2_ID,
-                      row: 0,
-                      col: 0,
-                      sizeX: 10,
-                      sizeY: 8,
-                      series: [],
-                      visualization_settings: {},
-                      // Connect both filters and to the card
-                      parameter_mappings: [
-                        {
-                          parameter_id: "78d4ba0b",
-                          card_id: Q2_ID,
-                          target: [
-                            "dimension",
-                            ["field", PRODUCTS.CREATED_AT, null],
-                          ],
-                        },
-                        {
-                          parameter_id: "20976cce",
-                          card_id: Q2_ID,
-                          target: [
-                            "dimension",
-                            ["field", PRODUCTS.CATEGORY, null],
-                          ],
-                        },
-                      ],
-                    },
-                  ],
-                });
-              });
-              cy.visit(`/dashboard/${DASHBOARD_ID}`);
-            },
-          );
+            });
+            cy.visit(`/dashboard/${DASHBOARD_ID}`);
+          });
         });
       });
 
@@ -133,57 +131,55 @@ describe("scenarios > question > filter", () => {
           filter: [">", ["field", "count", { "base-type": "type/Integer" }], 1],
         },
       }).then(({ body: { id: QUESTION_ID } }) => {
-        cy.createDashboard("12985-v2D").then(
-          ({ body: { id: DASHBOARD_ID } }) => {
-            cy.log("Add a category filter to the dashboard");
+        cy.createDashboard().then(({ body: { id: DASHBOARD_ID } }) => {
+          cy.log("Add a category filter to the dashboard");
 
-            cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}`, {
-              parameters: [
+          cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}`, {
+            parameters: [
+              {
+                name: "Category",
+                slug: "category",
+                id: "7c4htcv8",
+                type: "category",
+              },
+            ],
+          });
+
+          cy.log("Add previously created question to the dashboard");
+
+          cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
+            cardId: QUESTION_ID,
+          }).then(({ body: { id: DASH_CARD_ID } }) => {
+            cy.log("Connect dashboard filter to the aggregated card");
+
+            cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}/cards`, {
+              cards: [
                 {
-                  name: "Category",
-                  slug: "category",
-                  id: "7c4htcv8",
-                  type: "category",
+                  id: DASH_CARD_ID,
+                  card_id: QUESTION_ID,
+                  row: 0,
+                  col: 0,
+                  sizeX: 8,
+                  sizeY: 6,
+                  series: [],
+                  visualization_settings: {},
+                  // Connect filter to the card
+                  parameter_mappings: [
+                    {
+                      parameter_id: "7c4htcv8",
+                      card_id: QUESTION_ID,
+                      target: [
+                        "dimension",
+                        ["field", "CATEGORY", { "base-type": "type/Text" }],
+                      ],
+                    },
+                  ],
                 },
               ],
             });
-
-            cy.log("Add previously created question to the dashboard");
-
-            cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
-              cardId: QUESTION_ID,
-            }).then(({ body: { id: DASH_CARD_ID } }) => {
-              cy.log("Connect dashboard filter to the aggregated card");
-
-              cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}/cards`, {
-                cards: [
-                  {
-                    id: DASH_CARD_ID,
-                    card_id: QUESTION_ID,
-                    row: 0,
-                    col: 0,
-                    sizeX: 8,
-                    sizeY: 6,
-                    series: [],
-                    visualization_settings: {},
-                    // Connect filter to the card
-                    parameter_mappings: [
-                      {
-                        parameter_id: "7c4htcv8",
-                        card_id: QUESTION_ID,
-                        target: [
-                          "dimension",
-                          ["field", "CATEGORY", { "base-type": "type/Text" }],
-                        ],
-                      },
-                    ],
-                  },
-                ],
-              });
-            });
-            cy.visit(`/dashboard/${DASHBOARD_ID}`);
-          },
-        );
+          });
+          cy.visit(`/dashboard/${DASHBOARD_ID}`);
+        });
       });
 
       cy.findByPlaceholderText("Category").click();
@@ -345,13 +341,12 @@ describe("scenarios > question > filter", () => {
       },
       display: "pie",
     }).then(({ body: { id: QUESTION_ID } }) => {
-      cy.createDashboard("13960D").then(({ body: { id: DASHBOARD_ID } }) => {
+      cy.createDashboard().then(({ body: { id: DASHBOARD_ID } }) => {
         cy.log(
           "Add filters to the dashboard and set the default value to the first one",
         );
 
         cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}`, {
-          name: "13960D",
           parameters: [
             {
               name: "Category",

--- a/frontend/test/metabase/scenarios/question/nested.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nested.cy.spec.js
@@ -210,7 +210,7 @@ describe("scenarios > question > nested", () => {
       },
     );
 
-    cy.createDashboard("13186D").then(({ body: { id: DASBOARD_ID } }) => {
+    cy.createDashboard().then(({ body: { id: DASBOARD_ID } }) => {
       cy.visit(`/dashboard/${DASBOARD_ID}`);
     });
 

--- a/frontend/test/metabase/scenarios/question/nulls.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nulls.cy.spec.js
@@ -54,59 +54,61 @@ describe("scenarios > question > null", () => {
 
       display: "pie",
     }).then(({ body: { id: questionId } }) => {
-      cy.createDashboard("13626D").then(({ body: { id: dashboardId } }) => {
-        // add filter (ID) to the dashboard
-        cy.request("PUT", `/api/dashboard/${dashboardId}`, {
-          parameters: [
-            {
-              id: "1f97c149",
-              name: "ID",
-              slug: "id",
-              type: "id",
-            },
-          ],
-        });
-
-        // add previously created question to the dashboard
-        cy.request("POST", `/api/dashboard/${dashboardId}/cards`, {
-          cardId: questionId,
-        }).then(({ body: { id: dashCardId } }) => {
-          // connect filter to that question
-          cy.request("PUT", `/api/dashboard/${dashboardId}/cards`, {
-            cards: [
+      cy.createDashboard({ name: "13626D" }).then(
+        ({ body: { id: dashboardId } }) => {
+          // add filter (ID) to the dashboard
+          cy.request("PUT", `/api/dashboard/${dashboardId}`, {
+            parameters: [
               {
-                id: dashCardId,
-                card_id: questionId,
-                row: 0,
-                col: 0,
-                sizeX: 8,
-                sizeY: 6,
-                parameter_mappings: [
-                  {
-                    parameter_id: "1f97c149",
-                    card_id: questionId,
-                    target: ["dimension", ["field", ORDERS.ID, null]],
-                  },
-                ],
+                id: "1f97c149",
+                name: "ID",
+                slug: "id",
+                type: "id",
               },
             ],
           });
-        });
-        // NOTE: The actual "Assertion" phase begins here
-        cy.visit(`/dashboard/${dashboardId}?id=1`);
-        cy.findByText("13626D");
 
-        cy.log("Reported failing in v0.37.0.2");
-        cy.get(".DashCard").within(() => {
-          cy.get(".LoadingSpinner").should("not.exist");
-          cy.findByText("13626");
-          // [quarantine]: flaking in CircleCI, passing locally
-          // TODO: figure out the cause of the failed test in CI after #13721 is merged
-          // cy.get("svg[class*=PieChart__Donut]");
-          // cy.get("[class*=PieChart__Value]").contains("0");
-          // cy.get("[class*=PieChart__Title]").contains(/total/i);
-        });
-      });
+          // add previously created question to the dashboard
+          cy.request("POST", `/api/dashboard/${dashboardId}/cards`, {
+            cardId: questionId,
+          }).then(({ body: { id: dashCardId } }) => {
+            // connect filter to that question
+            cy.request("PUT", `/api/dashboard/${dashboardId}/cards`, {
+              cards: [
+                {
+                  id: dashCardId,
+                  card_id: questionId,
+                  row: 0,
+                  col: 0,
+                  sizeX: 8,
+                  sizeY: 6,
+                  parameter_mappings: [
+                    {
+                      parameter_id: "1f97c149",
+                      card_id: questionId,
+                      target: ["dimension", ["field", ORDERS.ID, null]],
+                    },
+                  ],
+                },
+              ],
+            });
+          });
+          // NOTE: The actual "Assertion" phase begins here
+          cy.visit(`/dashboard/${dashboardId}?id=1`);
+          cy.findByText("13626D");
+
+          cy.log("Reported failing in v0.37.0.2");
+          cy.get(".DashCard").within(() => {
+            cy.get(".LoadingSpinner").should("not.exist");
+            cy.findByText("13626");
+            // [quarantine]: flaking in CircleCI, passing locally
+            // TODO: figure out the cause of the failed test in CI after #13721 is merged
+            // cy.get("svg[class*=PieChart__Donut]");
+            // cy.get("[class*=PieChart__Value]").contains("0");
+            // cy.get("[class*=PieChart__Title]").contains(/total/i);
+          });
+        },
+      );
     });
   });
 
@@ -121,7 +123,7 @@ describe("scenarios > question > null", () => {
         native: { query: "SELECT 0", "template-tags": {} },
         display: "scalar",
       }).then(({ body: { id: Q2_ID } }) => {
-        cy.createDashboard("13801D").then(({ body: { id: DASHBOARD_ID } }) => {
+        cy.createDashboard().then(({ body: { id: DASHBOARD_ID } }) => {
           cy.log("Add both previously created questions to the dashboard");
 
           [Q1_ID, Q2_ID].forEach((questionId, index) => {

--- a/frontend/test/metabase/scenarios/question/view.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/view.cy.spec.js
@@ -99,7 +99,7 @@ describe("scenarios > question > view", () => {
       cy.findByText("Yes").click();
 
       // Native query saved in dasbhoard
-      cy.createDashboard("Dashboard");
+      cy.createDashboard();
 
       cy.createNativeQuestion({
         name: "Question",

--- a/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
@@ -15,7 +15,7 @@ describe("scenarios > dashboard > subscriptions", () => {
   });
 
   it("should not allow sharing if there are no dashboard cards", () => {
-    cy.createDashboard("15077D").then(({ body: { id: DASHBOARD_ID } }) => {
+    cy.createDashboard().then(({ body: { id: DASHBOARD_ID } }) => {
       cy.visit(`/dashboard/${DASHBOARD_ID}`);
     });
     cy.findByText("This dashboard is looking empty.");
@@ -31,7 +31,7 @@ describe("scenarios > dashboard > subscriptions", () => {
   });
 
   it("should allow sharing if dashboard contains only text cards (metabase#15077)", () => {
-    cy.createDashboard("15077D").then(({ body: { id: DASHBOARD_ID } }) => {
+    cy.createDashboard().then(({ body: { id: DASHBOARD_ID } }) => {
       cy.visit(`/dashboard/${DASHBOARD_ID}`);
     });
     cy.icon("pencil").click();
@@ -162,48 +162,50 @@ describe("scenarios > dashboard > subscriptions", () => {
           },
         },
       }).then(({ body: { id: QUESTION_ID } }) => {
-        cy.createDashboard("15705D").then(({ body: { id: DASHBOARD_ID } }) => {
-          // Add filter to the dashboard
-          cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}`, {
-            // Using the old dashboard filter syntax
-            parameters: [
-              {
-                name: "Quantity",
-                slug: "quantity",
-                id: "930e4001",
-                type: "category",
-                default: "20",
-              },
-            ],
-          });
-
-          // Add question to the dashboard
-          cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
-            cardId: QUESTION_ID,
-          }).then(({ body: { id: DASH_CARD_ID } }) => {
-            // Connect filter to that question
-            cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}/cards`, {
-              cards: [
+        cy.createDashboard({ name: "15705D" }).then(
+          ({ body: { id: DASHBOARD_ID } }) => {
+            // Add filter to the dashboard
+            cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}`, {
+              // Using the old dashboard filter syntax
+              parameters: [
                 {
-                  id: DASH_CARD_ID,
-                  card_id: QUESTION_ID,
-                  row: 0,
-                  col: 0,
-                  sizeX: 12,
-                  sizeY: 10,
-                  parameter_mappings: [
-                    {
-                      parameter_id: "930e4001",
-                      card_id: QUESTION_ID,
-                      target: ["variable", ["template-tag", "qty"]],
-                    },
-                  ],
+                  name: "Quantity",
+                  slug: "quantity",
+                  id: "930e4001",
+                  type: "category",
+                  default: "20",
                 },
               ],
             });
-          });
-          assignRecipient({ dashboard_id: DASHBOARD_ID });
-        });
+
+            // Add question to the dashboard
+            cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
+              cardId: QUESTION_ID,
+            }).then(({ body: { id: DASH_CARD_ID } }) => {
+              // Connect filter to that question
+              cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}/cards`, {
+                cards: [
+                  {
+                    id: DASH_CARD_ID,
+                    card_id: QUESTION_ID,
+                    row: 0,
+                    col: 0,
+                    sizeX: 12,
+                    sizeY: 10,
+                    parameter_mappings: [
+                      {
+                        parameter_id: "930e4001",
+                        card_id: QUESTION_ID,
+                        target: ["variable", ["template-tag", "qty"]],
+                      },
+                    ],
+                  },
+                ],
+              });
+            });
+            assignRecipient({ dashboard_id: DASHBOARD_ID });
+          },
+        );
       });
       // Click anywhere outside to close the popover
       cy.findByText("15705D").click();

--- a/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
@@ -91,60 +91,62 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
         },
         display: "line",
       }).then(({ body: { id: Q2_ID } }) => {
-        cy.createDashboard("11442D").then(({ body: { id: DASHBOARD_ID } }) => {
-          cy.log("Add the first question to the dashboard");
+        cy.createDashboard({ name: "11442D" }).then(
+          ({ body: { id: DASHBOARD_ID } }) => {
+            cy.log("Add the first question to the dashboard");
 
-          cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
-            cardId: Q1_ID,
-          }).then(({ body: { id: DASH_CARD_ID } }) => {
-            cy.log(
-              "Add additional series combining it with the second question",
-            );
+            cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
+              cardId: Q1_ID,
+            }).then(({ body: { id: DASH_CARD_ID } }) => {
+              cy.log(
+                "Add additional series combining it with the second question",
+              );
 
-            cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}/cards`, {
-              cards: [
-                {
-                  id: DASH_CARD_ID,
-                  card_id: Q1_ID,
-                  row: 0,
-                  col: 0,
-                  sizeX: 16,
-                  sizeY: 12,
-                  series: [
-                    {
-                      id: Q2_ID,
-                      model: "card",
-                    },
-                  ],
-                  visualization_settings: {},
-                  parameter_mappings: [],
-                },
-              ],
+              cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}/cards`, {
+                cards: [
+                  {
+                    id: DASH_CARD_ID,
+                    card_id: Q1_ID,
+                    row: 0,
+                    col: 0,
+                    sizeX: 16,
+                    sizeY: 12,
+                    series: [
+                      {
+                        id: Q2_ID,
+                        model: "card",
+                      },
+                    ],
+                    visualization_settings: {},
+                    parameter_mappings: [],
+                  },
+                ],
+              });
             });
-          });
 
-          cy.visit(`/dashboard/${DASHBOARD_ID}`);
+            cy.visit(`/dashboard/${DASHBOARD_ID}`);
 
-          cy.log("The first series line");
-          cy.get(".sub.enable-dots._0")
-            .find(".dot")
-            .eq(0)
-            .click({ force: true });
-          cy.findByText(/Zoom in/i);
-          cy.findByText(/View these Orders/i);
+            cy.log("The first series line");
+            cy.get(".sub.enable-dots._0")
+              .find(".dot")
+              .eq(0)
+              .click({ force: true });
+            cy.findByText(/Zoom in/i);
+            cy.findByText(/View these Orders/i);
 
-          // Click anywhere else to close the first action panel
-          cy.findByText("11442D").click();
+            // Click anywhere else to close the first action panel
+            cy.findByText("11442D").click();
 
-          // Second line from the second question
-          cy.log("The second series line");
-          cy.get(".sub.enable-dots._1")
-            .find(".dot")
-            .eq(0)
-            .click({ force: true });
-          cy.findByText(/Zoom in/i);
-          cy.findByText(/View these Products/i);
-        });
+            // Second line from the second question
+            cy.log("The second series line");
+            cy.get(".sub.enable-dots._1")
+              .find(".dot")
+              .eq(0)
+              .click({ force: true });
+            cy.findByText(/Zoom in/i);
+            cy.findByText(/View these Products/i);
+          },
+        );
       });
     });
   });
@@ -171,60 +173,62 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
         },
         display: "line",
       }).then(({ body: { id: Q2_ID } }) => {
-        cy.createDashboard("13457D").then(({ body: { id: DASHBOARD_ID } }) => {
-          cy.log("Add the first question to the dashboard");
+        cy.createDashboard({ name: "13457D" }).then(
+          ({ body: { id: DASHBOARD_ID } }) => {
+            cy.log("Add the first question to the dashboard");
 
-          cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
-            cardId: Q1_ID,
-          }).then(({ body: { id: DASH_CARD_ID } }) => {
-            cy.log(
-              "Add additional series combining it with the second question",
-            );
+            cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
+              cardId: Q1_ID,
+            }).then(({ body: { id: DASH_CARD_ID } }) => {
+              cy.log(
+                "Add additional series combining it with the second question",
+              );
 
-            cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}/cards`, {
-              cards: [
-                {
-                  id: DASH_CARD_ID,
-                  card_id: Q1_ID,
-                  row: 0,
-                  col: 0,
-                  sizeX: 16,
-                  sizeY: 12,
-                  series: [
-                    {
-                      id: Q2_ID,
-                      model: "card",
-                    },
-                  ],
-                  visualization_settings: {},
-                  parameter_mappings: [],
-                },
-              ],
+              cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}/cards`, {
+                cards: [
+                  {
+                    id: DASH_CARD_ID,
+                    card_id: Q1_ID,
+                    row: 0,
+                    col: 0,
+                    sizeX: 16,
+                    sizeY: 12,
+                    series: [
+                      {
+                        id: Q2_ID,
+                        model: "card",
+                      },
+                    ],
+                    visualization_settings: {},
+                    parameter_mappings: [],
+                  },
+                ],
+              });
             });
-          });
 
-          cy.visit(`/dashboard/${DASHBOARD_ID}`);
+            cy.visit(`/dashboard/${DASHBOARD_ID}`);
 
-          cy.log("The first series line");
-          cy.get(".sub.enable-dots._0")
-            .find(".dot")
-            .eq(0)
-            .click({ force: true });
-          cy.findByText(/Zoom in/i);
-          cy.findByText(/View these Orders/i);
+            cy.log("The first series line");
+            cy.get(".sub.enable-dots._0")
+              .find(".dot")
+              .eq(0)
+              .click({ force: true });
+            cy.findByText(/Zoom in/i);
+            cy.findByText(/View these Orders/i);
 
-          // Click anywhere else to close the first action panel
-          cy.findByText("13457D").click();
+            // Click anywhere else to close the first action panel
+            cy.findByText("13457D").click();
 
-          // Second line from the second question
-          cy.log("The third series line");
-          cy.get(".sub.enable-dots._2")
-            .find(".dot")
-            .eq(0)
-            .click({ force: true });
-          cy.findByText(/Zoom in/i);
-          cy.findByText(/View these Orders/i);
-        });
+            // Second line from the second question
+            cy.log("The third series line");
+            cy.get(".sub.enable-dots._2")
+              .find(".dot")
+              .eq(0)
+              .click({ force: true });
+            cy.findByText(/Zoom in/i);
+            cy.findByText(/View these Orders/i);
+          },
+        );
       });
     });
   });
@@ -532,7 +536,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
       },
       display: "pie",
     }).then(({ body: { id: QUESTION_ID } }) => {
-      cy.createDashboard("15250D").then(({ body: { id: DASHBOARD_ID } }) => {
+      cy.createDashboard().then(({ body: { id: DASHBOARD_ID } }) => {
         cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
           cardId: QUESTION_ID,
         }).then(({ body: { id: DASH_CARD_ID } }) => {

--- a/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
@@ -196,7 +196,7 @@ describe("scenarios > visualizations > line chart", () => {
             ],
           ],
         }).then(({ body: { id: question2Id } }) => {
-          cy.createDashboard("16249D").then(({ body: { id: dashboardId } }) => {
+          cy.createDashboard().then(({ body: { id: dashboardId } }) => {
             addBothSeriesToDashboard({
               dashboardId,
               firstCardId: question1Id,
@@ -245,7 +245,7 @@ describe("scenarios > visualizations > line chart", () => {
           },
           display: "line",
         }).then(({ body: { id: question2Id } }) => {
-          cy.createDashboard("16249D").then(({ body: { id: dashboardId } }) => {
+          cy.createDashboard().then(({ body: { id: dashboardId } }) => {
             addBothSeriesToDashboard({
               dashboardId,
               firstCardId: question1Id,

--- a/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -527,7 +527,7 @@ describe("scenarios > visualizations > pivot tables", () => {
         display: "pivot",
         visualization_settings: {},
       }).then(({ body: { id: QUESTION_ID } }) => {
-        cy.createDashboard(DASHBOARD_NAME).then(
+        cy.createDashboard({ name: DASHBOARD_NAME }).then(
           ({ body: { id: DASHBOARD_ID } }) => {
             cy.log("Add previously created question to that dashboard");
             cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
@@ -587,7 +587,7 @@ describe("scenarios > visualizations > pivot tables", () => {
           enable_embedding: true,
         });
 
-        cy.createDashboard(DASHBOARD_NAME).then(
+        cy.createDashboard({ name: DASHBOARD_NAME }).then(
           ({ body: { id: DASHBOARD_ID } }) => {
             cy.log("Add previously created question to that dashboard");
             cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {

--- a/frontend/test/metabase/scenarios/visualizations/scalar.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/scalar.cy.spec.js
@@ -17,7 +17,7 @@ describe("scenarios > visualizations > scalar", () => {
   };
 
   Object.entries(SCREEN_SIZES).forEach(([size, viewport]) => {
-    it(`should render human readable numbers on ${size} screen size (metabase#12629)`, () => {
+    it(`should render human readable numbers on ${size} screen size (metabase`, () => {
       const [width, height] = viewport;
 
       cy.skipOn(size === "mobile");
@@ -31,7 +31,7 @@ describe("scenarios > visualizations > scalar", () => {
         },
         display: "scalar",
       }).then(({ body: { id: questionId } }) => {
-        cy.createDashboard("12629").then(({ body: { id: dashboardId } }) => {
+        cy.createDashboard().then(({ body: { id: dashboardId } }) => {
           // Add previously created question to the dashboard
           cy.request("POST", `/api/dashboard/${dashboardId}/cards`, {
             cardId: questionId,

--- a/frontend/test/snapshot-creators/default.cy.snap.js
+++ b/frontend/test/snapshot-creators/default.cy.snap.js
@@ -152,7 +152,7 @@ describe("snapshots", () => {
     });
 
     // dashboard 1: Orders in a dashboard
-    cy.createDashboard("Orders in a dashboard");
+    cy.createDashboard({ name: "Orders in a dashboard" });
     cy.request("POST", `/api/dashboard/1/cards`, { cardId: 1 }).then(
       ({ body: { id: dashCardId } }) => {
         cy.request("PUT", `/api/dashboard/1/cards`, {


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Updates the syntax for `cy.createDashboard` custom command to make it more compatible with the `cy.createQuestion`
- Updates composite API custom Cypress commands that were using `cy.createDashboard`
- Updates tests

### How to make sure it works?
- All tests should pass in CI
- Although it looks hard to review 28 changed files, there are only 3 files that are core to this change. Everything else are just test updates (which should fail in CI if anything is wrong)


```javascript
Cypress.Commands.add(
  "createDashboard",
  // This function now provides a fallback for the **required** `name`, and it doesn't rely on the position of the params anymore
  ({ name = "Test Dashboard", ...dashboardDetails } = {}) => {
    cy.log(`Create a dashboard: ${name}`);

    // For all the possible keys, refer to `src/metabase/api/dashboard.clj`
    cy.request("POST", "/api/dashboard", { name, ...dashboardDetails });
  },
);
```

### Examples
```javascript
cy.createDashboard(); /* => "Test Dashboard" */
cy.createDashboard({ name: "Foo" }); /* => "Foo" */
cy.createDashboard({ name: "Foo", description: "Bar" });

// create a dashboard in some specific collection
cy.createDashboard({ collection_id: 42 });
```

Since we don't hard code accepted params anymore, it's possible to add filters to the dashboard directly. Please refer to the source: https://github.com/metabase/metabase/blob/master/src/metabase/api/dashboard.clj#L77

```javascript
const parameters = [
  { name: "Title", slug: "title", id: "9f20a0d5", type: "category" },
  { name: "Vendor", slug: "vendor", id: "a73b7c9", type: "category" },
];

cy.createDashboard({
  name: "Foo"", // we can also safely omit this
  parameters,
})
```

Thanks @gusaiani for the help and pairing while I was working on this.