### PR TITLE
Append indexes to duplicate expression names

### DIFF
--- a/frontend/src/metabase-lib/lib/queries/StructuredQuery.js
+++ b/frontend/src/metabase-lib/lib/queries/StructuredQuery.js
@@ -1011,13 +1011,21 @@ export default class StructuredQuery extends AtomicQuery {
   }
 
   updateExpression(name, expression, oldName) {
-    let query = this._updateQuery(Q.updateExpression, arguments);
+    const isRename = oldName && oldName !== name;
+    const uniqueName = isRename
+      ? getUniqueExpressionName(this.expressions(), name)
+      : name;
+    let query = this._updateQuery(Q.updateExpression, [
+      uniqueName,
+      expression,
+      oldName,
+    ]);
     // extra logic for renaming expressions in fields clause
     // TODO: push into query/expression?
-    if (name !== oldName) {
+    if (isRename) {
       const index = query._indexOfField(["expression", oldName]);
       if (index >= 0) {
-        query = query.updateField(index, ["expression", name]);
+        query = query.updateField(index, ["expression", uniqueName]);
       }
     }
     return query;

--- a/frontend/src/metabase-lib/lib/queries/StructuredQuery.js
+++ b/frontend/src/metabase-lib/lib/queries/StructuredQuery.js
@@ -3,6 +3,7 @@
  */
 
 import * as Q from "metabase/lib/query/query";
+import { getUniqueExpressionName } from "metabase/lib/query/expression";
 import {
   format as formatExpression,
   DISPLAY_QUOTES,
@@ -999,11 +1000,12 @@ export default class StructuredQuery extends AtomicQuery {
   }
 
   addExpression(name, expression) {
-    let query = this._updateQuery(Q.addExpression, arguments);
+    const uniqueName = getUniqueExpressionName(this.expressions(), name);
+    let query = this._updateQuery(Q.addExpression, [uniqueName, expression]);
     // extra logic for adding expressions in fields clause
     // TODO: push into query/expression?
     if (query.hasFields() && query.isRaw()) {
-      query = query.addField(["expression", name]);
+      query = query.addField(["expression", uniqueName]);
     }
     return query;
   }

--- a/frontend/src/metabase/lib/query/expression.js
+++ b/frontend/src/metabase/lib/query/expression.js
@@ -76,5 +76,13 @@ export function getUniqueExpressionName(expressions, originalName) {
   const duplicateNames = expressionNames.filter(
     name => name === originalName || handledDuplicateNamePattern.test(name),
   );
-  return `${originalName} (${duplicateNames.length})`;
+  return getUniqueName(duplicateNames, originalName, duplicateNames.length);
+}
+
+function getUniqueName(expressionNames, originalName, index) {
+  const nameWithIndexAppended = `${originalName} (${index})`;
+  const isUnique = !expressionNames.includes(nameWithIndexAppended);
+  return isUnique
+    ? nameWithIndexAppended
+    : getUniqueName(expressionNames, originalName, index + 1);
 }

--- a/frontend/src/metabase/lib/query/expression.js
+++ b/frontend/src/metabase/lib/query/expression.js
@@ -50,3 +50,31 @@ export function clearExpressions(
 ): ?ExpressionClause {
   return {};
 }
+
+/**
+ * Ensures expression's name uniqueness
+ *
+ * Example: if query has a "Double Total" expression,
+ * and we're adding a new "Double Total" expression,
+ * the second expression will be called "Double Total (1)",
+ * the next one will be "Double Total (2)" and so on
+ *
+ * If the original name is already unique, the fn just returns it
+ *
+ * @param {string} originalName - expression's name
+ * @param {object} expressions - object with existing query expressions
+ * @returns {string}
+ */
+export function getUniqueExpressionName(expressions, originalName) {
+  if (!expressions[originalName]) {
+    return originalName;
+  }
+  const expressionNames = Object.keys(expressions);
+  const handledDuplicateNamePattern = new RegExp(
+    `^${originalName} \\([0-9]+\\)$`,
+  );
+  const duplicateNames = expressionNames.filter(
+    name => name === originalName || handledDuplicateNamePattern.test(name),
+  );
+  return `${originalName} (${duplicateNames.length})`;
+}

--- a/frontend/test/__support__/e2e/cypress.js
+++ b/frontend/test/__support__/e2e/cypress.js
@@ -17,6 +17,7 @@ export * from "./helpers/e2e-qa-databases-helpers";
 export * from "./helpers/e2e-ad-hoc-question-helpers";
 export * from "./helpers/e2e-enterprise-helpers";
 export * from "./helpers/e2e-mock-app-settings-helpers";
+export * from "./helpers/e2e-notebook-helpers";
 export * from "./helpers/e2e-assertion-helpers";
 export * from "./helpers/e2e-cloud-helpers";
 export * from "./helpers/e2e-data-model-helpers";

--- a/frontend/test/__support__/e2e/helpers/e2e-notebook-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-notebook-helpers.js
@@ -1,0 +1,13 @@
+/**
+ * Helps to select specific notebook steps like filters, joins, break outs, etc.
+ *
+ * Details:
+ * https://github.com/metabase/metabase/pull/17708#discussion_r700082403
+ *
+ * @param {string} type — notebook step type (filter, join, expression, summarize, etc.)
+ * @param {{stage: number; index: number}} positionConfig - indexes specifying step's position
+ * @returns
+ */
+export function getNotebookStep(type, { stage = 0, index = 0 } = {}) {
+  return cy.findByTestId(`step-${type}-${stage}-${index}`);
+}

--- a/frontend/test/metabase-lib/lib/queries/StructuredQuery-expressions.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/StructuredQuery-expressions.unit.spec.js
@@ -86,6 +86,24 @@ describe("StructuredQuery", () => {
       });
     });
 
+    it("should handle gaps in names with indexes appended", () => {
+      let query = getQuery({
+        expressions: { double_total: TEST_EXPRESSION },
+      });
+
+      query = query
+        .addExpression("double_total", TEST_EXPRESSION)
+        .addExpression("double_total", TEST_EXPRESSION_2)
+        .removeExpression("double_total (1)", TEST_EXPRESSION)
+        .addExpression("double_total", TEST_EXPRESSION);
+
+      expect(query.expressions()).toEqual({
+        double_total: TEST_EXPRESSION,
+        "double_total (2)": TEST_EXPRESSION_2,
+        "double_total (3)": TEST_EXPRESSION,
+      });
+    });
+
     it("should detect duplicate names in case-sensitive way", () => {
       let query = getQuery({
         expressions: { double_total: TEST_EXPRESSION },

--- a/frontend/test/metabase-lib/lib/queries/StructuredQuery-expressions.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/StructuredQuery-expressions.unit.spec.js
@@ -1,12 +1,9 @@
 import { ORDERS, SAMPLE_DATASET } from "__support__/sample_dataset_fixture";
 import Question from "metabase-lib/lib/Question";
 
-const TEST_EXPRESSION = ["*", ["field", ORDERS.TOTAL.id, null], 2];
-const TEST_EXPRESSION_2 = [
-  "-",
-  ["field", ORDERS.TOTAL.id, null],
-  ["field", ORDERS.SUBTOTAL.id, null],
-];
+const TEST_EXPRESSION = ["+", 1, 1];
+const TEST_EXPRESSION_2 = ["+", 2, 2];
+const TEST_EXPRESSION_3 = ["+", 3, 3];
 
 function getQuery({ expressions } = {}) {
   const question = new Question({
@@ -174,6 +171,28 @@ describe("StructuredQuery", () => {
 
       expect(query.expressions()).toEqual({
         "Double Total": TEST_EXPRESSION,
+      });
+    });
+
+    it("should handle duplicate expression names", () => {
+      let query = getQuery({
+        expressions: {
+          double_total: TEST_EXPRESSION,
+          "double_total (1)": TEST_EXPRESSION_2,
+          "double_total (2)": TEST_EXPRESSION_3,
+        },
+      });
+
+      query = query.updateExpression(
+        "double_total",
+        TEST_EXPRESSION_3,
+        "double_total (2)",
+      );
+
+      expect(query.expressions()).toEqual({
+        double_total: TEST_EXPRESSION,
+        "double_total (1)": TEST_EXPRESSION_2,
+        "double_total (3)": TEST_EXPRESSION_3,
       });
     });
   });

--- a/frontend/test/metabase-lib/lib/queries/StructuredQuery-expressions.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/StructuredQuery-expressions.unit.spec.js
@@ -1,17 +1,137 @@
-import { ORDERS } from "__support__/sample_dataset_fixture";
+import { ORDERS, SAMPLE_DATASET } from "__support__/sample_dataset_fixture";
+import Question from "metabase-lib/lib/Question";
 
 const TEST_EXPRESSION = ["*", ["field", ORDERS.TOTAL.id, null], 2];
+const TEST_EXPRESSION_2 = [
+  "-",
+  ["field", ORDERS.TOTAL.id, null],
+  ["field", ORDERS.SUBTOTAL.id, null],
+];
+
+function getQuery({ expressions } = {}) {
+  const question = new Question({
+    dataset_query: {
+      type: "query",
+      database: SAMPLE_DATASET.id,
+      query: {
+        "source-table": ORDERS.id,
+        expressions: expressions,
+      },
+    },
+  });
+  return question.query();
+}
 
 describe("StructuredQuery", () => {
+  describe("expressions", () => {
+    it("should return empty object when there are no expressions", () => {
+      expect(getQuery().expressions()).toEqual({});
+    });
+
+    it("should return expressions object", () => {
+      const query = getQuery({
+        expressions: {
+          double_total: TEST_EXPRESSION,
+          diff: TEST_EXPRESSION_2,
+        },
+      });
+
+      expect(query.expressions()).toEqual({
+        double_total: TEST_EXPRESSION,
+        diff: TEST_EXPRESSION_2,
+      });
+    });
+  });
+
   describe("hasExpressions", () => {
     it("should return false for queries without expressions", () => {
-      const q = ORDERS.query();
-      expect(q.hasExpressions()).toBe(false);
+      const query = getQuery();
+      expect(query.hasExpressions()).toBe(false);
     });
 
     it("should return true for queries with expressions", () => {
-      const q = ORDERS.query().addExpression("double_total", TEST_EXPRESSION);
-      expect(q.hasExpressions()).toBe(true);
+      const query = getQuery({
+        expressions: {
+          double_total: TEST_EXPRESSION,
+        },
+      });
+      expect(query.hasExpressions()).toBe(true);
+    });
+  });
+
+  describe("addExpression", () => {
+    it("should add new expressions correctly", () => {
+      let query = getQuery();
+
+      query = query.addExpression("double_total", TEST_EXPRESSION);
+
+      expect(query.expressions()).toEqual({
+        double_total: TEST_EXPRESSION,
+      });
+    });
+  });
+
+  describe("updateExpression", () => {
+    it("should update expressions correctly", () => {
+      let query = getQuery();
+
+      query = query.addExpression("double_total", TEST_EXPRESSION);
+
+      expect(query.expressions()).toEqual({
+        double_total: TEST_EXPRESSION,
+      });
+    });
+  });
+
+  describe("removeExpression", () => {
+    it("should remove expression correctly", () => {
+      let query = getQuery({
+        expressions: {
+          double_total: TEST_EXPRESSION,
+          diff: TEST_EXPRESSION_2,
+        },
+      });
+
+      query = query.removeExpression("double_total");
+
+      expect(query.expressions()).toEqual({
+        diff: TEST_EXPRESSION_2,
+      });
+    });
+
+    it("should do nothing when removing not existing expression", () => {
+      let query = getQuery({
+        expressions: {
+          double_total: TEST_EXPRESSION,
+        },
+      });
+
+      query = query.removeExpression("this_query_has_no_expression_like_that");
+
+      expect(query.expressions()).toEqual({
+        double_total: TEST_EXPRESSION,
+      });
+    });
+  });
+
+  describe("clearExpressions", () => {
+    it("should remove all existing expressions", () => {
+      let query = getQuery({
+        expressions: {
+          double_total: TEST_EXPRESSION,
+          diff: TEST_EXPRESSION_2,
+        },
+      });
+
+      query = query.clearExpressions();
+
+      expect(query.expressions()).toEqual({});
+    });
+
+    it("should do nothing if there are no expressions", () => {
+      let query = getQuery();
+      query = query.clearExpressions();
+      expect(query.expressions()).toEqual({});
     });
   });
 });

--- a/frontend/test/metabase-lib/lib/queries/StructuredQuery-expressions.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/StructuredQuery-expressions.unit.spec.js
@@ -69,6 +69,61 @@ describe("StructuredQuery", () => {
         double_total: TEST_EXPRESSION,
       });
     });
+
+    it("should append indexes to duplicate names", () => {
+      let query = getQuery({
+        expressions: { double_total: TEST_EXPRESSION },
+      });
+
+      query = query
+        .addExpression("double_total", TEST_EXPRESSION)
+        .addExpression("double_total", TEST_EXPRESSION);
+
+      expect(query.expressions()).toEqual({
+        double_total: TEST_EXPRESSION,
+        "double_total (1)": TEST_EXPRESSION,
+        "double_total (2)": TEST_EXPRESSION,
+      });
+    });
+
+    it("should detect duplicate names in case-sensitive way", () => {
+      let query = getQuery({
+        expressions: { double_total: TEST_EXPRESSION },
+      });
+
+      query = query.addExpression("DOUBLE_TOTAL", TEST_EXPRESSION);
+
+      expect(query.expressions()).toEqual({
+        double_total: TEST_EXPRESSION,
+        DOUBLE_TOTAL: TEST_EXPRESSION,
+      });
+    });
+
+    it("should not append indexes when expression names are similar", () => {
+      let query = getQuery({
+        expressions: { double_total: TEST_EXPRESSION },
+      });
+
+      query = query
+        .addExpression("double_total", TEST_EXPRESSION)
+        .addExpression("double", TEST_EXPRESSION)
+        .addExpression("total", TEST_EXPRESSION)
+        .addExpression("double_total", TEST_EXPRESSION)
+        .addExpression("foo_double_total", TEST_EXPRESSION)
+        .addExpression("double_total_bar", TEST_EXPRESSION)
+        .addExpression("double_total", TEST_EXPRESSION);
+
+      expect(query.expressions()).toEqual({
+        double_total: TEST_EXPRESSION,
+        "double_total (1)": TEST_EXPRESSION,
+        "double_total (2)": TEST_EXPRESSION,
+        "double_total (3)": TEST_EXPRESSION,
+        double: TEST_EXPRESSION,
+        total: TEST_EXPRESSION,
+        foo_double_total: TEST_EXPRESSION,
+        double_total_bar: TEST_EXPRESSION,
+      });
+    });
   });
 
   describe("updateExpression", () => {

--- a/frontend/test/metabase-lib/lib/queries/StructuredQuery-expressions.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/StructuredQuery-expressions.unit.spec.js
@@ -140,6 +140,24 @@ describe("StructuredQuery", () => {
         double_total: TEST_EXPRESSION_2,
       });
     });
+
+    it("should update expression names correctly", () => {
+      let query = getQuery({
+        expressions: {
+          double_total: TEST_EXPRESSION,
+        },
+      });
+
+      query = query.updateExpression(
+        "Double Total",
+        TEST_EXPRESSION,
+        "double_total",
+      );
+
+      expect(query.expressions()).toEqual({
+        "Double Total": TEST_EXPRESSION,
+      });
+    });
   });
 
   describe("removeExpression", () => {

--- a/frontend/test/metabase-lib/lib/queries/StructuredQuery-expressions.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/StructuredQuery-expressions.unit.spec.js
@@ -128,12 +128,16 @@ describe("StructuredQuery", () => {
 
   describe("updateExpression", () => {
     it("should update expressions correctly", () => {
-      let query = getQuery();
+      let query = getQuery({
+        expressions: {
+          double_total: TEST_EXPRESSION,
+        },
+      });
 
-      query = query.addExpression("double_total", TEST_EXPRESSION);
+      query = query.updateExpression("double_total", TEST_EXPRESSION_2);
 
       expect(query.expressions()).toEqual({
-        double_total: TEST_EXPRESSION,
+        double_total: TEST_EXPRESSION_2,
       });
     });
   });

--- a/frontend/test/metabase-lib/lib/queries/StructuredQuery-expressions.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/StructuredQuery-expressions.unit.spec.js
@@ -1,17 +1,16 @@
 import { ORDERS } from "__support__/sample_dataset_fixture";
 
+const TEST_EXPRESSION = ["*", ["field", ORDERS.TOTAL.id, null], 2];
+
 describe("StructuredQuery", () => {
   describe("hasExpressions", () => {
     it("should return false for queries without expressions", () => {
       const q = ORDERS.query();
       expect(q.hasExpressions()).toBe(false);
     });
+
     it("should return true for queries with expressions", () => {
-      const q = ORDERS.query().addExpression("double_total", [
-        "*",
-        ["field", ORDERS.TOTAL.id, null],
-        2,
-      ]);
+      const q = ORDERS.query().addExpression("double_total", TEST_EXPRESSION);
       expect(q.hasExpressions()).toBe(true);
     });
   });

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -133,7 +133,7 @@ describe("scenarios > question > notebook", () => {
     });
   });
 
-  it("should append indexes to duplicate custom expression names", () => {
+  it("should append indexes to duplicate custom expression names (metabase#12104)", () => {
     cy.intercept("POST", "/api/dataset").as("dataset");
     openProductsTable({ mode: "notebook" });
 

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -7,6 +7,7 @@ import {
   modal,
   visitQuestionAdhoc,
   interceptPromise,
+  getNotebookStep,
 } from "__support__/e2e/cypress";
 
 import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
@@ -138,37 +139,19 @@ describe("scenarios > question > notebook", () => {
     openProductsTable({ mode: "notebook" });
 
     cy.findByText("Custom column").click();
-    popover()
-      .findByText("Category")
-      .click();
-    cy.findByPlaceholderText("Something nice and descriptive")
-      .click()
-      .type("EXPR");
-    cy.button("Done").click();
+    addSimpleCustomColumn("EXPR");
 
-    cy.findByTestId("step-expression-0-0").within(() => {
+    getNotebookStep("expression").within(() => {
       cy.icon("add").click();
     });
-    popover()
-      .findByText("Category")
-      .click();
-    cy.findByPlaceholderText("Something nice and descriptive")
-      .click()
-      .type("EXPR");
-    cy.button("Done").click();
+    addSimpleCustomColumn("EXPR");
 
-    cy.findByTestId("step-expression-0-0").within(() => {
+    getNotebookStep("expression").within(() => {
       cy.icon("add").click();
     });
-    popover()
-      .findByText("Category")
-      .click();
-    cy.findByPlaceholderText("Something nice and descriptive")
-      .click()
-      .type("EXPR");
-    cy.button("Done").click();
+    addSimpleCustomColumn("EXPR");
 
-    cy.findByTestId("step-expression-0-0").within(() => {
+    getNotebookStep("expression").within(() => {
       cy.findByText("EXPR");
       cy.findByText("EXPR (1)");
       cy.findByText("EXPR (2)");
@@ -1070,4 +1053,14 @@ function joinTwoSavedQuestions() {
       cy.url().should("contain", "/notebook");
     });
   });
+}
+
+function addSimpleCustomColumn(name) {
+  popover()
+    .findByText("Category")
+    .click();
+  cy.findByPlaceholderText("Something nice and descriptive")
+    .click()
+    .type(name);
+  cy.button("Done").click();
 }

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -133,6 +133,55 @@ describe("scenarios > question > notebook", () => {
     });
   });
 
+  it("should append indexes to duplicate custom expression names", () => {
+    cy.intercept("POST", "/api/dataset").as("dataset");
+    openProductsTable({ mode: "notebook" });
+
+    cy.findByText("Custom column").click();
+    popover()
+      .findByText("Category")
+      .click();
+    cy.findByPlaceholderText("Something nice and descriptive")
+      .click()
+      .type("EXPR");
+    cy.button("Done").click();
+
+    cy.findByTestId("step-expression-0-0").within(() => {
+      cy.icon("add").click();
+    });
+    popover()
+      .findByText("Category")
+      .click();
+    cy.findByPlaceholderText("Something nice and descriptive")
+      .click()
+      .type("EXPR");
+    cy.button("Done").click();
+
+    cy.findByTestId("step-expression-0-0").within(() => {
+      cy.icon("add").click();
+    });
+    popover()
+      .findByText("Category")
+      .click();
+    cy.findByPlaceholderText("Something nice and descriptive")
+      .click()
+      .type("EXPR");
+    cy.button("Done").click();
+
+    cy.findByTestId("step-expression-0-0").within(() => {
+      cy.findByText("EXPR");
+      cy.findByText("EXPR (1)");
+      cy.findByText("EXPR (2)");
+    });
+
+    cy.button("Visualize").click();
+    cy.wait("@dataset");
+
+    cy.findByText("EXPR");
+    cy.findByText("EXPR (1)");
+    cy.findByText("EXPR (2)");
+  });
+
   it("should process the updated expression when pressing Enter", () => {
     openProductsTable({ mode: "notebook" });
     cy.findByText("Filter").click();


### PR DESCRIPTION
Fixes #12104

In the notebook editor, if you have an expression called e.g. `EXP` and you add another expression called `EXP`, it will silently replace the first expression, which can be confusing. This PR changes that behavior, so we append indexes to duplicate names. So if we're adding `EXP` and an `EXP` expression already exists, the new one will be added as `EXP (1)`, `EXP (2)`, etc.

### To Verfy

1. Ask a question > Custom question > Orders
2. Click "Custom column"
3. Add any expression, let's say it's called "EXP", but any name should work
4. Click the plus icon near the "EXP" notebook cell
5. Add any expression and use the same name as from step 3, repeat it a few times
6. You should see columns like "EXP", "EXP (1)", "EXP (2)", etc.
7. Other names for expressions should work fine

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/135498404-943165d9-8890-4419-a05a-be04d6c4ac1a.mov

**After**

https://user-images.githubusercontent.com/17258145/135498422-d831ce43-e4f1-4e66-a585-3dc69b91d4ff.mov


