### PR TITLE
Fix #17673: Rounded buttons have excessive white background

### DIFF
--- a/frontend/src/metabase/components/SchedulePicker.jsx
+++ b/frontend/src/metabase/components/SchedulePicker.jsx
@@ -147,7 +147,7 @@ export default class SchedulePicker extends Component {
           style={{ minWidth: "48px" }}
         >{t`on the`}</span>
         <Select
-          className="text-bold bg-white"
+          className="text-bold"
           value={schedule.schedule_frame}
           onChange={({ target: { value } }) =>
             this.handleChangeProperty("schedule_frame", value)
@@ -157,7 +157,7 @@ export default class SchedulePicker extends Component {
         {schedule.schedule_frame !== "mid" && (
           <span className="mx1">
             <Select
-              className="text-bold bg-white"
+              className="text-bold"
               value={schedule.schedule_day}
               onChange={({ target: { value } }) =>
                 this.handleChangeProperty("schedule_day", value)
@@ -177,7 +177,7 @@ export default class SchedulePicker extends Component {
       <span className="flex align-center">
         <span className="text-bold mx1">{t`on`}</span>
         <Select
-          className="text-bold bg-white"
+          className="text-bold"
           value={schedule.schedule_day}
           onChange={({ target: { value } }) =>
             this.handleChangeProperty("schedule_day", value)
@@ -201,7 +201,7 @@ export default class SchedulePicker extends Component {
             style={{ minWidth: "48px" }}
           >{t`at`}</span>
           <Select
-            className="mr1 text-bold bg-white"
+            className="mr1 text-bold"
             value={minuteOfHour}
             options={MINUTE_OPTIONS}
             onChange={({ target: { value } }) =>
@@ -231,7 +231,7 @@ export default class SchedulePicker extends Component {
             style={{ minWidth: "48px" }}
           >{t`at`}</span>
           <Select
-            className="mr1 text-bold bg-white"
+            className="mr1 text-bold"
             value={hour}
             options={HOUR_OPTIONS}
             onChange={({ target: { value } }) =>
@@ -269,7 +269,7 @@ export default class SchedulePicker extends Component {
             {textBeforeInterval}
           </span>
           <Select
-            className="text-bold bg-white"
+            className="text-bold"
             value={scheduleType}
             onChange={({ target: { value } }) =>
               this.handleChangeProperty("schedule_type", value)

--- a/frontend/src/metabase/components/SchedulePicker.jsx
+++ b/frontend/src/metabase/components/SchedulePicker.jsx
@@ -147,7 +147,6 @@ export default class SchedulePicker extends Component {
           style={{ minWidth: "48px" }}
         >{t`on the`}</span>
         <Select
-          className="text-bold"
           value={schedule.schedule_frame}
           onChange={({ target: { value } }) =>
             this.handleChangeProperty("schedule_frame", value)
@@ -157,7 +156,6 @@ export default class SchedulePicker extends Component {
         {schedule.schedule_frame !== "mid" && (
           <span className="mx1">
             <Select
-              className="text-bold"
               value={schedule.schedule_day}
               onChange={({ target: { value } }) =>
                 this.handleChangeProperty("schedule_day", value)
@@ -177,7 +175,6 @@ export default class SchedulePicker extends Component {
       <span className="flex align-center">
         <span className="text-bold mx1">{t`on`}</span>
         <Select
-          className="text-bold"
           value={schedule.schedule_day}
           onChange={({ target: { value } }) =>
             this.handleChangeProperty("schedule_day", value)
@@ -201,7 +198,7 @@ export default class SchedulePicker extends Component {
             style={{ minWidth: "48px" }}
           >{t`at`}</span>
           <Select
-            className="mr1 text-bold"
+            className="mr1"
             value={minuteOfHour}
             options={MINUTE_OPTIONS}
             onChange={({ target: { value } }) =>
@@ -231,7 +228,7 @@ export default class SchedulePicker extends Component {
             style={{ minWidth: "48px" }}
           >{t`at`}</span>
           <Select
-            className="mr1 text-bold"
+            className="mr1"
             value={hour}
             options={HOUR_OPTIONS}
             onChange={({ target: { value } }) =>
@@ -269,7 +266,6 @@ export default class SchedulePicker extends Component {
             {textBeforeInterval}
           </span>
           <Select
-            className="text-bold"
             value={scheduleType}
             onChange={({ target: { value } }) =>
               this.handleChangeProperty("schedule_type", value)


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Fixes CSS issues with our custom `select` picker components
- As described in the original issue, there was a white background around that component and it came from its parent/container
    - This PR removes the background color from the container
- Additionally removes superfluous `text-bold` CSS class from the container
    - It is not needed because `.AdminSelect` class already sets the `font-weight` property
```css
.AdminSelect {
    display: inline-block;
    padding: 0.6em;
    border: 1px solid #f0f0f0;
    background-color: #ffffff; /* the reason why we didn't need background-color in the container as well */
    border-radius: 8px;
    font-weight: 700; /* the reason why we didn't need to set `text-bold` class on the container */
    min-width: 104px;
}
```
- Closes #17673 

### Before this PR:
![image](https://user-images.githubusercontent.com/31325167/131568796-2fb22717-1f66-497b-9d3d-0fca66b32e9f.png)

### After this PR:
![image](https://user-images.githubusercontent.com/31325167/131568599-a825ae82-4885-4b71-9417-d66b8afe2347.png)

### How to test?
Go to any dashboard's subscriptions or any other component that uses hourly, daily, weekly or monthly picker. Change the background of the sidebar in dev tools to something really obnoxious to make this change obvious. There should be no rectangular white background around the "pill-shaped" select component.