### PR TITLE
Fix Metabase Cloud tests

### DIFF
--- a/frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx
+++ b/frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx
@@ -162,10 +162,18 @@ export default class SettingsEditorApp extends Component {
   }
 
   renderSettingsSections() {
-    const { sections, activeSectionName, newVersionAvailable } = this.props;
+    const {
+      sections,
+      activeSectionName,
+      newVersionAvailable,
+      settingValues,
+    } = this.props;
 
-    const renderedSections = Object.entries(sections).map(
-      ([slug, section], idx) => {
+    const renderedSections = Object.entries(sections)
+      .filter(([slug, section]) =>
+        section.getHidden ? !section.getHidden(settingValues) : true,
+      )
+      .map(([slug, section], idx) => {
         // HACK - This is used to hide specific items in the sidebar and is currently
         // only used as a way to fake the multi page auth settings pages without
         // requiring a larger refactor.
@@ -209,8 +217,7 @@ export default class SettingsEditorApp extends Component {
             </Link>
           </li>
         );
-      },
-    );
+      });
 
     return (
       <div className="MetadataEditor-table-list AdminList flex-no-shrink">

--- a/frontend/src/metabase/admin/settings/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors.js
@@ -67,6 +67,7 @@ const SECTIONS = updateSectionsWithPlugins({
         type: "string",
         widget: SiteUrlWidget,
         warningMessage: t`Only change this if you know what you're doing!`,
+        getHidden: settings => settings["is-hosted?"],
       },
       {
         key: "redirect-all-requests-to-https",
@@ -115,6 +116,7 @@ const SECTIONS = updateSectionsWithPlugins({
     name: t`Updates`,
     order: 3,
     component: SettingsUpdatesForm,
+    getHidden: settings => settings["is-hosted?"],
     settings: [
       {
         key: "check-for-updates",
@@ -127,6 +129,7 @@ const SECTIONS = updateSectionsWithPlugins({
     name: t`Email`,
     order: 4,
     component: SettingsEmailForm,
+    getHidden: settings => settings["is-hosted?"],
     settings: [
       {
         key: "email-smtp-host",

--- a/frontend/test/__support__/e2e/helpers/e2e-cloud-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-cloud-helpers.js
@@ -1,5 +1,18 @@
 export const setupMetabaseCloud = () => {
-  cy.request("PUT", "/api/setting/site-url", {
-    value: "https://CYPRESSTESTENVIRONMENT.metabaseapp.com",
-  });
+  cy.intercept(
+    {
+      method: "GET",
+      url: "/api/setting",
+    },
+    [
+      {
+        key: "is-hosted?",
+        value: true,
+        is_env_setting: false,
+        env_name: "MB_IS_HOSTED",
+        description: "Is the Metabase instance running in the cloud?",
+        default: null,
+      },
+    ],
+  ).as("getSettings");
 };

--- a/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
@@ -32,7 +32,7 @@ describe("scenarios > admin > settings", () => {
     const DOMAIN_AND_PORT = BASE_URL.replace("http://", "");
 
     cy.server();
-    cy.route("PUT", "/api/setting/site-url").as("url");
+    cy.intercept("PUT", "/api/setting/site-url").as("url");
 
     cy.visit("/admin/settings/general");
 
@@ -81,7 +81,7 @@ describe("scenarios > admin > settings", () => {
 
   it("should save a setting", () => {
     cy.server();
-    cy.route("PUT", "**/admin-email").as("saveSettings");
+    cy.intercept("PUT", "/api/setting/admin-email").as("saveSettings");
 
     cy.visit("/admin/settings/general");
 
@@ -114,7 +114,7 @@ describe("scenarios > admin > settings", () => {
   it("should check for working https before enabling a redirect", () => {
     cy.visit("/admin/settings/general");
     cy.server();
-    cy.route("GET", "**/api/health", "ok").as("httpsCheck");
+    cy.intercept("GET", "/api/health", "ok").as("httpsCheck");
 
     // settings have loaded, but there's no redirect setting visible
     cy.contains("Site URL");
@@ -143,7 +143,7 @@ describe("scenarios > admin > settings", () => {
     cy.visit("/admin/settings/general");
     cy.server();
     // return 500 on https check
-    cy.route({ method: "GET", url: "**/api/health", status: 500 }).as(
+    cy.intercept({ method: "GET", url: "/api/health", status: 500 }).as(
       "httpsCheck",
     );
 
@@ -164,7 +164,7 @@ describe("scenarios > admin > settings", () => {
 
   it("should update the formatting", () => {
     cy.server();
-    cy.route("PUT", "**/custom-formatting").as("saveFormatting");
+    cy.intercept("PUT", "/api/setting/custom-formatting").as("saveFormatting");
 
     // update the formatting
     cy.visit("/admin/settings/localization");
@@ -187,7 +187,7 @@ describe("scenarios > admin > settings", () => {
 
   it("should correctly apply the globalized date formats (metabase#11394)", () => {
     cy.server();
-    cy.route("PUT", "**/custom-formatting").as("saveFormatting");
+    cy.intercept("PUT", "/api/setting/custom-formatting").as("saveFormatting");
 
     cy.request("PUT", `/api/field/${ORDERS.CREATED_AT}`, {
       semantic_type: null,
@@ -210,7 +210,7 @@ describe("scenarios > admin > settings", () => {
 
   it("should search for and select a new timezone", () => {
     cy.server();
-    cy.route("PUT", "**/report-timezone").as("reportTimezone");
+    cy.intercept("PUT", "/api/setting/report-timezone").as("reportTimezone");
 
     cy.visit("/admin/settings/localization");
     cy.contains("Report Timezone")
@@ -229,7 +229,7 @@ describe("scenarios > admin > settings", () => {
     describe(" > embedding settings", () => {
       it("should validate a premium embedding token has a valid format", () => {
         cy.server();
-        cy.route("PUT", "/api/setting/premium-embedding-token").as(
+        cy.intercept("PUT", "/api/setting/premium-embedding-token").as(
           "saveEmbeddingToken",
         );
 
@@ -252,7 +252,7 @@ describe("scenarios > admin > settings", () => {
 
       it("should validate a premium embedding token exists", () => {
         cy.server();
-        cy.route("PUT", "/api/setting/premium-embedding-token").as(
+        cy.intercept("PUT", "/api/setting/premium-embedding-token").as(
           "saveEmbeddingToken",
         );
 
@@ -281,7 +281,7 @@ describe("scenarios > admin > settings", () => {
           "11397b1e60cfb1372f2f33ac8af234a15faee492bbf5c04d0edbad76da3e614a";
 
         cy.server();
-        cy.route({
+        cy.intercept({
           method: "PUT",
           url: "/api/setting/premium-embedding-token",
           response: embeddingToken,
@@ -291,8 +291,10 @@ describe("scenarios > admin > settings", () => {
         cy.contains("Premium embedding");
         cy.contains("Enter a token").click();
 
-        cy.route("GET", "/api/session/properties").as("getSessionProperties");
-        cy.route({
+        cy.intercept("GET", "/api/session/properties").as(
+          "getSessionProperties",
+        );
+        cy.intercept({
           method: "GET",
           url: "/api/setting",
           response: [
@@ -334,7 +336,7 @@ describe("scenarios > admin > settings", () => {
       });
 
       // 3. Stub the whole response
-      cy.route("GET", "/api/setting", STUBBED_BODY).as("appSettings");
+      cy.intercept("GET", "/api/setting", STUBBED_BODY).as("appSettings");
     });
     cy.visit("/admin/settings/general");
 
@@ -360,9 +362,11 @@ describe("scenarios > admin > settings", () => {
   });
 
   // Unskip when mocking Cloud in Cypress is fixed (#18289)
-  it.skip("should hide self-hosted settings when running Metabase Cloud", () => {
+  it("should hide self-hosted settings when running Metabase Cloud", () => {
     setupMetabaseCloud();
     cy.visit("/admin/settings/general");
+
+    cy.wait(["@getSettings"]);
 
     cy.findByText("Site Name");
     cy.findByText("Site URL").should("not.exist");
@@ -414,7 +418,7 @@ describeWithToken("scenarios > admin > settings (EE)", () => {
   });
 
   // Unskip when mocking Cloud in Cypress is fixed (#18289)
-  it.skip("should hide Enterprise page when running Metabase Cloud", () => {
+  it("should hide Enterprise page when running Metabase Cloud", () => {
     setupMetabaseCloud();
     cy.visit("/admin/settings/general");
 

--- a/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
@@ -43,7 +43,7 @@ describe("scenarios > admin > settings", () => {
       .blur();
 
     cy.wait("@url").should(xhr => {
-      expect(xhr.status).to.eq(500);
+      expect(xhr.response.statusCode).to.eq(500);
       // Switching to regex match for assertions - the test was flaky because of the "typing" issue
       // i.e. it sometimes doesn't type the whole string "foo", but only "oo".
       // We only care that the `cause` is starting with "Invalid site URL"


### PR DESCRIPTION
A first approach to https://github.com/metabase/metabase/issues/18289.

I have worked with the assumption that the `is-hosted?` parameter indicates whether Metabase Cloud is running. Therefore, I have:
- Included the `is-hosted?` parameter to avoid showing the `Email` and `Updates` sections on the sidebar (I have included the `getHidden` parameter). It seems that currently we are not conditionally showing those components although there is a test that states it.
- I have mocked the `/api/setting` request (where `is-hosted?` is taken from) during the Cypress tests.
- Replaced the `cy.route` method by `cy.intercept`, because `cy.route` is deprecated.

Things that are left:
- The `Email` and `Updates` sections are hided in the sidebar, but they are still accesible from a route. We should also create routes based on the `is-hosted?` parameter.
- There is a skipped test (`should hide the store link when running Metabase Cloud`), because the `StoreLink` component should be hided based on the `is-hosted?` and I still need some more research to do that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/18851)
<!-- Reviewable:end -->
