### PR TITLE
Escape HTML in markdown cards when rendered for emails

### DIFF
--- a/src/metabase/pulse/markdown.clj
+++ b/src/metabase/pulse/markdown.clj
@@ -9,6 +9,7 @@
             Paragraph Reference SoftLineBreak StrongEmphasis Text ThematicBreak]
            com.vladsch.flexmark.html.HtmlRenderer
            com.vladsch.flexmark.parser.Parser
+           com.vladsch.flexmark.util.data.MutableDataSet
            [com.vladsch.flexmark.util.ast Document Node]
            java.net.URI))
 
@@ -300,7 +301,10 @@
 
 (def ^:private renderer
   "An instance of a Flexmark HTML renderer"
-  (delay (.build (HtmlRenderer/builder))))
+  (let [options (.. (MutableDataSet.)
+                    (set (. HtmlRenderer ESCAPE_HTML) true)
+                    (toImmutable))]
+    (delay (.build (HtmlRenderer/builder options)))))
 
 (defmulti process-markdown
   "Converts a markdown string from a virtual card into a form that can be sent to a channel

--- a/src/metabase/pulse/markdown.clj
+++ b/src/metabase/pulse/markdown.clj
@@ -9,8 +9,8 @@
             Paragraph Reference SoftLineBreak StrongEmphasis Text ThematicBreak]
            com.vladsch.flexmark.html.HtmlRenderer
            com.vladsch.flexmark.parser.Parser
-           com.vladsch.flexmark.util.data.MutableDataSet
            [com.vladsch.flexmark.util.ast Document Node]
+           com.vladsch.flexmark.util.data.MutableDataSet
            java.net.URI))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/test/metabase/pulse/markdown_test.clj
+++ b/test/metabase/pulse/markdown_test.clj
@@ -157,3 +157,27 @@
     (is (= "&" (mrkdwn "&amp;")))
     (is (= ">" (mrkdwn "&gt;")))
     (is (= "ℋ" (mrkdwn "&HilbertSpace;")))))
+
+(defn- html
+  [markdown]
+  (md/process-markdown markdown :html))
+
+(deftest process-markdown-email-test
+  (testing "HTML is generated correctly from Markdown input for emails. Not an exhaustive test suite since parsing and
+           rendering is fully handled by flexmark."
+    (is (= "<h1>header</h1>\n"
+           (html "# header")))
+    (is (= "<p><strong>bold</strong></p>\n"
+           (html "**bold**")))
+    (is (= "<p><a href=\"https://metabase.com\" title=\"tooltip\">Metabase</a></p>\n"
+           (html "[Metabase](https://metabase.com \"tooltip\")")))
+    (is (= "<ol>\n<li>foo\n<ol>\n<li>bar</li>\n</ol>\n</li>\n</ol>\n"
+           (html "1. foo\n   1. bar")))
+    (is (= "<p>/</p>\n"
+           (html "\\/")))
+    (is (= "<p><img src=\"image.png\" alt=\"alt-text\" /></p>\n"
+           (html "![alt-text](image.png)"))))
+
+  (testing "HTML in the source markdown is escaped properly, but HTML entities are retained"
+    (is (= "<p>&lt;h1&gt;header&lt;/h1&gt;</p>\n" (html "<h1>header</h1>")))
+    (is (= "<p>&amp;</p>\n"                       (html "&amp;")))))


### PR DESCRIPTION
Sets an option on the Flexmark `HtmlRenderer` to ensure HTML in the source markdown is escaped properly when being rendered (since we don't allow HTML in markdown on the frontend).

Also adds some basic tests for general markdown -> HTML rendering. Just some sanity checks, not an exhaustive test suite (like we have for Slack) since Flexmark handles the entire rendering pipeline.