### PR TITLE
Fix calculation in `ttl-hierarchy`

### DIFF
--- a/frontend/test/metabase/scenarios/admin/settings/cache.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/cache.cy.spec.js
@@ -15,7 +15,7 @@ describe("scenarios > admin > settings > cache", () => {
     cy.signInAsAdmin();
   });
 
-  describe("'issue 18458", () => {
+  describe("issue 18458", () => {
     beforeEach(() => {
       cy.visit("/admin/settings/caching");
 

--- a/frontend/test/metabase/scenarios/admin/settings/cache.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/cache.cy.spec.js
@@ -15,7 +15,7 @@ describe("scenarios > admin > settings > cache", () => {
     cy.signInAsAdmin();
   });
 
-  describe.skip("issue 18458", () => {
+  describe("'issue 18458", () => {
     beforeEach(() => {
       cy.visit("/admin/settings/caching");
 

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -675,7 +675,7 @@
   (when (public-settings/enable-query-caching)
     (let [ttls (map :cache_ttl [card dashboard database])
           most-granular-ttl (first (filter some? ttls))]
-      (or (when (some? most-granular-ttl) ; stored TTLs are in hours; convert to seconds
+      (or (when most-granular-ttl ; stored TTLs are in hours; convert to seconds
             (* most-granular-ttl 3600))
           (query-magic-ttl query)))))
 

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -668,11 +668,15 @@
         ttl-seconds))))
 
 (defn- ttl-hierarchy
+  "Returns the cache ttl (in seconds), by first checking whether there is a stored value for the database,
+  dashboard, or card (in that order of increasing preference), and if all of those don't exist, then the
+  `query-magic-ttl`, which is based on average execution time."
   [card dashboard database query]
   (when (public-settings/enable-query-caching)
     (let [ttls (map :cache_ttl [card dashboard database])
           most-granular-ttl (first (filter some? ttls))]
-      (or most-granular-ttl
+      (or (when (some? most-granular-ttl) ; stored TTLs are in hours; convert to seconds
+            (* most-granular-ttl 3600))
           (query-magic-ttl query)))))
 
 (defn query-for-card
@@ -687,9 +691,7 @@
                              :middleware  middleware))
         dashboard (db/select-one [Dashboard :cache_ttl] :id (:dashboard-id ids))
         database  (db/select-one [Database :cache_ttl] :id (:database_id card))
-        ttl       (ttl-hierarchy card dashboard database query)
-        ;; Stored TTL's are in hours: query wants seconds
-        ttl-secs  (if (nil? ttl) nil (* 3600 ttl))]
+        ttl-secs  (ttl-hierarchy card dashboard database query)]
     (assoc query :cache-ttl ttl-secs)))
 
 (defn run-query-for-card-async


### PR DESCRIPTION
The `ttl-hierarchy` function falls back to `query-magic-ttl` if no stored (card, dashboard, database) cache settings are available.  But that function returns its TTL value in milliseconds, while the model level, granular TTLs are stored in hours.  Convert those to seconds before returning, so that `ttl-hierarchy` is always returning in seconds

Add backend test for this scenario (no stored model ttls, but an average query execution time is available, and hence the `query-magic-ttl` should be used)

Unskip Cypress repro