### PR TITLE
Svg test improvements

### DIFF
--- a/src/metabase/pulse/render/js_engine.clj
+++ b/src/metabase/pulse/render/js_engine.clj
@@ -6,7 +6,8 @@
   graal jdk. See https://github.com/oracle/graaljs/blob/master/docs/user/RunOnJDK.md for more information.
 
   Javadocs: https://www.graalvm.org/truffle/javadoc/overview-summary.html"
-  (:require [clojure.java.io :as io])
+  (:require [clojure.java.io :as io]
+            [metabase.util.i18n :refer [trs]])
   (:import [org.graalvm.polyglot Context HostAccess Source Value]))
 
 (defn ^Context context
@@ -31,7 +32,11 @@
 (defn load-resource
   "Load a resource into the js context"
   [^Context context source]
-  (.eval context (.build (Source/newBuilder "js" (io/resource source)))))
+  (let [resource (io/resource source)]
+    (when (nil? resource)
+      (throw (ex-info (trs "Javascript resource not found: {0}" source)
+                      {:source source})))
+    (.eval context (.build (Source/newBuilder "js" resource)))))
 
 (defn ^Value execute-fn-name
   "Executes `js-fn-name` in js context with args"

--- a/test/metabase/test_runner/effects.clj
+++ b/test/metabase/test_runner/effects.clj
@@ -9,7 +9,14 @@
   This would not have had the random namespace that requires these helpers and the run fails.
   "
   (:require [clojure.test :as t]
-            [schema.core :as s]))
+            [schema.core :as s]
+            [metabase.util.date-2 :as date-2]
+            [metabase.util.i18n.impl :as i18n.impl]))
+
+(comment
+  ;; these are necessary so data_readers.clj functions can function
+  date-2/keep-me
+  i18n.impl/keep-me)
 
 (defmethod t/assert-expr 're= [msg [_ pattern actual]]
   `(let [pattern#  ~pattern

--- a/test/metabase/test_runner/effects.clj
+++ b/test/metabase/test_runner/effects.clj
@@ -9,9 +9,9 @@
   This would not have had the random namespace that requires these helpers and the run fails.
   "
   (:require [clojure.test :as t]
-            [schema.core :as s]
             [metabase.util.date-2 :as date-2]
-            [metabase.util.i18n.impl :as i18n.impl]))
+            [metabase.util.i18n.impl :as i18n.impl]
+            [schema.core :as s]))
 
 (comment
   ;; these are necessary so data_readers.clj functions can function


### PR DESCRIPTION
#### Ensure that data_readers functions are included in tests

`clj -X:dev:test :only metabase.pulse.render.js-svg-test` uses the
`#t` data reader, which passes the value to
`metabase.util.date-2/parse` but this function hasn't been evaluated
yet and it errors

```shell
% clj -X:dev:test :only metabase.pulse.render.js-svg-test
Warning: environ value /Users/dan/.sdkman/candidates/java/current for key :java-home has been overwritten with /Users/dan/.sdkman/candidates/java/11.0.11.hs-adpt
Running tests in metabase.pulse.render.js-svg-test
Syntax error reading source at (metabase/pulse/render/js_svg_test.clj:71:27).
Attempting to call unbound fn: #'metabase.util.date-2/parse
```

#### Throw an error if resource is not found when loading sources

##### After
```shell
ERROR in metabase.pulse.render.js-svg-test/categorical-donut-test (js_engine.clj:37)
Uncaught exception, not in assertion.

clojure.lang.ExceptionInfo: Javascript resource not found: frontend_client/app/dist/lib-static-viz.bundle.js
    source: "frontend_client/app/dist/lib-static-viz.bundle.js"
   metabase.pulse.render.js-engine/load-resource    js_engine.clj:   37
    metabase.pulse.render.js-svg/load-viz-bundle       js_svg.clj:   94
 metabase.pulse.render.js-svg/static-viz-context       js_svg.clj:  100
                 metabase.pulse.render.js-svg/fn       js_svg.clj:  106
                                             ...
                              clojure.core/deref         core.clj: 2324
metabase.pulse.render.js-svg/timelineseries-line       js_svg.clj:  167
         metabase.pulse.render.js-svg-test/fn/fn  js_svg_test.clj:   75
            metabase.pulse.render.js-svg-test/fn  js_svg_test.clj:   74
                        clojure.test/test-var/fn         test.clj:  717
                           clojure.test/test-var         test.clj:  717
                   metabase.test-runner/run-test  test_runner.clj:  107

...
```

##### Before 
```shell
ERROR in metabase.pulse.render.js-svg-test/categorical-donut-test (Objects.java:221)
Uncaught exception, not in assertion.

java.lang.NullPointerException:
                java.util.Objects.requireNonNull     Objects.java:  221
      org.graalvm.polyglot.Source$Builder.<init>      Source.java:  725
          org.graalvm.polyglot.Source.newBuilder      Source.java:  546
   metabase.pulse.render.js-engine/load-resource    js_engine.clj:   34
    metabase.pulse.render.js-svg/load-viz-bundle       js_svg.clj:   94
 metabase.pulse.render.js-svg/static-viz-context       js_svg.clj:  100
                 metabase.pulse.render.js-svg/fn       js_svg.clj:  106
```
