### PR TITLE
Revert changes to ModalRoute

### DIFF
--- a/frontend/src/metabase/hoc/ModalRoute.jsx
+++ b/frontend/src/metabase/hoc/ModalRoute.jsx
@@ -23,11 +23,11 @@ const ModalWithRoute = (ComposedModal, modalProps = {}) =>
       static displayName = `ModalWithRoute[${ComposedModal.displayName ||
         ComposedModal.name}]`;
 
-      onClose = state => {
+      onClose = () => {
         const { location, route } = this.props;
 
-        const pathname = getParentPath(route, location);
-        this.props.onChangeLocation({ pathname, state });
+        const parentPath = getParentPath(route, location);
+        this.props.onChangeLocation(parentPath);
       };
 
       render() {


### PR DESCRIPTION
Fixes close modal behavior:

<img width="764" alt="Screen Shot 2021-09-23 at 8 35 20 pm" src="https://user-images.githubusercontent.com/8542534/134557137-6ba86aa2-16e1-4956-bba4-8f4704f386eb.png">
<img width="655" alt="Screen Shot 2021-09-23 at 8 36 57 pm" src="https://user-images.githubusercontent.com/8542534/134557145-369c7d16-21ec-4b01-9b5e-01151442522e.png">
