### PR TITLE
Fix virtual fields are not passed to ParameterValueWidget

### DIFF
--- a/frontend/src/metabase/components/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget.jsx
@@ -233,9 +233,16 @@ export class FieldValuesWidget extends Component {
   }
 
   shouldList() {
+    // Virtual fields come from questions that are based on other questions.
+    // Currently, the back end does not return `has_field_values` in their metadata,
+    // so we ignore them for now.
+    const nonVirtualFields = this.props.fields.filter(
+      field => typeof field.id === "number",
+    );
+
     return (
       !this.props.disableSearch &&
-      this.props.fields.every(field => field.has_field_values === "list")
+      nonVirtualFields.every(field => field.has_field_values === "list")
     );
   }
 

--- a/frontend/src/metabase/meta/Dashboard.js
+++ b/frontend/src/metabase/meta/Dashboard.js
@@ -378,7 +378,10 @@ export function getDashboardParametersWithFieldMetadata(
     const hasOnlyFieldTargets = mappings.every(x => x.field_id != null);
 
     const fields = _.uniq(
-      mappings.map(mapping => mapping.field).filter(field => field != null),
+      mappings
+        .map(mapping => mapping.field)
+        .filter(field => field != null)
+        .map(field => field.target ?? field),
       field => field.id,
     );
 

--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
@@ -257,9 +257,12 @@ function getFields(metadata, parameter) {
   if (!metadata) {
     return [];
   }
-  return getFieldIds(parameter)
-    .map(id => metadata.field(id))
-    .filter(f => f != null);
+  return (
+    parameter.fields ??
+    getFieldIds(parameter)
+      .map(id => metadata.field(id))
+      .filter(f => f != null)
+  );
 }
 
 function getFieldIds(parameter) {


### PR DESCRIPTION
### Description

When a question is based on another native question, the BE returns field ref clauses `["field", "COLUMN_NAME", {...}]` as IDs and the FE puts it in the store like that:
<img width="864" alt="Screen Shot 2021-10-05 at 00 55 49" src="https://user-images.githubusercontent.com/14301985/135930181-d69938db-8ea9-46d3-a7ed-1b9787842d10.png">

Before https://github.com/metabase/metabase/pull/17982 `getFieldTargetId()` checked the type of field id of the field clause and if it was string it returned the entire field clause. https://github.com/metabase/metabase/pull/17982 changed to return string ID instead which is totally correct, however other parts of app are still relying on using stringified field refs as field ids because the field lookup in metadata is built this way.

Using stringified field refs as IDs looks a bit awkward but changing that requires refactoring which is not a good idea right before the release.

### How to verify

Please check the repro steps from the linked issue.