### PR TITLE
Undo turning a question info a dataset

### DIFF
--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -5,6 +5,7 @@ declare var ace: any;
 import { createAction } from "redux-actions";
 import _ from "underscore";
 import { getIn, assocIn, updateIn } from "icepick";
+import { t } from "ttag";
 
 import * as Urls from "metabase/lib/urls";
 
@@ -12,6 +13,7 @@ import { createThunkAction } from "metabase/lib/redux";
 import { push, replace } from "react-router-redux";
 import { setErrorPage } from "metabase/redux/app";
 import { loadMetadataForQuery } from "metabase/redux/metadata";
+import { addUndo } from "metabase/redux/undo";
 
 import * as MetabaseAnalytics from "metabase/lib/analytics";
 import { startTimer } from "metabase/lib/performance";
@@ -1419,4 +1421,11 @@ export const turnQuestionIntoDataset = () => async (dispatch, getState) => {
   if (question.display() !== "table") {
     dispatch(runQuestionQuery());
   }
+
+  dispatch(
+    addUndo({
+      message: t`This is a dataset now.`,
+      actions: [apiUpdateQuestion(question)],
+    }),
+  );
 };

--- a/frontend/test/metabase/scenarios/question/datasets.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/datasets.cy.spec.js
@@ -27,6 +27,18 @@ describe("scenarios > datasets", () => {
     cy.get(".LineAreaBarChart").should("not.exist");
   });
 
+  it("allows to undo turning a question into a dataset", () => {
+    cy.visit("/question/3");
+    cy.get(".LineAreaBarChart");
+
+    turnIntoDataset();
+    cy.findByText("This is a dataset now.");
+    cy.findByText("Undo").click();
+
+    cy.get(".LineAreaBarChart");
+    cy.icon("dataset");
+  });
+
   describe("data picker", () => {
     beforeEach(() => {
       cy.intercept("GET", "/api/search").as("search");


### PR DESCRIPTION
After a question is turned into a dataset, a toast message telling "This is a dataset now" will appear in the bottom left. It also provides an ability to undo the change. If a question had some non-table visualization before the change (datasets are always tables), it will get back to the previous viz.

### To Verify

1. Follow the steps from #18702 to turn a question into a dataset
2. After the modal closes, you should see a "This is a dataset now" toast message in the bottom left
3. Click the "undo" button, the dataset should become a question now
4. If it was visualized not as a table, the viz type should change back to the original one

### Demo

https://user-images.githubusercontent.com/17258145/140421090-a7de6bc5-87bd-4351-b357-0e5deaf45b42.mov

