### PR TITLE
Fix mongodb driver to support date range (hours and minutes) queries

### DIFF
--- a/modules/drivers/mongo/src/metabase/driver/mongo/parameters.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/parameters.clj
@@ -49,7 +49,8 @@
 
     ;; convert temporal types to ISODate("2019-12-09T...") (etc.)
     (instance? Temporal x)
-    (format "ISODate(\"%s\")" (u.date/format x))
+    (let [d (u.date/format x)]
+      (format "ISODate(\"%s\")" (if (str/includes? d "T") (str d "Z") d)))
 
     ;; there's a special record type for sequences of numbers; pull the sequence it wraps out and recur
     (instance? CommaSeparatedNumbers x)


### PR DESCRIPTION
This is a dirty fix for #15945. It's missing a 'Z' at the end of the string when hour and minute are present so the BSON parser is happy.

I'm new to clojure, so forgive me if it's not the best way to implement this. I'm too newbie to write new tests, sorry :grimacing: but current ones are working.

Closes #15945

### Tests

- [X] Run the frontend and Cypress end-to-end tests with `yarn lint && yarn test`)
- [X] If there are changes to the backend codebase, run the backend tests with `clojure -X:dev:test`
- [X] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
      (unless it's a tiny documentation change).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/18137)
<!-- Reviewable:end -->
