### PR TITLE
tree view for datasets

### DIFF
--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -121,7 +121,7 @@
                (db/select-ids Database))))
 
 (defn- source-query-cards
-  "Fetch the Cards that can be used as source queries (e.g. presented as virtual tables)."
+  "Fetch the Cards that can be used as source queries (e.g. presented as virtual tables). Since Cards can be either `dataset` or `card`, pass in the `question-type` of `:dataset` or `:card`"
   [question-type & {:keys [additional-constraints xform], :or {xform identity}}]
   {:pre [(#{:card :dataset} question-type)]}
   (when-let [ids-of-dbs-that-support-source-queries (not-empty (ids-of-dbs-that-support-source-queries))]


### PR DESCRIPTION
Addresses #18656 

Creates similar api for datasets as already exists for the saved questions in the "virtual database". This is largely mechanical and flowing a boolean through the existing api, selecting for datasets (cards with `:dataset true`) or saved questions (cards with `:dataset false`).

One thing this does not do is remove nodes without children.
![image](https://user-images.githubusercontent.com/6377293/139100310-8df62325-21a1-4edc-8a84-d2a4d4aa34ce.png)

the entire highlighted tree has no saved questions and should ideally be omitted from this view entirely. That work is left as a follow-on