### PR TITLE
Fix ENV case for `QA_DB_ENABLED`

### DIFF
--- a/frontend/test/metabase-db/README.md
+++ b/frontend/test/metabase-db/README.md
@@ -27,7 +27,7 @@ QA_DB_ENABLED=true
 ```
 
 ```fish
-set -x QA_Db_ENABLED true
+set -x QA_DB_ENABLED true
 ```
 
 The list of all supported databases that we currently have Docker images for can be found at [Metabase QA repo](https://github.com/metabase/metabase-qa).


### PR DESCRIPTION
Fix ENV (`QA_DB_ENABLED`) case in the README file for running the `metabase-db` Cypress specs.