### PR TITLE
Adopt new migration numbering scheme

### DIFF
--- a/bin/lint-migrations-file/src/change/strict.clj
+++ b/bin/lint-migrations-file/src/change/strict.clj
@@ -29,8 +29,12 @@
    ;; remarks are required for new tables in strict mode
    (s/keys :req-un [:change.strict.create-table/columns ::remarks])))
 
+;; migration should be <= 381 (legacy pre-42 migration numbering scheme) or >= 4200000 (42+ major-minor-id scheme)
+(s/def ::id
+  #(<= 381 % 420000))
+
 (s/def ::change
-  (s/keys :opt-un [::addColumn ::createTable]))
+  (s/keys :opt-un [::addColumn ::createTable ::id]))
 
 (s/def :change.strict.dbms-qualified-sql-change.sql/dbms
   string?)

--- a/bin/lint-migrations-file/src/change/strict.clj
+++ b/bin/lint-migrations-file/src/change/strict.clj
@@ -29,12 +29,8 @@
    ;; remarks are required for new tables in strict mode
    (s/keys :req-un [:change.strict.create-table/columns ::remarks])))
 
-;; migration should be <= 381 (legacy pre-42 migration numbering scheme) or >= 4200000 (42+ major-minor-id scheme)
-(s/def ::id
-  #(<= 381 % 420000))
-
 (s/def ::change
-  (s/keys :opt-un [::addColumn ::createTable ::id]))
+  (s/keys :opt-un [::addColumn ::createTable]))
 
 (s/def :change.strict.dbms-qualified-sql-change.sql/dbms
   string?)

--- a/bin/lint-migrations-file/src/change_set/common.clj
+++ b/bin/lint-migrations-file/src/change_set/common.clj
@@ -4,32 +4,23 @@
 
 ;; See PR #18821 for more info on the new migration ID format adopted in 0.42.0+
 
-(defn- ->int [id]
-  (if (string? id)
-    (Integer/parseUnsignedInt id)
-    id))
+(s/def ::legacy-id
+  ;; some legacy IDs are integers and some are strings. so handle either case.
+  (s/or
+   :int    (s/and int?
+                  #(<= 1 % 382))
+   :string (s/and string?
+                  #(re-matches #"^\d+$" %)
+                  #(<= 1 (Integer/parseUnsignedInt %) 382))))
 
-(defn legacy-id? [id]
-  (<= 1 (->int id) 382))
-
-(defn enough-zeroes? [id]
-  (>= (->int id) 4200000))
-
-(defn not-too-many-zeroes?
-  "Check that the id is less than 9900000 to make sure someone didn't accidentally put an extra zero in there."
-  [id]
-  (< (->int id) 9900000))
-
-(s/def ::id-in-range
-  (s/or :legacy    legacy-id?
-        :new-style (s/and (complement legacy-id?)
-                          enough-zeroes?
-                          not-too-many-zeroes?)))
+(s/def ::new-style-id
+  (s/and string?
+         #(re-matches #"^v\d{2}\.\d{2}-\d{3}$" %)))
 
 (s/def ::id
   (s/or
-   :int        (s/and int? pos? ::id-in-range)
-   :int-string (s/and string? ::id-in-range)))
+   :legacy-id    ::legacy-id
+   :new-style-id ::new-style-id))
 
 (s/def ::author string?)
 

--- a/bin/lint-migrations-file/src/change_set/common.clj
+++ b/bin/lint-migrations-file/src/change_set/common.clj
@@ -3,10 +3,10 @@
             [clojure.string :as str]))
 
 (defn id-in-range?
-  "Migration should be 1-381 (inclusive; legacy pre-42 migration numbering scheme) or >= 4200000 (42+ major-minor-id
+  "Migration should be 1-382 (inclusive; legacy pre-42 migration numbering scheme) or >= 4200000 (42+ major-minor-id
   scheme). See PR #18821 for more info."
   [id]
-  (or (<= 1 id 381)
+  (or (<= 1 id 382)
       ;; check that the id is less than 9900000 to make sure someone didn't accidentally put an extra zero in there.
       (<= 4200000 id 9900000)))
 

--- a/bin/lint-migrations-file/src/change_set/common.clj
+++ b/bin/lint-migrations-file/src/change_set/common.clj
@@ -2,14 +2,23 @@
   (:require [clojure.spec.alpha :as s]
             [clojure.string :as str]))
 
+(defn id-in-range?
+  "Migration should be 1-381 (inclusive; legacy pre-42 migration numbering scheme) or >= 4200000 (42+ major-minor-id
+  scheme). See PR #18821 for more info."
+  [id]
+  (or (<= 1 id 381)
+      ;; check that the id is less than 9900000 to make sure someone didn't accidentally put an extra zero in there.
+      (<= 4200000 id 9900000)))
+
 (s/def ::id
   (s/or
-   :int int?
+   :int (s/and int? id-in-range?)
    :int-string (s/and
                 string?
                 (fn [^String s]
                   (try
-                    (Integer/parseInt s)
+                    (let [id (Integer/parseInt s)]
+                      (id-in-range? id))
                     (catch Throwable _
                       false))))))
 

--- a/bin/lint-migrations-file/src/lint_migrations_file.clj
+++ b/bin/lint-migrations-file/src/lint_migrations_file.clj
@@ -1,5 +1,6 @@
 (ns lint-migrations-file
-  (:require [change-set strict unstrict]
+  (:require change-set.strict
+            change-set.unstrict
             [clojure.java.io :as io]
             [clojure.pprint :as pprint]
             [clojure.spec.alpha :as s]
@@ -16,12 +17,21 @@
 (s/def ::migrations
   (s/keys :req-un [::databaseChangeLog]))
 
-(defn- change-set-ids [change-log]
+;; some change set IDs are integers, and some are strings!!!!!
+
+(defn- maybe-parse-to-int [x]
+  (if (and (string? x)
+           (re-matches #"^\d+$" x))
+    (Integer/parseInt x)
+    x))
+
+(defn- change-set-ids
+  "Get the sequence of all change set IDs. String IDs that can be parsed as integers will be returned as integers;
+  everything else will be returned as a String."
+  [change-log]
   (for [{{id :id} :changeSet} change-log
-        :when                 id]
-    (if (string? id)
-      (Integer/parseInt id)
-      id)))
+        :when id]
+    (maybe-parse-to-int id)))
 
 (defn distinct-change-set-ids? [change-log]
   ;; there are actually two migration 32s, so that's the only exception we're allowing.
@@ -29,9 +39,17 @@
     ;; can't apply distinct? with so many IDs
     (= (count ids) (count (set ids)))))
 
+(defn- compare-ids
+  "If `x` and `y` are integers, compare numerical values. Otherwise do String comparison."
+  [x y]
+  ;; Clojure gets confused if you try to compare a String and a Number.
+  (if (= (class x) (class y))
+    (compare x y)
+    (compare (str x) (str y))))
+
 (defn change-set-ids-in-order? [change-log]
   (let [ids (change-set-ids change-log)]
-    (= ids (sort ids))))
+    (= ids (sort-by identity compare-ids ids))))
 
 ;; TODO -- change sets must be distinct by ID.
 (s/def ::databaseChangeLog
@@ -45,13 +63,11 @@
   172)
 
 (defn change-set-validation-level [{id :id}]
-  (let [id (cond
-             (integer? id) id
-             (string? id)  (Integer/parseInt ^String id)
-             :else         (throw (ex-info "Invalid ID" {:id id})))]
-    (if (>= id strict-change-set-cutoff)
-      :strict
-      :unstrict)))
+  (or (when-let [id (maybe-parse-to-int id)]
+        (when (and (int? id)
+                   (< id strict-change-set-cutoff))
+          :unstrict))
+      :strict))
 
 (defmulti change-set
   change-set-validation-level)
@@ -68,11 +84,11 @@
   (s/multi-spec change-set change-set-validation-level))
 
 (defn validate-migrations [migrations]
-  (when (= (s/conform ::migrations migrations) :clojure.spec.alpha/invalid)
+  (when (= (s/conform ::migrations migrations) ::s/invalid)
     (let [data (s/explain-data ::migrations migrations)]
       (throw (ex-info (str "Validation failed:\n" (with-out-str (pprint/pprint (mapv #(dissoc % :val)
-                                                                                     (:clojure.spec.alpha/problems data)))))
-                      (or (dissoc data :clojure.spec.alpha/value) {})))))
+                                                                                     (::s/problems data)))))
+                      (or (dissoc data ::s/value) {})))))
   :ok)
 
 (def filename

--- a/bin/lint-migrations-file/test/lint_migrations_file_test.clj
+++ b/bin/lint-migrations-file/test/lint_migrations_file_test.clj
@@ -154,28 +154,31 @@
             {:sql {:dbms "postgresql,h2", :sql "2"}}]))))))
 
 (deftest validate-id-test
-  (doseq [[message id-fn] {"number IDs" identity
-                           "string IDs" str}]
-    (testing message
-      (letfn [(validate-id [id]
-                (validate
-                 (mock-change-set
-                  :id (id-fn id))))]
-        (testing "Valid new-style ID"
-          (is (= :ok
-                 (validate-id 4201001))))
-        (testing "Disallow another legacy ID"
+  (letfn [(validate-id [id]
+            (validate (mock-change-set :id id)))]
+    (testing "Valid new-style ID"
+      (is (= :ok
+             (validate-id "v42.00-000"))))
+    (testing "Disallow another legacy ID"
+      ;; should disallow either string *or* number
+      (doseq [id [383 "383"]]
+        (testing (pr-str id)
           (is (thrown-with-msg?
                clojure.lang.ExceptionInfo
-               #"legacy-id\?"
-               (validate-id 383))))
-        (testing "ID that's missing a zero should fail"
-          (is (thrown-with-msg?
-               clojure.lang.ExceptionInfo
-               #"enough-zeroes\?"
-               (validate-id 420101))))
-        (testing "ID with an extra zero should fail"
-          (is (thrown-with-msg?
-               clojure.lang.ExceptionInfo
-               #"not-too-many-zeroes\?"
-               (validate-id 42010001))))))))
+               #"legacy-id"
+               (validate-id id))))))
+    (testing "ID that's missing a zero should fail"
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"new-style-id"
+           (validate-id "v42.01-01"))))
+    (testing "ID with an extra zero should fail"
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"new-style-id"
+           (validate-id "v42.01-0001"))))
+    (testing "Has to start with v"
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"new-style-id"
+           (validate-id "42.01-001"))))))

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -8640,12 +8640,25 @@ databaseChangeLog:
       id: 42000000
       author: camsaul
       comment: Added 0.42.0 Remove unused column
-      # this migration was previously numbered 317 before we adopted the 0.42.0+ migration ID numbering scheme.
+      # this migration was previously numbered 317 and merged into master before we adopted the 0.42.0+ migration ID
+      # numbering scheme. See #18821 for more info.
       preConditions:
         - onFail: MARK_RAN
-        - sqlCheck:
-            expectedResult: 0
-            sql: SELECT count(*) FROM databasechangelog WHERE id = '317';
+        - or:
+            # For some insane reason databasechangelog is upper-case in MySQL and MariaDB.
+            - and:
+                - dbms:
+                    type: postgresql,h2
+                - sqlCheck:
+                    expectedResult: 0
+                    sql: SELECT count(*) FROM databasechangelog WHERE id = '317';
+            - and:
+                - dbms:
+                    type: mysql,mariadb
+                - sqlCheck:
+                    expectedResult: 0
+                    sql: SELECT count(*) FROM `DATABASECHANGELOG` WHERE id = '317';
+
       changes:
         - dropColumn:
             tableName: metabase_table
@@ -8655,12 +8668,23 @@ databaseChangeLog:
       id: 42000003
       author: dpsutton
       comment: Added 0.42.0 Initial support for datasets based on questions
-      # this migration was previously numbered 320 before we adopted the 0.42.0+ migration ID numbering scheme.
+      # this migration was previously numbered 320 and merged into master before we adopted the 0.42.0+ migration ID
+      # numbering scheme. See #18821 for more info.
       preConditions:
         - onFail: MARK_RAN
-        - sqlCheck:
-            expectedResult: 0
-            sql: SELECT count(*) FROM databasechangelog WHERE id = '320';
+        - or:
+            - and:
+                - dbms:
+                    type: postgresql,h2
+                - sqlCheck:
+                    expectedResult: 0
+                    sql: SELECT count(*) FROM databasechangelog WHERE id = '320';
+            - and:
+                - dbms:
+                    type: mysql,mariadb
+                - sqlCheck:
+                    expectedResult: 0
+                    sql: SELECT count(*) FROM `DATABASECHANGELOG` WHERE id = '320';
       changes:
         - addColumn:
             tableName: report_card

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -8637,7 +8637,7 @@ databaseChangeLog:
                   name: card_id
 
   - changeSet:
-      id: 4200000
+      id: v42.00-000
       author: camsaul
       comment: Added 0.42.0 Remove unused column
       # this migration was previously numbered 317 and merged into master before we adopted the 0.42.0+ migration ID
@@ -8665,7 +8665,7 @@ databaseChangeLog:
             columnName: entity_name
 
   - changeSet:
-      id: 4200003
+      id: v42.00-003
       author: dpsutton
       comment: Added 0.42.0 Initial support for datasets based on questions
       # this migration was previously numbered 320 and merged into master before we adopted the 0.42.0+ migration ID
@@ -8713,7 +8713,7 @@ databaseChangeLog:
 #
 # 3) Migrations IDs should follow the format
 #
-#    MMmmNNNN
+#    vMM.mm-NNN
 #
 #    where
 #
@@ -8721,8 +8721,8 @@ databaseChangeLog:
 #    m = minor version
 #    N = migration number relative to that major+minor version
 #
-#   e.g. the first migration added to 0.42.0 should be numbered 4200000 and the second migration should be numbered
-#   4200001. The first migration for 0.42.1 should be numbered 4201000, and so forth.
+#   e.g. the first migration added to 0.42.0 should be numbered v42.00-000 and the second migration should be numbered
+#   v42.00-001. The first migration for 0.42.1 should be numbered v42.01-000, and so forth.
 #
 #   This numbering scheme was adopted beginning with version 0.42.0 so that we could go back and add migrations to patch
 #   releases without the ID sequence getting wildly out of order. See PR #18821 for more information.

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -8625,18 +8625,42 @@ databaseChangeLog:
                     nullable: true
 
   - changeSet:
-      id: 317
+      id: 381
+      author: camsaul
+      comment: Added 0.41.2 Add index to QueryExecution card_id to fix performance issues (#18759)
+      changes:
+        - createIndex:
+            tableName: query_execution
+            indexName: idx_query_execution_card_id
+            columns:
+              - column:
+                  name: card_id
+
+  - changeSet:
+      id: 42000000
       author: camsaul
       comment: Added 0.42.0 Remove unused column
+      # this migration was previously numbered 317 before we adopted the 0.42.0+ migration ID numbering scheme.
+      preConditions:
+        - onFail: MARK_RAN
+        - sqlCheck:
+            expectedResult: 0
+            sql: SELECT count(*) FROM databasechangelog WHERE id = '317';
       changes:
         - dropColumn:
             tableName: metabase_table
             columnName: entity_name
 
   - changeSet:
-      id: 320
+      id: 42000003
       author: dpsutton
       comment: Added 0.42.0 Initial support for datasets based on questions
+      # this migration was previously numbered 317 before we adopted the 0.42.0+ migration ID numbering scheme.
+      preConditions:
+        - onFail: MARK_RAN
+        - sqlCheck:
+            expectedResult: 0
+            sql: SELECT count(*) FROM databasechangelog WHERE id = '320';
       changes:
         - addColumn:
             tableName: report_card
@@ -8649,17 +8673,6 @@ databaseChangeLog:
                     nullable: false
                   defaultValue: false
 
-  - changeSet:
-      id: 381
-      author: camsaul
-      comment: Added 0.41.2 Add index to QueryExecution card_id to fix performance issues (#18759)
-      changes:
-        - createIndex:
-            tableName: query_execution
-            indexName: idx_query_execution_card_id
-            columns:
-              - column:
-                  name: card_id
 
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
@@ -8673,6 +8686,22 @@ databaseChangeLog:
 #
 # 2) Please post a message in the Metabase Slack #migrations channel to let others know you are creating a new
 #    migration so someone else doesn't steal your ID number
+#
+# 3) Migrations IDs should follow the format
+#
+#    MMmmNNNN
+#
+#    where
+#
+#    M = major version
+#    m = minor version
+#    N = migration number relative to that major+minor version
+#
+#   e.g. the first migration added to 0.42.0 should be numbered 4200000 and the second migration should be numbered
+#   4200001. The first migration for 0.42.1 should be numbered 4201000, and so forth.
+#
+#   This numbering scheme was adopted beginning with version 0.42.0 so that we could go back and add migrations to patch
+#   releases without the ID sequence getting wildly out of order.
 #
 # PLEASE KEEP THIS MESSAGE AT THE BOTTOM OF THIS FILE!!!!! Add new migrations above the message.
 #

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -8655,7 +8655,7 @@ databaseChangeLog:
       id: 42000003
       author: dpsutton
       comment: Added 0.42.0 Initial support for datasets based on questions
-      # this migration was previously numbered 317 before we adopted the 0.42.0+ migration ID numbering scheme.
+      # this migration was previously numbered 320 before we adopted the 0.42.0+ migration ID numbering scheme.
       preConditions:
         - onFail: MARK_RAN
         - sqlCheck:
@@ -8701,7 +8701,7 @@ databaseChangeLog:
 #   4200001. The first migration for 0.42.1 should be numbered 4201000, and so forth.
 #
 #   This numbering scheme was adopted beginning with version 0.42.0 so that we could go back and add migrations to patch
-#   releases without the ID sequence getting wildly out of order.
+#   releases without the ID sequence getting wildly out of order. See PR #18821 for more information.
 #
 # PLEASE KEEP THIS MESSAGE AT THE BOTTOM OF THIS FILE!!!!! Add new migrations above the message.
 #

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -8637,7 +8637,7 @@ databaseChangeLog:
                   name: card_id
 
   - changeSet:
-      id: 42000000
+      id: 4200000
       author: camsaul
       comment: Added 0.42.0 Remove unused column
       # this migration was previously numbered 317 and merged into master before we adopted the 0.42.0+ migration ID
@@ -8665,7 +8665,7 @@ databaseChangeLog:
             columnName: entity_name
 
   - changeSet:
-      id: 42000003
+      id: 4200003
       author: dpsutton
       comment: Added 0.42.0 Initial support for datasets based on questions
       # this migration was previously numbered 320 and merged into master before we adopted the 0.42.0+ migration ID

--- a/test/metabase/db/schema_migrations_test/impl.clj
+++ b/test/metabase/db/schema_migrations_test/impl.clj
@@ -80,6 +80,51 @@
   [[conn-binding db-type] & body]
   `(do-with-temp-empty-app-db ~db-type (fn [~(vary-meta conn-binding assoc :tag 'java.sql.Connection)] ~@body)))
 
+;; all legacy (numeric) IDs should come before all `v___` IDs so just convert them to prefixed strings so we can do
+;; string comparison.
+(defn- migration-id->str [id]
+  (cond
+    (and (string? id)
+         (re-matches #"^\d+$" id))
+    (recur (Integer/parseUnsignedInt id))
+
+    (integer? id)
+    (format "legacy-%03d" id)
+
+    (string? id)
+    id))
+
+(defn- migration-id-in-range?
+  "Whether `id` should be considered to be between `start-id` and `end-id`, inclusive. Handles both legacy plain-integer
+  and new-style `vMM.mm-NNN` style IDs."
+  [start-id id end-id]
+  (let [start-id (migration-id->str start-id)
+        end-id   (migration-id->str end-id)
+        id       (migration-id->str id)]
+    (= (sort [start-id id end-id])
+       [start-id id end-id])))
+
+(deftest migration-id-in-range?-test
+  (testing "legacy IDs"
+    (is (migration-id-in-range? 1 2 3))
+    (is (migration-id-in-range? 1 1 3))
+    (is (migration-id-in-range? 1 3 3))
+    (is (not (migration-id-in-range? 2 1 3)))
+    (is (not (migration-id-in-range? 2 4 3)))
+    (testing "strings"
+      (is (migration-id-in-range? 1 "1" 3))
+      (is (not (migration-id-in-range? 1 "13" 3)))))
+  (testing "new-style IDs"
+    (is (migration-id-in-range? "v42.00-001" "v42.00-002" "v42.00-003"))
+    (is (not (migration-id-in-range? "v42.00-001" "v42.00-004" "v42.00-003")))
+    (is (not (migration-id-in-range? "v42.00-002" "v42.00-001" "v42.00-003"))))
+  (testing "mixed"
+    (is (migration-id-in-range? 1 3 "v42.00-001"))
+    (is (migration-id-in-range? 1 "v42.00-001" "v42.00-002"))
+    (is (not (migration-id-in-range? "v42.00-002" 1000 "v42.00-003")))
+    (is (not (migration-id-in-range? 1 "v42.00-001" 1000)))
+    (is (not (migration-id-in-range? 1 "v42.00-001" 1000)))))
+
 (defn run-migrations-in-range!
   "Run Liquibase migrations from our migrations YAML file in the range of `start-id` -> `end-id` (inclusive) against a
   DB with `jdbc-spec`."
@@ -93,8 +138,8 @@
                               (.setPhysicalFilePath (.getPhysicalFilePath change-log)))]
       ;; add the relevant migrations (change sets) to our subset change log
       (doseq [^ChangeSet change-set (.getChangeSets change-log)
-              :let                  [id (Integer/parseUnsignedInt (.getId change-set))]
-              :when                 (<= start-id id end-id)]
+              :let                  [id (.getId change-set)]
+              :when                 (migration-id-in-range? start-id id end-id)]
         (.addChangeSet subset-change-log change-set))
       ;; now create a new instance of Liquibase that will run just the subset change log
       (let [subset-liquibase (Liquibase. subset-change-log (.getResourceAccessor liquibase) (.getDatabase liquibase))]
@@ -118,7 +163,7 @@
     (f #(run-migrations-in-range! conn [start-id end-id])))
   (log/debug (u/format-color 'green "Done testing migrations for driver %s." driver)))
 
-(defn test-migrations*
+(defn do-test-migrations
   [migration-range f]
   ;; make sure the normal Metabase application DB is set up before running the tests so things don't get confused and
   ;; try to initialize it while the mock DB is bound
@@ -136,9 +181,9 @@
   Before invoking body, migrations up to `start-id` are automatically ran. In body, you should do the following in
   this order:
 
-  1. Load data and check any preconditions before running migrations you're testing. Prefer `toucan.db/simple-insert!`
-     or plain SQL for loading data to avoid dependencies on the current state of the schema that may be present in
-     Toucan `pre-insert` functions and the like.
+  1. Load data and check any preconditions before running migrations you're testing.
+     Prefer [[toucan.db/simple-insert!]] or plain SQL for loading data to avoid dependencies on the current state of
+     the schema that may be present in Toucan `pre-insert` functions and the like.
 
   2. Call `(migrate!)` to run migrations in range of `start-id` -> `end-id` (inclusive)
 
@@ -160,10 +205,10 @@
   single migration ID (e.g. `100`).
 
   These run against the current set of test `DRIVERS` (by default H2), so if you want to run against more than H2
-  either set the `DRIVERS` env var or use `mt/set-test-drivers!` from the REPL."
+  either set the `DRIVERS` env var or use [[mt/set-test-drivers!]] from the REPL."
   {:style/indent 2}
   [migration-range [migrate!-binding] & body]
-  `(test-migrations*
+  `(do-test-migrations
     ~migration-range
     (fn [~migrate!-binding]
       ~@body)))


### PR DESCRIPTION
New migration numbering scheme. Context:

We want to backport the migrations to add indexes I did in https://github.com/metabase/metabase/pull/18798 and https://github.com/metabase/metabase/pull/18799 to 0.41.2 since they solve performance issues. The slightly weird thing is their numbers are going to be off: `316` was the last 0.41.0 migration and `317` was the first 42.0 migration, but these new ones will end up being `381` and `382` respectively.

The migration ID is mostly used by Liquibase to determine what order to run unrun migrations in. So it actually won't matter if we run `316`, then `381`, then `382`, then hang out for a bit and then run `317`, `318`, and so forth.

In this particular case `381` and `382` _would_ work fine regardless of whether they run after `316` or after `380`.
I'm not sure we'll be so lucky going forward. Hence the immediate adoption of the new migration ID format for all migrations in x.42.0+. The new format is:

```
vMM.mm-NNN
```
where

```
M = major version
m = minor version
N = migration number relative to that major+minor version
```
e.g. the first migration added to 0.42.0 should be numbered `v42.00-000` and the second migration should be numbered
`v42.00-001`. The first migration for 0.42.1 should be numbered `v42.01-000`, and so forth.

At the time of this decision there were only two 0.42.0 migrations already merged in; there are however a lot of outstanding ones. This PR changes the ones that are already merged in to use the new format. 