### PR TITLE
invalidate revision entities cache when questions/dashboards updated/deleted

### DIFF
--- a/frontend/src/metabase/entities/revisions.js
+++ b/frontend/src/metabase/entities/revisions.js
@@ -4,6 +4,8 @@ import { GET, POST } from "metabase/lib/api";
 
 const listRevisions = GET("/api/revision");
 
+const ASSOCIATED_ENTITY_TYPES = ["questions", "dashboards"];
+
 const Revision = createEntity({
   name: "revisions",
   api: {
@@ -27,6 +29,22 @@ const Revision = createEntity({
         id: revision.model_id,
         revision_id: revision.id,
       }),
+  },
+
+  actionShouldInvalidateLists(action) {
+    const entities = require("metabase/entities");
+    for (const type of ASSOCIATED_ENTITY_TYPES) {
+      if (entities[type].actionShouldInvalidateLists(action)) {
+        return true;
+      }
+    }
+
+    return (
+      action.type === this.actionTypes.CREATE ||
+      action.type === this.actionTypes.DELETE ||
+      action.type === this.actionTypes.UPDATE ||
+      action.type === this.actionTypes.INVALIDATE_LISTS_ACTION
+    );
   },
 });
 

--- a/frontend/src/metabase/entities/revisions.js
+++ b/frontend/src/metabase/entities/revisions.js
@@ -39,12 +39,7 @@ const Revision = createEntity({
       }
     }
 
-    return (
-      action.type === this.actionTypes.CREATE ||
-      action.type === this.actionTypes.DELETE ||
-      action.type === this.actionTypes.UPDATE ||
-      action.type === this.actionTypes.INVALIDATE_LISTS_ACTION
-    );
+    return action.type === this.actionTypes.INVALIDATE_LISTS_ACTION;
   },
 });
 

--- a/frontend/test/metabase/scenarios/question/saved.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/saved.cy.spec.js
@@ -119,13 +119,11 @@ describe("scenarios > question > saved", () => {
     cy.button("Save").click();
     cy.wait("@updateQuestion");
 
-    cy.findByText(`changed description from "null" to "This is a question"".`);
+    cy.findByText(/changed description/i);
 
     cy.findByRole("button", { name: "Revert" }).click();
 
-    cy.findByText(
-      `Reverted to an earlier revision and changed description from "This is a question" to "null".`,
-    );
+    cy.findByText(/^Reverted to an earlier revision/i);
   });
 
   it("should be able to use integer filter on a saved native query (metabase#15808)", () => {

--- a/frontend/test/metabase/scenarios/question/saved.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/saved.cy.spec.js
@@ -104,6 +104,30 @@ describe("scenarios > question > saved", () => {
     });
   });
 
+  it("should revert a saved question to a previous version", () => {
+    cy.intercept("PUT", "/api/card/**").as("updateQuestion");
+
+    cy.visit("/question/1");
+    cy.findByTestId("saved-question-header-button").click();
+    cy.findByText("History").click();
+
+    cy.findByTestId("edit-details-button").click();
+    cy.findByLabelText("Description")
+      .click()
+      .type("This is a question");
+
+    cy.button("Save").click();
+    cy.wait("@updateQuestion");
+
+    cy.findByText(`changed description from "null" to "This is a question"".`);
+
+    cy.findByRole("button", { name: "Revert" }).click();
+
+    cy.findByText(
+      `Reverted to an earlier revision and changed description from "This is a question" to "null".`,
+    );
+  });
+
   it("should be able to use integer filter on a saved native query (metabase#15808)", () => {
     cy.createNativeQuestion({
       name: "15808",


### PR DESCRIPTION
Fixes #17910

We already do this with the search entity -- this makes it so that revision entities are invalidated whenever questions or dashboards are invalidated.

**Before**

https://user-images.githubusercontent.com/13057258/133516734-fcd16ce2-ff6b-4451-8d4d-ca2e016e96bf.mov

https://user-images.githubusercontent.com/13057258/133516775-2a23405a-f44d-4f75-a286-062793509211.mov


**After**

https://user-images.githubusercontent.com/13057258/133516754-037a0dd9-94af-49c0-a46a-d8c762c7c2e9.mov

https://user-images.githubusercontent.com/13057258/133516782-2fcc7701-a620-4238-95ed-fba4cafa7cc1.mov

