### PR TITLE
Limit autocomplete results for tables and fields

### DIFF
--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -317,15 +317,16 @@
 
 ;;; --------------------------------- GET /api/database/:id/autocomplete_suggestions ---------------------------------
 
-(defn- autocomplete-tables [db-id prefix]
+(defn- autocomplete-tables [db-id prefix limit]
   (db/select [Table :id :db_id :schema :name]
     {:where    [:and [:= :db_id db-id]
                      [:= :active true]
                      [:like :%lower.name (str (str/lower-case prefix) "%")]
                      [:= :visibility_type nil]]
-     :order-by [[:%lower.name :asc]]}))
+     :order-by [[:%lower.name :asc]]
+     :limit    limit}))
 
-(defn- autocomplete-fields [db-id prefix]
+(defn- autocomplete-fields [db-id prefix limit]
   (db/select [Field :name :base_type :semantic_type :id :table_id [:table.name :table_name]]
     :metabase_field.active          true
     :%lower.metabase_field.name     [:like (str (str/lower-case prefix) "%")]
@@ -333,22 +334,28 @@
     :table.db_id                    db-id
     {:order-by  [[:%lower.metabase_field.name :asc]
                  [:%lower.table.name :asc]]
-     :left-join [[:metabase_table :table] [:= :table.id :metabase_field.table_id]]}))
+     :left-join [[:metabase_table :table] [:= :table.id :metabase_field.table_id]]
+     :limit     limit}))
 
-(defn- autocomplete-results [tables fields]
-  (concat (for [{table-name :name} tables]
-            [table-name "Table"])
-          (for [{:keys [table_name base_type semantic_type name]} fields]
-            [name (str table_name
-                       " "
-                       base_type
-                       (when semantic_type
-                         (str " " semantic_type)))])))
+(defn- autocomplete-results [tables fields limit]
+  (let [tbl-count   (count tables)
+        fld-count   (count fields)
+        take-tables (min tbl-count (- limit (/ fld-count 2)))
+        take-fields (- limit take-tables)]
+    (concat (for [{table-name :name} (take take-tables tables)]
+              [table-name "Table"])
+            (for [{:keys [table_name base_type semantic_type name]} (take take-fields fields)]
+              [name (str table_name
+                         " "
+                         base_type
+                         (when semantic_type
+                           (str " " semantic_type)))]))))
 
 (defn- autocomplete-suggestions [db-id prefix]
-  (let [tables (filter mi/can-read? (autocomplete-tables db-id prefix))
-        fields (readable-fields-only (autocomplete-fields db-id prefix))]
-    (autocomplete-results tables fields)))
+  (let [limit  50
+        tables (filter mi/can-read? (autocomplete-tables db-id prefix limit))
+        fields (readable-fields-only (autocomplete-fields db-id prefix limit))]
+    (autocomplete-results tables fields limit)))
 
 (api/defendpoint GET "/:id/autocomplete_suggestions"
   "Return a list of autocomplete suggestions for a given `prefix`.

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -23,7 +23,8 @@
             [ring.util.codec :as codec]
             [schema.core :as s]
             [toucan.db :as db]
-            [toucan.hydrate :as hydrate]))
+            [toucan.hydrate :as hydrate]
+            [clojure.string :as str]))
 
 (use-fixtures :once (fixtures/initialize :db :plugins :test-drivers))
 
@@ -302,16 +303,37 @@
                         (some (partial = "PRICE"))))))))))
 
 (deftest autocomplete-suggestions-test
-  (testing "GET /api/database/:id/autocomplete_suggestions"
-    (doseq [[prefix expected] {"u"   [["USERS" "Table"]
-                                      ["USER_ID" "CHECKINS :type/Integer :type/FK"]]
-                               "c"   [["CATEGORIES" "Table"]
-                                      ["CHECKINS" "Table"]
-                                      ["CATEGORY_ID" "VENUES :type/Integer :type/FK"]]
-                               "cat" [["CATEGORIES" "Table"]
-                                      ["CATEGORY_ID" "VENUES :type/Integer :type/FK"]]}]
-      (is (= expected
-             (mt/user-http-request :rasta :get 200 (format "database/%d/autocomplete_suggestions" (mt/id)) :prefix prefix))))))
+  (let [suggest-fn (fn [db-id prefix]
+                     (mt/user-http-request :rasta :get 200
+                                           (format "database/%d/autocomplete_suggestions" db-id)
+                                           :prefix prefix))]
+    (testing "GET /api/database/:id/autocomplete_suggestions"
+      (doseq [[prefix expected] {"u"   [["USERS" "Table"]
+                                        ["USER_ID" "CHECKINS :type/Integer :type/FK"]]
+                                 "c"   [["CATEGORIES" "Table"]
+                                        ["CHECKINS" "Table"]
+                                        ["CATEGORY_ID" "VENUES :type/Integer :type/FK"]]
+                                 "cat" [["CATEGORIES" "Table"]
+                                        ["CATEGORY_ID" "VENUES :type/Integer :type/FK"]]}]
+        (is (= expected (suggest-fn (mt/id) prefix))))
+      (testing " handles large numbers of tables and fields sensibly"
+        (mt/with-model-cleanup [Field Table Database]
+          (let [tmp-db (db/insert! Database {:name "Temp Autocomplete Pagination DB" :engine "h2" :details "{}"})]
+            ;; insert more than 50 temporary tables and fields
+            (doseq [i (range 60)]
+              (let [tmp-tbl (db/insert! Table {:name (format "My Table %d" i) :db_id (u/the-id tmp-db) :active true})]
+                (db/insert! Field {:name (format "My Field %d" i) :table_id (u/the-id tmp-tbl) :base_type "type/Text" :database_type "varchar"})))
+            ;; for each type-specific prefix, we should get 50 fields
+            (is (= 50 (count (suggest-fn (u/the-id tmp-db) "My Field"))))
+            (is (= 50 (count (suggest-fn (u/the-id tmp-db) "My Table"))))
+            (let [my-results (suggest-fn (u/the-id tmp-db) "My")]
+              ;; for this prefix, we should a mixture of 25 fields and 25 tables
+              (is (= 50 (count my-results)))
+              (is (= 25 (-> (filter #(str/starts-with? % "My Field") (map first my-results))
+                            count)))
+              (is (= 25 (-> (filter #(str/starts-with? % "My Table") (map first my-results))
+                          count))))))))))
+
 
 (defn- card-with-native-query {:style/indent 1} [card-name & {:as kvs}]
   (merge

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.api.database-test
   "Tests for /api/database endpoints."
-  (:require [clojure.test :refer :all]
+  (:require [clojure.string :as str]
+            [clojure.test :refer :all]
             [medley.core :as m]
             [metabase.api.database :as database-api]
             [metabase.api.table :as table-api]
@@ -23,8 +24,7 @@
             [ring.util.codec :as codec]
             [schema.core :as s]
             [toucan.db :as db]
-            [toucan.hydrate :as hydrate]
-            [clojure.string :as str]))
+            [toucan.hydrate :as hydrate]))
 
 (use-fixtures :once (fixtures/initialize :db :plugins :test-drivers))
 


### PR DESCRIPTION
Add limit of 50 total fields or tables returned from the autocomplete_suggestions API, which can be a mixture of tables and/or fields

Adding test that confirms results are limited properly