### PR TITLE
add support expression for time-interval clause

### DIFF
--- a/shared/src/metabase/mbql/schema.cljc
+++ b/shared/src/metabase/mbql/schema.cljc
@@ -687,7 +687,7 @@
 ;;
 ;; SUGAR: This is automatically rewritten as a filter clause with a relative-datetime value
 (defclause ^:sugar time-interval
-  field   field
+  field   Field
   n       (s/cond-pre
            s/Int
            (s/enum :current :last :next))


### PR DESCRIPTION
This should fix #16273

The error from #16273 came from the fact that :time-interval doesn't recognize :expression as a field. So I
- Modify the [scheme](shared/src/metabase/mbql/schema.cljc) for :time-filter so it'll pass the validate-query middleware
- Modify the [desugar middleware](shared/src/metabase/mbql/util.cljc) so it'll recognize :expression and correctly replace the query