### PR TITLE
move dashboard parameter options logic to own file

### DIFF
--- a/frontend/src/metabase/dashboard/components/ParametersPopover.jsx
+++ b/frontend/src/metabase/dashboard/components/ParametersPopover.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import { t } from "ttag";
-import { getParameterSections } from "metabase/meta/Dashboard";
+import { getDashboardParameterSections } from "metabase/parameters/utils/dashboard-options";
 import Icon from "metabase/components/Icon";
 import { getParameterIconName } from "metabase/meta/Parameter";
 import styled from "styled-components";
@@ -32,7 +32,7 @@ export default class ParametersPopover extends Component {
     this.state = {};
   }
 
-  PARAMETER_SECTIONS = getParameterSections();
+  PARAMETER_SECTIONS = getDashboardParameterSections();
 
   render() {
     const { section } = this.state;

--- a/frontend/src/metabase/meta/Dashboard.js
+++ b/frontend/src/metabase/meta/Dashboard.js
@@ -1,8 +1,6 @@
 import _ from "underscore";
 import { setIn } from "icepick";
-import { t } from "ttag";
 
-import MetabaseSettings from "metabase/lib/settings";
 import Question from "metabase-lib/lib/Question";
 
 import { ExpressionDimension } from "metabase-lib/lib/Dimension";
@@ -15,17 +13,13 @@ import type {
   ParameterMappingUIOption,
 } from "metabase-types/types/Parameter";
 
-import {
-  getParameterOptions,
-  PARAMETER_OPERATOR_TYPES,
-  getParameterTargetField,
-} from "metabase/meta/Parameter";
-import { getOperatorDisplayName } from "metabase/parameters/utils/operators";
+import { getParameterTargetField } from "metabase/meta/Parameter";
 import {
   dimensionFilterForParameter,
   getTagOperatorFilterForParameter,
   variableFilterForParameter,
 } from "metabase/parameters/utils/filters";
+
 import { slugify } from "metabase/lib/formatting";
 
 export type ParameterSection = {
@@ -34,109 +28,6 @@ export type ParameterSection = {
   description: string,
   options: ParameterOption[],
 };
-
-const areFieldFilterOperatorsEnabled = () =>
-  MetabaseSettings.get("field-filter-operators-enabled?");
-
-const LOCATION_OPTIONS = [
-  {
-    type: "location/city",
-    name: t`City`,
-  },
-  {
-    type: "location/state",
-    name: t`State`,
-  },
-  {
-    type: "location/zip_code",
-    name: t`ZIP or Postal Code`,
-  },
-  {
-    type: "location/country",
-    name: t`Country`,
-  },
-];
-const CATEGORY_OPTIONS = [{ type: "category", name: t`Category` }];
-
-export function getParameterSections(): ParameterSection[] {
-  const parameterOptions = getParameterOptions();
-
-  return [
-    {
-      id: "date",
-      name: t`Time`,
-      description: t`Date range, relative date, time of day, etc.`,
-      options: PARAMETER_OPERATOR_TYPES["date"].map(option => {
-        return {
-          ...option,
-          sectionId: "date",
-          combinedName: getOperatorDisplayName(option, "date", t`Date`),
-        };
-      }),
-    },
-    {
-      id: "location",
-      name: t`Location`,
-      description: t`City, State, Country, ZIP code.`,
-      options: areFieldFilterOperatorsEnabled()
-        ? PARAMETER_OPERATOR_TYPES["string"].map(option => {
-            return {
-              ...option,
-              sectionId: "location",
-              combinedName: getOperatorDisplayName(
-                option,
-                "string",
-                t`Location`,
-              ),
-            };
-          })
-        : LOCATION_OPTIONS,
-    },
-
-    {
-      id: "id",
-      name: t`ID`,
-      description: t`User ID, Product ID, Event ID, etc.`,
-      options: [
-        {
-          ..._.findWhere(parameterOptions, { type: "id" }),
-          sectionId: "id",
-        },
-      ],
-    },
-    areFieldFilterOperatorsEnabled() && {
-      id: "number",
-      name: t`Number`,
-      description: t`Subtotal, Age, Price, Quantity, etc.`,
-      options: PARAMETER_OPERATOR_TYPES["number"].map(option => {
-        return {
-          ...option,
-          sectionId: "number",
-          combinedName: getOperatorDisplayName(option, "number", t`Number`),
-        };
-      }),
-    },
-    areFieldFilterOperatorsEnabled()
-      ? {
-          id: "string",
-          name: t`Text or Category`,
-          description: t`Name, Rating, Description, etc.`,
-          options: PARAMETER_OPERATOR_TYPES["string"].map(option => {
-            return {
-              ...option,
-              sectionId: "string",
-              combinedName: getOperatorDisplayName(option, "string", t`Text`),
-            };
-          }),
-        }
-      : {
-          id: "category",
-          name: t`Other Categories`,
-          description: t`Category, Type, Model, Rating, etc.`,
-          options: CATEGORY_OPTIONS,
-        },
-  ].filter(Boolean);
-}
 
 export function getParameterMappingOptions(
   metadata: Metadata,

--- a/frontend/src/metabase/parameters/constants.js
+++ b/frontend/src/metabase/parameters/constants.js
@@ -1,0 +1,149 @@
+import { t } from "ttag";
+
+export const PARAMETER_OPERATOR_TYPES = {
+  number: [
+    {
+      type: "number/=",
+      operator: "=",
+      name: t`Equal to`,
+    },
+    {
+      type: "number/!=",
+      operator: "!=",
+      name: t`Not equal to`,
+    },
+    {
+      type: "number/between",
+      operator: "between",
+      name: t`Between`,
+    },
+    {
+      type: "number/>=",
+      operator: ">=",
+      name: t`Greater than or equal to`,
+    },
+    {
+      type: "number/<=",
+      operator: "<=",
+      name: t`Less than or equal to`,
+    },
+  ],
+  string: [
+    {
+      type: "string/=",
+      operator: "=",
+      name: t`Dropdown`,
+      description: t`Select one or more values from a list or search box.`,
+    },
+    {
+      type: "string/!=",
+      operator: "!=",
+      name: t`Is not`,
+      description: t`Exclude one or more specific values.`,
+    },
+    {
+      type: "string/contains",
+      operator: "contains",
+      name: t`Contains`,
+      description: t`Match values that contain the entered text.`,
+    },
+    {
+      type: "string/does-not-contain",
+      operator: "does-not-contain",
+      name: t`Does not contain`,
+      description: t`Filter out values that contain the entered text.`,
+    },
+    {
+      type: "string/starts-with",
+      operator: "starts-with",
+      name: t`Starts with`,
+      description: t`Match values that begin with the entered text.`,
+    },
+    {
+      type: "string/ends-with",
+      operator: "ends-with",
+      name: t`Ends with`,
+      description: t`Match values that end with the entered text.`,
+    },
+  ],
+  date: [
+    {
+      type: "date/month-year",
+      operator: "month-year",
+      name: t`Month and Year`,
+      description: t`Like January, 2016`,
+    },
+    {
+      type: "date/quarter-year",
+      operator: "quarter-year",
+      name: t`Quarter and Year`,
+      description: t`Like Q1, 2016`,
+    },
+    {
+      type: "date/single",
+      operator: "single",
+      name: t`Single Date`,
+      description: t`Like January 31, 2016`,
+    },
+    {
+      type: "date/range",
+      operator: "range",
+      name: t`Date Range`,
+      description: t`Like December 25, 2015 - February 14, 2016`,
+    },
+    {
+      type: "date/relative",
+      operator: "relative",
+      name: t`Relative Date`,
+      description: t`Like "the last 7 days" or "this month"`,
+    },
+    {
+      type: "date/all-options",
+      operator: "all-options",
+      name: t`Date Filter`,
+      menuName: t`All Options`,
+      description: t`Contains all of the above`,
+    },
+  ],
+};
+
+export const OPTIONS_WITH_OPERATOR_SUBTYPES = [
+  {
+    type: "date",
+    typeName: t`Date`,
+  },
+  {
+    type: "string",
+    typeName: t`String`,
+  },
+  {
+    type: "number",
+    typeName: t`Number`,
+  },
+];
+
+export const ID_OPTION = {
+  type: "id",
+  name: t`ID`,
+};
+
+export const CATEGORY_OPTION = { type: "category", name: t`Category` };
+
+export const LOCATION_OPTIONS = [
+  {
+    type: "location/city",
+    name: t`City`,
+  },
+  {
+    type: "location/state",
+    name: t`State`,
+  },
+  {
+    type: "location/zip_code",
+    name: t`ZIP or Postal Code`,
+  },
+  {
+    type: "location/country",
+    name: t`Country`,
+  },
+];

--- a/frontend/src/metabase/parameters/utils/dashboard-options.js
+++ b/frontend/src/metabase/parameters/utils/dashboard-options.js
@@ -1,0 +1,87 @@
+import { t } from "ttag";
+import { areFieldFilterOperatorsEnabled } from "./feature-flag";
+import { getOperatorDisplayName } from "./operators";
+import {
+  PARAMETER_OPERATOR_TYPES,
+  LOCATION_OPTIONS,
+  ID_OPTION,
+  CATEGORY_OPTION,
+} from "../constants";
+
+export function getDashboardParameterSections() {
+  return [
+    {
+      id: "date",
+      name: t`Time`,
+      description: t`Date range, relative date, time of day, etc.`,
+      options: PARAMETER_OPERATOR_TYPES["date"].map(option => {
+        return {
+          ...option,
+          sectionId: "date",
+          combinedName: getOperatorDisplayName(option, "date", t`Date`),
+        };
+      }),
+    },
+    {
+      id: "location",
+      name: t`Location`,
+      description: t`City, State, Country, ZIP code.`,
+      options: areFieldFilterOperatorsEnabled()
+        ? PARAMETER_OPERATOR_TYPES["string"].map(option => {
+            return {
+              ...option,
+              sectionId: "location",
+              combinedName: getOperatorDisplayName(
+                option,
+                "string",
+                t`Location`,
+              ),
+            };
+          })
+        : LOCATION_OPTIONS,
+    },
+
+    {
+      id: "id",
+      name: t`ID`,
+      description: t`User ID, Product ID, Event ID, etc.`,
+      options: [
+        {
+          ...ID_OPTION,
+          sectionId: "id",
+        },
+      ],
+    },
+    areFieldFilterOperatorsEnabled() && {
+      id: "number",
+      name: t`Number`,
+      description: t`Subtotal, Age, Price, Quantity, etc.`,
+      options: PARAMETER_OPERATOR_TYPES["number"].map(option => {
+        return {
+          ...option,
+          sectionId: "number",
+          combinedName: getOperatorDisplayName(option, "number", t`Number`),
+        };
+      }),
+    },
+    areFieldFilterOperatorsEnabled()
+      ? {
+          id: "string",
+          name: t`Text or Category`,
+          description: t`Name, Rating, Description, etc.`,
+          options: PARAMETER_OPERATOR_TYPES["string"].map(option => {
+            return {
+              ...option,
+              sectionId: "string",
+              combinedName: getOperatorDisplayName(option, "string", t`Text`),
+            };
+          }),
+        }
+      : {
+          id: "category",
+          name: t`Other Categories`,
+          description: t`Category, Type, Model, Rating, etc.`,
+          options: [CATEGORY_OPTION],
+        },
+  ].filter(Boolean);
+}

--- a/frontend/src/metabase/parameters/utils/dashboard-options.js
+++ b/frontend/src/metabase/parameters/utils/dashboard-options.js
@@ -8,39 +8,36 @@ import {
   CATEGORY_OPTION,
 } from "../constants";
 
+function buildTypedOperatorOptions(operatorType, sectionId, sectionName) {
+  return PARAMETER_OPERATOR_TYPES[operatorType].map(operatorOption => {
+    return {
+      ...operatorOption,
+      sectionId,
+      combinedName: getOperatorDisplayName(
+        operatorOption,
+        operatorType,
+        sectionName,
+      ),
+    };
+  });
+}
+
 export function getDashboardParameterSections() {
   return [
     {
       id: "date",
       name: t`Time`,
       description: t`Date range, relative date, time of day, etc.`,
-      options: PARAMETER_OPERATOR_TYPES["date"].map(option => {
-        return {
-          ...option,
-          sectionId: "date",
-          combinedName: getOperatorDisplayName(option, "date", t`Date`),
-        };
-      }),
+      options: buildTypedOperatorOptions("date", "date", t`Date`),
     },
     {
       id: "location",
       name: t`Location`,
       description: t`City, State, Country, ZIP code.`,
       options: areFieldFilterOperatorsEnabled()
-        ? PARAMETER_OPERATOR_TYPES["string"].map(option => {
-            return {
-              ...option,
-              sectionId: "location",
-              combinedName: getOperatorDisplayName(
-                option,
-                "string",
-                t`Location`,
-              ),
-            };
-          })
+        ? buildTypedOperatorOptions("string", "location", t`Location`)
         : LOCATION_OPTIONS,
     },
-
     {
       id: "id",
       name: t`ID`,
@@ -56,26 +53,14 @@ export function getDashboardParameterSections() {
       id: "number",
       name: t`Number`,
       description: t`Subtotal, Age, Price, Quantity, etc.`,
-      options: PARAMETER_OPERATOR_TYPES["number"].map(option => {
-        return {
-          ...option,
-          sectionId: "number",
-          combinedName: getOperatorDisplayName(option, "number", t`Number`),
-        };
-      }),
+      options: buildTypedOperatorOptions("number", "number", t`Number`),
     },
     areFieldFilterOperatorsEnabled()
       ? {
           id: "string",
           name: t`Text or Category`,
           description: t`Name, Rating, Description, etc.`,
-          options: PARAMETER_OPERATOR_TYPES["string"].map(option => {
-            return {
-              ...option,
-              sectionId: "string",
-              combinedName: getOperatorDisplayName(option, "string", t`Text`),
-            };
-          }),
+          options: buildTypedOperatorOptions("string", "string", t`Text`),
         }
       : {
           id: "category",

--- a/frontend/src/metabase/parameters/utils/dashboard-options.unit.spec.js
+++ b/frontend/src/metabase/parameters/utils/dashboard-options.unit.spec.js
@@ -1,0 +1,83 @@
+import _ from "underscore";
+import MetabaseSettings from "metabase/lib/settings";
+import { getDashboardParameterSections } from "./dashboard-options";
+
+MetabaseSettings.get = jest.fn();
+
+function mockFieldFilterOperatorsFlag(value) {
+  MetabaseSettings.get.mockImplementation(flag => {
+    if (flag === "field-filter-operators-enabled?") {
+      return value;
+    }
+  });
+}
+
+describe("parameters/utils/dashboard-options", () => {
+  describe("getDashboardParameterSections", () => {
+    beforeEach(() => {
+      mockFieldFilterOperatorsFlag(false);
+    });
+
+    describe("when `field-filter-operators-enabled?` is false", () => {
+      it("should not have a number section", () => {
+        expect(
+          _.findWhere(getDashboardParameterSections(), { id: "number" }),
+        ).not.toBeDefined();
+      });
+
+      it("should have location options that map to location/* parameters", () => {
+        const locationSection = _.findWhere(getDashboardParameterSections(), {
+          id: "location",
+        });
+        expect(
+          locationSection.options.every(option =>
+            option.type.startsWith("location"),
+          ),
+        ).toBe(true);
+      });
+
+      it("should have a category section", () => {
+        expect(
+          _.findWhere(getDashboardParameterSections(), { id: "category" }),
+        ).toBeDefined();
+
+        expect(
+          _.findWhere(getDashboardParameterSections(), { id: "string" }),
+        ).not.toBeDefined();
+      });
+    });
+
+    describe("when `field-filter-operators-enabled?` is true", () => {
+      beforeEach(() => {
+        mockFieldFilterOperatorsFlag(true);
+      });
+
+      it("should have a number section", () => {
+        expect(
+          _.findWhere(getDashboardParameterSections(), { id: "number" }),
+        ).toBeDefined();
+      });
+
+      it("should have location options that map to string/* parameters", () => {
+        const locationSection = _.findWhere(getDashboardParameterSections(), {
+          id: "location",
+        });
+        expect(
+          locationSection.options.every(option =>
+            option.type.startsWith("string"),
+          ),
+        ).toBe(true);
+      });
+
+      it("should have a string section", () => {
+        expect(
+          _.findWhere(getDashboardParameterSections(), { id: "category" }),
+        ).not.toBeDefined();
+
+        expect(
+          _.findWhere(getDashboardParameterSections(), { id: "string" }),
+        ).toBeDefined();
+      });
+    });
+  });
+});

--- a/frontend/src/metabase/parameters/utils/feature-flag.js
+++ b/frontend/src/metabase/parameters/utils/feature-flag.js
@@ -1,0 +1,5 @@
+import MetabaseSettings from "metabase/lib/settings";
+
+export function areFieldFilterOperatorsEnabled() {
+  return MetabaseSettings.get("field-filter-operators-enabled?");
+}

--- a/frontend/test/metabase/meta/Dashboard.unit.spec.js
+++ b/frontend/test/metabase/meta/Dashboard.unit.spec.js
@@ -1,4 +1,3 @@
-import _ from "underscore";
 import {
   metadata,
   SAMPLE_DATASET,
@@ -6,9 +5,7 @@ import {
   ORDERS,
   PRODUCTS,
 } from "__support__/sample_dataset_fixture";
-import MetabaseSettings from "metabase/lib/settings";
 import {
-  getParameterSections,
   createParameter,
   setParameterName,
   setParameterDefaultValue,
@@ -29,85 +26,7 @@ function native(native) {
   return SAMPLE_DATASET.nativeQuestion(native).card();
 }
 
-MetabaseSettings.get = jest.fn();
-
-function mockFieldFilterOperatorsFlag(value) {
-  MetabaseSettings.get.mockImplementation(flag => {
-    if (flag === "field-filter-operators-enabled?") {
-      return value;
-    }
-  });
-}
-
 describe("meta/Dashboard", () => {
-  describe("getParameterSections", () => {
-    beforeEach(() => {
-      mockFieldFilterOperatorsFlag(false);
-    });
-
-    describe("when `field-filter-operators-enabled?` is false", () => {
-      it("should not have a number section", () => {
-        expect(
-          _.findWhere(getParameterSections(), { id: "number" }),
-        ).not.toBeDefined();
-      });
-
-      it("should have location options that map to location/* parameters", () => {
-        const locationSection = _.findWhere(getParameterSections(), {
-          id: "location",
-        });
-        expect(
-          locationSection.options.every(option =>
-            option.type.startsWith("location"),
-          ),
-        ).toBe(true);
-      });
-
-      it("should have a category section", () => {
-        expect(
-          _.findWhere(getParameterSections(), { id: "category" }),
-        ).toBeDefined();
-
-        expect(
-          _.findWhere(getParameterSections(), { id: "string" }),
-        ).not.toBeDefined();
-      });
-    });
-
-    describe("when `field-filter-operators-enabled?` is true", () => {
-      beforeEach(() => {
-        mockFieldFilterOperatorsFlag(true);
-      });
-
-      it("should have a number section", () => {
-        expect(
-          _.findWhere(getParameterSections(), { id: "number" }),
-        ).toBeDefined();
-      });
-
-      it("should have location options that map to string/* parameters", () => {
-        const locationSection = _.findWhere(getParameterSections(), {
-          id: "location",
-        });
-        expect(
-          locationSection.options.every(option =>
-            option.type.startsWith("string"),
-          ),
-        ).toBe(true);
-      });
-
-      it("should have a string section", () => {
-        expect(
-          _.findWhere(getParameterSections(), { id: "category" }),
-        ).not.toBeDefined();
-
-        expect(
-          _.findWhere(getParameterSections(), { id: "string" }),
-        ).toBeDefined();
-      });
-    });
-  });
-
   describe("createParameter", () => {
     it("should create a new parameter using the given parameter option", () => {
       expect(


### PR DESCRIPTION
The is part of a series of PRs to split all the parameters logic in `metabase/meta/(Card|Dashboard|Parameter).js` into more reasonable utils files.

This PR moves logic relevant to dashboard parameter options to a `metabase/parameters/utils/dashboard-options.js` file. In addition to that, I've added a `metabase/parameters/constants.js` file to hold a few options-related constants. This constants file will also get used in https://github.com/metabase/metabase/pull/18637.