### PR TITLE
Put new dashboards in edit mode

### DIFF
--- a/frontend/src/metabase/components/CreateDashboardModal.jsx
+++ b/frontend/src/metabase/components/CreateDashboardModal.jsx
@@ -34,7 +34,7 @@ export default class CreateDashboardModal extends Component {
 
   onSaved = dashboard => {
     const { onClose, onChangeLocation } = this.props;
-    onChangeLocation(Urls.dashboard(dashboard, { editingMode: true }));
+    onChangeLocation(Urls.dashboard(dashboard, { editMode: true }));
     if (onClose) {
       onClose();
     }

--- a/frontend/src/metabase/components/CreateDashboardModal.jsx
+++ b/frontend/src/metabase/components/CreateDashboardModal.jsx
@@ -34,7 +34,7 @@ export default class CreateDashboardModal extends Component {
 
   onSaved = dashboard => {
     const { onClose, onChangeLocation } = this.props;
-    onChangeLocation(Urls.dashboard(dashboard));
+    onChangeLocation(Urls.dashboard(dashboard, { editingMode: true }));
     if (onClose) {
       onClose();
     }

--- a/frontend/src/metabase/containers/AddToDashSelectDashModal.jsx
+++ b/frontend/src/metabase/containers/AddToDashSelectDashModal.jsx
@@ -39,7 +39,7 @@ export default class AddToDashSelectDashModal extends Component {
 
     onChangeLocation(
       Urls.dashboard(dashboard, {
-        editingMode: true,
+        editMode: true,
         addCardWithId: card.id,
       }),
     );

--- a/frontend/src/metabase/containers/AddToDashSelectDashModal.jsx
+++ b/frontend/src/metabase/containers/AddToDashSelectDashModal.jsx
@@ -35,8 +35,13 @@ export default class AddToDashSelectDashModal extends Component {
   };
 
   navigateToDashboard = dashboard => {
-    this.props.onChangeLocation(
-      Urls.dashboard(dashboard, { addCardWithId: this.props.card.id }),
+    const { card, onChangeLocation } = this.props;
+
+    onChangeLocation(
+      Urls.dashboard(dashboard, {
+        editingMode: true,
+        addCardWithId: card.id,
+      }),
     );
   };
 

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -49,7 +49,8 @@ export default class Dashboard extends Component {
     parameterValues: PropTypes.object,
     editingParameter: PropTypes.object,
 
-    addCardOnLoad: PropTypes.func,
+    editingOnLoad: PropTypes.bool,
+    addCardOnLoad: PropTypes.number,
     addCardToDashboard: PropTypes.func.isRequired,
     addParameter: PropTypes.func,
     archiveDashboard: PropTypes.func.isRequired,
@@ -131,6 +132,7 @@ export default class Dashboard extends Component {
 
   async loadDashboard(dashboardId) {
     const {
+      editingOnLoad,
       addCardOnLoad,
       addCardToDashboard,
       fetchDashboard,
@@ -146,10 +148,10 @@ export default class Dashboard extends Component {
 
     try {
       await fetchDashboard(dashboardId, location.query);
-      if (addCardOnLoad != null) {
-        // if we destructure this.props.dashboard, for some reason
-        // if will render dashboards as empty
+      if (editingOnLoad) {
         this.setEditing(this.props.dashboard);
+      }
+      if (addCardOnLoad != null) {
         addCardToDashboard({ dashId: dashboardId, cardId: addCardOnLoad });
       }
     } catch (error) {

--- a/frontend/src/metabase/dashboard/containers/DashboardApp.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp.jsx
@@ -91,15 +91,25 @@ export default class DashboardApp extends Component {
 
   UNSAFE_componentWillMount() {
     const options = parseHashOptions(window.location.hash);
-    if (options.add) {
-      this.setState({ addCardOnLoad: parseInt(options.add) });
+
+    if (options) {
+      this.setState({
+        editingOnLoad: options.edit,
+        addCardOnLoad: options.add && parseInt(options.add),
+      });
     }
   }
 
   render() {
+    const { editingOnLoad, addCardOnLoad } = this.state;
+
     return (
       <div className="shrink-below-content-size full-height">
-        <Dashboard addCardOnLoad={this.state.addCardOnLoad} {...this.props} />
+        <Dashboard
+          editingOnLoad={editingOnLoad}
+          addCardOnLoad={addCardOnLoad}
+          {...this.props}
+        />
         {/* For rendering modal urls */}
         {this.props.children}
       </div>

--- a/frontend/src/metabase/dashboard/hoc/DashboardControls.jsx
+++ b/frontend/src/metabase/dashboard/hoc/DashboardControls.jsx
@@ -114,10 +114,12 @@ export default (ComposedComponent: React.Class) =>
 
         delete options.night; // DEPRECATED: options.night
 
-        // Delete the "add card to dashboard" parameter if it's present because we don't
-        // want to add the card again on page refresh. The `add` parameter is already handled in
-        // DashboardApp before this method is called.
+        // Delete the "add card to dashboard" and "editing mode" parameters
+        // if they are present because we do not want to add the card again on
+        // page refresh. The parameters are already handled in DashboardApp
+        // before this method is called.
         delete options.add;
+        delete options.edit;
 
         let hash = stringifyHashOptions(options);
         hash = hash ? "#" + hash : "";

--- a/frontend/src/metabase/lib/urls.js
+++ b/frontend/src/metabase/lib/urls.js
@@ -98,12 +98,9 @@ export function newQuestion({ mode, ...options } = {}) {
   }
 }
 
-export function dashboard(dashboard, { addCardWithId, editingMode } = {}) {
+export function dashboard(dashboard, { addCardWithId, editMode } = {}) {
   const path = appendSlug(dashboard.id, slugg(dashboard.name));
-  const options = stringifyHashOptions({
-    add: addCardWithId,
-    edit: editingMode,
-  });
+  const options = stringifyHashOptions({ add: addCardWithId, edit: editMode });
   return options ? `/dashboard/${path}#${options}` : `/dashboard/${path}`;
 }
 

--- a/frontend/src/metabase/lib/urls.js
+++ b/frontend/src/metabase/lib/urls.js
@@ -99,12 +99,14 @@ export function newQuestion({ mode, ...options } = {}) {
 }
 
 export function dashboard(dashboard, { addCardWithId, editMode } = {}) {
-  const path = appendSlug(dashboard.id, slugg(dashboard.name));
-  const options = stringifyHashOptions({
+  const options = {
     ...(addCardWithId ? { add: addCardWithId } : {}),
     ...(editMode ? { edit: editMode } : {}),
-  });
-  return options ? `/dashboard/${path}#${options}` : `/dashboard/${path}`;
+  };
+
+  const path = appendSlug(dashboard.id, slugg(dashboard.name));
+  const hash = stringifyHashOptions(options);
+  return hash ? `/dashboard/${path}#${hash}` : `/dashboard/${path}`;
 }
 
 function prepareModel(item) {

--- a/frontend/src/metabase/lib/urls.js
+++ b/frontend/src/metabase/lib/urls.js
@@ -100,7 +100,10 @@ export function newQuestion({ mode, ...options } = {}) {
 
 export function dashboard(dashboard, { addCardWithId, editMode } = {}) {
   const path = appendSlug(dashboard.id, slugg(dashboard.name));
-  const options = stringifyHashOptions({ add: addCardWithId, edit: editMode });
+  const options = stringifyHashOptions({
+    ...(addCardWithId ? { add: addCardWithId } : {}),
+    ...(editMode ? { edit: editMode } : {}),
+  });
   return options ? `/dashboard/${path}#${options}` : `/dashboard/${path}`;
 }
 

--- a/frontend/src/metabase/lib/urls.js
+++ b/frontend/src/metabase/lib/urls.js
@@ -3,6 +3,7 @@ import { serializeCardForUrl } from "metabase/lib/card";
 import { SAVED_QUESTIONS_VIRTUAL_DB_ID } from "metabase/lib/saved-questions";
 import MetabaseSettings from "metabase/lib/settings";
 import Question from "metabase-lib/lib/Question";
+import { stringifyHashOptions } from "metabase/lib/browser";
 
 function appendSlug(path, slug) {
   return slug ? `${path}-${slug}` : path;
@@ -97,13 +98,13 @@ export function newQuestion({ mode, ...options } = {}) {
   }
 }
 
-export function dashboard(dashboard, { addCardWithId } = {}) {
+export function dashboard(dashboard, { addCardWithId, editingMode } = {}) {
   const path = appendSlug(dashboard.id, slugg(dashboard.name));
-  return addCardWithId != null
-    ? // NOTE: no-color-literals rule thinks #add is a color, oops
-      // eslint-disable-next-line no-color-literals
-      `/dashboard/${path}#add=${addCardWithId}`
-    : `/dashboard/${path}`;
+  const options = stringifyHashOptions({
+    add: addCardWithId,
+    edit: editingMode,
+  });
+  return options ? `/dashboard/${path}#${options}` : `/dashboard/${path}`;
 }
 
 function prepareModel(item) {

--- a/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
@@ -32,6 +32,7 @@ describe("scenarios > dashboard", () => {
     cy.findByLabelText("Description").type("Desc");
     cy.findByText("Create").click();
     cy.findByText("This dashboard is looking empty.");
+    cy.findByText("You're editing this dashboard.");
 
     // See it as a listed dashboard
     cy.visit("/collection/root?type=dashboard");
@@ -74,7 +75,7 @@ describe("scenarios > dashboard", () => {
     cy.findByText("Orders, Count");
   });
 
-  it("should link filters to custom question with filtered aggregate data (metabase#11007)", () => {
+  it.only("should link filters to custom question with filtered aggregate data (metabase#11007)", () => {
     // programatically create and save a question as per repro instructions in #11007
     cy.request("POST", "/api/card", {
       name: "11007",

--- a/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
@@ -75,7 +75,7 @@ describe("scenarios > dashboard", () => {
     cy.findByText("Orders, Count");
   });
 
-  it.only("should link filters to custom question with filtered aggregate data (metabase#11007)", () => {
+  it("should link filters to custom question with filtered aggregate data (metabase#11007)", () => {
     // programatically create and save a question as per repro instructions in #11007
     cy.request("POST", "/api/card", {
       name: "11007",


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/16939

How to test:
- Click on `plus` icon in the navbar -> `New dashboard`
- Fill in required details and submit the form
- After newly dashboard is opened, it should be in edit mode
- Opening an existing dashboard should not toggle edit mode