### PR TITLE
Fix flaky `rotate-encryption-key!-test`

### DIFF
--- a/src/metabase/util/i18n.clj
+++ b/src/metabase/util/i18n.clj
@@ -24,10 +24,16 @@
   *use*, use the `user-locale` function instead."
   nil)
 
+(def ^:dynamic *site-locale-override*
+  "Bind this to a string, keyword, or `Locale` to override the value returned by `site-locale`. For testing purposes,
+  such as when swapping out an application database temporarily, when the setting table may not even exist."
+  nil)
+
 (defn site-locale
   "The default locale for this Metabase installation. Normally this is the value of the `site-locale` Setting."
   ^Locale []
-  (locale (or (impl/site-locale-from-setting)
+  (locale (or *site-locale-override*
+              (impl/site-locale-from-setting)
               ;; if DB is not initialized yet fall back to English
               "en")))
 

--- a/test/metabase/cmd/rotate_encryption_key_test.clj
+++ b/test/metabase/cmd/rotate_encryption_key_test.clj
@@ -15,9 +15,9 @@
             [metabase.test :as mt]
             [metabase.test.data.interface :as tx]
             [metabase.test.fixtures :as fixtures]
-            [metabase.util.i18n :as i18n]
             [metabase.util.encryption :as encrypt]
             [metabase.util.encryption-test :as eu]
+            [metabase.util.i18n :as i18n]
             [toucan.db :as db]
             [toucan.models :as models]))
 

--- a/test/metabase/cmd/rotate_encryption_key_test.clj
+++ b/test/metabase/cmd/rotate_encryption_key_test.clj
@@ -11,9 +11,11 @@
             [metabase.driver :as driver]
             [metabase.models :refer [Database Setting]]
             [metabase.models.interface :as interface]
+            [metabase.models.setting :as setting]
             [metabase.test :as mt]
             [metabase.test.data.interface :as tx]
             [metabase.test.fixtures :as fixtures]
+            [metabase.util.i18n :as i18n]
             [metabase.util.encryption :as encrypt]
             [metabase.util.encryption-test :as eu]
             [toucan.db :as db]
@@ -67,10 +69,26 @@
                               "BCQbKNVu6N8TQ2BwyTC0U0oCBqsvFVr2uhEM/tRgJUM="]]
       (mt/test-drivers #{:postgres :h2 :mysql}
         (with-model-type :encrypted-json {:out #'interface/encrypted-json-out}
-          (binding [mdb.connection/*db-type*   driver/*driver*
-                    mdb.connection/*jdbc-spec* (persistent-jdbcspec driver/*driver* db-name)
-                    db/*db-connection*         (persistent-jdbcspec driver/*driver* db-name)
-                    db/*quoting-style*         driver/*driver*]
+          (binding [;; EXPLANATION FOR WHY THIS TEST IS FLAKY
+                    ;; at this point, all the state switching craziness that happens for
+                    ;; `metabase.util.i18n.impl/site-locale-from-setting` has already taken place, so this function has
+                    ;; been bootstrapped to now return the site locale from the real, actual setting function
+                    ;; the trouble is, when we are swapping out the app DB, attempting to fetch the setting value WILL
+                    ;; FAIL, since there is no `SETTING `table yet created
+                    ;; the `load-from-h2!`, by way of invoking `copy!`, below, needs the site locale to internationalize
+                    ;; its loading progress messages (ex: "Set up h2 source database and run migrations...")
+                    ;; the reason this test has been flaky is that if we get "lucky" the *cached* value of the site
+                    ;; locale setting is returned, instead of the setting code having to query the app DB for it, and
+                    ;; hence no error occurs, but for a cache miss, then the error happens
+                    ;; this dynamic rebinding will bypass the call to `i18n/site-locale` and hence avoid that whole mess
+                    i18n/*site-locale-override* "en"
+                    ;; while we're at it, disable the setting cache entirely; we are effectively creating a new app DB
+                    ;; so the cache itself is invalid and can only mask the real issues
+                    setting/*disable-cache*     true?
+                    mdb.connection/*db-type*    driver/*driver*
+                    mdb.connection/*jdbc-spec*  (persistent-jdbcspec driver/*driver* db-name)
+                    db/*db-connection*          (persistent-jdbcspec driver/*driver* db-name)
+                    db/*quoting-style*          driver/*driver*]
             (when-not (= driver/*driver* :h2)
               (tx/create-db! driver/*driver* {:database-name db-name}))
             (load-from-h2/load-from-h2! h2-fixture-db-file)

--- a/test/metabase/cmd/rotate_encryption_key_test.clj
+++ b/test/metabase/cmd/rotate_encryption_key_test.clj
@@ -69,7 +69,7 @@
                               "BCQbKNVu6N8TQ2BwyTC0U0oCBqsvFVr2uhEM/tRgJUM="]]
       (mt/test-drivers #{:postgres :h2 :mysql}
         (with-model-type :encrypted-json {:out #'interface/encrypted-json-out}
-          (binding [;; EXPLANATION FOR WHY THIS TEST IS FLAKY
+          (binding [;; EXPLANATION FOR WHY THIS TEST WAS FLAKY
                     ;; at this point, all the state switching craziness that happens for
                     ;; `metabase.util.i18n.impl/site-locale-from-setting` has already taken place, so this function has
                     ;; been bootstrapped to now return the site locale from the real, actual setting function


### PR DESCRIPTION
Bind a temporary site locale when running the test, and disable the settings cache

Now, a full explanation of what was making the test flaky, for posterity:

When this test runs, it first tries to create a blank app DB.  This is either postgres, h2, or mysql, depending on the driver under test, which is slightly confusing, but anyway...

In order to populate all the app DB tables (since the "real" app DB has already been initialized at this point to even run the test), it first rebinds the appropriate dynamic vars for the db type, spec, connection, etc. and then loads a test fixture H2 file into the app DB.  This h2 test fixture file, evidently, contains all the current app DB tables, etc.

When initializing the app DB from H2 (in `metabase.cmd.copy/copy!`), the code needs to internationalize certain loading message strings.  And in order to internationalize messages, it has to look up the current site locale, which is itself an application setting, which of course comes from the setting entity table.

For the "regular" blank app DB scenario (i.e. when Metabase first starts with a blank app DB), there is some code in the `metabase.util.i18n.impl` namespace to handle this chicken and egg problem (basically, defaulting to "en" if it can't be loaded from the app DB because there is no app DB yet).  But after this tricky process finishes, that temporary, hacked lookup is replaced by the real one (since now, the app DB exists and the locale can just be loaded normally).

For the purpose of our test, that is the problem.  That state (which swaps out the `site-locale-from-setting` fn) has already run (remember, we have already initialized the app DB to even run this test in the first place, and now we are swapping in a temporary one).  So the call to load the site locate from the settings table (which is needed to print the loading message to initialize this temp app DB) fails, and hence the test fails.

Now, the reason this test was flaky, instead of just always failing, is because of the settings cache.  If the site locale had been loaded anywhere within some short time frame before this test needs to load it, to print init messages, then it succeeds!  But that doesn't always end up happening, of course, since it's effectively a race condition (setting cache expiration versus test execution timing).
