### PR TITLE
Refactor `cy.editDashbardCard` Cypress custom command

### DIFF
--- a/frontend/test/__support__/e2e/commands/api/dashboardCard.js
+++ b/frontend/test/__support__/e2e/commands/api/dashboardCard.js
@@ -1,17 +1,20 @@
 import _ from "underscore";
 
-Cypress.Commands.add("editDashboardCard", (oldCard, newCard) => {
-  const { id, dashboard_id } = oldCard;
+Cypress.Commands.add(
+  "editDashboardCard",
+  (dashboardCard, updatedProperties) => {
+    const { id, dashboard_id } = dashboardCard;
 
-  const cleanOldCard = sanitizeCard(oldCard);
+    const cleanCard = sanitizeCard(dashboardCard);
 
-  const updatedCard = Object.assign({}, cleanOldCard, newCard);
+    const updatedCard = Object.assign({}, cleanCard, updatedProperties);
 
-  cy.log(`Edit dashboard card ${id}`);
-  cy.request("PUT", `/api/dashboard/${dashboard_id}/cards`, {
-    cards: [updatedCard],
-  });
-});
+    cy.log(`Edit dashboard card ${id}`);
+    cy.request("PUT", `/api/dashboard/${dashboard_id}/cards`, {
+      cards: [updatedCard],
+    });
+  },
+);
 
 /**
  * Remove `created_at` and `updated_at` fields from the dashboard card that was previously added to the dashboard.

--- a/frontend/test/metabase-visual/dashboard/parameters-widget.cy.spec.js
+++ b/frontend/test/metabase-visual/dashboard/parameters-widget.cy.spec.js
@@ -22,8 +22,8 @@ describe("visual tests > dashboard > parameters widget", () => {
     cy.signInAsAdmin();
 
     cy.createQuestionAndDashboard({ questionDetails }).then(
-      ({ body: oldCard }) => {
-        const { dashboard_id } = oldCard;
+      ({ body: card }) => {
+        const { dashboard_id } = card;
 
         cy.request("PUT", `/api/dashboard/${dashboard_id}`, {
           parameters: filters,
@@ -34,7 +34,7 @@ describe("visual tests > dashboard > parameters widget", () => {
           sizeY: 32,
         };
 
-        cy.editDashboardCard(oldCard, updatedSize);
+        cy.editDashboardCard(card, updatedSize);
 
         cy.visit(`/dashboard/${dashboard_id}`);
       },

--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/17551.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/17551.cy.spec.js
@@ -30,8 +30,8 @@ describe.skip("issue 17551", () => {
       cy.createQuestionAndDashboard({
         questionDetails,
         dashboardDetails,
-      }).then(({ body: oldCard }) => {
-        const { card_id, dashboard_id } = oldCard;
+      }).then(({ body: card }) => {
+        const { card_id, dashboard_id } = card;
 
         const mapFilterToCard = {
           parameter_mappings: [
@@ -52,7 +52,7 @@ describe.skip("issue 17551", () => {
           ],
         };
 
-        cy.editDashboardCard(oldCard, mapFilterToCard);
+        cy.editDashboardCard(card, mapFilterToCard);
 
         cy.visit(`/dashboard/${dashboard_id}`);
       });

--- a/frontend/test/metabase/scenarios/question/reproductions/17514-ui-overlay.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/17514-ui-overlay.cy.spec.js
@@ -50,8 +50,8 @@ describe.skip("issue 17514", () => {
   describe("scenario 1", () => {
     beforeEach(() => {
       cy.createQuestionAndDashboard({ questionDetails, dashboardDetails }).then(
-        ({ body: oldCard }) => {
-          const { card_id, dashboard_id } = oldCard;
+        ({ body: card }) => {
+          const { card_id, dashboard_id } = card;
 
           cy.intercept("POST", `/api/card/${card_id}/query`).as("cardQuery");
 
@@ -65,7 +65,7 @@ describe.skip("issue 17514", () => {
             ],
           };
 
-          cy.editDashboardCard(oldCard, mapFilterToCard);
+          cy.editDashboardCard(card, mapFilterToCard);
 
           cy.visit(`/dashboard/${dashboard_id}`);
 


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Slightly changes/updates parameter names for this custom command to make them less confusing

@flamber reported the term `oldCard` threw him off and made the review process more difficult. A simple `dashboardCard` or even a `card` itself is a better choice.

Also, we rarely ever pass completely new card as the second argument. Most of the time it's just one updated property/key. Accounted for that as well.

Hope that this makes more sense now?