### PR TITLE
Email rework mobile fixes

### DIFF
--- a/src/metabase/email/pulse.mustache
+++ b/src/metabase/email/pulse.mustache
@@ -51,14 +51,14 @@
         line-height: 18px;
       }
 
-      @media screen and (max-width: 320px) {
+      {{!-- Emails on smaller devices should have less of our UI chrome to make the content easier to read --}}
+      @media screen and (max-width: 420px) {
         .background {
-          background-color: white !important;
+          background-color: #ffffff !important;
+          padding: 0px !important;
         }
-      }
-      @media screen and (min-width: 640px) {
         .container {
-          border-radius: 30px !important;
+          padding: 10px !important;
         }
       }
     </style>
@@ -67,7 +67,7 @@
     <table class="background" width="100%" border="0" cellspacing="0" cellpadding="0" style="background-color: #F9F9F9; padding: 20px; table-layout: fixed;">
       <tr>
         <td>
-          <div class="container" style="background-color: white; max-width: 555px; border-radius: 10px; margin: 0 auto; padding: 30px;">
+          <div class="container" style="background-color: white; max-width: 555px; border-radius: 24px; margin: 0 auto; padding: 30px;">
             <table class="header">
               <tr>
                 <td>

--- a/src/metabase/email/pulse.mustache
+++ b/src/metabase/email/pulse.mustache
@@ -50,13 +50,24 @@
         font-size: 14px;
         line-height: 18px;
       }
+
+      @media screen and (max-width: 320px) {
+        .background {
+          background-color: white !important;
+        }
+      }
+      @media screen and (min-width: 640px) {
+        .container {
+          border-radius: 30px !important;
+        }
+      }
     </style>
   </head>
   <body style="padding: 0px">
-    <table width="100%" border="0" cellspacing="0" cellpadding="0" style="background-color: #F9F9F9; padding: 20px">
+    <table class="background" width="100%" border="0" cellspacing="0" cellpadding="0" style="background-color: #F9F9F9; padding: 20px; table-layout: fixed;">
       <tr>
         <td>
-          <div class="container" style="background-color: white; max-width: 555px; border-radius: 30px; margin: 0 auto; padding: 30px;">
+          <div class="container" style="background-color: white; max-width: 555px; border-radius: 10px; margin: 0 auto; padding: 30px;">
             <table class="header">
               <tr>
                 <td>


### PR DESCRIPTION
A couple mobile fixes for our new email template. Here's what's happening.

1. We set the table-layout to "fixed." This is one of those CSS properties I'd forgotten about but adding it to our overall layout table helps make sure that even if there's overflow content (like a table with many columns) that that doesn't cause the overall layout container (the table in this case) to stretch. Before this, the email would be scaled so that the whole container was in view making the text small and hard to read.
2. We remove some of our UI chrome. The extra padding and background just compress the content on the smaller screen, so we reduce the padding and remove the background color to get a nice edge to edge layout while retaining the nicer style when viewed on desktop. 

Here's a quick overview. (The effect is very noticeable when viewing these emails on an email client on your phone).

https://user-images.githubusercontent.com/5248953/132737377-753511a7-75cf-41d7-a55f-3ac0d31458f5.mov

