### PR TITLE
#17551 Repro: Dashboard date filter "Include today" does not work for relative "Next"

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/17551.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/17551.cy.spec.js
@@ -59,7 +59,7 @@ describe.skip("issue 17551", () => {
     });
   });
 
-  it("should include today (metabase#17551)", () => {
+  it("should include today in the 'All time' date filter when chosen 'Next' (metabase#17551)", () => {
     filterWidget().click();
     setAdHocFilter({ condition: "Next", includeCurrent: true });
 

--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/17551.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/17551.cy.spec.js
@@ -1,0 +1,71 @@
+import { restore, filterWidget } from "__support__/e2e/cypress";
+import { setAdHocFilter } from "../../native-filters/helpers/e2e-date-filter-helpers";
+
+describe.skip("issue 17551", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.createNativeQuestion({
+      native: {
+        query:
+          "select 'yesterday' as \"text\", dateadd('day', -1, current_date::date) as \"date\" union all\nselect 'today', current_date::date union all\nselect 'tomorrow', dateadd('day', 1, current_date::date)\n",
+      },
+    }).then(({ body: { id: baseQuestionId } }) => {
+      const questionDetails = {
+        name: "17551 QB",
+        query: { "source-table": `card__${baseQuestionId}` },
+      };
+
+      const filter = {
+        name: "Date Filter",
+        slug: "date_filter",
+        id: "888188ad",
+        type: "date/all-options",
+        sectionId: "date",
+      };
+
+      const dashboardDetails = { parameters: [filter] };
+
+      cy.createQuestionAndDashboard({
+        questionDetails,
+        dashboardDetails,
+      }).then(({ body: oldCard }) => {
+        const { card_id, dashboard_id } = oldCard;
+
+        const mapFilterToCard = {
+          parameter_mappings: [
+            {
+              parameter_id: filter.id,
+              card_id,
+              target: [
+                "dimension",
+                [
+                  "field",
+                  "date",
+                  {
+                    "base-type": "type/DateTime",
+                  },
+                ],
+              ],
+            },
+          ],
+        };
+
+        cy.editDashboardCard(oldCard, mapFilterToCard);
+
+        cy.visit(`/dashboard/${dashboard_id}`);
+      });
+    });
+  });
+
+  it("should include today (metabase#17551)", () => {
+    filterWidget().click();
+    setAdHocFilter({ condition: "Next", includeCurrent: true });
+
+    cy.url().should("include", "?date_filter=next30days~");
+
+    cy.findByText("tomorrow");
+    cy.findByText("today");
+  });
+});

--- a/frontend/test/metabase/scenarios/native-filters/helpers/e2e-date-filter-helpers.js
+++ b/frontend/test/metabase/scenarios/native-filters/helpers/e2e-date-filter-helpers.js
@@ -29,7 +29,12 @@ export function setRelativeDate(term) {
   cy.findByText(term).click();
 }
 
-export function setAdHocFilter({ condition, quantity, timeBucket } = {}) {
+export function setAdHocFilter({
+  condition,
+  quantity,
+  timeBucket,
+  includeCurrent = false,
+} = {}) {
   if (condition) {
     cy.get(".AdminSelect")
       .contains("Previous")
@@ -57,6 +62,8 @@ export function setAdHocFilter({ condition, quantity, timeBucket } = {}) {
       .contains(timeBucket)
       .click();
   }
+
+  includeCurrent && cy.findByText(/^Include/).click();
 
   cy.button("Update filter").click();
 }


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #17551

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/dashboard-filters/reproductions/17551.cy.spec.js`
- Unskip the test
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/130491826-a01d50a5-2a63-4d7b-a2e2-7f57d953bb9b.png)

