### PR TITLE
Notebook animation: use CSS instead of react-motion

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -33,11 +33,12 @@ import SummarizeSidebar from "./sidebars/SummarizeSidebar";
 import FilterSidebar from "./sidebars/FilterSidebar";
 import QuestionDetailsSidebar from "./sidebars/QuestionDetailsSidebar";
 
-import Notebook from "../notebook/Notebook";
 import { Motion, spring } from "react-motion";
 
 import NativeQuery from "metabase-lib/lib/queries/NativeQuery";
 import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
+
+import QueryViewNotebook from "./View/QueryViewNotebook";
 
 const DEFAULT_POPOVER_STATE = {
   aggregationIndex: null,
@@ -193,6 +194,9 @@ export default class View extends React.Component {
 
     const isSidebarOpen = leftSideBar || rightSideBar;
 
+    const isNotebookContainerOpen =
+      isNewQuestion || queryBuilderMode === "notebook";
+
     return (
       <div className={fitClassNames}>
         <div className={cx("QueryBuilder flex flex-column bg-white spread")}>
@@ -222,39 +226,10 @@ export default class View extends React.Component {
 
           <div className="flex flex-full relative">
             {query instanceof StructuredQuery && (
-              <Motion
-                defaultStyle={
-                  isNewQuestion
-                    ? { opacity: 1, translateY: 0 }
-                    : { opacity: 0, translateY: -100 }
-                }
-                style={
-                  queryBuilderMode === "notebook"
-                    ? {
-                        opacity: spring(1),
-                        translateY: spring(0),
-                      }
-                    : {
-                        opacity: spring(0),
-                        translateY: spring(-100),
-                      }
-                }
-              >
-                {({ opacity, translateY }) =>
-                  opacity > 0 ? (
-                    // note the `bg-white class here is necessary to obscure the other layer
-                    <div
-                      className="spread bg-white scroll-y z2 border-top border-bottom"
-                      style={{
-                        // opacity: opacity,
-                        transform: `translateY(${translateY}%)`,
-                      }}
-                    >
-                      <Notebook {...this.props} />
-                    </div>
-                  ) : null
-                }
-              </Motion>
+              <QueryViewNotebook
+                isNotebookContainerOpen={isNotebookContainerOpen}
+                {...this.props}
+              />
             )}
 
             <ViewSidebar side="left" isOpen={!!leftSideBar}>

--- a/frontend/src/metabase/query_builder/components/view/View/QueryViewNotebook/QueryViewNotebook.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View/QueryViewNotebook/QueryViewNotebook.jsx
@@ -1,0 +1,39 @@
+import React, { useEffect, useState } from "react";
+import PropTypes from "prop-types";
+
+import Notebook from "metabase/query_builder/components/notebook/Notebook";
+import { NotebookContainer } from "./QueryViewNotebook.styled";
+
+const delayBeforeNotRenderingNotebook = 300;
+
+const QueryViewNotebook = ({ isNotebookContainerOpen, ...props }) => {
+  const [shouldShowNotebook, setShouldShowNotebook] = useState(
+    isNotebookContainerOpen,
+  );
+
+  useEffect(() => {
+    isNotebookContainerOpen && setShouldShowNotebook(isNotebookContainerOpen);
+  }, [isNotebookContainerOpen]);
+
+  const handleTransitionEnd = event => {
+    if (event.propertyName === "opacity" && !isNotebookContainerOpen) {
+      setShouldShowNotebook(false);
+    }
+  };
+
+  return (
+    <NotebookContainer
+      isOpen={isNotebookContainerOpen}
+      transitionTime={delayBeforeNotRenderingNotebook}
+      onTransitionEnd={handleTransitionEnd}
+    >
+      {shouldShowNotebook && <Notebook {...props} />}
+    </NotebookContainer>
+  );
+};
+
+QueryViewNotebook.propTypes = {
+  isNotebookContainerOpen: PropTypes.bool.isRequired,
+};
+
+export default QueryViewNotebook;

--- a/frontend/src/metabase/query_builder/components/view/View/QueryViewNotebook/QueryViewNotebook.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View/QueryViewNotebook/QueryViewNotebook.styled.jsx
@@ -1,0 +1,29 @@
+import styled, { css } from "styled-components";
+
+import { color } from "metabase/lib/colors";
+
+export const NotebookContainer = styled.div`
+  background: white;
+  border-top: 1px solid ${color("border")};
+  bottom: 0;
+  left: 0;
+  opacity: 0;
+  overflow-y: auto;
+  position: absolute;
+  right: 0;
+  top: 0;
+  transform: translateY(-100%);
+  z-index: 2;
+
+  ${({ transitionTime }) =>
+    css`
+      transition: transform ${transitionTime}ms, opacity ${transitionTime}ms;
+    `}
+
+  ${({ isOpen }) =>
+    isOpen &&
+    css`
+      opacity: 1;
+      transform: translateY(0);
+    `}
+`;

--- a/frontend/src/metabase/query_builder/components/view/View/QueryViewNotebook/index.js
+++ b/frontend/src/metabase/query_builder/components/view/View/QueryViewNotebook/index.js
@@ -1,0 +1,1 @@
+export { default } from "./QueryViewNotebook";


### PR DESCRIPTION
This gets rid of the potential bouncing due to the mass-spring animation model of react-motion. See the video in #18889.

To see why and how the bouncing happens, try the [online demo](http://chenglou.github.io/react-motion/demos/demo5-spring-parameters-chooser/) of react-motion. Depends the damping factor and also the distance covered by the animation (in our Metabase app, that corresponds to how complex a notebook can be), the bouncing might become more obvious at the end of the animation.

It works by rewriting the motion-based animation to CSS animation instead. This is basically a manual backport of PR #18532 with some other tweaks (can't do auto backport due to code divergence).