### PR TITLE
#18384 Repro: Data Model shows blank page if there are any hidden tables in the database

### DIFF
--- a/frontend/test/metabase/scenarios/admin/datamodel/reproductions/18384-field-settings-breaks-ui.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/reproductions/18384-field-settings-breaks-ui.cy.spec.js
@@ -1,0 +1,33 @@
+import { restore } from "__support__/e2e/cypress";
+import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
+
+const { PEOPLE_ID, PEOPLE, REVIEWS_ID } = SAMPLE_DATASET;
+
+describe.skip("issue 18384", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    // Hide Reviews table
+    cy.request("PUT", "/api/table", {
+      ids: [REVIEWS_ID],
+      visibility_type: "hidden",
+    });
+  });
+
+  it("should be able to open field properties even when one of the tables is hidden (metabase#18384)", () => {
+    cy.visit(`/admin/datamodel/database/1/table/${PEOPLE_ID}`);
+
+    cy.findByDisplayValue("Address")
+      .parent()
+      .find(".Icon-gear")
+      .click();
+
+    cy.location("pathname").should(
+      "eq",
+      `/admin/datamodel/database/1/table/${PEOPLE_ID}/${PEOPLE.ADDRESS}/general`,
+    );
+
+    cy.findByText(/Address – Field Settings/i);
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #18384

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/admin/datamodel/reproductions/18384-field-settings-breaks-ui.cy.spec.js`
- Unskip the test
- It should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/136820717-f187ebe8-67e5-4727-bbd8-d8e39644c9c0.png)

