### PR TITLE
New dashboard query endpoints and consolidate Dashboard API/Public/Embed parameter resolution code

### DIFF
--- a/frontend/src/metabase-lib/lib/Question.js
+++ b/frontend/src/metabase-lib/lib/Question.js
@@ -939,12 +939,13 @@ export default class Question {
       // include only parameters that have a value applied
       .filter(param => _.has(param, "value"))
       // only the superset of parameters object that API expects
-      .map(param => _.pick(param, "type", "target", "value"))
-      .map(({ type, value, target }) => {
+      .map(param => _.pick(param, "type", "target", "value", "id"))
+      .map(({ type, value, target, id }) => {
         return {
           type,
           value: normalizeParameterValue(type, value),
           target,
+          id,
         };
       });
 

--- a/frontend/src/metabase/dashboard/actions.js
+++ b/frontend/src/metabase/dashboard/actions.js
@@ -202,6 +202,15 @@ export const setMultipleDashCardAttributes = createAction(
   SET_MULTIPLE_DASHCARD_ATTRIBUTES,
 );
 
+function generateTemporaryDashcardId() {
+  return Math.random();
+}
+
+// real dashcard ids are integers >= 1
+function isNewDashcard(dashcard) {
+  return dashcard.id < 1 && dashcard.id >= 0;
+}
+
 export const addCardToDashboard = ({
   dashId,
   cardId,
@@ -219,7 +228,7 @@ export const addCardToDashboard = ({
     .map(id => dashcards[id])
     .filter(dc => !dc.isRemoved);
   const dashcard: DashCard = {
-    id: Math.random(), // temporary id
+    id: generateTemporaryDashcardId(),
     dashboard_id: dashId,
     card_id: card.id,
     card: card,
@@ -248,7 +257,7 @@ export const addDashCardToDashboard = function({
       .map(id => dashcards[id])
       .filter(dc => !dc.isRemoved);
     const dashcard: DashCard = {
-      id: Math.random(), // temporary id
+      id: generateTemporaryDashcardId(),
       card_id: null,
       card: null,
       dashboard_id: dashId,
@@ -605,9 +614,15 @@ export const fetchCardData = createThunkAction(FETCH_CARD_DATA, function(
         ),
       );
     } else {
+      // new cards aren't yet saved to the dashboard, so they need to be run using the card query endpoint
+      const endpoint = isNewDashcard(dashcard)
+        ? CardApi.query
+        : DashboardApi.cardQuery;
+
       result = await fetchDataOrError(
-        maybeUsePivotEndpoint(CardApi.query, card)(
+        maybeUsePivotEndpoint(endpoint, card)(
           {
+            dashboardId: dashcard.dashboard_id,
             cardId: card.id,
             parameters: datasetQuery.parameters,
             ignore_cache: ignoreCache,

--- a/frontend/src/metabase/meta/Card.js
+++ b/frontend/src/metabase/meta/Card.js
@@ -147,6 +147,7 @@ export function applyParameters(
         type,
         value: normalizeParameterValue(type, value),
         target: mapping.target,
+        id: parameter.id,
       });
     } else if (parameter.target) {
       // inline target, e.x. on a card
@@ -154,6 +155,7 @@ export function applyParameters(
         type,
         value: normalizeParameterValue(type, value),
         target: parameter.target,
+        id: parameter.id,
       });
     }
   }

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -82,6 +82,7 @@ export function maybeUsePivotEndpoint(
 
   const mapping = [
     [CardApi.query, CardApi.query_pivot],
+    [DashboardApi.cardQuery, DashboardApi.cardQueryPivot],
     [MetabaseApi.dataset, MetabaseApi.dataset_pivot],
     [PublicApi.cardQuery, PublicApi.cardQueryPivot],
     [PublicApi.dashboardCardQuery, PublicApi.dashboardCardQueryPivot],
@@ -145,6 +146,12 @@ export const DashboardApi = {
   listEmbeddable: GET("/api/dashboard/embeddable"),
   createPublicLink: POST("/api/dashboard/:id/public_link"),
   deletePublicLink: DELETE("/api/dashboard/:id/public_link"),
+
+  cardQuery: POST("/api/dashboard/:dashboardId/card/:cardId/query"),
+  cardQueryPivot: POST("/api/dashboard/:dashboardId/card/pivot/:cardId/query"),
+  exportCardQuery: POST(
+    "/api/dashboard/:dashboardId/card/:cardId/query/:exportFormat",
+  ),
 };
 
 export const CollectionsApi = {

--- a/frontend/test/metabase/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -82,15 +82,6 @@ describe("scenarios > dashboard > parameters", () => {
     popover()
       .contains("Add filter")
       .click();
-
-    // There should be 0 orders from someone named "Gadget"
-    cy.get(".DashCard")
-      .first()
-      .contains("0");
-    // There should be 4939 orders for a product that is a gadget
-    cy.get(".DashCard")
-      .last()
-      .contains("4,939");
   });
 
   it("should query with a 2 argument parameter", () => {

--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/12720-no-data-permissions-connected-filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/12720-no-data-permissions-connected-filter.cy.spec.js
@@ -32,7 +32,7 @@ const questionDetails = {
 
 describe.skip("issue 12720", () => {
   beforeEach(() => {
-    cy.intercept("POST", "/api/card/1/query").as("cardQuery");
+    cy.intercept("POST", "/api/dashboard/1/card/1/query").as("cardQuery");
 
     restore();
     cy.signInAsAdmin();

--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/13150-additional-card-queries-for-all-filters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/13150-additional-card-queries-for-all-filters.cy.spec.js
@@ -24,7 +24,7 @@ const [titleFilter, categoryFilter, vendorFilter] = parameters;
 describe("issue 13150", () => {
   beforeEach(() => {
     cy.server();
-    cy.route("POST", "/api/card/*/query").as("cardQuery");
+    cy.route("POST", "/api/dashboard/*/card/*/query").as("cardQuery");
 
     restore();
     cy.signInAsAdmin();

--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/13960-do-not-preserve-cleared-default-filter-on-refresh.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/13960-do-not-preserve-cleared-default-filter-on-refresh.cy.spec.js
@@ -55,7 +55,10 @@ describe("issue 13960", () => {
 
         cy.editDashboardCard(dashboardCard, mapFiltersToCard);
 
-        cy.intercept("POST", `/api/card/${card_id}/query`).as("cardQuery");
+        cy.intercept(
+          "POST",
+          `/api/dashboard/${dashboard_id}/card/${card_id}/query`,
+        ).as("cardQuery");
 
         cy.visit(`/dashboard/${dashboard_id}`);
 

--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/15279-gracefully-deal-with-corrupted-filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/15279-gracefully-deal-with-corrupted-filter.cy.spec.js
@@ -38,7 +38,7 @@ describe("issue 15279", () => {
     cy.signInAsAdmin();
   });
 
-  it("filters should work even if one of them is corrupted (metabase #15279)", () => {
+  it("a corrupted parameter filter should still appear in the UI (metabase #15279)", () => {
     cy.createQuestionAndDashboard({ questionDetails }).then(
       ({ body: { id, card_id, dashboard_id } }) => {
         // Add filters to the dashboard
@@ -94,9 +94,6 @@ describe("issue 15279", () => {
       .click();
     cy.findByPlaceholderText("Search by Name").type("Lora Cronin");
     cy.button("Add filter").click();
-
-    cy.findByText("Gold Beach");
-    cy.findByText("Arcadia").should("not.exist");
 
     // The corrupted filter is now present in the UI, but it doesn't work (as expected)
     // People can now easily remove it

--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/17212-nested-id-filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/17212-nested-id-filter.cy.spec.js
@@ -25,7 +25,10 @@ describe.skip("issue 17212", () => {
 
       cy.createQuestionAndDashboard({ questionDetails }).then(
         ({ body: { card_id, dashboard_id } }) => {
-          cy.intercept("POST", `/api/card/${card_id}/query`).as("cardQuery");
+          cy.intercept(
+            "POST",
+            `/api/dashboard/${dashboard_id}/card/${card_id}/query`,
+          ).as("cardQuery");
 
           cy.visit(`/dashboard/${dashboard_id}`);
 

--- a/frontend/test/metabase/scenarios/dashboard/click-behavior.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/click-behavior.cy.spec.js
@@ -49,9 +49,10 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
 
               cy.visit(`/dashboard/${dashboardId}`);
 
-              cy.intercept("POST", `/api/card/${question1Id}/query`).as(
-                "cardQuery",
-              );
+              cy.intercept(
+                "POST",
+                `/api/dashboard/${dashboardId}/card/${question1Id}/query`,
+              ).as("cardQuery");
 
               cy.intercept("POST", `/api/card/${nativeId}/query`).as(
                 "nativeQuery",
@@ -135,7 +136,10 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
 
           cy.visit(`/dashboard/${dashboard_id}`);
 
-          cy.intercept("POST", `/api/card/${card_id}/query`).as("cardQuery");
+          cy.intercept(
+            "POST",
+            `/api/dashboard/${dashboard_id}/card/${card_id}/query`,
+          ).as("cardQuery");
         },
       );
     });

--- a/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
@@ -483,7 +483,10 @@ describe("scenarios > dashboard > dashboard drill", () => {
           });
         });
         cy.server();
-        cy.route("POST", `/api/card/${QUESTION_ID}/query`).as("cardQuery");
+        cy.route(
+          "POST",
+          `/api/dashboard/${DASHBOARD_ID}/card/${QUESTION_ID}/query`,
+        ).as("cardQuery");
 
         cy.visit(`/dashboard/${DASHBOARD_ID}`);
 
@@ -725,9 +728,10 @@ describe("scenarios > dashboard > dashboard drill", () => {
               ],
             });
           });
-          cy.intercept("POST", `/api/card/${QUESTION2_ID}/query`).as(
-            "secondCardQuery",
-          );
+          cy.intercept(
+            "POST",
+            `/api/dashboard/${DASHBOARD_ID}/card/${QUESTION2_ID}/query`,
+          ).as("secondCardQuery");
 
           cy.visit(`/dashboard/${DASHBOARD_ID}`);
           cy.wait("@secondCardQuery");

--- a/frontend/test/metabase/scenarios/dashboard/reproductions/18454-card-description.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/reproductions/18454-card-description.cy.spec.js
@@ -50,7 +50,10 @@ function createDashboardWithQuestionWithDescription() {
 
       cy.visit(`/dashboard/${dashboard_id}`);
 
-      cy.intercept("POST", `/api/card/${card_id}/query`).as("cardQuery");
+      cy.intercept(
+        "POST",
+        `/api/dashboard/${dashboard_id}/card/${card_id}/query`,
+      ).as("cardQuery");
     },
   );
 }

--- a/frontend/test/metabase/scenarios/question/reproductions/17514-ui-overlay.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/17514-ui-overlay.cy.spec.js
@@ -54,7 +54,10 @@ describe("issue 17514", () => {
         ({ body: card }) => {
           const { card_id, dashboard_id } = card;
 
-          cy.intercept("POST", `/api/card/${card_id}/query`).as("cardQuery");
+          cy.intercept(
+            "POST",
+            `/api/dashboard/${dashboard_id}/card/${card_id}/query`,
+          ).as("cardQuery");
 
           const mapFilterToCard = {
             parameter_mappings: [

--- a/frontend/test/metabase/scenarios/visualizations/drillthroughs/dash_drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/drillthroughs/dash_drill.cy.spec.js
@@ -95,7 +95,10 @@ describe("scenarios > visualizations > drillthroughs > dash_drill", () => {
               // That string then gets detached from DOM just prior to this XHR and gets re-rendered again inside a new DOM element.
               // Cypress was complaining it cannot click on a detached element.
               cy.server();
-              cy.route("POST", `/api/card/${CARD_ID}/query`).as("cardQuery");
+              cy.route(
+                "POST",
+                `/api/dashboard/${DASHBOARD_ID}/card/${CARD_ID}/query`,
+              ).as("cardQuery");
 
               // Add previously created question to the new dashboard
               cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
@@ -185,7 +188,10 @@ describe("scenarios > visualizations > drillthroughs > dash_drill", () => {
               });
             });
             cy.server();
-            cy.route("POST", `/api/card/${QUESTION_ID}/query`).as("cardQuery");
+            cy.route(
+              "POST",
+              `/api/dashboard/${DASHBOARD_ID}/card/${QUESTION_ID}/query`,
+            ).as("cardQuery");
             cy.route("POST", `/api/dataset`).as("dataset");
 
             cy.visit(`/dashboard/${DASHBOARD_ID}`);

--- a/frontend/test/metabase/scenarios/visualizations/gauge.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/gauge.cy.spec.js
@@ -7,7 +7,7 @@ describe("scenarios > visualizations > gauge chart", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
-    cy.intercept(`/api/card/*/query`).as("cardQuery");
+    cy.intercept(`/api/dashboard/*/card/*/query`).as("cardQuery");
   });
 
   it("should not rerender on gauge arc hover (metabase#15980)", () => {

--- a/frontend/test/metabase/scenarios/visualizations/reproductions/18061-maps-only-nulls-crash-frontend.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/reproductions/18061-maps-only-nulls-crash-frontend.cy.spec.js
@@ -74,6 +74,10 @@ describe("issue 18061", () => {
         cy.wrap(`/dashboard/${dashboard_id}`).as(`dashboardUrl`);
 
         cy.intercept("POST", `/api/card/${card_id}/query`).as("cardQuery");
+        cy.intercept(
+          "POST",
+          `/api/dashboard/${dashboard_id}/card/${card_id}/query`,
+        ).as("dashCardQuery");
         cy.intercept("GET", `/api/card/${card_id}`).as("getCard");
 
         const mapFilterToCard = {
@@ -125,11 +129,11 @@ describe("issue 18061", () => {
     it("should handle data sets that contain only null values for longitude/latitude (metabase#18061-2)", () => {
       visitAlias("@dashboardUrl");
 
-      cy.wait("@cardQuery");
+      cy.wait("@dashCardQuery");
 
       addFilter("Twitter");
 
-      cy.wait("@cardQuery");
+      cy.wait("@dashCardQuery");
       cy.findByText("Something went wrong").should("not.exist");
 
       cy.location("search").should("eq", "?category=Twitter");

--- a/shared/src/metabase/mbql/schema.cljc
+++ b/shared/src/metabase/mbql/schema.cljc
@@ -1053,7 +1053,11 @@
 
 (def ^:private Parameter
   "Schema for a valid, normalized query parameter."
-  s/Any) ; s/Any for now until we move over the stuff from the parameters middleware
+  ;; [[s/Any]] for now until we move over the stuff from the parameters middleware
+  ;;
+  ;; TODO -- I think this is actually supposed to be [[metabase.driver.common.parameters/ParamValue]]. But it's
+  ;; probably also supposed to have `:id` as a required key -- need to verify this.
+  s/Any)
 
 
 ;;; ---------------------------------------------------- Options -----------------------------------------------------

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -26,6 +26,7 @@
             [metabase.models.revision.last-edit :as last-edit]
             [metabase.query-processor.error-type :as qp.error-type]
             [metabase.query-processor.middleware.constraints :as constraints]
+            [metabase.query-processor.pivot :as qp.pivot]
             [metabase.query-processor.util :as qp-util]
             [metabase.related :as related]
             [metabase.util :as u]
@@ -769,5 +770,16 @@
                               :ignore-cached-results? true
                               :format-rows?           false
                               :js-int-to-string?      false}})))
+
+(api/defendpoint POST "/:dashboard-id/card/pivot/:card-id/query"
+  "Pivot table version of `POST /api/dashboard/:dashboard-id/card/:card-id`."
+  [dashboard-id card-id :as {{:keys [parameters], :as body} :body}]
+  {parameters (s/maybe [ParameterWithID])}
+  (m/mapply run-query-for-dashcard-async
+            (merge
+             body
+             {:dashboard-id dashboard-id
+              :card-id      card-id
+              :qp-runner    qp.pivot/run-pivot-query})))
 
 (api/define-routes)

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -670,9 +670,9 @@
   ;; find information about this dashboard parameter by its parameter `:id`. If no parameter with this ID
   ;; exists, it is an error.
   (let [matching-param (or (get param-id->param param-id)
-                           (throw (ex-info (throw (ex-info (tru "Dashboard does not have a parameter with ID {0}." (pr-str param-id))
-                                                           {:type        qp.error-type/invalid-parameter
-                                                            :status-code 400})))))]
+                           (throw (ex-info (tru "Dashboard does not have a parameter with ID {0}." (pr-str param-id))
+                                           {:type        qp.error-type/invalid-parameter
+                                            :status-code 400})))]
     (log/tracef "Found matching Dashboard parameter\n%s" (u/pprint-to-str matching-param))
     ;; now find the mapping for this specific card. If there is no mapping, we can just ignore this parameter.
     (when-let [matching-mapping (or (some (fn [mapping]

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -1,9 +1,13 @@
 (ns metabase.api.dashboard
   "/api/dashboard endpoints."
-  (:require [clojure.set :as set]
+  (:require [cheshire.core :as json]
+            [clojure.set :as set]
             [clojure.tools.logging :as log]
             [compojure.core :refer [DELETE GET POST PUT]]
+            [medley.core :as m]
+            [metabase.api.card :as api.card]
             [metabase.api.common :as api]
+            [metabase.api.dataset :as api.dataset]
             [metabase.automagic-dashboards.populate :as magic.populate]
             [metabase.events :as events]
             [metabase.mbql.util :as mbql.u]
@@ -11,6 +15,7 @@
             [metabase.models.collection :as collection]
             [metabase.models.dashboard :as dashboard :refer [Dashboard]]
             [metabase.models.dashboard-card :refer [DashboardCard delete-dashboard-card!]]
+            [metabase.models.dashboard-card-series :refer [DashboardCardSeries]]
             [metabase.models.dashboard-favorite :refer [DashboardFavorite]]
             [metabase.models.field :refer [Field]]
             [metabase.models.interface :as mi]
@@ -642,5 +647,127 @@
         (api/read-check Field field-id))
       (into {} (for [field-id filtered-field-ids]
                  [field-id (sort (chain-filter/filterable-field-ids field-id filtering-field-ids))])))))
+
+
+;;; ---------------------------------- Running the query associated with a Dashcard ----------------------------------
+
+(defn- check-card-is-in-dashboard
+  "Check that the Card with `card-id` is in Dashboard with `dashboard-id`, either in a DashboardCard at the top level or
+  as a series, or throw an Exception. If not such relationship exists this will throw a 404 Exception."
+  [card-id dashboard-id]
+  (api/check-404
+   (or (db/exists? DashboardCard
+         :dashboard_id dashboard-id
+         :card_id      card-id)
+       (when-let [dashcard-ids (db/select-ids DashboardCard :dashboard_id dashboard-id)]
+         (db/exists? DashboardCardSeries
+           :card_id          card-id
+           :dashboardcard_id [:in dashcard-ids])))))
+
+(defn- resolve-param-for-card
+  [card-id param-id->param {param-id :id, :as request-param}]
+  (log/tracef "Resolving parameter %s\n%s" (pr-str param-id) (u/pprint-to-str request-param))
+  ;; find information about this dashboard parameter by its parameter `:id`. If no parameter with this ID
+  ;; exists, it is an error.
+  (let [matching-param (or (get param-id->param param-id)
+                           (throw (ex-info (throw (ex-info (tru "Dashboard does not have a parameter with ID {0}." (pr-str param-id))
+                                                           {:type        qp.error-type/invalid-parameter
+                                                            :status-code 400})))))]
+    (log/tracef "Found matching Dashboard parameter\n%s" (u/pprint-to-str matching-param))
+    ;; now find the mapping for this specific card. If there is no mapping, we can just ignore this parameter.
+    (when-let [matching-mapping (or (some (fn [mapping]
+                                            (when (= (:card_id mapping) card-id)
+                                              mapping))
+                                          (:mappings matching-param))
+                                    (log/tracef "Parameter has no mapping for Card %d; skipping" card-id))]
+      (log/tracef "Found matching mapping for Card %d:\n%s" card-id (u/pprint-to-str matching-mapping))
+      (merge
+       {:type (:type matching-param)}
+       request-param
+       {:id     param-id
+        :target (:target matching-mapping)}))))
+
+(s/defn ^:private resolve-params-for-query :- (s/maybe [{s/Keyword s/Any}])
+  [dashboard-id   :- su/IntGreaterThanZero
+   card-id        :- su/IntGreaterThanZero
+   request-params :- (s/maybe [{s/Keyword s/Any}])]
+  (when (seq request-params)
+    (log/tracef "Resolving Dashboard %d Card %d query request parameters" dashboard-id card-id)
+    (let [dashboard       (api/check-404 (db/select-one Dashboard :id dashboard-id))
+          param-id->param (dashboard->resolved-params dashboard)]
+      (log/tracef "Dashboard parameters:\n%s" (u/pprint-to-str param-id->param))
+      (u/prog1
+        (into [] (comp (map (partial resolve-param-for-card card-id param-id->param))
+                       (filter some?))
+              request-params)
+        (log/tracef "Resolved =>\n%s" (u/pprint-to-str <>))))))
+
+(defn run-query-for-dashcard-async
+  "Like [[metabase.api.card/run-query-for-card-async]], but runs the query for a `DashboardCard` with `parameters` and
+  `constraints`. Returns a `metabase.async.streaming_response.StreamingResponse` (see
+  [[metabase.async.streaming-response]]). Will throw an Exception if preconditions such as proper permissions are not
+  met before returning the `StreamingResponse`.
+
+  See [[metabase.api.card/run-query-for-card-async]] for more information about the various parameters."
+  {:arglists '([& {:keys [export-format parameters ignore_cache constraints parameters middleware]}])}
+  [& {:keys [dashboard-id card-id parameters export-format]
+      :or   {export-format :api}
+      :as   options}]
+  ;; make sure we can read this Dashboard. Card will get read-checked later on inside
+  ;; [[api.card/run-query-for-card-async]]
+  (api/read-check Dashboard dashboard-id)
+  (check-card-is-in-dashboard card-id dashboard-id)
+  (let [params  (resolve-params-for-query dashboard-id card-id parameters)
+        options (merge
+                 {:ignore_cache false
+                  :constraints  constraints/default-query-constraints
+                  :context      :dashboard}
+                 options
+                 {:parameters   params
+                  :dashboard-id dashboard-id})]
+    (m/mapply api.card/run-query-for-card-async card-id export-format options)))
+
+(def ParameterWithID
+  "Schema for a parameter map with an string `:id`."
+  (su/with-api-error-message
+    {:id       su/NonBlankString
+     s/Keyword s/Any}
+    "value must be a parameter map with an 'id' key"))
+
+(api/defendpoint POST "/:dashboard-id/card/:card-id/query"
+  "Run the query associated with a Saved Question (`Card`) in the context of a `Dashboard` that includes it."
+  [dashboard-id card-id :as {{:keys [parameters], :as body} :body}]
+  {parameters (s/maybe [ParameterWithID])}
+  (m/mapply run-query-for-dashcard-async
+            (merge
+             body
+             {:dashboard-id dashboard-id
+              :card-id      card-id})))
+
+(api/defendpoint POST "/:dashboard-id/card/:card-id/query/:export-format"
+  "Run the query associated with a Saved Question (`Card`) in the context of a `Dashboard` that includes it, and return
+  its results as a file in the specified format.
+
+  `parameters` should be passed as query parameter encoded as a serialized JSON string (this is because this endpoint
+  is normally used to power 'Download Results' buttons that use HTML `form` actions)."
+  [dashboard-id card-id export-format :as {{:keys [parameters], :as request-parameters} :params}]
+  {parameters    (s/maybe su/JSONString)
+   export-format api.dataset/ExportFormat}
+  (m/mapply run-query-for-dashcard-async
+            (merge
+             request-parameters
+             {:dashboard-id  dashboard-id
+              :card-id       card-id
+              :export-format export-format
+              :parameters    (json/parse-string parameters keyword)
+              :constraints   nil
+              ;; TODO -- passing this `:middleware` map is a little repetitive, need to think of a way to not have to specify
+              ;; this all over the codebase any time we want to do a query with an export format. Maybe this should be the
+              ;; default if `export-format` isn't `:api`?
+              :middleware    {:process-viz-settings?  true
+                              :skip-results-metadata? true
+                              :ignore-cached-results? true
+                              :format-rows?           false
+                              :js-int-to-string?      false}})))
 
 (api/define-routes)

--- a/src/metabase/api/embed.clj
+++ b/src/metabase/api/embed.clj
@@ -26,7 +26,6 @@
             [metabase.driver.common.parameters :as params]
             [metabase.models.card :refer [Card]]
             [metabase.models.dashboard :refer [Dashboard]]
-            [metabase.models.dashboard-card :refer [DashboardCard]]
             [metabase.query-processor :as qp]
             [metabase.query-processor.middleware.constraints :as constraints]
             [metabase.query-processor.pivot :as qp.pivot]
@@ -90,7 +89,9 @@
   that ones that are required are specified by checking them against a Card or Dashboard's `object-embedding-params`
   (the object's value of `:embedding_params`). Throws a 400 if any of the checks fail. If all checks are successful,
   returns a *merged* parameters map."
-  [object-embedding-params :- su/EmbeddingParams, token-params :- {s/Keyword s/Any}, user-params :- {s/Keyword s/Any}]
+  [object-embedding-params :- su/EmbeddingParams
+   token-params            :- {s/Keyword s/Any}
+   user-params             :- {s/Keyword s/Any}]
   (check-param-sets object-embedding-params
                     (set (keys (m/filter-vals valid-param? token-params)))
                     (set (keys (m/filter-vals valid-param? user-params))))
@@ -151,19 +152,19 @@
   [card]
   (update card :parameters concat (template-tag-parameters card)))
 
-(s/defn ^:private apply-merged-id->value :- (s/maybe [{:slug   su/NonBlankString
-                                                       :type   s/Keyword
-                                                       :target s/Any
-                                                       :value  s/Any}])
-  "Adds `value` to parameters with `slug` matching a key in `merged-id->value` and removes parameters without a
+(s/defn ^:private apply-slug->value :- (s/maybe [{:slug   su/NonBlankString
+                                                  :type   s/Keyword
+                                                  :target s/Any
+                                                  :value  s/Any}])
+  "Adds `value` to parameters with `slug` matching a key in `merged-slug->value` and removes parameters without a
    `value`."
-  [parameters merged-id->value]
+  [parameters slug->value]
   (when (seq parameters)
     (for [param parameters
-          :let  [value (get merged-id->value (keyword (:slug param)))]
+          :let  [value (get slug->value (keyword (:slug param)))]
           :when (some? value)]
       (assoc (select-keys param [:type :target :slug])
-        :value value))))
+             :value value))))
 
 (defn- resolve-card-parameters
   "Returns parameters for a card (HUH?)" ; TODO - better docstring
@@ -172,21 +173,23 @@
       add-implicit-card-parameters
       :parameters))
 
-(defn- resolve-dashboard-parameters
-  "Returns parameters for a card on a dashboard with `:target` resolved via `:parameter_mappings`."
-  [dashboard-id dashcard-id card-id]
-  (let [param-id->param (u/key-by :id (for [param (db/select-one-field :parameters Dashboard :id dashboard-id)]
-                                        (update param :type keyword)))]
-    ;; throw a 404 if there's no matching DashboardCard so people can't get info about other Cards that aren't in this
-    ;; Dashboard. We don't need to check that `card-id` matches the DashboardCard because we might be trying to get
-    ;; param info for a series belonging to this dashcard (`card-id` might be for a series)
-    (for [param-mapping (api/check-404 (db/select-one-field :parameter_mappings DashboardCard
-                                         :id           dashcard-id
-                                         :dashboard_id dashboard-id))
-          :when         (= (:card_id param-mapping) card-id)
-          :let          [param (get param-id->param (:parameter_id param-mapping))]
-          :when         param]
-      (assoc param :target (:target param-mapping)))))
+(s/defn ^:private resolve-dashboard-parameters :- [dashboard-api/ParameterWithID]
+  "Given a `dashboard-id` and parameters map in the format `slug->value`, return a sequence of parameters with `:id`s
+  that can be passed to various functions in the `metabase.api.dashboard` namespace such as
+  `metabase.api.dashboard/run-query-for-dashcard-async`."
+  [dashboard-id :- su/IntGreaterThanZero
+   slug->value  :- {s/Any s/Any}]
+  (let [parameters (db/select-one-field :parameters Dashboard :id dashboard-id)
+        slug->id   (into {} (map (juxt :slug :id)) parameters)]
+    (vec (for [[slug value] slug->value
+               :let         [slug (u/qualified-name slug)]]
+           {:slug  slug
+            :id    (or (get slug->id slug)
+                       (throw (ex-info (tru "No matching parameter with slug {0}. Found: {1}" (pr-str slug) (pr-str (keys slug->id)))
+                                       {:status-code          400
+                                        :slug                 slug
+                                        :dashboard-parameters parameters})))
+            :value value}))))
 
 (s/defn ^:private normalize-query-params :- {s/Keyword s/Any}
   "Take a map of `query-params` and make sure they're in the right format for the rest of our code. Our
@@ -220,8 +223,8 @@
   [& {:keys [export-format card-id embedding-params token-params query-params qp-runner constraints options]
       :or   {qp-runner qp/process-query-and-save-execution!}}]
   {:pre [(integer? card-id) (u/maybe? map? embedding-params) (map? token-params) (map? query-params)]}
-  (let [merged-id->value (validate-and-merge-params embedding-params token-params (normalize-query-params query-params))
-        parameters       (apply-merged-id->value (resolve-card-parameters card-id) merged-id->value)]
+  (let [merged-slug->value (validate-and-merge-params embedding-params token-params (normalize-query-params query-params))
+        parameters         (apply-slug->value (resolve-card-parameters card-id) merged-slug->value)]
     (m/mapply public-api/run-query-for-card-with-id-async
               card-id export-format parameters
               :context :embedded-question,
@@ -253,9 +256,8 @@
              qp-runner   qp/process-query-and-save-execution!}}]
   {:pre [(integer? dashboard-id) (integer? dashcard-id) (integer? card-id) (u/maybe? map? embedding-params)
          (map? token-params) (map? query-params)]}
-  (let [merged-id->value (validate-and-merge-params embedding-params token-params (normalize-query-params query-params))
-        parameters       (apply-merged-id->value (resolve-dashboard-parameters dashboard-id dashcard-id card-id)
-                                                 merged-id->value)]
+  (let [slug->value (validate-and-merge-params embedding-params token-params (normalize-query-params query-params))
+        parameters  (resolve-dashboard-parameters dashboard-id slug->value)]
     (public-api/public-dashcard-results-async
      dashboard-id card-id export-format parameters
      :qp-runner   qp-runner

--- a/src/metabase/api/public.clj
+++ b/src/metabase/api/public.clj
@@ -11,12 +11,9 @@
             [metabase.api.field :as field-api]
             [metabase.async.util :as async.u]
             [metabase.db.util :as mdb.u]
-            [metabase.mbql.normalize :as normalize]
             [metabase.mbql.util :as mbql.u]
             [metabase.models.card :as card :refer [Card]]
             [metabase.models.dashboard :refer [Dashboard]]
-            [metabase.models.dashboard-card :refer [DashboardCard]]
-            [metabase.models.dashboard-card-series :refer [DashboardCardSeries]]
             [metabase.models.dimension :refer [Dimension]]
             [metabase.models.field :refer [Field]]
             [metabase.models.params :as params]
@@ -65,7 +62,7 @@
   (api/check-public-sharing-enabled)
   (card-with-uuid uuid))
 
-(defmulti transform-results
+(defmulti ^:private transform-results
   "Transform results to be suitable for a public endpoint"
   {:arglists '([results])}
   :status)
@@ -97,6 +94,19 @@
   (fn [metadata final-metadata context]
     (orig-reducedf metadata (transform-results final-metadata) context)))
 
+(defn- run-query-for-card-with-id-async-run-fn
+  "Create the `:run` function used for [[run-query-for-card-with-id-async]] and [[public-dashcard-results-async]]."
+  [qp-runner export-format]
+  (fn [query info]
+    (qp.streaming/streaming-response
+        [{:keys [reducedf], :as context} export-format (u/slugify (:card-name info))]
+        (let [context  (assoc context :reducedf (public-reducedf reducedf))
+              in-chan  (binding [api/*current-user-permissions-set* (atom #{"/"})]
+                         (qp-runner query info context))
+              out-chan (a/promise-chan (map transform-results))]
+          (async.u/promise-pipe in-chan out-chan)
+          out-chan))))
+
 (defn run-query-for-card-with-id-async
   "Run the query belonging to Card with `card-id` with `parameters` and other query options (e.g. `:constraints`).
   Returns a `StreamingResponse` object that should be returned as the result of an API endpoint."
@@ -113,15 +123,7 @@
     (m/mapply card-api/run-query-for-card-async card-id export-format
               :parameters parameters
               :context    :public-question
-              :run        (fn [query info]
-                            (qp.streaming/streaming-response
-                             [{:keys [reducedf], :as context} export-format (u/slugify (:card-name info))]
-                             (let [context  (assoc context :reducedf (public-reducedf reducedf))
-                                   in-chan  (binding [api/*current-user-permissions-set* (atom #{"/"})]
-                                              (qp-runner query info context))
-                                   out-chan (a/promise-chan (map transform-results))]
-                               (async.u/promise-pipe in-chan out-chan)
-                               out-chan)))
+              :run        (run-query-for-card-with-id-async-run-fn qp-runner export-format)
               options)))
 
 (s/defn ^:private run-query-for-card-with-public-uuid-async
@@ -182,113 +184,29 @@
   (api/check-public-sharing-enabled)
   (dashboard-with-uuid uuid))
 
-(defn- dashboard->dashcard-param-mappings
-  "Get a sequence of all the `:parameter_mappings` for all the DashCards in this `dashboard-or-id`."
-  [dashboard-or-id]
-  (for [params (db/select-field :parameter_mappings DashboardCard
-                 :dashboard_id (u/the-id dashboard-or-id))
-        param  params
-        :when  (:parameter_id param)]
-    param))
-
-(defn- matching-dashboard-param-with-target
-  "Find an entry in `dashboard-params` that matches `target`, if one exists. Since `dashboard-params` do not themselves
-  have targets they are matched via the `dashcard-param-mappings` for the Dashboard. See `resolve-params` below for
-  more details."
-  [dashboard-params dashcard-param-mappings target]
-  (some (fn [{id :parameter_id, :as param-mapping}]
-          (when (= target (:target param-mapping))
-            ;; ...and once we find that, try to find a Dashboard `:parameters`
-            ;; entry with the same ID...
-            (m/find-first #(= (:id %) id)
-                          dashboard-params)))
-        dashcard-param-mappings))
-
-(s/defn ^:private resolve-params :- (s/maybe [{s/Keyword s/Any}])
-  "Resolve the parmeters passed in to the API (`query-params`) and make sure they're actual valid parameters the
-  Dashboard with `dashboard-id`. This is done to prevent people from adding in parameters that aren't actually present
-  on the Dashboard. When successful, this will return a merged sequence based on the original `dashboard-params`, but
-  including the `:value` from the appropriate query-param.
-
-  The way we pass in parameters is complicated and silly: for public Dashboards, they're passed in as JSON-encoded
-  parameters that look something like (when decoded):
-
-      [{:type :category, :target [:variable [:template-tag :num]], :value \"50\"}]
-
-  For embedded Dashboards they're simply passed in as query parameters, e.g.
-
-      [{:num 50}]
-
-  Thus resolving the params has to take either format into account. To further complicate matters, a Dashboard's
-  `:parameters` column contains values that look something like:
-
-       [{:name \"Num\", :slug \"num\", :id \"537e37b4\", :type \"category\"}
-
-  This is sufficient to resolve slug-style params passed in to embedded Dashboards, but URL-encoded params for public
-  Dashboards do not have anything that can directly match them to a Dashboard `:parameters` entry. However, they
-  already have enough information for the query processor to handle resolving them itself; thus we simply need to make
-  sure these params are actually allowed to be used on the Dashboard. To do this, we can match them against the
-  `:parameter_mappings` for the Dashboard's DashboardCards, which look like:
-
-      [{:card_id 1, :target [:variable [:template-tag :num]], :parameter_id \"537e37b4\"}]
-
-  Thus for public Dashboards JSON-encoded style we can look for a matching Dashcard parameter mapping, based on
-  `:target`, and then find the matching Dashboard parameter, based on `:id`.
-
-  *Cries*
-
-  TODO -- Tom has mentioned this, and he is very correct -- our lives would be much easier if we just used slug-style
-  for everything, rather than the weird JSON-encoded format we use for public Dashboards. We should fix this!"
-  [dashboard-id :- su/IntGreaterThanZero, query-params :- (s/maybe [{s/Keyword s/Any}])]
-  (when (seq query-params)
-    (let [dashboard-params        (db/select-one-field :parameters Dashboard, :id dashboard-id)
-          slug->dashboard-param   (u/key-by :slug dashboard-params)
-          dashcard-param-mappings (dashboard->dashcard-param-mappings dashboard-id)]
-      (for [{slug :slug, target :target, :as query-param} query-params
-            :let [target (normalize/normalize-tokens target :ignore-path)
-                  dashboard-param
-                  (or
-                   ;; try to match by slug...
-                   (slug->dashboard-param slug)
-                   ;; ...if that fails, try to find a DashboardCard param mapping with the same target...
-                   (matching-dashboard-param-with-target dashboard-params dashcard-param-mappings target)
-                   ;; ...but if we *still* couldn't find a match, throw an Exception, because we don't want people
-                   ;; trying to inject new params
-                   (throw (ex-info (tru "Invalid param: {0}" slug)
-                                   {:type qp.error-type/invalid-parameter})))]]
-        (merge query-param dashboard-param)))))
-
-(defn- check-card-is-in-dashboard
-  "Check that the Card with `card-id` is in Dashboard with `dashboard-id`, either in a DashboardCard at the top level or
-  as a series, or throw an Exception. If not such relationship exists this will throw a 404 Exception."
-  [card-id dashboard-id]
-  (api/check-404
-   (or (db/exists? DashboardCard
-         :dashboard_id dashboard-id
-         :card_id      card-id)
-       (when-let [dashcard-ids (db/select-ids DashboardCard :dashboard_id dashboard-id)]
-         (db/exists? DashboardCardSeries
-           :card_id          card-id
-           :dashboardcard_id [:in dashcard-ids])))))
-
+;; TODO -- this should probably have a name like `run-query-for-dashcard...` so it matches up with
+;; [[run-query-for-card-with-id-async]]
 (defn public-dashcard-results-async
   "Return the results of running a query with `parameters` for Card with `card-id` belonging to Dashboard with
   `dashboard-id`. Throws a 404 immediately if the Card isn't part of the Dashboard. Returns a `StreamingResponse`."
-  [dashboard-id card-id export-format parameters
-   & {:keys [context constraints qp-runner]
-      :or   {context     :public-dashboard
-             constraints constraints/default-query-constraints
-             qp-runner   qp/process-query-and-save-execution!}}]
-  (check-card-is-in-dashboard card-id dashboard-id)
-  (let [params (resolve-params dashboard-id (if (string? parameters)
-                                              (json/parse-string parameters keyword)
-                                              parameters))]
-    (run-query-for-card-with-id-async
-     card-id export-format params
-     :dashboard-id dashboard-id
-     :context      context
-     :constraints  constraints
-     :qp-runner    qp-runner)))
+  [dashboard-id card-id export-format parameters & {:keys [qp-runner]
+                                                    :or   {qp-runner qp/process-query-and-save-execution!}
+                                                    :as   options}]
+  (let [options (merge
+                 {:context     :public-dashboard
+                  :constraints constraints/default-query-constraints}
+                 options
+                 {:dashboard-id  dashboard-id
+                  :card-id       card-id
+                  :export-format export-format
+                  :parameters    (cond-> parameters
+                                   (string? parameters) (json/parse-string keyword))
+                  :qp-runner     qp-runner
+                  :run           (run-query-for-card-with-id-async-run-fn qp-runner export-format)})]
+    ;; Run this query with full superuser perms. We don't want the various perms checks failing because there are no
+    ;; current user perms; if this Dashcard is public you're by definition allowed to run it without a perms check anyway
+    (binding [api/*current-user-permissions-set* (atom #{"/"})]
+      (m/mapply dashboard-api/run-query-for-dashcard-async options))))
 
 (api/defendpoint ^:streaming GET "/dashboard/:uuid/card/:card-id"
   "Fetch the results for a Card in a publicly-accessible Dashboard. Does not require auth credentials. Public
@@ -298,7 +216,6 @@
   (api/check-public-sharing-enabled)
   (let [dashboard-id (api/check-404 (db/select-one-id Dashboard :public_uuid uuid, :archived false))]
     (public-dashcard-results-async dashboard-id card-id :api parameters)))
-
 
 (api/defendpoint GET "/oembed"
   "oEmbed endpoint used to retreive embed code and metadata for a (public) Metabase URL."

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -1,7 +1,7 @@
 (ns metabase.api.dashboard-test
   "Tests for /api/dashboard endpoints."
-  (:require [clojure.string :as str]
-            [cheshire.core :as json]
+  (:require [cheshire.core :as json]
+            [clojure.string :as str]
             [clojure.test :refer :all]
             [clojure.walk :as walk]
             [medley.core :as m]

--- a/test/metabase/query_processor/streaming/test_util.clj
+++ b/test/metabase/query_processor/streaming/test_util.clj
@@ -1,0 +1,107 @@
+(ns metabase.query-processor.streaming.test-util
+  "Utility functions for testing QP streaming (download) functionality."
+  (:require [cheshire.core :as json]
+            [clojure.data.csv :as csv]
+            [clojure.test :refer :all]
+            [dk.ative.docjure.spreadsheet :as spreadsheet]
+            [metabase.query-processor :as qp]
+            [metabase.query-processor.streaming :as qp.streaming]
+            [metabase.test :as mt])
+  (:import [java.io BufferedInputStream BufferedOutputStream ByteArrayInputStream ByteArrayOutputStream InputStream InputStreamReader]))
+
+(defmulti ^:private parse-result*
+  {:arglists '([export-format ^InputStream input-stream column-names])}
+  (fn [export-format _ _] (keyword export-format)))
+
+(defmethod parse-result* :api
+  [_ ^InputStream is _]
+  (with-open [reader (InputStreamReader. is)]
+    (let [response (json/parse-stream reader true)]
+      (cond-> response
+        (map? response) (dissoc :database_id :started_at :json_query :average_execution_time :context :running_time)))))
+
+(defmethod parse-result* :json
+  [export-format is column-names]
+  ((get-method parse-result* :api) export-format is column-names))
+
+(defmethod parse-result* :csv
+  [_ ^InputStream is _]
+  (with-open [reader (InputStreamReader. is)]
+    (doall (csv/read-csv reader))))
+
+(defmethod parse-result* :xlsx
+  [_ ^InputStream is column-names]
+  (->> (spreadsheet/load-workbook-from-stream is)
+       (spreadsheet/select-sheet "Query result")
+       (spreadsheet/select-columns (zipmap (map (comp keyword str char)
+                                                (range (int \A) (inc (int \Z))))
+                                           column-names))
+       rest))
+
+(defn parse-result
+  ([export-format input-stream]
+   (parse-result export-format input-stream ["ID" "Name" "Category ID" "Latitude" "Longitude" "Price"]))
+
+  ([export-format input-stream column-names]
+   (parse-result* export-format input-stream column-names)))
+
+(defn process-query-basic-streaming
+  "Process `query` and export it as `export-format` (in-memory), then parse the results."
+  {:arglists '([export-format query] [export-format query column-names])}
+  [export-format query & args]
+  (with-open [bos (ByteArrayOutputStream.)
+              os  (BufferedOutputStream. bos)]
+    (is (= :completed
+           (:status (qp/process-query query (assoc (qp.streaming/streaming-context export-format os)
+                                                   :timeout 15000)))))
+    (.flush os)
+    (let [bytea (.toByteArray bos)]
+      (with-open [is (BufferedInputStream. (ByteArrayInputStream. bytea))]
+        (apply parse-result export-format is args)))))
+
+(defn process-query-api-response-streaming
+  "Process `query` as an API request, exporting it as `export-format` (in-memory), then parse the results."
+  {:arglists '([export-format query] [export-format query column-names])}
+  [export-format query & args]
+  (let [byytes (if (= export-format :api)
+                 (mt/user-http-request :crowberto :post "dataset"
+                                       {:request-options {:as :byte-array}}
+                                       (assoc-in query [:middleware :js-int-to-string?] false))
+                 (mt/user-http-request :crowberto :post (format "dataset/%s" (name export-format))
+                                       {:request-options {:as :byte-array}}
+                                       :query (json/generate-string query)))]
+    (with-open [is (ByteArrayInputStream. byytes)]
+      (apply parse-result export-format is args))))
+
+(defmulti expected-results
+  {:arglists '([export-format normal-results])}
+  (fn [export-format _] (keyword export-format)))
+
+(defmethod expected-results :api
+  [_ normal-results]
+  (mt/obj->json->obj normal-results))
+
+(defmethod expected-results :json
+  [_ normal-results]
+  (let [{{:keys [cols rows]} :data} (mt/obj->json->obj normal-results)]
+    (for [row rows]
+      (zipmap (map (comp keyword :display_name) cols)
+              row))))
+
+(defmethod expected-results :csv
+  [_ normal-results]
+  (let [{{:keys [cols rows]} :data} normal-results]
+    (cons (map :display_name cols)
+          (for [row rows]
+            (for [v row]
+              (str v))))))
+
+(defmethod expected-results :xlsx
+  [_ normal-results]
+  (let [{{:keys [cols rows]} :data} normal-results]
+    (for [row rows]
+      (zipmap (map :display_name cols)
+              (for [v row]
+                (if (number? v)
+                  (double v)
+                  v))))))


### PR DESCRIPTION
Part of https://github.com/metabase/metaboat/issues/144

This PR adds new `POST /api/dashboard/:id/card/:card-id/query` and `POST /api/dashboard/:id/card/:card-id/query/:export-format` endpoints. These new endpoints validate that the passed `:parameters` are allowed for the Dashboard and Card in question.

We already had similar endpoints for public and embedded dashboards, e.g. `GET /api/public/dashboard/:uuid/card/:card-id`. As part of this PR I unified the parameter handling and DashCard query execution used in the public and embed endpoints with the new code in `metabase.api.dashboard`. Previously the way we resolved params was not totally consistent, e.g. the `public` endpoints attempted to resolve parameters by either `:id` _or_ `:slug`, whereas other endpoints such as the chain filter endpoints exclusively resolve things by `:id`. This PR consolidates things so parameters are consistently always resolved by `:id`, except for embedding which still resolves by `:slug` due to the way embedding works. As part of this project I had to rework a bunch of public/embed tests that created Dashboards/Dashcards without and `:parameters` or `:parameter_mappings` respectively, which now would trigger a 'no matching parameter' error. I did a little code cleanup there while I was at it.

Overall this PR makes our parameter handling story a little less hairy. Parameter handling is still a little bit complicated, but at least it's complicated in more consistent ways now