### PR TITLE
Disable menu transition if reduced motion is preferred

### DIFF
--- a/frontend/src/metabase/components/EntityMenu.jsx
+++ b/frontend/src/metabase/components/EntityMenu.jsx
@@ -2,6 +2,8 @@ import React, { Component } from "react";
 import { Motion, spring } from "react-motion";
 import cx from "classnames";
 
+import { isReducedMotionPreferred } from "metabase/lib/dom";
+
 import Card from "metabase/components/Card";
 import EntityMenuTrigger from "metabase/components/EntityMenuTrigger";
 import EntityMenuItem from "metabase/components/EntityMenuItem";
@@ -21,6 +23,8 @@ type Props = {
   tooltip?: string,
   triggerProps: Object,
 };
+
+const MENU_SHIFT_Y = 10;
 
 class EntityMenu extends Component {
   props: Props;
@@ -49,6 +53,8 @@ class EntityMenu extends Component {
   };
 
   render() {
+    const preferReducedMotion = isReducedMotionPreferred();
+
     const { items, triggerIcon, triggerProps, className, tooltip } = this.props;
     const { open, menuItemContent } = this.state;
     return (
@@ -80,66 +86,78 @@ class EntityMenu extends Component {
             }}
             style={{
               opacity: open ? spring(1) : spring(0),
-              translateY: open ? spring(10) : spring(0),
+              translateY: open ? spring(MENU_SHIFT_Y) : spring(0),
             }}
           >
-            {({ opacity, translateY }) => (
-              <div
-                style={{
-                  opacity: opacity,
-                  transform: `translateY(${translateY}px)`,
-                }}
-              >
-                <Card>
-                  {menuItemContent || (
-                    <ol className="py1" style={{ minWidth: 210 }}>
-                      {items.map(item => {
-                        if (!item) {
-                          return null;
-                        } else if (item.content) {
-                          return (
-                            <li key={item.title}>
-                              <EntityMenuItem
-                                icon={item.icon}
-                                title={item.title}
-                                action={() =>
-                                  this.replaceMenuWithItemContent(
-                                    item.content(
-                                      this.toggleMenu,
-                                      this.setFreezeMenu,
-                                    ),
-                                  )
-                                }
-                              />
-                            </li>
-                          );
-                        } else {
-                          return (
-                            <li key={item.title}>
-                              <EntityMenuItem
-                                icon={item.icon}
-                                title={item.title}
-                                externalLink={item.externalLink}
-                                action={
-                                  item.action &&
-                                  (() => {
-                                    item.action();
-                                    this.toggleMenu();
-                                  })
-                                }
-                                event={item.event && item.event}
-                                link={item.link}
-                                onClose={() => this.toggleMenu()}
-                              />
-                            </li>
-                          );
-                        }
-                      })}
-                    </ol>
-                  )}
-                </Card>
-              </div>
-            )}
+            {({ opacity, translateY }) => {
+              const motionOpacity = preferReducedMotion
+                ? opacity > 0.5
+                  ? 1
+                  : 0
+                : opacity;
+              const motionY = preferReducedMotion
+                ? translateY > MENU_SHIFT_Y / 2
+                  ? MENU_SHIFT_Y
+                  : 0
+                : translateY;
+              return (
+                <div
+                  style={{
+                    opacity: motionOpacity,
+                    transform: `translateY(${motionY}px)`,
+                  }}
+                >
+                  <Card>
+                    {menuItemContent || (
+                      <ol className="py1" style={{ minWidth: 210 }}>
+                        {items.map(item => {
+                          if (!item) {
+                            return null;
+                          } else if (item.content) {
+                            return (
+                              <li key={item.title}>
+                                <EntityMenuItem
+                                  icon={item.icon}
+                                  title={item.title}
+                                  action={() =>
+                                    this.replaceMenuWithItemContent(
+                                      item.content(
+                                        this.toggleMenu,
+                                        this.setFreezeMenu,
+                                      ),
+                                    )
+                                  }
+                                />
+                              </li>
+                            );
+                          } else {
+                            return (
+                              <li key={item.title}>
+                                <EntityMenuItem
+                                  icon={item.icon}
+                                  title={item.title}
+                                  externalLink={item.externalLink}
+                                  action={
+                                    item.action &&
+                                    (() => {
+                                      item.action();
+                                      this.toggleMenu();
+                                    })
+                                  }
+                                  event={item.event && item.event}
+                                  link={item.link}
+                                  onClose={() => this.toggleMenu()}
+                                />
+                              </li>
+                            );
+                          }
+                        })}
+                      </ol>
+                    )}
+                  </Card>
+                </div>
+              );
+            }}
           </Motion>
         </Popover>
       </div>


### PR DESCRIPTION
How to verify quickly:
1. Make sure to enable [prefers-reduced-motion](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion#user_preferences)
2. Go to `/` and click the + button (Create)

![image](https://user-images.githubusercontent.com/7288/139901202-8f37be5c-062e-443d-af18-504f2a715572.png)


**Before this PR**

The menu shows up with a transition on the position and opacity.

**Before this PR**

The menu shows up without any animation.
