### PR TITLE
Secrets 🔐 PR 2 - Add secret model

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -8495,6 +8495,78 @@ databaseChangeLog:
               )
               WHERE dashboard_id IS NOT NULL;
 
+  - changeSet:
+      id: 313
+      author: jeff303
+      comment: Added 0.41.0 - Secret domain object.
+      changes:
+        - createTable:
+            columns:
+              - column:
+                  autoIncrement: true
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                  name: id
+                  remarks: Part of composite primary key for secret; this is the uniquely generted ID column
+                  type: int
+              - column:
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                  name: version
+                  defaultValue: 1
+                  remarks: Part of composite primary key for secret; this is the version column
+                  type: int
+              - column:
+                  constraints:
+                    nullable: false
+                  name: created_at
+                  remarks: Timestamp for when this secret record was created
+                  type: DATETIME
+              - column:
+                  constraints:
+                    nullable: true
+                  name: updated_at
+                  remarks: >-
+                    Timestamp for when this secret record was updated. Only relevant when non-value field changes
+                    since a value change will result in a new version being inserted.
+                  type: DATETIME
+              - column:
+                  constraints:
+                    nullable: false
+                  name: name
+                  remarks: The name of this secret record.
+                  type: varchar(254)
+              - column:
+                  constraints:
+                    # TODO: do we want to constrain this field or leave open for extension? or separate table with FK?
+                    nullable: false
+                  name: kind
+                  remarks: >-
+                    The kind of secret this record represents; the value is interpreted as a Clojure keyword with a
+                    hierarchy. Ex: 'bytes' means generic binary data, 'jks-keystore' extends 'bytes' but has a specific
+                    meaning.
+                  type: varchar(254)
+              - column:
+                  constraints:
+                    # TODO: similar question to above?
+                    nullable: true
+                  name: source
+                  remarks: >-
+                    The source of secret record, which controls how Metabase interprets the value (ex: 'file-path'
+                    means the 'simple_value' is not the real value, but a pointer to a file that contains the value).
+                  type: varchar(254)
+              - column:
+                  constraints:
+                    nullable: false
+                  name: value
+                  remarks: The base64 encoded binary value of this secret record. If encryption is enabled, this will
+                    be the output of the encryption procedure on the plaintext. If not, it will be the base64 encoded
+                    plaintext.
+                  type: ${blob.type}
+            tableName: secret
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -1,5 +1,6 @@
 (ns metabase.models.interface
-  (:require [cheshire.core :as json]
+  (:require [buddy.core.codecs :as codecs]
+            [cheshire.core :as json]
             [clojure.core.memoize :as memoize]
             [clojure.tools.logging :as log]
             [clojure.walk :as walk]
@@ -160,6 +161,10 @@
 
 (models/add-type! :encrypted-text
   :in  encryption/maybe-encrypt
+  :out encryption/maybe-decrypt)
+
+(models/add-type! :secret-value
+  :in  (comp encryption/maybe-encrypt-bytes codecs/to-bytes)
   :out encryption/maybe-decrypt)
 
 (defn decompress

--- a/src/metabase/models/secret.clj
+++ b/src/metabase/models/secret.clj
@@ -1,0 +1,33 @@
+(ns metabase.models.secret
+  (:require [cheshire.generate :refer [add-encoder encode-map]]
+            [metabase.models.interface :as i]
+            [metabase.util :as u]
+            [toucan.models :as models]))
+
+;;; ----------------------------------------------- Entity & Lifecycle -----------------------------------------------
+
+(models/defmodel Secret :secret)
+
+(u/strict-extend (class Secret)
+  models/IModel
+  (merge models/IModelDefaults
+         {;:hydration-keys (constantly [:database :db]) ; don't think there's any hydration going on since other models
+                                                        ; won't have a direct secret-id column
+          :types          (constantly {:value  :secret-value
+                                       :kind   :keyword
+                                       :source :keyword})
+          :properties     (constantly {:timestamped? true})})
+  i/IObjectPermissions
+  (merge i/IObjectPermissionsDefaults
+         {:can-read?         i/superuser?
+          :can-write?        i/superuser?}))
+
+;;; ---------------------------------------------- Hydration / Util Fns ----------------------------------------------
+;; none yet
+
+;;; -------------------------------------------------- JSON Encoder --------------------------------------------------
+
+(add-encoder SecretInstance (fn [secret json-generator]
+                              (encode-map
+                               (dissoc secret :value) ; never include the secret value in JSON
+                               json-generator)))

--- a/src/metabase/util/encryption.clj
+++ b/src/metabase/util/encryption.clj
@@ -141,25 +141,44 @@
       (possibly-encrypted-bytes? b))))
 
 (defn maybe-decrypt
-  "If `MB_ENCRYPTION_SECRET_KEY` is set and `s` is encrypted, decrypt `s`; otherwise return `s` as-is."
+  "If `MB_ENCRYPTION_SECRET_KEY` is set and `v` is encrypted, decrypt `v`; otherwise return `s` as-is. Attempts to check
+  whether `v` is an encrypted String, in which case the decrypted String is returned, or whether `v` is encrypted bytes,
+  in which case the decrypted bytes are returned."
   {:arglists '([secret-key? s & {:keys [log-errors?], :or {log-errors? true}}])}
   [& args]
-  (let [[secret-key & more]        (if (bytes? (first args))
+  (let [[secret-key & more]        (if (and (bytes? (first args)) (string? (second args))) ;TODO: fix hackiness
                                      args
                                      (cons default-secret-key args))
-        [s & options]              more
+        [v & options]              more
         {:keys [log-errors?]
-         :or   {log-errors? true}} (apply hash-map options)]
-    (if (and secret-key (possibly-encrypted-string? s))
-      (try
-        (decrypt secret-key s)
-        (catch Throwable e
-          ;; if we can't decrypt `s`, but it *is* probably encrypted, log a warning
-          (when log-errors?
-            (log/warn
-             (trs "Cannot decrypt encrypted string. Have you changed or forgot to set MB_ENCRYPTION_SECRET_KEY?")
-             (.getMessage e)
-             (u/pprint-to-str (u/filtered-stacktrace e))))
-          s))
-      ;; otherwise return `s` without decrypting. It's probably not encrypted in the first place
-      s)))
+         :or   {log-errors? true}} (apply hash-map options)
+        log-error-fn (fn [kind e]
+                       (when log-errors?
+                         (log/warn (trs "Cannot decrypt encrypted {0}. Have you changed or forgot to set MB_ENCRYPTION_SECRET_KEY?"
+                                        kind)
+                                   (.getMessage e)
+                                   (u/pprint-to-str (u/filtered-stacktrace e)))))]
+
+    (cond (not (some? secret-key))
+          v
+
+          (possibly-encrypted-string? v)
+          (try
+            (decrypt secret-key v)
+            (catch Throwable e
+              ;; if we can't decrypt `v`, but it *is* probably encrypted, log a warning
+              (log-error-fn "String" e)
+              v))
+
+          (possibly-encrypted-bytes? v)
+          (try
+            (decrypt-bytes secret-key v)
+            (catch Throwable e
+              ;; if we can't decrypt `v`, but it *is* probably encrypted, log a warning
+              (log-error-fn "bytes" e)
+              v))
+
+          :else
+          v)))
+
+

--- a/test/metabase/models/secret_test.clj
+++ b/test/metabase/models/secret_test.clj
@@ -1,0 +1,37 @@
+(ns metabase.models.secret-test
+  (:require [clojure.test :refer :all]
+            [metabase.models.secret :as secret :refer [Secret]]
+            [metabase.test :as mt]
+            [metabase.util.encryption-test :as encryption-test]))
+
+(defn- check-secret []
+  (doseq [value ["fourtytwo" (byte-array (range 0 100))]]
+    (let [name        "Test Secret"
+          kind        ::secret/password
+          val-equals? (fn [expected secret]
+                        (if-let [v (:value secret)]
+                          (cond (string? expected)
+                                (= expected (String. v))
+
+                                (bytes? expected)
+                                (= (seq expected) (seq v)))))]
+      (mt/with-temp Secret [{:keys [id] :as secret} {:name  name
+                                                     :kind  kind
+                                                     :value value}]
+         (is (= name (:name secret)))
+         (is (= kind (:kind secret)))
+         (is (val-equals? value secret))
+         (let [loaded (Secret id)]
+           (is (= name (:name loaded)))
+           (is (= kind (:kind loaded)))
+           (is (val-equals? value loaded)))))))
+
+(deftest secret-retrieval-test
+  (testing "A secret value can be retrieved successfully"
+    (testing " when there is NO encryption key in place"
+      (encryption-test/with-secret-key nil
+        (check-secret)))
+    (testing " when there is an encryption key in place"
+      (encryption-test/with-secret-key (resolve 'encryption-test/secret)
+        (check-secret)))))
+

--- a/test/metabase/util/encryption_test.clj
+++ b/test/metabase/util/encryption_test.clj
@@ -82,7 +82,7 @@
 (defn- includes-encryption-warning? [log-messages]
   (some (fn [[level _ message]]
           (and (= level :warn)
-               (str/includes? message (str "Cannot decrypt encrypted string. Have you changed or forgot to set "
+               (str/includes? message (str "Cannot decrypt encrypted String. Have you changed or forgot to set "
                                            "MB_ENCRYPTION_SECRET_KEY? Message seems corrupt or manipulated."))))
         log-messages))
 


### PR DESCRIPTION
Add Liquibase migration for secret table

Implement bare bones model namespace for secret

Add simple test to ensure secret values are stored and retrieved under an encryption key (or not)
