### PR TITLE
CI with GitHub Actions: another bump in the unit tests timeout

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -78,7 +78,7 @@ jobs:
 
   fe-tests-unit:
     runs-on: ubuntu-20.04
-    timeout-minutes: 12
+    timeout-minutes: 14
     steps:
     - uses: actions/checkout@v2
     - name: Prepare Node.js


### PR DESCRIPTION
Looks like more tests are being added and a timeout of 12 minutes is barely adequate.
Source: occasional failures on master CI.