### PR TITLE
i18n: do not remove empty plural from translation

### DIFF
--- a/bin/i18n/src/i18n/common.clj
+++ b/bin/i18n/src/i18n/common.clj
@@ -36,7 +36,7 @@
     {:id                (.getMsgid message)
      :id-plural         (.getMsgidPlural message)
      :str               (.getMsgstr message)
-     :str-plural        (seq (remove str/blank? (.getMsgstrPlural message)))
+     :str-plural        (seq (.getMsgstrPlural message))
      :fuzzy?            (.isFuzzy message)
      :plural?           (.isPlural message)
      :source-references (seq (remove str/blank? (.getSourceReferences message)))

--- a/bin/i18n/test/i18n/create_artifacts/frontend_test.clj
+++ b/bin/i18n/test/i18n/create_artifacts/frontend_test.clj
@@ -25,5 +25,9 @@
 
                           "${ 0 } Queryable Table"
                           {:msgid_plural "{0} Queryable Tables"
-                           :msgstr       ["${ 0 } Tabla Consultable" "${ 0 } Tablas consultables"]}}}}
+                           :msgstr       ["${ 0 } Tabla Consultable" "${ 0 } Tablas consultables"]}
+
+                          "${ 0 } metric"
+                          {:msgid_plural "{0} metrics"
+                           :msgstr       ["${ 0 } metrik" ""]}}}}
          (#'frontend/->i18n-map test-common/po-contents))))

--- a/bin/i18n/test/i18n/create_artifacts/test_common.clj
+++ b/bin/i18n/test/i18n/create_artifacts/test_common.clj
@@ -50,12 +50,23 @@
    :source-references ["frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:77"]
    :comment           nil})
 
+(def plural-message-frontend-with-empty
+  {:id                "{0} metric"
+   :id-plural         "{0} metrics"
+   :str               nil
+   :str-plural        ["{0} metrik" ""]
+   :fuzzy?            false
+   :plural?           true
+   :source-references ["frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:20"]
+   :comment           nil})
+
 (def messages
   [singular-message-frontend
    singular-message-backend
    singular-template-message-frontend
    singular-template-message-backend
-   plural-message-frontend])
+   plural-message-frontend
+   plural-message-frontend-with-empty])
 
 (def po-contents
   {:headers  {"MIME-Version"              "1.0",


### PR DESCRIPTION
The ttag library expect the plural array to be exactly the size as the number of plural forms defined in the header.

If we remove empty plural, the array will have the wrong size and the library will crash when the trying to use the non-existent plural.

By leaving the empty string there, the ttag library will correctly detect it and use the English version for the missing variant.

This does not affect the backend because the backend does not support plurals.

Fixes #16323
