### PR TITLE
Removing duplicate property declaration from presto-jdbc driver YAML

### DIFF
--- a/frontend/test/metabase/scenarios/admin/databases/add-presto.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/add-presto.cy.spec.js
@@ -1,0 +1,123 @@
+import { restore, popover } from "__support__/e2e/cypress";
+
+describe("admin > database > add > Presto", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.visit("/admin/databases/create");
+    cy.contains("Database type")
+      .closest(".Form-field")
+      .find("a")
+      .click();
+  });
+
+  it("should render correctly and allow switching between the new and the old drivers (metabase#18351)", () => {
+    // There should be only the new driver listed originally in the popover
+    popover().within(() => {
+      cy.findByText("Presto (Deprecated Driver)").should("not.exist");
+      cy.findByText("Presto").click();
+    });
+
+    cy.findByLabelText("Name").type("Foo");
+
+    /**
+     *  No need to fill out all these fields, because we can't connect to Presto from Cypress.
+     * Just making sure they are all there.
+     */
+    cy.findByLabelText("Host");
+    cy.findByLabelText("Port");
+    cy.findByLabelText("Catalog");
+    cy.findByLabelText("Schema (optional)");
+    cy.findByLabelText("Username");
+    cy.findByLabelText("Password");
+    // Implicit assertion - reproduces metabase#18351
+    cy.findByLabelText("Additional JDBC options");
+
+    cy.findByLabelText("Use a secure connection (SSL)?");
+    cy.findByLabelText("Authenticate with Kerberos?");
+    // Turned on by default
+    cy.findByLabelText(
+      "Automatically run queries when doing simple filtering and summarizing",
+    ).should("have.attr", "aria-checked", "true");
+
+    cy.findByLabelText(
+      "This is a large database, so let me choose when Metabase syncs and scans",
+    ).should("have.attr", "aria-checked", "");
+
+    cy.findByLabelText("Periodically refingerprint tables").should(
+      "have.attr",
+      "aria-checked",
+      "",
+    );
+
+    // This should be disabled but we'll not add that assertion until we mark all the required fields in the form
+    cy.button("Save");
+
+    cy.findByText("Need help setting up your database?");
+    cy.findByRole("link", { name: "Our docs can help." });
+
+    cy.findByText(
+      "This is our new Presto driver, which is faster and more reliable.",
+    );
+
+    // Switch to the deprecated old Presto driver
+    cy.contains(
+      "The old driver has been deprecated and will be removed in a future release. If you really need to use it, you can find it here.",
+    )
+      .find("a")
+      .click();
+
+    cy.get(".AdminSelect").contains("Presto (Deprecated Driver)");
+
+    // It should have persisted the previously set database name
+    cy.findByDisplayValue("Foo");
+
+    cy.findByLabelText("Host");
+    cy.findByLabelText("Port");
+    cy.findByLabelText("Database name");
+    cy.findByLabelText("Catalog").should("not.exist");
+    cy.findByLabelText("Schema (optional)").should("not.exist");
+    cy.findByLabelText("Username");
+    cy.findByLabelText("Password");
+
+    // Reproduces metabase#18351
+    cy.findByLabelText("Additional JDBC options").should("not.exist");
+
+    cy.findByLabelText("Use a secure connection (SSL)?");
+    cy.findByLabelText("Use an SSH-tunnel for database connections");
+
+    cy.findByLabelText(
+      "Automatically run queries when doing simple filtering and summarizing",
+    ).should("have.attr", "aria-checked", "true");
+
+    cy.findByLabelText(
+      "This is a large database, so let me choose when Metabase syncs and scans",
+    ).should("have.attr", "aria-checked", "");
+
+    cy.findByLabelText("Periodically refingerprint tables").should(
+      "have.attr",
+      "aria-checked",
+      "",
+    );
+
+    cy.findByText(
+      "This driver has been deprecated and will be removed in a future release.",
+    );
+
+    // Switch back to the new Presto driver
+    cy.contains(
+      "We recommend that you upgrade to the new Presto driver, which is faster and more reliable.",
+    )
+      .find("a")
+      .click();
+
+    cy.get(".AdminSelect")
+      .contains("Presto")
+      .click();
+
+    popover()
+      .should("contain", "Presto")
+      .and("contain", "Presto (Deprecated Driver)");
+  });
+});

--- a/modules/drivers/presto-jdbc/resources/metabase-plugin.yaml
+++ b/modules/drivers/presto-jdbc/resources/metabase-plugin.yaml
@@ -30,9 +30,6 @@ driver:
         - password
         - required: false
     - ssl
-    - merge:
-        - additional-options
-        - placeholder: "trustServerCertificate=false"
     - name: kerberos
       type: boolean
       display-name: Authenticate with Kerberos?

--- a/test/metabase/driver_test.clj
+++ b/test/metabase/driver_test.clj
@@ -2,7 +2,8 @@
   (:require [clojure.test :refer :all]
             [metabase.driver :as driver]
             [metabase.driver.impl :as impl]
-            [metabase.plugins.classloader :as classloader]))
+            [metabase.plugins.classloader :as classloader]
+            [metabase.test.data.env :as tx.env]))
 
 (driver/register! ::test-driver, :abstract? true)
 
@@ -36,3 +37,21 @@
     (is (driver/available? ::test-driver))
     (is (driver/available? "metabase.driver-test/test-driver")
         "`driver/available?` should work for if `driver` is a string -- see #10135")))
+
+(deftest unique-connection-property-test
+  ;; abnormal usage here; we are not using the regular mt/test-driver or mt/test-drivers, because those involve
+  ;; initializing the driver and test data namespaces, which don't necessarily exist for all drivers (ex:
+  ;; googleanalytics), and besides which, we don't actually need sample data or test extensions for this test itself
+
+  ;; so instead, just iterate through all drivers currently set to test by the environment, and check their
+  ;; connection-properties; between all the different CI driver runs, this should cover everything
+  (doseq [d (tx.env/test-drivers)]
+    (testing (str d " has entirely unique connection property names")
+      (let [props         (driver/connection-properties d)
+            props-by-name (group-by :name props)]
+        (is (= (count props) (count props-by-name))
+            (format "Property(s) with duplicate name: %s" (-> (filter (fn [[_ props]]
+                                                                        (> (count props) 1))
+                                                                      props-by-name)
+                                                              vec
+                                                              pr-str)))))))


### PR DESCRIPTION
Add test that executes against all drivers to confirm that no duplicate names come out of connection-properties

Change the way the test runs to avoid needing to initialize test data namespace (to make `googleanalytics` happy)

Unskip repro Cypress test
