### PR TITLE
Allow searching a table in a specific database in DataPicker

### DIFF
--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -668,7 +668,7 @@ export class UnconnectedDataSelector extends Component {
     });
 
   renderActiveStep() {
-    const { combineDatabaseSchemaSteps, hasTableSearch } = this.props;
+    const { combineDatabaseSchemaSteps } = this.props;
     const props = {
       ...this.state,
 
@@ -681,7 +681,7 @@ export class UnconnectedDataSelector extends Component {
       isLoading: this.state.isLoading,
       hasNextStep: !!this.getNextStep(),
       onBack: this.getPreviousStep() ? this.previousStep : null,
-      hasFiltering: !hasTableSearch,
+      hasFiltering: true,
     };
 
     switch (this.state.activeStep) {
@@ -968,6 +968,7 @@ const TablePicker = ({
   onBack,
   isLoading,
   hasFiltering,
+  minTablesToShowSearch = 15,
 }) => {
   // In case DataSelector props get reseted
   if (!selectedDatabase) {
@@ -1021,7 +1022,7 @@ const TablePicker = ({
           sections={sections}
           maxHeight={Infinity}
           width={"100%"}
-          searchable={hasFiltering}
+          searchable={hasFiltering && tables.length >= minTablesToShowSearch}
           onChange={item => onChangeTable(item.table)}
           itemIsSelected={item =>
             item.table && selectedTable

--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -968,7 +968,7 @@ const TablePicker = ({
   onBack,
   isLoading,
   hasFiltering,
-  minTablesToShowSearch = 15,
+  minTablesToShowSearch = 10,
 }) => {
   // In case DataSelector props get reseted
   if (!selectedDatabase) {


### PR DESCRIPTION
Fixes #17011

After a DataPicker update in 0.40, the ability to search for a table in a specific database has disappeared. This PR puts it back (keeping an ability to search for a table and saved questions across all databases)

### To Verify

1. Ask a question > Simple / Custom question
2. Search for a table and a saved question with the "Search for a table..." input
3. You should see search results containing tables and saved questions (if there are some for the search query you entered. They should have "Saved question in {collection_name}" or "Table in {db_name}" labels
4. Clear your search query and click any database in the picker
5. You should see a list of DB tables and a search input at the top
6. Enter some table names, ensure searching works correctly and you only see tables from the selected DB

### Demo

**Before (and a proof Cypress repro works)**

<img width="1490" alt="CleanShot 2021-09-21 at 16 10 13@2x" src="https://user-images.githubusercontent.com/17258145/134179668-5eda85ea-c40a-479b-836a-f52073f92a6f.png">

**After (data picker)**

![CleanShot 2021-09-21 at 16 13 24](https://user-images.githubusercontent.com/17258145/134179720-053722c5-a643-4b9c-9d17-55b1bf52abf0.gif)

**After (table picker for joins)**

<img width="904" alt="CleanShot 2021-09-21 at 16 13 55@2x" src="https://user-images.githubusercontent.com/17258145/134179795-72fd9c7e-f590-46d0-bf12-67ccbf653057.png">


