### PR TITLE
Add list to reload function for entity polling

### DIFF
--- a/frontend/src/metabase/entities/containers/EntityListLoader.jsx
+++ b/frontend/src/metabase/entities/containers/EntityListLoader.jsx
@@ -90,13 +90,17 @@ const getMemoizedEntityQuery = createMemoizedSelector(
   if (typeof entityQuery === "function") {
     entityQuery = entityQuery(state, props);
   }
-  if (typeof reloadInterval === "function") {
-    reloadInterval = reloadInterval(state, props);
-  }
   if (typeof pageSize === "number" && typeof page === "number") {
     entityQuery = { limit: pageSize, offset: pageSize * page, ...entityQuery };
   }
-  entityQuery = getMemoizedEntityQuery(state, { entityQuery });
+  if (entityQuery != null) {
+    entityQuery = getMemoizedEntityQuery(state, { entityQuery });
+  }
+
+  const list = entityDef.selectors[selectorName](state, { entityQuery });
+  if (typeof reloadInterval === "function") {
+    reloadInterval = reloadInterval(state, props, list);
+  }
 
   const loading = entityDef.selectors.getLoading(state, { entityQuery });
   const loaded = entityDef.selectors.getLoaded(state, { entityQuery });
@@ -105,9 +109,9 @@ const getMemoizedEntityQuery = createMemoizedSelector(
   const metadata = entityDef.selectors.getListMetadata(state, { entityQuery });
 
   return {
+    list,
     entityQuery,
     reloadInterval,
-    list: entityDef.selectors[selectorName](state, { entityQuery }),
     metadata,
     loading,
     loaded,

--- a/frontend/src/metabase/entities/containers/EntityListLoader.jsx
+++ b/frontend/src/metabase/entities/containers/EntityListLoader.jsx
@@ -93,9 +93,7 @@ const getMemoizedEntityQuery = createMemoizedSelector(
   if (typeof pageSize === "number" && typeof page === "number") {
     entityQuery = { limit: pageSize, offset: pageSize * page, ...entityQuery };
   }
-  if (entityQuery != null) {
-    entityQuery = getMemoizedEntityQuery(state, { entityQuery });
-  }
+  entityQuery = getMemoizedEntityQuery(state, { entityQuery });
 
   const list = entityDef.selectors[selectorName](state, { entityQuery });
   if (typeof reloadInterval === "function") {


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/18675

Adds a loaded `list` as an argument to `reloadInterval` to support cases where the interval depends on the loaded data.