### PR TITLE
When creating database, pass syncing schedule options to api

### DIFF
--- a/frontend/src/metabase/admin/databases/database.js
+++ b/frontend/src/metabase/admin/databases/database.js
@@ -190,6 +190,10 @@ export const proceedWithDbCreation = function(database) {
 };
 
 export const createDatabase = function(database) {
+  if (database.details["let-user-control-scheduling"]) {
+    database.is_full_sync = false;
+  }
+
   return async function(dispatch, getState) {
     try {
       dispatch.action(CREATE_DATABASE_STARTED, {});

--- a/frontend/src/metabase/admin/databases/database.js
+++ b/frontend/src/metabase/admin/databases/database.js
@@ -192,6 +192,11 @@ export const proceedWithDbCreation = function(database) {
 export const createDatabase = function(database) {
   if (database.details["let-user-control-scheduling"]) {
     database.is_full_sync = false;
+    database.schedules = {
+      metadata_sync: {
+        schedule_type: "daily",
+      },
+    };
   }
 
   return async function(dispatch, getState) {

--- a/frontend/src/metabase/admin/databases/database.js
+++ b/frontend/src/metabase/admin/databases/database.js
@@ -165,10 +165,12 @@ export const proceedWithDbCreation = function(database) {
     if (database.details["let-user-control-scheduling"]) {
       try {
         dispatch.action(VALIDATE_DATABASE_STARTED);
+
         const { valid } = await MetabaseApi.db_validate({ details: database });
+
         if (valid) {
           dispatch.action(SET_DATABASE_CREATION_STEP, {
-            database: database,
+            database,
             step: DB_EDIT_FORM_SCHEDULING_TAB,
           });
         } else {
@@ -190,14 +192,7 @@ export const proceedWithDbCreation = function(database) {
 };
 
 export const createDatabase = function(database) {
-  if (database.details["let-user-control-scheduling"]) {
-    database.is_full_sync = false;
-    database.schedules = {
-      metadata_sync: {
-        schedule_type: "daily",
-      },
-    };
-  }
+  editSyncParamsForUserControlledScheduling(database);
 
   return async function(dispatch, getState) {
     try {
@@ -218,6 +213,17 @@ export const createDatabase = function(database) {
       throw error;
     }
   };
+};
+
+const editSyncParamsForUserControlledScheduling = database => {
+  if (database.details["let-user-control-scheduling"]) {
+    database.is_full_sync = false;
+    database.schedules = {
+      metadata_sync: {
+        schedule_type: "daily",
+      },
+    };
+  }
 };
 
 export const updateDatabase = function(database) {

--- a/frontend/src/metabase/admin/databases/database.js
+++ b/frontend/src/metabase/admin/databases/database.js
@@ -12,6 +12,8 @@ import MetabaseSettings from "metabase/lib/settings";
 import { MetabaseApi } from "metabase/services";
 import Databases from "metabase/entities/databases";
 
+import { editParamsForUserControlledScheduling } from "./editParamsForUserControlledScheduling";
+
 // Default schedules for db sync and deep analysis
 export const DEFAULT_SCHEDULES = {
   cache_field_values: {
@@ -192,7 +194,7 @@ export const proceedWithDbCreation = function(database) {
 };
 
 export const createDatabase = function(database) {
-  editSyncParamsForUserControlledScheduling(database);
+  editParamsForUserControlledScheduling(database);
 
   return async function(dispatch, getState) {
     try {
@@ -213,17 +215,6 @@ export const createDatabase = function(database) {
       throw error;
     }
   };
-};
-
-const editSyncParamsForUserControlledScheduling = database => {
-  if (database.details["let-user-control-scheduling"]) {
-    database.is_full_sync = false;
-    database.schedules = {
-      metadata_sync: {
-        schedule_type: "daily",
-      },
-    };
-  }
 };
 
 export const updateDatabase = function(database) {

--- a/frontend/src/metabase/admin/databases/editParamsForUserControlledScheduling.js
+++ b/frontend/src/metabase/admin/databases/editParamsForUserControlledScheduling.js
@@ -1,0 +1,20 @@
+export function editParamsForUserControlledScheduling(database) {
+  editSyncParamsForUserControlledScheduling(database);
+  editScheduleParamsForUserControlledScheduling(database);
+}
+
+function editSyncParamsForUserControlledScheduling(database) {
+  if (database.details["let-user-control-scheduling"]) {
+    database.is_full_sync = false;
+  }
+}
+
+function editScheduleParamsForUserControlledScheduling(database) {
+  const { details, schedules } = database;
+
+  if (details["let-user-control-scheduling"] && !schedules?.metadata_sync) {
+    database.schedules.metadata_sync = {
+      schedule_type: "daily",
+    };
+  }
+}

--- a/frontend/src/metabase/admin/databases/editParamsForUserControlledScheduling.unit.spec.js
+++ b/frontend/src/metabase/admin/databases/editParamsForUserControlledScheduling.unit.spec.js
@@ -1,0 +1,56 @@
+import { editParamsForUserControlledScheduling } from "./editParamsForUserControlledScheduling";
+
+it("adds full_sync param if user will control scheduling", () => {
+  const database = {
+    schedules: {},
+    details: { "let-user-control-scheduling": true },
+  };
+
+  editParamsForUserControlledScheduling(database);
+
+  expect(database.is_full_sync).toBe(false);
+});
+
+it("does not add full_sync param if user will not control scheduling", () => {
+  const database = {
+    schedules: {},
+    details: {},
+  };
+
+  editParamsForUserControlledScheduling(database);
+
+  expect(database.is_full_sync).toBe(undefined);
+});
+
+it("adds metadata_sync param if user will control scheduling and no metadata_sync data is present", () => {
+  const database = {
+    schedules: {},
+    details: { "let-user-control-scheduling": true },
+  };
+
+  editParamsForUserControlledScheduling(database);
+
+  expect(database.schedules.metadata_sync.schedule_type).toBe("daily");
+});
+
+it("does not add metadata_sync param if user will not control scheduling", () => {
+  const database = {
+    schedules: {},
+    details: {},
+  };
+
+  editParamsForUserControlledScheduling(database);
+
+  expect(database.schedules).toStrictEqual({});
+});
+
+it("does not add metadata_sync param if user will control scheduling and metadata_sync data is present", () => {
+  const database = {
+    schedules: { metadata_sync: { schedule_type: "hourly" } },
+    details: { "let-user-control-scheduling": true },
+  };
+
+  editParamsForUserControlledScheduling(database);
+
+  expect(database.schedules.metadata_sync.schedule_type).toBe("hourly");
+});

--- a/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
@@ -184,7 +184,7 @@ describe("scenarios > admin > databases > add", () => {
     );
   });
 
-  it.skip("should respect users' decision to manually sync large database (metabase#17450)", () => {
+  it("should respect users' decision to manually sync large database (metabase#17450)", () => {
     const H2_CONNECTION_STRING =
       "zip:./target/uberjar/metabase.jar!/sample-dataset.db;USER=GUEST;PASSWORD=guest";
 


### PR DESCRIPTION
Fixes #17450

## Issue we're fixing

Setting up a new database and specifying the "This is a large database ...", the choice is not persisted to backend and default sync+scan settings are used.

## How to Test

1. Admin > Databases > create new database
2. Enable "This is a large database, so let me choose when Metabase syncs and scans" - click Next

![image](https://user-images.githubusercontent.com/1447303/129395064-c1d10f13-b48c-4858-bfbd-d416586fbfe6.png)

3. Do not make any change, when it shows the Scheduling-page - just click Save

![image](https://user-images.githubusercontent.com/1447303/129395228-2ea7210c-3937-432c-8a1b-38bfd797e3e1.png)

4. Now go to the newly created database and click the Scheduling-tab - and it has saved what was shown before.

![image](https://user-images.githubusercontent.com/380816/131162069-1746d87d-b091-412e-bef0-0cd96c8dbbce.png)
