### PR TITLE
Notification api changes

### DIFF
--- a/frontend/src/metabase/account/notifications/components/UnsubscribeModal/UnsubscribeModal.jsx
+++ b/frontend/src/metabase/account/notifications/components/UnsubscribeModal/UnsubscribeModal.jsx
@@ -24,7 +24,7 @@ const UnsubscribeModal = ({
 }) => {
   const [error, setError] = useState();
 
-  const handleArchiveClick = useCallback(async () => {
+  const handleUnsubscribeClick = useCallback(async () => {
     try {
       await onUnsubscribe(item);
 
@@ -46,7 +46,7 @@ const UnsubscribeModal = ({
         <Button key="cancel" onClick={onClose}>
           {t`I changed my mind`}
         </Button>,
-        <Button key="submit" warning onClick={handleArchiveClick}>
+        <Button key="submit" warning onClick={handleUnsubscribeClick}>
           {t`Unsubscribe`}
         </Button>,
       ]}

--- a/frontend/src/metabase/account/notifications/components/UnsubscribeModal/UnsubscribeModal.jsx
+++ b/frontend/src/metabase/account/notifications/components/UnsubscribeModal/UnsubscribeModal.jsx
@@ -26,7 +26,7 @@ const UnsubscribeModal = ({
 
   const handleArchiveClick = useCallback(async () => {
     try {
-      await onUnsubscribe(item, user);
+      await onUnsubscribe(item);
 
       if (isCreator(item, user)) {
         onArchive(item, type, true);

--- a/frontend/src/metabase/account/notifications/components/UnsubscribeModal/UnsubscribeModal.unit.spec.js
+++ b/frontend/src/metabase/account/notifications/components/UnsubscribeModal/UnsubscribeModal.unit.spec.js
@@ -55,7 +55,7 @@ describe("UnsubscribeModal", () => {
     screen.getByText("Unsubscribe").click();
 
     waitFor(() => {
-      expect(onUnsubscribe).toHaveBeenCalledWith(alert, user);
+      expect(onUnsubscribe).toHaveBeenCalledWith(alert);
       expect(onArchive).not.toHaveBeenCalled();
       expect(onClose).toHaveBeenCalled();
     });
@@ -84,7 +84,7 @@ describe("UnsubscribeModal", () => {
     screen.getByText("Unsubscribe").click();
 
     waitFor(() => {
-      expect(onUnsubscribe).toHaveBeenCalledWith(alert, user);
+      expect(onUnsubscribe).toHaveBeenCalledWith(alert);
       expect(onArchive).toHaveBeenCalledWith(alert, "alert", true);
       expect(onClose).not.toHaveBeenCalled();
     });

--- a/frontend/src/metabase/account/notifications/components/UnsubscribeModal/UnsubscribeModal.unit.spec.js
+++ b/frontend/src/metabase/account/notifications/components/UnsubscribeModal/UnsubscribeModal.unit.spec.js
@@ -34,7 +34,6 @@ describe("UnsubscribeModal", () => {
   });
 
   it("should close if unsubscribed successfully", () => {
-    const user = getUser();
     const alert = getAlert();
     const onUnsubscribe = jest.fn();
     const onArchive = jest.fn();

--- a/frontend/src/metabase/alert/alert.js
+++ b/frontend/src/metabase/alert/alert.js
@@ -131,14 +131,10 @@ export const unsubscribeFromAlert = alert => {
 };
 
 export const DELETE_ALERT = "metabase/alerts/DELETE_ALERT";
-const deleteAlertRequest = new RestfulRequest({
-  endpoint: AlertApi.delete,
-  actionPrefix: DELETE_ALERT,
-  storeAsDictionary: true,
-});
 export const deleteAlert = alertId => {
   return async (dispatch, getState) => {
-    await dispatch(deleteAlertRequest.trigger({ id: alertId }));
+    // Archive alert rather than deleting it
+    await dispatch(updateAlertRequest.trigger({ id: alertId, archived: true}));
 
     dispatch(
       addUndo({

--- a/frontend/src/metabase/alert/alert.js
+++ b/frontend/src/metabase/alert/alert.js
@@ -132,13 +132,13 @@ export const unsubscribeFromAlert = alert => {
 
 export const DELETE_ALERT = "metabase/alerts/DELETE_ALERT";
 const deleteAlertRequest = new RestfulRequest({
-  endpoint: AlertApi.delete,
+  endpoint: AlertApi.update,
   actionPrefix: DELETE_ALERT,
   storeAsDictionary: true,
 });
 export const deleteAlert = alertId => {
   return async (dispatch, getState) => {
-    await dispatch(deleteAlertRequest.trigger({ id: alertId }));
+    await dispatch(deleteAlertRequest.trigger({ id: alertId, archived: true }));
 
     dispatch(
       addUndo({

--- a/frontend/src/metabase/alert/alert.js
+++ b/frontend/src/metabase/alert/alert.js
@@ -131,10 +131,14 @@ export const unsubscribeFromAlert = alert => {
 };
 
 export const DELETE_ALERT = "metabase/alerts/DELETE_ALERT";
+const deleteAlertRequest = new RestfulRequest({
+  endpoint: AlertApi.delete,
+  actionPrefix: DELETE_ALERT,
+  storeAsDictionary: true,
+});
 export const deleteAlert = alertId => {
   return async (dispatch, getState) => {
-    // Archive alert rather than deleting it
-    await dispatch(updateAlertRequest.trigger({ id: alertId, archived: true }));
+    await dispatch(deleteAlertRequest.trigger({ id: alertId }));
 
     dispatch(
       addUndo({

--- a/frontend/src/metabase/alert/alert.js
+++ b/frontend/src/metabase/alert/alert.js
@@ -134,7 +134,7 @@ export const DELETE_ALERT = "metabase/alerts/DELETE_ALERT";
 export const deleteAlert = alertId => {
   return async (dispatch, getState) => {
     // Archive alert rather than deleting it
-    await dispatch(updateAlertRequest.trigger({ id: alertId, archived: true}));
+    await dispatch(updateAlertRequest.trigger({ id: alertId, archived: true }));
 
     dispatch(
       addUndo({

--- a/frontend/src/metabase/entities/alerts.js
+++ b/frontend/src/metabase/entities/alerts.js
@@ -1,6 +1,7 @@
 import { t } from "ttag";
 import { createEntity, undo } from "metabase/lib/entities";
 import { AlertApi } from "metabase/services";
+import { addUndo } from "metabase/redux/undo";
 
 export const UNSUBSCRIBE = "metabase/entities/alerts/unsubscribe";
 
@@ -18,12 +19,13 @@ const Alerts = createEntity({
       return Alerts.actions.update(
         { id },
         { archived },
-        undo(opts, t`alert`, archived ? t`archived` : t`unarchived`),
+        undo(opts, t`alert`, archived ? t`deleted` : t`restored`),
       );
     },
 
-    unsubscribe: async ({ id }) => {
+    unsubscribe: ({ id }) => async dispatch => {
       await AlertApi.unsubscribe({ id });
+      dispatch(addUndo({ message: t`Successfully unsubscribed` }));
       return { type: UNSUBSCRIBE };
     },
   },

--- a/frontend/src/metabase/entities/alerts.js
+++ b/frontend/src/metabase/entities/alerts.js
@@ -1,10 +1,17 @@
 import { t } from "ttag";
 import { createEntity, undo } from "metabase/lib/entities";
+import { AlertApi } from "metabase/services";
+
+export const UNSUBSCRIBE = "metabase/entities/alerts/unsubscribe";
 
 const Alerts = createEntity({
   name: "alerts",
   nameOne: "alert",
   path: "/api/alert",
+
+  actionTypes: {
+    UNSUBSCRIBE,
+  },
 
   objectActions: {
     setArchived: ({ id }, archived, opts) => {
@@ -15,19 +22,9 @@ const Alerts = createEntity({
       );
     },
 
-    unsubscribe: ({ id, channels }, user, opts) => {
-      const newChannels = channels.map(channel => ({
-        ...channel,
-        recipients: channel.recipients.filter(
-          recipient => recipient.id !== user.id,
-        ),
-      }));
-
-      return Alerts.actions.update(
-        { id },
-        { channels: newChannels },
-        undo(opts, "", t`unsubscribed`),
-      );
+    unsubscribe: async ({ id }) => {
+      await AlertApi.unsubscribe({ id });
+      return { type: UNSUBSCRIBE };
     },
   },
 });

--- a/frontend/src/metabase/entities/pulses.js
+++ b/frontend/src/metabase/entities/pulses.js
@@ -2,11 +2,12 @@ import { t } from "ttag";
 import { createEntity, undo } from "metabase/lib/entities";
 import * as Urls from "metabase/lib/urls";
 import { color } from "metabase/lib/colors";
+import { PulseApi } from "metabase/services";
+import { addUndo } from "metabase/redux/undo";
 import {
   canonicalCollectionId,
   getCollectionType,
 } from "metabase/entities/collections";
-import { PulseApi } from "metabase/services";
 
 export const UNSUBSCRIBE = "metabase/entities/pulses/unsubscribe";
 
@@ -24,7 +25,7 @@ const Pulses = createEntity({
       return Pulses.actions.update(
         { id },
         { archived },
-        undo(opts, t`subscription`, archived ? t`archived` : t`unarchived`),
+        undo(opts, t`subscription`, archived ? t`deleted` : t`restored`),
       );
     },
 
@@ -47,8 +48,9 @@ const Pulses = createEntity({
       );
     },
 
-    unsubscribe: async ({ id }) => {
+    unsubscribe: ({ id }) => async dispatch => {
       await PulseApi.unsubscribe({ id });
+      dispatch(addUndo({ message: t`Successfully unsubscribed` }));
       return { type: UNSUBSCRIBE };
     },
   },

--- a/frontend/src/metabase/entities/pulses.js
+++ b/frontend/src/metabase/entities/pulses.js
@@ -2,16 +2,22 @@ import { t } from "ttag";
 import { createEntity, undo } from "metabase/lib/entities";
 import * as Urls from "metabase/lib/urls";
 import { color } from "metabase/lib/colors";
-
 import {
   canonicalCollectionId,
   getCollectionType,
 } from "metabase/entities/collections";
+import { PulseApi } from "metabase/services";
+
+export const UNSUBSCRIBE = "metabase/entities/pulses/unsubscribe";
 
 const Pulses = createEntity({
   name: "pulses",
   nameOne: "pulse",
   path: "/api/pulse",
+
+  actionTypes: {
+    UNSUBSCRIBE,
+  },
 
   objectActions: {
     setArchived: ({ id }, archived, opts) => {
@@ -41,19 +47,9 @@ const Pulses = createEntity({
       );
     },
 
-    unsubscribe: ({ id, channels }, user, opts) => {
-      const newChannels = channels.map(channel => ({
-        ...channel,
-        recipients: channel.recipients.filter(
-          recipient => recipient.id !== user.id,
-        ),
-      }));
-
-      return Pulses.actions.update(
-        { id },
-        { channels: newChannels },
-        undo(opts, "", t`unsubscribed`),
-      );
+    unsubscribe: async ({ id }) => {
+      await PulseApi.unsubscribe({ id });
+      return { type: UNSUBSCRIBE };
     },
   },
 

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -330,7 +330,8 @@ export const AlertApi = {
   get: GET("/api/alert/:id"),
   create: POST("/api/alert"),
   update: PUT("/api/alert/:id"),
-  unsubscribe: DELETE("/api/alert/:id/unsubscribe"),
+  delete: DELETE("/api/alert/:id"),
+  unsubscribe: PUT("/api/alert/:id/unsubscribe"),
 };
 
 export const SegmentApi = {

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -321,6 +321,7 @@ export const PulseApi = {
   test: POST("/api/pulse/test"),
   form_input: GET("/api/pulse/form_input"),
   preview_card: GET("/api/pulse/preview_card_info/:id"),
+  unsubscribe: DELETE("/api/pulse/:id/subscription"),
 };
 
 export const AlertApi = {
@@ -330,7 +331,7 @@ export const AlertApi = {
   create: POST("/api/alert"),
   update: PUT("/api/alert/:id"),
   delete: DELETE("/api/alert/:id"),
-  unsubscribe: PUT("/api/alert/:id/unsubscribe"),
+  unsubscribe: DELETE("/api/alert/:id/subscription"),
 };
 
 export const SegmentApi = {

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -330,7 +330,6 @@ export const AlertApi = {
   get: GET("/api/alert/:id"),
   create: POST("/api/alert"),
   update: PUT("/api/alert/:id"),
-  delete: DELETE("/api/alert/:id"),
   unsubscribe: DELETE("/api/alert/:id/subscription"),
 };
 

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -330,8 +330,7 @@ export const AlertApi = {
   get: GET("/api/alert/:id"),
   create: POST("/api/alert"),
   update: PUT("/api/alert/:id"),
-  delete: DELETE("/api/alert/:id"),
-  unsubscribe: PUT("/api/alert/:id/unsubscribe"),
+  unsubscribe: DELETE("/api/alert/:id/unsubscribe"),
 };
 
 export const SegmentApi = {

--- a/src/metabase/api/alert.clj
+++ b/src/metabase/api/alert.clj
@@ -208,7 +208,7 @@
          (= unsubscribing-user-id (:id (first recipients)))
          (nil? (slack-channel alert)))))
 
-(api/defendpoint DELETE "/:id/unsubscribe"
+(api/defendpoint DELETE "/:id/subscription"
   "Unsubscribes a user from the given alert"
   [id]
   (let [alert (pulse/retrieve-alert id)]

--- a/src/metabase/email/alert_was_deleted.mustache
+++ b/src/metabase/email/alert_was_deleted.mustache
@@ -1,4 +1,0 @@
-{{> metabase/email/_header }}
-    <p>{{adminName}} deleted an alert you created about <a href="{{questionURL}}">{{questionName}}.</p>
-    <p>Since we're in the business of alerts, we thought we'd alert you.</p>
-{{> metabase/email/_footer}}

--- a/src/metabase/email/messages.clj
+++ b/src/metabase/email/messages.clj
@@ -477,7 +477,6 @@
 (def ^:private admin-unsubscribed-template (template-path "alert_admin_unsubscribed_you"))
 (def ^:private added-template              (template-path "alert_you_were_added"))
 (def ^:private stopped-template            (template-path "alert_stopped_working"))
-(def ^:private deleted-template            (template-path "alert_was_deleted"))
 
 (defn send-new-alert-email!
   "Send out the initial 'new alert' email to the `creator` of the alert"
@@ -517,10 +516,3 @@
   [alert user {:keys [first_name last_name] :as archiver}]
   (let [edited-text (format "the question was edited by %s %s" first_name last_name)]
     (send-email! user not-working-subject stopped-template (assoc (default-alert-context alert) :deletionCause edited-text))))
-
-(defn send-admin-deleted-your-alert!
-  "Email to notify users when an admin has deleted their alert"
-  [alert user {:keys [first_name last_name] :as deletor}]
-  (let [subject (format "%s %s deleted an alert you created" first_name last_name)
-        admin-name (format "%s %s" first_name last_name)]
-    (send-email! user subject deleted-template (assoc (default-alert-context alert) :adminName admin-name))))

--- a/test/metabase/api/alert_test.clj
+++ b/test/metabase/api/alert_test.clj
@@ -719,7 +719,7 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 (defn- alert-unsubscribe-url [alert-or-id]
-  (format "alert/%d/unsubscribe" (u/the-id alert-or-id)))
+  (format "alert/%d/subscription" (u/the-id alert-or-id)))
 
 (defn- api:unsubscribe! [user-kw expected-status-code alert-or-id]
   (mt/user-http-request user-kw :delete expected-status-code (alert-unsubscribe-url alert-or-id)))


### PR DESCRIPTION
Support BE changes https://github.com/metabase/metabase/pull/17740:
- Always archive alerts and pulses instead of deleting them
- Use new `subscription` endpoint for unsubscribing

How to test:
- Merge the referenced PR into this branch locally
- Run cypress tests, e.g. `notifications.cy.spec.js`
