### PR TITLE
Bump the threshold for front-end coverage to 40%

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -14,7 +14,7 @@ coverage:
           - back-end
 
       front-end:
-        target: 35%
+        target: 40%
         threshold: 5%
         flags:
           - front-end


### PR DESCRIPTION
According to [Codecov](https://app.codecov.io/gh/metabase/metabase), we're > 43% already so let's keep raising the bar!

![image](https://user-images.githubusercontent.com/7288/139871712-a55cc9de-c20f-4701-a618-45bb39c3420d.png)
