### PR TITLE
Remove depstar

### DIFF
--- a/bin/build-drivers/deps.edn
+++ b/bin/build-drivers/deps.edn
@@ -7,7 +7,7 @@
   commons-codec/commons-codec     {:mvn/version "1.14"}
   hiccup/hiccup                   {:mvn/version "1.0.5"}
   io.forward/yaml                 {:mvn/version "1.0.9"} ; Don't upgrade yet, new version doesn't support Java 8 (see https://github.com/owainlewis/yaml/issues/37)
-  io.github.clojure/tools.build   {:git/tag "v0.1.6", :git/sha "5636e61"}
+  io.github.clojure/tools.build   {:git/tag "v0.5.0", :git/sha "7d77952"}
   org.clojure/tools.deps.alpha    {:mvn/version "0.12.985"}
   org.flatland/ordered            {:mvn/version "1.5.9"} ; used by io.forward/yaml -- need the newer version
   stencil/stencil                 {:mvn/version "0.5.0"}

--- a/build.clj
+++ b/build.clj
@@ -6,7 +6,6 @@
             [clojure.tools.namespace.dependency :as ns.deps]
             [clojure.tools.namespace.find :as ns.find]
             [clojure.tools.namespace.parse :as ns.parse]
-            [hf.depstar.api :as d]
             [metabuild-common.core :as c])
   (:import java.io.OutputStream
            java.net.URI
@@ -94,7 +93,7 @@
 (defn create-uberjar! [basis]
   (c/step "Create uberjar"
     (with-duration-ms [duration-ms]
-      (d/uber {:class-dir class-dir
+      (b/uber {:class-dir class-dir
                :uber-file uberjar-filename
                :basis     basis})
       (c/announce "Created uberjar in %.1f seconds." (/ duration-ms 1000.0)))))

--- a/build.clj
+++ b/build.clj
@@ -125,8 +125,8 @@
                :manifest manifest-entries
 
                ;; exclude license.* from jar. We compile 3rd party licenses elsewhere and run into issues on osx due
-               ;; to case insensitive collisions with META-INF/license and META-INF/LICENSE/license.txt
-               :exclude [#"license.*"]})
+               ;; to case insensitive collisions with LICENSE (a file) and license/*.txt
+               :exclude [#"LICENSE"]})
       (c/announce "Created uberjar in %.1f seconds." (/ duration-ms 1000.0)))))
 
 ;; clojure -T:build uberjar :edition <edition>

--- a/deps.edn
+++ b/deps.edn
@@ -396,8 +396,7 @@
   ;; clojure -T:build uberjar
   ;; clojure -T:build uberjar :edition :ee
   :build
-  {:deps       {io.github.clojure/tools.build   {:git/tag "v0.1.6", :git/sha "5636e61"}
-                com.github.seancorfield/depstar {:mvn/version "2.1.278"}
+  {:deps       {io.github.clojure/tools.build   {:git/tag "v0.5.0", :git/sha "7d77952"}
                 metabase/build.common           {:local/root "bin/common"}
                 metabase/buid-mb                {:local/root "bin/build-mb"}}
    :ns-default build}

--- a/java/deps.edn
+++ b/java/deps.edn
@@ -7,7 +7,7 @@
 
  :aliases
  {:build
-  {:deps       {io.github.clojure/tools.build {:git/tag "v0.1.6" :git/sha "5636e61"}}
+  {:deps       {io.github.clojure/tools.build {:git/tag "v0.5.0", :git/sha "7d77952"}}
    :ns-default build}
 
   ;; dependencies needed for compiling the Java files.

--- a/modules/drivers/sparksql/deps.edn
+++ b/modules/drivers/sparksql/deps.edn
@@ -35,7 +35,7 @@
 
  :aliases
  {:aot
-  {:deps       {io.github.clojure/tools.build {:git/tag "v0.1.6" :git/sha "5636e61"}}
+  {:deps       {io.github.clojure/tools.build {:git/tag "v0.5.0", :git/sha "7d77952"}}
    :ns-default build}
 
   ;; dependencies needed for AOT compilation. Same as deps above but without all the exclusions.


### PR DESCRIPTION
tools.build has been updated and depstar has been
[archived](https://github.com/seancorfield/depstar/blob/develop/README.md).

Tools.build copies all of the files into a temp jar whereas depstar would consume
directly from jars. The difference of this raised his head on osx. OSX
is a case insensitive file system whereas jar files are case
insensitive. In our dependency jars we had a situation like

LICENSE   - a file
license/license.txt - a file in a directory called license

In a jar these are fine. On a case sensitive filesystem these can exist
side by side since a file license and a folder LICENSE can
coexist. However on osx this cannot happen since ./license and ./LICENSE
are the same, and one being a file and one a directory is impossible.

Tools.build added exclusions and conflict handlers

```clojure
clojure.tools.build.api/uber
([params])
  Create uberjar file containing contents of deps in basis and class-dir.
  Use main class in manifest if provided. Returns nil.

  Options:
    :class-dir - required, local class dir to include
    :uber-file - required, uber jar file to create
    :basis - used to pull dep jars
    :main - main class symbol
    :manifest - map of manifest attributes, merged last over defaults + :main
    :exclude - coll of string patterns (regex) to exclude from deps
    :conflict-handlers - map of string pattern (regex) to built-in handlers,
                         symbols to eval, or function instances
```

We exclude the single `LICENSE` file so that the other `license/*` files can exist on the filesystem. We still have 3rd party licenses bundled so no issue.

Tools.build also adds ability to pass in manifest options. One thing we have to do though is override the auto-detection of multi-release (#17002) so we end up with `Multi-Release: false` in our jar.