### PR TITLE
Add temporary defaults for initial_sync

### DIFF
--- a/frontend/src/metabase/schema.js
+++ b/frontend/src/metabase/schema.js
@@ -17,6 +17,7 @@ export const DatabaseSchema = new schema.Entity(
       // TODO Alexander Polyankin 11/05/21
       // Until BE returns databases before the initial sync, set it to true to unblock FE changes
       database.initial_sync = true;
+      return database;
     },
   },
 );

--- a/frontend/src/metabase/schema.js
+++ b/frontend/src/metabase/schema.js
@@ -9,7 +9,17 @@ export const DashboardSchema = new schema.Entity("dashboards");
 export const PulseSchema = new schema.Entity("pulses");
 export const CollectionSchema = new schema.Entity("collections");
 
-export const DatabaseSchema = new schema.Entity("databases");
+export const DatabaseSchema = new schema.Entity(
+  "databases",
+  {},
+  {
+    processStrategy: database => {
+      // TODO Alexander Polyankin 11/05/21
+      // Until BE returns databases before the initial sync, set it to true to unblock FE changes
+      database.initial_sync = true;
+    },
+  },
+);
 export const SchemaSchema = new schema.Entity("schemas");
 export const TableSchema = new schema.Entity(
   "tables",
@@ -36,6 +46,11 @@ export const TableSchema = new schema.Entity(
           },
         };
       }
+
+      // TODO Alexander Polyankin 11/05/21
+      // Until BE returns tables before the initial sync, set it to true to unblock FE changes
+      table.initial_sync = true;
+
       return table;
     },
   },

--- a/frontend/test/metabase/entities/databases.unit.spec.js
+++ b/frontend/test/metabase/entities/databases.unit.spec.js
@@ -26,7 +26,12 @@ describe("database entity", () => {
     );
     const { databases, schemas, tables } = store.getState().entities;
     expect(databases).toEqual({
-      "123": { id: 123, tables: [234], is_saved_questions: false },
+      "123": {
+        id: 123,
+        tables: [234],
+        initial_sync: true,
+        is_saved_questions: false,
+      },
     });
     expect(schemas).toEqual({
       "123:public": {
@@ -42,6 +47,7 @@ describe("database entity", () => {
         id: 234,
         schema: "123:public",
         schema_name: "public",
+        initial_sync: true,
       },
     });
   });

--- a/frontend/test/metabase/entities/schemas.unit.spec.js
+++ b/frontend/test/metabase/entities/schemas.unit.spec.js
@@ -34,8 +34,8 @@ describe("schema entity", () => {
       },
     });
     expect(tables).toEqual({
-      "123": { id: 123, name: "foo" },
-      "234": { id: 234, name: "bar" },
+      "123": { id: 123, name: "foo", initial_sync: true },
+      "234": { id: 234, name: "bar", initial_sync: true },
     });
   });
 
@@ -79,8 +79,8 @@ describe("schema entity", () => {
       },
     });
     expect(tables).toEqual({
-      "123": { id: 123, name: "foo" },
-      "234": { id: 234, name: "bar" },
+      "123": { id: 123, name: "foo", initial_sync: true },
+      "234": { id: 234, name: "bar", initial_sync: true },
     });
   });
 


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/18675

To unlock merging FE branches for the feature, we need to set `initial_sync` to `true` until BE actually starts to support Databases and Tables until the initial sync finishes.