### PR TITLE
React-Ace Editor (Custom Expressions) Control autocomplete

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -146,7 +146,9 @@ export default class ExpressionEditorTextfield extends React.Component {
 
     if (suggestion) {
       const { tokens } = tokenize(source);
+      const { editor } = this.input.current;
       const token = tokens.find(t => t.end >= suggestion.index);
+
       if (token) {
         const prefix = source.slice(0, token.start);
         const postfix = source.slice(token.end);
@@ -162,13 +164,14 @@ export default class ExpressionEditorTextfield extends React.Component {
         const updatedExpression = prefix + replacement.trim() + postfix;
         this.onExpressionChange(updatedExpression);
         const caretPos = updatedExpression.length - postfix.length;
-        setTimeout(() => {
-          this._setCaretPosition(caretPos, true);
-        });
+
+        const { row } = editor.getCursorPosition();
+        editor.moveCursorTo(row, caretPos);
       } else {
         const newExpression = source + suggestion.text;
         this.onExpressionChange(newExpression);
-        setTimeout(() => this._setCaretPosition(newExpression.length, true));
+        const { row } = editor.getCursorPosition();
+        this.input.current.editor.moveCursorTo(row, newExpression.length);
       }
     }
   };

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -174,6 +174,7 @@ export default class ExpressionEditorTextfield extends React.Component {
   };
 
   onInputKeyDown = e => {
+    console.log("🚀", "here");
     const { suggestions, highlightedSuggestionIndex } = this.state;
 
     if (e.keyCode === KEYCODE_LEFT || e.keyCode === KEYCODE_RIGHT) {
@@ -320,6 +321,25 @@ export default class ExpressionEditorTextfield extends React.Component {
       <EditorContainer isFocused={isFocused}>
         <EditorEqualsSign>=</EditorEqualsSign>
         <AceEditor
+          commands={[
+            {
+              name: "commandName",
+              bindKey: { win: "ArrowDown", mac: "ArrowDown" },
+              exec: () => {
+                console.log("🚀, key-binding used");
+              },
+            },
+            {
+              name: "save",
+              bindKey: {
+                win: "Ctrl-enter",
+                mac: "Cmd-enter",
+              },
+              exec: () => {
+                console.log("🚀, key-binding used ctrl-enter");
+              },
+            },
+          ]}
           ref={this.input}
           value={source}
           focus={true}
@@ -327,6 +347,7 @@ export default class ExpressionEditorTextfield extends React.Component {
           wrapEnabled={true}
           fontSize={16}
           onBlur={this.handleEditorBlur}
+          onInput={this.onInputKeyDown}
           onFocus={this.handleEditorFocus}
           setOptions={{
             indentedSoftWrap: false,

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -173,14 +173,50 @@ export default class ExpressionEditorTextfield extends React.Component {
     }
   };
 
+  handleArrowUp = () => {
+    const { highlightedSuggestionIndex, suggestions } = this.state;
+
+    if (suggestions.length) {
+      this.setState({
+        highlightedSuggestionIndex:
+          (highlightedSuggestionIndex + suggestions.length - 1) %
+          suggestions.length,
+      });
+    } else {
+      this.input.current.editor.navigateLineEnd();
+    }
+  };
+
+  handleArrowDown = () => {
+    const { highlightedSuggestionIndex, suggestions } = this.state;
+
+    if (suggestions.length) {
+      this.setState({
+        highlightedSuggestionIndex:
+          (highlightedSuggestionIndex + suggestions.length + 1) %
+          suggestions.length,
+      });
+    } else {
+      this.input.current.editor.navigateLineEnd();
+    }
+  };
+
+  handleEnter = () => {
+    const { highlightedSuggestionIndex, suggestions } = this.state;
+
+    if (suggestions.length) {
+      this.onSuggestionSelected(highlightedSuggestionIndex);
+    }
+  };
+
   onInputKeyDown = e => {
-    console.log("🚀", "here");
     const { suggestions, highlightedSuggestionIndex } = this.state;
 
     if (e.keyCode === KEYCODE_LEFT || e.keyCode === KEYCODE_RIGHT) {
       setTimeout(() => this._triggerAutosuggest());
       return;
     }
+
     if (e.keyCode === KEYCODE_ESCAPE) {
       e.stopPropagation();
       e.preventDefault();
@@ -323,20 +359,24 @@ export default class ExpressionEditorTextfield extends React.Component {
         <AceEditor
           commands={[
             {
-              name: "commandName",
-              bindKey: { win: "ArrowDown", mac: "ArrowDown" },
+              name: "arrowDown",
+              bindKey: { win: "Down", mac: "Down" },
               exec: () => {
-                console.log("🚀, key-binding used");
+                this.handleArrowDown();
               },
             },
             {
-              name: "save",
-              bindKey: {
-                win: "Ctrl-enter",
-                mac: "Cmd-enter",
-              },
+              name: "arrowUp",
+              bindKey: { win: "Up", mac: "Up" },
               exec: () => {
-                console.log("🚀, key-binding used ctrl-enter");
+                this.handleArrowUp();
+              },
+            },
+            {
+              name: "enter",
+              bindKey: { win: "Enter", mac: "Enter" },
+              exec: () => {
+                this.handleEnter();
               },
             },
           ]}
@@ -347,7 +387,6 @@ export default class ExpressionEditorTextfield extends React.Component {
           wrapEnabled={true}
           fontSize={16}
           onBlur={this.handleEditorBlur}
-          onInput={this.onInputKeyDown}
           onFocus={this.handleEditorFocus}
           setOptions={{
             indentedSoftWrap: false,

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -146,8 +146,10 @@ export default class ExpressionEditorTextfield extends React.Component {
 
     if (suggestion) {
       const { tokens } = tokenize(source);
-      const { editor } = this.input.current;
       const token = tokens.find(t => t.end >= suggestion.index);
+
+      const { editor } = this.input.current;
+      const { row } = editor.getCursorPosition();
 
       if (token) {
         const prefix = source.slice(0, token.start);
@@ -165,12 +167,10 @@ export default class ExpressionEditorTextfield extends React.Component {
         this.onExpressionChange(updatedExpression);
         const caretPos = updatedExpression.length - postfix.length;
 
-        const { row } = editor.getCursorPosition();
         editor.moveCursorTo(row, caretPos);
       } else {
         const newExpression = source + suggestion.text;
         this.onExpressionChange(newExpression);
-        const { row } = editor.getCursorPosition();
         this.input.current.editor.moveCursorTo(row, newExpression.length);
       }
     }
@@ -353,6 +353,37 @@ export default class ExpressionEditorTextfield extends React.Component {
     });
   }
 
+  commands = [
+    {
+      name: "arrowDown",
+      bindKey: { win: "Down", mac: "Down" },
+      exec: () => {
+        this.handleArrowDown();
+      },
+    },
+    {
+      name: "arrowUp",
+      bindKey: { win: "Up", mac: "Up" },
+      exec: () => {
+        this.handleArrowUp();
+      },
+    },
+    {
+      name: "enter",
+      bindKey: { win: "Enter", mac: "Enter" },
+      exec: () => {
+        this.handleEnter();
+      },
+    },
+    {
+      name: "tab",
+      bindKey: { win: "Tab", mac: "Tab" },
+      exec: () => {
+        this.handleEnter();
+      },
+    },
+  ];
+
   render() {
     const { source, suggestions, errorMessage, isFocused } = this.state;
 
@@ -360,29 +391,7 @@ export default class ExpressionEditorTextfield extends React.Component {
       <EditorContainer isFocused={isFocused}>
         <EditorEqualsSign>=</EditorEqualsSign>
         <AceEditor
-          commands={[
-            {
-              name: "arrowDown",
-              bindKey: { win: "Down", mac: "Down" },
-              exec: () => {
-                this.handleArrowDown();
-              },
-            },
-            {
-              name: "arrowUp",
-              bindKey: { win: "Up", mac: "Up" },
-              exec: () => {
-                this.handleArrowUp();
-              },
-            },
-            {
-              name: "enter",
-              bindKey: { win: "Enter", mac: "Enter" },
-              exec: () => {
-                this.handleEnter();
-              },
-            },
-          ]}
+          commands={this.commands}
           ref={this.input}
           value={source}
           focus={true}


### PR DESCRIPTION
Bind editor to autocomplete.

Now it's possible to:

1. navigate the autocomplete options using the up and down arrow keys
2. choose an autocomplete option by hitting `enter` and `tab`

![Metabase autocomplete](https://user-images.githubusercontent.com/380816/143059417-a0437c77-ea22-4537-99fa-e65119109ef0.gif)
