### PR TITLE
Don't compress content when opening sidebar in Question page

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/ViewSidebar/ViewSidebar.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewSidebar/ViewSidebar.styled.jsx
@@ -33,5 +33,10 @@ export const ViewSidebarAside = styled.aside`
 export const ViewSidebarContent = styled.div`
   position: absolute;
   height: 100%;
-  width: 100%;
+
+  ${({ widthProp: width }) =>
+    width &&
+    css`
+      width: ${width}px;
+    `}
 `;


### PR DESCRIPTION
A little tweak to the animation of the refactored sidebar (see #18098)

## How to Test

1. Ask a Question
2. Simple question
3. Sample dataset
4. Orders
5. Visualization (bottom left)

### Before

As animation starts, buttons in sidebar are initially narrower than in final width ("squished")

### After

As animation starts, buttons in sidebar are in final width.