### PR TITLE
sqlite: update sqlite-jdbc to 3.36.0.1 and improve date/time handling

### DIFF
--- a/modules/drivers/sqlite/deps.edn
+++ b/modules/drivers/sqlite/deps.edn
@@ -2,4 +2,4 @@
  ["src" "resources"]
 
  :deps
- {org.xerial/sqlite-jdbc {:mvn/version "3.25.2"}}}
+ {org.xerial/sqlite-jdbc {:mvn/version "3.36.0.1"}}}

--- a/modules/drivers/sqlite/src/metabase/driver/sqlite.clj
+++ b/modules/drivers/sqlite/src/metabase/driver/sqlite.clj
@@ -387,12 +387,12 @@
 (defn- sqlite-handle-timestamp
   [^ResultSet rs ^Integer i]
   (let [obj (.getObject rs i)]
-    (if (instance? String obj)
+    (cond
       ;; For strings, use our own parser which is more flexible than sqlite-jdbc's and handles timezones correctly
-      (u.date/parse obj)
+      (instance? String obj) (u.date/parse obj)
       ;; For other types, fallback to sqlite-jdbc's parser
       ;; Even in DATE column, it is possible to put DATETIME, so always treat as DATETIME
-      (t/local-date-time (.getTimestamp rs i)))))
+      (some? obj) (t/local-date-time (.getTimestamp rs i)))))
 
 (defmethod sql-jdbc.execute/read-column-thunk [:sqlite Types/DATE]
   [_ ^ResultSet rs _ ^Integer i]

--- a/modules/drivers/sqlite/src/metabase/driver/sqlite.clj
+++ b/modules/drivers/sqlite/src/metabase/driver/sqlite.clj
@@ -376,14 +376,30 @@
         (.close stmt)
         (throw e)))))
 
-;; (.getObject rs i LocalDate) doesn't seem to work, nor does `(.getDate)`; and it seems to be the case that
-;; timestamps come back as `Types/DATE` as well? Fetch them as a String and then parse them
+;; SQLite has no intrinsic date/time type. The sqlite-jdbc driver provides the following de-facto mappings:
+;;    DATE or DATETIME => Types/DATE (only if type is int or string)
+;;    TIMESTAMP => Types/TIMESTAMP (only if type is int)
+;; The data itself can be stored either as
+;;    1) integer (unix epoch) - this is "point in time", so no confusion about timezone
+;;    2) float (julian days) - this is "point in time", so no confusion about timezone
+;;    3) string (ISO8601) - zoned or unzoned depending on content, sqlite-jdbc always treat it as local time
+;; Note that it is possible to store other invalid data in the column as SQLite does not perform any validation.
+(defn- sqlite-handle-timestamp
+  [^ResultSet rs ^Integer i]
+  (let [obj (.getObject rs i)]
+    (if (instance? String obj)
+      ;; For strings, use our own parser which is more flexible than sqlite-jdbc's and handles timezones correctly
+      (u.date/parse obj)
+      ;; For other types, fallback to sqlite-jdbc's parser
+      ;; Even in DATE column, it is possible to put DATETIME, so always treat as DATETIME
+      (t/local-date-time (.getTimestamp rs i)))))
+
 (defmethod sql-jdbc.execute/read-column-thunk [:sqlite Types/DATE]
   [_ ^ResultSet rs _ ^Integer i]
   (fn []
-    (try
-      (when-let [t (.getDate rs i)]
-        (t/local-date t))
-      (catch Throwable _
-        (when-let [s (.getString rs i)]
-          (u.date/parse s))))))
+    (sqlite-handle-timestamp rs i)))
+
+(defmethod sql-jdbc.execute/read-column-thunk [:sqlite Types/TIMESTAMP]
+  [_ ^ResultSet rs _ ^Integer i]
+  (fn []
+    (sqlite-handle-timestamp rs i)))

--- a/modules/drivers/sqlite/test/metabase/driver/sqlite_test.clj
+++ b/modules/drivers/sqlite/test/metabase/driver/sqlite_test.clj
@@ -158,7 +158,8 @@
                       ('epoch',           1629865104000,             1629849600000, 1629865104000),
                       ('iso8601-ms',      '2021-08-25 04:18:24.111', null,          '2021-08-25 04:18:24.111'),
                       ('iso8601-no-ms',   '2021-08-25 04:18:24',     null,          '2021-08-25 04:18:24'),
-                      ('iso8601-no-time', null,                      '2021-08-25',  null);"]]
+                      ('iso8601-no-time', null,                      '2021-08-25',  null),
+                      ('null',            null,                      null,          null);"]]
         (jdbc/execute! (sql-jdbc.conn/connection-details->spec :sqlite details)
                        [stmt]))
       (mt/with-temp Database [db {:engine :sqlite :details (assoc details :dbname db-name)}]
@@ -195,4 +196,10 @@
                    (qp.test/rows
                      (mt/run-mbql-query :datetime_table
                                         {:fields [$col_date]
-                                         :filter [:= $test_case "iso8601-no-time"]}))))))))))
+                                         :filter [:= $test_case "iso8601-no-time"]})))))
+          (testing "select NULL"
+            (is (= [[nil nil nil]]
+                   (qp.test/rows
+                     (mt/run-mbql-query :datetime_table
+                                        {:fields [$col_timestamp $col_date $col_datetime]
+                                         :filter [:= $test_case "null"]}))))))))))


### PR DESCRIPTION
The new version includes arm64 binaries and allows Cypress, which uses SQLite, to run on Apple Silicon.

Without this, you'd get this following error:
```
java.lang.Exception: No native library is found for os.name=Mac and os.arch=aarch64. path=/org/sqlite/native/Mac/aarch64
```

Not sure if there's any concerns with updating or not.

Also improved date/time handling as documented at https://github.com/metabase/metabase/pull/17567#issuecomment-905218824
