### PR TITLE
Refactor question ViewHeader component

### DIFF
--- a/frontend/src/metabase/hooks/use-toggle.ts
+++ b/frontend/src/metabase/hooks/use-toggle.ts
@@ -1,0 +1,13 @@
+import { useState, useCallback } from "react";
+
+export function useToggle(initialValue = false) {
+  const [value, setValue] = useState(initialValue);
+
+  const turnOn = useCallback(() => setValue(true), []);
+
+  const turnOff = useCallback(() => setValue(false), []);
+
+  const toggle = useCallback(() => setValue(current => !current), []);
+
+  return [value, { turnOn, turnOff, toggle }];
+}

--- a/frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx
@@ -50,6 +50,7 @@ export default function QuestionFilters({
                 ? `View Mode; Header Filters Collapse Click`
                 : `View Mode; Header Filters Expand Click`
             }
+            data-testid="filters-visibility-control"
           >
             {expanded ? null : filters.length}
           </FilterPill>

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -24,10 +24,12 @@ import QuestionNotebookButton from "./QuestionNotebookButton";
 import QuestionFilters, { QuestionFilterWidget } from "./QuestionFilters";
 import { QuestionSummarizeWidget } from "./QuestionSummaries";
 import NativeQueryButton from "./NativeQueryButton";
-import ViewSection, { ViewHeading, ViewSubHeading } from "./ViewSection";
+import ViewSection, { ViewHeading } from "./ViewSection";
 import {
   SaveButton,
   SavedQuestionHeaderButtonContainer,
+  ViewHeaderMainLeftContentContainer,
+  ViewHeaderLeftSubHeading,
   ViewHeaderContainer,
   ViewSQLButtonContainer,
 } from "./ViewHeader.styled";
@@ -168,7 +170,7 @@ function SavedQuestionLeftSide(props) {
   } = props;
   return (
     <div>
-      <div className="flex align-center">
+      <ViewHeaderMainLeftContentContainer>
         <SavedQuestionHeaderButtonContainer>
           <SavedQuestionHeaderButton
             question={question}
@@ -187,8 +189,8 @@ function SavedQuestionLeftSide(props) {
             onClick={onOpenQuestionHistory}
           />
         )}
-      </div>
-      <ViewSubHeading className="flex align-center flex-wrap pt1">
+      </ViewHeaderMainLeftContentContainer>
+      <ViewHeaderLeftSubHeading className="pt1">
         <CollectionBadge
           className="mb1"
           collectionId={question.collectionId()}
@@ -210,7 +212,7 @@ function SavedQuestionLeftSide(props) {
             onCollapse={onCollapseFilters}
           />
         )}
-      </ViewSubHeading>
+      </ViewHeaderLeftSubHeading>
     </div>
   );
 }
@@ -241,7 +243,7 @@ function AhHocQuestionLeftSide(props) {
   } = props;
   return (
     <div>
-      <div className="flex align-baseline flex-wrap">
+      <ViewHeaderMainLeftContentContainer>
         <ViewHeading className="mt1 mr2 mb1">
           {isNative ? (
             t`New question`
@@ -268,8 +270,8 @@ function AhHocQuestionLeftSide(props) {
             originalQuestion={originalQuestion}
           />
         )}
-      </div>
-      <div className="flex align-center flex-wrap">
+      </ViewHeaderMainLeftContentContainer>
+      <ViewHeaderLeftSubHeading>
         {isSummarized && (
           <QuestionDataSource
             className="mb1"
@@ -288,7 +290,7 @@ function AhHocQuestionLeftSide(props) {
             onCollapse={onCollapseFilters}
           />
         )}
-      </div>
+      </ViewHeaderLeftSubHeading>
     </div>
   );
 }

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -24,8 +24,9 @@ import QuestionNotebookButton from "./QuestionNotebookButton";
 import QuestionFilters, { QuestionFilterWidget } from "./QuestionFilters";
 import { QuestionSummarizeWidget } from "./QuestionSummaries";
 import NativeQueryButton from "./NativeQueryButton";
-import ViewSection, { ViewHeading } from "./ViewSection";
+import ViewSection from "./ViewSection";
 import {
+  AdHocViewHeading,
   SaveButton,
   SavedQuestionHeaderButtonContainer,
   ViewHeaderMainLeftContentContainer,
@@ -244,7 +245,7 @@ function AhHocQuestionLeftSide(props) {
   return (
     <div>
       <ViewHeaderMainLeftContentContainer align="baseline">
-        <ViewHeading className="mt1 mr2 mb1">
+        <AdHocViewHeading>
           {isNative ? (
             t`New question`
           ) : (
@@ -253,7 +254,7 @@ function AhHocQuestionLeftSide(props) {
               isObjectDetail={isObjectDetail}
             />
           )}
-        </ViewHeading>
+        </AdHocViewHeading>
         {showFiltersInHeading && QuestionFilters.shouldRender(props) && (
           <QuestionFilters
             className="mr2 mb1"

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -72,35 +72,7 @@ const viewTitleHeaderPropTypes = {
 };
 
 export function ViewTitleHeader(props) {
-  const {
-    className,
-    style,
-    question,
-    onOpenModal,
-    originalQuestion,
-    isDirty,
-    queryBuilderMode,
-    setQueryBuilderMode,
-    result,
-    isRunnable,
-    isRunning,
-    isResultDirty,
-    isPreviewing,
-    isNativeEditorOpen,
-    runQuestionQuery,
-    cancelQuery,
-    isShowingSummarySidebar,
-    onEditSummary,
-    onCloseSummary,
-    isShowingFilterSidebar,
-    onAddFilter,
-    onCloseFilter,
-    isShowingQuestionDetailsSidebar,
-    onOpenQuestionDetails,
-    onCloseQuestionDetails,
-    onOpenQuestionHistory,
-    isObjectDetail,
-  } = props;
+  const { question, className, style } = props;
 
   const [
     areFiltersExpanded,
@@ -122,7 +94,6 @@ export function ViewTitleHeader(props) {
     }
   }, [previousQuestion, question, expandFilters]);
 
-  const isShowingNotebook = queryBuilderMode === "notebook";
   const lastEditInfo = question.lastEditInfo();
 
   const isStructured = question.isStructured();
@@ -141,183 +112,315 @@ export function ViewTitleHeader(props) {
   return (
     <ViewHeaderContainer className={className} style={style}>
       {isSaved ? (
-        <div>
-          <div className="flex align-center">
-            <SavedQuestionHeaderButtonContainer>
-              <SavedQuestionHeaderButton
-                question={question}
-                isActive={isShowingQuestionDetailsSidebar}
-                onClick={
-                  isShowingQuestionDetailsSidebar
-                    ? onCloseQuestionDetails
-                    : onOpenQuestionDetails
-                }
-              />
-            </SavedQuestionHeaderButtonContainer>
-            {lastEditInfo && (
-              <LastEditInfoLabel
-                className="ml1 text-light"
-                item={question.card()}
-                onClick={onOpenQuestionHistory}
-              />
-            )}
-          </div>
-          <ViewSubHeading className="flex align-center flex-wrap pt1">
-            <CollectionBadge
-              className="mb1"
-              collectionId={question.collectionId()}
-            />
-
-            {QuestionDataSource.shouldRender(props) && (
-              <QuestionDataSource
-                className="ml3 mb1"
-                question={question}
-                isObjectDetail={isObjectDetail}
-                subHead
-              />
-            )}
-
-            {QuestionFilters.shouldRender(props) && (
-              <QuestionFilters
-                className="mb1"
-                question={question}
-                expanded={areFiltersExpanded}
-                onExpand={expandFilters}
-                onCollapse={collapseFilters}
-              />
-            )}
-          </ViewSubHeading>
-        </div>
+        <SavedQuestionLeftSide
+          {...props}
+          lastEditInfo={lastEditInfo}
+          areFiltersExpanded={areFiltersExpanded}
+          onExpandFilters={expandFilters}
+          onCollapseFilters={collapseFilters}
+        />
       ) : (
-        <div>
-          <div className="flex align-baseline flex-wrap">
-            <ViewHeading className="mt1 mr2 mb1">
-              {isNative ? (
-                t`New question`
-              ) : (
-                <QuestionDescription
-                  question={question}
-                  isObjectDetail={isObjectDetail}
-                />
-              )}
-            </ViewHeading>
-            {showFiltersInHeading && QuestionFilters.shouldRender(props) && (
-              <QuestionFilters
-                className="mr2 mb1"
-                question={question}
-                expanded={areFiltersExpanded}
-                onExpand={expandFilters}
-                onCollapse={collapseFilters}
-              />
-            )}
-            {QuestionLineage.shouldRender(props) && (
-              <QuestionLineage
-                className="mr2 mb1"
-                question={question}
-                originalQuestion={originalQuestion}
-              />
-            )}
-          </div>
-          <div className="flex align-center flex-wrap">
-            {isSummarized && (
-              <QuestionDataSource
-                className="mb1"
-                question={question}
-                isObjectDetail={isObjectDetail}
-                subHead
-                data-metabase-event={`Question Data Source Click`}
-              />
-            )}
-            {!showFiltersInHeading && QuestionFilters.shouldRender(props) && (
-              <QuestionFilters
-                className="mb1"
-                question={question}
-                expanded={areFiltersExpanded}
-                onExpand={expandFilters}
-                onCollapse={collapseFilters}
-              />
-            )}
-          </div>
-        </div>
+        <AhHocQuestionLeftSide
+          {...props}
+          isNative={isNative}
+          isSummarized={isSummarized}
+          areFiltersExpanded={areFiltersExpanded}
+          showFiltersInHeading={showFiltersInHeading}
+          onExpandFilters={expandFilters}
+          onCollapseFilters={collapseFilters}
+        />
       )}
-      <div className="ml-auto flex align-center">
-        {!!isDirty && (
-          <SaveButton
-            disabled={!question.canRun()}
-            data-metabase-event={
-              isShowingNotebook
-                ? `Notebook Mode; Click Save`
-                : `View Mode; Click Save`
-            }
-            onClick={() => onOpenModal("save")}
-          >
-            {t`Save`}
-          </SaveButton>
-        )}
-        {QuestionFilterWidget.shouldRender(props) && (
-          <QuestionFilterWidget
-            className="hide sm-show"
-            ml={1}
-            isShowingFilterSidebar={isShowingFilterSidebar}
-            onAddFilter={onAddFilter}
-            onCloseFilter={onCloseFilter}
-            data-metabase-event={`View Mode; Open Filter Widget`}
-          />
-        )}
-        {QuestionSummarizeWidget.shouldRender(props) && (
-          <QuestionSummarizeWidget
-            className="hide sm-show"
-            ml={1}
-            isShowingSummarySidebar={isShowingSummarySidebar}
-            onEditSummary={onEditSummary}
-            onCloseSummary={onCloseSummary}
-            data-metabase-event={`View Mode; Open Summary Widget`}
-          />
-        )}
-        {QuestionNotebookButton.shouldRender({ question }) && (
-          <QuestionNotebookButton
-            className="hide sm-show"
-            ml={2}
+      <ViewTitleHeaderRightSide
+        {...props}
+        isSaved={isSaved}
+        isNative={isNative}
+        isSummarized={isSummarized}
+      />
+    </ViewHeaderContainer>
+  );
+}
+
+SavedQuestionLeftSide.propTypes = {
+  question: PropTypes.object.isRequired,
+  lastEditInfo: PropTypes.object,
+  areFiltersExpanded: PropTypes.bool.isRequired,
+  isShowingQuestionDetailsSidebar: PropTypes.bool,
+  isObjectDetail: PropTypes.bool,
+  onExpandFilters: PropTypes.func.isRequired,
+  onCollapseFilters: PropTypes.func.isRequired,
+  onOpenQuestionDetails: PropTypes.func.isRequired,
+  onCloseQuestionDetails: PropTypes.func.isRequired,
+  onOpenQuestionHistory: PropTypes.func.isRequired,
+};
+
+function SavedQuestionLeftSide(props) {
+  const {
+    question,
+    areFiltersExpanded,
+    isObjectDetail,
+    isShowingQuestionDetailsSidebar,
+    onExpandFilters,
+    onCollapseFilters,
+    onOpenQuestionDetails,
+    onCloseQuestionDetails,
+    lastEditInfo,
+    onOpenQuestionHistory,
+  } = props;
+  return (
+    <div>
+      <div className="flex align-center">
+        <SavedQuestionHeaderButtonContainer>
+          <SavedQuestionHeaderButton
             question={question}
-            isShowingNotebook={isShowingNotebook}
-            setQueryBuilderMode={setQueryBuilderMode}
-            data-metabase-event={
-              isShowingNotebook
-                ? `Notebook Mode;Go to View Mode`
-                : `View Mode; Go to Notebook Mode`
+            isActive={isShowingQuestionDetailsSidebar}
+            onClick={
+              isShowingQuestionDetailsSidebar
+                ? onCloseQuestionDetails
+                : onOpenQuestionDetails
             }
           />
-        )}
-        {NativeQueryButton.shouldRender(props) && (
-          <ViewSQLButtonContainer>
-            <NativeQueryButton
-              size={16}
-              question={question}
-              data-metabase-event={`Notebook Mode; Convert to SQL Click`}
-            />
-          </ViewSQLButtonContainer>
-        )}
-        {isNative && isSaved && <ExploreResultsLink question={question} />}
-        {isRunnable && !isNativeEditorOpen && (
-          <RunButtonWithTooltip
-            className={cx("text-brand-hover hide", {
-              "sm-show": !isShowingNotebook || isNative,
-              "text-white-hover": isResultDirty,
-            })}
-            medium
-            borderless
-            ml={1}
-            compact
-            result={result}
-            isRunning={isRunning}
-            isDirty={isResultDirty}
-            isPreviewing={isPreviewing}
-            onRun={() => runQuestionQuery({ ignoreCache: true })}
-            onCancel={cancelQuery}
+        </SavedQuestionHeaderButtonContainer>
+        {lastEditInfo && (
+          <LastEditInfoLabel
+            className="ml1 text-light"
+            item={question.card()}
+            onClick={onOpenQuestionHistory}
           />
         )}
       </div>
-    </ViewHeaderContainer>
+      <ViewSubHeading className="flex align-center flex-wrap pt1">
+        <CollectionBadge
+          className="mb1"
+          collectionId={question.collectionId()}
+        />
+        {QuestionDataSource.shouldRender(props) && (
+          <QuestionDataSource
+            className="ml3 mb1"
+            question={question}
+            isObjectDetail={isObjectDetail}
+            subHead
+          />
+        )}
+        {QuestionFilters.shouldRender(props) && (
+          <QuestionFilters
+            className="mb1"
+            question={question}
+            expanded={areFiltersExpanded}
+            onExpand={onExpandFilters}
+            onCollapse={onCollapseFilters}
+          />
+        )}
+      </ViewSubHeading>
+    </div>
+  );
+}
+
+AhHocQuestionLeftSide.propTypes = {
+  question: PropTypes.object.isRequired,
+  originalQuestion: PropTypes.object,
+  isNative: PropTypes.bool,
+  isObjectDetail: PropTypes.bool,
+  isSummarized: PropTypes.bool,
+  areFiltersExpanded: PropTypes.bool,
+  showFiltersInHeading: PropTypes.bool,
+  onExpandFilters: PropTypes.func.isRequired,
+  onCollapseFilters: PropTypes.func.isRequired,
+};
+
+function AhHocQuestionLeftSide(props) {
+  const {
+    question,
+    originalQuestion,
+    isNative,
+    isObjectDetail,
+    isSummarized,
+    areFiltersExpanded,
+    showFiltersInHeading,
+    onExpandFilters,
+    onCollapseFilters,
+  } = props;
+  return (
+    <div>
+      <div className="flex align-baseline flex-wrap">
+        <ViewHeading className="mt1 mr2 mb1">
+          {isNative ? (
+            t`New question`
+          ) : (
+            <QuestionDescription
+              question={question}
+              isObjectDetail={isObjectDetail}
+            />
+          )}
+        </ViewHeading>
+        {showFiltersInHeading && QuestionFilters.shouldRender(props) && (
+          <QuestionFilters
+            className="mr2 mb1"
+            question={question}
+            expanded={areFiltersExpanded}
+            onExpand={onExpandFilters}
+            onCollapse={onCollapseFilters}
+          />
+        )}
+        {QuestionLineage.shouldRender(props) && (
+          <QuestionLineage
+            className="mr2 mb1"
+            question={question}
+            originalQuestion={originalQuestion}
+          />
+        )}
+      </div>
+      <div className="flex align-center flex-wrap">
+        {isSummarized && (
+          <QuestionDataSource
+            className="mb1"
+            question={question}
+            isObjectDetail={isObjectDetail}
+            subHead
+            data-metabase-event={`Question Data Source Click`}
+          />
+        )}
+        {!showFiltersInHeading && QuestionFilters.shouldRender(props) && (
+          <QuestionFilters
+            className="mb1"
+            question={question}
+            expanded={areFiltersExpanded}
+            onExpand={onExpandFilters}
+            onCollapse={onCollapseFilters}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+ViewTitleHeaderRightSide.propTypes = {
+  question: PropTypes.object.isRequired,
+  result: PropTypes.object,
+  queryBuilderMode: PropTypes.oneOf(["view", "notebook"]),
+  isSaved: PropTypes.bool,
+  isNative: PropTypes.bool,
+  isRunnable: PropTypes.bool,
+  isRunning: PropTypes.bool,
+  isPreviewing: PropTypes.bool,
+  isNativeEditorOpen: PropTypes.bool,
+  isShowingFilterSidebar: PropTypes.bool,
+  isShowingSummarySidebar: PropTypes.bool,
+  isDirty: PropTypes.bool,
+  isResultDirty: PropTypes.bool,
+  runQuestionQuery: PropTypes.func,
+  cancelQuery: PropTypes.func,
+  onOpenModal: PropTypes.func,
+  onAddFilter: PropTypes.func,
+  onCloseFilter: PropTypes.func,
+  onEditSummary: PropTypes.func,
+  onCloseSummary: PropTypes.func,
+  setQueryBuilderMode: PropTypes.func,
+};
+
+function ViewTitleHeaderRightSide(props) {
+  const {
+    question,
+    result,
+    queryBuilderMode,
+    isSaved,
+    isNative,
+    isRunnable,
+    isRunning,
+    isPreviewing,
+    isNativeEditorOpen,
+    isShowingFilterSidebar,
+    isShowingSummarySidebar,
+    isDirty,
+    isResultDirty,
+    runQuestionQuery,
+    cancelQuery,
+    onOpenModal,
+    onAddFilter,
+    onCloseFilter,
+    onEditSummary,
+    onCloseSummary,
+    setQueryBuilderMode,
+  } = props;
+  const isShowingNotebook = queryBuilderMode === "notebook";
+
+  return (
+    <div className="ml-auto flex align-center">
+      {!!isDirty && (
+        <SaveButton
+          disabled={!question.canRun()}
+          data-metabase-event={
+            isShowingNotebook
+              ? `Notebook Mode; Click Save`
+              : `View Mode; Click Save`
+          }
+          onClick={() => onOpenModal("save")}
+        >
+          {t`Save`}
+        </SaveButton>
+      )}
+      {QuestionFilterWidget.shouldRender(props) && (
+        <QuestionFilterWidget
+          className="hide sm-show"
+          ml={1}
+          isShowingFilterSidebar={isShowingFilterSidebar}
+          onAddFilter={onAddFilter}
+          onCloseFilter={onCloseFilter}
+          data-metabase-event={`View Mode; Open Filter Widget`}
+        />
+      )}
+      {QuestionSummarizeWidget.shouldRender(props) && (
+        <QuestionSummarizeWidget
+          className="hide sm-show"
+          ml={1}
+          isShowingSummarySidebar={isShowingSummarySidebar}
+          onEditSummary={onEditSummary}
+          onCloseSummary={onCloseSummary}
+          data-metabase-event={`View Mode; Open Summary Widget`}
+        />
+      )}
+      {QuestionNotebookButton.shouldRender({ question }) && (
+        <QuestionNotebookButton
+          className="hide sm-show"
+          ml={2}
+          question={question}
+          isShowingNotebook={isShowingNotebook}
+          setQueryBuilderMode={setQueryBuilderMode}
+          data-metabase-event={
+            isShowingNotebook
+              ? `Notebook Mode;Go to View Mode`
+              : `View Mode; Go to Notebook Mode`
+          }
+        />
+      )}
+      {NativeQueryButton.shouldRender(props) && (
+        <ViewSQLButtonContainer>
+          <NativeQueryButton
+            size={16}
+            question={question}
+            data-metabase-event={`Notebook Mode; Convert to SQL Click`}
+          />
+        </ViewSQLButtonContainer>
+      )}
+      {isNative && isSaved && <ExploreResultsLink question={question} />}
+      {isRunnable && !isNativeEditorOpen && (
+        <RunButtonWithTooltip
+          className={cx("text-brand-hover hide", {
+            "sm-show": !isShowingNotebook || isNative,
+            "text-white-hover": isResultDirty,
+          })}
+          medium
+          borderless
+          ml={1}
+          compact
+          result={result}
+          isRunning={isRunning}
+          isDirty={isResultDirty}
+          isPreviewing={isPreviewing}
+          onRun={() => runQuestionQuery({ ignoreCache: true })}
+          onCancel={cancelQuery}
+        />
+      )}
+    </div>
   );
 }
 

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -243,7 +243,7 @@ function AhHocQuestionLeftSide(props) {
   } = props;
   return (
     <div>
-      <ViewHeaderMainLeftContentContainer>
+      <ViewHeaderMainLeftContentContainer align="baseline">
         <ViewHeading className="mt1 mr2 mb1">
           {isNative ? (
             t`New question`

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -2,7 +2,6 @@ import React, { useEffect } from "react";
 import PropTypes from "prop-types";
 import { t } from "ttag";
 import cx from "classnames";
-import { Box } from "grid-styled";
 
 import ButtonBar from "metabase/components/ButtonBar";
 import CollectionBadge from "metabase/questions/components/CollectionBadge";
@@ -26,7 +25,12 @@ import QuestionFilters, { QuestionFilterWidget } from "./QuestionFilters";
 import { QuestionSummarizeWidget } from "./QuestionSummaries";
 import NativeQueryButton from "./NativeQueryButton";
 import ViewSection, { ViewHeading, ViewSubHeading } from "./ViewSection";
-import { SavedQuestionHeaderButtonContainer } from "./ViewHeader.styled";
+import {
+  SaveButton,
+  SavedQuestionHeaderButtonContainer,
+  ViewHeaderContainer,
+  ViewSQLButtonContainer,
+} from "./ViewHeader.styled";
 
 const viewTitleHeaderPropTypes = {
   question: PropTypes.object.isRequired,
@@ -135,11 +139,7 @@ export function ViewTitleHeader(props) {
   const showFiltersInHeading = !isSummarized && !areFiltersExpanded;
 
   return (
-    <ViewSection
-      className={cx("border-bottom", className)}
-      style={style}
-      py={[1]}
-    >
+    <ViewHeaderContainer className={className} style={style}>
       {isSaved ? (
         <div>
           <div className="flex align-center">
@@ -241,10 +241,9 @@ export function ViewTitleHeader(props) {
         </div>
       )}
       <div className="ml-auto flex align-center">
-        {isDirty ? (
-          <Link
+        {!!isDirty && (
+          <SaveButton
             disabled={!question.canRun()}
-            className="text-brand text-bold py1 px2 rounded bg-white bg-light-hover"
             data-metabase-event={
               isShowingNotebook
                 ? `Notebook Mode; Click Save`
@@ -253,8 +252,8 @@ export function ViewTitleHeader(props) {
             onClick={() => onOpenModal("save")}
           >
             {t`Save`}
-          </Link>
-        ) : null}
+          </SaveButton>
+        )}
         {QuestionFilterWidget.shouldRender(props) && (
           <QuestionFilterWidget
             className="hide sm-show"
@@ -290,36 +289,20 @@ export function ViewTitleHeader(props) {
           />
         )}
         {NativeQueryButton.shouldRender(props) && (
-          <Box
-            ml={2}
-            p={1}
-            className="text-medium text-brand-hover cursor-pointer"
-          >
+          <ViewSQLButtonContainer>
             <NativeQueryButton
               size={16}
               question={question}
               data-metabase-event={`Notebook Mode; Convert to SQL Click`}
             />
-          </Box>
+          </ViewSQLButtonContainer>
         )}
-        {question.query().database() && isNative && isSaved && (
-          <Link
-            to={question
-              .composeThisQuery()
-              .setDisplay("table")
-              .setSettings({})
-              .getUrl()}
-          >
-            <ViewButton medium p={[2, 1]} icon="insight" labelBreakpoint="sm">
-              {t`Explore results`}
-            </ViewButton>
-          </Link>
-        )}
+        {isNative && isSaved && <ExploreResultsLink question={question} />}
         {isRunnable && !isNativeEditorOpen && (
           <RunButtonWithTooltip
             className={cx("text-brand-hover hide", {
               "sm-show": !isShowingNotebook || isNative,
-              "text-white-hover": isResultDirty && isRunnable,
+              "text-white-hover": isResultDirty,
             })}
             medium
             borderless
@@ -330,11 +313,31 @@ export function ViewTitleHeader(props) {
             isDirty={isResultDirty}
             isPreviewing={isPreviewing}
             onRun={() => runQuestionQuery({ ignoreCache: true })}
-            onCancel={() => cancelQuery()}
+            onCancel={cancelQuery}
           />
         )}
       </div>
-    </ViewSection>
+    </ViewHeaderContainer>
+  );
+}
+
+ExploreResultsLink.propTypes = {
+  question: PropTypes.object.isRequired,
+};
+
+function ExploreResultsLink({ question }) {
+  const url = question
+    .composeThisQuery()
+    .setDisplay("table")
+    .setSettings({})
+    .getUrl();
+
+  return (
+    <Link to={url}>
+      <ViewButton medium p={[2, 1]} icon="insight" labelBreakpoint="sm">
+        {t`Explore results`}
+      </ViewButton>
+    </Link>
   );
 }
 

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useCallback, useState } from "react";
 import PropTypes from "prop-types";
 import { t } from "ttag";
 import cx from "classnames";
@@ -12,6 +12,9 @@ import SavedQuestionHeaderButton from "metabase/query_builder/components/SavedQu
 import ViewSection, { ViewHeading, ViewSubHeading } from "./ViewSection";
 import ViewButton from "metabase/query_builder/components/view/ViewButton";
 
+import { usePrevious } from "metabase/hooks/use-previous";
+import { useToggle } from "metabase/hooks/use-toggle";
+
 import QuestionDataSource from "./QuestionDataSource";
 import QuestionDescription from "./QuestionDescription";
 import QuestionLineage from "./QuestionLineage";
@@ -24,8 +27,6 @@ import { QuestionSummarizeWidget } from "./QuestionSummaries";
 import NativeQueryButton from "./NativeQueryButton";
 import RunButtonWithTooltip from "../RunButtonWithTooltip";
 import { SavedQuestionHeaderButtonContainer } from "./ViewHeader.styled";
-
-import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
 
 const viewTitleHeaderPropTypes = {
   question: PropTypes.object.isRequired,
@@ -66,286 +67,275 @@ const viewTitleHeaderPropTypes = {
   style: PropTypes.object,
 };
 
-export class ViewTitleHeader extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      isFiltersExpanded: props.question && !props.question.isSaved(),
-    };
-  }
+export function ViewTitleHeader(props) {
+  const {
+    className,
+    style,
+    question,
+    onOpenModal,
+    originalQuestion,
+    isDirty,
+    queryBuilderMode,
+    setQueryBuilderMode,
+    result,
+    isRunnable,
+    isRunning,
+    isResultDirty,
+    isPreviewing,
+    isNativeEditorOpen,
+    runQuestionQuery,
+    cancelQuery,
+    isShowingSummarySidebar,
+    onEditSummary,
+    onCloseSummary,
+    isShowingFilterSidebar,
+    onAddFilter,
+    onCloseFilter,
+    isShowingQuestionDetailsSidebar,
+    onOpenQuestionDetails,
+    onCloseQuestionDetails,
+    onOpenQuestionHistory,
+    isObjectDetail,
+  } = props;
 
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    const query = this.props.question.query();
-    const nextQuery = nextProps.question.query();
-    const filtersCount =
-      query instanceof StructuredQuery ? query.filters().length : 0;
-    const nextFiltersCount =
-      nextQuery instanceof StructuredQuery ? nextQuery.filters().length : 0;
-    if (nextFiltersCount > filtersCount) {
-      this.expandFilters();
+  const [
+    areFiltersExpanded,
+    { turnOn: expandFilters, turnOff: collapseFilters },
+  ] = useToggle(!question?.isSaved());
+
+  const previousQuestion = usePrevious(question);
+
+  useEffect(() => {
+    if (!question.isStructured() || !previousQuestion?.isStructured()) {
+      return;
     }
-  }
 
-  expandFilters = () => {
-    this.setState({ isFiltersExpanded: true });
-  };
+    const filtersCount = question.query().filters().length;
+    const previousFiltersCount = previousQuestion.query().filters().length;
 
-  collapseFilters = () => {
-    this.setState({ isFiltersExpanded: false });
-  };
+    if (filtersCount > previousFiltersCount) {
+      expandFilters();
+    }
+  }, [previousQuestion, question, expandFilters]);
 
-  render() {
-    const {
-      className,
-      style,
-      question,
-      onOpenModal,
-      originalQuestion,
-      isDirty,
-      queryBuilderMode,
-      setQueryBuilderMode,
-      result,
-      isRunnable,
-      isRunning,
-      isResultDirty,
-      isPreviewing,
-      isNativeEditorOpen,
-      runQuestionQuery,
-      cancelQuery,
-      isShowingSummarySidebar,
-      onEditSummary,
-      onCloseSummary,
-      isShowingFilterSidebar,
-      onAddFilter,
-      onCloseFilter,
-      isShowingQuestionDetailsSidebar,
-      onOpenQuestionDetails,
-      onCloseQuestionDetails,
-      onOpenQuestionHistory,
-      isObjectDetail,
-    } = this.props;
-    const { isFiltersExpanded } = this.state;
-    const isShowingNotebook = queryBuilderMode === "notebook";
-    const lastEditInfo = question.lastEditInfo();
+  const isShowingNotebook = queryBuilderMode === "notebook";
+  const lastEditInfo = question.lastEditInfo();
 
-    const isStructured = question.isStructured();
-    const isNative = question.isNative();
-    const isSaved = question.isSaved();
+  const isStructured = question.isStructured();
+  const isNative = question.isNative();
+  const isSaved = question.isSaved();
 
-    const isSummarized =
-      isStructured &&
-      question
-        .query()
-        .topLevelQuery()
-        .hasAggregations();
+  const isSummarized =
+    isStructured &&
+    question
+      .query()
+      .topLevelQuery()
+      .hasAggregations();
 
-    const showFiltersInHeading = !isSummarized && !isFiltersExpanded;
+  const showFiltersInHeading = !isSummarized && !areFiltersExpanded;
 
-    return (
-      <ViewSection
-        className={cx("border-bottom", className)}
-        style={style}
-        py={[1]}
-      >
-        {isSaved ? (
-          <div>
-            <div className="flex align-center">
-              <SavedQuestionHeaderButtonContainer>
-                <SavedQuestionHeaderButton
-                  question={question}
-                  isActive={isShowingQuestionDetailsSidebar}
-                  onClick={
-                    isShowingQuestionDetailsSidebar
-                      ? onCloseQuestionDetails
-                      : onOpenQuestionDetails
-                  }
-                />
-              </SavedQuestionHeaderButtonContainer>
-              {lastEditInfo && (
-                <LastEditInfoLabel
-                  className="ml1 text-light"
-                  item={question.card()}
-                  onClick={onOpenQuestionHistory}
-                />
-              )}
-            </div>
-            <ViewSubHeading className="flex align-center flex-wrap pt1">
-              <CollectionBadge
-                className="mb1"
-                collectionId={question.collectionId()}
-              />
-
-              {QuestionDataSource.shouldRender(this.props) && (
-                <QuestionDataSource
-                  className="ml3 mb1"
-                  question={question}
-                  isObjectDetail={isObjectDetail}
-                  subHead
-                />
-              )}
-
-              {QuestionFilters.shouldRender(this.props) && (
-                <QuestionFilters
-                  className="mb1"
-                  question={question}
-                  expanded={isFiltersExpanded}
-                  onExpand={this.expandFilters}
-                  onCollapse={this.collapseFilters}
-                />
-              )}
-            </ViewSubHeading>
-          </div>
-        ) : (
-          <div>
-            <div className="flex align-baseline flex-wrap">
-              <ViewHeading className="mt1 mr2 mb1">
-                {isNative ? (
-                  t`New question`
-                ) : (
-                  <QuestionDescription
-                    question={question}
-                    isObjectDetail={isObjectDetail}
-                  />
-                )}
-              </ViewHeading>
-              {showFiltersInHeading &&
-                QuestionFilters.shouldRender(this.props) && (
-                  <QuestionFilters
-                    className="mr2 mb1"
-                    question={question}
-                    expanded={isFiltersExpanded}
-                    onExpand={this.expandFilters}
-                    onCollapse={this.collapseFilters}
-                  />
-                )}
-              {QuestionLineage.shouldRender(this.props) && (
-                <QuestionLineage
-                  className="mr2 mb1"
-                  question={question}
-                  originalQuestion={originalQuestion}
-                />
-              )}
-            </div>
-            <div className="flex align-center flex-wrap">
-              {isSummarized && (
-                <QuestionDataSource
-                  className="mb1"
-                  question={question}
-                  isObjectDetail={isObjectDetail}
-                  subHead
-                  data-metabase-event={`Question Data Source Click`}
-                />
-              )}
-              {!showFiltersInHeading &&
-                QuestionFilters.shouldRender(this.props) && (
-                  <QuestionFilters
-                    className="mb1"
-                    question={question}
-                    expanded={isFiltersExpanded}
-                    onExpand={this.expandFilters}
-                    onCollapse={this.collapseFilters}
-                  />
-                )}
-            </div>
-          </div>
-        )}
-        <div className="ml-auto flex align-center">
-          {isDirty ? (
-            <Link
-              disabled={!question.canRun()}
-              className="text-brand text-bold py1 px2 rounded bg-white bg-light-hover"
-              data-metabase-event={
-                isShowingNotebook
-                  ? `Notebook Mode; Click Save`
-                  : `View Mode; Click Save`
-              }
-              onClick={() => onOpenModal("save")}
-            >
-              {t`Save`}
-            </Link>
-          ) : null}
-          {QuestionFilterWidget.shouldRender(this.props) && (
-            <QuestionFilterWidget
-              className="hide sm-show"
-              ml={1}
-              isShowingFilterSidebar={isShowingFilterSidebar}
-              onAddFilter={onAddFilter}
-              onCloseFilter={onCloseFilter}
-              data-metabase-event={`View Mode; Open Filter Widget`}
-            />
-          )}
-          {QuestionSummarizeWidget.shouldRender(this.props) && (
-            <QuestionSummarizeWidget
-              className="hide sm-show"
-              ml={1}
-              isShowingSummarySidebar={isShowingSummarySidebar}
-              onEditSummary={onEditSummary}
-              onCloseSummary={onCloseSummary}
-              data-metabase-event={`View Mode; Open Summary Widget`}
-            />
-          )}
-          {QuestionNotebookButton.shouldRender({ question }) && (
-            <QuestionNotebookButton
-              className="hide sm-show"
-              ml={2}
-              question={question}
-              isShowingNotebook={isShowingNotebook}
-              setQueryBuilderMode={setQueryBuilderMode}
-              data-metabase-event={
-                isShowingNotebook
-                  ? `Notebook Mode;Go to View Mode`
-                  : `View Mode; Go to Notebook Mode`
-              }
-            />
-          )}
-          {NativeQueryButton.shouldRender(this.props) && (
-            <Box
-              ml={2}
-              p={1}
-              className="text-medium text-brand-hover cursor-pointer"
-            >
-              <NativeQueryButton
-                size={16}
+  return (
+    <ViewSection
+      className={cx("border-bottom", className)}
+      style={style}
+      py={[1]}
+    >
+      {isSaved ? (
+        <div>
+          <div className="flex align-center">
+            <SavedQuestionHeaderButtonContainer>
+              <SavedQuestionHeaderButton
                 question={question}
-                data-metabase-event={`Notebook Mode; Convert to SQL Click`}
+                isActive={isShowingQuestionDetailsSidebar}
+                onClick={
+                  isShowingQuestionDetailsSidebar
+                    ? onCloseQuestionDetails
+                    : onOpenQuestionDetails
+                }
               />
-            </Box>
-          )}
-          {question.query().database() && isNative && isSaved && (
-            <Link
-              to={question
-                .composeThisQuery()
-                .setDisplay("table")
-                .setSettings({})
-                .getUrl()}
-            >
-              <ViewButton medium p={[2, 1]} icon="insight" labelBreakpoint="sm">
-                {t`Explore results`}
-              </ViewButton>
-            </Link>
-          )}
-          {isRunnable && !isNativeEditorOpen && (
-            <RunButtonWithTooltip
-              className={cx("text-brand-hover hide", {
-                "sm-show": !isShowingNotebook || isNative,
-                "text-white-hover": isResultDirty && isRunnable,
-              })}
-              medium
-              borderless
-              ml={1}
-              compact
-              result={result}
-              isRunning={isRunning}
-              isDirty={isResultDirty}
-              isPreviewing={isPreviewing}
-              onRun={() => runQuestionQuery({ ignoreCache: true })}
-              onCancel={() => cancelQuery()}
+            </SavedQuestionHeaderButtonContainer>
+            {lastEditInfo && (
+              <LastEditInfoLabel
+                className="ml1 text-light"
+                item={question.card()}
+                onClick={onOpenQuestionHistory}
+              />
+            )}
+          </div>
+          <ViewSubHeading className="flex align-center flex-wrap pt1">
+            <CollectionBadge
+              className="mb1"
+              collectionId={question.collectionId()}
             />
-          )}
+
+            {QuestionDataSource.shouldRender(props) && (
+              <QuestionDataSource
+                className="ml3 mb1"
+                question={question}
+                isObjectDetail={isObjectDetail}
+                subHead
+              />
+            )}
+
+            {QuestionFilters.shouldRender(props) && (
+              <QuestionFilters
+                className="mb1"
+                question={question}
+                expanded={areFiltersExpanded}
+                onExpand={expandFilters}
+                onCollapse={collapseFilters}
+              />
+            )}
+          </ViewSubHeading>
         </div>
-      </ViewSection>
-    );
-  }
+      ) : (
+        <div>
+          <div className="flex align-baseline flex-wrap">
+            <ViewHeading className="mt1 mr2 mb1">
+              {isNative ? (
+                t`New question`
+              ) : (
+                <QuestionDescription
+                  question={question}
+                  isObjectDetail={isObjectDetail}
+                />
+              )}
+            </ViewHeading>
+            {showFiltersInHeading && QuestionFilters.shouldRender(props) && (
+              <QuestionFilters
+                className="mr2 mb1"
+                question={question}
+                expanded={areFiltersExpanded}
+                onExpand={expandFilters}
+                onCollapse={collapseFilters}
+              />
+            )}
+            {QuestionLineage.shouldRender(props) && (
+              <QuestionLineage
+                className="mr2 mb1"
+                question={question}
+                originalQuestion={originalQuestion}
+              />
+            )}
+          </div>
+          <div className="flex align-center flex-wrap">
+            {isSummarized && (
+              <QuestionDataSource
+                className="mb1"
+                question={question}
+                isObjectDetail={isObjectDetail}
+                subHead
+                data-metabase-event={`Question Data Source Click`}
+              />
+            )}
+            {!showFiltersInHeading && QuestionFilters.shouldRender(props) && (
+              <QuestionFilters
+                className="mb1"
+                question={question}
+                expanded={areFiltersExpanded}
+                onExpand={expandFilters}
+                onCollapse={collapseFilters}
+              />
+            )}
+          </div>
+        </div>
+      )}
+      <div className="ml-auto flex align-center">
+        {isDirty ? (
+          <Link
+            disabled={!question.canRun()}
+            className="text-brand text-bold py1 px2 rounded bg-white bg-light-hover"
+            data-metabase-event={
+              isShowingNotebook
+                ? `Notebook Mode; Click Save`
+                : `View Mode; Click Save`
+            }
+            onClick={() => onOpenModal("save")}
+          >
+            {t`Save`}
+          </Link>
+        ) : null}
+        {QuestionFilterWidget.shouldRender(props) && (
+          <QuestionFilterWidget
+            className="hide sm-show"
+            ml={1}
+            isShowingFilterSidebar={isShowingFilterSidebar}
+            onAddFilter={onAddFilter}
+            onCloseFilter={onCloseFilter}
+            data-metabase-event={`View Mode; Open Filter Widget`}
+          />
+        )}
+        {QuestionSummarizeWidget.shouldRender(props) && (
+          <QuestionSummarizeWidget
+            className="hide sm-show"
+            ml={1}
+            isShowingSummarySidebar={isShowingSummarySidebar}
+            onEditSummary={onEditSummary}
+            onCloseSummary={onCloseSummary}
+            data-metabase-event={`View Mode; Open Summary Widget`}
+          />
+        )}
+        {QuestionNotebookButton.shouldRender({ question }) && (
+          <QuestionNotebookButton
+            className="hide sm-show"
+            ml={2}
+            question={question}
+            isShowingNotebook={isShowingNotebook}
+            setQueryBuilderMode={setQueryBuilderMode}
+            data-metabase-event={
+              isShowingNotebook
+                ? `Notebook Mode;Go to View Mode`
+                : `View Mode; Go to Notebook Mode`
+            }
+          />
+        )}
+        {NativeQueryButton.shouldRender(props) && (
+          <Box
+            ml={2}
+            p={1}
+            className="text-medium text-brand-hover cursor-pointer"
+          >
+            <NativeQueryButton
+              size={16}
+              question={question}
+              data-metabase-event={`Notebook Mode; Convert to SQL Click`}
+            />
+          </Box>
+        )}
+        {question.query().database() && isNative && isSaved && (
+          <Link
+            to={question
+              .composeThisQuery()
+              .setDisplay("table")
+              .setSettings({})
+              .getUrl()}
+          >
+            <ViewButton medium p={[2, 1]} icon="insight" labelBreakpoint="sm">
+              {t`Explore results`}
+            </ViewButton>
+          </Link>
+        )}
+        {isRunnable && !isNativeEditorOpen && (
+          <RunButtonWithTooltip
+            className={cx("text-brand-hover hide", {
+              "sm-show": !isShowingNotebook || isNative,
+              "text-white-hover": isResultDirty && isRunnable,
+            })}
+            medium
+            borderless
+            ml={1}
+            compact
+            result={result}
+            isRunning={isRunning}
+            isDirty={isResultDirty}
+            isPreviewing={isPreviewing}
+            onRun={() => runQuestionQuery({ ignoreCache: true })}
+            onCancel={() => cancelQuery()}
+          />
+        )}
+      </div>
+    </ViewSection>
+  );
 }
 
 ViewTitleHeader.propTypes = viewTitleHeaderPropTypes;

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -1,31 +1,31 @@
-import React, { useEffect, useCallback, useState } from "react";
+import React, { useEffect } from "react";
 import PropTypes from "prop-types";
 import { t } from "ttag";
 import cx from "classnames";
 import { Box } from "grid-styled";
 
-import Link from "metabase/components/Link";
 import ButtonBar from "metabase/components/ButtonBar";
 import CollectionBadge from "metabase/questions/components/CollectionBadge";
 import LastEditInfoLabel from "metabase/components/LastEditInfoLabel";
-import SavedQuestionHeaderButton from "metabase/query_builder/components/SavedQuestionHeaderButton/SavedQuestionHeaderButton";
-import ViewSection, { ViewHeading, ViewSubHeading } from "./ViewSection";
+import Link from "metabase/components/Link";
 import ViewButton from "metabase/query_builder/components/view/ViewButton";
 
 import { usePrevious } from "metabase/hooks/use-previous";
 import { useToggle } from "metabase/hooks/use-toggle";
+
+import SavedQuestionHeaderButton from "metabase/query_builder/components/SavedQuestionHeaderButton/SavedQuestionHeaderButton";
+
+import RunButtonWithTooltip from "../RunButtonWithTooltip";
 
 import QuestionDataSource from "./QuestionDataSource";
 import QuestionDescription from "./QuestionDescription";
 import QuestionLineage from "./QuestionLineage";
 import QuestionPreviewToggle from "./QuestionPreviewToggle";
 import QuestionNotebookButton from "./QuestionNotebookButton";
-
 import QuestionFilters, { QuestionFilterWidget } from "./QuestionFilters";
 import { QuestionSummarizeWidget } from "./QuestionSummaries";
-
 import NativeQueryButton from "./NativeQueryButton";
-import RunButtonWithTooltip from "../RunButtonWithTooltip";
+import ViewSection, { ViewHeading, ViewSubHeading } from "./ViewSection";
 import { SavedQuestionHeaderButtonContainer } from "./ViewHeader.styled";
 
 const viewTitleHeaderPropTypes = {

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.styled.jsx
@@ -6,8 +6,8 @@ import ViewSection from "./ViewSection";
 
 export const ViewHeaderContainer = styled(ViewSection)`
   border-bottom: 1px solid ${color("border")};
-  padding-top: ${space(2)};
-  padding-bottom: ${space(2)};
+  padding-top: ${space(1)};
+  padding-bottom: ${space(1)};
 `;
 
 export const SaveButton = styled(Link)`

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.styled.jsx
@@ -12,7 +12,7 @@ export const ViewHeaderContainer = styled(ViewSection)`
 
 export const ViewHeaderMainLeftContentContainer = styled.div`
   display: flex;
-  align-items: baseline;
+  align-item: ${props => props.align || "center"};
   flex-wrap: wrap;
 `;
 

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.styled.jsx
@@ -2,12 +2,24 @@ import styled from "styled-components";
 import Link from "metabase/components/Link";
 import { color } from "metabase/lib/colors";
 import { space } from "metabase/styled-components/theme";
-import ViewSection from "./ViewSection";
+import ViewSection, { ViewSubHeading } from "./ViewSection";
 
 export const ViewHeaderContainer = styled(ViewSection)`
   border-bottom: 1px solid ${color("border")};
   padding-top: ${space(1)};
   padding-bottom: ${space(1)};
+`;
+
+export const ViewHeaderMainLeftContentContainer = styled.div`
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+`;
+
+export const ViewHeaderLeftSubHeading = styled(ViewSubHeading)`
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
 `;
 
 export const SaveButton = styled(Link)`

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.styled.jsx
@@ -40,7 +40,7 @@ export const SavedQuestionHeaderButtonContainer = styled.div`
 `;
 
 export const ViewSQLButtonContainer = styled.div`
-  margin-left: ${space(3)};
+  margin-left: ${space(2)};
   padding: ${space(1)};
 
   cursor: pointer;

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.styled.jsx
@@ -2,7 +2,7 @@ import styled from "styled-components";
 import Link from "metabase/components/Link";
 import { color } from "metabase/lib/colors";
 import { space } from "metabase/styled-components/theme";
-import ViewSection, { ViewSubHeading } from "./ViewSection";
+import ViewSection, { ViewSubHeading, ViewHeading } from "./ViewSection";
 
 export const ViewHeaderContainer = styled(ViewSection)`
   border-bottom: 1px solid ${color("border")};
@@ -12,7 +12,7 @@ export const ViewHeaderContainer = styled(ViewSection)`
 
 export const ViewHeaderMainLeftContentContainer = styled.div`
   display: flex;
-  align-item: ${props => props.align || "center"};
+  align-items: ${props => props.align || "center"};
   flex-wrap: wrap;
 `;
 
@@ -20,6 +20,12 @@ export const ViewHeaderLeftSubHeading = styled(ViewSubHeading)`
   display: flex;
   align-items: center;
   flex-wrap: wrap;
+`;
+
+export const AdHocViewHeading = styled(ViewHeading)`
+  margin-bottom: ${space(0)};
+  margin-top: ${space(0)};
+  margin-right: ${space(2)};
 `;
 
 export const SaveButton = styled(Link)`

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.styled.jsx
@@ -1,6 +1,39 @@
 import styled from "styled-components";
+import Link from "metabase/components/Link";
+import { color } from "metabase/lib/colors";
+import { space } from "metabase/styled-components/theme";
+import ViewSection from "./ViewSection";
+
+export const ViewHeaderContainer = styled(ViewSection)`
+  border-bottom: 1px solid ${color("border")};
+  padding-top: ${space(2)};
+  padding-bottom: ${space(2)};
+`;
+
+export const SaveButton = styled(Link)`
+  color: ${color("brand")};
+  font-weight: bold;
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+  background-color: ${color("bg-white")};
+
+  :hover {
+    background-color: ${color("bg-light")};
+  }
+`;
 
 export const SavedQuestionHeaderButtonContainer = styled.div`
   position: relative;
   right: 0.38rem;
+`;
+
+export const ViewSQLButtonContainer = styled.div`
+  margin-left: ${space(3)};
+  padding: ${space(1)};
+
+  cursor: pointer;
+  color: ${color("text-medium")};
+  :hover {
+    color: ${color("brand")};
+  }
 `;

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.unit.spec.js
@@ -84,8 +84,9 @@ function getSavedNativeQuestion(overrides) {
   });
 }
 
-function setup({ question, ...props } = {}) {
+function setup({ question, isRunnable = true, ...props } = {}) {
   const callbacks = {
+    runQuestionQuery: jest.fn(),
     setQueryBuilderMode: jest.fn(),
     onOpenQuestionDetails: jest.fn(),
     onCloseQuestionDetails: jest.fn(),
@@ -97,7 +98,12 @@ function setup({ question, ...props } = {}) {
   };
 
   renderWithProviders(
-    <ViewTitleHeader {...callbacks} {...props} question={question} />,
+    <ViewTitleHeader
+      {...callbacks}
+      {...props}
+      isRunnable={isRunnable}
+      question={question}
+    />,
     {
       withRouter: true,
       withSampleDataset: true,
@@ -181,6 +187,19 @@ describe("ViewHeader", () => {
         it(`does not offer to save if it's not dirty`, () => {
           setup({ question, isDirty: false });
           expect(screen.queryByText("Save")).not.toBeInTheDocument();
+        });
+
+        it("offers to refresh query results", () => {
+          const { runQuestionQuery } = setup({ question });
+          fireEvent.click(screen.getByLabelText("refresh icon"));
+          expect(runQuestionQuery).toHaveBeenCalledWith({ ignoreCache: true });
+        });
+
+        it("does not offer to refresh query results if question is not runnable", () => {
+          setup({ question, isRunnable: false });
+          expect(
+            screen.queryByLabelText("refresh icon"),
+          ).not.toBeInTheDocument();
         });
       });
     });
@@ -272,6 +291,13 @@ describe("ViewHeader", () => {
         it(`does not offer to summarize query results`, () => {
           setup({ question });
           expect(screen.queryByText("Summarize")).not.toBeInTheDocument();
+        });
+
+        it("does not offer to refresh query results if native editor is open", () => {
+          setup({ question, isNativeEditorOpen: true });
+          expect(
+            screen.queryByLabelText("refresh icon"),
+          ).not.toBeInTheDocument();
         });
       });
     });

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.unit.spec.js
@@ -148,7 +148,7 @@ describe("ViewHeader", () => {
     },
     SAVED_NATIVE_QUESTION: {
       question: getSavedNativeQuestion(),
-      questionType: "native question",
+      questionType: "saved native question",
     },
   };
 
@@ -160,6 +160,10 @@ describe("ViewHeader", () => {
   const NATIVE_TEST_CASES = [
     TEST_CASE.SAVED_NATIVE_QUESTION,
     TEST_CASE.NATIVE_QUESTION,
+  ];
+  const SAVED_QUESTIONS_TEST_CASES = [
+    TEST_CASE.SAVED_GUI_QUESTION,
+    TEST_CASE.SAVED_NATIVE_QUESTION,
   ];
 
   describe("Common", () => {
@@ -271,6 +275,40 @@ describe("ViewHeader", () => {
       });
     });
   });
+
+  describe("Saved", () => {
+    SAVED_QUESTIONS_TEST_CASES.forEach(testCase => {
+      const { question, questionType } = testCase;
+
+      describe(questionType, () => {
+        beforeEach(() => {
+          xhrMock.setup();
+          xhrMock.get("/api/collection/root", {
+            body: JSON.stringify({
+              id: "root",
+              name: "Our analytics",
+            }),
+          });
+        });
+
+        afterEach(() => {
+          xhrMock.teardown();
+        });
+
+        it("displays collection where a question is saved to", async () => {
+          setup({ question });
+          await waitFor(() => screen.queryByText("Our analytics"));
+          expect(screen.queryByText("Our analytics")).toBeInTheDocument();
+        });
+
+        it("opens details sidebar on question name click", () => {
+          const { onOpenQuestionDetails } = setup({ question });
+          fireEvent.click(screen.getByText(question.displayName()));
+          expect(onOpenQuestionDetails).toHaveBeenCalled();
+        });
+      });
+    });
+  });
 });
 
 describe("ViewHeader | Ad-hoc GUI question", () => {
@@ -281,28 +319,6 @@ describe("ViewHeader | Ad-hoc GUI question", () => {
     fireEvent.click(screen.getByText(tableName));
 
     expect(onOpenQuestionDetails).not.toHaveBeenCalled();
-  });
-});
-
-describe("ViewHeader | Saved GUI question", () => {
-  beforeEach(() => {
-    xhrMock.setup();
-  });
-
-  afterEach(() => {
-    xhrMock.teardown();
-  });
-
-  it("displays collection where a question is saved to", async () => {
-    const { collection } = setupSavedGUI();
-    await waitFor(() => screen.queryByText(collection.name));
-    expect(screen.queryByText(collection.name)).toBeInTheDocument();
-  });
-
-  it("opens details sidebar on question name click", () => {
-    const { question, onOpenQuestionDetails } = setupSavedGUI();
-    fireEvent.click(screen.getByText(question.displayName()));
-    expect(onOpenQuestionDetails).toHaveBeenCalled();
   });
 });
 
@@ -332,18 +348,6 @@ describe("View Header | Saved native question", () => {
     const { question } = setupSavedNative();
     const databaseName = question.database().displayName();
     expect(screen.queryByText(databaseName)).toBeInTheDocument();
-  });
-
-  it("displays collection where a question is saved to", async () => {
-    const { collection } = setupSavedNative();
-    await waitFor(() => screen.queryByText(collection.name));
-    expect(screen.queryByText(collection.name)).toBeInTheDocument();
-  });
-
-  it("opens details sidebar on question name click", () => {
-    const { question, onOpenQuestionDetails } = setupSavedNative();
-    fireEvent.click(screen.getByText(question.displayName()));
-    expect(onOpenQuestionDetails).toHaveBeenCalled();
   });
 
   it("offers to explore query results", () => {

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.unit.spec.js
@@ -91,15 +91,15 @@ function setupSavedGUI(props = {}) {
   };
 }
 
-describe("ViewHeader | Common", () => {
+describe("ViewHeader", () => {
   const TEST_CASE = {
     SAVED_GUI_QUESTION: {
       question: getSavedGUIQuestion(),
-      questionType: "a saved GUI question",
+      questionType: "saved GUI question",
     },
     AD_HOC_QUESTION: {
       question: getAdHocQuestion(),
-      questionType: "an ad-hoc question",
+      questionType: "ad-hoc GUI question",
     },
   };
 
@@ -109,101 +109,100 @@ describe("ViewHeader | Common", () => {
     TEST_CASE.AD_HOC_QUESTION,
   ];
 
-  ALL_TEST_CASES.forEach(testCase => {
-    const { question, questionType } = testCase;
+  describe("Common", () => {
+    ALL_TEST_CASES.forEach(testCase => {
+      const { question, questionType } = testCase;
 
-    it(`offers to save ${questionType}`, () => {
-      const { onOpenModal } = setup({ question, isDirty: true });
-      fireEvent.click(screen.getByText("Save"));
-      expect(onOpenModal).toHaveBeenCalledWith("save");
-    });
+      describe(questionType, () => {
+        it(`offers to save`, () => {
+          const { onOpenModal } = setup({ question, isDirty: true });
+          fireEvent.click(screen.getByText("Save"));
+          expect(onOpenModal).toHaveBeenCalledWith("save");
+        });
 
-    it(`does not offer to save ${questionType} if it's not dirty`, () => {
-      setup({ question, isDirty: false });
-      expect(screen.queryByText("Save")).not.toBeInTheDocument();
+        it(`does not offer to save if it's not dirty`, () => {
+          setup({ question, isDirty: false });
+          expect(screen.queryByText("Save")).not.toBeInTheDocument();
+        });
+      });
     });
   });
 
-  GUI_TEST_CASES.forEach(testCase => {
-    const { question, questionType } = testCase;
+  describe("GUI", () => {
+    GUI_TEST_CASES.forEach(testCase => {
+      const { question, questionType } = testCase;
 
-    it(`displays database and table names for ${questionType}`, () => {
-      setup({ question });
-      const databaseName = question.database().displayName();
-      const tableName = question.table().displayName();
+      describe(questionType, () => {
+        it(`displays database and table names`, () => {
+          setup({ question });
+          const databaseName = question.database().displayName();
+          const tableName = question.table().displayName();
 
-      expect(screen.queryByText(databaseName)).toBeInTheDocument();
-      expect(screen.queryByText(tableName)).toBeInTheDocument();
-    });
+          expect(screen.queryByText(databaseName)).toBeInTheDocument();
+          expect(screen.queryByText(tableName)).toBeInTheDocument();
+        });
 
-    it(`offers to filter ${questionType} results`, () => {
-      const { onAddFilter } = setup({
-        question,
-        queryBuilderMode: "view",
+        it(`offers to filter query results`, () => {
+          const { onAddFilter } = setup({
+            question,
+            queryBuilderMode: "view",
+          });
+          fireEvent.click(screen.getByText("Filter"));
+          expect(onAddFilter).toHaveBeenCalled();
+        });
+
+        it(`offers to summarize query results`, () => {
+          const { onEditSummary } = setup({
+            question,
+            queryBuilderMode: "view",
+          });
+          fireEvent.click(screen.getByText("Summarize"));
+          expect(onEditSummary).toHaveBeenCalled();
+        });
+
+        it(`allows to open notebook editor`, () => {
+          const { setQueryBuilderMode } = setup({
+            question,
+            queryBuilderMode: "view",
+          });
+          fireEvent.click(screen.getByLabelText("notebook icon"));
+          expect(setQueryBuilderMode).toHaveBeenCalledWith("notebook");
+        });
+
+        it(`allows to close notebook editor`, () => {
+          const { setQueryBuilderMode } = setup({
+            question,
+            queryBuilderMode: "notebook",
+          });
+          fireEvent.click(screen.getByLabelText("notebook icon"));
+          expect(setQueryBuilderMode).toHaveBeenCalledWith("view");
+        });
+
+        it(`does not offer to filter query results in notebook mode`, () => {
+          setup({ question, queryBuilderMode: "notebook" });
+          expect(screen.queryByText("Filter")).not.toBeInTheDocument();
+        });
+
+        it(`does not offer to filter query in detail view`, () => {
+          setup({ question, isObjectDetail: true });
+          expect(screen.queryByText("Filter")).not.toBeInTheDocument();
+        });
+
+        it(`does not offer to summarize query results in notebook mode`, () => {
+          setup({ question, queryBuilderMode: "notebook" });
+          expect(screen.queryByText("Summarize")).not.toBeInTheDocument();
+        });
+
+        it(`does not offer to summarize query in detail view`, () => {
+          setup({ question, isObjectDetail: true });
+          expect(screen.queryByText("Summarize")).not.toBeInTheDocument();
+        });
       });
-      fireEvent.click(screen.getByText("Filter"));
-      expect(onAddFilter).toHaveBeenCalled();
-    });
-
-    it(`offers to summarize ${questionType} results`, () => {
-      const { onEditSummary } = setup({
-        question,
-        queryBuilderMode: "view",
-      });
-      fireEvent.click(screen.getByText("Summarize"));
-      expect(onEditSummary).toHaveBeenCalled();
-    });
-
-    it(`allows to open notebook editor for ${questionType}`, () => {
-      const { setQueryBuilderMode } = setup({
-        question,
-        queryBuilderMode: "view",
-      });
-      fireEvent.click(screen.getByLabelText("notebook icon"));
-      expect(setQueryBuilderMode).toHaveBeenCalledWith("notebook");
-    });
-
-    it(`allows to close notebook editor for ${questionType}`, () => {
-      const { setQueryBuilderMode } = setup({
-        question,
-        queryBuilderMode: "notebook",
-      });
-      fireEvent.click(screen.getByLabelText("notebook icon"));
-      expect(setQueryBuilderMode).toHaveBeenCalledWith("view");
-    });
-
-    it(`does not offer to filter ${questionType} results in notebook mode`, () => {
-      setup({ question, queryBuilderMode: "notebook" });
-      expect(screen.queryByText("Filter")).not.toBeInTheDocument();
-    });
-
-    it(`does not offer to filter ${questionType} in detail view`, () => {
-      setup({ question, isObjectDetail: true });
-      expect(screen.queryByText("Filter")).not.toBeInTheDocument();
-    });
-
-    it(`does not offer to summarize ${questionType} results in notebook mode`, () => {
-      setup({ question, queryBuilderMode: "notebook" });
-      expect(screen.queryByText("Summarize")).not.toBeInTheDocument();
-    });
-
-    it(`does not offer to summarize ${questionType} in detail view`, () => {
-      setup({ question, isObjectDetail: true });
-      expect(screen.queryByText("Summarize")).not.toBeInTheDocument();
     });
   });
 });
 
 describe("ViewHeader | Ad-hoc GUI question", () => {
-  it("displays database and table names", () => {
-    const { question } = setupAdHoc();
-    const databaseName = question.database().displayName();
-    const tableName = question.table().displayName();
-
-    expect(screen.queryByText(databaseName)).toBeInTheDocument();
-    expect(screen.queryByText(tableName)).toBeInTheDocument();
-  });
-
   it("does not open details sidebar on table name click", () => {
     const { question, onOpenQuestionDetails } = setupAdHoc();
     const tableName = question.table().displayName();

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.unit.spec.js
@@ -322,6 +322,16 @@ describe("ViewHeader | Ad-hoc GUI question", () => {
     expect(onOpenQuestionDetails).not.toHaveBeenCalled();
   });
 
+  it("displays original question name if a question is started from one", () => {
+    const originalQuestion = getSavedGUIQuestion();
+    setupAdHoc({ originalQuestion });
+
+    expect(screen.queryByText("Started from")).toBeInTheDocument();
+    expect(
+      screen.queryByText(originalQuestion.displayName()),
+    ).toBeInTheDocument();
+  });
+
   describe("filters", () => {
     const question = getAdHocQuestion(FILTERED_GUI_QUESTION);
 
@@ -417,6 +427,16 @@ describe("View Header | Not saved native question", () => {
   it("does not offer to explore query results", () => {
     setupNative();
     expect(screen.queryByText("Explore results")).not.toBeInTheDocument();
+  });
+
+  it("displays original question name if a question is started from one", () => {
+    const originalQuestion = getSavedNativeQuestion();
+    setupNative({ originalQuestion });
+
+    expect(screen.queryByText("Started from")).toBeInTheDocument();
+    expect(
+      screen.queryByText(originalQuestion.displayName()),
+    ).toBeInTheDocument();
   });
 });
 

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.unit.spec.js
@@ -178,13 +178,13 @@ describe("ViewHeader", () => {
       const { question, questionType } = testCase;
 
       describe(questionType, () => {
-        it(`offers to save`, () => {
+        it("offers to save", () => {
           const { onOpenModal } = setup({ question, isDirty: true });
           fireEvent.click(screen.getByText("Save"));
           expect(onOpenModal).toHaveBeenCalledWith("save");
         });
 
-        it(`does not offer to save if it's not dirty`, () => {
+        it("does not offer to save if it's not dirty", () => {
           setup({ question, isDirty: false });
           expect(screen.queryByText("Save")).not.toBeInTheDocument();
         });
@@ -210,7 +210,7 @@ describe("ViewHeader", () => {
       const { question, questionType } = testCase;
 
       describe(questionType, () => {
-        it(`displays database and table names`, () => {
+        it("displays database and table names", () => {
           setup({ question });
           const databaseName = question.database().displayName();
           const tableName = question.table().displayName();
@@ -219,7 +219,7 @@ describe("ViewHeader", () => {
           expect(screen.queryByText(tableName)).toBeInTheDocument();
         });
 
-        it(`offers to filter query results`, () => {
+        it("offers to filter query results", () => {
           const { onAddFilter } = setup({
             question,
             queryBuilderMode: "view",
@@ -228,7 +228,7 @@ describe("ViewHeader", () => {
           expect(onAddFilter).toHaveBeenCalled();
         });
 
-        it(`offers to summarize query results`, () => {
+        it("offers to summarize query results", () => {
           const { onEditSummary } = setup({
             question,
             queryBuilderMode: "view",
@@ -237,7 +237,7 @@ describe("ViewHeader", () => {
           expect(onEditSummary).toHaveBeenCalled();
         });
 
-        it(`allows to open notebook editor`, () => {
+        it("allows to open notebook editor", () => {
           const { setQueryBuilderMode } = setup({
             question,
             queryBuilderMode: "view",
@@ -246,7 +246,7 @@ describe("ViewHeader", () => {
           expect(setQueryBuilderMode).toHaveBeenCalledWith("notebook");
         });
 
-        it(`allows to close notebook editor`, () => {
+        it("allows to close notebook editor", () => {
           const { setQueryBuilderMode } = setup({
             question,
             queryBuilderMode: "notebook",
@@ -255,22 +255,22 @@ describe("ViewHeader", () => {
           expect(setQueryBuilderMode).toHaveBeenCalledWith("view");
         });
 
-        it(`does not offer to filter query results in notebook mode`, () => {
+        it("does not offer to filter query results in notebook mode", () => {
           setup({ question, queryBuilderMode: "notebook" });
           expect(screen.queryByText("Filter")).not.toBeInTheDocument();
         });
 
-        it(`does not offer to filter query in detail view`, () => {
+        it("does not offer to filter query in detail view", () => {
           setup({ question, isObjectDetail: true });
           expect(screen.queryByText("Filter")).not.toBeInTheDocument();
         });
 
-        it(`does not offer to summarize query results in notebook mode`, () => {
+        it("does not offer to summarize query results in notebook mode", () => {
           setup({ question, queryBuilderMode: "notebook" });
           expect(screen.queryByText("Summarize")).not.toBeInTheDocument();
         });
 
-        it(`does not offer to summarize query in detail view`, () => {
+        it("does not offer to summarize query in detail view", () => {
           setup({ question, isObjectDetail: true });
           expect(screen.queryByText("Summarize")).not.toBeInTheDocument();
         });
@@ -283,12 +283,12 @@ describe("ViewHeader", () => {
       const { question, questionType } = testCase;
 
       describe(questionType, () => {
-        it(`does not offer to filter query results`, () => {
+        it("does not offer to filter query results", () => {
           setup({ question });
           expect(screen.queryByText("Filter")).not.toBeInTheDocument();
         });
 
-        it(`does not offer to summarize query results`, () => {
+        it("does not offer to summarize query results", () => {
           setup({ question });
           expect(screen.queryByText("Summarize")).not.toBeInTheDocument();
         });

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.unit.spec.js
@@ -1,0 +1,237 @@
+import React from "react";
+import xhrMock from "xhr-mock";
+import {
+  fireEvent,
+  renderWithProviders,
+  screen,
+  waitFor,
+} from "__support__/ui";
+import {
+  SAMPLE_DATASET,
+  ORDERS,
+  metadata,
+} from "__support__/sample_dataset_fixture";
+import Question from "metabase-lib/lib/Question";
+import { ViewTitleHeader } from "./ViewHeader";
+
+const BASE_GUI_QUESTION = {
+  display: "table",
+  visualization_settings: {},
+  dataset_query: {
+    type: "query",
+    database: SAMPLE_DATASET.id,
+    query: {
+      "source-table": ORDERS.id,
+    },
+  },
+};
+
+const SAVED_GUI_QUESTION = {
+  ...BASE_GUI_QUESTION,
+  id: 1,
+  name: "Q1",
+  description: null,
+  collection_id: null,
+};
+
+function getQuestion(card) {
+  return new Question(card, metadata);
+}
+
+function getAdHocQuestion() {
+  return getQuestion(BASE_GUI_QUESTION);
+}
+
+function getSavedGUIQuestion() {
+  return getQuestion(SAVED_GUI_QUESTION);
+}
+
+function setup({ question, ...props } = {}) {
+  const callbacks = {
+    setQueryBuilderMode: jest.fn(),
+    onOpenQuestionDetails: jest.fn(),
+    onCloseQuestionDetails: jest.fn(),
+    onOpenModal: jest.fn(),
+    onAddFilter: jest.fn(),
+    onCloseFilter: jest.fn(),
+    onEditSummary: jest.fn(),
+    onCloseSummary: jest.fn(),
+  };
+
+  renderWithProviders(
+    <ViewTitleHeader {...callbacks} {...props} question={question} />,
+    {
+      withRouter: true,
+      withSampleDataset: true,
+    },
+  );
+
+  return { question, ...callbacks };
+}
+
+function setupAdHoc(props = {}) {
+  return setup({ question: getAdHocQuestion(), ...props });
+}
+
+function setupSavedGUI(props = {}) {
+  const collection = {
+    id: "root",
+    name: "Our analytics",
+  };
+
+  xhrMock.get("/api/collection/root", {
+    body: JSON.stringify(collection),
+  });
+
+  const utils = setup({ question: getSavedGUIQuestion(), ...props });
+
+  return {
+    ...utils,
+    collection,
+  };
+}
+
+describe("ViewHeader | Common", () => {
+  const TEST_CASE = {
+    SAVED_GUI_QUESTION: {
+      question: getSavedGUIQuestion(),
+      questionType: "a saved GUI question",
+    },
+    AD_HOC_QUESTION: {
+      question: getAdHocQuestion(),
+      questionType: "an ad-hoc question",
+    },
+  };
+
+  const ALL_TEST_CASES = Object.values(TEST_CASE);
+  const GUI_TEST_CASES = [
+    TEST_CASE.SAVED_GUI_QUESTION,
+    TEST_CASE.AD_HOC_QUESTION,
+  ];
+
+  ALL_TEST_CASES.forEach(testCase => {
+    const { question, questionType } = testCase;
+
+    it(`offers to save ${questionType}`, () => {
+      const { onOpenModal } = setup({ question, isDirty: true });
+      fireEvent.click(screen.getByText("Save"));
+      expect(onOpenModal).toHaveBeenCalledWith("save");
+    });
+
+    it(`does not offer to save ${questionType} if it's not dirty`, () => {
+      setup({ question, isDirty: false });
+      expect(screen.queryByText("Save")).not.toBeInTheDocument();
+    });
+  });
+
+  GUI_TEST_CASES.forEach(testCase => {
+    const { question, questionType } = testCase;
+
+    it(`displays database and table names for ${questionType}`, () => {
+      setup({ question });
+      const databaseName = question.database().displayName();
+      const tableName = question.table().displayName();
+
+      expect(screen.queryByText(databaseName)).toBeInTheDocument();
+      expect(screen.queryByText(tableName)).toBeInTheDocument();
+    });
+
+    it(`offers to filter ${questionType} results`, () => {
+      const { onAddFilter } = setup({
+        question,
+        queryBuilderMode: "view",
+      });
+      fireEvent.click(screen.getByText("Filter"));
+      expect(onAddFilter).toHaveBeenCalled();
+    });
+
+    it(`offers to summarize ${questionType} results`, () => {
+      const { onEditSummary } = setup({
+        question,
+        queryBuilderMode: "view",
+      });
+      fireEvent.click(screen.getByText("Summarize"));
+      expect(onEditSummary).toHaveBeenCalled();
+    });
+
+    it(`allows to open notebook editor for ${questionType}`, () => {
+      const { setQueryBuilderMode } = setup({
+        question,
+        queryBuilderMode: "view",
+      });
+      fireEvent.click(screen.getByLabelText("notebook icon"));
+      expect(setQueryBuilderMode).toHaveBeenCalledWith("notebook");
+    });
+
+    it(`allows to close notebook editor for ${questionType}`, () => {
+      const { setQueryBuilderMode } = setup({
+        question,
+        queryBuilderMode: "notebook",
+      });
+      fireEvent.click(screen.getByLabelText("notebook icon"));
+      expect(setQueryBuilderMode).toHaveBeenCalledWith("view");
+    });
+
+    it(`does not offer to filter ${questionType} results in notebook mode`, () => {
+      setup({ question, queryBuilderMode: "notebook" });
+      expect(screen.queryByText("Filter")).not.toBeInTheDocument();
+    });
+
+    it(`does not offer to filter ${questionType} in detail view`, () => {
+      setup({ question, isObjectDetail: true });
+      expect(screen.queryByText("Filter")).not.toBeInTheDocument();
+    });
+
+    it(`does not offer to summarize ${questionType} results in notebook mode`, () => {
+      setup({ question, queryBuilderMode: "notebook" });
+      expect(screen.queryByText("Summarize")).not.toBeInTheDocument();
+    });
+
+    it(`does not offer to summarize ${questionType} in detail view`, () => {
+      setup({ question, isObjectDetail: true });
+      expect(screen.queryByText("Summarize")).not.toBeInTheDocument();
+    });
+  });
+});
+
+describe("ViewHeader | Ad-hoc GUI question", () => {
+  it("displays database and table names", () => {
+    const { question } = setupAdHoc();
+    const databaseName = question.database().displayName();
+    const tableName = question.table().displayName();
+
+    expect(screen.queryByText(databaseName)).toBeInTheDocument();
+    expect(screen.queryByText(tableName)).toBeInTheDocument();
+  });
+
+  it("does not open details sidebar on table name click", () => {
+    const { question, onOpenQuestionDetails } = setupAdHoc();
+    const tableName = question.table().displayName();
+
+    fireEvent.click(screen.getByText(tableName));
+
+    expect(onOpenQuestionDetails).not.toHaveBeenCalled();
+  });
+});
+
+describe("ViewHeader | Saved GUI question", () => {
+  beforeEach(() => {
+    xhrMock.setup();
+  });
+
+  afterEach(() => {
+    xhrMock.teardown();
+  });
+
+  it("displays collection where a question is saved to", async () => {
+    const { collection } = setupSavedGUI();
+    await waitFor(() => screen.queryByText(collection.name));
+    expect(screen.queryByText(collection.name)).toBeInTheDocument();
+  });
+
+  it("opens details sidebar on question name click", () => {
+    const { question, onOpenQuestionDetails } = setupSavedGUI();
+    fireEvent.click(screen.getByText(question.displayName()));
+    expect(onOpenQuestionDetails).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
This PR is the first step for updating the question page for datasets (feature epic: #18659). ViewHeader is displayed for any question (saved vs ad-hoc, native vs GUI, etc.), so it has lots of possible states. This PR adds unit tests for the component and refactors it to simplify subsequent changes.

* turned into a functional component
* some visual components are extracted as styled-components
* the component itself is broken down into left side (are different for saved vs ad-hoc question) and right side components
* reordered imports

### To Verify

1. For saved GUI, ad-hoc GUI, saved native and ad-hoc native questions
2. Open the question page
3. Make sure there are no changes in the header's look and behavior

We have some Percy coverage for questions already. I've also submitted a PR with table visual tests that also cover ad-hoc header view #18826