### PR TITLE
Fix linter warning about not used variable in the Icon component

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,7 +3,10 @@
     "strict": [2, "never"],
     "no-undef": 2,
     "no-var": 1,
-    "no-unused-vars": [1, { "vars": "all", "args": "none" }],
+    "no-unused-vars": [
+      1,
+      { "vars": "all", "args": "none", "varsIgnorePattern": "^_" }
+    ],
     "no-empty": [1, { "allowEmptyCatch": true }],
     "curly": [1, "all"],
     "eqeqeq": [1, "smart"],

--- a/.eslintrc
+++ b/.eslintrc
@@ -72,6 +72,10 @@
         "@typescript-eslint/explicit-module-boundary-types": "off",
         "@typescript-eslint/no-inferrable-types": "off",
         "@typescript-eslint/no-explicit-any": "off",
+        "@typescript-eslint/no-unused-vars": [
+          "warn",
+          { "varsIgnorePattern": "^_" }
+        ],
         "@typescript-eslint/no-use-before-define": [
           "error",
           { "functions": false }

--- a/frontend/src/metabase/components/Icon.tsx
+++ b/frontend/src/metabase/components/Icon.tsx
@@ -96,8 +96,7 @@ class BaseIcon extends Component<IconProps> {
 
     if (icon.img) {
       // avoid passing `role="img"` to an actual image file
-      // eslint-disable-next-line no-unused-vars
-      const { role, ...rest } = props;
+      const { _role, ...rest } = props;
       return (
         <img
           src={icon.img}

--- a/frontend/src/metabase/components/Icon.tsx
+++ b/frontend/src/metabase/components/Icon.tsx
@@ -28,7 +28,7 @@ export const IconWrapper = styled.div<IconWrapperProps>`
   cursor: pointer;
   color: ${props => (props.open ? c("brand") : "inherit")};
   // special cases for certain icons
-  // Icon-share has a taller viewvbox than most so to optically center
+  // Icon-share has a taller viewbox than most so to optically center
   // the icon we need to translate it upwards
   "> .icon.icon-share": {
     transform: translateY(-2px);


### PR DESCRIPTION
When starting Metabase FE, you can see a warning about the unused `role` variable in the Icon component. There is a comment disabling eslint's `no-unused-vars` rule above, but as Icon is now a TypeScript file, `@typescript-eslint/no-unused-vars` is fired.

It's a common pattern to prefix not used variables with underscores, like in case you want to omit some object key with a spread operator. WDYT if we allow that in eslint conf?

### To Verify

1. Launch Metabase (`yarn dev` / `yarn built-hot`)
2. Wait until the webpack completes its job
3. You shouldn't see the `'role' is assigned a value but never used` warning