### PR TITLE
Use /dataset URLs for datasets

### DIFF
--- a/frontend/src/metabase/App.jsx
+++ b/frontend/src/metabase/App.jsx
@@ -25,7 +25,7 @@ const mapStateToProps = (state, props) => ({
 const getErrorComponent = ({ status, data, context }) => {
   if (status === 403) {
     return <Unauthorized />;
-  } else if (status === 404) {
+  } else if (status === 404 || data?.error_code === "not-found") {
     return <NotFound />;
   } else if (
     data &&

--- a/frontend/src/metabase/lib/urls.js
+++ b/frontend/src/metabase/lib/urls.js
@@ -49,6 +49,8 @@ export function question(card, hash = "", query = "") {
   }
 
   const { card_id, id, name } = card;
+  const basePath =
+    card?.dataset || card?.model === "dataset" ? "dataset" : "question";
 
   /**
    * If the question has been added to the dashboard we're reading the dashCard's properties.
@@ -65,10 +67,10 @@ export function question(card, hash = "", query = "") {
    * Please see: https://github.com/metabase/metabase/pull/15989#pullrequestreview-656646149
    */
   if (!name) {
-    return `/question/${questionId}${query}${hash}`;
+    return `/${basePath}/${questionId}${query}${hash}`;
   }
 
-  const path = appendSlug(`/question/${questionId}`, slugg(name));
+  const path = appendSlug(`/${basePath}/${questionId}`, slugg(name));
 
   return `${path}${query}${hash}`;
 }

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -449,6 +449,18 @@ export const initializeQB = (location, params, queryParams) => {
           card = null;
         }
 
+        if (!card.dataset && location.pathname.startsWith("/dataset")) {
+          dispatch(
+            setErrorPage({
+              data: {
+                error_code: "not-found",
+              },
+              context: "query-builder",
+            }),
+          );
+          card = null;
+        }
+
         preserveParameters = true;
       } catch (error) {
         console.warn("initializeQb failed because of an error:", error);

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -240,6 +240,13 @@ export const getRoutes = store => (
           <Route path=":slug/notebook" component={QueryBuilder} />
         </Route>
 
+        <Route path="/dataset">
+          <IndexRoute component={QueryBuilder} />
+          <Route path="notebook" component={QueryBuilder} />
+          <Route path=":slug" component={QueryBuilder} />
+          <Route path=":slug/notebook" component={QueryBuilder} />
+        </Route>
+
         <Route path="/ready" component={PostSetupApp} />
 
         <Route path="browse" component={BrowseApp}>

--- a/frontend/test/metabase/lib/urls.unit.spec.js
+++ b/frontend/test/metabase/lib/urls.unit.spec.js
@@ -66,6 +66,20 @@ describe("urls", () => {
         );
       });
     });
+
+    describe("dataset", () => {
+      it("returns /dataset URLS", () => {
+        expect(question({ id: 1, dataset: true, name: "Foo" })).toEqual(
+          "/dataset/1-foo",
+        );
+        expect(
+          question({ id: 1, card_id: 42, dataset: true, name: "Foo" }),
+        ).toEqual("/dataset/42-foo");
+        expect(
+          question({ id: 1, card_id: 42, model: "dataset", name: "Foo" }),
+        ).toEqual("/dataset/42-foo");
+      });
+    });
   });
 
   describe("query", () => {

--- a/frontend/test/metabase/scenarios/question/datasets.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/datasets.cy.spec.js
@@ -83,7 +83,7 @@ describe("scenarios > datasets", () => {
   it("allows to turn a dataset back into a saved question", () => {
     cy.request("PUT", "/api/card/1", { dataset: true });
     cy.intercept("PUT", "/api/card/1").as("cardUpdate");
-    cy.visit("/question/1");
+    cy.visit("/dataset/1");
 
     openDetailsSidebar();
     cy.findByText("Turn back into a saved question").click();
@@ -95,6 +95,19 @@ describe("scenarios > datasets", () => {
     cy.findByText("Undo").click();
     cy.wait("@cardUpdate");
     assertIsDataset();
+  });
+
+  it("shows 404 when opening a question with a /dataset URL", () => {
+    cy.visit("/dataset/1");
+    cy.findByText(/We're a little lost/i);
+  });
+
+  it("redirects to /dataset URL when opening a dataset with /question URL", () => {
+    cy.request("PUT", "/api/card/1", { dataset: true });
+    cy.visit("/question/1");
+    openDetailsSidebar();
+    assertIsDataset();
+    cy.url().should("include", "/dataset");
   });
 
   describe("data picker", () => {
@@ -508,7 +521,7 @@ function openDetailsSidebar() {
   cy.findByTestId("saved-question-header-button").click();
 }
 
-function getDetailsSidebarActions(iconName) {
+function getDetailsSidebarActions() {
   return cy.findByTestId("question-action-buttons");
 }
 


### PR DESCRIPTION
This PR makes dataset pages use `/dataset/:id-:slug` URLs instead of `/quesiton/:id-:slug`

### To Verify

1. Try opening a dataset in a few ways:
   * from your browser address bar
   * by clicking on it on a collection page
   * from search
   * in any other way that comes to mind
2. You should always end up on the `/dataset/:id-:slug` page
3. While being on the dataset page, add a filter or summarize some data to make an ad-hoc question out of it. The URL should change to `/question#hash`
4. Open another saved question and turn it into a dataset, the URL should change to `/dataset/:id-:slug`
5. Turn a dataset back into a saved question (from a details sidebar), the URL should change to `/question/:id-:slug`
6. Paste `/question/$DS_ID` (where `DS_ID` is a _dataset_ ID) in your browser's address bar. The URL should be replaced with `/dataset` at some point
7. Paste `/dataset/$Q_ID` (where `Q_ID` is a _question_ ID) in your browser's address bar, you should see a 404 page