### PR TITLE
Revert Mongo QA Docker image update back to the version 4.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,12 +195,11 @@ executors:
     # OOM all the time with the default medium size.
     resource_class: large
 
-
-  fe-mongo-5:
+  fe-mongo-4:
     working_directory: /home/circleci/metabase/metabase/
     docker:
       - image: metabase/ci:circleci-java-11-clj-1.10.3.929-07-27-2021-node-browsers
-      - image: metabase/qa-databases:mongo-sample-5.0
+      - image: metabase/qa-databases:mongo-sample-4.0
 
   fe-postgres-12:
     working_directory: /home/circleci/metabase/metabase/
@@ -1266,10 +1265,10 @@ workflows:
           source-folder: << matrix.folder >>
 
       - fe-tests-cypress:
-          name: e2e-tests-mongo-5-<< matrix.edition >>
+          name: e2e-tests-mongo-4-<< matrix.edition >>
           requires:
             - build-uberjar-<< matrix.edition >>
-          e: fe-mongo-5
+          e: fe-mongo-4
           cypress-group: "mongo"
           source-folder: mongo
           qa-db: true

--- a/frontend/test/metabase-db/mongo/query.cy.spec.js
+++ b/frontend/test/metabase-db/mongo/query.cy.spec.js
@@ -104,5 +104,5 @@ function writeNativeMongoQuery() {
     parseSpecialCharSequences: false,
   });
   cy.get(".NativeQueryEditor .Icon-play").click();
-  cy.findByText("42");
+  cy.findByText("18,760");
 }


### PR DESCRIPTION
https://github.com/metabase/metabase/pull/17117 broke `master` for everyone.
2 mongo E2E tests are consistently failing in the CI due to [this change](https://github.com/metabase/metabase/pull/17117/commits/69998854b2801b132b7d98e11fc42af585b2ffb5).

Examples of those failures:
https://app.circleci.com/pipelines/github/metabase/metabase/20599/workflows/c435d81e-c40b-4920-9237-e55d71ff97dd/jobs/869136/artifacts

This PR reverts QA mongo image update for E2E tests and reverts the assertion change in an attempt to unblock `master` branch.

EoL date for mongo 4.0 is [April 2022](https://www.mongodb.com/support-policy/lifecycles), which means we should still support it. Adding new mongo version is ok, but it should've been done:
1. in a separate PR
2. in such a way that it preserves both versions

**NOTE**
I left CircleCi's mongo 5 image for backend tests, for now. Let's deal with that in a separate PR. We've already had a template for multiple DB versions. Just take a look at postgres and mysql.