### PR TITLE
Fix table name gets included in pinned dimension names even for the query root table

### DIFF
--- a/frontend/src/metabase-lib/lib/Dimension.js
+++ b/frontend/src/metabase-lib/lib/Dimension.js
@@ -598,6 +598,10 @@ export class FieldDimension extends Dimension {
     });
   }
 
+  tableId() {
+    return this.field()?.table?.id;
+  }
+
   /**
    * Return a copy of this FieldDimension that excludes `options`.
    */
@@ -1223,10 +1227,6 @@ export class TemplateTagDimension extends FieldDimension {
   field() {
     const dimension = this.dimension();
     return dimension ? dimension.field() : super.field();
-  }
-
-  tableId() {
-    return this.field()?.table?.id;
   }
 
   name() {

--- a/frontend/test/metabase/scenarios/question/summarization.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/summarization.cy.spec.js
@@ -45,6 +45,7 @@ describe("scenarios > question > summarize sidebar", () => {
 
     // Displayed in the pinned list
     cy.findByTestId("pinned-dimensions").within(() => {
+      cy.findByText("Orders → Total").should("not.exist");
       getDimensionByName({ name: "Total" }).should(
         "have.attr",
         "aria-selected",
@@ -58,6 +59,27 @@ describe("scenarios > question > summarize sidebar", () => {
     cy.findByTestId("unpinned-dimensions").within(() => {
       cy.findByText("Total");
     });
+  });
+
+  it("selected dimensions from another table includes the table name when becomes pinned to the top", () => {
+    getDimensionByName({ name: "State" }).click();
+
+    cy.button("Done").click();
+    cy.findAllByText("Summarize")
+      .first()
+      .click();
+
+    cy.findByTestId("pinned-dimensions").within(() => {
+      getDimensionByName({ name: "People → State" }).should(
+        "have.attr",
+        "aria-selected",
+        "true",
+      );
+    });
+
+    getRemoveDimensionButton({ name: "People → State" }).click();
+
+    cy.findByText("People → State").should("not.exist");
   });
 
   it("selecting a binning adds a dimension", () => {


### PR DESCRIPTION
Was by mistake introduced while fixing review comments here https://github.com/metabase/metabase/pull/18587

How to verify:
- Simple question -> Orders table
- Click "Summarize" button
- Select "Total" from the "Orders" table and "State" from the "Users" table
- Click "Done" and then "Summarize" again
- Ensure the "Total" dimension is selected and it does not include "Orders" table name
- Ensure the "State" dimension is selected and it includes "People" table name

<img width="346" alt="Screen Shot 2021-10-29 at 15 17 12" src="https://user-images.githubusercontent.com/14301985/139432839-c8e04360-5367-47c8-a64b-8c13ec658094.png">