### PR TITLE
Basic skeleton of front-end dependencies analyzer

### DIFF
--- a/frontend/parse-deps.js
+++ b/frontend/parse-deps.js
@@ -17,71 +17,115 @@ const ALIAS = {
   "metabase-types": "frontend/src/metabase-types",
 };
 
-const files = glob.sync(PATTERN);
+function files() {
+  return glob.sync(PATTERN);
+}
 
-const deps = files.map(fileName => {
-  const contents = fs.readFileSync(fileName, "utf-8");
-  const options = {
-    allowImportExportEverywhere: true,
-    allowReturnOutsideFunction: true,
-    decoratorsBeforeExport: true,
-    sourceType: "unambiguous",
-    plugins: ["jsx", "flow", "decorators-legacy", "exportDefaultFrom"],
-  };
-  const importList = [];
-  try {
-    const ast = parser.parse(contents, options);
-    traverse(ast, {
-      enter(path) {
-        if (path.node.type === "ImportDeclaration") {
-          importList.push(path.node.source.value);
-        }
-        if (path.node.type === "CallExpression") {
-          const callee = path.node.callee;
-          const args = path.node.arguments;
-          if (callee.type === "Identifier" && callee.name === "require") {
-            if (args.length === 1 && args[0].type === "StringLiteral") {
-              importList.push(args[0].value);
+function dependencies() {
+  const deps = files().map(fileName => {
+    const contents = fs.readFileSync(fileName, "utf-8");
+    const options = {
+      allowImportExportEverywhere: true,
+      allowReturnOutsideFunction: true,
+      decoratorsBeforeExport: true,
+      sourceType: "unambiguous",
+      plugins: ["jsx", "flow", "decorators-legacy", "exportDefaultFrom"],
+    };
+    const importList = [];
+    try {
+      const ast = parser.parse(contents, options);
+      traverse(ast, {
+        enter(path) {
+          if (path.node.type === "ImportDeclaration") {
+            importList.push(path.node.source.value);
+          }
+          if (path.node.type === "CallExpression") {
+            const callee = path.node.callee;
+            const args = path.node.arguments;
+            if (callee.type === "Identifier" && callee.name === "require") {
+              if (args.length === 1 && args[0].type === "StringLiteral") {
+                importList.push(args[0].value);
+              }
             }
           }
-        }
-      },
-    });
-  } catch (e) {
-    console.error(fileName, e.toString());
-    process.exit(-1);
-  }
-  const base = path.dirname(fileName) + path.sep;
-  const absoluteImportList = importList
-    .map(name => {
-      const absName = name[0] === "." ? path.normalize(base + name) : name;
-      const parts = absName.split(path.sep);
-      const realPath = ALIAS[parts[0]];
-      parts[0] = realPath ? realPath : parts[0];
-      const realName = parts.join(path.sep);
-      return realName;
-    })
-    .filter(name => name.indexOf("frontend") === 0);
-
-  const source = path.format({
-    ...path.parse(fileName),
-    ext: null,
-    base: null,
-  });
-  const dependencies = absoluteImportList.sort();
-
-  return { source, dependencies };
-});
-
-let dependents = {};
-deps.forEach(dep => {
-  const { source, dependencies } = dep;
-  dependencies.forEach(d => {
-    if (!dependents[d]) {
-      dependents[d] = [];
+        },
+      });
+    } catch (e) {
+      console.error(fileName, e.toString());
+      process.exit(-1);
+      n;
     }
-    dependents[d].push(source);
-  });
-});
+    const base = path.dirname(fileName) + path.sep;
+    const absoluteImportList = importList
+      .map(name => {
+        const absName = name[0] === "." ? path.normalize(base + name) : name;
+        const parts = absName.split(path.sep);
+        const realPath = ALIAS[parts[0]];
+        parts[0] = realPath ? realPath : parts[0];
+        const realName = parts.join(path.sep);
+        return realName;
+      })
+      .filter(name => name.indexOf("frontend") === 0);
 
-console.log(JSON.stringify(dependents, null, 2));
+    const source = path.format({
+      ...path.parse(fileName),
+      ext: null,
+      base: null,
+    });
+    const dependencies = absoluteImportList.sort();
+
+    return { source, dependencies };
+  });
+  return deps;
+}
+
+function dependents() {
+  let dependents = {};
+  dependencies().forEach(dep => {
+    const { source, dependencies } = dep;
+    dependencies.forEach(d => {
+      if (!dependents[d]) {
+        dependents[d] = [];
+      }
+      dependents[d].push(source);
+    });
+  });
+  return dependents;
+}
+
+const USAGE = `
+parse-deps cmd
+
+cmd must be one of:
+
+        files     Display list of source files
+ dependencies     Show the dependencies of each source file
+   dependents     Show the dependents of each source file
+`;
+
+function main(args) {
+  const cmd = args[0];
+  if (cmd) {
+    switch (cmd.toLowerCase()) {
+      case "files":
+        console.log(files().join("\n"));
+        break;
+      case "dependencies":
+        console.log(JSON.stringify(dependencies(), null, 2));
+        break;
+      case "dependents":
+        console.log(JSON.stringify(dependents(), null, 2));
+        break;
+      default:
+        console.log(USAGE);
+        break;
+    }
+  } else {
+    console.log(USAGE);
+  }
+}
+
+let args = process.argv;
+args.shift();
+args.shift();
+main(args);

--- a/frontend/parse-deps.js
+++ b/frontend/parse-deps.js
@@ -7,7 +7,7 @@ const glob = require("glob");
 const parser = require("@babel/parser");
 const traverse = require("@babel/traverse").default;
 
-const PATTERN = "frontend/src/metabase/**/*.{js,jsx}";
+const PATTERN = "{enterprise/,}frontend/src/**/*.{js,jsx}";
 
 // after webpack.config.js
 const ALIAS = {

--- a/frontend/parse-deps.js
+++ b/frontend/parse-deps.js
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+
+const glob = require("glob");
+const parser = require("@babel/parser");
+const traverse = require("@babel/traverse").default;
+
+const PATTERN = "frontend/src/metabase/**/*.{js,jsx}";
+
+// after webpack.config.js
+const ALIAS = {
+  metabase: "frontend/src/metabase",
+  "metabase-lib": "frontend/src/metabase-lib",
+  "metabase-enterprise": "enterprise/frontend/src/metabase-enterprise",
+  "metabase-types": "frontend/src/metabase-types",
+};
+
+const files = glob.sync(PATTERN);
+
+const deps = files.map(fileName => {
+  const contents = fs.readFileSync(fileName, "utf-8");
+  const options = {
+    allowImportExportEverywhere: true,
+    allowReturnOutsideFunction: true,
+    decoratorsBeforeExport: true,
+    sourceType: "unambiguous",
+    plugins: ["jsx", "flow", "decorators-legacy", "exportDefaultFrom"],
+  };
+  const importList = [];
+  try {
+    const ast = parser.parse(contents, options);
+    traverse(ast, {
+      enter(path) {
+        if (path.node.type === "ImportDeclaration") {
+          importList.push(path.node.source.value);
+        }
+      },
+    });
+  } catch (e) {
+    console.error(fileName, e.toString());
+  }
+  const base = path.dirname(fileName) + path.sep;
+  const absoluteImportList = importList
+    .map(name => {
+      const absName = name[0] === "." ? path.normalize(base + name) : name;
+      const parts = absName.split(path.sep);
+      const realPath = ALIAS[parts[0]];
+      parts[0] = realPath ? realPath : parts[0];
+      const realName = parts.join(path.sep);
+      return realName;
+    })
+    .filter(name => name.indexOf("frontend") === 0);
+
+  const source = path.format({
+    ...path.parse(fileName),
+    ext: null,
+    base: null,
+  });
+  const dependencies = absoluteImportList.sort();
+
+  return { source, dependencies };
+});
+
+let dependents = {};
+deps.forEach(dep => {
+  const { source, dependencies } = dep;
+  dependencies.forEach(d => {
+    if (!dependents[d]) {
+      dependents[d] = [];
+    }
+    dependents[d].push(source);
+  });
+});
+
+console.log(JSON.stringify(dependents, null, 2));

--- a/frontend/parse-deps.js
+++ b/frontend/parse-deps.js
@@ -66,7 +66,7 @@ function dependencies() {
         const realName = parts.join(path.sep);
         return realName;
       })
-      .filter(name => name.indexOf("frontend") === 0);
+      .filter(name => name.indexOf("frontend") >= 0);
 
     const source = path.format({
       ...path.parse(fileName),

--- a/frontend/parse-deps.js
+++ b/frontend/parse-deps.js
@@ -124,15 +124,51 @@ function filterDependents() {
   start();
 }
 
+function filterAllDependents() {
+  const rl = readline.createInterface({
+    input: process.stdin,
+  });
+
+  const allDependents = dependents();
+  let filteredDependents = [];
+
+  const start = async () => {
+    for await (const line of rl) {
+      const name = line
+        .trim()
+        .replace(/\.js$/, "")
+        .replace(/\.jsx$/, "");
+      if (name.length > 0) {
+        const list = allDependents[name];
+        if (list && Array.isArray(list) && list.length > 0) {
+          filteredDependents.push(...list);
+        }
+      }
+    }
+    filteredDependents = Array.from(new Set(filteredDependents)); // unique
+    for (let i = 0; i < filteredDependents.length; ++i) {
+      const name = filteredDependents[i];
+      const list = allDependents[name];
+      if (list && Array.isArray(list) && list.length > 0) {
+        const newAddition = list.filter(e => filteredDependents.indexOf(e) < 0);
+        filteredDependents.push(...newAddition);
+      }
+    }
+    console.log(filteredDependents.sort().join("\n"));
+  };
+  start();
+}
+
 const USAGE = `
 parse-deps cmd
 
 cmd must be one of:
 
-            files   Display list of source files
-     dependencies   Show the dependencies of each source file
-       dependents   Show the dependents of each source file
-filter-dependents   Filter dependents based on stdin
+                files   Display list of source files
+         dependencies   Show the dependencies of each source file
+           dependents   Show the dependents of each source file
+    filter-dependents   Filter direct dependents based on stdin
+filter-all-dependents   Filter all inderect and direct dependents based on stdin
 `;
 
 function main(args) {
@@ -150,6 +186,9 @@ function main(args) {
         break;
       case "filter-dependents":
         filterDependents();
+        break;
+      case "filter-all-dependents":
+        filterAllDependents();
         break;
       default:
         console.log(USAGE);

--- a/frontend/parse-deps.js
+++ b/frontend/parse-deps.js
@@ -104,52 +104,51 @@ function dependents() {
   return dependents;
 }
 
-function filterDependents() {
-  const rl = readline.createInterface({
-    input: process.stdin,
+function getDependents(sources) {
+  const allDependents = dependents();
+  let filteredDependents = [];
+
+  sources.forEach(name => {
+    const list = allDependents[name];
+    if (list && Array.isArray(list) && list.length > 0) {
+      filteredDependents.push(...list);
+    }
   });
 
-  const allDependents = dependents();
-  const filteredDependents = [];
+  return Array.from(new Set(filteredDependents)).sort(); // unique
+}
+
+function filterDependents() {
+  const rl = readline.createInterface({ input: process.stdin });
 
   const start = async () => {
+    let sources = [];
     for await (const line of rl) {
       const name = line.trim();
       if (name.length > 0) {
-        const list = allDependents[name];
-        if (list && Array.isArray(list) && list.length > 0) {
-          filteredDependents.push(...list);
-        }
+        sources.push(name);
       }
     }
-    console.log(
-      Array.from(new Set(filteredDependents))
-        .sort()
-        .join("\n"),
-    );
+    const filteredDependents = getDependents(sources);
+    console.log(filteredDependents.join("\n"));
   };
   start();
 }
 
 function filterAllDependents() {
-  const rl = readline.createInterface({
-    input: process.stdin,
-  });
-
-  const allDependents = dependents();
-  let filteredDependents = [];
+  const rl = readline.createInterface({ input: process.stdin });
 
   const start = async () => {
+    let sources = [];
     for await (const line of rl) {
       const name = line.trim();
       if (name.length > 0) {
-        const list = allDependents[name];
-        if (list && Array.isArray(list) && list.length > 0) {
-          filteredDependents.push(...list);
-        }
+        sources.push(name);
       }
     }
-    filteredDependents = Array.from(new Set(filteredDependents)); // unique
+    let filteredDependents = getDependents(sources);
+
+    const allDependents = dependents();
     for (let i = 0; i < filteredDependents.length; ++i) {
       const name = filteredDependents[i];
       const list = allDependents[name];

--- a/frontend/parse-deps.js
+++ b/frontend/parse-deps.js
@@ -36,6 +36,15 @@ const deps = files.map(fileName => {
         if (path.node.type === "ImportDeclaration") {
           importList.push(path.node.source.value);
         }
+        if (path.node.type === "CallExpression") {
+          const callee = path.node.callee;
+          const args = path.node.arguments;
+          if (callee.type === "Identifier" && callee.name === "require") {
+            if (args.length === 1 && args[0].type === "StringLiteral") {
+              importList.push(args[0].value);
+            }
+          }
+        }
       },
     });
   } catch (e) {

--- a/frontend/parse-deps.js
+++ b/frontend/parse-deps.js
@@ -162,6 +162,44 @@ function filterAllDependents() {
   start();
 }
 
+function countDependents() {
+  const allDependents = dependents();
+  const sources = Object.keys(allDependents).sort();
+  const tally = sources.map(name => {
+    return { name, count: allDependents[name].length };
+  });
+  console.log(tally.map(({ name, count }) => `${count} ${name}`).join("\n"));
+}
+
+function countAllDependents() {
+  const allDependents = dependents();
+  const sources = Object.keys(allDependents).sort();
+  const tally = sources.map(name => {
+    const list = allDependents[name];
+    for (let i = 0; i < list.length; ++i) {
+      const deps = allDependents[list[i]];
+      if (deps && Array.isArray(deps) && deps.length > 1) {
+        const newAddition = deps.filter(e => list.indexOf(e) < 0);
+        list.push(...newAddition);
+      }
+    }
+    return { name, count: list.length };
+  });
+  console.log(tally.map(({ name, count }) => `${count} ${name}`).join("\n"));
+}
+
+function matrix() {
+  const allDependents = dependents();
+  const sources = Object.keys(allDependents).sort();
+  const width = Math.max(...sources.map(s => s.length));
+  const rows = sources.map(name => {
+    const list = allDependents[name];
+    const checks = sources.map(dep => (list.indexOf(dep) < 0 ? " " : "x"));
+    return name.padEnd(width) + " | " + checks.join("");
+  });
+  console.log(rows.join("\n"));
+}
+
 const USAGE = `
 parse-deps cmd
 
@@ -171,7 +209,10 @@ cmd must be one of:
          dependencies   Show the dependencies of each source file
            dependents   Show the dependents of each source file
     filter-dependents   Filter direct dependents based on stdin
-filter-all-dependents   Filter all inderect and direct dependents based on stdin
+filter-all-dependents   Filter all indirect and direct dependents based on stdin
+     count-dependents   List the total count of direct dependents
+ count-all-dependents   List the total count of its direct and indirect dependents
+               matrix   Display 2-D matrix of dependent relationship
 `;
 
 function main(args) {
@@ -192,6 +233,15 @@ function main(args) {
         break;
       case "filter-all-dependents":
         filterAllDependents();
+        break;
+      case "count-dependents":
+        countDependents();
+        break;
+      case "count-all-dependents":
+        countAllDependents();
+        break;
+      case "matrix":
+        matrix();
         break;
       default:
         console.log(USAGE);

--- a/frontend/parse-deps.js
+++ b/frontend/parse-deps.js
@@ -49,6 +49,7 @@ const deps = files.map(fileName => {
     });
   } catch (e) {
     console.error(fileName, e.toString());
+    process.exit(-1);
   }
   const base = path.dirname(fileName) + path.sep;
   const absoluteImportList = importList


### PR DESCRIPTION
This is a simple tool that basically helps to answer the following question

> "When I change source file _X_, what others source files might be affected directly and indirectly?"

### Example Usage

To find out all other front-end source files which **directly** import `frontend/src/metabase/entities/search.js` (therefore those might be affected by any change in the said file);

```bash
$ echo "frontend/src/metabase/entities/search.js" | node frontend/parse-deps.js filter-dependents
frontend/src/metabase/collections/containers/CollectionContent.jsx
frontend/src/metabase/containers/CollectionItemsLoader.jsx
frontend/src/metabase/containers/Overworld.jsx
frontend/src/metabase/dashboard/components/add-card-sidebar/QuestionList.jsx
frontend/src/metabase/home/containers/ArchiveApp.jsx
frontend/src/metabase/home/containers/SearchApp.jsx
frontend/src/metabase/nav/components/SearchResults.jsx
frontend/src/metabase/query_builder/components/data-search/SearchResults.jsx
frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx
```

However, to find out all possible source files which can be **indirectly**  affected (via the transitive dependencies), use `filter-all-dependents` command instead (that will list 22 files, instead of just the previous 9 files):

```bash
$ echo "frontend/src/metabase/entities/search.js" | node frontend/parse-deps.js filter-all-dependents
frontend/src/metabase/App.jsx
frontend/src/metabase/app-main.js
frontend/src/metabase/collections/containers/CollectionContent.jsx
frontend/src/metabase/components/CollectionLanding/CollectionLanding.jsx
frontend/src/metabase/containers/CollectionItemsLoader.jsx
frontend/src/metabase/containers/Overworld.jsx
frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
frontend/src/metabase/dashboard/components/DashboardSidebars.jsx
frontend/src/metabase/dashboard/components/add-card-sidebar/AddCardSidebar.jsx
frontend/src/metabase/dashboard/components/add-card-sidebar/QuestionList.jsx
frontend/src/metabase/dashboard/components/add-card-sidebar/QuestionPicker.jsx
frontend/src/metabase/dashboard/containers/DashboardApp.jsx
frontend/src/metabase/home/containers/ArchiveApp.jsx
frontend/src/metabase/home/containers/SearchApp.jsx
frontend/src/metabase/nav/components/SearchBar.jsx
frontend/src/metabase/nav/components/SearchResults.jsx
frontend/src/metabase/nav/containers/Navbar.jsx
frontend/src/metabase/query_builder/components/data-search/SearchResults.jsx
frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx
frontend/src/metabase/query_builder/components/view/View.jsx
frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
frontend/src/metabase/routes.jsx
```

To find out all other front-end source files which **directly** import the files changed by commit `d81424ebbd`:

```bash
$ git show d81424ebbd --name-only | node frontend/parse-deps.js filter-dependents
frontend/src/metabase-lib/lib/Question.js
frontend/src/metabase-lib/lib/queries/structured/Filter.js
frontend/src/metabase/lib/query/query.js
frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx
frontend/src/metabase/query_builder/components/Filter.jsx
frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx
frontend/src/metabase/reference/selectors.js
```

Likewise, to find out all possible source files which can be **indirectly**  affected (via the transitive dependencies), then do the following (note that the list is very long, 654 files)

```bash
$ git show d81424ebbd --name-only | node frontend/parse-deps.js filter-all-dependents
enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditCustomView.jsx
enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditDashboard.jsx
enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTable.jsx
enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTableVisualization.jsx
enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTableWithSearch.jsx
enterprise/frontend/src/metabase-enterprise/audit_app/containers/QuestionLoadAndDisplay.jsx
enterprise/frontend/src/metabase-enterprise/audit_app/containers/QuestionsAuditTable.jsx
enterprise/frontend/src/metabase-enterprise/audit_app/index.js
enterprise/frontend/src/metabase-enterprise/audit_app/lib/util.js
enterprise/frontend/src/metabase-enterprise/audit_app/pages/AuditDashboardDetail.jsx
...
```

Explanation for the above: `git show --name-only` produces the list of changed/added/deleted files and this list is fed into the dependencies/dependents analysis.

Which source files has the **most dependents**? Run the following and it shows that changing `Icon.jsx` has a direct impact on 243 other source files.

```
$ node frontend/parse-deps.js count-dependents | sort -nr | head
243 frontend/src/metabase/components/Icon.jsx
175 frontend/src/metabase/lib/colors.js
89 frontend/src/metabase/lib/settings.js
72 frontend/src/metabase/components/Button.jsx
67 frontend/src/metabase/lib/urls.js
58 frontend/src/metabase-types/types/Visualization.js
56 frontend/src/metabase/lib/analytics.js
53 frontend/src/metabase/redux/metadata.js
52 frontend/src/metabase/services.js
52 frontend/src/metabase/plugins/index.js
```

But what if we also count other source files **indirectly** affected by the dependents (and the transitive ones)? It turns out it's `deterministic.js`, `colors.js` , etc which practically have some indirect impact on the majority of front-end source files:

```
 $ node frontend/parse-deps.js count-all-dependents | sort -nr | head
970 frontend/src/metabase/lib/deterministic.js
969 frontend/src/metabase/lib/colors.js
968 frontend/src/metabase/lib/time.js
962 frontend/src/metabase/lib/utils.js
962 frontend/src/metabase/lib/settings.js
934 frontend/src/metabase/lib/keyboard.js
910 frontend/src/metabase/icon_paths.js
910 frontend/src/metabase/hoc/Tooltipify.jsx
896 frontend/src/metabase/components/Icon.jsx
732 frontend/src/metabase/env.js
```

### Task

**Source processing**

* [x] Parse `frontend`
* [x] Parse `enterprise/frontend`
* [x] Process vanilla `.js`
* [x] Process `.jsx`
* [x] Recognize `import`
* [x] Recognize good ol' `require`
* [x] Resolve alias (e.g. `metabase-lib` as `frontend/src/metabase-lib`)
* [x] Handle directory reference (e.g. `foo/` is `foo/index` if the latter exists)

**Split into specific command**

* [x] Display dependencies as JSON
* [x] Display dependents as JSON
* [x] Filter dependent from stdin
* [x] Choice of direct or all dependents (including transitive)
* [x] Count dependents (only direct, all including transitive)

**Punted** (until we really need it)

* ~~Process `.d.ts`~~

