### PR TITLE
Visual test for UserAvatar component (via _internal)

### DIFF
--- a/frontend/test/metabase-visual/internal/components.cy.spec.js
+++ b/frontend/test/metabase-visual/internal/components.cy.spec.js
@@ -1,0 +1,16 @@
+import { restore } from "__support__/e2e/cypress";
+
+describe("visual tests > internal > components", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsNormalUser();
+  });
+
+  it("UserAvatar", () => {
+    cy.visit("/_internal");
+
+    cy.findByText("UserAvatar").click();
+
+    cy.percySnapshot();
+  });
+});


### PR DESCRIPTION
UserAvatar component *potentially* breaks with the upgraded styled-component (based on some initial test), hence this visual test to prevent regression.

To verify, run `yarn test-visual-open` and then choose `frontend/test/metabase-visual/internal/components.cy.spec.js` from the list.

![image](https://user-images.githubusercontent.com/7288/132932815-e51555a0-dfd7-4996-bed5-908f288d8205.png)
