### PR TITLE
Only select type information on type inference of coalesce

### DIFF
--- a/frontend/test/metabase/scenarios/question/reproductions/18630-field-literals-in-joins.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/18630-field-literals-in-joins.cy.spec.js
@@ -56,8 +56,9 @@ describe("issue 18630", () => {
       { visitQuestion: true },
     );
 
-    // The query itself is not expected to run,
-    // it just shouldn't stuck on the loading phase
-    cy.findByText("There was a problem with your question");
+    // The query runs and we assert the page is not blank,
+    // rather than an infinite loop and stack overflow.
+    // 'test question' is the name of the question.
+    cy.findByText("test question");
   });
 });

--- a/src/metabase/query_processor/middleware/annotate.clj
+++ b/src/metabase/query_processor/middleware/annotate.clj
@@ -133,7 +133,8 @@
     (col-info-for-field-clause {} expression)
 
     (mbql.u/is-clause? :coalesce expression)
-    (infer-expression-type (second expression))
+    (select-keys (infer-expression-type (second expression))
+                 [:base_type :effective_type :coercion_strategy :semantic_type])
 
     (mbql.u/is-clause? :length expression)
     {:base_type :type/BigInteger}

--- a/src/metabase/query_processor/middleware/annotate.clj
+++ b/src/metabase/query_processor/middleware/annotate.clj
@@ -119,6 +119,11 @@
 
 (declare col-info-for-field-clause)
 
+(def type-info-columns
+  "Columns to select from a field to get its type information without getting information that is specific to that
+  column."
+  [:base_type :effective_type :coercion_strategy :semantic_type])
+
 (defn infer-expression-type
   "Infer base-type/semantic-type information about an `expression` clause."
   [expression]
@@ -133,8 +138,7 @@
     (col-info-for-field-clause {} expression)
 
     (mbql.u/is-clause? :coalesce expression)
-    (select-keys (infer-expression-type (second expression))
-                 [:base_type :effective_type :coercion_strategy :semantic_type])
+    (select-keys (infer-expression-type (second expression)) type-info-columns)
 
     (mbql.u/is-clause? :length expression)
     {:base_type :type/BigInteger}
@@ -148,7 +152,7 @@
                     (or (not (mbql.u/is-clause? :value expression))
                         (let [[_ value] expression]
                           (not= value nil))))
-           (infer-expression-type expression)))
+           (select-keys (infer-expression-type expression) type-info-columns)))
        clauses))
 
     (mbql.u/datetime-arithmetics? expression)

--- a/test/metabase/query_processor/middleware/annotate_test.clj
+++ b/test/metabase/query_processor/middleware/annotate_test.clj
@@ -438,10 +438,71 @@
   (-> (add-column-info (mt/mbql-query venues {:expressions {"expr" expr}
                                               :fields      [[:expression "expr"]]
                                               :limit       10})
-                                      {})
+                       {})
       :cols
       first
       (select-keys [:base_type :semantic_type])))
+
+(deftest computed-columns-inference
+  (letfn [(infer [expr] (-> (mt/mbql-query venues
+                                           {:expressions {"expr" expr}
+                                            :fields [[:expression "expr"]]
+                                            :limit 10})
+                            (add-column-info {})
+                            :cols
+                            first))]
+    (testing "Coalesce"
+      (testing "Uses the first clause"
+        (testing "Gets the type information from the field"
+          (is (= {:semantic_type :type/Name,
+                  :coercion_strategy nil,
+                  :name "expr",
+                  :expression_name "expr",
+                  :source :fields,
+                  :field_ref [:expression "expr"],
+                  :effective_type :type/Text,
+                  :display_name "expr",
+                  :base_type :type/Text}
+                 (infer [:coalesce [:field (mt/id :venues :name) nil] "bar"])))
+          (testing "Does not contain a field id in its analysis (#18513)"
+            (is (false? (contains? (infer [:coalesce [:field (mt/id :venues :name) nil] "bar"])
+                                   :id)))))
+        (testing "Gets the type information from the literal"
+          (is (= {:base_type :type/Text,
+                  :name "expr",
+                  :display_name "expr",
+                  :expression_name "expr",
+                  :field_ref [:expression "expr"],
+                  :source :fields}
+                 (infer [:coalesce "bar" [:field (mt/id :venues :name) nil]]))))))
+    (testing "Case"
+      (testing "Uses first available type information"
+        (testing "From a field"
+          (is (= {:semantic_type :type/Name,
+                  :coercion_strategy nil,
+                  :name "expr",
+                  :expression_name "expr",
+                  :source :fields,
+                  :field_ref [:expression "expr"],
+                  :effective_type :type/Text,
+                  :display_name "expr",
+                  :base_type :type/Text}
+                 (infer [:coalesce [:field (mt/id :venues :name) nil] "bar"])))
+          (testing "does not contain a field id in its analysis (#17512)"
+            (is (false?
+                 (contains? (infer [:coalesce [:field (mt/id :venues :name) nil] "bar"])
+                            :id))))))
+      (is (= {:base_type :type/Text}
+             (infered-col-type [:case [[[:> [:field (mt/id :venues :price) nil] 2] "big"]]])))
+      (is (= {:base_type :type/Float}
+             (infered-col-type [:case [[[:> [:field (mt/id :venues :price) nil] 2]
+                                        [:+ [:field (mt/id :venues :price) nil] 1]]]])))
+      (testing "Make sure we skip nils when infering case return type"
+        (is (= {:base_type :type/Number}
+               (infered-col-type [:case [[[:< [:field (mt/id :venues :price) nil] 10] [:value nil {:base_type :type/Number}]]
+                                         [[:> [:field (mt/id :venues :price) nil] 2] 10]]]))))
+      (is (= {:base_type :type/Float}
+             (infered-col-type [:case [[[:> [:field (mt/id :venues :price) nil] 2] [:+ [:field (mt/id :venues :price) nil] 1]]]]))))))
 
 (deftest test-string-extracts
   (is (= {:base_type :type/Text}
@@ -469,19 +530,6 @@
   (is (= {:base_type     :type/Text
           :semantic_type :type/Name}
          (infered-col-type  [:coalesce [:field (mt/id :venues :name) nil] "bar"]))))
-
-(deftest test-case
-  (is (= {:base_type :type/Text}
-         (infered-col-type [:case [[[:> [:field (mt/id :venues :price) nil] 2] "big"]]])))
-  (is (= {:base_type :type/Float}
-         (infered-col-type [:case [[[:> [:field (mt/id :venues :price) nil] 2]
-                                    [:+ [:field (mt/id :venues :price) nil] 1]]]])))
-  (testing "Make sure we skip nils when infering case return type"
-    (is (= {:base_type :type/Number}
-           (infered-col-type [:case [[[:< [:field (mt/id :venues :price) nil] 10] [:value nil {:base_type :type/Number}]]
-                                     [[:> [:field (mt/id :venues :price) nil] 2] 10]]]))))
-  (is (= {:base_type :type/Float}
-         (infered-col-type [:case [[[:> [:field (mt/id :venues :price) nil] 2] [:+ [:field (mt/id :venues :price) nil] 1]]]]))))
 
 (deftest unique-name-key-test
   (testing "Make sure `:cols` always come back with a unique `:name` key (#8759)"


### PR DESCRIPTION
Fixes #18513
Fixes #17512 

When emitting nested queries, we use the metadata of the columns to create the fields clause of what to select. We have middleware that will get the expected columns from the subselect. In the `add-implicit-clauses` middleware we `add-implicit-fields` to select all that we are querying for. That will use the metadata to create the fields clause. And that mechanism, if it sees a field-id, will just emit a reference to that field.

This previously just selected hte inferred information from the second
argument to the coalesce. For fields this would return the entire field
object which includes an id.

Later, in `source-metadata->fields` this assumes that since an id is
present, we should select `[:field id nil]`, but this confused that the
type of the coalesce column is the same as that field-id, not that we
want to select that field id.

```clojure
add-source-metadata=> (pprint
                        (mbql-source-query->metadata {:source-table 2
                                                      :joins [{:fields [[:field
                                                                         22
                                                                         {:join-alias "People - User"}]
                                                                        [:field
                                                                         15
                                                                         {:join-alias "People - User"}]]
                                                               :source-table 3
                                                               :condition [:=
                                                                           [:field 3 nil]
                                                                           [:field
                                                                            22
                                                                            {:join-alias "People - User"}]]
                                                               :alias "People - User"}]
                                                      :expressions {:coalesce [:coalesce
                                                                               [:field 3 nil]
                                                                               [:field
                                                                                22
                                                                                {:join-alias "People - User"}]]}
                                                      :aggregation [[:count]]
                                                      :breakout [[:expression "coalesce"]]}))
({:semantic_type :type/FK,
  :table_id 2,
  :coercion_strategy nil,
  :name "coalesce",                    ;; merging maintains the correct name
  :settings nil,
  :field_ref [:expression "coalesce"], ;; merging maintains the field ref
  :effective_type :type/Integer,
  :parent_id nil,
  :id 3,                               ;; the type inference selected
                                       ;; the entire field, including its id
  :display_name "coalesce",
  :fingerprint {:global {:distinct-count 929, :nil% 0.0}},
  :base_type :type/Integer}
 {:name "count",
  :display_name "Count",
  :base_type :type/BigInteger,
  :semantic_type :type/Quantity,
  :field_ref [:aggregation 0]})
nil
```

updating to only select the type information:

```clojure
add-source-metadata=> (pprint
                        (mbql-source-query->metadata {:source-table 2
                                                      :joins [{:fields [[:field
                                                                         22
                                                                         {:join-alias "People - User"}]
                                                                        [:field
                                                                         15
                                                                         {:join-alias "People - User"}]]
                                                               :source-table 3
                                                               :condition [:=
                                                                           [:field 3 nil]
                                                                           [:field
                                                                            22
                                                                            {:join-alias "People - User"}]]
                                                               :alias "People - User"}]
                                                      :expressions {:coalesce [:coalesce
                                                                               [:field 3 nil]
                                                                               [:field
                                                                                22
                                                                                {:join-alias "People - User"}]]}
                                                      :aggregation [[:count]]
                                                      :breakout [[:expression "coalesce"]]}))
({:name "coalesce",
  :display_name "coalesce",
  :base_type :type/Integer,
  :effective_type :type/Integer,  ;; no more field information beyond
                                  ;; the types
  :coercion_strategy nil,
  :semantic_type :type/FK,
  :field_ref [:expression "coalesce"]}
 {:name "count",
  :display_name "Count",
  :base_type :type/BigInteger,
  :semantic_type :type/Quantity,
  :field_ref [:aggregation 0]})
```

An invariant that we have to watch out for is that no ids can end up on these inferences unless it is literally going to select a field.

```clojure
(s/defn ^:private source-metadata->fields :- mbql.s/Fields
  "Get implicit Fields for a query with a `:source-query` that has `source-metadata`."
  [source-metadata :- (su/non-empty [mbql.s/SourceQueryMetadata])]
  (distinct
   (for [{field-name :name, base-type :base_type, field-id :id, field-ref :field_ref} source-metadata]
     ;; return field-ref directly if it's a `:field` clause already. It might include important info such as
     ;; `:join-alias` or `:source-field`. Remove binning/temporal bucketing info. The Field should already be getting
     ;; bucketed in the source query; don't need to apply bucketing again in the parent query.
     (or (some-> (mbql.u/match-one field-ref :field)
                 (mbql.u/update-field-options dissoc :binning :temporal-unit))
         ;; otherwise construct a field reference that can be used to refer to this Field.
         (if field-id
           ;; If we have a Field ID, return a `:field` (id) clause
           [:field field-id nil]
           ;; otherwise return a `:field` (name) clause, e.g. for a Field that's the result of an aggregation or
           ;; expression
           [:field field-name {:base-type base-type}])))))   ;; all custom fields must take this branch
```