### PR TITLE
Change implementation of docsUrl to handle RC suffixes for EE versions

### DIFF
--- a/frontend/src/metabase/lib/settings.js
+++ b/frontend/src/metabase/lib/settings.js
@@ -141,10 +141,19 @@ class Settings {
 
   docsUrl(page = "", anchor = "") {
     let { tag } = this.get("version", {});
-    let matches = tag.match(/v[01]\.(\d+)(?:\.\d+)?(?:-.*)?/);
+    const matches = tag.match(/v[01]\.(\d+)(?:\.\d+)?(-.*)?/);
     if (matches) {
-      // if it's a regular OSS or EE version string, just link to the major OSS doc link
-      tag = "v0." + matches[1];
+      if (
+        matches.length > 2 &&
+        matches[2] &&
+        "-snapshot" === matches[2].toLowerCase()
+      ) {
+        // always point -SNAPSHOT suffixes to "latest", since this is likely a development build off of master
+        tag = "latest";
+      } else {
+        // otherwise, it's a regular OSS or EE version string, just link to the major OSS doc link
+        tag = "v0." + matches[1];
+      }
     } else {
       // otherwise, just link to the latest tag
       tag = "latest";

--- a/frontend/src/metabase/lib/settings.js
+++ b/frontend/src/metabase/lib/settings.js
@@ -141,11 +141,12 @@ class Settings {
 
   docsUrl(page = "", anchor = "") {
     let { tag } = this.get("version", {});
-    if (/^v1\.\d+\.\d+$/.test(tag)) {
-      // if it's a normal EE version, link to the corresponding CE docs
-      tag = tag.replace("v1", "v0");
-    } else if (!tag || /v1/.test(tag) || /SNAPSHOT$/.test(tag)) {
-      // if there's no tag or it's an EE version that might not have a matching CE version, or it's a local build, link to latest
+    let matches = tag.match(/v[01]\.(\d+)(?:\.\d+)?(?:-.*)?/);
+    if (matches) {
+      // if it's a regular OSS or EE version string, just link to the major OSS doc link
+      tag = "v0." + matches[1];
+    } else {
+      // otherwise, just link to the latest tag
       tag = "latest";
     }
     if (page) {

--- a/frontend/test/metabase/lib/settings.unit.spec.js
+++ b/frontend/test/metabase/lib/settings.unit.spec.js
@@ -1,0 +1,33 @@
+import MetabaseSettings from "metabase/lib/settings";
+
+function withTempSetting(settingName, settingValue, thunk) {
+  const origVal = MetabaseSettings.get(settingName);
+  MetabaseSettings.set(settingName, settingValue);
+  try {
+    thunk();
+  } finally {
+    MetabaseSettings.set(settingName, origVal);
+  }
+}
+
+describe("MetabaseSettings.docsUrl", () => {
+  // all of these should point to the same doc URL
+  [
+    "v0.41.0",
+    "v0.41.1-SNAPSHOT",
+    "v0.41.2-rc1",
+    "v0.41.3-RC2",
+    "v1.41.4",
+    "v1.41.3-SNAPSHOT",
+    "v1.41.2-rc1",
+    "v1.41.1-RANDOM-SUFFIX",
+  ].forEach(v => {
+    it("handles version " + v + " correctly", () => {
+      withTempSetting("version", { tag: v }, () => {
+        expect(MetabaseSettings.docsUrl()).toBe(
+          "https://www.metabase.com/docs/v0.41/",
+        );
+      });
+    });
+  });
+});

--- a/frontend/test/metabase/lib/settings.unit.spec.js
+++ b/frontend/test/metabase/lib/settings.unit.spec.js
@@ -13,19 +13,19 @@ function withTempSetting(settingName, settingValue, thunk) {
 describe("MetabaseSettings.docsUrl", () => {
   // all of these should point to the same doc URL
   [
-    "v0.41.0",
-    "v0.41.1-SNAPSHOT",
-    "v0.41.2-rc1",
-    "v0.41.3-RC2",
-    "v1.41.4",
-    "v1.41.3-SNAPSHOT",
-    "v1.41.2-rc1",
-    "v1.41.1-RANDOM-SUFFIX",
+    ["v0.41.0", "v0.41"],
+    ["v0.41.1-SNAPSHOT", "latest"],
+    ["v0.41.2-rc1", "v0.41"],
+    ["v0.41.3-RC2", "v0.41"],
+    ["v1.41.4", "v0.41"],
+    ["v1.41.3-snapshot", "latest"],
+    ["v1.41.2-rc1", "v0.41"],
+    ["v1.41.1-RANDOM-SUFFIX", "v0.41"],
   ].forEach(v => {
-    it("handles version " + v + " correctly", () => {
-      withTempSetting("version", { tag: v }, () => {
+    it("handles version " + v[0] + " by pointing it to " + v[1], () => {
+      withTempSetting("version", { tag: v[0] }, () => {
         expect(MetabaseSettings.docsUrl()).toBe(
-          "https://www.metabase.com/docs/v0.41/",
+          "https://www.metabase.com/docs/" + v[1] + "/",
         );
       });
     });


### PR DESCRIPTION
Change the regex used to test the tag to detect any OSS or EE version, including (possibly) an arbitrary suffix after the major and minor parts, and normalize to the major OSS equivalent version instead

v0.41.0 => v0.41
v1.41.1 => v0.41
v1.41.2-RC1 => v0.41

Adding unit tests for all cases
