### PR TITLE
Track tracking permission changes

### DIFF
--- a/frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx
+++ b/frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx
@@ -79,6 +79,15 @@ export default class SettingsEditorApp extends Component {
     // TODO: mutation bad!
     setting.value = newValue;
     try {
+      if (setting.onBeforeChanged) {
+        await setting.onBeforeChanged(
+          oldValue,
+          newValue,
+          settingValues,
+          this.handleChangeSetting,
+        );
+      }
+
       await updateSetting(setting);
 
       if (setting.onChanged) {

--- a/frontend/src/metabase/admin/settings/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors.js
@@ -89,6 +89,9 @@ const SECTIONS = updateSectionsWithPlugins({
         onChanged: (oldValue, newValue) => {
           trackTrackingPermissionChanged(newValue);
         },
+        onBeforeChanged: (oldValue, newValue) => {
+          trackTrackingPermissionChanged(newValue);
+        },
       },
       {
         key: "humanization-strategy",

--- a/frontend/src/metabase/admin/settings/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors.js
@@ -19,6 +19,7 @@ import SettingsUpdatesForm from "./components/SettingsUpdatesForm/SettingsUpdate
 import SettingsEmailForm from "./components/SettingsEmailForm";
 import SettingsSetupList from "./components/SettingsSetupList";
 import SettingsSlackForm from "./components/SettingsSlackForm";
+import { trackTrackingPermissionChanged } from "./tracking";
 
 import { UtilApi } from "metabase/services";
 import { PLUGIN_ADMIN_SETTINGS_UPDATES } from "metabase/plugins";
@@ -85,6 +86,9 @@ const SECTIONS = updateSectionsWithPlugins({
         key: "anon-tracking-enabled",
         display_name: t`Anonymous Tracking`,
         type: "boolean",
+        onChanged: (oldValue, newValue) => {
+          trackTrackingPermissionChanged(newValue);
+        },
       },
       {
         key: "humanization-strategy",

--- a/frontend/src/metabase/admin/settings/tracking.js
+++ b/frontend/src/metabase/admin/settings/tracking.js
@@ -1,0 +1,10 @@
+import { trackSchemaEvent } from "metabase/lib/analytics";
+
+export const trackTrackingPermissionChanged = isEnabled => {
+  trackSchemaEvent("settings", "1-0-1", {
+    event: isEnabled
+      ? "tracking_permission_enabled"
+      : "tracking_permission_disabled",
+    source: "admin",
+  });
+};

--- a/frontend/src/metabase/env.js
+++ b/frontend/src/metabase/env.js
@@ -1,4 +1,4 @@
 export const isCypressActive = !!window.Cypress;
 
 // eslint-disable-next-line no-undef
-export const isProduction = process.env.WEBPACK_BUNDLE === "production";
+export const isProduction = true; // process.env.WEBPACK_BUNDLE === "production";

--- a/frontend/src/metabase/env.js
+++ b/frontend/src/metabase/env.js
@@ -1,4 +1,4 @@
 export const isCypressActive = !!window.Cypress;
 
 // eslint-disable-next-line no-undef
-export const isProduction = true; // process.env.WEBPACK_BUNDLE === "production";
+export const isProduction = process.env.WEBPACK_BUNDLE === "production";

--- a/frontend/src/metabase/setup/components/PreferencesStep.jsx
+++ b/frontend/src/metabase/setup/components/PreferencesStep.jsx
@@ -1,16 +1,16 @@
 /* eslint "react/prop-types": "warn" */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import { t, jt } from "ttag";
+import { jt, t } from "ttag";
 import { Box } from "grid-styled";
 import * as MetabaseAnalytics from "metabase/lib/analytics";
 import MetabaseSettings from "metabase/lib/settings";
 import Toggle from "metabase/components/Toggle";
+import ExternalLink from "metabase/components/ExternalLink";
 
 import StepTitle from "./StepTitle";
 import CollapsedStep from "./CollapsedStep";
-
-import ExternalLink from "metabase/components/ExternalLink";
+import { trackTrackingPermissionChanged } from "../tracking";
 
 export default class PreferencesStep extends Component {
   state = { errorMessage: null };
@@ -28,8 +28,8 @@ export default class PreferencesStep extends Component {
 
   toggleTracking() {
     const { allowTracking } = this.props;
-
     this.props.setAllowTracking(!allowTracking);
+    trackTrackingPermissionChanged(allowTracking);
   }
 
   async formSubmitted(e) {

--- a/frontend/src/metabase/setup/components/PreferencesStep.jsx
+++ b/frontend/src/metabase/setup/components/PreferencesStep.jsx
@@ -28,8 +28,9 @@ export default class PreferencesStep extends Component {
 
   toggleTracking() {
     const { allowTracking } = this.props;
-    this.props.setAllowTracking(!allowTracking);
-    trackTrackingPermissionChanged(allowTracking);
+    const newAllowTracking = !allowTracking;
+    this.props.setAllowTracking(newAllowTracking);
+    trackTrackingPermissionChanged(newAllowTracking);
   }
 
   async formSubmitted(e) {

--- a/frontend/src/metabase/setup/tracking.js
+++ b/frontend/src/metabase/setup/tracking.js
@@ -26,9 +26,9 @@ export const trackAddDataLaterClicked = database => {
   });
 };
 
-export const trackTrackingPermissionChanged = allowTracking => {
+export const trackTrackingPermissionChanged = isEnabled => {
   trackSchemaEvent("settings", "1-0-1", {
-    event: allowTracking
+    event: isEnabled
       ? "tracking_permission_enabled"
       : "tracking_permission_disabled",
     source: "setup",

--- a/frontend/src/metabase/setup/tracking.js
+++ b/frontend/src/metabase/setup/tracking.js
@@ -25,3 +25,12 @@ export const trackAddDataLaterClicked = database => {
     source: database ? "post_selection" : "pre_selection",
   });
 };
+
+export const trackTrackingPermissionChanged = allowTracking => {
+  trackSchemaEvent("settings", "1-0-1", {
+    event: allowTracking
+      ? "tracking_permission_enabled"
+      : "tracking_permission_disabled",
+    source: "setup",
+  });
+};


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/18291

How to test:

Setup:
- Run a fresh Metabase instance
- During the setup, toggle anonymous tracking
- Check that both `tracking_permission_enabled` and `tracking_permission_disabled` fire correctly

Admin:
- After the setup, go to Admin -> General
- Toggle anonymous tracking
- Check that both `tracking_permission_enabled` and `tracking_permission_disabled` fire correctly