### PR TITLE
Allow sorting of the results of more aggregation functions

### DIFF
--- a/frontend/src/metabase/lib/query/aggregation.js
+++ b/frontend/src/metabase/lib/query/aggregation.js
@@ -16,9 +16,12 @@ import type { MetricId } from "metabase-types/types/Metric";
 export const SORTABLE_AGGREGATION_TYPES = new Set([
   "avg",
   "count",
+  "count-where",
   "distinct",
   "stddev",
   "sum",
+  "sum-where",
+  "cum-sum",
   "min",
   "max",
 ]);

--- a/frontend/test/metabase/scenarios/question/reproductions/6239.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/6239.cy.spec.js
@@ -1,6 +1,6 @@
 import { restore, popover, openOrdersTable } from "__support__/e2e/cypress";
 
-describe.skip("issue 6239", () => {
+describe("issue 6239", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();


### PR DESCRIPTION
This should fix #6239.

The corresponding repro test is unskipped.

How to verify:

1. Ask a question, Custom question.
2. Sample Dataset, Orders table.
3. Summarize, Custom Expression, type `Average([Tax] + [Discount])` and name it _AvgTaxDiscount_.
4. Another one: Custom Expression, type `CountIf([Discount] > 0)` and name it _Discounted_.
5. Group by e.g. _Created At_.
6. Sort

**Before this PR**

The popup for Sort only shows:
* Created At
* AvgTaxDiscount

![image](https://user-images.githubusercontent.com/7288/134590905-421880df-37e6-42b8-a91e-db8aafa2349d.png)

**After this PR**

The popup for Sort should show three items (this is the correct behavior):
* Created At
* AvgTaxDiscount
* Discounted

![image](https://user-images.githubusercontent.com/7288/136276584-7c4169d5-7d4a-46a4-b145-32e1458bff94.png)

**Note**

Other custom expressions for the summary which now should work as well:

* `CumulativeSum([Subtotal])` (or `cum-sum` in MBQL)
* `SumIf([Tax], [Discount] > 0)` (or `cum-count` in MBQL)
