### PR TITLE
fix missing prop types import after renaming

### DIFF
--- a/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditorContent.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditorContent.jsx
@@ -14,7 +14,7 @@ import { useDebouncedValue } from "metabase/hooks/use-debounced-value";
 
 import { PermissionsEditorBreadcrumbs } from "./PermissionsEditorBreadcrumbs";
 
-export const permissionEditorPropTypes = {
+export const permissionEditorContentPropTypes = {
   title: PropTypes.string.isRequired,
   description: PropTypes.string,
   columns: PropTypes.array,
@@ -100,4 +100,4 @@ export function PermissionsEditorContent({
   );
 }
 
-PermissionsEditorContent.propTypes = permissionEditorPropTypes;
+PermissionsEditorContent.propTypes = permissionEditorContentPropTypes;


### PR DESCRIPTION
I had to rename components and prop types in https://github.com/metabase/metabase/pull/18171 and I missed one renaming of exported prop types.

### How to verify

- Run the project and ensure there is no warning about a missing export in the console.