### PR TITLE
docs - custom expressions

### DIFF
--- a/docs/users-guide/expressions-list.md
+++ b/docs/users-guide/expressions-list.md
@@ -1,6 +1,6 @@
 # List of expressions
 
-For an intro to expressions, check out [Writing expressions in the notebook editor][expressions].
+For an introduction to expressions, check out [Writing expressions in the notebook editor][expressions].
 
 - [Aggregations](#aggregations)
   - [Average](#average)
@@ -229,7 +229,7 @@ Example: `ceil([Price])`. `ceil(2.99)` would return 3.
 
 Databases that don't support `ceil`: BigQuery.
 
-Related: [floor](#floor), [round](round).
+Related: [floor](#floor), [round](#round).
 
 ### coalesce
 
@@ -455,19 +455,19 @@ Example: `upper([Status])`. If status were "hyper", `upper("hyper")` would retur
 
 Limitations are noted for each aggregation and function above, and here there are in summary:
 
-**BigQuery**: `abs`, `ceil`, `floor`, `median`, `percentile` and `round`
+**BigQuery**: `abs`, `ceil`, `floor`, `Median`, `Percentile` and `round`
 
-**H2**: `median`, `percentile` and `regexextract`
+**H2**: `Median`, `Percentile` and `regexextract`
 
-**MySQL**: `median`, `percentile` and `regexextract`
+**MySQL**: `Median`, `Percentile` and `regexextract`
 
-**SQL Server**: `median`, `percentile` and `regexextract`
+**SQL Server**: `Median`, `Percentile` and `regexextract`
 
-**SQLite**: `log`, `median`, `percentile`, `power`, `regexextract`, `standarddeviation`, `sqrt` and `variance`
+**SQLite**: `log`, `Median`, `Percentile`, `power`, `regexextract`, `StandardDeviation`, `sqrt` and `Variance`
 
-**Vertica**: `median` and `percentile`
+**Vertica**: `Median` and `Percentile`
 
-Additionally, **Presto** only provides _approximate_ results for `median` and `percentile`.
+Additionally, **Presto** only provides _approximate_ results for `Median` and `Percentile`.
 
 If you're using or maintaining a third-party database driver, please [refer to the wiki](https://github.com/metabase/metabase/wiki/What's-new-in-0.35.0-for-Metabase-driver-authors) to see how your driver might be impacted.
 

--- a/docs/users-guide/expressions-list.md
+++ b/docs/users-guide/expressions-list.md
@@ -1,59 +1,58 @@
-
 # List of expressions
 
 For an intro to expressions, check out [Writing expressions in the notebook editor][expressions].
 
-    - [Aggregations](#aggregations)
-        - [Avg](#avg)
-        - [Count](#count)
-        - [CountIf](#countif)
-        - [CumulativeCount](#cumulativecount)
-        - [CumulativeSum](#cumulativesum)
-        - [Distinct](#distinct)
-        - [Max](#max)
-        - [Median](#median)
-        - [Min](#min)
-        - [Percentile](#percentile)
-        - [Share](#share)
-        - [StandardDeviation](#standarddeviation)
-        - [Sum](#sum)
-        - [SumIf](#sumif)
-        - [Variance](#variance)
-    - [Functions](#functions)
-        - [abs](#abs)
-        - [between](#between)
-        - [case](#case)
-        - [ceil](#ceil)
-        - [coalesce](#coalesce)
-        - [concat](#concat)
-        - [contains](#contains)
-        - [endswith](#endswith)
-        - [exp](#exp)
-        - [floor](#floor)
-        - [interval](#interval)
-        - [isempty](#isempty)
-        - [isnull](#isnull)
-        - [lefttrim](#lefttrim)
-        - [length](#length)
-        - [log](#log)
-        - [lower](#lower)
-        - [power](#power)
-        - [regexextract](#regexextract)
-        - [replace](#replace)
-        - [righttrim](#righttrim)
-        - [round](#round)
-        - [sqrt](#sqrt)
-        - [startswith](#startswith)
-        - [substring](#substring)
-        - [trim](#trim)
-        - [upper](#upper)
-    - [Database limitations](#database-limitations)
+- [Aggregations](#aggregations)
+  - [Average](#average)
+  - [Count](#count)
+  - [CountIf](#countif)
+  - [CumulativeCount](#cumulativecount)
+  - [CumulativeSum](#cumulativesum)
+  - [Distinct](#distinct)
+  - [Max](#max)
+  - [Median](#median)
+  - [Min](#min)
+  - [Percentile](#percentile)
+  - [Share](#share)
+  - [StandardDeviation](#standarddeviation)
+  - [Sum](#sum)
+  - [SumIf](#sumif)
+  - [Variance](#variance)
+- [Functions](#functions)
+  - [abs](#abs)
+  - [between](#between)
+  - [case](#case)
+  - [ceil](#ceil)
+  - [coalesce](#coalesce)
+  - [concat](#concat)
+  - [contains](#contains)
+  - [endswith](#endswith)
+  - [exp](#exp)
+  - [floor](#floor)
+  - [interval](#interval)
+  - [isempty](#isempty)
+  - [isnull](#isnull)
+  - [lefttrim](#lefttrim)
+  - [length](#length)
+  - [log](#log)
+  - [lower](#lower)
+  - [power](#power)
+  - [regexextract](#regexextract)
+  - [replace](#replace)
+  - [righttrim](#righttrim)
+  - [round](#round)
+  - [sqrt](#sqrt)
+  - [startswith](#startswith)
+  - [substring](#substring)
+  - [trim](#trim)
+  - [upper](#upper)
+- [Database limitations](#database-limitations)
 
 ## Aggregations
 
 Aggregation expressions take into account all values in a field. They can only be used in the **Summarize** section of the notebook editor.
 
-### Avg
+### Average
 
 Returns the average of the values in the column.
 
@@ -93,7 +92,7 @@ Syntax: `CumulativeSum(column)`.
 
 Example: `CumulativeSum([Subtotal])`.
 
-See also [Sum](#sum) and [SumIf](#sumif).
+Related: [Sum](#sum) and [SumIf](#sumif).
 
 ### Distinct
 
@@ -111,7 +110,7 @@ Syntax: `Max(column)`.
 
 Example: `Max([Age])` would return the oldest age found across all values in the `Age` column.
 
-See also [Min](#min), [Avg](#avg), [Median](#median).
+Related: [Min](#min), [Average](#average), [Median](#median).
 
 ### Median
 
@@ -123,7 +122,7 @@ Example: `Median([Age])` would find the midpoint age where half of the ages are 
 
 Databases that don't support `median`: BigQuery, SQLite, Vertica, SQL server, MySQL. Presto only provides approximate results.
 
-See also [Min](#min), [Max](#max), [Avg](#avg).
+Related: [Min](#min), [Max](#max), [Average](#average).
 
 ### Min
 
@@ -132,6 +131,8 @@ Returns the smallest value found in the column.
 Syntax: `Min(column)`.
 
 Example: `Min([Salary])` would find the lowest salary among all salaries in the `Salary` column.
+
+Related: [Max](#max), [Median](#median), [Average](#average).
 
 ### Percentile
 
@@ -145,11 +146,12 @@ Databases that don't support `percentile`: BigQuery, H2, MySQL, SQL Server, SQLi
 
 ### Share
 
+Returns the percent of rows in the data that match the condition, as a decimal.
+
 Syntax: `Share(condition)`
 
 Example: `Share([Color] = "Blue")` would return the number of rows with the `Color` field set to `Blue`, divided by the total number of rows.
 
-Returns the percent of rows in the data that match the condition, as a decimal.
 
 ### StandardDeviation
 
@@ -183,7 +185,7 @@ Syntax: `Variance(column)`
 
 Example: `Variance([Temperature])` will return a measure of the dispersion from the mean temperature for all temps in that column.
 
-See also [StandardDeviation](#standarddeviation), [Avg](#avg).
+Related: [StandardDeviation](#standarddeviation), [Average](#average).
 
 ## Functions
 
@@ -191,7 +193,7 @@ Function expressions apply to each individual value. They can be used to alter o
 
 ### abs
 
-Returns the absolute (positive) value of the specified column. |
+Returns the absolute (positive) value of the specified column.
 
 Syntax: `abs(column)`
 
@@ -206,6 +208,8 @@ Checks a date or number column's values to see if they're within the specified r
 Syntax: `between(column, start, end)`
 
 Example: `between([Created At], "2019-01-01", "2020-12-31")` would return rows where `Created At` date fell within the range of January 1, 2019 and December 31, 2020.
+
+Related: [interval](#interval).
 
 ### case
 
@@ -225,7 +229,7 @@ Example: `ceil([Price])`. `ceil(2.99)` would return 3.
 
 Databases that don't support `ceil`: BigQuery.
 
-See also [Floor](#floor).
+Related: [floor](#floor), [round](round).
 
 ### coalesce
 
@@ -251,6 +255,8 @@ Syntax: `contains(string1, string2)`
 
 Example: `contains([Status], "Class")`. If `Status` were "Classified", the expression would return `true`.
 
+Related: [regexextract](#regexextract).
+
 ### endswith
 
 Returns true if the end of the text matches the comparison text.
@@ -259,15 +265,17 @@ Syntax: `endsWith(text, comparison)`
 
 `endsWith([Appetite], "hungry")`
 
-See also [contains](#contains) and [startswith](#startswith).
+Related: [contains](#contains) and [startswith](#startswith).
 
 ### exp
 
-Returns [Euler's number](https://en.wikipedia.org/wiki/E_(mathematical_constant), e, raised to the power of the supplied number. (Euler sounds like "Oy-ler").
+Returns [Euler's number](https://en.wikipedia.org/wiki/E_(mathematical_constant)), e, raised to the power of the supplied number. (Euler sounds like "Oy-ler").
 
 Syntax: `exp(column)`.
 
 Example: `exp([Interest Months])`
+
+Related: [power](#power).
 
 ### floor
 
@@ -279,7 +287,7 @@ Example: `floor([Price])`. If the `Price` were 1.99, the expression would return
 
 Databases that don't support `floor`: BigQuery.
 
-See also [ceil](#ceil).
+Related: [ceil](#ceil), [round](#round).
 
 ### interval
 
@@ -288,6 +296,8 @@ Checks a date column's values to see if they're within the relative range.
 Syntax: `interval(column, number, text)`.
 
 Example: `interval([Created At], -1, "month")`.
+
+Related: [between](#between).
 
 ### isempty
 
@@ -313,7 +323,7 @@ Syntax: `ltrim(text)`
 
 Example: `ltrim([Comment])`. If the comment were " I'd prefer not to", `ltrim` would return "I'd prefer not to".
 
-See also [trim](#trim) and [righttrim](#righttrim).
+Related: [trim](#trim) and [righttrim](#righttrim).
 
 ### length
 
@@ -321,7 +331,7 @@ Returns the number of characters in text.
 
 Syntax: `length(text)`
 
-Example: `length([Comment])` If the `comment` were "wizard", `length` would return 6 ("wizard" has six characters). |
+Example: `length([Comment])` If the `comment` were "wizard", `length` would return 6 ("wizard" has six characters).
 
 ### log
 
@@ -337,7 +347,9 @@ Returns the string of text in all lower case.
 
 Syntax: `lower(text)`.
 
-Example: `lower([Status])`. If the `Status` were "Chillin''", the expression would return "chillin'".
+Example: `lower([Status])`. If the `Status` were "QUIET", the expression would return "quiet".
+
+Related: [upper](#upper).
 
 ### power
 
@@ -349,6 +361,8 @@ Example: `power([Length], 2)`. If the length were `3`, the expression would retu
 
 Databases that don't support `power`: SQLite.
 
+Related: [exp](#exp).
+
 ### regexextract
 
 Extracts matching substrings according to a regular expression.
@@ -358,6 +372,8 @@ Syntax: `regexextract(text, regular_expression)`.
 Example: `regexextract([Address], "[0-9]+")`.
 
 Databases that don't support `regexextract`: H2, MySQL, SQL Server, SQLite.
+
+Related: [contains](#contains).
 
 ### replace
 
@@ -375,7 +391,7 @@ Syntax: `rtrim(text)`
 
 Example: `rtrim([Comment])`. If the comment were "Fear is the mindkiller. ", the expression would return "Fear is the mindkiller."
 
-See also [trim](#trim) and [lefttrim](#lefttrim).
+Related: [trim](#trim) and [lefttrim](#lefttrim).
 
 ### round
 
@@ -397,7 +413,7 @@ Example: `sqrt([Hypotenuse])`.
 
 Databases that don't support `sqrt`: SQLite.
 
-See also [Power](#power).
+Related: [Power](#power).
 
 ### startswith
 
@@ -407,6 +423,8 @@ Syntax: `startsWith(text, comparison)`.
 
 Example: `startsWith([Course Name], "Computer Science")` would return true for course names that began with "Computer Science", like "Computer Science 101: An introduction".
 
+Related: [endswith](#endswith), [contains](#contains).
+
 ### substring
 
 Returns a portion of the supplied text, specified by a starting position and a length.
@@ -414,6 +432,8 @@ Returns a portion of the supplied text, specified by a starting position and a l
 Syntax: `substring(text, position, length)`
 
 Example: `substring([Title], 0, 10)` returns the first 11 letters of a string (the string index starts at position 0).
+
+Related: [replace](#replace).
 
 ### trim
 

--- a/docs/users-guide/expressions-list.md
+++ b/docs/users-guide/expressions-list.md
@@ -10,7 +10,7 @@ There are two basic types of expressions, Aggregations and Functions. Aggregatio
 
 Aggregation expressions take into account all values in a field, therefore they cannot be used to filter data.
 
-### Average
+### Avg
 
 Returns the average of the values in the column.
 
@@ -270,7 +270,7 @@ Syntax: `ltrim(text)`
 
 Example: `ltrim([Comment])`. If the comment were " I'd prefer not to", `ltrim` would return "I'd prefer not to".
 
-See also [Trim](#trim) and [Right trim](#right-trim).
+See also [trim](#trim) and [righttrim](#righttrim).
 
 ### length
 
@@ -306,7 +306,7 @@ Example: `power([Length], 2)`. If the length were `3`, the expression would retu
 
 Databases that don't support `power`: SQLite.
 
-### RegexExtract
+### regexextract
 
 Extracts matching substrings according to a regular expression.
 
@@ -316,7 +316,7 @@ Example: `regexextract([Address], "[0-9]+")`.
 
 Databases that don't support `regexextract`: H2, MySQL, SQL Server, SQLite.
 
-### Replace
+### replace
 
 Replaces a part of the input text with new text.
 
@@ -324,7 +324,7 @@ Syntax: `replace(text, find, replace)`.
 
 Example: `replace([Title], "Enormous", "Gigantic")`.
 
-### Right Trim
+### righttrim
 
 Removes trailing whitespace from a string of text.
 
@@ -332,9 +332,9 @@ Syntax: `rtrim(text)`
 
 Example: `rtrim([Comment])`. If the comment were "Fear is the mindkiller. ", the expression would return "Fear is the mindkiller."
 
-See also [Trim](#trim) and [Left trim](#left-trim).
+See also [trim](#trim) and [lefttrim](#lefttrim).
 
-### Round
+### round
 
 Rounds a decimal number either up or down to the nearest integer value.
 
@@ -344,7 +344,7 @@ Example: `round([Temperature])`. If the temp were `13.5` degrees centigrade, the
 
 Databases that don't support `round`: BigQuery.
 
-### Sqrt
+### sqrt
 
 Returns the square root of a value.
 
@@ -356,7 +356,7 @@ Databases that don't support `sqrt`: SQLite.
 
 See also [Power](#power).
 
-### Starts with
+### startswith
 
 Returns true if the beginning of the text matches the comparison text.
 
@@ -364,7 +364,7 @@ Syntax: `startsWith(text, comparison)`.
 
 Example: `startsWith([Course Name], "Computer Science")` would return true for course names that began with "Computer Science", like "Computer Science 101: An introduction".
 
-### Substring
+### substring
 
 Returns a portion of the supplied text, specified by a starting position and a length.
 
@@ -372,7 +372,7 @@ Syntax: `substring(text, position, length)`
 
 Example: `substring([Title], 0, 10)` returns the first 11 letters of a string (the string index starts at position 0).
 
-### Trim
+### trim
 
 Removes leading and trailing whitespace from a string of text.
 
@@ -380,7 +380,7 @@ Syntax: `trim(text)`
 
 Example: `trim([Comment])` will remove any whitespace characters on either side of a comment.
 
-### Upper
+### upper
 
 Returns the text in all upper case.
 
@@ -388,7 +388,7 @@ Syntax: `upper(text)`.
 
 Example: `upper([Status])`. If status were "hyper", `upper("hyper")` would return "HYPER".
 
-### Database limitations
+## Database limitations
 
 Limitations are noted for each aggregation and function above, and here there are in summary:
 
@@ -410,5 +410,4 @@ If you're using or maintaining a third-party database driver, please [refer to t
 
 See [Custom expressions in the notebook editor](https://www.metabase.com/blog/custom-expressions/index.html) to learn more.
 
-
-[expressions]: expressions.md
+[expressions]: expressions.html

--- a/docs/users-guide/expressions-list.md
+++ b/docs/users-guide/expressions-list.md
@@ -364,7 +364,7 @@ Syntax: `regexextract(text, regular_expression)`.
 
 Example: `regexextract([Address], "[0-9]+")`.
 
-Databases that don't support `regexextract`: H2, MySQL, SQL Server, SQLite.
+Databases that don't support `regexextract`: H2, SQL Server, SQLite.
 
 Related: [contains](#contains).
 
@@ -448,7 +448,7 @@ Limitations are noted for each aggregation and function above, and here there ar
 
 **H2**: `Median`, `Percentile` and `regexextract`
 
-**MySQL**: `Median`, `Percentile` and `regexextract`
+**MySQL/MariaDB**: `Median`, `Percentile`.
 
 **SQL Server**: `Median`, `Percentile` and `regexextract`
 

--- a/docs/users-guide/expressions-list.md
+++ b/docs/users-guide/expressions-list.md
@@ -120,7 +120,7 @@ Syntax: `Median(column)`.
 
 Example: `Median([Age])` would find the midpoint age where half of the ages are older, and half of the ages are younger.
 
-Databases that don't support `median`: BigQuery, SQLite, Vertica, SQL server, MySQL. Presto only provides approximate results.
+Databases that don't support `median`: SQLite, Vertica, SQL server, MySQL. Presto only provides approximate results.
 
 Related: [Min](#min), [Max](#max), [Average](#average).
 
@@ -142,7 +142,7 @@ Syntax: `Percentile(column, percentile-value)`
 
 Example: `Percentile([Score], 0.9)` would return the value at the 90th percentile for all values in that column.
 
-Databases that don't support `percentile`: BigQuery, H2, MySQL, SQL Server, SQLite, Vertica. Presto only provides approximate results.
+Databases that don't support `percentile`: H2, MySQL, SQL Server, SQLite, Vertica. Presto only provides approximate results.
 
 ### Share
 
@@ -198,8 +198,6 @@ Syntax: `abs(column)`
 
 Example: `abs([Debt])`. If `Debt` were -100, `abs(-100)` would return `100`.
 
-Databases that don't support `abs`: BigQuery.
-
 ### between
 
 Checks a date or number column's values to see if they're within the specified range.
@@ -225,8 +223,6 @@ Rounds a decimal up (ciel as in ceiling).
 Syntax: `ceil(column)`.
 
 Example: `ceil([Price])`. `ceil(2.99)` would return 3.
-
-Databases that don't support `ceil`: BigQuery.
 
 Related: [floor](#floor), [round](#round).
 
@@ -283,8 +279,6 @@ Rounds a decimal number down.
 Syntax: `floor(column)`
 
 Example: `floor([Price])`. If the `Price` were 1.99, the expression would return 1.
-
-Databases that don't support `floor`: BigQuery.
 
 Related: [ceil](#ceil), [round](#round).
 
@@ -400,8 +394,6 @@ Syntax: `round(column)`.
 
 Example: `round([Temperature])`. If the temp were `13.5` degrees centigrade, the expression would return `14`.
 
-Databases that don't support `round`: BigQuery.
-
 ### sqrt
 
 Returns the square root of a value.
@@ -453,8 +445,6 @@ Example: `upper([Status])`. If status were "hyper", `upper("hyper")` would retur
 ## Database limitations
 
 Limitations are noted for each aggregation and function above, and here there are in summary:
-
-**BigQuery**: `abs`, `ceil`, `floor`, `Median`, `Percentile` and `round`
 
 **H2**: `Median`, `Percentile` and `regexextract`
 

--- a/docs/users-guide/expressions-list.md
+++ b/docs/users-guide/expressions-list.md
@@ -1,14 +1,57 @@
+
 # List of expressions
 
 For an intro to expressions, check out [Writing expressions in the notebook editor][expressions].
 
-## Types of expressions
-
-There are two basic types of expressions, Aggregations and Functions. Aggregations take values from multiple rows to perform a calculation, such as finding the average value from all values in a column. Functions, by contrast, do something to each value in a column, like searching for a word in each value, rounding each value up (the `ceil` function), and so on.
+    - [Aggregations](#aggregations)
+        - [Avg](#avg)
+        - [Count](#count)
+        - [CountIf](#countif)
+        - [CumulativeCount](#cumulativecount)
+        - [CumulativeSum](#cumulativesum)
+        - [Distinct](#distinct)
+        - [Max](#max)
+        - [Median](#median)
+        - [Min](#min)
+        - [Percentile](#percentile)
+        - [Share](#share)
+        - [StandardDeviation](#standarddeviation)
+        - [Sum](#sum)
+        - [SumIf](#sumif)
+        - [Variance](#variance)
+    - [Functions](#functions)
+        - [abs](#abs)
+        - [between](#between)
+        - [case](#case)
+        - [ceil](#ceil)
+        - [coalesce](#coalesce)
+        - [concat](#concat)
+        - [contains](#contains)
+        - [endswith](#endswith)
+        - [exp](#exp)
+        - [floor](#floor)
+        - [interval](#interval)
+        - [isempty](#isempty)
+        - [isnull](#isnull)
+        - [lefttrim](#lefttrim)
+        - [length](#length)
+        - [log](#log)
+        - [lower](#lower)
+        - [power](#power)
+        - [regexextract](#regexextract)
+        - [replace](#replace)
+        - [righttrim](#righttrim)
+        - [round](#round)
+        - [sqrt](#sqrt)
+        - [startswith](#startswith)
+        - [substring](#substring)
+        - [trim](#trim)
+        - [upper](#upper)
+    - [Database limitations](#database-limitations)
 
 ## Aggregations
 
-Aggregation expressions take into account all values in a field, therefore they cannot be used to filter data.
+Aggregation expressions take into account all values in a field. They can only be used in the **Summarize** section of the notebook editor.
 
 ### Avg
 
@@ -172,7 +215,7 @@ Syntax: `case(condition, output, …)`
 
 Example: `case([Weight] > 200, "Large", [Weight] > 150, "Medium", "Small")` If a `Weight` is 250, the expression would return "Large". In this case, the default value is "Small", so any `Weight` 150 or less would return "Small".
 
-## ceil
+### ceil
 
 Rounds a decimal up (ciel as in ceiling).
 
@@ -216,11 +259,11 @@ Syntax: `endsWith(text, comparison)`
 
 `endsWith([Appetite], "hungry")`
 
-See also [Contains](#contains) and [Starts with](#starts-with).
+See also [contains](#contains) and [startswith](#startswith).
 
 ### exp
 
-Returns [Euler's number](https://en.wikipedia.org/wiki/E_(mathematical_constant), e, raised to the power of the supplied number. (Euler sounds like "Oiler").
+Returns [Euler's number](https://en.wikipedia.org/wiki/E_(mathematical_constant), e, raised to the power of the supplied number. (Euler sounds like "Oy-ler").
 
 Syntax: `exp(column)`.
 
@@ -410,4 +453,4 @@ If you're using or maintaining a third-party database driver, please [refer to t
 
 See [Custom expressions in the notebook editor](https://www.metabase.com/blog/custom-expressions/index.html) to learn more.
 
-[expressions]: expressions.html
+[expressions]: ./expressions.html

--- a/docs/users-guide/expressions-list.md
+++ b/docs/users-guide/expressions-list.md
@@ -152,7 +152,6 @@ Syntax: `Share(condition)`
 
 Example: `Share([Color] = "Blue")` would return the number of rows with the `Color` field set to `Blue`, divided by the total number of rows.
 
-
 ### StandardDeviation
 
 Calculates the standard deviation of the column, which is a measure of the variation in a set of values. Low standard deviation indicates values cluster around the mean, whereas a high standard deviation means the values are spread out over a wide range.

--- a/docs/users-guide/expressions-list.md
+++ b/docs/users-guide/expressions-list.md
@@ -1,0 +1,414 @@
+# List of expressions
+
+For an intro to expressions, check out [Writing expressions in the notebook editor][expressions].
+
+## Types of expressions
+
+There are two basic types of expressions, Aggregations and Functions. Aggregations take values from multiple rows to perform a calculation, such as finding the average value from all values in a column. Functions, by contrast, do something to each value in a column, like searching for a word in each value, rounding each value up (the `ceil` function), and so on.
+
+## Aggregations
+
+Aggregation expressions take into account all values in a field, therefore they cannot be used to filter data.
+
+### Average
+
+Returns the average of the values in the column.
+
+Syntax: `Average(column)`
+
+Example: `Average([Quantity])` would return the mean for the `Quantity` field.
+
+### Count
+
+Returns the count of rows (also known as records) in the selected data.
+
+Syntax: `Count`
+
+Example: `Count` If a table or result returns 10 rows, `Count` will return `10`.
+
+### CountIf
+
+Only counts rows where the condition is true.
+
+Syntax: `CountIf(condition)`.
+
+Example: `CountIf([Subtotal] > 100)` would return the number of rows where the subtotal were greater than 100.
+
+### CumulativeCount
+
+The additive total of rows across a breakout.
+
+Syntax: `CumulativeCount`.
+
+Example: `CumulativeCount`.
+
+### CumulativeSum
+
+The rolling sum of a column across a breakout.
+
+Syntax: `CumulativeSum(column)`.
+
+Example: `CumulativeSum([Subtotal])`.
+
+See also [Sum](#sum) and [SumIf](#sumif).
+
+### Distinct
+
+The number of distinct values in this column.
+
+Syntax: `Distinct(column)`.
+
+`Distinct([Last Name])`. Returns the count of unique last names in the column. Duplicates (of the last name "Smith" for example) are not counted.
+
+### Max
+
+Returns the largest value found in the column.
+
+Syntax: `Max(column)`.
+
+Example: `Max([Age])` would return the oldest age found across all values in the `Age` column.
+
+See also [Min](#min), [Avg](#avg), [Median](#median).
+
+### Median
+
+Returns the median value of the specified column.
+
+Syntax: `Median(column)`.
+
+Example: `Median([Age])` would find the midpoint age where half of the ages are older, and half of the ages are younger.
+
+Databases that don't support `median`: BigQuery, SQLite, Vertica, SQL server, MySQL. Presto only provides approximate results.
+
+See also [Min](#min), [Max](#max), [Avg](#avg).
+
+### Min
+
+Returns the smallest value found in the column.
+
+Syntax: `Min(column)`.
+
+Example: `Min([Salary])` would find the lowest salary among all salaries in the `Salary` column.
+
+### Percentile
+
+Returns the value of the column at the percentile value.
+
+Syntax: `Percentile(column, percentile-value)`
+
+Example: `Percentile([Score], 0.9)` would return the value at the 90th percentile for all values in that column.
+
+Databases that don't support `percentile`: BigQuery, H2, MySQL, SQL Server, SQLite, Vertica. Presto only provides approximate results.
+
+### Share
+
+Syntax: `Share(condition)`
+
+Example: `Share([Color] = "Blue")` would return the number of rows with the `Color` field set to `Blue`, divided by the total number of rows.
+
+Returns the percent of rows in the data that match the condition, as a decimal.
+
+### StandardDeviation
+
+Calculates the standard deviation of the column, which is a measure of the variation in a set of values. Low standard deviation indicates values cluster around the mean, whereas a high standard deviation means the values are spread out over a wide range.
+
+Syntax: `StandardDeviation(column)`
+
+Example: `StandardDeviation([Population])` would return the SD for the values in the `Population` column.
+
+### Sum
+
+Adds up all the values of the column.
+
+Syntax: `Sum(column)`
+
+Example: `Sum([Subtotal])` would add up all the values in the `Subtotal` column.
+
+### SumIf
+
+Sums up the specified column only for rows where the condition is true.
+
+Syntax: `SumIf(column, condition)`.
+
+Example:`SumIf([Subtotal], [Order Status] = "Valid")` would add up all the subtotals for orders with a status of "Valid".
+
+### Variance
+
+Returns the numeric variance for a given column.
+
+Syntax: `Variance(column)`
+
+Example: `Variance([Temperature])` will return a measure of the dispersion from the mean temperature for all temps in that column.
+
+See also [StandardDeviation](#standarddeviation), [Avg](#avg).
+
+## Functions
+
+Function expressions apply to each individual value. They can be used to alter or filter values in a column, or create new, custom columns.
+
+### abs
+
+Returns the absolute (positive) value of the specified column. |
+
+Syntax: `abs(column)`
+
+Example: `abs([Debt])`. If `Debt` were -100, `abs(-100)` would return `100`.
+
+Databases that don't support `abs`: BigQuery.
+
+### between
+
+Checks a date or number column's values to see if they're within the specified range.
+
+Syntax: `between(column, start, end)`
+
+Example: `between([Created At], "2019-01-01", "2020-12-31")` would return rows where `Created At` date fell within the range of January 1, 2019 and December 31, 2020.
+
+### case
+
+Tests an expression against a list of cases and returns the corresponding value of the first matching case, with an optional default value if nothing else is met.
+
+Syntax: `case(condition, output, …)`
+
+Example: `case([Weight] > 200, "Large", [Weight] > 150, "Medium", "Small")` If a `Weight` is 250, the expression would return "Large". In this case, the default value is "Small", so any `Weight` 150 or less would return "Small".
+
+## ceil
+
+Rounds a decimal up (ciel as in ceiling).
+
+Syntax: `ceil(column)`.
+
+Example: `ceil([Price])`. `ceil(2.99)` would return 3.
+
+Databases that don't support `ceil`: BigQuery.
+
+See also [Floor](#floor).
+
+### coalesce
+
+Looks at the values in each argument in order and returns the first non-null value for each row.
+
+Syntax: `coalesce(value1, value2, …)`
+
+Example: `coalesce([Comments], [Notes], "No comments")`. If both the `Comments` and `Notes` columns are null for that row, the expression will return the string "No comments".
+
+### concat
+
+Combine two or more strings together.
+
+Syntax: `concat(value1, value2, …)`
+
+Example: `concat([Last Name], ", ", [First Name])` would produce a string of the format "Last Name, First Name", like "Palazzo, Enrico".
+
+### contains
+
+Checks to see if string1 contains string2 within it.
+
+Syntax: `contains(string1, string2)`
+
+Example: `contains([Status], "Class")`. If `Status` were "Classified", the expression would return `true`.
+
+### endswith
+
+Returns true if the end of the text matches the comparison text.
+
+Syntax: `endsWith(text, comparison)`
+
+`endsWith([Appetite], "hungry")`
+
+See also [Contains](#contains) and [Starts with](#starts-with).
+
+### exp
+
+Returns [Euler's number](https://en.wikipedia.org/wiki/E_(mathematical_constant), e, raised to the power of the supplied number. (Euler sounds like "Oiler").
+
+Syntax: `exp(column)`.
+
+Example: `exp([Interest Months])`
+
+### floor
+
+Rounds a decimal number down.
+
+Syntax: `floor(column)`
+
+Example: `floor([Price])`. If the `Price` were 1.99, the expression would return 1.
+
+Databases that don't support `floor`: BigQuery.
+
+See also [ceil](#ceil).
+
+### interval
+
+Checks a date column's values to see if they're within the relative range.
+
+Syntax: `interval(column, number, text)`.
+
+Example: `interval([Created At], -1, "month")`.
+
+### isempty
+
+Returns true if the column is empty.
+
+Syntax: `isempty(column)`
+
+Example: `isempty([Discount])` would return true if there were no value in the discount field.
+
+### isnull
+
+Returns true if the column is null.
+
+Syntax: `isnull(column)`
+
+Example: `isnull([Tax])` would return true if no value were present in the column for that row.
+
+### lefttrim
+
+Removes leading whitespace from a string of text.
+
+Syntax: `ltrim(text)`
+
+Example: `ltrim([Comment])`. If the comment were " I'd prefer not to", `ltrim` would return "I'd prefer not to".
+
+See also [Trim](#trim) and [Right trim](#right-trim).
+
+### length
+
+Returns the number of characters in text.
+
+Syntax: `length(text)`
+
+Example: `length([Comment])` If the `comment` were "wizard", `length` would return 6 ("wizard" has six characters). |
+
+### log
+
+Returns the base 10 log of the number.
+
+Syntax: `log(column)`.
+
+Example: `log([Value])`.
+
+### lower
+
+Returns the string of text in all lower case.
+
+Syntax: `lower(text)`.
+
+Example: `lower([Status])`. If the `Status` were "Chillin''", the expression would return "chillin'".
+
+### power
+
+Raises a number to the power of the exponent value.
+
+Syntax: `power(column, exponent)`.
+
+Example: `power([Length], 2)`. If the length were `3`, the expression would return `9` (3 to the second power is 3\*3).
+
+Databases that don't support `power`: SQLite.
+
+### RegexExtract
+
+Extracts matching substrings according to a regular expression.
+
+Syntax: `regexextract(text, regular_expression)`.
+
+Example: `regexextract([Address], "[0-9]+")`.
+
+Databases that don't support `regexextract`: H2, MySQL, SQL Server, SQLite.
+
+### Replace
+
+Replaces a part of the input text with new text.
+
+Syntax: `replace(text, find, replace)`.
+
+Example: `replace([Title], "Enormous", "Gigantic")`.
+
+### Right Trim
+
+Removes trailing whitespace from a string of text.
+
+Syntax: `rtrim(text)`
+
+Example: `rtrim([Comment])`. If the comment were "Fear is the mindkiller. ", the expression would return "Fear is the mindkiller."
+
+See also [Trim](#trim) and [Left trim](#left-trim).
+
+### Round
+
+Rounds a decimal number either up or down to the nearest integer value.
+
+Syntax: `round(column)`.
+
+Example: `round([Temperature])`. If the temp were `13.5` degrees centigrade, the expression would return `14`.
+
+Databases that don't support `round`: BigQuery.
+
+### Sqrt
+
+Returns the square root of a value.
+
+Syntax: `sqrt(column)`.
+
+Example: `sqrt([Hypotenuse])`.
+
+Databases that don't support `sqrt`: SQLite.
+
+See also [Power](#power).
+
+### Starts with
+
+Returns true if the beginning of the text matches the comparison text.
+
+Syntax: `startsWith(text, comparison)`.
+
+Example: `startsWith([Course Name], "Computer Science")` would return true for course names that began with "Computer Science", like "Computer Science 101: An introduction".
+
+### Substring
+
+Returns a portion of the supplied text, specified by a starting position and a length.
+
+Syntax: `substring(text, position, length)`
+
+Example: `substring([Title], 0, 10)` returns the first 11 letters of a string (the string index starts at position 0).
+
+### Trim
+
+Removes leading and trailing whitespace from a string of text.
+
+Syntax: `trim(text)`
+
+Example: `trim([Comment])` will remove any whitespace characters on either side of a comment.
+
+### Upper
+
+Returns the text in all upper case.
+
+Syntax: `upper(text)`.
+
+Example: `upper([Status])`. If status were "hyper", `upper("hyper")` would return "HYPER".
+
+### Database limitations
+
+Limitations are noted for each aggregation and function above, and here there are in summary:
+
+**BigQuery**: `abs`, `ceil`, `floor`, `median`, `percentile` and `round`
+
+**H2**: `median`, `percentile` and `regexextract`
+
+**MySQL**: `median`, `percentile` and `regexextract`
+
+**SQL Server**: `median`, `percentile` and `regexextract`
+
+**SQLite**: `log`, `median`, `percentile`, `power`, `regexextract`, `standarddeviation`, `sqrt` and `variance`
+
+**Vertica**: `median` and `percentile`
+
+Additionally, **Presto** only provides _approximate_ results for `median` and `percentile`.
+
+If you're using or maintaining a third-party database driver, please [refer to the wiki](https://github.com/metabase/metabase/wiki/What's-new-in-0.35.0-for-Metabase-driver-authors) to see how your driver might be impacted.
+
+See [Custom expressions in the notebook editor](https://www.metabase.com/blog/custom-expressions/index.html) to learn more.
+
+
+[expressions]: expressions.md

--- a/docs/users-guide/expressions.md
+++ b/docs/users-guide/expressions.md
@@ -47,31 +47,241 @@ Example:
 
 This would return rows where `Created At` is between January 1, 2020 and March 31, 2020, or where `Received At` is after December 25, 2019.
 
-### List of all available functions for expressions
+## Types of expressions
+
+There are two basic types of expressions, Aggregations and Functions. Aggregations take values from multiple rows to perform a calculation, such as finding the average value from all values in a column. Functions, by contrast, do something to each value in a column, like searching for a word in each value, rounding each value up (the `ceil` function), and so on.
+
+## Aggregations
+
+### Average
+
+Returns the average of the values in the column.
+
+Syntax: `Average(column)`
+
+Example: `Average([Quantity])` would return the mean for the `Quantity` field.
+
+### Count
+
+Returns the count of rows (also known as records) in the selected data.
+
+Syntax: `Count`
+
+Example: `Count` If a table or result returns 10 rows, `Count` will return `10`.
+
+### CountIf
+
+Only counts rows where the condition is true.
+
+Syntax: `CountIf(condition)`.
+
+Example: `CountIf([Subtotal] > 100)` would return the number of rows where the subtotal were greater than 100.
+
+### Cumulative count
+
+The additive total of rows across a breakout.
+
+Syntax: `CumulativeCount`.
+
+Example: `CumulativeCount`. 
+                                                 |
+### Distinct
+
+The number of distinct values in this column.
+
+Syntax: `Distinct(column)`.
+
+`Distinct([Last Name])`. Returns the count of unique last names in the column. Duplicates (of the last name "Smith" for example) are not counted.
+
+### Share
+
+Syntax: `Share(condition)`
+
+Example: `Share([Color] = "Blue")` would return the number of rows with the `Color` field set to `Blue`, divided by the total number of rows.
+
+Returns the percent of rows in the data that match the condition, as a decimal.
+
+### Standard deviation
+
+Calculates the standard deviation of the column, which is a measure of the variation in a set of values. Low standard deviation indicates values cluster around the mean, whereas a high standard deviation means the values are spread out over a wide range.
+
+Syntax: `StandardDeviation(column)`
+
+Example: `StandardDeviation([Population])` would return the SD for the values in the `Population` column. 
+
+### Sum
+
+Adds up all the values of the column.
+
+Syntax: `Sum(column)`
+
+Example: `Sum([Subtotal])` would add up all the values in the `Subtotal` column.
+
+### Sum if
+ 
+Sums up the specified column only for rows where the condition is true.
+
+Syntax: `SumIf(column, condition)`.
+
+Example:`SumIf([Subtotal], [Order Status] = "Valid")` would add up all the subtotals for orders with a status of "Valid".
+
+## Functions
+ 
+### Abs
+
+Returns the absolute (positive) value of the specified column.                                                        |
+ 
+Syntax: `abs(column)` 
+
+Example: `abs([Debt])`. If `Debt` were -100, `abs(-100)` would return `100`.
+
+Databases that don't support `abs`: BigQuery.
+
+### Between
+
+Checks a date or number column's values to see if they're within the specified range.
+
+Syntax: `between(column, start, end)`
+
+Example: `between([Created At], "2019-01-01", "2020-12-31")` would return rows where `Created At` date fell within the range of January 1, 2019 and December 31, 2020.   
+
+### Case
+
+Tests an expression against a list of cases and returns the corresponding value of the first matching case, with an optional default value if nothing else is met.
+
+Syntax: `case(condition, output, …)`
+
+Example: `case([Weight] > 200, "Large", [Weight] > 150, "Medium", "Small")` If a `Weight` is 250, the expression would return "Large". In this case, the default value is "Small", so any `Weight` 150 or less would return "Small".
+
+## Ceil
+
+Rounds a decimal up (ciel as in ceiling).
+
+Syntax: `ceil(column)`.
+
+Example: `ceil([Price])`. `ceil(2.99)` would return 3.
+
+See also [Floor](#floor)
+
+### Coalesce
+
+Looks at the values in each argument in order and returns the first non-null value for each row.
+
+Syntax: `coalesce(value1, value2, …)`
+
+Example: `coalesce([Comments], [Notes], "No comments")`. If both the `Comments` and `Notes` columns are null for that row, the expression will return the string "No comments".
+
+### Concat
+
+Combine two or more strings together.
+
+Syntax: `concat(value1, value2, …)`
+
+Example: `concat([Last Name], ", ", [First Name])` would produce a string of the format "Last Name, First Name", like "Palazzo, Enrico".
+
+### Contains
+
+Checks to see if string1 contains string2 within it.
+
+Syntax: `contains(string1, string2)`
+
+Example: `contains([Status], "Class")`. If `Status` were "Classified", the expression would return `true`.
+
+### Ends with
+
+Returns true if the end of the text matches the comparison text.  
+
+Syntax: `endsWith(text, comparison)`
+
+`endsWith([Appetite], "hungry")`
+
+See also [Contains](#contains) and [Starts with](#starts-with).
+
+### Exp
+
+Returns [Euler's number](https://en.wikipedia.org/wiki/E_(mathematical_constant), e, raised to the power of the supplied number. (Euler sounds like "Oiler").
+
+Syntax: `exp(column)`.
+
+Example: `exp([Interest Months])` 
+
+### Floor
+
+Rounds a decimal number down.                                                                                                                                      
+
+Syntax: `floor(column)`
+
+Example: `floor([Price])`. If the `Price` were 1.99, the expression would return 1.
+
+See also [ceil](#ceil).
+                                                   |
+### Left trim
+
+Removes leading whitespace from a string of text.       
+
+Syntax: `ltrim(text)`
+
+Example: `ltrim([Comment])`. If the comment were "    I'd prefer not to", `ltrim` would return "I'd prefer not to".
+
+See also [Trim](#trim) and [Right trim](#right-trim).
+
+### Length
+
+Syntax: `length(text)`
+
+Returns the number of characters in text.
+
+Example: `length([Comment])` If the `comment` were "wizard", `length` would return 6 ("wizard" has six characters).                                               |
+
+### Right Trim
+
+Removes trailing whitespace from a string of text.
+
+Syntax: `rtrim(text)` 
+
+Example: `rtrim([Comment])`. If the comment were "Fear is the mindkiller.   ", the expression would return "Fear is the mindkiller."
+
+See also [Trim](#trim) and [Left trim](#left-trim).
+
+### Starts with
+
+Returns true if the beginning of the text matches the comparison text.
+
+Syntax: `startsWith(text, comparison)`
+
+Example: `startsWith([Course Name], "Computer Science")`
+
+### Substring
+
+Returns a portion of the supplied text, specified by a starting position and a length.
+
+Syntax: `substring(text, position, length)`
+
+Example: `substring([Title], 0, 10)` returns the first 11 letters of a string (the string index starts at position 0).   
+
+### Trim
+
+Removes leading and trailing whitespace from a string of text.
+
+Syntax: `trim(text)`
+
+Example: `trim([Comment])` will remove any whitespace characters on either side of a comment.
+
+### Upper
+
+Returns the text in all upper case. 
+
+Syntax: `upper(text)`
+
+Example: `upper([Status])`
+
 
 | Name               | Syntax                                   | Description                                                                                                                                                        | Example                                                            |
 | ------------------ | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------ |
-| Absolute           | `abs(column)`                            | Returns the absolute (positive) value of the specified column.                                                                                                     | `abs([Debt])`                                                      |
-| Average            | `Average(column)`                        | Returns the average of the values in the column.                                                                                                                   | `Average([Quantity])`                                              |
-| Between            | `between(column, start, end)`            | Checks a date or number column's values to see if they're within the specified range.                                                                              | `between([Created At], "2019-01-01", "2020-12-31")`                |
-| Case               | `case(condition, output, …)`             | Tests an expression against a list of cases and returns the corresponding value of the first matching case, with an optional default value if nothing else is met. | `case([Weight] > 200, "Large", [Weight] > 150, "Medium", "Small")` |
-| Ceiling            | `ceil(column)`                           | Rounds a decimal number up.                                                                                                                                        | `ceil([Price])`                                                    |
-| Coalesce           | `coalesce(value1, value2, …)`            | Looks at the values in each argument in order and returns the first non-null value for each row.                                                                   | `coalesce([Comments], [Notes], "No comments")`                     |
-| Concatenate        | `concat(value1, value2, …)`              | Combine two or more strings of text together.                                                                                                                      | `concat([Last Name], ", ", [First Name])`                          |
-| Contains           | `contains(string1, string2)`             | Checks to see if string1 contains string2 within it.                                                                                                               | `contains([Status], "Pass")`                                       |
-| Count              | `Count`                                  | Returns the count of rows in the selected data.                                                                                                                    | `Count`                                                            |
-| Count if           | `CountIf(condition)`                     | Only counts rows where the condition is true.                                                                                                                      | `CountIf([Subtotal] > 100)`                                        |
-| Cumulative count   | `CumulativeCount`                        | The additive total of rows across a breakout.                                                                                                                      | `CumulativeCount`                                                  |
 | Cumulative sum     | `CumulativeSum(column)`                  | The rolling sum of a column across a breakout.                                                                                                                     | `CumulativeSum([Subtotal])`                                        |
-| Distinct           | `Distinct(column)`                       | The number of distinct values in this column.                                                                                                                      | `Distinct([Last Name])`                                            |
-| Ends with          | `endsWith(text, comparison)`             | Returns true if the end of the text matches the comparison text.                                                                                                   | `endsWith([Appetite], "hungry")`                                   |
-| Exp                | `exp(column)`                            | Returns Euler's number, e, raised to the power of the supplied number.                                                                                             | `exp([Interest Months])`                                           |
-| Floor              | `floor(column)`                          | Rounds a decimal number down.                                                                                                                                      | `floor([Price])`                                                   |
 | Interval           | `interval(column, number, text)`         | Checks a date column's values to see if they're within the relative range.                                                                                         | `interval([Created At], -1, "month")`                              |
 | IsEmpty            | `isempty(column)`                        | Returns true if the column is empty.                                                                                                                               | `isempty([Discount])`                                              |
 | IsNull             | `isnull(column)`                         | Returns true if the column is null.                                                                                                                                | `isnull([Tax])`                                                    |
-| Left trim          | `ltrim(text)`                            | Removes leading whitespace from a string of text.                                                                                                                  | `ltrim([Comment])`                                                 |
-| Length             | `length(text)`                           | Returns the number of characters in text.                                                                                                                          | `length([Comment])`                                                |
 | Log                | `log(column)`                            | Returns the base 10 log of the number.                                                                                                                             | `log([Value])`                                                     |
 | Lower              | `lower(text)`                            | Returns the string of text in all lower case.                                                                                                                      | `lower([Status])`                                                  |
 | Max                | `Max(column)`                            | Returns the largest value found in the column.                                                                                                                     | `Max([Age])`                                                       |
@@ -81,17 +291,8 @@ This would return rows where `Created At` is between January 1, 2020 and March 3
 | Power              | `power(column, exponent)`                | Raises a number to the power of the exponent value.                                                                                                                | `power([Length], 2)`                                               |
 | Regex extract      | `regexextract(text, regular_expression)` | Extracts matching substrings according to a regular expression.                                                                                                    | `regexextract([Address], "[0-9]+")`                                |
 | Replace            | `replace(text, find, replace)`           | Replaces a part of the input text with new text.                                                                                                                   | `replace([Title], "Enormous", "Gigantic")`                         |
-| Right trim         | `rtrim(text)`                            | Removes trailing whitespace from a string of text.                                                                                                                 | `rtrim([Comment])`                                                 |
 | Round              | `round(column)`                          | Rounds a decimal number either up or down to the nearest integer value.                                                                                            | `round([Temperature])`                                             |
-| Share              | `Share(condition)`                       | Returns the percent of rows in the data that match the condition, as a decimal.                                                                                    | `Share([Source] = "Google")`                                       |
 | Square root        | `sqrt(column)`                           | Returns the square root.                                                                                                                                           | `sqrt([Hypotenuse])`                                               |
-| Standard deviation | `StandardDeviation(column)`              | Calculates the standard deviation of the column.                                                                                                                   | `StandardDeviation([Population])`                                  |
-| Starts with        | `startsWith(text, comparison)`           | Returns true if the beginning of the text matches the comparison text.                                                                                             | `startsWith([Course Name], "Computer Science")`                    |
-| Substring          | `substring(text, position, length)`      | Returns a portion of the supplied text.                                                                                                                            | `substring([Title], 0, 10)`                                        |
-| Sum                | `Sum(column)`                            | Adds up all the values of the column.                                                                                                                              | `Sum([Subtotal])`                                                  |
-| Sum if             | `SumIf(column, condition)`               | Sums up the specified column only for rows where the condition is true.                                                                                            | `SumIf([Subtotal], [Order Status] = "Valid")`                      |
-| Trim               | `trim(text)`                             | Removes leading and trailing whitespace from a string of text.                                                                                                     | `trim([Comment])`                                                  |
-| Upper              | `upper(text)`                            | Returns the text in all upper case.                                                                                                                                | `upper([Status])`                                                  |
 | Variance           | `Variance(column)`                       | Returns the numeric variance for a given column.                                                                                                                   | `Variance([Temperature])`                                          |
 
 ### Database limitations

--- a/docs/users-guide/expressions.md
+++ b/docs/users-guide/expressions.md
@@ -63,4 +63,4 @@ For a tutorial on expressions, see [Custom expressions in the notebook editor][c
 
 
 [custom-expressions]: https://www.metabase.com/learn/questions/custom-expressions.html
-[expression-list]: expression-list.md
+[expression-list]: expression-list.html

--- a/docs/users-guide/expressions.md
+++ b/docs/users-guide/expressions.md
@@ -1,32 +1,14 @@
 # Writing expressions in the notebook editor
 
-[Custom expressions][custom-expressions] are like formulas in spreadsheet software like Excel, Google Sheets, and LibreOffice Calc. You can use them in the notebook editor of the query builder to ask more complicated questions.
+[Custom expressions][expression-list] are like formulas in spreadsheet software like Excel, Google Sheets, and LibreOffice Calc. They are the power tools in the notebook editor of the query builder that allow you to ask more complicated questions.
 
 When using the query builder, you can use expressions to create new:
 
 - **Filters**. The expression `= contains([comment], "Metabase")` would filter for rows where the `comment` field contained the word "Metabase".
-- **Metrics**. `= share([Total] > 50)` would return the percentage of orders with totals greater than 50 dollars.
+- **Metrics**. Also known as summaries. `= share([Total] > 50)` would return the percentage of orders with totals greater than 50 dollars.
 - **Custom columns**. You could use `= [Subtotal] / [Quantity]` to create a new column, which you could name "Item price".
 
-This page covers the basics of expressions. You can also check out a [full list of expressions][expression-list].
-
-## Basic mathematical operators
-
-Use `+`, `-`, `*` (multiply), `/` (divide) on numeric columns with numeric values, like integers, floats, and double. You can use parentheses, `(` ad `)`, to group parts of your expression.
-
-You can't currently do math on timestamp columns (we're working on adding new date functions soon, so stay tuned).
-
-## Conditional operators
-
-`AND`, `OR`, `NOT`, `>`, `>=` (greater than or equal to), `<`, `<=` (less than or equal to), `=`, `!=` (not equal to).
-
-## Referencing other columns
-
-You can refer to columns in the current table, or columns that are linked via a foreign key relationship. Column names should be included inside of square brackets, like this: `[Name of Column]`. Columns in connected tables can be referred to like this: `[ConnectedTableName.Column]`.
-
-## Referencing Segments and metrics
-
-You can refer to saved [Segments or Metrics](../administration-guide/07-segments-and-metrics.md) that are present in the currently selected table. You write these out the same as with columns, like this: `[Valid User Sessions]`.
+This page covers the basics of expressions. You can check out a [full list of expressions][expression-list] in Metabase, or walk through a tutorial that shows you how you can use [custom expressions in the notebook editor][custom-expressions].
 
 ## Types of expressions 
 
@@ -40,11 +22,33 @@ There are two basic types of expressions, **Aggregations** and **Functions**. Ch
 
 [Functions][functions], by contrast, do something to each value in a column, like searching for a word in each value (`contains`), rounding each value up to the nearest integer (the `ceil` function), and so on.
 
+## Basic mathematical operators
+
+Use `+`, `-`, `*` (multiply), `/` (divide) on numeric columns with numeric values, like integers, floats, and double. You can use parentheses, `(` ad `)`, to group parts of your expression.
+
+For example, you could create a new column that calculates the difference between the total and subtotal of a order: `= [Total] - [Subtotal]`.
+
+You can't currently do math on timestamp columns (we're working on adding new date functions soon, so stay tuned).
+
+## Conditional operators
+
+`AND`, `OR`, `NOT`, `>`, `>=` (greater than or equal to), `<`, `<=` (less than or equal to), `=`, `!=` (not equal to).
+
+For example, you could create a filter for customers from California or Vermont: `= [State] = "CA" OR [State] = "VT"`.
+
+## Referencing other columns
+
+You can refer to columns in the current table, or columns that are linked via a foreign key relationship. Column names should be included inside of square brackets, like this: `[Name of Column]`. Columns in connected tables can be referred to like this: `[ConnectedTableName.Column]`.
+
+## Referencing Segments and metrics
+
+You can refer to saved [Segments or Metrics](../administration-guide/07-segments-and-metrics.md) that are present in the currently selected table. You write these out the same as with columns, like this: `[Valid User Sessions]`.
+
 ## Filter expressions and conditionals
 
 Some things to keep in mind about filter expressions and conditionals:
 
-- Filter expressions are different in that they must return a Boolean value (something that's either true or false). For example, you could write `[Subtotal] + [Tax] < 100`, but not just `[Subtotal] + [Tax]`.
+- Filter expressions are different in that they must return a Boolean value (something that's either true or false). For example, you could write `[Subtotal] + [Tax] < 100`. Metabase would look at each row, add its subtotal and tax, the check if that sum is greater than 100. If it is, the statement evaluates as true, and Metabase will include the row in the result. If instead you were to (incorrectly) write `[Subtotal] + [Tax]`, Metabase wouldn't know what to do, as that expression doesn't evaluate to true or false.
 - You can use functions inside of the conditional portion of the `Countif` and `Sumif` aggregations, like so: `countif( round([Subtotal]) > 100 OR floor([Tax]) < 10 )`.
 
 ## Working with dates in filter expressions

--- a/docs/users-guide/expressions.md
+++ b/docs/users-guide/expressions.md
@@ -1,59 +1,61 @@
 # Writing expressions in the notebook editor
 
-[Custom expressions][custom-expressions] are like formulas in spreadsheet software like Excel, Google Sheets, and LibreOffice Calc.
-When using the query builder, you can use expressions to create a new:
+[Custom expressions][custom-expressions] are like formulas in spreadsheet software like Excel, Google Sheets, and LibreOffice Calc. You can use them in the notebook editor of the query builder to ask more complicated questions.
 
-- **Filter**. The expression `= contains([comment], "Metabase")` would filter for rows where the `comment` field contained the word "Metabase".
-- **Metric**. `= share([Total] > 50)` would return the percentage of orders with totals greater than 50 dollars.
-- **Custom column** You could use `= [Subtotal] / [Quantity]` to create a new column, which you could name "Item price".
+When using the query builder, you can use expressions to create new:
 
-See a full list of [expressions][expression-list].
+- **Filters**. The expression `= contains([comment], "Metabase")` would filter for rows where the `comment` field contained the word "Metabase".
+- **Metrics**. `= share([Total] > 50)` would return the percentage of orders with totals greater than 50 dollars.
+- **Custom columns** You could use `= [Subtotal] / [Quantity]` to create a new column, which you could name "Item price".
 
-## How to write expressions
+This page covers the basics of expressions. You can also check out a [full list of expressions][expression-list].
 
-In each of these three places, you can:
+## Basic mathematical operators
 
-- Use parentheses to group parts of your expression.
-- Use basic mathematical operators: `+`, `-`, `*` (multiply), `/` (divide) on numeric column with numeric values, like integers, floats, and doubles. You can't currently do math on timestamp columns. - Use conditional operators: `AND`, `OR`, `NOT`, `>`, `>=` (greater than or equal to), `<`, `<=` (less than or equal to), `=`, `!=` (not equal to).
-- Refer to columns in the current table, or columns that are linked via a foreign key relationship. Column names should be included inside of square brackets, like this: `[Name of Column]`. Columns in connected tables can be referred to like this: `[ConnectedTableName.Column]`.
-- Refer to saved [Segments or Metrics](../administration-guide/07-segments-and-metrics.md) that are present in the currently selected table. You write these out the same as with columns, like this: `[Valid User Sessions]`.
-- Use most of the different functions listed below.
+Use `+`, `-`, `*` (multiply), `/` (divide) on numeric column with numeric values, like integers, floats, and doubles. You can use parentheses `(` ad `)` to group parts of your expression.
 
-For a tutorial on working with custom expressions, check out [Custom expressions in the notebook editor][custom-expressions].
+You can't currently do math on timestamp columns (we're working on adding new date functions soon, so stay tuned).
 
-## Aggregation functions
+## Conditional operators
 
-Some of the functions listed below can only be used inside of a metric expression in the Summarize area, because they aggregate an entire column. So while you could create a custom column with the formula `[Subtotal] + [Tax]`, you could _not_ write `Sum([Subtotal] + [Tax])` unless you were creating a custom metric expression. Here are the functions that can only be used when writing a metric expression:
+`AND`, `OR`, `NOT`, `>`, `>=` (greater than or equal to), `<`, `<=` (less than or equal to), `=`, `!=` (not equal to).
 
-- Average
-- Count
-- CumulativeCount
-- CumulativeSum
-- Distinct
-- Max
-- Median
-- Min
-- Percentile
-- StandardDeviation
-- Sum
-- Variance
+## Reference other columns
+
+You can refer to columns in the current table, or columns that are linked via a foreign key relationship. Column names should be included inside of square brackets, like this: `[Name of Column]`. Columns in connected tables can be referred to like this: `[ConnectedTableName.Column]`.
+
+## Referencing Segments and metrics
+
+You can refer to saved [Segments or Metrics](../administration-guide/07-segments-and-metrics.md) that are present in the currently selected table. You write these out the same as with columns, like this: `[Valid User Sessions]`.
+
+## Types of expressions 
+
+There are two basic types of expressions, **Aggregations** and **Functions**. Check out a [full list of expressions][expression-list].
+
+### Aggregations
+
+[Aggregations][aggregations] take values from multiple rows to perform a calculation, such as finding the average value from all values in a column. Aggregations functions can only be used to the **Summarize** section of the notebook editor, because aggregations use values from all rows for that column. So while you could create a custom column with the formula `[Subtotal] + [Tax]`, you could _not_ write `Sum([Subtotal] + [Tax])` unless you were creating a custom metric expression (that would add up all the subtotals and taxes together).
+
+### Functions
+
+[Functions][functions], by contrast, do something to each value in a column, like searching for a word in each value (`contains`), rounding each value up to the nearest integer (the `ceil` function), and so on.
 
 ## Filter expressions and conditionals
 
-Some other things to keep in mind about filter expressions and conditionals:
+Some things to keep in mind about filter expressions and conditionals:
 
-- Filter expressions are different in that they must return something that's true or false. E.g., you could write `[Subtotal] + [Tax] < 100`, but not just `[Subtotal] + [Tax]`.
-- You can use functions inside of the conditional portion of the `countif` and `sumif` aggregations, like so: `countif( round([Subtotal]) > 100 OR floor([Tax]) < 10 )`
+- Filter expressions are different in that they must return a Boolean value (something that's true or false). E.g., you could write `[Subtotal] + [Tax] < 100`, but not just `[Subtotal] + [Tax]`.
+- You can use functions inside of the conditional portion of the `Countif` and `Sumif` aggregations, like so: `countif( round([Subtotal]) > 100 OR floor([Tax]) < 10 )`.
 
 ## Working with dates in filter expressions
 
-If you want to work with dates in your filter expressions, they'll need to follow the format, `"YYYY-MM-DD"` — i.e., four characters for the year, two for the month, and two for the day, enclosed in quotes and separated by dashes.
+If you want to work with dates in your filter expressions, the dates need to follow the format, `"YYYY-MM-DD"` — i.e., four characters for the year, two for the month, and two for the day, enclosed in quotes `"` and separated by dashes `-`.
 
 Example:
 
 `between([Created At], "2020-01-01", "2020-03-31") OR [Received At] > "2019-12-25"`
 
-This would return rows where `Created At` is between January 1, 2020 and March 31, 2020, or where `Received At` is after December 25, 2019.
+This expression would return rows where `Created At` is between January 1, 2020 and March 31, 2020, or where `Received At` is after December 25, 2019.
 
 ## All expressions
 
@@ -61,6 +63,7 @@ See a full list of [expressions][expression-list].
 
 For a tutorial on expressions, see [Custom expressions in the notebook editor][custom-expressions].
 
-
+[aggregations]: aggregations.html#aggregations
 [custom-expressions]: https://www.metabase.com/learn/questions/custom-expressions.html
-[expression-list]: expression-list.html
+[expression-list]: expressions-list.html
+[functions]: expression-list.html#functions

--- a/docs/users-guide/expressions.md
+++ b/docs/users-guide/expressions.md
@@ -6,13 +6,13 @@ When using the query builder, you can use expressions to create new:
 
 - **Filters**. The expression `= contains([comment], "Metabase")` would filter for rows where the `comment` field contained the word "Metabase".
 - **Metrics**. `= share([Total] > 50)` would return the percentage of orders with totals greater than 50 dollars.
-- **Custom columns** You could use `= [Subtotal] / [Quantity]` to create a new column, which you could name "Item price".
+- **Custom columns**. You could use `= [Subtotal] / [Quantity]` to create a new column, which you could name "Item price".
 
 This page covers the basics of expressions. You can also check out a [full list of expressions][expression-list].
 
 ## Basic mathematical operators
 
-Use `+`, `-`, `*` (multiply), `/` (divide) on numeric column with numeric values, like integers, floats, and doubles. You can use parentheses `(` ad `)` to group parts of your expression.
+Use `+`, `-`, `*` (multiply), `/` (divide) on numeric columns with numeric values, like integers, floats, and double. You can use parentheses, `(` ad `)`, to group parts of your expression.
 
 You can't currently do math on timestamp columns (we're working on adding new date functions soon, so stay tuned).
 
@@ -20,7 +20,7 @@ You can't currently do math on timestamp columns (we're working on adding new da
 
 `AND`, `OR`, `NOT`, `>`, `>=` (greater than or equal to), `<`, `<=` (less than or equal to), `=`, `!=` (not equal to).
 
-## Reference other columns
+## Referencing other columns
 
 You can refer to columns in the current table, or columns that are linked via a foreign key relationship. Column names should be included inside of square brackets, like this: `[Name of Column]`. Columns in connected tables can be referred to like this: `[ConnectedTableName.Column]`.
 
@@ -34,7 +34,7 @@ There are two basic types of expressions, **Aggregations** and **Functions**. Ch
 
 ### Aggregations
 
-[Aggregations][aggregations] take values from multiple rows to perform a calculation, such as finding the average value from all values in a column. Aggregations functions can only be used to the **Summarize** section of the notebook editor, because aggregations use values from all rows for that column. So while you could create a custom column with the formula `[Subtotal] + [Tax]`, you could _not_ write `Sum([Subtotal] + [Tax])` unless you were creating a custom metric expression (that would add up all the subtotals and taxes together).
+[Aggregations][aggregations] take values from multiple rows to perform a calculation, such as finding the average value from all values in a column. Aggregations functions can only be used in the **Summarize** section of the notebook editor, because aggregations use values from all rows for that column. So while you could create a custom column with the formula `[Subtotal] + [Tax]`, you could _not_ write `Sum([Subtotal] + [Tax])`, unless you were creating a custom metric expression (that would add up all the subtotals and taxes together).
 
 ### Functions
 
@@ -44,12 +44,12 @@ There are two basic types of expressions, **Aggregations** and **Functions**. Ch
 
 Some things to keep in mind about filter expressions and conditionals:
 
-- Filter expressions are different in that they must return a Boolean value (something that's true or false). E.g., you could write `[Subtotal] + [Tax] < 100`, but not just `[Subtotal] + [Tax]`.
+- Filter expressions are different in that they must return a Boolean value (something that's either true or false). For example, you could write `[Subtotal] + [Tax] < 100`, but not just `[Subtotal] + [Tax]`.
 - You can use functions inside of the conditional portion of the `Countif` and `Sumif` aggregations, like so: `countif( round([Subtotal]) > 100 OR floor([Tax]) < 10 )`.
 
 ## Working with dates in filter expressions
 
-If you want to work with dates in your filter expressions, the dates need to follow the format, `"YYYY-MM-DD"` — i.e., four characters for the year, two for the month, and two for the day, enclosed in quotes `"` and separated by dashes `-`.
+If you want to work with dates in your filter expressions, the dates need to follow the format, `"YYYY-MM-DD"` — i.e., four characters for the year, two for the month, and two for the day, enclosed in quotes `"` and separated by dashes `-`.
 
 Example:
 
@@ -57,13 +57,13 @@ Example:
 
 This expression would return rows where `Created At` is between January 1, 2020 and March 31, 2020, or where `Received At` is after December 25, 2019.
 
-## All expressions
+## List of expressions
 
 See a full list of [expressions][expression-list].
 
 For a tutorial on expressions, see [Custom expressions in the notebook editor][custom-expressions].
 
-[aggregations]: aggregations.html#aggregations
+[aggregations]: expressions-list.html#aggregations
 [custom-expressions]: https://www.metabase.com/learn/questions/custom-expressions.html
 [expression-list]: expressions-list.html
-[functions]: expression-list.html#functions
+[functions]: expressions-list.html#functions

--- a/docs/users-guide/expressions.md
+++ b/docs/users-guide/expressions.md
@@ -1,19 +1,27 @@
-## Writing expressions in the notebook editor
+# Writing expressions in the notebook editor
 
-[Custom expressions](https://www.metabase.com/blog/custom-expressions/index.html) are a way to create more advanced filters and aggregations, or to add custom columns to your custom question. These expressions are accessible in the notebook editor of custom questions when clicking the button to add a new filter, a new metric in the Summarize area, or when creating a new custom column.
+[Custom expressions][custom-expressions] are like formulas in spreadsheet software like Excel, Google Sheets, and LibreOffice Calc.
+When using the query builder, you can use expressions to create a new:
 
-### How to write expressions
+- **Filter**. The expression `= contains([comment], "Metabase")` would filter for rows where the `comment` field contained the word "Metabase".
+- **Metric**. `= share([Total] > 50)` would return the percentage of orders with totals greater than 50 dollars.
+- **Custom column** You could use `= [Subtotal] / [Quantity]` to create a new column, which you could name "Item price".
+
+See a full list of [expressions][expression-list].
+
+## How to write expressions
 
 In each of these three places, you can:
 
 - Use parentheses to group parts of your expression.
-- Use basic mathematical operators: `+`, `-`, `*` (multiply), `/` (divide) on numeric column with numeric values, like integers, floats, and doubles. You can't currently do math on timestamp columns.
-- Use conditional operators: `AND`, `OR`, `NOT`, `>`, `>=` (greater than or equal to), `<`, `<=` (less than or equal to), `=`, `!=` (not equal to).
+- Use basic mathematical operators: `+`, `-`, `*` (multiply), `/` (divide) on numeric column with numeric values, like integers, floats, and doubles. You can't currently do math on timestamp columns. - Use conditional operators: `AND`, `OR`, `NOT`, `>`, `>=` (greater than or equal to), `<`, `<=` (less than or equal to), `=`, `!=` (not equal to).
 - Refer to columns in the current table, or columns that are linked via a foreign key relationship. Column names should be included inside of square brackets, like this: `[Name of Column]`. Columns in connected tables can be referred to like this: `[ConnectedTableName.Column]`.
 - Refer to saved [Segments or Metrics](../administration-guide/07-segments-and-metrics.md) that are present in the currently selected table. You write these out the same as with columns, like this: `[Valid User Sessions]`.
 - Use most of the different functions listed below.
 
-### Aggregation functions
+For a tutorial on working with custom expressions, check out [Custom expressions in the notebook editor][custom-expressions].
+
+## Aggregation functions
 
 Some of the functions listed below can only be used inside of a metric expression in the Summarize area, because they aggregate an entire column. So while you could create a custom column with the formula `[Subtotal] + [Tax]`, you could _not_ write `Sum([Subtotal] + [Tax])` unless you were creating a custom metric expression. Here are the functions that can only be used when writing a metric expression:
 
@@ -30,14 +38,14 @@ Some of the functions listed below can only be used inside of a metric expressio
 - Sum
 - Variance
 
-### Filter expressions and conditionals
+## Filter expressions and conditionals
 
 Some other things to keep in mind about filter expressions and conditionals:
 
 - Filter expressions are different in that they must return something that's true or false. E.g., you could write `[Subtotal] + [Tax] < 100`, but not just `[Subtotal] + [Tax]`.
 - You can use functions inside of the conditional portion of the `countif` and `sumif` aggregations, like so: `countif( round([Subtotal]) > 100 OR floor([Tax]) < 10 )`
 
-### Working with dates in filter expressions
+## Working with dates in filter expressions
 
 If you want to work with dates in your filter expressions, they'll need to follow the format, `"YYYY-MM-DD"` — i.e., four characters for the year, two for the month, and two for the day, enclosed in quotes and separated by dashes.
 
@@ -47,273 +55,12 @@ Example:
 
 This would return rows where `Created At` is between January 1, 2020 and March 31, 2020, or where `Received At` is after December 25, 2019.
 
-## Types of expressions
+## All expressions
 
-There are two basic types of expressions, Aggregations and Functions. Aggregations take values from multiple rows to perform a calculation, such as finding the average value from all values in a column. Functions, by contrast, do something to each value in a column, like searching for a word in each value, rounding each value up (the `ceil` function), and so on.
+See a full list of [expressions][expression-list].
 
-## Aggregations
+For a tutorial on expressions, see [Custom expressions in the notebook editor][custom-expressions].
 
-### Average
 
-Returns the average of the values in the column.
-
-Syntax: `Average(column)`
-
-Example: `Average([Quantity])` would return the mean for the `Quantity` field.
-
-### Count
-
-Returns the count of rows (also known as records) in the selected data.
-
-Syntax: `Count`
-
-Example: `Count` If a table or result returns 10 rows, `Count` will return `10`.
-
-### CountIf
-
-Only counts rows where the condition is true.
-
-Syntax: `CountIf(condition)`.
-
-Example: `CountIf([Subtotal] > 100)` would return the number of rows where the subtotal were greater than 100.
-
-### Cumulative count
-
-The additive total of rows across a breakout.
-
-Syntax: `CumulativeCount`.
-
-Example: `CumulativeCount`. 
-                                                 |
-### Distinct
-
-The number of distinct values in this column.
-
-Syntax: `Distinct(column)`.
-
-`Distinct([Last Name])`. Returns the count of unique last names in the column. Duplicates (of the last name "Smith" for example) are not counted.
-
-### Share
-
-Syntax: `Share(condition)`
-
-Example: `Share([Color] = "Blue")` would return the number of rows with the `Color` field set to `Blue`, divided by the total number of rows.
-
-Returns the percent of rows in the data that match the condition, as a decimal.
-
-### Standard deviation
-
-Calculates the standard deviation of the column, which is a measure of the variation in a set of values. Low standard deviation indicates values cluster around the mean, whereas a high standard deviation means the values are spread out over a wide range.
-
-Syntax: `StandardDeviation(column)`
-
-Example: `StandardDeviation([Population])` would return the SD for the values in the `Population` column. 
-
-### Sum
-
-Adds up all the values of the column.
-
-Syntax: `Sum(column)`
-
-Example: `Sum([Subtotal])` would add up all the values in the `Subtotal` column.
-
-### Sum if
- 
-Sums up the specified column only for rows where the condition is true.
-
-Syntax: `SumIf(column, condition)`.
-
-Example:`SumIf([Subtotal], [Order Status] = "Valid")` would add up all the subtotals for orders with a status of "Valid".
-
-## Functions
- 
-### Abs
-
-Returns the absolute (positive) value of the specified column.                                                        |
- 
-Syntax: `abs(column)` 
-
-Example: `abs([Debt])`. If `Debt` were -100, `abs(-100)` would return `100`.
-
-Databases that don't support `abs`: BigQuery.
-
-### Between
-
-Checks a date or number column's values to see if they're within the specified range.
-
-Syntax: `between(column, start, end)`
-
-Example: `between([Created At], "2019-01-01", "2020-12-31")` would return rows where `Created At` date fell within the range of January 1, 2019 and December 31, 2020.   
-
-### Case
-
-Tests an expression against a list of cases and returns the corresponding value of the first matching case, with an optional default value if nothing else is met.
-
-Syntax: `case(condition, output, …)`
-
-Example: `case([Weight] > 200, "Large", [Weight] > 150, "Medium", "Small")` If a `Weight` is 250, the expression would return "Large". In this case, the default value is "Small", so any `Weight` 150 or less would return "Small".
-
-## Ceil
-
-Rounds a decimal up (ciel as in ceiling).
-
-Syntax: `ceil(column)`.
-
-Example: `ceil([Price])`. `ceil(2.99)` would return 3.
-
-See also [Floor](#floor)
-
-### Coalesce
-
-Looks at the values in each argument in order and returns the first non-null value for each row.
-
-Syntax: `coalesce(value1, value2, …)`
-
-Example: `coalesce([Comments], [Notes], "No comments")`. If both the `Comments` and `Notes` columns are null for that row, the expression will return the string "No comments".
-
-### Concat
-
-Combine two or more strings together.
-
-Syntax: `concat(value1, value2, …)`
-
-Example: `concat([Last Name], ", ", [First Name])` would produce a string of the format "Last Name, First Name", like "Palazzo, Enrico".
-
-### Contains
-
-Checks to see if string1 contains string2 within it.
-
-Syntax: `contains(string1, string2)`
-
-Example: `contains([Status], "Class")`. If `Status` were "Classified", the expression would return `true`.
-
-### Ends with
-
-Returns true if the end of the text matches the comparison text.  
-
-Syntax: `endsWith(text, comparison)`
-
-`endsWith([Appetite], "hungry")`
-
-See also [Contains](#contains) and [Starts with](#starts-with).
-
-### Exp
-
-Returns [Euler's number](https://en.wikipedia.org/wiki/E_(mathematical_constant), e, raised to the power of the supplied number. (Euler sounds like "Oiler").
-
-Syntax: `exp(column)`.
-
-Example: `exp([Interest Months])` 
-
-### Floor
-
-Rounds a decimal number down.                                                                                                                                      
-
-Syntax: `floor(column)`
-
-Example: `floor([Price])`. If the `Price` were 1.99, the expression would return 1.
-
-See also [ceil](#ceil).
-                                                   |
-### Left trim
-
-Removes leading whitespace from a string of text.       
-
-Syntax: `ltrim(text)`
-
-Example: `ltrim([Comment])`. If the comment were "    I'd prefer not to", `ltrim` would return "I'd prefer not to".
-
-See also [Trim](#trim) and [Right trim](#right-trim).
-
-### Length
-
-Syntax: `length(text)`
-
-Returns the number of characters in text.
-
-Example: `length([Comment])` If the `comment` were "wizard", `length` would return 6 ("wizard" has six characters).                                               |
-
-### Right Trim
-
-Removes trailing whitespace from a string of text.
-
-Syntax: `rtrim(text)` 
-
-Example: `rtrim([Comment])`. If the comment were "Fear is the mindkiller.   ", the expression would return "Fear is the mindkiller."
-
-See also [Trim](#trim) and [Left trim](#left-trim).
-
-### Starts with
-
-Returns true if the beginning of the text matches the comparison text.
-
-Syntax: `startsWith(text, comparison)`
-
-Example: `startsWith([Course Name], "Computer Science")`
-
-### Substring
-
-Returns a portion of the supplied text, specified by a starting position and a length.
-
-Syntax: `substring(text, position, length)`
-
-Example: `substring([Title], 0, 10)` returns the first 11 letters of a string (the string index starts at position 0).   
-
-### Trim
-
-Removes leading and trailing whitespace from a string of text.
-
-Syntax: `trim(text)`
-
-Example: `trim([Comment])` will remove any whitespace characters on either side of a comment.
-
-### Upper
-
-Returns the text in all upper case. 
-
-Syntax: `upper(text)`
-
-Example: `upper([Status])`
-
-
-| Name               | Syntax                                   | Description                                                                                                                                                        | Example                                                            |
-| ------------------ | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------ |
-| Cumulative sum     | `CumulativeSum(column)`                  | The rolling sum of a column across a breakout.                                                                                                                     | `CumulativeSum([Subtotal])`                                        |
-| Interval           | `interval(column, number, text)`         | Checks a date column's values to see if they're within the relative range.                                                                                         | `interval([Created At], -1, "month")`                              |
-| IsEmpty            | `isempty(column)`                        | Returns true if the column is empty.                                                                                                                               | `isempty([Discount])`                                              |
-| IsNull             | `isnull(column)`                         | Returns true if the column is null.                                                                                                                                | `isnull([Tax])`                                                    |
-| Log                | `log(column)`                            | Returns the base 10 log of the number.                                                                                                                             | `log([Value])`                                                     |
-| Lower              | `lower(text)`                            | Returns the string of text in all lower case.                                                                                                                      | `lower([Status])`                                                  |
-| Max                | `Max(column)`                            | Returns the largest value found in the column.                                                                                                                     | `Max([Age])`                                                       |
-| Median             | `Median(column)`                         | Returns the median value of the specified column.                                                                                                                  | `Median([Age])`                                                    |
-| Minimum            | `Min(column)`                            | Returns the smallest value found in the column                                                                                                                     | `Min([Salary])`                                                    |
-| Percentile         | `Percentile(column, percentile-value)`   | Returns the value of the column at the percentile value.                                                                                                           | `Percentile([Score], 0.9)`                                         |
-| Power              | `power(column, exponent)`                | Raises a number to the power of the exponent value.                                                                                                                | `power([Length], 2)`                                               |
-| Regex extract      | `regexextract(text, regular_expression)` | Extracts matching substrings according to a regular expression.                                                                                                    | `regexextract([Address], "[0-9]+")`                                |
-| Replace            | `replace(text, find, replace)`           | Replaces a part of the input text with new text.                                                                                                                   | `replace([Title], "Enormous", "Gigantic")`                         |
-| Round              | `round(column)`                          | Rounds a decimal number either up or down to the nearest integer value.                                                                                            | `round([Temperature])`                                             |
-| Square root        | `sqrt(column)`                           | Returns the square root.                                                                                                                                           | `sqrt([Hypotenuse])`                                               |
-| Variance           | `Variance(column)`                       | Returns the numeric variance for a given column.                                                                                                                   | `Variance([Temperature])`                                          |
-
-### Database limitations
-
-Certain database types don't support some of the above functions:
-
-**BigQuery**: `abs`, `ceil`, `floor`, `median`, `percentile` and `round`
-
-**H2**: `median`, `percentile` and `regexextract`
-
-**MySQL**: `median`, `percentile` and `regexextract`
-
-**SQL Server**: `median`, `percentile` and `regexextract`
-
-**SQLite**: `log`, `median`, `percentile`, `power`, `regexextract`, `standardDeviation`, `sqrt` and `variance`
-
-**Vertica**: `median` and `percentile`
-
-Additionally, **Presto** only provides _approximate_ results for `median` and `percentile`.
-
-If you're using or maintaining a third-party database driver, please [refer to the wiki](https://github.com/metabase/metabase/wiki/What's-new-in-0.35.0-for-Metabase-driver-authors) to see how your driver might be impacted.
-
-
-See [Custom expressions in the notebook editor](https://www.metabase.com/blog/custom-expressions/index.html) to learn more.
+[custom-expressions]: https://www.metabase.com/learn/questions/custom-expressions.html
+[expression-list]: expression-list.md

--- a/docs/users-guide/expressions.md
+++ b/docs/users-guide/expressions.md
@@ -2,10 +2,14 @@
 
 [Custom expressions][expression-list] are like formulas in spreadsheet software like Excel, Google Sheets, and LibreOffice Calc. They are the power tools in the notebook editor of the query builder that allow you to ask more complicated questions.
 
+## Custom expressions to create filters, metrics, and custom columns
+
+To use custom expression, create a __Custom Column__ (where the custom expression is used as a Field Formula to calculate values for the new column), or click on __Filter__ or __Summarize__ and select __Custom Expression__.
+
 When using the query builder, you can use expressions to create new:
 
 - **Filters**. The expression `= contains([comment], "Metabase")` would filter for rows where the `comment` field contained the word "Metabase".
-- **Metrics**. Also known as summaries. `= share([Total] > 50)` would return the percentage of orders with totals greater than 50 dollars.
+- **Metrics**. Also known as summaries or aggregations. `= share([Total] > 50)` would return the percentage of orders with totals greater than 50 dollars.
 - **Custom columns**. You could use `= [Subtotal] / [Quantity]` to create a new column, which you could name "Item price".
 
 This page covers the basics of expressions. You can check out a [full list of expressions][expression-list] in Metabase, or walk through a tutorial that shows you how you can use [custom expressions in the notebook editor][custom-expressions].
@@ -38,7 +42,7 @@ For example, you could create a filter for customers from California or Vermont:
 
 ## Referencing other columns
 
-You can refer to columns in the current table, or columns that are linked via a foreign key relationship. Column names should be included inside of square brackets, like this: `[Name of Column]`. Columns in connected tables can be referred to like this: `[ConnectedTableName.Column]`.
+You can refer to columns in the current table, or to columns that are linked via a foreign key relationship. Column names should be included inside of square brackets, like this: `[Name of Column]`. Columns in connected tables can be referred to like this: `[ConnectedTableName.Column]`.
 
 ## Referencing Segments and metrics
 

--- a/docs/users-guide/start.md
+++ b/docs/users-guide/start.md
@@ -12,6 +12,7 @@
 - [Asking questions in Metabase](04-asking-questions.md)
 - [Using the notebook editor to ask custom questions](custom-questions.md)
 - [Writing custom expressions in the notebook editor](expressions.md)
+  - [Full list of expressions: aggregations and functions](expressions-list.md)
 - [How to visualize the answers to questions](05-visualizing-results.md)
 - [Referencing saved question in queries](referencing-saved-questions-in-queries.md)
 
@@ -27,7 +28,7 @@
 - [Making dashboards interactive](interactive-dashboards.md)
 - [Creating dashboard charts with multiple series](09-multi-series-charting.md)
 
-## Set up subscriptions and alerts
+## Setting up subscriptions and alerts
 
 - [Setting up dashboard subscriptions](dashboard-subscriptions.md)
 - [Setting and getting alerts](15-alerts.md)

--- a/docs/users-guide/start.md
+++ b/docs/users-guide/start.md
@@ -12,7 +12,7 @@
 - [Asking questions in Metabase](04-asking-questions.md)
 - [Using the notebook editor to ask custom questions](custom-questions.md)
 - [Writing custom expressions in the notebook editor](expressions.md)
-  - [Full list of expressions: aggregations and functions](expressions-list.md)
+- [Full list of expressions: aggregations and functions](expressions-list.md)
 - [How to visualize the answers to questions](05-visualizing-results.md)
 - [Referencing saved question in queries](referencing-saved-questions-in-queries.md)
 


### PR DESCRIPTION
Significant update to our documentation on custom expressions to anticipate upcoming changes.

- Removes the pseudo-legible table of expressions.
- Creates a new page that lists all expressions, grouped as either aggregations or functions, and explains the difference between the two. We  should consider further grouping expressions down the line (e.g., string/text functions, numeric functions, date functions, etc.), but we can hold off until we implement the new date functions.
- Adds more examples.
- Adds related expressions.
- Leaves the database limitations section as is so people can see limitations across all expressions, but the docs now also specify which databases don't support each expression (if any), e.g., the entry for `Median` lists the databases that don't support `Median`.
- Revises the custom expression intro page to include more explanation and examples.