### PR TITLE
Handle input blur to enable Done button

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -282,16 +282,6 @@ export default class ExpressionEditorTextfield extends React.Component {
 
   handleEditorBlur = () => {
     this.setState({ isFocused: false });
-  };
-
-  onInputBlur = e => {
-    // Switching to another window also triggers the blur event.
-    // When our window gets focus again, the input will automatically
-    // get focus, so ignore the blue event to avoid showing an
-    // error message when the user is not actually done.
-    if (e.target === document.activeElement) {
-      return;
-    }
 
     this.clearSuggestions();
 
@@ -332,6 +322,9 @@ export default class ExpressionEditorTextfield extends React.Component {
 
   onExpressionChange(source) {
     this.setState({ source });
+    if (this.props.onBlankChange) {
+      this.props.onBlankChange(source.length === 0);
+    }
   }
 
   onCursorChange(selection) {


### PR DESCRIPTION
Note: this doesn't handle invalid expression yet.

Steps to try:
1. Ask a question, Custom question
2. Sample Dataset, People table
3. Filter, Custom Expression, type `[State] = "CA"`

**Before this PR**

You can't press `Done` button even after switch focus away from the editor.

![image](https://user-images.githubusercontent.com/7288/143086331-2e0da86c-dbee-4520-8b88-4f4d67bdcb5d.png)

**After this PR**

You can press `Done` button since it's enabled.

![image](https://user-images.githubusercontent.com/7288/143086212-ba6c897f-e1b2-4707-afa3-fdfcd9bd1ca1.png)

