### PR TITLE
Make dashboard filters sticky in edit mode

### DIFF
--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -248,6 +248,7 @@ export default class Dashboard extends Component {
 
             <DashboardBody isEditingOrSharing={isEditing || isSharing}>
               <ParametersAndCardsContainer
+                data-testid="dashboard-parameters-and-cards"
                 innerRef={element =>
                   (this.parametersAndCardsContainerRef = element)
                 }

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -210,6 +210,9 @@ export default class Dashboard extends Component {
       />
     );
 
+    const shouldRenderParametersWidgetInViewMode =
+      !isEditing && !isFullscreen && parametersWidget;
+
     return (
       <DashboardLoadingAndErrorWrapper
         isFullHeight={isEditing || isSharing}
@@ -235,6 +238,12 @@ export default class Dashboard extends Component {
                 onToggleAddQuestionSidebar={this.onToggleAddQuestionSidebar}
                 showAddQuestionSidebar={showAddQuestionSidebar}
               />
+
+              {isEditing && (
+                <ParametersWidgetContainer isEditing={isEditing}>
+                  {parametersWidget}
+                </ParametersWidgetContainer>
+              )}
             </HeaderContainer>
 
             <DashboardBody isEditingOrSharing={isEditing || isSharing}>
@@ -243,7 +252,7 @@ export default class Dashboard extends Component {
                   (this.parametersAndCardsContainerRef = element)
                 }
               >
-                {!isFullscreen && parametersWidget && (
+                {shouldRenderParametersWidgetInViewMode && (
                   <ParametersWidgetContainer
                     innerRef={element => (this.parametersWidgetRef = element)}
                     isSticky={isParametersWidgetSticky}

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.jsx
@@ -82,6 +82,12 @@ export const ParametersWidgetContainer = styled(FullWidthContainer)`
   padding-bottom: ${space(1)};
   z-index: 4;
 
+  ${({ isEditing }) =>
+    isEditing &&
+    css`
+      border-top: 1px solid ${color("border")};
+    `}
+
   ${({ isSticky }) =>
     isSticky &&
     css`

--- a/frontend/test/metabase-visual/dashboard/parameters-widget.cy.spec.js
+++ b/frontend/test/metabase-visual/dashboard/parameters-widget.cy.spec.js
@@ -48,4 +48,16 @@ describe("visual tests > dashboard > parameters widget", () => {
 
     cy.percySnapshot();
   });
+
+  it("is sticky in edit mode", () => {
+    cy.findByText("test question");
+
+    cy.icon("pencil").click();
+
+    cy.findByTestId("dashboard-parameters-and-cards")
+      .scrollTo(0, 464)
+      .then(() => {
+        cy.percySnapshot();
+      });
+  });
 });


### PR DESCRIPTION
## How to Test

1. Make a tall dashboard — for example, a dashboard with a card tall enough to make the browser window scrollable
2. Visit that dashboard page
3. Click on the pencil icon to enter edit mode
4. Scroll

Filters should not scroll along now.

![Metabase Sticky Param](https://user-images.githubusercontent.com/380816/131739086-73824380-515d-48d3-832a-e27fca3ee55b.gif)
