### PR TITLE
Treat base64 form inputs

### DIFF
--- a/frontend/src/metabase/components/form/widgets/FormInputWidget.jsx
+++ b/frontend/src/metabase/components/form/widgets/FormInputWidget.jsx
@@ -3,6 +3,9 @@ import React from "react";
 
 import { formDomOnlyProps } from "metabase/lib/redux";
 
+// Important: do NOT use this as an input of type="file"
+// For file inputs, See component FormTextFileWidget.jsx
+
 const FormInputWidget = ({
   type = "text",
   placeholder,

--- a/frontend/src/metabase/components/form/widgets/FormTextFileWidget.jsx
+++ b/frontend/src/metabase/components/form/widgets/FormTextFileWidget.jsx
@@ -3,29 +3,41 @@ import React from "react";
 import cx from "classnames";
 import { formDomOnlyProps } from "metabase/lib/redux";
 
-const FormTextFileWidget = ({ field }) => {
-  // setting value on a file input throws an error
-  const { value, ...otherProps } = formDomOnlyProps(field); // eslint-disable-line no-unused-vars
+// This is a special-case widget
+// setting value on a file input widget throws an error
+
+const FormTextFileWidget = ({ field, treatBeforePosting }) => {
+  const { value, ...otherProps } = formDomOnlyProps(field);
+
   return (
     <input
       type="file"
       className={cx({ "Form-file-input--has-value": value }, "Form-file-input")}
       aria-labelledby={`${field.name}-label`}
       {...otherProps}
-      onChange={wrapHandler(field.onChange)}
-      onBlur={wrapHandler(field.onBlur)}
+      onChange={wrapHandler(field.onChange, treatBeforePosting)}
+      onBlur={wrapHandler(field.onBlur, treatBeforePosting)}
     />
   );
 };
 
-function wrapHandler(h) {
+function wrapHandler(h, treatBeforePosting) {
   return ({ target: { files } }) => {
     if (files.length === 0) {
       h("");
     }
+
     const fr = new FileReader();
+
     fr.onload = () => h(fr.result);
-    fr.readAsText(files[0]);
+
+    const [file] = files;
+
+    if (treatBeforePosting === "base64") {
+      fr.readAsDataURL(file);
+    } else {
+      fr.readAsText(file);
+    }
   };
 }
 


### PR DESCRIPTION
This PR tackles one of the "form widgets" - the one called "FormTextFileWidget".

It adds one form of treatment for its data, converting it to base64.