### PR TITLE
Skip sending dashboard subscription if dashboard is archived

### DIFF
--- a/src/metabase/models/pulse.clj
+++ b/src/metabase/models/pulse.clj
@@ -20,7 +20,6 @@
             [metabase.events :as events]
             [metabase.models.card :refer [Card]]
             [metabase.models.collection :as collection]
-            [metabase.models.dashboard :refer [Dashboard]]
             [metabase.models.dashboard-card :as dashboard-card :refer [DashboardCard]]
             [metabase.models.interface :as i]
             [metabase.models.permissions :as perms]
@@ -311,7 +310,7 @@
                :modifiers [:distinct]
                :from      [[Pulse :p]]
                :left-join (concat
-                           [[Dashboard :d] [:= :p.dashboard_id :d.id]]
+                           [['Dashboard :d] [:= :p.dashboard_id :d.id]]
                            (when user-id
                              [[PulseChannel :pchan] [:= :p.id :pchan.pulse_id]
                               [PulseChannelRecipient :pcr] [:= :pchan.id :pcr.pulse_channel_id]]))

--- a/src/metabase/models/pulse.clj
+++ b/src/metabase/models/pulse.clj
@@ -310,7 +310,7 @@
                :modifiers [:distinct]
                :from      [[Pulse :p]]
                :left-join (concat
-                           [['Dashboard :d] [:= :p.dashboard_id :d.id]]
+                           [[:report_dashboard :d] [:= :p.dashboard_id :d.id]]
                            (when user-id
                              [[PulseChannel :pchan] [:= :p.id :pchan.pulse_id]
                               [PulseChannelRecipient :pcr] [:= :pchan.id :pcr.pulse_channel_id]]))

--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -96,11 +96,10 @@
     (compare (:row dashcard-1) (:row dashcard-2))
     (compare (:col dashcard-1) (:col dashcard-2))))
 
-(defn execute-dashboard
+(defn- execute-dashboard
   "Fetch all the dashcards in a dashboard for a Pulse, and execute non-text cards"
-  [{pulse-creator-id :creator_id, :as pulse} dashboard-or-id & {:as options}]
-  (let [dashboard-id      (u/the-id dashboard-or-id)
-        dashboard         (Dashboard :id dashboard-id)
+  [{pulse-creator-id :creator_id, :as pulse} dashboard & {:as options}]
+  (let [dashboard-id      (u/the-id dashboard)
         dashcards         (db/select DashboardCard :dashboard_id dashboard-id)
         ordered-dashcards (sort dashcard-comparator dashcards)]
     (for [dashcard ordered-dashcards]

--- a/test/metabase/api/pulse_test.clj
+++ b/test/metabase/api/pulse_test.clj
@@ -791,7 +791,12 @@
         (is (= #{"LuckyRecipient" "Other"}
                (set (map :name (mt/user-http-request :rasta :get 200 (str "pulse?user_id=" (mt/user->id :rasta)))))))
         (is (= #{}
-               (set (map :name (mt/user-http-request :rasta :get 200 (str "pulse?user_id=" (mt/user->id :trashbird)))))))))))
+               (set (map :name (mt/user-http-request :rasta :get 200 (str "pulse?user_id=" (mt/user->id :trashbird)))))))))
+
+    (testing "excludes dashboard subscriptions associated with archived dashboards"
+      (mt/with-temp* [Dashboard [{dashboard-id :id} {:archived true}]
+                      Pulse     [_ {:dashboard_id dashboard-id}]]
+        (is (= [] (mt/user-http-request :rasta :get 200 "pulse")))))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/test/metabase/dashboard_subscription_test.clj
+++ b/test/metabase/dashboard_subscription_test.clj
@@ -133,11 +133,11 @@
   (testing "it runs for each non-virtual card"
     (mt/with-temp* [Card          [{card-id-1 :id}]
                     Card          [{card-id-2 :id}]
-                    Dashboard     [{dashboard-id :id} {:name "Birdfeed Usage"}]
+                    Dashboard     [{dashboard-id :id, :as dashboard} {:name "Birdfeed Usage"}]
                     DashboardCard [dashcard-1 {:dashboard_id dashboard-id :card_id card-id-1}]
                     DashboardCard [dashcard-2 {:dashboard_id dashboard-id :card_id card-id-2}]
                     User [{user-id :id}]]
-      (let [result (pulse/execute-dashboard {:creator_id user-id} dashboard-id)]
+      (let [result (@#'pulse/execute-dashboard {:creator_id user-id} dashboard)]
         (is (= (count result) 2))
         (is (schema= [{:card     (s/pred map?)
                        :dashcard (s/pred map?)
@@ -147,22 +147,22 @@
     (mt/with-temp* [Card          [{card-id-1 :id}]
                     Card          [{card-id-2 :id}]
                     Card          [{card-id-3 :id}]
-                    Dashboard     [{dashboard-id :id} {:name "Birdfeed Usage"}]
+                    Dashboard     [{dashboard-id :id, :as dashboard} {:name "Birdfeed Usage"}]
                     DashboardCard [dashcard-1 {:dashboard_id dashboard-id :card_id card-id-1 :row 1 :col 0}]
                     DashboardCard [dashcard-2 {:dashboard_id dashboard-id :card_id card-id-2 :row 0 :col 1}]
                     DashboardCard [dashcard-3 {:dashboard_id dashboard-id :card_id card-id-3 :row 0 :col 0}]
                     User [{user-id :id}]]
-      (let [result (pulse/execute-dashboard {:creator_id user-id} dashboard-id)]
+      (let [result (@#'pulse/execute-dashboard {:creator_id user-id} dashboard)]
         (is (= [card-id-3 card-id-2 card-id-1]
                (map #(-> % :card :id) result))))))
   (testing "virtual (text) cards are returned as a viz settings map"
     (mt/with-temp* [Card          [{card-id-1 :id}]
                     Card          [{card-id-2 :id}]
-                    Dashboard     [{dashboard-id :id} {:name "Birdfeed Usage"}]
+                    Dashboard     [{dashboard-id :id, :as dashboard} {:name "Birdfeed Usage"}]
                     DashboardCard [dashcard-1 {:dashboard_id dashboard-id
                                                :visualization_settings {:virtual_card {}, :text "test"}}]
                     User [{user-id :id}]]
-      (is (= [{:virtual_card {}, :text "test"}] (pulse/execute-dashboard {:creator_id user-id} dashboard-id))))))
+      (is (= [{:virtual_card {}, :text "test"}] (@#'pulse/execute-dashboard {:creator_id user-id} dashboard))))))
 
 (deftest basic-table-test
   (tests {:pulse {:skip_if_empty false}}

--- a/test/metabase/dashboard_subscription_test.clj
+++ b/test/metabase/dashboard_subscription_test.clj
@@ -337,3 +337,17 @@
       (fn [{:keys [card-id]} [pulse-results]]
         (is (= {:blocks [{:type "section" :text {:type "mrkdwn" :text "abcdefghi…"}}]}
                (nth (:attachments (thunk->boolean pulse-results)) 2))))}}))
+
+(deftest archived-dashboard-test
+  (tests {:dashboard {:archived true}}
+    "Dashboard subscriptions are not sent if dashboard is archived"
+    {:card (checkins-query-card {})
+
+     :assert
+     {:slack
+      (fn [_ [pulse-results]]
+        (is (= {:attachments []} (thunk->boolean pulse-results))))
+
+      :email
+      (fn [_ _]
+        (is (= {} (mt/summarize-multipart-email))))}}))


### PR DESCRIPTION
* Check `:archived` on the associated dashboard before sending out a subscription, and skip sending it if the dashboard is archived. Since I'm not actually setting `archived?` to `true` on the individual subscriptions, they'll resume being sent if a dashboard is unarchived.
* When querying the list of pulses (for displaying in a user's account info page), don't include dashboard subscriptions for archived dashboards. My reasoning here is that we already don't include subscriptions that are explicitly archived, and these are _de facto_ archived.
* Some lightweight refactor of related code

Resolves #17487