### PR TITLE
Update assertions in repro for #15612

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
@@ -751,13 +751,27 @@ describe("scenarios > dashboard > dashboard drill", () => {
           cy.intercept("POST", `/api/card/${QUESTION2_ID}/query`).as(
             "secondCardQuery",
           );
-          cy.visit(`/dashboard/${DASHBOARD_ID}`);
 
+          cy.visit(`/dashboard/${DASHBOARD_ID}`);
           cy.wait("@secondCardQuery");
+
+          cy.get(".bar")
+            .first()
+            .trigger("mousemove");
+
+          popover().within(() => {
+            testPairedTooltipValues("AXIS", "1");
+            testPairedTooltipValues("VALUE", "5");
+          });
+
           cy.get(".bar")
             .last()
             .trigger("mousemove");
-          popover().contains("10");
+
+          popover().within(() => {
+            testPairedTooltipValues("AXIS", "1");
+            testPairedTooltipValues("VALUE", "10");
+          });
         });
       });
     });
@@ -1015,4 +1029,11 @@ function drillThroughCardTitle(title) {
     .contains(title)
     .click();
   cy.contains(`Started from ${title}`);
+}
+
+function testPairedTooltipValues(val1, val2) {
+  cy.contains(val1)
+    .closest("td")
+    .siblings("td")
+    .findByText(val2);
 }


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- Updates the assertion in repro for #15612 in such a way that it checks both for the column name and its value
- Adds the assertion for the second bar as well

### How to test this?
- All tests should still pass in the CI

### Additional notes:
This was needed to guard against regressions. Please see the following issues:
- https://github.com/metabase/metabase/issues/16249
- https://github.com/metabase/metabase/issues/18210

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/136373516-00dfe2df-4310-4e45-b453-8647fcb66394.png)

