### PR TITLE
Register mocked Slack configuration (global e2e helper)

### DIFF
--- a/frontend/test/__support__/e2e/cypress.js
+++ b/frontend/test/__support__/e2e/cypress.js
@@ -24,6 +24,7 @@ export * from "./helpers/e2e-data-model-helpers";
 export * from "./helpers/e2e-misc-helpers";
 export * from "./helpers/e2e-deprecated-helpers";
 export * from "./helpers/e2e-email-helpers";
+export * from "./helpers/e2e-slack-helpers";
 export * from "./helpers/e2e-custom-column-helpers";
 
 Cypress.on("uncaught:exception", (err, runnable) => false);

--- a/frontend/test/__support__/e2e/helpers/e2e-slack-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-slack-helpers.js
@@ -1,0 +1,35 @@
+// Since there is no testing API token for Slack, it's easier to mock its configuration
+const mockedSlack = {
+  type: "slack",
+  name: "Slack",
+  allows_recipients: true,
+  schedules: ["hourly", "daily", "weekly", "monthly"],
+  fields: [
+    {
+      name: "channel",
+      type: "select",
+      displayName: "Post to",
+      options: ["#work", "#play"],
+      required: true,
+    },
+  ],
+  configured: true,
+};
+
+export function mockSlackConfigured() {
+  // First, let's get the actual config (email might have already been configured and we want to preserve that)
+  cy.request("GET", "/api/pulse/form_input").then(({ body }) => {
+    const originalEmailConfig = body.channels.email;
+
+    const mockedConfig = Object.assign({}, body, {
+      channels: {
+        email: originalEmailConfig,
+        slack: mockedSlack,
+      },
+    });
+
+    // Stubbing the response in advance
+    // (Cypress will intercept it when we navigate to "Dashboard subscriptions" or a question alert)
+    cy.intercept("GET", "/api/pulse/form_input", mockedConfig);
+  });
+}

--- a/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
@@ -5,6 +5,7 @@ import {
   popover,
   mockSessionProperty,
   sidebar,
+  mockSlackConfigured,
 } from "__support__/e2e/cypress";
 import { USERS } from "__support__/e2e/cypress_data";
 const { admin } = USERS;
@@ -434,37 +435,4 @@ function addParametersToDashboard() {
   cy.findByText("Save").click();
   // wait for dashboard to save
   cy.contains("You're editing this dashboard.").should("not.exist");
-}
-
-function mockSlackConfigured() {
-  // Stubbing the response in advance (Cypress will intercept it when we navigate to "Dashboard subscriptions")
-  cy.server();
-  cy.route("GET", "/api/pulse/form_input", {
-    channels: {
-      email: {
-        type: "email",
-        name: "Email",
-        allows_recipients: false,
-        recipients: ["user", "email"],
-        schedules: ["hourly", "daily", "weekly", "monthly"],
-        configured: false,
-      },
-      slack: {
-        type: "slack",
-        name: "Slack",
-        allows_recipients: true,
-        schedules: ["hourly", "daily", "weekly", "monthly"],
-        fields: [
-          {
-            name: "channel",
-            type: "select",
-            displayName: "Post to",
-            options: ["#work", "#play"],
-            required: true,
-          },
-        ],
-        configured: true,
-      },
-    },
-  });
 }


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- It moves the local `mockSlackConfigured` helper to the global scope
- It refactors the existing helper and improves its readability and functionality
    - The old one was mocking email as well
    - The new one preserves whichever email config was already there (if any)