### PR TITLE
treat empty string parameter in url like it is unset

### DIFF
--- a/frontend/src/metabase/dashboard/actions.js
+++ b/frontend/src/metabase/dashboard/actions.js
@@ -20,7 +20,6 @@ import { applyParameters, questionUrlWithParameters } from "metabase/meta/Card";
 import {
   getParameterValuesBySlug,
   getParameterValuesByIdFromQueryParams,
-  removeDefaultedParametersWithEmptyStringValue,
 } from "metabase/meta/Parameter";
 import * as Urls from "metabase/lib/urls";
 import { SIDEBAR_NAME } from "metabase/dashboard/constants";
@@ -707,11 +706,9 @@ export const fetchDashboard = createThunkAction(FETCH_DASHBOARD, function(
 
     const parameterValuesById = preserveParameters
       ? getParameterValues(getState())
-      : getParameterValuesByIdFromQueryParams(
-          result.parameters,
-          queryParams,
-          removeDefaultedParametersWithEmptyStringValue,
-        );
+      : getParameterValuesByIdFromQueryParams(result.parameters, queryParams, {
+          forcefullyUnsetDefaultedParametersWithEmptyStringValue: true,
+        });
 
     return {
       ...normalize(result, dashboard), // includes `result` and `entities`

--- a/frontend/src/metabase/dashboard/actions.js
+++ b/frontend/src/metabase/dashboard/actions.js
@@ -21,7 +21,6 @@ import {
   getParameterValuesBySlug,
   getParameterValuesByIdFromQueryParams,
   removeDefaultedParametersWithEmptyStringValue,
-  getParameterValuesByIdFromPreviousValues,
 } from "metabase/meta/Parameter";
 import * as Urls from "metabase/lib/urls";
 import { SIDEBAR_NAME } from "metabase/dashboard/constants";
@@ -707,10 +706,7 @@ export const fetchDashboard = createThunkAction(FETCH_DASHBOARD, function(
     }
 
     const parameterValuesById = preserveParameters
-      ? getParameterValuesByIdFromPreviousValues(
-          result.parameters,
-          getParameterValues(getState()),
-        )
+      ? getParameterValues(getState())
       : getParameterValuesByIdFromQueryParams(
           result.parameters,
           queryParams,

--- a/frontend/src/metabase/meta/Parameter.js
+++ b/frontend/src/metabase/meta/Parameter.js
@@ -627,17 +627,18 @@ export function isDefaultedParameterSpecialCase(parameter, value) {
 }
 
 export function removeDefaultedParametersWithEmptyStringValue(pairs) {
-  return pairs.filter(
-    ([parameter, value]) => !isDefaultedParameterSpecialCase(parameter, value),
-  );
+  return pairs
+    .map(([parameter, value]) => [parameter, value === "" ? undefined : value])
+    .filter(([parameter, value]) => hasParameterValue(value));
 }
 
-export function treatEmptyStringLikeNilForDefaultedParameters(pairs) {
-  return pairs.map(([parameter, value]) =>
-    isDefaultedParameterSpecialCase(parameter, value)
-      ? [parameter, parameter.default]
-      : [parameter, value],
-  );
+export function removeUndefaultedEmptyStringParameters(pairs) {
+  return pairs
+    .map(([parameter, value]) => [
+      parameter,
+      value === "" ? parameter.default : value,
+    ])
+    .filter(([, value]) => hasParameterValue(value));
 }
 
 export function removeNilValuedPairs(pairs) {
@@ -688,7 +689,7 @@ export function getParameterValuesByIdFromQueryParams(
 
   const transformedPairs = _.isFunction(transform)
     ? transform(parameterValuePairs)
-    : treatEmptyStringLikeNilForDefaultedParameters(parameterValuePairs);
+    : removeUndefaultedEmptyStringParameters(parameterValuePairs);
 
   const idValuePairs = transformedPairs.map(([parameter, value]) => [
     parameter.id,
@@ -696,17 +697,6 @@ export function getParameterValuesByIdFromQueryParams(
   ]);
 
   return Object.fromEntries(idValuePairs);
-}
-
-export function getParameterValuesByIdFromPreviousValues(
-  parameters,
-  parameterValues,
-) {
-  const parameterEntries = parameters
-    .map(p => [p.id, parameterValues[p.id]])
-    .filter(([id, value]) => value != null);
-
-  return Object.fromEntries(parameterEntries);
 }
 
 export function getParameterValuesBySlug(

--- a/frontend/src/metabase/meta/Parameter.js
+++ b/frontend/src/metabase/meta/Parameter.js
@@ -618,40 +618,6 @@ export function getValuePopulatedParameters(parameters, parameterValues) {
     : parameters;
 }
 
-// on dashboards we treat a default parameter with a set value of "" (from a query parameter)
-// to mean that the parameter value is explicitly unset.
-// this is NOT the case elsewhere (native questions, pulses) because default values are
-// automatically used in the query when unset.
-export function isDefaultedParameterSpecialCase(parameter, value) {
-  return hasDefaultParameterValue(parameter) && value === "";
-}
-
-export function removeDefaultedParametersWithEmptyStringValue(pairs) {
-  return pairs
-    .map(([parameter, value]) => [parameter, value === "" ? undefined : value])
-    .filter(([parameter, value]) => hasParameterValue(value));
-}
-
-export function removeUndefaultedEmptyStringParameters(pairs) {
-  return pairs
-    .map(([parameter, value]) => [
-      parameter,
-      value === "" ? parameter.default : value,
-    ])
-    .filter(([, value]) => hasParameterValue(value));
-}
-
-export function removeNilValuedPairs(pairs) {
-  return pairs.filter(([, value]) => hasParameterValue(value));
-}
-
-export function removeUndefaultedNilValuedPairs(pairs) {
-  return pairs.filter(
-    ([parameter, value]) =>
-      hasDefaultParameterValue(parameter) || hasParameterValue(value),
-  );
-}
-
 export function hasDefaultParameterValue(parameter) {
   return parameter.default != null;
 }
@@ -668,27 +634,39 @@ export function getParameterValueFromQueryParams(parameter, queryParams) {
     : parameter.default;
 }
 
-export function getParameterValuePairsFromQueryParams(parameters, queryParams) {
-  return parameters
-    .map(parameter => [
+// on dashboards we treat a default parameter with a set value of "" (from a query parameter)
+// to mean that the parameter value is explicitly unset.
+// this is NOT the case elsewhere (native questions, pulses) because default values are
+// automatically used in the query when unset.
+function removeAllEmptyStringParameters(pairs) {
+  return pairs
+    .map(([parameter, value]) => [parameter, value === "" ? undefined : value])
+    .filter(([parameter, value]) => hasParameterValue(value));
+}
+
+function removeUndefaultedEmptyStringParameters(pairs) {
+  return pairs
+    .map(([parameter, value]) => [
       parameter,
-      getParameterValueFromQueryParams(parameter, queryParams),
+      value === "" ? parameter.default : value,
     ])
     .filter(([, value]) => hasParameterValue(value));
 }
 
+// when `forcefullyUnsetDefaultedParametersWithEmptyStringValue` is true, we treat defaulted parameters with an empty string value as explecitly unset.
+// This CAN'T be used with native questions because defaulted parameters are always applied on the BE when unset on the FE.
 export function getParameterValuesByIdFromQueryParams(
   parameters,
   queryParams,
-  transform,
+  { forcefullyUnsetDefaultedParametersWithEmptyStringValue } = {},
 ) {
-  const parameterValuePairs = getParameterValuePairsFromQueryParams(
-    parameters,
-    queryParams,
-  );
+  const parameterValuePairs = parameters.map(parameter => [
+    parameter,
+    getParameterValueFromQueryParams(parameter, queryParams),
+  ]);
 
-  const transformedPairs = _.isFunction(transform)
-    ? transform(parameterValuePairs)
+  const transformedPairs = forcefullyUnsetDefaultedParametersWithEmptyStringValue
+    ? removeAllEmptyStringParameters(parameterValuePairs)
     : removeUndefaultedEmptyStringParameters(parameterValuePairs);
 
   const idValuePairs = transformedPairs.map(([parameter, value]) => [
@@ -699,10 +677,24 @@ export function getParameterValuesByIdFromQueryParams(
   return Object.fromEntries(idValuePairs);
 }
 
+function removeNilValuedPairs(pairs) {
+  return pairs.filter(([, value]) => hasParameterValue(value));
+}
+
+function removeUndefaultedNilValuedPairs(pairs) {
+  return pairs.filter(
+    ([parameter, value]) =>
+      hasDefaultParameterValue(parameter) || hasParameterValue(value),
+  );
+}
+
+// when `preserveDefaultedParameters` is true, we don't remove defaulted parameters with nil values
+// so that they can be set in the URL query without a value. Used alongside `getParameterValuesByIdFromQueryParams`
+// with `forcefullyUnsetDefaultedParametersWithEmptyStringValue` set to true.
 export function getParameterValuesBySlug(
   parameters,
   parameterValuesById,
-  transform,
+  { preserveDefaultedParameters } = {},
 ) {
   parameterValuesById = parameterValuesById || {};
   const parameterValuePairs = parameters.map(parameter => [
@@ -712,8 +704,8 @@ export function getParameterValuesBySlug(
       : parameterValuesById[parameter.id],
   ]);
 
-  const transformedPairs = _.isFunction(transform)
-    ? transform(parameterValuePairs)
+  const transformedPairs = preserveDefaultedParameters
+    ? removeUndefaultedNilValuedPairs(parameterValuePairs)
     : removeNilValuedPairs(parameterValuePairs);
 
   const slugValuePairs = transformedPairs.map(([parameter, value]) => [

--- a/frontend/src/metabase/parameters/components/Parameters/Parameters.jsx
+++ b/frontend/src/metabase/parameters/components/Parameters/Parameters.jsx
@@ -5,10 +5,7 @@ import querystring from "querystring";
 
 import ParametersList from "metabase/parameters/components/ParametersList";
 import { syncQueryParamsWithURL } from "./syncQueryParamsWithURL";
-import {
-  getParameterValuesBySlug,
-  removeUndefaultedNilValuedPairs,
-} from "metabase/meta/Parameter";
+import { getParameterValuesBySlug } from "metabase/meta/Parameter";
 import { getMetadata } from "metabase/selectors/metadata";
 
 @connect(state => ({ metadata: getMetadata(state) }))
@@ -27,7 +24,7 @@ export default class Parameters extends Component {
       const parameterValuesBySlug = getParameterValuesBySlug(
         parameters,
         parameterValues,
-        dashboard && removeUndefaultedNilValuedPairs,
+        dashboard && { preserveDefaultedParameters: true },
       );
 
       let search = querystring.stringify(parameterValuesBySlug);

--- a/frontend/src/metabase/parameters/components/Parameters/syncQueryParamsWithURL.js
+++ b/frontend/src/metabase/parameters/components/Parameters/syncQueryParamsWithURL.js
@@ -1,9 +1,5 @@
 import Dimension from "metabase-lib/lib/Dimension";
-import {
-  getParameterValueFromQueryParams,
-  getParameterValuePairsFromQueryParams,
-  hasParameterValue,
-} from "metabase/meta/Parameter";
+import { getParameterValuesByIdFromQueryParams } from "metabase/meta/Parameter";
 
 export const syncQueryParamsWithURL = props => {
   props.commitImmediately
@@ -17,13 +13,15 @@ const syncForInternalQuestion = props => {
   if (!setParameterValue) {
     return;
   }
+  const parameterValuesById = getParameterValuesByIdFromQueryParams(
+    parameters,
+    query,
+  );
 
   parameters.forEach(parameter => {
-    const parameterValue = getParameterValueFromQueryParams(parameter, query);
-
-    if (hasParameterValue(parameterValue)) {
+    if (parameter.id in parameterValuesById) {
       const parsedParameterValue = parseQueryParams(
-        parameterValue,
+        parameterValuesById[parameter.id],
         parameter,
         metadata,
       );
@@ -39,15 +37,22 @@ const syncForPublicQuestion = props => {
     return;
   }
 
-  const parameterIdValuePairs = getParameterValuePairsFromQueryParams(
+  const parameterValuesById = getParameterValuesByIdFromQueryParams(
     parameters,
     query,
-  ).map(([parameter, value]) => [
-    parameter.id,
-    parseQueryParams(value, parameter, metadata),
-  ]);
+  );
 
-  const parameterValuesById = Object.fromEntries(parameterIdValuePairs);
+  parameters.forEach(parameter => {
+    if (parameter.id in parameterValuesById) {
+      const parsedParameterValue = parseQueryParams(
+        parameterValuesById[parameter.id],
+        parameter,
+        metadata,
+      );
+
+      parameterValuesById[parameter.id] = parsedParameterValue;
+    }
+  });
 
   setMultipleParameterValues(parameterValuesById);
 };

--- a/frontend/test/metabase/meta/Parameter.unit.spec.js
+++ b/frontend/test/metabase/meta/Parameter.unit.spec.js
@@ -610,8 +610,8 @@ describe("metabase/meta/Parameter", () => {
         it("should treat special cased defaulted parameters + empty string value as NIL and use the defaulted value", () => {
           const queryParamsWithSpecialCase = {
             ...queryParams,
-            foo: "", // has no default
-            bar: "", // has a defautl
+            [parameter1.slug]: "", // this parameter has no default
+            [parameter2.slug]: "", // this parameter has a default
           };
 
           expect(
@@ -620,7 +620,6 @@ describe("metabase/meta/Parameter", () => {
               queryParamsWithSpecialCase,
             ),
           ).toEqual({
-            [parameter1.id]: "",
             [parameter2.id]: "parameter2 default value",
             [parameter3.id]: "parameter3 default value",
           });
@@ -644,8 +643,8 @@ describe("metabase/meta/Parameter", () => {
         it("should return a result that has been transformed by the given transform function", () => {
           const queryParamsWithSpecialCase = {
             ...queryParams,
-            foo: "", // has no default
-            bar: "", // has a defautl
+            [parameter1.slug]: "", // this parameter has no default
+            [parameter2.slug]: "", // this parameter has a default
           };
 
           expect(
@@ -655,7 +654,6 @@ describe("metabase/meta/Parameter", () => {
               removeDefaultedParametersWithEmptyStringValue,
             ),
           ).toEqual({
-            [parameter1.id]: "",
             [parameter3.id]: "parameter3 default value",
           });
         });

--- a/frontend/test/metabase/meta/Parameter.unit.spec.js
+++ b/frontend/test/metabase/meta/Parameter.unit.spec.js
@@ -9,16 +9,10 @@ import {
   getTemplateTagParameters,
   getValuePopulatedParameters,
   getParameterValueFromQueryParams,
-  getParameterValuePairsFromQueryParams,
   getParameterValuesByIdFromQueryParams,
   getParameterValuesBySlug,
   buildHiddenParametersSlugSet,
   getVisibleParameters,
-  isDefaultedParameterSpecialCase,
-  removeDefaultedParametersWithEmptyStringValue,
-  treatEmptyStringLikeNilForDefaultedParameters,
-  removeNilValuedPairs,
-  removeUndefaultedNilValuedPairs,
 } from "metabase/meta/Parameter";
 
 MetabaseSettings.get = jest.fn();
@@ -439,40 +433,6 @@ describe("metabase/meta/Parameter", () => {
     });
   });
 
-  describe("isDefaultedParameterSpecialCase", () => {
-    it("should return true when given a parameter with a default value and a parameter value that is an empty string", () => {
-      const parameter = {
-        default: "abc",
-      };
-
-      expect(isDefaultedParameterSpecialCase(parameter, "")).toBe(true);
-    });
-
-    it("should return false when given a parameter with a default value and a nil parameter value", () => {
-      const parameter = {
-        default: "abc",
-      };
-
-      expect(isDefaultedParameterSpecialCase(parameter, null)).toBe(false);
-    });
-
-    it("should return false when given a parameter with a default value and a parameter value that is not an empty string", () => {
-      const parameter = {
-        default: "abc",
-      };
-
-      expect(isDefaultedParameterSpecialCase(parameter, "foo")).toBe(false);
-    });
-
-    it("should return false when given an undefaulted parameter", () => {
-      const parameter = {};
-
-      expect(isDefaultedParameterSpecialCase(parameter, "")).toBe(false);
-      expect(isDefaultedParameterSpecialCase(parameter, "foo")).toBe(false);
-      expect(isDefaultedParameterSpecialCase(parameter, undefined)).toBe(false);
-    });
-  });
-
   describe("parameter collection-building utils", () => {
     // found in queryParams and not defaulted
     const parameter1 = {
@@ -503,10 +463,12 @@ describe("metabase/meta/Parameter", () => {
       valueNotFoundInParameters: "nonexistent parameter queryParam value",
     };
 
-    const parameterValues = getParameterValuesByIdFromQueryParams(
-      parameters,
-      queryParams,
-    );
+    // typically generated using getParameterValuesByIdFromQueryParams(parameters, queryParams)
+    const parameterValues = {
+      [parameter1.id]: "parameter1 parameterValue",
+      [parameter2.id]: "parameter2 parameterValue",
+      [parameter3.id]: "parameter3 default value",
+    };
 
     describe("getValuePopulatedParameters", () => {
       it("should return an array of parameter objects with the `value` property set if it exists in the given `parameterValues` id, value map", () => {
@@ -567,46 +529,35 @@ describe("metabase/meta/Parameter", () => {
           "parameter2 queryParam value",
         );
       });
-    });
 
-    describe("getParameterValuePairsFromQueryParams", () => {
-      it("should build a list of parameter and parameter value pairs", () => {
+      it("should return an empty string as the value for a defaulted parameter because we handle that special case elsewhere", () => {
         expect(
-          getParameterValuePairsFromQueryParams(parameters, queryParams),
-        ).toEqual([
-          [parameter1, "parameter1 queryParam value"],
-          [parameter2, "parameter2 queryParam value"],
-          [parameter3, "parameter3 default value"],
-        ]);
-      });
-
-      it("should handle undefined queryParams", () => {
-        expect(getParameterValuePairsFromQueryParams(parameters)).toEqual([
-          [parameter2, "parameter2 default value"],
-          [parameter3, "parameter3 default value"],
-        ]);
+          getParameterValueFromQueryParams(parameter2, {
+            [parameter2.slug]: "",
+          }),
+        ).toBe("");
       });
     });
 
     describe("getParameterValuesByIdFromQueryParams", () => {
-      it("should generate a map of parameter values found in the queryParams or with default values", () => {
-        expect(
-          getParameterValuesByIdFromQueryParams(parameters, queryParams),
-        ).toEqual({
-          [parameter1.id]: "parameter1 queryParam value",
-          [parameter2.id]: "parameter2 queryParam value",
-          [parameter3.id]: "parameter3 default value",
+      describe("`forcefullyUnsetDefaultedParametersWithEmptyStringValue` === false", () => {
+        it("should generate a map of parameter values found in the queryParams or with default values", () => {
+          expect(
+            getParameterValuesByIdFromQueryParams(parameters, queryParams),
+          ).toEqual({
+            [parameter1.id]: "parameter1 queryParam value",
+            [parameter2.id]: "parameter2 queryParam value",
+            [parameter3.id]: "parameter3 default value",
+          });
         });
-      });
 
-      it("should handle an undefined queryParams", () => {
-        expect(getParameterValuesByIdFromQueryParams(parameters)).toEqual({
-          [parameter2.id]: "parameter2 default value",
-          [parameter3.id]: "parameter3 default value",
+        it("should handle an undefined queryParams", () => {
+          expect(getParameterValuesByIdFromQueryParams(parameters)).toEqual({
+            [parameter2.id]: "parameter2 default value",
+            [parameter3.id]: "parameter3 default value",
+          });
         });
-      });
 
-      describe("without transform", () => {
         it("should treat special cased defaulted parameters + empty string value as NIL and use the defaulted value", () => {
           const queryParamsWithSpecialCase = {
             ...queryParams,
@@ -618,6 +569,7 @@ describe("metabase/meta/Parameter", () => {
             getParameterValuesByIdFromQueryParams(
               parameters,
               queryParamsWithSpecialCase,
+              { forcefullyUnsetDefaultedParametersWithEmptyStringValue: false },
             ),
           ).toEqual({
             [parameter2.id]: "parameter2 default value",
@@ -633,14 +585,14 @@ describe("metabase/meta/Parameter", () => {
             getParameterValuesByIdFromQueryParams(
               parameters,
               queryParamsWithSpecialCase,
-              treatEmptyStringLikeNilForDefaultedParameters,
+              { forcefullyUnsetDefaultedParametersWithEmptyStringValue: false },
             ),
           );
         });
       });
 
-      describe("with transform", () => {
-        it("should return a result that has been transformed by the given transform function", () => {
+      describe("`forcefullyUnsetDefaultedParametersWithEmptyStringValue` === true", () => {
+        it("should remove defaulted parameters set to '' from the output", () => {
           const queryParamsWithSpecialCase = {
             ...queryParams,
             [parameter1.slug]: "", // this parameter has no default
@@ -651,7 +603,7 @@ describe("metabase/meta/Parameter", () => {
             getParameterValuesByIdFromQueryParams(
               parameters,
               queryParamsWithSpecialCase,
-              removeDefaultedParametersWithEmptyStringValue,
+              { forcefullyUnsetDefaultedParametersWithEmptyStringValue: true },
             ),
           ).toEqual({
             [parameter3.id]: "parameter3 default value",
@@ -661,43 +613,47 @@ describe("metabase/meta/Parameter", () => {
     });
 
     describe("getParameterValuesBySlug", () => {
-      it("should return a map of defined parameter values keyed by the parameter's slug", () => {
-        expect(getParameterValuesBySlug(parameters, parameterValues)).toEqual({
-          [parameter1.slug]: "parameter1 queryParam value",
-          [parameter2.slug]: "parameter2 queryParam value",
-          [parameter3.slug]: "parameter3 default value",
-        });
-      });
-
-      it("should prioritize values found on the parameter object over the parameterValues map", () => {
-        const valuePopulatedParameter1 = {
-          ...parameter1,
-          value: "parameter1 value prop",
-        };
-        const parameters = [valuePopulatedParameter1, parameter2];
-
-        expect(getParameterValuesBySlug(parameters, parameterValues)).toEqual({
-          [parameter1.slug]: "parameter1 value prop",
-          [parameter2.slug]: "parameter2 queryParam value",
-        });
-      });
-
-      it("should handle an undefined parameterValues map", () => {
-        expect(getParameterValuesBySlug(parameters, undefined)).toEqual({});
-        expect(
-          getParameterValuesBySlug([
+      describe("`preserveDefaultedParameters` === false", () => {
+        it("should return a map of defined parameter values keyed by the parameter's slug", () => {
+          expect(getParameterValuesBySlug(parameters, parameterValues)).toEqual(
             {
-              ...parameter1,
-              value: "parameter1 value prop",
+              [parameter1.slug]: "parameter1 parameterValue",
+              [parameter2.slug]: "parameter2 parameterValue",
+              [parameter3.slug]: "parameter3 default value",
             },
-          ]),
-        ).toEqual({
-          [parameter1.slug]: "parameter1 value prop",
+          );
         });
-      });
 
-      describe("without transform", () => {
-        it("should exclude any nil values in the map", () => {
+        it("should prioritize values found on the parameter object over the parameterValues map", () => {
+          const valuePopulatedParameter1 = {
+            ...parameter1,
+            value: "parameter1 value prop",
+          };
+          const parameters = [valuePopulatedParameter1, parameter2];
+
+          expect(getParameterValuesBySlug(parameters, parameterValues)).toEqual(
+            {
+              [parameter1.slug]: "parameter1 value prop", // was set on parameter object
+              [parameter2.slug]: "parameter2 parameterValue", // was NOT set on parameter object, found on parameterValues
+            },
+          );
+        });
+
+        it("should handle an undefined parameterValues map", () => {
+          expect(getParameterValuesBySlug(parameters, undefined)).toEqual({});
+          expect(
+            getParameterValuesBySlug([
+              {
+                ...parameter1,
+                value: "parameter1 value prop",
+              },
+            ]),
+          ).toEqual({
+            [parameter1.slug]: "parameter1 value prop",
+          });
+        });
+
+        it("should remove any properties with nil values from the map", () => {
           const defaultedParameter = {
             id: 999,
             slug: "abc",
@@ -718,18 +674,18 @@ describe("metabase/meta/Parameter", () => {
               defaultedParameterWithValue.value,
           });
 
-          expect(getParameterValuesBySlug(parameters, {})).toEqual(
+          expect(
             getParameterValuesBySlug(
               parameters,
-              parameterValues,
-              removeNilValuedPairs,
+              {},
+              { preserveDefaultedParameters: false },
             ),
-          );
+          ).toEqual(getParameterValuesBySlug(parameters, parameterValues));
         });
       });
 
-      describe("with transform", () => {
-        it("should return a result that has been transformed by the given transform function", () => {
+      describe("`preserveDefaultedParameters` === true", () => {
+        it("should keep defaulted parameters with nil values in the outputted map", () => {
           const defaultedParameter = {
             id: 999,
             slug: "abc",
@@ -746,11 +702,9 @@ describe("metabase/meta/Parameter", () => {
           const parameters = [defaultedParameter, defaultedParameterWithValue];
 
           expect(
-            getParameterValuesBySlug(
-              parameters,
-              parameterValues,
-              removeUndefaultedNilValuedPairs,
-            ),
+            getParameterValuesBySlug(parameters, parameterValues, {
+              preserveDefaultedParameters: true,
+            }),
           ).toEqual({
             [defaultedParameter.slug]: undefined,
             [defaultedParameterWithValue.slug]:


### PR DESCRIPTION
Fixes #17578 

This change let me simplify the `metabase/meta/Parameter.js` interface a bit, so I refactored it further to make it clearer what it does.

When building the map of parameter values from query parameters, we now ALWAYS treat a value of `""` as meaning the same thing as `null` or `undefined`. This means that for a native query, a value of `""` for a defaulted parameter will get set to the default value. On dashboards, it takes on a bit of special meaning; a defaulted parameter set to `""` will not defer to using the default value, unlike `undefined` and `null`.

Here's the behavior on a dashboard:

https://user-images.githubusercontent.com/13057258/133671178-b755d762-ab89-45e9-bb23-d51c58d3c074.mov

Here's the behavior for a native question:

https://user-images.githubusercontent.com/13057258/133671220-c5777b81-c8b7-4dc2-9fd5-e5bb2485a71f.mov


