### PR TITLE
Fix markdown image link click area

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/Text.css
+++ b/frontend/src/metabase/visualizations/visualizations/Text.css
@@ -83,6 +83,7 @@
 }
 
 :local .text-card-markdown a {
+  display: inline-block;
   font-weight: bold;
   cursor: pointer;
   text-decoration: none;


### PR DESCRIPTION
Fixes #18641: textbox markdown links on images difficult to click

### To Verify

1. Go to dashboard and add Textbox with the following and save the dashboard
`[![](https://www.metabase.com/images/twitter/default-share.png)](/question/1)`
2. Hover the image, the whole image block should be wrapped with a link
3. Click anywhere on the image, you should be navigated to an expected destination (`/question/1`)

### Demo

**Before**

<img src="https://user-images.githubusercontent.com/17258145/139834588-ef148eea-8615-42ec-a16c-28a50af219e0.gif" alt="before" width="50%" height="50%"/>

**After**

<img src="https://user-images.githubusercontent.com/17258145/139834568-cb179ad6-eb3a-4898-a8cb-0a1e64f07791.gif" alt="after" width="50%" height="50%"/>
