### PR TITLE
Select temporal units for join date-time dimensions

### DIFF
--- a/frontend/src/metabase/lib/query/field_ref.js
+++ b/frontend/src/metabase/lib/query/field_ref.js
@@ -107,3 +107,7 @@ export function getDatetimeUnit(fieldClause) {
     return dimension && dimension.temporalUnit();
   }
 }
+
+export function isDateTimeField(fieldClause) {
+  return Boolean(getDatetimeUnit(fieldClause));
+}

--- a/frontend/src/metabase/query_builder/components/DimensionList.jsx
+++ b/frontend/src/metabase/query_builder/components/DimensionList.jsx
@@ -146,7 +146,9 @@ export default class DimensionList extends Component {
                 dimension={sectionDimension}
                 dimensions={subDimensions}
                 onChangeDimension={dimension => {
-                  this.props.onChangeDimension(dimension);
+                  this.props.onChangeDimension(dimension, {
+                    isSubDimension: true,
+                  });
                   onClose();
                 }}
               />

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -623,15 +623,9 @@ class JoinDimensionPicker extends React.Component {
             fieldOptions={options}
             table={query.table()}
             query={query}
-            onFieldChange={(field, item) => {
+            onFieldChange={(field, { isSubDimension = false } = {}) => {
               if (isDateTimeField(field)) {
-                // When we set a default temporal unit by just clicking the dimension name,
-                // FieldList provides a second argument to onFieldChange callback
-                // When a temporal unit is selected explicitly (like by Week, Quarter, Year, etc.)
-                // the item argument is undefined
-                // In this case we want to make sure the second dimension will use the same unit
-                const isSubDimension = !item;
-                onChange(field, { overwrite: !isSubDimension });
+                onChange(field, { overwrite: isSubDimension });
               } else {
                 onChange(field);
               }

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -8,6 +8,7 @@ import PopoverWithTrigger from "metabase/components/PopoverWithTrigger";
 import { DatabaseSchemaAndTableDataSelector } from "metabase/query_builder/components/DataSelector";
 import FieldList from "metabase/query_builder/components/FieldList";
 import Join from "metabase-lib/lib/queries/structured/Join";
+import { isDateTimeField } from "metabase/lib/query/field_ref";
 
 import {
   NotebookCell,
@@ -594,11 +595,6 @@ class JoinDimensionPicker extends React.Component {
     this._popover.open();
   }
 
-  hasTemporalUnit = fieldRef => {
-    const [, , opts] = fieldRef;
-    return !!opts?.["temporal-unit"];
-  };
-
   render() {
     const { dimension, onChange, onRemove, options, query, color } = this.props;
     const testID = this.props["data-testid"] || "join-dimension";
@@ -628,13 +624,14 @@ class JoinDimensionPicker extends React.Component {
             table={query.table()}
             query={query}
             onFieldChange={(field, item) => {
-              if (this.hasTemporalUnit(field)) {
+              if (isDateTimeField(field)) {
                 // When we set a default temporal unit by just clicking the dimension name,
                 // FieldList provides a second argument to onFieldChange callback
                 // When a temporal unit is selected explicitly (like by Week, Quarter, Year, etc.)
                 // the item argument is undefined
                 // In this case we want to make sure the second dimension will use the same unit
-                onChange(field, { overwrite: !item });
+                const isSubDimension = !item;
+                onChange(field, { overwrite: !isSubDimension });
               } else {
                 onChange(field);
               }

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -537,6 +537,16 @@ function getDimensionSourceName(dimension) {
     .displayName();
 }
 
+function getDimensionDisplayName(dimension) {
+  if (!dimension) {
+    return t`Pick a column...`;
+  }
+  if (dimension.temporalUnit()) {
+    return `${dimension.displayName()}: ${dimension.subDisplayName()}`;
+  }
+  return dimension.displayName();
+}
+
 function JoinDimensionCellItem({ dimension, color, testID, onRemove }) {
   return (
     <NotebookCellItem color={color} inactive={!dimension} data-testid={testID}>
@@ -547,7 +557,7 @@ function JoinDimensionCellItem({ dimension, color, testID, onRemove }) {
               {getDimensionSourceName(dimension)}
             </DimensionSourceName>
           )}
-          {dimension?.displayName() || t`Pick a column...`}
+          {getDimensionDisplayName(dimension)}
         </div>
         {dimension && <RemoveDimensionIcon onClick={onRemove} />}
       </DimensionContainer>

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -617,6 +617,7 @@ class JoinDimensionPicker extends React.Component {
               onChange(field);
               onClose();
             }}
+            enableSubDimensions
             data-testid={`${testID}-picker`}
           />
         )}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.unit.spec.js
@@ -384,6 +384,24 @@ describe("Notebook Editor > Join Step", () => {
     expect(screen.queryByRole("tooltip")).toBe(null);
   });
 
+  it("shows temporal unit for date-time fields", async () => {
+    await setup({ joinTable: "Products" });
+
+    fireEvent.click(screen.getByTestId("parent-dimension"));
+    let picker = await screen.findByRole("rowgroup");
+    fireEvent.click(within(picker).queryByText("Created At"));
+    fireEvent.click(screen.getByTestId("join-dimension"));
+    picker = await screen.findByRole("rowgroup");
+    fireEvent.click(within(picker).queryByText("Created At"));
+
+    expect(screen.getByTestId("parent-dimension")).toHaveTextContent(
+      "Created At: Day",
+    );
+    expect(screen.getByTestId("join-dimension")).toHaveTextContent(
+      "Created At: Day",
+    );
+  });
+
   describe("joins on multiple fields", () => {
     it("does not display a new dimensions pair control until first pair is valid", async () => {
       await setup({ joinTable: "Reviews" });

--- a/frontend/test/metabase-lib/lib/queries/structured/Join.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/structured/Join.unit.spec.js
@@ -248,6 +248,58 @@ describe("Join", () => {
         "source-table": PRODUCTS.id,
       });
     });
+
+    it("inherits join dimension's temporal unit", () => {
+      const joinDimension = getDateFieldRef(PRODUCTS.CREATED_AT, {
+        joinAlias: "Products",
+        temporalUnit: "day",
+      });
+      let join = getJoin({
+        query: getOrdersJoinQuery({
+          condition: ["=", null, joinDimension],
+        }),
+      });
+
+      join = join.setParentDimension({
+        dimension: ORDERS_CREATED_AT_FIELD_REF,
+      });
+
+      expect(join).toEqual({
+        alias: "Products",
+        condition: [
+          "=",
+          getDateFieldRef(ORDERS.CREATED_AT, { temporalUnit: "day" }),
+          joinDimension,
+        ],
+        "source-table": PRODUCTS.id,
+      });
+    });
+
+    it("overwrites join dimension's temporal unit if flag provided", () => {
+      let join = getJoin({
+        query: getOrdersJoinQuery({
+          condition: ["=", null, PRODUCTS_CREATED_AT_JOIN_FIELD_REF],
+        }),
+      });
+
+      join = join.setParentDimension({
+        dimension: getDateFieldRef(ORDERS.CREATED_AT, { temporalUnit: "week" }),
+        overwriteTemporalUnit: true,
+      });
+
+      expect(join).toEqual({
+        alias: "Products",
+        condition: [
+          "=",
+          getDateFieldRef(ORDERS.CREATED_AT, { temporalUnit: "week" }),
+          getDateFieldRef(PRODUCTS.CREATED_AT, {
+            joinAlias: "Products",
+            temporalUnit: "week",
+          }),
+        ],
+        "source-table": PRODUCTS.id,
+      });
+    });
   });
 
   describe("setJoinDimension", () => {
@@ -342,6 +394,63 @@ describe("Join", () => {
           "and",
           ORDERS_PRODUCT_JOIN_CONDITION,
           ["=", null, PRODUCTS_CREATED_AT_FIELD_REF],
+        ],
+        "source-table": PRODUCTS.id,
+      });
+    });
+
+    it("inherits parent dimension's temporal unit", () => {
+      const parentDimension = getDateFieldRef(ORDERS.CREATED_AT, {
+        temporalUnit: "day",
+      });
+      let join = getJoin({
+        query: getOrdersJoinQuery({
+          condition: ["=", parentDimension, null],
+        }),
+      });
+
+      join = join.setJoinDimension({
+        dimension: PRODUCTS_CREATED_AT_JOIN_FIELD_REF,
+      });
+
+      expect(join).toEqual({
+        alias: "Products",
+        condition: [
+          "=",
+          parentDimension,
+          getDateFieldRef(PRODUCTS.CREATED_AT, {
+            temporalUnit: "day",
+            joinAlias: "Products",
+          }),
+        ],
+        "source-table": PRODUCTS.id,
+      });
+    });
+
+    it("overwrites parent dimension's temporal unit if flag provided", () => {
+      let join = getJoin({
+        query: getOrdersJoinQuery({
+          condition: ["=", ORDERS_CREATED_AT_FIELD_REF, null],
+        }),
+      });
+
+      join = join.setJoinDimension({
+        dimension: getDateFieldRef(PRODUCTS.CREATED_AT, {
+          temporalUnit: "week",
+          joinAlias: "Products",
+        }),
+        overwriteTemporalUnit: true,
+      });
+
+      expect(join).toEqual({
+        alias: "Products",
+        condition: [
+          "=",
+          getDateFieldRef(ORDERS.CREATED_AT, { temporalUnit: "week" }),
+          getDateFieldRef(PRODUCTS.CREATED_AT, {
+            temporalUnit: "week",
+            joinAlias: "Products",
+          }),
         ],
         "source-table": PRODUCTS.id,
       });

--- a/frontend/test/metabase-lib/lib/queries/structured/Join.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/structured/Join.unit.spec.js
@@ -178,6 +178,24 @@ describe("Join", () => {
       });
     });
 
+    it("removes the dimensions", () => {
+      let join = getJoin({
+        query: getOrdersJoinQuery({
+          condition: ORDERS_PRODUCT_JOIN_CONDITION,
+        }),
+      });
+
+      join = join.setParentDimension({
+        dimension: null,
+      });
+
+      expect(join).toEqual({
+        alias: "Products",
+        condition: ["=", null, PRODUCTS_ID_JOIN_FIELD_REF],
+        "source-table": PRODUCTS.id,
+      });
+    });
+
     it("sets a dimension for multi-dimension condition by index", () => {
       let join = getJoin({
         query: getOrdersJoinQuery({
@@ -254,6 +272,24 @@ describe("Join", () => {
       expect(join).toEqual({
         alias: "Products",
         condition: ORDERS_PRODUCT_JOIN_CONDITION,
+        "source-table": PRODUCTS.id,
+      });
+    });
+
+    it("removes the dimensions", () => {
+      let join = getJoin({
+        query: getOrdersJoinQuery({
+          condition: ORDERS_PRODUCT_JOIN_CONDITION,
+        }),
+      });
+
+      join = join.setJoinDimension({
+        dimension: null,
+      });
+
+      expect(join).toEqual({
+        alias: "Products",
+        condition: ["=", ORDERS_PRODUCT_ID_FIELD_REF, null],
         "source-table": PRODUCTS.id,
       });
     });

--- a/frontend/test/metabase-lib/lib/queries/structured/Join.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/structured/Join.unit.spec.js
@@ -17,13 +17,21 @@ function getJoin({ query = getOrdersJoinQuery() } = {}) {
   return query.joins()[0];
 }
 
+function getDateFieldRef(field, { temporalUnit = "month", joinAlias } = {}) {
+  const opts = { "temporal-unit": temporalUnit };
+  if (joinAlias) {
+    opts["join-alias"] = joinAlias;
+  }
+  return ["field", field.id, opts];
+}
+
 const ORDERS_PRODUCT_ID_FIELD_REF = ["field", ORDERS.PRODUCT_ID.id, null];
 
-const ORDERS_CREATED_AT_FIELD_REF = ["field", ORDERS.CREATED_AT.id, null];
+const ORDERS_CREATED_AT_FIELD_REF = getDateFieldRef(ORDERS.CREATED_AT);
 
 const PRODUCTS_ID_FIELD_REF = ["field", PRODUCTS.ID.id, null];
 
-const PRODUCTS_CREATED_AT_FIELD_REF = ["field", PRODUCTS.CREATED_AT.id, null];
+const PRODUCTS_CREATED_AT_FIELD_REF = getDateFieldRef(PRODUCTS.CREATED_AT);
 
 const PRODUCTS_ID_JOIN_FIELD_REF = [
   "field",
@@ -31,11 +39,10 @@ const PRODUCTS_ID_JOIN_FIELD_REF = [
   { "join-alias": "Products" },
 ];
 
-const PRODUCTS_CREATED_AT_JOIN_FIELD_REF = [
-  "field",
-  PRODUCTS.CREATED_AT.id,
-  { "join-alias": "Products" },
-];
+const PRODUCTS_CREATED_AT_JOIN_FIELD_REF = getDateFieldRef(
+  PRODUCTS.CREATED_AT,
+  { joinAlias: "Products" },
+);
 
 const ORDERS_PRODUCT_JOIN_CONDITION = [
   "=",

--- a/frontend/test/metabase/scenarios/question/joins.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/joins.cy.spec.js
@@ -50,28 +50,15 @@ describe("scenarios > question > joined questions", () => {
     cy.intercept("POST", "/api/dataset").as("dataset");
     openOrdersTable({ mode: "notebook" });
 
-    cy.findByText("Join data").click();
-    popover()
-      .findByText("Products")
-      .click();
+    joinTable("Products");
+    selectJoinType("Inner join");
 
     cy.findByTestId("step-join-0-0").within(() => {
       cy.icon("add").click();
     });
 
-    popover()
-      .findByText("Created At")
-      .click();
-    popover()
-      .findByText("Created At")
-      .click();
-
-    cy.icon("join_left_outer")
-      .first()
-      .click();
-    popover()
-      .findByText("Inner join")
-      .click();
+    selectFromDropdown("Created At");
+    selectFromDropdown("Created At");
 
     cy.button("Visualize").click();
     cy.wait("@dataset");
@@ -80,4 +67,71 @@ describe("scenarios > question > joined questions", () => {
     // (join on product's FK + join on the same "created_at" field)
     cy.findByText("Showing 415 rows");
   });
+
+  it("should allow joins on date-time fields", () => {
+    cy.intercept("POST", "/api/dataset").as("dataset");
+    openOrdersTable({ mode: "notebook" });
+
+    joinTable("Products");
+    selectJoinType("Inner join");
+
+    // Test join dimension infers parent dimension's temporal unit
+
+    cy.findByTestId("parent-dimension").click();
+    selectFromDropdown("by month", { force: true });
+    selectFromDropdown("Week");
+
+    cy.findByTestId("join-dimension").click();
+    selectFromDropdown("Created At");
+
+    assertDimensionName("parent", "Created At: Week");
+    assertDimensionName("join", "Created At: Week");
+
+    // Test changing a temporal unit on one dimension would update a second one
+
+    cy.findByTestId("join-dimension").click();
+    selectFromDropdown("by week", { force: true });
+    selectFromDropdown("Day");
+
+    assertDimensionName("parent", "Created At: Day");
+    assertDimensionName("join", "Created At: Day");
+
+    cy.findByText("Summarize").click();
+    selectFromDropdown("Count of rows");
+
+    cy.button("Visualize").click();
+    cy.wait("@dataset");
+
+    // 2087 rows mean the join is done correctly,
+    // (orders joined with products on the same day-month-year)
+    cy.get(".ScalarValue").contains("2,087");
+  });
 });
+
+function joinTable(table) {
+  cy.findByText("Join data").click();
+  popover()
+    .findByText(table)
+    .click();
+}
+
+function selectJoinType(strategy) {
+  cy.icon("join_left_outer")
+    .first()
+    .click();
+  popover()
+    .findByText(strategy)
+    .click();
+}
+
+function selectFromDropdown(option, clickOpts) {
+  popover()
+    .findByText(option)
+    .click(clickOpts);
+}
+
+function assertDimensionName(type, name) {
+  cy.findByTestId(`${type}-dimension`).within(() => {
+    cy.findByText(name);
+  });
+}


### PR DESCRIPTION
In the notebook editor, when you join tables by date-time columns, the SQL casts the joining columns as months. So rows with 11 Jul 2020 and 27 Jul 2020 will match the condition.

This PR makes it possible to select a temporal unit for join dimensions. The options are the same as for breakouts (Day, Week, Month, Year, Quarter, etc.)

Fixes #17826, resolves #10924

### To Verify

1. Ask a question > Custom question > Sample Dataset > Orders
2. Join Products table
3. Select "Inner join" strategy (otherwise the join wouldn't make a lot of sense)
4. Click the "+" button on the right side of the `Orders.PRODUCT_ID = Products.ID` condition to add a new dimensions pair
5. The dimensions picker should open automatically. Hover the "Created At" option and click the "by month" label. From a new popup, select the "Week" option
6. Once the "left" dimension is selected, the "right" dimension picker should open automatically. Now just click "Created At" without specifying the temporal unit.
7. "right" dimension's unit should now also be "Week"
8. Click on the left / right "Created At" dimension and change the temporal unit to "Day"
9. The second dimension's temporal unit should also change to "Day"
10. Click visualize and make sure "Created At" and "Products —> Created At" are the same day-month-year (time can vary). You can hide irrelevant columns to make the testing more convenient.

### Demo

https://user-images.githubusercontent.com/17258145/133302634-20583cc9-2aa3-4545-a191-0364f4302e58.mov

