### PR TITLE
Fix drag-n-drop in dashboard visualisation settings modal

### DIFF
--- a/frontend/src/metabase/components/Modal.jsx
+++ b/frontend/src/metabase/components/Modal.jsx
@@ -29,6 +29,7 @@ function getModalContent(props) {
 export class WindowModal extends Component {
   static propTypes = {
     isOpen: PropTypes.bool,
+    enableMouseEvents: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -77,12 +78,15 @@ export class WindowModal extends Component {
   }
 
   render() {
-    const { backdropClassName, isOpen, style } = this.props;
+    const { enableMouseEvents, backdropClassName, isOpen, style } = this.props;
     const backdropClassnames =
       "flex justify-center align-center fixed top left bottom right";
 
     return (
-      <SandboxedPortal container={this._modalElement}>
+      <SandboxedPortal
+        container={this._modalElement}
+        enableMouseEvents={enableMouseEvents}
+      >
         <CSSTransitionGroup
           transitionName="Modal"
           transitionAppear={true}

--- a/frontend/src/metabase/components/SandboxedPortal.jsx
+++ b/frontend/src/metabase/components/SandboxedPortal.jsx
@@ -1,13 +1,27 @@
-import React from "react";
+import React, { useMemo } from "react";
 import ReactDOM from "react-dom";
 
 function stop(event) {
   event.stopPropagation();
 }
 
+const mouseEventBlockers = {
+  onMouseDown: stop,
+  onMouseEnter: stop,
+  onMouseLeave: stop,
+  onMouseMove: stop,
+  onMouseOver: stop,
+  onMouseOut: stop,
+  onMouseUp: stop,
+};
+
 // Prevent DOM events from bubbling through the React component tree
 // See https://reactjs.org/docs/portals.html#event-bubbling-through-portals
-function SandboxedPortal({ children, container }) {
+function SandboxedPortal({ children, container, enableMouseEvents = false }) {
+  const extraProps = useMemo(() => {
+    return enableMouseEvents ? {} : mouseEventBlockers;
+  }, [enableMouseEvents]);
+
   return ReactDOM.createPortal(
     <div
       onClick={stop}
@@ -21,13 +35,6 @@ function SandboxedPortal({ children, container }) {
       onDragOver={stop}
       onDragStart={stop}
       onDrop={stop}
-      onMouseDown={stop}
-      onMouseEnter={stop}
-      onMouseLeave={stop}
-      onMouseMove={stop}
-      onMouseOver={stop}
-      onMouseOut={stop}
-      onMouseUp={stop}
       onKeyDown={stop}
       onKeyPress={stop}
       onKeyUp={stop}
@@ -37,6 +44,7 @@ function SandboxedPortal({ children, container }) {
       onInput={stop}
       onInvalid={stop}
       onSubmit={stop}
+      {...extraProps}
     >
       {children}
     </div>,

--- a/frontend/src/metabase/dashboard/components/DashCard.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard.jsx
@@ -390,6 +390,7 @@ const ChartSettingsButton = ({ series, onReplaceAllVisualizationSettings }) => (
       </Tooltip>
     }
     triggerClasses="text-dark-hover cursor-pointer flex align-center flex-no-shrink mr1 drag-disabled"
+    enableMouseEvents
   >
     <ChartSettingsWithState
       className="spread"

--- a/frontend/test/metabase/scenarios/dashboard/visualizaiton-options.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/visualizaiton-options.cy.spec.js
@@ -6,7 +6,7 @@ describe("scenarios > dashboard > visualization options", () => {
     cy.signInAsAdmin();
   });
 
-  it.skip("column reordering should work (metabase#16229)", () => {
+  it("column reordering should work (metabase#16229)", () => {
     cy.visit("/dashboard/1");
     cy.icon("pencil").click();
     cy.get(".Card").realHover();


### PR DESCRIPTION
Fixes #16229

It's impossible to drag-n-drop items in the dashboard visualization settings modal. It happened in 0.39 during React upgrade to v16. Dashboard visualization modal is wrapped with [`SandboxedPortal`](https://github.com/metabase/metabase/blob/master/frontend/src/metabase/components/SandboxedPortal.jsx) which disables any mouse and drag events bubbling. Because of that, `react-sortable-hoc` couldn't receive any events to handle, so the DND stopped working.

This PR adds a `enableMouseEvents` prop to `SandboxedPortal` (`false` by default) and turns it on for the dashboard viz settings modal.

### To Verify

1. Open / create a dashboard with a question displayed as a table
2. Switch to dashboard edit mode (pencil icon in the top right)
3. Hover the question, you should see an action panel appear at the top right side of the question
4. Click the palette icon (visualization settings)
5. You should see a modal with a list of columns on the left side
6. Rearrange table columns order using drag-n-drop; it should work without any problems
7. Scroll to the bottom of the modal, click "Done"
8. The order of columns should be the same as you left it after dragging-n-dropping

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/134544537-fbf77e0f-a216-4db7-809d-c5dfb5422301.mov

**After**

https://user-images.githubusercontent.com/17258145/134544551-26e66f62-b191-457a-91ec-6ea7a39d0c83.mov

