### PR TITLE
Make EE audit app frontend display error if queries fail

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/audit_app/containers/QuestionLoadAndDisplay.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/containers/QuestionLoadAndDisplay.jsx
@@ -41,7 +41,7 @@ const QuestionLoadAndDisplay = ({
         return (
           <LoadingAndErrorWrapper
             loading={shouldShowLoader}
-            error={error}
+            error={error || resultProps?.result?.error}
             noWrapper
           >
             <Visualization {...props} {...resultProps} />


### PR DESCRIPTION
Pursuant to #18124. EE audit app current behavior is silently failing with "No Results" if queries fail. This annoys me personally occasionally so here's a 1-liner to fix it so that it will display QP error if queries fail.