### PR TITLE
Coalesce audit question query runs to be 0 if no query executions

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/audit_app/pages/queries.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_app/pages/queries.clj
@@ -193,8 +193,8 @@
                              [:card.creator_id :user_id]
                              [(common/user-full-name :u) :user_name]
                              :card.cache_ttl
-                             [(common/zero-if-null :avg_exec_time_45.avg_running_time_ms) :avg_exec_time]
-                             [(common/zero-if-null :total_runtime_45.total_running_time_ms) :total_runtime]
+                             [:avg_exec_time_45.avg_running_time_ms :avg_exec_time]
+                             [:total_runtime_45.total_running_time_ms :total_runtime]
                              [(common/zero-if-null :query_runs.count) :query_runs]
                              [(common/card-public-url :card.public_uuid) :public_link]]
                  :from      [[:report_card :card]]

--- a/enterprise/backend/src/metabase_enterprise/audit_app/pages/queries.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_app/pages/queries.clj
@@ -193,9 +193,9 @@
                              [:card.creator_id :user_id]
                              [(common/user-full-name :u) :user_name]
                              :card.cache_ttl
-                             [:avg_exec_time_45.avg_running_time_ms :avg_exec_time]
-                             [:total_runtime_45.total_running_time_ms :total_runtime]
-                             [:query_runs.count :query_runs]
+                             [(common/zero-if-null :avg_exec_time_45.avg_running_time_ms) :avg_exec_time]
+                             [(common/zero-if-null :total_runtime_45.total_running_time_ms) :total_runtime]
+                             [(common/zero-if-null :query_runs.count) :query_runs]
                              [(common/card-public-url :card.public_uuid) :public_link]]
                  :from      [[:report_card :card]]
                  :left-join [[:collection :coll]      [:= :card.collection_id :coll.id]


### PR DESCRIPTION
Pursuant to #18271
So there are valid-ish cases where there's cards without query executions.

- Someone saves a complex question without actually running it (which is an affordance in the question UI)
- Someone creates card by API

But in this case query executions is nil so the ordering in audit table is wrong because nil comes before other elems in sorted DB in many cases. So coalesce it all so we don't have null vals in the first place.