### PR TITLE
Add fixture warning to rebuild static viz on failures

### DIFF
--- a/test/metabase/pulse/render/js_svg_test.clj
+++ b/test/metabase/pulse/render/js_svg_test.clj
@@ -17,6 +17,12 @@
 
 (def parse-svg #'js-svg/parse-svg-string)
 
+(use-fixtures :each
+  (fn warn-possible-rebuild
+    [thunk]
+    (testing "[PRO TIP] If this test fails, you may need to rebuild the bundle with `yarn build-static-viz`\n"
+      (thunk))))
+
 (deftest post-process-test
   (let [svg   "<svg ><g><line/></g><g><rect/></g><g><circle/></g></svg>"
         nodes (atom [])]


### PR DESCRIPTION
Had wanted to make a heuristic that would look at timestamp of the
bundle and timestamps of the sources and compare. But this could fail
when switching branches. Simpler and easier to just throw a warning on
all failures

```clojure
js-svg-test=> (binding [*test-out* *out*] (run-tests))

Testing metabase.pulse.render.js-svg-test

FAIL in (foo) (js_svg_test.clj:28)
[PRO TIP] If this test fails, you may need to rebuild the bundle with `yarn build-static-viz`

expected: 1
  actual: 2
    diff: - 1
          + 2

Ran 8 tests containing 29 assertions.
1 failures, 0 errors.
{:test 8, :pass 28, :fail 1, :error 0, :type :summary}
```

For posterity, attempt using timestamps was

```clojure
(deftest bundle-up-to-date-test
  (let [js-bundle (io/file (io/resource js-svg/bundle-path))
        to-date   (fn [epoch] (java.time.Instant/ofEpochMilli epoch))]
    (is (.exists js-bundle) bundle-recreate-warning)
    (when (.exists js-bundle)
      (let [source-files       (file-seq (io/file "frontend/src/metabase/static-viz"))
            most-recent-source (apply max-key #(.lastModified %) source-files)]
        (is (.isAfter (to-date (.lastModified js-bundle))
                      (to-date (.lastModified most-recent-source)))
            bundle-recreate-warning)))))
```
