### PR TITLE
Disable dashboard transition when reduced-motion is preferred

### DIFF
--- a/frontend/src/metabase/css/dashboard.css
+++ b/frontend/src/metabase/css/dashboard.css
@@ -162,6 +162,7 @@
 }
 
 @media (prefers-reduced-motion) {
+  /* short duration (instead of none) to still trigger transition events */
   .DashCard {
     transition-duration: 0.001ms !important;
   }

--- a/frontend/src/metabase/css/dashboard.css
+++ b/frontend/src/metabase/css/dashboard.css
@@ -161,6 +161,12 @@
   border-radius: 8px;
 }
 
+@media (prefers-reduced-motion) {
+  .DashCard {
+    transition-duration: 0.001ms !important;
+  }
+}
+
 .Dash--editing .DashCard.react-draggable-dragging .Card {
   box-shadow: 3px 3px 8px var(--color-shadow);
 }

--- a/frontend/src/metabase/css/dashboard.css
+++ b/frontend/src/metabase/css/dashboard.css
@@ -164,7 +164,7 @@
 @media (prefers-reduced-motion) {
   /* short duration (instead of none) to still trigger transition events */
   .DashCard {
-    transition-duration: 0.001ms !important;
+    transition-duration: 10ms !important;
   }
 }
 


### PR DESCRIPTION
How to verify quickly:
1. Make sure to enable [prefers-reduced-motion](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion#user_preferences)
2. Go to `/` and pick one of the X-Ray, e.g. "A look at your People table".

**Before this PR**

The cards in the dashboard will "fly" to their position.

**After this PR**

The cards in the dashboard will be immediately positioned right where they are supposed to be.
