### PR TITLE
docs - compatibility ntoes

### DIFF
--- a/docs/operations-guide/java-versions.md
+++ b/docs/operations-guide/java-versions.md
@@ -1,12 +1,12 @@
 # Java Versions
 
-Metabase requires a Java Runtime Environment (JRE).
+Metabase requires a Java Runtime Environment (JRE), with a Java version of 11 or higher.
 
-We recommend the latest LTS version of JRE from [AdoptOpenJDK](https://adoptopenjdk.net/releases.html) with HotSpot JVM and x64 architecture, but any [supported version](https://adoptopenjdk.net/support.html) should work, including other types of JVM and architecture, and other distributions such as [OpenJDK](https://openjdk.java.net/), [Amazon Corretto](https://aws.amazon.com/corretto/), [Zulu OpenJDK](https://www.azul.com/downloads/zulu-community), and [Oracle Java](https://www.java.com/).
+We recommend the latest LTS version of JRE from [AdoptOpenJDK](https://adoptopenjdk.net/releases.html) with HotSpot JVM and x64 architecture, but any version Java 11 or higher should work (see [supported versions](https://adoptopenjdk.net/support.html)), including other types of JVM and architecture, and other distributions such as [OpenJDK](https://openjdk.java.net/), [Amazon Corretto](https://aws.amazon.com/corretto/), [Zulu OpenJDK](https://www.azul.com/downloads/zulu-community), and [Oracle Java](https://www.java.com/).
 
 **Note** When using a "headless" version, the JVM needs to have AWT classes, which are sometimes not included. Otherwise Pulses and other functionality might not work correctly or not at all.
 
-When developing and building Metabase a Java Development Kit (JDK) is required. It is recommended to use the latest LTS version of JDK from AdoptOpenJDK with HotSpot JVM.
+When developing and building Metabase, a Java Development Kit (JDK) is required. We recommend the latest LTS version of JDK from AdoptOpenJDK with HotSpot JVM.
 
 #### Check installed version
 

--- a/docs/users-guide/05-visualizing-results.md
+++ b/docs/users-guide/05-visualizing-results.md
@@ -152,7 +152,6 @@ Pivot tables allow you swap rows and columns, group data, and include subtotals 
 
 Pivot tables are not currently available for the following databases in Metabase:
 
-- BigQuery
 - Druid
 - Google Analytics
 - MongoDB


### PR DESCRIPTION
Two small changes to note:

- Use Java version 11 or higher
- BigQuery works with pivot tables