### PR TITLE
Harmonize Google dependency versions

### DIFF
--- a/modules/drivers/bigquery/deps.edn
+++ b/modules/drivers/bigquery/deps.edn
@@ -3,8 +3,8 @@
 
  :deps
  ;; TODO: use BOM to manage these (see extensive comment in project.clj under bigquery for more details)
- {com.google.apis/google-api-services-bigquery {:mvn/version "v2-rev20200523-1.30.9"}
-  ;; keep this synced with bigquery-cloud-sdk driver dependency version
-  com.google.http-client/google-http-client-jackson2 {:mvn/version "1.39.2"}}
+ ;; ensure the version of google-http-client transitively depended on here matches that of bigquery-cloud-sdk
+ ;; (which, at the moment, is 1.39.2)
+ {com.google.apis/google-api-services-bigquery {:mvn/version "v2-rev20211106-1.32.1"}}
 
  :metabase.driver/parents #{:google}}

--- a/modules/drivers/googleanalytics/deps.edn
+++ b/modules/drivers/googleanalytics/deps.edn
@@ -1,6 +1,8 @@
 {:paths ["src" "resources"]
 
  :deps
- {com.google.apis/google-api-services-analytics {:mvn/version "v3-rev20180622-1.27.0"}}
+ ;; ensure the version of google-http-client transitively depended on here matches that of bigquery-cloud-sdk
+ ;; (which, at the moment, is 1.39.2)
+ {com.google.apis/google-api-services-analytics {:mvn/version "v3-rev20190807-1.32.1"}}
 
  :metabase.driver/parents #{:google}}


### PR DESCRIPTION
Update bigquery and googleanalytics drivers dependencies to newer versions, such that their transitive dependencies on google-api-client/google-http-client match the versions used in the new BigQuery driver
