### PR TITLE
Fetch fields before parsing parameter values so we correctly parse values for boolean fields

### DIFF
--- a/frontend/src/metabase-lib/lib/queries/NativeQuery.js
+++ b/frontend/src/metabase-lib/lib/queries/NativeQuery.js
@@ -24,7 +24,7 @@ import type { DatabaseEngine, DatabaseId } from "metabase-types/types/Database";
 
 import AtomicQuery from "metabase-lib/lib/queries/AtomicQuery";
 
-import Dimension, { TemplateTagDimension } from "../Dimension";
+import Dimension, { TemplateTagDimension, FieldDimension } from "../Dimension";
 import Variable, { TemplateTagVariable } from "../Variable";
 import DimensionOptions from "../DimensionOptions";
 
@@ -457,5 +457,27 @@ export default class NativeQuery extends AtomicQuery {
       }
     }
     return {};
+  }
+
+  dependentMetadata() {
+    const templateTags = this.templateTags();
+
+    return templateTags
+      .filter(
+        tag =>
+          tag.type === "dimension" &&
+          FieldDimension.isFieldClause(tag.dimension),
+      )
+      .map(tag => {
+        const dimension = FieldDimension.parseMBQL(
+          tag.dimension,
+          this.metadata(),
+        );
+
+        return {
+          type: "field",
+          id: dimension.field().id,
+        };
+      });
   }
 }

--- a/frontend/src/metabase/parameters/components/Parameters/syncQueryParamsWithURL.js
+++ b/frontend/src/metabase/parameters/components/Parameters/syncQueryParamsWithURL.js
@@ -87,7 +87,9 @@ const treatValueForFieldValuesWidget = (value, parameter) => {
 // ["field", <integer-id>, <options>] or
 // ["field", <string-name>, <options>]
 const getFields = (parameter, metadata) => {
-  const fieldIds = parameter.field_ids || [];
+  const fieldIds =
+    parameter.field_ids || [parameter.field_id].filter(f => f != null);
+
   return fieldIds.map(
     id => metadata.field(id) || Dimension.parseMBQL(id, metadata).field(),
   );

--- a/frontend/src/metabase/redux/metadata.js
+++ b/frontend/src/metabase/redux/metadata.js
@@ -318,6 +318,8 @@ export const loadMetadataForQueries = queries => dispatch =>
           return (foreignTables
             ? Tables.actions.fetchMetadataAndForeignTables
             : Tables.actions.fetchMetadata)({ id });
+        } else if (type === "field") {
+          return Fields.actions.fetch({ id });
         } else {
           console.warn(`loadMetadataForQueries: type ${type} not implemented`);
         }

--- a/frontend/src/metabase/redux/metadata.unit.spec.js
+++ b/frontend/src/metabase/redux/metadata.unit.spec.js
@@ -1,15 +1,13 @@
 import Fields from "metabase/entities/fields";
-import { fetchField } from "./metadata";
+import Tables from "metabase/entities/tables";
+import { fetchField, loadMetadataForQuery } from "./metadata";
 
 describe("deprecated metadata actions", () => {
   let dispatch;
   beforeEach(() => {
     jest.clearAllMocks();
 
-    dispatch = jest.fn(async foo => {
-      const action = await foo;
-      return action;
-    });
+    dispatch = jest.fn(a => a);
   });
 
   describe("fetchField", () => {
@@ -78,6 +76,65 @@ describe("deprecated metadata actions", () => {
         { reload: true },
       );
       expect(Fields.actions.fetch.mock.calls.length).toBe(2);
+    });
+  });
+
+  describe("loadMetadataForQuery", () => {
+    beforeEach(() => {
+      Fields.actions.fetch = jest.fn(() =>
+        Promise.resolve({
+          type: Fields.actionTypes.FETCH_ACTION,
+          payload: {},
+        }),
+      );
+
+      Tables.actions.fetchMetadata = jest.fn(() =>
+        Promise.resolve({
+          type: Tables.actionTypes.FETCH_METADATA,
+          payload: {},
+        }),
+      );
+
+      Tables.actions.fetchMetadataAndForeignTables = jest.fn(() =>
+        Promise.resolve({
+          type: Tables.actionTypes.FETCH_TABLE_METADATA,
+          payload: {},
+        }),
+      );
+    });
+
+    it("should send requests for any tables/fields needed by the query", () => {
+      const query = {
+        dependentMetadata: () => [
+          {
+            type: "table",
+            id: 1,
+          },
+          {
+            type: "table",
+            id: 1,
+          },
+          {
+            foreignTables: true,
+            type: "table",
+            id: 2,
+          },
+          {
+            type: "field",
+            id: 3,
+          },
+          { type: "card", id: 4 },
+        ],
+      };
+
+      loadMetadataForQuery(query)(dispatch);
+      expect(Tables.actions.fetchMetadata).toHaveBeenCalledWith({ id: 1 });
+      expect(Tables.actions.fetchMetadataAndForeignTables).toHaveBeenCalledWith(
+        { id: 2 },
+      );
+      expect(Tables.actions.fetchMetadata.mock.calls.length).toBe(1);
+
+      expect(Fields.actions.fetch).toHaveBeenCalledWith({ id: 3 });
     });
   });
 });

--- a/frontend/test/metabase-lib/lib/queries/NativeQuery.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/NativeQuery.unit.spec.js
@@ -311,4 +311,25 @@ describe("NativeQuery", () => {
       expect(dimensions.map(d => d.displayName())).toEqual(["Category"]);
     });
   });
+
+  describe("dependentMetadata", () => {
+    it("should return a list of dependent fieldIds needed by the query's template tags", () => {
+      const q = makeQuery()
+        .setQueryText("SELECT * FROM PRODUCTS WHERE {{category}}")
+        .setTemplateTag("category", {
+          name: "category",
+          type: "dimension",
+          dimension: ["field", PRODUCTS.CATEGORY.id, null],
+        })
+        .setTemplateTag("foo", { name: "foo", type: "dimension" })
+        .setTemplateTag("bar", { name: "bar", type: "test" });
+
+      expect(q.dependentMetadata()).toEqual([
+        {
+          type: "field",
+          id: PRODUCTS.CATEGORY.id,
+        },
+      ]);
+    });
+  });
 });


### PR DESCRIPTION
Related to #15498 

**The problem**
- In the Native Query builder, parameter values are set by a function call (`syncQueryParamsWithURL`) in the `Parameters` component constructor.
- In order for `syncQueryParamsWithURL` to correctly parse a parameter value it needs information from the parameter's associated Field (assuming it is a Field Filter)
- We currently aren't fetching the necessary field info until AFTER the `syncQueryParamsWithURL` has happened
- This usually isn't a problem, because category filters are typically strings. However, `category` is a semantic type that includes booleans, and without having the boolean field to look at, we end up treating `"true"` as a string and not a boolean.

**The fix**
- The `initializeQb` action awaits on a call to `loadMetadataForQuery`
- I've added fields found in a native query's field filter template tags to the native query's (previously empty) list of dependent metadata
- I've extended the logic of `loadMetadataForQueries` to also fetch Fields since it currently only fetches table metadata
- Now, the needed `/api/field/:fieldId` GET is sent and resolved before `<Parameters>` is instantiated

Note: dashboards are still broken, as dashboard parameter values aren't passed through the necessary logic found in `syncQueryParamsWithURL`. I'm fixing that in a subsequent PR. I'm guessing we might need to do something for GUI questions with applied parameters, as well.

https://user-images.githubusercontent.com/13057258/134264596-eae95a46-7fd0-4ec2-b22e-e6299483c6fb.mov

