### PR TITLE
#17658 Repro: Not possible to delete dashboard subscription unless dashboard is in root collection

### DIFF
--- a/frontend/test/metabase/scenarios/sharing/reproductions/17658.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/reproductions/17658.cy.spec.js
@@ -1,0 +1,101 @@
+import { restore } from "__support__/e2e/cypress";
+
+describe("issue 17658", () => {
+  beforeEach(() => {
+    cy.intercept("PUT", "/api/pulse/*").as("deletePulse");
+    restore();
+    cy.signInAsAdmin();
+
+    setUpEmail();
+
+    moveDashboardToCollection("First collection");
+  });
+
+  it("should delete dashboard subscription from any collection (metabase#17658)", () => {
+    cy.visit("/dashboard/1");
+
+    cy.icon("share").click();
+    cy.findByText("Dashboard subscriptions").click();
+
+    cy.findByText(/^Emailed monthly/).click();
+
+    cy.findByText("Delete this subscription").click();
+    cy.findByText(/^This dashboard will no longer be emailed to/).click();
+
+    cy.button("Delete").click();
+
+    cy.wait("@deletePulse").then(({ response }) => {
+      expect(response.body.cause).not.to.exist;
+      expect(response.statusCode).not.to.eq(500);
+    });
+
+    cy.button("Delete").should("not.exist");
+  });
+});
+
+function moveDashboardToCollection(collectionName) {
+  cy.request("GET", "/api/collection/tree?tree=true").then(
+    ({ body: collections }) => {
+      const { id } = collections.find(
+        collection => collection.name === collectionName,
+      );
+
+      // Move dashboard
+      cy.request("PUT", "/api/dashboard/1", { collection_id: id });
+
+      // Create subscription
+      cy.request("POST", "/api/pulse", {
+        name: "Orders in a dashboard",
+        cards: [
+          {
+            id: 1,
+            collection_id: null,
+            description: null,
+            display: "table",
+            name: "Orders",
+            include_csv: false,
+            include_xls: false,
+            dashboard_card_id: 1,
+            dashboard_id: 1,
+            parameter_mappings: [],
+          },
+        ],
+        channels: [
+          {
+            channel_type: "email",
+            enabled: true,
+            recipients: [
+              {
+                id: 1,
+                email: "admin@metabase.test",
+                first_name: "Bobby",
+                last_name: "Tables",
+                common_name: "Bobby Tables",
+              },
+            ],
+            details: {},
+            schedule_type: "monthly",
+            schedule_day: "mon",
+            schedule_hour: 8,
+            schedule_frame: "first",
+          },
+        ],
+        skip_if_empty: false,
+        collection_id: id,
+        parameters: [],
+        dashboard_id: 1,
+      });
+    },
+  );
+}
+
+function setUpEmail() {
+  cy.request("PUT", "/api/setting", {
+    "email-smtp-host": "localhost",
+    "email-smtp-port": "25",
+    "email-smtp-username": "admin",
+    "email-smtp-password": "admin",
+    "email-smtp-security": "none",
+    "email-from-address": "mailer@metabase.test",
+  });
+}


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #17658 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/sharing/reproductions/17658.cy.spec.js`
- All tests should pass

### Additional notes:
- The bug was fixed in #17670

### Screenshots:

Before the fix
![Screen Shot 2021-08-31 at 11 32 48 PM](https://user-images.githubusercontent.com/31325167/131580164-1cec10cb-680c-443b-8583-3deb9a68c915.png)

After the fix
![image](https://user-images.githubusercontent.com/31325167/131580199-538011bf-509b-4ee3-a2d3-427b5807c297.png)

