### PR TITLE
Custom expression editor: Press Tab to select

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -18,6 +18,7 @@ import colors from "metabase/lib/colors";
 import { setCaretPosition, getSelectionPosition } from "metabase/lib/dom";
 
 import {
+  KEYCODE_TAB,
   KEYCODE_ENTER,
   KEYCODE_ESCAPE,
   KEYCODE_LEFT,
@@ -192,7 +193,7 @@ export default class ExpressionEditorTextfield extends React.Component {
       return;
     }
 
-    if (e.keyCode === KEYCODE_ENTER) {
+    if (e.keyCode === KEYCODE_ENTER || e.keyCode === KEYCODE_TAB) {
       this.onSuggestionSelected(highlightedSuggestionIndex);
       e.preventDefault();
     } else if (e.keyCode === KEYCODE_UP) {


### PR DESCRIPTION
How to verify:

1. Ask a question, Simple question
2. Sample Dataset, Orders table
3. Filter, Custom Expression, type `d`. The suggestions will appear
![image](https://user-images.githubusercontent.com/7288/140967347-c90a0622-ddbf-47f8-a7d8-c6f3e07230b4.png)

4. Press `tab` key, the intention of accepting/choosing the first choice `Discount`

**Before this PR**

The focus is switched somewhere, leaving the editor to only have `d` and thus, triggering an error:

![image](https://user-images.githubusercontent.com/7288/140967455-e828bb30-cb09-4afe-88ca-f8712f1dd53d.png)

**After this PR**

`Discount` is accepted, the editor stays in focus, the user can continue typing.

![image](https://user-images.githubusercontent.com/7288/140967545-6f1400c2-1c26-42df-a082-1aebfed81269.png)

