### PR TITLE
Relativize links when emitting html from md in pulse/subscriptions

### DIFF
--- a/src/metabase/pulse/markdown.clj
+++ b/src/metabase/pulse/markdown.clj
@@ -2,8 +2,7 @@
   (:require [clojure.edn :as edn]
             [clojure.java.io :as io]
             [clojure.string :as str]
-            [metabase.public-settings :as public-settings]
-            [metabase.util.urls :as url])
+            [metabase.public-settings :as public-settings])
   (:import [com.vladsch.flexmark.ast AutoLink BlockQuote BulletList BulletListItem Code Emphasis FencedCodeBlock
             HardLineBreak Heading HtmlBlock HtmlCommentBlock HtmlEntity HtmlInline HtmlInlineBase HtmlInlineComment
             HtmlInnerBlockComment Image ImageRef IndentedCodeBlock Link LinkRef MailLink OrderedList OrderedListItem

--- a/src/metabase/pulse/markdown.clj
+++ b/src/metabase/pulse/markdown.clj
@@ -191,11 +191,14 @@
 (defn- resolve-uri
   "If the provided URI is a relative path, resolve it relative to the site URL so that links work
   correctly in Slack/Email."
-  [uri]
-  (when uri
-    (if-let [site-url (public-settings/site-url)]
-      (.toString (.resolve (new URI ^String site-url) ^String uri))
-      uri)))
+  [^String uri]
+  (letfn [(ensure-slash [s] (when s
+                              (cond-> s
+                                (not (str/ends-with? s "/")) (str "/"))))]
+    (when uri
+      (if-let [^String site-url (ensure-slash (public-settings/site-url))]
+        (.. (URI. site-url) (resolve uri) toString)
+        uri))))
 
 (defn- ast->mrkdwn
   "Takes an AST representing Markdown input, and converts it to a mrkdwn string that will render nicely in Slack.

--- a/test/metabase/pulse/markdown_test.clj
+++ b/test/metabase/pulse/markdown_test.clj
@@ -175,8 +175,11 @@
            (html "1. foo\n   1. bar")))
     (is (= "<p>/</p>\n"
            (html "\\/")))
-    (is (= "<p><img src=\"image.png\" alt=\"alt-text\" /></p>\n"
-           (html "![alt-text](image.png)"))))
+    (tu/with-temporary-setting-values [site-url "https://example.com"]
+      (is (= "<p><img src=\"https://example.com/image.png\" alt=\"alt-text\" /></p>\n"
+             (html "![alt-text](/image.png)")))
+      (is (= "<p><a href=\"https://example.com/dashboard/1\">dashboard 1</a></p>\n"
+             (html "[dashboard 1](/dashboard/1)")))))
 
   (testing "HTML in the source markdown is escaped properly, but HTML entities are retained"
     (is (= "<p>&lt;h1&gt;header&lt;/h1&gt;</p>\n" (html "<h1>header</h1>")))

--- a/test/metabase/pulse/markdown_test.clj
+++ b/test/metabase/pulse/markdown_test.clj
@@ -175,11 +175,14 @@
            (html "1. foo\n   1. bar")))
     (is (= "<p>/</p>\n"
            (html "\\/")))
-    (tu/with-temporary-setting-values [site-url "https://example.com"]
-      (is (= "<p><img src=\"https://example.com/image.png\" alt=\"alt-text\" /></p>\n"
-             (html "![alt-text](/image.png)")))
-      (is (= "<p><a href=\"https://example.com/dashboard/1\">dashboard 1</a></p>\n"
-             (html "[dashboard 1](/dashboard/1)")))))
+    (doseq [temp-setting ["https://example.com" "https://example.com/"]]
+      (tu/with-temporary-setting-values [site-url temp-setting]
+        (is (= "<p><img src=\"https://example.com/image.png\" alt=\"alt-text\" /></p>\n"
+               (html "![alt-text](/image.png)")))
+        (is (= "<p><img src=\"https://example.com/image.png\" alt=\"alt-text\" /></p>\n"
+               (html "![alt-text](image.png)")))
+        (is (= "<p><a href=\"https://example.com/dashboard/1\">dashboard 1</a></p>\n"
+               (html "[dashboard 1](/dashboard/1)"))))))
 
   (testing "HTML in the source markdown is escaped properly, but HTML entities are retained"
     (is (= "<p>&lt;h1&gt;header&lt;/h1&gt;</p>\n" (html "<h1>header</h1>")))


### PR DESCRIPTION
Fixes #18165 

Helpful links:
- https://awesomeopensource.com/project/vsch/flexmark-java
- https://github.com/vsch/flexmark-java/blob/master/flexmark-java-samples/src/com/vladsch/flexmark/java/samples/PegdownCustomLinkResolverOptions.java
- https://github.com/vsch/flexmark-java/blob/8a881b73109a287b5f202e2e1fc9f9c497d5eecf/flexmark/src/main/java/com/vladsch/flexmark/html/HtmlRenderer.java#L433
- https://github.com/vsch/flexmark-java/blob/8a881b73109a287b5f202e2e1fc9f9c497d5eecf/flexmark/src/main/java/com/vladsch/flexmark/html/renderer/ResolvedLink.java#L10

This was a pain in the ass. I had been looking for a way to just easily
traverse the ast, but this might cause problems since there are spans
and text positions everywhere. So i looked at how to change the
parser. Everything is so difficult to change. Luckily there was a
built-in way to do this with link resolvers, found in a github issue
https://github.com/vsch/flexmark-java/issues/308 . And ideally this
would be done in the parser but it seems to be done in the html
emitter.

https://github.com/vsch/flexmark-java/blob/master/flexmark-java-samples/src/com/vladsch/flexmark/java/samples/CustomLinkResolverSample.java

And then I got turned around on what is relative or not. What happens if
you do something seemingly sane like:

```markdown
[a link to google](www.google.com)
```

This is apparently a relative link since it lacks a protocol. And our
`resolve-uri` code treats it as such:

```clojure
markdown=> (resolve-uri "www.google.com")
"http://localhost:3000www.google.com"
markdown=>
```

This seems strange to me but is also the behavior on gist.github.com:
https://gist.github.com/dpsutton/412502ffa89186487e41885855dfa781 has a
link to https://gist.github.com/dpsutton/www.google.com

In all, trying to figure out this object oriented factory mess i had 24
tabs open to the source of NodeVisitor, NodeVisitorBase,
AstActionHandler, VisitHandler, ParserExtension,
NodePostProcessorFactory, etc. It was truly unpleasant.

I'm still not sure what we should do for relative things without a slash. Note that "www.google.com" was added into the host part "http://localhost:3000www.google.com" whereas the link in the gist is aware to add a slash. Should we prepend a slash if there's not a leading slash and not a protocol?