### PR TITLE
fix expression dimension failing to find underlying field

### DIFF
--- a/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
@@ -250,6 +250,34 @@ describe("Dimension", () => {
           expect(dimension.field().metadata).toEqual(metadata);
           expect(dimension.field().displayName()).toEqual("Total");
         });
+
+        it("should return the correct Field from a query's result_metadata when the metadata object is missing the Field", () => {
+          const emptyMetadata = {
+            field: () => {},
+            table: () => {},
+          };
+
+          const question = ORDERS.question().setResultsMetadata({
+            columns: [ORDERS.TOTAL],
+          });
+          const query = new StructuredQuery(question, {
+            type: "query",
+            database: SAMPLE_DATASET.id,
+            query: {
+              "source-table": ORDERS.id,
+            },
+          });
+          const dimension = Dimension.parseMBQL(
+            ["field", ORDERS.TOTAL.id, null],
+            emptyMetadata,
+            query,
+          );
+
+          const field = dimension.field();
+
+          expect(field.id).toEqual(ORDERS.TOTAL.id);
+          expect(field.base_type).toEqual("type/Float");
+        });
       });
     });
   });

--- a/frontend/test/metabase/scenarios/custom-column/reproductions/18747-cc-connected-to-dashboard-parameter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/reproductions/18747-cc-connected-to-dashboard-parameter.cy.spec.js
@@ -1,0 +1,86 @@
+import { restore, popover } from "__support__/e2e/cypress";
+
+import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
+
+const { ORDERS, ORDERS_ID } = SAMPLE_DATASET;
+
+const questionDetails = {
+  name: "18747",
+  query: {
+    "source-table": ORDERS_ID,
+    expressions: {
+      ["Quantity_2"]: ["field", ORDERS.QUANTITY, null],
+    },
+  },
+};
+
+describe("issue 18747", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.createQuestionAndDashboard({ questionDetails }).then(
+      ({ body: { id, card_id, dashboard_id } }) => {
+        cy.request("PUT", `/api/dashboard/${dashboard_id}`, {
+          cards: [
+            {
+              id,
+              card_id,
+              row: 0,
+              col: 0,
+              sizeX: 12,
+              sizeY: 8,
+            },
+          ],
+        }).then(() => {
+          cy.visit(`/dashboard/${dashboard_id}`);
+        });
+      },
+    );
+  });
+
+  it("should correctly filter the table with a number parameter mapped to the custom column Quantity_2", () => {
+    addNumberParameterToDashboard();
+    mapParameterToCustomColumn();
+
+    cy.contains("Save").click();
+    // wait for saving to finish
+    cy.contains("You're editing this dashboard.").should("not.exist");
+
+    addValueToParameterFilter();
+
+    cy.get(".CardVisualization tbody > tr").should("have.length", 1);
+
+    // check that the parameter value is parsed correctly on page load
+    cy.reload();
+    cy.get(".LoadingSpinner").should("not.exist");
+
+    cy.get(".CardVisualization tbody > tr").should("have.length", 1);
+  });
+});
+
+function addNumberParameterToDashboard() {
+  cy.icon("pencil").click();
+  cy.icon("filter").click();
+  cy.contains("Number").click();
+  cy.findByText("Equal to").click();
+}
+
+function mapParameterToCustomColumn() {
+  cy.get(".DashCard")
+    .contains("Select…")
+    .click();
+  popover()
+    .contains("Quantity_2")
+    .click({ force: true });
+}
+
+function addValueToParameterFilter() {
+  cy.contains("Equal to").click();
+  popover()
+    .find("input")
+    .type("14");
+  popover()
+    .contains("Add filter")
+    .click();
+}


### PR DESCRIPTION
Fixes #18747 

We clearly have a race condition in our app where `metadata` isn't populated with fields before gears start turning and parameters code starts tying parameter objects to fields. Obviously, the race condition should be fixed. In the meantime, we have a handy back-up, the `result_metadata` array that is added to cards. In this PR, I'm adding some code that looks in `result_metadata` in case a field is not found in `metadata`.  We're already doing this for "virtual" fields, so now, we're doing this for all fields that come through `FieldDimension.prototype.field`.

I'm also going to try to track down why things are getting sequenced nicely so that we can trust that `metadata` has things we need, since it should.

Before

https://user-images.githubusercontent.com/13057258/139336556-d5cec495-1b50-4402-ba61-1f978b7a9580.mov

After


https://user-images.githubusercontent.com/13057258/139336569-dea879e5-b0fe-4459-9e60-d92d0a46dfb6.mov



