### PR TITLE
Update dataset simple mode implementation

### DIFF
--- a/frontend/src/metabase/query_builder/utils.js
+++ b/frontend/src/metabase/query_builder/utils.js
@@ -13,24 +13,3 @@ export function isAdHocDatasetQuestion(question, originalQuestion) {
 
   return isDataset && isSameCard && isSelfReferencing;
 }
-
-export function toAdHocDatasetQuestionCard(card, originalCard) {
-  return {
-    ...card,
-    dataset_query: {
-      ...originalCard.dataset_query,
-      query: {
-        "source-table": getQuestionVirtualTableId(originalCard),
-      },
-    },
-  };
-}
-
-export function toAdHocDatasetQuestion(question, originalQuestion) {
-  return question.setDatasetQuery({
-    ...originalQuestion.datasetQuery(),
-    query: {
-      "source-table": getQuestionVirtualTableId(originalQuestion.card()),
-    },
-  });
-}

--- a/frontend/src/metabase/visualizations/components/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization.jsx
@@ -278,7 +278,15 @@ export default class Visualization extends React.PureComponent {
 
   @memoize
   _getQuestionForCardCached(metadata, card) {
-    return metadata && card && new Question(card, metadata);
+    if (!metadata || !card) {
+      return;
+    }
+    const question = new Question(card, metadata);
+
+    // Datasets in QB should behave as raw tables opened in simple mode
+    // composeDataset replaces the dataset_query with a clean query using the dataset as a source table
+    // Ideally, this logic should happen somewhere else
+    return question.isDataset() ? question.composeDataset() : question;
   }
 
   getClickActions(clicked: ?ClickObject) {


### PR DESCRIPTION
Refactors the approach to unlock simple mode features for datasets. The original implementation was added in #18993 

The original implementation was swapping QB question's `dataset_query` with a clean query, using the dataset as a `source-table`. However, all the other dataset card properties were kept, so we don't lose saved question behaviors (renaming, adding to dashboards, etc.). The main limitation is that it became harder to access the actual dataset's `dataset_query` object, so it made it harder to implement the dataset query editor.

This PR slightly changes the approach, so we swap the query inside the `getQuestion` QB selector if a dataset is open in the QB. In that way, it's easy to access the dataset's real `dataset_query` object. Also, it requires much less code compared to the original solution (the diff is mostly reverting the changes from the original PR).

### To Verify

1. Open a dataset (you can create one following the steps from #18702)
3. Add a filter / summarize something
4. Make sure the URL is changed from /question/:id-:slug to /question#hash (moved to ad-hoc mode)
5. Click the "Save" button
6. Make sure you're not offered to replace the dataset, only to save a new question
7. Save the question
8. Make sure it shows the dataset name and its collection instead of database and tables

### Demo

https://user-images.githubusercontent.com/17258145/141836214-2ea7f8e8-112a-4d07-9aa7-feb90ec0a80d.mov