### PR TITLE
Allow caching of fonts and images

### DIFF
--- a/src/metabase/server/request/util.clj
+++ b/src/metabase/server/request/util.clj
@@ -36,6 +36,8 @@
         ;; match requests that are js/css and have a cache-busting query string
         (and query-string
              (re-matches #"^/app/dist/.*\.(js|css)$" uri))
+        ;; any resource that is named as a cache-busting hex string (e.g. fonts, images)
+        (re-matches #"^/app/dist/[a-f0-9]{20}+.*$" uri)
         ;; GeoJSON proxy requests should also be cached
         (re-matches #"^/api/geojson/.*" uri))))
 


### PR DESCRIPTION
Webpack generate multiple resources with the name of `/app/dist/[md4-hash].ext`. We should allow those to be cached.

Examples:
```
26dbbd86902f1d892352.svg
f1405bd8a987c2ea8a67.woff2
416d91365b44e4b4f477.png
```

Before:
<img width="1289" alt="Screen Shot 2564-10-05 at 14 53 13" src="https://user-images.githubusercontent.com/88995137/135982980-e065422f-ea7c-4e81-9203-40cd8c562231.png">

After:
<img width="1295" alt="Screen Shot 2564-10-05 at 14 54 29" src="https://user-images.githubusercontent.com/88995137/135983052-30e63aa2-75de-4265-8150-0373205b642f.png">

