### PR TITLE
Drop long-unused Table.entity_name column

### DIFF
--- a/frontend/src/metabase-types/types/Table.js
+++ b/frontend/src/metabase-types/types/Table.js
@@ -23,7 +23,6 @@ export type Table = {
   active: boolean,
   visibility_type: TableVisibilityType,
 
-  // entity_name:          null // unused?
   // entity_type:          null // unused?
 
   fields: Field[],

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -8540,6 +8540,15 @@ databaseChangeLog:
                   constraints:
                     nullable: true
 
+  - changeSet:
+      id: 317
+      author: camsaul
+      comment: Added 0.42.0 Remove unused column
+      changes:
+        - dropColumn:
+            tableName: metabase_table
+            columnName: entity_name
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -55,7 +55,7 @@
 
 (defn- table-details [table]
   (-> (merge (mt/obj->json->obj (mt/object-defaults Table))
-             (select-keys table [:active :created_at :db_id :description :display_name :entity_name :entity_type
+             (select-keys table [:active :created_at :db_id :description :display_name :entity_type
                                  :id :name :rows :schema :updated_at :visibility_type]))
       (update :entity_type #(when % (str "entity/" (name %))))
       (update :visibility_type #(when % (name %)))))

--- a/test/metabase/api/field_test.clj
+++ b/test/metabase/api/field_test.clj
@@ -44,7 +44,6 @@
                                      :schema                  "PUBLIC"
                                      :name                    "USERS"
                                      :display_name            "Users"
-                                     :entity_name             nil
                                      :active                  true
                                      :id                      (mt/id :users)
                                      :db_id                   (mt/id)

--- a/test/metabase/test/mock/util.clj
+++ b/test/metabase/test/mock/util.clj
@@ -10,7 +10,6 @@
    :fields                  []
    :rows                    nil
    :updated_at              true
-   :entity_name             nil
    :active                  true
    :id                      true
    :db_id                   true


### PR DESCRIPTION
We stopped using this column way back in either 2016 or 2017... time to finally take out the trash

Fixes #5240