### PR TITLE
#9027 Repro: New questions do not appear in 'Saved Questions' until you refresh the browser

### DIFF
--- a/frontend/test/metabase/scenarios/question/reproductions/9027-new-questions-not-in-saved-questions-immediately.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/9027-new-questions-not-in-saved-questions-immediately.cy.spec.js
@@ -1,0 +1,39 @@
+import { restore } from "__support__/e2e/cypress";
+
+const QUESTION_NAME = "Foo";
+
+describe.skip("issue 9027", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.visit("/question/new");
+    cy.findByText("Custom question").click();
+    cy.findByText("Saved Questions").click();
+
+    // Wait for the existing questions to load
+    cy.findByText("Orders");
+
+    cy.icon("sql").click();
+
+    cy.get(".ace_content").type("select 0");
+    cy.get(".NativeQueryEditor .Icon-play").click();
+
+    saveQuestion(QUESTION_NAME);
+  });
+
+  it("should display newly saved question in the 'Saved Questions' list immediately (metabase#9027)", () => {
+    cy.findByText("Ask a question").click();
+    cy.findByText("Custom question").click();
+    cy.findByText("Saved Questions").click();
+
+    cy.findByText(QUESTION_NAME);
+  });
+});
+
+function saveQuestion(name) {
+  cy.findByText("Save").click();
+  cy.findByLabelText("Name").type(name);
+  cy.button("Save").click();
+  cy.button("Not now").click();
+}


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #9027 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/question/reproductions/9027-new-questions-not-in-saved-questions-immediately.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/134957902-91b7f1b7-6bfb-40dd-9db9-d18632b649ae.png)

