### PR TITLE
Add special case for sample dataset exploration

### DIFF
--- a/frontend/src/metabase/containers/CandidateListLoader.jsx
+++ b/frontend/src/metabase/containers/CandidateListLoader.jsx
@@ -95,12 +95,15 @@ class CandidateListLoader extends React.Component {
     try {
       const { databaseId } = this.state;
       if (databaseId != null) {
+        const database = await MetabaseApi.db_get({
+          dbId: databaseId,
+        });
         const candidates = await AutoApi.db_candidates({
           id: databaseId,
         });
         if (candidates && candidates.length > 0) {
           this._clearTimers();
-          this.setState({ candidates });
+          this.setState({ candidates, isSample: database.is_sample });
         }
       }
     } catch (e) {

--- a/frontend/src/metabase/setup/containers/PostSetupApp.jsx
+++ b/frontend/src/metabase/setup/containers/PostSetupApp.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from "react";
 import { Link } from "react-router";
 import cx from "classnames";
-import { t } from "ttag";
+import { jt, t } from "ttag";
 
 import fitViewport from "metabase/hoc/FitViewPort";
 
@@ -74,12 +74,14 @@ export default class PostSetupApp extends Component {
                 );
               }
               return (
-                <Card px={3} py={1}>
+                <Card p={3}>
                   <ExplorePane
                     candidates={candidates}
                     description={
                       isSample
-                        ? t`Once you connect your own data, I can show you some automatic explorations called x-rays. Here are some examples with sample data.`
+                        ? jt`While we’re syncing your data, you can check out these explorations of our ${(
+                            <strong>{t`Sample Dataset`}</strong>
+                          )}. Hope you like them!`
                         : t`I took a look at the data you just connected, and I have some explorations of interesting things I found. Hope you like them!`
                     }
                   />


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/18675

Changes copy and paddings for sample dataset exploration. 

<img width="660" alt="Screen Shot 2021-11-03 at 9 36 08 pm" src="https://user-images.githubusercontent.com/8542534/140171868-678161fd-8ff8-4f87-b2c2-c317025e4939.png">


