### PR TITLE
Fix joins with incomplete conditions are removed on query run

### DIFF
--- a/frontend/src/metabase-lib/lib/queries/StructuredQuery.js
+++ b/frontend/src/metabase-lib/lib/queries/StructuredQuery.js
@@ -361,7 +361,11 @@ export default class StructuredQuery extends AtomicQuery {
   }
 
   cleanJoins(): StructuredQuery {
-    return this._cleanClauseList("joins");
+    let query = this;
+    this.joins().forEach((join, index) => {
+      query = query.updateJoin(index, join.clean());
+    });
+    return query._cleanClauseList("joins");
   }
 
   cleanExpressions(): StructuredQuery {

--- a/frontend/src/metabase-lib/lib/queries/structured/Join.js
+++ b/frontend/src/metabase-lib/lib/queries/structured/Join.js
@@ -551,7 +551,8 @@ export default class Join extends MBQLObjectClause {
   }
 
   clean() {
-    if (!this.condition || this.isValid()) {
+    const invalidAndCantFix = !this.condition || !this.joinedTable();
+    if (invalidAndCantFix || this.isValid()) {
       return this;
     }
     let join = this;

--- a/frontend/src/metabase-lib/lib/queries/structured/Join.js
+++ b/frontend/src/metabase-lib/lib/queries/structured/Join.js
@@ -283,7 +283,7 @@ export default class Join extends MBQLObjectClause {
       return this;
     }
     if (this.isSingleConditionJoin()) {
-      return this.setCondition(undefined);
+      return this.setCondition(null);
     }
     const filteredCondition = this.condition.filter((_, i) => {
       // Adding 1 because the first element of a condition is an operator ("and")
@@ -548,5 +548,28 @@ export default class Join extends MBQLObjectClause {
       joinDimensions.every(Boolean) &&
       parentDimensions.length === joinDimensions.length
     );
+  }
+
+  clean() {
+    if (!this.condition || this.isValid()) {
+      return this;
+    }
+    let join = this;
+
+    let invalidDimensionIndex = this.parentDimensions().findIndex(
+      dimension => dimension == null,
+    );
+    if (invalidDimensionIndex >= 0) {
+      join = this.removeCondition(invalidDimensionIndex);
+    }
+
+    invalidDimensionIndex = this.joinDimensions().findIndex(
+      dimension => dimension == null,
+    );
+    if (invalidDimensionIndex >= 0) {
+      join = this.removeCondition(invalidDimensionIndex);
+    }
+
+    return join.clean();
   }
 }

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx
@@ -90,6 +90,11 @@ const STEP_UI = {
   },
 };
 
+function getTestId(step) {
+  const { type, stageIndex, itemIndex } = step;
+  return `step-${type}-${stageIndex || 0}-${itemIndex || 0}`;
+}
+
 const CONTENT_WIDTH = [11 / 12, 8 / 12];
 
 export default class NotebookStep extends React.Component {
@@ -147,7 +152,12 @@ export default class NotebookStep extends React.Component {
 
     return (
       <ExpandingContent isInitiallyOpen={!isLastOpened} isOpen>
-        <Box mb={[1, 2]} pb={[1, 2]} className="hover-parent hover--visibility">
+        <Box
+          mb={[1, 2]}
+          pb={[1, 2]}
+          className="hover-parent hover--visibility"
+          data-testid={getTestId(step)}
+        >
           {(title || onRemove) && (
             <Flex
               mb={1}

--- a/frontend/test/metabase-lib/lib/queries/StructuredQuery-clean.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/StructuredQuery-clean.unit.spec.js
@@ -43,14 +43,14 @@ describe("StructuredQuery", () => {
         expect(q.clean().query()).toEqual({ "source-table": 12345 });
       });
 
-      xit("should remove join referencing invalid source field", () => {
+      it("should remove join referencing invalid source field", () => {
         const q = ORDERS.query().join(
           getJoin({ condition: ["=", null, PRODUCT_ID_FIELD_REF] }),
         );
         expect(q.clean().query()).toEqual({ "source-table": ORDERS.id });
       });
 
-      xit("should remove join referencing invalid join field", () => {
+      it("should remove join referencing invalid join field", () => {
         const q = ORDERS.query().join(
           getJoin({ condition: ["=", ORDERS_PRODUCT_ID_FIELD_REF, null] }),
         );

--- a/frontend/test/metabase-lib/lib/queries/StructuredQuery-clean.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/StructuredQuery-clean.unit.spec.js
@@ -29,7 +29,7 @@ describe("StructuredQuery", () => {
         expect(q.clean() === q).toBe(true);
       });
 
-      xit("should remove join referencing invalid source-table", () => {
+      it.skip("should remove join referencing invalid source-table", () => {
         const q = ORDERS.query()
           .setTableId(12345)
           .join([JOIN]);
@@ -98,7 +98,7 @@ describe("StructuredQuery", () => {
           expect(q.clean().query()).toEqual(q.query());
           expect(q.clean() === q).toBe(true);
         });
-        xit("should remove invalid named aggregations", () => {
+        it.skip("should remove invalid named aggregations", () => {
           const q = ORDERS.query().aggregate([
             "aggregation-option",
             ["invalid"],
@@ -139,7 +139,7 @@ describe("StructuredQuery", () => {
           expect(q.clean().query()).toEqual(q.query());
           expect(q.clean() === q).toBe(true);
         });
-        xit("should remove aggregations referencing invalid field ID", () => {
+        it.skip("should remove aggregations referencing invalid field ID", () => {
           const q = ORDERS.query().aggregate([
             ["+", ["avg", ["field", 12345, null]], 1],
           ]);
@@ -196,7 +196,7 @@ describe("StructuredQuery", () => {
         expect(q.clean() === q).toBe(true);
       });
 
-      xit("should remove sort referencing invalid field ID", () => {
+      it.skip("should remove sort referencing invalid field ID", () => {
         const q = ORDERS.query().sort(["asc", ["field", 12345, null]]);
         expect(q.clean().query()).toEqual({ "source-table": ORDERS.id });
       });

--- a/frontend/test/metabase-lib/lib/queries/structured/Join.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/structured/Join.unit.spec.js
@@ -661,6 +661,23 @@ describe("Join", () => {
           "source-table": PRODUCTS.id,
         });
       });
+
+      it("does nothing if the joined table is invalid", () => {
+        const join = getJoin({
+          query: getOrdersJoinQuery({
+            condition: ORDERS_PRODUCT_JOIN_CONDITION,
+            sourceTable: "invalid",
+          }),
+        });
+
+        const cleanJoin = join.clean();
+
+        expect(cleanJoin).toEqual({
+          alias: "Products",
+          condition: ORDERS_PRODUCT_JOIN_CONDITION,
+          "source-table": "invalid",
+        });
+      });
     });
   });
 });

--- a/frontend/test/metabase/scenarios/question/reproductions/17710-notebook-incomplete-joins-removed.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/17710-notebook-incomplete-joins-removed.cy.spec.js
@@ -1,0 +1,38 @@
+import { restore, popover, openOrdersTable } from "__support__/e2e/cypress";
+
+describe("issue 17710", () => {
+  beforeEach(() => {
+    cy.intercept("POST", "/api/dataset").as("dataset");
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should remove only invalid join clauses (metabase#17710)", () => {
+    openOrdersTable({ mode: "notebook" });
+
+    cy.findByText("Join data").click();
+    popover()
+      .findByText("Products")
+      .click();
+
+    cy.findByTestId("step-join-0-0").within(() => {
+      cy.icon("add").click();
+    });
+
+    visualizeResults();
+
+    cy.icon("notebook")
+      .click()
+      .then(() => {
+        cy.findByTestId("step-join-0-0").within(() => {
+          cy.findByText("ID");
+          cy.findByText("Product ID");
+        });
+      });
+  });
+});
+
+function visualizeResults() {
+  cy.button("Visualize").click();
+  cy.wait("@dataset");
+}


### PR DESCRIPTION
Followup on [this comment](https://github.com/metabase/metabase/pull/17633#issuecomment-908330423) from #17633. In notebook editor, if you have an incomplete join condition (e.g. you specified the left join field, but not the right one), once you click "Visualise" to run the query, the whole join gets removed. [It worked that way earlier](https://github.com/metabase/metabase/pull/17633#issuecomment-908527953), but with joins on multiple fields it became much easier to face the problem.

This happens because of the current "query lifecycle" in the notebook editor. Right before Metabase runs the query after a user clicks "Visualize", it invokes the `StructuredQuery's` [`clean` method](https://github.com/metabase/metabase/blob/cd758c966f59beddfeb75eae64ac54020dbfa9af/frontend/src/metabase-lib/lib/queries/StructuredQuery.js#L324) that removes invalid MBQL clauses from it.

A [`Join` instance](https://github.com/metabase/metabase/blob/cd758c966f59beddfeb75eae64ac54020dbfa9af/frontend/src/metabase-lib/lib/queries/structured/Join.js#L538) is considered invalid if at least one join field is not specified (left or right). Right now, multiple fields join would be treated as invalid if it has _just one_ incomplete pair of fields. E.g. we join Orders and Products on `orders.PRODUCT_ID = products.ID` and have a `orders.CREATED_AT = N/A`. Because of a single missed field, the whole join will be removed, no matter how many valid field pairs it has.

Reproduces #17710, fixes #17710

**About the fix**

This PR adds a `clean` method to `Join` that would remove incomplete conditions and keep the valid ones. So if we join Orders and Products on `orders.PRODUCT_ID = products.ID` and have a `orders.CREATED_AT = N/A`, after `clean` is invoked, the join will only contain the `orders.PRODUCT_ID = products.ID` condition.

On top of that, this PR updates `StructuredQuery's` `cleanJoins` method. Normally `cleanJoins` will just drop any invalid join (and lose the valid conditions). In this PR, it starts by sequentially calling `join.clean()` for every join the query has. After that, it follows the rest of the `cleanJoins` flow, but now `cleanJoins` will only remove completely invalid joins (e.g. ones without a table / any field / just one field specified).

### To Verify

1. Ask a question > Custom Question > Sample Dataset > Orders
2. Join the Products table, you should see Metabase automatically suggests joining on `PRODUCT_ID` FK
3. Click "Visualize", then open the notebook editor back (with an icon in the top right corner). You should see the join sections
4. Click the "+" icon on the right side of the join section. Two cells with "Pick a column..." labels should appear. Don't touch them. Click "Visualize" again, open the notebook editor back. You should see two empty cells disappeared, but the `PRODUCT_ID` condition has to be there.
5. Click the "+" icon again, but select _just a one_ field now (left OR right). Click "Visualize" again, open the notebook editor back. You should see the incomplete condition disappeared, but the `PRODUCT_ID` condition has to be there.

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/131647933-9a274d1c-43be-4d00-8c92-e66bff58b99e.mov

**After**

https://user-images.githubusercontent.com/17258145/131647955-53b74609-109c-4361-97d6-f8ceb0100dd2.mov
