### PR TITLE
Don't throw exception when archiving a dashboard in non-root collection

### DIFF
--- a/src/metabase/models/pulse.clj
+++ b/src/metabase/models/pulse.clj
@@ -65,9 +65,10 @@
 (defn- pre-update [notification]
   (let [{:keys [collection_id dashboard_id]} (db/select-one [Pulse :collection_id :dashboard_id] :id (u/the-id notification))]
     (when (and dashboard_id
+               (contains? notification :collection_id)
                (not= (:collection_id notification) collection_id)
                (not *allow-moving-dashboard-subscriptions*))
-      (throw (ex-info (tru "collection ID of dashboard subscription cannot be directly modified") notification)))
+      (throw (ex-info (tru "collection ID of a dashboard subscription cannot be directly modified") notification)))
     (when (and dashboard_id
                (contains? notification :dashboard_id)
                (not= (:dashboard_id notification) dashboard_id))

--- a/test/metabase/models/pulse_test.clj
+++ b/test/metabase/models/pulse_test.clj
@@ -259,9 +259,9 @@
       (mt/with-temp* [Collection [{collection-id :id}]
                       Dashboard  [{dashboard-id :id}]
                       Pulse      [{pulse-id :id} {:dashboard_id dashboard-id :collection_id collection-id}]]
-        (is (thrown-with-msg? Exception #"collection ID of dashboard subscription cannot be directly modified"
+        (is (thrown-with-msg? Exception #"collection ID of a dashboard subscription cannot be directly modified"
               (db/update! Pulse pulse-id {:collection_id (inc collection-id)})))
-        (is (thrown-with-msg? Exception #"collection ID of dashboard subscription cannot be directly modified"
+        (is (thrown-with-msg? Exception #"dashboard ID of a dashboard subscription cannot be modified"
               (db/update! Pulse pulse-id {:dashboard_id (inc dashboard-id)}))))))
 
 (deftest no-archived-cards-test


### PR DESCRIPTION
Removes the assumption that `collection_id` is sent from the FE on a dashboard subscription update request. Only tests for equality w/ the existing value if the field is included.

Also updates the test assertion, which had been asserting on the wrong error message 🤦‍♂️

Fixes #17658