### PR TITLE
Update URL when converting to native query

### DIFF
--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -916,6 +916,15 @@ export const updateQuestion = (
     }
     // </PIVOT LOGIC>
 
+    // Native query should never be in notebook mode (metabase#12651)
+    if (getQueryBuilderMode(getState()) !== "view" && newQuestion.isNative()) {
+      await dispatch(
+        setQueryBuilderMode("view", {
+          shouldUpdateUrl: false,
+        }),
+      );
+    }
+
     // Replace the current question with a new one
     await dispatch.action(UPDATE_QUESTION, { card: newQuestion.card() });
 

--- a/frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx
+++ b/frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx
@@ -58,7 +58,7 @@ export default class NativeQueryButton extends React.Component {
         native: { query: this.getFormattedQuery() },
         database: this.state.datasetQuery.database,
       })
-      .update();
+      .update(null, { shouldUpdateUrl: true });
   };
 
   getFormattedQuery() {

--- a/frontend/test/metabase/scenarios/question/new.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/new.cy.spec.js
@@ -301,7 +301,7 @@ describe("scenarios > question > new", () => {
       });
     });
 
-    it.skip("should remove `/notebook` from URL when converting question to SQL/Native (metabase#12651)", () => {
+    it("should remove `/notebook` from URL when converting question to SQL/Native (metabase#12651)", () => {
       cy.server();
       cy.route("POST", "/api/dataset").as("dataset");
       openOrdersTable();


### PR DESCRIPTION
In addition, mode should be switched to `view` to remove `/notebook` from the URL.

Fixes #12651
