### PR TITLE
only apply DataSelectorContainer css hack in QuestionDataSelector

### DIFF
--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -188,6 +188,7 @@ export class UnconnectedDataSelector extends Component {
     tableFilter: PropTypes.func,
     hasTableSearch: PropTypes.bool,
     canChangeDatabase: PropTypes.bool,
+    containerClassName: PropTypes.string,
   };
 
   static defaultProps = {
@@ -766,10 +767,10 @@ export class UnconnectedDataSelector extends Component {
     return (
       <PopoverWithTrigger
         id="DataPopover"
-        containerClassName="DataPopoverContainer"
         autoWidth
         ref={this.popover}
         isInitiallyOpen={this.props.isInitiallyOpen}
+        containerClassName={this.props.containerClassName}
         triggerElement={this.getTriggerElement()}
         triggerClasses={this.getTriggerClasses()}
         horizontalAttachments={["center", "left", "right"]}

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSelector.jsx
@@ -6,6 +6,7 @@ import { DatabaseSchemaAndTableDataSelector } from "metabase/query_builder/compo
 export default function QuestionDataSelector({ query, triggerElement }) {
   return (
     <DatabaseSchemaAndTableDataSelector
+      containerClassName="DataPopoverContainer"
       hasTableSearch
       databaseQuery={{ saved: true }}
       selectedDatabaseId={query.databaseId()}

--- a/frontend/test/metabase/scenarios/native-filters/reproductions/17490.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native-filters/reproductions/17490.cy.spec.js
@@ -6,7 +6,7 @@ import {
 
 import * as SQLFilter from "../helpers/e2e-sql-filter-helpers";
 
-describe.skip("issue 17490", () => {
+describe("issue 17490", () => {
   beforeEach(() => {
     mockSessionProperty("field-filter-operators-enabled?", true);
 


### PR DESCRIPTION
Resolves #17490 

I'm limiting usage of the reduced `z-index` `DataSelector` Popover hack because we don't need it outside of the GUI query creation view, and having it causes the DataSelector to sometimes be hidden by the nav.

Here's an image of the DataSelector in the sidebar of the native query builder:

<img width="679" alt="Screen Shot 2021-08-31 at 6 12 20 PM" src="https://user-images.githubusercontent.com/13057258/131582503-6c9a3b0b-c0c5-4e00-9833-d6753acb22b3.png">


And proof that the hack is still applied in the scenario that it fixes:

<img width="595" alt="Screen Shot 2021-08-31 at 6 11 58 PM" src="https://user-images.githubusercontent.com/13057258/131582524-d4f9cb57-fc28-4a8d-9bf3-bdabe88b44d5.png">
