### PR TITLE
Fix whitelabling for chart colors

### DIFF
--- a/frontend/src/metabase/lib/colors.js
+++ b/frontend/src/metabase/lib/colors.js
@@ -199,7 +199,7 @@ export function lighten(
 }
 
 const PREFERRED_COLORS = {
-  [colors["success"]]: [
+  success: [
     "success",
     "succeeded",
     "pass",
@@ -211,7 +211,7 @@ const PREFERRED_COLORS = {
     "active",
     "profit",
   ],
-  [colors["error"]]: [
+  error: [
     "error",
     "fail",
     "failed",
@@ -225,10 +225,10 @@ const PREFERRED_COLORS = {
     "deleted",
     "pending",
   ],
-  [colors["warning"]]: ["warn", "warning", "incomplete", "unstable"],
-  [colors["brand"]]: ["count"],
-  [colors["accent1"]]: ["sum"],
-  [colors["accent2"]]: ["average"],
+  warning: ["warn", "warning", "incomplete", "unstable"],
+  brand: ["count"],
+  accent1: ["sum"],
+  accent2: ["average"],
 };
 
 const PREFERRED_COLORS_MAP = {};
@@ -244,7 +244,7 @@ for (const color in PREFERRED_COLORS) {
 type Key = string;
 
 function getPreferredColor(key: Key) {
-  return PREFERRED_COLORS_MAP[key.toLowerCase()];
+  return color(PREFERRED_COLORS_MAP[key.toLowerCase()]);
 }
 
 // returns a mapping of deterministically assigned colors to keys, optionally with a fixed value mapping

--- a/frontend/test/metabase/lib/colors.unit.spec.js
+++ b/frontend/test/metabase/lib/colors.unit.spec.js
@@ -1,8 +1,25 @@
-import { getRandomColor, normal } from "metabase/lib/colors";
+import colors, { getColorForValue, getRandomColor } from "metabase/lib/colors";
 
 describe("getRandomColor", () => {
   it("should return a color string from the proper family", () => {
-    const color = getRandomColor(normal);
-    expect(Object.values(normal)).toContain(color);
+    const color = getRandomColor(colors);
+    expect(Object.values(colors)).toContain(color);
+  });
+});
+
+describe("getColorForValue", () => {
+  it("should get a color by semantic name", () => {
+    const color = getColorForValue("sum");
+    expect(color).toBe(colors.accent1);
+  });
+
+  it("should respect changes in colors", () => {
+    const { accent1, accent2 } = colors;
+
+    colors.accent1 = accent2;
+    const color = getColorForValue("sum");
+    colors.accent1 = accent1;
+
+    expect(color).toBe(colors.accent2);
   });
 });


### PR DESCRIPTION
The issue is that chart colors were not changed by whitelabling.

How to test:
- `yarn dev-ee`
- Navigate to `Admin > Settings > Whitelabel` and change `accent1`  color.
- Create a question, e.g. based on Orders with Count of rows + Created by month
- Check that the line color is the same as was set