### PR TITLE
React Ace: handle blur

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -280,8 +280,16 @@ export default class ExpressionEditorTextfield extends React.Component {
     this.setState({ isFocused: true });
   };
 
-  handleEditorBlur = () => {
+  onInputBlur = e => {
     this.setState({ isFocused: false });
+
+    // Switching to another window also triggers the blur event.
+    // When our window gets focus again, the input will automatically
+    // get focus, so ignore the blue event to avoid showing an
+    // error message when the user is not actually done.
+    if (e.target === document.activeElement) {
+      return;
+    }
 
     this.clearSuggestions();
 

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -213,6 +213,7 @@ export default class ExpressionEditorTextfield extends React.Component {
   };
 
   onInputKeyDown = e => {
+    console.log("🚀", "here");
     const { suggestions, highlightedSuggestionIndex } = this.state;
 
     if (e.keyCode === KEYCODE_LEFT || e.keyCode === KEYCODE_RIGHT) {
@@ -392,6 +393,7 @@ export default class ExpressionEditorTextfield extends React.Component {
           wrapEnabled={true}
           fontSize={16}
           onBlur={this.handleEditorBlur}
+          onInput={this.onInputKeyDown}
           onFocus={this.handleEditorFocus}
           setOptions={{
             indentedSoftWrap: false,

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -213,7 +213,6 @@ export default class ExpressionEditorTextfield extends React.Component {
   };
 
   onInputKeyDown = e => {
-    console.log("🚀", "here");
     const { suggestions, highlightedSuggestionIndex } = this.state;
 
     if (e.keyCode === KEYCODE_LEFT || e.keyCode === KEYCODE_RIGHT) {
@@ -393,7 +392,6 @@ export default class ExpressionEditorTextfield extends React.Component {
           wrapEnabled={true}
           fontSize={16}
           onBlur={this.handleEditorBlur}
-          onInput={this.onInputKeyDown}
           onFocus={this.handleEditorFocus}
           setOptions={{
             indentedSoftWrap: false,

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -381,31 +381,33 @@ export default class ExpressionEditorTextfield extends React.Component {
     const { source, suggestions, errorMessage, isFocused } = this.state;
 
     return (
-      <EditorContainer isFocused={isFocused}>
-        <EditorEqualsSign>=</EditorEqualsSign>
-        <AceEditor
-          commands={this.commands}
-          ref={this.input}
-          value={source}
-          focus={true}
-          highlightActiveLine={false}
-          wrapEnabled={true}
-          fontSize={16}
-          onBlur={this.handleEditorBlur}
-          onFocus={this.handleEditorFocus}
-          setOptions={{
-            indentedSoftWrap: false,
-            minLines: 1,
-            maxLines: 9,
-            showLineNumbers: false,
-            showGutter: false,
-            showFoldWidgets: false,
-            showPrintMargin: false,
-          }}
-          onChange={source => this.onExpressionChange(source)}
-          onCursorChange={selection => this.onCursorChange(selection)}
-          width="100%"
-        />
+      <React.Fragment>
+        <EditorContainer isFocused={isFocused} hasError={Boolean(errorMessage)}>
+          <EditorEqualsSign>=</EditorEqualsSign>
+          <AceEditor
+            commands={this.commands}
+            ref={this.input}
+            value={source}
+            focus={true}
+            highlightActiveLine={false}
+            wrapEnabled={true}
+            fontSize={12}
+            onBlur={this.onInputBlur}
+            onFocus={this.handleEditorFocus}
+            setOptions={{
+              indentedSoftWrap: false,
+              minLines: 1,
+              maxLines: 9,
+              showLineNumbers: false,
+              showGutter: false,
+              showFoldWidgets: false,
+              showPrintMargin: false,
+            }}
+            onChange={source => this.onExpressionChange(source)}
+            onCursorChange={selection => this.onCursorChange(selection)}
+            width="100%"
+          />
+        </EditorContainer>
         <ErrorMessage error={errorMessage} />
         <HelpText helpText={this.state.helpText} width={this.props.width} />
         <ExpressionEditorSuggestions
@@ -413,7 +415,7 @@ export default class ExpressionEditorTextfield extends React.Component {
           onSuggestionMouseDown={this.onSuggestionSelected}
           highlightedIndex={this.state.highlightedSuggestionIndex}
         />
-      </EditorContainer>
+      </React.Fragment>
     );
   }
 }

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.styled.jsx
@@ -1,17 +1,29 @@
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 
 import { space } from "metabase/styled-components/theme";
 import { color } from "metabase/lib/colors";
 
 export const EditorContainer = styled.div`
   border: 1px solid;
-  border-color: ${({ isFocused }) =>
-    isFocused ? color("brand") : color("border")};
+  border-color: ${color("border")};
   border-radius: ${space(0)};
   display: flex;
   position: relative;
   margin: ${space(1)} 0;
   padding: ${space(1)};
+  transition: border 0.3s linear;
+
+  ${({ isFocused }) =>
+    isFocused &&
+    css`
+      border-color: ${color("brand")};
+    `}
+
+  ${({ hasError }) =>
+    hasError &&
+    css`
+      border-color: ${color("error")};
+    `}
 `;
 
 export const EditorEqualsSign = styled.div`

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.styled.jsx
@@ -24,6 +24,10 @@ export const EditorContainer = styled.div`
     css`
       border-color: ${color("error")};
     `}
+
+  @media (prefers-reduced-motion) {
+    transition: none;
+  }
 `;
 
 export const EditorEqualsSign = styled.div`


### PR DESCRIPTION
Error message is back in its desired position.

Editor border color is red if there is an error message.

Border color transitions in .3 seconds.

![Metabase error message](https://user-images.githubusercontent.com/380816/143092257-9ac0ee44-b405-4949-9899-1e7fa8046b6e.gif)
