### PR TITLE
Fix options menu in visualization settings sidebar

### DIFF
--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingNestedSettings.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingNestedSettings.jsx
@@ -64,10 +64,12 @@ const chartSettingNestedSettings = ({
 
     constructor(props: Props) {
       super(props);
+      this.state = {};
     }
 
     getEditingObjectKey = () => {
       return (
+        this.state.objectKeyOverride ||
         this.props.initialKey ||
         (this.props.objects.length === 1
           ? getObjectKey(this.props.objects[0])
@@ -76,6 +78,9 @@ const chartSettingNestedSettings = ({
     };
 
     handleChangeEditingObject = (editingObject: ?NestedObject) => {
+      this.setState({
+        objectKeyOverride: editingObject ? getObjectKey(editingObject) : null,
+      });
       // special prop to notify ChartSettings it should unswap replaced widget
       if (!editingObject && this.props.onEndShowWidget) {
         this.props.onEndShowWidget();

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingNestedSettings.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingNestedSettings.jsx
@@ -78,6 +78,8 @@ const chartSettingNestedSettings = ({
     };
 
     handleChangeEditingObject = (editingObject: ?NestedObject) => {
+      // objectKeyOverride allows child components to set the editing object key to a different value than is derived
+      // from the props. For example, this is used by the "More options" button in ChartNestedSettingSeries.
       this.setState({
         objectKeyOverride: editingObject ? getObjectKey(editingObject) : null,
       });

--- a/frontend/test/metabase/scenarios/visualizations/reproductions/17619-line-more-options.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/reproductions/17619-line-more-options.cy.spec.js
@@ -16,7 +16,7 @@ const questionDetails = {
   display: "line",
 };
 
-describe.skip("issue 17619", () => {
+describe("issue 17619", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();


### PR DESCRIPTION
This PR fixes a regression introduced by #17355, in which the "More options" button in the line chart display settings sidebar was not working.

Basically, when I converted `ChartSettingNestedSettings` into a fully controlled component, it also meant that `handleChangeEditingObject` was no longer updating `editingObjectKey` in the component's state. And `handleChangeEditingObject` is the callback that is invoked when you click the "More options" button.

I've tried to fix this by having `handleChangeEditingObject` set an `objectKeyOverride` field on the component's state, which overrides the key that is computed from the props. This makes it a sort of partially-controlled component, but only for this one specific case.

The Cypress repro is passing and I've done manual testing to check that original issue in #16043 is still fixed and nothing else is broken. But I'd appreciate if others verify as well, since the sidebar logic is pretty complex.

Resolves #17619