### PR TITLE
Cleanup QuestionDataSource and fix breadcrumb links issues

### DIFF
--- a/frontend/src/metabase/lib/saved-questions/saved-questions.js
+++ b/frontend/src/metabase/lib/saved-questions/saved-questions.js
@@ -29,6 +29,18 @@ export function getQuestionVirtualTableId(card) {
   return `card__${card.id}`;
 }
 
+export function isVirtualCardId(tableId) {
+  return typeof tableId === "string" && tableId.startsWith("card__");
+}
+
+export function getQuestionIdFromVirtualTableId(tableId) {
+  if (typeof tableId !== "string") {
+    return null;
+  }
+  const id = parseInt(tableId.replace("card__", ""));
+  return Number.isSafeInteger(id) ? id : null;
+}
+
 export function convertSavedQuestionToVirtualTable(card) {
   return {
     id: getQuestionVirtualTableId(card),

--- a/frontend/src/metabase/lib/saved-questions/saved-questions.unit.spec.js
+++ b/frontend/src/metabase/lib/saved-questions/saved-questions.unit.spec.js
@@ -3,6 +3,8 @@ import {
   getCollectionVirtualSchemaId,
   getCollectionVirtualSchemaName,
   getQuestionVirtualTableId,
+  isVirtualCardId,
+  getQuestionIdFromVirtualTableId,
   convertSavedQuestionToVirtualTable,
 } from "./saved-questions";
 
@@ -81,6 +83,57 @@ describe("saved question helpers", () => {
   describe("getQuestionVirtualTableId", () => {
     it("returns question prefixed question ID", () => {
       expect(getQuestionVirtualTableId({ id: 7 })).toBe("card__7");
+    });
+  });
+
+  describe("isVirtualCardId", () => {
+    it("should return true for virtual table ID", () => {
+      expect(isVirtualCardId("card__4")).toBe(true);
+    });
+
+    it("should return false for normal table ID", () => {
+      expect(isVirtualCardId(4)).toBe(false);
+    });
+
+    it("should return false for garbage", () => {
+      expect(isVirtualCardId()).toBe(false);
+      expect(isVirtualCardId(null)).toBe(false);
+      expect(isVirtualCardId(null)).toBe(false);
+      expect(isVirtualCardId(0)).toBe(false);
+      expect(isVirtualCardId(-1)).toBe(false);
+      expect(isVirtualCardId("1")).toBe(false);
+      expect(isVirtualCardId({ foo: "bar" })).toBe(false);
+    });
+  });
+
+  describe("getQuestionIdFromVirtualTableId", () => {
+    [
+      { tableId: "card__1", cardId: 1 },
+      { tableId: "card__234", cardId: 234 },
+    ].forEach(testCase => {
+      const { tableId, cardId } = testCase;
+      it(`should extract ID from virtual ID (${tableId})`, () => {
+        expect(getQuestionIdFromVirtualTableId(tableId)).toBe(cardId);
+      });
+    });
+
+    [
+      { id: undefined },
+      { id: null },
+      { id: 123 },
+      { id: true },
+      { id: { foo: "bar" } },
+    ].forEach(testCase => {
+      const { id } = testCase;
+      it(`should handle non string input (${id})`, () => {
+        expect(getQuestionIdFromVirtualTableId(id)).toBe(null);
+      });
+    });
+
+    ["card__", "card__test"].forEach(id => {
+      it(`should handle invalid ID ${id}`, () => {
+        expect(getQuestionIdFromVirtualTableId(id)).toBe(null);
+      });
     });
   });
 

--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -6,7 +6,10 @@ import { t } from "ttag";
 import cx from "classnames";
 import _ from "underscore";
 
-import { SAVED_QUESTIONS_VIRTUAL_DB_ID } from "metabase/lib/saved-questions";
+import {
+  isVirtualCardId,
+  SAVED_QUESTIONS_VIRTUAL_DB_ID,
+} from "metabase/lib/saved-questions";
 
 import ListSearchField from "metabase/components/ListSearchField";
 import ExternalLink from "metabase/components/ExternalLink";
@@ -25,7 +28,6 @@ import Search from "metabase/entities/search";
 import {
   SearchResults,
   convertSearchResultToTableLikeItem,
-  isSavedQuestion,
 } from "./data-search";
 import SavedQuestionPicker from "./saved-question-picker/SavedQuestionPicker";
 
@@ -429,7 +431,7 @@ export class UnconnectedDataSelector extends Component {
     const invalidTable =
       selectedSchema &&
       selectedTable &&
-      !isSavedQuestion(selectedTable.id) &&
+      !isVirtualCardId(selectedTable.id) &&
       selectedTable.schema.id !== selectedSchema.id;
     const invalidField =
       selectedTable &&
@@ -832,7 +834,7 @@ export class UnconnectedDataSelector extends Component {
     return null;
   }
 
-  isSavedQuestionSelected = () => isSavedQuestion(this.props.selectedTableId);
+  isSavedQuestionSelected = () => isVirtualCardId(this.props.selectedTableId);
 
   handleSavedQuestionSelect = async table => {
     if (this.props.setSourceTableFn) {

--- a/frontend/src/metabase/query_builder/components/data-search/utils.js
+++ b/frontend/src/metabase/query_builder/components/data-search/utils.js
@@ -1,4 +1,4 @@
-const SAVED_QUESTION_ID_PREFIX = "card__";
+import { getQuestionVirtualTableId } from "metabase/lib/saved-questions";
 
 export function convertSearchResultToTableLikeItem(searchResultItem) {
   // NOTE: in the entire application when we want to use saved questions as tables
@@ -9,15 +9,9 @@ export function convertSearchResultToTableLikeItem(searchResultItem) {
   ) {
     return {
       ...searchResultItem,
-      id: `${SAVED_QUESTION_ID_PREFIX}${searchResultItem.id}`,
+      id: getQuestionVirtualTableId(searchResultItem),
     };
   }
 
   return searchResultItem;
-}
-
-export function isSavedQuestion(tableId) {
-  return (
-    typeof tableId === "string" && tableId.startsWith(SAVED_QUESTION_ID_PREFIX)
-  );
 }

--- a/frontend/src/metabase/query_builder/components/view/HeaderBreadcrumbs/HeaderBreadcrumbs.jsx
+++ b/frontend/src/metabase/query_builder/components/view/HeaderBreadcrumbs/HeaderBreadcrumbs.jsx
@@ -26,18 +26,12 @@ export function HeadBreadcrumbs({
     <Container {...props} variant={variant}>
       {parts.map((part, index) => {
         const isLast = index === parts.length - 1;
-        const inactiveColor =
-          isLast && variant === "head" ? "text-dark" : "text-light";
         return (
           <React.Fragment key={index}>
             {React.isValidElement(part) ? (
               part
             ) : (
-              <HeaderBadge
-                to={part.href}
-                icon={part.icon}
-                inactiveColor={inactiveColor}
-              >
+              <HeaderBadge to={part.href} icon={part.icon}>
                 {part.name}
               </HeaderBadge>
             )}

--- a/frontend/src/metabase/query_builder/components/view/HeaderBreadcrumbs/HeaderBreadcrumbs.jsx
+++ b/frontend/src/metabase/query_builder/components/view/HeaderBreadcrumbs/HeaderBreadcrumbs.jsx
@@ -13,25 +13,37 @@ const partPropType = PropTypes.oneOfType([crumbShape, PropTypes.node]);
 HeadBreadcrumbs.propTypes = {
   variant: PropTypes.oneOf(["head", "subhead"]),
   parts: PropTypes.arrayOf(partPropType).isRequired,
+  inactiveColor: PropTypes.string,
   divider: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
 };
+
+function getBadgeInactiveColor({ variant, isLast }) {
+  return isLast && variant === "head" ? "text-dark" : "text-light";
+}
 
 export function HeadBreadcrumbs({
   variant = "head",
   parts,
   divider,
+  inactiveColor,
   ...props
 }) {
   return (
     <Container {...props} variant={variant}>
       {parts.map((part, index) => {
         const isLast = index === parts.length - 1;
+        const badgeInactiveColor =
+          inactiveColor || getBadgeInactiveColor({ variant, isLast });
         return (
           <React.Fragment key={index}>
             {React.isValidElement(part) ? (
               part
             ) : (
-              <HeaderBadge to={part.href} icon={part.icon}>
+              <HeaderBadge
+                to={part.href}
+                icon={part.icon}
+                inactiveColor={badgeInactiveColor}
+              >
                 {part.name}
               </HeaderBadge>
             )}

--- a/frontend/src/metabase/query_builder/components/view/HeaderBreadcrumbs/HeaderBreadcrumbs.jsx
+++ b/frontend/src/metabase/query_builder/components/view/HeaderBreadcrumbs/HeaderBreadcrumbs.jsx
@@ -13,9 +13,15 @@ const partPropType = PropTypes.oneOfType([crumbShape, PropTypes.node]);
 HeadBreadcrumbs.propTypes = {
   variant: PropTypes.oneOf(["head", "subhead"]),
   parts: PropTypes.arrayOf(partPropType).isRequired,
+  divider: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
 };
 
-export function HeadBreadcrumbs({ variant = "head", parts, ...props }) {
+export function HeadBreadcrumbs({
+  variant = "head",
+  parts,
+  divider,
+  ...props
+}) {
   return (
     <Container {...props} variant={variant}>
       {parts.map((part, index) => {
@@ -35,7 +41,12 @@ export function HeadBreadcrumbs({ variant = "head", parts, ...props }) {
                 {part.name}
               </HeaderBadge>
             )}
-            {!isLast && <Divider />}
+            {!isLast &&
+              (React.isValidElement(divider) ? (
+                divider
+              ) : (
+                <Divider char={divider} />
+              ))}
           </React.Fragment>
         );
       })}

--- a/frontend/src/metabase/query_builder/components/view/HeaderBreadcrumbs/HeaderBreadcrumbs.jsx
+++ b/frontend/src/metabase/query_builder/components/view/HeaderBreadcrumbs/HeaderBreadcrumbs.jsx
@@ -8,24 +8,33 @@ const crumbShape = PropTypes.shape({
   href: PropTypes.string,
 });
 
+const partPropType = PropTypes.oneOfType([crumbShape, PropTypes.node]);
+
 HeadBreadcrumbs.propTypes = {
   variant: PropTypes.oneOf(["head", "subhead"]),
-  parts: PropTypes.arrayOf(crumbShape).isRequired,
+  parts: PropTypes.arrayOf(partPropType).isRequired,
 };
 
 export function HeadBreadcrumbs({ variant = "head", parts, ...props }) {
   return (
     <Container {...props} variant={variant}>
       {parts.map((part, index) => {
-        const { name, icon, href } = part;
         const isLast = index === parts.length - 1;
         const inactiveColor =
           isLast && variant === "head" ? "text-dark" : "text-light";
         return (
           <React.Fragment key={index}>
-            <HeaderBadge to={href} icon={icon} inactiveColor={inactiveColor}>
-              {name}
-            </HeaderBadge>
+            {React.isValidElement(part) ? (
+              part
+            ) : (
+              <HeaderBadge
+                to={part.href}
+                icon={part.icon}
+                inactiveColor={inactiveColor}
+              >
+                {part.name}
+              </HeaderBadge>
+            )}
             {!isLast && <Divider />}
           </React.Fragment>
         );
@@ -33,3 +42,5 @@ export function HeadBreadcrumbs({ variant = "head", parts, ...props }) {
     </Container>
   );
 }
+
+HeadBreadcrumbs.Badge = HeaderBadge;

--- a/frontend/src/metabase/query_builder/components/view/HeaderBreadcrumbs/HeaderBreadcrumbs.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/view/HeaderBreadcrumbs/HeaderBreadcrumbs.styled.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import styled, { css } from "styled-components";
 import Badge from "metabase/components/Badge";
 import { color } from "metabase/lib/colors";
@@ -34,6 +35,10 @@ const DividerSpan = styled.span`
   user-select: none;
 `;
 
-export function Divider() {
-  return <DividerSpan>/</DividerSpan>;
+Divider.propTypes = {
+  char: PropTypes.string,
+};
+
+export function Divider({ char = "/" }) {
+  return <DividerSpan>{char}</DividerSpan>;
 }

--- a/frontend/src/metabase/query_builder/components/view/HeaderBreadcrumbs/HeaderBreadcrumbs.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/view/HeaderBreadcrumbs/HeaderBreadcrumbs.styled.jsx
@@ -3,23 +3,25 @@ import styled, { css } from "styled-components";
 import Badge from "metabase/components/Badge";
 import { color } from "metabase/lib/colors";
 
-export const Container = styled.span`
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-
-  ${props =>
-    props.variant === "head" &&
-    css`
-      font-size: 1.25rem;
-    `}
-`;
-
 export const HeaderBadge = styled(Badge)`
   .Icon {
     width: 1em;
     height: 1em;
     margin-right: 0.5em;
+  }
+`;
+
+export const Container = styled.span`
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+
+  ${HeaderBadge} {
+    ${props =>
+      props.variant === "head" &&
+      css`
+        font-size: 1.25rem;
+      `}
   }
 `;
 

--- a/frontend/src/metabase/query_builder/components/view/HeaderBreadcrumbs/HeaderBreadcrumbs.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/view/HeaderBreadcrumbs/HeaderBreadcrumbs.styled.jsx
@@ -18,24 +18,10 @@ export const Container = styled.span`
   flex-wrap: wrap;
 
   ${HeaderBadge} {
-    color: ${color("text-light")};
-
-    :hover {
-      color: ${color("brand")};
-    }
-
     ${props =>
       props.variant === "head" &&
       css`
         font-size: 1.25rem;
-      `}
-  }
-
-  ${HeaderBadge} :last-child {
-    ${props =>
-      props.variant === "head" &&
-      css`
-        color: ${color("text-dark")};
       `}
   }
 `;

--- a/frontend/src/metabase/query_builder/components/view/HeaderBreadcrumbs/HeaderBreadcrumbs.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/view/HeaderBreadcrumbs/HeaderBreadcrumbs.styled.jsx
@@ -18,10 +18,24 @@ export const Container = styled.span`
   flex-wrap: wrap;
 
   ${HeaderBadge} {
+    color: ${color("text-light")};
+
+    :hover {
+      color: ${color("brand")};
+    }
+
     ${props =>
       props.variant === "head" &&
       css`
         font-size: 1.25rem;
+      `}
+  }
+
+  ${HeaderBadge} :last-child {
+    ${props =>
+      props.variant === "head" &&
+      css`
+        color: ${color("text-dark")};
       `}
   }
 `;

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
@@ -1,5 +1,9 @@
 import React from "react";
 import PropTypes from "prop-types";
+import {
+  isVirtualCardId,
+  getQuestionIdFromVirtualTableId,
+} from "metabase/lib/saved-questions";
 import * as Urls from "metabase/lib/urls";
 import { HeadBreadcrumbs } from "./HeaderBreadcrumbs";
 import { TablesDivider } from "./QuestionDataSource.styled";
@@ -62,7 +66,7 @@ function getDataSourceParts({ question, subHead, isObjectDetail }) {
     if (!isStructuredQuery) {
       return {
         name: table.displayName(),
-        link: hasTableLink ? table.newQuestion().getUrl() : "",
+        link: hasTableLink ? getTableURL() : "",
       };
     }
 
@@ -101,7 +105,7 @@ function QuestionTableBadges({ tables, subHead, hasLink }) {
   const parts = tables.map(table => (
     <HeadBreadcrumbs.Badge
       key={table.id}
-      to={hasLink ? table.newQuestion().getUrl() : ""}
+      to={hasLink ? getTableURL(table) : ""}
     >
       {table.displayName()}
     </HeadBreadcrumbs.Badge>
@@ -114,6 +118,14 @@ function QuestionTableBadges({ tables, subHead, hasLink }) {
       divider={<TablesDivider>+</TablesDivider>}
     />
   );
+}
+
+function getTableURL(table) {
+  if (isVirtualCardId(table.id)) {
+    const cardId = getQuestionIdFromVirtualTableId(table.id);
+    return Urls.question({ id: cardId, name: table.displayName() });
+  }
+  return table.newQuestion().getUrl();
 }
 
 export default QuestionDataSource;

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
@@ -6,14 +6,12 @@ import { HeadBreadcrumbs } from "./HeaderBreadcrumbs";
 const QuestionDataSource = ({
   question,
   subHead,
-  noLink,
   isObjectDetail,
   ...props
 }) => {
   const parts = getDataSourceParts({
     question,
     subHead,
-    noLink,
     isObjectDetail,
   });
   return (
@@ -28,7 +26,7 @@ const QuestionDataSource = ({
 QuestionDataSource.shouldRender = ({ question, isObjectDetail }) =>
   getDataSourceParts({ question, isObjectDetail }).length > 0;
 
-function getDataSourceParts({ question, noLink, subHead, isObjectDetail }) {
+function getDataSourceParts({ question, subHead, isObjectDetail }) {
   if (!question) {
     return [];
   }
@@ -47,7 +45,7 @@ function getDataSourceParts({ question, noLink, subHead, isObjectDetail }) {
     parts.push({
       icon: "database",
       name: database.displayName(),
-      href: !noLink && database.id >= 0 && browseDatabase(database),
+      href: database.id >= 0 && browseDatabase(database),
     });
   }
 
@@ -55,7 +53,7 @@ function getDataSourceParts({ question, noLink, subHead, isObjectDetail }) {
   if (table && table.hasSchema()) {
     parts.push({
       name: table.schema_name,
-      href: !noLink && database.id >= 0 && browseSchema(table),
+      href: database.id >= 0 && browseSchema(table),
     });
   }
 
@@ -73,8 +71,7 @@ function getDataSourceParts({ question, noLink, subHead, isObjectDetail }) {
     }
     parts.push({
       name: name,
-      href:
-        !noLink && (subHead || isObjectDetail) && table.newQuestion().getUrl(),
+      href: (subHead || isObjectDetail) && table.newQuestion().getUrl(),
     });
   }
 

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
@@ -34,12 +34,10 @@ function getDataSourceParts({ question, subHead, isObjectDetail }) {
 
   const parts = [];
 
-  let query = question.query();
   const isStructuredQuery = question.isStructured();
-
-  if (isStructuredQuery) {
-    query = query.rootQuery();
-  }
+  const query = isStructuredQuery
+    ? question.query().rootQuery()
+    : question.query();
 
   const database = query.database();
   if (database) {

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
@@ -83,6 +83,7 @@ function getDataSourceParts({ question, subHead, isObjectDetail }) {
         tables={allTables}
         subHead={subHead}
         hasLink={hasTableLink}
+        isLast={!isObjectDetail}
       />,
     );
   }
@@ -102,13 +103,17 @@ QuestionTableBadges.propTypes = {
   tables: PropTypes.arrayOf(PropTypes.object).isRequired,
   hasLink: PropTypes.bool,
   subHead: PropTypes.bool,
+  isLast: PropTypes.bool,
 };
 
-function QuestionTableBadges({ tables, subHead, hasLink }) {
+function QuestionTableBadges({ tables, subHead, hasLink, isLast }) {
+  const badgeInactiveColor = isLast && !subHead ? "text-dark" : "text-light";
+
   const parts = tables.map(table => (
     <HeadBreadcrumbs.Badge
       key={table.id}
       to={hasLink ? getTableURL(table) : ""}
+      inactiveColor={badgeInactiveColor}
     >
       {table.displayName()}
     </HeadBreadcrumbs.Badge>

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
@@ -119,6 +119,7 @@ function QuestionTableBadges({ tables, subHead, hasLink }) {
       parts={parts}
       variant={subHead ? "subhead" : "head"}
       divider={<TablesDivider>+</TablesDivider>}
+      data-testid="question-table-badges"
     />
   );
 }

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
@@ -1,7 +1,13 @@
-/* eslint-disable react/prop-types */
 import React from "react";
+import PropTypes from "prop-types";
 import * as Urls from "metabase/lib/urls";
 import { HeadBreadcrumbs } from "./HeaderBreadcrumbs";
+
+QuestionDataSource.propTypes = {
+  question: PropTypes.object,
+  subHead: PropTypes.bool,
+  isObjectDetail: PropTypes.bool,
+};
 
 function QuestionDataSource({ question, subHead, isObjectDetail, ...props }) {
   const parts = getDataSourceParts({

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 import React from "react";
-import { browseDatabase, browseSchema } from "metabase/lib/urls";
+import * as Urls from "metabase/lib/urls";
 import { HeadBreadcrumbs } from "./HeaderBreadcrumbs";
 
 const QuestionDataSource = ({
@@ -45,7 +45,7 @@ function getDataSourceParts({ question, subHead, isObjectDetail }) {
     parts.push({
       icon: "database",
       name: database.displayName(),
-      href: database.id >= 0 && browseDatabase(database),
+      href: database.id >= 0 && Urls.browseDatabase(database),
     });
   }
 
@@ -53,7 +53,7 @@ function getDataSourceParts({ question, subHead, isObjectDetail }) {
   if (table && table.hasSchema()) {
     parts.push({
       name: table.schema_name,
-      href: database.id >= 0 && browseSchema(table),
+      href: database.id >= 0 && Urls.browseSchema(table),
     });
   }
 

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
@@ -3,12 +3,7 @@ import React from "react";
 import * as Urls from "metabase/lib/urls";
 import { HeadBreadcrumbs } from "./HeaderBreadcrumbs";
 
-const QuestionDataSource = ({
-  question,
-  subHead,
-  isObjectDetail,
-  ...props
-}) => {
+function QuestionDataSource({ question, subHead, isObjectDetail, ...props }) {
   const parts = getDataSourceParts({
     question,
     subHead,
@@ -21,7 +16,7 @@ const QuestionDataSource = ({
       {...props}
     />
   );
-};
+}
 
 QuestionDataSource.shouldRender = ({ question, isObjectDetail }) =>
   getDataSourceParts({ question, isObjectDetail }).length > 0;

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
@@ -55,10 +55,13 @@ function getDataSourceParts({ question, subHead, isObjectDetail }) {
 
   const table = query.table();
   if (table && table.hasSchema()) {
-    parts.push({
-      name: table.schema_name,
-      href: database.id >= 0 && Urls.browseSchema(table),
-    });
+    const isBasedOnSavedQuestion = isVirtualCardId(table.id);
+    if (!isBasedOnSavedQuestion) {
+      parts.push({
+        name: table.schema_name,
+        href: database.id >= 0 && Urls.browseSchema(table),
+      });
+    }
   }
 
   if (table) {

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSource.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSource.styled.jsx
@@ -1,0 +1,10 @@
+import styled from "styled-components";
+import { color } from "metabase/lib/colors";
+
+export const TablesDivider = styled.span`
+  color: ${color("text-light")};
+  font-size: 1em;
+  font-weight: bold;
+  padding: 0 0.2em;
+  user-select: none;
+`;

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSource.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSource.unit.spec.js
@@ -327,10 +327,22 @@ describe("QuestionDataSource", () => {
       const { question, questionType } = testCase;
 
       describe(questionType, () => {
-        it("displays 2 joined tables", () => {
-          setup({ question });
-          expect(screen.queryByText(/Orders/)).toBeInTheDocument();
-          expect(screen.queryByText(/Products/)).toBeInTheDocument();
+        it("displays 2 joined tables (metabase#17961)", () => {
+          setup({ question, subHead: true });
+
+          const orders = screen.queryByText(/Orders/);
+          const products = screen.queryByText(/Products/);
+
+          expect(orders).toBeInTheDocument();
+          expect(orders.closest("a")).toHaveAttribute(
+            "href",
+            ORDERS.newQuestion().getUrl(),
+          );
+          expect(products).toBeInTheDocument();
+          expect(products.closest("a")).toHaveAttribute(
+            "href",
+            PRODUCTS.newQuestion().getUrl(),
+          );
         });
       });
     });
@@ -342,11 +354,28 @@ describe("QuestionDataSource", () => {
       const { question, questionType } = testCase;
 
       describe(questionType, () => {
-        it("displays > 2 joined tables", () => {
-          setup({ question });
-          expect(screen.queryByText(/Orders/)).toBeInTheDocument();
-          expect(screen.queryByText(/Products/)).toBeInTheDocument();
-          expect(screen.queryByText(/People/)).toBeInTheDocument();
+        it("displays > 2 joined tables (metabase#17961)", () => {
+          setup({ question, subHead: true });
+
+          const orders = screen.queryByText(/Orders/);
+          const products = screen.queryByText(/Products/);
+          const people = screen.queryByText(/People/);
+
+          expect(orders).toBeInTheDocument();
+          expect(orders.closest("a")).toHaveAttribute(
+            "href",
+            ORDERS.newQuestion().getUrl(),
+          );
+          expect(products).toBeInTheDocument();
+          expect(products.closest("a")).toHaveAttribute(
+            "href",
+            PRODUCTS.newQuestion().getUrl(),
+          );
+          expect(people).toBeInTheDocument();
+          expect(people.closest("a")).toHaveAttribute(
+            "href",
+            PEOPLE.newQuestion().getUrl(),
+          );
         });
       });
     });

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSource.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSource.unit.spec.js
@@ -1,0 +1,371 @@
+/* eslint-disable react/display-name, react/prop-types */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import {
+  SAMPLE_DATASET,
+  MULTI_SCHEMA_DATABASE,
+  ORDERS,
+  PRODUCTS,
+  PEOPLE,
+  metadata,
+} from "__support__/sample_dataset_fixture";
+import Question from "metabase-lib/lib/Question";
+import * as Urls from "metabase/lib/urls";
+import QuestionDataSource from "./QuestionDataSource";
+
+const BASE_GUI_QUESTION = {
+  display: "table",
+  visualization_settings: {},
+  dataset_query: {
+    type: "query",
+    database: SAMPLE_DATASET.id,
+    query: {
+      "source-table": ORDERS.id,
+    },
+  },
+};
+
+const BASE_NATIVE_QUESTION = {
+  display: "table",
+  visualization_settings: {},
+  dataset_query: {
+    type: "native",
+    database: SAMPLE_DATASET.id,
+    native: {
+      query: "select * from orders",
+    },
+  },
+};
+
+const SAVED_QUESTION = {
+  id: 1,
+  name: "Q1",
+  description: null,
+  collection_id: null,
+};
+
+const QUERY_IN_MULTI_SCHEMA_DB = {
+  type: "query",
+  database: MULTI_SCHEMA_DATABASE.id,
+  query: {
+    "source-table": MULTI_SCHEMA_DATABASE.tables[0].id,
+  },
+};
+
+// Joins
+
+const ORDERS_PRODUCT_JOIN_CONDITION = [
+  "=",
+  ["field", ORDERS.PRODUCT_ID.id, null],
+  ["field", PRODUCTS.ID.id, { "join-alias": "Products" }],
+];
+
+const ORDERS_PEOPLE_JOIN_CONDITION = [
+  "=",
+  ["field", ORDERS.USER_ID.id, null],
+  ["field", PEOPLE.ID.id, { "join-alias": "People" }],
+];
+
+const PRODUCTS_JOIN = {
+  alias: "Products",
+  condition: ORDERS_PRODUCT_JOIN_CONDITION,
+  "source-table": PRODUCTS.id,
+};
+
+const PEOPLE_JOIN = {
+  alias: "People",
+  condition: ORDERS_PEOPLE_JOIN_CONDITION,
+  "source-table": PEOPLE.id,
+};
+
+const QUERY_WITH_PRODUCTS_JOIN = {
+  type: "query",
+  database: SAMPLE_DATASET.id,
+  query: {
+    "source-table": ORDERS.id,
+    joins: [PRODUCTS_JOIN],
+  },
+};
+
+const QUERY_WITH_PRODUCTS_PEOPLE_JOIN = {
+  type: "query",
+  database: SAMPLE_DATASET.id,
+  query: {
+    "source-table": ORDERS.id,
+    joins: [PRODUCTS_JOIN, PEOPLE_JOIN],
+  },
+};
+
+// Filters
+
+const RANDOM_ORDER_ID = 155;
+const ORDERS_PK_FILTER = ["=", ["field", ORDERS.ID.id, null], RANDOM_ORDER_ID];
+
+const ORDER_DETAIL_QUERY = {
+  type: "query",
+  database: SAMPLE_DATASET.id,
+  query: {
+    "source-table": ORDERS.id,
+    filter: ["and", ORDERS_PK_FILTER],
+  },
+};
+
+// Factories
+
+function getQuestion(card) {
+  return new Question(card, metadata);
+}
+
+function getAdHocQuestion(overrides) {
+  return getQuestion({ ...BASE_GUI_QUESTION, ...overrides });
+}
+
+function getNativeQuestion() {
+  return getQuestion(BASE_NATIVE_QUESTION);
+}
+
+function getSavedGUIQuestion(overrides) {
+  return getQuestion({ ...BASE_GUI_QUESTION, ...SAVED_QUESTION, ...overrides });
+}
+
+function getSavedNativeQuestion(overrides) {
+  return getQuestion({
+    ...BASE_NATIVE_QUESTION,
+    ...SAVED_QUESTION,
+    ...overrides,
+  });
+}
+
+class ErrorBoundary extends React.Component {
+  componentDidCatch() {
+    this.props.onError();
+  }
+
+  render() {
+    return this.props.children;
+  }
+}
+
+function setup({ question, subHead = false, isObjectDetail = false } = {}) {
+  const onError = jest.fn();
+  render(
+    <ErrorBoundary onError={onError}>
+      <QuestionDataSource
+        question={question}
+        subHead={subHead}
+        isObjectDetail={isObjectDetail}
+      />
+    </ErrorBoundary>,
+  );
+  return { onError };
+}
+
+jest.mock("metabase/components/Link", () => ({ to: href, ...props }) => (
+  <a href={href} {...props} />
+));
+
+describe("QuestionDataSource", () => {
+  const GUI_TEST_CASE = {
+    SAVED_GUI_QUESTION: {
+      question: getSavedGUIQuestion(),
+      questionType: "saved GUI question",
+    },
+    AD_HOC_QUESTION: {
+      question: getAdHocQuestion(),
+      questionType: "ad-hoc GUI question",
+    },
+    SAVED_GUI_PRODUCTS_JOIN: {
+      question: getSavedGUIQuestion({
+        dataset_query: QUERY_WITH_PRODUCTS_JOIN,
+      }),
+      questionType: "saved GUI question joining a table",
+    },
+    AD_HOC_PRODUCTS_JOIN: {
+      question: getAdHocQuestion({ dataset_query: QUERY_WITH_PRODUCTS_JOIN }),
+      questionType: "ad-hoc GUI question joining a table",
+    },
+    SAVED_GUI_PRODUCTS_PEOPLE_JOIN: {
+      question: getSavedGUIQuestion({
+        dataset_query: QUERY_WITH_PRODUCTS_PEOPLE_JOIN,
+      }),
+      questionType: "saved GUI question joining a few tables",
+    },
+    AD_HOC_PRODUCTS_PEOPLE_JOIN: {
+      question: getAdHocQuestion({
+        dataset_query: QUERY_WITH_PRODUCTS_PEOPLE_JOIN,
+      }),
+      questionType: "ad-hoc GUI question joining a few tables",
+    },
+    SAVED_GUI_MULTI_SCHEMA_DB: {
+      question: getSavedGUIQuestion({
+        dataset_query: QUERY_IN_MULTI_SCHEMA_DB,
+      }),
+      questionType: "saved GUI question using multi-schema DB",
+    },
+    AD_HOC_MULTI_SCHEMA_DB: {
+      question: getAdHocQuestion({ dataset_query: QUERY_IN_MULTI_SCHEMA_DB }),
+      questionType: "ad-hoc GUI question using multi-schema DB",
+    },
+    SAVED_OBJECT_DETAIL: {
+      question: getSavedGUIQuestion({ dataset_query: ORDER_DETAIL_QUERY }),
+      questionType: "saved object detail",
+    },
+    AD_HOC_OBJECT_DETAIL: {
+      question: getAdHocQuestion({ dataset_query: ORDER_DETAIL_QUERY }),
+      questionType: "ad-hoc object detail",
+    },
+  };
+
+  const GUI_TEST_CASES = Object.values(GUI_TEST_CASE);
+  const ALL_TEST_CASES = [
+    ...GUI_TEST_CASES,
+    {
+      question: getNativeQuestion(),
+      questionType: "not saved native question",
+    },
+    {
+      question: getSavedNativeQuestion(),
+      questionType: "saved native question",
+    },
+  ];
+
+  it("does not fail if question is not passed", () => {
+    const { onError } = setup({ question: undefined });
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  describe("common", () => {
+    ALL_TEST_CASES.forEach(testCase => {
+      const { question, questionType } = testCase;
+
+      describe(questionType, () => {
+        it("displays database name", () => {
+          setup({ question });
+          const node = screen.queryByText(question.database().displayName());
+          expect(node).toBeInTheDocument();
+          expect(node.closest("a")).toHaveAttribute(
+            "href",
+            Urls.browseDatabase(question.database()),
+          );
+        });
+      });
+    });
+  });
+
+  describe("GUI", () => {
+    Object.values(GUI_TEST_CASE).forEach(testCase => {
+      const { question, questionType } = testCase;
+
+      describe(questionType, () => {
+        it("displays table name", () => {
+          setup({ question });
+          const node = screen.queryByText(
+            new RegExp(question.table().displayName()),
+          );
+          expect(node).toBeInTheDocument();
+          expect(node.closest("a")).not.toBeInTheDocument();
+        });
+
+        it("displays table link in subhead variant", () => {
+          setup({ question, subHead: true });
+          const node = screen.queryByText(
+            new RegExp(question.table().displayName()),
+          );
+          expect(node.closest("a")).toHaveAttribute(
+            "href",
+            question
+              .table()
+              .newQuestion()
+              .getUrl(),
+          );
+        });
+
+        it("displays table link in object detail view", () => {
+          setup({ question, isObjectDetail: true });
+          const node = screen.queryByText(
+            new RegExp(question.table().displayName()),
+          );
+          expect(node.closest("a")).toHaveAttribute(
+            "href",
+            question
+              .table()
+              .newQuestion()
+              .getUrl(),
+          );
+        });
+      });
+    });
+  });
+
+  describe("GUI with schema", () => {
+    [
+      GUI_TEST_CASE.SAVED_GUI_MULTI_SCHEMA_DB,
+      GUI_TEST_CASE.AD_HOC_MULTI_SCHEMA_DB,
+    ].forEach(testCase => {
+      const { question, questionType } = testCase;
+
+      describe(questionType, () => {
+        it("displays schema name", () => {
+          setup({ question });
+          const node = screen.queryByText(question.table().schema_name);
+          expect(node).toBeInTheDocument();
+          expect(node.closest("a")).toHaveAttribute(
+            "href",
+            Urls.browseSchema(question.table()),
+          );
+        });
+      });
+    });
+  });
+
+  describe("GUI with joins", () => {
+    [
+      GUI_TEST_CASE.SAVED_GUI_PRODUCTS_JOIN,
+      GUI_TEST_CASE.AD_HOC_PRODUCTS_JOIN,
+    ].forEach(testCase => {
+      const { question, questionType } = testCase;
+
+      describe(questionType, () => {
+        it("displays 2 joined tables", () => {
+          setup({ question });
+          expect(screen.queryByText(/Orders/)).toBeInTheDocument();
+          expect(screen.queryByText(/Products/)).toBeInTheDocument();
+        });
+      });
+    });
+
+    [
+      GUI_TEST_CASE.SAVED_GUI_PRODUCTS_PEOPLE_JOIN,
+      GUI_TEST_CASE.AD_HOC_PRODUCTS_PEOPLE_JOIN,
+    ].forEach(testCase => {
+      const { question, questionType } = testCase;
+
+      describe(questionType, () => {
+        it("displays > 2 joined tables", () => {
+          setup({ question });
+          expect(screen.queryByText(/Orders/)).toBeInTheDocument();
+          expect(screen.queryByText(/Products/)).toBeInTheDocument();
+          expect(screen.queryByText(/People/)).toBeInTheDocument();
+        });
+      });
+    });
+  });
+
+  describe("Object Detail", () => {
+    [
+      GUI_TEST_CASE.SAVED_OBJECT_DETAIL,
+      GUI_TEST_CASE.AD_HOC_OBJECT_DETAIL,
+    ].forEach(testCase => {
+      const { question, questionType } = testCase;
+
+      describe(questionType, () => {
+        it("displays object PK in object detail mode", () => {
+          setup({ question, isObjectDetail: true });
+          expect(
+            screen.queryByText(String(RANDOM_ORDER_ID)),
+          ).toBeInTheDocument();
+        });
+      });
+    });
+  });
+});

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSource.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSource.unit.spec.js
@@ -137,7 +137,8 @@ function getSavedNativeQuestion(overrides) {
 }
 
 class ErrorBoundary extends React.Component {
-  componentDidCatch() {
+  componentDidCatch(...args) {
+    console.error(...args);
     this.props.onError();
   }
 

--- a/frontend/test/metabase/scenarios/native/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/native.cy.spec.js
@@ -115,10 +115,6 @@ describe("scenarios > question > native", () => {
     cy.findByText("This has a value");
 
     FILTERS.forEach(filter => {
-      // Clicking on a question's name in UI resets previously applied filters
-      // We can ask variations of that question "on the fly"
-      cy.findByText(QUESTION).click();
-
       cy.log("Apply a filter");
       cy.findAllByText("Filter")
         .first()
@@ -148,6 +144,13 @@ describe("scenarios > question > native", () => {
         .click();
       cy.findByText("Done").click();
       cy.get(".ScalarValue").contains("1");
+
+      cy.icon("close").click();
+      cy.findAllByText("Summarize")
+        .first()
+        .click();
+      cy.icon("close").click();
+      cy.findByText("Done").click();
     });
   });
 

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -232,7 +232,11 @@ describe("scenarios > question > notebook", () => {
 
       visualize();
 
-      cy.contains("Orders + Reviews");
+      cy.findByTestId("question-table-badges").within(() => {
+        cy.findByText("Orders");
+        cy.findByText("Reviews");
+      });
+
       cy.contains("3");
     });
 
@@ -246,7 +250,11 @@ describe("scenarios > question > notebook", () => {
       cy.log("Join to People table using default settings");
       cy.icon("join_left_outer ").click();
       cy.contains("People").click();
-      cy.contains("Orders + People");
+
+      cy.findByTestId("question-table-badges").within(() => {
+        cy.findByText("Orders");
+        cy.findByText("People");
+      });
 
       visualize();
 
@@ -305,7 +313,11 @@ describe("scenarios > question > notebook", () => {
       visualize();
 
       // check that query worked
-      cy.findByText("question a + question b");
+
+      cy.findByTestId("question-table-badges").within(() => {
+        cy.findByText("question a");
+        cy.findByText("question b");
+      });
       cy.findByText("A_COLUMN");
       cy.findByText("Question 5 → B Column");
       cy.findByText("Showing 1 row");
@@ -462,7 +474,11 @@ describe("scenarios > question > notebook", () => {
 
       cy.log("Reported failing in v1.35.4.1 and `master` on July, 16 2020");
 
-      cy.findByText("12928_Q1 + 12928_Q2");
+      cy.findByTestId("question-table-badges").within(() => {
+        cy.findByText("12928_Q1");
+        cy.findByText("12928_Q2");
+      });
+
       cy.findAllByText(/Products? → Category/).should("have.length", 2);
     });
 


### PR DESCRIPTION
This PR refactors the `QuestionDataSource` component, fixes #12616, fixes #17961, and also increases the Simple Mode font size (was supposed to be shipped with #18903, but I broke it at some point). `QuestionDataSource` is used in the query builder header and displays breadcrumb links to question data sources (database, schema, table, join tables, source question, etc.)

### To Verify

**Breadcrumb path with multiple joined tables only has a single link to the first table #17961**

1. Ask a question > Custom Question > Sample Dataset > Orders
2. Join Products and People tables
3. Save the question, exit the notebook editor
4. You should see the "Orders + People + Products" label in the header breadcrumbs
5. Click every table name, it should open the clicked table

**Breadcrumb links not working correctly in Nested Questions #12616**

1. Create a question on a schema-based database (can be Simple or Native) - save as "Q1"
2. Simple question > Saved Questions > "Q1" - save as "Q2"
3. You should not see Q1's collection name in data source breadcrumbs, it should be "DB / Q1"
4. Click "Q1", you should be navigated to `/question/:id-q1` instead of an ad-hoc query based on Q1

### Demo

<details>
<summary>Breadcrumb path with multiple joined tables only has a single link to the first table</summary>

**Before**

https://user-images.githubusercontent.com/17258145/141514930-cfe9a14c-d2f1-4511-83cb-3221e330b68a.mov

**After**

https://user-images.githubusercontent.com/17258145/141514946-574ec03b-78db-4553-bc00-84aac74de7b5.mov

</details>

<details>
<summary>Breadcrumb links not working correctly in Nested Questions</summary>

**Before**

https://user-images.githubusercontent.com/17258145/141514988-17d409d8-d138-4615-90e8-7c10bfbb92ac.mov

**After**

https://user-images.githubusercontent.com/17258145/141514993-34633337-1981-46ce-9c66-b251221b3327.mov

</details>
