### PR TITLE
Add day of week formatting with formatting options

### DIFF
--- a/frontend/src/metabase/lib/formatting.js
+++ b/frontend/src/metabase/lib/formatting.js
@@ -532,7 +532,7 @@ export function formatDateTimeWithUnit(
     );
   }
 
-  return formatDateTimeWithFormats(value, dateFormat, timeFormat, options);
+  return formatDateTimeWithFormats(m, dateFormat, timeFormat, options);
 }
 
 export function formatTime(value: Value) {

--- a/frontend/src/metabase/lib/time.js
+++ b/frontend/src/metabase/lib/time.js
@@ -85,9 +85,9 @@ export function parseTimestamp(value, unit = null, local = false) {
     m = value;
   } else if (typeof value === "string" && /(Z|[+-]\d\d:?\d\d)$/.test(value)) {
     m = moment.parseZone(value);
-  } else if (typeof value === "string" && unit in TEXT_UNIT_FORMATS) {
+  } else if (unit in TEXT_UNIT_FORMATS && typeof value === "string") {
     m = TEXT_UNIT_FORMATS[unit](value);
-  } else if (typeof value == "number" && unit in NUMERIC_UNIT_FORMATS) {
+  } else if (unit in NUMERIC_UNIT_FORMATS && typeof value == "number") {
     m = NUMERIC_UNIT_FORMATS[unit](value);
   } else {
     m = moment.utc(value);

--- a/frontend/src/metabase/lib/time.js
+++ b/frontend/src/metabase/lib/time.js
@@ -33,6 +33,10 @@ function addAbbreviatedLocale() {
   moment.locale(initialLocale);
 }
 
+const TEXT_UNIT_FORMATS = {
+  "day-of-week": value => moment.parseZone(value, "ddd").startOf("day"),
+};
+
 const NUMERIC_UNIT_FORMATS = {
   // workaround for https://github.com/metabase/metabase/issues/1992
   year: value =>
@@ -81,7 +85,9 @@ export function parseTimestamp(value, unit = null, local = false) {
     m = value;
   } else if (typeof value === "string" && /(Z|[+-]\d\d:?\d\d)$/.test(value)) {
     m = moment.parseZone(value);
-  } else if (unit in NUMERIC_UNIT_FORMATS && typeof value == "number") {
+  } else if (typeof value === "string" && unit in TEXT_UNIT_FORMATS) {
+    m = TEXT_UNIT_FORMATS[unit](value);
+  } else if (typeof value == "number" && unit in NUMERIC_UNIT_FORMATS) {
     m = NUMERIC_UNIT_FORMATS[unit](value);
   } else {
     m = moment.utc(value);

--- a/frontend/src/metabase/lib/time.js
+++ b/frontend/src/metabase/lib/time.js
@@ -125,6 +125,7 @@ export function formatHourAMPM(hour) {
   }
 }
 
+// @deprecated use formatDateTimeWithUnit(day, "day-of-week")
 export function formatDay(day) {
   switch (day) {
     case "mon":

--- a/frontend/test/metabase/lib/formatting.unit.spec.js
+++ b/frontend/test/metabase/lib/formatting.unit.spec.js
@@ -464,8 +464,22 @@ describe("formatting", () => {
         ).toEqual("julio 7, 2019 – julio 13, 2019");
       } finally {
         // globally reset locale
-        moment.locale(false);
+        moment.locale("en");
       }
+    });
+
+    it("should format days of week with default options", () => {
+      expect(formatDateTimeWithUnit("mon", "day-of-week")).toEqual("Monday");
+    });
+
+    it("should format days of week with compact option", () => {
+      const options = {
+        compact: true,
+      };
+
+      expect(formatDateTimeWithUnit("sun", "day-of-week", options)).toEqual(
+        "Sun",
+      );
     });
   });
 


### PR DESCRIPTION
For notifications we need to display days of week with respect to localization options of the current user. This PR adds support for days of week for `formatDateTimeWithUnit`.