### PR TITLE
Make the front-end metadata sources valid JavaScript

### DIFF
--- a/frontend/src/metabase-lib/lib/metadata/Database.js
+++ b/frontend/src/metabase-lib/lib/metadata/Database.js
@@ -1,17 +1,14 @@
 import Question from "../Question";
 
 import Base from "./Base";
-import Table from "./Table";
-import Schema from "./Schema";
 
 import { memoize, createLookupByProperty } from "metabase-lib/lib/utils";
 
 import { generateSchemaId } from "metabase/schema";
 
-import type { SchemaName } from "metabase-types/types/Table";
-import type { DatabaseFeature } from "metabase-types/types/Database";
-
-type VirtualDatabaseFeature = "join";
+/**
+ * @typedef { import("./metadata").SchemaName } SchemaName
+ */
 
 /**
  * Wrapper class for database metadata objects. Contains {@link Schema}s, {@link Table}s, {@link Metric}s, {@link Segment}s.
@@ -21,25 +18,20 @@ type VirtualDatabaseFeature = "join";
 export default class Database extends Base {
   // TODO Atte Keinänen 6/11/17: List all fields here (currently only in types/Database)
 
-  name: string;
-  description: ?string;
-
-  tables: Table[];
-  schemas: Schema[];
-
-  auto_run_queries: boolean;
-
-  displayName(): string {
+  displayName() {
     return this.name;
   }
 
   // SCHEMAS
 
-  schema(schemaName: ?SchemaName) {
+  /**
+   * @param {SchemaName} [schemaName]
+   */
+  schema(schemaName) {
     return this.metadata.schema(generateSchemaId(this.id, schemaName));
   }
 
-  schemaNames(): SchemaName[] {
+  schemaNames() {
     return this.schemas.map(s => s.name).sort((a, b) => a.localeCompare(b));
   }
 
@@ -69,7 +61,12 @@ export default class Database extends Base {
 
   // FEATURES
 
-  hasFeature(feature: null | DatabaseFeature | VirtualDatabaseFeature) {
+  /**
+   * @typedef {import("./metadata").DatabaseFeature} DatabaseFeature
+   * @typedef {"join"} VirtualDatabaseFeature
+   * @param {DatabaseFeature | VirtualDatabaseFeature} [feature]
+   */
+  hasFeature(feature) {
     if (!feature) {
       return true;
     }
@@ -92,13 +89,13 @@ export default class Database extends Base {
 
   // QUESTIONS
 
-  newQuestion(): Question {
+  newQuestion() {
     return this.question()
       .setDefaultQuery()
       .setDefaultDisplay();
   }
 
-  question(query = { "source-table": null }): Question {
+  question(query = { "source-table": null }) {
     return Question.create({
       metadata: this.metadata,
       dataset_query: {
@@ -109,7 +106,7 @@ export default class Database extends Base {
     });
   }
 
-  nativeQuestion(native = {}): Question {
+  nativeQuestion(native = {}) {
     return Question.create({
       metadata: this.metadata,
       dataset_query: {
@@ -129,7 +126,35 @@ export default class Database extends Base {
   }
 
   /** Returns a database containing only the saved questions from the same database, if any */
-  savedQuestionsDatabase(): ?Database {
+  savedQuestionsDatabase() {
     return this.metadata.databasesList().find(db => db.is_saved_questions);
+  }
+
+  /**
+   * @private
+   * @param {number} id
+   * @param {string} name
+   * @param {?string} description
+   * @param {Table[]} tables
+   * @param {Schema[]} schemas
+   * @param {Metadata} metadata
+   * @param {boolean} auto_run_queries
+   */
+  _constructor(
+    id,
+    name,
+    description,
+    tables,
+    schemas,
+    metadata,
+    auto_run_queries,
+  ) {
+    this.id = id;
+    this.name = name;
+    this.description = description;
+    this.tables = tables;
+    this.schemas = schemas;
+    this.metadata = metadata;
+    this.auto_run_queries = auto_run_queries;
   }
 }

--- a/frontend/src/metabase-lib/lib/metadata/Field.js
+++ b/frontend/src/metabase-lib/lib/metadata/Field.js
@@ -1,5 +1,4 @@
 import Base from "./Base";
-import Table from "./Table";
 
 import moment from "moment";
 
@@ -34,19 +33,14 @@ import {
   getFilterOperators,
 } from "metabase/lib/schema_metadata";
 
-import type { FieldValues } from "metabase-types/types/Field";
+/**
+ * @typedef { import("./metadata").FieldValues } FieldValues
+ */
 
 /**
  * Wrapper class for field metadata objects. Belongs to a Table.
  */
 export default class Field extends Base {
-  name: string;
-  display_name: string;
-  description: string;
-
-  table: Table;
-  name_field: ?Field;
-
   parent() {
     return this.metadata ? this.metadata.field(this.parent_id) : null;
   }
@@ -153,7 +147,10 @@ export default class Field extends Base {
     return isEntityName(this);
   }
 
-  isCompatibleWith(field: Field) {
+  /**
+   * @param {Field} field
+   */
+  isCompatibleWith(field) {
     return (
       this.isDate() === field.isDate() ||
       this.isNumeric() === field.isNumeric() ||
@@ -161,7 +158,10 @@ export default class Field extends Base {
     );
   }
 
-  fieldValues(): FieldValues {
+  /**
+   * @returns {FieldValues}
+   */
+  fieldValues() {
     return getFieldValues(this._object);
   }
 
@@ -282,8 +282,9 @@ export default class Field extends Base {
 
   /**
    * Returns the remapped field, if any
+   * @return {?Field}
    */
-  remappedField(): ?Field {
+  remappedField() {
     const displayFieldId =
       this.dimensions && this.dimensions.human_readable_field_id;
     if (displayFieldId != null) {
@@ -299,8 +300,9 @@ export default class Field extends Base {
 
   /**
    * Returns the human readable remapped value, if any
+   * @returns {?string}
    */
-  remappedValue(value): ?string {
+  remappedValue(value) {
     // TODO: Ugh. Should this be handled further up by the parameter widget?
     if (this.isNumeric() && typeof value !== "number") {
       value = parseFloat(value);
@@ -310,8 +312,9 @@ export default class Field extends Base {
 
   /**
    * Returns whether the field has a human readable remapped value for this value
+   * @returns {?string}
    */
-  hasRemappedValue(value): ?string {
+  hasRemappedValue(value) {
     // TODO: Ugh. Should this be handled further up by the parameter widget?
     if (this.isNumeric() && typeof value !== "number") {
       value = parseFloat(value);
@@ -321,6 +324,7 @@ export default class Field extends Base {
 
   /**
    * Returns true if this field can be searched, e.x. in filter or parameter widgets
+   * @returns {boolean}
    */
   isSearchable() {
     // TODO: ...?
@@ -333,8 +337,38 @@ export default class Field extends Base {
 
   /**
    * Returns a FKDimension for this field and the provided field
+   * @param {Field} foreignField
+   * @return {Dimension}
    */
-  foreign(foreignField: Field): Dimension {
+  foreign(foreignField) {
     return this.dimension().foreign(foreignField.dimension());
+  }
+
+  /**
+   * @private
+   * @param {number} id
+   * @param {string} name
+   * @param {string} display_name
+   * @param {string} description
+   * @param {Table} table
+   * @param {?Field} name_field
+   * @param {Metadata} metadata
+   */
+  _constructor(
+    id,
+    name,
+    display_name,
+    description,
+    table,
+    name_field,
+    metadata,
+  ) {
+    this.id = id;
+    this.name = name;
+    this.display_name = display_name;
+    this.description = description;
+    this.table = table;
+    this.name_field = name_field;
+    this.metadata = metadata;
   }
 }

--- a/frontend/src/metabase-lib/lib/metadata/Metadata.js
+++ b/frontend/src/metabase-lib/lib/metadata/Metadata.js
@@ -2,33 +2,26 @@ import _ from "underscore";
 
 import Base from "./Base";
 
-import Database from "./Database";
-import Table from "./Table";
-import Schema from "./Schema";
-import Field from "./Field";
-import Segment from "./Segment";
-import Metric from "./Metric";
-
 import Question from "../Question";
 
-import type { DatabaseId } from "metabase-types/types/Database";
-import type { TableId } from "metabase-types/types/Table";
-import type { FieldId } from "metabase-types/types/Field";
-import type { MetricId } from "metabase-types/types/Metric";
-import type { SegmentId } from "metabase-types/types/Segment";
+/**
+ * @typedef { import("./metadata").DatabaseId } DatabaseId
+ * @typedef { import("./metadata").SchemaId } SchemaId
+ * @typedef { import("./metadata").TableId } TableId
+ * @typedef { import("./metadata").FieldId } FieldId
+ * @typedef { import("./metadata").MetricId } MetricId
+ * @typedef { import("./metadata").SegmentId } SegmentId
+ */
 
 /**
  * Wrapper class for the entire metadata store
  */
 export default class Metadata extends Base {
-  databases: { [id: DatabaseId]: Database };
-  tables: { [id: TableId]: Table };
-  fields: { [id: FieldId]: Field };
-  metrics: { [id: MetricId]: Metric };
-  segments: { [id: SegmentId]: Segment };
-
-  // DEPRECATED: this won't be sorted or filtered in a meaningful way
-  databasesList({ savedQuestions = true } = {}): Database[] {
+  /**
+   * @deprecated this won't be sorted or filtered in a meaningful way
+   * @returns {Database[]}
+   */
+  databasesList({ savedQuestions = true } = {}) {
     return _.chain(this.databases)
       .values()
       .filter(db => savedQuestions || !db.is_saved_questions)
@@ -36,46 +29,97 @@ export default class Metadata extends Base {
       .value();
   }
 
-  // DEPRECATED: this won't be sorted or filtered in a meaningful way
-  tablesList(): Database[] {
-    return (Object.values(this.tables): Database[]);
+  /**
+   * @deprecated this won't be sorted or filtered in a meaningful way
+   * @returns {Table[]}
+   */
+  tablesList() {
+    return Object.values(this.tables);
   }
 
-  // DEPRECATED: this won't be sorted or filtered in a meaningful way
-  metricsList(): Metric[] {
-    return (Object.values(this.metrics): Metric[]);
+  /**
+   * @deprecated this won't be sorted or filtered in a meaningful way
+   * @returns {Metric[]}
+   */
+  metricsList() {
+    return Object.values(this.metrics);
   }
 
-  // DEPRECATED: this won't be sorted or filtered in a meaningful way
-  segmentsList(): Metric[] {
-    return (Object.values(this.segments): Segment[]);
+  /**
+   * @deprecated this won't be sorted or filtered in a meaningful way
+   * @returns {Segment[]}
+   */
+  segmentsList() {
+    return Object.values(this.segments);
   }
 
-  segment(segmentId): ?Segment {
+  /**
+   * @param {SegmentId} segmentId
+   * @returns {?Segment}
+   */
+
+  segment(segmentId) {
     return (segmentId != null && this.segments[segmentId]) || null;
   }
 
-  metric(metricId): ?Metric {
+  /**
+   * @param {MetricId} metricId
+   * @returns {?Metric}
+   */
+  metric(metricId) {
     return (metricId != null && this.metrics[metricId]) || null;
   }
 
-  database(databaseId): ?Database {
+  /**
+   * @param {DatabaseId} databaseId
+   * @returns {?Database}
+   */
+  database(databaseId) {
     return (databaseId != null && this.databases[databaseId]) || null;
   }
 
-  schema(schemaId): ?Schema {
+  /**
+   * @param {SchemaId} schemaId
+   * @returns {Schema}
+   */
+  schema(schemaId) {
     return (schemaId != null && this.schemas[schemaId]) || null;
   }
 
-  table(tableId): ?Table {
+  /**
+   *
+   * @param {TableId} tableId
+   * @returns {?Table}
+   */
+  table(tableId) {
     return (tableId != null && this.tables[tableId]) || null;
   }
 
-  field(fieldId): ?Field {
+  /**
+   * @param {FieldId} fieldId
+   * @returns {?Field}
+   */
+  field(fieldId) {
     return (fieldId != null && this.fields[fieldId]) || null;
   }
 
   question(card) {
     return new Question(card, this);
+  }
+
+  /**
+   * @private
+   * @param {Object.<number, Database>} databases
+   * @param {Object.<number, Table>} tables
+   * @param {Object.<number, Field>} fields
+   * @param {Object.<number, Metric>} metrics
+   * @param {Object.<number, Segment>} segments
+   */
+  _constructor(databases, tables, fields, metrics, segments) {
+    this.databases = databases;
+    this.tables = tables;
+    this.fields = fields;
+    this.metrics = metrics;
+    this.segments = segments;
   }
 }

--- a/frontend/src/metabase-lib/lib/metadata/Metric.js
+++ b/frontend/src/metabase-lib/lib/metadata/Metric.js
@@ -1,23 +1,21 @@
 import Base from "./Base";
-import Database from "./Database";
-import Table from "./Table";
-import type { Aggregation } from "metabase-types/types/Query";
+
+/**
+ * @typedef { import("./metadata").Aggregation } Aggregation
+ */
 
 /**
  * Wrapper class for a metric. Belongs to a {@link Database} and possibly a {@link Table}
  */
 export default class Metric extends Base {
-  name: string;
-  description: string;
-
-  database: Database;
-  table: Table;
-
-  displayName(): string {
+  displayName() {
     return this.name;
   }
 
-  aggregationClause(): Aggregation {
+  /**
+   * @returns {Aggregation}
+   */
+  aggregationClause() {
     return ["metric", this.id];
   }
 
@@ -51,5 +49,25 @@ export default class Metric extends Base {
 
   isActive() {
     return !this.archived;
+  }
+
+  /**
+   * @private
+   * @param {string} name
+   * @param {string} description
+   * @param {Database} database
+   * @param {Table} table
+   * @param {number} id
+   * @param {StructuredQuery} definition
+   * @param {boolean} archived
+   */
+  _constructor(name, description, database, table, id, definition, archived) {
+    this.name = name;
+    this.description = description;
+    this.database = database;
+    this.table = table;
+    this.id = id;
+    this.definition = definition;
+    this.archived = archived;
   }
 }

--- a/frontend/src/metabase-lib/lib/metadata/Schema.js
+++ b/frontend/src/metabase-lib/lib/metadata/Schema.js
@@ -1,6 +1,4 @@
 import Base from "./Base";
-import Database from "./Database";
-import Table from "./Table";
 
 import { titleize, humanize } from "metabase/lib/formatting";
 
@@ -8,14 +6,23 @@ import { titleize, humanize } from "metabase/lib/formatting";
  * Wrapper class for a {@link Database} schema. Contains {@link Table}s.
  */
 export default class Schema extends Base {
-  database: Database;
-  tables: Table[];
-
   displayName() {
     return titleize(humanize(this.name));
   }
 
   getTables() {
     return this.tables;
+  }
+
+  /**
+   * @private
+   * @param {string} name
+   * @param {Database} database
+   * @param {Table[]} tables
+   */
+  _constructor(name, database, tables) {
+    this.name = name;
+    this.database = database;
+    this.tables = tables;
   }
 }

--- a/frontend/src/metabase-lib/lib/metadata/Segment.js
+++ b/frontend/src/metabase-lib/lib/metadata/Segment.js
@@ -1,27 +1,43 @@
 import Base from "./Base";
-import Database from "./Database";
-import Table from "./Table";
-import type { FilterClause } from "metabase-types/types/Query";
+
+/**
+ * @typedef { import("./metadata").FilterClause } FilterClause
+ */
 
 /**
  * Wrapper class for a segment. Belongs to a {@link Database} and possibly a {@link Table}
  */
 export default class Segment extends Base {
-  name: string;
-  description: string;
-
-  database: Database;
-  table: Table;
-
-  displayName(): string {
+  displayName() {
     return this.name;
   }
 
-  filterClause(): FilterClause {
+  /**
+   * @returns {FilterClause}
+   */
+  filterClause() {
     return ["segment", this.id];
   }
 
   isActive() {
     return !this.archived;
+  }
+
+  /**
+   * @private
+   * @param {string} name
+   * @param {string} description
+   * @param {Database} database
+   * @param {Table} table
+   * @param {number} id
+   * @param {boolean} archived
+   */
+  _constructor(name, description, database, table, id, archived) {
+    this.name = name;
+    this.description = description;
+    this.database = database;
+    this.table = table;
+    this.id = id;
+    this.archived = archived;
   }
 }

--- a/frontend/src/metabase-lib/lib/metadata/Table.js
+++ b/frontend/src/metabase-lib/lib/metadata/Table.js
@@ -2,35 +2,19 @@
 import Question from "../Question";
 
 import Base from "./Base";
-import Database from "./Database";
-import Schema from "./Schema";
-import Field from "./Field";
-
-import Dimension from "../Dimension";
 
 import { singularize } from "metabase/lib/formatting";
 import { getAggregationOperatorsWithFields } from "metabase/lib/schema_metadata";
 import { memoize, createLookupByProperty } from "metabase-lib/lib/utils";
 
-import type { SchemaName } from "metabase-types/types/Table";
-import type StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
-
-type EntityType = string; // TODO: move somewhere central
+/**
+ * @typedef { import("./metadata").SchemaName } SchemaName
+ * @typedef { import("./metadata").EntityType } EntityType
+ * @typedef { import("./metadata").StructuredQuery } StructuredQuery
+ */
 
 /** This is the primary way people interact with tables */
 export default class Table extends Base {
-  description: string;
-
-  db: Database;
-
-  schema: ?Schema;
-  // @deprecated: use schema.name (all tables should have a schema object, in theory)
-  schema_name: ?SchemaName;
-
-  fields: Field[];
-
-  entity_type: ?EntityType;
-
   hasSchema() {
     return (this.schema_name && this.db && this.db.schemas.length > 1) || false;
   }
@@ -40,13 +24,13 @@ export default class Table extends Base {
     return this.db;
   }
 
-  newQuestion(): Question {
+  newQuestion() {
     return this.question()
       .setDefaultQuery()
       .setDefaultDisplay();
   }
 
-  question(): Question {
+  question() {
     return Question.create({
       databaseId: this.db && this.db.id,
       tableId: this.id,
@@ -63,13 +47,16 @@ export default class Table extends Base {
     return match ? parseInt(match[1]) : null;
   }
 
-  query(query = {}): StructuredQuery {
+  /**
+   * @returns {StructuredQuery}
+   */
+  query(query = {}) {
     return this.question()
       .query()
       .updateQuery(q => ({ ...q, ...query }));
   }
 
-  dimensions(): Dimension[] {
+  dimensions() {
     return this.fields.map(field => field.dimension());
   }
 
@@ -89,7 +76,7 @@ export default class Table extends Base {
     return singularize(this.displayName());
   }
 
-  dateFields(): Field[] {
+  dateFields() {
     return this.fields.filter(field => field.isDate());
   }
 
@@ -129,5 +116,23 @@ export default class Table extends Base {
   // @deprecated: use fieldsLookup
   get fields_lookup() {
     return this.fieldsLookup();
+  }
+
+  /**
+   * @private
+   * @param {string} description
+   * @param {Database} db
+   * @param {Schema?} schema
+   * @param {SchemaName} [schema_name]
+   * @param {Field[]} fields
+   * @param {EntityType} entity_type
+   */
+  _constructor(description, db, schema, schema_name, fields, entity_type) {
+    this.description = description;
+    this.db = db;
+    this.schema = schema;
+    this.schema_name = schema_name;
+    this.fields = fields;
+    this.entity_type = entity_type;
   }
 }

--- a/frontend/src/metabase-lib/lib/metadata/metadata.d.ts
+++ b/frontend/src/metabase-lib/lib/metadata/metadata.d.ts
@@ -1,0 +1,39 @@
+// to help declaring nominal types
+interface Flavoring<FlavorT> {
+    _type?: FlavorT;
+}
+export type Flavor<T, FlavorT> = T & Flavoring<FlavorT>;
+
+
+export type EntityType = Flavor<string, "EntityType">;
+export type SchemaName = Flavor<string, "SchemaName">;
+
+
+// TODO: move to types.d.ts
+
+export type DatabaseId = Flavor<number, "DatabaseId">;
+export type TableId = Flavor<number, "TableId">;
+export type FieldId = Flavor<number, "FieldId">;
+export type MetricId = Flavor<number, "MetricId">;
+export type SegmentId = Flavor<number, "SegmentId">;
+
+export type SchemaId = Flavor<string, "SchemaId">;
+
+export type DatabaseFeature =
+  | "basic-aggregations"
+  | "standard-deviation-aggregations"
+  | "expression-aggregations"
+  | "foreign-keys"
+  | "native-parameters"
+  | "nested-queries"
+  | "expressions"
+  | "case-sensitivity-string-filter-options"
+  | "binning";
+
+export type FieldValues = Flavor<any, "FieldValues">;
+
+
+// TODO: move to query.d.ts
+export type Aggregation = Flavor<any, "Aggregation">;
+export type FilterClause = Flavor<any, "FilterClause">;
+export type StructuredQuery = Flavor<any, "StructuredQuery">;


### PR DESCRIPTION
Everything under `frontend/src/metabase-lib/lib/metadata/Metadata.js` is now valid JavaScript!

To preserve the useful type information, we rely mostly on the power of type inference (of the editor with LSP, which works remarkably well, see the previous related PR #17518, #17519, etc), combined with the following:

* "fake" constructor (see `_constructor`) to give the type hints of member variables
* JSDoc-annotations (e.g., `@return`) whenever necessary
* a new external type definition, `metadata.d.ts`, importable from any source file, which is work-in-progress and which will be continuously updated with the forthcoming cleanup of `frontend/src/metabase-lib`.

How to try: the editing/debugging experience should be the same, whenever there is a need to access or to find some information on the member variables/methods of Table, Field, Database, etc.

In a few cases, there is a minor improvement due to the use of nominal typing. For instance, in `queries/StructuredQuery.js`, the member `entity_type` is correctly type-inferred.

**Before this PR**

![image](https://user-images.githubusercontent.com/7288/130303492-9062ae37-a725-4767-a27f-f7d7fc0c8a25.png)

**After this PR**

![image](https://user-images.githubusercontent.com/7288/130303487-56cf9fff-df4a-4d5b-be58-b6d58ae22b4c.png)

