### PR TITLE
Revert "Circle CI: build a complete Uberjar on a release branch"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -890,13 +890,7 @@ jobs:
                   # INTERACTIVE=false will tell the clojure build scripts not to do interactive retries etc.
                   INTERACTIVE: "false"
                   MB_EDITION: << parameters.edition >>
-                command: |
-                  if [[ $CIRCLE_BRANCH == release* || $CIRCLE_BRANCH == master  ]]; then
-                    echo 'This is a release or master branch; building a complete Uberjar'
-                    ./bin/build
-                  else
-                    ./bin/build version uberjar
-                  fi
+                command: ./bin/build version uberjar
                 no_output_timeout: 15m
             - store_artifacts:
                 path: /home/circleci/metabase/metabase/target/uberjar/metabase.jar


### PR DESCRIPTION
This reverts commit b0f72ce8 since it broke Uberjar builds.
