### PR TITLE
Add `snowplow-available` and `snowplow-url` settings

### DIFF
--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -468,3 +468,19 @@
   :type       :json
   :setter     :none
   :getter     fetch-cloud-gateway-ips-fn)
+
+(defsetting snowplow-available
+  (str (deferred-tru "Boolean indicating whether a Snowplow collector is available to receive analytics events.")
+       " "
+       (deferred-tru "Should be set via environment variable in Cypress tests or during local development."))
+  :type       :boolean
+  :default    config/is-prod?
+  :visibility :public)
+
+(defsetting snowplow-url
+  (deferred-tru "The URL of the Snowplow collector to send analytics events to.")
+  :default    (if config/is-prod?
+                "https://sp.metabase.com"
+                ;; Run `docker compose up` from the `snowplow/` subdirectory to start a local Snowplow collector
+                "http://localhost:9095")
+  :visibility :public)


### PR DESCRIPTION
New settings requested by @ranquild to facilitate running Snowplow Micro in CI for Cypress testing.

These are being broken out from #18784 to unblock the testing PR. I'll rebase #18784 onto this branch, and move the settings from `public-settings` to the new snowplow namespace in that PR.