### PR TITLE
Custom expression tokenizer: rewind on an unterminated string literal

### DIFF
--- a/frontend/src/metabase/lib/expressions/tokenizer.js
+++ b/frontend/src/metabase/lib/expressions/tokenizer.js
@@ -215,10 +215,17 @@ export function tokenize(expression) {
       }
     }
     const type = TOKEN.String;
-    const end = index;
-    const terminated = quote === source[end - 1];
-    const error = terminated ? null : t`Missing closing quotes`;
-    return { type, value, start, end, error };
+    let error = null;
+
+    const terminated = quote === source[index - 1];
+    if (!terminated) {
+      // unterminated string, rewind after the opening quote
+      index = start + 1;
+      value = quote;
+      error = t`Missing closing quotes`;
+    }
+
+    return { type, value, start, end: index, error };
   };
 
   const scanBracketIdentifier = () => {

--- a/frontend/test/metabase/lib/expressions/completer.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/completer.unit.spec.js
@@ -22,8 +22,6 @@ describe("metabase/lib/expressions/completer", () => {
       expect(partialMatch("X OR")).toEqual(null);
       expect(partialMatch("42 +")).toEqual(null);
       expect(partialMatch("3.14")).toEqual(null);
-      expect(partialMatch('"Hello')).toEqual(null);
-      expect(partialMatch("'world")).toEqual(null);
     });
 
     it("should handle empty input", () => {

--- a/frontend/test/metabase/lib/expressions/tokenizer.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/tokenizer.unit.spec.js
@@ -66,6 +66,18 @@ describe("metabase/lib/expressions/tokenizer", () => {
     expect(errors('"double')[0].message).toEqual("Missing closing quotes");
   });
 
+  it("should continue to tokenize when encountering an unterminated string literal", () => {
+    expect(types("CONCAT(universe') = [answer]")).toEqual([
+      T.Identifier,
+      T.Operator,
+      T.Identifier,
+      T.String,
+      T.Operator,
+      T.Operator,
+      T.Identifier,
+    ]);
+  });
+
   it("should tokenize identifiers", () => {
     expect(types("Price")).toEqual([T.Identifier]);
     expect(types("Special_Deal")).toEqual([T.Identifier]);


### PR DESCRIPTION
As suggested by @akiselev, when a string literal is invalid because it does not have both enclosing single/double quotes, mark it as a invalid character and don't consume the rest of the expression, but rather, proceed to treat the rest of the expression after that dangling single/double quote as usual.

Ran the unit tests with:
```
yarn test-unit frontend/test/metabase/lib/expressions/tokenizer.unit.spec.js
```
and also verify visually:

1. Ask a question, Custom question
2. Sample Dataset, Products table
3. Filter, Custom Expression, type `contains([Category], gadget") AND [Rating] > 3`

Note that the (intentional) missing opening quote for the string `gadget`.

**Before this PR**

The rest of the expression is recognized as a string literal, hence the yellow highlighting.

![image](https://user-images.githubusercontent.com/7288/141540575-0876a9e7-1513-4b12-9a8b-0127d87aa007.png)


**After this PR**

The rest of the expression following that dangling `"` is still colored properly, `[Rating]` as a column name, `>` for the comparison operator, and `3` as a number.

![image](https://user-images.githubusercontent.com/7288/141540414-de2e9161-e110-4d6a-b340-300393d670c9.png)

