### PR TITLE
Bump connection-pool version

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -67,7 +67,7 @@
   me.raynes/fs                              {:mvn/version "1.4.6"               ; Filesystem tools
                                              :exclusions  [org.apache.commons/commons-compress]}
   medley/medley                             {:mvn/version "1.3.0"}              ; lightweight lib of useful functions
-  metabase/connection-pool                  {:mvn/version "1.1.1"}              ; simple wrapper around C3P0. JDBC connection pools
+  metabase/connection-pool                  {:mvn/version "1.2.0"}              ; simple wrapper around C3P0. JDBC connection pools
   metabase/saml20-clj                       {:mvn/version "2.0.0"}              ; EE SAML integration
   metabase/throttle                         {:mvn/version "1.0.2"}              ; Tools for throttling access to API endpoints and other code pathways
   net.cgrand/macrovich                      {:mvn/version "0.2.1"}              ; utils for writing macros for both Clojure & ClojureScript


### PR DESCRIPTION
Bump metabase/connection-pool version from 1.1.1 to 1.2.0 to get the updated c3p0 version (0.9.5.5)
