### PR TITLE
interval function: lossless conversion between GUI and MBQL

### DIFF
--- a/frontend/src/metabase/lib/expressions/compile.js
+++ b/frontend/src/metabase/lib/expressions/compile.js
@@ -91,9 +91,11 @@ class ExpressionMBQLCompilerVisitor extends ExpressionCstVisitor {
         // the last one holds the function options
         const fnOptions = this.visit(parameters.pop());
 
-        // HACK: very specific to some string functions for now
+        // HACK: very specific to some string/time functions for now
         if (fnOptions === "case-insensitive") {
           options.push({ "case-sensitive": false });
+        } else if (fnOptions === "include-current") {
+          options.push({ "include-current": true });
         }
       }
     }

--- a/frontend/src/metabase/lib/expressions/config.js
+++ b/frontend/src/metabase/lib/expressions/config.js
@@ -226,6 +226,7 @@ export const MBQL_CLAUSES = {
     displayName: `interval`,
     type: "boolean",
     args: ["expression", "number", "string"],
+    hasOptions: true,
   },
   "is-null": {
     displayName: `isnull`,

--- a/frontend/src/metabase/lib/expressions/format.js
+++ b/frontend/src/metabase/lib/expressions/format.js
@@ -88,12 +88,18 @@ function formatSegment([, segmentId], options) {
   return formatSegmentName(segment, options);
 }
 
-// HACK: very specific to some string functions for now
+// HACK: very specific to some string/time functions for now
 function formatFunctionOptions(fnOptions) {
   if (Object.prototype.hasOwnProperty.call(fnOptions, "case-sensitive")) {
     const caseSensitive = fnOptions["case-sensitive"];
     if (!caseSensitive) {
       return "case-insensitive";
+    }
+  }
+  if (Object.prototype.hasOwnProperty.call(fnOptions, "include-current")) {
+    const includeCurrent = fnOptions["include-current"];
+    if (includeCurrent) {
+      return "include-current";
     }
   }
 }

--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -676,6 +676,29 @@ describe("scenarios > question > filter", () => {
     cy.get("[contenteditable='true']");
   });
 
+  it("should be able to convert time interval filter to custom expression (metabase#12457)", () => {
+    openOrdersTable({ mode: "notebook" });
+
+    // Via the GUI, create a filter with "include-current" option
+    cy.findByText("Filter").click();
+    cy.findByText("Created At").click();
+    cy.get("input[type='text']").type("{selectall}{del}5");
+    cy.contains("Include today").click();
+    cy.findByText("Add filter").click();
+
+    // Switch to custom expression
+    cy.findByText("Created At Previous 5 Days").click();
+    popover().within(() => {
+      cy.icon("chevronleft").click();
+      cy.findByText("Custom Expression").click();
+    });
+    cy.findByText("Done").click();
+
+    // Back to GUI and "Include today" should be still checked
+    cy.findByText("Created At Previous 5 Days").click();
+    cy.findByLabelText("Include today").should("be.checked");
+  });
+
   it("should be able to convert case-insensitive filter to custom expression (metabase#14959)", () => {
     cy.server();
     cy.route("POST", "/api/dataset").as("dataset");


### PR DESCRIPTION
Status: still needs some tests.

1. Ask a question, Custom question
2. Sample dataset, Orders table
3. Filter, Created At, choose Previous 3 years and check _Include this year_, click Add Filter

![image](https://user-images.githubusercontent.com/7288/143326647-4576c41f-05ee-4af4-92e4-4d1b910d3f20.png)


4. Click on the newly created filter, click on the chevron, choose Custom Expression.
It should display `interval([Created At], -3, "year")`. Don't change anything, click Done.
5. Click on the same filter again.


**Before this PR**

_Include this year_ is not checked.

This means there is a **lossy round-trip** between GUI filter and Custom expression.

![image](https://user-images.githubusercontent.com/7288/143326587-e9d15224-4f5c-4e67-acd4-ca426332d0f0.png)


**After this PR**

_Include this year_ is still checked.

The reason the round-trip is preserved is because at Step 4, the converted custom expression for the filter is
`interval([Created At], -3, "year", "include-current")`. Note the last argument,  `"include-current"`, denoting the option to also include the current time period.

![image](https://user-images.githubusercontent.com/7288/143326804-f25e892d-9d3d-4367-8859-6ceeadf8e7fa.png)

This will also work even if the custom expression (in Step 4) is modified, e.g. from `3` to `4`.

![image](https://user-images.githubusercontent.com/7288/143326771-a4fe863f-a41e-48fc-a6e2-5a526732b7e2.png)







