### PR TITLE
Remove PII from anonymous tracking

### DIFF
--- a/frontend/src/metabase/lib/analytics.js
+++ b/frontend/src/metabase/lib/analytics.js
@@ -60,11 +60,11 @@ const createSnowplowTracker = store => {
   Snowplow.newTracker("sp", "https://sp.metabase.com", {
     appId: "metabase",
     platform: "web",
-    cookieSameSite: "Lax",
+    eventMethod: "post",
     discoverRootDomain: true,
-    contexts: {
-      webPage: true,
-    },
+    contexts: { webPage: true },
+    anonymousTracking: { withServerAnonymisation: true },
+    stateStorageStrategy: "none",
     plugins: [createSnowplowPlugin(store)],
   });
 };


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/18291
Docs https://snowplowanalytics.com/blog/2021/01/05/how-to-leverage-cookieless-and-anonymous-tracking-with-snowplow/

Snowplow tracks by default:
1. `domain_userid` - cookie set by the client
2. `network_userid` - cookie set by the server
3. `user_ipaddress` - user IP address

This PR disables tracking this data as it can be considered PII.