### PR TITLE
Add `snowplow-enabled` setting

### DIFF
--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -474,6 +474,7 @@
        " "
        (deferred-tru "Should be set via environment variable in Cypress tests or during local development."))
   :type       :boolean
+  :visibility :internal
   :default    config/is-prod?)
 
 (defsetting snowplow-enabled
@@ -483,7 +484,8 @@
   :type   :boolean
   :setter :none
   :getter (fn [] (and (snowplow-available)
-                      (anon-tracking-enabled))))
+                      (anon-tracking-enabled)))
+  :visibility :public)
 
 (defsetting snowplow-url
   (deferred-tru "The URL of the Snowplow collector to send analytics events to.")

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -474,13 +474,21 @@
        " "
        (deferred-tru "Should be set via environment variable in Cypress tests or during local development."))
   :type       :boolean
-  :default    config/is-prod?
-  :visibility :public)
+  :default    config/is-prod?)
+
+(defsetting snowplow-enabled
+  (str (deferred-tru "Boolean indicating whether analytics events are being sent to Snowplow. True if anonymous tracking")
+       " "
+       (deferred-tru "is enabled for this instance, and a Snowplow collector is available."))
+  :type   :boolean
+  :setter :none
+  :getter (fn [] (and (snowplow-available)
+                      (anon-tracking-enabled))))
 
 (defsetting snowplow-url
   (deferred-tru "The URL of the Snowplow collector to send analytics events to.")
   :default    (if config/is-prod?
                 "https://sp.metabase.com"
                 ;; Run `docker compose up` from the `snowplow/` subdirectory to start a local Snowplow collector
-                "http://localhost:9095")
+                "http://localhost:9090")
   :visibility :public)


### PR DESCRIPTION
Quick follow-on to #19067 to fix an issue @ranquild discovered. We have a blanket policy of not exposing the values of settings set by env var via the API, for security reasons. So setting `MB_SNOWPLOW_AVAILABLE=true` won't actually make that value available to Cypress.

Instead we can create a separate `snowplow-enabled` setting which derives its value from `snowplow-available`, iff anonymous tracking is available. I think having these two separate settings also helps resolves some confusion that  @dpsutton had on the previous PR, about which settings actually determine whether Snowplow events are sent in production.