### PR TITLE
React Ace — Fix autocomplete layout

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -415,14 +415,14 @@ export default class ExpressionEditorTextfield extends React.Component {
             onCursorChange={selection => this.onCursorChange(selection)}
             width="100%"
           />
+          <ExpressionEditorSuggestions
+            suggestions={suggestions}
+            onSuggestionMouseDown={this.onSuggestionSelected}
+            highlightedIndex={this.state.highlightedSuggestionIndex}
+          />
         </EditorContainer>
         <ErrorMessage error={errorMessage} />
         <HelpText helpText={this.state.helpText} width={this.props.width} />
-        <ExpressionEditorSuggestions
-          suggestions={suggestions}
-          onSuggestionMouseDown={this.onSuggestionSelected}
-          highlightedIndex={this.state.highlightedSuggestionIndex}
-        />
       </React.Fragment>
     );
   }


### PR DESCRIPTION
Fixes "regression", autocomplete back to desired position.

### After

![image](https://user-images.githubusercontent.com/380816/143264255-4552ad77-b618-4e75-90cc-947043c3aba3.png)
