### PR TITLE
#17751 Repro: Filter with a single long value hides the remove-button

### DIFF
--- a/frontend/test/metabase/scenarios/native-filters/reproductions/17751-long-filter-name-hides-close-icon.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native-filters/reproductions/17751-long-filter-name-hides-close-icon.cy.spec.js
@@ -1,0 +1,55 @@
+import {
+  restore,
+  mockSessionProperty,
+  filterWidget,
+  popover,
+} from "__support__/e2e/cypress";
+
+import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
+
+const { PRODUCTS } = SAMPLE_DATASET;
+
+const inputValue =
+  "A long value that hides the close icon after reopening the filter widget";
+
+const questionDetails = {
+  native: {
+    query: "{{filter}}",
+    "template-tags": {
+      filter: {
+        id: "3ae0f2d7-c78e-a474-77b3-c3a827d8b919",
+        name: "filter",
+        "display-name": "Filter",
+        type: "dimension",
+        dimension: ["field", PRODUCTS.CATEGORY, null],
+        "widget-type": "string/=",
+        default: inputValue,
+      },
+    },
+  },
+};
+
+describe.skip("issue 17751", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    mockSessionProperty("field-filter-operators-enabled?", true);
+
+    cy.createNativeQuestion(questionDetails, { visitQuestion: true });
+  });
+
+  it("should handle long filter values correctly with the visible 'close' icon  (metabase#17751)", () => {
+    filterWidget()
+      .find(".Icon-close")
+      .should("be.visible");
+
+    cy.findByText(inputValue).click();
+
+    popover()
+      .contains(inputValue)
+      .closest("li")
+      .find(".Icon-close")
+      .should("be.visible");
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #17751 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/native-filters/reproductions/17751-long-filter-name-hides-close-icon.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/132065486-fb0f13f6-4272-4380-9f7e-dfe5c9d904e2.png)

