### PR TITLE
Overworld: use consistent CSS for "X" buttons

### DIFF
--- a/frontend/src/metabase/containers/Overworld.jsx
+++ b/frontend/src/metabase/containers/Overworld.jsx
@@ -110,7 +110,7 @@ class Overworld extends React.Component {
                                       <Icon
                                         ml="2"
                                         name="close"
-                                        className="hover-child text-brand-hover"
+                                        className="block hover-child text-brand-hover"
                                       />
                                     </Tooltip>
                                   }


### PR DESCRIPTION
Before:
<img width="514" alt="Screen Shot 2564-10-21 at 16 32 15" src="https://user-images.githubusercontent.com/88995137/138251271-261ade13-628e-4257-b0b6-a2e73a0c9dfb.png">

After:
<img width="515" alt="Screen Shot 2564-10-21 at 16 32 31" src="https://user-images.githubusercontent.com/88995137/138251286-8f954d50-0ae5-4831-9019-0818a60289b1.png">

"Our Data" for comparison:
<img width="181" alt="Screen Shot 2564-10-21 at 16 32 35" src="https://user-images.githubusercontent.com/88995137/138251243-6794b151-7863-4c48-b609-45c94570580f.png">


Fixes #18156