### PR TITLE
Fix binning / temporal units selection for dimensions from a joined native question

### DIFF
--- a/frontend/src/metabase-lib/lib/Dimension.js
+++ b/frontend/src/metabase-lib/lib/Dimension.js
@@ -604,17 +604,6 @@ export class FieldDimension extends Dimension {
       }
     }
 
-    let fieldMetadata = {};
-
-    // If a field dimension isn't associated with a query,
-    // there is a chance it's stored in fields metadata
-    if (this.isStringFieldName()) {
-      // As field literal's IDs are not numeric like in field references,
-      // in metadata.fields their IDs are stringified MBQL objects
-      const metadataFieldLiteralId = String(this.mbql());
-      fieldMetadata = this._metadata?.field(metadataFieldLiteralId) || {};
-    }
-
     // despite being unable to find a field, we _might_ still have enough data to know a few things about it
     // for example, if we have an mbql field reference, it might contain a `base-type`
     return new Field({
@@ -626,7 +615,6 @@ export class FieldDimension extends Dimension {
       base_type: this.getOption("base-type"),
       query: this._query,
       metadata: this._metadata,
-      ...fieldMetadata,
     });
   }
 

--- a/frontend/src/metabase-lib/lib/Dimension.js
+++ b/frontend/src/metabase-lib/lib/Dimension.js
@@ -604,6 +604,17 @@ export class FieldDimension extends Dimension {
       }
     }
 
+    let fieldMetadata = {};
+
+    // If a field dimension isn't associated with a query,
+    // there is a chance it's stored in fields metadata
+    if (this.isStringFieldName()) {
+      // As field literal's IDs are not numeric like in field references,
+      // in metadata.fields their IDs are stringified MBQL objects
+      const metadataFieldLiteralId = String(this.mbql());
+      fieldMetadata = this._metadata?.field(metadataFieldLiteralId) || {};
+    }
+
     // despite being unable to find a field, we _might_ still have enough data to know a few things about it
     // for example, if we have an mbql field reference, it might contain a `base-type`
     return new Field({
@@ -615,6 +626,7 @@ export class FieldDimension extends Dimension {
       base_type: this.getOption("base-type"),
       query: this._query,
       metadata: this._metadata,
+      ...fieldMetadata,
     });
   }
 

--- a/frontend/src/metabase-lib/lib/Dimension.js
+++ b/frontend/src/metabase-lib/lib/Dimension.js
@@ -854,9 +854,18 @@ export class FieldDimension extends Dimension {
   }
 
   _dimensionForOption(option): FieldDimension {
-    const dimension = option.mbql
+    let dimension = option.mbql
       ? FieldDimension.parseMBQLOrWarn(option.mbql, this._metadata, this._query)
       : this;
+
+    // Field literal's sub-dimensions sometimes don't have a specified base-type
+    // This can break a query, so here we need to ensure it mirrors the parent dimension
+    if (this.getOption("base-type") && !dimension.getOption("base-type")) {
+      dimension = dimension.withOption(
+        "base-type",
+        this.getOption("base-type"),
+      );
+    }
 
     if (!dimension) {
       console.warn(

--- a/frontend/src/metabase-lib/lib/queries/StructuredQuery.js
+++ b/frontend/src/metabase-lib/lib/queries/StructuredQuery.js
@@ -316,7 +316,19 @@ export default class StructuredQuery extends AtomicQuery {
         metrics: [],
       });
     } else {
-      return this.metadata().table(this.sourceTableId());
+      const metadata = this.metadata();
+      const table = metadata.table(this.sourceTableId());
+      return new Table({
+        ...table,
+        db: table.db,
+        fields: table.fields.map(
+          field =>
+            new Field({
+              ...metadata.field(field.id),
+              query: this,
+            }),
+        ),
+      });
     }
   }
 

--- a/frontend/src/metabase-lib/lib/queries/StructuredQuery.js
+++ b/frontend/src/metabase-lib/lib/queries/StructuredQuery.js
@@ -294,7 +294,7 @@ export default class StructuredQuery extends AtomicQuery {
    * @returns the table object, if a table is selected and loaded.
    */
   @memoize
-  table(): Table {
+  table(boundQuery = this): Table {
     const sourceQuery = this.sourceQuery();
     if (sourceQuery) {
       return new Table({
@@ -328,7 +328,11 @@ export default class StructuredQuery extends AtomicQuery {
         field =>
           new Field({
             ...metadata.field(field.id),
-            query: this,
+            // Need to pass the query here, so some fields can access their metadata from `results_metadata`
+            // (see FieldDimension.prototype.field implementation)
+            // Usually it would just pass `this`, but when accessing joined query / table,
+            // we want to bind the fields to the top-level query to preserve join aliases
+            query: boundQuery,
           }),
       ),
     });

--- a/frontend/src/metabase-lib/lib/queries/StructuredQuery.js
+++ b/frontend/src/metabase-lib/lib/queries/StructuredQuery.js
@@ -315,21 +315,23 @@ export default class StructuredQuery extends AtomicQuery {
         segments: [],
         metrics: [],
       });
-    } else {
-      const metadata = this.metadata();
-      const table = metadata.table(this.sourceTableId());
-      return new Table({
-        ...table,
-        db: table.db,
-        fields: table.fields.map(
-          field =>
-            new Field({
-              ...metadata.field(field.id),
-              query: this,
-            }),
-        ),
-      });
     }
+    const metadata = this.metadata();
+    const table = metadata.table(this.sourceTableId());
+    if (!table) {
+      return null;
+    }
+    return new Table({
+      ...table,
+      db: table.db,
+      fields: table.fields.map(
+        field =>
+          new Field({
+            ...metadata.field(field.id),
+            query: this,
+          }),
+      ),
+    });
   }
 
   /**

--- a/frontend/src/metabase-lib/lib/queries/structured/Join.js
+++ b/frontend/src/metabase-lib/lib/queries/structured/Join.js
@@ -504,7 +504,7 @@ export default class Join extends MBQLObjectClause {
   }
   joinedTable() {
     const joinedQuery = this.joinedQuery();
-    return joinedQuery && joinedQuery.table();
+    return joinedQuery && joinedQuery.table(this.query());
   }
   parentQuery() {
     return this.query();

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -461,9 +461,10 @@ function JoinTypePicker({ join, color, updateQuery }) {
           <JoinStrategyIcon
             tooltip={t`Change join type`}
             name={strategyOption.icon}
+            data-testid="join-strategy-control"
           />
         ) : (
-          <NotebookCellItem color={color}>
+          <NotebookCellItem color={color} data-testid="join-strategy-control">
             {`Choose a join type`}
           </NotebookCellItem>
         )

--- a/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
@@ -6,6 +6,7 @@ import {
   visitQuestionAdhoc,
   changeBinningForDimension,
   getBinningButtonForDimension,
+  getNotebookStep,
 } from "__support__/e2e/cypress";
 import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
 
@@ -191,9 +192,7 @@ describe("binning related reproductions", () => {
       cy.findByText("18646").click();
     });
 
-    popover()
-      .findByText("Product ID")
-      .click();
+    selectFromDropdown("Created At");
 
     popover().within(() => {
       cy.findByText("CREATED_AT")
@@ -201,6 +200,18 @@ describe("binning related reproductions", () => {
         .findByText("by month")
         .click({ force: true });
     });
+
+    cy.findByText("Day").click();
+
+    // Joining on ID too to speed up query
+    getNotebookStep("join").within(() => {
+      cy.icon("add").click();
+    });
+    selectFromDropdown("Product ID");
+    selectFromDropdown("ID");
+
+    cy.findByTestId("join-strategy-control").click();
+    selectFromDropdown("Inner join");
 
     cy.findByText("Pick the metric you want to see").click();
     cy.findByText("Count of rows").click();
@@ -213,6 +224,9 @@ describe("binning related reproductions", () => {
         .closest(".List-item")
         .findByText("by month");
     });
+
+    visualize();
+    cy.get(".ScalarValue").contains("16");
   });
 
   describe("binning should work on nested question based on question that has aggregation (metabase#16379)", () => {
@@ -333,4 +347,10 @@ function openSummarizeOptions(questionType) {
   cy.findByText("Saved Questions").click();
   cy.findByText("16379").click();
   cy.findByText("Summarize").click();
+}
+
+function selectFromDropdown(optionName) {
+  popover()
+    .findByText(optionName)
+    .click();
 }

--- a/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
@@ -169,7 +169,7 @@ describe("binning related reproductions", () => {
     cy.findByText("CREATED_AT");
   });
 
-  it.skip("should render binning options when joining on the saved native question (metabase#18646)", () => {
+  it("should render binning options when joining on the saved native question (metabase#18646)", () => {
     cy.createNativeQuestion(
       {
         name: "18646",

--- a/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
@@ -170,7 +170,7 @@ describe("binning related reproductions", () => {
     cy.findByText("CREATED_AT");
   });
 
-  it("should render binning options when joining on the saved native question (metabase#18646)", () => {
+  it("should render binning and temporal unit options when joining on the saved native question (metabase#18646)", () => {
     cy.createNativeQuestion(
       {
         name: "18646",

--- a/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
@@ -195,6 +195,14 @@ describe("binning related reproductions", () => {
     selectFromDropdown("Created At");
 
     popover().within(() => {
+      // Ensure binning options are hidden
+      // https://github.com/metabase/metabase/pull/18800
+      cy.findByText("PRICE")
+        .closest(".List-item")
+        .within(() => {
+          cy.findByTestId("dimension-list-item-binning").should("not.exist");
+        });
+
       cy.findByText("CREATED_AT")
         .closest(".List-item")
         .findByText("by month")
@@ -220,6 +228,14 @@ describe("binning related reproductions", () => {
     cy.findByText(/Question \d/).click();
 
     popover().within(() => {
+      cy.findByText("PRICE")
+        .closest(".List-item")
+        .within(() => {
+          cy.findByTestId("dimension-list-item-binning").findByText(
+            "Auto binned",
+          );
+        });
+
       cy.findByText("CREATED_AT")
         .closest(".List-item")
         .findByText("by month");

--- a/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
@@ -199,7 +199,7 @@ describe("binning related reproductions", () => {
       cy.findByText("CREATED_AT")
         .closest(".List-item")
         .findByText("by month")
-        .click();
+        .click({ force: true });
     });
 
     cy.findByText("Pick the metric you want to see").click();

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -328,7 +328,7 @@ describe("scenarios > question > notebook", () => {
       cy.icon("add_data").click();
       popover().within(() => {
         cy.get("[contenteditable='true']").type(
-          "[Question 5 → sum] / [Sum of Rating]",
+          "[Question 5 → Sum of Rating] / [Sum of Rating]",
         );
         cy.findByPlaceholderText("Something nice and descriptive")
           .click()


### PR DESCRIPTION
Fixes #18646: when joining a native question, it's impossible to:

* specify a temporal unit for date-time dimension when joining
* specify a temporal unit for date-time dimension when summarizing
* specify binning strategy when summarizing

Binning options and temporal units are retrieved from dimension's field dimension options list (`fieldDimension.field().dimension_options`). The problem is that for dimensions coming from a native question, some metadata like temporal units and binning options don't end up in the `field` object.

The field is generated in `FieldDimension's` `field` method [here](https://github.com/metabase/metabase/blob/13e9414b5ead9e3553b9a0b06237bfb24ec3ad33/frontend/src/metabase-lib/lib/Dimension.js#L547). Right now, reliable field info can only be obtained [if it's either a field reference](https://github.com/metabase/metabase/blob/13e9414b5ead9e3553b9a0b06237bfb24ec3ad33/frontend/src/metabase-lib/lib/Dimension.js#L548) (with numerical field ID) or [if a dimension is associated with a query](https://github.com/metabase/metabase/blob/13e9414b5ead9e3553b9a0b06237bfb24ec3ad33/frontend/src/metabase-lib/lib/Dimension.js#L581) (here). Dimensions coming from a native question use a field literal syntax, and unless they're bound to a query, [the field info ends up incomplete](https://github.com/metabase/metabase/blob/13e9414b5ead9e3553b9a0b06237bfb24ec3ad33/frontend/src/metabase-lib/lib/Dimension.js#L609). However, once a native question is selected for a join, the FE sends a request to `/api/table/$CARD_ID/query_metadata` endpoint and receives the needed metadata, but doesn't use it.

This PR extends `FieldDimension's` `field` method to use field metadata for dimensions coming from native questions (field literals)

### To Verify

1. Ask a question > Native Question > Sample Dataset. `select * from products` and save as "Native Products"
2. Ask a question > Custom Question > Sample Dataset > Orders
3. Join the "Native Products" question on `Product ID = ID`
4. Add another join conditions pair (click the plus icon near the `Product ID = ID` condition)
5. Selected Order's `Created At` column
6. Once a popover with a list of "Native Products" columns shows up, do the next:
    * hover the "PRICE" column, you shouldn't see any binning options on the right side (see #18800)
    * hover the "CREATED_AT" column, you should see "Month" temporal unit
    * click the "Month" option and select "Day"
7. Change join strategy to "Inner join"
9. Click the Group By step, click "Native Products" in the popover that appeared, and follow the next:
    * hover the "PRICE" column, you should be able to configure binning (it's only disabled in joins)
    * hover the "CREATED_AT" column, you should be able to select a temporal unit
    * close the popover without selecting anything
10. Click visualize, the query should work fine

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/140974961-d3390487-f3cc-4004-b6b4-59587835e7f5.mov

**After**

https://user-images.githubusercontent.com/17258145/140974982-82ee05ee-c5ee-49d5-b5f4-24778bb08ed4.mov
