### PR TITLE
Fix text selection while rearranging table columns

### DIFF
--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx
@@ -1,8 +1,7 @@
 /* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { t } from "ttag";
-
-import ColumnItem from "./ColumnItem";
+import _ from "underscore";
 
 import { SortableContainer, SortableElement } from "react-sortable-hoc";
 
@@ -10,7 +9,8 @@ import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
 import { keyForColumn, findColumnForColumnSetting } from "metabase/lib/dataset";
 import { getFriendlyName } from "metabase/visualizations/lib/utils";
 
-import _ from "underscore";
+import { SortableColumnListContainer } from "./ChartSettingOrderedColumns.styled";
+import ColumnItem from "./ColumnItem";
 
 const SortableColumn = SortableElement(
   ({ columnSetting, getColumnName, onEdit, onRemove }) => (
@@ -26,7 +26,7 @@ const SortableColumn = SortableElement(
 const SortableColumnList = SortableContainer(
   ({ columnSettings, getColumnName, onEdit, onRemove }) => {
     return (
-      <div>
+      <SortableColumnListContainer>
         {columnSettings.map((columnSetting, index) => (
           <SortableColumn
             key={`item-${index}`}
@@ -37,7 +37,7 @@ const SortableColumnList = SortableContainer(
             onRemove={onRemove}
           />
         ))}
-      </div>
+      </SortableColumnListContainer>
     );
   },
 );

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.styled.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.styled.jsx
@@ -1,0 +1,5 @@
+import styled from "styled-components";
+
+export const SortableColumnListContainer = styled.div`
+  user-select: none;
+`;


### PR DESCRIPTION
When rearranging table columns order in Safari or Firefox, drag-n-drop also triggers text selection which doesn't look very nice. This PR wraps the question's table columns list with `user-select: none` style to prevent this behavior.

### To Verify

With **Safari** and/or **Firefox**:

1. Ask a question > Simple Question > Sample Dataset > Orders
2. Click the "Settings" button at the bottom left
3. The sidebar with a list of table columns should appear on the left
4. Try moving the columns around
5. You should see no text selection which doesn't look right

You can still select the columns name by double-clicking it

### Demo

**Before**

<details>
<summary>Safari</summary>

https://user-images.githubusercontent.com/17258145/134548143-8cd20a73-3692-40ec-aa55-4221a616e778.mov


</details>

<details>
<summary>Firefox</summary>

https://user-images.githubusercontent.com/17258145/134548157-b88a248e-5698-419b-b03b-53451f8a8d00.mov


</details>

**After**

<details>
<summary>Safari</summary>

https://user-images.githubusercontent.com/17258145/134548178-bc48363e-979b-48e9-be1b-4e7376f94b36.mov


</details>

<details>
<summary>Firefox</summary>

https://user-images.githubusercontent.com/17258145/134548186-9009aa06-0b32-4f73-827e-2fecab9f16c6.mov


</details>