### PR TITLE
#18547 Repro: Wrong id used in links for questions added to dashboard in the activity page

### DIFF
--- a/frontend/test/metabase/scenarios/onboarding/home/activity-page.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/home/activity-page.cy.spec.js
@@ -1,5 +1,12 @@
 //Replaces HomepageApp.e2e.spec.js
-import { restore, openProductsTable, popover } from "__support__/e2e/cypress";
+import {
+  restore,
+  openProductsTable,
+  popover,
+  sidebar,
+  editDashboard,
+  saveDashboard,
+} from "__support__/e2e/cypress";
 
 describe("metabase > scenarios > home > activity-page", () => {
   beforeEach(() => {
@@ -46,5 +53,34 @@ describe("metabase > scenarios > home > activity-page", () => {
     cy.findAllByText("joined!").should("have.length", 2);
     cy.findAllByText("Robert").should("have.length", 2);
     cy.findByText("Products, Filtered by Rating");
+  });
+
+  it.skip("should respect the (added to dashboard) card id in the link (metabase#18547)", () => {
+    cy.intercept("GET", `/api/dashboard/1`).as("dashboard");
+
+    cy.visit("/dashboard/1");
+    cy.wait("@dashboard");
+
+    editDashboard();
+
+    cy.icon("add")
+      .last()
+      .click();
+
+    sidebar().within(() => {
+      cy.get(".LoadingSpinner").should("not.exist");
+      cy.findByText("Orders").click();
+    });
+
+    saveDashboard();
+    cy.wait("@dashboard");
+
+    cy.visit("/activity");
+
+    cy.contains("You added a question to the dashboard - Orders in a dashboard")
+      .closest("li")
+      .findByRole("link", { name: "Orders" })
+      .should("have.attr", "href")
+      .and("include", "question/1");
   });
 });


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #18547

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/onboarding/home/activity-page.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/138149004-98a22d8f-ad96-4619-8ba5-a7fe04c42d1f.png)

