### PR TITLE
Validate suffix & strip whitespace from Google auth client id

### DIFF
--- a/frontend/test/metabase/scenarios/admin/settings/sso/google.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/sso/google.cy.spec.js
@@ -8,22 +8,28 @@ describe("scenarios > admin > settings > SSO > Google", () => {
   });
 
   it("Google sign-in client ID should save on subsequent tries (metabase#15974)", () => {
-    cy.findByLabelText("Client ID").type("fake-client-id.apps.googleusercontent.com");
+    cy.findByLabelText("Client ID").type(
+      "fake-client-id.apps.googleusercontent.com",
+    );
     saveSettings();
 
     // This string lingers for far too long in the UI, so we have to wait for it to disappear before we assert on that same button again.
     // Otherwise, the test fails. That's why we added a custom timeout of 6s.
     cy.findByText("Success", { timeout: 6000 }).should("not.exist");
 
-    cy.findByDisplayValue("123").type("fake-client-id2.apps.googleusercontent.com");
+    cy.findByDisplayValue("123").type(
+      "fake-client-id2.apps.googleusercontent.com",
+    );
     saveSettings();
   });
 
-  it("Google sign-in client ID form should show an error message if it does not end with the correct suffix (metabase#15975)")
-    cy.findByLabelText("Client ID").type("fake-client-id");
-    saveSettings();
+  it(
+    "Google sign-in client ID form should show an error message if it does not end with the correct suffix (metabase#15975)",
+  );
+  cy.findByLabelText("Client ID").type("fake-client-id");
+  saveSettings();
 
-    cy.findByText("Invalid Google Sign-In Client ID");
+  cy.findByText("Invalid Google Sign-In Client ID");
 });
 
 function saveSettings() {

--- a/frontend/test/metabase/scenarios/admin/settings/sso/google.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/sso/google.cy.spec.js
@@ -8,16 +8,22 @@ describe("scenarios > admin > settings > SSO > Google", () => {
   });
 
   it("Google sign-in client ID should save on subsequent tries (metabase#15974)", () => {
-    cy.findByLabelText("Client ID").type("123");
+    cy.findByLabelText("Client ID").type("fake-client-id.apps.googleusercontent.com");
     saveSettings();
 
     // This string lingers for far too long in the UI, so we have to wait for it to disappear before we assert on that same button again.
     // Otherwise, the test fails. That's why we added a custom timeout of 6s.
     cy.findByText("Success", { timeout: 6000 }).should("not.exist");
 
-    cy.findByDisplayValue("123").type("456");
+    cy.findByDisplayValue("123").type("fake-client-id2.apps.googleusercontent.com");
     saveSettings();
   });
+
+  it("Google sign-in client ID form should show an error message if it does not end with the correct suffix (metabase#15975)")
+    cy.findByLabelText("Client ID").type("fake-client-id");
+    saveSettings();
+
+    cy.findByText("Invalid Google Sign-In Client ID");
 });
 
 function saveSettings() {

--- a/frontend/test/metabase/scenarios/admin/settings/sso/google.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/sso/google.cy.spec.js
@@ -25,11 +25,13 @@ describe("scenarios > admin > settings > SSO > Google", () => {
 
   it(
     "Google sign-in client ID form should show an error message if it does not end with the correct suffix (metabase#15975)",
-  );
-  cy.findByLabelText("Client ID").type("fake-client-id");
-  saveSettings();
+  ),
+    () => {
+      cy.findByLabelText("Client ID").type("fake-client-id");
+      saveSettings();
 
-  cy.findByText("Invalid Google Sign-In Client ID");
+      cy.findByText("Invalid Google Sign-In Client ID");
+    };
 });
 
 function saveSettings() {

--- a/frontend/test/metabase/scenarios/admin/settings/sso/google.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/sso/google.cy.spec.js
@@ -17,7 +17,7 @@ describe("scenarios > admin > settings > SSO > Google", () => {
     // Otherwise, the test fails. That's why we added a custom timeout of 6s.
     cy.findByText("Success", { timeout: 6000 }).should("not.exist");
 
-    cy.findByDisplayValue("123").type(
+    cy.findByDisplayValue("fake-client-id.apps.googleusercontent.com").type(
       "fake-client-id2.apps.googleusercontent.com",
     );
     saveSettings();

--- a/frontend/test/metabase/scenarios/onboarding/auth/sso.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/auth/sso.cy.spec.js
@@ -13,7 +13,7 @@ describe("scenarios > auth > signin > SSO", () => {
     cy.signInAsAdmin();
     // Set fake Google client ID
     cy.request("PUT", "/api/setting/google-auth-client-id", {
-      value: "123",
+      value: "fake-client-id.apps.googleusercontent.com",
     });
   });
 

--- a/src/metabase/integrations/google.clj
+++ b/src/metabase/integrations/google.clj
@@ -26,10 +26,10 @@
   :setter (fn [client-id]
             (if client-id
               (let [trimmed-client-id (str/trim client-id)]
-                (if-not (str/ends-with? trimmed-client-id ".apps.googleusercontent.com")
+                (when-not (str/ends-with? trimmed-client-id ".apps.googleusercontent.com")
                   (throw (ex-info (tru "Invalid Google Sign-In Client ID: must end with \".apps.googleusercontent.com\"")
-                                  {:status-code 400}))
-                  (setting/set-string! :google-auth-client-id trimmed-client-id)))
+                                  {:status-code 400})))
+                (setting/set-string! :google-auth-client-id trimmed-client-id))
               (setting/set-string! :google-auth-client-id nil))))
 
 (define-multi-setting-impl google.i/google-auth-auto-create-accounts-domain :oss

--- a/src/metabase/integrations/google.clj
+++ b/src/metabase/integrations/google.clj
@@ -24,11 +24,13 @@
   (deferred-tru "Client ID for Google Sign-In. If this is set, Google Sign-In is considered to be enabled.")
   :visibility :public
   :setter (fn [client-id]
-            (let [trimmed-client-id (str/trim client-id)]
-              (when-not (str/ends-with? trimmed-client-id ".apps.googleusercontent.com")
-                (throw (ex-info (tru "Invalid Google Sign-In Client ID: must end with \".apps.googleusercontent.com\"")
-                                {:status-code 400})))
-              (setting/set-string! :google-auth-client-id trimmed-client-id))))
+            (if client-id
+              (let [trimmed-client-id (str/trim client-id)]
+                (if-not (str/ends-with? trimmed-client-id ".apps.googleusercontent.com")
+                  (throw (ex-info (tru "Invalid Google Sign-In Client ID: must end with \".apps.googleusercontent.com\"")
+                                  {:status-code 400}))
+                  (setting/set-string! :google-auth-client-id trimmed-client-id)))
+              (setting/set-string! :google-auth-client-id nil))))
 
 (define-multi-setting-impl google.i/google-auth-auto-create-accounts-domain :oss
   :getter (fn [] (setting/get-string :google-auth-auto-create-accounts-domain))

--- a/src/metabase/integrations/google.clj
+++ b/src/metabase/integrations/google.clj
@@ -21,8 +21,14 @@
   (deferred-tru "You'll need an administrator to create a Metabase account before you can use Google to log in."))
 
 (defsetting google-auth-client-id
-  (deferred-tru "Client ID for Google Auth SSO. If this is set, Google Auth is considered to be enabled.")
-  :visibility :public)
+  (deferred-tru "Client ID for Google Sign-In. If this is set, Google Sign-In is considered to be enabled.")
+  :visibility :public
+  :setter (fn [client-id]
+            (let [trimmed-client-id (str/trim client-id)]
+              (when-not (str/ends-with? trimmed-client-id ".apps.googleusercontent.com")
+                (throw (ex-info (tru "Invalid Google Sign-In Client ID: must end with \".apps.googleusercontent.com\"")
+                                {:status-code 400})))
+              (setting/set-string! :google-auth-client-id trimmed-client-id))))
 
 (define-multi-setting-impl google.i/google-auth-auto-create-accounts-domain :oss
   :getter (fn [] (setting/get-string :google-auth-auto-create-accounts-domain))
@@ -40,12 +46,12 @@
   ([token-info-response client-id]
    (let [{:keys [status body]} token-info-response]
      (when-not (= status 200)
-       (throw (ex-info (tru "Invalid Google Auth token.") {:status-code 400})))
+       (throw (ex-info (tru "Invalid Google Sign-In token.") {:status-code 400})))
      (u/prog1 (json/parse-string body keyword)
        (let [audience (:aud <>)
              audience (if (string? audience) [audience] audience)]
          (when-not (contains? (set audience) client-id)
-           (throw (ex-info (str (deferred-tru "Google Auth token appears to be incorrect. ")
+           (throw (ex-info (str (deferred-tru "Google Sign-In token appears to be incorrect. ")
                                 (deferred-tru "Double check that it matches in Google and Metabase."))
                            {:status-code 400}))))
        (when-not (= (:email_verified <>) "true")
@@ -87,5 +93,5 @@
   [{{:keys [token]} :body, :as request}]
   (let [token-info-response                    (http/post (format google-auth-token-info-url token))
         {:keys [given_name family_name email]} (google-auth-token-info token-info-response)]
-    (log/info (trs "Successfully authenticated Google Auth token for: {0} {1}" given_name family_name))
+    (log/info (trs "Successfully authenticated Google Sign-In token for: {0} {1}" given_name family_name))
     (api/check-500 (google-auth-fetch-or-create-user! given_name family_name email))))

--- a/test/metabase/api/session_test.clj
+++ b/test/metabase/api/session_test.clj
@@ -369,11 +369,11 @@
 
 (deftest google-auth-test
   (testing "POST /google_auth"
-    (mt/with-temporary-setting-values [google-auth-client-id "PRETEND-GOOD-GOOGLE-CLIENT-ID"]
+    (mt/with-temporary-setting-values [google-auth-client-id "pretend-client-id.apps.googleusercontent.com"]
       (testing "Google auth works with an active account"
         (mt/with-temp User [user {:email "test@metabase.com" :is_active true}]
           (with-redefs [http/post (fn [url] {:status 200
-                                             :body   (str "{\"aud\":\"PRETEND-GOOD-GOOGLE-CLIENT-ID\","
+                                             :body   (str "{\"aud\":\"pretend-client-id.apps.googleusercontent.com\","
                                                           "\"email_verified\":\"true\","
                                                           "\"first_name\":\"test\","
                                                           "\"last_name\":\"user\","
@@ -383,7 +383,7 @@
       (testing "Google auth throws exception for a disabled account"
         (mt/with-temp User [user {:email "test@metabase.com" :is_active false}]
           (with-redefs [http/post (fn [url] {:status 200
-                                             :body   (str "{\"aud\":\"PRETEND-GOOD-GOOGLE-CLIENT-ID\","
+                                             :body   (str "{\"aud\":\"pretend-client-id.apps.googleusercontent.com\","
                                                           "\"email_verified\":\"true\","
                                                           "\"first_name\":\"test\","
                                                           "\"last_name\":\"user\","

--- a/test/metabase/api/user_test.clj
+++ b/test/metabase/api/user_test.clj
@@ -761,7 +761,7 @@
 
     (testing (str "test that when disabling Google auth if a user gets disabled and re-enabled they are no longer "
                   "Google Auth (#3323)")
-      (mt/with-temporary-setting-values [google-auth-client-id "ABCDEFG"]
+      (mt/with-temporary-setting-values [google-auth-client-id "pretend-client-id.apps.googleusercontent.com"]
         (mt/with-temp User [user {:google_auth true}]
           (db/update! User (u/the-id user)
             :is_active false)

--- a/test/metabase/integrations/google_test.clj
+++ b/test/metabase/integrations/google_test.clj
@@ -48,20 +48,20 @@
              clojure.lang.ExceptionInfo
              (#'google/google-auth-create-new-user! {:first_name "Rasta"
                                                      :last_name  "Toucan"
-                                                     :email      "rasta@metabase.com"}))))
+                                                     :email      "rasta@metabase.com"})))))
 
-      (testing "should totally work if the email domains match up"
-        (et/with-fake-inbox
-          (mt/with-temporary-setting-values [google-auth-auto-create-accounts-domain "sf-toucannery.com"
-                                             admin-email                             "rasta@toucans.com"]
-            (try
-              (let [user (#'google/google-auth-create-new-user! {:first_name "Rasta"
-                                                                 :last_name  "Toucan"
-                                                                 :email      "rasta@sf-toucannery.com"})]
-                (is (= {:first_name "Rasta", :last_name "Toucan", :email "rasta@sf-toucannery.com"}
-                       (select-keys user [:first_name :last_name :email]))))
-              (finally
-                (db/delete! User :email "rasta@sf-toucannery.com")))))))))
+    (testing "should totally work if the email domains match up"
+      (et/with-fake-inbox
+        (mt/with-temporary-setting-values [google-auth-auto-create-accounts-domain "sf-toucannery.com"
+                                           admin-email                             "rasta@toucans.com"]
+          (try
+            (let [user (#'google/google-auth-create-new-user! {:first_name "Rasta"
+                                                               :last_name  "Toucan"
+                                                               :email      "rasta@sf-toucannery.com"})]
+              (is (= {:first_name "Rasta", :last_name "Toucan", :email "rasta@sf-toucannery.com"}
+                     (select-keys user [:first_name :last_name :email]))))
+            (finally
+              (db/delete! User :email "rasta@sf-toucannery.com"))))))))
 
 
 ;;; --------------------------------------------- google-auth-token-info ---------------------------------------------

--- a/test/metabase/integrations/google_test.clj
+++ b/test/metabase/integrations/google_test.clj
@@ -69,14 +69,14 @@
 (deftest google-auth-token-info-tests
   (testing "Throws exception"
     (testing "for non-200 status"
-      (is (= [400 "Invalid Google Auth token."]
+      (is (= [400 "Invalid Google Sign-In token."]
              (try
                (#'google/google-auth-token-info {:status 400} "")
                (catch Exception e
                  [(-> e ex-data :status-code) (.getMessage e)])))))
 
     (testing "for invalid data."
-      (is (= [400 "Google Auth token appears to be incorrect. Double check that it matches in Google and Metabase."]
+      (is (= [400 "Google Sign-In token appears to be incorrect. Double check that it matches in Google and Metabase."]
              (try
                (#'google/google-auth-token-info
                 {:status 200


### PR DESCRIPTION
* Adds a custom setter for the `google-auth-client-id` setting which strips whitespace and makes sure the client ID ends with the correct suffix
* Some tests and formatting tweaks
* Changed "Google Auth" to "Google Sign-In" in user-facing strings, since "Sign-In" is the official name

Resolves  #15976 and #15975.

The error message on an invalid suffix is surfaced to the frontend, but the padding is a bit odd. I'll open a separate issue for tweaking this CSS. 
<img width="547" alt="Screen Shot 2021-11-18 at 11 28 40 AM" src="https://user-images.githubusercontent.com/32746338/142456807-40e6b75e-ea81-4f50-bf5c-26a6b9ffa7c9.png">
