### PR TITLE
Add helper to run jest tests in enterprise environment

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/caching/components/CacheTTLField/CacheTTLField.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/CacheTTLField/CacheTTLField.jsx
@@ -20,7 +20,7 @@ const propTypes = {
 export function CacheTTLField({ field, message, ...props }) {
   const hasError = !!field.error;
   return (
-    <CacheTTLFieldContainer {...props}>
+    <CacheTTLFieldContainer {...props} data-testid="cache-ttl-field">
       {message && (
         <FieldText margin="right" hasError={hasError}>
           {message}
@@ -32,6 +32,7 @@ export function CacheTTLField({ field, message, ...props }) {
         value={field.value}
         placeholder="24"
         hasError={hasError}
+        data-testid="cache-ttl-input"
       />
       <FieldText margin="left" hasError={hasError}>{t`hours`}</FieldText>
     </CacheTTLFieldContainer>

--- a/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.unit.spec.js
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.unit.spec.js
@@ -6,7 +6,7 @@ import {
 } from "__support__/ui";
 import admin from "metabase/admin/admin";
 import MetabaseSettings from "metabase/lib/settings";
-import { PLUGIN_CACHING } from "metabase/plugins";
+import { setupEnterpriseTest } from "__support__/enterprise";
 import DatabaseEditApp from "./DatabaseEditApp";
 
 const ENGINES_MOCK = {
@@ -27,6 +27,7 @@ const ENGINES_MOCK = {
 };
 
 function mockSettings({ cachingEnabled = false }) {
+  const original = MetabaseSettings.get.bind(MetabaseSettings);
   const spy = jest.spyOn(MetabaseSettings, "get");
   spy.mockImplementation(key => {
     if (key === "engines") {
@@ -38,6 +39,13 @@ function mockSettings({ cachingEnabled = false }) {
     if (key === "site-url") {
       return "http://localhost:3333";
     }
+    if (key === "application-name") {
+      return "Metabase Test";
+    }
+    if (key === "is-hosted?") {
+      return false;
+    }
+    return original(key);
   });
 }
 
@@ -64,15 +72,7 @@ describe("DatabaseEditApp", () => {
 
     describe("EE", () => {
       beforeEach(() => {
-        PLUGIN_CACHING.databaseCacheTTLFormField = {
-          name: "cache_ttl",
-          type: "integer",
-          title: "Default result cache duration",
-        };
-      });
-
-      afterEach(() => {
-        PLUGIN_CACHING.databaseCacheTTLFormField = null;
+        setupEnterpriseTest();
       });
 
       it("is visible", async () => {

--- a/frontend/src/metabase/collections/containers/CollectionSidebar/Collections/CollectionsList/CollectionsList.unit.spec.js
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/Collections/CollectionsList/CollectionsList.unit.spec.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { renderWithProviders, screen } from "__support__/ui";
 import userEvent from "@testing-library/user-event";
-import { PLUGIN_COLLECTIONS } from "metabase/plugins";
+import { setupEnterpriseTest } from "__support__/enterprise";
 import CollectionsList from "./CollectionsList";
 
 describe("CollectionsList", () => {
@@ -90,25 +90,8 @@ describe("CollectionsList", () => {
     });
 
     describe("EE", () => {
-      const ORIGINAL_COLLECTIONS_PLUGIN = {
-        ...PLUGIN_COLLECTIONS,
-      };
-
       beforeAll(() => {
-        PLUGIN_COLLECTIONS.isRegularCollection = c => !c.authority_level;
-        PLUGIN_COLLECTIONS.AUTHORITY_LEVEL = {
-          ...ORIGINAL_COLLECTIONS_PLUGIN,
-          official: {
-            icon: "badge",
-          },
-        };
-      });
-
-      afterAll(() => {
-        PLUGIN_COLLECTIONS.isRegularCollection =
-          ORIGINAL_COLLECTIONS_PLUGIN.isRegularCollection;
-        PLUGIN_COLLECTIONS.AUTHORITY_LEVEL =
-          ORIGINAL_COLLECTIONS_PLUGIN.AUTHORITY_LEVEL;
+        setupEnterpriseTest();
       });
 
       it("displays folder icon for regular collections", () => {

--- a/frontend/src/metabase/components/CreateDashboardModal.unit.spec.js
+++ b/frontend/src/metabase/components/CreateDashboardModal.unit.spec.js
@@ -2,16 +2,28 @@ import React from "react";
 import { fireEvent, renderWithProviders, screen } from "__support__/ui";
 import userEvent from "@testing-library/user-event";
 import xhrMock from "xhr-mock";
+import { setupEnterpriseTest } from "__support__/enterprise";
 import MetabaseSettings from "metabase/lib/settings";
-import { PLUGIN_CACHING } from "metabase/plugins";
 import CreateDashboardModal from "./CreateDashboardModal";
 
 function mockCachingEnabled(enabled = true) {
-  const original = MetabaseSettings.get;
+  const original = MetabaseSettings.get.bind(MetabaseSettings);
   const spy = jest.spyOn(MetabaseSettings, "get");
   spy.mockImplementation(key => {
     if (key === "enable-query-caching") {
       return enabled;
+    }
+    if (key === "application-name") {
+      return "Metabase Test";
+    }
+    if (key === "version") {
+      return { tag: "" };
+    }
+    if (key === "is-hosted?") {
+      return false;
+    }
+    if (key === "enable-enhancements?") {
+      return false;
     }
     return original(key);
   });
@@ -141,14 +153,7 @@ describe("CreateDashboardModal", () => {
 
     describe("EE", () => {
       beforeEach(() => {
-        PLUGIN_CACHING.cacheTTLFormField = {
-          name: "cache_ttl",
-          type: "integer",
-        };
-      });
-
-      afterEach(() => {
-        PLUGIN_CACHING.cacheTTLFormField = null;
+        setupEnterpriseTest();
       });
 
       it("is not shown", () => {

--- a/frontend/src/metabase/dashboard/components/DashboardDetailsModal.unit.spec.js
+++ b/frontend/src/metabase/dashboard/components/DashboardDetailsModal.unit.spec.js
@@ -3,9 +3,8 @@ import _ from "underscore";
 import { fireEvent, renderWithProviders, screen } from "__support__/ui";
 import userEvent from "@testing-library/user-event";
 import xhrMock from "xhr-mock";
+import { setupEnterpriseTest } from "__support__/enterprise";
 import MetabaseSettings from "metabase/lib/settings";
-import { PLUGIN_CACHING, PLUGIN_FORM_WIDGETS } from "metabase/plugins";
-import NumericFormField from "metabase/components/form/widgets/FormNumericInputWidget";
 import DashboardDetailsModal from "./DashboardDetailsModal";
 
 const DASHBOARD = {
@@ -19,11 +18,14 @@ const DASHBOARD = {
 };
 
 function mockCachingEnabled(enabled = true) {
-  const original = MetabaseSettings.get;
+  const original = MetabaseSettings.get.bind(MetabaseSettings);
   const spy = jest.spyOn(MetabaseSettings, "get");
   spy.mockImplementation(key => {
     if (key === "enable-query-caching") {
       return enabled;
+    }
+    if (key === "application-name") {
+      return "Test Metabase";
     }
     return original(key);
   });
@@ -93,7 +95,7 @@ function fillForm({ name, description, cache_ttl } = {}) {
     nextDashboardState.description = description;
   }
   if (cache_ttl) {
-    const input = screen.getByLabelText("Cache TTL");
+    const input = screen.getByTestId("cache-ttl-input");
     userEvent.clear(input);
     userEvent.type(input, String(cache_ttl));
     input.blur();
@@ -182,16 +184,7 @@ describe("DashboardDetailsModal", () => {
 
     describe("EE", () => {
       beforeEach(() => {
-        PLUGIN_CACHING.cacheTTLFormField = {
-          name: "cache_ttl",
-          title: "Cache TTL",
-        };
-        PLUGIN_FORM_WIDGETS.dashboardCacheTTL = NumericFormField;
-      });
-
-      afterEach(() => {
-        PLUGIN_CACHING.cacheTTLFormField = null;
-        PLUGIN_FORM_WIDGETS.dashboardCacheTTL = null;
+        setupEnterpriseTest();
       });
 
       describe("caching enabled", () => {
@@ -202,7 +195,7 @@ describe("DashboardDetailsModal", () => {
         it("is shown", () => {
           setup();
           fireEvent.click(screen.queryByText("More options"));
-          expect(screen.queryByLabelText("Cache TTL")).toHaveValue("0");
+          expect(screen.queryByTestId("cache-ttl-input")).toHaveValue("0");
         });
 
         it("can be changed", done => {
@@ -220,8 +213,11 @@ describe("DashboardDetailsModal", () => {
       });
 
       describe("caching disabled", () => {
-        it("is not shown if caching is disabled", () => {
+        beforeEach(() => {
           mockCachingEnabled(false);
+        });
+
+        it("is not shown if caching is disabled", () => {
           setup();
           expect(screen.queryByText("More options")).not.toBeInTheDocument();
           expect(

--- a/frontend/src/metabase/search/components/SearchResult.unit.spec.js
+++ b/frontend/src/metabase/search/components/SearchResult.unit.spec.js
@@ -1,7 +1,7 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 import { render, screen } from "@testing-library/react";
-import { PLUGIN_COLLECTIONS } from "metabase/plugins";
+import { setupEnterpriseTest } from "__support__/enterprise";
 import SearchResult from "./SearchResult";
 
 function collection({
@@ -56,24 +56,8 @@ describe("SearchResult > Collections", () => {
       getIcon: () => ({ name: "badge" }),
     });
 
-    const ORIGINAL_COLLECTIONS_PLUGIN = { ...PLUGIN_COLLECTIONS };
-
     beforeAll(() => {
-      PLUGIN_COLLECTIONS.isRegularCollection = c => !c.authority_level;
-      PLUGIN_COLLECTIONS.AUTHORITY_LEVEL = {
-        ...ORIGINAL_COLLECTIONS_PLUGIN.AUTHORITY_LEVEL,
-        official: {
-          name: "Official",
-          icon: "badge",
-        },
-      };
-    });
-
-    afterAll(() => {
-      PLUGIN_COLLECTIONS.isRegularCollection =
-        ORIGINAL_COLLECTIONS_PLUGIN.isRegularCollection;
-      PLUGIN_COLLECTIONS.AUTHORITY_LEVEL =
-        ORIGINAL_COLLECTIONS_PLUGIN.AUTHORITY_LEVEL;
+      setupEnterpriseTest();
     });
 
     it("renders regular collection correctly", () => {

--- a/frontend/test/__support__/enterprise.js
+++ b/frontend/test/__support__/enterprise.js
@@ -1,0 +1,7 @@
+export function setupEnterpriseTest() {
+  jest.mock("metabase-enterprise/settings", () => ({
+    hasPremiumFeature: jest.fn().mockReturnValue(true),
+  }));
+
+  require("metabase-enterprise/plugins");
+}

--- a/frontend/test/__support__/mocks.js
+++ b/frontend/test/__support__/mocks.js
@@ -1,5 +1,3 @@
-/* eslint-disable no-import-assign*/
-
 global.ga = () => {};
 global.snowplow = () => {};
 global.ace.define = () => {};
@@ -10,10 +8,8 @@ global.window.matchMedia = () => ({
   removeListener: () => {},
 });
 
-// Disable analytics
 jest.mock("metabase/lib/analytics");
 
-// Suppress ace import errors
 jest.mock("ace/ace", () => {}, { virtual: true });
 jest.mock("ace/mode-plain_text", () => {}, { virtual: true });
 jest.mock("ace/mode-javascript", () => {}, { virtual: true });
@@ -34,23 +30,3 @@ jest.mock("ace/snippets/sqlserver", () => {}, { virtual: true });
 jest.mock("ace/snippets/json", () => {}, { virtual: true });
 jest.mock("ace/snippets/json", () => {}, { virtual: true });
 jest.mock("ace/ext-language_tools", () => {}, { virtual: true });
-
-jest.mock("metabase/components/Popover");
-
-// Replace addEventListener with a test implementation which collects all event listeners to `eventListeners` map
-export const eventListeners = {};
-const testAddEventListener = jest.fn((event, listener) => {
-  eventListeners[event] = eventListeners[event]
-    ? [...eventListeners[event], listener]
-    : [listener];
-});
-const testRemoveEventListener = jest.fn((event, listener) => {
-  eventListeners[event] = (eventListeners[event] || []).filter(
-    l => l !== listener,
-  );
-});
-
-global.document.addEventListener = testAddEventListener;
-global.window.addEventListener = testAddEventListener;
-global.document.removeEventListener = testRemoveEventListener;
-global.window.removeEventListener = testRemoveEventListener;

--- a/frontend/test/__support__/ui-mocks.js
+++ b/frontend/test/__support__/ui-mocks.js
@@ -1,0 +1,21 @@
+jest.mock("metabase/components/Popover");
+
+// Replace addEventListener with a test implementation which collects all event listeners to `eventListeners` map
+export const eventListeners = {};
+
+const testAddEventListener = jest.fn((event, listener) => {
+  eventListeners[event] = eventListeners[event]
+    ? [...eventListeners[event], listener]
+    : [listener];
+});
+
+const testRemoveEventListener = jest.fn((event, listener) => {
+  eventListeners[event] = (eventListeners[event] || []).filter(
+    l => l !== listener,
+  );
+});
+
+global.document.addEventListener = testAddEventListener;
+global.window.addEventListener = testAddEventListener;
+global.document.removeEventListener = testRemoveEventListener;
+global.window.removeEventListener = testRemoveEventListener;

--- a/frontend/test/jest-setup.js
+++ b/frontend/test/jest-setup.js
@@ -1,5 +1,6 @@
 import "raf/polyfill";
 import "jest-localstorage-mock";
+import "__support__/mocks";
 
 // NOTE: this is needed because sometimes asynchronous code tries to access
 // window.location or similar jsdom properties after the tests have ended and

--- a/frontend/test/metabase/containers/SaveQuestionModal.unit.spec.js
+++ b/frontend/test/metabase/containers/SaveQuestionModal.unit.spec.js
@@ -6,20 +6,32 @@ import mock from "xhr-mock";
 import SaveQuestionModal from "metabase/containers/SaveQuestionModal";
 import Question from "metabase-lib/lib/Question";
 import MetabaseSettings from "metabase/lib/settings";
-import { PLUGIN_CACHING } from "metabase/plugins";
 
 import {
   SAMPLE_DATASET,
   ORDERS,
   metadata,
 } from "__support__/sample_dataset_fixture";
+import { setupEnterpriseTest } from "__support__/enterprise";
 
 function mockCachingEnabled(enabled = true) {
-  const original = MetabaseSettings.get;
+  const original = MetabaseSettings.get.bind(MetabaseSettings);
   const spy = jest.spyOn(MetabaseSettings, "get");
   spy.mockImplementation(key => {
     if (key === "enable-query-caching") {
       return enabled;
+    }
+    if (key === "application-name") {
+      return "Metabase Test";
+    }
+    if (key === "version") {
+      return { tag: "" };
+    }
+    if (key === "is-hosted?") {
+      return false;
+    }
+    if (key === "enable-enhancements?") {
+      return false;
     }
     return original(key);
   });
@@ -496,14 +508,7 @@ describe("SaveQuestionModal", () => {
 
     describe("EE", () => {
       beforeEach(() => {
-        PLUGIN_CACHING.cacheTTLFormField = {
-          name: "cache_ttl",
-          type: "integer",
-        };
-      });
-
-      afterEach(() => {
-        PLUGIN_CACHING.cacheTTLFormField = null;
+        setupEnterpriseTest();
       });
 
       it("is not shown", () => {

--- a/frontend/test/metabase/entities/collections/getCollectionIcon.unit.spec.js
+++ b/frontend/test/metabase/entities/collections/getCollectionIcon.unit.spec.js
@@ -1,4 +1,4 @@
-import { PLUGIN_COLLECTIONS } from "metabase/plugins";
+import { setupEnterpriseTest } from "__support__/enterprise";
 import {
   getCollectionIcon,
   ROOT_COLLECTION,
@@ -6,10 +6,6 @@ import {
 } from "metabase/entities/collections";
 
 describe("getCollectionIcon", () => {
-  const ORIGINAL_AUTHORITY_LEVELS = {
-    ...PLUGIN_COLLECTIONS.AUTHORITY_LEVEL,
-  };
-
   function collection({
     id = 10,
     personal_owner_id = null,
@@ -78,21 +74,7 @@ describe("getCollectionIcon", () => {
 
   describe("EE", () => {
     beforeEach(() => {
-      PLUGIN_COLLECTIONS.AUTHORITY_LEVEL = {
-        ...ORIGINAL_AUTHORITY_LEVELS,
-        official: {
-          type: "official",
-          icon: "badge",
-          color: "yellow",
-          tooltips: {
-            default: "Official Collection",
-          },
-        },
-      };
-    });
-
-    afterEach(() => {
-      PLUGIN_COLLECTIONS.AUTHORITY_LEVEL = ORIGINAL_AUTHORITY_LEVELS;
+      setupEnterpriseTest();
     });
 
     testCasesEE.forEach(testCase => {

--- a/frontend/test/metabase/query_builder/components/filters/FilterPopover.unit.spec.js
+++ b/frontend/test/metabase/query_builder/components/filters/FilterPopover.unit.spec.js
@@ -1,4 +1,4 @@
-import "__support__/mocks";
+import "__support__/ui-mocks";
 import React from "react";
 
 import { fireEvent, render, screen } from "@testing-library/react";

--- a/frontend/test/metabase/visualizations/components/LineAreaBarRenderer-bar.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/LineAreaBarRenderer-bar.unit.spec.js
@@ -1,4 +1,4 @@
-import "__support__/mocks"; // included explicitly whereas with e2e tests it comes with __support__/e2e
+import "__support__/ui-mocks"; // included explicitly whereas with e2e tests it comes with __support__/e2e
 
 import {
   NumberColumn,

--- a/frontend/test/metabase/visualizations/components/LineAreaBarRenderer-scatter.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/LineAreaBarRenderer-scatter.unit.spec.js
@@ -1,4 +1,4 @@
-import "__support__/mocks"; // included explicitly whereas with e2e tests it comes with __support__/e2e
+import "__support__/ui-mocks"; // included explicitly whereas with e2e tests it comes with __support__/e2e
 
 import {
   NumberColumn,

--- a/frontend/test/metabase/visualizations/components/LineAreaBarRenderer-waterfall.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/LineAreaBarRenderer-waterfall.unit.spec.js
@@ -1,4 +1,4 @@
-import "__support__/mocks"; // included explicitly whereas with e2e tests it comes with __support__/e2e
+import "__support__/ui-mocks"; // included explicitly whereas with e2e tests it comes with __support__/e2e
 
 import {
   NumberColumn,

--- a/frontend/test/metabase/visualizations/components/LineAreaBarRenderer.tz.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/LineAreaBarRenderer.tz.unit.spec.js
@@ -1,4 +1,4 @@
-import "__support__/mocks"; // included explicitly whereas with integrated tests it comes with __support__/integrated_tests
+import "__support__/ui-mocks"; // included explicitly whereas with integrated tests it comes with __support__/integrated_tests
 import testAcrossTimezones from "__support__/timezones";
 
 import _ from "underscore";

--- a/frontend/test/metabase/visualizations/components/LineAreaBarRenderer.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/LineAreaBarRenderer.unit.spec.js
@@ -1,4 +1,4 @@
-import "__support__/mocks"; // included explicitly whereas with e2e tests it comes with __support__/e2e
+import "__support__/ui-mocks"; // included explicitly whereas with e2e tests it comes with __support__/e2e
 
 import {
   NumberColumn,

--- a/frontend/test/metabase/visualizations/components/RowRenderer.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/RowRenderer.unit.spec.js
@@ -1,4 +1,4 @@
-import "__support__/mocks";
+import "__support__/ui-mocks";
 
 import {
   createFixture,


### PR DESCRIPTION
This PR adds a unit testing helper function to simplify testing paid features. At the moment, we mainly cover paid features with Cypress. Still, covering a wide variety of scenarios can become too expensive with the E2E approach. We have some coverage for code inside `metabase-enterprise`, but not around components _consuming_ the paid-features code because paid features are not available by default in the Jest environment.

This PR adds a [`setupEnterpriseTest` utility under `__support__/enterprise`](https://github.com/metabase/metabase/blob/582c14e3ab67066cd92e40df21d6689acdeced81/frontend/test/__support__/enterprise.js). It basically just requires everything from `metabase-enterprise/plugins` and mocks `hasPaidFeature` function to always return `true`. Once you run the function inside one of your tests, it'll execute as if all paid features are available.

## Usage

Let's take a look at [`getCollectionIcon` function](https://github.com/metabase/metabase/blob/24975664f7208c4c8c1819b76f94b9b4c61da820/frontend/src/metabase/entities/collections.js#L143) under `metabase/entities/collection`. We have ["Official collections" feature](https://www.metabase.com/docs/latest/users-guide/collections.html#official-collections) available in paid plans. Long story short, some collections can be marked as officials, and they should be displayed with a `badge` icon instead of the default `folder` one. But if you're running OSS and a collection is marked as official in the application database, we should display it with a usual `folder` icon.

We can test it this way:

```jsx
const OFFICIAL_COLLECTION = { ... }

it("displays folder icon for official collections in OSS", () => {
 const icon = getCollectionIcon(OFFICIAL_COLLECTION);
 expect(icon).toBe("folder");
});
```

Earlier, the only way to make it run as if the paid plan is activated was to patch `metabase/plugins` manually. It kind of worked, but it's still pretty confusing and not very reliable. With the helper from this PR, we can add a new test in the same file:

```jsx
import { setupEnterpriseTest } from "__support__/enterprise"

const OFFICIAL_COLLECTION = { ... }

describe("OSS", () => {
  it("displays folder icon for official collections", () => {
    const icon = getCollectionIcon(OFFICIAL_COLLECTION);
    expect(icon).toBe("folder");
  });
});

describe("Paid plan", () => {
  beforeEach(() => {
    setupEnterpriseTest();
  });

  it("displays badge icon for official collections", () => {
    const icon = getCollectionIcon(OFFICIAL_COLLECTION);
    expect(icon).toBe("badge");
  });
});
```

## Limitations

### Mocking enabled features

`setupEnterpriseTest` imports everything from `metabase-enterprise` plugins. Every plugin has top-level code that checks if a particular feature flag is enabled, and in that case, it patches the `PLUGINS` object.

One of the limitations, for now, is that this code is executed only once for the whole test file. So it's impossible to test behaviors with a flag enabled and disabled in the same file.

Most likely, it should be solved with something like [`jest.resetModules`](https://jestjs.io/docs/jest-object#jestresetmodules) or [`jest.isolateModules()`](https://jestjs.io/docs/jest-object#jestisolatemodulesfn), but I haven't figured that out yet. I would appreciate a fresh look on that 🙏 

### Mocking MetabaseSettings

If you go through some of the test files in the PR, you will notice that paid feature tests had to mock some `MetabaseSettings` properties. Apparently, they're used by `metabase-enterprise` code, so we should mock them. I haven't included the `MetabaseSettings` mock into the `setupEnterpriseTest` helper itself as some tests need to mock settings for their own purposes (like advanced caching controls tests need to manipulate caching settings). I think it would make sense to introduce a helper function for mocking `MetabaseSettings` to solve that more cleanly, but it seems out of scope of this PR