### PR TITLE
Update subscriptions and alerts audit tables when data changes

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditAlertTable/AuditAlertTable.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditAlertTable/AuditAlertTable.jsx
@@ -1,17 +1,17 @@
 import { connect } from "react-redux";
 import { push } from "react-router-redux";
 import { t } from "ttag";
+import { AuditEntitiesTable } from "../AuditEntitiesTable";
 import * as AlertCards from "../../lib/cards/alerts";
-import AuditTableWithSearch from "../AuditTableWithSearch";
 
 const mapStateToProps = (state, props) => ({
   table: AlertCards.table(),
   placeholder: t`Filter by question name`,
-  reload: props.location.state,
+  getExtraDataForClick: () => ({ type: "alert" }),
+  entities: state.entities.alerts,
 });
 
 const mapDispatchToProps = {
-  getExtraDataForClick: () => ({ type: "alert" }),
   onRemoveRow: ({ pulse_id }) =>
     push(`/admin/audit/subscriptions/alerts/${pulse_id}/delete`),
 };
@@ -19,4 +19,4 @@ const mapDispatchToProps = {
 export default connect(
   mapStateToProps,
   mapDispatchToProps,
-)(AuditTableWithSearch);
+)(AuditEntitiesTable);

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditEntitiesTable/AuditEntitiesTable.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditEntitiesTable/AuditEntitiesTable.jsx
@@ -1,0 +1,22 @@
+import React from "react";
+import PropTypes from "prop-types";
+import _ from "underscore";
+
+import AuditTableWithSearch from "../AuditTableWithSearch";
+import { usePrevious } from "metabase/hooks/use-previous";
+
+const propTypes = {
+  entities: PropTypes.array,
+};
+
+export const AuditEntitiesTable = ({ entities, ...rest }) => {
+  const previousEntities = usePrevious(entities);
+
+  const shouldReload =
+    previousEntities?.length === entities?.length &&
+    !_.isEqual(previousEntities, entities);
+
+  return <AuditTableWithSearch {...rest} reload={shouldReload} />;
+};
+
+AuditEntitiesTable.propTypes = propTypes;

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditEntitiesTable/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditEntitiesTable/index.js
@@ -1,0 +1,1 @@
+export * from "./AuditEntitiesTable";

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditSubscriptionTable/AuditSubscriptionTable.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditSubscriptionTable/AuditSubscriptionTable.jsx
@@ -2,16 +2,16 @@ import { connect } from "react-redux";
 import { push } from "react-router-redux";
 import { t } from "ttag";
 import * as SubscriptionCards from "../../lib/cards/subscriptions";
-import AuditTableWithSearch from "../AuditTableWithSearch";
+import { AuditEntitiesTable } from "../AuditEntitiesTable";
 
 const mapStateToProps = (state, props) => ({
   table: SubscriptionCards.table(),
   placeholder: t`Filter by dashboard name`,
-  reload: props.location.state,
+  getExtraDataForClick: () => ({ type: "subscription" }),
+  entities: state.entities.pulses,
 });
 
 const mapDispatchToProps = {
-  getExtraDataForClick: () => ({ type: "subscription" }),
   onRemoveRow: ({ pulse_id }) =>
     push(`/admin/audit/subscriptions/subscriptions/${pulse_id}/delete`),
 };
@@ -19,4 +19,4 @@ const mapDispatchToProps = {
 export default connect(
   mapStateToProps,
   mapDispatchToProps,
-)(AuditTableWithSearch);
+)(AuditEntitiesTable);

--- a/frontend/src/metabase/hooks/use-previous.js
+++ b/frontend/src/metabase/hooks/use-previous.js
@@ -1,0 +1,11 @@
+import { useRef, useEffect } from "react";
+
+export const usePrevious = value => {
+  const ref = useRef();
+
+  useEffect(() => {
+    ref.current = value;
+  }, [value]);
+
+  return ref.current;
+};

--- a/frontend/test/metabase/scenarios/admin/audit/subscriptions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/audit/subscriptions.cy.spec.js
@@ -67,9 +67,6 @@ describeWithToken("audit > auditing > subscriptions", () => {
 
   describe("subscriptions", () => {
     beforeEach(() => {
-      restore();
-      cy.signInAsAdmin();
-
       cy.getCurrentUser().then(({ body: { id: user_id } }) => {
         cy.createQuestionAndDashboard({
           questionDetails: getQuestionDetails(),
@@ -107,9 +104,9 @@ describeWithToken("audit > auditing > subscriptions", () => {
       });
     });
 
-    it.skip("allows to delete subscriptions", testRemovingAuditItem);
+    it("allows to delete subscriptions", testRemovingAuditItem);
 
-    it.skip("allows to edit recipients", () => {
+    it("allows to edit recipients", () => {
       testEditingRecipients({
         editModalHeader: "Subscription recipients",
       });
@@ -118,9 +115,6 @@ describeWithToken("audit > auditing > subscriptions", () => {
 
   describe("alerts", () => {
     beforeEach(() => {
-      restore();
-      cy.signInAsAdmin();
-
       cy.getCurrentUser().then(({ body: { id: user_id } }) => {
         cy.createQuestion(getQuestionDetails()).then(
           ({ body: { id: card_id } }) => {
@@ -156,9 +150,9 @@ describeWithToken("audit > auditing > subscriptions", () => {
       });
     });
 
-    it.skip("allows to delete alerts", testRemovingAuditItem);
+    it("allows to delete alerts", testRemovingAuditItem);
 
-    it.skip("allows to edit recipients", () => {
+    it("allows to edit recipients", () => {
       testEditingRecipients({
         editModalHeader: "Test Question alert recipients",
       });


### PR DESCRIPTION
### Description

Fixes subscriptions and alerts audit tables not being updated after removing or editing subscriptions/alerts via modals or undo changes.

### How to verify
- Create dashboard subscriptions and questions alerts
- Go to `/admin/audit/subscriptions/subscriptions`
    - Ensure after editing recipients the table updates
    - Ensure after removing a subscription the table updates
    - Ensure after undoing removing/editing the table updates back

- Go to `/admin/audit/subscriptions/alerts`
    - Ensure after editing recipients the table updates
    - Ensure after removing an alert the table updates
    - Ensure after undoing removing/editing the table updates back
