### PR TITLE
Keep `collection_id` of dashboard subscriptions in sync with same field on dashboard

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -8474,9 +8474,8 @@ databaseChangeLog:
             sql: >-
               UPDATE pulse p
               INNER JOIN report_dashboard d
-              ON p.dashboard_id = d.
-              id SET p.collection_id = d.collection_id
-              WHERE p.dashboard_id IS NOT NULL;
+              ON p.dashboard_id = d.id
+              SET p.collection_id = d.collection_id;
         - sql:
             dbms: postgresql
             sql: >-

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -8470,13 +8470,13 @@ databaseChangeLog:
       comment: Added 0.41.0 Backfill collection_id for dashboard subscriptions
       changes:
         - sql:
-              sql: >-
-                UPDATE pulse p
-                SET collection_id = (
-                  SELECT d.collection_id
-                  FROM report_dashboard d
-                  WHERE d.id = p.dashboard_id
-                );
+            sql: >-
+              UPDATE pulse p
+              SET collection_id = (
+              SELECT d.collection_id
+                FROM report_dashboard d
+                WHERE d.id = p.dashboard_id
+              );
 
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -8472,11 +8472,10 @@ databaseChangeLog:
         - sql:
             sql: >-
               UPDATE pulse p
-              SET collection_id = (
-              SELECT d.collection_id
-                FROM report_dashboard d
-                WHERE d.id = p.dashboard_id
-              );
+              SET collection_id = d.collection_id
+              FROM report_dashboard d
+              WHERE p.dashboard_id = d.id
+              AND p.dashboard_id IS NOT NULL;
 
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -8495,7 +8495,6 @@ databaseChangeLog:
               )
               WHERE dashboard_id IS NOT NULL;
 
-
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -8464,6 +8464,20 @@ databaseChangeLog:
                 UPDATE setting SET value='simple' WHERE key='humanization-strategy'
                 AND value='advanced'
 
+  - changeSet:
+      id: 312
+      author: noahmoss
+      comment: Added 0.41.0 Backfill collection_id for dashboard subscriptions
+      changes:
+        - sql:
+              sql: >-
+                UPDATE pulse p
+                SET collection_id = (
+                  SELECT d.collection_id
+                  FROM report_dashboard d
+                  WHERE d.id = p.dashboard_id
+                );
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -8470,7 +8470,14 @@ databaseChangeLog:
       comment: Added 0.41.0 Backfill collection_id for dashboard subscriptions
       changes:
         - sql:
-            dbms: postgresql,mariadb,mysql
+            dbms: mariadb,mysql
+              UPDATE pulse p
+              INNER JOIN report_dashboard d
+              ON p.dashboard_id = d.
+              id SET p.collection_id = d.collection_id
+              WHERE p.dashboard_id IS NOT NULL;
+        - sql:
+            dbms: postgresql
             sql: >-
               UPDATE pulse p
               SET collection_id = d.collection_id

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -8470,12 +8470,24 @@ databaseChangeLog:
       comment: Added 0.41.0 Backfill collection_id for dashboard subscriptions
       changes:
         - sql:
+            dbms: postgresql,mariadb,mysql
             sql: >-
               UPDATE pulse p
               SET collection_id = d.collection_id
               FROM report_dashboard d
               WHERE p.dashboard_id = d.id
               AND p.dashboard_id IS NOT NULL;
+        - sql:
+            dbms: h2
+            sql: >-
+              UPDATE pulse p
+              SET collection_id = (
+                SELECT d.collection_id
+                FROM report_dashboard d
+                WHERE d.id = p.dashboard_id
+              )
+              WHERE collection_id IS NULL;
+
 
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -8471,6 +8471,7 @@ databaseChangeLog:
       changes:
         - sql:
             dbms: mariadb,mysql
+            sql: >-
               UPDATE pulse p
               INNER JOIN report_dashboard d
               ON p.dashboard_id = d.

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -8493,7 +8493,7 @@ databaseChangeLog:
                 FROM report_dashboard d
                 WHERE d.id = p.dashboard_id
               )
-              WHERE collection_id IS NULL;
+              WHERE dashboard_id IS NOT NULL;
 
 
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<

--- a/src/metabase/models/pulse.clj
+++ b/src/metabase/models/pulse.clj
@@ -68,7 +68,7 @@
                (not= (:collection_id notification) collection_id)
                (not *allow-moving-dashboard-subscriptions*))
       (throw (ex-info (tru "collection ID of dashboard subscription cannot be directly modified") notification)))
-    (when (not= (:collection_id notification) dashboard_id)
+    (when (not= (:dashboard_id notification) dashboard_id)
       (throw (ex-info (tru "dashboard ID of a dashboard subscription cannot be modified") notification))))
   (u/prog1 notification
     (assert-valid-parameters notification)

--- a/src/metabase/models/pulse.clj
+++ b/src/metabase/models/pulse.clj
@@ -68,7 +68,8 @@
                (not= (:collection_id notification) collection_id)
                (not *allow-moving-dashboard-subscriptions*))
       (throw (ex-info (tru "collection ID of dashboard subscription cannot be directly modified") notification)))
-    (when (not= (:dashboard_id notification) dashboard_id)
+    (when (and dashboard_id
+               (not= (:dashboard_id notification) dashboard_id))
       (throw (ex-info (tru "dashboard ID of a dashboard subscription cannot be modified") notification))))
   (u/prog1 notification
     (assert-valid-parameters notification)

--- a/src/metabase/models/pulse.clj
+++ b/src/metabase/models/pulse.clj
@@ -62,7 +62,6 @@
   only be done when the associated dashboard is being moved to a new collection."
   false)
 
-
 (defn- pre-update [notification]
   (let [{:keys [collection_id dashboard_id]} (db/select-one [Pulse :collection_id :dashboard_id] :id (u/the-id notification))]
     (when (and dashboard_id

--- a/src/metabase/models/pulse.clj
+++ b/src/metabase/models/pulse.clj
@@ -44,8 +44,15 @@
                     {:parameters parameters}))))
 
 (defn- pre-insert [notification]
-  (let [defaults     {:parameters []}
-        notification (apply merge defaults (for [[k v] notification :when (some? v)] {k v}))]
+  (let [defaults      {:parameters []}
+        dashboard-id  (:dashboard_id notification)
+        collection-id (if dashboard-id
+                        (db/select-one-field :collection_id 'Dashboard, :id dashboard-id)
+                        (:collection_id notification))
+        notification  (->> (for [[k v] notification
+                                 :when (some? v)]
+                             {k v})
+                           (apply merge defaults {:collection_id collection-id}))]
     (u/prog1 notification
       (assert-valid-parameters notification)
       (collection/check-collection-namespace Pulse (:collection_id notification)))))

--- a/src/metabase/models/pulse.clj
+++ b/src/metabase/models/pulse.clj
@@ -69,6 +69,7 @@
                (not *allow-moving-dashboard-subscriptions*))
       (throw (ex-info (tru "collection ID of dashboard subscription cannot be directly modified") notification)))
     (when (and dashboard_id
+               (contains? notification :dashboard_id)
                (not= (:dashboard_id notification) dashboard_id))
       (throw (ex-info (tru "dashboard ID of a dashboard subscription cannot be modified") notification))))
   (u/prog1 notification

--- a/test/metabase/models/dashboard_test.clj
+++ b/test/metabase/models/dashboard_test.clj
@@ -173,15 +173,19 @@
                  (:public_uuid dashboard))))))))
 
 (deftest post-update-test
-  (tt/with-temp* [Dashboard           [{dashboard-id :id} {:name "Lucky the Pigeon's Lucky Stuff"}]
+  (tt/with-temp* [Collection          [{collection-id-1 :id}]
+                  Collection          [{collection-id-2 :id}]
+                  Dashboard           [{dashboard-id :id} {:name "Lucky the Pigeon's Lucky Stuff", :collection_id collection-id-1}]
                   Card                [{card-id :id}]
-                  Pulse               [{pulse-id :id} {:dashboard_id dashboard-id}]
+                  Pulse               [{pulse-id :id} {:dashboard_id dashboard-id, :collection_id collection-id-1}]
                   DashboardCard       [{dashcard-id :id} {:dashboard_id dashboard-id, :card_id card-id}]
                   PulseCard           [{pulse-card-id :id} {:pulse_id pulse-id, :card_id card-id, :dashboard_card_id dashcard-id}]]
-    (testing "Pulse name updates"
-      (db/update! Dashboard dashboard-id :name "Lucky's Close Shaves")
+    (testing "Pulse name and collection-id updates"
+      (db/update! Dashboard dashboard-id :name "Lucky's Close Shaves" :collection_id collection-id-2)
       (is (= "Lucky's Close Shaves"
-             (db/select-one-field :name Pulse :id pulse-id))))
+             (db/select-one-field :name Pulse :id pulse-id)))
+      (is (= collection-id-2
+             (db/select-one-field :collection_id Pulse :id pulse-id))))
     (testing "PulseCard syncing"
       (tt/with-temp Card [{new-card-id :id}]
         (add-dashcard! dashboard-id new-card-id)

--- a/test/metabase/models/pulse_test.clj
+++ b/test/metabase/models/pulse_test.clj
@@ -254,6 +254,16 @@
                                                                          {:id (mt/user->id :crowberto)}]}]
                                         :skip_if_empty false}))))))
 
+(deftest dashboard-subscription-update-test
+  (testing "collection_id and dashboard_id of a dashboard subscription cannot be directly updated"
+      (mt/with-temp* [Collection [{collection-id :id}]
+                      Dashboard  [{dashboard-id :id}]
+                      Pulse      [pulse {:dashboard_id dashboard-id :collection_id collection-id}]]
+        (is (thrown? Exception
+              (db/update! Pulse (u/the-id pulse) {:collection_id (inc collection-id)})))
+        (is (thrown? Exception
+              (db/update! Pulse (u/the-id pulse) {:dashboard_id (inc dashboard-id)}))))))
+
 (deftest no-archived-cards-test
   (testing "make sure fetching a Pulse doesn't return any archived cards"
     (mt/with-temp* [Pulse     [pulse]

--- a/test/metabase/models/pulse_test.clj
+++ b/test/metabase/models/pulse_test.clj
@@ -255,14 +255,14 @@
                                         :skip_if_empty false}))))))
 
 (deftest dashboard-subscription-update-test
-  (testing "collection_id and dashboard_id of a dashboard subscription cannot be directly updated"
+  (testing "collection_id and dashboard_id of a dashboard subscription cannot be directly modified"
       (mt/with-temp* [Collection [{collection-id :id}]
                       Dashboard  [{dashboard-id :id}]
-                      Pulse      [pulse {:dashboard_id dashboard-id :collection_id collection-id}]]
-        (is (thrown? Exception
-              (db/update! Pulse (u/the-id pulse) {:collection_id (inc collection-id)})))
-        (is (thrown? Exception
-              (db/update! Pulse (u/the-id pulse) {:dashboard_id (inc dashboard-id)}))))))
+                      Pulse      [{pulse-id :id} {:dashboard_id dashboard-id :collection_id collection-id}]]
+        (is (thrown-with-msg? Exception #"collection ID of dashboard subscription cannot be directly modified"
+              (db/update! Pulse pulse-id {:collection_id (inc collection-id)})))
+        (is (thrown-with-msg? Exception #"collection ID of dashboard subscription cannot be directly modified"
+              (db/update! Pulse pulse-id {:dashboard_id (inc dashboard-id)}))))))
 
 (deftest no-archived-cards-test
   (testing "make sure fetching a Pulse doesn't return any archived cards"

--- a/test/metabase/models/pulse_test.clj
+++ b/test/metabase/models/pulse_test.clj
@@ -179,16 +179,18 @@
 (deftest create-dashboard-subscription-test
   (testing "Make sure that the dashboard_id is set correctly when creating a Dashboard Subscription pulse"
     (mt/with-model-cleanup [Pulse]
-      (mt/with-temp* [Dashboard     [{dashboard-id :id}]
+      (mt/with-temp* [Collection    [{collection-id :id}]
+                      Dashboard     [{dashboard-id :id} {:collection_id collection-id}]
                       Card          [{card-id :id, :as card}]
                       DashboardCard [{dashcard-id :id} {:dashboard_id dashboard-id, :card_id card-id}]]
-        (is (schema= {:name         (s/eq "Abnormal Pulse")
-                      :dashboard_id (s/eq dashboard-id)
-                      :cards        [(s/one {:dashboard_id      (s/eq dashboard-id)
-                                             :dashboard_card_id (s/eq dashcard-id)
-                                             s/Keyword          s/Any}
-                                            "pulse card")]
-                      s/Keyword     s/Any}
+        (is (schema= {:name          (s/eq "Abnormal Pulse")
+                      :dashboard_id  (s/eq dashboard-id)
+                      :collection_id (s/eq collection-id)
+                      :cards         [(s/one {:dashboard_id      (s/eq dashboard-id)
+                                              :dashboard_card_id (s/eq dashcard-id)
+                                              s/Keyword          s/Any}
+                                             "pulse card")]
+                      s/Keyword      s/Any}
                      (create-pulse-then-select!
                       "Abnormal Pulse"
                       (mt/user->id :rasta)


### PR DESCRIPTION
* On dashboard subscription creation, sets `collection_id` to the collection ID of the associated dashboard
* When a dashboard is updated, updates `collection_id` on any associated subscriptions, in case the dashboard was moved to a new collection
* Prevents `collection_id` and `dashboard_id` of dashboard subscriptions from being directly modified
* Adds a DB migration to backfill `collection_id` for any dashboard subscriptions that are missing it