### PR TITLE
Fix notification management FE issues

### DIFF
--- a/frontend/src/metabase/account/notifications/components/NotificationCard/NotificationCard.jsx
+++ b/frontend/src/metabase/account/notifications/components/NotificationCard/NotificationCard.jsx
@@ -19,7 +19,7 @@ import {
 const propTypes = {
   item: PropTypes.object.isRequired,
   type: PropTypes.oneOf(["pulse", "alert"]).isRequired,
-  user: PropTypes.object,
+  user: PropTypes.object.isRequired,
   onUnsubscribe: PropTypes.func,
   onArchive: PropTypes.func,
 };
@@ -70,7 +70,7 @@ const canArchive = (item, user) => {
     channel.recipients.map(recipient => recipient.id),
   );
 
-  const isCreator = item.creator?.id === user?.id;
+  const isCreator = item.creator?.id === user.id;
   const isSubscribed = recipients.includes(user.id);
   const isOnlyRecipient = recipients.length === 1;
 
@@ -162,7 +162,7 @@ const formatCreator = (item, user) => {
   let creatorString = "";
   const options = Settings.formattingOptions();
 
-  if (user?.id === item.creator?.id) {
+  if (user.id === item.creator?.id) {
     creatorString += t`Created by you`;
   } else if (item.creator?.common_name) {
     creatorString += t`Created by ${item.creator.common_name}`;

--- a/frontend/src/metabase/account/notifications/components/NotificationCard/NotificationCard.jsx
+++ b/frontend/src/metabase/account/notifications/components/NotificationCard/NotificationCard.jsx
@@ -25,7 +25,7 @@ const propTypes = {
 };
 
 const NotificationCard = ({ item, type, user, onUnsubscribe, onArchive }) => {
-  const hasSubscribed = isSubscribed(item, user);
+  const hasArchive = canArchive(item, user);
 
   const onUnsubscribeClick = useCallback(() => {
     onUnsubscribe(item, type);
@@ -45,14 +45,14 @@ const NotificationCard = ({ item, type, user, onUnsubscribe, onArchive }) => {
           {formatDescription(item, user)}
         </NotificationDescription>
       </NotificationContent>
-      {hasSubscribed && (
+      {!hasArchive && (
         <NotificationIcon
           name="close"
           tooltip={t`Unsubscribe`}
           onClick={onUnsubscribeClick}
         />
       )}
-      {!hasSubscribed && (
+      {hasArchive && (
         <NotificationIcon
           name="close"
           tooltip={t`Delete`}
@@ -65,10 +65,16 @@ const NotificationCard = ({ item, type, user, onUnsubscribe, onArchive }) => {
 
 NotificationCard.propTypes = propTypes;
 
-const isSubscribed = (item, user) => {
-  return item.channels.some(channel =>
-    channel.recipients.some(recipient => recipient.id === user.id),
+const canArchive = (item, user) => {
+  const recipients = item.channels.flatMap(channel =>
+    channel.recipients.map(recipient => recipient.id),
   );
+
+  const isCreator = item.creator?.id === user?.id;
+  const isSubscribed = recipients.includes(user.id);
+  const isOnlyRecipient = recipients.length === 1;
+
+  return isCreator && (!isSubscribed || isOnlyRecipient);
 };
 
 const formatTitle = (item, type) => {

--- a/frontend/src/metabase/account/notifications/components/NotificationCard/NotificationCard.unit.spec.js
+++ b/frontend/src/metabase/account/notifications/components/NotificationCard/NotificationCard.unit.spec.js
@@ -116,9 +116,13 @@ describe("NotificationCard", () => {
     screen.getByText("Created by John Doe", { exact: false });
   });
 
-  it("should unsubscribe when subscribed and clicked on the close icon", () => {
-    const user = getUser();
-    const alert = getAlert({ channels: [getChannel({ recipients: [user] })] });
+  it("should unsubscribe when the user is not the creator and subscribed", () => {
+    const creator = getUser({ id: 1 });
+    const user = getUser({ id: 2 });
+    const alert = getAlert({
+      creator,
+      channels: [getChannel({ recipients: [user] })],
+    });
     const onUnsubscribe = jest.fn();
     const onArchive = jest.fn();
 
@@ -137,9 +141,13 @@ describe("NotificationCard", () => {
     expect(onArchive).not.toHaveBeenCalled();
   });
 
-  it("should archive when not subscribed and clicked on the close icon", () => {
-    const alert = getAlert();
-    const user = getUser();
+  it("should unsubscribe when user user is the creator and subscribed with another user", () => {
+    const creator = getUser({ id: 1 });
+    const recipient = getUser({ id: 2 });
+    const alert = getAlert({
+      creator,
+      channels: [getChannel({ recipients: [creator, recipient] })],
+    });
     const onUnsubscribe = jest.fn();
     const onArchive = jest.fn();
 
@@ -147,7 +155,52 @@ describe("NotificationCard", () => {
       <NotificationCard
         item={alert}
         type="alert"
-        user={user}
+        user={creator}
+        onUnsubscribe={onUnsubscribe}
+        onArchive={onArchive}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText("close icon"));
+    expect(onUnsubscribe).toHaveBeenCalledWith(alert, "alert");
+    expect(onArchive).not.toHaveBeenCalled();
+  });
+
+  it("should archive when the user is the creator and not subscribed", () => {
+    const creator = getUser();
+    const alert = getAlert({ creator });
+    const onUnsubscribe = jest.fn();
+    const onArchive = jest.fn();
+
+    render(
+      <NotificationCard
+        item={alert}
+        type="alert"
+        user={creator}
+        onUnsubscribe={onUnsubscribe}
+        onArchive={onArchive}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText("close icon"));
+    expect(onUnsubscribe).not.toHaveBeenCalled();
+    expect(onArchive).toHaveBeenCalledWith(alert, "alert");
+  });
+
+  it("should archive when the user is the creator and is the only one subscribed", () => {
+    const creator = getUser();
+    const alert = getAlert({
+      creator,
+      channels: [getChannel({ recipients: [creator] })],
+    });
+    const onUnsubscribe = jest.fn();
+    const onArchive = jest.fn();
+
+    render(
+      <NotificationCard
+        item={alert}
+        type="alert"
+        user={creator}
         onUnsubscribe={onUnsubscribe}
         onArchive={onArchive}
       />,

--- a/frontend/src/metabase/account/notifications/components/NotificationList/NotificationList.jsx
+++ b/frontend/src/metabase/account/notifications/components/NotificationList/NotificationList.jsx
@@ -13,7 +13,7 @@ import {
 
 const propTypes = {
   items: PropTypes.array.isRequired,
-  user: PropTypes.object,
+  user: PropTypes.object.isRequired,
   children: PropTypes.node,
   onHelp: PropTypes.func,
   onUnsubscribe: PropTypes.func,

--- a/frontend/src/metabase/account/notifications/components/NotificationList/NotificationList.unit.spec.js
+++ b/frontend/src/metabase/account/notifications/components/NotificationList/NotificationList.unit.spec.js
@@ -8,17 +8,27 @@ const getPulse = () => ({
   created_at: "2021-05-08T02:02:07.441Z",
 });
 
+const getUser = () => ({
+  id: 1,
+  common_name: "John Doe",
+});
+
 describe("NotificationList", () => {
   it("should render items", () => {
     const pulse = getPulse();
+    const user = getUser();
 
-    render(<NotificationList items={[{ item: pulse, type: "pulse" }]} />);
+    render(
+      <NotificationList items={[{ item: pulse, type: "pulse" }]} user={user} />,
+    );
 
     screen.getByText("Pulse");
   });
 
   it("should render empty state when there are no items", () => {
-    render(<NotificationList items={[]} />);
+    const user = getUser();
+
+    render(<NotificationList items={[]} user={user} />);
 
     screen.getByText("you’ll be able to manage those here", { exact: false });
   });

--- a/frontend/src/metabase/account/notifications/selectors.js
+++ b/frontend/src/metabase/account/notifications/selectors.js
@@ -1,4 +1,5 @@
 import { createSelector } from "reselect";
+import { parseTimestamp } from "metabase/lib/time";
 
 export const getAlertId = ({ params: { alertId } }) => {
   return parseInt(alertId);
@@ -22,6 +23,10 @@ export const getNotifications = createSelector(
       })),
     ];
 
-    return items.sort((a, b) => b.item.created_at - a.item.created_at);
+    return items.sort(
+      (a, b) =>
+        parseTimestamp(b.item.created_at).unix() -
+        parseTimestamp(a.item.created_at).unix(),
+    );
   },
 );

--- a/frontend/src/metabase/entities/alerts.js
+++ b/frontend/src/metabase/entities/alerts.js
@@ -26,7 +26,7 @@ const Alerts = createEntity({
       return Alerts.actions.update(
         { id },
         { channels: newChannels },
-        undo(opts, "", t`Successfully unsubscribed`),
+        undo(opts, "", t`unsubscribed`),
       );
     },
   },

--- a/frontend/src/metabase/entities/pulses.js
+++ b/frontend/src/metabase/entities/pulses.js
@@ -52,7 +52,7 @@ const Pulses = createEntity({
       return Pulses.actions.update(
         { id },
         { channels: newChannels },
-        undo(opts, "", t`Successfully unsubscribed`),
+        undo(opts, "", t`unsubscribed`),
       );
     },
   },


### PR DESCRIPTION
Fixes recently found issues on the FE side:
- Fix sorting of notifications by `created_at` date
- Add special handling for the case with the user being the creator of a notification and the only recipient

How to test:

1st case:
- Create an alert / dashboard subscription and subscribe yourself to it
- Go to Account settings > Notifications
- Press X to **archive** the notification

2nd case:
- Create an alert / dashboard subscription and subscribe another user to it
- Go to Account settings > Notifications
- Press X to **archive** the notification

3rd case:
- Create an alert / dashboard subscription and subscribe yourself and another user to it
- Login as this another user
- Go to Account settings > Notifications
- Press X to **unsubscribe** from the notification
- After unsubscribing, there should be additional modal for archiving notification
- It should be possible to leave the notification and **archive** it

4th case:
- Create an alert / dashboard subscription and subscribe another user to it
- Login as this another user
- Go to Account settings > Notifications
- Press X to **unsubscribe** from the notification
