### PR TITLE
#18028 Repro: X-ray dashboards crash on first opening immediately after they are saved

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard/x-rays.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/x-rays.cy.spec.js
@@ -140,7 +140,7 @@ describe("scenarios > x-rays", () => {
     cy.visit("/");
     cy.contains("A look at your Orders table").click();
 
-    // There are a lot of spinners in this dashboard. Give them some time to finish.
+    // There are a lot of spinners in this dashboard. Give them some time to disappear.
     cy.get(".LoadingSpinner", { timeout: 10000 }).should("not.exist");
 
     cy.button("Save this").click();
@@ -149,8 +149,6 @@ describe("scenarios > x-rays", () => {
     cy.findByText("See it").click();
 
     cy.url().should("contain", "a-look-at-your-orders-table");
-
-    // cy.reload();
 
     cy.get(".Card").contains("18,760");
     cy.findByText("How these transactions are distributed");

--- a/frontend/test/metabase/scenarios/dashboard/x-rays.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/x-rays.cy.spec.js
@@ -135,4 +135,24 @@ describe("scenarios > x-rays", () => {
       cy.contains("null").should("not.exist");
     });
   });
+
+  it.skip("should be able to save an x-ray as a dashboard and visit it immediately (metabase#18028)", () => {
+    cy.visit("/");
+    cy.contains("A look at your Orders table").click();
+
+    // There are a lot of spinners in this dashboard. Give them some time to finish.
+    cy.get(".LoadingSpinner", { timeout: 10000 }).should("not.exist");
+
+    cy.button("Save this").click();
+
+    cy.findByText("Your dashboard was saved");
+    cy.findByText("See it").click();
+
+    cy.url().should("contain", "a-look-at-your-orders-table");
+
+    // cy.reload();
+
+    cy.get(".Card").contains("18,760");
+    cy.findByText("How these transactions are distributed");
+  });
 });


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #18028

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/dashboard/x-rays.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/134553511-acc97bf8-6d40-466a-a4aa-dda7c6f00fdf.png)

