### PR TITLE
Suppress bundle size warnings for the static visualizations bundle

### DIFF
--- a/webpack.static-viz.config.js
+++ b/webpack.static-viz.config.js
@@ -9,6 +9,10 @@ module.exports = {
   mode: "production",
   context: SRC_PATH,
 
+  performance: {
+    hints: false,
+  },
+
   entry: {
     "lib-static-viz": {
       import: "./static-viz/index.js",


### PR DESCRIPTION
Static visualizations bundle is being used on the BE only, so these warnings make not much sense.