### PR TITLE
Allow joins on multiple fields in the notebook editor

### DIFF
--- a/frontend/src/metabase-lib/lib/queries/StructuredQuery.js
+++ b/frontend/src/metabase-lib/lib/queries/StructuredQuery.js
@@ -1124,11 +1124,19 @@ export default class StructuredQuery extends AtomicQuery {
       const keyForFk = (src, dst) =>
         src && dst ? `${src.id},${dst.id}` : null;
       const explicitJoins = new Set(
-        joins.map(join => {
-          const p = join.parentDimension();
-          const j = join.joinDimension();
-          return keyForFk(p && p.field(), j && j.field());
-        }),
+        _.flatten(
+          joins.map(join => {
+            const dimensionPairs = join.getDimensions();
+            return dimensionPairs.map(pair => {
+              // eslint-disable-next-line no-unused-vars
+              const [parentDimension, joinDimension] = pair;
+              return keyForFk(
+                parentDimension && parentDimension.field(),
+                joinDimension && joinDimension.field(),
+              );
+            });
+          }),
+        ),
       );
       explicitJoins.delete(null);
 

--- a/frontend/src/metabase-lib/lib/queries/StructuredQuery.js
+++ b/frontend/src/metabase-lib/lib/queries/StructuredQuery.js
@@ -1087,6 +1087,32 @@ export default class StructuredQuery extends AtomicQuery {
 
   // DIMENSION OPTIONS
 
+  _keyForFK(source, destination) {
+    if (source && destination) {
+      return `${source.id},${destination.id}`;
+    }
+    return null;
+  }
+
+  _getExplicitJoinsSet(joins) {
+    const joinDimensionPairs = joins.map(join => {
+      const dimensionPairs = join.getDimensions();
+      return dimensionPairs.map(pair => {
+        const [parentDimension, joinDimension] = pair;
+        return this._keyForFK(
+          parentDimension && parentDimension.field(),
+          joinDimension && joinDimension.field(),
+        );
+      });
+    });
+
+    const flatJoinDimensions = _.flatten(joinDimensionPairs);
+    const explicitJoins = new Set(flatJoinDimensions);
+    explicitJoins.delete(null);
+
+    return explicitJoins;
+  }
+
   // TODO Atte Keinänen 6/18/17: Refactor to dimensionOptions which takes a dimensionFilter
   // See aggregationFieldOptions for an explanation why that covers more use cases
   dimensionOptions(
@@ -1121,29 +1147,12 @@ export default class StructuredQuery extends AtomicQuery {
       }
 
       // de-duplicate explicit and implicit joined tables
-      const keyForFk = (src, dst) =>
-        src && dst ? `${src.id},${dst.id}` : null;
-      const explicitJoins = new Set(
-        _.flatten(
-          joins.map(join => {
-            const dimensionPairs = join.getDimensions();
-            return dimensionPairs.map(pair => {
-              // eslint-disable-next-line no-unused-vars
-              const [parentDimension, joinDimension] = pair;
-              return keyForFk(
-                parentDimension && parentDimension.field(),
-                joinDimension && joinDimension.field(),
-              );
-            });
-          }),
-        ),
-      );
-      explicitJoins.delete(null);
+      const explicitJoins = this._getExplicitJoinsSet(joins);
 
       const fkDimensions = this.dimensions().filter(dimensionIsFKReference);
       for (const dimension of fkDimensions) {
         const field = dimension.field();
-        if (field && explicitJoins.has(keyForFk(field, field.target))) {
+        if (field && explicitJoins.has(this._keyForFK(field, field.target))) {
           continue;
         }
 

--- a/frontend/src/metabase-lib/lib/queries/structured/Join.js
+++ b/frontend/src/metabase-lib/lib/queries/structured/Join.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars */
 import { MBQLObjectClause } from "./MBQLClause";
 import { t } from "ttag";
 
@@ -210,7 +209,7 @@ export default class Join extends MBQLObjectClause {
     if (this.isSingleConditionJoin()) {
       return [this.condition];
     }
-    const [_operator, ...conditions] = this.condition;
+    const [, ...conditions] = this.condition;
     return conditions;
   }
 
@@ -253,7 +252,7 @@ export default class Join extends MBQLObjectClause {
       return this.condition;
     }
     if (this.isMultipleConditionsJoin()) {
-      const [_operator, ...conditions] = this.condition;
+      const [, ...conditions] = this.condition;
       return conditions[index];
     }
     return null;
@@ -290,7 +289,7 @@ export default class Join extends MBQLObjectClause {
       // Adding 1 because the first element of a condition is an operator ("and")
       return i !== index + 1;
     });
-    const [_operator, ...conditions] = filteredCondition;
+    const [, ...conditions] = filteredCondition;
     const isSingleNewCondition = conditions.length === 1;
     if (isSingleNewCondition) {
       return this.setCondition(conditions[0]);
@@ -325,7 +324,7 @@ export default class Join extends MBQLObjectClause {
   }
 
   _getJoinDimensionFromCondition(condition) {
-    const [_operator, parentDimension, joinDimension] = condition;
+    const [, , joinDimension] = condition;
     const joinedQuery = this.joinedQuery();
     return (
       joinedQuery &&
@@ -335,7 +334,7 @@ export default class Join extends MBQLObjectClause {
   }
 
   _getJoinDimensionsFromMultipleConditions() {
-    const [_operator, ...conditions] = this.condition;
+    const [, ...conditions] = this.condition;
     return conditions.map(condition =>
       this._getJoinDimensionFromCondition(condition),
     );
@@ -348,12 +347,12 @@ export default class Join extends MBQLObjectClause {
   // TODO: should we rename them to lhsDimension/rhsDimension etc?
 
   _getParentDimensionFromCondition(condition) {
-    const [_operator, parentDimension] = condition;
+    const [, parentDimension] = condition;
     return parentDimension && this.query().parseFieldReference(parentDimension);
   }
 
   _getParentDimensionsFromMultipleConditions() {
-    const [_operator, ...conditions] = this.condition;
+    const [, ...conditions] = this.condition;
     return conditions.map(condition =>
       this._getParentDimensionFromCondition(condition),
     );
@@ -441,7 +440,7 @@ export default class Join extends MBQLObjectClause {
   getDimensions() {
     const conditions = this.getConditions();
     return conditions.map(condition => {
-      const [_operator, parentDimension, joinDimension] = condition;
+      const [, parentDimension, joinDimension] = condition;
       return [
         parentDimension
           ? this.query().parseFieldReference(parentDimension)

--- a/frontend/src/metabase-lib/lib/queries/structured/Join.js
+++ b/frontend/src/metabase-lib/lib/queries/structured/Join.js
@@ -276,6 +276,10 @@ export default class Join extends MBQLObjectClause {
     return this;
   }
 
+  _convertDimensionIntoMBQL(dimension: Dimension | ConcreteField) {
+    return dimension instanceof Dimension ? dimension.mbql() : dimension;
+  }
+
   // simplified "=" join condition helpers:
 
   // NOTE: parentDimension refers to the left-hand side of the join,

--- a/frontend/src/metabase-lib/lib/queries/structured/Join.js
+++ b/frontend/src/metabase-lib/lib/queries/structured/Join.js
@@ -377,8 +377,16 @@ export default class Join extends MBQLObjectClause {
       : this._getJoinDimensionsFromMultipleConditions();
   }
 
+  addEmptyDimensionsPair() {
+    if (!this.condition) {
+      return this.setCondition([]);
     }
+    if (this.isSingleConditionJoin()) {
+      return this.setCondition(["and", this.condition, []]);
+    } else {
+      return this.setCondition([...this.condition, []]);
     }
+  }
 
   setJoinDimension({ index = 0, dimension }) {
     const condition = this.getConditionByIndex(index);

--- a/frontend/src/metabase-lib/lib/queries/structured/Join.js
+++ b/frontend/src/metabase-lib/lib/queries/structured/Join.js
@@ -211,7 +211,6 @@ export default class Join extends MBQLObjectClause {
     );
   }
 
-  // CONDITION
   // CONDITIONS
 
   isSingleConditionJoin() {

--- a/frontend/src/metabase-lib/lib/queries/structured/Join.js
+++ b/frontend/src/metabase-lib/lib/queries/structured/Join.js
@@ -277,6 +277,24 @@ export default class Join extends MBQLObjectClause {
     conditions[index + 1] = condition;
     return this.setCondition(conditions);
   }
+
+  removeCondition(index) {
+    if (index == null || !this.getConditionByIndex(index)) {
+      return this;
+    }
+    if (this.isSingleConditionJoin()) {
+      return this.setCondition(undefined);
+    }
+    const filteredCondition = this.condition.filter((_, i) => {
+      // Adding 1 because the first element of a condition is an operator ("and")
+      return i !== index + 1;
+    });
+    const [_operator, ...conditions] = filteredCondition;
+    const isSingleNewCondition = conditions.length === 1;
+    if (isSingleNewCondition) {
+      return this.setCondition(conditions[0]);
+    }
+    return this.setCondition(filteredCondition);
   }
 
   setDefaultCondition() {

--- a/frontend/src/metabase-lib/lib/queries/structured/Join.js
+++ b/frontend/src/metabase-lib/lib/queries/structured/Join.js
@@ -202,6 +202,17 @@ export default class Join extends MBQLObjectClause {
     return this.setAlias(alias);
   }
 
+  getConditions() {
+    if (!this.condition) {
+      return [];
+    }
+    if (this.isSingleConditionJoin()) {
+      return [this.condition];
+    }
+    const [_operator, ...conditions] = this.condition;
+    return conditions;
+  }
+
   // STRATEGY
   setStrategy(strategy: JoinStrategy) {
     return this.set({ ...this, strategy });

--- a/frontend/src/metabase-lib/lib/queries/structured/Join.js
+++ b/frontend/src/metabase-lib/lib/queries/structured/Join.js
@@ -29,6 +29,8 @@ const JOIN_STRATEGY_OPTIONS = [
 ];
 
 const PARENT_DIMENSION_INDEX = 1;
+const JOIN_DIMENSION_INDEX = 2;
+
 export default class Join extends MBQLObjectClause {
   strategy: ?JoinStrategy;
   alias: ?JoinAlias;
@@ -319,21 +321,22 @@ export default class Join extends MBQLObjectClause {
       const joinedQuery = this.joinedQuery();
       return joinedQuery && joinedQuery.parseFieldReference(condition[2]);
     }
-  }
-  setJoinDimension(dimension: Dimension | ConcreteField): Join {
-    if (dimension instanceof Dimension) {
-      dimension = dimension.mbql();
     }
-    const parentDimension = this.parentDimension();
-    return this.setCondition([
+
+  setJoinDimension({ index = 0, dimension }) {
+    const condition = this.getConditionByIndex(index);
+    const newCondition = [
+      "=",
+      condition ? condition[PARENT_DIMENSION_INDEX] : null,
+      this._convertDimensionIntoMBQL(dimension),
+    ];
+    return this.setConditionByIndex({ index, condition: newCondition });
+  }
 
   setParentDimension({ index = 0, dimension }) {
     const condition = this.getConditionByIndex(index);
     const newCondition = [
       "=",
-      parentDimension instanceof Dimension ? parentDimension.mbql() : null,
-      dimension,
-    ]);
       this._convertDimensionIntoMBQL(dimension),
       condition ? condition[JOIN_DIMENSION_INDEX] : null,
     ];

--- a/frontend/src/metabase-lib/lib/queries/structured/Join.js
+++ b/frontend/src/metabase-lib/lib/queries/structured/Join.js
@@ -212,6 +212,18 @@ export default class Join extends MBQLObjectClause {
   }
 
   // CONDITION
+  // CONDITIONS
+
+  isSingleConditionJoin() {
+    const { condition } = this;
+    return Array.isArray(condition) && condition[0] === "=";
+  }
+
+  isMultipleConditionsJoin() {
+    const { condition } = this;
+    return Array.isArray(condition) && condition[0] === "and";
+  }
+
   setCondition(condition: JoinCondition): Join {
     return this.set({ ...this, condition });
   }

--- a/frontend/src/metabase-lib/lib/queries/structured/Join.js
+++ b/frontend/src/metabase-lib/lib/queries/structured/Join.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 import { MBQLObjectClause } from "./MBQLClause";
 import { t } from "ttag";
 

--- a/frontend/src/metabase-lib/lib/queries/structured/Join.js
+++ b/frontend/src/metabase-lib/lib/queries/structured/Join.js
@@ -28,6 +28,7 @@ const JOIN_STRATEGY_OPTIONS = [
   { value: "full-join", name: t`Full outer join`, icon: "join_full_outer" },
 ];
 
+const PARENT_DIMENSION_INDEX = 1;
 export default class Join extends MBQLObjectClause {
   strategy: ?JoinStrategy;
   alias: ?JoinAlias;
@@ -309,17 +310,7 @@ export default class Join extends MBQLObjectClause {
     }
     return new DimensionOptions(options);
   }
-  // TODO -- in what way is this setting a "parent dimension"? These names make no sense
-  setParentDimension(dimension: Dimension | ConcreteField): Join {
-    if (dimension instanceof Dimension) {
-      dimension = dimension.mbql();
     }
-    const joinDimension = this.joinDimension();
-    return this.setCondition([
-      "=",
-      dimension,
-      joinDimension instanceof Dimension ? joinDimension.mbql() : null,
-    ]);
   }
 
   joinDimension() {
@@ -335,11 +326,20 @@ export default class Join extends MBQLObjectClause {
     }
     const parentDimension = this.parentDimension();
     return this.setCondition([
+
+  setParentDimension({ index = 0, dimension }) {
+    const condition = this.getConditionByIndex(index);
+    const newCondition = [
       "=",
       parentDimension instanceof Dimension ? parentDimension.mbql() : null,
       dimension,
     ]);
+      this._convertDimensionIntoMBQL(dimension),
+      condition ? condition[JOIN_DIMENSION_INDEX] : null,
+    ];
+    return this.setConditionByIndex({ index, condition: newCondition });
   }
+
   joinDimensionOptions() {
     const dimensions = this.joinedDimensions();
     return new DimensionOptions({

--- a/frontend/src/metabase-lib/lib/queries/structured/Join.js
+++ b/frontend/src/metabase-lib/lib/queries/structured/Join.js
@@ -438,6 +438,19 @@ export default class Join extends MBQLObjectClause {
 
   // HELPERS
 
+  getDimensions() {
+    const conditions = this.getConditions();
+    return conditions.map(condition => {
+      const [_operator, parentDimension, joinDimension] = condition;
+      return [
+        parentDimension
+          ? this.query().parseFieldReference(parentDimension)
+          : null,
+        joinDimension ? this.query().parseFieldReference(joinDimension) : null,
+      ];
+    });
+  }
+
   joinedQuery() {
     const sourceTable = this.joinSourceTableId();
     const sourceQuery = this.joinSourceQuery();

--- a/frontend/src/metabase-lib/lib/queries/structured/Join.js
+++ b/frontend/src/metabase-lib/lib/queries/structured/Join.js
@@ -272,11 +272,11 @@ export default class Join extends MBQLObjectClause {
       } else {
         return this.setCondition(["and", this.condition, condition]);
       }
-    } else {
-      const conditions = [...this.condition];
-      conditions[index + 1] = condition;
-      return this.setCondition(conditions);
     }
+    const conditions = [...this.condition];
+    conditions[index + 1] = condition;
+    return this.setCondition(conditions);
+  }
   }
 
   setDefaultCondition() {

--- a/frontend/src/metabase-lib/lib/queries/structured/Join.js
+++ b/frontend/src/metabase-lib/lib/queries/structured/Join.js
@@ -344,14 +344,17 @@ export default class Join extends MBQLObjectClause {
     }
     return new DimensionOptions(options);
   }
+
+  joinDimensions() {
+    if (!this.condition) {
+      return [];
     }
+
+    return this.isSingleConditionJoin()
+      ? [this._getJoinDimensionFromCondition(this.condition)]
+      : this._getJoinDimensionsFromMultipleConditions();
   }
 
-  joinDimension() {
-    const { condition } = this;
-    if (Array.isArray(condition) && condition[0] === "=" && condition[2]) {
-      const joinedQuery = this.joinedQuery();
-      return joinedQuery && joinedQuery.parseFieldReference(condition[2]);
     }
     }
 

--- a/frontend/src/metabase-lib/lib/queries/structured/Join.js
+++ b/frontend/src/metabase-lib/lib/queries/structured/Join.js
@@ -224,9 +224,41 @@ export default class Join extends MBQLObjectClause {
     return Array.isArray(condition) && condition[0] === "and";
   }
 
+  getConditionByIndex(index) {
+    if (!this.condition) {
+      return null;
+    }
+    if (this.isSingleConditionJoin() && !index) {
+      return this.condition;
+    }
+    if (this.isMultipleConditionsJoin()) {
+      const [_operator, ...conditions] = this.condition;
+      return conditions[index];
+    }
+    return null;
+  }
+
   setCondition(condition: JoinCondition): Join {
     return this.set({ ...this, condition });
   }
+
+  setConditionByIndex({ index = 0, condition }): Join {
+    if (!this.condition) {
+      return this.setCondition(condition);
+    }
+    if (this.isSingleConditionJoin()) {
+      if (index === 0) {
+        return this.setCondition(condition);
+      } else {
+        return this.setCondition(["and", this.condition, condition]);
+      }
+    } else {
+      const conditions = [...this.condition];
+      conditions[index + 1] = condition;
+      return this.setCondition(conditions);
+    }
+  }
+
   setDefaultCondition() {
     const { dimensions } = this.parentDimensionOptions();
     // look for foreign keys linking the two tables

--- a/frontend/src/metabase-lib/lib/queries/structured/Join.js
+++ b/frontend/src/metabase-lib/lib/queries/structured/Join.js
@@ -486,10 +486,17 @@ export default class Join extends MBQLObjectClause {
   }
 
   isValid(): boolean {
-    return !!(
-      this.joinedTable() &&
-      this.parentDimension() &&
-      this.joinDimension()
+    if (!this.joinedTable()) {
+      return false;
+    }
+    const parentDimensions = this.parentDimensions();
+    const joinDimensions = this.joinDimensions();
+    return (
+      parentDimensions.length > 0 &&
+      joinDimensions.length > 0 &&
+      parentDimensions.every(Boolean) &&
+      joinDimensions.every(Boolean) &&
+      parentDimensions.length === joinDimensions.length
     );
   }
 }

--- a/frontend/src/metabase-lib/lib/queries/structured/Join.js
+++ b/frontend/src/metabase-lib/lib/queries/structured/Join.js
@@ -278,9 +278,13 @@ export default class Join extends MBQLObjectClause {
         return target && target.table && target.table.id === joinedTable.id;
       });
       if (fk) {
-        return this.setParentDimension(fk).setJoinDimension(
-          this.joinedDimension(fk.field().target.dimension()),
-        );
+        return this.setParentDimension({
+          index: 0,
+          dimension: fk,
+        }).setJoinDimension({
+          index: 0,
+          dimension: this.joinedDimension(fk.field().target.dimension()),
+        });
       }
     }
     return this;

--- a/frontend/src/metabase/components/Triggerable.jsx
+++ b/frontend/src/metabase/components/Triggerable.jsx
@@ -152,7 +152,9 @@ export default ComposedComponent =>
           aria-disabled={this.props.disabled}
           style={triggerStyle}
         >
-          {triggerElement}
+          {typeof triggerElement === "function"
+            ? triggerElement({ isTriggeredComponentOpen: isOpen })
+            : triggerElement}
           <ComposedComponent
             {...this.props}
             isOpen={isOpen}

--- a/frontend/src/metabase/query_builder/components/notebook/FieldsPickerIcon.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/FieldsPickerIcon.jsx
@@ -4,6 +4,11 @@ import { t } from "ttag";
 
 import Icon from "metabase/components/Icon";
 import Tooltip from "metabase/components/Tooltip";
+import { NotebookCell } from "./NotebookCell";
+
+const IconContainer = styled.div`
+  padding: ${NotebookCell.CONTAINER_PADDING};
+`;
 
 const StyledIcon = styled(Icon)`
   opacity: 0.5;
@@ -12,7 +17,9 @@ const StyledIcon = styled(Icon)`
 export function FieldsPickerIcon() {
   return (
     <Tooltip tooltip={<span>{t`Pick columns`}</span>}>
-      <StyledIcon name="table" size={14} />
+      <IconContainer>
+        <StyledIcon name="table" size={14} />
+      </IconContainer>
     </Tooltip>
   );
 }
@@ -21,6 +28,7 @@ export const FIELDS_PICKER_STYLES = {
   notebookItemContainer: {
     width: 37,
     height: 37,
+    padding: 0,
   },
   trigger: {
     marginTop: 1,

--- a/frontend/src/metabase/query_builder/components/notebook/FieldsPickerIcon.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/FieldsPickerIcon.jsx
@@ -7,7 +7,7 @@ import Icon from "metabase/components/Icon";
 import Tooltip from "metabase/components/Tooltip";
 import { NotebookCell } from "./NotebookCell";
 
-const IconContainer = styled.div`
+export const FieldPickerContentContainer = styled.div`
   padding: ${NotebookCell.CONTAINER_PADDING};
 `;
 
@@ -25,9 +25,9 @@ export function FieldsPickerIcon({ isTriggeredComponentOpen }) {
       tooltip={<span>{t`Pick columns`}</span>}
       isEnabled={!isTriggeredComponentOpen}
     >
-      <IconContainer>
+      <FieldPickerContentContainer>
         <StyledIcon name="table" size={14} />
-      </IconContainer>
+      </FieldPickerContentContainer>
     </Tooltip>
   );
 }
@@ -36,6 +36,9 @@ FieldsPickerIcon.propTypes = propTypes;
 
 export const FIELDS_PICKER_STYLES = {
   notebookItemContainer: {
+    padding: 0,
+  },
+  notebookRightItemContainer: {
     width: 37,
     height: 37,
     padding: 0,

--- a/frontend/src/metabase/query_builder/components/notebook/FieldsPickerIcon.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/FieldsPickerIcon.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import styled from "styled-components";
 import { t } from "ttag";
 
@@ -14,15 +15,24 @@ const StyledIcon = styled(Icon)`
   opacity: 0.5;
 `;
 
-export function FieldsPickerIcon() {
+const propTypes = {
+  isTriggeredComponentOpen: PropTypes.bool,
+};
+
+export function FieldsPickerIcon({ isTriggeredComponentOpen }) {
   return (
-    <Tooltip tooltip={<span>{t`Pick columns`}</span>}>
+    <Tooltip
+      tooltip={<span>{t`Pick columns`}</span>}
+      isEnabled={!isTriggeredComponentOpen}
+    >
       <IconContainer>
         <StyledIcon name="table" size={14} />
       </IconContainer>
     </Tooltip>
   );
 }
+
+FieldsPickerIcon.propTypes = propTypes;
 
 export const FIELDS_PICKER_STYLES = {
   notebookItemContainer: {

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookCell.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookCell.jsx
@@ -40,10 +40,12 @@ const NotebookCellItemContainer = styled(Flex).attrs({ align: "center" })`
   }
 `;
 
+const CONTAINER_PADDING = "10px";
+
 const NotebookCellItemContentContainer = styled.div`
   display: flex;
   align-items: center;
-  padding: 10px;
+  padding: ${CONTAINER_PADDING};
   background-color: ${props => (props.inactive ? "transparent" : props.color)};
 
   &:hover {
@@ -72,6 +74,10 @@ const NotebookCellItemContentContainer = styled.div`
 
   transition: background 300ms linear;
 `;
+
+NotebookCellItemContentContainer.defaultProps = {
+  hasPadding: true,
+};
 
 export function NotebookCellItem({
   inactive,
@@ -111,6 +117,7 @@ export function NotebookCellItem({
 }
 
 NotebookCellItem.displayName = "NotebookCellItem";
+NotebookCell.CONTAINER_PADDING = CONTAINER_PADDING;
 
 export const NotebookCellAdd = styled(NotebookCellItem).attrs({
   inactive: ({ initialAddText }) => initialAddText,

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookCell.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookCell.jsx
@@ -14,7 +14,7 @@ export const NotebookCell = styled(Flex).attrs({
 })`
   border-radius: 8px;
   background-color: ${props => alpha(props.color, 0.1)};
-  padding: 14px;
+  padding: ${props => props.padding || "14px"};
 `;
 
 NotebookCell.displayName = "NotebookCell";

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookCell.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookCell.jsx
@@ -75,13 +75,10 @@ const NotebookCellItemContentContainer = styled.div`
   transition: background 300ms linear;
 `;
 
-NotebookCellItemContentContainer.defaultProps = {
-  hasPadding: true,
-};
-
 export function NotebookCellItem({
   inactive,
   color,
+  containerStyle,
   right,
   rightContainerStyle,
   children,
@@ -98,6 +95,7 @@ export function NotebookCellItem({
         inactive={inactive}
         color={color}
         roundedCorners={mainContentRoundedCorners}
+        style={containerStyle}
       >
         {children}
       </NotebookCellItemContentContainer>

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx
@@ -162,6 +162,7 @@ export default class NotebookStep extends React.Component {
                   className="ml-auto cursor-pointer text-light text-medium-hover hover-child"
                   tooltip={t`Remove`}
                   onClick={onRemove}
+                  data-testid="remove-step"
                 />
               )}
             </Flex>

--- a/frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx
@@ -7,7 +7,11 @@ import { DatabaseSchemaAndTableDataSelector } from "metabase/query_builder/compo
 import { getDatabasesList } from "metabase/query_builder/selectors";
 
 import { NotebookCell, NotebookCellItem } from "../NotebookCell";
-import { FieldsPickerIcon, FIELDS_PICKER_STYLES } from "../FieldsPickerIcon";
+import {
+  FieldsPickerIcon,
+  FieldPickerContentContainer,
+  FIELDS_PICKER_STYLES,
+} from "../FieldsPickerIcon";
 import FieldsPicker from "./FieldsPicker";
 
 function DataStep({ color, query, updateQuery }) {
@@ -28,7 +32,8 @@ function DataStep({ color, query, updateQuery }) {
             />
           )
         }
-        rightContainerStyle={FIELDS_PICKER_STYLES.notebookItemContainer}
+        containerStyle={FIELDS_PICKER_STYLES.notebookItemContainer}
+        rightContainerStyle={FIELDS_PICKER_STYLES.notebookRightItemContainer}
         data-testid="data-step-cell"
       >
         <DatabaseSchemaAndTableDataSelector
@@ -44,7 +49,9 @@ function DataStep({ color, query, updateQuery }) {
           }
           isInitiallyOpen={!query.tableId()}
           triggerElement={
-            table ? table.displayName() : t`Pick your starting data`
+            <FieldPickerContentContainer>
+              {table ? table.displayName() : t`Pick your starting data`}
+            </FieldPickerContentContainer>
           }
         />
       </NotebookCellItem>

--- a/frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx
@@ -24,7 +24,7 @@ function DataStep({ color, query, updateQuery }) {
               query={query}
               updateQuery={updateQuery}
               triggerStyle={FIELDS_PICKER_STYLES.trigger}
-              triggerElement={<FieldsPickerIcon />}
+              triggerElement={FieldsPickerIcon}
             />
           )
         }

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -144,7 +144,7 @@ function JoinClause({ color, join, updateQuery, showRemove }) {
   if (join.index() === 0) {
     // first join's lhs is always the parent table
     lhsTable = join.parentTable();
-  } else if (join.parentDimension()) {
+  } else if (join.parentDimensions().length > 0) {
     // subsequent can be one of the previously joined tables
     // NOTE: `lhsDimension` would probably be a better name for `parentDimension`
     lhsTable = join.parentDimensions()[0].field().table;

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -213,6 +213,14 @@ function JoinClause({ color, join, updateQuery, showRemove }) {
           >
             {displayConditions.map((condition, index) => {
               const isLast = index === displayConditions.length - 1;
+
+              function removeDimensionPair() {
+                join
+                  .removeCondition(index)
+                  .parent()
+                  .update(updateQuery);
+              }
+
               return (
                 <JoinDimensionControlsContainer key={index}>
                   <JoinDimensionPicker
@@ -239,12 +247,14 @@ function JoinClause({ color, join, updateQuery, showRemove }) {
                     data-testid="join-dimension"
                   />
                   {isLast ? (
-                    join.isValid() && (
+                    join.isValid() ? (
                       <NotebookCellAdd
                         color={color}
                         className="cursor-pointer ml-auto"
                         onClick={addNewDimensionsPair}
                       />
+                    ) : (
+                      <RemoveJoinIcon onClick={removeDimensionPair} size={12} />
                     )
                   ) : (
                     <JoinConditionLabel>{t`on`}</JoinConditionLabel>

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -183,6 +183,9 @@ function JoinClause({ color, join, updateQuery, showRemove }) {
       .addEmptyDimensionsPair()
       .parent()
       .update(updateQuery);
+
+    // Need to wait, so a new dimensions pair renders
+    // and a corresponding ref is created, so we can reference it here
     setTimeout(() => {
       parentDimensionPickersRef.current[index]?.open();
     });

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -14,7 +14,11 @@ import {
   NotebookCellItem,
   NotebookCellAdd,
 } from "../NotebookCell";
-import { FieldsPickerIcon, FIELDS_PICKER_STYLES } from "../FieldsPickerIcon";
+import {
+  FieldsPickerIcon,
+  FieldPickerContentContainer,
+  FIELDS_PICKER_STYLES,
+} from "../FieldsPickerIcon";
 import FieldsPicker from "./FieldsPicker";
 import {
   DimensionContainer,
@@ -401,7 +405,8 @@ function JoinTablePicker({
           />
         )
       }
-      rightContainerStyle={FIELDS_PICKER_STYLES.notebookItemContainer}
+      containerStyle={FIELDS_PICKER_STYLES.notebookItemContainer}
+      rightContainerStyle={FIELDS_PICKER_STYLES.notebookRightItemContainer}
     >
       <DatabaseSchemaAndTableDataSelector
         hasTableSearch
@@ -413,7 +418,9 @@ function JoinTablePicker({
         setSourceTableFn={onChange}
         isInitiallyOpen={join.joinSourceTableId() == null}
         triggerElement={
-          joinedTable ? joinedTable.displayName() : t`Pick a table...`
+          <FieldPickerContentContainer>
+            {joinedTable ? joinedTable.displayName() : t`Pick a table...`}
+          </FieldPickerContentContainer>
         }
       />
     </NotebookCellItem>

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -295,7 +295,7 @@ function JoinClause({ color, join, updateQuery, showRemove }) {
                       onRemoveDimensionPair={removeDimensionPair}
                     />
                   ) : (
-                    <JoinConditionLabel>{t`on`}</JoinConditionLabel>
+                    <JoinConditionLabel>{t`and`}</JoinConditionLabel>
                   )}
                 </JoinDimensionControlsContainer>
               );

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -27,6 +27,7 @@ import {
   JoinTypeOptionRoot,
   JoinTypeIcon,
   JoinDimensionControlsContainer,
+  JoinWhereConditionLabelContainer,
   JoinWhereConditionLabel,
   JoinConditionLabel,
   RemoveJoinIcon,
@@ -189,7 +190,7 @@ function JoinClause({ color, join, updateQuery, showRemove }) {
 
   return (
     <JoinClauseRoot>
-      <NotebookCell color={color} flex={1}>
+      <NotebookCell color={color} flex={1} alignSelf="start">
         <NotebookCellItem color={color}>
           {lhsTable?.displayName() || t`Previous results`}
         </NotebookCellItem>
@@ -208,12 +209,15 @@ function JoinClause({ color, join, updateQuery, showRemove }) {
 
       {joinedTable && (
         <React.Fragment>
-          <JoinWhereConditionLabel />
+          <JoinWhereConditionLabelContainer>
+            <JoinWhereConditionLabel />
+          </JoinWhereConditionLabelContainer>
           <NotebookCell
             color={color}
             flex={1}
             flexDirection="column"
             align="start"
+            padding="8px"
           >
             {displayConditions.map((condition, index) => {
               const isLast = index === displayConditions.length - 1;

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -27,7 +27,7 @@ import {
   JoinTypeIcon,
   JoinDimensionControlsContainer,
   JoinWhereConditionLabel,
-  JoinOnConditionLabel,
+  JoinConditionLabel,
   RemoveJoinIcon,
 } from "./JoinStep.styled";
 
@@ -226,7 +226,7 @@ function JoinClause({ color, join, updateQuery, showRemove }) {
                     // ref={parentDimensionPickerRef}
                     data-testid="parent-dimension"
                   />
-                  <JoinOnConditionLabel />
+                  <JoinConditionLabel>=</JoinConditionLabel>
                   <JoinDimensionPicker
                     color={color}
                     query={query}
@@ -238,12 +238,16 @@ function JoinClause({ color, join, updateQuery, showRemove }) {
                     // ref={joinDimensionPickerRef}
                     data-testid="join-dimension"
                   />
-                  {isLast && join.isValid() && (
-                    <NotebookCellAdd
-                      color={color}
-                      className="cursor-pointer ml-auto"
-                      onClick={addNewDimensionsPair}
-                    />
+                  {isLast ? (
+                    join.isValid() && (
+                      <NotebookCellAdd
+                        color={color}
+                        className="cursor-pointer ml-auto"
+                        onClick={addNewDimensionsPair}
+                      />
+                    )
+                  ) : (
+                    <JoinConditionLabel>{t`on`}</JoinConditionLabel>
                   )}
                 </JoinDimensionControlsContainer>
               );

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -140,6 +140,8 @@ function JoinClause({ color, join, updateQuery, showRemove }) {
   const joinConditions = join.getConditions();
   const displayConditions = joinConditions.length > 0 ? joinConditions : [[]];
 
+  const hasAtLeastOneDimensionSelected = join.getDimensions().length > 0;
+
   let lhsTable;
   if (join.index() === 0) {
     // first join's lhs is always the parent table
@@ -219,7 +221,7 @@ function JoinClause({ color, join, updateQuery, showRemove }) {
             flex={1}
             flexDirection="column"
             align="start"
-            padding="8px"
+            padding={hasAtLeastOneDimensionSelected && "8px"}
           >
             {displayConditions.map((condition, index) => {
               const isFirst = index === 0;

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -166,7 +166,7 @@ function JoinClause({ color, join, updateQuery, showRemove }) {
       .setDefaultAlias()
       .parent()
       .update(updateQuery);
-    if (!join.joinDimensions[index]) {
+    if (!join.joinDimensions()[index]) {
       joinDimensionPickersRef.current[index]?.open();
     }
   }

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -282,23 +282,15 @@ function JoinClause({ color, join, updateQuery, showRemove }) {
                     data-testid="join-dimension"
                   />
                   {isLast ? (
-                    join.isValid() ? (
-                      <NotebookCellAdd
-                        color={color}
-                        className="cursor-pointer ml-auto"
-                        onClick={() => {
-                          addNewDimensionsPair(index + 1);
-                        }}
-                      />
-                    ) : (
-                      !isFirst && (
-                        <RemoveJoinIcon
-                          onClick={removeDimensionPair}
-                          size={12}
-                          data-testid="remove-dimension-pair"
-                        />
-                      )
-                    )
+                    <JoinDimensionsRightControl
+                      isValidJoin={join.isValid()}
+                      color={color}
+                      isFirst={isFirst}
+                      onAddNewDimensionPair={() =>
+                        addNewDimensionsPair(index + 1)
+                      }
+                      onRemoveDimensionPair={removeDimensionPair}
+                    />
                   ) : (
                     <JoinConditionLabel>{t`on`}</JoinConditionLabel>
                   )}
@@ -315,6 +307,44 @@ function JoinClause({ color, join, updateQuery, showRemove }) {
 }
 
 JoinClause.propTypes = joinClausePropTypes;
+
+const joinDimensionsRightControlPropTypes = {
+  isValidJoin: PropTypes.bool.isRequired,
+  isFirst: PropTypes.bool.isRequired,
+  color: PropTypes.string,
+  onAddNewDimensionPair: PropTypes.func.isRequired,
+  onRemoveDimensionPair: PropTypes.func.isRequired,
+};
+
+function JoinDimensionsRightControl({
+  isValidJoin,
+  isFirst,
+  color,
+  onAddNewDimensionPair,
+  onRemoveDimensionPair,
+}) {
+  if (isValidJoin) {
+    return (
+      <NotebookCellAdd
+        color={color}
+        className="cursor-pointer ml-auto"
+        onClick={onAddNewDimensionPair}
+      />
+    );
+  }
+  if (!isFirst) {
+    return (
+      <RemoveJoinIcon
+        onClick={onRemoveDimensionPair}
+        size={12}
+        data-testid="remove-dimension-pair"
+      />
+    );
+  }
+  return null;
+}
+
+JoinDimensionsRightControl.propTypes = joinDimensionsRightControlPropTypes;
 
 const joinTablePickerPropTypes = {
   join: PropTypes.object,

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -389,7 +389,7 @@ function JoinTablePicker({
           <JoinFieldsPicker
             join={join}
             updateQuery={updateQuery}
-            triggerElement={<FieldsPickerIcon />}
+            triggerElement={FieldsPickerIcon}
             triggerStyle={FIELDS_PICKER_STYLES.trigger}
           />
         )

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -506,6 +506,40 @@ function JoinTypeOption({ name, value, icon, selected, onChange }) {
 
 JoinTypeOption.propTypes = joinTypeOptionPropTypes;
 
+const joinDimensionCellItemPropTypes = {
+  dimension: PropTypes.object,
+  onRemove: PropTypes.func.isRequired,
+  color: PropTypes.string,
+  testID: PropTypes.string,
+};
+
+function getDimensionSourceName(dimension) {
+  return dimension
+    .query()
+    .table()
+    .displayName();
+}
+
+function JoinDimensionCellItem({ dimension, color, testID, onRemove }) {
+  return (
+    <NotebookCellItem color={color} inactive={!dimension} data-testid={testID}>
+      <DimensionContainer>
+        <div>
+          {dimension && (
+            <DimensionSourceName>
+              {getDimensionSourceName(dimension)}
+            </DimensionSourceName>
+          )}
+          {dimension?.displayName() || t`Pick a column...`}
+        </div>
+        {dimension && <RemoveDimensionIcon onClick={onRemove} />}
+      </DimensionContainer>
+    </NotebookCellItem>
+  );
+}
+
+JoinDimensionCellItem.propTypes = joinDimensionCellItemPropTypes;
+
 const joinDimensionPickerPropTypes = {
   dimension: PropTypes.object,
   onChange: PropTypes.func.isRequired,
@@ -527,37 +561,22 @@ class JoinDimensionPicker extends React.Component {
   render() {
     const { dimension, onChange, onRemove, options, query, color } = this.props;
     const testID = this.props["data-testid"] || "join-dimension";
+
+    function onRemoveDimension(e) {
+      e.stopPropagation(); // don't trigger picker popover
+      onRemove();
+    }
+
     return (
       <PopoverWithTrigger
         ref={ref => (this._popover = ref)}
         triggerElement={
-          <NotebookCellItem
+          <JoinDimensionCellItem
+            dimension={dimension}
             color={color}
-            inactive={!dimension}
-            data-testid={testID}
-          >
-            <DimensionContainer>
-              <div>
-                {dimension && (
-                  <DimensionSourceName>
-                    {dimension
-                      .query()
-                      .table()
-                      .displayName()}
-                  </DimensionSourceName>
-                )}
-                {dimension?.displayName() || t`Pick a column...`}
-              </div>
-              {dimension && (
-                <RemoveDimensionIcon
-                  onClick={e => {
-                    e.stopPropagation();
-                    onRemove();
-                  }}
-                />
-              )}
-            </DimensionContainer>
-          </NotebookCellItem>
+            testID={testID}
+            onRemove={onRemoveDimension}
+          />
         }
       >
         {({ onClose }) => (

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -118,8 +118,8 @@ const joinClausePropTypes = {
 };
 
 function JoinClause({ color, join, updateQuery, showRemove }) {
-  const joinDimensionPickerRef = useRef();
-  const parentDimensionPickerRef = useRef();
+  const joinDimensionPickersRef = useRef([]);
+  const parentDimensionPickersRef = useRef([]);
 
   const query = join.query();
   if (!query) {
@@ -149,7 +149,7 @@ function JoinClause({ color, join, updateQuery, showRemove }) {
   function onSourceTableSet(newJoin) {
     if (!newJoin.parentDimensions().length) {
       setTimeout(() => {
-        // parentDimensionPickerRef.current.open();
+        parentDimensionPickersRef.current[0]?.open();
       });
     }
   }
@@ -160,8 +160,8 @@ function JoinClause({ color, join, updateQuery, showRemove }) {
       .setDefaultAlias()
       .parent()
       .update(updateQuery);
-    if (!join.joinDimensions().length) {
-      // joinDimensionPickerRef.current.open();
+    if (!join.joinDimensions[index]) {
+      joinDimensionPickersRef.current[index]?.open();
     }
   }
 
@@ -172,11 +172,14 @@ function JoinClause({ color, join, updateQuery, showRemove }) {
       .update(updateQuery);
   }
 
-  function addNewDimensionsPair() {
+  function addNewDimensionsPair(index) {
     join
       .addEmptyDimensionsPair()
       .parent()
       .update(updateQuery);
+    setTimeout(() => {
+      parentDimensionPickersRef.current[index]?.open();
+    });
   }
 
   function removeJoin() {
@@ -235,7 +238,9 @@ function JoinClause({ color, join, updateQuery, showRemove }) {
                     onChange={fieldRef =>
                       onParentDimensionChange(index, fieldRef)
                     }
-                    // ref={parentDimensionPickerRef}
+                    ref={ref =>
+                      (parentDimensionPickersRef.current[index] = ref)
+                    }
                     data-testid="parent-dimension"
                   />
                   <JoinConditionLabel>=</JoinConditionLabel>
@@ -247,7 +252,7 @@ function JoinClause({ color, join, updateQuery, showRemove }) {
                     onChange={fieldRef =>
                       onJoinDimensionChange(index, fieldRef)
                     }
-                    // ref={joinDimensionPickerRef}
+                    ref={ref => (joinDimensionPickersRef.current[index] = ref)}
                     data-testid="join-dimension"
                   />
                   {isLast ? (
@@ -255,7 +260,9 @@ function JoinClause({ color, join, updateQuery, showRemove }) {
                       <NotebookCellAdd
                         color={color}
                         className="cursor-pointer ml-auto"
-                        onClick={addNewDimensionsPair}
+                        onClick={() => {
+                          addNewDimensionsPair(index + 1);
+                        }}
                       />
                     ) : (
                       <RemoveJoinIcon onClick={removeDimensionPair} size={12} />

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -149,7 +149,7 @@ function JoinClause({ color, join, updateQuery, showRemove }) {
   function onSourceTableSet(newJoin) {
     if (!newJoin.parentDimensions().length) {
       setTimeout(() => {
-        parentDimensionPickerRef.current.open();
+        // parentDimensionPickerRef.current.open();
       });
     }
   }
@@ -161,7 +161,7 @@ function JoinClause({ color, join, updateQuery, showRemove }) {
       .parent()
       .update(updateQuery);
     if (!join.joinDimensions().length) {
-      joinDimensionPickerRef.current.open();
+      // joinDimensionPickerRef.current.open();
     }
   }
 

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -25,6 +25,7 @@ import {
   JoinTypeSelectRoot,
   JoinTypeOptionRoot,
   JoinTypeIcon,
+  JoinDimensionControlsContainer,
   JoinWhereConditionLabel,
   JoinOnConditionLabel,
   RemoveJoinIcon,
@@ -197,10 +198,15 @@ function JoinClause({ color, join, updateQuery, showRemove }) {
       {joinedTable && (
         <React.Fragment>
           <JoinWhereConditionLabel />
-          <NotebookCell color={color} flex={1}>
+          <NotebookCell
+            color={color}
+            flex={1}
+            flexDirection="column"
+            align="start"
+          >
             {displayConditions.map((condition, index) => {
               return (
-                <React.Fragment key={index}>
+                <JoinDimensionControlsContainer key={index}>
                   <JoinDimensionPicker
                     color={color}
                     query={query}
@@ -235,6 +241,7 @@ function JoinClause({ color, join, updateQuery, showRemove }) {
                     }}
                   />
                 </React.Fragment>
+                </JoinDimensionControlsContainer>
               );
             })}
           </NotebookCell>

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -146,7 +146,7 @@ function JoinClause({ color, join, updateQuery, showRemove }) {
   }
 
   function onSourceTableSet(newJoin) {
-    if (!newJoin.parentDimension()) {
+    if (!newJoin.parentDimensions().length) {
       setTimeout(() => {
         parentDimensionPickerRef.current.open();
       });
@@ -159,7 +159,7 @@ function JoinClause({ color, join, updateQuery, showRemove }) {
       .setDefaultAlias()
       .parent()
       .update(updateQuery);
-    if (!join.joinDimension()) {
+    if (!join.joinDimensions().length) {
       joinDimensionPickerRef.current.open();
     }
   }

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -33,6 +33,7 @@ import {
   JoinConditionLabel,
   RemoveDimensionIcon,
   RemoveJoinIcon,
+  Row,
 } from "./JoinStep.styled";
 
 const stepShape = {
@@ -257,46 +258,52 @@ function JoinClause({ color, join, updateQuery, showRemove }) {
                   isFirst={isFirst}
                   data-testid={`join-dimensions-pair-${index}`}
                 >
-                  <JoinDimensionPicker
-                    color={color}
-                    query={query}
-                    dimension={parentDimensions[index]}
-                    options={parentDimensionOptions}
-                    onChange={fieldRef =>
-                      onParentDimensionChange(index, fieldRef)
-                    }
-                    onRemove={removeParentDimension}
-                    ref={ref =>
-                      (parentDimensionPickersRef.current[index] = ref)
-                    }
-                    data-testid="parent-dimension"
-                  />
-                  <JoinConditionLabel>=</JoinConditionLabel>
-                  <JoinDimensionPicker
-                    color={color}
-                    query={query}
-                    dimension={joinDimensions[index]}
-                    options={joinDimensionOptions}
-                    onChange={fieldRef =>
-                      onJoinDimensionChange(index, fieldRef)
-                    }
-                    onRemove={removeJoinDimension}
-                    ref={ref => (joinDimensionPickersRef.current[index] = ref)}
-                    data-testid="join-dimension"
-                  />
-                  {isLast ? (
-                    <JoinDimensionsRightControl
-                      isValidJoin={join.isValid()}
+                  <Row>
+                    <JoinDimensionPicker
                       color={color}
-                      isFirst={isFirst}
-                      onAddNewDimensionPair={() =>
-                        addNewDimensionsPair(index + 1)
+                      query={query}
+                      dimension={parentDimensions[index]}
+                      options={parentDimensionOptions}
+                      onChange={fieldRef =>
+                        onParentDimensionChange(index, fieldRef)
                       }
-                      onRemoveDimensionPair={removeDimensionPair}
+                      onRemove={removeParentDimension}
+                      ref={ref =>
+                        (parentDimensionPickersRef.current[index] = ref)
+                      }
+                      data-testid="parent-dimension"
                     />
-                  ) : (
-                    <JoinConditionLabel>{t`and`}</JoinConditionLabel>
-                  )}
+                    <JoinConditionLabel>=</JoinConditionLabel>
+                  </Row>
+                  <Row>
+                    <JoinDimensionPicker
+                      color={color}
+                      query={query}
+                      dimension={joinDimensions[index]}
+                      options={joinDimensionOptions}
+                      onChange={fieldRef =>
+                        onJoinDimensionChange(index, fieldRef)
+                      }
+                      onRemove={removeJoinDimension}
+                      ref={ref =>
+                        (joinDimensionPickersRef.current[index] = ref)
+                      }
+                      data-testid="join-dimension"
+                    />
+                    {isLast ? (
+                      <JoinDimensionsRightControl
+                        isValidJoin={join.isValid()}
+                        color={color}
+                        isFirst={isFirst}
+                        onAddNewDimensionPair={() =>
+                          addNewDimensionsPair(index + 1)
+                        }
+                        onRemoveDimensionPair={removeDimensionPair}
+                      />
+                    ) : (
+                      <JoinConditionLabel>{t`and`}</JoinConditionLabel>
+                    )}
+                  </Row>
                 </JoinDimensionControlsContainer>
               );
             })}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -172,6 +172,13 @@ function JoinClause({ color, join, updateQuery, showRemove }) {
       .update(updateQuery);
   }
 
+  function addNewDimensionsPair() {
+    join
+      .addEmptyDimensionsPair()
+      .parent()
+      .update(updateQuery);
+  }
+
   function removeJoin() {
     join.remove().update(updateQuery);
   }
@@ -205,6 +212,7 @@ function JoinClause({ color, join, updateQuery, showRemove }) {
             align="start"
           >
             {displayConditions.map((condition, index) => {
+              const isLast = index === displayConditions.length - 1;
               return (
                 <JoinDimensionControlsContainer key={index}>
                   <JoinDimensionPicker
@@ -230,17 +238,13 @@ function JoinClause({ color, join, updateQuery, showRemove }) {
                     // ref={joinDimensionPickerRef}
                     data-testid="join-dimension"
                   />
-                  <NotebookCellAdd
-                    color={color}
-                    className="cursor-pointer ml-auto"
-                    onClick={() => {
-                      join
-                        .addEmptyDimensionsPair()
-                        .parent()
-                        .update(updateQuery);
-                    }}
-                  />
-                </React.Fragment>
+                  {isLast && join.isValid() && (
+                    <NotebookCellAdd
+                      color={color}
+                      className="cursor-pointer ml-auto"
+                      onClick={addNewDimensionsPair}
+                    />
+                  )}
                 </JoinDimensionControlsContainer>
               );
             })}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -424,7 +424,7 @@ function JoinTypeOption({ name, value, icon, selected, onChange }) {
 JoinTypeOption.propTypes = joinTypeOptionPropTypes;
 
 const joinDimensionPickerPropTypes = {
-  dimension: PropTypes.object.isRequired,
+  dimension: PropTypes.object,
   onChange: PropTypes.func.isRequired,
   options: PropTypes.shape({
     count: PropTypes.number.isRequired,

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -222,7 +222,11 @@ function JoinClause({ color, join, updateQuery, showRemove }) {
               }
 
               return (
-                <JoinDimensionControlsContainer key={index}>
+                <JoinDimensionControlsContainer
+                  key={index}
+                  isFirst={index === 0}
+                  data-testid={`join-dimensions-pair-${index}`}
+                >
                   <JoinDimensionPicker
                     color={color}
                     query={query}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -17,6 +17,7 @@ import {
 import { FieldsPickerIcon, FIELDS_PICKER_STYLES } from "../FieldsPickerIcon";
 import FieldsPicker from "./FieldsPicker";
 import {
+  DimensionSourceName,
   JoinStepRoot,
   JoinClausesContainer,
   JoinClauseRoot,
@@ -473,7 +474,17 @@ class JoinDimensionPicker extends React.Component {
             inactive={!dimension}
             data-testid={testID}
           >
-            {dimension ? dimension.displayName() : `Pick a column...`}
+            <div>
+              {dimension && (
+                <DimensionSourceName>
+                  {dimension
+                    .query()
+                    .table()
+                    .displayName()}
+                </DimensionSourceName>
+              )}
+              {dimension?.displayName() || t`Pick a column...`}
+            </div>
           </NotebookCellItem>
         }
       >

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.styled.jsx
@@ -72,7 +72,7 @@ export const JoinWhereConditionLabel = styled.span.attrs({ children: "on" })`
   margin: 0 ${space(2)};
 `;
 
-export const JoinOnConditionLabel = styled.span.attrs({ children: "=" })`
+export const JoinConditionLabel = styled.span`
   font-size: 20;
   font-weight: bold;
   color: ${color("text-medium")};

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.styled.jsx
@@ -1,7 +1,12 @@
 import styled from "styled-components";
 import { color } from "metabase/lib/colors";
-import { space } from "metabase/styled-components/theme";
+import { space, breakpointMaxMedium } from "metabase/styled-components/theme";
 import Icon from "metabase/components/Icon";
+
+export const Row = styled.div`
+  display: flex;
+  align-items: center;
+`;
 
 export const JoinStepRoot = styled.div`
   display: flex;
@@ -66,6 +71,11 @@ export const JoinDimensionControlsContainer = styled.div`
   align-items: center;
 
   margin-top: ${props => (props.isFirst ? 0 : space(1))};
+
+  ${breakpointMaxMedium} {
+    flex-direction: column;
+    align-items: flex-start;
+  }
 `;
 
 export const JoinWhereConditionLabelContainer = styled.div`

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.styled.jsx
@@ -62,6 +62,7 @@ export const JoinTypeIcon = styled(Icon).attrs({ size: 24 })`
 
 export const JoinDimensionControlsContainer = styled.div`
   display: flex;
+  flex: 1;
   align-items: center;
 
   margin-top: ${props => (props.isFirst ? 0 : space(1))};

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.styled.jsx
@@ -82,6 +82,13 @@ export const JoinConditionLabel = styled.span`
   margin-right: 6px;
 `;
 
+export const DimensionSourceName = styled.div`
+  display: block;
+  font-size: 11px;
+  color: ${color("text-white")};
+  opacity: 0.65;
+`;
+
 export const RemoveJoinIcon = styled(Icon).attrs({ name: "close", size: 18 })`
   cursor: pointer;
   color: ${color("text-light")};

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.styled.jsx
@@ -20,7 +20,6 @@ export const JoinClauseContainer = styled.div`
 
 export const JoinClauseRoot = styled.div`
   display: flex;
-  align-items: baseline;
   margin-bottom: ${props => (props.isLast ? 0 : "2px")};
 `;
 
@@ -66,6 +65,13 @@ export const JoinDimensionControlsContainer = styled.div`
   align-items: center;
 
   margin-top: ${props => (props.isFirst ? 0 : space(1))};
+`;
+
+export const JoinWhereConditionLabelContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 60px;
 `;
 
 export const JoinWhereConditionLabel = styled.span.attrs({ children: "on" })`

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.styled.jsx
@@ -64,6 +64,8 @@ export const JoinTypeIcon = styled(Icon).attrs({ size: 24 })`
 export const JoinDimensionControlsContainer = styled.div`
   display: flex;
   align-items: center;
+
+  margin-top: ${props => (props.isFirst ? 0 : space(1))};
 `;
 
 export const JoinWhereConditionLabel = styled.span.attrs({ children: "on" })`

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.styled.jsx
@@ -61,6 +61,11 @@ export const JoinTypeIcon = styled(Icon).attrs({ size: 24 })`
   color: ${props => (props.isSelected ? color("text-white") : color("brand"))};
 `;
 
+export const JoinDimensionControlsContainer = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
 export const JoinWhereConditionLabel = styled.span.attrs({ children: "on" })`
   color: ${color("brand")};
   font-weight: bold;

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.styled.jsx
@@ -88,11 +88,23 @@ export const JoinConditionLabel = styled.span`
   margin-right: 6px;
 `;
 
+export const DimensionContainer = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
 export const DimensionSourceName = styled.div`
   display: block;
   font-size: 11px;
   color: ${color("text-white")};
   opacity: 0.65;
+`;
+
+export const RemoveDimensionIcon = styled(Icon).attrs({ name: "close" })`
+  cursor: pointer;
+  color: ${color("text-white")};
+  opacity: 0.65;
+  margin-left: 12px;
 `;
 
 export const RemoveJoinIcon = styled(Icon).attrs({ name: "close", size: 18 })`

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.styled.jsx
@@ -20,7 +20,7 @@ export const JoinClauseContainer = styled.div`
 
 export const JoinClauseRoot = styled.div`
   display: flex;
-  align-items: center;
+  align-items: baseline;
   margin-bottom: ${props => (props.isLast ? 0 : "2px")};
 `;
 

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.unit.spec.js
@@ -286,6 +286,14 @@ describe("Notebook Editor > Join Step", () => {
   });
 
   describe("joins on multiple fields", () => {
+    it("does not display a new dimensions pair control until first pair is valid", async () => {
+      setup();
+      await selectTable(/Reviews/i);
+
+      expect(screen.queryAllByText("Pick a column...")).toHaveLength(2);
+      expect(screen.queryByLabelText("add icon")).toBe(null);
+    });
+
     it("can add a new dimension pair", async () => {
       setup();
       await selectTable(/Products/i);
@@ -293,6 +301,15 @@ describe("Notebook Editor > Join Step", () => {
       fireEvent.click(screen.queryByLabelText("add icon"));
 
       expect(screen.queryAllByText("Pick a column...")).toHaveLength(2);
+    });
+
+    it("does not display a new dimensions pair control for a new empty pair", async () => {
+      setup();
+      await selectTable(/Products/i);
+
+      fireEvent.click(screen.queryByLabelText("add icon"));
+
+      expect(screen.queryByLabelText("add icon")).toBe(null);
     });
   });
 });

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.unit.spec.js
@@ -19,7 +19,8 @@ import {
 } from "__support__/sample_dataset_fixture";
 import JoinStep from "./JoinStep";
 
-jest.setTimeout(10000);
+// Workaround for timeouts on CI
+jest.setTimeout(15000);
 
 describe("Notebook Editor > Join Step", () => {
   const TEST_QUERY = {

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.unit.spec.js
@@ -311,5 +311,19 @@ describe("Notebook Editor > Join Step", () => {
 
       expect(screen.queryByLabelText("add icon")).toBe(null);
     });
+
+    it("can remove an empty dimension pair", async () => {
+      setup();
+      await selectTable(/Products/i);
+      fireEvent.click(screen.queryByLabelText("add icon"));
+
+      fireEvent.click(screen.queryByLabelText("close icon"));
+
+      expect(screen.queryAllByText("Pick a column...")).toEqual([]);
+      expect(screen.getByTestId("parent-dimension")).toHaveTextContent(
+        /Product ID/i,
+      );
+      expect(screen.getByTestId("join-dimension")).toHaveTextContent(/ID/i);
+    });
   });
 });

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.unit.spec.js
@@ -8,6 +8,7 @@ import {
   within,
   waitForElementToBeRemoved,
 } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import xhrMock from "xhr-mock";
 import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
 import { getStore } from "__support__/entities-store";
@@ -362,6 +363,25 @@ describe("Notebook Editor > Join Step", () => {
     await setup({ joinTable: "Reviews" });
 
     expect(screen.queryAllByLabelText("close icon")).toHaveLength(0);
+  });
+
+  it("shows the fields picker tooltip on control hover", async () => {
+    await setup({ joinTable: "Products" });
+
+    userEvent.hover(screen.getByLabelText("table icon"));
+
+    const tooltip = screen.queryByRole("tooltip");
+    expect(tooltip).toBeInTheDocument();
+    expect(tooltip).toHaveTextContent("Pick columns");
+  });
+
+  it("hides the fields picker tooltip when the picker opens", async () => {
+    await setup({ joinTable: "Products" });
+
+    userEvent.click(screen.getByLabelText("table icon"));
+    userEvent.hover(screen.getByLabelText("table icon"));
+
+    expect(screen.queryByRole("tooltip")).toBe(null);
   });
 
   describe("joins on multiple fields", () => {

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.unit.spec.js
@@ -298,6 +298,30 @@ describe("Notebook Editor > Join Step", () => {
       expect(screen.queryAllByText("Pick a column...")).toHaveLength(2);
     });
 
+    it("automatically opens a parent dimension picker for new fields pair", async () => {
+      await setup({ joinTable: "Products" });
+
+      fireEvent.click(screen.queryByLabelText("add icon"));
+
+      const picker = await screen.findByRole("rowgroup");
+      expect(picker).toBeInTheDocument();
+      expect(picker).toBeVisible();
+      expect(within(picker).queryByText("Order")).toBeInTheDocument();
+    });
+
+    it("automatically opens a join dimension picker for new fields pair", async () => {
+      await setup({ joinTable: "Products" });
+
+      fireEvent.click(screen.queryByLabelText("add icon"));
+      let picker = await screen.findByRole("rowgroup");
+      fireEvent.click(within(picker).queryByText("Created At"));
+
+      picker = await screen.findByRole("rowgroup");
+      expect(picker).toBeInTheDocument();
+      expect(picker).toBeVisible();
+      expect(within(picker).queryByText("Product")).toBeInTheDocument();
+    });
+
     it("does not display a new dimensions pair control for a new empty pair", async () => {
       await setup({ joinTable: "Products" });
 

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.unit.spec.js
@@ -284,4 +284,15 @@ describe("Notebook Editor > Join Step", () => {
       }),
     );
   });
+
+  describe("joins on multiple fields", () => {
+    it("can add a new dimension pair", async () => {
+      setup();
+      await selectTable(/Products/i);
+
+      fireEvent.click(screen.queryByLabelText("add icon"));
+
+      expect(screen.queryAllByText("Pick a column...")).toHaveLength(2);
+    });
+  });
 });

--- a/frontend/test/metabase-lib/lib/queries/StructuredQuery-joins.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/StructuredQuery-joins.unit.spec.js
@@ -16,7 +16,7 @@ describe("StructuredQuery nesting", () => {
       const j = ORDERS.query()
         .join(EXAMPLE_JOIN)
         .joins()[0];
-      expect(j.parentDimension().mbql()).toEqual([
+      expect(j.parentDimensions()[0].mbql()).toEqual([
         "field",
         ORDERS.PRODUCT_ID.id,
         null,
@@ -28,7 +28,7 @@ describe("StructuredQuery nesting", () => {
       const j = ORDERS.query()
         .join(EXAMPLE_JOIN)
         .joins()[0];
-      expect(j.joinDimension().mbql()).toEqual([
+      expect(j.joinDimensions()[0].mbql()).toEqual([
         "field",
         PRODUCTS.ID.id,
         { "join-alias": "join0" },

--- a/frontend/test/metabase-lib/lib/queries/structured/Join.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/structured/Join.unit.spec.js
@@ -1,89 +1,105 @@
 import { ORDERS, PRODUCTS, REVIEWS } from "__support__/sample_dataset_fixture";
 import Join from "metabase-lib/lib/queries/structured/Join";
 
+function getOrdersJoinQuery({
+  alias = "Products",
+  condition,
+  sourceTable = PRODUCTS.id,
+} = {}) {
+  return ORDERS.query().join({
+    alias,
+    condition,
+    "source-table": sourceTable,
+  });
+}
+
+function getJoin({ query = getOrdersJoinQuery() } = {}) {
+  return query.joins()[0];
+}
+
+const ORDERS_PRODUCT_ID_FIELD_REF = ["field", ORDERS.PRODUCT_ID.id, null];
+
+const PRODUCTS_ID_FIELD_REF = [
+  "field",
+  PRODUCTS.ID.id,
+  { "join-alias": "Products" },
+];
+
+const ORDERS_PRODUCT_JOIN_CONDITION = [
+  "=",
+  ORDERS_PRODUCT_ID_FIELD_REF,
+  PRODUCTS_ID_FIELD_REF,
+];
+
+const REVIEWS_PRODUCT_ID_FIELD_REF = [
+  "field",
+  REVIEWS.PRODUCT_ID.id,
+  { "join-alias": "Reviews - Products" },
+];
+
+const ORDERS_REVIEWS_JOIN_CONDITION = [
+  "=",
+  ORDERS_PRODUCT_ID_FIELD_REF,
+  REVIEWS_PRODUCT_ID_FIELD_REF,
+];
+
 describe("Join", () => {
   describe("setJoinSourceTableId", () => {
     it("should pick an alias based on the source table name by default", () => {
-      const q = ORDERS.query();
-      const j = new Join({}, 0, q).setJoinSourceTableId(PRODUCTS.id);
-      expect(j.alias).toEqual("Products");
+      const query = ORDERS.query();
+      const join = new Join({}, 0, query).setJoinSourceTableId(PRODUCTS.id);
+      expect(join.alias).toEqual("Products");
     });
 
     it("should deduplicate aliases", () => {
-      const q = ORDERS.query().join({
-        alias: "Products",
-        "source-table": PRODUCTS.id,
-      });
-      const j = new Join({}, 1, q).setJoinSourceTableId(PRODUCTS.id);
-      expect(j.alias).toEqual("Products_2");
+      const join = new Join({}, 1, getOrdersJoinQuery()).setJoinSourceTableId(
+        PRODUCTS.id,
+      );
+      expect(join.alias).toEqual("Products_2");
     });
   });
 
   describe("setDefaultCondition", () => {
     it("should set default condition to be fk relationship", () => {
-      const q = ORDERS.query().join({
-        alias: "x",
+      let join = getJoin();
+
+      join = join.setDefaultCondition();
+
+      expect(join).toEqual({
+        alias: "Products",
+        condition: ORDERS_PRODUCT_JOIN_CONDITION,
         "source-table": PRODUCTS.id,
-      });
-      const j = q.joins()[0].setDefaultCondition();
-      expect(j).toEqual({
-        alias: "x",
-        condition: [
-          "=",
-          ["field", 3, null],
-          ["field", 24, { "join-alias": "x" }],
-        ],
-        "source-table": 3,
       });
     });
   });
 
   describe("setDefaultAlias", () => {
     it("should set default alias to be table + field name and update join condition", () => {
-      const q = ORDERS.query().join({
-        alias: "x",
-        condition: [
-          "=",
-          ["field", ORDERS.PRODUCT_ID.id, null],
-          ["field", REVIEWS.PRODUCT_ID.id, { "join-alias": "x" }],
-        ],
-        "source-table": REVIEWS.id,
+      let join = getJoin({
+        query: getOrdersJoinQuery({
+          alias: "x",
+          condition: ORDERS_REVIEWS_JOIN_CONDITION,
+          sourceTable: REVIEWS.id,
+        }),
       });
-      const j = q
-        .joins()[0]
-        .setDefaultCondition()
-        .setDefaultAlias();
-      expect(j).toEqual({
+
+      join = join.setDefaultCondition().setDefaultAlias();
+
+      expect(join).toEqual({
         alias: "Reviews - Product",
-        condition: [
-          "=",
-          ["field", ORDERS.PRODUCT_ID.id, null],
-          [
-            "field",
-            REVIEWS.PRODUCT_ID.id,
-            { "join-alias": "Reviews - Product" },
-          ],
-        ],
+        condition: ORDERS_REVIEWS_JOIN_CONDITION,
         "source-table": REVIEWS.id,
       });
     });
 
     it("should set default alias to be table name only if it is similar to field name", () => {
-      const q = ORDERS.query().join({
-        alias: "x",
-        "source-table": PRODUCTS.id,
-      });
-      const j = q
-        .joins()[0]
-        .setDefaultCondition()
-        .setDefaultAlias();
-      expect(j).toEqual({
+      let join = getJoin({ query: getOrdersJoinQuery({ alias: "x" }) });
+
+      join = join.setDefaultCondition().setDefaultAlias();
+
+      expect(join).toEqual({
         alias: "Products",
-        condition: [
-          "=",
-          ["field", ORDERS.PRODUCT_ID.id, null],
-          ["field", PRODUCTS.ID.id, { "join-alias": "Products" }],
-        ],
+        condition: ORDERS_PRODUCT_JOIN_CONDITION,
         "source-table": PRODUCTS.id,
       });
     });

--- a/frontend/test/metabase-lib/lib/queries/structured/Join.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/structured/Join.unit.spec.js
@@ -201,5 +201,85 @@ describe("Join", () => {
       });
     });
   });
+
+  describe("setJoinDimension", () => {
+    it("creates a condition if not present", () => {
+      let join = getJoin();
+
+      join = join.setJoinDimension({
+        dimension: PRODUCTS_ID_FIELD_REF,
+      });
+
+      expect(join).toEqual({
+        alias: "Products",
+        condition: ["=", null, PRODUCTS_ID_FIELD_REF],
+        "source-table": PRODUCTS.id,
+      });
+    });
+
+    it("sets a dimension for existing condition", () => {
+      let join = getJoin({
+        query: getOrdersJoinQuery({
+          condition: ["=", ORDERS_PRODUCT_ID_FIELD_REF, null],
+        }),
+      });
+
+      join = join.setJoinDimension({
+        dimension: PRODUCTS_ID_JOIN_FIELD_REF,
+      });
+
+      expect(join).toEqual({
+        alias: "Products",
+        condition: ORDERS_PRODUCT_JOIN_CONDITION,
+        "source-table": PRODUCTS.id,
+      });
+    });
+
+    it("sets a dimension for multi-dimension condition by index", () => {
+      let join = getJoin({
+        query: getOrdersJoinQuery({
+          condition: [
+            "and",
+            ORDERS_PRODUCT_JOIN_CONDITION,
+            ["=", ORDERS_CREATED_AT_FIELD_REF, null],
+          ],
+        }),
+      });
+
+      join = join.setJoinDimension({
+        index: 1,
+        dimension: PRODUCTS_CREATED_AT_FIELD_REF,
+      });
+
+      expect(join).toEqual({
+        alias: "Products",
+        condition: ORDERS_PRODUCT_MULTI_FIELD_JOIN_CONDITION,
+        "source-table": PRODUCTS.id,
+      });
+    });
+
+    it("turns into multi-dimension join if not existing condition index provided", () => {
+      let join = getJoin({
+        query: getOrdersJoinQuery({
+          condition: ORDERS_PRODUCT_JOIN_CONDITION,
+        }),
+      });
+
+      join = join.setJoinDimension({
+        index: 1,
+        dimension: PRODUCTS_CREATED_AT_FIELD_REF,
+      });
+
+      expect(join).toEqual({
+        alias: "Products",
+        condition: [
+          "and",
+          ORDERS_PRODUCT_JOIN_CONDITION,
+          ["=", null, PRODUCTS_CREATED_AT_FIELD_REF],
+        ],
+        "source-table": PRODUCTS.id,
+      });
+    });
+  });
   });
 });

--- a/frontend/test/metabase-lib/lib/queries/structured/Join.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/structured/Join.unit.spec.js
@@ -299,6 +299,34 @@ describe("Join", () => {
     });
   });
 
+  describe("getConditions", () => {
+    it("should return empty array for a join without condition", () => {
+      const join = getJoin();
+      expect(join.getConditions()).toEqual([]);
+    });
+
+    it("should return condition for one-fields pair join", () => {
+      const join = getJoin({
+        query: getOrdersJoinQuery({
+          condition: ORDERS_PRODUCT_JOIN_CONDITION,
+        }),
+      });
+      expect(join.getConditions()).toEqual([ORDERS_PRODUCT_JOIN_CONDITION]);
+    });
+
+    it("should return condition for multi-fields join", () => {
+      const join = getJoin({
+        query: getOrdersJoinQuery({
+          condition: ORDERS_PRODUCT_MULTI_FIELD_JOIN_CONDITION,
+        }),
+      });
+      expect(join.getConditions()).toEqual([
+        ORDERS_PRODUCT_JOIN_CONDITION,
+        ORDERS_PRODUCT_JOIN_CONDITION_BY_CREATED_AT,
+      ]);
+    });
+  });
+
   describe("isValid", () => {
     it("should return true for complete one-fields pair join", () => {
       const join = getJoin({

--- a/frontend/test/metabase-lib/lib/queries/structured/Join.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/structured/Join.unit.spec.js
@@ -1,5 +1,4 @@
 import { ORDERS, PRODUCTS, REVIEWS } from "__support__/sample_dataset_fixture";
-
 import Join from "metabase-lib/lib/queries/structured/Join";
 
 describe("Join", () => {
@@ -9,6 +8,7 @@ describe("Join", () => {
       const j = new Join({}, 0, q).setJoinSourceTableId(PRODUCTS.id);
       expect(j.alias).toEqual("Products");
     });
+
     it("should deduplicate aliases", () => {
       const q = ORDERS.query().join({
         alias: "Products",
@@ -18,6 +18,7 @@ describe("Join", () => {
       expect(j.alias).toEqual("Products_2");
     });
   });
+
   describe("setDefaultCondition", () => {
     it("should set default condition to be fk relationship", () => {
       const q = ORDERS.query().join({
@@ -36,6 +37,7 @@ describe("Join", () => {
       });
     });
   });
+
   describe("setDefaultAlias", () => {
     it("should set default alias to be table + field name and update join condition", () => {
       const q = ORDERS.query().join({
@@ -65,6 +67,7 @@ describe("Join", () => {
         "source-table": REVIEWS.id,
       });
     });
+
     it("should set default alias to be table name only if it is similar to field name", () => {
       const q = ORDERS.query().join({
         alias: "x",

--- a/frontend/test/metabase-lib/lib/queries/structured/Join.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/structured/Join.unit.spec.js
@@ -122,6 +122,23 @@ describe("Join", () => {
       });
     });
 
+    it("should set default alias correctly for multi-field joins", () => {
+      let join = getJoin({
+        query: getOrdersJoinQuery({
+          condition: ORDERS_PRODUCT_MULTI_FIELD_JOIN_CONDITION,
+        }),
+      });
+
+      join = join.setDefaultCondition().setDefaultAlias();
+
+      expect(join).toEqual({
+        alias: "Products",
+        condition: ORDERS_PRODUCT_MULTI_FIELD_JOIN_CONDITION,
+        "source-table": PRODUCTS.id,
+      });
+    });
+  });
+
   describe("setParentDimension", () => {
     it("creates a condition if not present", () => {
       let join = getJoin();

--- a/frontend/test/metabase-lib/lib/queries/structured/Join.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/structured/Join.unit.spec.js
@@ -298,5 +298,92 @@ describe("Join", () => {
       });
     });
   });
+
+  describe("isValid", () => {
+    it("should return true for complete one-fields pair join", () => {
+      const join = getJoin({
+        query: getOrdersJoinQuery({
+          condition: ORDERS_PRODUCT_JOIN_CONDITION,
+        }),
+      });
+      expect(join.isValid()).toBe(true);
+    });
+
+    it("should return true for complete multi-fields join", () => {
+      const join = getJoin({
+        query: getOrdersJoinQuery({
+          condition: ORDERS_PRODUCT_MULTI_FIELD_JOIN_CONDITION,
+        }),
+      });
+      expect(join.isValid()).toBe(true);
+    });
+
+    const invalidTestCases = [
+      [
+        "missing source table",
+        {
+          sourceTable: null,
+        },
+      ],
+      [
+        "missing condition",
+        {
+          condition: null,
+        },
+      ],
+      [
+        "missing both dimensions",
+        {
+          condition: ["=", null, null],
+        },
+      ],
+      [
+        "missing parent dimension",
+        {
+          condition: ["=", null, PRODUCTS_ID_FIELD_REF],
+        },
+      ],
+      [
+        "missing join dimension",
+        {
+          condition: ["=", ORDERS_PRODUCT_ID_FIELD_REF, null],
+        },
+      ],
+      [
+        "second condition is empty",
+        {
+          condition: ["and", ORDERS_PRODUCT_JOIN_CONDITION, ["=", null, null]],
+        },
+      ],
+      [
+        "missing parent dimension in second condition",
+        {
+          condition: [
+            "and",
+            ORDERS_PRODUCT_JOIN_CONDITION,
+            ["=", null, PRODUCTS_CREATED_AT_FIELD_REF],
+          ],
+        },
+      ],
+      [
+        "missing join dimension in second condition",
+        {
+          condition: [
+            "and",
+            ORDERS_PRODUCT_JOIN_CONDITION,
+            ["=", ORDERS_CREATED_AT_FIELD_REF, null],
+          ],
+        },
+      ],
+    ];
+
+    invalidTestCases.forEach(([invalidReason, queryOpts]) => {
+      it(`should return 'false' when ${invalidReason}`, () => {
+        const join = getJoin({
+          query: getOrdersJoinQuery(queryOpts),
+        });
+        expect(join.isValid()).toBe(false);
+      });
+    });
   });
 });

--- a/frontend/test/metabase-lib/lib/queries/structured/Join.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/structured/Join.unit.spec.js
@@ -327,6 +327,103 @@ describe("Join", () => {
     });
   });
 
+  describe("removeCondition", () => {
+    it("does nothing when there is no condition", () => {
+      let join = getJoin();
+
+      join = join.removeCondition(0);
+
+      expect(join).toEqual({
+        alias: "Products",
+        condition: undefined,
+        "source-table": PRODUCTS.id,
+      });
+    });
+
+    it("removes condition for single fields pair join by index", () => {
+      let join = getJoin();
+
+      join = join.removeCondition(0);
+
+      expect(join).toEqual({
+        alias: "Products",
+        condition: undefined,
+        "source-table": PRODUCTS.id,
+      });
+    });
+
+    it("does nothing if condition index is out of range for single fields pair join", () => {
+      let join = getJoin({
+        query: getOrdersJoinQuery({
+          condition: ORDERS_PRODUCT_JOIN_CONDITION,
+        }),
+      });
+
+      join = join.removeCondition(100);
+
+      expect(join).toEqual({
+        alias: "Products",
+        condition: ORDERS_PRODUCT_JOIN_CONDITION,
+        "source-table": PRODUCTS.id,
+      });
+    });
+
+    it("removes condition from multi-fields join by index", () => {
+      let join = getJoin({
+        query: getOrdersJoinQuery({
+          condition: [
+            ...ORDERS_PRODUCT_MULTI_FIELD_JOIN_CONDITION,
+            [
+              "=",
+              ["field", ORDERS.TAX.id, null],
+              ["field", PRODUCTS.PRICE.id, null],
+            ],
+          ],
+        }),
+      });
+
+      join = join.removeCondition(2);
+
+      expect(join).toEqual({
+        alias: "Products",
+        condition: ORDERS_PRODUCT_MULTI_FIELD_JOIN_CONDITION,
+        "source-table": PRODUCTS.id,
+      });
+    });
+
+    it("turns multi-fields join condition into single pair when only one condition is left", () => {
+      let join = getJoin({
+        query: getOrdersJoinQuery({
+          condition: ORDERS_PRODUCT_MULTI_FIELD_JOIN_CONDITION,
+        }),
+      });
+
+      join = join.removeCondition(1);
+
+      expect(join).toEqual({
+        alias: "Products",
+        condition: ORDERS_PRODUCT_JOIN_CONDITION,
+        "source-table": PRODUCTS.id,
+      });
+    });
+
+    it("does nothing if condition index is out of range for multi-fields join", () => {
+      let join = getJoin({
+        query: getOrdersJoinQuery({
+          condition: ORDERS_PRODUCT_MULTI_FIELD_JOIN_CONDITION,
+        }),
+      });
+
+      join = join.removeCondition(100);
+
+      expect(join).toEqual({
+        alias: "Products",
+        condition: ORDERS_PRODUCT_MULTI_FIELD_JOIN_CONDITION,
+        "source-table": PRODUCTS.id,
+      });
+    });
+  });
+
   describe("isValid", () => {
     it("should return true for complete one-fields pair join", () => {
       const join = getJoin({

--- a/frontend/test/metabase-visual/notebook/notebook.cy.spec.js
+++ b/frontend/test/metabase-visual/notebook/notebook.cy.spec.js
@@ -1,8 +1,8 @@
 import { restore, popover } from "__support__/e2e/cypress";
 
 describe("visual tests > notebook > major UI elements", () => {
-  const VIEWPORT_WIDTH = 2200;
-  const VIEWPORT_HEIGHT = 1200;
+  const VIEWPORT_WIDTH = 2500;
+  const VIEWPORT_HEIGHT = 1500;
 
   beforeEach(() => {
     restore();
@@ -18,6 +18,14 @@ describe("visual tests > notebook > major UI elements", () => {
 
     addJoin({
       rightTable: "Products",
+    });
+    addJoinDimensions({
+      currentJoinsCount: 1,
+      leftField: "Created At",
+      rightField: "Created At",
+    });
+    addJoinDimensions({
+      currentJoinsCount: 2,
     });
 
     addCustomColumn({
@@ -56,6 +64,19 @@ function addJoin({ rightTable }) {
     .click();
 
   selectFromDropdown(rightTable).click();
+}
+
+function addJoinDimensions({ currentJoinsCount, leftField, rightField }) {
+  const lastJoinIndex = currentJoinsCount - 1;
+
+  cy.findByTestId(`join-dimensions-pair-${lastJoinIndex}`).within(() => {
+    cy.icon("add").click();
+  });
+
+  if (leftField && rightField) {
+    selectFromDropdown(leftField).click();
+    selectFromDropdown(rightField).click();
+  }
 }
 
 function addCustomColumn({ name, formula }) {

--- a/frontend/test/metabase/scenarios/question/reproductions/17514-ui-overlay.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/17514-ui-overlay.cy.spec.js
@@ -167,7 +167,7 @@ function openNotebookMode() {
 function removeJoinedTable() {
   cy.findAllByText("Join data")
     .parent()
-    .find(".Icon-close")
+    .findByTestId("remove-step")
     .click({ force: true });
 }
 


### PR DESCRIPTION
This PR updates the `Join` class and notebook editor to support joining tables on multiple fields. The underlying MBQL is translated into SQL like:

```sql
SELECT * FROM Orders AS o
INNER JOIN Products AS p
ON o.PRODUCT_ID = p.ID AND o.CREATED_AT = p.CREATED_AT
```

`Join` class from `metabase-lib` used to have a single `condition` property storing the join dimension references (as MBQL). Let's say we want to join the Orders table with the Products table by Product ID. Join's `condition` in that case will look like the following:

```js
const condition = [
   "=", // eq operator means the following two field are expected to be equal
   [ "field", 3, null ], // left side field (ORDERS.PRODUCT_ID, the number is field's internal ID)
   [ "field", 14, { "join-alias": "Products" } ], // right side field (PRODUCTS.ID, the number is field's internal ID)
]
```

Now `Join` would also support more complex conditions. Let's say we now also want to join tables on the `CREATED_AT` field. The condition will now look like that:

```js
const condition = [
   "and",
   // The expressions below are the same as in the example above.
   // The whole idea is that we combine them using "and" operator
   [ "=", [ "field", 3, null ], [ "field", 14, { "join-alias": "Products" } ],
   [ "=", [ "field", 7, null ], [ "field", 19, { "join-alias": "Products" } ],
]
```

### To Verify

In order to test multiple joins, we're going to join the Orders and Products tables on Product ID and creation date (orders created in the same month with a related product).

1. Ask a question > Custom question > Sample Dataset > Orders
2. Join Products table on `Orders.PRODUCT_ID = Products.ID`
3. Summarize by "Count of rows"
4. Select "inner" join strategy (inner join will provide the most notable results)
4. Click "Visualize"
5. You should see there are 18760 records
6. Open the notebook again and extend add another join dimensions pair: `Orders.CREATED_AT` on `Products.CREATED_AT`
7. Click "Visualize"
8. You should see there are 415 records now. The number changed because `INNER JOIN` returned only records where the order's creation date matches the product's creation date (by month, not by exact date time)
9. If you clean up the summarize step (remove "Count of rows", you should see that for every row `Product ID` and `Product > ID` columns & `Created At` and `Product > Created At` match

### Demo


https://user-images.githubusercontent.com/17258145/131162557-dc8768c0-2e22-4c0a-87f9-826f54feee19.mov

