### PR TITLE
fix permissions editor missing scroll

### DIFF
--- a/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditor.styled.js
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditor.styled.js
@@ -2,4 +2,5 @@ import styled from "styled-components";
 
 export const PermissionsEditorRoot = styled.div`
   flex-grow: 1;
+  overflow: auto;
 `;


### PR DESCRIPTION
### Description

Introduced while addressing review comments [here](https://github.com/metabase/metabase/pull/17328) and later missed because of a small dataset on my local instance.

<img width="1440" alt="Screen Shot 2021-08-25 at 20 40 24" src="https://user-images.githubusercontent.com/14301985/130839130-99b22225-102f-4a34-bfa0-ea68ed01c37d.png">

### How to verify
Open permissions pages and ensure that the container has scroll
