### PR TITLE
Fix personal sub-collections are hidden in item picker

### DIFF
--- a/frontend/src/metabase/entities/collections.js
+++ b/frontend/src/metabase/entities/collections.js
@@ -238,11 +238,12 @@ export function getExpandedCollectionsById(
 
   // "My personal collection"
   if (userPersonalCollectionId != null) {
+    const personalCollection = collectionsById[userPersonalCollectionId];
     collectionsById[ROOT_COLLECTION.id].children.push({
       ...PERSONAL_COLLECTION,
       id: userPersonalCollectionId,
       parent: collectionsById[ROOT_COLLECTION.id],
-      children: [],
+      children: personalCollection?.children || [],
       is_personal: true,
     });
   }

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -329,7 +329,7 @@ describe("scenarios > collection_defaults", () => {
       });
     });
 
-    it.skip("sub-collection should be available in save and move modals (#14122)", () => {
+    it("sub-collection should be available in save and move modals (#14122)", () => {
       const COLLECTION = "14122C";
       // Create Parent collection within `Our analytics`
       cy.request("POST", "/api/collection", {


### PR DESCRIPTION
Fixes #14122: current user's personal sub-collections are not accessible in the Save or Move dialogs

### To Reproduce

1. Create a collection and save it into your personal collection
2. Click the '+' icon in the navbar
3. Select "New dashboard"
4. Click the collection picker
5. "My personal collection" should have a chevron icon on the right side
6. Click the chevron icon, you should see your personal collection child collections

### Demo

**Before**

![CleanShot 2021-09-27 at 14 15 01@2x](https://user-images.githubusercontent.com/17258145/134906294-3e963298-5f31-4063-af18-70b162c167fc.png)

**After**

https://user-images.githubusercontent.com/17258145/134906320-089060c3-09c8-4700-afc7-b7c0dc4b2a7f.mov
