### PR TITLE
Disable question's "Save" button until native query can be run

### DIFF
--- a/frontend/src/metabase/components/Link.jsx
+++ b/frontend/src/metabase/components/Link.jsx
@@ -33,6 +33,9 @@ const Link = styled(BaseLink)`
   ${space}
   ${hover}
   ${color}
+
+  transition: color 0.3s linear;
+  transition: opacity 0.3s linear;
 `;
 
 export default Link;

--- a/frontend/src/metabase/components/Link.jsx
+++ b/frontend/src/metabase/components/Link.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import cx from "classnames";
 import PropTypes from "prop-types";
 import { Link as ReactRouterLink } from "react-router";
 import styled from "styled-components";
@@ -7,15 +8,19 @@ import { stripLayoutProps } from "metabase/lib/utils";
 
 BaseLink.propTypes = {
   to: PropTypes.string.isRequired,
+  disabled: PropTypes.bool,
   className: PropTypes.string,
   children: PropTypes.node,
 };
 
-function BaseLink({ to, className, children, ...props }) {
+function BaseLink({ to, className, children, disabled, ...props }) {
   return (
     <ReactRouterLink
       to={to}
-      className={className || "link"}
+      className={cx(className || "link", {
+        disabled: disabled,
+        "text-light": disabled,
+      })}
       {...stripLayoutProps(props)}
     >
       {children}

--- a/frontend/src/metabase/components/Link.jsx
+++ b/frontend/src/metabase/components/Link.jsx
@@ -1,19 +1,27 @@
-/* eslint-disable react/prop-types */
 import React from "react";
+import PropTypes from "prop-types";
 import { Link as ReactRouterLink } from "react-router";
 import styled from "styled-components";
 import { display, color, hover, space } from "styled-system";
 import { stripLayoutProps } from "metabase/lib/utils";
 
-const BaseLink = ({ to, className, children, ...props }) => (
-  <ReactRouterLink
-    to={to}
-    className={className || "link"}
-    {...stripLayoutProps(props)}
-  >
-    {children}
-  </ReactRouterLink>
-);
+BaseLink.propTypes = {
+  to: PropTypes.string.isRequired,
+  className: PropTypes.string,
+  children: PropTypes.node,
+};
+
+function BaseLink({ to, className, children, ...props }) {
+  return (
+    <ReactRouterLink
+      to={to}
+      className={className || "link"}
+      {...stripLayoutProps(props)}
+    >
+      {children}
+    </ReactRouterLink>
+  );
+}
 
 const Link = styled(BaseLink)`
   ${display}

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -252,6 +252,7 @@ export class ViewTitleHeader extends React.Component {
         <div className="ml-auto flex align-center">
           {isDirty ? (
             <Link
+              disabled={!question.canRun()}
               className="text-brand text-bold py1 px2 rounded bg-white bg-light-hover"
               data-metabase-event={
                 isShowingNotebook


### PR DESCRIPTION
Fixes #18148

For now, the "Save" button is always active on the native query editor page. In this way, you can try to save a completely empty question and see an error. This PR fixes it by disabling the button until a native query is valid. In the PR we use `question.canRun()` method which will return `true` if:

* there is a database selected
* query text is not empty
* all template tags are valid

### To Verify

1. Ask a question > Native Query
2. Ensure the "Save" button is grey and can't be clicked
3. Select a database (skip if you only have the sample dataset). Ensure the "Save" button is grey and can't be clicked
4. Fill `select 0` in the query editor
5. Ensure the "Save" button is now active and can be clicked

### Demo

https://user-images.githubusercontent.com/17258145/136064680-d351e566-595e-40b7-acdb-6e72008c0eed.mov
