### PR TITLE
add show total setting to the waterfall static viz

### DIFF
--- a/frontend/src/metabase/internal/pages/StaticVizPage.jsx
+++ b/frontend/src/metabase/internal/pages/StaticVizPage.jsx
@@ -285,7 +285,7 @@ export default function StaticVizPage() {
           />
         </Box>
         <Box>
-          <Subhead>Waterfall chart with timeseries data</Subhead>
+          <Subhead>Waterfall chart with timeseries data and no total</Subhead>
           <StaticChart
             type="timeseries/waterfall"
             options={{
@@ -298,6 +298,7 @@ export default function StaticVizPage() {
                 ["2020-10-25", -30],
                 ["2020-10-26", -10],
                 ["2020-10-27", 20],
+                ["2020-10-28", -15],
               ],
               accessors: {
                 x: row => new Date(row[0]).valueOf(),
@@ -311,7 +312,7 @@ export default function StaticVizPage() {
           />
         </Box>
         <Box py={3}>
-          <Subhead>Waterfall chart with categorical data</Subhead>
+          <Subhead>Waterfall chart with categorical data and total</Subhead>
           <StaticChart
             type="categorical/waterfall"
             options={{
@@ -330,6 +331,9 @@ export default function StaticVizPage() {
               accessors: {
                 x: row => row[0],
                 y: row => row[1],
+              },
+              settings: {
+                showTotal: true,
               },
               labels: {
                 left: "Count",

--- a/frontend/src/metabase/static-viz/components/CategoricalWaterfallChart/CategoricalWaterfallChart.jsx
+++ b/frontend/src/metabase/static-viz/components/CategoricalWaterfallChart/CategoricalWaterfallChart.jsx
@@ -32,6 +32,7 @@ const propTypes = {
     x: PropTypes.object,
     y: PropTypes.object,
     colors: PropTypes.object,
+    showTotal: PropTypes.bool,
   }),
   labels: PropTypes.shape({
     left: PropTypes.string,
@@ -60,7 +61,6 @@ const layout = {
     waterfallPositive: "#88BF4D",
     waterfallNegative: "#EF8C8C",
   },
-  numTicks: 5,
   barPadding: 0.2,
   labelFontWeight: 700,
   labelPadding: 12,
@@ -69,7 +69,11 @@ const layout = {
 };
 
 const CategoricalWaterfallChart = ({ data, accessors, settings, labels }) => {
-  const entries = calculateWaterfallEntries(data, accessors);
+  const entries = calculateWaterfallEntries(
+    data,
+    accessors,
+    settings?.showTotal,
+  );
   const colors = settings?.colors;
   const isVertical = entries.length > 10;
   const xTickWidth = getXTickWidth(data, accessors, layout.maxTickWidth);

--- a/frontend/src/metabase/static-viz/components/TimeSeriesWaterfallChart/TimeSeriesWaterfallChart.jsx
+++ b/frontend/src/metabase/static-viz/components/TimeSeriesWaterfallChart/TimeSeriesWaterfallChart.jsx
@@ -29,6 +29,7 @@ const propTypes = {
     x: PropTypes.object,
     y: PropTypes.object,
     colors: PropTypes.object,
+    showTotal: PropTypes.bool,
   }),
   labels: PropTypes.shape({
     left: PropTypes.string,
@@ -76,7 +77,11 @@ const TimeSeriesWaterfallChart = ({ data, accessors, settings, labels }) => {
   const bottomLabel = labels?.bottom;
   const palette = { ...layout.colors, ...colors };
 
-  const entries = calculateWaterfallEntries(data, accessors);
+  const entries = calculateWaterfallEntries(
+    data,
+    accessors,
+    settings?.showTotal,
+  );
 
   const xScale = scaleBand({
     domain: entries.map(entry => entry.x),

--- a/frontend/src/metabase/static-viz/lib/waterfall.js
+++ b/frontend/src/metabase/static-viz/lib/waterfall.js
@@ -3,7 +3,7 @@ import { formatDate } from "./dates";
 
 const WATERFALL_TOTAL = "Total";
 
-export const calculateWaterfallEntries = (data, accessors) => {
+export const calculateWaterfallEntries = (data, accessors, showTotal) => {
   let total = 0;
 
   const entries = data.map(datum => {
@@ -21,13 +21,15 @@ export const calculateWaterfallEntries = (data, accessors) => {
     };
   });
 
-  entries.push({
-    x: WATERFALL_TOTAL,
-    y: total,
-    start: 0,
-    end: total,
-    isTotal: true,
-  });
+  if (showTotal) {
+    entries.push({
+      x: WATERFALL_TOTAL,
+      y: total,
+      start: 0,
+      end: total,
+      isTotal: true,
+    });
+  }
 
   return entries;
 };

--- a/frontend/src/metabase/static-viz/lib/waterfall.unit.spec.js
+++ b/frontend/src/metabase/static-viz/lib/waterfall.unit.spec.js
@@ -6,9 +6,35 @@ const accessors = {
 };
 
 describe("calculateWaterfallEntries", () => {
+  it("calculates waterfall entries without total", () => {
+    const data = [["1", 100], ["2", -50], ["3", 10]];
+    const entries = calculateWaterfallEntries(data, accessors, false);
+
+    expect(entries).toStrictEqual([
+      {
+        start: 0,
+        end: 100,
+        x: "1",
+        y: 100,
+      },
+      {
+        start: 100,
+        end: 50,
+        x: "2",
+        y: -50,
+      },
+      {
+        start: 50,
+        end: 60,
+        x: "3",
+        y: 10,
+      },
+    ]);
+  });
+
   it("calculates waterfall entries with positive total", () => {
     const data = [["1", 100], ["2", -50], ["3", 10]];
-    const entries = calculateWaterfallEntries(data, accessors);
+    const entries = calculateWaterfallEntries(data, accessors, true);
 
     expect(entries).toStrictEqual([
       {
@@ -41,7 +67,7 @@ describe("calculateWaterfallEntries", () => {
 
   it("calculates waterfall entries with negative total", () => {
     const data = [["1", 100], ["2", -200], ["3", 50]];
-    const entries = calculateWaterfallEntries(data, accessors);
+    const entries = calculateWaterfallEntries(data, accessors, true);
 
     expect(entries).toStrictEqual([
       {


### PR DESCRIPTION
Add support of `showTotal` setting for the waterfall static viz. 
BE branch is not merged yet, so the only way to check is to open http://localhost:3000/_internal/static-viz — there are examples with and without total.

<img width="567" alt="Screen Shot 2021-11-15 at 16 04 05" src="https://user-images.githubusercontent.com/14301985/141779024-f7ffa938-1fc6-4b95-8a20-67e06c228389.png">