### PR TITLE
Autofill inputs for repeated fields during self-serve set up

### DIFF
--- a/frontend/src/metabase-lib/lib/Question.js
+++ b/frontend/src/metabase-lib/lib/Question.js
@@ -1,5 +1,5 @@
 import _ from "underscore";
-import { chain, assoc, dissoc, assocIn, getIn } from "icepick";
+import { assoc, assocIn, chain, dissoc, getIn } from "icepick";
 
 // NOTE: the order of these matters due to circular dependency issues
 import StructuredQuery, {
@@ -28,11 +28,10 @@ import { isStandard } from "metabase/lib/query/filter";
 import { memoize, sortObject } from "metabase-lib/lib/utils";
 
 // TODO: remove these dependencies
-import * as Card_DEPRECATED from "metabase/lib/card";
 import * as Urls from "metabase/lib/urls";
 import {
-  findColumnSettingIndexForColumn,
   findColumnIndexForColumnSetting,
+  findColumnSettingIndexForColumn,
   syncTableColumnsToQuery,
 } from "metabase/lib/dataset";
 import {
@@ -40,19 +39,19 @@ import {
   isTransientId,
 } from "metabase/meta/Card";
 import {
-  parameterToMBQLFilter,
   normalizeParameterValue,
+  parameterToMBQLFilter,
 } from "metabase/meta/Parameter";
 import {
   aggregate,
   breakout,
+  distribution,
+  drillUnderlyingRecords,
   filter,
   pivot,
-  distribution,
   toUnderlyingRecords,
-  drillUnderlyingRecords,
 } from "metabase/modes/lib/actions";
-import { MetabaseApi, CardApi, maybeUsePivotEndpoint } from "metabase/services";
+import { CardApi, maybeUsePivotEndpoint, MetabaseApi } from "metabase/services";
 import Questions from "metabase/entities/questions";
 
 import type {
@@ -60,8 +59,8 @@ import type {
   ParameterValues,
 } from "metabase-types/types/Parameter";
 import type {
-  DatasetQuery,
   Card as CardObject,
+  DatasetQuery,
   VisualizationSettings,
 } from "metabase-types/types/Card";
 import type { Dataset, Value } from "metabase-types/types/Dataset";
@@ -74,6 +73,7 @@ import {
   ALERT_TYPE_ROWS,
   ALERT_TYPE_TIMESERIES_GOAL,
 } from "metabase-lib/lib/Alert";
+import { utf8_to_b64url } from "metabase/lib/encoding";
 
 type QuestionUpdateFn = (q: Question) => ?Promise<void>;
 
@@ -849,15 +849,13 @@ export default class Question {
     let cellQuery = "";
     if (filters.length > 0) {
       const mbqlFilter = filters.length > 1 ? ["and", ...filters] : filters[0];
-      cellQuery = `/cell/${Card_DEPRECATED.utf8_to_b64url(
-        JSON.stringify(mbqlFilter),
-      )}`;
+      cellQuery = `/cell/${utf8_to_b64url(JSON.stringify(mbqlFilter))}`;
     }
     const questionId = this.id();
     if (questionId != null && !isTransientId(questionId)) {
       return `/auto/dashboard/question/${questionId}${cellQuery}`;
     } else {
-      const adHocQuery = Card_DEPRECATED.utf8_to_b64url(
+      const adHocQuery = utf8_to_b64url(
         JSON.stringify(this.card().dataset_query),
       );
       return `/auto/dashboard/adhoc/${adHocQuery}${cellQuery}`;
@@ -868,9 +866,7 @@ export default class Question {
     let cellQuery = "";
     if (filters.length > 0) {
       const mbqlFilter = filters.length > 1 ? ["and", ...filters] : filters[0];
-      cellQuery = `/cell/${Card_DEPRECATED.utf8_to_b64url(
-        JSON.stringify(mbqlFilter),
-      )}`;
+      cellQuery = `/cell/${utf8_to_b64url(JSON.stringify(mbqlFilter))}`;
     }
     const questionId = this.id();
     const query = this.query();
@@ -880,7 +876,7 @@ export default class Question {
         if (questionId != null && !isTransientId(questionId)) {
           return `/auto/dashboard/question/${questionId}${cellQuery}/compare/table/${tableId}`;
         } else {
-          const adHocQuery = Card_DEPRECATED.utf8_to_b64url(
+          const adHocQuery = utf8_to_b64url(
             JSON.stringify(this.card().dataset_query),
           );
           return `/auto/dashboard/adhoc/${adHocQuery}${cellQuery}/compare/table/${tableId}`;
@@ -1083,7 +1079,7 @@ export default class Question {
         : {}),
     };
 
-    return Card_DEPRECATED.utf8_to_b64url(JSON.stringify(sortObject(cardCopy)));
+    return utf8_to_b64url(JSON.stringify(sortObject(cardCopy)));
   }
 
   convertParametersToFilters() {

--- a/frontend/src/metabase/entities/users/forms.js
+++ b/frontend/src/metabase/entities/users/forms.js
@@ -81,13 +81,13 @@ export default {
   setup: () => ({
     fields: [
       ...DETAILS_FORM_FIELDS(),
-      ...PASSWORD_FORM_FIELDS(),
       {
         name: "site_name",
         title: t`Company or team name`,
         placeholder: t`Department of Awesome`,
         validate: validate.required(),
       },
+      ...PASSWORD_FORM_FIELDS(),
     ],
   }),
   password: {

--- a/frontend/src/metabase/entities/users/forms.js
+++ b/frontend/src/metabase/entities/users/forms.js
@@ -84,7 +84,7 @@ export default {
       ...PASSWORD_FORM_FIELDS(),
       {
         name: "site_name",
-        title: t`Your company or team name`,
+        title: t`Company or team name`,
         placeholder: t`Department of Awesome`,
         validate: validate.required(),
       },

--- a/frontend/src/metabase/lib/card.js
+++ b/frontend/src/metabase/lib/card.js
@@ -4,7 +4,7 @@ import Utils from "metabase/lib/utils";
 import * as Urls from "metabase/lib/urls";
 
 import { CardApi } from "metabase/services";
-import { b64url_to_utf8, utf8_to_b64url } from "metabase/lib/encoding";
+import { b64hash_to_utf8, utf8_to_b64url } from "metabase/lib/encoding";
 
 export function createCard(name = null) {
   return {
@@ -91,8 +91,7 @@ export function serializeCardForUrl(card) {
 }
 
 export function deserializeCardFromUrl(serialized) {
-  serialized = serialized.replace(/^#/, "");
-  return JSON.parse(b64url_to_utf8(serialized));
+  return JSON.parse(b64hash_to_utf8(serialized));
 }
 
 export function urlForCardState(state, dirty) {

--- a/frontend/src/metabase/lib/card.js
+++ b/frontend/src/metabase/lib/card.js
@@ -4,6 +4,7 @@ import Utils from "metabase/lib/utils";
 import * as Urls from "metabase/lib/urls";
 
 import { CardApi } from "metabase/services";
+import { b64url_to_utf8, utf8_to_b64url } from "metabase/lib/encoding";
 
 export function createCard(name = null) {
   return {
@@ -92,25 +93,6 @@ export function serializeCardForUrl(card) {
 export function deserializeCardFromUrl(serialized) {
   serialized = serialized.replace(/^#/, "");
   return JSON.parse(b64url_to_utf8(serialized));
-}
-
-// escaping before base64 encoding is necessary for non-ASCII characters
-// https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/btoa
-export function utf8_to_b64(str) {
-  return window.btoa(unescape(encodeURIComponent(str)));
-}
-export function b64_to_utf8(b64) {
-  return decodeURIComponent(escape(window.atob(b64)));
-}
-
-// for "URL safe" base64, replace "+" with "-" and "/" with "_" as per RFC 4648
-export function utf8_to_b64url(str) {
-  return utf8_to_b64(str)
-    .replace(/\+/g, "-")
-    .replace(/\//g, "_");
-}
-export function b64url_to_utf8(b64url) {
-  return b64_to_utf8(b64url.replace(/-/g, "+").replace(/_/g, "/"));
 }
 
 export function urlForCardState(state, dirty) {

--- a/frontend/src/metabase/lib/encoding.js
+++ b/frontend/src/metabase/lib/encoding.js
@@ -1,0 +1,20 @@
+// escaping before base64 encoding is necessary for non-ASCII characters
+// https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/btoa
+export function utf8_to_b64(str) {
+  return window.btoa(unescape(encodeURIComponent(str)));
+}
+
+export function b64_to_utf8(b64) {
+  return decodeURIComponent(escape(window.atob(b64)));
+}
+
+// for "URL safe" base64, replace "+" with "-" and "/" with "_" as per RFC 4648
+export function utf8_to_b64url(str) {
+  return utf8_to_b64(str)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+}
+
+export function b64url_to_utf8(b64url) {
+  return b64_to_utf8(b64url.replace(/-/g, "+").replace(/_/g, "/"));
+}

--- a/frontend/src/metabase/lib/encoding.js
+++ b/frontend/src/metabase/lib/encoding.js
@@ -18,3 +18,7 @@ export function utf8_to_b64url(str) {
 export function b64url_to_utf8(b64url) {
   return b64_to_utf8(b64url.replace(/-/g, "+").replace(/_/g, "/"));
 }
+
+export function b64hash_to_utf8(b64hash) {
+  return b64url_to_utf8(b64hash.replace(/^#/, ""));
+}

--- a/frontend/src/metabase/setup/components/Setup.jsx
+++ b/frontend/src/metabase/setup/components/Setup.jsx
@@ -55,7 +55,7 @@ export default class Setup extends Component {
 
   componentDidMount() {
     this.setDefaultLanguage();
-    this.setDefaultUserDetails();
+    this.setDefaultDetails();
   }
 
   setDefaultLanguage() {
@@ -77,14 +77,14 @@ export default class Setup extends Component {
     }
   }
 
-  setDefaultUserDetails() {
+  setDefaultDetails() {
     const { hash } = this.props.location;
 
     try {
       const userDetails = hash && JSON.parse(b64hash_to_utf8(hash));
-      this.setState({ defaultUserDetails: userDetails });
+      this.setState({ defaultDetails: userDetails });
     } catch (e) {
-      this.setState({ defaultUserDetails: undefined });
+      this.setState({ defaultDetails: undefined });
     }
   }
 
@@ -176,7 +176,7 @@ export default class Setup extends Component {
               <UserStep
                 {...this.props}
                 stepNumber={USER_STEP_NUMBER}
-                defaultUserDetails={this.state.defaultUserDetails}
+                defaultUserDetails={this.state.defaultDetails?.user}
               />
               <DatabaseConnectionStep
                 {...this.props}

--- a/frontend/src/metabase/setup/components/Setup.jsx
+++ b/frontend/src/metabase/setup/components/Setup.jsx
@@ -84,11 +84,11 @@ export default class Setup extends Component {
     );
   }
 
-  UNSAFE_componentWillReceiveProps(nextProps) {
+  componentDidUpdate(prevProps) {
     // If we are entering the scheduling step, we need to scroll to the top of scheduling step container
     if (
-      this.props.activeStep !== nextProps.activeStep &&
-      nextProps.activeStep === 3
+      prevProps.activeStep !== this.props.activeStep &&
+      this.props.activeStep === DATABASE_CONNECTION_STEP_NUMBER
     ) {
       setTimeout(() => {
         if (this.databaseSchedulingStepContainer.current) {
@@ -98,7 +98,7 @@ export default class Setup extends Component {
       }, 10);
     }
 
-    if (!this.props.setupComplete && nextProps.setupComplete) {
+    if (!prevProps.setupComplete && this.props.setupComplete) {
       MetabaseAnalytics.trackEvent("Setup", "Complete");
     }
   }

--- a/frontend/src/metabase/setup/components/UserStep.jsx
+++ b/frontend/src/metabase/setup/components/UserStep.jsx
@@ -98,9 +98,9 @@ export default class UserStep extends Component {
                   <FormField name="last_name" className="flex-full" />
                 </Flex>
                 <FormField name="email" />
+                <FormField name="site_name" />
                 <FormField name="password" />
                 <FormField name="password_confirm" />
-                <FormField name="site_name" />
                 <FormFooter submitTitle={t`Next`} />
               </Form>
             )}

--- a/frontend/src/metabase/setup/components/UserStep.jsx
+++ b/frontend/src/metabase/setup/components/UserStep.jsx
@@ -19,6 +19,7 @@ export default class UserStep extends Component {
     setActiveStep: PropTypes.func.isRequired,
 
     userDetails: PropTypes.object,
+    defaultUserDetails: PropTypes.object,
     setUserDetails: PropTypes.func.isRequired,
     validatePassword: PropTypes.func.isRequired,
   };
@@ -43,7 +44,14 @@ export default class UserStep extends Component {
   };
 
   render() {
-    const { activeStep, setActiveStep, stepNumber, userDetails } = this.props;
+    const {
+      activeStep,
+      setActiveStep,
+      stepNumber,
+      userDetails,
+      defaultUserDetails,
+    } = this.props;
+
     const stepText =
       activeStep <= stepNumber
         ? t`What should we call you?`
@@ -70,12 +78,11 @@ export default class UserStep extends Component {
           <User.Form
             className="mt1"
             form={User.forms.setup()}
-            user={
-              userDetails && {
-                ...userDetails,
-                password_confirm: userDetails.password,
-              }
-            }
+            user={{
+              ...defaultUserDetails,
+              ...userDetails,
+              password_confirm: userDetails?.password,
+            }}
             onSubmit={this.handleSubmit}
             asyncValidate={this.handleAsyncValidate}
             asyncBlurFields={["password"]}

--- a/frontend/src/metabase/setup/components/UserStep.jsx
+++ b/frontend/src/metabase/setup/components/UserStep.jsx
@@ -74,7 +74,11 @@ export default class UserStep extends Component {
           className="SetupStep SetupStep--active rounded bg-white full relative"
         >
           <StepTitle title={stepText} circleText={String(stepNumber)} />
-
+          {defaultUserDetails && (
+            <div className="Form-field">
+              {t`We know you’ve already created one of these. We like to keep billing and product accounts separate so that you don’t have to share logins.`}
+            </div>
+          )}
           <User.Form
             className="mt1"
             form={User.forms.setup()}

--- a/frontend/test/metabase/lib/card.unit.spec.js
+++ b/frontend/test/metabase/lib/card.unit.spec.js
@@ -1,13 +1,15 @@
 import {
   createCard,
-  utf8_to_b64,
-  b64_to_utf8,
-  utf8_to_b64url,
-  b64url_to_utf8,
   isCardDirty,
   serializeCardForUrl,
   deserializeCardFromUrl,
 } from "metabase/lib/card";
+import {
+  b64_to_utf8,
+  b64url_to_utf8,
+  utf8_to_b64,
+  utf8_to_b64url,
+} from "metabase/lib/encoding";
 
 const CARD_ID = 31;
 

--- a/frontend/test/metabase/scenarios/onboarding/setup/setup.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/setup/setup.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, popover } from "__support__/e2e/cypress";
+import { popover, restore } from "__support__/e2e/cypress";
 
 // we're testing for one known (en) and one unknown (xx) locale
 const locales = ["en", "xx"];
@@ -44,7 +44,7 @@ describe("scenarios > setup", () => {
       cy.findByLabelText("First name").type("Testy");
       cy.findByLabelText("Last name").type("McTestface");
       cy.findByLabelText("Email").type("testy@metabase.test");
-      cy.findByLabelText("Your company or team name").type("Epic Team");
+      cy.findByLabelText("Company or team name").type("Epic Team");
 
       // test first with a weak password
       cy.findByLabelText("Create a password").type("password");
@@ -176,5 +176,33 @@ describe("scenarios > setup", () => {
       cy.findByText("Take me to Metabase").click();
       cy.location("pathname").should("eq", "/");
     });
+  });
+
+  it("should allow pre-filling user details", () => {
+    const details = {
+      user: {
+        first_name: "Testy",
+        last_name: "McTestface",
+        email: "testy@metabase.test",
+        site_name: "Epic Team",
+      },
+    };
+
+    cy.visit(`/setup#${btoa(JSON.stringify(details))}`);
+
+    cy.findByText("Welcome to Metabase");
+    cy.findByText("Let's get started").click();
+
+    cy.findByText("What's your preferred language?");
+    cy.findByTestId("language-option-en");
+    cy.findByText("Next").click();
+
+    cy.findByLabelText("First name").should("have.value", "Testy");
+    cy.findByLabelText("Last name").should("have.value", "McTestface");
+    cy.findByLabelText("Email").should("have.value", "testy@metabase.test");
+    cy.findByLabelText("Company or team name").should(
+      "have.value",
+      "Epic Team",
+    );
   });
 });

--- a/frontend/test/metabase/scenarios/smoketest/admin.cy.spec.js
+++ b/frontend/test/metabase/scenarios/smoketest/admin.cy.spec.js
@@ -32,7 +32,7 @@ describe("metabase-smoketest > admin", () => {
       cy.findByLabelText("First name").type(admin.first_name);
       cy.findByLabelText("Last name").type(admin.last_name);
       cy.findByLabelText("Email").type(admin.email);
-      cy.findByLabelText("Your company or team name").type("Epic Team");
+      cy.findByLabelText("Company or team name").type("Epic Team");
 
       cy.findByLabelText("Create a password")
         .clear()


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/18469

Allow auto-filling details during the setup process with url params. The url is `/setup#hash`, where hash is base64-encoded json:
```
{
  user: {
    first_name: "",
    last_name: "",
    email: "",
    site_name: ""
  }
}
```

**How to test**
- Run `yarn dev`
- Navigate to `http://localhost:3000/setup#eyJ1c2VyIjp7ImZpcnN0X25hbWUiOiJUZXN0eSIsImxhc3RfbmFtZSI6Ik1jVGVzdGZhY2UiLCJlbWFpbCI6InRlc3R5QG1ldGFiYXNlLnRlc3QiLCJzaXRlX25hbWUiOiJFcGljIFRlYW0ifX0=`
- You should see that user fields have specified values
- It should be possible to finish the setup process

<img width="736" alt="Screen Shot 2021-10-19 at 4 25 57 pm" src="https://user-images.githubusercontent.com/8542534/137919109-f02a7d1c-b3de-47b6-8de5-d495b10ac91a.png">
