### PR TITLE
add DimensionLabel ui component

### DIFF
--- a/frontend/src/metabase/components/DimensionLabel/DimensionLabel.info.js
+++ b/frontend/src/metabase/components/DimensionLabel/DimensionLabel.info.js
@@ -1,0 +1,17 @@
+import React from "react";
+
+import { PRODUCTS, metadata } from "__support__/sample_dataset_fixture";
+import Dimension from "metabase-lib/lib/Dimension";
+
+import DimensionLabel from "./DimensionLabel";
+
+const fieldDimension = Dimension.parseMBQL(
+  ["field", PRODUCTS.CATEGORY.id, null],
+  metadata,
+);
+
+export const component = DimensionLabel;
+export const description = "A label for instances of Dimension";
+export const examples = {
+  "field dimension": <DimensionLabel dimension={fieldDimension} />,
+};

--- a/frontend/src/metabase/components/DimensionLabel/DimensionLabel.info.js
+++ b/frontend/src/metabase/components/DimensionLabel/DimensionLabel.info.js
@@ -1,4 +1,5 @@
 import React from "react";
+import styled from "styled-components";
 
 import { PRODUCTS, metadata } from "__support__/sample_dataset_fixture";
 import Dimension from "metabase-lib/lib/Dimension";
@@ -10,8 +11,13 @@ const fieldDimension = Dimension.parseMBQL(
   metadata,
 );
 
+const BiggerDimensionLabel = styled(DimensionLabel)`
+  font-size: 32px;
+`;
+
 export const component = DimensionLabel;
 export const description = "A label for instances of Dimension";
 export const examples = {
-  "field dimension": <DimensionLabel dimension={fieldDimension} />,
+  DimensionLabel: <DimensionLabel dimension={fieldDimension} />,
+  "Bigger DimensionLabel": <BiggerDimensionLabel dimension={fieldDimension} />,
 };

--- a/frontend/src/metabase/components/DimensionLabel/DimensionLabel.jsx
+++ b/frontend/src/metabase/components/DimensionLabel/DimensionLabel.jsx
@@ -1,0 +1,24 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+import Dimension from "metabase-lib/lib/Dimension";
+import Icon from "metabase/components/Icon";
+import IconWrapper from "metabase/components/IconWrapper";
+import { color } from "metabase/lib/colors";
+
+import { Container, Label } from "./DimensionLabel.styled";
+
+DimensionLabel.propTypes = {
+  dimension: PropTypes.instanceOf(Dimension).isRequired,
+};
+
+export default function DimensionLabel({ dimension }) {
+  return (
+    <Container>
+      <IconWrapper borderRadius="4px" bg={color("brand")} p={0}>
+        <Icon name={dimension.icon()} size={12} color={color("white")} />
+      </IconWrapper>
+      <Label>{dimension.displayName()}</Label>
+    </Container>
+  );
+}

--- a/frontend/src/metabase/components/DimensionLabel/DimensionLabel.jsx
+++ b/frontend/src/metabase/components/DimensionLabel/DimensionLabel.jsx
@@ -2,22 +2,22 @@ import React from "react";
 import PropTypes from "prop-types";
 
 import Dimension from "metabase-lib/lib/Dimension";
-import Icon from "metabase/components/Icon";
-import IconWrapper from "metabase/components/IconWrapper";
-import { color } from "metabase/lib/colors";
 
-import { Container, Label } from "./DimensionLabel.styled";
+import {
+  Container,
+  Label,
+  PaddedInvertedColorIcon,
+} from "./DimensionLabel.styled";
 
 DimensionLabel.propTypes = {
+  className: PropTypes.string,
   dimension: PropTypes.instanceOf(Dimension).isRequired,
 };
 
-export default function DimensionLabel({ dimension }) {
+export default function DimensionLabel({ className, dimension }) {
   return (
-    <Container>
-      <IconWrapper borderRadius="4px" bg={color("brand")} p={0}>
-        <Icon name={dimension.icon()} size={12} color={color("white")} />
-      </IconWrapper>
+    <Container className={className}>
+      <PaddedInvertedColorIcon name={dimension.icon()} />
       <Label>{dimension.displayName()}</Label>
     </Container>
   );

--- a/frontend/src/metabase/components/DimensionLabel/DimensionLabel.styled.jsx
+++ b/frontend/src/metabase/components/DimensionLabel/DimensionLabel.styled.jsx
@@ -2,15 +2,26 @@ import styled from "styled-components";
 
 import { space } from "metabase/styled-components/theme";
 import { color } from "metabase/lib/colors";
+import Icon from "metabase/components/Icon";
 
 export const Container = styled.div`
   display: inline-flex;
   align-items: center;
   column-gap: ${space(0)};
+  font-size: 12px;
 `;
 
 export const Label = styled.span`
   font-weight: 900;
   color: ${color("brand")};
-  font-size: 12px;
+  font-size: 1em;
+`;
+
+export const PaddedInvertedColorIcon = styled(Icon)`
+  background-color: ${color("brand")};
+  color: ${color("white")};
+  border-radius: ${space(0)};
+  padding: ${space(0)};
+  height: 1em;
+  width: 1em;
 `;

--- a/frontend/src/metabase/components/DimensionLabel/DimensionLabel.styled.jsx
+++ b/frontend/src/metabase/components/DimensionLabel/DimensionLabel.styled.jsx
@@ -1,0 +1,16 @@
+import styled from "styled-components";
+
+import { space } from "metabase/styled-components/theme";
+import { color } from "metabase/lib/colors";
+
+export const Container = styled.div`
+  display: inline-flex;
+  align-items: center;
+  column-gap: ${space(0)};
+`;
+
+export const Label = styled.span`
+  font-weight: 900;
+  color: ${color("brand")};
+  font-size: 12px;
+`;

--- a/frontend/src/metabase/components/DimensionLabel/DimensionLabel.unit.spec.js
+++ b/frontend/src/metabase/components/DimensionLabel/DimensionLabel.unit.spec.js
@@ -1,0 +1,122 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import {
+  SAMPLE_DATASET,
+  PRODUCTS,
+  metadata,
+} from "__support__/sample_dataset_fixture";
+import DimensionLabel from "./DimensionLabel";
+import Dimension from "metabase-lib/lib/Dimension";
+import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
+import NativeQuery from "metabase-lib/lib/queries/NativeQuery";
+
+function setup(dimension) {
+  return render(<DimensionLabel dimension={dimension} />);
+}
+
+describe("DimensionLabel", () => {
+  describe("given a FieldDimension", () => {
+    beforeEach(() => {
+      const fieldDimension = Dimension.parseMBQL(
+        ["field", PRODUCTS.CREATED_AT.id, null],
+        metadata,
+      );
+
+      setup(fieldDimension);
+    });
+
+    it("should show an icon corresponding to the given dimension's underlying field type", () => {
+      expect(screen.queryByLabelText("calendar icon")).toBeInTheDocument();
+    });
+
+    it("it should display the given dimension's display name", () => {
+      expect(
+        screen.getByText(PRODUCTS.CREATED_AT.display_name),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("given a AggregationDimension", () => {
+    beforeEach(() => {
+      const aggQuery = new StructuredQuery(PRODUCTS.question(), {
+        type: "query",
+        database: SAMPLE_DATASET.id,
+        query: {
+          "source-table": PRODUCTS.id,
+          aggregation: ["sum", ["field", PRODUCTS.RATING.id, null]],
+        },
+      });
+      const aggregationDimension = Dimension.parseMBQL(
+        ["aggregation", 0],
+        metadata,
+        aggQuery,
+      );
+
+      setup(aggregationDimension);
+    });
+
+    it("should show an icon corresponding to the given dimension's underlying field type", () => {
+      expect(screen.queryByLabelText("int icon")).toBeInTheDocument();
+    });
+
+    it("it should display the given dimension's display name", () => {
+      expect(screen.getByText("Sum of Rating")).toBeInTheDocument();
+    });
+  });
+
+  describe("given a ExpressionDimension", () => {
+    beforeEach(() => {
+      const expressionDimension = Dimension.parseMBQL(
+        ["expression", "Hello World"],
+        metadata,
+      );
+
+      setup(expressionDimension);
+    });
+
+    it("should show an icon corresponding to the given dimension's underlying field type", () => {
+      expect(screen.queryByLabelText("string icon")).toBeInTheDocument();
+    });
+
+    it("it should display the given dimension's display name", () => {
+      expect(screen.getByText("Hello World")).toBeInTheDocument();
+    });
+  });
+
+  describe("given a TemplateTagDimension", () => {
+    beforeEach(() => {
+      const nativeQuery = new NativeQuery(PRODUCTS.question(), {
+        database: SAMPLE_DATASET.id,
+        type: "native",
+        native: {
+          query: "select * from PRODUCTS where CREATED_AT = {{date}}",
+          "template-tags": {
+            date: {
+              id: "abc",
+              name: "date",
+              "display-name": "Date variable",
+              type: "date",
+            },
+          },
+        },
+      });
+
+      const templateTagDimension = Dimension.parseMBQL(
+        ["template-tag", "date"],
+        metadata,
+        nativeQuery,
+      );
+
+      setup(templateTagDimension);
+    });
+
+    it("should show an icon corresponding to the given dimension's underlying field type", () => {
+      expect(screen.queryByLabelText("calendar icon")).toBeInTheDocument();
+    });
+
+    it("it should display the given dimension's display name", () => {
+      expect(screen.getByText("Date variable")).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/metabase/components/DimensionLabel/index.js
+++ b/frontend/src/metabase/components/DimensionLabel/index.js
@@ -1,0 +1,1 @@
+export { default } from "./DimensionLabel";


### PR DESCRIPTION
Related to #18738

We're building hover cards that show information for a given dimension:
![Screen Shot 2021-11-01 at 1 37 50 PM](https://user-images.githubusercontent.com/13057258/139738688-8be7b069-6762-41dd-a01b-0f454cf141cb.png)

This component represents the label on the hover card. Basically just adds a bit of ui around a `dimension.icon()` and `dimension.displayName()` call. The logic behind these method calls is fairly complex and varies depending on the type of Dimension, so I've added unit tests for each type of unit test. We can probably simplify these unit tests at some point once more trust is built around Dimension unit tests, but for now, I think it is worthwhile to keep them.

<img width="367" alt="Screen Shot 2021-11-02 at 5 52 36 PM" src="https://user-images.githubusercontent.com/13057258/139971221-44f2eac3-566a-4b21-9b31-7198f71c3877.png">

