### PR TITLE
Subcollections view, fixes 15339

### DIFF
--- a/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebar.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebar.jsx
@@ -19,9 +19,11 @@ import Footer from "./CollectionSidebarFooter/CollectionSidebarFooter";
 import Collections from "./Collections/Collections";
 import LoadingSpinner from "metabase/components/LoadingSpinner";
 
-import { isAnotherUsersPersonalCollection,
+import {
+  isAnotherUsersPersonalCollection,
   getParentPath,
-  getParentPersonalCollection } from "metabase/collections/utils";
+  getParentPersonalCollection,
+} from "metabase/collections/utils";
 import { updateOpenCollectionList } from "./updateOpenCollectionList";
 
 const collectionEntityQuery = {
@@ -86,11 +88,11 @@ function CollectionSidebar({
     [collections, openCollections],
   );
 
-    const isAnotherUserCollectionOpened = isAnotherUsersPersonalCollection(
-      parsetInt(collectionId),
-      collectionsById,
-      currentUser.id,
-    );
+  const isAnotherUserCollectionOpened = isAnotherUsersPersonalCollection(
+    parsetInt(collectionId),
+    collectionsById,
+    currentUser.id,
+  );
 
   useEffect(() => {
     if (!loading && collectionId) {
@@ -124,16 +126,16 @@ function CollectionSidebar({
             onClose={onClose}
           />
           <Footer
-        isAdmin={currentUser.is_superuser}
-        openCollections={openCollections}
-        collectionId={collectionId}
-        onOpen={onOpen}
-        onClose={onClose}
-        otherCollections={getParentPersonalCollection(
-          parseInt(collectionId),
-          collectionsById
-        )}
-        />
+            isAdmin={currentUser.is_superuser}
+            openCollections={openCollections}
+            collectionId={collectionId}
+            onOpen={onOpen}
+            onClose={onClose}
+            otherCollections={getParentPersonalCollection(
+              parseInt(collectionId),
+              collectionsById,
+            )}
+          />
         </React.Fragment>
       ) : (
         <LoadingView />

--- a/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebar.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebar.jsx
@@ -19,7 +19,9 @@ import Footer from "./CollectionSidebarFooter/CollectionSidebarFooter";
 import Collections from "./Collections/Collections";
 import LoadingSpinner from "metabase/components/LoadingSpinner";
 
-import { getParentPath } from "metabase/collections/utils";
+import { isAnotherUsersPersonalCollection,
+  getParentPath,
+  getParentPersonalCollection } from "metabase/collections/utils";
 import { updateOpenCollectionList } from "./updateOpenCollectionList";
 
 const collectionEntityQuery = {
@@ -35,6 +37,7 @@ const collectionEntityQuery = {
 function mapStateToProps(state) {
   return {
     currentUser: getUser(state),
+    collectionsById: state.entities.collections,
   };
 }
 
@@ -53,6 +56,7 @@ CollectionSidebar.propTypes = {
 function CollectionSidebar({
   currentUser,
   collectionId,
+  collectionsById,
   collections,
   isRoot,
   allFetched,
@@ -81,6 +85,12 @@ function CollectionSidebar({
     },
     [collections, openCollections],
   );
+
+    const isAnotherUserCollectionOpened = isAnotherUsersPersonalCollection(
+      parsetInt(collectionId),
+      collectionsById,
+      currentUser.id,
+    );
 
   useEffect(() => {
     if (!loading && collectionId) {
@@ -113,7 +123,17 @@ function CollectionSidebar({
             onOpen={onOpen}
             onClose={onClose}
           />
-          <Footer isAdmin={currentUser.is_superuser} />
+          <Footer
+        isAdmin={currentUser.is_superuser}
+        openCollections={openCollections}
+        collectionId={collectionId}
+        onOpen={onOpen}
+        onClose={onClose}
+        otherCollections={getParentPersonalCollection(
+          parseInt(collectionId),
+          collectionsById
+        )}
+        />
         </React.Fragment>
       ) : (
         <LoadingView />

--- a/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebar.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebar.jsx
@@ -47,6 +47,7 @@ CollectionSidebar.propTypes = {
   currentUser: PropTypes.object.isRequired,
   collectionId: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   collections: PropTypes.arrayOf(PropTypes.object).isRequired,
+  collectionsById: PropTypes.object,
   isRoot: PropTypes.bool,
   allFetched: PropTypes.bool,
   loading: PropTypes.bool,
@@ -58,8 +59,8 @@ CollectionSidebar.propTypes = {
 function CollectionSidebar({
   currentUser,
   collectionId,
-  collectionsById,
   collections,
+  collectionsById,
   isRoot,
   allFetched,
   loading,
@@ -89,7 +90,7 @@ function CollectionSidebar({
   );
 
   const isAnotherUserCollectionOpened = isAnotherUsersPersonalCollection(
-    parsetInt(collectionId),
+    parseInt(collectionId),
     collectionsById,
     currentUser.id,
   );
@@ -127,12 +128,13 @@ function CollectionSidebar({
           />
           <Footer
             isAdmin={currentUser.is_superuser}
+            isAnotherUserCollectionOpened={isAnotherUserCollectionOpened}
             openCollections={openCollections}
             collectionId={collectionId}
             onOpen={onOpen}
             onClose={onClose}
             otherCollections={getParentPersonalCollection(
-              parseInt(collectionId),
+              collectionId,
               collectionsById,
             )}
           />

--- a/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebarFooter/CollectionSidebarFooter.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebarFooter/CollectionSidebarFooter.jsx
@@ -9,11 +9,28 @@ import { Container, Icon, Link } from "./CollectionSidebarFooter.styled";
 
 const propTypes = {
   isAdmin: PropTypes.bool.isRequired,
+  isAnotherUserCollectionOpened: PropTypes.bool,
+  collectionId: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  collections: PropTypes.arrayOf(PropTypes.object),
+  onClose: PropTypes.func,
+  onOpen: PropTypes.func,
+  otherCollections: PropTypes.arrayOf(PropTypes.object),
 };
 
 export default function CollectionSidebarFooter({ isAdmin }) {
   return (
     <Container>
+      {isAdmin && isAnotherUserCollectionOpened && (
+        <CollectionsList
+        openCollections={openCollections}
+        onClose={onClose}
+        onOpen={onOpen}
+        collections={otherCollections}
+        initialIcon="group"
+        currentCollection={collectionId}
+        />
+      )}
+
       {isAdmin && (
         <Link to={Urls.collection({ id: "users" })}>
           <CollectionsList.Icon collection={PERSONAL_COLLECTIONS} />

--- a/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebarFooter/CollectionSidebarFooter.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebarFooter/CollectionSidebarFooter.jsx
@@ -22,12 +22,12 @@ export default function CollectionSidebarFooter({ isAdmin }) {
     <Container>
       {isAdmin && isAnotherUserCollectionOpened && (
         <CollectionsList
-        openCollections={openCollections}
-        onClose={onClose}
-        onOpen={onOpen}
-        collections={otherCollections}
-        initialIcon="group"
-        currentCollection={collectionId}
+          openCollections={openCollections}
+          onClose={onClose}
+          onOpen={onOpen}
+          collections={otherCollections}
+          initialIcon="group"
+          currentCollection={collectionId}
         />
       )}
 

--- a/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebarFooter/CollectionSidebarFooter.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebarFooter/CollectionSidebarFooter.jsx
@@ -15,9 +15,17 @@ const propTypes = {
   onClose: PropTypes.func,
   onOpen: PropTypes.func,
   otherCollections: PropTypes.arrayOf(PropTypes.object),
+  openCollections: PropTypes.arrayOf(PropTypes.object),
 };
 
-export default function CollectionSidebarFooter({ isAdmin }) {
+export default function CollectionSidebarFooter({ isAdmin,
+  isAnotherUserCollectionOpened,
+  openCollections,
+  onClose,
+  onOpen,
+  otherCollections,
+  collectionId,
+}) {
   return (
     <Container>
       {isAdmin && isAnotherUserCollectionOpened && (

--- a/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebarFooter/CollectionSidebarFooter.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebarFooter/CollectionSidebarFooter.jsx
@@ -18,7 +18,8 @@ const propTypes = {
   openCollections: PropTypes.arrayOf(PropTypes.object),
 };
 
-export default function CollectionSidebarFooter({ isAdmin,
+export default function CollectionSidebarFooter({
+  isAdmin,
   isAnotherUserCollectionOpened,
   openCollections,
   onClose,

--- a/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebarFooter/CollectionSidebarFooter.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebarFooter/CollectionSidebarFooter.jsx
@@ -36,7 +36,7 @@ export default function CollectionSidebarFooter({
           onOpen={onOpen}
           collections={otherCollections}
           initialIcon="group"
-          filter={(member) => true}
+          filter={member => true}
           currentCollection={collectionId}
         />
       )}

--- a/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebarFooter/CollectionSidebarFooter.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebarFooter/CollectionSidebarFooter.jsx
@@ -36,6 +36,7 @@ export default function CollectionSidebarFooter({
           onOpen={onOpen}
           collections={otherCollections}
           initialIcon="group"
+          filter={(member) => true}
           currentCollection={collectionId}
         />
       )}

--- a/frontend/src/metabase/collections/containers/CollectionSidebar/Collections/Collections.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/Collections/Collections.jsx
@@ -11,7 +11,7 @@ import {
 import { Container } from "./Collections.styled";
 
 const propTypes = {
-  collectionId: PropTypes.number,
+  collectionId: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   currentUserId: PropTypes.number,
   handleToggleMobileSidebar: PropTypes.func.isRequired,
   list: PropTypes.array,

--- a/frontend/src/metabase/collections/utils.js
+++ b/frontend/src/metabase/collections/utils.js
@@ -28,8 +28,6 @@ export function currentUserPersonalCollections(collectionList, userID) {
 }
 
 export function getParentPersonalCollection(collectionId, collectionById) {
-  console.log(collectionId);
-  console.log(collectionById);
   const targetCollection = collectionById[collectionId];
   if (targetCollection.personal_owner_id) {
     return [targetCollection];
@@ -38,7 +36,11 @@ export function getParentPersonalCollection(collectionId, collectionById) {
     const collection = collectionById[ancestor.id];
     return collection && collection.personal_owner_id;
   });
-  return [collectionById[parent.id]];
+  if (parent) {
+    return [collectionById[parent.id]];
+  } else {
+    return [];
+  }
 }
 
 export function isAnotherUsersPersonalCollection(

--- a/frontend/src/metabase/collections/utils.js
+++ b/frontend/src/metabase/collections/utils.js
@@ -28,6 +28,8 @@ export function currentUserPersonalCollections(collectionList, userID) {
 }
 
 export function getParentPersonalCollection(collectionId, collectionById) {
+  console.log(collectionId);
+  console.log(collectionById);
   const targetCollection = collectionById[collectionId];
   if (targetCollection.personal_owner_id) {
     return [targetCollection];

--- a/frontend/src/metabase/collections/utils.js
+++ b/frontend/src/metabase/collections/utils.js
@@ -29,7 +29,7 @@ export function currentUserPersonalCollections(collectionList, userID) {
 
 export function getParentPersonalCollection(collectionId, collectionById) {
   const targetCollection = collectionById[collectionId];
-  if (targetCollection.personal_owner_id) {
+  if (targetCollection?.personal_owner_id) {
     return [targetCollection];
   }
   const ancestors = targetCollection?.effective_ancestors;
@@ -38,10 +38,11 @@ export function getParentPersonalCollection(collectionId, collectionById) {
       const collection = collectionById[ancestor.id];
       return collection && collection.personal_owner_id;
     });
-    return [collectionById[parent.id]];
-  } else {
-    return [];
+    if (parent) {
+      return [collectionById[parent.id]];
+    }
   }
+  return [];
 }
 
 export function isAnotherUsersPersonalCollection(

--- a/frontend/src/metabase/collections/utils.js
+++ b/frontend/src/metabase/collections/utils.js
@@ -27,6 +27,43 @@ export function currentUserPersonalCollections(collectionList, userID) {
     .map(preparePersonalCollection);
 }
 
+export function getParentPersonalCollection(collectionId, collectionById) {
+  const targetCollection = collectionById[collectionId];
+  if (targetCollection.personal_owner_id) {
+    return [targetCollection];
+  }
+  const parent = targetCollection.effective_ancestors.find(ancestor => {
+    const collection = collectionById[ancestor.id];
+    return collection && collection.personal_owner_id;
+  });
+  return [collectionById[parent.id]];
+}
+
+export function isAnotherUsersPersonalCollection(
+  collectionId,
+  collectionById,
+  userId,
+) {
+  const targetCollection = collectionById[collectionId];
+  if (!targetCollection) {
+    return false;
+  }
+  if (targetCollection.personal_owner_id) {
+    return targetCollection.personal_owner_id !== userId;
+  }
+  if (!Array.isArray(targetCollection.effective_ancestors)) {
+    return false;
+  }
+  return targetCollection.effective_ancestors.some(ancestor => {
+    const collection = collectionById[ancestor.id];
+    return (
+      collection &&
+      collection.personal_owner_id &&
+      collection.personal_owner_id !== userId
+    );
+  });
+}
+
 export function getParentPath(collections, targetId) {
   if (collections.length === 0) {
     return null; // not found!

--- a/frontend/src/metabase/collections/utils.js
+++ b/frontend/src/metabase/collections/utils.js
@@ -32,11 +32,12 @@ export function getParentPersonalCollection(collectionId, collectionById) {
   if (targetCollection.personal_owner_id) {
     return [targetCollection];
   }
-  const parent = targetCollection.effective_ancestors.find(ancestor => {
-    const collection = collectionById[ancestor.id];
-    return collection && collection.personal_owner_id;
-  });
-  if (parent) {
+  const ancestors = targetCollection?.effective_ancestors;
+  if (ancestors) {
+    const parent = ancestors.find(ancestor => {
+      const collection = collectionById[ancestor.id];
+      return collection && collection.personal_owner_id;
+    });
     return [collectionById[parent.id]];
   } else {
     return [];

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -8,6 +8,7 @@ import {
 } from "__support__/e2e/cypress";
 import { displaySidebarChildOf } from "./helpers/e2e-collections-sidebar.js";
 import { USERS, USER_GROUPS } from "__support__/e2e/cypress_data";
+import { getSidebarCollectionChildrenFor } from "./utils";
 
 const { nocollection } = USERS;
 const { DATA_GROUP } = USER_GROUPS;
@@ -583,14 +584,6 @@ function selectItemUsingCheckbox(item, icon = "table") {
         .findByRole("checkbox")
         .click();
     });
-}
-
-function getSidebarCollectionChildrenFor(item) {
-  return sidebar()
-    .findByText(item)
-    .closest("a")
-    .parent()
-    .parent();
 }
 
 function pinAllRootItems() {

--- a/frontend/test/metabase/scenarios/collections/utils.js
+++ b/frontend/test/metabase/scenarios/collections/utils.js
@@ -1,0 +1,8 @@
+export function getSidebarCollectionChildrenFor(item) {
+  return cy
+    .get("aside")
+    .findByText(item)
+    .closest("a")
+    .parent()
+    .parent();
+}


### PR DESCRIPTION
Underlying problem of #15339 is that admins can't see sub-collections of people whose personal collections they're looking at in the sidebar. This one just adds that little bit to the sidebar footer.

This is like 2/3 Anton's code.

Anton had PR up to fix #15339 which I was working on directly on the branch, and then I literally forgot about it because it wasn't under my PR's. Anyhow, the fix is still pretty easy to port to current version.