### PR TITLE
fix dashboard subscription default value for non-field filters

### DIFF
--- a/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
@@ -161,7 +161,7 @@ describe("scenarios > dashboard > subscriptions", () => {
       cy.findByText(/^Emailed monthly on the first (?!null)/);
     });
 
-    it.skip("should work when using dashboard default filter value on native query with required parameter (metabase#15705)", () => {
+    it("should work when using dashboard default filter value on native query with required parameter (metabase#15705)", () => {
       // In order to reproduce this test, we need to use the old syntac for dashboard filters
       mockSessionProperty("field-filter-operators-enabled?", false);
 
@@ -191,7 +191,7 @@ describe("scenarios > dashboard > subscriptions", () => {
                   slug: "quantity",
                   id: "930e4001",
                   type: "category",
-                  default: "20",
+                  default: "3",
                 },
               ],
             });
@@ -233,6 +233,7 @@ describe("scenarios > dashboard > subscriptions", () => {
         expect(body[0].html).not.to.include(
           "An error occurred while displaying this card.",
         );
+        expect(body[0].html).to.include("2,738");
       });
     });
 

--- a/src/metabase/driver/common/parameters/values.clj
+++ b/src/metabase/driver/common/parameters/values.clj
@@ -197,7 +197,7 @@
         (throw (missing-required-param-exception display-name)))))
 
 (s/defn ^:private param-value-for-tag [{tag-name :name, :as tag} :- TagParam, params :- (s/maybe [i/ParamValue])]
-  (or (:value (param-with-target params [:variable [:template-tag tag-name]]))
+  (or (:value (param-with-target (map defaulted-param params) [:variable [:template-tag tag-name]]))
       (default-value-for-tag tag)
       i/no-value))
 

--- a/test/metabase/api/public_test.clj
+++ b/test/metabase/api/public_test.clj
@@ -510,8 +510,7 @@
 (deftest execute-public-dashcard-dimension-value-params-test
   (testing "GET /api/public/dashboard/:uuid/card/:card-id"
     (testing (str "make sure DimensionValue params also work if they have a default value, even if some is passed in "
-                  "for some reason as part of the query (#7253) If passed in as part of the query however make sure it "
-                  "doesn't override what's actually in the DB")
+                  "for some reason as part of the query (#7253)")
       (mt/with-temporary-setting-values [enable-public-sharing true]
         (mt/with-temp Card [card {:dataset_query {:database (mt/id)
                                                   :type     :native
@@ -530,14 +529,14 @@
               :parameter_mappings [{:card_id      (u/the-id card)
                                     :target       [:variable [:template-tag :msg]]
                                     :parameter_id "181da7c5"}])
-            (is (= [["Wow"]]
+            (is (= [["World"]]
                    (-> ((mt/user->client :crowberto)
                         :get (str (dashcard-url dash card)
                                   "?parameters="
                                   (json/generate-string
                                    [{:type    :category
                                      :target  [:variable [:template-tag :msg]]
-                                     :value   nil
+                                     :value   "World"
                                      :default "Hello"}])))
                        mt/rows)))))))))
 


### PR DESCRIPTION
When loading dashboard filters, the default value is in `:default` not in `:value`. In the field filter code path, the default is copied to `:value`.

Fix the issue by calling the same code for non-field filters too.

Fixes #15705