### PR TITLE
Manual backport of #18654

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/settings/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/settings/index.js
@@ -1,7 +1,7 @@
 import MetabaseSettings from "metabase/lib/settings";
 
 export function hasPremiumFeature(feature) {
-  const hasFeature = MetabaseSettings.get("premium-features", {})[feature];
+  const hasFeature = MetabaseSettings.get("token-features", {})[feature];
   if (hasFeature == null) {
     console.warn("Unknown premium feature", feature);
   }

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -399,8 +399,8 @@
   :setter     :none
   :getter     (constantly config/mb-version-info))
 
-(defsetting premium-features
-  "Premium  features enabled for this instance."
+(defsetting token-features
+  "Features registered for this instance's token"
   :visibility :public
   :setter     :none
   :getter     (fn [] {:embedding            (premium-features/hide-embed-branding?)
@@ -410,7 +410,8 @@
                       :sso                  (premium-features/enable-sso?)
                       :advanced_config      (premium-features/enable-advanced-config?)
                       :advanced_permissions (premium-features/enable-advanced-permissions?)
-                      :content_management   (premium-features/enable-content-management?)}))
+                      :content_management   (premium-features/enable-content-management?)
+                      :hosting              (premium-features/is-hosted?)}))
 
 (defsetting redirect-all-requests-to-https
   (deferred-tru "Force all traffic to use HTTPS via a redirect, if the site URL is HTTPS")

--- a/src/metabase/public_settings/premium_features.clj
+++ b/src/metabase/public_settings/premium_features.clj
@@ -218,6 +218,13 @@
   etc.)?"
   :content-management)
 
+(defsetting is-hosted?
+  "Is the Metabase instance running in the cloud?"
+  :type       :boolean
+  :visibility :public
+  :setter     :none
+  :getter     (fn [] (boolean ((token-features) "hosting"))))
+
 ;; `enhancements` are not currently a specific "feature" that EE tokens can have or not have. Instead, it's a
 ;; catch-all term for various bits of EE functionality that we assume all EE licenses include. (This may change in the
 ;; future.)


### PR DESCRIPTION
#18654 wasn't automatically backported because of a merge conflict; had to wait for a different PR to be backported first.

Needed for new Snowplow analytics which we are partially releasing in 41.2.

Edit: also including the backend part of #17256 which this depends on (adding the `is-hosted?` setting in the first place)