### PR TITLE
Fix errors from disallowed characters in BigQuery custom expression names

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
@@ -536,17 +536,13 @@
       ;; when compared to other strings that may have normalized to the same thing.
       (str (substring-first-n-characters replaced-str 119) \_ (short-string-hash s)))))
 
-(defmethod sql.qp/expression-name->alias :bigquery-cloud-sdk
+(defmethod sql.qp/escape-alias :bigquery-cloud-sdk
   [_ expression-name]
   (->valid-field-identifier expression-name))
 
 (defmethod driver/format-custom-field-name :bigquery-cloud-sdk
   [_ custom-field-name]
   (->valid-field-identifier custom-field-name))
-
-(defmethod sql.qp/field->alias :bigquery-cloud-sdk
-  [driver field]
-  (->valid-field-identifier ((get-method sql.qp/field->alias :sql) driver field)))
 
 (defmethod sql.qp/prefix-field-alias :bigquery-cloud-sdk
   [driver prefix field-alias]

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
@@ -536,6 +536,10 @@
       ;; when compared to other strings that may have normalized to the same thing.
       (str (substring-first-n-characters replaced-str 119) \_ (short-string-hash s)))))
 
+(defmethod sql.qp/expression-name->alias :bigquery-cloud-sdk
+  [_ expression-name]
+  (->valid-field-identifier expression-name))
+
 (defmethod driver/format-custom-field-name :bigquery-cloud-sdk
   [_ custom-field-name]
   (->valid-field-identifier custom-field-name))

--- a/modules/drivers/bigquery/src/metabase/driver/bigquery/query_processor.clj
+++ b/modules/drivers/bigquery/src/metabase/driver/bigquery/query_processor.clj
@@ -501,9 +501,9 @@
   [_ custom-field-name]
   (->valid-field-identifier custom-field-name))
 
-(defmethod sql.qp/field->alias :bigquery
-  [driver field]
-  (->valid-field-identifier ((get-method sql.qp/field->alias :sql) driver field)))
+(defmethod sql.qp/escape-alias :bigquery
+  [_ alias-name]
+  (->valid-field-identifier alias-name))
 
 (defmethod sql.qp/prefix-field-alias :bigquery
   [driver prefix field-alias]

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -195,7 +195,7 @@
   [_ alias-name]
   alias-name)
 
-(defmulti ^:deprecated ^String field->alias
+(defmulti ^String field->alias
   "Return the string alias that should be used to for `field`, an instance of the Field model, i.e. in an `AS` clause.
   The default implementation calls `escape-alias` on the field `:name`, which returns the *unqualified* name of the
   Field.
@@ -204,7 +204,7 @@
 
   DEPRECATED as of x.41.  This multimethod will be removed in a future release.  Instead, drivers will simply
   override the `escape-alias` multimethod if they want to influence the alias to be used for a given field name."
-  {:arglists '([driver field])}
+  {:arglists '([driver field]), :deprecated "0.41.0"}
   driver/dispatch-on-initialized-driver
   :hierarchy #'driver/hierarchy)
 

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -195,15 +195,22 @@
   [_ alias-name]
   alias-name)
 
-(defn- ^String field->alias
+(defmulti ^:deprecated ^String field->alias
   "Return the string alias that should be used to for `field`, an instance of the Field model, i.e. in an `AS` clause.
-  The default implementation calls `escape-alias` with the `:name` value, which returns the *unqualified* name of the
+  The default implementation calls `escape-alias` on the field `:name`, which returns the *unqualified* name of the
   Field.
 
-  Return `nil` to prevent `field` from being aliased."
+  Return `nil` to prevent `field` from being aliased.
+
+  DEPRECATED as of x.41.  This multimethod will be removed in a future release.  Instead, drivers will simply
+  override the `escape-alias` multimethod if they want to influence the alias to be used for a given field name."
+  {:arglists '([driver field])}
+  driver/dispatch-on-initialized-driver
+  :hierarchy #'driver/hierarchy)
+
+(defmethod field->alias :sql
   [driver field]
-  (when-let [field-name (:name field)]
-    (escape-alias driver field-name)))
+  (escape-alias driver (:name field)))
 
 (defmulti quote-style
   "Return the quoting style that should be used by [HoneySQL](https://github.com/jkk/honeysql) when building a SQL

--- a/test/metabase/query_processor_test/expressions_test.clj
+++ b/test/metabase/query_processor_test/expressions_test.clj
@@ -99,8 +99,7 @@
                                         oneplusone   [:+ 1 1]}
                           :fields      [$price [:expression oneplusone]]
                           :order-by    [[:asc $id]]
-                          :limit       3})
-          ]
+                          :limit       3})]
       (testing "If an explicit `:fields` clause is present, expressions *not* in that clause should not come back"
         (is (= [[3 2] [2 2] [2 2]]
                (mt/formatted-rows [int int]
@@ -408,3 +407,13 @@
           (is (= [["Red Medicine" "Red" "RedMedicine"]
                   ["Rush Street" "Rush" "RushStreet"]]
                  (mt/formatted-rows [str str str] results))))))))
+
+(deftest expression-name-weird-characters-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
+    (testing "An expression whose name contains weird characters works properly"
+      (is (= [[1 "Red Medicine" 4 10.0646 -165.374 3 -3]]
+             (mt/formatted-rows [int str int 4.0 4.0 int int]
+               (mt/run-mbql-query venues
+                 {:expressions {(keyword "Refund Amount (?)") [:* $price -1]}
+                  :limit       1
+                  :order-by    [[:asc $id]]})))))))


### PR DESCRIPTION
Add `expression-name->alias` multimethod to sql.qp to handle translating the expression name to one that is supported by the driver

Add default impl that is essentially identity

Override for new BigQuery driver to run through the same `->valid-field-identifier` function already added for this purpose

Add test for a custom expression with weird characters
