### PR TITLE
Add `cloud-gateway-ips` setting

### DIFF
--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -458,9 +458,9 @@
                :body
                (json/parse-string keyword)
                :ip_addresses)
-           (catch clojure.lang.ExceptionInfo e
+           (catch Exception e
              (log/error e (trs "Error fetching Metabase Cloud gateway IP addresses:"))))))
-   :ttl/threshold (* 1000 60 5)))
+   :ttl/threshold (* 1000 60 60 24)))
 
 (defsetting cloud-gateway-ips
   (deferred-tru "Metabase Cloud gateway IP addresses, to configure connections to DBs behind firewalls")

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -452,15 +452,15 @@
 (def ^:private fetch-cloud-gateway-ips-fn
   (memoize/ttl
    (fn []
-     (when (premium-features/is-hosted?)
-       (try
-         (-> (http/get (cloud-gateway-ips-url))
-             :body
-             (json/parse-string keyword)
-             :ip_addresses)
-         (catch clojure.lang.ExceptionInfo e
-           (log/error e (trs "Error fetching Metabase Cloud gateway IP addresses:")
-                 :ttl/threshold (* 1000 60 5))))))))
+       (when (premium-features/is-hosted?)
+         (try
+           (-> (http/get (cloud-gateway-ips-url))
+               :body
+               (json/parse-string keyword)
+               :ip_addresses)
+           (catch clojure.lang.ExceptionInfo e
+             (log/error e (trs "Error fetching Metabase Cloud gateway IP addresses:"))))))
+   :ttl/threshold (* 1000 60 5)))
 
 (defsetting cloud-gateway-ips
   (deferred-tru "Metabase Cloud gateway IP addresses, to configure connections to DBs behind firewalls")

--- a/test/metabase/public_settings_test.clj
+++ b/test/metabase/public_settings_test.clj
@@ -1,5 +1,6 @@
 (ns metabase.public-settings-test
-  (:require [clojure.core.memoize :as memoize]
+  (:require [clj-http.fake :as http-fake]
+            [clojure.core.memoize :as memoize]
             [clojure.test :refer :all]
             [metabase.models.setting :as setting :refer [Setting]]
             [metabase.models.user :refer [User]]

--- a/test/metabase/public_settings_test.clj
+++ b/test/metabase/public_settings_test.clj
@@ -1,8 +1,10 @@
 (ns metabase.public-settings-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.core.memoize :as memoize]
+            [clojure.test :refer :all]
             [metabase.models.setting :as setting :refer [Setting]]
             [metabase.models.user :refer [User]]
             [metabase.public-settings :as public-settings]
+            [metabase.public-settings.premium-features :as premium-features]
             [metabase.test :as mt]
             [metabase.test.fixtures :as fixtures]
             [metabase.util.i18n :as i18n :refer [tru]]
@@ -201,3 +203,32 @@
                    (java-time/local-date-time instance-creation))))))
       (finally
         (db/update-where! Setting {:key "instance-creation"} :value original-value)))))
+
+(deftest cloud-gateway-ips-test
+  (with-redefs [premium-features/is-hosted? (constantly true)]
+    (testing "Setting calls Store URL to fetch IP addresses"
+      (memoize/memo-clear! @#'public-settings/fetch-cloud-gateway-ips-fn)
+      (http-fake/with-fake-routes-in-isolation
+        {{:address (public-settings/cloud-gateway-ips-url)}
+         (constantly {:status 200 :body "{\"ip_addresses\": [\"127.0.0.1\"]}"})}
+        (is (= ["127.0.0.1"] (public-settings/cloud-gateway-ips))))
+
+      (testing "Getter is memoized to avoid frequent HTTP calls"
+        (http-fake/with-fake-routes-in-isolation
+          {{:address (public-settings/cloud-gateway-ips-url)}
+           (constantly {:status 200 :body "{\"ip_addresses\": [\"0.0.0.0\"]}"})}
+          (is (= ["127.0.0.1"] (public-settings/cloud-gateway-ips))))))
+
+    (testing "Setting returns nil if URL is unreachable"
+      (memoize/memo-clear! @#'public-settings/fetch-cloud-gateway-ips-fn)
+      (http-fake/with-fake-routes-in-isolation
+        {{:address (public-settings/cloud-gateway-ips-url)}
+         (constantly {:status 500})}
+        (is (= nil (public-settings/cloud-gateway-ips))))))
+
+  (testing "Setting returns nil in self-hosted environments"
+    (memoize/memo-clear! @#'public-settings/fetch-cloud-gateway-ips-fn)
+    (http-fake/with-fake-routes-in-isolation
+      {{:address (public-settings/cloud-gateway-ips-url)}
+       (constantly {:status 200 :body "{\"ip_addresses\": [\"127.0.0.1\"]}"})}
+      (is (= nil (public-settings/cloud-gateway-ips))))))


### PR DESCRIPTION
Adds a new `cloud-gateway-ips` setting for cloud instances which fetches data from the following store endpoint which redirects to an s3 instance: https://store.metabase.com/static/cloud_gateways.json This will be displayed on the frontend during DB connection. HTTP call results are cached for 5 minutes to avoid frequent requests.

Product doc: https://www.notion.so/metabase/Make-IP-addresses-visible-for-firewall-Cloud-users-4153069c110140e9bd91a164da103584#602785381f30495a81ebb353e0d746ff