### PR TITLE
Git ignore `clj-kondo` cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,7 @@ dev/src/dev/nocommit/
 **/cypress_sample_dataset.json
 /frontend/src/cljs
 .shadow-cljs
+.clj-kondo/cache/
 
 # lsp: ignore all but the config file
 .lsp/*


### PR DESCRIPTION
Not sure what caused this, but I started seeing hundreds of tracked files in git that all match `.clj-kondo/cache/` path.

This PR adds them to the `.gitignore` list.