### PR TITLE
enable default parameters to be unset on dashboards

### DIFF
--- a/frontend/src/metabase/dashboard/dashboard.js
+++ b/frontend/src/metabase/dashboard/dashboard.js
@@ -34,6 +34,7 @@ import { applyParameters, questionUrlWithParameters } from "metabase/meta/Card";
 import {
   getParameterValuesBySlug,
   getParameterValuesByIdFromQueryParams,
+  removeDefaultedParametersWithEmptyStringValue,
 } from "metabase/meta/Parameter";
 import * as Urls from "metabase/lib/urls";
 
@@ -738,6 +739,7 @@ export const fetchDashboard = createThunkAction(FETCH_DASHBOARD, function(
     const parameterValuesById = getParameterValuesByIdFromQueryParams(
       result.parameters,
       queryParams,
+      removeDefaultedParametersWithEmptyStringValue,
     );
 
     return {

--- a/frontend/src/metabase/meta/Parameter.js
+++ b/frontend/src/metabase/meta/Parameter.js
@@ -618,6 +618,10 @@ export function getValuePopulatedParameters(parameters, parameterValues) {
     : parameters;
 }
 
+// on dashboards we treat a default parameter with a set value of "" (from a query parameter)
+// to mean that the parameter value is explicitly unset.
+// this is NOT the case elsewhere (native questions, pulses) because default values are
+// automatically used in the query when unset.
 export function isDefaultedParameterSpecialCase(parameter, value) {
   return hasDefaultParameterValue(parameter) && value === "";
 }

--- a/frontend/src/metabase/parameters/components/Parameters/Parameters.jsx
+++ b/frontend/src/metabase/parameters/components/Parameters/Parameters.jsx
@@ -5,7 +5,10 @@ import querystring from "querystring";
 
 import ParametersList from "metabase/parameters/components/ParametersList";
 import { syncQueryParamsWithURL } from "./syncQueryParamsWithURL";
-import { getParameterValuesBySlug } from "metabase/meta/Parameter";
+import {
+  getParameterValuesBySlug,
+  removeUndefaultedNilValuedPairs,
+} from "metabase/meta/Parameter";
 import { getMetadata } from "metabase/selectors/metadata";
 
 @connect(state => ({ metadata: getMetadata(state) }))
@@ -21,13 +24,14 @@ export default class Parameters extends Component {
   }
 
   componentDidUpdate() {
-    const { parameters, parameterValues } = this.props;
+    const { parameters, parameterValues, dashboard } = this.props;
 
     if (this.props.syncQueryString) {
       // sync parameters to URL query string
       const parameterValuesBySlug = getParameterValuesBySlug(
         parameters,
         parameterValues,
+        dashboard && removeUndefaultedNilValuedPairs,
       );
 
       let search = querystring.stringify(parameterValuesBySlug);

--- a/frontend/test/metabase/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -400,6 +400,49 @@ describe("scenarios > dashboard > parameters", () => {
     cy.findByText("Text contains").click();
     cy.findByText("No valid fields");
   });
+
+  it("should allow for forcefully unset default parameters by clicking the parameter widget's removal button", () => {
+    cy.visit("/dashboard/1");
+
+    // Add a filter
+    cy.icon("pencil").click();
+    cy.icon("filter").click();
+    cy.findByText("Location").click();
+    cy.findByText("Dropdown").click();
+
+    // Link that filter to the card
+    cy.findByText("Select…").click();
+    popover().within(() => {
+      cy.findByText("City").click();
+    });
+
+    // Create a default value and save filter
+    cy.findByText("No default").click();
+    cy.findByPlaceholderText("Search by City")
+      .click()
+      .type("Boz");
+    cy.findByText("Bozeman").click();
+    cy.findByText("Add filter").click();
+    cy.get(".Button--primary")
+      .contains("Done")
+      .click();
+
+    // Save the dashboard and wait for the card query to rerun
+    cy.findByText("Save").click();
+    cy.findByText("You're editing this dashboard.").should("not.exist");
+    cy.findByText("Bozeman");
+    cy.findByText("No results!");
+
+    // Remove the filter and check that there are now results where there previously weren't
+    cy.icon("close").click();
+    cy.findByText("Bozeman").should("not.exist");
+    cy.findByText("39.72");
+
+    cy.log("**Unset filter should persist across a reload of the page**");
+    cy.reload();
+    cy.findByText("Bozeman").should("not.exist");
+    cy.findByText("39.72");
+  });
 });
 
 function selectFilter(selection, filterName) {


### PR DESCRIPTION
This PRs adds code so that **defaulted** parameters **on dashboards** get treated slightly differently so that we are able to share URLs with the default values unapplied.

1. When a defaulted parameter is found in a URL's query params with a value of `""` it will treat the parameter as being **unset**
2. When clearing a defaulted parameter by clicking the close icon on the parameter's widget, it will set the parameter in the URL with a value of `""` (it will look like `foo=`)

This should only affect parameters on dashboards. Native questions should behave as they do currently. This is because native queries use defaulted parameters regardless of being found in the `parameters` array on the query, so you can't actually remove them from the FE.

Here's a video of how defaulted parameters work:

https://user-images.githubusercontent.com/13057258/130283917-248ab52c-32be-4176-a948-5e4392cdd7c1.mov

Here's a video of how parameters without default values work:

https://user-images.githubusercontent.com/13057258/130283963-e84e0425-5bb4-4b9a-8672-8e8584e8996d.mov

Here's a recording of unchanged native question behavior:

https://user-images.githubusercontent.com/13057258/130284020-e0655ac2-fbe1-4c80-9ce2-50aafbbfc68a.mov

