### PR TITLE
Unskip repro for markdown in dashboard subscriptions

### DIFF
--- a/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
@@ -237,7 +237,7 @@ describe("scenarios > dashboard > subscriptions", () => {
       });
     });
 
-    it.skip("should include text cards (metabase#15744)", () => {
+    it("should include text cards (metabase#15744)", () => {
       const TEXT_CARD = "FooBar";
 
       cy.visit("/dashboard/1");


### PR DESCRIPTION
Closes out #15744 which was already resolved by #17781