### PR TITLE
Disable run button's animation when reduced motion is preferred

### DIFF
--- a/frontend/src/metabase/css/query_builder.css
+++ b/frontend/src/metabase/css/query_builder.css
@@ -542,6 +542,14 @@
   opacity: 0;
 }
 
+@media (prefers-reduced-motion) {
+  .RunButton,
+  .RunButton.RunButton--compact,
+  .RunButton.RunButton--hidden {
+    transition-duration: 10ms;
+  }
+}
+
 /* DATA REFERENCE */
 
 .SideDrawer {


### PR DESCRIPTION
How to verify:

1. Make sure to enable [prefers-reduced-motion](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion#user_preferences)
2. Ask a question, Custom question
3. Sample Dataset, Orders table
4. Click Hide editor (top right)
5. Click the big Run button to start the query
![image](https://user-images.githubusercontent.com/7288/140111776-3cac2e18-46bd-4520-8969-d554b4238133.png)

**Before this PR**

Right after being clicked, the Run button animates (moves a bit, also changes its opacity).

**After this PR**

The run button does not animate at all.
