### PR TITLE
Custom expression editor: decouple suggestions and diagnostics

### DIFF
--- a/frontend/src/metabase/lib/expressions/diagnostics.js
+++ b/frontend/src/metabase/lib/expressions/diagnostics.js
@@ -1,0 +1,65 @@
+import { t } from "ttag";
+
+import { tokenize, TOKEN, OPERATOR } from "metabase/lib/expressions/tokenizer";
+import { getMBQLName } from "metabase/lib/expressions";
+import { processSource } from "metabase/lib/expressions/process";
+
+// e.g. "COUNTIF(([Total]-[Tax] <5" returns 2 (missing parentheses)
+export function countMatchingParentheses(tokens) {
+  const isOpen = t => t.op === OPERATOR.OpenParenthesis;
+  const isClose = t => t.op === OPERATOR.CloseParenthesis;
+  const count = (c, token) =>
+    isOpen(token) ? c + 1 : isClose(token) ? c - 1 : c;
+  return tokens.reduce(count, 0);
+}
+
+export function diagnose(source, startRule, query) {
+  if (!source || source.length === 0) {
+    return null;
+  }
+
+  const { tokens, errors } = tokenize(source);
+  if (errors && errors.length > 0) {
+    return errors[0];
+  }
+
+  for (let i = 0; i < tokens.length - 1; ++i) {
+    const token = tokens[i];
+    if (token.type === TOKEN.Identifier && source[token.start] !== "[") {
+      const functionName = source.slice(token.start, token.end);
+      if (getMBQLName(functionName)) {
+        const next = tokens[i + 1];
+        if (next.op !== OPERATOR.OpenParenthesis) {
+          return {
+            message: t`Expecting an opening parenthesis after function ${functionName}`,
+          };
+        }
+      }
+    }
+  }
+
+  const mismatchedParentheses = countMatchingParentheses(tokens);
+  const message =
+    mismatchedParentheses === 1
+      ? t`Expecting a closing parenthesis`
+      : mismatchedParentheses > 1
+      ? t`Expecting ${mismatchedParentheses} closing parentheses`
+      : mismatchedParentheses === -1
+      ? t`Expecting an opening parenthesis`
+      : mismatchedParentheses < -1
+      ? t`Expecting ${-mismatchedParentheses} opening parentheses`
+      : null;
+  if (message) {
+    return { message };
+  }
+
+  const { compileError } = processSource({ source, query, startRule });
+
+  if (compileError) {
+    return Array.isArray(compileError) && compileError.length > 0
+      ? compileError[0]
+      : compileError;
+  }
+
+  return null;
+}

--- a/frontend/src/metabase/lib/expressions/process.js
+++ b/frontend/src/metabase/lib/expressions/process.js
@@ -4,13 +4,10 @@ export function processSource(options) {
   // https://github.com/metabase/metabase/issues/13472
   const parse = require("./parser").parse;
   const compile = require("./compile").compile;
-  const suggest = require("./suggest").suggest;
 
-  const { source, targetOffset } = options;
+  const { source } = options;
 
   let expression;
-  let suggestions = [];
-  let helpText;
   let compileError;
 
   // PARSE
@@ -31,24 +28,9 @@ export function processSource(options) {
     }
   }
 
-  // SUGGEST
-  if (targetOffset != null) {
-    try {
-      ({ suggestions = [], helpText } = suggest({
-        cst,
-        tokenVector,
-        ...options,
-      }));
-    } catch (e) {
-      console.warn("suggest error", e);
-    }
-  }
-
   return {
     source,
     expression,
-    helpText,
-    suggestions,
     compileError,
   };
 }

--- a/frontend/src/metabase/lib/expressions/suggest.js
+++ b/frontend/src/metabase/lib/expressions/suggest.js
@@ -36,7 +36,7 @@ export function suggest({
     if (functionDisplayName) {
       const helpText = getHelpText(getMBQLName(functionDisplayName));
       if (helpText) {
-        return { helpText };
+        return { suggestions, helpText };
       }
     }
     return { suggestions };

--- a/frontend/src/metabase/lib/expressions/tokenizer.js
+++ b/frontend/src/metabase/lib/expressions/tokenizer.js
@@ -341,12 +341,3 @@ export function tokenize(expression) {
 
   return main();
 }
-
-// e.g. "COUNTIF(([Total]-[Tax] <5" returns 2 (missing parentheses)
-export function countMatchingParentheses(tokens) {
-  const isOpen = t => t.op === OPERATOR.OpenParenthesis;
-  const isClose = t => t.op === OPERATOR.CloseParenthesis;
-  const count = (c, token) =>
-    isOpen(token) ? c + 1 : isClose(token) ? c - 1 : c;
-  return tokens.reduce(count, 0);
-}

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -7,17 +7,13 @@ import _ from "underscore";
 import cx from "classnames";
 
 import { format } from "metabase/lib/expressions/format";
+import { suggest } from "metabase/lib/expressions/suggest";
 import { processSource } from "metabase/lib/expressions/process";
-import {
-  tokenize,
-  countMatchingParentheses,
-  TOKEN,
-  OPERATOR as OP,
-} from "metabase/lib/expressions/tokenizer";
+import { diagnose } from "metabase/lib/expressions/diagnostics";
+import { tokenize } from "metabase/lib/expressions/tokenizer";
+
 import MetabaseSettings from "metabase/lib/settings";
 import colors from "metabase/lib/colors";
-
-import memoize from "lodash.memoize";
 
 import { setCaretPosition, getSelectionPosition } from "metabase/lib/dom";
 
@@ -37,7 +33,7 @@ import ExplicitSize from "metabase/components/ExplicitSize";
 
 import TokenizedInput from "./TokenizedInput";
 
-import { getMBQLName, isExpression } from "metabase/lib/expressions";
+import { isExpression } from "metabase/lib/expressions";
 
 import ExpressionEditorSuggestions from "./ExpressionEditorSuggestions";
 
@@ -99,12 +95,6 @@ const ErrorMessage = ({ error }) => {
 export default class ExpressionEditorTextfield extends React.Component {
   constructor() {
     super();
-    // memoize processSource for performance when editing previously seen source/targetOffset
-    this._processSource = memoize(processSource, ({ source, targetOffset }) =>
-      // resovle should include anything that affect the results of processSource
-      // except currently we exclude `startRule` and `query` since they shouldn't change
-      [source, targetOffset].join(","),
-    );
     this.input = React.createRef();
   }
 
@@ -122,42 +112,17 @@ export default class ExpressionEditorTextfield extends React.Component {
     placeholder: "write some math!",
   };
 
-  _getParserOptions(props = this.props) {
-    return {
-      query: props.query,
-      startRule: props.startRule,
-    };
-  }
-
   UNSAFE_componentWillMount() {
     this.UNSAFE_componentWillReceiveProps(this.props);
   }
 
   UNSAFE_componentWillReceiveProps(newProps) {
     // we only refresh our state if we had no previous state OR if our expression changed
-    if (!this.state || !_.isEqual(this.props.expression, newProps.expression)) {
-      const parserOptions = this._getParserOptions(newProps);
-      const source = format(newProps.expression, parserOptions);
-
-      const { expression, compileError } =
-        source && source.length
-          ? this._processSource({
-              source,
-              ...this._getParserOptions(newProps),
-            })
-          : {
-              expression: null,
-              tokenizerError: [],
-              compileError: null,
-            };
-      this.setState({
-        source,
-        expression,
-        tokenizeError: [],
-        compileError,
-        suggestions: [],
-        highlightedSuggestionIndex: 0,
-      });
+    const { expression, query, startRule } = newProps;
+    if (!this.state || !_.isEqual(this.props.expression, expression)) {
+      const source = format(expression, { query, startRule });
+      this.setState({ source, expression });
+      this.clearSuggestions();
     }
   }
 
@@ -218,15 +183,15 @@ export default class ExpressionEditorTextfield extends React.Component {
     }
 
     if (!suggestions.length) {
-      if (
-        e.keyCode === KEYCODE_ENTER &&
-        this.props.onCommit &&
-        this.state.expression != null
-      ) {
-        this.props.onCommit(this.state.expression);
+      if (e.keyCode === KEYCODE_ENTER && this.props.onCommit) {
+        const expression = this._compileExpression();
+        if (isExpression(expression)) {
+          this.props.onCommit(expression);
+        }
       }
       return;
     }
+
     if (e.keyCode === KEYCODE_ENTER) {
       this.onSuggestionSelected(highlightedSuggestionIndex);
       e.preventDefault();
@@ -255,6 +220,17 @@ export default class ExpressionEditorTextfield extends React.Component {
     });
   }
 
+  _compileExpression() {
+    const { source } = this.state;
+    if (!source || source.length === 0) {
+      return null;
+    }
+    const { query, startRule } = this.props;
+    const { expression } = processSource({ source, query, startRule });
+
+    return expression;
+  }
+
   onInputBlur = e => {
     // Switching to another window also triggers the blur event.
     // When our window gets focus again, the input will automatically
@@ -266,25 +242,21 @@ export default class ExpressionEditorTextfield extends React.Component {
 
     this.clearSuggestions();
 
-    const { tokenizerError, compileError } = this.state;
-    let displayError = [...tokenizerError];
-    if (compileError) {
-      if (Array.isArray(compileError)) {
-        displayError = [...displayError, ...compileError];
-      } else {
-        displayError.push(compileError);
-      }
-    }
-    this.setState({ displayError });
+    const { query, startRule } = this.props;
+    const { source } = this.state;
+
+    const errorMessage = diagnose(source, startRule, query);
+    this.setState({ errorMessage });
 
     // whenever our input blurs we push the updated expression to our parent if valid
-    if (this.state.expression) {
-      if (!isExpression(this.state.expression)) {
-        console.warn("isExpression=false", this.state.expression);
+    const expression = this._compileExpression();
+    if (expression) {
+      if (!isExpression(expression)) {
+        console.warn("isExpression=false", expression);
       }
-      this.props.onChange(this.state.expression);
-    } else if (displayError && displayError.length > 0) {
-      this.props.onError(displayError);
+      this.props.onChange(expression);
+    } else if (errorMessage) {
+      this.props.onError(errorMessage);
     } else {
       this.props.onError({ message: t`Invalid expression` });
     }
@@ -311,99 +283,38 @@ export default class ExpressionEditorTextfield extends React.Component {
       return;
     }
 
+    this.setState({ source });
+    this.clearSuggestions();
+
     const [selectionStart, selectionEnd] = getSelectionPosition(inputElement);
     const hasSelection = selectionStart !== selectionEnd;
-    const isAtEnd = selectionEnd === source.length;
-    const endsWithWhitespace = /\s$/.test(source);
     const targetOffset = !hasSelection ? selectionEnd : null;
 
-    const { expression, compileError, suggestions, helpText } = source
-      ? this._processSource({
-          source,
-          targetOffset,
-          ...this._getParserOptions(),
-        })
-      : {
-          expression: null,
-          compileError: null,
-          suggestions: [],
-          helpText: null,
-        };
+    const { query, startRule } = this.props;
+    const { suggestions, helpText } = suggest({
+      query,
+      startRule,
+      source,
+      targetOffset,
+    });
+    this.setState({ suggestions, helpText });
 
-    const isValid = expression !== undefined;
     if (this.props.onBlankChange) {
       this.props.onBlankChange(source.length === 0);
     }
-    // don't show suggestions if
-    // * there's a selection
-    // * we're at the end of a valid expression, unless the user has typed another space
-    const showSuggestions =
-      !hasSelection && !(isValid && isAtEnd && !endsWithWhitespace);
 
-    const { tokens, errors: tokenizerError } = tokenize(source);
-    const mismatchedParentheses = countMatchingParentheses(tokens);
-    const mismatchedError =
-      mismatchedParentheses === 1
-        ? t`Expecting a closing parenthesis`
-        : mismatchedParentheses > 1
-        ? t`Expecting ${mismatchedParentheses} closing parentheses`
-        : mismatchedParentheses === -1
-        ? t`Expecting an opening parenthesis`
-        : mismatchedParentheses < -1
-        ? t`Expecting ${-mismatchedParentheses} opening parentheses`
-        : null;
-    if (mismatchedError) {
-      tokenizerError.push({
-        message: mismatchedError,
-      });
-    }
-
-    for (let i = 0; i < tokens.length - 1; ++i) {
-      const token = tokens[i];
-      if (token.type === TOKEN.Identifier && source[token.start] !== "[") {
-        const functionName = source.slice(token.start, token.end);
-        if (getMBQLName(functionName)) {
-          const next = tokens[i + 1];
-          if (next.op !== OP.OpenParenthesis) {
-            tokenizerError.unshift({
-              message: t`Expecting an opening parenthesis after function ${functionName}`,
-            });
-          }
-        }
-      }
-    }
-
-    this.setState({
-      source,
-      expression,
-      tokenizerError,
-      compileError,
-      displayError: null,
-      suggestions: showSuggestions ? suggestions : [],
-      helpText,
-      highlightedSuggestionIndex: 0,
-    });
-
-    if (!source || source.length <= 0) {
-      const { suggestions } = this._processSource({
-        source,
-        targetOffset,
-        ...this._getParserOptions(),
-      });
-      this.setState({ suggestions });
-    }
+    this.setState({ suggestions: hasSelection ? [] : suggestions });
   }
 
   render() {
     const { placeholder } = this.props;
-    const { displayError, source, suggestions } = this.state;
+    const { source, suggestions, errorMessage } = this.state;
 
     const inputClassName = cx("input text-bold text-monospace", {
       "text-dark": source,
       "text-light": !source,
     });
     const inputStyle = { fontSize: 12 };
-    const priorityError = _.first(displayError);
 
     return (
       <div className={cx("relative my1")}>
@@ -421,13 +332,12 @@ export default class ExpressionEditorTextfield extends React.Component {
           ref={this.input}
           type="text"
           className={cx(inputClassName, {
-            "border-error": priorityError,
+            "border-error": errorMessage,
           })}
           style={{ ...inputStyle, paddingLeft: 26, whiteSpace: "pre-wrap" }}
           placeholder={placeholder}
           value={source}
           startRule={this.props.startRule}
-          parserOptions={this._getParserOptions()}
           onChange={e => this.onExpressionChange(e.target.value)}
           onKeyDown={this.onInputKeyDown}
           onBlur={this.onInputBlur}
@@ -435,7 +345,7 @@ export default class ExpressionEditorTextfield extends React.Component {
           onClick={this.onInputClick}
           autoFocus
         />
-        <ErrorMessage error={priorityError} />
+        <ErrorMessage error={errorMessage} />
         <HelpText helpText={this.state.helpText} width={this.props.width} />
         <ExpressionEditorSuggestions
           suggestions={suggestions}

--- a/frontend/src/metabase/query_builder/components/expressions/TokenizedInput.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/TokenizedInput.jsx
@@ -192,7 +192,6 @@ TokenizedInput.propTypes = {
   onClick: PropTypes.func,
   onFocus: PropTypes.func,
   onKeyDown: PropTypes.func,
-  parserOptions: PropTypes.object,
   style: PropTypes.object,
   tokenizedEditing: PropTypes.bool,
   value: PropTypes.string,

--- a/frontend/test/metabase/lib/expressions/diagnostics.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/diagnostics.unit.spec.js
@@ -1,0 +1,55 @@
+import { tokenize } from "metabase/lib/expressions/tokenizer";
+import {
+  countMatchingParentheses,
+  diagnose,
+} from "metabase/lib/expressions/diagnostics";
+
+describe("metabase/lib/expressions/diagnostics", () => {
+  it("should count matching parentheses", () => {
+    const count = expr => countMatchingParentheses(tokenize(expr).tokens);
+    expect(count("()")).toEqual(0);
+    expect(count("(")).toEqual(1);
+    expect(count(")")).toEqual(-1);
+    expect(count("(A+(")).toEqual(2);
+    expect(count("SUMIF(")).toEqual(1);
+    expect(count("COUNTIF(Deal))")).toEqual(-1);
+  });
+
+  it("should catch mismatched parentheses", () => {
+    expect(diagnose("FLOOR [Price]/2)").message).toEqual(
+      "Expecting an opening parenthesis after function FLOOR",
+    );
+  });
+
+  it("should catch missing parentheses", () => {
+    expect(diagnose("LOWER [Vendor]").message).toEqual(
+      "Expecting an opening parenthesis after function LOWER",
+    );
+  });
+
+  it("should catch invalid characters", () => {
+    expect(diagnose("[Price] / #").message).toEqual("Invalid character: #");
+  });
+
+  it("should catch unterminated string literals", () => {
+    expect(diagnose('[Category] = "widget').message).toEqual(
+      "Missing closing quotes",
+    );
+  });
+
+  it("should catch unterminated field reference", () => {
+    expect(diagnose("[Price / 2").message).toEqual("Missing a closing bracket");
+  });
+
+  it("should show the correct number of CASE arguments in a custom expression", () => {
+    expect(diagnose("CASE([Price]>0)").message).toEqual(
+      "CASE expects 2 arguments or more",
+    );
+  });
+
+  it("should show the correct number of function arguments in a custom expression", () => {
+    expect(diagnose("contains([Category])").message).toEqual(
+      "Function contains expects 2 arguments",
+    );
+  });
+});

--- a/frontend/test/metabase/lib/expressions/tokenizer.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/tokenizer.unit.spec.js
@@ -2,7 +2,6 @@ import {
   tokenize,
   TOKEN as T,
   OPERATOR as OP,
-  countMatchingParentheses,
 } from "metabase/lib/expressions/tokenizer";
 
 import { generateExpression } from "./generator";
@@ -141,16 +140,6 @@ describe("metabase/lib/expressions/tokenizer", () => {
     expect(errors("!")[0].message).toEqual("Invalid character: !");
     expect(errors(" % @")[1].message).toEqual("Invalid character: @");
     expect(errors("    #")[0].pos).toEqual(4);
-  });
-
-  it("should count matching parentheses", () => {
-    const count = expr => countMatchingParentheses(tokenize(expr).tokens);
-    expect(count("()")).toEqual(0);
-    expect(count("(")).toEqual(1);
-    expect(count(")")).toEqual(-1);
-    expect(count("(A+(")).toEqual(2);
-    expect(count("SUMIF(")).toEqual(1);
-    expect(count("COUNTIF(Deal))")).toEqual(-1);
   });
 });
 

--- a/frontend/test/metabase/scenarios/custom-column/cc-error-feedback.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/cc-error-feedback.cy.spec.js
@@ -13,50 +13,6 @@ describe("scenarios > question > custom column > error feedback", () => {
     cy.findByText("Custom column").click();
   });
 
-  it("should catch mismatched parentheses", () => {
-    enterCustomColumnDetails({
-      formula: "FLOOR [Price]/2)",
-      name: "Massive Discount",
-    });
-
-    cy.contains(/^Expecting an opening parenthesis after function FLOOR/i);
-  });
-
-  it("should catch missing parentheses", () => {
-    enterCustomColumnDetails({
-      formula: "LOWER [Vendor]",
-      name: "Massive Discount",
-    });
-
-    cy.contains(/^Expecting an opening parenthesis after function LOWER/i);
-  });
-
-  it("should catch invalid characters", () => {
-    enterCustomColumnDetails({
-      formula: "[Price] / #",
-      name: "Massive Discount",
-    });
-
-    cy.contains(/^Invalid character: #/i);
-  });
-
-  it("should catch unterminated string literals", () => {
-    cy.get("[contenteditable='true']")
-      .type('[Category] = "widget')
-      .blur();
-
-    cy.findByText("Missing closing quotes");
-  });
-
-  it("should catch unterminated field reference", () => {
-    enterCustomColumnDetails({
-      formula: "[Price / 2",
-      name: "Massive Discount",
-    });
-
-    cy.contains(/^Missing a closing bracket/i);
-  });
-
   it("should catch non-existent field reference", () => {
     enterCustomColumnDetails({
       formula: "abcdef",
@@ -64,22 +20,5 @@ describe("scenarios > question > custom column > error feedback", () => {
     });
 
     cy.contains(/^Unknown Field: abcdef/i);
-  });
-
-  it("should show the correct number of CASE arguments in a custom expression", () => {
-    enterCustomColumnDetails({
-      formula: "CASE([Price]>0)",
-      name: "Sum Divide",
-    });
-
-    cy.contains(/^CASE expects 2 arguments or more/i);
-  });
-
-  it("should show the correct number of function arguments in a custom expression", () => {
-    cy.get("[contenteditable='true']")
-      .type("contains([Category])")
-      .blur();
-
-    cy.contains(/^Function contains expects 2 arguments/i);
   });
 });


### PR DESCRIPTION
With the suggestions and highlighting being done through via lexical analysis
only, there is no need to run the computationally-expensive syntactical
analysis on every keystroke anymore. We only need to do that when the
user finishes the editing and wants to use the expression.

This should lead to a noticeable speed-up when dealing with a very long custom expression.

To experiment with it, follow the steps in #16094:

**To Reproduce**
1. Ask a question, Custom question
2. Sample Dataset, Reviews table
3. Filter, Custom Expression
4. Type (or better: copy + paste) `contains([Product → Vendor], "Lorem ipsum dolor sit amet") OR` repeatedly

**Before this PR**

Things get slower and slower as the expression becomes longer and longer.

If a breakpoint is placed in `processSource()`, it's evident that this function is being called for every single keystroke. 

**After this PR**

A breakpoint in `processSource()` will never be hit as long as the focus is in the editor, even as the user keeps typing more characters. 
