### PR TITLE
Fix unable to click "Learn more" on custom expression

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -250,6 +250,7 @@ export default class ExpressionEditorTextfield extends React.Component {
     this.setState({
       suggestions: [],
       highlightedSuggestionIndex: 0,
+      helpText: null,
     });
   }
 
@@ -265,7 +266,7 @@ export default class ExpressionEditorTextfield extends React.Component {
         displayError.push(compileError);
       }
     }
-    this.setState({ displayError, helpText: null });
+    this.setState({ displayError });
 
     // whenever our input blurs we push the updated expression to our parent if valid
     if (this.state.expression) {

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -254,7 +254,15 @@ export default class ExpressionEditorTextfield extends React.Component {
     });
   }
 
-  onInputBlur = () => {
+  onInputBlur = e => {
+    // Switching to another window also triggers the blur event.
+    // When our window gets focus again, the input will automatically
+    // get focus, so ignore the blue event to avoid showing an
+    // error message when the user is not actually done.
+    if (e.target === document.activeElement) {
+      return;
+    }
+
     this.clearSuggestions();
 
     const { tokenizerError, compileError } = this.state;

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -51,31 +51,34 @@ const HelpText = ({ helpText, width }) =>
       style={{ width: width }}
       isOpen
     >
-      <p
-        className="p2 m0 text-monospace text-bold"
-        style={{ background: colors["bg-yellow"] }}
-      >
-        {helpText.structure}
-      </p>
-      <div className="p2 border-top">
-        <p className="mt0 text-bold">{helpText.description}</p>
-        <p className="text-code m0 text-body">{helpText.example}</p>
-      </div>
-      <div className="p2 border-top">
-        {helpText.args.map(({ name, description }, index) => (
-          <div key={index}>
-            <h4 className="text-medium">{name}</h4>
-            <p className="mt1 text-bold">{description}</p>
-          </div>
-        ))}
-        <ExternalLink
-          className="link text-bold block my1"
-          target="_blank"
-          href={MetabaseSettings.docsUrl("users-guide/expressions")}
+      {/* Prevent stealing focus from input box causing the help text to be closed (metabase#17548) */}
+      <div onMouseDown={e => e.preventDefault()}>
+        <p
+          className="p2 m0 text-monospace text-bold"
+          style={{ background: colors["bg-yellow"] }}
         >
-          <Icon name="reference" size={12} className="mr1" />
-          {t`Learn more`}
-        </ExternalLink>
+          {helpText.structure}
+        </p>
+        <div className="p2 border-top">
+          <p className="mt0 text-bold">{helpText.description}</p>
+          <p className="text-code m0 text-body">{helpText.example}</p>
+        </div>
+        <div className="p2 border-top">
+          {helpText.args.map(({ name, description }, index) => (
+            <div key={index}>
+              <h4 className="text-medium">{name}</h4>
+              <p className="mt1 text-bold">{description}</p>
+            </div>
+          ))}
+          <ExternalLink
+            className="link text-bold block my1"
+            target="_blank"
+            href={MetabaseSettings.docsUrl("users-guide/expressions")}
+          >
+            <Icon name="reference" size={12} className="mr1" />
+            {t`Learn more`}
+          </ExternalLink>
+        </div>
       </div>
     </Popover>
   ) : null;

--- a/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/custom_column.cy.spec.js
@@ -635,6 +635,26 @@ describe("scenarios > question > custom columns", () => {
     cy.findByText("round([Temperature])");
     cy.findByText(/Field formula/i).click(); // Click outside of formula field instead of blur
     cy.findByText("round([Temperature])").should("not.exist");
+
+    // Should also work with escape key
+    popover().within(() => cy.get("[contenteditable='true']").click());
+    cy.findByText("round([Temperature])");
+    popover().within(() => cy.get("[contenteditable='true']").type("{esc}"));
+    cy.findByText("round([Temperature])").should("not.exist");
+  });
+
+  it("custom expression helper shouldn't be hidden when clicked on (metabase#17548)", () => {
+    openPeopleTable({ mode: "notebook" });
+    cy.findByText("Custom column").click();
+    popover().within(() => {
+      cy.get("[contenteditable='true']").type(`rou{enter}`, {
+        delay: 100,
+      });
+    });
+
+    // Shouldn't hide on click
+    cy.findByText("round([Temperature])").click();
+    cy.findByText("round([Temperature])");
   });
 
   it.skip("should work with `isNull` function (metabase#15922)", () => {


### PR DESCRIPTION
Fix 3 issues with the custom expression editor popup

1. The help dialog cannot be closed with ESC key unlike the auto-suggest dialog
2. The help dialog disappears when the browser window is unfocused (cannot Cypress test this one this Cypress has no concept of unfocusing the window)
3. The help dialog disappears when you try to click on "Learn more" (Fixes #17548)

The third issue is fixed by not allowing the click on the help dialog to unfocus the input box. A side-effect of this is that you cannot select/copy anything from the help dialog, but clicking on a link still works.

I've tried to make selecting text on the help dialog work, but it turns out to be quite complicated as we will have to take focus away from the input box and yet when we close the help dialog, return the focus back to input box and put the text insertion cursor back in the original place.