### PR TITLE
Annotate collection tree with datasets and cards

### DIFF
--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -764,8 +764,7 @@
           :card
           :additional-constraints [(if (= schema (table-api/root-collection-schema-name))
                                       [:= :collection_id nil]
-                                      [:in :collection_id (api/check-404 (seq (db/select-ids Collection :name schema)))])
-                                   [:= :dataset false]])
+                                      [:in :collection_id (api/check-404 (seq (db/select-ids Collection :name schema)))])])
          (map table-api/card->virtual-table))))
 
 (api/defendpoint GET ["/:virtual-db/datasets/:schema"
@@ -777,8 +776,7 @@
           :dataset
           :additional-constraints [(if (= schema (table-api/root-collection-schema-name))
                                       [:= :collection_id nil]
-                                      [:in :collection_id (api/check-404 (seq (db/select-ids Collection :name schema)))])
-                                   [:= :dataset true]])
+                                      [:in :collection_id (api/check-404 (seq (db/select-ids Collection :name schema)))])])
          (map table-api/card->virtual-table))))
 
 (api/defendpoint GET "/db-ids-with-deprecated-drivers"

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -4,6 +4,7 @@
   `metabase.models.collection.graph`. `metabase.models.collection.graph`"
   (:refer-clojure :exclude [ancestors descendants])
   (:require [clojure.core.memoize :as memoize]
+            [clojure.set :as set]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
             [honeysql.core :as hsql]
@@ -1038,20 +1039,48 @@
                                :allowed-namespaces   allowed-namespaces
                                :collection-namespace collection-namespace})))))))
 
+(defn annotate-collections
+  [{:keys [dataset card] :as _coll-type-ids} collections]
+  (let [parent-info (reduce (fn [m {:keys [location id] :as _collection}]
+                              (let [parent-ids (set (location-path->ids location))]
+                                (cond-> m
+                                  (contains? dataset id)
+                                  (update :dataset set/union parent-ids)
+                                  (contains? card id)
+                                  (update :card set/union parent-ids))))
+                            {:dataset #{} :card #{}}
+                            collections)]
+    (map (fn [{:keys [id] :as collection}]
+           (let [types (cond-> #{}
+                         (contains? (:dataset parent-info) id)
+                         (conj :dataset)
+                         (contains? (:card parent-info) id)
+                         (conj :card))]
+             (cond-> collection
+               (seq types) (assoc :below types)
+               (contains? dataset id) (update :here (fnil conj #{}) :dataset)
+               (contains? card id) (update :here (fnil conj #{}) :card))))
+         collections)))
+
 (defn collections->tree
   "Convert a flat sequence of Collections into a tree structure e.g.
 
-    (collections->tree [A B C D E F G])
+    (collections->tree {:dataset #{C D} :card #{F C} [A B C D E F G])
     ;; ->
     [{:name     \"A\"
+      :below    #{:card :dataset}
       :children [{:name \"B\"}
                  {:name     \"C\"
+                  :here     #{:dataset :card}
+                  :below    #{:dataset :card}
                   :children [{:name     \"D\"
+                              :here     #{:dataset}
                               :children [{:name \"E\"}]}
                              {:name     \"F\"
+                              :here     #{:card}
                               :children [{:name \"G\"}]}]}]}
      {:name \"H\"}]"
-  [collections]
+  [coll-type-ids collections]
   (let [all-visible-ids (set (map :id collections))]
     (transduce
      identity
@@ -1087,4 +1116,4 @@
              (map #(update % :children ->tree))
              (sort-by (fn [{coll-name :name, coll-id :id}]
                         [((fnil u/lower-case-en "") coll-name) coll-id])))))
-     collections)))
+     (annotate-collections coll-type-ids collections))))

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -1040,6 +1040,8 @@
                                :collection-namespace collection-namespace})))))))
 
 (defn annotate-collections
+  "Annotate collections with `:below` and `:here` keys to indicate which types are in their subtree and which types are
+  in the collection at that level."
   [{:keys [dataset card] :as _coll-type-ids} collections]
   (let [parent-info (reduce (fn [m {:keys [location id] :as _collection}]
                               (let [parent-ids (set (location-path->ids location))]

--- a/test/metabase/models/collection_test.clj
+++ b/test/metabase/models/collection_test.clj
@@ -1584,18 +1584,19 @@
                            (not (seq (:children x))) (dissoc :children))
                          x))
                      %)]
-    (is (= [{:id 1 :name "a" :location "/" :here #{:card} :below #{:card :dataset}}
-            {:id 2, :name "b", :location "/1/" :below #{:dataset}}
-            {:id 3, :name "c", :location "/1/2/" :here #{:dataset} :below #{:dataset}}
-            {:id 4, :name "d", :location "/1/2/3/" :here #{:dataset}}
-            {:id 5, :name "e", :location "/1/" :here #{:card}}]
+    (is (= [{:id 1 :name "a" :location "/"       :here #{:card}    :below #{:card :dataset}}
+            {:id 2 :name "b" :location "/1/"                       :below #{:dataset}}
+            {:id 3 :name "c" :location "/1/2/"   :here #{:dataset} :below #{:dataset}}
+            {:id 4 :name "d" :location "/1/2/3/" :here #{:dataset}}
+            {:id 5 :name "e" :location "/1/"     :here #{:card}}]
            (collection/annotate-collections {:card #{1 5} :dataset #{3 4}} collections)))
     (is (= [{:id 1 :here #{:card} :below #{:card :dataset}
-             :children [{:id 2 :below #{:dataset}
-                         :children
-                         [{:id 3 :here #{:dataset} :below #{:dataset}
-                           :children
-                           [{:id 4 :here #{:dataset}}]}]}
-                        {:id 5 :here #{:card}}]}]
+             :children
+             [{:id 2 :below #{:dataset}
+               :children
+               [{:id 3 :here #{:dataset} :below #{:dataset}
+                 :children
+                 [{:id 4 :here #{:dataset}}]}]}
+              {:id 5 :here #{:card}}]}]
            (clean (collection/collections->tree {:card #{1 5} :dataset #{3 4}}
                                                 collections))))))

--- a/test/metabase/models/collection_test.clj
+++ b/test/metabase/models/collection_test.clj
@@ -3,6 +3,7 @@
   (:require [clojure.math.combinatorics :as math.combo]
             [clojure.string :as str]
             [clojure.test :refer :all]
+            [clojure.walk :as walk]
             [metabase.api.common :refer [*current-user-permissions-set*]]
             [metabase.models :refer [Card Collection Dashboard NativeQuerySnippet Permissions PermissionsGroup Pulse User]]
             [metabase.models.collection :as collection]
@@ -1478,21 +1479,28 @@
   (is (= [{:name     "A"
            :id       1
            :location "/"
+           :below    #{:dataset :card}
            :children [{:name "B", :id 2, :location "/1/", :children []}
                       {:name     "C"
                        :id       3
                        :location "/1/"
+                       :below    #{:dataset :card}
                        :children [{:name     "D"
                                    :id       4
                                    :location "/1/3/"
-                                   :children [{:name "E", :id 5, :location "/1/3/4/", :children []}]}
+                                   :here     #{:dataset}
+                                   :below    #{:dataset}
+                                   :children [{:name "E", :id 5, :location "/1/3/4/",
+                                               :children [] :here #{:dataset}}]}
                                   {:name     "F"
                                    :id       6
                                    :location "/1/3/"
+                                   :here     #{:card}
                                    :children [{:name "G", :id 7, :location "/1/3/6/", :children []}]}]}]}
-          {:name "aaa", :id 9, :location "/", :children []}
+          {:name "aaa", :id 9, :location "/", :children [] :here #{:card}}
           {:name "H", :id 8, :location "/", :children []}]
          (collection/collections->tree
+          {:dataset #{4 5} :card #{6 9}}
           [{:name "A", :id 1, :location "/"}
            {:name "B", :id 2, :location "/1/"}
            {:name "C", :id 3, :location "/1/"}
@@ -1503,12 +1511,13 @@
            {:name "H", :id 8, :location "/"}
            {:name "aaa", :id 9, :location "/"}])))
   (is (= []
-         (collection/collections->tree nil)
-         (collection/collections->tree [])))
+         (collection/collections->tree {} nil)
+         (collection/collections->tree {} [])))
   (testing "Make sure it doesn't throw an NPE if Collection name is nil for some reason (FE test data?)"
     (is (= [{:name nil, :location "/", :id 1, :children []}
             {:name "a", :location "/", :id 2, :children []}]
-           (collection/collections->tree [{:name nil, :location "/", :id 1}
+           (collection/collections->tree {}
+                                         [{:name nil, :location "/", :id 1}
                                           {:name "a", :location "/", :id 2}])))))
 
 (deftest collections->tree-missing-parents-test
@@ -1522,8 +1531,11 @@
     (is (= [{:name     "Child"
              :location "/1/"
              :id       2
-             :children [{:name "Grandchild", :location "/1/2/", :id 3, :children []}]}]
-           (collection/collections->tree [{:name "Child", :location "/1/", :id 2}
+             :here     #{:card}
+             :below    #{:card}
+             :children [{:name "Grandchild", :location "/1/2/", :id 3, :children [] :here #{:card}}]}]
+           (collection/collections->tree {:card #{1 2 3}}
+                                         [{:name "Child", :location "/1/", :id 2}
                                           {:name "Grandchild", :location "/1/2/", :id 3}])))))
 
 (deftest collections->tree-permutations-test
@@ -1556,4 +1568,34 @@
                              :name     "a"
                              :location "/3/"
                              :children []}]}]
-               (collection/collections->tree collections)))))))
+               (collection/collections->tree {} collections)))))))
+
+(deftest annotate-collections-test
+  (let [collections [{:id 1, :name "a", :location "/"}
+                     {:id 2, :name "b", :location "/1/"}
+                     {:id 3, :name "c", :location "/1/2/"}
+                     {:id 4, :name "d", :location "/1/2/3/"}
+                     {:id 5, :name "e", :location "/1/"}]
+        clean      #(walk/prewalk
+                     (fn [x]
+                       ;; select important keys and remove empty children
+                       (if (map? x)
+                         (cond-> (select-keys x [:id :here :below :children])
+                           (not (seq (:children x))) (dissoc :children))
+                         x))
+                     %)]
+    (is (= [{:id 1 :name "a" :location "/" :here #{:card} :below #{:card :dataset}}
+            {:id 2, :name "b", :location "/1/" :below #{:dataset}}
+            {:id 3, :name "c", :location "/1/2/" :here #{:dataset} :below #{:dataset}}
+            {:id 4, :name "d", :location "/1/2/3/" :here #{:dataset}}
+            {:id 5, :name "e", :location "/1/" :here #{:card}}]
+           (collection/annotate-collections {:card #{1 5} :dataset #{3 4}} collections)))
+    (is (= [{:id 1 :here #{:card} :below #{:card :dataset}
+             :children [{:id 2 :below #{:dataset}
+                         :children
+                         [{:id 3 :here #{:dataset} :below #{:dataset}
+                           :children
+                           [{:id 4 :here #{:dataset}}]}]}
+                        {:id 5 :here #{:card}}]}]
+           (clean (collection/collections->tree {:card #{1 5} :dataset #{3 4}}
+                                                collections))))))


### PR DESCRIPTION
Addresses #18672 

In order to know which collections have items of interest, they are
annotated with two new keys: `:here` and `:below`. These keys will have
a collection (in clojure a set, in js an array) which could contain
dataset and card, depending if they have those items "here" or in
collections below this node.

We include information about which subtrees are interesting so we know
to show or highlight those. We include information about which nodes
have interesting things versus which contain nodes which have things so
we can possibly implement drilldown in an intelligent manner.

ie

```
.
├── root
```

could expand automatically to

```
.
├── root
│   ├── collection
│   │   ├── collection that actually has items
```

without requiring someone to click on the intermediate collection which
has no items itself, just a collection with items.

http://localhost:3000/api/collection/tree?tree=true

```js
{
    "name": "super",
    "id": 154,
    "location": "/",
    "below": ["dataset"]  ;; indicates collections below have datasets
    "children": [{
        "name": "parent",
        "id": 155,
        "location": "/154/",
        "below": ["dataset"]  ;; indicates the same
        "children": [{
            "children": [],
            "slug": "contains",
            "name": "contains",
            "here": ["dataset"],  ;; this node has datasets
            "id": 157,
            "location": "/154/155/",
        }],

    }, {
        "children": [],
        "name": "sibling",
        "id": 156,
        "location": "/154/",
    }],
}
```
