### PR TITLE
#18114 Repro: Dashboard Textbox does not render links unless using Markdown

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard/text-box.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/text-box.cy.spec.js
@@ -94,5 +94,19 @@ describe("scenarios > dashboard > text-box", () => {
         .should("have.css", "overflow", "auto")
         .scrollTo("bottom");
     });
+
+    it.skip("should literal links, and not just the markdown flavor of it (metabse#18114)", () => {
+      addTextBox(
+        "- Visit https://www.metabase.com{enter}- Or go to [Metabase](https://www.metabase.com)",
+      );
+
+      cy.findByText("Save").click();
+      cy.findByText("You're editing this dashboard.").should("not.exist");
+
+      cy.get(".Card")
+        .findAllByRole("link")
+        .should("be.visible")
+        .and("have.length", 2);
+    });
   });
 });


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #18114 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/dashboard/text-box.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/136096811-e66561ff-cc73-4292-978f-57977f026cf6.png)

