### PR TITLE
Fix issue with moment locale not working

### DIFF
--- a/frontend/src/metabase/lib/i18n.js
+++ b/frontend/src/metabase/lib/i18n.js
@@ -91,10 +91,8 @@ function mapToMomentLocale(locale) {
   switch (locale) {
     case "zh-Hans":
       return "zh-cn";
-    case "zh-TW":
-      return "zh-tw";
     default:
-      return locale;
+      return locale.toLowerCase();
   }
 }
 

--- a/frontend/src/metabase/lib/i18n.js
+++ b/frontend/src/metabase/lib/i18n.js
@@ -87,7 +87,7 @@ function updateMomentLocale(locale) {
   moment.locale(momentLocale);
 }
 
-function mapToMomentLocale(locale) {
+function mapToMomentLocale(locale = "") {
   switch (locale) {
     case "zh-Hans":
       return "zh-cn";

--- a/frontend/src/metabase/lib/i18n.js
+++ b/frontend/src/metabase/lib/i18n.js
@@ -74,8 +74,15 @@ export function setLocalization(translationsObject) {
   // eslint-disable-next-line react-hooks/rules-of-hooks
   useLocale(locale);
 
-  moment.locale(mapToMomentLocale(locale));
+  updateMomentLocale(locale);
   updateMomentStartOfWeek(locale);
+}
+
+function updateMomentLocale(locale) {
+  const momentLocale = mapToMomentLocale(locale);
+  require("moment/locale/" + momentLocale);
+
+  moment.locale(mapToMomentLocale(momentLocale));
 }
 
 function mapToMomentLocale(locale) {

--- a/frontend/src/metabase/lib/i18n.js
+++ b/frontend/src/metabase/lib/i18n.js
@@ -74,8 +74,19 @@ export function setLocalization(translationsObject) {
   // eslint-disable-next-line react-hooks/rules-of-hooks
   useLocale(locale);
 
-  moment.locale(locale);
+  moment.locale(mapToMomentLocale(locale));
   updateMomentStartOfWeek(locale);
+}
+
+function mapToMomentLocale(locale) {
+  switch (locale) {
+    case "zh-Hans":
+      return "zh-cn";
+    case "zh-TW":
+      return "zh-tw";
+    default:
+      return locale;
+  }
 }
 
 // Format a fixed timestamp in local time to see if the current locale defaults

--- a/frontend/src/metabase/lib/i18n.js
+++ b/frontend/src/metabase/lib/i18n.js
@@ -80,9 +80,11 @@ export function setLocalization(translationsObject) {
 
 function updateMomentLocale(locale) {
   const momentLocale = mapToMomentLocale(locale);
-  require("moment/locale/" + momentLocale);
+  if (momentLocale !== "en") {
+    require("moment/locale/" + momentLocale);
+  }
 
-  moment.locale(mapToMomentLocale(momentLocale));
+  moment.locale(momentLocale);
 }
 
 function mapToMomentLocale(locale) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -131,7 +131,6 @@ const config = (module.exports = {
         process.env.MB_EDITION === "ee"
           ? ENTERPRISE_SRC_PATH + "/plugins"
           : SRC_PATH + "/lib/noop",
-      moment: __dirname + "/node_modules/moment/min/moment-with-locales.js",
     },
   },
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -131,6 +131,7 @@ const config = (module.exports = {
         process.env.MB_EDITION === "ee"
           ? ENTERPRISE_SRC_PATH + "/plugins"
           : SRC_PATH + "/lib/noop",
+      moment: __dirname + "/node_modules/moment/min/moment-with-locales.js",
     },
   },
 


### PR DESCRIPTION
Fixes #8964

Seems like we include moment locales in our bundle already as you can see the files in devtools with source maps but for whatever reason doing `moment.locale(momentLocale)` alone does not work. Adding an additional `require` for the specific locale file fixes things. I'm... not sure why.

![Screen Shot 2021-11-12 at 1 42 58 PM](https://user-images.githubusercontent.com/13057258/141539788-906bb671-100f-457f-ad73-297b3d788346.png)

