### PR TITLE
Restyle the Verify button

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationActions/ModerationActions.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationActions/ModerationActions.jsx
@@ -4,8 +4,7 @@ import { t } from "ttag";
 
 import { isItemVerified } from "metabase-enterprise/moderation/service";
 
-import { Container, Label, VerifyButton } from "./ModerationActions.styled";
-import Tooltip from "metabase/components/Tooltip";
+import { Container, VerifyButton } from "./ModerationActions.styled";
 
 export default ModerationActions;
 

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationActions/ModerationActions.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationActions/ModerationActions.jsx
@@ -21,14 +21,10 @@ function ModerationActions({ moderationReview, className, onVerify }) {
 
   return hasActions ? (
     <Container className={className}>
-      <Label>{t`Moderation`}</Label>
       {!isVerified && (
-        <Tooltip tooltip={t`Verify this`}>
-          <VerifyButton
-            data-testid="moderation-verify-action"
-            onClick={onVerify}
-          />
-        </Tooltip>
+        <VerifyButton data-testid="moderation-verify-action" onClick={onVerify}>
+          {t`Verify this question`}
+        </VerifyButton>
       )}
     </Container>
   ) : null;

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationActions/ModerationActions.styled.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationActions/ModerationActions.styled.jsx
@@ -30,6 +30,8 @@ export const VerifyButton = styled(Button).attrs({
 })`
   border: none;
 
+  padding: 8px;
+
   &:hover {
     color: ${color(verifiedIconColor)};
   }

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationActions/ModerationActions.styled.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationActions/ModerationActions.styled.jsx
@@ -29,12 +29,8 @@ export const VerifyButton = styled(Button).attrs({
   iconSize: 20,
 })`
   border: none;
-
+  color: ${color(verifiedIconColor)};
   padding: 8px;
-
-  &:hover {
-    color: ${color(verifiedIconColor)};
-  }
 
   &:disabled {
     color: ${color("text-medium")};

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebarPanel.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebarPanel.jsx
@@ -38,7 +38,7 @@ function QuestionDetailsSidebarPanel({
       <SidebarPaddedContent>
         <QuestionActionButtons canWrite={canWrite} onOpenModal={onOpenModal} />
         <ClampedDescription
-          className="pb2"
+          className="pl1 pb2"
           visibleLines={8}
           description={description}
           onEdit={onDescriptionEdit}


### PR DESCRIPTION
After looking at it for a while now, the whole "moderation" section in the sidebar feels silly to me with its one button. It doesn't feel intentional, and it doesn't feel especially clear that the checkmark is a button; it kind of feels like a section heading without any content.

So in this PR I've restyled things to make the Verify action look more clearly like a button. If and when we ever build out the rest of this section (flagging as wrong, etc.), we can restyle this, but I just want to make sure that if Verify is the only action here for a while, that it looks right by itself.

## Before
<img width="667" alt="Screen Shot 2021-09-29 at 2 55 01 PM" src="https://user-images.githubusercontent.com/2223916/135364858-f74a42c3-f725-42ea-9581-c58235cd51b3.png">

## After
![image](https://user-images.githubusercontent.com/2223916/136076829-f1b673ef-69cd-4b75-b6b1-5e1351608ad4.png)
