### PR TITLE
Audit cards data display problem

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/audit_app/pages/users.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_app/pages/users.clj
@@ -6,6 +6,8 @@
             [ring.util.codec :as codec]
             [schema.core :as s]))
 
+(def ^:private ^:const date-cardinality-limit 25000)
+
 ;; DEPRECATED Query that returns data for a two-series timeseries: the number of DAU (a User is considered active for
 ;; purposes of this query if they ran at least one query that day), and total number of queries ran. Broken out by
 ;; day.
@@ -40,13 +42,15 @@
                                  {:select   [[(common/grouped-datetime datetime-unit :started_at) :date]
                                              [:%distinct-count.executor_id :count]]
                                   :from     [:query_execution]
-                                  :group-by [(common/grouped-datetime datetime-unit :started_at)]})
+                                  :group-by [(common/grouped-datetime datetime-unit :started_at)]
+                                  :limit    date-cardinality-limit})
                    date->active (zipmap (map :date active) (map :count active))
                    new          (common/query
                                  {:select   [[(common/grouped-datetime datetime-unit :date_joined) :date]
                                              [:%count.* :count]]
                                   :from     [:core_user]
-                                  :group-by [(common/grouped-datetime datetime-unit :date_joined)]})
+                                  :group-by [(common/grouped-datetime datetime-unit :date_joined)]
+                                  :limit    date-cardinality-limit})
                    date->new    (zipmap (map :date new) (map :count new))
                    all-dates    (sort (keep identity (distinct (concat (keys date->active)
                                                                        (keys date->new)))))]


### PR DESCRIPTION
This is pursuant to #17820. Default cardinality of limit on enterprise queries is 1000, which is not enough after slightly less than 3 years of dates. Increases limit.

Kind of a nightmare to figure out how to repro reliably but after that, simple enough repro and a really simple fix. See #17820 itself for repro steps.