### PR TITLE
Allow creating & editing dashboard subscriptions if you have view-only access to a collection

### DIFF
--- a/src/metabase/api/pulse.clj
+++ b/src/metabase/api/pulse.clj
@@ -65,11 +65,13 @@
    parameters          [su/Map]}
   ;; make sure we are allowed to *read* all the Cards we want to put in this Pulse
   (check-card-read-permissions cards)
-  ;; if we're trying to create this Pulse inside a Collection, make sure we have write permissions for that collection
-  (collection/check-write-perms-for-collection collection_id)
-  ;; prohibit sending dashboard subs for unauthorized dashboards
+  ;; if we're trying to create this Pulse inside a Collection, and it is not a dashboard subscription,
+  ;; make sure we have write permissions for that collection
+  (when-not dashboard_id
+    (collection/check-write-perms-for-collection collection_id))
+  ;; prohibit creating dashboard subs if the the user doesn't have at least read access for the dashboard
   (when dashboard_id
-    (api/write-check Dashboard dashboard_id))
+    (api/read-check Dashboard dashboard_id))
   (let [pulse-data {:name                name
                     :creator_id          api/*current-user-id*
                     :skip_if_empty       skip_if_empty

--- a/src/metabase/models/pulse.clj
+++ b/src/metabase/models/pulse.clj
@@ -32,7 +32,8 @@
             [schema.core :as s]
             [toucan.db :as db]
             [toucan.hydrate :refer [hydrate]]
-            [toucan.models :as models]))
+            [toucan.models :as models]
+            [metabase.api.common :as api]))
 
 ;;; ----------------------------------------------- Entity & Lifecycle -----------------------------------------------
 
@@ -94,8 +95,13 @@
   [notification]
   (boolean (:alert_condition notification)))
 
+(defn- is-dashboard-subscription?
+  "Whether `notification` is a Dashboard Subscription (as opposed to a regular Pulse or an Alert)."
+  [notification]
+  (boolean (:dashboard_id notification)))
+
 (defn- perms-objects-set
-  "Permissions to read or write a *Pulse* are the same as those of its parent Collection.
+  "Permissions to read or write a *Pulse* or *Dashboard Subscription* are the same as those of its parent Collection.
 
   Permissions to read or write an *Alert* are the same as those of its 'parent' *Card*. For all intents and purposes,
   an Alert cannot be put into a Collection."
@@ -103,6 +109,16 @@
   (if (is-alert? notification)
     (i/perms-objects-set (alert->card notification) read-or-write)
     (perms/perms-objects-set-for-parent-collection notification read-or-write)))
+
+(defn- can-write?
+  "A user with read-only permissions for a dashboard should be able to create subscriptions, and update
+  subscriptions that they created, but not edit anyone else's subscriptions."
+  [notification]
+  (if (and (is-dashboard-subscription? notification)
+           (i/current-user-has-full-permissions? :read notification)
+           (not (i/current-user-has-full-permissions? :write notification)))
+    (= api/*current-user-id* (:creator_id notification))
+    (i/current-user-has-full-permissions? :write notification)))
 
 (u/strict-extend (class Pulse)
   models/IModel
@@ -117,7 +133,7 @@
   (merge
    i/IObjectPermissionsDefaults
    {:can-read?         (partial i/current-user-has-full-permissions? :read)
-    :can-write?        (partial i/current-user-has-full-permissions? :write)
+    :can-write?        can-write?
     :perms-objects-set perms-objects-set}))
 
 

--- a/src/metabase/models/pulse.clj
+++ b/src/metabase/models/pulse.clj
@@ -17,6 +17,7 @@
   (:require [clojure.string :as str]
             [clojure.tools.logging :as log]
             [medley.core :as m]
+            [metabase.api.common :as api]
             [metabase.events :as events]
             [metabase.models.card :refer [Card]]
             [metabase.models.collection :as collection]
@@ -32,8 +33,7 @@
             [schema.core :as s]
             [toucan.db :as db]
             [toucan.hydrate :refer [hydrate]]
-            [toucan.models :as models]
-            [metabase.api.common :as api]))
+            [toucan.models :as models]))
 
 ;;; ----------------------------------------------- Entity & Lifecycle -----------------------------------------------
 


### PR DESCRIPTION
Updates the `Pulse` permission checks so that a user with read-only access to a collection can still create dashboard subscriptions in the collection, and edit ones that they created.

Also adds tests & test macros for dashboard subscription permissions based on the similar tests for pulses.