### PR TITLE
Fix composite key PK/FK drills

### DIFF
--- a/frontend/test/metabase-lib/lib/Question.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Question.unit.spec.js
@@ -3,6 +3,7 @@ import {
   SAMPLE_DATASET,
   ORDERS,
   PRODUCTS,
+  createMetadata,
 } from "__support__/sample_dataset_fixture";
 
 import { assoc, dissoc } from "icepick";
@@ -621,6 +622,71 @@ describe("Question", () => {
             "source-table": ORDERS.id,
             filter: ["=", ["field", ORDERS.ID.id, null], 1],
           },
+        });
+      });
+
+      describe("with composite PK", () => {
+        // Making TOTAL a PK column in addition to ID
+        const metadata = createMetadata(state =>
+          state.assocIn(
+            ["entities", "fields", ORDERS.TOTAL.id, "semantic_type"],
+            "type/PK",
+          ),
+        );
+        let question;
+
+        beforeEach(() => {
+          question = new Question(orders_raw_card, metadata);
+        });
+
+        it("when drills to one column of a composite key returns equals filter by the column", () => {
+          const drilledQuestion = question.drillPK(ORDERS.ID, 1);
+
+          expect(drilledQuestion.canRun()).toBe(true);
+          expect(drilledQuestion._card.dataset_query).toEqual({
+            type: "query",
+            database: SAMPLE_DATASET.id,
+            query: {
+              "source-table": ORDERS.id,
+              filter: ["=", ["field", ORDERS.ID.id, null], 1],
+            },
+          });
+        });
+
+        it("when drills to both columns of a composite key returns query with equality filter by both PKs", () => {
+          const drilledQuestion = question
+            .drillPK(ORDERS.ID, 1)
+            .drillPK(ORDERS.TOTAL, 1);
+
+          expect(drilledQuestion.canRun()).toBe(true);
+          expect(drilledQuestion._card.dataset_query).toEqual({
+            type: "query",
+            database: SAMPLE_DATASET.id,
+            query: {
+              "source-table": ORDERS.id,
+              filter: [
+                "and",
+                ["=", ["field", ORDERS.TOTAL.id, null], 1],
+                ["=", ["field", ORDERS.ID.id, null], 1],
+              ],
+            },
+          });
+        });
+
+        it("when drills to other table PK removes the previous table PK filters", () => {
+          const drilledQuestion = question
+            .drillPK(ORDERS.ID, 1)
+            .drillPK(PRODUCTS.ID, 1);
+
+          expect(drilledQuestion.canRun()).toBe(true);
+          expect(drilledQuestion._card.dataset_query).toEqual({
+            type: "query",
+            database: SAMPLE_DATASET.id,
+            query: {
+              "source-table": PRODUCTS.id,
+              filter: ["=", ["field", PRODUCTS.ID.id, null], 1],
+            },
+          });
         });
       });
     });


### PR DESCRIPTION
### Description

A follow-up for https://github.com/metabase/metabase/pull/18016

For tables with composite PKs clicking on a single PK column removed all previous filters and added `=` filter on a clicked PK column. However, it would be reasonable to show the "object detail" view when users select all PKs by clicking on them.

**Before**
<video src="https://user-images.githubusercontent.com/14301985/134729899-3c3edb82-c7c0-47c9-b157-8cb48add2aea.mov" />

**After**
<video src="https://user-images.githubusercontent.com/14301985/134729903-516e292e-0bb2-45ee-8024-eb119a73706e.mov" />
