### PR TITLE
#18219 Repro: Temporal breakout fields are not formatted in export

### DIFF
--- a/frontend/test/metabase/scenarios/downloads/reproductions/18219-temporal-units-not-formatted.cy.spec.js
+++ b/frontend/test/metabase/scenarios/downloads/reproductions/18219-temporal-units-not-formatted.cy.spec.js
@@ -1,0 +1,83 @@
+import { restore } from "__support__/e2e/cypress";
+import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
+
+const xlsx = require("xlsx");
+const { ORDERS, ORDERS_ID } = SAMPLE_DATASET;
+
+const questionDetails = {
+  name: "18219",
+  query: {
+    "source-table": ORDERS_ID,
+    aggregation: [["count"]],
+    breakout: [["field", ORDERS.CREATED_AT, { "temporal-unit": "year" }]],
+  },
+};
+
+const testCases = [
+  { type: "csv", sheetName: "Sheet1" },
+  { type: "xlsx", sheetName: "Query result" },
+];
+
+describe.skip("issue 18219", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should format temporal units on export (metabase#18219)", () => {
+    cy.createQuestion(questionDetails).then(({ body: { id } }) => {
+      cy.intercept("POST", `/api/card/${id}/query`).as("cardQuery");
+      cy.visit(`/question/${id}`);
+
+      // Wait for `result_metadata` to load
+      cy.wait("@cardQuery");
+
+      cy.findByText("Created At: Year");
+      cy.findByText("2016");
+      cy.findByText("744");
+
+      cy.icon("download").click();
+
+      cy.wrap(testCases).each(({ type, sheetName }) => {
+        cy.log(`downloading a ${type} file`);
+        const endpoint = `/api/card/${id}/query/${type}`;
+
+        cy.request({
+          url: endpoint,
+          method: "POST",
+          encoding: "binary",
+        }).then(resp => {
+          const workbook = xlsx.read(resp.body, {
+            type: "binary",
+            raw: true,
+          });
+
+          const A1 = workbook.Sheets[sheetName]["A1"];
+          const A2 = workbook.Sheets[sheetName]["A2"];
+
+          expect(A1.v).to.eq("Created At: Year");
+
+          if (type === "csv") {
+            expect(A2.v).to.eq("2016");
+          }
+
+          if (type === "xlsx") {
+            /**
+             * Depending on how we end up solving this issue,
+             * the following assertion on the cell type might not be correct.
+             * It's very likely we'll format temporal breakouts as strings.
+             * I.e. we have to take into account Q1, Q2, etc.
+             */
+            // expect(A2.t).to.eq("n");
+
+            /**
+             * Because of the excel date format, we cannot assert on the raw value `v`.
+             * Rather, we have to do it on the parsed value `w`.
+             */
+            expect(A2.w).to.eq("2016");
+          }
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #18219 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/downloads/reproductions/18219-temporal-units-not-formatted.cy.spec.js`
- Unskip the test
- It should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/137157390-8c70f16f-f6fe-4540-8bfe-097f2b9db04a.png)

### Additional context:
<details>
    <summary>CSV</summary>

```
{
    "SheetNames": [
        "Sheet1"
    ],
    "Sheets": {
        "Sheet1": {
            "A1": {
                "t": "s",
                "v": "Created At"
            },
            "B1": {
                "t": "s",
                "v": "Count"
            },
            "A2": {
                "t": "s",
                "v": "2016-01-01"
            },
            "B2": {
                "t": "s",
                "v": "744"
            },
            "A3": {
                "t": "s",
                "v": "2017-01-01"
            },
            "B3": {
                "t": "s",
                "v": "3610"
            },
            "A4": {
                "t": "s",
                "v": "2018-01-01"
            },
            "B4": {
                "t": "s",
                "v": "5834"
            },
            "A5": {
                "t": "s",
                "v": "2019-01-01"
            },
            "B5": {
                "t": "s",
                "v": "6578"
            },
            "A6": {
                "t": "s",
                "v": "2020-01-01"
            },
            "B6": {
                "t": "s",
                "v": "1994"
            },
            "!ref": "A1:B6"
        }
    }
}
```
</details>


<details>
    <summary>XLSX</summary>

```
{
    "Directory": {
        "workbooks": [
            "/xl/workbook.xml"
        ],
        "sheets": [
            "/xl/worksheets/sheet1.xml"
        ],
        "charts": [],
        "dialogs": [],
        "macros": [],
        "rels": [],
        "strs": [
            "/xl/sharedStrings.xml"
        ],
        "comments": [],
        "links": [],
        "coreprops": [
            "/docProps/core.xml"
        ],
        "extprops": [
            "/docProps/app.xml"
        ],
        "custprops": [],
        "themes": [],
        "styles": [
            "/xl/styles.xml"
        ],
        "vba": [],
        "drawings": [],
        "TODO": [],
        "xmlns": "http://schemas.openxmlformats.org/package/2006/content-types",
        "calcchain": "",
        "sst": "/xl/sharedStrings.xml",
        "style": "/xl/styles.xml",
        "defaults": {
            "rels": "application/vnd.openxmlformats-package.relationships+xml",
            "xml": "application/xml"
        }
    },
    "Workbook": {
        "AppVersion": {},
        "WBProps": {
            "date1904": false,
            "allowRefreshQuery": false,
            "autoCompressPictures": true,
            "backupFile": false,
            "checkCompatibility": false,
            "CodeName": "",
            "defaultThemeVersion": 0,
            "filterPrivacy": false,
            "hidePivotFieldList": false,
            "promptedSolutions": false,
            "publishItems": false,
            "refreshAllConnections": false,
            "saveExternalLinkValues": true,
            "showBorderUnselectedTables": true,
            "showInkAnnotation": true,
            "showObjects": "all",
            "showPivotChartFilter": false,
            "updateLinks": "userSet"
        },
        "WBView": [
            {
                "activeTab": 0,
                "activetab": "0",
                "autoFilterDateGrouping": true,
                "firstSheet": 0,
                "minimized": false,
                "showHorizontalScroll": true,
                "showSheetTabs": true,
                "showVerticalScroll": true,
                "tabRatio": 600,
                "visibility": "visible"
            }
        ],
        "Sheets": [
            {
                "name": "Query result",
                "id": "rId3",
                "sheetId": "1",
                "sheetid": "1",
                "Hidden": 0
            }
        ],
        "CalcPr": {
            "calcCompleted": "true",
            "calcMode": "auto",
            "calcOnSave": "true",
            "concurrentCalc": "true",
            "fullCalcOnLoad": "false",
            "fullPrecision": "true",
            "iterate": "false",
            "iterateCount": "100",
            "iterateDelta": "0.001",
            "refMode": "A1"
        },
        "Names": [
            {
                "Name": "_xlnm._FilterDatabase",
                "Sheet": 0,
                "Hidden": true,
                "Ref": "'Query result'!$A$1:$B$1"
            }
        ],
        "xmlns": "http://schemas.openxmlformats.org/spreadsheetml/2006/main",
        "Views": [
            {}
        ]
    },
    "Props": {
        "Author": "Apache POI",
        "CreatedDate": "2021-10-13T14:49:35.000Z",
        "Application": "Apache POI",
        "HyperlinksChanged": false,
        "SharedDoc": false,
        "LinksUpToDate": false,
        "ScaleCrop": false,
        "Worksheets": 1,
        "SheetNames": [
            "Query result"
        ]
    },
    "Custprops": {},
    "Deps": {},
    "Sheets": {
        "Query result": {
            "A1": {
                "t": "s",
                "v": "Created At",
                "h": "Created At",
                "w": "Created At"
            },
            "B1": {
                "t": "s",
                "v": "Count",
                "h": "Count",
                "w": "Count"
            },
            "A2": {
                "t": "n",
                "v": 42370,
                "w": "January 1, 2016, 12:00 AM"
            },
            "B2": {
                "t": "n",
                "v": 744,
                "w": "744"
            },
            "A3": {
                "t": "n",
                "v": 42736,
                "w": "January 1, 2017, 12:00 AM"
            },
            "B3": {
                "t": "n",
                "v": 3610,
                "w": "3,610"
            },
            "A4": {
                "t": "n",
                "v": 43101,
                "w": "January 1, 2018, 12:00 AM"
            },
            "B4": {
                "t": "n",
                "v": 5834,
                "w": "5,834"
            },
            "A5": {
                "t": "n",
                "v": 43466,
                "w": "January 1, 2019, 12:00 AM"
            },
            "B5": {
                "t": "n",
                "v": 6578,
                "w": "6,578"
            },
            "A6": {
                "t": "n",
                "v": 43831,
                "w": "January 1, 2020, 12:00 AM"
            },
            "B6": {
                "t": "n",
                "v": 1994,
                "w": "1,994"
            },
            "!autofilter": {
                "ref": "A1:B1"
            },
            "!margins": {
                "left": 0.7,
                "right": 0.7,
                "top": 0.75,
                "bottom": 0.75,
                "header": 0.3,
                "footer": 0.3
            },
            "!ref": "A1:B6"
        }
    },
    "SheetNames": [
        "Query result"
    ],
    "Strings": [],
    "Styles": {
        "NumberFmt": [
            "General",
            "0",
            "0.00",
            "#,##0",
            "#,##0.00",
            null,
            null,
            null,
            null,
            "0%",
            "0.00%",
            "0.00E+00",
            "# ?/?",
            "# ??/??",
            "m/d/yy",
            "d-mmm-yy",
            "d-mmm",
            "mmm-yy",
            "h:mm AM/PM",
            "h:mm:ss AM/PM",
            "h:mm",
            "h:mm:ss",
            "m/d/yy h:mm",
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            "#,##0 ;(#,##0)",
            "#,##0 ;[Red](#,##0)",
            "#,##0.00;(#,##0.00)",
            "#,##0.00;[Red](#,##0.00)",
            null,
            null,
            null,
            null,
            "mm:ss",
            "[h]:mm:ss",
            "mmss.0",
            "##0.0E+0",
            "@",
            null,
            null,
            null,
            null,
            null,
            null,
            "\"上午/下午 \"hh\"時\"mm\"分\"ss\"秒 \"",
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            "mmmm d, yyyy, h:mm am/pm"
        ],
        "Fonts": [
            {
                "sz": 11,
                "color": {
                    "index": 8,
                    "rgb": "000"
                },
                "name": "Calibri",
                "family": 2,
                "scheme": "minor"
            }
        ],
        "Fills": [
            {
                "patternType": "none"
            },
            {
                "patternType": "darkGray"
            }
        ],
        "Borders": [
            {}
        ],
        "CellXf": [
            {
                "numFmtId": 0,
                "numfmtid": "0",
                "fontId": 0,
                "fontid": "0",
                "fillId": 0,
                "fillid": "0",
                "borderId": 0,
                "borderid": "0",
                "xfId": 0,
                "xfid": "0"
            },
            {
                "numFmtId": 164,
                "numfmtid": "164",
                "fontId": 0,
                "fontid": "0",
                "fillId": 0,
                "fillid": "0",
                "borderId": 0,
                "borderid": "0",
                "xfId": 0,
                "xfid": "0",
                "applyNumberFormat": true,
                "applynumberformat": "true"
            },
            {
                "numFmtId": 3,
                "numfmtid": "3",
                "fontId": 0,
                "fontid": "0",
                "fillId": 0,
                "fillid": "0",
                "borderId": 0,
                "borderid": "0",
                "xfId": 0,
                "xfid": "0",
                "applyNumberFormat": true,
                "applynumberformat": "true"
            }
        ]
    },
    "Themes": {},
    "SSF": {
        "0": "General",
        "1": "0",
        "2": "0.00",
        "3": "#,##0",
        "4": "#,##0.00",
        "9": "0%",
        "10": "0.00%",
        "11": "0.00E+00",
        "12": "# ?/?",
        "13": "# ??/??",
        "14": "m/d/yy",
        "15": "d-mmm-yy",
        "16": "d-mmm",
        "17": "mmm-yy",
        "18": "h:mm AM/PM",
        "19": "h:mm:ss AM/PM",
        "20": "h:mm",
        "21": "h:mm:ss",
        "22": "m/d/yy h:mm",
        "37": "#,##0 ;(#,##0)",
        "38": "#,##0 ;[Red](#,##0)",
        "39": "#,##0.00;(#,##0.00)",
        "40": "#,##0.00;[Red](#,##0.00)",
        "45": "mm:ss",
        "46": "[h]:mm:ss",
        "47": "mmss.0",
        "48": "##0.0E+0",
        "49": "@",
        "56": "\"上午/下午 \"hh\"時\"mm\"分\"ss\"秒 \"",
        "164": "mmmm d, yyyy, h:mm am/pm"
    }
}
```
</details>