### PR TITLE
Fix filtering by null

### DIFF
--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -163,7 +163,7 @@ const getNextRunParameterValues = createSelector(
 );
 
 function normalizeClause(clause) {
-  return typeof clause.raw === "function" ? clause.raw() : clause;
+  return typeof clause?.raw === "function" ? clause.raw() : clause;
 }
 
 // Certain differences in a query should be ignored. `normalizeQuery`

--- a/frontend/src/metabase/query_builder/utils.unit.spec.js
+++ b/frontend/src/metabase/query_builder/utils.unit.spec.js
@@ -82,6 +82,23 @@ describe("normalizeQuery", () => {
   });
 
   describe("structured query", () => {
+    it("handles null in filter clauses", () => {
+      const FILTER_WITH_NULL = ["=", ["field", ORDERS.TOTAL, null], null];
+
+      const { datasetQuery } = setup({
+        query: {
+          filter: FILTER_WITH_NULL,
+        },
+      });
+
+      const { query: normalizedQuery } = normalizeQuery(datasetQuery);
+
+      expect(normalizedQuery).toEqual({
+        ...datasetQuery.query,
+        filter: FILTER_WITH_NULL,
+      });
+    });
+
     it("adds explicit list of fields if missing", () => {
       const { datasetQuery, query, tableMetadata } = setup();
       const expectedFields = getTableFields(query.sourceTableId());

--- a/frontend/test/metabase/scenarios/question/nulls.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nulls.cy.spec.js
@@ -159,7 +159,7 @@ describe("scenarios > question > null", () => {
     });
   });
 
-  it.skip("should filter by clicking on the row with `null` value (metabase#18386)", () => {
+  it("should filter by clicking on the row with `null` value (metabase#18386)", () => {
     openOrdersTable();
 
     // Total of "39.72", and the next cell is the `discount` (which is empty)


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/18386
Introduced in https://github.com/metabase/metabase/pull/17971

### How to verify

1. Simple question > Sample Data > Orders
2. Click any of the empty Discount column values
![image](https://user-images.githubusercontent.com/1447303/136813697-3921d1c3-9767-4dcf-998e-196fa8c85971.png)
3. Select any of the action menu options `<` `>` `=` `!=`
4. Ensure table is filtered by empty discount value
