### PR TITLE
Avoid prop shorthand in the database/schema/table browser

### DIFF
--- a/frontend/src/metabase/browse/containers/DatabaseBrowser.jsx
+++ b/frontend/src/metabase/browse/containers/DatabaseBrowser.jsx
@@ -24,7 +24,7 @@ function DatabaseBrowser({ databases }) {
 
       <Grid>
         {databases.map(database => (
-          <GridItem w={ITEM_WIDTHS} key={database.id}>
+          <GridItem width={ITEM_WIDTHS} key={database.id}>
             <Link
               to={Urls.browseDatabase(database)}
               data-metabase-event={`${ANALYTICS_CONTEXT};Database Click`}

--- a/frontend/src/metabase/browse/containers/SchemaBrowser.jsx
+++ b/frontend/src/metabase/browse/containers/SchemaBrowser.jsx
@@ -47,7 +47,7 @@ function SchemaBrowser(props) {
           ) : (
             <Grid>
               {schemas.map(schema => (
-                <GridItem w={ITEM_WIDTHS} key={schema.id}>
+                <GridItem width={ITEM_WIDTHS} key={schema.id}>
                   <Link
                     to={`/browse/${dbId}/schema/${schema.name}`}
                     mb={1}

--- a/frontend/src/metabase/browse/containers/TableBrowser.jsx
+++ b/frontend/src/metabase/browse/containers/TableBrowser.jsx
@@ -82,7 +82,7 @@ function TableBrowser(props) {
             // NOTE: don't clean since we might not have all the metadata loaded?
             metadataTable.newQuestion().getUrl({ clean: false });
           return (
-            <GridItem w={ITEM_WIDTHS} key={table.id}>
+            <GridItem width={ITEM_WIDTHS} key={table.id}>
               <Card hoverable px={1} className="hover-parent hover--visibility">
                 <Link
                   to={link}


### PR DESCRIPTION
Go to `/browse/1` (or `/browse`) and pay attention to the items in the grid:

![image](https://user-images.githubusercontent.com/7288/130500830-fc38cba5-85b5-40ba-97fe-ff528d0abc86.png)

![image](https://user-images.githubusercontent.com/7288/130500452-4467b72f-6218-4dd8-9b00-a5142c55230f.png)

Before and after this change, it should look **exactly** the same.