### PR TITLE
fix wrong data used for click actions in old pivot table

### DIFF
--- a/frontend/src/metabase/lib/data_grid.js
+++ b/frontend/src/metabase/lib/data_grid.js
@@ -525,6 +525,9 @@ export function pivot(data, normalCol, pivotCol, cellCol) {
     return row;
   });
 
+  // keep a record of which row the data came from for onVisualizationClick
+  const sourceRows = normalValues.map(() => pivotValues.map(() => null));
+
   // fill it up with the data
   for (let j = 0; j < data.rows.length; j++) {
     const normalColIdx = normalValues.lastIndexOf(data.rows[j][normalCol]);
@@ -532,6 +535,7 @@ export function pivot(data, normalCol, pivotCol, cellCol) {
 
     pivotedRows[normalColIdx][0] = data.rows[j][normalCol];
     pivotedRows[normalColIdx][pivotColIdx] = data.rows[j][cellCol];
+    sourceRows[normalColIdx][pivotColIdx] = j;
   }
 
   // provide some column metadata to maintain consistency
@@ -558,6 +562,7 @@ export function pivot(data, normalCol, pivotCol, cellCol) {
     cols: cols,
     columns: pivotValues,
     rows: pivotedRows,
+    sourceRows,
   };
 }
 

--- a/frontend/src/metabase/visualizations/components/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive.jsx
@@ -356,7 +356,14 @@ export default class TableInteractive extends Component {
     isPivoted,
     series,
   ) {
-    const clickedRowData = getTableClickedObjectRowData(series, rowIndex);
+    const clickedRowData = getTableClickedObjectRowData(
+      series,
+      rowIndex,
+      columnIndex,
+      isPivoted,
+      data,
+    );
+
     return getTableCellClickedObject(
       data,
       settings,

--- a/frontend/src/metabase/visualizations/components/TableSimple.jsx
+++ b/frontend/src/metabase/visualizations/components/TableSimple.jsx
@@ -208,6 +208,9 @@ export default class TableSimple extends Component {
                       const clickedRowData = getTableClickedObjectRowData(
                         series,
                         rowIndex,
+                        columnIndex,
+                        isPivoted,
+                        data,
                       );
                       const column = cols[columnIndex];
                       const clicked = getTableCellClickedObject(

--- a/frontend/src/metabase/visualizations/lib/table.js
+++ b/frontend/src/metabase/visualizations/lib/table.js
@@ -2,13 +2,29 @@ import type { DatasetData, Column } from "metabase-types/types/Dataset";
 import type { ClickObject } from "metabase-types/types/Visualization";
 import { isNumber, isCoordinate } from "metabase/lib/schema_metadata";
 
-export function getTableClickedObjectRowData([series], rowIndex) {
+export function getTableClickedObjectRowData(
+  [series],
+  rowIndex,
+  columnIndex,
+  isPivoted,
+  data,
+) {
   const { rows, cols } = series.data;
 
-  return rows[rowIndex].map((value, index) => ({
-    value,
-    col: cols[index],
-  }));
+  // if pivoted, we need to find the original rowIndex from the pivoted row/columnIndex
+  const originalRowIndex = isPivoted
+    ? data.sourceRows[rowIndex][columnIndex]
+    : rowIndex;
+
+  // originalRowIndex may be null if the pivot table is empty in that cell
+  if (originalRowIndex === null) {
+    return null;
+  } else {
+    return rows[originalRowIndex].map((value, index) => ({
+      value,
+      col: cols[index],
+    }));
+  }
 }
 
 export function getTableCellClickedObject(

--- a/frontend/test/metabase/lib/data_grid.unit.spec.js
+++ b/frontend/test/metabase/lib/data_grid.unit.spec.js
@@ -64,6 +64,10 @@ describe("data_grid", () => {
         ["a", 1, 2, 3],
         ["b", 4, 5, 6],
       ]);
+      expect(pivotedData.sourceRows).toEqual([
+        [null, 0, 1, 2],
+        [null, 3, 4, 5],
+      ]);
     });
     it("should pivot non-numeric values correctly", () => {
       const data = makeData([
@@ -85,6 +89,10 @@ describe("data_grid", () => {
         ["a", "q", "w", "e"],
         ["b", "r", "t", "y"],
       ]);
+      expect(pivotedData.sourceRows).toEqual([
+        [null, 0, 1, 2],
+        [null, 3, 4, 5],
+      ]);
     });
     it("should pivot values correctly with columns flipped", () => {
       const data = makeData([
@@ -105,6 +113,11 @@ describe("data_grid", () => {
         ["x", 1, 4],
         ["y", 2, 5],
         ["z", 3, 6],
+      ]);
+      expect(pivotedData.sourceRows).toEqual([
+        [null, 0, 3],
+        [null, 1, 4],
+        [null, 2, 5],
       ]);
     });
 
@@ -137,6 +150,10 @@ describe("data_grid", () => {
       expect(pivotedData.rows.map(row => [...row])).toEqual([
         ["a", 1, null, 3],
         ["b", 4, 5, 6],
+      ]);
+      expect(pivotedData.sourceRows).toEqual([
+        [null, 0, null, 1],
+        [null, 2, 3, 4],
       ]);
     });
   });

--- a/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
@@ -138,6 +138,42 @@ describe("scenarios > dashboard > dashboard drill", () => {
     });
   });
 
+  it("should insert data from the correct row in the URL for pivot tables (metabase#17920)", () => {
+    const query =
+      "SELECT STATE, SOURCE, COUNT(*) AS CNT from PEOPLE GROUP BY STATE, SOURCE";
+    const questionSettings = {
+      "table.pivot": true,
+      "table.pivot_column": "SOURCE",
+      "table.cell_column": "CNT",
+    };
+    const columnKey = JSON.stringify(["name", "CNT"]);
+    const dashCardSettings = {
+      column_settings: {
+        [columnKey]: {
+          click_behavior: {
+            type: "link",
+            linkType: "url",
+            linkTemplate: "/test/{{CNT}}/{{STATE}}/{{SOURCE}}",
+          },
+        },
+      },
+    };
+    createQuestion(
+      { query, visualization_settings: questionSettings },
+      questionId => {
+        createDashboard(
+          { questionId, visualization_settings: dashCardSettings },
+          dashboardIdA => cy.visit(`/dashboard/${dashboardIdA}`),
+        );
+      },
+    );
+
+    cy.findAllByText("18")
+      .first()
+      .click();
+    cy.location("pathname").should("eq", "/test/18/CO/Organic");
+  });
+
   it("should handle question click through on a table", () => {
     createDashboardWithQuestion({}, dashboardId =>
       cy.visit(`/dashboard/${dashboardId}`),
@@ -904,7 +940,9 @@ function createQuestion(options, callback) {
     dataset_query: {
       database: 1,
       type: "native",
-      native: { query: "select 111 as my_number, 'foo' as my_string" },
+      native: {
+        query: options.query || "select 111 as my_number, 'foo' as my_string",
+      },
     },
     display: "table",
     visualization_settings: options.visualization_settings || {},

--- a/frontend/test/metabase/visualizations/lib/table.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/table.unit.spec.js
@@ -17,22 +17,76 @@ const DIMENSION_COLUMN = {
 
 describe("metabase/visualization/lib/table", () => {
   describe("getTableClickedObjectRowData", () => {
-    it("should get row data from series", () => {
-      const series = [
-        {
-          data: {
-            rows: [[1, 2, 3]],
-            cols: [DIMENSION_COLUMN, METRIC_COLUMN, RAW_COLUMN],
-          },
+    const series = [
+      {
+        data: {
+          rows: [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+          cols: [DIMENSION_COLUMN, METRIC_COLUMN, RAW_COLUMN],
         },
-      ];
-      const rowIndex = 0;
+      },
+    ];
 
-      expect(getTableClickedObjectRowData(series, rowIndex)).toEqual([
+    it("should get row data from series", () => {
+      const rowIndex = 0;
+      const colIndex = 0;
+      const isPivoted = false;
+      const data = {};
+
+      expect(
+        getTableClickedObjectRowData(
+          series,
+          rowIndex,
+          colIndex,
+          isPivoted,
+          data,
+        ),
+      ).toEqual([
         { col: { source: "breakout" }, value: 1 },
         { col: { source: "aggregation" }, value: 2 },
         { col: { source: "fields" }, value: 3 },
       ]);
+    });
+
+    it("should get correct row data when pivoted", () => {
+      const rowIndex = 1;
+      const colIndex = 2;
+      const isPivoted = true;
+      const pivotedData = {
+        sourceRows: [[null, 0, 1], [null, null, 2]],
+      };
+
+      expect(
+        getTableClickedObjectRowData(
+          series,
+          rowIndex,
+          colIndex,
+          isPivoted,
+          pivotedData,
+        ),
+      ).toEqual([
+        { col: { source: "breakout" }, value: 7 },
+        { col: { source: "aggregation" }, value: 8 },
+        { col: { source: "fields" }, value: 9 },
+      ]);
+    });
+
+    it("should return null when asked for an empty cell in a pivot table", () => {
+      const rowIndex = 1;
+      const colIndex = 1;
+      const isPivoted = true;
+      const pivotedData = {
+        sourceRows: [[null, 0, 1], [null, null, 2]],
+      };
+
+      expect(
+        getTableClickedObjectRowData(
+          series,
+          rowIndex,
+          colIndex,
+          isPivoted,
+          pivotedData,
+        ),
+      ).toBeNull();
     });
   });
 


### PR DESCRIPTION
In `getTableClickedObjectRowData`, we try to get the original row of the data from the rowIndex but because the rowIndex of the pivoted table and the original table does not necessarily match, we get the wrong data.

This PR fixes it by storing a mapping between pivoted (row, col) and the original row number and using that to determine which row to use for the data.

Fixes #17920