### PR TITLE
fix a few prop errors causing console warnings

### DIFF
--- a/frontend/src/metabase/components/Badge.jsx
+++ b/frontend/src/metabase/components/Badge.jsx
@@ -6,7 +6,6 @@ import { iconPropTypes } from "metabase/components/Icon";
 import { BadgeIcon, MaybeLink } from "./Badge.styled";
 
 const propTypes = {
-  name: PropTypes.string.isRequired,
   to: PropTypes.string,
   icon: PropTypes.shape(iconPropTypes),
   activeColor: PropTypes.string,
@@ -16,7 +15,7 @@ const propTypes = {
 
 const DEFAULT_ICON_SIZE = 12;
 
-function Badge({ name, icon, activeColor = "brand", children, ...props }) {
+function Badge({ icon, activeColor = "brand", children, ...props }) {
   const extraIconProps = {};
   if (icon && !icon.size && !icon.width && !icon.height) {
     extraIconProps.size = DEFAULT_ICON_SIZE;

--- a/frontend/src/metabase/components/LastEditInfoLabel.js
+++ b/frontend/src/metabase/components/LastEditInfoLabel.js
@@ -27,7 +27,8 @@ LastEditInfoLabel.propTypes = {
   user: PropTypes.shape({
     id: PropTypes.number,
   }).isRequired,
-  onClick: PropTypes.func.isRequired,
+  onClick: PropTypes.func,
+  className: PropTypes.string,
 };
 
 function formatEditorName(firstName, lastName) {
@@ -35,7 +36,7 @@ function formatEditorName(firstName, lastName) {
   return `${firstName} ${lastNameFirstLetter}.`;
 }
 
-function LastEditInfoLabel({ item, user, onClick, ...props }) {
+function LastEditInfoLabel({ item, user, onClick, className }) {
   const { first_name, last_name, id: editorId, timestamp } = item[
     "last-edit-info"
   ];
@@ -47,9 +48,9 @@ function LastEditInfoLabel({ item, user, onClick, ...props }) {
   return (
     <TextButton
       size="small"
+      className={className}
       onClick={onClick}
       data-testid="revision-history-button"
-      {...props}
     >{t`Edited ${time} by ${editor}`}</TextButton>
   );
 }

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -67,10 +67,8 @@ export default class Dashboard extends Component {
     onReplaceAllDashCardVisualizationSettings: PropTypes.func.isRequired,
 
     onChangeLocation: PropTypes.func.isRequired,
-
     onSharingClick: PropTypes.func,
     onEmbeddingClick: PropTypes.any,
-
     sidebar: PropTypes.shape({
       name: PropTypes.string,
       props: PropTypes.object,
@@ -187,8 +185,6 @@ export default class Dashboard extends Component {
     this.props.setSharing(true);
   };
 
-  onEmbeddingClick = () => {};
-
   render() {
     const {
       addParameter,
@@ -236,7 +232,6 @@ export default class Dashboard extends Component {
                 addParameter={addParameter}
                 parametersWidget={parametersWidget}
                 onSharingClick={this.onSharingClick}
-                onEmbeddingClick={this.onEmbeddingClick}
                 onToggleAddQuestionSidebar={this.onToggleAddQuestionSidebar}
                 showAddQuestionSidebar={showAddQuestionSidebar}
               />

--- a/frontend/src/metabase/dashboard/components/DashboardHeader.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader.jsx
@@ -68,7 +68,6 @@ type Props = {
   onChangeLocation: string => void,
 
   onSharingClick: void => void,
-  onEmbeddingClick: void => void,
 };
 
 type State = {
@@ -109,7 +108,6 @@ export default class DashboardHeader extends Component {
     onFullscreenChange: PropTypes.func.isRequired,
 
     onSharingClick: PropTypes.func.isRequired,
-    onEmbeddingClick: PropTypes.func.isRequred,
   };
 
   handleEdit(dashboard: DashboardWithCards) {

--- a/frontend/src/metabase/dashboard/components/DashboardSidebars.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardSidebars.jsx
@@ -20,7 +20,7 @@ DashboardSidebars.propTypes = {
   editingParameter: PropTypes.object,
   isEditingParameter: PropTypes.bool.isRequired,
   showAddQuestionSidebar: PropTypes.bool.isRequired,
-  clickBehaviorSidebarDashcard: PropTypes.object.isRequired,
+  clickBehaviorSidebarDashcard: PropTypes.object, // only defined when click-behavior sidebar is open
   onReplaceAllDashCardVisualizationSettings: PropTypes.func.isRequired,
   onUpdateDashCardVisualizationSettings: PropTypes.func.isRequired,
   onUpdateDashCardColumnSettings: PropTypes.func.isRequired,

--- a/frontend/test/metabase/components/LastEditInfoLabel.unit.spec.js
+++ b/frontend/test/metabase/components/LastEditInfoLabel.unit.spec.js
@@ -38,7 +38,7 @@ describe("LastEditInfoLabel", () => {
 
     return render(
       <Provider store={store}>
-        <LastEditInfoLabel item={testItem} data-testid="label" />
+        <LastEditInfoLabel item={testItem} />
       </Provider>,
     );
   }
@@ -74,7 +74,7 @@ describe("LastEditInfoLabel", () => {
     it(`should display "${expectedTimestamp}" timestamp correctly`, () => {
       mockDate.set(date.toDate(), 0);
       const { getByTestId } = setup();
-      expect(getByTestId("label")).toHaveTextContent(
+      expect(getByTestId("revision-history-button")).toHaveTextContent(
         new RegExp(`Edited ${expectedTimestamp} by .*`, "i"),
       );
     });
@@ -86,14 +86,14 @@ describe("LastEditInfoLabel", () => {
     const expectedName = `${first_name} ${last_name.charAt(0)}.`;
 
     const { getByTestId } = setup();
-    expect(getByTestId("label")).toHaveTextContent(
+    expect(getByTestId("revision-history-button")).toHaveTextContent(
       new RegExp(`Edited .* by ${expectedName}`),
     );
   });
 
   it("should display if user is the last editor", () => {
     const { getByTestId } = setup({ isLastEditedByCurrentUser: true });
-    expect(getByTestId("label")).toHaveTextContent(
+    expect(getByTestId("revision-history-button")).toHaveTextContent(
       new RegExp(`Edited .* by you`),
     );
   });


### PR DESCRIPTION
This gets rid of most prop console warnings when you refresh your browser on `/dashboard/:dashId`. Only ones left are from `styled-components` passing props to the DOM -- one day we will update to v5 and get rid of those...

1. `Badge` no longer uses the `name` prop so I'm removing it + its `propType` validation
2. the `LastEditInfoLabel` component was passing all extra props to its children via a `{...props}` but we only ever pass `LastEditInfoLabel` `className`, so I just made that an explicit prop and removed the spread.
3. `onSharingClick` is not a `Dashboard` prop; it is defined as a method on `Dashboard`
4. `onEmbeddingClick` is defined on `Dashboard` as a function that does nothing and then it isn't ever used, besides getting passed to `DashboardHeader`. Removed it.
5. the `clickBehaviorSidebarDashcard` prop will be `undefined` if the click behavior sidebar is closed, so I removed the `isRequired` part of the `propType`