### PR TITLE
Keep Visualization tooltips open until the mouse leaves the chart or hovers over another datapoint

### DIFF
--- a/frontend/src/metabase/components/Popover.css
+++ b/frontend/src/metabase/components/Popover.css
@@ -30,6 +30,16 @@
   max-width: none;
 }
 
+/* 
+ * Reenable pointer events so users can select tooltip text. This style
+ * is marked important because it's enabled by the <Popover> component when
+ * onMouseEnter/onMouseLeave are set, which are useless if something else
+ * overrides pointer events on the tooltip 
+ */
+.PopoverBody.PopoverBody--pointerEvents {
+  pointer-events: all !important;
+}
+
 .PopoverBody.PopoverBody--tooltip {
   color: white;
   font-weight: bold;

--- a/frontend/src/metabase/components/Popover.jsx
+++ b/frontend/src/metabase/components/Popover.jsx
@@ -54,6 +54,9 @@ export default class Popover extends Component {
     noOnClickOutsideWrapper: PropTypes.bool,
     targetOffsetX: PropTypes.number,
     targetOffsetY: PropTypes.number,
+    // Allows consumers to keep the tooltip open when hovering over datapoints
+    onMouseEnter: PropTypes.func,
+    onMouseLeave: PropTypes.func,
     onClose: PropTypes.func,
     containerClassName: PropTypes.string,
     className: PropTypes.string,
@@ -146,12 +149,15 @@ export default class Popover extends Component {
             "PopoverBody--withArrow":
               this.props.hasArrow && this.props.hasBackground,
             "PopoverBody--autoWidth": this.props.autoWidth,
+            "PopoverBody--pointerEvents": this.props.onMouseEnter || this.props.onMouseLeave,
           },
           // TODO kdoh 10/16/2017 we should eventually remove this
           this.props.className,
         )}
         role={this.props.role}
         style={this.props.style}
+        onMouseEnter={this.props.onMouseEnter}
+        onMouseLeave={this.props.onMouseLeave}
       >
         {typeof this.props.children === "function"
           ? this.props.children(childProps)

--- a/frontend/src/metabase/components/Popover.jsx
+++ b/frontend/src/metabase/components/Popover.jsx
@@ -54,7 +54,6 @@ export default class Popover extends Component {
     noOnClickOutsideWrapper: PropTypes.bool,
     targetOffsetX: PropTypes.number,
     targetOffsetY: PropTypes.number,
-    // Allows consumers to keep the tooltip open when hovering over datapoints
     onMouseEnter: PropTypes.func,
     onMouseLeave: PropTypes.func,
     onClose: PropTypes.func,

--- a/frontend/src/metabase/components/Popover.jsx
+++ b/frontend/src/metabase/components/Popover.jsx
@@ -149,7 +149,8 @@ export default class Popover extends Component {
             "PopoverBody--withArrow":
               this.props.hasArrow && this.props.hasBackground,
             "PopoverBody--autoWidth": this.props.autoWidth,
-            "PopoverBody--pointerEvents": this.props.onMouseEnter || this.props.onMouseLeave,
+            "PopoverBody--pointerEvents":
+              this.props.onMouseEnter || this.props.onMouseLeave,
           },
           // TODO kdoh 10/16/2017 we should eventually remove this
           this.props.className,

--- a/frontend/src/metabase/visualizations/components/ChartTooltip.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartTooltip.jsx
@@ -49,7 +49,11 @@ export default class ChartTooltip extends Component {
       hovered &&
       ((hovered.element && document.body.contains(hovered.element)) ||
         hovered.event);
-    const isOpen = rows.length > 0 && !!hasEventOrElement;
+    const isOpen = !!hasEventOrElement;
+    if (hovered === null) {
+      debugger; // eslint-disable-line
+    }
+    console.log("hoevered", hovered);
     return (
       <TooltipPopover
         target={hovered && hovered.element}

--- a/frontend/src/metabase/visualizations/components/ChartTooltip.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartTooltip.jsx
@@ -11,7 +11,6 @@ export default class ChartTooltip extends Component {
   static propTypes = {
     hovered: PropTypes.object,
     settings: PropTypes.object,
-    // Allows consumers to keep the tooltip open when hovering over datapoints
     onMouseEnter: PropTypes.func,
     onMouseLeave: PropTypes.func,
   };

--- a/frontend/src/metabase/visualizations/components/ChartTooltip.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartTooltip.jsx
@@ -52,7 +52,7 @@ export default class ChartTooltip extends Component {
       hovered &&
       ((hovered.element && document.body.contains(hovered.element)) ||
         hovered.event);
-    const isOpen = !!hasEventOrElement;
+    const isOpen = rows.length > 0 && !!hasEventOrElement;
     return (
       <TooltipPopover
         target={hovered && hovered.element}

--- a/frontend/src/metabase/visualizations/components/ChartTooltip.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartTooltip.jsx
@@ -11,6 +11,9 @@ export default class ChartTooltip extends Component {
   static propTypes = {
     hovered: PropTypes.object,
     settings: PropTypes.object,
+    // Allows consumers to keep the tooltip open when hovering over datapoints
+    onMouseEnter: PropTypes.func,
+    onMouseLeave: PropTypes.func,
   };
 
   _getRows() {
@@ -43,22 +46,20 @@ export default class ChartTooltip extends Component {
   }
 
   render() {
-    const { hovered, settings } = this.props;
+    const { hovered, settings, onMouseEnter, onMouseLeave } = this.props;
     const rows = this._getRows();
     const hasEventOrElement =
       hovered &&
       ((hovered.element && document.body.contains(hovered.element)) ||
         hovered.event);
     const isOpen = !!hasEventOrElement;
-    if (hovered === null) {
-      debugger; // eslint-disable-line
-    }
-    console.log("hoevered", hovered);
     return (
       <TooltipPopover
         target={hovered && hovered.element}
         targetEvent={hovered && hovered.event}
         verticalAttachments={["bottom", "top"]}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
         isOpen={isOpen}
         // Make sure that for chart tooltips we don't constrain the width so longer strings don't get cut off
         constrainedWidth={false}

--- a/frontend/src/metabase/visualizations/components/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization.jsx
@@ -279,9 +279,23 @@ export default class Visualization extends React.PureComponent {
     }
   };
 
+  handleMouseEnter = e => {
+    console.log("mouse enter")
+    if (this._setTooltipTimer) {
+      clearTimeout(this._setTooltipTimer);
+      this._setTooltipTimer = null;
+    }
+  };
+
   handleMouseLeave = e => {
+    console.log("mouse leave")
+    // The mouseenter handler below gets fired after this one, so we have to
+    // preserve the tooltip
     if (this.state.tooltip) {
-      this.setState({ tooltip: null });
+      this._setTooltipTimer = setTimeout(() => {
+        this.setState({ tooltip: null });
+        this._setTooltipTimer = null;
+      }, 0);
     }
   };
 
@@ -393,6 +407,15 @@ export default class Visualization extends React.PureComponent {
     return hovered;
   };
 
+  getMouseState = (clickActions) => {
+    const { hovered, tooltip, } = this.state;
+    // disable hover when click action is active
+    if (clickActions.length > 0) {
+      return [null, null];
+    }
+    return [hovered, tooltip];
+  };
+
   render() {
     const {
       actionButtons,
@@ -416,7 +439,7 @@ export default class Visualization extends React.PureComponent {
     let { style } = this.props;
 
     const clickActions = this.getClickActions(clicked);
-    let hovered = this.getHovered(clickActions);
+    let [hovered, tooltip] = this.getMouseState(clickActions);
 
     let error = this.props.error || this.state.error;
     const loading = !(
@@ -634,8 +657,9 @@ export default class Visualization extends React.PureComponent {
         )}
         <ChartTooltip
           series={series}
-          hovered={hovered}
+          hovered={hovered || tooltip}
           settings={settings}
+          onMouseEnter={this.handleMouseEnter}
         />
         {this.props.onChangeCardAndRun && (
           <ChartClickActions

--- a/frontend/src/metabase/visualizations/components/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization.jsx
@@ -273,9 +273,7 @@ export default class Visualization extends React.PureComponent {
   handleMouseLeave = e => {
     // When reseting the hover wait in case we're simply transitioning from one
     // element to another. This allows visualizations to use mouseleave events etc.
-    console.log("mouse leave")
     this._resetHoverTimer = setTimeout(() => {
-      console.log("hover reset")
       this.setState({ hovered: null });
       this._resetHoverTimer = null;
     }, 0);

--- a/frontend/src/metabase/visualizations/components/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization.jsx
@@ -252,6 +252,7 @@ export default class Visualization extends React.PureComponent {
   handleHoverChange = hovered => {
     if (hovered) {
       const { yAxisSplit } = this.state;
+      console.log("hover change");
       // if we have Y axis split info then find the Y axis index (0 = left, 1 = right)
       if (yAxisSplit) {
         const axisIndex = _.findIndex(yAxisSplit, indexes =>
@@ -266,14 +267,18 @@ export default class Visualization extends React.PureComponent {
         clearTimeout(this._resetHoverTimer);
         this._resetHoverTimer = null;
       }
-    } else {
-      // When reseting the hover wait in case we're simply transitioning from one
-      // element to another. This allows visualizations to use mouseleave events etc.
-      this._resetHoverTimer = setTimeout(() => {
-        this.setState({ hovered: null });
-        this._resetHoverTimer = null;
-      }, 0);
     }
+  };
+
+  handleMouseLeave = e => {
+    // When reseting the hover wait in case we're simply transitioning from one
+    // element to another. This allows visualizations to use mouseleave events etc.
+    console.log("mouse leave")
+    this._resetHoverTimer = setTimeout(() => {
+      console.log("hover reset")
+      this.setState({ hovered: null });
+      this._resetHoverTimer = null;
+    }, 0);
   };
 
   @memoize
@@ -519,6 +524,7 @@ export default class Visualization extends React.PureComponent {
 
     return (
       <div
+        onMouseLeave={this.handleMouseLeave}
         className={cx(className, "flex flex-column full-height")}
         style={style}
       >

--- a/frontend/src/metabase/visualizations/components/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization.jsx
@@ -280,7 +280,6 @@ export default class Visualization extends React.PureComponent {
   };
 
   handleMouseEnter = e => {
-    console.log("mouse enter")
     if (this._setTooltipTimer) {
       clearTimeout(this._setTooltipTimer);
       this._setTooltipTimer = null;
@@ -288,7 +287,6 @@ export default class Visualization extends React.PureComponent {
   };
 
   handleMouseLeave = e => {
-    console.log("mouse leave")
     // The mouseenter handler below gets fired after this one, so we have to
     // preserve the tooltip
     if (this.state.tooltip) {
@@ -407,8 +405,8 @@ export default class Visualization extends React.PureComponent {
     return hovered;
   };
 
-  getMouseState = (clickActions) => {
-    const { hovered, tooltip, } = this.state;
+  getMouseState = clickActions => {
+    const { hovered, tooltip } = this.state;
     // disable hover when click action is active
     if (clickActions.length > 0) {
       return [null, null];

--- a/frontend/src/metabase/visualizations/components/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization.jsx
@@ -142,6 +142,7 @@ export default class Visualization extends React.PureComponent {
   props: Props;
 
   _resetHoverTimer: ?number;
+  _setTooltipTimer: ?number;
 
   constructor(props: Props) {
     super(props);
@@ -261,7 +262,7 @@ export default class Visualization extends React.PureComponent {
         );
         hovered = assoc(hovered, "axisIndex", axisIndex);
       }
-      this.setState({ hovered });
+      this.setState({ hovered, tooltip: hovered });
       // If we previously set a timeout for clearing the hover clear it now since we received
       // a new hover.
       if (this._resetHoverTimer !== null) {
@@ -275,12 +276,6 @@ export default class Visualization extends React.PureComponent {
         this.setState({ hovered: null });
         this._resetHoverTimer = null;
       }, 0);
-    }
-  };
-
-  handleMouseEnter = e => {
-    if (this.state.hovered) {
-      this.setState({ tooltip: this.state.hovered });
     }
   };
 
@@ -387,8 +382,8 @@ export default class Visualization extends React.PureComponent {
     }
   };
 
-  getHovered = (clickActions) => {
-    const { hovered, tooltip, } = this.state;
+  getHovered = clickActions => {
+    const { hovered, tooltip } = this.state;
     // disable hover when click action is active
     if (clickActions.length > 0) {
       return null;
@@ -543,6 +538,7 @@ export default class Visualization extends React.PureComponent {
       <div
         className={cx(className, "flex flex-column full-height")}
         style={style}
+        onMouseLeave={this.handleMouseLeave}
       >
         {!!hasHeader && (
           <div className="p1 flex-no-shrink">
@@ -640,8 +636,6 @@ export default class Visualization extends React.PureComponent {
           series={series}
           hovered={hovered}
           settings={settings}
-          onMouseEnter={this.handleMouseEnter}
-          onMouseLeave={this.handleMouseLeave}
         />
         {this.props.onChangeCardAndRun && (
           <ChartClickActions


### PR DESCRIPTION
Fixes  #17613

This PR makes Chart tooltips "sticky" by only hiding tooltips when the mouse leaves the chart completely or hovers over another data point/bar/etc.

This PR fixes the above bug but there are a lot of complex interactions with the visualization UI so this PR needs to be reviewed by product people as much as developers. It might be better to add a separate visualization setting that enables or disables these sticky tooltips.

@rlotun @flamber @paoliniluis please add relevant reviewers.

## How to test

1. Click `Sample Dataset` from `/`
2. Select `Orders`
3. Summarize => Group by `Created At`
4. Test with different kinds of visualizations


### What to expect

![image](https://user-images.githubusercontent.com/653604/137022780-c2fe06fb-3b92-48f3-9650-0ebeb85146e3.png)

![image](https://user-images.githubusercontent.com/653604/137022724-396d0eec-ca38-4cb1-8a72-fcfa49f6df51.png)

![image](https://user-images.githubusercontent.com/653604/137022936-73b96ff6-3c49-4191-8ffc-a992e71a67a0.png)

