### PR TITLE
Avoid prop shorthand in month-year parameter widget

### DIFF
--- a/frontend/src/metabase/parameters/components/widgets/DateMonthYearWidget.jsx
+++ b/frontend/src/metabase/parameters/components/widgets/DateMonthYearWidget.jsx
@@ -57,9 +57,9 @@ export default class DateMonthYearWidget extends React.Component {
             onChange={year => this.setState({ year: year })}
           />
         </div>
-        <Flex flexWrap="wrap" w="100%" p={1}>
+        <Flex flexWrap="wrap" width="100%" p={1}>
           {_.range(0, 12).map(m => (
-            <Flex key={m} w={1 / 3} align="center" justifyContent="center">
+            <Flex key={m} width={1 / 3} align="center" justifyContent="center">
               <Month
                 month={m}
                 selected={m === month}


### PR DESCRIPTION
First, create a dashboard that has month-year widget, e.g. choosing Orders table for a question, create a dashboard from it, and then add a filter to the dashboard (Time, Month and Year).

It will look like the following and pay attention to the two Flex containers:

![image](https://user-images.githubusercontent.com/7288/131200021-72fdf723-4be7-4001-9f21-3215c81ad3c0.png)

![image](https://user-images.githubusercontent.com/7288/131200028-05858aef-4558-4dac-ad0d-655c020873c4.png)

Before and after this PR, they should be **exactly the same**.