### PR TITLE
Tools for fixing errors problems with postgres semantics of limits (blank display of error table)

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/audit_app/pages/common/cards.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_app/pages/common/cards.clj
@@ -28,13 +28,12 @@
 
 (def latest-qe
   "HoneySQL for a CTE to get latest QueryExecution for a Card."
-  [:latest_qe {:select [:query_execution.card_id :error :query_execution.started_at]
-               :from   [:query_execution]
-               :join   [[{:select [:card_id [:%max.started_at :started_at]]
-                          :from [:query_execution]
-                          :group-by [:card_id]} :inner_qe]
-                        [:= :query_execution.started_at :inner_qe.started_at]]
-               :limit  1}])
+  [:latest_qe {:select   [:query_execution.card_id :error :query_execution.started_at]
+               :from     [:query_execution]
+               :join     [[{:select [:card_id [:%max.started_at :started_at]]
+                            :from [:query_execution]
+                            :group-by [:card_id]} :inner_qe]
+                          [:= :query_execution.started_at :inner_qe.started_at]]}])
 
 (def query-runs
   "HoneySQL for a CTE to include the total number of queries for each Card forever."

--- a/enterprise/backend/src/metabase_enterprise/audit_app/pages/common/cards.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_app/pages/common/cards.clj
@@ -12,19 +12,19 @@
 
 (def avg-exec-time-45
   "HoneySQL for a CTE to include the average execution time for each Card for 45 days."
-  [:avg_exec_time (-> {:select   [:card_id
-                                  [:%avg.running_time :avg_running_time_ms]]
-                       :from     [:query_execution]
-                       :group-by [:card_id]}
-                      (common/add-45-days-clause :started_at))])
+  [:avg_exec_time_45 (-> {:select   [:card_id
+                                     [:%avg.running_time :avg_running_time_ms]]
+                          :from     [:query_execution]
+                          :group-by [:card_id]}
+                         (common/add-45-days-clause :started_at))])
 
 (def total-exec-time-45
   "HoneySQL for a CTE to include the total execution time for each Card for 45 days."
-  [:total_runtime (-> {:select   [:card_id
-                                  [:%sum.running_time :total_running_time_ms]]
-                       :from     [:query_execution]
-                       :group-by [:card_id]}
-                      (common/add-45-days-clause :started_at))])
+  [:total_runtime_45 (-> {:select   [:card_id
+                                     [:%sum.running_time :total_running_time_ms]]
+                          :from     [:query_execution]
+                          :group-by [:card_id]}
+                         (common/add-45-days-clause :started_at))])
 
 (def latest-qe
   "HoneySQL for a CTE to get latest QueryExecution for a Card."

--- a/enterprise/backend/src/metabase_enterprise/audit_app/pages/queries.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_app/pages/queries.clj
@@ -172,11 +172,11 @@
                [:table_name      {:display_name "Table",                :base_type :type/Text,    :remapped_from :table_id}]
                [:user_id         {:display_name "Created By ID",        :base_type :type/Integer, :remapped_to   :user_name}]
                [:user_name       {:display_name "Created By",           :base_type :type/Text,    :remapped_from :user_id}]
-               [:public_link     {:display_name "Public Link",          :base_type :type/URL}]
-               [:cache_ttl       {:display_name "Cache Duration",       :base_type :type/Number}]
+               [:cache_ttl       {:display_name "Cache Duration",       :base_type :type/Integer}]
                [:avg_exec_time   {:display_name "Average Runtime (ms)", :base_type :type/Integer}]
-               [:total_runtime   {:display_name "Total Runtime (ms)",   :base_type :type/Number}]
-               [:query_runs      {:display_name "Query Runs",           :base_type :type/Integer}]]
+               [:total_runtime   {:display_name "Total Runtime (ms)",   :base_type :type/Integer}]
+               [:query_runs      {:display_name "Query Runs",           :base_type :type/Integer}]
+               [:public_link     {:display_name "Public Link",          :base_type :type/URL}]]
     :results  (common/reducible-query
                (->
                 {:with      [cards/avg-exec-time-45
@@ -192,18 +192,18 @@
                              [:t.name :table_name]
                              [:card.creator_id :user_id]
                              [(common/user-full-name :u) :user_name]
-                             [(common/card-public-url :card.public_uuid) :public_link]
                              :card.cache_ttl
-                             [:avg_exec_time.avg_running_time_ms :avg_exec_time]
-                             [:total_runtime.total_running_time_ms :total_runtime]
-                             [:query_runs.count :query_runs]]
+                             [:avg_exec_time_45.avg_running_time_ms :avg_exec_time]
+                             [:total_runtime_45.total_running_time_ms :total_runtime]
+                             [:query_runs.count :query_runs]
+                             [(common/card-public-url :card.public_uuid) :public_link]]
                  :from      [[:report_card :card]]
                  :left-join [[:collection :coll]      [:= :card.collection_id :coll.id]
                              [:metabase_database :db] [:= :card.database_id :db.id]
                              [:metabase_table :t]     [:= :card.table_id :t.id]
                              [:core_user :u]          [:= :card.creator_id :u.id]
-                             :avg_exec_time           [:= :card.id :avg_exec_time.card_id]
-                             :total_runtime           [:= :card.id :total_runtime.card_id]
+                             :avg_exec_time_45        [:= :card.id :avg_exec_time_45.card_id]
+                             :total_runtime_45        [:= :card.id :total_runtime_45.card_id]
                              :query_runs              [:= :card.id :query_runs.card_id]]
                  :where     [:= :card.archived false]}
                 (common/add-search-clause question-filter :card.name)

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/lib/cards/queries.js
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/lib/cards/queries.js
@@ -108,9 +108,9 @@ export const table = (
       "table.columns": [
         { name: "card_id", enabled: true },
         { name: "query_runs", enabled: true },
-        { name: "avg_exec_time", enabled: true },
+        { name: "avg_exec_time_45", enabled: true },
         { name: "cache_ttl", enabled: true },
-        { name: "total_runtime", enabled: true },
+        { name: "total_runtime_45", enabled: true },
         { name: "database_id", enabled: true },
         { name: "table_id", enabled: true },
         { name: "collection_id", enabled: true },


### PR DESCRIPTION
Putative fix for blank display of error table on stats (which doesn't seem to have a separate issue, although I was conflating it with #17820 for a while - it is not the same as #17820) as well as #18317.

With regards to the blank display of error tables: DB's are heterogenous with regards to the behavior of `limit` without order by. Postgres works very differently from H2 where this was tested.

With regards to link fix: This was a very action-at-a-distance error stemming from how the markdown fix actually behaves again.