### PR TITLE
Components in store admin should not use prop shorthands

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/store/components/StoreIcon.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/store/components/StoreIcon.jsx
@@ -14,7 +14,7 @@ const StoreIconWrapper = ({ children, color }) => (
     p={2}
     bg={color || colors["brand"]}
     color="white"
-    w={WRAPPER_SIZE}
+    width={WRAPPER_SIZE}
     style={{ borderRadius: 99, height: WRAPPER_SIZE }}
   >
     {children}

--- a/enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/store/containers/StoreAccount.jsx
@@ -209,7 +209,7 @@ const AccountStatus = ({
       flexDirection="column"
       className={className}
       p={[2, 4]}
-      w="100%"
+      width="100%"
     >
       <Box>
         <h2>{title}</h2>
@@ -219,7 +219,7 @@ const AccountStatus = ({
           {subtitle}
         </Box>
       )}
-      <Flex mt={4} align="center" flexWrap="wrap" w="100%">
+      <Flex mt={4} align="center" flexWrap="wrap" width="100%">
         {featuresOrdered.map(([id, feature]) => (
           <Feature
             key={id}
@@ -245,7 +245,7 @@ const CallToAction = ({ title, buttonText, buttonLink }) => (
 );
 
 const Feature = ({ feature, included, expired, preview }) => (
-  <Box w={[1, 1 / 2, 1 / 4]} p={2}>
+  <Box width={[1, 1 / 2, 1 / 4]} p={2}>
     <Card
       p={[1, 2]}
       style={{


### PR DESCRIPTION
This applies only to activated EE.

Go to `/admin/store` and make sure all the Flex and Box stay **exactly the same** before and after this PR.

![image](https://user-images.githubusercontent.com/7288/131161156-b908c4d1-749f-42e3-a3c6-6ec20cb6172a.png)

![image](https://user-images.githubusercontent.com/7288/131161265-f01ee384-9eba-4f08-93d5-b0a0a2f12754.png)

![image](https://user-images.githubusercontent.com/7288/131161182-7b347968-3780-4849-acda-4abf3e987c89.png)
