### PR TITLE
Collection sidebar: expand/collapse children when clicking on parent collection name

### DIFF
--- a/frontend/src/metabase/collections/containers/CollectionSidebar/Collections/CollectionsList/CollectionsList.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/Collections/CollectionsList/CollectionsList.jsx
@@ -19,22 +19,18 @@ import { PLUGIN_COLLECTIONS } from "metabase/plugins";
 
 const IRREGULAR_COLLECTION_ICON_SIZE = 14;
 
-function ToggleChildCollectionButton({ action, collectionId, isOpen }) {
+function ToggleChildCollectionButton({ isOpen }) {
   const iconName = isOpen ? "chevrondown" : "chevronright";
-
-  function handleClick(e) {
-    action(collectionId);
-  }
 
   return (
     <ExpandCollectionButton>
-      <Icon name={iconName} onClick={handleClick} size={12} />
+      <Icon name={iconName} size={12} />
     </ExpandCollectionButton>
   );
 }
 
 function Label({ action, depth, collection, isOpen }) {
-  const { children, id, name } = collection;
+  const { children, name } = collection;
 
   const isRegular = PLUGIN_COLLECTIONS.isRegularCollection(collection);
   const hasChildren =
@@ -46,13 +42,7 @@ function Label({ action, depth, collection, isOpen }) {
 
   return (
     <LabelContainer>
-      {hasChildren && (
-        <ToggleChildCollectionButton
-          action={action}
-          collectionId={id}
-          isOpen={isOpen}
-        />
-      )}
+      {hasChildren && <ToggleChildCollectionButton isOpen={isOpen} />}
 
       <CollectionListIcon
         collection={collection}
@@ -89,6 +79,7 @@ function Collection({
           // when we click on a link, if there are children,
           // expand to show sub collections
           function handleClick() {
+            action(collection.id);
             handleToggleMobileSidebar();
           }
 

--- a/frontend/src/metabase/collections/containers/CollectionSidebar/Collections/CollectionsList/CollectionsList.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/Collections/CollectionsList/CollectionsList.jsx
@@ -19,18 +19,24 @@ import { PLUGIN_COLLECTIONS } from "metabase/plugins";
 
 const IRREGULAR_COLLECTION_ICON_SIZE = 14;
 
-function ToggleChildCollectionButton({ isOpen }) {
+function ToggleChildCollectionButton({ action, collectionId, isOpen }) {
   const iconName = isOpen ? "chevrondown" : "chevronright";
+
+  function handleClick(e) {
+    e.preventDefault();
+    e.stopPropagation();
+    action(collectionId);
+  }
 
   return (
     <ExpandCollectionButton>
-      <Icon name={iconName} size={12} />
+      <Icon name={iconName} onClick={handleClick} size={12} />
     </ExpandCollectionButton>
   );
 }
 
 function Label({ action, depth, collection, isOpen }) {
-  const { children, name } = collection;
+  const { children, id, name } = collection;
 
   const isRegular = PLUGIN_COLLECTIONS.isRegularCollection(collection);
   const hasChildren =
@@ -42,7 +48,13 @@ function Label({ action, depth, collection, isOpen }) {
 
   return (
     <LabelContainer>
-      {hasChildren && <ToggleChildCollectionButton isOpen={isOpen} />}
+      {hasChildren && (
+        <ToggleChildCollectionButton
+          action={action}
+          collectionId={id}
+          isOpen={isOpen}
+        />
+      )}
 
       <CollectionListIcon
         collection={collection}

--- a/frontend/src/metabase/collections/containers/CollectionSidebar/Collections/CollectionsList/CollectionsList.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/Collections/CollectionsList/CollectionsList.jsx
@@ -23,8 +23,6 @@ function ToggleChildCollectionButton({ action, collectionId, isOpen }) {
   const iconName = isOpen ? "chevrondown" : "chevronright";
 
   function handleClick(e) {
-    e.preventDefault();
-    e.stopPropagation();
     action(collectionId);
   }
 

--- a/frontend/src/metabase/collections/containers/CollectionSidebar/Collections/CollectionsList/CollectionsList.unit.spec.js
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/Collections/CollectionsList/CollectionsList.unit.spec.js
@@ -3,6 +3,8 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { DragDropContextProvider } from "react-dnd";
 import HTML5Backend from "react-dnd-html5-backend";
+import { Router, Route } from "react-router";
+import { createMemoryHistory } from "history";
 
 import { PLUGIN_COLLECTIONS } from "metabase/plugins";
 
@@ -10,15 +12,22 @@ import CollectionsList from "./CollectionsList";
 
 describe("CollectionsList", () => {
   function setup({ collections = [], openCollections = [], ...props } = {}) {
-    render(
+    const Page = () => (
       <DragDropContextProvider backend={HTML5Backend}>
         <CollectionsList
           collections={collections}
           openCollections={openCollections}
           filter={() => true}
+          handleToggleMobileSidebar={() => false}
           {...props}
         />
-      </DragDropContextProvider>,
+      </DragDropContextProvider>
+    );
+
+    render(
+      <Router history={createMemoryHistory()}>
+        <Route path="/" component={Page} />
+      </Router>,
     );
   }
 

--- a/frontend/src/metabase/collections/containers/CollectionSidebar/Collections/CollectionsList/CollectionsList.unit.spec.js
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/Collections/CollectionsList/CollectionsList.unit.spec.js
@@ -76,7 +76,7 @@ describe("CollectionsList", () => {
       onOpen,
     });
 
-    userEvent.click(screen.getByLabelText("chevronright icon"));
+    userEvent.click(screen.getByText("Parent collection name"));
 
     expect(onOpen).toHaveBeenCalled();
   });


### PR DESCRIPTION
Fixes #17339

## How to Test

1. Have nested collections.

2. Go to a collections page

3. Click on the title of a collection that has children.

The collection should reveal its children.

4. Click again on the title of the parent collection above.

The collection should hide its children.

<img src=https://user-images.githubusercontent.com/380816/131538753-384c11df-d92a-4e44-afdb-93aee557e3e6.gif width=400 />
