### PR TITLE
Convert deprecated k:mm time style to HH:mm on viz settings normalization

### DIFF
--- a/shared/src/metabase/shared/models/visualization_settings.cljc
+++ b/shared/src/metabase/shared/models/visualization_settings.cljc
@@ -519,6 +519,13 @@
       (dissoc :parameterMapping)
       (set/rename-keys db->norm-click-behavior-keys)))
 
+(defn- db->norm-time-style
+  "Converts the deprecated k:mm format to HH:mm (#18112)"
+  [v]
+  (if (= v "k:mm")
+    "HH:mm"
+    v))
+
 (defn- db->norm-table-columns [v]
   (-> v
     (assoc ::table-columns (mapv (fn [tbl-col]
@@ -531,7 +538,12 @@
   `norm->db-column-settings-entry`."
   [m k v]
   (case k
-    :click_behavior (assoc m ::click-behavior (db->norm-click-behavior v))
+    :click_behavior
+    (assoc m ::click-behavior (db->norm-click-behavior v))
+
+    :time_style
+    (assoc m ::time-style (db->norm-time-style v))
+
     (assoc m (db->norm-column-settings-keys k) v)))
 
 (defn db->norm-column-settings-entries

--- a/shared/test/metabase/shared/models/visualization_settings_test.cljc
+++ b/shared/test/metabase/shared/models/visualization_settings_test.cljc
@@ -83,8 +83,8 @@
           norm-col-nm         {::mb.viz/column-title  "Name Column"
                                ::mb.viz/show-mini-bar true}
           norm-click-bhvr-map {::mb.viz/click-behavior norm-click-behavior}
-          norm-col-settings {(mb.viz/field-id->column-ref f-id {"base-type" "type/Integer"}) norm-click-bhvr-map
-                             (mb.viz/column-name->column-ref col-name)                       norm-col-nm}
+          norm-col-settings   {(mb.viz/field-id->column-ref f-id {"base-type" "type/Integer"}) norm-click-bhvr-map
+                               (mb.viz/column-name->column-ref col-name)                       norm-col-nm}
           norm-viz-settings   {::mb.viz/column-settings norm-col-settings
                                ::mb.viz/table-columns [{::mb.viz/table-column-name      "ID"
                                                         ::mb.viz/table-column-field-ref [:field f-id nil]
@@ -98,7 +98,14 @@
           (let [to-db (mb.viz/norm->db to-norm)]
             (t/is (= db-form to-db)))))
       ;; for a non-table card, the :click_behavior map is directly underneath :visualization_settings
-      (t/is (= norm-click-bhvr-map (mb.viz/db->norm db-click-bhv-map))))))
+      (t/is (= norm-click-bhvr-map (mb.viz/db->norm db-click-bhv-map)))))
+
+  (t/testing "The deprecated k:mm :time_style is converted to HH:mm when normalized, and kept in the new style when converted back to the DB form"
+    (let [db-col-settings-old {:column_settings {"[\"name\",\"Column Name\"]" {:time_style "k:mm"}}}
+          db-col-settings-new {:column_settings {"[\"name\",\"Column Name\"]" {:time_style "HH:mm"}}}
+          norm-col-settings   {::mb.viz/column-settings {{::mb.viz/column-name "Column Name"} {::mb.viz/time-style "HH:mm"}}}]
+      (t/is (= norm-col-settings (mb.viz/db->norm db-col-settings-old)))
+      (t/is (= db-col-settings-new (mb.viz/norm->db norm-col-settings))))))
 
 (t/deftest virtual-card-test
   (t/testing "Virtual card in visualization settings is preserved through normalization roundtrip"

--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -170,6 +170,11 @@
                              "HH:mm"
                              (str "h" base-time-format)
 
+                             ;; Deprecated time style which should be already converted to HH:mm when viz settings are
+                             ;; normalized, but we'll handle it here too just in case. (#18112)
+                             "k:mm"
+                             (str "h" base-time-format)
+
                              "h:mm A"
                              (str base-time-format " am/pm")
 

--- a/test/metabase/query_processor/streaming/xlsx_test.clj
+++ b/test/metabase/query_processor/streaming/xlsx_test.clj
@@ -187,6 +187,7 @@
 
       (testing "time-style"
         (is (= "mmmm d, yyyy, hh:mm"      (format-string {::mb.viz/time-style "HH:mm"})))
+        (is (= "mmmm d, yyyy, hh:mm"      (format-string {::mb.viz/time-style "k:mm"})))
         (is (= "mmmm d, yyyy, h:mm am/pm" (format-string {::mb.viz/time-style "h:mm A"})))
         (is (= "mmmm d, yyyy, h am/pm"    (format-string {::mb.viz/time-style "h A"}))))
 


### PR DESCRIPTION
Converts the deprecated `k:mm` time style to `HH:mm` when column settings in the DB are normalized.

Doesn't convert it back, so if the viz settings for a question are edited, the new time format will replace the old one in the DB.

Also adds code to handle `k:mm` style in Excel formatting as another layer of redundancy.

Resolves #18112