### PR TITLE
Fix DataSelector infinite loop

### DIFF
--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -6,6 +6,8 @@ import { t } from "ttag";
 import cx from "classnames";
 import _ from "underscore";
 
+import { SAVED_QUESTIONS_VIRTUAL_DB_ID } from "metabase/lib/constants";
+
 import ListSearchField from "metabase/components/ListSearchField";
 import ExternalLink from "metabase/components/ExternalLink";
 import Icon from "metabase/components/Icon";
@@ -359,7 +361,8 @@ export class UnconnectedDataSelector extends Component {
       selectedDatabase &&
       selectedSchema &&
       selectedSchema.database.id !== selectedDatabase.id &&
-      !selectedSchema.database.is_saved_questions;
+      selectedSchema.database.id !== SAVED_QUESTIONS_VIRTUAL_DB_ID;
+
     const invalidTable =
       selectedSchema &&
       selectedTable &&


### PR DESCRIPTION
Fixes #18220 

When all the necessary data hasn't been fetched you can find yourself
stuck in a loop between the invalid state checks in DataSelector's
componentDidUpdate method and the skipSteps method.

1. there seems to always be a single schema (the "Everything Else"
   schema) available on instantiation
2. the skipSteps method auto-selects this schema when no other schemas
   exist. Selecting this schema re-triggers the invalidity check in `componentDidUpdate`.
3. there's some pre-existing logic to avoid getting in this loop by
   checking the is_saved_questions property of the database in the
   selectedSchema. However, for whatever reason this property doesn't
   exist until AFTER we've fetched some things.

The fix is checking a property that is guaranteed to exist, the ID for
the "Everything Else" database.

A better solution probably exists. We could avoid running all this logic
until AFTER everything we need has loaded. This `DataSelector` component
is ridiculously complex, however, so that might take more work.