### PR TITLE
#18148 Repro: "Save" button shouldn't appear before one selects the source for a native question

### DIFF
--- a/frontend/test/metabase/scenarios/native/reproductions/18148-save-button-before-it-is-possible-to-save.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/reproductions/18148-save-button-before-it-is-possible-to-save.cy.spec.js
@@ -1,0 +1,32 @@
+import { restore } from "__support__/e2e/cypress";
+
+const dbName = "Sample2";
+
+describe("issue 18148", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.addH2SampleDataset({
+      name: dbName,
+    });
+
+    cy.visit("/");
+    cy.icon("sql").click();
+  });
+
+  it("should not offer to save the question before it is actually possible to save it (metabase#18148)", () => {
+    cy.findByText("Select a database");
+    cy.findByText("Save").should("have.class", "disabled");
+
+    cy.findByText(dbName).click();
+
+    cy.get(".ace_content")
+      .should("be.visible")
+      .type("select foo");
+
+    cy.findByText("Save").click();
+
+    cy.get(".Modal").should("exist");
+  });
+});


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Reproduces #18148 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/native/reproductions/18148-save-button-before-it-is-possible-to-save.cy.spec.js`
- The test should pass

### Additional notes:
- The bug was fixed in #18252

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/136091112-6d7efb26-1495-474f-98b4-0ac3a8d90c0e.png)

