### PR TITLE
Update suggestion from AdoptOpenJDK to Eclipse Temurin

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ docker run -d -p 3000:3000 --name metabase metabase/metabase
 
 To run Metabase via a JAR file, you will need to have a Java Runtime Environment installed on your system.
 
-We recommend the latest LTS version of JRE from [AdoptOpenJDK](https://adoptopenjdk.net/releases.html) with HotSpot JVM and x64 architecture, but other [Java versions](https://www.metabase.com/docs/latest/operations-guide/java-versions.html) might work too.
+We recommend the latest LTS version of JRE from [Eclipse Temurin](https://adoptium.net/) with HotSpot JVM and x64 architecture, but other [Java versions](https://www.metabase.com/docs/latest/operations-guide/java-versions.html) might work too.
 
 Go to the [Metabase download page](https://metabase.com/start/jar.html) and download the latest release. Place the downloaded JAR file into a newly created directory (as it will create some files when it is run), and run it with the following command:
 

--- a/docs/operations-guide/java-versions.md
+++ b/docs/operations-guide/java-versions.md
@@ -2,11 +2,11 @@
 
 Metabase requires a Java Runtime Environment (JRE), with a Java version of 11 or higher.
 
-We recommend the latest LTS version of JRE from [AdoptOpenJDK](https://adoptopenjdk.net/releases.html) with HotSpot JVM and x64 architecture, but any version Java 11 or higher should work (see [supported versions](https://adoptopenjdk.net/support.html)), including other types of JVM and architecture, and other distributions such as [OpenJDK](https://openjdk.java.net/), [Amazon Corretto](https://aws.amazon.com/corretto/), [Zulu OpenJDK](https://www.azul.com/downloads/zulu-community), and [Oracle Java](https://www.java.com/).
+We recommend the latest LTS version of JRE from [Eclipse Temurin](https://adoptium.net/) with HotSpot JVM and x64 architecture, but any version Java 11 or higher should work (see [supported versions](https://adoptium.net/support.html)), including other types of JVM and architecture, and other distributions such as [OpenJDK](https://openjdk.java.net/), [Amazon Corretto](https://aws.amazon.com/corretto/), [Zulu OpenJDK](https://www.azul.com/downloads/zulu-community), [Oracle Java](https://www.java.com/), and [IBM Semeru](https://developer.ibm.com/languages/java/semeru-runtimes/) (If you want an OpenJ9 alternative of Eclipse Temurin).
 
 **Note** When using a "headless" version, the JVM needs to have AWT classes, which are sometimes not included. Otherwise Pulses and other functionality might not work correctly or not at all.
 
-When developing and building Metabase, a Java Development Kit (JDK) is required. We recommend the latest LTS version of JDK from AdoptOpenJDK with HotSpot JVM.
+When developing and building Metabase, a Java Development Kit (JDK) is required. We recommend the latest LTS version of JDK from Eclipse Temurin with HotSpot JVM.
 
 #### Check installed version
 
@@ -18,8 +18,8 @@ java -version
 
 You should see output similar to this:
 
-    openjdk version "11.0.7" 2020-04-14
-    OpenJDK Runtime Environment AdoptOpenJDK (build 11.0.7+10)
-    OpenJDK 64-Bit Server VM AdoptOpenJDK (build 11.0.7+10, mixed mode)
+    openjdk version "11.0.13" 2021-10-19
+    OpenJDK Runtime Environment Temurin-11.0.13+8 (build 11.0.13+8)
+    OpenJDK 64-Bit Server VM Temurin-11.0.13+8 (build 11.0.13+8, mixed mode)
 
 If you get an error, you need to install Java. If the Java release date is more than a few months old, you should update Java.

--- a/docs/operations-guide/running-the-metabase-jar-file.md
+++ b/docs/operations-guide/running-the-metabase-jar-file.md
@@ -4,7 +4,7 @@ To run Metabase via a JAR file, you will need to have a Java Runtime Environment
 
 ### Install Java JRE
 
-We recommend the latest LTS version of JRE from [AdoptOpenJDK](https://adoptopenjdk.net/releases.html) with HotSpot JVM and x64 architecture, but other [Java versions](./java-versions.md) are supported too.
+We recommend the latest LTS version of JRE from [Eclipse Temurin](https://adoptium.net/) with HotSpot JVM and x64 architecture, but other [Java versions](./java-versions.md) are supported too.
 
 ### Download Metabase
 


### PR DESCRIPTION
Eclipse Temurin is the replacement for AdoptOpenJDK Hotspot, as the project now is part from Eclipse Foundation, and the OpenJ9 build is called now as Semeru.