### PR TITLE
fix tables are not clickable in recents

### DIFF
--- a/frontend/src/metabase/lib/urls.js
+++ b/frontend/src/metabase/lib/urls.js
@@ -94,13 +94,17 @@ function prepareModel(item) {
 }
 
 export function modelToUrl(item) {
+  const modelData = prepareModel(item);
+
   switch (item.model) {
     case "card":
-      return question(prepareModel(item));
+      return question(modelData);
     case "dashboard":
-      return dashboard(prepareModel(item));
+      return dashboard(modelData);
     case "pulse":
-      return pulse(item.model_id);
+      return pulse(modelData.id);
+    case "table":
+      return tableRowsQuery(modelData.db_id, modelData.id);
     default:
       return null;
   }

--- a/frontend/test/metabase/scenarios/onboarding/search/recently-viewed.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/search/recently-viewed.cy.spec.js
@@ -21,13 +21,23 @@ describe(`search > recently viewed`, () => {
     cy.findByPlaceholderText("Search…").click();
     cy.get(".LoadingSpinner").should("not.exist");
 
-    assertRecentlyViewedItem(0, "Orders in a dashboard", "Dashboard");
-    assertRecentlyViewedItem(1, "Orders", "Question");
-    assertRecentlyViewedItem(2, "People", "Table");
+    assertRecentlyViewedItem(
+      0,
+      "Orders in a dashboard",
+      "Dashboard",
+      "/dashboard/1-orders-in-a-dashboard",
+    );
+    assertRecentlyViewedItem(1, "Orders", "Question", "/question/1-orders");
+    assertRecentlyViewedItem(2, "People", "Table", "/question#?db=1&table=3");
   });
 });
 
-const assertRecentlyViewedItem = (index, title, type) => {
+const assertRecentlyViewedItem = (index, title, type, link) => {
+  cy.findAllByTestId("recently-viewed-item")
+    .eq(index)
+    .parent()
+    .should("have.attr", "href", link);
+
   cy.findAllByTestId("recently-viewed-item-title")
     .eq(index)
     .should("have.text", title);


### PR DESCRIPTION
### Description

This PR makes tables clickable in the recently viewed items list

### How to verify
- Open any table from browse page the `/browse/1-sample-dataset`
- Click on the search bar to show recently visited items
- Ensure the table is on the list and it is clickable
