### PR TITLE
Fix questions with joins or filters cause re-run overlay after first save

### DIFF
--- a/frontend/src/metabase-lib/lib/queries/structured/MBQLClause.js
+++ b/frontend/src/metabase-lib/lib/queries/structured/MBQLClause.js
@@ -115,6 +115,14 @@ export class MBQLObjectClause {
   metadata() {
     return this._query.metadata();
   }
+
+  raw() {
+    const entries = Object.entries(this).filter(entry => {
+      const [, value] = entry;
+      return value !== undefined;
+    });
+    return Object.fromEntries(entries);
+  }
 }
 
 function _private(object, key, value) {

--- a/frontend/src/metabase-lib/lib/queries/structured/MBQLClause.js
+++ b/frontend/src/metabase-lib/lib/queries/structured/MBQLClause.js
@@ -117,11 +117,11 @@ export class MBQLObjectClause {
   }
 
   raw() {
-    const entries = Object.entries(this).filter(entry => {
+    const entriesWithDefinedValue = Object.entries(this).filter(entry => {
       const [, value] = entry;
       return value !== undefined;
     });
-    return Object.fromEntries(entries);
+    return Object.fromEntries(entriesWithDefinedValue);
   }
 }
 

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -163,8 +163,8 @@ const getNextRunParameterValues = createSelector(
 );
 
 // Certain differences in a query should be ignored. `normalizeQuery`
-function normalizeQuery(query, tableMetadata) {
 // standardizes the query before comparison in `getIsResultDirty`.
+export function normalizeQuery(query, tableMetadata) {
   if (!query) {
     return query;
   }

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -163,8 +163,8 @@ const getNextRunParameterValues = createSelector(
 );
 
 // Certain differences in a query should be ignored. `normalizeQuery`
-// standardizes the query before comparision in `getIsResultDirty`.
 function normalizeQuery(query, tableMetadata) {
+// standardizes the query before comparison in `getIsResultDirty`.
   if (!query) {
     return query;
   }

--- a/frontend/src/metabase/query_builder/utils.unit.spec.js
+++ b/frontend/src/metabase/query_builder/utils.unit.spec.js
@@ -1,0 +1,139 @@
+import Question from "metabase-lib/lib/Question";
+import {
+  SAMPLE_DATASET,
+  ORDERS,
+  metadata,
+} from "__support__/sample_dataset_fixture";
+import { normalizeQuery } from "./selectors";
+
+function toFieldRef(field) {
+  return ["field", field.id, null];
+}
+
+function sortFields(f1, f2) {
+  return JSON.stringify(f2).localeCompare(JSON.stringify(f1));
+}
+
+function getTableFields(tableId) {
+  const table = SAMPLE_DATASET.tables.find(table => table.id === tableId);
+  return table.fields.map(toFieldRef).sort(sortFields);
+}
+
+function getQuestion({ type = "query", query = {} } = {}) {
+  const queryObjectKey = type === "query" ? "query" : "native";
+  let queryObject = {};
+
+  if (type === "query") {
+    queryObject = {
+      ...query,
+      "source-table": ORDERS.id,
+    };
+  } else {
+    queryObject = query;
+  }
+
+  return new Question({
+    display: "table",
+    visualization_settings: {},
+    dataset_query: {
+      type,
+      database: SAMPLE_DATASET.id,
+      [queryObjectKey]: queryObject,
+    },
+  });
+}
+
+function setup(questionOpts) {
+  const question = getQuestion(questionOpts);
+  const query = question.query();
+  const tableMetadata = question.isStructured()
+    ? metadata.table(query.sourceTableId())
+    : null;
+  return { question, query, datasetQuery: query.datasetQuery(), tableMetadata };
+}
+
+const FEW_ORDERS_TABLE_FIELDS = [
+  ORDERS.ID,
+  ORDERS.TOTAL,
+  ORDERS.CREATED_AT,
+].map(toFieldRef);
+
+describe("normalizeQuery", () => {
+  it("does nothing if query is nullish", () => {
+    expect(normalizeQuery(null)).toBe(null);
+    expect(normalizeQuery(undefined)).toBe(undefined);
+  });
+
+  describe("structured query", () => {
+    it("adds explicit list of fields if missing", () => {
+      const { datasetQuery, query, tableMetadata } = setup();
+      const expectedFields = getTableFields(query.sourceTableId());
+
+      const normalizedQuery = normalizeQuery(datasetQuery, tableMetadata);
+
+      expect(normalizedQuery.query).toEqual(
+        expect.objectContaining({
+          fields: expectedFields,
+        }),
+      );
+    });
+
+    it("sorts query fields if they're set explicitly", () => {
+      const { datasetQuery, tableMetadata } = setup({
+        query: { fields: FEW_ORDERS_TABLE_FIELDS },
+      });
+
+      const normalizedQuery = normalizeQuery(datasetQuery, tableMetadata);
+
+      expect(normalizedQuery.query.fields).toEqual(
+        FEW_ORDERS_TABLE_FIELDS.sort(sortFields),
+      );
+    });
+
+    it("does nothing to query fields if table metadata is not provided", () => {
+      const { datasetQuery } = setup({
+        query: { fields: FEW_ORDERS_TABLE_FIELDS },
+      });
+
+      const normalizedQuery = normalizeQuery(datasetQuery);
+
+      expect(normalizedQuery).toEqual(datasetQuery);
+    });
+  });
+
+  describe("native query", () => {
+    it("assigns empty object to template tags if missing", () => {
+      const { datasetQuery } = setup({
+        type: "native",
+      });
+
+      const normalizedQuery = normalizeQuery(datasetQuery);
+
+      expect(normalizedQuery).toEqual({
+        ...datasetQuery,
+        native: {
+          ...datasetQuery.native,
+          "template-tags": {},
+        },
+      });
+    });
+
+    it("does nothing to template tags if they're set explicitly", () => {
+      const { datasetQuery } = setup({
+        type: "native",
+        query: {
+          "template-tags": {
+            total: {
+              name: "total",
+              type: "dimension",
+            },
+          },
+        },
+      });
+
+      const normalizedQuery = normalizeQuery(datasetQuery);
+
+      expect(normalizedQuery).toEqual(datasetQuery);
+    });
+  });
+});

--- a/frontend/test/metabase/scenarios/question/reproductions/13468.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/13468.cy.spec.js
@@ -1,6 +1,6 @@
 import { restore, openOrdersTable } from "__support__/e2e/cypress";
 
-describe.skip("issue 13468", () => {
+describe("issue 13468", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/dataset").as("dataset");
     restore();


### PR DESCRIPTION
Fixes #13468

Once you save a GUI question with joins or filters, a re-run overlay is shown. The re-run overlay is intended to show the query is changed and the displayed results are no longer relevant. Here it's not the case as the query doesn't change when the question is saved.

### About the fix

The overlay is displayed depending on the `isResultDirty` calculated by [this selector](https://github.com/metabase/metabase/blob/25179f743eb5249db2ed5fb3e874c64bf6d35eed/frontend/src/metabase/query_builder/selectors.js#L189). The selector compares previous and current states of a dataset query and parameters and if they're different, the `isDirty` flag is set to `true`.

When you're building a question with GUI editors, some clauses are stored as our query classes (like [Join](https://github.com/metabase/metabase/blob/master/frontend/src/metabase-lib/lib/queries/structured/Join.js) or [Filter](https://github.com/metabase/metabase/blob/master/frontend/src/metabase-lib/lib/queries/structured/Filter.js)). And other clauses are represented as plain JavaScript arrays (aggregations, breakouts, order-by clauses, etc.). So if you explore the dataset query state while building a GUI question, it would look like the following:

![CleanShot 2021-09-20 at 15 03 13@2x](https://user-images.githubusercontent.com/17258145/133999314-89fcef89-f39e-4c97-9d55-32f6dab471c9.png)

Once a question is saved, the "current" dataset query state is replaced with a dataset_query JSON from the server's POST response. The problem happens when the selector compares the previous and the current state. Joins' and filters' before and current states are de-facto equal, but the `isDirty` is still `true` because there're `Join` and `Filter` instances in the "previous" state and plain arrays in the "current" state.

Fixed by extending the `normalizeQuery` function, so it converts `Join` and `Filter` to JS arrays and objects for comparison.

### To Verify

1. Ask a question > Custom question > Sample Dataset > Orders
2. Join People OR add any filter
3. Click "Visualize"
3. Save the question anywhere, and click "Not now", when asked if the question should be added to a dashboard
4. You should just see the results table without the re-run overlay

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/134000825-f569ebd9-df66-462a-8f77-226bb1d03319.mov

**After**

https://user-images.githubusercontent.com/17258145/134001013-f2738981-26a3-4eca-8e15-03734ccc2306.mov



