### PR TITLE
Fix CSP issue for Google Analytics

### DIFF
--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -76,6 +76,10 @@
                   :connect-src  ["'self'"
                                  ;; MailChimp. So people can sign up for the Metabase mailing list in the sign up process
                                  "metabase.us10.list-manage.com"
+                                 ;; Google analytics
+                                 (when (public-settings/anon-tracking-enabled)
+                                   "www.google-analytics.com")
+                                 ;; Webpack dev server
                                  (when config/is-dev?
                                    "localhost:8080 ws://localhost:8080")]
                   :manifest-src ["'self'"]}]

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -51,9 +51,10 @@
                                    "'unsafe-eval'" ; TODO - we keep working towards removing this entirely
                                    "https://maps.google.com"
                                    "https://apis.google.com"
-                                   "https://www.google-analytics.com" ; Safari requires the protocol
                                    "https://*.googleapis.com"
                                    "*.gstatic.com"
+                                   (when (public-settings/anon-tracking-enabled)
+                                     "https://www.google-analytics.com")
                                    ;; for webpack hot reloading
                                    (when config/is-dev?
                                      "localhost:8080")


### PR DESCRIPTION
How to test:
- Setup Metabase with tracking enabled
- Open the home page and navigate to any other page
- Make sure that the `collect` request to google-analytics.com succeeds

Feel free to modify the code

Without the fix:
<img width="457" alt="Screen Shot 2021-10-06 at 6 41 05 pm" src="https://user-images.githubusercontent.com/8542534/136242910-1ce2e914-92ae-44e8-9b44-1df0cfb3ed83.png">

With the fix:
<img width="547" alt="Screen Shot 2021-10-06 at 7 17 20 pm" src="https://user-images.githubusercontent.com/8542534/136243358-22737f5a-f983-463a-96a0-ad4ad1b911a9.png">
