### PR TITLE
Fix subscriptions being sent for the wrong dashboard

### DIFF
--- a/frontend/src/metabase/lib/pulse.js
+++ b/frontend/src/metabase/lib/pulse.js
@@ -4,6 +4,15 @@ import {
   hasParameterValue,
 } from "metabase/meta/Parameter";
 
+export const NEW_PULSE_TEMPLATE = {
+  name: null,
+  cards: [],
+  channels: [],
+  skip_if_empty: false,
+  collection_id: null,
+  parameters: [],
+};
+
 export function channelIsValid(channel, channelSpec) {
   if (!channelSpec) {
     return false;

--- a/frontend/src/metabase/pulse/actions.js
+++ b/frontend/src/metabase/pulse/actions.js
@@ -7,7 +7,11 @@ import Pulses from "metabase/entities/pulses";
 import { getEditingPulse, getPulseFormInput } from "./selectors";
 import { setErrorPage } from "metabase/redux/app";
 
-import { getDefaultChannel, createChannel } from "metabase/lib/pulse";
+import {
+  getDefaultChannel,
+  createChannel,
+  NEW_PULSE_TEMPLATE,
+} from "metabase/lib/pulse";
 
 export const SET_EDITING_PULSE = "SET_EDITING_PULSE";
 export const UPDATE_EDITING_PULSE = "UPDATE_EDITING_PULSE";
@@ -42,12 +46,9 @@ export const setEditingPulse = createThunkAction(SET_EDITING_PULSE, function(
         (await PulseApi.form_input()).channels;
       const defaultChannelSpec = getDefaultChannel(channels);
       return {
-        name: null,
-        cards: [],
+        ...NEW_PULSE_TEMPLATE,
         channels: defaultChannelSpec ? [createChannel(defaultChannelSpec)] : [],
-        skip_if_empty: false,
         collection_id: initialCollectionId,
-        parameters: [],
       };
     }
   };

--- a/frontend/src/metabase/sharing/components/SharingSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/SharingSidebar.jsx
@@ -21,6 +21,7 @@ import {
   cleanPulse,
   createChannel,
   getPulseParameters,
+  NEW_PULSE_TEMPLATE,
 } from "metabase/lib/pulse";
 
 import { getEditingPulse, getPulseFormInput } from "metabase/pulse/selectors";
@@ -28,7 +29,6 @@ import { getEditingPulse, getPulseFormInput } from "metabase/pulse/selectors";
 import { getUser } from "metabase/selectors/user";
 
 import {
-  setEditingPulse,
   updateEditingPulse,
   saveEditingPulse,
   fetchPulseFormInput,
@@ -99,7 +99,6 @@ const mapStateToProps = (state, props) => ({
 });
 
 const mapDispatchToProps = {
-  setEditingPulse,
   updateEditingPulse,
   saveEditingPulse,
   fetchPulseFormInput,
@@ -131,7 +130,6 @@ class SharingSidebar extends React.Component {
     initialCollectionId: PropTypes.number,
     pulse: PropTypes.object.isRequired,
     saveEditingPulse: PropTypes.func.isRequired,
-    setEditingPulse: PropTypes.func.isRequired,
     testPulse: PropTypes.func.isRequired,
     updateEditingPulse: PropTypes.func.isRequired,
     pulses: PropTypes.array.isRequired,
@@ -146,7 +144,7 @@ class SharingSidebar extends React.Component {
   };
 
   setPulseWithChannel = type => {
-    const { dashboard, pulse, formInput } = this.props;
+    const { dashboard, formInput } = this.props;
 
     const channelSpec = formInput.channels[type];
     if (!channelSpec) {
@@ -156,7 +154,7 @@ class SharingSidebar extends React.Component {
     const channel = createChannel(channelSpec);
 
     const newPulse = {
-      ...pulse,
+      ...NEW_PULSE_TEMPLATE,
       channels: [channel],
       cards: nonTextCardsFromDashboard(dashboard),
     };
@@ -251,8 +249,6 @@ class SharingSidebar extends React.Component {
         returnMode: returnMode.concat([editingMode]),
       };
     });
-
-    this.props.setEditingPulse(null, null);
   };
 
   editPulse = (pulse, channelType) => {


### PR DESCRIPTION
When creating a new pulse, take values from an empty template rather than the current state which may contain dirty data.

Before #17791, this used to work because `setEditingPulse` is called on `componentDidMount` clearing the previous state.

Note: Please feel free to fix/merge/backport this PR.

Fixes #18278