### PR TITLE
Convert simple filter with case-insensitive string function

### DIFF
--- a/frontend/src/metabase/lib/expressions/config.js
+++ b/frontend/src/metabase/lib/expressions/config.js
@@ -203,21 +203,18 @@ export const MBQL_CLAUSES = {
     displayName: `contains`,
     type: "boolean",
     args: ["string", "string"],
-    multiple: true,
     hasOptions: true,
   },
   "starts-with": {
     displayName: `startsWith`,
     type: "boolean",
     args: ["string", "string"],
-    multiple: true,
     hasOptions: true,
   },
   "ends-with": {
     displayName: `endsWith`,
     type: "boolean",
     args: ["string", "string"],
-    multiple: true,
     hasOptions: true,
   },
   between: {

--- a/frontend/src/metabase/lib/expressions/config.js
+++ b/frontend/src/metabase/lib/expressions/config.js
@@ -203,16 +203,22 @@ export const MBQL_CLAUSES = {
     displayName: `contains`,
     type: "boolean",
     args: ["string", "string"],
+    multiple: true,
+    hasOptions: true,
   },
   "starts-with": {
     displayName: `startsWith`,
     type: "boolean",
     args: ["string", "string"],
+    multiple: true,
+    hasOptions: true,
   },
   "ends-with": {
     displayName: `endsWith`,
     type: "boolean",
     args: ["string", "string"],
+    multiple: true,
+    hasOptions: true,
   },
   between: {
     displayName: `between`,

--- a/frontend/src/metabase/lib/expressions/format.js
+++ b/frontend/src/metabase/lib/expressions/format.js
@@ -88,10 +88,22 @@ function formatSegment([, segmentId], options) {
   return formatSegmentName(segment, options);
 }
 
+// HACK: very specific to some string functions for now
+function formatFunctionOptions(fnOptions) {
+  if (Object.prototype.hasOwnProperty.call(fnOptions, "case-sensitive")) {
+    const caseSensitive = fnOptions["case-sensitive"];
+    if (!caseSensitive) {
+      return "case-insensitive";
+    }
+  }
+}
+
 function formatFunction([fn, ...args], options) {
   if (hasOptions(args)) {
-    // FIXME: how should we format args?
-    args = args.slice(0, -1);
+    const fnOptions = formatFunctionOptions(args.pop());
+    if (fnOptions) {
+      args = [...args, fnOptions];
+    }
   }
   const formattedName = getExpressionName(fn);
   const formattedArgs = args.map(arg => format(arg, options));

--- a/frontend/src/metabase/lib/expressions/typechecker.js
+++ b/frontend/src/metabase/lib/expressions/typechecker.js
@@ -72,24 +72,30 @@ export function typeCheck(cst, rootType) {
       const functionToken = ctx.functionName[0].tokenType;
       const clause = CLAUSE_TOKENS.get(functionToken);
       const name = functionToken.name;
-      const expectedArgsLength = clause.args.length;
-      if (!clause.multiple && clause.args.length !== args.length) {
-        const message = ngettext(
-          msgid`Function ${name} expects ${expectedArgsLength} argument`,
-          `Function ${name} expects ${expectedArgsLength} arguments`,
-          expectedArgsLength,
-        );
-        this.errors.push({ message });
-      } else {
-        // check for return value sub-type mismatch
-        const type = this.typeStack[0];
-        if (type === "number") {
-          const op = getMBQLName(name);
-          const returnType = MBQL_CLAUSES[op].type;
-          if (returnType !== "number" && returnType !== "string") {
-            const message = t`Expecting ${type} but found function ${name} returning ${returnType}`;
-            this.errors.push({ message });
-          }
+
+      // check for return value sub-type mismatch
+      const type = this.typeStack[0];
+      if (type === "number") {
+        const op = getMBQLName(name);
+        const returnType = MBQL_CLAUSES[op].type;
+        if (returnType !== "number" && returnType !== "string") {
+          const message = t`Expecting ${type} but found function ${name} returning ${returnType}`;
+          this.errors.push({ message });
+        }
+      }
+
+      if (!clause.multiple) {
+        const expectedArgsLength = clause.args.length;
+        const maxArgCount = clause.hasOptions
+          ? expectedArgsLength + 1
+          : expectedArgsLength;
+        if (args.length < expectedArgsLength || args.length > maxArgCount) {
+          const message = ngettext(
+            msgid`Function ${name} expects ${expectedArgsLength} argument`,
+            `Function ${name} expects ${expectedArgsLength} arguments`,
+            expectedArgsLength,
+          );
+          this.errors.push({ message });
         }
 
         // check for argument type matching

--- a/frontend/test/metabase/lib/expressions/typechecker.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/typechecker.unit.spec.js
@@ -173,8 +173,13 @@ describe("type-checker", () => {
     it("should catch mismatched number of function parameters", () => {
       expect(() => validate("CONTAINS()")).toThrow();
       expect(() => validate("CONTAINS([Name])")).toThrow();
-      expect(() => validate("CONTAINS([Type],'X','Y')")).toThrow();
-      expect(() => validate("CONTAINS([Type],'P','Q','R')")).toThrow();
+      expect(() => validate("CONTAINS([Type],'A','B','C')")).toThrow();
+      expect(() => validate("StartsWith()")).toThrow();
+      expect(() => validate("StartsWith([Name])")).toThrow();
+      expect(() => validate("StartsWith([Type],'P','Q','R')")).toThrow();
+      expect(() => validate("EndsWith()")).toThrow();
+      expect(() => validate("EndsWith([Name])")).toThrow();
+      expect(() => validate("EndsWith([Type],'X','Y','Z')")).toThrow();
     });
 
     it("should allow a comparison (lexicographically) on strings", () => {

--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -629,7 +629,7 @@ describe("scenarios > question > filter", () => {
     cy.get(".Icon-chevronleft").click();
     cy.findByText("Custom Expression").click();
     cy.get("[contenteditable='true']").contains(
-      'NOT contains([Title], "Wallet")',
+      'NOT contains([Title], "Wallet", "case-insensitive")',
     );
   });
 

--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -657,7 +657,7 @@ describe("scenarios > question > filter", () => {
     cy.get("[contenteditable='true']");
   });
 
-  it.skip("should be able to convert case-insensitive filter to custom expression (metabase#14959)", () => {
+  it("should be able to convert case-insensitive filter to custom expression (metabase#14959)", () => {
     cy.server();
     cy.route("POST", "/api/dataset").as("dataset");
 
@@ -683,10 +683,10 @@ describe("scenarios > question > filter", () => {
     cy.get(".Icon-chevronleft").click();
     cy.findByText("Custom Expression").click();
     cy.get("[contenteditable='true']").contains(
-      'contains([Reviewer], "MULLER")',
+      'contains([Reviewer], "MULLER", "case-insensitive")',
     );
     cy.button("Done").click();
-    cy.wait("@dataset.2").then(xhr => {
+    cy.wait("@dataset").then(xhr => {
       expect(xhr.response.body.data.rows).to.have.lengthOf(1);
     });
     cy.findByText("wilma-muller");


### PR DESCRIPTION
This is more of a quick workaround (read: hack) until we have a better parsing infrastructure.

The idea is to have an extra argument to contains/startsWith/endsWith, which will be "case-insensitive" if the comparison is to be carred out by ignoring the case. If this extra argument wasn't specified, then it'll be assumed that the case-sensitive comparison is intended.

IOW, this MBQL `["contains", X, Y`] or `["contains", X, Y, {case-sensitive: true}]` will be equivalent to the user-visible custom expression `CONTAINS(X)`.

Meanwhile, MBQL `["contains", X, Y, {case-sensitive: false}]` will be mapped to the user-visible custom expression `CONTAINS(X, Y, "case-insensitive")`.

With this, we achieve a lossless conversion for 3 string functions (contains, startsWith, endsWith) when involving case-sensitivity.

### How to verify manually

1. Ask a question, simple question
2. Sample Dataset, Reviews
3. Filter by Review, Contains
4. Type `MULLER` in the text input
5. Make sure "Case sensitive" is **not** checked
6. Click _Add Filter_
7. There should only one row in the table. Click on the "Reviewer contains MULLER" filter
8. Click on the left-chevron, scroll down, Custom Expression

### Before this PR

The filter is converted into the custom expression `contains([Reviewer], "MULLER")`. However, proceeding with that, the query gives an empty table (i.e. there's no match), which is clearly wrong.

![image](https://user-images.githubusercontent.com/7288/136644906-54e57b6d-4ddc-4335-af8f-671f2ea28ca5.png)

### After  this PR

The filter is converted into the custom expression `contains([Reviewer], "MULLER", "case-insensitive")`. Proceeding with that, the query result is still exactly the same (one row only in the table).

![image](https://user-images.githubusercontent.com/7288/136644886-ca1e135c-2fe7-43d4-bec2-d88f671770a0.png)
