### PR TITLE
Update query builder data selector for datasets

### DIFF
--- a/frontend/src/metabase-lib/lib/metadata/Database.js
+++ b/frontend/src/metabase-lib/lib/metadata/Database.js
@@ -2,9 +2,8 @@ import Question from "../Question";
 
 import Base from "./Base";
 
+import { generateSchemaId } from "metabase/lib/schema";
 import { memoize, createLookupByProperty } from "metabase-lib/lib/utils";
-
-import { generateSchemaId } from "metabase/schema";
 
 /**
  * @typedef { import("./metadata").SchemaName } SchemaName

--- a/frontend/src/metabase/collections/components/CollectionCopyEntityModal.jsx
+++ b/frontend/src/metabase/collections/components/CollectionCopyEntityModal.jsx
@@ -6,7 +6,7 @@ import { t } from "ttag";
 
 import * as Urls from "metabase/lib/urls";
 import withToast from "metabase/hoc/Toast";
-import { entityTypeForObject } from "metabase/schema";
+import { entityTypeForObject } from "metabase/lib/schema";
 
 import Link from "metabase/components/Link";
 

--- a/frontend/src/metabase/components/AccordionList.jsx
+++ b/frontend/src/metabase/components/AccordionList.jsx
@@ -73,6 +73,7 @@ export default class AccordionList extends Component {
     renderItemIcon: PropTypes.func,
     renderItemExtra: PropTypes.func,
     getItemClassName: PropTypes.func,
+    getItemIconPosition: PropTypes.func,
 
     alwaysTogglable: PropTypes.bool,
     alwaysExpanded: PropTypes.bool,
@@ -111,6 +112,7 @@ export default class AccordionList extends Component {
     renderItemExtra: item => null,
     renderItemIcon: item => item.icon && <Icon name={item.icon} size={18} />,
     getItemClassName: item => item.className,
+    getItemIconPosition: item => "left-block",
   };
 
   componentDidMount() {
@@ -477,6 +479,7 @@ const AccordionListCell = ({
   showItemArrows,
   itemTestId,
   getItemClassName,
+  getItemIconPosition,
 }) => {
   const { type, section, sectionIndex, item, itemIndex, isLastItem } = row;
   let content;
@@ -549,8 +552,17 @@ const AccordionListCell = ({
     const isSelected = itemIsSelected(item, itemIndex);
     const isClickable = itemIsClickable(item, itemIndex);
     const icon = renderItemIcon(item, itemIndex, isSelected);
+    const iconPosition = getItemIconPosition(item, itemIndex);
     const name = renderItemName(item, itemIndex, isSelected);
     const description = renderItemDescription(item, itemIndex, isSelected);
+    const isLeftBlockIcon = iconPosition === "left-block";
+    const iconClassNames = cx("List-item-icon text-default", {
+      "flex align-center": isLeftBlockIcon,
+    });
+    const descriptionClassNames = cx("List-item-description text-wrap", {
+      ml1: isLeftBlockIcon,
+    });
+    const Icon = icon && <span className={iconClassNames}>{icon}</span>;
     content = (
       <div
         data-testid={itemTestId}
@@ -572,17 +584,16 @@ const AccordionListCell = ({
           )}
           onClick={isClickable ? () => onChange(item) : null}
         >
-          {icon && (
-            <span className="List-item-icon text-default flex align-center">
-              {icon}
-            </span>
-          )}
+          {iconPosition === "left-block" && Icon}
           <div>
-            {name && <h4 className="List-item-title ml1 text-wrap">{name}</h4>}
+            {name && (
+              <div className="flex align-center">
+                {iconPosition === "near-name" && Icon}
+                <h4 className="List-item-title ml1 text-wrap inline">{name}</h4>
+              </div>
+            )}
             {description && (
-              <p className="List-item-description ml1 text-wrap">
-                {description}
-              </p>
+              <p className={descriptionClassNames}>{description}</p>
             )}
           </div>
         </a>

--- a/frontend/src/metabase/components/AccordionList.jsx
+++ b/frontend/src/metabase/components/AccordionList.jsx
@@ -562,7 +562,6 @@ const AccordionListCell = ({
     const descriptionClassNames = cx("List-item-description text-wrap", {
       ml1: isLeftBlockIcon,
     });
-    const Icon = icon && <span className={iconClassNames}>{icon}</span>;
     content = (
       <div
         data-testid={itemTestId}
@@ -584,11 +583,15 @@ const AccordionListCell = ({
           )}
           onClick={isClickable ? () => onChange(item) : null}
         >
-          {iconPosition === "left-block" && Icon}
+          {icon && iconPosition === "left-block" && (
+            <span className={iconClassNames}>{icon}</span>
+          )}
           <div>
             {name && (
               <div className="flex align-center">
-                {iconPosition === "near-name" && Icon}
+                {icon && iconPosition === "near-name" && (
+                  <span className={iconClassNames}>{icon}</span>
+                )}
                 <h4 className="List-item-title ml1 text-wrap inline">{name}</h4>
               </div>
             )}

--- a/frontend/src/metabase/entities/recents.js
+++ b/frontend/src/metabase/entities/recents.js
@@ -1,5 +1,6 @@
 import { createEntity } from "metabase/lib/entities";
-import { RecentsSchema, entityTypeForObject } from "metabase/schema";
+import { entityTypeForObject } from "metabase/lib/schema";
+import { RecentsSchema } from "metabase/schema";
 
 const Recents = createEntity({
   name: "recents",

--- a/frontend/src/metabase/entities/schemas.js
+++ b/frontend/src/metabase/entities/schemas.js
@@ -6,8 +6,9 @@ import {
   getCollectionVirtualSchemaId,
   getQuestionVirtualTableId,
 } from "metabase/lib/saved-questions";
+import { generateSchemaId, parseSchemaId } from "metabase/lib/schema";
 
-import { SchemaSchema, generateSchemaId, parseSchemaId } from "metabase/schema";
+import { SchemaSchema } from "metabase/schema";
 import Questions from "metabase/entities/questions";
 
 // This is a weird entity because we don't have actual schema objects

--- a/frontend/src/metabase/entities/schemas.js
+++ b/frontend/src/metabase/entities/schemas.js
@@ -14,6 +14,7 @@ import Questions from "metabase/entities/questions";
 
 const listDatabaseSchemas = GET("/api/database/:dbId/schemas");
 const getSchemaTables = GET("/api/database/:dbId/schema/:schemaName");
+const getVirtualDatasetTables = GET("/api/database/:dbId/datasets/:schemaName");
 
 export default createEntity({
   name: "schemas",
@@ -32,11 +33,13 @@ export default createEntity({
       }));
     },
     get: async ({ id }) => {
-      const [dbId, schemaName] = parseSchemaId(id);
+      const [dbId, schemaName, opts] = parseSchemaId(id);
       if (!dbId || schemaName === undefined) {
         throw new Error("Schemas ID is of the form dbId:schemaName");
       }
-      const tables = await getSchemaTables({ dbId, schemaName });
+      const tables = opts?.isDatasets
+        ? await getVirtualDatasetTables({ dbId, schemaName })
+        : await getSchemaTables({ dbId, schemaName });
       return {
         id,
         name: schemaName,

--- a/frontend/src/metabase/entities/search.js
+++ b/frontend/src/metabase/entities/search.js
@@ -1,12 +1,9 @@
 import { createEntity } from "metabase/lib/entities";
 
 import { GET } from "metabase/lib/api";
+import { entityTypeForObject } from "metabase/lib/schema";
 
-import {
-  ObjectUnionSchema,
-  ENTITIES_SCHEMA_MAP,
-  entityTypeForObject,
-} from "metabase/schema";
+import { ObjectUnionSchema, ENTITIES_SCHEMA_MAP } from "metabase/schema";
 
 import { canonicalCollectionId } from "metabase/entities/collections";
 

--- a/frontend/src/metabase/lib/saved-questions/saved-questions.js
+++ b/frontend/src/metabase/lib/saved-questions/saved-questions.js
@@ -1,4 +1,5 @@
 import { t } from "ttag";
+import { generateSchemaId } from "metabase/lib/schema";
 
 export const SAVED_QUESTIONS_VIRTUAL_DB_ID = -1337;
 export const ROOT_COLLECTION_VIRTUAL_SCHEMA_NAME = t`Everything else`;
@@ -8,14 +9,18 @@ export const ROOT_COLLECTION_VIRTUAL_SCHEMA = getCollectionVirtualSchemaId({
 });
 
 export function getCollectionVirtualSchemaName(collection) {
-  return !collection || collection.id === null
+  return !collection || collection.id === null || collection.id === "root"
     ? ROOT_COLLECTION_VIRTUAL_SCHEMA_NAME
     : collection.name;
 }
 
-export function getCollectionVirtualSchemaId(collection) {
+export function getCollectionVirtualSchemaId(collection, { isDatasets } = {}) {
   const collectionName = getCollectionVirtualSchemaName(collection);
-  return `${SAVED_QUESTIONS_VIRTUAL_DB_ID}:${collectionName}`;
+  return generateSchemaId(
+    SAVED_QUESTIONS_VIRTUAL_DB_ID,
+    collectionName,
+    isDatasets ? { isDatasets } : undefined,
+  );
 }
 
 export function getQuestionVirtualTableId(card) {

--- a/frontend/src/metabase/lib/saved-questions/saved-questions.js
+++ b/frontend/src/metabase/lib/saved-questions/saved-questions.js
@@ -9,9 +9,11 @@ export const ROOT_COLLECTION_VIRTUAL_SCHEMA = getCollectionVirtualSchemaId({
 });
 
 export function getCollectionVirtualSchemaName(collection) {
-  return !collection || collection.id === null || collection.id === "root"
+  const isRoot =
+    !collection || collection.id === null || collection.id === "root";
+  return isRoot
     ? ROOT_COLLECTION_VIRTUAL_SCHEMA_NAME
-    : collection.name;
+    : collection.schemaName || collection.name;
 }
 
 export function getCollectionVirtualSchemaId(collection, { isDatasets } = {}) {

--- a/frontend/src/metabase/lib/saved-questions/saved-questions.unit.spec.js
+++ b/frontend/src/metabase/lib/saved-questions/saved-questions.unit.spec.js
@@ -12,6 +12,9 @@ describe("saved question helpers", () => {
       expect(getCollectionVirtualSchemaName({ id: null })).toBe(
         "Everything else",
       );
+      expect(getCollectionVirtualSchemaName({ id: "root" })).toBe(
+        "Everything else",
+      );
     });
 
     it("should return 'Everything else' if collection is not passed", () => {
@@ -27,8 +30,18 @@ describe("saved question helpers", () => {
 
   describe("getCollectionVirtualSchemaId", () => {
     [
-      { collection: undefined, expectedName: "Everything else" },
-      { collection: { id: null }, expectedName: "Everything else" },
+      {
+        collection: undefined,
+        expectedName: encodeURIComponent("Everything else"),
+      },
+      {
+        collection: { id: null },
+        expectedName: encodeURIComponent("Everything else"),
+      },
+      {
+        collection: { id: "root" },
+        expectedName: encodeURIComponent("Everything else"),
+      },
       { collection: { id: 3, name: "Marketing" }, expectedName: "Marketing" },
     ].forEach(({ collection, expectedName }) => {
       it("returns name prefixed with virtual saved question DB ID", () => {
@@ -36,6 +49,18 @@ describe("saved question helpers", () => {
           `${SAVED_QUESTIONS_VIRTUAL_DB_ID}:${expectedName}`,
         );
       });
+    });
+
+    it("should return correct schema for collection datasets", () => {
+      const collection = { id: 1, name: "Marketing" };
+      const payload = JSON.stringify({
+        isDatasets: true,
+      });
+      const expectedId = `${SAVED_QUESTIONS_VIRTUAL_DB_ID}:Marketing:${payload}`;
+
+      expect(
+        getCollectionVirtualSchemaId(collection, { isDatasets: true }),
+      ).toBe(expectedId);
     });
   });
 
@@ -88,7 +113,9 @@ describe("saved question helpers", () => {
         description: question.description,
         moderated_status: question.moderated_status,
         db_id: question.dataset_query.database,
-        schema: `${SAVED_QUESTIONS_VIRTUAL_DB_ID}:Everything else`,
+        schema: `${SAVED_QUESTIONS_VIRTUAL_DB_ID}:${encodeURIComponent(
+          "Everything else",
+        )}`,
         schema_name: "Everything else",
       });
     });

--- a/frontend/src/metabase/lib/saved-questions/saved-questions.unit.spec.js
+++ b/frontend/src/metabase/lib/saved-questions/saved-questions.unit.spec.js
@@ -7,6 +7,11 @@ import {
 } from "./saved-questions";
 
 describe("saved question helpers", () => {
+  function getEncodedPayload(object) {
+    const json = JSON.stringify(object);
+    return encodeURIComponent(json);
+  }
+
   describe("getCollectionVirtualSchemaName", () => {
     it("should return 'Everything else' for root collection", () => {
       expect(getCollectionVirtualSchemaName({ id: null })).toBe(
@@ -53,9 +58,7 @@ describe("saved question helpers", () => {
 
     it("should return correct schema for collection datasets", () => {
       const collection = { id: 1, name: "Marketing" };
-      const payload = JSON.stringify({
-        isDatasets: true,
-      });
+      const payload = getEncodedPayload({ isDatasets: true });
       const expectedId = `${SAVED_QUESTIONS_VIRTUAL_DB_ID}:Marketing:${payload}`;
 
       expect(

--- a/frontend/src/metabase/lib/saved-questions/saved-questions.unit.spec.js
+++ b/frontend/src/metabase/lib/saved-questions/saved-questions.unit.spec.js
@@ -31,6 +31,17 @@ describe("saved question helpers", () => {
         getCollectionVirtualSchemaName({ id: 23, name: "Important questions" }),
       ).toBe("Important questions");
     });
+
+    it("should prefer collection's schema name over just name", () => {
+      const collection = {
+        id: 5,
+        name: "Your personal collection",
+        schemaName: "John Doe's Personal collection",
+      };
+      expect(getCollectionVirtualSchemaName(collection)).toBe(
+        collection.schemaName,
+      );
+    });
   });
 
   describe("getCollectionVirtualSchemaId", () => {

--- a/frontend/src/metabase/lib/schema/index.js
+++ b/frontend/src/metabase/lib/schema/index.js
@@ -1,0 +1,1 @@
+export * from "./schema";

--- a/frontend/src/metabase/lib/schema/schema.js
+++ b/frontend/src/metabase/lib/schema/schema.js
@@ -1,0 +1,38 @@
+// backend returns model = "card" instead of "question"
+export const entityTypeForModel = model =>
+  model === "card" || model === "dataset" ? "questions" : `${model}s`;
+
+export const entityTypeForObject = object =>
+  object && entityTypeForModel(object.model);
+
+export const getSchemaName = id => parseSchemaId(id)[1];
+
+export const parseSchemaId = id => {
+  const schemaId = String(id || "");
+  const firstColonIndex = schemaId.indexOf(":");
+  const secondColonIndex = schemaId.indexOf(":", firstColonIndex + 1);
+  const dbId = schemaId.substring(0, firstColonIndex);
+  const schemaName =
+    secondColonIndex === -1
+      ? schemaId.substring(firstColonIndex + 1)
+      : schemaId.substring(firstColonIndex + 1, secondColonIndex);
+  const payload =
+    secondColonIndex > 0 && schemaId.substring(secondColonIndex + 1);
+  const parsed = [dbId, decodeURIComponent(schemaName)];
+  if (payload) {
+    parsed.push(JSON.parse(payload));
+  }
+  return parsed;
+};
+
+export const generateSchemaId = (dbId, schemaName, payload) => {
+  // Schema ID components are separated with colons
+  // Schema name should be encoded to escape colon characters
+  // so parseSchemaId can work correctly
+  const name = schemaName ? encodeURIComponent(schemaName) : "";
+  let id = `${dbId}:${name}`;
+  if (payload) {
+    id += `:${JSON.stringify(payload)}`;
+  }
+  return id;
+};

--- a/frontend/src/metabase/lib/schema/schema.js
+++ b/frontend/src/metabase/lib/schema/schema.js
@@ -9,20 +9,12 @@ export const getSchemaName = id => parseSchemaId(id)[1];
 
 export const parseSchemaId = id => {
   const schemaId = String(id || "");
-  const firstColonIndex = schemaId.indexOf(":");
-  const secondColonIndex = schemaId.indexOf(":", firstColonIndex + 1);
-  const dbId = schemaId.substring(0, firstColonIndex);
-  const schemaName =
-    secondColonIndex === -1
-      ? schemaId.substring(firstColonIndex + 1)
-      : schemaId.substring(firstColonIndex + 1, secondColonIndex);
-  const payload =
-    secondColonIndex > 0 && schemaId.substring(secondColonIndex + 1);
-  const parsed = [dbId, decodeURIComponent(schemaName)];
-  if (payload) {
-    parsed.push(JSON.parse(payload));
+  const [databaseId, schemaName, encodedPayload] = schemaId.split(":");
+  const result = [databaseId, decodeURIComponent(schemaName)];
+  if (encodedPayload) {
+    result.push(JSON.parse(decodeURIComponent(encodedPayload)));
   }
-  return parsed;
+  return result;
 };
 
 export const generateSchemaId = (dbId, schemaName, payload) => {
@@ -32,7 +24,9 @@ export const generateSchemaId = (dbId, schemaName, payload) => {
   const name = schemaName ? encodeURIComponent(schemaName) : "";
   let id = `${dbId}:${name}`;
   if (payload) {
-    id += `:${JSON.stringify(payload)}`;
+    const json = JSON.stringify(payload);
+    const encodedPayload = encodeURIComponent(json);
+    id += `:${encodedPayload}`;
   }
   return id;
 };

--- a/frontend/src/metabase/lib/schema/schema.unit.spec.js
+++ b/frontend/src/metabase/lib/schema/schema.unit.spec.js
@@ -39,7 +39,7 @@ describe("schemas", () => {
     MODEL_ENTITY_TYPE.forEach(testCase => {
       const { model, entityType } = testCase;
       it(`returns "${entityType}" for "${model}" model`, () => {
-        expect(entityTypeForModel(model)).tpoBe(entityType);
+        expect(entityTypeForModel(model)).toBe(entityType);
       });
     });
   });

--- a/frontend/src/metabase/lib/schema/schema.unit.spec.js
+++ b/frontend/src/metabase/lib/schema/schema.unit.spec.js
@@ -30,11 +30,16 @@ describe("schemas", () => {
     },
   ];
 
+  function getEncodedPayload(object) {
+    const json = JSON.stringify(object);
+    return encodeURIComponent(json);
+  }
+
   describe("entityTypeForModel", () => {
     MODEL_ENTITY_TYPE.forEach(testCase => {
       const { model, entityType } = testCase;
       it(`returns "${entityType}" for "${model}" model`, () => {
-        expect(entityTypeForModel(model)).toBe(entityType);
+        expect(entityTypeForModel(model)).tpoBe(entityType);
       });
     });
   });
@@ -62,8 +67,11 @@ describe("schemas", () => {
 
     it("encodes extra payload", () => {
       const payload = { isDataset: true };
+      const expectedPayload = getEncodedPayload(payload);
+
       const schema = generateSchemaId(1, 2, payload);
-      expect(schema).toBe(`1:2:${JSON.stringify(payload)}`);
+
+      expect(schema).toBe(`1:2:${expectedPayload}`);
     });
   });
 
@@ -89,7 +97,7 @@ describe("schemas", () => {
     it("decodes extra payload", () => {
       const payload = { isDataset: true };
       const [dbId, schemaName, decodedPayload] = parseSchemaId(
-        `1:2:${JSON.stringify(payload)}`,
+        `1:2:${getEncodedPayload(payload)}`,
       );
       expect({ dbId, schemaName, payload: decodedPayload }).toEqual({
         dbId: "1",

--- a/frontend/src/metabase/lib/schema/schema.unit.spec.js
+++ b/frontend/src/metabase/lib/schema/schema.unit.spec.js
@@ -97,6 +97,25 @@ describe("schemas", () => {
         payload,
       });
     });
+
+    it("handles colons inside schema name", () => {
+      const databaseId = "-1337";
+      const collectionName = "test:collection";
+      const payload = { foo: "bar" };
+
+      const schemaId = generateSchemaId(databaseId, collectionName, payload);
+      const [
+        decodedDatabaseId,
+        decodedCollectionName,
+        decodedPayload,
+      ] = parseSchemaId(schemaId);
+
+      expect({
+        databaseId: decodedDatabaseId,
+        collectionName: decodedCollectionName,
+        payload: decodedPayload,
+      }).toEqual({ databaseId, collectionName, payload });
+    });
   });
 
   describe("getSchemaName", () => {

--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -1040,7 +1040,16 @@ const DatabaseSchemaPicker = ({
       sections={sections}
       onChange={item => onChangeSchema(item.schema)}
       onChangeSection={(_section, sectionIndex) => {
-        onChangeDatabase(databases[sectionIndex]);
+        const isNavigationSection = hasPreviousStep && sectionIndex === 0;
+        if (isNavigationSection) {
+          return false;
+        }
+        // the "go back" button is also a section,
+        // so need to take its index in mind
+        const database = hasPreviousStep
+          ? databases[sectionIndex - 1]
+          : databases[sectionIndex];
+        onChangeDatabase(database);
         return true;
       }}
       itemIsSelected={schema => schema === selectedSchema}

--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -762,9 +762,11 @@ export class UnconnectedDataSelector extends Component {
     const { hasTableSearch, steps } = this.props;
     const { activeStep } = this.state;
     const hasTableStep = steps.includes(TABLE_STEP);
-    const isAllowedToShowOnActiveStep = [SCHEMA_STEP, DATABASE_STEP].includes(
-      activeStep,
-    );
+    const isAllowedToShowOnActiveStep = [
+      DATA_BUCKET_STEP,
+      SCHEMA_STEP,
+      DATABASE_STEP,
+    ].includes(activeStep);
 
     return hasTableSearch && hasTableStep && isAllowedToShowOnActiveStep;
   };

--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -501,9 +501,14 @@ export class UnconnectedDataSelector extends Component {
 
   getPreviousStep() {
     const { steps } = this.props;
-    let index = steps.indexOf(this.state.activeStep);
+    const { activeStep } = this.state;
+    if (this.isLoadingDatasets() || activeStep === null) {
+      return null;
+    }
+
+    let index = steps.indexOf(activeStep);
     if (index === -1) {
-      console.error(`Step ${this.state.activeStep} not found in ${steps}.`);
+      console.error(`Step ${activeStep} not found in ${steps}.`);
       return null;
     }
 

--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -858,6 +858,20 @@ export class UnconnectedDataSelector extends Component {
       : t`Search for a table...`;
   };
 
+  getSearchModels = () => {
+    const { selectedDataBucketId, isSavedQuestionPickerShown } = this.state;
+    if (!selectedDataBucketId) {
+      return ["card", "dataset", "table"];
+    }
+    if (selectedDataBucketId === DATA_BUCKET.DATASETS) {
+      return ["dataset"];
+    }
+    if (isSavedQuestionPickerShown) {
+      return ["card"];
+    }
+    return this.hasDatasets() ? ["table", "card"] : ["table"];
+  };
+
   render() {
     const {
       searchText,
@@ -869,9 +883,6 @@ export class UnconnectedDataSelector extends Component {
 
     const isSearchActive = searchText.trim().length >= MIN_SEARCH_LENGTH;
 
-    const searchModels = isSavedQuestionPickerShown
-      ? ["card"]
-      : ["card", "table"];
 
     return (
       <PopoverWithTrigger
@@ -905,7 +916,7 @@ export class UnconnectedDataSelector extends Component {
             )}
             {isSearchActive && (
               <SearchResults
-                searchModels={searchModels}
+                searchModels={this.getSearchModels()}
                 searchQuery={searchText.trim()}
                 databaseId={currentDatabaseId}
                 onSelect={this.handleSearchItemSelect}

--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -872,14 +872,14 @@ export class UnconnectedDataSelector extends Component {
       isSavedQuestionPickerShown,
     } = this.state;
     if (activeStep === DATA_BUCKET_STEP) {
-      return t`Search for some data...`;
+      return t`Search for some data…`;
     }
     if (selectedDataBucketId === DATA_BUCKET.DATASETS) {
-      return t`Search for a model...`;
+      return t`Search for a model…`;
     }
     return isSavedQuestionPickerShown
-      ? t`Search for a question...`
-      : t`Search for a table...`;
+      ? t`Search for a question…`
+      : t`Search for a table…`;
   };
 
   getSearchModels = () => {

--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -30,10 +30,22 @@ import SavedQuestionPicker from "./saved-question-picker/SavedQuestionPicker";
 import { getMetadata } from "metabase/selectors/metadata";
 import { getSchemaName } from "metabase/schema";
 
+import {
+  DataBucketIcon,
+  DataBucketDescription,
+} from "./DataSelector.styled";
 import "./DataSelector.css";
 
 const MIN_SEARCH_LENGTH = 2;
 
+export const DATA_BUCKET = {
+  DATASETS: "datasets",
+  RAW_DATA: "raw-data",
+  SAVED_QUESTIONS: "saved-questions",
+};
+
+// chooses a data source bucket (datasets / raw data (tables) / saved questions)
+const DATA_BUCKET_STEP = "BUCKET";
 // chooses a database
 const DATABASE_STEP = "DATABASE";
 // chooses a schema (given that a database has already been selected)
@@ -53,7 +65,7 @@ export const DatabaseDataSelector = props => (
 
 export const DatabaseSchemaAndTableDataSelector = props => (
   <DataSelector
-    steps={[DATABASE_STEP, SCHEMA_STEP, TABLE_STEP]}
+    steps={[DATA_BUCKET_STEP, DATABASE_STEP, SCHEMA_STEP, TABLE_STEP]}
     combineDatabaseSchemaSteps
     getTriggerElementContent={TableTriggerContent}
     {...props}
@@ -688,6 +700,8 @@ export class UnconnectedDataSelector extends Component {
     };
 
     switch (this.state.activeStep) {
+      case DATA_BUCKET_STEP:
+        return <DataBucketPicker {...props} />;
       case DATABASE_STEP:
         return combineDatabaseSchemaSteps ? (
           <DatabaseSchemaPicker {...props} />
@@ -821,6 +835,49 @@ export class UnconnectedDataSelector extends Component {
     );
   }
 }
+
+const DataBucketPicker = () => {
+  const sections = [
+    {
+      items: [
+        {
+          id: DATA_BUCKET.DATASETS,
+          index: 0,
+          icon: "dataset",
+          name: t`Datasets`,
+          description: t`The best starting place for new questions.`,
+        },
+        {
+          id: DATA_BUCKET.RAW_DATA,
+          index: 1,
+          icon: "database",
+          name: t`Raw Data`,
+          description: t`Unaltered tables in connected databases.`,
+        },
+        {
+          id: DATA_BUCKET.SAVED_QUESTIONS,
+          index: 2,
+          name: t`Saved Questions`,
+          icon: "folder",
+          description: t`Use any question’s results to start a new question.`,
+        },
+      ],
+    },
+  ];
+
+  return (
+    <AccordionList
+      id="DataBucketPicker"
+      className="text-brand"
+      sections={sections}
+      renderItemIcon={item => <DataBucketIcon name={item.icon} size={18} />}
+      getItemIconPosition={() => "near-name"}
+      renderItemDescription={item => (
+        <DataBucketDescription>{item.description}</DataBucketDescription>
+      )}
+    />
+  );
+};
 
 const DatabasePicker = ({
   databases,

--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -33,6 +33,7 @@ import { getSchemaName } from "metabase/schema";
 import {
   DataBucketIcon,
   DataBucketDescription,
+  RawDataBackButton,
 } from "./DataSelector.styled";
 import "./DataSelector.css";
 
@@ -910,6 +911,7 @@ const DatabasePicker = ({
   selectedDatabase,
   onChangeDatabase,
   hasNextStep,
+  onBack,
 }) => {
   if (databases.length === 0) {
     return <DataSelectorLoading />;
@@ -917,6 +919,7 @@ const DatabasePicker = ({
 
   const sections = [
     {
+      name: onBack ? <RawDataBackButton onBack={onBack} /> : null,
       items: databases.map((database, index) => ({
         name: database.name,
         index,
@@ -983,10 +986,13 @@ const DatabaseSchemaPicker = ({
   onChangeDatabase,
   hasNextStep,
   isLoading,
+  onBack,
 }) => {
   if (databases.length === 0) {
     return <DataSelectorLoading />;
   }
+
+  const hasPreviousStep = typeof onBack === "function";
 
   const sections = databases.map(database => ({
     name: database.is_saved_questions ? t`Saved Questions` : database.name,
@@ -1005,6 +1011,12 @@ const DatabaseSchemaPicker = ({
       database.schemas.length === 0 &&
       isLoading,
   }));
+
+  if (hasPreviousStep) {
+    sections.unshift({
+      name: <RawDataBackButton onBack={onBack} />,
+    });
+  }
 
   let openSection = selectedSchema
     ? databases.findIndex(db => db.id === selectedSchema.database.id)
@@ -1032,9 +1044,11 @@ const DatabaseSchemaPicker = ({
         return true;
       }}
       itemIsSelected={schema => schema === selectedSchema}
-      renderSectionIcon={item => (
-        <Icon className="Icon text-default" name={item.icon} size={18} />
-      )}
+      renderSectionIcon={item =>
+        item.icon && (
+          <Icon className="Icon text-default" name={item.icon} size={18} />
+        )
+      }
       renderItemIcon={() => <Icon name="folder" size={16} />}
       initiallyOpenSection={openSection}
       alwaysTogglable={true}

--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -884,16 +884,17 @@ export class UnconnectedDataSelector extends Component {
 
   getSearchModels = () => {
     const { selectedDataBucketId, isSavedQuestionPickerShown } = this.state;
+    if (!this.hasDatasets()) {
+      return isSavedQuestionPickerShown ? ["card"] : ["card", "table"];
+    }
     if (!selectedDataBucketId) {
       return ["card", "dataset", "table"];
     }
-    if (selectedDataBucketId === DATA_BUCKET.DATASETS) {
-      return ["dataset"];
-    }
-    if (isSavedQuestionPickerShown) {
-      return ["card"];
-    }
-    return this.hasDatasets() ? ["table", "card"] : ["table"];
+    return {
+      [DATA_BUCKET.DATASETS]: ["dataset"],
+      [DATA_BUCKET.RAW_DATA]: ["table"],
+      [DATA_BUCKET.SAVED_QUESTIONS]: ["card"],
+    }[selectedDataBucketId];
   };
 
   render() {

--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -793,13 +793,19 @@ export class UnconnectedDataSelector extends Component {
         return <DataBucketPicker {...props} />;
       case DATABASE_STEP:
         return combineDatabaseSchemaSteps ? (
-          <DatabaseSchemaPicker {...props} />
+          <DatabaseSchemaPicker
+            {...props}
+            hasBackButton={this.hasDatasets() && props.onBack}
+          />
         ) : (
           <DatabasePicker {...props} />
         );
       case SCHEMA_STEP:
         return combineDatabaseSchemaSteps ? (
-          <DatabaseSchemaPicker {...props} />
+          <DatabaseSchemaPicker
+            {...props}
+            hasBackButton={this.hasDatasets() && props.onBack}
+          />
         ) : (
           <SchemaPicker {...props} />
         );
@@ -1088,13 +1094,12 @@ const DatabaseSchemaPicker = ({
   onChangeDatabase,
   hasNextStep,
   isLoading,
+  hasBackButton,
   onBack,
 }) => {
   if (databases.length === 0) {
     return <DataSelectorLoading />;
   }
-
-  const hasPreviousStep = typeof onBack === "function";
 
   const sections = databases.map(database => ({
     name: database.is_saved_questions ? t`Saved Questions` : database.name,
@@ -1114,7 +1119,7 @@ const DatabaseSchemaPicker = ({
       isLoading,
   }));
 
-  if (hasPreviousStep) {
+  if (hasBackButton) {
     sections.unshift({
       name: <RawDataBackButton onBack={onBack} />,
     });
@@ -1142,13 +1147,13 @@ const DatabaseSchemaPicker = ({
       sections={sections}
       onChange={item => onChangeSchema(item.schema)}
       onChangeSection={(_section, sectionIndex) => {
-        const isNavigationSection = hasPreviousStep && sectionIndex === 0;
+        const isNavigationSection = hasBackButton && sectionIndex === 0;
         if (isNavigationSection) {
           return false;
         }
         // the "go back" button is also a section,
         // so need to take its index in mind
-        const database = hasPreviousStep
+        const database = hasBackButton
           ? databases[sectionIndex - 1]
           : databases[sectionIndex];
         onChangeDatabase(database);

--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -841,6 +841,23 @@ export class UnconnectedDataSelector extends Component {
     this.setState({ searchText: "" });
   };
 
+  getSearchInputPlaceholder = () => {
+    const {
+      activeStep,
+      selectedDataBucketId,
+      isSavedQuestionPickerShown,
+    } = this.state;
+    if (activeStep === DATA_BUCKET_STEP) {
+      return t`Search for some data...`;
+    }
+    if (selectedDataBucketId === DATA_BUCKET.DATASETS) {
+      return t`Search for a model...`;
+    }
+    return isSavedQuestionPickerShown
+      ? t`Search for a question...`
+      : t`Search for a table...`;
+  };
+
   render() {
     const {
       searchText,
@@ -852,9 +869,6 @@ export class UnconnectedDataSelector extends Component {
 
     const isSearchActive = searchText.trim().length >= MIN_SEARCH_LENGTH;
 
-    const searchPlaceholder = isSavedQuestionPickerShown
-      ? t`Search for a question`
-      : t`Search for a table...`;
     const searchModels = isSavedQuestionPickerShown
       ? ["card"]
       : ["card", "table"];
@@ -885,7 +899,7 @@ export class UnconnectedDataSelector extends Component {
                 className="bg-white m1"
                 onChange={this.handleSearchTextChange}
                 value={searchText}
-                placeholder={searchPlaceholder}
+                placeholder={this.getSearchInputPlaceholder()}
                 autoFocus
               />
             )}

--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -759,8 +759,16 @@ export class UnconnectedDataSelector extends Component {
 
   renderActiveStep() {
     const { combineDatabaseSchemaSteps } = this.props;
+    const { databases } = this.state;
+
+    const showSavedQuestionsInDatabasePicker = !this.hasDatasets();
+    const filteredDatabases = showSavedQuestionsInDatabasePicker
+      ? databases
+      : databases?.filter(db => !db.is_saved_questions);
+
     const props = {
       ...this.state,
+      databases: filteredDatabases,
 
       onChangeDataBucket: this.onChangeDataBucket,
       onChangeDatabase: this.onChangeDatabase,

--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -16,6 +16,7 @@ import AccordionList from "metabase/components/AccordionList";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 
 import MetabaseSettings from "metabase/lib/settings";
+import { getSchemaName } from "metabase/lib/schema";
 
 import Databases from "metabase/entities/databases";
 import Schemas from "metabase/entities/schemas";
@@ -29,7 +30,6 @@ import {
 import SavedQuestionPicker from "./saved-question-picker/SavedQuestionPicker";
 
 import { getMetadata } from "metabase/selectors/metadata";
-import { getSchemaName } from "metabase/schema";
 
 import {
   DataBucketIcon,

--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -166,6 +166,7 @@ export class UnconnectedDataSelector extends Component {
     super();
 
     const state = {
+      selectedDataBucketId: props.selectedDataBucketId,
       selectedDatabaseId: props.selectedDatabaseId,
       selectedSchemaId: props.selectedSchemaId,
       selectedTableId: props.selectedTableId,
@@ -185,6 +186,7 @@ export class UnconnectedDataSelector extends Component {
   }
 
   static propTypes = {
+    selectedDataBucketId: PropTypes.number,
     selectedDatabaseId: PropTypes.number,
     selectedSchemaId: PropTypes.string,
     selectedTableId: PropTypes.number,
@@ -494,7 +496,15 @@ export class UnconnectedDataSelector extends Component {
   };
 
   getClearedStateForStep(step) {
-    if (step === DATABASE_STEP) {
+    if (step === DATA_BUCKET_STEP) {
+      return {
+        selectedDataBucketId: null,
+        selectedDatabaseId: null,
+        selectedSchemaId: null,
+        selectedTableId: null,
+        selectedFieldId: null,
+      };
+    } else if (step === DATABASE_STEP) {
       return {
         selectedDatabaseId: null,
         selectedSchemaId: null,
@@ -596,6 +606,19 @@ export class UnconnectedDataSelector extends Component {
   showSavedQuestionPicker = () =>
     this.setState({ isSavedQuestionPickerShown: true });
 
+  onChangeDataBucket = selectedDataBucketId => {
+    const { databases } = this.props;
+    if (selectedDataBucketId === DATA_BUCKET.RAW_DATA) {
+      this.switchToStep(DATABASE_STEP, { selectedDataBucketId });
+      return;
+    }
+    this.switchToStep(DATABASE_STEP, { selectedDataBucketId });
+    const database = databases.find(db => db.is_saved_questions);
+    if (database) {
+      this.onChangeDatabase(database);
+    }
+  };
+
   onChangeDatabase = async database => {
     if (database.is_saved_questions) {
       this.showSavedQuestionPicker();
@@ -687,6 +710,7 @@ export class UnconnectedDataSelector extends Component {
     const props = {
       ...this.state,
 
+      onChangeDataBucket: this.onChangeDataBucket,
       onChangeDatabase: this.onChangeDatabase,
       onChangeSchema: this.onChangeSchema,
       onChangeTable: this.onChangeTable,
@@ -836,7 +860,7 @@ export class UnconnectedDataSelector extends Component {
   }
 }
 
-const DataBucketPicker = () => {
+const DataBucketPicker = ({ selectedDataBucketId, onChangeDataBucket }) => {
   const sections = [
     {
       items: [
@@ -870,6 +894,8 @@ const DataBucketPicker = () => {
       id="DataBucketPicker"
       className="text-brand"
       sections={sections}
+      onChange={item => onChangeDataBucket(item.id)}
+      itemIsSelected={item => item.id === selectedDataBucketId}
       renderItemIcon={item => <DataBucketIcon name={item.icon} size={18} />}
       getItemIconPosition={() => "near-name"}
       renderItemDescription={item => (

--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -752,10 +752,13 @@ export class UnconnectedDataSelector extends Component {
       : "flex align-center";
   }
 
-  handleSavedQuestionPickerClose = () =>
-    this.setState({
-      isSavedQuestionPickerShown: false,
-    });
+  handleSavedQuestionPickerClose = () => {
+    const { selectedDataBucketId } = this.state;
+    if (selectedDataBucketId === DATA_BUCKET.DATASETS || this.hasDatasets()) {
+      this.previousStep();
+    }
+    this.setState({ isSavedQuestionPickerShown: false });
+  };
 
   renderActiveStep() {
     const { combineDatabaseSchemaSteps } = this.props;
@@ -884,6 +887,7 @@ export class UnconnectedDataSelector extends Component {
     const {
       searchText,
       isSavedQuestionPickerShown,
+      selectedDataBucketId,
       selectedTable,
     } = this.state;
     const { canChangeDatabase, selectedDatabaseId } = this.props;
@@ -891,6 +895,9 @@ export class UnconnectedDataSelector extends Component {
 
     const isSearchActive = searchText.trim().length >= MIN_SEARCH_LENGTH;
 
+    const isPickerOpen =
+      isSavedQuestionPickerShown ||
+      selectedDataBucketId === DATA_BUCKET.DATASETS;
 
     return (
       <PopoverWithTrigger
@@ -931,13 +938,14 @@ export class UnconnectedDataSelector extends Component {
               />
             )}
             {!isSearchActive &&
-              (isSavedQuestionPickerShown ? (
+              (isPickerOpen ? (
                 <SavedQuestionPicker
                   collectionName={
                     selectedTable &&
                     selectedTable.schema &&
                     getSchemaName(selectedTable.schema.id)
                   }
+                  isDatasets={selectedDataBucketId === DATA_BUCKET.DATASETS}
                   tableId={selectedTable && selectedTable.id}
                   databaseId={currentDatabaseId}
                   onSelect={this.handleSavedQuestionSelect}

--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -517,6 +517,11 @@ export class UnconnectedDataSelector extends Component {
       index -= 1;
     }
 
+    // data bucket step doesn't make a lot of sense when there're no datasets
+    if (steps[index] === DATA_BUCKET_STEP && !this.hasDatasets()) {
+      return null;
+    }
+
     // can't go back to a previous step
     if (index < 0) {
       return null;

--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -378,6 +378,11 @@ export class UnconnectedDataSelector extends Component {
   }
 
   async componentDidMount() {
+    const { activeStep } = this.state;
+    if (!this.isLoadingDatasets() && !activeStep) {
+      await this.hydrateActiveStep();
+    }
+
     if (this.props.selectedTableId) {
       await this.props.fetchFields(this.props.selectedTableId);
       if (this.isSavedQuestionSelected()) {
@@ -387,7 +392,7 @@ export class UnconnectedDataSelector extends Component {
   }
 
   async componentDidUpdate(prevProps) {
-    const { steps, loading } = this.props;
+    const { loading } = this.props;
     const loadedDatasets = prevProps.loading && !loading;
 
     // Once datasets are queried with the search endpoint,
@@ -395,12 +400,7 @@ export class UnconnectedDataSelector extends Component {
     // If there is at least one dataset, DATA_BUCKER_STEP will be shown,
     // otherwise, the picker will jump to the next step and present the regular picker
     if (loadedDatasets) {
-      const [firstStep] = steps;
-      if (firstStep === DATA_BUCKET_STEP && !this.hasDatasets()) {
-        this.switchToStep(steps[1]);
-      } else {
-        this.hydrateActiveStep();
-      }
+      await this.hydrateActiveStep();
     }
 
     // this logic cleans up invalid states, e.x. if a selectedSchema's database
@@ -460,6 +460,8 @@ export class UnconnectedDataSelector extends Component {
       await this.switchToStep(TABLE_STEP);
     } else if (this.state.selectedDatabaseId && steps.includes(SCHEMA_STEP)) {
       await this.switchToStep(SCHEMA_STEP);
+    } else if (steps[0] === DATA_BUCKET_STEP && !this.hasDatasets()) {
+      await this.switchToStep(steps[1]);
     } else {
       await this.switchToStep(steps[0]);
     }

--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -1033,7 +1033,6 @@ const DatabasePicker = ({
 
   const sections = [
     {
-      name: onBack ? <RawDataBackButton onBack={onBack} /> : null,
       items: databases.map((database, index) => ({
         name: database.name,
         index,
@@ -1042,6 +1041,10 @@ const DatabasePicker = ({
     },
   ];
 
+  if (onBack) {
+    sections.unshift({ name: <RawDataBackButton /> });
+  }
+
   return (
     <AccordionList
       id="DatabasePicker"
@@ -1049,6 +1052,13 @@ const DatabasePicker = ({
       className="text-brand"
       sections={sections}
       onChange={item => onChangeDatabase(item.database)}
+      onChangeSection={(_section, sectionIndex) => {
+        const isNavigationSection = onBack && sectionIndex === 0;
+        if (isNavigationSection) {
+          onBack();
+        }
+        return false;
+      }}
       itemIsSelected={item =>
         selectedDatabase && item.database.id === selectedDatabase.id
       }
@@ -1127,7 +1137,7 @@ const DatabaseSchemaPicker = ({
 
   if (hasBackButton) {
     sections.unshift({
-      name: <RawDataBackButton onBack={onBack} />,
+      name: <RawDataBackButton />,
     });
   }
 
@@ -1155,6 +1165,7 @@ const DatabaseSchemaPicker = ({
       onChangeSection={(_section, sectionIndex) => {
         const isNavigationSection = hasBackButton && sectionIndex === 0;
         if (isNavigationSection) {
+          onBack();
           return false;
         }
         // the "go back" button is also a section,

--- a/frontend/src/metabase/query_builder/components/DataSelector.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.styled.jsx
@@ -1,0 +1,21 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { t } from "ttag";
+import styled from "styled-components";
+import Icon from "metabase/components/Icon";
+import { color } from "metabase/lib/colors";
+
+export const DataBucketIcon = styled(Icon)`
+  margin-top: 2px;
+  color: ${color("text-dark")} !important;
+`;
+
+export const DataBucketDescription = styled.span`
+  font-weight: bold;
+  font-size: 12px;
+`;
+
+RawDataBackButton.propTypes = {
+  onBack: PropTypes.func.isRequired,
+};
+

--- a/frontend/src/metabase/query_builder/components/DataSelector.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.styled.jsx
@@ -4,6 +4,7 @@ import { t } from "ttag";
 import styled from "styled-components";
 import Icon from "metabase/components/Icon";
 import { color } from "metabase/lib/colors";
+import { space } from "metabase/styled-components/theme";
 
 export const DataBucketIcon = styled(Icon)`
   margin-top: 2px;
@@ -19,3 +20,32 @@ RawDataBackButton.propTypes = {
   onBack: PropTypes.func.isRequired,
 };
 
+const BackButtonContainer = styled.div`
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+`;
+
+const BackButtonLabel = styled.span`
+  font-size: 16px;
+  color: ${color("text-dark")};
+
+  margin-left: ${space(1)};
+
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  word-wrap: anywhere;
+
+  :hover {
+    color: ${color("brand")};
+  }
+`;
+
+export function RawDataBackButton({ onBack }) {
+  return (
+    <BackButtonContainer onClick={onBack}>
+      <Icon name="chevronleft" size={16} />
+      <BackButtonLabel>{t`Raw Data`}</BackButtonLabel>
+    </BackButtonContainer>
+  );
+}

--- a/frontend/src/metabase/query_builder/components/DataSelector.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.styled.jsx
@@ -41,9 +41,9 @@ const BackButtonLabel = styled.span`
   }
 `;
 
-export function RawDataBackButton({ onBack }) {
+export function RawDataBackButton() {
   return (
-    <BackButtonContainer onClick={onBack}>
+    <BackButtonContainer>
       <Icon name="chevronleft" size={16} />
       <BackButtonLabel>{t`Raw Data`}</BackButtonLabel>
     </BackButtonContainer>

--- a/frontend/src/metabase/query_builder/components/data-search/ItemLocation.jsx
+++ b/frontend/src/metabase/query_builder/components/data-search/ItemLocation.jsx
@@ -15,6 +15,8 @@ import { color } from "metabase/lib/colors";
 
 export const ItemLocation = ({ item }) => {
   switch (item.model) {
+    case "dataset":
+      return <DatasetLocation item={item} />;
     case "card":
       return <QuestionLocation item={item} />;
     case "table":
@@ -22,6 +24,17 @@ export const ItemLocation = ({ item }) => {
     default:
       return null;
   }
+};
+
+function DatasetLocation({ item }) {
+  const collection = item.getCollection();
+  return jt`Dataset in ${(
+    <Collection.Link id={collection.id} LinkComponent={LocationLink} />
+  )}`;
+}
+
+DatasetLocation.propTypes = {
+  item: PropTypes.object.isRequired,
 };
 
 ItemLocation.propTypes = {

--- a/frontend/src/metabase/query_builder/components/data-search/SearchResultItem.jsx
+++ b/frontend/src/metabase/query_builder/components/data-search/SearchResultItem.jsx
@@ -9,13 +9,17 @@ import { color, lighten } from "metabase/lib/colors";
 
 import { ItemLocation } from "./ItemLocation";
 
+function getSearchResultItemIcon(item) {
+  return item.model === "dataset" ? "dataset" : "table2";
+}
+
 export function SearchResultItem({ item, onSelect }) {
   const handleClick = () => onSelect(item);
 
   return (
     <SearchResultItemRoot onClick={handleClick}>
       <IconWrapper>
-        <Icon name="table2" size={22} />
+        <Icon name={getSearchResultItemIcon(item)} size={22} />
       </IconWrapper>
       <Details>
         <Title>{item.name}</Title>

--- a/frontend/src/metabase/query_builder/components/data-search/utils.js
+++ b/frontend/src/metabase/query_builder/components/data-search/utils.js
@@ -3,7 +3,10 @@ const SAVED_QUESTION_ID_PREFIX = "card__";
 export function convertSearchResultToTableLikeItem(searchResultItem) {
   // NOTE: in the entire application when we want to use saved questions as tables
   // we have to convert IDs by adding "card__" prefix to a question id
-  if (searchResultItem.model === "card") {
+  if (
+    searchResultItem.model === "card" ||
+    searchResultItem.model === "dataset"
+  ) {
     return {
       ...searchResultItem,
       id: `${SAVED_QUESTION_ID_PREFIX}${searchResultItem.id}`,

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.unit.spec.js
@@ -155,7 +155,6 @@ describe("Notebook Editor > Join Step", () => {
 
   async function selectTable(tableName) {
     await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
-    fireEvent.click(screen.queryByText(/Sample Dataset/i));
     const dataSelector = await screen.findByTestId("data-selector");
     fireEvent.click(within(dataSelector).queryByText(tableName));
 
@@ -211,7 +210,6 @@ describe("Notebook Editor > Join Step", () => {
     await setup();
     await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
 
-    fireEvent.click(screen.queryByText(/Sample Dataset/i));
     const dataSelector = await screen.findByTestId("data-selector");
 
     SAMPLE_DATASET.tables.forEach(table => {
@@ -425,6 +423,7 @@ describe("Notebook Editor > Join Step", () => {
       expect(screen.queryAllByText("Pick a column...")).toHaveLength(2);
     });
 
+    // ###
     it("automatically opens a parent dimension picker for new fields pair", async () => {
       await setup({ joinTable: "Products" });
 

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.unit.spec.js
@@ -154,6 +154,7 @@ describe("Notebook Editor > Join Step", () => {
   }
 
   async function selectTable(tableName) {
+    await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
     fireEvent.click(screen.queryByText(/Sample Dataset/i));
     const dataSelector = await screen.findByTestId("data-selector");
     fireEvent.click(within(dataSelector).queryByText(tableName));
@@ -185,6 +186,15 @@ describe("Notebook Editor > Join Step", () => {
         SAMPLE_DATASET.tables.filter(table => table.schema === "PUBLIC"),
       ),
     });
+    xhrMock.get("/api/search?models=dataset&limit=1", {
+      body: JSON.stringify({
+        data: [],
+        limit: 1,
+        models: ["dataset"],
+        offset: 0,
+        total: 0,
+      }),
+    });
   });
 
   afterEach(() => {
@@ -199,6 +209,7 @@ describe("Notebook Editor > Join Step", () => {
 
   it("opens a schema browser by default", async () => {
     await setup();
+    await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
 
     fireEvent.click(screen.queryByText(/Sample Dataset/i));
     const dataSelector = await screen.findByTestId("data-selector");

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.unit.spec.js
@@ -423,7 +423,6 @@ describe("Notebook Editor > Join Step", () => {
       expect(screen.queryAllByText("Pick a column...")).toHaveLength(2);
     });
 
-    // ###
     it("automatically opens a parent dimension picker for new fields pair", async () => {
       await setup({ joinTable: "Products" });
 

--- a/frontend/src/metabase/query_builder/components/saved-question-picker/SavedQuestionList.jsx
+++ b/frontend/src/metabase/query_builder/components/saved-question-picker/SavedQuestionList.jsx
@@ -70,7 +70,10 @@ function SavedQuestionList({
                     key={t.id}
                     size="small"
                     name={t.display_name}
-                    icon={isDatasets ? "dataset" : "table2"}
+                    icon={{
+                      name: isDatasets ? "dataset" : "table2",
+                      size: 16,
+                    }}
                     onSelect={() => onSelect(t)}
                     rightIcon={PLUGIN_MODERATION.getStatusIcon(
                       t.moderated_status,

--- a/frontend/src/metabase/query_builder/components/saved-question-picker/SavedQuestionList.jsx
+++ b/frontend/src/metabase/query_builder/components/saved-question-picker/SavedQuestionList.jsx
@@ -17,6 +17,7 @@ import {
 import { PERSONAL_COLLECTIONS } from "metabase/entities/collections";
 
 const propTypes = {
+  isDatasets: PropTypes.bool,
   databaseId: PropTypes.string,
   schema: PropTypes.object.isRequired,
   onSelect: PropTypes.func.isRequired,
@@ -30,7 +31,8 @@ const propTypes = {
   }).isRequired,
 };
 
-export default function SavedQuestionList({
+function SavedQuestionList({
+  isDatasets,
   onSelect,
   databaseId,
   selectedId,
@@ -51,6 +53,7 @@ export default function SavedQuestionList({
           id={generateSchemaId(
             SAVED_QUESTIONS_VIRTUAL_DB_ID,
             collection.schemaName,
+            { isDatasets },
           )}
         >
           {({ schema }) => {
@@ -67,7 +70,7 @@ export default function SavedQuestionList({
                     key={t.id}
                     size="small"
                     name={t.display_name}
-                    icon="table2"
+                    icon={isDatasets ? "dataset" : "table2"}
                     onSelect={() => onSelect(t)}
                     rightIcon={PLUGIN_MODERATION.getStatusIcon(
                       t.moderated_status,
@@ -87,3 +90,5 @@ export default function SavedQuestionList({
 }
 
 SavedQuestionList.propTypes = propTypes;
+
+export default SavedQuestionList;

--- a/frontend/src/metabase/query_builder/components/saved-question-picker/SavedQuestionList.jsx
+++ b/frontend/src/metabase/query_builder/components/saved-question-picker/SavedQuestionList.jsx
@@ -6,9 +6,8 @@ import { Box } from "grid-styled";
 
 import { PLUGIN_MODERATION } from "metabase/plugins";
 import Schemas from "metabase/entities/schemas";
-import { SAVED_QUESTIONS_VIRTUAL_DB_ID } from "metabase/lib/saved-questions";
+import { getCollectionVirtualSchemaId } from "metabase/lib/saved-questions";
 import EmptyState from "metabase/components/EmptyState";
-import { generateSchemaId } from "metabase/schema";
 
 import {
   SavedQuestionListRoot,
@@ -45,17 +44,12 @@ function SavedQuestionList({
   );
 
   const isVirtualCollection = collection.id === PERSONAL_COLLECTIONS.id;
+  const schemaId = getCollectionVirtualSchemaId(collection, { isDatasets });
 
   return (
     <SavedQuestionListRoot>
       {!isVirtualCollection && (
-        <Schemas.Loader
-          id={generateSchemaId(
-            SAVED_QUESTIONS_VIRTUAL_DB_ID,
-            collection.schemaName,
-            { isDatasets },
-          )}
-        >
+        <Schemas.Loader id={schemaId}>
           {({ schema }) => {
             const tables =
               databaseId != null

--- a/frontend/src/metabase/query_builder/components/saved-question-picker/SavedQuestionPicker.jsx
+++ b/frontend/src/metabase/query_builder/components/saved-question-picker/SavedQuestionPicker.jsx
@@ -26,6 +26,7 @@ import {
 import { buildCollectionTree, findCollectionByName } from "./utils";
 
 const propTypes = {
+  isDatasets: PropTypes.bool,
   onSelect: PropTypes.func.isRequired,
   onBack: PropTypes.func.isRequired,
   collections: PropTypes.array.isRequired,
@@ -46,6 +47,7 @@ const ALL_PERSONAL_COLLECTIONS_ROOT = {
 };
 
 function SavedQuestionPicker({
+  isDatasets,
   onBack,
   onSelect,
   collections,
@@ -110,7 +112,7 @@ function SavedQuestionPicker({
       <CollectionsContainer>
         <BackButton onClick={onBack}>
           <Icon name="chevronleft" className="mr1" />
-          {t`Saved Questions`}
+          {isDatasets ? t`Datasets` : t`Saved Questions`}
         </BackButton>
         <Box my={1}>
           <Tree
@@ -121,6 +123,7 @@ function SavedQuestionPicker({
         </Box>
       </CollectionsContainer>
       <SavedQuestionList
+        isDatasets={isDatasets}
         collection={selectedCollection}
         selectedId={tableId}
         databaseId={databaseId}

--- a/frontend/src/metabase/schema.js
+++ b/frontend/src/metabase/schema.js
@@ -1,6 +1,7 @@
 // normalizr schema for use in actions/reducers
 
 import { schema } from "normalizr";
+import { generateSchemaId, entityTypeForObject } from "metabase/lib/schema";
 import { SAVED_QUESTIONS_VIRTUAL_DB_ID } from "metabase/lib/saved-questions";
 
 export const QuestionSchema = new schema.Entity("questions");
@@ -80,13 +81,6 @@ MetricSchema.define({
   table: TableSchema,
 });
 
-// backend returns model = "card" instead of "question"
-export const entityTypeForModel = model =>
-  model === "card" || model === "dataset" ? "questions" : `${model}s`;
-
-export const entityTypeForObject = object =>
-  object && entityTypeForModel(object.model);
-
 export const ENTITIES_SCHEMA_MAP = {
   questions: QuestionSchema,
   dashboards: DashboardSchema,
@@ -106,33 +100,6 @@ export const ObjectUnionSchema = new schema.Union(
 CollectionSchema.define({
   items: [ObjectUnionSchema],
 });
-
-export const getSchemaName = id => parseSchemaId(id)[1];
-export const parseSchemaId = id => {
-  const schemaId = String(id || "");
-  const firstColonIndex = schemaId.indexOf(":");
-  const secondColonIndex = schemaId.indexOf(":", firstColonIndex + 1);
-  const dbId = schemaId.substring(0, firstColonIndex);
-  const schemaName =
-    secondColonIndex === -1
-      ? schemaId.substring(firstColonIndex + 1)
-      : schemaId.substring(firstColonIndex + 1, secondColonIndex);
-  const payload =
-    secondColonIndex > 0 && schemaId.substring(secondColonIndex + 1);
-  const parsed = [dbId, schemaName];
-  if (payload) {
-    parsed.push(JSON.parse(payload));
-  }
-  return parsed;
-};
-
-export const generateSchemaId = (dbId, schemaName, payload) => {
-  let id = `${dbId}:${schemaName || ""}`;
-  if (payload) {
-    id += `:${JSON.stringify(payload)}`;
-  }
-  return id;
-};
 
 export const RecentsSchema = new schema.Entity("recents", undefined, {
   idAttribute: ({ model, model_id }) => `${model}:${model_id}`,

--- a/frontend/src/metabase/schema.js
+++ b/frontend/src/metabase/schema.js
@@ -111,13 +111,28 @@ export const getSchemaName = id => parseSchemaId(id)[1];
 export const parseSchemaId = id => {
   const schemaId = String(id || "");
   const firstColonIndex = schemaId.indexOf(":");
+  const secondColonIndex = schemaId.indexOf(":", firstColonIndex + 1);
   const dbId = schemaId.substring(0, firstColonIndex);
-  const schemaName = schemaId.substring(firstColonIndex + 1);
-
-  return [dbId, schemaName];
+  const schemaName =
+    secondColonIndex === -1
+      ? schemaId.substring(firstColonIndex + 1)
+      : schemaId.substring(firstColonIndex + 1, secondColonIndex);
+  const payload =
+    secondColonIndex > 0 && schemaId.substring(secondColonIndex + 1);
+  const parsed = [dbId, schemaName];
+  if (payload) {
+    parsed.push(JSON.parse(payload));
+  }
+  return parsed;
 };
-export const generateSchemaId = (dbId, schemaName) =>
-  `${dbId}:${schemaName || ""}`;
+
+export const generateSchemaId = (dbId, schemaName, payload) => {
+  let id = `${dbId}:${schemaName || ""}`;
+  if (payload) {
+    id += `:${JSON.stringify(payload)}`;
+  }
+  return id;
+};
 
 export const RecentsSchema = new schema.Entity("recents", undefined, {
   idAttribute: ({ model, model_id }) => `${model}:${model_id}`,

--- a/frontend/src/metabase/schema.unit.spec.js
+++ b/frontend/src/metabase/schema.unit.spec.js
@@ -59,6 +59,12 @@ describe("schemas", () => {
         expect(generateSchemaId(dbId, schemaName)).toBe(schema);
       });
     });
+
+    it("encodes extra payload", () => {
+      const payload = { isDataset: true };
+      const schema = generateSchemaId(1, 2, payload);
+      expect(schema).toBe(`1:2:${JSON.stringify(payload)}`);
+    });
   });
 
   describe("parseSchemaId", () => {
@@ -77,6 +83,18 @@ describe("schemas", () => {
           dbId: expectedDatabaseId,
           schemaName: expectedSchemaName,
         });
+      });
+    });
+
+    it("decodes extra payload", () => {
+      const payload = { isDataset: true };
+      const [dbId, schemaName, decodedPayload] = parseSchemaId(
+        `1:2:${JSON.stringify(payload)}`,
+      );
+      expect({ dbId, schemaName, payload: decodedPayload }).toEqual({
+        dbId: "1",
+        schemaName: "2",
+        payload,
       });
     });
   });

--- a/frontend/src/metabase/schema.unit.spec.js
+++ b/frontend/src/metabase/schema.unit.spec.js
@@ -1,0 +1,93 @@
+import {
+  entityTypeForModel,
+  entityTypeForObject,
+  getSchemaName,
+  parseSchemaId,
+  generateSchemaId,
+} from "./schema";
+
+describe("schemas", () => {
+  const MODEL_ENTITY_TYPE = [
+    { model: "card", entityType: "questions" },
+    { model: "dataset", entityType: "questions" },
+    { model: "dashboard", entityType: "dashboards" },
+    { model: "pulse", entityType: "pulses" },
+    { model: "collection", entityType: "collections" },
+    { model: "segment", entityType: "segments" },
+    { model: "metric", entityType: "metrics" },
+    { model: "snippet", entityType: "snippets" },
+    { model: "snippetCollection", entityType: "snippetCollections" },
+  ];
+
+  const SCHEMA_TEST_CASES = [
+    { dbId: 1, schemaName: 2, schema: "1:2" },
+    { dbId: "1", schemaName: "2", schema: "1:2" },
+    { dbId: "1", schema: "1:" },
+    {
+      dbId: -1337,
+      schemaName: "Collection",
+      schema: "-1337:Collection",
+    },
+  ];
+
+  describe("entityTypeForModel", () => {
+    MODEL_ENTITY_TYPE.forEach(testCase => {
+      const { model, entityType } = testCase;
+      it(`returns "${entityType}" for "${model}" model`, () => {
+        expect(entityTypeForModel(model)).toBe(entityType);
+      });
+    });
+  });
+
+  describe("entityTypeForObject", () => {
+    MODEL_ENTITY_TYPE.forEach(testCase => {
+      const { model, entityType } = testCase;
+      it(`returns "${entityType}" for "${model}" model`, () => {
+        expect(entityTypeForObject({ model })).toBe(entityType);
+      });
+    });
+
+    it(`handles undefined object`, () => {
+      expect(entityTypeForObject()).toBe(undefined);
+    });
+  });
+
+  describe("generateSchemaId", () => {
+    SCHEMA_TEST_CASES.forEach(testCase => {
+      const { dbId, schemaName, schema } = testCase;
+      it(`returns "${schema}" for "${dbId}" DB and ${schemaName} schema`, () => {
+        expect(generateSchemaId(dbId, schemaName)).toBe(schema);
+      });
+    });
+  });
+
+  describe("parseSchemaId", () => {
+    SCHEMA_TEST_CASES.forEach(testCase => {
+      const { schema, dbId, schemaName } = testCase;
+
+      const expectedDatabaseId = String(dbId);
+      const expectedSchemaName = schemaName ? String(schemaName) : "";
+
+      it(`parses "${schema}" correctly`, () => {
+        const [parsedDatabaseId, parsedSchemaName] = parseSchemaId(schema);
+        expect({
+          dbId: parsedDatabaseId,
+          schemaName: parsedSchemaName,
+        }).toEqual({
+          dbId: expectedDatabaseId,
+          schemaName: expectedSchemaName,
+        });
+      });
+    });
+  });
+
+  describe("getSchemaName", () => {
+    SCHEMA_TEST_CASES.forEach(testCase => {
+      const { schema, schemaName } = testCase;
+      const expectedSchemaName = schemaName ? String(schemaName) : "";
+      it(`returns "${expectedSchemaName}" for "${schema}"`, () => {
+        expect(getSchemaName(schema)).toBe(expectedSchemaName);
+      });
+    });
+  });
+});

--- a/frontend/test/metabase/query_builder/components/DataSelector.unit.spec.js
+++ b/frontend/test/metabase/query_builder/components/DataSelector.unit.spec.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { render, fireEvent } from "@testing-library/react";
+import xhrMock from "xhr-mock";
 
 import _ from "underscore";
 
@@ -18,6 +19,23 @@ import {
 import { UnconnectedDataSelector as DataSelector } from "metabase/query_builder/components/DataSelector";
 
 describe("DataSelector", () => {
+  beforeEach(() => {
+    xhrMock.setup();
+    xhrMock.get("/api/search?models=dataset&limit=1", {
+      body: JSON.stringify({
+        data: [],
+        limit: 1,
+        models: ["dataset"],
+        offset: 0,
+        total: 0,
+      }),
+    });
+  });
+
+  afterEach(() => {
+    xhrMock.teardown();
+  });
+
   const emptyMetadata = {
     databases: {},
     schemas: {},

--- a/frontend/test/metabase/scenarios/question/datasets.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/datasets.cy.spec.js
@@ -39,7 +39,7 @@ describe("scenarios > datasets", () => {
 
       popover().within(() => {
         testDataPickerSearch({
-          inputPlaceholderText: "Search for some data...",
+          inputPlaceholderText: "Search for some data…",
           query: "Ord",
           datasets: true,
           cards: true,
@@ -52,7 +52,7 @@ describe("scenarios > datasets", () => {
           cy.findByText("Orders, Count").should("not.exist");
         });
         testDataPickerSearch({
-          inputPlaceholderText: "Search for a model...",
+          inputPlaceholderText: "Search for a model…",
           query: "Ord",
           datasets: true,
         });
@@ -64,7 +64,7 @@ describe("scenarios > datasets", () => {
           cy.findByText("Orders").should("not.exist");
         });
         testDataPickerSearch({
-          inputPlaceholderText: "Search for a question...",
+          inputPlaceholderText: "Search for a question…",
           query: "Ord",
           cards: true,
         });
@@ -74,7 +74,7 @@ describe("scenarios > datasets", () => {
         cy.findByText("Sample Dataset");
         cy.findByText("Saved Questions").should("not.exist");
         testDataPickerSearch({
-          inputPlaceholderText: "Search for a table...",
+          inputPlaceholderText: "Search for a table…",
           query: "Ord",
           tables: true,
         });

--- a/frontend/test/metabase/scenarios/question/datasets.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/datasets.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, modal } from "__support__/e2e/cypress";
+import { restore, modal, popover } from "__support__/e2e/cypress";
 
 describe("scenarios > datasets", () => {
   beforeEach(() => {
@@ -26,6 +26,79 @@ describe("scenarios > datasets", () => {
     cy.get(".TableInteractive");
     cy.get(".LineAreaBarChart").should("not.exist");
   });
+
+  describe("data picker", () => {
+    beforeEach(() => {
+      cy.intercept("GET", "/api/search").as("search");
+    });
+
+    it("remains the same when there are no datasets", () => {
+      cy.visit("/question/new");
+      cy.findByText("Custom question").click();
+
+      popover().within(() => {
+        cy.findByText("Sample Dataset");
+        cy.findByText("Saved Questions");
+
+        testDataPickerSearch({
+          inputPlaceholderText: "Search for a table...",
+          query: "Ord",
+          cards: true,
+          tables: true,
+        });
+      });
+    });
+
+    it("transforms the data picker", () => {
+      cy.request("PUT", "/api/card/1", { dataset: true });
+
+      cy.visit("/question/new");
+      cy.findByText("Custom question").click();
+
+      popover().within(() => {
+        testDataPickerSearch({
+          inputPlaceholderText: "Search for some data...",
+          query: "Ord",
+          datasets: true,
+          cards: true,
+          tables: true,
+        });
+
+        cy.findByText("Datasets").click();
+        cy.findByTestId("select-list").within(() => {
+          cy.findByText("Orders");
+          cy.findByText("Orders, Count").should("not.exist");
+        });
+        testDataPickerSearch({
+          inputPlaceholderText: "Search for a model...",
+          query: "Ord",
+          datasets: true,
+        });
+        cy.icon("chevronleft").click();
+
+        cy.findByText("Saved Questions").click();
+        cy.findByTestId("select-list").within(() => {
+          cy.findByText("Orders, Count");
+          cy.findByText("Orders").should("not.exist");
+        });
+        testDataPickerSearch({
+          inputPlaceholderText: "Search for a question...",
+          query: "Ord",
+          cards: true,
+        });
+        cy.icon("chevronleft").click();
+
+        cy.findByText("Raw Data").click();
+        cy.findByText("Sample Dataset");
+        cy.findByText("Saved Questions").should("not.exist");
+        testDataPickerSearch({
+          inputPlaceholderText: "Search for a table...",
+          query: "Ord",
+          tables: true,
+        });
+      });
+    });
+  });
 });
 
 function turnIntoDataset() {
@@ -38,4 +111,21 @@ function turnIntoDataset() {
 
 function getCollectionItemRow(itemName) {
   return cy.findByText(itemName).closest("tr");
+}
+
+function testDataPickerSearch({
+  inputPlaceholderText,
+  query,
+  datasets = false,
+  cards = false,
+  tables = false,
+} = {}) {
+  cy.findByPlaceholderText(inputPlaceholderText).type(query);
+  cy.wait("@search");
+
+  cy.findAllByText(/Dataset in/i).should(datasets ? "exist" : "not.exist");
+  cy.findAllByText(/Saved question in/i).should(cards ? "exist" : "not.exist");
+  cy.findAllByText(/Table in/i).should(tables ? "exist" : "not.exist");
+
+  cy.icon("close").click();
 }

--- a/frontend/test/metabase/scenarios/question/new.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/new.cy.spec.js
@@ -187,7 +187,7 @@ describe("scenarios > question > new", () => {
       });
 
       it("should perform a search scoped to saved questions", () => {
-        cy.findByPlaceholderText("Search for a question").type("Grouped");
+        cy.findByPlaceholderText("Search for a question...").type("Grouped");
         cy.findByText("Orders, Count, Grouped by Created At (year)").click();
         cy.findByText("1,994");
       });
@@ -230,7 +230,7 @@ describe("scenarios > question > new", () => {
       });
 
       it("should perform a search scoped to saved questions", () => {
-        cy.findByPlaceholderText("Search for a question").type("Grouped");
+        cy.findByPlaceholderText("Search for a question...").type("Grouped");
         cy.findByText("Orders, Count, Grouped by Created At (year)").click();
 
         visualize();

--- a/frontend/test/metabase/scenarios/question/new.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/new.cy.spec.js
@@ -108,7 +108,7 @@ describe("scenarios > question > new", () => {
     describe("on a (simple) question page", () => {
       beforeEach(() => {
         cy.findByText("Simple question").click();
-        cy.findByPlaceholderText("Search for a table...").type("Ord");
+        cy.findByPlaceholderText("Search for a table…").type("Ord");
       });
 
       it("should allow to search saved questions", () => {
@@ -130,7 +130,7 @@ describe("scenarios > question > new", () => {
     describe("on a (custom) question page", () => {
       beforeEach(() => {
         cy.findByText("Custom question").click();
-        cy.findByPlaceholderText("Search for a table...").type("Ord");
+        cy.findByPlaceholderText("Search for a table…").type("Ord");
       });
 
       it("should allow to search saved questions", () => {
@@ -159,7 +159,7 @@ describe("scenarios > question > new", () => {
         expect("Unexpected call to /api/search").to.be.false;
       });
       cy.findByText("Custom question").click();
-      cy.findByPlaceholderText("Search for a table...").type("  ");
+      cy.findByPlaceholderText("Search for a table…").type("  ");
     });
   });
 
@@ -187,7 +187,7 @@ describe("scenarios > question > new", () => {
       });
 
       it("should perform a search scoped to saved questions", () => {
-        cy.findByPlaceholderText("Search for a question...").type("Grouped");
+        cy.findByPlaceholderText("Search for a question…").type("Grouped");
         cy.findByText("Orders, Count, Grouped by Created At (year)").click();
         cy.findByText("1,994");
       });
@@ -230,7 +230,7 @@ describe("scenarios > question > new", () => {
       });
 
       it("should perform a search scoped to saved questions", () => {
-        cy.findByPlaceholderText("Search for a question...").type("Grouped");
+        cy.findByPlaceholderText("Search for a question…").type("Grouped");
         cy.findByText("Orders, Count, Grouped by Created At (year)").click();
 
         visualize();


### PR DESCRIPTION
This PR adds datasets support for GUI query data source picker (feature epic #18659)

![before-after-img](https://user-images.githubusercontent.com/17258145/139724310-c0e7fba3-7a2a-4a13-831f-a0d200e49272.png)

When people have at least one dataset in Metabase, we're going to display a new first step. Otherwise, the picker should remain the same. About the "tabs":

* **Saved Questions** works the same way it does now
* **Raw Data** contains databases, schemas, and tables (the one you can see when using the picker now). The only difference here is that Raw Data doesn't list the "Saved Questions" option as they have their own tab
* **Datasets** tab looks the same way as the saved question picker, but only lists datasets

## Implementation Details

The goal is to have a minimal version of datasets on `master` ASAP, so we can play around with the whole experience and introduce changes early. There are some trade-offs I had to address, and the main principles in the decisions are speed and YAGNI in case we want to change something about the requirements.

### Reusing saved questions picker

Datasets picker is expected to look and work the same way as the saved question picker, but only display datasets. So we should either extend the existing saved questions picker to support datasets too (datasets are saved questions under the hood, so their APIs are almost identical) or extract some common code and create two different components. This PR _extends_ the saved questions picker, so the data selector uses _just one_ component for both datasets and saved questions.

### Encoding extra parameters in schema ID

As mentioned above, this PR actually uses the saved questions picker for datasets too. When a user selects a collection from the picker, [`SavedQuestionList` requests a list of questions from the backend using the Schema entity loader](https://github.com/metabase/metabase/blob/5fcf4a3aa216298ec12a2d380668df0ab33d9e16/frontend/src/metabase/query_builder/components/saved-question-picker/SavedQuestionList.jsx#L50).

The trick here is that the BE will only return saved questions (not datasets) as expected. And we need to use another API endpoint to get datasets from a particular collection. So we need a way to let the Schema entity loader know when we need questions and when we need datasets. 

This PR extends the schema ID string to also contain some extra JSON data. Schema IDs currently look like `14:Application` where `14` is the database's ID and `Application` is a name of a schema. For saved questions, schema IDs look like `-1337:Marketing` where `-1337` is a "virtual" database with saved questions and `Marketing` is a name of a collection. This PR extends the format, so we can now also have something like `-1337:Marketing:{"isDatasets":true}`. Schema entity later [uses this parameter](https://github.com/metabase/metabase/blob/139ee2cea6460cc0a4183ddc59d86de9922d37b2/frontend/src/metabase/entities/schemas.js#L41) to decide which endpoint it should use.

### Schema file reorg

There is a [`schema` file in FE source code root](https://github.com/metabase/metabase/blob/master/frontend/src/metabase/schema.js). It has entity schema definitions and some extra helpers for encoding and decoding schema ID, etc. I needed to use `generateSchemaId` in `metabase/lib/saved-questions` ([here](https://github.com/metabase/metabase/blob/139ee2cea6460cc0a4183ddc59d86de9922d37b2/frontend/src/metabase/lib/saved-questions/saved-questions.js#L19)), but the FE broke because some intertwined imports order if I just imported it. So in this PR, the schema utils are moved to [`metabase/lib/schema`](https://github.com/metabase/metabase/blob/139ee2cea6460cc0a4183ddc59d86de9922d37b2/frontend/src/metabase/lib/schema/schema.js). Entity schemas are still kept in `metabase/schema`

## To Verify

1. Archive any datasets if you have any
2. Ask a question > Simple / Custom Question
3. Make sure the data source picker looks and works the same way it does on `master`
4. Turn any question into a dataset (you can follow the steps from #18702)
5. Ask a question > Simple / Custom Question
6. The picker should have a new look now. You should see three options: Datasets, Raw Data, Saved Questions. Don't click anything for now

**Common Search**

Try to find a dataset, a table, and a saved question by their names. The search shouldn't skip any of these models

**Raw Data Tab**

1. Click the "Raw Data" tab
2. You should not see "Saved Questions" DB anywhere in the list
3. Try to find a dataset, a table, and a saved question by their names. While being on the "Raw Data" tab, the search should be scoped to tables. So you shouldn't see any datasets and saved questions in the results
4. Make sure the picker works the same way it does on `master` (expanding DB schemas, selecting things, etc.)
5. Click the back button, you should appear on the list with "Datasets", "Raw Data" and "Saved Questions"

**Datasets Tab**

1. Click the "Datasets" tab
2. Try to find a dataset, a table, and a saved question by their names. While being on the "Datasets" tab, the search should be scoped to datasets. So you shouldn't see any tables and saved questions in the results
3. Click on a few collections. If a collection has datasets, they should be shown on the right side
4. Make sure you don't see saved questions in the collections

**Saved Questions Tab**

1. Click the "Saved Questions" tab
2. Try to find a dataset, a table, and a saved question by their names. While being on the "Saved Questions" tab, the search should be scoped to saved questions only. So you shouldn't see any datasets and tables in the results
3. Make sure the picker works the same way it does on `master` (clicking collections, displaying content, etc.)
4. Make sure you don't see a dataset in the collection you saved it to
5. Click the back button, you should appear on the list with "Datasets", "Raw Data" and "Saved Questions"

**Ask a question!**

Create and save a question based on a dataset

## Demo

https://user-images.githubusercontent.com/17258145/139733530-ea3182f6-a820-407d-b8db-3490859fc061.mov

