### PR TITLE
Fix SaveQuestionModal's submit button state

### DIFF
--- a/frontend/src/metabase/containers/SaveQuestionModal.jsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal.jsx
@@ -28,6 +28,14 @@ export default class SaveQuestionModal extends Component {
     multiStep: PropTypes.bool,
   };
 
+  validateName = (name, context) => {
+    if (context.form.saveType.value !== "overwrite") {
+      // We don't care if the form is valid when overwrite mode is enabled,
+      // as original question's data will be submitted instead of the form values
+      return validate.required()(name);
+    }
+  };
+
   handleSubmit = async details => {
     // TODO Atte Keinäenn 31/1/18 Refactor this
     // I think that the primary change should be that
@@ -105,7 +113,10 @@ export default class SaveQuestionModal extends Component {
           initialValues={initialValues}
           fields={[
             { name: "saveType" },
-            { name: "name" },
+            {
+              name: "name",
+              validate: this.validateName,
+            },
             { name: "description" },
             { name: "collection_id" },
           ]}
@@ -133,11 +144,6 @@ export default class SaveQuestionModal extends Component {
                       name="name"
                       title={t`Name`}
                       placeholder={t`What is the name of your card?`}
-                      validate={
-                        values.saveType === "create"
-                          ? validate.required()
-                          : null
-                      }
                     />
                     <FormField
                       name="description"

--- a/frontend/test/metabase/containers/SaveQuestionModal.unit.spec.js
+++ b/frontend/test/metabase/containers/SaveQuestionModal.unit.spec.js
@@ -368,6 +368,7 @@ describe("SaveQuestionModal", () => {
     userEvent.click(screen.getByLabelText("close icon"));
     expect(onCloseMock).toHaveBeenCalledTimes(1);
   });
+
   describe("Cache TTL field", () => {
     beforeEach(() => {
       mockCachingEnabled();

--- a/frontend/test/metabase/containers/SaveQuestionModal.unit.spec.js
+++ b/frontend/test/metabase/containers/SaveQuestionModal.unit.spec.js
@@ -82,6 +82,7 @@ function getQuestion({
     metadata,
   );
 }
+
 const EXPECTED_DIRTY_SUGGESTED_NAME = "Orders, Count, Grouped by Total";
 
 function getDirtyQuestion(originalQuestion) {
@@ -151,6 +152,26 @@ describe("SaveQuestionModal", () => {
       expect(screen.getByLabelText("Name")).toHaveValue(
         EXPECTED_SUGGESTED_NAME,
       );
+    });
+
+    it("should not suggest a name for native queries", () => {
+      renderSaveQuestionModal(
+        new Question(
+          {
+            dataset_query: {
+              type: "native",
+              database: ORDERS.id,
+              native: {
+                query: "select * from orders",
+              },
+              display: "table",
+            },
+          },
+          metadata,
+        ),
+      );
+
+      expect(screen.getByLabelText("Name")).toHaveValue("");
     });
 
     it("should display empty description input", () => {

--- a/frontend/test/metabase/containers/SaveQuestionModal.unit.spec.js
+++ b/frontend/test/metabase/containers/SaveQuestionModal.unit.spec.js
@@ -1,4 +1,6 @@
 import React from "react";
+import { Provider } from "react-redux";
+import { reducer as form } from "redux-form";
 import { render, screen, fireEvent } from "@testing-library/react";
 import mock from "xhr-mock";
 
@@ -14,9 +16,6 @@ import {
   metadata,
 } from "__support__/sample_dataset_fixture";
 import { getStore } from "__support__/entities-store";
-
-import { Provider } from "react-redux";
-import { reducer as form } from "redux-form";
 
 function mockCachingEnabled(enabled = true) {
   const original = MetabaseSettings.get;

--- a/frontend/test/metabase/containers/SaveQuestionModal.unit.spec.js
+++ b/frontend/test/metabase/containers/SaveQuestionModal.unit.spec.js
@@ -209,66 +209,6 @@ describe("SaveQuestionModal", () => {
     });
   });
 
-  describe("overwriting a saved question", () => {
-    it("should call onSave correctly when form is submitted", () => {
-      const originalQuestion = getQuestion({ isSaved: true });
-      const dirtyQuestion = getDirtyQuestion(originalQuestion);
-      const { onSaveMock } = renderSaveQuestionModal(
-        dirtyQuestion,
-        originalQuestion,
-      );
-
-      userEvent.click(screen.getByText("Save"));
-
-      expect(onSaveMock).toHaveBeenCalledTimes(1);
-      expect(onSaveMock).toHaveBeenCalledWith({
-        ...dirtyQuestion.card(),
-        id: originalQuestion.id(),
-      });
-    });
-
-    it("should preserve original question's collection id", () => {
-      const originalQuestion = getQuestion({
-        isSaved: true,
-        collection_id: 5,
-      });
-      const { onSaveMock } = renderSaveQuestionModal(
-        getDirtyQuestion(originalQuestion),
-        originalQuestion,
-      );
-
-      userEvent.click(screen.getByText("Save"));
-
-      expect(onSaveMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          collection_id: originalQuestion.collectionId(),
-        }),
-      );
-    });
-
-    it("shouldn't allow to save a question if form is invalid", () => {
-      renderSaveQuestionModal(getQuestion());
-
-      userEvent.clear(screen.getByLabelText("Name"));
-      userEvent.clear(screen.getByLabelText("Description"));
-
-      expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
-    });
-
-    it("shouldn't call onCreate when form is submitted", () => {
-      const originalQuestion = getQuestion({ isSaved: true });
-      const dirtyQuestion = getDirtyQuestion(originalQuestion);
-      const { onCreateMock } = renderSaveQuestionModal(
-        dirtyQuestion,
-        originalQuestion,
-      );
-
-      userEvent.click(screen.getByText("Save"));
-
-      expect(onCreateMock).not.toHaveBeenCalled();
-    });
-  });
-
   describe("saving as a new question", () => {
     it("should offer to replace the original question by default", () => {
       const originalQuestion = getQuestion({ isSaved: true });
@@ -354,6 +294,66 @@ describe("SaveQuestionModal", () => {
       userEvent.clear(screen.getByLabelText("Description"));
 
       expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+    });
+  });
+
+  describe("overwriting a saved question", () => {
+    it("should call onSave correctly when form is submitted", () => {
+      const originalQuestion = getQuestion({ isSaved: true });
+      const dirtyQuestion = getDirtyQuestion(originalQuestion);
+      const { onSaveMock } = renderSaveQuestionModal(
+        dirtyQuestion,
+        originalQuestion,
+      );
+
+      userEvent.click(screen.getByText("Save"));
+
+      expect(onSaveMock).toHaveBeenCalledTimes(1);
+      expect(onSaveMock).toHaveBeenCalledWith({
+        ...dirtyQuestion.card(),
+        id: originalQuestion.id(),
+      });
+    });
+
+    it("should preserve original question's collection id", () => {
+      const originalQuestion = getQuestion({
+        isSaved: true,
+        collection_id: 5,
+      });
+      const { onSaveMock } = renderSaveQuestionModal(
+        getDirtyQuestion(originalQuestion),
+        originalQuestion,
+      );
+
+      userEvent.click(screen.getByText("Save"));
+
+      expect(onSaveMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          collection_id: originalQuestion.collectionId(),
+        }),
+      );
+    });
+
+    it("shouldn't allow to save a question if form is invalid", () => {
+      renderSaveQuestionModal(getQuestion());
+
+      userEvent.clear(screen.getByLabelText("Name"));
+      userEvent.clear(screen.getByLabelText("Description"));
+
+      expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+    });
+
+    it("shouldn't call onCreate when form is submitted", () => {
+      const originalQuestion = getQuestion({ isSaved: true });
+      const dirtyQuestion = getDirtyQuestion(originalQuestion);
+      const { onCreateMock } = renderSaveQuestionModal(
+        dirtyQuestion,
+        originalQuestion,
+      );
+
+      userEvent.click(screen.getByText("Save"));
+
+      expect(onCreateMock).not.toHaveBeenCalled();
     });
   });
 

--- a/frontend/test/metabase/containers/SaveQuestionModal.unit.spec.js
+++ b/frontend/test/metabase/containers/SaveQuestionModal.unit.spec.js
@@ -32,6 +32,7 @@ const renderSaveQuestionModal = (question, originalQuestion) => {
   const store = getStore({ form });
   const onCreateMock = jest.fn(() => Promise.resolve());
   const onSaveMock = jest.fn(() => Promise.resolve());
+  const onCloseMock = jest.fn();
   render(
     <Provider store={store}>
       <SaveQuestionModal
@@ -40,11 +41,11 @@ const renderSaveQuestionModal = (question, originalQuestion) => {
         tableMetadata={question.table()}
         onCreate={onCreateMock}
         onSave={onSaveMock}
-        onClose={() => {}}
+        onClose={onCloseMock}
       />
     </Provider>,
   );
-  return { store, onSaveMock, onCreateMock };
+  return { store, onSaveMock, onCreateMock, onCloseMock };
 };
 
 const EXPECTED_SUGGESTED_NAME = "Orders, Count";
@@ -258,6 +259,18 @@ describe("SaveQuestionModal", () => {
     });
   });
 
+
+  it("should call onClose when Cancel button is clicked", () => {
+    const { onCloseMock } = renderSaveQuestionModal(getQuestion());
+    userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onCloseMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("should call onClose when close icon is clicked", () => {
+    const { onCloseMock } = renderSaveQuestionModal(getQuestion());
+    userEvent.click(screen.getByLabelText("close icon"));
+    expect(onCloseMock).toHaveBeenCalledTimes(1);
+  });
   describe("Cache TTL field", () => {
     beforeEach(() => {
       mockCachingEnabled();

--- a/frontend/test/metabase/containers/SaveQuestionModal.unit.spec.js
+++ b/frontend/test/metabase/containers/SaveQuestionModal.unit.spec.js
@@ -245,6 +245,15 @@ describe("SaveQuestionModal", () => {
       );
     });
 
+    it("shouldn't allow to save a question if form is invalid", () => {
+      renderSaveQuestionModal(getQuestion());
+
+      userEvent.clear(screen.getByLabelText("Name"));
+      userEvent.clear(screen.getByLabelText("Description"));
+
+      expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+    });
+
     it("shouldn't call onCreate when form is submitted", () => {
       const originalQuestion = getQuestion({ isSaved: true });
       const dirtyQuestion = getDirtyQuestion(originalQuestion);

--- a/frontend/test/metabase/containers/SaveQuestionModal.unit.spec.js
+++ b/frontend/test/metabase/containers/SaveQuestionModal.unit.spec.js
@@ -82,10 +82,16 @@ function getQuestion({
 }
 
 function getDirtyQuestion(originalQuestion) {
-  return originalQuestion
+  const question = originalQuestion
     .query()
     .breakout(["field", ORDERS.TOTAL.id, null])
     .question();
+  return question.setCard({
+    ...question.card(),
+    // After a saved question is edited, the ID gets removed
+    // and a user can either overwrite a question or save it as a new one
+    id: undefined,
+  });
 }
 
 describe("SaveQuestionModal", () => {
@@ -149,7 +155,10 @@ describe("SaveQuestionModal", () => {
     fireEvent.click(screen.getByText("Save"));
 
     expect(onSaveMock).toHaveBeenCalledTimes(1);
-    expect(onSaveMock).toHaveBeenCalledWith(dirtyQuestion.card());
+    expect(onSaveMock).toHaveBeenCalledWith({
+      ...dirtyQuestion.card(),
+      id: originalQuestion.id(),
+    });
   });
 
   it("should preserve the collection_id of a question in overwrite mode", async () => {

--- a/frontend/test/metabase/containers/SaveQuestionModal.unit.spec.js
+++ b/frontend/test/metabase/containers/SaveQuestionModal.unit.spec.js
@@ -96,7 +96,7 @@ describe("SaveQuestionModal", () => {
     const { onCreateMock } = renderSaveQuestionModal(newQuestion, null);
 
     fireEvent.click(screen.getByText("Save"));
-    expect(onCreateMock.mock.calls).toHaveLength(1);
+    expect(onCreateMock).toHaveBeenCalledTimes(1);
   });
 
   it("should call onSave correctly for a dirty, saved question", async () => {
@@ -122,7 +122,7 @@ describe("SaveQuestionModal", () => {
       originalQuestion,
     );
     fireEvent.click(screen.getByText("Save"));
-    expect(onSaveMock.mock.calls.length).toBe(1);
+    expect(onSaveMock).toHaveBeenCalledTimes(1);
   });
 
   it("should preserve the collection_id of a question in overwrite mode", async () => {

--- a/frontend/test/metabase/containers/SaveQuestionModal.unit.spec.js
+++ b/frontend/test/metabase/containers/SaveQuestionModal.unit.spec.js
@@ -298,6 +298,19 @@ describe("SaveQuestionModal", () => {
   });
 
   describe("overwriting a saved question", () => {
+    it("should display original question's name on save mode control", () => {
+      const originalQuestion = getQuestion({
+        isSaved: true,
+        name: "Beautiful Orders",
+      });
+      const dirtyQuestion = getDirtyQuestion(originalQuestion);
+      renderSaveQuestionModal(dirtyQuestion, originalQuestion);
+
+      expect(
+        screen.queryByText('Replace original question, "Beautiful Orders"'),
+      ).toBeInTheDocument();
+    });
+
     it("should call onSave correctly when form is submitted", () => {
       const originalQuestion = getQuestion({ isSaved: true });
       const dirtyQuestion = getDirtyQuestion(originalQuestion);
@@ -306,6 +319,25 @@ describe("SaveQuestionModal", () => {
         originalQuestion,
       );
 
+      userEvent.click(screen.getByText("Save"));
+
+      expect(onSaveMock).toHaveBeenCalledTimes(1);
+      expect(onSaveMock).toHaveBeenCalledWith({
+        ...dirtyQuestion.card(),
+        id: originalQuestion.id(),
+      });
+    });
+
+    it("should allow switching to 'save as new' and back", () => {
+      const originalQuestion = getQuestion({ isSaved: true });
+      const dirtyQuestion = getDirtyQuestion(originalQuestion);
+      const { onSaveMock } = renderSaveQuestionModal(
+        dirtyQuestion,
+        originalQuestion,
+      );
+
+      userEvent.click(screen.getByText("Save as new question"));
+      userEvent.click(screen.getByText(/Replace original question, ".*"/));
       userEvent.click(screen.getByText("Save"));
 
       expect(onSaveMock).toHaveBeenCalledTimes(1);

--- a/frontend/test/metabase/containers/SaveQuestionModal.unit.spec.js
+++ b/frontend/test/metabase/containers/SaveQuestionModal.unit.spec.js
@@ -189,6 +189,25 @@ describe("SaveQuestionModal", () => {
       });
     });
 
+    it("should trim name and description", () => {
+      const question = getQuestion();
+      const { onCreateMock } = renderSaveQuestionModal(question);
+
+      fillForm({
+        name: "    My favorite orders ",
+        description: "  So many of them   ",
+      });
+      userEvent.click(screen.getByText("Save"));
+
+      expect(onCreateMock).toHaveBeenCalledTimes(1);
+      expect(onCreateMock).toHaveBeenCalledWith({
+        ...question.card(),
+        name: "My favorite orders",
+        description: "So many of them",
+        collection_id: undefined,
+      });
+    });
+
     it("shouldn't call onSave when form is submitted", () => {
       const question = getQuestion();
       const { onSaveMock } = renderSaveQuestionModal(question);

--- a/frontend/test/metabase/containers/SaveQuestionModal.unit.spec.js
+++ b/frontend/test/metabase/containers/SaveQuestionModal.unit.spec.js
@@ -1,7 +1,8 @@
 import React from "react";
 import { Provider } from "react-redux";
 import { reducer as form } from "redux-form";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import mock from "xhr-mock";
 
 import SaveQuestionModal from "metabase/containers/SaveQuestionModal";
@@ -133,7 +134,7 @@ describe("SaveQuestionModal", () => {
     const question = getQuestion();
     const { onCreateMock } = renderSaveQuestionModal(question);
 
-    fireEvent.click(screen.getByText("Save"));
+    userEvent.click(screen.getByText("Save"));
 
     expect(onCreateMock).toHaveBeenCalledTimes(1);
     expect(onCreateMock).toHaveBeenCalledWith({
@@ -152,7 +153,7 @@ describe("SaveQuestionModal", () => {
       originalQuestion,
     );
 
-    fireEvent.click(screen.getByText("Save"));
+    userEvent.click(screen.getByText("Save"));
 
     expect(onSaveMock).toHaveBeenCalledTimes(1);
     expect(onSaveMock).toHaveBeenCalledWith({
@@ -171,7 +172,7 @@ describe("SaveQuestionModal", () => {
       originalQuestion,
     );
 
-    fireEvent.click(screen.getByText("Save"));
+    userEvent.click(screen.getByText("Save"));
 
     expect(onSaveMock).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/frontend/test/metabase/containers/SaveQuestionModal.unit.spec.js
+++ b/frontend/test/metabase/containers/SaveQuestionModal.unit.spec.js
@@ -427,6 +427,41 @@ describe("SaveQuestionModal", () => {
 
       expect(onCreateMock).not.toHaveBeenCalled();
     });
+
+    it("should keep 'save as new' form values while switching saving modes", () => {
+      const originalQuestion = getQuestion({ isSaved: true });
+      renderSaveQuestionModal(
+        getDirtyQuestion(originalQuestion),
+        originalQuestion,
+      );
+
+      userEvent.click(screen.getByText("Save as new question"));
+      fillForm({
+        name: "Should not be erased",
+        description: "This should not be erased too",
+      });
+      userEvent.click(screen.getByText(/Replace original question, ".*"/));
+      userEvent.click(screen.getByText("Save as new question"));
+
+      expect(screen.getByLabelText("Name")).toHaveValue("Should not be erased");
+      expect(screen.getByLabelText("Description")).toHaveValue(
+        "This should not be erased too",
+      );
+    });
+
+    it("should allow to replace the question if new question form is invalid (metabase#13817", () => {
+      const originalQuestion = getQuestion({ isSaved: true });
+      renderSaveQuestionModal(
+        getDirtyQuestion(originalQuestion),
+        originalQuestion,
+      );
+
+      userEvent.click(screen.getByText("Save as new question"));
+      userEvent.clear(screen.getByLabelText("Name"));
+      userEvent.click(screen.getByText(/Replace original question, ".*"/));
+
+      expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();
+    });
   });
 
   it("should call onClose when Cancel button is clicked", () => {

--- a/frontend/test/metabase/containers/SaveQuestionModal.unit.spec.js
+++ b/frontend/test/metabase/containers/SaveQuestionModal.unit.spec.js
@@ -207,41 +207,55 @@ describe("SaveQuestionModal", () => {
     });
   });
 
-  it("should call onSave correctly for a dirty, saved question", async () => {
-    const originalQuestion = getQuestion({ isSaved: true });
-    const dirtyQuestion = getDirtyQuestion(originalQuestion);
-    const { onSaveMock } = renderSaveQuestionModal(
-      dirtyQuestion,
-      originalQuestion,
-    );
+  describe("overwriting a saved question", () => {
+    it("should call onSave correctly when form is submitted", () => {
+      const originalQuestion = getQuestion({ isSaved: true });
+      const dirtyQuestion = getDirtyQuestion(originalQuestion);
+      const { onSaveMock } = renderSaveQuestionModal(
+        dirtyQuestion,
+        originalQuestion,
+      );
 
-    userEvent.click(screen.getByText("Save"));
+      userEvent.click(screen.getByText("Save"));
 
-    expect(onSaveMock).toHaveBeenCalledTimes(1);
-    expect(onSaveMock).toHaveBeenCalledWith({
-      ...dirtyQuestion.card(),
-      id: originalQuestion.id(),
+      expect(onSaveMock).toHaveBeenCalledTimes(1);
+      expect(onSaveMock).toHaveBeenCalledWith({
+        ...dirtyQuestion.card(),
+        id: originalQuestion.id(),
+      });
     });
-  });
 
-  it("should preserve the collection_id of a question in overwrite mode", async () => {
-    const originalQuestion = getQuestion({
-      isSaved: true,
-      collection_id: 5,
+    it("should preserve original question's collection id", () => {
+      const originalQuestion = getQuestion({
+        isSaved: true,
+        collection_id: 5,
+      });
+      const { onSaveMock } = renderSaveQuestionModal(
+        getDirtyQuestion(originalQuestion),
+        originalQuestion,
+      );
+
+      userEvent.click(screen.getByText("Save"));
+
+      expect(onSaveMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          collection_id: originalQuestion.collectionId(),
+        }),
+      );
     });
-    const { onSaveMock } = renderSaveQuestionModal(
-      getDirtyQuestion(originalQuestion),
-      originalQuestion,
-    );
 
-    userEvent.click(screen.getByText("Save"));
+    it("shouldn't call onCreate when form is submitted", () => {
+      const originalQuestion = getQuestion({ isSaved: true });
+      const dirtyQuestion = getDirtyQuestion(originalQuestion);
+      const { onCreateMock } = renderSaveQuestionModal(
+        dirtyQuestion,
+        originalQuestion,
+      );
 
-    expect(onSaveMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        collection_id: originalQuestion.collectionId(),
-      }),
-    );
-  });
+      userEvent.click(screen.getByText("Save"));
+
+      expect(onCreateMock).not.toHaveBeenCalled();
+    });
   });
 
   describe("Cache TTL field", () => {

--- a/frontend/test/metabase/scenarios/question/saved.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/saved.cy.spec.js
@@ -11,7 +11,7 @@ describe("scenarios > question > saved", () => {
     cy.signInAsNormalUser();
   });
 
-  it.skip("should should correctly display 'Save' modal (metabase#13817)", () => {
+  it("should should correctly display 'Save' modal (metabase#13817)", () => {
     openOrdersTable({ mode: "notebook" });
     cy.findByText("Summarize").click();
     cy.findByText("Count of rows").click();


### PR DESCRIPTION
Fixes #13817

When saving a question based on another question, you're offered to replace the original one or save the question as a new one. The modal form has a radio control to switch between these two modes. The issue is that if you leave the "save as new" form invalid and switch to the "replace" mode, the submit buttons remains disabled. This happens because of incorrectly configured form validation.

This PR also adds a bunch of unit tests for the component itself

### To Verify

1. Open any question
2. Changing something in the query (add a filter / summarization step, etc.)
3. Click the "Save" button
4. The modal should appear and you should see a radio control with "replace the original question" and "save as new question" option
5. Click "save as new option" and remove question's name completely, notice the "Save" button became disabled
6. Click "replace the original question"
7. The "Save" button should be enabled again as we're not going to submit the "save as new question" form

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/133824571-30733c3f-75d4-4811-beb6-70f07f34d118.mov

**After**

https://user-images.githubusercontent.com/17258145/133824603-1db7739a-a822-409f-85be-e28ebf818642.mov



