### PR TITLE
Fix SAML login with OpenAM

### DIFF
--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -566,7 +566,9 @@
   "Is `s` a Base-64 encoded string?"
   ^Boolean [s]
   (boolean (when (string? s)
-             (re-matches #"^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$" s))))
+             (as-> s s
+                   (str/replace s #"\s" "")
+                   (re-matches #"^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$" s)))))
 
 (defn decode-base64
   "Decodes a Base64 string to a UTF-8 string"

--- a/test/metabase/util_test.clj
+++ b/test/metabase/util_test.clj
@@ -176,6 +176,9 @@
     "QQ"           false
     "QQ="          false
     "QQ=="         true
+    ;; line breaks and spaces should be OK
+    "Q\rQ\n=\r\n=" true
+    " Q Q = = "    true
     ;; padding has to go at the end
     "==QQ"         false))
 


### PR DESCRIPTION
OpenAM SAMLResponse contains "\r\n" every 76 characters leading our SAML code to think it's not base64-encoded.

Fix by relaxing our valid base64 check to ignore all spaces.

Fixes #15567
