### PR TITLE
#18009 Repro: Nodata user can create dashboard subscription, but receives an error

### DIFF
--- a/frontend/test/metabase/scenarios/sharing/reproductions/18009-nodata-creates-subscription-receives-error.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/reproductions/18009-nodata-creates-subscription-receives-error.cy.spec.js
@@ -1,0 +1,52 @@
+import { restore, popover } from "__support__/e2e/cypress";
+
+describe.skip("issue 18009", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.request("DELETE", "http://localhost:80/email/all");
+    setUpEmail();
+
+    cy.signIn("nodata");
+  });
+
+  it("nodata user should be able to create and receive an email subscription without errors (metabase#18009)", () => {
+    cy.visit("/dashboard/1");
+
+    cy.icon("share").click();
+    cy.findByText("Dashboard subscriptions").click();
+
+    cy.findByText("Email it").click();
+
+    cy.findByPlaceholderText("Enter user names or email addresses").click();
+    popover()
+      .contains(/^No Data/)
+      .click();
+
+    // Click anywhere to close the popover that covers the "Send email now" button
+    cy.findByText("To:").click();
+
+    cy.button("Send email now").click();
+    cy.findByText("Email sent");
+
+    cy.request("GET", "http://localhost:80/email").then(({ body }) => {
+      expect(body[0].html).not.to.include(
+        "An error occurred while displaying this card.",
+      );
+
+      expect(body[0].html).to.include("37.65");
+    });
+  });
+});
+
+function setUpEmail() {
+  cy.request("PUT", "/api/setting", {
+    "email-smtp-host": "localhost",
+    "email-smtp-port": "25",
+    "email-smtp-username": "admin",
+    "email-smtp-password": "admin",
+    "email-smtp-security": "none",
+    "email-from-address": "mailer@metabase.test",
+  });
+}


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #18009 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/sharing/reproductions/18009-nodata-creates-subscription-receives-error.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/134406031-012c43f1-198a-421f-91ff-10c57219af5d.png)

