### PR TITLE
Fix showing saved value in language picker

### DIFF
--- a/src/metabase/util/i18n.clj
+++ b/src/metabase/util/i18n.clj
@@ -43,7 +43,9 @@
   "Returns all locale abbreviations and their full names"
   []
   (for [locale-name (impl/available-locale-names)]
-    [locale-name (.getDisplayName (locale locale-name))]))
+    ;; Abbreviation must be normalized or the language picker will show incorrect saved value
+    ;; because the locale is normalized before saving (metabase#15657, metabase#16654)
+    [(normalized-locale-string locale-name) (.getDisplayName (locale locale-name))]))
 
 (defn translate-site-locale
   "Translate a string with the System locale."

--- a/test/metabase/util/i18n_test.clj
+++ b/test/metabase/util/i18n_test.clj
@@ -4,6 +4,11 @@
             [metabase.test :as mt]
             [metabase.util.i18n :as i18n]))
 
+(deftest available-locales-test
+  (testing "Should return locale in normalized format"
+    (is (contains? (set (i18n/available-locales-with-names))
+                   ["pt_BR", "Portuguese (Brazil)"]))))
+
 (deftest tru-test
   (mt/with-mock-i18n-bundles {"es" {"must be {0} characters or less" "deben tener {0} caracteres o menos"}}
     (doseq [[message f] {"tru"          (fn [] (i18n/tru "must be {0} characters or less" 140))


### PR DESCRIPTION
The locale list sent to the UI is formatted "pt-BR" but when it is saved to the database, we re-format the locale to "pt_BR", thus on next load, the UI cannot match the saved locale with the locale list.

Fix the issue by using normalized value (e.g. "pt_BR") in the available locale list.

Fixes #15657, fixes #16654