### PR TITLE
translate options in SchedulePicker

### DIFF
--- a/frontend/src/metabase/components/SchedulePicker.jsx
+++ b/frontend/src/metabase/components/SchedulePicker.jsx
@@ -41,6 +41,13 @@ export const MONTH_DAY_OPTIONS = [
   { name: t`15th (Midpoint)`, value: "mid" },
 ];
 
+const optionNameTranslations = {
+  hourly: t`Hourly`,
+  daily: t`Daily`,
+  weekly: t`Weekly`,
+  monthly: t`Monthly`,
+};
+
 /**
  * Picker for selecting a hourly/daily/weekly/monthly schedule.
  *
@@ -271,7 +278,7 @@ export default class SchedulePicker extends Component {
               this.handleChangeProperty("schedule_type", value)
             }
             options={scheduleOptions}
-            optionNameFn={o => capitalize(o)}
+            optionNameFn={o => optionNameTranslations[o] || capitalize(o)}
             optionValueFn={o => o}
           />
           {scheduleType === "weekly" && this.renderDayPicker()}


### PR DESCRIPTION
Fixes #17714 

There are only a few different options we pass to the `SchedulePicker` so we can safely add a map of option name to translated option name. As a fallback in case one of the names doesn't exist in the map I am keeping the previous logic, as well.