### PR TITLE
#13468 Repro: Question with joins causes re-run overlay after first save

### DIFF
--- a/frontend/test/metabase/scenarios/question/reproductions/13468.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/13468.cy.spec.js
@@ -1,0 +1,35 @@
+import { restore, openOrdersTable } from "__support__/e2e/cypress";
+
+describe.skip("issue 13468", () => {
+  beforeEach(() => {
+    cy.intercept("POST", "/api/dataset").as("dataset");
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should not show run overlay after save on a joined question (metabase#13468)", () => {
+    openOrdersTable({ mode: "notebook" });
+
+    cy.findByText("Join data").click();
+    cy.findByText("Products").click();
+
+    visualizeResults();
+
+    saveQuestion();
+
+    // Cypress cannot click elements that are blocked by an overlay so this will immediately fail if the issue is not fixed
+    cy.findByText("110.93").click();
+    cy.findByText("Filter by this value");
+  });
+});
+
+function visualizeResults() {
+  cy.button("Visualize").click();
+  cy.wait("@dataset");
+}
+
+function saveQuestion() {
+  cy.findByText("Save").click();
+  cy.button("Save").click();
+  cy.button("Not now").click();
+}


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #13468

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/question/reproductions/13468.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/130296994-35178fc3-7b2d-4866-a6d8-0f960c9da6d5.png)
