### PR TITLE
ESLint rules to prevent prop shorthands for w and h

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,6 +21,7 @@
     "react/no-unescaped-entities": 2,
     "react/jsx-no-target-blank": 2,
     "react/jsx-key": 2,
+    "react/forbid-component-props": [2, { "forbid": ["w", "h"] }],
     "prefer-const": [1, { "destructuring": "all" }],
     "no-useless-escape": 0,
     "no-only-tests/no-only-tests": "error",


### PR DESCRIPTION
See #17402 for the detailed context. Basically this simple ESLint rule stops us from re-introducing prop shorthands.

To give it a try, try to change `width` in a Flex/Box to `w` (e.g. by reverting commit b795f9f1).

**Before this PR**

Nothing happens, `w` silently makes into the source code.

**After this PR**

Loud complain from ESLint:

```
frontend/src/metabase/auth/components/AuthLayout.jsx
  20:50  error  Prop `w` is forbidden on Components  react/forbid-component-props
```
