### PR TITLE
Attempt to fix #17751: filter widget input value overflowing

### DIFF
--- a/frontend/src/metabase/components/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget.jsx
@@ -478,7 +478,7 @@ export class FieldValuesWidget extends Component {
           multi={multi}
           autoFocus={autoFocus}
           color={color}
-          style={style}
+          style={{ ...style, minWidth: "inherit" }}
           className={className}
           parameter={this.props.parameter}
           optionsStyle={!parameter ? { maxHeight: "none" } : {}}

--- a/frontend/src/metabase/components/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget.jsx
@@ -466,7 +466,7 @@ export class FieldValuesWidget extends Component {
         style={{
           width: this.props.expand ? this.props.maxWidth : null,
           minWidth: this.props.minWidth,
-          maxWidth: this.props.maxWidth,
+          maxWidth: "100%",
         }}
       >
         <TokenField

--- a/frontend/src/metabase/components/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget.jsx
@@ -466,7 +466,7 @@ export class FieldValuesWidget extends Component {
         style={{
           width: this.props.expand ? this.props.maxWidth : null,
           minWidth: this.props.minWidth,
-          maxWidth: "100%",
+          maxWidth: this.props.maxWidth,
         }}
       >
         <TokenField

--- a/frontend/test/metabase/scenarios/native-filters/reproductions/17751-long-filter-name-hides-close-icon.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native-filters/reproductions/17751-long-filter-name-hides-close-icon.cy.spec.js
@@ -29,7 +29,7 @@ const questionDetails = {
   },
 };
 
-describe.skip("issue 17751", () => {
+describe("issue 17751", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Attempts to fix #17751 ~~by constraining `FieldValuesWidget`'s container's max-width to 100% of its parent.~~

Although `ul` (TokenField) gets its `style` from the parent (props), I couldn't determine why its `min-width` resolves to a much larger value than the parent component that passes down the `style` to it.  No matter how far "up" I went, the `min-width` was always 300px. Before this fix, `ul` resolved to a `min-width` of `690px`.
![image](https://user-images.githubusercontent.com/31325167/132412509-09d66fc7-c661-48a5-a996-f4cbb7a00b40.png)


The only thing I could think of was to make it inherit the `min-width` from the parent. I couldn't imagine a scenario where the child would need to have greater (or even different) `min-width` than its parent.

```html
<div class="PopoverBody--marginBottom" style="min-width: 300px; max-width: 400px;">
  <div>
    <!-- will inherit `min-width` from a parent div -->
    <ul><!-- content --></ul>
  </div>
</div>
```

### Additional info:
⚠️ While this seems to work for this particular scenario, I am not sure if it has any unforeseen consequences in some other parts of the app.  @gusaiani you're probably the most familiar with this component and the popover by now. Can you please take a look?

![ ](https://p58.f1.n0.cdn.getcloudapp.com/items/JruxOxOv/830f50d9-03de-4e70-aa5b-0aa3fd24156a.gif?source=viewer&v=99c736be7374170fb0dcb8a56c4be1f2)