### PR TITLE
Simplify expression editor function: onExpressionChange

### DIFF
--- a/frontend/src/metabase/query_builder/components/ExpressionEditor/ExpressionEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/ExpressionEditor/ExpressionEditor.jsx
@@ -248,17 +248,70 @@ export default class ExpressionEditor extends React.Component {
     }
   };
 
-  onExpressionChange(source) {
-    const inputElement = this.input.current;
-    if (!inputElement) {
-      return;
+  getSuggestions = (source, suggestions, expression) => {
+    const targetOffset = this.getTargetOffset();
+
+    const suggestionsForNoSource = this.getSuggestionsForNoSource(
+      source,
+      targetOffset,
+    );
+
+    return suggestionsForNoSource
+      ? suggestionsForNoSource
+      : this.getSuggestionsFromSource(expression, source, suggestions);
+  };
+
+  getSuggestionsForNoSource(source, targetOffset) {
+    if (!source || source.length <= 0) {
+      const { suggestions } = this._processSource({
+        source,
+        targetOffset,
+        ...this._getParserOptions(),
+      });
+      return suggestions;
     }
 
+    return false;
+  }
+
+  getSuggestionsFromSource(expression, source, suggestions) {
+    const showSuggestions = this.checkIfShouldShowSuggestions(
+      expression,
+      source,
+    );
+
+    return showSuggestions ? suggestions : [];
+  }
+
+  checkIfShouldShowSuggestions(expression, source) {
+    const inputElement = this.input.current;
     const [selectionStart, selectionEnd] = getSelectionPosition(inputElement);
+
     const hasSelection = selectionStart !== selectionEnd;
     const isAtEnd = selectionEnd === source.length;
     const endsWithWhitespace = /\s$/.test(source);
-    const targetOffset = !hasSelection ? selectionEnd : null;
+    const isValid = expression !== undefined;
+
+    // don't show suggestions if there's a selection
+    // we're at the end of a valid expression, unless the user has typed another space
+    return !hasSelection && !(isValid && isAtEnd && !endsWithWhitespace);
+  }
+
+  getTargetOffset() {
+    const inputElement = this.input.current;
+    const [selectionStart, selectionEnd] = getSelectionPosition(inputElement);
+    const hasSelection = selectionStart !== selectionEnd;
+    const targetOffset = hasSelection ? null : selectionEnd;
+
+    return targetOffset;
+  }
+
+  onExpressionChange(source) {
+    if (!this.input.current) {
+      return;
+    }
+
+    const targetOffset = this.getTargetOffset();
 
     const { expression, compileError, suggestions, helpText } = source
       ? this._processSource({
@@ -273,18 +326,18 @@ export default class ExpressionEditor extends React.Component {
           helpText: null,
         };
 
-    const isValid = expression !== undefined;
     if (this.props.onBlankChange) {
       this.props.onBlankChange(source.length === 0);
     }
-    // don't show suggestions if
-    // * there's a selection
-    // * we're at the end of a valid expression, unless the user has typed another space
-    const showSuggestions =
-      !hasSelection && !(isValid && isAtEnd && !endsWithWhitespace);
 
     const { tokens, errors: tokenizerErrors } = tokenize(source);
     getTokenizerErrors(source, tokens, tokenizerErrors);
+
+    const treatedSuggestions = this.getSuggestions(
+      source,
+      suggestions,
+      expression,
+    );
 
     this.setState({
       source,
@@ -292,19 +345,10 @@ export default class ExpressionEditor extends React.Component {
       tokenizerError: tokenizerErrors,
       compileError,
       displayError: null,
-      suggestions: showSuggestions ? suggestions : [],
+      suggestions: treatedSuggestions,
       helpText,
       highlightedSuggestionIndex: 0,
     });
-
-    if (!source || source.length <= 0) {
-      const { suggestions } = this._processSource({
-        source,
-        targetOffset,
-        ...this._getParserOptions(),
-      });
-      this.setState({ suggestions });
-    }
   }
 
   render() {


### PR DESCRIPTION
Chipping away impediments to get to #18647

⚠️ This is a chain of PRs. Please review #18718 first.

<hr />

The main change here is converting two `setState` operations inside `onExpressionChange` into one.

In the process we reduce `onExpressionChange`’s
1. line count from 57 to 43 (in master it's 87)
2. cyclomatic complexity from 11 to 4 (in master it's 21)