### PR TITLE
Static viz: respect whitelabel colors

### DIFF
--- a/frontend/src/metabase/static-viz/components/CategoricalAreaChart/CategoricalAreaChart.jsx
+++ b/frontend/src/metabase/static-viz/components/CategoricalAreaChart/CategoricalAreaChart.jsx
@@ -20,6 +20,7 @@ const propTypes = {
   accessors: PropTypes.shape({
     x: PropTypes.func.isRequired,
     y: PropTypes.func.isRequired,
+    colors: PropTypes.object,
   }).isRequired,
   settings: PropTypes.shape({
     x: PropTypes.object,
@@ -29,7 +30,6 @@ const propTypes = {
     left: PropTypes.string,
     bottom: PropTypes.string,
   }),
-  colors: PropTypes.object,
 };
 
 const layout = {
@@ -57,13 +57,8 @@ const layout = {
   strokeDasharray: "4",
 };
 
-const CategoricalAreaChart = ({
-  data,
-  accessors,
-  settings,
-  labels,
-  colors,
-}) => {
+const CategoricalAreaChart = ({ data, accessors, settings, labels }) => {
+  const colors = settings?.colors;
   const isVertical = data.length > 10;
   const xTickWidth = getXTickWidth(data, accessors, layout.maxTickWidth);
   const xTickHeight = getXTickHeight(xTickWidth);

--- a/frontend/src/metabase/static-viz/components/CategoricalAreaChart/CategoricalAreaChart.jsx
+++ b/frontend/src/metabase/static-viz/components/CategoricalAreaChart/CategoricalAreaChart.jsx
@@ -20,11 +20,11 @@ const propTypes = {
   accessors: PropTypes.shape({
     x: PropTypes.func.isRequired,
     y: PropTypes.func.isRequired,
-    colors: PropTypes.object,
   }).isRequired,
   settings: PropTypes.shape({
     x: PropTypes.object,
     y: PropTypes.object,
+    colors: PropTypes.object,
   }),
   labels: PropTypes.shape({
     left: PropTypes.string,

--- a/frontend/src/metabase/static-viz/components/CategoricalBarChart/CategoricalBarChart.jsx
+++ b/frontend/src/metabase/static-viz/components/CategoricalBarChart/CategoricalBarChart.jsx
@@ -24,12 +24,12 @@ const propTypes = {
   settings: PropTypes.shape({
     x: PropTypes.object,
     y: PropTypes.object,
+    colors: PropTypes.object,
   }),
   labels: PropTypes.shape({
     left: PropTypes.string,
     bottom: PropTypes.string,
   }),
-  colors: PropTypes.object,
 };
 
 const layout = {
@@ -56,7 +56,8 @@ const layout = {
   strokeDasharray: "4",
 };
 
-const CategoricalBarChart = ({ data, accessors, settings, labels, colors }) => {
+const CategoricalBarChart = ({ data, accessors, settings, labels }) => {
+  const colors = settings?.colors;
   const isVertical = data.length > 10;
   const xTickWidth = getXTickWidth(data, accessors, layout.maxTickWidth);
   const xTickHeight = getXTickHeight(xTickWidth);

--- a/frontend/src/metabase/static-viz/components/CategoricalDonutChart/CategoricalDonutChart.jsx
+++ b/frontend/src/metabase/static-viz/components/CategoricalDonutChart/CategoricalDonutChart.jsx
@@ -8,13 +8,13 @@ import { formatNumber } from "../../lib/numbers";
 
 const propTypes = {
   data: PropTypes.array,
+  colors: PropTypes.object,
   accessors: PropTypes.shape({
     dimension: PropTypes.func,
     metric: PropTypes.func,
   }),
   settings: PropTypes.shape({
     metric: PropTypes.object,
-    colors: PropTypes.object,
   }),
 };
 
@@ -37,8 +37,7 @@ const layout = {
   labelFontSize: 14,
 };
 
-const CategoricalDonutChart = ({ data, accessors, settings }) => {
-  const colors = settings?.colors;
+const CategoricalDonutChart = ({ data, colors, accessors, settings }) => {
   const innerWidth = layout.width - layout.margin * 2;
   const innerHeight = layout.height - layout.margin * 2;
   const outerRadius = Math.min(innerWidth, innerHeight) / 2;

--- a/frontend/src/metabase/static-viz/components/CategoricalDonutChart/CategoricalDonutChart.jsx
+++ b/frontend/src/metabase/static-viz/components/CategoricalDonutChart/CategoricalDonutChart.jsx
@@ -8,13 +8,13 @@ import { formatNumber } from "../../lib/numbers";
 
 const propTypes = {
   data: PropTypes.array,
-  colors: PropTypes.object,
   accessors: PropTypes.shape({
     dimension: PropTypes.func,
     metric: PropTypes.func,
   }),
   settings: PropTypes.shape({
     metric: PropTypes.object,
+    colors: PropTypes.object,
   }),
 };
 
@@ -37,7 +37,8 @@ const layout = {
   labelFontSize: 14,
 };
 
-const CategoricalDonutChart = ({ data, colors, accessors, settings }) => {
+const CategoricalDonutChart = ({ data, accessors, settings }) => {
+  const colors = settings?.colors;
   const innerWidth = layout.width - layout.margin * 2;
   const innerHeight = layout.height - layout.margin * 2;
   const outerRadius = Math.min(innerWidth, innerHeight) / 2;

--- a/frontend/src/metabase/static-viz/components/CategoricalLineChart/CategoricalLineChart.jsx
+++ b/frontend/src/metabase/static-viz/components/CategoricalLineChart/CategoricalLineChart.jsx
@@ -24,12 +24,12 @@ const propTypes = {
   settings: PropTypes.shape({
     x: PropTypes.object,
     y: PropTypes.object,
+    colors: PropTypes.object,
   }),
   labels: PropTypes.shape({
     left: PropTypes.string,
     bottom: PropTypes.string,
   }),
-  colors: PropTypes.object,
 };
 
 const layout = {
@@ -56,13 +56,8 @@ const layout = {
   strokeDasharray: "4",
 };
 
-const CategoricalLineChart = ({
-  data,
-  accessors,
-  settings,
-  labels,
-  colors,
-}) => {
+const CategoricalLineChart = ({ data, accessors, settings, labels }) => {
+  const colors = settings?.colors;
   const isVertical = data.length > 10;
   const xTickWidth = getXTickWidth(data, accessors, layout.maxTickWidth);
   const xTickHeight = getXTickHeight(xTickWidth);

--- a/frontend/src/metabase/static-viz/components/TimeSeriesAreaChart/TimeSeriesAreaChart.jsx
+++ b/frontend/src/metabase/static-viz/components/TimeSeriesAreaChart/TimeSeriesAreaChart.jsx
@@ -21,12 +21,12 @@ const propTypes = {
   settings: PropTypes.shape({
     x: PropTypes.object,
     y: PropTypes.object,
+    colors: PropTypes.object,
   }),
   labels: PropTypes.shape({
     left: PropTypes.string,
     bottom: PropTypes.string,
   }),
-  colors: PropTypes.object,
 };
 
 const layout = {
@@ -55,7 +55,8 @@ const layout = {
   strokeDasharray: "4",
 };
 
-const TimeSeriesAreaChart = ({ data, accessors, settings, labels, colors }) => {
+const TimeSeriesAreaChart = ({ data, accessors, settings, labels }) => {
+  const colors = settings?.colors;
   const yTickWidth = getYTickWidth(data, accessors, settings);
   const yLabelOffset = yTickWidth + layout.labelPadding;
   const xMin = yLabelOffset + layout.font.size * 1.5;

--- a/frontend/src/metabase/static-viz/components/TimeSeriesBarChart/TimeSeriesBarChart.jsx
+++ b/frontend/src/metabase/static-viz/components/TimeSeriesBarChart/TimeSeriesBarChart.jsx
@@ -21,12 +21,12 @@ const propTypes = {
   settings: PropTypes.shape({
     x: PropTypes.object,
     y: PropTypes.object,
+    colors: PropTypes.object,
   }),
   labels: PropTypes.shape({
     left: PropTypes.string,
     bottom: PropTypes.string,
   }),
-  colors: PropTypes.object,
 };
 
 const layout = {
@@ -53,7 +53,8 @@ const layout = {
   strokeDasharray: "4",
 };
 
-const TimeSeriesBarChart = ({ data, accessors, settings, labels, colors }) => {
+const TimeSeriesBarChart = ({ data, accessors, settings, labels }) => {
+  const colors = settings?.colors;
   const yTickWidth = getYTickWidth(data, accessors, settings);
   const yLabelOffset = yTickWidth + layout.labelPadding;
   const xMin = yLabelOffset + layout.font.size * 1.5;

--- a/frontend/src/metabase/static-viz/components/TimeSeriesLineChart/TimeSeriesLineChart.jsx
+++ b/frontend/src/metabase/static-viz/components/TimeSeriesLineChart/TimeSeriesLineChart.jsx
@@ -21,12 +21,12 @@ const propTypes = {
   settings: PropTypes.shape({
     x: PropTypes.object,
     y: PropTypes.object,
+    colors: PropTypes.object,
   }),
   labels: PropTypes.shape({
     left: PropTypes.string,
     bottom: PropTypes.string,
   }),
-  colors: PropTypes.object,
 };
 
 const layout = {
@@ -53,7 +53,8 @@ const layout = {
   strokeDasharray: "4",
 };
 
-const TimeSeriesLineChart = ({ data, accessors, settings, labels, colors }) => {
+const TimeSeriesLineChart = ({ data, accessors, settings, labels }) => {
+  const colors = settings?.colors;
   const yTickWidth = getYTickWidth(data, accessors, settings);
   const yLabelOffset = yTickWidth + layout.labelPadding;
   const xMin = yLabelOffset + layout.font.size * 1.5;

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -17,7 +17,7 @@
             [metabase.util :as u]
             [metabase.util.i18n :refer [trs tru]]
             [schema.core :as s])
-  (:import (java.text DecimalFormat DecimalFormatSymbols)))
+  (:import [java.text DecimalFormat DecimalFormatSymbols]))
 
 (def error-rendered-info
   "Default rendered-info map when there is an error displaying a card. Is a delay due to the call to `trs`."
@@ -289,7 +289,7 @@
                 (u/update-when :date_style update-date-style (:unit col))))]
     (let [x-col-settings (settings x-col)
           y-col-settings (settings y-col)]
-      (cond-> {}
+      (cond-> {:colors (public-settings/application-colors)}
         x-col-settings
         (assoc :x (for-js x-col-settings x-col))
         y-col-settings


### PR DESCRIPTION
Follow-on to #18248

Fixes #18163

@ranquild there is no way to pass in `colors` at the top level as you suggested in https://github.com/metabase/metabase/issues/18163#issuecomment-934580283 -- the static viz interface is 

```js
renderFunction(data, labels, settings)
```

See https://github.com/metabase/metabase/blob/master/resources/frontend_shared/static_viz_interface.js#L32 for example.

I tweaked the FE changes you made in #18248 to pull colors out of the `settings` map instead.

The backend changes are pretty simple so this fix ended up being mostly a FE one -- but could still use a review for both FE and BE

