### PR TITLE
Unverify cards when they are edited

### DIFF
--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -3,6 +3,7 @@
   (:require [cheshire.core :as json]
             [clojure.string :as str]
             [clojure.test :refer :all]
+            [clojure.tools.macro :as tools.macro]
             [dk.ative.docjure.spreadsheet :as spreadsheet]
             [java-time :as t]
             [medley.core :as m]
@@ -12,6 +13,7 @@
             [metabase.http-client :as http]
             [metabase.models :refer [Card CardFavorite Collection Dashboard Database ModerationReview
                                      Pulse PulseCard PulseChannel PulseChannelRecipient Table ViewLog]]
+            [metabase.models.moderation-review :as moderation-review]
             [metabase.models.permissions :as perms]
             [metabase.models.permissions-group :as perms-group]
             [metabase.models.revision :as revision :refer [Revision]]
@@ -27,7 +29,8 @@
             [metabase.util :as u]
             [metabase.util.schema :as su]
             [schema.core :as s]
-            [toucan.db :as db])
+            [toucan.db :as db]
+            [toucan.hydrate :refer [hydrate]])
   (:import java.io.ByteArrayInputStream
            java.util.UUID))
 
@@ -1506,6 +1509,93 @@
 
    :collections
    (collection-names cards-or-card-ids)))
+
+(deftest changed?-test
+  (letfn [(changed? [before after]
+            (#'card-api/changed? before after {:ignore card-api/card-compare-ignores}))]
+   (testing "Ignores keyword/string"
+     (is (false? (changed? {:dataset_query {:type :query}} {:dataset_query {:type "query"}}))))
+   (testing "Ignores properties passed in `card-api/card-compare-ignores"
+     (is (false? (changed? {:collection_id 1
+                            :collection_position 0}
+                           {:collection_id 2
+                            :collection_position 1}))))
+   (testing "Sees changes"
+     (is (true? (changed? {:description "foo"} {:description "diff"})))
+     (testing "But only when they are different in the after"
+       (is (false? (changed? {:description "foo" :title "something" :collection_id 1}
+                             {:collection_id 1})))
+       (is (true? (changed? {:description "foo" :title "something" :collection_id 1}
+                            {:description nil :title nil :collection_id 1})))))))
+
+(deftest update-verified-card-test
+  (tools.macro/macrolet
+      [(with-card [verified & body]
+         `(mt/with-temp* ~(cond-> `[Collection [~'collection]
+                                    Collection [~'collection2]
+                                    Card       [~'card {:collection_id (u/the-id ~'collection)
+                                                        :dataset_query (mt/mbql-query ~'venues)}]]
+                            (= verified :verified)
+                            (into
+                             `[ModerationReview
+                               [~'review {:moderated_item_id   (:id ~'card)
+                                          :moderated_item_type "card"
+                                          :moderator_id        (mt/user->id :rasta)
+                                          :most_recent         true
+                                          :status              "verified"
+                                          :text                "lookin good"}]]))
+            ~@body))]
+      (letfn [(verified? [card]
+                (-> card (hydrate [:moderation_reviews :moderator_details])
+                    :moderation_reviews first :status #{"verified"} boolean))
+              (reviews [card]
+                (db/select ModerationReview
+                           :moderated_item_type "card"
+                           :moderated_item_id (u/the-id card)
+                           {:order-by [[:id :desc]]}))
+              (update-card [card diff]
+                (mt/user-http-request :rasta :put 202 (str "card/" (u/the-id card)) (merge card diff)))]
+        (testing "Changing core attributes un-verifies the card"
+          (with-card :verified
+            (is (verified? card))
+            (update-card card {:description "a new description"})
+            (is (not (verified? card)))
+            (testing "The unverification edit has explanatory text"
+              (is (= "Unverified due to edit"
+                     (-> (reviews card) first :text))))))
+        (testing "Changing some attributes does not unverify"
+          (tools.macro/macrolet [(remains-verified [& body]
+                                   `(~'with-card :verified
+                                     (is (~'verified? ~'card) "Not verified initially")
+                                     ~@body
+                                     (is (~'verified? ~'card) "Not verified after action")))]
+            (testing "changing collection"
+              (remains-verified
+               (update-card card {:collection_id (u/the-id collection2)})))
+            (testing "pinning"
+              (remains-verified
+               (update-card card {:collection_position 1})))
+            (testing "making public"
+              (remains-verified
+               (update-card card {:made_public_by_id (mt/user->id :rasta)
+                                  :public_uuid (UUID/randomUUID)})))))
+        (testing "Does not add a new nil moderation review when not verified"
+          (with-card :not-verified
+            (is (empty? (reviews card)))
+            (update-card card {:description "a new description"})
+            (is (empty? (reviews card)))))
+        (testing "Does not add nil moderation reviews when there are reviews but not verified"
+          ;; testing that we aren't just adding a nil moderation each time we update a card
+          (with-card :verified
+            (is (verified? card))
+            (moderation-review/create-review! {:moderated_item_id   (u/the-id card)
+                                               :moderated_item_type "card"
+                                               :moderator_id        (mt/user->id :rasta)
+                                               :status              nil})
+            (is (not (verified? card)))
+            (is (= 2 (count (reviews card))))
+            (update-card card {:description "a new description"})
+            (is (= 2 (count (reviews card)))))))))
 
 (deftest test-that-we-can-bulk-move-some-cards-with-no-collection-into-a-collection
   (mt/with-temp* [Collection [collection {:name "Pog Collection"}]


### PR DESCRIPTION
Fixes #17886

Verified questions lose verification status when edited to prevent hijinks.

from maz in slack:
##### Should not remove verification:
 - Moving to another collection
 - Pinning/unpinning
 - Adding/removing an alert on the question
 - Turning sharing on the question on/off

##### Should remove verification:
 - Editing the query
 - Editing the visualization or viz settings
 - Editing the title or description

This really just identifies when not to remove verification, otherwise
does remove verification. Alerts are not related to questions through
the api so no worries there. Everything else is just excluding
attributes from the diff calculation.

In tests, went perhaps a bit haywire with the macrolet, allowing to
define macros inline rather than farther away from the call site. Used
twice:
- once to optionally add in moderation review into the with-temp. This
macro is handy to ensure we always have a fresh state of card and don't
have leftover changes or verifications. Has to be a macro since i want
to dynamically change whether there are verifications in the with-temp*
vector binding
- a way to more easily reduce repetition when asserting something is
verified, do an action, and assert it is still verified

I'm like 70/30 in favor of this style. Happy to be convinced to change but the tests really just move all of the boilerplate above and focus just on the behavior and assertion.