### PR TITLE
Make the checkins_interval transient datasets more uniquely named in BigQuery test runs

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/test/data/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/test/data/bigquery_cloud_sdk.clj
@@ -21,6 +21,8 @@
 
 (sql.tx/add-test-extensions! :bigquery-cloud-sdk)
 
+(def ^:private ns-load-time (System/currentTimeMillis))
+
 ;; Don't enable foreign keys when testing because BigQuery *doesn't* have a notion of foreign keys. Joins are still
 ;; allowed, which puts us in a weird position, however; people can manually specifiy "foreign key" relationships in
 ;; admin and everything should work correctly. Since we can't infer any "FK" relationships during sync our normal FK
@@ -36,7 +38,9 @@
 (defn- normalize-name ^String [db-or-table identifier]
   (let [s (str/replace (name identifier) "-" "_")]
     (case db-or-table
-      :db    (str "v3_" s)
+      :db    (cond-> (str "v3_" s)
+               (str/includes? s "checkins_interval_")
+               (str "_" ns-load-time))
       :table s)))
 
 (defn- test-db-details []

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/test/data/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/test/data/bigquery_cloud_sdk.clj
@@ -39,7 +39,12 @@
   (let [s (str/replace (name identifier) "-" "_")]
     (case db-or-table
       :db    (cond-> (str "v3_" s)
+               ;; for transient datasets (i.e. those that are created and torn down with each test run), we should add
+               ;; some unique name portion to prevent independent parallel test runs from interfering with each other
+               ;; for now, the only transient datasets that the BigQuery driver(s) make use of are checkins_interval_*
                (str/includes? s "checkins_interval_")
+               ;; for transient datasets, we will make them unique by appending a suffix that represents the millisecond
+               ;; timestamp from when this namespace was loaded (i.e. test initialized on this particular JVM/instance)
                (str "_" ns-load-time))
       :table s)))
 

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/test/data/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/test/data/bigquery_cloud_sdk.clj
@@ -54,7 +54,7 @@
                ;; note that this particular dataset will not be deleted after this test run finishes, since there is no
                ;; reasonable hook to do so (from this test extension namespace), so instead we will rely on each run
                ;; cleaning up outdated, transient datasets via the `transient-dataset-outdated?` mechanism above
-               (str "_" ns-load-time))
+               (str "__transient_" ns-load-time))
       :table s)))
 
 (defn- test-db-details []
@@ -313,9 +313,11 @@
   suffix, so we can just look for that here."
   [dataset-name]
   (let [[_ ds-timestamp-str] (re-matches #".*__transient_(\d+)$" dataset-name)
-        ds-timestamp         (Long. ds-timestamp-str)]
+        ds-timestamp         (when ds-timestamp-str
+                               (Long. ds-timestamp-str))]
     ;; millis to hours
-    (< (* 1000 60 60 2) (- ns-load-time ds-timestamp))))
+    (when ds-timestamp
+      (< (* 1000 60 60 2) (- ns-load-time ds-timestamp)))))
 
 (defmethod tx/create-db! :bigquery-cloud-sdk [_ {:keys [database-name table-definitions]} & _]
   {:pre [(seq database-name) (sequential? table-definitions)]}

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/test/data/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/test/data/bigquery_cloud_sdk.clj
@@ -333,7 +333,8 @@
                    "These BigQuery datasets are transient, and more than two hours old; deleting them: %s`."
                    (u/pprint-to-str (sort outdated-transient-datasets))))
         (doseq [delete-ds outdated-transient-datasets]
-          (destroy-dataset! delete-ds)))))
+          (u/ignore-exceptions
+            (destroy-dataset! delete-ds))))))
   ;; now check and see if we need to create the requested one
   (let [database-name (normalize-name :db database-name)]
     (when-not (contains? @existing-datasets database-name)

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/test/data/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/test/data/bigquery_cloud_sdk.clj
@@ -36,8 +36,9 @@
 ;;; ----------------------------------------------- Connection Details -----------------------------------------------
 
 (defn- transient-dataset?
-  "Returns a boolean indicating whether the given `dataset-name` is transient (i.e. created and destroyed with every
-  test run, for instance to check time intervals relative to \"now\")"
+  "Returns a boolean indicating whether the given `dataset-name` (as per its definition, NOT the physical schema name
+  that is to be created on the cluster) should be made transient (i.e. created and destroyed with every test run, for
+  instance to check time intervals relative to \"now\")."
   [dataset-name]
   (str/includes? dataset-name "checkins_interval_"))
 
@@ -47,10 +48,12 @@
       :db    (cond-> (str "v3_" s)
                ;; for transient datasets (i.e. those that are created and torn down with each test run), we should add
                ;; some unique name portion to prevent independent parallel test runs from interfering with each other
-               ;; for now, the only transient datasets that the BigQuery driver(s) make use of are checkins_interval_*
                (transient-dataset? s)
                ;; for transient datasets, we will make them unique by appending a suffix that represents the millisecond
                ;; timestamp from when this namespace was loaded (i.e. test initialized on this particular JVM/instance)
+               ;; note that this particular dataset will not be deleted after this test run finishes, since there is no
+               ;; reasonable hook to do so (from this test extension namespace), so instead we will rely on each run
+               ;; cleaning up outdated, transient datasets via the `transient-dataset-outdated?` mechanism above
                (str "_" ns-load-time))
       :table s)))
 
@@ -296,23 +299,39 @@
   "Fetch a list of *all* dataset names that currently exist in the BQ test project."
   []
   (for [^Dataset dataset (.iterateAll (.listDatasets (bigquery) (into-array BigQuery$DatasetListOption [])))
-        :let    [dataset-name (.. dataset getDatasetId getDataset)]
-        ;; don't consider that checkins_interval_ datasets created in
-        ;; `metabase.query-processor-test.date-bucketing-test` to be already created, since those test things relative
-        ;; to the current moment in time and thus need to be recreated before running the tests.
-        :when   (not (transient-dataset? dataset-name))]
+        :let    [dataset-name (.. dataset getDatasetId getDataset)]]
     dataset-name))
 
 ;; keep track of databases we haven't created yet
 (def ^:private existing-datasets
   (atom #{}))
 
+(defn- transient-dataset-outdated?
+  "Checks whether the given `dataset-name` is a transient dataset that is outdated, and should be deleted.  Note that
+  unlike `transient-dataset?`, this doesn't need any domain specific knowledge about which transient datasets are
+  outdated. The fact that a *created* dataset (i.e. created on BigQuery) is transient has already been encoded by a
+  suffix, so we can just look for that here."
+  [dataset-name]
+  (let [[_ ds-timestamp-str] (re-matches #".*__transient_(\d+)$" dataset-name)
+        ds-timestamp         (Long. ds-timestamp-str)]
+    ;; millis to hours
+    (< (* 1000 60 60 2) (- ns-load-time ds-timestamp))))
+
 (defmethod tx/create-db! :bigquery-cloud-sdk [_ {:keys [database-name table-definitions]} & _]
   {:pre [(seq database-name) (sequential? table-definitions)]}
   ;; fetch existing datasets if we haven't done so yet
   (when-not (seq @existing-datasets)
-    (reset! existing-datasets (set (existing-dataset-names)))
-    (println "These BigQuery datasets have already been loaded:\n" (u/pprint-to-str (sort @existing-datasets))))
+    (let [{transient-datasets true non-transient-datasets false} (group-by transient-dataset?
+                                                                   (existing-dataset-names))]
+      (reset! existing-datasets (set non-transient-datasets))
+      (println "These BigQuery datasets have already been loaded:\n" (u/pprint-to-str (sort @existing-datasets)))
+      (when-let [outdated-transient-datasets (seq (filter transient-dataset-outdated? transient-datasets))]
+        (println (u/format-color
+                   'blue
+                   "These BigQuery datasets are transient, and more than two hours old; deleting them: %s`."
+                   (u/pprint-to-str (sort outdated-transient-datasets))))
+        (doseq [delete-ds outdated-transient-datasets]
+          (destroy-dataset! delete-ds)))))
   ;; now check and see if we need to create the requested one
   (let [database-name (normalize-name :db database-name)]
     (when-not (contains? @existing-datasets database-name)

--- a/modules/drivers/bigquery/test/metabase/test/data/bigquery.clj
+++ b/modules/drivers/bigquery/test/metabase/test/data/bigquery.clj
@@ -37,52 +37,17 @@
 
 ;; keep track of databases we have already created
 (def ^:private existing-datasets
+  "All datasets that already exist in the BigQuery cluster, so that we can possibly avoid recreating/repopulating them
+  on every run."
   (atom #{}))
-
-(def ^:private current-dataset-version-prefix "v3_")
-
-(defn- transient-dataset?
-  "Returns a boolean indicating whether the given `dataset-name` is transient (i.e. created and destroyed with every
-  test run, for instance to check time intervals relative to \"now\")"
-  [dataset-name]
-  (str/includes? dataset-name "checkins_interval_"))
-
-(defn- make-dataset-name-unique
-  "Adds a legacydriver_ prefix to the db-name, if the `existing-dataset` atom does not contain it. This is to ensure
-  that transient datasets created and destroyed by these tests do not interfere with parallel test runs for the new
-  BigQuery driver (which are also creating and destroying datasets that would have the same name, if not for this
-  change). If the `db-name` is already an existing one, however, the assumption is it's not transient (i.e. not being
-  created and destroyed at test time), and hence, it can keep its name without modification.
-
-  Also, for the checkins_interval datasets (which are always transient, since they use timestamps relative to
-  \"now\", append a unique suffix."
-  [db-name]
-  (if (contains? @existing-datasets db-name)
-    db-name
-    (cond-> (str/replace-first db-name
-                               current-dataset-version-prefix
-                               (str current-dataset-version-prefix "legacydriver_"))
-      ;; for transient datasets (i.e. those that are created and torn down with each test run), we should add
-      ;; some unique name portion to prevent independent parallel test runs from interfering with each other
-      ;; for now, the only transient datasets that the BigQuery driver(s) make use of are checkins_interval_*
-      (transient-dataset? db-name)
-      ;; for transient datasets, we will make them unique by appending a suffix that represents the millisecond
-      ;; timestamp from when this namespace was loaded (i.e. test initialized on this particular JVM/instance)
-      (str "_" ns-load-time))))
-
-(defn- normalize-name ^String [db-or-table-or-field identifier]
-  (let [s (str/replace (name identifier) "-" "_")]
-    (case db-or-table-or-field
-      :db             (make-dataset-name-unique (str current-dataset-version-prefix s))
-      (:table :field) s)))
 
 (def ^:private details
   (delay
     (reduce
-     (fn [acc env-var]
-       (assoc acc env-var (tx/db-test-env-var :bigquery env-var)))
-     {}
-     [:project-id :client-id :client-secret :access-token :refresh-token :service-account-json])))
+      (fn [acc env-var]
+        (assoc acc env-var (tx/db-test-env-var :bigquery env-var)))
+      {}
+      [:project-id :client-id :client-secret :access-token :refresh-token :service-account-json])))
 
 (defn project-id
   "BigQuery project ID that we're using for tests, from the env var `MB_BIGQUERY_TEST_PROJECT_ID`."
@@ -92,6 +57,56 @@
 (def ^:private ^{:arglists '(^com.google.api.services.bigquery.Bigquery [])} bigquery
   "Get an instance of a `Bigquery` client."
   (partial deref (delay (#'bigquery/database->client {:details @details}))))
+
+(defn- destroy-dataset! [^String dataset-id]
+  {:pre [(seq dataset-id)]}
+  (google/execute-no-auto-retry (doto (.delete (.datasets (bigquery)) (project-id) dataset-id)
+                                  (.setDeleteContents true)))
+  (println (u/format-color 'red "Deleted BigQuery dataset `%s.%s`." (project-id) dataset-id)))
+
+(defn- transient-dataset-outdated?
+  "Checks whether the given `dataset-name` is a transient dataset that is outdated, and should be deleted.  Note that
+  unlike `transient-dataset?`, this doesn't need any domain specific knowledge about which transient datasets are
+  outdated. The fact that a *created* dataset (i.e. created on BigQuery) is transient has already been encoded by a
+  suffix, so we can just look for that here."
+  [dataset-name]
+  (let [[_ ds-timestamp-str] (re-matches #".*__transient_(\d+)$" dataset-name)
+        ds-timestamp         (Long. ds-timestamp-str)]
+    ;; millis to hours
+    (< (* 1000 60 60 2) (- ns-load-time ds-timestamp))))
+
+(def ^:private current-dataset-version-prefix "v3_")
+
+(defn- transient-dataset?
+  "Returns a boolean indicating whether the given `dataset-name` (as per its definition, NOT the physical schema name
+  that is to be created on the cluster) should be made transient (i.e. created and destroyed with every test run, for
+  instance to check time intervals relative to \"now\")."
+  [dataset-name]
+  (str/includes? dataset-name "checkins_interval_"))
+
+(defn- make-dataset-name-unique
+  "Ensure a dataset name is unique. If it appears in the `@existing-datasets` atom, it is assumed to be a non-transient
+  dataset that is shared across runs with no problems. If not, and it is transient, then we append a unique suffix to
+  ensure multiple independent parallel runs do not interfere with each other."
+  [db-name]
+  (if (contains? @existing-datasets db-name)
+    db-name
+    (cond-> db-name
+      ;; for transient datasets (i.e. those that are created and torn down with each test run), we should add
+      ;; some unique name portion to prevent independent parallel test runs from interfering with each other
+      (transient-dataset? db-name)
+      ;; for transient datasets, we will make them unique by appending a suffix that represents the millisecond
+      ;; timestamp from when this namespace was loaded (i.e. test initialized on this particular JVM/instance)
+      ;; note that this particular dataset will not be deleted after this test run finishes, since there is no
+      ;; reasonable hook to do so (from this test extension namespace), so instead we will rely on each run cleaning
+      ;; up outdated, transient datasets via the `transient-dataset-outdated?` mechanism above
+      (str "__transient_" ns-load-time))))
+
+(defn- normalize-name ^String [db-or-table-or-field identifier]
+  (let [s (str/replace (name identifier) "-" "_")]
+    (case db-or-table-or-field
+      :db             (make-dataset-name-unique (str current-dataset-version-prefix s))
+      (:table :field) s)))
 
 (defmethod tx/dbdef->connection-details :bigquery [_ _ {:keys [database-name]}]
   (assoc @details :dataset-id (normalize-name :db database-name) :include-user-id-and-hash true))
@@ -113,12 +128,6 @@
       (.setDatasetReference (doto (DatasetReference.)
                               (.setDatasetId dataset-id))))))
   (println (u/format-color 'blue "Created BigQuery dataset `%s.%s`." (project-id) dataset-id)))
-
-(defn- destroy-dataset! [^String dataset-id]
-  {:pre [(seq dataset-id)]}
-  (google/execute-no-auto-retry (doto (.delete (.datasets (bigquery)) (project-id) dataset-id)
-                                  (.setDeleteContents true)))
-  (println (u/format-color 'red "Deleted BigQuery dataset `%s.%s`." (project-id) dataset-id)))
 
 (defn execute!
   "Execute arbitrary (presumably DDL) SQL statements against the test project. Waits for statement to complete, throwing
@@ -352,25 +361,30 @@
             (throw e)))))))
 
 (defn- existing-dataset-names
-  "Fetch a list of *all* dataset names that currently exist in the BQ test project."
+  "Fetch a list of *all* existing dataset names that currently exist in the BQ test project."
   []
   (for [dataset (get (google/execute (doto (.list (.datasets (bigquery)) (project-id))
                                        ;; Long/MAX_VALUE barfs but it has to be a Long
                                        (.setMaxResults (long Integer/MAX_VALUE))))
                      "datasets")
-        :let    [dataset-name (get-in dataset ["datasetReference" "datasetId"])]
-        ;; don't consider that checkins_interval_ datasets created in
-        ;; `metabase.query-processor-test.date-bucketing-test` to be already created, since those test things relative
-        ;; to the current moment in time and thus need to be recreated before running the tests.
-        :when   (not (transient-dataset? dataset-name))]
+        :let    [dataset-name (get-in dataset ["datasetReference" "datasetId"])]]
     dataset-name))
 
 (defmethod tx/create-db! :bigquery [_ {:keys [database-name table-definitions]} & _]
   {:pre [(seq database-name) (sequential? table-definitions)]}
   ;; fetch existing datasets if we haven't done so yet
   (when-not (seq @existing-datasets)
-    (reset! existing-datasets (set (existing-dataset-names)))
-    (println "These BigQuery datasets have already been loaded:\n" (u/pprint-to-str (sort @existing-datasets))))
+    (let [{transient-datasets true non-transient-datasets false} (group-by transient-dataset?
+                                                                           (existing-dataset-names))]
+      (reset! existing-datasets (set non-transient-datasets))
+      (println "These BigQuery datasets have already been loaded:\n" (u/pprint-to-str (sort @existing-datasets)))
+      (when-let [outdated-transient-datasets (seq (filter transient-dataset-outdated? transient-datasets))]
+        (println (u/format-color
+                  'blue
+                  "These BigQuery datasets are transient, and more than two hours old; deleting them: %s`."
+                   (u/pprint-to-str (sort outdated-transient-datasets))))
+        (doseq [delete-ds outdated-transient-datasets]
+          (destroy-dataset! delete-ds)))))
   ;; now check and see if we need to create the requested one
   (let [database-name (normalize-name :db database-name)]
     (when-not (contains? @existing-datasets database-name)

--- a/modules/drivers/bigquery/test/metabase/test/data/bigquery.clj
+++ b/modules/drivers/bigquery/test/metabase/test/data/bigquery.clj
@@ -70,12 +70,9 @@
   outdated. The fact that a *created* dataset (i.e. created on BigQuery) is transient has already been encoded by a
   suffix, so we can just look for that here."
   [dataset-name]
-  (let [[_ ds-timestamp-str] (re-matches #".*__transient_(\d+)$" dataset-name)
-        ds-timestamp         (when ds-timestamp-str
-                               (Long. ds-timestamp-str))]
+  (when-let [[_ ds-timestamp-str] (re-matches #".*__transient_(\d+)$" dataset-name)]
     ;; millis to hours
-    (when ds-timestamp
-      (< (* 1000 60 60 2) (- ns-load-time ds-timestamp)))))
+    (< (* 1000 60 60 2) (- ns-load-time (Long. ds-timestamp-str)))))
 
 (def ^:private current-dataset-version-prefix "v3_")
 

--- a/modules/drivers/bigquery/test/metabase/test/data/bigquery.clj
+++ b/modules/drivers/bigquery/test/metabase/test/data/bigquery.clj
@@ -386,7 +386,8 @@
                   "These BigQuery datasets are transient, and more than two hours old; deleting them: %s`."
                    (u/pprint-to-str (sort outdated-transient-datasets))))
         (doseq [delete-ds outdated-transient-datasets]
-          (destroy-dataset! delete-ds)))))
+          (u/ignore-exceptions
+            (destroy-dataset! delete-ds))))))
   ;; now check and see if we need to create the requested one
   (let [database-name (normalize-name :db database-name)]
     (when-not (contains? @existing-datasets database-name)

--- a/modules/drivers/bigquery/test/metabase/test/data/bigquery.clj
+++ b/modules/drivers/bigquery/test/metabase/test/data/bigquery.clj
@@ -71,9 +71,11 @@
   suffix, so we can just look for that here."
   [dataset-name]
   (let [[_ ds-timestamp-str] (re-matches #".*__transient_(\d+)$" dataset-name)
-        ds-timestamp         (Long. ds-timestamp-str)]
+        ds-timestamp         (when ds-timestamp-str
+                               (Long. ds-timestamp-str))]
     ;; millis to hours
-    (< (* 1000 60 60 2) (- ns-load-time ds-timestamp))))
+    (when ds-timestamp
+      (< (* 1000 60 60 2) (- ns-load-time ds-timestamp)))))
 
 (def ^:private current-dataset-version-prefix "v3_")
 

--- a/modules/drivers/bigquery/test/metabase/test/data/bigquery.clj
+++ b/modules/drivers/bigquery/test/metabase/test/data/bigquery.clj
@@ -56,7 +56,12 @@
     (cond-> (str/replace-first db-name
                                current-dataset-version-prefix
                                (str current-dataset-version-prefix "legacydriver_"))
+      ;; for transient datasets (i.e. those that are created and torn down with each test run), we should add
+      ;; some unique name portion to prevent independent parallel test runs from interfering with each other
+      ;; for now, the only transient datasets that the BigQuery driver(s) make use of are checkins_interval_*
       (str/includes? db-name "checkins_interval_")
+      ;; for transient datasets, we will make them unique by appending a suffix that represents the millisecond
+      ;; timestamp from when this namespace was loaded (i.e. test initialized on this particular JVM/instance)
       (str "_" ns-load-time))))
 
 (defn- normalize-name ^String [db-or-table-or-field identifier]


### PR DESCRIPTION
Append a timestamp suffix (initialized when the namespace was loaded) to the `checkins_interval_` database names
