### PR TITLE
Check feature flag on backend /graph PUT API for block permission

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/enhancements/models/permissions/block_permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/enhancements/models/permissions/block_permissions_test.clj
@@ -88,7 +88,9 @@
 (deftest update-graph-test
   (testing "Should be able to set block permissions with"
     (doseq [[description grant!] {"the graph update function"
-                                  grant-block-perms!
+                                  (fn [group-id]
+                                    (premium-features-test/with-premium-features #{:advanced-permissions}
+                                      (grant-block-perms! group-id)))
 
                                   "the perms graph API endpoint"
                                   api-grant-block-perms!}]
@@ -113,7 +115,7 @@
 
 (deftest update-graph-delete-sandboxes-test
   (testing "When setting `:block` permissions any GTAP rows for that Group/Database should get deleted."
-    (premium-features-test/with-premium-features #{:sandboxes}
+    (premium-features-test/with-premium-features #{:sandboxes :advanced-permissions}
       (mt/with-model-cleanup [Permissions]
         (mt/with-temp* [PermissionsGroup       [{group-id :id}]
                         GroupTableAccessPolicy [_ {:table_id (mt/id :venues)

--- a/enterprise/backend/test/metabase_enterprise/enhancements/models/permissions/block_permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/enhancements/models/permissions/block_permissions_test.clj
@@ -81,7 +81,7 @@
         (let [current-graph (perms/data-perms-graph)
               new-graph     (assoc-in current-graph [:groups group-id (mt/id)] {:schemas :block})
               result        (premium-features-test/with-premium-features #{} ; disable premium features
-                              (mt/user-http-request :crowberto :put 403 "permissions/graph" new-graph))]
+                              (mt/user-http-request :crowberto :put 402 "permissions/graph" new-graph))]
           (is (= "Can't use block permissions without having the advanced-permissions premium feature"
                  result)))))))
 

--- a/src/metabase/api/permissions.clj
+++ b/src/metabase/api/permissions.clj
@@ -1,7 +1,6 @@
 (ns metabase.api.permissions
   "/api/permissions endpoints."
   (:require [clojure.spec.alpha :as spec]
-            [clojure.walk :as walk]
             [compojure.core :refer [DELETE GET POST PUT]]
             [honeysql.helpers :as hh]
             [metabase.api.common :as api]
@@ -10,7 +9,6 @@
             [metabase.models.permissions :as perms]
             [metabase.models.permissions-group :as group :refer [PermissionsGroup]]
             [metabase.models.permissions-group-membership :refer [PermissionsGroupMembership]]
-            [metabase.public-settings.premium-features :as premium-features]
             [metabase.server.middleware.offset-paging :as offset-paging]
             [metabase.util :as u]
             [metabase.util.i18n :refer [tru]]
@@ -48,16 +46,6 @@
                            (spec/explain-str ::pg/data-permissions-graph body))
                       {:status-code 400
                        :error       (spec/explain-data ::pg/data-permissions-graph body)})))
-
-    (let [has-block-perms? (atom false)]
-      (walk/postwalk (fn [x]
-                       (if (and (map? x) (= (:schemas x) :block))
-                         (do (reset! has-block-perms? true)
-                             nil)
-                         x)) graph)
-      (when (and @has-block-perms? (not (premium-features/has-feature? :advanced-permissions)))
-        (throw (ex-info (tru "Can''t use block permissions without having the advanced-permissions premium feature")
-                        {:status-code 403}))))
     (perms/update-data-perms-graph! graph))
   (perms/data-perms-graph))
 

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -181,6 +181,7 @@
             [metabase.models.permissions.delete-sandboxes :as delete-sandboxes]
             [metabase.models.permissions.parse :as perms-parse]
             [metabase.plugins.classloader :as classloader]
+            [metabase.public-settings.premium-features :as premium-features]
             [metabase.util :as u]
             [metabase.util.honeysql-extensions :as hx]
             [metabase.util.i18n :as ui18n :refer [deferred-tru trs tru]]
@@ -859,6 +860,11 @@
                  (delete-block-perms-for-this-db!))
         ;; TODO -- should this code be enterprise only?
         :block (do
+                 (when-not (premium-features/has-feature? :advanced-permissions)
+                   (throw
+                    (ex-info
+                     (tru "Can''t use block permissions without having the advanced-permissions premium feature")
+                     {:status-code 402})))
                  (revoke-data-perms! group-id db-id)
                  (grant-permissions! group-id (database-block-perms-path db-id)))
         (when (map? schemas)


### PR DESCRIPTION
Check for the `:advanced-permissions` flag in API handler, when a `:schemas` `:block` entry is present in the graph

Set feature flag in tests when using API

Add new test to ensure failure in the case that feature flag is missing
