### PR TITLE
Fix errors on tests when adding a database

### DIFF
--- a/frontend/test/metabase/scenarios/admin/databases/add-external.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/add-external.cy.spec.js
@@ -23,6 +23,10 @@ describe("admin > database > add > external databases", () => {
     typeAndBlurUsingLabel("Database name", "sample");
     typeAndBlurUsingLabel("Username", "metabase");
     typeAndBlurUsingLabel("Password", "metasample123");
+    typeAndBlurUsingLabel(
+      "Additional JDBC connection string options",
+      "sslmode=prefer",
+    );
 
     cy.findByText("Save")
       .should("not.be.disabled")
@@ -82,13 +86,6 @@ describe("admin > database > add > external databases", () => {
     typeAndBlurUsingLabel("Database name", "sample");
     typeAndBlurUsingLabel("Username", "metabase");
     typeAndBlurUsingLabel("Password", "metasample123");
-
-    // Bypass the RSA public key error for MySQL database
-    // https://github.com/metabase/metabase/issues/12545
-    typeAndBlurUsingLabel(
-      "Additional JDBC connection string options",
-      "allowPublicKeyRetrieval=true",
-    );
 
     cy.findByText("Save")
       .should("not.be.disabled")

--- a/frontend/test/metabase/scenarios/admin/databases/add-external.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/add-external.cy.spec.js
@@ -23,10 +23,6 @@ describe("admin > database > add > external databases", () => {
     typeAndBlurUsingLabel("Database name", "sample");
     typeAndBlurUsingLabel("Username", "metabase");
     typeAndBlurUsingLabel("Password", "metasample123");
-    typeAndBlurUsingLabel(
-      "Additional JDBC connection string options",
-      "sslmode=disable",
-    );
 
     cy.findByText("Save")
       .should("not.be.disabled")

--- a/frontend/test/metabase/scenarios/admin/databases/add-external.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/add-external.cy.spec.js
@@ -25,7 +25,7 @@ describe("admin > database > add > external databases", () => {
     typeAndBlurUsingLabel("Password", "metasample123");
     typeAndBlurUsingLabel(
       "Additional JDBC connection string options",
-      "sslmode=prefer",
+      "sslmode=allow",
     );
 
     cy.findByText("Save")

--- a/frontend/test/metabase/scenarios/admin/databases/add-external.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/add-external.cy.spec.js
@@ -25,7 +25,7 @@ describe("admin > database > add > external databases", () => {
     typeAndBlurUsingLabel("Password", "metasample123");
     typeAndBlurUsingLabel(
       "Additional JDBC connection string options",
-      "sslmode=allow",
+      "sslmode=disable",
     );
 
     cy.findByText("Save")

--- a/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
@@ -52,7 +52,7 @@ describe("scenarios > admin > databases > add", () => {
     typeField("Password", "metasample123");
     typeField(
       "Additional JDBC connection string options",
-      "sslmode=allow",
+      "sslmode=disable",
     );
 
     cy.button("Save")
@@ -76,7 +76,7 @@ describe("scenarios > admin > databases > add", () => {
     typeField("Password", "metasample123");
     typeField(
       "Additional JDBC connection string options",
-      "sslmode=allow",
+      "sslmode=disable",
     );
 
     cy.findByText("Save").click();
@@ -128,7 +128,7 @@ describe("scenarios > admin > databases > add", () => {
     typeField("Password", "metasample123");
     typeField(
       "Additional JDBC connection string options",
-      "sslmode=allow",
+      "sslmode=disable",
     );
     
 
@@ -347,7 +347,7 @@ describe("scenarios > admin > databases > add", () => {
       typeField("Password", "metasample123");
       typeField(
         "Additional JDBC connection string options",
-        "sslmode=allow",
+        "sslmode=disable",
       );
 
       cy.button("Save").click();
@@ -369,7 +369,7 @@ describe("scenarios > admin > databases > add", () => {
       typeField("Password", "metasample123");
       typeField(
         "Additional JDBC connection string options",
-        "sslmode=allow",
+        "sslmode=disable",
       );
 
       cy.findByText("Use instance default (TTL)").click();

--- a/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
@@ -50,10 +50,6 @@ describe("scenarios > admin > databases > add", () => {
     typeField("Database name", "sample");
     typeField("Username", "metabase");
     typeField("Password", "metasample123");
-    typeField(
-      "Additional JDBC connection string options",
-      "sslmode=disable",
-    );
 
     cy.button("Save")
       .should("not.be.disabled")
@@ -74,10 +70,6 @@ describe("scenarios > admin > databases > add", () => {
     typeField("Database name", " sample");
     typeField("Username", "   metabase   ");
     typeField("Password", "metasample123");
-    typeField(
-      "Additional JDBC connection string options",
-      "sslmode=disable",
-    );
 
     cy.findByText("Save").click();
 
@@ -126,11 +118,6 @@ describe("scenarios > admin > databases > add", () => {
     typeField("Database name", "sample");
     typeField("Username", "metabase");
     typeField("Password", "metasample123");
-    typeField(
-      "Additional JDBC connection string options",
-      "sslmode=disable",
-    );
-    
 
     cy.button("Save").should("not.be.disabled");
 
@@ -345,10 +332,6 @@ describe("scenarios > admin > databases > add", () => {
       typeField("Database name", "sample");
       typeField("Username", "metabase");
       typeField("Password", "metasample123");
-      typeField(
-        "Additional JDBC connection string options",
-        "sslmode=disable",
-      );
 
       cy.button("Save").click();
 
@@ -367,10 +350,6 @@ describe("scenarios > admin > databases > add", () => {
       typeField("Database name", "sample");
       typeField("Username", "metabase");
       typeField("Password", "metasample123");
-      typeField(
-        "Additional JDBC connection string options",
-        "sslmode=disable",
-      );
 
       cy.findByText("Use instance default (TTL)").click();
       popover()

--- a/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
@@ -46,8 +46,10 @@ describe("scenarios > admin > databases > add", () => {
 
     typeField("Name", "Test db name");
     typeField("Host", "localhost");
-    typeField("Database name", "test_postgres_db");
-    typeField("Username", "uberadmin");
+    typeField("Port", "5432");
+    typeField("Database name", "sample");
+    typeField("Username", "metabase");
+    typeField("Password", "metasample123");
 
     cy.button("Save")
       .should("not.be.disabled")
@@ -64,8 +66,10 @@ describe("scenarios > admin > databases > add", () => {
 
     typeField("Name", "Test db name");
     typeField("Host", "localhost  \n  ");
-    typeField("Database name", " test_postgres_db");
-    typeField("Username", "   uberadmin   ");
+    typeField("Port", "5432");
+    typeField("Database name", " sample");
+    typeField("Username", "   metabase   ");
+    typeField("Password", "metasample123");
 
     cy.findByText("Save").click();
 
@@ -109,8 +113,12 @@ describe("scenarios > admin > databases > add", () => {
     cy.visit("/admin/databases/create");
 
     typeField("Name", "Test db name");
-    typeField("Database name", "test_postgres_db");
-    typeField("Username", "uberadmin");
+    typeField("Host", "localhost");
+    typeField("Port", "5432");
+    typeField("Database name", "sample");
+    typeField("Username", "metabase");
+    typeField("Password", "metasample123");
+    
 
     cy.button("Save").should("not.be.disabled");
 

--- a/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
@@ -50,6 +50,10 @@ describe("scenarios > admin > databases > add", () => {
     typeField("Database name", "sample");
     typeField("Username", "metabase");
     typeField("Password", "metasample123");
+    typeAndBlurUsingLabel(
+      "Additional JDBC connection string options",
+      "sslmode=prefer",
+    );
 
     cy.button("Save")
       .should("not.be.disabled")
@@ -70,6 +74,10 @@ describe("scenarios > admin > databases > add", () => {
     typeField("Database name", " sample");
     typeField("Username", "   metabase   ");
     typeField("Password", "metasample123");
+    typeAndBlurUsingLabel(
+      "Additional JDBC connection string options",
+      "sslmode=prefer",
+    );
 
     cy.findByText("Save").click();
 
@@ -118,6 +126,10 @@ describe("scenarios > admin > databases > add", () => {
     typeField("Database name", "sample");
     typeField("Username", "metabase");
     typeField("Password", "metasample123");
+    typeAndBlurUsingLabel(
+      "Additional JDBC connection string options",
+      "sslmode=prefer",
+    );
     
 
     cy.button("Save").should("not.be.disabled");

--- a/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
@@ -83,8 +83,8 @@ describe("scenarios > admin > databases > add", () => {
 
     cy.wait("@createDatabase").then(({ request }) => {
       expect(request.body.details.host).to.equal("localhost");
-      expect(request.body.details.dbname).to.equal("test_postgres_db");
-      expect(request.body.details.user).to.equal("uberadmin");
+      expect(request.body.details.dbname).to.equal("sample");
+      expect(request.body.details.user).to.equal("metabase");
     });
   });
 
@@ -147,7 +147,7 @@ describe("scenarios > admin > databases > add", () => {
     cy.wait("@createDatabase").then(({ request }) => {
       expect(request.body.engine).to.equal("postgres");
       expect(request.body.name).to.equal("Test db name");
-      expect(request.body.details.user).to.equal("uberadmin");
+      expect(request.body.details.user).to.equal("metabase");
     });
 
     cy.url().should("match", /\/admin\/databases\?created=42$/);

--- a/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
@@ -50,9 +50,9 @@ describe("scenarios > admin > databases > add", () => {
     typeField("Database name", "sample");
     typeField("Username", "metabase");
     typeField("Password", "metasample123");
-    typeAndBlurUsingLabel(
+    typeField(
       "Additional JDBC connection string options",
-      "sslmode=prefer",
+      "sslmode=allow",
     );
 
     cy.button("Save")
@@ -74,9 +74,9 @@ describe("scenarios > admin > databases > add", () => {
     typeField("Database name", " sample");
     typeField("Username", "   metabase   ");
     typeField("Password", "metasample123");
-    typeAndBlurUsingLabel(
+    typeField(
       "Additional JDBC connection string options",
-      "sslmode=prefer",
+      "sslmode=allow",
     );
 
     cy.findByText("Save").click();
@@ -126,9 +126,9 @@ describe("scenarios > admin > databases > add", () => {
     typeField("Database name", "sample");
     typeField("Username", "metabase");
     typeField("Password", "metasample123");
-    typeAndBlurUsingLabel(
+    typeField(
       "Additional JDBC connection string options",
-      "sslmode=prefer",
+      "sslmode=allow",
     );
     
 
@@ -341,8 +341,14 @@ describe("scenarios > admin > databases > add", () => {
 
       typeField("Name", "Test db name");
       typeField("Host", "localhost");
-      typeField("Database name", "test_postgres_db");
-      typeField("Username", "uberadmin");
+      typeField("Port", "5432");
+      typeField("Database name", "sample");
+      typeField("Username", "metabase");
+      typeField("Password", "metasample123");
+      typeField(
+        "Additional JDBC connection string options",
+        "sslmode=allow",
+      );
 
       cy.button("Save").click();
 
@@ -357,8 +363,14 @@ describe("scenarios > admin > databases > add", () => {
 
       typeField("Name", "Test db name");
       typeField("Host", "localhost");
-      typeField("Database name", "test_postgres_db");
-      typeField("Username", "uberadmin");
+      typeField("Port", "5432");
+      typeField("Database name", "sample");
+      typeField("Username", "metabase");
+      typeField("Password", "metasample123");
+      typeField(
+        "Additional JDBC connection string options",
+        "sslmode=allow",
+      );
 
       cy.findByText("Use instance default (TTL)").click();
       popover()


### PR DESCRIPTION
This will fix the errors that were happening when adding databases (https://github.com/metabase/metabase/pull/16890, e2e-tests-admin-ee step)

Our postgres qa database does not have a uberadmin user, but rather a metabase user. Also it seems that this test types each field instead of using the data from the e2e-qa-database-helpers function

NOTE: I replaced the MySQL options as the new container images have 5.7 auth mechanism, so the flag of public key retrieval is no longer relevant