### PR TITLE
Fix #15893 by disallowing literal left-hand side in comparison

### DIFF
--- a/frontend/src/metabase/lib/expressions/typechecker.js
+++ b/frontend/src/metabase/lib/expressions/typechecker.js
@@ -34,12 +34,12 @@ export function typeCheck(cst, rootType) {
       const result = super.relationalExpression(ctx);
       this.typeStack.shift();
 
-      // backward-compatibility: literal on the left-hand side isn't allowed
+      // backward-compatibility: literal on the left-hand side isn't allowed (MBQL limitation)
       if (ctx.operands.length > 1) {
         const lhs = ctx.operands[0];
         if (lhs.name === "numberLiteral") {
           const literal = getIn(lhs, ["children", "NumberLiteral", 0, "image"]);
-          const message = t`Expecting boolean but found ${literal}`;
+          const message = t`Expecting field but found ${literal}`;
           this.errors.push({ message });
         }
       }

--- a/frontend/src/metabase/lib/expressions/typechecker.js
+++ b/frontend/src/metabase/lib/expressions/typechecker.js
@@ -33,6 +33,16 @@ export function typeCheck(cst, rootType) {
       this.typeStack.unshift("expression");
       const result = super.relationalExpression(ctx);
       this.typeStack.shift();
+
+      // backward-compatibility: literal on the left-hand side isn't allowed
+      if (ctx.operands.length > 1) {
+        const lhs = ctx.operands[0];
+        if (lhs.name === "numberLiteral") {
+          const literal = getIn(lhs, ["children", "NumberLiteral", 0, "image"]);
+          const message = t`Expecting boolean but found ${literal}`;
+          this.errors.push({ message });
+        }
+      }
       return result;
     }
 

--- a/frontend/test/metabase/lib/expressions/parser.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/parser.unit.spec.js
@@ -127,9 +127,6 @@ describe("metabase/lib/expressions/parser", () => {
     it("should accept a simple comparison", () => {
       expect(() => parseFilter("[Total] > 12")).not.toThrow();
     });
-    it("should accept another simple comparison", () => {
-      expect(() => parseFilter("10 < [DiscountPercent]")).not.toThrow();
-    });
     it("should accept a logical NOT", () => {
       expect(() => parseFilter("NOT [Debt] > 5")).not.toThrow();
     });
@@ -154,6 +151,9 @@ describe("metabase/lib/expressions/parser", () => {
     });
     it("should reject CASE with only one argument", () => {
       expect(() => parseFilter("case([Deal])")).toThrow();
+    });
+    it("should reject a number on the left-hand side", () => {
+      expect(() => parseFilter("10 < [DiscountPercent]")).toThrow();
     });
   });
 });

--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -799,7 +799,7 @@ describe("scenarios > question > filter", () => {
     cy.get("[contenteditable=true]")
       .type("0 < [ID]")
       .blur();
-    cy.findByText("Expecting boolean but found 0");
+    cy.findByText("Expecting field but found 0");
   });
 
   it.skip("should work on twice summarized questions (metabase#15620)", () => {

--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -790,7 +790,7 @@ describe("scenarios > question > filter", () => {
     cy.button("Done").should("not.be.disabled");
   });
 
-  it.skip("custom expression filter should work with numeric value before an operator (metabase#15893)", () => {
+  it("custom expression filter should refuse to work with numeric value before an operator (metabase#15893)", () => {
     cy.intercept("POST", "/api/dataset").as("dataset");
 
     openOrdersTable({ mode: "notebook" });
@@ -799,11 +799,7 @@ describe("scenarios > question > filter", () => {
     cy.get("[contenteditable=true]")
       .type("0 < [ID]")
       .blur();
-    cy.button("Done").click();
-    cy.button("Visualize").click();
-    cy.wait("@dataset").then(xhr => {
-      expect(xhr.response.body.error).to.not.exist;
-    });
+    cy.findByText("Expecting boolean but found 0");
   });
 
   it.skip("should work on twice summarized questions (metabase#15620)", () => {


### PR DESCRIPTION
Unit tests and Cypress tests are adjusted accordingly.

**How to verify**

1. Ask a question, Custom question.
2. Sample Dataset, Orders table.
3. Filter, Custom Expression and type `10 < [Discount]`

**Before this PR**

The expression is treated as valid, the query continues and it leads to a wrong result.

![image](https://user-images.githubusercontent.com/7288/134418801-3494fa9f-e1fd-461c-9d3f-435d50abb282.png)

**After this PR**

The expression is treated as invalid, therefore it's rejected and the user can't continue.
This restores to the behavior of v38 and earlier.

![image](https://user-images.githubusercontent.com/7288/134418332-40ce1f8f-cc0b-4aca-b176-8fa76bcafd96.png)
