### PR TITLE
When fetching field also fetch field associated with its human_readable_field_id

### DIFF
--- a/frontend/src/metabase/redux/metadata.js
+++ b/frontend/src/metabase/redux/metadata.js
@@ -81,10 +81,25 @@ export const fetchTableMetadata = (id, reload = false) => {
   return Tables.actions.fetchMetadataAndForeignTables({ id }, { reload });
 };
 
-export const fetchField = (id, reload = false) => {
-  deprecated("metabase/redux/metadata fetchField");
-  return Fields.actions.fetch({ id }, { reload });
-};
+export const METADATA_FETCH_FIELD = "metabase/metadata/FETCH_FIELD";
+export const fetchField = createThunkAction(
+  METADATA_FETCH_FIELD,
+  (id, reload = false) => {
+    deprecated("metabase/redux/metadata fetchField");
+    return async dispatch => {
+      const action = await dispatch(Fields.actions.fetch({ id }, { reload }));
+      const field = Fields.HACK_getObjectFromAction(action);
+      if (field?.dimensions?.human_readable_field_id != null) {
+        await dispatch(
+          Fields.actions.fetch(
+            { id: field.dimensions.human_readable_field_id },
+            { reload },
+          ),
+        );
+      }
+    };
+  },
+);
 
 export const FETCH_FIELD_VALUES = Fields.actions.fetchFieldValues.toString();
 export const fetchFieldValues = (id, reload = false) => {

--- a/frontend/src/metabase/redux/metadata.unit.spec.js
+++ b/frontend/src/metabase/redux/metadata.unit.spec.js
@@ -1,0 +1,83 @@
+import Fields from "metabase/entities/fields";
+import { fetchField } from "./metadata";
+
+describe("deprecated metadata actions", () => {
+  let dispatch;
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    dispatch = jest.fn(async foo => {
+      const action = await foo;
+      return action;
+    });
+  });
+
+  describe("fetchField", () => {
+    it("should fetch a field", async () => {
+      Fields.actions.fetch = jest.fn(() =>
+        Promise.resolve({
+          type: Fields.actionTypes.FETCH_ACTION,
+          payload: {
+            result: 0,
+            entities: {
+              fields: {
+                0: { id: 0 },
+              },
+            },
+          },
+        }),
+      );
+
+      await fetchField(0, false)(dispatch);
+      expect(Fields.actions.fetch).toHaveBeenCalledWith(
+        { id: 0 },
+        { reload: false },
+      );
+      expect(Fields.actions.fetch.mock.calls.length).toBe(1);
+    });
+
+    it("should fetch the field associated with a field's dimensions.human_readable_field_id property", async () => {
+      Fields.actions.fetch = jest.fn();
+
+      Fields.actions.fetch.mockReturnValueOnce(
+        Promise.resolve({
+          type: Fields.actionTypes.FETCH_ACTION,
+          payload: {
+            result: 0,
+            entities: {
+              fields: {
+                0: { id: 0, dimensions: { human_readable_field_id: 1 } },
+              },
+            },
+          },
+        }),
+      );
+
+      Fields.actions.fetch.mockReturnValueOnce(
+        Promise.resolve({
+          type: Fields.actionTypes.FETCH_ACTION,
+          payload: {
+            result: 1,
+            entities: {
+              fields: {
+                0: { id: 0, dimensions: { human_readable_field_id: 1 } },
+                1: { id: 1 },
+              },
+            },
+          },
+        }),
+      );
+
+      await fetchField(0, true)(dispatch);
+      expect(Fields.actions.fetch).toHaveBeenCalledWith(
+        { id: 0 },
+        { reload: true },
+      );
+      expect(Fields.actions.fetch).toHaveBeenCalledWith(
+        { id: 1 },
+        { reload: true },
+      );
+      expect(Fields.actions.fetch.mock.calls.length).toBe(2);
+    });
+  });
+});


### PR DESCRIPTION
Fixes #12904

We aren't fetching the mapped field when initializing the native query builder. If you've previously done something to fetch and cache the proper field value (like going into Admin > Data Model > Sample Dataset and then back to the query builder) you'll see the correct behavior, but if not then you won't.

The simplest fix for this is... gross. This function, `fetchField` is deprecated, but it is what is used when fetching fields for parameter widgets. It's only used for this specific purpose, however, so we can pretty safely fix this specific bug by fetching the mapped field after fetching the initial field.

Obviously, there's probably a cleaner/better fix for this out there, but for `ParameterValueWidget` it entails a lot of refactoring.

Recording of the fix:

https://user-images.githubusercontent.com/13057258/133854852-a29c88d7-7b28-4013-b5c3-b6edbcc4f271.mov


