### PR TITLE
Fix exports for queries with aggregations

### DIFF
--- a/src/metabase/query_processor/streaming.clj
+++ b/src/metabase/query_processor/streaming.clj
@@ -47,8 +47,9 @@
                                ;; If table-columns is not provided (e.g. for saved cards), we can construct a fake one
                                ;; that retains the original column ordering in `cols`
                                (for [col cols]
-                                 (let [id-or-name (or (:id col) (:name col))]
-                                   {::mb.viz/table-column-field-ref ["field" id-or-name nil]
+                                 (let [id-or-name (or (:id col) (:name col))
+                                       field-ref  (:field_ref col)]
+                                   {::mb.viz/table-column-field-ref (or field-ref [:field id-or-name nil])
                                     ::mb.viz/table-column-enabled true})))
         enabled-table-cols (filter ::mb.viz/table-column-enabled table-columns')
         cols-vector        (into [] cols)

--- a/src/metabase/query_processor/streaming.clj
+++ b/src/metabase/query_processor/streaming.clj
@@ -34,6 +34,11 @@
        (mbql.u/uniquify-names (map :name cols))))
 
 (defn- field-ref->map-key
+  "Converts the field-ref of a column to a vector that is used for lookups in the `cols-index` map in
+  `export-column-order`.
+
+  TODO: Figure out why keywords in the field-ref in `cols` are strings in the equivalent fields in `table-columns`.
+  If this can be fixed, we could use the entire field-ref directly as a map key."
   [field-ref]
   [(keyword (first field-ref)) (second field-ref)])
 

--- a/test/metabase/query_processor/streaming_test.clj
+++ b/test/metabase/query_processor/streaming_test.clj
@@ -305,6 +305,18 @@
             [{::mb.viz/table-column-field-ref ["aggregation" 1], ::mb.viz/table-column-enabled true}
              {::mb.viz/table-column-field-ref ["aggregation" 0], ::mb.viz/table-column-enabled true}]))))
 
+  (testing "correlation of custom expressions by field_ref"
+    (is (= [0 1]
+           (@#'qp.streaming/export-column-order
+            [{:id 0, :field_ref [:expression "Name0"]}, {:id 1, :field_ref [:expression "Name1"]}]
+            [{::mb.viz/table-column-field-ref ["expression" "Name0"], ::mb.viz/table-column-enabled true}
+             {::mb.viz/table-column-field-ref ["expression" "Name1"], ::mb.viz/table-column-enabled true}])))
+    (is (= [1 0]
+           (@#'qp.streaming/export-column-order
+            [{:id 0, :field_ref [:expression "Name0"]}, {:id 1, :field_ref [:expression "Name1"]}]
+            [{::mb.viz/table-column-field-ref ["expression" "Name1"], ::mb.viz/table-column-enabled true}
+             {::mb.viz/table-column-field-ref ["expression" "Name0"], ::mb.viz/table-column-enabled true}]))))
+
   (testing "disabled columns are excluded from ordering"
     (is (= [0]
            (@#'qp.streaming/export-column-order

--- a/test/metabase/query_processor/streaming_test.clj
+++ b/test/metabase/query_processor/streaming_test.clj
@@ -293,6 +293,18 @@
             [{::mb.viz/table-column-field-ref ["field" "Col2" nil], ::mb.viz/table-column-enabled true}
              {::mb.viz/table-column-field-ref ["field" "Col1" nil], ::mb.viz/table-column-enabled true}]))))
 
+  (testing "correlation of aggregation fields by field_ref"
+    (is (= [0 1]
+           (@#'qp.streaming/export-column-order
+            [{:id 0, :field_ref [:aggregation 0]}, {:id 1, :field_ref [:aggregation 1]}]
+            [{::mb.viz/table-column-field-ref ["aggregation" 0], ::mb.viz/table-column-enabled true}
+             {::mb.viz/table-column-field-ref ["aggregation" 1], ::mb.viz/table-column-enabled true}])))
+    (is (= [1 0]
+           (@#'qp.streaming/export-column-order
+            [{:id 0, :field_ref [:aggregation 0]}, {:id 1, :field_ref [:aggregation 1]}]
+            [{::mb.viz/table-column-field-ref ["aggregation" 1], ::mb.viz/table-column-enabled true}
+             {::mb.viz/table-column-field-ref ["aggregation" 0], ::mb.viz/table-column-enabled true}]))))
+
   (testing "disabled columns are excluded from ordering"
     (is (= [0]
            (@#'qp.streaming/export-column-order


### PR DESCRIPTION
Previously, to order viz settings & data for exports, I was using a map that associated column IDs and/or names with their position in the `cols` list. This code made an assumption that the `field_ref` for a column to have either an ID or name in the second position.
 
This approach worked fine for most fields, but did not work for aggregated fields which have the `field_ref` format `[:aggregation n]` where `n` is, I believe, unique for each aggregated field in the query. I've changed the key to use the first two entries in the field ref as the key instead (i.e. excluding metadata), which works for normal and aggregated fields. 

I needed to call `keyword` on the first entry in the key ref since it's a string in the viz settings (e.g. `["aggregation" 0]`), but a keyword in `cols` (e.g. `[:aggregation 0]`). I'm not sure where this discrepancy arises; if anyone knows, please enlighten me. 

Resolves #18181