### PR TITLE
combine sidebar state for various dashboard sidebars

### DIFF
--- a/frontend/src/metabase/dashboard/actions.js
+++ b/frontend/src/metabase/dashboard/actions.js
@@ -83,7 +83,6 @@ const dashboard = new schema.Entity("dashboard", {
 export const INITIALIZE = "metabase/dashboard/INITIALIZE";
 
 export const SET_EDITING_DASHBOARD = "metabase/dashboard/SET_EDITING_DASHBOARD";
-export const SET_SHARING = "metabase/dashboard/SET_SHARING";
 
 // NOTE: this is used in metabase/redux/metadata but can't be imported directly due to circular reference
 export const FETCH_DASHBOARD = "metabase/dashboard/FETCH_DASHBOARD";
@@ -120,8 +119,6 @@ export const CLEAR_CARD_DATA = "metabase/dashboard/CLEAR_CARD_DATA";
 
 export const MARK_NEW_CARD_SEEN = "metabase/dashboard/MARK_NEW_CARD_SEEN";
 
-export const SET_EDITING_PARAMETER_ID =
-  "metabase/dashboard/SET_EDITING_PARAMETER_ID";
 export const ADD_PARAMETER = "metabase/dashboard/ADD_PARAMETER";
 export const REMOVE_PARAMETER = "metabase/dashboard/REMOVE_PARAMETER";
 export const SET_PARAMETER_MAPPING = "metabase/dashboard/SET_PARAMETER_MAPPING";
@@ -136,25 +133,70 @@ export const SHOW_ADD_PARAMETER_POPOVER =
 export const HIDE_ADD_PARAMETER_POPOVER =
   "metabase/dashboard/HIDE_ADD_PARAMETER_POPOVER";
 
-export const SHOW_CLICK_BEHAVIOR_SIDEBAR =
-  "metabase/dashboard/SHOW_CLICK_BEHAVIOR_SIDEBAR";
-export const HIDE_CLICK_BEHAVIOR_SIDEBAR =
-  "metabase/dashboard/HIDE_CLICK_BEHAVIOR_SIDEBAR";
+export const SET_SIDEBAR = "metabase/dashboard/SET_SIDEBAR";
+export const CLOSE_SIDEBAR = "metabase/dashboard/CLOSE_SIDEBAR";
 
 export const initialize = createAction(INITIALIZE);
 export const setEditingDashboard = createAction(SET_EDITING_DASHBOARD);
-export const setSharing = createAction(SET_SHARING);
+
+export const setSidebar = createAction(SET_SIDEBAR);
+export const closeSidebar = createAction(CLOSE_SIDEBAR);
+
+export const setSharing = isSharing => dispatch => {
+  if (isSharing) {
+    dispatch(
+      setSidebar({
+        name: "sharing",
+      }),
+    );
+  } else {
+    dispatch(closeSidebar());
+  }
+};
+
+export const showClickBehaviorSidebar = dashcardId => dispatch => {
+  if (dashcardId != null) {
+    dispatch(
+      setSidebar({
+        name: "click-behavior",
+        props: { dashcardId },
+      }),
+    );
+  } else {
+    dispatch(closeSidebar());
+  }
+};
+
+export const hideClickBehaviorSidebar = () => dispatch => {
+  dispatch(closeSidebar());
+};
+
+export const setEditingParameter = parameterId => dispatch => {
+  if (parameterId != null) {
+    dispatch(
+      setSidebar({
+        name: "edit-parameter",
+        props: {
+          parameterId,
+        },
+      }),
+    );
+  } else {
+    dispatch(closeSidebar());
+  }
+};
+
+export const openAddQuestionSidebar = () => dispatch => {
+  dispatch(
+    setSidebar({
+      name: "add-question",
+    }),
+  );
+};
 
 export const markNewCardSeen = createAction(MARK_NEW_CARD_SEEN);
 export const showAddParameterPopover = createAction(SHOW_ADD_PARAMETER_POPOVER);
 export const hideAddParameterPopover = createAction(HIDE_ADD_PARAMETER_POPOVER);
-export const showClickBehaviorSidebar = createAction(
-  SHOW_CLICK_BEHAVIOR_SIDEBAR,
-);
-export const hideClickBehaviorSidebar = createAction(
-  HIDE_CLICK_BEHAVIOR_SIDEBAR,
-);
-
 // these operations don't get saved to server immediately
 export const setDashboardAttributes = createAction(SET_DASHBOARD_ATTRIBUTES);
 export const setDashCardAttributes = createAction(SET_DASHCARD_ATTRIBUTES);
@@ -706,7 +748,6 @@ export const onReplaceAllDashCardVisualizationSettings = createAction(
   (id, settings) => ({ id, settings }),
 );
 
-export const setEditingParameter = createAction(SET_EDITING_PARAMETER_ID);
 export const setParameterMapping = createThunkAction(
   SET_PARAMETER_MAPPING,
   (parameter_id, dashcard_id, card_id, target) => (dispatch, getState) => {
@@ -767,7 +808,15 @@ export const addParameter = createThunkAction(
       parameter = createParameter(parameterOption, parameters);
       return parameters.concat(parameter);
     });
-    return parameter;
+
+    dispatch(
+      setSidebar({
+        name: "edit-parameter",
+        props: {
+          parameterId: parameter.id,
+        },
+      }),
+    );
   },
 );
 
@@ -777,7 +826,19 @@ export const removeParameter = createThunkAction(
     updateParameters(dispatch, getState, parameters =>
       parameters.filter(p => p.id !== parameterId),
     );
-    return { id: parameterId };
+
+    if (parameterId != null) {
+      dispatch(
+        setSidebar({
+          name: "edit-parameter",
+          props: {
+            parameterId,
+          },
+        }),
+      );
+    } else {
+      dispatch(closeSidebar());
+    }
   },
 );
 

--- a/frontend/src/metabase/dashboard/actions.js
+++ b/frontend/src/metabase/dashboard/actions.js
@@ -167,10 +167,6 @@ export const showClickBehaviorSidebar = dashcardId => dispatch => {
   }
 };
 
-export const hideClickBehaviorSidebar = () => dispatch => {
-  dispatch(closeSidebar());
-};
-
 export const setEditingParameter = parameterId => dispatch => {
   if (parameterId != null) {
     dispatch(

--- a/frontend/src/metabase/dashboard/actions.js
+++ b/frontend/src/metabase/dashboard/actions.js
@@ -23,6 +23,7 @@ import {
   removeDefaultedParametersWithEmptyStringValue,
 } from "metabase/meta/Parameter";
 import * as Urls from "metabase/lib/urls";
+import { SIDEBAR_NAME } from "metabase/dashboard/constants";
 
 import type {
   DashboardWithCards,
@@ -146,7 +147,7 @@ export const setSharing = isSharing => dispatch => {
   if (isSharing) {
     dispatch(
       setSidebar({
-        name: "sharing",
+        name: SIDEBAR_NAME.sharing,
       }),
     );
   } else {
@@ -158,7 +159,7 @@ export const showClickBehaviorSidebar = dashcardId => dispatch => {
   if (dashcardId != null) {
     dispatch(
       setSidebar({
-        name: "click-behavior",
+        name: SIDEBAR_NAME.clickBehavior,
         props: { dashcardId },
       }),
     );
@@ -171,7 +172,7 @@ export const setEditingParameter = parameterId => dispatch => {
   if (parameterId != null) {
     dispatch(
       setSidebar({
-        name: "edit-parameter",
+        name: SIDEBAR_NAME.editParameter,
         props: {
           parameterId,
         },
@@ -185,7 +186,7 @@ export const setEditingParameter = parameterId => dispatch => {
 export const openAddQuestionSidebar = () => dispatch => {
   dispatch(
     setSidebar({
-      name: "add-question",
+      name: SIDEBAR_NAME.addQuestion,
     }),
   );
 };
@@ -807,7 +808,7 @@ export const addParameter = createThunkAction(
 
     dispatch(
       setSidebar({
-        name: "edit-parameter",
+        name: SIDEBAR_NAME.editParameter,
         props: {
           parameterId: parameter.id,
         },
@@ -826,7 +827,7 @@ export const removeParameter = createThunkAction(
     if (parameterId != null) {
       dispatch(
         setSidebar({
-          name: "edit-parameter",
+          name: SIDEBAR_NAME.editParameter,
           props: {
             parameterId,
           },

--- a/frontend/src/metabase/dashboard/actions.unit.spec.js
+++ b/frontend/src/metabase/dashboard/actions.unit.spec.js
@@ -1,0 +1,105 @@
+import {
+  setSidebar,
+  SET_SIDEBAR,
+  closeSidebar,
+  CLOSE_SIDEBAR,
+  setSharing,
+  showClickBehaviorSidebar,
+  setEditingParameter,
+  openAddQuestionSidebar,
+} from "./actions";
+import { SIDEBAR_NAME } from "./constants";
+
+describe("dashboard actions", () => {
+  let dispatch;
+  beforeEach(() => {
+    dispatch = jest.fn();
+  });
+
+  describe("setSidebar", () => {
+    it("should create a SET_SIDEBAR action with sidebar payload", () => {
+      const sidebar = {
+        name: SIDEBAR_NAME.sharing,
+      };
+
+      expect(setSidebar(sidebar)).toEqual({
+        type: SET_SIDEBAR,
+        payload: sidebar,
+      });
+    });
+  });
+
+  describe("closeSidebar", () => {
+    it("should create a CLOSE_SIDEBAR action", () => {
+      expect(closeSidebar()).toEqual({
+        type: CLOSE_SIDEBAR,
+      });
+    });
+  });
+
+  describe("setSharing", () => {
+    it("should set a sharing sidebar when the `isSharing` boolean arg is true", () => {
+      setSharing(true)(dispatch);
+
+      expect(dispatch).toHaveBeenCalledWith(
+        setSidebar({ name: SIDEBAR_NAME.sharing }),
+      );
+    });
+
+    it("should clear sidebar state when the `isSharing` boolean arg is false", () => {
+      setSharing(false)(dispatch);
+
+      expect(dispatch).toHaveBeenCalledWith(closeSidebar());
+    });
+  });
+
+  describe("showClickBehaviorSidebar", () => {
+    it("should set a click behavior sidebar when given a dashcardId", () => {
+      showClickBehaviorSidebar(0)(dispatch);
+
+      expect(dispatch).toHaveBeenCalledWith(
+        setSidebar({
+          name: SIDEBAR_NAME.clickBehavior,
+          props: { dashcardId: 0 },
+        }),
+      );
+    });
+
+    it("should clear sidebar state when given a nil dashcardId", () => {
+      showClickBehaviorSidebar(null)(dispatch);
+
+      expect(dispatch).toHaveBeenCalledWith(closeSidebar());
+    });
+  });
+
+  describe("setEditingParameter", () => {
+    it("should set an edit parameter sidebar when given a parameterId", () => {
+      setEditingParameter(0)(dispatch);
+
+      expect(dispatch).toHaveBeenCalledWith(
+        setSidebar({
+          name: SIDEBAR_NAME.editParameter,
+          props: { parameterId: 0 },
+        }),
+      );
+    });
+
+    it("should clear sidebar state when given a nil parameterId", () => {
+      setEditingParameter()(dispatch);
+
+      expect(dispatch).toHaveBeenCalledWith(closeSidebar());
+    });
+  });
+
+  describe("openAddQuestionSidebar", () => {
+    it("should set an add question sidebar", () => {
+      openAddQuestionSidebar()(dispatch);
+
+      expect(dispatch).toHaveBeenCalledWith(
+        setSidebar({
+          name: SIDEBAR_NAME.addQuestion,
+        }),
+      );
+    });
+  });
+});

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -27,7 +27,6 @@ const SCROLL_THROTTLE_INTERVAL = 1000 / 24;
 export default class Dashboard extends Component {
   state = {
     error: null,
-    showAddQuestionSidebar: false,
     isParametersWidgetSticky: false,
   };
 
@@ -71,6 +70,14 @@ export default class Dashboard extends Component {
 
     onSharingClick: PropTypes.func,
     onEmbeddingClick: PropTypes.any,
+
+    sidebar: PropTypes.shape({
+      name: PropTypes.string,
+      props: PropTypes.object,
+    }).isRequired,
+    closeSidebar: PropTypes.func.isRequired,
+    openAddQuestionSidebar: PropTypes.func.isRequired,
+    showAddQuestionSidebar: PropTypes.bool.isRequired,
   };
 
   static defaultProps = {
@@ -155,10 +162,6 @@ export default class Dashboard extends Component {
   setEditing = isEditing => {
     this.props.onRefreshPeriodChange(null);
     this.props.setEditingDashboard(isEditing);
-
-    this.setState({
-      showAddQuestionSidebar: false,
-    });
   };
 
   setDashboardAttribute = (attribute, value) => {
@@ -169,9 +172,11 @@ export default class Dashboard extends Component {
   };
 
   onToggleAddQuestionSidebar = () => {
-    this.setState(prev => ({
-      showAddQuestionSidebar: !prev.showAddQuestionSidebar,
-    }));
+    if (this.props.showAddQuestionSidebar) {
+      this.props.closeSidebar();
+    } else {
+      this.props.openAddQuestionSidebar();
+    }
   };
 
   onCancel = () => {
@@ -192,13 +197,10 @@ export default class Dashboard extends Component {
       isFullscreen,
       isNightMode,
       isSharing,
+      showAddQuestionSidebar,
     } = this.props;
 
-    const {
-      error,
-      isParametersWidgetSticky,
-      showAddQuestionSidebar,
-    } = this.state;
+    const { error, isParametersWidgetSticky } = this.state;
 
     const shouldRenderAsNightMode = isNightMode && isFullscreen;
     const dashboardHasCards = dashboard => dashboard.ordered_cards.length > 0;

--- a/frontend/src/metabase/dashboard/components/DashboardSidebars.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardSidebars.jsx
@@ -2,6 +2,8 @@ import React, { useCallback } from "react";
 import PropTypes from "prop-types";
 import _ from "underscore";
 
+import { SIDEBAR_NAME } from "metabase/dashboard/constants";
+
 import ClickBehaviorSidebar from "./ClickBehaviorSidebar";
 import ParameterSidebar from "metabase/parameters/components/ParameterSidebar";
 import SharingSidebar from "metabase/sharing/components/SharingSidebar";
@@ -83,14 +85,14 @@ export function DashboardSidebars({
   }
 
   switch (sidebar.name) {
-    case "add-question":
+    case SIDEBAR_NAME.addQuestion:
       return (
         <AddCardSidebar
           initialCollection={dashboard.collection_id}
           onSelect={handleAddCard}
         />
       );
-    case "click-behavior":
+    case SIDEBAR_NAME.clickBehavior:
       return (
         <ClickBehaviorSidebar
           dashboard={dashboard}
@@ -107,7 +109,7 @@ export function DashboardSidebars({
           }
         />
       );
-    case "edit-parameter": {
+    case SIDEBAR_NAME.editParameter: {
       const { id: editingParameterId } = editingParameter || {};
       const [[parameter], otherParameters] = _.partition(
         parameters,
@@ -134,7 +136,7 @@ export function DashboardSidebars({
         />
       );
     }
-    case "sharing":
+    case SIDEBAR_NAME.sharing:
       return (
         <SharingSidebar
           dashboard={dashboard}

--- a/frontend/src/metabase/dashboard/components/DashboardSidebars.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardSidebars.jsx
@@ -34,6 +34,11 @@ DashboardSidebars.propTypes = {
   isFullscreen: PropTypes.bool.isRequired,
   onCancel: PropTypes.func.isRequired,
   params: PropTypes.object,
+  sidebar: PropTypes.shape({
+    name: PropTypes.string,
+    props: PropTypes.object,
+  }).isRequired,
+  closeSidebar: PropTypes.func.isRequired,
 };
 
 export function DashboardSidebars({
@@ -61,6 +66,8 @@ export function DashboardSidebars({
   isFullscreen,
   onCancel,
   params,
+  sidebar,
+  closeSidebar,
 }) {
   const handleAddCard = useCallback(
     cardId => {
@@ -73,72 +80,71 @@ export function DashboardSidebars({
     [addCardToDashboard, dashboard.id],
   );
 
-  if (showAddQuestionSidebar) {
-    return (
-      <AddCardSidebar
-        initialCollection={dashboard.collection_id}
-        onSelect={handleAddCard}
-      />
-    );
+  if (isFullscreen) {
+    return null;
   }
 
-  if (clickBehaviorSidebarDashcard) {
-    return (
-      <ClickBehaviorSidebar
-        dashboard={dashboard}
-        dashcard={clickBehaviorSidebarDashcard}
-        parameters={parameters}
-        dashcardData={dashcardData[clickBehaviorSidebarDashcard.id]}
-        onUpdateDashCardVisualizationSettings={
-          onUpdateDashCardVisualizationSettings
-        }
-        onUpdateDashCardColumnSettings={onUpdateDashCardColumnSettings}
-        hideClickBehaviorSidebar={hideClickBehaviorSidebar}
-        onReplaceAllDashCardVisualizationSettings={
-          onReplaceAllDashCardVisualizationSettings
-        }
-      />
-    );
+  switch (sidebar.name) {
+    case "add-question":
+      return (
+        <AddCardSidebar
+          initialCollection={dashboard.collection_id}
+          onSelect={handleAddCard}
+        />
+      );
+    case "click-behavior":
+      return (
+        <ClickBehaviorSidebar
+          dashboard={dashboard}
+          dashcard={clickBehaviorSidebarDashcard}
+          parameters={parameters}
+          dashcardData={dashcardData[clickBehaviorSidebarDashcard.id]}
+          onUpdateDashCardVisualizationSettings={
+            onUpdateDashCardVisualizationSettings
+          }
+          onUpdateDashCardColumnSettings={onUpdateDashCardColumnSettings}
+          hideClickBehaviorSidebar={hideClickBehaviorSidebar}
+          onReplaceAllDashCardVisualizationSettings={
+            onReplaceAllDashCardVisualizationSettings
+          }
+        />
+      );
+    case "edit-parameter": {
+      const { id: editingParameterId } = editingParameter || {};
+      const [[parameter], otherParameters] = _.partition(
+        parameters,
+        p => p.id === editingParameterId,
+      );
+      return (
+        <ParameterSidebar
+          parameter={parameter}
+          otherParameters={otherParameters}
+          remove={() => {
+            closeSidebar();
+            removeParameter(editingParameterId);
+          }}
+          done={() => closeSidebar()}
+          showAddParameterPopover={showAddParameterPopover}
+          setParameter={setParameter}
+          setName={name => setParameterName(editingParameterId, name)}
+          setDefaultValue={value =>
+            setParameterDefaultValue(editingParameterId, value)
+          }
+          setFilteringParameters={ids =>
+            setParameterFilteringParameters(editingParameterId, ids)
+          }
+        />
+      );
+    }
+    case "sharing":
+      return (
+        <SharingSidebar
+          dashboard={dashboard}
+          params={params}
+          onCancel={onCancel}
+        />
+      );
+    default:
+      return null;
   }
-
-  if (isEditingParameter) {
-    const { id: editingParameterId } = editingParameter || {};
-    const [[parameter], otherParameters] = _.partition(
-      parameters,
-      p => p.id === editingParameterId,
-    );
-    return (
-      <ParameterSidebar
-        parameter={parameter}
-        otherParameters={otherParameters}
-        remove={() => {
-          setEditingParameter(null);
-          removeParameter(editingParameterId);
-        }}
-        done={() => setEditingParameter(null)}
-        showAddParameterPopover={showAddParameterPopover}
-        setParameter={setParameter}
-        setName={name => setParameterName(editingParameterId, name)}
-        setDefaultValue={value =>
-          setParameterDefaultValue(editingParameterId, value)
-        }
-        setFilteringParameters={ids =>
-          setParameterFilteringParameters(editingParameterId, ids)
-        }
-      />
-    );
-  }
-
-  const shouldShowSidebar = !isEditing && !isFullscreen && isSharing;
-  if (shouldShowSidebar) {
-    return (
-      <SharingSidebar
-        dashboard={dashboard}
-        params={params}
-        onCancel={onCancel}
-      />
-    );
-  }
-
-  return null;
 }

--- a/frontend/src/metabase/dashboard/components/DashboardSidebars.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardSidebars.jsx
@@ -22,7 +22,6 @@ DashboardSidebars.propTypes = {
   onReplaceAllDashCardVisualizationSettings: PropTypes.func.isRequired,
   onUpdateDashCardVisualizationSettings: PropTypes.func.isRequired,
   onUpdateDashCardColumnSettings: PropTypes.func.isRequired,
-  hideClickBehaviorSidebar: PropTypes.func.isRequired,
   setEditingParameter: PropTypes.func.isRequired,
   setParameter: PropTypes.func.isRequired,
   setParameterName: PropTypes.func.isRequired,
@@ -54,7 +53,6 @@ export function DashboardSidebars({
   onReplaceAllDashCardVisualizationSettings,
   onUpdateDashCardVisualizationSettings,
   onUpdateDashCardColumnSettings,
-  hideClickBehaviorSidebar,
   setEditingParameter,
   setParameter,
   setParameterName,
@@ -103,7 +101,7 @@ export function DashboardSidebars({
             onUpdateDashCardVisualizationSettings
           }
           onUpdateDashCardColumnSettings={onUpdateDashCardColumnSettings}
-          hideClickBehaviorSidebar={hideClickBehaviorSidebar}
+          hideClickBehaviorSidebar={closeSidebar}
           onReplaceAllDashCardVisualizationSettings={
             onReplaceAllDashCardVisualizationSettings
           }

--- a/frontend/src/metabase/dashboard/constants.js
+++ b/frontend/src/metabase/dashboard/constants.js
@@ -1,0 +1,6 @@
+export const SIDEBAR_NAME = {
+  addQuestion: "addQuestion",
+  clickBehavior: "clickBehavior",
+  editParameter: "editParameter",
+  sharing: "sharing",
+};

--- a/frontend/src/metabase/dashboard/containers/DashboardApp.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp.jsx
@@ -26,6 +26,8 @@ import {
   getLoadingStartTime,
   getClickBehaviorSidebarDashcard,
   getIsAddParameterPopoverOpen,
+  getSidebar,
+  getShowAddQuestionSidebar,
 } from "../selectors";
 import { getDatabases, getMetadata } from "metabase/selectors/metadata";
 import { getUserIsAdmin } from "metabase/selectors/user";
@@ -57,6 +59,8 @@ const mapStateToProps = (state, props) => {
     loadingStartTime: getLoadingStartTime(state),
     clickBehaviorSidebarDashcard: getClickBehaviorSidebarDashcard(state),
     isAddParameterPopoverOpen: getIsAddParameterPopoverOpen(state),
+    sidebar: getSidebar(state),
+    showAddQuestionSidebar: getShowAddQuestionSidebar(state),
   };
 };
 

--- a/frontend/src/metabase/dashboard/reducers.js
+++ b/frontend/src/metabase/dashboard/reducers.js
@@ -5,7 +5,6 @@ import {
   INITIALIZE,
   FETCH_DASHBOARD,
   SET_EDITING_DASHBOARD,
-  SET_SHARING,
   SET_DASHBOARD_ATTRIBUTES,
   ADD_CARD_TO_DASH,
   CREATE_PUBLIC_LINK,
@@ -19,8 +18,6 @@ import {
   REPLACE_ALL_DASHCARD_VISUALIZATION_SETTINGS,
   REMOVE_CARD_FROM_DASH,
   MARK_NEW_CARD_SEEN,
-  SET_EDITING_PARAMETER_ID,
-  ADD_PARAMETER,
   REMOVE_PARAMETER,
   FETCH_CARD_DATA,
   CLEAR_CARD_DATA,
@@ -31,8 +28,8 @@ import {
   CANCEL_FETCH_CARD_DATA,
   SHOW_ADD_PARAMETER_POPOVER,
   HIDE_ADD_PARAMETER_POPOVER,
-  SHOW_CLICK_BEHAVIOR_SIDEBAR,
-  HIDE_CLICK_BEHAVIOR_SIDEBAR,
+  SET_SIDEBAR,
+  CLOSE_SIDEBAR,
 } from "./actions";
 
 import { isVirtualDashCard, syncParametersAndEmbeddingParams } from "./utils";
@@ -52,16 +49,6 @@ const isEditing = handleActions(
     [INITIALIZE]: { next: state => null },
     [SET_EDITING_DASHBOARD]: {
       next: (state, { payload }) => (payload ? payload : null),
-    },
-  },
-  {},
-);
-
-const isSharing = handleActions(
-  {
-    [INITIALIZE]: { next: state => false },
-    [SET_SHARING]: {
-      next: (state, { payload }) => payload || false,
     },
   },
   {},
@@ -206,22 +193,6 @@ const dashcards = handleActions(
   {},
 );
 
-const editingParameterId = handleActions(
-  {
-    [SET_EDITING_PARAMETER_ID]: { next: (state, { payload }) => payload },
-    [ADD_PARAMETER]: { next: (state, { payload: { id } }) => id },
-    // possibly clear state:
-    [REMOVE_PARAMETER]: {
-      next: (state, { payload: { id } }) => (state === id ? null : state),
-    },
-    [SET_EDITING_DASHBOARD]: {
-      next: (state, { payload }) => (payload ? state : null),
-    },
-    [INITIALIZE]: { next: state => null },
-  },
-  null,
-);
-
 const isAddParameterPopoverOpen = handleActions(
   {
     [SHOW_ADD_PARAMETER_POPOVER]: () => true,
@@ -229,20 +200,6 @@ const isAddParameterPopoverOpen = handleActions(
     [INITIALIZE]: () => false,
   },
   false,
-);
-
-const clickBehaviorSidebarDashcardId = handleActions(
-  {
-    [SHOW_CLICK_BEHAVIOR_SIDEBAR]: (state, { payload }) => payload,
-    [HIDE_CLICK_BEHAVIOR_SIDEBAR]: state => null,
-    // possibly clear state:
-    [SET_EDITING_DASHBOARD]: (state, { payload }) => (payload ? state : null),
-    [SET_EDITING_PARAMETER_ID]: (state, { payload }) =>
-      payload != null ? null : state,
-    [ADD_PARAMETER]: (state, { payload }) => null,
-    [INITIALIZE]: state => null,
-  },
-  null,
 );
 
 const dashcardData = handleActions(
@@ -342,17 +299,36 @@ const loadingDashCards = handleActions(
   { dashcardIds: [], loadingIds: [], startTime: null },
 );
 
+const sidebar = handleActions(
+  {
+    [SET_SIDEBAR]: {
+      next: (state, { payload: { name, props } }) => ({
+        name,
+        props: props || {},
+      }),
+    },
+    [CLOSE_SIDEBAR]: {
+      next: () => ({}),
+    },
+    [INITIALIZE]: {
+      next: () => ({}),
+    },
+    [SET_EDITING_DASHBOARD]: {
+      next: (state, { payload }) => (payload ? state : {}),
+    },
+  },
+  {},
+);
+
 export default combineReducers({
   dashboardId,
   isEditing,
-  isSharing,
   dashboards,
   dashcards,
-  editingParameterId,
-  clickBehaviorSidebarDashcardId,
   dashcardData,
   slowCards,
   parameterValues,
   loadingDashCards,
   isAddParameterPopoverOpen,
+  sidebar,
 });

--- a/frontend/src/metabase/dashboard/reducers.js
+++ b/frontend/src/metabase/dashboard/reducers.js
@@ -314,7 +314,7 @@ const sidebar = handleActions(
       next: () => ({}),
     },
     [SET_EDITING_DASHBOARD]: {
-      next: (state, { payload }) => (payload ? state : {}),
+      next: (state, { payload: isEditing }) => (isEditing ? state : {}),
     },
   },
   {},

--- a/frontend/src/metabase/dashboard/reducers.unit.spec.js
+++ b/frontend/src/metabase/dashboard/reducers.unit.spec.js
@@ -1,0 +1,119 @@
+import reducer from "./reducers";
+import {
+  INITIALIZE,
+  SET_EDITING_DASHBOARD,
+  SET_SIDEBAR,
+  CLOSE_SIDEBAR,
+} from "./actions";
+
+describe("dashboard reducers", () => {
+  let initState;
+  beforeEach(() => {
+    initState = reducer(undefined, {});
+  });
+
+  it("should return the initial state", () => {
+    expect(initState).toEqual({
+      dashboardId: null,
+      dashboards: {},
+      dashcardData: {},
+      dashcards: {},
+      isAddParameterPopoverOpen: false,
+      isEditing: {},
+      loadingDashCards: {
+        dashcardIds: [],
+        loadingIds: [],
+        startTime: null,
+      },
+      parameterValues: {},
+      sidebar: {},
+      slowCards: {},
+    });
+  });
+
+  describe("SET_SIDEBAR", () => {
+    it("should set the sidebar", () => {
+      expect(
+        reducer(undefined, {
+          type: SET_SIDEBAR,
+          payload: { name: "foo", props: { abc: 123 } },
+        }),
+      ).toEqual({
+        ...initState,
+        sidebar: { name: "foo", props: { abc: 123 } },
+      });
+    });
+
+    it("should default `props` to an object", () => {
+      expect(
+        reducer(undefined, {
+          type: SET_SIDEBAR,
+          payload: { name: "foo" },
+        }),
+      ).toEqual({
+        ...initState,
+        sidebar: { name: "foo", props: {} },
+      });
+    });
+  });
+
+  describe("CLOSE_SIDEBAR", () => {
+    it("should return `sidebar` to initial state", () => {
+      expect(
+        reducer(
+          {
+            ...initState,
+            sidebar: { name: "foo", props: { abc: 123 } },
+          },
+          {
+            type: CLOSE_SIDEBAR,
+          },
+        ),
+      ).toEqual(initState);
+    });
+  });
+
+  describe("INITIALIZE", () => {
+    it("should return `sidebar` to initial state", () => {
+      expect(
+        reducer(
+          {
+            ...initState,
+            sidebar: { name: "foo", props: { abc: 123 } },
+          },
+          {
+            type: INITIALIZE,
+          },
+        ),
+      ).toEqual({ ...initState, isEditing: null });
+    });
+  });
+
+  describe("SET_EDITING_DASHBOARD", () => {
+    it("should preserve sidebar state if payload is true to signify the entering of dashboard edit mode", () => {
+      const state = {
+        ...initState,
+        sidebar: { name: "foo", props: { abc: 123 } },
+      };
+      expect(
+        reducer(state, {
+          type: SET_EDITING_DASHBOARD,
+          payload: true,
+        }),
+      ).toEqual({ ...state, isEditing: true });
+    });
+
+    it("should clear sideabr state when leaving edit mode", () => {
+      const state = {
+        ...initState,
+        sidebar: { name: "foo", props: { abc: 123 } },
+      };
+      expect(
+        reducer(state, {
+          type: SET_EDITING_DASHBOARD,
+          payload: false,
+        }),
+      ).toEqual({ ...initState, isEditing: null });
+    });
+  });
+});

--- a/frontend/src/metabase/dashboard/selectors.js
+++ b/frontend/src/metabase/dashboard/selectors.js
@@ -53,9 +53,11 @@ export const getLoadingStartTime = state =>
 export const getIsAddParameterPopoverOpen = state =>
   state.dashboard.isAddParameterPopoverOpen;
 
-export const getIsSharing = state =>
-  state.dashboard.sidebar.name === SIDEBAR_NAME.sharing;
 export const getSidebar = state => state.dashboard.sidebar;
+export const getIsSharing = createSelector(
+  [getSidebar],
+  sidebar => sidebar.name === SIDEBAR_NAME.sharing,
+);
 
 export const getShowAddQuestionSidebar = createSelector(
   [getSidebar],
@@ -99,7 +101,7 @@ export const getEditingParameterId = createSelector(
   [getSidebar],
   sidebar => {
     return sidebar.name === SIDEBAR_NAME.editParameter
-      ? sidebar.props.parameterId
+      ? sidebar.props?.parameterId
       : null;
   },
 );

--- a/frontend/src/metabase/dashboard/selectors.js
+++ b/frontend/src/metabase/dashboard/selectors.js
@@ -35,11 +35,12 @@ export type MappingsByParameter = {
 
 export const getDashboardId = state => state.dashboard.dashboardId;
 export const getIsEditing = state => !!state.dashboard.isEditing;
-export const getIsSharing = state => !!state.dashboard.isSharing;
 export const getDashboardBeforeEditing = state => state.dashboard.isEditing;
 export const getClickBehaviorSidebarDashcard = state => {
-  const { clickBehaviorSidebarDashcardId, dashcards } = state.dashboard;
-  return dashcards[clickBehaviorSidebarDashcardId];
+  const { sidebar, dashcards } = state.dashboard;
+  return sidebar.name === "click-behavior"
+    ? dashcards[sidebar.props.dashcardId]
+    : null;
 };
 export const getDashboards = state => state.dashboard.dashboards;
 export const getDashcards = state => state.dashboard.dashcards;
@@ -50,6 +51,14 @@ export const getLoadingStartTime = state =>
   state.dashboard.loadingDashCards.startTime;
 export const getIsAddParameterPopoverOpen = state =>
   state.dashboard.isAddParameterPopoverOpen;
+
+export const getIsSharing = state => state.dashboard.sidebar.name === "sharing";
+export const getSidebar = state => state.dashboard.sidebar;
+
+export const getShowAddQuestionSidebar = createSelector(
+  [getSidebar],
+  sidebar => sidebar.name === "add-question",
+);
 
 export const getDashboard = createSelector(
   [getDashboardId, getDashboards],
@@ -84,8 +93,17 @@ export const getIsDirty = createSelector(
     ),
 );
 
-export const getEditingParameterId = state =>
-  state.dashboard.editingParameterId;
+export const getEditingParameterId = createSelector(
+  [getSidebar],
+  sidebar => {
+    return sidebar.name === "edit-parameter" ? sidebar.props.parameterId : null;
+  },
+);
+
+export const getIsEditingParameter = createSelector(
+  [getEditingParameterId],
+  parameterId => parameterId != null,
+);
 
 export const getEditingParameter = createSelector(
   [getDashboard, getEditingParameterId],
@@ -94,9 +112,6 @@ export const getEditingParameter = createSelector(
       ? _.findWhere(dashboard.parameters, { id: editingParameterId })
       : null,
 );
-
-export const getIsEditingParameter = state =>
-  state.dashboard.editingParameterId != null;
 
 const getCard = (state, props) => props.card;
 const getDashCard = (state, props) => props.dashcard;

--- a/frontend/src/metabase/dashboard/selectors.js
+++ b/frontend/src/metabase/dashboard/selectors.js
@@ -8,6 +8,7 @@ import { getMetadata } from "metabase/selectors/metadata";
 import * as Dashboard from "metabase/meta/Dashboard";
 
 import { getParameterTargetFieldId } from "metabase/meta/Parameter";
+import { SIDEBAR_NAME } from "metabase/dashboard/constants";
 
 import type { CardId, Card } from "metabase-types/types/Card";
 import type { DashCardId } from "metabase-types/types/Dashboard";
@@ -38,7 +39,7 @@ export const getIsEditing = state => !!state.dashboard.isEditing;
 export const getDashboardBeforeEditing = state => state.dashboard.isEditing;
 export const getClickBehaviorSidebarDashcard = state => {
   const { sidebar, dashcards } = state.dashboard;
-  return sidebar.name === "click-behavior"
+  return sidebar.name === SIDEBAR_NAME.clickBehavior
     ? dashcards[sidebar.props.dashcardId]
     : null;
 };
@@ -52,12 +53,13 @@ export const getLoadingStartTime = state =>
 export const getIsAddParameterPopoverOpen = state =>
   state.dashboard.isAddParameterPopoverOpen;
 
-export const getIsSharing = state => state.dashboard.sidebar.name === "sharing";
+export const getIsSharing = state =>
+  state.dashboard.sidebar.name === SIDEBAR_NAME.sharing;
 export const getSidebar = state => state.dashboard.sidebar;
 
 export const getShowAddQuestionSidebar = createSelector(
   [getSidebar],
-  sidebar => sidebar.name === "add-question",
+  sidebar => sidebar.name === SIDEBAR_NAME.addQuestion,
 );
 
 export const getDashboard = createSelector(
@@ -96,7 +98,9 @@ export const getIsDirty = createSelector(
 export const getEditingParameterId = createSelector(
   [getSidebar],
   sidebar => {
-    return sidebar.name === "edit-parameter" ? sidebar.props.parameterId : null;
+    return sidebar.name === SIDEBAR_NAME.editParameter
+      ? sidebar.props.parameterId
+      : null;
   },
 );
 

--- a/frontend/src/metabase/dashboard/selectors.unit.spec.js
+++ b/frontend/src/metabase/dashboard/selectors.unit.spec.js
@@ -1,5 +1,13 @@
-// import { getMetadata } from "metabase/selectors/metadata";
-import { getParameters } from "metabase/dashboard/selectors";
+import {
+  getParameters,
+  getSidebar,
+  getShowAddQuestionSidebar,
+  getIsSharing,
+  getEditingParameterId,
+  getIsEditingParameter,
+  getClickBehaviorSidebarDashcard,
+} from "metabase/dashboard/selectors";
+import { SIDEBAR_NAME } from "./constants";
 
 import { chain } from "icepick";
 
@@ -22,6 +30,7 @@ const STATE = {
         parameter_mappings: [],
       },
     },
+    sidebar: {},
   },
   entities: {
     databases: {},
@@ -158,6 +167,135 @@ describe("dashboard/selectors", () => {
           hasOnlyFieldTargets: true,
         },
       ]);
+    });
+  });
+
+  describe("getSidebar", () => {
+    it("should return the sidebar property", () => {
+      expect(getSidebar(STATE)).toBe(STATE.dashboard.sidebar);
+    });
+  });
+
+  describe("getShowAddQuestionSidebar", () => {
+    it("should return false when sidebar is not set to the add question sidebar", () => {
+      expect(getShowAddQuestionSidebar(STATE)).toBe(false);
+    });
+
+    it("should returnftrue when the sidebar is set to the add question sidebar", () => {
+      const state = {
+        ...STATE,
+        dashboard: {
+          ...STATE.dashboard,
+          sidebar: {
+            name: SIDEBAR_NAME.addQuestion,
+          },
+        },
+      };
+
+      expect(getShowAddQuestionSidebar(state)).toBe(true);
+    });
+  });
+
+  describe("getIsSharing", () => {
+    it("should return false when dashboard is not shared", () => {
+      expect(getIsSharing(STATE)).toBe(false);
+    });
+
+    it("should return true when dashboard is shared", () => {
+      const state = {
+        ...STATE,
+        dashboard: {
+          ...STATE.dashboard,
+          sidebar: {
+            name: SIDEBAR_NAME.sharing,
+          },
+        },
+      };
+
+      expect(getIsSharing(state)).toBe(true);
+    });
+  });
+
+  describe("getEditingParameterId", () => {
+    it("should return null when the edit parameter sidebar is not open", () => {
+      expect(getEditingParameterId(STATE)).toBe(null);
+    });
+
+    it("should return the editing parameter id", () => {
+      const state = {
+        ...STATE,
+        dashboard: {
+          ...STATE.dashboard,
+          sidebar: {
+            name: SIDEBAR_NAME.editParameter,
+            props: { parameterId: 1 },
+          },
+        },
+      };
+
+      expect(getEditingParameterId(state)).toBe(1);
+    });
+  });
+
+  describe("getIsEditingParameterId", () => {
+    it("should return false when the edit parameter sidebar is not open", () => {
+      expect(getIsEditingParameter(STATE)).toBe(false);
+    });
+
+    it("should return false when the edit parameter sidebar is open but there is no set parameterId", () => {
+      const state = {
+        ...STATE,
+        dashboard: {
+          ...STATE.dashboard,
+          sidebar: {
+            name: SIDEBAR_NAME.editParameter,
+          },
+        },
+      };
+
+      expect(getIsEditingParameter(state)).toBe(false);
+    });
+
+    it("should return true when the edit parameter sidebar is open and there is a set parameterId", () => {
+      const state = {
+        ...STATE,
+        dashboard: {
+          ...STATE.dashboard,
+          sidebar: {
+            name: SIDEBAR_NAME.editParameter,
+            props: {
+              parameterId: 0,
+            },
+          },
+        },
+      };
+
+      expect(getIsEditingParameter(state)).toBe(true);
+    });
+  });
+
+  describe("getClickBehaviorSidebarDashcard", () => {
+    it("should return null when the click behavior sidebar is not open", () => {
+      expect(getClickBehaviorSidebarDashcard(STATE)).toBe(null);
+    });
+
+    it("should return the dashboard associated with the given set dashcardId if the click behavior sidebar is open", () => {
+      const state = {
+        ...STATE,
+        dashboard: {
+          ...STATE.dashboard,
+          sidebar: {
+            name: SIDEBAR_NAME.clickBehavior,
+            props: {
+              dashcardId: 1,
+            },
+          },
+        },
+      };
+
+      expect(getClickBehaviorSidebarDashcard(state)).toEqual(
+        state.dashboard.dashcards[1],
+      );
     });
   });
 });


### PR DESCRIPTION
Fixes #16783 

This PR half-cleans up code for managing sidebar state in dashboards. I've moved all sidebar state in redux to `state.dashboard.sidebar` for better management of the various sidebar states (closed, sharing, click behavior, editing a parameter, adding a question).

To avoid making this too big of a change I've limited this clean up to redux code + the fix in the `DashboardSidebars` component. That means there's a bit of redundant code added for selectors / actions currently in use that now all trigger `SET_SIDEBAR` or `CLOSE_SIDEBAR` under the hood. That can get cleaned up later.

Recording of me opening/closing various dash sidebars

https://user-images.githubusercontent.com/13057258/133175037-d9973b32-a059-4bc2-a330-c683ac38e330.mov

