### PR TITLE
add PK icon

### DIFF
--- a/frontend/src/metabase/lib/schema_metadata.js
+++ b/frontend/src/metabase/lib/schema_metadata.js
@@ -759,7 +759,7 @@ export const ICON_MAPPING = {
   [NUMBER]: "int",
   [BOOLEAN]: "io",
   [FOREIGN_KEY]: "connections",
-  [PRIMARY_KEY]: "key",
+  [PRIMARY_KEY]: "label",
 };
 
 export function getIconForField(field) {

--- a/frontend/src/metabase/lib/schema_metadata.js
+++ b/frontend/src/metabase/lib/schema_metadata.js
@@ -759,6 +759,7 @@ export const ICON_MAPPING = {
   [NUMBER]: "int",
   [BOOLEAN]: "io",
   [FOREIGN_KEY]: "connections",
+  [PRIMARY_KEY]: "key",
 };
 
 export function getIconForField(field) {


### PR DESCRIPTION
I noticed that we have a circle icon for primary keys everywhere. The circle icon renders by default when it is not specified explicitly. 
<img width="299" alt="Screen Shot 2021-09-22 at 22 13 33" src="https://user-images.githubusercontent.com/14301985/134407131-239cd4b0-505a-46c8-811a-54f213c38dc8.png">

I'm wondering if it should be `key` icon:
<img width="301" alt="Screen Shot 2021-09-22 at 22 13 06" src="https://user-images.githubusercontent.com/14301985/134407149-2650fda2-af6a-482e-993b-69b97efac9cc.png">

