### PR TITLE
Add MB_SEND_EMAIL_ON_FIRST_LOGIN_FROM_NEW_DEVICE

### DIFF
--- a/docs/operations-guide/environment-variables.md
+++ b/docs/operations-guide/environment-variables.md
@@ -946,7 +946,7 @@ Send email notifications to users in Admin group, when a new SSO users is create
 Type: boolean<br>
 Default: `true`
 
-Send email notifications to users in about login activity, every time they log in from a new IP or Device.
+Send email notification to user, when they login from a new device. Set to `false` to stop sending "We've noticed a new login on your Metabase account" emails for all users.
 
 #### `MB_SESSION_COOKIES`
 

--- a/docs/operations-guide/environment-variables.md
+++ b/docs/operations-guide/environment-variables.md
@@ -941,6 +941,13 @@ Default: `true`
 
 Send email notifications to users in Admin group, when a new SSO users is created on Metabase.
 
+#### `MB_SEND_EMAIL_ON_FIRST_LOGIN_FROM_NEW_DEVICE`
+
+Type: boolean<br>
+Default: `true`
+
+Send email notifications to users in about login activity, every time they log in from a new IP or Device.
+
 #### `MB_SESSION_COOKIES`
 
 Type: boolean<br>


### PR DESCRIPTION
Adding an the env var to prevent the emails from being fired when logging in from a new device or IP