### PR TITLE
Fix settings saving behavior

### DIFF
--- a/frontend/src/metabase/admin/settings/settings.js
+++ b/frontend/src/metabase/admin/settings/settings.js
@@ -83,7 +83,8 @@ export const updateEmailSettings = createThunkAction(
   function(settings) {
     return async function(dispatch, getState) {
       try {
-        return await EmailApi.updateSettings(settings);
+        await EmailApi.updateSettings(settings);
+        await dispatch(reloadSettings());
       } catch (error) {
         console.log("error updating email settings", settings, error);
         throw error;
@@ -119,6 +120,7 @@ export const updateSlackSettings = createThunkAction(
     return async function(dispatch, getState) {
       try {
         await SlackApi.updateSettings(settings);
+        await dispatch(reloadSettings());
       } catch (error) {
         console.log("error updating slack settings", settings, error);
         throw error;
@@ -136,6 +138,7 @@ export const updateLdapSettings = createThunkAction(
     return async function(dispatch, getState) {
       try {
         await LdapApi.updateSettings(settings);
+        await dispatch(reloadSettings());
       } catch (error) {
         console.log("error updating LDAP settings", settings, error);
         throw error;

--- a/frontend/src/metabase/admin/settings/settings.js
+++ b/frontend/src/metabase/admin/settings/settings.js
@@ -83,8 +83,9 @@ export const updateEmailSettings = createThunkAction(
   function(settings) {
     return async function(dispatch, getState) {
       try {
-        await EmailApi.updateSettings(settings);
+        const result = await EmailApi.updateSettings(settings);
         await dispatch(reloadSettings());
+        return result;
       } catch (error) {
         console.log("error updating email settings", settings, error);
         throw error;
@@ -119,8 +120,9 @@ export const updateSlackSettings = createThunkAction(
   function(settings) {
     return async function(dispatch, getState) {
       try {
-        await SlackApi.updateSettings(settings);
+        const result = await SlackApi.updateSettings(settings);
         await dispatch(reloadSettings());
+        return result;
       } catch (error) {
         console.log("error updating slack settings", settings, error);
         throw error;
@@ -137,8 +139,9 @@ export const updateLdapSettings = createThunkAction(
   function(settings) {
     return async function(dispatch, getState) {
       try {
-        await LdapApi.updateSettings(settings);
+        const result = await LdapApi.updateSettings(settings);
         await dispatch(reloadSettings());
+        return result;
       } catch (error) {
         console.log("error updating LDAP settings", settings, error);
         throw error;

--- a/frontend/test/metabase/scenarios/admin/settings/email.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/email.cy.spec.js
@@ -28,11 +28,12 @@ describe("scenarios > admin > settings > email settings", () => {
     cy.findByText("Changes saved!");
 
     // This part was added as a repro for metabase#17615
-    cy.findByDisplayValue("localhost");
-    cy.findByDisplayValue("25");
-    cy.findAllByDisplayValue("admin");
-    cy.findByDisplayValue("mailer@metabase.test");
+    cy.findByDisplayValue("smtp.mailtrap.io");
+    cy.findByDisplayValue("2525");
+    cy.findAllByDisplayValue("6100f28480a34f");
+    cy.findByDisplayValue("from@example.com");
   });
+
   it("should show an error if test email fails", () => {
     // Reuse Email setup without relying on the previous test
     cy.request("PUT", "/api/setting", {

--- a/frontend/test/metabase/scenarios/admin/settings/email.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/email.cy.spec.js
@@ -25,13 +25,13 @@ describe("scenarios > admin > settings > email settings", () => {
       .blur();
     cy.findByText("Save changes").click();
 
-    cy.findByText("Changes saved!");
+    cy.findByText("Changes saved!", { timeout: 10000 });
 
     // This part was added as a repro for metabase#17615
-    cy.findByDisplayValue("smtp.mailtrap.io");
-    cy.findByDisplayValue("2525");
-    cy.findAllByDisplayValue("6100f28480a34f");
-    cy.findByDisplayValue("from@example.com");
+    cy.findByDisplayValue("localhost");
+    cy.findByDisplayValue("25");
+    cy.findAllByDisplayValue("admin");
+    cy.findByDisplayValue("mailer@metabase.test");
   });
 
   it("should show an error if test email fails", () => {

--- a/frontend/test/metabase/scenarios/admin/settings/email.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/email.cy.spec.js
@@ -6,7 +6,7 @@ describe("scenarios > admin > settings > email settings", () => {
     cy.signInAsAdmin();
   });
 
-  it.skip("should be able to save email settings (metabase#17615)", () => {
+  it.only("should be able to save email settings (metabase#17615)", () => {
     cy.visit("/admin/settings/email");
     cy.findByPlaceholderText("smtp.yourservice.com")
       .type("localhost")

--- a/frontend/test/metabase/scenarios/admin/settings/email.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/email.cy.spec.js
@@ -6,7 +6,7 @@ describe("scenarios > admin > settings > email settings", () => {
     cy.signInAsAdmin();
   });
 
-  it.only("should be able to save email settings (metabase#17615)", () => {
+  it("should be able to save email settings (metabase#17615)", () => {
     cy.visit("/admin/settings/email");
     cy.findByPlaceholderText("smtp.yourservice.com")
       .type("localhost")


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/17615 
Initially broken by https://github.com/metabase/metabase/pull/17123

We need to reload settings when they are successfully saved to populate internal caches with saved data.

How to test with cypress:
- run `docker run -p 80:80 -p 25:25 --name maildev maildev/maildev`
- run `yarn dev`
- run `yarn test-cypress-open`
- execute `emails.cy.spec.js`

How to test manually:
- follow the steps from changed cypress test