### PR TITLE
Effective type in result cols

### DIFF
--- a/frontend/src/metabase/visualizations/lib/settings/column.js
+++ b/frontend/src/metabase/visualizations/lib/settings/column.js
@@ -479,7 +479,7 @@ export function getSettingDefintionsForColumn(series: Series, column: Column) {
       ? visualization.columnSettings(column)
       : visualization.columnSettings || {};
 
-  if (isDate(column)) {
+  if (isDate(column) || column.unit) {
     return {
       ...extraColumnSettings,
       ...DATE_COLUMN_SETTINGS,

--- a/frontend/src/metabase/visualizations/lib/settings/column.js
+++ b/frontend/src/metabase/visualizations/lib/settings/column.js
@@ -479,7 +479,7 @@ export function getSettingDefintionsForColumn(series: Series, column: Column) {
       ? visualization.columnSettings(column)
       : visualization.columnSettings || {};
 
-  if (isDate(column) || column.unit) {
+  if (isDate(column) || (column.unit && column.unit !== "default")) {
     return {
       ...extraColumnSettings,
       ...DATE_COLUMN_SETTINGS,

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
@@ -38,16 +38,19 @@
                :display_name "venue_id"
                :source       :native
                :base_type    :type/Integer
+               :effective_type :type/Integer
                :field_ref    [:field "venue_id" {:base-type :type/Integer}]}
               {:name         "user_id"
                :display_name "user_id"
                :source       :native
                :base_type    :type/Integer
+               :effective_type :type/Integer
                :field_ref    [:field "user_id" {:base-type :type/Integer}]}
               {:name         "checkins_id"
                :display_name "checkins_id"
                :source       :native
                :base_type    :type/Integer
+               :effective_type :type/Integer
                :field_ref    [:field "checkins_id" {:base-type :type/Integer}]}]
              (qp.test/cols
                (qp/process-query

--- a/modules/drivers/bigquery/test/metabase/driver/bigquery/query_processor_test.clj
+++ b/modules/drivers/bigquery/test/metabase/driver/bigquery/query_processor_test.clj
@@ -38,16 +38,19 @@
                :display_name "venue_id"
                :source       :native
                :base_type    :type/Integer
+               :effective_type :type/Integer
                :field_ref    [:field "venue_id" {:base-type :type/Integer}]}
               {:name         "user_id"
                :display_name "user_id"
                :source       :native
                :base_type    :type/Integer
+               :effective_type :type/Integer
                :field_ref    [:field "user_id" {:base-type :type/Integer}]}
               {:name         "checkins_id"
                :display_name "checkins_id"
                :source       :native
                :base_type    :type/Integer
+               :effective_type :type/Integer
                :field_ref    [:field "checkins_id" {:base-type :type/Integer}]}]
              (qp.test/cols
                (qp/process-query

--- a/modules/drivers/druid/test/metabase/driver/druid/query_processor_test.clj
+++ b/modules/drivers/druid/test/metabase/driver/druid/query_processor_test.clj
@@ -288,26 +288,31 @@
                                             :source       :native
                                             :display_name "id"
                                             :field_ref    [:field "id" {:base-type :type/Integer}]
-                                            :base_type    :type/Integer}
+                                            :base_type    :type/Integer
+                                            :effective_type :type/Integer}
                                            {:name         "user_name"
                                             :source       :native
                                             :display_name "user_name"
                                             :base_type    :type/Text
+                                            :effective_type :type/Text
                                             :field_ref    [:field "user_name" {:base-type :type/Text}]}
                                            {:name         "venue_price"
                                             :source       :native
                                             :display_name "venue_price"
                                             :base_type    :type/Integer
+                                            :effective_type :type/Integer
                                             :field_ref    [:field "venue_price" {:base-type :type/Integer}]}
                                            {:name         "venue_name"
                                             :source       :native
                                             :display_name "venue_name"
                                             :base_type    :type/Text
+                                            :effective_type :type/Text
                                             :field_ref    [:field "venue_name" {:base-type :type/Text}]}
                                            {:name         "count"
                                             :source       :native
                                             :display_name "count"
                                             :base_type    :type/Integer
+                                            :effective_type :type/Integer
                                             :field_ref    [:field "count" {:base-type :type/Integer}]}]
                         :native_form      {:query native-query-1}
                         :results_timezone "UTC"}}

--- a/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
@@ -81,6 +81,7 @@
                         :cols             [{:name         "count"
                                             :display_name "count"
                                             :base_type    :type/Integer
+                                            :effective_type :type/Integer
                                             :source       :native
                                             :field_ref    [:field "count" {:base-type :type/Integer}]}]
                         :native_form      {:collection "venues"

--- a/src/metabase/query_processor/middleware/annotate.clj
+++ b/src/metabase/query_processor/middleware/annotate.clj
@@ -549,11 +549,14 @@
   (let [non-nil-driver-col-metadata (m/filter-vals some? driver-col-metadata)
         our-base-type               (when (= (:base_type driver-col-metadata) :type/*)
                                       (u/select-non-nil-keys our-col-metadata [:base_type]))
+        ;; whatever type comes back from the query is by definition the effective type
+        effective-type              {:effective_type (:base_type driver-col-metadata)}
         our-name                    (u/select-non-nil-keys our-col-metadata [:name])]
     (merge our-col-metadata
            non-nil-driver-col-metadata
            our-base-type
-           our-name)))
+           our-name
+           effective-type)))
 
 (defn- merge-cols-returned-by-driver
   "Merge our column metadata (`:cols`) derived from logic above with the column metadata returned by the driver. We'll

--- a/src/metabase/query_processor/middleware/annotate.clj
+++ b/src/metabase/query_processor/middleware/annotate.clj
@@ -549,8 +549,12 @@
   (let [non-nil-driver-col-metadata (m/filter-vals some? driver-col-metadata)
         our-base-type               (when (= (:base_type driver-col-metadata) :type/*)
                                       (u/select-non-nil-keys our-col-metadata [:base_type]))
-        ;; whatever type comes back from the query is by definition the effective type
-        effective-type              {:effective_type (:base_type driver-col-metadata)}
+        ;; whatever type comes back from the query is by definition the effective type, fallback to our effective
+        ;; type, fallback to the base_type
+        effective-type              (when-let [db-base (or (:base_type driver-col-metadata)
+                                                           (:effective_type our-col-metadata)
+                                                           (:base_type our-col-metadata))]
+                                      {:effective_type db-base})
         our-name                    (u/select-non-nil-keys our-col-metadata [:name])]
     (merge our-col-metadata
            non-nil-driver-col-metadata

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -474,6 +474,7 @@
                         :metadata_checksum  "ABCDEF"))) ; bad checksum
               (testing "check the correct metadata was fetched and was saved in the DB"
                 (is (= [{:base_type     (count-base-type)
+                         :effective_type (count-base-type)
                          :display_name  "count"
                          :name          "count"
                          :semantic_type :type/Quantity

--- a/test/metabase/api/dataset_test.clj
+++ b/test/metabase/api/dataset_test.clj
@@ -341,6 +341,7 @@
                         "test-expr"]
                        (map :display_name cols)))
                 (is (= {:base_type       "type/Integer"
+                        :effective_type  "type/Integer"
                         :name            "pivot-grouping"
                         :display_name    "pivot-grouping"
                         :expression_name "pivot-grouping"

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -469,12 +469,14 @@
                                           [{:name         "NAME"
                                             :display_name "NAME"
                                             :base_type    "type/Text"
+                                            :effective_type "type/Text"
                                             :semantic_type "type/Name"
                                             :fingerprint  (:name mutil/venue-fingerprints)
                                             :field_ref    ["field" "NAME" {:base-type "type/Text"}]}
                                            {:name         "ID"
                                             :display_name "ID"
                                             :base_type    "type/BigInteger"
+                                            :effective_type "type/BigInteger"
                                             :semantic_type nil
                                             :fingerprint  (:id mutil/venue-fingerprints)
                                             :field_ref    ["field" "ID" {:base-type "type/BigInteger"}]}
@@ -482,6 +484,7 @@
                                              {:name         "PRICE"
                                               :display_name "PRICE"
                                               :base_type    "type/Integer"
+                                              :effective_type "type/Integer"
                                               :semantic_type nil
                                               :fingerprint  (:price mutil/venue-fingerprints)
                                               :field_ref    ["field" "PRICE" {:base-type "type/Integer"}]})
@@ -489,6 +492,7 @@
                                              {:name         "LATITUDE"
                                               :display_name "LATITUDE"
                                               :base_type    "type/Float"
+                                              :effective_type "type/Float"
                                               :semantic_type "type/Latitude"
                                               :fingerprint  (:latitude mutil/venue-fingerprints)
                                               :field_ref    ["field" "LATITUDE" {:base-type "type/Float"}]})])})
@@ -522,6 +526,7 @@
                     :fields            [{:name                     "NAME"
                                          :display_name             "NAME"
                                          :base_type                "type/Text"
+                                         :effective_type           "type/Text"
                                          :table_id                 card-virtual-table-id
                                          :id                       ["field" "NAME" {:base-type "type/Text"}]
                                          :semantic_type            "type/Name"
@@ -532,6 +537,7 @@
                                         {:name                     "LAST_LOGIN"
                                          :display_name             "LAST_LOGIN"
                                          :base_type                "type/DateTime"
+                                         :effective_type           "type/DateTime"
                                          :table_id                 card-virtual-table-id
                                          :id                       ["field" "LAST_LOGIN" {:base-type "type/DateTime"}]
                                          :semantic_type            nil

--- a/test/metabase/driver/h2_test.clj
+++ b/test/metabase/driver/h2_test.clj
@@ -93,6 +93,7 @@
         (testing "cols"
           (is (= [{:display_name "NAME"
                    :base_type    :type/Text
+                   :effective_type :type/Text
                    :source       :native
                    :field_ref    [:field "NAME" {:base-type :type/Text}]
                    :name         "NAME"}]
@@ -103,6 +104,7 @@
     (testing "A native query that doesn't return a column class name metadata should work correctly (#12150)"
       (is (= [{:display_name "D"
                :base_type    :type/DateTime
+               :effective_type :type/DateTime
                :source       :native
                :field_ref    [:field "D" {:base-type :type/DateTime}]
                :name         "D"}]

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -588,6 +588,7 @@
         (testing "cols"
           (is (= [{:display_name "sleep"
                    :base_type    :type/Text
+                   :effective_type :type/Text
                    :source       :native
                    :field_ref    [:field "sleep" {:base-type :type/Text}]
                    :name         "sleep"}]

--- a/test/metabase/driver/sql_jdbc/native_test.clj
+++ b/test/metabase/driver/sql_jdbc/native_test.clj
@@ -17,6 +17,7 @@
                         :cols             [{:name         "ID"
                                             :display_name "ID"
                                             :base_type    :type/BigInteger
+                                            :effective_type :type/BigInteger
                                             :source       :native
                                             :field_ref    [:field "ID" {:base-type :type/BigInteger}]}]
                         :native_form      {:query "SELECT ID FROM VENUES ORDER BY ID DESC LIMIT 2"}
@@ -37,16 +38,19 @@
                                             :display_name "ID"
                                             :source       :native
                                             :base_type    :type/BigInteger
+                                            :effective_type :type/BigInteger
                                             :field_ref    [:field "ID" {:base-type :type/BigInteger}]}
                                            {:name         "NAME"
                                             :display_name "NAME"
                                             :source       :native
                                             :base_type    :type/Text
+                                            :effective_type :type/Text
                                             :field_ref    [:field "NAME" {:base-type :type/Text}]}
                                            {:name         "CATEGORY_ID"
                                             :display_name "CATEGORY_ID"
                                             :source       :native
                                             :base_type    :type/Integer
+                                            :effective_type :type/Integer
                                             :field_ref    [:field "CATEGORY_ID" {:base-type :type/Integer}]}]
                         :native_form      {:query "SELECT ID, NAME, CATEGORY_ID FROM VENUES ORDER BY ID DESC LIMIT 2"}
                         :results_timezone "UTC"}}

--- a/test/metabase/query_processor/middleware/add_source_metadata_test.clj
+++ b/test/metabase/query_processor/middleware/add_source_metadata_test.clj
@@ -200,7 +200,9 @@
                        (concat
                         (venues-source-metadata :price)
                         (let [[count-col] (results-metadata (mt/run-mbql-query venues {:aggregation [[:count]]}))]
-                          [(assoc count-col :field_ref field-ref)])))]
+                          [(-> count-col
+                               (dissoc :effective_type)
+                               (assoc :field_ref field-ref))])))]
                (mt/mbql-query venues
                  {:source-query    {:source-query    {:source-query    {:source-table $$venues
                                                                         :aggregation  [[:count]]
@@ -253,7 +255,9 @@
                                                                            :max-value 45.0
                                                                            :num-bins  7
                                                                            :bin-width 5.0}}])])
-                                  (results-metadata (mt/run-mbql-query venues {:aggregation [[:count]]})))})
+                                  ;; computed column doesn't have an effective type in middleware before query
+                                  (map #(dissoc % :effective_type)
+                                       (results-metadata (mt/run-mbql-query venues {:aggregation [[:count]]}))))})
              (add-source-metadata
               (mt/mbql-query venues
                 {:source-query

--- a/test/metabase/query_processor/middleware/annotate_test.clj
+++ b/test/metabase/query_processor/middleware/annotate_test.clj
@@ -416,6 +416,7 @@
       (is (= {:cols [{:name         "metric"
                       :display_name "Total Events"
                       :base_type    :type/Text
+                      :effective_type :type/Text
                       :source       :aggregation
                       :field_ref    [:aggregation 0]}]}
              (add-column-info
@@ -486,6 +487,7 @@
   (testing "Make sure `:cols` always come back with a unique `:name` key (#8759)"
     (is (= {:cols
             [{:base_type     :type/Number
+              :effective_type :type/Number
               :semantic_type :type/Quantity
               :name          "count"
               :display_name  "count"
@@ -495,14 +497,17 @@
               :name         "sum"
               :display_name "sum"
               :base_type    :type/Number
+              :effective_type :type/Number
               :field_ref    [:aggregation 1]}
              {:base_type     :type/Number
+              :effective_type :type/Number
               :semantic_type :type/Quantity
               :name          "count_2"
               :display_name  "count"
               :source        :aggregation
               :field_ref     [:aggregation 2]}
              {:base_type     :type/Number
+              :effective_type :type/Number
               :semantic_type :type/Quantity
               :name          "count_3"
               :display_name  "count_2"

--- a/test/metabase/query_processor/middleware/results_metadata_test.clj
+++ b/test/metabase/query_processor/middleware/results_metadata_test.clj
@@ -29,36 +29,42 @@
   [{:name         "ID"
     :display_name "ID"
     :base_type    :type/BigInteger
+    :effective_type :type/BigInteger
     :semantic_type :type/PK
     :fingerprint  (:id mutil/venue-fingerprints)
     :field_ref    [:field "ID" {:base-type :type/BigInteger}]}
    {:name         "NAME"
     :display_name "Name"
     :base_type    :type/Text
+    :effective_type :type/Text
     :semantic_type :type/Name
     :fingerprint  (:name mutil/venue-fingerprints)
     :field_ref    [:field "NAME" {:base-type :type/Text}]}
    {:name         "PRICE"
     :display_name "Price"
     :base_type    :type/Integer
+    :effective_type :type/Integer
     :semantic_type nil
     :fingerprint  (:price mutil/venue-fingerprints)
     :field_ref    [:field "PRICE" {:base-type :type/Integer}]}
    {:name         "CATEGORY_ID"
     :display_name "Category ID"
     :base_type    :type/Integer
+    :effective_type :type/Integer
     :semantic_type nil
     :fingerprint  (:category_id mutil/venue-fingerprints)
     :field_ref    [:field "CATEGORY_ID" {:base-type :type/Integer}]}
    {:name         "LATITUDE"
     :display_name "Latitude"
     :base_type    :type/Float
+    :effective_type :type/Float
     :semantic_type :type/Latitude
     :fingerprint  (:latitude mutil/venue-fingerprints)
     :field_ref    [:field "LATITUDE" {:base-type :type/Float}]}
    {:name         "LONGITUDE"
     :display_name "Longitude"
     :base_type    :type/Float
+    :effective_type :type/Float
     :semantic_type :type/Longitude
     :fingerprint  (:longitude mutil/venue-fingerprints)
     :field_ref    [:field "LONGITUDE" {:base-type :type/Float}]}])
@@ -190,7 +196,7 @@
         :info     {:card-id    (u/the-id card)
                    :query-hash (qputil/query-hash {})}})
       (is (= [{:base_type    :type/DateTime
-               :effective_type    :type/Date
+               :effective_type    :type/DateTime
                :coercion_strategy nil
                :display_name "Date"
                :name         "DATE"
@@ -202,6 +208,7 @@
                :id           (mt/id :checkins :date)
                :field_ref    [:field (mt/id :checkins :date) {:temporal-unit :year}]}
               {:base_type    :type/BigInteger
+               :effective_type :type/BigInteger
                :display_name "Count"
                :name         "count"
                :semantic_type :type/Quantity
@@ -239,6 +246,7 @@
                      :database (mt/id)}))]
       (testing "Sanity check: annotate should infer correct type from `:cols`"
         (is (= {:base_type    :type/DateTime,
+                :effective_type :type/DateTime
                 :display_name "D" :name "D"
                 :source       :native
                 :field_ref    [:field "D" {:base-type :type/DateTime}]}
@@ -246,6 +254,7 @@
 
       (testing "Results metadata should have the same type info")
       (is (= {:base_type    :type/DateTime
+              :effective_type :type/DateTime
               :display_name "D"
               :name         "D"
               :semantic_type nil

--- a/test/metabase/query_processor_test.clj
+++ b/test/metabase/query_processor_test.clj
@@ -111,6 +111,10 @@
   ([table-kw cols]
    (mapv (partial col table-kw) cols)))
 
+(defn- backfill-effective-type [{:keys [base_type effective_type] :as col}]
+  (cond-> col
+    (nil? effective_type) (assoc :effective_type base_type)))
+
 (defn aggregate-col
   "Return the column information we'd expect for an aggregate column. For all columns besides `:count`, you'll need to
   pass the `Field` in question as well.
@@ -119,13 +123,16 @@
     (aggregate-col :avg (col :venues :id))
     (aggregate-col :avg :venues :id)"
   ([ag-type]
-   (tx/aggregate-column-info (tx/driver) ag-type))
+   (backfill-effective-type
+    (tx/aggregate-column-info (tx/driver) ag-type)))
 
   ([ag-type field]
-   (tx/aggregate-column-info (tx/driver) ag-type field))
+   (backfill-effective-type
+    (tx/aggregate-column-info (tx/driver) ag-type field)))
 
   ([ag-type table-kw field-kw]
-   (tx/aggregate-column-info (tx/driver) ag-type (col table-kw field-kw))))
+   (backfill-effective-type
+    (tx/aggregate-column-info (tx/driver) ag-type (col table-kw field-kw)))))
 
 (defn breakout-col
   "Return expected `:cols` info for a Field used as a breakout.

--- a/test/metabase/query_processor_test.clj
+++ b/test/metabase/query_processor_test.clj
@@ -113,7 +113,7 @@
 
 (defn- backfill-effective-type [{:keys [base_type effective_type] :as col}]
   (cond-> col
-    (nil? effective_type) (assoc :effective_type base_type)))
+    (and (nil? effective_type) base_type) (assoc :effective_type base_type)))
 
 (defn aggregate-col
   "Return the column information we'd expect for an aggregate column. For all columns besides `:count`, you'll need to

--- a/test/metabase/query_processor_test/aggregation_test.clj
+++ b/test/metabase/query_processor_test/aggregation_test.clj
@@ -198,7 +198,6 @@
 
 
 ;;; ------------------------------------------------ CUMULATIVE COUNT ------------------------------------------------
-
 (deftest cumulative-count-test
   (mt/test-drivers (mt/normal-drivers)
     (testing "cumulative count aggregations"

--- a/test/metabase/query_processor_test/breakout_test.clj
+++ b/test/metabase/query_processor_test/breakout_test.clj
@@ -182,7 +182,7 @@
                    (dissoc :base_type :effective_type)))))
 
       (testing "binning-strategy = num-bins: 5"
-        (is (= (assoc (dissoc (qp.test/breakout-col :venues :latitude) :base_type)
+        (is (= (assoc (dissoc (qp.test/breakout-col :venues :latitude) :base_type :effective_type)
                       :binning_info {:min_value 7.5, :max_value 45.0, :num_bins 5, :bin_width 7.5, :binning_strategy :num-bins}
                       :field_ref    [:field (mt/id :venues :latitude) {:binning {:strategy  :num-bins
                                                                                  :min-value 7.5
@@ -194,7 +194,7 @@
                       :breakout    [[:field %latitude {:binning {:strategy :num-bins, :num-bins 5}}]]})
                    qp.test/cols
                    first
-                   (dissoc :base_type))))))))
+                   (dissoc :base_type :effective_type))))))))
 
 (deftest binning-error-test
   (mt/test-drivers (mt/normal-drivers-with-feature :binning)

--- a/test/metabase/query_processor_test/breakout_test.clj
+++ b/test/metabase/query_processor_test/breakout_test.clj
@@ -167,7 +167,7 @@
     (testing "Validate binning info is returned with the binning-strategy"
       (testing "binning-strategy = default"
         ;; base_type can differ slightly between drivers and it's really not important for the purposes of this test
-        (is (= (assoc (dissoc (qp.test/breakout-col :venues :latitude) :base_type)
+        (is (= (assoc (dissoc (qp.test/breakout-col :venues :latitude) :base_type :effective_type)
                       :binning_info {:min_value 10.0, :max_value 50.0, :num_bins 4, :bin_width 10.0, :binning_strategy :bin-width}
                       :field_ref    [:field (mt/id :venues :latitude) {:binning {:strategy  :bin-width
                                                                                  :min-value 10.0
@@ -179,7 +179,7 @@
                       :breakout    [[:field %latitude {:binning {:strategy :default}}]]})
                    qp.test/cols
                    first
-                   (dissoc :base_type)))))
+                   (dissoc :base_type :effective_type)))))
 
       (testing "binning-strategy = num-bins: 5"
         (is (= (assoc (dissoc (qp.test/breakout-col :venues :latitude) :base_type)

--- a/test/metabase/query_processor_test/expression_aggregations_test.clj
+++ b/test/metabase/query_processor_test/expression_aggregations_test.clj
@@ -247,7 +247,6 @@
   (mt/test-drivers (mt/normal-drivers-with-feature :expression-aggregations)
     (testing "check that named aggregations come back with the correct column metadata (#4002)"
       (is (= (assoc (qp.test/aggregate-col :count)
-                    :effective_type :type/BigInteger
                     :name         "auto_generated_name"
                     :display_name "Count of Things")
              (-> (mt/run-mbql-query venues

--- a/test/metabase/query_processor_test/expression_aggregations_test.clj
+++ b/test/metabase/query_processor_test/expression_aggregations_test.clj
@@ -247,6 +247,7 @@
   (mt/test-drivers (mt/normal-drivers-with-feature :expression-aggregations)
     (testing "check that named aggregations come back with the correct column metadata (#4002)"
       (is (= (assoc (qp.test/aggregate-col :count)
+                    :effective_type :type/BigInteger
                     :name         "auto_generated_name"
                     :display_name "Count of Things")
              (-> (mt/run-mbql-query venues

--- a/test/metabase/query_processor_test/native_test.clj
+++ b/test/metabase/query_processor_test/native_test.clj
@@ -26,7 +26,8 @@
             :source       :native
             :field_ref    [:field "NAME" {:base-type :type/Text}]
             :name         "NAME"
-            :base_type    :type/Text}]}
+            :base_type    :type/Text
+            :effective_type :type/Text}]}
          (qp.test/rows-and-cols
           (qp/process-query
            (mt/native-query

--- a/test/metabase/query_processor_test/nested_queries_test.clj
+++ b/test/metabase/query_processor_test/nested_queries_test.clj
@@ -67,12 +67,12 @@
           [4  6]]
    :cols [(cond-> (qp.test/breakout-col (qp.test/col :venues :price))
             native-source?
-            (-> (assoc :field_ref [:field "PRICE" {:base-type :type/Integer}])
+            (-> (assoc :field_ref [:field "PRICE" {:base-type :type/Integer}]
+                       :effective_type :type/Integer)
                 (dissoc :description :parent_id :visibility_type))
 
             (not has-source-metadata?)
-            (dissoc :id :semantic_type :settings :fingerprint :table_id
-                    :effective_type :coercion_strategy))
+            (dissoc :id :semantic_type :settings :fingerprint :table_id :coercion_strategy))
           (qp.test/aggregate-col :count)]})
 
 (deftest mbql-source-query-breakout-aggregation-test
@@ -400,7 +400,7 @@
                        :unit      :day)
                 ;; because this field literal comes from a native query that does not include `:source-metadata` it won't have
                 ;; the usual extra keys
-                (dissoc :semantic_type :effective_type :coercion_strategy :table_id
+                (dissoc :semantic_type :coercion_strategy :table_id
                         :id :settings :fingerprint))
             (qp.test/aggregate-col :count)]
            (mt/cols

--- a/test/metabase/query_processor_test/remapping_test.clj
+++ b/test/metabase/query_processor_test/remapping_test.clj
@@ -51,7 +51,7 @@
                       :limit       3}))
                  qp.test/rows-and-cols
                  (update :cols (fn [[c1 c2 agg]]
-                                 [(dissoc c1 :source_alias) c2 (dissoc agg :base_type)]))))))))
+                                 [(dissoc c1 :source_alias) c2 (dissoc agg :base_type :effective_type)]))))))))
 
 (deftest nested-remapping-test
   (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries)

--- a/test/metabase/util/ssh_test.clj
+++ b/test/metabase/util/ssh_test.clj
@@ -263,11 +263,13 @@
               (mt/with-db db
                 (sync/sync-database! db)
                 (letfn [(check-data [] (is (= {:cols [{:base_type    :type/Text
+                                                       :effective_type :type/Text
                                                        :display_name "COL1"
                                                        :field_ref    [:field "COL1" {:base-type :type/Text}]
                                                        :name         "COL1"
                                                        :source       :native}
                                                       {:base_type    :type/Decimal
+                                                       :effective_type :type/Decimal
                                                        :display_name "COL2"
                                                        :field_ref    [:field "COL2" {:base-type :type/Decimal}]
                                                        :name         "COL2"


### PR DESCRIPTION
This fixes an issue with analysis i ran into when trying to format the results of queries that have a datetime column with a unit.

```clojure
(-> (qp/process-query {:database 1
                       :type :query
                       :query {:aggregation ["count"]
                               :breakout [[:field 4 {:temporal-unit :month-of-year}]]
                               :source-table 2}})
    :data :cols first )

;; yields (with editing)
{:description "The date and time an order was submitted.",
 :unit :month-of-year,
 :name "CREATED_AT",
 :field_ref [:field 4 {:temporal-unit :month-of-year}],
 :effective_type :type/DateTime ;; this is bad!
 :base_type :type/Integer}

;; rows look like this
[[1 1826] [2 1686] [3 1801] [4 1555] [5 1371] [6 1277] [7 1468] [8 1479] [9 1455] [10 1564] [11 1606] [12 1672]]

;; where the integers are the months.
```

##### raw sql
```sql
SELECT month("PUBLIC"."ORDERS"."CREATED_AT") AS "CREATED_AT",
       count(*) AS "count"
FROM "PUBLIC"."ORDERS"
GROUP BY month("PUBLIC"."ORDERS"."CREATED_AT")
ORDER BY month("PUBLIC"."ORDERS"."CREATED_AT") ASC
```

##### graphical display
<img width="1542" alt="image" src="https://user-images.githubusercontent.com/6377293/130290211-81c9e075-d354-460b-a21d-65cea37e0d4b.png">

The effective_type was carried over from the field's effective type. This change makes the base_type of the results be the effective type of the column metadata. Effective_type is what you actually got, regardless of any of considerations. Usually this is set due to coercion strategies: you have an integer, coerce it to datetime as a unix epoch timestamp, and base_type is Integer, effective_type is DateTime. 

But when using units like this, you get back results for `month(timestamp)` which comes back as an integer. It doesn't make sense to have the effective_type of the column act as the effective_type of the result as they are quite different. This actually feels close to an expression or computed column. Not sure of the details on those in depth, but it is a result loosely based on a column, not just selecting a column.