### PR TITLE
Example snippet should not use prop shorthand

### DIFF
--- a/frontend/src/metabase/components/Position.info.js
+++ b/frontend/src/metabase/components/Position.info.js
@@ -12,7 +12,7 @@ Any props that work on Box and Flex work here.
 export const examples = {
   Relative: <Relative>Some content relative to its parent</Relative>,
   Absolute: (
-    <Relative p={4} w="100%">
+    <Relative p={4} width="100%">
       Some content
       <Absolute bg="red" p={1} top={0} right={0}>
         Some content positioned absolutely to its parent


### PR DESCRIPTION
How to verify: go to `/_internal/components/position` and check the snippet.

**Before**

![image](https://user-images.githubusercontent.com/7288/130867429-91ad5a54-a6f5-4460-a011-426b894dc3d8.png)

**After**

![image](https://user-images.githubusercontent.com/7288/130867473-d78acf34-667b-4667-bb10-fc2a648838c6.png)
