### PR TITLE
mark dataset queries in the qp

### DIFF
--- a/src/metabase/query_processor/middleware/fetch_source_query.clj
+++ b/src/metabase/query_processor/middleware/fetch_source_query.clj
@@ -268,6 +268,10 @@
   (fn [query rff context]
     (let [{:keys [query card-id]} (resolve-card-id-source-tables* query)]
       (if card-id
-        (binding [qp.perms/*card-id* (or card-id qp.perms/*card-id*)]
-          (qp query rff context))
+        (let [dataset? (db/select-one-field :dataset Card :id card-id)]
+          (binding [qp.perms/*card-id* (or card-id qp.perms/*card-id*)]
+            (qp query
+                (fn [metadata]
+                  (rff (cond-> metadata dataset? (assoc :dataset dataset?))))
+                context)))
         (qp query rff context)))))


### PR DESCRIPTION
Mark queries based on datasets in the qp.

We only want to mark them when the source query is itself a dataset, and not when there is a dataset at any arbitrary depth in the query.

Lots of unchanged noise removed from the following diff

```javascript
{
  "data": {
    "rows": [...],
    "cols": [...],
    ...
    "dataset": true, // new annotation in the data metadata
    "rows_truncated": 2000,
    "insights": null
  },
  "json_query": {
    "database": 1,
    "query": {
      "source-table": "card__176"  // based on a query on a dataset
    },
    "type": "query",
    "middleware": {
      "js-int-to-string?": true,
      "add-default-userland-constraints?": true
    }
  },
  "status": "completed",
  "context": "ad-hoc",
  "row_count": 2000,
  "running_time": 217
}

```