### PR TITLE
React ace style tweaks

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -311,6 +311,7 @@ export default class ExpressionEditorTextfield extends React.Component {
           wrapEnabled={true}
           fontSize={16}
           setOptions={{
+            indentedSoftWrap: false,
             minLines: 1,
             maxLines: 9,
             showLineNumbers: false,

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -307,6 +307,7 @@ export default class ExpressionEditorTextfield extends React.Component {
           ref={this.input}
           value={source}
           focus={true}
+          highlightActiveLine={false}
           wrapEnabled={true}
           fontSize={16}
           setOptions={{
@@ -319,6 +320,7 @@ export default class ExpressionEditorTextfield extends React.Component {
           }}
           onChange={source => this.onExpressionChange(source)}
           onCursorChange={selection => this.onCursorChange(selection)}
+          width="100%"
         />
         <ErrorMessage error={errorMessage} />
         <HelpText helpText={this.state.helpText} width={this.props.width} />


### PR DESCRIPTION
Makes editor width fit container.

Remove gray background when editor is empty (actually removes highlight from active line).

Soft wrap no longer creates a tab in new line.

### After

![metabase screenshot](https://user-images.githubusercontent.com/380816/142281852-89c01430-c545-49d6-a14a-43717dd52a79.gif)
