### PR TITLE
DELETE /api/ee/audit-app/user/:id/subscriptions archive Pulses created by User

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/audit_app/api/user.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_app/api/user.clj
@@ -3,15 +3,20 @@
   (:require [compojure.core :refer [DELETE]]
             [metabase.api.common :as api]
             [metabase.api.user :as api.user]
+            [metabase.models.pulse :refer [Pulse]]
             [metabase.models.pulse-channel-recipient :refer [PulseChannelRecipient]]
             [toucan.db :as db]))
 
 (api/defendpoint DELETE "/:id/subscriptions"
-  "Delete all Alert and DashboardSubscription subscriptions for a User. Only allowed for admins or for the current
-  user."
+  "Delete all Alert and DashboardSubscription subscriptions for a User (i.e., so they will no longer receive them).
+  Archive all Alerts and DashboardSubscriptions created by the User. Only allowed for admins or for the current user."
   [id]
   (api.user/check-self-or-superuser id)
+  ;; delete all `PulseChannelRecipient` rows for this User, which means they will no longer receive any
+  ;; Alerts/DashboardSubscriptions
   (db/delete! PulseChannelRecipient :user_id id)
+  ;; archive anything they created.
+  (db/update-where! Pulse {:creator_id id, :archived false} :archived true)
   api/generic-204-no-content)
 
 (api/define-routes)


### PR DESCRIPTION
Follow-on to #17888

Tweak the `DELETE /api/ee/audit-app/user/:id/subscriptions` Audit App API endpoint so that it _also_ archives any Alerts or DashboardSubscriptions created by the User in question (this was the original design, but I missed that part when implementing the first pass of the endpoint)