### PR TITLE
React Ace: have tab move focus to next tabbable element if suggestions are not shown

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -212,6 +212,17 @@ export default class ExpressionEditorTextfield extends React.Component {
     }
   };
 
+  handleTab = () => {
+    const { highlightedSuggestionIndex, suggestions } = this.state;
+    const { editor } = this.input.current;
+
+    if (suggestions.length) {
+      this.onSuggestionSelected(highlightedSuggestionIndex);
+    } else {
+      editor.commands.byName.tab();
+    }
+  };
+
   onInputKeyDown = e => {
     const { suggestions, highlightedSuggestionIndex } = this.state;
 
@@ -380,7 +391,7 @@ export default class ExpressionEditorTextfield extends React.Component {
       name: "tab",
       bindKey: { win: "Tab", mac: "Tab" },
       exec: () => {
-        this.handleEnter();
+        this.handleTab();
       },
     },
   ];


### PR DESCRIPTION
### How to Test

1. Tab to accept an autocomplete suggestion

In custom question custom expression editor,

a. type `c`
b. accept suggestion of `case` by hitting the Tab key

You should see `case` in the editor

2. Tab to move to next tabbable element


In custom question custom expression editor,

a. type something that will not generate a suggestion, like `carstarstrsta`
b. hit the Tab key

Focus should move to the anchor with text of `Learn more`.