### PR TITLE
Refactor audit queries to use defmethod instead of ^:internal-query-fn metadata

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/audit/interface.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit/interface.clj
@@ -25,7 +25,7 @@
   (throw (ex-info (str (tru "Unable to run internal query function: cannot resolve {0}" query-type))
                   {:status-code 400})))
 
-(defn invoke-internal-query
+(defn resolve-internal-query
   "Invoke the internal query with `query-type` (invokes the corresponding implementation of [[internal-query]])."
   [query-type & args]
   (let [query-type (keyword query-type)

--- a/enterprise/backend/src/metabase_enterprise/audit/interface.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit/interface.clj
@@ -1,0 +1,35 @@
+(ns metabase-enterprise.audit.interface
+  (:require [metabase.plugins.classloader :as classloader]
+            [metabase.util.i18n :refer [tru]]
+            [metabase.util.schema :as su]
+            [schema.core :as s]))
+
+(def ResultsMetadata
+  "Schema for the expected format for `:metadata` returned by an internal query function."
+  (su/non-empty
+   [[(s/one su/KeywordOrString "field name")
+     (s/one {:base_type su/FieldType, :display_name su/NonBlankString, s/Keyword s/Any}
+            "field metadata")]]))
+
+(defmulti internal-query
+  "Define a new internal query type. Conventionally `query-type` should be a namespaced keyword with the namespace in
+  which the method is defined. See docstring
+  for [[metabase-enterprise.audit.query-processor.middleware.handle-audit-queries]] for a description of what this
+  method should return."
+  {:arglists '([query-type & args])}
+  (fn [query-type & _]
+    (keyword query-type)))
+
+(defmethod internal-query :default
+  [query-type & _]
+  (throw (ex-info (str (tru "Unable to run internal query function: cannot resolve {0}" query-type))
+                  {:status-code 400})))
+
+(defn invoke-internal-query
+  "Invoke the internal query with `query-type` (invokes the corresponding implementation of [[internal-query]])."
+  [query-type & args]
+  (let [query-type (keyword query-type)
+        ns-str     (namespace query-type)]
+    (when ns-str
+      (classloader/require (symbol ns-str)))
+    (apply internal-query query-type args)))

--- a/enterprise/backend/src/metabase_enterprise/audit/pages/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit/pages/common.clj
@@ -109,7 +109,6 @@
                 cols     (sql-jdbc.execute/column-metadata driver rsmeta)
                 metadata {:cols cols}
                 rf       (rff metadata)]
-
             (reduce rf init (sql-jdbc.execute/reducible-rows driver rs rsmeta canceled-chan))))
         (catch InterruptedException e
           (a/>!! canceled-chan :cancel)

--- a/enterprise/backend/src/metabase_enterprise/audit/pages/dashboard_detail.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit/pages/dashboard_detail.clj
@@ -1,30 +1,31 @@
 (ns metabase-enterprise.audit.pages.dashboard-detail
   "Detail page for a single dashboard."
-  (:require [metabase-enterprise.audit.pages.common :as common]
+  (:require [metabase-enterprise.audit.interface :as audit.i]
+            [metabase-enterprise.audit.pages.common :as common]
             [metabase-enterprise.audit.pages.common.card-and-dashboard-detail :as card-and-dash-detail]
             [metabase-enterprise.audit.pages.common.cards :as cards]
             [metabase.models.dashboard :refer [Dashboard]]
             [metabase.util.schema :as su]
             [schema.core :as s]))
 
-(s/defn ^:internal-query-fn views-by-time
-  "Get views of a Dashboard broken out by a time `unit`, e.g. `day` or `day-of-week`."
-  [dashboard-id :- su/IntGreaterThanZero, datetime-unit :- common/DateTimeUnitStr]
+;; Get views of a Dashboard broken out by a time `unit`, e.g. `day` or `day-of-week`.
+(s/defmethod audit.i/internal-query ::views-by-time
+  [_ dashboard-id  :- su/IntGreaterThanZero datetime-unit :- common/DateTimeUnitStr]
   (card-and-dash-detail/views-by-time "dashboard" dashboard-id datetime-unit))
 
-(s/defn ^:internal-query-fn revision-history
-  "Revision history for a specific Dashboard."
-  [dashboard-id :- su/IntGreaterThanZero]
+;; Revision history for a specific Dashboard.
+(s/defmethod audit.i/internal-query ::revision-history
+  [_ dashboard-id :- su/IntGreaterThanZero]
   (card-and-dash-detail/revision-history Dashboard dashboard-id))
 
-(s/defn ^:internal-query-fn audit-log
-  "View log for a specific Dashboard."
-  [dashboard-id :- su/IntGreaterThanZero]
+;; View log for a specific Dashboard.
+(s/defmethod audit.i/internal-query ::audit-log
+  [_ dashboard-id :- su/IntGreaterThanZero]
   (card-and-dash-detail/audit-log "dashboard" dashboard-id))
 
-(s/defn ^:internal-query-fn cards
-  "Information about the Saved Questions (Cards) in this instance."
-  [dashboard-id :- su/IntGreaterThanZero]
+;; Information about the Saved Questions (Cards) in this instance.
+(s/defmethod audit.i/internal-query ::cards
+  [_ dashboard-id :- su/IntGreaterThanZero]
   {:metadata [[:card_id             {:display_name "Card ID",              :base_type :type/Integer, :remapped_to   :card_name}]
               [:card_name           {:display_name "Title",                :base_type :type/Name,    :remapped_from :card_id}]
               [:collection_id       {:display_name "Collection ID",        :base_type :type/Integer, :remapped_to   :collection_name}]

--- a/enterprise/backend/src/metabase_enterprise/audit/pages/dashboards.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit/pages/dashboards.clj
@@ -1,44 +1,31 @@
 (ns metabase-enterprise.audit.pages.dashboards
   "Dashboards overview page."
-  (:require [metabase-enterprise.audit.pages.common :as common]
+  (:require [metabase-enterprise.audit.interface :as audit.i]
+            [metabase-enterprise.audit.pages.common :as common]
             [metabase-enterprise.audit.pages.common.dashboards :as dashboards]
             [metabase.util.honeysql-extensions :as hx]
             [schema.core :as s]))
 
-(defn ^:deprecated ^:internal-query-fn views-per-day
-  "DEPRECATED: use `views-and-saves-by-time ` instead."
-  []
-  {:metadata [[:day   {:display_name "Date",  :base_type :type/Date}]
-              [:views {:display_name "Views", :base_type :type/Integer}]]
-   :results  (common/reducible-query
-              {:select   [[(hx/cast :date :timestamp) :day]
-                          [:%count.* :views]]
-               :from     [:view_log]
-               :where    [:= :model (hx/literal "dashboard")]
-               :group-by [(hx/cast :date :timestamp)]
-               :order-by [(hx/cast :date :timestamp)]})})
-
-
-(s/defn ^:internal-query-fn views-and-saves-by-time
-  "Two-series timeseries that includes total number of Dashboard views and saves broken out by a `datetime-unit`."
-  [datetime-unit :- common/DateTimeUnitStr]
+;; Two-series timeseries that includes total number of Dashboard views and saves broken out by a `datetime-unit`.
+(s/defmethod audit.i/internal-query ::views-and-saves-by-time
+  [_ datetime-unit :- common/DateTimeUnitStr]
   {:metadata [[:date  {:display_name "Date",  :base_type (common/datetime-unit-str->base-type datetime-unit)}]
               [:views {:display_name "Views", :base_type :type/Integer}]
               [:saves {:display_name "Saves", :base_type :type/Integer}]]
    ;; this is so nice and easy to implement in a single query with FULL OUTER JOINS but unfortunately only pg supports
    ;; them(!)
    :results (let [views        (common/query
-                                 {:select   [[(common/grouped-datetime datetime-unit :timestamp) :date]
-                                             [:%count.* :views]]
-                                  :from     [:view_log]
-                                  :where    [:= :model (hx/literal "dashboard")]
-                                  :group-by [(common/grouped-datetime datetime-unit :timestamp)]})
+                                {:select   [[(common/grouped-datetime datetime-unit :timestamp) :date]
+                                            [:%count.* :views]]
+                                 :from     [:view_log]
+                                 :where    [:= :model (hx/literal "dashboard")]
+                                 :group-by [(common/grouped-datetime datetime-unit :timestamp)]})
                   date->views  (zipmap (map :date views) (map :views views))
                   saves        (common/query
-                                 {:select   [[(common/grouped-datetime datetime-unit :created_at) :date]
-                                             [:%count.* :saves]]
-                                  :from     [:report_dashboard]
-                                  :group-by [(common/grouped-datetime datetime-unit :created_at)]})
+                                {:select   [[(common/grouped-datetime datetime-unit :created_at) :date]
+                                            [:%count.* :saves]]
+                                 :from     [:report_dashboard]
+                                 :group-by [(common/grouped-datetime datetime-unit :created_at)]})
                   date->saves  (zipmap (map :date saves) (map :saves saves))
                   all-dates    (sort (keep identity (distinct (concat (keys date->views)
                                                                       (keys date->saves)))))]
@@ -47,10 +34,9 @@
                  :views (date->views date 0)
                  :saves (date->saves date 0)}))})
 
-
-(defn ^:internal-query-fn ^:deprecated most-popular
-  "Deprecated: use `most-popular-with-avg-speed` instead."
-  []
+;; DEPRECATED Use `most-popular-with-avg-speed` instead.
+(defmethod audit.i/internal-query ::most-popular
+  [_]
   {:metadata [[:dashboard_id   {:display_name "Dashboard ID", :base_type :type/Integer, :remapped_to   :dashboard_name}]
               [:dashboard_name {:display_name "Dashboard",    :base_type :type/Title,   :remapped_from :dashboard_id}]
               [:views          {:display_name "Views",        :base_type :type/Integer}]]
@@ -65,49 +51,48 @@
                :order-by  [[:%count.* :desc]]
                :limit     10})})
 
-(defn ^:internal-query-fn most-popular-with-avg-speed
-  "10 most popular dashboards with their average speed."
-  []
+;; Ten most popular dashboards with their average speed.
+(defmethod audit.i/internal-query ::most-popular-with-avg-speed
+  [_]
   {:metadata [[:dashboard_id     {:display_name "Dashboard ID",                 :base_type :type/Integer, :remapped_to   :dashboard_name}]
               [:dashboard_name   {:display_name "Dashboard",                    :base_type :type/Title,   :remapped_from :dashboard_id}]
               [:views            {:display_name "Views",                        :base_type :type/Integer}]
               [:avg_running_time {:display_name "Avg. Question Load Time (ms)", :base_type :type/Decimal}]]
    :results  (common/reducible-query
-               {:with      [[:most_popular {:select    [[:d.id :dashboard_id]
-                                                        [:d.name :dashboard_name]
-                                                        [:%count.* :views]]
-                                            :from      [[:view_log :vl]]
-                                            :left-join [[:report_dashboard :d] [:= :vl.model_id :d.id]]
-                                            :where     [:= :vl.model (hx/literal "dashboard")]
-                                            :group-by  [:d.id]
-                                            :order-by  [[:%count.* :desc]]
-                                            :limit     10}]
-                            [:card_running_time {:select   [:qe.card_id
-                                                            [:%avg.qe.running_time :avg_running_time]]
-                                                 :from     [[:query_execution :qe]]
-                                                 :where    [:not= :qe.card_id nil]
-                                                 :group-by [:qe.card_id]}]
-                            [:dash_avg_running_time {:select    [[:d.id :dashboard_id]
-                                                                 [:%avg.rt.avg_running_time :avg_running_time]]
-                                                     :from      [[:report_dashboardcard :dc]]
-                                                     :left-join [[:card_running_time :rt] [:= :dc.card_id :rt.card_id]
-                                                                 [:report_dashboard :d]   [:= :dc.dashboard_id :d.id]]
-                                                     :group-by  [:d.id]
-                                                     :where     [:in :d.id {:select [:dashboard_id]
-                                                                            :from   [:most_popular]}]}]]
-                :select    [:mp.dashboard_id
-                            :mp.dashboard_name
-                            :mp.views
-                            :rt.avg_running_time]
-                :from      [[:most_popular :mp]]
-                :left-join [[:dash_avg_running_time :rt] [:= :mp.dashboard_id :rt.dashboard_id]]
-                :order-by  [[:mp.views :desc]]
-                :limit     10})})
+              {:with      [[:most_popular {:select    [[:d.id :dashboard_id]
+                                                       [:d.name :dashboard_name]
+                                                       [:%count.* :views]]
+                                           :from      [[:view_log :vl]]
+                                           :left-join [[:report_dashboard :d] [:= :vl.model_id :d.id]]
+                                           :where     [:= :vl.model (hx/literal "dashboard")]
+                                           :group-by  [:d.id]
+                                           :order-by  [[:%count.* :desc]]
+                                           :limit     10}]
+                           [:card_running_time {:select   [:qe.card_id
+                                                           [:%avg.qe.running_time :avg_running_time]]
+                                                :from     [[:query_execution :qe]]
+                                                :where    [:not= :qe.card_id nil]
+                                                :group-by [:qe.card_id]}]
+                           [:dash_avg_running_time {:select    [[:d.id :dashboard_id]
+                                                                [:%avg.rt.avg_running_time :avg_running_time]]
+                                                    :from      [[:report_dashboardcard :dc]]
+                                                    :left-join [[:card_running_time :rt] [:= :dc.card_id :rt.card_id]
+                                                                [:report_dashboard :d]   [:= :dc.dashboard_id :d.id]]
+                                                    :group-by  [:d.id]
+                                                    :where     [:in :d.id {:select [:dashboard_id]
+                                                                           :from   [:most_popular]}]}]]
+               :select    [:mp.dashboard_id
+                           :mp.dashboard_name
+                           :mp.views
+                           :rt.avg_running_time]
+               :from      [[:most_popular :mp]]
+               :left-join [[:dash_avg_running_time :rt] [:= :mp.dashboard_id :rt.dashboard_id]]
+               :order-by  [[:mp.views :desc]]
+               :limit     10})})
 
-
-(defn ^:internal-query-fn ^:deprecated slowest
-  "Query that returns the 10 Dashboards that have the slowest average execution times, in descending order."
-  []
+;; DEPRECATED Query that returns the 10 Dashboards that have the slowest average execution times, in descending order.
+(defmethod audit.i/internal-query ::slowest
+  [_]
   {:metadata [[:dashboard_id     {:display_name "Dashboard ID",                 :base_type :type/Integer, :remapped_to   :dashboard_name}]
               [:dashboard_name   {:display_name "Dashboard",                    :base_type :type/Title,   :remapped_from :dashboard_id}]
               [:avg_running_time {:display_name "Avg. Question Load Time (ms)", :base_type :type/Decimal}]]
@@ -127,10 +112,9 @@
                :order-by  [[:avg_running_time :desc]]
                :limit     10})})
 
-
-(defn ^:internal-query-fn ^:deprecated most-common-questions
-  "Query that returns the 10 Cards that appear most often in Dashboards, in descending order."
-  []
+;; DEPRECATED Query that returns the 10 Cards that appear most often in Dashboards, in descending order.
+(defmethod audit.i/internal-query ::most-common-questions
+  [_]
   {:metadata [[:card_id   {:display_name "Card ID", :base_type :type/Integer, :remapped_to   :card_name}]
               [:card_name {:display_name "Card",    :base_type :type/Title,   :remapped_from :card_id}]
               [:count     {:display_name "Count",   :base_type :type/Integer}]]
@@ -144,10 +128,9 @@
                :order-by [[:%count.* :desc]]
                :limit    10})})
 
-
-(s/defn ^:internal-query-fn table
-  "Internal audit app query powering a table of different Dashboards with lots of extra info about them."
-  ([]
-   (table nil))
-  ([query-string :- (s/maybe s/Str)]
+;; Internal audit app query powering a table of different Dashboards with lots of extra info about them.
+(s/defmethod audit.i/internal-query ::table
+  ([query-type]
+   (audit.i/internal-query query-type nil))
+  ([_ query-string :- (s/maybe s/Str)]
    (dashboards/table query-string)))

--- a/enterprise/backend/src/metabase_enterprise/audit/pages/queries.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit/pages/queries.clj
@@ -1,134 +1,139 @@
 (ns metabase-enterprise.audit.pages.queries
-  (:require [metabase-enterprise.audit.pages.common :as common]
+  (:require [metabase-enterprise.audit.interface :as audit.i]
+            [metabase-enterprise.audit.pages.common :as common]
             [metabase-enterprise.audit.pages.common.cards :as cards]
             [metabase.util.honeysql-extensions :as hx]
             [schema.core :as s]))
 
-(defn ^:internal-query-fn ^:deprecated  views-and-avg-execution-time-by-day
-  "Query that returns data for a two-series timeseries chart with number of queries ran and average query running time
-  broken out by day."
-  []
+;; DEPRECATED Query that returns data for a two-series timeseries chart with number of queries ran and average query
+;; running time broken out by day.
+(defmethod audit.i/internal-query ::views-and-avg-execution-time-by-day
+  [_]
   {:metadata [[:day              {:display_name "Date",                   :base_type :type/Date}]
               [:views            {:display_name "Views",                  :base_type :type/Integer}]
               [:avg_running_time {:display_name "Avg. Running Time (ms)", :base_type :type/Decimal}]]
    :results  (common/reducible-query
-               {:select   [[(hx/cast :date :started_at) :day]
-                           [:%count.* :views]
-                           [:%avg.running_time :avg_running_time]]
-                :from     [:query_execution]
-                :group-by [(hx/cast :date :started_at)]
-                :order-by [[(hx/cast :date :started_at) :asc]]})})
+              {:select   [[(hx/cast :date :started_at) :day]
+                          [:%count.* :views]
+                          [:%avg.running_time :avg_running_time]]
+               :from     [:query_execution]
+               :group-by [(hx/cast :date :started_at)]
+               :order-by [[(hx/cast :date :started_at) :asc]]})})
 
-(defn ^:internal-query-fn most-popular
-  "Query that returns the 10 most-popular Cards based on number of query executions, in descending order."
-  []
+;; Query that returns the 10 most-popular Cards based on number of query executions, in descending order.
+(defmethod audit.i/internal-query ::most-popular
+  [_]
   {:metadata [[:card_id    {:display_name "Card ID",    :base_type :type/Integer, :remapped_to   :card_name}]
               [:card_name  {:display_name "Card",       :base_type :type/Title,   :remapped_from :card_id}]
               [:executions {:display_name "Executions", :base_type :type/Integer}]]
    :results  (common/reducible-query
-               {:select   [[:c.id :card_id]
-                           [:c.name :card_name]
-                           [:%count.* :executions]]
-                :from     [[:query_execution :qe]]
-                :join     [[:report_card :c] [:= :qe.card_id :c.id]]
-                :group-by [:c.id]
-                :order-by [[:executions :desc]]
-                :limit    10})})
+              {:select   [[:c.id :card_id]
+                          [:c.name :card_name]
+                          [:%count.* :executions]]
+               :from     [[:query_execution :qe]]
+               :join     [[:report_card :c] [:= :qe.card_id :c.id]]
+               :group-by [:c.id]
+               :order-by [[:executions :desc]]
+               :limit    10})})
 
-(defn ^:internal-query-fn ^:deprecated slowest
-  "Query that returns the 10 slowest-running Cards based on average query execution time, in descending order."
-  []
+;; DEPRECATED Query that returns the 10 slowest-running Cards based on average query execution time, in descending
+;; order.
+(defmethod audit.i/internal-query ::slowest
+  [_]
   {:metadata [[:card_id          {:display_name "Card ID",                :base_type :type/Integer, :remapped_to   :card_name}]
               [:card_name        {:display_name "Card",                   :base_type :type/Title,   :remapped_from :card_id}]
               [:avg_running_time {:display_name "Avg. Running Time (ms)", :base_type :type/Decimal}]]
    :results  (common/reducible-query
-               {:select   [[:c.id :card_id]
-                           [:c.name :card_name]
-                           [:%avg.running_time :avg_running_time]]
-                :from     [[:query_execution :qe]]
-                :join     [[:report_card :c] [:= :qe.card_id :c.id]]
-                :group-by [:c.id]
-                :order-by [[:avg_running_time :desc]]
-                :limit    10})})
+              {:select   [[:c.id :card_id]
+                          [:c.name :card_name]
+                          [:%avg.running_time :avg_running_time]]
+               :from     [[:query_execution :qe]]
+               :join     [[:report_card :c] [:= :qe.card_id :c.id]]
+               :group-by [:c.id]
+               :order-by [[:avg_running_time :desc]]
+               :limit    10})})
 
-(s/defn ^:internal-query-fn table
-  "A list of all questions.
+;; A list of all questions.
+;;
+;; Three possible argument lists. All arguments are always nullable.
+;;
+;; - [] :
+;; Dump them all, sort by name ascending
+;;
+;; - [question-filter] :
+;; Dump all filtered by the question-filter string, sort by name ascending.
+;; question-filter filters on the `name` column in `cards` table.
+;;
+;; - [question-filter, collection-filter, sort-column, sort-direction] :
+;; Dump all filtered by both question-filter and collection-filter,
+;; sort by the given column and sort direction.
+;; question-filter filters on the `name` column in `cards` table.
+;; collection-filter filters on the `name` column in `collections` table.
+;;
+;; Sort column is given over in keyword form to honeysql. Default `card.name`
+;;
+;; Sort direction can be `asc` or `desc`, ascending and descending respectively. Default `asc`.
+;;
+;; All inputs have to be strings because that's how the magic middleware
+;; that turns these functions into clojure-backed 'datasets' works.
+(s/defmethod audit.i/internal-query ::table
+  ([query-type]
+   (audit.i/internal-query query-type nil nil nil nil))
 
-  Three possible argument lists. All arguments are always nullable.
-  - [] :
-  Dump them all, sort by name ascending
+  ([query-type question-filter :- (s/maybe s/Str)]
+   (audit.i/internal-query query-type question-filter nil nil nil))
 
-  - [questionFilter] :
-  Dump all filtered by the questionFilter string, sort by name ascending.
-  questionFilter filters on the `name` column in `cards` table.
-
-  - [questionFilter, collectionFilter, sortColumn, sortDirection] :
-  Dump all filtered by both questionFilter and collectionFilter,
-  sort by the given column and sort direction.
-  questionFilter filters on the `name` column in `cards` table.
-  collectionFilter filters on the `name` column in `collections` table.
-
-  Sort column is given over in keyword form to honeysql. Default `card.name`
-
-  Sort direction can be `asc` or `desc`, ascending and descending respectively. Default `asc`.
-
-  All inputs have to be strings because that's how the magic middleware
-  that turns these functions into clojure-backed 'datasets' works."
-  ([]
-   (table nil nil nil nil))
-  ([questionFilter :- (s/maybe s/Str)]
-   (table questionFilter nil nil nil))
-  ([questionFilter   :- (s/maybe s/Str)
-    collectionFilter :- (s/maybe s/Str)
-    sortColumn       :- (s/maybe s/Str)
-    sortDirection    :- (s/maybe (s/enum "asc" "desc"))]
-   {:metadata [[:card_id         {:display_name "Card ID",         :base_type :type/Integer, :remapped_to   :card_name}]
-               [:card_name       {:display_name "Name",            :base_type :type/Name,    :remapped_from :card_id}]
-               [:collection_id   {:display_name "Collection ID",   :base_type :type/Integer, :remapped_to   :collection_name}]
-               [:collection_name {:display_name "Collection",      :base_type :type/Text,    :remapped_from :collection_id}]
-               [:database_id     {:display_name "Database ID",     :base_type :type/Integer, :remapped_to   :database_name}]
-               [:database_name   {:display_name "Database",        :base_type :type/Text,    :remapped_from :database_id}]
-               [:table_id        {:display_name "Table ID",        :base_type :type/Integer, :remapped_to   :table_name}]
-               [:table_name      {:display_name "Table",           :base_type :type/Text,    :remapped_from :table_id}]
-               [:user_id         {:display_name "Created By ID",   :base_type :type/Integer, :remapped_to   :user_name}]
-               [:user_name       {:display_name "Created By",      :base_type :type/Text,    :remapped_from :user_id}]
-               [:public_link     {:display_name "Public Link",     :base_type :type/URL}]
-               [:cache_ttl       {:display_name "Cache Duration",  :base_type :type/Number}]
+  ([_
+    question-filter   :- (s/maybe s/Str)
+    collection-filter :- (s/maybe s/Str)
+    sort-column       :- (s/maybe s/Str)
+    sort-direction    :- (s/maybe (s/enum "asc" "desc"))]
+   {:metadata [[:card_id         {:display_name "Card ID",              :base_type :type/Integer, :remapped_to   :card_name}]
+               [:card_name       {:display_name "Name",                 :base_type :type/Name,    :remapped_from :card_id}]
+               [:collection_id   {:display_name "Collection ID",        :base_type :type/Integer, :remapped_to   :collection_name}]
+               [:collection_name {:display_name "Collection",           :base_type :type/Text,    :remapped_from :collection_id}]
+               [:database_id     {:display_name "Database ID",          :base_type :type/Integer, :remapped_to   :database_name}]
+               [:database_name   {:display_name "Database",             :base_type :type/Text,    :remapped_from :database_id}]
+               [:table_id        {:display_name "Table ID",             :base_type :type/Integer, :remapped_to   :table_name}]
+               [:table_name      {:display_name "Table",                :base_type :type/Text,    :remapped_from :table_id}]
+               [:user_id         {:display_name "Created By ID",        :base_type :type/Integer, :remapped_to   :user_name}]
+               [:user_name       {:display_name "Created By",           :base_type :type/Text,    :remapped_from :user_id}]
+               [:public_link     {:display_name "Public Link",          :base_type :type/URL}]
+               [:cache_ttl       {:display_name "Cache Duration",       :base_type :type/Number}]
                [:avg_exec_time   {:display_name "Average Runtime (ms)", :base_type :type/Integer}]
                [:total_runtime   {:display_name "Total Runtime (ms)",   :base_type :type/Number}]
-               [:query_runs      {:display_name "Query Runs",      :base_type :type/Integer}]
-               ]
+               [:query_runs      {:display_name "Query Runs",           :base_type :type/Integer}]]
     :results  (common/reducible-query
-                (->
-                 {:with      [cards/avg-exec-time-45
-                              cards/total-exec-time-45
-                              cards/query-runs-45]
-                  :select    [[:card.id :card_id]
-                              [:card.name :card_name]
-                              :collection_id
-                              [:coll.name :collection_name]
-                              :card.database_id
-                              [:db.name :database_name]
-                              :card.table_id
-                              [:t.name :table_name]
-                              [:card.creator_id :user_id]
-                              [(common/user-full-name :u) :user_name]
-                              [(common/card-public-url :card.public_uuid) :public_link]
-                              :card.cache_ttl
-                              [:avg_exec_time.avg_running_time_ms :avg_exec_time]
-                              [:total_runtime.total_running_time_ms :total_runtime]
-                              [:query_runs.count :query_runs]]
-                  :from      [[:report_card :card]]
-                  :left-join [[:collection :coll]      [:= :card.collection_id :coll.id]
-                              [:metabase_database :db] [:= :card.database_id :db.id]
-                              [:metabase_table :t]     [:= :card.table_id :t.id]
-                              [:core_user :u]          [:= :card.creator_id :u.id]
-                              :avg_exec_time           [:= :card.id :avg_exec_time.card_id]
-                              :total_runtime           [:= :card.id :total_runtime.card_id]
-                              :query_runs              [:= :card.id :query_runs.card_id]]
-                  :where     [:= :card.archived false]}
-                 (common/add-search-clause questionFilter :card.name)
-                 (common/add-search-clause collectionFilter :coll.name)
-                 (common/add-sort-clause
-                   (or sortColumn "card.name")
-                   (or sortDirection "asc"))))}))
+               (->
+                {:with      [cards/avg-exec-time-45
+                             cards/total-exec-time-45
+                             cards/query-runs-45]
+                 :select    [[:card.id :card_id]
+                             [:card.name :card_name]
+                             :collection_id
+                             [:coll.name :collection_name]
+                             :card.database_id
+                             [:db.name :database_name]
+                             :card.table_id
+                             [:t.name :table_name]
+                             [:card.creator_id :user_id]
+                             [(common/user-full-name :u) :user_name]
+                             [(common/card-public-url :card.public_uuid) :public_link]
+                             :card.cache_ttl
+                             [:avg_exec_time.avg_running_time_ms :avg_exec_time]
+                             [:total_runtime.total_running_time_ms :total_runtime]
+                             [:query_runs.count :query_runs]]
+                 :from      [[:report_card :card]]
+                 :left-join [[:collection :coll]      [:= :card.collection_id :coll.id]
+                             [:metabase_database :db] [:= :card.database_id :db.id]
+                             [:metabase_table :t]     [:= :card.table_id :t.id]
+                             [:core_user :u]          [:= :card.creator_id :u.id]
+                             :avg_exec_time           [:= :card.id :avg_exec_time.card_id]
+                             :total_runtime           [:= :card.id :total_runtime.card_id]
+                             :query_runs              [:= :card.id :query_runs.card_id]]
+                 :where     [:= :card.archived false]}
+                (common/add-search-clause question-filter :card.name)
+                (common/add-search-clause collection-filter :coll.name)
+                (common/add-sort-clause
+                 (or sort-column "card.name")
+                 (or sort-direction "asc"))))}))

--- a/enterprise/backend/src/metabase_enterprise/audit/pages/query_detail.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit/pages/query_detail.clj
@@ -4,11 +4,12 @@
             [metabase-enterprise.audit.pages.common :as common]
             [metabase.util.schema :as su]
             [ring.util.codec :as codec]
-            [schema.core :as s]))
+            [schema.core :as s]
+            [metabase-enterprise.audit.interface :as audit.i]))
 
-(s/defn ^:internal-query-fn details
-  "Details about a specific query (currently just average execution time)."
-  [query-hash :- su/NonBlankString]
+;; Details about a specific query (currently just average execution time).
+(s/defmethod audit.i/internal-query ::details
+  [_ query-hash :- su/NonBlankString]
   {:metadata [[:query                  {:display_name "Query",                :base_type :type/Dictionary}]
               [:average_execution_time {:display_name "Avg. Exec. Time (ms)", :base_type :type/Number}]]
    :results  (common/reducible-query

--- a/enterprise/backend/src/metabase_enterprise/audit/pages/query_detail.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit/pages/query_detail.clj
@@ -1,11 +1,11 @@
 (ns metabase-enterprise.audit.pages.query-detail
   "Queries to show details about a (presumably ad-hoc) query."
   (:require [cheshire.core :as json]
+            [metabase-enterprise.audit.interface :as audit.i]
             [metabase-enterprise.audit.pages.common :as common]
             [metabase.util.schema :as su]
             [ring.util.codec :as codec]
-            [schema.core :as s]
-            [metabase-enterprise.audit.interface :as audit.i]))
+            [schema.core :as s]))
 
 ;; Details about a specific query (currently just average execution time).
 (s/defmethod audit.i/internal-query ::details

--- a/enterprise/backend/src/metabase_enterprise/audit/pages/question_detail.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit/pages/question_detail.clj
@@ -4,29 +4,30 @@
             [metabase-enterprise.audit.pages.common.card-and-dashboard-detail :as card-and-dash-detail]
             [metabase.models.card :refer [Card]]
             [metabase.util.schema :as su]
-            [schema.core :as s]))
+            [schema.core :as s]
+            [metabase-enterprise.audit.interface :as audit.i]))
 
-(s/defn ^:internal-query-fn views-by-time
-  "Get views of a Card broken out by a time `unit`, e.g. `day` or `day-of-week`."
-  [card-id :- su/IntGreaterThanZero, datetime-unit :- common/DateTimeUnitStr]
+;; Get views of a Card broken out by a time `unit`, e.g. `day` or `day-of-week`.
+(s/defmethod audit.i/internal-query ::views-by-time
+  [_ card-id :- su/IntGreaterThanZero datetime-unit :- common/DateTimeUnitStr]
   (card-and-dash-detail/views-by-time "card" card-id datetime-unit))
 
-(s/defn ^:internal-query-fn cached-views-by-time
-  "Get cached views of a Card broken out by a time `unit`, e.g. `day` or `day-of-week`."
-  [card-id :- su/IntGreaterThanZero, datetime-unit :- common/DateTimeUnitStr]
+;; Get cached views of a Card broken out by a time `unit`, e.g. `day` or `day-of-week`.
+(s/defmethod audit.i/internal-query ::cached-views-by-time
+  [_ card-id :- su/IntGreaterThanZero, datetime-unit :- common/DateTimeUnitStr]
   (card-and-dash-detail/cached-views-by-time card-id datetime-unit))
 
-(s/defn ^:internal-query-fn revision-history
-  "Get the revision history for a Card."
-  [card-id :- su/IntGreaterThanZero]
+;; Get the revision history for a Card.
+(s/defmethod audit.i/internal-query ::revision-history
+  [_ card-id :- su/IntGreaterThanZero]
   (card-and-dash-detail/revision-history Card card-id))
 
-(s/defn ^:internal-query-fn audit-log
-  "Get a view log for a Card."
-  [card-id :- su/IntGreaterThanZero]
+;; Get a view log for a Card.
+(s/defmethod audit.i/internal-query ::audit-log
+  [_ card-id :- su/IntGreaterThanZero]
   (card-and-dash-detail/audit-log "card" card-id))
 
-(s/defn ^:internal-query-fn avg-execution-time-by-time
-  "Average execution time broken out by period"
-  [card-id :- su/IntGreaterThanZero, datetime-unit :- common/DateTimeUnitStr]
+;; Average execution time broken out by period
+(s/defmethod audit.i/internal-query ::avg-execution-time-by-time
+  [_ card-id :- su/IntGreaterThanZero datetime-unit :- common/DateTimeUnitStr]
   (card-and-dash-detail/avg-execution-time-by-time card-id datetime-unit))

--- a/enterprise/backend/src/metabase_enterprise/audit/pages/question_detail.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit/pages/question_detail.clj
@@ -1,11 +1,11 @@
 (ns metabase-enterprise.audit.pages.question-detail
   "Detail page for a single Card (Question)."
-  (:require [metabase-enterprise.audit.pages.common :as common]
+  (:require [metabase-enterprise.audit.interface :as audit.i]
+            [metabase-enterprise.audit.pages.common :as common]
             [metabase-enterprise.audit.pages.common.card-and-dashboard-detail :as card-and-dash-detail]
             [metabase.models.card :refer [Card]]
             [metabase.util.schema :as su]
-            [schema.core :as s]
-            [metabase-enterprise.audit.interface :as audit.i]))
+            [schema.core :as s]))
 
 ;; Get views of a Card broken out by a time `unit`, e.g. `day` or `day-of-week`.
 (s/defmethod audit.i/internal-query ::views-by-time

--- a/enterprise/backend/src/metabase_enterprise/audit/pages/schemas.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit/pages/schemas.clj
@@ -1,5 +1,6 @@
 (ns metabase-enterprise.audit.pages.schemas
-  (:require [metabase-enterprise.audit.pages.common :as common]
+  (:require [metabase-enterprise.audit.interface :as audit.i]
+            [metabase-enterprise.audit.pages.common :as common]
             [metabase.util.honeysql-extensions :as hx]
             [schema.core :as s]))
 
@@ -22,9 +23,10 @@
 ;; GROUP BY db_name, db_schema
 ;; ORDER BY count(*) DESC
 ;; LIMIT 10
-(defn ^:internal-query-fn ^:deprecated most-queried
-  "Query that returns the top 10 most-queried schemas, in descending order."
-  []
+;;
+;; DEPRECATED Query that returns the top 10 most-queried schemas, in descending order.
+(defmethod audit.i/internal-query ::most-queried
+  [_]
   {:metadata [[:schema     {:display_name "Schema",     :base_type :type/Title}]
               [:executions {:display_name "Executions", :base_type :type/Integer}]]
    :results  (common/reducible-query
@@ -64,9 +66,10 @@
 ;; GROUP BY db_name, db_schema
 ;; ORDER BY avg_running_time DESC
 ;; LIMIT 10
-(defn ^:internal-query-fn ^:deprecated slowest-schemas
-  "Query that returns the top 10 schemas with the slowest average query execution time in descending order."
-  []
+;;
+;; DEPRECATED Query that returns the top 10 schemas with the slowest average query execution time in descending order.
+(defmethod audit.i/internal-query ::slowest-schemas
+  [_]
   {:metadata [[:schema           {:display_name "Schema",                    :base_type :type/Title}]
               [:avg_running_time {:display_name "Average Running Time (ms)", :base_type :type/Decimal}]]
    :results  (common/reducible-query
@@ -109,13 +112,15 @@
 ;; SELECT s.database_name AS "database", s."schema", s.tables, c.saved_count AS saved_queries
 ;; FROM schemas
 ;; LEFT JOIN cards c
-;;   ON s.database_id = c.database_id AND s."schema" = c."schema"
-(s/defn ^:internal-query-fn ^:deprecated table
-  "Query that returns a data for a table full of fascinating information about the different schemas in use in our
-  application."
-  ([]
-   (table nil))
-  ([query-string :- (s/maybe s/Str)]
+;;   ON s.database_id = c.database_id
+;;  AND s."schema" = c."schema"
+;;
+;; DEPRECATED Query that returns a data for a table full of fascinating information about the different schemas in use
+;; in our application.
+(s/defmethod audit.i/internal-query ::table
+  ([query-type]
+   (audit.i/internal-query query-type nil))
+  ([_ query-string :- (s/maybe s/Str)]
    {:metadata [[:database_id   {:display_name "Database ID",   :base_type :type/Integer, :remapped_to   :database}]
                [:database      {:display_name "Database",      :base_type :type/Title,   :remapped_from :database_id}]
                [:schema_id     {:display_name "Schema ID",     :base_type :type/Text,    :remapped_to   :schema}]
@@ -123,30 +128,30 @@
                [:tables        {:display_name "Tables",        :base_type :type/Integer}]
                [:saved_queries {:display_name "Saved Queries", :base_type :type/Integer}]]
     :results  (common/reducible-query
-                (->
-                 {:with      [[:cards {:select    [[:t.db_id :database_id]
-                                                   :t.schema
-                                                   [:%count.* :saved_count]]
-                                       :from      [[:report_card :c]]
-                                       :left-join [[:metabase_table :t] [:= :c.table_id :t.id]]
-                                       :where     [:not= :c.table_id nil]
-                                       :group-by  [:t.db_id :t.schema]}]
-                              [:schemas {:select    [[:db.id :database_id]
-                                                     [:db.name :database_name]
-                                                     :t.schema
-                                                     [:%count.* :tables]]
-                                         :from      [[:metabase_table :t]]
-                                         :left-join [[:metabase_database :db] [:= :t.db_id :db.id]]
-                                         :group-by  [:db.id :t.schema]
-                                         :order-by  [[:db.id :asc] [:t.schema :asc]]}]]
-                  :select    [:s.database_id
-                              [:s.database_name :database]
-                              [(hx/concat :s.database_id (hx/literal ".") :s.schema) :schema_id]
-                              :s.schema
-                              :s.tables
-                              [:c.saved_count :saved_queries]]
-                  :from      [[:schemas :s]]
-                  :left-join [[:cards :c] [:and
-                                           [:= :s.database_id :c.database_id]
-                                           [:= :s.schema :c.schema]]]}
-                 (common/add-search-clause query-string :s.schema)))}))
+               (->
+                {:with      [[:cards {:select    [[:t.db_id :database_id]
+                                                  :t.schema
+                                                  [:%count.* :saved_count]]
+                                      :from      [[:report_card :c]]
+                                      :left-join [[:metabase_table :t] [:= :c.table_id :t.id]]
+                                      :where     [:not= :c.table_id nil]
+                                      :group-by  [:t.db_id :t.schema]}]
+                             [:schemas {:select    [[:db.id :database_id]
+                                                    [:db.name :database_name]
+                                                    :t.schema
+                                                    [:%count.* :tables]]
+                                        :from      [[:metabase_table :t]]
+                                        :left-join [[:metabase_database :db] [:= :t.db_id :db.id]]
+                                        :group-by  [:db.id :t.schema]
+                                        :order-by  [[:db.id :asc] [:t.schema :asc]]}]]
+                 :select    [:s.database_id
+                             [:s.database_name :database]
+                             [(hx/concat :s.database_id (hx/literal ".") :s.schema) :schema_id]
+                             :s.schema
+                             :s.tables
+                             [:c.saved_count :saved_queries]]
+                 :from      [[:schemas :s]]
+                 :left-join [[:cards :c] [:and
+                                          [:= :s.database_id :c.database_id]
+                                          [:= :s.schema :c.schema]]]}
+                (common/add-search-clause query-string :s.schema)))}))

--- a/enterprise/backend/src/metabase_enterprise/audit/pages/table_detail.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit/pages/table_detail.clj
@@ -2,11 +2,12 @@
   (:require [metabase-enterprise.audit.pages.common :as common]
             [metabase.util.schema :as su]
             [ring.util.codec :as codec]
-            [schema.core :as s]))
+            [schema.core :as s]
+            [metabase-enterprise.audit.interface :as audit.i]))
 
-(s/defn ^:internal-query-fn audit-log
-  "View log for a specific Table."
-  [table-id :- su/IntGreaterThanZero]
+;; View log for a specific Table.
+(s/defmethod audit.i/internal-query ::audit-log
+  [_ table-id :- su/IntGreaterThanZero]
   {:metadata [[:started_at {:display_name "Viewed on",  :base_type :type/DateTime}]
               [:card_id    {:display_name "Card ID",    :base_type :type/Integer, :remapped_to   :query}]
               [:query      {:display_name "Query",      :base_type :type/Text,    :remapped_from :card_id}]

--- a/enterprise/backend/src/metabase_enterprise/audit/pages/table_detail.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit/pages/table_detail.clj
@@ -1,9 +1,9 @@
 (ns metabase-enterprise.audit.pages.table-detail
-  (:require [metabase-enterprise.audit.pages.common :as common]
+  (:require [metabase-enterprise.audit.interface :as audit.i]
+            [metabase-enterprise.audit.pages.common :as common]
             [metabase.util.schema :as su]
             [ring.util.codec :as codec]
-            [schema.core :as s]
-            [metabase-enterprise.audit.interface :as audit.i]))
+            [schema.core :as s]))
 
 ;; View log for a specific Table.
 (s/defmethod audit.i/internal-query ::audit-log

--- a/enterprise/backend/src/metabase_enterprise/audit/pages/users.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit/pages/users.clj
@@ -3,12 +3,14 @@
             [metabase-enterprise.audit.pages.common :as common]
             [metabase.util.honeysql-extensions :as hx]
             [ring.util.codec :as codec]
-            [schema.core :as s]))
+            [schema.core :as s]
+            [metabase-enterprise.audit.interface :as audit.i]))
 
-(defn ^:internal-query-fn ^:deprecated active-users-and-queries-by-day
-  "Query that returns data for a two-series timeseries: the number of DAU (a User is considered active for purposes of
-  this query if they ran at least one query that day), and total number of queries ran. Broken out by day."
-  []
+;; DEPRECATED Query that returns data for a two-series timeseries: the number of DAU (a User is considered active for
+;; purposes of this query if they ran at least one query that day), and total number of queries ran. Broken out by
+;; day.
+(defmethod audit.i/internal-query ::active-users-and-queries-by-day
+  [_]
   {:metadata [[:users   {:display_name "Users",   :base_type :type/Integer}]
               [:queries {:display_name "Queries", :base_type :type/Integer}]
               [:day     {:display_name "Date",    :base_type :type/Date}]]
@@ -25,27 +27,26 @@
                :group-by [:day]
                :order-by [[:day :asc]]})})
 
-
-(s/defn ^:internal-query-fn active-and-new-by-time
-  "Two-series timeseries that returns number of active Users (Users who ran at least one query) and number of new Users,
-  broken out by `datetime-unit`."
-  [datetime-unit :- common/DateTimeUnitStr]
+;; Two-series timeseries that returns number of active Users (Users who ran at least one query) and number of new
+;; Users, broken out by `datetime-unit`.
+(s/defmethod audit.i/internal-query ::active-and-new-by-time
+  [_ datetime-unit :- common/DateTimeUnitStr]
   {:metadata [[:date         {:display_name "Date",         :base_type (common/datetime-unit-str->base-type datetime-unit)}]
               [:active_users {:display_name "Active Users", :base_type :type/Integer}]
               [:new_users    {:display_name "New Users",    :base_type :type/Integer}]]
    ;; this is so nice and easy to implement in a single query with FULL OUTER JOINS but unfortunately only pg supports
    ;; them(!)
    :results  (let [active       (common/query
-                                  {:select   [[(common/grouped-datetime datetime-unit :started_at) :date]
-                                              [:%distinct-count.executor_id :count]]
-                                   :from     [:query_execution]
-                                   :group-by [(common/grouped-datetime datetime-unit :started_at)]})
+                                 {:select   [[(common/grouped-datetime datetime-unit :started_at) :date]
+                                             [:%distinct-count.executor_id :count]]
+                                  :from     [:query_execution]
+                                  :group-by [(common/grouped-datetime datetime-unit :started_at)]})
                    date->active (zipmap (map :date active) (map :count active))
                    new          (common/query
-                                  {:select   [[(common/grouped-datetime datetime-unit :date_joined) :date]
-                                              [:%count.* :count]]
-                                   :from     [:core_user]
-                                   :group-by [(common/grouped-datetime datetime-unit :date_joined)]})
+                                 {:select   [[(common/grouped-datetime datetime-unit :date_joined) :date]
+                                             [:%count.* :count]]
+                                  :from     [:core_user]
+                                  :group-by [(common/grouped-datetime datetime-unit :date_joined)]})
                    date->new    (zipmap (map :date new) (map :count new))
                    all-dates    (sort (keep identity (distinct (concat (keys date->active)
                                                                        (keys date->new)))))]
@@ -54,10 +55,9 @@
                   :active_users (date->active date 0)
                   :new_users    (date->new   date 0)}))})
 
-
-(defn ^:internal-query-fn most-active
-  "Query that returns the 10 most active Users (by number of query executions) in descending order."
-  []
+;; Query that returns the 10 most active Users (by number of query executions) in descending order.
+(defmethod audit.i/internal-query ::most-active
+  [_]
   {:metadata [[:user_id {:display_name "User ID",          :base_type :type/Integer, :remapped_to   :name}]
               [:name    {:display_name "Name",             :base_type :type/Name,    :remapped_from :user_id}]
               [:count   {:display_name "Query Executions", :base_type :type/Integer}]]
@@ -79,74 +79,72 @@
                            [:%lower.u.first_name :asc]]
                :limit     10})})
 
-
-(defn ^:internal-query-fn most-saves
-  "Query that returns the 10 Users with the most saved objects in descending order."
-  []
+;; Query that returns the 10 Users with the most saved objects in descending order.
+(defmethod audit.i/internal-query ::most-saves
+  [_]
   {:metadata [[:user_id   {:display_name "User ID",       :base_type :type/Integer, :remapped_to :user_name}]
               [:user_name {:display_name "Name",          :base_type :type/Name,    :remapped_from :user_id}]
               [:saves     {:display_name "Saved Objects", :base_type :type/Integer}]]
    :results  (common/reducible-query
-               {:with      [[:card_saves       {:select   [:creator_id
-                                                           [:%count.* :count]]
-                                                :from     [:report_card]
-                                                :group-by [:creator_id]}]
-                            [:dashboard_saves {:select   [:creator_id
+              {:with      [[:card_saves       {:select   [:creator_id
                                                           [:%count.* :count]]
-                                               :from     [:report_dashboard]
+                                               :from     [:report_card]
                                                :group-by [:creator_id]}]
-                            [:pulse_saves     {:select   [:creator_id
-                                                          [:%count.* :count]]
-                                               :from     [:pulse]
-                                               :group-by [:creator_id]}]]
-                :select    [[:u.id :user_id]
-                            [(common/user-full-name :u) :user_name]
-                            [(hx/+ (common/zero-if-null :card_saves.count)
-                                   (common/zero-if-null :dashboard_saves.count)
-                                   (common/zero-if-null :pulse_saves.count))
-                             :saves]]
-                :from      [[:core_user :u]]
-                :left-join [:card_saves      [:= :u.id :card_saves.creator_id]
-                            :dashboard_saves [:= :u.id :dashboard_saves.creator_id]
-                            :pulse_saves     [:= :u.id :pulse_saves.creator_id]]
-                :order-by  [[:saves :desc]
-                            [:u.last_name :asc]
-                            [:u.first_name :asc]]
-                :limit     10})})
+                           [:dashboard_saves {:select   [:creator_id
+                                                         [:%count.* :count]]
+                                              :from     [:report_dashboard]
+                                              :group-by [:creator_id]}]
+                           [:pulse_saves     {:select   [:creator_id
+                                                         [:%count.* :count]]
+                                              :from     [:pulse]
+                                              :group-by [:creator_id]}]]
+               :select    [[:u.id :user_id]
+                           [(common/user-full-name :u) :user_name]
+                           [(hx/+ (common/zero-if-null :card_saves.count)
+                                  (common/zero-if-null :dashboard_saves.count)
+                                  (common/zero-if-null :pulse_saves.count))
+                            :saves]]
+               :from      [[:core_user :u]]
+               :left-join [:card_saves      [:= :u.id :card_saves.creator_id]
+                           :dashboard_saves [:= :u.id :dashboard_saves.creator_id]
+                           :pulse_saves     [:= :u.id :pulse_saves.creator_id]]
+               :order-by  [[:saves :desc]
+                           [:u.last_name :asc]
+                           [:u.first_name :asc]]
+               :limit     10})})
 
-
-(defn ^:internal-query-fn query-execution-time-per-user
-  "Query that returns the total time spent executing queries, broken out by User, for the top 10 Users."
-  []
+;; Query that returns the total time spent executing queries, broken out by User, for the top 10 Users.
+(defmethod audit.i/internal-query ::query-execution-time-per-user
+  [_]
   {:metadata [[:user_id           {:display_name "User ID",                   :base_type :type/Integer, :remapped_to   :name}]
               [:name              {:display_name "Name",                      :base_type :type/Name,    :remapped_from :user_id}]
               [:execution_time_ms {:display_name "Total Execution Time (ms)", :base_type :type/Decimal}]]
    :results  (common/reducible-query
-               {:with      [[:exec_time {:select   [[:%sum.running_time :execution_time_ms]
-                                                    :qe.executor_id]
-                                         :from     [[:query_execution :qe]]
-                                         :where    [:not= nil :qe.executor_id]
-                                         :group-by [:qe.executor_id]
-                                         :order-by [[:%sum.running_time :desc]]
-                                         :limit    10}]]
-                :select    [[:u.id :user_id]
-                            [(common/user-full-name :u) :name]
-                            [(hsql/call :case [:not= :exec_time.execution_time_ms nil] :exec_time.execution_time_ms
-                                        :else 0)
-                             :execution_time_ms]]
-                :from      [[:core_user :u]]
-                :left-join [:exec_time [:= :exec_time.executor_id :u.id]]
-                :order-by  [[:execution_time_ms :desc]
-                            [:%lower.u.last_name :asc]
-                            [:%lower.u.first_name :asc]]
-                :limit     10})})
+              {:with      [[:exec_time {:select   [[:%sum.running_time :execution_time_ms]
+                                                   :qe.executor_id]
+                                        :from     [[:query_execution :qe]]
+                                        :where    [:not= nil :qe.executor_id]
+                                        :group-by [:qe.executor_id]
+                                        :order-by [[:%sum.running_time :desc]]
+                                        :limit    10}]]
+               :select    [[:u.id :user_id]
+                           [(common/user-full-name :u) :name]
+                           [(hsql/call :case [:not= :exec_time.execution_time_ms nil] :exec_time.execution_time_ms
+                              :else 0)
+                            :execution_time_ms]]
+               :from      [[:core_user :u]]
+               :left-join [:exec_time [:= :exec_time.executor_id :u.id]]
+               :order-by  [[:execution_time_ms :desc]
+                           [:%lower.u.last_name :asc]
+                           [:%lower.u.first_name :asc]]
+               :limit     10})})
 
-(s/defn ^:internal-query-fn table
-  "A table of all the Users for this instance, and various statistics about them (see metadata below)."
-  ([]
-   (table nil))
+;; A table of all the Users for this instance, and various statistics about them (see metadata below).
+(s/defmethod audit.i/internal-query ::table
+  ([query-type]
+   (audit.i/internal-query query-type nil))
 
-  ([query-string :- (s/maybe s/Str)]
+  ([_ query-string :- (s/maybe s/Str)]
    {:metadata [[:user_id          {:display_name "User ID",          :base_type :type/Integer, :remapped_to :name}]
                [:name             {:display_name "Name",             :base_type :type/Name,    :remapped_from :user_id}]
                [:role             {:display_name "Role",             :base_type :type/Text}]
@@ -222,11 +220,10 @@
                              [:%lower.u.first_name :asc]]}
                 (common/add-search-clause query-string :u.first_name :u.last_name)))}))
 
-
-(defn ^:internal-query-fn query-views
-  "Return a log of all query executions, including information about the Card associated with the query and the
-  Collection it is in (both, if applicable) and Database/Table referenced by the query."
-  []
+;; Return a log of all query executions, including information about the Card associated with the query and the
+;; Collection it is in (both, if applicable) and Database/Table referenced by the query.
+(defmethod audit.i/internal-query ::query-views
+  [_]
   {:metadata [[:viewed_on     {:display_name "Viewed On",       :base_type :type/DateTime}]
               [:card_id       {:display_name "Card ID"          :base_type :type/Integer, :remapped_to   :card_name}]
               [:card_name     {:display_name "Query",           :base_type :type/Text,    :remapped_from :card_id}]
@@ -268,9 +265,9 @@
               :order-by  [[:qe.started_at :desc]]})
    :xform (map #(update (vec %) 3 codec/base64-encode))})
 
-(defn ^:internal-query-fn dashboard-views
-  "Return a log of when all Dashboard views, including the Collection the Dashboard belongs to."
-  []
+;; Return a log of when all Dashboard views, including the Collection the Dashboard belongs to.
+(defmethod audit.i/internal-query ::dashboard-views
+  [_]
   {:metadata [[:timestamp       {:display_name "Viewed on",     :base_type :type/DateTime}]
               [:dashboard_id    {:display_name "Dashboard ID",  :base_type :type/Integer, :remapped_to   :dashboard_name}]
               [:dashboard_name  {:display_name "Dashboard",     :base_type :type/Text,    :remapped_from :dashboard_id}]

--- a/enterprise/backend/src/metabase_enterprise/audit/pages/users.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit/pages/users.clj
@@ -1,10 +1,10 @@
 (ns metabase-enterprise.audit.pages.users
   (:require [honeysql.core :as hsql]
+            [metabase-enterprise.audit.interface :as audit.i]
             [metabase-enterprise.audit.pages.common :as common]
             [metabase.util.honeysql-extensions :as hx]
             [ring.util.codec :as codec]
-            [schema.core :as s]
-            [metabase-enterprise.audit.interface :as audit.i]))
+            [schema.core :as s]))
 
 ;; DEPRECATED Query that returns data for a two-series timeseries: the number of DAU (a User is considered active for
 ;; purposes of this query if they ran at least one query that day), and total number of queries ran. Broken out by

--- a/enterprise/backend/src/metabase_enterprise/audit/query_processor/middleware/handle_audit_queries.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit/query_processor/middleware/handle_audit_queries.clj
@@ -1,17 +1,18 @@
 (ns metabase-enterprise.audit.query-processor.middleware.handle-audit-queries
-  "Middleware that handles special `internal` type queries. `internal` queries are implementeed directly by Clojure
-  functions, and do not neccesarily need to query a database to provide results; by default, they completely skip
-  the rest of the normal QP pipeline. `internal` queries should look like the following:
+  "Middleware that handles special `internal` type queries. `internal` queries are implemented directly by various
+  implementations of the [[metabase-enterprise.audit.interface/internal-query]] multimethod, and do not necessarily
+  need to query a database to provide results; by default, they completely skip the rest of the normal QP pipeline.
+  `internal` queries as passed to the Query Processor should look like the following:
 
     {:type :internal
      :fn   \"metabase-enterprise.audit.pages.dashboards/table\"
      :args []} ; optional vector of args to pass to the fn above
 
-  To run an `internal` query, you must have superuser permissions, and the function itself must be tagged as an
-  `:internal-query-fn`. This middleware will automatically resolve the function as appropriate, loading its namespace
-  if needed.
+  To run an `internal` query, you must have superuser permissions. This middleware will automatically resolve the
+  function as appropriate, loading its namespace if needed.
 
-    (defn ^:internal-query-fn table []
+    (defmethod audit.i/internal-query ::table
+      [_]
       {:metadata ..., :results ...})
 
   The function should return a map with two keys, `:metadata` and `:results`, in either the 'legacy' or 'reducible'
@@ -19,7 +20,7 @@
 
   LEGACY FORMAT:
 
-  *  `:metadata` is a series of [col-name metadata-map] pairs.
+  *  `:metadata` is a series of [col-name metadata-map] pairs. See [[metabase-enterprise.audit.interface/ResultsMetadata]]
   *  `:results` is a series of maps.
 
     {:metadata [[:title {:display_name \"Title\", :base_type :type/Text}]
@@ -37,7 +38,7 @@
      :results  (fn [context] ...)
      :xform    ...}"
   (:require [clojure.data :as data]
-            [clojure.string :as str]
+            [metabase-enterprise.audit.interface :as audit.i]
             [metabase.api.common :as api]
             [metabase.public-settings.metastore :as metastore]
             [metabase.query-processor.context :as context]
@@ -45,13 +46,6 @@
             [metabase.util.i18n :refer [tru]]
             [metabase.util.schema :as su]
             [schema.core :as s]))
-
-(def ^:private ResultsMetadata
-  "Schema for the expected format for `:metadata` returned by an internal query function."
-  (su/non-empty
-   [[(s/one su/KeywordOrString "field name")
-     (s/one {:base_type su/FieldType, :display_name su/NonBlankString, s/Keyword s/Any}
-            "field metadata")]]))
 
 (defn- check-results-and-metadata-keys-match
   "Primarily for dev and debugging purposes. We can probably take this out when shipping the finished product."
@@ -74,7 +68,7 @@
     (assoc v :name (name k))))
 
 (s/defn ^:private format-results [{:keys [results metadata]} :- {:results  [su/Map]
-                                                                 :metadata ResultsMetadata}]
+                                                                 :metadata audit.i/ResultsMetadata}]
   (check-results-and-metadata-keys-match results metadata)
   {:cols (metadata->cols metadata)
    :rows (for [row results]
@@ -93,26 +87,6 @@
   chance to do something clever outside of the normal function args. For example audit app uses `limit` and `offset`
   to implement paging for all audit app queries automatically."
   nil)
-
-(def ^:private resolve-internal-query-fn-lock (Object.))
-
-(defn- resolve-internal-query-fn
-  "Returns the varr for the internal query fn."
-  [qualified-fn-str]
-  (let [[ns-str] (str/split qualified-fn-str #"/")]
-    (or
-     ;; resolve if already available...
-     (locking resolve-internal-query-fn-lock
-       (resolve (symbol qualified-fn-str))
-       ;; if not, load the namespace...
-       (require (symbol ns-str))
-       ;; ...then try resolving again
-       (resolve (symbol qualified-fn-str)))
-     ;; failing that, throw an Exception
-     (throw
-      (Exception.
-       (str (tru "Unable to run internal query function: cannot resolve {0}"
-                 qualified-fn-str)))))))
 
 (defn- reduce-reducible-results [rff context {:keys [metadata results xform], :or {xform identity}}]
   (let [cols           (metadata->cols metadata)
@@ -143,15 +117,9 @@
   (when-not (metastore/enable-audit-app?)
     (throw (ex-info (tru "Audit App queries are not enabled on this instance.")
                     {:type error-type/invalid-query})))
-  ;;now resolve the query
-  (let [fn-varr (resolve-internal-query-fn qualified-fn-str)]
-    ;; Make sure this is actually allowed to be a internal query fn & has the results metadata we'll need
-    (when-not (:internal-query-fn (meta fn-varr))
-      (throw (Exception. (str (tru "Invalid internal query function: {0} is not marked as an ^:internal-query-fn"
-                                   qualified-fn-str)))))
-    (binding [*additional-query-params* (dissoc query :fn :args)]
-      (let [results (apply @fn-varr args)]
-        (reduce-results rff context results)))))
+  (binding [*additional-query-params* (dissoc query :fn :args)]
+    (let [results (apply audit.i/invoke-internal-query qualified-fn-str args)]
+      (reduce-results rff context results))))
 
 (defn handle-internal-queries
   "Middleware that handles `internal` type queries."

--- a/enterprise/backend/src/metabase_enterprise/audit/query_processor/middleware/handle_audit_queries.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit/query_processor/middleware/handle_audit_queries.clj
@@ -118,8 +118,8 @@
     (throw (ex-info (tru "Audit App queries are not enabled on this instance.")
                     {:type error-type/invalid-query})))
   (binding [*additional-query-params* (dissoc query :fn :args)]
-    (let [results (apply audit.i/invoke-internal-query qualified-fn-str args)]
-      (reduce-results rff context results))))
+    (let [resolved (apply audit.i/resolve-internal-query qualified-fn-str args)]
+      (reduce-results rff context resolved))))
 
 (defn handle-internal-queries
   "Middleware that handles `internal` type queries."

--- a/enterprise/backend/test/metabase_enterprise/audit/pages/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit/pages/common_test.clj
@@ -1,5 +1,6 @@
 (ns metabase-enterprise.audit.pages.common-test
   (:require [clojure.test :refer :all]
+            [metabase-enterprise.audit.interface :as audit.i]
             [metabase-enterprise.audit.pages.common :as pages.common]
             [metabase.db :as mdb]
             [metabase.public-settings.metastore-test :as metastore-test]
@@ -15,8 +16,8 @@
                                         (format "%s/%s" (ns-name (:ns mta)) (:name mta)))}
                                additional-query-params)))))
 
-(defn- ^:private ^:internal-query-fn legacy-format-query-fn
-  [a1]
+(defmethod audit.i/internal-query ::legacy-format-query-fn
+  [_ a1]
   (let [h2? (= (mdb/db-type) :h2)]
     {:metadata [[:A {:display_name "A", :base_type :type/DateTime}]
                 [:B {:display_name "B", :base_type :type/Integer}]]
@@ -24,8 +25,8 @@
                 {:union-all [{:select [[a1 :A] [2 :B]]}
                              {:select [[3 :A] [4 :B]]}]})}))
 
-(defn- ^:private ^:internal-query-fn reducible-format-query-fn
-  [a1]
+(defmethod audit.i/internal-query ::reducible-format-query-fn
+  [_ a1]
   {:metadata [[:A {:display_name "A", :base_type :type/DateTime}]
               [:B {:display_name "B", :base_type :type/Integer}]]
    :results  (pages.common/reducible-query

--- a/enterprise/backend/test/metabase_enterprise/audit/pages/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit/pages/common_test.clj
@@ -5,15 +5,15 @@
             [metabase.db :as mdb]
             [metabase.public-settings.metastore-test :as metastore-test]
             [metabase.query-processor :as qp]
-            [metabase.test :as mt]))
+            [metabase.test :as mt]
+            [metabase.util :as u]))
 
 (defn- run-query
-  [varr & {:as additional-query-params}]
+  [query-type & {:as additional-query-params}]
   (mt/with-test-user :crowberto
     (metastore-test/with-metastore-token-features #{:audit-app}
       (qp/process-query (merge {:type :internal
-                                :fn   (let [mta (meta varr)]
-                                        (format "%s/%s" (ns-name (:ns mta)) (:name mta)))}
+                                :fn   (u/qualified-name query-type)}
                                additional-query-params)))))
 
 (defmethod audit.i/internal-query ::legacy-format-query-fn
@@ -37,12 +37,12 @@
 (deftest transform-results-test
   (testing "Make sure query function result are transformed to QP results correctly"
     (metastore-test/with-metastore-token-features #{:audit-app}
-      (doseq [[format-name {:keys [varr expected-rows]}] {"legacy"    {:varr          #'legacy-format-query-fn
-                                                                       :expected-rows [[100 2] [3 4]]}
-                                                          "reducible" {:varr          #'reducible-format-query-fn
-                                                                       :expected-rows [[101 2] [4 4]]}}]
+      (doseq [[format-name {:keys [query-type expected-rows]}] {"legacy"    {:query-type          ::legacy-format-query-fn
+                                                                             :expected-rows [[100 2] [3 4]]}
+                                                                "reducible" {:query-type          ::reducible-format-query-fn
+                                                                             :expected-rows [[101 2] [4 4]]}}]
         (testing (format "format = %s" format-name)
-          (let [results (delay (run-query varr :args [100]))]
+          (let [results (delay (run-query query-type :args [100]))]
             (testing "cols"
               (is (= [{:display_name "A", :base_type :type/DateTime, :name "A"}
                       {:display_name "B", :base_type :type/Integer, :name "B"}]
@@ -54,17 +54,17 @@
 (deftest query-limit-and-offset-test
   (testing "Make sure params passed in as part of the query map are respected"
     (metastore-test/with-metastore-token-features #{:audit-app}
-      (doseq [[format-name {:keys [varr expected-rows]}] {"legacy"    {:varr          #'legacy-format-query-fn
-                                                                       :expected-rows [[100 2] [3 4]]}
-                                                          "reducible" {:varr          #'reducible-format-query-fn
-                                                                       :expected-rows [[101 2] [4 4]]}}]
+      (doseq [[format-name {:keys [query-type expected-rows]}] {"legacy"    {:query-type          ::legacy-format-query-fn
+                                                                             :expected-rows [[100 2] [3 4]]}
+                                                                "reducible" {:query-type          ::reducible-format-query-fn
+                                                                             :expected-rows [[101 2] [4 4]]}}]
         (testing (format "format = %s" format-name)
           (testing :limit
             (is (= [(first expected-rows)]
-                   (mt/rows (run-query varr :args [100], :limit 1)))))
+                   (mt/rows (run-query query-type :args [100], :limit 1)))))
           (testing :offset
             (is (= [(second expected-rows)]
-                   (mt/rows (run-query varr :args [100], :offset 1))))))))))
+                   (mt/rows (run-query query-type :args [100], :offset 1))))))))))
 
 (deftest CTES->subselects-test
   (testing "FROM substitution"

--- a/enterprise/backend/test/metabase_enterprise/audit/pages_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit/pages_test.clj
@@ -21,8 +21,8 @@
 
 (deftest preconditions-test
   (classloader/require 'metabase-enterprise.audit.pages.dashboards)
-  (testing "the query should exist"
-    (is (some? (resolve (symbol "metabase-enterprise.audit.pages.dashboards/most-popular-with-avg-speed")))))
+  (testing "the method should exist"
+    (is (fn? (get-method audit.i/internal-query :metabase-enterprise.audit.pages.dashboards/most-popular-with-avg-speed))))
 
   (testing "test that a query will fail if not ran by an admin"
     (metastore-test/with-metastore-token-features #{:audit-app}

--- a/enterprise/backend/test/metabase_enterprise/audit/pages_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit/pages_test.clj
@@ -1,8 +1,11 @@
 (ns metabase-enterprise.audit.pages-test
   (:require [clojure.java.classpath :as classpath]
+            [clojure.java.io :as io]
             [clojure.string :as str]
             [clojure.test :refer :all]
             [clojure.tools.namespace.find :as ns-find]
+            [clojure.tools.reader :as tools.reader]
+            [metabase-enterprise.audit.interface :as audit.i]
             [metabase.models :refer [Card Dashboard DashboardCard Database Table]]
             [metabase.plugins.classloader :as classloader]
             [metabase.public-settings.metastore-test :as metastore-test]
@@ -37,40 +40,110 @@
                                         :fn   "metabase-enterprise.audit.pages.dashboards/most-popular-with-avg-speed"})
                  (select-keys [:status :error])))))))
 
-(defn- all-queries []
-  (for [ns-symb  (ns-find/find-namespaces (classpath/system-classpath))
-        :when    (and (str/starts-with? (name ns-symb) "metabase-enterprise.audit.pages")
-                      (not (str/ends-with? (name ns-symb) "-test")))
-        [_ varr] (do (classloader/require ns-symb)
-                     (ns-interns ns-symb))
-        :when    (:internal-query-fn (meta varr))]
-    varr))
+(defn- all-query-methods
+  "Return a set of all audit/internal query types (excluding test/`:default` impls)."
+  []
+  ;; load all `metabase-enterprise.audit.pages` namespaces.
+  (doseq [ns-symb  (ns-find/find-namespaces (classpath/system-classpath))
+          :when    (and (str/starts-with? (name ns-symb) "metabase-enterprise.audit.pages")
+                        (not (str/ends-with? (name ns-symb) "-test")))]
+    (classloader/require ns-symb))
+  ;; now find all the impls of [[metabase-enterprise.audit.interface/internal-query]] from the pages namespaces
+  (into (sorted-set)
+        (filter (fn [query-type]
+                  (when-let [ns-str (namespace query-type)]
+                    (and (str/starts-with? ns-str "metabase-enterprise.audit.pages.")
+                         (not (str/ends-with? ns-str "-test"))))))
+        (keys (methods audit.i/internal-query))))
 
-(defn- varr->query [varr {:keys [database table card dash]}]
-  (let [mta     (meta varr)
-        fn-str  (str (ns-name (:ns mta)) "/" (:name mta))
-        arglist (mapv keyword (first (:arglists mta)))]
+(defn- query-defmethod-source-form
+  "Find the source [[defmethod]] or [[schema.core/defmethod]] form for the internal query named by `query-type`."
+  [query-type]
+  (let [file    (-> (namespace query-type)
+                    munge
+                    (str/replace #"\." "/")
+                    (str ".clj"))
+        ns-symb (symbol (namespace query-type))]
+    (with-open [reader (java.io.PushbackReader. (io/reader (io/resource file)))]
+      (binding [*ns* (the-ns ns-symb)]
+        (loop []
+          (let [form (tools.reader/read reader false ::eof)]
+            (cond
+              (= form ::eof)
+              (throw (ex-info (str "Cannot find source for " query-type)
+                              {:namespace ns-symb, :file file}))
+
+              (and (seq? form)
+                   (#{'defmethod 's/defmethod} (first form))
+                   (= (second form) 'audit.i/internal-query)
+                   (= (nth form 2) query-type))
+              form
+
+              :else
+              (recur))))))))
+
+(defn- arglist-strip-schema-annotations
+  "Remove Schema `:-` annotations from `arglist`."
+  [arglist]
+  (let [remove-next? (volatile! false)]
+    (into []
+          (remove (fn [value]
+                    (cond
+                      (= value :-)
+                      (do
+                        (vreset! remove-next? true)
+                        true)
+
+                      @remove-next?
+                      (do
+                        (vreset! remove-next? false)
+                        true)
+
+                      :else
+                      false)))
+          arglist)))
+
+(defn- query-defmethod-arglists
+  "Return a sequence of arglists for the internal query named by `query-type`."
+  [query-type]
+  (let [fn-tail (drop 3 (query-defmethod-source-form query-type))]
+    (mapv arglist-strip-schema-annotations
+          (if (vector? (first fn-tail))
+            [(first fn-tail)]
+            (map first fn-tail)))))
+
+(defn- test-query-maps
+  "Generate a sequence of test query maps (as you'd pass to the QP) for the internal query named by `query-type`.
+  Generates one map for arity of the method."
+  [query-type {:keys [database table card dash]}]
+  (for [arglist (query-defmethod-arglists query-type)]
     {:type :internal
-     :fn   fn-str
-     :args (for [arg arglist]
+     :fn   (u/qualified-name query-type)
+     :args (for [arg (mapv keyword (rest arglist))]
              (case arg
-               :datetime-unit "day"
-               :dashboard-id  (u/the-id dash)
-               :card-id       (u/the-id card)
-               :user-id       (mt/user->id :crowberto)
-               :database-id   (u/the-id database)
-               :table-id      (u/the-id table)
-               :model         "card"
-               :query-hash    (codec/base64-encode (qp-util/query-hash {:database 1, :type :native}))))}))
+               :datetime-unit     "day"
+               :dashboard-id      (u/the-id dash)
+               :card-id           (u/the-id card)
+               :user-id           (mt/user->id :crowberto)
+               :database-id       (u/the-id database)
+               :table-id          (u/the-id table)
+               :model             "card"
+               :query-hash        (codec/base64-encode (qp-util/query-hash {:database 1, :type :native}))
+               :query-string      "toucans"
+               :question-filter   "bird sales"
+               :collection-filter "coin collection"
+               :sort-column       "card.id"
+               :sort-direction    "desc"))}))
 
-(defn- test-varr
-  [varr objects]
-  (testing (format "%s %s:%d" varr (ns-name (:ns (meta varr))) (:line (meta varr)))
-    (let [query (varr->query varr objects)]
-      (testing (format "\nquery =\n%s" (u/pprint-to-str query))
-        (is (schema= {:status (s/eq :completed)
-                      s/Keyword s/Any}
-                     (qp/process-query query)))))))
+(defn- do-tests-for-query-type
+  "Run test(s) for the internal query named by `query-type`. Runs one test for each map returned
+  by [[test-query-maps]]."
+  [query-type objects]
+  (doseq [query (test-query-maps query-type objects)]
+    (testing (format "\nquery =\n%s" (u/pprint-to-str query))
+      (is (schema= {:status (s/eq :completed)
+                    s/Keyword s/Any}
+                   (qp/process-query query))))))
 
 (defn- do-with-temp-objects [f]
   (mt/with-temp* [Database      [database]
@@ -87,5 +160,6 @@
   (mt/with-test-user :crowberto
      (with-temp-objects [objects]
        (metastore-test/with-metastore-token-features #{:audit-app}
-         (doseq [varr (all-queries)]
-           (test-varr varr objects))))))
+         (doseq [query-type (all-query-methods)]
+           (testing query-type
+             (do-tests-for-query-type query-type objects)))))))

--- a/enterprise/backend/test/metabase_enterprise/audit/pages_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit/pages_test.clj
@@ -158,8 +158,8 @@
 
 (deftest all-queries-test
   (mt/with-test-user :crowberto
-     (with-temp-objects [objects]
-       (metastore-test/with-metastore-token-features #{:audit-app}
-         (doseq [query-type (all-query-methods)]
-           (testing query-type
-             (do-tests-for-query-type query-type objects)))))))
+    (with-temp-objects [objects]
+      (metastore-test/with-metastore-token-features #{:audit-app}
+        (doseq [query-type (all-query-methods)]
+          (testing query-type
+            (do-tests-for-query-type query-type objects)))))))

--- a/enterprise/backend/test/metabase_enterprise/audit/query_processor/middleware/handle_audit_queries_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit/query_processor/middleware/handle_audit_queries_test.clj
@@ -1,28 +1,29 @@
 (ns metabase-enterprise.audit.query-processor.middleware.handle-audit-queries-test
   "Additional tests for this namespace can be found in `metabase-enterprise.audit.pages-test`."
   (:require [clojure.test :refer :all]
+            [metabase-enterprise.audit.interface :as audit.i]
             [metabase.public-settings.metastore-test :as metastore-test]
             [metabase.query-processor :as qp]
-            [metabase.test :as mt]))
+            [metabase.test :as mt]
+            [metabase.util :as u]))
 
 (defn- run-query
-  [varr & {:as additional-query-params}]
+  [query-type & {:as additional-query-params}]
   (mt/with-test-user :crowberto
     (metastore-test/with-metastore-token-features #{:audit-app}
       (qp/process-query (merge {:type :internal
-                                :fn   (let [mta (meta varr)]
-                                        (format "%s/%s" (ns-name (:ns mta)) (:name mta)))}
+                                :fn   (u/qualified-name query-type)}
                                additional-query-params)))))
 
-(defn- ^:private ^:internal-query-fn legacy-format-query-fn
-  [a1]
+(defmethod audit.i/internal-query ::legacy-format-query-fn
+  [_ a1]
   {:metadata [[:a {:display_name "A", :base_type :type/DateTime}]
               [:b {:display_name "B", :base_type :type/Integer}]]
    :results  [{:a a1, :b 2}
               {:a 3, :b 5}]})
 
-(defn- ^:private ^:internal-query-fn reducible-format-query-fn
-  [a1]
+(defmethod audit.i/internal-query ::reducible-format-query-fn
+  [_ a1]
   {:metadata [[:a {:display_name "A", :base_type :type/DateTime}]
               [:b {:display_name "B", :base_type :type/Integer}]]
    :results  (constantly [[a1 2]
@@ -31,12 +32,12 @@
 
 (deftest transform-results-test
   (testing "Make sure query function result are transformed to QP results correctly"
-    (doseq [[format-name {:keys [varr expected-rows]}] {"legacy"    {:varr          #'legacy-format-query-fn
-                                                                     :expected-rows [[100 2] [3 5]]}
-                                                        "reducible" {:varr          #'reducible-format-query-fn
-                                                                     :expected-rows [[101 2] [4 5]]}}]
+    (doseq [[format-name {:keys [query-type expected-rows]}] {"legacy"    {:query-type    ::legacy-format-query-fn
+                                                                           :expected-rows [[100 2] [3 5]]}
+                                                              "reducible" {:query-type    ::reducible-format-query-fn
+                                                                           :expected-rows [[101 2] [4 5]]}}]
       (testing (format "format = %s" format-name)
-        (let [results (delay (run-query varr :args [100]))]
+        (let [results (delay (run-query query-type :args [100]))]
           (testing "cols"
             (is (= [{:display_name "A", :base_type :type/DateTime, :name "a"}
                     {:display_name "B", :base_type :type/Integer, :name "b"}]

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/lib/cards/dashboards.js
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/lib/cards/dashboards.js
@@ -1,16 +1,3 @@
-//  DEPRECATED: use `views-and-saves-by-time ` instead.
-export const viewsPerDay = () => ({
-  card: {
-    name: "Total dashboard views per day",
-    display: "line",
-    dataset_query: {
-      type: "internal",
-      fn: "metabase-enterprise.audit.pages.dashboards/views-per-day",
-      args: [],
-    },
-  },
-});
-
 export const viewsAndSavesByTime = () => ({
   card: {
     name: "Dashboard views and saves per day",

--- a/src/metabase/models/pulse_channel.clj
+++ b/src/metabase/models/pulse_channel.clj
@@ -42,7 +42,7 @@
 (defn schedule-frame?
   "Is `frame` a valid schedule frame?"
   [frame]
-  (schedule-frames frame))
+  (contains? schedule-frames frame))
 
 (def ^:private schedule-types
   "Set of the possible schedule-types allowed for a PulseChannel."

--- a/src/metabase/models/pulse_channel.clj
+++ b/src/metabase/models/pulse_channel.clj
@@ -40,9 +40,9 @@
   #{:first :mid :last})
 
 (defn schedule-frame?
-  "Is FRAME a valid schedule frame?"
+  "Is `frame` a valid schedule frame?"
   [frame]
-  (contains? schedule-frames frame))
+  (schedule-frames frame))
 
 (def ^:private schedule-types
   "Set of the possible schedule-types allowed for a PulseChannel."


### PR DESCRIPTION
Previously the `:internal` audit queries would resolve and run the function marked with `^:internal-query-fn`. That is a wacky way of doing things. Defining the queries with `defmethod` is a much more sane/normal way of doing things, and that's what this PR does. 

This PR adds a new `metabase-enterprise.audit.interface` namespace that defines a `internal-query` method; various implementations are changed from functions to implementations of this method.

I had to do a little bit of magic to get the existing (already magic) automatic test code to work. Previously the automatic test would find vars with `^:internal-query-fn` metadata, read their `:arglists` metadata, build a query map using values that made sense for the arg names, then run that query. Since `defmethod` functions don't have `:arglists` metadata I had to tweak this code to read the source file where the method is defined and pull the arglists out of the `defmethod` or `s/defmethod` forms... totally doable since code is data.

![image](https://user-images.githubusercontent.com/1455846/132606739-bcfbae58-10c6-4a5f-bb62-23a0ceea71cc.png)

The other parts are the same. Actually, I improved things a bit and now the tests run for all the arities of the method -- the old version only ran tests for the first arity.