### PR TITLE
#17767 Repro: Summarizing with implicit join does not allow subsequent joins

### DIFF
--- a/frontend/test/metabase/scenarios/question/reproductions/17767-cannot-join-on-aggregation-with-implicit-joins.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/17767-cannot-join-on-aggregation-with-implicit-joins.cy.spec.js
@@ -1,0 +1,51 @@
+import { restore, popover } from "__support__/e2e/cypress";
+import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
+
+const { ORDERS, ORDERS_ID, PRODUCTS } = SAMPLE_DATASET;
+
+const questionDetails = {
+  name: "17767",
+  query: {
+    "source-table": ORDERS_ID,
+    aggregation: [["count"]],
+    breakout: [["field", PRODUCTS.ID, { "source-field": ORDERS.PRODUCT_ID }]],
+  },
+};
+
+describe.skip("issue 17767", () => {
+  beforeEach(() => {
+    cy.intercept("POST", "/api/dataset").as("dataset");
+
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should be able to do subsequent joins on question with the aggregation that uses implicit joins (metabase#17767)", () => {
+    cy.createQuestion(questionDetails, { visitQuestion: true });
+
+    cy.icon("notebook").click();
+
+    cy.findByText("Join data").click();
+
+    // Join "Previous results" with
+    popover()
+      .contains("Reviews")
+      .click();
+
+    // On
+    popover()
+      .contains("ID")
+      .click();
+    // =
+    popover()
+      .contains(/Products? ID/)
+      .click();
+
+    cy.button("Visualize").click();
+    cy.wait("@dataset").then(({ response }) => {
+      expect(response.body.error).not.to.exist;
+    });
+
+    cy.findByText("xavier");
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #17767

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/question/reproductions/17767-cannot-join-on-aggregation-with-implicit-joins.cy.spec.js`
- Unskip the test
- It should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/137640937-803a222f-d622-426e-8923-0e179318f89e.png)

