### PR TITLE
Map tiles improvements

### DIFF
--- a/frontend/src/metabase/visualizations/components/LeafletTilePinMap.jsx
+++ b/frontend/src/metabase/visualizations/components/LeafletTilePinMap.jsx
@@ -52,10 +52,6 @@ export default class LeafletTilePinMap extends LeafletMap {
       "/" +
       (longitudeField.id || encodeURIComponent(longitudeField.name)) +
       "/" +
-      latitudeIndex +
-      "/" +
-      longitudeIndex +
-      "/" +
       "?query=" +
       encodeURIComponent(JSON.stringify(dataset_query))
     );

--- a/src/metabase/api/tiles.clj
+++ b/src/metabase/api/tiles.clj
@@ -129,8 +129,10 @@
   "Parse a string into an integer if it can be otherwise return the string. Intended to determine whether something is a
   field id or a field name."
   [x]
-  (try (Integer/parseInt x)
-       (catch NumberFormatException _ x)))
+  (if (re-matches #"\d+" x)
+    (Integer/parseInt x)
+    x))
+
 
 ;; TODO - this can be reworked to be `defendpoint-async` instead
 ;;

--- a/src/metabase/api/tiles.clj
+++ b/src/metabase/api/tiles.clj
@@ -143,7 +143,14 @@
   (let [id-or-name' (int-or-string id-or-name)]
     [:field id-or-name' (when (string? id-or-name') {:base-type :type/Float})]))
 
-(defn query->tiles-query [query {:keys [zoom x y lat-field lon-field]}]
+(defn query->tiles-query
+  "Transform a card's query into a query finding coordinates in a particular region.
+
+  - transform native queries into nested mbql queries from that native query
+  - add [:inside lat lon bounding-region coordings] filter
+  - limit query results to `tile-coordinate-limit` number of results
+  - only select lat and lon fields rather than entire query's fields"
+  [query {:keys [zoom x y lat-field lon-field]}]
   (let [lat-ref (field-ref lat-field)
         lon-ref (field-ref lon-field)]
     (-> query

--- a/src/metabase/api/tiles.clj
+++ b/src/metabase/api/tiles.clj
@@ -23,6 +23,9 @@
 (def ^:private ^:const pin-size              6)
 (def ^:private ^:const pixels-per-lon-degree (float (/ tile-size 360)))
 (def ^:private ^:const pixels-per-lon-radian (float (/ tile-size (* 2 Math/PI))))
+(def ^:private ^:const tile-coordinate-limit
+  "Limit for number of pins to query for per tile."
+  2000)
 
 
 ;;; ---------------------------------------------------- UTIL FNS ----------------------------------------------------
@@ -149,6 +152,7 @@
                 lat-ref lon-ref
                 x y zoom)
         (assoc-in [:query :fields] [lat-ref lon-ref])
+        (assoc-in [:query :limit] tile-coordinate-limit)
         (assoc :async? false))))
 
 ;; TODO - this can be reworked to be `defendpoint-async` instead

--- a/test/metabase/api/tiles_test.clj
+++ b/test/metabase/api/tiles_test.clj
@@ -19,9 +19,9 @@
                                  :fields [[:field (mt/id :venues :name) nil]
                                           [:field (mt/id :venues :latitude) nil]
                                           [:field (mt/id :venues :longitude) nil]]}}]
-    (testing "GET /api/tiles/:zoom/:x/:y/:lat-field-id/:lon-field-id/:lat-col-idx/:lon-col-idx/"
+    (testing "GET /api/tiles/:zoom/:x/:y/:lat-field-id/:lon-field-id/"
       (is (png? (mt/user-http-request
-                 :rasta :get 200 (format "tiles/1/1/1/%d/%d/1/2/"
+                 :rasta :get 200 (format "tiles/1/1/1/%d/%d/"
                                          (mt/id :venues :latitude)
                                          (mt/id :venues :longitude))
                  :query (json/generate-string venues-query)))))
@@ -29,7 +29,7 @@
       (let [native-query {:query (:query (qp/query->native venues-query))
                           :template-tags {}}]
         (is (png? (mt/user-http-request
-                   :rasta :get 200 (format "tiles/1/1/1/%s/%s/1/2/"
+                   :rasta :get 200 (format "tiles/1/1/1/%s/%s/"
                                            "LATITUDE" "LONGITUDE")
                    :query (json/generate-string
                            {:database (mt/id)
@@ -88,7 +88,7 @@
     (is (schema= {:status   (s/eq "failed")
                   s/Keyword s/Any}
                  (mt/user-http-request
-                  :rasta :get 400 (format "tiles/1/1/1/%d/%d/1/1/"
+                  :rasta :get 400 (format "tiles/1/1/1/%d/%d/"
                                           (mt/id :venues :latitude)
                                           (mt/id :venues :longitude))
                   :query "{}")))))
@@ -96,7 +96,7 @@
 (deftest always-run-sync-test
   (testing "even if the original query was saved as `:async?` we shouldn't run the query as async"
     (is (png? (mt/user-http-request
-               :rasta :get 200 (format "tiles/1/1/1/%d/%d/1/1/"
+               :rasta :get 200 (format "tiles/1/1/1/%d/%d/"
                                        (mt/id :venues :latitude)
                                        (mt/id :venues :longitude))
                :query (json/generate-string

--- a/test/metabase/api/tiles_test.clj
+++ b/test/metabase/api/tiles_test.clj
@@ -48,7 +48,7 @@
                                       [:field 574 nil] ; lat
                                       [:field 576 nil] ; lon
                                       ]
-                             :limit 2000}
+                             :limit 50000}
                      :type :query}]
           (is (= {:database 19
                   :query {:source-table 88
@@ -65,7 +65,7 @@
     (testing "native"
       (testing "nests the query, selects fields"
         (let [query {:type :native
-                     :native {:query "select name, latitude, longitude from zomato limit 2000;"
+                     :native {:query "select name, latitude, longitude from zomato limit 5000;"
                               :template-tags {}}
                      :database 19}]
           (is (= {:database 19
@@ -74,7 +74,8 @@
                                    [:field "longitude" {:base-type :type/Float}]]
                           :filter [:inside
                                    [:field "latitude" {:base-type :type/Float}]
-                                   [:field "longitude" {:base-type :type/Float}]]}
+                                   [:field "longitude" {:base-type :type/Float}]]
+                          :limit  2000}
                   :type :query
                   :async? false}
                  (clean (tiles/query->tiles-query query

--- a/test/metabase/api/tiles_test.clj
+++ b/test/metabase/api/tiles_test.clj
@@ -19,9 +19,9 @@
                                  :fields [[:field (mt/id :venues :name) nil]
                                           [:field (mt/id :venues :latitude) nil]
                                           [:field (mt/id :venues :longitude) nil]]}}]
-    (testing "GET /api/tiles/:zoom/:x/:y/:lat-field-id/:lon-field-id/"
+    (testing "GET /api/tiles/:zoom/:x/:y/:lat-field-id/:lon-field-id"
       (is (png? (mt/user-http-request
-                 :rasta :get 200 (format "tiles/1/1/1/%d/%d/"
+                 :rasta :get 200 (format "tiles/1/1/1/%d/%d"
                                          (mt/id :venues :latitude)
                                          (mt/id :venues :longitude))
                  :query (json/generate-string venues-query)))))
@@ -29,7 +29,7 @@
       (let [native-query {:query (:query (qp/query->native venues-query))
                           :template-tags {}}]
         (is (png? (mt/user-http-request
-                   :rasta :get 200 (format "tiles/1/1/1/%s/%s/"
+                   :rasta :get 200 (format "tiles/1/1/1/%s/%s"
                                            "LATITUDE" "LONGITUDE")
                    :query (json/generate-string
                            {:database (mt/id)
@@ -88,7 +88,7 @@
     (is (schema= {:status   (s/eq "failed")
                   s/Keyword s/Any}
                  (mt/user-http-request
-                  :rasta :get 400 (format "tiles/1/1/1/%d/%d/"
+                  :rasta :get 400 (format "tiles/1/1/1/%d/%d"
                                           (mt/id :venues :latitude)
                                           (mt/id :venues :longitude))
                   :query "{}")))))
@@ -96,7 +96,7 @@
 (deftest always-run-sync-test
   (testing "even if the original query was saved as `:async?` we shouldn't run the query as async"
     (is (png? (mt/user-http-request
-               :rasta :get 200 (format "tiles/1/1/1/%d/%d/"
+               :rasta :get 200 (format "tiles/1/1/1/%d/%d"
                                        (mt/id :venues :latitude)
                                        (mt/id :venues :longitude))
                :query (json/generate-string


### PR DESCRIPTION
Addresses #4844 

Two fixes:
- select only lat/long from each row
- select fewer rows
- (also includes minor speedup for the `int-or-string` function

#### Only select lat/lon fields in api/tiles

We required the index of lat and long columns, ran the whole query, and
then just grabbed those columns in a `(for [row rows] [(nth row
lat-idx)..])`. But of course we can just update the fields we want to
select in the query.

MBQL and native queries flow through this codepath depending on the
source of the query of the card being mapped. For mbql queries, it is
straightforward, add a filter on the lat long and replace the fields
with just lat and long fields. For native, we nest the native query as a
nested query and then proceed on the resulting mbql query. The only
difference is requiring the type annotation for the field type.

mbql field: [:field 32 nil] vs [:field "latitude" {:base-type :type/Float}]

This addresses memory concerns. The query is not limited and we don't
need to select an entire row for these purposes. Dropping lots of text
fields, id fields, etc could save quite a bit of memory when resolving
the entire result set in memory.


#### Add limit to number of coordinates per tile

these queries were unbounded in getting coordinates for each tile. But
in a visualization, can there really be more information provided? We
were leaving them unbounded and getting back millions of rows (reported
on #4844). So we were adding unnecessary detail at the price of OOM
errors.

Note tests have been changed to show that the limit of the original mbql
query is clobbered and the limit of the original native query is only
present in the nested query whereas the outer query selects its own
limit.

As always, should this number be exposed as a setting? Configurable in
the UI? Leaving as a hardcoded and documented number for the moment.