### PR TITLE
add workflow that creates backport PRs which had a backport label before merge

### DIFF
--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -1,0 +1,131 @@
+# Creates a pull request with the latest release branch as a target with a cherry-picked commit if an associated pull request has `backport` label
+name: AutoBackport
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  pr_info:
+    name: Check if the commit should be backported
+    runs-on: ubuntu-latest
+    outputs:
+      title: ${{ fromJson(steps.collect_pr_info.outputs.result).title }}
+      number: ${{ fromJson(steps.collect_pr_info.outputs.result).pullRequestNumber }}
+      author: ${{ fromJson(steps.collect_pr_info.outputs.result).author }}
+      should_backport: ${{ fromJson(steps.collect_pr_info.outputs.result).hasBackportLabel }}
+    steps:
+      - uses: actions/github-script@v4
+        id: collect_pr_info
+        with:
+          script: |
+            const commitMessage = context.payload.commits[0].message;
+            const pullRequestNumbers = Array.from(commitMessage.matchAll(/\(#(.*?)\)/g))
+
+            if (pullRequestNumbers.length === 0) {
+              return;
+            }
+
+            if (pullRequestNumbers > 1) {
+              throw "Multiple PRs are associated with this commit";
+            }
+
+            const pullRequestNumber = pullRequestNumbers[0][1];
+
+            const { data } = await github.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pullRequestNumber
+            });
+
+            const hasBackportLabel = data.labels.some((label) => label.name === 'backport');
+            const { title, user } = data
+
+            console.log(`PR #${pullRequestNumber}: "${title}" hasBackportLabel=${hasBackportLabel}`)
+
+            return {
+              author: user.login,
+              pullRequestNumber,
+              title: data.title,
+              hasBackportLabel
+            }
+
+  get_latest_release_branch:
+    name: Get latest release branch
+    runs-on: ubuntu-latest
+    outputs:
+      branch_name: ${{ steps.get_branch_name.outputs.result }}
+    steps:
+      - uses: actions/github-script@v4
+        id: get_branch_name
+        with:
+          result-encoding: string
+          script: |
+            const releaseBranches = await github.git.listMatchingRefs({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: "heads/release-x.",
+            });
+
+            const getVersionFromBranch = branch => {
+              const match = branch.match(/release-x\.(.*?)\.x/);
+              return match && parseInt(match[1])
+            };
+            const latestReleaseBranch = releaseBranches.data
+              .filter(branch => getVersionFromBranch(branch.ref) !== null)
+              .reduce((prev, current) => getVersionFromBranch(prev.ref) > getVersionFromBranch(current.ref) ? prev : current);
+            const latestReleaseBranchName = latestReleaseBranch.ref.replace(/^refs\/heads\//, "");
+
+            console.log(`Latest release branch: ${latestReleaseBranchName}`)
+
+            return latestReleaseBranchName;
+
+  create_backport_pull_request:
+    runs-on: ubuntu-latest
+    name: Create a backport PR with the commit
+    needs: [pr_info, get_latest_release_branch]
+    if: ${{ needs.pr_info.outputs.should_backport == 'true' }}
+    env:
+      TARGET_BRANCH: ${{ needs.get_latest_release_branch.outputs.branch_name }}
+      ORIGINAL_PULL_REQUEST_NUMBER: ${{ needs.pr_info.outputs.number }}
+      ORIGINAL_TITLE: ${{ needs.pr_info.outputs.title }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+        name: Checkout
+        with:
+          fetch-depth: 0
+      - run: |
+          git config --global user.email "metabase-github-automation@metabase.com"
+          git config --global user.name "$GITHUB_ACTOR"
+
+          BACKPORT_BRANCH="backport-$GITHUB_SHA"
+
+          git fetch --all
+          git checkout -b "${BACKPORT_BRANCH}" origin/"${TARGET_BRANCH}"
+          git cherry-pick "${GITHUB_SHA}"
+          git push -u origin "${BACKPORT_BRANCH}"
+
+          hub pull-request -b "${TARGET_BRANCH}" -h "${BACKPORT_BRANCH}" -l "auto-backported" -a "${GITHUB_ACTOR}" -F- <<<"🤖 backported \"${ORIGINAL_TITLE}\"
+
+          #${ORIGINAL_PULL_REQUEST_NUMBER}"
+
+  notify_when_failed:
+    runs-on: ubuntu-latest
+    name: Notify about failure
+    needs: [pr_info, create_backport_pull_request]
+    if: ${{ failure() }}
+    steps:
+      - uses: actions/github-script@v4
+        with:
+          script: |
+            const { GITHUB_SERVER_URL, GITHUB_REPOSITORY, GITHUB_RUN_ID} = process.env;
+            const runUrl = `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}`
+
+            github.issues.createComment({
+              issue_number: ${{ needs.pr_info.outputs.number }},
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '@${{ needs.pr_info.outputs.author }} could not automatically create a backport PR 😩 [[Logs]](${runUrl})'
+            })


### PR DESCRIPTION
Return back the Github actions workflow that creates backports on merge labeled with `backport` PRs.
It is simple but limited due to the inability to specify a target branch when we have active two milestones because of an additional maintenance release. 

Added a document that describes both ways to create a backport
https://www.notion.so/metabase/Dev-workflow-automation-718eaca2c63d4620b4611cd51185f3cd