### PR TITLE
Snowflake: fix error in aggregation expression having different casing in order clause

### DIFF
--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -275,10 +275,6 @@
 
 (defmethod sql.qp/current-datetime-honeysql-form :snowflake [_] :%current_timestamp)
 
-(defmethod driver/format-custom-field-name :snowflake
-  [_ s]
-  (str/lower-case s))
-
 ;; See https://docs.snowflake.net/manuals/sql-reference/data-types-datetime.html#timestamp.
 (defmethod driver.common/current-db-time-date-formatters :snowflake
   [_]

--- a/test/metabase/query_processor_test/expression_aggregations_test.clj
+++ b/test/metabase/query_processor_test/expression_aggregations_test.clj
@@ -274,6 +274,20 @@
                  {:aggregation [[:sum [:expression "double-price"]]]
                   :expressions {"double-price" [:* $price 2]}})))))))
 
+(deftest order-by-named-aggregation-test
+  (testing "Ordering by a named aggregation whose alias has uppercase letters works (#18211)"
+    (mt/test-drivers (mt/normal-drivers-with-feature :expression-aggregations)
+      (mt/dataset sample-dataset
+        (is (= [["Doohickey" 156.6]
+                ["Widget" 170.3]
+                ["Gadget" 181.9]
+                ["Gizmo" 185.5]]
+              (mt/formatted-rows [str 1.0]
+                (mt/run-mbql-query products
+                  {:aggregation [[:aggregation-options [:sum $rating] {:name "MyCE"}]]
+                   :breakout    [$category]
+                   :order-by    [[:asc [:aggregation 0]]]}))))))))
+
 #_(deftest multiple-cumulative-sums-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expression-aggregations)
     (testing "The results of divide or multiply two CumulativeSum should be correct (#15118)"


### PR DESCRIPTION
Remove the `driver/format-custom-field-name` implementation for `:snowflake`, which was causing the problem and appears to be no longer needed anyway

Add test for this scenario to `metabase.query-processor-test.expression-aggregations-test`
