### PR TITLE
Handle unaggregated data warning for waterfall chart

### DIFF
--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -193,11 +193,17 @@ function getDimensionsAndGroupsAndUpdateSeriesDisplayNamesForStackedChart(
 
   const dimension = dataset.dimension(d => d[0]);
   const groups = [
-    datas.map((data, seriesIndex) =>
-      reduceGroup(dimension.group(), seriesIndex + 1, () =>
-        warn(unaggregatedDataWarning(props.series[seriesIndex].data.cols[0])),
-      ),
-    ),
+    datas.map((data, seriesIndex) => {
+      // HACK: waterfall chart is a stacked bar chart that supports only one series
+      // and the groups number does not match the series number due to the implementation
+      const realSeriesIndex = props.chartType === "waterfall" ? 0 : seriesIndex;
+
+      return reduceGroup(dimension.group(), seriesIndex + 1, () =>
+        warn(
+          unaggregatedDataWarning(props.series[realSeriesIndex].data.cols[0]),
+        ),
+      );
+    }),
   ];
 
   return { dimension, groups };

--- a/frontend/test/metabase/scenarios/visualizations/waterfall.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/waterfall.cy.spec.js
@@ -162,7 +162,7 @@ describe("scenarios > visualizations > waterfall", () => {
       .should("not.have.css", "opacity", "1");
   });
 
-  it.skip("should work for unaggregated data (metabase#15465)", () => {
+  it("should work for unaggregated data (metabase#15465)", () => {
     visitQuestionAdhoc({
       dataset_query: {
         type: "native",


### PR DESCRIPTION
### Description

Fixes https://github.com/metabase/metabase/issues/15465

The waterfall chart is a stacked bar chart that supports only one series and the groups' number does not match the series number due to the implementation.

### How to verify

Check the repro steps in the linked issue