### PR TITLE
Circle CI: build a complete Uberjar on a release branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -890,7 +890,13 @@ jobs:
                   # INTERACTIVE=false will tell the clojure build scripts not to do interactive retries etc.
                   INTERACTIVE: "false"
                   MB_EDITION: << parameters.edition >>
-                command: ./bin/build version uberjar
+                command: |
+                  if [[ $CIRCLE_BRANCH == release* || $CIRCLE_BRANCH == master  ]]; then
+                    echo 'This is a release or master branch; building a complete Uberjar'
+                    ./bin/build
+                  else
+                    ./bin/build version uberjar
+                  fi
                 no_output_timeout: 15m
             - store_artifacts:
                 path: /home/circleci/metabase/metabase/target/uberjar/metabase.jar


### PR DESCRIPTION
Make sure that the built Uberjar contains translations etc.

This adds a few minutes to the build process, but it should not affect PR workflows (those PRs are not running in a release branch), so that the built Uberjar is complete and releasable.
