### PR TITLE
Do not display dashboard sticky filter container if no filters set

### DIFF
--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -193,6 +193,7 @@ export default class Dashboard extends Component {
       isFullscreen,
       isNightMode,
       isSharing,
+      parameters,
       showAddQuestionSidebar,
     } = this.props;
 
@@ -209,7 +210,7 @@ export default class Dashboard extends Component {
     );
 
     const shouldRenderParametersWidgetInViewMode =
-      !isEditing && !isFullscreen && parametersWidget;
+      !isEditing && !isFullscreen && parameters.length > 0;
 
     return (
       <DashboardLoadingAndErrorWrapper

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -3,11 +3,11 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import _ from "underscore";
 
-import { FullWidthContainer } from "metabase/styled-components/layout/FullWidthContainer";
 import DashboardControls from "../../hoc/DashboardControls";
 import { DashboardSidebars } from "../DashboardSidebars";
 import DashboardHeader from "../DashboardHeader";
 import {
+  CardsContainer,
   DashboardStyled,
   DashboardLoadingAndErrorWrapper,
   DashboardBody,
@@ -190,6 +190,7 @@ export default class Dashboard extends Component {
       addParameter,
       dashboard,
       isEditing,
+      isEditingParameter,
       isFullscreen,
       isNightMode,
       isSharing,
@@ -214,6 +215,10 @@ export default class Dashboard extends Component {
 
     const shouldRenderParametersWidgetInEditMode =
       isEditing && parameters.length > 0;
+
+    const cardsContainerShouldHaveMarginTop =
+      !shouldRenderParametersWidgetInViewMode &&
+      (!isEditing || isEditingParameter);
 
     return (
       <DashboardLoadingAndErrorWrapper
@@ -263,7 +268,9 @@ export default class Dashboard extends Component {
                   </ParametersWidgetContainer>
                 )}
 
-                <FullWidthContainer>
+                <CardsContainer
+                  addMarginTop={cardsContainerShouldHaveMarginTop}
+                >
                   {dashboardHasCards(dashboard) ? (
                     <DashboardGrid
                       {...this.props}
@@ -274,7 +281,7 @@ export default class Dashboard extends Component {
                       isNightMode={shouldRenderAsNightMode}
                     />
                   )}
-                </FullWidthContainer>
+                </CardsContainer>
               </ParametersAndCardsContainer>
 
               <DashboardSidebars

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -212,6 +212,9 @@ export default class Dashboard extends Component {
     const shouldRenderParametersWidgetInViewMode =
       !isEditing && !isFullscreen && parameters.length > 0;
 
+    const shouldRenderParametersWidgetInEditMode =
+      isEditing && parameters.length > 0;
+
     return (
       <DashboardLoadingAndErrorWrapper
         isFullHeight={isEditing || isSharing}
@@ -237,7 +240,7 @@ export default class Dashboard extends Component {
                 showAddQuestionSidebar={showAddQuestionSidebar}
               />
 
-              {isEditing && (
+              {shouldRenderParametersWidgetInEditMode && (
                 <ParametersWidgetContainer isEditing={isEditing}>
                   {parametersWidget}
                 </ParametersWidgetContainer>

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.jsx
@@ -97,3 +97,11 @@ export const ParametersWidgetContainer = styled(FullWidthContainer)`
       left: 0;
     `}
 `;
+
+export const CardsContainer = styled(FullWidthContainer)`
+  ${({ addMarginTop }) =>
+    addMarginTop &&
+    css`
+      margin-top: ${space(2)};
+    `}
+`;


### PR DESCRIPTION
Fixes #17921

## How to Test

Create a dashboard that is tall enough to generate a scroll in the page — for example, make one card 25 tiles tall.

In view mode, scroll down.

At the very top, there should **not** be a subtle horizontal band the color of the background covering the cards.

Go to edit mode, scroll down.

Below the dashboard title, there should **not** be a subtle horizontal band the color of the background covering the cards.

Please also try adding/editing filters inside edit mode.

<hr />

### After

<img src=https://user-images.githubusercontent.com/380816/133629902-7ac3c164-0f17-4697-953b-e7bb99b22cdd.png width=400 />

### Before

<img src=https://user-images.githubusercontent.com/380816/133630092-b608a5ce-d52c-4c67-8415-2d66cbb60f5f.png width=400 />
