### PR TITLE
Fix wrong data picker is used on admin data modeling page

### DIFF
--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -57,6 +57,15 @@ const TABLE_STEP = "TABLE";
 // chooses a table field (table has already been selected)
 const FIELD_STEP = "FIELD";
 
+export const DataSourceSelector = props => (
+  <DataSelector
+    steps={[DATA_BUCKET_STEP, DATABASE_STEP, SCHEMA_STEP, TABLE_STEP]}
+    combineDatabaseSchemaSteps
+    getTriggerElementContent={TableTriggerContent}
+    {...props}
+  />
+);
+
 export const DatabaseDataSelector = props => (
   <DataSelector
     steps={[DATABASE_STEP]}
@@ -67,7 +76,7 @@ export const DatabaseDataSelector = props => (
 
 export const DatabaseSchemaAndTableDataSelector = props => (
   <DataSelector
-    steps={[DATA_BUCKET_STEP, DATABASE_STEP, SCHEMA_STEP, TABLE_STEP]}
+    steps={[DATABASE_STEP, SCHEMA_STEP, TABLE_STEP]}
     combineDatabaseSchemaSteps
     getTriggerElementContent={TableTriggerContent}
     {...props}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx
@@ -3,7 +3,7 @@ import React from "react";
 import { connect } from "react-redux";
 import { t } from "ttag";
 
-import { DatabaseSchemaAndTableDataSelector } from "metabase/query_builder/components/DataSelector";
+import { DataSourceSelector } from "metabase/query_builder/components/DataSelector";
 import { getDatabasesList } from "metabase/query_builder/selectors";
 
 import { NotebookCell, NotebookCellItem } from "../NotebookCell";
@@ -36,7 +36,7 @@ function DataStep({ color, query, updateQuery }) {
         rightContainerStyle={FIELDS_PICKER_STYLES.notebookRightItemContainer}
         data-testid="data-step-cell"
       >
-        <DatabaseSchemaAndTableDataSelector
+        <DataSourceSelector
           hasTableSearch
           databaseQuery={{ saved: true }}
           selectedDatabaseId={query.databaseId()}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -5,7 +5,7 @@ import { t } from "ttag";
 
 import PopoverWithTrigger from "metabase/components/PopoverWithTrigger";
 
-import { DatabaseSchemaAndTableDataSelector } from "metabase/query_builder/components/DataSelector";
+import { DataSourceSelector } from "metabase/query_builder/components/DataSelector";
 import FieldList from "metabase/query_builder/components/FieldList";
 import Join from "metabase-lib/lib/queries/structured/Join";
 import { isDateTimeField } from "metabase/lib/query/field_ref";
@@ -417,7 +417,7 @@ function JoinTablePicker({
       containerStyle={FIELDS_PICKER_STYLES.notebookItemContainer}
       rightContainerStyle={FIELDS_PICKER_STYLES.notebookRightItemContainer}
     >
-      <DatabaseSchemaAndTableDataSelector
+      <DataSourceSelector
         hasTableSearch
         canChangeDatabase={false}
         databases={databases}

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSelector.jsx
@@ -1,11 +1,11 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 
-import { DatabaseSchemaAndTableDataSelector } from "metabase/query_builder/components/DataSelector";
+import { DataSourceSelector } from "metabase/query_builder/components/DataSelector";
 
 export default function QuestionDataSelector({ query, triggerElement }) {
   return (
-    <DatabaseSchemaAndTableDataSelector
+    <DataSourceSelector
       containerClassName="DataPopoverContainer"
       hasTableSearch
       databaseQuery={{ saved: true }}


### PR DESCRIPTION
Fixes a regression from #18764. When creating or editing a segment or metric on `/admin/datamodel`, the data selector should only display databases without saved questions or datasets.

#18764 updated the `DatabaseSchemaAndTableDataSelector` instead of introducing a different picker. In that way, if the selector was meant to be used only with databases, schemas, and tables, it still had the "Saved Questions" and "Datasets" buckets. Fixed by introducing a `DataSourceSelector` selector with the new "data bucket" step and reverting `DatabaseSchemaAndTableDataSelector` to its original purpose.

### To Verify

1. Sign in as admin
2. Go to `/admin/datamodel/segment/create`
3. Click "Select table" in the query builder
4. You should only see databases, schemas and tables in the picker
5. Go to `/question/new` > Simple / Custom Question
6. You should see datasets, raw data and saved questions options

### Demo

**Before**

<img width="1022" alt="CleanShot 2021-11-08 at 19 45 27@2x" src="https://user-images.githubusercontent.com/17258145/140909599-b76bd401-c6fe-4f8d-a428-6c688c03b0ef.png">

**After**

<img width="999" alt="CleanShot 2021-11-08 at 19 43 35@2x" src="https://user-images.githubusercontent.com/17258145/140909614-4c7943e8-8be0-476a-8b06-674933bce97e.png">


