### PR TITLE
Switch to Temurin official image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN INTERACTIVE=false CI=true MB_EDITION=$MB_EDITION bin/build
 ## Remember that this runner image needs to be the same as bin/docker/Dockerfile with the exception that this one grabs the
 ## jar from the previous stage rather than the local build
 
-FROM adoptopenjdk/openjdk11:alpine-jre as runner
+FROM eclipse-temurin:11.0.13_8-jre-alpine as runner
 
 ENV FC_LANG en-US LC_CTYPE en_US.UTF-8
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN INTERACTIVE=false CI=true MB_EDITION=$MB_EDITION bin/build
 ## Remember that this runner image needs to be the same as bin/docker/Dockerfile with the exception that this one grabs the
 ## jar from the previous stage rather than the local build
 
-FROM eclipse-temurin:11.0.13_8-jre-alpine as runner
+FROM eclipse-temurin:11-jre-alpine as runner
 
 ENV FC_LANG en-US LC_CTYPE en_US.UTF-8
 

--- a/bin/docker/Dockerfile
+++ b/bin/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11.0.13_8-jre-alpine
+FROM eclipse-temurin:11-jre-alpine
 
 ENV FC_LANG en-US LC_CTYPE en_US.UTF-8
 

--- a/bin/docker/Dockerfile
+++ b/bin/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11:alpine-jre
+FROM eclipse-temurin:11.0.13_8-jre-alpine
 
 ENV FC_LANG en-US LC_CTYPE en_US.UTF-8
 


### PR DESCRIPTION
A pure musl image for the release, no more musl and glibc mixed in the same image as we had before with adoptopenjdk