### PR TITLE
#17738 Repro: "Native query editing" permission selector is inconsistent between "No self service" and "Block" permissions

### DIFF
--- a/frontend/test/metabase/scenarios/admin/permissions/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/permissions/permissions.cy.spec.js
@@ -510,19 +510,25 @@ describe("scenarios > admin > permissions", () => {
     cy.findAllByText("Orders").should("not.exist");
   });
 
-  it.skip("'no self-service' data option should have editable 'native query editing' option (metabase#17738)", () => {
+  it.skip("'block' data permission should not have editable 'native query editing' option (metabase#17738)", () => {
     cy.visit("/admin/permissions/data/database/1");
 
     cy.findByText("All Users")
       .closest("tr")
+      .as("allUsersRow")
       .within(() => {
-        cy.findByText("No self-service");
-        cy.icon("chevrondown").should("have.length", 2);
-
-        cy.findByText("No").click();
+        isPermissionDisabled("No", true);
+        isPermissionDisabled("No self-service", false).click();
       });
 
-    popover().contains("Yes");
+    popover()
+      .contains("Block")
+      .click();
+
+    cy.get("@allUsersRow").within(() => {
+      isPermissionDisabled("Block", false);
+      isPermissionDisabled("No", true);
+    });
   });
 });
 
@@ -647,4 +653,18 @@ function assertPermissionTable(rows) {
       cy.wrap($permissionEl).should("have.text", permissions[index]);
     });
   });
+}
+
+/**
+ * @param {string} permission
+ * @param {boolean} isDisabled
+ */
+function isPermissionDisabled(permission, isDisabled) {
+  return (
+    cy
+      .findByText(permission)
+      .closest("a")
+      // This assertion works only with strings "true" | "false", and not with booleans.
+      .should("have.attr", "aria-disabled", "" + isDisabled)
+  );
 }

--- a/frontend/test/metabase/scenarios/admin/permissions/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/permissions/permissions.cy.spec.js
@@ -509,6 +509,21 @@ describe("scenarios > admin > permissions", () => {
 
     cy.findAllByText("Orders").should("not.exist");
   });
+
+  it.skip("'no self-service' data option should have editable 'native query editing' option (metabase#17738)", () => {
+    cy.visit("/admin/permissions/data/database/1");
+
+    cy.findByText("All Users")
+      .closest("tr")
+      .within(() => {
+        cy.findByText("No self-service");
+        cy.icon("chevrondown").should("have.length", 2);
+
+        cy.findByText("No").click();
+      });
+
+    popover().contains("Yes");
+  });
 });
 
 describeWithToken("scenarios > admin > permissions", () => {


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #17738

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/admin/permissions/permissions.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/132059140-7260b80a-b7f2-4d9b-871d-e49dc9046105.png)


