### PR TITLE
Remove deprecated e2e helper `createNativeQuestion`

### DIFF
--- a/frontend/test/__support__/e2e/helpers/e2e-deprecated-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-deprecated-helpers.js
@@ -17,19 +17,6 @@ export function createBasicAlert({ firstAlert, includeNormal } = {}) {
   cy.findByText("Let's set up your alert").should("not.exist");
 }
 
-export function createNativeQuestion(name, query) {
-  return cy.request("POST", "/api/card", {
-    name,
-    dataset_query: {
-      type: "native",
-      native: { query },
-      database: 1,
-    },
-    display: "table",
-    visualization_settings: {},
-  });
-}
-
 export function setupLocalHostEmail() {
   // Email info
   cy.findByPlaceholderText("smtp.yourservice.com").type("localhost");

--- a/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
@@ -3,7 +3,6 @@ import {
   modal,
   popover,
   filterWidget,
-  createNativeQuestion,
   showDashboardCardActions,
 } from "__support__/e2e/cypress";
 
@@ -65,77 +64,55 @@ describe("scenarios > dashboard > dashboard drill", () => {
   });
 
   it("should insert values from hidden column on custom destination URL click through (metabase#13927)", () => {
-    cy.log("Create a question");
+    const questionDetails = {
+      name: "13927",
+      native: { query: "SELECT PEOPLE.STATE, PEOPLE.CITY from PEOPLE;" },
+    };
 
-    createNativeQuestion(
-      "13927",
-      `SELECT PEOPLE.STATE, PEOPLE.CITY from PEOPLE;`,
-    ).then(({ body: { id: QUESTION_ID } }) => {
-      cy.createDashboard().then(({ body: { id: DASHBOARD_ID } }) => {
-        cy.log("Add question to the dashboard");
+    const clickBehavior = {
+      "table.cell_column": "CITY",
+      "table.pivot_column": "STATE",
+      column_settings: {
+        '["name","CITY"]': {
+          click_behavior: {
+            type: "link",
+            linkType: "url",
+            linkTextTemplate:
+              "Click to find out which state does {{CITY}} belong to.",
+            linkTemplate: "/test/{{STATE}}",
+          },
+        },
+      },
+      "table.columns": [
+        {
+          name: "STATE",
+          fieldRef: ["field", "STATE", { "base-type": "type/Text" }],
+          enabled: false,
+        },
+        {
+          name: "CITY",
+          fieldRef: ["field", "CITY", { "base-type": "type/Text" }],
+          enabled: true,
+        },
+      ],
+    };
 
-        cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
-          cardId: QUESTION_ID,
-        }).then(({ body: { id: DASH_CARD_ID } }) => {
-          cy.log("Set card parameters");
+    cy.createNativeQuestionAndDashboard({ questionDetails }).then(
+      ({ body: dashboardCard }) => {
+        const { dashboard_id } = dashboardCard;
 
-          cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}/cards`, {
-            cards: [
-              {
-                id: DASH_CARD_ID,
-                card_id: QUESTION_ID,
-                row: 0,
-                col: 0,
-                sizeX: 6,
-                sizeY: 8,
-                series: [],
-                visualization_settings: {
-                  "table.cell_column": "CITY",
-                  "table.pivot_column": "STATE",
-                  column_settings: {
-                    '["name","CITY"]': {
-                      click_behavior: {
-                        type: "link",
-                        linkType: "url",
-                        linkTextTemplate:
-                          "Click to find out which state does {{CITY}} belong to.",
-                        linkTemplate: "/test/{{STATE}}",
-                      },
-                    },
-                  },
-                  "table.columns": [
-                    {
-                      name: "STATE",
-                      fieldRef: [
-                        "field",
-                        "STATE",
-                        { "base-type": "type/Text" },
-                      ],
-                      enabled: false,
-                    },
-                    {
-                      name: "CITY",
-                      fieldRef: ["field", "CITY", { "base-type": "type/Text" }],
-                      enabled: true,
-                    },
-                  ],
-                },
-                parameter_mappings: [],
-              },
-            ],
-          });
+        cy.editDashboardCard(dashboardCard, {
+          visualization_settings: clickBehavior,
         });
 
-        cy.visit(`/dashboard/${DASHBOARD_ID}`);
+        cy.visit(`/dashboard/${dashboard_id}`);
+      },
+    );
 
-        cy.findByText(
-          "Click to find out which state does Rye belong to.",
-        ).click();
+    cy.findByText("Click to find out which state does Rye belong to.").click();
 
-        cy.log("Reported failing on v0.37.2");
-        cy.location("pathname").should("eq", "/test/CO");
-      });
-    });
+    cy.log("Reported failing on v0.37.2");
+    cy.location("pathname").should("eq", "/test/CO");
   });
 
   it("should insert data from the correct row in the URL for pivot tables (metabase#17920)", () => {

--- a/frontend/test/metabase/scenarios/question/nested.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nested.cy.spec.js
@@ -1,7 +1,6 @@
 import {
   restore,
   popover,
-  createNativeQuestion,
   openOrdersTable,
   remapDisplayValueToFK,
   visitQuestionAdhoc,
@@ -196,11 +195,16 @@ describe("scenarios > question > nested", () => {
   });
 
   it.skip("should show all filter options for a nested question (metabase#13186)", () => {
-    cy.log("Create and save native question Q1");
+    const nativeQuestionDetails = {
+      name: "13816_Q1",
+      native: {
+        query: "SELECT * FROM PRODUCTS",
+      },
+    };
 
-    createNativeQuestion("13816_Q1", "SELECT * FROM PRODUCTS").then(
+    cy.createNativeQuestion(nativeQuestionDetails).then(
       ({ body: { id: Q1_ID } }) => {
-        cy.log("Convert it to `query` and save as Q2");
+        cy.log("Convert Q1 to `query` and save as Q2");
         cy.createQuestion({
           name: "13816_Q2",
           query: {
@@ -223,7 +227,8 @@ describe("scenarios > question > nested", () => {
 
     // Add filter to the dashboard...
     cy.icon("filter").click();
-    cy.findByText("Other Categories").click();
+    cy.findByText("Text or Category").click();
+    cy.findByText("Dropdown").click();
     // ...and try to connect it to the question
     cy.findByText("Select…").click();
 

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -1,5 +1,4 @@
 import {
-  createNativeQuestion,
   restore,
   openOrdersTable,
   openProductsTable,
@@ -267,8 +266,15 @@ describe("scenarios > question > notebook", () => {
 
     it("should join on field literals", () => {
       // create two native questions
-      createNativeQuestion("question a", "select 'foo' as a_column");
-      createNativeQuestion("question b", "select 'foo' as b_column");
+      cy.createNativeQuestion({
+        name: "question a",
+        native: { query: "select 'foo' as a_column" },
+      });
+
+      cy.createNativeQuestion({
+        name: "question b",
+        native: { query: "select 'foo' as b_column" },
+      });
 
       // start a custom question with question a
       cy.visit("/question/new");


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Removes the deprecated e2e helper `createNativeQuestion` and refactors the existing tests that were using it
- Use Cypress custom command `cy.createNativeQuestion` instead