### PR TITLE
Create E2E `visualize` (notebook results) helper

### DIFF
--- a/frontend/test/__support__/e2e/helpers/e2e-notebook-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-notebook-helpers.js
@@ -11,3 +11,20 @@
 export function getNotebookStep(type, { stage = 0, index = 0 } = {}) {
   return cy.findByTestId(`step-${type}-${stage}-${index}`);
 }
+
+/**
+ * Visualize notebook query results.
+ *
+ * @param {function} callback
+ */
+export function visualize(callback) {
+  cy.intercept("POST", "/api/dataset").as("dataset");
+
+  cy.button("Visualize").click();
+
+  cy.wait("@dataset").then(({ response }) => {
+    if (callback) {
+      callback(response);
+    }
+  });
+}

--- a/frontend/test/metabase/scenarios/admin/datamodel/metrics.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/metrics.cy.spec.js
@@ -3,6 +3,7 @@ import {
   popover,
   modal,
   openOrdersTable,
+  visualize,
 } from "__support__/e2e/cypress";
 import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
 
@@ -49,9 +50,8 @@ describe("scenarios > admin > datamodel > metrics", () => {
       .parent()
       .contains("Revenue");
 
-    // Visualize results:
-    // It will render line chart by default. Switch to the table.
-    cy.button("Visualize").click();
+    visualize();
+    // Visualization will render line chart by default. Switch to the table.
     cy.icon("table2").click();
 
     cy.findAllByRole("grid").as("table");

--- a/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
@@ -1,6 +1,7 @@
 import {
   restore,
   popover,
+  visualize,
   openOrdersTable,
   visitQuestionAdhoc,
 } from "__support__/e2e/cypress";
@@ -225,7 +226,7 @@ describe("binning related reproductions", () => {
           cy.findByText("10 bins").click();
         });
 
-      cy.button("Visualize").click();
+      visualize();
       cy.get(".bar");
     });
   });

--- a/frontend/test/metabase/scenarios/binning/qb-explicit-joins.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/qb-explicit-joins.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, popover } from "__support__/e2e/cypress";
+import { restore, popover, visualize } from "__support__/e2e/cypress";
 import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
 
 const {
@@ -294,11 +294,7 @@ function chooseBucketAndAssert({
       cy.findByText(bucketSize).click();
     });
 
-  if (mode === "notebook") {
-    cy.button("Visualize").click();
-  }
-
-  waitAndAssertOnRequest("@dataset");
+  mode === "notebook" ? visualize() : waitAndAssertOnRequest("@dataset");
 
   const visualizaitonSelector = columnType === "time" ? "circle" : ".bar";
   cy.get(visualizaitonSelector);

--- a/frontend/test/metabase/scenarios/binning/qb-implicit-joins.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/qb-implicit-joins.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, popover } from "__support__/e2e/cypress";
+import { restore, popover, visualize } from "__support__/e2e/cypress";
 
 describe("scenarios > binning > from a saved QB question using implicit joins", () => {
   beforeEach(() => {
@@ -159,10 +159,7 @@ function chooseBucketAndAssert({
       cy.findByText(bucketSize).click();
     });
 
-  if (mode === "notebook") {
-    cy.button("Visualize").click();
-  }
-  waitAndAssertOnRequest("@dataset");
+  mode === "notebook" ? visualize() : waitAndAssertOnRequest("@dataset");
 
   cy.findByText(title);
   cy.get(".cellData")

--- a/frontend/test/metabase/scenarios/binning/qb-regular-table.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/qb-regular-table.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, openTable } from "__support__/e2e/cypress";
+import { restore, openTable, visualize } from "__support__/e2e/cypress";
 import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
 
 const { ORDERS_ID, PEOPLE_ID } = SAMPLE_DATASET;
@@ -161,7 +161,8 @@ function chooseInitialBinningOption({
       .click();
 
     cy.findByText(bucketSize).click();
-    cy.button("Visualize").click();
+
+    visualize();
   } else {
     cy.findByTestId("sidebar-right")
       .contains(column)

--- a/frontend/test/metabase/scenarios/binning/sql.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/sql.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, popover } from "__support__/e2e/cypress";
+import { restore, popover, visualize } from "__support__/e2e/cypress";
 
 const questionDetails = {
   name: "SQL Binning",
@@ -104,9 +104,11 @@ describe("scenarios > binning > from a saved sql question", () => {
       cy.findByText("Year").click();
 
       cy.findByText("Count by CREATED_AT: Year");
-      cy.button("Visualize").click();
 
-      waitAndAssertOnRequest("@dataset");
+      visualize(response => {
+        assertOnResponse(response);
+      });
+
       cy.get("circle");
     });
 
@@ -117,9 +119,11 @@ describe("scenarios > binning > from a saved sql question", () => {
       cy.findByText("50 bins").click();
 
       cy.findByText("Count by TOTAL: 50 bins");
-      cy.button("Visualize").click();
 
-      waitAndAssertOnRequest("@dataset");
+      visualize(response => {
+        assertOnResponse(response);
+      });
+
       cy.get(".bar");
     });
 
@@ -137,9 +141,11 @@ describe("scenarios > binning > from a saved sql question", () => {
       cy.findByText("10°").click();
 
       cy.findByText("Count by LONGITUDE: 10°");
-      cy.button("Visualize").click();
 
-      waitAndAssertOnRequest("@dataset");
+      visualize(response => {
+        assertOnResponse(response);
+      });
+
       cy.get(".bar");
     });
   });
@@ -215,7 +221,11 @@ function assertOnXYAxisLabels({ xLabel, yLabel } = {}) {
 }
 
 function waitAndAssertOnRequest(requestAlias) {
-  cy.wait(requestAlias).then(xhr => {
-    expect(xhr.response.body.error).to.not.exist;
+  cy.wait(requestAlias).then(({ response }) => {
+    assertOnResponse(response);
   });
+}
+
+function assertOnResponse(response) {
+  expect(response.body.error).to.not.exist;
 }

--- a/frontend/test/metabase/scenarios/custom-column/custom-column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/custom-column.cy.spec.js
@@ -1,6 +1,7 @@
 import {
   restore,
   popover,
+  visualize,
   openOrdersTable,
   visitQuestionAdhoc,
   enterCustomColumnDetails,
@@ -25,8 +26,7 @@ describe("scenarios > question > custom column", () => {
     enterCustomColumnDetails({ formula: "1 + 1", name: "Math" });
     cy.button("Done").click();
 
-    cy.button("Visualize").click();
-    cy.wait("@dataset");
+    visualize();
 
     cy.findByText("There was a problem with your question").should("not.exist");
     cy.get(".Visualization").contains("Math");
@@ -51,8 +51,7 @@ describe("scenarios > question > custom column", () => {
       enterCustomColumnDetails({ formula, name });
       cy.button("Done").click();
 
-      cy.button("Visualize").click();
-      cy.wait("@dataset");
+      visualize();
 
       cy.get(".Visualization").contains(name);
     });
@@ -92,8 +91,7 @@ describe("scenarios > question > custom column", () => {
     });
     cy.button("Done").click();
 
-    cy.button("Visualize").click();
-    cy.wait("@dataset");
+    visualize();
 
     cy.findByText("There was a problem with your question").should("not.exist");
     // This is a pre-save state of the question but the column name should appear
@@ -330,9 +328,10 @@ describe("scenarios > question > custom column", () => {
       .should("not.exist");
     cy.button("Visualize").click();
 
-    cy.wait("@dataset").then(xhr => {
-      expect(xhr.response.body.error).to.not.exist;
+    visualize(response => {
+      expect(response.body.error).to.not.exist;
     });
+
     cy.contains("37.65");
   });
 
@@ -417,10 +416,11 @@ describe("scenarios > question > custom column", () => {
       name: "No discount",
     });
     cy.button("Done").click();
-    cy.button("Visualize").click();
-    cy.wait("@dataset").then(xhr => {
-      expect(xhr.response.body.error).to.not.exist;
+
+    visualize(response => {
+      expect(response.body.error).to.not.exist;
     });
+
     cy.contains("37.65");
     cy.findByText("No discount");
   });
@@ -446,10 +446,11 @@ describe("scenarios > question > custom column", () => {
     cy.findByText("Days").click();
     cy.findByText("Years").click();
     cy.button("Add filter").click();
-    cy.button("Visualize").click();
-    cy.wait("@dataset").then(interception => {
-      expect(interception.response.body.error).not.to.exist;
+
+    visualize(response => {
+      expect(response.body.error).to.not.exist;
     });
+
     cy.findByText("MiscDate");
   });
 });

--- a/frontend/test/metabase/scenarios/custom-column/custom-column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/custom-column.cy.spec.js
@@ -110,11 +110,7 @@ describe("scenarios > question > custom column", () => {
     enterCustomColumnDetails({ formula: "1 + 1", name: "x" });
     cy.button("Done").click();
 
-    cy.button("Visualize").click();
-
-    // wait for results to load
-    cy.get(".LoadingSpinner").should("not.exist");
-    cy.button("Visualize").should("not.exist");
+    visualize();
 
     cy.log(
       "**Fails in 0.35.0, 0.35.1, 0.35.2, 0.35.4 and the latest master (2020-10-21)**",
@@ -326,7 +322,6 @@ describe("scenarios > question > custom column", () => {
     cy.get("[class*=NotebookCellItem]")
       .contains(CE_NAME)
       .should("not.exist");
-    cy.button("Visualize").click();
 
     visualize(response => {
       expect(response.body.error).to.not.exist;

--- a/frontend/test/metabase/scenarios/custom-column/reproductions/13289-cc-post-aggregation-zoom-in.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/reproductions/13289-cc-post-aggregation-zoom-in.cy.spec.js
@@ -3,6 +3,7 @@ import {
   openOrdersTable,
   popover,
   enterCustomColumnDetails,
+  visualize,
 } from "__support__/e2e/cypress";
 
 const CC_NAME = "Math";
@@ -40,8 +41,7 @@ describe("issue 13289", () => {
       cy.findByText("Created At").click();
     });
 
-    cy.button("Visualize").click();
-    cy.wait("@dataset");
+    visualize();
 
     cy.get(".Visualization").within(() => {
       cy.get("circle")

--- a/frontend/test/metabase/scenarios/custom-column/reproductions/13751-cc-allow-strings-in-filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/reproductions/13751-cc-allow-strings-in-filter.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, popover } from "__support__/e2e/cypress";
+import { restore, popover, visualize } from "__support__/e2e/cypress";
 
 const CC_NAME = "C-States";
 const PG_DB_NAME = "QA Postgres12";
@@ -45,7 +45,8 @@ describe("issue 13751", () => {
         .click();
     });
 
-    cy.button("Visualize").click();
+    visualize();
+
     cy.findByText("Arnold Adams");
   });
 });

--- a/frontend/test/metabase/scenarios/custom-column/reproductions/14843-cc-apply-filter-not-equal-to.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/reproductions/14843-cc-apply-filter-not-equal-to.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, popover } from "__support__/e2e/cypress";
+import { restore, popover, visualize } from "__support__/e2e/cypress";
 import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
 
 const { PEOPLE, PEOPLE_ID } = SAMPLE_DATASET;
@@ -36,8 +36,7 @@ describe("issue 14843", () => {
     cy.findByPlaceholderText("Enter a number").type("3");
     cy.button("Add filter").click();
 
-    cy.button("Visualize").click();
-    cy.wait("@dataset");
+    visualize();
 
     cy.findByText(`${CC_NAME} is not equal to 3`);
     cy.findByText("Rye").should("not.exist");

--- a/frontend/test/metabase/scenarios/custom-column/reproductions/18069-cc-sum-aggregation-dimension-type.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/reproductions/18069-cc-sum-aggregation-dimension-type.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, popover } from "__support__/e2e/cypress";
+import { restore, popover, visualize } from "__support__/e2e/cypress";
 
 import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
 
@@ -20,8 +20,6 @@ const questionDetails = {
 
 describe("issue 18069", () => {
   beforeEach(() => {
-    cy.intercept("POST", "/api/dataset").as("dataset");
-
     restore();
     cy.signInAsAdmin();
 
@@ -49,8 +47,8 @@ describe("issue 18069", () => {
       cy.findByText("CC_ScaledRating").click();
     });
 
-    cy.button("Visualize").click();
-    cy.wait("@dataset");
+    visualize();
+
     cy.findByText("1,041.45");
   });
 });

--- a/frontend/test/metabase/scenarios/permissions/sandboxes.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/sandboxes.cy.spec.js
@@ -8,6 +8,7 @@ import {
   restore,
   remapDisplayValueToFK,
   setupSMTP,
+  visualize,
 } from "__support__/e2e/cypress";
 import { USER_GROUPS } from "__support__/e2e/cypress_data";
 
@@ -146,7 +147,8 @@ describeWithToken("formatting > sandboxes", () => {
         cy.findByText("Greater than").click();
         cy.findByPlaceholderText("Enter a number").type("100");
         cy.findByText("Add filter").click();
-        cy.button("Visualize").click();
+
+        visualize();
 
         cy.log("Make sure user is still sandboxed");
         cy.get(".TableInteractive-cellWrapper--firstColumn").should(
@@ -219,7 +221,8 @@ describeWithToken("formatting > sandboxes", () => {
           .click();
       });
 
-      cy.button("Visualize").click();
+      visualize();
+
       cy.findByText("Count by User → ID");
       cy.findByText("11"); // Sum of orders for user with ID #1
     });
@@ -776,10 +779,9 @@ describeWithToken("formatting > sandboxes", () => {
       cy.findByText("Count of rows").click();
       cy.findByText("Pick a column to group by").click();
       cy.findByText(/Products? → ID/).click();
-      cy.button("Visualize").click();
 
-      cy.wait("@dataset").then(xhr => {
-        expect(xhr.response.body.error).not.to.exist;
+      visualize(response => {
+        expect(response.body.error).to.not.exist;
       });
 
       // Number of products with ID = 1 (and ID = 19)

--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -7,6 +7,7 @@ import {
   popover,
   filterWidget,
   visitQuestionAdhoc,
+  visualize,
 } from "__support__/e2e/cypress";
 
 import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
@@ -214,9 +215,8 @@ describe("scenarios > question > filter", () => {
     cy.findByText("Add filter").click();
     cy.contains("Category is not Gizmo");
 
-    cy.button("Visualize").click();
-    // wait for results to load
-    cy.get(".LoadingSpinner").should("not.exist");
+    visualize();
+
     cy.log("The point of failure in 0.37.0-rc3");
     cy.contains("37.65");
     cy.findByText("There was a problem with your question").should("not.exist");
@@ -556,7 +556,8 @@ describe("scenarios > question > filter", () => {
       .click();
 
     // check that filter is applied and rows displayed
-    cy.button("Visualize").click();
+    visualize();
+
     cy.contains("Showing 1,112 rows");
   });
 
@@ -935,7 +936,8 @@ describe("scenarios > question > filter", () => {
         .parent()
         .find(".Icon-close")
         .click();
-      cy.button("Visualize");
+
+      visualize();
     });
   });
 
@@ -1012,7 +1014,8 @@ describe("scenarios > question > filter", () => {
           addBooleanFilter();
         });
 
-        cy.button("Visualize").click();
+        visualize();
+
         assertOnTheResult();
       });
 

--- a/frontend/test/metabase/scenarios/question/joins.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/joins.cy.spec.js
@@ -1,4 +1,9 @@
-import { restore, openOrdersTable, popover } from "__support__/e2e/cypress";
+import {
+  restore,
+  openOrdersTable,
+  popover,
+  visualize,
+} from "__support__/e2e/cypress";
 import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
 
 const { ORDERS, ORDERS_ID, PRODUCTS } = SAMPLE_DATASET;
@@ -44,9 +49,8 @@ describe("scenarios > question > joined questions", () => {
       .findByText("Product ID")
       .click();
 
-    cy.button("Visualize").click();
-    cy.wait("@dataset").then(xhr => {
-      expect(xhr.response.body.error).not.to.exist;
+    visualize(response => {
+      expect(response.body.error).to.not.exist;
     });
   });
 
@@ -64,8 +68,7 @@ describe("scenarios > question > joined questions", () => {
     selectFromDropdown("Created At");
     selectFromDropdown("Created At");
 
-    cy.button("Visualize").click();
-    cy.wait("@dataset");
+    visualize();
 
     // 415 rows mean the join is done correctly,
     // (join on product's FK + join on the same "created_at" field)
@@ -73,7 +76,6 @@ describe("scenarios > question > joined questions", () => {
   });
 
   it("should allow joins on date-time fields", () => {
-    cy.intercept("POST", "/api/dataset").as("dataset");
     openOrdersTable({ mode: "notebook" });
 
     joinTable("Products");
@@ -103,8 +105,7 @@ describe("scenarios > question > joined questions", () => {
     cy.findByText("Summarize").click();
     selectFromDropdown("Count of rows");
 
-    cy.button("Visualize").click();
-    cy.wait("@dataset");
+    visualize();
 
     // 2087 rows mean the join is done correctly,
     // (orders joined with products on the same day-month-year)
@@ -112,7 +113,6 @@ describe("scenarios > question > joined questions", () => {
   });
 
   it("should show 'Previous results' instead of a table name for non-field dimensions", () => {
-    cy.intercept("POST", "/api/dataset").as("dataset");
     openOrdersTable({ mode: "notebook" });
 
     cy.findByText("Summarize").click();

--- a/frontend/test/metabase/scenarios/question/nested.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nested.cy.spec.js
@@ -4,6 +4,7 @@ import {
   openOrdersTable,
   remapDisplayValueToFK,
   visitQuestionAdhoc,
+  visualize,
 } from "__support__/e2e/cypress";
 
 import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
@@ -571,7 +572,8 @@ describe("scenarios > question > nested", () => {
       cy.findByText("Pick a column to group by").click();
       cy.findByText("CAT").click();
 
-      cy.button("Visualize").click();
+      visualize();
+
       cy.get("@consoleWarn").should(
         "not.be.calledWith",
         "Removing invalid MBQL clause",
@@ -583,8 +585,8 @@ describe("scenarios > question > nested", () => {
       cy.findByText("Pick a column to group by").click();
       cy.findByText("CAT").click();
 
-      cy.button("Visualize").click();
-      cy.wait("@dataset");
+      visualize();
+
       cy.findAllByRole("button")
         .contains("Summarize")
         .click();

--- a/frontend/test/metabase/scenarios/question/new.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/new.cy.spec.js
@@ -2,6 +2,7 @@ import {
   browse,
   restore,
   popover,
+  visualize,
   openOrdersTable,
   openReviewsTable,
 } from "__support__/e2e/cypress";
@@ -71,7 +72,9 @@ describe("scenarios > question > new", () => {
         .click();
       cy.findByText("Rating").click();
     });
-    cy.button("Visualize").click();
+
+    visualize();
+
     cy.get(".Visualization .bar").should("have.length", 6);
   });
 
@@ -131,7 +134,8 @@ describe("scenarios > question > new", () => {
 
       it("should allow to search saved questions", () => {
         cy.findByText("Orders, Count").click();
-        cy.findByText("Visualize").click();
+
+        visualize();
         cy.findByText("18,760");
       });
 
@@ -140,7 +144,9 @@ describe("scenarios > question > new", () => {
           .closest("li")
           .findByText("Table in")
           .click();
-        cy.findByText("Visualize").click();
+
+        visualize();
+
         cy.url().should("include", "question#");
         cy.findByText("Sample Dataset");
         cy.findByText("Orders");
@@ -200,7 +206,9 @@ describe("scenarios > question > new", () => {
         cy.findByText("Orders, Count, Grouped by Created At (year)");
         cy.findByText("Orders");
         cy.findByText("Orders, Count").click();
-        cy.button("Visualize").click();
+
+        visualize();
+
         cy.findByText("18,760");
       });
 
@@ -214,7 +222,8 @@ describe("scenarios > question > new", () => {
         cy.findByText("Orders");
         cy.findByText("Orders, Count, Grouped by Created At (year)").click();
 
-        cy.button("Visualize").click();
+        visualize();
+
         cy.findByText("2016");
         cy.findByText("5,834");
       });
@@ -222,13 +231,17 @@ describe("scenarios > question > new", () => {
       it("should perform a search scoped to saved questions", () => {
         cy.findByPlaceholderText("Search for a question").type("Grouped");
         cy.findByText("Orders, Count, Grouped by Created At (year)").click();
-        cy.button("Visualize").click();
+
+        visualize();
+
         cy.findByText("2018");
       });
 
       it("should reopen saved question picker after returning back to editor mode", () => {
         cy.findByText("Orders, Count, Grouped by Created At (year)").click();
-        cy.button("Visualize").click();
+
+        visualize();
+
         cy.icon("notebook").click();
         cy.findByTestId("data-step-cell").click();
 
@@ -404,7 +417,9 @@ describe("scenarios > question > new", () => {
       cy.contains("Custom question").click();
       cy.contains("Sample Dataset").click();
       cy.contains("Orders").click();
-      cy.contains("Visualize").click();
+
+      visualize();
+
       cy.contains("37.65");
     });
 
@@ -419,7 +434,9 @@ describe("scenarios > question > new", () => {
         cy.findByPlaceholderText("Name (required)").type("twice max total");
         cy.findByText("Done").click();
       });
-      cy.button("Visualize").click();
+
+      visualize();
+
       cy.findByText("318.7");
     });
 

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -4,6 +4,7 @@ import {
   openProductsTable,
   popover,
   modal,
+  visualize,
   visitQuestionAdhoc,
   interceptPromise,
   getNotebookStep,
@@ -38,6 +39,7 @@ describe("scenarios > question > notebook", () => {
     cy.findByText("Not now").click();
     // enter "notebook" and visualize without changing anything
     cy.icon("notebook").click();
+
     cy.button("Visualize").click();
 
     // there were no changes to the question, so we shouldn't have the option to "Save"
@@ -66,7 +68,9 @@ describe("scenarios > question > notebook", () => {
       cy.get("input").type("46");
       cy.contains("Add filter").click();
     });
-    cy.contains("Visualize").click();
+
+    visualize();
+
     cy.contains("2372"); // user's id in the table
     cy.contains("Showing 1 row"); // ensure only one user was returned
   });
@@ -130,8 +134,7 @@ describe("scenarios > question > notebook", () => {
       cy.findByText("EXPR (2)");
     });
 
-    cy.button("Visualize").click();
-    cy.wait("@dataset");
+    visualize();
 
     cy.findByText("EXPR");
     cy.findByText("EXPR (1)");
@@ -176,7 +179,8 @@ describe("scenarios > question > notebook", () => {
     cy.button("Done")
       .should("not.be.disabled")
       .click();
-    cy.contains("Visualize").click();
+
+    visualize();
 
     cy.contains("Showing 99 rows");
 
@@ -225,7 +229,9 @@ describe("scenarios > question > notebook", () => {
       popover()
         .contains("Rating")
         .click();
-      cy.contains("Visualize").click();
+
+      visualize();
+
       cy.contains("Orders + Reviews");
       cy.contains("3");
     });
@@ -241,7 +247,9 @@ describe("scenarios > question > notebook", () => {
       cy.icon("join_left_outer ").click();
       cy.contains("People").click();
       cy.contains("Orders + People");
-      cy.contains("Visualize").click();
+
+      visualize();
+
       cy.contains("Showing first 2,000");
 
       cy.log("Attempt to filter on the joined table");
@@ -294,8 +302,7 @@ describe("scenarios > question > notebook", () => {
       popover().within(() => cy.findByText("A_COLUMN").click());
       popover().within(() => cy.findByText("B_COLUMN").click());
 
-      cy.button("Visualize").click();
-      cy.queryByText("Visualize").then($el => cy.wrap($el).should("not.exist")); // wait for that screen to disappear to avoid "multiple elements" errors
+      visualize();
 
       // check that query worked
       cy.findByText("question a + question b");
@@ -331,11 +338,9 @@ describe("scenarios > question > notebook", () => {
           .should("not.be.disabled")
           .click();
       });
-      cy.button("Visualize").click();
 
-      cy.wait("@cardQuery").then(xhr => {
-        expect(xhr.response.body.error).not.to.exist;
-      });
+      visualize();
+
       cy.findByText("Sum Divide");
     });
 
@@ -431,33 +436,34 @@ describe("scenarios > question > notebook", () => {
         },
       });
 
-      cy.server();
-      cy.route("POST", "/api/dataset").as("dataset");
-
       // Join two previously saved questions
       cy.visit("/");
       cy.findByText("Ask a question").click();
       cy.findByText("Custom question").click();
       cy.findByText("Saved Questions").click();
+
       cy.findByText("12928_Q1").click();
+
       cy.icon("join_left_outer").click();
+
       popover().within(() => {
         cy.findByText("Sample Dataset").click();
         cy.findByText("Saved Questions").click();
       });
       cy.findByText("12928_Q2").click();
+
       cy.contains(/Products? → Category/).click();
+
       popover()
         .contains(/Products? → Category/)
         .click();
-      cy.button("Visualize").click();
+
+      visualize();
+
+      cy.log("Reported failing in v1.35.4.1 and `master` on July, 16 2020");
 
       cy.findByText("12928_Q1 + 12928_Q2");
-      cy.log("Reported failing in v1.35.4.1 and `master` on July, 16 2020");
-      // TODO: Add a positive assertion once this issue is fixed
-      cy.wait("@dataset").then(xhr => {
-        expect(xhr.response.body.error).not.to.exist;
-      });
+      cy.findAllByText(/Products? → Category/).should("have.length", 2);
     });
 
     it.skip("should join saved question with sorted metric (metabase#13744)", () => {
@@ -734,7 +740,8 @@ describe("scenarios > question > notebook", () => {
         cy.findByText("Add filter").click();
       });
 
-      cy.button("Visualize").click();
+      visualize();
+
       cy.findByText("Gadget").should("exist");
       cy.findByText("Gizmo").should("not.exist");
 
@@ -775,7 +782,8 @@ describe("scenarios > question > notebook", () => {
         .should("not.be.disabled")
         .click();
 
-      cy.button("Visualize").click();
+      visualize();
+
       cy.contains("Example");
       cy.contains("Big");
       cy.contains("Small");
@@ -796,7 +804,8 @@ describe("scenarios > question > notebook", () => {
         .should("not.be.disabled")
         .click();
 
-      cy.button("Visualize").click();
+      visualize();
+
       cy.contains("Showing 97 rows");
     });
 
@@ -827,7 +836,8 @@ describe("scenarios > question > notebook", () => {
           .should("not.be.disabled")
           .click();
 
-        cy.button("Visualize").click();
+        visualize();
+
         cy.contains(filter);
         cy.contains(result);
       });
@@ -853,7 +863,6 @@ function joinTwoSavedQuestions() {
         "source-table": PRODUCTS_ID,
       },
     }).then(() => {
-      cy.intercept("POST", "/api/dataset").as("cardQuery");
       cy.visit(`/question/new`);
       cy.findByText("Custom question").click();
 
@@ -876,8 +885,7 @@ function joinTwoSavedQuestions() {
         .findByText("ID")
         .click();
 
-      cy.button("Visualize").click();
-      cy.wait("@cardQuery");
+      visualize();
 
       cy.icon("notebook").click();
       cy.url().should("contain", "/notebook");

--- a/frontend/test/metabase/scenarios/question/reproductions/13097-mongo-apply-distinct-count-multiple-columns.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/13097-mongo-apply-distinct-count-multiple-columns.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore } from "__support__/e2e/cypress";
+import { restore, visualize } from "__support__/e2e/cypress";
 
 const MONGO_DB_NAME = "QA Mongo4";
 
@@ -27,8 +27,7 @@ describe.skip("issue 13097", () => {
 
     cy.intercept("POST", "/api/dataset").as("dataset");
 
-    cy.button("Visualize").click();
-    cy.wait("@dataset");
+    visualize();
 
     cy.log("Reported failing on stats ~v0.36.3");
     cy.findAllByText("1,966").should("have.length", 1); // City

--- a/frontend/test/metabase/scenarios/question/reproductions/13468.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/13468.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, openOrdersTable } from "__support__/e2e/cypress";
+import { restore, openOrdersTable, visualize } from "__support__/e2e/cypress";
 
 describe("issue 13468", () => {
   beforeEach(() => {
@@ -13,7 +13,7 @@ describe("issue 13468", () => {
     cy.findByText("Join data").click();
     cy.findByText("Products").click();
 
-    visualizeResults();
+    visualize();
 
     saveQuestion();
 
@@ -22,11 +22,6 @@ describe("issue 13468", () => {
     cy.findByText("Filter by this value");
   });
 });
-
-function visualizeResults() {
-  cy.button("Visualize").click();
-  cy.wait("@dataset");
-}
 
 function saveQuestion() {
   cy.findByText("Save").click();

--- a/frontend/test/metabase/scenarios/question/reproductions/15342-mysql-correct-joins-order.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/15342-mysql-correct-joins-order.cy.spec.js
@@ -1,11 +1,9 @@
-import { restore, popover } from "__support__/e2e/cypress";
+import { restore, popover, visualize } from "__support__/e2e/cypress";
 
 const MYSQL_DB_NAME = "QA MySQL8";
 
 describe.skip("issue 15342", () => {
   beforeEach(() => {
-    cy.intercept("POST", "/api/dataset").as("query");
-
     restore("mysql-8");
     cy.signInAsAdmin();
 
@@ -32,8 +30,7 @@ describe.skip("issue 15342", () => {
       joinType: "inner",
     });
 
-    cy.button("Visualize").click();
-    cy.wait("@query");
+    visualize();
 
     cy.get(".Visualization").within(() => {
       cy.findByText("Email"); // from People table

--- a/frontend/test/metabase/scenarios/question/reproductions/17512.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/17512.cy.spec.js
@@ -1,4 +1,9 @@
-import { restore, openOrdersTable, popover } from "__support__/e2e/cypress";
+import {
+  restore,
+  openOrdersTable,
+  popover,
+  visualize,
+} from "__support__/e2e/cypress";
 
 describe.skip("issue 17512", () => {
   beforeEach(() => {
@@ -21,10 +26,8 @@ describe.skip("issue 17512", () => {
 
     addCustomColumn("1 + 1", "CC");
 
-    cy.button("Visualize").click();
-
-    cy.wait("@dataset").then(({ response }) => {
-      expect(response.body.error).not.to.exist;
+    visualize(response => {
+      expect(response.body.error).to.not.exist;
     });
 
     cy.findByText("CE");

--- a/frontend/test/metabase/scenarios/question/reproductions/17514-ui-overlay.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/17514-ui-overlay.cy.spec.js
@@ -4,6 +4,7 @@ import {
   filterWidget,
   saveDashboard,
   editDashboard,
+  visualize,
 } from "__support__/e2e/cypress";
 
 import { setAdHocFilter } from "../../native-filters/helpers/e2e-date-filter-helpers";
@@ -112,7 +113,7 @@ describe("issue 17514", () => {
 
       removeJoinedTable();
 
-      visualizeResults();
+      visualize();
 
       cy.findByText("Save").click();
 
@@ -127,7 +128,7 @@ describe("issue 17514", () => {
       cy.findByText("Join data").click();
       cy.findByText("Products").click();
 
-      visualizeResults();
+      visualize();
 
       // Cypress cannot click elements that are blocked by an overlay so this will immediately fail if the issue is not fixed
       cy.findByText("110.93").click();
@@ -153,11 +154,6 @@ function closeModal() {
   cy.get(".Modal").within(() => {
     cy.button("Done").click();
   });
-}
-
-function visualizeResults() {
-  cy.button("Visualize").click();
-  cy.wait("@dataset");
 }
 
 function openNotebookMode() {

--- a/frontend/test/metabase/scenarios/question/reproductions/17710-notebook-incomplete-joins-removed.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/17710-notebook-incomplete-joins-removed.cy.spec.js
@@ -1,4 +1,9 @@
-import { restore, popover, openOrdersTable } from "__support__/e2e/cypress";
+import {
+  restore,
+  popover,
+  openOrdersTable,
+  visualize,
+} from "__support__/e2e/cypress";
 
 describe("issue 17710", () => {
   beforeEach(() => {
@@ -19,7 +24,7 @@ describe("issue 17710", () => {
       cy.icon("add").click();
     });
 
-    visualizeResults();
+    visualize();
 
     cy.icon("notebook")
       .click()
@@ -31,8 +36,3 @@ describe("issue 17710", () => {
       });
   });
 });
-
-function visualizeResults() {
-  cy.button("Visualize").click();
-  cy.wait("@dataset");
-}

--- a/frontend/test/metabase/scenarios/question/reproductions/17767-cannot-join-on-aggregation-with-implicit-joins.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/17767-cannot-join-on-aggregation-with-implicit-joins.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, popover } from "__support__/e2e/cypress";
+import { restore, popover, visualize } from "__support__/e2e/cypress";
 import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
 
 const { ORDERS, ORDERS_ID, PRODUCTS } = SAMPLE_DATASET;
@@ -41,9 +41,8 @@ describe.skip("issue 17767", () => {
       .contains(/Products? ID/)
       .click();
 
-    cy.button("Visualize").click();
-    cy.wait("@dataset").then(({ response }) => {
-      expect(response.body.error).not.to.exist;
+    visualize(response => {
+      expect(response.body.error).to.not.exist;
     });
 
     cy.findByText("xavier");

--- a/frontend/test/metabase/scenarios/question/reproductions/17963-mongo-filter-expression-compare-two-fields.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/17963-mongo-filter-expression-compare-two-fields.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, popover } from "__support__/e2e/cypress";
+import { restore, popover, visualize } from "__support__/e2e/cypress";
 
 describe("issue 17963", () => {
   beforeEach(() => {
@@ -30,7 +30,7 @@ describe("issue 17963", () => {
     cy.findByText("Pick the metric you want to see").click();
     cy.findByText("Count of rows").click();
 
-    cy.button("Visualize").click();
+    visualize();
 
     cy.get(".ScalarValue").contains("1,337");
   });

--- a/frontend/test/metabase/scenarios/question/reproductions/18502-cannot-join-two-saved-questions-same-table.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/18502-cannot-join-two-saved-questions-same-table.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, popover } from "__support__/e2e/cypress";
+import { restore, popover, visualize } from "__support__/e2e/cypress";
 import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
 
 const { PEOPLE, PEOPLE_ID } = SAMPLE_DATASET;
@@ -33,9 +33,7 @@ describe.skip("issue 18502", () => {
     cy.findByText("Created At").click();
     cy.findByText("Birth Date").click();
 
-    cy.button("Visualize").click();
-
-    cy.wait("@dataset").then(({ response }) => {
+    visualize(response => {
       expect(response.body.error).to.not.exist;
     });
 

--- a/frontend/test/metabase/scenarios/question/reproductions/18512-cannot-join-two-saved-questions-with-same-implicit-explicit-grouped-field.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/18512-cannot-join-two-saved-questions-with-same-implicit-explicit-grouped-field.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, popover } from "__support__/e2e/cypress";
+import { restore, popover, visualize } from "__support__/e2e/cypress";
 import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
 
 const { PRODUCTS, PRODUCTS_ID, REVIEWS, REVIEWS_ID } = SAMPLE_DATASET;
@@ -38,9 +38,7 @@ describe.skip("issue 18512", () => {
       .findByText("Products → Created At")
       .click();
 
-    cy.button("Visualize").click();
-
-    cy.wait("@dataset").then(({ response }) => {
+    visualize(response => {
       expect(response.body.error).to.not.exist;
     });
 

--- a/frontend/test/metabase/scenarios/question/reproductions/4482-temporal-min-max.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/4482-temporal-min-max.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore } from "__support__/e2e/cypress";
+import { restore, visualize } from "__support__/e2e/cypress";
 
 describe("issue 4482", () => {
   beforeEach(() => {
@@ -21,8 +21,8 @@ describe("issue 4482", () => {
     cy.findByText("Rating");
     cy.contains("Created At").click();
 
-    cy.button("Visualize").click();
-    cy.wait("@dataset");
+    visualize();
+
     cy.findByText("April 1, 2016, 12:00 AM");
   });
 
@@ -39,8 +39,8 @@ describe("issue 4482", () => {
     cy.findByText("Rating");
     cy.contains("Created At").click();
 
-    cy.button("Visualize").click();
-    cy.wait("@dataset");
+    visualize();
+
     cy.findByText("April 1, 2019, 12:00 AM");
   });
 

--- a/frontend/test/metabase/scenarios/question/reproductions/6239.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/6239.cy.spec.js
@@ -1,4 +1,9 @@
-import { restore, popover, openOrdersTable } from "__support__/e2e/cypress";
+import {
+  restore,
+  popover,
+  openOrdersTable,
+  visualize,
+} from "__support__/e2e/cypress";
 
 describe("issue 6239", () => {
   beforeEach(() => {
@@ -29,7 +34,7 @@ describe("issue 6239", () => {
       .contains(/^CE$/)
       .click();
 
-    cy.button("Visualize").click();
+    visualize();
 
     // Line chart renders initially. Switch to the table view.
     cy.icon("table2").click();
@@ -52,7 +57,7 @@ describe("issue 6239", () => {
     cy.icon("arrow_up").should("not.exist");
     cy.icon("arrow_down");
 
-    cy.button("Visualize").click();
+    visualize();
 
     cy.get(".cellData")
       .eq(1)

--- a/frontend/test/metabase/scenarios/sharing/alert/alert.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/alert/alert.cy.spec.js
@@ -4,6 +4,7 @@ import {
   createBasicAlert,
   popover,
   openPeopleTable,
+  visualize,
 } from "__support__/e2e/cypress";
 
 // Ported from alert.e2e.spec.js
@@ -176,7 +177,8 @@ describe("scenarios > alert", () => {
         cy.findByPlaceholderText("Find...").type("Cr");
         cy.findByText("Created At").click();
       });
-      cy.button("Visualize").click();
+
+      visualize();
 
       // Set a goal
       setGoal("35");

--- a/frontend/test/metabase/scenarios/smoketest/admin.cy.spec.js
+++ b/frontend/test/metabase/scenarios/smoketest/admin.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, sidebar } from "__support__/e2e/cypress";
+import { restore, sidebar, visualize } from "__support__/e2e/cypress";
 import { USERS } from "__support__/e2e/cypress_data";
 
 const { admin } = USERS;
@@ -165,7 +165,8 @@ describe("metabase-smoketest > admin", () => {
 
       cy.findByText("Join data").click();
       cy.findByText("People").click();
-      cy.button("Visualize").click();
+
+      visualize();
 
       // Summarize by State
       cy.findAllByText("Summarize")

--- a/frontend/test/metabase/scenarios/smoketest/admin_setup.cy.spec.js
+++ b/frontend/test/metabase/scenarios/smoketest/admin_setup.cy.spec.js
@@ -5,6 +5,7 @@ import {
   setupLocalHostEmail,
   modal,
   openPeopleTable,
+  visualize,
 } from "__support__/e2e/cypress";
 import { USERS } from "__support__/e2e/cypress_data";
 
@@ -477,7 +478,8 @@ describe("smoketest > admin_setup", () => {
         .last()
         .click();
       cy.findByText("Add filter").click();
-      cy.button("Visualize").click();
+
+      visualize();
 
       cy.findAllByText("Awesome Concrete Shoes");
       cy.findByText("Mediocre Wooden Bench").should("not.exist");

--- a/frontend/test/metabase/scenarios/smoketest/user.cy.spec.js
+++ b/frontend/test/metabase/scenarios/smoketest/user.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, sidebar, popover } from "__support__/e2e/cypress";
+import { restore, sidebar, popover, visualize } from "__support__/e2e/cypress";
 
 describe("smoketest > user", () => {
   // Goal: user can use all the features of the simple question and notebook editor
@@ -24,7 +24,7 @@ describe("smoketest > user", () => {
 
     cy.findByText("Average of Rating");
 
-    cy.button("Visualize").click();
+    visualize();
 
     cy.icon("bar");
     cy.findAllByText("Vendor is not empty");
@@ -67,7 +67,8 @@ describe("smoketest > user", () => {
     popover().within(() => {
       cy.findAllByText("Title").click();
     });
-    cy.button("Visualize").click();
+
+    visualize();
 
     cy.get("@firstTableCell").contains("Aerodynamic Bronze Hat");
 
@@ -106,9 +107,9 @@ describe("smoketest > user", () => {
     cy.findByText("Greater than or equal to").click();
     cy.get("input[placeholder='Enter a number']").type("5");
     cy.findByText("Add filter").click();
-    cy.button("Visualize").click();
 
-    cy.button("Visualize").should("not.exist");
+    visualize();
+
     cy.get("svg");
     cy.findByText("Average of Rating is greater than or equal to 5");
 
@@ -180,7 +181,8 @@ describe("smoketest > user", () => {
     cy.findByText("Count of rows").click();
     cy.findByText("Pick a column to group by").click();
     cy.icon("calendar").click();
-    cy.button("Visualize").click();
+
+    visualize();
 
     cy.get("svg");
     cy.findAllByText("Created At");
@@ -193,7 +195,8 @@ describe("smoketest > user", () => {
 
     cy.icon("join_left_outer").click();
     cy.findByText("People").click(); // column selection happens automatcially
-    cy.button("Visualize").click();
+
+    visualize();
 
     cy.findByText("User → ID");
     cy.findByText("Created At");
@@ -205,7 +208,8 @@ describe("smoketest > user", () => {
 
     cy.findByText("Row limit").click();
     cy.get("input[type='number']").type("10");
-    cy.button("Visualize").click();
+
+    visualize();
 
     cy.get(".TableInteractive-cellWrapper--firstColumn").should(
       "have.length",
@@ -236,7 +240,7 @@ describe("smoketest > user", () => {
     // Distinctions
     // *** This test needs to be improved with variables that will change if the Sample data changes
 
-    cy.button("Visualize").click();
+    visualize();
 
     cy.findByText("Category").click();
     cy.findByText("Distincts").click();
@@ -330,7 +334,8 @@ describe("smoketest > user", () => {
       .last()
       .click();
     cy.findByText("People").click();
-    cy.button("Visualize").click();
+
+    visualize();
 
     cy.findByText("Longitude").click();
 

--- a/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
@@ -5,6 +5,7 @@ import {
   popover,
   sidebar,
   visitQuestionAdhoc,
+  visualize,
 } from "__support__/e2e/cypress";
 import { USER_GROUPS } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
@@ -322,8 +323,8 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
       .type("1");
     cy.findByText("Add filter").click();
 
-    // Visualize: line
-    cy.button("Visualize").click();
+    visualize();
+
     cy.findByText("Visualization").click();
     cy.icon("line").click();
     cy.findByText("Done").click();

--- a/frontend/test/metabase/scenarios/visualizations/trendline.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/trendline.cy.spec.js
@@ -1,4 +1,9 @@
-import { restore, openOrdersTable, sidebar } from "__support__/e2e/cypress";
+import {
+  restore,
+  openOrdersTable,
+  sidebar,
+  visualize,
+} from "__support__/e2e/cypress";
 
 describe("scenarios > question > trendline", () => {
   beforeEach(() => {
@@ -26,10 +31,8 @@ describe("scenarios > question > trendline", () => {
     cy.findByText("by month").click();
     cy.findByText("Year").click();
 
-    cy.button("Visualize").click();
+    visualize();
 
-    // Check graph is there
-    cy.button("Visualize").should("not.exist");
     cy.findByText("Visualization");
     cy.get("rect");
 

--- a/frontend/test/metabase/scenarios/visualizations/waterfall.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/waterfall.cy.spec.js
@@ -3,6 +3,7 @@ import {
   restore,
   visitQuestionAdhoc,
   openNativeEditor,
+  visualize,
 } from "__support__/e2e/cypress";
 import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
 
@@ -112,7 +113,8 @@ describe("scenarios > visualizations > waterfall", () => {
       .blur();
     cy.button("Done").click();
 
-    cy.button("Visualize").click();
+    visualize();
+
     cy.contains("Visualization").click();
     cy.icon("waterfall").click();
 
@@ -126,7 +128,8 @@ describe("scenarios > visualizations > waterfall", () => {
     cy.findByText("Pick a column to group by").click();
     cy.findByText("Created At").click();
 
-    cy.button("Visualize").click();
+    visualize();
+
     cy.contains("Visualization").click();
     cy.icon("waterfall").click();
 


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Creates a new abstraction for the extremely common action of visualizing notebook query results
- Applies that new helper function in a several different specs as a PoC

If reviewers decide this is useful and good to go, I'll update the rest of the specs.