### PR TITLE
Turn dataset_query into structured data in search results

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
@@ -407,9 +407,9 @@ describe("scenarios > dashboard", () => {
     assertScrollBarExists();
   });
 
-  it.skip("should show values of added dashboard card via search immediately (metabase#15959)", () => {
+  it("should show values of added dashboard card via search immediately (metabase#15959)", () => {
     /**
-     * For the reason I don't udnerstand, I could reproduce this issue ONLY if I use these specific functions in this order:
+     * For the reason I don't understand, I could reproduce this issue ONLY if I use these specific functions in this order:
      *  1. realType()
      *  2. type()
      */

--- a/src/metabase/search/scoring.clj
+++ b/src/metabase/search/scoring.clj
@@ -1,8 +1,10 @@
 (ns metabase.search.scoring
-  (:require [clojure.core.memoize :as memoize]
+  (:require [cheshire.core :as json]
+            [clojure.core.memoize :as memoize]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
             [java-time :as t]
+            [metabase.mbql.normalize :as normalize]
             [metabase.plugins.classloader :as classloader]
             [metabase.search.config :as search-config]
             [metabase.util :as u]
@@ -227,6 +229,7 @@
                           :name            collection_name
                           :authority_level collection_authority_level}
          :scores          scores)
+        (update :dataset_query #(some-> % json/parse-string normalize/normalize))
         (dissoc
          :collection_id
          :collection_name

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -76,7 +76,7 @@
   (sorted-results
    [(make-result "dashboard test dashboard", :model "dashboard", :favorite false)
     test-collection
-    (make-result "card test card", :model "card", :favorite false, :dataset_query "{}", :dashboardcard_count 0)
+    (make-result "card test card", :model "card", :favorite false, :dataset_query nil, :dashboardcard_count 0)
     (make-result "pulse test pulse", :model "pulse", :archived nil, :updated_at false)
     (merge
      (make-result "metric test metric", :model "metric", :description "Lookin' for a blueberry")
@@ -250,7 +250,7 @@
 (def ^:private dashboard-count-results
   (letfn [(make-card [dashboard-count]
             (make-result (str "dashboard-count " dashboard-count) :dashboardcard_count dashboard-count,
-                         :model "card", :favorite false, :dataset_query "{}"))]
+                         :model "card", :favorite false, :dataset_query nil))]
     (set [(make-card 5)
           (make-card 3)
           (make-card 0)])))

--- a/test/metabase/search/scoring_test.clj
+++ b/test/metabase/search/scoring_test.clj
@@ -1,5 +1,6 @@
 (ns metabase.search.scoring-test
   (:require [clojure.test :refer :all]
+            [cheshire.core :as json]
             [java-time :as t]
             [metabase.search.config :as search-config]
             [metabase.search.scoring :as search]))
@@ -271,3 +272,17 @@
                      [{:weight 100 :score 0 :name "Some score type"}
                       {:weight 100 :score 0 :name "Some other score type"}]))]
       (is (= 0 (:score (search/score-and-result scorer "" {:name "racing yo" :model "card"})))))))
+
+(deftest serialize-test
+  (testing "It normalizes dataset queries from strings"
+    (let [query  {:type     :query
+                  :query    {:source-query {:source-table 1}}
+                  :database 1}
+          result {:name          "card"
+                  :model         "card"
+                  :dataset_query (json/generate-string query)}]
+      (is (= query (-> result (#'search/serialize {} {}) :dataset_query)))))
+  (testing "Doesn't error on other models without a query"
+    (is (nil? (-> {:name "dash" :model "dashboard"}
+                  (#'search/serialize {} {})
+                  :dataset_query)))))

--- a/test/metabase/search/scoring_test.clj
+++ b/test/metabase/search/scoring_test.clj
@@ -1,6 +1,6 @@
 (ns metabase.search.scoring-test
-  (:require [clojure.test :refer :all]
-            [cheshire.core :as json]
+  (:require [cheshire.core :as json]
+            [clojure.test :refer :all]
             [java-time :as t]
             [metabase.search.config :as search-config]
             [metabase.search.scoring :as search]))


### PR DESCRIPTION
Fixes #15959 

Search results query a card's dataset query as text but we need to send it back as structured data afterwards

#### Before
```javascript
{
      "name": "bar - races count",
      ...
      "dataset_query": "{\"type\":\"query\",\"query\":{\"source-query\":{\"source-table\":62,\"aggregation\":[[\"count\"]],\"breakout\":[[\"field\",379,null]]},\"filter\":[\">\",[\"field\",\"count\",{\"base-type\":\"type/Integer\"}],20]},\"database\":13}",
      "id": 5867,
            
    },
```

#### After
```javascript
 {
      "name": "bar - races count",
      ...
      "dataset_query": {
        "type": "query",
        "query": {
          "source-query": {
            "source-table": 62,
            "aggregation": [
              [
                "count"
              ]
            ],
            "breakout": [
              [
                "field",
                379,
                null
              ]
            ]
          },
          "filter": [
            ">",
            [
              "field",
              "count",
              {
                "base-type": "type/Integer"
              }
            ],
            20
          ]
        },
        "database": 13
      },
      ...
    },
```