### PR TITLE
Rename NODE_ENV to WEBPACK_BUNDLE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ARG MB_EDITION=oss
 WORKDIR /home/circleci
 
 COPY --chown=circleci . .
-RUN NODE_ENV=production MB_EDITION=$MB_EDITION yarn --frozen-lockfile && \
+RUN WEBPACK_BUNDLE=production MB_EDITION=$MB_EDITION yarn --frozen-lockfile && \
     yarn build && yarn build-static-viz && bin/i18n/build-translation-resources
 
 ###################

--- a/bin/build-mb/src/build.clj
+++ b/bin/build-mb/src/build.clj
@@ -28,30 +28,20 @@
             (u/announce "CI run: enforce the lockfile")
             (u/sh {:dir u/project-root-directory} "yarn" "--frozen-lockfile"))
           (u/sh {:dir u/project-root-directory} "yarn")))
-      ;; TODO -- I don't know why it doesn't work if we try to combine the two steps below by calling `yarn build`,
-      ;; which does the same thing.
-      (u/step "Build frontend (ClojureScript)"
+      (u/step "Build frontend"
         (u/sh {:dir u/project-root-directory
                :env {"PATH"       (env/env :path)
                      "HOME"       (env/env :user-home)
-                     "NODE_ENV"   "production"
+                     "WEBPACK_BUNDLE"   "production"
                      "MB_EDITION" mb-edition}}
-              "./node_modules/.bin/shadow-cljs" "release" "app"))
-      (u/step "Run 'webpack' with NODE_ENV=production to assemble and minify frontend assets"
-        (u/sh {:dir u/project-root-directory
-               :env {"PATH"       (env/env :path)
-                     "HOME"       (env/env :user-home)
-                     "NODE_ENV"   "production"
-                     "MB_EDITION" mb-edition}}
-              "./node_modules/.bin/webpack" "--bail"))
-      ;; related to the above TODO -- not sure why `yarn build-static-viz` fails here
+              "yarn" "build"))
       (u/step "Build static viz"
         (u/sh {:dir u/project-root-directory
                :env {"PATH"       (env/env :path)
                      "HOME"       (env/env :user-home)
-                     "NODE_ENV"   "production"
+                     "WEBPACK_BUNDLE"   "production"
                      "MB_EDITION" mb-edition}}
-              "./node_modules/.bin/webpack" "--bail" "--config" "webpack.static-viz.config.js"))
+              "yarn" "build-static-viz"))
       (u/announce "Frontend built successfully."))))
 
 (defn- build-licenses!

--- a/frontend/src/metabase/env.js
+++ b/frontend/src/metabase/env.js
@@ -1,4 +1,4 @@
 export const isCypressActive = !!window.Cypress;
 
 // eslint-disable-next-line no-undef
-export const isProduction = process.env.NODE_ENV === "production";
+export const isProduction = process.env.WEBPACK_BUNDLE === "production";

--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
     "test-timezones": "yarn && ./frontend/test/__runner__/run_timezone_tests",
     "build:js": "yarn && webpack --bail",
     "build-watch:js": "yarn && webpack --watch",
-    "build-hot:js": "yarn && NODE_ENV=hot webpack serve --progress --host 0.0.0.0",
+    "build-hot:js": "yarn && WEBPACK_BUNDLE=hot webpack serve --progress --host 0.0.0.0",
     "build:cljs": "yarn && rm -rf frontend/src/cljs/* && shadow-cljs release app",
     "build-quick:cljs": "yarn build:cljs",
     "build-watch:cljs": "yarn cljs-server-restart && shadow-cljs watch app",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,9 +23,9 @@ const CLJS_SRC_PATH = __dirname + "/frontend/src/cljs";
 const TEST_SUPPORT_PATH = __dirname + "/frontend/test/__support__";
 const BUILD_PATH = __dirname + "/resources/frontend_client";
 
-// default NODE_ENV to development
-const NODE_ENV = process.env.NODE_ENV || "development";
-const devMode = NODE_ENV !== "production";
+// default WEBPACK_BUNDLE to development
+const WEBPACK_BUNDLE = process.env.WEBPACK_BUNDLE || "development";
+const devMode = WEBPACK_BUNDLE !== "production";
 
 // Babel:
 const BABEL_CONFIG = {
@@ -173,7 +173,7 @@ const config = (module.exports = {
   ],
 });
 
-if (NODE_ENV === "hot") {
+if (WEBPACK_BUNDLE === "hot") {
   config.target = "web";
   // suffixing with ".hot" allows us to run both `yarn run build-hot` and `yarn run test` or `yarn run test-watch` simultaneously
   config.output.filename = "[name].hot.bundle.js?[contenthash]";
@@ -232,7 +232,7 @@ if (NODE_ENV === "hot") {
   );
 }
 
-if (NODE_ENV !== "production") {
+if (WEBPACK_BUNDLE !== "production") {
   // replace minified files with un-minified versions
   for (const name in config.resolve.alias) {
     const minified = config.resolve.alias[name];


### PR DESCRIPTION
NODE_ENV interferes with other tools (e.g. `yarn` won't pull devDependencies). Since what we need is only a flag indicating Webpack to bundle for production vs developement, invent our own env.

This also solves the mystery of unable to call `yarn build` in the build script `bin/build-mb/src/build.clj`.