### PR TITLE
Add entity polling to EntityListLoader

### DIFF
--- a/frontend/src/metabase/entities/containers/EntityListLoader.jsx
+++ b/frontend/src/metabase/entities/containers/EntityListLoader.jsx
@@ -197,9 +197,12 @@ class EntityListLoader extends React.Component {
       this.setState({ previousList: prevProps.list });
     }
 
-    if (loaded && !prevProps.loaded && reloadInterval) {
+    if (loaded && !prevProps.loaded) {
       clearTimeout(this.reloadTimeout);
-      this.reloadTimeout = setTimeout(this.reload, reloadInterval);
+
+      if (reloadInterval) {
+        this.reloadTimeout = setTimeout(this.reload, reloadInterval);
+      }
     }
   }
 

--- a/frontend/src/metabase/entities/containers/EntityListLoader.jsx
+++ b/frontend/src/metabase/entities/containers/EntityListLoader.jsx
@@ -51,6 +51,7 @@ const CONSUMED_PROPS = [
   "entityType",
   "entityQuery",
   // "reload", // Masked by `reload` function. Should we rename that?
+  "reloadInterval",
   "wrapped",
   "debounced",
   "loadingAndErrorWrapper",
@@ -200,6 +201,10 @@ class EntityListLoader extends React.Component {
       clearTimeout(this.reloadTimeout);
       this.reloadTimeout = setTimeout(this.reload, reloadInterval);
     }
+  }
+
+  componentWillUnmount() {
+    clearTimeout(this.reloadTimeout);
   }
 
   renderChildren = () => {

--- a/frontend/src/metabase/entities/containers/EntityListLoader.jsx
+++ b/frontend/src/metabase/entities/containers/EntityListLoader.jsx
@@ -13,6 +13,7 @@ const propTypes = {
   entityType: PropTypes.string,
   entityQuery: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
   reload: PropTypes.bool,
+  reloadInterval: PropTypes.oneOfType([PropTypes.number, PropTypes.func]),
   wrapped: PropTypes.bool,
   debounced: PropTypes.bool,
   loadingAndErrorWrapper: PropTypes.bool,
@@ -76,6 +77,7 @@ const getMemoizedEntityQuery = createMemoizedSelector(
   let {
     entityDef,
     entityQuery,
+    reloadInterval,
     page,
     pageSize,
     allLoading,
@@ -86,6 +88,9 @@ const getMemoizedEntityQuery = createMemoizedSelector(
   } = props;
   if (typeof entityQuery === "function") {
     entityQuery = entityQuery(state, props);
+  }
+  if (typeof reloadInterval === "function") {
+    reloadInterval = reloadInterval(state, props);
   }
   if (typeof pageSize === "number" && typeof page === "number") {
     entityQuery = { limit: pageSize, offset: pageSize * page, ...entityQuery };
@@ -100,6 +105,7 @@ const getMemoizedEntityQuery = createMemoizedSelector(
 
   return {
     entityQuery,
+    reloadInterval,
     list: entityDef.selectors[selectorName](state, { entityQuery }),
     metadata,
     loading,
@@ -156,8 +162,13 @@ class EntityListLoader extends React.Component {
     250,
   );
 
-  UNSAFE_componentWillMount() {
-    this.fetchList(this.props, { reload: this.props.reload });
+  componentDidMount() {
+    const { loaded, reload, reloadInterval } = this.props;
+    this.fetchList(this.props, { reload });
+
+    if (loaded && reloadInterval) {
+      this.reloadTimeout = setTimeout(this.reload, reloadInterval);
+    }
   }
 
   UNSAFE_componentWillReceiveProps(nextProps) {
@@ -173,7 +184,7 @@ class EntityListLoader extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { keepListWhileLoading } = this.props;
+    const { loaded, reloadInterval, keepListWhileLoading } = this.props;
     const { previousList } = this.state;
 
     const shouldUpdatePrevList =
@@ -183,6 +194,11 @@ class EntityListLoader extends React.Component {
 
     if (shouldUpdatePrevList) {
       this.setState({ previousList: prevProps.list });
+    }
+
+    if (loaded && !prevProps.loaded && reloadInterval) {
+      clearTimeout(this.reloadTimeout);
+      this.reloadTimeout = setTimeout(this.reload, reloadInterval);
     }
   }
 


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/18675

For the DB sync project I need an ability to conditionally poll for data in various places. This PR adds it to `Entity`.

Example usage:
```
Tables.loadList({
  reloadInterval: (state, { list = [] }) => list.some(t => !t.active) ? 5000 : 0
})
```

This will send a request each 5 seconds until all tables become `active`. It is expected that polling will be used sparingly and only for short periods of time, e.g. poll the BE until a table has been synced. 