### PR TITLE
Update logic to hide db add/edit fields

### DIFF
--- a/frontend/src/metabase/entities/databases/forms.js
+++ b/frontend/src/metabase/entities/databases/forms.js
@@ -206,32 +206,46 @@ function getEngineInfo(engine, details, id) {
   }
 }
 
-function isHiddenField(field, details) {
-  // NOTE: special case to hide tunnel settings if tunnel is disabled
-  const isDisabledTunnelSettingsField =
-    field.name.startsWith("tunnel-") &&
-    field.name !== "tunnel-enabled" &&
-    !details["tunnel-enabled"];
+// function isHiddenField(field, details) {
+//   // NOTE: special case to hide tunnel settings if tunnel is disabled
+//   const isDisabledTunnelSettingsField =
+//     field.name.startsWith("tunnel-") &&
+//     field.name !== "tunnel-enabled" &&
+//     !details["tunnel-enabled"];
 
-  // hide the auth settings based on which auth method is selected
-  // private key auth needs tunnel-private-key and tunnel-private-key-passphrase
-  const isTunnelPrivateFieldWithoutProperAuthMethod =
-    field.name.startsWith("tunnel-private-") &&
-    details["tunnel-auth-option"] !== "ssh-key";
+//   // hide the auth settings based on which auth method is selected
+//   // private key auth needs tunnel-private-key and tunnel-private-key-passphrase
+//   const isTunnelPrivateFieldWithoutProperAuthMethod =
+//     field.name.startsWith("tunnel-private-") &&
+//     details["tunnel-auth-option"] !== "ssh-key";
 
-  // username / password auth uses tunnel-pass
-  const isTunnelPassFieldWithoutProperAuthMethod =
-    field.name === "tunnel-pass" && details["tunnel-auth-option"] === "ssh-key";
+//   // username / password auth uses tunnel-pass
+//   const isTunnelPassFieldWithoutProperAuthMethod =
+//     field.name === "tunnel-pass" && details["tunnel-auth-option"] === "ssh-key";
 
-  // NOTE: special case to hide the SSL cert field if SSL is disabled
-  const isDisabledSslField = field.name === "ssl-cert" && !details["ssl"];
+//   // NOTE: special case to hide the SSL cert field if SSL is disabled
+//   const isDisabledSslField = field.name === "ssl-cert" && !details["ssl"];
 
-  return (
-    isDisabledTunnelSettingsField ||
-    isTunnelPrivateFieldWithoutProperAuthMethod ||
-    isTunnelPassFieldWithoutProperAuthMethod ||
-    isDisabledSslField
-  );
+//   return (
+//     isDisabledTunnelSettingsField ||
+//     isTunnelPrivateFieldWithoutProperAuthMethod ||
+//     isTunnelPassFieldWithoutProperAuthMethod ||
+//     isDisabledSslField
+//   );
+// }
+
+function shouldShowEngineProvidedField(field, details) {
+  const detailAndValueRequiredToShowField = field["visible-if"];
+
+  if (!detailAndValueRequiredToShowField) {
+    return true;
+  }
+
+  const [detail, expectedDetailValue] = Object.entries(
+    detailAndValueRequiredToShowField,
+  )[0];
+
+  return details[detail] === expectedDetailValue;
 }
 
 function getDefaultValue(field) {
@@ -257,7 +271,7 @@ function getEngineFormFields(engine, details, id) {
 
   // convert database details-fields to Form fields
   return engineFields
-    .filter(field => !isHiddenField(field, details))
+    .filter(field => shouldShowEngineProvidedField(field, details))
     .map(field => {
       const overrides = DATABASE_DETAIL_OVERRIDES[field.name];
 

--- a/frontend/src/metabase/entities/databases/forms.js
+++ b/frontend/src/metabase/entities/databases/forms.js
@@ -209,15 +209,15 @@ function getEngineInfo(engine, details, id) {
 function shouldShowEngineProvidedField(field, details) {
   const detailAndValueRequiredToShowField = field["visible-if"];
 
-  if (!detailAndValueRequiredToShowField) {
-    return true;
+  if (detailAndValueRequiredToShowField) {
+    const [detail, expectedDetailValue] = Object.entries(
+      detailAndValueRequiredToShowField,
+    )[0];
+
+    return details[detail] === expectedDetailValue;
   }
 
-  const [detail, expectedDetailValue] = Object.entries(
-    detailAndValueRequiredToShowField,
-  )[0];
-
-  return details[detail] === expectedDetailValue;
+  return true;
 }
 
 function getDefaultValue(field) {

--- a/frontend/src/metabase/entities/databases/forms.js
+++ b/frontend/src/metabase/entities/databases/forms.js
@@ -206,34 +206,6 @@ function getEngineInfo(engine, details, id) {
   }
 }
 
-// function isHiddenField(field, details) {
-//   // NOTE: special case to hide tunnel settings if tunnel is disabled
-//   const isDisabledTunnelSettingsField =
-//     field.name.startsWith("tunnel-") &&
-//     field.name !== "tunnel-enabled" &&
-//     !details["tunnel-enabled"];
-
-//   // hide the auth settings based on which auth method is selected
-//   // private key auth needs tunnel-private-key and tunnel-private-key-passphrase
-//   const isTunnelPrivateFieldWithoutProperAuthMethod =
-//     field.name.startsWith("tunnel-private-") &&
-//     details["tunnel-auth-option"] !== "ssh-key";
-
-//   // username / password auth uses tunnel-pass
-//   const isTunnelPassFieldWithoutProperAuthMethod =
-//     field.name === "tunnel-pass" && details["tunnel-auth-option"] === "ssh-key";
-
-//   // NOTE: special case to hide the SSL cert field if SSL is disabled
-//   const isDisabledSslField = field.name === "ssl-cert" && !details["ssl"];
-
-//   return (
-//     isDisabledTunnelSettingsField ||
-//     isTunnelPrivateFieldWithoutProperAuthMethod ||
-//     isTunnelPassFieldWithoutProperAuthMethod ||
-//     isDisabledSslField
-//   );
-// }
-
 function shouldShowEngineProvidedField(field, details) {
   const detailAndValueRequiredToShowField = field["visible-if"];
 

--- a/modules/drivers/mongo/resources/metabase-plugin.yaml
+++ b/modules/drivers/mongo/resources/metabase-plugin.yaml
@@ -38,6 +38,9 @@ driver:
     - name: ssl-cert
       type: string
       display-name: Server SSL certificate chain
+      visible-if:
+        ssl: true
+
   connection-properties-include-tunnel-config: true
 init:
   - step: load-namespace

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -79,7 +79,9 @@
   "Server SSL certificate chain, in PEM format."
   {:name         "ssl-cert"
    :display-name (deferred-tru "Server SSL certificate chain")
-   :placeholder  ""})
+   :placeholder  ""
+   :visible-if   {"ssl" true}}
+)
 
 (defmethod driver/connection-properties :mysql
   [_]

--- a/src/metabase/util/ssh.clj
+++ b/src/metabase/util/ssh.clj
@@ -80,36 +80,43 @@
    {:name         "tunnel-host"
     :display-name "SSH tunnel host"
     :placeholder  "What hostname do you use to connect to the SSH tunnel?"
-    :required     true}
+    :required     true
+    :visible-if   {"tunnel-enabled" true}}
    {:name         "tunnel-port"
     :display-name "SSH tunnel port"
     :type         :integer
     :default      22
-    :required     false}
+    :required     false
+    :visible-if   {"tunnel-enabled" true}}
    {:name         "tunnel-user"
     :display-name "SSH tunnel username"
     :placeholder  "What username do you use to login to the SSH tunnel?"
-    :required     true}
+    :required     true
+    :visible-if   {"tunnel-enabled" true}}
    ;; this is entirely a UI flag
    {:name         "tunnel-auth-option"
     :display-name "SSH Authentication"
     :type         :select
     :options      [{:name "SSH Key" :value "ssh-key"}
                    {:name "Password" :value "password"}]
-    :default      "ssh-key"}
+    :default      "ssh-key"
+    :visible-if   {"tunnel-enabled" true}}
    {:name         "tunnel-pass"
     :display-name "SSH tunnel password"
     :type         :password
-    :placeholder  "******"}
+    :placeholder  "******"
+    :visible-if   {"tunnel-enabled" true}}
    {:name         "tunnel-private-key"
     :display-name "SSH private key to connect to the tunnel"
     :type         :string
     :placeholder  "Paste the contents of an ssh private key here"
-    :required     true}
+    :required     true
+    :visible-if   {"tunnel-auth-option" "ssh-key"}}
    {:name         "tunnel-private-key-passphrase"
     :display-name "Passphrase for SSH private key"
     :type         :password
-    :placeholder  "******"}])
+    :placeholder  "******"
+    :visible-if   {"tunnel-auth-option" "ssh-key"}}])
 
 (defn with-tunnel-config
   "Add preferences for ssh tunnels to a drivers :connection-properties"

--- a/src/metabase/util/ssh.clj
+++ b/src/metabase/util/ssh.clj
@@ -105,7 +105,7 @@
     :display-name "SSH tunnel password"
     :type         :password
     :placeholder  "******"
-    :visible-if   {"tunnel-enabled" true}}
+    :visible-if   {"tunnel-auth-option" "password"}}
    {:name         "tunnel-private-key"
     :display-name "SSH private key to connect to the tunnel"
     :type         :string


### PR DESCRIPTION
A few form fields for adding / editing database connections are set by configuration coming via the back-end.

SSH tunnel fields are an example.

They are meant to only be displayed if the SSH tunnel option is chosen in a form toggle.

The logic for this used to live in js code that was written specifically to cover SSH-tunnel fields.

This PR makes the ability to hide/show fields:

1. simpler in the front-end codebase
2. clearer in the configuration files (although more verbose), as each form field declares their condition to be shown.

So here we convert the conditionals that existed in JS to configuration.

### How to test

Visit http://localhost:3000/admin/databases/create

Choose Postgres as the database.

All behavior of the form should be unchanged:

1. toggling SSH-tunnel should reveal fields for SSH tunnel details
2. changing SSH authentication option to `password` should now should only the password input below it