### PR TITLE
CI with GitHub Actions: make some jobs conditional on the context

### DIFF
--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -24,7 +24,12 @@ jobs:
             const pullRequestNumbers = Array.from(commitMessage.matchAll(/\(#(.*?)\)/g))
 
             if (pullRequestNumbers.length === 0) {
-              return;
+              return {
+                author: "",
+                pullRequestNumber: 0,
+                title: "",
+                hasBackportLabel: false
+              };
             }
 
             if (pullRequestNumbers > 1) {
@@ -74,7 +79,7 @@ jobs:
             };
             const latestReleaseBranch = releaseBranches.data
               .filter(branch => getVersionFromBranch(branch.ref) !== null)
-              .reduce((prev, current) => getVersionFromBranch(prev.ref) > getVersionFromBranch(current.ref) ? prev : current);
+              .reduce((prev, current) => getVersionFromBranch(prev.ref) > getVersionFromBranch(current.ref) ? prev : current, { ref: "" });
             const latestReleaseBranchName = latestReleaseBranch.ref.replace(/^refs\/heads\//, "");
 
             console.log(`Latest release branch: ${latestReleaseBranchName}`)

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -115,3 +115,4 @@ jobs:
         run: yarn run test-visual-no-build
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+        if: env.PERCY_TOKEN != null


### PR DESCRIPTION
Main use case: someone forks this repo and GitHub Action workflows run in their fork.

Some additional checks in this PR ensure that some job won't fail in case:
* there is no open PR in the repo
* there is no release branch in the repo
* PERCY_TOKEN isn't supplied as a secret