### PR TITLE
Fix missing formatting on the x axis of the row chart

### DIFF
--- a/frontend/src/metabase/visualizations/lib/RowRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/RowRenderer.js
@@ -119,6 +119,13 @@ export default function rowRenderer(
     .group(group)
     .ordering(d => d.index);
 
+  chart.xAxis().tickFormat(value => {
+    return formatValue(value, {
+      ...settings.column(cols[1]),
+      type: "axis",
+    });
+  });
+
   const labelPadHorizontal = 5;
   let labelsOutside = false;
 

--- a/frontend/test/metabase-visual/visualizations/row.cy.spec.js
+++ b/frontend/test/metabase-visual/visualizations/row.cy.spec.js
@@ -1,0 +1,40 @@
+import { restore, visitQuestionAdhoc } from "__support__/e2e/cypress";
+import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
+
+const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATASET;
+
+const testQuery = {
+  type: "query",
+  query: {
+    "source-table": PRODUCTS_ID,
+    aggregation: [["count"]],
+    breakout: [["field", PRODUCTS.PRICE, { binning: { strategy: "default" } }]],
+  },
+  database: 1,
+};
+
+describe("visual tests > visualizations > row", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsNormalUser();
+    cy.server();
+    cy.route("POST", "/api/dataset").as("dataset");
+  });
+
+  it("with formatted x-axis", () => {
+    visitQuestionAdhoc({
+      dataset_query: testQuery,
+      display: "row",
+      displayIsLocked: true,
+      visualization_settings: {
+        column_settings: {
+          '["name","count"]': { suffix: " items", number_style: "decimal" },
+        },
+      },
+    });
+
+    cy.wait("@dataset");
+
+    cy.percySnapshot();
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/12185

### Description

The formatting of x-axis ticks on the row chart was missing. E2E repro looks redundant since I've added a visual test.

### How to verify
- Simple question -> Sample dataset -> Products
- Summarize by Price
- Change visualization to Row chart
- On the settings sidebar, click on the settings button for X-Axis and change the formatting
- Ensure the formatting has changed

### Screenshot
<img width="1182" alt="Screen Shot 2021-09-20 at 17 55 50" src="https://user-images.githubusercontent.com/14301985/134027982-dc821192-4b1b-4992-bc85-89fcb52a01d0.png">