### PR TITLE
Fix #17397 - "Showing first 2000 rows" is always displayed when results are loading

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx
@@ -31,7 +31,11 @@ const QuestionRowCount = ({
   const limitMessage =
     query instanceof StructuredQuery
       ? query.limit() == null || query.limit() >= HARD_ROW_LIMIT
-        ? cappedMessage
+        ? typeof result.row_count === "number"
+          ? // The query has been altered but we might still have the old result set,
+            // so show that instead of a generic HARD_ROW_LIMIT
+            t`Showing ${formatRowCount(result.row_count)}`
+          : cappedMessage
         : t`Show ${formatRowCount(query.limit())}`
       : null;
 

--- a/frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx
@@ -28,24 +28,30 @@ const QuestionRowCount = ({
   const cappedMessage = t`Showing first ${HARD_ROW_LIMIT} rows`;
 
   // Shown based on a query that has been altered
-  const limitMessage =
-    query instanceof StructuredQuery
-      ? query.limit() == null || query.limit() >= HARD_ROW_LIMIT
-        ? typeof result.row_count === "number"
-          ? // The query has been altered but we might still have the old result set,
-            // so show that instead of a generic HARD_ROW_LIMIT
-            t`Showing ${formatRowCount(result.row_count)}`
-          : cappedMessage
-        : t`Show ${formatRowCount(query.limit())}`
-      : null;
+  let limitMessage = null;
+  if (query instanceof StructuredQuery) {
+    if (query.limit() == null || query.limit() >= HARD_ROW_LIMIT) {
+      if (typeof result.row_count === "number") {
+        // The query has been altered but we might still have the old result set,
+        // so show that instead of a generic HARD_ROW_LIMIT
+        limitMessage = t`Showing ${formatRowCount(result.row_count)}`;
+      } else {
+        limitMessage = cappedMessage;
+      }
+    } else {
+      limitMessage = t`Show ${formatRowCount(query.limit())}`;
+    }
+  }
 
   // Shown based on a query that has been run
-  const resultMessage =
-    result.data.rows_truncated != null
-      ? t`Showing first ${formatRowCount(result.row_count)}`
-      : result.row_count === HARD_ROW_LIMIT
-      ? cappedMessage
-      : t`Showing ${formatRowCount(result.row_count)}`;
+  let resultMessage;
+  if (result.data.rows_truncated != null) {
+    resultMessage = t`Showing first ${formatRowCount(result.row_count)}`;
+  } else if (result.row_count === HARD_ROW_LIMIT) {
+    resultMessage = cappedMessage;
+  } else {
+    resultMessage = t`Showing ${formatRowCount(result.row_count)}`;
+  }
 
   const message = isResultDirty ? limitMessage : resultMessage;
 

--- a/frontend/test/__support__/e2e/helpers/e2e-misc-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-misc-helpers.js
@@ -53,12 +53,12 @@ export function runNativeQuery(xhrAlias = "dataset") {
  */
 export function interceptPromise(method, path) {
   let state = {};
-  const promise = new Promise((resolve) => {
+  const promise = new Promise(resolve => {
     state.resolve = resolve;
   });
   cy.intercept(method, path, req => {
     return promise.then(() => {
-      req.continue()
+      req.continue();
     });
   });
   return state;

--- a/frontend/test/__support__/e2e/helpers/e2e-misc-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-misc-helpers.js
@@ -39,3 +39,27 @@ export function runNativeQuery(xhrAlias = "dataset") {
   cy.wait("@" + xhrAlias);
   cy.icon("play").should("not.exist");
 }
+
+/**
+ * Intercepts a request and returns resolve function that allows
+ * the request to continue
+ *
+ * @param {string} method - Request method ("GET", "POST", etc)
+ * @param {string} path - Request URL to intercept
+ * @example
+ * let req = interceptPromise("GET", "/dashboard/1");
+ * // ... do something before request is allowed to go through ...
+ * req.resolve();
+ */
+export function interceptPromise(method, path) {
+  let state = {};
+  const promise = new Promise((resolve) => {
+    state.resolve = resolve;
+  });
+  cy.intercept(method, path, req => {
+    return promise.then(() => {
+      req.continue()
+    });
+  });
+  return state;
+}

--- a/frontend/test/__support__/e2e/helpers/e2e-misc-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-misc-helpers.js
@@ -47,12 +47,12 @@ export function runNativeQuery(xhrAlias = "dataset") {
  * @param {string} method - Request method ("GET", "POST", etc)
  * @param {string} path - Request URL to intercept
  * @example
- * let req = interceptPromise("GET", "/dashboard/1");
+ * const req = interceptPromise("GET", "/dashboard/1");
  * // ... do something before request is allowed to go through ...
  * req.resolve();
  */
 export function interceptPromise(method, path) {
-  let state = {};
+  const state = {};
   const promise = new Promise(resolve => {
     state.resolve = resolve;
   });

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -175,7 +175,7 @@ describe("scenarios > question > notebook", () => {
 
     cy.contains("Showing 99 rows");
 
-    let req = interceptPromise("POST", "/api/dataset");
+    const req = interceptPromise("POST", "/api/dataset");
     cy.contains("ID is less than 100").click();
     cy.get(".Icon-chevronleft").click();
     cy.findByText("Custom Expression").click();

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -6,6 +6,7 @@ import {
   popover,
   modal,
   visitQuestionAdhoc,
+  interceptPromise,
 } from "__support__/e2e/cypress";
 
 import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
@@ -151,6 +152,42 @@ describe("scenarios > question > notebook", () => {
       .clear()
       .type("[Price] > 1 AND [Price] < 5{enter}");
     cy.contains(/^Price is less than 5/i);
+  });
+
+  it("should show the real number of rows instead of HARD_ROW_LIMIT when loading", () => {
+    // start a custom question with orders
+    cy.visit("/question/new");
+    cy.contains("Custom question").click();
+    cy.contains("Sample Dataset").click();
+    cy.contains("Orders").click();
+
+    // Add filter for ID < 100
+    cy.findByText("Add filters to narrow your answer").click();
+    cy.findByText("Custom Expression").click();
+    cy.get("[contenteditable='true']")
+      .click()
+      .clear()
+      .type("ID < 100", { delay: 50 });
+    cy.button("Done")
+      .should("not.be.disabled")
+      .click();
+    cy.contains("Visualize").click();
+
+    cy.contains("Showing 99 rows");
+
+    let req = interceptPromise("POST", "/api/dataset");
+    cy.contains("ID is less than 100").click();
+    cy.get(".Icon-chevronleft").click();
+    cy.findByText("Custom Expression").click();
+    cy.get("[contenteditable='true']")
+      .click()
+      .clear()
+      .type("ID < 2010");
+    cy.button("Done")
+      .click();
+    cy.contains("Showing 99 rows");
+    req.resolve();
+    cy.contains("Showing first 2000 rows");
   });
 
   describe("joins", () => {

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -183,8 +183,7 @@ describe("scenarios > question > notebook", () => {
       .click()
       .clear()
       .type("ID < 2010");
-    cy.button("Done")
-      .click();
+    cy.button("Done").click();
     cy.contains("Showing 99 rows");
     req.resolve();
     cy.contains("Showing first 2000 rows");


### PR DESCRIPTION
Checks for existing result set when the dirty flag is set instead of automatically showing the HARD_ROW_LIMIT message

Added a Cypress unit test and a helper to intercept requests and hold them until a resolve function is called