### PR TITLE
Don't render sparkline unless first col is temporal or a number

### DIFF
--- a/frontend/test/metabase/scenarios/sharing/reproductions/18352-subscription-int64-value-card.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/reproductions/18352-subscription-int64-value-card.cy.spec.js
@@ -12,7 +12,7 @@ const questionDetails = {
   },
 };
 
-describe.skip("issue 18352", () => {
+describe("issue 18352", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();

--- a/src/metabase/pulse/render.clj
+++ b/src/metabase/pulse/render.clj
@@ -6,6 +6,7 @@
             [metabase.pulse.render.image-bundle :as image-bundle]
             [metabase.pulse.render.png :as png]
             [metabase.pulse.render.style :as style]
+            [metabase.types :as types]
             [metabase.util.i18n :refer [trs tru]]
             [metabase.util.urls :as urls]
             [schema.core :as s]))
@@ -96,6 +97,7 @@
 
         (and (= @col-sample-count 2)
              (> @row-sample-count 1)
+             (or (types/temporal-field? @col-1) (number-field? @col-1))
              (number-field? @col-2)
              (not (#{:waterfall :pie} display-type)))
         (chart-type :sparkline "result has 2 cols (%s and %s (number)) and > 1 row" (col-description @col-1) (col-description @col-2))

--- a/src/metabase/pulse/render/sparkline.clj
+++ b/src/metabase/pulse/render/sparkline.clj
@@ -97,7 +97,6 @@
                            (/ (double (- v ymin)) yrange)))]
     (image-bundle/make-image-bundle render-type (render-sparkline-to-png x-axis-values y-axis-values))))
 
-
 (s/defn cleaned-rows
   "Get sorted rows from query results, with nils removed, appropriate for rendering as a sparkline."
   [timezone-id :- (s/maybe s/Str) card {:keys [rows cols], :as data}]


### PR DESCRIPTION
#18279 removed the check that `col-1` is a temporal field when determining whether to render results as a sparkline. But the sparkline rendering code includes a comparison that will throw an exception if the values are strings: https://github.com/metabase/metabase/blob/9573f6d808d12ab38bf14f586a442a50ac143bb1/src/metabase/pulse/render/sparkline.clj#L108-L109

So I think we actually want to just check if the values are temporal _or_ numerical here.