### PR TITLE
Fix SSH tunnel for SSH servers with certain configuration

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -88,7 +88,7 @@
   org.apache.poi/poi-ooxml                  {:mvn/version "5.0.0"
                                              :exclusions  [org.bouncycastle/bcpkix-jdk15on
                                                            org.bouncycastle/bcprov-jdk15on]}
-  org.apache.sshd/sshd-core                 {:mvn/version "2.7.0"}              ; ssh tunneling and test server
+  org.apache.sshd/sshd-core                 {:mvn/version "2.4.0"}              ; ssh tunneling and test server -- do not use 2.6.0 to 2.7.0, see metabase#18316
   org.apache.xmlgraphics/batik-all          {:mvn/version "1.14"}               ; SVG -> image
   org.clojars.pntblnk/clj-ldap              {:mvn/version "0.0.17"}             ; LDAP client
   org.bouncycastle/bcpkix-jdk15on           {:mvn/version "1.69"}               ; Bouncy Castle crypto library -- explicit version of BC specified to resolve illegal reflective access errors


### PR DESCRIPTION
Version 2.6.0 until 2.7.0 of org.apache.sshd has a bug that will fail to connect to SSH servers configured to use `-oKexAlgorithms=diffie-hellman-group-exchange-sha256`.

Reverting to the known working version (ref - #17326). We can upgrade to 2.7.1 once it is released.

Reference: https://issues.apache.org/jira/browse/SSHD-1163

Fixes #18316
