### PR TITLE
add input to dashboard single date filter

### DIFF
--- a/frontend/src/metabase/parameters/components/widgets/DateAllOptionsWidget.jsx
+++ b/frontend/src/metabase/parameters/components/widgets/DateAllOptionsWidget.jsx
@@ -15,6 +15,7 @@ import type {
   FieldFilter,
   LocalFieldReference,
 } from "metabase-types/types/Query";
+import { Container, Footer, UpdateButton } from "./DateWidget.styled";
 
 type UrlEncoded = string;
 
@@ -124,7 +125,7 @@ export default class DateAllOptionsWidget extends Component {
   render() {
     const { filter } = this.state;
     return (
-      <div style={{ minWidth: "300px" }}>
+      <Container>
         <DatePicker
           className="m2"
           filter={this.state.filter}
@@ -132,22 +133,22 @@ export default class DateAllOptionsWidget extends Component {
           hideEmptinessOperators
           hideTimeSelectors
         />
-        <div className="FilterPopover-footer border-top flex align-center p2">
+        <Footer>
           <FilterOptions
             filter={filter}
             onFilterChange={this.setFilter}
             operator={getOperator(filter)}
           />
-          <button
-            className={cx("Button Button--purple ml-auto", {
+          <UpdateButton
+            className={cx({
               disabled: !this.isValid(),
             })}
             onClick={this.commitAndClose}
           >
             {t`Update filter`}
-          </button>
-        </div>
-      </div>
+          </UpdateButton>
+        </Footer>
+      </Container>
     );
   }
 }

--- a/frontend/src/metabase/parameters/components/widgets/DateAllOptionsWidget.jsx
+++ b/frontend/src/metabase/parameters/components/widgets/DateAllOptionsWidget.jsx
@@ -77,6 +77,7 @@ function getFilterTitle(filter) {
 type Props = {
   setValue: (value: ?string) => void,
   onClose: () => void,
+  disableOperatorSelection: boolean,
 };
 
 type State = { filter: FieldFilter };
@@ -124,6 +125,7 @@ export default class DateAllOptionsWidget extends Component {
 
   render() {
     const { filter } = this.state;
+    const { disableOperatorSelection } = this.props;
     return (
       <Container>
         <DatePicker
@@ -132,6 +134,7 @@ export default class DateAllOptionsWidget extends Component {
           onFilterChange={this.setFilter}
           hideEmptinessOperators
           hideTimeSelectors
+          disableOperatorSelection={disableOperatorSelection}
         />
         <Footer>
           <FilterOptions

--- a/frontend/src/metabase/parameters/components/widgets/DateRangeWidget.jsx
+++ b/frontend/src/metabase/parameters/components/widgets/DateRangeWidget.jsx
@@ -1,7 +1,6 @@
-import React, { Component } from "react";
+import React from "react";
 import PropTypes from "prop-types";
-
-import Calendar from "metabase/components/Calendar";
+import DateAllOptionsWidget from "./DateAllOptionsWidget";
 import moment from "moment";
 
 const SEPARATOR = "~"; // URL-safe
@@ -10,52 +9,35 @@ function parseDateRangeValue(value) {
   const [start, end] = (value || "").split(SEPARATOR);
   return { start, end };
 }
-function serializeDateRangeValue({ start, end }) {
-  return [start, end].join(SEPARATOR);
+
+DateRangeWidget.propTypes = {
+  value: PropTypes.string,
+  setValue: PropTypes.func.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
+
+function DateRangeWidget({ value, ...props }) {
+  const defaultedValue =
+    value == null
+      ? `${moment().format("YYYY-MM-DD")}~${moment().format("YYYY-MM-DD")}`
+      : value;
+
+  return (
+    <DateAllOptionsWidget
+      {...props}
+      value={defaultedValue}
+      disableOperatorSelection
+    />
+  );
 }
 
-export default class DateRangeWidget extends Component {
-  constructor(props, context) {
-    super(props, context);
-    this.state = parseDateRangeValue(props.value);
-  }
+DateRangeWidget.format = value => {
+  const { start, end } = parseDateRangeValue(value);
+  return start && end
+    ? moment(start).format("MMMM D, YYYY") +
+        " - " +
+        moment(end).format("MMMM D, YYYY")
+    : "";
+};
 
-  static propTypes = {
-    value: PropTypes.string,
-    setValue: PropTypes.func.isRequired,
-  };
-  static defaultProps = {};
-
-  static format = value => {
-    const { start, end } = parseDateRangeValue(value);
-    return start && end
-      ? moment(start).format("MMMM D, YYYY") +
-          " - " +
-          moment(end).format("MMMM D, YYYY")
-      : "";
-  };
-
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    if (nextProps.value !== this.props.value) {
-      this.setState(parseDateRangeValue(nextProps.value));
-    }
-  }
-
-  render() {
-    const { start, end } = this.state;
-    return (
-      <Calendar
-        initial={start ? moment(start) : null}
-        selected={start ? moment(start) : null}
-        selectedEnd={end ? moment(end) : null}
-        onChange={(start, end) => {
-          if (end == null) {
-            this.setState({ start, end });
-          } else {
-            this.props.setValue(serializeDateRangeValue({ start, end }));
-          }
-        }}
-      />
-    );
-  }
-}
+export default DateRangeWidget;

--- a/frontend/src/metabase/parameters/components/widgets/DateSingleWidget.jsx
+++ b/frontend/src/metabase/parameters/components/widgets/DateSingleWidget.jsx
@@ -1,40 +1,22 @@
-import React, { useState } from "react";
+import React from "react";
 import PropTypes from "prop-types";
+import DateAllOptionsWidget from "./DateAllOptionsWidget";
 import moment from "moment";
-import { t } from "ttag";
-
-import {
-  Container,
-  Footer,
-  UpdateButton,
-  PaddedSpecificDatePicker,
-} from "./DateWidget.styled";
 
 DateSingleWidget.propTypes = {
-  value: PropTypes.any,
+  value: PropTypes.string,
   setValue: PropTypes.func.isRequired,
   onClose: PropTypes.func.isRequired,
 };
 
-function DateSingleWidget({ value, setValue, onClose }) {
-  const [internalValue, setInternalValue] = useState(value);
-  const commitAndClose = () => {
-    setValue(internalValue);
-    onClose();
-  };
-
+function DateSingleWidget({ value, ...props }) {
+  const defaultedValue = value == null ? moment().format("YYYY-MM-DD") : value;
   return (
-    <Container>
-      <PaddedSpecificDatePicker
-        value={internalValue}
-        onChange={setInternalValue}
-        calendar
-        hideTimeSelectors
-      />
-      <Footer>
-        <UpdateButton onClick={commitAndClose}>{t`Update filter`}</UpdateButton>
-      </Footer>
-    </Container>
+    <DateAllOptionsWidget
+      {...props}
+      value={defaultedValue}
+      disableOperatorSelection
+    />
   );
 }
 

--- a/frontend/src/metabase/parameters/components/widgets/DateSingleWidget.jsx
+++ b/frontend/src/metabase/parameters/components/widgets/DateSingleWidget.jsx
@@ -3,8 +3,12 @@ import PropTypes from "prop-types";
 import moment from "moment";
 import { t } from "ttag";
 
-import SpecificDatePicker from "metabase/query_builder/components/filters/pickers/SpecificDatePicker";
-import { Container, Footer, UpdateButton } from "./DateWidget.styled";
+import {
+  Container,
+  Footer,
+  UpdateButton,
+  PaddedSpecificDatePicker,
+} from "./DateWidget.styled";
 
 DateSingleWidget.propTypes = {
   value: PropTypes.any,
@@ -21,7 +25,7 @@ function DateSingleWidget({ value, setValue, onClose }) {
 
   return (
     <Container>
-      <SpecificDatePicker
+      <PaddedSpecificDatePicker
         value={internalValue}
         onChange={setInternalValue}
         calendar

--- a/frontend/src/metabase/parameters/components/widgets/DateSingleWidget.jsx
+++ b/frontend/src/metabase/parameters/components/widgets/DateSingleWidget.jsx
@@ -1,24 +1,38 @@
-/* eslint-disable react/prop-types */
-import React from "react";
-
-import Calendar from "metabase/components/Calendar";
+import React, { useState } from "react";
+import PropTypes from "prop-types";
 import moment from "moment";
+import { t } from "ttag";
 
-const DateSingleWidget = ({ value, setValue, onClose }) => {
-  value = value ? moment(value) : moment();
-  return (
-    <Calendar
-      initial={value}
-      selected={value}
-      selectedEnd={value}
-      isRangePicker={false}
-      onChange={value => {
-        setValue(value);
-        onClose();
-      }}
-    />
-  );
+import SpecificDatePicker from "metabase/query_builder/components/filters/pickers/SpecificDatePicker";
+import { Container, Footer, UpdateButton } from "./DateWidget.styled";
+
+DateSingleWidget.propTypes = {
+  value: PropTypes.any,
+  setValue: PropTypes.func.isRequired,
+  onClose: PropTypes.func.isRequired,
 };
+
+function DateSingleWidget({ value, setValue, onClose }) {
+  const [internalValue, setInternalValue] = useState(value);
+  const commitAndClose = () => {
+    setValue(internalValue);
+    onClose();
+  };
+
+  return (
+    <Container>
+      <SpecificDatePicker
+        value={internalValue}
+        onChange={setInternalValue}
+        calendar
+        hideTimeSelectors
+      />
+      <Footer>
+        <UpdateButton onClick={commitAndClose}>{t`Update filter`}</UpdateButton>
+      </Footer>
+    </Container>
+  );
+}
 
 DateSingleWidget.format = value =>
   value ? moment(value).format("MMMM D, YYYY") : "";

--- a/frontend/src/metabase/parameters/components/widgets/DateWidget.styled.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/DateWidget.styled.tsx
@@ -1,0 +1,24 @@
+import styled from "styled-components";
+
+import { color } from "metabase/lib/colors";
+import Button from "metabase/components/Button";
+
+export const Container = styled.div`
+  min-width: 300px;
+  margin: 1rem;
+`;
+
+export const Footer = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  align-items: center;
+`;
+
+export const UpdateButton = styled(Button).attrs({
+  purple: true,
+})`
+  padding: 1rem;
+  border: 1px solid ${color("border")};
+  justify-self: end;
+  grid-column-start: 2;
+`;

--- a/frontend/src/metabase/parameters/components/widgets/DateWidget.styled.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/DateWidget.styled.tsx
@@ -1,14 +1,21 @@
 import styled from "styled-components";
 
 import { color } from "metabase/lib/colors";
+import { space } from "metabase/styled-components/theme";
 import Button from "metabase/components/Button";
+import SpecificDatePicker from "metabase/query_builder/components/filters/pickers/SpecificDatePicker";
 
 export const Container = styled.div`
   min-width: 300px;
-  margin: 1rem;
+`;
+
+export const PaddedSpecificDatePicker = styled(SpecificDatePicker)`
+  padding: ${space(1)};
 `;
 
 export const Footer = styled.div`
+  border-top: 1px solid ${color("border")};
+  padding: ${space(1)};
   display: grid;
   grid-template-columns: 1fr 1fr;
   align-items: center;
@@ -17,8 +24,6 @@ export const Footer = styled.div`
 export const UpdateButton = styled(Button).attrs({
   purple: true,
 })`
-  padding: 1rem;
-  border: 1px solid ${color("border")};
   justify-self: end;
   grid-column-start: 2;
 `;

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx
@@ -339,6 +339,7 @@ type Props = {
   hideTimeSelectors?: boolean,
   includeAllTime?: boolean,
   operators?: Operator[],
+  disableOperatorSelection: boolean,
 };
 
 type State = {
@@ -380,6 +381,7 @@ export default class DatePicker extends Component {
       onFilterChange,
       includeAllTime,
       isSidebar,
+      disableOperatorSelection,
     } = this.props;
 
     let { operators } = this.state;
@@ -400,15 +402,17 @@ export default class DatePicker extends Component {
         })}
         style={{ minWidth: 300 }}
       >
-        <DateOperatorSelector
-          className={cx({
-            mr2: Widget && Widget.horizontalLayout,
-            mb2: Widget && !Widget.horizontalLayout,
-          })}
-          operator={operator && operator.name}
-          operators={operators}
-          onOperatorChange={operator => onFilterChange(operator.init(filter))}
-        />
+        {disableOperatorSelection !== true && (
+          <DateOperatorSelector
+            className={cx({
+              mr2: Widget && Widget.horizontalLayout,
+              mb2: Widget && !Widget.horizontalLayout,
+            })}
+            operator={operator && operator.name}
+            operators={operators}
+            onOperatorChange={operator => onFilterChange(operator.init(filter))}
+          />
+        )}
         {Widget && (
           <Widget
             {...this.props}


### PR DESCRIPTION
resolves #4585 

There's a lot of dup date field widget code that we can avoid by having everything go through the `frontend/src/metabase/parameters/components/widgets/DateAllOptionsWidget.jsx` widget. We just need to hide the ability to select other options. The `DateAllOptionsWidget` has a nice approach in that it is implemented in a similar way to the filter widget code in the QB -- updates are made to a `Filter` instance.