### PR TITLE
Refactor field ordering logic in exports to avoid dropped fields

### DIFF
--- a/frontend/test/metabase/scenarios/downloads/reproductions/18440-remapped-display-value-dropped.cy.spec.js
+++ b/frontend/test/metabase/scenarios/downloads/reproductions/18440-remapped-display-value-dropped.cy.spec.js
@@ -18,7 +18,7 @@ const testCases = [
   { type: "xlsx", sheetName: "Query result" },
 ];
 
-describe.skip("issue 18440", () => {
+describe("issue 18440", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/card").as("saveQuestion");
 

--- a/src/metabase/query_processor/streaming.clj
+++ b/src/metabase/query_processor/streaming.clj
@@ -71,10 +71,11 @@
         cols-vector        (into [] cols)
         ;; cols-index is a map from keys representing fields to their indices into `cols`
         cols-index         (reduce-kv (fn [m i col]
-                                        ;; Always add [:field col-name] as a key, for native queries and old fields using :field-literal (#18382)
+                                        ;; Always add [:field col-name] as a key, so that native queries,
+                                        ;; remapped fields, and old fields using :field-literal work correctly (#18382)
                                         (let [m' (assoc m [:field (:name col)] i)]
                                           (if-let [field-ref (:field_ref col)]
-                                            ;; Construct a map key from the column's field-ref, if available
+                                            ;; Add a map key based on the column's field-ref, if available
                                             (assoc m' (field-ref->map-key field-ref) i)
 
                                             ;; Otherwise construct a key using the id of the column, if available

--- a/test/metabase/api/dataset_test.clj
+++ b/test/metabase/api/dataset_test.clj
@@ -227,6 +227,24 @@
             (is (= 101
                    (count (csv/read-csv result))))))))))
 
+(deftest export-with-remapped-fields
+  (testing "POST /api/dataset/:format"
+    (testing "Downloaded CSV/JSON/XLSX results should respect remapped fields (#18440)"
+      (let [query (json/generate-string {:database (mt/id)
+                                         :type     :query
+                                         :query    {:source-table (mt/id :venues)
+                                                    :limit 1}
+                                         :middleware
+                                         {:add-default-userland-constraints? true
+                                          :userland-query?                   true}})]
+        (mt/with-column-remappings [venues.category_id categories.name]
+          (let [result (mt/user-http-request :rasta :post 200 "dataset/csv"
+                                             :query query)]
+            (is (str/includes? result "Asian"))))
+        (mt/with-column-remappings [venues.category_id (values-of categories.name)]
+          (let [result (mt/user-http-request :rasta :post 200 "dataset/csv"
+                                             :query query)]
+            (is (str/includes? result "Asian"))))))))
 
 (deftest non--download--queries-should-still-get-the-default-constraints
   (testing (str "non-\"download\" queries should still get the default constraints "

--- a/test/metabase/query_processor/streaming_test.clj
+++ b/test/metabase/query_processor/streaming_test.clj
@@ -317,6 +317,18 @@
             [{::mb.viz/table-column-field-ref ["expression" "Name1"], ::mb.viz/table-column-enabled true}
              {::mb.viz/table-column-field-ref ["expression" "Name0"], ::mb.viz/table-column-enabled true}]))))
 
+  (testing "correlation of fields using deprecated field dimensions"
+    (is (= [1 0]
+           (@#'qp.streaming/export-column-order
+            [{:id 0, :field_ref [:field_literal "Name0"]}, {:id 1, :field_ref [:field_literal "Name1"]}]
+            [{::mb.viz/table-column-field-ref ["field_literal" "Name1"], ::mb.viz/table-column-enabled true}
+             {::mb.viz/table-column-field-ref ["field_literal" "Name0"], ::mb.viz/table-column-enabled true}])))
+    (is (= [1 0]
+           (@#'qp.streaming/export-column-order
+            [{:id 0, :field_ref [:field_id 0]}, {:id 1, :field_ref [:field_id 1]}]
+            [{::mb.viz/table-column-field-ref ["field_id" 1], ::mb.viz/table-column-enabled true}
+             {::mb.viz/table-column-field-ref ["field_id" 0], ::mb.viz/table-column-enabled true}]))))
+
   (testing "disabled columns are excluded from ordering"
     (is (= [0]
            (@#'qp.streaming/export-column-order
@@ -332,7 +344,8 @@
   (testing "remapped columns use the index of the new column"
     (is (= [1]
            (@#'qp.streaming/export-column-order
-            [{:id 0, :name "Col1", :remapped_to "Col2"}, {:id 1, :name "Col2", :remapped_from "Col1"}]
+            [{:id 0, :name "Col1", :remapped_to "Col2", :field_ref ["field" 0 nil]},
+             {:id 1, :name "Col2", :remapped_from "Col1", :field_ref ["field" 1 nil]}]
             [{::mb.viz/table-column-field-ref ["field" 0 nil], ::mb.viz/table-column-enabled true}]))))
 
   (testing "entries in table-columns without corresponding entries in cols are ignored"


### PR DESCRIPTION
This PR refactors some code in the function `export-column-order` in `metabase.query-processor.streaming`, which should resolve two regressions involving dropped fields in exports: fixes #18440 and fixes #18382.

#18440 was introduced by #18205. Essentially, we needed to be able to look up remapped fields by name in the `cols-index` map. But #18205 changed key generation so that it would be based fully off of `field-ref`, if one was provided. For remapped fields, `field-ref` contains the field ID, and not the field name, so lookups in the map would then fail and the field would be dropped from the export. I've changed the logic to _always_ add a key to the map containing the field name, in addition to the field ID.

#18382 was just caused by the code not recognizing old field dimensions of `:field-id` and `:field-literal` in viz settings -- it was only handling `:field` or `:aggregation` properly. I've changed the logic to convert these to `:field` for `cols-index` map keys.

I've updated the `export-column-order` unit tests to account for these cases and added an API-level test for the remapped fields case. I have some ideas for expanding API-level export test coverage to a lot of other cases but I'll need to experiment with some new helper functions first, so I won't include them in this PR.