### PR TITLE
Remove Cypress from yarn `resolutions`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -784,7 +784,7 @@ jobs:
             - restore-fe-deps-cache
             - run:
                 name: Run yarn to install deps
-                command: yarn;
+                command: rm -rf node_modules/ && yarn --frozen-lockfile;
                 no_output_timeout: 15m
             - save_cache:
                 name: Cache frontend dependencies

--- a/package.json
+++ b/package.json
@@ -217,7 +217,6 @@
     ]
   },
   "resolutions": {
-    "cypress": "6.8.0",
     "styled-components": "3.2.6",
     "styled-system": "2.2.5"
   },


### PR DESCRIPTION
Since the Webpack and Babel upgrades, this shouldn't be needed any more. In the past, we **had to** explicitly resolve to the specific version of Cypress. Now it resolves to this version by default.