### PR TITLE
Fix data picker's bucket step look

### DIFF
--- a/frontend/src/metabase/components/AccordionList.jsx
+++ b/frontend/src/metabase/components/AccordionList.jsx
@@ -73,7 +73,6 @@ export default class AccordionList extends Component {
     renderItemIcon: PropTypes.func,
     renderItemExtra: PropTypes.func,
     getItemClassName: PropTypes.func,
-    getItemIconPosition: PropTypes.func,
 
     alwaysTogglable: PropTypes.bool,
     alwaysExpanded: PropTypes.bool,
@@ -112,7 +111,6 @@ export default class AccordionList extends Component {
     renderItemExtra: item => null,
     renderItemIcon: item => item.icon && <Icon name={item.icon} size={18} />,
     getItemClassName: item => item.className,
-    getItemIconPosition: item => "left-block",
   };
 
   componentDidMount() {
@@ -479,7 +477,6 @@ const AccordionListCell = ({
   showItemArrows,
   itemTestId,
   getItemClassName,
-  getItemIconPosition,
 }) => {
   const { type, section, sectionIndex, item, itemIndex, isLastItem } = row;
   let content;
@@ -552,16 +549,8 @@ const AccordionListCell = ({
     const isSelected = itemIsSelected(item, itemIndex);
     const isClickable = itemIsClickable(item, itemIndex);
     const icon = renderItemIcon(item, itemIndex, isSelected);
-    const iconPosition = getItemIconPosition(item, itemIndex);
     const name = renderItemName(item, itemIndex, isSelected);
     const description = renderItemDescription(item, itemIndex, isSelected);
-    const isLeftBlockIcon = iconPosition === "left-block";
-    const iconClassNames = cx("List-item-icon text-default", {
-      "flex align-center": isLeftBlockIcon,
-    });
-    const descriptionClassNames = cx("List-item-description text-wrap", {
-      ml1: isLeftBlockIcon,
-    });
     content = (
       <div
         data-testid={itemTestId}
@@ -583,20 +572,17 @@ const AccordionListCell = ({
           )}
           onClick={isClickable ? () => onChange(item) : null}
         >
-          {icon && iconPosition === "left-block" && (
-            <span className={iconClassNames}>{icon}</span>
+          {icon && (
+            <span className="List-item-icon text-default flex align-center">
+              {icon}
+            </span>
           )}
           <div>
-            {name && (
-              <div className="flex align-center">
-                {icon && iconPosition === "near-name" && (
-                  <span className={iconClassNames}>{icon}</span>
-                )}
-                <h4 className="List-item-title ml1 text-wrap inline">{name}</h4>
-              </div>
-            )}
+            {name && <h4 className="List-item-title ml1 text-wrap">{name}</h4>}
             {description && (
-              <p className={descriptionClassNames}>{description}</p>
+              <p className="List-item-description ml1 text-wrap">
+                {description}
+              </p>
             )}
           </div>
         </a>

--- a/frontend/src/metabase/components/select-list/BaseSelectListItem.jsx
+++ b/frontend/src/metabase/components/select-list/BaseSelectListItem.jsx
@@ -1,0 +1,47 @@
+import React from "react";
+import PropTypes from "prop-types";
+import _ from "underscore";
+
+import { useScrollOnMount } from "metabase/hooks/use-scroll-on-mount";
+
+import { BaseItemRoot } from "./SelectListItem.styled";
+
+const propTypes = {
+  id: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  onSelect: PropTypes.func.isRequired,
+  isSelected: PropTypes.bool,
+  size: PropTypes.oneOf(["small", "medium"]),
+  className: PropTypes.string,
+  children: PropTypes.node.isRequired,
+  as: PropTypes.element,
+};
+
+export function BaseSelectListItem({
+  id,
+  onSelect,
+  isSelected = false,
+  size = "medium",
+  className,
+  as = BaseItemRoot,
+  children,
+}) {
+  const ref = useScrollOnMount();
+  const Root = as;
+  return (
+    <Root
+      innerRef={isSelected ? ref : null}
+      isSelected={isSelected}
+      role="menuitem"
+      tabIndex={0}
+      size={size}
+      onClick={() => onSelect(id)}
+      onKeyDown={e => e.key === "Enter" && onSelect(id)}
+      className={className}
+    >
+      {children}
+    </Root>
+  );
+}
+
+BaseSelectListItem.propTypes = propTypes;

--- a/frontend/src/metabase/components/select-list/SelectList.jsx
+++ b/frontend/src/metabase/components/select-list/SelectList.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 
+import { BaseSelectListItem } from "./BaseSelectListItem";
 import { SelectListItem } from "./SelectListItem";
 
 const propTypes = {
@@ -18,4 +19,5 @@ export function SelectList({ children, className }) {
 
 SelectList.propTypes = propTypes;
 
+SelectList.BaseItem = BaseSelectListItem;
 SelectList.Item = SelectListItem;

--- a/frontend/src/metabase/components/select-list/SelectListItem.jsx
+++ b/frontend/src/metabase/components/select-list/SelectListItem.jsx
@@ -5,7 +5,7 @@ import _ from "underscore";
 import { iconPropTypes } from "metabase/components/Icon";
 
 import { BaseSelectListItem } from "./BaseSelectListItem";
-import { ItemIcon, ItemTitle } from "./SelectListItem.styled";
+import { ItemRoot, ItemIcon, ItemTitle } from "./SelectListItem.styled";
 
 const iconPropType = PropTypes.oneOfType([
   PropTypes.string,
@@ -28,7 +28,7 @@ export function SelectListItem(props) {
     : { name: rightIcon };
 
   return (
-    <BaseSelectListItem {...props}>
+    <BaseSelectListItem as={ItemRoot} {...props}>
       <ItemIcon color="brand" {...iconProps} />
       <ItemTitle>{name}</ItemTitle>
       {rightIconProps.name && <ItemIcon {...rightIconProps} />}

--- a/frontend/src/metabase/components/select-list/SelectListItem.jsx
+++ b/frontend/src/metabase/components/select-list/SelectListItem.jsx
@@ -3,39 +3,24 @@ import PropTypes from "prop-types";
 import _ from "underscore";
 
 import { iconPropTypes } from "metabase/components/Icon";
-import { useScrollOnMount } from "metabase/hooks/use-scroll-on-mount";
 
-import { ItemRoot, ItemIcon, ItemTitle } from "./SelectListItem.styled";
+import { BaseSelectListItem } from "./BaseSelectListItem";
+import { ItemIcon, ItemTitle } from "./SelectListItem.styled";
+
+const iconPropType = PropTypes.oneOfType([
+  PropTypes.string,
+  PropTypes.shape(iconPropTypes),
+]);
 
 const propTypes = {
-  id: PropTypes.string.isRequired,
-  name: PropTypes.string.isRequired,
-  icon: PropTypes.oneOfType([PropTypes.string, PropTypes.shape(iconPropTypes)])
-    .isRequired,
+  ...BaseSelectListItem.propTypes,
+  icon: iconPropType.isRequired,
   iconColor: PropTypes.string,
-  onSelect: PropTypes.func.isRequired,
-  isSelected: PropTypes.bool,
-  rightIcon: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.shape({
-      name: PropTypes.name,
-    }),
-  ]),
-  size: PropTypes.oneOf(["small", "medium"]),
-  className: PropTypes.string,
+  rightIcon: iconPropType,
 };
 
-export function SelectListItem({
-  id,
-  name,
-  icon,
-  onSelect,
-  isSelected = false,
-  rightIcon,
-  size = "medium",
-  className,
-}) {
-  const ref = useScrollOnMount();
+export function SelectListItem(props) {
+  const { name, icon, rightIcon } = props;
 
   const iconProps = _.isObject(icon) ? icon : { name: icon };
   const rightIconProps = _.isObject(rightIcon)
@@ -43,20 +28,11 @@ export function SelectListItem({
     : { name: rightIcon };
 
   return (
-    <ItemRoot
-      innerRef={isSelected ? ref : null}
-      isSelected={isSelected}
-      role="menuitem"
-      tabIndex={0}
-      size={size}
-      onClick={() => onSelect(id)}
-      onKeyDown={e => e.key === "Enter" && onSelect(id)}
-      className={className}
-    >
+    <BaseSelectListItem {...props}>
       <ItemIcon color="brand" {...iconProps} />
       <ItemTitle>{name}</ItemTitle>
       {rightIconProps.name && <ItemIcon {...rightIconProps} />}
-    </ItemRoot>
+    </BaseSelectListItem>
   );
 }
 

--- a/frontend/src/metabase/components/select-list/SelectListItem.styled.jsx
+++ b/frontend/src/metabase/components/select-list/SelectListItem.styled.jsx
@@ -29,6 +29,7 @@ const VERTICAL_PADDING_BY_SIZE = {
 };
 
 export const BaseItemRoot = styled.li`
+  display: grid;
   align-items: center;
   cursor: pointer;
   padding: ${props => VERTICAL_PADDING_BY_SIZE[props.size]} 0.5rem;

--- a/frontend/src/metabase/components/select-list/SelectListItem.styled.jsx
+++ b/frontend/src/metabase/components/select-list/SelectListItem.styled.jsx
@@ -28,10 +28,7 @@ const VERTICAL_PADDING_BY_SIZE = {
   medium: "0.75rem",
 };
 
-export const ItemRoot = styled.li`
-  display: grid;
-  grid-template-columns: min-content 1fr min-content;
-  gap: 0.5rem;
+export const BaseItemRoot = styled.li`
   align-items: center;
   cursor: pointer;
   padding: ${props => VERTICAL_PADDING_BY_SIZE[props.size]} 0.5rem;
@@ -47,4 +44,10 @@ export const ItemRoot = styled.li`
   &:hover {
     ${activeItemCss}
   }
+`;
+
+export const ItemRoot = styled(BaseItemRoot)`
+  display: grid;
+  grid-template-columns: min-content 1fr min-content;
+  gap: 0.5rem;
 `;

--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -32,8 +32,8 @@ import SavedQuestionPicker from "./saved-question-picker/SavedQuestionPicker";
 import { getMetadata } from "metabase/selectors/metadata";
 
 import {
-  DataBucketIcon,
-  DataBucketDescription,
+  DataBucketList,
+  DataBucketListItem,
   RawDataBackButton,
 } from "./DataSelector.styled";
 import "./DataSelector.css";
@@ -975,48 +975,38 @@ export class UnconnectedDataSelector extends Component {
   }
 }
 
-const DataBucketPicker = ({ selectedDataBucketId, onChangeDataBucket }) => {
-  const sections = [
+const DataBucketPicker = ({ onChangeDataBucket }) => {
+  const BUCKETS = [
     {
-      items: [
-        {
-          id: DATA_BUCKET.DATASETS,
-          index: 0,
-          icon: "dataset",
-          name: t`Datasets`,
-          description: t`The best starting place for new questions.`,
-        },
-        {
-          id: DATA_BUCKET.RAW_DATA,
-          index: 1,
-          icon: "database",
-          name: t`Raw Data`,
-          description: t`Unaltered tables in connected databases.`,
-        },
-        {
-          id: DATA_BUCKET.SAVED_QUESTIONS,
-          index: 2,
-          name: t`Saved Questions`,
-          icon: "folder",
-          description: t`Use any question’s results to start a new question.`,
-        },
-      ],
+      id: DATA_BUCKET.DATASETS,
+      icon: "dataset",
+      name: t`Datasets`,
+      description: t`The best starting place for new questions.`,
+    },
+    {
+      id: DATA_BUCKET.RAW_DATA,
+      icon: "database",
+      name: t`Raw Data`,
+      description: t`Unaltered tables in connected databases.`,
+    },
+    {
+      id: DATA_BUCKET.SAVED_QUESTIONS,
+      name: t`Saved Questions`,
+      icon: "folder",
+      description: t`Use any question’s results to start a new question.`,
     },
   ];
 
   return (
-    <AccordionList
-      id="DataBucketPicker"
-      className="text-brand"
-      sections={sections}
-      onChange={item => onChangeDataBucket(item.id)}
-      itemIsSelected={item => item.id === selectedDataBucketId}
-      renderItemIcon={item => <DataBucketIcon name={item.icon} size={18} />}
-      getItemIconPosition={() => "near-name"}
-      renderItemDescription={item => (
-        <DataBucketDescription>{item.description}</DataBucketDescription>
-      )}
-    />
+    <DataBucketList>
+      {BUCKETS.map(bucket => (
+        <DataBucketListItem
+          {...bucket}
+          key={bucket.id}
+          onSelect={onChangeDataBucket}
+        />
+      ))}
+    </DataBucketList>
   );
 };
 

--- a/frontend/src/metabase/query_builder/components/DataSelector.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.styled.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import { t } from "ttag";
 import styled from "styled-components";
 import Icon from "metabase/components/Icon";
+import { SelectList } from "metabase/components/select-list";
 import { color } from "metabase/lib/colors";
 import { space } from "metabase/styled-components/theme";
 
@@ -43,5 +44,69 @@ export function RawDataBackButton() {
       <Icon name="chevronleft" size={16} />
       <BackButtonLabel>{t`Raw Data`}</BackButtonLabel>
     </BackButtonContainer>
+  );
+}
+
+export const DataBucketList = styled(SelectList)`
+  width: 300px;
+  padding: ${space(0)} ${space(1)} 12px ${space(1)};
+`;
+
+const DataBucketListItemIcon = styled(Icon)`
+  color: ${color("text-dark")};
+`;
+
+const DataBucketTitleContainer = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const DataBucketListItemTitle = styled.span`
+  color: ${color("text-dark")};
+  font-weight: 700;
+  font-size: 14px;
+  margin-left: ${space(1)};
+`;
+
+const DataBucketListItemDescriptionContainer = styled.div`
+  margin-top: ${space(0)};
+`;
+
+const DataBucketListItemDescription = styled.span`
+  color: ${color("text-light")};
+  font-weight: 700;
+  font-size: 12px;
+`;
+
+const DataBucketListItemContainer = styled(SelectList.BaseItem)`
+  &:hover {
+    ${DataBucketListItemIcon},
+    ${DataBucketListItemTitle},
+    ${DataBucketListItemDescription} {
+      color: ${color("text-white")};
+    }
+  }
+`;
+
+DataBucketListItem.propTypes = {
+  name: PropTypes.string.isRequired,
+  icon: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired,
+};
+
+export function DataBucketListItem(props) {
+  const { name, icon, description } = props;
+  return (
+    <DataBucketListItemContainer {...props}>
+      <DataBucketTitleContainer>
+        <DataBucketListItemIcon name={icon} size={18} />
+        <DataBucketListItemTitle>{name}</DataBucketListItemTitle>
+      </DataBucketTitleContainer>
+      <DataBucketListItemDescriptionContainer>
+        <DataBucketListItemDescription>
+          {description}
+        </DataBucketListItemDescription>
+      </DataBucketListItemDescriptionContainer>
+    </DataBucketListItemContainer>
   );
 }

--- a/frontend/src/metabase/query_builder/components/DataSelector.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.styled.jsx
@@ -16,10 +16,6 @@ export const DataBucketDescription = styled.span`
   font-size: 12px;
 `;
 
-RawDataBackButton.propTypes = {
-  onBack: PropTypes.func.isRequired,
-};
-
 const BackButtonContainer = styled.div`
   display: flex;
   align-items: center;


### PR DESCRIPTION
Minor UI polish to data selector's new step introduced in #18764. Mostly fixes padding and spacing, and also the hover state for data bucket descriptions (remain grey on `master`)

It was originally implemented as an `AccordionList`. It's a pretty complex component for lists with complex UI (virtualization with dynamic heights, sections, nested content, etc.). The data bucket step is very straightforward, so there is actually no need to use the `AccordionList`. This PR replaces it with a `SelectList`. On top of that, this PR extracts `BaseListItem` from `SelectListItem` to make it easier to customize the list item appearance.

### To Verify

1. Make sure you have at least one dataset. If not, follow the steps from #18702 to create one
2. Ask a question > Simple / Custom question
3. Make sure the first data picker's view matches the "After" screenshot below and there are no weird UI elements

### Demo

**Before**

<img width="310" alt="CleanShot 2021-11-05 at 14 45 08@2x" src="https://user-images.githubusercontent.com/17258145/140512362-06fbacd9-1944-4f56-93d0-73cf470e77ba.png">

**After**

<img width="309" alt="CleanShot 2021-11-05 at 14 44 52@2x" src="https://user-images.githubusercontent.com/17258145/140512339-2f67a7f4-b7ce-4e93-816b-89e2bfd27fca.png">


