### PR TITLE
Fix #17975 by supporting getting MBQL field literal

### DIFF
--- a/frontend/src/metabase/lib/query/field_ref.js
+++ b/frontend/src/metabase/lib/query/field_ref.js
@@ -41,7 +41,8 @@ export function isSameField(fieldA, fieldB, exact = false) {
  */
 export function getFieldTargetId(field: FieldReference): ?FieldId {
   if (isLocalField(field)) {
-    return typeof field[1] === "number" ? field[1] : field;
+    const type = typeof field[1];
+    return type === "number" || type === "string" ? field[1] : field;
   }
   console.warn("Unknown field type:", field);
 }

--- a/frontend/test/metabase/lib/query/query.unit.spec.js
+++ b/frontend/test/metabase/lib/query/query.unit.spec.js
@@ -121,6 +121,17 @@ describe("Query", () => {
       ).toEqual({
         breakout: [["field", 2, null]],
       });
+      expect(
+        Query.updateBreakout(
+          {
+            breakout: [["field", "CREATED_AT", null]],
+          },
+          0,
+          ["field", "DISCOUNT", null],
+        ),
+      ).toEqual({
+        breakout: [["field", "DISCOUNT", null]],
+      });
     });
     it("should update sort as well", () => {
       expect(
@@ -135,6 +146,23 @@ describe("Query", () => {
       ).toEqual({
         breakout: [["field", 3, { "temporal-unit": "year" }]],
         "order-by": [["asc", ["field", 3, { "temporal-unit": "year" }]]],
+      });
+      expect(
+        Query.updateBreakout(
+          {
+            breakout: [["field", "CREATED_AT", { "temporal-unit": "month" }]],
+            "order-by": [
+              ["asc", ["field", "CREATED_AT", { "temporal-unit": "month" }]],
+            ],
+          },
+          0,
+          ["field", "CREATED_AT", { "temporal-unit": "year" }],
+        ),
+      ).toEqual({
+        breakout: [["field", "CREATED_AT", { "temporal-unit": "year" }]],
+        "order-by": [
+          ["asc", ["field", "CREATED_AT", { "temporal-unit": "year" }]],
+        ],
       });
     });
   });

--- a/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
@@ -139,7 +139,7 @@ describe("binning related reproductions", () => {
     cy.findByText("2018");
   });
 
-  it.skip("should not remove order-by (sort) when changing the breakout field on an SQL saved question (metabase#17975)", () => {
+  it("should not remove order-by (sort) when changing the breakout field on an SQL saved question (metabase#17975)", () => {
     cy.createNativeQuestion(
       {
         name: "17975",


### PR DESCRIPTION
Unit tests are added. The corresponding Cypress test is unskipped.

**To verify**

1. Ask a question, native question.
2. Choose Sample Dataset, type `select * from orders`.
3. Save it as _SQL Orders_.
4. Ask a question, Custom question.
5. Choose Saved Questions, _SQL Orders_.
6. Summarize: Count, by CREATED_AT.
7. Add sorting, choose CREATED_AT
8. Now go back and change the summarization to CREATED_AT: Year

**Before this PR**

Sort is gone.

![image](https://user-images.githubusercontent.com/7288/134237667-eec954d1-424f-44b1-abc8-27fb3aa1feb8.png)


**After this PR**

Sort is still there, adjusted correctly (run Visualize).

![image](https://user-images.githubusercontent.com/7288/134237541-93753065-9bbc-478e-a408-5f4292c8298a.png)
