### PR TITLE
Disable all pivot tests on redshift

### DIFF
--- a/test/metabase/api/dataset_test.clj
+++ b/test/metabase/api/dataset_test.clj
@@ -387,7 +387,7 @@
             (is (= [nil nil 3 7562] (last rows)))))))))
 
 (deftest pivot-parameter-dataset-test
-  (mt/test-drivers (disj (pivots/applicable-drivers) :redshift) ; disable on Redshift until #18834 is fixed
+  (mt/test-drivers (pivots/applicable-drivers)
     (mt/dataset sample-dataset
       (testing "POST /api/dataset/pivot"
         (testing "Run a pivot table"

--- a/test/metabase/api/pivots.clj
+++ b/test/metabase/api/pivots.clj
@@ -4,7 +4,9 @@
 (defn applicable-drivers
   "Drivers that these pivot table tests should run on"
   []
-  (mt/normal-drivers-with-feature :expressions :left-join))
+  (disj (mt/normal-drivers-with-feature :expressions :left-join)
+        ;; Disable on Redshift due to OutOfMemory issue (see #18834)
+        :redshift))
 
 (defn pivot-query
   "A basic pivot table query"

--- a/test/metabase/api/public_test.clj
+++ b/test/metabase/api/public_test.clj
@@ -1055,7 +1055,7 @@
   (str "public/pivot/dashboard/" (:public_uuid dash) "/card/" (u/the-id card)))
 
 (deftest pivot-public-dashcard-test
-  (mt/test-drivers (disj (pivots/applicable-drivers) :redshift) ; disable on Redshift until #18834 is fixed
+  (mt/test-drivers (pivots/applicable-drivers)
     (mt/dataset sample-dataset
       (let [dashboard-defaults {:parameters [{:id      "_STATE_"
                                               :name    "State"


### PR DESCRIPTION
Pivot tests were originally enabled in #18089

But when we've found OutOfMemory errors (#18834) so we've disabled some in #18935. However, that wasn't enough. This PR disables all of them.