### PR TITLE
remove .info.js files from FE unit test coverage

### DIFF
--- a/jest.unit.conf.json
+++ b/jest.unit.conf.json
@@ -36,7 +36,8 @@
     "/frontend/src/cljs/",
     "/frontend/src/metabase/internal/",
     "/frontend/test/",
-    ".styled.jsx"
+    ".styled.jsx",
+    ".info.js"
   ],
   "testEnvironment": "jsdom",
   "watchPlugins": [


### PR DESCRIPTION
We're already ignoring code in the `/frontend/src/metabase/internal/` directory, but `*.info.js` files live in `/frontend/src/metabase/components` so they are still included.