### PR TITLE
Fix Cypress binary not being available

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -784,7 +784,7 @@ jobs:
             - restore-fe-deps-cache
             - run:
                 name: Run yarn to install deps
-                command: yarn;
+                command: rm -rf node_modules/ && yarn --frozen-lockfile;
                 no_output_timeout: 15m
             - save_cache:
                 name: Cache frontend dependencies


### PR DESCRIPTION
The node_modules folder was being persisted in the first step (checkout) as it's doing the building of the static viz package. This had an impact in the fe-deps step, so wiping the folder and doing a clean install should make the trick