### PR TITLE
Add `ga-enabled` setting

### DIFF
--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -166,6 +166,13 @@
   :default    "UA-60817802-1"
   :visibility :public)
 
+(defsetting ga-enabled
+  (deferred-tru "Boolean indicating whether analytics data should be sent to Google Analytics on the frontend")
+  :type       :boolean
+  :setter     :none
+  :getter     (fn [] (and config/is-prod? (anon-tracking-enabled)))
+  :visibility :public)
+
 (defsetting map-tile-server-url
   (deferred-tru "The map tile server URL template used in map visualizations, for example from OpenStreetMaps or MapBox.")
   :default    "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"


### PR DESCRIPTION
Adds a `ga-enabled` setting suggested by @ranquild which should be read by the frontend to determine whether data should be sent to GA. Enabled iff anonymous tracking is enabled _and_ the environment is prod. Should replace the current checks on the `WEBPACK_ENV` environment variable, and is consistent with the `snowplow-enabled` setting I'm adding in #19074.