### PR TITLE
don't set pulse on SharingSidebar mount to prevent race condition when moving between sidebar views

### DIFF
--- a/frontend/src/metabase/sharing/components/SharingSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/SharingSidebar.jsx
@@ -174,11 +174,6 @@ class SharingSidebar extends React.Component {
 
   componentDidMount = async () => {
     await this.props.fetchPulseFormInput();
-
-    this.props.setEditingPulse(
-      this.props.pulseId,
-      this.props.initialCollectionId,
-    );
   };
 
   onChannelPropertyChange = (index, name, value) => {

--- a/frontend/src/metabase/sharing/components/SharingSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/SharingSidebar.jsx
@@ -11,7 +11,6 @@ import {
   AddEditEmailSidebar,
 } from "metabase/sharing/components/AddEditSidebar";
 import Sidebar from "metabase/dashboard/components/Sidebar";
-import Collections from "metabase/entities/collections";
 import Pulses from "metabase/entities/pulses";
 import User from "metabase/entities/users";
 import { normalizeParameterValue } from "metabase/meta/Parameter";
@@ -24,11 +23,7 @@ import {
   getPulseParameters,
 } from "metabase/lib/pulse";
 
-import {
-  getPulseId,
-  getEditingPulse,
-  getPulseFormInput,
-} from "metabase/pulse/selectors";
+import { getEditingPulse, getPulseFormInput } from "metabase/pulse/selectors";
 
 import { getUser } from "metabase/selectors/user";
 
@@ -98,14 +93,9 @@ const getEditingPulseWithDefaults = (state, props) => {
 };
 
 const mapStateToProps = (state, props) => ({
-  pulseId: getPulseId(state, props),
   pulse: getEditingPulseWithDefaults(state, props),
   formInput: getPulseFormInput(state, props),
   user: getUser(state),
-  initialCollectionId: Collections.selectors.getInitialCollectionId(
-    state,
-    props,
-  ),
 });
 
 const mapDispatchToProps = {
@@ -138,7 +128,6 @@ class SharingSidebar extends React.Component {
     formInput: PropTypes.object.isRequired,
     initialCollectionId: PropTypes.number,
     pulse: PropTypes.object.isRequired,
-    pulseId: PropTypes.number,
     saveEditingPulse: PropTypes.func.isRequired,
     setEditingPulse: PropTypes.func.isRequired,
     testPulse: PropTypes.func.isRequired,


### PR DESCRIPTION
Fixes #17479 

For whatever reason the `SharingSidebar` will sometimes get unmounted and then remounted causing the code I'm deleting here to run on mount. I think the code is vestigial; it is well over 4 years old and that `pulseId` is expected to come from queryParams and we don't ever set `pulseId` in queryParams for this component. This means the `setEditingPulse` call I'm deleting only ever _unsets_ the pulse set in state. If you are mildly quick, you can click a pulse to see its details before this `setEditingPulse` call triggers, which gets you into a funky state, as seen in the issue.

Here's me clicking into the pulse details quickly after a save:

https://user-images.githubusercontent.com/13057258/132421931-4d99e21e-b125-429a-bb70-aa8dfe50c96a.mov

