### PR TITLE
Circle CI: build a complete Uberjar on a release branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -863,6 +863,7 @@ jobs:
     parameters:
       <<: *Params
     executor: clojure-and-node-and-browsers
+    resource_class: large
     steps:
       - attach-workspace
       - run-on-change:
@@ -890,7 +891,13 @@ jobs:
                   # INTERACTIVE=false will tell the clojure build scripts not to do interactive retries etc.
                   INTERACTIVE: "false"
                   MB_EDITION: << parameters.edition >>
-                command: ./bin/build version uberjar
+                command: |
+                  if [[ $CIRCLE_BRANCH == release* || $CIRCLE_BRANCH == master  ]]; then
+                    echo 'This is a release or master branch; building a complete Uberjar'
+                    ./bin/build
+                  else
+                    ./bin/build version uberjar
+                  fi
                 no_output_timeout: 15m
             - store_artifacts:
                 path: /home/circleci/metabase/metabase/target/uberjar/metabase.jar


### PR DESCRIPTION
Make sure that the built Uberjar contains translations etc.
Also, build with "large" resource_class on Circle CI.

Note: this is a remake of PR #18370 but with the bumped up CI resource (thanks to @paoliniluis for the suggestion).
