### PR TITLE
Don't qualify breakout field name for BigQuery when source is not from a table

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
@@ -836,3 +836,19 @@
                                                   [:percentile $orders.quantity 0.5]
                                                   {:name "CE", :display-name "CE"}]]
                                    :limit       10}))))))))
+
+
+(deftest no-qualify-breakout-field-name-with-subquery-test
+  (mt/test-driver :bigquery-cloud-sdk
+    (testing "Breakout field name is not qualified if the source query is not a table (#18742)"
+      (is (= {:query      (str "SELECT `source`.`source` AS `source`, count(*) AS `count` FROM"
+                               " (select 1 as `val`, '2' as `source`) `source`"
+                               " GROUP BY `source` ORDER BY `source` ASC")
+              :params     nil
+              :table-name "source"
+              :mbql?      true}
+            (qp/query->native
+              (mt/mbql-query checkins
+                {:aggregation  [[:count]],
+                 :breakout     [[:field "source" {:base-type :type/Text}]],
+                 :source-query {:native "select 1 as `val`, '2' as `source`"}})))))))

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -287,6 +287,11 @@
   schema + Table name. Used to implement things like joined `:field`s."
   nil)
 
+(def ^:dynamic *source-query*
+  "The source-query in effect.  Used when the query processor might need to distinguish between the type of the source
+  query (ex: to provide different behavior depending on whether the source query is from a table versus a subquery)."
+  nil)
+
 (defmethod ->honeysql [:sql nil]    [_ _]    nil)
 (defmethod ->honeysql [:sql Object] [_ this] this)
 
@@ -1003,7 +1008,8 @@
   "Bind `*table-alias*` which will cause `field` and the like to be compiled to SQL that is qualified by that alias
   rather than their normal table."
   [driver honeysql-form {:keys [source-query], :as inner-query}]
-  (binding [*table-alias* source-query-alias]
+  (binding [*table-alias*  source-query-alias
+            *source-query* source-query]
     (apply-top-level-clauses driver honeysql-form (dissoc inner-query :source-query))))
 
 


### PR DESCRIPTION
Add a new dynamic var - *source-query* - to sqp.qp to bind the current source-query, and bind that in the same place that *table-alias* is currently bound

Update bigquery-cloud-sqp qp implementation to check the sqp.qp/*source-query*, and only qualify the source query alias if the type of source query is a table (which is apparently required; see #15074)

Add test for #18742
