### PR TITLE
match tick stroke color to axis stroke color in static viz components

### DIFF
--- a/frontend/src/metabase/static-viz/categorical/bar.js
+++ b/frontend/src/metabase/static-viz/categorical/bar.js
@@ -62,6 +62,7 @@ export default function CategoricalBar(
       />
       <AxisBottom
         hideTicks={false}
+        tickStroke={layout.colors.axis.stroke}
         numTicks={5}
         top={layout.yMax}
         scale={xAxisScale}

--- a/frontend/src/metabase/static-viz/timeseries/bar.js
+++ b/frontend/src/metabase/static-viz/timeseries/bar.js
@@ -74,6 +74,7 @@ export default function TimeseriesBar(
         hideTicks={false}
         numTicks={5}
         top={layout.yMax}
+        tickStroke={layout.colors.axis.stroke}
         tickFormat={d => new Date(d).toLocaleDateString("en")}
         scale={xAxisScale}
         stroke={layout.colors.axis.stroke}

--- a/frontend/src/metabase/static-viz/timeseries/line.js
+++ b/frontend/src/metabase/static-viz/timeseries/line.js
@@ -80,6 +80,7 @@ export default function TimeseriesLine(
       <AxisBottom
         label={labels.bottom || t`Dimension`}
         hideTicks={false}
+        tickStroke={layout.colors.axis.stroke}
         numTicks={5}
         top={layout.yMax}
         stroke={layout.colors.axis.stroke}


### PR DESCRIPTION
Tiny tweak to match the axis and tick stroke colors.

Before:
<img width="547" alt="Screen Shot 2021-08-30 at 11 12 18 AM" src="https://user-images.githubusercontent.com/5248953/131361830-1b86b4c3-f9e8-462a-b3e9-b3f57a0ec639.png">


After: 
<img width="585" alt="Screen Shot 2021-08-30 at 11 12 06 AM" src="https://user-images.githubusercontent.com/5248953/131361828-da97ce29-2e49-408a-ad12-76705d5cc7a8.png">