### PR TITLE
Binning time-series: wait for @dataset to reduce potential flakiness

### DIFF
--- a/frontend/test/metabase/scenarios/binning/correctness/time-series.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/correctness/time-series.cy.spec.js
@@ -105,6 +105,8 @@ describe("scenarios > binning > correctness > time series", () => {
     restore();
     cy.signInAsAdmin();
 
+    cy.intercept("POST", "/api/dataset").as("dataset");
+
     openOrdersTable();
     cy.findByText("Summarize").click();
     openPopoverFromDefaultBucketSize("Created At", "by month");
@@ -121,6 +123,7 @@ describe("scenarios > binning > correctness > time series", () => {
       it(`should return correct values for ${bucketSize}`, () => {
         popover().within(() => {
           cy.findByText(bucketSize).click();
+          cy.wait("@dataset");
         });
 
         cy.get(".List-item--selected")


### PR DESCRIPTION
The issue was discovered when trying to run the tests extensively via GitHub Actions.