### PR TITLE
Skip flaky JoinStep tests

### DIFF
--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.unit.spec.js
@@ -17,10 +17,11 @@ import {
 } from "__support__/sample_dataset_fixture";
 import JoinStep from "./JoinStep";
 
-// Workaround for timeouts on CI
-jest.setTimeout(15000);
-
-describe("Notebook Editor > Join Step", () => {
+// These tests appeared to be flaky, so they're disabled for now
+// (timeouts on CI, with jest.setTimeout varying from 15 to 30 sec)
+// Most likely it'll become more reliable once we update the Popover component
+// which is heavily used in tests
+describe.skip("Notebook Editor > Join Step", () => {
   const TEST_QUERY = {
     type: "query",
     database: SAMPLE_DATASET.id,


### PR DESCRIPTION
Skips JoinStep unit tests until the better times.

Tried increasing jest timeout and manipulating various jest modes, but no luck there