### PR TITLE
#17524 Reproductions: Visualization type is not always respected, when filters are applied

### DIFF
--- a/frontend/test/metabase/scenarios/visualizations/reproductions/17524.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/reproductions/17524.cy.spec.js
@@ -1,0 +1,86 @@
+import { restore, filterWidget } from "__support__/e2e/cypress";
+import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
+
+const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATASET;
+
+const nativeQuestionDetails = {
+  native: {
+    query:
+      "select * from (\nselect 'A' step, 41 users, 42 median union all\nselect 'B' step, 31 users, 32 median union all\nselect 'C' step, 21 users, 22 median union all\nselect 'D' step, 11 users, 12 median\n) x\n[[where users>{{num}}]]\n",
+    "template-tags": {
+      num: {
+        id: "d7f1fb15-c7b8-6051-443d-604b6ed5457b",
+        name: "num",
+        "display-name": "Num",
+        type: "number",
+        default: null,
+      },
+    },
+  },
+  display: "funnel",
+  visualization_settings: {
+    "funnel.dimension": "STEP",
+    "funnel.metric": "USERS",
+  },
+};
+
+const questionDetails = {
+  query: {
+    "source-table": PRODUCTS_ID,
+    aggregation: [["count"], ["sum", ["field", PRODUCTS.PRICE, null]]],
+    breakout: [["field", PRODUCTS.CATEGORY, null]],
+  },
+  display: "funnel",
+  visualization_settings: {
+    "funnel.metric": "count",
+    "funnel.dimension": "CATEGORY",
+  },
+};
+
+describe.skip("issue 17524", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  describe("scenario 1", () => {
+    beforeEach(() => {
+      cy.createNativeQuestion(nativeQuestionDetails, { visitQuestion: true });
+    });
+
+    it("should not alter visualization type when applying filter on a native question (metabase#17524-1)", () => {
+      filterWidget().type("1");
+
+      cy.get("polygon");
+
+      cy.icon("play")
+        .last()
+        .click();
+
+      cy.get("polygon");
+      cy.findByText("Save").should("not.exist");
+    });
+  });
+
+  describe("scenario 2", () => {
+    beforeEach(() => {
+      cy.createQuestion(questionDetails, { visitQuestion: true });
+    });
+
+    it("should not alter visualization type when applying filter on a QB question (metabase#17524-2)", () => {
+      cy.get("polygon");
+
+      cy.findAllByRole("button")
+        .contains("Filter")
+        .click();
+      cy.findByText("ID").click();
+      cy.findByText("Is").click();
+      cy.findByText("Greater than").click();
+
+      cy.findByPlaceholderText("Enter an ID").type("1");
+      cy.button("Add filter").click();
+
+      cy.get("polygon");
+    });
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #17524 (both scenarios)

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/visualizations/reproductions/17524.cy.spec.js`
- Unskip tests
- Both tests should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part
- Make sure both tests are passing and
- Merge spec together with the fix

### Screenshots:

Scenario 1 (native)
![image](https://user-images.githubusercontent.com/31325167/130526088-c3cb3441-e6fa-48e9-ad9c-ea9aff409a9d.png)

Scenario 2 (qb)
![image](https://user-images.githubusercontent.com/31325167/130526137-e7be9660-fd83-415a-9d9b-d52697e334ec.png)
