### PR TITLE
Upgrade prettier one minor version to support Typescript `import type {} from "..."` and elvis operator syntax in precommit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -217,7 +217,7 @@
     "postcss-loader": "^6.2.0",
     "postcss-preset-env": "^6.7.0",
     "postcss-url": "^10.1.3",
-    "prettier": "1.18.2",
+    "prettier": "1.19.1",
     "promise-loader": "^1.0.0",
     "raf": "^3.4.0",
     "shadow-cljs": "2.11.20",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13191,10 +13191,10 @@ prepend-http@^1.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
 
-prettier@1.18.2:
-  version "1.18.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
-  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
+prettier@1.19.1:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
+  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
 pretty-bytes@^5.4.1:
   version "5.4.1"


### PR DESCRIPTION
Parser feature branch is blocked (can't even commit due to the precommit git hook!) by this upgrade.

Checking CI...