### PR TITLE
Add "Datasets" search filter

### DIFF
--- a/frontend/src/metabase/home/containers/SearchApp.jsx
+++ b/frontend/src/metabase/home/containers/SearchApp.jsx
@@ -40,7 +40,7 @@ const SEARCH_FILTERS = [
     icon: "database",
   },
   {
-    name: t`Tables`,
+    name: t`Raw Tables`,
     filter: "table",
     icon: "table",
   },

--- a/frontend/src/metabase/home/containers/SearchApp.jsx
+++ b/frontend/src/metabase/home/containers/SearchApp.jsx
@@ -40,6 +40,11 @@ const SEARCH_FILTERS = [
     icon: "database",
   },
   {
+    name: t`Datasets`,
+    filter: "dataset",
+    icon: "dataset",
+  },
+  {
     name: t`Raw Tables`,
     filter: "table",
     icon: "table",
@@ -164,7 +169,7 @@ export default function SearchApp({ location }) {
                           query: { ...location.query, type: f.filter },
                         }}
                       >
-                        <Icon mr={1} name={f.icon} />
+                        <Icon mr={1} name={f.icon} size={16} />
                         <h4>{f.name}</h4>
                       </Link>
                     );

--- a/frontend/src/metabase/search/components/InfoText.jsx
+++ b/frontend/src/metabase/search/components/InfoText.jsx
@@ -31,6 +31,8 @@ export function InfoText({ result }) {
   switch (result.model) {
     case "card":
       return jt`Saved question in ${formatCollection(result.getCollection())}`;
+    case "dataset":
+      return jt`Dataset in ${formatCollection(result.getCollection())}`;
     case "collection":
       return getCollectionInfoText(result.collection);
     case "database":


### PR DESCRIPTION
Adds "Datasets" search filter to `/search` page and renames "Tables" filter into "Raw Tables"

### To Verify

1. Follow the steps from #18702 to create a dataset
2. Use the navbar search to find a dataset
3. While being focused on the search input, hit "Enter"
4. You should appear on the `/search` page. You should see result filters on the right side
5. Click "Datasets" in the list of filters, you should only see datasets

### Demo

**Before**

<img width="1054" alt="CleanShot 2021-11-05 at 19 18 38@2x" src="https://user-images.githubusercontent.com/17258145/140552760-6a253fdc-3683-498d-80aa-f54361d07daa.png">


**After**

<img width="1090" alt="CleanShot 2021-11-05 at 19 19 42@2x" src="https://user-images.githubusercontent.com/17258145/140552785-5a992194-3d62-4033-aa07-d6f465bfa5ab.png">
