### PR TITLE
Fuzz the tokenizer of custom expression

### DIFF
--- a/frontend/test/metabase/lib/expressions/generator.js
+++ b/frontend/test/metabase/lib/expressions/generator.js
@@ -1,0 +1,110 @@
+// Simple Fast Counter - as recommended by PRACTRAND
+const sfc32 = (a, b, c, d) => {
+  return () => {
+    a >>>= 0;
+    b >>>= 0;
+    c >>>= 0;
+    d >>>= 0;
+    let t = (a + b) | 0;
+    a = b ^ (b >>> 9);
+    b = (c + (c << 3)) | 0;
+    c = (c << 21) | (c >>> 11);
+    d = (d + 1) | 0;
+    t = (t + d) | 0;
+    c = (c + t) | 0;
+    return (t >>> 0) / 4294967296;
+  };
+};
+
+export function generateExpression(seed) {
+  const u32seed = seed ^ 0xc0fefe;
+  const mathRandom = sfc32(0x9e3779b9, 0x243f6a88, 0xb7e15162, u32seed);
+  for (let i = 0; i < 15; ++i) mathRandom();
+
+  const randomInt = max => Math.floor(max * mathRandom());
+  const randomItem = items => items[randomInt(items.length)];
+  const oneOf = functions => () => randomItem(functions).apply(null, []);
+
+  const id = () => String.fromCharCode(65 + randomInt(25));
+  const field = () => {
+    let name = id();
+    while (mathRandom() < 0.7) name += id();
+    return { type: "Field", field: name };
+  };
+
+  const zero = () => 0;
+  const one = () => 1;
+  const integer = () => randomInt(1e6);
+  const number = () => oneOf([zero, one, integer])();
+
+  const alphanum = () => String.fromCharCode(32 + randomInt(94));
+  const string = () => {
+    let str = alphanum();
+    while (mathRandom() < 0.9) str += alphanum();
+    return '"' + str + '"';
+  };
+
+  const literal = () => {
+    return {
+      type: "Literal",
+      value: oneOf([number, string])(),
+    };
+  };
+
+  const unary = () => {
+    return {
+      type: "Unary",
+      op: randomItem("-", "NOT"),
+      child: expression(),
+    };
+  };
+
+  const binary = () => {
+    return {
+      type: "Binary",
+      op: randomItem([
+        "+",
+        "-",
+        "*",
+        "/",
+        "!=",
+        "<=",
+        ">=",
+        "<",
+        ">",
+        "=",
+        "AND",
+        "OR",
+      ]),
+      left: expression(),
+      right: expression(),
+    };
+  };
+
+  const expression = () => oneOf([field, literal, unary, binary])();
+
+  const format = node => {
+    let str = null;
+    const { type } = node;
+    switch (type) {
+      case "Field":
+        str = "[" + node.field + "]";
+        break;
+      case "Literal":
+        str = node.value;
+        break;
+      case "Unary":
+        str = node.op + " " + format(node.child);
+        break;
+      case "Binary":
+        str = format(node.left) + " " + node.op + " " + format(node.right);
+        break;
+    }
+
+    if (str === null) throw new Error(`Unknown AST node ${type}`);
+    return str;
+  };
+
+  const expr = expression();
+  return format(expr);
+}

--- a/frontend/test/metabase/lib/expressions/generator.js
+++ b/frontend/test/metabase/lib/expressions/generator.js
@@ -141,7 +141,7 @@ export function generateExpression(seed) {
   const expression = () => (depth <= 0 ? literal() : primary());
 
   const format = node => {
-    const spaces = () => listOf(1, [space])().join("");
+    const spaces = () => listOf(1, [space, () => ""])().join("");
     const blank = ch => spaces() + ch + spaces();
     let str = null;
     const { type, value, op, left, right, child, params } = node;
@@ -154,7 +154,7 @@ export function generateExpression(seed) {
         str = blank(op) + " " + format(child);
         break;
       case NODE.Binary:
-        str = format(left) + " " + blank(op) + " " + format(right);
+        str = format(left) + blank(op) + format(right);
         break;
       case NODE.FunctionCall:
         str = value + blank("(") + params.map(format).join(", ") + blank(")");

--- a/frontend/test/metabase/lib/expressions/generator.js
+++ b/frontend/test/metabase/lib/expressions/generator.js
@@ -89,7 +89,7 @@ export function generateExpression(seed) {
   const unary = () => {
     return {
       type: NODE.Unary,
-      op: randomItem(["-", "NOT"]),
+      op: randomItem(["-", "NOT "]),
       child: expression(),
     };
   };
@@ -108,8 +108,8 @@ export function generateExpression(seed) {
         ">",
         "<=",
         ">=",
-        "AND",
-        "OR",
+        " AND ",
+        " OR ",
       ]),
       left: expression(),
       right: expression(),

--- a/frontend/test/metabase/lib/expressions/tokenizer.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/tokenizer.unit.spec.js
@@ -5,6 +5,8 @@ import {
   countMatchingParentheses,
 } from "metabase/lib/expressions/tokenizer";
 
+import { generateExpression } from "./generator";
+
 describe("metabase/lib/expressions/tokenizer", () => {
   const types = expr => tokenize(expr).tokens.map(t => t.type);
   const ops = expr => tokenize(expr).tokens.map(t => t.op);
@@ -151,3 +153,20 @@ describe("metabase/lib/expressions/tokenizer", () => {
     expect(count("COUNTIF(Deal))")).toEqual(-1);
   });
 });
+
+if (process.env.MB_FUZZ) {
+  describe("FUZZING metabase/lib/expressions/tokenizer", () => {
+    const MAX_SEED = 5e4;
+
+    for (let seed = 0; seed < MAX_SEED; ++seed) {
+      it("should handle generated expression from seed " + seed, () => {
+        const { expression } = generateExpression(seed);
+        expect(() => tokenize(expression)).not.toThrow();
+      });
+      it("should not error on generated expression from seed " + seed, () => {
+        const { expression } = generateExpression(seed);
+        expect(tokenize(expression).errors).toEqual([]);
+      });
+    }
+  });
+}


### PR DESCRIPTION
The function `generateExpression` constructs a lexically valid expression, though the expression is not guaranteed to be syntactically valid. This is fine since the expression is being fed to the tokenizer, which should not throw any error at all since there is no invalid token (e.g. unterminated quoted string etc). Above all, the tokenizer must terminate and must not throw an exception. For more background and context, refer to PR #15659.

This also serves as the basis for the upcoming fuzzer for the parser.

Since fuzzing is too stressful for CI, right now it's **not** being executed as part of CI (we'll evaluate that at some point).

To run the test manually, set the environment variable `MB_FUZZ`, e.g.

```bash
MB_FUZZ=1 yarn test-unit frontend/test/metabase/lib/expressions/tokenizer.unit.spec.js
```

**WARNING**: The tests might torture your machine for approx 7 minutes. To reduce the stress, modify `MAX_SEED` accordingly.
