### PR TITLE
Add revision messages for datasets

### DIFF
--- a/frontend/src/metabase/lib/revisions/revisions.js
+++ b/frontend/src/metabase/lib/revisions/revisions.js
@@ -94,6 +94,12 @@ const CHANGE_DESCRIPTIONS = {
   },
 
   // Questions
+  dataset: {
+    [CHANGE_TYPE.UPDATE]: (wasDataset, isDataset) =>
+      isDataset
+        ? t`turned this into a dataset`
+        : t`reverted this from a dataset to a saved question`,
+  },
   dataset_query: {
     [CHANGE_TYPE.ADD]: t`edited the question`,
     [CHANGE_TYPE.UPDATE]: t`edited the question`,

--- a/frontend/src/metabase/lib/revisions/revisions.unit.spec.js
+++ b/frontend/src/metabase/lib/revisions/revisions.unit.spec.js
@@ -254,6 +254,28 @@ describe("getRevisionDescription | questions", () => {
       "changed the visualization settings",
     );
   });
+
+  it("handles turning a question into a dataset", () => {
+    const revision = getSimpleRevision({
+      field: "dataset",
+      before: false,
+      after: true,
+    });
+
+    expect(getRevisionDescription(revision)).toBe("turned this into a dataset");
+  });
+
+  it("handles turning a dataset back into a saved question", () => {
+    const revision = getSimpleRevision({
+      field: "dataset",
+      before: true,
+      after: false,
+    });
+
+    expect(getRevisionDescription(revision)).toBe(
+      "reverted this from a dataset to a saved question",
+    );
+  });
 });
 
 describe("getRevisionDescription | dashboards", () => {


### PR DESCRIPTION
Adds revision messages when a question is turned into a dataset or vice-versa

### To Verify

1. Open any saved question
2. Click the question name in the header
3. Click the new dataset icon in the left sidebar (aka the waffle icon 🧇 )
4. Click the "Turn this into a dataset", confirm the modal
5. Click the "Undo" button in the toast message at the bottom left of the page
6. Click the "History" button at the bottom of the details sidebar
7. You should see two messages like one the screenshot below

### Demo

<img width="322" alt="revisions" src="https://user-images.githubusercontent.com/17258145/140545841-99e9edaf-d688-41b8-aa32-2127badafc4b.png">
