### PR TITLE
#17963 Repro: MongoDB cannot use filter expression comparing two fields

### DIFF
--- a/frontend/test/metabase/scenarios/question/reproductions/17963-mongo-filter-expression-compare-two-fields.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/17963-mongo-filter-expression-compare-two-fields.cy.spec.js
@@ -1,0 +1,47 @@
+import { restore, popover } from "__support__/e2e/cypress";
+
+describe.skip("issue 17963", () => {
+  beforeEach(() => {
+    restore("mongo-4");
+    cy.signInAsAdmin();
+
+    cy.visit("/question/new");
+    cy.findByText("Custom question").click();
+    cy.findByText("QA Mongo4").click();
+    cy.findByText("Orders").click();
+  });
+
+  it("should be able to compare two fields using filter expression (metabase#17963)", () => {
+    cy.findByText("Add filters to narrow your answer").click();
+
+    popover()
+      .contains("Custom Expression")
+      .click();
+
+    typeAndSelect([
+      { string: "dis", field: "Discount" },
+      { string: "> qu", field: "Quantity" },
+    ]);
+
+    cy.button("Done").click();
+
+    cy.findByText("Discount > Quantity");
+
+    cy.findByText("Pick the metric you want to see").click();
+    cy.findByText("Count of rows").click();
+
+    cy.button("Visualize").click();
+
+    cy.get(".ScalarValue").contains("1,337");
+  });
+});
+
+function typeAndSelect(arr) {
+  arr.forEach(({ string, field }) => {
+    cy.get("[contenteditable=true]").type(string);
+
+    popover()
+      .contains(field)
+      .click();
+  });
+}


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #17963 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/question/reproductions/17963-mongo-filter-expression-compare-two-fields.cy.spec.js`
- Unskip the test
- It should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/136273133-aab71279-ee10-4ee9-8c15-0194efc46f57.png)

