### PR TITLE
Fix removing a notebook section can remove other sections

### DIFF
--- a/frontend/src/metabase-lib/lib/queries/structured/Join.js
+++ b/frontend/src/metabase-lib/lib/queries/structured/Join.js
@@ -535,18 +535,29 @@ export default class Join extends MBQLObjectClause {
     return this._query.removeJoin(this._index);
   }
 
-  isValid() {
+  hasGaps() {
     if (!this.joinedTable()) {
-      return false;
+      return true;
     }
     const parentDimensions = this.parentDimensions();
     const joinDimensions = this.joinDimensions();
     return (
-      parentDimensions.length > 0 &&
-      joinDimensions.length > 0 &&
-      parentDimensions.every(Boolean) &&
-      joinDimensions.every(Boolean) &&
-      parentDimensions.length === joinDimensions.length
+      parentDimensions.length === 0 ||
+      joinDimensions.length === 0 ||
+      parentDimensions.length !== joinDimensions.length ||
+      parentDimensions.some(dimension => dimension == null) ||
+      joinDimensions.some(dimension => dimension == null)
+    );
+  }
+
+  isValid() {
+    if (this.hasGaps()) {
+      return false;
+    }
+    const dimensionOptions = this.parent().dimensionOptions();
+    const dimensions = [...this.parentDimensions(), ...this.joinDimensions()];
+    return dimensions.every(dimension =>
+      dimensionOptions.hasDimension(dimension),
     );
   }
 

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx
@@ -142,14 +142,6 @@ export default class NotebookStep extends React.Component {
     actions.sort((a, b) => (b.priority || 0) - (a.priority || 0));
     const actionButtons = actions.map(action => action.button);
 
-    let onRemove = null;
-    if (step.revert) {
-      const reverted = step.revert(step.query).clean();
-      if (reverted.isValid()) {
-        onRemove = () => reverted.update(updateQuery);
-      }
-    }
-
     return (
       <ExpandingContent isInitiallyOpen={!isLastOpened} isOpen>
         <Box
@@ -158,25 +150,21 @@ export default class NotebookStep extends React.Component {
           className="hover-parent hover--visibility"
           data-testid={getTestId(step)}
         >
-          {(title || onRemove) && (
-            <Flex
-              mb={1}
-              width={CONTENT_WIDTH}
-              className="text-bold"
-              style={{ color }}
-            >
-              {title}
-              {onRemove && (
-                <Icon
-                  name="close"
-                  className="ml-auto cursor-pointer text-light text-medium-hover hover-child"
-                  tooltip={t`Remove`}
-                  onClick={onRemove}
-                  data-testid="remove-step"
-                />
-              )}
-            </Flex>
-          )}
+          <Flex
+            mb={1}
+            width={CONTENT_WIDTH}
+            className="text-bold"
+            style={{ color }}
+          >
+            {title}
+            <Icon
+              name="close"
+              className="ml-auto cursor-pointer text-light text-medium-hover hover-child"
+              tooltip={t`Remove`}
+              onClick={() => step.revert(step.query).update(updateQuery)}
+              data-testid="remove-step"
+            />
+          </Flex>
 
           {NotebookStepComponent && (
             <Flex align="center">

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx
@@ -211,7 +211,11 @@ export default class NotebookStep extends React.Component {
             />
           )}
 
-          {actionButtons.length > 0 && <Box mt={1}>{actionButtons}</Box>}
+          {actionButtons.length > 0 && (
+            <Box mt={1} data-testid="action-buttons">
+              {actionButtons}
+            </Box>
+          )}
         </Box>
       </ExpandingContent>
     );

--- a/frontend/src/metabase/query_builder/components/notebook/lib/steps.js
+++ b/frontend/src/metabase/query_builder/components/notebook/lib/steps.js
@@ -110,11 +110,11 @@ const STEPS: StepDefinition[] = [
     revert: (query, index) => query.removeJoin(index),
     clean: (query, index) => {
       const join = query.joins()[index];
-      if (!join || join.isValid()) {
+      if (!join || join.isValid() || join.hasGaps()) {
         return query;
       }
       const cleanJoin = join.clean();
-      if (!cleanJoin.isValid()) {
+      if (cleanJoin.isValid()) {
         return query.updateJoin(index, cleanJoin);
       }
       return query.removeJoin(index);

--- a/frontend/src/metabase/query_builder/components/notebook/lib/steps.js
+++ b/frontend/src/metabase/query_builder/components/notebook/lib/steps.js
@@ -110,7 +110,14 @@ const STEPS: StepDefinition[] = [
     revert: (query, index) => query.removeJoin(index),
     clean: (query, index) => {
       const join = query.joins()[index];
-      return !join || join.isValid() ? query : query.removeJoin(index);
+      if (!join || join.isValid()) {
+        return query;
+      }
+      const cleanJoin = join.clean();
+      if (!cleanJoin.isValid()) {
+        return query.updateJoin(index, cleanJoin);
+      }
+      return query.removeJoin(index);
     },
   },
   {

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -154,7 +154,7 @@ function JoinClause({ color, join, updateQuery, showRemove }) {
   } else if (join.parentDimensions().length > 0) {
     // subsequent can be one of the previously joined tables
     // NOTE: `lhsDimension` would probably be a better name for `parentDimension`
-    lhsTable = join.parentDimensions()[0].field().table;
+    lhsTable = join.parentDimensions()[0]?.field().table;
   }
 
   function onSourceTableSet(newJoin) {

--- a/frontend/test/metabase-lib/lib/queries/StructuredQuery-clean.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/StructuredQuery-clean.unit.spec.js
@@ -5,11 +5,15 @@ import {
 } from "__support__/sample_dataset_fixture";
 
 const ORDERS_PRODUCT_ID_FIELD_REF = ["field", ORDERS.ID.id, null];
-const PRODUCT_ID_FIELD_REF = ["field", PRODUCTS.ID.id, null];
+const PRODUCT_ID_FIELD_REF = [
+  "field",
+  PRODUCTS.ID.id,
+  { "join-alias": "Products" },
+];
 
 function getJoin({
   sourceTable = PRODUCTS.id,
-  alias = "join1234",
+  alias = "Products",
   condition = ["=", ORDERS_PRODUCT_ID_FIELD_REF, PRODUCT_ID_FIELD_REF],
   fields = "all",
 } = {}) {
@@ -213,7 +217,7 @@ describe("StructuredQuery", () => {
       it("should not remove breakout referencing valid joined fields", () => {
         const q = ORDERS.query()
           .join(getJoin())
-          .breakout(["field", PRODUCTS.TITLE.id, { "join-alias": "join1234" }]);
+          .breakout(["field", PRODUCTS.TITLE.id, { "join-alias": "Products" }]);
         expect(q.clean().query()).toEqual(q.query());
       });
       it("should remove breakout referencing invalid field ID", () => {

--- a/frontend/test/metabase-lib/lib/queries/structured/Join.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/structured/Join.unit.spec.js
@@ -31,6 +31,12 @@ const PRODUCTS_ID_JOIN_FIELD_REF = [
   { "join-alias": "Products" },
 ];
 
+const PRODUCTS_CREATED_AT_JOIN_FIELD_REF = [
+  "field",
+  PRODUCTS.CREATED_AT.id,
+  { "join-alias": "Products" },
+];
+
 const ORDERS_PRODUCT_JOIN_CONDITION = [
   "=",
   ORDERS_PRODUCT_ID_FIELD_REF,
@@ -40,7 +46,7 @@ const ORDERS_PRODUCT_JOIN_CONDITION = [
 const ORDERS_PRODUCT_JOIN_CONDITION_BY_CREATED_AT = [
   "=",
   ORDERS_CREATED_AT_FIELD_REF,
-  PRODUCTS_CREATED_AT_FIELD_REF,
+  PRODUCTS_CREATED_AT_JOIN_FIELD_REF,
 ];
 
 const ORDERS_PRODUCT_MULTI_FIELD_JOIN_CONDITION = [
@@ -178,7 +184,7 @@ describe("Join", () => {
           condition: [
             "and",
             ORDERS_PRODUCT_JOIN_CONDITION,
-            ["=", null, PRODUCTS_CREATED_AT_FIELD_REF],
+            ["=", null, PRODUCTS_CREATED_AT_JOIN_FIELD_REF],
           ],
         }),
       });
@@ -265,7 +271,7 @@ describe("Join", () => {
 
       join = join.setJoinDimension({
         index: 1,
-        dimension: PRODUCTS_CREATED_AT_FIELD_REF,
+        dimension: PRODUCTS_CREATED_AT_JOIN_FIELD_REF,
       });
 
       expect(join).toEqual({
@@ -424,8 +430,96 @@ describe("Join", () => {
     });
   });
 
+  const invalidTestCases = [
+    [
+      "missing source table",
+      {
+        sourceTable: null,
+      },
+    ],
+    [
+      "missing condition",
+      {
+        condition: null,
+      },
+    ],
+    [
+      "missing both dimensions",
+      {
+        condition: ["=", null, null],
+      },
+    ],
+    [
+      "missing parent dimension",
+      {
+        condition: ["=", null, PRODUCTS_ID_FIELD_REF],
+      },
+    ],
+    [
+      "missing join dimension",
+      {
+        condition: ["=", ORDERS_PRODUCT_ID_FIELD_REF, null],
+      },
+    ],
+    [
+      "second condition is empty",
+      {
+        condition: ["and", ORDERS_PRODUCT_JOIN_CONDITION, ["=", null, null]],
+      },
+    ],
+    [
+      "missing parent dimension in second condition",
+      {
+        condition: [
+          "and",
+          ORDERS_PRODUCT_JOIN_CONDITION,
+          ["=", null, PRODUCTS_CREATED_AT_FIELD_REF],
+        ],
+      },
+    ],
+    [
+      "missing join dimension in second condition",
+      {
+        condition: [
+          "and",
+          ORDERS_PRODUCT_JOIN_CONDITION,
+          ["=", ORDERS_CREATED_AT_FIELD_REF, null],
+        ],
+      },
+    ],
+  ];
+
+  describe("hasGaps", () => {
+    it("should return 'false' for complete one-fields pair join", () => {
+      const join = getJoin({
+        query: getOrdersJoinQuery({
+          condition: ORDERS_PRODUCT_JOIN_CONDITION,
+        }),
+      });
+      expect(join.hasGaps()).toBe(false);
+    });
+
+    it("should return 'false' for complete multi-fields join", () => {
+      const join = getJoin({
+        query: getOrdersJoinQuery({
+          condition: ORDERS_PRODUCT_MULTI_FIELD_JOIN_CONDITION,
+        }),
+      });
+      expect(join.hasGaps()).toBe(false);
+    });
+
+    invalidTestCases.forEach(([invalidReason, queryOpts]) => {
+      it(`should return 'true' when ${invalidReason}`, () => {
+        const join = getJoin({
+          query: getOrdersJoinQuery(queryOpts),
+        });
+        expect(join.hasGaps()).toBe(true);
+      });
+    });
+  });
+
   describe("isValid", () => {
-    it("should return true for complete one-fields pair join", () => {
+    it("should return 'true' for complete one-fields pair join", () => {
       const join = getJoin({
         query: getOrdersJoinQuery({
           condition: ORDERS_PRODUCT_JOIN_CONDITION,
@@ -434,7 +528,7 @@ describe("Join", () => {
       expect(join.isValid()).toBe(true);
     });
 
-    it("should return true for complete multi-fields join", () => {
+    it("should return 'true' for complete multi-fields join", () => {
       const join = getJoin({
         query: getOrdersJoinQuery({
           condition: ORDERS_PRODUCT_MULTI_FIELD_JOIN_CONDITION,
@@ -443,64 +537,19 @@ describe("Join", () => {
       expect(join.isValid()).toBe(true);
     });
 
-    const invalidTestCases = [
-      [
-        "missing source table",
-        {
-          sourceTable: null,
-        },
-      ],
-      [
-        "missing condition",
-        {
-          condition: null,
-        },
-      ],
-      [
-        "missing both dimensions",
-        {
-          condition: ["=", null, null],
-        },
-      ],
-      [
-        "missing parent dimension",
-        {
-          condition: ["=", null, PRODUCTS_ID_FIELD_REF],
-        },
-      ],
-      [
-        "missing join dimension",
-        {
-          condition: ["=", ORDERS_PRODUCT_ID_FIELD_REF, null],
-        },
-      ],
-      [
-        "second condition is empty",
-        {
-          condition: ["and", ORDERS_PRODUCT_JOIN_CONDITION, ["=", null, null]],
-        },
-      ],
-      [
-        "missing parent dimension in second condition",
-        {
+    it("should return 'false' if references unavailable field", () => {
+      const join = getJoin({
+        query: getOrdersJoinQuery({
           condition: [
             "and",
             ORDERS_PRODUCT_JOIN_CONDITION,
-            ["=", null, PRODUCTS_CREATED_AT_FIELD_REF],
+            ["=", ["field", 111222333444, null], PRODUCTS_CREATED_AT_FIELD_REF],
           ],
-        },
-      ],
-      [
-        "missing join dimension in second condition",
-        {
-          condition: [
-            "and",
-            ORDERS_PRODUCT_JOIN_CONDITION,
-            ["=", ORDERS_CREATED_AT_FIELD_REF, null],
-          ],
-        },
-      ],
-    ];
+        }),
+      });
+
+      expect(join.isValid()).toBe(false);
+    });
 
     invalidTestCases.forEach(([invalidReason, queryOpts]) => {
       it(`should return 'false' when ${invalidReason}`, () => {

--- a/frontend/test/metabase/scenarios/question/reproductions/17712-notebook-extra-sections-removed.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/17712-notebook-extra-sections-removed.cy.spec.js
@@ -1,0 +1,40 @@
+import { restore, popover, openOrdersTable } from "__support__/e2e/cypress";
+
+describe("issue 17712", () => {
+  beforeEach(() => {
+    cy.intercept("POST", "/api/dataset").as("dataset");
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("doesn't remove extra sections when removing a single section (metabase#17712)", () => {
+    openOrdersTable({ mode: "notebook" });
+
+    cy.findByText("Join data").click();
+    popover()
+      .findByText("Products")
+      .click();
+    cy.findByTestId("step-join-0-0")
+      .findByTestId("parent-dimension")
+      .within(() => {
+        cy.icon("close").click();
+      });
+
+    cy.findByTestId("action-buttons")
+      .findByText("Join data")
+      .click();
+    popover()
+      .findByText("Reviews")
+      .click();
+
+    cy.findByTestId("step-join-0-1").within(() => {
+      cy.icon("close").click({ force: true });
+    });
+
+    cy.findByTestId("step-join-0-0").within(() => {
+      cy.findByText("Orders");
+      cy.findAllByText("Products");
+      cy.findByText("ID");
+    });
+  });
+});


### PR DESCRIPTION
Followup [this comment](https://github.com/metabase/metabase/pull/17633#issuecomment-908330423) from #17633. On the notebook editor, if there are two incomplete join sections (without table / any field / second field specified), once you remove one of them, the second is also removed.

The issue can be easily reproduced with joins, but most likely it can happen with any other notebook step.
It's just easier to make an "invalid MBQL" join.

Reproduces #17712, fixes #17712

### ⚠️ Warning

The reason removing a section also removes other invalid sections is because of this code section from the `NotebookStep`:

```js
const reverted = step.revert(step.query).clean();
if (reverted.isValid()) {
   onRemove = () => reverted.update(updateQuery);
}
```

`onRemove` will be called when a user clicks the cross icon on the section. It will generate a reverted query (current query, but without a section you're removing) and also call `StructuredQuery's` `clean` method on it. `clean` will remove the invalid MBQL clauses and that leads to removing other sections apart from the one user removes intentionally.

We used to display the cross icon only if removing a section will result in a valid query state (see in the code block: get reverted query > clean it > check if the reverted and clean query is valid > define the `onRemove` callback > display the icon if there is a callback).

My thinking here is that we _MAYBE_ can display the icon all the time because the `clean` will happen anyway once we run the query, so we should be safe about query validity. This is something I'm not sure about, so I'd appreciate feedback from somebody confident about the notebook 🙏 

Also, the cleanup happens any time you remove a section. In that way, we can remove clauses that were depending on a removed part. Let's say you joined a Products table and then added a filter on "Category" and a summarization like "Average of Price". If you remove the join, the filter and the summarization are invalid now, so we should remove that. The problem with join sections is that an incomplete join is also considered invalid and gets removed. This PR extends the `Join` class with a `hasGaps` method. If there are not yet specified join dimensions, the join won't get removed not to confuse people. `join.isValid()` will still be `false` if there are gaps, so once you run the query, all the incomplete joins will be removed.

### To Verify

1. Ask a question > Custom Question > Sample Dataset > Orders
2. Join the Products table
3. Join the Reviews table
4. Remove only one field from the right side of the Products join section
5. Hover the Reviews join section and click the cross icon in the top-right
6. Only the section you clicked has to be removed.

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/131664455-4e1dffaf-3980-42f5-aab7-95ea83437ddb.mov

**After**

https://user-images.githubusercontent.com/17258145/131813760-aeedab4e-230c-46fd-b892-504a510564bd.mov
