### PR TITLE
Add admin toggle to disable query downloads

### DIFF
--- a/frontend/src/metabase/admin/settings/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors.js
@@ -87,6 +87,12 @@ const SECTIONS = updateSectionsWithPlugins({
         type: "boolean",
       },
       {
+        key: "enable-downloads",
+        display_name: t`Download Results`,
+        type: "boolean",
+        defaultValue: true,
+      },
+      {
         key: "humanization-strategy",
         display_name: t`Friendly Table and Field Names`,
         type: "select",

--- a/frontend/src/metabase/dashboard/components/DashCard.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard.jsx
@@ -16,6 +16,7 @@ import QueryDownloadWidget from "metabase/query_builder/components/QueryDownload
 import ModalWithTrigger from "metabase/components/ModalWithTrigger";
 import { ChartSettingsWithState } from "metabase/visualizations/components/ChartSettings";
 import WithVizSettingsData from "metabase/visualizations/hoc/WithVizSettingsData";
+import MetabaseSettings from "metabase/lib/settings";
 
 import Icon, { iconPropTypes } from "metabase/components/Icon";
 import Tooltip from "metabase/components/Tooltip";
@@ -229,7 +230,7 @@ export default class DashCard extends Component {
               : { width: dashcard.sizeX, height: dashcard.sizeY }
           }
           actionButtons={
-            isEmbed ? (
+            isEmbed && MetabaseSettings.downloadsEnabled() ? (
               <QueryDownloadWidget
                 className="m1 text-brand-hover text-light"
                 classNameClose="hover-child"

--- a/frontend/src/metabase/lib/settings.js
+++ b/frontend/src/metabase/lib/settings.js
@@ -17,6 +17,7 @@ export type SettingName =
   | "enable-enhancements?"
   | "enable-public-sharing"
   | "enable-xrays"
+  | "enable-downloads"
   | "engines"
   | "ga-code"
   | "google-auth-client-id"
@@ -80,6 +81,10 @@ class Settings {
 
   enhancementsEnabled() {
     return this.get("enable-enhancements?");
+  }
+
+  downloadsEnabled() {
+    return this.get("enable-downloads");
   }
 
   isEmailConfigured() {

--- a/frontend/src/metabase/public/containers/PublicQuestion.jsx
+++ b/frontend/src/metabase/public/containers/PublicQuestion.jsx
@@ -8,6 +8,7 @@ import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import ExplicitSize from "metabase/components/ExplicitSize";
 import EmbedFrame from "../components/EmbedFrame";
 import title from "metabase/hoc/Title";
+import MetabaseSettings from "metabase/lib/settings";
 
 import type { Card } from "metabase-types/types/Card";
 import type { Dataset } from "metabase-types/types/Dataset";
@@ -194,7 +195,7 @@ export default class PublicQuestion extends Component {
     } = this.props;
     const { card, result, initialized, parameterValues } = this.state;
 
-    const actionButtons = result && (
+    const actionButtons = result && MetabaseSettings.downloadsEnabled() && (
       <QueryDownloadWidget
         className="m1 text-medium-hover"
         uuid={uuid}

--- a/frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx
@@ -11,6 +11,7 @@ import PopoverWithTrigger from "metabase/components/PopoverWithTrigger";
 import Icon from "metabase/components/Icon";
 import DownloadButton from "metabase/components/DownloadButton";
 import Tooltip from "metabase/components/Tooltip";
+import MetabaseSettings from "metabase/lib/settings";
 
 import * as Urls from "metabase/lib/urls";
 
@@ -186,6 +187,9 @@ QueryDownloadWidget.defaultProps = {
 };
 
 QueryDownloadWidget.shouldRender = ({ result, isResultDirty }) =>
-  !isResultDirty && result && !result.error;
+  !isResultDirty &&
+  result &&
+  !result.error &&
+  MetabaseSettings.downloadsEnabled();
 
 export default QueryDownloadWidget;

--- a/frontend/src/metabase/selectors/settings.js
+++ b/frontend/src/metabase/selectors/settings.js
@@ -7,6 +7,9 @@ export const getIsApplicationEmbeddingEnabled = state =>
   state.settings.values["enable-embedding"];
 // Whether or not xrays are enabled on the instance
 export const getXraysEnabled = state => state.settings.values["enable-xrays"];
+// Are users allowed to download results?
+export const getDownloadsEnabled = state =>
+  state.settings.values["enable-downloads"];
 
 export const getShowHomepageData = state =>
   state.settings.values["show-homepage-data"];

--- a/resources/locales.clj
+++ b/resources/locales.clj
@@ -1,5 +1,27 @@
 {:locales
- #{"nl" "en" "zh" "tr" "it" "fa" "vi" "zh-TW" "uk" "pl" "ca" "sv"
-   "zh-HK" "fr" "pt-BR" "de" "nb" "ru" "sk" "es" "ja" "cs" "bg"},
+ #{"nl"
+   "en"
+   "zh"
+   "sr"
+   "tr"
+   "it"
+   "fa"
+   "vi"
+   "zh-TW"
+   "uk"
+   "pl"
+   "ca"
+   "sv"
+   "zh-HK"
+   "fr"
+   "pt-BR"
+   "de"
+   "nb"
+   "ru"
+   "sk"
+   "es"
+   "ja"
+   "cs"
+   "bg"},
  :packages ["metabase"],
  :bundle "metabase.Messages"}

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -741,6 +741,7 @@
   [card-id export-format :as {{:keys [parameters]} :params}]
   {parameters    (s/maybe su/JSONString)
    export-format dataset-api/ExportFormat}
+  (api/check-downloads-enabled)
   (run-query-for-card-async
    card-id export-format
    :parameters  (json/parse-string parameters keyword)

--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -406,6 +406,12 @@
   (check (public-settings/enable-public-sharing)
     [400 (tru "Public sharing is not enabled.")]))
 
+(defn check-downloads-enabled
+  "Check that the `enable-downloads` Setting is `true` or throw a `400`."
+  []
+  (check (public-settings/enable-downloads)
+    [400 (tru "Downloading query results is not enabled.")]))
+
 (defn check-embedding-enabled
   "Is embedding of Cards or Objects (secured access via `/api/embed` endpoints with a signed JWT enabled?"
   []

--- a/src/metabase/api/dataset.clj
+++ b/src/metabase/api/dataset.clj
@@ -6,6 +6,7 @@
             [compojure.core :refer [POST]]
             [metabase.api.common :as api]
             [metabase.events :as events]
+            [metabase.public-settings :as public-settings]
             [metabase.mbql.schema :as mbql.s]
             [metabase.models.card :refer [Card]]
             [metabase.models.database :as database :refer [Database]]
@@ -101,27 +102,32 @@
      (keyword json-key)))
 
 (api/defendpoint ^:streaming POST ["/:export-format", :export-format export-format-regex]
-  "Execute a query and download the result data as a file in the specified format."
+  "Execute a query and download the result data as a file in the specified format.
+  If downloading is disabled, returns 403."
   [export-format :as {{:keys [query visualization_settings] :or {visualization_settings "{}"}} :params}]
   {query                  su/JSONString
    visualization_settings su/JSONString
    export-format          ExportFormat}
-  (let [query        (json/parse-string query keyword)
-        viz-settings (mb.viz/db->norm (json/parse-string visualization_settings viz-setting-key-fn))
-        query        (-> (assoc query
-                                :async? true
-                                :viz-settings viz-settings)
-                         (dissoc :constraints)
-                         (update :middleware #(-> %
-                                                  (dissoc :add-default-userland-constraints? :js-int-to-string?)
-                                                  (assoc :process-viz-settings? true
-                                                         :skip-results-metadata? true
-                                                         :format-rows? false))))]
-    (run-query-async
-     query
-     :export-format export-format
-     :context       (export-format->context export-format)
-     :qp-runner     qp/process-query-and-save-execution!)))
+   (if (public-settings/enable-downloads)
+    (let [query        (json/parse-string query keyword)
+            viz-settings (mb.viz/db->norm (json/parse-string visualization_settings viz-setting-key-fn))
+            query        (-> (assoc query
+                                    :async? true
+                                    :viz-settings viz-settings)
+                            (dissoc :constraints)
+                            (update :middleware #(-> %
+                                                      (dissoc :add-default-userland-constraints? :js-int-to-string?)
+                                                      (assoc :process-viz-settings? true
+                                                            :skip-results-metadata? true
+                                                            :format-rows? false))))]
+        (run-query-async
+        query
+        :export-format export-format
+        :context       (export-format->context export-format)
+        :qp-runner     qp/process-query-and-save-execution!))
+    (throw (ex-info (tru "Query downloads are disabled.")
+                      {:status-code    403}))
+                      ))
 
 
 ;;; ------------------------------------------------ Other Endpoints -------------------------------------------------

--- a/src/metabase/api/public.clj
+++ b/src/metabase/api/public.clj
@@ -145,6 +145,7 @@
   [uuid export-format :as {{:keys [parameters]} :params}]
   {parameters    (s/maybe su/JSONString)
    export-format dataset-api/ExportFormat}
+  (api/check-downloads-enabled)
   (run-query-for-card-with-public-uuid-async
    uuid
    export-format

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -283,6 +283,12 @@
   :default    true
   :visibility :authenticated)
 
+(defsetting enable-downloads
+  (deferred-tru "Allow users to download query results")
+  :type       :boolean
+  :default    true
+  :visibility :authenticated)
+
 (defsetting show-homepage-data
   (deferred-tru "Whether or not to display data on the homepage. Admins might turn this off in order to direct users to better content than raw data")
   :type       :boolean


### PR DESCRIPTION
This is a very basic and somewhat crude solution to #9264 (and #6369 I think), while advanced download permissions are being implemented. This PR introduces an admin toggle that will disable all query download functionality on the instance.

### Tests

- [x] Run the frontend and Cypress end-to-end tests with `yarn lint && yarn test`) (but some tests failed on my master checkout already?)
- [x] If there are changes to the backend codebase, run the backend tests with `clojure -X:dev:test` (but some tests failed on my master checkout already?)
- [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
