### PR TITLE
Disable modal transition when reduced-motion is preferred

### DIFF
--- a/frontend/src/metabase/css/components/modal.css
+++ b/frontend/src/metabase/css/components/modal.css
@@ -108,6 +108,6 @@
   .Modal-backdrop.Modal-appear .Modal,
   .Modal-backdrop.Modal-enter .Modal,
   .Modal-backdrop.Modal-leave .Modal {
-    transition: opacity 0ms, transform 0ms;
+    transition: none;
   }
 }

--- a/frontend/src/metabase/css/components/modal.css
+++ b/frontend/src/metabase/css/components/modal.css
@@ -101,7 +101,7 @@
   transform: translate(0, -40px);
 }
 
-@media (prefers-reduced-motion: reduce) {
+@media (prefers-reduced-motion) {
   .Modal-backdrop.Modal-appear,
   .Modal-backdrop.Modal-enter,
   .Modal-backdrop.Modal-leave,

--- a/frontend/src/metabase/css/components/modal.css
+++ b/frontend/src/metabase/css/components/modal.css
@@ -100,3 +100,14 @@
   opacity: 0.01;
   transform: translate(0, -40px);
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .Modal-backdrop.Modal-appear,
+  .Modal-backdrop.Modal-enter,
+  .Modal-backdrop.Modal-leave,
+  .Modal-backdrop.Modal-appear .Modal,
+  .Modal-backdrop.Modal-enter .Modal,
+  .Modal-backdrop.Modal-leave .Modal {
+    transition: opacity 0ms, transform 0ms;
+  }
+}


### PR DESCRIPTION
The modal component is used in various places. Here are two simplest ones to check (but make sure to exercise the modals elsewhere):

### SQL for this question

1. Make sure to enable [prefers-reduced-motion](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion#user_preferences)
2. Ask a question, Custom Question
3. Sample Dataset, Products
4. Click View the SQL (top right corner)

**Before this PR**

The modal "SQL for this question" shows up with a gradual transition (`opacity` in CSS). The same with the darker backdrop,

**After this PR**

The modal appears instantly. The backdrop changes to become darker instantly.

### Save questions

1. Make sure to enable [prefers-reduced-motion](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion#user_preferences)
2. Ask a question, Simple Question
3. Sample Dataset, Products
4. Click Save

**Before this PR**

The modal "Save question" shows up with a gradual transition (`opacity` in CSS). The same with the backdrop getting darker.

**After this PR**

The modal appears instantly. The backdrop changes to become darker instantly.