### PR TITLE
Docker build: just one build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,5 @@
 ###################
-# STAGE 1.1: builder frontend
-###################
-
-FROM metabase/ci:circleci-java-11-clj-1.10.3.929-07-27-2021-node-browsers as frontend
-
-ARG MB_EDITION=oss
-
-WORKDIR /home/circleci
-
-COPY --chown=circleci . .
-RUN WEBPACK_BUNDLE=production MB_EDITION=$MB_EDITION yarn --frozen-lockfile && \
-    yarn build && yarn build-static-viz && bin/i18n/build-translation-resources
-
-###################
-# STAGE 1.4: main builder
+# STAGE 1: builder
 ###################
 
 FROM metabase/ci:circleci-java-11-clj-1.10.3.929-07-27-2021-node-browsers as builder
@@ -22,12 +8,8 @@ ARG MB_EDITION=oss
 
 WORKDIR /home/circleci
 
-# try to reuse caching as much as possible
-COPY --from=frontend /home/circleci/.m2/repository/. /home/circleci/.m2/repository/.
-COPY --from=frontend /home/circleci/. .
-
-# build the app
-RUN INTERACTIVE=false MB_EDITION=$MB_EDITION bin/build version drivers uberjar
+COPY --chown=circleci . .
+RUN INTERACTIVE=false CI=true MB_EDITION=$MB_EDITION bin/build
 
 # ###################
 # # STAGE 2: runner


### PR DESCRIPTION
As a follow-up to PR #18087, this PR will ensure that doing a build inside a Docker container will yield an optimized, production bundle for all front-end assets.

**To verify** (`rainbow-dash` is just a random name, pick whatever you like):

```
docker build --no-cache -t rainbow-dash .
docker run --rm -dp 3000:3000 rainbow-dash
sleep 60
```

and inspect the freshly started container (using the usual `docker exec -it`)

```
cd /app
unzip metabase.jar
find frontend_client/app/dist/*.js | xargs wc -c
```

**Before this PR**

The result is:

```
    31424 frontend_client/app/dist/app-embed.bundle.js
  5932510 frontend_client/app/dist/app-main.bundle.js
    31659 frontend_client/app/dist/app-public.bundle.js
  6066679 frontend_client/app/dist/app_js-dashboard_reducers_js-public_containers_PublicDashboard_jsx-public_containers_PublicQu-4a0a54.bundle.js
   152983 frontend_client/app/dist/lib-static-viz.bundle.js
   114106 frontend_client/app/dist/node_modules_babel-loader_lib_index_js_ruleSet_1_rules_0_use_0_node_modules_eslint-loader_dis-546ef7.bundle.js
   142063 frontend_client/app/dist/styles.bundle.js
 10943838 frontend_client/app/dist/vendors-node_modules_ace-builds_src-min-noconflict_ace_js-node_modules_ace-builds_src-min-noc-bf8b0d.bundle.js
    16915 frontend_client/app/dist/vendors-node_modules_css-loader_lib_css-base_js-node_modules_css-loader_lib_url_escape_js-nod-8b1f87.bundle.js
    35770 frontend_client/app/dist/vendors-node_modules_iframe-resizer_js_iframeResizer_contentWindow_js.bundle.js
  1022942 frontend_client/app/dist/vendors-node_modules_visx_axis_esm_axis_AxisBottom_js-node_modules_visx_axis_esm_axis_AxisLef-17c1f1.bundle.js
 24490889 total
```

**After this PR**

The result is:

```
    25922 frontend_client/app/dist/323.bundle.js
  3907626 frontend_client/app/dist/367.bundle.js
   612831 frontend_client/app/dist/370.bundle.js
  1775855 frontend_client/app/dist/411.bundle.js
    13584 frontend_client/app/dist/425.bundle.js
   347266 frontend_client/app/dist/93.bundle.js
    67606 frontend_client/app/dist/932.bundle.js
     7553 frontend_client/app/dist/app-embed.bundle.js
  2587671 frontend_client/app/dist/app-main.bundle.js
     7996 frontend_client/app/dist/app-public.bundle.js
   152983 frontend_client/app/dist/lib-static-viz.bundle.js
       99 frontend_client/app/dist/styles.bundle.js
  9506992 total
```
