### PR TITLE
docs - add caching to Enterprise guide landing page

### DIFF
--- a/docs/enterprise-guide/cache.md
+++ b/docs/enterprise-guide/cache.md
@@ -1,0 +1,12 @@
+# Advanced caching controls
+
+All Metabase editions include global caching controls. The Enterprise edition includes additional caching options that let you control caching for individual questions.
+
+With Enterprise, you can override your default caching options for questions, caching the results for more or less time than the default time-to-live (TTL) duration set by your site-wide caching settings. Setting caching per question is especially useful when data relevant to the question has a different natural cadence than your site-wide caching rule, such as when the question queries data that doesn't change often.
+
+To learn how to set caching preferences on individual questions, check out our [User's guide][caching].
+
+For an overview of site-wide caching available to all Metabase editions, check out our [Adminstrator's guide][caching-admin].
+
+[caching]: ../users-guide/06-sharing-answers.md#caching-results
+[caching-admin]: ../administration-guide/14-caching.html

--- a/docs/enterprise-guide/start.md
+++ b/docs/enterprise-guide/start.md
@@ -24,6 +24,7 @@ The Enterprise Edition of Metabase provides additional features that help organi
 
 - [Copying contents of one Metabase instance to another (serialization)](serialization.md)
 - [Using the audit logs](audit.md)
+- [Caching answers to questions](cache.md);
 - [Organizing SQL snippets with folders and permissions](sql-snippets.md)
 - [Customizing filter values for each dashboard subscription](dashboard-subscriptions.md)
-- [Admin tools for tracking errors](tools.md)
+- [Tracking query errors](tools.md)


### PR DESCRIPTION
Adds caching controls to Enterprise page and includes a small summary page that links out to relevant sections on caching.

@LopMike is there anything else you'd want us to include here. @flamber, do we want to mention the caching/sandbox issue in the docs?