### PR TITLE
Add `hosting` to `token-features` setting

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/settings/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/settings/index.js
@@ -1,7 +1,7 @@
 import MetabaseSettings from "metabase/lib/settings";
 
 export function hasPremiumFeature(feature) {
-  const hasFeature = MetabaseSettings.get("premium-features", {})[feature];
+  const hasFeature = MetabaseSettings.get("token-features", {})[feature];
   if (hasFeature == null) {
     console.warn("Unknown premium feature", feature);
   }

--- a/frontend/src/metabase/lib/analytics.js
+++ b/frontend/src/metabase/lib/analytics.js
@@ -78,7 +78,7 @@ const createSnowplowPlugin = store => {
     contexts: () => {
       const id = Settings.get("analytics-uuid");
       const version = Settings.get("version", {});
-      const features = Settings.get("premium-features");
+      const features = Settings.get("token-features");
 
       return [
         {

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -379,8 +379,8 @@
   :setter     :none
   :getter     (constantly config/mb-version-info))
 
-(defsetting premium-features
-  "Premium  features enabled for this instance."
+(defsetting token-features
+  "Features registered for this instance's token"
   :visibility :public
   :setter     :none
   :getter     (fn [] {:embedding            (premium-features/hide-embed-branding?)
@@ -390,7 +390,8 @@
                       :sso                  (premium-features/enable-sso?)
                       :advanced_config      (premium-features/enable-advanced-config?)
                       :advanced_permissions (premium-features/enable-advanced-permissions?)
-                      :content_management   (premium-features/enable-content-management?)}))
+                      :content_management   (premium-features/enable-content-management?)
+                      :hosting              (premium-features/is-hosted?)}))
 
 (defsetting redirect-all-requests-to-https
   (deferred-tru "Force all traffic to use HTTPS via a redirect, if the site URL is HTTPS")


### PR DESCRIPTION
Tiny PR to add `hosting` to the `premium-features`, and rename it to `token-features`. This will allow us to include `token-features` directly in Snowplow analytics.

I think we should do a broader cleanup of names in this code since `premium features token` is a misnomer now that `hosting` is included in it, and it'll probably include other non-premium things in the future. But I'm not sure what the ideal end state should be.

part of epic #18291