### PR TITLE
#18021 Repro: "Recents" list in search should display the Verified badge

### DIFF
--- a/frontend/test/metabase/scenarios/moderation/reproductions/18021-verified-badge-not-visible-in-recents.cy.spec.js
+++ b/frontend/test/metabase/scenarios/moderation/reproductions/18021-verified-badge-not-visible-in-recents.cy.spec.js
@@ -1,0 +1,30 @@
+import { restore, describeWithToken } from "__support__/e2e/cypress";
+
+describeWithToken.skip("issue 18021", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.request("POST", "/api/moderation-review", {
+      status: "verified",
+      moderated_item_id: 1,
+      moderated_item_type: "card",
+    });
+
+    cy.visit("/question/1");
+
+    cy.findByTestId("saved-question-header-button").find(".Icon-verified");
+  });
+
+  it("should show verified badge in the 'Recently viewed' list (metabase#18021)", () => {
+    cy.findByPlaceholderText("Search…").click();
+
+    cy.findByText("Recently viewed")
+      .parent()
+      .within(() => {
+        cy.findByText("Orders")
+          .closest("a")
+          .find(".Icon-verified");
+      });
+  });
+});

--- a/frontend/test/metabase/scenarios/moderation/reproductions/18021-verified-badge-not-visible-in-recents.cy.spec.js
+++ b/frontend/test/metabase/scenarios/moderation/reproductions/18021-verified-badge-not-visible-in-recents.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, describeWithToken } from "__support__/e2e/cypress";
+import { restore } from "__support__/e2e/cypress";
 
 describe.skip("issue 18021", () => {
   beforeEach(() => {

--- a/frontend/test/metabase/scenarios/moderation/reproductions/18021-verified-badge-not-visible-in-recents.cy.spec.js
+++ b/frontend/test/metabase/scenarios/moderation/reproductions/18021-verified-badge-not-visible-in-recents.cy.spec.js
@@ -1,7 +1,10 @@
 import { restore, describeWithToken } from "__support__/e2e/cypress";
 
-describeWithToken.skip("issue 18021", () => {
+describe.skip("issue 18021", () => {
   beforeEach(() => {
+    // Run the test only for EE version
+    cy.onlyOn(!!Cypress.env("HAS_ENTERPRISE_TOKEN"));
+
     restore();
     cy.signInAsAdmin();
 


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #18021 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/moderation/reproductions/18021-verified-badge-not-visible-in-recents.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/134975984-69a8f85d-0e14-4445-b1ce-45c7b7850dfd.png)

