### PR TITLE
move parameter type utils into own file

### DIFF
--- a/frontend/src/metabase/meta/Parameter.js
+++ b/frontend/src/metabase/meta/Parameter.js
@@ -30,6 +30,10 @@ import {
   NUMBER,
   PRIMARY_KEY,
 } from "metabase/lib/schema_metadata";
+import {
+  getParameterType,
+  getParameterSubType,
+} from "metabase/parameters/utils/parameter-type";
 
 import Variable, { TemplateTagVariable } from "metabase-lib/lib/Variable";
 
@@ -211,21 +215,6 @@ export function getOperatorDisplayName(option, operatorType, sectionName) {
   } else {
     return `${sectionName} ${option.name.toLowerCase()}`;
   }
-}
-
-// sectionId will match a type of field (category, location, number, date, id, etc.)
-// if sectionId is undefined, it is an old parameter that did have it set
-// OR it is a PARAMETER_OPTION entry. In those situations,
-// a `type` will exist like "category" or "location/city" or "string/="
-// we split on the `/` and take the first entry to get the field type
-function getParameterType(parameter) {
-  const { sectionId } = parameter;
-  return sectionId || splitType(parameter)[0];
-}
-
-function getParameterSubType(parameter) {
-  const [, subtype] = splitType(parameter);
-  return subtype;
 }
 
 function fieldFilterForParameter(parameter: Parameter): FieldPredicate {
@@ -561,7 +550,7 @@ export function getParameterIconName(parameter: ?Parameter) {
 }
 
 export function normalizeParameterValue(type, value) {
-  const [fieldType] = splitType(type);
+  const fieldType = getParameterType(type);
 
   if (["string", "number"].includes(fieldType)) {
     return value == null ? [] : [].concat(value);
@@ -597,13 +586,6 @@ function getParameterOperatorType(parameterType) {
     default:
       return undefined;
   }
-}
-
-function splitType(parameterOrType) {
-  const parameterType = _.isString(parameterOrType)
-    ? parameterOrType
-    : (parameterOrType || {}).type || "";
-  return parameterType.split("/");
 }
 
 export function getValuePopulatedParameters(parameters, parameterValues) {

--- a/frontend/src/metabase/parameters/utils/parameter-type.js
+++ b/frontend/src/metabase/parameters/utils/parameter-type.js
@@ -1,0 +1,18 @@
+import _ from "underscore";
+
+export function getParameterType(parameter) {
+  return parameter.sectionId || splitType(parameter)[0];
+}
+
+export function getParameterSubType(parameter) {
+  const [, subtype] = splitType(parameter);
+  return subtype;
+}
+
+function splitType(parameterOrType) {
+  const parameterType = _.isString(parameterOrType)
+    ? parameterOrType
+    : parameterOrType?.type || "";
+
+  return parameterType.split("/");
+}

--- a/frontend/src/metabase/parameters/utils/parameter-type.unit.spec.js
+++ b/frontend/src/metabase/parameters/utils/parameter-type.unit.spec.js
@@ -1,0 +1,33 @@
+import { getParameterType, getParameterSubType } from "./parameter-type";
+
+describe("parameters/utils/parameter-type", () => {
+  describe("getParameterType", () => {
+    it("should return the string before the slash in a parameter type", () => {
+      expect(getParameterType({ type: "string/foo" })).toEqual("string");
+      expect(getParameterType({ type: "category" })).toEqual("category");
+    });
+
+    it("should return the string before the slash in a parameter's type", () => {
+      expect(getParameterType({ type: "string/foo" })).toEqual("string");
+      expect(getParameterType({ type: "category" })).toEqual("category");
+    });
+
+    it("should prefer using a sectionId for determing the type if it exists", () => {
+      expect(
+        getParameterType({ sectionId: "location", type: "string/=" }),
+      ).toEqual("location");
+    });
+  });
+
+  describe("getParameterSubType", () => {
+    it("should return the string before the slash in a parameter type", () => {
+      expect(getParameterSubType("string/foo")).toEqual("foo");
+      expect(getParameterSubType("category")).toBeUndefined();
+    });
+
+    it("should return the string before the slash in a parameter's type", () => {
+      expect(getParameterSubType("string/foo")).toEqual("foo");
+      expect(getParameterSubType("category")).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
The is part of a series of PRs to split all the parameters logic in `metabase/meta/(Card|Dashboard|Parameter).js` into more reasonable utils files. 

This PR is the first in the series because a number of functions in `metabase/meta/Parameter.js` rely on it. All I'm doing here is moving these functions from `metabase/meta/Parameter.js` to a new file, `metabase/parameters/utils/parameter-type.js`.