### PR TITLE
#18476 Repro: Visible columns list in table options sidebar does not respect renamed columns

### DIFF
--- a/frontend/test/metabase/scenarios/question/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/settings.cy.spec.js
@@ -4,6 +4,7 @@ import {
   openOrdersTable,
   visitQuestionAdhoc,
   popover,
+  sidebar,
 } from "__support__/e2e/cypress";
 
 import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
@@ -171,6 +172,34 @@ describe("scenarios > question > settings", () => {
         .click(); // open created_at column header actions
       popover().within(() => cy.icon("gear").click()); // open created_at column settings
       cy.findByText("Date style"); // shows created_at column settings
+    });
+
+    it.skip("should respect renamed column names in the settings sidebar (metabase#18476)", () => {
+      const newColumnTitle = "Pre-tax";
+
+      const questionDetails = {
+        dataset_query: {
+          database: 1,
+          query: { "source-table": 2 },
+          type: "query",
+        },
+        display: "table",
+        visualization_settings: {
+          column_settings: {
+            [`["ref",["field",${ORDERS.SUBTOTAL},null]]`]: {
+              column_title: newColumnTitle,
+            },
+          },
+        },
+      };
+
+      visitQuestionAdhoc(questionDetails);
+
+      cy.findByText(newColumnTitle);
+
+      cy.findByTestId("viz-settings-button").click();
+
+      sidebar().findByText(newColumnTitle);
     });
   });
 


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #18476

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/question/settings.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/137596505-9d578090-96ea-479e-ae1b-46054e99ac56.png)

