### PR TITLE
Collapse small donut slices into a single "Other" category

### DIFF
--- a/test/metabase/pulse/render/body_test.clj
+++ b/test/metabase/pulse/render/body_test.clj
@@ -477,3 +477,20 @@
                [:div [:span "•"] [:span "Doohickey"] [:span "75%"]]
                [:div [:span "•"] [:span "Widget"] [:span "25%"]]]]
              (prune (:content (render [["Doohickey" 75] ["Widget" 25]]))))))))
+
+(def donut-info #'body/donut-info)
+
+(deftest donut-info-test
+  (let [rows [["a" 45] ["b" 45] ["c" 5] ["d" 5]]]
+    (testing "If everything is above the threshold does nothing"
+      (is (= rows (:rows (donut-info 4 rows)))))
+    (testing "Collapses smaller sections below threshold"
+      (is (= [["a" 45] ["b" 45] ["Other" 10]]
+             (:rows (donut-info 5 rows)))))
+    (testing "Computes percentages"
+      (is (= {"a" "45%" "b" "45%" "Other" "10%"}
+             (:percentages (donut-info 5 rows)))))
+    (testing "Includes zero percent rows"
+      (let [rows [["a" 50] ["b" 50] ["d" 0]]]
+        (is (= {"a" "50%" "b" "50%" "Other" "0%"}
+               (:percentages (donut-info 5 rows))))))))

--- a/test/metabase/pulse/render/body_test.clj
+++ b/test/metabase/pulse/render/body_test.clj
@@ -494,3 +494,11 @@
       (let [rows [["a" 50] ["b" 50] ["d" 0]]]
         (is (= {"a" "50%" "b" "50%" "Other" "0%"}
                (:percentages (donut-info 5 rows))))))))
+
+(deftest format-percentage-test
+  (let [value 12345.54321]
+    (is (= "1,234,543.21%" (body/format-percentage 12345.4321 ".,")))
+    (is (= "1&234&543^21%" (body/format-percentage 12345.4321 "^&")))
+    (is (= "1,234,543 21%" (body/format-percentage 12345.4321 " ")))
+    (is (= "1,234,543.21%" (body/format-percentage 12345.4321 nil)))
+    (is (= "1,234,543.21%" (body/format-percentage 12345.4321 "")))))


### PR DESCRIPTION
Use viz settings for donut slices

##### Before
<img width="664" alt="image" src="https://user-images.githubusercontent.com/6377293/131147843-28e1e794-453d-401c-8701-55289e6d3e30.png">

##### After
<img width="1042" alt="image" src="https://user-images.githubusercontent.com/6377293/131147875-33117170-8b94-4687-a4c1-afe5683cfdba.png">

#### Reference UI
<img width="1057" alt="image" src="https://user-images.githubusercontent.com/6377293/131147946-8ef7761f-2e6b-468f-98b3-ea72ca3b4fb2.png">
