### PR TITLE
Ignore the coverage of semi-constructors only for type hints

### DIFF
--- a/frontend/src/metabase-lib/lib/metadata/Database.js
+++ b/frontend/src/metabase-lib/lib/metadata/Database.js
@@ -140,6 +140,7 @@ export default class Database extends Base {
    * @param {Metadata} metadata
    * @param {boolean} auto_run_queries
    */
+  /* istanbul ignore next */
   _constructor(
     id,
     name,

--- a/frontend/src/metabase-lib/lib/metadata/Field.js
+++ b/frontend/src/metabase-lib/lib/metadata/Field.js
@@ -354,6 +354,7 @@ export default class Field extends Base {
    * @param {?Field} name_field
    * @param {Metadata} metadata
    */
+  /* istanbul ignore next */
   _constructor(
     id,
     name,

--- a/frontend/src/metabase-lib/lib/metadata/Metadata.js
+++ b/frontend/src/metabase-lib/lib/metadata/Metadata.js
@@ -115,6 +115,7 @@ export default class Metadata extends Base {
    * @param {Object.<number, Metric>} metrics
    * @param {Object.<number, Segment>} segments
    */
+  /* istanbul ignore next */
   _constructor(databases, tables, fields, metrics, segments) {
     this.databases = databases;
     this.tables = tables;

--- a/frontend/src/metabase-lib/lib/metadata/Metric.js
+++ b/frontend/src/metabase-lib/lib/metadata/Metric.js
@@ -61,6 +61,7 @@ export default class Metric extends Base {
    * @param {StructuredQuery} definition
    * @param {boolean} archived
    */
+  /* istanbul ignore next */
   _constructor(name, description, database, table, id, definition, archived) {
     this.name = name;
     this.description = description;

--- a/frontend/src/metabase-lib/lib/metadata/Schema.js
+++ b/frontend/src/metabase-lib/lib/metadata/Schema.js
@@ -20,6 +20,7 @@ export default class Schema extends Base {
    * @param {Database} database
    * @param {Table[]} tables
    */
+  /* istanbul ignore next */
   _constructor(name, database, tables) {
     this.name = name;
     this.database = database;

--- a/frontend/src/metabase-lib/lib/metadata/Segment.js
+++ b/frontend/src/metabase-lib/lib/metadata/Segment.js
@@ -32,6 +32,7 @@ export default class Segment extends Base {
    * @param {number} id
    * @param {boolean} archived
    */
+  /* istanbul ignore next */
   _constructor(name, description, database, table, id, archived) {
     this.name = name;
     this.description = description;

--- a/frontend/src/metabase-lib/lib/metadata/Table.js
+++ b/frontend/src/metabase-lib/lib/metadata/Table.js
@@ -127,6 +127,7 @@ export default class Table extends Base {
    * @param {Field[]} fields
    * @param {EntityType} entity_type
    */
+  /* istanbul ignore next */
   _constructor(description, db, schema, schema_name, fields, entity_type) {
     this.description = description;
     this.db = db;


### PR DESCRIPTION
Those functions ("fake" constructors) are only to provide member type hints, they are safe to ignore. See #17539.

To verify, run:
```
yarn run test-unit --coverage --silent
```
and then open `./coverage/index.html` to see the coverage report.

**Before this PR**

![image](https://user-images.githubusercontent.com/7288/132899416-0c29ddf2-ea23-4429-9a3d-409c2e07ac40.png)

**After this PR**

![image](https://user-images.githubusercontent.com/7288/132899749-37c116d2-bc00-4e55-b937-94e2028116c3.png)

