### PR TITLE
Avoid prop shorthand in query download widget

### DIFF
--- a/frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx
@@ -42,7 +42,7 @@ const QueryDownloadWidget = ({
   >
     <Box
       p={2}
-      w={result.data && result.data.rows_truncated != null ? 300 : 260}
+      width={result.data && result.data.rows_truncated != null ? 300 : 260}
     >
       <Box p={1}>
         <h4>{t`Download full results`}</h4>
@@ -55,7 +55,7 @@ const QueryDownloadWidget = ({
       )}
       <Box>
         {EXPORT_FORMATS.map(type => (
-          <Box key={type} w={"100%"}>
+          <Box key={type} width={"100%"}>
             {dashcardId && token ? (
               <DashboardEmbedQueryButton
                 key={type}


### PR DESCRIPTION
To verify:
1. Ask a question, Simple question
2. Sample Dataset, Orders
3. Click on the download button (bottom right)

Once the download box shows up, pay attention to the following:

![image](https://user-images.githubusercontent.com/7288/130877425-58b6be58-0d4d-45d2-b845-296ae114837c.png)

![image](https://user-images.githubusercontent.com/7288/130877451-37d7ef62-84f2-4ef1-bab2-58f9774a5935.png)

Before and after this change, it should look **exactly** the same.