### PR TITLE
Do not unset filter values with click behavior

### DIFF
--- a/frontend/src/metabase/dashboard/actions.js
+++ b/frontend/src/metabase/dashboard/actions.js
@@ -888,11 +888,9 @@ export const setParameterIndex = createThunkAction(
   },
 );
 
-export const setParameterValue = createThunkAction(
+export const setParameterValue = createAction(
   SET_PARAMETER_VALUE,
-  (parameterId, value) => (dispatch, getState) => {
-    return { id: parameterId, value };
-  },
+  (parameterId, value) => ({ id: parameterId, value }),
 );
 
 export const setParameterValues = parameterIdValuePairs => (
@@ -901,7 +899,7 @@ export const setParameterValues = parameterIdValuePairs => (
 ) => {
   parameterIdValuePairs
     .map(([id, value]) => setParameterValue(id, value))
-    .forEach(dispatch);
+    .forEach(action => dispatch(action));
 };
 
 export const CREATE_PUBLIC_LINK = "metabase/dashboard/CREATE_PUBLIC_LINK";

--- a/frontend/src/metabase/dashboard/actions.js
+++ b/frontend/src/metabase/dashboard/actions.js
@@ -895,15 +895,12 @@ export const setParameterValue = createThunkAction(
   },
 );
 
-export const setOrUnsetParameterValues = parameterIdValuePairs => (
+export const setParameterValues = parameterIdValuePairs => (
   dispatch,
   getState,
 ) => {
-  const parameterValues = getParameterValues(getState());
   parameterIdValuePairs
-    .map(([id, value]) =>
-      setParameterValue(id, value === parameterValues[id] ? null : value),
-    )
+    .map(([id, value]) => setParameterValue(id, value))
     .forEach(dispatch);
 };
 

--- a/frontend/src/metabase/dashboard/actions.unit.spec.js
+++ b/frontend/src/metabase/dashboard/actions.unit.spec.js
@@ -9,6 +9,9 @@ import {
   openAddQuestionSidebar,
   removeParameter,
   SET_DASHBOARD_ATTRIBUTES,
+  setParameterValue,
+  SET_PARAMETER_VALUE,
+  setParameterValues,
 } from "./actions";
 import { SIDEBAR_NAME } from "./constants";
 
@@ -114,6 +117,42 @@ describe("dashboard actions", () => {
           name: SIDEBAR_NAME.addQuestion,
         }),
       );
+    });
+  });
+
+  describe("setParameterValue", () => {
+    it("should set the parameter with value", () => {
+      dispatch(setParameterValue(1, "v1"));
+
+      expect(dispatch).toHaveBeenCalledWith({
+        type: SET_PARAMETER_VALUE,
+        payload: {
+          id: 1,
+          value: "v1",
+        },
+      });
+    });
+  });
+
+  describe("setParameterValues", () => {
+    it("should set multiple parameters with value", () => {
+      setParameterValues([[1, "v1"], [2, "v2"]])(dispatch, getState);
+
+      expect(dispatch).toHaveBeenCalledWith({
+        type: SET_PARAMETER_VALUE,
+        payload: {
+          id: 1,
+          value: "v1",
+        },
+      });
+
+      expect(dispatch).toHaveBeenCalledWith({
+        type: SET_PARAMETER_VALUE,
+        payload: {
+          id: 2,
+          value: "v2",
+        },
+      });
     });
   });
 

--- a/frontend/src/metabase/dashboard/actions.unit.spec.js
+++ b/frontend/src/metabase/dashboard/actions.unit.spec.js
@@ -29,6 +29,9 @@ describe("dashboard actions", () => {
             parameters: [{ id: 123 }, { id: 456 }],
           },
         },
+        parameterValues: {
+          123: "abc",
+        },
       },
     });
   });
@@ -122,35 +125,35 @@ describe("dashboard actions", () => {
 
   describe("setParameterValue", () => {
     it("should set the parameter with value", () => {
-      dispatch(setParameterValue(1, "v1"));
+      dispatch(setParameterValue(123, "abc"));
 
       expect(dispatch).toHaveBeenCalledWith({
         type: SET_PARAMETER_VALUE,
         payload: {
-          id: 1,
-          value: "v1",
+          id: 123,
+          value: "abc",
         },
       });
     });
   });
 
   describe("setParameterValues", () => {
-    it("should set multiple parameters with value", () => {
-      setParameterValues([[1, "v1"], [2, "v2"]])(dispatch, getState);
+    it("should set multiple parameters without unsetting existing ones", () => {
+      setParameterValues([[123, "abc"], [456, "def"]])(dispatch, getState);
 
       expect(dispatch).toHaveBeenCalledWith({
         type: SET_PARAMETER_VALUE,
         payload: {
-          id: 1,
-          value: "v1",
+          id: 123,
+          value: "abc",
         },
       });
 
       expect(dispatch).toHaveBeenCalledWith({
         type: SET_PARAMETER_VALUE,
         payload: {
-          id: 2,
-          value: "v2",
+          id: 456,
+          value: "def",
         },
       });
     });

--- a/frontend/src/metabase/modes/components/drill/DashboardClickDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/DashboardClickDrill.jsx
@@ -2,7 +2,7 @@ import { getIn } from "icepick";
 import _ from "underscore";
 
 import Question from "metabase-lib/lib/Question";
-import { setOrUnsetParameterValues } from "metabase/dashboard/actions";
+import { setParameterValues } from "metabase/dashboard/actions";
 import {
   getDataFromClicked,
   getTargetForQueryParams,
@@ -53,7 +53,7 @@ export default ({ question, clicked }: ClickActionProps): ClickAction[] => {
       })
       .value();
 
-    behavior = { action: () => setOrUnsetParameterValues(valuesToSet) };
+    behavior = { action: () => setParameterValues(valuesToSet) };
   } else if (type === "link") {
     if (linkType === "url") {
       behavior = {


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/16304

How to test:
- Create a dashboard with table, e.g. People
- Add a category filter
- Link the filter to `State` column of the table
- Add a click behavior to the table
- Make the click behavior update the filter
- Click on a cell in `State` column to set the filter - it should filter the table
- Click one more time - it should not reset the filter
- Sanity check - it should be possible to clear the filter by clicking on the remove icon