### PR TITLE
Make editor container look like the original

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -113,6 +113,10 @@ export default class ExpressionEditorTextfield extends React.Component {
     placeholder: "write some math!",
   };
 
+  state: {
+    isFocused: false,
+  };
+
   UNSAFE_componentWillMount() {
     this.UNSAFE_componentWillReceiveProps(this.props);
   }
@@ -232,6 +236,14 @@ export default class ExpressionEditorTextfield extends React.Component {
     return expression;
   }
 
+  handleEditorFocus = () => {
+    this.setState({ isFocused: true });
+  };
+
+  handleEditorBlur = () => {
+    this.setState({ isFocused: false });
+  };
+
   onInputBlur = e => {
     // Switching to another window also triggers the blur event.
     // When our window gets focus again, the input will automatically
@@ -302,10 +314,10 @@ export default class ExpressionEditorTextfield extends React.Component {
   }
 
   render() {
-    const { source, suggestions, errorMessage } = this.state;
+    const { source, suggestions, errorMessage, isFocused } = this.state;
 
     return (
-      <EditorContainer>
+      <EditorContainer isFocused={isFocused}>
         <EditorEqualsSign>=</EditorEqualsSign>
         <AceEditor
           ref={this.input}
@@ -314,6 +326,8 @@ export default class ExpressionEditorTextfield extends React.Component {
           highlightActiveLine={false}
           wrapEnabled={true}
           fontSize={16}
+          onBlur={this.handleEditorBlur}
+          onFocus={this.handleEditorFocus}
           setOptions={{
             indentedSoftWrap: false,
             minLines: 1,

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -4,7 +4,6 @@ import PropTypes from "prop-types";
 
 import { t } from "ttag";
 import _ from "underscore";
-import cx from "classnames";
 import AceEditor from "react-ace";
 
 import { format } from "metabase/lib/expressions/format";
@@ -34,6 +33,10 @@ import ExplicitSize from "metabase/components/ExplicitSize";
 import { isExpression } from "metabase/lib/expressions";
 
 import ExpressionEditorSuggestions from "./ExpressionEditorSuggestions";
+import {
+  EditorContainer,
+  EditorEqualsSign,
+} from "./ExpressionEditorTextfield.styled";
 
 const HelpText = ({ helpText, width }) =>
   helpText ? (
@@ -302,7 +305,8 @@ export default class ExpressionEditorTextfield extends React.Component {
     const { source, suggestions, errorMessage } = this.state;
 
     return (
-      <div className={cx("relative my1")}>
+      <EditorContainer>
+        <EditorEqualsSign>=</EditorEqualsSign>
         <AceEditor
           ref={this.input}
           value={source}
@@ -330,7 +334,7 @@ export default class ExpressionEditorTextfield extends React.Component {
           onSuggestionMouseDown={this.onSuggestionSelected}
           highlightedIndex={this.state.highlightedSuggestionIndex}
         />
-      </div>
+      </EditorContainer>
     );
   }
 }

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.styled.jsx
@@ -1,0 +1,20 @@
+import styled from "styled-components";
+
+import { space } from "metabase/styled-components/theme";
+import { color } from "metabase/lib/colors";
+
+export const EditorContainer = styled.div`
+  border: 1px solid ${color("border")};
+  border-radius: ${space(1)};
+  display: flex;
+  position: relative;
+  margin: ${space(1)} 0;
+  padding: ${space(1)};
+`;
+
+export const EditorEqualsSign = styled.div`
+  font-family: Monaco, monospace;
+  font-size: 12px;
+  font-weight: 700;
+  margin: 0 ${space(0)}};
+`;

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.styled.jsx
@@ -4,8 +4,10 @@ import { space } from "metabase/styled-components/theme";
 import { color } from "metabase/lib/colors";
 
 export const EditorContainer = styled.div`
-  border: 1px solid ${color("border")};
-  border-radius: ${space(1)};
+  border: 1px solid;
+  border-color: ${({ isFocused }) =>
+    isFocused ? color("brand") : color("border")};
+  border-radius: ${space(0)};
   display: flex;
   position: relative;
   margin: ${space(1)} 0;


### PR DESCRIPTION
Adds equal sign to the left of editor.

Gets margins and paddings together.

Adds border color to editor container, updated on focus/blur

![Metabase screenshot](https://user-images.githubusercontent.com/380816/142480754-5d49cf83-cc5b-44d5-90d2-1546c03618f9.gif)
