### PR TITLE
Fix #18003 regression by adding a check for borderless buttons

### DIFF
--- a/frontend/src/metabase/query_builder/components/RunButton.jsx
+++ b/frontend/src/metabase/query_builder/components/RunButton.jsx
@@ -56,7 +56,7 @@ export default class RunButton extends Component {
         iconSize={16}
         className={cx(className, "RunButton", {
           "RunButton--hidden": hidden,
-          "RunButton--compact": !props.borderless && compact,
+          "RunButton--compact": circular && !props.borderless && compact,
           circular: circular,
         })}
         onClick={isRunning ? onCancel : onRun}

--- a/frontend/src/metabase/query_builder/components/RunButton.jsx
+++ b/frontend/src/metabase/query_builder/components/RunButton.jsx
@@ -29,7 +29,6 @@ export default class RunButton extends Component {
       className,
       compact,
       circular,
-      borderless,
       hidden,
       ...props
     } = this.props;
@@ -57,7 +56,7 @@ export default class RunButton extends Component {
         iconSize={16}
         className={cx(className, "RunButton", {
           "RunButton--hidden": hidden,
-          "RunButton--compact": !borderless && compact,
+          "RunButton--compact": !props.borderless && compact,
           circular: circular,
         })}
         onClick={isRunning ? onCancel : onRun}

--- a/frontend/src/metabase/query_builder/components/RunButton.jsx
+++ b/frontend/src/metabase/query_builder/components/RunButton.jsx
@@ -29,6 +29,7 @@ export default class RunButton extends Component {
       className,
       compact,
       circular,
+      borderless,
       hidden,
       ...props
     } = this.props;
@@ -56,7 +57,7 @@ export default class RunButton extends Component {
         iconSize={16}
         className={cx(className, "RunButton", {
           "RunButton--hidden": hidden,
-          "RunButton--compact": compact,
+          "RunButton--compact": !borderless && compact,
           circular: circular,
         })}
         onClick={isRunning ? onCancel : onRun}

--- a/frontend/test/metabase-visual/notebook/notebook.cy.spec.js
+++ b/frontend/test/metabase-visual/notebook/notebook.cy.spec.js
@@ -70,6 +70,7 @@ describe("visual tests > notebook > major UI elements", () => {
       "visual tests > notebook > major UI elements Custom question run buttons render correctly",
       {
         minHeight: VIEWPORT_HEIGHT,
+        minWidth: VIEWPORT_WIDTH,
       },
     );
   });
@@ -85,6 +86,7 @@ describe("visual tests > notebook > major UI elements", () => {
       "visual tests > notebook > major UI elements Native Query run button renders correctly",
       {
         minHeight: VIEWPORT_HEIGHT,
+        minWidth: VIEWPORT_WIDTH,
       },
     );
   });

--- a/frontend/test/metabase-visual/notebook/notebook.cy.spec.js
+++ b/frontend/test/metabase-visual/notebook/notebook.cy.spec.js
@@ -70,7 +70,7 @@ describe("visual tests > notebook > major UI elements", () => {
       "visual tests > notebook > major UI elements Custom question run buttons render correctly",
       {
         minHeight: VIEWPORT_HEIGHT,
-        minWidth: VIEWPORT_WIDTH,
+        widths: [1920],
       },
     );
   });
@@ -86,7 +86,7 @@ describe("visual tests > notebook > major UI elements", () => {
       "visual tests > notebook > major UI elements Native Query run button renders correctly",
       {
         minHeight: VIEWPORT_HEIGHT,
-        minWidth: VIEWPORT_WIDTH,
+        widths: [1920],
       },
     );
   });

--- a/frontend/test/metabase-visual/notebook/notebook.cy.spec.js
+++ b/frontend/test/metabase-visual/notebook/notebook.cy.spec.js
@@ -52,9 +52,20 @@ describe("visual tests > notebook > major UI elements", () => {
       },
     );
   });
+});
+
+describe("visual tests > notebook > Run buttons", () => {
+  const VIEWPORT_WIDTH = 1920;
+  const VIEWPORT_HEIGHT = 1500;
+
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+    cy.viewport(VIEWPORT_WIDTH, VIEWPORT_HEIGHT);
+  });
 
   // This tests that the run buttons are the correct size on the Custom question page
-  it("Custom question run buttons render correctly", () => {
+  it("in Custom Question render correctly", () => {
     cy.visit("/question/new");
     cy.findByText("Custom question").click();
     cy.findByText("Sample Dataset").click();
@@ -67,26 +78,26 @@ describe("visual tests > notebook > major UI elements", () => {
     // Check that we're on the blank question page
     cy.findByText("Here's where your results will appear");
     cy.percySnapshot(
-      "visual tests > notebook > major UI elements Custom question run buttons render correctly",
+      "visual tests > notebook > Run buttons in Custom Question render correctly",
       {
         minHeight: VIEWPORT_HEIGHT,
-        widths: [1920],
+        widths: [VIEWPORT_WIDTH],
       },
     );
   });
 
   // This tests that the run buttons are the correct size on the Native query page
-  it("Native Query run button renders correctly", () => {
+  it("in Native Query render correctly", () => {
     cy.visit("/question/new");
     cy.findByText("Native query").click();
 
     // Check that we're on the blank question page
     cy.findByText("Here's where your results will appear");
     cy.percySnapshot(
-      "visual tests > notebook > major UI elements Native Query run button renders correctly",
+      "visual tests > notebook > Run buttons in Native Query render correctly",
       {
         minHeight: VIEWPORT_HEIGHT,
-        widths: [1920],
+        widths: [VIEWPORT_WIDTH],
       },
     );
   });

--- a/frontend/test/metabase-visual/notebook/notebook.cy.spec.js
+++ b/frontend/test/metabase-visual/notebook/notebook.cy.spec.js
@@ -52,6 +52,42 @@ describe("visual tests > notebook > major UI elements", () => {
       },
     );
   });
+
+  // This tests that the run buttons are the correct size on the Custom question page
+  it("Custom question run buttons render correctly", () => {
+    cy.visit("/question/new");
+    cy.findByText("Custom question").click();
+    cy.findByText("Sample Dataset").click();
+    cy.findByText("Orders").click();
+    // Waiting for notebook icon to load
+    cy.wait(1000);
+    cy.icon("notebook").click();
+    // Waiting for empty question to load
+    cy.wait(1000);
+    // Check that we're on the blank question page
+    cy.findByText("Here's where your results will appear");
+    cy.percySnapshot(
+      "visual tests > notebook > major UI elements Custom question run buttons render correctly",
+      {
+        minHeight: VIEWPORT_HEIGHT,
+      },
+    );
+  });
+
+  // This tests that the run buttons are the correct size on the Native query page
+  it("Native Query run button renders correctly", () => {
+    cy.visit("/question/new");
+    cy.findByText("Native query").click();
+
+    // Check that we're on the blank question page
+    cy.findByText("Here's where your results will appear");
+    cy.percySnapshot(
+      "visual tests > notebook > major UI elements Native Query run button renders correctly",
+      {
+        minHeight: VIEWPORT_HEIGHT,
+      },
+    );
+  });
 });
 
 function selectFromDropdown(itemName) {


### PR DESCRIPTION
Fixes #18003

I created this silly regression with my second PR since I wasn't yet used to the appearance of some of the other buttons on the same page :facepalm:

Fix by checking for borderless buttons which covers the `<RunButtonWithTooltip>` in the `<ViewHeader>` component

**Steps to verify:**

1. Custom question > Sample Dataset > Orders
2. Do not click Visualize, just click "Hide editor" in top-right corner image


**Before (with regression):**
![image](https://user-images.githubusercontent.com/653604/134430264-2c4a35d6-f92f-4d43-bbf7-35f4a67e4fae.png)

**After:**
![image](https://user-images.githubusercontent.com/653604/134430292-026e99a9-197d-4c31-bcee-ad9cdc27550f.png)
