### PR TITLE
Extract sidebar component from NativeQueryEditor

### DIFF
--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
@@ -26,7 +26,6 @@ import { ResizableBox } from "react-resizable";
 
 import "./NativeQueryEditor.css";
 
-import { isMac } from "metabase/lib/browser";
 import { isEventOverElement } from "metabase/lib/dom";
 import { delay } from "metabase/lib/promise";
 import { SQLBehaviour } from "metabase/lib/ace/sql_behaviour";
@@ -41,17 +40,13 @@ import SnippetCollections from "metabase/entities/snippet-collections";
 import Parameters from "metabase/parameters/components/Parameters/Parameters";
 import Question from "metabase-lib/lib/Question";
 import NativeQuery from "metabase-lib/lib/queries/NativeQuery";
+import NativeQueryEditorSidebar from "./NativeQueryEditor/NativeQueryEditorSidebar";
 
 import {
   DatabaseDataSelector,
   SchemaAndTableDataSelector,
 } from "metabase/query_builder/components/DataSelector";
 import SnippetModal from "metabase/query_builder/components/template_tags/SnippetModal";
-
-import RunButtonWithTooltip from "./RunButtonWithTooltip";
-import DataReferenceButton from "./view/DataReferenceButton";
-import NativeVariablesButton from "./view/NativeVariablesButton";
-import SnippetSidebarButton from "./view/SnippetSidebarButton";
 
 import type { DatasetQuery } from "metabase-types/types/Card";
 import type { DatabaseId } from "metabase-types/types/Database";
@@ -111,8 +106,6 @@ const SCROLL_MARGIN = 8;
 const LINE_HEIGHT = 16;
 
 const MIN_HEIGHT_LINES = 13;
-
-const ICON_SIZE = 18;
 
 const getEditorLineHeight = lines => lines * LINE_HEIGHT + 2 * SCROLL_MARGIN;
 const getLinesForHeight = height => (height - 2 * SCROLL_MARGIN) / LINE_HEIGHT;
@@ -482,29 +475,15 @@ export default class NativeQueryEditor extends Component {
   render() {
     const {
       query,
-      cancelQuery,
       setParameterValue,
       location,
       readOnly,
       isNativeEditorOpen,
-      isRunnable,
-      isRunning,
-      isResultDirty,
-      isPreviewing,
-      snippetCollections,
-      snippets,
     } = this.props;
 
     const database = query.database();
     const databases = query.metadata().databasesList({ savedQuestions: false });
     const parameters = query.question().parameters();
-
-    // hide the snippet sidebar if there aren't any visible snippets/collections and the root collection isn't writable
-    const showSnippetSidebarButton = !(
-      snippets?.length === 0 &&
-      snippetCollections?.length === 1 &&
-      snippetCollections[0].can_write === false
-    );
 
     let dataSelectors = [];
     if (isNativeEditorOpen && databases.length > 0) {
@@ -627,14 +606,14 @@ export default class NativeQueryEditor extends Component {
             <div className="flex flex-column">
               <a className="p2 bg-medium-hover flex" onClick={this.runQuery}>
                 <Icon name={"play"} size={16} className="mr1" />
-                <h4>Run selection</h4>
+                <h4>{t`Run selection`}</h4>
               </a>
               <a
                 className="p2 bg-medium-hover flex"
                 onClick={this.props.openSnippetModalWithSelectedText}
               >
                 <Icon name={"snippet"} size={16} className="mr1" />
-                <h4>Save as snippet</h4>
+                <h4>{t`Save as snippet`}</h4>
               </a>
             </div>
           </Popover>
@@ -653,43 +632,10 @@ export default class NativeQueryEditor extends Component {
             />
           )}
           {!readOnly && (
-            <div className="flex flex-column align-center">
-              <DataReferenceButton
-                {...this.props}
-                size={ICON_SIZE}
-                className="mt3"
-              />
-              <NativeVariablesButton
-                {...this.props}
-                size={ICON_SIZE}
-                className="mt3"
-              />
-              {showSnippetSidebarButton && (
-                <SnippetSidebarButton
-                  {...this.props}
-                  size={ICON_SIZE}
-                  className="mt3"
-                />
-              )}
-              <RunButtonWithTooltip
-                disabled={!isRunnable}
-                isRunning={isRunning}
-                isDirty={isResultDirty}
-                isPreviewing={isPreviewing}
-                onRun={this.runQuery}
-                onCancel={() => cancelQuery()}
-                compact
-                className="mx2 mb2 mt-auto"
-                style={{ width: 40, height: 40 }}
-                getTooltip={() =>
-                  (this.props.nativeEditorSelectedText
-                    ? t`Run selected text`
-                    : t`Run query`) +
-                  " " +
-                  (isMac() ? t`(⌘ + enter)` : t`(Ctrl + enter)`)
-                }
-              />
-            </div>
+            <NativeQueryEditorSidebar
+              runQuery={this.runQuery}
+              {...this.props}
+            />
           )}
         </ResizableBox>
       </div>

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditorSidebar/NativeQueryEditorSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditorSidebar/NativeQueryEditorSidebar.jsx
@@ -1,0 +1,62 @@
+/* eslint-disable react/prop-types */
+
+import React from "react";
+import { t } from "ttag";
+
+import { isMac } from "metabase/lib/browser";
+
+import RunButtonWithTooltip from "metabase/query_builder/components/RunButtonWithTooltip";
+import DataReferenceButton from "metabase/query_builder/components/view/DataReferenceButton";
+import NativeVariablesButton from "metabase/query_builder/components/view/NativeVariablesButton";
+import SnippetSidebarButton from "metabase/query_builder/components/view/SnippetSidebarButton";
+
+const ICON_SIZE = 18;
+
+const NativeQueryEditorSidebar = props => {
+  const {
+    cancelQuery,
+    isRunnable,
+    isRunning,
+    isResultDirty,
+    isPreviewing,
+    nativeEditorSelectedText,
+    runQuery,
+    snippetCollections,
+    snippets,
+  } = props;
+
+  // hide the snippet sidebar if there aren't any visible snippets/collections and the root collection isn't writable
+  const showSnippetSidebarButton = !(
+    snippets?.length === 0 &&
+    snippetCollections?.length === 1 &&
+    snippetCollections[0].can_write === false
+  );
+
+  return (
+    <div className="flex flex-column align-center">
+      <DataReferenceButton {...props} size={ICON_SIZE} className="mt3" />
+      <NativeVariablesButton {...props} size={ICON_SIZE} className="mt3" />
+      {showSnippetSidebarButton && (
+        <SnippetSidebarButton {...props} size={ICON_SIZE} className="mt3" />
+      )}
+      <RunButtonWithTooltip
+        disabled={!isRunnable}
+        isRunning={isRunning}
+        isDirty={isResultDirty}
+        isPreviewing={isPreviewing}
+        onRun={runQuery}
+        onCancel={() => cancelQuery()}
+        compact
+        className="mx2 mb2 mt-auto"
+        style={{ width: 40, height: 40 }}
+        getTooltip={() =>
+          (nativeEditorSelectedText ? t`Run selected text` : t`Run query`) +
+          " " +
+          (isMac() ? t`(⌘ + enter)` : t`(Ctrl + enter)`)
+        }
+      />
+    </div>
+  );
+};
+
+export default NativeQueryEditorSidebar;

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditorSidebar/NativeQueryEditorSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditorSidebar/NativeQueryEditorSidebar.jsx
@@ -4,14 +4,14 @@ import { t } from "ttag";
 
 import { isMac } from "metabase/lib/browser";
 
+import DataReferenceButton from "metabase/query_builder/components/view/DataReferenceButton";
+import NativeVariablesButton from "metabase/query_builder/components/view/NativeVariablesButton";
+import SnippetSidebarButton from "metabase/query_builder/components/view/SnippetSidebarButton";
+
 import {
   Container,
   RunButtonWithTooltipStyled,
 } from "./NativeQueryEditorSidebar.styled";
-
-import DataReferenceButton from "metabase/query_builder/components/view/DataReferenceButton";
-import NativeVariablesButton from "metabase/query_builder/components/view/NativeVariablesButton";
-import SnippetSidebarButton from "metabase/query_builder/components/view/SnippetSidebarButton";
 
 const propTypes = {
   cancelQuery: PropTypes.func.isRequired,
@@ -45,10 +45,10 @@ const NativeQueryEditorSidebar = props => {
   const showSnippetSidebarButton = !(
     snippets?.length === 0 &&
     snippetCollections?.length === 1 &&
-    snippetCollections[0].can_write === false
+    !snippetCollections[0].can_write
   );
 
-  const getTooltip = function() {
+  const getTooltip = () => {
     const command = nativeEditorSelectedText
       ? t`Run selected text`
       : t`Run query`;

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditorSidebar/NativeQueryEditorSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditorSidebar/NativeQueryEditorSidebar.jsx
@@ -1,5 +1,5 @@
-/* eslint-disable react/prop-types */
 import React from "react";
+import PropTypes from "prop-types";
 import { t } from "ttag";
 
 import { isMac } from "metabase/lib/browser";
@@ -13,15 +13,27 @@ import DataReferenceButton from "metabase/query_builder/components/view/DataRefe
 import NativeVariablesButton from "metabase/query_builder/components/view/NativeVariablesButton";
 import SnippetSidebarButton from "metabase/query_builder/components/view/SnippetSidebarButton";
 
+const propTypes = {
+  cancelQuery: PropTypes.func.isRequired,
+  isPreviewing: PropTypes.bool.isRequired,
+  isResultDirty: PropTypes.bool.isRequired,
+  isRunnable: PropTypes.bool.isRequired,
+  isRunning: PropTypes.bool.isRequired,
+  nativeEditorSelectedText: PropTypes.string,
+  runQuery: PropTypes.func.isRequired,
+  snippetCollections: PropTypes.array,
+  snippets: PropTypes.array,
+};
+
 const ICON_SIZE = 18;
 
 const NativeQueryEditorSidebar = props => {
   const {
     cancelQuery,
+    isPreviewing,
+    isResultDirty,
     isRunnable,
     isRunning,
-    isResultDirty,
-    isPreviewing,
     nativeEditorSelectedText,
     runQuery,
     snippetCollections,
@@ -66,5 +78,7 @@ const NativeQueryEditorSidebar = props => {
     </Container>
   );
 };
+
+NativeQueryEditorSidebar.propTypes = propTypes;
 
 export default NativeQueryEditorSidebar;

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditorSidebar/NativeQueryEditorSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditorSidebar/NativeQueryEditorSidebar.jsx
@@ -32,6 +32,16 @@ const NativeQueryEditorSidebar = props => {
     snippetCollections[0].can_write === false
   );
 
+  const getTooltip = function() {
+    const command = nativeEditorSelectedText
+      ? t`Run selected text`
+      : t`Run query`;
+
+    const shortcut = isMac() ? t`(⌘ + enter)` : t`(Ctrl + enter)`;
+
+    return command + " " + shortcut;
+  };
+
   return (
     <div className="flex flex-column align-center">
       <DataReferenceButton {...props} size={ICON_SIZE} className="mt3" />
@@ -49,11 +59,7 @@ const NativeQueryEditorSidebar = props => {
         compact
         className="mx2 mb2 mt-auto"
         style={{ width: 40, height: 40 }}
-        getTooltip={() =>
-          (nativeEditorSelectedText ? t`Run selected text` : t`Run query`) +
-          " " +
-          (isMac() ? t`(⌘ + enter)` : t`(Ctrl + enter)`)
-        }
+        getTooltip={getTooltip}
       />
     </div>
   );

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditorSidebar/NativeQueryEditorSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditorSidebar/NativeQueryEditorSidebar.jsx
@@ -1,11 +1,14 @@
 /* eslint-disable react/prop-types */
-
 import React from "react";
 import { t } from "ttag";
 
 import { isMac } from "metabase/lib/browser";
 
-import RunButtonWithTooltip from "metabase/query_builder/components/RunButtonWithTooltip";
+import {
+  Container,
+  RunButtonWithTooltipStyled,
+} from "./NativeQueryEditorSidebar.styled";
+
 import DataReferenceButton from "metabase/query_builder/components/view/DataReferenceButton";
 import NativeVariablesButton from "metabase/query_builder/components/view/NativeVariablesButton";
 import SnippetSidebarButton from "metabase/query_builder/components/view/SnippetSidebarButton";
@@ -44,13 +47,13 @@ const NativeQueryEditorSidebar = props => {
   };
 
   return (
-    <div className="flex flex-column align-center">
+    <Container>
       <DataReferenceButton {...props} size={ICON_SIZE} className="mt3" />
       <NativeVariablesButton {...props} size={ICON_SIZE} className="mt3" />
       {showSnippetSidebarButton && (
         <SnippetSidebarButton {...props} size={ICON_SIZE} className="mt3" />
       )}
-      <RunButtonWithTooltip
+      <RunButtonWithTooltipStyled
         disabled={!isRunnable}
         isRunning={isRunning}
         isDirty={isResultDirty}
@@ -58,11 +61,9 @@ const NativeQueryEditorSidebar = props => {
         onRun={runQuery}
         onCancel={cancelQuery}
         compact
-        className="mx2 mb2 mt-auto"
-        style={{ width: 40, height: 40 }}
         getTooltip={getTooltip}
       />
-    </div>
+    </Container>
   );
 };
 

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditorSidebar/NativeQueryEditorSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditorSidebar/NativeQueryEditorSidebar.jsx
@@ -25,7 +25,8 @@ const NativeQueryEditorSidebar = props => {
     snippets,
   } = props;
 
-  // hide the snippet sidebar if there aren't any visible snippets/collections and the root collection isn't writable
+  // hide the snippet sidebar if there aren't any visible snippets/collections
+  // and the root collection isn't writable
   const showSnippetSidebarButton = !(
     snippets?.length === 0 &&
     snippetCollections?.length === 1 &&
@@ -55,7 +56,7 @@ const NativeQueryEditorSidebar = props => {
         isDirty={isResultDirty}
         isPreviewing={isPreviewing}
         onRun={runQuery}
-        onCancel={() => cancelQuery()}
+        onCancel={cancelQuery}
         compact
         className="mx2 mb2 mt-auto"
         style={{ width: 40, height: 40 }}

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditorSidebar/NativeQueryEditorSidebar.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditorSidebar/NativeQueryEditorSidebar.styled.jsx
@@ -1,0 +1,18 @@
+import styled from "styled-components";
+
+import { space } from "metabase/styled-components/theme";
+
+import RunButtonWithTooltip from "metabase/query_builder/components/RunButtonWithTooltip";
+
+export const Container = styled.aside`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+export const RunButtonWithTooltipStyled = styled(RunButtonWithTooltip)`
+  margin: ${space(2)};
+  margin-top: auto;
+  height: 40px;
+  width: 40px;
+`;

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditorSidebar/index.js
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditorSidebar/index.js
@@ -1,0 +1,1 @@
+export { default } from "./NativeQueryEditorSidebar";


### PR DESCRIPTION
One step to solve #18536

The `NativeQueryEditor` component was nearly 700 lines of code, this reduces count by 7.7%.

Here we extract one component from it, add prop types, isolate presentation from semantics and clean up props by setting them outside a component's declaration.

## How to test

1. Ask a question
2. Native query
3. Use the query along with the sidebar. Should work as before.

### What has been extracted

![image](https://user-images.githubusercontent.com/380816/138318687-27345a90-f29c-4798-b5ce-a837b6114518.png)
