### PR TITLE
Fix broken pin map when there are no valid points

### DIFF
--- a/frontend/src/metabase/visualizations/components/PinMap.jsx
+++ b/frontend/src/metabase/visualizations/components/PinMap.jsx
@@ -16,6 +16,8 @@ import L from "leaflet";
 
 import type { VisualizationProps } from "metabase-types/types/Visualization";
 
+const WORLD_BOUNDS = [[-90, -180], [90, 180]];
+
 type Props = VisualizationProps;
 
 type State = {
@@ -159,7 +161,7 @@ export default class PinMap extends Component {
       onUpdateWarnings(warnings);
     }
 
-    const bounds = L.latLngBounds(points);
+    const bounds = L.latLngBounds(points.length > 0 ? points : WORLD_BOUNDS);
 
     const min = d3.min(points, point => point[2]);
     const max = d3.max(points, point => point[2]);

--- a/frontend/test/metabase/scenarios/visualizations/reproductions/18061-maps-only-nulls-crash-frontend.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/reproductions/18061-maps-only-nulls-crash-frontend.cy.spec.js
@@ -52,7 +52,7 @@ const filter = {
 
 const dashboardDetails = { name: "18061D", parameters: [filter] };
 
-describe.skip("issue 18061", () => {
+describe("issue 18061", () => {
   beforeEach(() => {
     mockSessionProperty("field-filter-operators-enabled?", true);
 
@@ -108,7 +108,6 @@ describe.skip("issue 18061", () => {
 
       cy.button("Update filter").click();
 
-      cy.wait("@getCard");
       cy.findByText("Something went wrong").should("not.exist");
 
       cy.findByText("ID is less than 2");


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/18061

Please check the repro steps in the original issue.

Map rendering fails when there are no valid points with non-null latitude and longitude. Other charts, for instance, line/area/bar do not show any errors. Instead, they render a blank chart with just axes. Similarly, I made pin maps render an empty map zoomed out.