### PR TITLE
dimension list: hide sub-dimensions for fields that are FK

### DIFF
--- a/frontend/src/metabase/query_builder/components/DimensionList.jsx
+++ b/frontend/src/metabase/query_builder/components/DimensionList.jsx
@@ -108,7 +108,11 @@ export default class DimensionList extends Component {
       onRemoveDimension,
     } = this.props;
     const subDimensions =
-      enableSubDimensions && item.dimension && item.dimension.dimensions();
+      enableSubDimensions &&
+      item.dimension &&
+      // Do not display sub dimension if this is an FK (metabase#16787)
+      !item.dimension.field().isFK() &&
+      item.dimension.dimensions();
 
     const multiSelect = !!(onAddDimension || onRemoveDimension);
 

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -70,6 +70,16 @@ describe("scenarios > question > notebook", () => {
     cy.contains("Showing 1 row"); // ensure only one user was returned
   });
 
+  it("shouldn't show sub-dimensions for FK (metabase#16787)", () => {
+    openOrdersTable({ mode: "notebook" });
+    cy.findByText("Summarize").click();
+    cy.findByText("Pick a column to group by").click();
+    cy.findByText("User ID")
+      .closest(".List-item")
+      .find(".Field-extra")
+      .should("not.have.descendants", "*");
+  });
+
   it("should show the original custom expression filter field on subsequent click (metabase#14726)", () => {
     cy.server();
     cy.route("POST", "/api/dataset").as("dataset");


### PR DESCRIPTION
This is likely a regression from #14897 treating FK as sub-dimensions of the FK field (https://github.com/metabase/metabase/commit/6bdd5e094aecf6c2ea081f9fbc698c8b3512511f#diff-7af510db40767873db52e7ebfd7cdeb5b4918d10ef08dfa2e998dab79fe66741R725) which DimensionList then later pick up to display.

Fixes #16787