### PR TITLE
Fuzz the parser with CASE and COALESCE functions

### DIFF
--- a/frontend/test/metabase/lib/expressions/fuzz.parser.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/fuzz.parser.unit.spec.js
@@ -18,8 +18,16 @@ describe("metabase/lib/expressions/parser", () => {
 
 fuzz("FUZZING metabase/lib/expressions/parser", () => {
   for (let seed = 1; seed < 1e4; ++seed) {
-    it("should parse generated expression from seed " + seed, () => {
-      const { expression } = generateExpression(seed);
+    it("should parse generated number expression from seed " + seed, () => {
+      const { expression } = generateExpression(seed, "number");
+      expect(() => handle(expression)).not.toThrow();
+    });
+    it("should parse generated string expression from seed " + seed, () => {
+      const { expression } = generateExpression(seed, "string");
+      expect(() => handle(expression)).not.toThrow();
+    });
+    it("should parse generated boolean expression from seed " + seed, () => {
+      const { expression } = generateExpression(seed, "boolean");
       expect(() => handle(expression)).not.toThrow();
     });
   }

--- a/frontend/test/metabase/lib/expressions/fuzz.tokenizer.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/fuzz.tokenizer.unit.spec.js
@@ -12,7 +12,7 @@ describe("metabase/lib/expressions/tokenizer", () => {
 });
 
 fuzz("FUZZING metabase/lib/expressions/tokenizer", () => {
-  const MAX_SEED = 5e4;
+  const MAX_SEED = 2e4;
 
   for (let seed = 0; seed < MAX_SEED; ++seed) {
     it("should handle generated expression from seed " + seed, () => {

--- a/frontend/test/metabase/lib/expressions/generator.js
+++ b/frontend/test/metabase/lib/expressions/generator.js
@@ -88,6 +88,30 @@ export function generateExpression(seed, resultType, depth = 13) {
     return String(str);
   };
 
+  const coalesce = fn => {
+    return {
+      type: NODE.FunctionCall,
+      value: "coalesce",
+      params: listOf(1 + randomInt(3), [fn])(),
+    };
+  };
+
+  const caseExpression = fn => {
+    const params = [];
+    for (let i = 0; i < 1 + randomInt(3); ++i) {
+      params.push(booleanExpression());
+      params.push(fn());
+    }
+    if (randomInt(10) < 3) {
+      params.push(fn());
+    }
+    return {
+      type: NODE.FunctionCall,
+      value: "case",
+      params,
+    };
+  };
+
   const numberExpression = () => {
     --depth;
     const node =
@@ -102,6 +126,8 @@ export function generateExpression(seed, resultType, depth = 13) {
             power,
             stringLength,
             numberGroup,
+            coalesceNumber,
+            caseNumber,
           ])();
     ++depth;
     return node;
@@ -183,6 +209,10 @@ export function generateExpression(seed, resultType, depth = 13) {
       child: numberExpression(),
     };
   };
+
+  const coalesceNumber = () => coalesce(numberExpression);
+
+  const caseNumber = () => caseExpression(numberExpression);
 
   const booleanExpression = () => {
     --depth;
@@ -284,6 +314,8 @@ export function generateExpression(seed, resultType, depth = 13) {
             stringReplace,
             substring,
             regexextract,
+            coalesceString,
+            caseString,
           ])();
     ++depth;
     return node;
@@ -336,6 +368,10 @@ export function generateExpression(seed, resultType, depth = 13) {
       params: [field(), stringLiteral()], // FIXME: maybe regexpLiteral?
     };
   };
+
+  const coalesceString = () => coalesce(stringExpression);
+
+  const caseString = () => caseExpression(stringExpression);
 
   const generatorFunctions = [];
   switch (resultType) {

--- a/frontend/test/metabase/lib/expressions/generator.js
+++ b/frontend/test/metabase/lib/expressions/generator.js
@@ -117,19 +117,10 @@ export function generateExpression(seed, resultType, depth = 13) {
     };
   };
 
-  const validIdentifier = () => {
-    const KEYWORDS = ["and", "or", "not"];
-    let candidate;
-    do {
-      candidate = identifier();
-    } while (KEYWORDS.includes(candidate.toLowerCase()));
-    return candidate;
-  };
-
   const field = () => {
     const fk = () => "[" + identifier() + " → " + identifier() + "]";
     const bracketedName = () => "[" + identifier() + "]";
-    const name = oneOf([validIdentifier, fk, bracketedName])();
+    const name = oneOf([fk, bracketedName])();
     return {
       type: NODE.Field,
       value: name,

--- a/frontend/test/metabase/lib/expressions/generator.js
+++ b/frontend/test/metabase/lib/expressions/generator.js
@@ -1,6 +1,6 @@
 import { createRandom } from "./prng";
 
-export function generateExpression(seed, depth = 13) {
+export function generateExpression(seed, resultType, depth = 13) {
   const random = createRandom(seed);
 
   const randomInt = max => Math.floor(max * random());
@@ -346,8 +346,31 @@ export function generateExpression(seed, depth = 13) {
     };
   };
 
-  const tree = oneOf([numberExpression, booleanExpression, stringExpression])();
+  const generatorFunctions = [];
+  switch (resultType) {
+    case "boolean":
+      generatorFunctions.push(booleanExpression);
+      break;
+    case "number":
+      generatorFunctions.push(numberExpression);
+      break;
+    case "string":
+      generatorFunctions.push(stringExpression);
+      break;
+    // alias for number | string
+    case "expression":
+      generatorFunctions.push(numberExpression);
+      generatorFunctions.push(stringExpression);
+      break;
 
+    default:
+      generatorFunctions.push(booleanExpression);
+      generatorFunctions.push(numberExpression);
+      generatorFunctions.push(stringExpression);
+      break;
+  }
+
+  const tree = oneOf(generatorFunctions)();
   const expression = format(tree);
 
   return { tree, expression };


### PR DESCRIPTION
The `generateExpression` now also randomly inserts two variadic functions, `CASE` and `COALESCE`, whenever appropriate.

It turns out to incorporate these functions to the fuzzer, the expression generator needs to be slightly modified to pick a particular type of expression result. This is because the return type of such functions (more obvious in the case of `COALESCE`, but quite also evident from `CASE`) depends on the type of its parameters. To be able to distinguish it clearly, the expected expression type now must be supplied to `generateExpression`.

Another related change is that the only generated identifier is in the form of bracketed once, e.g. `[Price]`. The current parser has the limitation that expression such as `EXP + ` yields a syntax error since `EXP` is a valid function name but used as an identifier instead, even if there is no parentheses after `EXP`. Thus, for now, we restrict the identifier names to the bracket form.

To give it a try, follow the same steps as in #18942:

```
MB_FUZZ=1 yarn test-unit frontend/test/metabase/lib/expressions/fuzz.parser.unit.spec.js

```