### PR TITLE
Fix default formatting options for numeric types

### DIFF
--- a/frontend/src/metabase/visualizations/lib/settings/column.js
+++ b/frontend/src/metabase/visualizations/lib/settings/column.js
@@ -70,20 +70,17 @@ export function columnSettings({
 }
 
 import MetabaseSettings from "metabase/lib/settings";
-import { isa } from "metabase/lib/types";
 
 export function getGlobalSettingsForColumn(column: Column) {
-  const settings = {};
+  const columnSettings = {};
+  const customFormatting = MetabaseSettings.get("custom-formatting") || {};
 
-  const customFormatting = MetabaseSettings.get("custom-formatting");
   // NOTE: the order of these doesn't matter as long as there's no overlap between settings
-  for (const [type, globalSettings] of Object.entries(customFormatting || {})) {
-    if (isa(column.semantic_type || column.base_type, type)) {
-      Object.assign(settings, globalSettings);
-    }
+  for (const [, globalSettings] of Object.entries(customFormatting)) {
+    Object.assign(columnSettings, globalSettings);
   }
 
-  return settings;
+  return columnSettings;
 }
 
 function getLocalSettingsForColumn(column: Column): Settings {

--- a/frontend/test/metabase/scenarios/admin/settings/localization.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/localization.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore } from "__support__/e2e/cypress";
+import { restore, visitQuestionAdhoc } from "__support__/e2e/cypress";
 import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATASET;
@@ -119,6 +119,36 @@ describe("scenarios > admin > localization", () => {
     cy.findByText(/First day of the week/i);
     cy.findByText(/Localization options/i);
     cy.contains(/Column title/i).should("not.exist");
+  });
+
+  it("should use currency settings for number columns with style set to currency (metabase#10787)", () => {
+    cy.visit("/admin/settings/localization");
+
+    cy.findByText("Unit of currency");
+    cy.findByText("US Dollar").click();
+    cy.findByText("Euro").click();
+    cy.findByText("Saved");
+
+    visitQuestionAdhoc({
+      display: "scalar",
+      dataset_query: {
+        type: "native",
+        native: {
+          query: "SELECT 10 as a",
+          "template-tags": {},
+        },
+        database: 1,
+      },
+      visualization_settings: {
+        column_settings: {
+          '["name","A"]': {
+            number_style: "currency",
+          },
+        },
+      },
+    });
+
+    cy.findByText("€10.00");
   });
 });
 

--- a/frontend/test/metabase/scenarios/admin/settings/localization.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/localization.cy.spec.js
@@ -134,7 +134,7 @@ describe("scenarios > admin > localization", () => {
       dataset_query: {
         type: "native",
         native: {
-          query: "SELECT 10 as a",
+          query: "SELECT 10 as A",
           "template-tags": {},
         },
         database: 1,


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/10787

Previously `custom-formatting` settings were inherited when the type of the column was equal/subtype of the type used for the settings, e.g.
- `type/Float` inherited settings for `type/Number` but not `type/Currency`
- `type/Currency` inherited settings for `type/Number` and `type/Currency`

This was problematic as it's possible to change `number_style` for a `type/Float` column to be `Currency` and the user expects options for `type/Currency` to be applied in this case. This PR fixes the issue by inheriting all `custom-formatting` settings for all columns.

How to test:
- Follow the steps from the Cypress test