### PR TITLE
#18646 Repro: Cannot select granularity/binning on fields from SQL question, which is joined

### DIFF
--- a/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
@@ -172,6 +172,52 @@ describe("binning related reproductions", () => {
     cy.findByText("CREATED_AT");
   });
 
+  it.skip("should render binning options when joining on the saved native question (metabase#18646)", () => {
+    cy.createNativeQuestion(
+      {
+        name: "18646",
+        native: { query: "select * from products" },
+      },
+      { loadMetadata: true },
+    );
+
+    cy.visit("/question/new");
+    cy.findByText("Custom question").click();
+    cy.findByText("Sample Dataset").click();
+    cy.findByText("Orders").click();
+
+    cy.icon("join_left_outer").click();
+
+    popover().within(() => {
+      cy.findByText("Sample Dataset").click();
+      cy.findByText("Saved Questions").click();
+      cy.findByText("18646").click();
+    });
+
+    popover()
+      .findByText("Product ID")
+      .click();
+
+    popover().within(() => {
+      cy.findByText("CREATED_AT")
+        .closest(".List-item")
+        .findByText("by month")
+        .click();
+    });
+
+    cy.findByText("Pick the metric you want to see").click();
+    cy.findByText("Count of rows").click();
+
+    cy.findByText("Pick a column to group by").click();
+    cy.findByText(/Question \d/).click();
+
+    popover().within(() => {
+      cy.findByText("CREATED_AT")
+        .closest(".List-item")
+        .findByText("by month");
+    });
+  });
+
   describe("binning should work on nested question based on question that has aggregation (metabase#16379)", () => {
     beforeEach(() => {
       cy.createQuestion({


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #18646 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/138766780-6d068486-9f43-45e2-b4b2-d04ac7a6b4b2.png)

