### PR TITLE
Use dashcard title instead of card name in dashboard subscriptions, if it is set

### DIFF
--- a/frontend/test/metabase/scenarios/sharing/reproductions/18344-subscription-shows-original-question-name.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/reproductions/18344-subscription-shows-original-question-name.cy.spec.js
@@ -11,7 +11,7 @@ const {
   admin: { first_name, last_name },
 } = USERS;
 
-describe.skip("issue 18344", () => {
+describe("issue 18344", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();

--- a/src/metabase/email/messages.clj
+++ b/src/metabase/email/messages.clj
@@ -464,7 +464,7 @@
         icon-attachment (first (map make-message-attachment (icon-bundle icon-name)))
         filters         (when dashboard
                           (render-filters notification dashboard))
-        message-body    (assoc message-context :pulse   (html (vec (cons :div (map :content rendered-cards))))
+        message-body    (assoc message-context :pulse (html (vec (cons :div (map :content rendered-cards))))
                                :filters filters
                                :iconCid (:content-id icon-attachment))
         attachments     (apply merge (map :attachments rendered-cards))]

--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -146,9 +146,10 @@
   [card-results]
   (let [{channel-id :id} (slack/files-channel)]
     (->> (for [card-result card-results]
-           (let [{{card-id :id, card-name :name, :as card} :card, result :result} card-result]
+           (let [{{card-id :id, card-name :name, :as card} :card, dashcard :dashcard, result :result} card-result]
              (if (and card result)
-               {:title           card-name
+               {:title           (or (-> dashcard :visualization_settings :card.title)
+                                     card-name)
                 :rendered-info   (render/render-pulse-card :inline (defaulted-timezone card) card nil result)
                 :title_link      (urls/card-url card-id)
                 :attachment-name "image.png"

--- a/src/metabase/pulse/render.clj
+++ b/src/metabase/pulse/render.clj
@@ -23,9 +23,11 @@
   false)
 
 (s/defn ^:private make-title-if-needed :- (s/maybe common/RenderedPulseCard)
-  [render-type card]
+  [render-type card dashcard]
   (when *include-title*
-    (let [image-bundle (when *include-buttons*
+    (let [card-name    (or (-> dashcard :visualization_settings :card.title)
+                           (-> card :name))
+          image-bundle (when *include-buttons*
                          (image-bundle/external-link-image-bundle render-type))]
       {:attachments (when image-bundle
                       (image-bundle/image-bundle->attachment image-bundle))
@@ -37,7 +39,7 @@
                        [:td {:style (style/style {:padding :0
                                                   :margin  :0})}
                         [:span {:style (style/style (style/header-style))}
-                         (-> card :name h)]]
+                         (h card-name)]]
                        [:td {:style (style/style {:text-align :right})}
                         (when *include-buttons*
                           [:img {:style (style/style {:width :16px})
@@ -139,7 +141,7 @@
 - render/text : raw text suitable for substituting on clients when text is preferable. (Currently slack uses this for
   scalar results where text is preferable to an image of a div of a single result."
   [render-type timezone-id :- (s/maybe s/Str) card dashcard results]
-  (let [{title :content, title-attachments :attachments} (make-title-if-needed render-type card)
+  (let [{title :content, title-attachments :attachments} (make-title-if-needed render-type card dashcard)
         {description :content}                           (make-description-if-needed dashcard)
         {pulse-body       :content
          body-attachments :attachments


### PR DESCRIPTION
Pretty simple fix for #18344. Pulls `:card.title` out of the viz settings for a dashboard card and uses it instead of the card name, if it exists.