### PR TITLE
Fix grid map tooltips without metric column

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChartTooltip.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartTooltip.jsx
@@ -34,7 +34,7 @@ export default class ChartTooltip extends Component {
         dimensions.push({ value: hovered.value, column: hovered.column });
       }
       return dimensions.map(({ value, column }) => ({
-        key: getFriendlyName(column),
+        key: column && getFriendlyName(column),
         value: value,
         col: column,
       }));

--- a/frontend/test/metabase/scenarios/visualizations/maps.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/maps.cy.spec.js
@@ -140,4 +140,49 @@ describe("scenarios > visualizations > maps", () => {
     cy.findByText("State is TX");
     cy.findByText("171 Olive Oyle Lane"); // Address in the first row
   });
+
+  it("should display a tooltip for a grid map without a metric column (metabase#17940)", () => {
+    visitQuestionAdhoc({
+      display: "map",
+      dataset_query: {
+        database: 1,
+        type: "query",
+        query: {
+          "source-table": PEOPLE_ID,
+          breakout: [
+            [
+              "field",
+              PEOPLE.LONGITUDE,
+              {
+                binning: {
+                  strategy: "default",
+                },
+              },
+            ],
+            [
+              "field",
+              PEOPLE.LATITUDE,
+              {
+                binning: {
+                  strategy: "default",
+                },
+              },
+            ],
+          ],
+          limit: 1,
+        },
+      },
+      visualization_settings: {
+        "map.type": "grid",
+        "table.pivot_column": "LATITUDE",
+        "table.cell_column": "LONGITUDE",
+      },
+    });
+
+    cy.get(".leaflet-interactive").trigger("mousemove");
+
+    cy.findByText("Latitude:");
+    cy.findByText("Longitude:");
+    cy.findByText("1");
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/17940

Currently it's not possible to use grid maps without metric column as it throws exception.

How to test:
- Follow the steps from the issue or
- Run the cypress test which does the same

<img width="730" alt="Screen Shot 2021-09-20 at 2 05 02 pm" src="https://user-images.githubusercontent.com/8542534/133992312-246e4c7a-d98a-44c2-b72c-2650a00acf47.png">
