### PR TITLE
Visual test for ClampedText component (via _internal)

### DIFF
--- a/frontend/test/metabase-visual/internal/components.cy.spec.js
+++ b/frontend/test/metabase-visual/internal/components.cy.spec.js
@@ -6,6 +6,14 @@ describe("visual tests > internal > components", () => {
     cy.signInAsNormalUser();
   });
 
+  it("ClampedText", () => {
+    cy.visit("/_internal");
+
+    cy.findByText("ClampedText").click();
+
+    cy.percySnapshot();
+  });
+
   it("UserAvatar", () => {
     cy.visit("/_internal");
 


### PR DESCRIPTION
ClampedText component *potentially* breaks with the upgraded styled-component (based on some initial test), hence this visual test to prevent regression.

To verify, run `yarn build-hot` and then `yarn test-visual-open` and then  choose `frontend/test/metabase-visual/internal/components.cy.spec.js` from the list.

![image](https://user-images.githubusercontent.com/7288/133137228-dd6d645b-6050-4607-9afe-66451f35aef5.png)
