### PR TITLE
Custom expression suggestion: don't highlight too many characters

### DIFF
--- a/frontend/src/metabase/lib/expressions/suggest.js
+++ b/frontend/src/metabase/lib/expressions/suggest.js
@@ -130,7 +130,8 @@ export function suggest({
     ]) {
       const lower = (text || "").toLowerCase();
       if (lower.startsWith(partial)) {
-        suggestion.range = [0, partial.length];
+        const offset = partial[0] === "[" ? 1 : 0;
+        suggestion.range = [0, partial.length - offset];
         break suggestion;
       }
       let index = 0;

--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -517,7 +517,7 @@ describe("scenarios > question > filter", () => {
 
     typeInExpressionEditor("p");
 
-    // only the latter "P" (of Products etc) should be highlighted, and not "Pr"
+    // only "P" (of Products etc) should be highlighted, and not "Pr"
     popover()
       .get("span.text-dark")
       .contains("Pr")

--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -508,6 +508,22 @@ describe("scenarios > question > filter", () => {
       .and("not.eq", transparent);
   });
 
+  it("should highlight the correct matching for suggestions", () => {
+    openExpressionEditorFromFreshlyLoadedPage();
+
+    typeInExpressionEditor("[");
+
+    popover().findByText("Body");
+
+    typeInExpressionEditor("p");
+
+    // only the latter "P" (of Products etc) should be highlighted, and not "Pr"
+    popover()
+      .get("span.text-dark")
+      .contains("Pr")
+      .should("not.exist");
+  });
+
   it("should provide accurate auto-complete custom-expression suggestions based on the aggregated column name (metabase#14776)", () => {
     cy.viewport(1400, 1000); // We need a bit taller window for this repro to see all custom filter options in the popover
     cy.createQuestion({


### PR DESCRIPTION
I've added a Cypress test in `frontend/test/metabase/scenarios/question/filter.cy.spec.js`.

How to verify:

1. Ask a question, Custom question
2. Sample dataset, Products table
3. Filter, Custom expression and type `[`
4. Continue to type `p`

**Before this PR**

Initially, the first character in each suggestion is (confusingly) highlighted/in bold:

![image](https://user-images.githubusercontent.com/7288/142296233-2829a74f-8454-478f-81f6-df202dd61efa.png)

and then one more character after *C* is also highlighted/in bold:

![image](https://user-images.githubusercontent.com/7288/142296355-e682e749-fd71-4fa6-b267-7fae133098c3.png)

**After this PR**

Initially, no character is highlighted/in bold

![image](https://user-images.githubusercontent.com/7288/142296006-cb84743b-fce2-4663-a203-35f04d3a77a2.png)

and then only the **C** character is highlighted/in bold.

![image](https://user-images.githubusercontent.com/7288/142295892-5ceba221-f1f0-4bb9-8007-03400d8b8c79.png)

