### PR TITLE
show meaningful error for waterfall chart of multiple series questions

### DIFF
--- a/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
+++ b/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
@@ -103,6 +103,10 @@ export default class LineAreaBarChart extends Component {
   }
 
   static checkRenderable(series, settings) {
+    if (series.length > this.maxMetricsSupported) {
+      throw new Error(t`${this.uiName} chart does not support multiple series`);
+    }
+
     const singleSeriesHasNoRows = ({ data: { cols, rows } }) => rows.length < 1;
     if (_.every(series, singleSeriesHasNoRows)) {
       throw new MinRowsError(1, 0);

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx
@@ -54,6 +54,7 @@ const ChartSettingFieldPicker = ({
         />
       )}
       <Icon
+        data-testid={`remove-${value}`}
         name="close"
         className={cx("ml1 text-medium text-brand-hover cursor-pointer", {
           "disabled hidden": !onRemove,

--- a/frontend/src/metabase/visualizations/index.js
+++ b/frontend/src/metabase/visualizations/index.js
@@ -97,6 +97,11 @@ export const extractRemappings = series => {
   return se;
 };
 
+export function getMaxMetricsSupported(display) {
+  const visualization = visualizations.get(display);
+  return visualization.maxMetricsSupported || Infinity;
+}
+
 // removes columns with `remapped_from` property and adds a `remapping` to the appropriate column
 const extractRemappedColumns = data => {
   const cols = data.cols.map(col => ({

--- a/frontend/src/metabase/visualizations/lib/RowRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/RowRenderer.js
@@ -27,10 +27,6 @@ export default function rowRenderer(
 ): DeregisterFunction {
   const { cols } = series[0].data;
 
-  if (series.length > 1) {
-    throw new Error("Row chart does not support multiple series");
-  }
-
   const chart = dc.rowChart(element);
 
   // disable clicks

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -154,13 +154,15 @@ export const GRAPH_DATA_SETTINGS = {
         .filter(vizSettings["graph._metric_filter"])
         .map(getOptionFromColumn);
 
+      const hasBreakout = vizSettings["graph.dimensions"].length > 1;
       const addedMetricsCount = vizSettings["graph.metrics"].length;
-      const supportedMetrics = getMaxMetricsSupported(card.display);
+      const maxMetricsSupportedCount = getMaxMetricsSupported(card.display);
 
+      const hasMetricsToAdd = options.length > value.length;
       const canAddAnother =
-        addedMetricsCount < supportedMetrics &&
-        options.length > value.length &&
-        vizSettings["graph.dimensions"].length < 2;
+        addedMetricsCount < maxMetricsSupportedCount &&
+        hasMetricsToAdd &&
+        !hasBreakout;
 
       return {
         options,

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -19,6 +19,7 @@ import { dimensionIsNumeric } from "metabase/visualizations/lib/numeric";
 import { dimensionIsTimeseries } from "metabase/visualizations/lib/timeseries";
 
 import _ from "underscore";
+import { getMaxMetricsSupported } from "metabase/visualizations";
 
 // NOTE: currently we don't consider any date extracts to be histgrams
 const HISTOGRAM_DATE_EXTRACTS = new Set([
@@ -152,13 +153,18 @@ export const GRAPH_DATA_SETTINGS = {
       const options = data.cols
         .filter(vizSettings["graph._metric_filter"])
         .map(getOptionFromColumn);
+
+      const addedMetricsCount = vizSettings["graph.metrics"].length;
+      const supportedMetrics = getMaxMetricsSupported(card.display);
+
+      const canAddAnother =
+        addedMetricsCount < supportedMetrics &&
+        options.length > value.length &&
+        vizSettings["graph.dimensions"].length < 2;
+
       return {
         options,
-        addAnother:
-          options.length > value.length &&
-          vizSettings["graph.dimensions"].length < 2
-            ? t`Add another series...`
-            : null,
+        addAnother: canAddAnother ? t`Add another series...` : null,
         columns: data.cols,
         showColumnSetting: true,
       };

--- a/frontend/src/metabase/visualizations/visualizations/RowChart.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart.jsx
@@ -13,6 +13,7 @@ export default class RowChart extends LineAreaBarChart {
   static iconName = "horizontal_bar";
   static noun = t`row chart`;
 
+  static maxMetricsSupported = 1;
   static supportsSeries = false;
 
   static renderer = rowRenderer;

--- a/frontend/src/metabase/visualizations/visualizations/WaterfallChart.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/WaterfallChart.jsx
@@ -1,5 +1,5 @@
 import { t } from "ttag";
-import LineAreaBarChart from "../components/LineAreaBarChart.jsx";
+import LineAreaBarChart from "../components/LineAreaBarChart";
 import { waterfallRenderer } from "../lib/LineAreaBarRenderer";
 import { assocIn } from "icepick";
 
@@ -16,6 +16,8 @@ export default class WaterfallChart extends LineAreaBarChart {
   static identifier = "waterfall";
   static iconName = "waterfall";
   static noun = t`waterfall chart`;
+
+  static maxMetricsSupported = 1;
 
   static settings = {
     ...GRAPH_AXIS_SETTINGS,

--- a/frontend/test/metabase/scenarios/visualizations/waterfall.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/waterfall.cy.spec.js
@@ -135,7 +135,7 @@ describe("scenarios > visualizations > waterfall", () => {
     });
   });
 
-  it.skip("should not be enabled for multi-series questions (metabase#15152)", () => {
+  it("should show error for multi-series questions (metabase#15152)", () => {
     cy.server();
     cy.route("POST", "/api/dataset").as("dataset");
 
@@ -155,11 +155,15 @@ describe("scenarios > visualizations > waterfall", () => {
     });
 
     cy.wait("@dataset");
-    cy.findByText("Visualization").click();
 
-    cy.findByText("Waterfall")
-      .parent()
-      .should("not.have.css", "opacity", "1");
+    cy.findByText("Visualization").click();
+    cy.findByTestId("Waterfall-button").click();
+    cy.findByText("Waterfall chart does not support multiple series");
+
+    cy.findByTestId("remove-count").click();
+    cy.get(".CardVisualization svg"); // Chart renders after removing the second metric
+
+    cy.findByText("Add another series...").should("not.exist");
   });
 
   it("should work for unaggregated data (metabase#15465)", () => {


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/15152

### Description

The original issue suggests disabling "Waterfall" visualization button when more than 1 metric is selected. I think it might be better to show a meaningful error message the same way as we do for the Row chart in the same situation. It seems like we use pseudo-disabled buttons to indicate data shape compatibility. Wdyt @flamber?

### How to verify

Check repro steps of the linked issue https://github.com/metabase/metabase/issues/15152

### Screenshots

Before
<img width="1438" alt="Screen Shot 2021-09-21 at 22 07 02" src="https://user-images.githubusercontent.com/14301985/134232504-3bb6c37a-3530-4549-b773-2517876f25fc.png">

After
<img width="1430" alt="Screen Shot 2021-09-21 at 22 03 52" src="https://user-images.githubusercontent.com/14301985/134232445-7746f5d2-4f0b-4745-b98d-9ab89ddf921b.png">