### PR TITLE
#18502 Repro: Cannot join two saved questions based on the same table

### DIFF
--- a/frontend/test/metabase/scenarios/question/reproductions/18502-cannot-join-two-saved-questions-same-table.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/18502-cannot-join-two-saved-questions-same-table.cy.spec.js
@@ -1,0 +1,55 @@
+import { restore, popover } from "__support__/e2e/cypress";
+import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
+
+const { PEOPLE, PEOPLE_ID } = SAMPLE_DATASET;
+
+const question1 = getQuestionDetails("18502#1", PEOPLE.CREATED_AT);
+const question2 = getQuestionDetails("18502#2", PEOPLE.BIRTH_DATE);
+
+describe.skip("issue 18502", () => {
+  beforeEach(() => {
+    cy.intercept("POST", "/api/dataset").as("dataset");
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should be able to join two saved questions based on the same table (metabase#18502)", () => {
+    cy.createQuestion(question1);
+    cy.createQuestion(question2);
+
+    cy.visit("/question/new");
+    cy.findByText("Custom question").click();
+    cy.findByText("Saved Questions").click();
+
+    cy.findByText("18502#1").click();
+    cy.icon("join_left_outer").click();
+
+    popover().within(() => {
+      cy.findByText("Sample Dataset").click();
+      cy.findByText("Saved Questions").click();
+      cy.findByText("18502#2").click();
+    });
+
+    cy.findByText("Created At").click();
+    cy.findByText("Birth Date").click();
+
+    cy.button("Visualize").click();
+
+    cy.wait("@dataset").then(({ response }) => {
+      expect(response.body.error).to.not.exist;
+    });
+
+    cy.findByText("April, 2016");
+  });
+});
+
+function getQuestionDetails(name, breakoutColumn) {
+  return {
+    name,
+    query: {
+      "source-table": PEOPLE_ID,
+      aggregation: [["count"]],
+      breakout: [["field", breakoutColumn, { "temporal-unit": "month" }]],
+    },
+  };
+}


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #18502

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/question/reproductions/18502-cannot-join-two-saved-questions-same-table.cy.spec.js`
- Unskip the test
- It should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/137597609-15fe2cbf-166a-4e86-af60-725213e9d258.png)

