### PR TITLE
add keys to arrays of routes

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/audit_app/routes.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/routes.jsx
@@ -42,7 +42,9 @@ function getPageRoutes(path, page: Page) {
   // add a redirect for the default tab
   const defaultTab = getDefaultTab(page);
   if (defaultTab) {
-    subRoutes.push(<IndexRedirect to={defaultTab.path} />);
+    subRoutes.push(
+      <IndexRedirect key={defaultTab.path} to={defaultTab.path} />,
+    );
   }
   // add sub routes for each tab
   if (page.tabs) {
@@ -72,7 +74,7 @@ function getDefaultTab(page: Page): ?Tab {
 }
 
 const getRoutes = (store: any) => (
-  <Route path="audit" title={t`Audit`} component={AuditApp}>
+  <Route key="audit" path="audit" title={t`Audit`} component={AuditApp}>
     {/* <IndexRedirect to="overview" /> */}
     <IndexRedirect to="members" />
 

--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/index.js
@@ -57,10 +57,18 @@ if (hasPremiumFeature("sandboxes")) {
     type: LoginAttributesWidget,
   });
   PLUGIN_ADMIN_PERMISSIONS_TABLE_ROUTES.push(
-    <ModalRoute path=":tableId/segmented" modal={GTAPModal} />,
+    <ModalRoute
+      key=":tableId/segmented"
+      path=":tableId/segmented"
+      modal={GTAPModal}
+    />,
   );
   PLUGIN_ADMIN_PERMISSIONS_TABLE_GROUP_ROUTES.push(
-    <ModalRoute path="segmented/group/:groupId" modal={GTAPModal} />,
+    <ModalRoute
+      key="segmented/group/:groupId"
+      path="segmented/group/:groupId"
+      modal={GTAPModal}
+    />,
   );
   PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_OPTIONS.push(OPTION_SEGMENTED);
   PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_ACTIONS["controlled"].push({

--- a/enterprise/frontend/src/metabase-enterprise/store/routes.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/store/routes.jsx
@@ -9,7 +9,7 @@ import StoreAccount from "./containers/StoreAccount";
 
 export default function getRoutes() {
   return (
-    <Route path="store" title={t`Store`}>
+    <Route key="store" path="store" title={t`Store`}>
       <IndexRoute component={StoreAccount} />
       <Route path="activate" component={StoreActivate} />
     </Route>

--- a/frontend/src/metabase/admin/routes.jsx
+++ b/frontend/src/metabase/admin/routes.jsx
@@ -140,10 +140,12 @@ const getRoutes = (store, IsAdmin) => (
     </Route>
 
     {/* PERMISSIONS */}
-    {getAdminPermissionsRoutes(store)}
+    <React.Fragment>{getAdminPermissionsRoutes(store)}</React.Fragment>
 
     {/* PLUGINS */}
-    {PLUGIN_ADMIN_ROUTES.map(getRoutes => getRoutes(store))}
+    <React.Fragment>
+      {PLUGIN_ADMIN_ROUTES.map(getRoutes => getRoutes(store))}
+    </React.Fragment>
   </Route>
 );
 


### PR DESCRIPTION
This gets rid of a react warning about lists of components missing `key` props.