### PR TITLE
Nest qbnewb under /modal to allow for other modals

### DIFF
--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -402,7 +402,7 @@ export const UserApi = {
   // get:                         GET("/api/user/:userId"),
   update: PUT("/api/user/:id"),
   update_password: PUT("/api/user/:id/password"),
-  update_qbnewb: PUT("/api/user/:id/qbnewb"),
+  update_qbnewb: PUT("/api/user/:id/modal/qbnewb"),
   delete: DELETE("/api/user/:userId"),
   reactivate: PUT("/api/user/:userId/reactivate"),
   send_invite: POST("/api/user/:id/send_invite"),

--- a/frontend/test/__support__/e2e/commands/user/createUser.js
+++ b/frontend/test/__support__/e2e/commands/user/createUser.js
@@ -3,7 +3,7 @@ import { USERS } from "__support__/e2e/cypress_data";
 Cypress.Commands.add("createUserFromRawData", user => {
   return cy.request("POST", "/api/user", user).then(({ body }) => {
     // Dismiss `it's ok to play around` modal for the created user
-    cy.request("PUT", `/api/user/${body.id}/qbnewb`, {});
+    cy.request("PUT", `/api/user/${body.id}/modal/qbnewb`, {});
   });
 });
 

--- a/frontend/test/snapshot-creators/default.cy.snap.js
+++ b/frontend/test/snapshot-creators/default.cy.snap.js
@@ -48,7 +48,7 @@ describe("snapshots", () => {
       },
     );
     // Dismiss `it's ok to play around` modal for admin
-    cy.request("PUT", `/api/user/1/qbnewb`, {});
+    cy.request("PUT", `/api/user/1/modal/qbnewb`, {});
   }
 
   function updateSettings() {

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -9761,6 +9761,7 @@ databaseChangeLog:
               - column:
                   name: is_datasetnewb
                   type: boolean
+                  remarks: "Boolean flag to indicate if the dataset info modal has been dismissed."
                   defaultValueBoolean: true
                   constraints:
                     nullable: false

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -9748,6 +9748,22 @@ databaseChangeLog:
         - onFail: MARK_RAN
         - dbms:
             type: mysql,mariadb
+  - changeSet:
+      id: v42.00-065
+      author: dpsutton
+      comment: >-
+        Added 0.42.0 - Another modal dismissed state on user. Retaining the same suffix and boolean style to ease an
+        eventual migration.
+      changes:
+        - addColumn:
+            tableName: core_user
+            columns:
+              - column:
+                  name: is_datasetnewb
+                  type: boolean
+                  defaultValueBoolean: true
+                  constraints:
+                    nullable: false
 
 
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<

--- a/src/metabase/api/user.clj
+++ b/src/metabase/api/user.clj
@@ -306,10 +306,12 @@
   "Indicate that a user has been informed about the vast intricacies of 'the' Query Builder."
   [id modal]
   (check-self-or-superuser id)
-  (let [k (or (get {"qbnewb" :is_qbnewb} modal)
+  (let [k (or (get {"qbnewb"      :is_qbnewb
+                    "datasetnewb" :is_datasetnewb}
+                   modal)
               (throw (ex-info (tru "Unrecognized modal: {0}" modal)
                               {:modal modal
-                               :allowable-modals #{"qbnewb"}})))]
+                               :allowable-modals #{"qbnewb" "datasetnewb"}})))]
     (api/check-500 (db/update! User id, k false)))
   {:success true})
 

--- a/src/metabase/api/user.clj
+++ b/src/metabase/api/user.clj
@@ -302,11 +302,15 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 ;; TODO - This could be handled by PUT /api/user/:id, we don't need a separate endpoint
-(api/defendpoint PUT "/:id/qbnewb"
+(api/defendpoint PUT "/:id/modal/:modal"
   "Indicate that a user has been informed about the vast intricacies of 'the' Query Builder."
-  [id]
+  [id modal]
   (check-self-or-superuser id)
-  (api/check-500 (db/update! User id, :is_qbnewb false))
+  (let [k (or (get {"qbnewb" :is_qbnewb} modal)
+              (throw (ex-info (tru "Unrecognized modal: {0}" modal)
+                              {:modal modal
+                               :allowable-modals #{"qbnewb"}})))]
+    (api/check-500 (db/update! User id, k false)))
   {:success true})
 
 (api/defendpoint POST "/:id/send_invite"

--- a/test/metabase/api/user_test.clj
+++ b/test/metabase/api/user_test.clj
@@ -840,7 +840,7 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 (deftest update-qbnewb-test
-  (testing "PUT /api/user/:id/qbnewb"
+  (testing "PUT /api/user/:id/modal/qbnewb"
     (testing "Test that we can set the QB newb status of ourselves"
       (mt/with-temp User [{:keys [id]} {:first_name (mt/random-name)
                                         :last_name  (mt/random-name)
@@ -850,14 +850,14 @@
                      :password "def123"}]
           (testing "response"
             (is (= {:success true}
-                   (mt/client creds :put 200 (format "user/%d/qbnewb" id)))))
+                   (mt/client creds :put 200 (format "user/%d/modal/qbnewb" id)))))
           (testing "newb?"
             (is (= false
                    (db/select-one-field :is_qbnewb User, :id id)))))))
 
     (testing "shouldn't be allowed to set someone else's QB newb status"
       (is (= "You don't have permissions to do that."
-             (mt/user-http-request :rasta :put 403 (format "user/%d/qbnewb" (mt/user->id :trashbird))))))))
+             (mt/user-http-request :rasta :put 403 (format "user/%d/modal/qbnewb" (mt/user->id :trashbird))))))))
 
 (deftest send-invite-test
   (testing "POST /api/user/:id/send_invite"


### PR DESCRIPTION
- move the api from api/user/:id/qbnewb -> api/user/:id/modal/qbnewb to
allow for the upcoming new dismissable modal
- recognize api/user/:id/datasetnewb
