### PR TITLE
Enable `allowJs` and some other options in tsconfig 

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,9 @@
         "./enterprise/frontend/test/*"
       ]
     },
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "esModuleInterop": true,
+    "allowJs": true
   },
   "include": [
     "frontend/src/**/*.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,9 +17,10 @@
         "./enterprise/frontend/test/*"
       ]
     },
-    "forceConsistentCasingInFileNames": true,
+    "allowJs": true,
     "esModuleInterop": true,
-    "allowJs": true
+    "experimentalDecorators": true,
+    "forceConsistentCasingInFileNames": true
   },
   "include": [
     "frontend/src/**/*.ts",


### PR DESCRIPTION
This allows typescript to infer limited types from Javascript files - it's not perfect but significantly improves intellisense for JS imports.

For example, in `frontend/src/metabase/components/Select.jsx`, the import `import SelectButton from "./SelectButton.jsx";` resolves to:

![image](https://user-images.githubusercontent.com/653604/136472511-e2cf23eb-f577-43dc-8156-fc31a1f3e397.png)
