### PR TITLE
CI to show dependency analysis result on PR

### DIFF
--- a/.github/workflows/pr-deps.yml
+++ b/.github/workflows/pr-deps.yml
@@ -1,0 +1,44 @@
+name: Source dependency analysis
+
+on:
+  pull_request:
+    types: [opened, synchronize, edited, reopened]
+    paths:
+    - 'frontend/**'
+    - 'shared/**'
+    - 'enterprise/frontend/**'
+    - '**/package.json'
+    - '**/yarn.lock'
+    - '**/.eslintrc'
+    - '.github/workflows/**'
+
+jobs:
+
+  analyze-deps:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Prepare Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: 14.x
+    - name: Get yarn cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/yarn
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+    - run: yarn install --frozen-lockfile --prefer-offline
+
+    - name: Get the base branch
+      run: git fetch origin master
+
+    - name: List changed source files
+      run: git diff origin/master..HEAD --name-only
+
+    - name: Find other source files potentially affected directly
+      run: git diff origin/master..HEAD --name-only | node frontend/parse-deps.js filter-dependents
+
+    - name: Find ALL other source files potentially affected INdirectly
+      run: git diff origin/master..HEAD --name-only | node frontend/parse-deps.js filter-all-dependents


### PR DESCRIPTION
This is to utilize the front-end dependency analyzer in PR #17743.

When there is a PR that touches any front-end code, the diff is being collected and fed into the the dependency analyzer.

* [x] Get the diff
* [x] Find potentially affected source files, directly and indirectly
* [ ] Post the analysis result as a PR comment

The action workflow will look like this:

![image](https://user-images.githubusercontent.com/7288/135015464-d9168ebc-0b87-4503-9543-cd888578c0fd.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/18085)
<!-- Reviewable:end -->
