### PR TITLE
#18364 Repro: Unable to save a nested question in the "Our analytics" collection

### DIFF
--- a/frontend/test/metabase/scenarios/native/reproductions/18364-cannot-save-nested.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/reproductions/18364-cannot-save-nested.cy.spec.js
@@ -1,0 +1,33 @@
+import { restore } from "__support__/e2e/cypress";
+
+const questionDetails = {
+  name: "REVIEWS SQL",
+  native: { query: "select REVIEWER from REVIEWS LIMIT 1" },
+};
+
+describe.skip("issue 18364", () => {
+  beforeEach(() => {
+    cy.intercept("POST", "/api/card").as("cardCreated");
+
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should be able to save a nested question (metabase#18364)", () => {
+    cy.createNativeQuestion(questionDetails, { visitQuestion: true });
+
+    cy.findByText("Explore results").click();
+
+    cy.findByText("Save").click();
+
+    cy.get(".Modal")
+      .button("Save")
+      .click();
+
+    cy.wait("@cardCreated").then(({ response: { body } }) => {
+      expect(body.error).not.to.exist;
+    });
+
+    cy.button("Failed").should("not.exist");
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #18364

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/native/reproductions/18364-cannot-save-nested.cy.spec.js`
- Unskip the test
- It should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/136781283-8599639b-4c5a-4477-8f07-454944b35aff.png)

