### PR TITLE
Separate qa db snapshots

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1263,6 +1263,7 @@ workflows:
             - build-uberjar-<< matrix.edition >>
           cypress-group: "<< matrix.folder >>-<< matrix.edition >>"
           source-folder: << matrix.folder >>
+          qa-db: true
           before-steps:
             - wait-for-port:
                 port: 3306

--- a/frontend/test/__support__/e2e/cypress-plugins.js
+++ b/frontend/test/__support__/e2e/cypress-plugins.js
@@ -67,8 +67,9 @@ module.exports = (on, config) => {
    ********************************************************************/
 
   if (!isQaDatabase) {
-    config.ignoreTestFiles = "**/metabase-db/**";
+    config.ignoreTestFiles = ["**/metabase-db/**", "qa-db.cy.snap.js"];
   }
+
   config.env.HAS_ENTERPRISE_TOKEN = hasEnterpriseToken;
 
   return config;

--- a/frontend/test/snapshot-creators/default.cy.snap.js
+++ b/frontend/test/snapshot-creators/default.cy.snap.js
@@ -34,9 +34,6 @@ describe("snapshots", () => {
 
       snapshot("default");
 
-      addPostgresDatabase();
-      snapshot("postgres-12");
-
       restore("blank");
     });
   });

--- a/frontend/test/snapshot-creators/default.cy.snap.js
+++ b/frontend/test/snapshot-creators/default.cy.snap.js
@@ -1,10 +1,5 @@
 import _ from "underscore";
-import {
-  snapshot,
-  restore,
-  withSampleDataset,
-  addPostgresDatabase,
-} from "__support__/e2e/cypress";
+import { snapshot, restore, withSampleDataset } from "__support__/e2e/cypress";
 import { USERS, USER_GROUPS } from "__support__/e2e/cypress_data";
 
 const {

--- a/frontend/test/snapshot-creators/qa-db.cy.snap.js
+++ b/frontend/test/snapshot-creators/qa-db.cy.snap.js
@@ -1,0 +1,19 @@
+import {
+  restore,
+  snapshot,
+  addPostgresDatabase,
+} from "__support__/e2e/cypress";
+
+describe("qa databases snapshots", () => {
+  beforeEach(() => {
+    restore("default");
+    cy.signInAsAdmin();
+  });
+
+  it("creates snapshots for supported qa databases", () => {
+    addPostgresDatabase();
+    snapshot("postgres-12");
+
+    restore("blank");
+  });
+});


### PR DESCRIPTION
### Status
READY

### Context
- a56b640dfc8bbd4ae3d6047e0a9594f1c709a2b1 broke Percy workflow on `master` and introduced a major inconvenience for developers who wish to run Cypress locally. In both cases, it's required to have all supported QA DB docker images running at all times. Otherwise, the Cypress snapshot creation phase breaks.

### What does this PR accomplish?
- uses the existing ENV var to conditionally skip qa db snapshots
- if `QA_DB_ENABLED` is not present, the only file used to create snapshots would be `frontend/test/snapshot-creators/default.cy.snap.js`
- all QA DB related snapshots now live in a separate file (`frontend/test/snapshot-creators/qa-db.cy.snap.js`) that we skip conditionally
- This doesn't affect CircleCI workflow - it merely makes life easier for developers running Cypress locally and for a Percy workflow that runs on GitHub Actions (where we still don't have QA docker images available)

### How to test this?
- All e2e tests should pass on CircleCI
- Percy should be green in GitHub Actions (on `master`)

Manually:
1. Make sure you **don't** have any of the QA docker images running locally
2. delete `QA_DB_ENABLED` env var from your terminal
3. run `yarn test-cypress-open`
4. "Generating snapshots" step should pass and you should see the following report

Note that it found only one spec (`default.cy.snap.js`) and completely ignored `qa-db.cy.snap.js`
```
  (Run Starting)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Cypress:    6.8.0                                                                              │
  │ Browser:    Electron 87 (headless)                                                             │
  │ Specs:      1 found (snapshot-creators/default.cy.snap.js)                                     │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


────────────────────────────────────────────────────────────────────────────────────────────────────

  Running:  snapshot-creators/default.cy.snap.js                                            (1 of 1)


  snapshots
    default
      ✓ default (2848ms)
    withSqlite
Load lazy loading driver :sqlite took 160.6 ms
      ✓ withSqlite (2809ms)


  2 passing (6s)


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        2                                                                                │
  │ Passing:      2                                                                                │
  │ Failing:      0                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        true                                                                             │
  │ Duration:     5 seconds                                                                        │
  │ Spec Ran:     snapshot-creators/default.cy.snap.js                                             │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
```

Alternatively, you can set `QA_DB_ENABLED` to `true` in your ENVs without having ANY of the supported QA DB Docker images running on your system. 
1. "Generating snapshots" step should fail
2. You should see the following report
<details>
  <summary>Example of the stacktrace for Postgres</summary>

```
  Running:  snapshot-creators/qa-db.cy.snap.js                                              (2 of 2)

    1) creates snapshots for supported qa databases


  0 passing (754ms)
  1 failing

  1) qa databases snapshots
       creates snapshots for supported qa databases:
     CypressError: `cy.request()` failed on:

http://localhost:4000/api/database

The response we received from your web server was:

  > 400: Bad Request

This was considered a failure because the status code was not `2xx` or `3xx`.

If you do not want status codes to cause failures pass the option: `failOnStatusCode: false`

-----------------------------------------------------------

The request we sent was:

Method: POST
URL: http://localhost:4000/api/database
Headers: {
  "Connection": "keep-alive",
  "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 11_6_0) AppleWebKit/537.36 (KHTML, like Gecko) Cypress/6.8.0 Chrome/87.0.4280.141 Electron/11.3.0 Safari/537.36",
  "accept": "*/*",
  "cookie": "metabase.DEVICE=cdaa3ee6-b8ce-44dc-a618-f3e832006e4b; metabase.SESSION=ff0ca00f-e987-4ab9-9f2b-a354308b5b84",
  "accept-encoding": "gzip, deflate",
  "content-type": "application/json",
  "content-length": 500
}
Body: {"engine":"postgres","name":"QA Postgres12","details":{"dbname":"sample","host":"localhost","port":5432,"user":"metabase","password":"metasample123","authdb":null,"additional-options":null,"use-srv":false,"tunnel-enabled":false},"auto_run_queries":true,"is_full_sync":true,"schedules":{"cache_field_values":{"schedule_day":null,"schedule_frame":null,"schedule_hour":0,"schedule_type":"daily"},"metadata_sync":{"schedule_day":null,"schedule_frame":null,"schedule_hour":null,"schedule_type":"hourly"}}}

-----------------------------------------------------------

The response we got was:

Status: 400 - Bad Request
Headers: {
  "date": "Fri, 01 Oct 2021 11:48:07 GMT",
  "x-frame-options": "DENY",
  "x-xss-protection": "1; mode=block",
  "last-modified": "Fri, 1 Oct 2021 04:48:07 -0700",
  "strict-transport-security": "max-age=31536000",
  "x-permitted-cross-domain-policies": "none",
  "cache-control": "max-age=0, no-cache, must-revalidate, proxy-revalidate",
  "x-content-type-options": "nosniff",
  "content-security-policy": "default-src 'none'; script-src 'self' 'unsafe-eval' https://maps.google.com https://apis.google.com https://www.google-analytics.com https://*.googleapis.com *.gstatic.com   'sha256-lMAh4yjVuDkQ9NqkK4H+YHUga+anpFs5JAuj/uZh0Rs=' 'sha256-sMNbXyc1lLzhHbH/CKs11HIQMnMkZAN2eA99WhJeEC0=' 'sha256-JJa56hyDfUbgNfq+0nq6Qs866JKgZ/+qCq2pkDJED8k='; child-src 'self' https://accounts.google.com; style-src 'self' 'unsafe-inline'; font-src 'self' ; img-src * 'self' data:; connect-src 'self' metabase.us10.list-manage.com ; manifest-src 'self';  frame-ancestors 'none';",
  "content-type": "application/json;charset=utf-8",
  "expires": "Tue, 03 Jul 2001 06:00:00 GMT",
  "content-length": "318",
  "server": "Jetty(9.4.43.v20210629)"
}
Body: {
  "valid": false,
  "dbname": "Connection to localhost:5432 refused. Check that the hostname and port are correct and that the postmaster is accepting TCP/IP connections.",
  "message": "Connection to localhost:5432 refused. Check that the hostname and port are correct and that the postmaster is accepting TCP/IP connections."
}
```
</details>

### If you need to write or run db-related Cypress tests locally
1. Make sure you have the related QA DB docker image running first (you can see the full list [here](https://github.com/metabase/metabase-qa))
2. Set `QA_DB_ENABLED` to `true` in your ENVs
3. Start the Cypress either in open mode `yarn test-cypress-open` or in the run mode `yarn test-cypress-no-build`