### PR TITLE
CI with GitHub Actions: bump the timeout for front-end unit tests

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -78,7 +78,7 @@ jobs:
 
   fe-tests-unit:
     runs-on: ubuntu-20.04
-    timeout-minutes: 10
+    timeout-minutes: 12
     steps:
     - uses: actions/checkout@v2
     - name: Prepare Node.js


### PR DESCRIPTION
This is the side effect of front-ende coverage tracking (#17440).

With the code being instrumented for code coverage, and another additional time to analyze + send the code coverage to codecov.io, the typical execution runs awfully close to the 10-min limit.
Hence, add some extra room.

