### PR TITLE
Update new BigQuery driver to only use project-id in qualified names if it differs from credentials

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -8,7 +8,6 @@
             [metabase.driver.bigquery-cloud-sdk.common :as bigquery.common]
             [metabase.driver.bigquery-cloud-sdk.params :as bigquery.params]
             [metabase.driver.bigquery-cloud-sdk.query-processor :as bigquery.qp]
-            [metabase.models :refer [Database]]
             [metabase.query-processor.context :as context]
             [metabase.query-processor.error-type :as error-type]
             [metabase.query-processor.store :as qp.store]
@@ -18,8 +17,7 @@
             [metabase.util.i18n :refer [tru]]
             [metabase.util.schema :as su]
             [schema.core :as s])
-  (:import com.google.auth.oauth2.ServiceAccountCredentials
-           [com.google.cloud.bigquery BigQuery BigQuery$DatasetOption BigQuery$JobOption BigQuery$TableListOption
+  (:import [com.google.cloud.bigquery BigQuery BigQuery$DatasetOption BigQuery$JobOption BigQuery$TableListOption
                                       BigQuery$TableOption BigQueryException BigQueryOptions DatasetId Field Field$Mode FieldValue
                                       FieldValueList QueryJobConfiguration Schema Table TableId TableResult]
            java.util.Collections))

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -17,13 +17,11 @@
             [metabase.util :as u]
             [metabase.util.i18n :refer [tru]]
             [metabase.util.schema :as su]
-            [schema.core :as s]
-            [toucan.db :as db])
+            [schema.core :as s])
   (:import com.google.auth.oauth2.ServiceAccountCredentials
            [com.google.cloud.bigquery BigQuery BigQuery$DatasetOption BigQuery$JobOption BigQuery$TableListOption
                                       BigQuery$TableOption BigQueryException BigQueryOptions DatasetId Field Field$Mode FieldValue
                                       FieldValueList QueryJobConfiguration Schema Table TableId TableResult]
-           java.io.ByteArrayInputStream
            java.util.Collections))
 
 (driver/register! :bigquery-cloud-sdk, :parent :sql)

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/common.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/common.clj
@@ -1,4 +1,10 @@
-(ns metabase.driver.bigquery-cloud-sdk.common)
+(ns metabase.driver.bigquery-cloud-sdk.common
+  "Common utility functions and utilities for the bigquery-cloud-sdk driver and related namespaces."
+  (:require [metabase.models :refer [Database]]
+            [metabase.util :as u]
+            [toucan.db :as db])
+  (:import com.google.auth.oauth2.ServiceAccountCredentials
+           java.io.ByteArrayInputStream))
 
 (def ^:dynamic ^String *bigquery-timezone-id*
   "BigQuery stores all of it's timestamps in UTC. That timezone can be changed via a SQL function invocation in a
@@ -7,3 +13,33 @@
   invocation, they can set their JVM TZ to the correct timezone, mark `use-jvm-timezone` to `true` and that will bind
   this dynamic var to the JVM TZ rather than UTC"
   "UTC")
+
+(defn database-details->service-account-credential
+  "Returns a `ServiceAccountCredentials` (not scoped) for the given `db-details`, which is based upon the value
+  associated to its `service-account-json` key (a String)."
+  {:added "0.42.0"}
+  ^ServiceAccountCredentials [{:keys [^String service-account-json] :as db-details}]
+  {:pre [(map? db-details) (seq service-account-json)]}
+  (ServiceAccountCredentials/fromStream (ByteArrayInputStream. (.getBytes service-account-json))))
+
+(defn populate-project-id-from-credentials!
+  "Update the given `database` details blob to include the credentials' project-id as a separate entry (under a
+  `project-id-from-credentials` key). This is basically an inferred/calculated key (not something the user will ever
+  set directly), since it's simply encoded within the `service-account-json` payload.
+
+  This would require a lot of extra computation/invocation of the Google SDK methods to recalculate this on every query
+  (since it will involve parsing this JSON repeatedly), and even using something like `qp.store/cached` functionality
+  would still require recomputing it on every query execution.  Because this will only ever change if/when the DB
+  details change (i.e. the service account), just calculate it once per change (when the DB is updated, or upon first
+  query for a new Database), and store it back to the app DB.
+
+  Returns the calculated project-id String from the credentials."
+  {:added "0.42.0"}
+  ^String [{:keys [details] :as database}]
+  (let [creds-proj-id  (-> (database-details->service-account-credential details)
+                           .getProjectId)]
+    (db/update! Database
+      (u/the-id database)
+      :details
+      (assoc details :project-id-from-credentials creds-proj-id))
+    creds-proj-id))

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -398,4 +398,5 @@
                   (check-card-query-res temp-card)
                   ;; the :project-id-from-credentials is set in a background thread, since it's based on the
                   ;; `metabase.events` functionality, but by the time the check above is finished, it should be set
-                  (is (= "metabase-bigquery-driver" (get-in (mt/db) [:details :project-id-from-credentials]))))))))))))
+                  (is (= "metabase-bigquery-driver" (get-in (Database db-id)
+                                                            [:details :project-id-from-credentials]))))))))))))

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -272,7 +272,9 @@
                    (mt/first-row
                      (mt/run-mbql-query taxi_trips
                        {:filter [:= [:field (mt/id :taxi_trips :unique_key) nil]
-                                    "67794e631648a002f88d4b7f3ab0bcb6a9ed306a"]}))))))))))
+                                    "67794e631648a002f88d4b7f3ab0bcb6a9ed306a"]})))))
+          (testing " has project-id-from-credentials set correctly"
+            (is (= "metabase-bigquery-driver" (get-in temp-db [:details :project-id-from-credentials])))))))))
 
 (deftest bigquery-specific-types-test
   (testing "Table with decimal types"
@@ -394,13 +396,6 @@
                 (mt/with-db (Database db-id)
                   ;; having only changed the driver old->new, the existing card query should produce the same results
                   (check-card-query-res temp-card)
-                  ;; TODO: figure out how to make this pass!  the driver/notify-database-updated :bigquery-cloud-sdk
-                  ;; method always runs AFTER everything I try to do here!
-                  ;; things I have tried:
-                  ;; opening a separate core.async channel, and using events/subscribe-to-topics! to decide when to
-                  ;; check this assertion
-                  ;; creating a delay, future, or promise, with this function, and derefing it after the mt/with-db
-                  ;; in all cases, the driver/notify-database-updated :bigquery-cloud-sdk method always runs later!
                   (is (= "metabase-bigquery-driver" (get-in (Database db-id)
                                                             [:details :project-id-from-credentials]))))))))))))
 


### PR DESCRIPTION
Add new key to db-details for :bigquery-cloud-sdk when a database is updated, called :project-id-from-credentials, and extract the project-id from the service account creds when the database is saved

Updating logic in bigquery-cloud-sdk QP to only include the project-id when qualifying an Identifier, if the project-id (override) value is set, and its value differs from the :project-id-from-credentials value mentioned above

Adding a test to confirm that a card query continues to work after changing the associated DB's driver from :bigquery to :bigquery-cloud-sdk
