### PR TITLE
Repro #18589: Multi-column join interface defaults binning for numeric fields causing incorrect results

### DIFF
--- a/frontend/test/metabase/scenarios/question/reproductions/18589-numeric-binning-in-joins.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/18589-numeric-binning-in-joins.cy.spec.js
@@ -1,0 +1,44 @@
+import {
+  restore,
+  openOrdersTable,
+  getNotebookStep,
+  popover,
+} from "__support__/e2e/cypress";
+
+describe("issue 18589", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+    cy.intercept("POST", "/api/dataset").as("dataset");
+  });
+
+  it.skip("should not bin numeric fields in join condition by default (metabase#18589)", () => {
+    openOrdersTable({ mode: "notebook" });
+
+    joinTable("Reviews");
+    selectFromDropdown("Quantity");
+    selectFromDropdown("Rating");
+
+    cy.findByText("Summarize").click();
+    selectFromDropdown("Count of rows");
+
+    getNotebookStep("summarize").within(() => {
+      cy.icon("play").click();
+      cy.wait("@dataset");
+      cy.findByText("2.860.368");
+    });
+  });
+});
+
+function joinTable(table) {
+  cy.findByText("Join data").click();
+  popover()
+    .findByText(table)
+    .click();
+}
+
+function selectFromDropdown(option, clickOpts) {
+  popover()
+    .findByText(option)
+    .click(clickOpts);
+}


### PR DESCRIPTION
Reproduces #18589: Multi-column join interface defaults binning for numeric fields causing incorrect results

### To Verify

1. Run `yarn test-cypress-open`
2. `frontend/test/metabase/scenarios/question/reproductions/18589-numeric-binning-in-joins.cy.spec.js`
3. Replace `it.skip` with `it` and run the test
4. The test should fail

### Screenshot

<img width="1709" alt="CleanShot 2021-10-28 at 16 52 33@2x" src="https://user-images.githubusercontent.com/17258145/139269936-52789099-8b94-42cd-b121-994d733bbaa6.png">
