### PR TITLE
GridItem should not use prop shorthand

### DIFF
--- a/frontend/src/metabase/collections/components/BulkActions.jsx
+++ b/frontend/src/metabase/collections/components/BulkActions.jsx
@@ -66,8 +66,8 @@ function BulkActions(props) {
                    to the main content above to ensure the bulk checkbox lines up */}
       <Box px={[2, 4]} py={1}>
         <Grid>
-          <GridItem w={[1, 1 / 3]} />
-          <GridItem w={[1, 2 / 3]} px={[1, 2]}>
+          <GridItem width={[1, 1 / 3]} />
+          <GridItem width={[1, 2 / 3]} px={[1, 2]}>
             <Flex align="center" justify="center" px={2}>
               <SelectionControls {...props} />
               <BulkActionControls

--- a/frontend/src/metabase/components/CollectionList.jsx
+++ b/frontend/src/metabase/components/CollectionList.jsx
@@ -33,7 +33,7 @@ function CollectionList({
       {collections
         .filter(c => c.id !== currentUser.personal_collection_id)
         .map(collection => (
-          <GridItem w={w} key={collection.id}>
+          <GridItem width={w} key={collection.id}>
             <CollectionItem
               collection={collection}
               event={`${analyticsContext};Collection List;Collection click`}

--- a/frontend/src/metabase/components/ExplorePane.jsx
+++ b/frontend/src/metabase/components/ExplorePane.jsx
@@ -139,7 +139,7 @@ export const ExploreList = ({
   <Grid>
     {candidates &&
       candidates.map((option, index) => (
-        <GridItem w={gridColumns} key={index}>
+        <GridItem width={gridColumns} key={index}>
           {asCards ? (
             <Card hoverable p={2}>
               <ExploreOption option={option} />

--- a/frontend/src/metabase/components/Grid.jsx
+++ b/frontend/src/metabase/components/Grid.jsx
@@ -2,14 +2,14 @@
 import React from "react";
 import { Box, Flex } from "grid-styled";
 
-export const GridItem = ({ children, w, px, py, ...props }) => (
-  <Box px={px} py={py} {...props} width={w}>
+export const GridItem = ({ children, width, px, py, ...props }) => (
+  <Box px={px} py={py} {...props} width={width}>
     {children}
   </Box>
 );
 
 GridItem.defaultProps = {
-  w: 1 / 4,
+  width: 1 / 4,
   px: 1,
   py: 1,
 };

--- a/frontend/src/metabase/containers/Overworld.jsx
+++ b/frontend/src/metabase/containers/Overworld.jsx
@@ -164,7 +164,7 @@ class Overworld extends React.Component {
                   {items.map(pin => {
                     return (
                       <GridItem
-                        w={[1, 1 / 2, 1 / 3]}
+                        width={[1, 1 / 2, 1 / 3]}
                         key={`${pin.model}-${pin.id}`}
                       >
                         <Link
@@ -288,7 +288,7 @@ class Overworld extends React.Component {
                   <Box mb={4}>
                     <Grid>
                       {databases.map(database => (
-                        <GridItem w={[1, 1 / 3]} key={database.id}>
+                        <GridItem width={[1, 1 / 3]} key={database.id}>
                           <Link
                             to={Urls.browseDatabase(database)}
                             hover={{ color: color("brand") }}

--- a/frontend/src/metabase/containers/UserCollectionList.jsx
+++ b/frontend/src/metabase/containers/UserCollectionList.jsx
@@ -44,7 +44,7 @@ const UserCollectionList = ({ collectionsById }) => (
               list.map(
                 user =>
                   user.personal_collection_id && (
-                    <GridItem w={1 / 3} key={user.personal_collection_id}>
+                    <GridItem width={1 / 3} key={user.personal_collection_id}>
                       <Link
                         to={Urls.collection(
                           collectionsById[user.personal_collection_id],

--- a/frontend/src/metabase/new_query/containers/NewQueryOptions.jsx
+++ b/frontend/src/metabase/new_query/containers/NewQueryOptions.jsx
@@ -83,7 +83,7 @@ export default class NewQueryOptions extends Component {
       <Box my="auto" mx={PAGE_PADDING}>
         <Grid className="justifyCenter">
           {hasDataAccess && (
-            <GridItem w={ITEM_WIDTHS}>
+            <GridItem width={ITEM_WIDTHS}>
               <NewQueryOption
                 image="app/img/simple_mode_illustration"
                 title={t`Simple question`}
@@ -95,7 +95,7 @@ export default class NewQueryOptions extends Component {
             </GridItem>
           )}
           {hasDataAccess && (
-            <GridItem w={ITEM_WIDTHS}>
+            <GridItem width={ITEM_WIDTHS}>
               <NewQueryOption
                 image="app/img/notebook_mode_illustration"
                 title={t`Custom question`}
@@ -107,7 +107,7 @@ export default class NewQueryOptions extends Component {
             </GridItem>
           )}
           {hasNativeWrite && (
-            <GridItem w={ITEM_WIDTHS}>
+            <GridItem width={ITEM_WIDTHS}>
               <NewQueryOption
                 image="app/img/sql_illustration"
                 title={t`Native query`}


### PR DESCRIPTION
Unfortunately, unlike all the other changes (see #17402 for the list), this has to be carried out in one go since it modified `GridItem`. There are 7 (seven) places where the change happens, and therefore the visual for each of them must be inspected carefully. **Before and after this PR, each of them should look _exactly_ the same.**

**GridItem 1** Go to `/` and check the X-ray card

![image](https://user-images.githubusercontent.com/7288/131051575-23914651-8f40-443b-8e29-5dd2b307b3a9.png)

**GridItem 2** ... and scroll to see the list of database and check the container for each database card:

![image](https://user-images.githubusercontent.com/7288/131030132-8fd5b330-a3f4-4f6d-9c91-7bc1a6933c61.png)

**GridItem 3** ...and make sure there is one or more pinned dashboard and check the container for each pinned dashboard card:

![image](https://user-images.githubusercontent.com/7288/131033714-bee6ef88-b5a1-4b8f-9760-a0cfcb74310a.png)

**GridItem 4** ...and make sure there is one or more collections and check each collection card:

![image](https://user-images.githubusercontent.com/7288/131053103-ccacccae-b8d5-47dc-b744-e668442bfd96.png)

**GridItem 5** Go to `/question/new` and check each of the three boxes:

![image](https://user-images.githubusercontent.com/7288/131028399-7377471e-83b2-4106-8fb6-6dd4f1941f65.png)

**GridItem 6** Go to `/collection/users` and check the container for each card:

![image](https://user-images.githubusercontent.com/7288/131029285-8613ee47-d534-41ca-be4b-93893579a4b5.png)

**GridItem 7** Go to `/collection/root`, click on the icon of any collection so that the bulk actions bar appear (bottom of the screen):

![image](https://user-images.githubusercontent.com/7288/131154640-d6af5deb-95fd-44c6-8eb5-2a4883ded3d0.png)
