### PR TITLE
Custom expression suggestion: tackle a dangling single/double quote

### DIFF
--- a/frontend/src/metabase/lib/expressions/completer.js
+++ b/frontend/src/metabase/lib/expressions/completer.js
@@ -13,6 +13,13 @@ export function partialMatch(expression) {
   const lastToken = _.last(tokens);
   if (lastToken && lastToken.type === TOKEN.Identifier) {
     if (lastToken.end === expression.length) {
+      const prevToken = tokens[tokens.length - 2];
+      if (prevToken && prevToken.type === TOKEN.String) {
+        if (prevToken.start + 1 === prevToken.end) {
+          // a dangling single- or double-quote
+          return null;
+        }
+      }
       return expression.slice(lastToken.start, lastToken.end);
     }
   }

--- a/frontend/test/metabase/lib/expressions/completer.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/completer.unit.spec.js
@@ -28,6 +28,11 @@ describe("metabase/lib/expressions/completer", () => {
       expect(partialMatch("")).toEqual(null);
       expect(partialMatch(" ")).toEqual(null);
     });
+
+    it("should handle a dangling quote", () => {
+      expect(partialMatch("concat('s")).toEqual(null);
+      expect(partialMatch('length("c')).toEqual(null);
+    });
   });
 
   describe("enclosingFunction", () => {


### PR DESCRIPTION
If the expression is invalid due to an unterminated string (perhaps the user is still not finished typing the expression), do not try to suggest possible matches (functions etc) for an identifier following that dangling quote.

This fixes the regression after PR #18969.

How to verify:
1. Ask a question, Custom question
2. Sample Dataset, People table
3. Filter, Custom expression, type `concat("n`

**Before this PR**

`n` is treated as a possible prefix for a match (in this case `Name` field).

![image](https://user-images.githubusercontent.com/7288/142442435-f352f553-dcbf-4dec-a68e-e1ab8435851c.png)

**After this PR**

`n` is ignored.

![image](https://user-images.githubusercontent.com/7288/142442489-17092c14-b5cc-44e3-b358-90f4453119ff.png)
