### PR TITLE
don't show exact seconds for a formatted relative time

### DIFF
--- a/frontend/src/metabase/lib/time.js
+++ b/frontend/src/metabase/lib/time.js
@@ -13,8 +13,8 @@ function addAbbreviatedLocale() {
     relativeTime: {
       future: "in %s",
       past: "%s",
-      s: "%d s",
-      ss: "%d s",
+      s: t`just now`,
+      ss: t`just now`,
       m: "%d m",
       mm: "%d m",
       h: "%d h",

--- a/frontend/test/metabase/lib/time.unit.spec.js
+++ b/frontend/test/metabase/lib/time.unit.spec.js
@@ -1,4 +1,8 @@
-import { parseTime, parseTimestamp } from "metabase/lib/time";
+import {
+  parseTime,
+  parseTimestamp,
+  getRelativeTimeAbbreviated,
+} from "metabase/lib/time";
 import moment from "moment";
 
 describe("time", () => {
@@ -63,6 +67,36 @@ describe("time", () => {
 
       expect(moment.isMoment(result)).toBe(true);
       expect(result.format("h:mm A")).toBe("1:02 AM");
+    });
+  });
+
+  describe("getRelativeTimeAbbreviated", () => {
+    it("should show 'just now' for timestamps from the immediate past", () => {
+      expect(
+        getRelativeTimeAbbreviated(
+          moment()
+            .subtract(30, "s")
+            .toString(),
+        ),
+      ).toEqual("just now");
+    });
+
+    it("should show a shortened string for times 1 minute+", () => {
+      expect(
+        getRelativeTimeAbbreviated(
+          moment()
+            .subtract(61, "s")
+            .toString(),
+        ),
+      ).toEqual("1 m");
+
+      expect(
+        getRelativeTimeAbbreviated(
+          moment()
+            .subtract(5, "d")
+            .toString(),
+        ),
+      ).toEqual("5 d");
     });
   });
 });


### PR DESCRIPTION
The moderation banner and anything else that uses `getRelativeTimeAbbreviated` (nothing else right now) will see "just now" instead of `1s` to `59s` so that the number doesn't update when mousing over the banner.

<img width="328" alt="Screen Shot 2021-09-09 at 1 33 34 PM" src="https://user-images.githubusercontent.com/13057258/132758638-d476538b-87f0-47e2-848d-1fc8fe2ac90a.png">
