### PR TITLE
Better with-temp error messages

### DIFF
--- a/test/metabase/models/user_test.clj
+++ b/test/metabase/models/user_test.clj
@@ -415,8 +415,9 @@
           (is (= "en_US"
                  (db/select-one-field :locale User :id user-id)))))
       (testing "invalid locale"
-        (is (thrown?
-             AssertionError
+        (is (thrown-with-msg?
+             Exception
+             #"Assert failed: \(i18n/available-locale\? locale\)"
              (mt/with-temp User [{user-id :id} {:locale "en_XX"}])))))
 
     (testing "updating a User"
@@ -426,8 +427,9 @@
           (is (= "en_GB"
                  (db/select-one-field :locale User :id user-id))))
         (testing "invalid locale"
-          (is (thrown?
+          (is (thrown-with-msg?
                AssertionError
+               #"Assert failed: \(i18n/available-locale\? locale\)"
                (db/update! User user-id :locale "en_XX"))))))))
 
 (deftest normalize-locale-test

--- a/test/metabase/pulse_test.clj
+++ b/test/metabase/pulse_test.clj
@@ -754,9 +754,8 @@
                 (send-pulse-created-by-user! user-kw card)))]
       (is (= [[1 "2014-04-07T00:00:00Z" 5 12]]
              (send-pulse-created-by-user!* :crowberto)))
-      (is (thrown-with-msg?
-           clojure.lang.ExceptionInfo
-           #"^You do not have permissions to view Card [\d,]+."
-           (mt/suppress-output
-             (send-pulse-created-by-user!* :rasta)))
-          "If the current user doesn't have permissions to execute the Card for a Pulse, an Exception should be thrown."))))
+      (testing "If the current user doesn't have permissions to execute the Card for a Pulse, an Exception should be thrown."
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"You do not have permissions to view Card [\d,]+."
+             (send-pulse-created-by-user!* :rasta)))))))

--- a/test/metabase/query_processor/middleware/permissions_test.clj
+++ b/test/metabase/query_processor/middleware/permissions_test.clj
@@ -24,7 +24,6 @@
 
 (defn- check-perms-for-rasta
   "Check permissions for `query` with rasta as the current user."
-  {:style/indent 0}
   [query]
   (do-with-rasta (fn [] (check-perms query))))
 
@@ -32,11 +31,13 @@
 
 (deftest native-query-perms-test
   (testing "Make sure the NATIVE query fails to run if current user doesn't have perms"
-    (is (thrown-with-msg? ExceptionInfo perms-error-msg
-          (check-perms-for-rasta
-           {:database 1000
-            :type     :native
-            :native   {:query "SELECT * FROM VENUES"}}))))
+    (is (thrown-with-msg?
+         ExceptionInfo
+         perms-error-msg
+         (check-perms-for-rasta
+          {:database 1000
+           :type     :native
+           :native   {:query "SELECT * FROM VENUES"}}))))
 
   (testing "...but it should work if user has perms"
     (mt/with-temp Database [db]
@@ -59,9 +60,9 @@
            ;; All users get perms for all new DBs by default
            (perms/revoke-data-perms! (perms-group/all-users) (u/the-id db))
            (check-perms-for-rasta
-             {:database (u/the-id db)
-              :type     :query
-              :query    {:source-table (u/the-id table)}})))))
+            {:database (u/the-id db)
+             :type     :query
+             :query    {:source-table (u/the-id table)}})))))
 
   (testing "...but it should work if user has perms [MBQL]"
     (mt/with-temp* [Database [db]
@@ -71,17 +72,19 @@
               :type     :query
               :query    {:source-table (u/the-id table)}}
              (check-perms-for-rasta
-               {:database (u/the-id db)
-                :type     :query
-                :query    {:source-table (u/the-id table)}}))))))
+              {:database (u/the-id db)
+               :type     :query
+               :query    {:source-table (u/the-id table)}}))))))
 
 (deftest nested-native-query-test
   (testing "Make sure nested native query fails to run if current user doesn't have perms"
-    (is (thrown-with-msg? ExceptionInfo perms-error-msg
-          (check-perms-for-rasta
-           {:database 1000
-            :type     :query
-            :query   {:source-query {:native "SELECT * FROM VENUES"}}}))))
+    (is (thrown-with-msg?
+         ExceptionInfo
+         perms-error-msg
+         (check-perms-for-rasta
+          {:database 1000
+           :type     :query
+           :query   {:source-query {:native "SELECT * FROM VENUES"}}}))))
 
   (testing "...but it should work if user has perms [nested native queries]"
     (mt/with-temp Database [db]
@@ -104,9 +107,9 @@
            ;; All users get perms for all new DBs by default
            (perms/revoke-data-perms! (perms-group/all-users) (u/the-id db))
            (check-perms-for-rasta
-             {:database (u/the-id db)
-              :type     :query
-              :query    {:source-query {:source-table (u/the-id table)}}})))))
+            {:database (u/the-id db)
+             :type     :query
+             :query    {:source-query {:source-table (u/the-id table)}}})))))
 
   (testing "...but it should work if user has perms [nested MBQL queries]"
     (mt/with-temp* [Database [db]
@@ -115,9 +118,9 @@
               :type     :query
               :query    {:source-query {:source-table (u/the-id table)}}}
              (check-perms-for-rasta
-               {:database (u/the-id db)
-                :type     :query
-                :query    {:source-query {:source-table (u/the-id table)}}}))))))
+              {:database (u/the-id db)
+               :type     :query
+               :query    {:source-query {:source-table (u/the-id table)}}}))))))
 
 (deftest template-tags-referenced-queries-test
   (testing "Fails for MBQL query referenced in template tag, when user has no perms to referenced query"
@@ -134,12 +137,12 @@
            (let [card-id  (:id card)
                  tag-name (str "#" card-id)]
              (check-perms-for-rasta
-               {:database (u/the-id db)
-                :type     :native
-                :native   {:query         (format "SELECT * FROM {{%s}} AS x" tag-name)
-                           :template-tags {tag-name
-                                           {:id tag-name, :name tag-name, :display-name tag-name,
-                                            :type "card", :card card-id}}}}))))))
+              {:database (u/the-id db)
+               :type     :native
+               :native   {:query         (format "SELECT * FROM {{%s}} AS x" tag-name)
+                          :template-tags {tag-name
+                                          {:id tag-name, :name tag-name, :display-name tag-name,
+                                           :type "card", :card card-id}}}}))))))
 
   (testing "...but it should work if user has perms [template tag referenced query]"
     (mt/with-temp* [Database [db]
@@ -157,30 +160,32 @@
                          :template-tags {tag-name {:id tag-name, :name tag-name, :display-name tag-name, :type "card",
                                                    :card card-id}}}}
                (check-perms-for-rasta
-                 {:database (u/the-id db)
-                  :type     :native
-                  :native   {:query         query-sql
-                             :template-tags {tag-name
-                                             {:id tag-name, :name tag-name, :display-name tag-name,
-                                              :type "card", :card card-id}}}}))))))
+                {:database (u/the-id db)
+                 :type     :native
+                 :native   {:query         query-sql
+                            :template-tags {tag-name
+                                            {:id tag-name, :name tag-name, :display-name tag-name,
+                                             :type "card", :card card-id}}}}))))))
 
   (testing "Fails for native query referenced in template tag, when user has no perms to referenced query"
-    (is (thrown-with-msg? ExceptionInfo perms-error-msg
-                          (mt/with-temp* [Database [db]
-                                          Card     [card {:dataset_query
-                                                          {:database (u/the-id db), :type :native,
-                                                           :native {:query "SELECT 1 AS \"foo\", 2 AS \"bar\", 3 AS \"baz\""}}}]]
-                            ;; All users get perms for all new DBs by default
-                            (perms/revoke-data-perms! (perms-group/all-users) (u/the-id db))
-                            (let [card-id  (:id card)
-                                  tag-name (str "#" card-id)]
-                              (check-perms-for-rasta
-                                {:database (u/the-id db)
-                                 :type     :native
-                                 :native   {:query         (format "SELECT * FROM {{%s}} AS x" tag-name)
-                                            :template-tags {tag-name
-                                                            {:id tag-name, :name tag-name, :display-name tag-name,
-                                                             :type "card", :card card-id}}}}))))))
+    (is (thrown-with-msg?
+         ExceptionInfo
+         perms-error-msg
+         (mt/with-temp* [Database [db]
+                         Card     [card {:dataset_query
+                                         {:database (u/the-id db), :type :native,
+                                          :native {:query "SELECT 1 AS \"foo\", 2 AS \"bar\", 3 AS \"baz\""}}}]]
+           ;; All users get perms for all new DBs by default
+           (perms/revoke-data-perms! (perms-group/all-users) (u/the-id db))
+           (let [card-id  (:id card)
+                 tag-name (str "#" card-id)]
+             (check-perms-for-rasta
+              {:database (u/the-id db)
+               :type     :native
+               :native   {:query         (format "SELECT * FROM {{%s}} AS x" tag-name)
+                          :template-tags {tag-name
+                                          {:id tag-name, :name tag-name, :display-name tag-name,
+                                           :type "card", :card card-id}}}}))))))
 
   (testing "...but it should work if user has perms [template tag referenced query]"
     (mt/with-temp* [Database [db]
@@ -197,12 +202,12 @@
                            :template-tags {tag-name {:id tag-name, :name tag-name, :display-name tag-name, :type "card",
                                                      :card card-id}}}}
                (check-perms-for-rasta
-                 {:database (u/the-id db)
-                  :type     :native
-                  :native   {:query         query-sql
-                             :template-tags {tag-name
-                                             {:id tag-name, :name tag-name, :display-name tag-name,
-                                              :type "card", :card card-id}}}})))))))
+                {:database (u/the-id db)
+                 :type     :native
+                 :native   {:query         query-sql
+                            :template-tags {tag-name
+                                            {:id tag-name, :name tag-name, :display-name tag-name,
+                                             :type "card", :card card-id}}}})))))))
 
 (deftest end-to-end-test
   (testing (str "Make sure it works end-to-end: make sure bound `*current-user-id*` and `*current-user-permissions-set*` "


### PR DESCRIPTION
Improve error messages for the `with-temp` and `with-temp*` test util macros.

New error messages explicitly specify that they're coming from `with-temp` and include the arguments passed to it

(motivation: I ran into an error where MySQL didn't like a column I was trying to insert, and it took me a while to track down where it was coming from)

I had to update a few tests that were checking error messages caused by `with-temp?`