### PR TITLE
Remove outdated resolutions in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -217,10 +217,6 @@
       "prettier --write"
     ]
   },
-  "resolutions": {
-    "styled-components": "3.2.6",
-    "styled-system": "2.2.5"
-  },
   "browserslist": [
     "defaults"
   ]


### PR DESCRIPTION
Before and after this PR, all kind of tests (front-end unit tests, E2E tests, visual tests) should continue to pass.