### PR TITLE
Fix CSS in setup user and preferences sections

### DIFF
--- a/frontend/src/metabase/setup/components/PreferencesStep.jsx
+++ b/frontend/src/metabase/setup/components/PreferencesStep.jsx
@@ -97,7 +97,11 @@ export default class PreferencesStep extends Component {
 
             <div className="Form-field mr4">
               <div
-                style={{ borderWidth: "2px" }}
+                style={{
+                  borderWidth: "2px",
+                  flexWrap: "wrap",
+                  justifyContent: "center",
+                }}
                 className="flex align-center bordered rounded p2"
               >
                 <Toggle
@@ -106,7 +110,11 @@ export default class PreferencesStep extends Component {
                   className="inline-block"
                   aria-labelledby="anonymous-usage-events-label"
                 />
-                <span className="ml1" id="anonymous-usage-events-label">
+                <span
+                  style={{ textAlign: "center" }}
+                  className="ml1"
+                  id="anonymous-usage-events-label"
+                >
                   {t`Allow Metabase to anonymously collect usage events`}
                 </span>
               </div>

--- a/frontend/src/metabase/setup/components/UserStep.jsx
+++ b/frontend/src/metabase/setup/components/UserStep.jsx
@@ -97,7 +97,7 @@ export default class UserStep extends Component {
           >
             {({ Form, FormField, FormFooter }) => (
               <Form>
-                <Flex align="center">
+                <Flex align="center" flexWrap="wrap">
                   <FormField name="first_name" className="flex-full mr1" />
                   <FormField name="last_name" className="flex-full" />
                 </Flex>


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/18411 and https://github.com/metabase/metabase/issues/18414

I have simply fixed the issues by adding the `flex-wrap` CSS property. Let me know if you think this is a wrong approach.

![metabase-lastname](https://user-images.githubusercontent.com/51820585/140527729-b33e9172-7e9c-4e9e-976f-b32ace3f604a.png)


