### PR TITLE
reduce data picker search results to 50 items

### DIFF
--- a/frontend/src/metabase/dashboard/components/add-card-sidebar/QuestionList.jsx
+++ b/frontend/src/metabase/dashboard/components/add-card-sidebar/QuestionList.jsx
@@ -7,6 +7,7 @@ import { PLUGIN_MODERATION } from "metabase/plugins";
 import EmptyState from "metabase/components/EmptyState";
 import Search from "metabase/entities/search";
 import { SelectList } from "metabase/components/select-list";
+import { DEFAULT_SEARCH_LIMIT } from "metabase/lib/constants";
 
 import { EmptyStateContainer, QuestionListItem } from "./QuestionList.styled";
 
@@ -16,8 +17,6 @@ QuestionList.propTypes = {
   onSelect: PropTypes.func.isRequired,
   hasCollections: PropTypes.bool,
 };
-
-const SEARCH_LIMIT = 1000;
 
 export function QuestionList({
   searchText,
@@ -39,7 +38,7 @@ export function QuestionList({
   query = {
     ...query,
     models: "card",
-    limit: SEARCH_LIMIT,
+    limit: DEFAULT_SEARCH_LIMIT,
   };
 
   return (

--- a/frontend/src/metabase/lib/constants.js
+++ b/frontend/src/metabase/lib/constants.js
@@ -2,6 +2,8 @@ import { t } from "ttag";
 
 export const SEARCH_DEBOUNCE_DURATION = 300;
 
+export const DEFAULT_SEARCH_LIMIT = 50;
+
 // A part of hack required to work with both null and 0
 // values in numeric dimensions
 export const NULL_NUMERIC_VALUE = -Infinity;

--- a/frontend/src/metabase/nav/components/SearchResults.jsx
+++ b/frontend/src/metabase/nav/components/SearchResults.jsx
@@ -3,11 +3,10 @@ import PropTypes from "prop-types";
 import { Box } from "grid-styled";
 import { t } from "ttag";
 
+import { DEFAULT_SEARCH_LIMIT } from "metabase/lib/constants";
 import Search from "metabase/entities/search";
 import SearchResult from "metabase/search/components/SearchResult";
 import EmptyState from "metabase/components/EmptyState";
-
-const SEARCH_LIMIT = 50;
 
 const propTypes = {
   searchText: PropTypes.string,
@@ -16,7 +15,7 @@ const propTypes = {
 export const SearchResults = ({ searchText }) => {
   return (
     <Search.ListLoader
-      query={{ q: searchText, limit: SEARCH_LIMIT }}
+      query={{ q: searchText, limit: DEFAULT_SEARCH_LIMIT }}
       wrapped
       reload
       debounced

--- a/frontend/src/metabase/query_builder/components/data-search/SearchResults.jsx
+++ b/frontend/src/metabase/query_builder/components/data-search/SearchResults.jsx
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 import { t } from "ttag";
 
 import Icon from "metabase/components/Icon";
-
+import { DEFAULT_SEARCH_LIMIT } from "metabase/lib/constants";
 import Search from "metabase/entities/search";
 
 import { SearchResultItem } from "./SearchResultItem";
@@ -18,8 +18,6 @@ const propTypes = {
   ),
 };
 
-const SEARCH_LIMIT = 1000;
-
 export function SearchResults({
   searchQuery,
   onSelect,
@@ -29,7 +27,7 @@ export function SearchResults({
   const query = {
     q: searchQuery,
     models: searchModels,
-    limit: SEARCH_LIMIT,
+    limit: DEFAULT_SEARCH_LIMIT,
   };
 
   if (databaseId) {


### PR DESCRIPTION
### Description

Data picker search can be slow both on the server and on the client since we return 1000 results. This PR limits the number of search results to 50 for:
1) Data picker
2) Dashboard > Add question sidebar

### How to verify

#### Data picker
- Ask a question > Simple question
- Enter a search string that should return more than 50 results
- Ensure the number of results is limited to 50

#### Dashboard > Add question sidebar
- Create a new dashboard > Add question
- Enter a search string that should return more than 50 results
- Ensure the number of results is limited to 50

<img width="659" alt="Screen Shot 2021-10-05 at 18 54 28" src="https://user-images.githubusercontent.com/14301985/136058901-2ebe7639-4f26-459f-8c0e-495f820ac913.png">
