### PR TITLE
Fix composite chart layout

### DIFF
--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -535,12 +535,12 @@ function getCharts(
   const { settings, chartType, series, onChangeCardAndRun } = props;
   const { yAxisSplit } = yAxisProps;
 
-  const isHeterogenous =
-    _.uniq(series.map(single => getSeriesDisplay(settings, single))).length > 1;
-  const isHeterogenousOrdinal =
-    settings["graph.x_axis.scale"] === "ordinal" && isHeterogenous;
+  const displays = _.uniq(series.map(s => getSeriesDisplay(settings, s)));
+  const isMixedBar = displays.includes("bar") && displays.length > 1;
+  const isOrdinal = settings["graph.x_axis.scale"] === "ordinal";
+  const isMixedOrdinalBar = isMixedBar && isOrdinal;
 
-  if (isHeterogenousOrdinal) {
+  if (isMixedOrdinalBar) {
     // HACK: ordinal + mix of line and bar results in uncentered points, shift by
     // half the width
     parent.on("renderlet.shift", () => {
@@ -601,7 +601,7 @@ function getCharts(
       settings,
       seriesChartType,
       seriesSettings,
-      isHeterogenousOrdinal,
+      isMixedOrdinalBar,
     );
 
     return chart;

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -410,13 +410,7 @@ function getDcjsChart(cardType, parent) {
   }
 }
 
-function applyChartLineBarSettings(
-  chart,
-  settings,
-  chartType,
-  seriesSettings,
-  forceCenterBar,
-) {
+function applyChartLineBarSettings(chart, settings, chartType, seriesSettings) {
   // LINE/AREA:
   // for chart types that have an 'interpolate' option (line/area charts), enable based on settings
   if (chart.interpolate) {
@@ -436,9 +430,7 @@ function applyChartLineBarSettings(
   if (chart.barPadding) {
     chart
       .barPadding(BAR_PADDING_RATIO)
-      .centerBar(
-        forceCenterBar || settings["graph.x_axis.scale"] !== "ordinal",
-      );
+      .centerBar(settings["graph.x_axis.scale"] !== "ordinal");
   }
 
   // AREA/BAR:
@@ -540,24 +532,6 @@ function getCharts(
   const isHeterogenousOrdinal =
     settings["graph.x_axis.scale"] === "ordinal" && isHeterogenous;
 
-  if (isHeterogenousOrdinal) {
-    // HACK: ordinal + mix of line and bar results in uncentered points, shift by
-    // half the width
-    parent.on("renderlet.shift", () => {
-      // ordinal, so we can get the first two points to determine spacing
-      const scale = parent.x();
-      const values = scale.domain();
-      const spacing = scale(values[1]) - scale(values[0]);
-      parent
-        .svg()
-        // shift bar/line and dots
-        .selectAll(".stack, .dc-tooltip")
-        .each(function() {
-          this.setAttribute("transform", `translate(${spacing / 2}, 0)`);
-        });
-    });
-  }
-
   return groups.map((group, index) => {
     const single = series[index];
     const seriesSettings = settings.series(single);
@@ -596,13 +570,7 @@ function getCharts(
       chart.stack(group[i]);
     }
 
-    applyChartLineBarSettings(
-      chart,
-      settings,
-      seriesChartType,
-      seriesSettings,
-      isHeterogenousOrdinal,
-    );
+    applyChartLineBarSettings(chart, settings, seriesChartType, seriesSettings);
 
     return chart;
   });

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -410,7 +410,13 @@ function getDcjsChart(cardType, parent) {
   }
 }
 
-function applyChartLineBarSettings(chart, settings, chartType, seriesSettings) {
+function applyChartLineBarSettings(
+  chart,
+  settings,
+  chartType,
+  seriesSettings,
+  forceCenterBar,
+) {
   // LINE/AREA:
   // for chart types that have an 'interpolate' option (line/area charts), enable based on settings
   if (chart.interpolate) {
@@ -430,7 +436,9 @@ function applyChartLineBarSettings(chart, settings, chartType, seriesSettings) {
   if (chart.barPadding) {
     chart
       .barPadding(BAR_PADDING_RATIO)
-      .centerBar(settings["graph.x_axis.scale"] !== "ordinal");
+      .centerBar(
+        forceCenterBar || settings["graph.x_axis.scale"] !== "ordinal",
+      );
   }
 
   // AREA/BAR:
@@ -532,6 +540,24 @@ function getCharts(
   const isHeterogenousOrdinal =
     settings["graph.x_axis.scale"] === "ordinal" && isHeterogenous;
 
+  if (isHeterogenousOrdinal) {
+    // HACK: ordinal + mix of line and bar results in uncentered points, shift by
+    // half the width
+    parent.on("renderlet.shift", () => {
+      // ordinal, so we can get the first two points to determine spacing
+      const scale = parent.x();
+      const values = scale.domain();
+      const spacing = scale(values[1]) - scale(values[0]);
+      parent
+        .svg()
+        // shift bar/line and dots
+        .selectAll(".stack, .dc-tooltip")
+        .each(function() {
+          this.setAttribute("transform", `translate(${spacing / 2}, 0)`);
+        });
+    });
+  }
+
   return groups.map((group, index) => {
     const single = series[index];
     const seriesSettings = settings.series(single);
@@ -570,7 +596,13 @@ function getCharts(
       chart.stack(group[i]);
     }
 
-    applyChartLineBarSettings(chart, settings, seriesChartType, seriesSettings);
+    applyChartLineBarSettings(
+      chart,
+      settings,
+      seriesChartType,
+      seriesSettings,
+      isHeterogenousOrdinal,
+    );
 
     return chart;
   });

--- a/frontend/test/metabase-visual/visualizations/line.cy.spec.js
+++ b/frontend/test/metabase-visual/visualizations/line.cy.spec.js
@@ -118,4 +118,45 @@ describe("visual tests > visualizations > line", () => {
 
     cy.percySnapshot();
   });
+
+  it("with multiple series and different display types (metabase#11216)", () => {
+    visitQuestionAdhoc({
+      dataset_query: {
+        type: "query",
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: [["count"], ["sum", ["field", ORDERS.TOTAL, null]]],
+          breakout: [
+            [
+              "field",
+              ORDERS.CREATED_AT,
+              {
+                "temporal-unit": "year",
+              },
+            ],
+          ],
+        },
+        database: 1,
+      },
+      display: "line",
+      visualization_settings: {
+        series_settings: {
+          sum: {
+            display: "line",
+          },
+          count: {
+            display: "area",
+          },
+        },
+        "graph.dimensions": ["CREATED_AT"],
+        "graph.x_axis.scale": "ordinal",
+        "graph.show_values": true,
+        "graph.metrics": ["count", "sum"],
+      },
+    });
+
+    cy.wait("@dataset");
+
+    cy.percySnapshot();
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/11216

How to test:
- Create a question based on Orders, Group by Created At (Year), Aggregate up by Count + Sum of Total
- Change visualization type to `line`
- Change the display type for one of the series to `area`

It should not break the chart layout, e.g. look the same it was with `line` for both series

<img width="1531" alt="Screen Shot 2021-10-04 at 6 15 57 pm" src="https://user-images.githubusercontent.com/8542534/135877666-f1992289-7da7-48ed-a378-28f18f5037f9.png">

Please note that this PR doesn't solve the issue with mixing bars with other display types.