### PR TITLE
#18063 Repro: Pin map with null locations shows tooltip of the wrong row

### DIFF
--- a/frontend/test/metabase/scenarios/visualizations/reproductions/18063-maps-null-location-wrong-tooltip.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/reproductions/18063-maps-null-location-wrong-tooltip.cy.spec.js
@@ -1,0 +1,68 @@
+import { restore, popover } from "__support__/e2e/cypress";
+
+const questionDetails = {
+  name: "18063",
+  native: {
+    query:
+      'select null "LATITUDE", null "LONGITUDE", null "COUNT", \'NULL ROW\' "NAME"\nunion all select 55.6761, 12.5683, 1, \'Copenhagen\'\n',
+    "template-tags": {},
+  },
+  display: "map",
+};
+
+describe.skip("issue 18063", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.createNativeQuestion(questionDetails, { visitQuestion: true });
+
+    // Select a Pin map
+    cy.findByTestId("viz-settings-button").click();
+    cy.get(".AdminSelect")
+      .contains("Region map")
+      .click();
+
+    popover()
+      .contains("Pin map")
+      .click();
+
+    // Click anywhere to close both popovers that open automatically.
+    // Please see: https://github.com/metabase/metabase/issues/18063#issuecomment-927836691
+    cy.findByText("Map type").click();
+    cy.findByText("Map type").click();
+  });
+
+  it("should show the correct tooltip details for pin map even when some locations are null (metabase#18063)", () => {
+    selectFieldValue("Latitude field", "LATITUDE");
+    selectFieldValue("Longitude field", "LONGITUDE");
+
+    cy.get(".leaflet-marker-icon").trigger("mousemove");
+
+    popover().within(() => {
+      testPairedTooltipValues("LATITUDE", "55.6761");
+      testPairedTooltipValues("LONGITUDE", "12.5683");
+      testPairedTooltipValues("COUNT", "1");
+      testPairedTooltipValues("NAME", "Copenhagen");
+    });
+  });
+});
+
+function selectFieldValue(field, value) {
+  cy.findByText(field)
+    .parent()
+    .within(() => {
+      cy.findByText("Select a field").click();
+    });
+
+  popover()
+    .contains(value)
+    .click();
+}
+
+function testPairedTooltipValues(val1, val2) {
+  cy.contains(val1)
+    .closest("td")
+    .siblings("td")
+    .findByText(val2);
+}


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #18063 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/visualizations/reproductions/18063-maps-null-location-wrong-tooltip.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/134915947-c524eff2-7a32-4c5b-931a-267536fc2d55.png)

