### PR TITLE
Fix sorting admin sections by order

### DIFF
--- a/frontend/src/metabase/admin/settings/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors.js
@@ -35,8 +35,8 @@ function updateSectionsWithPlugins(sections) {
     // see: https://github.com/aearly/icepick/issues/48
     // therefore, re-sort the reduced object according to the original key order
     const sortByOrder = (
-      [, { order: order1 = 0 }],
-      [, { order: order2 = 0 }],
+      [, { order: order1 = Number.MAX_VALUE }],
+      [, { order: order2 = Number.MAX_VALUE }],
     ) => order1 - order2;
 
     return Object.fromEntries(Object.entries(reduced).sort(sortByOrder));

--- a/frontend/src/metabase/admin/settings/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors.js
@@ -34,10 +34,12 @@ function updateSectionsWithPlugins(sections) {
     // the update functions may change the key ordering inadvertently
     // see: https://github.com/aearly/icepick/issues/48
     // therefore, re-sort the reduced object according to the original key order
-    const reSortFn = ([, aVal], [, bVal]) =>
-      aVal && bVal && aVal.order - bVal.order;
+    const sortByOrder = (
+      [, { order: order1 = 0 }],
+      [, { order: order2 = 0 }],
+    ) => order1 - order2;
 
-    return Object.fromEntries(Object.entries(reduced).sort(reSortFn));
+    return Object.fromEntries(Object.entries(reduced).sort(sortByOrder));
   } else {
     return sections;
   }

--- a/frontend/src/metabase/plugins/builtin/settings/hosted.js
+++ b/frontend/src/metabase/plugins/builtin/settings/hosted.js
@@ -22,7 +22,6 @@ if (MetabaseSettings.isHosted()) {
     ...sections,
     cloud: {
       name: t`Cloud`,
-      order: _.max(sections, "order").order + 1,
       settings: [
         {
           key: "store-link",


### PR DESCRIPTION
Master:
<img width="295" alt="Screen Shot 2021-09-03 at 11 41 20 pm" src="https://user-images.githubusercontent.com/8542534/132063420-701cbd14-72c2-41d4-a1fa-005b78b50a07.png">

PR:
<img width="295" alt="Screen Shot 2021-09-03 at 11 40 54 pm" src="https://user-images.githubusercontent.com/8542534/132063424-ef075b59-d746-4b79-bf9b-cc7741b795ae.png">

How to test:
- Change `isHosted` in `settings.js` to return `true`.