### PR TITLE
Fix questions with field literals in joins cause an infinite loop on the frontend

### DIFF
--- a/frontend/src/metabase-lib/lib/queries/structured/Join.js
+++ b/frontend/src/metabase-lib/lib/queries/structured/Join.js
@@ -570,9 +570,6 @@ export default class Join extends MBQLObjectClause {
   }
 
   hasGaps() {
-    if (!this.joinedTable()) {
-      return true;
-    }
     const parentDimensions = this.parentDimensions();
     const joinDimensions = this.joinDimensions();
     return (
@@ -585,7 +582,7 @@ export default class Join extends MBQLObjectClause {
   }
 
   isValid() {
-    if (this.hasGaps()) {
+    if (!this.condition || !this.joinedTable() || this.hasGaps()) {
       return false;
     }
     const dimensionOptions = this.parent().dimensionOptions();
@@ -604,8 +601,7 @@ export default class Join extends MBQLObjectClause {
   }
 
   clean() {
-    const invalidAndCantFix = !this.condition || !this.joinedTable();
-    if (invalidAndCantFix || this.isValid()) {
+    if (!this.condition || !this.hasGaps()) {
       return this;
     }
     let join = this;

--- a/frontend/src/metabase/lib/query/field_ref.js
+++ b/frontend/src/metabase/lib/query/field_ref.js
@@ -102,6 +102,14 @@ export function getFieldTarget(fieldClause, tableDef, path = []) {
   return info;
 }
 
+export function isFieldLiteral(fieldClause) {
+  return (
+    isValidField(fieldClause) &&
+    isLocalField(fieldClause) &&
+    typeof fieldClause[1] === "string"
+  );
+}
+
 export function getDatetimeUnit(fieldClause) {
   if (isLocalField(fieldClause)) {
     const dimension = FieldDimension.parseMBQLOrWarn(fieldClause);

--- a/frontend/test/metabase-lib/lib/queries/structured/Join.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/structured/Join.unit.spec.js
@@ -703,6 +703,20 @@ describe("Join", () => {
       expect(join.isValid()).toBe(false);
     });
 
+    it("should ignore field literals not present in dimension options for backward compatibility", () => {
+      const join = getJoin({
+        query: getOrdersJoinQuery({
+          condition: [
+            "=",
+            ORDERS_PRODUCT_ID_FIELD_REF,
+            ["field", "USER_ID", { "base-type": "type/Integer" }],
+          ],
+        }),
+      });
+
+      expect(join.isValid()).toBe(true);
+    });
+
     invalidTestCases.forEach(([invalidReason, queryOpts]) => {
       it(`should return 'false' when ${invalidReason}`, () => {
         const join = getJoin({

--- a/frontend/test/metabase/scenarios/question/reproductions/18630-field-literals-in-joins.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/18630-field-literals-in-joins.cy.spec.js
@@ -1,0 +1,63 @@
+import { restore } from "__support__/e2e/cypress";
+
+import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
+
+const { ORDERS, ORDERS_ID, PEOPLE, PEOPLE_ID } = SAMPLE_DATASET;
+
+describe("issue 18630", () => {
+  beforeEach(() => {
+    cy.intercept("POST", "/api/dataset").as("dataset");
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  const QUERY_WITH_FIELD_CLAUSE = {
+    "source-query": {
+      "source-table": ORDERS_ID,
+      joins: [
+        {
+          fields: "all",
+          "source-table": PEOPLE_ID,
+          condition: [
+            "=",
+            ["field", ORDERS.USER_ID, null],
+            ["field", PEOPLE.ID, { "join-alias": "People - User" }],
+          ],
+          alias: "People - User",
+        },
+      ],
+      expressions: {
+        coalesce: [
+          "coalesce",
+          ["field", ORDERS.USER_ID, null],
+          ["field", PEOPLE.ID, { "join-alias": "People - User" }],
+        ],
+      },
+      aggregation: [["count"]],
+      breakout: [["expression", "coalesce"]],
+    },
+    joins: [
+      {
+        fields: "all",
+        "source-table": PEOPLE_ID,
+        condition: [
+          "=",
+          ["field", "coalesce", { "base-type": "type/Float" }],
+          ["field", PEOPLE.ID, { "join-alias": "People" }],
+        ],
+        alias: "People",
+      },
+    ],
+  };
+
+  it("should normally open queries with field literals in joins (metabase#18630)", () => {
+    cy.createQuestion(
+      { query: QUERY_WITH_FIELD_CLAUSE },
+      { visitQuestion: true },
+    );
+
+    // The query itself is not expected to run,
+    // it just shouldn't stuck on the loading phase
+    cy.findByText("There was a problem with your question");
+  });
+});


### PR DESCRIPTION
Fixes #18630: FE crashes with an infinite recursion when opening some questions using legacy field notation.

### Background

The error happens because of `Join's` `clean` and `isValid` methods introduced in #17708 and #17727. I'd recommend reading both PRs to get a complete picture of what's happening here.

TLDR: these PRs extended join's `isValid` method and introduced the `clean` method. It fixed some weird cases when removing some sections in the notebook editor would lead to removing other sections too (#17710 and #17712). `clean` is intended to recursively remove invalid parts of a join until it either becomes valid or there is nothing left to do to make it valid (in this case, the join will be removed before running a query).

The join is considered valid when the following is valid:

* the join has a right-hand side table (joining `Products` table)
* the join has a condition (joining `Products` table on `ProductID = ID`)
* the join has no gaps in the condition (joining `Products` table on `ProductID = ID` vs. joining `Products` table on `ProductID = _`
* every dimension used inside join's condition is available (let's say to add a custom column. You can now use it when building a join. But once you remove the custom column, the join becomes invalid because the column is no longer there)

### Root Cause

The root cause is the `every dimension used inside join's condition is available` condition. It's checked by the `isValid` [here](https://github.com/metabase/metabase/blob/24975664f7208c4c8c1819b76f94b9b4c61da820/frontend/src/metabase-lib/lib/queries/structured/Join.js#L590). `clean` method uses `isValid` as an exit criteria [here](https://github.com/metabase/metabase/blob/24975664f7208c4c8c1819b76f94b9b4c61da820/frontend/src/metabase-lib/lib/queries/structured/Join.js#L596).

The check doesn't work correctly for some questions created in the earlier version of Metabase than use **field literal notation**.

**Field Literals**

The most common way to reference a field in MBQL is a field reference: `[ "field", $NUMERIC_FIELD_ID, $OPTIONS ]`

* for instance, `Product.ID` field from the sample dataset can be referenced like `[ "field", 8, null ]
* `Orders.CREATED_AT` can be referenced like `[ "field", 12, { "temporal-unit": "day" } ]`

On the other hand, a field literal has the following structure: `[ "field", $STR_FIELD_NAME, $OPTIONS ]`. So we can reference a field like `[ "field", "PRODUCT_ID", { "base-type": "type/Integer" } ]`

GUI editor has used field literals in the past, but now it primarily uses field references (see #14824). The field literals are mainly used in native queries, though.

**Field literals from older questions**

There are two behaviors that cause an infinite loop here:

* `Join's` `isValid` method returns `false` for some old questions using field literals inside joins
* `clean` relies on the `isValid` check, but it actually has no way to fix the problem with `dimensionOptions.hasDimension` returning `false`. So it stucks in a loop

### About the fix

With the repro examples, I had, `dimensionOptions` actually _contained_ the "problematic" dimension, but they had a different `base-type`, so the comparison returns `false` for them.

Example:

* there is a nested query with a custom column
* a query built on top of the nested query has a join using the custom column
* the custom column inside join is referenced as a field literal with `base-type: "type/Float"`
* join's `dimensionOptions` contain the custom column, but with `base-type: "type/Integer"`
* `dimensionOptions.hasDimension` returns `false` because of different `base-type` values

This looks like an unexpected behavior. If you create the same query in 0.41, it will use field literals, but the `base-type` values would be the same.

I haven't found a workaround for that, so the fix itself is pretty straightforward:

1. Refactored `clean`, so it no longer relies on `isValid` because it's not intended to fix inavailable dimensions
2. made `isValid` still return `true` if the missing dimension is a field literal

Point 2 actually introduces another issue, but it looks better than the FE crashing when opening some pages and I'm out of better ideas 😞 

<details>
<summary>Steps to reproduce a new issue on this branch</summary>

1. Ask a question > Custom Question > Sample Dataset > Orders
2. Add a custom column just referencing `PRODUCT_ID`, call it `PRODUCT`
3. Summarize `count` by `PRODUCT`
4. Join Products table on `PRODUCT` = `Product.ID`
5. Remove `PRODUCT` custom column
6. `PRODUCT` reference still remains in the second join

**Expected:** `PRODUCT` should reference be removed

This happens because `isValid` will skip `PRODUCT` now because it's a field reference. There is no easy way to find out if a field literal is just a legacy thing or an actually unavailable dimension.
</details>

### To Verify

Follow the steps from [this comment](https://github.com/metabase/metabase/issues/18630#issuecomment-950672809). It requires to run Metabase 0.37.8, create a query, and then open it on 0.41. I could reproduce the issue on 0.41 by creating the question via API. [Here's a request body example](https://gist.github.com/kulyk/3b1978082197b43aa5225ebd750409ff)

1. Using curl or something like Postman: `POST '/api/question` with [this payload](https://gist.github.com/kulyk/3b1978082197b43aa5225ebd750409ff) to create an erroring question (don't forget to include `Session` header, you can copy it from Network dev tools in your browser)
2. Open the question, open the notebook editor
3. It should open fine. ⚠️ The query itself is invalid and will fail, it just shouldn't crash

### Demo

**Before (also proof the repro works)**

![CleanShot 2021-10-25 at 16 17 42@2x](https://user-images.githubusercontent.com/17258145/139251575-6733a072-363c-4862-953d-27b43a17259f.png)

**After**

https://user-images.githubusercontent.com/17258145/139251876-7e1f74ba-2c66-4ece-bb62-8ebfcc8f2c4d.mov



