### PR TITLE
Drop invalid column refs when normalizing viz settings

### DIFF
--- a/shared/src/metabase/shared/models/visualization_settings.cljc
+++ b/shared/src/metabase/shared/models/visualization_settings.cljc
@@ -553,13 +553,17 @@
   (reduce-kv db->norm-column-settings-entry {} entries))
 
 (defn db->norm-column-settings
-  "Converts a :column_settings DB form to its normalized form."
+  "Converts a :column_settings DB form to its normalized form. Drops any columns that fail to be parsed."
   [settings]
-  (m/map-kv (fn [k v]
-              (let [k1 (parse-db-column-ref k)
-                    v1 (db->norm-column-settings-entries v)]
-                [k1 v1]))
-            settings))
+  (reduce-kv (fn [m k v]
+               (try
+                 (let [k1 (parse-db-column-ref k)
+                       v1 (db->norm-column-settings-entries v)]
+                   (assoc m k1 v1))
+                 (catch Exception e
+                   m)))
+             {}
+             settings))
 
 (defn db->norm
   "Converts a DB form of visualization settings (i.e. map with key `:visualization_settings`) into the equivalent

--- a/shared/src/metabase/shared/models/visualization_settings.cljc
+++ b/shared/src/metabase/shared/models/visualization_settings.cljc
@@ -560,7 +560,7 @@
                  (let [k1 (parse-db-column-ref k)
                        v1 (db->norm-column-settings-entries v)]
                    (assoc m k1 v1))
-                 (catch Exception e
+                 (catch #?(:clj Throwable :cljs js/Error) e
                    m)))
              {}
              settings))

--- a/shared/test/metabase/shared/models/visualization_settings_test.cljc
+++ b/shared/test/metabase/shared/models/visualization_settings_test.cljc
@@ -98,14 +98,21 @@
           (let [to-db (mb.viz/norm->db to-norm)]
             (t/is (= db-form to-db)))))
       ;; for a non-table card, the :click_behavior map is directly underneath :visualization_settings
-      (t/is (= norm-click-bhvr-map (mb.viz/db->norm db-click-bhv-map)))))
+      (t/is (= norm-click-bhvr-map (mb.viz/db->norm db-click-bhv-map))))))
 
+(t/deftest form-transformation-test
   (t/testing "The deprecated k:mm :time_style is converted to HH:mm when normalized, and kept in the new style when converted back to the DB form"
     (let [db-col-settings-old {:column_settings {"[\"name\",\"Column Name\"]" {:time_style "k:mm"}}}
           db-col-settings-new {:column_settings {"[\"name\",\"Column Name\"]" {:time_style "HH:mm"}}}
           norm-col-settings   {::mb.viz/column-settings {{::mb.viz/column-name "Column Name"} {::mb.viz/time-style "HH:mm"}}}]
       (t/is (= norm-col-settings (mb.viz/db->norm db-col-settings-old)))
-      (t/is (= db-col-settings-new (mb.viz/norm->db norm-col-settings))))))
+      (t/is (= db-col-settings-new (mb.viz/norm->db norm-col-settings)))))
+
+  (t/testing "Invalid column refs are dropped when viz settings are normalized (#18972)"
+    (t/is (= {::mb.viz/column-settings {}}
+             (mb.viz/db->norm {:column_settings {"[\"ref\",null]" {:column_title "invalid"}}})))
+    (t/is (= {::mb.viz/column-settings {}}
+             (mb.viz/db->norm {:column_settings {"bad-column-ref" {:column_title "invalid"}}})))))
 
 (t/deftest virtual-card-test
   (t/testing "Virtual card in visualization settings is preserved through normalization roundtrip"


### PR DESCRIPTION
Prior to exports, we pass viz settings from the frontend through normalization, and if a column ref cannot be parsed according to the spec, an exception is thrown and the export will fail. It seems that some users have column refs in saved questions like `[\"ref\",null]` which were left over perhaps by some bug on the frontend, and which are triggering these kinds of exceptions on exports. This is the issue reported in #18972. 

Per @camsaul:

> In terms of backend behavior I think what we want to do here is just remove those sorts of invalid entries entirely on save, and when they come out of the DB. We should be able to do that as part of the viz-settings normalization code

This PR modifies our viz setting normalization code to catch exceptions thrown during column ref normalization and drop these invalid columns. We don't currently run normalization in any places other than exports and serialization, so it's not a general fix for these invalid column refs, but it should at least close out the attached issue.