### PR TITLE
#16785 Repro: Search shows hidden tables

### DIFF
--- a/frontend/test/metabase/scenarios/onboarding/search/reproductions/16785-do-not-display-hidden-tables.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/search/reproductions/16785-do-not-display-hidden-tables.cy.spec.js
@@ -1,0 +1,25 @@
+import { restore } from "__support__/e2e/cypress";
+import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
+
+const { REVIEWS_ID } = SAMPLE_DATASET;
+
+describe.skip("issue 16785", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.request("PUT", "/api/table", {
+      ids: [REVIEWS_ID],
+      visibility_type: "hidden",
+    });
+  });
+
+  it("should not display hidden tables (metabase#16785)", () => {
+    cy.visit("/");
+    cy.findByPlaceholderText("Search…").type("Reviews");
+
+    cy.findByTestId("search-results-list").within(() => {
+      cy.findByText("Reviews").should("not.exist");
+    });
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #16785 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/onboarding/search/reproductions/16785-do-not-display-hidden-tables.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/132344799-2236ade5-30da-45ab-975c-a65d1b37bfe9.png)

