### PR TITLE
[Dashboard filters coverage] Add test for dashboard filter applied to the explicitly joined field

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-explicit-join.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-explicit-join.cy.spec.js
@@ -1,0 +1,103 @@
+import { restore, filterWidget, popover } from "__support__/e2e/cypress";
+import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
+
+const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATASET;
+
+const questionDetails = {
+  name: "Orders join Products",
+  query: {
+    "source-table": ORDERS_ID,
+    joins: [
+      {
+        fields: "all",
+        "source-table": PRODUCTS_ID,
+        condition: [
+          "=",
+          ["field-id", ORDERS.PRODUCT_ID],
+          ["joined-field", "Products", ["field-id", PRODUCTS.ID]],
+        ],
+        alias: "Products",
+      },
+    ],
+  },
+};
+
+const filter = {
+  name: "Text",
+  slug: "text",
+  id: "7653fdfa",
+  type: "string/=",
+  sectionId: "string",
+};
+
+const dashboardDetails = {
+  parameters: [filter],
+};
+
+describe("scenarios > dashboard > filters", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.createQuestionAndDashboard({ questionDetails, dashboardDetails }).then(
+      ({ body: dashboardCard }) => {
+        const { card_id, dashboard_id } = dashboardCard;
+
+        const updatedCardDetails = {
+          sizeX: 16,
+          sizeY: 10,
+          parameter_mappings: [
+            {
+              parameter_id: filter.id,
+              card_id,
+              target: [
+                "dimension",
+                [
+                  "field",
+                  PRODUCTS.TITLE,
+                  {
+                    "join-alias": "Products",
+                  },
+                ],
+              ],
+            },
+          ],
+        };
+
+        cy.editDashboardCard(dashboardCard, updatedCardDetails);
+
+        cy.visit(`/dashboard/${dashboard_id}`);
+      },
+    );
+  });
+
+  it("should work properly when connected to the explicitly joined field", () => {
+    filterWidget().click();
+
+    cy.findByPlaceholderText(/^Search by/).type("Awe");
+
+    selectFromDropdown(["Awesome Concrete Shoes", "Awesome Iron Hat"]);
+
+    cy.button("Add filter").click();
+
+    cy.location("search").should(
+      "eq",
+      "?text=Awesome%20Concrete%20Shoes&text=Awesome%20Iron%20Hat",
+    );
+
+    filterWidget().contains("2 selections");
+
+    cy.get(".Card").within(() => {
+      cy.findAllByText("Awesome Concrete Shoes");
+      cy.findAllByText("Awesome Iron Hat");
+    });
+  });
+});
+
+function selectFromDropdown(values) {
+  popover().within(() => {
+    values.forEach(value => {
+      cy.findByText(value).click();
+    });
+  });
+}


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- As an ongoing effort to increase the test coverage of dashboard filters (https://github.com/metabase/metabase/issues/17078), this PR adds the basic test for a dashboard filter applied to the explicitly joined field in a QB question 

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/131185608-d7a25d94-e117-4b18-a65d-2da19e7706d8.png)

