### PR TITLE
support ts and tsx in parse-deps

### DIFF
--- a/frontend/parse-deps.js
+++ b/frontend/parse-deps.js
@@ -30,7 +30,6 @@ function dependencies() {
     try {
       const file = babel.transformSync(contents, {
         filename,
-        plugins: ["@babel/plugin-transform-flow-strip-types"],
         presets: ["@babel/preset-typescript"],
         ast: true,
         code: false,


### PR DESCRIPTION
### Description

Since we introduced Typescript, we need to support it in `parse-deps` CLI that helps to find dependencies from imports.
Turned out, `flow` and `typescript` plugins do not work together.

### How to verify

Ensure all commands of `node frontend/parse-deps.js` as expected including all TS files. For now we have only `use-debounced-value.ts` 

