### PR TITLE
Static viz whitelabel colors

### DIFF
--- a/frontend/src/metabase/internal/pages/StaticVizPage.jsx
+++ b/frontend/src/metabase/internal/pages/StaticVizPage.jsx
@@ -34,7 +34,7 @@ export default function StaticVizPage() {
               labels: {
                 left: "Count",
                 bottom: "Created At",
-              }
+              },
             }}
           />
         </Box>

--- a/frontend/src/metabase/internal/pages/StaticVizPage.jsx
+++ b/frontend/src/metabase/internal/pages/StaticVizPage.jsx
@@ -35,6 +35,9 @@ export default function StaticVizPage() {
                 left: "Count",
                 bottom: "Created At",
               },
+              colors: {
+                brand: "#88BF4D",
+              }
             }}
           />
         </Box>

--- a/frontend/src/metabase/internal/pages/StaticVizPage.jsx
+++ b/frontend/src/metabase/internal/pages/StaticVizPage.jsx
@@ -34,9 +34,6 @@ export default function StaticVizPage() {
               labels: {
                 left: "Count",
                 bottom: "Created At",
-              },
-              colors: {
-                brand: "#88BF4D",
               }
             }}
           />
@@ -63,6 +60,9 @@ export default function StaticVizPage() {
               labels: {
                 left: "Count",
                 bottom: "Created At",
+              },
+              colors: {
+                brand: "#88BF4D",
               },
             }}
           />

--- a/frontend/src/metabase/static-viz/components/CategoricalAreaChart/CategoricalAreaChart.jsx
+++ b/frontend/src/metabase/static-viz/components/CategoricalAreaChart/CategoricalAreaChart.jsx
@@ -29,6 +29,7 @@ const propTypes = {
     left: PropTypes.string,
     bottom: PropTypes.string,
   }),
+  colors: PropTypes.object,
 };
 
 const layout = {
@@ -46,17 +47,17 @@ const layout = {
   },
   colors: {
     brand: "#509ee3",
-    brandLight: "#DDECFA",
     textLight: "#b8bbc3",
     textMedium: "#949aab",
   },
   barPadding: 0.2,
   labelPadding: 12,
   maxTickWidth: 100,
+  areaOpacity: 0.2,
   strokeDasharray: "4",
 };
 
-const CategoricalAreaChart = ({ data, accessors, settings, labels }) => {
+const CategoricalAreaChart = ({ data, accessors, settings, labels, colors }) => {
   const isVertical = data.length > 10;
   const xTickWidth = getXTickWidth(data, accessors, layout.maxTickWidth);
   const xTickHeight = getXTickHeight(xTickWidth);
@@ -71,6 +72,7 @@ const CategoricalAreaChart = ({ data, accessors, settings, labels }) => {
   const textBaseline = Math.floor(layout.font.size / 2);
   const leftLabel = labels?.left;
   const bottomLabel = !isVertical ? labels?.bottom : undefined;
+  const palette = { ...layout.colors, ...colors };
 
   const xScale = scaleBand({
     domain: data.map(accessors.x),
@@ -106,7 +108,8 @@ const CategoricalAreaChart = ({ data, accessors, settings, labels }) => {
       <AreaClosed
         data={data}
         yScale={yScale}
-        fill={layout.colors.brandLight}
+        fill={palette.brand}
+        opacity={layout.areaOpacity}
         x={d => xScale(accessors.x(d)) + xScale.bandwidth() / 2}
         y={d => yScale(accessors.y(d))}
       />
@@ -122,7 +125,7 @@ const CategoricalAreaChart = ({ data, accessors, settings, labels }) => {
       />
       <LinePath
         data={data}
-        stroke={layout.colors.brand}
+        stroke={palette.brand}
         strokeWidth={layout.strokeWidth}
         x={d => xScale(accessors.x(d)) + xScale.bandwidth() / 2}
         y={d => yScale(accessors.y(d))}
@@ -132,8 +135,8 @@ const CategoricalAreaChart = ({ data, accessors, settings, labels }) => {
         top={yMax}
         label={bottomLabel}
         numTicks={data.length}
-        stroke={layout.colors.textLight}
-        tickStroke={layout.colors.textLight}
+        stroke={palette.textLight}
+        tickStroke={palette.textLight}
         tickComponent={props => <Text {...getXTickProps(props)} />}
         tickLabelProps={() => getXTickLabelProps(layout, isVertical)}
       />

--- a/frontend/src/metabase/static-viz/components/CategoricalAreaChart/CategoricalAreaChart.jsx
+++ b/frontend/src/metabase/static-viz/components/CategoricalAreaChart/CategoricalAreaChart.jsx
@@ -57,7 +57,13 @@ const layout = {
   strokeDasharray: "4",
 };
 
-const CategoricalAreaChart = ({ data, accessors, settings, labels, colors }) => {
+const CategoricalAreaChart = ({
+  data,
+  accessors,
+  settings,
+  labels,
+  colors,
+}) => {
   const isVertical = data.length > 10;
   const xTickWidth = getXTickWidth(data, accessors, layout.maxTickWidth);
   const xTickHeight = getXTickHeight(xTickWidth);

--- a/frontend/src/metabase/static-viz/components/CategoricalBarChart/CategoricalBarChart.jsx
+++ b/frontend/src/metabase/static-viz/components/CategoricalBarChart/CategoricalBarChart.jsx
@@ -29,6 +29,7 @@ const propTypes = {
     left: PropTypes.string,
     bottom: PropTypes.string,
   }),
+  colors: PropTypes.object,
 };
 
 const layout = {
@@ -55,7 +56,7 @@ const layout = {
   strokeDasharray: "4",
 };
 
-const CategoricalBarChart = ({ data, accessors, settings, labels }) => {
+const CategoricalBarChart = ({ data, accessors, settings, labels, colors }) => {
   const isVertical = data.length > 10;
   const xTickWidth = getXTickWidth(data, accessors, layout.maxTickWidth);
   const xTickHeight = getXTickHeight(xTickWidth);
@@ -71,6 +72,7 @@ const CategoricalBarChart = ({ data, accessors, settings, labels }) => {
   const textBaseline = Math.floor(layout.font.size / 2);
   const leftLabel = labels?.left;
   const bottomLabel = !isVertical ? labels?.bottom : undefined;
+  const palette = { ...layout.colors, ...colors };
 
   const xScale = scaleBand({
     domain: data.map(accessors.x),
@@ -91,7 +93,7 @@ const CategoricalBarChart = ({ data, accessors, settings, labels }) => {
     const x = xScale(accessors.x(d));
     const y = yMax - height;
 
-    return { x, y, width, height, fill: layout.colors.brand };
+    return { x, y, width, height, fill: palette.brand };
   };
 
   const getXTickProps = ({ x, y, formattedValue, ...props }) => {
@@ -130,8 +132,8 @@ const CategoricalBarChart = ({ data, accessors, settings, labels }) => {
         top={yMax}
         label={bottomLabel}
         numTicks={data.length}
-        stroke={layout.colors.textLight}
-        tickStroke={layout.colors.textLight}
+        stroke={palette.textLight}
+        tickStroke={palette.textLight}
         tickComponent={props => <Text {...getXTickProps(props)} />}
         tickLabelProps={() => getXTickLabelProps(layout, isVertical)}
       />

--- a/frontend/src/metabase/static-viz/components/CategoricalLineChart/CategoricalLineChart.jsx
+++ b/frontend/src/metabase/static-viz/components/CategoricalLineChart/CategoricalLineChart.jsx
@@ -56,7 +56,13 @@ const layout = {
   strokeDasharray: "4",
 };
 
-const CategoricalLineChart = ({ data, accessors, settings, labels, colors }) => {
+const CategoricalLineChart = ({
+  data,
+  accessors,
+  settings,
+  labels,
+  colors,
+}) => {
   const isVertical = data.length > 10;
   const xTickWidth = getXTickWidth(data, accessors, layout.maxTickWidth);
   const xTickHeight = getXTickHeight(xTickWidth);

--- a/frontend/src/metabase/static-viz/components/CategoricalLineChart/CategoricalLineChart.jsx
+++ b/frontend/src/metabase/static-viz/components/CategoricalLineChart/CategoricalLineChart.jsx
@@ -29,6 +29,7 @@ const propTypes = {
     left: PropTypes.string,
     bottom: PropTypes.string,
   }),
+  colors: PropTypes.object,
 };
 
 const layout = {
@@ -55,7 +56,7 @@ const layout = {
   strokeDasharray: "4",
 };
 
-const CategoricalLineChart = ({ data, accessors, settings, labels }) => {
+const CategoricalLineChart = ({ data, accessors, settings, labels, colors }) => {
   const isVertical = data.length > 10;
   const xTickWidth = getXTickWidth(data, accessors, layout.maxTickWidth);
   const xTickHeight = getXTickHeight(xTickWidth);
@@ -70,6 +71,7 @@ const CategoricalLineChart = ({ data, accessors, settings, labels }) => {
   const textBaseline = Math.floor(layout.font.size / 2);
   const leftLabel = labels?.left;
   const bottomLabel = !isVertical ? labels?.bottom : undefined;
+  const palette = { ...layout.colors, ...colors };
 
   const xScale = scaleBand({
     domain: data.map(accessors.x),
@@ -104,7 +106,7 @@ const CategoricalLineChart = ({ data, accessors, settings, labels }) => {
       />
       <LinePath
         data={data}
-        stroke={layout.colors.brand}
+        stroke={palette.brand}
         strokeWidth={layout.strokeWidth}
         x={d => xScale(accessors.x(d)) + xScale.bandwidth() / 2}
         y={d => yScale(accessors.y(d))}
@@ -124,8 +126,8 @@ const CategoricalLineChart = ({ data, accessors, settings, labels }) => {
         top={yMax}
         label={bottomLabel}
         numTicks={data.length}
-        stroke={layout.colors.textLight}
-        tickStroke={layout.colors.textLight}
+        stroke={palette.textLight}
+        tickStroke={palette.textLight}
         tickComponent={props => <Text {...getXTickProps(props)} />}
         tickLabelProps={() => getXTickLabelProps(layout, isVertical)}
       />

--- a/frontend/src/metabase/static-viz/components/TimeSeriesAreaChart/TimeSeriesAreaChart.jsx
+++ b/frontend/src/metabase/static-viz/components/TimeSeriesAreaChart/TimeSeriesAreaChart.jsx
@@ -26,6 +26,7 @@ const propTypes = {
     left: PropTypes.string,
     bottom: PropTypes.string,
   }),
+  colors: PropTypes.object,
 };
 
 const layout = {
@@ -50,10 +51,11 @@ const layout = {
   numTicks: 5,
   strokeWidth: 2,
   labelPadding: 12,
+  areaOpacity: 0.2,
   strokeDasharray: "4",
 };
 
-const TimeSeriesAreaChart = ({ data, accessors, settings, labels }) => {
+const TimeSeriesAreaChart = ({ data, accessors, settings, labels, colors }) => {
   const yTickWidth = getYTickWidth(data, accessors, settings);
   const yLabelOffset = yTickWidth + layout.labelPadding;
   const xMin = yLabelOffset + layout.font.size * 1.5;
@@ -62,6 +64,7 @@ const TimeSeriesAreaChart = ({ data, accessors, settings, labels }) => {
   const innerWidth = xMax - xMin;
   const leftLabel = labels?.left;
   const bottomLabel = labels?.bottom;
+  const palette = { ...layout.colors, ...colors };
 
   const xScale = scaleTime({
     domain: [
@@ -88,13 +91,14 @@ const TimeSeriesAreaChart = ({ data, accessors, settings, labels }) => {
       <AreaClosed
         data={data}
         yScale={yScale}
-        fill={layout.colors.brandLight}
+        fill={palette.brand}
+        opacity={layout.areaOpacity}
         x={d => xScale(accessors.x(d))}
         y={d => yScale(accessors.y(d))}
       />
       <LinePath
         data={data}
-        stroke={layout.colors.brand}
+        stroke={palette.brand}
         strokeWidth={layout.strokeWidth}
         x={d => xScale(accessors.x(d))}
         y={d => yScale(accessors.y(d))}
@@ -114,8 +118,8 @@ const TimeSeriesAreaChart = ({ data, accessors, settings, labels }) => {
         top={yMax}
         label={bottomLabel}
         numTicks={layout.numTicks}
-        stroke={layout.colors.textLight}
-        tickStroke={layout.colors.textLight}
+        stroke={palette.textLight}
+        tickStroke={palette.textLight}
         tickFormat={value => formatDate(value, settings?.x)}
         tickLabelProps={() => getXTickLabelProps(layout)}
       />

--- a/frontend/src/metabase/static-viz/components/TimeSeriesBarChart/TimeSeriesBarChart.jsx
+++ b/frontend/src/metabase/static-viz/components/TimeSeriesBarChart/TimeSeriesBarChart.jsx
@@ -26,6 +26,7 @@ const propTypes = {
     left: PropTypes.string,
     bottom: PropTypes.string,
   }),
+  colors: PropTypes.object,
 };
 
 const layout = {
@@ -52,7 +53,7 @@ const layout = {
   strokeDasharray: "4",
 };
 
-const TimeSeriesBarChart = ({ data, accessors, settings, labels }) => {
+const TimeSeriesBarChart = ({ data, accessors, settings, labels, colors }) => {
   const yTickWidth = getYTickWidth(data, accessors, settings);
   const yLabelOffset = yTickWidth + layout.labelPadding;
   const xMin = yLabelOffset + layout.font.size * 1.5;
@@ -62,6 +63,7 @@ const TimeSeriesBarChart = ({ data, accessors, settings, labels }) => {
   const innerHeight = yMax - layout.margin.top;
   const leftLabel = labels?.left;
   const bottomLabel = labels?.bottom;
+  const palette = { ...layout.colors, ...colors };
 
   const xScale = scaleBand({
     domain: data.map(accessors.x),
@@ -82,7 +84,7 @@ const TimeSeriesBarChart = ({ data, accessors, settings, labels }) => {
     const x = xScale(accessors.x(d));
     const y = yMax - height;
 
-    return { x, y, width, height, fill: layout.colors.brand };
+    return { x, y, width, height, fill: palette.brand };
   };
 
   return (
@@ -111,8 +113,8 @@ const TimeSeriesBarChart = ({ data, accessors, settings, labels }) => {
         top={yMax}
         label={bottomLabel}
         numTicks={layout.numTicks}
-        stroke={layout.colors.textLight}
-        tickStroke={layout.colors.textLight}
+        stroke={palette.textLight}
+        tickStroke={palette.textLight}
         tickFormat={value => formatDate(value, settings?.x)}
         tickLabelProps={() => getXTickLabelProps(layout)}
       />

--- a/frontend/src/metabase/static-viz/components/TimeSeriesLineChart/TimeSeriesLineChart.jsx
+++ b/frontend/src/metabase/static-viz/components/TimeSeriesLineChart/TimeSeriesLineChart.jsx
@@ -26,6 +26,7 @@ const propTypes = {
     left: PropTypes.string,
     bottom: PropTypes.string,
   }),
+  colors: PropTypes.object,
 };
 
 const layout = {
@@ -52,7 +53,7 @@ const layout = {
   strokeDasharray: "4",
 };
 
-const TimeSeriesLineChart = ({ data, accessors, settings, labels }) => {
+const TimeSeriesLineChart = ({ data, accessors, settings, labels, colors }) => {
   const yTickWidth = getYTickWidth(data, accessors, settings);
   const yLabelOffset = yTickWidth + layout.labelPadding;
   const xMin = yLabelOffset + layout.font.size * 1.5;
@@ -61,6 +62,7 @@ const TimeSeriesLineChart = ({ data, accessors, settings, labels }) => {
   const innerWidth = xMax - xMin;
   const leftLabel = labels?.left;
   const bottomLabel = labels?.bottom;
+  const palette = { ...layout.colors, ...colors };
 
   const xScale = scaleTime({
     domain: [
@@ -86,7 +88,7 @@ const TimeSeriesLineChart = ({ data, accessors, settings, labels }) => {
       />
       <LinePath
         data={data}
-        stroke={layout.colors.brand}
+        stroke={palette.brand}
         strokeWidth={layout.strokeWidth}
         x={d => xScale(accessors.x(d))}
         y={d => yScale(accessors.y(d))}
@@ -106,8 +108,8 @@ const TimeSeriesLineChart = ({ data, accessors, settings, labels }) => {
         top={yMax}
         label={bottomLabel}
         numTicks={layout.numTicks}
-        stroke={layout.colors.textLight}
-        tickStroke={layout.colors.textLight}
+        stroke={palette.textLight}
+        tickStroke={palette.textLight}
         tickFormat={value => formatDate(value, settings?.x)}
         tickLabelProps={() => getXTickLabelProps(layout)}
       />


### PR DESCRIPTION
FE part for https://github.com/metabase/metabase/issues/18163

This PR adds `colors` parameter that should be set to `application-colors` setting by the BE.

How to test:
- Open `/_internal/static-viz`
- Check that a custom brand color was applied for the second chart:

<img width="561" alt="Screen Shot 2021-10-05 at 6 34 42 pm" src="https://user-images.githubusercontent.com/8542534/136055267-fabbf80a-ec77-4845-911c-91f5701454a7.png">
