### PR TITLE
Fix empty state in the Erroring questions page

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditParameters.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/components/AuditParameters.jsx
@@ -52,7 +52,7 @@ export default class AuditParameters extends React.Component {
     const { parameters, children, buttons, hasResults } = this.props;
     const { inputValues, committedValues } = this.state;
 
-    const disabled =
+    const isEmpty =
       hasResults === false &&
       inputValues &&
       Object.values(inputValues).every(v => v === "");
@@ -60,26 +60,26 @@ export default class AuditParameters extends React.Component {
     return (
       <div>
         <div className="pt4">
-          {parameters.map(({ key, placeholder, icon }) => (
+          {parameters.map(({ key, placeholder, icon, disabled }) => (
             <AuditParametersInput
               key={key}
               type="text"
               value={inputValues[key] || ""}
               placeholder={placeholder}
-              disabled={disabled}
+              disabled={isEmpty || disabled}
               onChange={value => {
                 this.changeValue(key, value);
               }}
               icon={icon}
             />
           ))}
-          {buttons?.map(({ key, onClick, label }) => (
+          {buttons?.map(({ key, label, disabled, onClick }) => (
             <Button
-              primary
-              key={key}
-              onClick={onClick}
-              disabled={disabled}
               className="ml2"
+              key={key}
+              primary
+              disabled={isEmpty || disabled}
+              onClick={onClick}
             >
               {label}
             </Button>

--- a/enterprise/frontend/src/metabase-enterprise/tools/containers/ErrorOverview.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/tools/containers/ErrorOverview.jsx
@@ -28,8 +28,8 @@ export default function ErrorOverview(props) {
   const [rowChecked, setRowChecked] = useState({});
   const [rowToCardId, setRowToCardId] = useState({});
   const handleRowSelectClick = e => {
-    const newRowChecked = rowChecked;
-    const newRowToCardId = rowToCardId;
+    const newRowChecked = { ...rowChecked };
+    const newRowToCardId = { ...rowToCardId };
     newRowChecked[e.rowIndex] = !(rowChecked[e.rowIndex] || false);
     newRowToCardId[e.rowIndex] = e.row[CARD_ID_COL];
     setRowChecked(newRowChecked);
@@ -68,6 +68,7 @@ export default function ErrorOverview(props) {
         {
           key: "reloadSelected",
           label: t`Rerun Selected`,
+          disabled: Object.values(rowChecked).every(isChecked => !isChecked),
           onClick: handleReloadSelected,
         },
       ]}

--- a/frontend/test/metabase/scenarios/admin/tools/erroring-questions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/tools/erroring-questions.cy.spec.js
@@ -37,28 +37,15 @@ describeWithToken("admin > tools > erroring questions ", () => {
         .click();
 
       cy.location("pathname").should("eq", TOOLS_ERRORS_URL);
-
-      cy.findByText("No results");
-
       cy.findByRole("link", { name: "Erroring Questions" })
         .should("have.attr", "href")
         .and("eq", TOOLS_ERRORS_URL);
-    });
 
-    it.skip("should disable search input fields (metabase#18050)", () => {
-      cy.visit(TOOLS_ERRORS_URL);
-
-      // When the issue gets fixed, it's safe to merge these assertions with the main test above
+      cy.findByText("No results");
+      cy.button("Rerun Selected").should("be.disabled");
       cy.findByPlaceholderText("Error name").should("be.disabled");
       cy.findByPlaceholderText("DB name").should("be.disabled");
       cy.findByPlaceholderText("Collection name").should("be.disabled");
-    });
-
-    it.skip('should disable "Rerun Selected" button (metabase#18048)', () => {
-      cy.visit(TOOLS_ERRORS_URL);
-
-      // When the issue gets fixed, it's safe to merge these assertions with the main test above
-      cy.button("Rerun Selected").should("be.disabled");
     });
   });
 
@@ -69,11 +56,6 @@ describeWithToken("admin > tools > erroring questions ", () => {
       });
 
       cy.visit(TOOLS_ERRORS_URL);
-    });
-
-    it.skip('should disable "Rerun Selected" button (metabase#18048)', () => {
-      // When the issue gets fixed, merge it with the main test below
-      cy.button("Rerun Selected").should("be.disabled");
     });
 
     it("should render correctly", () => {
@@ -90,6 +72,7 @@ describeWithToken("admin > tools > erroring questions ", () => {
       // The question is still there because we didn't fix it
       cy.findByText(brokenQuestionDetails.name);
 
+      cy.button("Rerun Selected").should("be.disabled");
       cy.findByPlaceholderText("Error name").should("not.be.disabled");
       cy.findByPlaceholderText("DB name").should("not.be.disabled");
       cy.findByPlaceholderText("Collection name")


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/18050
Fixes https://github.com/metabase/metabase/issues/18048

This PR fixes reproduced bugs, the easiest way to test it is to run CY tests in `erroring-questions.cy.spec.js`.

How to manually test:
- Create a broken question, e.g. a native question with a required parameter without providing default value
- Try to visualize the question, there should be an error
- Go to Admin > Tools > Erroring questions
- There should be the question from the first step
- Check that `Rerun selected` button is disabled
- Fix the question, e.g. by providing a default value to the parameter
- Select the question and click `Rerun selected`. Button should not be disabled.
