### PR TITLE
Fix combined tooltip for charts

### DIFF
--- a/frontend/src/metabase/visualizations/lib/apply_tooltips.js
+++ b/frontend/src/metabase/visualizations/lib/apply_tooltips.js
@@ -32,11 +32,13 @@ export function getClickHoverObject(
   const isBar = classList.includes("bar");
   const isSingleSeriesBar = isBar && !isMultiseries;
 
-  function getColumnDisplayName(col) {
-    const title = getIn(settings, ["series_settings", col.name, "title"]);
+  function getColumnDisplayName(col, colIndex, card) {
+    const colKey = seriesIndex > 0 && colIndex === 1 ? card.name : col.name;
+    const colTitle = getIn(settings, ["series_settings", colKey, "title"]);
+
     // don't replace with series title for breakout multiseries since the series title is shown in the breakout value
-    if (!isBreakoutMultiseries && title) {
-      return title;
+    if (!isBreakoutMultiseries && colTitle) {
+      return colTitle;
     }
 
     return getFriendlyName(col);
@@ -114,7 +116,7 @@ export function getClickHoverObject(
           };
         }
         return {
-          key: getColumnDisplayName(col),
+          key: getColumnDisplayName(col, i, card),
           value: formatNull(aggregatedRow[i]),
           col: col,
         };

--- a/frontend/src/metabase/visualizations/lib/apply_tooltips.js
+++ b/frontend/src/metabase/visualizations/lib/apply_tooltips.js
@@ -33,6 +33,10 @@ export function getClickHoverObject(
   const isSingleSeriesBar = isBar && !isMultiseries;
 
   function getColumnDisplayName(col, colIndex, card) {
+    // `visualization_settings.series_settings` use `card.name` and
+    // not `column.name` for renamed series when the `seriesIndex > 0`;
+    // check for `columnIndex === 1` because only the first metric column
+    // should be renamed by this setting
     const colKey = seriesIndex > 0 && colIndex === 1 ? card.name : col.name;
     const colTitle = getIn(settings, ["series_settings", colKey, "title"]);
 

--- a/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
@@ -171,7 +171,7 @@ describe("scenarios > visualizations > line chart", () => {
       .should("have.length", 2);
   });
 
-  describe.skip("tooltip of combined dashboard cards (multi-series) should show the correct column title (metabase#16249", () => {
+  describe.only("tooltip of combined dashboard cards (multi-series) should show the correct column title (metabase#16249", () => {
     const RENAMED_FIRST_SERIES = "Foo";
     const RENAMED_SECOND_SERIES = "Bar";
 
@@ -411,5 +411,5 @@ function showTooltipForFirstCircleInSeries(series_index) {
     .as("firstSeries")
     .find("circle")
     .first()
-    .realHover();
+    .trigger("mousemove", { force: true });
 }

--- a/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
@@ -171,7 +171,7 @@ describe("scenarios > visualizations > line chart", () => {
       .should("have.length", 2);
   });
 
-  describe.only("tooltip of combined dashboard cards (multi-series) should show the correct column title (metabase#16249", () => {
+  describe("tooltip of combined dashboard cards (multi-series) should show the correct column title (metabase#16249", () => {
     const RENAMED_FIRST_SERIES = "Foo";
     const RENAMED_SECOND_SERIES = "Bar";
 


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/16249

How to test:
- Follow the steps from the issue or
- Run the unskipped cy test

The original issue comes from this line https://github.com/metabase/metabase/blob/dd6f0cc45346b2d8ad49cb9fc34acfddac68bb01/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx#L543 Basically all `visualization_settings.series_settings` use `card.name` and not `column.key` for renamed series when the `seriesIndex > 0`. Because of backward compatibility issues, we cannot change `_seriesKey` but have to get the correct column name for the tooltip by mirroring this logic. We also need to check for `columnIndex === 1` because only the first metric column should be renamed by this setting.