### PR TITLE
move template-tag options logic to own file

### DIFF
--- a/frontend/src/metabase/meta/Parameter.js
+++ b/frontend/src/metabase/meta/Parameter.js
@@ -7,7 +7,6 @@ import type {
 } from "metabase-types/types/Query";
 import type {
   Parameter,
-  ParameterOption,
   ParameterInstance,
   ParameterTarget,
   ParameterValue,
@@ -15,199 +14,20 @@ import type {
 } from "metabase-types/types/Parameter";
 import type { FieldId } from "metabase-types/types/Field";
 import type Metadata from "metabase-lib/lib/metadata/Metadata";
-import type Field from "metabase-lib/lib/metadata/Field";
 import Dimension, {
   FieldDimension,
   TemplateTagDimension,
 } from "metabase-lib/lib/Dimension";
 import moment from "moment";
-import { t } from "ttag";
 import _ from "underscore";
 import {
   getParameterType,
   getParameterSubType,
 } from "metabase/parameters/utils/parameter-type";
-import {
-  getOperatorDisplayName,
-  getParameterOperatorName,
-} from "metabase/parameters/utils/operators";
-import { fieldFilterForParameter } from "metabase/parameters/utils/filters";
+import { getParameterOperatorName } from "metabase/parameters/utils/operators";
 
 const areFieldFilterOperatorsEnabled = () =>
   MetabaseSettings.get("field-filter-operators-enabled?");
-
-export const PARAMETER_OPERATOR_TYPES = {
-  number: [
-    {
-      type: "number/=",
-      operator: "=",
-      name: t`Equal to`,
-    },
-    {
-      type: "number/!=",
-      operator: "!=",
-      name: t`Not equal to`,
-    },
-    {
-      type: "number/between",
-      operator: "between",
-      name: t`Between`,
-    },
-    {
-      type: "number/>=",
-      operator: ">=",
-      name: t`Greater than or equal to`,
-    },
-    {
-      type: "number/<=",
-      operator: "<=",
-      name: t`Less than or equal to`,
-    },
-  ],
-  string: [
-    {
-      type: "string/=",
-      operator: "=",
-      name: t`Dropdown`,
-      description: t`Select one or more values from a list or search box.`,
-    },
-    {
-      type: "string/!=",
-      operator: "!=",
-      name: t`Is not`,
-      description: t`Exclude one or more specific values.`,
-    },
-    {
-      type: "string/contains",
-      operator: "contains",
-      name: t`Contains`,
-      description: t`Match values that contain the entered text.`,
-    },
-    {
-      type: "string/does-not-contain",
-      operator: "does-not-contain",
-      name: t`Does not contain`,
-      description: t`Filter out values that contain the entered text.`,
-    },
-    {
-      type: "string/starts-with",
-      operator: "starts-with",
-      name: t`Starts with`,
-      description: t`Match values that begin with the entered text.`,
-    },
-    {
-      type: "string/ends-with",
-      operator: "ends-with",
-      name: t`Ends with`,
-      description: t`Match values that end with the entered text.`,
-    },
-  ],
-  date: [
-    {
-      type: "date/month-year",
-      operator: "month-year",
-      name: t`Month and Year`,
-      description: t`Like January, 2016`,
-    },
-    {
-      type: "date/quarter-year",
-      operator: "quarter-year",
-      name: t`Quarter and Year`,
-      description: t`Like Q1, 2016`,
-    },
-    {
-      type: "date/single",
-      operator: "single",
-      name: t`Single Date`,
-      description: t`Like January 31, 2016`,
-    },
-    {
-      type: "date/range",
-      operator: "range",
-      name: t`Date Range`,
-      description: t`Like December 25, 2015 - February 14, 2016`,
-    },
-    {
-      type: "date/relative",
-      operator: "relative",
-      name: t`Relative Date`,
-      description: t`Like "the last 7 days" or "this month"`,
-    },
-    {
-      type: "date/all-options",
-      operator: "all-options",
-      name: t`Date Filter`,
-      menuName: t`All Options`,
-      description: t`Contains all of the above`,
-    },
-  ],
-};
-
-const OPTIONS_WITH_OPERATOR_SUBTYPES = [
-  {
-    type: "date",
-    typeName: t`Date`,
-  },
-  {
-    type: "string",
-    typeName: t`String`,
-  },
-  {
-    type: "number",
-    typeName: t`Number`,
-  },
-];
-
-export function getParameterOptions(): ParameterOption[] {
-  return [
-    {
-      type: "id",
-      name: t`ID`,
-    },
-    ...(areFieldFilterOperatorsEnabled()
-      ? OPTIONS_WITH_OPERATOR_SUBTYPES.map(option =>
-          buildOperatorSubtypeOptions(option),
-        )
-      : [
-          { type: "category", name: t`Category` },
-          {
-            type: "location/city",
-            name: t`City`,
-          },
-          {
-            type: "location/state",
-            name: t`State`,
-          },
-          {
-            type: "location/zip_code",
-            name: t`ZIP or Postal Code`,
-          },
-          {
-            type: "location/country",
-            name: t`Country`,
-          },
-          ...PARAMETER_OPERATOR_TYPES["date"],
-        ]),
-  ].flat();
-}
-
-function buildOperatorSubtypeOptions({ type, typeName }) {
-  return PARAMETER_OPERATOR_TYPES[type].map(option => ({
-    ...option,
-    combinedName: getOperatorDisplayName(option, type, typeName),
-  }));
-}
-
-export function parameterOptionsForField(field: Field): ParameterOption[] {
-  return getParameterOptions()
-    .filter(option => fieldFilterForParameter(option)(field))
-    .map(option => {
-      return {
-        ...option,
-        name: option.combinedName || option.name,
-      };
-    });
-}
 
 // NOTE: this should mirror `template-tag-parameters` in src/metabase/api/embed.clj
 export function getTemplateTagParameters(tags: TemplateTag[]): Parameter[] {

--- a/frontend/src/metabase/parameters/utils/template-tag-options.js
+++ b/frontend/src/metabase/parameters/utils/template-tag-options.js
@@ -1,0 +1,44 @@
+import { areFieldFilterOperatorsEnabled } from "./feature-flag";
+import { getOperatorDisplayName } from "./operators";
+import { fieldFilterForParameter } from "./filters";
+
+import {
+  OPTIONS_WITH_OPERATOR_SUBTYPES,
+  PARAMETER_OPERATOR_TYPES,
+  LOCATION_OPTIONS,
+  ID_OPTION,
+  CATEGORY_OPTION,
+} from "../constants";
+
+export function getParameterOptions() {
+  return [
+    ID_OPTION,
+    ...(areFieldFilterOperatorsEnabled()
+      ? OPTIONS_WITH_OPERATOR_SUBTYPES.map(option =>
+          buildOperatorSubtypeOptions(option),
+        )
+      : [
+          CATEGORY_OPTION,
+          ...LOCATION_OPTIONS,
+          ...PARAMETER_OPERATOR_TYPES["date"],
+        ]),
+  ].flat();
+}
+
+function buildOperatorSubtypeOptions({ type, typeName }) {
+  return PARAMETER_OPERATOR_TYPES[type].map(option => ({
+    ...option,
+    combinedName: getOperatorDisplayName(option, type, typeName),
+  }));
+}
+
+export function getParameterOptionsForField(field) {
+  return getParameterOptions()
+    .filter(option => fieldFilterForParameter(option)(field))
+    .map(option => {
+      return {
+        ...option,
+        name: option.combinedName || option.name,
+      };
+    });
+}

--- a/frontend/src/metabase/parameters/utils/template-tag-options.unit.spec.js
+++ b/frontend/src/metabase/parameters/utils/template-tag-options.unit.spec.js
@@ -1,0 +1,136 @@
+import _ from "underscore";
+import MetabaseSettings from "metabase/lib/settings";
+import { PARAMETER_OPERATOR_TYPES } from "../constants";
+import {
+  getParameterOptions,
+  getParameterOptionsForField,
+} from "./template-tag-options";
+
+MetabaseSettings.get = jest.fn();
+
+function mockFieldFilterOperatorsFlag(value) {
+  MetabaseSettings.get.mockImplementation(flag => {
+    if (flag === "field-filter-operators-enabled?") {
+      return value;
+    }
+  });
+}
+
+describe("parameters/utils/template-tag-options", () => {
+  beforeEach(() => {
+    mockFieldFilterOperatorsFlag(false);
+  });
+
+  describe("getParameterOptions", () => {
+    describe("when `field-filter-operators-enabled?` is false", () => {
+      beforeEach(() => {
+        mockFieldFilterOperatorsFlag(false);
+      });
+
+      it("should return options without operator subtypes (except for date parameters)", () => {
+        const options = new Set(_.map(getParameterOptions(), "type"));
+        const expectedOptionTypes = [
+          "id",
+          "category",
+          "location/city",
+          "location/state",
+          "location/zip_code",
+          "location/country",
+        ].concat(_.map(PARAMETER_OPERATOR_TYPES.date, "type"));
+
+        expect(expectedOptionTypes.length).toEqual(options.size);
+        expect(expectedOptionTypes.every(option => options.has(option))).toBe(
+          true,
+        );
+      });
+    });
+
+    describe("when `field-filter-operators-enabled?` is true", () => {
+      beforeEach(() => {
+        mockFieldFilterOperatorsFlag(true);
+      });
+
+      it("should return options with operator subtypes", () => {
+        const options = new Set(_.map(getParameterOptions(), "type"));
+        const expectedOptionTypes = ["id"].concat(
+          _.map(PARAMETER_OPERATOR_TYPES.number, "type"),
+          _.map(PARAMETER_OPERATOR_TYPES.string, "type"),
+          _.map(PARAMETER_OPERATOR_TYPES.date, "type"),
+        );
+
+        expect(expectedOptionTypes.length).toEqual(options.size);
+        expect(expectedOptionTypes.every(option => options.has(option))).toBe(
+          true,
+        );
+      });
+
+      it("should add a `combinedName` property to options", () => {
+        const optionsByType = _.indexBy(getParameterOptions(), "type");
+
+        expect(optionsByType["string/="].combinedName).toEqual("String");
+        expect(optionsByType["string/!="].combinedName).toEqual(
+          "String is not",
+        );
+        expect(optionsByType["number/!="].combinedName).toEqual("Not equal to");
+        expect(optionsByType["date/single"].combinedName).toEqual(
+          "Single Date",
+        );
+      });
+    });
+  });
+
+  describe("getParameterOptionsForField", () => {
+    const field = {
+      isDate: () => false,
+      isID: () => false,
+      isCategory: () => false,
+      isCity: () => false,
+      isState: () => false,
+      isZipCode: () => false,
+      isCountry: () => false,
+      isNumber: () => false,
+      isString: () => false,
+      isLocation: () => false,
+    };
+    it("should return relevantly typed options for date field", () => {
+      const dateField = {
+        ...field,
+        isDate: () => true,
+      };
+      const availableOptions = getParameterOptionsForField(dateField);
+      expect(
+        availableOptions.length > 0 &&
+          availableOptions.every(option => option.type.startsWith("date")),
+      ).toBe(true);
+    });
+
+    it("should return relevantly typed options for id field", () => {
+      const idField = {
+        ...field,
+        isID: () => true,
+      };
+      const availableOptions = getParameterOptionsForField(idField);
+      expect(
+        availableOptions.length > 0 &&
+          availableOptions.every(option => option.type.startsWith("id")),
+      ).toBe(true);
+    });
+
+    it("should return the specific location/state option for a state field", () => {
+      const stateField = {
+        ...field,
+        isState: () => true,
+      };
+      const availableOptions = getParameterOptionsForField(stateField);
+      expect(availableOptions).toEqual([
+        expect.objectContaining({ type: "location/state" }),
+      ]);
+    });
+
+    it("as a result of all location parameters haiving subtypes should return nothing for a generic location field", () => {
+      const locationField = { ...field, isLocation: () => true };
+      const availableOptions = getParameterOptionsForField(locationField);
+      expect(availableOptions).toEqual([]);
+    });
+  });
+});

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx
@@ -10,7 +10,7 @@ import InputBlurChange from "metabase/components/InputBlurChange";
 import Select, { Option } from "metabase/components/Select";
 import ParameterValueWidget from "metabase/parameters/components/ParameterValueWidget";
 
-import { parameterOptionsForField } from "metabase/meta/Parameter";
+import { getParameterOptionsForField } from "metabase/parameters/utils/template-tag-options";
 import type { TemplateTag } from "metabase-types/types/Query";
 import type { Database } from "metabase-types/types/Database";
 
@@ -97,7 +97,7 @@ export default class TagEditorParam extends Component {
       if (!field) {
         return;
       }
-      const options = parameterOptionsForField(field);
+      const options = getParameterOptionsForField(field);
       let widgetType;
       if (
         tag["widget-type"] &&
@@ -124,7 +124,7 @@ export default class TagEditorParam extends Component {
       const field = metadata.field(tag.dimension[1]);
 
       if (field) {
-        widgetOptions = parameterOptionsForField(field);
+        widgetOptions = getParameterOptionsForField(field);
         table = field.table;
         fieldMetadataLoaded = true;
       }

--- a/frontend/test/metabase/meta/Parameter.unit.spec.js
+++ b/frontend/test/metabase/meta/Parameter.unit.spec.js
@@ -1,15 +1,10 @@
-import _ from "underscore";
-
 import MetabaseSettings from "metabase/lib/settings";
 import {
-  PARAMETER_OPERATOR_TYPES,
-  getParameterOptions,
   getParameterTargetField,
   dateParameterValueToMBQL,
   stringParameterValueToMBQL,
   numberParameterValueToMBQL,
   parameterToMBQLFilter,
-  parameterOptionsForField,
   normalizeParameterValue,
   getTemplateTagParameters,
   getValuePopulatedParameters,
@@ -39,64 +34,6 @@ describe("metabase/meta/Parameter", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     MetabaseSettings.get.mockReturnValue(false);
-  });
-
-  describe("getParameterOptions", () => {
-    describe("when `field-filter-operators-enabled?` is false", () => {
-      beforeEach(() => {
-        mockFieldFilterOperatorsFlag(false);
-      });
-
-      it("should return options without operator subtypes (except for date parameters)", () => {
-        const options = new Set(_.map(getParameterOptions(), "type"));
-        const expectedOptionTypes = [
-          "id",
-          "category",
-          "location/city",
-          "location/state",
-          "location/zip_code",
-          "location/country",
-        ].concat(_.map(PARAMETER_OPERATOR_TYPES.date, "type"));
-
-        expect(expectedOptionTypes.length).toEqual(options.size);
-        expect(expectedOptionTypes.every(option => options.has(option))).toBe(
-          true,
-        );
-      });
-    });
-
-    describe("when `field-filter-operators-enabled?` is true", () => {
-      beforeEach(() => {
-        mockFieldFilterOperatorsFlag(true);
-      });
-
-      it("should return options with operator subtypes", () => {
-        const options = new Set(_.map(getParameterOptions(), "type"));
-        const expectedOptionTypes = ["id"].concat(
-          _.map(PARAMETER_OPERATOR_TYPES.number, "type"),
-          _.map(PARAMETER_OPERATOR_TYPES.string, "type"),
-          _.map(PARAMETER_OPERATOR_TYPES.date, "type"),
-        );
-
-        expect(expectedOptionTypes.length).toEqual(options.size);
-        expect(expectedOptionTypes.every(option => options.has(option))).toBe(
-          true,
-        );
-      });
-
-      it("should add a `combinedName` property to options", () => {
-        const optionsByType = _.indexBy(getParameterOptions(), "type");
-
-        expect(optionsByType["string/="].combinedName).toEqual("String");
-        expect(optionsByType["string/!="].combinedName).toEqual(
-          "String is not",
-        );
-        expect(optionsByType["number/!="].combinedName).toEqual("Not equal to");
-        expect(optionsByType["date/single"].combinedName).toEqual(
-          "Single Date",
-        );
-      });
-    });
   });
 
   describe("dateParameterValueToMBQL", () => {
@@ -362,61 +299,6 @@ describe("metabase/meta/Parameter", () => {
           metadata,
         ),
       ).toEqual(["between", ["field", PRODUCTS.RATING.id, null], 1, 100]);
-    });
-  });
-
-  describe("parameterOptionsForField", () => {
-    const field = {
-      isDate: () => false,
-      isID: () => false,
-      isCategory: () => false,
-      isCity: () => false,
-      isState: () => false,
-      isZipCode: () => false,
-      isCountry: () => false,
-      isNumber: () => false,
-      isString: () => false,
-      isLocation: () => false,
-    };
-    it("should return relevantly typed options for date field", () => {
-      const dateField = {
-        ...field,
-        isDate: () => true,
-      };
-      const availableOptions = parameterOptionsForField(dateField);
-      expect(
-        availableOptions.length > 0 &&
-          availableOptions.every(option => option.type.startsWith("date")),
-      ).toBe(true);
-    });
-
-    it("should return relevantly typed options for id field", () => {
-      const idField = {
-        ...field,
-        isID: () => true,
-      };
-      const availableOptions = parameterOptionsForField(idField);
-      expect(
-        availableOptions.length > 0 &&
-          availableOptions.every(option => option.type.startsWith("id")),
-      ).toBe(true);
-    });
-
-    it("should return the specific location/state option for a state field", () => {
-      const stateField = {
-        ...field,
-        isState: () => true,
-      };
-      const availableOptions = parameterOptionsForField(stateField);
-      expect(availableOptions).toEqual([
-        expect.objectContaining({ type: "location/state" }),
-      ]);
-    });
-
-    it("as a result of all location parameters haiving subtypes should return nothing for a generic location field", () => {
-      const locationField = { ...field, isLocation: () => true };
-      const availableOptions = parameterOptionsForField(locationField);
-      expect(availableOptions).toEqual([]);
     });
   });
 


### PR DESCRIPTION
The is part of a series of PRs to split all the parameters logic in `metabase/meta/(Card|Dashboard|Parameter).js` into more reasonable utils files.

This PR takes the option logic found in `metabase/meta/Parameter.js` and moves it to the more specific `metabase/parameters/utils/template-tag-options.js`. The constants I'm deleting in this PR were moved to a `metabase/parameters/constants.js` file in https://github.com/metabase/metabase/pull/18635