### PR TITLE
Fix references to the possessive form of 'its'

### DIFF
--- a/frontend/src/metabase/admin/permissions/pages/CollectionPermissionsPage/CollectionPermissionsPage.jsx
+++ b/frontend/src/metabase/admin/permissions/pages/CollectionPermissionsPage/CollectionPermissionsPage.jsx
@@ -111,7 +111,7 @@ function CollectionsPermissionsPage({
       {!permissionEditor && (
         <PermissionsEditorEmptyState
           icon="all"
-          message={t`Select a collection to see it's permissions`}
+          message={t`Select a collection to see its permissions`}
         />
       )}
 

--- a/frontend/src/metabase/admin/permissions/pages/GroupDataPermissionsPage/GroupsPermissionsPage.jsx
+++ b/frontend/src/metabase/admin/permissions/pages/GroupDataPermissionsPage/GroupsPermissionsPage.jsx
@@ -126,7 +126,7 @@ function GroupsPermissionsPage({
       {!permissionEditor && (
         <PermissionsEditorEmptyState
           icon="group"
-          message={t`Select a group to see it's data permissions`}
+          message={t`Select a group to see its data permissions`}
         />
       )}
 

--- a/frontend/test/metabase/scenarios/admin/permissions/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/permissions/permissions.cy.spec.js
@@ -235,7 +235,7 @@ describeWithoutToken("scenarios > admin > permissions", () => {
         cy.visit("/admin/permissions");
 
         // no groups selected initially and it shows an empty state
-        cy.findByText("Select a group to see it's data permissions");
+        cy.findByText("Select a group to see its data permissions");
 
         const groups = [
           "Administrators",


### PR DESCRIPTION
Noticed a copy error with the wrong possessive form for `it`.
This PR fixes that in the source code and updates the related e2e test.