### PR TITLE
Visual test for ClampedText component (via _internal)

### DIFF
--- a/frontend/test/metabase-visual/internal/components.cy.spec.js
+++ b/frontend/test/metabase-visual/internal/components.cy.spec.js
@@ -9,7 +9,7 @@ describe("visual tests > internal > components", () => {
   it("ClampedText", () => {
     cy.visit("/_internal/components/clampedtext");
 
-    cy.findByText("No 'See more' button when all text visible:");
+    cy.wait(1000).findByText("No 'See more' button when all text visible:");
 
     cy.percySnapshot();
   });

--- a/frontend/test/metabase-visual/internal/components.cy.spec.js
+++ b/frontend/test/metabase-visual/internal/components.cy.spec.js
@@ -6,6 +6,14 @@ describe("visual tests > internal > components", () => {
     cy.signInAsNormalUser();
   });
 
+  it("ClampedText", () => {
+    cy.visit("/_internal");
+
+    cy.findByText("ClampedText").click();
+
+    cy.percySnapshot();
+  });
+
   it("UserAvatar", () => {
     cy.visit("/_internal");
 

--- a/frontend/test/metabase-visual/internal/components.cy.spec.js
+++ b/frontend/test/metabase-visual/internal/components.cy.spec.js
@@ -9,7 +9,7 @@ describe("visual tests > internal > components", () => {
   it("ClampedText", () => {
     cy.visit("/_internal/components/clampedtext");
 
-    cy.wait(1000).findByText("No 'See more' button when all text visible:");
+    cy.wait(2000).findByText("No 'See more' button when all text visible:");
 
     cy.percySnapshot();
   });

--- a/frontend/test/metabase-visual/internal/components.cy.spec.js
+++ b/frontend/test/metabase-visual/internal/components.cy.spec.js
@@ -9,6 +9,8 @@ describe("visual tests > internal > components", () => {
   it("ClampedText", () => {
     cy.visit("/_internal/components/clampedtext");
 
+    cy.findByText("No 'See more' button when all text visible:");
+
     cy.percySnapshot();
   });
 

--- a/frontend/test/metabase-visual/internal/components.cy.spec.js
+++ b/frontend/test/metabase-visual/internal/components.cy.spec.js
@@ -6,18 +6,18 @@ describe("visual tests > internal > components", () => {
     cy.signInAsNormalUser();
   });
 
-  it("ClampedText", () => {
-    cy.visit("/_internal/components/clampedtext");
-
-    cy.wait(2000).findByText("No 'See more' button when all text visible:");
-
-    cy.percySnapshot();
-  });
-
   it("UserAvatar", () => {
     cy.visit("/_internal");
 
     cy.findByText("UserAvatar").click();
+
+    cy.percySnapshot();
+  });
+
+  it("ClampedText", () => {
+    cy.visit("/_internal/components/clampedtext");
+
+    cy.wait(2000).findByText("No 'See more' button when all text visible:");
 
     cy.percySnapshot();
   });

--- a/frontend/test/metabase-visual/internal/components.cy.spec.js
+++ b/frontend/test/metabase-visual/internal/components.cy.spec.js
@@ -17,7 +17,7 @@ describe("visual tests > internal > components", () => {
   it("ClampedText", () => {
     cy.visit("/_internal/components/clampedtext");
 
-    cy.wait(2000).findByText("No 'See more' button when all text visible:");
+    cy.wait(5000).findByText("No 'See more' button when all text visible:");
 
     cy.percySnapshot();
   });

--- a/frontend/test/metabase-visual/internal/components.cy.spec.js
+++ b/frontend/test/metabase-visual/internal/components.cy.spec.js
@@ -7,9 +7,7 @@ describe("visual tests > internal > components", () => {
   });
 
   it("ClampedText", () => {
-    cy.visit("/_internal");
-
-    cy.findByText("ClampedText").click();
+    cy.visit("/_internal/components/clampedtext");
 
     cy.percySnapshot();
   });

--- a/frontend/test/metabase-visual/internal/components.cy.spec.js
+++ b/frontend/test/metabase-visual/internal/components.cy.spec.js
@@ -4,6 +4,9 @@ describe("visual tests > internal > components", () => {
   beforeEach(() => {
     restore();
     cy.signInAsNormalUser();
+
+    cy.visit("/_internal");
+    cy.reload(true);
   });
 
   it("UserAvatar", () => {


### PR DESCRIPTION
ClampedText component *potentially* breaks with the upgraded styled-component (based on some initial test), hence this visual test to prevent regression.

To verify, run `yarn build-hot` and then `yarn test-visual-open` and then  choose `frontend/test/metabase-visual/internal/components.cy.spec.js` from the list.

![image](https://user-images.githubusercontent.com/7288/133137228-dd6d645b-6050-4607-9afe-66451f35aef5.png)
