### PR TITLE
pass 'noEvent' api option to prevent unauthed event

### DIFF
--- a/frontend/src/metabase/lib/entities.js
+++ b/frontend/src/metabase/lib/entities.js
@@ -306,8 +306,8 @@ export function createEntity(def: EntityDefinition): Entity {
         ({ id }) => [...getObjectStatePath(id), "fetch"],
       ),
       withEntityActionDecorators("fetch"),
-    )(entityObject => async (dispatch, getState) =>
-      entity.normalize(await entity.api.get({ id: entityObject.id })),
+    )((entityObject, options = {}) => async (dispatch, getState) =>
+      entity.normalize(await entity.api.get({ id: entityObject.id }, options)),
     ),
 
     create: compose(

--- a/frontend/src/metabase/visualizations/hoc/WithVizSettingsData.js
+++ b/frontend/src/metabase/visualizations/hoc/WithVizSettingsData.js
@@ -63,7 +63,9 @@ const WithVizSettingsData = ComposedComponent => {
       fetch() {
         getLinkTargets(this.dashcardSettings(this.props)).forEach(
           ({ entity, entityId }) =>
-            this.props.dispatch(entity.actions.fetch({ id: entityId })),
+            this.props.dispatch(
+              entity.actions.fetch({ id: entityId }, { noEvent: true }),
+            ),
         );
       }
 

--- a/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
@@ -326,7 +326,7 @@ describe("scenarios > dashboard", () => {
     expectedRouteCalls({ route_alias: "fetchFieldValues", calls: 0 });
   });
 
-  it.skip("should be possible to visit a dashboard with click-behavior linked to the dashboard without permissions (metabase#15368)", () => {
+  it("should be possible to visit a dashboard with click-behavior linked to the dashboard without permissions (metabase#15368)", () => {
     cy.request("GET", "/api/user/current").then(
       ({ body: { personal_collection_id } }) => {
         // Save new dashboard in admin's personal collection


### PR DESCRIPTION
Fixes #15368 

In `app-main.js` there's a listener for all 403 status requests. If the request url matches a regex in the `NOT_AUTHORIZED_TRIGGERS` list it shows the user the unauthorized page. Click behavior sends a request that may resolve with a 403 status, as described in the issue, but since the functionality is auxiliary to the dashboard itself, we shouldn't totally obliterate the page. Simplest fix is passing this `noEvent` flag when fetching. Kind of hacky in my opinion but the alternative is probably a much heavier lift.

Before (user without perms to the click behavior dash on the left)

https://user-images.githubusercontent.com/13057258/140994666-61ebc099-9af2-4365-bf98-ef57d2bc8a9a.mov

After (user without perms to the click behavior dash on the left)

https://user-images.githubusercontent.com/13057258/140994673-e4e56fb6-9766-46f5-aacd-0bd36c32c664.mov


 