### PR TITLE
#17615 Repro: Valid Email settings disappear on save

### DIFF
--- a/frontend/test/metabase/scenarios/admin/settings/email.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/email.cy.spec.js
@@ -5,7 +5,8 @@ describe("scenarios > admin > settings > email settings", () => {
     restore();
     cy.signInAsAdmin();
   });
-  it("should be able to save email settings", () => {
+
+  it.skip("should be able to save email settings (metabase#17615)", () => {
     cy.visit("/admin/settings/email");
     cy.findByPlaceholderText("smtp.yourservice.com")
       .type("localhost")
@@ -25,6 +26,12 @@ describe("scenarios > admin > settings > email settings", () => {
     cy.findByText("Save changes").click();
 
     cy.findByText("Changes saved!");
+
+    // This part was added as a repro for metabase#17615
+    cy.findByDisplayValue("localhost");
+    cy.findByDisplayValue("25");
+    cy.findAllByDisplayValue("admin");
+    cy.findByDisplayValue("mailer@metabase.test");
   });
   it("should show an error if test email fails", () => {
     // Reuse Email setup without relying on the previous test


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #17615

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/admin/settings/email.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/131023545-3b2a1b17-6484-4208-858f-32faac6b1984.png)

