### PR TITLE
Update undo toast look

### DIFF
--- a/frontend/src/metabase/containers/UndoListing.jsx
+++ b/frontend/src/metabase/containers/UndoListing.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { Flex } from "grid-styled";
 import { t } from "ttag";
+import _ from "underscore";
 
 import { color } from "metabase/lib/colors";
 import { capitalize, inflect } from "metabase/lib/formatting";
@@ -41,12 +42,7 @@ DefaultMessage.propTypes = {
   undo: PropTypes.object.isRequired,
 };
 
-@connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)
-@BodyComponent
-export default class UndoListing extends Component {
+class UndoListing extends Component {
   static propTypes = {
     undos: PropTypes.array.isRequired,
     performUndo: PropTypes.func.isRequired,
@@ -94,3 +90,11 @@ export default class UndoListing extends Component {
     );
   }
 }
+
+export default _.compose(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps,
+  ),
+  BodyComponent,
+)(UndoListing);

--- a/frontend/src/metabase/containers/UndoListing.jsx
+++ b/frontend/src/metabase/containers/UndoListing.jsx
@@ -12,7 +12,9 @@ import BodyComponent from "metabase/components/BodyComponent";
 
 import {
   CardContent,
+  CardContentSide,
   CardIcon,
+  DefaultText,
   DismissIcon,
   ToastCard,
   UndoButton,
@@ -36,11 +38,11 @@ function DefaultMessage({
   undo: { verb = t`modified`, count = 1, subject = t`item` },
 }) {
   return (
-    <div>
+    <DefaultText>
       {count > 1
         ? `${capitalize(verb)} ${count} ${inflect(subject, count)}`
         : `${capitalize(verb)} ${subject}`}
-    </div>
+    </DefaultText>
   );
 }
 
@@ -62,12 +64,16 @@ function UndoToast({ undo, onUndo, onDismiss }) {
   return (
     <ToastCard dark>
       <CardContent>
-        <CardIcon name={undo.icon || "check"} color="white" />
-        {renderMessage(undo)}
-        {undo.actions?.length > 0 && (
-          <UndoButton onClick={onUndo}>{t`Undo`}</UndoButton>
-        )}
-        <DismissIcon name="close" onClick={onDismiss} />
+        <CardContentSide>
+          <CardIcon name={undo.icon || "check"} color="white" />
+          {renderMessage(undo)}
+        </CardContentSide>
+        <CardContentSide>
+          {undo.actions?.length > 0 && (
+            <UndoButton onClick={onUndo}>{t`Undo`}</UndoButton>
+          )}
+          <DismissIcon name="close" onClick={onDismiss} />
+        </CardContentSide>
       </CardContent>
     </ToastCard>
   );

--- a/frontend/src/metabase/containers/UndoListing.jsx
+++ b/frontend/src/metabase/containers/UndoListing.jsx
@@ -5,9 +5,9 @@ import styled from "styled-components";
 import { space } from "styled-system";
 import { Flex } from "grid-styled";
 import { t } from "ttag";
-import { capitalize, inflect } from "metabase/lib/formatting";
 
 import { color } from "metabase/lib/colors";
+import { capitalize, inflect } from "metabase/lib/formatting";
 import { dismissUndo, performUndo } from "metabase/redux/undo";
 import { getUndos } from "metabase/selectors/undo";
 

--- a/frontend/src/metabase/containers/UndoListing.jsx
+++ b/frontend/src/metabase/containers/UndoListing.jsx
@@ -62,7 +62,7 @@ UndoToast.propTypes = {
 
 function UndoToast({ undo, onUndo, onDismiss }) {
   return (
-    <ToastCard dark>
+    <ToastCard dark data-testid="toast-undo">
       <CardContent>
         <CardContentSide>
           <CardIcon name={undo.icon || "check"} color="white" />

--- a/frontend/src/metabase/containers/UndoListing.jsx
+++ b/frontend/src/metabase/containers/UndoListing.jsx
@@ -86,8 +86,8 @@ function UndoListing({ undos, performUndo, dismissUndo }) {
         <UndoToast
           key={undo._domId}
           undo={undo}
-          onUndo={() => performUndo(undo)}
-          onDismiss={() => dismissUndo(undo)}
+          onUndo={() => performUndo(undo.id)}
+          onDismiss={() => dismissUndo(undo.id)}
         />
       ))}
     </UndoList>

--- a/frontend/src/metabase/containers/UndoListing.jsx
+++ b/frontend/src/metabase/containers/UndoListing.jsx
@@ -25,15 +25,17 @@ const mapDispatchToProps = {
   performUndo,
 };
 
-const DefaultMessage = ({
+function DefaultMessage({
   undo: { verb = t`modified`, count = 1, subject = t`item` },
-}) => (
-  <div>
-    {count > 1 // TODO: figure out how to i18n this?
-      ? `${capitalize(verb)} ${count} ${inflect(subject, count)}`
-      : `${capitalize(verb)} ${subject}`}
-  </div>
-);
+}) {
+  return (
+    <div>
+      {count > 1
+        ? `${capitalize(verb)} ${count} ${inflect(subject, count)}`
+        : `${capitalize(verb)} ${subject}`}
+    </div>
+  );
+}
 
 DefaultMessage.propTypes = {
   undo: PropTypes.object.isRequired,

--- a/frontend/src/metabase/containers/UndoListing.jsx
+++ b/frontend/src/metabase/containers/UndoListing.jsx
@@ -1,4 +1,3 @@
-/* eslint "react/prop-types": "warn" */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";

--- a/frontend/src/metabase/containers/UndoListing.jsx
+++ b/frontend/src/metabase/containers/UndoListing.jsx
@@ -1,8 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
-import styled from "styled-components";
-import { space } from "styled-system";
 import { Flex } from "grid-styled";
 import { t } from "ttag";
 
@@ -16,6 +14,8 @@ import Card from "metabase/components/Card";
 import Icon from "metabase/components/Icon";
 import Link from "metabase/components/Link";
 
+import { UndoList } from "./UndoListing.styled";
+
 const mapStateToProps = (state, props) => ({
   undos: getUndos(state, props),
 });
@@ -24,10 +24,6 @@ const mapDispatchToProps = {
   dismissUndo,
   performUndo,
 };
-
-const UndoList = styled.ul`
-  ${space};
-`;
 
 const DefaultMessage = ({
   undo: { verb = t`modified`, count = 1, subject = t`item` },
@@ -38,6 +34,7 @@ const DefaultMessage = ({
       : `${capitalize(verb)} ${subject}`}
   </div>
 );
+
 DefaultMessage.propTypes = {
   undo: PropTypes.object.isRequired,
 };

--- a/frontend/src/metabase/containers/UndoListing.jsx
+++ b/frontend/src/metabase/containers/UndoListing.jsx
@@ -26,6 +26,10 @@ const mapDispatchToProps = {
   performUndo,
 };
 
+DefaultMessage.propTypes = {
+  undo: PropTypes.object.isRequired,
+};
+
 function DefaultMessage({
   undo: { verb = t`modified`, count = 1, subject = t`item` },
 }) {
@@ -38,57 +42,50 @@ function DefaultMessage({
   );
 }
 
-DefaultMessage.propTypes = {
-  undo: PropTypes.object.isRequired,
+UndoListing.propTypes = {
+  undos: PropTypes.array.isRequired,
+  performUndo: PropTypes.func.isRequired,
+  dismissUndo: PropTypes.func.isRequired,
 };
 
-class UndoListing extends Component {
-  static propTypes = {
-    undos: PropTypes.array.isRequired,
-    performUndo: PropTypes.func.isRequired,
-    dismissUndo: PropTypes.func.isRequired,
-  };
+function UndoListing({ undos, performUndo, dismissUndo }) {
+  return (
+    <UndoList m={2} className="fixed left bottom zF">
+      {undos.map(undo => (
+        <Card key={undo._domId} dark p={2} mt={1}>
+          <Flex align="center">
+            <Icon
+              name={(undo.icon && undo.icon) || "check"}
+              color="white"
+              mr={1}
+            />
+            {typeof undo.message === "function" ? (
+              undo.message(undo)
+            ) : undo.message ? (
+              undo.message
+            ) : (
+              <DefaultMessage undo={undo || {}} />
+            )}
 
-  render() {
-    const { undos, performUndo, dismissUndo } = this.props;
-    return (
-      <UndoList m={2} className="fixed left bottom zF">
-        {undos.map(undo => (
-          <Card key={undo._domId} dark p={2} mt={1}>
-            <Flex align="center">
-              <Icon
-                name={(undo.icon && undo.icon) || "check"}
-                color="white"
-                mr={1}
-              />
-              {typeof undo.message === "function" ? (
-                undo.message(undo)
-              ) : undo.message ? (
-                undo.message
-              ) : (
-                <DefaultMessage undo={undo || {}} />
-              )}
-
-              {undo.actions && undo.actions.length > 0 && (
-                <Link
-                  ml={1}
-                  onClick={() => performUndo(undo.id)}
-                  className="link text-bold"
-                >{t`Undo`}</Link>
-              )}
-              <Icon
+            {undo.actions && undo.actions.length > 0 && (
+              <Link
                 ml={1}
-                color={color("text-light")}
-                hover={{ color: color("text-medium") }}
-                name="close"
-                onClick={() => dismissUndo(undo.id)}
-              />
-            </Flex>
-          </Card>
-        ))}
-      </UndoList>
-    );
-  }
+                onClick={() => performUndo(undo.id)}
+                className="link text-bold"
+              >{t`Undo`}</Link>
+            )}
+            <Icon
+              ml={1}
+              color={color("text-light")}
+              hover={{ color: color("text-medium") }}
+              name="close"
+              onClick={() => dismissUndo(undo.id)}
+            />
+          </Flex>
+        </Card>
+      ))}
+    </UndoList>
+  );
 }
 
 export default _.compose(

--- a/frontend/src/metabase/containers/UndoListing.styled.jsx
+++ b/frontend/src/metabase/containers/UndoListing.styled.jsx
@@ -1,6 +1,49 @@
 import styled from "styled-components";
-import { space } from "styled-system";
+import Card from "metabase/components/Card";
+import Icon from "metabase/components/Icon";
+import Link from "metabase/components/Link";
+import { color } from "metabase/lib/colors";
+import { space } from "metabase/styled-components/theme";
 
 export const UndoList = styled.ul`
-  ${space};
+  position: fixed;
+  left: 0;
+  bottom: 0;
+  margin: ${space(2)};
+  z-index: 999;
+`;
+
+export const ToastCard = styled(Card)`
+  padding: ${space(2)};
+  margin-top: ${space(1)};
+`;
+
+export const CardContent = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+export const CardIcon = styled(Icon)`
+  margin-right: ${space(1)};
+`;
+
+export const UndoButton = styled(Link)`
+  margin-left: ${space(1)};
+  font-weight: bold;
+  text-decoration: none;
+  color: ${color("brand")};
+
+  &:hover {
+    text-decoration: underline;
+  }
+`;
+
+export const DismissIcon = styled(Icon)`
+  margin-left: ${space(1)};
+  color: ${color("text-light")};
+  cursor: pointer;
+
+  :hover {
+    color: ${color("text-medium")};
+  }
 `;

--- a/frontend/src/metabase/containers/UndoListing.styled.jsx
+++ b/frontend/src/metabase/containers/UndoListing.styled.jsx
@@ -1,0 +1,6 @@
+import styled from "styled-components";
+import { space } from "styled-system";
+
+export const UndoList = styled.ul`
+  ${space};
+`;

--- a/frontend/src/metabase/containers/UndoListing.styled.jsx
+++ b/frontend/src/metabase/containers/UndoListing.styled.jsx
@@ -2,7 +2,7 @@ import styled from "styled-components";
 import Card from "metabase/components/Card";
 import Icon from "metabase/components/Icon";
 import Link from "metabase/components/Link";
-import { color } from "metabase/lib/colors";
+import { alpha, color, lighten } from "metabase/lib/colors";
 import { space } from "metabase/styled-components/theme";
 
 export const UndoList = styled.ul`
@@ -14,11 +14,18 @@ export const UndoList = styled.ul`
 `;
 
 export const ToastCard = styled(Card)`
-  padding: ${space(2)};
+  padding: 10px ${space(2)};
   margin-top: ${space(1)};
+  min-width: 310px;
 `;
 
 export const CardContent = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+export const CardContentSide = styled.div`
   display: flex;
   align-items: center;
 `;
@@ -27,23 +34,28 @@ export const CardIcon = styled(Icon)`
   margin-right: ${space(1)};
 `;
 
-export const UndoButton = styled(Link)`
-  margin-left: ${space(1)};
-  font-weight: bold;
-  text-decoration: none;
-  color: ${color("brand")};
+export const DefaultText = styled.span`
+  font-weight: 700;
+`;
 
-  &:hover {
-    text-decoration: underline;
+export const UndoButton = styled(Link)`
+  font-weight: bold;
+  background-color: ${alpha(color("bg-white"), 0.1)};
+  padding: 4px 12px;
+  margin-left: ${space(1)};
+  border-radius: 8px;
+
+  :hover {
+    background-color: ${alpha(color("bg-white"), 0.3)};
   }
 `;
 
 export const DismissIcon = styled(Icon)`
-  margin-left: ${space(1)};
-  color: ${color("text-light")};
+  margin-left: ${space(2)};
+  color: ${color("bg-dark")};
   cursor: pointer;
 
   :hover {
-    color: ${color("text-medium")};
+    color: ${lighten(color("bg-dark"), 0.3)};
   }
 `;

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -167,9 +167,10 @@ describe("collection permissions", () => {
                     cy.visit("collection/root");
                     openEllipsisMenuFor("Orders");
                     cy.findByText("Archive this item").click();
-                    cy.findByText("Archived question")
-                      .siblings(".Icon-close")
-                      .click();
+                    cy.findByTestId("toast-undo").within(() => {
+                      cy.findByText("Archived question");
+                      cy.icon("close").click();
+                    });
                     cy.findByText("View archive").click();
                     cy.location("pathname").should("eq", "/archive");
                     cy.findByText("Orders");


### PR DESCRIPTION
Cleans up the `UndoListing` component and updates its visual appearance.

### To Verify

1. Go to any collection
2. Archive any item
3. Notice a toast in the bottom left looks as on the screenshot below
4. Try to dismiss and actually undo the operation, both should work as expected

### Demo

**Before**

<img width="254" alt="CleanShot 2021-11-04 at 22 54 22@2x" src="https://user-images.githubusercontent.com/17258145/140419397-8fa1c6dd-393c-40b4-9a8e-66baee9baea4.png">


**After**

<img width="329" alt="CleanShot 2021-11-04 at 22 53 58@2x" src="https://user-images.githubusercontent.com/17258145/140419411-113292da-e3a3-4ff5-bfb0-49838bab01a7.png">

