### PR TITLE
Add labels to settings fields

### DIFF
--- a/frontend/src/metabase/admin/settings/components/SettingHeader.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingHeader.jsx
@@ -1,11 +1,11 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 
-const SettingHeader = ({ setting }) => (
+const SettingHeader = ({ id, setting }) => (
   <div>
-    <div className="text-medium text-bold text-uppercase">
+    <label className="text-medium text-bold text-uppercase" htmlFor={id}>
       {setting.display_name}
-    </div>
+    </label>
     <div className="text-medium text-measure my1">
       {setting.warningMessage && (
         <React.Fragment>

--- a/frontend/src/metabase/admin/settings/components/SettingHeader/SettingHeader.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingHeader/SettingHeader.jsx
@@ -1,12 +1,11 @@
 /* eslint-disable react/prop-types */
 import React from "react";
+import { SettingDescription, SettingTitle } from "./SettingHeader.styled";
 
 const SettingHeader = ({ id, setting }) => (
   <div>
-    <label className="text-medium text-bold text-uppercase" htmlFor={id}>
-      {setting.display_name}
-    </label>
-    <div className="text-medium text-measure my1">
+    <SettingTitle htmlFor={id}>{setting.display_name}</SettingTitle>
+    <SettingDescription>
       {setting.warningMessage && (
         <React.Fragment>
           <strong>{setting.warningMessage}</strong>{" "}
@@ -14,8 +13,7 @@ const SettingHeader = ({ id, setting }) => (
       )}
       {setting.description}
       {setting.note && <div>{setting.note}</div>}
-    </div>
+    </SettingDescription>
   </div>
 );
-
 export default SettingHeader;

--- a/frontend/src/metabase/admin/settings/components/SettingHeader/SettingHeader.styled.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingHeader/SettingHeader.styled.jsx
@@ -1,0 +1,16 @@
+import styled from "styled-components";
+import { color } from "metabase/lib/colors";
+import { space } from "metabase/styled-components/theme";
+
+export const SettingTitle = styled.label`
+  display: block;
+  color: ${color("text-medium")};
+  font-weight: bold;
+  text-transform: uppercase;
+`;
+
+export const SettingDescription = styled.div`
+  color: ${color("text-medium")};
+  margin: ${space(1)} 0;
+  max-width: 38.75rem;
+`;

--- a/frontend/src/metabase/admin/settings/components/SettingHeader/index.js
+++ b/frontend/src/metabase/admin/settings/components/SettingHeader/index.js
@@ -1,0 +1,1 @@
+export { default } from "./SettingHeader";

--- a/frontend/src/metabase/admin/settings/components/SettingsSetting.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsSetting.jsx
@@ -14,6 +14,7 @@ import SettingToggle from "./widgets/SettingToggle";
 import SettingSelect from "./widgets/SettingSelect";
 import SettingText from "./widgets/SettingText";
 import SettingColor from "./widgets/SettingColor";
+import { settingToFormFieldId } from "./../../settings/utils";
 
 const SETTING_WIDGET_MAP = {
   string: SettingInput,
@@ -48,6 +49,8 @@ export default class SettingsSetting extends Component {
 
   render() {
     const { setting, errorMessage } = this.props;
+    const settingId = settingToFormFieldId(setting);
+
     let Widget = setting.widget || SETTING_WIDGET_MAP[setting.type];
     if (!Widget) {
       console.warn(
@@ -60,9 +63,12 @@ export default class SettingsSetting extends Component {
     return (
       // TODO - this formatting needs to be moved outside this component
       <li className="m2 mb4">
-        {!setting.noHeader && <SettingHeader setting={setting} />}
+        {!setting.noHeader && (
+          <SettingHeader id={settingId} setting={setting} />
+        )}
         <div className="flex">
           <Widget
+            id={settingId}
             {...(setting.props || {})}
             {...updatePlaceholderForEnvironmentVars(this.props)}
           />

--- a/frontend/src/metabase/admin/settings/components/widgets/SettingInput.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/SettingInput.jsx
@@ -11,6 +11,7 @@ const SettingInput = ({
   autoFocus,
   errorMessage,
   fireOnChange,
+  id,
   type = "text",
 }) => (
   <InputBlurChange
@@ -19,6 +20,7 @@ const SettingInput = ({
       SettingsPassword: type === "password",
       "border-error bg-error-input": errorMessage,
     })}
+    id={id}
     type={type}
     value={setting.value || ""}
     placeholder={setting.placeholder}

--- a/frontend/src/metabase/admin/settings/utils.js
+++ b/frontend/src/metabase/admin/settings/utils.js
@@ -15,3 +15,5 @@ export const settingToFormField = setting => ({
     : setting.placeholder || setting.default,
   validate: setting.required ? value => !value && "required" : null,
 });
+
+export const settingToFormFieldId = setting => `setting-${setting.key}`;

--- a/frontend/test/metabase/scenarios/admin/settings/email.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/email.cy.spec.js
@@ -8,19 +8,19 @@ describe("scenarios > admin > settings > email settings", () => {
 
   it("should be able to save email settings (metabase#17615)", () => {
     cy.visit("/admin/settings/email");
-    cy.findByPlaceholderText("smtp.yourservice.com")
+    cy.findByLabelText("SMTP Host")
       .type("localhost")
       .blur();
-    cy.findByPlaceholderText("587")
+    cy.findByLabelText("SMTP Port")
       .type("25")
       .blur();
-    cy.findByPlaceholderText("youlooknicetoday")
+    cy.findByLabelText("SMTP Username")
       .type("admin")
       .blur();
-    cy.findByPlaceholderText("Shhh...")
+    cy.findByLabelText("SMTP Password")
       .type("admin")
       .blur();
-    cy.findByPlaceholderText("metabase@yourcompany.com")
+    cy.findByLabelText("From Address")
       .type("mailer@metabase.test")
       .blur();
     cy.findByText("Save changes").click();
@@ -72,12 +72,9 @@ describe("scenarios > admin > settings > email settings", () => {
   it("should be able to clear email settings", () => {
     cy.visit("/admin/settings/email");
     cy.findByText("Clear").click();
-    cy.findByPlaceholderText("smtp.yourservice.com").should("have.value", "");
-    cy.findByPlaceholderText("587").should("have.value", "");
-    cy.findByPlaceholderText("metabase@yourcompany.com").should(
-      "have.value",
-      "",
-    );
+    cy.findByLabelText("SMTP Host").should("have.value", "");
+    cy.findByLabelText("SMTP Port").should("have.value", "");
+    cy.findByLabelText("From Address").should("have.value", "");
   });
 
   it("should not offer to save email changes when there aren't any (metabase#14749)", () => {
@@ -96,19 +93,19 @@ describe("scenarios > admin > settings > email settings", () => {
     cy.visit("/admin/settings/email");
 
     // First we fill out wrong settings
-    cy.findByPlaceholderText("smtp.yourservice.com")
+    cy.findByLabelText("SMTP Host")
       .type("foo") // Invalid SMTP host
       .blur();
-    cy.findByPlaceholderText("587")
+    cy.findByLabelText("SMTP Port")
       .type("25")
       .blur();
-    cy.findByPlaceholderText("youlooknicetoday")
+    cy.findByLabelText("SMTP Username")
       .type("admin")
       .blur();
-    cy.findByPlaceholderText("Shhh...")
+    cy.findByLabelText("SMTP Password")
       .type("admin")
       .blur();
-    cy.findByPlaceholderText("metabase@yourcompany.com")
+    cy.findByLabelText("From Address")
       .type("mailer@metabase.test")
       .blur();
 

--- a/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
@@ -382,7 +382,7 @@ describe("scenarios > admin > settings", () => {
     it("should present the form and display errors", () => {
       cy.visit("/admin/settings/slack");
       cy.contains("Answers sent right to your Slack");
-      cy.findByPlaceholderText("Enter the token you received from Slack")
+      cy.findByLabelText("Slack API Token")
         .type("not-a-real-token")
         .blur();
       cy.findByText("Save changes").click();

--- a/frontend/test/metabase/scenarios/admin/settings/sso/jwt.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/sso/jwt.cy.spec.js
@@ -19,7 +19,7 @@ describeWithToken("scenarios > admin > settings > SSO > JWT", () => {
       });
     cy.findByText("Enabled");
 
-    cy.findByPlaceholderText("https://jwt.yourdomain.org")
+    cy.findByLabelText("JWT Identity Provider URI")
       .type("localhost")
       .blur();
     cy.button("Save changes").click();

--- a/frontend/test/metabase/scenarios/admin/settings/sso/ldap.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/sso/ldap.cy.spec.js
@@ -23,8 +23,8 @@ describe("scenarios > admin > settings > SSO > LDAP", () => {
       // Although the endpoint was fixed, we want to always be able to test these issues separately and independently of each other.
       cy.intercept("PUT", "/api/**").as("update");
 
-      cy.findByPlaceholderText("ldap.yourdomain.org").type("foobar");
-      cy.findByPlaceholderText("389").type(port);
+      cy.findByLabelText("LDAP Host").type("foobar");
+      cy.findByLabelText("LDAP Port").type(port);
       cy.button("Save changes").click();
       cy.wait("@update").then(interception => {
         expect(interception.response.statusCode).to.eq(500);
@@ -35,8 +35,8 @@ describe("scenarios > admin > settings > SSO > LDAP", () => {
 
   it("should use the correct endpoint (metabase#16173)", () => {
     cy.intercept("PUT", "/api/ldap/settings").as("ldapUpdate");
-    cy.findByPlaceholderText("ldap.yourdomain.org").type("foobar");
-    cy.findByPlaceholderText("389").type("888");
+    cy.findByLabelText("LDAP Host").type("foobar");
+    cy.findByLabelText("LDAP Port").type("888");
     cy.findByText(/Username or DN/i)
       .closest("li")
       .find("input")
@@ -53,8 +53,8 @@ describe("scenarios > admin > settings > SSO > LDAP", () => {
   });
 
   it("should not reset previously populated fields when validation fails for just one of them (metabase#16226)", () => {
-    cy.findByPlaceholderText("ldap.yourdomain.org").type("foobar");
-    cy.findByPlaceholderText("389").type("baz");
+    cy.findByLabelText("LDAP Host").type("foobar");
+    cy.findByLabelText("LDAP Port").type("baz");
     cy.button("Save changes").click();
 
     cy.findByText('For input string: "baz"'); // The error message

--- a/frontend/test/metabase/scenarios/admin/settings/whitelabel.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/whitelabel.cy.spec.js
@@ -93,7 +93,7 @@ describeWithToken("formatting > whitelabel", () => {
     beforeEach(() => {
       cy.log("Change company name");
       cy.visit("/admin/settings/whitelabel");
-      cy.findByPlaceholderText("Metabase")
+      cy.findByLabelText("Application Name")
         .clear()
         .type(COMPANY_NAME);
       // Helps scroll the page up in order to see "Saved" notification
@@ -203,7 +203,7 @@ describeWithToken("formatting > whitelabel", () => {
       cy.visit("/admin/settings/whitelabel");
 
       cy.log("Add favicon");
-      cy.findByPlaceholderText("/app/assets/img/favicon.ico").type(
+      cy.findByLabelText("Favicon").type(
         "https://cdn.ecosia.org/assets/images/ico/favicon.ico",
       );
       cy.get("ul")


### PR DESCRIPTION
Currently it's not possible to add a cypress test to test a setting without placeholder. This PR fixes the issue by adding `label`s and linking them with input fields.