### PR TITLE
#18729 Repro: XLSX export of "X of Y" (eg. Month of Year) is formatted as date column

### DIFF
--- a/frontend/test/metabase/scenarios/downloads/reproductions/18729-date-formatting-x-of-y.cy.spec.js
+++ b/frontend/test/metabase/scenarios/downloads/reproductions/18729-date-formatting-x-of-y.cy.spec.js
@@ -40,7 +40,7 @@ describe("issue 18729", () => {
       visitQuestionAdhoc(questionDetails);
       cy.wait("@dataset");
 
-      downloadAndAssert({ fileType, logResults: true }, assertion);
+      downloadAndAssert({ fileType }, assertion);
     });
   });
 });

--- a/frontend/test/metabase/scenarios/downloads/reproductions/18729-date-formatting-x-of-y.cy.spec.js
+++ b/frontend/test/metabase/scenarios/downloads/reproductions/18729-date-formatting-x-of-y.cy.spec.js
@@ -1,0 +1,61 @@
+import {
+  restore,
+  downloadAndAssert,
+  visitQuestionAdhoc,
+} from "__support__/e2e/cypress";
+import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
+
+const { ORDERS, ORDERS_ID, PRODUCTS } = SAMPLE_DATASET;
+
+const questionDetails = {
+  dataset_query: {
+    database: 1,
+    query: {
+      "source-table": ORDERS_ID,
+      aggregation: [["count"]],
+      breakout: [
+        ["field", ORDERS.CREATED_AT, { "temporal-unit": "month-of-year" }],
+        ["field", PRODUCTS.CATEGORY, { "source-field": ORDERS.PRODUCT_ID }],
+      ],
+      limit: 2,
+    },
+    type: "query",
+  },
+  display: "line",
+};
+
+describe("issue 18729", () => {
+  beforeEach(() => {
+    cy.intercept("POST", "/api/dataset").as("dataset");
+
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  ["csv", "xlsx"].forEach(fileType => {
+    it(`should properly format the 'X of Y'dates in ${fileType} exports (metabase#18729)`, () => {
+      // TODO: Remove this line once the issue gets resolved
+      cy.skipOn(fileType === "xlsx");
+
+      visitQuestionAdhoc(questionDetails);
+      cy.wait("@dataset");
+
+      downloadAndAssert({ fileType, logResults: true }, assertion);
+    });
+  });
+});
+
+function assertion(sheet) {
+  // It currently says only "Created At", but that is already covered in an issue #18219.
+
+  // TODO: When 18219 gets fixed, uncomment the following assertion and delete the `contain` one.
+  // expect(sheet["A1"].v).to.eq("Created At: Month of year");
+  expect(sheet["A1"].v).to.contain("Created At");
+
+  // Based on how this issue gets resolved, the following assertions might need to change!
+
+  expect(sheet["A2"].v).to.eq(1);
+  expect(sheet["A2"].t).to.eq("n");
+  // Parsed values are always in the form of a string
+  expect(sheet["A2"].w).to.eq("1");
+}


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #18729

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/downloads/reproductions/18729-date-formatting-x-of-y.cy.spec.js`
- Remove `cy.skipOn()` line
- The "xlsx" test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `cy.skipOn()` part (unskip the test completely)
- Make sure both tests are passing and
- Merge the spec together with the fix

### Screenshots:
CSV
![image](https://user-images.githubusercontent.com/31325167/139729654-be0a5f69-184d-4637-9eba-1b2b833a0e51.png)

XLSX
![image](https://user-images.githubusercontent.com/31325167/139729740-f781f908-e25e-45f6-9f59-0fccf3f92040.png)

