### PR TITLE
Fix #17630: Removed extra border-bottom on EntityItemWrapper

### DIFF
--- a/frontend/src/metabase/components/EntityItem.styled.jsx
+++ b/frontend/src/metabase/components/EntityItem.styled.jsx
@@ -39,7 +39,6 @@ export const EntityIconWrapper = styled(IconButtonWrapper)`
 `;
 
 export const EntityItemWrapper = styled(Flex)`
-  border-bottom: 1px solid ${color("bg-medium")};
   align-items: center;
   &:hover {
     color: ${color("brand")};


### PR DESCRIPTION
Fixes #17630 

First PR so I went with `master` but can easily backport to `release-x.40.x` branch  (files renamed from `.js` to `.jsx` is the only relevant difference I can see)

Before:
![issue-17630-before](https://user-images.githubusercontent.com/653604/133160486-ed1fc0d7-b5cb-4aba-9937-18a0f946261d.png)

After:
![issue-17630-after](https://user-images.githubusercontent.com/653604/133160503-b497a10c-5080-48ed-a7f3-4efefab72207.png)

(Fix applies to non-hover state as well)