### PR TITLE
Tweak Avatar: don't use attrs()

### DIFF
--- a/frontend/src/metabase/components/UserAvatar.jsx
+++ b/frontend/src/metabase/components/UserAvatar.jsx
@@ -1,26 +1,25 @@
 import styled from "styled-components";
 import { Flex } from "grid-styled";
-import { height } from "styled-system";
+import { color, height, width } from "styled-system";
 
-import { color } from "metabase/lib/colors";
+import { color as brandColor } from "metabase/lib/colors";
 
-const Avatar = styled(Flex).attrs({
-  align: "center",
-  justifyContent: "center",
-  height: ({ size }) => size,
-  width: ({ size }) => size,
-  fontSize: ({ size }) => size * 0.75,
-})`
-  ${height};
+const Avatar = styled(Flex)`
+  justify-content: center;
+  align-items: center;
   border-radius: 999px;
   font-weight: 900;
   line-height: 1;
+  ${height};
+  ${width};
+  ${color};
 `;
 
 Avatar.defaultProps = {
-  bg: color("brand"),
+  bg: brandColor("brand"),
   color: "white",
-  size: ["3em"],
+  height: ["3em"],
+  width: ["3em"],
 };
 
 function initial(name) {


### PR DESCRIPTION
The custom prop `size` isn't being used anymore, so there's no need to define it. As such, `attr()` is superfluous.

Also, this makes it easy to migrate this component to the upgraded styled-components (see #17056).

To verify, go to `/account/profile` as well as `/admin/people` and make sure the avatar (colored circle, with the user initials) still renders correctly. It should **exactly the same** before and after this PR.

![image](https://user-images.githubusercontent.com/7288/133352065-daf389e1-1ba5-4e12-956e-dd3b77d91b42.png)
