### PR TITLE
GitHub Actions CI: split docs-triggered workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,44 +1,33 @@
-name: Fuzzing
+name: Docs
 
 on:
   push:
     branches:
       - '**'
     paths:
-    - 'frontend/**'
-    - 'shared/**'
-    - 'enterprise/frontend/**'
+    - 'docs/**'
+    - './bin/verify-docs-links'
     - '**/package.json'
     - '**/yarn.lock'
-    - '**/.eslintrc'
     - '.github/workflows/**'
   pull_request:
-    paths-ignore:
-    - 'docs/**'
 
 jobs:
 
-  fe-fuzz-tokenizer:
+  fe-linter-docs-links:
     runs-on: ubuntu-20.04
-    timeout-minutes: 7
+    timeout-minutes: 10
     steps:
     - uses: actions/checkout@v2
     - name: Prepare Node.js
       uses: actions/setup-node@v1
       with:
         node-version: 14.x
-    - name: Get M2 cache
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-cljs-${{ hashFiles('**/shadow-cljs.edn') }}
     - name: Get yarn cache
       uses: actions/cache@v2
       with:
         path: ~/.cache/yarn
         key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
     - run: yarn install --frozen-lockfile --prefer-offline
-    - run: yarn test-unit frontend/test/metabase/lib/expressions/fuzz.tokenizer.unit.spec.js
-      env:
-        MB_FUZZ: 1
-      name: Run fuzz testing on the tokenizer
+    - run: yarn run lint-docs-links
+      name: Run docs links checker

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -9,7 +9,6 @@ on:
     - 'frontend/**'
     - 'shared/**'
     - 'enterprise/frontend/**'
-    - 'docs/**'
     - '**/package.json'
     - '**/yarn.lock'
     - '**/.eslintrc'
@@ -57,24 +56,6 @@ jobs:
     - run: yarn install --frozen-lockfile --prefer-offline
     - run: yarn run lint-eslint
       name: Run ESLint linter
-
-  fe-linter-docs-links:
-    runs-on: ubuntu-20.04
-    timeout-minutes: 10
-    steps:
-    - uses: actions/checkout@v2
-    - name: Prepare Node.js
-      uses: actions/setup-node@v1
-      with:
-        node-version: 14.x
-    - name: Get yarn cache
-      uses: actions/cache@v2
-      with:
-        path: ~/.cache/yarn
-        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-    - run: yarn install --frozen-lockfile --prefer-offline
-    - run: yarn run lint-docs-links
-      name: Run docs links checker
 
   fe-type-check:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Some checks, which are not related to `docs/` changes, should not run when `docs/` is modified.

Note: this is only for push changes (to e.g. `master`), and not affecting PR workflow (since we need to those check status).