### PR TITLE
remove Parameters component defaultProps to get rid of warning message

### DIFF
--- a/frontend/src/metabase/parameters/components/Parameters/Parameters.jsx
+++ b/frontend/src/metabase/parameters/components/Parameters/Parameters.jsx
@@ -13,10 +13,6 @@ import { getMetadata } from "metabase/selectors/metadata";
 
 @connect(state => ({ metadata: getMetadata(state) }))
 export default class Parameters extends Component {
-  defaultProps = {
-    syncQueryString: false,
-  };
-
   constructor(props) {
     super(props);
 


### PR DESCRIPTION
The `defaultProps` set on `Parameters` don't work since they are set on the `Parameters` instance instead of the `Parameters` constructor (by adding the `static` keyword). As a result, React triggers a rather noisy console warning, not helped by the fact that `Parameters` gets rerendered frequently. Since the `defaultProps` here don't do anything, I'm just going to remove them. In addition to that, the `syncQueryString` boolean prop is only ever used in a falsy check, so if the prop is `undefined` it will work identically to how it works when set explicitly as `false`