### PR TITLE
#17768 Repro: If Entity Key fields are fingerprinted, then they show binning options in GUI

### DIFF
--- a/frontend/test/metabase/scenarios/admin/datamodel/reproductions/17768-entity-key-showing-binning-options.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/reproductions/17768-entity-key-showing-binning-options.cy.spec.js
@@ -1,0 +1,45 @@
+import { restore, openReviewsTable, popover } from "__support__/e2e/cypress";
+import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
+
+const { REVIEWS } = SAMPLE_DATASET;
+
+describe.skip("issue 17768", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.request("PUT", `/api/field/${REVIEWS.ID}`, {
+      semantic_type: "type/Category",
+      has_field_values: "list",
+    });
+
+    // Sync "Sample Dataset" schema
+    cy.request("POST", `/api/database/1/sync_schema`);
+    /**
+     * This is a bit fragile and may result in the false positive result, depending on the CI machine that runs tests.
+     * However, 3s should be a plenty of time for the sync to finish.
+     * Although the arbitrary waiting is considered a bad practice, we don't have any other way to determine when the sync is finished.
+     */
+    cy.wait(3000);
+
+    cy.request("PUT", `/api/field/${REVIEWS.ID}`, {
+      semantic_type: "type/PK",
+      has_field_values: "none",
+    });
+  });
+
+  it("should not show binning options for an entity key, regardless of its underlying type (metabase#17768)", () => {
+    openReviewsTable({ mode: "notebook" });
+
+    cy.findByText("Summarize").click();
+    cy.findByText("Pick a column to group by").click();
+
+    popover().within(() => {
+      cy.findByText("ID")
+        .closest(".List-section")
+        .realHover()
+        .contains("Auto bin")
+        .should("not.exist");
+    });
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #17768 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/admin/datamodel/reproductions/17768-entity-key-showing-binning-options.cy.spec.js`
- Unskip the repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/132247186-0bac5b08-3a7a-4bff-84cb-10b7eef6ff22.png)

