### PR TITLE
Add Presto database e2e coverage with repro for #18351

### DIFF
--- a/frontend/test/metabase/scenarios/admin/databases/add-presto.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/add-presto.cy.spec.js
@@ -1,0 +1,123 @@
+import { restore, popover } from "__support__/e2e/cypress";
+
+describe.skip("admin > database > add > Presto", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.visit("/admin/databases/create");
+    cy.contains("Database type")
+      .closest(".Form-field")
+      .find("a")
+      .click();
+  });
+
+  it("should render correctly and allow switching between the new and the old drivers (metabase#18351)", () => {
+    // There should be only the new driver listed originally in the popover
+    popover().within(() => {
+      cy.findByText("Presto (Deprecated Driver)").should("not.exist");
+      cy.findByText("Presto").click();
+    });
+
+    cy.findByLabelText("Name").type("Foo");
+
+    /**
+     *  No need to fill out all these fields, because we can't connect to Presto from Cypress.
+     * Just making sure they are all there.
+     */
+    cy.findByLabelText("Host");
+    cy.findByLabelText("Port");
+    cy.findByLabelText("Catalog");
+    cy.findByLabelText("Schema (optional)");
+    cy.findByLabelText("Username");
+    cy.findByLabelText("Password");
+    // Implicit assertion - reproduces metabase#18351
+    cy.findByLabelText("Additional JDBC options");
+
+    cy.findByLabelText("Use a secure connection (SSL)?");
+    cy.findByLabelText("Authenticate with Kerberos?");
+    // Turned on by default
+    cy.findByLabelText(
+      "Automatically run queries when doing simple filtering and summarizing",
+    ).should("have.attr", "aria-checked", "true");
+
+    cy.findByLabelText(
+      "This is a large database, so let me choose when Metabase syncs and scans",
+    ).should("have.attr", "aria-checked", "");
+
+    cy.findByLabelText("Periodically refingerprint tables").should(
+      "have.attr",
+      "aria-checked",
+      "",
+    );
+
+    // This should be disabled but we'll not add that assertion until we mark all the required fields in the form
+    cy.button("Save");
+
+    cy.findByText("Need help setting up your database?");
+    cy.findByRole("link", { name: "Our docs can help." });
+
+    cy.findByText(
+      "This is our new Presto driver, which is faster and more reliable.",
+    );
+
+    // Switch to the deprecated old Presto driver
+    cy.contains(
+      "The old driver has been deprecated and will be removed in a future release. If you really need to use it, you can find it here.",
+    )
+      .find("a")
+      .click();
+
+    cy.get(".AdminSelect").contains("Presto (Deprecated Driver)");
+
+    // It should have persisted the previously set database name
+    cy.findByDisplayValue("Foo");
+
+    cy.findByLabelText("Host");
+    cy.findByLabelText("Port");
+    cy.findByLabelText("Database name");
+    cy.findByLabelText("Catalog").should("not.exist");
+    cy.findByLabelText("Schema (optional)").should("not.exist");
+    cy.findByLabelText("Username");
+    cy.findByLabelText("Password");
+
+    // Reproduces metabase#18351
+    cy.findByLabelText("Additional JDBC options").should("not.exist");
+
+    cy.findByLabelText("Use a secure connection (SSL)?");
+    cy.findByLabelText("Use an SSH-tunnel for database connections");
+
+    cy.findByLabelText(
+      "Automatically run queries when doing simple filtering and summarizing",
+    ).should("have.attr", "aria-checked", "true");
+
+    cy.findByLabelText(
+      "This is a large database, so let me choose when Metabase syncs and scans",
+    ).should("have.attr", "aria-checked", "");
+
+    cy.findByLabelText("Periodically refingerprint tables").should(
+      "have.attr",
+      "aria-checked",
+      "",
+    );
+
+    cy.findByText(
+      "This driver has been deprecated and will be removed in a future release.",
+    );
+
+    // Switch back to the new Presto driver
+    cy.contains(
+      "We recommend that you upgrade to the new Presto driver, which is faster and more reliable.",
+    )
+      .find("a")
+      .click();
+
+    cy.get(".AdminSelect")
+      .contains("Presto")
+      .click();
+
+    popover()
+      .should("contain", "Presto")
+      .and("contain", "Presto (Deprecated Driver)");
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Adds e2e coverage around adding a Presto driver and making sure we can switch between the new and the old (deprecated) drivers
- Reproduces #18351

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/admin/databases/add-presto.cy.spec.js`
- Unskip the test
- It should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/136619009-7ff71c63-7bc4-4895-9240-ebe0ca00d6f0.png)

