### PR TITLE
Don't warn when running interpreted js

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -111,7 +111,6 @@
   org.eclipse.jetty/jetty-server            {:mvn/version "9.4.43.v20210629"}   ; web server
   org.flatland/ordered                      {:mvn/version "1.5.9"}              ; ordered maps & sets
   org.graalvm.js/js                         {:mvn/version "21.2.0"}           ; JavaScript engine
-  org.graalvm.js/js-scriptengine            {:mvn/version "21.2.0"}
   org.liquibase/liquibase-core              {:mvn/version "3.6.3"               ; migration management (Java lib)
                                              :exclusions  [ch.qos.logback/logback-classic]}
   org.mariadb.jdbc/mariadb-java-client      {:mvn/version "2.6.2"}              ; MySQL/MariaDB driver

--- a/src/metabase/pulse/render/js_engine.clj
+++ b/src/metabase/pulse/render/js_engine.clj
@@ -1,4 +1,11 @@
 (ns metabase.pulse.render.js-engine
+  "Graal polyglot context suitable for executing javascript code.
+
+  We run the js in interpreted mode and turn off the warning with the `(option \"engine.WarnInterpreterOnly\"
+  \"false\")`. Ideally we would compile the javascript but this is difficult when using the graal ecosystem in a non
+  graal jdk. See https://github.com/oracle/graaljs/blob/master/docs/user/RunOnJDK.md for more information.
+
+  Javadocs: https://www.graalvm.org/truffle/javadoc/overview-summary.html"
   (:require [clojure.java.io :as io])
   (:import [org.graalvm.polyglot Context HostAccess Source Value]))
 
@@ -6,6 +13,8 @@
   "Create a new org.graalvm.polyglot.Context suitable to evaluate javascript"
   []
   (.. (Context/newBuilder (into-array String ["js"]))
+      ;; https://github.com/oracle/graaljs/blob/master/docs/user/RunOnJDK.md
+      (option "engine.WarnInterpreterOnly" "false")
       (allowHostAccess HostAccess/ALL)
       (allowHostClassLookup (reify java.util.function.Predicate
                               (test [_ _] true)))


### PR DESCRIPTION
I'm not sure we can fix this. We need the graal compiler which doesn't
appear to be jdk 8 compatible but I can't actually find javadocs for
it. Its not clear from
https://github.com/oracle/graaljs/blob/master/docs/user/RunOnJDK.md
how you can actually run it.

I tried adding the graal compiler but that seems to assume you are in
a graal vm and fails not finding a class.

To get a list of all the options available for a context's engine,

```clojure
(doto 'metabase.pulse.render.js-engine require in-ns)
(map (comp (juxt :name :help) bean)
     (.getOptions (.getEngine (context))))
```

I've done some profiling

```clojure
(dotimes [_ 5]
  (time
   (do (let [rows [["apples" 2]
                   ["bananas" 3]]
             colors {"apples" "red" "bananas" "yellow"}]
         (js-svg/categorical-donut rows colors))
       nil)))

"Elapsed time: 210.32659 msecs"
"Elapsed time: 193.211736 msecs"
"Elapsed time: 190.97775 msecs"
"Elapsed time: 195.843254 msecs"
"Elapsed time: 188.077405 msecs"
nil
```

For interpreted and in another language, this doesn't seem the end of
the world.

And adding more quantities
```clojure
(letfn [(rand-string [] (str/join "-" (repeatedly 4 #(rand-nth ["banana" "horse" "battery" "cloak"]))))]
  (dotimes [_ 5]
    (let [rows (repeatedly 20 (fn [] [(rand-string) (rand-int 100)]))
          colors (zipmap (map first rows) (cycle ["red" "green" "blue" "yellow"]))]
      (time
       (js-svg/categorical-donut rows colors)))))

"Elapsed time: 288.659887 msecs"
"Elapsed time: 334.733071 msecs"
"Elapsed time: 317.369294 msecs"
"Elapsed time: 272.084918 msecs"
"Elapsed time: 272.7203 msecs"
nil
```

For a timeline line chart, rendering one datapoint per day for a whole
year:

```clojure
(dotimes [_ 5]
  (let [dates (take 365 (iterate #(.plusDays % 1) #t "2020"))
        rows   (map (fn [d] [d (rand-int 200)]) dates)
        labels {:left "count" :bottom "year"}]
    (time
     (js-svg/timelineseries-line rows labels))))

"Elapsed time: 569.691124 msecs"
"Elapsed time: 544.415676 msecs"
"Elapsed time: 539.131092 msecs"
"Elapsed time: 492.60486 msecs"
"Elapsed time: 523.765691 msecs"
nil
```
