### PR TITLE
Fix run overlay not going away on GUI questions

### DIFF
--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -1133,16 +1133,23 @@ export const queryCompleted = (question, queryResults) => {
     const dirty =
       !originalQuestion ||
       (originalQuestion && question.isDirtyComparedTo(originalQuestion));
+
     if (dirty) {
+      if (question.isNative()) {
+        question = question.syncColumnsAndSettings(
+          originalQuestion,
+          queryResults[0],
+        );
+      }
       // Only update the display if the question is new or has been changed.
       // Otherwise, trust that the question was saved with the correct display.
       question = question
         // if we are going to trigger autoselection logic, check if the locked display no longer is "sensible".
-        .syncColumnsAndSettings(originalQuestion, queryResults[0])
         .maybeUnlockDisplay(getSensibleDisplays(data))
         .setDefaultDisplay()
         .switchTableScalar(data);
     }
+
     dispatch.action(QUERY_COMPLETED, { card: question.card(), queryResults });
   };
 };

--- a/frontend/test/metabase/scenarios/question/reproductions/17514-ui-overlay.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/17514-ui-overlay.cy.spec.js
@@ -41,7 +41,7 @@ const filter = {
 
 const dashboardDetails = { parameters: [filter] };
 
-describe.skip("issue 17514", () => {
+describe("issue 17514", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();


### PR DESCRIPTION
Fixes #17514 — a regression since #16761. In #16761 we added a `question.syncColumnsAndSettings` call for questions to address #15393 and #7612. It fixed the behavior for native questions but caused some side effects for GUI ones.

Fixed by making sure `question.syncColumnsAndSettings` on query complete is called only for native questions

### To Verify

Follow the steps from #17514

### Demo

**Before**

The 'run overlay' is visible and doesn't hide no matter what you do

![130088434-cf9c46ef-6e8c-494e-831f-22f6864249fa](https://user-images.githubusercontent.com/17258145/130803088-47a268e7-70e1-45f5-8be9-fb943cc844b3.png)

**After**

https://user-images.githubusercontent.com/17258145/130805207-2379c411-9beb-40a4-ab7f-0148bdb9e774.mov

