### PR TITLE
Remove sortable limitation for aggregation

### DIFF
--- a/frontend/src/metabase-lib/lib/queries/StructuredQuery.js
+++ b/frontend/src/metabase-lib/lib/queries/StructuredQuery.js
@@ -947,10 +947,8 @@ export default class StructuredQuery extends AtomicQuery {
       }
       if (this.hasBreakouts()) {
         for (const aggregation of this.aggregations()) {
-          if (aggregation.isSortable()) {
-            sortOptions.dimensions.push(aggregation.aggregationDimension());
-            sortOptions.count++;
-          }
+          sortOptions.dimensions.push(aggregation.aggregationDimension());
+          sortOptions.count++;
         }
       }
 

--- a/frontend/src/metabase-lib/lib/queries/structured/Aggregation.js
+++ b/frontend/src/metabase-lib/lib/queries/structured/Aggregation.js
@@ -276,8 +276,4 @@ export default class Aggregation extends MBQLClause {
       this._query,
     );
   }
-
-  isSortable() {
-    return AGGREGATION.isSortable(this);
-  }
 }

--- a/frontend/src/metabase/lib/query.js
+++ b/frontend/src/metabase/lib/query.js
@@ -3,7 +3,6 @@ import Utils from "metabase/lib/utils";
 
 import * as QUERY from "./query/query";
 import * as FieldRef from "./query/field_ref";
-import { SORTABLE_AGGREGATION_TYPES } from "./query/aggregation";
 
 export * from "./query/query";
 export * from "./query/field_ref";
@@ -158,9 +157,5 @@ function canSortByAggregateField(query, index) {
     return false;
   }
   const aggregations = QUERY.getAggregations(query);
-  return (
-    aggregations[index] &&
-    aggregations[index][0] &&
-    SORTABLE_AGGREGATION_TYPES.has(aggregations[index][0])
-  );
+  return aggregations[index] && aggregations[index][0];
 }

--- a/frontend/src/metabase/lib/query/aggregation.js
+++ b/frontend/src/metabase/lib/query/aggregation.js
@@ -13,16 +13,6 @@ import type {
 } from "metabase-types/types/Query";
 import type { MetricId } from "metabase-types/types/Metric";
 
-export const SORTABLE_AGGREGATION_TYPES = new Set([
-  "avg",
-  "count",
-  "distinct",
-  "stddev",
-  "sum",
-  "min",
-  "max",
-]);
-
 // returns canonical list of Aggregations, i.e. with deprecated "rows" removed
 export function getAggregations(
   aggregation: ?AggregationClause,
@@ -183,10 +173,4 @@ export function setField(aggregation: any, fieldRef: ConcreteField) {
     // TODO: is there a better failure response than just returning the aggregation unmodified??
     return aggregation;
   }
-}
-
-// MISC
-
-export function isSortable(aggregation: any) {
-  return SORTABLE_AGGREGATION_TYPES.has(getContent(aggregation)[0]);
 }

--- a/frontend/test/metabase/scenarios/question/reproductions/6239.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/6239.cy.spec.js
@@ -1,6 +1,6 @@
 import { restore, popover, openOrdersTable } from "__support__/e2e/cypress";
 
-describe.skip("issue 6239", () => {
+describe("issue 6239", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();


### PR DESCRIPTION
This should fix #6239.

The corresponding repro test is unskipped.

How to verify:

1. Ask a question, Custom question.
2. Sample Dataset, Orders table.
3. Summarize, Custom Expression, type `Average([Tax] + [Discount])` and name it _AvgTaxDiscount_.
4. Another one: Custom Expression, type `CountIf([Discount] > 0)` and name it _Discounted_.
5. Another one: Custom Expression, type `2 * Average([Discount])` and name it _TwiceAvgDiscount_.
6. Group by e.g. _Created At_.
7. Sort

**Before this PR**

The popup for Sort only shows:
* Created At
* AvgTaxDiscount

![image](https://user-images.githubusercontent.com/7288/137033414-115f6ffe-9a0d-4414-9554-93737c630073.png)

**After this PR**

The popup for Sort should show four items (this is the correct behavior):
* Created At
* AvgTaxDiscount
* Discounted
* TwiceAvgDiscount

![image](https://user-images.githubusercontent.com/7288/137033496-77051791-8029-4ace-8714-8957cda8ce7a.png)
