### PR TITLE
Fix saved question DB displayed in native editor DB picker

### DIFF
--- a/frontend/src/metabase/schema.js
+++ b/frontend/src/metabase/schema.js
@@ -16,16 +16,23 @@ export const TableSchema = new schema.Entity(
   {
     // convert "schema" returned by API as a string value to an object that can be normalized
     processStrategy({ ...table }) {
-      const databaseId =
-        typeof table.id === "string"
-          ? SAVED_QUESTIONS_VIRTUAL_DB_ID
-          : table.db_id;
+      // Saved questions are represented as database tables,
+      // and collections they're saved to as schemas
+      // Virtual tables ID are strings like "card__45" (where 45 is a question ID)
+      const isVirtualSchema = typeof table.id === "string";
+
+      const databaseId = isVirtualSchema
+        ? SAVED_QUESTIONS_VIRTUAL_DB_ID
+        : table.db_id;
       if (typeof table.schema === "string" || table.schema === null) {
         table.schema_name = table.schema;
         table.schema = {
           id: generateSchemaId(databaseId, table.schema_name),
           name: table.schema_name,
-          database: { id: databaseId },
+          database: {
+            id: databaseId,
+            is_saved_questions: isVirtualSchema,
+          },
         };
       }
       return table;

--- a/frontend/test/metabase/entities/databases.unit.spec.js
+++ b/frontend/test/metabase/entities/databases.unit.spec.js
@@ -25,9 +25,15 @@ describe("database entity", () => {
       Databases.objectActions.fetchDatabaseMetadata({ id: 123 }),
     );
     const { databases, schemas, tables } = store.getState().entities;
-    expect(databases).toEqual({ "123": { id: 123, tables: [234] } });
+    expect(databases).toEqual({
+      "123": { id: 123, tables: [234], is_saved_questions: false },
+    });
     expect(schemas).toEqual({
-      "123:public": { database: 123, id: "123:public", name: "public" },
+      "123:public": {
+        database: 123,
+        id: "123:public",
+        name: "public",
+      },
     });
     expect(tables).toEqual({
       "234": {

--- a/frontend/test/metabase/scenarios/native/reproductions/18418-saved-question-db-appears-in-db-picker.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/reproductions/18418-saved-question-db-appears-in-db-picker.cy.spec.js
@@ -1,0 +1,36 @@
+import { restore, popover } from "__support__/e2e/cypress";
+
+const questionDetails = {
+  name: "REVIEWS SQL",
+  native: { query: "select REVIEWER from REVIEWS LIMIT 1" },
+};
+
+describe("issue 18418", () => {
+  beforeEach(() => {
+    cy.intercept("POST", "/api/card").as("cardCreated");
+
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should not show saved questions DB in native question's DB picker (metabase#18418)", () => {
+    cy.createNativeQuestion(questionDetails, { visitQuestion: true });
+
+    cy.findByText("Explore results").click();
+
+    cy.findByText("Save").click();
+
+    cy.get(".Modal")
+      .button("Save")
+      .click();
+
+    cy.button("Not now").click();
+
+    cy.icon("sql").click();
+
+    // Clicking native question's database picker usually opens a popover with a list of databases
+    // As default Cypress environment has only the sample dataset available, we expect no popup to appear
+    cy.findByText("Sample Dataset").click();
+    popover().should("not.exist");
+  });
+});


### PR DESCRIPTION
Fixes #18418 — a regression since #18095. #18095 added a schemas reducer updating collection schemas and tables. It didn't handle a case when a saved question (represented as a virtual DB table) was in redux, but the Saved Question virtual DB was not yet there. In this case, when building DB metadata for a virtual question, its `database` was represented as a usual one, so it was rendered by the DB picker

### To Verify

1. New Question > Native Question > Sample Dataset
2. Create a native question using the query `select * from PEOPLE` and save
3. Click "Explore Results"
4. Click the Save button and then click the Save button again in the modal that appears
5. Click the "SQL" icon in the navbar
6. Click the database picker
7.  The final step depends on the number of databases your Metabase instance is connected to:
     * if you have **> 1 databases**: the database picker should only display real databases, a blank DB should be gone
     * if you have **only one database (Sample Dataset)**: click "Sample Dataset" under the query editor. Nothing should happen (normally it would open a picker, but it doesn't show if there is only one DB)

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/136984332-cc9fc106-1443-4a40-8d41-690cb98b333a.mov

**After**

https://user-images.githubusercontent.com/17258145/136984708-c8da3b5d-0ad7-43c4-8f5f-c374b9b42ccd.mov
