### PR TITLE
URI encode schema names in links

### DIFF
--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions.js
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions.js
@@ -302,7 +302,8 @@ const buildTablesPermissions = (
       postActions: {
         controlled: () =>
           push(
-            `/admin/permissions/data/group/${groupId}/database/${entityId.databaseId}/schema/${entityId.schemaName}`,
+            `/admin/permissions/data/group/${groupId}/database/${entityId.databaseId}/schema/` +
+              encodeURIComponent(entityId.schemaName),
           ),
       },
       options: [

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions.unit.spec.fixtures.js
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions.unit.spec.fixtures.js
@@ -15,6 +15,8 @@ export const normalizedMetadata = {
         7,
         8,
         9,
+        // In schema/4
+        14,
       ],
       id: 2,
     },
@@ -39,6 +41,11 @@ export const normalizedMetadata = {
       id: "3:",
       name: null,
       database: 3,
+    },
+    "4:schema/4": {
+      id: "4:schema/4",
+      name: "schema/4",
+      database: 2,
     },
   },
   tables: {
@@ -113,6 +120,14 @@ export const normalizedMetadata = {
       display_name: "Badminton Mixed Singles Results",
       id: 13,
       db_id: 3,
+    },
+    "14": {
+      schema: "4:schema/4",
+      schema_name: "schema/4",
+      name: "Biggie Sightings Cities",
+      display_name: "Biggie Sightings Cities",
+      id: 14,
+      db_id: 2,
     },
   },
   fields: {

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions.unit.spec.js
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions.unit.spec.js
@@ -190,6 +190,27 @@ describe("getDatabasesSidebar", () => {
             id: "schema:schema_2",
             name: "schema_2",
           },
+          {
+            children: [
+              {
+                entityId: {
+                  databaseId: 2,
+                  schemaName: "schema/4",
+                  tableId: 14,
+                },
+                icon: "table",
+                id: "table:14",
+                name: "Biggie Sightings Cities",
+              },
+            ],
+            entityId: {
+              databaseId: 2,
+              schemaName: "schema/4",
+            },
+            icon: "folder",
+            id: "schema:schema/4",
+            name: "schema/4",
+          },
         ],
       ]);
     });

--- a/frontend/src/metabase/admin/permissions/utils/urls.js
+++ b/frontend/src/metabase/admin/permissions/utils/urls.js
@@ -14,12 +14,17 @@ export const getDatabaseFocusPermissionsUrl = entityId => {
 
   if (isTableEntityId(entityId)) {
     return entityId.schemaName != null
-      ? `${DATABASES_BASE_PATH}/${entityId.databaseId}/schema/${entityId.schemaName}/table/${entityId.tableId}`
+      ? `${DATABASES_BASE_PATH}/${entityId.databaseId}/schema/` +
+          encodeURIComponent(entityId.schemaName) +
+          `/table/${entityId.tableId}`
       : `${DATABASES_BASE_PATH}/${entityId.databaseId}/table/${entityId.tableId}`;
   }
 
   if (isSchemaEntityId(entityId)) {
-    return `${DATABASES_BASE_PATH}/${entityId.databaseId}/schema/${entityId.schemaName}`;
+    return (
+      `${DATABASES_BASE_PATH}/${entityId.databaseId}/schema/` +
+      encodeURIComponent(entityId.schemaName)
+    );
   }
 
   if (isDatabaseEntityId(entityId)) {
@@ -41,6 +46,9 @@ export const getGroupFocusPermissionsUrl = (groupId, entityId) => {
   }
 
   if (isSchemaEntityId(entityId)) {
-    return `${GROUPS_BASE_PATH}/${groupId}/database/${entityId.databaseId}/schema/${entityId.schemaName}`;
+    return (
+      `${GROUPS_BASE_PATH}/${groupId}/database/${entityId.databaseId}/schema/` +
+      encodeURIComponent(entityId.schemaName)
+    );
   }
 };

--- a/frontend/src/metabase/admin/permissions/utils/urls.unit.spec.js
+++ b/frontend/src/metabase/admin/permissions/utils/urls.unit.spec.js
@@ -22,6 +22,16 @@ describe("getDatabaseFocusPermissionsUrl", () => {
     expect(url).toEqual("/admin/permissions/data/database/1/schema/my_schema");
   });
 
+  it("when entityId is a schema with a / id it returns database permissions url", () => {
+    const url = getDatabaseFocusPermissionsUrl({
+      databaseId: 1,
+      schemaName: "my/schema",
+    });
+    expect(url).toEqual(
+      "/admin/permissions/data/database/1/schema/my%2Fschema",
+    );
+  });
+
   it("when entityId is a table id with schema it returns table permissions url", () => {
     const url = getDatabaseFocusPermissionsUrl({
       databaseId: 1,
@@ -30,6 +40,17 @@ describe("getDatabaseFocusPermissionsUrl", () => {
     });
     expect(url).toEqual(
       "/admin/permissions/data/database/1/schema/my_schema/table/10",
+    );
+  });
+
+  it("when entityId is a table id with schema with a / it returns table permissions url", () => {
+    const url = getDatabaseFocusPermissionsUrl({
+      databaseId: 1,
+      schemaName: "my/schema",
+      tableId: 10,
+    });
+    expect(url).toEqual(
+      "/admin/permissions/data/database/1/schema/my%2Fschema/table/10",
     );
   });
 
@@ -60,6 +81,16 @@ describe("getGroupFocusPermissionsUrl", () => {
     });
     expect(url).toEqual(
       "/admin/permissions/data/group/1/database/1/schema/my_schema",
+    );
+  });
+
+  it("when entityId is a schema with a / with a id it returns database permissions url", () => {
+    const url = getGroupFocusPermissionsUrl(1, {
+      databaseId: 1,
+      schemaName: "my/schema",
+    });
+    expect(url).toEqual(
+      "/admin/permissions/data/group/1/database/1/schema/my%2Fschema",
     );
   });
 });

--- a/frontend/src/metabase/browse/containers/SchemaBrowser.jsx
+++ b/frontend/src/metabase/browse/containers/SchemaBrowser.jsx
@@ -49,7 +49,10 @@ function SchemaBrowser(props) {
               {schemas.map(schema => (
                 <GridItem width={ITEM_WIDTHS} key={schema.id}>
                   <Link
-                    to={`/browse/${dbId}/schema/` + encodeURIComponent(schema.name)}
+                    to={
+                      `/browse/${dbId}/schema/` +
+                      encodeURIComponent(schema.name)
+                    }
                     mb={1}
                     hover={{ color: color("accent2") }}
                     data-metabase-event={`${ANALYTICS_CONTEXT};Schema Click`}

--- a/frontend/src/metabase/browse/containers/SchemaBrowser.jsx
+++ b/frontend/src/metabase/browse/containers/SchemaBrowser.jsx
@@ -49,7 +49,7 @@ function SchemaBrowser(props) {
               {schemas.map(schema => (
                 <GridItem width={ITEM_WIDTHS} key={schema.id}>
                   <Link
-                    to={`/browse/${dbId}/schema/${schema.name}`}
+                    to={`/browse/${dbId}/schema/` + encodeURIComponent(schema.name)}
                     mb={1}
                     hover={{ color: color("accent2") }}
                     data-metabase-event={`${ANALYTICS_CONTEXT};Schema Click`}

--- a/frontend/src/metabase/lib/urls.js
+++ b/frontend/src/metabase/lib/urls.js
@@ -231,11 +231,15 @@ export function browseDatabase(database) {
 }
 
 export function browseSchema(table) {
-  return `/browse/${table.db.id}/schema/` + encodeURIComponent(table.schema_name);
+  return (
+    `/browse/${table.db.id}/schema/` + encodeURIComponent(table.schema_name)
+  );
 }
 
 export function browseTable(table) {
-  return `/browse/${table.db.id}/schema/` + encodeURIComponent(table.schema_name);
+  return (
+    `/browse/${table.db.id}/schema/` + encodeURIComponent(table.schema_name)
+  );
 }
 
 export function extractEntityId(slug) {

--- a/frontend/src/metabase/lib/urls.js
+++ b/frontend/src/metabase/lib/urls.js
@@ -231,11 +231,11 @@ export function browseDatabase(database) {
 }
 
 export function browseSchema(table) {
-  return `/browse/${table.db.id}/schema/${table.schema_name}`;
+  return `/browse/${table.db.id}/schema/` + encodeURIComponent(table.schema_name);
 }
 
 export function browseTable(table) {
-  return `/browse/${table.db.id}/schema/${table.schema_name}`;
+  return `/browse/${table.db.id}/schema/` + encodeURIComponent(table.schema_name);
 }
 
 export function extractEntityId(slug) {


### PR DESCRIPTION
###### Before submitting the PR, please make sure you do the following

Fix for https://github.com/metabase/metabase/issues/15454 - adds URL-encoding to schema names when used in links, to allow schema names with `/` characters in them.


### Tests

- [X] Run the frontend and Cypress end-to-end tests with `yarn lint && yarn test`)
- [X] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
      (unless it's a tiny documentation change).
