### PR TITLE
Fix #18547 - Wrong id applied to the link to the question added to the dashboard [Activity log]

### DIFF
--- a/frontend/src/metabase/lib/urls.js
+++ b/frontend/src/metabase/lib/urls.js
@@ -47,9 +47,7 @@ export function question(card, hash = "", query = "") {
     return `/question${query}${hash}`;
   }
 
-  if (!card.name) {
-    return `/question/${card.id}${query}${hash}`;
-  }
+  const { card_id, id, name } = card;
 
   /**
    * If the question has been added to the dashboard we're reading the dashCard's properties.
@@ -57,9 +55,19 @@ export function question(card, hash = "", query = "") {
    *
    * There can be multiple instances of the same question in a dashboard, hence this distinction.
    */
-  const { card_id, id } = card;
+  const questionId = card_id || id;
 
-  const path = appendSlug(`/question/${card_id || id}`, slugg(card.name));
+  /**
+   * Although it's not possible to intentionally save a question without a name,
+   * it is possible that the `name` is not recognized if it contains symbols.
+   *
+   * Please see: https://github.com/metabase/metabase/pull/15989#pullrequestreview-656646149
+   */
+  if (!name) {
+    return `/question/${questionId}${query}${hash}`;
+  }
+
+  const path = appendSlug(`/question/${questionId}`, slugg(name));
 
   return `${path}${query}${hash}`;
 }

--- a/frontend/src/metabase/lib/urls.js
+++ b/frontend/src/metabase/lib/urls.js
@@ -28,24 +28,39 @@ export function question(card, hash = "", query = "") {
   if (hash && typeof hash === "object") {
     hash = serializeCardForUrl(hash);
   }
+
   if (query && typeof query === "object") {
     query = extractQueryParams(query)
       .map(kv => kv.map(encodeURIComponent).join("="))
       .join("&");
   }
+
   if (hash && hash.charAt(0) !== "#") {
     hash = "#" + hash;
   }
+
   if (query && query.charAt(0) !== "?") {
     query = "?" + query;
   }
+
   if (!card || !card.id) {
     return `/question${query}${hash}`;
   }
+
   if (!card.name) {
     return `/question/${card.id}${query}${hash}`;
   }
-  const path = appendSlug(`/question/${card.id}`, slugg(card.name));
+
+  /**
+   * If the question has been added to the dashboard we're reading the dashCard's properties.
+   * In that case `card_id` is the actual question's id, while `id` corresponds with the dashCard itself.
+   *
+   * There can be multiple instances of the same question in a dashboard, hence this distinction.
+   */
+  const { card_id, id } = card;
+
+  const path = appendSlug(`/question/${card_id || id}`, slugg(card.name));
+
   return `${path}${query}${hash}`;
 }
 

--- a/frontend/test/metabase/lib/urls.unit.spec.js
+++ b/frontend/test/metabase/lib/urls.unit.spec.js
@@ -40,8 +40,29 @@ describe("urls", () => {
       it("returns the correct url", () => {
         expect(question(null)).toEqual("/question");
         expect(question({ id: 1 })).toEqual("/question/1");
+
+        /**
+         * If we're dealing with the question in a dashboard, we're reading the dashCard properties.
+         * Make sure `card_id` gets assigned to the question url.
+         */
+
         expect(question({ id: 1, card_id: 42, name: "Foo" })).toEqual(
           "/question/42-foo",
+        );
+
+        /** Symbol-based languages are unsupported. Such names result in the `name` being dropped.
+         * Please see: https://github.com/metabase/metabase/pull/15989#pullrequestreview-656646149
+         *
+         * * We still have to make sure links to questions in a dashboard render correctly.
+         */
+
+        expect(question({ id: 1, card_id: 42 })).toEqual("/question/42");
+
+        expect(question({ id: 1, card_id: 42, name: "ベーコン" })).toEqual(
+          "/question/42",
+        );
+        expect(question({ id: 1, card_id: 42, name: "培根" })).toEqual(
+          "/question/42",
         );
       });
     });

--- a/frontend/test/metabase/lib/urls.unit.spec.js
+++ b/frontend/test/metabase/lib/urls.unit.spec.js
@@ -35,6 +35,16 @@ describe("urls", () => {
         );
       });
     });
+
+    describe("question ids", () => {
+      it("returns the correct url", () => {
+        expect(question(null)).toEqual("/question");
+        expect(question({ id: 1 })).toEqual("/question/1");
+        expect(question({ id: 1, card_id: 42, name: "Foo" })).toEqual(
+          "/question/42-foo",
+        );
+      });
+    });
   });
 
   describe("query", () => {

--- a/frontend/test/metabase/scenarios/onboarding/home/activity-page.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/home/activity-page.cy.spec.js
@@ -55,7 +55,7 @@ describe("metabase > scenarios > home > activity-page", () => {
     cy.findByText("Products, Filtered by Rating");
   });
 
-  it.skip("should respect the (added to dashboard) card id in the link (metabase#18547)", () => {
+  it("should respect the (added to dashboard) card id in the link (metabase#18547)", () => {
     cy.intercept("GET", `/api/dashboard/1`).as("dashboard");
 
     cy.visit("/dashboard/1");


### PR DESCRIPTION
### Status:
PENDING REVIEW

### What does this PR accomplish?
- Fixes #18547 - the regression that was most likely caused by https://github.com/metabase/metabase/pull/15989.
- Adds unit tests for question ids

Explanation:
When constructing question link, this helper function didn't take into account the possibility that the question can be in the dashboard, which is what's happening here:
https://github.com/metabase/metabase/blob/master/frontend/src/metabase/home/components/Activity.jsx#L473

`dashCard.card_id` is the question's id, while `dashCard.id` is the actual dashboard card id.

This PR added a conditional logic that checks if `card_id` exists and then uses it as question's id when constructing the path.

### How to test?
- Related repro should pass
- Adding multiple identical questions to the dashboard should result in all links rendering correctly (using the same id)

Before the fix:
![ ](https://p58.f1.n0.cdn.getcloudapp.com/items/5zu95Kvd/ebbcf0a0-6b1d-4cc1-8ced-d7aeb6274c5e.gif?source=viewer&v=64c8ba3bbfb59310e5ad7b4eefc2d6f5)

After the fix:
![ ](https://p58.f1.n0.cdn.getcloudapp.com/items/jkuEypWA/8facf596-6c5a-4e9a-996a-2961cfa12902.gif?source=viewer&v=ea69b86c11c89d20d1f2dfd8128caab7)