### PR TITLE
Disable parameter widget input when not mapped to a card on dashboard

### DIFF
--- a/frontend/src/metabase/meta/Dashboard.js
+++ b/frontend/src/metabase/meta/Dashboard.js
@@ -247,3 +247,24 @@ export function setParameterDefaultValue(
     default: value,
   };
 }
+
+export function hasMapping(parameter, dashboard) {
+  return dashboard.ordered_cards.some(ordered_card => {
+    return ordered_card.parameter_mappings.some(parameter_mapping => {
+      return parameter_mapping.parameter_id === parameter.id;
+    });
+  });
+}
+
+export function isDashboardParameterWithoutMapping(parameter, dashboard) {
+  if (!dashboard) {
+    return false;
+  }
+
+  const parameterExistsOnDashboard = dashboard.parameters.some(
+    dashParam => dashParam.id === parameter.id,
+  );
+  const parameterHasMapping = hasMapping(parameter, dashboard);
+
+  return parameterExistsOnDashboard && !parameterHasMapping;
+}

--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
@@ -167,7 +167,7 @@ export default class ParameterValueWidget extends Component {
       parameter,
       dashboard,
     );
-    const isDashParamWithoutMappingText = t`In order to use this filter it needs to be connected with a card on the dashboard.`;
+    const isDashParamWithoutMappingText = t`This filter needs to be connected to a card.`;
     const WidgetDefinition = getWidgetDefinition(metadata, parameter);
     const { noPopover } = WidgetDefinition;
     const showTypeIcon = !isEditing && !hasValue && !isFocused;

--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
@@ -15,6 +15,7 @@ import DateQuarterYearWidget from "./widgets/DateQuarterYearWidget";
 import DateAllOptionsWidget from "./widgets/DateAllOptionsWidget";
 import TextWidget from "./widgets/TextWidget";
 import ParameterFieldWidget from "./widgets/ParameterFieldWidget/ParameterFieldWidget";
+import Tooltip from "metabase/components/Tooltip";
 
 import { fetchField, fetchFieldValues } from "metabase/redux/metadata";
 import {
@@ -26,6 +27,7 @@ import {
   getParameterIconName,
   deriveFieldOperatorFromParameter,
 } from "metabase/meta/Parameter";
+import { isDashboardParameterWithoutMapping } from "metabase/meta/Dashboard";
 
 import S from "./ParameterWidget.css";
 
@@ -157,36 +159,48 @@ export default class ParameterValueWidget extends Component {
       isFullscreen,
       noReset,
       className,
+      dashboard,
     } = this.props;
     const { isFocused } = this.state;
     const hasValue = value != null;
+    const isDashParamWithoutMapping = isDashboardParameterWithoutMapping(
+      parameter,
+      dashboard,
+    );
+    const isDashParamWithoutMappingText = t`In order to use this filter it needs to be connected with a card on the dashboard.`;
     const WidgetDefinition = getWidgetDefinition(metadata, parameter);
     const { noPopover } = WidgetDefinition;
     const showTypeIcon = !isEditing && !hasValue && !isFocused;
 
     if (noPopover) {
       return (
-        <div
-          className={cx(S.parameter, S.noPopover, className, {
-            [S.selected]: hasValue,
-            [S.isEditing]: isEditing,
-          })}
+        <Tooltip
+          tooltip={isDashParamWithoutMappingText}
+          isEnabled={isDashParamWithoutMapping}
         >
-          {showTypeIcon && <ParameterTypeIcon parameter={parameter} />}
-          <Widget
-            {...this.props}
-            onFocusChanged={this.onFocusChanged}
-            onPopoverClose={this.onPopoverClose}
-          />
-          <WidgetStatusIcon
-            isFullscreen={isFullscreen}
-            hasValue={hasValue}
-            noReset={noReset}
-            noPopover={noPopover}
-            isFocused={isFocused}
-            setValue={setValue}
-          />
-        </div>
+          <div
+            className={cx(S.parameter, S.noPopover, className, {
+              [S.selected]: hasValue,
+              [S.isEditing]: isEditing,
+            })}
+          >
+            {showTypeIcon && <ParameterTypeIcon parameter={parameter} />}
+            <Widget
+              {...this.props}
+              onFocusChanged={this.onFocusChanged}
+              onPopoverClose={this.onPopoverClose}
+              disabled={isDashParamWithoutMapping}
+            />
+            <WidgetStatusIcon
+              isFullscreen={isFullscreen}
+              hasValue={hasValue}
+              noReset={noReset}
+              noPopover={noPopover}
+              isFocused={isFocused}
+              setValue={setValue}
+            />
+          </div>
+        </Tooltip>
       );
     } else {
       const placeholderText = isEditing
@@ -194,37 +208,46 @@ export default class ParameterValueWidget extends Component {
         : placeholder || t`Select…`;
 
       return (
-        <PopoverWithTrigger
-          ref={this.valuePopover}
-          triggerElement={
-            <div
-              ref={this.trigger}
-              className={cx(S.parameter, className, { [S.selected]: hasValue })}
-            >
-              {showTypeIcon && <ParameterTypeIcon parameter={parameter} />}
-              <div className="mr1 text-nowrap">
-                {hasValue ? WidgetDefinition.format(value) : placeholderText}
-              </div>
-              <WidgetStatusIcon
-                isFullscreen={isFullscreen}
-                hasValue={hasValue}
-                noReset={noReset}
-                noPopover={noPopover}
-                isFocused={isFocused}
-                setValue={setValue}
-              />
-            </div>
-          }
-          target={this.getTargetRef}
-          // make sure the full date picker will expand to fit the dual calendars
-          autoWidth={parameter.type === "date/all-options"}
+        <Tooltip
+          tooltip={isDashParamWithoutMappingText}
+          isEnabled={isDashParamWithoutMapping}
         >
-          <Widget
-            {...this.props}
-            onFocusChanged={this.onFocusChanged}
-            onPopoverClose={this.onPopoverClose}
-          />
-        </PopoverWithTrigger>
+          <PopoverWithTrigger
+            ref={this.valuePopover}
+            triggerElement={
+              <div
+                ref={this.trigger}
+                className={cx(S.parameter, className, {
+                  [S.selected]: hasValue,
+                  "cursor-not-allowed": isDashParamWithoutMapping,
+                })}
+              >
+                {showTypeIcon && <ParameterTypeIcon parameter={parameter} />}
+                <div className="mr1 text-nowrap">
+                  {hasValue ? WidgetDefinition.format(value) : placeholderText}
+                </div>
+                <WidgetStatusIcon
+                  isFullscreen={isFullscreen}
+                  hasValue={hasValue}
+                  noReset={noReset}
+                  noPopover={noPopover}
+                  isFocused={isFocused}
+                  setValue={setValue}
+                />
+              </div>
+            }
+            target={this.getTargetRef}
+            // make sure the full date picker will expand to fit the dual calendars
+            autoWidth={parameter.type === "date/all-options"}
+          >
+            <Widget
+              {...this.props}
+              onFocusChanged={this.onFocusChanged}
+              onPopoverClose={this.onPopoverClose}
+              disabled={isDashParamWithoutMapping}
+            />
+          </PopoverWithTrigger>
+        </Tooltip>
       );
     }
   }
@@ -258,9 +281,21 @@ function Widget({
   onFocusChanged,
   parameters,
   dashboard,
+  disabled,
 }) {
   const DateWidget = DATE_WIDGETS[parameter.type];
   const fields = getFields(metadata, parameter);
+
+  if (disabled) {
+    return (
+      <TextWidget
+        className={cx(className, "cursor-not-allowed")}
+        placeholder={placeholder}
+        disabled={disabled}
+      />
+    );
+  }
+
   if (DateWidget) {
     return (
       <DateWidget value={value} setValue={setValue} onClose={onPopoverClose} />
@@ -294,6 +329,7 @@ function Widget({
     );
   }
 }
+
 Widget.propTypes = {
   ...ParameterValueWidget.propTypes,
   onPopoverClose: PropTypes.func.isRequired,

--- a/frontend/src/metabase/parameters/components/widgets/TextWidget.jsx
+++ b/frontend/src/metabase/parameters/components/widgets/TextWidget.jsx
@@ -23,6 +23,7 @@ export default class TextWidget extends Component {
     commitImmediately: PropTypes.bool,
     placeholder: PropTypes.string,
     focusChanged: PropTypes.func,
+    disabled: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -48,6 +49,7 @@ export default class TextWidget extends Component {
       className,
       isEditing,
       focusChanged: parentFocusChanged,
+      disabled,
     } = this.props;
     const defaultPlaceholder = this.state.isFocused
       ? ""
@@ -89,6 +91,7 @@ export default class TextWidget extends Component {
         placeholder={
           isEditing ? t`Enter a default value...` : defaultPlaceholder
         }
+        disabled={disabled}
       />
     );
   }

--- a/frontend/test/metabase/meta/Dashboard.unit.spec.js
+++ b/frontend/test/metabase/meta/Dashboard.unit.spec.js
@@ -5,7 +5,11 @@ import {
   ORDERS,
   PRODUCTS,
 } from "__support__/sample_dataset_fixture";
-import { getParameterMappingOptions } from "metabase/meta/Dashboard";
+import {
+  getParameterMappingOptions,
+  hasMapping,
+  isDashboardParameterWithoutMapping,
+} from "metabase/meta/Dashboard";
 
 function structured(query) {
   return SAMPLE_DATASET.question(query).card();
@@ -29,105 +33,133 @@ function native(native) {
   // };
 }
 
-describe("getParameterMappingOptions", () => {
-  describe("Structured Query", () => {
-    it("should return field-id and fk-> dimensions", () => {
-      const options = getParameterMappingOptions(
-        metadata,
-        { type: "date/single" },
-        structured({
-          "source-table": REVIEWS.id,
-        }),
-      );
-      expect(options).toEqual([
-        {
-          sectionName: "Review",
-          icon: "calendar",
-          name: "Created At",
-          target: ["dimension", ["field", REVIEWS.CREATED_AT.id, null]],
-          isForeign: false,
-        },
-        {
-          sectionName: "Product",
-          name: "Created At",
-          icon: "calendar",
-          target: [
-            "dimension",
-            [
-              "field",
-              PRODUCTS.CREATED_AT.id,
-              { "source-field": REVIEWS.PRODUCT_ID.id },
+describe("meta/Dashboard", () => {
+  describe("getParameterMappingOptions", () => {
+    describe("Structured Query", () => {
+      it("should return field-id and fk-> dimensions", () => {
+        const options = getParameterMappingOptions(
+          metadata,
+          { type: "date/single" },
+          structured({
+            "source-table": REVIEWS.id,
+          }),
+        );
+        expect(options).toEqual([
+          {
+            sectionName: "Review",
+            icon: "calendar",
+            name: "Created At",
+            target: ["dimension", ["field", REVIEWS.CREATED_AT.id, null]],
+            isForeign: false,
+          },
+          {
+            sectionName: "Product",
+            name: "Created At",
+            icon: "calendar",
+            target: [
+              "dimension",
+              [
+                "field",
+                PRODUCTS.CREATED_AT.id,
+                { "source-field": REVIEWS.PRODUCT_ID.id },
+              ],
             ],
-          ],
-          isForeign: true,
-        },
-      ]);
-    });
-    it("should also return fields from explicitly joined tables", () => {
-      const options = getParameterMappingOptions(
-        metadata,
-        { type: "date/single" },
-        structured({
-          "source-table": REVIEWS.id,
-          joins: [
-            {
-              alias: "Joined Table",
+            isForeign: true,
+          },
+        ]);
+      });
+      it("should also return fields from explicitly joined tables", () => {
+        const options = getParameterMappingOptions(
+          metadata,
+          { type: "date/single" },
+          structured({
+            "source-table": REVIEWS.id,
+            joins: [
+              {
+                alias: "Joined Table",
+                "source-table": ORDERS.id,
+              },
+            ],
+          }),
+        );
+        expect(options).toEqual([
+          {
+            sectionName: "Review",
+            name: "Created At",
+            icon: "calendar",
+            target: ["dimension", ["field", 30, null]],
+            isForeign: false,
+          },
+          {
+            sectionName: "Joined Table",
+            name: "Created At",
+            icon: "calendar",
+            target: [
+              "dimension",
+              ["field", 1, { "join-alias": "Joined Table" }],
+            ],
+            isForeign: true,
+          },
+          {
+            sectionName: "Product",
+            name: "Created At",
+            icon: "calendar",
+            target: ["dimension", ["field", 22, { "source-field": 32 }]],
+            isForeign: true,
+          },
+        ]);
+      });
+      it("should return fields in nested query", () => {
+        const options = getParameterMappingOptions(
+          metadata,
+          { type: "date/single" },
+          structured({
+            "source-query": {
               "source-table": ORDERS.id,
             },
-          ],
-        }),
-      );
-      expect(options).toEqual([
-        {
-          sectionName: "Review",
-          name: "Created At",
-          icon: "calendar",
-          target: ["dimension", ["field", 30, null]],
-          isForeign: false,
-        },
-        {
-          sectionName: "Joined Table",
-          name: "Created At",
-          icon: "calendar",
-          target: ["dimension", ["field", 1, { "join-alias": "Joined Table" }]],
-          isForeign: true,
-        },
-        {
-          sectionName: "Product",
-          name: "Created At",
-          icon: "calendar",
-          target: ["dimension", ["field", 22, { "source-field": 32 }]],
-          isForeign: true,
-        },
-      ]);
-    });
-    it("should return fields in nested query", () => {
-      const options = getParameterMappingOptions(
-        metadata,
-        { type: "date/single" },
-        structured({
-          "source-query": {
-            "source-table": ORDERS.id,
+          }),
+        );
+        expect(options).toEqual([
+          {
+            sectionName: null,
+            name: "Created At",
+            icon: "calendar",
+            target: [
+              "dimension",
+              ["field", "CREATED_AT", { "base-type": "type/DateTime" }],
+            ],
+            isForeign: false,
           },
-        }),
-      );
-      expect(options).toEqual([
-        {
-          sectionName: null,
-          name: "Created At",
-          icon: "calendar",
-          target: [
-            "dimension",
-            ["field", "CREATED_AT", { "base-type": "type/DateTime" }],
-          ],
-          isForeign: false,
-        },
-      ]);
+        ]);
+      });
     });
-  });
 
-  describe("NativeQuery", () => {
-    it("should return variables for non-dimension template-tags", () => {
+    describe("NativeQuery", () => {
+      it("should return variables for non-dimension template-tags", () => {
+        const options = getParameterMappingOptions(
+          metadata,
+          { type: "date/single" },
+          native({
+            query: "select * from ORDERS where CREATED_AT = {{created}}",
+            "template-tags": {
+              created: {
+                type: "date",
+                name: "created",
+              },
+            },
+          }),
+        );
+        expect(options).toEqual([
+          {
+            name: "created",
+            icon: "calendar",
+            target: ["variable", ["template-tag", "created"]],
+            isForeign: false,
+          },
+        ]);
+      });
+    });
+    it("should return dimensions for dimension template-tags", () => {
       const options = getParameterMappingOptions(
         metadata,
         { type: "date/single" },
@@ -135,44 +167,188 @@ describe("getParameterMappingOptions", () => {
           query: "select * from ORDERS where CREATED_AT = {{created}}",
           "template-tags": {
             created: {
-              type: "date",
+              type: "dimension",
               name: "created",
+              dimension: ["field", ORDERS.CREATED_AT.id, null],
             },
           },
         }),
       );
       expect(options).toEqual([
         {
-          name: "created",
+          name: "Created At",
           icon: "calendar",
-          target: ["variable", ["template-tag", "created"]],
+          target: ["dimension", ["template-tag", "created"]],
           isForeign: false,
         },
       ]);
     });
   });
-  it("should return dimensions for dimension template-tags", () => {
-    const options = getParameterMappingOptions(
-      metadata,
-      { type: "date/single" },
-      native({
-        query: "select * from ORDERS where CREATED_AT = {{created}}",
-        "template-tags": {
-          created: {
-            type: "dimension",
-            name: "created",
-            dimension: ["field", ORDERS.CREATED_AT.id, null],
+
+  describe("hasMapping", () => {
+    const parameter = { id: "foo" };
+
+    it("should return false when there are no cards on the dashboard", () => {
+      const dashboard = {
+        ordered_cards: [],
+      };
+      expect(hasMapping(parameter, dashboard)).toBe(false);
+    });
+
+    it("should return false when there are no cards with parameter mappings", () => {
+      const dashboard = {
+        ordered_cards: [
+          {
+            parameter_mappings: [],
           },
-        },
-      }),
-    );
-    expect(options).toEqual([
-      {
-        name: "Created At",
-        icon: "calendar",
-        target: ["dimension", ["template-tag", "created"]],
-        isForeign: false,
-      },
-    ]);
+          {
+            parameter_mappings: [],
+          },
+        ],
+      };
+
+      expect(hasMapping(parameter, dashboard)).toBe(false);
+    });
+
+    it("should return false when there are no matching parameter mapping parameter_ids", () => {
+      const dashboard = {
+        ordered_cards: [
+          {
+            parameter_mappings: [
+              {
+                parameter_id: "bar",
+              },
+            ],
+          },
+          {
+            parameter_mappings: [
+              {
+                parameter_id: "baz",
+              },
+              {
+                parameter_id: "abc",
+              },
+            ],
+          },
+        ],
+      };
+
+      expect(hasMapping(parameter, dashboard)).toBe(false);
+    });
+
+    it("should return true when the given parameter's id is found in a parameter_mappings object", () => {
+      const dashboard = {
+        ordered_cards: [
+          {
+            parameter_mappings: [
+              {
+                parameter_id: "bar",
+              },
+            ],
+          },
+          {
+            parameter_mappings: [
+              {
+                parameter_id: "baz",
+              },
+              {
+                parameter_id: "foo",
+              },
+            ],
+          },
+        ],
+      };
+
+      expect(hasMapping(parameter, dashboard)).toBe(true);
+    });
+  });
+
+  describe("isDashboardParameterWithoutMapping", () => {
+    const parameter = { id: "foo" };
+
+    it("should return false when passed a falsy dashboard", () => {
+      expect(isDashboardParameterWithoutMapping(parameter, undefined)).toBe(
+        false,
+      );
+    });
+
+    it("should return false when the given parameter is not found in the dashboard's parameters list", () => {
+      const brokenDashboard = {
+        ordered_cards: [
+          {
+            parameter_mappings: [
+              {
+                parameter_id: "bar",
+              },
+              {
+                // having this parameter mapped but not in the parameters list shouldn't happen in practice,
+                // but I am proving the significance of having the parameter exist in the dashboard's parameters list
+                parameter_id: "foo",
+              },
+            ],
+          },
+        ],
+        parameters: [
+          {
+            id: "bar",
+          },
+        ],
+      };
+
+      expect(
+        isDashboardParameterWithoutMapping(parameter, brokenDashboard),
+      ).toBe(false);
+    });
+
+    it("should return false when the given parameter is both found in the dashboard's parameters and also mapped", () => {
+      const dashboard = {
+        ordered_cards: [
+          {
+            parameter_mappings: [
+              {
+                parameter_id: "bar",
+              },
+              {
+                parameter_id: "foo",
+              },
+            ],
+          },
+        ],
+        parameters: [
+          {
+            id: "bar",
+          },
+          { id: "foo" },
+        ],
+      };
+
+      expect(isDashboardParameterWithoutMapping(parameter, dashboard)).toBe(
+        false,
+      );
+    });
+
+    it("should return true when the given parameter is found on the dashboard but is not mapped", () => {
+      const dashboard = {
+        ordered_cards: [
+          {
+            parameter_mappings: [
+              {
+                parameter_id: "bar",
+              },
+            ],
+          },
+        ],
+        parameters: [
+          {
+            id: "bar",
+          },
+          { id: "foo" },
+        ],
+      };
+
+      expect(isDashboardParameterWithoutMapping(parameter, dashboard)).toBe(
+        true,
+      );
+    });
   });
 });


### PR DESCRIPTION
Fixes #15548

This PR disables the ability to access and use the inputs/widgets of dashboard parameters that aren't mapped to any cards. Currently, you're able to apply filters to the dashboard with these parameters, but since they're not mapped to anything, the filter does nothing, and that might be confusing to users.

The fix is fairly straightforward:
1. I've introduced a predicate function `isDashboardParameterWithoutMapping` that checks for the specific scenario we want to disable. `ParameterValueWidget` is used outside of dashboards, in the native query builder, so I have a check in the function to ensure that it returns `false` when the passed `dashboard` arg is undefined.
2. When `isDashboardParameterWithoutMapping` is true, I'm applying a `disabled` state to the widget and adding a tooltip message.

Here's what it looks like:

https://user-images.githubusercontent.com/13057258/133838952-b0613bc3-6d7b-4be7-b252-e6ac0d43f887.mov

Making sure Native Query parameters aren't disabled:

https://user-images.githubusercontent.com/13057258/133838976-4cdb2644-7d51-45e9-a436-e1cc0f5ff125.mov


