### PR TITLE
Update notebook editor's join step UI

### DIFF
--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -171,7 +171,7 @@ function JoinClause({ color, join, updateQuery, showRemove }) {
     <JoinClauseRoot>
       <NotebookCell color={color} flex={1}>
         <NotebookCellItem color={color}>
-          {(lhsTable && lhsTable.displayName()) || `Previous results`}
+          {lhsTable?.displayName() || `Previous results`}
         </NotebookCellItem>
 
         <JoinTypePicker join={join} color={color} updateQuery={updateQuery} />

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -19,12 +19,12 @@ import FieldsPicker from "./FieldsPicker";
 import {
   JoinStepRoot,
   JoinClausesContainer,
+  JoinClauseRoot,
   JoinClauseContainer,
   JoinStrategyIcon,
   JoinTypeSelectRoot,
   JoinTypeOptionRoot,
   JoinTypeIcon,
-  JoinedTableControlRoot,
   JoinWhereConditionLabel,
   JoinOnConditionLabel,
   RemoveJoinIcon,
@@ -168,52 +168,54 @@ function JoinClause({ color, join, updateQuery, showRemove }) {
   }
 
   return (
-    <NotebookCell color={color}>
-      <NotebookCellItem color={color}>
-        {(lhsTable && lhsTable.displayName()) || `Previous results`}
-      </NotebookCellItem>
+    <JoinClauseRoot>
+      <NotebookCell color={color} flex={1}>
+        <NotebookCellItem color={color}>
+          {(lhsTable && lhsTable.displayName()) || `Previous results`}
+        </NotebookCellItem>
 
-      <JoinTypePicker join={join} color={color} updateQuery={updateQuery} />
+        <JoinTypePicker join={join} color={color} updateQuery={updateQuery} />
 
-      <JoinTablePicker
-        join={join}
-        query={query}
-        joinedTable={joinedTable}
-        color={color}
-        updateQuery={updateQuery}
-        onSourceTableSet={onSourceTableSet}
-      />
+        <JoinTablePicker
+          join={join}
+          query={query}
+          joinedTable={joinedTable}
+          color={color}
+          updateQuery={updateQuery}
+          onSourceTableSet={onSourceTableSet}
+        />
+      </NotebookCell>
 
       {joinedTable && (
-        <JoinedTableControlRoot>
+        <React.Fragment>
           <JoinWhereConditionLabel />
 
-          <JoinDimensionPicker
-            color={color}
-            query={query}
-            dimension={join.parentDimension()}
-            options={join.parentDimensionOptions()}
-            onChange={onParentDimensionChange}
-            ref={parentDimensionPickerRef}
-            data-testid="parent-dimension"
-          />
-
-          <JoinOnConditionLabel />
-
-          <JoinDimensionPicker
-            color={color}
-            query={query}
-            dimension={join.joinDimension()}
-            options={join.joinDimensionOptions()}
-            onChange={onJoinDimensionChange}
-            ref={joinDimensionPickerRef}
-            data-testid="join-dimension"
-          />
-        </JoinedTableControlRoot>
+          <NotebookCell color={color} flex={1}>
+            <JoinDimensionPicker
+              color={color}
+              query={query}
+              dimension={join.parentDimension()}
+              options={join.parentDimensionOptions()}
+              onChange={onParentDimensionChange}
+              ref={parentDimensionPickerRef}
+              data-testid="parent-dimension"
+            />
+            <JoinOnConditionLabel />
+            <JoinDimensionPicker
+              color={color}
+              query={query}
+              dimension={join.joinDimension()}
+              options={join.joinDimensionOptions()}
+              onChange={onJoinDimensionChange}
+              ref={joinDimensionPickerRef}
+              data-testid="join-dimension"
+            />
+          </NotebookCell>
+        </React.Fragment>
       )}
 
       {showRemove && <RemoveJoinIcon onClick={removeJoin} />}
-    </NotebookCell>
+    </JoinClauseRoot>
   );
 }
 

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -189,7 +189,6 @@ function JoinClause({ color, join, updateQuery, showRemove }) {
       {joinedTable && (
         <React.Fragment>
           <JoinWhereConditionLabel />
-
           <NotebookCell color={color} flex={1}>
             <JoinDimensionPicker
               color={color}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -17,9 +17,9 @@ import {
 import { FieldsPickerIcon, FIELDS_PICKER_STYLES } from "../FieldsPickerIcon";
 import FieldsPicker from "./FieldsPicker";
 import {
+  JoinStepRoot,
   JoinClausesContainer,
   JoinClauseContainer,
-  JoinClauseRoot,
   JoinStrategyIcon,
   JoinTypeSelectRoot,
   JoinTypeOptionRoot,
@@ -79,7 +79,7 @@ export default function JoinStep({
   }
 
   return (
-    <NotebookCell color={color} flexWrap="nowrap">
+    <JoinStepRoot>
       <JoinClausesContainer>
         {joins.map((join, index) => {
           const isLast = index === joins.length - 1;
@@ -103,7 +103,7 @@ export default function JoinStep({
           onClick={addNewJoinClause}
         />
       )}
-    </NotebookCell>
+    </JoinStepRoot>
   );
 }
 
@@ -168,7 +168,7 @@ function JoinClause({ color, join, updateQuery, showRemove }) {
   }
 
   return (
-    <JoinClauseRoot>
+    <NotebookCell color={color}>
       <NotebookCellItem color={color}>
         {(lhsTable && lhsTable.displayName()) || `Previous results`}
       </NotebookCellItem>
@@ -213,7 +213,7 @@ function JoinClause({ color, join, updateQuery, showRemove }) {
       )}
 
       {showRemove && <RemoveJoinIcon onClick={removeJoin} />}
-    </JoinClauseRoot>
+    </NotebookCell>
   );
 }
 

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -171,7 +171,7 @@ function JoinClause({ color, join, updateQuery, showRemove }) {
     <JoinClauseRoot>
       <NotebookCell color={color} flex={1}>
         <NotebookCellItem color={color}>
-          {lhsTable?.displayName() || `Previous results`}
+          {lhsTable?.displayName() || t`Previous results`}
         </NotebookCellItem>
 
         <JoinTypePicker join={join} color={color} updateQuery={updateQuery} />

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.styled.jsx
@@ -64,7 +64,7 @@ export const JoinTypeIcon = styled(Icon).attrs({ size: 24 })`
 export const JoinWhereConditionLabel = styled.span.attrs({ children: "on" })`
   color: ${color("brand")};
   font-weight: bold;
-  margin: 0 16px;
+  margin: 0 ${space(2)};
 `;
 
 export const JoinOnConditionLabel = styled.span.attrs({ children: "=" })`

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.styled.jsx
@@ -3,6 +3,11 @@ import { color } from "metabase/lib/colors";
 import { space } from "metabase/styled-components/theme";
 import Icon from "metabase/components/Icon";
 
+export const JoinStepRoot = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
 export const JoinClausesContainer = styled.div`
   display: flex;
   flex-direction: column;
@@ -11,12 +16,6 @@ export const JoinClausesContainer = styled.div`
 
 export const JoinClauseContainer = styled.div`
   margin-bottom: ${props => (props.isLast ? 0 : "2px")};
-`;
-
-export const JoinClauseRoot = styled.div`
-  display: flex;
-  align-items: center;
-  flex: 1 1 auto;
 `;
 
 export const JoinStrategyIcon = styled(Icon).attrs({ size: 32 })`

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.styled.jsx
@@ -11,7 +11,7 @@ export const JoinStepRoot = styled.div`
 export const JoinClausesContainer = styled.div`
   display: flex;
   flex-direction: column;
-  flex: 1 0 auto;
+  flex: 1;
 `;
 
 export const JoinClauseContainer = styled.div`
@@ -61,20 +61,18 @@ export const JoinTypeIcon = styled(Icon).attrs({ size: 24 })`
   color: ${props => (props.isSelected ? color("text-white") : color("brand"))};
 `;
 
-export const JoinWhereConditionLabel = styled.span.attrs({ children: "where" })`
-  color: ${color("text-medium")};
+export const JoinWhereConditionLabel = styled.span.attrs({ children: "on" })`
+  color: ${color("brand")};
   font-weight: bold;
-  margin-top: 6px;
-  margin-left: 10px;
-  margin-right: 14px;
+  margin: 0 16px;
 `;
 
 export const JoinOnConditionLabel = styled.span.attrs({ children: "=" })`
+  font-size: 20;
   font-weight: bold;
   color: ${color("text-medium")};
   margin-left: 2px;
   margin-right: 6px;
-  margin-top: 6px;
 `;
 
 export const RemoveJoinIcon = styled(Icon).attrs({ name: "close", size: 18 })`

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.styled.jsx
@@ -18,6 +18,12 @@ export const JoinClauseContainer = styled.div`
   margin-bottom: ${props => (props.isLast ? 0 : "2px")};
 `;
 
+export const JoinClauseRoot = styled.div`
+  display: flex;
+  align-items: center;
+  margin-bottom: ${props => (props.isLast ? 0 : "2px")};
+`;
+
 export const JoinStrategyIcon = styled(Icon).attrs({ size: 32 })`
   color: ${color("brand")};
   margin-right: 6px;
@@ -53,11 +59,6 @@ export const JoinTypeOptionRoot = styled.div`
 export const JoinTypeIcon = styled(Icon).attrs({ size: 24 })`
   margin-right: ${space(1)};
   color: ${props => (props.isSelected ? color("text-white") : color("brand"))};
-`;
-
-export const JoinedTableControlRoot = styled.div`
-  display: flex;
-  align-items: center;
 `;
 
 export const JoinWhereConditionLabel = styled.span.attrs({ children: "where" })`


### PR DESCRIPTION
This PR splits the notebook editor's join step UI into two different cells.
Also fixes #16937 (Content in notebook step UI can overflow in ugly ways)

## To Verify

### Updated UI

1. Ask a question > Custom Question > Sample Dataset > Orders
2. Click the join icon under the schema and table selector
3. Select different tables and fields, make sure it works as it used to and only the UI changes

### Content Overflow

1. Sign in as admin
2. Go to `/admin/datamodel/database/1/table/1` (Sample Dataset Products' table data model page)
3. Give any column a really long name like "Very Long Field Name Here to Test Fields Wrapping"
4. Ask a question > Custom Question > Sample Dataset > Orders
5. Click the join icon under the schema and table selector
6. Join the Products table on the field with a long name
7. Make sure the content is wrapped and there is no overflow with any window size

## Demo

### Updated UI

**Before**
<img width="996" alt="before" src="https://user-images.githubusercontent.com/17258145/130189642-68c60989-02cb-47bd-8a51-913fe8f194b2.png">

**After**
<img width="1086" alt="after" src="https://user-images.githubusercontent.com/17258145/130189657-fd24fea0-0acc-49e2-9a2b-c18fe927eca5.png">

### Content Overflow

<details>
<summary>Long dimension name</summary>
<img width="690" alt="long-name-example" src="https://user-images.githubusercontent.com/17258145/130190852-db642a47-2963-48a9-bf98-4cfa50c17870.png">
</details>

<details>
<summary>Resizing</summary>
**Before**

https://user-images.githubusercontent.com/17258145/130190869-5f9e1771-cbbd-4b3e-a212-98633e37b22c.mov

**After**

https://user-images.githubusercontent.com/17258145/130190874-726ea6ab-033f-45a3-ae9b-ad40f2581ecb.mov
</details>

