### PR TITLE
Fix error on PostgreSQL tests about SSL

### DIFF
--- a/frontend/test/__support__/e2e/helpers/e2e-qa-databases-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-qa-databases-helpers.js
@@ -20,7 +20,7 @@ export function addMySQLDatabase(name = "QA MySQL8") {
 function addQADatabase(engine, db_display_name, port) {
   const PASS_KEY = engine === "mongo" ? "pass" : "password";
   const AUTH_DB = engine === "mongo" ? "admin" : null;
-  const OPTIONS = engine === "mysql" ? "allowPublicKeyRetrieval=true" : null;
+  const OPTIONS = engine === "postgres" ? "sslmode=prefer" : null;
 
   cy.log(`**-- Adding ${engine.toUpperCase()} DB --**`);
   cy.request("POST", "/api/database", {


### PR DESCRIPTION
Metabase started being way more verbose about connections, and in the latest versions it tried to connect with SSL, but when the server didn't like that, it went with a less secure method and threw the exception in the logs.

Now, it will connect with a `prefer` sslmode (https://www.postgresql.org/docs/9.1/libpq-ssl.html) so it doesn't enforce SSL but will connect if the server supports it, which is future proof if we do it in the future and does not fill the logs with errors that doesn't matter

NOTE: I replaced the MySQL options as the new container images have 5.7 auth mechanism, so the flag of public key retrieval is no longer relevant