### PR TITLE
embed: call postMessage to all origins

### DIFF
--- a/frontend/src/metabase/lib/embed.js
+++ b/frontend/src/metabase/lib/embed.js
@@ -47,10 +47,16 @@ export function initializeEmbedding(store) {
 }
 
 function sendMessage(message) {
-  window.parent.postMessage(
-    { metabase: message },
-    MetabaseSettings.get("embedding-app-origin"),
-  );
+  // Since postMessage does not support multiple origins and sending message to "*"
+  // is discouraged, what we can do is send a message to each origin and messages
+  // where the origin does not match will be dropped by the browser.
+  const origins = MetabaseSettings.get("embedding-app-origin").split(" ");
+  for (const origin of origins) {
+    // Skip empty origin (e.g. if there are multiple spaces between each origin in the setting)
+    if (origin) {
+      window.parent.postMessage({ metabase: message }, origin);
+    }
+  }
 }
 
 function getFrameSpec() {

--- a/frontend/src/metabase/lib/embed.js
+++ b/frontend/src/metabase/lib/embed.js
@@ -47,16 +47,14 @@ export function initializeEmbedding(store) {
 }
 
 function sendMessage(message) {
-  // Since postMessage does not support multiple origins and sending message to "*"
-  // is discouraged, what we can do is send a message to each origin and messages
-  // where the origin does not match will be dropped by the browser.
-  const origins = MetabaseSettings.get("embedding-app-origin").split(" ");
-  for (const origin of origins) {
-    // Skip empty origin (e.g. if there are multiple spaces between each origin in the setting)
-    if (origin) {
-      window.parent.postMessage({ metabase: message }, origin);
-    }
-  }
+  // Reason for using "*" (see #18824)
+  //  1) We cannot use MetabaseSettings.get("embedding-app-origin") because the format is different
+  //      - the setting value can have multiple URLs but postMessage only supports one URL
+  //      - the setting value support wildcard in subdomain but postMessage does not
+  //  2) The risk should be very low because
+  //      - the data we sent is not sensitive data (frame size, current URL)
+  //      - we are already using frame ancestor policy to limit domains that can embed metabase
+  window.parent.postMessage({ metabase: message }, "*");
 }
 
 function getFrameSpec() {

--- a/frontend/src/metabase/lib/embed.js
+++ b/frontend/src/metabase/lib/embed.js
@@ -3,7 +3,6 @@ import { push } from "react-router-redux";
 import _ from "underscore";
 
 import { IFRAMED, IFRAMED_IN_SELF } from "metabase/lib/dom";
-import MetabaseSettings from "metabase/lib/settings";
 
 import { isFitViewportMode } from "metabase/hoc/FitViewPort";
 


### PR DESCRIPTION
`embedding-app-origin` may contain multiple origins but postMessage supports only a single origin, so we need to use `*` instead.

The risk should be very low because
 - the data we send is not sensitive data (frame size, current URL)
 - we are already using frame ancestor policy to limit domains that can embed metabase

Fixes #12069