### PR TITLE
fix PropTypes console warning

### DIFF
--- a/frontend/src/metabase/components/Badge.styled.jsx
+++ b/frontend/src/metabase/components/Badge.styled.jsx
@@ -6,7 +6,7 @@ import Icon from "metabase/components/Icon";
 import Link from "metabase/components/Link";
 
 const propTypes = {
-  to: PropTypes.oneOfType([PropTypes.string, PropTypes.boolean]),
+  to: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
 };
 
 function RawMaybeLink({ to, ...props }) {


### PR DESCRIPTION
This change cleans up a console warning because `PropTypes.boolean` doesn't exist and `PropTypes.oneOfType` complains about an `undefined` array entry.

`PropTypes` really should just include shorthands so that you can use `PropTypes.bool` and `PropTypes.boolean` interchangeably because I accidentally make this mistake (and `PropTypes.func`//`PropTypes.function`) all the time.