### PR TITLE
#17512 Repro: Custom Expression case is using wrong field reference when nested query

### DIFF
--- a/frontend/test/metabase/scenarios/question/reproductions/17512.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/17512.cy.spec.js
@@ -1,0 +1,59 @@
+import { restore, openOrdersTable, popover } from "__support__/e2e/cypress";
+
+describe.skip("issue 17512", () => {
+  beforeEach(() => {
+    cy.intercept("POST", "/api/dataset").as("dataset");
+
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("custom expression should work with `case` in nested queries (metabase#17512)", () => {
+    openOrdersTable({ mode: "notebook" });
+
+    addSummarizeCustomExpression(
+      "Distinct(case([Discount] > 0, [Subtotal], [Total]))",
+      "CE",
+    );
+
+    cy.findByText("Pick a column to group by").click();
+    cy.findByText("Created At").click();
+
+    addCustomColumn("1 + 1", "CC");
+
+    cy.button("Visualize").click();
+
+    cy.wait("@dataset").then(({ response }) => {
+      expect(response.body.error).not.to.exist;
+    });
+
+    cy.findByText("CE");
+    cy.findByText("CC");
+  });
+});
+
+function addSummarizeCustomExpression(formula, name) {
+  cy.findByText("Summarize").click();
+  popover()
+    .contains("Custom Expression")
+    .click();
+
+  popover().within(() => {
+    cy.get("[contenteditable='true']")
+      .type(formula)
+      .blur();
+    cy.findByPlaceholderText("Name (required)").type(name);
+    cy.button("Done").click();
+  });
+}
+
+function addCustomColumn(formula, name) {
+  cy.findByText("Custom column").click();
+  popover().within(() => {
+    cy.get("[contenteditable='true']")
+      .type(formula)
+      .blur();
+    cy.findByPlaceholderText("Something nice and descriptive").type(name);
+    cy.button("Done").click();
+  });
+}


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #17512 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/question/reproductions/17512.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/130632463-ab55b585-a8ee-4f0d-bd11-acaa954f3851.png)

