### PR TITLE
MAX_INT as default audit query limit

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/audit_app/pages/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_app/pages/common.clj
@@ -24,7 +24,7 @@
             [schema.core :as s]
             [toucan.db :as db]))
 
-(def ^:private ^:const default-limit 1000)
+(def ^:private ^:const default-limit Integer/MAX_VALUE)
 
 (defn- add-default-params [honeysql-query]
   (let [{:keys [limit offset]} qp.middleware.audit/*additional-query-params*]

--- a/enterprise/backend/src/metabase_enterprise/audit_app/pages/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_app/pages/common.clj
@@ -24,15 +24,17 @@
             [schema.core :as s]
             [toucan.db :as db]))
 
+(def ^:private ^:const default-limit Integer/MAX_VALUE)
+
 (defn- add-default-params [honeysql-query]
   (let [{:keys [limit offset]} qp.middleware.audit/*additional-query-params*]
     (if (and (nil? limit) (nil? offset))
       honeysql-query
-      (cond-> honeysql-query
-        limit (update :limit (fn [query-limit]
-                               (or limit query-limit)))
-        true  (update :offset (fn [query-offset]
-                                (or offset query-offset 0)))))))
+      (-> honeysql-query
+          (update :limit (fn [query-limit]
+                           (or limit query-limit default-limit)))
+          (update :offset (fn [query-offset]
+                            (or offset query-offset 0)))))))
 
 (defn- inject-cte-body-into-from
   [from ctes]

--- a/enterprise/backend/src/metabase_enterprise/audit_app/pages/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_app/pages/common.clj
@@ -24,15 +24,13 @@
             [schema.core :as s]
             [toucan.db :as db]))
 
-(def ^:private ^:const default-limit Integer/MAX_VALUE)
-
 (defn- add-default-params [honeysql-query]
   (let [{:keys [limit offset]} qp.middleware.audit/*additional-query-params*]
-    (-> honeysql-query
-        (update :limit (fn [query-limit]
-                         (or limit query-limit default-limit)))
-        (update :offset (fn [query-offset]
-                          (or offset query-offset 0))))))
+    (cond-> honeysql-query
+      limit (update :limit (fn [query-limit]
+                             (or limit query-limit)))
+      true (update :offset (fn [query-offset]
+                            (or offset query-offset 0))))))
 
 (defn- inject-cte-body-into-from
   [from ctes]

--- a/enterprise/backend/src/metabase_enterprise/audit_app/pages/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_app/pages/common.clj
@@ -24,15 +24,15 @@
             [schema.core :as s]
             [toucan.db :as db]))
 
-(def ^:private ^:const default-limit Integer/MAX_VALUE)
-
 (defn- add-default-params [honeysql-query]
   (let [{:keys [limit offset]} qp.middleware.audit/*additional-query-params*]
-    (-> honeysql-query
-        (update :limit (fn [query-limit]
-                         (or limit query-limit default-limit)))
-        (update :offset (fn [query-offset]
-                          (or offset query-offset 0))))))
+    (if (and (nil? limit) (nil? offset))
+      honeysql-query
+      (cond-> honeysql-query
+        limit (update :limit (fn [query-limit]
+                               (or limit query-limit)))
+        true  (update :offset (fn [query-offset]
+                                (or offset query-offset 0)))))))
 
 (defn- inject-cte-body-into-from
   [from ctes]

--- a/enterprise/backend/src/metabase_enterprise/audit_app/pages/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_app/pages/common.clj
@@ -24,13 +24,15 @@
             [schema.core :as s]
             [toucan.db :as db]))
 
+(def ^:private ^:const default-limit Integer/MAX_VALUE)
+
 (defn- add-default-params [honeysql-query]
   (let [{:keys [limit offset]} qp.middleware.audit/*additional-query-params*]
-    (cond-> honeysql-query
-      limit (update :limit (fn [query-limit]
-                             (or limit query-limit)))
-      true (update :offset (fn [query-offset]
-                            (or offset query-offset 0))))))
+    (-> honeysql-query
+        (update :limit (fn [query-limit]
+                         (or limit query-limit default-limit)))
+        (update :offset (fn [query-offset]
+                          (or offset query-offset 0))))))
 
 (defn- inject-cte-body-into-from
   [from ctes]

--- a/enterprise/backend/src/metabase_enterprise/audit_app/pages/users.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_app/pages/users.clj
@@ -6,8 +6,6 @@
             [ring.util.codec :as codec]
             [schema.core :as s]))
 
-(def ^:private ^:const date-cardinality-limit 25000)
-
 ;; DEPRECATED Query that returns data for a two-series timeseries: the number of DAU (a User is considered active for
 ;; purposes of this query if they ran at least one query that day), and total number of queries ran. Broken out by
 ;; day.
@@ -42,15 +40,13 @@
                                  {:select   [[(common/grouped-datetime datetime-unit :started_at) :date]
                                              [:%distinct-count.executor_id :count]]
                                   :from     [:query_execution]
-                                  :group-by [(common/grouped-datetime datetime-unit :started_at)]
-                                  :limit    date-cardinality-limit})
+                                  :group-by [(common/grouped-datetime datetime-unit :started_at)]})
                    date->active (zipmap (map :date active) (map :count active))
                    new          (common/query
                                  {:select   [[(common/grouped-datetime datetime-unit :date_joined) :date]
                                              [:%count.* :count]]
                                   :from     [:core_user]
-                                  :group-by [(common/grouped-datetime datetime-unit :date_joined)]
-                                  :limit    date-cardinality-limit})
+                                  :group-by [(common/grouped-datetime datetime-unit :date_joined)]})
                    date->new    (zipmap (map :date new) (map :count new))
                    all-dates    (sort (keep identity (distinct (concat (keys date->active)
                                                                        (keys date->new)))))]


### PR DESCRIPTION
Dan said in review of #18527 that we should just set limit to MAX_INT since there might be others with underlying problem of #18527. I didn't find any in pretty desultory testing but flamber found like 3 immediately. Should actually whack #17820.