### PR TITLE
Remove unused function props passed to ParameterWidget

### DIFF
--- a/frontend/src/metabase/dashboard/components/Dashboard/ParametersWidget/ParametersWidget.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/ParametersWidget/ParametersWidget.jsx
@@ -13,11 +13,8 @@ const propTypes = {
   location: PropTypes.object,
   parameterValues: PropTypes.object,
   parameters: PropTypes.array,
-  removeParameter: PropTypes.func,
   setEditingParameter: PropTypes.func,
-  setParameterDefaultValue: PropTypes.func,
   setParameterIndex: PropTypes.func,
-  setParameterName: PropTypes.func,
   setParameterValue: PropTypes.func,
   shouldRenderAsNightMode: PropTypes.bool.isRequired,
 };
@@ -31,11 +28,8 @@ const ParametersWidget = ({
   location,
   parameterValues,
   parameters,
-  removeParameter,
   setEditingParameter,
-  setParameterDefaultValue,
   setParameterIndex,
-  setParameterName,
   setParameterValue,
   shouldRenderAsNightMode,
 }) => {
@@ -51,10 +45,7 @@ const ParametersWidget = ({
       query={location.query}
       editingParameter={editingParameter}
       setEditingParameter={setEditingParameter}
-      setParameterName={setParameterName}
       setParameterIndex={setParameterIndex}
-      setParameterDefaultValue={setParameterDefaultValue}
-      removeParameter={removeParameter}
       setParameterValue={setParameterValue}
     />
   ) : null;

--- a/frontend/src/metabase/parameters/components/Parameters/Parameters.jsx
+++ b/frontend/src/metabase/parameters/components/Parameters/Parameters.jsx
@@ -57,11 +57,8 @@ export default class Parameters extends Component {
       vertical,
       commitImmediately,
 
-      setParameterName,
       setParameterValue,
-      setParameterDefaultValue,
       setParameterIndex,
-      removeParameter,
       setEditingParameter,
     } = this.props;
 
@@ -79,11 +76,8 @@ export default class Parameters extends Component {
         isQB={isQB}
         vertical={vertical}
         commitImmediately={commitImmediately}
-        setParameterName={setParameterName}
         setParameterValue={setParameterValue}
-        setParameterDefaultValue={setParameterDefaultValue}
         setParameterIndex={setParameterIndex}
-        removeParameter={removeParameter}
         setEditingParameter={setEditingParameter}
       />
     );

--- a/frontend/src/metabase/parameters/components/ParametersList.jsx
+++ b/frontend/src/metabase/parameters/components/ParametersList.jsx
@@ -37,14 +37,7 @@ type Props = {
   vertical?: boolean,
   commitImmediately?: boolean,
 
-  setParameterName?: (parameterId: ParameterId, name: string) => void,
-  setParameterValue?: (parameterId: ParameterId, value: string) => void,
-  setParameterDefaultValue?: (
-    parameterId: ParameterId,
-    defaultValue: string,
-  ) => void,
   setParameterIndex?: (parameterId: ParameterId, index: number) => void,
-  removeParameter?: (parameterId: ParameterId) => void,
   setEditingParameter?: (parameterId: ParameterId) => void,
 };
 
@@ -84,9 +77,7 @@ function ParametersList({
   vertical,
   commitImmediately,
 
-  setParameterName,
   setParameterValue,
-  setParameterDefaultValue,
   setParameterIndex,
   removeParameter,
   setEditingParameter,
@@ -154,22 +145,9 @@ function ParametersList({
           editingParameter={editingParameter}
           setEditingParameter={setEditingParameter}
           index={index}
-          setName={
-            setParameterName &&
-            (name => setParameterName(valuePopulatedParameter.id, name))
-          }
           setValue={
             setParameterValue &&
             (value => setParameterValue(valuePopulatedParameter.id, value))
-          }
-          setDefaultValue={
-            setParameterDefaultValue &&
-            (value =>
-              setParameterDefaultValue(valuePopulatedParameter.id, value))
-          }
-          remove={
-            removeParameter &&
-            (() => removeParameter(valuePopulatedParameter.id))
           }
           commitImmediately={commitImmediately}
           dragHandle={


### PR DESCRIPTION
These props aren't used in `ParameterWidget`, so we can safely remove them. I imagine that these callbacks were used at some point before the existence of the `ParametersSidebar`, which is where we now manage all three of the things referenced by these props.