### PR TITLE
Only include dashboard subscriptions in `GET /api/pulse` if `user_id` param is included

### DIFF
--- a/src/metabase/models/pulse.clj
+++ b/src/metabase/models/pulse.clj
@@ -287,9 +287,11 @@
                            (when dashboard-id
                              [:= :p.dashboard_id dashboard-id])
                            (when user-id
-                             [:or
-                              [:= :p.creator_id user-id]
-                              [:= :pcr.user_id user-id]])]
+                             [:and
+                              [:not= :p.dashboard_id nil]
+                              [:or
+                               [:= :p.creator_id user-id]
+                               [:= :pcr.user_id user-id]]])]
                :order-by  [[:lower-name :asc]]}]
     (for [pulse (query-as Pulse query)]
       (-> pulse

--- a/test/metabase/api/pulse_test.clj
+++ b/test/metabase/api/pulse_test.clj
@@ -803,11 +803,17 @@
           (is (= #{"Archived"}
                  (set (map :name (mt/user-http-request :rasta :get 200 "pulse?archived=true"))))))))
 
-    (testing "can fetch pulses by user ID -- should return pulses created by the user,
-           or pulses for which the user is a known recipient"
-      (mt/with-temp* [Pulse                 [creator-pulse   {:name "LuckyCreator" :creator_id (mt/user->id :lucky)}]
-                      Pulse                 [recipient-pulse {:name "LuckyRecipient"}]
-                      Pulse                 [other-pulse     {:name "Other"}]
+    (testing "can fetch dashboard subscriptions by user ID -- should return subscriptions created by the user,
+           or subscriptions for which the user is a known recipient. Should exclude pulses."
+      (mt/with-temp* [Dashboard             [{dashboard-id :id}]
+                      Pulse                 [creator-pulse   {:name "LuckyCreator",
+                                                              :creator_id (mt/user->id :lucky)
+                                                              :dashboard_id dashboard-id}]
+                      Pulse                 [recipient-pulse {:name "LuckyRecipient",
+                                                              :dashboard_id dashboard-id}]
+                      Pulse                 [other-pulse     {:name "Other",
+                                                              :dashboard_id dashboard-id}]
+                      Pulse                 [excluded-pulse  {:name "Excluded"}]
                       PulseChannel          [pulse-channel   {:pulse_id (u/the-id recipient-pulse)}]
                       PulseChannelRecipient [_               {:pulse_channel_id (u/the-id pulse-channel),
                                                               :user_id (mt/user->id :lucky)}]]


### PR DESCRIPTION
Updates the pulse list endpoint to only include dashboard subscriptions, and exclude pulses, if the new `user_id` parameter is included.

The semantics of these endpoints are a bit muddled (e.g. which ones apply to pulses vs dashboard subscriptions vs both), but I think it's probably OK since we'll be removing pulses soon anyway.

Requested by @ranquild for the subscription management project.