### PR TITLE
Fix approved domains validation for alerts and dashboard subscriptions

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_config/models/pulse_channel.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_config/models/pulse_channel.clj
@@ -39,5 +39,4 @@
                                (pr-str domain)
                                (str/join ", " allowed-domains))
                           {:email           email
-                           :allowed-domains allowed-domains
-                           :status-code     403})))))))
+                           :allowed-domains allowed-domains})))))))

--- a/frontend/src/metabase/components/form/FormMessage.jsx
+++ b/frontend/src/metabase/components/form/FormMessage.jsx
@@ -11,15 +11,9 @@ export default class FormMessage extends Component {
 
     if (!message) {
       if (formError) {
-        if (formError.data && formError.data.message) {
-          message = formError.data.message;
-        } else if (formError.status >= 400) {
-          message = SERVER_ERROR_MESSAGE;
-        } else {
-          message = UNKNOWN_ERROR_MESSAGE;
-        }
-      } else if (formSuccess && formSuccess.data.message) {
-        message = formSuccess.data.message;
+        message = getErrorMessage(formError);
+      } else if (formSuccess) {
+        message = getSuccessMessage(formSuccess);
       }
     }
 
@@ -32,3 +26,21 @@ export default class FormMessage extends Component {
     return <span className={classes}>{message}</span>;
   }
 }
+
+export const getErrorMessage = formError => {
+  if (formError) {
+    if (formError.data && formError.data.message) {
+      return formError.data.message;
+    } else if (formError.status >= 400) {
+      return SERVER_ERROR_MESSAGE;
+    } else {
+      return UNKNOWN_ERROR_MESSAGE;
+    }
+  }
+};
+
+export const getSuccessMessage = formSuccess => {
+  if (formSuccess && formSuccess.data.message) {
+    return formSuccess.data.message;
+  }
+};

--- a/frontend/src/metabase/dashboard/components/Sidebar.jsx
+++ b/frontend/src/metabase/dashboard/components/Sidebar.jsx
@@ -4,7 +4,8 @@ import PropTypes from "prop-types";
 import { t } from "ttag";
 
 import Button from "metabase/components/Button";
-import FormMessage from "metabase/components/form/FormMessage";
+import { getErrorMessage } from "metabase/components/form/FormMessage";
+import { SidebarError, SidebarFooter } from "./Sidebar.styled";
 
 const WIDTH = 384;
 
@@ -49,7 +50,11 @@ function Sidebar({ closeIsDisabled, formError, children, onClose, onCancel }) {
           )}
         </div>
       )}
-      {formError && <FormMessage formError={formError} />}
+      {formError && (
+        <SidebarFooter>
+          <SidebarError>{getErrorMessage(formError)}</SidebarError>
+        </SidebarFooter>
+      )}
     </aside>
   );
 }

--- a/frontend/src/metabase/dashboard/components/Sidebar.jsx
+++ b/frontend/src/metabase/dashboard/components/Sidebar.jsx
@@ -1,12 +1,22 @@
 /* eslint-disable react/prop-types */
 import React from "react";
+import PropTypes from "prop-types";
 import { t } from "ttag";
 
 import Button from "metabase/components/Button";
+import FormMessage from "metabase/components/form/FormMessage";
 
 const WIDTH = 384;
 
-function Sidebar({ onClose, onCancel, closeIsDisabled, children }) {
+const propTypes = {
+  closeIsDisabled: PropTypes.bool,
+  formError: PropTypes.object,
+  children: PropTypes.node,
+  onClose: PropTypes.func,
+  onCancel: PropTypes.func,
+};
+
+function Sidebar({ closeIsDisabled, formError, children, onClose, onCancel }) {
   return (
     <aside
       style={{ width: WIDTH, minWidth: WIDTH }}
@@ -39,8 +49,11 @@ function Sidebar({ onClose, onCancel, closeIsDisabled, children }) {
           )}
         </div>
       )}
+      {formError && <FormMessage formError={formError} />}
     </aside>
   );
 }
+
+Sidebar.propTypes = propTypes;
 
 export default Sidebar;

--- a/frontend/src/metabase/dashboard/components/Sidebar.styled.jsx
+++ b/frontend/src/metabase/dashboard/components/Sidebar.styled.jsx
@@ -1,0 +1,11 @@
+import styled from "styled-components";
+import { color } from "metabase/lib/colors";
+import { space } from "metabase/styled-components/theme";
+
+export const SidebarFooter = styled.div`
+  padding: 0 ${space(3)} ${space(2)};
+`;
+
+export const SidebarError = styled.div`
+  color: ${color("error")};
+`;

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -1045,7 +1045,6 @@ export const apiUpdateQuestion = question => {
     // so we want the databases list to be re-fetched next time we hit "New Question" so it shows up
     dispatch(setRequestUnloaded(["entities", "databases"]));
 
-    dispatch(updateUrl(updatedQuestion.card(), { dirty: false }));
     MetabaseAnalytics.trackEvent(
       "QueryBuilder",
       "Update Card",

--- a/frontend/src/metabase/query_builder/components/AlertModals.jsx
+++ b/frontend/src/metabase/query_builder/components/AlertModals.jsx
@@ -15,7 +15,8 @@ import Icon from "metabase/components/Icon";
 import ChannelSetupModal from "metabase/components/ChannelSetupModal";
 import ButtonWithStatus from "metabase/components/ButtonWithStatus";
 import PulseEditChannels from "metabase/pulse/components/PulseEditChannels";
-import { AlertModalFooter, AlertModalMessage } from "./AlertModals.styled";
+import { getErrorMessage } from "metabase/components/form/FormMessage";
+import { AlertModalFooter, AlertModalError } from "./AlertModals.styled";
 
 import User from "metabase/entities/users";
 
@@ -196,7 +197,9 @@ export class CreateAlertModalContent extends Component {
             onAlertChange={this.onAlertChange}
           />
           <AlertModalFooter>
-            <AlertModalMessage formError={formError} />
+            {formError && (
+              <AlertModalError>{getErrorMessage(formError)}</AlertModalError>
+            )}
             <Button onClick={onCancel} className="mr2">{t`Cancel`}</Button>
             <ButtonWithStatus
               titleForState={{ default: t`Done` }}
@@ -391,7 +394,9 @@ export class UpdateAlertModalContent extends Component {
           )}
 
           <AlertModalFooter>
-            <AlertModalMessage formError={formError} />
+            {formError && (
+              <AlertModalError>{getErrorMessage(formError)}</AlertModalError>
+            )}
             <Button onClick={onCancel} className="mr2">{t`Cancel`}</Button>
             <ButtonWithStatus
               titleForState={{ default: t`Save changes` }}

--- a/frontend/src/metabase/query_builder/components/AlertModals.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/AlertModals.styled.jsx
@@ -1,0 +1,15 @@
+import styled from "styled-components";
+import { space } from "metabase/styled-components/theme";
+import FormMessage from "metabase/components/form/FormMessage";
+
+export const AlertModalFooter = styled.div`
+  display: flex;
+  justify-content: right;
+  align-items: center;
+  margin-top: ${space(3)};
+`;
+
+export const AlertModalMessage = styled(FormMessage)`
+  margin-left: -${space(2)};
+  margin-right: -${space(2)};
+`;

--- a/frontend/src/metabase/query_builder/components/AlertModals.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/AlertModals.styled.jsx
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 import { space } from "metabase/styled-components/theme";
-import FormMessage from "metabase/components/form/FormMessage";
+import { color } from "metabase/lib/colors";
 
 export const AlertModalFooter = styled.div`
   display: flex;
@@ -9,7 +9,6 @@ export const AlertModalFooter = styled.div`
   margin-top: ${space(3)};
 `;
 
-export const AlertModalMessage = styled(FormMessage)`
-  margin-left: -${space(2)};
-  margin-right: -${space(2)};
+export const AlertModalError = styled.div`
+  color: ${color("error")};
 `;

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
@@ -253,9 +253,10 @@ export default class QueryBuilder extends Component {
   };
 
   handleSave = async card => {
-    const { question, apiUpdateQuestion } = this.props;
+    const { question, apiUpdateQuestion, updateUrl } = this.props;
     const questionWithUpdatedCard = question.setCard(card);
     await apiUpdateQuestion(questionWithUpdatedCard);
+    await updateUrl(questionWithUpdatedCard.card(), { dirty: false });
 
     if (this.props.fromUrl) {
       this.props.onChangeLocation(this.props.fromUrl);

--- a/frontend/src/metabase/sharing/components/AddEditSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/AddEditSidebar.jsx
@@ -56,6 +56,7 @@ export const AddEditSlackSidebar = connect(mapStateToProps)(
 function _AddEditEmailSidebar({
   pulse,
   formInput,
+  formError,
   channel,
   channelSpec,
   users,
@@ -76,10 +77,10 @@ function _AddEditEmailSidebar({
 }) {
   return (
     <Sidebar
+      closeIsDisabled={!dashboardPulseIsValid(pulse, formInput.channels)}
+      formError={formError}
       onClose={handleSave}
       onCancel={onCancel}
-      className="text-dark"
-      closeIsDisabled={!dashboardPulseIsValid(pulse, formInput.channels)}
     >
       <div className="pt4 px4 flex align-center">
         <Icon name="mail" className="mr1" size={21} />
@@ -187,6 +188,7 @@ function _AddEditEmailSidebar({
 _AddEditEmailSidebar.propTypes = {
   pulse: PropTypes.object.isRequired,
   formInput: PropTypes.object.isRequired,
+  formError: PropTypes.object,
   channel: PropTypes.object.isRequired,
   channelSpec: PropTypes.object.isRequired,
   users: PropTypes.array,
@@ -269,6 +271,7 @@ function getConfirmItems(pulse) {
 function _AddEditSlackSidebar({
   pulse,
   formInput,
+  formError,
   channel,
   channelSpec,
   parameters,
@@ -286,10 +289,10 @@ function _AddEditSlackSidebar({
 }) {
   return (
     <Sidebar
+      closeIsDisabled={!dashboardPulseIsValid(pulse, formInput.channels)}
+      formError={formError}
       onClose={handleSave}
       onCancel={onCancel}
-      className="text-dark"
-      closeIsDisabled={!dashboardPulseIsValid(pulse, formInput.channels)}
     >
       <div className="pt4 flex align-center px4 mb3">
         <Icon name="slack" className="mr1" size={21} />
@@ -368,6 +371,7 @@ function _AddEditSlackSidebar({
 _AddEditSlackSidebar.propTypes = {
   pulse: PropTypes.object.isRequired,
   formInput: PropTypes.object.isRequired,
+  formError: PropTypes.object,
   channel: PropTypes.object.isRequired,
   channelSpec: PropTypes.object.isRequired,
   users: PropTypes.array,

--- a/frontend/src/metabase/sharing/components/SharingSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/SharingSidebar.jsx
@@ -287,7 +287,7 @@ class SharingSidebar extends React.Component {
   };
 
   render() {
-    const { editingMode } = this.state;
+    const { editingMode, formError } = this.state;
     const {
       pulse,
       pulses,
@@ -333,6 +333,7 @@ class SharingSidebar extends React.Component {
         <AddEditEmailSidebar
           pulse={pulse}
           formInput={formInput}
+          formError={formError}
           channel={channel}
           channelSpec={channelSpec}
           handleSave={this.handleSave}
@@ -375,6 +376,7 @@ class SharingSidebar extends React.Component {
         <AddEditSlackSidebar
           pulse={pulse}
           formInput={formInput}
+          formError={formError}
           channel={channel}
           channelSpec={channelSpec}
           handleSave={this.handleSave}

--- a/frontend/src/metabase/sharing/components/SharingSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/SharingSidebar.jsx
@@ -120,6 +120,8 @@ class SharingSidebar extends React.Component {
     editingMode: "list-pulses",
     // use this to know where to go "back" to
     returnMode: [],
+    isSaving: false,
+    formError: null,
   };
 
   static propTypes = {
@@ -200,6 +202,11 @@ class SharingSidebar extends React.Component {
 
   handleSave = async () => {
     const { pulse, dashboard, formInput } = this.props;
+    const { isSaving } = this.state;
+
+    if (isSaving) {
+      return;
+    }
 
     const cleanedPulse = cleanPulse(pulse, formInput.channels);
     cleanedPulse.name = dashboard.name;
@@ -225,11 +232,16 @@ class SharingSidebar extends React.Component {
       },
     );
 
-    await this.props.updateEditingPulse(cleanedPulse);
-
-    // The order below matters; it hides the "Done" button faster and prevents two pulses from being made if it's double-clicked
-    this.setState({ editingMode: "list-pulses", returnMode: [] });
-    await this.props.saveEditingPulse();
+    try {
+      this.setState({ isSaving: true, formError: null });
+      await this.props.updateEditingPulse(cleanedPulse);
+      await this.props.saveEditingPulse();
+      this.setState({ editingMode: "list-pulses", returnMode: [] });
+    } catch (e) {
+      this.setState({ formError: e });
+    } finally {
+      this.setState({ isSaving: false });
+    }
   };
 
   createSubscription = () => {


### PR DESCRIPTION
Previously errors during creating/updating subscriptions/alerts were not shown. This became an issue with `approved email domains` setting as the BE validates recipients and returns an error if the validation fails. This PR adds a generic way to show error messages for these entities.

How to test:
- `yarn dev-ee`
- Go to Admin > Settings > General
- Enter a domain (e.g. `gmail.com`) for `Approved domains for notifications`
- Try to create or update an alert with an email recipient (type an email and hit enter) with a wrong domain. It should display an error message
- Try to create or update an alert with email recipients with correct domain. It should no fail and no error message should be shown.
- The same with dashboard subscriptions

Dashboard subscriptions:
<img width="579" alt="Screen Shot 2021-09-24 at 8 31 04 pm" src="https://user-images.githubusercontent.com/8542534/134716903-9c76212d-9622-4349-901e-07bc15f60f2f.png">

Alerts:
<img width="392" alt="Screen Shot 2021-09-24 at 8 31 26 pm" src="https://user-images.githubusercontent.com/8542534/134716913-d4f11ecc-3147-437b-b9d6-e0caae8e6a96.png">
