### PR TITLE
Cypress email setup

### DIFF
--- a/frontend/test/__support__/e2e/cypress.js
+++ b/frontend/test/__support__/e2e/cypress.js
@@ -22,5 +22,6 @@ export * from "./helpers/e2e-cloud-helpers";
 export * from "./helpers/e2e-data-model-helpers";
 export * from "./helpers/e2e-misc-helpers";
 export * from "./helpers/e2e-deprecated-helpers";
+export * from "./helpers/e2e-email-helpers";
 
 Cypress.on("uncaught:exception", (err, runnable) => false);

--- a/frontend/test/__support__/e2e/helpers/e2e-deprecated-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-deprecated-helpers.js
@@ -17,18 +17,6 @@ export function createBasicAlert({ firstAlert, includeNormal } = {}) {
   cy.findByText("Let's set up your alert").should("not.exist");
 }
 
-export function setupDummySMTP() {
-  cy.log("Set up dummy SMTP server");
-  cy.request("PUT", "/api/setting", {
-    "email-smtp-host": "smtp.foo.test",
-    "email-smtp-port": "587",
-    "email-smtp-security": "none",
-    "email-smtp-username": "nevermind",
-    "email-smtp-password": "it-is-secret-NOT",
-    "email-from-address": "nonexisting@metabase.test",
-  });
-}
-
 export function createNativeQuestion(name, query) {
   return cy.request("POST", "/api/card", {
     name,

--- a/frontend/test/__support__/e2e/helpers/e2e-email-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-email-helpers.js
@@ -1,0 +1,21 @@
+/**
+ * Make sure you have webmail Docker image running locally:
+ * `docker run -p 80:80 -p 25:25 maildev/maildev`
+ *
+ * or
+ *
+ * install: `yarn global add maildev`
+ * run:     `maildev -s 25 -w 80`
+ */
+export function setupSMTP() {
+  cy.log("Set up Webmail SMTP server");
+
+  cy.request("PUT", "/api/email", {
+    "email-smtp-host": "localhost",
+    "email-smtp-port": "25",
+    "email-smtp-username": "admin",
+    "email-smtp-password": "admin",
+    "email-smtp-security": "none",
+    "email-from-address": "mailer@metabase.test",
+  });
+}

--- a/frontend/test/__support__/e2e/helpers/e2e-email-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-email-helpers.js
@@ -18,4 +18,11 @@ export function setupSMTP() {
     "email-smtp-security": "none",
     "email-from-address": "mailer@metabase.test",
   });
+
+  // We must always clear Webmail's inbox before each test
+  clearInbox();
+}
+
+export function clearInbox() {
+  cy.request("DELETE", "http://localhost:80/email/all");
 }

--- a/frontend/test/metabase/scenarios/admin/people/people.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/people/people.cy.spec.js
@@ -3,7 +3,7 @@ import {
   restore,
   modal,
   popover,
-  setupDummySMTP,
+  setupSMTP,
   describeWithToken,
 } from "__support__/e2e/cypress";
 import { USERS, USER_GROUPS } from "__support__/e2e/cypress_data";
@@ -182,7 +182,7 @@ describe("scenarios > admin > people", () => {
       const { first_name, last_name } = normal;
       const FULL_NAME = `${first_name} ${last_name}`;
 
-      setupDummySMTP();
+      setupSMTP();
 
       cy.visit("/admin/people");
       showUserOptions(FULL_NAME);

--- a/frontend/test/metabase/scenarios/admin/settings/email.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/email.cy.spec.js
@@ -52,14 +52,8 @@ describe("scenarios > admin > settings > email settings", () => {
   it("should send a test email for a valid SMTP configuration", () => {
     // We must clear maildev inbox before each run - this will be extracted and automated
     cy.request("DELETE", "http://localhost:80/email/all");
-    cy.request("PUT", "/api/setting", {
-      "email-smtp-host": "localhost",
-      "email-smtp-port": "25",
-      "email-smtp-username": "admin",
-      "email-smtp-password": "admin",
-      "email-smtp-security": "none",
-      "email-from-address": "mailer@metabase.test",
-    });
+    setupSMTP();
+
     cy.visit("/admin/settings/email");
     cy.findByText("Send test email").click();
     cy.findByText("Sent!");

--- a/frontend/test/metabase/scenarios/admin/settings/email.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/email.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, setupDummySMTP } from "__support__/e2e/cypress";
+import { restore, setupSMTP } from "__support__/e2e/cypress";
 
 describe("scenarios > admin > settings > email settings", () => {
   beforeEach(() => {
@@ -79,7 +79,7 @@ describe("scenarios > admin > settings > email settings", () => {
 
   it("should not offer to save email changes when there aren't any (metabase#14749)", () => {
     // Make sure some settings are already there
-    setupDummySMTP();
+    setupSMTP();
 
     cy.visit("/admin/settings/email");
     cy.findByText("Send test email").scrollIntoView();

--- a/frontend/test/metabase/scenarios/admin/settings/email.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/email.cy.spec.js
@@ -50,8 +50,6 @@ describe("scenarios > admin > settings > email settings", () => {
   });
 
   it("should send a test email for a valid SMTP configuration", () => {
-    // We must clear maildev inbox before each run - this will be extracted and automated
-    cy.request("DELETE", "http://localhost:80/email/all");
     setupSMTP();
 
     cy.visit("/admin/settings/email");

--- a/frontend/test/metabase/scenarios/permissions/sandboxes.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/sandboxes.cy.spec.js
@@ -7,6 +7,7 @@ import {
   popover,
   restore,
   remapDisplayValueToFK,
+  setupSMTP,
 } from "__support__/e2e/cypress";
 import { USER_GROUPS } from "__support__/e2e/cypress_data";
 
@@ -1034,14 +1035,8 @@ describeWithToken("formatting > sandboxes", () => {
 
     it("sandboxed user should receive sandboxed dashboard subscription", () => {
       cy.request("DELETE", "http://localhost:80/email/all");
-      cy.request("PUT", "/api/setting", {
-        "email-smtp-host": "localhost",
-        "email-smtp-port": "25",
-        "email-smtp-username": "admin",
-        "email-smtp-password": "admin",
-        "email-smtp-security": "none",
-        "email-from-address": "mailer@metabase.test",
-      });
+      setupSMTP();
+
       cy.sandboxTable({
         table_id: ORDERS_ID,
         attribute_remappings: {

--- a/frontend/test/metabase/scenarios/permissions/sandboxes.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/sandboxes.cy.spec.js
@@ -1034,7 +1034,6 @@ describeWithToken("formatting > sandboxes", () => {
     });
 
     it("sandboxed user should receive sandboxed dashboard subscription", () => {
-      cy.request("DELETE", "http://localhost:80/email/all");
       setupSMTP();
 
       cy.sandboxTable({

--- a/frontend/test/metabase/scenarios/sharing/reproductions/17658.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/reproductions/17658.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore } from "__support__/e2e/cypress";
+import { restore, setupSMTP } from "__support__/e2e/cypress";
 
 describe("issue 17658", () => {
   beforeEach(() => {
@@ -6,7 +6,7 @@ describe("issue 17658", () => {
     restore();
     cy.signInAsAdmin();
 
-    setUpEmail();
+    setupSMTP();
 
     moveDashboardToCollection("First collection");
   });
@@ -87,15 +87,4 @@ function moveDashboardToCollection(collectionName) {
       });
     },
   );
-}
-
-function setUpEmail() {
-  cy.request("PUT", "/api/setting", {
-    "email-smtp-host": "localhost",
-    "email-smtp-port": "25",
-    "email-smtp-username": "admin",
-    "email-smtp-password": "admin",
-    "email-smtp-security": "none",
-    "email-from-address": "mailer@metabase.test",
-  });
 }

--- a/frontend/test/metabase/scenarios/sharing/reproductions/18009-nodata-creates-subscription-receives-error.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/reproductions/18009-nodata-creates-subscription-receives-error.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, popover } from "__support__/e2e/cypress";
+import { restore, popover, setupSMTP } from "__support__/e2e/cypress";
 
 describe.skip("issue 18009", () => {
   beforeEach(() => {
@@ -6,7 +6,7 @@ describe.skip("issue 18009", () => {
     cy.signInAsAdmin();
 
     cy.request("DELETE", "http://localhost:80/email/all");
-    setUpEmail();
+    setupSMTP();
 
     cy.signIn("nodata");
   });
@@ -39,14 +39,3 @@ describe.skip("issue 18009", () => {
     });
   });
 });
-
-function setUpEmail() {
-  cy.request("PUT", "/api/setting", {
-    "email-smtp-host": "localhost",
-    "email-smtp-port": "25",
-    "email-smtp-username": "admin",
-    "email-smtp-password": "admin",
-    "email-smtp-security": "none",
-    "email-from-address": "mailer@metabase.test",
-  });
-}

--- a/frontend/test/metabase/scenarios/sharing/reproductions/18009-nodata-creates-subscription-receives-error.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/reproductions/18009-nodata-creates-subscription-receives-error.cy.spec.js
@@ -5,7 +5,6 @@ describe.skip("issue 18009", () => {
     restore();
     cy.signInAsAdmin();
 
-    cy.request("DELETE", "http://localhost:80/email/all");
     setupSMTP();
 
     cy.signIn("nodata");

--- a/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
@@ -66,7 +66,6 @@ describe("scenarios > dashboard > subscriptions", () => {
 
   describe("with email set up", () => {
     beforeEach(() => {
-      cy.request("DELETE", "http://localhost:80/email/all");
       setupSMTP();
     });
 

--- a/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
@@ -1,6 +1,6 @@
 import {
   restore,
-  setupDummySMTP,
+  setupSMTP,
   describeWithToken,
   popover,
   mockSessionProperty,
@@ -289,7 +289,7 @@ describe("scenarios > dashboard > subscriptions", () => {
     beforeEach(() => {
       cy.skipOn(!!Cypress.env("HAS_ENTERPRISE_TOKEN"));
       cy.visit(`/dashboard/1`);
-      setupDummySMTP();
+      setupSMTP();
     });
 
     describe("with parameters", () => {
@@ -310,7 +310,7 @@ describe("scenarios > dashboard > subscriptions", () => {
   describeWithToken("EE email subscriptions", () => {
     beforeEach(() => {
       cy.visit(`/dashboard/1`);
-      setupDummySMTP();
+      setupSMTP();
     });
 
     describe("with no parameters", () => {

--- a/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
@@ -67,14 +67,7 @@ describe("scenarios > dashboard > subscriptions", () => {
   describe("with email set up", () => {
     beforeEach(() => {
       cy.request("DELETE", "http://localhost:80/email/all");
-      cy.request("PUT", "/api/setting", {
-        "email-smtp-host": "localhost",
-        "email-smtp-port": "25",
-        "email-smtp-username": "admin",
-        "email-smtp-password": "admin",
-        "email-smtp-security": "none",
-        "email-from-address": "mailer@metabase.test",
-      });
+      setupSMTP();
     });
 
     describe("with no existing subscriptions", () => {


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Replaces the deprecated `setupDummySMTP` helper with the up to date one `setupSMTP`
- Actually sets up the functioning email (using the Webmail Docker image) that we can use in tests
- Makes sure to automatically delete / clear the inbox before the test runs
- Removes a lot of overhead each individual developer had when writing tests that depend on the email setup

### What is outside of the scope for this PR?
- `setupLocalHostEmail` and a lot of skipped tests that relied on that (will tackle it in a separate release)
- this dates from long ago when the only way to have a local SMTP was to run `python -m smtpd -n -c DebuggingServer localhost:1025`

### How to test?
- You need to have Webmail Docker image running locally `docker run -p 80:80 -p 25:25 maildev/maildev` or you can use yarn/npm:

```bash
# install
yarn global add maildev
# run
maildev -s 25 -w 80
```
- Run any of the tests that require email being set up
- Tests should pass

Alternatively, start without a Webmail and observe the tests failing.