### PR TITLE
Fix data points formatting for multi-series

### DIFF
--- a/frontend/src/metabase/visualizations/lib/apply_axis.js
+++ b/frontend/src/metabase/visualizations/lib/apply_axis.js
@@ -486,10 +486,12 @@ export function getYValueFormatter(chart, series, yExtent) {
   if (chart.settings["stackable.stack_type"] === "normalized") {
     return value => Math.round(value * 100) + "%";
   }
-  const metricColumn = series[0].data.cols[1];
-  const columnSettings = chart.settings.column(metricColumn);
-  return (value, options) => {
-    const roundedValue = maybeRoundValueToZero(value, yExtent);
+
+  return (value, options, seriesIndex = 0) => {
+    const metricColumn = series[seriesIndex].data.cols[1];
+    const columnSettings = chart.settings.column(metricColumn);
+    const columnExtent = options.extent ?? yExtent;
+    const roundedValue = maybeRoundValueToZero(value, columnExtent);
     return formatValue(roundedValue, { ...columnSettings, ...options });
   };
 }

--- a/frontend/src/metabase/visualizations/lib/chart_values.js
+++ b/frontend/src/metabase/visualizations/lib/chart_values.js
@@ -271,7 +271,7 @@ export function onRenderValueLabels(
         .attr("class", klass)
         .text(({ y, seriesIndex }) => {
           const options = {
-            extent: [0, Number.MIN_VALUE],
+            extent: [],
             negativeInParentheses: displays[seriesIndex] === "waterfall",
             compact: compact === null ? compactForSeries[seriesIndex] : compact,
           };

--- a/frontend/src/metabase/visualizations/lib/chart_values.js
+++ b/frontend/src/metabase/visualizations/lib/chart_values.js
@@ -269,12 +269,15 @@ export function onRenderValueLabels(
         // only create labels for the correct class(es) given the type of label
         .filter(d => !(d.rotated ^ (klass === "value-label-white")))
         .attr("class", klass)
-        .text(({ y, seriesIndex }) =>
-          formatYValue(y, {
+        .text(({ y, seriesIndex }) => {
+          const options = {
+            extent: [0, Number.MIN_VALUE],
             negativeInParentheses: displays[seriesIndex] === "waterfall",
             compact: compact === null ? compactForSeries[seriesIndex] : compact,
-          }),
-        ),
+          };
+
+          return formatYValue(y, options, seriesIndex);
+        }),
     );
   };
 

--- a/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
@@ -36,7 +36,7 @@ describe("scenarios > visualizations > line chart", () => {
     cy.get(Y_AXIS_RIGHT_SELECTOR);
   });
 
-  it.skip("should be able to format data point values style independently on multi-series chart (metabase#13095)", () => {
+  it("should be able to format data point values style independently on multi-series chart (metabase#13095)", () => {
     visitQuestionAdhoc({
       dataset_query: {
         type: "query",


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/13095

Previously:
- Data points formatting used column settings always for the 1st column
- Data points values were rounded to zero using extents of the Y axis, rounding percentage points to `0`.

How to test:
- Follow the steps from the issue or
- Run the cypress test as it does the same