### PR TITLE
Fix #17701: "Set up your own alert" text missing horizontal padding

### DIFF
--- a/frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx
+++ b/frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx
@@ -98,7 +98,7 @@ export default class AlertListPopoverContent extends Component {
               className="link flex align-center text-bold text-small"
               onClick={this.onAdd}
             >
-              <Icon name="add" style={{ marginLeft: 9, marignRight: 17 }} />{" "}
+              <Icon name="add" style={{ marginLeft: 9, marginRight: 17 }} />{" "}
               {t`Set up your own alert`}
             </a>
           </div>


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- Fixes the typo in the `style` for `marginRight`
- which fixes and closes #17701 

Before:
![image](https://user-images.githubusercontent.com/31325167/138357956-a5d74e06-715e-485f-9ef7-2a91f8ec85bf.png)

After:
![image](https://user-images.githubusercontent.com/31325167/138357894-ee445bf0-12bc-47c1-8983-ff93cae3ef88.png)
