### PR TITLE
Custom expression editor: use lexical-based highlighting

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -426,6 +426,7 @@ export default class ExpressionEditorTextfield extends React.Component {
           style={{ ...inputStyle, paddingLeft: 26, whiteSpace: "pre-wrap" }}
           placeholder={placeholder}
           value={source}
+          startRule={this.props.startRule}
           parserOptions={this._getParserOptions()}
           onChange={e => this.onExpressionChange(e.target.value)}
           onKeyDown={this.onInputKeyDown}

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -139,7 +139,7 @@ export default class ExpressionEditorTextfield extends React.Component {
       const parserOptions = this._getParserOptions(newProps);
       const source = format(newProps.expression, parserOptions);
 
-      const { expression, compileError, syntaxTree } =
+      const { expression, compileError } =
         source && source.length
           ? this._processSource({
               source,
@@ -149,14 +149,12 @@ export default class ExpressionEditorTextfield extends React.Component {
               expression: null,
               tokenizerError: [],
               compileError: null,
-              syntaxTree: null,
             };
       this.setState({
         source,
         expression,
         tokenizeError: [],
         compileError,
-        syntaxTree,
         suggestions: [],
         highlightedSuggestionIndex: 0,
       });
@@ -319,13 +317,7 @@ export default class ExpressionEditorTextfield extends React.Component {
     const endsWithWhitespace = /\s$/.test(source);
     const targetOffset = !hasSelection ? selectionEnd : null;
 
-    const {
-      expression,
-      compileError,
-      suggestions,
-      helpText,
-      syntaxTree,
-    } = source
+    const { expression, compileError, suggestions, helpText } = source
       ? this._processSource({
           source,
           targetOffset,
@@ -336,7 +328,6 @@ export default class ExpressionEditorTextfield extends React.Component {
           compileError: null,
           suggestions: [],
           helpText: null,
-          syntaxTree: null,
         };
 
     const isValid = expression !== undefined;
@@ -385,7 +376,6 @@ export default class ExpressionEditorTextfield extends React.Component {
     this.setState({
       source,
       expression,
-      syntaxTree,
       tokenizerError,
       compileError,
       displayError: null,
@@ -406,7 +396,7 @@ export default class ExpressionEditorTextfield extends React.Component {
 
   render() {
     const { placeholder } = this.props;
-    const { displayError, source, suggestions, syntaxTree } = this.state;
+    const { displayError, source, suggestions } = this.state;
 
     const inputClassName = cx("input text-bold text-monospace", {
       "text-dark": source,
@@ -436,7 +426,6 @@ export default class ExpressionEditorTextfield extends React.Component {
           style={{ ...inputStyle, paddingLeft: 26, whiteSpace: "pre-wrap" }}
           placeholder={placeholder}
           value={source}
-          syntaxTree={syntaxTree}
           parserOptions={this._getParserOptions()}
           onChange={e => this.onExpressionChange(e.target.value)}
           onKeyDown={this.onInputKeyDown}

--- a/frontend/src/metabase/query_builder/components/expressions/TokenizedExpression.css
+++ b/frontend/src/metabase/query_builder/components/expressions/TokenizedExpression.css
@@ -1,20 +1,20 @@
 /* DIMENSION */
-.Expression-dimension > .Expression-identifier {
+.Expression-dimension {
   color: var(--color-brand);
 }
 
 /* METRIC */
-.Expression-metric > .Expression-identifier {
+.Expression-metric {
   color: var(--color-accent1);
 }
 
 /* SEGMENT */
-.Expression-segment > .Expression-identifier {
+.Expression-segment {
   color: var(--color-accent2);
 }
 
 /* UNKNOWN IDENTIFIER */
-.Expression-unknown > .Expression-identifier {
+.Expression-identifier {
   color: var(--color-text-medium);
 }
 
@@ -25,15 +25,15 @@
 
 /* AGGREGATION */
 .Expression-aggregation > .Expression-function-name,
-.Expression-aggregation > .Expression-group > .Expression-open-paren,
-.Expression-aggregation > .Expression-group > .Expression-close-paren {
+.Expression-aggregation > .Expression-open-paren,
+.Expression-aggregation > .Expression-close-paren {
   color: var(--color-accent1);
 }
 
 /* BOOLEAN (FILTER) FUNCTION */
 .Expression-boolean > .Expression-function-name,
-.Expression-boolean > .Expression-group > .Expression-open-paren,
-.Expression-boolean > .Expression-group > .Expression-close-paren {
+.Expression-boolean > .Expression-open-paren,
+.Expression-boolean > .Expression-close-paren {
   color: var(--color-accent2);
 }
 

--- a/frontend/src/metabase/query_builder/components/expressions/TokenizedExpression.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/TokenizedExpression.jsx
@@ -30,7 +30,8 @@ function mapTokenType(token) {
 }
 
 function createSpans(source) {
-  const isFunction = name => FUNCTIONS.has(getMBQLName(name));
+  const isFunction = name =>
+    name.toLowerCase() === "case" || FUNCTIONS.has(getMBQLName(name));
   const { tokens } = tokenize(source);
   let lastPos = 0;
   const spans = [];

--- a/frontend/src/metabase/query_builder/components/expressions/TokenizedExpression.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/TokenizedExpression.jsx
@@ -5,37 +5,73 @@ import "./TokenizedExpression.css";
 
 import cx from "classnames";
 
-export default class TokenizedExpression extends React.Component {
-  render() {
-    const { syntaxTree, source } = this.props;
-    if (syntaxTree) {
-      return renderSyntaxTree(syntaxTree);
-    } else {
-      if (source && source.length > 0) {
-        return <span className="Expression-node">{source}</span>;
-      } else {
-        // <br> is inserted to workaround Firefox caret position issue
-        return (
-          <span className="Expression-node">
-            <br />
-          </span>
-        );
-      }
-    }
+import { tokenize, TOKEN, OPERATOR } from "metabase/lib/expressions/tokenizer";
+
+function mapTokenType(token) {
+  const { type, op } = token;
+  switch (type) {
+    case TOKEN.Operator:
+      return op === OPERATOR.OpenParenthesis
+        ? "open-paren"
+        : op === OPERATOR.CloseParenthesis
+        ? "close-paren"
+        : "operator";
+    case TOKEN.Number:
+      return "number-literal";
+    case TOKEN.String:
+      return "string-literal";
+    case TOKEN.Identifier:
+      // FIXME function-name vs metric vs dimension vs segment
+      return "segment";
+    default:
+      return ""; // fallback
   }
 }
 
-const renderSyntaxTree = (node, index) => (
-  <span
-    key={index}
-    className={cx("Expression-node", "Expression-" + node.type, {
-      "Expression-tokenized": node.tokenized,
-    })}
-  >
-    {node.text != null
-      ? node.text
-      : node.children
-      ? node.children.map(renderSyntaxTree)
-      : null}
-  </span>
-);
+function createSpans(source) {
+  const { tokens } = tokenize(source);
+  let lastPos = 0;
+  const spans = [];
+  tokens.forEach(token => {
+    const str = source.substring(lastPos, token.start);
+    if (str.length > 0) {
+      spans.push({
+        kind: "whitespace",
+        text: str,
+      });
+    }
+    spans.push({
+      kind: mapTokenType(token),
+      text: source.substring(token.start, token.end),
+    });
+    lastPos = token.end;
+  });
+  const tail = source.substring(lastPos);
+  if (tail.length > 0) {
+    spans.push({
+      kind: "whitespace",
+      text: tail,
+    });
+  }
+  return spans;
+}
+
+export default class TokenizedExpression extends React.Component {
+  render() {
+    const { source } = this.props;
+    const spans = createSpans(source);
+    const topLevel = "boolean"; // FIXME aggregation
+    return (
+      <span className={cx(`Expression-node`, `Expression-${topLevel}`)}>
+        {spans.map(({ kind, text }, index) => (
+          <span
+            key={index}
+            className={cx(`Expression-node`, `Expression-${kind}`)}
+          >
+            {text}
+          </span>
+        ))}
+      </span>
+    );
+  }
+}

--- a/frontend/src/metabase/query_builder/components/expressions/TokenizedInput.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/TokenizedInput.jsx
@@ -140,11 +140,7 @@ class TokenizedInput extends Component {
     const restore = saveSelection(inputNode);
 
     inputNode.innerHTML = ReactDOMServer.renderToStaticMarkup(
-      <TokenizedExpression
-        source={this._getValue()}
-        syntaxTree={this.props.syntaxTree}
-        parserOptions={this.props.parserOptions}
-      />,
+      <TokenizedExpression source={this._getValue()} />,
     );
 
     if (document.activeElement === inputNode) {
@@ -192,7 +188,6 @@ TokenizedInput.propTypes = {
   onKeyDown: PropTypes.func,
   parserOptions: PropTypes.object,
   style: PropTypes.object,
-  syntaxTree: PropTypes.object,
   tokenizedEditing: PropTypes.bool,
   value: PropTypes.string,
 };

--- a/frontend/src/metabase/query_builder/components/expressions/TokenizedInput.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/TokenizedInput.jsx
@@ -140,7 +140,10 @@ class TokenizedInput extends Component {
     const restore = saveSelection(inputNode);
 
     inputNode.innerHTML = ReactDOMServer.renderToStaticMarkup(
-      <TokenizedExpression source={this._getValue()} />,
+      <TokenizedExpression
+        source={this._getValue()}
+        startRule={this.props.startRule}
+      />,
     );
 
     if (document.activeElement === inputNode) {
@@ -190,4 +193,5 @@ TokenizedInput.propTypes = {
   style: PropTypes.object,
   tokenizedEditing: PropTypes.bool,
   value: PropTypes.string,
+  startRule: PropTypes.string,
 };


### PR DESCRIPTION
This reduces the memory pressure since the spans (for the contentEditable) will be flat (before, they construct a tree).

It doesn't completely solve #16094, but it does provide some noticeable performance improvements. Moreover, this offers another step towards eliminating the dependency on the syntax tree (and hence, the parser) on the UI-side of custom expression.

To experiment with it, follow the steps in #16094:

**To Reproduce**
1. Ask a question, Custom question
2. Sample Dataset, Reviews table
3. Filter, Custom Expression
4. Type (or better: copy + paste) `contains([Product → Vendor], "Lorem ipsum dolor sit amet") OR` repeatedly

![image](https://user-images.githubusercontent.com/7288/137554523-186c3b8d-9269-4ef4-bca1-4ee41dc796e0.png)

**Another illustration**
1. Ask a question, Custom question
2. Sample Dataset, Products table
3. Custom Column, and type `case([Category] = "test", 1, 2)`
4. Open DevTools and select the custom expression with the element Inspector

_Before this PR:_

The tokens in the expression are represented by a number of `<span>` in a tree (which can be quite deep):

![image](https://user-images.githubusercontent.com/7288/137555573-9aacc9a5-bb60-469e-8c03-e9c2016a92cf.png)

_After this PR:_

The tokens in the expression are represented by a number of `<span>` in a flat list:

![image](https://user-images.githubusercontent.com/7288/137555326-eec8fec8-0bf4-4a66-9c7d-258146bade5a.png)
