### PR TITLE
Correctly format 0 decimal places

### DIFF
--- a/src/metabase/pulse/render/common.clj
+++ b/src/metabase/pulse/render/common.clj
@@ -53,7 +53,9 @@
         base               (if (= number-style "scientific") "0" "#,###")
         integral?          (isa? (or effective_type base_type) :type/Integer)
         fmt-str            (cond-> (cond
-                                     decimals  (apply str base "." (repeat decimals "0"))
+                                     decimals  (if (zero? decimals)
+                                                 base
+                                                 (apply str base "." (repeat decimals "0")))
                                      integral? base
                                      :else     (str base ".00"))
                              (= number-style "scientific") (str "E0")

--- a/test/metabase/pulse/render/common_test.clj
+++ b/test/metabase/pulse/render/common_test.clj
@@ -18,7 +18,8 @@
       (is (= "12*345^54" (fmt {::mb.viz/number-separators "^*"})))
       (is (= "prefix12,345.54suffix" (fmt {::mb.viz/prefix "prefix"
                                            ::mb.viz/suffix "suffix"})))
-      (is (= "12,345.5432000" (fmt {::mb.viz/decimals 7}))))
+      (is (= "12,345.5432000" (fmt {::mb.viz/decimals 7})))
+      (is (= "12,346" (fmt {::mb.viz/decimals 0}))))
     (testing "Currency"
       (testing "defaults to USD and two decimal places and symbol"
         (is (= "$12,345.54" (fmt {::mb.viz/number-style "currency"}))))
@@ -43,8 +44,8 @@
       (is (= "1.23E4" (fmt {::mb.viz/number-style "scientific"})))
       (is (= "1.2346E4" (fmt {::mb.viz/number-style "scientific"
                               ::mb.viz/decimals 4})))
-      (is (= "1.E4" (fmt {::mb.viz/number-style "scientific"
-                          ::mb.viz/decimals 0}))))
+      (is (= "1E4" (fmt {::mb.viz/number-style "scientific"
+                         ::mb.viz/decimals 0}))))
     (testing "Percentage"
       (is (= "1,234,554.32%" (fmt {::mb.viz/number-style "percent"})))
       (is (= "1.234.554,3200%"


### PR DESCRIPTION
Fixes #18363 

Input:    12345.65432
Expected: 12346
Actual:   12346.

We were unconditionally adding "." (repeat decimals "0") to the base
formatting string. Obviously when the decimals are 0, we are appending
"." to the base format string
