### PR TITLE
Update question header breadcrumbs

### DIFF
--- a/frontend/src/metabase/components/Badge.jsx
+++ b/frontend/src/metabase/components/Badge.jsx
@@ -13,6 +13,7 @@ const iconProp = PropTypes.oneOfType([
 const propTypes = {
   to: PropTypes.string,
   icon: iconProp,
+  inactiveColor: PropTypes.string,
   activeColor: PropTypes.string,
   onClick: PropTypes.func,
   children: PropTypes.node,
@@ -31,9 +32,19 @@ function getIconProps(iconProp) {
   return props;
 }
 
-function Badge({ icon, activeColor = "brand", children, ...props }) {
+function Badge({
+  icon,
+  inactiveColor = "text-medium",
+  activeColor = "brand",
+  children,
+  ...props
+}) {
   return (
-    <MaybeLink activeColor={activeColor} {...props}>
+    <MaybeLink
+      inactiveColor={inactiveColor}
+      activeColor={activeColor}
+      {...props}
+    >
       {icon && <BadgeIcon {...getIconProps(icon)} hasMargin={!!children} />}
       {children && <span className="text-wrap">{children}</span>}
     </MaybeLink>

--- a/frontend/src/metabase/components/Badge.jsx
+++ b/frontend/src/metabase/components/Badge.jsx
@@ -5,9 +5,14 @@ import { iconPropTypes } from "metabase/components/Icon";
 
 import { BadgeIcon, MaybeLink } from "./Badge.styled";
 
+const iconProp = PropTypes.oneOfType([
+  PropTypes.string,
+  PropTypes.shape(iconPropTypes),
+]);
+
 const propTypes = {
   to: PropTypes.string,
-  icon: PropTypes.shape(iconPropTypes),
+  icon: iconProp,
   activeColor: PropTypes.string,
   onClick: PropTypes.func,
   children: PropTypes.node,
@@ -15,16 +20,21 @@ const propTypes = {
 
 const DEFAULT_ICON_SIZE = 12;
 
-function Badge({ icon, activeColor = "brand", children, ...props }) {
-  const extraIconProps = {};
-  if (icon && !icon.size && !icon.width && !icon.height) {
-    extraIconProps.size = DEFAULT_ICON_SIZE;
+function getIconProps(iconProp) {
+  if (!iconProp) {
+    return;
   }
+  const props = typeof iconProp === "string" ? { name: iconProp } : iconProp;
+  if (!props.size && !props.width && !props.height) {
+    props.size = DEFAULT_ICON_SIZE;
+  }
+  return props;
+}
+
+function Badge({ icon, activeColor = "brand", children, ...props }) {
   return (
     <MaybeLink activeColor={activeColor} {...props}>
-      {icon && (
-        <BadgeIcon {...icon} {...extraIconProps} hasMargin={!!children} />
-      )}
+      {icon && <BadgeIcon {...getIconProps(icon)} hasMargin={!!children} />}
       {children && <span className="text-wrap">{children}</span>}
     </MaybeLink>
   );

--- a/frontend/src/metabase/components/Badge.styled.jsx
+++ b/frontend/src/metabase/components/Badge.styled.jsx
@@ -25,7 +25,7 @@ export const MaybeLink = styled(RawMaybeLink)`
   align-items: center;
   font-size: 0.875em;
   font-weight: bold;
-  color: ${color("text-medium")};
+  color: ${props => color(props.inactiveColor)};
 
   :hover {
     ${props => (props.to || props.onClick) && hoverStyle}

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
@@ -85,7 +85,7 @@ export default class ExpressionEditorSuggestions extends React.Component {
         }}
         sizeToFit
       >
-        <UlStyled>
+        <UlStyled data-testid="expression-suggestions-list">
           {suggestions.map((suggestion, i) => {
             const shouldRenderSectionTitle =
               i === 0 || suggestion.type !== suggestions[i - 1].type;

--- a/frontend/src/metabase/query_builder/components/view/HeaderBreadcrumbs/HeaderBreadcrumbs.jsx
+++ b/frontend/src/metabase/query_builder/components/view/HeaderBreadcrumbs/HeaderBreadcrumbs.jsx
@@ -1,12 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import {
-  Container,
-  Divider,
-  TitleOrLink,
-  SubHeadContainer,
-  SubHeadBadge,
-} from "./HeaderBreadcrumbs.styled";
+import { Container, Divider, HeaderBadge } from "./HeaderBreadcrumbs.styled";
 
 const crumbShape = PropTypes.shape({
   name: PropTypes.string.isRequired,
@@ -15,36 +9,27 @@ const crumbShape = PropTypes.shape({
 });
 
 HeadBreadcrumbs.propTypes = {
+  variant: PropTypes.oneOf(["head", "subhead"]),
   parts: PropTypes.arrayOf(crumbShape).isRequired,
 };
 
-export function HeadBreadcrumbs({ parts, ...props }) {
+export function HeadBreadcrumbs({ variant = "head", parts, ...props }) {
   return (
-    <Container {...props}>
-      {parts.map(({ name, href }, index) => (
-        <React.Fragment key={index}>
-          <TitleOrLink to={href}>{name}</TitleOrLink>
-          {index < parts.length - 1 && <Divider />}
-        </React.Fragment>
-      ))}
+    <Container {...props} variant={variant}>
+      {parts.map((part, index) => {
+        const { name, icon, href } = part;
+        const isLast = index === parts.length - 1;
+        const inactiveColor =
+          isLast && variant === "head" ? "text-dark" : "text-light";
+        return (
+          <React.Fragment key={index}>
+            <HeaderBadge to={href} icon={icon} inactiveColor={inactiveColor}>
+              {name}
+            </HeaderBadge>
+            {!isLast && <Divider />}
+          </React.Fragment>
+        );
+      })}
     </Container>
-  );
-}
-
-SubHeadBreadcrumbs.propTypes = {
-  parts: PropTypes.arrayOf(crumbShape).isRequired,
-};
-
-export function SubHeadBreadcrumbs({ parts, ...props }) {
-  return (
-    <span {...props}>
-      <SubHeadContainer>
-        {parts.map(({ name, icon, href }, index) => (
-          <SubHeadBadge key={index} icon={{ name: icon }} to={href}>
-            {name}
-          </SubHeadBadge>
-        ))}
-      </SubHeadContainer>
-    </span>
   );
 }

--- a/frontend/src/metabase/query_builder/components/view/HeaderBreadcrumbs/HeaderBreadcrumbs.jsx
+++ b/frontend/src/metabase/query_builder/components/view/HeaderBreadcrumbs/HeaderBreadcrumbs.jsx
@@ -1,0 +1,50 @@
+import React from "react";
+import PropTypes from "prop-types";
+import {
+  Container,
+  Divider,
+  TitleOrLink,
+  SubHeadContainer,
+  SubHeadBadge,
+} from "./HeaderBreadcrumbs.styled";
+
+const crumbShape = PropTypes.shape({
+  name: PropTypes.string.isRequired,
+  icon: PropTypes.string,
+  href: PropTypes.string,
+});
+
+HeadBreadcrumbs.propTypes = {
+  parts: PropTypes.arrayOf(crumbShape).isRequired,
+};
+
+export function HeadBreadcrumbs({ parts, ...props }) {
+  return (
+    <Container {...props}>
+      {parts.map(({ name, href }, index) => (
+        <React.Fragment key={index}>
+          <TitleOrLink to={href}>{name}</TitleOrLink>
+          {index < parts.length - 1 && <Divider />}
+        </React.Fragment>
+      ))}
+    </Container>
+  );
+}
+
+SubHeadBreadcrumbs.propTypes = {
+  parts: PropTypes.arrayOf(crumbShape).isRequired,
+};
+
+export function SubHeadBreadcrumbs({ parts, ...props }) {
+  return (
+    <span {...props}>
+      <SubHeadContainer>
+        {parts.map(({ name, icon, href }, index) => (
+          <SubHeadBadge key={index} icon={{ name: icon }} to={href}>
+            {name}
+          </SubHeadBadge>
+        ))}
+      </SubHeadContainer>
+    </span>
+  );
+}

--- a/frontend/src/metabase/query_builder/components/view/HeaderBreadcrumbs/HeaderBreadcrumbs.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/view/HeaderBreadcrumbs/HeaderBreadcrumbs.styled.jsx
@@ -1,41 +1,37 @@
 import React from "react";
-import PropTypes from "prop-types";
-import styled from "styled-components";
-import Badge, { MaybeLink } from "metabase/components/Badge";
+import styled, { css } from "styled-components";
+import Badge from "metabase/components/Badge";
 import { color } from "metabase/lib/colors";
 
 export const Container = styled.span`
   display: flex;
   align-items: center;
   flex-wrap: wrap;
+
+  ${props =>
+    props.variant === "head" &&
+    css`
+      font-size: 1.25rem;
+    `}
 `;
 
-export const SubHeadContainer = styled(Container)`
-  margin-bottom: -0.5rem;
-`;
-
-export const TitleOrLink = styled(MaybeLink)`
-  display: flex;
-  align-items: center;
-  color: ${props => color(props.to ? "text-medium" : "text-dark")};
+export const HeaderBadge = styled(Badge)`
+  .Icon {
+    width: 1em;
+    height: 1em;
+    margin-right: 0.5em;
+  }
 `;
 
 const DividerSpan = styled.span`
   color: ${color("text-light")};
   font-size: 0.8em;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
+  font-weight: bold;
+  padding-left: 0.5em;
+  padding-right: 0.5em;
+  user-select: none;
 `;
 
-export const SubHeadBadge = styled(Badge)`
-  margin-right: 1rem;
-  margin-bottom: 0.5rem;
-`;
-
-Divider.propTypes = {
-  children: PropTypes.string,
-};
-
-export function Divider({ children = "•" }) {
-  return <DividerSpan>{children}</DividerSpan>;
+export function Divider() {
+  return <DividerSpan>/</DividerSpan>;
 }

--- a/frontend/src/metabase/query_builder/components/view/HeaderBreadcrumbs/HeaderBreadcrumbs.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/view/HeaderBreadcrumbs/HeaderBreadcrumbs.styled.jsx
@@ -1,0 +1,41 @@
+import React from "react";
+import PropTypes from "prop-types";
+import styled from "styled-components";
+import Badge, { MaybeLink } from "metabase/components/Badge";
+import { color } from "metabase/lib/colors";
+
+export const Container = styled.span`
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+`;
+
+export const SubHeadContainer = styled(Container)`
+  margin-bottom: -0.5rem;
+`;
+
+export const TitleOrLink = styled(MaybeLink)`
+  display: flex;
+  align-items: center;
+  color: ${props => color(props.to ? "text-medium" : "text-dark")};
+`;
+
+const DividerSpan = styled.span`
+  color: ${color("text-light")};
+  font-size: 0.8em;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+`;
+
+export const SubHeadBadge = styled(Badge)`
+  margin-right: 1rem;
+  margin-bottom: 0.5rem;
+`;
+
+Divider.propTypes = {
+  children: PropTypes.string,
+};
+
+export function Divider({ children = "•" }) {
+  return <DividerSpan>{children}</DividerSpan>;
+}

--- a/frontend/src/metabase/query_builder/components/view/HeaderBreadcrumbs/index.js
+++ b/frontend/src/metabase/query_builder/components/view/HeaderBreadcrumbs/index.js
@@ -1,0 +1,1 @@
+export * from "./HeaderBreadcrumbs";

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
@@ -6,8 +6,19 @@ import { browseDatabase, browseSchema } from "metabase/lib/urls";
 
 import { HeadBreadcrumbs, SubHeadBreadcrumbs } from "./HeaderBreadcrumbs";
 
-const QuestionDataSource = ({ question, subHead, noLink, ...props }) => {
-  const parts = getDataSourceParts({ question, subHead, noLink });
+const QuestionDataSource = ({
+  question,
+  subHead,
+  noLink,
+  isObjectDetail,
+  ...props
+}) => {
+  const parts = getDataSourceParts({
+    question,
+    subHead,
+    noLink,
+    isObjectDetail,
+  });
   return subHead ? (
     <SubHeadBreadcrumbs parts={parts} {...props} />
   ) : (

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
@@ -1,11 +1,10 @@
 /* eslint-disable react/prop-types */
 import React from "react";
-import cx from "classnames";
-
-import Badge, { MaybeLink } from "metabase/components/Badge";
 
 import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
 import { browseDatabase, browseSchema } from "metabase/lib/urls";
+
+import { HeadBreadcrumbs, SubHeadBreadcrumbs } from "./HeaderBreadcrumbs";
 
 const QuestionDataSource = ({ question, subHead, noLink, ...props }) => {
   const parts = getDataSourceParts({ question, subHead, noLink });
@@ -81,34 +80,3 @@ function getDataSourceParts({ question, noLink, subHead, isObjectDetail }) {
 }
 
 export default QuestionDataSource;
-
-const SubHeadBreadcrumbs = ({ parts, className, ...props }) => (
-  <span {...props} className={className}>
-    <span className="flex align-center flex-wrap mbn1">
-      {parts.map(({ name, icon, href }, index) => (
-        <Badge key={index} className="mr2 mb1" icon={{ name: icon }} to={href}>
-          {name}
-        </Badge>
-      ))}
-    </span>
-  </span>
-);
-
-const HeadBreadcrumbs = ({ parts, ...props }) => (
-  <span {...props} className="flex align-center flex-wrap">
-    {parts.map(({ name, icon, href }, index) => [
-      <MaybeLink
-        key={index}
-        to={href}
-        className={cx("flex align-center", href ? "text-medium" : "text-dark")}
-      >
-        {name}
-      </MaybeLink>,
-      index < parts.length - 1 ? (
-        <span key={index + "-divider"} className="mx1 text-light text-smaller">
-          •
-        </span>
-      ) : null,
-    ])}
-  </span>
-);

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
@@ -44,7 +44,6 @@ function getDataSourceParts({ question, noLink, subHead, isObjectDetail }) {
   const table = query.table();
   if (table && table.hasSchema()) {
     parts.push({
-      icon: "folder",
       name: table.schema_name,
       href: !noLink && database.id >= 0 && browseSchema(table),
     });
@@ -63,7 +62,6 @@ function getDataSourceParts({ question, noLink, subHead, isObjectDetail }) {
       }, name);
     }
     parts.push({
-      icon: "table_spaced",
       name: name,
       href:
         !noLink && (subHead || isObjectDetail) && table.newQuestion().getUrl(),

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
@@ -4,7 +4,7 @@ import React from "react";
 import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
 import { browseDatabase, browseSchema } from "metabase/lib/urls";
 
-import { HeadBreadcrumbs, SubHeadBreadcrumbs } from "./HeaderBreadcrumbs";
+import { HeadBreadcrumbs } from "./HeaderBreadcrumbs";
 
 const QuestionDataSource = ({
   question,
@@ -19,10 +19,12 @@ const QuestionDataSource = ({
     noLink,
     isObjectDetail,
   });
-  return subHead ? (
-    <SubHeadBreadcrumbs parts={parts} {...props} />
-  ) : (
-    <HeadBreadcrumbs parts={parts} {...props} />
+  return (
+    <HeadBreadcrumbs
+      parts={parts}
+      variant={subHead ? "subhead" : "head"}
+      {...props}
+    />
   );
 };
 

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
@@ -1,13 +1,11 @@
 /* eslint-disable react/prop-types */
 import React from "react";
+import cx from "classnames";
 
 import Badge, { MaybeLink } from "metabase/components/Badge";
 
-import { browseDatabase, browseSchema } from "metabase/lib/urls";
-
 import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
-
-import cx from "classnames";
+import { browseDatabase, browseSchema } from "metabase/lib/urls";
 
 const QuestionDataSource = ({ question, subHead, noLink, ...props }) => {
   const parts = getDataSourceParts({ question, subHead, noLink });
@@ -29,7 +27,9 @@ function getDataSourceParts({ question, noLink, subHead, isObjectDetail }) {
   const parts = [];
 
   let query = question.query();
-  if (query instanceof StructuredQuery) {
+  const isStructuredQuery = query instanceof StructuredQuery;
+
+  if (isStructuredQuery) {
     query = query.rootQuery();
   }
 
@@ -53,7 +53,7 @@ function getDataSourceParts({ question, noLink, subHead, isObjectDetail }) {
 
   if (table) {
     let name = table.displayName();
-    if (query instanceof StructuredQuery) {
+    if (isStructuredQuery) {
       name = query.joins().reduce((name, join) => {
         const joinedTable = join.joinedTable();
         if (joinedTable) {

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
@@ -1,9 +1,6 @@
 /* eslint-disable react/prop-types */
 import React from "react";
-
-import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
 import { browseDatabase, browseSchema } from "metabase/lib/urls";
-
 import { HeadBreadcrumbs } from "./HeaderBreadcrumbs";
 
 const QuestionDataSource = ({
@@ -39,7 +36,7 @@ function getDataSourceParts({ question, noLink, subHead, isObjectDetail }) {
   const parts = [];
 
   let query = question.query();
-  const isStructuredQuery = query instanceof StructuredQuery;
+  const isStructuredQuery = question.isStructured();
 
   if (isStructuredQuery) {
     query = query.rootQuery();

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -191,14 +191,11 @@ function SavedQuestionLeftSide(props) {
           />
         )}
       </ViewHeaderMainLeftContentContainer>
-      <ViewHeaderLeftSubHeading className="pt1">
-        <CollectionBadge
-          className="mb1"
-          collectionId={question.collectionId()}
-        />
+      <ViewHeaderLeftSubHeading>
+        <CollectionBadge collectionId={question.collectionId()} />
         {QuestionDataSource.shouldRender(props) && (
           <QuestionDataSource
-            className="ml3 mb1"
+            className="ml3"
             question={question}
             isObjectDetail={isObjectDetail}
             subHead
@@ -206,7 +203,6 @@ function SavedQuestionLeftSide(props) {
         )}
         {QuestionFilters.shouldRender(props) && (
           <QuestionFilters
-            className="mb1"
             question={question}
             expanded={areFiltersExpanded}
             onExpand={onExpandFilters}
@@ -274,7 +270,6 @@ function AhHocQuestionLeftSide(props) {
       <ViewHeaderLeftSubHeading>
         {isSummarized && (
           <QuestionDataSource
-            className="mb1"
             question={question}
             isObjectDetail={isObjectDetail}
             subHead
@@ -283,7 +278,7 @@ function AhHocQuestionLeftSide(props) {
         )}
         {!showFiltersInHeading && QuestionFilters.shouldRender(props) && (
           <QuestionFilters
-            className="mb1 mt1"
+            className={cx({ ml2: isSummarized })}
             question={question}
             expanded={areFiltersExpanded}
             onExpand={onExpandFilters}

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -192,10 +192,13 @@ function SavedQuestionLeftSide(props) {
         )}
       </ViewHeaderMainLeftContentContainer>
       <ViewHeaderLeftSubHeading>
-        <CollectionBadge collectionId={question.collectionId()} />
+        <CollectionBadge
+          collectionId={question.collectionId()}
+          className="mb1"
+        />
         {QuestionDataSource.shouldRender(props) && (
           <QuestionDataSource
-            className="ml3"
+            className="ml3 mb1 pr2"
             question={question}
             isObjectDetail={isObjectDetail}
             subHead
@@ -203,6 +206,7 @@ function SavedQuestionLeftSide(props) {
         )}
         {QuestionFilters.shouldRender(props) && (
           <QuestionFilters
+            className="mb1"
             question={question}
             expanded={areFiltersExpanded}
             onExpand={onExpandFilters}
@@ -270,6 +274,7 @@ function AhHocQuestionLeftSide(props) {
       <ViewHeaderLeftSubHeading>
         {isSummarized && (
           <QuestionDataSource
+            className="mb1"
             question={question}
             isObjectDetail={isObjectDetail}
             subHead
@@ -278,7 +283,7 @@ function AhHocQuestionLeftSide(props) {
         )}
         {!showFiltersInHeading && QuestionFilters.shouldRender(props) && (
           <QuestionFilters
-            className={cx({ ml2: isSummarized })}
+            className={cx("mb1", { ml2: isSummarized })}
             question={question}
             expanded={areFiltersExpanded}
             onExpand={onExpandFilters}

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -244,7 +244,7 @@ function AhHocQuestionLeftSide(props) {
   } = props;
   return (
     <div>
-      <ViewHeaderMainLeftContentContainer align="baseline">
+      <ViewHeaderMainLeftContentContainer>
         <AdHocViewHeading>
           {isNative ? (
             t`New question`
@@ -257,7 +257,7 @@ function AhHocQuestionLeftSide(props) {
         </AdHocViewHeading>
         {showFiltersInHeading && QuestionFilters.shouldRender(props) && (
           <QuestionFilters
-            className="mr2 mb1"
+            className="mr2"
             question={question}
             expanded={areFiltersExpanded}
             onExpand={onExpandFilters}
@@ -266,7 +266,6 @@ function AhHocQuestionLeftSide(props) {
         )}
         {QuestionLineage.shouldRender(props) && (
           <QuestionLineage
-            className="mr2 mb1"
             question={question}
             originalQuestion={originalQuestion}
           />
@@ -284,7 +283,7 @@ function AhHocQuestionLeftSide(props) {
         )}
         {!showFiltersInHeading && QuestionFilters.shouldRender(props) && (
           <QuestionFilters
-            className="mb1"
+            className="mb1 mt1"
             question={question}
             expanded={areFiltersExpanded}
             onExpand={onExpandFilters}

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.styled.jsx
@@ -23,7 +23,6 @@ export const ViewHeaderLeftSubHeading = styled(ViewSubHeading)`
 
   &:not(:empty) {
     margin-top: ${space(0)};
-    margin-bottom: ${space(1)};
   }
 `;
 

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.styled.jsx
@@ -12,7 +12,7 @@ export const ViewHeaderContainer = styled(ViewSection)`
 
 export const ViewHeaderMainLeftContentContainer = styled.div`
   display: flex;
-  align-items: "center";
+  align-items: center;
   flex-wrap: wrap;
 `;
 

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.styled.jsx
@@ -12,7 +12,7 @@ export const ViewHeaderContainer = styled(ViewSection)`
 
 export const ViewHeaderMainLeftContentContainer = styled.div`
   display: flex;
-  align-items: ${props => props.align || "center"};
+  align-items: "center";
   flex-wrap: wrap;
 `;
 

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.styled.jsx
@@ -20,6 +20,11 @@ export const ViewHeaderLeftSubHeading = styled(ViewSubHeading)`
   display: flex;
   align-items: center;
   flex-wrap: wrap;
+
+  &:not(:empty) {
+    margin-top: ${space(0)};
+    margin-bottom: ${space(1)};
+  }
 `;
 
 export const AdHocViewHeading = styled(ViewHeading)`

--- a/frontend/src/metabase/questions/components/CollectionBadge.jsx
+++ b/frontend/src/metabase/questions/components/CollectionBadge.jsx
@@ -35,6 +35,7 @@ function CollectionBadge({ collection, analyticsContext, className }) {
       to={collection.getUrl()}
       icon={icon}
       activeColor={icon.color}
+      inactiveColor="text-light"
       className={className}
       data-metabase-event={`${analyticsContext};Collection Badge Click`}
     >

--- a/frontend/test/metabase/scenarios/custom-column/cc-typing-suggestion.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/cc-typing-suggestion.cy.spec.js
@@ -11,7 +11,7 @@ describe("scenarios > question > custom column > typing suggestion", () => {
 
   it("should not suggest arithmetic operators", () => {
     cy.get("[contenteditable='true']").type("[Price] ");
-    cy.contains("/").should("not.exist");
+    cy.findByTestId("expression-suggestions-list").should("not.exist");
   });
 
   it("should correctly accept the chosen field suggestion", () => {


### PR DESCRIPTION
Updates question header breadcrumbs. Most noticeable changes:

* there is a database icon in simple mode's breadcrumbs. Later, for questions built on datasets, we're going to display a dataset icon there
* the dot divider is replaced with a slash to mirror data sources nesting (e.g. database / schema / table)
* font size in simple mode is increased and is now the same as saved question's title
* breadcrumb colors are changed from `text-medium` to `text-light`
* breadcrumb links have hover effects

Fixes #17922

### Scenarios

<details>
<summary>Simple Question</summary>

**Before**

<img width="259" alt="table view : adhoc before" src="https://user-images.githubusercontent.com/17258145/140788793-7411ae71-c95f-425c-90ea-42ecf892aa01.png">

**After**

<img width="279" alt="table view : adhoc" src="https://user-images.githubusercontent.com/17258145/140788810-198fcb3a-c810-45e1-92e3-ae9a965baa0a.png">

</details>

<details>
<summary>Simple Question (with schema)</summary>

**Before**
<img width="286" alt="table view with schema before" src="https://user-images.githubusercontent.com/17258145/140789327-d375ecae-241b-491a-92df-5a1fdc6b482a.png">

**After**
<img width="312" alt="table view (with schema)" src="https://user-images.githubusercontent.com/17258145/140789335-7eb08720-fd6e-40e5-9062-cdbf80542749.png">

</details>

<details>
<summary>Saved Question (with schema)</summary>

**Before**

<img width="390" alt="saved with schema before" src="https://user-images.githubusercontent.com/17258145/140789114-30578c60-48c0-4894-bebd-5b712811f76f.png">

**After**

<img width="365" alt="saved with schema" src="https://user-images.githubusercontent.com/17258145/140789110-02ad49c8-0e2b-4dd0-a59f-f8b10e630e12.png">

</details>

<details>
<summary>Native Saved Question</summary>

**Before**

<img width="307" alt="native-saved-before" src="https://user-images.githubusercontent.com/17258145/140789188-fcb53070-7fc5-453a-8519-ad41338d6f7a.png">

**After**

<img width="302" alt="native-saved" src="https://user-images.githubusercontent.com/17258145/140789207-1a110b31-ee32-437a-8387-434d95bbfd5e.png">

</details>

<details>
<summary>Using saved question as a data source</summary>

**Before**

<img width="430" alt="based-on-question-before" src="https://user-images.githubusercontent.com/17258145/140789432-4f8151e0-8f09-4488-95bf-186e7b1f8482.png">

**After**

<img width="415" alt="based-on-question" src="https://user-images.githubusercontent.com/17258145/140789445-e51ad9fc-ec6f-49f2-ac62-124a4109a470.png">

</details>

<details>
<summary>Question started from another question</summary>

**Before**

<img width="359" alt="from-question-filters-expanded-before" src="https://user-images.githubusercontent.com/17258145/140789526-e027a11d-ca64-4e15-9078-3d53a512b61e.png">

<img width="413" alt="from-question-filters-collapsed-before" src="https://user-images.githubusercontent.com/17258145/140789534-22c4a322-0de3-41c7-9d8b-e6aba58ce60d.png">

**After**

<img width="400" alt="from-question-filters-expanded" src="https://user-images.githubusercontent.com/17258145/140789556-ce11d569-d153-466a-80cd-eeffbca76b97.png">

<img width="460" alt="from-question-filters-collapsed" src="https://user-images.githubusercontent.com/17258145/140789563-309a9824-ca27-472b-9831-455dd5928ed9.png">

</details>

<details>
<summary>Detail View</summary>

**Before**

Note: fixes missing object PK in breadcrumbs

<img width="259" alt="detail view before" src="https://user-images.githubusercontent.com/17258145/140789623-d4d8b300-8de8-4ce0-ae9d-f6ae789e5d41.png">

**After**

<img width="311" alt="detail view" src="https://user-images.githubusercontent.com/17258145/140789639-1b887acd-5af0-4120-ae92-081beb387db7.png">

</details>