### PR TITLE
#18352 Repro: Pulse table cards with INT64 values fail to render in 0.41.0

### DIFF
--- a/frontend/test/metabase/scenarios/sharing/reproductions/18352-subscription-int64-value-card.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/reproductions/18352-subscription-int64-value-card.cy.spec.js
@@ -1,0 +1,59 @@
+import { restore, setupSMTP } from "__support__/e2e/cypress";
+import { USERS } from "__support__/e2e/cypress_data";
+
+const {
+  admin: { first_name, last_name },
+} = USERS;
+
+const questionDetails = {
+  name: "18352",
+  native: {
+    query: "SELECT 'foo', 1 UNION ALL SELECT 'bar', 2",
+  },
+};
+
+describe.skip("issue 18352", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    setupSMTP();
+
+    cy.createNativeQuestionAndDashboard({ questionDetails }).then(
+      ({ body: { card_id, dashboard_id } }) => {
+        cy.intercept("POST", `/api/card/${card_id}/query`).as("cardQuery");
+
+        cy.visit(`/question/${card_id}`);
+        cy.wait("@cardQuery");
+
+        cy.visit(`/dashboard/${dashboard_id}`);
+      },
+    );
+  });
+
+  it("should send the card with the INT64 values (metabase#18352)", () => {
+    cy.icon("share").click();
+    cy.findByText("Dashboard subscriptions").click();
+
+    cy.findByText("Email it").click();
+
+    cy.findByPlaceholderText("Enter user names or email addresses").click();
+    cy.findByText(`${first_name} ${last_name}`).click();
+    // Click this just to close the popover that is blocking the "Send email now" button
+    cy.findByText(`To:`).click();
+
+    cy.button("Send email now").click();
+    cy.findByText("Email sent");
+
+    cy.request("GET", "http://localhost:80/email").then(
+      ({ body: [{ html }] }) => {
+        expect(html).not.to.include(
+          "An error occurred while displaying this card.",
+        );
+
+        expect(html).to.include("foo");
+        expect(html).to.include("bar");
+      },
+    );
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #18352

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/sharing/reproductions/18352-subscription-int64-value-card.cy.spec.js`
- Unskip the test
- It should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/136604420-6ecfde54-fe7a-4fba-a7ba-866984f71209.png)

