### PR TITLE
#18573 Repro: Remapped columns do not use renamed titles in exports

### DIFF
--- a/frontend/test/metabase/scenarios/downloads/reproductions/18573-remapped-fields-not-renamed.cy.spec.js
+++ b/frontend/test/metabase/scenarios/downloads/reproductions/18573-remapped-fields-not-renamed.cy.spec.js
@@ -1,0 +1,56 @@
+import {
+  restore,
+  visitQuestionAdhoc,
+  downloadAndAssert,
+} from "__support__/e2e/cypress";
+import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
+
+const { ORDERS, ORDERS_ID, PRODUCTS } = SAMPLE_DATASET;
+
+const questionDetails = {
+  dataset_query: {
+    type: "query",
+    query: { "source-table": ORDERS_ID, limit: 2 },
+    database: 1,
+  },
+  visualization_settings: {
+    column_settings: {
+      [`["ref",["field",${ORDERS.PRODUCT_ID},null]]`]: {
+        column_title: "Foo",
+      },
+    },
+  },
+};
+
+describe.skip("issue 18573", () => {
+  beforeEach(() => {
+    cy.intercept("POST", "/api/dataset").as("dataset");
+
+    restore();
+    cy.signInAsAdmin();
+
+    // Remap Product ID -> Product Title
+    cy.request("POST", `/api/field/${ORDERS.PRODUCT_ID}/dimension`, {
+      name: "Product ID",
+      type: "external",
+      human_readable_field_id: PRODUCTS.TITLE,
+    });
+  });
+
+  ["csv", "xlsx"].forEach(fileType => {
+    it(`for the remapped columns, it should preserve renamed column name in exports for ${fileType} (metabase#18573)`, () => {
+      visitQuestionAdhoc(questionDetails);
+      cy.wait("@dataset");
+
+      cy.findByText("Foo");
+      cy.findByText("Awesome Concrete Shoes");
+
+      downloadAndAssert({ fileType }, assertion);
+    });
+  });
+});
+
+function assertion(sheet) {
+  expect(sheet["C1"].v).to.eq("Foo");
+  expect(sheet["C2"].v).to.eq("Awesome Concrete Shoes");
+}


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #18573 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/downloads/reproductions/18573-remapped-fields-not-renamed.cy.spec.js`
- Unskip repro
- All tests should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
Fails for both CSV and XLSX with
![image](https://user-images.githubusercontent.com/31325167/139733912-16339f97-941c-4606-a107-ed453101cb79.png)

