### PR TITLE
Fix missing card descriptions

### DIFF
--- a/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
+++ b/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
@@ -283,7 +283,7 @@ export default class LineAreaBarChart extends Component {
     } = this.props;
 
     const title = settings["card.title"] || card.name;
-    const description = series["card.description"];
+    const description = settings["card.description"];
 
     const rawSeries = series._raw || series;
     const cardIds = new Set(rawSeries.map(s => s.card.id));

--- a/frontend/src/metabase/visualizations/components/legend/LegendCaption.jsx
+++ b/frontend/src/metabase/visualizations/components/legend/LegendCaption.jsx
@@ -39,7 +39,7 @@ const LegendCaption = ({
       </LegendLabel>
       {description && (
         <Tooltip tooltip={description} maxWidth="22em">
-          <LegendDescriptionIcon />
+          <LegendDescriptionIcon className="hover-child" />
         </Tooltip>
       )}
       {actionButtons && <LegendActions>{actionButtons}</LegendActions>}

--- a/frontend/src/metabase/visualizations/components/legend/LegendCaption.styled.jsx
+++ b/frontend/src/metabase/visualizations/components/legend/LegendCaption.styled.jsx
@@ -12,6 +12,7 @@ export const LegendLabel = styled.div`
   color: ${colors["text-dark"]};
   font-weight: bold;
   cursor: ${({ onClick }) => (onClick ? "pointer" : "")};
+  overflow: hidden;
 
   &:hover {
     color: ${({ onClick }) => (onClick ? colors["brand"] : "")};

--- a/frontend/test/__support__/e2e/commands/api/question.js
+++ b/frontend/test/__support__/e2e/commands/api/question.js
@@ -25,6 +25,7 @@ Cypress.Commands.add(
  *
  * @param {object} questionDetails
  * @param {string} [questionDetails.name="test question"]
+ * @param {string} questionDetails.description
  * @param {object} questionDetails.native
  * @param {object} questionDetails.query
  * @param {number} [questionDetails.database=1]
@@ -41,6 +42,7 @@ function question(
   type,
   {
     name = "test question",
+    description,
     native,
     query,
     database = 1,
@@ -53,6 +55,7 @@ function question(
 ) {
   cy.request("POST", "/api/card", {
     name,
+    description,
     dataset_query: {
       type,
       [type]: type === "native" ? native : query,

--- a/frontend/test/metabase/scenarios/dashboard/reproductions/18454-card-description.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/reproductions/18454-card-description.cy.spec.js
@@ -1,0 +1,56 @@
+import { restore } from "__support__/e2e/cypress";
+
+import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
+
+const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATASET;
+
+const CARD_DESCRIPTION = "CARD_DESCRIPTION";
+
+describe("issue 18454", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should show card descriptions (metabase#18454)", () => {
+    createDashboardWithQuestionWithDescription();
+
+    cy.wait("@cardQuery");
+    cy.icon("info").realHover();
+    cy.findByText(CARD_DESCRIPTION);
+  });
+});
+
+function createDashboardWithQuestionWithDescription() {
+  const questionDetails = {
+    name: "18454 Question",
+    description: CARD_DESCRIPTION,
+    query: {
+      "source-table": PRODUCTS_ID,
+      aggregation: [["count"]],
+      breakout: [["field", PRODUCTS.CATEGORY, null]],
+    },
+    display: "pie",
+  };
+
+  cy.createQuestionAndDashboard({ questionDetails }).then(
+    ({ body: { id, card_id, dashboard_id } }) => {
+      cy.request("PUT", `/api/dashboard/${dashboard_id}/cards`, {
+        cards: [
+          {
+            id,
+            card_id,
+            row: 0,
+            col: 0,
+            sizeX: 12,
+            sizeY: 10,
+          },
+        ],
+      });
+
+      cy.visit(`/dashboard/${dashboard_id}`);
+
+      cy.intercept("POST", `/api/card/${card_id}/query`).as("cardQuery");
+    },
+  );
+}

--- a/frontend/test/metabase/scenarios/dashboard/reproductions/18454-card-description.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/reproductions/18454-card-description.cy.spec.js
@@ -30,7 +30,7 @@ function createDashboardWithQuestionWithDescription() {
       aggregation: [["count"]],
       breakout: [["field", PRODUCTS.CATEGORY, null]],
     },
-    display: "pie",
+    display: "line",
   };
 
   cy.createQuestionAndDashboard({ questionDetails }).then(


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/18454

### How to verify
- Add a question that has a description to a dashboard
- Open the dashboard
- Ensure the `info` visible, ensure it shows the question description on hover

### Screenshot

<img width="706" alt="Screen Shot 2021-10-15 at 23 53 00" src="https://user-images.githubusercontent.com/14301985/137552203-6c584ea9-ccc6-4915-83d9-b8b19f8a5128.png">

