### PR TITLE
Fix skipped unit test

### DIFF
--- a/frontend/test/metabase/query_builder/components/QuestionActivityTimeline.unit.spec.js
+++ b/frontend/test/metabase/query_builder/components/QuestionActivityTimeline.unit.spec.js
@@ -3,8 +3,7 @@ import { render, screen } from "@testing-library/react";
 
 import { QuestionActivityTimeline } from "metabase/query_builder/components/QuestionActivityTimeline";
 
-// FIXME: fix and unskip
-describe.skip("QuestionActivityTimeline", () => {
+describe("QuestionActivityTimeline", () => {
   let question;
   let revisions;
   let revertToRevision;
@@ -35,6 +34,7 @@ describe.skip("QuestionActivityTimeline", () => {
     beforeEach(() => {
       question = {
         canWrite: () => false,
+        getModerationReviews: () => [],
       };
 
       render(
@@ -55,6 +55,7 @@ describe.skip("QuestionActivityTimeline", () => {
     beforeEach(() => {
       question = {
         canWrite: () => true,
+        getModerationReviews: () => [],
       };
 
       render(


### PR DESCRIPTION
The tested component uses Question's `getModerationReviews` method, so we need to provide some mock implementation for it