### PR TITLE
Implement progress static visualization renderer

### DIFF
--- a/frontend/src/metabase/internal/pages/StaticVizPage.jsx
+++ b/frontend/src/metabase/internal/pages/StaticVizPage.jsx
@@ -218,13 +218,15 @@ export default function StaticVizPage() {
                 value: 0,
                 goal: 100000,
               },
-              format: {
-                number_style: "currency",
-                currency: "USD",
-                currency_style: "symbol",
-                decimals: 0,
+              settings: {
+                format: {
+                  number_style: "currency",
+                  currency: "USD",
+                  currency_style: "symbol",
+                  decimals: 0,
+                },
+                color: "#84BB4C",
               },
-              color: "#84BB4C",
             }}
           />
           <StaticChart
@@ -234,13 +236,15 @@ export default function StaticVizPage() {
                 value: 30000,
                 goal: 100000,
               },
-              format: {
-                number_style: "currency",
-                currency: "USD",
-                currency_style: "symbol",
-                decimals: 0,
+              settings: {
+                format: {
+                  number_style: "currency",
+                  currency: "USD",
+                  currency_style: "symbol",
+                  decimals: 0,
+                },
+                color: "#84BB4C",
               },
-              color: "#84BB4C",
             }}
           />
           <StaticChart
@@ -250,13 +254,15 @@ export default function StaticVizPage() {
                 value: 100000,
                 goal: 100000,
               },
-              format: {
-                number_style: "currency",
-                currency: "USD",
-                currency_style: "symbol",
-                decimals: 0,
+              settings: {
+                format: {
+                  number_style: "currency",
+                  currency: "USD",
+                  currency_style: "symbol",
+                  decimals: 0,
+                },
+                color: "#84BB4C",
               },
-              color: "#84BB4C",
             }}
           />
           <StaticChart
@@ -266,13 +272,15 @@ export default function StaticVizPage() {
                 value: 135000,
                 goal: 100000,
               },
-              format: {
-                number_style: "currency",
-                currency: "USD",
-                currency_style: "symbol",
-                decimals: 0,
+              settings: {
+                format: {
+                  number_style: "currency",
+                  currency: "USD",
+                  currency_style: "symbol",
+                  decimals: 0,
+                },
+                color: "#84BB4C",
               },
-              color: "#84BB4C",
             }}
           />
         </Box>

--- a/frontend/src/metabase/internal/pages/StaticVizPage.jsx
+++ b/frontend/src/metabase/internal/pages/StaticVizPage.jsx
@@ -209,6 +209,73 @@ export default function StaticVizPage() {
             }}
           />
         </Box>
+        <Box py={3}>
+          <Subhead>Progress bar</Subhead>
+          <StaticChart
+            type="progress"
+            options={{
+              data: {
+                value: 0,
+                goal: 100000,
+              },
+              format: {
+                number_style: "currency",
+                currency: "USD",
+                currency_style: "symbol",
+                decimals: 0,
+              },
+              color: "#84BB4C",
+            }}
+          />
+          <StaticChart
+            type="progress"
+            options={{
+              data: {
+                value: 30000,
+                goal: 100000,
+              },
+              format: {
+                number_style: "currency",
+                currency: "USD",
+                currency_style: "symbol",
+                decimals: 0,
+              },
+              color: "#84BB4C",
+            }}
+          />
+          <StaticChart
+            type="progress"
+            options={{
+              data: {
+                value: 100000,
+                goal: 100000,
+              },
+              format: {
+                number_style: "currency",
+                currency: "USD",
+                currency_style: "symbol",
+                decimals: 0,
+              },
+              color: "#84BB4C",
+            }}
+          />
+          <StaticChart
+            type="progress"
+            options={{
+              data: {
+                value: 135000,
+                goal: 100000,
+              },
+              format: {
+                number_style: "currency",
+                currency: "USD",
+                currency_style: "symbol",
+                decimals: 0,
+              },
+              color: "#84BB4C",
+            }}
+          />
+        </Box>
       </Box>
     </Box>
   );

--- a/frontend/src/metabase/static-viz/components/ProgressBar/CheckMarkIcon.tsx
+++ b/frontend/src/metabase/static-viz/components/ProgressBar/CheckMarkIcon.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+
+interface CheckMarkIconProps {
+  size: number;
+  color: string;
+  x?: number;
+  y?: number;
+}
+
+export const CheckMarkIcon = ({
+  size = 16,
+  color,
+  x,
+  y,
+}: CheckMarkIconProps) => (
+  <svg width={size} height={size} viewBox="0 0 40 40" fill="none" x={x} y={y}>
+    <path
+      d="M9 19.5L12 16.5L18 22.5L28.5 12L31.5 15L18 28.5L9 19.5Z"
+      fill={color}
+    />
+    <path
+      d="M38.5 20C38.5 30.2173 30.2173 38.5 20 38.5C9.78273 38.5 1.5 30.2173 1.5 20C1.5 9.78273 9.78273 1.5 20 1.5C30.2173 1.5 38.5 9.78273 38.5 20Z"
+      stroke={color}
+      strokeWidth="3"
+    />
+  </svg>
+);

--- a/frontend/src/metabase/static-viz/components/ProgressBar/Pointer.tsx
+++ b/frontend/src/metabase/static-viz/components/ProgressBar/Pointer.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+interface PointerProps {
+  width: number;
+  height: number;
+  fill?: string;
+}
+
+export const Pointer = ({ width, height, fill }: PointerProps) => {
+  const points = [[-width / 2, 0], [width / 2, 0], [0, height]]
+    .map(point => point.join(","))
+    .join(" ");
+
+  return <polygon fill={fill} points={points} />;
+};

--- a/frontend/src/metabase/static-viz/components/ProgressBar/ProgressBar.tsx
+++ b/frontend/src/metabase/static-viz/components/ProgressBar/ProgressBar.tsx
@@ -6,16 +6,21 @@ import { formatNumber } from "../../lib/numbers";
 import { Text } from "../Text";
 import { Pointer } from "./Pointer";
 import { CheckMarkIcon } from "./CheckMarkIcon";
-import { createPalette, getBarText, getColors } from "./utils";
+import {
+  createPalette,
+  getBarText,
+  getColors,
+  calculatePointerLabelShift,
+} from "./utils";
 import { ProgressBarData } from "./types";
 
 const layout = {
-  width: 400,
+  width: 440,
   height: 110,
   margin: {
     top: 40,
-    right: 100,
-    left: 20,
+    right: 40,
+    left: 40,
   },
   barHeight: 40,
   borderRadius: 5,
@@ -29,11 +34,16 @@ const layout = {
 
 interface ProgressBarProps {
   data: ProgressBarData;
-  color: string;
-  format: any;
+  settings: {
+    color: string;
+    format: any;
+  };
 }
 
-const ProgressBar = ({ data, color, format }: ProgressBarProps) => {
+const ProgressBar = ({
+  data,
+  settings: { color, format },
+}: ProgressBarProps) => {
   const palette = createPalette(color);
   const colors = getColors(data, palette);
   const barWidth = layout.width - layout.margin.left - layout.margin.right;
@@ -51,9 +61,19 @@ const ProgressBar = ({ data, color, format }: ProgressBarProps) => {
   const currentX = xScale(Math.min(data.goal, data.value));
 
   const pointerY = layout.margin.top - layout.pointer.height * 1.5;
-  const pointerX = xMin + xScale(data.value);
+  const pointerX = xMin + Math.max(xScale(data.value), 0);
 
   const barText = getBarText(data);
+
+  const valueText = formatNumber(data.value, format);
+
+  const valueTextShift = calculatePointerLabelShift(
+    valueText,
+    pointerX,
+    xMin,
+    xMax,
+    layout.pointer.width,
+  );
 
   return (
     <svg width={layout.width} height={layout.height}>
@@ -97,8 +117,8 @@ const ProgressBar = ({ data, color, format }: ProgressBarProps) => {
         )}
       </Group>
       <Group left={pointerX} top={pointerY}>
-        <Text textAnchor="middle" dy="-0.4em">
-          {formatNumber(data.value, format)}
+        <Text textAnchor={"middle"} dy="-0.4em" dx={valueTextShift}>
+          {valueText}
         </Text>
         <Pointer
           width={layout.pointer.width}

--- a/frontend/src/metabase/static-viz/components/ProgressBar/ProgressBar.tsx
+++ b/frontend/src/metabase/static-viz/components/ProgressBar/ProgressBar.tsx
@@ -1,0 +1,125 @@
+import React from "react";
+import { scaleLinear } from "@visx/scale";
+import { Group } from "@visx/group";
+import { ClipPath } from "@visx/clip-path";
+import { formatNumber } from "../../lib/numbers";
+import { Text } from "../Text";
+import { Pointer } from "./Pointer";
+import { CheckMarkIcon } from "./CheckMarkIcon";
+import { createPalette, getBarText, getColors } from "./utils";
+import { ProgressBarData } from "./types";
+
+const layout = {
+  width: 400,
+  height: 110,
+  margin: {
+    top: 40,
+    right: 100,
+    left: 20,
+  },
+  barHeight: 40,
+  borderRadius: 5,
+  labelsMargin: 16,
+  iconSize: 20,
+  pointer: {
+    width: 20,
+    height: 10,
+  },
+};
+
+interface ProgressBarProps {
+  data: ProgressBarData;
+  color: string;
+  format: any;
+}
+
+const ProgressBar = ({ data, color, format }: ProgressBarProps) => {
+  const palette = createPalette(color);
+  const colors = getColors(data, palette);
+  const barWidth = layout.width - layout.margin.left - layout.margin.right;
+
+  const xMin = layout.margin.left;
+  const xMax = xMin + barWidth;
+
+  const labelsY = layout.margin.top + layout.barHeight + layout.labelsMargin;
+
+  const xScale = scaleLinear({
+    domain: [0, Math.max(data.goal, data.value)],
+    range: [0, barWidth],
+  });
+
+  const currentX = xScale(Math.min(data.goal, data.value));
+
+  const pointerY = layout.margin.top - layout.pointer.height * 1.5;
+  const pointerX = xMin + xScale(data.value);
+
+  const barText = getBarText(data);
+
+  return (
+    <svg width={layout.width} height={layout.height}>
+      <ClipPath id="rounded-bar">
+        <rect
+          width={barWidth}
+          height={layout.barHeight}
+          rx={layout.borderRadius}
+        />
+      </ClipPath>
+      <Group clipPath={`url(#rounded-bar)`} top={layout.margin.top} left={xMin}>
+        <rect
+          width={barWidth}
+          height={layout.barHeight}
+          fill={colors.backgroundBar}
+        />
+        <rect
+          width={currentX}
+          height={layout.barHeight}
+          fill={colors.foregroundBar}
+        />
+        {barText && (
+          <>
+            <CheckMarkIcon
+              size={layout.iconSize}
+              color="white"
+              x={10}
+              y={(layout.barHeight - layout.iconSize) / 2}
+            />
+            <Text
+              textAnchor="start"
+              color="white"
+              x={layout.iconSize + 16}
+              y={layout.barHeight / 2}
+              dominantBaseline="central"
+              fill="white"
+            >
+              {barText}
+            </Text>
+          </>
+        )}
+      </Group>
+      <Group left={pointerX} top={pointerY}>
+        <Text textAnchor="middle" dy="-0.4em">
+          {formatNumber(data.value, format)}
+        </Text>
+        <Pointer
+          width={layout.pointer.width}
+          height={layout.pointer.height}
+          fill={colors.pointer}
+        />
+      </Group>
+      <Group top={labelsY}>
+        <Text
+          textAnchor="start"
+          alignmentBaseline="baseline"
+          x={layout.margin.left}
+        >
+          {formatNumber(0, format)}
+        </Text>
+        <Text textAnchor="end" x={xMax}>
+          {`Goal ${formatNumber(data.goal, format)}`}
+        </Text>
+      </Group>
+    </svg>
+  );
+};
+
+export default ProgressBar;

--- a/frontend/src/metabase/static-viz/components/ProgressBar/index.ts
+++ b/frontend/src/metabase/static-viz/components/ProgressBar/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ProgressBar";

--- a/frontend/src/metabase/static-viz/components/ProgressBar/types.ts
+++ b/frontend/src/metabase/static-viz/components/ProgressBar/types.ts
@@ -1,0 +1,4 @@
+export type ProgressBarData = {
+  value: number;
+  goal: number;
+};

--- a/frontend/src/metabase/static-viz/components/ProgressBar/utils.ts
+++ b/frontend/src/metabase/static-viz/components/ProgressBar/utils.ts
@@ -1,4 +1,5 @@
 import Color from "color";
+import { measureText } from "metabase/static-viz/lib/text";
 import { ProgressBarData } from "./types";
 
 export const createPalette = (color: string) => ({
@@ -36,4 +37,28 @@ export const getBarText = ({ value, goal }: ProgressBarData) => {
   }
 
   return null;
+};
+
+export const calculatePointerLabelShift = (
+  valueText: string,
+  pointerX: number,
+  xMin: number,
+  xMax: number,
+  pointerWidth: number,
+) => {
+  const valueTextWidth = measureText(valueText, 7);
+
+  const distanceToLeftBorder = pointerX - xMin;
+  const isCrossingLeftBorder = valueTextWidth / 2 > distanceToLeftBorder;
+  if (isCrossingLeftBorder) {
+    return valueTextWidth / 2 - distanceToLeftBorder - pointerWidth / 2;
+  }
+
+  const distanceToRightBorder = xMax - pointerX;
+  const isCrossingRightBorder = valueTextWidth / 2 > distanceToRightBorder;
+  if (isCrossingRightBorder) {
+    return distanceToRightBorder - valueTextWidth / 2 + pointerWidth / 2;
+  }
+
+  return 0;
 };

--- a/frontend/src/metabase/static-viz/components/ProgressBar/utils.ts
+++ b/frontend/src/metabase/static-viz/components/ProgressBar/utils.ts
@@ -1,0 +1,39 @@
+import Color from "color";
+import { ProgressBarData } from "./types";
+
+export const createPalette = (color: string) => ({
+  unachieved: color,
+  achieved: Color(color)
+    .darken(0.25)
+    .hex(),
+  exceeded: Color(color)
+    .darken(0.5)
+    .hex(),
+});
+
+export const getColors = (
+  { value, goal }: ProgressBarData,
+  palette: ReturnType<typeof createPalette>,
+) => {
+  const isExceeded = value > goal;
+
+  const backgroundBar = isExceeded ? palette.exceeded : palette.unachieved;
+  const foregroundBar = palette.achieved;
+  const pointer = isExceeded ? palette.exceeded : palette.achieved;
+
+  return {
+    backgroundBar,
+    foregroundBar,
+    pointer,
+  };
+};
+
+export const getBarText = ({ value, goal }: ProgressBarData) => {
+  if (value === goal) {
+    return "Goal met";
+  } else if (value > goal) {
+    return "Goal exceeded";
+  }
+
+  return null;
+};

--- a/frontend/src/metabase/static-viz/components/Text/Text.tsx
+++ b/frontend/src/metabase/static-viz/components/Text/Text.tsx
@@ -1,0 +1,6 @@
+import React from "react";
+import { Text as VText, TextProps } from "@visx/text";
+
+export const Text = (props: TextProps) => {
+  return <VText fontFamily="Lato" fontSize="13" fill="#4C5773" {...props} />;
+};

--- a/frontend/src/metabase/static-viz/components/Text/index.ts
+++ b/frontend/src/metabase/static-viz/components/Text/index.ts
@@ -1,0 +1,1 @@
+export * from "./Text";

--- a/frontend/src/metabase/static-viz/containers/StaticChart/StaticChart.jsx
+++ b/frontend/src/metabase/static-viz/containers/StaticChart/StaticChart.jsx
@@ -7,6 +7,7 @@ import CategoricalLineChart from "../../components/CategoricalLineChart";
 import TimeSeriesAreaChart from "../../components/TimeSeriesAreaChart";
 import TimeSeriesBarChart from "../../components/TimeSeriesBarChart";
 import TimeSeriesLineChart from "../../components/TimeSeriesLineChart";
+import ProgressBar from "../../components/ProgressBar";
 
 const propTypes = {
   type: PropTypes.oneOf([
@@ -17,6 +18,7 @@ const propTypes = {
     "timeseries/area",
     "timeseries/bar",
     "timeseries/line",
+    "progress",
   ]).isRequired,
   options: PropTypes.object.isRequired,
 };
@@ -37,6 +39,8 @@ const StaticChart = ({ type, options }) => {
       return <TimeSeriesBarChart {...options} />;
     case "timeseries/line":
       return <TimeSeriesLineChart {...options} />;
+    case "progress":
+      return <ProgressBar {...options} />;
   }
 };
 

--- a/frontend/src/metabase/static-viz/lib/text.ts
+++ b/frontend/src/metabase/static-viz/lib/text.ts
@@ -1,8 +1,8 @@
 const CHAR_WIDTH = 6;
 const CHAR_ELLIPSES = "…";
 
-export const measureText = (text: string) => {
-  return text.length * CHAR_WIDTH;
+export const measureText = (text: string, charWidth = CHAR_WIDTH) => {
+  return text.length * charWidth;
 };
 
 export const truncateText = (text: string, width: number) => {

--- a/frontend/src/metabase/static-viz/lib/text.ts
+++ b/frontend/src/metabase/static-viz/lib/text.ts
@@ -1,11 +1,11 @@
 const CHAR_WIDTH = 6;
 const CHAR_ELLIPSES = "…";
 
-export const measureText = text => {
+export const measureText = (text: string) => {
   return text.length * CHAR_WIDTH;
 };
 
-export const truncateText = (text, width) => {
+export const truncateText = (text: string, width: number) => {
   if (measureText(text) <= width) {
     return text;
   }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@snowplow/browser-tracker": "^3.1.6",
     "@visx/axis": "1.8.0",
+    "@visx/clip-path": "^2.1.0",
     "@visx/grid": "1.16.0",
     "@visx/group": "1.7.0",
     "@visx/scale": "1.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3273,6 +3273,14 @@
     classnames "^2.2.5"
     prop-types "^15.6.0"
 
+"@visx/clip-path@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@visx/clip-path/-/clip-path-2.1.0.tgz#5730ebda167493a56d033c454453900ed0b4904b"
+  integrity sha512-g8OC8M4H+AunfT2taKyy++X7muMrhlqITNDan25gVopGuHxydiDYatu4qdZIGbYjAoiI0KHEB07/HV8iePcTdQ==
+  dependencies:
+    "@types/react" "*"
+    prop-types "^15.5.10"
+
 "@visx/curve@1.7.0":
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/@visx/curve/-/curve-1.7.0.tgz#b8c8ae902de469ae43014c78ed9bfda8aed8137c"


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/18676

Add progress static viz renderer:
<img width="367" alt="Screen Shot 2021-11-08 at 02 09 26" src="https://user-images.githubusercontent.com/14301985/140663601-f14bcc48-5ca5-4c62-af02-73d5d60b7a74.png">

### How to verify
- Run Metabase locally and go to http://localhost:3000/_internal/static-viz
- Ensure the progress bar static visualization renders correctly

