### PR TITLE
Add typing hints to `isa` to assist type inference

### DIFF
--- a/frontend/src/metabase/lib/types.js
+++ b/frontend/src/metabase/lib/types.js
@@ -1,6 +1,18 @@
-import { isa, TYPE } from "cljs/metabase.types";
+import { isa as cljs_isa, TYPE } from "cljs/metabase.types";
 
-export { isa, TYPE };
+export { TYPE };
+
+/**
+ * Is x the same as, or a descendant type of, y?
+ *
+ * @example
+ * isa(field.semantic_type, TYPE.Currency);
+ *
+ * @param {string} x
+ * @param {string} y
+ * @return {boolean}
+ */
+export const isa = (x, y) => cljs_isa(x, y);
 
 // convenience functions since these operations are super-common
 // this will also make it easier to tweak how these checks work in the future,


### PR DESCRIPTION
This requires unfortunately an additional layer of indirection, however I believe it's super cheap and it shouldn't impact execution speed.

In the mean time, many other predicates (isFoo etc) which rely on isa() will be correctly type-inferred, which gives a huge win for editing and debugging purposes.

To give a try, use VS Code and open `frontend/src/metabase/lib/schema_metadata.js` and find something like `isCurrency`.

**Before this PR**

Just a super generic function signature, rather useless.

![image](https://user-images.githubusercontent.com/7288/130266798-65fd2401-e058-4865-ba62-399a3a1bf687.png)

**After this PR**

Now the return type (boolean) is inferred correctly.

![image](https://user-images.githubusercontent.com/7288/130266884-d7c310e5-1f05-41a3-8468-8d0c45c4613a.png)

**Note**

It also works well with any editors which support LSP, shown here with Vim:

![image](https://user-images.githubusercontent.com/7288/130267045-180cbd36-160f-4322-b3da-eace24bde76c.png)
