### PR TITLE
move fullscreen toggle onClick to button from icon el

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashboardActions.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardActions.jsx
@@ -191,11 +191,12 @@ export const getDashboardActions = (
         <span
           data-metabase-event={"Dashboard;Fullscreen Mode;" + !isFullscreen}
         >
-          <DashboardHeaderButton>
+          <DashboardHeaderButton
+            onClick={e => onFullscreenChange(!isFullscreen, !e.altKey)}
+          >
             <FullscreenIcon
-              className="text-brand-hover cursor-pointer"
+              className="text-brand-hover"
               isFullscreen={isFullscreen}
-              onClick={e => onFullscreenChange(!isFullscreen, !e.altKey)}
             />
           </DashboardHeaderButton>
         </span>


### PR DESCRIPTION
The `onClick` callback for the fullscreen toggle icon button was on the `Icon` component and not the `button`. This caused a deadzone where nothing happened when you clicked the button.

Before:

https://user-images.githubusercontent.com/13057258/132913281-587073d8-1032-4948-beb2-ced0c2672bed.mov

After:

https://user-images.githubusercontent.com/13057258/132913332-2fab682b-daa5-4a00-94f8-cbe7480923df.mov

