### PR TITLE
fix chart tooltip isOpen boolean evaluation

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChartTooltip.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartTooltip.jsx
@@ -50,7 +50,7 @@ export default class ChartTooltip extends Component {
       hovered?.element != null && document.body.contains(hovered.element);
     const hasTargetEvent = hovered?.event != null;
 
-    const isOpen = (rows.length > 0 && hasTargetElement) || hasTargetEvent;
+    const isOpen = rows.length > 0 && (hasTargetElement || hasTargetEvent);
 
     let target;
     if (hasTargetElement) {


### PR DESCRIPTION
Caused by misplaced parens

Before

https://user-images.githubusercontent.com/13057258/142699853-23201711-1d31-4001-a2e8-fbc733a5a46d.mov

After

https://user-images.githubusercontent.com/13057258/142699859-b0631d07-4969-4f6b-a1c1-8343dbd9e075.mov


