### PR TITLE
Cap XLSX column widths at 255 characters

### DIFF
--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -428,12 +428,17 @@
   This ensures the cells in the header row have enough room for the filter dropdown icon."
   (* 4 256))
 
+(def ^:private max-column-width
+  "Cap column widths at 255 characters"
+  (* 255 256))
+
 (defn- autosize-columns!
   "Adjusts each column to fit its largest value, plus a constant amount of extra padding."
   [sheet]
   (doseq [i (.getTrackedColumnsForAutoSizing ^SXSSFSheet sheet)]
     (.autoSizeColumn ^SXSSFSheet sheet i)
-    (.setColumnWidth ^SXSSFSheet sheet i (+ (.getColumnWidth ^SXSSFSheet sheet i) extra-column-width))
+    (.setColumnWidth ^SXSSFSheet sheet i (min max-column-width
+                                              (+ (.getColumnWidth ^SXSSFSheet sheet i) extra-column-width)))
     (.untrackColumnForAutoSizing ^SXSSFSheet sheet i)))
 
 (defn- setup-header-row!

--- a/test/metabase/query_processor/streaming/xlsx_test.clj
+++ b/test/metabase/query_processor/streaming/xlsx_test.clj
@@ -451,4 +451,10 @@
                                              {}
                                              [["abcdef"] ["abcedf"] ["abcdef"]]
                                              parse-column-width))]
-        (is (<= 2800 col-width 2900))))))
+        (is (<= 2800 col-width 2900)))))
+  (testing "An auto-sized column does not exceed max-column-width (the width of 255 characters)"
+    (let [[col-width] (second (xlsx-export [{:id 0, :name "Col1"}]
+                                           {}
+                                           [[(apply str (repeat 256 "0"))]]
+                                           parse-column-width))]
+      (is (= 65280 col-width)))))


### PR DESCRIPTION
Caps the width of auto-resized XLSX columns to 255 characters (units are 1/256 of a character width).

Resolves #18531