### PR TITLE
Refactor query builder sidebar 

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -24,7 +24,7 @@ import QueryModals from "../QueryModals";
 import { ViewTitleHeader, ViewSubHeader } from "./ViewHeader";
 import NewQuestionHeader from "./NewQuestionHeader";
 import ViewFooter from "./ViewFooter";
-import ViewSidebar from "./ViewSidebar/ViewSidebar";
+import ViewSidebar from "./ViewSidebar";
 import QuestionDataSelector from "./QuestionDataSelector";
 
 import ChartSettingsSidebar from "./sidebars/ChartSettingsSidebar";
@@ -257,7 +257,7 @@ export default class View extends React.Component {
               </Motion>
             )}
 
-            <ViewSidebar left isOpen={!!leftSideBar}>
+            <ViewSidebar side="left" isOpen={!!leftSideBar}>
               {leftSideBar}
             </ViewSidebar>
 
@@ -302,7 +302,7 @@ export default class View extends React.Component {
               <ViewFooter {...this.props} className="flex-no-shrink" />
             </div>
 
-            <ViewSidebar right isOpen={!!rightSideBar}>
+            <ViewSidebar side="right" isOpen={!!rightSideBar}>
               {rightSideBar}
             </ViewSidebar>
           </div>

--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -24,7 +24,7 @@ import QueryModals from "../QueryModals";
 import { ViewTitleHeader, ViewSubHeader } from "./ViewHeader";
 import NewQuestionHeader from "./NewQuestionHeader";
 import ViewFooter from "./ViewFooter";
-import ViewSidebar from "./ViewSidebar";
+import ViewSidebar from "./ViewSidebar/ViewSidebar";
 import QuestionDataSelector from "./QuestionDataSelector";
 
 import ChartSettingsSidebar from "./sidebars/ChartSettingsSidebar";

--- a/frontend/src/metabase/query_builder/components/view/ViewSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewSidebar.jsx
@@ -1,34 +1,22 @@
-/* eslint-disable react/prop-types */
 import React from "react";
-// import cx from "classnames";
-// import { Motion, spring } from "react-motion";
+import PropTypes from "prop-types";
 
-import { ViewSideBarAside, ViewSidebarContent } from "./ViewSidebar.styled";
+import { ViewSidebarAside, ViewSidebarContent } from "./ViewSidebar.styled";
 
-// const SPRING_CONFIG = { stiffness: 200, damping: 26 };
-
-const ViewSideBar = ({ left, right, width = 355, isOpen, children }) => (
-  <ViewSideBarAside left={left} right={right} width={width} isOpen={isOpen}>
-    <ViewSidebarContent>{children}</ViewSidebarContent>
-  </ViewSideBarAside>
+const ViewSidebar = ({ left, right, width = 355, isOpen, children }) => (
+  // If we passed `width` as prop, it would end up in the final HTML elements.
+  // This would ruin the animation, so we pass it as `widthProp`.
+  <ViewSidebarAside left={left} right={right} widthProp={width} isOpen={isOpen}>
+    <ViewSidebarContent widthProp={width}>{children}</ViewSidebarContent>
+  </ViewSidebarAside>
 );
 
-export default ViewSideBar;
+ViewSidebar.propTypes = {
+  left: PropTypes.bool,
+  right: PropTypes.bool,
+  width: PropTypes.number,
+  isOpen: PropTypes.bool,
+  children: PropTypes.node,
+};
 
-// <Motion
-//   defaultStyle={{ opacity: 0, width: 0 }}
-//   style={
-//     isOpen
-//       ? { opacity: spring(1), width: spring(width, SPRING_CONFIG) }
-//       : { opacity: spring(0), width: spring(0, SPRING_CONFIG) }
-//   }
-// >
-// {motionStyle => (
-// <aside
-//   data-testid={right ? "sidebar-right" : "sidebar-left"}
-//   className={cx("scroll-y bg-white relative overflow-x-hidden", {
-//     "border-right": left,
-//     "border-left": right,
-//   })}
-//   style={motionStyle}
-// >
+export default ViewSidebar;

--- a/frontend/src/metabase/query_builder/components/view/ViewSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewSidebar.jsx
@@ -1,41 +1,34 @@
 /* eslint-disable react/prop-types */
 import React from "react";
-import cx from "classnames";
-import { Motion, spring } from "react-motion";
+// import cx from "classnames";
+// import { Motion, spring } from "react-motion";
 
-const SPRING_CONFIG = { stiffness: 200, damping: 26 };
+import { ViewSideBarAside, ViewSidebarContent } from "./ViewSidebar.styled";
+
+// const SPRING_CONFIG = { stiffness: 200, damping: 26 };
 
 const ViewSideBar = ({ left, right, width = 355, isOpen, children }) => (
-  <Motion
-    defaultStyle={{ opacity: 0, width: 0 }}
-    style={
-      isOpen
-        ? { opacity: spring(1), width: spring(width, SPRING_CONFIG) }
-        : { opacity: spring(0), width: spring(0, SPRING_CONFIG) }
-    }
-  >
-    {motionStyle => (
-      <aside
-        data-testid={right ? "sidebar-right" : "sidebar-left"}
-        className={cx("scroll-y bg-white relative overflow-x-hidden", {
-          "border-right": left,
-          "border-left": right,
-        })}
-        style={motionStyle}
-      >
-        <div
-          className="absolute top bottom"
-          style={{
-            width: width,
-            right: left ? 0 : undefined,
-            left: right ? 0 : undefined,
-          }}
-        >
-          {children}
-        </div>
-      </aside>
-    )}
-  </Motion>
+  <ViewSideBarAside left={left} right={right} width={width} isOpen={isOpen}>
+    <ViewSidebarContent>{children}</ViewSidebarContent>
+  </ViewSideBarAside>
 );
 
 export default ViewSideBar;
+
+// <Motion
+//   defaultStyle={{ opacity: 0, width: 0 }}
+//   style={
+//     isOpen
+//       ? { opacity: spring(1), width: spring(width, SPRING_CONFIG) }
+//       : { opacity: spring(0), width: spring(0, SPRING_CONFIG) }
+//   }
+// >
+// {motionStyle => (
+// <aside
+//   data-testid={right ? "sidebar-right" : "sidebar-left"}
+//   className={cx("scroll-y bg-white relative overflow-x-hidden", {
+//     "border-right": left,
+//     "border-left": right,
+//   })}
+//   style={motionStyle}
+// >

--- a/frontend/src/metabase/query_builder/components/view/ViewSidebar.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewSidebar.styled.jsx
@@ -1,38 +1,49 @@
 import styled, { css } from "styled-components";
 
-export const ViewSideBarAside = styled.aside`
-  background: white;
-  height: 100%;
+export const ViewSidebarAside = styled.aside`
   overflow-x: hidden;
   overflow-y: auto;
-  position: absolute;
-  width: 355px;
+  opacity: 0;
+  position: relative;
+  transition: width .3s, opacity .3s;
+  width: 0;
+
+  @media (prefers-reduced-motion) {
+    transition: none;
+  }
+
 
   ${({ left }) =>
     left &&
     css`
+      border-right: 1px solid #f0f0f0;
       left: 0;
     `}
 
   ${({ right }) =>
     right &&
     css`
+      border-left: 1px solid #f0f0f0;
       right: 0;
     `}
 
-  ${({ width }) =>
+  ${({ isOpen, widthProp: width }) =>
+    isOpen &&
     width &&
     css`
+      opacity: 1;
       width: ${width}px;
     `}
-
 `;
 
 export const ViewSidebarContent = styled.div`
   position: absolute;
-  width: 355px;
-  left: 0;
-  right: 0;
-  top: 0;
-  bottom: 0;
+  height: 100%;
+  width: 100%;
+
+  ${({ widthProp: width }) =>
+    width &&
+    css`
+      width: ${width}px;
+    `}
 `;

--- a/frontend/src/metabase/query_builder/components/view/ViewSidebar.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewSidebar.styled.jsx
@@ -1,0 +1,38 @@
+import styled, { css } from "styled-components";
+
+export const ViewSideBarAside = styled.aside`
+  background: white;
+  height: 100%;
+  overflow-x: hidden;
+  overflow-y: auto;
+  position: absolute;
+  width: 355px;
+
+  ${({ left }) =>
+    left &&
+    css`
+      left: 0;
+    `}
+
+  ${({ right }) =>
+    right &&
+    css`
+      right: 0;
+    `}
+
+  ${({ width }) =>
+    width &&
+    css`
+      width: ${width}px;
+    `}
+
+`;
+
+export const ViewSidebarContent = styled.div`
+  position: absolute;
+  width: 355px;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+`;

--- a/frontend/src/metabase/query_builder/components/view/ViewSidebar/ViewSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewSidebar/ViewSidebar.jsx
@@ -6,7 +6,13 @@ import { ViewSidebarAside, ViewSidebarContent } from "./ViewSidebar.styled";
 const ViewSidebar = ({ left, right, width = 355, isOpen, children }) => (
   // If we passed `width` as prop, it would end up in the final HTML elements.
   // This would ruin the animation, so we pass it as `widthProp`.
-  <ViewSidebarAside left={left} right={right} widthProp={width} isOpen={isOpen}>
+  <ViewSidebarAside
+    data-testid={right ? "sidebar-right" : "sidebar-left"}
+    left={left}
+    right={right}
+    widthProp={width}
+    isOpen={isOpen}
+  >
     <ViewSidebarContent widthProp={width}>{children}</ViewSidebarContent>
   </ViewSidebarAside>
 );

--- a/frontend/src/metabase/query_builder/components/view/ViewSidebar/ViewSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewSidebar/ViewSidebar.jsx
@@ -3,13 +3,12 @@ import PropTypes from "prop-types";
 
 import { ViewSidebarAside, ViewSidebarContent } from "./ViewSidebar.styled";
 
-const ViewSidebar = ({ left, right, width = 355, isOpen, children }) => (
+const ViewSidebar = ({ side = "right", width = 355, isOpen, children }) => (
   // If we passed `width` as prop, it would end up in the final HTML elements.
   // This would ruin the animation, so we pass it as `widthProp`.
   <ViewSidebarAside
-    data-testid={right ? "sidebar-right" : "sidebar-left"}
-    left={left}
-    right={right}
+    data-testid={`sidebar-${side}`}
+    side={side}
     widthProp={width}
     isOpen={isOpen}
   >
@@ -22,6 +21,7 @@ ViewSidebar.propTypes = {
   right: PropTypes.bool,
   width: PropTypes.number,
   isOpen: PropTypes.bool,
+  side: PropTypes.oneOf[("left", "right")],
   children: PropTypes.node,
 };
 

--- a/frontend/src/metabase/query_builder/components/view/ViewSidebar/ViewSidebar.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewSidebar/ViewSidebar.styled.jsx
@@ -12,7 +12,6 @@ export const ViewSidebarAside = styled.aside`
     transition: none;
   }
 
-
   ${({ left }) =>
     left &&
     css`
@@ -40,10 +39,4 @@ export const ViewSidebarContent = styled.div`
   position: absolute;
   height: 100%;
   width: 100%;
-
-  ${({ widthProp: width }) =>
-    width &&
-    css`
-      width: ${width}px;
-    `}
 `;

--- a/frontend/src/metabase/query_builder/components/view/ViewSidebar/ViewSidebar.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewSidebar/ViewSidebar.styled.jsx
@@ -7,22 +7,19 @@ export const ViewSidebarAside = styled.aside`
   overflow-y: auto;
   opacity: 0;
   position: relative;
-  transition: width .3s, opacity .3s;
+  transition: width 0.3s, opacity 0.3s;
   width: 0;
 
-  ${({ left }) =>
-    left &&
-    css`
-      border-right: 1px solid ${color("border")};
-      left: 0;
-    `}
-
-  ${({ right }) =>
-    right &&
-    css`
-      border-left: 1px solid ${color("border")};
-      right: 0;
-    `}
+  ${({ side }) =>
+    side === "left"
+      ? css`
+          border-right: 1px solid ${color("border")};
+          left: 0;
+        `
+      : css`
+          border-left: 1px solid ${color("border")};
+          right: 0;
+        `}
 
   ${({ isOpen, widthProp: width }) =>
     isOpen &&

--- a/frontend/src/metabase/query_builder/components/view/ViewSidebar/ViewSidebar.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewSidebar/ViewSidebar.styled.jsx
@@ -1,5 +1,7 @@
 import styled, { css } from "styled-components";
 
+import { color } from "metabase/lib/colors";
+
 export const ViewSidebarAside = styled.aside`
   overflow-x: hidden;
   overflow-y: auto;
@@ -11,14 +13,14 @@ export const ViewSidebarAside = styled.aside`
   ${({ left }) =>
     left &&
     css`
-      border-right: 1px solid #f0f0f0;
+      border-right: 1px solid ${color("border")};
       left: 0;
     `}
 
   ${({ right }) =>
     right &&
     css`
-      border-left: 1px solid #f0f0f0;
+      border-left: 1px solid ${color("border")};
       right: 0;
     `}
 

--- a/frontend/src/metabase/query_builder/components/view/ViewSidebar/ViewSidebar.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewSidebar/ViewSidebar.styled.jsx
@@ -8,10 +8,6 @@ export const ViewSidebarAside = styled.aside`
   transition: width .3s, opacity .3s;
   width: 0;
 
-  @media (prefers-reduced-motion) {
-    transition: none;
-  }
-
   ${({ left }) =>
     left &&
     css`

--- a/frontend/src/metabase/query_builder/components/view/ViewSidebar/index.js
+++ b/frontend/src/metabase/query_builder/components/view/ViewSidebar/index.js
@@ -1,0 +1,1 @@
+export { default } from "./ViewSidebar";

--- a/frontend/test/metabase/scenarios/question/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/settings.cy.spec.js
@@ -26,7 +26,7 @@ describe("scenarios > question > settings", () => {
       cy.contains("Settings").click();
 
       // wait for settings sidebar to open
-      cy.get(".border-right.overflow-x-hidden")
+      cy.findByTestId("sidebar-left")
         .invoke("width")
         .should("be.gt", 350);
 

--- a/frontend/test/metabase/scenarios/visualizations/maps.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/maps.cy.spec.js
@@ -83,8 +83,8 @@ describe("scenarios > visualizations > maps", () => {
     cy.get("@vizButton").find(".Icon-pinmap");
     cy.get("@vizButton").click();
     cy.findByText("Choose a visualization");
-    // Sidebar should really have a distinct class name
-    cy.get(".scroll-y .scroll-y").as("vizSidebar");
+
+    cy.findByTestId("sidebar-left").as("vizSidebar");
 
     cy.get("@vizSidebar").within(() => {
       // There should be a unique class for "selected" viz type


### PR DESCRIPTION
In preparation to add one more step to implement issue #17726 

The ViewSidebar component used a lib for the animation, probably due to a lack of familiarity with CSS. And adding new checks in the implementation file just to conditionally remove the animation would make the unclear code more confusing. It was trivial enough to rewrite.

Improves on issue https://github.com/metabase/metabase/issues/16704 as it makes the number of flickers go down to 1.

## How to Test

1. Ask a Question
2. Simple question
3. Sample dataset
4. Orders
5. Click on
  a. Visualization
  b. Settings
  c. Filter
  d. Summarize
  
 Sidebars should function just as before.