### PR TITLE
Two column table

### DIFF
--- a/frontend/test/metabase/scenarios/sharing/reproductions/18352-subscription-int64-value-card.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/reproductions/18352-subscription-int64-value-card.cy.spec.js
@@ -12,7 +12,7 @@ const questionDetails = {
   },
 };
 
-describe.skip("issue 18352", () => {
+describe("issue 18352", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();

--- a/shared/src/metabase/types.cljc
+++ b/shared/src/metabase/types.cljc
@@ -332,12 +332,17 @@
    (into {} (for [t (descendants root)]
               {t (parents t)}))))
 
+(defn field-is-type?
+  "True if a Metabase `Field` instance has a temporal base or semantic type, i.e. if this Field represents a value
+  relating to a moment in time."
+  [tyype {base-type :base_type, effective-type :effective_type}]
+  (some #(isa? % tyype) [base-type effective-type]))
+
 (defn temporal-field?
   "True if a Metabase `Field` instance has a temporal base or semantic type, i.e. if this Field represents a value
   relating to a moment in time."
-  {:arglists '([field])}
-  [{base-type :base_type, effective-type :effective_type}]
-  (some #(isa? % :type/Temporal) [base-type effective-type]))
+  [field]
+  (field-is-type? :type/Temporal field))
 
 #?(:cljs
    (defn ^:export isa

--- a/src/metabase/pulse/render.clj
+++ b/src/metabase/pulse/render.clj
@@ -97,7 +97,7 @@
         (and (= @col-sample-count 2)
              (> @row-sample-count 1)
              (number-field? @col-2)
-             (not (#{:waterfall :pie} display-type)))
+             (not (#{:waterfall :pie :table} display-type)))
         (chart-type :sparkline "result has 2 cols (%s and %s (number)) and > 1 row" (col-description @col-1) (col-description @col-2))
 
         (and (= @col-sample-count 2)

--- a/src/metabase/pulse/render/sparkline.clj
+++ b/src/metabase/pulse/render/sparkline.clj
@@ -97,6 +97,11 @@
                            (/ (double (- v ymin)) yrange)))]
     (image-bundle/make-image-bundle render-type (render-sparkline-to-png x-axis-values y-axis-values))))
 
+(defn- comparable?
+  [column]
+  (or (types/temporal-field? column)
+      (types/field-is-type? :type/Number column)))
+
 
 (s/defn cleaned-rows
   "Get sorted rows from query results, with nils removed, appropriate for rendering as a sparkline."
@@ -104,8 +109,10 @@
   (let [[x-axis-rowfn y-axis-rowfn] (common/graphing-column-row-fns card data)
         format-val                  (format-val-fn timezone-id cols x-axis-rowfn)
         present-rows                (common/non-nil-rows x-axis-rowfn y-axis-rowfn rows)
-        formatted-value             (comp format-val x-axis-rowfn)]
-    (if (> (formatted-value (first present-rows))
-           (formatted-value (last present-rows)))
+        formatted-value             (comp format-val x-axis-rowfn)
+        x-col                       (x-axis-rowfn cols)]
+    (if (and (comparable? x-col)
+             (> (formatted-value (first present-rows))
+                (formatted-value (last present-rows))))
       (reverse present-rows)
       present-rows)))

--- a/src/metabase/pulse/render/sparkline.clj
+++ b/src/metabase/pulse/render/sparkline.clj
@@ -102,7 +102,6 @@
   (or (types/temporal-field? column)
       (types/field-is-type? :type/Number column)))
 
-
 (s/defn cleaned-rows
   "Get sorted rows from query results, with nils removed, appropriate for rendering as a sparkline."
   [timezone-id :- (s/maybe s/Str) card {:keys [rows cols], :as data}]

--- a/test/metabase/pulse/render_test.clj
+++ b/test/metabase/pulse/render_test.clj
@@ -17,7 +17,8 @@
    (render/render-pulse-card-for-display (pulse/defaulted-timezone card) card results)))
 
 (defn- render-results [query]
-  (mt/with-temp Card [card {:dataset_query query}]
+  (mt/with-temp Card [card {:dataset_query query
+                            :display       :line}]
     (render-pulse-card card)))
 
 (deftest render-test

--- a/test/metabase/pulse_test.clj
+++ b/test/metabase/pulse_test.clj
@@ -92,7 +92,9 @@
           :when        f]
     (assert (fn? f))
     (testing (format "sent to %s channel" channel-type)
-      (mt/with-temp* [Card          [{card-id :id} (merge {:name card-name} card)]]
+      (mt/with-temp* [Card          [{card-id :id} (merge {:name    card-name
+                                                           :display :line}
+                                                          card)]]
         (with-pulse-for-card [{pulse-id :id}
                               {:card       card-id
                                :pulse      pulse
@@ -380,7 +382,8 @@
       :fixture
       (fn [{:keys [pulse-id]} thunk]
         (mt/with-temp* [Card [{card-id-2 :id} (assoc (checkins-query-card {:breakout [!month.date]})
-                                                     :name "card 2")]
+                                                     :name "card 2"
+                                                     :display :line)]
                         PulseCard [_ {:pulse_id pulse-id
                                       :card_id  card-id-2
                                       :position 1}]]


### PR DESCRIPTION
Fixes #18352 

Addressing two sub issues in two commits:

- we should not render table charts are sparklines. We have been using a heuristic for when to use sparklines rather than just directly using the display. Felt a bit too fragile to swap it totally around, but seems reasonable to ensure that tables are not rendered as sparklines. In the future the negative check `(not (#{:waterfall :pie :table} display-type))` can be inverted to `(#{:line} display-type)` but we aren't there yet
- don't compare incomparable types anyways