### PR TITLE
Adding collection items from collection page

### DIFF
--- a/frontend/src/metabase-lib/lib/Question.js
+++ b/frontend/src/metabase-lib/lib/Question.js
@@ -139,6 +139,7 @@ export default class Question {
   static create({
     databaseId,
     tableId,
+    collectionId,
     metadata,
     parameterValues,
     type = "query",
@@ -161,6 +162,7 @@ export default class Question {
   } = {}) {
     let card: CardObject = {
       name,
+      collection_id: collectionId,
       display,
       visualization_settings,
       dataset_query,
@@ -1066,6 +1068,7 @@ export default class Question {
     const cardCopy = {
       name: this._card.name,
       description: this._card.description,
+      collection_id: this._card.collection_id,
       dataset_query: query.datasetQuery(),
       display: this._card.display,
       parameters: this._card.parameters,

--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.jsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.jsx
@@ -9,7 +9,9 @@ import Icon, { IconWrapper } from "metabase/components/Icon";
 import Link from "metabase/components/Link";
 import PageHeading from "metabase/components/type/PageHeading";
 import Tooltip from "metabase/components/Tooltip";
+
 import CollectionEditMenu from "metabase/collections/components/CollectionEditMenu";
+import NewCollectionItemMenu from "metabase/collections/components/NewCollectionItemMenu";
 
 import { PLUGIN_COLLECTION_COMPONENTS } from "metabase/plugins";
 
@@ -83,30 +85,12 @@ function EditMenu({
   ) : null;
 }
 
-function CreateCollectionLink({
-  collection,
-  collectionId,
-  hasWritePermission,
-}) {
-  const tooltip = t`New collection`;
-  const link = Urls.newCollection(collectionId);
-
-  return hasWritePermission ? (
-    <Tooltip tooltip={tooltip}>
-      <Link to={link}>
-        <IconWrapper>
-          <Icon name="new_folder" />
-        </IconWrapper>
-      </Link>
-    </Tooltip>
-  ) : null;
-}
-
 function Menu(props) {
+  const { hasWritePermission } = props;
   return (
-    <MenuContainer>
+    <MenuContainer data-testid="collection-menu">
+      {hasWritePermission && <NewCollectionItemMenu {...props} />}
       <EditMenu {...props} />
-      <CreateCollectionLink {...props} />
       <PermissionsLink {...props} />
     </MenuContainer>
   );

--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.unit.spec.js
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.unit.spec.js
@@ -78,8 +78,8 @@ describe("permissions link", () => {
   });
 });
 
-describe("link to edit collection", () => {
-  const ariaLabel = "pencil icon";
+describe("link to add new collection items", () => {
+  const ariaLabel = "add icon";
 
   describe("should not be displayed", () => {
     it("when no detail is passed in the collection to determine if user can change collection", () => {
@@ -104,8 +104,8 @@ describe("link to edit collection", () => {
   });
 });
 
-describe("link to create a new collection", () => {
-  const ariaLabel = "new_folder icon";
+describe("link to add new collection items", () => {
+  const ariaLabel = "add icon";
 
   describe("should not be displayed", () => {
     it("if user is not allowed to change collection", () => {

--- a/frontend/src/metabase/collections/components/NewCollectionItemMenu.jsx
+++ b/frontend/src/metabase/collections/components/NewCollectionItemMenu.jsx
@@ -1,0 +1,39 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { t } from "ttag";
+
+import * as Urls from "metabase/lib/urls";
+
+import EntityMenu from "metabase/components/EntityMenu";
+import { ANALYTICS_CONTEXT } from "metabase/collections/constants";
+
+const propTypes = {
+  collection: PropTypes.func,
+  list: PropTypes.arrayOf(PropTypes.object),
+};
+
+function NewCollectionItemMenu({ collection }) {
+  const items = [
+    {
+      title: t`Question`,
+      link: Urls.newQuestion({ mode: "notebook", collectionId: collection.id }),
+      event: `${ANALYTICS_CONTEXT};New Item Menu;Question Click`,
+    },
+    {
+      title: t`Dashboard`,
+      link: Urls.newDashboard(collection.id),
+      event: `${ANALYTICS_CONTEXT};New Item Menu;Dashboard Click`,
+    },
+    {
+      title: t`Collection`,
+      link: Urls.newCollection(collection.id),
+      event: `${ANALYTICS_CONTEXT};New Item Menu;Collection Click`,
+    },
+  ];
+
+  return <EntityMenu items={items} triggerIcon="add" tooltip={t`Create`} />;
+}
+
+NewCollectionItemMenu.propTypes = propTypes;
+
+export default NewCollectionItemMenu;

--- a/frontend/src/metabase/collections/components/NewCollectionItemMenu.jsx
+++ b/frontend/src/metabase/collections/components/NewCollectionItemMenu.jsx
@@ -15,23 +15,26 @@ const propTypes = {
 function NewCollectionItemMenu({ collection }) {
   const items = [
     {
+      icon: "insight",
       title: t`Question`,
       link: Urls.newQuestion({ mode: "notebook", collectionId: collection.id }),
       event: `${ANALYTICS_CONTEXT};New Item Menu;Question Click`,
     },
     {
+      icon: "dashboard",
       title: t`Dashboard`,
       link: Urls.newDashboard(collection.id),
       event: `${ANALYTICS_CONTEXT};New Item Menu;Dashboard Click`,
     },
     {
+      icon: "folder",
       title: t`Collection`,
       link: Urls.newCollection(collection.id),
       event: `${ANALYTICS_CONTEXT};New Item Menu;Collection Click`,
     },
   ];
 
-  return <EntityMenu items={items} triggerIcon="add" tooltip={t`Create`} />;
+  return <EntityMenu items={items} triggerIcon="add" tooltip={t`New…`} />;
 }
 
 NewCollectionItemMenu.propTypes = propTypes;

--- a/frontend/src/metabase/containers/CollectionName.jsx
+++ b/frontend/src/metabase/containers/CollectionName.jsx
@@ -4,10 +4,10 @@ import React from "react";
 import Collection, { ROOT_COLLECTION } from "metabase/entities/collections";
 
 const CollectionName = ({ id }) => {
-  if (id === undefined || isNaN(id)) {
-    return null;
-  } else if (id === "root" || id === null) {
+  if (id === "root" || id === null) {
     return <span>{ROOT_COLLECTION.name}</span>;
+  } else if (id === undefined || isNaN(id)) {
+    return null;
   } else {
     return <Collection.Name id={id} />;
   }

--- a/frontend/src/metabase/query_builder/components/DataSelector.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.styled.jsx
@@ -119,3 +119,32 @@ export function DataBucketListItem(props) {
     </DataBucketListItemContainer>
   );
 }
+
+export const CollectionDatasetSelectList = styled(SelectList)`
+  width: 300px;
+  max-width: 300px;
+  padding: 0.5rem;
+`;
+
+CollectionDatasetSelectList.Item = SelectList.Item;
+
+export const CollectionDatasetAllDataLink = styled(SelectList.BaseItem)`
+  padding: 0.5rem;
+
+  color: ${color("text-light")};
+  font-weight: bold;
+  cursor: pointer;
+
+  :hover {
+    color: ${color("brand")};
+  }
+`;
+
+CollectionDatasetAllDataLink.Content = styled.span`
+  display: flex;
+  align-items: center;
+
+  .Icon {
+    margin-left: ${space(0)};
+  }
+`;

--- a/frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx
@@ -3,7 +3,7 @@ import React from "react";
 import { connect } from "react-redux";
 import { t } from "ttag";
 
-import { DataSourceSelector } from "metabase/query_builder/components/DataSelector";
+import { CollectionDatasetOrDataSourceSelector } from "metabase/query_builder/components/DataSelector";
 import { getDatabasesList } from "metabase/query_builder/selectors";
 
 import { NotebookCell, NotebookCellItem } from "../NotebookCell";
@@ -15,8 +15,17 @@ import {
 import FieldsPicker from "./FieldsPicker";
 
 function DataStep({ color, query, updateQuery }) {
+  const question = query.question();
   const table = query.table();
   const canSelectTableColumns = table && query.isRaw();
+
+  const hasCollectionDatasetsStep =
+    question &&
+    !question.isSaved() &&
+    !question.databaseId() &&
+    !question.tableId() &&
+    question.collectionId() !== undefined;
+
   return (
     <NotebookCell color={color}>
       <NotebookCellItem
@@ -36,8 +45,10 @@ function DataStep({ color, query, updateQuery }) {
         rightContainerStyle={FIELDS_PICKER_STYLES.notebookRightItemContainer}
         data-testid="data-step-cell"
       >
-        <DataSourceSelector
+        <CollectionDatasetOrDataSourceSelector
           hasTableSearch
+          collectionId={question.collectionId()}
+          hasCollectionDatasetsStep={hasCollectionDatasetsStep}
           databaseQuery={{ saved: true }}
           selectedDatabaseId={query.databaseId()}
           selectedTableId={query.tableId()}

--- a/frontend/test/__support__/e2e/cypress.js
+++ b/frontend/test/__support__/e2e/cypress.js
@@ -20,6 +20,7 @@ export * from "./helpers/e2e-mock-app-settings-helpers";
 export * from "./helpers/e2e-notebook-helpers";
 export * from "./helpers/e2e-assertion-helpers";
 export * from "./helpers/e2e-cloud-helpers";
+export * from "./helpers/e2e-collection-helpers";
 export * from "./helpers/e2e-data-model-helpers";
 export * from "./helpers/e2e-misc-helpers";
 export * from "./helpers/e2e-email-helpers";

--- a/frontend/test/__support__/e2e/helpers/e2e-collection-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-collection-helpers.js
@@ -1,0 +1,20 @@
+import { popover } from "__support__/e2e/cypress";
+
+export function assertCanAddItemsToCollection() {
+  cy.findByTestId("collection-menu").within(() => {
+    cy.icon("add");
+  });
+}
+
+/**
+ * Clicks the "+" icon on the collection page and selects one of the menu options
+ * @param {"question" | "dashboard" | "collection"} type
+ */
+export function openNewCollectionItemFlowFor(type) {
+  cy.findByTestId("collection-menu").within(() => {
+    cy.icon("add").click();
+  });
+  popover()
+    .findByText(new RegExp(type, "i"))
+    .click();
+}

--- a/frontend/test/metabase/scenarios/collections/collection-types.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collection-types.cy.spec.js
@@ -156,7 +156,7 @@ describeWithoutToken("collection types", () => {
   it("should not be able to manage collection's authority level", () => {
     cy.visit("/collection/root");
 
-    openNewCollectionModal();
+    openNewCollectionItemFlowFor("collection");
     modal().within(() => {
       assertNoCollectionTypeInput();
       cy.icon("close").click();

--- a/frontend/test/metabase/scenarios/collections/collection-types.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collection-types.cy.spec.js
@@ -4,6 +4,7 @@ import {
   sidebar,
   describeWithToken,
   describeWithoutToken,
+  openNewCollectionItemFlowFor,
 } from "__support__/e2e/cypress";
 import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
 
@@ -59,7 +60,7 @@ describeWithToken("collections types", () => {
     cy.findByText("First collection").click();
 
     // Test not visible when creating a new collection
-    cy.icon("new_folder").click();
+    openNewCollectionItemFlowFor("collection");
     modal().within(() => {
       cy.findByText(TREE_UPDATE_REGULAR_MESSAGE).should("not.exist");
       cy.findByText(TREE_UPDATE_OFFICIAL_MESSAGE).should("not.exist");
@@ -110,7 +111,7 @@ describeWithToken("collections types", () => {
 
     openCollection("First collection");
 
-    cy.icon("new_folder").click();
+    openNewCollectionItemFlowFor("collection");
     modal().within(() => {
       assertNoCollectionTypeInput();
       cy.icon("close").click();
@@ -129,7 +130,7 @@ describeWithToken("collections types", () => {
     openCollection("Your personal collection");
     cy.icon("pencil").should("not.exist");
 
-    cy.icon("new_folder").click();
+    openNewCollectionItemFlowFor("collection");
     modal().within(() => {
       assertNoCollectionTypeInput();
       cy.findByLabelText("Name").type("Personal collection child");
@@ -138,7 +139,7 @@ describeWithToken("collections types", () => {
 
     openCollection("Personal collection child");
 
-    cy.icon("new_folder").click();
+    openNewCollectionItemFlowFor("collection");
     modal().within(() => {
       assertNoCollectionTypeInput();
       cy.icon("close").click();
@@ -155,7 +156,7 @@ describeWithoutToken("collection types", () => {
   it("should not be able to manage collection's authority level", () => {
     cy.visit("/collection/root");
 
-    cy.icon("new_folder").click();
+    openNewCollectionModal();
     modal().within(() => {
       assertNoCollectionTypeInput();
       cy.icon("close").click();
@@ -301,7 +302,7 @@ function setOfficial(official = true) {
 }
 
 function createAndOpenOfficialCollection({ name }) {
-  cy.icon("new_folder").click();
+  openNewCollectionItemFlowFor("collection");
   modal().within(() => {
     cy.findByLabelText("Name").type(name);
     setOfficial();

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -49,7 +49,9 @@ describe("collection permissions", () => {
                     displaySidebarChildOf("First collection");
                     displaySidebarChildOf("Second collection");
                   });
-                  cy.icon("add").click();
+                  cy.get(".Nav").within(() => {
+                    cy.icon("add").click();
+                  });
                   cy.findByText("New dashboard").click();
                   cy.get(".AdminSelect").findByText("Second collection");
                 });

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -242,7 +242,9 @@ describe("collection permissions", () => {
                       .as("title")
                       .contains("Third collection");
                     // Creating new sub-collection at this point shouldn't be possible
-                    cy.icon("new_folder").should("not.exist");
+                    cy.findByTestId("collection-menu").within(() => {
+                      cy.icon("add").should("not.exist");
+                    });
                     // We shouldn't be able to change permissions for an archived collection (the root issue of #12489!)
                     cy.icon("lock").should("not.exist");
                     /**

--- a/frontend/test/metabase/scenarios/collections/personal-collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/personal-collections.cy.spec.js
@@ -1,4 +1,11 @@
-import { restore, popover, modal, sidebar } from "__support__/e2e/cypress";
+import {
+  restore,
+  popover,
+  modal,
+  sidebar,
+  assertCanAddItemsToCollection,
+  openNewCollectionItemFlowFor,
+} from "__support__/e2e/cypress";
 import { USERS } from "__support__/e2e/cypress_data";
 
 describe("personal collections", () => {
@@ -31,12 +38,12 @@ describe("personal collections", () => {
     it("shouldn't be able to change permission levels or edit personal collections", () => {
       cy.visit("/collection/root");
       cy.findByText("Your personal collection").click();
-      cy.icon("new_folder");
+      assertCanAddItemsToCollection();
       cy.icon("lock").should("not.exist");
       cy.icon("pencil").should("not.exist");
       // Visit random user's personal collection
       cy.visit("/collection/5");
-      cy.icon("new_folder");
+      assertCanAddItemsToCollection();
       cy.icon("lock").should("not.exist");
       cy.icon("pencil").should("not.exist");
     });
@@ -49,7 +56,7 @@ describe("personal collections", () => {
       sidebar()
         .findByText("Foo")
         .click();
-      cy.icon("new_folder");
+      assertCanAddItemsToCollection();
       cy.icon("pencil");
       cy.icon("lock").should("not.exist");
 
@@ -74,7 +81,7 @@ describe("personal collections", () => {
 
     it.skip("should be able view other users' personal sub-collections (metabase#15339)", () => {
       cy.visit("/collection/5");
-      cy.icon("new_folder").click();
+      openNewCollectionItemFlowFor("collection");
       cy.findByLabelText("Name").type("Foo");
       cy.findByText("Create").click();
       // This repro could possibly change depending on the design decision for this feature implementation
@@ -150,7 +157,7 @@ describe("personal collections", () => {
 });
 
 function addNewCollection(name) {
-  cy.icon("new_folder").click();
+  openNewCollectionItemFlowFor("collection");
   cy.findByLabelText("Name").type(name);
   cy.findByText("Create").click();
 }

--- a/frontend/test/metabase/scenarios/question/datasets.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/datasets.cy.spec.js
@@ -192,7 +192,7 @@ describe("scenarios > datasets", () => {
       cy.visit("/collection/root");
       openNewCollectionItemFlowFor("question");
 
-      cy.findByText("All data").click();
+      cy.findByText("All data").click({ force: true });
 
       cy.findByText("Datasets");
       cy.findByText("Raw Data");


### PR DESCRIPTION
Adds a new flow for creating items inside collections. Every collection a user has write access to will have an "add" item next to "permissions" and "edit" icons in the top left side. It allows to create a question, dashboard or another collection inside the opened one.

Also, when you're selecting the "Question" option, it navigates you to a new custom question and suggests using one of the collection's datasets as starting data (if there are no datasets, the regular picker is shown. if there is only one dataset, it gets selected automatically)