### PR TITLE
fix permissions page race condition

### DIFF
--- a/frontend/src/metabase/admin/permissions/pages/DataPermissionsPage/DataPermissionsPage.jsx
+++ b/frontend/src/metabase/admin/permissions/pages/DataPermissionsPage/DataPermissionsPage.jsx
@@ -6,6 +6,7 @@ import { connect } from "react-redux";
 import { PLUGIN_ADVANCED_PERMISSIONS } from "metabase/plugins";
 import Tables from "metabase/entities/tables";
 import Groups from "metabase/entities/groups";
+import Databases from "metabase/entities/databases";
 
 import { getIsDirty, getDiff } from "../../selectors/data-permissions";
 import {
@@ -90,6 +91,7 @@ DataPermissionsPage.propTypes = propTypes;
 
 export default _.compose(
   Groups.loadList(),
+  Databases.loadList(),
   connect(
     mapStateToProps,
     mapDispatchToProps,


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/18829

Sometimes the database list was not loaded, which led to an error. I was able to reproduce it locally with `Slow 3G` throttling enabled. The reason is that I missed adding loading databases because it already worked due navbar which loads them.

### How to verify
- Open http://localhost:3000/admin/permissions/data/database/1
- Open dev tools, set the network throttling to `Slow 3G`, and reload the page
- Ensure the page loads as expected