### PR TITLE
Show "Previous results" as a left hand side table for chained joins

### DIFF
--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -212,7 +212,7 @@ function JoinClause({ color, join, updateQuery, showRemove }) {
   return (
     <JoinClauseRoot>
       <NotebookCell color={color} flex={1} alignSelf="start">
-        <NotebookCellItem color={color}>
+        <NotebookCellItem color={color} data-testid="left-table">
           {lhsTable?.displayName() || t`Previous results`}
         </NotebookCellItem>
 
@@ -416,6 +416,7 @@ function JoinTablePicker({
       }
       containerStyle={FIELDS_PICKER_STYLES.notebookItemContainer}
       rightContainerStyle={FIELDS_PICKER_STYLES.notebookRightItemContainer}
+      data-testid="right-table"
     >
       <DatabaseSchemaAndTableDataSelector
         hasTableSearch

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -148,15 +148,10 @@ function JoinClause({ color, join, updateQuery, showRemove }) {
 
   const hasAtLeastOneDimensionSelected = join.getDimensions().length > 0;
 
-  let lhsTable;
-  if (join.index() === 0) {
-    // first join's lhs is always the parent table
-    lhsTable = join.parentTable();
-  } else if (join.parentDimensions().length > 0) {
-    // subsequent can be one of the previously joined tables
-    // NOTE: `lhsDimension` would probably be a better name for `parentDimension`
-    lhsTable = join.parentDimensions()[0]?.field().table;
-  }
+  // first join's lhs is always the parent table
+  // subsequent should always be a string "Previous results" as per:
+  // https://github.com/metabase/metabase/pull/13895#issuecomment-735933018
+  const lhsTable = join.index() === 0 ? join.parentTable() : null;
 
   function onSourceTableSet(newJoin) {
     if (!newJoin.parentDimensions().length) {

--- a/frontend/test/metabase/scenarios/question/reproductions/13894-chained-joins-table-name.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/13894-chained-joins-table-name.cy.spec.js
@@ -1,0 +1,59 @@
+import { restore, popover, openOrdersTable } from "__support__/e2e/cypress";
+
+describe("issue 13894", () => {
+  beforeEach(() => {
+    cy.intercept("POST", "/api/dataset").as("dataset");
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should always display 'Previous results' for subsequent joins (metabase#13894)", () => {
+    openOrdersTable({ mode: "notebook" });
+
+    clickActionButton("Join data");
+    selectFromDropdown("People");
+    assertLeftTableName("Orders");
+
+    clickActionButton("Join data");
+    assertLeftTableName("Previous results", { step: 1 });
+    selectFromDropdown("Products");
+
+    clickActionButton("Join data");
+    selectFromDropdown("People");
+
+    assertLeftTableName("Orders", { step: 0 });
+    assertLeftTableName("Previous results", { step: 1 });
+    assertLeftTableName("Previous results", { step: 2 });
+
+    // Test joins in the next notebook stages also show "Previous results"
+
+    clickActionButton("Summarize");
+    selectFromDropdown("Count of rows");
+    cy.findByText("Pick a column to group by").click();
+    selectFromDropdown("Created At");
+
+    cy.findByTestId("step-summarize-0-0").within(() => {
+      clickActionButton("Join data");
+    });
+    selectFromDropdown("Reviews");
+    assertLeftTableName("Previous results", { stage: 1 });
+  });
+});
+
+function clickActionButton(name) {
+  cy.findByTestId("action-buttons")
+    .findByText(name)
+    .click();
+}
+
+function selectFromDropdown(text) {
+  popover()
+    .findByText(text)
+    .click();
+}
+
+function assertLeftTableName(name, { stage = 0, step = 0 } = {}) {
+  cy.findByTestId(`step-join-${stage}-${step}`)
+    .findByTestId("left-table")
+    .should("have.text", name);
+}


### PR DESCRIPTION
Resolves #13894

When you join many tables in the notebook editor (e.g., joining Orders with Products and People), the left-side-hand table name is shown as "Previous results" until the dimensions are selected. Then it changes to the left dimension's table name. This brings confusion because if you have at least one join, the subsequent join is always done on the previous results. See an example (notice how left table cell label changes):

<details>
<summary>GIF demo</summary>

![CleanShot 2021-09-21 at 12 18 08](https://user-images.githubusercontent.com/17258145/134145793-c016569c-b8c9-4fcc-9b0e-61043d1184e0.gif)

</details>

**Background**

It was fixed in #13895, but then reverted because it made it harder to understand from which table a dimension is coming. Let's say you join:

* Orders with Products (on `Orders.Product_ID = Products.ID`)
* Orders-Products join result and Reviews (on `Products.ID = Reviews.Product_ID`)

On the UI, the 2nd join looked like: "Previous results with Reviews WHERE ID = PRODUCT_ID". It was unclear which "ID" column was in use, so the fix has been reverted.

**What changed**

Since we added multiple field joins (#17633), Metabase now always displays the join dimension's table name in the cell itself. So if we now switch back to showing "Previous results" it won't affect the UX as the original fix did.

### To Verify

1. Ask a question > Custom question > Sample Dataset > Orders
2. Join the Products table, keep the default dimensions. The LHS table should be displayed as "Orders"
3. Click "Join data" and pick the Reviews table. The LHS table should be displayed as "Previous results"
4. Select the join condition: `Products.ID = Reviews.Product_ID`. The LHS table should be displayed as "Previous results"
5. Add some summarization and breakout (e.g., Count by Created At)
6. Join any other table. The LHS table should be displayed as "Previous results"
7. Ensure the _first_ join section displays the actual LHS table ("Orders" in this scenario). The first join is done between two tables, but the subsequent ones are made on the previous results + another table.

### Demo

**Before (also a proof Cypress repro works)**

![before](https://user-images.githubusercontent.com/17258145/134146373-455e7976-6557-439f-8032-ecc805ed7164.png)

**After**

<img width="1177" alt="after" src="https://user-images.githubusercontent.com/17258145/134146550-58df76e7-49f4-4fb2-94ce-a56472bc5b88.png">


