### PR TITLE
Keep mongo 4.0 for backend tests until its end of life

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,13 @@ executors:
           # MYSQL_USER: root
           # MYSQL_ALLOW_EMPTY_PASSWORD: yes
 
-  mongo:
+  mongo-4-0:
+     working_directory: /home/circleci/metabase/metabase/
+     docker:
+       - image: metabase/ci:circleci-java-11-clj-1.10.3.929-07-27-2021-node-browsers
+       - image: circleci/mongo:4.0
+
+  mongo-latest:
      working_directory: /home/circleci/metabase/metabase/
      docker:
        - image: metabase/ci:circleci-java-11-clj-1.10.3.929-07-27-2021-node-browsers

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,7 +132,7 @@ executors:
      working_directory: /home/circleci/metabase/metabase/
      docker:
        - image: metabase/ci:circleci-java-11-clj-1.10.3.929-07-27-2021-node-browsers
-       - image: circleci/mongo:5.0
+       - image: circleci/mongo:latest
 
   presto-186:
     working_directory: /home/circleci/metabase/metabase/
@@ -1060,7 +1060,7 @@ workflows:
           driver: mongo
 
       - test-driver:
-          name: be-tests-mongo-ee
+          name: be-tests-mongo-latest-ee
           description: "(Mongo latest)"
           requires:
             - be-tests-ee

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1053,9 +1053,18 @@ workflows:
 
       - test-driver:
           name: be-tests-mongo-ee
+          description: "(Mongo 4.0)"
           requires:
             - be-tests-ee
-          e: mongo
+          e: mongo-4-0
+          driver: mongo
+
+      - test-driver:
+          name: be-tests-mongo-ee
+          description: "(Mongo latest)"
+          requires:
+            - be-tests-ee
+          e: mongo-latest
           driver: mongo
 
       - test-driver:


### PR DESCRIPTION
This is the follow-up fix/update for the https://github.com/metabase/metabase/pull/17117 and https://github.com/metabase/metabase/pull/17574.

If we're going to introduce mongo 5.0, we should still keep testing the old version 4.0 until its end of life ([April 2022](https://www.mongodb.com/support-policy/lifecycles)).

This PR follows the same pattern we're using for postgres and mysql.
1. early version
2. latest version