### PR TITLE
let users disable attachments with questions checked

### DIFF
--- a/frontend/src/metabase/components/Toggle.jsx
+++ b/frontend/src/metabase/components/Toggle.jsx
@@ -23,6 +23,7 @@ export default class Toggle extends Component {
     const { value, small, className, color, onChange, ...props } = this.props;
     return (
       <a
+        data-testid="toggle"
         {...props}
         role="checkbox"
         aria-checked={value}

--- a/frontend/src/metabase/components/Toggle.jsx
+++ b/frontend/src/metabase/components/Toggle.jsx
@@ -23,7 +23,6 @@ export default class Toggle extends Component {
     const { value, small, className, color, onChange, ...props } = this.props;
     return (
       <a
-        data-testid="toggle"
         {...props}
         role="checkbox"
         aria-checked={value}

--- a/frontend/src/metabase/sharing/components/EmailAttachmentPicker.jsx
+++ b/frontend/src/metabase/sharing/components/EmailAttachmentPicker.jsx
@@ -184,7 +184,11 @@ export default class EmailAttachmentPicker extends Component {
 
     return (
       <div>
-        <Toggle value={isEnabled} onChange={this.toggleAttach} />
+        <Toggle
+          aria-label="Attach results"
+          value={isEnabled}
+          onChange={this.toggleAttach}
+        />
 
         {isEnabled && (
           <div>

--- a/frontend/src/metabase/sharing/components/EmailAttachmentPicker.jsx
+++ b/frontend/src/metabase/sharing/components/EmailAttachmentPicker.jsx
@@ -185,7 +185,7 @@ export default class EmailAttachmentPicker extends Component {
     return (
       <div>
         <Toggle
-          aria-label="Attach results"
+          aria-label={t`Attach results`}
           value={isEnabled}
           onChange={this.toggleAttach}
         />

--- a/frontend/src/metabase/sharing/components/EmailAttachmentPicker.jsx
+++ b/frontend/src/metabase/sharing/components/EmailAttachmentPicker.jsx
@@ -22,6 +22,7 @@ export default class EmailAttachmentPicker extends Component {
   static propTypes = {
     pulse: PropTypes.object.isRequired,
     setPulse: PropTypes.func.isRequired,
+    cards: PropTypes.array.isRequired,
   };
 
   componentDidMount() {
@@ -115,6 +116,10 @@ export default class EmailAttachmentPicker extends Component {
    * Called when attachments are enabled/disabled at all
    */
   toggleAttach = includeAttachment => {
+    if (!includeAttachment) {
+      this.disableAllCards();
+    }
+
     this.setState({ isEnabled: includeAttachment });
   };
 
@@ -158,6 +163,12 @@ export default class EmailAttachmentPicker extends Component {
       return { selectedCardIds: newSelectedCardIds };
     });
   };
+
+  disableAllCards() {
+    const selectedCardIds = new Set();
+    this.updatePulseCards(this.state.selectedAttachmentType, selectedCardIds);
+    this.setState({ selectedCardIds });
+  }
 
   areAllSelected(allCards, selectedCardSet) {
     return allCards.length === selectedCardSet.size;

--- a/frontend/src/metabase/sharing/components/EmailAttachmentPicker.unit.spec.js
+++ b/frontend/src/metabase/sharing/components/EmailAttachmentPicker.unit.spec.js
@@ -23,7 +23,7 @@ describe("EmailAttachmentPicker", () => {
       const toggle = screen.getByRole("checkbox");
       expect(toggle).toBeInTheDocument();
       expect(toggle.dataset.testid).toEqual("toggle");
-      expect(toggle.getAttribute("aria-checked")).toBe("false");
+      expect(toggle).toHaveAttribute("aria-checked", "false");
     });
 
     it("should have a clickable toggle that reveals attachment type and a checkbox per question", () => {
@@ -36,16 +36,16 @@ describe("EmailAttachmentPicker", () => {
       fireEvent.click(toggle);
 
       const csvFormatInput = screen.getByLabelText(".csv");
-      expect(csvFormatInput.checked).toBe(true);
+      expect(csvFormatInput).toBeChecked();
 
       const toggleAllCheckbox = screen.getByLabelText("Questions to attach");
-      expect(toggleAllCheckbox.checked).toBe(false);
+      expect(toggleAllCheckbox).not.toBeChecked();
 
       const card1Checkbox = screen.getByLabelText("card1");
-      expect(card1Checkbox.checked).toBe(false);
+      expect(card1Checkbox).not.toBeChecked();
 
       const card2Checkbox = screen.getByLabelText("card2");
-      expect(card2Checkbox.checked).toBe(false);
+      expect(card2Checkbox).not.toBeChecked();
     });
   });
 
@@ -68,40 +68,40 @@ describe("EmailAttachmentPicker", () => {
     it("should have a toggled Toggle", () => {
       const toggle = screen.getByTestId("toggle");
       expect(toggle).toBeInTheDocument();
-      expect(toggle.getAttribute("aria-checked")).toBe("true");
+      expect(toggle).toHaveAttribute("aria-checked", "true");
     });
 
     it("should have selected the xlsv format", () => {
       const csvFormatInput = screen.getByLabelText(".csv");
-      expect(csvFormatInput.checked).toBe(false);
+      expect(csvFormatInput).not.toBeChecked();
       const xlsxFormatInput = screen.getByLabelText(".xlsx");
-      expect(xlsxFormatInput.checked).toBe(true);
+      expect(xlsxFormatInput).toBeChecked();
     });
 
     it("should show a checked checkbox for the card with an attachment", () => {
       const toggleAllCheckbox = screen.getByLabelText("Questions to attach");
-      expect(toggleAllCheckbox.checked).toBe(false);
+      expect(toggleAllCheckbox).not.toBeChecked();
 
       const card1Checkbox = screen.getByLabelText("card1");
-      expect(card1Checkbox.checked).toBe(true);
+      expect(card1Checkbox).toBeChecked();
 
       const card2Checkbox = screen.getByLabelText("card2");
-      expect(card2Checkbox.checked).toBe(false);
+      expect(card2Checkbox).not.toBeChecked();
     });
 
     it("should let you check or uncheck card checkboxes", () => {
       const card1Checkbox = screen.getByLabelText("card1");
       fireEvent.click(card1Checkbox);
-      expect(card1Checkbox.checked).toBe(false);
+      expect(card1Checkbox).not.toBeChecked();
       fireEvent.click(card1Checkbox);
-      expect(card1Checkbox.checked).toBe(true);
+      expect(card1Checkbox).toBeChecked();
     });
 
     it("should let you check all checkboxes", () => {
       const card2Checkbox = screen.getByLabelText("card2");
       fireEvent.click(card2Checkbox);
-      expect(card2Checkbox.checked).toBe(true);
-      expect(screen.getByLabelText("Questions to attach").checked).toBe(true);
+      expect(card2Checkbox).toBeChecked();
+      expect(screen.getByLabelText("Questions to attach")).toBeChecked();
     });
 
     it("should let you check/uncheck all boxes via the `Questions to attach` toggle", () => {
@@ -111,20 +111,20 @@ describe("EmailAttachmentPicker", () => {
 
       fireEvent.click(toggleAllCheckbox);
 
-      expect(screen.getByLabelText("Questions to attach").checked).toBe(true);
-      expect(card1Checkbox.checked).toBe(true);
-      expect(card2Checkbox.checked).toBe(true);
+      expect(screen.getByLabelText("Questions to attach")).toBeChecked();
+      expect(card1Checkbox).toBeChecked();
+      expect(card2Checkbox).toBeChecked();
 
       fireEvent.click(toggleAllCheckbox);
 
-      expect(screen.getByLabelText("Questions to attach").checked).toBe(false);
-      expect(card1Checkbox.checked).toBe(false);
-      expect(card2Checkbox.checked).toBe(false);
+      expect(screen.getByLabelText("Questions to attach")).not.toBeChecked();
+      expect(card1Checkbox).not.toBeChecked();
+      expect(card2Checkbox).not.toBeChecked();
     });
 
     it("should uncheck all boxes if disabling attachments", () => {
       const toggle = screen.getByTestId("toggle");
-      expect(screen.getByLabelText("card1").checked).toBe(true);
+      expect(screen.getByLabelText("card1")).toBeChecked();
 
       fireEvent.click(toggle);
 
@@ -134,7 +134,7 @@ describe("EmailAttachmentPicker", () => {
       expect(screen.queryByText("card2")).toBeNull();
 
       fireEvent.click(toggle);
-      expect(screen.getByLabelText("card1").checked).toBe(false);
+      expect(screen.getByLabelText("card1")).not.toBeChecked();
     });
   });
 });

--- a/frontend/src/metabase/sharing/components/EmailAttachmentPicker.unit.spec.js
+++ b/frontend/src/metabase/sharing/components/EmailAttachmentPicker.unit.spec.js
@@ -1,0 +1,198 @@
+import React from "react";
+import { render, fireEvent, screen } from "@testing-library/react";
+
+import EmailAttachmentPicker from "./EmailAttachmentPicker";
+
+describe("EmailAttachmentPicker", () => {
+  describe("when instantiated without any cards with attachments", () => {
+    let pulse;
+    let setPulse;
+    beforeEach(() => {
+      pulse = createPulse();
+      setPulse = jest.fn();
+      render(
+        <EmailAttachmentPicker
+          cards={pulse.cards}
+          pulse={pulse}
+          setPulse={setPulse}
+        />,
+      );
+    });
+
+    it("should have a Toggle that is not toggled", () => {
+      const toggle = screen.getByRole("checkbox");
+      expect(toggle).toBeInTheDocument();
+      expect(toggle.dataset.testid).toEqual("toggle");
+      expect(toggle.getAttribute("aria-checked")).toBe("false");
+    });
+
+    it("should have a clickable toggle that reveals attachment type and a checkbox per question", () => {
+      expect(screen.queryByText("File format")).toBeNull();
+      expect(screen.queryByText("Questions to attach")).toBeNull();
+      expect(screen.queryByText("card1")).toBeNull();
+      expect(screen.queryByText("card2")).toBeNull();
+
+      const toggle = screen.getByRole("checkbox");
+      fireEvent.click(toggle);
+
+      const csvFormatInput = screen.getByLabelText(".csv");
+      expect(csvFormatInput.checked).toBe(true);
+
+      const toggleAllCheckbox = screen.getByLabelText("Questions to attach");
+      expect(toggleAllCheckbox.checked).toBe(false);
+
+      const card1Checkbox = screen.getByLabelText("card1");
+      expect(card1Checkbox.checked).toBe(false);
+
+      const card2Checkbox = screen.getByLabelText("card2");
+      expect(card2Checkbox.checked).toBe(false);
+    });
+  });
+
+  describe("when instantiated with cards with attachments", () => {
+    let pulse;
+    let setPulse;
+    beforeEach(() => {
+      pulse = createPulse();
+      pulse.cards[0]["include_xls"] = true;
+      setPulse = jest.fn();
+      render(
+        <EmailAttachmentPicker
+          cards={pulse.cards}
+          pulse={pulse}
+          setPulse={setPulse}
+        />,
+      );
+    });
+
+    it("should have a toggled Toggle", () => {
+      const toggle = screen.getByTestId("toggle");
+      expect(toggle).toBeInTheDocument();
+      expect(toggle.getAttribute("aria-checked")).toBe("true");
+    });
+
+    it("should have selected the xlsv format", () => {
+      const csvFormatInput = screen.getByLabelText(".csv");
+      expect(csvFormatInput.checked).toBe(false);
+      const xlsxFormatInput = screen.getByLabelText(".xlsx");
+      expect(xlsxFormatInput.checked).toBe(true);
+    });
+
+    it("should show a checked checkbox for the card with an attachment", () => {
+      const toggleAllCheckbox = screen.getByLabelText("Questions to attach");
+      expect(toggleAllCheckbox.checked).toBe(false);
+
+      const card1Checkbox = screen.getByLabelText("card1");
+      expect(card1Checkbox.checked).toBe(true);
+
+      const card2Checkbox = screen.getByLabelText("card2");
+      expect(card2Checkbox.checked).toBe(false);
+    });
+
+    it("should let you check or uncheck card checkboxes", () => {
+      const card1Checkbox = screen.getByLabelText("card1");
+      fireEvent.click(card1Checkbox);
+      expect(card1Checkbox.checked).toBe(false);
+      fireEvent.click(card1Checkbox);
+      expect(card1Checkbox.checked).toBe(true);
+    });
+
+    it("should let you check all checkboxes", () => {
+      const card2Checkbox = screen.getByLabelText("card2");
+      fireEvent.click(card2Checkbox);
+      expect(card2Checkbox.checked).toBe(true);
+      expect(screen.getByLabelText("Questions to attach").checked).toBe(true);
+    });
+
+    it("should let you check/uncheck all boxes via the `Questions to attach` toggle", () => {
+      const toggleAllCheckbox = screen.getByLabelText("Questions to attach");
+      const card1Checkbox = screen.getByLabelText("card1");
+      const card2Checkbox = screen.getByLabelText("card2");
+
+      fireEvent.click(toggleAllCheckbox);
+
+      expect(screen.getByLabelText("Questions to attach").checked).toBe(true);
+      expect(card1Checkbox.checked).toBe(true);
+      expect(card2Checkbox.checked).toBe(true);
+
+      fireEvent.click(toggleAllCheckbox);
+
+      expect(screen.getByLabelText("Questions to attach").checked).toBe(false);
+      expect(card1Checkbox.checked).toBe(false);
+      expect(card2Checkbox.checked).toBe(false);
+    });
+
+    it("should uncheck all boxes if disabling attachments", () => {
+      const toggle = screen.getByTestId("toggle");
+      expect(screen.getByLabelText("card1").checked).toBe(true);
+
+      fireEvent.click(toggle);
+
+      expect(screen.queryByText("File format")).toBeNull();
+      expect(screen.queryByText("Questions to attach")).toBeNull();
+      expect(screen.queryByText("card1")).toBeNull();
+      expect(screen.queryByText("card2")).toBeNull();
+
+      fireEvent.click(toggle);
+      expect(screen.getByLabelText("card1").checked).toBe(false);
+    });
+  });
+});
+
+function createPulse() {
+  return {
+    name: "Parameters",
+    cards: [
+      {
+        id: 4,
+        collection_id: null,
+        description: null,
+        display: "map",
+        name: "card1",
+        include_csv: false,
+        include_xls: false,
+        dashboard_card_id: 3,
+        dashboard_id: 1,
+        parameter_mappings: [],
+      },
+      {
+        id: 6,
+        collection_id: null,
+        description: null,
+        display: "scalar",
+        name: "card2",
+        include_csv: false,
+        include_xls: false,
+        dashboard_card_id: 4,
+        dashboard_id: 1,
+        parameter_mappings: [],
+      },
+    ],
+    channels: [
+      {
+        channel_type: "email",
+        enabled: true,
+        recipients: [],
+        details: {},
+        schedule_type: "hourly",
+        schedule_day: "mon",
+        schedule_hour: 8,
+        schedule_frame: "first",
+      },
+      {
+        channel_type: "email",
+        enabled: true,
+        recipients: [],
+        details: {},
+        schedule_type: "hourly",
+        schedule_day: "mon",
+        schedule_hour: 8,
+        schedule_frame: "first",
+      },
+    ],
+    skip_if_empty: false,
+    collection_id: null,
+    parameters: [],
+    dashboard_id: 1,
+  };
+}

--- a/frontend/src/metabase/sharing/components/EmailAttachmentPicker.unit.spec.js
+++ b/frontend/src/metabase/sharing/components/EmailAttachmentPicker.unit.spec.js
@@ -20,9 +20,8 @@ describe("EmailAttachmentPicker", () => {
     });
 
     it("should have a Toggle that is not toggled", () => {
-      const toggle = screen.getByRole("checkbox");
+      const toggle = screen.getByLabelText("Attach results");
       expect(toggle).toBeInTheDocument();
-      expect(toggle.dataset.testid).toEqual("toggle");
       expect(toggle).toHaveAttribute("aria-checked", "false");
     });
 
@@ -32,7 +31,7 @@ describe("EmailAttachmentPicker", () => {
       expect(screen.queryByText("card1")).toBeNull();
       expect(screen.queryByText("card2")).toBeNull();
 
-      const toggle = screen.getByRole("checkbox");
+      const toggle = screen.getByLabelText("Attach results");
       fireEvent.click(toggle);
 
       const csvFormatInput = screen.getByLabelText(".csv");
@@ -66,7 +65,7 @@ describe("EmailAttachmentPicker", () => {
     });
 
     it("should have a toggled Toggle", () => {
-      const toggle = screen.getByTestId("toggle");
+      const toggle = screen.getByLabelText("Attach results");
       expect(toggle).toBeInTheDocument();
       expect(toggle).toHaveAttribute("aria-checked", "true");
     });
@@ -123,7 +122,7 @@ describe("EmailAttachmentPicker", () => {
     });
 
     it("should uncheck all boxes if disabling attachments", () => {
-      const toggle = screen.getByTestId("toggle");
+      const toggle = screen.getByLabelText("Attach results");
       expect(screen.getByLabelText("card1")).toBeChecked();
 
       fireEvent.click(toggle);


### PR DESCRIPTION
Fixes #17762 

There's logic to check if any cards have certain properties related to attachments set to `true` on every component update so that the toggle is never in a state of untoggled + cards with set attachments. We just need to add some additional logic to explicitly unset attachments on all cards when untoggling the toggle.

https://user-images.githubusercontent.com/13057258/132420246-e52a3652-9555-4a65-aac9-90f7fef2677d.mov

