### PR TITLE
Circle CI: build without cache for the release branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -550,6 +550,13 @@ jobs:
             else
                echo '' > .CACHE-PREFIX
             fi
+      - run:
+          name: 'Check for branch name to bust caches if it is a release branch'
+          command: |
+            if [[ $CIRCLE_BRANCH == release* ]]; then
+              echo 'This is a release branch; using cache-busting prefix'
+                echo '<< pipeline.id >>' > .CACHE-PREFIX
+            fi
       - run-yarn-command:
           command-name: Create static visualization js bundle
           command: build-static-viz

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -553,8 +553,8 @@ jobs:
       - run:
           name: 'Check for branch name to bust caches if it is a release branch'
           command: |
-            if [[ $CIRCLE_BRANCH == release* ]]; then
-              echo 'This is a release branch; using cache-busting prefix'
+            if [[ $CIRCLE_BRANCH == release* || $CIRCLE_BRANCH == master  ]]; then
+              echo 'This is a release or master branch; using cache-busting prefix'
                 echo '<< pipeline.id >>' > .CACHE-PREFIX
             fi
       - run-yarn-command:


### PR DESCRIPTION
This is to ensure that Uberjar built in the `release-*` and `master` branch is free from any left-overs.

The approach is straightforward (just like `[ci nocache]` in the commit message): dump a unique ID to the cache prefix when it is detected that the branch to be built starts with `release`.