### PR TITLE
Correct the instruction to run E2E tests

### DIFF
--- a/docs/developers-e2e-tests.md
+++ b/docs/developers-e2e-tests.md
@@ -13,10 +13,10 @@ To run all Cypress tests programmatically in the terminal:
 yarn run test-cypress-no-build
 ```
 
-You can run a specific set of scenarios by using the `--folder` flag.
+You can run a specific set of scenarios by using the `--folder` flag, which will pick up the chosen scenarios under `frontend/test/metabase/scenarios/`.
 
 ```
-yarn run test-cypress-no-build --folder frontend/test/metabase/scenarios/auth/
+yarn run test-cypress-no-build --folder sharing
 ```
 
 You can quickly test a single file only by using the `--spec` flag.


### PR DESCRIPTION
**Before this PR**

Follow the instruction/example and get the following error instead:

```
Can't run because no spec files were found.
We searched for any files matching this glob pattern:

frontend/test/metabase/scenarios/frontend/test/metabase/scenarios/auth/**/*.cy.spec.js
```

**After this PR**

Follow the instruction/example and some tests are running.