### PR TITLE
Use UTC as default timezone in alert template when report timezone isn't set

### DIFF
--- a/src/metabase/email/messages.clj
+++ b/src/metabase/email/messages.clj
@@ -23,7 +23,6 @@
             [metabase.query-processor.store :as qp.store]
             [metabase.query-processor.streaming :as qp.streaming]
             [metabase.query-processor.streaming.interface :as qp.streaming.i]
-            [metabase.task.send-pulses :as send-pulses]
             [metabase.util :as u]
             [metabase.util.date-2 :as u.date]
             [metabase.util.i18n :as i18n :refer [deferred-trs trs tru]]
@@ -536,6 +535,10 @@
         "sat" "Saturday"}
        day))
 
+(defn- schedule-timezone
+  []
+  (or (driver/report-timezone) "UTC"))
+
 (defn- alert-schedule-text
   "Returns a string that describes the run schedule of an alert (i.e. how often results are checked),
   for inclusion in the email template. Not translated, since emails in general are not currently translated."
@@ -547,13 +550,13 @@
     :daily
     (format "Run daily at %s %s"
             (schedule-hour-text channel)
-            (send-pulses/pulse-timezone))
+            (schedule-timezone))
 
     :weekly
     (format "Run weekly on %s at %s %s"
             (schedule-day-text channel)
             (schedule-hour-text channel)
-            (send-pulses/pulse-timezone))))
+            (schedule-timezone))))
 
 (defn- alert-context
   "Context that is applicable only to the actual alert template (not alert management templates)"

--- a/src/metabase/email/messages.clj
+++ b/src/metabase/email/messages.clj
@@ -23,6 +23,7 @@
             [metabase.query-processor.store :as qp.store]
             [metabase.query-processor.streaming :as qp.streaming]
             [metabase.query-processor.streaming.interface :as qp.streaming.i]
+            [metabase.task.send-pulses :as send-pulses]
             [metabase.util :as u]
             [metabase.util.date-2 :as u.date]
             [metabase.util.i18n :as i18n :refer [deferred-trs trs tru]]
@@ -546,13 +547,13 @@
     :daily
     (format "Run daily at %s %s"
             (schedule-hour-text channel)
-            (driver/report-timezone))
+            (send-pulses/pulse-timezone))
 
     :weekly
     (format "Run weekly on %s at %s %s"
             (schedule-day-text channel)
             (schedule-hour-text channel)
-            (driver/report-timezone))))
+            (send-pulses/pulse-timezone))))
 
 (defn- alert-context
   "Context that is applicable only to the actual alert template (not alert management templates)"

--- a/src/metabase/task/send_pulses.clj
+++ b/src/metabase/task/send_pulses.clj
@@ -76,15 +76,19 @@
       (< start-of-last-week curr-day-of-month) :last
       :else                                    :other)))
 
+(defn pulse-timezone
+  "The timezone in which pulse schedules should be based."
+  []
+  (or (driver/report-timezone) "UTC"))
+
 ;; triggers the sending of all pulses which are scheduled to run in the current hour
 (jobs/defjob SendPulses [_]
   (try
     (task-history/with-task-history {:task "send-pulses"}
-      ;; determine what time it is right now (hour-of-day & day-of-week) in reporting timezone
-      (let [reporting-timezone (driver/report-timezone)
-            now                (if (empty? reporting-timezone)
-                                 (time/now)
-                                 (time/to-time-zone (time/now) (time/time-zone-for-id reporting-timezone)))
+      ;; determine what time it is right now (hour-of-day & day-of-week) in reporting timezone,
+      ;; defaulting to UTC if not set
+      (let [reporting-timezone (pulse-timezone)
+            now                (time/to-time-zone (time/now) (time/time-zone-for-id reporting-timezone))
             curr-hour          (time/hour now)
             ;; joda time produces values of 1-7 here (Mon -> Sun) and we subtract 1 from it to
             ;; make the values zero based to correspond to the indexes in pulse-channel/days-of-week

--- a/test/metabase/email/messages_test.clj
+++ b/test/metabase/email/messages_test.clj
@@ -74,4 +74,9 @@
       (is (= "Run weekly on Monday at 8 AM America/Pacific"
              (@#'messages/alert-schedule-text {:schedule_type :weekly
                                                :schedule_day  "mon"
-                                               :schedule_hour 8}))))))
+                                               :schedule_hour 8})))))
+  (testing "If report-timezone is not set, falls back to UTC"
+    (tu/with-temporary-setting-values [report-timezone nil]
+      (is (= "Run daily at 12 AM UTC"
+             (@#'messages/alert-schedule-text {:schedule_type :daily
+                                               :schedule_hour 0}))))))


### PR DESCRIPTION
Quick fix in the alert template to mirror the logic we use when actually sending out pulses -- if report timezone isn't set, we fall back to UTC.