### PR TITLE
For sparklines, check that viz type is line

### DIFF
--- a/src/metabase/pulse/render.clj
+++ b/src/metabase/pulse/render.clj
@@ -99,7 +99,7 @@
              (> @row-sample-count 1)
              (types/temporal-field? @col-1)
              (number-field? @col-2)
-             (= chart-type :line))
+             (not= display-type :waterfall))
         (chart-type :sparkline "result has 2 cols (%s (temporal) and %s (number)) and > 1 row" (col-description @col-1) (col-description @col-2))
 
         (and (= @col-sample-count 2)

--- a/src/metabase/pulse/render.clj
+++ b/src/metabase/pulse/render.clj
@@ -98,7 +98,8 @@
         (and (= @col-sample-count 2)
              (> @row-sample-count 1)
              (types/temporal-field? @col-1)
-             (number-field? @col-2))
+             (number-field? @col-2)
+             (= chart-type :line))
         (chart-type :sparkline "result has 2 cols (%s (temporal) and %s (number)) and > 1 row" (col-description @col-1) (col-description @col-2))
 
         (and (= @col-sample-count 2)


### PR DESCRIPTION
this actually goes to fix waterfalls. They would match these
requirements but the viz type of waterfall would give results that would
dip out of the viewport. Fallback to table rendering

##### before
<img width="1112" alt="image" src="https://user-images.githubusercontent.com/6377293/133823643-7d9c1f84-1062-4423-8a21-ac0a0a2a29ea.png">

##### after
<img width="1112" alt="image" src="https://user-images.githubusercontent.com/6377293/133823682-91fc18d2-16c1-4bb9-b3ca-4bad12f0cdbf.png">


