### PR TITLE
Refactor pulse specs

### DIFF
--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -1,7 +1,6 @@
 import _ from "underscore";
 import {
   restore,
-  setupLocalHostEmail,
   modal,
   popover,
   openOrdersTable,
@@ -29,7 +28,6 @@ const [admin, collection, sub_collection] = [
   },
 ];
 
-const pulse_name = "Test pulse";
 const dashboard_name = "Test Dashboard";
 
 describe("scenarios > collection_defaults", () => {
@@ -179,29 +177,6 @@ describe("scenarios > collection_defaults", () => {
       });
     });
 
-    // [quarantine]: cannot run tests that rely on email setup in CI (yet)
-    describe.skip("a new pulse", () => {
-      it("should be in the root collection", () => {
-        // Configure email
-        cy.visit("/admin/settings/email");
-        setupLocalHostEmail();
-
-        // Make new pulse
-        createPulse();
-
-        // Check for pulse in root collection
-        cy.visit("/collection/root");
-        cy.findByText("My personal collection").then(() => {
-          cy.icon("pulse");
-        });
-
-        // cy.request("/api/pulse").then((response) => {
-        //     // *** Should the value here really be nll or should it be "root"?
-        //     expect(response.body[0].collection_id).to.have.value(null);
-        // });
-      });
-    });
-
     describe("a new dashboard", () => {
       it("should be in the root collection", () => {
         // Make new dashboard and check collection name
@@ -217,24 +192,6 @@ describe("scenarios > collection_defaults", () => {
     beforeEach(() => {
       restore();
       cy.signInAsNormalUser();
-    });
-
-    // [quarantine]: cannot run tests that rely on email setup in CI (yet)
-    describe.skip("a new pulse", () => {
-      beforeEach(() => {
-        cy.visit("/admin/settings/email");
-        setupLocalHostEmail();
-      });
-
-      it("should be in the root collection", () => {
-        // Make new pulse
-        createPulse();
-
-        // Check for pulse in root collection
-        cy.visit("/collection/root");
-        cy.findByText("My personal collection");
-        cy.icon("pulse");
-      });
     });
 
     describe("a new dashboard", () => {
@@ -608,24 +565,6 @@ describe("scenarios > collection_defaults", () => {
     });
   });
 });
-
-function createPulse() {
-  cy.visit("/pulse/create");
-  cy.findByPlaceholderText("Important metrics").type(pulse_name);
-  cy.findByText("Select a question").click();
-  cy.findByText("Orders").click();
-  cy.findByPlaceholderText(
-    "Enter email addresses you'd like this data to go to",
-  )
-    .click()
-    .clear();
-  cy.contains("Bobby").click();
-  cy.findByText("To:").click();
-
-  cy.findByText("Robert Tableton").should("not.exist");
-  cy.findByText("Bobby Tables");
-  cy.findByText("Create pulse").click();
-}
 
 function openEllipsisMenuFor(item) {
   cy.findByText(item)

--- a/frontend/test/metabase/scenarios/sharing/pulse.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/pulse.cy.spec.js
@@ -1,22 +1,11 @@
-import { restore } from "__support__/e2e/cypress";
-
-const MOCK_PULSE_FORM_INPUT = {
-  channels: {
-    email: {
-      type: "email",
-      name: "Email",
-      allows_recipients: true,
-      configured: true,
-      recipients: ["user", "email"],
-      schedules: ["daily", "weekly", "monthly"],
-    },
-  },
-};
+import { restore, setupSMTP } from "__support__/e2e/cypress";
 
 describe("scenarios > pulse", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
+
+    setupSMTP();
   });
   it("should be able get to the new pulse page from the nav bar", () => {
     cy.visit("/");
@@ -28,9 +17,6 @@ describe("scenarios > pulse", () => {
   });
 
   it("should create a new pulse", () => {
-    cy.server();
-    cy.route("GET", "/api/pulse/form_input", MOCK_PULSE_FORM_INPUT);
-
     cy.visit("/pulse/create");
 
     cy.findByPlaceholderText("Important metrics")
@@ -39,6 +25,7 @@ describe("scenarios > pulse", () => {
 
     cy.contains("Select a question").click();
     cy.contains("Orders, Count").click();
+
     cy.findByPlaceholderText("Enter user names or email addresses")
       .type("bobby@example.test")
       .blur();
@@ -46,9 +33,10 @@ describe("scenarios > pulse", () => {
     // pulse card preview
     cy.contains("18,760");
 
-    cy.contains("Create pulse").click();
+    cy.button("Create pulse").click();
 
     cy.url().should("match", /\/collection\/root$/);
+
     cy.contains("pulse title");
   });
 


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Removes some obsolete and redundant pulse tests from the `collections` spec
- Retires the mocked version of the pulse creation test and use the actual SMTP setup

This is the first step towards removing the deprecated `setupLocalHostEmail` helper.