### PR TITLE
Fix issues reverting dashboard

### DIFF
--- a/frontend/src/metabase/containers/HistoryModal.jsx
+++ b/frontend/src/metabase/containers/HistoryModal.jsx
@@ -18,11 +18,12 @@ export default class HistoryModalContainer extends React.Component {
   };
 
   onRevert = async revision => {
-    const { onReverted } = this.props;
+    const { onReverted, reload } = this.props;
     await revision.revert();
     if (onReverted) {
       onReverted();
     }
+    await reload();
   };
 
   render() {

--- a/frontend/src/metabase/dashboard/components/DashboardHistoryModal.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHistoryModal.jsx
@@ -5,7 +5,10 @@ import { withRouter } from "react-router";
 
 import HistoryModal from "metabase/containers/HistoryModal";
 import * as Urls from "metabase/lib/urls";
-import { fetchDashboard, fetchDashboardCardData } from "metabase/dashboard/actions";
+import {
+  fetchDashboard,
+  fetchDashboardCardData,
+} from "metabase/dashboard/actions";
 import Dashboards from "metabase/entities/dashboards";
 
 @withRouter

--- a/frontend/src/metabase/dashboard/components/DashboardHistoryModal.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHistoryModal.jsx
@@ -1,12 +1,12 @@
 /* eslint-disable react/prop-types */
 import React from "react";
+import { connect } from "react-redux";
 import { withRouter } from "react-router";
 
 import HistoryModal from "metabase/containers/HistoryModal";
 import * as Urls from "metabase/lib/urls";
-import * as dashboardActions from "metabase/dashboard/actions";
+import { fetchDashboard, fetchDashboardCardData } from "metabase/dashboard/actions";
 import Dashboards from "metabase/entities/dashboards";
-import connect from "react-redux/lib/connect/connect";
 
 @withRouter
 @Dashboards.load({
@@ -15,7 +15,7 @@ import connect from "react-redux/lib/connect/connect";
 })
 @connect(
   null,
-  dashboardActions,
+  { fetchDashboard, fetchDashboardCardData },
 )
 export default class DashboardHistoryModal extends React.Component {
   render() {

--- a/frontend/src/metabase/dashboard/components/DashboardHistoryModal.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHistoryModal.jsx
@@ -4,24 +4,37 @@ import { withRouter } from "react-router";
 
 import HistoryModal from "metabase/containers/HistoryModal";
 import * as Urls from "metabase/lib/urls";
+import * as dashboardActions from "metabase/dashboard/actions";
 import Dashboards from "metabase/entities/dashboards";
+import connect from "react-redux/lib/connect/connect";
 
 @withRouter
 @Dashboards.load({
   id: (state, props) => Urls.extractEntityId(props.params.slug),
   wrapped: false,
 })
+@connect(
+  null,
+  dashboardActions,
+)
 export default class DashboardHistoryModal extends React.Component {
   render() {
-    const { dashboard, fetch, onClose, location } = this.props;
+    const {
+      dashboard,
+      fetchDashboard,
+      fetchDashboardCardData,
+      onClose,
+      location,
+    } = this.props;
     return (
       <HistoryModal
         modelType="dashboard"
         modelId={dashboard.id}
         canRevert={dashboard.can_write}
-        onReverted={() => {
-          fetch(dashboard.id, location.query);
+        onReverted={async () => {
           onClose();
+          await fetchDashboard(dashboard.id, location.query);
+          await fetchDashboardCardData({ reload: false, clear: true });
         }}
         onClose={onClose}
       />

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -658,7 +658,7 @@ describe("collection permissions", () => {
                 cy.findAllByRole("button", { name: "Revert" });
               });
 
-              it.skip("should be able to revert the dashboard (metabase#15237)", () => {
+              it("should be able to revert the dashboard (metabase#15237)", () => {
                 cy.visit("/dashboard/1");
                 cy.icon("ellipsis").click();
                 cy.findByText("Revision history").click();
@@ -670,6 +670,15 @@ describe("collection permissions", () => {
                 cy.findAllByText(/Revert/).should("not.exist");
                 // We reverted the dashboard to the state prior to adding any cards to it
                 cy.findByText("This dashboard is looking empty.");
+
+                // Should be able to revert back again
+                cy.findByText("Revision history").click();
+                clickRevert("rearranged the cards.");
+                cy.wait("@revert").then(xhr => {
+                  expect(xhr.status).to.eq(200);
+                  expect(xhr.cause).not.to.exist;
+                });
+                cy.findByText("117.03");
               });
 
               it("should be able to access the question's revision history via the revision history button in the header of the query builder", () => {

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -166,7 +166,8 @@
   ;; Now update the cards as needed
   (let [serialized-cards    (:cards serialized-dashboard)
         id->serialized-card (zipmap (map :id serialized-cards) serialized-cards)
-        current-cards       (db/select [DashboardCard :sizeX :sizeY :row :col :id :card_id], :dashboard_id dashboard-id)
+        current-cards       (db/select [DashboardCard :sizeX :sizeY :row :col :id :card_id :dashboard_id]
+                                       :dashboard_id dashboard-id)
         id->current-card    (zipmap (map :id current-cards) current-cards)
         all-dashcard-ids    (concat (map :id serialized-cards)
                                     (map :id current-cards))]

--- a/test/metabase/models/dashboard_test.clj
+++ b/test/metabase/models/dashboard_test.clj
@@ -127,6 +127,10 @@
                                          :id      (= dashcard-id id)
                                          :card_id (= card-id card_id)
                                          :series  (= [series-id-1 series-id-2] series))])
+          empty-dashboard      {:name        "Revert Test"
+                                :description "something"
+                                :cache_ttl   nil
+                                :cards       []}
           serialized-dashboard (serialize-dashboard dashboard)]
       (testing "original state"
         (is (= {:name         "Test Dashboard"
@@ -146,10 +150,7 @@
           :name        "Revert Test"
           :description "something")
         (testing "capture updated Dashboard state"
-          (is (= {:name        "Revert Test"
-                  :description "something"
-                  :cache_ttl   nil
-                  :cards       []}
+          (is (= empty-dashboard
                  (serialize-dashboard (Dashboard dashboard-id))))))
       (testing "now do the reversion; state should return to original"
         (#'dashboard/revert-dashboard! nil dashboard-id (users/user->id :crowberto) serialized-dashboard)
@@ -163,7 +164,11 @@
                                 :id      false
                                 :card_id true
                                 :series  true}]}
-               (update (serialize-dashboard (Dashboard dashboard-id)) :cards check-ids)))))))
+               (update (serialize-dashboard (Dashboard dashboard-id)) :cards check-ids))))
+      (testing "revert back to the empty state"
+        (#'dashboard/revert-dashboard! nil dashboard-id (users/user->id :crowberto) empty-dashboard)
+        (is (= empty-dashboard
+               (serialize-dashboard (Dashboard dashboard-id))))))))
 
 (deftest public-sharing-test
   (testing "test that a Dashboard's :public_uuid comes back if public sharing is enabled..."


### PR DESCRIPTION
Backend Issues:
 - Reverting will fail if the revert involves dashcard deletion due to missing parameter

Frontend Issues:
 - After reverting, the frontend does not reload the dashboard (regression from #15654)
 - After reverting, the frontend does not reload the history list

Fixes #15237