### PR TITLE
Support building and hacking on third-party drivers with our new Clojure CLI setup

### DIFF
--- a/bin/build-drivers/src/build_drivers/build_driver.clj
+++ b/bin/build-drivers/src/build_drivers/build_driver.clj
@@ -14,7 +14,7 @@
 (defn build-driver!
   ;; 1-arity that takes just a map is mean for use directly with clojure -X
   ([{:keys [driver edition], :as options}]
-   (build-driver! driver edition (dissoc options [:driver :edition])))
+   (build-driver! driver edition (dissoc options :driver :edition)))
 
   ([driver edition]
    (build-driver! driver edition nil))

--- a/bin/build-drivers/src/build_drivers/common.clj
+++ b/bin/build-drivers/src/build_drivers/common.clj
@@ -2,23 +2,29 @@
   (:require [clojure.tools.deps.alpha :as deps]
             [metabuild-common.core :as u]))
 
+(def ^:dynamic *driver-project-dir* nil)
+
+(def ^:dynamic *target-directory* nil)
+
 (defn driver-project-dir
   "e.g. \"/home/cam/metabase/modules/drivers/redshift\""
   ^String [driver]
-  (u/filename u/project-root-directory "modules" "drivers" (name driver)))
+  (or *driver-project-dir*
+      (u/filename u/project-root-directory "modules" "drivers" (name driver))))
 
 (defn driver-jar-name
   "e.g. \"redshift.metabase-driver.jar\""
   ^String [driver]
   (format "%s.metabase-driver.jar" (name driver)))
 
-(def ^String driver-jar-destination-directory
-  (u/filename u/project-root-directory "resources" "modules"))
+(defn driver-jar-destination-directory ^String []
+  (or *target-directory*
+      (u/filename u/project-root-directory "resources" "modules")))
 
 (defn driver-jar-destination-path
   "e.g. \"/home/cam/metabase/resources/modules/redshift.metabase-driver.jar\""
   ^String [driver]
-  (u/filename driver-jar-destination-directory (driver-jar-name driver)))
+  (u/filename (driver-jar-destination-directory) (driver-jar-name driver)))
 
 (defn compiled-source-target-dir [driver]
   (u/filename (driver-project-dir driver) "target" "jar"))

--- a/bin/build-drivers/src/build_drivers/create_uberjar.clj
+++ b/bin/build-drivers/src/build_drivers/create_uberjar.clj
@@ -1,7 +1,6 @@
 (ns build-drivers.create-uberjar
   (:require [build-drivers.common :as c]
             [clojure.java.io :as io]
-            [clojure.tools.build.api :as build]
             [clojure.tools.deps.alpha :as deps]
             [clojure.tools.deps.alpha.util.dir :as deps.dir]
             [colorize.core :as colorize]

--- a/bin/common/src/metabuild_common/files.clj
+++ b/bin/common/src/metabuild_common/files.clj
@@ -105,7 +105,8 @@
       getParentFile   ; /home/cam/metabase/bin/common/src/
       getParentFile   ; /home/cam/metabase/bin/common/
       getParentFile   ; /home/cam/metabase/bin/
-      getParentFile)) ; /home/cam/metabase/
+      getParentFile   ; /home/cam/metabase/
+      getCanonicalPath))
 
 (defn download-file!
   "Download a file from `url` to `dest-path` using `wget`."

--- a/resources/log4j2.xml
+++ b/resources/log4j2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration>
   <Appenders>
-    <Console name="STDOUT" target="SYSTEM_OUT">
+    <Console name="STDOUT" target="SYSTEM_OUT" follow="true">
       <PatternLayout pattern="%date %level %logger{2} :: %message%n%throwable">
         <replace regex=":basic-auth \\[.*\\]" replacement=":basic-auth [redacted]"/>
       </PatternLayout>


### PR DESCRIPTION
Tweak the build-driver scripts to support running with `-X` and for building 3rd-party drivers in other directories.

Tweak the dev local-plugin-manifest loading code to let you specify additional plugin manifest files to load on launch to support hacking on 3rd party drivers.

https://github.com/metabase/sudoku-driver/pull/3

is a proof of concept using the new tweaks. See updated `README` in that file for examples of using the new tooling. By creating a `deps.edn` alias you can build the sudoku driver with `clojure -X:build`.

You can also build drivers without any special config like this:

```sh
clojure \
  -Sdeps '{:deps {metabase/sudoku-driver {:local/root "/home/cam/sudoku-driver"}
                  metabase/build-drivers {:local/root "bin/build-drivers"}}}' \
  -X 'build-drivers.build-driver/build-driver!' \
  :driver      :sudoku \
  :project-dir '"/home/cam/sudoku-driver"' \
  :target-dir  '"/home/cam/sudoku-driver/target"'
```

Hack on them locally:

```sh
clojure \
  -Sdeps '{:deps {metabase/sudoku-driver {:local/root "/home/cam/sudoku-driver"}}}' \
  -J-Dmb.dev.additional.driver.manifest.paths=/home/cam/sudoku-driver/resources/metabase-plugin.yaml \
  -M:dev:nrepl
```