### PR TITLE
Hide password reset screen until token is loaded

### DIFF
--- a/frontend/src/metabase/auth/containers/PasswordResetApp.jsx
+++ b/frontend/src/metabase/auth/containers/PasswordResetApp.jsx
@@ -25,6 +25,7 @@ const mapStateToProps = (state, props) => {
 @connect(mapStateToProps)
 export default class PasswordResetApp extends Component {
   state = {
+    loading: true,
     tokenValid: false,
     resetSuccess: false,
   };
@@ -39,6 +40,8 @@ export default class PasswordResetApp extends Component {
       }
     } catch (error) {
       console.log("error validating token", error);
+    } finally {
+      this.setState({ loading: false });
     }
   }
 
@@ -57,7 +60,7 @@ export default class PasswordResetApp extends Component {
 
   render() {
     const { newUserJoining } = this.props;
-    const { resetSuccess } = this.state;
+    const { loading, resetSuccess } = this.state;
 
     const passwordComplexity = MetabaseSettings.passwordComplexityDescription();
 
@@ -66,6 +69,10 @@ export default class PasswordResetApp extends Component {
         {t`request a new reset email`}
       </Link>
     );
+
+    if (loading) {
+      return null;
+    }
 
     return (
       <AuthLayout>


### PR DESCRIPTION
I've opted not to use the loading animation because token validation is usually very fast and showing the loader for a second looks bad.

I've tested these using "Fast 3G" setting on Chrome

Before

https://user-images.githubusercontent.com/88995137/138261090-a395bafa-6330-45b0-b1bc-15e5e2197949.mp4

After - Valid Token

https://user-images.githubusercontent.com/88995137/138261160-f3e57418-32df-499d-9a03-5b04207b3f1e.mp4

After - Invalid Token

https://user-images.githubusercontent.com/88995137/138261188-77f8bfd0-e474-4292-853b-019b9229179a.mp4

Fixes #16722