### PR TITLE
Add subscription-allowed-domains allow list Setting

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_config/models/pulse_channel.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_config/models/pulse_channel.clj
@@ -1,0 +1,36 @@
+(ns metabase-enterprise.advanced-config.models.pulse-channel
+  (:require [clojure.string :as str]
+            [flatland.ordered.set :as ordered.set]
+            [metabase.models.setting :as setting :refer [defsetting]]
+            [metabase.public-settings.premium-features :as premium-features]
+            [metabase.util :as u]
+            [metabase.util.i18n :refer [deferred-tru tru]]))
+
+(defsetting subscription-allowed-domains
+  (deferred-tru "Allowed email address domain(s) for new DashboardSubscriptions and Alerts. Does not affect existing subscriptions.")
+  :visibility :public
+  :type       :csv
+  ;; maintain the order of the domains so it doesn't shift around during the roundtrip after someone updates the list.
+  :getter     #(not-empty (into (ordered.set/ordered-set) (setting/get-csv :subscription-allowed-domains))))
+
+(defn validate-email-domains
+  "Check that `email-addresses` associated with a [[metabase.models.pulse-channel]] are allowed based on the value of
+  the [[subscription-allowed-domains]] Setting, if set. This function no-ops if `subscription-allowed-domains` is
+  unset or if we do not have a premium token with the `:advanced-config` feature.
+
+  This function is called by [[metabase.models.pulse-channel/validate-email-domains]] when Pulses are created and
+  updated."
+  [email-addresses]
+  (when (premium-features/enable-advanced-config?)
+    (when-let [allowed-domains (subscription-allowed-domains)]
+      (doseq [email email-addresses
+              :let  [domain (u/email->domain email)]]
+        (assert (u/email? email)
+                (tru "Invalid email address: {0}" (pr-str email)))
+        (when-not (contains? allowed-domains domain)
+          (throw (ex-info (tru "You cannot create new subscriptions for the domain {0}. Allowed domains are: {1}"
+                               (pr-str domain)
+                               (str/join ", " allowed-domains))
+                          {:email           email
+                           :allowed-domains allowed-domains
+                           :status-code     403})))))))

--- a/enterprise/backend/src/metabase_enterprise/advanced_config/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_config/settings.clj
@@ -1,0 +1,2 @@
+(ns metabase-enterprise.advanced-config.settings
+  "Settings related to functionality enabled by the `:advanced-config` token feature.")

--- a/enterprise/backend/src/metabase_enterprise/advanced_config/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_config/settings.clj
@@ -1,2 +1,0 @@
-(ns metabase-enterprise.advanced-config.settings
-  "Settings related to functionality enabled by the `:advanced-config` token feature.")

--- a/enterprise/backend/test/metabase_enterprise/advanced_config/models/pulse_channel_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_config/models/pulse_channel_test.clj
@@ -1,0 +1,51 @@
+(ns metabase-enterprise.advanced-config.models.pulse-channel-test
+  (:require [clojure.string :as str]
+            [clojure.test :refer :all]
+            [metabase.models :refer [Pulse PulseChannel]]
+            [metabase.public-settings.premium-features-test :as premium-features-test]
+            [metabase.test :as mt]
+            [metabase.util :as u]
+            [toucan.db :as db]
+            [toucan.util.test :as tt]))
+
+(deftest validate-email-domains-test
+  (mt/with-temp Pulse [{pulse-id :id}]
+    (doseq [operation               [:create :update]
+            enable-advanced-config? [true false]
+            allowed-domains         [nil
+                                     #{"metabase.com"}
+                                     #{"metabase.com" "toucan.farm"}]
+            emails                  [nil
+                                     ["cam@metabase.com"]
+                                     ["cam@metabase.com" "cam@toucan.farm"]
+                                     ["cam@metabase.com" "cam@disallowed-domain.com"]]
+            :let                    [fail? (and enable-advanced-config?
+                                                allowed-domains
+                                                (not (every? (fn [email]
+                                                               (contains? allowed-domains (u/email->domain email)))
+                                                             emails)))]]
+      (premium-features-test/with-premium-features (if enable-advanced-config?
+                                                     #{:advanced-config}
+                                                     #{})
+        (mt/with-temporary-setting-values [subscription-allowed-domains (str/join "," allowed-domains)]
+          ;; `with-premium-features` and `with-temporary-setting-values` will add `testing` context for the other
+          ;; stuff.
+          (testing (str (format "\nOperation = %s" operation)
+                        (format "\nEmails = %s" (pr-str emails)))
+            (let [thunk (case operation
+                          :create
+                          #(db/insert! PulseChannel
+                             (merge (tt/with-temp-defaults PulseChannel)
+                                    {:pulse_id pulse-id, :details {:emails emails}}))
+
+                          :update
+                          #(mt/with-temp PulseChannel [{pulse-channel-id :id} {:pulse_id pulse-id}]
+                             (db/update! PulseChannel pulse-channel-id, :details {:emails emails})))]
+              (if fail?
+                (testing "should fail"
+                  (is (thrown-with-msg?
+                       clojure.lang.ExceptionInfo
+                       #"You cannot create new subscriptions for the domain \"[\w@\.-]+\". Allowed domains are: .+"
+                       (thunk))))
+                (testing "should succeed"
+                  (is (thunk)))))))))))

--- a/src/metabase/integrations/google.clj
+++ b/src/metabase/integrations/google.clj
@@ -51,19 +51,11 @@
        (when-not (= (:email_verified <>) "true")
          (throw (ex-info (tru "Email is not verified.") {:status-code 400})))))))
 
-; TODO - are these general enough to move to `metabase.util`?
-(defn- email->domain ^String [email]
-  (last (re-find #"^.*@(.*$)" email)))
-
-(defn- email-in-domain? ^Boolean [email domain]
-  {:pre [(u/email? email)]}
-  (= (email->domain email) domain))
-
 (defn- autocreate-user-allowed-for-email? [email]
   (boolean
    (when-let [domains (google.i/google-auth-auto-create-accounts-domain)]
      (some
-      (partial email-in-domain? email)
+      (partial u/email-in-domain? email)
       (str/split domains #"\s*,\s*")))))
 
 (defn- check-autocreate-user-allowed-for-email

--- a/src/metabase/models/pulse_channel.clj
+++ b/src/metabase/models/pulse_channel.clj
@@ -133,20 +133,21 @@
   (classloader/require 'metabase.models.pulse)
   ((resolve 'metabase.models.pulse/will-delete-channel) pulse-channel))
 
-(def ^:private ^{:arglists '([pulse-channel])} validate-email-domains
+;; we want to load this at the top level so the Setting the namespace defines gets loaded
+(def ^:private ^{:arglists '([email-addresses])} validate-email-domains*
+  (or (u/ignore-exceptions
+        (classloader/require 'metabase-enterprise.advanced-config.models.pulse-channel)
+        (resolve 'metabase-enterprise.advanced-config.models.pulse-channel/validate-email-domains))
+      (constantly nil)))
+
+(defn- validate-email-domains
   "For channels that are being sent to raw email addresses: check that the domains in the emails are allowed by
   the [[metabase-enterprise.advanced-config.models.pulse-channel/subscription-allowed-domains]] Setting, if set. This
   will no-op if `subscription-allowed-domains` is unset or if we do not have a premium token with the
   `:advanced-config` feature."
-  (let [validate* (delay
-                    (u/ignore-exceptions
-                      (classloader/require 'metabase-enterprise.advanced-config.models.pulse-channel)
-                      (resolve 'metabase-enterprise.advanced-config.models.pulse-channel/validate-email-domains)))]
-    (fn [{{:keys [emails]} :details, :as pulse-channel}]
-      (u/prog1 pulse-channel
-        (when (seq emails)
-          (when-let [validate @validate*]
-            (validate emails)))))))
+  [{{:keys [emails]} :details, :as pulse-channel}]
+  (u/prog1 pulse-channel
+    (validate-email-domains* emails)))
 
 (u/strict-extend (class PulseChannel)
   models/IModel

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -933,3 +933,20 @@
            q))
        (doto q
          (.offer item))))))
+
+(defn email->domain
+  "Extract the domain portion of an `email-address`.
+
+    (email->domain \"cam@toucan.farm\") ; -> \"toucan.farm\""
+  ^String [email-address]
+  (when (string? email-address)
+    (last (re-find #"^.*@(.*$)" email-address))))
+
+(defn email-in-domain?
+  "Is `email-address` in `domain`?
+
+    (email-in-domain? \"cam@toucan.farm\" \"toucan.farm\")  ; -> true
+    (email-in-domain? \"cam@toucan.farm\" \"metabase.com\") ; -> false"
+  [email-address domain]
+  {:pre [(email? email-address)]}
+  (= (email->domain email-address) domain))

--- a/test/metabase/integrations/google_test.clj
+++ b/test/metabase/integrations/google_test.clj
@@ -1,28 +1,11 @@
 (ns metabase.integrations.google-test
-  (:require [clojure.test :refer :all]
-            [metabase.email-test :as et]
+  (:require [metabase.email-test :as et]
             [metabase.integrations.google :as google]
             [metabase.integrations.google.interface :as google.i]
             [metabase.models.user :refer [User]]
             [metabase.public-settings.premium-features :as premium-features]
             [metabase.test :as mt]
             [toucan.db :as db]))
-
-(deftest email->domain-test
-  (are [domain email] (is (= domain
-                             (#'google/email->domain email))
-                          (format "Domain of email address '%s'" email))
-    "metabase.com"   "cam@metabase.com"
-    "metabase.co.uk" "cam@metabase.co.uk"
-    "metabase.com"   "cam.saul+1@metabase.com"))
-
-(deftest email-in-domain-test
-  (are [in-domain? email domain] (is (= in-domain?
-                                        (#'google/email-in-domain? email domain))
-                                     (format "Is email '%s' in domain '%s'?" email domain))
-    true  "cam@metabase.com"          "metabase.com"
-    false "cam.saul+1@metabase.co.uk" "metabase.com"
-    true  "cam.saul+1@metabase.com"   "metabase.com"))
 
 (deftest allow-autocreation-test
   (with-redefs [premium-features/enable-sso? (constantly false)]

--- a/test/metabase/integrations/google_test.clj
+++ b/test/metabase/integrations/google_test.clj
@@ -1,5 +1,6 @@
 (ns metabase.integrations.google-test
-  (:require [metabase.email-test :as et]
+  (:require [clojure.test :refer :all]
+            [metabase.email-test :as et]
             [metabase.integrations.google :as google]
             [metabase.integrations.google.interface :as google.i]
             [metabase.models.user :refer [User]]

--- a/test/metabase/util_test.clj
+++ b/test/metabase/util_test.clj
@@ -341,3 +341,19 @@
          (transduce (map identity)
                     (u/sorted-take size kompare)
                     coll)))))
+(deftest email->domain-test
+  (are [domain email] (is (= domain
+                             (u/email->domain email))
+                          (format "Domain of email address '%s'" email))
+    nil              nil
+    "metabase.com"   "cam@metabase.com"
+    "metabase.co.uk" "cam@metabase.co.uk"
+    "metabase.com"   "cam.saul+1@metabase.com"))
+
+(deftest email-in-domain-test
+  (are [in-domain? email domain] (is (= in-domain?
+                                        (u/email-in-domain? email domain))
+                                     (format "Is email '%s' in domain '%s'?" email domain))
+    true  "cam@metabase.com"          "metabase.com"
+    false "cam.saul+1@metabase.co.uk" "metabase.com"
+    true  "cam.saul+1@metabase.com"   "metabase.com"))


### PR DESCRIPTION
You can set it either with raw comma-separated strings or as an array of Strings but it will come back as a broken-out array... hopefully this is ok for the FE code. We have existing tooling in the backend to define `:csv` Settings that I wanted to leverage here. If it's a big problem I can rework stuff 