### PR TITLE
Remove errant `tap>`s

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/content_management/api/review_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_management/api/review_test.clj
@@ -83,11 +83,11 @@
               (doseq [status mod-review/statuses]
                 (is (= status (:status (moderate! status "good")))))
               ;; i wish this was better. Should have a better error message and honestly shouldn't be a 500
-              (tap> (mt/user-http-request :crowberto :post 400 "moderation-review"
-                                          {:text                "not a chance this works"
-                                           :status              "invalid status"
-                                           :moderated_item_id   card-id
-                                           :moderated_item_type "card"})))
+              (mt/user-http-request :crowberto :post 400 "moderation-review"
+                                    {:text                "not a chance this works"
+                                     :status              "invalid status"
+                                     :moderated_item_id   card-id
+                                     :moderated_item_type "card"}))
             (testing "Can't moderate a card that doesn't exist"
               (is (= "Not found."
                      (mt/user-http-request :crowberto :post 404 "moderation-review"

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -581,7 +581,7 @@
                          (mt/user-http-request :rasta :get 200)
                          :data)]
           (is (= #{"card" "dash" "subcollection" "dataset"}
-                 (doto (into #{} (map :name) items) tap>))))))))
+                 (into #{} (map :name) items))))))))
 
 (deftest children-sort-clause-test
   (testing "Default sort"


### PR DESCRIPTION
some errant `tap>`s left in the codebase.

I've been using reveal and it makes a nice visualizer

<img width="1329" alt="image" src="https://user-images.githubusercontent.com/6377293/142665654-6edc2085-c90b-46c2-b5cf-8312ab0a1d00.png">

[reveal on github](https://github.com/vlaaad/reveal)

This adds a nice tap> viewer. If you're interested easy to throw it in with the following alias in your `~/.clojure/deps.edn` file
```clojure
:reveal
{:extra-deps {vlaaad/reveal {:mvn/version "RELEASE"}}
 :main-opts ["-m" "vlaaad.reveal" "repl"]
 ;; make the font more readable:
 :jvm-opts ["-Dvlaaad.reveal.prefs={:font-size,16}"]}
```

and add the reveal alias to your startup. With nrepl, you need to maintain the nrepl main so there are [instructions](https://vlaaad.github.io/reveal/#nrepl-based-editors) on how to get that up and running.