### PR TITLE
Fix better source mapping option 

### DIFF
--- a/docs/developers-guide/devenv.md
+++ b/docs/developers-guide/devenv.md
@@ -72,6 +72,18 @@ yarn test
 
 which will run unit and Cypress end-to-end tests in sequence.
 
+## Frontend debugging
+
+By default, we use a simple source mapping option that is optimized for speed.
+
+If you run into issues with breakpoints, especially inside jsx, please set env variable `BETTER_SOURCE_MAPS` to true before you run the server.
+
+Example:
+
+```
+BETTER_SOURCE_MAPS=true yarn dev
+```
+
 ### Cypress end-to-end tests
 
 End-to-end tests simulate realistic sequences of user interactions. Read more about how we approach end-to-end testing with Cypress in our [wiki page](https://github.com/metabase/metabase/wiki/E2E-Tests-with-Cypress).

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -245,7 +245,7 @@ if (NODE_ENV !== "production") {
   // by default enable "cheap" source maps for fast re-build speed
   // with BETTER_SOURCE_MAPS we switch to sourcemaps that work with breakpoints and makes stacktraces readable
   config.devtool = process.env.BETTER_SOURCE_MAPS
-    ? "inline-module-source-map"
+    ? "inline-source-map"
     : "cheap-module-source-map";
 
   // helps with source maps


### PR DESCRIPTION
Fixes issue where we add a JS breakpoint and it jumps to a different line.

This was an option inside the Webpack config file, but its name wasn't quite right — if we used it, the server would not run.

We also add a few lines documenting this possibility.

## How to Test

### After

Start the application with

```
BETTER_SOURCE_MAPS=true yarn dev
```

Go to http://localhost:3000/

In the browser dev tools `Sources` tab, do `cmd + O` (`ctrl + O` if in Linux etc).

Search  for`Overworld.jsx`

Add breakpoint to line 200.

Breakpoint should show up over line 200.

<hr />

### Before

Start the application with

```
yarn dev
```

Go to http://localhost:3000/

In the browser dev tools `Sources` tab, do `cmd + O` (`ctrl + O` if in Linux etc).

Search for `Overworld.jsx`

Add breakpoint to line 200.

Breakpoint should actually show up over line 206.