### PR TITLE
Add visual tests for table visualisation

### DIFF
--- a/frontend/test/metabase-visual/visualizations/table.cy.spec.js
+++ b/frontend/test/metabase-visual/visualizations/table.cy.spec.js
@@ -1,0 +1,32 @@
+import { restore, openOrdersTable, modal } from "__support__/e2e/cypress";
+
+describe("visual tests > visualizations > table", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsNormalUser();
+    cy.intercept("POST", "/api/dataset").as("dataset");
+  });
+
+  it("ad-hoc", () => {
+    openOrdersTable();
+    cy.wait("@dataset");
+    cy.percySnapshot();
+  });
+
+  it("saved", () => {
+    openOrdersTable();
+    cy.wait("@dataset");
+    saveQuestion();
+    cy.percySnapshot();
+  });
+});
+
+function saveQuestion() {
+  cy.findByText("Save").click();
+  modal().within(() => {
+    cy.button("Save").click();
+  });
+  modal()
+    .findByText("Not now")
+    .click();
+}

--- a/frontend/test/metabase-visual/visualizations/table.cy.spec.js
+++ b/frontend/test/metabase-visual/visualizations/table.cy.spec.js
@@ -2,20 +2,20 @@ import { restore, openOrdersTable, modal } from "__support__/e2e/cypress";
 
 describe("visual tests > visualizations > table", () => {
   beforeEach(() => {
+    cy.intercept("POST", "/api/dataset").as("dataset");
     restore();
     cy.signInAsNormalUser();
-    cy.intercept("POST", "/api/dataset").as("dataset");
+
+    openOrdersTable();
+    cy.wait("@dataset");
+    cy.findByTestId("loading-spinner").should("not.exist");
   });
 
   it("ad-hoc", () => {
-    openOrdersTable();
-    cy.wait("@dataset");
     cy.percySnapshot();
   });
 
   it("saved", () => {
-    openOrdersTable();
-    cy.wait("@dataset");
     saveQuestion();
     cy.percySnapshot();
   });


### PR DESCRIPTION
This PR adds a visual test for ad-hoc and saved GUI questions showing orders table without any filters, summarisations, etc.

### Demo

**Ad-hoc**

<img width="1919" alt="ad-hoc" src="https://user-images.githubusercontent.com/17258145/140049096-cb8785ac-af02-461d-86cc-331a9277d60e.png">

**Saved**

<img width="1920" alt="saved" src="https://user-images.githubusercontent.com/17258145/140049084-82385940-4170-4594-9878-bf6f165e58cc.png">


