### PR TITLE
XLSX export formatting for pulse attachments 

### DIFF
--- a/src/metabase/email/messages.clj
+++ b/src/metabase/email/messages.clj
@@ -19,7 +19,6 @@
             [metabase.query-processor.store :as qp.store]
             [metabase.query-processor.streaming :as qp.streaming]
             [metabase.query-processor.streaming.interface :as qp.streaming.i]
-            [metabase.shared.models.visualization-settings :as mb.viz]
             [metabase.util :as u]
             [metabase.util.date-2 :as u.date]
             [metabase.util.i18n :as i18n :refer [deferred-trs trs tru]]
@@ -362,11 +361,11 @@
   (driver/with-driver (driver.u/database->driver database-id)
     (qp.store/with-store
       (qp.store/fetch-and-store-database! database-id)
-      (let [w             (qp.streaming.i/streaming-results-writer export-format os)
-            cols          (-> results :data :cols)
-            viz-settings  (-> results :data :viz-settings)
-            {:keys [ordered-cols output-order]} (qp.streaming/order-cols cols viz-settings)
-            viz-settings' (assoc viz-settings :output-order output-order)]
+      (let [w                           (qp.streaming.i/streaming-results-writer export-format os)
+            cols                        (-> results :data :cols)
+            viz-settings                (-> results :data :viz-settings)
+            [ordered-cols output-order] (qp.streaming/order-cols cols viz-settings)
+            viz-settings'               (assoc viz-settings :output-order output-order)]
         (qp.streaming.i/begin! w
                                (assoc-in results [:data :ordered-cols] ordered-cols)
                                viz-settings')

--- a/src/metabase/email/messages.clj
+++ b/src/metabase/email/messages.clj
@@ -364,13 +364,8 @@
       (qp.store/fetch-and-store-database! database-id)
       (let [w             (qp.streaming.i/streaming-results-writer export-format os)
             cols          (-> results :data :cols)
-            deduped-cols  (qp.streaming/deduplicate-col-names cols)
             viz-settings  (-> results :data :viz-settings)
-            output-order  (qp.streaming/export-column-order deduped-cols (::mb.viz/table-columns viz-settings))
-            ordered-cols  (if output-order
-                            (let [v (into [] deduped-cols)]
-                              (for [i output-order] (v i)))
-                            deduped-cols)
+            {:keys [ordered-cols output-order]} (qp.streaming/order-cols cols viz-settings)
             viz-settings' (assoc viz-settings :output-order output-order)]
         (qp.streaming.i/begin! w
                                (assoc-in results [:data :ordered-cols] ordered-cols)

--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -86,6 +86,8 @@
                     :context       :pulse ; TODO - we should support for `:dashboard-subscription` and use that to differentiate the two
                     :export-format :api
                     :parameters    params
+                    :middleware    {:process-viz-settings? true
+                                    :js-int-to-string?     false}
                     :run (fn [query info]
                            (qp/process-query-and-save-with-max-results-constraints! (assoc query :async? false) info))))]
       {:card card

--- a/src/metabase/query_processor/streaming.clj
+++ b/src/metabase/query_processor/streaming.clj
@@ -21,7 +21,7 @@
 
 ;; HACK: this function includes logic that is normally is done by the annotate middleware, but hasn't been run yet
 ;; at this point in the code. (#17195)
-(defn- deduplicate-col-names
+(defn deduplicate-col-names
   [cols]
   (map (fn [col unique-name]
          (let [col-with-display-name (if (:display_name col)
@@ -31,7 +31,7 @@
        cols
        (mbql.u/uniquify-names (map :name cols))))
 
-(defn- export-column-order
+(defn export-column-order
   "For each entry in `table-columns` that is enabled, finds the index of the corresponding
   entry in `cols` by name or id. If a col has been remapped, uses the index of the new column.
 

--- a/src/metabase/query_processor/streaming.clj
+++ b/src/metabase/query_processor/streaming.clj
@@ -83,9 +83,9 @@
 
 (defn- streaming-rff [results-writer]
   (fn [{:keys [cols viz-settings] :as initial-metadata}]
-    (let [{:keys [ordered-cols output-order]} (order-cols cols viz-settings)
-          viz-settings' (assoc viz-settings :output-order output-order)
-          row-count     (volatile! 0)]
+    (let [[ordered-cols output-order] (order-cols cols viz-settings)
+          viz-settings'               (assoc viz-settings :output-order output-order)
+          row-count                   (volatile! 0)]
       (fn
         ([]
          (i/begin! results-writer

--- a/src/metabase/query_processor/streaming.clj
+++ b/src/metabase/query_processor/streaming.clj
@@ -19,9 +19,11 @@
          streaming.json/keep-me
          streaming.xlsx/keep-me)
 
-;; HACK: this function includes logic that is normally is done by the annotate middleware, but hasn't been run yet
-;; at this point in the code. (#17195)
 (defn deduplicate-col-names
+  "Deduplicate column names that would otherwise conflict.
+
+  TODO: This function includes logic that is normally is done by the annotate middleware, but hasn't been run yet
+  at this point in the code. We should eventually refactor this (#17195)"
   [cols]
   (map (fn [col unique-name]
          (let [col-with-display-name (if (:display_name col)


### PR DESCRIPTION
Fixes the regression in which XLSX pulse attachments have no data, and additionally enables (most) export formatting for them. The only part of formatting that isn't working is the timestamp issue from #14393, since when I disable the `format-rows?` middleware it breaks downstream pulse rendering code, so I won't address that right now.

I didn't catch this regression since I didn't understand the pulse generation code paths well when I was originally working on export formatting, so I wasn't including it in the scope of the project, and thus not manually testing it. Fortunately it's not a big change to get it working, now that I'm more familiar with this part of the code. 

All the column ordering logic already has tests, but we're still missing e2e tests that actually validate the data in the attachments. I'm not sure if there's an currently an easy way to do that here. If anyone has ideas I'm happy to try them.

Resolves #17752