### PR TITLE
Update dev guide with info on deprecated Debugger for Chrome

### DIFF
--- a/docs/developers-guide-vscode.md
+++ b/docs/developers-guide-vscode.md
@@ -2,9 +2,10 @@
 
 ## Debugging
 
-First, install the following extensions:
+First, install the following extension:
 * [Debugger for Firefox](https://marketplace.visualstudio.com/items?itemName=firefox-devtools.vscode-firefox-debug)
-* [Debugger for Chrome](https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-chrome)
+
+_Note_: [Debugger for Chrome has been deprecated]. You can safely delete it as Visual Studio Code now has [a bundled JavaScript Debugger](https://github.com/microsoft/vscode-js-debug) that covers the same functionality.
 
 Before starting the debugging session, make sure that Metabase is built and running. Choose menu _View_, _Command Palette_, search for and choose _Tasks: Run Build Task_. Alternatively, use the corresponding shortcut `Ctrl+Shift+B`. The built-in terminal will appear to show the progress, wait a few moment until webpack indicates a complete (100%) bundling.
 


### PR DESCRIPTION
Was searching for ways to optimize VSCode performance and ran into this: https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-chrome.

> This extension has been deprecated as Visual Studio Code now has [a bundled JavaScript Debugger](https://github.com/microsoft/vscode-js-debug) that covers the same functionality. It is a debugger that debugs Node.js, Chrome, Edge, WebView2, VS Code extensions, and more. You can safely un-install this extension and you will still be able to have the functionality you need.