### PR TITLE
#18317 Repro: Audit > Questions > Total runtime displays link instead of an actual time

### DIFF
--- a/frontend/test/metabase/scenarios/admin/audit/questions-audit.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/audit/questions-audit.cy.spec.js
@@ -70,6 +70,20 @@ describeWithToken("audit > auditing > questions", () => {
       cy.get("tbody > tr").should("have.length", 1);
       cy.findByText("My question");
     });
+
+    it.skip("should display total runtime correctly (metabase#18317)", () => {
+      const runtimeIndex = 4;
+
+      cy.visit("/admin/audit/questions/all");
+
+      cy.get("th")
+        .eq(runtimeIndex)
+        .should("contain", "Total Runtime (ms)");
+
+      cy.get("td")
+        .eq(runtimeIndex)
+        .should("not.contain", "Link");
+    });
   });
 });
 


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #18317 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/admin/audit/questions-audit.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/137640223-2eb4958b-097b-4fb7-807a-ddf2e833aeb2.png)

