### PR TITLE
Simplify LoadingSpinner animation in reduced motion

### DIFF
--- a/frontend/src/metabase/components/LoadingSpinner.css
+++ b/frontend/src/metabase/components/LoadingSpinner.css
@@ -11,6 +11,12 @@
     cubic-bezier(0.785, 0.135, 0.15, 0.86);
 }
 
+@media (prefers-reduced-motion) {
+  .LoadingSpinner {
+    animation: none;
+  }
+}
+
 .LoadingSpinner:after {
   content: "";
 


### PR DESCRIPTION
One more step to implement issue #17726 

## How to Test

In your OS, enable "reduced motion".

In macOS, this is accomplished by going to the **Settings app › Accessibility › Display › Reduce Motion**.

(Interestingly, the browser will react to toggling that in real-time, with the page already loaded.)

Spinners should not be animated if reduce motion is on.

If it's hard to get a spinner long enough onscreen, I suggest manually adding an early return of `<LoadingSpinner />` in the `LoadingAndErrorWrapper` component, then visiting, say, a dashboard page.