### PR TITLE
Allow using Grid map in native questies questions

### DIFF
--- a/frontend/src/metabase/lib/dataset.js
+++ b/frontend/src/metabase/lib/dataset.js
@@ -31,12 +31,7 @@ export const rangeForValue = (
   value: Value,
   column: ?Column,
 ): ?[number, number] => {
-  if (
-    typeof value === "number" &&
-    column &&
-    column.binning_info &&
-    column.binning_info.bin_width
-  ) {
+  if (typeof value === "number" && column?.binning_info?.bin_width) {
     return [value, value + column.binning_info.bin_width];
   }
 };

--- a/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx
@@ -105,6 +105,8 @@ const ChartTypeOption = ({
         borderRadius: 10,
         padding: 12,
       }}
+      data-testid={`${visualization.uiName}-button`}
+      data-is-sensible={isSensible}
     >
       <Icon name={visualization.iconName} size={20} />
     </Flex>

--- a/frontend/src/metabase/visualizations/visualizations/Map.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Map.jsx
@@ -5,6 +5,7 @@ import ChoroplethMap, {
   getColorplethColorScale,
 } from "../components/ChoroplethMap";
 import PinMap from "../components/PinMap";
+import LeafletGridHeatMap from "../components/LeafletGridHeatMap";
 
 import { ChartSettingsError } from "metabase/visualizations/lib/errors";
 import {
@@ -46,7 +47,8 @@ export default class Map extends Component {
   static isSensible({ cols, rows }) {
     return (
       PinMap.isSensible({ cols, rows }) ||
-      ChoroplethMap.isSensible({ cols, rows })
+      ChoroplethMap.isSensible({ cols, rows }) ||
+      LeafletGridHeatMap.isSensible({ cols, rows })
     );
   }
 

--- a/frontend/test/metabase/scenarios/visualizations/maps.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/maps.cy.spec.js
@@ -208,6 +208,16 @@ describe("scenarios > visualizations > maps", () => {
       },
     });
 
+    // Ensure chart is rendered
     cy.get(".leaflet-interactive");
+
+    cy.findByText("Visualization").click();
+
+    // Ensure the Map visualization is sensible
+    cy.findByTestId("Map-button").should(
+      "have.attr",
+      "data-is-sensible",
+      "true",
+    );
   });
 });

--- a/frontend/test/metabase/scenarios/visualizations/maps.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/maps.cy.spec.js
@@ -185,4 +185,29 @@ describe("scenarios > visualizations > maps", () => {
     cy.findByText("Longitude:");
     cy.findByText("1");
   });
+
+  it("should render grid map visualization for native questions (metabase#8362)", () => {
+    visitQuestionAdhoc({
+      dataset_query: {
+        type: "native",
+        native: {
+          query: `
+              select 20 as "Latitude", -110 as "Longitude", 1 as "metric" union all
+              select 70 as "Latitude", -170 as "Longitude", 5 as "metric"
+            `,
+          "template-tags": {},
+        },
+        database: 1,
+      },
+      display: "map",
+      visualization_settings: {
+        "map.type": "grid",
+        "map.latitude_column": "Latitude",
+        "map.longitude_column": "Longitude",
+        "map.metric_column": "metric",
+      },
+    });
+
+    cy.get(".leaflet-interactive");
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/8362

### Changes
- Map visualization is now suggested for native queries that have two valid coordinates columns and one metric column
- Fixes the error when `LeafletGridHeatMap` was used with native questions. It looked for `column.binning_info` to compute square bounds. However, with native questions, we don't have it so we need to compute bounds from data.

### How to verify
- Simple question -> Sample dataset -> People table
- Summarize by latitude and longitude
- Ensure map is rendered
- Click "Show editor" icon in the top right corner
- Click "View in SQL" icon in the top right corner -> Convert this question to SQL
- Ensure map is rendered