### PR TITLE
Mock site-name setting in dashboard subscription tests

### DIFF
--- a/test/metabase/dashboard_subscription_test.clj
+++ b/test/metabase/dashboard_subscription_test.clj
@@ -172,7 +172,8 @@
      :fixture
      (fn [_ thunk]
        (with-redefs [render.body/attached-results-text (wrap-function @#'render.body/attached-results-text)]
-         (thunk)))
+         (mt/with-temporary-setting-values [site-name "Metabase Test"]
+           (thunk))))
 
      :assert
      {:email
@@ -245,7 +246,8 @@
      :fixture
      (fn [{dashboard-id :dashboard-id} thunk]
        (mt/with-temp DashboardCard [_ {:dashboard_id dashboard-id, :visualization_settings {:text "# header"}}]
-         (thunk)))
+         (mt/with-temporary-setting-values [site-name "Metabase Test"]
+           (thunk))))
 
      :assert
      {:email
@@ -285,6 +287,11 @@
           :dashboard test-dashboard}
     "Dashboard subscription that includes a dashboard filters"
     {:card (checkins-query-card {})
+
+     :fixture
+     (fn [_ thunk]
+       (mt/with-temporary-setting-values [site-name "Metabase Test"]
+          (thunk)))
 
      :assert
      {:email


### PR DESCRIPTION
These tests are relying on the `site-name` being `Metabase Test`, but they're failing for me locally on master and in CI on #18784 since `site-name` is just `Metabase`.

I remember these passing everywhere when I first added something, so maybe something changed in our test environment and `site-name` setting is no longer set via env var? Or at least it's not being set consistently?

Regardless, this can be made consistent by always changing the value of this setting to `Metabase Test` in the fixtures for these tests.