### PR TITLE
#17619 Repro:More Options menu not opening

### DIFF
--- a/frontend/test/metabase/scenarios/visualizations/reproductions/17619-line-more-options.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/reproductions/17619-line-more-options.cy.spec.js
@@ -1,0 +1,49 @@
+import { restore } from "__support__/e2e/cypress";
+import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
+
+const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATASET;
+
+const questionDetails = {
+  name: "17619",
+  query: {
+    "source-table": PRODUCTS_ID,
+    aggregation: [["count"]],
+    breakout: [
+      ["field", PRODUCTS.CREATED_AT, { "temporal-unit": "month-of-year" }],
+      ["field", PRODUCTS.CATEGORY, null],
+    ],
+  },
+  display: "line",
+};
+
+describe.skip("issue 17619", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should show and open 'More options' on visualizations with multiple lines (metabase#17619)", () => {
+    cy.createQuestion(questionDetails, { visitQuestion: true });
+
+    cy.findByTestId("viz-settings-button").click();
+
+    openMoreOptionsForCategory("Doohickey");
+
+    cy.findByText("Line style");
+    cy.findByText("Show dots on lines");
+    cy.findByText("Replace missing values with");
+    cy.findByText("Which axis?");
+    cy.findByText("Show values for this series");
+
+    cy.icon("chevronup");
+  });
+});
+
+function openMoreOptionsForCategory(category) {
+  cy.findByTestId("sidebar-left").within(() => {
+    cy.findByDisplayValue(category)
+      .siblings()
+      .find(".Icon-chevrondown")
+      .click();
+  });
+}


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #17619 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/visualizations/reproductions/17619-line-more-options.cy.spec.js`
- Unskip the test
- It should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/131018069-9a1455c7-ab78-43f6-97a8-c49ebf11b874.png)
