### PR TITLE
Fix data points for scatter charts

### DIFF
--- a/frontend/src/metabase/visualizations/lib/chart_values.js
+++ b/frontend/src/metabase/visualizations/lib/chart_values.js
@@ -22,11 +22,14 @@ export function onRenderValueLabels(
     chart.settings.series(chart.series[seriesIndex]),
   );
 
-  // See if each series is enabled. Fall back to the chart-level setting if undefined.
+  // See if each series is enabled, fall back to the chart-level setting if undefined.
+  // Scatter charts should not have labels, the setting could be enabled when switching between chart types.
   let showSeries = seriesSettings.map(
-    ({ show_series_values = chart.settings["graph.show_values"] }) =>
-      show_series_values,
+    ({ display, show_series_values = chart.settings["graph.show_values"] }) =>
+      show_series_values && !isScatter(display),
   );
+
+  let displays = seriesSettings.map(settings => settings.display);
 
   if (
     showSeries.every(s => s === false) || // every series setting is off
@@ -35,7 +38,6 @@ export function onRenderValueLabels(
     return;
   }
 
-  let displays = seriesSettings.map(settings => settings.display);
   if (chart.settings["stackable.stack_type"] === "stacked") {
     // When stacked, flatten datas into one series. We'll sum values on the same x point later.
     datas = [datas.flat()];
@@ -48,6 +50,10 @@ export function onRenderValueLabels(
 
   function isBarLike(display) {
     return display === "bar" || display === "waterfall";
+  }
+
+  function isScatter(display) {
+    return display === "scatter";
   }
 
   let barWidth;

--- a/frontend/test/metabase/scenarios/visualizations/scatter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/scatter.cy.spec.js
@@ -70,6 +70,21 @@ describe("scenarios > visualizations > scatter", () => {
       cy.findByText("Products count:");
     });
   });
+
+  it("should not display data points even when enabled in settings (metabase#13247)", () => {
+    visitQuestionAdhoc({
+      display: "scatter",
+      dataset_query: testQuery,
+      visualization_settings: {
+        "graph.metrics": ["count"],
+        "graph.dimensions": ["CREATED_AT"],
+        "graph.show_values": true,
+      },
+    });
+
+    cy.findByText("Visualization");
+    cy.findAllByText("79").should("not.exist");
+  });
 });
 
 function triggerPopoverForBubble(index = 13) {


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/13247

How to test:
- Create a question, e.g. Products Created at -> Count of rows
- Change visualization type to `Line`
- Enable data points in visualization settings
- Change visualization type to `Scatter`
- Data points should not be enabled