### PR TITLE
Do not truncate X labels in timeseries charts

### DIFF
--- a/frontend/src/metabase/static-viz/components/TimeSeriesBarChart/TimeSeriesBarChart.jsx
+++ b/frontend/src/metabase/static-viz/components/TimeSeriesBarChart/TimeSeriesBarChart.jsx
@@ -4,7 +4,6 @@ import { AxisBottom, AxisLeft } from "@visx/axis";
 import { GridRows } from "@visx/grid";
 import { scaleBand, scaleLinear } from "@visx/scale";
 import { Bar } from "@visx/shape";
-import { Text } from "@visx/text";
 import {
   getXTickLabelProps,
   getYTickLabelProps,
@@ -12,7 +11,6 @@ import {
 } from "../../lib/axes";
 import { formatDate } from "../../lib/dates";
 import { formatNumber } from "../../lib/numbers";
-import { truncateText } from "../../lib/text";
 
 const propTypes = {
   data: PropTypes.array.isRequired,
@@ -87,13 +85,6 @@ const TimeSeriesBarChart = ({ data, accessors, settings, labels }) => {
     return { x, y, width, height, fill: layout.colors.brand };
   };
 
-  const getXTickProps = ({ formattedValue, ...props }) => {
-    const textWidth = xScale.bandwidth();
-    const truncatedText = truncateText(formattedValue, textWidth);
-
-    return { ...props, children: truncatedText };
-  };
-
   return (
     <svg width={layout.width} height={layout.height}>
       <GridRows
@@ -123,7 +114,6 @@ const TimeSeriesBarChart = ({ data, accessors, settings, labels }) => {
         stroke={layout.colors.textLight}
         tickStroke={layout.colors.textLight}
         tickFormat={value => formatDate(value, settings?.x)}
-        tickComponent={props => <Text {...getXTickProps(props)} />}
         tickLabelProps={() => getXTickLabelProps(layout)}
       />
     </svg>


### PR DESCRIPTION
Do not truncate X labels in timeseries charts as the labels are approximate and spawn for multiple bars.