### PR TITLE
Disable these tests for Redshift, since they are consistently failing with Out of Memory errors

### DIFF
--- a/test/metabase/api/dataset_test.clj
+++ b/test/metabase/api/dataset_test.clj
@@ -387,7 +387,7 @@
             (is (= [nil nil 3 7562] (last rows)))))))))
 
 (deftest pivot-parameter-dataset-test
-  (mt/test-drivers (pivots/applicable-drivers)
+  (mt/test-drivers (disj (pivots/applicable-drivers) :redshift) ; disable on Redshift until #18834 is fixed
     (mt/dataset sample-dataset
       (testing "POST /api/dataset/pivot"
         (testing "Run a pivot table"

--- a/test/metabase/api/public_test.clj
+++ b/test/metabase/api/public_test.clj
@@ -1055,7 +1055,7 @@
   (str "public/pivot/dashboard/" (:public_uuid dash) "/card/" (u/the-id card)))
 
 (deftest pivot-public-dashcard-test
-  (mt/test-drivers (pivots/applicable-drivers)
+  (mt/test-drivers (disj (pivots/applicable-drivers) :redshift) ; disable on Redshift until #18834 is fixed
     (mt/dataset sample-dataset
       (let [dashboard-defaults {:parameters [{:id      "_STATE_"
                                               :name    "State"


### PR DESCRIPTION
* `pivot-parameter-dataset-test`
* `pivot-public-dashcard-test`

Re-enable if/when #18834 is resolved