### PR TITLE
Make temporal fields selectable for max/min summary

### DIFF
--- a/frontend/src/metabase-lib/lib/metadata/Field.js
+++ b/frontend/src/metabase-lib/lib/metadata/Field.js
@@ -16,7 +16,7 @@ import {
   isBoolean,
   isString,
   isSummable,
-  isLimit,
+  isScope,
   isCategory,
   isAddress,
   isCity,
@@ -121,8 +121,8 @@ export default class Field extends Base {
   isSummable() {
     return isSummable(this);
   }
-  isLimit() {
-    return isLimit(this);
+  isScope() {
+    return isScope(this);
   }
   isCategory() {
     return isCategory(this);

--- a/frontend/src/metabase-lib/lib/metadata/Field.js
+++ b/frontend/src/metabase-lib/lib/metadata/Field.js
@@ -16,6 +16,7 @@ import {
   isBoolean,
   isString,
   isSummable,
+  isLimit,
   isCategory,
   isAddress,
   isCity,
@@ -119,6 +120,9 @@ export default class Field extends Base {
   }
   isSummable() {
     return isSummable(this);
+  }
+  isLimit() {
+    return isLimit(this);
   }
   isCategory() {
     return isCategory(this);

--- a/frontend/src/metabase/lib/schema_metadata.js
+++ b/frontend/src/metabase/lib/schema_metadata.js
@@ -21,7 +21,7 @@ export const PRIMARY_KEY = "PRIMARY_KEY";
 // other types used for various purporses
 export const ENTITY = "ENTITY";
 export const SUMMABLE = "SUMMABLE";
-export const LIMIT = "LIMIT";
+export const SCOPE = "SCOPE";
 export const CATEGORY = "CATEGORY";
 export const DIMENSION = "DIMENSION";
 
@@ -72,7 +72,7 @@ const TYPES = {
     include: [NUMBER],
     exclude: [ENTITY, LOCATION, TEMPORAL],
   },
-  [LIMIT]: {
+  [SCOPE]: {
     include: [NUMBER, TEMPORAL],
     exclude: [ENTITY, LOCATION],
   },
@@ -152,7 +152,7 @@ export const isNumeric = isFieldType.bind(null, NUMBER);
 export const isBoolean = isFieldType.bind(null, BOOLEAN);
 export const isString = isFieldType.bind(null, STRING);
 export const isSummable = isFieldType.bind(null, SUMMABLE);
-export const isLimit = isFieldType.bind(null, LIMIT);
+export const isScope = isFieldType.bind(null, SCOPE);
 export const isCategory = isFieldType.bind(null, CATEGORY);
 export const isLocation = isFieldType.bind(null, LOCATION);
 
@@ -584,8 +584,8 @@ function summableFields(fields) {
   return _.filter(fields, isSummable);
 }
 
-function limitFields(fields) {
-  return _.filter(fields, isLimit);
+function scopeFields(fields) {
+  return _.filter(fields, isScope);
 }
 
 const AGGREGATION_OPERATORS = [
@@ -666,7 +666,7 @@ const AGGREGATION_OPERATORS = [
     name: t`Minimum of ...`,
     columnName: t`Min`,
     description: t`Minimum value of a column`,
-    validFieldsFilters: [limitFields],
+    validFieldsFilters: [scopeFields],
     requiresField: true,
     requiredDriverFeature: "basic-aggregations",
   },
@@ -675,7 +675,7 @@ const AGGREGATION_OPERATORS = [
     name: t`Maximum of ...`,
     columnName: t`Max`,
     description: t`Maximum value of a column`,
-    validFieldsFilters: [limitFields],
+    validFieldsFilters: [scopeFields],
     requiresField: true,
     requiredDriverFeature: "basic-aggregations",
   },

--- a/frontend/src/metabase/lib/schema_metadata.js
+++ b/frontend/src/metabase/lib/schema_metadata.js
@@ -21,6 +21,7 @@ export const PRIMARY_KEY = "PRIMARY_KEY";
 // other types used for various purporses
 export const ENTITY = "ENTITY";
 export const SUMMABLE = "SUMMABLE";
+export const LIMIT = "LIMIT";
 export const CATEGORY = "CATEGORY";
 export const DIMENSION = "DIMENSION";
 
@@ -70,6 +71,10 @@ const TYPES = {
   [SUMMABLE]: {
     include: [NUMBER],
     exclude: [ENTITY, LOCATION, TEMPORAL],
+  },
+  [LIMIT]: {
+    include: [NUMBER, TEMPORAL],
+    exclude: [ENTITY, LOCATION],
   },
   [CATEGORY]: {
     base: [TYPE.Boolean],
@@ -147,6 +152,7 @@ export const isNumeric = isFieldType.bind(null, NUMBER);
 export const isBoolean = isFieldType.bind(null, BOOLEAN);
 export const isString = isFieldType.bind(null, STRING);
 export const isSummable = isFieldType.bind(null, SUMMABLE);
+export const isLimit = isFieldType.bind(null, LIMIT);
 export const isCategory = isFieldType.bind(null, CATEGORY);
 export const isLocation = isFieldType.bind(null, LOCATION);
 
@@ -578,6 +584,10 @@ function summableFields(fields) {
   return _.filter(fields, isSummable);
 }
 
+function limitFields(fields) {
+  return _.filter(fields, isLimit);
+}
+
 const AGGREGATION_OPERATORS = [
   {
     // DEPRECATED: "rows" is equivalent to no aggregations
@@ -656,7 +666,7 @@ const AGGREGATION_OPERATORS = [
     name: t`Minimum of ...`,
     columnName: t`Min`,
     description: t`Minimum value of a column`,
-    validFieldsFilters: [summableFields],
+    validFieldsFilters: [limitFields],
     requiresField: true,
     requiredDriverFeature: "basic-aggregations",
   },
@@ -665,7 +675,7 @@ const AGGREGATION_OPERATORS = [
     name: t`Maximum of ...`,
     columnName: t`Max`,
     description: t`Maximum value of a column`,
-    validFieldsFilters: [summableFields],
+    validFieldsFilters: [limitFields],
     requiresField: true,
     requiredDriverFeature: "basic-aggregations",
   },

--- a/frontend/test/metabase/scenarios/question/reproductions/4482-temporal-min-max.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/4482-temporal-min-max.cy.spec.js
@@ -2,6 +2,8 @@ import { restore } from "__support__/e2e/cypress";
 
 describe("issue 4482", () => {
   beforeEach(() => {
+    cy.intercept("POST", "/api/dataset").as("dataset");
+
     restore();
     cy.signInAsAdmin();
   });
@@ -20,6 +22,8 @@ describe("issue 4482", () => {
     cy.contains("Created At").click();
 
     cy.button("Visualize").click();
+    cy.wait("@dataset");
+    cy.findByText("April 1, 2016, 12:00 AM");
   });
 
   it("should be possible to summarize max of a temporal column (metabase#6239)", () => {
@@ -36,6 +40,8 @@ describe("issue 4482", () => {
     cy.contains("Created At").click();
 
     cy.button("Visualize").click();
+    cy.wait("@dataset");
+    cy.findByText("April 1, 2019, 12:00 AM");
   });
 
   it("should be not possible to average a temporal column (metabase#6239)", () => {

--- a/frontend/test/metabase/scenarios/question/reproductions/4482-temporal-min-max.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/4482-temporal-min-max.cy.spec.js
@@ -1,0 +1,54 @@
+import { restore } from "__support__/e2e/cypress";
+
+describe("issue 4482", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should be possible to summarize min of a temporal column (metabase#6239)", () => {
+    cy.visit("/question/new");
+    cy.contains("Custom question").click();
+    cy.contains("Sample Dataset").click();
+    cy.contains("Products").click();
+
+    cy.contains("Pick the metric").click();
+
+    cy.contains("Minimum of").click();
+    cy.findByText("Price");
+    cy.findByText("Rating");
+    cy.contains("Created At").click();
+
+    cy.button("Visualize").click();
+  });
+
+  it("should be possible to summarize max of a temporal column (metabase#6239)", () => {
+    cy.visit("/question/new");
+    cy.contains("Custom question").click();
+    cy.contains("Sample Dataset").click();
+    cy.contains("Products").click();
+
+    cy.contains("Pick the metric").click();
+
+    cy.contains("Maximum of").click();
+    cy.findByText("Price");
+    cy.findByText("Rating");
+    cy.contains("Created At").click();
+
+    cy.button("Visualize").click();
+  });
+
+  it("should be not possible to average a temporal column (metabase#6239)", () => {
+    cy.visit("/question/new");
+    cy.contains("Custom question").click();
+    cy.contains("Sample Dataset").click();
+    cy.contains("Products").click();
+
+    cy.contains("Pick the metric").click();
+
+    cy.contains("Average of").click();
+    cy.findByText("Price");
+    cy.findByText("Rating");
+    cy.findByText("Created At").should("not.exist");
+  });
+});


### PR DESCRIPTION
This is achieved by having a new type of field called `LIMIT` (if anyone has a better name, I'm all ears), which includes `NUMBER` and `TEMPORAL` and changing the function `min` and `max` to operate on `LIMIT`, instead of `SUMMABLE` (which is more suitable for e.g. `avg`).

New Cypress tests were added.

**To verify manually**

1. Ask a question, Custom question.
2. Sample Dataset, Products table.
3. Summarize: Pick the metric and choose _Minimum of..._.

**Before this PR**

The choices are _only_ Price and Rating.

![image](https://user-images.githubusercontent.com/7288/135370365-456f098e-b7a5-46dd-8f17-de273e9c6d48.png)


**After this PR**

The choices are Price, Rating, and Created At.

![image](https://user-images.githubusercontent.com/7288/135370164-290e0da7-76e5-4fd2-a6be-1c52e3eeb297.png)