### PR TITLE
React Ace: update e2e tests and handle focus event

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -402,6 +402,7 @@ export default class ExpressionEditorTextfield extends React.Component {
             fontSize={12}
             onBlur={this.onInputBlur}
             onFocus={this.handleEditorFocus}
+            role="ace-editor"
             setOptions={{
               indentedSoftWrap: false,
               minLines: 1,

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -276,9 +276,10 @@ export default class ExpressionEditorTextfield extends React.Component {
     return expression;
   }
 
-  handleEditorFocus = () => {
+  handleFocus = () => {
     this.setState({ isFocused: true });
-    setTimeout(() => this._triggerAutosuggest());
+    const { editor } = this.input.current;
+    this.onCursorChange(editor.selection);
   };
 
   onInputBlur = e => {
@@ -402,7 +403,7 @@ export default class ExpressionEditorTextfield extends React.Component {
             wrapEnabled={true}
             fontSize={12}
             onBlur={this.onInputBlur}
-            onFocus={this.handleEditorFocus}
+            onFocus={this.handleFocus}
             role="ace-editor"
             setOptions={{
               indentedSoftWrap: false,

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -278,6 +278,7 @@ export default class ExpressionEditorTextfield extends React.Component {
 
   handleEditorFocus = () => {
     this.setState({ isFocused: true });
+    setTimeout(() => this._triggerAutosuggest());
   };
 
   onInputBlur = e => {

--- a/frontend/test/__support__/e2e/helpers/e2e-custom-column-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-custom-column-helpers.js
@@ -1,6 +1,8 @@
 export function enterCustomColumnDetails({ formula, name } = {}) {
-  cy.get("[contenteditable='true']")
+  cy.get(".ace_text-input")
+    .first()
     .as("formula")
+    .focus()
     .type(formula);
 
   cy.findByPlaceholderText("Something nice and descriptive").type(name);

--- a/frontend/test/__support__/e2e/helpers/e2e-custom-column-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-custom-column-helpers.js
@@ -5,5 +5,7 @@ export function enterCustomColumnDetails({ formula, name } = {}) {
     .focus()
     .type(formula);
 
-  cy.findByPlaceholderText("Something nice and descriptive").type(name);
+  if (name) {
+    cy.findByPlaceholderText("Something nice and descriptive").type(name);
+  }
 }

--- a/frontend/test/metabase/scenarios/custom-column/cc-expression-editor.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/cc-expression-editor.cy.spec.js
@@ -16,24 +16,24 @@ describe("scenarios > question > custom column > expression editor", () => {
     openOrdersTable({ mode: "notebook" });
     cy.findByText("Custom column").click();
 
-    // enterCustomColumnDetails({
-    //   formula: "1+1", // Formula was intentionally written without spaces (important for this repro)!
-    //   name: "Math",
-    // });
-    // cy.button("Done").should("not.be.disabled");
+    enterCustomColumnDetails({
+      formula: "1+1", // Formula was intentionally written without spaces (important for this repro)!
+      name: "Math",
+    });
+    cy.button("Done").should("not.be.disabled");
   });
 
+  /**
+   * We abuse {force: true} arguments below because AceEditor cannot be found
+   * on a second click and type commands (the first ones happen in the beforeEach block above )
+   */
   it("should not accidentally delete Custom Column formula value and/or Custom Column name (metabase#15734)", () => {
-    cy.get(".ace_text-input")
-      .first()
-      .focus()
-      .type("1+1{movetoend}{leftarrow}{movetostart}{rightarrow}{rightarrow}", {
-        delay: 100,
-      })
-      .blur();
-
-    cy.findByPlaceholderText("Something nice and descriptive").type("Math");
-    cy.findByDisplayValue("Math");
+    cy.get("@formula")
+      .click({ force: true })
+      .type("{movetoend}{leftarrow}{movetostart}{rightarrow}{rightarrow}", {
+        force: true,
+      });
+    cy.findByDisplayValue("Math").focus();
     cy.button("Done").should("not.be.disabled");
   });
 
@@ -43,24 +43,18 @@ describe("scenarios > question > custom column > expression editor", () => {
    *  - This gives it enough time to update the DOM. The same result can be achieved with `cy.wait(1)`
    */
   it("should not erase Custom column formula and Custom column name when expression is incomplete (metabase#16126)", () => {
-    cy.get(".ace_text-input")
-      .first()
+    cy.get("@formula")
       .focus()
-      .type("1+1{movetoend}{backspace}", { delay: 100 })
+      .click({ force: true })
+      .type("{movetoend}{backspace}", { force: true })
       .blur();
+
     cy.findByText("Expected expression");
     cy.button("Done").should("be.disabled");
-    // cy.get("@formula").click(); /* See comment (1) above */
-    // cy.findByDisplayValue("Math");
   });
 
   it("should not erase Custom Column formula and Custom Column name on window resize (metabase#16127)", () => {
     cy.viewport(1260, 800);
-    cy.get(".ace_text-input")
-      .first()
-      .focus()
-      .type("1+1", { delay: 100 });
-    cy.findByPlaceholderText("Something nice and descriptive").type("Math");
     cy.findByDisplayValue("Math");
     cy.button("Done").should("not.be.disabled");
   });

--- a/frontend/test/metabase/scenarios/custom-column/cc-expression-editor.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/cc-expression-editor.cy.spec.js
@@ -16,19 +16,23 @@ describe("scenarios > question > custom column > expression editor", () => {
     openOrdersTable({ mode: "notebook" });
     cy.findByText("Custom column").click();
 
-    enterCustomColumnDetails({
-      formula: "1+1", // Formula was intentionally written without spaces (important for this repro)!
-      name: "Math",
-    });
-    cy.button("Done").should("not.be.disabled");
+    // enterCustomColumnDetails({
+    //   formula: "1+1", // Formula was intentionally written without spaces (important for this repro)!
+    //   name: "Math",
+    // });
+    // cy.button("Done").should("not.be.disabled");
   });
 
   it("should not accidentally delete Custom Column formula value and/or Custom Column name (metabase#15734)", () => {
     cy.get(".ace_text-input")
       .first()
       .focus()
-      .type("{movetoend}{leftarrow}{movetostart}{rightarrow}{rightarrow}")
+      .type("1+1{movetoend}{leftarrow}{movetostart}{rightarrow}{rightarrow}", {
+        delay: 100,
+      })
       .blur();
+
+    cy.findByPlaceholderText("Something nice and descriptive").type("Math");
     cy.findByDisplayValue("Math");
     cy.button("Done").should("not.be.disabled");
   });
@@ -42,17 +46,21 @@ describe("scenarios > question > custom column > expression editor", () => {
     cy.get(".ace_text-input")
       .first()
       .focus()
-      .type("{movetoend}{backspace}")
+      .type("1+1{movetoend}{backspace}", { delay: 100 })
       .blur();
     cy.findByText("Expected expression");
     cy.button("Done").should("be.disabled");
-    cy.get("@formula").click(); /* See comment (1) above */
-    cy.findByDisplayValue("Math");
+    // cy.get("@formula").click(); /* See comment (1) above */
+    // cy.findByDisplayValue("Math");
   });
 
   it("should not erase Custom Column formula and Custom Column name on window resize (metabase#16127)", () => {
     cy.viewport(1260, 800);
-    cy.get("@formula").click(); /* See comment (1) above */
+    cy.get(".ace_text-input")
+      .first()
+      .focus()
+      .type("1+1", { delay: 100 });
+    cy.findByPlaceholderText("Something nice and descriptive").type("Math");
     cy.findByDisplayValue("Math");
     cy.button("Done").should("not.be.disabled");
   });

--- a/frontend/test/metabase/scenarios/custom-column/cc-expression-editor.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/cc-expression-editor.cy.spec.js
@@ -24,8 +24,9 @@ describe("scenarios > question > custom column > expression editor", () => {
   });
 
   it("should not accidentally delete Custom Column formula value and/or Custom Column name (metabase#15734)", () => {
-    cy.get("@formula")
-      .click()
+    cy.get(".ace_text-input")
+      .first()
+      .focus()
       .type("{movetoend}{leftarrow}{movetostart}{rightarrow}{rightarrow}")
       .blur();
     cy.findByDisplayValue("Math");
@@ -38,8 +39,9 @@ describe("scenarios > question > custom column > expression editor", () => {
    *  - This gives it enough time to update the DOM. The same result can be achieved with `cy.wait(1)`
    */
   it("should not erase Custom column formula and Custom column name when expression is incomplete (metabase#16126)", () => {
-    cy.get("@formula")
-      .click()
+    cy.get(".ace_text-input")
+      .first()
+      .focus()
       .type("{movetoend}{backspace}")
       .blur();
     cy.findByText("Expected expression");

--- a/frontend/test/metabase/scenarios/custom-column/cc-help-text.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/cc-help-text.cy.spec.js
@@ -38,10 +38,10 @@ describe("scenarios > question > custom column > help text", () => {
     cy.findByText("round([Temperature])").should("not.exist");
 
     // Should also work with escape key
-    cy.get("@formula").click({ force: true });
+    cy.get("@formula").focus();
     cy.findByText("round([Temperature])");
 
-    cy.get("@formula").type("{esc}", { force: true });
+    cy.get("@formula").type("{esc}");
     cy.findByText("round([Temperature])").should("not.exist");
   });
 

--- a/frontend/test/metabase/scenarios/custom-column/cc-help-text.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/cc-help-text.cy.spec.js
@@ -1,4 +1,8 @@
-import { restore, openProductsTable } from "__support__/e2e/cypress";
+import {
+  enterCustomColumnDetails,
+  restore,
+  openProductsTable,
+} from "__support__/e2e/cypress";
 
 describe("scenarios > question > custom column > help text", () => {
   beforeEach(() => {
@@ -10,24 +14,23 @@ describe("scenarios > question > custom column > help text", () => {
   });
 
   it("should appear while inside a function", () => {
-    cy.get("[contenteditable='true']").type("Lower(");
+    enterCustomColumnDetails({ formula: "Lower(" });
     cy.findByText("lower(text)");
   });
 
   it("should appear after a field reference", () => {
-    cy.get("[contenteditable='true']").type("Lower([Category]");
+    // cy.get("[contenteditable='true']").type("Lower([Category]");
+    enterCustomColumnDetails({ formula: "Lower([Category]" });
     cy.findByText("lower(text)");
   });
 
   it("should not appear while outside a function", () => {
-    cy.get("[contenteditable='true']").type("Lower([Category])");
+    enterCustomColumnDetails({ formula: "Lower([Category])" });
     cy.findByText("lower(text)").should("not.exist");
   });
 
   it("should not appear when formula field is not in focus (metabase#15891)", () => {
-    cy.get("[contenteditable='true']")
-      .as("formulaField")
-      .type(`rou{enter}1.5`);
+    enterCustomColumnDetails({ formula: "rou{enter}1.5" });
 
     cy.findByText("round([Temperature])");
 
@@ -35,10 +38,10 @@ describe("scenarios > question > custom column > help text", () => {
     cy.findByText("round([Temperature])").should("not.exist");
 
     // Should also work with escape key
-    cy.get("@formulaField").click();
+    cy.get("@formula").click({ force: true });
     cy.findByText("round([Temperature])");
 
-    cy.get("@formulaField").type("{esc}");
+    cy.get("@formula").type("{esc}", { force: true });
     cy.findByText("round([Temperature])").should("not.exist");
   });
 

--- a/frontend/test/metabase/scenarios/custom-column/cc-help-text.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/cc-help-text.cy.spec.js
@@ -19,7 +19,6 @@ describe("scenarios > question > custom column > help text", () => {
   });
 
   it("should appear after a field reference", () => {
-    // cy.get("[contenteditable='true']").type("Lower([Category]");
     enterCustomColumnDetails({ formula: "Lower([Category]" });
     cy.findByText("lower(text)");
   });
@@ -34,7 +33,8 @@ describe("scenarios > question > custom column > help text", () => {
 
     cy.findByText("round([Temperature])");
 
-    cy.findByText(/Field formula/i).click(); // Click outside of formula field instead of blur
+    // Click outside of formula field instead of blur
+    cy.findByText(/Field formula/i).click();
     cy.findByText("round([Temperature])").should("not.exist");
 
     // Should also work with escape key
@@ -46,7 +46,7 @@ describe("scenarios > question > custom column > help text", () => {
   });
 
   it("should not disappear when clicked on (metabase#17548)", () => {
-    cy.get("[contenteditable='true']").type(`rou{enter}`);
+    enterCustomColumnDetails({ formula: "rou{enter}" });
 
     // Shouldn't hide on click
     cy.findByText("round([Temperature])").click();


### PR DESCRIPTION
Updates a few e2e tests.

Add `onFocus` feature detail that was lacking and e2e test caught.

### How to test `onFocus`

1. Custom question
2. Open expression editor
3. Type `rou` then `{enter}` to select the suggestion then `1.5`
4. Click outside the editor 
5. Click back inside the editor

Helper popover should appear on focus.