### PR TITLE
#8283 Repro: Not possible to sort by metric

### DIFF
--- a/frontend/test/metabase/scenarios/admin/datamodel/metrics.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/metrics.cy.spec.js
@@ -1,4 +1,9 @@
-import { restore, popover, modal } from "__support__/e2e/cypress";
+import {
+  restore,
+  popover,
+  modal,
+  openOrdersTable,
+} from "__support__/e2e/cypress";
 import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATASET;
@@ -8,6 +13,67 @@ describe("scenarios > admin > datamodel > metrics", () => {
     restore();
     cy.signInAsAdmin();
     cy.viewport(1400, 860);
+  });
+
+  it("should be possible to sort by metric (metabase#8283)", () => {
+    cy.request("POST", "/api/metric", {
+      name: "Revenue",
+      description: "Sum of orders subtotal",
+      table_id: ORDERS_ID,
+      definition: {
+        "source-table": ORDERS_ID,
+        aggregation: [["sum", ["field", ORDERS.SUBTOTAL, null]]],
+      },
+    });
+
+    openOrdersTable({ mode: "notebook" });
+
+    cy.findByText("Summarize").click();
+    cy.findByText("Common Metrics").click();
+    cy.findByText("Revenue").click();
+
+    cy.findByText("Pick a column to group by").click();
+    cy.findByText("Created At").click();
+
+    cy.findByText("Sort").click();
+
+    // Sorts ascending by default
+    popover()
+      .contains("Revenue")
+      .click();
+
+    // Let's make sure it's possible to sort descending as well
+    cy.icon("arrow_up").click();
+
+    cy.icon("arrow_down")
+      .parent()
+      .contains("Revenue");
+
+    // Visualize results:
+    // It will render line chart by default. Switch to the table.
+    cy.button("Visualize").click();
+    cy.icon("table2").click();
+
+    cy.findAllByRole("grid").as("table");
+    cy.get("@table")
+      .first()
+      .as("tableHeader")
+      .within(() => {
+        cy.get(".cellData")
+          .eq(1)
+          .invoke("text")
+          .should("eq", "Revenue");
+      });
+
+    cy.get("@table")
+      .last()
+      .as("tableBody")
+      .within(() => {
+        cy.get(".cellData")
+          .eq(1)
+          .invoke("text")
+          .should("eq", "50,072.98");
+      });
   });
 
   describe("with no metrics", () => {


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Reproduces #8283

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/admin/datamodel/metrics.cy.spec.js`
- All tests should pass

### Additional notes:
- The bug was fixed in #18429

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/137384447-80b318bf-a98e-40bd-b901-dcf5bd37ee7a.png)

