### PR TITLE
Add missing categorical charts

### DIFF
--- a/frontend/src/metabase/internal/pages/StaticVizPage.jsx
+++ b/frontend/src/metabase/internal/pages/StaticVizPage.jsx
@@ -18,40 +18,6 @@ export default function StaticVizPage() {
           see updates.
         </Text>
         <Box py={3}>
-          <Subhead>Bar chart with timeseries data</Subhead>
-          <StaticChart
-            type="timeseries/bar"
-            options={{
-              data: [
-                ["2020-10-21", 20],
-                ["2020-10-22", 30],
-                ["2020-10-23", 25],
-                ["2020-10-24", 10],
-                ["2020-10-25", 15],
-              ],
-              accessors: {
-                x: row => new Date(row[0]).valueOf(),
-                y: row => row[1],
-              },
-              settings: {
-                x: {
-                  date_style: "MMMM DD, YYYY",
-                },
-                y: {
-                  number_style: "currency",
-                  currency: "USD",
-                  currency_style: "symbol",
-                  decimals: 0,
-                },
-              },
-              labels: {
-                left: "Price",
-                bottom: "Created At",
-              },
-            }}
-          />
-        </Box>
-        <Box py={3}>
           <Subhead>Line chart with timeseries data</Subhead>
           <StaticChart
             type="timeseries/line"
@@ -94,6 +60,101 @@ export default function StaticVizPage() {
               labels: {
                 left: "Count",
                 bottom: "Created At",
+              },
+            }}
+          />
+        </Box>
+        <Box py={3}>
+          <Subhead>Bar chart with timeseries data</Subhead>
+          <StaticChart
+            type="timeseries/bar"
+            options={{
+              data: [
+                ["2020-10-21", 20],
+                ["2020-10-22", 30],
+                ["2020-10-23", 25],
+                ["2020-10-24", 10],
+                ["2020-10-25", 15],
+              ],
+              accessors: {
+                x: row => new Date(row[0]).valueOf(),
+                y: row => row[1],
+              },
+              settings: {
+                x: {
+                  date_style: "MM/DD/YYYY",
+                },
+                y: {
+                  number_style: "currency",
+                  currency: "USD",
+                  currency_style: "symbol",
+                  decimals: 0,
+                },
+              },
+              labels: {
+                left: "Price",
+                bottom: "Created At",
+              },
+            }}
+          />
+        </Box>
+
+        <Box py={3}>
+          <Subhead>Line chart with categorical data</Subhead>
+          <StaticChart
+            type="categorical/line"
+            options={{
+              data: [
+                ["Alden Sparks", 70],
+                ["Areli Guerra", 30],
+                ["Arturo Hopkins", 80],
+                ["Beatrice Lane", 120],
+                ["Brylee Davenport", 100],
+                ["Cali Nixon", 60],
+                ["Dane Terrell", 150],
+                ["Deshawn Rollins", 40],
+                ["Isabell Bright", 70],
+                ["Kaya Rowe", 20],
+                ["Roderick Herman", 50],
+                ["Ruth Dougherty", 75],
+              ],
+              accessors: {
+                x: row => row[0],
+                y: row => row[1],
+              },
+              labels: {
+                left: "Tasks",
+                bottom: "People",
+              },
+            }}
+          />
+        </Box>
+        <Box py={3}>
+          <Subhead>Area chart with categorical data</Subhead>
+          <StaticChart
+            type="categorical/area"
+            options={{
+              data: [
+                ["Alden Sparks", 70],
+                ["Areli Guerra", 30],
+                ["Arturo Hopkins", 80],
+                ["Beatrice Lane", 120],
+                ["Brylee Davenport", 100],
+                ["Cali Nixon", 60],
+                ["Dane Terrell", 150],
+                ["Deshawn Rollins", 40],
+                ["Isabell Bright", 70],
+                ["Kaya Rowe", 20],
+                ["Roderick Herman", 50],
+                ["Ruth Dougherty", 75],
+              ],
+              accessors: {
+                x: row => row[0],
+                y: row => row[1],
+              },
+              labels: {
+                left: "Tasks",
+                bottom: "People",
               },
             }}
           />

--- a/frontend/src/metabase/static-viz/components/CategoricalAreaChart/CategoricalAreaChart.jsx
+++ b/frontend/src/metabase/static-viz/components/CategoricalAreaChart/CategoricalAreaChart.jsx
@@ -1,0 +1,146 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { AxisBottom, AxisLeft } from "@visx/axis";
+import { GridRows } from "@visx/grid";
+import { scaleBand, scaleLinear } from "@visx/scale";
+import { AreaClosed, LinePath } from "@visx/shape";
+import { Text } from "@visx/text";
+import {
+  getXTickWidth,
+  getXTickLabelProps,
+  getYTickLabelProps,
+  getYTickWidth,
+  getXTickHeight,
+} from "../../lib/axes";
+import { formatNumber } from "../../lib/numbers";
+import { truncateText } from "../../lib/text";
+
+const propTypes = {
+  data: PropTypes.array.isRequired,
+  accessors: PropTypes.shape({
+    x: PropTypes.func.isRequired,
+    y: PropTypes.func.isRequired,
+  }).isRequired,
+  settings: PropTypes.shape({
+    x: PropTypes.object,
+    y: PropTypes.object,
+  }),
+  labels: PropTypes.shape({
+    left: PropTypes.string,
+    bottom: PropTypes.string,
+  }),
+};
+
+const layout = {
+  width: 540,
+  height: 300,
+  margin: {
+    top: 0,
+    left: 55,
+    right: 40,
+    bottom: 40,
+  },
+  font: {
+    size: 11,
+    family: "Lato, sans-serif",
+  },
+  colors: {
+    brand: "#509ee3",
+    brandLight: "#DDECFA",
+    textLight: "#b8bbc3",
+    textMedium: "#949aab",
+  },
+  barPadding: 0.2,
+  labelPadding: 12,
+  maxTickWidth: 100,
+  strokeDasharray: "4",
+};
+
+const CategoricalAreaChart = ({ data, accessors, settings, labels }) => {
+  const isVertical = data.length > 10;
+  const xTickWidth = getXTickWidth(data, accessors, layout.maxTickWidth);
+  const xTickHeight = getXTickHeight(xTickWidth);
+  const yTickWidth = getYTickWidth(data, accessors, settings);
+  const xLabelOffset = xTickHeight + layout.labelPadding + layout.font.size;
+  const yLabelOffset = yTickWidth + layout.labelPadding;
+  const xMin = yLabelOffset + layout.font.size * 1.5;
+  const xMax = layout.width - layout.margin.right;
+  const yMin = isVertical ? xLabelOffset : layout.margin.bottom;
+  const yMax = layout.height - yMin;
+  const innerWidth = xMax - xMin;
+  const textBaseline = Math.floor(layout.font.size / 2);
+  const leftLabel = labels?.left;
+  const bottomLabel = !isVertical ? labels?.bottom : undefined;
+
+  const xScale = scaleBand({
+    domain: data.map(accessors.x),
+    range: [xMin, xMax],
+    round: true,
+    padding: layout.barPadding,
+  });
+
+  const yScale = scaleLinear({
+    domain: [0, Math.max(...data.map(accessors.y))],
+    range: [yMax, 0],
+    nice: true,
+  });
+
+  const getXTickProps = ({ x, y, formattedValue, ...props }) => {
+    const textWidth = isVertical ? xTickWidth : xScale.bandwidth();
+    const truncatedText = truncateText(formattedValue, textWidth);
+    const transform = isVertical
+      ? `rotate(45, ${x} ${y}) translate(-${textBaseline} 0)`
+      : undefined;
+
+    return { ...props, x, y, transform, children: truncatedText };
+  };
+
+  return (
+    <svg width={layout.width} height={layout.height}>
+      <GridRows
+        scale={yScale}
+        left={xMin}
+        width={innerWidth}
+        strokeDasharray={layout.strokeDasharray}
+      />
+      <AreaClosed
+        data={data}
+        yScale={yScale}
+        fill={layout.colors.brandLight}
+        x={d => xScale(accessors.x(d)) + xScale.bandwidth() / 2}
+        y={d => yScale(accessors.y(d))}
+      />
+      <AxisLeft
+        scale={yScale}
+        left={xMin}
+        label={leftLabel}
+        labelOffset={yLabelOffset}
+        hideTicks
+        hideAxisLine
+        tickFormat={value => formatNumber(value, settings?.y)}
+        tickLabelProps={() => getYTickLabelProps(layout)}
+      />
+      <LinePath
+        data={data}
+        stroke={layout.colors.brand}
+        strokeWidth={layout.strokeWidth}
+        x={d => xScale(accessors.x(d)) + xScale.bandwidth() / 2}
+        y={d => yScale(accessors.y(d))}
+      />
+      <AxisBottom
+        scale={xScale}
+        top={yMax}
+        label={bottomLabel}
+        numTicks={data.length}
+        stroke={layout.colors.textLight}
+        tickStroke={layout.colors.textLight}
+        tickComponent={props => <Text {...getXTickProps(props)} />}
+        tickLabelProps={() => getXTickLabelProps(layout, isVertical)}
+      />
+    </svg>
+  );
+};
+
+CategoricalAreaChart.propTypes = propTypes;
+
+export default CategoricalAreaChart;

--- a/frontend/src/metabase/static-viz/components/CategoricalAreaChart/index.js
+++ b/frontend/src/metabase/static-viz/components/CategoricalAreaChart/index.js
@@ -1,0 +1,1 @@
+export { default } from "./CategoricalAreaChart";

--- a/frontend/src/metabase/static-viz/components/CategoricalLineChart/CategoricalLineChart.jsx
+++ b/frontend/src/metabase/static-viz/components/CategoricalLineChart/CategoricalLineChart.jsx
@@ -1,0 +1,138 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { AxisBottom, AxisLeft } from "@visx/axis";
+import { GridRows } from "@visx/grid";
+import { scaleBand, scaleLinear } from "@visx/scale";
+import { LinePath } from "@visx/shape";
+import { Text } from "@visx/text";
+import {
+  getXTickWidth,
+  getXTickLabelProps,
+  getYTickLabelProps,
+  getYTickWidth,
+  getXTickHeight,
+} from "../../lib/axes";
+import { formatNumber } from "../../lib/numbers";
+import { truncateText } from "../../lib/text";
+
+const propTypes = {
+  data: PropTypes.array.isRequired,
+  accessors: PropTypes.shape({
+    x: PropTypes.func.isRequired,
+    y: PropTypes.func.isRequired,
+  }).isRequired,
+  settings: PropTypes.shape({
+    x: PropTypes.object,
+    y: PropTypes.object,
+  }),
+  labels: PropTypes.shape({
+    left: PropTypes.string,
+    bottom: PropTypes.string,
+  }),
+};
+
+const layout = {
+  width: 540,
+  height: 300,
+  margin: {
+    top: 0,
+    left: 55,
+    right: 40,
+    bottom: 40,
+  },
+  font: {
+    size: 11,
+    family: "Lato, sans-serif",
+  },
+  colors: {
+    brand: "#509ee3",
+    textLight: "#b8bbc3",
+    textMedium: "#949aab",
+  },
+  barPadding: 0.2,
+  labelPadding: 12,
+  maxTickWidth: 100,
+  strokeDasharray: "4",
+};
+
+const CategoricalLineChart = ({ data, accessors, settings, labels }) => {
+  const isVertical = data.length > 10;
+  const xTickWidth = getXTickWidth(data, accessors, layout.maxTickWidth);
+  const xTickHeight = getXTickHeight(xTickWidth);
+  const yTickWidth = getYTickWidth(data, accessors, settings);
+  const xLabelOffset = xTickHeight + layout.labelPadding + layout.font.size;
+  const yLabelOffset = yTickWidth + layout.labelPadding;
+  const xMin = yLabelOffset + layout.font.size * 1.5;
+  const xMax = layout.width - layout.margin.right;
+  const yMin = isVertical ? xLabelOffset : layout.margin.bottom;
+  const yMax = layout.height - yMin;
+  const innerWidth = xMax - xMin;
+  const textBaseline = Math.floor(layout.font.size / 2);
+  const leftLabel = labels?.left;
+  const bottomLabel = !isVertical ? labels?.bottom : undefined;
+
+  const xScale = scaleBand({
+    domain: data.map(accessors.x),
+    range: [xMin, xMax],
+    round: true,
+    padding: layout.barPadding,
+  });
+
+  const yScale = scaleLinear({
+    domain: [0, Math.max(...data.map(accessors.y))],
+    range: [yMax, 0],
+    nice: true,
+  });
+
+  const getXTickProps = ({ x, y, formattedValue, ...props }) => {
+    const textWidth = isVertical ? xTickWidth : xScale.bandwidth();
+    const truncatedText = truncateText(formattedValue, textWidth);
+    const transform = isVertical
+      ? `rotate(45, ${x} ${y}) translate(-${textBaseline} 0)`
+      : undefined;
+
+    return { ...props, x, y, transform, children: truncatedText };
+  };
+
+  return (
+    <svg width={layout.width} height={layout.height}>
+      <GridRows
+        scale={yScale}
+        left={xMin}
+        width={innerWidth}
+        strokeDasharray={layout.strokeDasharray}
+      />
+      <LinePath
+        data={data}
+        stroke={layout.colors.brand}
+        strokeWidth={layout.strokeWidth}
+        x={d => xScale(accessors.x(d)) + xScale.bandwidth() / 2}
+        y={d => yScale(accessors.y(d))}
+      />
+      <AxisLeft
+        scale={yScale}
+        left={xMin}
+        label={leftLabel}
+        labelOffset={yLabelOffset}
+        hideTicks
+        hideAxisLine
+        tickFormat={value => formatNumber(value, settings?.y)}
+        tickLabelProps={() => getYTickLabelProps(layout)}
+      />
+      <AxisBottom
+        scale={xScale}
+        top={yMax}
+        label={bottomLabel}
+        numTicks={data.length}
+        stroke={layout.colors.textLight}
+        tickStroke={layout.colors.textLight}
+        tickComponent={props => <Text {...getXTickProps(props)} />}
+        tickLabelProps={() => getXTickLabelProps(layout, isVertical)}
+      />
+    </svg>
+  );
+};
+
+CategoricalLineChart.propTypes = propTypes;
+
+export default CategoricalLineChart;

--- a/frontend/src/metabase/static-viz/components/CategoricalLineChart/index.js
+++ b/frontend/src/metabase/static-viz/components/CategoricalLineChart/index.js
@@ -1,0 +1,1 @@
+export { default } from "./CategoricalLineChart";

--- a/frontend/src/metabase/static-viz/containers/StaticChart/StaticChart.jsx
+++ b/frontend/src/metabase/static-viz/containers/StaticChart/StaticChart.jsx
@@ -1,15 +1,19 @@
 import React from "react";
 import PropTypes from "prop-types";
+import CategoricalAreaChart from "../../components/CategoricalAreaChart";
 import CategoricalBarChart from "../../components/CategoricalBarChart";
 import CategoricalDonutChart from "../../components/CategoricalDonutChart";
+import CategoricalLineChart from "../../components/CategoricalLineChart";
 import TimeSeriesAreaChart from "../../components/TimeSeriesAreaChart";
 import TimeSeriesBarChart from "../../components/TimeSeriesBarChart";
 import TimeSeriesLineChart from "../../components/TimeSeriesLineChart";
 
 const propTypes = {
   type: PropTypes.oneOf([
+    "categorical/area",
     "categorical/bar",
     "categorical/donut",
+    "categorical/line",
     "timeseries/area",
     "timeseries/bar",
     "timeseries/line",
@@ -19,10 +23,14 @@ const propTypes = {
 
 const StaticChart = ({ type, options }) => {
   switch (type) {
+    case "categorical/area":
+      return <CategoricalAreaChart {...options} />;
     case "categorical/bar":
       return <CategoricalBarChart {...options} />;
     case "categorical/donut":
       return <CategoricalDonutChart {...options} />;
+    case "categorical/line":
+      return <CategoricalLineChart {...options} />;
     case "timeseries/area":
       return <TimeSeriesAreaChart {...options} />;
     case "timeseries/bar":

--- a/frontend/src/metabase/static-viz/containers/StaticChart/StaticChart.unit.spec.js
+++ b/frontend/src/metabase/static-viz/containers/StaticChart/StaticChart.unit.spec.js
@@ -3,6 +3,68 @@ import { render, screen } from "@testing-library/react";
 import StaticChart from "./StaticChart";
 
 describe("StaticChart", () => {
+  it("should render categorical/line", () => {
+    render(
+      <StaticChart
+        type="categorical/line"
+        options={{
+          data: [["Gadget", 20], ["Widget", 31]],
+          accessors: {
+            x: row => row[0],
+            y: row => row[1],
+          },
+          settings: {
+            y: {
+              number_style: "currency",
+              currency: "USD",
+              currency_style: "symbol",
+            },
+          },
+          labels: {
+            left: "Count",
+            bottom: "Category",
+          },
+        }}
+      />,
+    );
+
+    screen.getByText("Gadget");
+    screen.getByText("Widget");
+    screen.getAllByText("Count");
+    screen.getAllByText("Category");
+  });
+
+  it("should render categorical/area", () => {
+    render(
+      <StaticChart
+        type="categorical/area"
+        options={{
+          data: [["Gadget", 20], ["Widget", 31]],
+          accessors: {
+            x: row => row[0],
+            y: row => row[1],
+          },
+          settings: {
+            y: {
+              number_style: "currency",
+              currency: "USD",
+              currency_style: "symbol",
+            },
+          },
+          labels: {
+            left: "Count",
+            bottom: "Category",
+          },
+        }}
+      />,
+    );
+
+    screen.getByText("Gadget");
+    screen.getByText("Widget");
+    screen.getAllByText("Count");
+    screen.getAllByText("Category");
+  });
+
   it("should render categorical/bar", () => {
     render(
       <StaticChart
@@ -63,33 +125,6 @@ describe("StaticChart", () => {
     screen.getAllByText("TOTAL");
   });
 
-  it("should render timeseries/bar", () => {
-    render(
-      <StaticChart
-        type="timeseries/bar"
-        options={{
-          data: [["2010-11-07", 20], ["2020-11-08", 30]],
-          accessors: {
-            x: row => new Date(row[0]).valueOf(),
-            y: row => row[1],
-          },
-          settings: {
-            x: {
-              date_style: "dddd",
-            },
-          },
-          labels: {
-            left: "Count",
-            bottom: "Time",
-          },
-        }}
-      />,
-    );
-
-    screen.getAllByText("Count");
-    screen.getAllByText("Time");
-  });
-
   it("should render timeseries/line", () => {
     render(
       <StaticChart
@@ -130,6 +165,33 @@ describe("StaticChart", () => {
           settings: {
             x: {
               date_style: "MMM",
+            },
+          },
+          labels: {
+            left: "Count",
+            bottom: "Time",
+          },
+        }}
+      />,
+    );
+
+    screen.getAllByText("Count");
+    screen.getAllByText("Time");
+  });
+
+  it("should render timeseries/bar", () => {
+    render(
+      <StaticChart
+        type="timeseries/bar"
+        options={{
+          data: [["2010-11-07", 20], ["2020-11-08", 30]],
+          accessors: {
+            x: row => new Date(row[0]).valueOf(),
+            y: row => row[1],
+          },
+          settings: {
+            x: {
+              date_style: "dddd",
             },
           },
           labels: {


### PR DESCRIPTION
Related https://github.com/metabase/metabase/issues/18157

Some line/area questions aren't supported for static viz. To solve the issue, this PR adds missing chart types according to the current scheme. 

How to test:
- Open `_internal/static-viz`
- You should be able to see categorical line and area charts

<img width="646" alt="Screen Shot 2021-10-01 at 4 26 47 pm" src="https://user-images.githubusercontent.com/8542534/135627768-3a16eec0-a626-45d4-9d65-c2d6156e5280.png">
