### PR TITLE
Fix typo in object key

### DIFF
--- a/frontend/src/metabase/entities/snippets.js
+++ b/frontend/src/metabase/entities/snippets.js
@@ -8,7 +8,7 @@ const formFields = [
   {
     name: "content",
     title: t`Enter some SQL here so you can reuse it later`,
-    placholder: "AND canceled_at IS null\nAND account_type = 'PAID'",
+    placeholder: "AND canceled_at IS null\nAND account_type = 'PAID'",
     type: "text",
     className:
       "Form-input full text-monospace text-normal text-small bg-light text-spaced",


### PR DESCRIPTION
A drive-by typo fix as we work on https://github.com/metabase/metabase/pull/17998

Nothing should change in runtime or automated tests.