### PR TITLE
Fix Audit logging not showing ad-hoc native queries

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/audit_app/pages/AuditQueryDetail.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/pages/AuditQueryDetail.jsx
@@ -64,6 +64,7 @@ import { getMetadata } from "metabase/selectors/metadata";
 
 import NativeQuery from "metabase-lib/lib/queries/NativeQuery";
 
+import ExplicitSize from "metabase/components/ExplicitSize";
 import { loadMetadataForCard } from "metabase/query_builder/actions";
 
 const mapStateToProps = state => ({ metadata: getMetadata(state) });
@@ -73,13 +74,23 @@ const mapDispatchToProps = { loadMetadataForCard };
   mapStateToProps,
   mapDispatchToProps,
 )
+@ExplicitSize()
 class QueryBuilderReadOnly extends React.Component {
+  state = {
+    isNativeEditorOpen: false,
+  };
+
+  setIsNativeEditorOpen = open => {
+    this.setState({ isNativeEditorOpen: open });
+  };
+
   componentDidMount() {
     const { card, loadMetadataForCard } = this.props;
     loadMetadataForCard(card);
   }
+
   render() {
-    const { card, metadata } = this.props;
+    const { card, metadata, height } = this.props;
     const question = new Question(card, metadata);
 
     const query = question.query();
@@ -91,6 +102,9 @@ class QueryBuilderReadOnly extends React.Component {
           query={query}
           location={{ query: {} }}
           readOnly
+          viewHeight={height}
+          isNativeEditorOpen={this.state.isNativeEditorOpen}
+          setIsNativeEditorOpen={this.setIsNativeEditorOpen}
         />
       );
     } else {

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
@@ -648,43 +648,45 @@ export default class NativeQueryEditor extends Component {
               closeModal={this.props.closeSnippetModal}
             />
           )}
-          <div className="flex flex-column align-center">
-            <DataReferenceButton
-              {...this.props}
-              size={ICON_SIZE}
-              className="mt3"
-            />
-            <NativeVariablesButton
-              {...this.props}
-              size={ICON_SIZE}
-              className="mt3"
-            />
-            {showSnippetSidebarButton && (
-              <SnippetSidebarButton
+          {!readOnly && (
+            <div className="flex flex-column align-center">
+              <DataReferenceButton
                 {...this.props}
                 size={ICON_SIZE}
                 className="mt3"
               />
-            )}
-            <RunButtonWithTooltip
-              disabled={!isRunnable}
-              isRunning={isRunning}
-              isDirty={isResultDirty}
-              isPreviewing={isPreviewing}
-              onRun={this.runQuery}
-              onCancel={() => cancelQuery()}
-              compact
-              className="mx2 mb2 mt-auto"
-              style={{ width: 40, height: 40 }}
-              getTooltip={() =>
-                (this.props.nativeEditorSelectedText
-                  ? t`Run selected text`
-                  : t`Run query`) +
-                " " +
-                (isMac() ? t`(⌘ + enter)` : t`(Ctrl + enter)`)
-              }
-            />
-          </div>
+              <NativeVariablesButton
+                {...this.props}
+                size={ICON_SIZE}
+                className="mt3"
+              />
+              {showSnippetSidebarButton && (
+                <SnippetSidebarButton
+                  {...this.props}
+                  size={ICON_SIZE}
+                  className="mt3"
+                />
+              )}
+              <RunButtonWithTooltip
+                disabled={!isRunnable}
+                isRunning={isRunning}
+                isDirty={isResultDirty}
+                isPreviewing={isPreviewing}
+                onRun={this.runQuery}
+                onCancel={() => cancelQuery()}
+                compact
+                className="mx2 mb2 mt-auto"
+                style={{ width: 40, height: 40 }}
+                getTooltip={() =>
+                  (this.props.nativeEditorSelectedText
+                    ? t`Run selected text`
+                    : t`Run query`) +
+                  " " +
+                  (isMac() ? t`(⌘ + enter)` : t`(Ctrl + enter)`)
+                }
+              />
+            </div>
+          )}
         </ResizableBox>
       </div>
     );

--- a/frontend/test/metabase/scenarios/admin/audit/ad-hoc.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/audit/ad-hoc.cy.spec.js
@@ -24,7 +24,7 @@ describeWithToken("audit > ad-hoc", () => {
       cy.signInAsAdmin();
     });
 
-    it.skip("should appear in audit log (metabase#16845 metabase-enterprise#486)", () => {
+    it("should appear in audit log (metabase#16845 metabase-enterprise#486)", () => {
       cy.visit("/admin/audit/members/log");
 
       cy.findByText("Native")

--- a/frontend/test/metabase/scenarios/admin/audit/ad-hoc.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/audit/ad-hoc.cy.spec.js
@@ -24,7 +24,7 @@ describeWithToken("audit > ad-hoc", () => {
       cy.signInAsAdmin();
     });
 
-    it.skip("should appear in audit log (metabase-enterprise#486)", () => {
+    it.skip("should appear in audit log (metabase#16845 metabase-enterprise#486)", () => {
       cy.visit("/admin/audit/members/log");
 
       cy.findByText("Native")

--- a/frontend/test/metabase/scenarios/admin/audit/ad-hoc.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/audit/ad-hoc.cy.spec.js
@@ -38,6 +38,7 @@ describeWithToken("audit > ad-hoc", () => {
 
       cy.get(".PageTitle").contains("Query");
       cy.findByText("Open in Metabase");
+      cy.get(".ace_content").contains("SELECT 123");
     });
   });
 });

--- a/frontend/test/metabase/scenarios/admin/audit/ad-hoc.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/audit/ad-hoc.cy.spec.js
@@ -5,7 +5,7 @@ import {
 } from "__support__/e2e/cypress";
 
 describeWithToken("audit > ad-hoc", () => {
-  describe("native query with JOIN", () => {
+  describe("native query", () => {
     beforeEach(() => {
       restore();
 


### PR DESCRIPTION
Fixes #16845

Audit logging was crashing if you tried to open an ad-hoc native query log. This happened because `NativeQueryEditor` didn't receive the expected props (`viewHeight`, `isNativeEditorOpen`, `setIsNativeEditorOpen`). This PR fixes that and also hides the right native query editor bar (with the run button, snippets, etc.) in "read-only" mode

### To Verify

1. Spin up Metabase Enterprise and sign in as admin
2. Native query > Sample Dataset > `select 1` and run it
2. Admin > Audit > Team members > Audit Log > click the top "Ad-hoc"
3. You should see a native editor with `select 1` content. You shouldn't be able to edit the query, but you can click the "Open in Metabase" button and you'll be navigated to a native query editor with `select 1` filled

### Demo

**Before**

https://user-images.githubusercontent.com/1447303/124104258-5e610980-da62-11eb-992f-5cc689b6053b.mp4

**After**

https://user-images.githubusercontent.com/17258145/134659068-d22503cb-83ff-451c-aaf6-25c57472fd25.mov
