### PR TITLE
Reset filter value when widget type changes

### DIFF
--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -700,9 +700,9 @@ export const replaceAllCardVisualizationSettings = settings => async (
   );
 };
 
-export const UPDATE_TEMPLATE_TAG = "metabase/qb/UPDATE_TEMPLATE_TAG";
-export const updateTemplateTag = createThunkAction(
-  UPDATE_TEMPLATE_TAG,
+export const SET_TEMPLATE_TAG = "metabase/qb/SET_TEMPLATE_TAG";
+export const setTemplateTag = createThunkAction(
+  SET_TEMPLATE_TAG,
   templateTag => {
     return (dispatch, getState) => {
       const {

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx
@@ -24,7 +24,7 @@ import type { FieldId } from "metabase-types/types/Field";
 
 type Props = {
   tag: TemplateTag,
-  onUpdate: (tag: TemplateTag) => void,
+  setTemplateTag: (tag: TemplateTag) => void,
   databaseFields: Field[],
   database: Database,
   databases: Database[],
@@ -52,7 +52,7 @@ export default class TagEditorParam extends Component {
   setParameterAttribute(attr, val) {
     // only register an update if the value actually changes
     if (this.props.tag[attr] !== val) {
-      this.props.onUpdate({
+      this.props.setTemplateTag({
         ...this.props.tag,
         [attr]: val,
       });
@@ -61,7 +61,7 @@ export default class TagEditorParam extends Component {
 
   setRequired(required) {
     if (this.props.tag.required !== required) {
-      this.props.onUpdate({
+      this.props.setTemplateTag({
         ...this.props.tag,
         required: required,
         default: undefined,
@@ -71,7 +71,7 @@ export default class TagEditorParam extends Component {
 
   setType(type) {
     if (this.props.tag.type !== type) {
-      this.props.onUpdate({
+      this.props.setTemplateTag({
         ...this.props.tag,
         type: type,
         dimension: undefined,
@@ -81,7 +81,7 @@ export default class TagEditorParam extends Component {
   }
 
   setDimension(fieldId) {
-    const { tag, onUpdate, metadata } = this.props;
+    const { tag, setTemplateTag, metadata } = this.props;
     const dimension = ["field", fieldId, null];
     if (!_.isEqual(tag.dimension !== dimension)) {
       const field = metadata.field(dimension[1]);
@@ -98,7 +98,7 @@ export default class TagEditorParam extends Component {
       } else if (options.length > 0) {
         widgetType = options[0].type;
       }
-      onUpdate({
+      setTemplateTag({
         ...tag,
         dimension,
         "widget-type": widgetType,

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx
@@ -49,33 +49,42 @@ export default class TagEditorParam extends Component {
     }
   }
 
+  setType(type) {
+    const { tag, setTemplateTag } = this.props;
+
+    if (tag.type !== type) {
+      setTemplateTag({
+        ...tag,
+        type: type,
+        dimension: undefined,
+        "widget-type": undefined,
+      });
+    }
+  }
+
+  setWidgetType(widgetType) {
+    const { tag, setTemplateTag, setParameterValue } = this.props;
+
+    if (tag["widget-type"] !== widgetType) {
+      setTemplateTag({ ...this.props.tag, "widget-type": widgetType });
+      setParameterValue(tag.id, null);
+    }
+  }
+
+  setRequired(required) {
+    const { tag, setTemplateTag } = this.props;
+
+    if (tag.required !== required) {
+      setTemplateTag({ ...tag, required: required, default: undefined });
+    }
+  }
+
   setParameterAttribute(attr, val) {
     // only register an update if the value actually changes
     if (this.props.tag[attr] !== val) {
       this.props.setTemplateTag({
         ...this.props.tag,
         [attr]: val,
-      });
-    }
-  }
-
-  setRequired(required) {
-    if (this.props.tag.required !== required) {
-      this.props.setTemplateTag({
-        ...this.props.tag,
-        required: required,
-        default: undefined,
-      });
-    }
-  }
-
-  setType(type) {
-    if (this.props.tag.type !== type) {
-      this.props.setTemplateTag({
-        ...this.props.tag,
-        type: type,
-        dimension: undefined,
-        "widget-type": undefined,
       });
     }
   }
@@ -185,8 +194,7 @@ export default class TagEditorParam extends Component {
               // (see Uncontrollable.jsx, metabase#13825)
               value={tag["widget-type"] || "none"}
               onChange={e =>
-                this.setParameterAttribute(
-                  "widget-type",
+                this.setWidgetType(
                   e.target.value === "none" ? undefined : e.target.value,
                 )
               }

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx
@@ -138,7 +138,7 @@ const SettingsPane = ({
   query,
   setDatasetQuery,
   setTemplateTag,
-                        setParameterValue,
+  setParameterValue,
 }) => (
   <div>
     {tags.map(tag => (

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx
@@ -24,7 +24,7 @@ type Props = {
   query: NativeQuery,
 
   setDatasetQuery: (datasetQuery: DatasetQuery) => void,
-  updateTemplateTag: (tag: TemplateTag) => void,
+  setTemplateTag: (tag: TemplateTag) => void,
 
   databaseFields: FieldObject[],
   databases: Database[],
@@ -45,7 +45,7 @@ export default class TagEditorSidebar extends React.Component {
   static propTypes = {
     card: PropTypes.object.isRequired,
     onClose: PropTypes.func.isRequired,
-    updateTemplateTag: PropTypes.func.isRequired,
+    setTemplateTag: PropTypes.func.isRequired,
     databaseFields: PropTypes.array,
     setDatasetQuery: PropTypes.func.isRequired,
     sampleDatasetId: PropTypes.number,
@@ -67,7 +67,7 @@ export default class TagEditorSidebar extends React.Component {
       sampleDatasetId,
       setDatasetQuery,
       query,
-      updateTemplateTag,
+      setTemplateTag,
       onClose,
     } = this.props;
     // The tag editor sidebar excludes snippets since they have a separate sidebar.
@@ -105,7 +105,7 @@ export default class TagEditorSidebar extends React.Component {
             <SettingsPane
               tags={tags}
               parametersById={parametersById}
-              onUpdate={updateTemplateTag}
+              onUpdate={setTemplateTag}
               databaseFields={databaseFields}
               database={database}
               databases={databases}

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx
@@ -105,12 +105,12 @@ export default class TagEditorSidebar extends React.Component {
             <SettingsPane
               tags={tags}
               parametersById={parametersById}
-              onUpdate={setTemplateTag}
               databaseFields={databaseFields}
               database={database}
               databases={databases}
               query={query}
               setDatasetQuery={setDatasetQuery}
+              setTemplateTag={setTemplateTag}
             />
           ) : (
             <TagEditorHelp
@@ -129,12 +129,12 @@ export default class TagEditorSidebar extends React.Component {
 const SettingsPane = ({
   tags,
   parametersById,
-  onUpdate,
   databaseFields,
   database,
   databases,
   query,
   setDatasetQuery,
+  setTemplateTag,
 }) => (
   <div>
     {tags.map(tag => (
@@ -149,10 +149,10 @@ const SettingsPane = ({
           <TagEditorParam
             tag={tag}
             parameter={parametersById[tag.id]}
-            onUpdate={onUpdate}
             databaseFields={databaseFields}
             database={database}
             databases={databases}
+            setTemplateTag={setTemplateTag}
           />
         )}
       </div>
@@ -162,7 +162,7 @@ const SettingsPane = ({
 
 SettingsPane.propTypes = {
   tags: PropTypes.array.isRequired,
-  onUpdate: PropTypes.func.isRequired,
+  setTemplateTag: PropTypes.func.isRequired,
   setDatasetQuery: PropTypes.func.isRequired,
   query: NativeQuery,
   databaseFields: PropTypes.array,

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx
@@ -45,10 +45,11 @@ export default class TagEditorSidebar extends React.Component {
   static propTypes = {
     card: PropTypes.object.isRequired,
     onClose: PropTypes.func.isRequired,
-    setTemplateTag: PropTypes.func.isRequired,
     databaseFields: PropTypes.array,
-    setDatasetQuery: PropTypes.func.isRequired,
     sampleDatasetId: PropTypes.number,
+    setDatasetQuery: PropTypes.func.isRequired,
+    setTemplateTag: PropTypes.func.isRequired,
+    setParameterValue: PropTypes.func.isRequired,
   };
 
   setSection(section) {
@@ -68,6 +69,7 @@ export default class TagEditorSidebar extends React.Component {
       setDatasetQuery,
       query,
       setTemplateTag,
+      setParameterValue,
       onClose,
     } = this.props;
     // The tag editor sidebar excludes snippets since they have a separate sidebar.
@@ -111,6 +113,7 @@ export default class TagEditorSidebar extends React.Component {
               query={query}
               setDatasetQuery={setDatasetQuery}
               setTemplateTag={setTemplateTag}
+              setParameterValue={setParameterValue}
             />
           ) : (
             <TagEditorHelp
@@ -135,6 +138,7 @@ const SettingsPane = ({
   query,
   setDatasetQuery,
   setTemplateTag,
+                        setParameterValue,
 }) => (
   <div>
     {tags.map(tag => (
@@ -153,6 +157,7 @@ const SettingsPane = ({
             database={database}
             databases={databases}
             setTemplateTag={setTemplateTag}
+            setParameterValue={setParameterValue}
           />
         )}
       </div>
@@ -162,8 +167,9 @@ const SettingsPane = ({
 
 SettingsPane.propTypes = {
   tags: PropTypes.array.isRequired,
-  setTemplateTag: PropTypes.func.isRequired,
-  setDatasetQuery: PropTypes.func.isRequired,
   query: NativeQuery,
   databaseFields: PropTypes.array,
+  setDatasetQuery: PropTypes.func.isRequired,
+  setTemplateTag: PropTypes.func.isRequired,
+  setParameterValue: PropTypes.func.isRequired,
 };

--- a/frontend/src/metabase/query_builder/reducers.js
+++ b/frontend/src/metabase/query_builder/reducers.js
@@ -18,7 +18,7 @@ import {
   API_CREATE_QUESTION,
   API_UPDATE_QUESTION,
   SET_CARD_AND_RUN,
-  UPDATE_TEMPLATE_TAG,
+  SET_TEMPLATE_TAG,
   SET_PARAMETER_VALUE,
   UPDATE_QUESTION,
   RUN_QUERY,
@@ -258,7 +258,7 @@ export const card = handleActions(
     [API_CREATE_QUESTION]: { next: (state, { payload }) => payload },
     [API_UPDATE_QUESTION]: { next: (state, { payload }) => payload },
 
-    [UPDATE_TEMPLATE_TAG]: { next: (state, { payload }) => payload },
+    [SET_TEMPLATE_TAG]: { next: (state, { payload }) => payload },
 
     [UPDATE_QUESTION]: (state, { payload: { card } }) => card,
 

--- a/frontend/test/metabase/scenarios/native-filters/sql-field-filter-date.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native-filters/sql-field-filter-date.cy.spec.js
@@ -67,11 +67,16 @@ describe("scenarios > filters > sql filters > field filter > Date", () => {
         });
 
         it("when the widget type is changed (metabase#16756)", () => {
-          const anotherSubType = Object.keys(DATE_FILTER_SUBTYPES).find((type) => type !== subType)
+          const anotherSubType = Object.keys(DATE_FILTER_SUBTYPES).find(
+            type => type !== subType,
+          );
           const anotherValue = DATE_FILTER_SUBTYPES[anotherSubType].value;
 
           FieldFilter.setWidgetType(anotherSubType);
-          dateFilterSelector({ filterType: anotherSubType, filterValue: anotherValue });
+          dateFilterSelector({
+            filterType: anotherSubType,
+            filterValue: anotherValue,
+          });
 
           FieldFilter.setWidgetType(subType);
           dateFilterSelector({ filterType: subType, filterValue: value });
@@ -81,7 +86,7 @@ describe("scenarios > filters > sql filters > field filter > Date", () => {
           cy.get(".Visualization").within(() => {
             cy.findByText(representativeResult);
           });
-        })
+        });
       });
     },
   );

--- a/frontend/test/metabase/scenarios/native-filters/sql-field-filter-date.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native-filters/sql-field-filter-date.cy.spec.js
@@ -65,6 +65,23 @@ describe("scenarios > filters > sql filters > field filter > Date", () => {
             cy.findByText(representativeResult);
           });
         });
+
+        it("when the widget type is changed (metabase#16756)", () => {
+          const anotherSubType = Object.keys(DATE_FILTER_SUBTYPES).find((type) => type !== subType)
+          const anotherValue = DATE_FILTER_SUBTYPES[anotherSubType].value;
+
+          FieldFilter.setWidgetType(anotherSubType);
+          dateFilterSelector({ filterType: anotherSubType, filterValue: anotherValue });
+
+          FieldFilter.setWidgetType(subType);
+          dateFilterSelector({ filterType: subType, filterValue: value });
+
+          SQLFilter.runQuery();
+
+          cy.get(".Visualization").within(() => {
+            cy.findByText(representativeResult);
+          });
+        })
       });
     },
   );


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/16756

How to test manually:
- Create a native question with `SELECT * FROM products WHERE {{filter}}` query
- Change the parameter type to be `Field Filter`
- Change the widget type to `Date range`
- Set date value
- Change the widget type to `Single date`
- You should be able to open the date picker and set the value

