### PR TITLE
[Dashboard filters coverage] Add initial set of tests for dashboard SQL ID filters

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-sql-id.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-sql-id.cy.spec.js
@@ -1,0 +1,127 @@
+import {
+  restore,
+  popover,
+  mockSessionProperty,
+  filterWidget,
+  editDashboard,
+  saveDashboard,
+  setFilter,
+} from "__support__/e2e/cypress";
+
+import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
+
+import { addWidgetStringFilter } from "../native-filters/helpers/e2e-field-filter-helpers";
+
+const { ORDERS } = SAMPLE_DATASET;
+
+describe("scenarios > dashboard > filters > SQL > ID", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    mockSessionProperty("field-filter-operators-enabled?", true);
+  });
+
+  describe("should work for the primary key", () => {
+    beforeEach(() => {
+      prepareDashboardWithFilterConnectedTo(ORDERS.ID);
+    });
+
+    it("when set through the filter widget", () => {
+      saveDashboard();
+
+      filterWidget().click();
+      addWidgetStringFilter("15");
+
+      cy.get(".Card").within(() => {
+        cy.findByText("114.42");
+      });
+    });
+
+    it("when set as the default filter", () => {
+      cy.findByText("Default value")
+        .next()
+        .click();
+      addWidgetStringFilter("15");
+
+      saveDashboard();
+
+      cy.get(".Card").within(() => {
+        cy.findByText("114.42");
+      });
+    });
+  });
+
+  describe("should work for the foreign key", () => {
+    beforeEach(() => {
+      prepareDashboardWithFilterConnectedTo(ORDERS.USER_ID);
+    });
+
+    it("when set through the filter widget", () => {
+      saveDashboard();
+
+      filterWidget().click();
+      addWidgetStringFilter("4");
+
+      cy.get(".Card").within(() => {
+        cy.findByText("47.68");
+      });
+    });
+
+    it("when set as the default filter", () => {
+      cy.findByText("Default value")
+        .next()
+        .click();
+      addWidgetStringFilter("4");
+
+      saveDashboard();
+
+      cy.get(".Card").within(() => {
+        cy.findByText("47.68");
+      });
+    });
+  });
+});
+
+function prepareDashboardWithFilterConnectedTo(rowId) {
+  const questionDetails = {
+    name: "SQL with ID filter",
+    native: {
+      query: "select * from ORDERS where {{filter}}",
+      "template-tags": {
+        filter: {
+          id: "3ff86eea-2559-5ab7-af10-e532a54661c5",
+          name: "filter",
+          "display-name": "Filter",
+          type: "dimension",
+          dimension: ["field", rowId, null],
+          "widget-type": "id",
+          default: null,
+        },
+      },
+    },
+  };
+
+  cy.createNativeQuestionAndDashboard({ questionDetails }).then(
+    ({ body: { id, card_id, dashboard_id } }) => {
+      cy.intercept("POST", `/api/card/${card_id}/query`).as("cardQuery");
+      cy.visit(`/question/${card_id}`);
+
+      // Wait for `result_metadata` to load
+      cy.wait("@cardQuery");
+
+      cy.visit(`/dashboard/${dashboard_id}`);
+    },
+  );
+
+  editDashboard();
+  setFilter("ID");
+
+  cy.findByText("Column to filter on")
+    .next("a")
+    .click();
+
+  popover()
+    .contains("Filter")
+    .click();
+}


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- As an ongoing effort to increase the test coverage of dashboard filters (https://github.com/metabase/metabase/issues/17078), this PR adds basic tests around ID filters applied to the SQL question with the corresponding field filter
    - Make sure filter can be set via filter widget
    - Make sure filter can be set as the default filter
    - Do both of these checks for primary and the foreign key
    - 
### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/130872290-6a46bdfc-67a4-4f99-b8ff-b7e07c409835.png)
