### PR TITLE
Fix query->preprocessed when the query has cached results

### DIFF
--- a/src/metabase/query_processor.clj
+++ b/src/metabase/query_processor.clj
@@ -171,9 +171,11 @@
   "Return the fully preprocessed form for `query`, the way it would look immediately before `mbql->native` is called.
   Especially helpful for debugging or testing driver QP implementations."
   [query]
-  (preprocess-query query {:preprocessedf
-                           (fn [query context]
-                             (context/raisef (qp.reducible/quit query) context))}))
+  ;; Make sure the caching middleware doesn't try to return any cached results. That will totally break things
+  (preprocess-query (assoc-in query [:middleware :ignore-cached-results?] true)
+                    {:preprocessedf
+                     (fn [query context]
+                       (context/raisef (qp.reducible/quit query) context))}))
 
 (defn query->expected-cols
   "Return the `:cols` you would normally see in MBQL query results by preprocessing the query and calling `annotate` on

--- a/test/metabase/query_processor_test.clj
+++ b/test/metabase/query_processor_test.clj
@@ -12,12 +12,14 @@
             [metabase.models.table :refer [Table]]
             [metabase.query-processor :as qp]
             [metabase.query-processor.middleware.add-implicit-joins :as joins]
+            [metabase.test :as mt]
             [metabase.test-runner.init :as test-runner.init]
             [metabase.test.data :as data]
             [metabase.test.data.env :as tx.env]
             [metabase.test.data.interface :as tx]
             [metabase.test.util :as tu]
             [metabase.util :as u]
+            [schema.core :as s]
             [toucan.db :as db]))
 
 ;;; ---------------------------------------------- Helper Fns + Macros -----------------------------------------------
@@ -444,3 +446,37 @@
   replicate the situation where somebody has manually marked FK relationships for BigQuery."
   [d & body]
   `(do-with-bigquery-fks ~d (fn [] ~@body)))
+
+(deftest query->preprocessed-caching-test
+  (testing "`query->preprocessed` should work the same even if query has cached results (#18579)"
+    ;; make a copy of the `test-data` DB so there will be no cache entries from previous test runs possibly affecting
+    ;; this test.
+    (mt/with-temp-copy-of-db
+      (mt/with-temporary-setting-values [enable-query-caching  true
+                                         query-caching-min-ttl 0]
+        (let [query            (assoc (mt/mbql-query venues {:order-by [[:asc $id]], :limit 5})
+                                      :cache-ttl 10)
+              run-query        (fn []
+                                 (let [results (qp/process-query query)]
+                                   {:cached?  (boolean (:cached results))
+                                    :num-rows (count (mt/rows results))}))
+              expected-results (qp/query->preprocessed query)]
+          (testing "Check query->preprocessed before caching to make sure results make sense"
+            (is (schema= {:database (s/eq (mt/id))
+                          s/Keyword s/Any}
+                         expected-results)))
+          (testing "Run the query a few of times so we know it's cached"
+            (testing "first run"
+              (is (= {:cached?  false
+                      :num-rows 5}
+                     (run-query))))
+            ;; run a few more times to make sure stuff got a chance to be cached.
+            (run-query)
+            (run-query)
+            (testing "should be cached now"
+              (is (= {:cached?  true
+                      :num-rows 5}
+                     (run-query))))
+            (testing "query->preprocessed should return same results even when query was cached."
+              (is (= expected-results
+                     (qp/query->preprocessed query))))))))))


### PR DESCRIPTION
Fixes #18579

The problem here was `metabase.query-processor/query->preprocessed` was broken if the query had cached results. `query->preprocessed` is supposed to run the query thru the normal middleware steps and then at the last minute, instead of handing off the query to a driver to be executed, just return the query in its current state. When the query was cached however the caching middleware would ignore the rest of the pipleline and return the cached results instead. 

The fix here was to have `query->preprocessed` add the `:ignore-cached-results?` key to the query so the caching middleware would not attempt to return cached results. 