### PR TITLE
#18061 Repro(s): Pin map only containing null location results crashes the frontend

### DIFF
--- a/frontend/test/metabase/scenarios/visualizations/reproductions/18061-maps-only-nulls-crash-frontend.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/reproductions/18061-maps-only-nulls-crash-frontend.cy.spec.js
@@ -1,0 +1,171 @@
+import {
+  restore,
+  mockSessionProperty,
+  visitAlias,
+  popover,
+  filterWidget,
+} from "__support__/e2e/cypress";
+
+import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
+
+const { PEOPLE, PEOPLE_ID } = SAMPLE_DATASET;
+
+const questionDetails = {
+  name: "18061",
+  query: {
+    "source-table": PEOPLE_ID,
+    expressions: {
+      CClat: [
+        "case",
+        [
+          [
+            [">", ["field", PEOPLE.ID, null], 1],
+            ["field", PEOPLE.LATITUDE, null],
+          ],
+        ],
+      ],
+      CClong: [
+        "case",
+        [
+          [
+            [">", ["field", PEOPLE.ID, null], 1],
+            ["field", PEOPLE.LONGITUDE, null],
+          ],
+        ],
+      ],
+    },
+    filter: ["<", ["field", PEOPLE.ID, null], 3],
+  },
+  display: "map",
+  visualization_settings: {
+    "map.latitude_column": "CClat",
+    "map.longitude_column": "CClong",
+  },
+};
+
+const filter = {
+  name: "Category",
+  slug: "category",
+  id: "749a03b5",
+  type: "category",
+};
+
+const dashboardDetails = { name: "18061D", parameters: [filter] };
+
+describe.skip("issue 18061", () => {
+  beforeEach(() => {
+    mockSessionProperty("field-filter-operators-enabled?", true);
+
+    restore();
+    cy.signInAsAdmin();
+
+    cy.createQuestionAndDashboard({ questionDetails, dashboardDetails }).then(
+      ({ body: dashboardCard }) => {
+        const { dashboard_id, card_id } = dashboardCard;
+
+        const mapFilterToCard = {
+          parameter_mappings: [
+            {
+              parameter_id: filter.id,
+              card_id,
+              target: ["dimension", ["field", PEOPLE.SOURCE, null]],
+            },
+          ],
+        };
+
+        cy.editDashboardCard(dashboardCard, mapFilterToCard);
+
+        cy.wrap(`/question/${card_id}`).as(`questionUrl`);
+        cy.wrap(`/dashboard/${dashboard_id}`).as(`dashboardUrl`);
+
+        cy.intercept("POST", `/api/card/${card_id}/query`).as("cardQuery");
+        cy.intercept("GET", `/api/card/${card_id}`).as("getCard");
+
+        // Enable sharing
+        cy.request("POST", `/api/dashboard/${dashboard_id}/public_link`);
+      },
+    );
+  });
+
+  context("scenario 1: question with a filter", () => {
+    it("should handle data sets that contain only null values for longitude/latitude (metabase#18061-1)", () => {
+      visitAlias("@questionUrl");
+
+      cy.wait("@getCard");
+      cy.wait("@cardQuery");
+
+      cy.window().then(w => (w.beforeReload = true));
+
+      cy.icon("filter")
+        .parent()
+        .contains("1")
+        .click();
+      cy.findByText("ID is less than 3").click();
+
+      popover()
+        .find("input")
+        .type("{backspace}2");
+
+      cy.button("Update filter").click();
+
+      cy.wait("@getCard");
+      cy.findByText("Something went wrong").should("not.exist");
+
+      cy.findByText("ID is less than 2");
+      cy.get(".PinMap");
+
+      cy.window().should("have.prop", "beforeReload", true);
+    });
+  });
+
+  context("scenario 2: dashboard with a filter", () => {
+    it("should handle data sets that contain only null values for longitude/latitude (metabase#18061-2)", () => {
+      visitAlias("@dashboardUrl");
+
+      cy.wait("@cardQuery");
+
+      addFilter("Twitter");
+
+      cy.wait("@cardQuery");
+      cy.findByText("Something went wrong").should("not.exist");
+
+      cy.location("search").should("eq", "?category=Twitter");
+    });
+  });
+
+  context("scenario 3: publicly shared dashboard with a filter", () => {
+    it("should handle data sets that contain only null values for longitude/latitude (metabase#18061-3)", () => {
+      visitAlias("@dashboardUrl");
+      cy.wait("@cardQuery");
+
+      cy.icon("share").click();
+      cy.findByText("Sharing and embedding").click();
+
+      cy.findByText("Public link")
+        .parent()
+        .find("input")
+        .invoke("val")
+        .then($value => {
+          cy.visit($value);
+        });
+
+      cy.get(".PinMap");
+
+      addFilter("Twitter");
+
+      cy.location("search").should("eq", "?category=Twitter");
+
+      cy.findByText("18061D");
+      cy.findByText("18061");
+      cy.get(".PinMap");
+    });
+  });
+});
+
+function addFilter(filter) {
+  filterWidget().click();
+  popover()
+    .contains(filter)
+    .click();
+  cy.button("Add filter").click();
+}


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- Reproduces #18061 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/visualizations/reproductions/18061-maps-only-nulls-crash-frontend.cy.spec.js`
- Unskip the top most `describe` block
- All 3 tests should fail

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure ALL tests are passing and
- Merge this spec together with the fix

### Screenshots:

Scenario 1:
![image](https://user-images.githubusercontent.com/31325167/134942496-6b36e71b-5e97-461b-898c-18ed8c9fb240.png)

Scenario 2:
![image](https://user-images.githubusercontent.com/31325167/134942569-a8db78cc-fd87-4544-9dac-23342cfcf618.png)

Scenario 3:
![image](https://user-images.githubusercontent.com/31325167/134942661-087f87b2-47f6-43b9-b0d7-1f32b85950a7.png)

