### PR TITLE
Add expression support for :time-interval filter

### DIFF
--- a/shared/src/metabase/mbql/schema.cljc
+++ b/shared/src/metabase/mbql/schema.cljc
@@ -687,7 +687,7 @@
 ;;
 ;; SUGAR: This is automatically rewritten as a filter clause with a relative-datetime value
 (defclause ^:sugar time-interval
-  field   field
+  field   Field
   n       (s/cond-pre
            s/Int
            (s/enum :current :last :next))

--- a/shared/test/metabase/mbql/util_test.cljc
+++ b/shared/test/metabase/mbql/util_test.cljc
@@ -413,6 +413,12 @@
               [:field 1 {:temporal-unit :week}]
               [:relative-datetime 0 :week]]
              (mbql.u/negate-filter-clause [:time-interval [:field 1 nil] :current :week]))))
+  (t/testing :time-interval
+    (t/is (= [:!=
+              [:expression "CC"]
+              [:relative-datetime 0 :week]]
+             (mbql.u/negate-filter-clause [:time-interval [:expression "CC"] :current :week]))))
+
   (t/testing :is-null
     (t/is (= [:!= [:field 1 nil] nil]
              (mbql.u/negate-filter-clause [:is-null [:field 1 nil]]))))

--- a/shared/test/metabase/mbql/util_test.cljc
+++ b/shared/test/metabase/mbql/util_test.cljc
@@ -227,6 +227,48 @@
            (mbql.u/desugar-filter-clause [:time-interval [:field 1 nil] :current :week]))
         "keywords like `:current` should work correctly"))
 
+(t/deftest desugar-time-interval-with-expression-test
+  (t/is (= [:between
+            [:expression "CC"]
+            [:relative-datetime 1 :month]
+            [:relative-datetime 2 :month]]
+           (mbql.u/desugar-filter-clause [:time-interval [:expression "CC"] 2 :month]))
+        "`time-interval` with value > 1 or < -1 should generate a `between` clause")
+  (t/is (= [:between
+            [:expression "CC"]
+            [:relative-datetime 0 :month]
+            [:relative-datetime 2 :month]]
+           (mbql.u/desugar-filter-clause [:time-interval [:expression "CC"] 2 :month {:include-current true}]))
+        "test the `include-current` option -- interval should start or end at `0` instead of `1`")
+  (t/is (= [:=
+            [:expression "CC"]
+            [:relative-datetime 1 :month]]
+           (mbql.u/desugar-filter-clause [:time-interval [:expression "CC"] 1 :month]))
+        "`time-interval` with value = 1 should generate an `=` clause")
+  (t/is (= [:=
+            [:expression "CC"]
+            [:relative-datetime -1 :week]]
+           (mbql.u/desugar-filter-clause [:time-interval [:expression "CC"] -1 :week]))
+        "`time-interval` with value = -1 should generate an `=` clause")
+  (t/testing "`include-current` option"
+    (t/is (= [:between
+              [:expression "CC"]
+              [:relative-datetime 0 :month]
+              [:relative-datetime 1 :month]]
+             (mbql.u/desugar-filter-clause [:time-interval [:expression "CC"] 1 :month {:include-current true}]))
+          "interval with value = 1 should generate a `between` clause")
+    (t/is (= [:between
+              [:expression "CC"]
+              [:relative-datetime -1 :day]
+              [:relative-datetime 0 :day]]
+             (mbql.u/desugar-filter-clause [:time-interval [:expression "CC"] -1 :day {:include-current true}]))
+          "`include-current` option -- interval with value = 1 should generate a `between` clause"))
+  (t/is (= [:=
+            [:expression "CC"]
+            [:relative-datetime 0 :week]]
+           (mbql.u/desugar-filter-clause [:time-interval [:expression "CC"] :current :week]))
+        "keywords like `:current` should work correctly"))
+
 (t/deftest desugar-relative-datetime-with-current-test
   (t/testing "when comparing `:relative-datetime`to `:field`, it should take the temporal unit of the `:field`"
     (t/is (= [:=


### PR DESCRIPTION
This should fix #16273

The error from #16273 came from the fact that :time-interval doesn't recognize :expression as a field. So I
- Modify the [scheme](shared/src/metabase/mbql/schema.cljc) for :time-filter so it'll pass the validate-query middleware
- Modify the [desugar middleware](shared/src/metabase/mbql/util.cljc) so it'll recognize :expression and correctly replace the query

###### Before submitting the PR, please make sure you do the following

- [x] If you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.

### Tests

- [x] Run the frontend and Cypress end-to-end tests with `yarn lint && yarn test`)
- [x] If there are changes to the backend codebase, run the backend tests with `clojure -X:dev:test`
- [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
      (unless it's a tiny documentation change).
