### PR TITLE
GitHub CI: Switch to Temurin distribution

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -28,9 +28,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Prepare JDK 11
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
         java-version: 11
+        distribution: 'temurin'
     - name: Install Clojure CLI
       run: |
         curl -O https://download.clojure.org/install/linux-install-1.10.3.933.sh &&
@@ -54,9 +55,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Prepare JDK 11
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
         java-version: 11
+        distribution: 'temurin'
     - name: Install Clojure CLI
       run: |
         curl -O https://download.clojure.org/install/linux-install-1.10.3.933.sh &&

--- a/.github/workflows/percy-issue-comment.yml
+++ b/.github/workflows/percy-issue-comment.yml
@@ -49,9 +49,10 @@ jobs:
         with:
           node-version: 14.x
       - name: Prepare JDK 8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
           java-version: 8
+          distribution: 'temurin'
       - name: Install Clojure CLI
         run: |
           curl -O https://download.clojure.org/install/linux-install-1.10.3.933.sh &&
@@ -107,9 +108,10 @@ jobs:
         with:
           node-version: 14.x
       - name: Prepare JDK 8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
           java-version: 8
+          distribution: 'temurin'
       - name: Install Clojure CLI
         run: |
           curl -O https://download.clojure.org/install/linux-install-1.10.3.933.sh &&

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -30,9 +30,10 @@ jobs:
         with:
           node-version: 14.x
       - name: Prepare JDK 8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
           java-version: 8
+          distribution: 'temurin'
       - name: Install Clojure CLI
         run: |
           curl -O https://download.clojure.org/install/linux-install-1.10.3.933.sh &&
@@ -81,9 +82,10 @@ jobs:
         with:
           node-version: 14.x
       - name: Prepare JDK 8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
           java-version: 8
+          distribution: 'temurin'
       - name: Install Clojure CLI
         run: |
           curl -O https://download.clojure.org/install/linux-install-1.10.3.933.sh &&

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -27,9 +27,10 @@ jobs:
       with:
         node-version: 14.x
     - name: Prepare JDK 8
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
         java-version: 8
+        distribution: 'temurin'
     - name: Install Clojure CLI
       run: |
         curl -O https://download.clojure.org/install/linux-install-1.10.3.933.sh &&

--- a/.github/workflows/whitespace.yml
+++ b/.github/workflows/whitespace.yml
@@ -23,9 +23,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Prepare JDK 11
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
         java-version: 11
+        distribution: 'temurin'
     - name: Install Clojure CLI
       run: |
         curl -O https://download.clojure.org/install/linux-install-1.10.3.933.sh &&


### PR DESCRIPTION
tl;dr AdoptOpenJDK is now Temurin (part of Eclipse Adoptium)

https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/

**After this PR**: the log of the workflow run on GitHub Actions show show something like:

![image](https://user-images.githubusercontent.com/7288/136623847-969469b7-e665-44c2-a0eb-ac41b1559c04.png)
