### PR TITLE
Fix line charts with missing values and duplicate X

### DIFF
--- a/frontend/src/metabase/visualizations/lib/fill_data.js
+++ b/frontend/src/metabase/visualizations/lib/fill_data.js
@@ -22,9 +22,20 @@ function fillMissingValues(rows, xValues, fillValue, getKey = v => v) {
     const fillValues = rows[0].slice(1).map(d => fillValue);
 
     const map = new Map();
+
     for (const row of rows) {
-      map.set(getKey(row[0]), row);
+      const key = getKey(row[0]);
+      const oldRow = map.get(key);
+
+      if (oldRow) {
+        const newRow = row.map((_, i) => row[i] ?? oldRow[i]);
+        newRow._origin = row._origin;
+        map.set(key, newRow);
+      } else {
+        map.set(key, row);
+      }
     }
+
     const newRows = xValues.map(value => {
       const key = getKey(value);
       const row = map.get(key);

--- a/frontend/test/metabase-visual/visualizations/line.cy.spec.js
+++ b/frontend/test/metabase-visual/visualizations/line.cy.spec.js
@@ -159,4 +159,46 @@ describe("visual tests > visualizations > line", () => {
 
     cy.percySnapshot();
   });
+
+  it("with missing values and duplicate x (metabase#11076)", () => {
+    visitQuestionAdhoc({
+      dataset_query: {
+        type: "native",
+        native: {
+          query: `
+            SELECT CAST('2010-10-01' AS DATE) as d, null as v1, 1 as v2
+            UNION ALL
+            SELECT CAST('2010-10-01' AS DATE), 2, null
+            UNION ALL
+            SELECT CAST('2010-10-02' AS DATE), 3, null
+            UNION ALL
+            SELECT CAST('2010-10-02' AS DATE), null, 4
+            UNION ALL
+            SELECT CAST('2010-10-03' AS DATE), null, 5
+            UNION ALL
+            SELECT CAST('2010-10-03' AS DATE), 6, null
+          `,
+        },
+        database: 1,
+      },
+      display: "line",
+      visualization_settings: {
+        "graph.dimensions": ["D"],
+        "graph.show_values": true,
+        "graph.metrics": ["V1", "V2"],
+        series_settings: {
+          V1: {
+            "line.missing": "zero",
+          },
+          V2: {
+            "line.missing": "none",
+          },
+        },
+      },
+    });
+
+    cy.wait("@dataset");
+
+    cy.percySnapshot();
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/11076 by merging rows for duplicate X values. To preserve current behavior for the most cases new rows have precedence over previous ones in the query result.

**How to test**
Follow the steps https://github.com/metabase/metabase/issues/11076#issuecomment-539302409. The cypress test does exactly the same.

**Screenshots**
<img width="1041" alt="Screen Shot 2021-10-12 at 4 53 27 pm" src="https://user-images.githubusercontent.com/8542534/136969293-17057405-11b6-4ee2-9efd-170f0fd02c9b.png">
