### PR TITLE
Fix no databases on embedded new question page

### DIFF
--- a/frontend/src/metabase/new_query/containers/NewQueryOptions.jsx
+++ b/frontend/src/metabase/new_query/containers/NewQueryOptions.jsx
@@ -21,11 +21,14 @@ import {
   getHasNativeWrite,
 } from "metabase/new_query/selectors";
 
+import Database from "metabase/entities/databases";
+
 import type { NestedObjectKey } from "metabase/visualizations/lib/settings/nested";
 
 type Props = {
   hasDataAccess: Boolean,
   hasNativeWrite: Boolean,
+  prefetchDatabases: Function,
   initialKey?: NestedObjectKey,
 };
 
@@ -35,6 +38,7 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = {
+  prefetchDatabases: () => Database.actions.fetchList(),
   push,
 };
 
@@ -49,6 +53,7 @@ export default class NewQueryOptions extends Component {
   props: Props;
 
   UNSAFE_componentWillMount(props) {
+    this.props.prefetchDatabases();
     const { location, push } = this.props;
     if (Object.keys(location.query).length > 0) {
       const { database, table, ...options } = location.query;

--- a/frontend/src/metabase/new_query/containers/NewQueryOptions.jsx
+++ b/frontend/src/metabase/new_query/containers/NewQueryOptions.jsx
@@ -52,8 +52,12 @@ const PAGE_PADDING = [1, 4];
 export default class NewQueryOptions extends Component {
   props: Props;
 
-  UNSAFE_componentWillMount(props) {
+  componentDidMount() {
+    // We need to check if any databases exist otherwise show an empty state.
+    // Be aware that the embedded version does not have the Navbar, which also
+    // loads databases, so we should not remove it.
     this.props.prefetchDatabases();
+
     const { location, push } = this.props;
     if (Object.keys(location.query).length > 0) {
       const { database, table, ...options } = location.query;


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/18552
Introduced in https://github.com/metabase/metabase/pull/17455

### Explanation

Everything worked correctly in a standalone version because `frontend/src/metabase/nav/containers/Navbar.jsx`  component loads databases list and fills the store. However, in the embedded version we do not render the Navbar. Since a while back we stopped prefetching databases and tables for `/question/new` it started displaying that users don't have any DBs.

### How to verify

Check the original issue for repro steps.
