### PR TITLE
Do not emit view logs when there's no card id for query viewlogs (fixes #18136)

### DIFF
--- a/src/metabase/query_processor/middleware/process_userland_query.clj
+++ b/src/metabase/query_processor/middleware/process_userland_query.clj
@@ -85,7 +85,7 @@
       ([acc]
        (do
          ;; We don't actually have a guarantee that it's from a card just because it's userland
-         (if (integer? (:card_id execution-info))
+         (when (integer? (:card_id execution-info))
            (events/publish-event! :card-query {:card_id      (:card_id execution-info)
                                                :actor_id     (:executor_id execution-info)
                                                :cached       (:cached acc)

--- a/src/metabase/query_processor/middleware/process_userland_query.clj
+++ b/src/metabase/query_processor/middleware/process_userland_query.clj
@@ -84,10 +84,12 @@
 
       ([acc]
        (do
-         (events/publish-event! :card-query {:card_id      (:card_id execution-info)
-                                             :actor_id     (:executor_id execution-info)
-                                             :cached       (:cached acc)
-                                             :ignore_cache (get-in execution-info [:json_query :middleware :ignore-cached-results?])})
+         ;; We don't actually have a guarantee that it's from a card just because it's userland
+         (if (integer? (:card_id execution-info))
+           (events/publish-event! :card-query {:card_id      (:card_id execution-info)
+                                               :actor_id     (:executor_id execution-info)
+                                               :cached       (:cached acc)
+                                               :ignore_cache (get-in execution-info [:json_query :middleware :ignore-cached-results?])}))
          (when-not (:cached acc)
            (save-successful-query-execution! (:cached acc) execution-info @row-count)))
        (rf (if (map? acc)

--- a/test/metabase/query_processor/middleware/process_userland_query_test.clj
+++ b/test/metabase/query_processor/middleware/process_userland_query_test.clj
@@ -6,7 +6,6 @@
             [metabase.query-processor.error-type :as error-type]
             [metabase.query-processor.middleware.process-userland-query :as process-userland-query]
             [metabase.query-processor.util :as qputil]
-            [metabase.models.card :refer [Card]]
             [metabase.test :as mt]))
 
 (defn- do-with-query-execution [query run]


### PR DESCRIPTION
`process_userland_queries` middleware also gets queries which are not card queries. The added in view log functionality from #18046 assumes that all queries that get to that middleware have a card_id. This is etiology of #18136. So this should fix those occurrences by not spitting out the viewlog if there's no card_id. There is also a unit test.