### PR TITLE
Fix auto expanding nested collections

### DIFF
--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -41,7 +41,6 @@ function CollectionContent({
   isAdmin,
   isRoot,
   handleToggleMobileSidebar,
-  shouldDisplayMobileSidebar,
 }) {
   const [selectedItems, setSelectedItems] = useState(null);
   const [selectedAction, setSelectedAction] = useState(null);

--- a/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebar.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebar.jsx
@@ -83,11 +83,14 @@ function CollectionSidebar({
   );
 
   useEffect(() => {
-    if (!loading && collections && collectionId) {
-      const ancestors = getParentPath(collections, collectionId) || [];
+    if (!loading && collectionId) {
+      const ancestors = getParentPath(collections || [], collectionId) || [];
       setOpenCollections(ancestors);
     }
-  }, [collectionId, collections, loading]);
+    // collections list is intentionally not listed in dependencies
+    // otherwise, the hook can close manually opened collections
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [collectionId, loading]);
 
   return (
     <Sidebar

--- a/frontend/src/metabase/collections/containers/CollectionSidebar/RootCollectionLink/RootCollectionLink.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/RootCollectionLink/RootCollectionLink.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { t } from "ttag";
 
+import Collection, { ROOT_COLLECTION } from "metabase/entities/collections";
 import * as Urls from "metabase/lib/urls";
 
 import CollectionDropTarget from "metabase/containers/dnd/CollectionDropTarget";
@@ -13,35 +14,33 @@ import { Container } from "./RootCollectionLink.styled";
 const propTypes = {
   handleToggleMobileSidebar: PropTypes.func.isRequired,
   isRoot: PropTypes.bool.isRequired,
-  root: PropTypes.object.isRequired,
 };
 
 export default function RootCollectionLink({
   handleToggleMobileSidebar,
   isRoot,
-  root,
 }) {
-  function handleClick() {
-    handleToggleMobileSidebar();
-  }
-
   return (
-    <Container>
-      <CollectionDropTarget collection={root}>
-        {({ highlighted, hovered }) => (
-          <CollectionLink
-            to={Urls.collection({ id: "root" })}
-            onClick={handleClick}
-            selected={isRoot}
-            highlighted={highlighted}
-            hovered={hovered}
-          >
-            <CollectionsList.Icon collection={root} />
-            {t`Our analytics`}
-          </CollectionLink>
-        )}
-      </CollectionDropTarget>
-    </Container>
+    <Collection.Loader id={ROOT_COLLECTION.id}>
+      {({ collection: root }) => (
+        <Container>
+          <CollectionDropTarget collection={root}>
+            {({ highlighted, hovered }) => (
+              <CollectionLink
+                to={Urls.collection({ id: ROOT_COLLECTION.id })}
+                onClick={handleToggleMobileSidebar}
+                selected={isRoot}
+                highlighted={highlighted}
+                hovered={hovered}
+              >
+                <CollectionsList.Icon collection={root} />
+                {t`Our analytics`}
+              </CollectionLink>
+            )}
+          </CollectionDropTarget>
+        </Container>
+      )}
+    </Collection.Loader>
   );
 }
 

--- a/frontend/src/metabase/collections/containers/CollectionSidebar/RootCollectionLink/RootCollectionLink.unit.spec.js
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/RootCollectionLink/RootCollectionLink.unit.spec.js
@@ -1,18 +1,45 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import {
+  render,
+  screen,
+  waitForElementToBeRemoved,
+} from "@testing-library/react";
+import { getStore } from "__support__/entities-store";
+import xhrMock from "xhr-mock";
 import { DragDropContextProvider } from "react-dnd";
 import HTML5Backend from "react-dnd-html5-backend";
 
 import RootCollectionLink from "./RootCollectionLink";
 
-it("displays link to main collection: Our Analytics", () => {
-  const root = { name: "name", id: "root" };
-
+async function setup() {
   render(
-    <DragDropContextProvider backend={HTML5Backend}>
-      <RootCollectionLink isRoot={false} root={root} />
-    </DragDropContextProvider>,
+    <Provider store={getStore()}>
+      <DragDropContextProvider backend={HTML5Backend}>
+        <RootCollectionLink isRoot={false} />
+      </DragDropContextProvider>
+    </Provider>,
   );
+  await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
+}
 
-  screen.getByText("Our analytics");
+describe("RootCollectionLink", () => {
+  beforeEach(() => {
+    xhrMock.setup();
+    xhrMock.get("/api/collection/root", {
+      body: JSON.stringify({
+        id: "root",
+        name: "Our analytics",
+      }),
+    });
+  });
+
+  afterEach(() => {
+    xhrMock.teardown();
+  });
+
+  it("displays link to root collection", async () => {
+    await setup();
+    screen.getByText("Our analytics");
+  });
 });


### PR DESCRIPTION
Fixes #16762, fixes #16947

When opening a nested collection, the sidebar sometimes doesn't open the corresponding tree. Let's say you have "Our analytics" > "Marketing" > "Social Media" collection tree. Sometimes if you open `/collection/123-social-media`, the sidebar won't show "Marketing" and "Social Media" collections open.

The issue happens because of the collection sidebar component's lifecycle which should rerender the tree. Fixed by refactoring the collection sidebar to be a functional component and replacing the `componentDidUpdate` hook with `useEffect` which should make sure collection tree is updated when the dependencies change.

### To Verify

1. Go to `/collection/root` and expand a few collections, so they're loaded and cached in Redux
2. Go back to the home page and click any collection link
3. Ensure the selected collection is expanded in the sidebar and its children are visible
4. Go to any other page, use the search bar to find any non-root collection, click it
5. Ensure the selected collection is expanded in the sidebar and its children are visible
6. Open any question / dashboard inside a non-root collection. Click the collection name under question's / dashboard title
7. Ensure the selected collection is expanded in the sidebar and its children are visible

### Demo

https://user-images.githubusercontent.com/17258145/135998124-e427c5a8-580a-4d26-a42a-cfb1326b8e80.mov
