### PR TITLE
#12439 Repro: Clicking on legend in native question breaks the UI

### DIFF
--- a/frontend/test/metabase/scenarios/native/reproductions/12439-click-on-legend-breaks-ui.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/reproductions/12439-click-on-legend-breaks-ui.cy.spec.js
@@ -1,0 +1,48 @@
+import { restore, visitQuestionAdhoc, sidebar } from "__support__/e2e/cypress";
+
+const nativeQuery = `SELECT "PRODUCTS__via__PRODUCT_ID"."CATEGORY" AS "CATEGORY", parsedatetime(formatdatetime("PUBLIC"."ORDERS"."CREATED_AT", 'yyyyMM'), 'yyyyMM') AS "CREATED_AT", count(*) AS "count"
+FROM "PUBLIC"."ORDERS"
+LEFT JOIN "PUBLIC"."PRODUCTS" "PRODUCTS__via__PRODUCT_ID" ON "PUBLIC"."ORDERS"."PRODUCT_ID" = "PRODUCTS__via__PRODUCT_ID"."ID"
+GROUP BY "PRODUCTS__via__PRODUCT_ID"."CATEGORY", parsedatetime(formatdatetime("PUBLIC"."ORDERS"."CREATED_AT", 'yyyyMM'), 'yyyyMM')
+ORDER BY "PRODUCTS__via__PRODUCT_ID"."CATEGORY" ASC, parsedatetime(formatdatetime("PUBLIC"."ORDERS"."CREATED_AT", 'yyyyMM'), 'yyyyMM') ASC
+`;
+
+const questionDetails = {
+  dataset_query: {
+    database: 1,
+    native: {
+      query: nativeQuery,
+    },
+    type: "native",
+  },
+  display: "line",
+};
+
+describe.skip("issue 12439", () => {
+  beforeEach(() => {
+    cy.intercept("POST", "/api/dataset").as("dataset");
+
+    restore();
+    cy.signInAsAdmin();
+
+    visitQuestionAdhoc(questionDetails);
+    cy.wait("@dataset");
+  });
+
+  it("should allow clicking on a legend in a native question without breaking the UI (metabase#12439)", () => {
+    cy.get(".Visualization").within(() => {
+      cy.findByText("Gizmo").click();
+
+      // Make sure the legends and the graph are still there
+      cy.findByText("Gizmo").should("be.visible");
+      cy.findByText("Doohickey").should("be.visible");
+
+      cy.get("circle");
+    });
+
+    // Make sure buttons are clickable
+    cy.findByTestId("viz-settings-button").click();
+
+    sidebar().contains("Line options");
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #12439

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/native/reproductions/12439-click-on-legend-breaks-ui.cy.spec.js`
- Unskip the test
- It should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/136241687-f4d53678-473d-4bb6-888f-0f6a3e9b0280.png)

