### PR TITLE
#18011 Repro: Post aggregation drill-through by dragging/selecting a portion of a chart results in an error

### DIFF
--- a/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
@@ -71,34 +71,43 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
     });
   });
 
-  it("brush filter should work post-aggregation (metabase#18011)", () => {
-    cy.intercept("POST", "/api/dataset").as("dataset");
+  ["month", "month-of-year"].forEach(granularity => {
+    it(`brush filter should work post-aggregation for ${granularity} granularity (metabase#18011)`, () => {
+      // TODO: Remove this line when the issue is fixed!
+      cy.skipOn(granularity === "month-of-year");
 
-    const questionDetails = {
-      name: "18011",
-      database: 1,
-      query: {
-        "source-table": PRODUCTS_ID,
-        aggregation: [["count"]],
-        breakout: [
-          ["field", PRODUCTS.CREATED_AT, { "temporal-unit": "month" }],
-          ["field", PRODUCTS.CATEGORY, null],
-        ],
-      },
-      display: "line",
-    };
+      cy.intercept("POST", "/api/dataset").as("dataset");
 
-    cy.createQuestion(questionDetails, { visitQuestion: true });
+      const questionDetails = {
+        name: "18011",
+        database: 1,
+        query: {
+          "source-table": PRODUCTS_ID,
+          aggregation: [["count"]],
+          breakout: [
+            ["field", PRODUCTS.CREATED_AT, { "temporal-unit": granularity }],
+            ["field", PRODUCTS.CATEGORY, null],
+          ],
+        },
+        display: "line",
+      };
 
-    cy.get(".Visualization")
-      .trigger("mousedown", 240, 200)
-      .trigger("mousemove", 420, 200)
-      .trigger("mouseup", 420, 200);
+      cy.createQuestion(questionDetails, { visitQuestion: true });
 
-    cy.wait("@dataset");
+      cy.get(".Visualization")
+        .trigger("mousedown", 240, 200)
+        .trigger("mousemove", 420, 200)
+        .trigger("mouseup", 420, 200);
 
-    cy.findByText("Created At between September, 2016 February, 2017");
-    cy.get("circle");
+      cy.wait("@dataset");
+
+      granularity === "month"
+        ? cy.findByText("Created At between September, 2016 February, 2017")
+        : // Once the issue gets fixed, figure out the positive assertion for the "month-of-year" granularity
+          null;
+
+      cy.get("circle");
+    });
   });
 
   it("should correctly drill through on a card with multiple series (metabase#11442)", () => {

--- a/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
@@ -71,6 +71,36 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
     });
   });
 
+  it("brush filter should work post-aggregation (metabase#18011)", () => {
+    cy.intercept("POST", "/api/dataset").as("dataset");
+
+    const questionDetails = {
+      name: "18011",
+      database: 1,
+      query: {
+        "source-table": PRODUCTS_ID,
+        aggregation: [["count"]],
+        breakout: [
+          ["field", PRODUCTS.CREATED_AT, { "temporal-unit": "month" }],
+          ["field", PRODUCTS.CATEGORY, null],
+        ],
+      },
+      display: "line",
+    };
+
+    cy.createQuestion(questionDetails, { visitQuestion: true });
+
+    cy.get(".Visualization")
+      .trigger("mousedown", 240, 200)
+      .trigger("mousemove", 420, 200)
+      .trigger("mouseup", 420, 200);
+
+    cy.wait("@dataset");
+
+    cy.findByText("Created At between September, 2016 February, 2017");
+    cy.get("circle");
+  });
+
   it("should correctly drill through on a card with multiple series (metabase#11442)", () => {
     cy.createQuestion({
       name: "11442_Q1",


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #18011 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js`
- Change `cy.skipOn(granularity === "month-of-year")` to `cy.onlyOn(granularity === "month-of-year")`
- The test should fail

### Additional notes:
- This is working for "month" granularity, but not for "month-of-year", for example.
- Once this issue gets fixed, remove `cy.skipOn(granularity === "month-of-year")` completely and merge this repro together with the fix

### Screenshots:
"month"
![image](https://user-images.githubusercontent.com/31325167/138742968-5a3a193e-a8e0-46df-97a8-9cafc3df6950.png)

"month-of-year"
![image](https://user-images.githubusercontent.com/31325167/138754952-aa0d20dd-8d17-4f62-b3b1-6f3251d913fd.png)


