### PR TITLE
Do not bin numerical fields on join condition

### DIFF
--- a/frontend/src/metabase-lib/lib/queries/structured/Join.js
+++ b/frontend/src/metabase-lib/lib/queries/structured/Join.js
@@ -379,7 +379,9 @@ export default class Join extends MBQLObjectClause {
       count: dimensions.length,
       dimensions: dimensions,
       fks: [],
+      overrideDefaultAutobin: true,
     };
+
     // add all previous joined fields
     const joins = query.joins();
     for (let i = 0; i < this.index(); i++) {
@@ -466,6 +468,7 @@ export default class Join extends MBQLObjectClause {
       count: dimensions.length,
       dimensions: dimensions,
       fks: [],
+      overrideDefaultAutobin: true,
     });
   }
 

--- a/frontend/src/metabase-lib/lib/queries/structured/Join.js
+++ b/frontend/src/metabase-lib/lib/queries/structured/Join.js
@@ -379,7 +379,7 @@ export default class Join extends MBQLObjectClause {
       count: dimensions.length,
       dimensions: dimensions,
       fks: [],
-      overrideDefaultAutobin: true,
+      preventNumberSubDimensions: true,
     };
 
     // add all previous joined fields
@@ -468,7 +468,7 @@ export default class Join extends MBQLObjectClause {
       count: dimensions.length,
       dimensions: dimensions,
       fks: [],
-      overrideDefaultAutobin: true,
+      preventNumberSubDimensions: true,
     });
   }
 

--- a/frontend/src/metabase/query_builder/components/DimensionList.jsx
+++ b/frontend/src/metabase/query_builder/components/DimensionList.jsx
@@ -37,7 +37,7 @@ type Props = {
   alwaysExpanded?: boolean,
   enableSubDimensions?: boolean,
   useOriginalDimension?: boolean,
-  overrideDefaultAutobin?: boolean,
+  preventNumberSubDimensions?: boolean,
 };
 
 type State = {
@@ -106,20 +106,20 @@ export default class DimensionList extends Component {
     const {
       dimension,
       enableSubDimensions,
-      overrideDefaultAutobin,
+      preventNumberSubDimensions,
       onAddDimension,
       onRemoveDimension,
     } = this.props;
 
-    const surpressAutoBin =
-      overrideDefaultAutobin && item.dimension.field().isSummable();
+    const surpressSubDimensions =
+      preventNumberSubDimensions && item.dimension.field().isSummable();
 
     const subDimensions =
       enableSubDimensions &&
       item.dimension &&
       // Do not display sub dimension if this is an FK (metabase#16787)
       !item.dimension.field().isFK() &&
-      !surpressAutoBin &&
+      !surpressSubDimensions &&
       item.dimension.dimensions();
 
     const multiSelect = !!(onAddDimension || onRemoveDimension);
@@ -144,7 +144,7 @@ export default class DimensionList extends Component {
             triggerElement={this.renderSubDimensionTrigger(
               item.dimension,
               multiSelect,
-              overrideDefaultAutobin,
+              preventNumberSubDimensions,
             )}
             tetherOptions={multiSelect ? null : SUBMENU_TETHER_OPTIONS}
             sizeToFit
@@ -213,7 +213,7 @@ export default class DimensionList extends Component {
     const {
       enableSubDimensions,
       useOriginalDimension,
-      overrideDefaultAutobin,
+      preventNumberSubDimensions,
     } = this.props;
     const dimension = useOriginalDimension
       ? item.dimension
@@ -226,7 +226,7 @@ export default class DimensionList extends Component {
 
     if (
       shouldExcludeBinning ||
-      (overrideDefaultAutobin && dimension.field().isSummable())
+      (preventNumberSubDimensions && dimension.field().isSummable())
     ) {
       // If we don't let user choose the sub-dimension, we don't want to treat the field
       // as a binned field (which would use the default binning)

--- a/frontend/src/metabase/query_builder/components/DimensionList.jsx
+++ b/frontend/src/metabase/query_builder/components/DimensionList.jsx
@@ -37,6 +37,7 @@ type Props = {
   alwaysExpanded?: boolean,
   enableSubDimensions?: boolean,
   useOriginalDimension?: boolean,
+  overrideDefaultAutobin?: boolean,
 };
 
 type State = {
@@ -105,14 +106,20 @@ export default class DimensionList extends Component {
     const {
       dimension,
       enableSubDimensions,
+      overrideDefaultAutobin,
       onAddDimension,
       onRemoveDimension,
     } = this.props;
+
+    const surpressAutoBin =
+      overrideDefaultAutobin && item.dimension.field().isSummable();
+
     const subDimensions =
       enableSubDimensions &&
       item.dimension &&
       // Do not display sub dimension if this is an FK (metabase#16787)
       !item.dimension.field().isFK() &&
+      !surpressAutoBin &&
       item.dimension.dimensions();
 
     const multiSelect = !!(onAddDimension || onRemoveDimension);
@@ -137,6 +144,7 @@ export default class DimensionList extends Component {
             triggerElement={this.renderSubDimensionTrigger(
               item.dimension,
               multiSelect,
+              overrideDefaultAutobin,
             )}
             tetherOptions={multiSelect ? null : SUBMENU_TETHER_OPTIONS}
             sizeToFit
@@ -189,6 +197,7 @@ export default class DimensionList extends Component {
       _.find(dimensions, d => d.isSameBaseDimension(otherDimension)) ||
       otherDimension.defaultDimension();
     const name = subDimension ? subDimension.subTriggerDisplayName() : null;
+
     return (
       <div
         className="FieldList-grouping-trigger text-white-hover flex align-center p1 cursor-pointer"
@@ -201,7 +210,11 @@ export default class DimensionList extends Component {
   }
 
   _getDimensionFromItem(item) {
-    const { enableSubDimensions, useOriginalDimension } = this.props;
+    const {
+      enableSubDimensions,
+      useOriginalDimension,
+      overrideDefaultAutobin,
+    } = this.props;
     const dimension = useOriginalDimension
       ? item.dimension
       : item.dimension.defaultDimension() || item.dimension;
@@ -211,7 +224,10 @@ export default class DimensionList extends Component {
       dimension instanceof FieldDimension &&
       dimension.binningStrategy();
 
-    if (shouldExcludeBinning) {
+    if (
+      shouldExcludeBinning ||
+      (overrideDefaultAutobin && dimension.field().isSummable())
+    ) {
       // If we don't let user choose the sub-dimension, we don't want to treat the field
       // as a binned field (which would use the default binning)
       // Let's unwrap the base field of the binned field instead

--- a/frontend/src/metabase/query_builder/components/FieldList.jsx
+++ b/frontend/src/metabase/query_builder/components/FieldList.jsx
@@ -38,7 +38,7 @@ type Props = {
   // DimensionList props:
   enableSubDimensions?: boolean,
   useOriginalDimension?: boolean,
-  overrideDefaultAutobin?: boolean,
+  preventNumberSubDimensions?: boolean,
 };
 
 type State = {
@@ -104,7 +104,9 @@ export default class FieldList extends Component {
         // forward DimensionList props
         useOriginalDimension={this.props.useOriginalDimension}
         enableSubDimensions={this.props.enableSubDimensions}
-        overrideDefaultAutobin={this.props.fieldOptions.overrideDefaultAutobin}
+        preventNumberSubDimensions={
+          this.props.fieldOptions.preventNumberSubDimensions
+        }
       />
     );
   }

--- a/frontend/src/metabase/query_builder/components/FieldList.jsx
+++ b/frontend/src/metabase/query_builder/components/FieldList.jsx
@@ -38,6 +38,7 @@ type Props = {
   // DimensionList props:
   enableSubDimensions?: boolean,
   useOriginalDimension?: boolean,
+  overrideDefaultAutobin?: boolean,
 };
 
 type State = {
@@ -103,6 +104,7 @@ export default class FieldList extends Component {
         // forward DimensionList props
         useOriginalDimension={this.props.useOriginalDimension}
         enableSubDimensions={this.props.enableSubDimensions}
+        overrideDefaultAutobin={this.props.fieldOptions.overrideDefaultAutobin}
       />
     );
   }

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -629,6 +629,7 @@ class JoinDimensionPicker extends React.Component {
               onClose();
             }}
             enableSubDimensions
+            overrideDefaultAutobin
             data-testid={`${testID}-picker`}
           />
         )}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -629,7 +629,7 @@ class JoinDimensionPicker extends React.Component {
               onClose();
             }}
             enableSubDimensions
-            overrideDefaultAutobin
+            preventNumberSubDimensions
             data-testid={`${testID}-picker`}
           />
         )}

--- a/frontend/test/metabase/scenarios/question/reproductions/18589-numeric-binning-in-joins.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/18589-numeric-binning-in-joins.cy.spec.js
@@ -12,7 +12,7 @@ describe("issue 18589", () => {
     cy.intercept("POST", "/api/dataset").as("dataset");
   });
 
-  it.skip("should not bin numeric fields in join condition by default (metabase#18589)", () => {
+  it("should not bin numeric fields in join condition by default (metabase#18589)", () => {
     openOrdersTable({ mode: "notebook" });
 
     joinTable("Reviews");
@@ -25,7 +25,7 @@ describe("issue 18589", () => {
     getNotebookStep("summarize").within(() => {
       cy.icon("play").click();
       cy.wait("@dataset");
-      cy.findByText("2.860.368");
+      cy.findByText("2,860,368");
     });
   });
 });


### PR DESCRIPTION
This problem was introduce because in PR #17883, `enableSubDimensions` was set to true, as it was necessary to facilitate choosing the temporal unit for join date-time (the essence of that PR). As a side effect, which is not intended, this `enableSubDimensions` means that any subdimension and/or binning for other non-temporal is also displayed (and selectable) in the pop-up list.

The solution, or we can call it a workaround, is to add _yet more additional logic_ in the binning handling to exclude those dimensions intended to be joined.



To verify:

1. Ask a question, Custom question
2. Sample Dataset, Orders
3. Join data, choose Reviews table
4. For the join, choose Orders.Quantity and Reviews.Rating
5. Summarize, Count of Rows, Preview

**Before this PR**

At step 4, Quantity will have _Auto bin_ displayed when the mouse hovers on it.

![image](https://user-images.githubusercontent.com/7288/139776004-da85e0c6-676a-44b5-8318-95cbb56f519f.png)

With Step 5, the result preview will appear after a very long time (if the query finishes at all, which sometimes it doesn't).

![image](https://user-images.githubusercontent.com/7288/139776224-5e0fa06e-a773-4f89-aecb-7ea5120f76ee.png)

**After this PR**

At step 4, Order.Quantity does not have _Auto bin_ displayed. The same applies for other fields such as Reviews.Rating.
However, fields like Created At will still have binning options (as expected).

![image](https://user-images.githubusercontent.com/7288/139775804-2557abe8-9c98-4a57-96ec-1cf6ec0ced17.png)

And the query for the result preview in Step 5 should take a reasonable time to complete.

![image](https://user-images.githubusercontent.com/7288/139776363-dd57ef6f-11fb-4386-8bb1-7c8962e2e3bf.png)
