### PR TITLE
wrap moderation plugins in feature flag

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/moderation/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/index.js
@@ -1,4 +1,6 @@
 import { PLUGIN_MODERATION } from "metabase/plugins";
+import { hasPremiumFeature } from "metabase-enterprise/settings";
+
 import QuestionModerationSection from "./components/QuestionModerationSection/QuestionModerationSection";
 import ModerationStatusIcon from "./components/ModerationStatusIcon/ModerationStatusIcon";
 
@@ -8,10 +10,12 @@ import {
   getModerationTimelineEvents,
 } from "./service";
 
-Object.assign(PLUGIN_MODERATION, {
-  QuestionModerationSection,
-  ModerationStatusIcon,
-  getStatusIconForQuestion,
-  getStatusIcon,
-  getModerationTimelineEvents,
-});
+if (hasPremiumFeature("content_management")) {
+  Object.assign(PLUGIN_MODERATION, {
+    QuestionModerationSection,
+    ModerationStatusIcon,
+    getStatusIconForQuestion,
+    getStatusIcon,
+    getModerationTimelineEvents,
+  });
+}


### PR DESCRIPTION
Fixes #18740 

**Testing**
1. Run enterprise version of Metabase without a token -- you shouldn't be able to see the "Verify this question" button
2. Run enterprise Metabase with a token that enables `content_management` -- you should see the "Verify this question" button