### PR TITLE
Remove some superfluous return types in the queries library

### DIFF
--- a/frontend/src/metabase-lib/lib/queries/InternalQuery.js
+++ b/frontend/src/metabase-lib/lib/queries/InternalQuery.js
@@ -9,7 +9,7 @@ import AtomicQuery from "metabase-lib/lib/queries/AtomicQuery";
 //  args: [],
 // }
 export default class InternalQuery extends AtomicQuery {
-  static isDatasetQueryType(datasetQuery: DatasetQuery): boolean {
+  static isDatasetQueryType(datasetQuery: DatasetQuery) {
     return datasetQuery.type === "internal";
   }
 }

--- a/frontend/src/metabase-lib/lib/queries/NativeQuery.js
+++ b/frontend/src/metabase-lib/lib/queries/NativeQuery.js
@@ -76,7 +76,7 @@ export default class NativeQuery extends AtomicQuery {
     this._nativeDatasetQuery = (datasetQuery: NativeDatasetQuery);
   }
 
-  static isDatasetQueryType(datasetQuery: DatasetQuery): boolean {
+  static isDatasetQueryType(datasetQuery: DatasetQuery) {
     return datasetQuery && datasetQuery.type === NATIVE_QUERY_TEMPLATE.type;
   }
 
@@ -133,7 +133,7 @@ export default class NativeQuery extends AtomicQuery {
   /**
    * Returns true if the database metadata (or lack thererof indicates the user can modify and run this query
    */
-  readOnly(): boolean {
+  readOnly() {
     const database = this.database();
     return !database || database.native_permissions !== "write";
   }
@@ -168,12 +168,12 @@ export default class NativeQuery extends AtomicQuery {
     return this;
   }
 
-  hasWritePermission(): boolean {
+  hasWritePermission() {
     const database = this.database();
     return database != null && database.native_permissions === "write";
   }
 
-  supportsNativeParameters(): boolean {
+  supportsNativeParameters() {
     const database = this.database();
     return (
       database != null && _.contains(database.features, "native-parameters")
@@ -270,7 +270,7 @@ export default class NativeQuery extends AtomicQuery {
   templateTagsMap(): TemplateTags {
     return getIn(this.datasetQuery(), ["native", "template-tags"]) || {};
   }
-  allTemplateTagsAreValid(): boolean {
+  allTemplateTagsAreValid() {
     return this.templateTags().every(
       // field filters require a field
       t => !(t.type === "dimension" && t.dimension == null),

--- a/frontend/src/metabase-lib/lib/queries/StructuredQuery.js
+++ b/frontend/src/metabase-lib/lib/queries/StructuredQuery.js
@@ -72,7 +72,7 @@ export const STRUCTURED_QUERY_TEMPLATE = {
  * A wrapper around an MBQL (`query` type @type {DatasetQuery}) object
  */
 export default class StructuredQuery extends AtomicQuery {
-  static isDatasetQueryType(datasetQuery: DatasetQuery): boolean {
+  static isDatasetQueryType(datasetQuery: DatasetQuery) {
     return datasetQuery && datasetQuery.type === STRUCTURED_QUERY_TEMPLATE.type;
   }
 
@@ -117,7 +117,7 @@ export default class StructuredQuery extends AtomicQuery {
   /**
    * @returns true if this query is in a state where it can be edited. Must have database and table set, and metadata for the table loaded.
    */
-  isEditable(): boolean {
+  isEditable() {
     return this.hasMetadata();
   }
 
@@ -158,7 +158,7 @@ export default class StructuredQuery extends AtomicQuery {
   /**
    * Returns true if the database metadata (or lack thererof indicates the user can modify and run this query
    */
-  readOnly(): boolean {
+  readOnly() {
     return !this.database();
   }
 
@@ -404,7 +404,7 @@ export default class StructuredQuery extends AtomicQuery {
     }
   }
 
-  isValid(): boolean {
+  isValid() {
     if (!this.hasData()) {
       return false;
     }
@@ -647,21 +647,21 @@ export default class StructuredQuery extends AtomicQuery {
   /**
    * @returns true if the aggregation can be removed
    */
-  canRemoveAggregation(): boolean {
+  canRemoveAggregation() {
     return this.aggregations().length > 1;
   }
 
   /**
    * @returns true if the query has no aggregation
    */
-  isBareRows(): boolean {
+  isBareRows() {
     return !this.hasAggregations();
   }
 
   /**
    * @returns true if the query has no aggregation or breakouts
    */
-  isRaw(): boolean {
+  isRaw() {
     return !this.hasAggregations() && !this.hasBreakouts();
   }
 
@@ -734,14 +734,14 @@ export default class StructuredQuery extends AtomicQuery {
   /**
    * @returns whether a new breakout can be added or not
    */
-  canAddBreakout(): boolean {
+  canAddBreakout() {
     return this.breakoutOptions().count > 0;
   }
 
   /**
    * @returns whether the current query has a valid breakout
    */
-  hasValidBreakout(): boolean {
+  hasValidBreakout() {
     const breakouts = this.breakouts();
     return breakouts.length > 0 && breakouts[0].isValid();
   }
@@ -878,7 +878,7 @@ export default class StructuredQuery extends AtomicQuery {
   /**
    * @returns whether a new filter can be added or not
    */
-  canAddFilter(): boolean {
+  canAddFilter() {
     return (
       Q.canAddFilter(this.query()) &&
       (this.filterDimensionOptions().count > 0 ||
@@ -952,7 +952,7 @@ export default class StructuredQuery extends AtomicQuery {
       return new DimensionOptions(sortOptions);
     }
   }
-  canAddSort(): boolean {
+  canAddSort() {
     const sorts = this.sorts();
     return (
       this.sortOptions().count > 0 &&

--- a/frontend/src/metabase-lib/lib/queries/structured/Aggregation.js
+++ b/frontend/src/metabase-lib/lib/queries/structured/Aggregation.js
@@ -44,7 +44,7 @@ export default class Aggregation extends MBQLClause {
     return this._query.removeAggregation(this._index);
   }
 
-  canRemove(): boolean {
+  canRemove() {
     return this.remove()
       .clean()
       .isValid();
@@ -131,7 +131,7 @@ export default class Aggregation extends MBQLClause {
   /**
    * Predicate function to test if a given aggregation clause is valid
    */
-  isValid(): boolean {
+  isValid() {
     if (this.hasOptions()) {
       return this.aggregation().isValid();
     } else if (this.isStandard() && this.dimension()) {
@@ -159,21 +159,21 @@ export default class Aggregation extends MBQLClause {
   /**
    * Returns true if this is a "standard" metric
    */
-  isStandard(): boolean {
+  isStandard() {
     return AGGREGATION.isStandard(this);
   }
 
   /**
    * Returns true if this is a metric
    */
-  isMetric(): boolean {
+  isMetric() {
     return AGGREGATION.isMetric(this);
   }
 
   /**
    * Returns true if this is custom expression created with the expression editor
    */
-  isCustom(): boolean {
+  isCustom() {
     return AGGREGATION.isCustom(this);
   }
 

--- a/frontend/src/metabase-lib/lib/queries/structured/Breakout.js
+++ b/frontend/src/metabase-lib/lib/queries/structured/Breakout.js
@@ -43,7 +43,7 @@ export default class Breakout extends MBQLClause {
   /**
    * Predicate function to test if a given breakout clause is valid
    */
-  isValid(): boolean {
+  isValid() {
     const query = this.query();
     return !query || query.breakoutOptions(this).hasDimension(this.dimension());
   }

--- a/frontend/src/metabase-lib/lib/queries/structured/Filter.js
+++ b/frontend/src/metabase-lib/lib/queries/structured/Filter.js
@@ -115,28 +115,28 @@ export default class Filter extends MBQLClause {
   /**
    * Returns true if this is a "standard" filter
    */
-  isStandard(): boolean {
+  isStandard() {
     return isStandard(this);
   }
 
   /**
    * Returns true if this is a segment
    */
-  isSegment(): boolean {
+  isSegment() {
     return isSegment(this);
   }
 
   /**
    * Returns true if this is custom filter created with the expression editor
    */
-  isCustom(): boolean {
+  isCustom() {
     return isCustom(this);
   }
 
   /**
    * Returns true for filters where the first argument is a field
    */
-  isFieldFilter(): boolean {
+  isFieldFilter() {
     return isFieldFilter(this);
   }
 
@@ -308,7 +308,7 @@ export default class Filter extends MBQLClause {
     }
   }
 
-  isDimension(otherDimension: Dimension): boolean {
+  isDimension(otherDimension: Dimension) {
     const dimension = this.dimension();
     return dimension ? dimension.isEqual(otherDimension) : false;
   }

--- a/frontend/src/metabase-lib/lib/queries/structured/Join.js
+++ b/frontend/src/metabase-lib/lib/queries/structured/Join.js
@@ -535,7 +535,7 @@ export default class Join extends MBQLObjectClause {
     return this._query.removeJoin(this._index);
   }
 
-  isValid(): boolean {
+  isValid() {
     if (!this.joinedTable()) {
       return false;
     }

--- a/frontend/src/metabase-lib/lib/queries/structured/OrderBy.js
+++ b/frontend/src/metabase-lib/lib/queries/structured/OrderBy.js
@@ -43,7 +43,7 @@ export default class OrderBy extends MBQLClause {
   /**
    * Predicate function to test if a given order-by clause is valid
    */
-  isValid(): boolean {
+  isValid() {
     const query = this.query();
     return !query || query.sortOptions(this).hasDimension(this.dimension());
   }


### PR DESCRIPTION
All of these can be correctly inferred already, thus there is no need to the explicit type annotations.

This is basically continuing the strategy in #17519 but the queries library code.

**How to verify**: Open a file that refers to the class-method in `frontend/src/metabase-lib/lib/queries` with VS Code or any other editor with proper LSP integration (Vim/NeoVim with e.g. Conquer of Completion).

![image](https://user-images.githubusercontent.com/7288/131419114-3f4d1d35-caa7-43eb-9578-941feeff70ac.png)


Before and after this PR, the tooltip to display the function signature **must be the same** (this is despite the removal of explicit type annotation.
