### PR TITLE
Fix incorrect table names on join dimensions

### DIFF
--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -540,10 +540,7 @@ const joinDimensionCellItemPropTypes = {
 };
 
 function getDimensionSourceName(dimension) {
-  return dimension
-    .query()
-    .table()
-    .displayName();
+  return dimension.field()?.table?.display_name || t`Previous results`;
 }
 
 function getDimensionDisplayName(dimension) {

--- a/frontend/test/metabase/scenarios/question/joins.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/joins.cy.spec.js
@@ -106,6 +106,25 @@ describe("scenarios > question > joined questions", () => {
     // (orders joined with products on the same day-month-year)
     cy.get(".ScalarValue").contains("2,087");
   });
+
+  it("should show 'Previous results' instead of a table name for non-field dimensions", () => {
+    cy.intercept("POST", "/api/dataset").as("dataset");
+    openOrdersTable({ mode: "notebook" });
+
+    cy.findByText("Summarize").click();
+    selectFromDropdown("Count of rows");
+
+    cy.findByText("Pick a column to group by").click();
+    selectFromDropdown("Created At");
+
+    cy.findByText("Join data").click();
+    selectFromDropdown("Products");
+    selectFromDropdown("Count");
+
+    cy.findByTestId("step-join-1-0")
+      .findByTestId("parent-dimension")
+      .findByText("Previous results");
+  });
 });
 
 function joinTable(table) {

--- a/frontend/test/metabase/scenarios/question/reproductions/17968-notebook-join-table-names.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/17968-notebook-join-table-names.cy.spec.js
@@ -1,0 +1,38 @@
+import { restore, popover, openOrdersTable } from "__support__/e2e/cypress";
+
+describe("issue 17968", () => {
+  beforeEach(() => {
+    cy.intercept("POST", "/api/dataset").as("dataset");
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("shows correct table names when joining many tables (metabase#17968)", () => {
+    openOrdersTable({ mode: "notebook" });
+
+    cy.findByText("Join data").click();
+    popover()
+      .findByText("Products")
+      .click();
+
+    cy.findByTestId("action-buttons")
+      .findByText("Join data")
+      .click();
+    popover()
+      .findByText("Reviews")
+      .click();
+
+    popover().within(() => {
+      cy.findByText("Products").click();
+      cy.findByText("ID").click();
+    });
+
+    popover()
+      .findByText("Product ID")
+      .click();
+
+    cy.findByTestId("step-join-0-1")
+      .findByTestId("parent-dimension")
+      .findByText("Products");
+  });
+});


### PR DESCRIPTION
Fixes #17968: the notebook query builder displaying incorrect table names when joining multiple tables

### To Verify

1. Ask a question > Custom question > Sample Dataset > Orders
2. Join the Products table, keep the default dimensions
3. Join the Reviews table on "Products.ID = Reviews.Product_ID"
4. The Reviews join section should show that ID field comes from the Products table

### Demo

**Before (and a proof Cypress repro works)**

![CleanShot 2021-09-20 at 19 14 57@2x](https://user-images.githubusercontent.com/17258145/134044225-4e440f2b-e07d-44e8-b729-31a3fb932ead.png)

**After**

<img width="1035" alt="CleanShot 2021-09-20 at 20 08 30@2x" src="https://user-images.githubusercontent.com/17258145/134044334-625689ce-45a1-4391-ad84-e43c374a2f86.png">

 