### PR TITLE
Enforce allowed domains for "Send email now" button

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/advanced_config/models/pulse_channel_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_config/models/pulse_channel_test.clj
@@ -1,16 +1,17 @@
 (ns metabase-enterprise.advanced-config.models.pulse-channel-test
   (:require [clojure.string :as str]
             [clojure.test :refer :all]
-            [metabase.models :refer [Pulse PulseChannel]]
+            [metabase.models :refer [Card Pulse PulseChannel]]
             [metabase.public-settings.premium-features-test :as premium-features-test]
+            [metabase.pulse :as pulse]
             [metabase.test :as mt]
             [metabase.util :as u]
             [toucan.db :as db]
             [toucan.util.test :as tt]))
 
 (deftest validate-email-domains-test
-  (mt/with-temp Pulse [{pulse-id :id}]
-    (doseq [operation               [:create :update]
+  (mt/with-temp Pulse [temp-pulse]
+    (doseq [operation               [:create :update :send-email-now]
             enable-advanced-config? [true false]
             allowed-domains         [nil
                                      #{"metabase.com"}
@@ -36,11 +37,27 @@
                           :create
                           #(db/insert! PulseChannel
                              (merge (tt/with-temp-defaults PulseChannel)
-                                    {:pulse_id pulse-id, :details {:emails emails}}))
+                                    {:pulse_id (u/the-id temp-pulse), :details {:emails emails}}))
 
                           :update
-                          #(mt/with-temp PulseChannel [{pulse-channel-id :id} {:pulse_id pulse-id}]
-                             (db/update! PulseChannel pulse-channel-id, :details {:emails emails})))]
+                          #(mt/with-temp PulseChannel [{pulse-channel-id :id} {:pulse_id (u/the-id temp-pulse)}]
+                             (db/update! PulseChannel pulse-channel-id, :details {:emails emails}))
+
+                          :send-email-now
+                          ;; "Send email now" uses actual card(s), but then has temp instances of the Pulse and
+                          ;; PulseChannel (which will have :recipients filled in, not :details as for saved channels
+                          ;; in other cases); each recipient in this case is just a map from :email to the email addr
+                          ;; so this should simulate the same UI flow that happens for "Send email now"
+                          #(mt/with-temp Card [card]
+                             (let [temp-pc (assoc (tt/with-temp-defaults PulseChannel)
+                                             :channel_type :email
+                                             :recipients   (map (fn [email] {:email email}) emails)
+                                             :enabled      true)
+                                   temp-p  (assoc (tt/with-temp-defaults Pulse)
+                                             :channels [temp-pc]
+                                             :cards    [card])]
+                               (pulse/send-pulse! temp-p) ; will throw exception on disallowed domains
+                               true)))] ; return non-nil for assertion purposes, if no exception was thrown
               (if fail?
                 (testing "should fail"
                   (is (thrown-with-msg?

--- a/src/metabase/models/pulse_channel.clj
+++ b/src/metabase/models/pulse_channel.clj
@@ -140,14 +140,17 @@
         (resolve 'metabase-enterprise.advanced-config.models.pulse-channel/validate-email-domains))
       (constantly nil)))
 
-(defn- validate-email-domains
+(defn validate-email-domains
   "For channels that are being sent to raw email addresses: check that the domains in the emails are allowed by
   the [[metabase-enterprise.advanced-config.models.pulse-channel/subscription-allowed-domains]] Setting, if set. This
   will no-op if `subscription-allowed-domains` is unset or if we do not have a premium token with the
   `:advanced-config` feature."
+  {:added "0.41.0"}
   [{{:keys [emails]} :details, :as pulse-channel}]
-  (u/prog1 pulse-channel
-    (validate-email-domains* emails)))
+  (let [recipient-emails (map :email (:recipients pulse-channel)) ; addresses can also appear under :recipients
+        all-emails       (concat emails recipient-emails)]
+    (u/prog1 pulse-channel
+      (validate-email-domains* all-emails))))
 
 (u/strict-extend (class PulseChannel)
   models/IModel

--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -11,6 +11,7 @@
             [metabase.models.dashboard-card :refer [DashboardCard]]
             [metabase.models.database :refer [Database]]
             [metabase.models.pulse :as pulse :refer [Pulse]]
+            [metabase.models.pulse-channel :as pulse-channel]
             [metabase.plugins.classloader :as classloader]
             [metabase.pulse.interface :as i]
             [metabase.pulse.markdown :as markdown]
@@ -399,4 +400,7 @@
                   ;; to fetch the Pulse.
                   pulse/hydrate-notification
                   (merge (when channel-ids {:channel-ids channel-ids})))]
+    ;; validate all email domains in the pulse channels before sending, in case this is a "Send email now" kind of test
+    (doseq [channel (:channels pulse)]
+      (pulse-channel/validate-email-domains channel))
     (send-notifications! (pulse->notifications pulse))))


### PR DESCRIPTION
Make `validate-email-domains` under `metabase.models.pulse-channel` public, so it can be called from `metabase.pulse`

Update `validate-email-domains` to also check the addresses under `:recipients` in addition to `:details`

Add new case to the existing `validate-email-domains-test` to confirm the "Send email now" case throws the exception correctly