### PR TITLE
Put migrations in correct order to fix `check-migrations` script in CI 

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -9748,6 +9748,21 @@ databaseChangeLog:
         - onFail: MARK_RAN
         - dbms:
             type: mysql,mariadb
+
+  - changeSet:
+      id: v42.00-064
+      author: jeff303
+      comment: "Added 0.42.0 - fix type of query_cache.results on upgrade (in case changeSet 97 was run before #16095)"
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+      changes:
+        - modifyDataType:
+            tableName: query_cache
+            columnName: results
+            newDataType: longblob
+
   - changeSet:
       id: v42.00-065
       author: dpsutton
@@ -9765,20 +9780,6 @@ databaseChangeLog:
                   defaultValueBoolean: true
                   constraints:
                     nullable: false
-
-  - changeSet:
-      id: v42.00-064
-      author: jeff303
-      comment: "Added 0.42.0 - fix type of query_cache.results on upgrade (in case changeSet 97 was run before #16095)"
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: query_cache
-            columnName: results
-            newDataType: longblob
 
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 


### PR DESCRIPTION
The lint-migrations-file.sh script is failing on master because when v42.00-065 was added in #18926 it ended up being merged in before v42.00-064, so the IDs are now out of order. I've just swapped the order to fix this.