### PR TITLE
Handle expressions viz settings

### DIFF
--- a/shared/src/metabase/shared/models/visualization_settings.cljc
+++ b/shared/src/metabase/shared/models/visualization_settings.cljc
@@ -52,11 +52,15 @@
 (s/def ::click-behavior (s/keys))
 (s/def ::visualization-settings (s/keys :opt [::column-settings ::click-behavior]))
 
-(s/def ::field-id-vec (s/tuple (partial = "ref") (s/tuple (partial = "field")
-                                                   (s/or :field-id int? :field-str string?)
-                                                   (s/or :field-metadata map? :nil nil?))))
+(s/def ::field-id-vec (s/tuple #{"ref"}
+                               (s/tuple #{"field"}
+                                        (s/or :field-id int? :field-str string?)
+                                        (s/or :field-metadata map? :nil nil?))))
+
+(s/def ::expression-vec (s/tuple #{"ref"} (s/tuple #{"expression"} string?)))
 
 (s/def ::db-column-ref-vec (s/or :field ::field-id-vec
+                                 :expression ::expression-vec
                                  :column-name (s/tuple (partial = "name") string?)))
 
 (s/def ::click-behavior-type keyword? #_(s/or :cross-filter ::cross-filter
@@ -196,7 +200,10 @@
                       :field-str {::field-str v})
                     (some? field-md) (assoc ::field-metadata field-md)))
           :column-name
-          {::column-name (nth parts 1)})))))
+          {::column-name (nth parts 1)}
+          :expression
+          (let [[_expression [_ref [_expression column-name]]] parsed]
+           {::column-name column-name}))))))
 
 (s/fdef db->norm-column-ref
   :args (s/cat :column-ref ::db-column-ref-vec)

--- a/shared/test/metabase/shared/models/visualization_settings_test.cljc
+++ b/shared/test/metabase/shared/models/visualization_settings_test.cljc
@@ -44,12 +44,15 @@
   (t/testing "Column ref strings are parsed correctly"
     (let [f-qual-nm "/databases/MY_DB/tables/MY_TBL/fields/COL1"
           f-id      42
-          col-nm    "Year"]
+          col-nm    "Year"
+          expn-nm   "Calculated Column"]
       (doseq [[input-str expected] [[(fmt "[\"ref\",[\"field\",%d,null]]" f-id) {::mb.viz/field-id f-id}]
                                     [(fmt "[\"ref\",[\"field\",\"%s\",null]]" f-qual-nm)
                                      {::mb.viz/field-str f-qual-nm}]
                                     [(fmt "[\"name\",\"Year\"]" col-nm)
-                                     {::mb.viz/column-name col-nm}]]]
+                                     {::mb.viz/column-name col-nm}]
+                                    [(fmt "[\"ref\",[\"expression\",\"%s\"]]" expn-nm)
+                                     {::mb.viz/column-name expn-nm}]]]
         (t/is (= expected (mb.viz/parse-db-column-ref input-str)))))))
 
 (t/deftest form-conversion-test


### PR DESCRIPTION
added the viz-settings parsing middleware to static viz. Column settings are
spec'd for regular columns and by name, but we forgot expressions apparently.


This came up in static-viz. There's a handy middleware to grab the viz settings and normalize them. But this codepath doesn't anticipate expressions, just field refs by name or id. So running a pulse/subscription on a card that included viz settings on a custom column would fail.

```bash
:stacktrace
 ["--> shared.models.visualization_settings$db__GT_norm_column_ref.invokeStatic(visualization_settings.cljc:189)"
  "shared.models.visualization_settings$db__GT_norm_column_ref.invoke(visualization_settings.cljc:182)"
  "shared.models.visualization_settings$parse_db_column_ref.invokeStatic(visualization_settings.cljc:233)"
  "shared.models.visualization_settings$parse_db_column_ref.invoke(visualization_settings.cljc:205)"
  "shared.models.visualization_settings$db__GT_norm_column_settings$fn__37089.invoke(visualization_settings.cljc:539)"
  "shared.models.visualization_settings$db__GT_norm_column_settings.invokeStatic(visualization_settings.cljc:538)"
  "shared.models.visualization_settings$db__GT_norm_column_settings.invoke(visualization_settings.cljc:535)"
  "shared.models.visualization_settings$db__GT_norm.invokeStatic(visualization_settings.cljc:554)"
  "shared.models.visualization_settings$db__GT_norm.invoke(visualization_settings.cljc:544)"
  "query_processor.middleware.visualization_settings$viz_settings.invokeStatic(visualization_settings.clj:29)"
  "query_processor.middleware.visualization_settings$viz_settings.invoke(visualization_settings.clj:24)"
 ...
 :ex-data
 {:clojure.spec.alpha/problems
  ({:path [:field 1],
    :pred (clojure.core/= (clojure.core/count %) 3),
    :val ["expression" "Actual Subtotal"],
    :via
    [:metabase.shared.models.visualization-settings/db-column-ref-vec
     :metabase.shared.models.visualization-settings/field-id-vec],
    :in [1]}
   {:path [:column-name 0],
    :pred (clojure.core/partial clojure.core/= "name"),
    :val "ref",
    :via [:metabase.shared.models.visualization-settings/db-column-ref-vec],
    :in [0]}
   {:path [:column-name 1],
    :pred clojure.core/string?,
    :val ["expression" "Actual Subtotal"],
    :via [:metabase.shared.models.visualization-settings/db-column-ref-vec],
    :in [1]}),
  :clojure.spec.alpha/spec :metabase.shared.models.visualization-settings/db-column-ref-vec,
  :clojure.spec.alpha/value ["ref" ["expression" "Actual Subtotal"]]},
 :data {:rows [], :cols []}}
```

#### the pre-normalized viz settings
```clojure
:column_settings {"[\"name\",\"sum\"]" {:scale 2.3
                                        :prefix ""}
                  "[\"ref\",[\"expression\",\"multiplied total\"]]" {:prefix "pre"
                                                                     :scale 4
                                                                     :decimals 4
                                                                     :number_separators ",."}}
```

#### after normalization 
```clojure
::mb.viz/column-settings
{{::mb.viz/column-name "sum"} {::mb.viz/scale 2.3
                               ::mb.viz/prefix ""}
 {::mb.viz/column-name "multiplied total"} {::mb.viz/prefix "pre"
                                            ::mb.viz/scale 4
                                            ::mb.viz/decimals 4
                                            ::mb.viz/number-separators ",."}}
```

This `"[\"ref\",[\"expression\",\"multiplied total\"]]" ` is what the parser did not understand.

I'm 50/50 on whether to add error handling. This would never have worked if we swallowed the error and omitted the column settings. But it really shouldn't prevent rendering because we're unable to parse some viz settings.