### PR TITLE
Catch all exceptions when parsing strings as datetime values in XLSX exports

### DIFF
--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -394,7 +394,7 @@
             parsed-value (if (and *parse-temporal-string-values* (string? value))
                            (try (u.date/parse value)
                                 ;; Fallback to plain string value if it couldn't be parsed
-                                (catch java.time.format.DateTimeParseException _ value))
+                                (catch Exception _ value))
                            scaled-val)]
         (set-cell! (.createCell ^SXSSFRow row ^Integer index) parsed-value id-or-name)))
     row))

--- a/test/metabase/query_processor/streaming/xlsx_test.clj
+++ b/test/metabase/query_processor/streaming/xlsx_test.clj
@@ -419,7 +419,13 @@
                (second (xlsx-export [{:id 0, :name "Col"}] {} [[#t "10:12:06Z-03:21"]])))))
       (testing "ZonedDateTime"
         (is (= [#inst "2020-03-28T10:12:06.000-00:00"]
-               (second (xlsx-export [{:id 0, :name "Col"}] {} [[#t "2020-03-28T10:12:06Z"]]))))))))
+               (second (xlsx-export [{:id 0, :name "Col"}] {} [[#t "2020-03-28T10:12:06Z"]])))))))
+  (testing "Strings representing country names/codes don't error when *parse-temporal-string-values* is true (#18724)"
+    (binding [xlsx/*parse-temporal-string-values* true]
+      (is (= ["GB"]
+             (second (xlsx-export [{:id 0, :name "Col"}] {} [["GB"]]))))
+      (is (= ["Portugal"]
+             (second (xlsx-export [{:id 0, :name "Col"}] {} [["Portugal"]])))))))
 
 (defrecord ^:private SampleNastyClass [^String v])
 


### PR DESCRIPTION
In XLSX exports for dashboard subscription attachments, we attempt to parse strings as datetime values so that we can apply formatting correctly, since they would have been previously formatted as strings in the `format-rows` middleware. If this parsing fails we assume that the string is not a datetime value and use it as-is.

I had wrapped the parsing call in a try/catch which expects a `DateTimeParseException` which works in almost all cases. However, strings representing country names or codes don't actually error when passed to the underlying `DateTimeFormatter`. Instead they apparently return a valid `java.time.format.Parsed` object, which then causes a separate exception (not a `DateTimeParseException`) to be thrown in the surrounding wrapper code, which was not being caught.

Fixed this by just catching the generic `Exception` here and adding a test case.

Resolves #18724