### PR TITLE
Avoid prop shorthand in the login page

### DIFF
--- a/frontend/src/metabase/auth/components/AuthLayout.jsx
+++ b/frontend/src/metabase/auth/components/AuthLayout.jsx
@@ -17,7 +17,7 @@ const AuthLayout = ({ children }) => (
   >
     <Flex mt={-4} flexDirection="column">
       <LogoIcon height={65} />
-      <Card p={3} mt={3} className="relative z2" w={420}>
+      <Card p={3} mt={3} className="relative z2" width={420}>
         {children}
       </Card>
     </Flex>


### PR DESCRIPTION
Go to `/auth/login` and pay attention to main card:

![image](https://user-images.githubusercontent.com/7288/130531345-c064ba3a-5065-40a6-9f9f-f8565a7a6aa4.png)

Before and after this change, it should look **exactly** the same.