### PR TITLE
#17763 Repro: Trying to set "Granular" permissions after "Block" is broken

### DIFF
--- a/frontend/test/metabase/scenarios/permissions/reproductions/17763-cannot-edit-granular-after-block.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/reproductions/17763-cannot-edit-granular-after-block.cy.spec.js
@@ -4,6 +4,10 @@ import { USER_GROUPS } from "__support__/e2e/cypress_data";
 const { ALL_USERS_GROUP } = USER_GROUPS;
 
 describe.skip("issue 17763", () => {
+  // Run only for EE version even when the underlying issue gets fixed.
+  // Do not remove the following line. Only unskip the `describe` block.
+  cy.onlyOn(!!Cypress.env("HAS_ENTERPRISE_TOKEN"));
+
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();

--- a/frontend/test/metabase/scenarios/permissions/reproductions/17763-cannot-edit-granular-after-block.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/reproductions/17763-cannot-edit-granular-after-block.cy.spec.js
@@ -1,13 +1,9 @@
-import { restore, popover } from "__support__/e2e/cypress";
+import { restore, popover, describeWithToken } from "__support__/e2e/cypress";
 import { USER_GROUPS } from "__support__/e2e/cypress_data";
 
 const { ALL_USERS_GROUP } = USER_GROUPS;
 
-describe.skip("issue 17763", () => {
-  // Run only for EE version even when the underlying issue gets fixed.
-  // Do not remove the following line. Only unskip the `describe` block.
-  cy.onlyOn(!!Cypress.env("HAS_ENTERPRISE_TOKEN"));
-
+describeWithToken("issue 17763", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
@@ -19,7 +15,7 @@ describe.skip("issue 17763", () => {
     });
   });
 
-  it('should be able to edit tables permissions in granular view after "block" permissions (metabase#17763)', () => {
+  it.skip('should be able to edit tables permissions in granular view after "block" permissions (metabase#17763)', () => {
     cy.visit("/admin/permissions/data/database/1");
 
     cy.findByText("Block").click();

--- a/frontend/test/metabase/scenarios/permissions/reproductions/17763-cannot-edit-granular-after-block.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/reproductions/17763-cannot-edit-granular-after-block.cy.spec.js
@@ -1,0 +1,43 @@
+import { restore, popover } from "__support__/e2e/cypress";
+import { USER_GROUPS } from "__support__/e2e/cypress_data";
+
+const { ALL_USERS_GROUP } = USER_GROUPS;
+
+describe.skip("issue 17763", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.updatePermissionsGraph({
+      [ALL_USERS_GROUP]: {
+        "1": { schemas: "block", native: "none" },
+      },
+    });
+  });
+
+  it('should be able to edit tables permissions in granular view after "block" permissions (metabase#17763)', () => {
+    cy.visit("/admin/permissions/data/database/1");
+
+    cy.findByText("Block").click();
+
+    popover()
+      .contains("Granular")
+      .click();
+
+    cy.location("pathname").should(
+      "eq",
+      `/admin/permissions/data/group/${ALL_USERS_GROUP}/database/1`,
+    );
+
+    cy.findByTestId("permission-table").within(() => {
+      cy.findAllByText("No self-service")
+        .first()
+        .click();
+    });
+
+    popover().within(() => {
+      cy.findByText("Unrestricted");
+      cy.findByText("Sandboxed");
+    });
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #17763 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/permissions/reproductions/17763-cannot-edit-granular-after-block.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/132356740-06983df9-118a-425f-ba23-ebe625396594.png)

