### PR TITLE
Enable hot-reloading for server using ring reload middleware

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -177,6 +177,7 @@
     pjstadig/humane-test-output                           {:mvn/version "0.11.0"}
     reifyhealth/specmonstah                               {:mvn/version "2.0.0"}
     ring/ring-mock                                        {:mvn/version "0.4.0"}
+    ring/ring-devel                                       {:mvn/version "1.9.4"} ; functions and middleware to debug Ring
     talltale/talltale                                     {:mvn/version "0.5.4"}}
 
    :extra-paths ["dev/src" "local/src" "test" "shared/test" "test_resources"]

--- a/dev/src/dev.clj
+++ b/dev/src/dev.clj
@@ -18,7 +18,8 @@
             [metabase.test :as mt]
             [metabase.test.data.impl :as data.impl]
             [metabase.util :as u]
-            [potemkin :as p]))
+            [potemkin :as p]
+            [ring.middleware.reload :refer [wrap-reload]]))
 
 (comment debug-qp/keep-me)
 
@@ -40,7 +41,7 @@
   []
   (when-not @initialized?
     (init!))
-  (server/start-web-server! #'handler/app)
+  (server/start-web-server! (wrap-reload #'handler/app))
   (mdb/setup-db!)
   (plugins/load-plugins!)
   (init-status/set-complete!))


### PR DESCRIPTION
Follow up with #12181, This PR adds a middleware to reload the server when it detects changes.
I've been using it for a week now and it's working for APIs.

Question:
- This middleware by default will observe all namespaces in `src/` ([ref](https://ring-clojure.github.io/ring/ring.middleware.reload.html)), should I add the `shared` and `enterprise/backend/src/` folder too? 

P/s: my development circle is mostly around APIs so I'm not sure it'll work with other parts (I.e: syncing, events ...) So kindly try it out if you're working on those things.

###### Before submitting the PR, please make sure you do the following

- [x] If you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.

### Tests

- [x] Run the frontend and Cypress end-to-end tests with `yarn lint && yarn test`)
- [x] If there are changes to the backend codebase, run the backend tests with `clojure -X:dev:test`
- [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
      (unless it's a tiny documentation change).
