### PR TITLE
Fix #18030 by rejecting comparison with boolean/string

### DIFF
--- a/frontend/src/metabase/lib/expressions/typechecker.js
+++ b/frontend/src/metabase/lib/expressions/typechecker.js
@@ -3,6 +3,7 @@ import { ngettext, msgid, t } from "ttag";
 import { ExpressionVisitor } from "./visitor";
 import { CLAUSE_TOKENS } from "./lexer";
 import { MBQL_CLAUSES, getMBQLName } from "./config";
+import { OPERATOR } from "./tokenizer";
 
 export function typeCheck(cst, rootType) {
   class TypeChecker extends ExpressionVisitor {
@@ -31,7 +32,11 @@ export function typeCheck(cst, rootType) {
       return result;
     }
     relationalExpression(ctx) {
-      this.typeStack.unshift("number");
+      const ops = ctx.operators.map(op => op.image).join(" ");
+      const numericalComparison =
+        ops.includes(OPERATOR.LessThan) || ops.includes(OPERATOR.GreaterThan);
+
+      this.typeStack.unshift(numericalComparison ? "number" : "expression");
       const result = super.relationalExpression(ctx);
       this.typeStack.shift();
 

--- a/frontend/test/metabase/lib/expressions/typechecker.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/typechecker.unit.spec.js
@@ -176,6 +176,18 @@ describe("type-checker", () => {
       expect(() => validate("CONTAINS([Type],'X','Y')")).toThrow();
       expect(() => validate("CONTAINS([Type],'P','Q','R')")).toThrow();
     });
+
+    it("should reject a comparison with a string", () => {
+      expect(() => validate("'A' <= 99")).toThrow();
+    });
+
+    it("should reject a comparison with a function returning boolean", () => {
+      expect(() => validate("IsEmpty([Tax]) < 9")).toThrow();
+    });
+
+    it("should reject a comparison with a function returning string", () => {
+      expect(() => validate("Lower([Tax]) > 77")).toThrow();
+    });
   });
 
   describe("for an aggregation", () => {

--- a/frontend/test/metabase/lib/expressions/typechecker.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/typechecker.unit.spec.js
@@ -177,6 +177,26 @@ describe("type-checker", () => {
       expect(() => validate("CONTAINS([Type],'P','Q','R')")).toThrow();
     });
 
+    it("should accept an equality comparison of strings", () => {
+      expect(() => validate("LOWER([State]) = 'ca'")).not.toThrow();
+    });
+
+    it("should accept a non-equality comparison of strings", () => {
+      expect(() => validate("Upper([State]) != 'ny'")).not.toThrow();
+    });
+
+    it("should accept an equality comparison of booleans", () => {
+      expect(() =>
+        validate("IsEmpty([Discount]) = IsEmpty([Total])"),
+      ).not.toThrow();
+    });
+
+    it("should accept a non-equality comparison of booleans", () => {
+      expect(() =>
+        validate("IsEmpty([Discount]) != IsEmpty([Total])"),
+      ).not.toThrow();
+    });
+
     it("should reject a comparison with a string", () => {
       expect(() => validate("'A' <= 99")).toThrow();
     });


### PR DESCRIPTION
`=` and `!=` are fine for comparing booleans or strings, but `<`, `<=`, `>`, `>=` should be reserved only for comparing numbers.

Unit tests are added.

**To verify manually**

1. Ask a question, Custom question.
2. Sample Dataset, Orders table.
3. Filter and type `IsEmpty([Tax]) < 42`.
4. Visualize.

**Before this PR**

The filter expression is accepted, which leads to a cryptic error.

![image](https://user-images.githubusercontent.com/7288/134541542-e9802a58-a340-4f17-82c4-a68e89e6b8a0.png)

**After this PR**

The filter expression is treated as invalid and the user can't continue.

![image](https://user-images.githubusercontent.com/7288/134610108-64407ac5-be37-486d-830f-eae59e934c15.png)
