### PR TITLE
Implement waterfall static visualization

### DIFF
--- a/frontend/src/metabase/internal/pages/StaticVizPage.jsx
+++ b/frontend/src/metabase/internal/pages/StaticVizPage.jsx
@@ -284,6 +284,60 @@ export default function StaticVizPage() {
             }}
           />
         </Box>
+        <Box>
+          <Subhead>Waterfall chart with timeseries data</Subhead>
+          <StaticChart
+            type="timeseries/waterfall"
+            options={{
+              data: [
+                ["2020-10-20", 20],
+                ["2020-10-21", 20],
+                ["2020-10-22", 100],
+                ["2020-10-23", -10],
+                ["2020-10-24", 20],
+                ["2020-10-25", -30],
+                ["2020-10-26", -10],
+                ["2020-10-27", 20],
+              ],
+              accessors: {
+                x: row => new Date(row[0]).valueOf(),
+                y: row => row[1],
+              },
+              labels: {
+                left: "Count",
+                bottom: "Created At",
+              },
+            }}
+          />
+        </Box>
+        <Box py={3}>
+          <Subhead>Waterfall chart with categorical data</Subhead>
+          <StaticChart
+            type="categorical/waterfall"
+            options={{
+              data: [
+                ["Stage 1", 800],
+                ["Stage 2", 400],
+                ["Stage 3", -300],
+                ["Stage 4", -100],
+                ["Stage 5", -50],
+                ["Stage 6", 200],
+                ["Stage 7", -100],
+                ["Stage 8", 300],
+                ["Stage 9", 100],
+                ["Stage 10", -300],
+              ],
+              accessors: {
+                x: row => row[0],
+                y: row => row[1],
+              },
+              labels: {
+                left: "Count",
+                bottom: "Created At",
+              },
+            }}
+          />
+        </Box>
       </Box>
     </Box>
   );

--- a/frontend/src/metabase/static-viz/components/CategoricalWaterfallChart/CategoricalWaterfallChart.jsx
+++ b/frontend/src/metabase/static-viz/components/CategoricalWaterfallChart/CategoricalWaterfallChart.jsx
@@ -1,0 +1,177 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { AxisBottom, AxisLeft } from "@visx/axis";
+import { GridRows } from "@visx/grid";
+import { scaleBand, scaleLinear } from "@visx/scale";
+import { Bar } from "@visx/shape";
+import { Group } from "@visx/group";
+import { Text } from "@visx/text";
+import { truncateText } from "metabase/static-viz/lib/text";
+import {
+  getLabelProps,
+  getXTickLabelProps,
+  getYTickLabelProps,
+  getYTickWidth,
+  getXTickWidth,
+  getXTickHeight,
+} from "metabase/static-viz/lib/axes";
+import { formatNumber } from "metabase/static-viz/lib/numbers";
+import {
+  calculateWaterfallDomain,
+  calculateWaterfallEntries,
+  getWaterfallEntryColor,
+} from "metabase/static-viz/lib/waterfall";
+
+const propTypes = {
+  data: PropTypes.array.isRequired,
+  accessors: PropTypes.shape({
+    x: PropTypes.func.isRequired,
+    y: PropTypes.func.isRequired,
+  }).isRequired,
+  settings: PropTypes.shape({
+    x: PropTypes.object,
+    y: PropTypes.object,
+    colors: PropTypes.object,
+  }),
+  labels: PropTypes.shape({
+    left: PropTypes.string,
+    bottom: PropTypes.string,
+  }),
+};
+
+const layout = {
+  width: 540,
+  height: 300,
+  margin: {
+    top: 10,
+    left: 55,
+    right: 40,
+    bottom: 40,
+  },
+  font: {
+    size: 11,
+    family: "Lato, sans-serif",
+  },
+  colors: {
+    brand: "#509ee3",
+    textLight: "#b8bbc3",
+    textMedium: "#949aab",
+    waterfallTotal: "#4C5773",
+    waterfallPositive: "#88BF4D",
+    waterfallNegative: "#EF8C8C",
+  },
+  numTicks: 5,
+  barPadding: 0.2,
+  labelFontWeight: 700,
+  labelPadding: 12,
+  strokeDasharray: "4",
+  maxTickWidth: 100,
+};
+
+const CategoricalWaterfallChart = ({ data, accessors, settings, labels }) => {
+  const entries = calculateWaterfallEntries(data, accessors);
+  const colors = settings?.colors;
+  const isVertical = entries.length > 10;
+  const xTickWidth = getXTickWidth(data, accessors, layout.maxTickWidth);
+  const xTickHeight = getXTickHeight(xTickWidth);
+  const yTickWidth = getYTickWidth(data, accessors, settings);
+  const xLabelOffset = xTickHeight + layout.labelPadding + layout.font.size;
+  const yLabelOffset = yTickWidth + layout.labelPadding;
+  const xMin = yLabelOffset + layout.font.size * 1.5;
+  const xMax = layout.width - layout.margin.right - layout.margin.left;
+  const yMin = isVertical ? xLabelOffset : layout.margin.bottom;
+  const yMax = layout.height - yMin - layout.margin.top;
+  const innerWidth = xMax - xMin;
+  const textBaseline = Math.floor(layout.font.size / 2);
+  const leftLabel = labels?.left;
+  const bottomLabel = !isVertical ? labels?.bottom : undefined;
+  const palette = { ...layout.colors, ...colors };
+
+  const xScale = scaleBand({
+    domain: entries.map(entry => entry.x),
+    range: [0, xMax],
+    padding: layout.barPadding,
+  });
+
+  const yScale = scaleLinear({
+    domain: calculateWaterfallDomain(entries),
+    range: [yMax, 0],
+  });
+
+  const getBarProps = entry => {
+    const width = xScale.bandwidth();
+
+    const height = Math.abs(yScale(entry.start) - yScale(entry.end));
+    const x = xScale(entry.x);
+    const y = yScale(Math.max(entry.start, entry.end));
+    const fill = getWaterfallEntryColor(entry, palette);
+
+    return { x, y, width, height, fill };
+  };
+
+  const getXTickProps = ({ x, y, formattedValue, ...props }) => {
+    const textWidth = isVertical ? xTickWidth : xScale.bandwidth();
+    const truncatedText = truncateText(formattedValue, textWidth);
+    const transform = isVertical
+      ? `rotate(45, ${x} ${y}) translate(${textBaseline} 0)`
+      : undefined;
+
+    return { ...props, x, y, transform, children: truncatedText };
+  };
+
+  return (
+    <svg width={layout.width} height={layout.height}>
+      <Group top={layout.margin.top} left={xMin}>
+        <GridRows
+          scale={yScale}
+          width={innerWidth}
+          strokeDasharray={layout.strokeDasharray}
+        />
+        {entries.map((entry, index) => (
+          <Bar key={index} {...getBarProps(entry)} />
+        ))}
+      </Group>
+      <AxisLeft
+        scale={yScale}
+        top={layout.margin.top}
+        left={xMin}
+        label={leftLabel}
+        labelOffset={yLabelOffset}
+        hideTicks
+        hideAxisLine
+        labelProps={getLabelProps(layout)}
+        tickFormat={value => formatNumber(value, settings?.y)}
+        tickLabelProps={() => getYTickLabelProps(layout)}
+      />
+
+      <AxisBottom
+        scale={xScale}
+        left={xMin}
+        top={yMax + layout.margin.top}
+        label={bottomLabel}
+        numTicks={entries.length}
+        stroke={palette.textLight}
+        tickStroke={palette.textLight}
+        labelProps={getLabelProps(layout)}
+        tickComponent={props => <Text {...getXTickProps(props)} />}
+        tickLabelProps={() => getXTickLabelProps(layout, isVertical)}
+      />
+      {/* <AxisBottom
+        scale={xScale}
+        left={xMin}
+        top={yMax + layout.margin.top}
+        label={bottomLabel}
+        numTicks={entries.length}
+        stroke={palette.textLight}
+        tickStroke={palette.textLight}
+        labelProps={getLabelProps(layout)}
+        tickComponent={props => <Text {...getXTickProps(props)} />}
+        tickLabelProps={() => getXTickLabelProps(layout)}
+      /> */}
+    </svg>
+  );
+};
+
+CategoricalWaterfallChart.propTypes = propTypes;
+
+export default CategoricalWaterfallChart;

--- a/frontend/src/metabase/static-viz/components/CategoricalWaterfallChart/CategoricalWaterfallChart.jsx
+++ b/frontend/src/metabase/static-viz/components/CategoricalWaterfallChart/CategoricalWaterfallChart.jsx
@@ -43,7 +43,7 @@ const layout = {
   width: 540,
   height: 300,
   margin: {
-    top: 10,
+    top: 0,
     left: 55,
     right: 40,
     bottom: 40,
@@ -113,7 +113,7 @@ const CategoricalWaterfallChart = ({ data, accessors, settings, labels }) => {
     const textWidth = isVertical ? xTickWidth : xScale.bandwidth();
     const truncatedText = truncateText(formattedValue, textWidth);
     const transform = isVertical
-      ? `rotate(45, ${x} ${y}) translate(${textBaseline} 0)`
+      ? `rotate(45, ${x} ${y}) translate(-${textBaseline} 0)`
       : undefined;
 
     return { ...props, x, y, transform, children: truncatedText };
@@ -156,18 +156,6 @@ const CategoricalWaterfallChart = ({ data, accessors, settings, labels }) => {
         tickComponent={props => <Text {...getXTickProps(props)} />}
         tickLabelProps={() => getXTickLabelProps(layout, isVertical)}
       />
-      {/* <AxisBottom
-        scale={xScale}
-        left={xMin}
-        top={yMax + layout.margin.top}
-        label={bottomLabel}
-        numTicks={entries.length}
-        stroke={palette.textLight}
-        tickStroke={palette.textLight}
-        labelProps={getLabelProps(layout)}
-        tickComponent={props => <Text {...getXTickProps(props)} />}
-        tickLabelProps={() => getXTickLabelProps(layout)}
-      /> */}
     </svg>
   );
 };

--- a/frontend/src/metabase/static-viz/components/CategoricalWaterfallChart/index.js
+++ b/frontend/src/metabase/static-viz/components/CategoricalWaterfallChart/index.js
@@ -1,0 +1,1 @@
+export { default } from "./CategoricalWaterfallChart";

--- a/frontend/src/metabase/static-viz/components/TimeSeriesWaterfallChart/TimeSeriesWaterfallChart.jsx
+++ b/frontend/src/metabase/static-viz/components/TimeSeriesWaterfallChart/TimeSeriesWaterfallChart.jsx
@@ -1,0 +1,145 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { AxisBottom, AxisLeft } from "@visx/axis";
+import { GridRows } from "@visx/grid";
+import { scaleBand, scaleLinear } from "@visx/scale";
+import { Bar } from "@visx/shape";
+import { Group } from "@visx/group";
+import {
+  getLabelProps,
+  getXTickLabelProps,
+  getYTickLabelProps,
+  getYTickWidth,
+} from "metabase/static-viz/lib/axes";
+import { formatNumber } from "metabase/static-viz/lib/numbers";
+import {
+  calculateWaterfallDomain,
+  calculateWaterfallEntries,
+  formatTimescaleWaterfallTick,
+  getWaterfallEntryColor,
+} from "metabase/static-viz/lib/waterfall";
+
+const propTypes = {
+  data: PropTypes.array.isRequired,
+  accessors: PropTypes.shape({
+    x: PropTypes.func.isRequired,
+    y: PropTypes.func.isRequired,
+  }).isRequired,
+  settings: PropTypes.shape({
+    x: PropTypes.object,
+    y: PropTypes.object,
+    colors: PropTypes.object,
+  }),
+  labels: PropTypes.shape({
+    left: PropTypes.string,
+    bottom: PropTypes.string,
+  }),
+};
+
+const layout = {
+  width: 540,
+  height: 300,
+  margin: {
+    top: 0,
+    left: 55,
+    right: 40,
+    bottom: 40,
+  },
+  font: {
+    size: 11,
+    family: "Lato, sans-serif",
+  },
+  colors: {
+    brand: "#509ee3",
+    textLight: "#b8bbc3",
+    textMedium: "#949aab",
+    waterfallTotal: "#4C5773",
+    waterfallPositive: "#88BF4D",
+    waterfallNegative: "#EF8C8C",
+  },
+  numTicks: 5,
+  barPadding: 0.2,
+  labelFontWeight: 700,
+  labelPadding: 12,
+  strokeDasharray: "4",
+};
+
+const TimeSeriesWaterfallChart = ({ data, accessors, settings, labels }) => {
+  const colors = settings?.colors;
+  const yTickWidth = getYTickWidth(data, accessors, settings);
+  const yLabelOffset = yTickWidth + layout.labelPadding;
+  const xMin = yLabelOffset + layout.font.size * 1.5;
+  const xMax = layout.width - layout.margin.right - layout.margin.left;
+  const yMax = layout.height - layout.margin.bottom;
+  const innerWidth = xMax - xMin;
+  const leftLabel = labels?.left;
+  const bottomLabel = labels?.bottom;
+  const palette = { ...layout.colors, ...colors };
+
+  const entries = calculateWaterfallEntries(data, accessors);
+
+  const xScale = scaleBand({
+    domain: entries.map(entry => entry.x),
+    range: [0, xMax],
+    padding: layout.barPadding,
+  });
+
+  const yScale = scaleLinear({
+    domain: calculateWaterfallDomain(entries),
+    range: [yMax, 0],
+  });
+
+  const getBarProps = entry => {
+    const width = xScale.bandwidth();
+
+    const height = Math.abs(yScale(entry.start) - yScale(entry.end));
+    const x = xScale(entry.x);
+    const y = yScale(Math.max(entry.start, entry.end));
+    const fill = getWaterfallEntryColor(entry, palette);
+
+    return { x, y, width, height, fill };
+  };
+
+  return (
+    <svg width={layout.width} height={layout.height}>
+      <Group top={layout.margin.top} left={xMin}>
+        <GridRows
+          scale={yScale}
+          width={innerWidth}
+          strokeDasharray={layout.strokeDasharray}
+        />
+        {entries.map((entry, index) => (
+          <Bar key={index} {...getBarProps(entry)} />
+        ))}
+      </Group>
+      <AxisLeft
+        scale={yScale}
+        top={layout.margin.top}
+        left={xMin}
+        label={leftLabel}
+        labelOffset={yLabelOffset}
+        hideTicks
+        hideAxisLine
+        labelProps={getLabelProps(layout)}
+        tickFormat={value => formatNumber(value, settings?.y)}
+        tickLabelProps={() => getYTickLabelProps(layout)}
+      />
+      <AxisBottom
+        scale={xScale}
+        left={xMin}
+        top={yMax + layout.margin.top}
+        label={bottomLabel}
+        numTicks={layout.numTicks}
+        stroke={palette.textLight}
+        tickStroke={palette.textLight}
+        labelProps={getLabelProps(layout)}
+        tickFormat={value => formatTimescaleWaterfallTick(value, settings)}
+        tickLabelProps={() => getXTickLabelProps(layout)}
+      />
+    </svg>
+  );
+};
+
+TimeSeriesWaterfallChart.propTypes = propTypes;
+
+export default TimeSeriesWaterfallChart;

--- a/frontend/src/metabase/static-viz/components/TimeSeriesWaterfallChart/index.js
+++ b/frontend/src/metabase/static-viz/components/TimeSeriesWaterfallChart/index.js
@@ -1,0 +1,1 @@
+export { default } from "./TimeSeriesWaterfallChart";

--- a/frontend/src/metabase/static-viz/containers/StaticChart/StaticChart.jsx
+++ b/frontend/src/metabase/static-viz/containers/StaticChart/StaticChart.jsx
@@ -4,10 +4,12 @@ import CategoricalAreaChart from "../../components/CategoricalAreaChart";
 import CategoricalBarChart from "../../components/CategoricalBarChart";
 import CategoricalDonutChart from "../../components/CategoricalDonutChart";
 import CategoricalLineChart from "../../components/CategoricalLineChart";
+import CategoricalWaterfallChart from "../../components/CategoricalWaterfallChart";
 import TimeSeriesAreaChart from "../../components/TimeSeriesAreaChart";
 import TimeSeriesBarChart from "../../components/TimeSeriesBarChart";
 import TimeSeriesLineChart from "../../components/TimeSeriesLineChart";
 import ProgressBar from "../../components/ProgressBar";
+import TimeSeriesWaterfallChart from "../../components/TimeSeriesWaterfallChart";
 
 const propTypes = {
   type: PropTypes.oneOf([
@@ -15,9 +17,11 @@ const propTypes = {
     "categorical/bar",
     "categorical/donut",
     "categorical/line",
+    "categorical/waterfall",
     "timeseries/area",
     "timeseries/bar",
     "timeseries/line",
+    "timeseries/waterfall",
     "progress",
   ]).isRequired,
   options: PropTypes.object.isRequired,
@@ -33,12 +37,16 @@ const StaticChart = ({ type, options }) => {
       return <CategoricalDonutChart {...options} />;
     case "categorical/line":
       return <CategoricalLineChart {...options} />;
+    case "categorical/waterfall":
+      return <CategoricalWaterfallChart {...options} />;
     case "timeseries/area":
       return <TimeSeriesAreaChart {...options} />;
     case "timeseries/bar":
       return <TimeSeriesBarChart {...options} />;
     case "timeseries/line":
       return <TimeSeriesLineChart {...options} />;
+    case "timeseries/waterfall":
+      return <TimeSeriesWaterfallChart {...options} />;
     case "progress":
       return <ProgressBar {...options} />;
   }

--- a/frontend/src/metabase/static-viz/lib/axes.js
+++ b/frontend/src/metabase/static-viz/lib/axes.js
@@ -35,6 +35,7 @@ export const getYTickLabelProps = layout => ({
   fontFamily: layout.font.family,
   fill: layout.colors.textMedium,
   textAnchor: "end",
+  dy: "0.35em",
 });
 
 export const getLabelProps = layout => ({

--- a/frontend/src/metabase/static-viz/lib/axes.js
+++ b/frontend/src/metabase/static-viz/lib/axes.js
@@ -35,7 +35,6 @@ export const getYTickLabelProps = layout => ({
   fontFamily: layout.font.family,
   fill: layout.colors.textMedium,
   textAnchor: "end",
-  dy: "0.35em",
 });
 
 export const getLabelProps = layout => ({

--- a/frontend/src/metabase/static-viz/lib/waterfall.js
+++ b/frontend/src/metabase/static-viz/lib/waterfall.js
@@ -1,0 +1,49 @@
+import d3 from "d3";
+import { formatDate } from "./dates";
+
+const WATERFALL_TOTAL = "Total";
+
+export const calculateWaterfallEntries = (data, accessors) => {
+  let total = 0;
+
+  const entries = data.map(datum => {
+    const xValue = accessors.x(datum);
+    const yValue = accessors.y(datum);
+
+    const prevTotal = total;
+    total += yValue;
+
+    return {
+      x: xValue,
+      y: yValue,
+      start: prevTotal,
+      end: total,
+    };
+  });
+
+  entries.push({
+    x: WATERFALL_TOTAL,
+    y: total,
+    start: 0,
+    end: total,
+    isTotal: true,
+  });
+
+  return entries;
+};
+
+export const formatTimescaleWaterfallTick = (value, settings) =>
+  value === WATERFALL_TOTAL ? WATERFALL_TOTAL : formatDate(value, settings?.x);
+
+export const calculateWaterfallDomain = entries => {
+  const values = entries.flatMap(entry => [entry.start, entry.end]);
+  return d3.extent(values);
+};
+
+export const getWaterfallEntryColor = (entry, palette) => {
+  if (entry.isTotal) {
+    return palette.waterfallTotal;
+  }
+
+  return entry.y > 0 ? palette.waterfallPositive : palette.waterfallNegative;
+};

--- a/frontend/src/metabase/static-viz/lib/waterfall.unit.spec.js
+++ b/frontend/src/metabase/static-viz/lib/waterfall.unit.spec.js
@@ -1,0 +1,74 @@
+import { calculateWaterfallEntries } from "./waterfall";
+
+const accessors = {
+  x: row => row[0],
+  y: row => row[1],
+};
+
+describe("calculateWaterfallEntries", () => {
+  it("calculates waterfall entries with positive total", () => {
+    const data = [["1", 100], ["2", -50], ["3", 10]];
+    const entries = calculateWaterfallEntries(data, accessors);
+
+    expect(entries).toStrictEqual([
+      {
+        start: 0,
+        end: 100,
+        x: "1",
+        y: 100,
+      },
+      {
+        start: 100,
+        end: 50,
+        x: "2",
+        y: -50,
+      },
+      {
+        start: 50,
+        end: 60,
+        x: "3",
+        y: 10,
+      },
+      {
+        start: 0,
+        end: 60,
+        isTotal: true,
+        x: "Total",
+        y: 60,
+      },
+    ]);
+  });
+
+  it("calculates waterfall entries with negative total", () => {
+    const data = [["1", 100], ["2", -200], ["3", 50]];
+    const entries = calculateWaterfallEntries(data, accessors);
+
+    expect(entries).toStrictEqual([
+      {
+        start: 0,
+        end: 100,
+        x: "1",
+        y: 100,
+      },
+      {
+        start: 100,
+        end: -100,
+        x: "2",
+        y: -200,
+      },
+      {
+        start: -100,
+        end: -50,
+        x: "3",
+        y: 50,
+      },
+      {
+        start: 0,
+        end: -50,
+        isTotal: true,
+        x: "Total",
+        y: -50,
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/18676

Add waterfall static visualization renderers. The charts created following an already defined approach which results in some code duplication and limitations. It will be addressed further in static viz development.

<img width="607" alt="Screen Shot 2021-11-09 at 02 21 39" src="https://user-images.githubusercontent.com/14301985/140828476-ac279c17-100f-4be1-abfe-f730ccaaaa57.png">

### How to verify
- Run Metabase locally and go to http://localhost:3000/_internal/static-viz
- Ensure the waterfall static visualizations render charts correctly
