### PR TITLE
Fix cache native queries not working (18160)

### DIFF
--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -687,8 +687,10 @@
                              :middleware  middleware))
         dashboard (db/select-one [Dashboard :cache_ttl] :id (:dashboard-id ids))
         database  (db/select-one [Database :cache_ttl] :id (:database_id card))
-        ttl       (ttl-hierarchy card dashboard database query)]
-    (assoc query :cache-ttl ttl)))
+        ttl       (ttl-hierarchy card dashboard database query)
+        ;; Stored TTL's are in hours: query wants seconds
+        ttl-secs  (* 3600 ttl)]
+    (assoc query :cache-ttl ttl-secs)))
 
 (defn run-query-for-card-async
   "Run the query for Card with `parameters` and `constraints`, and return results in a `StreamingResponse` that should

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -689,7 +689,7 @@
         database  (db/select-one [Database :cache_ttl] :id (:database_id card))
         ttl       (ttl-hierarchy card dashboard database query)
         ;; Stored TTL's are in hours: query wants seconds
-        ttl-secs  (* 3600 ttl)]
+        ttl-secs  (if (nil? ttl) nil (* 3600 ttl))]
     (assoc query :cache-ttl ttl-secs)))
 
 (defn run-query-for-card-async

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -413,15 +413,6 @@
                                      202
                                      (str "card/" (u/the-id card))
                                      {:cache_ttl 1234}))))))
-    (testing "executing query after actually does the hour conversion"
-      (mt/with-temp Card [card]
-        (mt/user-http-request :rasta
-                              :put
-                              202
-                              (str "card/" (u/the-id card))
-                              {:cache_ttl 1})
-        (is (= 3600
-               (:cache-ttl (card-api/query-for-card (db/select-one Card, :id (u/the-id card)) {} {} {}))))))
     (testing "nilling out cache ttl works"
       (mt/with-temp Card [card]
         (is (= nil
@@ -1378,17 +1369,17 @@
     (public-settings/enable-query-caching true)
     (testing "card ttl only"
       (mt/with-temp* [Card [card {:cache_ttl 1337}]]
-        (is (= 1337 (:cache-ttl (card-api/query-for-card card {} {} {}))))))
+        (is (= (* 3600 1337) (:cache-ttl (card-api/query-for-card card {} {} {}))))))
     (testing "multiple ttl, dash wins"
       (mt/with-temp* [Database [db {:cache_ttl 1337}]
                       Dashboard [dash {:cache_ttl 1338}]
                       Card [card {:database_id (u/the-id db)}]]
-        (is (= 1338 (:cache-ttl (card-api/query-for-card card {} {} {} {:dashboard-id (u/the-id dash)}))))))
+        (is (= (* 3600 1338) (:cache-ttl (card-api/query-for-card card {} {} {} {:dashboard-id (u/the-id dash)}))))))
     (testing "multiple ttl, db wins"
       (mt/with-temp* [Database [db {:cache_ttl 1337}]
                       Dashboard [dash]
                       Card [card {:database_id (u/the-id db)}]]
-        (is (= 1337 (:cache-ttl (card-api/query-for-card card {} {} {} {:dashboard-id (u/the-id dash)}))))))
+        (is (= (* 3600 1337) (:cache-ttl (card-api/query-for-card card {} {} {} {:dashboard-id (u/the-id dash)}))))))
     (testing "no ttl, nil res"
       (mt/with-temp* [Database [db]
                       Dashboard [dash]

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -413,14 +413,22 @@
                                      202
                                      (str "card/" (u/the-id card))
                                      {:cache_ttl 1234}))))))
+    (testing "executing query after actually does the hour conversion"
+      (mt/with-temp Card [card]
+        (mt/user-http-request :rasta
+                              :put
+                              202
+                              (str "card/" (u/the-id card))
+                              {:cache_ttl 1})
+        (is (= 3600
+               (:cache-ttl (card-api/query-for-card (db/select-one Card, :id (u/the-id card)) {} {} {}))))))
     (testing "nilling out cache ttl works"
       (mt/with-temp Card [card]
         (is (= nil
                (do
                (mt/user-http-request :rasta :put 202 (str "card/" (u/the-id card)) {:cache_ttl 1234})
                (mt/user-http-request :rasta :put 202 (str "card/" (u/the-id card)) {:cache_ttl nil})
-               (:cache_ttl (mt/user-http-request :rasta :get 200 (str "card/" (u/the-id card))))
-               )))))))
+               (:cache_ttl (mt/user-http-request :rasta :get 200 (str "card/" (u/the-id card)))))))))))
 
 (defn- fingerprint-integers->doubles
   "Converts the min/max fingerprint values to doubles so simulate how the FE will change the metadata when POSTing a


### PR DESCRIPTION
Ulterior root of the phenomenon described in #18160 is the caching settings saying they're defined in hours but there being no conversion to the caching existing infrastructure, which expects them in seconds. I add the conversion.

I was very confused at trying to repro because when I just add 30000 hours to the question it would cache properly. Obviously that translates to 30000 seconds. This actually effects all the other "hours" settings too, so I fix them all at the pass. Test included.