### PR TITLE
Day Picker: Add "on" string to the translation

### DIFF
--- a/frontend/src/metabase/components/SchedulePicker.jsx
+++ b/frontend/src/metabase/components/SchedulePicker.jsx
@@ -175,7 +175,7 @@ export default class SchedulePicker extends Component {
 
     return (
       <span className="flex align-center">
-        <span className="text-bold mx1">on</span>
+        <span className="text-bold mx1">{t`on`}</span>
         <Select
           className="text-bold bg-white"
           value={schedule.schedule_day}


### PR DESCRIPTION
Day picker in the `SchedulePicker` component had the untranslated  preposition `on`.

This PR fixes that.