### PR TITLE
Show permissions for hidden tables

### DIFF
--- a/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditor.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditor.jsx
@@ -1,104 +1,28 @@
-import React, { useState, useMemo } from "react";
+import React from "react";
 import PropTypes from "prop-types";
-import { t } from "ttag";
-import { Box } from "grid-styled";
 
-import { PermissionsTable } from "../PermissionsTable";
-import Subhead from "metabase/components/type/Subhead";
-import Text from "metabase/components/type/Text";
-import TextInput from "metabase/components/TextInput";
-import Icon from "metabase/components/Icon";
-import EmptyState from "metabase/components/EmptyState";
-import { SEARCH_DEBOUNCE_DURATION } from "metabase/lib/constants";
-import { useDebouncedValue } from "metabase/hooks/use-debounced-value";
+import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 
+import {
+  PermissionsEditorContent,
+  permissionEditorContentPropTypes,
+} from "./PermissionsEditorContent";
 import { PermissionsEditorRoot } from "./PermissionsEditor.styled";
-import { PermissionsEditorBreadcrumbs } from "./PermissionsEditorBreadcrumbs";
 
 export const permissionEditorPropTypes = {
-  title: PropTypes.string.isRequired,
-  description: PropTypes.string,
-  columns: PropTypes.array,
-  entities: PropTypes.array,
-  filterPlaceholder: PropTypes.string.isRequired,
-  onChange: PropTypes.func,
-  onSelect: PropTypes.func,
-  onAction: PropTypes.func,
-  onBreadcrumbsItemSelect: PropTypes.func,
-  breadcrumbs: PropTypes.array,
+  isLoading: PropTypes.bool,
+  error: PropTypes.string,
+  ...permissionEditorContentPropTypes,
 };
 
-export function PermissionsEditor({
-  title,
-  description,
-  entities,
-  columns,
-  filterPlaceholder,
-  breadcrumbs,
-  onBreadcrumbsItemSelect,
-  onChange,
-  onSelect,
-  onAction,
-}) {
-  const [filter, setFilter] = useState("");
-  const debouncedFilter = useDebouncedValue(filter, SEARCH_DEBOUNCE_DURATION);
-
-  const filteredEntities = useMemo(() => {
-    const trimmedFilter = debouncedFilter.trim().toLowerCase();
-
-    if (trimmedFilter.length === 0) {
-      return null;
-    }
-
-    return entities.filter(entity =>
-      entity.name.toLowerCase().includes(trimmedFilter),
-    );
-  }, [entities, debouncedFilter]);
-
+export const PermissionsEditor = ({ isLoading, error, ...contentProps }) => {
   return (
     <PermissionsEditorRoot>
-      <Box px="3rem">
-        <Subhead>
-          {title}{" "}
-          {breadcrumbs && (
-            <PermissionsEditorBreadcrumbs
-              items={breadcrumbs}
-              onBreadcrumbsItemSelect={onBreadcrumbsItemSelect}
-            />
-          )}
-        </Subhead>
-
-        {description && <Text>{description}</Text>}
-
-        <Box mt={2} mb={1} width="280px">
-          <TextInput
-            hasClearButton
-            colorScheme="admin"
-            placeholder={filterPlaceholder}
-            onChange={setFilter}
-            value={filter}
-            padding="sm"
-            borderRadius="md"
-            icon={<Icon name="search" size={16} />}
-          />
-        </Box>
-      </Box>
-
-      <PermissionsTable
-        horizontalPadding="lg"
-        entities={filteredEntities || entities}
-        columns={columns}
-        onSelect={onSelect}
-        onChange={onChange}
-        onAction={onAction}
-        emptyState={
-          <Box mt="120px">
-            <EmptyState message={t`Nothing here`} icon="all" />
-          </Box>
-        }
-      />
+      <LoadingAndErrorWrapper loading={isLoading} error={error}>
+        <PermissionsEditorContent {...contentProps} />
+      </LoadingAndErrorWrapper>
     </PermissionsEditorRoot>
   );
-}
+};
 
 PermissionsEditor.propTypes = permissionEditorPropTypes;

--- a/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditor.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditor.jsx
@@ -18,7 +18,7 @@ export const permissionEditorPropTypes = {
 export const PermissionsEditor = ({ isLoading, error, ...contentProps }) => {
   return (
     <PermissionsEditorRoot>
-      <LoadingAndErrorWrapper loading={isLoading} error={error}>
+      <LoadingAndErrorWrapper loading={isLoading} error={error} noWrapper>
         <PermissionsEditorContent {...contentProps} />
       </LoadingAndErrorWrapper>
     </PermissionsEditorRoot>

--- a/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditorContent.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditorContent.jsx
@@ -1,0 +1,104 @@
+import React, { useState, useMemo } from "react";
+import PropTypes from "prop-types";
+import { t } from "ttag";
+import { Box } from "grid-styled";
+
+import { PermissionsTable } from "../PermissionsTable";
+import Subhead from "metabase/components/type/Subhead";
+import Text from "metabase/components/type/Text";
+import TextInput from "metabase/components/TextInput";
+import Icon from "metabase/components/Icon";
+import EmptyState from "metabase/components/EmptyState";
+import { SEARCH_DEBOUNCE_DURATION } from "metabase/lib/constants";
+import { useDebouncedValue } from "metabase/hooks/use-debounced-value";
+
+import { PermissionsEditorRoot } from "./PermissionsEditor.styled";
+import { PermissionsEditorBreadcrumbs } from "./PermissionsEditorBreadcrumbs";
+
+export const permissionEditorPropTypes = {
+  title: PropTypes.string.isRequired,
+  description: PropTypes.string,
+  columns: PropTypes.array,
+  entities: PropTypes.array,
+  filterPlaceholder: PropTypes.string.isRequired,
+  onChange: PropTypes.func,
+  onSelect: PropTypes.func,
+  onAction: PropTypes.func,
+  onBreadcrumbsItemSelect: PropTypes.func,
+  breadcrumbs: PropTypes.array,
+};
+
+export function PermissionsEditorContent({
+  title,
+  description,
+  entities,
+  columns,
+  filterPlaceholder,
+  breadcrumbs,
+  onBreadcrumbsItemSelect,
+  onChange,
+  onSelect,
+  onAction,
+}) {
+  const [filter, setFilter] = useState("");
+  const debouncedFilter = useDebouncedValue(filter, SEARCH_DEBOUNCE_DURATION);
+
+  const filteredEntities = useMemo(() => {
+    const trimmedFilter = debouncedFilter.trim().toLowerCase();
+
+    if (trimmedFilter.length === 0) {
+      return null;
+    }
+
+    return entities.filter(entity =>
+      entity.name.toLowerCase().includes(trimmedFilter),
+    );
+  }, [entities, debouncedFilter]);
+
+  return (
+    <PermissionsEditorRoot>
+      <Box px="3rem">
+        <Subhead>
+          {title}{" "}
+          {breadcrumbs && (
+            <PermissionsEditorBreadcrumbs
+              items={breadcrumbs}
+              onBreadcrumbsItemSelect={onBreadcrumbsItemSelect}
+            />
+          )}
+        </Subhead>
+
+        {description && <Text>{description}</Text>}
+
+        <Box mt={2} mb={1} width="280px">
+          <TextInput
+            hasClearButton
+            colorScheme="admin"
+            placeholder={filterPlaceholder}
+            onChange={setFilter}
+            value={filter}
+            padding="sm"
+            borderRadius="md"
+            icon={<Icon name="search" size={16} />}
+          />
+        </Box>
+      </Box>
+
+      <PermissionsTable
+        horizontalPadding="lg"
+        entities={filteredEntities || entities}
+        columns={columns}
+        onSelect={onSelect}
+        onChange={onChange}
+        onAction={onAction}
+        emptyState={
+          <Box mt="120px">
+            <EmptyState message={t`Nothing here`} icon="all" />
+          </Box>
+        }
+      />
+    </PermissionsEditorRoot>
+  );
+}
+
+PermissionsEditorContent.propTypes = permissionEditorPropTypes;

--- a/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditorContent.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditorContent.jsx
@@ -56,7 +56,7 @@ export function PermissionsEditorContent({
   }, [entities, debouncedFilter]);
 
   return (
-    <PermissionsEditorRoot>
+    <>
       <Box px="3rem">
         <Subhead>
           {title}{" "}
@@ -97,7 +97,7 @@ export function PermissionsEditorContent({
           </Box>
         }
       />
-    </PermissionsEditorRoot>
+    </>
   );
 }
 

--- a/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditorContent.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditorContent.jsx
@@ -12,7 +12,6 @@ import EmptyState from "metabase/components/EmptyState";
 import { SEARCH_DEBOUNCE_DURATION } from "metabase/lib/constants";
 import { useDebouncedValue } from "metabase/hooks/use-debounced-value";
 
-import { PermissionsEditorRoot } from "./PermissionsEditor.styled";
 import { PermissionsEditorBreadcrumbs } from "./PermissionsEditorBreadcrumbs";
 
 export const permissionEditorPropTypes = {

--- a/frontend/src/metabase/admin/permissions/components/PermissionsSelect/PermissionsSelect.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsSelect/PermissionsSelect.jsx
@@ -25,7 +25,7 @@ import {
 
 const propTypes = {
   options: PropTypes.arrayOf(PropTypes.shape(optionShape)).isRequired,
-  actions: PropTypes.arrayOf(PropTypes.shape(optionShape)),
+  actions: PropTypes.object,
   value: PropTypes.string.isRequired,
   toggleLabel: PropTypes.string,
   onChange: PropTypes.func.isRequired,

--- a/frontend/src/metabase/admin/permissions/components/PermissionsSidebar/PermissionsSidebar.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsSidebar/PermissionsSidebar.jsx
@@ -1,145 +1,27 @@
-import React, { useState, useMemo, memo } from "react";
+import React from "react";
 import PropTypes from "prop-types";
-import { t } from "ttag";
-import { Box, Flex } from "grid-styled";
 
-import EmptyState from "metabase/components/EmptyState";
-import Radio from "metabase/components/Radio";
-import TextInput from "metabase/components/TextInput";
-import Icon from "metabase/components/Icon";
-import Label from "metabase/components/type/Label";
-import Text from "metabase/components/type/Text";
-import { Tree } from "metabase/components/tree";
-import { useDebouncedValue } from "metabase/hooks/use-debounced-value";
-import { SEARCH_DEBOUNCE_DURATION } from "metabase/lib/constants";
-
-import { searchItems } from "./utils";
 import {
-  SidebarRoot,
-  SidebarHeader,
-  SidebarContent,
-  EntityGroupsDivider,
-  BackButton,
-  BackIcon,
-} from "./PermissionsSidebar.styled";
+  PermissionsSidebarContent,
+  permissionSidebarContentPropTypes,
+} from "./PermissionsSidebarContent";
+import { SidebarRoot } from "./PermissionsSidebar.styled";
+import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 
 export const permissionSidebarPropTypes = {
-  title: PropTypes.string,
-  description: PropTypes.string,
-  filterPlaceholder: PropTypes.string.isRequired,
-  onSelect: PropTypes.func.isRequired,
-  onBack: PropTypes.func,
-  selectedId: PropTypes.oneOfType([
-    PropTypes.string.isRequired,
-    PropTypes.number.isRequired,
-  ]),
-  entityGroups: PropTypes.arrayOf(PropTypes.array),
-  onEntityChange: PropTypes.func,
-  entitySwitch: PropTypes.shape({
-    value: PropTypes.string.isRequired,
-    options: PropTypes.arrayOf(
-      PropTypes.shape({
-        name: PropTypes.string.isRequired,
-        value: PropTypes.string.isRequired,
-      }),
-    ),
-  }),
+  isLoading: PropTypes.bool,
+  error: PropTypes.string,
+  ...permissionSidebarContentPropTypes,
 };
 
-export const PermissionsSidebar = memo(function PermissionsSidebar({
-  title,
-  description,
-  filterPlaceholder,
-  entityGroups,
-  entitySwitch,
-  selectedId,
-  onEntityChange,
-  onSelect,
-  onBack,
-}) {
-  const [filter, setFilter] = useState("");
-  const debouncedFilter = useDebouncedValue(filter, SEARCH_DEBOUNCE_DURATION);
-
-  const filteredList = useMemo(() => {
-    const trimmedFilter = debouncedFilter.trim().toLowerCase();
-
-    if (trimmedFilter.length === 0) {
-      return null;
-    }
-
-    return searchItems(entityGroups.flat(), trimmedFilter);
-  }, [entityGroups, debouncedFilter]);
-
+export const PermissionsSidebar = ({ isLoading, error, ...contentProps }) => {
   return (
     <SidebarRoot>
-      <SidebarHeader>
-        {onBack ? (
-          <BackButton onClick={onBack}>
-            <BackIcon />
-            {title}
-          </BackButton>
-        ) : (
-          <Flex alignItems="center">
-            {title && <Label px={1}>{title}</Label>}
-          </Flex>
-        )}
-        <Text color="text-dark" px={1}>
-          {description}
-        </Text>
-        {entitySwitch && (
-          <Box mb={2}>
-            <Radio
-              variant="bubble"
-              colorScheme="admin"
-              options={entitySwitch.options}
-              value={entitySwitch.value}
-              onChange={onEntityChange}
-            />
-          </Box>
-        )}
-        <TextInput
-          hasClearButton
-          colorScheme="admin"
-          placeholder={filterPlaceholder}
-          onChange={setFilter}
-          value={filter}
-          padding="sm"
-          borderRadius="md"
-          icon={<Icon name="search" size={16} />}
-        />
-      </SidebarHeader>
-      <SidebarContent>
-        {filteredList && (
-          <Tree
-            colorScheme="admin"
-            data={filteredList}
-            selectedId={selectedId}
-            onSelect={onSelect}
-            emptyState={
-              <Box mt="100px">
-                <EmptyState message={t`Nothing here`} icon="all" />
-              </Box>
-            }
-          />
-        )}
-        {!filteredList &&
-          entityGroups.map((entities, index) => {
-            const isLastGroup = index === entityGroups.length - 1;
-            return (
-              <React.Fragment key={index}>
-                <Tree
-                  colorScheme="admin"
-                  data={entities}
-                  selectedId={selectedId}
-                  onSelect={onSelect}
-                />
-                {!isLastGroup && <EntityGroupsDivider />}
-              </React.Fragment>
-            );
-          })}
-      </SidebarContent>
+      <LoadingAndErrorWrapper loading={isLoading} error={error}>
+        <PermissionsSidebarContent {...contentProps} />
+      </LoadingAndErrorWrapper>
     </SidebarRoot>
   );
-});
+};
 
 PermissionsSidebar.propTypes = permissionSidebarPropTypes;

--- a/frontend/src/metabase/admin/permissions/components/PermissionsSidebar/PermissionsSidebar.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsSidebar/PermissionsSidebar.jsx
@@ -17,7 +17,7 @@ export const permissionSidebarPropTypes = {
 export const PermissionsSidebar = ({ isLoading, error, ...contentProps }) => {
   return (
     <SidebarRoot>
-      <LoadingAndErrorWrapper loading={isLoading} error={error}>
+      <LoadingAndErrorWrapper loading={isLoading} error={error} noWrapper>
         <PermissionsSidebarContent {...contentProps} />
       </LoadingAndErrorWrapper>
     </SidebarRoot>

--- a/frontend/src/metabase/admin/permissions/components/PermissionsSidebar/PermissionsSidebarContent.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsSidebar/PermissionsSidebarContent.jsx
@@ -1,0 +1,147 @@
+import React, { useState, useMemo, memo } from "react";
+import PropTypes from "prop-types";
+import { t } from "ttag";
+import { Box, Flex } from "grid-styled";
+
+import EmptyState from "metabase/components/EmptyState";
+import Radio from "metabase/components/Radio";
+import TextInput from "metabase/components/TextInput";
+import Icon from "metabase/components/Icon";
+import Label from "metabase/components/type/Label";
+import Text from "metabase/components/type/Text";
+import { Tree } from "metabase/components/tree";
+import { useDebouncedValue } from "metabase/hooks/use-debounced-value";
+import { SEARCH_DEBOUNCE_DURATION } from "metabase/lib/constants";
+
+import { searchItems } from "./utils";
+import {
+  SidebarRoot,
+  SidebarHeader,
+  SidebarContent,
+  EntityGroupsDivider,
+  BackButton,
+  BackIcon,
+} from "./PermissionsSidebar.styled";
+
+export const permissionSidebarContentPropTypes = {
+  title: PropTypes.string,
+  description: PropTypes.string,
+  filterPlaceholder: PropTypes.string.isRequired,
+  onSelect: PropTypes.func,
+  onBack: PropTypes.func,
+  selectedId: PropTypes.oneOfType([
+    PropTypes.string.isRequired,
+    PropTypes.number.isRequired,
+  ]),
+  entityGroups: PropTypes.arrayOf(PropTypes.array),
+  onEntityChange: PropTypes.func,
+  entitySwitch: PropTypes.shape({
+    value: PropTypes.string.isRequired,
+    options: PropTypes.arrayOf(
+      PropTypes.shape({
+        name: PropTypes.string.isRequired,
+        value: PropTypes.string.isRequired,
+      }),
+    ),
+  }),
+};
+
+export const PermissionsSidebarContent = memo(
+  function PermissionsSidebarContent({
+    title,
+    description,
+    filterPlaceholder,
+    entityGroups,
+    entitySwitch,
+    selectedId,
+    onEntityChange,
+    onSelect,
+    onBack,
+  }) {
+    const [filter, setFilter] = useState("");
+    const debouncedFilter = useDebouncedValue(filter, SEARCH_DEBOUNCE_DURATION);
+
+    const filteredList = useMemo(() => {
+      const trimmedFilter = debouncedFilter.trim().toLowerCase();
+
+      if (trimmedFilter.length === 0) {
+        return null;
+      }
+
+      return searchItems(entityGroups.flat(), trimmedFilter);
+    }, [entityGroups, debouncedFilter]);
+
+    return (
+      <SidebarRoot>
+        <SidebarHeader>
+          {onBack ? (
+            <BackButton onClick={onBack}>
+              <BackIcon />
+              {title}
+            </BackButton>
+          ) : (
+            <Flex alignItems="center">
+              {title && <Label px={1}>{title}</Label>}
+            </Flex>
+          )}
+          <Text color="text-dark" px={1}>
+            {description}
+          </Text>
+          {entitySwitch && (
+            <Box mb={2}>
+              <Radio
+                variant="bubble"
+                colorScheme="admin"
+                options={entitySwitch.options}
+                value={entitySwitch.value}
+                onChange={onEntityChange}
+              />
+            </Box>
+          )}
+          <TextInput
+            hasClearButton
+            colorScheme="admin"
+            placeholder={filterPlaceholder}
+            onChange={setFilter}
+            value={filter}
+            padding="sm"
+            borderRadius="md"
+            icon={<Icon name="search" size={16} />}
+          />
+        </SidebarHeader>
+        <SidebarContent>
+          {filteredList && (
+            <Tree
+              colorScheme="admin"
+              data={filteredList}
+              selectedId={selectedId}
+              onSelect={onSelect}
+              emptyState={
+                <Box mt="100px">
+                  <EmptyState message={t`Nothing here`} icon="all" />
+                </Box>
+              }
+            />
+          )}
+          {!filteredList &&
+            entityGroups.map((entities, index) => {
+              const isLastGroup = index === entityGroups.length - 1;
+              return (
+                <React.Fragment key={index}>
+                  <Tree
+                    colorScheme="admin"
+                    data={entities}
+                    selectedId={selectedId}
+                    onSelect={onSelect}
+                  />
+                  {!isLastGroup && <EntityGroupsDivider />}
+                </React.Fragment>
+              );
+            })}
+        </SidebarContent>
+      </SidebarRoot>
+    );
+  },
+);
+
+PermissionsSidebarContent.propTypes = permissionSidebarContentPropTypes;

--- a/frontend/src/metabase/admin/permissions/components/PermissionsSidebar/PermissionsSidebarContent.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsSidebar/PermissionsSidebarContent.jsx
@@ -15,7 +15,6 @@ import { SEARCH_DEBOUNCE_DURATION } from "metabase/lib/constants";
 
 import { searchItems } from "./utils";
 import {
-  SidebarRoot,
   SidebarHeader,
   SidebarContent,
   EntityGroupsDivider,
@@ -72,7 +71,7 @@ export const PermissionsSidebarContent = memo(
     }, [entityGroups, debouncedFilter]);
 
     return (
-      <SidebarRoot>
+      <>
         <SidebarHeader>
           {onBack ? (
             <BackButton onClick={onBack}>
@@ -139,7 +138,7 @@ export const PermissionsSidebarContent = memo(
               );
             })}
         </SidebarContent>
-      </SidebarRoot>
+      </>
     );
   },
 );

--- a/frontend/src/metabase/admin/permissions/pages/DataPermissionsPage/DataPermissionsPage.jsx
+++ b/frontend/src/metabase/admin/permissions/pages/DataPermissionsPage/DataPermissionsPage.jsx
@@ -3,9 +3,9 @@ import PropTypes from "prop-types";
 import _ from "underscore";
 import { connect } from "react-redux";
 
-import Databases from "metabase/entities/databases";
-import Groups from "metabase/entities/groups";
 import { PLUGIN_ADVANCED_PERMISSIONS } from "metabase/plugins";
+import Tables from "metabase/entities/tables";
+import Groups from "metabase/entities/groups";
 
 import { getIsDirty, getDiff } from "../../selectors/data-permissions";
 import {
@@ -19,6 +19,11 @@ const mapDispatchToProps = {
   loadPermissions: loadDataPermissions,
   savePermissions: saveDataPermissions,
   initialize: initializeDataPermissions,
+  fetchTables: dbId =>
+    Tables.actions.fetchList({
+      dbId,
+      include_hidden: true,
+    }),
 };
 
 const mapStateToProps = (state, props) => ({
@@ -34,6 +39,10 @@ const propTypes = {
   loadPermissions: PropTypes.func.isRequired,
   initialize: PropTypes.func.isRequired,
   route: PropTypes.object,
+  params: PropTypes.shape({
+    databaseId: PropTypes.string,
+  }),
+  fetchTables: PropTypes.func,
 };
 
 function DataPermissionsPage({
@@ -43,11 +52,20 @@ function DataPermissionsPage({
   savePermissions,
   loadPermissions,
   route,
+  params,
   initialize,
+  fetchTables,
 }) {
   useEffect(() => {
     initialize();
   }, [initialize]);
+
+  useEffect(() => {
+    if (params.databaseId == null) {
+      return;
+    }
+    fetchTables(params.databaseId);
+  }, [params.databaseId, fetchTables]);
 
   return (
     <PermissionsPageLayout
@@ -71,7 +89,6 @@ function DataPermissionsPage({
 DataPermissionsPage.propTypes = propTypes;
 
 export default _.compose(
-  Databases.loadList({ entityQuery: { include: "tables" } }),
   Groups.loadList(),
   connect(
     mapStateToProps,

--- a/frontend/src/metabase/admin/permissions/pages/DatabasePermissionsPage/DatabasesPermissionsPage.jsx
+++ b/frontend/src/metabase/admin/permissions/pages/DatabasePermissionsPage/DatabasesPermissionsPage.jsx
@@ -8,7 +8,9 @@ import { connect } from "react-redux";
 
 import {
   getGroupsDataPermissionEditor,
-  getDatabasesSidebar,
+  getDataFocusSidebar,
+  getIsLoadingDatabaseTables,
+  getLoadingDatabaseTablesError,
 } from "../../selectors/data-permissions";
 import { updateDataPermission } from "../../permissions";
 
@@ -42,8 +44,10 @@ const mapDispatchToProps = dispatch => ({
 
 const mapStateToProps = (state, props) => {
   return {
-    sidebar: getDatabasesSidebar(state, props),
+    sidebar: getDataFocusSidebar(state, props),
     permissionEditor: getGroupsDataPermissionEditor(state, props),
+    isSidebarLoading: getIsLoadingDatabaseTables(state, props),
+    sidebarError: getLoadingDatabaseTablesError(state, props),
   };
 };
 
@@ -53,13 +57,15 @@ const propTypes = {
     schemaName: PropTypes.string,
     tableId: PropTypes.string,
   }),
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
   sidebar: PropTypes.shape(permissionSidebarPropTypes),
   permissionEditor: PropTypes.shape(permissionEditorPropTypes),
   navigateToItem: PropTypes.func.isRequired,
   switchView: PropTypes.func.isRequired,
   updateDataPermission: PropTypes.func.isRequired,
   navigateToDatabaseList: PropTypes.func.isRequired,
+  isSidebarLoading: PropTypes.bool,
+  sidebarError: PropTypes.string,
   dispatch: PropTypes.func.isRequired,
 };
 
@@ -73,6 +79,8 @@ function DatabasesPermissionsPage({
   switchView,
   updateDataPermission,
   dispatch,
+  isSidebarLoading,
+  sidebarError,
 }) {
   const handleEntityChange = useCallback(
     entityType => {
@@ -104,6 +112,8 @@ function DatabasesPermissionsPage({
     <React.Fragment>
       <PermissionsSidebar
         {...sidebar}
+        error={sidebarError}
+        isLoading={isSidebarLoading}
         onSelect={navigateToItem}
         onBack={params.databaseId == null ? null : navigateToDatabaseList}
         onEntityChange={handleEntityChange}

--- a/frontend/src/metabase/admin/permissions/pages/GroupDataPermissionsPage/GroupsPermissionsPage.jsx
+++ b/frontend/src/metabase/admin/permissions/pages/GroupDataPermissionsPage/GroupsPermissionsPage.jsx
@@ -9,6 +9,8 @@ import { connect } from "react-redux";
 import {
   getDatabasesPermissionEditor,
   getGroupsSidebar,
+  getIsLoadingDatabaseTables,
+  getLoadingDatabaseTablesError,
 } from "../../selectors/data-permissions";
 import { updateDataPermission } from "../../permissions";
 import {
@@ -44,6 +46,8 @@ const mapStateToProps = (state, props) => {
   return {
     sidebar: getGroupsSidebar(state, props),
     permissionEditor: getDatabasesPermissionEditor(state, props),
+    isEditorLoading: getIsLoadingDatabaseTables(state, props),
+    editorError: getLoadingDatabaseTablesError(state, props),
   };
 };
 
@@ -53,7 +57,7 @@ const propTypes = {
     databaseId: PropTypes.string,
     schemaName: PropTypes.string,
   }),
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
   sidebar: PropTypes.shape(permissionSidebarPropTypes),
   permissionEditor: PropTypes.shape(permissionEditorPropTypes),
   navigateToItem: PropTypes.func.isRequired,
@@ -61,7 +65,8 @@ const propTypes = {
   navigateToTableItem: PropTypes.func.isRequired,
   updateDataPermission: PropTypes.func.isRequired,
   dispatch: PropTypes.func.isRequired,
-  navigateToDatabase: PropTypes.func.isRequired,
+  isEditorLoading: PropTypes.bool,
+  editorError: PropTypes.string,
 };
 
 function GroupsPermissionsPage({
@@ -73,6 +78,8 @@ function GroupsPermissionsPage({
   switchView,
   navigateToTableItem,
   updateDataPermission,
+  isEditorLoading,
+  editorError,
   dispatch,
 }) {
   const handleEntityChange = useCallback(
@@ -115,6 +122,7 @@ function GroupsPermissionsPage({
 
   const handleBreadcrumbsItemSelect = item => dispatch(push(item.url));
 
+  const showEmptyState = !permissionEditor && !isEditorLoading && !editorError;
   return (
     <React.Fragment>
       <PermissionsSidebar
@@ -123,16 +131,18 @@ function GroupsPermissionsPage({
         onEntityChange={handleEntityChange}
       />
 
-      {!permissionEditor && (
+      {showEmptyState && (
         <PermissionsEditorEmptyState
           icon="group"
           message={t`Select a group to see its data permissions`}
         />
       )}
 
-      {permissionEditor && (
+      {!showEmptyState && (
         <PermissionsEditor
           {...permissionEditor}
+          isLoading={isEditorLoading}
+          error={editorError}
           onSelect={handleTableItemSelect}
           onChange={handlePermissionChange}
           onAction={handleAction}

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions.js
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions.js
@@ -6,6 +6,8 @@ import { push } from "react-router-redux";
 import { getMetadata } from "metabase/selectors/metadata";
 
 import Group from "metabase/entities/groups";
+import Tables from "metabase/entities/tables";
+
 import {
   isAdminGroup,
   isDefaultGroup,
@@ -48,9 +50,13 @@ import {
 } from "../utils/urls";
 import { limitDatabasePermission } from "../permissions";
 
+export const getMetadataWithHiddenTables = (state, props) => {
+  return getMetadata(state, { ...props, includeHiddenTables: true });
+};
+
 const getGroupsWithoutMetabot = createSelector(
   Group.selectors.getList,
-  groups => groups.filter(group => !isMetaBotGroup(group)),
+  groups => groups?.filter(group => !isMetaBotGroup(group)) ?? [],
 );
 
 export const getIsDirty = createSelector(
@@ -61,13 +67,35 @@ export const getIsDirty = createSelector(
 );
 
 export const getDiff = createSelector(
-  getMetadata,
+  getMetadataWithHiddenTables,
   getGroupsWithoutMetabot,
   state => state.admin.permissions.dataPermissions,
   state => state.admin.permissions.originalDataPermissions,
   (metadata, groups, permissions, originalPermissions) =>
     diffPermissions(permissions, originalPermissions, groups, metadata),
 );
+
+export const getIsLoadingDatabaseTables = (state, props) => {
+  const dbId = props.params.databaseId;
+
+  return Tables.selectors.getLoading(state, {
+    entityQuery: {
+      dbId,
+      include_hidden: true,
+    },
+  });
+};
+
+export const getLoadingDatabaseTablesError = (state, props) => {
+  const dbId = props.params.databaseId;
+
+  return Tables.selectors.getError(state, {
+    entityQuery: {
+      dbId,
+      include_hidden: true,
+    },
+  });
+};
 
 const getRouteParams = (_state, props) => {
   const { databaseId, schemaName, tableId } = props.params;
@@ -95,72 +123,83 @@ const getEntitySwitch = value => ({
 const getSchemaId = name => `schema:${name}`;
 const getTableId = id => `table:${id}`;
 
-export const getDatabasesSidebar = createSelector(
-  getMetadata,
+const getDatabasesSidebar = metadata => {
+  const entities = Object.values(metadata.databases)
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map(database => ({
+      id: database.id,
+      name: database.name,
+      entityId: getDatabaseEntityId(database),
+      icon: "database",
+    }));
+
+  return {
+    entityGroups: [entities],
+    entitySwitch: getEntitySwitch("database"),
+    filterPlaceholder: t`Search for a database`,
+  };
+};
+
+const getTablesSidebar = (database, schemaName, tableId) => {
+  let selectedId = null;
+
+  if (tableId != null) {
+    selectedId = getTableId(tableId);
+  } else if (schemaName != null) {
+    selectedId = getSchemaId(schemaName);
+  }
+
+  let entities = database
+    .getSchemas()
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map(schema => {
+      return {
+        id: getSchemaId(schema.name),
+        name: schema.name,
+        entityId: getSchemaEntityId(schema),
+        icon: "folder",
+        children: schema
+          .getTables()
+          .sort((a, b) => a.displayName().localeCompare(b.displayName()))
+          .map(table => ({
+            id: getTableId(table.id),
+            entityId: getTableEntityId(table),
+            name: table.displayName(),
+            icon: "table",
+          })),
+      };
+    });
+
+  const shouldIncludeSchemas = database.schemasCount() > 1;
+  if (!shouldIncludeSchemas) {
+    entities = entities[0]?.children;
+  }
+
+  return {
+    selectedId,
+    title: database.name,
+    description: t`Select a table to set more specific permissions`,
+    entityGroups: [entities].filter(Boolean),
+    filterPlaceholder: t`Search for a table`,
+  };
+};
+
+export const getDataFocusSidebar = createSelector(
+  getMetadataWithHiddenTables,
   getRouteParams,
-  (metadata, params) => {
+  getIsLoadingDatabaseTables,
+  (metadata, params, isLoading) => {
+    if (isLoading) {
+      return null;
+    }
+
     const { databaseId, schemaName, tableId } = params;
 
     if (databaseId == null) {
-      const entities = Object.values(metadata.databases)
-        .sort((a, b) => a.name.localeCompare(b.name))
-        .map(database => ({
-          id: database.id,
-          name: database.name,
-          entityId: getDatabaseEntityId(database),
-          icon: "database",
-        }));
-
-      return {
-        entityGroups: [entities],
-        entitySwitch: getEntitySwitch("database"),
-        filterPlaceholder: t`Search for a database`,
-      };
+      return getDatabasesSidebar(metadata);
     }
 
-    const database = metadata.database(databaseId);
-
-    let selectedId = null;
-
-    if (tableId != null) {
-      selectedId = getTableId(tableId);
-    } else if (schemaName != null) {
-      selectedId = getSchemaId(schemaName);
-    }
-
-    let entities = database
-      .getSchemas()
-      .sort((a, b) => a.name.localeCompare(b.name))
-      .map(schema => {
-        return {
-          id: getSchemaId(schema.name),
-          name: schema.name,
-          entityId: getSchemaEntityId(schema),
-          icon: "folder",
-          children: schema
-            .getTables()
-            .sort((a, b) => a.displayName().localeCompare(b.displayName()))
-            .map(table => ({
-              id: getTableId(table.id),
-              entityId: getTableEntityId(table),
-              name: table.displayName(),
-              icon: "table",
-            })),
-        };
-      });
-
-    const shouldIncludeSchemas = database.schemasCount() > 1;
-    if (!shouldIncludeSchemas) {
-      entities = entities[0].children;
-    }
-
-    return {
-      selectedId,
-      title: database.name,
-      description: t`Select a table to set more specific permissions`,
-      entityGroups: [entities],
-      filterPlaceholder: t`Search for a table`,
-    };
+    return getTablesSidebar(metadata.database(databaseId), schemaName, tableId);
   },
 );
 
@@ -179,7 +218,10 @@ const getGroupsDataEditorBreadcrumbs = (params, metadata) => {
     url: getDatabaseFocusPermissionsUrl(getDatabaseEntityId(database)),
   };
 
-  if (schemaName == null && tableId == null) {
+  if (
+    (schemaName == null && tableId == null) ||
+    database.schema(schemaName) == null
+  ) {
     return [databaseItem];
   }
 
@@ -197,6 +239,7 @@ const getGroupsDataEditorBreadcrumbs = (params, metadata) => {
   }
 
   const table = metadata.table(tableId);
+
   const tableItem = {
     id: table.id,
     text: table.display_name,
@@ -469,7 +512,7 @@ const buildSchemasPermissions = (
 };
 
 export const getGroupsDataPermissionEditor = createSelector(
-  getMetadata,
+  getMetadataWithHiddenTables,
   getRouteParams,
   getDataPermissions,
   getGroupsWithoutMetabot,
@@ -611,15 +654,16 @@ const getGroup = (state, props) =>
   });
 
 export const getDatabasesPermissionEditor = createSelector(
-  getMetadata,
+  getMetadataWithHiddenTables,
   getGroupRouteParams,
   getDataPermissions,
   getGroup,
   getGroupsWithoutMetabot,
-  (metadata, params, permissions, group, groups) => {
+  getIsLoadingDatabaseTables,
+  (metadata, params, permissions, group, groups, isLoading) => {
     const { groupId, databaseId, schemaName } = params;
 
-    if (!permissions || groupId == null) {
+    if (isLoading || !permissions || groupId == null) {
       return null;
     }
 
@@ -642,26 +686,30 @@ export const getDatabasesPermissionEditor = createSelector(
         ? metadata.database(databaseId).getSchemas()[0]
         : metadata.database(databaseId).schema(schemaName);
 
-      entities = schema.getTables().map(table => {
-        const entityId = getTableEntityId(table);
-        return {
-          id: table.id,
-          name: table.display_name,
-          entityId,
-          permissions: buildFieldsPermissions(
+      entities = schema
+        .getTables()
+        .sort((a, b) => a.display_name.localeCompare(b.display_name))
+        .map(table => {
+          const entityId = getTableEntityId(table);
+          return {
+            id: table.id,
+            name: table.display_name,
             entityId,
-            groupId,
-            isAdmin,
-            permissions,
-            defaultGroup,
-            metadata.database(databaseId),
-          ),
-        };
-      });
+            permissions: buildFieldsPermissions(
+              entityId,
+              groupId,
+              isAdmin,
+              permissions,
+              defaultGroup,
+              metadata.database(databaseId),
+            ),
+          };
+        });
     } else if (databaseId != null) {
       entities = metadata
         .database(databaseId)
         .getSchemas()
+        .sort((a, b) => a.name.localeCompare(b.name))
         .map(schema => {
           const entityId = getSchemaEntityId(schema);
           return {
@@ -681,6 +729,7 @@ export const getDatabasesPermissionEditor = createSelector(
     } else if (groupId != null) {
       entities = metadata
         .databasesList({ savedQuestions: false })
+        .sort((a, b) => a.name.localeCompare(b.name))
         .map(database => {
           const entityId = getDatabaseEntityId(database);
           return {

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions.unit.spec.js
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions.unit.spec.js
@@ -1,5 +1,5 @@
 import {
-  getDatabasesSidebar,
+  getDataFocusSidebar,
   getGroupsDataPermissionEditor,
 } from "./data-permissions";
 import { normalizedMetadata } from "./data-permissions.unit.spec.fixtures";
@@ -60,22 +60,22 @@ const getProps = ({ databaseId, schemaName, tableId, groupId }) => ({
   },
 });
 
-describe("getDatabasesSidebar", () => {
+describe("getDataFocusSidebar", () => {
   describe("when database is not selected", () => {
     it("returns a correct placeholder for databases list search", () => {
-      const sidebarData = getDatabasesSidebar(state, getProps({}));
+      const sidebarData = getDataFocusSidebar(state, getProps({}));
 
       expect(sidebarData.filterPlaceholder).toEqual("Search for a database");
     });
 
     it("returns entity switch value = database", () => {
-      const sidebarData = getDatabasesSidebar(state, getProps({}));
+      const sidebarData = getDataFocusSidebar(state, getProps({}));
 
       expect(sidebarData.entitySwitch.value).toEqual("database");
     });
 
     it("returns list of databases", () => {
-      const sidebarData = getDatabasesSidebar(state, getProps({}));
+      const sidebarData = getDataFocusSidebar(state, getProps({}));
 
       expect(sidebarData.entityGroups).toEqual([
         [
@@ -102,7 +102,7 @@ describe("getDatabasesSidebar", () => {
 
   describe("when a database is selected", () => {
     it("returns a correct placeholder for databases list search", () => {
-      const sidebarData = getDatabasesSidebar(
+      const sidebarData = getDataFocusSidebar(
         state,
         getProps({ databaseId: 2 }),
       );
@@ -111,7 +111,7 @@ describe("getDatabasesSidebar", () => {
     });
 
     it("returns tree of schemas and tables for a database with schemas", () => {
-      const sidebarData = getDatabasesSidebar(
+      const sidebarData = getDataFocusSidebar(
         state,
         getProps({ databaseId: 2 }),
       );
@@ -195,7 +195,7 @@ describe("getDatabasesSidebar", () => {
     });
 
     it("returns flat list of tables for a schemaless database", () => {
-      const sidebarData = getDatabasesSidebar(
+      const sidebarData = getDataFocusSidebar(
         state,
         getProps({ databaseId: 3 }),
       );

--- a/frontend/src/metabase/admin/permissions/utils/data-entity-id.js
+++ b/frontend/src/metabase/admin/permissions/utils/data-entity-id.js
@@ -8,8 +8,8 @@ export const getSchemaEntityId = schemaEntity => ({
 });
 
 export const getTableEntityId = tableEntity => ({
-  databaseId: tableEntity.database.id,
-  schemaName: tableEntity.schema.name,
+  databaseId: tableEntity.db_id,
+  schemaName: tableEntity.schema_name,
   tableId: tableEntity.id,
 });
 

--- a/frontend/test/metabase-visual/admin/permissions.cy.spec.js
+++ b/frontend/test/metabase-visual/admin/permissions.cy.spec.js
@@ -16,6 +16,7 @@ describe("visual tests > admin > permissions", () => {
     it("database focused view > table", () => {
       cy.visit("/admin/permissions/data/database/1/schema/PUBLIC/table/1");
       cy.findByPlaceholderText("Search for a group");
+      cy.findByPlaceholderText("Search for a table");
       cy.percySnapshot();
     });
 

--- a/frontend/test/metabase/scenarios/permissions/admin-permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/admin-permissions.cy.spec.js
@@ -16,6 +16,22 @@ describe("scenarios > admin > permissions", () => {
     cy.signInAsAdmin();
   });
 
+  it("shows hidden tables", () => {
+    cy.visit("/admin/datamodel/database/1");
+    cy.icon("eye_crossed_out")
+      .eq(0)
+      .click();
+
+    cy.visit("admin/permissions/data/group/1/database/1");
+
+    assertPermissionTable([
+      ["Orders", "No self-service", "No"],
+      ["People", "No self-service", "No"],
+      ["Products", "No self-service", "No"],
+      ["Reviews", "No self-service", "No"],
+    ]);
+  });
+
   it("should display error on failed save", () => {
     // revoke some permissions
     cy.visit("/admin/permissions/data/group/1");


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/17777

### Description

1) Showing hidden tables in the permissions editor
2) Replacing usage of `/api/database?include=tables` to load DBs+tables with separate requests for selected database tables

### How to verify

#### Hidden tables
- open Metabase Admin > Data model
- hide any tables
- open Metabase Admin > Permissions
- ensure the tables are visible and you can change their permissions

#### Loading tables only when needed
- Ensure the permissions editor behaves exactly the same as it was before and no regressions are introduced