### PR TITLE
reloading errors table

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/audit_app/containers/QuestionLoadAndDisplay.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/containers/QuestionLoadAndDisplay.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useImperativeHandle } from "react";
 import PropTypes from "prop-types";
 import QuestionResultLoader from "metabase/containers/QuestionResultLoader";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
@@ -9,6 +9,7 @@ const propTypes = {
   keepPreviousWhileLoading: PropTypes.bool,
   reload: PropTypes.bool,
   onLoad: PropTypes.func,
+  reloadRef: PropTypes.shape({ current: PropTypes.func }),
 };
 
 const QuestionLoadAndDisplay = ({
@@ -16,12 +17,15 @@ const QuestionLoadAndDisplay = ({
   keepPreviousWhileLoading,
   reload,
   onLoad,
+  reloadRef,
   ...props
 }) => {
-  const reloadRef = useRef();
+  const reloadFnRef = useRef();
+
+  useImperativeHandle(reloadRef, () => () => reloadFnRef.current?.());
 
   useEffect(() => {
-    reload && reloadRef.current();
+    reload && reloadFnRef.current();
   }, [reload]);
 
   return (
@@ -32,7 +36,7 @@ const QuestionLoadAndDisplay = ({
     >
       {({ loading, error, reload, ...resultProps }) => {
         const shouldShowLoader = loading && resultProps.results == null;
-        reloadRef.current = reload;
+        reloadFnRef.current = reload;
 
         return (
           <LoadingAndErrorWrapper

--- a/enterprise/frontend/src/metabase-enterprise/tools/containers/ErrorOverview.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/tools/containers/ErrorOverview.jsx
@@ -17,6 +17,7 @@ const CARD_ID_COL = 0;
 export default function ErrorOverview(props) {
   const reloadRef = useRef(null);
   // TODO: use isReloading to display a loading overlay
+  // eslint-disable-next-line no-unused-vars
   const [isReloading, setIsReloading] = useState(false);
   const [hasResults, setHasResults] = useState(false);
   const [sorting, setSorting] = useState({


### PR DESCRIPTION
Replace `location.reload();` with calling reload function for reloading questions errors table. The goal is not to reload the entire page and keep selected items