### PR TITLE
Isolate BigQuery legacy and new driver test runs

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
@@ -16,6 +16,7 @@
             [metabase.sync :as sync]
             [metabase.test :as mt]
             [metabase.test.data.bigquery-cloud-sdk :as bigquery.tx]
+            [metabase.test.util :as tu]
             [metabase.test.util.timezone :as tu.tz]
             [metabase.util :as u]
             [metabase.util.honeysql-extensions :as hx]
@@ -487,7 +488,7 @@
 
 (defn- do-with-datetime-timestamp-table [f]
   (driver/with-driver :bigquery-cloud-sdk
-    (let [table-name (name (munge (gensym "table_")))]
+    (let [table-name (format "table_%s" (tu/random-name))]
       (mt/with-temp-copy-of-db
         (try
           (bigquery.tx/execute!

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -76,7 +76,7 @@
 
 (defn- do-with-view [f]
   (driver/with-driver :bigquery-cloud-sdk
-    (let [view-name (name (munge (gensym "view_")))]
+    (let [view-name (format "view_%s" (tu/random-name))]
       (mt/with-temp-copy-of-db
         (try
           (bigquery.tx/execute!

--- a/modules/drivers/bigquery/test/metabase/driver/bigquery/query_processor_test.clj
+++ b/modules/drivers/bigquery/test/metabase/driver/bigquery/query_processor_test.clj
@@ -16,6 +16,7 @@
             [metabase.sync :as sync]
             [metabase.test :as mt]
             [metabase.test.data.bigquery :as bigquery.tx]
+            [metabase.test.util :as tu]
             [metabase.test.util.timezone :as tu.tz]
             [metabase.util :as u]
             [metabase.util.honeysql-extensions :as hx]
@@ -487,7 +488,7 @@
 
 (defn- do-with-datetime-timestamp-table [f]
   (driver/with-driver :bigquery
-    (let [table-name (name (munge (gensym "table_")))]
+    (let [table-name (format "table_%s" (tu/random-name))]
       (mt/with-temp-copy-of-db
         (try
           (bigquery.tx/execute!

--- a/modules/drivers/bigquery/test/metabase/driver/bigquery/query_processor_test.clj
+++ b/modules/drivers/bigquery/test/metabase/driver/bigquery/query_processor_test.clj
@@ -28,9 +28,9 @@
            (mt/rows
              (qp/process-query
               (mt/native-query
-                {:query (str "SELECT `v3_test_data.venues`.`id` "
-                             "FROM `v3_test_data.venues` "
-                             "ORDER BY `v3_test_data.venues`.`id` DESC "
+                {:query (str "SELECT `v3_legacydriver_test_data.venues`.`id` "
+                             "FROM `v3_legacydriver_test_data.venues` "
+                             "ORDER BY `v3_legacydriver_test_data.venues`.`id` DESC "
                              "LIMIT 2;")})))))
 
     (testing (str "make sure that BigQuery native queries maintain the column ordering specified in the SQL -- "
@@ -55,10 +55,10 @@
                :field_ref    [:field "checkins_id" {:base-type :type/Integer}]}]
              (qp.test/cols
                (qp/process-query
-                {:native   {:query (str "SELECT `v3_test_data.checkins`.`venue_id` AS `venue_id`, "
-                                        "       `v3_test_data.checkins`.`user_id` AS `user_id`, "
-                                        "       `v3_test_data.checkins`.`id` AS `checkins_id` "
-                                        "FROM `v3_test_data.checkins` "
+                {:native   {:query (str "SELECT `v3_legacydriver_test_data.checkins`.`venue_id` AS `venue_id`, "
+                                        "       `v3_legacydriver_test_data.checkins`.`user_id` AS `user_id`, "
+                                        "       `v3_legacydriver_test_data.checkins`.`id` AS `checkins_id` "
+                                        "FROM `v3_legacydriver_test_data.checkins` "
                                         "LIMIT 2")}
                  :type     :native
                  :database (mt/id)})))))
@@ -108,13 +108,13 @@
                rows))))
 
     (testing "let's make sure we're generating correct HoneySQL + SQL for aggregations"
-      (is (= {:select   [[(hx/with-database-type-info (hx/identifier :field "v3_test_data.venues" "price") "integer")
+      (is (= {:select   [[(hx/with-database-type-info (hx/identifier :field "v3_legacydriver_test_data.venues" "price") "integer")
                           (hx/identifier :field-alias "price")]
                          [(hsql/call :avg (hx/with-database-type-info
-                                           (hx/identifier :field "v3_test_data.venues" "category_id")
+                                           (hx/identifier :field "v3_legacydriver_test_data.venues" "category_id")
                                            "integer"))
                           (hx/identifier :field-alias "avg")]]
-              :from     [(hx/identifier :table "v3_test_data.venues")]
+              :from     [(hx/identifier :table "v3_legacydriver_test_data.venues")]
               :group-by [(hx/identifier :field-alias "price")]
               :order-by [[(hx/identifier :field-alias "avg") :asc]]}
              (mt/with-everything-store
@@ -125,9 +125,9 @@
                    :breakout    [$price]
                    :order-by    [[:asc [:aggregation 0]]]})))))
 
-      (is (= {:query      (str "SELECT `v3_test_data.venues`.`price` AS `price`,"
-                               " avg(`v3_test_data.venues`.`category_id`) AS `avg` "
-                               "FROM `v3_test_data.venues` "
+      (is (= {:query      (str "SELECT `v3_legacydriver_test_data.venues`.`price` AS `price`,"
+                               " avg(`v3_legacydriver_test_data.venues`.`category_id`) AS `avg` "
+                               "FROM `v3_legacydriver_test_data.venues` "
                                "GROUP BY `price` "
                                "ORDER BY `avg` ASC, `price` ASC")
               :params     nil
@@ -148,9 +148,9 @@
                          :breakout    [$category_id->categories.name]})]
           (is (= (str "SELECT `categories__via__category_id`.`name` AS `categories__via__category_id__name`,"
                       " count(*) AS `count` "
-                      "FROM `v3_test_data.venues` "
-                      "LEFT JOIN `v3_test_data.categories` `categories__via__category_id`"
-                      " ON `v3_test_data.venues`.`category_id` = `categories__via__category_id`.`id` "
+                      "FROM `v3_legacydriver_test_data.venues` "
+                      "LEFT JOIN `v3_legacydriver_test_data.categories` `categories__via__category_id`"
+                      " ON `v3_legacydriver_test_data.venues`.`category_id` = `categories__via__category_id`.`id` "
                       "GROUP BY `categories__via__category_id__name` "
                       "ORDER BY `categories__via__category_id__name` ASC")
                  (get-in results [:data :native_form :query] results))))))))
@@ -203,13 +203,13 @@
     (is (= (str
             "-- Metabase:: userID: 1000 queryType: MBQL queryHash: 01020304\n"
             "SELECT"
-            " `v3_test_data.venues`.`id` AS `id`,"
-            " `v3_test_data.venues`.`name` AS `name`,"
-            " `v3_test_data.venues`.`category_id` AS `category_id`,"
-            " `v3_test_data.venues`.`latitude` AS `latitude`,"
-            " `v3_test_data.venues`.`longitude` AS `longitude`,"
-            " `v3_test_data.venues`.`price` AS `price` "
-            "FROM `v3_test_data.venues` "
+            " `v3_legacydriver_test_data.venues`.`id` AS `id`,"
+            " `v3_legacydriver_test_data.venues`.`name` AS `name`,"
+            " `v3_legacydriver_test_data.venues`.`category_id` AS `category_id`,"
+            " `v3_legacydriver_test_data.venues`.`latitude` AS `latitude`,"
+            " `v3_legacydriver_test_data.venues`.`longitude` AS `longitude`,"
+            " `v3_legacydriver_test_data.venues`.`price` AS `price` "
+            "FROM `v3_legacydriver_test_data.venues` "
             "LIMIT 1")
            (query->native
             {:database (mt/id)
@@ -224,27 +224,27 @@
 (deftest remove-remark-test
   (mt/test-driver :bigquery
     (is (=  (str
-            "SELECT `v3_test_data.venues`.`id` AS `id`,"
-            " `v3_test_data.venues`.`name` AS `name` "
-            "FROM `v3_test_data.venues` "
-            "LIMIT 1")
-    (tt/with-temp* [Database [db {:engine :bigquery
-                                  :details (assoc (:details (mt/db))
-                                                  :include-user-id-and-hash false)}]
-                    Table    [table {:name "venues" :db_id (u/the-id db)}]
-                    Field    [_     {:table_id (u/the-id table)
-                                    :name "id"
-                                    :base_type "type/Integer"}]
-                    Field    [_     {:table_id (u/the-id table)
-                                    :name "name"
-                                    :base_type "type/Text"}]]
-      (query->native
-        {:database (u/the-id db)
-        :type     :query
-        :query    {:source-table (u/the-id table)
-                    :limit        1}
-        :info     {:executed-by 1000
-                    :query-hash  (byte-array [1 2 3 4])}}))))))
+             "SELECT `v3_legacydriver_test_data.venues`.`id` AS `id`,"
+             " `v3_legacydriver_test_data.venues`.`name` AS `name` "
+             "FROM `v3_legacydriver_test_data.venues` "
+             "LIMIT 1")
+            (tt/with-temp* [Database [db {:engine :bigquery
+                                          :details (assoc (:details (mt/db))
+                                                          :include-user-id-and-hash false)}]
+                            Table    [table {:name "venues" :db_id (u/the-id db)}]
+                            Field    [_     {:table_id (u/the-id table)
+                                             :name "id"
+                                             :base_type "type/Integer"}]
+                            Field    [_     {:table_id (u/the-id table)
+                                             :name "name"
+                                             :base_type "type/Text"}]]
+              (query->native
+                {:database (u/the-id db)
+                 :type     :query
+                 :query    {:source-table (u/the-id table)
+                            :limit        1}
+                 :info     {:executed-by 1000
+                            :query-hash  (byte-array [1 2 3 4])}}))))))
 
 (deftest unprepare-params-test
   (mt/test-driver :bigquery
@@ -252,9 +252,9 @@
            (qp.test/rows
              (qp/process-query
               (mt/native-query
-                {:query  (str "SELECT `v3_test_data.venues`.`name` AS `name` "
-                              "FROM `v3_test_data.venues` "
-                              "WHERE `v3_test_data.venues`.`name` = ?")
+                {:query  (str "SELECT `v3_legacydriver_test_data.venues`.`name` AS `name` "
+                              "FROM `v3_legacydriver_test_data.venues` "
+                              "WHERE `v3_legacydriver_test_data.venues`.`name` = ?")
                  :params ["Red Medicine"]}))))
         (str "Do we properly unprepare, and can we execute, queries that still have parameters for one reason or "
              "another? (EE #277)"))))
@@ -376,7 +376,7 @@
                                  :limit    1})
                 filter-clause (get-in query [:query :filter])]
             (mt/with-everything-store
-              (is (= [(str "timestamp_millis(v3_sample_dataset.reviews.rating)"
+              (is (= [(str "timestamp_millis(v3_legacydriver_sample_dataset.reviews.rating)"
                            " = "
                            "timestamp_trunc(timestamp_add(current_timestamp(), INTERVAL -30 day), day)")]
                      (hsql/format-predicate (sql.qp/->honeysql :bigquery filter-clause)))))
@@ -445,7 +445,7 @@
                               (t/local-date "2019-11-12")]))))
       (mt/test-driver :bigquery
         (mt/with-everything-store
-          (let [expected ["WHERE `v3_test_data.checkins`.`date` BETWEEN ? AND ?"
+          (let [expected ["WHERE `v3_legacydriver_test_data.checkins`.`date` BETWEEN ? AND ?"
                           (t/local-date "2019-11-11")
                           (t/local-date "2019-11-12")]]
             (testing "Should be able to get temporal type from a FieldInstance"
@@ -461,7 +461,7 @@
                                     (t/local-date "2019-11-11")
                                     (t/local-date "2019-11-12")]))))
             (testing "Should be able to get temporal type from a wrapped field-id"
-              (is (= (cons "WHERE date_trunc(`v3_test_data.checkins`.`date`, day) BETWEEN ? AND ?"
+              (is (= (cons "WHERE date_trunc(`v3_legacydriver_test_data.checkins`.`date`, day) BETWEEN ? AND ?"
                            (rest expected))
                      (between->sql [:between
                                     [:field (mt/id :checkins :date) {:temporal-unit :day}]
@@ -492,14 +492,14 @@
       (mt/with-temp-copy-of-db
         (try
           (bigquery.tx/execute!
-           (format "CREATE TABLE `v3_test_data.%s` ( ts TIMESTAMP, dt DATETIME )" table-name))
+           (format "CREATE TABLE `v3_legacydriver_test_data.%s` ( ts TIMESTAMP, dt DATETIME )" table-name))
           (bigquery.tx/execute!
-           (format "INSERT INTO `v3_test_data.%s` (ts, dt) VALUES (TIMESTAMP \"2020-01-01 00:00:00 UTC\", DATETIME \"2020-01-01 00:00:00\")"
+           (format "INSERT INTO `v3_legacydriver_test_data.%s` (ts, dt) VALUES (TIMESTAMP \"2020-01-01 00:00:00 UTC\", DATETIME \"2020-01-01 00:00:00\")"
                    table-name))
           (sync/sync-database! (mt/db))
           (f table-name)
           (finally
-            (bigquery.tx/execute! "DROP TABLE IF EXISTS `v3_test_data.%s`" table-name)))))))
+            (bigquery.tx/execute! "DROP TABLE IF EXISTS `v3_legacydriver_test_data.%s`" table-name)))))))
 
 (deftest filter-by-datetime-timestamp-test
   (mt/test-driver :bigquery
@@ -540,7 +540,7 @@
                        (qp/process-query
                          {:database   (mt/id)
                           :type       :native
-                          :native     {:query         "SELECT count(*) FROM `v3_attempted_murders.attempts` WHERE {{d}}"
+                          :native     {:query         "SELECT count(*) FROM `v3_legacydriver_attempted_murders.attempts` WHERE {{d}}"
                                        :template-tags {"d" {:name         "d"
                                                             :display-name "Date"
                                                             :type         :dimension
@@ -701,8 +701,8 @@
                  (qp/process-query
                   (mt/native-query
                     {:query  (str "SELECT count(*) AS `count` "
-                                  "FROM `v3_test_data.venues` "
-                                  "WHERE `v3_test_data.venues`.`name` = ?")
+                                  "FROM `v3_legacydriver_test_data.venues` "
+                                  "WHERE `v3_legacydriver_test_data.venues`.`name` = ?")
                      :params ["x\\\\' OR 1 = 1 -- "]})))))))))
 
 (deftest acceptable-dataset-test
@@ -760,10 +760,10 @@
         (let [query (mt/mbql-query checkins
                       {:fields [$id $venue_id->venues.name]})]
           (mt/with-temp-vals-in-db Table (mt/id :venues) {:name "Organização"}
-            (is (= (str "SELECT `v3_test_data.checkins`.`id` AS `id`,"
+            (is (= (str "SELECT `v3_legacydriver_test_data.checkins`.`id` AS `id`,"
                         " `Organização__via__venue_id`.`name` AS `Organizacao__via__venue_id__name_560a3449` "
-                        "FROM `v3_test_data.checkins` "
-                        "LEFT JOIN `v3_test_data.Organização` `Organização__via__venue_id`"
-                        " ON `v3_test_data.checkins`.`venue_id` = `Organização__via__venue_id`.`id` "
+                        "FROM `v3_legacydriver_test_data.checkins` "
+                        "LEFT JOIN `v3_legacydriver_test_data.Organização` `Organização__via__venue_id`"
+                        " ON `v3_legacydriver_test_data.checkins`.`venue_id` = `Organização__via__venue_id`.`id` "
                         "LIMIT 1048575")
                    (:query (qp/query->native query))))))))))

--- a/modules/drivers/bigquery/test/metabase/driver/bigquery/query_processor_test.clj
+++ b/modules/drivers/bigquery/test/metabase/driver/bigquery/query_processor_test.clj
@@ -28,9 +28,9 @@
            (mt/rows
              (qp/process-query
               (mt/native-query
-                {:query (str "SELECT `v3_legacydriver_test_data.venues`.`id` "
-                             "FROM `v3_legacydriver_test_data.venues` "
-                             "ORDER BY `v3_legacydriver_test_data.venues`.`id` DESC "
+                {:query (str "SELECT `v3_test_data.venues`.`id` "
+                             "FROM `v3_test_data.venues` "
+                             "ORDER BY `v3_test_data.venues`.`id` DESC "
                              "LIMIT 2;")})))))
 
     (testing (str "make sure that BigQuery native queries maintain the column ordering specified in the SQL -- "
@@ -55,10 +55,10 @@
                :field_ref    [:field "checkins_id" {:base-type :type/Integer}]}]
              (qp.test/cols
                (qp/process-query
-                {:native   {:query (str "SELECT `v3_legacydriver_test_data.checkins`.`venue_id` AS `venue_id`, "
-                                        "       `v3_legacydriver_test_data.checkins`.`user_id` AS `user_id`, "
-                                        "       `v3_legacydriver_test_data.checkins`.`id` AS `checkins_id` "
-                                        "FROM `v3_legacydriver_test_data.checkins` "
+                {:native   {:query (str "SELECT `v3_test_data.checkins`.`venue_id` AS `venue_id`, "
+                                        "       `v3_test_data.checkins`.`user_id` AS `user_id`, "
+                                        "       `v3_test_data.checkins`.`id` AS `checkins_id` "
+                                        "FROM `v3_test_data.checkins` "
                                         "LIMIT 2")}
                  :type     :native
                  :database (mt/id)})))))
@@ -108,13 +108,13 @@
                rows))))
 
     (testing "let's make sure we're generating correct HoneySQL + SQL for aggregations"
-      (is (= {:select   [[(hx/with-database-type-info (hx/identifier :field "v3_legacydriver_test_data.venues" "price") "integer")
+      (is (= {:select   [[(hx/with-database-type-info (hx/identifier :field "v3_test_data.venues" "price") "integer")
                           (hx/identifier :field-alias "price")]
                          [(hsql/call :avg (hx/with-database-type-info
-                                           (hx/identifier :field "v3_legacydriver_test_data.venues" "category_id")
+                                           (hx/identifier :field "v3_test_data.venues" "category_id")
                                            "integer"))
                           (hx/identifier :field-alias "avg")]]
-              :from     [(hx/identifier :table "v3_legacydriver_test_data.venues")]
+              :from     [(hx/identifier :table "v3_test_data.venues")]
               :group-by [(hx/identifier :field-alias "price")]
               :order-by [[(hx/identifier :field-alias "avg") :asc]]}
              (mt/with-everything-store
@@ -125,9 +125,9 @@
                    :breakout    [$price]
                    :order-by    [[:asc [:aggregation 0]]]})))))
 
-      (is (= {:query      (str "SELECT `v3_legacydriver_test_data.venues`.`price` AS `price`,"
-                               " avg(`v3_legacydriver_test_data.venues`.`category_id`) AS `avg` "
-                               "FROM `v3_legacydriver_test_data.venues` "
+      (is (= {:query      (str "SELECT `v3_test_data.venues`.`price` AS `price`,"
+                               " avg(`v3_test_data.venues`.`category_id`) AS `avg` "
+                               "FROM `v3_test_data.venues` "
                                "GROUP BY `price` "
                                "ORDER BY `avg` ASC, `price` ASC")
               :params     nil
@@ -148,9 +148,9 @@
                          :breakout    [$category_id->categories.name]})]
           (is (= (str "SELECT `categories__via__category_id`.`name` AS `categories__via__category_id__name`,"
                       " count(*) AS `count` "
-                      "FROM `v3_legacydriver_test_data.venues` "
-                      "LEFT JOIN `v3_legacydriver_test_data.categories` `categories__via__category_id`"
-                      " ON `v3_legacydriver_test_data.venues`.`category_id` = `categories__via__category_id`.`id` "
+                      "FROM `v3_test_data.venues` "
+                      "LEFT JOIN `v3_test_data.categories` `categories__via__category_id`"
+                      " ON `v3_test_data.venues`.`category_id` = `categories__via__category_id`.`id` "
                       "GROUP BY `categories__via__category_id__name` "
                       "ORDER BY `categories__via__category_id__name` ASC")
                  (get-in results [:data :native_form :query] results))))))))
@@ -203,13 +203,13 @@
     (is (= (str
             "-- Metabase:: userID: 1000 queryType: MBQL queryHash: 01020304\n"
             "SELECT"
-            " `v3_legacydriver_test_data.venues`.`id` AS `id`,"
-            " `v3_legacydriver_test_data.venues`.`name` AS `name`,"
-            " `v3_legacydriver_test_data.venues`.`category_id` AS `category_id`,"
-            " `v3_legacydriver_test_data.venues`.`latitude` AS `latitude`,"
-            " `v3_legacydriver_test_data.venues`.`longitude` AS `longitude`,"
-            " `v3_legacydriver_test_data.venues`.`price` AS `price` "
-            "FROM `v3_legacydriver_test_data.venues` "
+            " `v3_test_data.venues`.`id` AS `id`,"
+            " `v3_test_data.venues`.`name` AS `name`,"
+            " `v3_test_data.venues`.`category_id` AS `category_id`,"
+            " `v3_test_data.venues`.`latitude` AS `latitude`,"
+            " `v3_test_data.venues`.`longitude` AS `longitude`,"
+            " `v3_test_data.venues`.`price` AS `price` "
+            "FROM `v3_test_data.venues` "
             "LIMIT 1")
            (query->native
             {:database (mt/id)
@@ -224,9 +224,9 @@
 (deftest remove-remark-test
   (mt/test-driver :bigquery
     (is (=  (str
-             "SELECT `v3_legacydriver_test_data.venues`.`id` AS `id`,"
-             " `v3_legacydriver_test_data.venues`.`name` AS `name` "
-             "FROM `v3_legacydriver_test_data.venues` "
+             "SELECT `v3_test_data.venues`.`id` AS `id`,"
+             " `v3_test_data.venues`.`name` AS `name` "
+             "FROM `v3_test_data.venues` "
              "LIMIT 1")
             (tt/with-temp* [Database [db {:engine :bigquery
                                           :details (assoc (:details (mt/db))
@@ -252,9 +252,9 @@
            (qp.test/rows
              (qp/process-query
               (mt/native-query
-                {:query  (str "SELECT `v3_legacydriver_test_data.venues`.`name` AS `name` "
-                              "FROM `v3_legacydriver_test_data.venues` "
-                              "WHERE `v3_legacydriver_test_data.venues`.`name` = ?")
+                {:query  (str "SELECT `v3_test_data.venues`.`name` AS `name` "
+                              "FROM `v3_test_data.venues` "
+                              "WHERE `v3_test_data.venues`.`name` = ?")
                  :params ["Red Medicine"]}))))
         (str "Do we properly unprepare, and can we execute, queries that still have parameters for one reason or "
              "another? (EE #277)"))))
@@ -376,7 +376,7 @@
                                  :limit    1})
                 filter-clause (get-in query [:query :filter])]
             (mt/with-everything-store
-              (is (= [(str "timestamp_millis(v3_legacydriver_sample_dataset.reviews.rating)"
+              (is (= [(str "timestamp_millis(v3_sample_dataset.reviews.rating)"
                            " = "
                            "timestamp_trunc(timestamp_add(current_timestamp(), INTERVAL -30 day), day)")]
                      (hsql/format-predicate (sql.qp/->honeysql :bigquery filter-clause)))))
@@ -445,7 +445,7 @@
                               (t/local-date "2019-11-12")]))))
       (mt/test-driver :bigquery
         (mt/with-everything-store
-          (let [expected ["WHERE `v3_legacydriver_test_data.checkins`.`date` BETWEEN ? AND ?"
+          (let [expected ["WHERE `v3_test_data.checkins`.`date` BETWEEN ? AND ?"
                           (t/local-date "2019-11-11")
                           (t/local-date "2019-11-12")]]
             (testing "Should be able to get temporal type from a FieldInstance"
@@ -461,7 +461,7 @@
                                     (t/local-date "2019-11-11")
                                     (t/local-date "2019-11-12")]))))
             (testing "Should be able to get temporal type from a wrapped field-id"
-              (is (= (cons "WHERE date_trunc(`v3_legacydriver_test_data.checkins`.`date`, day) BETWEEN ? AND ?"
+              (is (= (cons "WHERE date_trunc(`v3_test_data.checkins`.`date`, day) BETWEEN ? AND ?"
                            (rest expected))
                      (between->sql [:between
                                     [:field (mt/id :checkins :date) {:temporal-unit :day}]
@@ -492,14 +492,14 @@
       (mt/with-temp-copy-of-db
         (try
           (bigquery.tx/execute!
-           (format "CREATE TABLE `v3_legacydriver_test_data.%s` ( ts TIMESTAMP, dt DATETIME )" table-name))
+           (format "CREATE TABLE `v3_test_data.%s` ( ts TIMESTAMP, dt DATETIME )" table-name))
           (bigquery.tx/execute!
-           (format "INSERT INTO `v3_legacydriver_test_data.%s` (ts, dt) VALUES (TIMESTAMP \"2020-01-01 00:00:00 UTC\", DATETIME \"2020-01-01 00:00:00\")"
+           (format "INSERT INTO `v3_test_data.%s` (ts, dt) VALUES (TIMESTAMP \"2020-01-01 00:00:00 UTC\", DATETIME \"2020-01-01 00:00:00\")"
                    table-name))
           (sync/sync-database! (mt/db))
           (f table-name)
           (finally
-            (bigquery.tx/execute! "DROP TABLE IF EXISTS `v3_legacydriver_test_data.%s`" table-name)))))))
+            (bigquery.tx/execute! "DROP TABLE IF EXISTS `v3_test_data.%s`" table-name)))))))
 
 (deftest filter-by-datetime-timestamp-test
   (mt/test-driver :bigquery
@@ -540,7 +540,7 @@
                        (qp/process-query
                          {:database   (mt/id)
                           :type       :native
-                          :native     {:query         "SELECT count(*) FROM `v3_legacydriver_attempted_murders.attempts` WHERE {{d}}"
+                          :native     {:query         "SELECT count(*) FROM `v3_attempted_murders.attempts` WHERE {{d}}"
                                        :template-tags {"d" {:name         "d"
                                                             :display-name "Date"
                                                             :type         :dimension
@@ -701,8 +701,8 @@
                  (qp/process-query
                   (mt/native-query
                     {:query  (str "SELECT count(*) AS `count` "
-                                  "FROM `v3_legacydriver_test_data.venues` "
-                                  "WHERE `v3_legacydriver_test_data.venues`.`name` = ?")
+                                  "FROM `v3_test_data.venues` "
+                                  "WHERE `v3_test_data.venues`.`name` = ?")
                      :params ["x\\\\' OR 1 = 1 -- "]})))))))))
 
 (deftest acceptable-dataset-test
@@ -760,10 +760,10 @@
         (let [query (mt/mbql-query checkins
                       {:fields [$id $venue_id->venues.name]})]
           (mt/with-temp-vals-in-db Table (mt/id :venues) {:name "Organização"}
-            (is (= (str "SELECT `v3_legacydriver_test_data.checkins`.`id` AS `id`,"
+            (is (= (str "SELECT `v3_test_data.checkins`.`id` AS `id`,"
                         " `Organização__via__venue_id`.`name` AS `Organizacao__via__venue_id__name_560a3449` "
-                        "FROM `v3_legacydriver_test_data.checkins` "
-                        "LEFT JOIN `v3_legacydriver_test_data.Organização` `Organização__via__venue_id`"
-                        " ON `v3_legacydriver_test_data.checkins`.`venue_id` = `Organização__via__venue_id`.`id` "
+                        "FROM `v3_test_data.checkins` "
+                        "LEFT JOIN `v3_test_data.Organização` `Organização__via__venue_id`"
+                        " ON `v3_test_data.checkins`.`venue_id` = `Organização__via__venue_id`.`id` "
                         "LIMIT 1048575")
                    (:query (qp/query->native query))))))))))

--- a/modules/drivers/bigquery/test/metabase/driver/bigquery_test.clj
+++ b/modules/drivers/bigquery/test/metabase/driver/bigquery_test.clj
@@ -58,7 +58,7 @@
 
 (defn- do-with-view [f]
   (driver/with-driver :bigquery
-    (let [view-name (name (munge (gensym "view_")))]
+    (let [view-name (format "view_%s" (tu/random-name))]
       (mt/with-temp-copy-of-db
         (try
           (bigquery.tx/execute!

--- a/modules/drivers/bigquery/test/metabase/test/data/bigquery.clj
+++ b/modules/drivers/bigquery/test/metabase/test/data/bigquery.clj
@@ -33,14 +33,14 @@
 
 ;;; ----------------------------------------------- Connection Details -----------------------------------------------
 
-;; keep track of databases we haven't created yet
+;; keep track of databases we have already created
 (def ^:private existing-datasets
   (atom #{}))
 
 (def ^:private current-dataset-version-prefix "v3_")
 
 (defn- prefix-legacydriver-if-new
-  "Adds a legacrydriver_ prefix to the db-name, if the `existing-dataset` atom does not contain it. This is to ensure
+  "Adds a legacydriver_ prefix to the db-name, if the `existing-dataset` atom does not contain it. This is to ensure
   that transient datasets created and destroyed by these tests do not interfere with parallel test runs for the new
   BigQuery driver (which are also creating and destroying datasets that would have the same name, if not for this
   change). If the `db-name` is already an existing one, however, the assumption is it's not transient (i.e. not being

--- a/modules/drivers/bigquery/test/metabase/test/data/bigquery.clj
+++ b/modules/drivers/bigquery/test/metabase/test/data/bigquery.clj
@@ -36,7 +36,7 @@
 (defn- normalize-name ^String [db-or-table-or-field identifier]
   (let [s (str/replace (name identifier) "-" "_")]
     (case db-or-table-or-field
-      :db             (str "v3_" s)
+      :db             (str "v3_legacydriver_" s)
       (:table :field) s)))
 
 (def ^:private details

--- a/modules/drivers/bigquery/test/metabase/test/data/bigquery.clj
+++ b/modules/drivers/bigquery/test/metabase/test/data/bigquery.clj
@@ -33,10 +33,27 @@
 
 ;;; ----------------------------------------------- Connection Details -----------------------------------------------
 
+;; keep track of databases we haven't created yet
+(def ^:private existing-datasets
+  (atom #{}))
+
+(def ^:private current-dataset-version-prefix "v3_")
+
+(defn- prefix-legacydriver-if-new
+  "Adds a legacrydriver_ prefix to the db-name, if the `existing-dataset` atom does not contain it. This is to ensure
+  that transient datasets created and destroyed by these tests do not interfere with parallel test runs for the new
+  BigQuery driver (which are also creating and destroying datasets that would have the same name, if not for this
+  change). If the `db-name` is already an existing one, however, the assumption is it's not transient (i.e. not being
+  created and destroyed at test time), and hence, it can keep its name without modification."
+  [db-name]
+  (if (contains? @existing-datasets db-name)
+    db-name
+    (str/replace-first db-name current-dataset-version-prefix (str current-dataset-version-prefix "legacydriver_"))))
+
 (defn- normalize-name ^String [db-or-table-or-field identifier]
   (let [s (str/replace (name identifier) "-" "_")]
     (case db-or-table-or-field
-      :db             (str "v3_legacydriver_" s)
+      :db             (prefix-legacydriver-if-new (str current-dataset-version-prefix s))
       (:table :field) s)))
 
 (def ^:private details
@@ -324,10 +341,6 @@
         ;; to the current moment in time and thus need to be recreated before running the tests.
         :when   (not (str/includes? dataset-name "checkins_interval_"))]
     dataset-name))
-
-;; keep track of databases we haven't created yet
-(def ^:private existing-datasets
-  (atom #{}))
 
 (defmethod tx/create-db! :bigquery [_ {:keys [database-name table-definitions]} & _]
   {:pre [(seq database-name) (sequential? table-definitions)]}


### PR DESCRIPTION
Use `tu/random-name` instead of a name based on the output of `gensym`, for both transient tables and views created by tests (since the `gensym` output can sometimes clash).

For transient datasets in the legacy BQ driver, append an extra prefix so that they don't clash with the new BQ driver running its tests (since they will both try to create and delete these transient datasets in an indeterminate order).
