### PR TITLE
Wait qa db metadata load

### DIFF
--- a/frontend/test/__support__/e2e/helpers/e2e-qa-databases-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-qa-databases-helpers.js
@@ -72,8 +72,8 @@ function assertOnDatabaseMetadata(engine) {
 }
 
 function recursiveCheck(id, i = 0) {
-  // Let's not wait more than 500ms for the sync to finish
-  if (i === 5) {
+  // Let's not wait more than 1s for the sync to finish
+  if (i === 10) {
     throw new Error();
   }
 

--- a/frontend/test/__support__/e2e/helpers/e2e-qa-databases-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-qa-databases-helpers.js
@@ -58,10 +58,38 @@ function addQADatabase(engine, db_display_name, port) {
   });
 
   // Make sure we have all the metadata because we'll need to use it in tests
-  cy.request("POST", "/api/database/2/sync_schema").then(({ status }) => {
-    expect(status).to.equal(200);
+  assertOnDatabaseMetadata(engine);
+}
+
+function assertOnDatabaseMetadata(engine) {
+  cy.request("GET", "/api/database").then(({ body }) => {
+    const { id } = body.data.find(db => {
+      return db.engine === engine;
+    });
+
+    recursiveCheck(id);
   });
-  cy.request("POST", "/api/database/2/rescan_values").then(({ status }) => {
-    expect(status).to.equal(200);
-  });
+}
+
+function recursiveCheck(id, i = 0) {
+  // Let's not wait more than 500ms for the sync to finish
+  if (i === 5) {
+    throw new Error();
+  }
+
+  cy.wait(100);
+
+  cy.request("GET", `/api/database/${id}/metadata`).then(
+    ({ body: { tables } }) => {
+      if (tables.length !== 4) {
+        recursiveCheck(id, ++i);
+      }
+
+      tables.forEach(({ fields }) => {
+        if (fields.length === 0) {
+          recursiveCheck(id, ++i);
+        }
+      });
+    },
+  );
 }

--- a/frontend/test/__support__/e2e/helpers/e2e-qa-databases-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-qa-databases-helpers.js
@@ -72,8 +72,8 @@ function assertOnDatabaseMetadata(engine) {
 }
 
 function recursiveCheck(id, i = 0) {
-  // Let's not wait more than 1s for the sync to finish
-  if (i === 10) {
+  // Let's not wait more than 2s for the sync to finish
+  if (i === 20) {
     throw new Error();
   }
 


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
Adds a way to programmatically wait for the sync to finish and metadata to load when adding [QA DBs](https://github.com/metabase/metabase-qa) in Cypress, instead of manually triggering the sync and then immediately rescan of the values (which wasn't too reliable in the past).

Upon adding a certain database, we're "pinging" a certain endpoint and making sure it contains 4 tables (because we're using Sample Dataset in all cases). Additionally, we're making sure `tables.fields` are not empty.

After all the fields are populated, we're sure we can continue with the test.
This is important especially for the scenario where we want to take an app db snapshot (which is going to be the topic for one of the future PRs).

### Note
Mongo takes a bit longer to sync. In the [original commit](https://github.com/metabase/metabase/pull/18116/commits/0826b7ff1db8250fa63745beebac183994b5ea20), it timed out after 500ms. [Increasing the timeout](https://github.com/metabase/metabase/pull/18116/commits/2ebeab01cbb58bda24c50ae2d98a70a5b451fefc) to 1s is **barely** enough and might fail if Ci is slow. I've [increased it to 2s](https://github.com/metabase/metabase/pull/18116/commits/4e1e8eab461c8e478866036384e2ed16e851d949). That should be plenty, but if we realize Mongo is failing in CI due to the timeout, we can increase this.