### PR TITLE
Fix notebook editor crash when joining on a custom column

### DIFF
--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -547,7 +547,7 @@ function getDimensionDisplayName(dimension) {
   if (!dimension) {
     return t`Pick a column...`;
   }
-  if (dimension.temporalUnit()) {
+  if (isDateTimeField(dimension.mbql())) {
     return `${dimension.displayName()}: ${dimension.subDisplayName()}`;
   }
   return dimension.displayName();

--- a/frontend/test/metabase/scenarios/question/reproductions/18818-crash-when-joining-on-custom-column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/18818-crash-when-joining-on-custom-column.cy.spec.js
@@ -1,0 +1,41 @@
+import { restore } from "__support__/e2e/cypress";
+
+import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
+
+const { ORDERS, ORDERS_ID, REVIEWS, REVIEWS_ID } = SAMPLE_DATASET;
+
+describe("issue 18818", () => {
+  beforeEach(() => {
+    cy.intercept("POST", "/api/dataset").as("dataset");
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should normally open notebook editor for queries joining on custom columns (metabase#18630)", () => {
+    cy.createQuestion(
+      {
+        query: {
+          "source-table": REVIEWS_ID,
+          expressions: {
+            "CC Rating": ["field", REVIEWS.RATING],
+          },
+          joins: [
+            {
+              fields: "all",
+              "source-table": ORDERS_ID,
+              condition: [
+                "=",
+                ["expression", "CC Rating"],
+                ["field", ORDERS.QUANTITY, { "join-alias": "Orders" }],
+              ],
+            },
+          ],
+        },
+      },
+      { visitQuestion: true },
+    );
+
+    cy.icon("notebook").click();
+    cy.findAllByText("CC Rating");
+  });
+});


### PR DESCRIPTION
Reproduces #18818, fixes #18818

The notebook editor crashes if you open a question with a join on a custom column. For the same reason, trying to join on a custom column fails too. Caused by #17883 (ability to select temporal units for join fields)

### To Verify

1. Ask a question > Sample Dataset > Reviews
2. Add a custom column: `[Rating]` as "CC just Rating"
3. Join the Orders table on `CC just Rating = Quantity`
4. Nothing should crash

### Demo

**Before (and a proof the repro works**

Everything is just blank because it crashed 🤷 

<img width="1314" alt="CleanShot 2021-11-04 at 19 28 03@2x" src="https://user-images.githubusercontent.com/17258145/140390938-b8935979-0f0f-4222-9ef5-8d4112e59eaa.png">

**After**

https://user-images.githubusercontent.com/17258145/140390963-dc925d21-39ea-488f-ae6f-4e797188d68c.mov

