### PR TITLE
fix clearing of sidebar state when removing a parameter

### DIFF
--- a/frontend/src/metabase/dashboard/actions.js
+++ b/frontend/src/metabase/dashboard/actions.js
@@ -830,19 +830,6 @@ export const removeParameter = createThunkAction(
     updateParameters(dispatch, getState, parameters =>
       parameters.filter(p => p.id !== parameterId),
     );
-
-    if (parameterId != null) {
-      dispatch(
-        setSidebar({
-          name: SIDEBAR_NAME.editParameter,
-          props: {
-            parameterId,
-          },
-        }),
-      );
-    } else {
-      dispatch(closeSidebar());
-    }
   },
 );
 

--- a/frontend/src/metabase/dashboard/actions.unit.spec.js
+++ b/frontend/src/metabase/dashboard/actions.unit.spec.js
@@ -7,13 +7,27 @@ import {
   showClickBehaviorSidebar,
   setEditingParameter,
   openAddQuestionSidebar,
+  removeParameter,
+  SET_DASHBOARD_ATTRIBUTES,
 } from "./actions";
 import { SIDEBAR_NAME } from "./constants";
 
 describe("dashboard actions", () => {
   let dispatch;
+  let getState;
   beforeEach(() => {
     dispatch = jest.fn();
+    getState = () => ({
+      dashboard: {
+        dashboardId: 1,
+        dashboards: {
+          1: {
+            id: 1,
+            parameters: [{ id: 123 }, { id: 456 }],
+          },
+        },
+      },
+    });
   });
 
   describe("setSidebar", () => {
@@ -100,6 +114,36 @@ describe("dashboard actions", () => {
           name: SIDEBAR_NAME.addQuestion,
         }),
       );
+    });
+  });
+
+  describe("removeParameter", () => {
+    it("should remove the parameter from the dashboard with the given parameterId", () => {
+      removeParameter(123)(dispatch, getState);
+
+      expect(dispatch).toHaveBeenCalledWith({
+        type: SET_DASHBOARD_ATTRIBUTES,
+        payload: {
+          id: 1,
+          attributes: {
+            parameters: [{ id: 456 }],
+          },
+        },
+      });
+    });
+
+    it("should not remove any parameters if the given parameterId does not match a parameter on the dashboard", () => {
+      removeParameter(999)(dispatch, getState);
+
+      expect(dispatch).toHaveBeenCalledWith({
+        type: SET_DASHBOARD_ATTRIBUTES,
+        payload: {
+          id: 1,
+          attributes: {
+            parameters: getState().dashboard.dashboards[1].parameters,
+          },
+        },
+      });
     });
   });
 });

--- a/frontend/src/metabase/dashboard/reducers.js
+++ b/frontend/src/metabase/dashboard/reducers.js
@@ -299,6 +299,7 @@ const loadingDashCards = handleActions(
   { dashcardIds: [], loadingIds: [], startTime: null },
 );
 
+const DEFAULT_SIDEBAR = { props: {} };
 const sidebar = handleActions(
   {
     [SET_SIDEBAR]: {
@@ -308,16 +309,20 @@ const sidebar = handleActions(
       }),
     },
     [CLOSE_SIDEBAR]: {
-      next: () => ({}),
+      next: () => DEFAULT_SIDEBAR,
     },
     [INITIALIZE]: {
-      next: () => ({}),
+      next: () => DEFAULT_SIDEBAR,
     },
     [SET_EDITING_DASHBOARD]: {
-      next: (state, { payload: isEditing }) => (isEditing ? state : {}),
+      next: (state, { payload: isEditing }) =>
+        isEditing ? state : DEFAULT_SIDEBAR,
+    },
+    [REMOVE_PARAMETER]: {
+      next: () => DEFAULT_SIDEBAR,
     },
   },
-  {},
+  DEFAULT_SIDEBAR,
 );
 
 export default combineReducers({

--- a/frontend/src/metabase/dashboard/reducers.unit.spec.js
+++ b/frontend/src/metabase/dashboard/reducers.unit.spec.js
@@ -4,6 +4,7 @@ import {
   SET_EDITING_DASHBOARD,
   SET_SIDEBAR,
   CLOSE_SIDEBAR,
+  REMOVE_PARAMETER,
 } from "./actions";
 
 describe("dashboard reducers", () => {
@@ -26,7 +27,7 @@ describe("dashboard reducers", () => {
         startTime: null,
       },
       parameterValues: {},
-      sidebar: {},
+      sidebar: { props: {} },
       slowCards: {},
     });
   });
@@ -114,6 +115,24 @@ describe("dashboard reducers", () => {
           payload: false,
         }),
       ).toEqual({ ...initState, isEditing: null });
+    });
+  });
+
+  describe("REMOVE_PARAMETER", () => {
+    it("should clear sidebar state and remove the associated parameter value", () => {
+      expect(
+        reducer(
+          {
+            ...initState,
+            sidebar: { name: "foo", props: { abc: 123 } },
+            parameterValues: { 123: "abc", 456: "def" },
+          },
+          {
+            type: REMOVE_PARAMETER,
+            payload: { id: 123 },
+          },
+        ),
+      ).toEqual({ ...initState, parameterValues: { 456: "def" } });
     });
   });
 });

--- a/frontend/test/metabase/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -21,31 +21,7 @@ describe("scenarios > dashboard > parameters", () => {
     cy.findByText("Baker").should("not.exist");
 
     // Add a filter
-    cy.icon("pencil").click();
-    cy.icon("filter").click();
-    cy.findByText("Location").click();
-    cy.findByText("Dropdown").click();
-
-    // Link that filter to the card
-    cy.findByText("Select…").click();
-    popover().within(() => {
-      cy.findByText("City").click();
-    });
-
-    // Create a default value and save filter
-    cy.findByText("No default").click();
-    cy.findByPlaceholderText("Search by City")
-      .click()
-      .type("B");
-    cy.findByText("Baker").click();
-    cy.findByText("Add filter").click();
-    cy.get(".Button--primary")
-      .contains("Done")
-      .click();
-
-    cy.findByText("Save").click();
-    cy.findByText("You're editing this dashboard.").should("not.exist");
-    cy.findByText("Baker");
+    addCityFilterWithDefault();
 
     cy.log(
       "**Filter should be set and applied after we leave and back to the dashboard**",
@@ -400,6 +376,21 @@ describe("scenarios > dashboard > parameters", () => {
     cy.findByText("Text contains").click();
     cy.findByText("No valid fields");
   });
+
+  it("should be removable from dashboard", () => {
+    cy.visit("/dashboard/1");
+    // Add a filter
+    addCityFilterWithDefault();
+
+    // Remove the filter from the dashboard
+    cy.icon("pencil").click();
+    cy.findByText("Location").click();
+    cy.findByText("Remove").click();
+    cy.findByText("Save").click();
+    cy.findByText("You're editing this dashboard.").should("not.exist");
+
+    cy.findByText("Baker").should("not.exist");
+  });
 });
 
 function selectFilter(selection, filterName) {
@@ -413,4 +404,32 @@ function addQuestion(name) {
   sidebar()
     .contains(name)
     .click();
+}
+
+function addCityFilterWithDefault() {
+  cy.icon("pencil").click();
+  cy.icon("filter").click();
+  cy.findByText("Location").click();
+  cy.findByText("Dropdown").click();
+
+  // Link that filter to the card
+  cy.findByText("Select…").click();
+  popover().within(() => {
+    cy.findByText("City").click();
+  });
+
+  // Create a default value and save filter
+  cy.findByText("No default").click();
+  cy.findByPlaceholderText("Search by City")
+    .click()
+    .type("B");
+  cy.findByText("Baker").click();
+  cy.findByText("Add filter").click();
+  cy.get(".Button--primary")
+    .contains("Done")
+    .click();
+
+  cy.findByText("Save").click();
+  cy.findByText("You're editing this dashboard.").should("not.exist");
+  cy.findByText("Baker");
 }


### PR DESCRIPTION
Fixes #17933 

I added incorrect logic to the `removeParameter` action that resulted in a wonky state, breaking UI code.

Fixed that logic + added tests for `removeParameter` and its dependent reducers.

https://user-images.githubusercontent.com/13057258/133676754-6f8e8915-bdd5-4c6a-92a7-817fca0f6e06.mov


