### PR TITLE
Fix the bulk actions bar on the archive page to reveal the last item

### DIFF
--- a/frontend/src/metabase/home/containers/ArchiveApp.jsx
+++ b/frontend/src/metabase/home/containers/ArchiveApp.jsx
@@ -50,7 +50,7 @@ export default class ArchiveApp extends Component {
         <Box mt={2} py={2}>
           <PageHeading>{t`Archive`}</PageHeading>
         </Box>
-        <Box width={2 / 3}>
+        <Box width={2 / 3} pb={4}>
           <Card
             style={{
               height: list.length > 0 ? ROW_HEIGHT * list.length : "auto",

--- a/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
@@ -197,7 +197,7 @@ describe("scenarios > visualizations > line chart", () => {
       .should("have.length", 2);
   });
 
-  describe.only("tooltip of combined dashboard cards (multi-series) should show the correct column title (metabase#16249", () => {
+  describe.skip("tooltip of combined dashboard cards (multi-series) should show the correct column title (metabase#16249", () => {
     const RENAMED_FIRST_SERIES = "Foo";
     const RENAMED_SECOND_SERIES = "Bar";
 

--- a/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
@@ -437,5 +437,5 @@ function showTooltipForFirstCircleInSeries(series_index) {
     .as("firstSeries")
     .find("circle")
     .first()
-    .trigger("mousemove", { force: true });
+    .realHover();
 }

--- a/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
@@ -197,7 +197,7 @@ describe("scenarios > visualizations > line chart", () => {
       .should("have.length", 2);
   });
 
-  describe.skip("tooltip of combined dashboard cards (multi-series) should show the correct column title (metabase#16249", () => {
+  describe.only("tooltip of combined dashboard cards (multi-series) should show the correct column title (metabase#16249", () => {
     const RENAMED_FIRST_SERIES = "Foo";
     const RENAMED_SECOND_SERIES = "Bar";
 
@@ -437,5 +437,5 @@ function showTooltipForFirstCircleInSeries(series_index) {
     .as("firstSeries")
     .find("circle")
     .first()
-    .realHover();
+    .trigger("mousemove", { force: true });
 }


### PR DESCRIPTION
How to test:
- Create and archive questions until you have more than approx. 15 archived questions to fill the entire page
- Navigate to `/archive`
- Check the last item by hovering over the icon
- Notice that by adding bottom padding the last item is no longer hidden by the bar

<img width="1155" alt="Screen Shot 2021-09-17 at 7 19 47 pm" src="https://user-images.githubusercontent.com/8542534/133821308-b56b27f2-8588-46c0-bafd-d3816474c4b0.png">
<img width="1129" alt="Screen Shot 2021-09-17 at 7 19 54 pm" src="https://user-images.githubusercontent.com/8542534/133821316-ae65f274-3792-47db-953f-ec537311ad00.png">
<img width="1138" alt="Screen Shot 2021-09-17 at 7 20 01 pm" src="https://user-images.githubusercontent.com/8542534/133821317-00bf40d4-9887-4fe4-a9ea-e780e6d9a24b.png">
