### PR TITLE
Normalize field refs in viz settings, rework column ordering approach, and expand test coverage

### DIFF
--- a/shared/src/metabase/shared/models/visualization_settings.cljc
+++ b/shared/src/metabase/shared/models/visualization_settings.cljc
@@ -422,8 +422,8 @@
 (def ^:private db->norm-table-columns-keys
   {:name     ::table-column-name
    ; for now, do not translate the value of this key (the field vector)
-   :fieldRef ::table-column-field-ref
    :fieldref ::table-column-field-ref
+   :fieldRef ::table-column-field-ref
    :enabled  ::table-column-enabled})
 
 (def ^:private norm->db-table-columns-keys

--- a/shared/src/metabase/shared/models/visualization_settings.cljc
+++ b/shared/src/metabase/shared/models/visualization_settings.cljc
@@ -423,6 +423,7 @@
   {:name     ::table-column-name
    ; for now, do not translate the value of this key (the field vector)
    :fieldRef ::table-column-field-ref
+   :fieldref ::table-column-field-ref
    :enabled  ::table-column-enabled})
 
 (def ^:private norm->db-table-columns-keys

--- a/src/metabase/api/dataset.clj
+++ b/src/metabase/api/dataset.clj
@@ -21,7 +21,8 @@
             [metabase.util :as u]
             [metabase.util.i18n :refer [trs tru]]
             [metabase.util.schema :as su]
-            [schema.core :as s]))
+            [schema.core :as s]
+            [metabase.mbql.normalize :as normalize]))
 
 ;;; -------------------------------------------- Running a Query Normally --------------------------------------------
 
@@ -106,8 +107,12 @@
   {query                  su/JSONString
    visualization_settings su/JSONString
    export-format          ExportFormat}
+  (def my-query query)
+  (def my-viz-settings visualization_settings)
   (let [query        (json/parse-string query keyword)
-        viz-settings (mb.viz/db->norm (json/parse-string visualization_settings viz-setting-key-fn))
+        viz-settings (-> (json/parse-string visualization_settings viz-setting-key-fn)
+                         (update-in [:table.columns] normalize/normalize)
+                         mb.viz/db->norm)
         query        (-> (assoc query
                                 :async? true
                                 :viz-settings viz-settings)

--- a/src/metabase/api/dataset.clj
+++ b/src/metabase/api/dataset.clj
@@ -6,6 +6,7 @@
             [compojure.core :refer [POST]]
             [metabase.api.common :as api]
             [metabase.events :as events]
+            [metabase.mbql.normalize :as normalize]
             [metabase.mbql.schema :as mbql.s]
             [metabase.models.card :refer [Card]]
             [metabase.models.database :as database :refer [Database]]
@@ -21,8 +22,7 @@
             [metabase.util :as u]
             [metabase.util.i18n :refer [trs tru]]
             [metabase.util.schema :as su]
-            [schema.core :as s]
-            [metabase.mbql.normalize :as normalize]))
+            [schema.core :as s]))
 
 ;;; -------------------------------------------- Running a Query Normally --------------------------------------------
 
@@ -107,8 +107,6 @@
   {query                  su/JSONString
    visualization_settings su/JSONString
    export-format          ExportFormat}
-  (def my-query query)
-  (def my-viz-settings visualization_settings)
   (let [query        (json/parse-string query keyword)
         viz-settings (-> (json/parse-string visualization_settings viz-setting-key-fn)
                          (update-in [:table.columns] normalize/normalize)

--- a/src/metabase/query_processor/streaming.clj
+++ b/src/metabase/query_processor/streaming.clj
@@ -33,25 +33,25 @@
        cols
        (mbql.u/uniquify-names (map :name cols))))
 
-(defn- field-ref->map-key
-  "Converts the field-ref of a column to a vector that is used for lookups in the `cols-index` map in
-  `export-column-order`.
+; (defn- field-ref->map-key
+;   "Converts the field-ref of a column to a vector that is used for lookups in the `cols-index` map in
+;   `export-column-order`.
 
-  This key is similar to the original field-ref, but should only contain the minimum amount of information necessary to
-  uniquely identify a field, while omitting extra metadata.
+;   This key is similar to the original field-ref, but should only contain the minimum amount of information necessary to
+;   uniquely identify a field, while omitting extra metadata.
 
-  TODO: It would be better if we could use the entire field-ref directly as the map key, or use a separate identifier.
-  The issue currently is that `table-columns` is passed down from the frontend for unsaved cards (in the viz settings)
-  and has to be parsed from JSON, so some fields in metadata might be strings instead of keywords."
-  [field-ref]
-  (let [field-ref-first-part (keyword (first field-ref))
-        key-first-part       (if (= :aggregation field-ref-first-part)
-                               :aggregation
-                               ;; Convert the deprecated :field-id to :field so that it matches the field refs in `cols` (#18382)
-                               :field)]
-    (if-let [join-alias (:join-alias (last field-ref))]
-      [key-first-part (second field-ref) {:join-alias join-alias}]
-      [key-first-part (second field-ref)])))
+;   TODO: It would be better if we could use the entire field-ref directly as the map key, or use a separate identifier.
+;   The issue currently is that `table-columns` is passed down from the frontend for unsaved cards (in the viz settings)
+;   and has to be parsed from JSON, so some fields in metadata might be strings instead of keywords."
+;   [field-ref]
+;   (let [field-ref-first-part (keyword (first field-ref))
+;         key-first-part       (if (= :aggregation field-ref-first-part)
+;                                :aggregation
+;                                ;; Convert the deprecated :field-id to :field so that it matches the field refs in `cols` (#18382)
+;                                :field)]
+;     (if-let [join-alias (:join-alias (last field-ref))]
+;       [key-first-part (second field-ref) {:join-alias join-alias}]
+;       [key-first-part (second field-ref)])))
 
 (defn- export-column-order
   "For each entry in `table-columns` that is enabled, finds the index of the corresponding
@@ -59,6 +59,10 @@
 
   The resulting list of indices determines the order of column names and data in exports."
   [cols table-columns]
+  (def my-cols cols)
+  (comment (clojure.pprint/pprint my-cols))
+  (def my-table-columns table-columns)
+  (comment (clojure.pprint/pprint my-table-columns))
   (let [table-columns'     (or table-columns
                                ;; If table-columns is not provided (e.g. for saved cards), we can construct a fake one
                                ;; that retains the original column ordering in `cols`
@@ -71,12 +75,12 @@
         cols-vector        (into [] cols)
         ;; cols-index is a map from keys representing fields to their indices into `cols`
         cols-index         (reduce-kv (fn [m i col]
-                                        ;; Always add [:field col-name] as a key, so that native queries,
+                                        ;; Always add col-name as a key, so that native queries,
                                         ;; remapped fields, and old fields using :field-literal work correctly (#18382)
-                                        (let [m' (assoc m [:field (:name col)] i)]
+                                        (let [m' (assoc m (:name col) i)]
                                           (if-let [field-ref (:field_ref col)]
                                             ;; Add a map key based on the column's field-ref, if available
-                                            (assoc m' (field-ref->map-key field-ref) i)
+                                            (assoc m' field-ref i)
 
                                             ;; Otherwise construct a key using the id of the column, if available
                                             (if (:id col)
@@ -85,16 +89,17 @@
                                       {}
                                       cols-vector)]
     (->> (map
-          (fn [{field-ref ::mb.viz/table-column-field-ref}]
-            (let [index         (get cols-index (field-ref->map-key field-ref))
-                  col           (get cols-vector index)
-                  remapped-to   (:remapped_to col)
-                  remapped-from (:remapped_from col)]
+          (fn [{field-ref ::mb.viz/table-column-field-ref, col-name ::mb.viz/table-column-name}]
+            (let [index              (or (get cols-index field-ref)
+                                         (get cols-index col-name))
+                  col                (get cols-vector index)
+                  remapped-to-name   (:remapped_to col)
+                  remapped-from-name (:remapped_from col)]
               (cond
-                remapped-to
-                (get cols-index [:field remapped-to])
+                remapped-to-name
+                (get cols-index remapped-to-name)
 
-                (not remapped-from)
+                (not remapped-from-name)
                 index)))
           enabled-table-cols)
          (remove nil?))))
@@ -113,6 +118,8 @@
 
 (defn- streaming-rff [results-writer]
   (fn [{:keys [cols viz-settings] :as initial-metadata}]
+    (def my-viz-settings viz-settings)
+    (comment (clojure.pprint/pprint my-viz-settings))
     (let [[ordered-cols output-order] (order-cols cols viz-settings)
           viz-settings'               (assoc viz-settings :output-order output-order)
           row-count                   (volatile! 0)]

--- a/src/metabase/query_processor/streaming.clj
+++ b/src/metabase/query_processor/streaming.clj
@@ -91,8 +91,6 @@
 
 (defn- streaming-rff [results-writer]
   (fn [{:keys [cols viz-settings] :as initial-metadata}]
-    (def my-viz-settings viz-settings)
-    (comment (clojure.pprint/pprint my-viz-settings))
     (let [[ordered-cols output-order] (order-cols cols viz-settings)
           viz-settings'               (assoc viz-settings :output-order output-order)
           row-count                   (volatile! 0)]

--- a/src/metabase/query_processor/streaming.clj
+++ b/src/metabase/query_processor/streaming.clj
@@ -33,59 +33,32 @@
        cols
        (mbql.u/uniquify-names (map :name cols))))
 
-; (defn- field-ref->map-key
-;   "Converts the field-ref of a column to a vector that is used for lookups in the `cols-index` map in
-;   `export-column-order`.
-
-;   This key is similar to the original field-ref, but should only contain the minimum amount of information necessary to
-;   uniquely identify a field, while omitting extra metadata.
-
-;   TODO: It would be better if we could use the entire field-ref directly as the map key, or use a separate identifier.
-;   The issue currently is that `table-columns` is passed down from the frontend for unsaved cards (in the viz settings)
-;   and has to be parsed from JSON, so some fields in metadata might be strings instead of keywords."
-;   [field-ref]
-;   (let [field-ref-first-part (keyword (first field-ref))
-;         key-first-part       (if (= :aggregation field-ref-first-part)
-;                                :aggregation
-;                                ;; Convert the deprecated :field-id to :field so that it matches the field refs in `cols` (#18382)
-;                                :field)]
-;     (if-let [join-alias (:join-alias (last field-ref))]
-;       [key-first-part (second field-ref) {:join-alias join-alias}]
-;       [key-first-part (second field-ref)])))
-
 (defn- export-column-order
   "For each entry in `table-columns` that is enabled, finds the index of the corresponding
   entry in `cols` by name or id. If a col has been remapped, uses the index of the new column.
 
   The resulting list of indices determines the order of column names and data in exports."
   [cols table-columns]
-  (def my-cols cols)
-  (comment (clojure.pprint/pprint my-cols))
-  (def my-table-columns table-columns)
-  (comment (clojure.pprint/pprint my-table-columns))
   (let [table-columns'     (or table-columns
                                ;; If table-columns is not provided (e.g. for saved cards), we can construct a fake one
                                ;; that retains the original column ordering in `cols`
                                (for [col cols]
-                                 (let [id-or-name (or (:id col) (:name col))
+                                 (let [col-name   (:name col)
+                                       id-or-name (or (:id col) col-name)
                                        field-ref  (:field_ref col)]
                                    {::mb.viz/table-column-field-ref (or field-ref [:field id-or-name nil])
-                                    ::mb.viz/table-column-enabled true})))
+                                    ::mb.viz/table-column-enabled true
+                                    ::mb.viz/table-column-name col-name})))
         enabled-table-cols (filter ::mb.viz/table-column-enabled table-columns')
         cols-vector        (into [] cols)
         ;; cols-index is a map from keys representing fields to their indices into `cols`
         cols-index         (reduce-kv (fn [m i col]
-                                        ;; Always add col-name as a key, so that native queries,
-                                        ;; remapped fields, and old fields using :field-literal work correctly (#18382)
+                                        ;; Always add col-name as a key, so that native queries and remapped fields work correctly
                                         (let [m' (assoc m (:name col) i)]
                                           (if-let [field-ref (:field_ref col)]
                                             ;; Add a map key based on the column's field-ref, if available
                                             (assoc m' field-ref i)
-
-                                            ;; Otherwise construct a key using the id of the column, if available
-                                            (if (:id col)
-                                              (assoc m' [:field (:id col)] i)
-                                              m'))))
+                                            m')))
                                       {}
                                       cols-vector)]
     (->> (map

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -417,9 +417,9 @@
       (mt/with-temp Card [card]
         (is (= nil
                (do
-               (mt/user-http-request :rasta :put 202 (str "card/" (u/the-id card)) {:cache_ttl 1234})
-               (mt/user-http-request :rasta :put 202 (str "card/" (u/the-id card)) {:cache_ttl nil})
-               (:cache_ttl (mt/user-http-request :rasta :get 200 (str "card/" (u/the-id card)))))))))))
+                (mt/user-http-request :rasta :put 202 (str "card/" (u/the-id card)) {:cache_ttl 1234})
+                (mt/user-http-request :rasta :put 202 (str "card/" (u/the-id card)) {:cache_ttl nil})
+                (:cache_ttl (mt/user-http-request :rasta :get 200 (str "card/" (u/the-id card)))))))))))
 
 (defn- fingerprint-integers->doubles
   "Converts the min/max fingerprint values to doubles so simulate how the FE will change the metadata when POSTing a

--- a/test/metabase/api/embed_test.clj
+++ b/test/metabase/api/embed_test.clj
@@ -174,7 +174,8 @@
 
 ;;; ------------------------- GET /api/embed/card/:token/query (and JSON/CSV/XLSX variants) --------------------------
 
-(defn- card-query-url [card response-format & [additional-token-params]]
+(defn card-query-url [card response-format & [additional-token-params]]
+  "Generate a query URL for an embedded card"
   (str "embed/card/"
        (card-token card additional-token-params)
        "/query"

--- a/test/metabase/query_processor/streaming/xlsx_test.clj
+++ b/test/metabase/query_processor/streaming/xlsx_test.clj
@@ -225,6 +225,10 @@
 ;;; |                                               XLSX export tests                                                |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
+;; These are tests that generate an XLSX binary and then parse and assert on its contents, to test logic and value
+;; formatting that is specific to the XLSX format. These do NOT test any of the column ordering logic in
+;; `metabase.query-processor.streaming`, or anything that happens in the API handlers for generating exports.
+
 (defn- parse-cell-content
   [sheet]
   (for [row (spreadsheet/into-seq sheet)]

--- a/test/metabase/query_processor/streaming_test.clj
+++ b/test/metabase/query_processor/streaming_test.clj
@@ -269,6 +269,8 @@
                   :time-ltz       #inst "1899-12-31T23:23:18.000-00:00"
                   :time-tz        #inst "1899-12-31T23:23:18.000-00:00"})))))))))
 
+
+
 (deftest export-column-order-test
   (testing "correlation of columns by field ref"
     (is (= [0 1]

--- a/test/metabase/query_processor/streaming_test.clj
+++ b/test/metabase/query_processor/streaming_test.clj
@@ -270,6 +270,22 @@
                   :time-tz        #inst "1899-12-31T23:23:18.000-00:00"})))))))))
 
 
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                             Export E2E tests                                                   |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+;;; This section contains helper functions and tests that call export APIs to generate XLSX, CSV and JSON results,
+;;; and assert on the results. These tests should generally be for ensuring that specific types of queries or
+;;; behaviors work across all endpoints that generate exports. Tests that are specific to single endpoints
+;;; (like `/api/dataset/:format`) should go in the corresponding test namespaces for those files
+;;; (like `metabase.api.dataset-test`).
+;;; TODO: migrate the test cases above to use these functions, if possible
+
+
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                        Streaming logic unit tests                                              |
+;;; +----------------------------------------------------------------------------------------------------------------+
 
 (deftest export-column-order-test
   (testing "correlation of columns by field ref"

--- a/test/metabase/query_processor/streaming_test.clj
+++ b/test/metabase/query_processor/streaming_test.clj
@@ -442,7 +442,7 @@
                    [{:name "ID", :fieldRef [:field (mt/id :venues :id) nil], :enabled true}
                     {:name "NAME", :fieldRef [:field (mt/id :venues :name) nil], :enabled true}
                     {:name "CATEGORY_ID", :fieldRef [:field (mt/id :venues :category_id) nil], :enabled true}
-                    {:name "NAME_2", :fieldRef [:field (mt/id :categories :id) {:join-alias "Categories"}], :enabled true}]}
+                    {:name "NAME_2", :fieldRef [:field (mt/id :categories :name) {:join-alias "Categories"}], :enabled true}]}
 
     :assertions {:csv (fn [results]
                         (is (= [["ID" "Name" "Category ID" "Categories → Name"]

--- a/test/metabase/query_processor/streaming_test.clj
+++ b/test/metabase/query_processor/streaming_test.clj
@@ -343,13 +343,7 @@
                  :query    {:source-table (mt/id :venues)
                             :limit 2}}
 
-    :assertions {:api (fn [results]
-                        (is (= [["ID" "Name" "Category ID" "Latitude" "Longitude" "Price"]
-                                ["1" "Red Medicine" "4" "10.0646" "-165.374" "3"]
-                                ["2" "Stout Burgers & Beers" "11" "34.0996" "-118.329" "2"]]
-                               results)))
-
-                 :csv (fn [results]
+    :assertions {:csv (fn [results]
                         (is (= [["ID" "Name" "Category ID" "Latitude" "Longitude" "Price"]
                                 ["1" "Red Medicine" "4" "10.0646" "-165.374" "3"]
                                 ["2" "Stout Burgers & Beers" "11" "34.0996" "-118.329" "2"]]

--- a/test/metabase/query_processor/streaming_test.clj
+++ b/test/metabase/query_processor/streaming_test.clj
@@ -439,10 +439,10 @@
 
     :viz-settings {:column_settings {},
                    :table.columns
-                   [{:name "ID", :fieldRef ["field" 52 nil], :enabled true}
-                    {:name "NAME", :fieldRef ["field" 51 nil], :enabled true}
-                    {:name "CATEGORY_ID", :fieldRef ["field" 48 nil], :enabled true}
-                    {:name "NAME_2", :fieldRef [:field 37 {:join-alias "Categories"}], :enabled true}]}
+                   [{:name "ID", :fieldRef [:field (mt/id :venues :id) nil], :enabled true}
+                    {:name "NAME", :fieldRef [:field (mt/id :venues :name) nil], :enabled true}
+                    {:name "CATEGORY_ID", :fieldRef [:field (mt/id :venues :category_id) nil], :enabled true}
+                    {:name "NAME_2", :fieldRef [:field (mt/id :categories :id) {:join-alias "Categories"}], :enabled true}]}
 
     :assertions {:csv (fn [results]
                         (is (= [["ID" "Name" "Category ID" "Categories → Name"]


### PR DESCRIPTION
* Revises our approach to column ordering in exports: field refs in viz settings are normalized using the MBQL normalization function, and then used directly as map keys when correlating columns to determine export order.
* Adds a new helper function in `metabase.query-processor.streaming-test` that allows us to run a single e2e test case for all three export formats (xlsx, json and csv) and across multiple APIs that can be used for exports (dataset, card, embed, public).
* Adds a number of e2e tests for common export cases. This is not exhaustive but hopefully at least kickstarts our backend test coverage for this area.

Resolves #18382 and #18450