### PR TITLE
add DimensionInfo component

### DIFF
--- a/frontend/src/metabase/components/DimensionInfo/DimensionInfo.info.js
+++ b/frontend/src/metabase/components/DimensionInfo/DimensionInfo.info.js
@@ -2,10 +2,11 @@ import React from "react";
 
 import { PRODUCTS, metadata } from "__support__/sample_dataset_fixture";
 import Dimension from "metabase-lib/lib/Dimension";
-
-import DimensionInfo from "./DimensionInfo";
 import Card from "metabase/components/Card";
 import PopoverWithTrigger from "metabase/components/PopoverWithTrigger";
+import Button from "metabase/components/Button";
+
+import DimensionInfo from "./DimensionInfo";
 
 const fieldDimension = Dimension.parseMBQL(
   ["field", PRODUCTS.CATEGORY.id, null],
@@ -34,7 +35,7 @@ export const examples = {
     </Card>
   ),
   "in a popoover": (
-    <PopoverWithTrigger triggerElement={<button>click me</button>}>
+    <PopoverWithTrigger triggerElement={<Button>click me</Button>}>
       <DimensionInfo dimension={fieldDimension} />
     </PopoverWithTrigger>
   ),

--- a/frontend/src/metabase/components/DimensionInfo/DimensionInfo.info.js
+++ b/frontend/src/metabase/components/DimensionInfo/DimensionInfo.info.js
@@ -23,12 +23,23 @@ const expressionDimension = Dimension.parseMBQL(
   metadata,
 );
 
+const longDescriptionDimension = {
+  displayName: () => "Foo",
+  icon: () => "string",
+  field: () => ({
+    description: Array(50)
+      .fill("Long description Long description")
+      .join("\n "),
+  }),
+};
+
 export const component = DimensionInfo;
 export const description =
   "A selection of information from a given Dimension instance, for use in some containing component";
 export const examples = {
   "with description": <DimensionInfo dimension={fieldDimension} />,
   "without description": <DimensionInfo dimension={expressionDimension} />,
+  "long description": <DimensionInfo dimension={longDescriptionDimension} />,
   "in a card": (
     <Card>
       <DimensionInfo dimension={fieldDimension} />
@@ -36,7 +47,7 @@ export const examples = {
   ),
   "in a popoover": (
     <PopoverWithTrigger triggerElement={<Button>click me</Button>}>
-      <DimensionInfo dimension={fieldDimension} />
+      <DimensionInfo dimension={longDescriptionDimension} />
     </PopoverWithTrigger>
   ),
 };

--- a/frontend/src/metabase/components/DimensionInfo/DimensionInfo.info.js
+++ b/frontend/src/metabase/components/DimensionInfo/DimensionInfo.info.js
@@ -1,0 +1,41 @@
+import React from "react";
+
+import { PRODUCTS, metadata } from "__support__/sample_dataset_fixture";
+import Dimension from "metabase-lib/lib/Dimension";
+
+import DimensionInfo from "./DimensionInfo";
+import Card from "metabase/components/Card";
+import PopoverWithTrigger from "metabase/components/PopoverWithTrigger";
+
+const fieldDimension = Dimension.parseMBQL(
+  ["field", PRODUCTS.CATEGORY.id, null],
+  metadata,
+);
+
+const expressionDimension = Dimension.parseMBQL(
+  [
+    "expression",
+    Array(15)
+      .fill("Long display name")
+      .join(" -- "),
+  ],
+  metadata,
+);
+
+export const component = DimensionInfo;
+export const description =
+  "A selection of information from a given Dimension instance, for use in some containing component";
+export const examples = {
+  "with description": <DimensionInfo dimension={fieldDimension} />,
+  "without description": <DimensionInfo dimension={expressionDimension} />,
+  "in a card": (
+    <Card>
+      <DimensionInfo dimension={fieldDimension} />
+    </Card>
+  ),
+  "in a popoover": (
+    <PopoverWithTrigger triggerElement={<button>click me</button>}>
+      <DimensionInfo dimension={fieldDimension} />
+    </PopoverWithTrigger>
+  ),
+};

--- a/frontend/src/metabase/components/DimensionInfo/DimensionInfo.jsx
+++ b/frontend/src/metabase/components/DimensionInfo/DimensionInfo.jsx
@@ -1,0 +1,34 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { t } from "ttag";
+
+import Dimension from "metabase-lib/lib/Dimension";
+import DimensionLabel from "metabase/components/DimensionLabel";
+
+import {
+  Container,
+  Description,
+  EmptyDescription,
+} from "./DimensionInfo.styled";
+
+DimensionInfo.propTypes = {
+  className: PropTypes.string,
+  dimension: PropTypes.instanceOf(Dimension).isRequired,
+};
+
+function DimensionInfo({ className, dimension }) {
+  const field = dimension.field();
+  const description = field?.description;
+  return (
+    <Container className={className}>
+      {description ? (
+        <Description>{description}</Description>
+      ) : (
+        <EmptyDescription>{t`No description`}</EmptyDescription>
+      )}
+      <DimensionLabel dimension={dimension} />
+    </Container>
+  );
+}
+
+export default DimensionInfo;

--- a/frontend/src/metabase/components/DimensionInfo/DimensionInfo.styled.jsx
+++ b/frontend/src/metabase/components/DimensionInfo/DimensionInfo.styled.jsx
@@ -1,0 +1,21 @@
+import styled from "styled-components";
+
+import { color } from "metabase/lib/colors";
+import { space } from "metabase/styled-components/theme";
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${space(2)};
+  padding: ${space(2)};
+  overflow: auto;
+`;
+
+export const Description = styled.div`
+  font-size: 14px;
+`;
+
+export const EmptyDescription = styled(Description)`
+  color: ${color("text-light")};
+  font-weight: 700;
+`;

--- a/frontend/src/metabase/components/DimensionInfo/DimensionInfo.styled.jsx
+++ b/frontend/src/metabase/components/DimensionInfo/DimensionInfo.styled.jsx
@@ -13,6 +13,9 @@ export const Container = styled.div`
 
 export const Description = styled.div`
   font-size: 14px;
+  white-space: pre-line;
+  max-height: 200px;
+  overflow: auto;
 `;
 
 export const EmptyDescription = styled(Description)`

--- a/frontend/src/metabase/components/DimensionInfo/DimensionInfo.unit.spec.js
+++ b/frontend/src/metabase/components/DimensionInfo/DimensionInfo.unit.spec.js
@@ -2,8 +2,9 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 
 import { PRODUCTS, metadata } from "__support__/sample_dataset_fixture";
-import DimensionInfo from "./DimensionInfo";
 import Dimension from "metabase-lib/lib/Dimension";
+
+import DimensionInfo from "./DimensionInfo";
 
 const fieldDimension = Dimension.parseMBQL(
   ["field", PRODUCTS.CREATED_AT.id, null],

--- a/frontend/src/metabase/components/DimensionInfo/DimensionInfo.unit.spec.js
+++ b/frontend/src/metabase/components/DimensionInfo/DimensionInfo.unit.spec.js
@@ -1,0 +1,42 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import { PRODUCTS, metadata } from "__support__/sample_dataset_fixture";
+import DimensionInfo from "./DimensionInfo";
+import Dimension from "metabase-lib/lib/Dimension";
+
+const fieldDimension = Dimension.parseMBQL(
+  ["field", PRODUCTS.CREATED_AT.id, null],
+  metadata,
+);
+
+const expressionDimension = Dimension.parseMBQL(
+  ["expression", "Hello World"],
+  metadata,
+);
+
+function setup(dimension) {
+  return render(<DimensionInfo dimension={dimension} />);
+}
+
+describe("DimensionInfo", () => {
+  it("should show the given dimension's display name", () => {
+    setup(expressionDimension);
+
+    expect(screen.getByText("Hello World")).toBeInTheDocument();
+  });
+
+  it("should display the given dimension's description", () => {
+    setup(fieldDimension);
+
+    expect(
+      screen.getByText(PRODUCTS.CREATED_AT.description),
+    ).toBeInTheDocument();
+  });
+
+  it("should show a placeholder for a dimension with no description", () => {
+    setup(expressionDimension);
+
+    expect(screen.getByText("No description")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/components/DimensionInfo/index.js
+++ b/frontend/src/metabase/components/DimensionInfo/index.js
@@ -1,0 +1,1 @@
+export { default } from "./DimensionInfo";


### PR DESCRIPTION
Related to #18738

We're building hover cards that show information for a given dimension:
![Screen Shot 2021-11-01 at 1 37 50 PM](https://user-images.githubusercontent.com/13057258/139738688-8be7b069-6762-41dd-a01b-0f454cf141cb.png)

This PR adds the `DimensionInfo` component. We'll be using it as the body of a `Popover`. I thought it'd be nice to keep the logic for this component separate from `Popover` so that `DimensionInfo` can be used in other ways, such as inside of a `Card`.

Right now, I'm only showing a dimension's description and a dimension's `DimensionLabel`. The bottom section, which pulls metadata from the `fingerprint` property, will be added in a later PR.

<img width="867" alt="Screen Shot 2021-11-03 at 9 44 52 AM" src="https://user-images.githubusercontent.com/13057258/140113507-d8fc959d-b099-415a-8b90-d09528a1fe4e.png">

When a dimension lacks a description, it is replaced by a placeholder. Eventually, this placeholder will be replaced with an editable description component (when that is possible).

<img width="768" alt="Screen Shot 2021-11-03 at 9 56 58 AM" src="https://user-images.githubusercontent.com/13057258/140116431-49ddc01d-2d58-4810-9376-e9ebc834acfb.png">


