### PR TITLE
Show hidden tables in perms graph page

### DIFF
--- a/frontend/src/metabase/admin/permissions/pages/DataPermissionsPage/DataPermissionsPage.jsx
+++ b/frontend/src/metabase/admin/permissions/pages/DataPermissionsPage/DataPermissionsPage.jsx
@@ -71,7 +71,9 @@ function DataPermissionsPage({
 DataPermissionsPage.propTypes = propTypes;
 
 export default _.compose(
-  Databases.loadList({ entityQuery: { include: "tables" } }),
+  Databases.loadList({
+    entityQuery: { include: "tables", include_hidden: "true" },
+  }),
   Groups.loadList(),
   connect(
     mapStateToProps,

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -6,7 +6,6 @@
             [medley.core :as m]
             [metabase.api.common :as api]
             [metabase.api.table :as table-api]
-            [metabase.config :as config]
             [metabase.driver :as driver]
             [metabase.driver.util :as driver.u]
             [metabase.events :as events]
@@ -198,34 +197,14 @@
 
   * `include=tables` means we should hydrate the Tables belonging to each DB. Default: `false`.
 
-  * `saved` means we should include the saved questions virtual database. Default: `false`.
-
-  * `include_tables` is a legacy alias for `include=tables`, but should be considered deprecated as of 0.35.0, and will
-    be removed in a future release.
-
-  * `include_cards` here means we should also include virtual Table entries for saved Questions, e.g. so we can easily
-    use them as source Tables in queries. This is a deprecated alias for `saved=true` + `include=tables` (for the saved
-    questions virtual DB). Prefer using `include` and `saved` instead. "
-  [include_tables include_cards include saved]
-  {include_tables (s/maybe su/BooleanString)
-   include_cards  (s/maybe su/BooleanString)
-   include        FetchAllIncludeValues
+  * `saved` means we should include the saved questions virtual database. Default: `false`."
+  [include saved]
+  {include        FetchAllIncludeValues
    saved          (s/maybe su/BooleanString)}
-  (when (and config/is-dev?
-             (or include_tables include_cards))
-    ;; don't need to i18n since this is dev-facing only
-    (log/warn "GET /api/database?include_tables and ?include_cards are deprecated."
-              "Prefer using ?include=tables and ?saved=true instead."))
-  (let [include-tables?                 (cond
-                                          (seq include)        (= include "tables")
-                                          (seq include_tables) (Boolean/parseBoolean include_tables))
-        include-saved-questions-db?     (cond
-                                          (seq saved)         (Boolean/parseBoolean saved)
-                                          (seq include_cards) (Boolean/parseBoolean include_cards))
-        include-saved-questions-tables? (when include-saved-questions-db?
-                                          (if (seq include_cards)
-                                            true
-                                            include-tables?))
+  (let [include-tables?                 (= include "tables")
+        include-saved-questions-db?     (when (seq saved) (Boolean/parseBoolean saved))
+        include-saved-questions-tables? (and include-tables?
+                                             include-saved-questions-db?)
         db-list-res                     (or (dbs-list :include-tables?                  include-tables?
                                                       :include-saved-questions-db?      include-saved-questions-db?
                                                       :include-saved-questions-tables?  include-saved-questions-tables?)

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -366,16 +366,12 @@
                         Database [{db-id-3 :id} {:engine ::test-driver}]]
           (is (< 1 (count (:data (mt/user-http-request :rasta :get 200 "database" :limit 1 :offset 0))))))))
 
-
-    ;; ?include=tables and ?include_tables=true mean the same thing so test them both the same way
-    (doseq [query-param ["?include_tables=true"
-                         "?include=tables"]]
-      (testing query-param
-        (mt/with-temp Database [{db-id :id, db-name :name} {:engine (u/qualified-name ::test-driver)}]
-          (doseq [db (:data (mt/user-http-request :rasta :get 200 (str "database" query-param)))]
-            (testing (format "Database %s %d %s" (:engine db) (u/the-id db) (pr-str (:name db)))
-              (is (= (expected-tables db)
-                     (:tables db))))))))))
+    (testing "?include=tables"
+      (mt/with-temp Database [{db-id :id, db-name :name} {:engine (u/qualified-name ::test-driver)}]
+        (doseq [db (:data (mt/user-http-request :rasta :get 200 "database?include=tables"))]
+          (testing (format "Database %s %d %s" (:engine db) (u/the-id db) (pr-str (:name db)))
+            (is (= (expected-tables db)
+                   (:tables db)))))))))
 
 (deftest databases-list-include-saved-questions-test
   (testing "GET /api/database?saved=true"
@@ -435,99 +431,96 @@
         (is (not (contains? response-tables table)))))))
 
 (deftest databases-list-include-saved-questions-tables-test
-  ;; `?saved=true&include=tables` and `?include_cards=true` mean the same thing, so test them both
-  (doseq [params ["?saved=true&include=tables"
-                  "?include_cards=true"]]
-    (testing (str "GET /api/database" params)
-      (letfn [(fetch-virtual-database []
-                (some #(when (= (:name %) "Saved Questions")
-                         %)
-                      (:data (mt/user-http-request :crowberto :get 200 (str "database" params)))))]
-        (testing "Check that we get back 'virtual' tables for Saved Questions"
-          (testing "The saved questions virtual DB should be the last DB in the list"
-            (mt/with-temp Card [card (card-with-native-query "Kanye West Quote Views Per Month")]
+  (testing "GET /api/database?saved=true&include=tables"
+    (letfn [(fetch-virtual-database []
+              (some #(when (= (:name %) "Saved Questions")
+                       %)
+                    (:data (mt/user-http-request :crowberto :get 200 "database?saved=true&include=tables"))))]
+      (testing "Check that we get back 'virtual' tables for Saved Questions"
+        (testing "The saved questions virtual DB should be the last DB in the list"
+          (mt/with-temp Card [card (card-with-native-query "Kanye West Quote Views Per Month")]
+            ;; run the Card which will populate its result_metadata column
+            (mt/user-http-request :crowberto :post 202 (format "card/%d/query" (u/the-id card)))
+            ;; Now fetch the database list. The 'Saved Questions' DB should be last on the list
+            (let [response (last (:data (mt/user-http-request :crowberto :get 200 "database?saved=true&include=tables")))]
+              (is (schema= SavedQuestionsDB
+                           response))
+              (check-tables-included response (virtual-table-for-card card)))))
+
+        (testing "Make sure saved questions are NOT included if the setting is disabled"
+          (mt/with-temp Card [card (card-with-native-query "Kanye West Quote Views Per Month")]
+            (mt/with-temporary-setting-values [enable-nested-queries false]
               ;; run the Card which will populate its result_metadata column
               (mt/user-http-request :crowberto :post 202 (format "card/%d/query" (u/the-id card)))
-              ;; Now fetch the database list. The 'Saved Questions' DB should be last on the list
-              (let [response (last (:data (mt/user-http-request :crowberto :get 200 (str "database" params))))]
-                (is (schema= SavedQuestionsDB
-                             response))
-                (check-tables-included response (virtual-table-for-card card)))))
+              ;; Now fetch the database list. The 'Saved Questions' DB should NOT be in the list
+              (is (= nil
+                     (fetch-virtual-database)))))))
 
-          (testing "Make sure saved questions are NOT included if the setting is disabled"
-            (mt/with-temp Card [card (card-with-native-query "Kanye West Quote Views Per Month")]
-              (mt/with-temporary-setting-values [enable-nested-queries false]
-                ;; run the Card which will populate its result_metadata column
-                (mt/user-http-request :crowberto :post 202 (format "card/%d/query" (u/the-id card)))
-                ;; Now fetch the database list. The 'Saved Questions' DB should NOT be in the list
-                (is (= nil
-                       (fetch-virtual-database)))))))
+      (testing "should pretend Collections are schemas"
+        (mt/with-temp* [Collection [stamp-collection {:name "Stamps"}]
+                        Collection [coin-collection  {:name "Coins"}]
+                        Card       [stamp-card (card-with-native-query "Total Stamp Count", :collection_id (u/the-id stamp-collection))]
+                        Card       [coin-card  (card-with-native-query "Total Coin Count",  :collection_id (u/the-id coin-collection))]]
+          ;; run the Cards which will populate their result_metadata columns
+          (doseq [card [stamp-card coin-card]]
+            (mt/user-http-request :crowberto :post 202 (format "card/%d/query" (u/the-id card))))
+          ;; Now fetch the database list. The 'Saved Questions' DB should be last on the list. Cards should have their
+          ;; Collection name as their Schema
+          (let [response (last (:data (mt/user-http-request :crowberto :get 200 "database?saved=true&include=tables")))]
+            (is (schema= SavedQuestionsDB
+                         response))
+            (check-tables-included
+             response
+             (virtual-table-for-card coin-card :schema "Coins")
+             (virtual-table-for-card stamp-card :schema "Stamps")))))
 
-        (testing "should pretend Collections are schemas"
-          (mt/with-temp* [Collection [stamp-collection {:name "Stamps"}]
-                          Collection [coin-collection  {:name "Coins"}]
-                          Card       [stamp-card (card-with-native-query "Total Stamp Count", :collection_id (u/the-id stamp-collection))]
-                          Card       [coin-card  (card-with-native-query "Total Coin Count",  :collection_id (u/the-id coin-collection))]]
-            ;; run the Cards which will populate their result_metadata columns
-            (doseq [card [stamp-card coin-card]]
-              (mt/user-http-request :crowberto :post 202 (format "card/%d/query" (u/the-id card))))
-            ;; Now fetch the database list. The 'Saved Questions' DB should be last on the list. Cards should have their
-            ;; Collection name as their Schema
-            (let [response (last (:data (mt/user-http-request :crowberto :get 200 (str "database" params))))]
-              (is (schema= SavedQuestionsDB
-                           response))
-              (check-tables-included
-               response
-               (virtual-table-for-card coin-card :schema "Coins")
-               (virtual-table-for-card stamp-card :schema "Stamps")))))
+      (testing "should remove Cards that have ambiguous columns"
+        (mt/with-temp* [Card [ok-card         (assoc (card-with-native-query "OK Card")         :result_metadata [{:name "cam"}])]
+                        Card [cambiguous-card (assoc (card-with-native-query "Cambiguous Card") :result_metadata [{:name "cam"} {:name "cam_2"}])]]
+          (let [response (fetch-virtual-database)]
+            (is (schema= SavedQuestionsDB
+                         response))
+            (check-tables-included response (virtual-table-for-card ok-card))
+            (check-tables-not-included response (virtual-table-for-card cambiguous-card)))))
 
-        (testing "should remove Cards that have ambiguous columns"
-          (mt/with-temp* [Card [ok-card         (assoc (card-with-native-query "OK Card")         :result_metadata [{:name "cam"}])]
-                          Card [cambiguous-card (assoc (card-with-native-query "Cambiguous Card") :result_metadata [{:name "cam"} {:name "cam_2"}])]]
-            (let [response (fetch-virtual-database)]
-              (is (schema= SavedQuestionsDB
-                           response))
-              (check-tables-included response (virtual-table-for-card ok-card))
-              (check-tables-not-included response (virtual-table-for-card cambiguous-card)))))
+      (testing "should remove Cards that belong to a driver that doesn't support nested queries"
+        (mt/with-temp* [Database [bad-db   {:engine ::no-nested-query-support, :details {}}]
+                        Card     [bad-card {:name            "Bad Card"
+                                            :dataset_query   {:database (u/the-id bad-db)
+                                                              :type     :native
+                                                              :native   {:query "[QUERY GOES HERE]"}}
+                                            :result_metadata [{:name "sparrows"}]
+                                            :database_id     (u/the-id bad-db)}]
+                        Card     [ok-card  (assoc (card-with-native-query "OK Card")
+                                                  :result_metadata [{:name "finches"}])]]
+          (let [response (fetch-virtual-database)]
+            (is (schema= SavedQuestionsDB
+                         response))
+            (check-tables-included response (virtual-table-for-card ok-card))
+            (check-tables-not-included response (virtual-table-for-card bad-card)))))
 
-        (testing "should remove Cards that belong to a driver that doesn't support nested queries"
-          (mt/with-temp* [Database [bad-db   {:engine ::no-nested-query-support, :details {}}]
-                          Card     [bad-card {:name            "Bad Card"
-                                              :dataset_query   {:database (u/the-id bad-db)
-                                                                :type     :native
-                                                                :native   {:query "[QUERY GOES HERE]"}}
-                                              :result_metadata [{:name "sparrows"}]
-                                              :database_id     (u/the-id bad-db)}]
-                          Card     [ok-card  (assoc (card-with-native-query "OK Card")
-                                                    :result_metadata [{:name "finches"}])]]
-            (let [response (fetch-virtual-database)]
-              (is (schema= SavedQuestionsDB
-                           response))
-              (check-tables-included response (virtual-table-for-card ok-card))
-              (check-tables-not-included response (virtual-table-for-card bad-card)))))
+      (testing "should work when there are no DBs that support nested queries"
+        (with-redefs [metabase.driver/supports? (constantly false)]
+          (is (nil? (fetch-virtual-database)))))
 
-        (testing "should work when there are no DBs that support nested queries"
-          (with-redefs [metabase.driver/supports? (constantly false)]
-            (is (nil? (fetch-virtual-database)))))
+      (testing "should work when there are no DBs that support nested queries"
+        (with-redefs [metabase.driver/supports? (constantly false)]
+          (is (nil? (fetch-virtual-database)))))
 
-        (testing "should work when there are no DBs that support nested queries"
-          (with-redefs [metabase.driver/supports? (constantly false)]
-            (is (nil? (fetch-virtual-database)))))
-
-        (testing "should remove Cards that use cumulative-sum and cumulative-count aggregations"
-          (mt/with-temp* [Card [ok-card  (ok-mbql-card)]
-                          Card [bad-card (merge
-                                          (mt/$ids checkins
-                                            (card-with-mbql-query "Cum Count Card"
-                                              :source-table $$checkins
-                                              :aggregation  [[:cum-count]]
-                                              :breakout     [!month.date]))
-                                          {:result_metadata [{:name "num_toucans"}]})]]
-            (let [response (fetch-virtual-database)]
-              (is (schema= SavedQuestionsDB
-                           response))
-              (check-tables-included response (virtual-table-for-card ok-card))
-              (check-tables-not-included response (virtual-table-for-card bad-card)))))))))
+      (testing "should remove Cards that use cumulative-sum and cumulative-count aggregations"
+        (mt/with-temp* [Card [ok-card  (ok-mbql-card)]
+                        Card [bad-card (merge
+                                        (mt/$ids checkins
+                                          (card-with-mbql-query "Cum Count Card"
+                                            :source-table $$checkins
+                                            :aggregation  [[:cum-count]]
+                                            :breakout     [!month.date]))
+                                        {:result_metadata [{:name "num_toucans"}]})]]
+          (let [response (fetch-virtual-database)]
+            (is (schema= SavedQuestionsDB
+                         response))
+            (check-tables-included response (virtual-table-for-card ok-card))
+            (check-tables-not-included response (virtual-table-for-card bad-card))))))))
 
 (deftest db-metadata-saved-questions-db-test
   (testing "GET /api/database/:id/metadata works for the Saved Questions 'virtual' database"


### PR DESCRIPTION
Fixes #17777

Added support for `GET /api/database?include_hidden=true` and updated the relevant FE code to use it. There is some other code in the FE somewhere that's filtering out the hidden Tables, and I'm not sure how to make that stop yet... might need some FE help with that.