### PR TITLE
Copied `delay` utility function into Cypress backend script

### DIFF
--- a/frontend/test/__runner__/backend.js
+++ b/frontend/test/__runner__/backend.js
@@ -4,7 +4,6 @@ import path from "path";
 import { spawn } from "child_process";
 
 import fetch from "isomorphic-fetch";
-import { delay } from "../../src/metabase/lib/promise";
 
 export const DEFAULT_DB_KEY = "/test_db_fixture.db";
 
@@ -175,4 +174,9 @@ function createSharedResource(
       }
     },
   };
+}
+
+// Copied here from `frontend/src/metabase/lib/promise.js` to decouple Cypress from Typescript
+function delay(duration) {
+  return new Promise((resolve, reject) => setTimeout(resolve, duration));
 }


### PR DESCRIPTION
This is the only place that imports `metabase/lib` in the Cypress test runner suite except for a constant. It's such a simple function that I don't think it's worth coupling `backend.js` to `metabase/lib`. This PR fixes the 30+ failed E2E gates in #18324 (cherry-picked to apply to parallel branches to prevent merge conflicts down the road)

**Alternative** `babel-node` *should* have the same `.babelrc` and *should* be picking it up and transpiling, but it's not. I don't want to mess that much with the testing infrastructure till I've got a better handle on some other TS changes