### PR TITLE
Fix saving chart with custom expressions only retains first 2 data series

### DIFF
--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -848,7 +848,7 @@ describe("scenarios > question > filter", () => {
     cy.button("Add filter").isVisibleInPopover();
   });
 
-  it.skip("shoud retain all data series after saving a question where custom expression formula is the first metric (metabase#15882)", () => {
+  it("shoud retain all data series after saving a question where custom expression formula is the first metric (metabase#15882)", () => {
     visitQuestionAdhoc({
       dataset_query: {
         database: 1,
@@ -884,7 +884,7 @@ describe("scenarios > question > filter", () => {
     cy.get(".line").should("have.length", 3);
 
     function assertOnLegendLabels() {
-      cy.get(".Card-title")
+      cy.findAllByTestId("legend-item")
         .should("contain", "Discount %")
         .and("contain", "Count")
         .and("contain", "Average of Total");

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -123,9 +123,12 @@
                (cond-> form
                  (mbql-field-clause? form) normalize/normalize))
              form))]
-    (cond-> (walk/keywordize-keys (dissoc viz-settings "column_settings"))
+    (cond-> (walk/keywordize-keys (dissoc viz-settings "column_settings" "graph.metrics"))
       (get viz-settings "column_settings") (assoc :column_settings (normalize-column-settings (get viz-settings "column_settings")))
-      true                                 normalize-mbql-clauses)))
+      true                                 normalize-mbql-clauses
+      ;; exclude graph.metrics from normalization as it may start with
+      ;; the word "expression" but it is not MBQL (metabase#15882)
+      (get viz-settings "graph.metrics")   (assoc :graph.metrics (get viz-settings "graph.metrics")))))
 
 (models/add-type! :visualization-settings
   :in  json-in

--- a/test/metabase/models/card_test.clj
+++ b/test/metabase/models/card_test.clj
@@ -249,6 +249,10 @@
 
     (testing "Don't normalize key-value pairs in maps that could be interpreted as MBQL clauses"
       (let [original {:field-id 1}]
+        (f original original)))
+
+    (testing "Don't normalize array in graph.metrics that could be interpreted as MBQL clauses"
+      (let [original {:graph.metrics ["expression" "sum" "count"]}]
         (f original original)))))
 
 (deftest normalize-visualization-settings-test


### PR DESCRIPTION
See https://github.com/metabase/metabase/issues/15882#issuecomment-917984049 for detailed explanation.

Fixes #15882