### PR TITLE
New endpoints for fetching alerts & subscriptions

### DIFF
--- a/src/metabase/api/alert.clj
+++ b/src/metabase/api/alert.clj
@@ -31,7 +31,7 @@
 (api/defendpoint GET "/:id"
   "Fetch an alert by ID"
   [id]
-  (-> (api/read-check (pulse/retrieve-notification id))
+  (-> (api/read-check (pulse/retrieve-alert id))
       (hydrate :can_write)))
 
 (api/defendpoint GET "/question/:id"

--- a/src/metabase/api/alert.clj
+++ b/src/metabase/api/alert.clj
@@ -20,9 +20,11 @@
 
 (api/defendpoint GET "/"
   "Fetch all alerts"
-  [archived]
-  {archived (s/maybe su/BooleanString)}
-  (as-> (pulse/retrieve-alerts {:archived? (Boolean/parseBoolean archived)}) <>
+  [archived user_id]
+  {archived (s/maybe su/BooleanString)
+   user_id  (s/maybe su/IntGreaterThanZero)}
+  (as-> (pulse/retrieve-alerts {:archived? (Boolean/parseBoolean archived)
+                                :user-id   user_id}) <>
     (filter mi/can-read? <>)
     (hydrate <> :can_write)))
 

--- a/src/metabase/api/alert.clj
+++ b/src/metabase/api/alert.clj
@@ -28,6 +28,12 @@
     (filter mi/can-read? <>)
     (hydrate <> :can_write)))
 
+(api/defendpoint GET "/:id"
+  "Fetch an alert by ID"
+  [id]
+  (-> (api/read-check (pulse/retrieve-notification id))
+      (hydrate :can_write)))
+
 (api/defendpoint GET "/question/:id"
   "Fetch all questions for the given question (`Card`) id"
   [id]

--- a/src/metabase/api/pulse.clj
+++ b/src/metabase/api/pulse.clj
@@ -31,7 +31,9 @@
 (u/ignore-exceptions (classloader/require 'metabase-enterprise.sandbox.api.util))
 
 (api/defendpoint GET "/"
-  "Fetch all Pulses"
+  "Fetch all Pulses. If `dashboard_id` is specified, restricts results to dashboard subscriptions
+  associated with that dashboard. If `user_id` is specified, restricts results to pulses or subscriptions
+  created by the user, or for which the user is a known recipient."
   [archived dashboard_id user_id]
   {archived     (s/maybe su/BooleanString)
    dashboard_id (s/maybe su/IntGreaterThanZero)

--- a/src/metabase/api/pulse.clj
+++ b/src/metabase/api/pulse.clj
@@ -32,11 +32,13 @@
 
 (api/defendpoint GET "/"
   "Fetch all Pulses"
-  [archived dashboard_id]
+  [archived dashboard_id user_id]
   {archived     (s/maybe su/BooleanString)
-   dashboard_id (s/maybe su/IntGreaterThanZero)}
+   dashboard_id (s/maybe su/IntGreaterThanZero)
+   user_id      (s/maybe su/IntGreaterThanZero)}
   (as-> (pulse/retrieve-pulses {:archived?    (Boolean/parseBoolean archived)
-                                :dashboard-id dashboard_id}) <>
+                                :dashboard-id dashboard_id
+                                :user-id      user_id}) <>
     (filter mi/can-read? <>)
     (hydrate <> :can_write)))
 

--- a/src/metabase/models/pulse.clj
+++ b/src/metabase/models/pulse.clj
@@ -228,7 +228,6 @@
 
   ([{:keys [archived? user-id]
      :or   {archived? false}}]
-   (def my-user-id user-id)
    (let [query {:select    [:p.* [:%lower.p.name :lower-name]]
                 :modifiers [:distinct]
                 :from      [[Pulse :p]]
@@ -255,22 +254,22 @@
   "Fetch all `Pulses`."
   [{:keys [archived? dashboard-id user-id]
     :or   {archived? false}}]
-  (let [query (merge {:select    [:p.* [:%lower.p.name :lower-name]]
-                      :modifiers [:distinct]
-                      :from      [[Pulse :p]]
-                      :left-join (when user-id
-                                  [[PulseChannel :pchan] [:= :p.id :pchan.pulse_id]
-                                   [PulseChannelRecipient :pcr] [:= :pchan.id :pcr.pulse_channel_id]])
-                      :where     [:and
-                                  [:= :p.alert_condition nil]
-                                  [:= :p.archived archived?]
-                                  (when dashboard-id
-                                    [:= :p.dashboard_id dashboard-id])
-                                  (when user-id
-                                    [:or
-                                     [:= :p.creator_id user-id]
-                                     [:= :pcr.user_id user-id]])]
-                      :order-by  [[:lower-name :asc]]})]
+  (let [query {:select    [:p.* [:%lower.p.name :lower-name]]
+               :modifiers [:distinct]
+               :from      [[Pulse :p]]
+               :left-join (when user-id
+                            [[PulseChannel :pchan] [:= :p.id :pchan.pulse_id]
+                             [PulseChannelRecipient :pcr] [:= :pchan.id :pcr.pulse_channel_id]])
+               :where     [:and
+                           [:= :p.alert_condition nil]
+                           [:= :p.archived archived?]
+                           (when dashboard-id
+                             [:= :p.dashboard_id dashboard-id])
+                           (when user-id
+                             [:or
+                              [:= :p.creator_id user-id]
+                              [:= :pcr.user_id user-id]])]
+               :order-by  [[:lower-name :asc]]}]
     (for [pulse (query-as Pulse query)]
       (-> pulse
           (dissoc :lower-name)

--- a/src/metabase/models/pulse.clj
+++ b/src/metabase/models/pulse.clj
@@ -241,16 +241,24 @@
 
 (s/defn retrieve-pulses :- [PulseInstance]
   "Fetch all `Pulses`."
-  [{:keys [archived? dashboard-id]
+  [{:keys [archived? dashboard-id user-id]
     :or   {archived? false}}]
-  (let [query {:select    [:p.* [:%lower.p.name :lower-name]]
-               :modifiers [:distinct]
-               :from      [[Pulse :p]]
-               :where     [:and
-                           [:= :p.alert_condition nil]
-                           [:= :p.archived archived?]
-                           [:= :p.dashboard_id dashboard-id]]
-               :order-by  [[:lower-name :asc]]}]
+  (let [query (merge {:select    [:p.* [:%lower.p.name :lower-name]]
+                      :modifiers [:distinct]
+                      :from      [[Pulse :p]]
+                      :left-join (when user-id
+                                  [[PulseChannel :pchan] [:= :p.id :pchan.pulse_id]
+                                   [PulseChannelRecipient :pcr] [:= :pchan.id :pcr.pulse_channel_id]])
+                      :where     [:and
+                                  [:= :p.alert_condition nil]
+                                  [:= :p.archived archived?]
+                                  (when dashboard-id
+                                    [:= :p.dashboard_id dashboard-id])
+                                  (when user-id
+                                    [:or
+                                     [:= :p.creator_id user-id]
+                                     [:= :pcr.user_id user-id]])]
+                      :order-by  [[:lower-name :asc]]})]
     (for [pulse (query-as Pulse query)]
       (-> pulse
           (dissoc :lower-name)

--- a/test/metabase/api/alert_test.clj
+++ b/test/metabase/api/alert_test.clj
@@ -145,7 +145,7 @@
 
 ;; by default, archived Alerts should be excluded
 
-(deftest get-alert-tests
+(deftest get-alerts-test
   (testing "archived alerts should be excluded"
     (is (= #{"Not Archived"}
            (with-alert-in-collection [_ _ not-archived-alert]
@@ -163,6 +163,20 @@
                (db/update! Pulse (u/the-id archived-alert)     :name "Archived", :archived true)
                (with-alerts-in-readable-collection [not-archived-alert archived-alert]
                  (set (map :name ((user->client :rasta) :get 200 "alert?archived=true"))))))))))
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                               GET /api/alert/:id                                               |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+(deftest get-alert-test
+  (testing "an alert can be fetched by ID"
+    (with-alert-in-collection [_ _ alert]
+      (with-alerts-in-readable-collection [alert]
+        (is (= (u/the-id alert)
+               (:id ((user->client :rasta) :get 200 (str "alert/" (u/the-id alert)))))))))
+
+  (testing "fetching a non-existing alert returns an error"
+    ((user->client :rasta) :get 404 (str "alert/" 123))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                                POST /api/alert                                                 |

--- a/test/metabase/api/alert_test.clj
+++ b/test/metabase/api/alert_test.clj
@@ -153,7 +153,7 @@
                (db/update! Pulse (u/the-id not-archived-alert) :name "Not Archived")
                (db/update! Pulse (u/the-id archived-alert)     :name "Archived", :archived true)
                (with-alerts-in-readable-collection [not-archived-alert archived-alert]
-                 (set (map :name ((user->client :rasta) :get 200 "alert")))))))))
+                 (set (map :name (mt/user-http-request :rasta :get 200 "alert")))))))))
 
   (testing "fetch archived alerts"
     (is (= #{"Archived"}
@@ -162,7 +162,7 @@
                (db/update! Pulse (u/the-id not-archived-alert) :name "Not Archived")
                (db/update! Pulse (u/the-id archived-alert)     :name "Archived", :archived true)
                (with-alerts-in-readable-collection [not-archived-alert archived-alert]
-                 (set (map :name ((user->client :rasta) :get 200 "alert?archived=true")))))))))
+                 (set (map :name (mt/user-http-request :rasta :get 200 "alert?archived=true")))))))))
 
   (testing "fetch alerts by user ID -- should return alerts created by the user,
            or alerts for which the user is a known recipient"
@@ -176,11 +176,11 @@
             (mt/with-temp* [PulseChannel [pulse-channel {:pulse_id (u/the-id recipient-alert)}]
                             PulseChannelRecipient [_ {:pulse_channel_id (u/the-id pulse-channel), :user_id (mt/user->id :lucky)}]]
               (is (= #{"LuckyCreator" "LuckyRecipient"}
-                      (set (map :name ((user->client :rasta) :get 200 (str "alert?user_id=" (mt/user->id :lucky)))))))
+                      (set (map :name (mt/user-http-request :rasta :get 200 (str "alert?user_id=" (mt/user->id :lucky)))))))
               (is (= #{"LuckyRecipient" "Other"}
-                      (set (map :name ((user->client :rasta) :get 200 (str "alert?user_id=" (mt/user->id :rasta)))))))
+                      (set (map :name (mt/user-http-request :rasta :get 200 (str "alert?user_id=" (mt/user->id :rasta)))))))
               (is (= #{}
-                      (set (map :name ((user->client :rasta) :get 200 (str "alert?user_id=" (mt/user->id :trashbird))))))))))))))
+                      (set (map :name (mt/user-http-request :rasta :get 200 (str "alert?user_id=" (mt/user->id :trashbird))))))))))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                               GET /api/alert/:id                                               |
@@ -191,10 +191,10 @@
     (with-alert-in-collection [_ _ alert]
       (with-alerts-in-readable-collection [alert]
         (is (= (u/the-id alert)
-               (:id ((user->client :rasta) :get 200 (str "alert/" (u/the-id alert)))))))))
+               (:id (mt/user-http-request :rasta :get 200 (str "alert/" (u/the-id alert)))))))))
 
   (testing "fetching a non-existing alert returns an error"
-    ((user->client :rasta) :get 404 (str "alert/" 123))))
+    (mt/user-http-request :rasta :get 404 (str "alert/" 123))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                                POST /api/alert                                                 |


### PR DESCRIPTION
* Adds a `user_id` parameter for the `/api/pulse` and `/api/alert` GET endpoints. If supplied, it limits the results to pulses/alerts that the user created, or for which the user is a known recipient.
* Adds a new `GET /api/alert/:id` endpoint to fetch a single alert.

These are both needed to unblock @ranquild's frontend work on subscription management.