### PR TITLE
Zooming in on email attachment tables on pulse (attacks #18755)

### DIFF
--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -231,6 +231,7 @@
 (s/defmethod render :table :- common/RenderedPulseCard
   [_ render-type timezone-id :- (s/maybe s/Str) card {:keys [cols rows] :as data}]
   (let [table-body [:div
+                    (when (= render-type :attachment {:style (style/style {:zoom "0.5"})}))
                     (table/render-table
                      (color/make-color-selector data (:visualization_settings card))
                      (mapv :name (:cols data))

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -231,7 +231,7 @@
 (s/defmethod render :table :- common/RenderedPulseCard
   [_ render-type timezone-id :- (s/maybe s/Str) card {:keys [cols rows] :as data}]
   (let [table-body [:div
-                    (when (= render-type :attachment {:style (style/style {:zoom "0.5"})}))
+                    (when (= render-type :attachment) {:style (style/style {:zoom "0.5"})})
                     (table/render-table
                      (color/make-color-selector data (:visualization_settings card))
                      (mapv :name (:cols data))


### PR DESCRIPTION
Pursuant to #18755. Underlying problem is purported to be not being zoomed out enough. This one just zooms out. This won't work on FF but the underlying problem only occurs in mobile.

Trouble with using `transform: scale` is that the label divs don't zoom with it - this would turn a 1 liner fix into a 100 liner total change of CSS fix, unless you've got better ideas to execute that one

I saw reports that you used to be able to permanently enable scroll bars by setting `overflow-x: scroll` but I could not replicate being able to permanently enable scroll bars inside of emails.

There are purported methods of being able to do scrolling for overflow and zooming, but I can't find any way of doing it w/o JS. (for example: https://stackoverflow.com/questions/34196639/zooming-in-overflow-scroll)