### PR TITLE
Approved domains tests

### DIFF
--- a/frontend/test/metabase/scenarios/sharing/alert/alert.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/alert/alert.cy.spec.js
@@ -218,8 +218,8 @@ describeWithToken("scenarios > alert (EE)", () => {
   });
 
   it("should validate for approved email domains", () => {
-    const email = "example@example.com";
-    const domain = "metabase.com";
+    const email = "mailer@metabase.test";
+    const domain = "metabase.example";
 
     setupDummySMTP();
     setAllowedEmailDomains(domain);
@@ -237,7 +237,7 @@ describeWithToken("scenarios > alert (EE)", () => {
     cy.findByText("Done").click();
 
     cy.findByText(
-      'You cannot create new subscriptions for the domain "example.com". Allowed domains are: metabase.com',
+      'You cannot create new subscriptions for the domain "metabase.test". Allowed domains are: metabase.example',
     );
   });
 });

--- a/frontend/test/metabase/scenarios/sharing/alert/alert.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/alert/alert.cy.spec.js
@@ -5,7 +5,9 @@ import {
   popover,
   openPeopleTable,
   describeWithToken,
+  setupSMTP,
 } from "__support__/e2e/cypress";
+
 import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
 // Ported from alert.e2e.spec.js
 // *** We should also check that alerts can be set up through slack
@@ -221,7 +223,7 @@ describeWithToken("scenarios > alert (EE)", () => {
     const email = "mailer@metabase.test";
     const domain = "metabase.example";
 
-    setupDummySMTP();
+    setupSMTP();
     setAllowedEmailDomains(domain);
 
     cy.createQuestion({

--- a/frontend/test/metabase/scenarios/sharing/alert/alert.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/alert/alert.cy.spec.js
@@ -4,15 +4,11 @@ import {
   createBasicAlert,
   popover,
   openPeopleTable,
-  describeWithToken,
-  setupSMTP,
 } from "__support__/e2e/cypress";
 
-import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
 // Ported from alert.e2e.spec.js
 // *** We should also check that alerts can be set up through slack
 
-const { ORDERS_ID } = SAMPLE_DATASET;
 const raw_q_id = 1;
 const timeseries_q_id = 3;
 
@@ -212,49 +208,3 @@ describe("scenarios > alert", () => {
     });
   });
 });
-
-describeWithToken("scenarios > alert (EE)", () => {
-  beforeEach(() => {
-    restore();
-    cy.signInAsAdmin();
-  });
-
-  it("should validate for approved email domains", () => {
-    const email = "mailer@metabase.test";
-    const domain = "metabase.example";
-
-    setupSMTP();
-    setAllowedEmailDomains(domain);
-
-    cy.createQuestion({
-      name: "Orders",
-      query: { "source-table": ORDERS_ID },
-    }).then(({ body: { id: questionId } }) => {
-      cy.visit(`/question/${questionId}`);
-    });
-
-    cy.icon("bell").click();
-    cy.findByText("Set up an alert").click();
-    addEmailRecipient(email);
-    cy.findByText("Done").click();
-
-    cy.findByText(
-      'You cannot create new subscriptions for the domain "metabase.test". Allowed domains are: metabase.example',
-    );
-  });
-});
-
-function addEmailRecipient(email) {
-  cy.findByText("Email alerts to:")
-    .parent()
-    .find("input")
-    .click()
-    .type(`${email}{enter}`)
-    .blur();
-}
-
-function setAllowedEmailDomains(domains) {
-  cy.request("PUT", "/api/setting/subscription-allowed-domains", {
-    value: domains,
-  });
-}

--- a/frontend/test/metabase/scenarios/sharing/approved-domains.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/approved-domains.cy.spec.js
@@ -1,0 +1,66 @@
+import {
+  restore,
+  setupSMTP,
+  describeWithToken,
+  sidebar,
+} from "__support__/e2e/cypress";
+
+const allowedDomain = "metabase.test";
+const deniedDomain = "metabase.example";
+const email = "mailer@" + deniedDomain;
+
+const errorMessage = `You cannot create new subscriptions for the domain "${deniedDomain}". Allowed domains are: ${allowedDomain}`;
+
+describeWithToken("scenarios > alert (EE)", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    setupSMTP();
+    setAllowedEmailDomains(allowedDomain);
+  });
+
+  it("should validate approved email domains for a question alert", () => {
+    cy.visit("/question/1");
+
+    cy.icon("bell").click();
+    cy.findByText("Set up an alert").click();
+
+    addEmailRecipient(email);
+
+    cy.button("Done").click();
+    cy.findByText(errorMessage);
+  });
+
+  it("should validate approved email domains for a dashboard subscription", () => {
+    cy.visit("/dashboard/1");
+
+    cy.icon("share").click();
+    cy.findByText("Dashboard subscriptions").click();
+    cy.findByText("Email it").click();
+    cy.findByPlaceholderText("Enter user names or email addresses")
+      .click()
+      .type(`${email}`)
+      .blur();
+
+    sidebar().within(() => {
+      cy.button("Done").click();
+      cy.findByText(errorMessage);
+    });
+  });
+});
+
+function addEmailRecipient(email) {
+  cy.findByText("Email alerts to:")
+    .parent()
+    .find("input")
+    .click()
+    .type(`${email}`)
+    .blur();
+}
+
+function setAllowedEmailDomains(domains) {
+  cy.request("PUT", "/api/setting/subscription-allowed-domains", {
+    value: domains,
+  });
+}

--- a/frontend/test/metabase/scenarios/sharing/approved-domains.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/approved-domains.cy.spec.js
@@ -32,18 +32,23 @@ describeWithToken("scenarios > alert (EE)", () => {
     cy.findByText(errorMessage);
   });
 
-  it("should validate approved email domains for a dashboard subscription", () => {
+  it("should validate approved email domains for a dashboard subscription (metabase#17977)", () => {
     cy.visit("/dashboard/1");
 
     cy.icon("share").click();
     cy.findByText("Dashboard subscriptions").click();
     cy.findByText("Email it").click();
+
     cy.findByPlaceholderText("Enter user names or email addresses")
       .click()
       .type(`${email}`)
       .blur();
 
     sidebar().within(() => {
+      // Reproduces metabase#17977
+      cy.findByText("Send email now").click();
+      cy.findByText("Sending failed");
+
       cy.button("Done").click();
       cy.findByText(errorMessage);
     });


### PR DESCRIPTION
Add cypress tests for approved domains for both alerts and dashboard subscriptions.

- Reproduces #17977 