### PR TITLE
Fix saving nested questions to Our Analytics

### DIFF
--- a/frontend/src/metabase/entities/schemas.js
+++ b/frontend/src/metabase/entities/schemas.js
@@ -79,5 +79,8 @@ export default createEntity({
 });
 
 function addTableAvoidingDuplicates(tables, tableId) {
+  if (!Array.isArray(tables)) {
+    return [tableId];
+  }
   return tables.includes(tableId) ? tables : [...tables, tableId];
 }

--- a/frontend/src/metabase/entities/schemas.js
+++ b/frontend/src/metabase/entities/schemas.js
@@ -54,10 +54,8 @@ export default createEntity({
         return state;
       }
       const virtualQuestionId = getQuestionVirtualTableId(question);
-      return updateIn(
-        state,
-        [getCollectionVirtualSchemaId(question.collection), "tables"],
-        tables => addTableAvoidingDuplicates(tables, virtualQuestionId),
+      return updateIn(state, [schema, "tables"], tables =>
+        addTableAvoidingDuplicates(tables, virtualQuestionId),
       );
     }
 
@@ -68,16 +66,12 @@ export default createEntity({
         return state;
       }
       const virtualQuestionId = getQuestionVirtualTableId(question);
-      return updateIn(
-        state,
-        [getCollectionVirtualSchemaId(question.collection), "tables"],
-        tables => {
-          if (question.archived) {
-            return tables.filter(id => id !== virtualQuestionId);
-          }
-          return addTableAvoidingDuplicates(tables, virtualQuestionId);
-        },
-      );
+      return updateIn(state, [schema, "tables"], tables => {
+        if (question.archived) {
+          return tables.filter(id => id !== virtualQuestionId);
+        }
+        return addTableAvoidingDuplicates(tables, virtualQuestionId);
+      });
     }
 
     return state;

--- a/frontend/test/metabase/entities/schemas.unit.spec.js
+++ b/frontend/test/metabase/entities/schemas.unit.spec.js
@@ -167,6 +167,23 @@ describe("schema entity", () => {
       });
     });
 
+    it("should create collection schema's tables when adding a saved question", () => {
+      const question = getQuestion();
+
+      const nextState = Schemas.reducer(
+        {
+          [ROOT_COLLECTION_VIRTUAL_SCHEMA]: {},
+        },
+        getCreateAction(question),
+      );
+
+      expect(nextState).toEqual({
+        [ROOT_COLLECTION_VIRTUAL_SCHEMA]: {
+          tables: [`card__${question.id}`],
+        },
+      });
+    });
+
     it("should not add new question ID if it's already present", () => {
       const question = getQuestion();
       const id = `card__${question.id}`;

--- a/frontend/test/metabase/scenarios/native/reproductions/18364-cannot-save-nested.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/reproductions/18364-cannot-save-nested.cy.spec.js
@@ -5,7 +5,7 @@ const questionDetails = {
   native: { query: "select REVIEWER from REVIEWS LIMIT 1" },
 };
 
-describe.skip("issue 18364", () => {
+describe("issue 18364", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/card").as("cardCreated");
 


### PR DESCRIPTION
Fixes #18364 — a regression since #18095. #18095 added a schemas reducer updating collection schemas (used for "Saved Questions" database). It wasn't handling a case when a collection schema hadn't loaded tables and `tables` value was undefined. Fixed by adding an `isArray` check

### To Verify

1. New Question > Native Question > Sample Dataset
2. Create a native question using the query `select * from PEOPLE` and save
3. Click "Explore Results"
4. Click the Save button and then click the Save button again in the modal that appears
5. Ensure the question is saved correctly

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/136794856-d6cf1e40-870d-4fb3-a9e6-3da3d6cb8b56.mov

**After**

https://user-images.githubusercontent.com/17258145/136794874-34bfe0f4-dac3-410f-8fce-9163bcb40c19.mov
