### PR TITLE
Remove flow types from Form.jsx

### DIFF
--- a/frontend/src/metabase/containers/Form.jsx
+++ b/frontend/src/metabase/containers/Form.jsx
@@ -20,78 +20,6 @@ export {
   CustomFormSection as FormSection,
 } from "metabase/components/form/CustomForm";
 
-type FormFieldName = string;
-type FormFieldTitle = string;
-type FormFieldDescription = string;
-type FormFieldType =
-  | "input"
-  | "password"
-  | "select"
-  | "text"
-  | "color"
-  | "hidden"
-  | "collection"
-  | "snippetCollection";
-
-type FormValue = any;
-type FormError = string;
-type FormValues = { [name: FormFieldName]: FormValue };
-type FormErrors = { [name: FormFieldName]: FormError };
-
-export type FormFieldDefinition = {
-  name: FormFieldName,
-  type?: FormFieldType,
-  title?: FormFieldTitle,
-  description?: FormFieldDescription,
-  initial?: FormValue | (() => FormValue),
-  normalize?: (value: FormValue) => FormValue,
-  validate?: (value: FormValue, props: FormProps) => ?FormError | boolean,
-  readOnly?: boolean,
-};
-
-export type FormDefinition = {
-  fields:
-    | ((values: FormValues) => FormFieldDefinition[])
-    | FormFieldDefinition[],
-  initial?: FormValues | (() => FormValues),
-  normalize?: (values: FormValues) => FormValues,
-  validate?: (values: FormValues, props: FormProps) => FormErrors,
-};
-
-type FormObject = {
-  fields: (values: FormValues) => FormFieldDefinition[],
-  fieldNames: (values: FormValues) => FormFieldName[],
-  initial: () => FormValues,
-  normalize: (values: FormValues) => FormValues,
-  validate: (values: FormValues, props: FormProps) => FormErrors,
-  disablePristineSubmit?: boolean,
-};
-
-type FormProps = {
-  values?: FormValues,
-};
-
-type Props = {
-  form: FormDefinition,
-  initialValues?: ?FormValues,
-  formName?: string,
-  onSubmit: (values: FormValues) => Promise<any>,
-  onSubmitSuccess: (action: any) => Promise<any>,
-  formComponent?: React.Component,
-  dispatch: Function,
-  values: FormValues,
-};
-
-type State = {
-  inlineFields: { [name: FormFieldName]: FormFieldDefinition },
-};
-
-type SubmitState = {
-  submitting: boolean,
-  failed: boolean,
-  result: any,
-};
-
 let FORM_ID = 0;
 // use makeMapStateToProps so each component gets it's own unique formId
 const makeMapStateToProps = () => {
@@ -128,21 +56,13 @@ const ReduxFormComponent = reduxForm()(
 
 @connect(makeMapStateToProps)
 export default class Form extends React.Component {
-  props: Props;
-  state: State;
-
-  _state: SubmitState = {
+  _state = {
     submitting: false,
     failed: false,
     result: undefined,
   };
 
-  _getFormDefinition: () => FormDefinition;
-  _getFormObject: () => FormObject;
-  _getInitialValues: () => FormValues;
-  _getFieldNames: () => FormFieldName[];
-
-  constructor(props: Props) {
+  constructor(props) {
     super(props);
 
     this.state = {
@@ -240,7 +160,7 @@ export default class Form extends React.Component {
     fieldNames: PropTypes.array,
   };
 
-  componentDidUpdate(prevProps: Props, prevState: State) {
+  componentDidUpdate(prevProps, prevState) {
     // HACK: when new fields are added they aren't initialized with their intialValues, so we have to force it here:
     const newFields = _.difference(
       Object.keys(this.state.inlineFields),
@@ -253,7 +173,7 @@ export default class Form extends React.Component {
     }
   }
 
-  _registerFormField = (field: FormFieldDefinition) => {
+  _registerFormField = field => {
     if (!_.isEqual(this.state.inlineFields[field.name], field)) {
       this.setState(prevState =>
         assocIn(prevState, ["inlineFields", field.name], field),
@@ -261,7 +181,7 @@ export default class Form extends React.Component {
     }
   };
 
-  _unregisterFormField = (field: FormFieldDefinition) => {
+  _unregisterFormField = field => {
     if (this.state.inlineFields[field.name]) {
       // this.setState(prevState =>
       //   dissocIn(prevState, ["inlineFields", field.name]),
@@ -276,7 +196,7 @@ export default class Form extends React.Component {
     };
   }
 
-  _validate = (values: FormValues, props: any) => {
+  _validate = (values, props) => {
     // HACK: clears failed state for global error
     if (!this._state.submitting && this._state.failed) {
       this._state.failed = false;
@@ -286,7 +206,7 @@ export default class Form extends React.Component {
     return formObject.validate(values, props);
   };
 
-  _onSubmit = async (values: FormValues) => {
+  _onSubmit = async values => {
     const formObject = this._getFormObject();
     // HACK: clears failed state for global error
     this._state.submitting = true;
@@ -321,7 +241,7 @@ export default class Form extends React.Component {
     }
   };
 
-  _handleSubmitSuccess = async (action: any) => {
+  _handleSubmitSuccess = async action => {
     if (this.props.onSubmitSuccess) {
       await this.props.onSubmitSuccess(action);
     }
@@ -330,12 +250,11 @@ export default class Form extends React.Component {
     );
   };
 
-  _handleChangeField = (fieldName: FormFieldName, value: FormValue) => {
+  _handleChangeField = (fieldName, value) => {
     return this.props.dispatch(change(this.props.formName, fieldName, value));
   };
 
   render() {
-    // eslint-disable-next-line
     const { formName, overwriteOnInitialValuesChange } = this.props;
     const formObject = this._getFormObject();
     const initialValues = this._getInitialValues();
@@ -371,12 +290,7 @@ export default class Form extends React.Component {
 // form.fields[0] is { name: "foo", initial: "bar" }
 // form.fields[0] is { name: "foo", initial: () => "bar" }
 //
-function makeFormMethod(
-  form: FormObject,
-  methodName: string,
-  defaultValues: any = {},
-  mergeFn,
-) {
+function makeFormMethod(form, methodName, defaultValues = {}, mergeFn) {
   const originalMethod = form[methodName];
   form[methodName] = (object, ...args) => {
     // make a copy
@@ -397,11 +311,13 @@ function makeFormMethod(
     return values;
   };
 }
+
 // if the first arg is a function, call it, otherwise return it.
-function getValue(fnOrValue, ...args): any {
+function getValue(fnOrValue, ...args) {
   return typeof fnOrValue === "function" ? fnOrValue(...args) : fnOrValue;
 }
-function makeFormObject(formDef: FormDefinition): FormObject {
+
+function makeFormObject(formDef) {
   const form = {
     ...formDef,
     fields: values => getValue(formDef.fields, values),
@@ -410,6 +326,7 @@ function makeFormObject(formDef: FormDefinition): FormObject {
       ...form.fields(values).map(field => field.name),
     ],
   };
+
   // for validating the object, or individual values
   makeFormMethod(form, "validate", {}, (a, b) =>
     [a, b].filter(a => a).join(", "),

--- a/frontend/src/metabase/entities/users/forms.js
+++ b/frontend/src/metabase/entities/users/forms.js
@@ -6,9 +6,7 @@ import { PLUGIN_ADMIN_USER_FORM_FIELDS } from "metabase/plugins";
 import validate from "metabase/lib/validate";
 import FormGroupsWidget from "metabase/components/form/widgets/FormGroupsWidget";
 
-import type { FormFieldDefinition } from "metabase/containers/Form";
-
-const DETAILS_FORM_FIELDS: () => FormFieldDefinition[] = () => [
+const DETAILS_FORM_FIELDS = () => [
   {
     name: "first_name",
     title: t`First name`,
@@ -30,7 +28,7 @@ const DETAILS_FORM_FIELDS: () => FormFieldDefinition[] = () => [
   },
 ];
 
-const LOCALE_FIELD: FormFieldDefinition = {
+const LOCALE_FIELD = {
   name: "locale",
   title: t`Language`,
   type: "select",
@@ -43,7 +41,7 @@ const LOCALE_FIELD: FormFieldDefinition = {
   ].map(([code, name]) => ({ name, value: code })),
 };
 
-const PASSWORD_FORM_FIELDS: () => FormFieldDefinition[] = () => [
+const PASSWORD_FORM_FIELDS = () => [
   {
     name: "password",
     title: t`Create a password`,

--- a/frontend/src/metabase/lib/entities.js
+++ b/frontend/src/metabase/lib/entities.js
@@ -31,7 +31,6 @@ import _ from "underscore";
 //
 
 import type { APIMethod } from "metabase/lib/api";
-import type { FormDefinition } from "metabase/containers/Form";
 
 type EntityName = string;
 
@@ -48,9 +47,6 @@ type EntityDefinition = {
 
   nameOne?: string,
   nameMany?: string,
-
-  form?: FormDefinition,
-  forms?: { [key: string]: FormDefinition },
 
   displayNameOne?: string,
   displayNameMany?: string,
@@ -106,9 +102,6 @@ export type Entity = {
 
   displayNameOne: string,
   displayNameMany: string,
-
-  form?: FormDefinition,
-  forms?: { [key: string]: FormDefinition },
 
   path?: string,
   api: {


### PR DESCRIPTION
This is related to https://github.com/metabase/metabase/pull/17998, as we should process a new option for form fields that go through this container.

Nothing should change in runtime, file should be a bit easier to read.