### PR TITLE
Remove Cypress from yarn `resolutions`

### DIFF
--- a/package.json
+++ b/package.json
@@ -217,7 +217,6 @@
     ]
   },
   "resolutions": {
-    "cypress": "6.8.0",
     "styled-components": "3.2.6",
     "styled-system": "2.2.5"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5155,7 +5155,7 @@ cypress-real-events@^1.4.0:
   resolved "https://registry.yarnpkg.com/cypress-real-events/-/cypress-real-events-1.4.0.tgz#39575031a4020581e0bbf105d7a306ee57d94f48"
   integrity sha512-1s4BQN1D++vFSuaad0qKsWcoApM5tQqPBFyDJEa6JeCZIsAdgMdGLuKi5QNIdl5KTJix0jxglzFJAThyz3borQ==
 
-cypress@*, cypress@6.8.0, cypress@^6.8.0:
+cypress@*, cypress@^6.8.0:
   version "6.8.0"
   resolved "https://registry.yarnpkg.com/cypress/-/cypress-6.8.0.tgz#8338f39212a8f71e91ff8c017a1b6e22d823d8c1"
   integrity sha512-W2e9Oqi7DmF48QtOD0LfsOLVq6ef2hcXZvJXI/E3PgFNmZXEVwBefhAxVCW9yTPortjYA2XkM20KyC4HRkOm9w==


### PR DESCRIPTION
Since the Webpack and Babel upgrades, this shouldn't be needed any more. In the past, we had to explicitly resolve to the specific version of Cypress. Now it resolves to this version by default.