### PR TITLE
#18386 Repro: Cannot filter on the null values using the inline context menu

### DIFF
--- a/frontend/test/metabase/scenarios/question/nulls.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nulls.cy.spec.js
@@ -159,6 +159,27 @@ describe("scenarios > question > null", () => {
     });
   });
 
+  it.skip("should filter by clicking on the row with `null` value (metabase#18386)", () => {
+    openOrdersTable();
+
+    // Total of "39.72", and the next cell is the `discount` (which is empty)
+    cy.findByText("39.72")
+      .closest(".TableInteractive-cellWrapper")
+      .next()
+      .find("div")
+      .should("be.empty")
+      // Open the context menu that lets us apply filter using this column directly
+      .click({ force: true });
+
+    popover()
+      .contains("=")
+      .click();
+
+    cy.findByText("39.72");
+    // This row ([id] 3) had the `discount` column value and should be filtered out now
+    cy.findByText("49.21").should("not.exist");
+  });
+
   describe("aggregations with null values", () => {
     beforeEach(() => {
       cy.server();


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #18386

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/question/nulls.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/136816210-873a6432-27bf-4c67-bba1-eb0e7e504011.png)

