### PR TITLE
Fix missing translation of Others on the row chart

### DIFF
--- a/frontend/src/metabase/visualizations/lib/RowRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/RowRenderer.js
@@ -3,6 +3,7 @@
 import crossfilter from "crossfilter";
 import d3 from "d3";
 import dc from "dc";
+import { t } from "ttag";
 
 import { formatValue } from "metabase/lib/formatting";
 
@@ -117,7 +118,8 @@ export default function rowRenderer(
     .elasticX(true)
     .dimension(dimension)
     .group(group)
-    .ordering(d => d.index);
+    .ordering(d => d.index)
+    .othersLabel(t`Others`);
 
   const labelPadHorizontal = 5;
   let labelsOutside = false;


### PR DESCRIPTION
### Description

"Others" was not translated on the row chart because it came from dc.js. There is a way to configure it.
https://dc-js.github.io/dc.js/docs/html/dc.capMixin.html

Fixes https://github.com/metabase/metabase/issues/14451