### PR TITLE
Do not change display on drill to questions

### DIFF
--- a/frontend/src/metabase-lib/lib/Question.js
+++ b/frontend/src/metabase-lib/lib/Question.js
@@ -1053,6 +1053,7 @@ export default class Question {
       description: this._card.description,
       dataset_query: query.datasetQuery(),
       display: this._card.display,
+      displayIsLocked: this._card.displayIsLocked,
       parameters: this._card.parameters,
       ...(_.isEmpty(this._parameterValues)
         ? undefined

--- a/frontend/src/metabase-lib/lib/Question.js
+++ b/frontend/src/metabase-lib/lib/Question.js
@@ -824,16 +824,22 @@ export default class Question {
     originalQuestion,
     clean = true,
     query,
+    includeDisplayIsLocked,
   }: {
     originalQuestion?: Question,
     clean?: boolean,
     query?: { [string]: any },
+    includeDisplayIsLocked?: boolean,
   } = {}): string {
     if (
       !this.id() ||
       (originalQuestion && this.isDirtyComparedTo(originalQuestion))
     ) {
-      return Urls.question(null, this._serializeForUrl({ clean }), query);
+      return Urls.question(
+        null,
+        this._serializeForUrl({ clean, includeDisplayIsLocked }),
+        query,
+      );
     } else {
       return Urls.question(this.card(), "", query);
     }
@@ -1045,7 +1051,11 @@ export default class Question {
   }
 
   // Internal methods
-  _serializeForUrl({ includeOriginalCardId = true, clean = true } = {}) {
+  _serializeForUrl({
+    includeOriginalCardId = true,
+    clean = true,
+    includeDisplayIsLocked = false,
+  } = {}) {
     const query = clean ? this.query().clean() : this.query();
 
     const cardCopy = {
@@ -1053,7 +1063,6 @@ export default class Question {
       description: this._card.description,
       dataset_query: query.datasetQuery(),
       display: this._card.display,
-      displayIsLocked: this._card.displayIsLocked,
       parameters: this._card.parameters,
       ...(_.isEmpty(this._parameterValues)
         ? undefined
@@ -1061,6 +1070,11 @@ export default class Question {
       visualization_settings: this._card.visualization_settings,
       ...(includeOriginalCardId
         ? { original_card_id: this._card.original_card_id }
+        : {}),
+      ...(includeDisplayIsLocked
+        ? {
+            displayIsLocked: this._card.displayIsLocked,
+          }
         : {}),
     };
 
@@ -1082,11 +1096,13 @@ export default class Question {
   }
 
   getUrlWithParameters() {
-    const question = this.query().isEditable()
-      ? this.convertParametersToFilters()
-      : this.markDirty(); // forces use of serialized question url
+    const question = this.convertParametersToFilters().markDirty();
     const query = this.isNative() ? this._parameterValues : undefined;
-    return question.getUrl({ originalQuestion: this, query });
+    return question.getUrl({
+      originalQuestion: this,
+      query,
+      includeDisplayIsLocked: true,
+    });
   }
 
   getModerationReviews() {

--- a/frontend/src/metabase/modes/components/drill/DashboardClickDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/DashboardClickDrill.jsx
@@ -72,7 +72,7 @@ export default ({ question, clicked }: ClickActionProps): ClickAction[] => {
         extraData.questions[targetId],
         question.metadata(),
         getQueryParams(parameterMapping, { data, extraData, clickBehavior }),
-      );
+      ).lockDisplay();
 
       if (targetQuestion.isStructured()) {
         targetQuestion = targetQuestion.setParameters(

--- a/frontend/test/metabase/scenarios/dashboard/click-behavior.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/click-behavior.cy.spec.js
@@ -100,7 +100,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
     });
   });
 
-  it.skip("should not change the visualization type in a targetted question with mapped filter (metabase#16334)", () => {
+  it("should not change the visualization type in a targetted question with mapped filter (metabase#16334)", () => {
     // Question 2, that we're adding to the dashboard
     const questionDetails = {
       query: {

--- a/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
@@ -210,7 +210,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
     cy.findByText("num: 111").click();
 
     // show filtered question
-    cy.findByText("Orders");
+    cy.findAllByText("Orders");
     cy.findByText("User ID is 111");
     cy.findByText("Category is Widget");
     cy.findByText("Showing 5 rows");


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/16334

Please check the original issue for repro steps.

We need to lock `display`, and make sure we include `displayIsLocked` in the url.