### PR TITLE
#17777 Repro: Hiding all tables in data model removes them from the permissions page

### DIFF
--- a/frontend/test/metabase/scenarios/permissions/reproductions/17777-hidden-tables-not-available.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/reproductions/17777-hidden-tables-not-available.cy.spec.js
@@ -1,0 +1,45 @@
+import { restore, popover } from "__support__/e2e/cypress";
+import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
+
+const { ORDERS_ID, PRODUCTS_ID, PEOPLE_ID, REVIEWS_ID } = SAMPLE_DATASET;
+
+describe.skip("issue 17777", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    hideTables([ORDERS_ID, PRODUCTS_ID, PEOPLE_ID, REVIEWS_ID]);
+  });
+
+  it("should still be able to set permissions on individual tables, even though they are hidden in data model (metabase#17777)", () => {
+    cy.visit("/admin/permissions/data/group/1");
+
+    cy.findByText("Permissions for the All Users group");
+    cy.findByText("Sample Dataset").click();
+
+    cy.location("pathname").should(
+      "eq",
+      "/admin/permissions/data/group/1/database/1",
+    );
+
+    cy.findByTestId("permission-table").within(() => {
+      cy.findByText("Orders");
+      cy.findByText("Products");
+      cy.findByText("Reviews");
+      cy.findByText("People");
+    });
+
+    cy.findAllByText("No self-service")
+      .first()
+      .click();
+
+    popover().contains("Unrestricted");
+  });
+});
+
+function hideTables(tables) {
+  cy.request("PUT", "/api/table", {
+    ids: tables,
+    visibility_type: "hidden",
+  });
+}


### PR DESCRIPTION
### Status
Needs #17778 to be merged first

### What does this PR accomplish?
- Reproduces #17777 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/permissions/reproductions/17777-hidden-tables-not-available.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/132262851-8c8dedb0-e03b-420a-b64c-f7d3b7cc029b.png)


Sanity check (without hiding the tables in data model)
![image](https://user-images.githubusercontent.com/31325167/132262880-c311867d-3b75-4487-985f-dec9f0896a15.png)

