### PR TITLE
Fix x-ray dashboards crash on first open

### DIFF
--- a/frontend/src/metabase/meta/Dashboard.js
+++ b/frontend/src/metabase/meta/Dashboard.js
@@ -250,7 +250,7 @@ export function setParameterDefaultValue(
 
 export function hasMapping(parameter, dashboard) {
   return dashboard.ordered_cards.some(ordered_card => {
-    return ordered_card.parameter_mappings.some(parameter_mapping => {
+    return ordered_card?.parameter_mappings?.some(parameter_mapping => {
       return parameter_mapping.parameter_id === parameter.id;
     });
   });

--- a/frontend/test/metabase/meta/Dashboard.unit.spec.js
+++ b/frontend/test/metabase/meta/Dashboard.unit.spec.js
@@ -210,6 +210,13 @@ describe("meta/Dashboard", () => {
       expect(hasMapping(parameter, dashboard)).toBe(false);
     });
 
+    it("should return false when missing parameter mappings", () => {
+      const dashboard = {
+        ordered_cards: [{ parameter_mappings: undefined }],
+      };
+      expect(hasMapping(parameter, dashboard)).toBe(false);
+    });
+
     it("should return false when there are no matching parameter mapping parameter_ids", () => {
       const dashboard = {
         ordered_cards: [

--- a/frontend/test/metabase/scenarios/dashboard/x-rays.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/x-rays.cy.spec.js
@@ -136,7 +136,7 @@ describe("scenarios > x-rays", () => {
     });
   });
 
-  it.skip("should be able to save an x-ray as a dashboard and visit it immediately (metabase#18028)", () => {
+  it("should be able to save an x-ray as a dashboard and visit it immediately (metabase#18028)", () => {
     cy.visit("/");
     cy.contains("A look at your Orders table").click();
 


### PR DESCRIPTION
Fixes #18028

The first time you open an automatic dashboard (suggested while x-raying a database table), it crashes and you see a blank page.

### To Verify

1. Go to `/browse/1-sample-dataset`
2. Hover the Orders table and click the yellow x-ray button
3. You're navigated to a dashboard based on Orders. Click the "Save this" button in the top right without any edits
4. After the dashboard is saved, you should see a toast message in the bottom left. Click the "See it" link
5. FE crashes and you see a blank page

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/134530463-812d06fc-f421-4e86-bfa8-3a30a94c1f88.mov

**After**

https://user-images.githubusercontent.com/17258145/134664336-2c798ff6-a874-4298-a91a-74dabaff2112.mov
