### PR TITLE
Do not stack up channels when creating a new dashboard subscription

### DIFF
--- a/frontend/src/metabase/sharing/components/SharingSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/SharingSidebar.jsx
@@ -143,7 +143,7 @@ class SharingSidebar extends React.Component {
     this.props.updateEditingPulse(pulse);
   };
 
-  addChannel = type => {
+  setPulseWithChannel = type => {
     const { dashboard, pulse, formInput } = this.props;
 
     const channelSpec = formInput.channels[type];
@@ -155,7 +155,7 @@ class SharingSidebar extends React.Component {
 
     const newPulse = {
       ...pulse,
-      channels: pulse.channels.concat(channel),
+      channels: [channel],
       cards: nonTextCardsFromDashboard(dashboard),
     };
     this.setPulse(newPulse);
@@ -403,7 +403,7 @@ class SharingSidebar extends React.Component {
                   returnMode: returnMode.concat([editingMode]),
                 };
               });
-              this.addChannel("email");
+              this.setPulseWithChannel("email");
             }
           }}
           onNewSlackPulse={() => {
@@ -414,7 +414,7 @@ class SharingSidebar extends React.Component {
                   returnMode: returnMode.concat([editingMode]),
                 };
               });
-              this.addChannel("slack");
+              this.setPulseWithChannel("slack");
             }
           }}
         />


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/18019

When creating a new subscription multiple times and pressing `Cancel`, multiple channels were added, which should never happen.

Case 1:
- Go to a dashboard with a question
- Open sharing sidebar
- Click "Email it"
- Add recipients
- Click "Cancel"
- Click "Email it"
- The recipients list should be empty

Case 2:
- Go to a dashboard with a question
- Open sharing sidebar
- Click "Email it"
- Add recipients
- Click "Cancel"
- Click "Send it to Slack"
- Pick a channel
- Click "Send now"
- You should not receive a subscription via email