### PR TITLE
Dataset recent activity

### DIFF
--- a/test/metabase/api/activity_test.clj
+++ b/test/metabase/api/activity_test.clj
@@ -184,27 +184,32 @@
 
 (deftest referenced-objects->existing-objects-test
   (mt/with-temp Dashboard [{dashboard-id :id}]
-    (is (= {"dashboard" #{dashboard-id}, "card" nil}
+    (is (= {"dashboard" #{dashboard-id}}
            (#'activity-api/referenced-objects->existing-objects {"dashboard" #{dashboard-id 0}
                                                                  "card"      #{0}})))))
 (deftest add-model-exists-info-test
   (mt/with-temp* [Dashboard [{dashboard-id :id}]
-                  Card      [{card-id :id}]]
+                  Card      [{card-id :id}]
+                  Card      [{dataset-id :id} {:dataset true}]]
     (is (= [{:model "dashboard", :model_id dashboard-id, :model_exists true}
             {:model "card", :model_id 0, :model_exists false}
+            {:model "dataset", :model_id dataset-id, :model_exists true}
             {:model        "dashboard"
              :model_id     0
              :model_exists false
              :topic        :dashboard-remove-cards
              :details      {:dashcards [{:card_id card-id, :exists true}
-                                        {:card_id 0, :exists false}]}}]
+                                        {:card_id 0, :exists false}
+                                        {:card_id dataset-id, :exists true}]}}]
            (#'activity-api/add-model-exists-info [{:model "dashboard", :model_id dashboard-id}
                                                   {:model "card", :model_id 0}
+                                                  {:model "card", :model_id dataset-id}
                                                   {:model    "dashboard"
                                                    :model_id 0
                                                    :topic    :dashboard-remove-cards
                                                    :details  {:dashcards [{:card_id card-id}
-                                                                          {:card_id 0}]}}])))))
+                                                                          {:card_id 0}
+                                                                          {:card_id dataset-id}]}}])))))
 
 (deftest activity-visibility-test
   (mt/with-temp Activity [activity {:topic     "user-joined"

--- a/test/metabase/api/activity_test.clj
+++ b/test/metabase/api/activity_test.clj
@@ -108,11 +108,12 @@
                                     :description "rand-name"
                                     :creator_id  (mt/user->id :crowberto)}]
                   Table     [table1 {:name        "rand-name"}]
-                  Card      [card2 {:name                   "rand-name"
-                                    :creator_id             (mt/user->id :crowberto)
-                                    :display                "table"
-                                    :visualization_settings {}}]]
-    (create-view! (mt/user->id :crowberto) "card"      (:id card2))
+                  Card      [dataset {:name                   "rand-name"
+                                      :dataset                true
+                                      :creator_id             (mt/user->id :crowberto)
+                                      :display                "table"
+                                      :visualization_settings {}}]]
+    (create-view! (mt/user->id :crowberto) "card"      (:id dataset))
     (create-view! (mt/user->id :crowberto) "dashboard" (:id dash1))
     (create-view! (mt/user->id :crowberto) "card"      (:id card1))
     (create-view! (mt/user->id :crowberto) "card"      36478)
@@ -133,6 +134,7 @@
              :model_object {:id            (:id card1)
                             :name          (:name card1)
                             :collection_id nil
+                            :dataset       false
                             :description   (:description card1)
                             :display       (name (:display card1))}}
             {:cnt          1
@@ -145,13 +147,14 @@
                             :description   (:description dash1)}}
             {:cnt          1
              :user_id      (mt/user->id :crowberto)
-             :model        "card"
-             :model_id     (:id card2)
-             :model_object {:id            (:id card2)
-                            :name          (:name card2)
+             :model        "dataset"
+             :model_id     (:id dataset)
+             :model_object {:id            (:id dataset)
+                            :name          (:name dataset)
+                            :dataset       true
                             :collection_id nil
-                            :description   (:description card2)
-                            :display       (name (:display card2))}}]
+                            :description   (:description dataset)
+                            :display       (name (:display dataset))}}]
            (for [recent-view (mt/user-http-request :crowberto :get 200 "activity/recent_views")]
              (dissoc recent-view :max_ts))))))
 


### PR DESCRIPTION
Handle datasets in the recents api.

Need to handle two apis:
- /activity
- /activity/recent_views

Both require just some mechanical looking at cards and marking them as `:model "dataset"` when applicable.

There might be some weirdness in the activity list (`/activity`). This comes from the fact that cards _become_ datasets. Imagine activity of creating a card, and then editing a card. We don't track when something becomes a card so the activity for that entity would change to "create a dataset, edit a dataset, ..." even though those activities were originally on a dataset, not a card. Our current model doesn't really handle 