### PR TITLE
Fix #17749: "master: Small Run-button"

### DIFF
--- a/frontend/src/metabase/css/query_builder.css
+++ b/frontend/src/metabase/css/query_builder.css
@@ -546,6 +546,10 @@
   transition: transform 0.25s, opacity 0.25s;
 }
 
+.RunButton.RunButton--compact {
+  padding: 16px 32px;
+}
+
 .RunButton.RunButton--hidden {
   transform: translateY(-20px);
   opacity: 0;

--- a/frontend/src/metabase/query_builder/components/RunButton.jsx
+++ b/frontend/src/metabase/query_builder/components/RunButton.jsx
@@ -56,6 +56,7 @@ export default class RunButton extends Component {
         iconSize={16}
         className={cx(className, "RunButton", {
           "RunButton--hidden": hidden,
+          "RunButton--compact": compact,
           circular: circular,
         })}
         onClick={isRunning ? onCancel : onRun}


### PR DESCRIPTION
Added padding override to .RunButton class from styles in `v0.40.3.1` tag.

For future references, the offending line is in `frontend/src/metabase/components/Button.jsx`:

```jsx
      className={cx("Button", className, "flex-no-shrink", variantClasses, {
        p1: !children,
      })}
```

That `.p1` class at the end overrides any padding if there are no children or a CSS class with higher priority. Catch 22: adding an empty `<span>` child adds padding between the children and the icon, shifting it to the left and making it off-center.