### PR TITLE
Fix incorrect date formatting

### DIFF
--- a/frontend/src/metabase/lib/formatting.js
+++ b/frontend/src/metabase/lib/formatting.js
@@ -14,6 +14,7 @@ import ExternalLink from "metabase/components/ExternalLink";
 import {
   isCoordinate,
   isDate,
+  isDateWithoutTime,
   isEmail,
   isLatitude,
   isLongitude,
@@ -475,7 +476,11 @@ function formatDateTimeWithFormats(value, dateFormat, timeFormat, options) {
   if (dateFormat) {
     format.push(replaceDateFormatNames(dateFormat, options));
   }
-  if (timeFormat && options.time_enabled) {
+
+  const shouldIncludeTime =
+    timeFormat && options.time_enabled && !isDateWithoutTime(options.column);
+
+  if (shouldIncludeTime) {
     format.push(timeFormat);
   }
   return m.format(format.join(", "));

--- a/frontend/src/metabase/lib/schema_metadata.js
+++ b/frontend/src/metabase/lib/schema_metadata.js
@@ -173,6 +173,17 @@ export const isNumericBaseType = field => {
   }
 };
 
+export const isDateWithoutTime = field => {
+  if (!field) {
+    return false;
+  }
+  if (field.effective_type) {
+    return isa(field.effective_type, TYPE.Date);
+  } else {
+    return isa(field.base_type, TYPE.Date);
+  }
+};
+
 // ZipCode, ID, etc derive from Number but should not be formatted as numbers
 export const isNumber = field =>
   field &&

--- a/frontend/src/metabase/visualizations/lib/settings/column.js
+++ b/frontend/src/metabase/visualizations/lib/settings/column.js
@@ -11,6 +11,7 @@ import {
   isNumber,
   isCoordinate,
   isCurrency,
+  isDateWithoutTime,
 } from "metabase/lib/schema_metadata";
 
 // HACK: cyclical dependency causing errors in unit tests
@@ -252,7 +253,8 @@ export const DATE_COLUMN_SETTINGS = {
       }
       return { options };
     },
-    getHidden: ({ unit }: Column, settings: ColumnSettings) => !hasHour(unit),
+    getHidden: (column: Column, settings: ColumnSettings) =>
+      !hasHour(column.unit) || isDateWithoutTime(column),
     getDefault: ({ unit }: Column) => (hasHour(unit) ? "minutes" : null),
   },
   time_style: {
@@ -269,7 +271,7 @@ export const DATE_COLUMN_SETTINGS = {
       ],
     }),
     getHidden: (column: Column, settings: ColumnSettings) =>
-      !settings["time_enabled"],
+      !settings["time_enabled"] || isDateWithoutTime(column),
     readDependencies: ["time_enabled"],
   },
 };

--- a/frontend/test/metabase/lib/formatting.unit.spec.js
+++ b/frontend/test/metabase/lib/formatting.unit.spec.js
@@ -282,6 +282,19 @@ describe("formatting", () => {
         }),
       ).toEqual("00:00");
     });
+    it("should not include time for type/Date type (metabase#7494)", () => {
+      expect(
+        formatValue("2019-07-07T00:00:00.000Z", {
+          date_style: "M/D/YYYY",
+          time_enabled: "minutes",
+          time_style: "HH:mm",
+          column: {
+            base_type: "type/Date",
+            unit: "hour-of-day",
+          },
+        }),
+      ).toEqual("7/7/2019");
+    });
   });
 
   describe("formatUrl", () => {

--- a/frontend/test/metabase/scenarios/visualizations/scalar.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/scalar.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore } from "__support__/e2e/cypress";
+import { restore, visitQuestionAdhoc } from "__support__/e2e/cypress";
 import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATASET;
@@ -55,5 +55,25 @@ describe("scenarios > visualizations > scalar", () => {
         });
       });
     });
+  });
+
+  it(`should render date without time (metabase#7494)`, () => {
+    visitQuestionAdhoc({
+      dataset_query: {
+        type: "native",
+        native: {
+          query: `SELECT cast('2018-05-01T00:00:00Z'::timestamp as date)`,
+          "template-tags": {},
+        },
+        database: 1,
+      },
+      display: "scalar",
+    });
+
+    cy.findByText("April 30, 2018");
+    cy.findByText("Settings").click();
+
+    cy.findByText("Show the time").should("be.hidden");
+    cy.findByText("Time style").should("be.hidden");
   });
 });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/7494
Closes https://github.com/metabase/metabase/issues/5859

### Description

We formatted `Date` columns as `DateTime`, which is not correct.

### How to verify

#### Date
- New question > Native query
- Run `SELECT cast('2018-05-01T00:00:00Z'::timestamp as date)`
- Ensure there is no time displayed, only date
- Click "Settings"
- Ensure there are no time formatting settings

#### DateTime
- New question > Native query
- Run `SELECT '2018-05-01T00:00:00Z'::timestamp`
- Ensure the date and time are displayed
- Click "Settings"
- Ensure there are settings for both date and time formatting