### PR TITLE
Add custom react-testing-library render function

### DIFF
--- a/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.unit.spec.js
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.unit.spec.js
@@ -1,5 +1,9 @@
 import React from "react";
-import { render, screen, waitForElementToBeRemoved } from "__support__/ui";
+import {
+  renderWithProviders,
+  screen,
+  waitForElementToBeRemoved,
+} from "__support__/ui";
 import admin from "metabase/admin/admin";
 import MetabaseSettings from "metabase/lib/settings";
 import { PLUGIN_CACHING } from "metabase/plugins";
@@ -39,7 +43,10 @@ function mockSettings({ cachingEnabled = false }) {
 
 async function setup({ cachingEnabled = false } = {}) {
   mockSettings({ cachingEnabled });
-  render(<DatabaseEditApp />, { withRouter: true, reducers: { admin } });
+  renderWithProviders(<DatabaseEditApp />, {
+    withRouter: true,
+    reducers: { admin },
+  });
   await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
 }
 

--- a/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.unit.spec.js
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.unit.spec.js
@@ -1,17 +1,8 @@
 import React from "react";
-import { Provider } from "react-redux";
-import { reducer as form } from "redux-form";
-import { Router, Route } from "react-router";
-import { createMemoryHistory } from "history";
-import {
-  render,
-  screen,
-  waitForElementToBeRemoved,
-} from "@testing-library/react";
+import { render, screen, waitForElementToBeRemoved } from "__support__/ui";
 import admin from "metabase/admin/admin";
 import MetabaseSettings from "metabase/lib/settings";
 import { PLUGIN_CACHING } from "metabase/plugins";
-import { getStore } from "__support__/entities-store";
 import DatabaseEditApp from "./DatabaseEditApp";
 
 const ENGINES_MOCK = {
@@ -48,15 +39,7 @@ function mockSettings({ cachingEnabled = false }) {
 
 async function setup({ cachingEnabled = false } = {}) {
   mockSettings({ cachingEnabled });
-
-  render(
-    <Provider store={getStore({ admin, form })}>
-      <Router history={createMemoryHistory()}>
-        <Route path="/" component={DatabaseEditApp} />
-      </Router>
-    </Provider>,
-  );
-
+  render(<DatabaseEditApp />, { withRouter: true, reducers: { admin } });
   await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
 }
 

--- a/frontend/src/metabase/collections/containers/CollectionSidebar/Collections/Collections.unit.spec.js
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/Collections/Collections.unit.spec.js
@@ -1,7 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
-import { DragDropContextProvider } from "react-dnd";
-import HTML5Backend from "react-dnd-html5-backend";
+import { render, screen } from "__support__/ui";
 
 import Collections from "./Collections";
 
@@ -10,16 +8,15 @@ const list = [{ name }];
 
 it("displays entries", () => {
   render(
-    <DragDropContextProvider backend={HTML5Backend}>
-      <Collections
-        collectionId={1}
-        currentUserId={1}
-        list={list}
-        onClose={() => {}}
-        onOpen={() => {}}
-        openCollections={[]}
-      />
-    </DragDropContextProvider>,
+    <Collections
+      collectionId={1}
+      currentUserId={1}
+      list={list}
+      onClose={() => {}}
+      onOpen={() => {}}
+      openCollections={[]}
+    />,
+    { withDND: true },
   );
 
   screen.getByText(name);

--- a/frontend/src/metabase/collections/containers/CollectionSidebar/Collections/Collections.unit.spec.js
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/Collections/Collections.unit.spec.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "__support__/ui";
+import { renderWithProviders, screen } from "__support__/ui";
 
 import Collections from "./Collections";
 
@@ -7,7 +7,7 @@ const name = "A collection name";
 const list = [{ name }];
 
 it("displays entries", () => {
-  render(
+  renderWithProviders(
     <Collections
       collectionId={1}
       currentUserId={1}

--- a/frontend/src/metabase/collections/containers/CollectionSidebar/Collections/CollectionsList/CollectionsList.unit.spec.js
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/Collections/CollectionsList/CollectionsList.unit.spec.js
@@ -1,33 +1,20 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen } from "__support__/ui";
 import userEvent from "@testing-library/user-event";
-import { DragDropContextProvider } from "react-dnd";
-import HTML5Backend from "react-dnd-html5-backend";
-import { Router, Route } from "react-router";
-import { createMemoryHistory } from "history";
-
 import { PLUGIN_COLLECTIONS } from "metabase/plugins";
-
 import CollectionsList from "./CollectionsList";
 
 describe("CollectionsList", () => {
   function setup({ collections = [], openCollections = [], ...props } = {}) {
-    const Page = () => (
-      <DragDropContextProvider backend={HTML5Backend}>
-        <CollectionsList
-          collections={collections}
-          openCollections={openCollections}
-          filter={() => true}
-          handleToggleMobileSidebar={() => false}
-          {...props}
-        />
-      </DragDropContextProvider>
-    );
-
     render(
-      <Router history={createMemoryHistory()}>
-        <Route path="/" component={Page} />
-      </Router>,
+      <CollectionsList
+        collections={collections}
+        openCollections={openCollections}
+        filter={() => true}
+        handleToggleMobileSidebar={() => false}
+        {...props}
+      />,
+      { withRouter: true, withDND: true },
     );
   }
 

--- a/frontend/src/metabase/collections/containers/CollectionSidebar/Collections/CollectionsList/CollectionsList.unit.spec.js
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/Collections/CollectionsList/CollectionsList.unit.spec.js
@@ -1,12 +1,12 @@
 import React from "react";
-import { render, screen } from "__support__/ui";
+import { renderWithProviders, screen } from "__support__/ui";
 import userEvent from "@testing-library/user-event";
 import { PLUGIN_COLLECTIONS } from "metabase/plugins";
 import CollectionsList from "./CollectionsList";
 
 describe("CollectionsList", () => {
   function setup({ collections = [], openCollections = [], ...props } = {}) {
-    render(
+    renderWithProviders(
       <CollectionsList
         collections={collections}
         openCollections={openCollections}

--- a/frontend/src/metabase/collections/containers/CollectionSidebar/RootCollectionLink/RootCollectionLink.unit.spec.js
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/RootCollectionLink/RootCollectionLink.unit.spec.js
@@ -1,11 +1,15 @@
 import React from "react";
-import { render, screen, waitForElementToBeRemoved } from "__support__/ui";
+import {
+  renderWithProviders,
+  screen,
+  waitForElementToBeRemoved,
+} from "__support__/ui";
 import xhrMock from "xhr-mock";
 
 import RootCollectionLink from "./RootCollectionLink";
 
 async function setup() {
-  render(<RootCollectionLink isRoot={false} />, { withDND: true });
+  renderWithProviders(<RootCollectionLink isRoot={false} />, { withDND: true });
   await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
 }
 

--- a/frontend/src/metabase/collections/containers/CollectionSidebar/RootCollectionLink/RootCollectionLink.unit.spec.js
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/RootCollectionLink/RootCollectionLink.unit.spec.js
@@ -1,25 +1,11 @@
 import React from "react";
-import { Provider } from "react-redux";
-import {
-  render,
-  screen,
-  waitForElementToBeRemoved,
-} from "@testing-library/react";
-import { getStore } from "__support__/entities-store";
+import { render, screen, waitForElementToBeRemoved } from "__support__/ui";
 import xhrMock from "xhr-mock";
-import { DragDropContextProvider } from "react-dnd";
-import HTML5Backend from "react-dnd-html5-backend";
 
 import RootCollectionLink from "./RootCollectionLink";
 
 async function setup() {
-  render(
-    <Provider store={getStore()}>
-      <DragDropContextProvider backend={HTML5Backend}>
-        <RootCollectionLink isRoot={false} />
-      </DragDropContextProvider>
-    </Provider>,
-  );
+  render(<RootCollectionLink isRoot={false} />, { withDND: true });
   await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
 }
 

--- a/frontend/src/metabase/components/CreateDashboardModal.unit.spec.js
+++ b/frontend/src/metabase/components/CreateDashboardModal.unit.spec.js
@@ -1,10 +1,7 @@
 import React from "react";
-import { Provider } from "react-redux";
-import { reducer as form } from "redux-form";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "__support__/ui";
 import userEvent from "@testing-library/user-event";
 import xhrMock from "xhr-mock";
-import { getStore } from "__support__/entities-store";
 import MetabaseSettings from "metabase/lib/settings";
 import { PLUGIN_CACHING } from "metabase/plugins";
 import CreateDashboardModal from "./CreateDashboardModal";
@@ -29,11 +26,7 @@ function setup({ mockCreateDashboardResponse = true } = {}) {
     );
   }
 
-  render(
-    <Provider store={getStore({ form })}>
-      <CreateDashboardModal onClose={onClose} />
-    </Provider>,
-  );
+  render(<CreateDashboardModal onClose={onClose} />);
 
   return {
     onClose,

--- a/frontend/src/metabase/components/CreateDashboardModal.unit.spec.js
+++ b/frontend/src/metabase/components/CreateDashboardModal.unit.spec.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { fireEvent, render, screen } from "__support__/ui";
+import { fireEvent, renderWithProviders, screen } from "__support__/ui";
 import userEvent from "@testing-library/user-event";
 import xhrMock from "xhr-mock";
 import MetabaseSettings from "metabase/lib/settings";
@@ -26,7 +26,7 @@ function setup({ mockCreateDashboardResponse = true } = {}) {
     );
   }
 
-  render(<CreateDashboardModal onClose={onClose} />);
+  renderWithProviders(<CreateDashboardModal onClose={onClose} />);
 
   return {
     onClose,

--- a/frontend/src/metabase/containers/ItemPicker.unit.spec.js
+++ b/frontend/src/metabase/containers/ItemPicker.unit.spec.js
@@ -1,6 +1,6 @@
 import React from "react";
 import {
-  render,
+  renderWithProviders,
   screen,
   waitForElementToBeRemoved,
   within,
@@ -134,9 +134,12 @@ async function setup({
 
   const onChange = jest.fn();
 
-  render(<ItemPicker models={models} onChange={onChange} {...props} />, {
-    currentUser: CURRENT_USER,
-  });
+  renderWithProviders(
+    <ItemPicker models={models} onChange={onChange} {...props} />,
+    {
+      currentUser: CURRENT_USER,
+    },
+  );
 
   await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
 

--- a/frontend/src/metabase/containers/ItemPicker.unit.spec.js
+++ b/frontend/src/metabase/containers/ItemPicker.unit.spec.js
@@ -1,14 +1,12 @@
 import React from "react";
-import { Provider } from "react-redux";
 import {
   render,
   screen,
   waitForElementToBeRemoved,
   within,
-} from "@testing-library/react";
+} from "__support__/ui";
 import userEvent from "@testing-library/user-event";
 import xhrMock from "xhr-mock";
-import { getStore } from "__support__/entities-store";
 import ItemPicker from "./ItemPicker";
 
 function collection({
@@ -136,15 +134,9 @@ async function setup({
 
   const onChange = jest.fn();
 
-  const store = getStore({
-    currentUser: () => CURRENT_USER,
+  render(<ItemPicker models={models} onChange={onChange} {...props} />, {
+    currentUser: CURRENT_USER,
   });
-
-  render(
-    <Provider store={store}>
-      <ItemPicker models={models} onChange={onChange} {...props} />
-    </Provider>,
-  );
 
   await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
 

--- a/frontend/src/metabase/dashboard/components/DashboardDetailsModal.unit.spec.js
+++ b/frontend/src/metabase/dashboard/components/DashboardDetailsModal.unit.spec.js
@@ -1,11 +1,8 @@
 import React from "react";
 import _ from "underscore";
-import { Provider } from "react-redux";
-import { reducer as form } from "redux-form";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "__support__/ui";
 import userEvent from "@testing-library/user-event";
 import xhrMock from "xhr-mock";
-import { getStore } from "__support__/entities-store";
 import MetabaseSettings from "metabase/lib/settings";
 import { PLUGIN_CACHING, PLUGIN_FORM_WIDGETS } from "metabase/plugins";
 import NumericFormField from "metabase/components/form/widgets/FormNumericInputWidget";
@@ -48,11 +45,11 @@ function setup({ mockDashboardUpdateResponse = true } = {}) {
     },
   });
 
-  render(
-    <Provider store={getStore({ form, dashboard: dashboardReducer })}>
-      <DashboardDetailsModal onClose={onClose} />
-    </Provider>,
-  );
+  render(<DashboardDetailsModal onClose={onClose} />, {
+    reducers: {
+      dashboard: dashboardReducer,
+    },
+  });
 
   return {
     onClose,

--- a/frontend/src/metabase/dashboard/components/DashboardDetailsModal.unit.spec.js
+++ b/frontend/src/metabase/dashboard/components/DashboardDetailsModal.unit.spec.js
@@ -1,6 +1,6 @@
 import React from "react";
 import _ from "underscore";
-import { fireEvent, render, screen } from "__support__/ui";
+import { fireEvent, renderWithProviders, screen } from "__support__/ui";
 import userEvent from "@testing-library/user-event";
 import xhrMock from "xhr-mock";
 import MetabaseSettings from "metabase/lib/settings";
@@ -45,7 +45,7 @@ function setup({ mockDashboardUpdateResponse = true } = {}) {
     },
   });
 
-  render(<DashboardDetailsModal onClose={onClose} />, {
+  renderWithProviders(<DashboardDetailsModal onClose={onClose} />, {
     reducers: {
       dashboard: dashboardReducer,
     },

--- a/frontend/src/metabase/nav/components/RecentsList.unit.spec.js
+++ b/frontend/src/metabase/nav/components/RecentsList.unit.spec.js
@@ -1,8 +1,6 @@
 import React from "react";
-import { Provider } from "react-redux";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "__support__/ui";
 import xhrMock from "xhr-mock";
-import { getStore } from "__support__/entities-store";
 import RecentsList from "./RecentsList";
 
 const recentsData = [
@@ -52,13 +50,7 @@ function mockRecentsEndpoint(recents) {
 async function setup(recents = recentsData) {
   mockRecentsEndpoint(recents);
 
-  const store = getStore();
-
-  render(
-    <Provider store={store}>
-      <RecentsList />
-    </Provider>,
-  );
+  render(<RecentsList />);
 
   await waitFor(() => screen.queryByText("Recently viewed"));
 }

--- a/frontend/src/metabase/nav/components/RecentsList.unit.spec.js
+++ b/frontend/src/metabase/nav/components/RecentsList.unit.spec.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, waitFor } from "__support__/ui";
+import { renderWithProviders, screen, waitFor } from "__support__/ui";
 import xhrMock from "xhr-mock";
 import RecentsList from "./RecentsList";
 
@@ -50,7 +50,7 @@ function mockRecentsEndpoint(recents) {
 async function setup(recents = recentsData) {
   mockRecentsEndpoint(recents);
 
-  render(<RecentsList />);
+  renderWithProviders(<RecentsList />);
 
   await waitFor(() => screen.queryByText("Recently viewed"));
 }

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.unit.spec.js
@@ -1,7 +1,7 @@
 /* eslint-disable react/prop-types */
 import React, { useState } from "react";
 import {
-  render,
+  renderWithProviders,
   screen,
   fireEvent,
   within,
@@ -63,7 +63,7 @@ describe("Notebook Editor > Join Step", () => {
       revert: jest.fn(),
     };
 
-    render(
+    renderWithProviders(
       <JoinStepWrapped
         initialQuery={query}
         step={TEST_STEP}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.unit.spec.js
@@ -1,19 +1,16 @@
 /* eslint-disable react/prop-types */
 import React, { useState } from "react";
-import { Provider } from "react-redux";
 import {
   render,
   screen,
   fireEvent,
   within,
   waitForElementToBeRemoved,
-} from "@testing-library/react";
+} from "__support__/ui";
 import userEvent from "@testing-library/user-event";
 import xhrMock from "xhr-mock";
 import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
-import { getStore } from "__support__/entities-store";
 import {
-  state,
   ORDERS,
   PRODUCTS,
   SAMPLE_DATASET,
@@ -67,13 +64,12 @@ describe("Notebook Editor > Join Step", () => {
     };
 
     render(
-      <Provider store={getStore({}, state)}>
-        <JoinStepWrapped
-          initialQuery={query}
-          step={TEST_STEP}
-          onChange={onQueryChange}
-        />
-      </Provider>,
+      <JoinStepWrapped
+        initialQuery={query}
+        step={TEST_STEP}
+        onChange={onQueryChange}
+      />,
+      { withSampleDataset: true },
     );
 
     if (joinTable) {

--- a/frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.unit.spec.js
@@ -1,10 +1,7 @@
 import React from "react";
-import { Provider } from "react-redux";
-import { reducer as form } from "redux-form";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "__support__/ui";
 import userEvent from "@testing-library/user-event";
 import xhrMock from "xhr-mock";
-import { getStore } from "__support__/entities-store";
 import { PLUGIN_CACHING, PLUGIN_FORM_WIDGETS } from "metabase/plugins";
 import NumericFormField from "metabase/components/form/widgets/FormNumericInputWidget";
 import MetabaseSettings from "metabase/lib/settings";
@@ -41,13 +38,11 @@ function setup({ cachingEnabled = true } = {}) {
   };
 
   render(
-    <Provider store={getStore({ form })}>
-      <EditQuestionInfoModal
-        question={question}
-        onSave={onSave}
-        onClose={onClose}
-      />
-    </Provider>,
+    <EditQuestionInfoModal
+      question={question}
+      onSave={onSave}
+      onClose={onClose}
+    />,
   );
 
   return {

--- a/frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.unit.spec.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { fireEvent, render, screen } from "__support__/ui";
+import { fireEvent, renderWithProviders, screen } from "__support__/ui";
 import userEvent from "@testing-library/user-event";
 import xhrMock from "xhr-mock";
 import { PLUGIN_CACHING, PLUGIN_FORM_WIDGETS } from "metabase/plugins";
@@ -37,7 +37,7 @@ function setup({ cachingEnabled = true } = {}) {
     card: () => QUESTION,
   };
 
-  render(
+  renderWithProviders(
     <EditQuestionInfoModal
       question={question}
       onSave={onSave}

--- a/frontend/src/metabase/search/components/InfoText.unit.spec.js
+++ b/frontend/src/metabase/search/components/InfoText.unit.spec.js
@@ -1,8 +1,6 @@
 import React from "react";
-import { Provider } from "react-redux";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "__support__/ui";
 import xhrMock from "xhr-mock";
-import { getStore } from "__support__/entities-store";
 
 import { InfoText } from "./InfoText";
 
@@ -19,13 +17,7 @@ async function setup(result) {
     body: JSON.stringify(database),
   });
 
-  const store = getStore();
-
-  render(
-    <Provider store={store}>
-      <InfoText result={result} />
-    </Provider>,
-  );
+  render(<InfoText result={result} />);
 }
 
 describe("InfoText", () => {

--- a/frontend/src/metabase/search/components/InfoText.unit.spec.js
+++ b/frontend/src/metabase/search/components/InfoText.unit.spec.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, waitFor } from "__support__/ui";
+import { renderWithProviders, screen, waitFor } from "__support__/ui";
 import xhrMock from "xhr-mock";
 
 import { InfoText } from "./InfoText";
@@ -17,7 +17,7 @@ async function setup(result) {
     body: JSON.stringify(database),
   });
 
-  render(<InfoText result={result} />);
+  renderWithProviders(<InfoText result={result} />);
 }
 
 describe("InfoText", () => {

--- a/frontend/test/__support__/ui.js
+++ b/frontend/test/__support__/ui.js
@@ -1,0 +1,116 @@
+/* eslint-disable react/prop-types, import/export */
+import React from "react";
+import { render } from "@testing-library/react";
+import { createMemoryHistory } from "history";
+import { Router, Route } from "react-router";
+import { Provider } from "react-redux";
+import { reducer as form } from "redux-form";
+import { ThemeProvider } from "styled-components";
+import { DragDropContextProvider } from "react-dnd";
+import HTML5Backend from "react-dnd-html5-backend";
+import { state as sampleDatasetReduxState } from "__support__/sample_dataset_fixture";
+import { getStore } from "./entities-store";
+
+function getUser(user = {}) {
+  return {
+    id: 1,
+    first_name: "Bobby",
+    last_name: "Tables",
+    email: "bobby@metabase.test",
+    is_superuser: true,
+    ...user,
+  };
+}
+
+/**
+ * Custom wrapper of react testing library's render function,
+ * helping to setup common wrappers and provider components
+ * (router, redux, drag-n-drop provider, etc.)
+ *
+ * @param {React.ReactElement} JSX to render
+ * @param {object} various wrapper settings and RTL render options
+ */
+function customRender(
+  ui,
+  {
+    currentUser,
+    reducers,
+    withSampleDataset,
+    withRouter = false,
+    withDND = false,
+    ...options
+  } = {},
+) {
+  const initialReduxState = withSampleDataset ? sampleDatasetReduxState : {};
+
+  const store = getStore(
+    {
+      form,
+      currentUser: () => getUser(currentUser),
+      ...reducers,
+    },
+    initialReduxState,
+  );
+
+  const wrapper = props => (
+    <Wrapper
+      {...props}
+      store={store}
+      withRouter={withRouter}
+      withDND={withDND}
+    />
+  );
+
+  const utils = render(ui, {
+    wrapper,
+    ...options,
+  });
+
+  return {
+    ...utils,
+    store,
+  };
+}
+
+function Wrapper({ children, store, withRouter, withDND }) {
+  return (
+    <Provider store={store}>
+      <MaybeDNDProvider hasDND={withDND}>
+        <ThemeProvider theme={{}}>
+          <MaybeRouter hasRouter={withRouter}>{children}</MaybeRouter>
+        </ThemeProvider>
+      </MaybeDNDProvider>
+    </Provider>
+  );
+}
+
+function MaybeRouter({ children, hasRouter }) {
+  if (!hasRouter) {
+    return children;
+  }
+  const history = createMemoryHistory({ initialEntries: ["/"] });
+
+  function Page(props) {
+    return React.cloneElement(children, props);
+  }
+
+  return (
+    <Router history={history}>
+      <Route path="/" component={Page} />
+    </Router>
+  );
+}
+
+function MaybeDNDProvider({ children, hasDND }) {
+  if (!hasDND) {
+    return children;
+  }
+  return (
+    <DragDropContextProvider backend={HTML5Backend}>
+      {children}
+    </DragDropContextProvider>
+  );
+}
+
+export * from "@testing-library/react";
+export { customRender as render };

--- a/frontend/test/__support__/ui.js
+++ b/frontend/test/__support__/ui.js
@@ -30,7 +30,7 @@ function getUser(user = {}) {
  * @param {React.ReactElement} JSX to render
  * @param {object} various wrapper settings and RTL render options
  */
-function customRender(
+export function renderWithProviders(
   ui,
   {
     currentUser,
@@ -113,4 +113,3 @@ function MaybeDNDProvider({ children, hasDND }) {
 }
 
 export * from "@testing-library/react";
-export { customRender as render };

--- a/frontend/test/__support__/ui.js
+++ b/frontend/test/__support__/ui.js
@@ -1,4 +1,4 @@
-/* eslint-disable react/prop-types, import/export */
+/* eslint-disable react/prop-types */
 import React from "react";
 import { render } from "@testing-library/react";
 import { createMemoryHistory } from "history";

--- a/frontend/test/metabase/collections/BaseItemsTable.unit.spec.js
+++ b/frontend/test/metabase/collections/BaseItemsTable.unit.spec.js
@@ -1,10 +1,7 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { render } from "__support__/ui";
 import userEvent from "@testing-library/user-event";
 import moment from "moment";
-
-import HTML5Backend from "react-dnd-html5-backend";
-import { DragDropContextProvider } from "react-dnd";
 
 import {
   DEFAULT_DATE_STYLE,
@@ -32,14 +29,13 @@ describe("Collections BaseItemsTable", () => {
 
   function setup({ items = [ITEM], ...props } = {}) {
     return render(
-      <DragDropContextProvider backend={HTML5Backend}>
-        <BaseItemsTable
-          items={items}
-          sortingOptions={{ sort_column: "name", sort_direction: "asc" }}
-          onSortingOptionsChange={jest.fn()}
-          {...props}
-        />
-      </DragDropContextProvider>,
+      <BaseItemsTable
+        items={items}
+        sortingOptions={{ sort_column: "name", sort_direction: "asc" }}
+        onSortingOptionsChange={jest.fn()}
+        {...props}
+      />,
+      { withDND: true },
     );
   }
 

--- a/frontend/test/metabase/collections/BaseItemsTable.unit.spec.js
+++ b/frontend/test/metabase/collections/BaseItemsTable.unit.spec.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { render } from "__support__/ui";
+import { renderWithProviders } from "__support__/ui";
 import userEvent from "@testing-library/user-event";
 import moment from "moment";
 
@@ -28,7 +28,7 @@ describe("Collections BaseItemsTable", () => {
   };
 
   function setup({ items = [ITEM], ...props } = {}) {
-    return render(
+    return renderWithProviders(
       <BaseItemsTable
         items={items}
         sortingOptions={{ sort_column: "name", sort_direction: "asc" }}

--- a/frontend/test/metabase/components/LastEditInfoLabel.unit.spec.js
+++ b/frontend/test/metabase/components/LastEditInfoLabel.unit.spec.js
@@ -1,11 +1,7 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { render } from "__support__/ui";
 import mockDate from "mockdate";
-
 import moment from "moment";
-import { Provider } from "react-redux";
-import { getStore } from "metabase/store";
-
 import LastEditInfoLabel from "metabase/components/LastEditInfoLabel";
 
 describe("LastEditInfoLabel", () => {
@@ -34,13 +30,11 @@ describe("LastEditInfoLabel", () => {
       return isLastEditedByCurrentUser ? TEST_USER : { id: TEST_USER.id + 1 };
     }
 
-    const store = getStore({ currentUser: userReducer });
-
-    return render(
-      <Provider store={store}>
-        <LastEditInfoLabel item={testItem} />
-      </Provider>,
-    );
+    return render(<LastEditInfoLabel item={testItem} />, {
+      reducers: {
+        currentUser: userReducer,
+      },
+    });
   }
 
   const A_FEW_SECONDS_AGO = moment().add(5, "seconds");

--- a/frontend/test/metabase/components/LastEditInfoLabel.unit.spec.js
+++ b/frontend/test/metabase/components/LastEditInfoLabel.unit.spec.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { render } from "__support__/ui";
+import { renderWithProviders } from "__support__/ui";
 import mockDate from "mockdate";
 import moment from "moment";
 import LastEditInfoLabel from "metabase/components/LastEditInfoLabel";
@@ -30,7 +30,7 @@ describe("LastEditInfoLabel", () => {
       return isLastEditedByCurrentUser ? TEST_USER : { id: TEST_USER.id + 1 };
     }
 
-    return render(<LastEditInfoLabel item={testItem} />, {
+    return renderWithProviders(<LastEditInfoLabel item={testItem} />, {
       reducers: {
         currentUser: userReducer,
       },

--- a/frontend/test/metabase/containers/SaveQuestionModal.unit.spec.js
+++ b/frontend/test/metabase/containers/SaveQuestionModal.unit.spec.js
@@ -1,7 +1,5 @@
 import React from "react";
-import { Provider } from "react-redux";
-import { reducer as form } from "redux-form";
-import { render, screen } from "@testing-library/react";
+import { render, screen } from "__support__/ui";
 import userEvent from "@testing-library/user-event";
 import mock from "xhr-mock";
 
@@ -15,7 +13,6 @@ import {
   ORDERS,
   metadata,
 } from "__support__/sample_dataset_fixture";
-import { getStore } from "__support__/entities-store";
 
 function mockCachingEnabled(enabled = true) {
   const original = MetabaseSettings.get;
@@ -29,23 +26,20 @@ function mockCachingEnabled(enabled = true) {
 }
 
 const renderSaveQuestionModal = (question, originalQuestion) => {
-  const store = getStore({ form });
   const onCreateMock = jest.fn(() => Promise.resolve());
   const onSaveMock = jest.fn(() => Promise.resolve());
   const onCloseMock = jest.fn();
   render(
-    <Provider store={store}>
-      <SaveQuestionModal
-        card={question.card()}
-        originalCard={originalQuestion && originalQuestion.card()}
-        tableMetadata={question.table()}
-        onCreate={onCreateMock}
-        onSave={onSaveMock}
-        onClose={onCloseMock}
-      />
-    </Provider>,
+    <SaveQuestionModal
+      card={question.card()}
+      originalCard={originalQuestion && originalQuestion.card()}
+      tableMetadata={question.table()}
+      onCreate={onCreateMock}
+      onSave={onSaveMock}
+      onClose={onCloseMock}
+    />,
   );
-  return { store, onSaveMock, onCreateMock, onCloseMock };
+  return { onSaveMock, onCreateMock, onCloseMock };
 };
 
 const EXPECTED_SUGGESTED_NAME = "Orders, Count";

--- a/frontend/test/metabase/containers/SaveQuestionModal.unit.spec.js
+++ b/frontend/test/metabase/containers/SaveQuestionModal.unit.spec.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "__support__/ui";
+import { renderWithProviders, screen } from "__support__/ui";
 import userEvent from "@testing-library/user-event";
 import mock from "xhr-mock";
 
@@ -29,7 +29,7 @@ const renderSaveQuestionModal = (question, originalQuestion) => {
   const onCreateMock = jest.fn(() => Promise.resolve());
   const onSaveMock = jest.fn(() => Promise.resolve());
   const onCloseMock = jest.fn();
-  render(
+  renderWithProviders(
     <SaveQuestionModal
       card={question.card()}
       originalCard={originalQuestion && originalQuestion.card()}

--- a/frontend/test/metabase/entities/containers/EntityListLoader.unit.spec.js
+++ b/frontend/test/metabase/entities/containers/EntityListLoader.unit.spec.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { render } from "__support__/ui";
+import { renderWithProviders } from "__support__/ui";
 import "mutationobserver-shim";
 import EntityListLoader from "metabase/entities/containers/EntityListLoader";
 import { Api } from "metabase/lib/api";
@@ -18,7 +18,7 @@ describe("EntityListLoader", () => {
 
   describe("with entityType of search", () => {
     it("should handle object entityQuery", async () => {
-      render(
+      renderWithProviders(
         <EntityListLoader
           entityType="search"
           entityQuery={{ collection: "foo" }}
@@ -30,7 +30,7 @@ describe("EntityListLoader", () => {
     });
 
     it("should handle function entityQuery", async () => {
-      render(
+      renderWithProviders(
         <EntityListLoader
           entityType="search"
           entityQuery={(state, props) => ({ collection: props.collectionId })}

--- a/frontend/test/metabase/entities/containers/EntityListLoader.unit.spec.js
+++ b/frontend/test/metabase/entities/containers/EntityListLoader.unit.spec.js
@@ -1,27 +1,17 @@
-/* eslint-disable react/prop-types */
 import React from "react";
-
-import { render } from "@testing-library/react";
+import { render } from "__support__/ui";
 import "mutationobserver-shim";
 import EntityListLoader from "metabase/entities/containers/EntityListLoader";
-import { Provider } from "react-redux";
-
-import entitiesReducer from "metabase/redux/entities";
-import { getStore } from "metabase/store";
 import { Api } from "metabase/lib/api";
-
-const MockEntityProvider = ({ children }) => (
-  <Provider store={getStore({ entities: entitiesReducer })}>
-    {children}
-  </Provider>
-);
 
 describe("EntityListLoader", () => {
   let _makeRequest;
+
   beforeEach(() => {
     _makeRequest = Api.prototype._makeRequest;
     Api.prototype._makeRequest = jest.fn().mockReturnValue(Promise.resolve([]));
   });
+
   afterEach(() => {
     Api.prototype._makeRequest = _makeRequest;
   });
@@ -29,12 +19,10 @@ describe("EntityListLoader", () => {
   describe("with entityType of search", () => {
     it("should handle object entityQuery", async () => {
       render(
-        <MockEntityProvider>
-          <EntityListLoader
-            entityType="search"
-            entityQuery={{ collection: "foo" }}
-          />
-        </MockEntityProvider>,
+        <EntityListLoader
+          entityType="search"
+          entityQuery={{ collection: "foo" }}
+        />,
       );
       expect(
         Api.prototype._makeRequest.mock.calls.map(c => c.slice(0, 2)),
@@ -43,13 +31,11 @@ describe("EntityListLoader", () => {
 
     it("should handle function entityQuery", async () => {
       render(
-        <MockEntityProvider>
-          <EntityListLoader
-            entityType="search"
-            entityQuery={(state, props) => ({ collection: props.collectionId })}
-            collectionId="foo"
-          />
-        </MockEntityProvider>,
+        <EntityListLoader
+          entityType="search"
+          entityQuery={(state, props) => ({ collection: props.collectionId })}
+          collectionId="foo"
+        />,
       );
       expect(
         Api.prototype._makeRequest.mock.calls.map(c => c.slice(0, 2)),


### PR DESCRIPTION
When testing components consuming Redux state, dispatching actions, relying on react-router, and so on with [react-testing-library](https://github.com/testing-library/react-testing-library), we often need to repeat a very similar kind of test setup. You need to create a store, mock some reducers and wrap a component with `react-redux` `Provider` and other providers sometimes.

Having that much boilerplate is exhausting and it can take too much time for FE newcomers to just set up a test that won't break for missing-this-missing-that reasons.

One of the @testing-library [common practices](https://testing-library.com/docs/react-testing-library/setup/#custom-render) is to define a custom wrapper for its `render` function, which will wrap everything under the hood.

This PR implements a custom render function for Metabase tests and migrates some of the tests to it. Many tests are left untouched because they don't rely on any global state and providers. Hopefully it can help us write more unit- and integration FE tests.

FYI, it's the first iteration of it, so I'd appreciate your feedback here.

## Details

The [helper](https://github.com/metabase/metabase/blob/3c53f855ed9c5862a79174fd52a9da2b8d03cacc/frontend/test/__support__/ui.js) itself is located under `__support__/ui` (not sure it's the best possible name, so I'd appreciate if you have a better idea). The file exports the whole `@testing-library/react` with a replaced `render` function, so you don't need to import both RTL and the helper in test files.

The features provided by the helper are explained below

### Redux Setup

Any UI rendered using the helper will be wrapped with redux `Provider` with a minimal store configurations:

* the helper uses [`getStore` utility from `__support__/entities-store`](https://github.com/metabase/metabase/blob/master/frontend/test/__support__/entities-store.js) to create a store with basic entities reducers
* the helper adds `redux-form` reducer to the store
* the helper adds a very dumb `currentUser` reducer (just returning a user object). The current user is an admin by default, and can be reconfigured via `render` params

<details>
<summary>👀  Before/After Example</summary>

Let's say we test a form with a few fields and some field should only be visible to admin users. The component retrieves current user's object from Redux and uses `redux-form` to manage the form itself. Without the helper, the code will look something like this:

```jsx
import { render, fireEvent } from "@testing-library/react"
import { Provider } from "react-redux"
import { reducer as form } from "redux-form"
import { getStore } from "__support__/entities-store"
import SomeForm from "./FormToCoverWithTests"

function setup({ isAdmin = false } = {}) {
  const user = isAdmin ? ADMIN_USER : NORMAL_USER

  const store = getStore({
    form,
    currentUser: () => user,
  })
  
  return render(
    <Provider store={store}>
       <SomeForm />
    </Provider store={store}>
  )
}
```

As you see, we need to import 4 files and add some boilerplate before writing a first test. With a custom render, we can achieve the same thing with:

```jsx
import { renderWithProviders, fireEvent } from "__support__/ui"
import "./FormToCoverWithTests"

function setup({ isAdmin = false } = {}) {
  const currentUser = isAdmin ? ADMIN_USER : NORMAL_USER
  return renderWithProviders(<SomeForm />, { currentUser });
}
```
</details>

### Sample Dataset

It was a surprise for me personally that we can use the sample dataset in unit tests 🎉  That's very handy when testing some pieces of query builder UI, like [`JoinStep` from the notebook editor](https://github.com/metabase/metabase/blob/master/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.unit.spec.js).

 [`sample_dataset_fixture.json`](https://github.com/metabase/metabase/blob/master/frontend/test/__support__/sample_dataset_fixture.json) is a Redux state dump, so it can be passed to `getStore` as initial state. The helper has a `withSampleDataset` boolean parameter to control that (disabled by default).

</details>

### Router

Some components like pages use `react-router` API, so it should be either mocked (which is a bit tricky right know I guess) or the component has to be wrapped with router in a test. 

The helpers has a `withRouter` option (disabled by default). When `true`, the UI will be wrapped with `Router` and placed into `react-router's` `<Page />` component.

### Misc

* by default, UI is also wrapped with `ThemeProvider` from `styled-components`.
* there is a `withDND` option to wrap the UI with `DragAndDropProvider` (disabled by default). Is used by collection page components