### PR TITLE
Fix color issue with step action buttons

### DIFF
--- a/frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx
@@ -126,20 +126,24 @@ export default class NotebookStep extends React.Component {
 
     const actions = [];
     actions.push(
-      ...step.actions.map(action => ({
-        priority: (STEP_UI[action.type] || {}).priority,
-        button: (
-          <ActionButton
-            mr={isLastStep ? 2 : 1}
-            mt={isLastStep ? 2 : null}
-            color={color}
-            large={largeActionButtons}
-            {...(STEP_UI[action.type] || {})}
-            key={`actionButton_${STEP_UI[action.type].title}`}
-            onClick={() => action.action({ query: step.query, openStep })}
-          />
-        ),
-      })),
+      ...step.actions.map(action => {
+        const stepUi = STEP_UI[action.type];
+
+        return {
+          priority: stepUi.priority,
+          button: (
+            <ActionButton
+              mr={isLastStep ? 2 : 1}
+              mt={isLastStep ? 2 : null}
+              color={stepUi.getColor()}
+              large={largeActionButtons}
+              {...stepUi}
+              key={`actionButton_${stepUi.title}`}
+              onClick={() => action.action({ query: step.query, openStep })}
+            />
+          ),
+        };
+      }),
     );
 
     actions.sort((a, b) => (b.priority || 0) - (a.priority || 0));


### PR DESCRIPTION
How to test:
- Ask a question -> Custom question
- Pick data source and remove filter and summarise steps
- Check colors of action buttons

Regression from https://github.com/metabase/metabase/pull/18217

Before the fix:
<img width="753" alt="Screen Shot 2021-10-07 at 7 58 02 pm" src="https://user-images.githubusercontent.com/8542534/136430387-78f81513-0202-4319-b59d-5aec4ad6cc5f.png">

After the fix:
<img width="760" alt="Screen Shot 2021-10-07 at 7 53 25 pm" src="https://user-images.githubusercontent.com/8542534/136430046-a975eb4f-6121-4b95-ab21-9cd47c1ce42f.png">
