### PR TITLE
Simple mode for native datasets

### DIFF
--- a/frontend/src/metabase-lib/lib/Question.js
+++ b/frontend/src/metabase-lib/lib/Question.js
@@ -553,7 +553,7 @@ export default class Question {
   }
 
   composeDataset() {
-    if (!this.isStructured() || !this.isDataset()) {
+    if (!this.isDataset()) {
       return this;
     }
     return this.setDatasetQuery({

--- a/frontend/test/metabase/scenarios/question/datasets.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/datasets.cy.spec.js
@@ -13,7 +13,7 @@ describe("scenarios > datasets", () => {
     cy.signInAsAdmin();
   });
 
-  it("allows to turn a question into a dataset", () => {
+  it("allows to turn a GUI question into a dataset", () => {
     cy.request("PUT", "/api/card/1", { name: "Orders Dataset" });
     cy.visit("/question/1");
 
@@ -35,6 +35,56 @@ describe("scenarios > datasets", () => {
     });
 
     saveQuestionBasedOnDataset({ datasetId: 1, name: "Q1" });
+
+    assertQuestionIsBasedOnDataset({
+      questionName: "Q1",
+      dataset: "Orders Dataset",
+      collection: "Our analytics",
+      table: "Orders",
+    });
+
+    cy.findAllByText("Our analytics")
+      .first()
+      .click();
+    getCollectionItemRow("Orders Dataset").within(() => {
+      cy.icon("dataset");
+    });
+    getCollectionItemRow("Q1").within(() => {
+      cy.icon("table");
+    });
+
+    cy.url().should("not.include", "/question/1");
+  });
+
+  it("allows to turn a native question into a dataset", () => {
+    cy.createNativeQuestion(
+      {
+        name: "Orders Dataset",
+        native: {
+          query: "SELECT * FROM orders",
+        },
+      },
+      { visitQuestion: true },
+    );
+
+    turnIntoDataset();
+    assertIsDataset();
+
+    cy.findByTestId("qb-header-action-panel").within(() => {
+      cy.findByText("Filter").click();
+    });
+    selectDimensionOptionFromSidebar("DISCOUNT");
+    cy.findByText("Equal to").click();
+    selectFromDropdown("Not empty");
+    cy.button("Add filter").click();
+
+    assertQuestionIsBasedOnDataset({
+      dataset: "Orders Dataset",
+      collection: "Our analytics",
+      table: "Orders",
+    });
+
+    saveQuestionBasedOnDataset({ datasetId: 4, name: "Q1" });
 
     assertQuestionIsBasedOnDataset({
       questionName: "Q1",
@@ -532,6 +582,10 @@ function assertIsDataset() {
   });
   cy.findByText("Dataset management");
   cy.findByText("Sample Dataset").should("not.exist");
+
+  // For native
+  cy.findByText("This question is written in SQL.").should("not.exist");
+  cy.get("ace_content").should("not.exist");
 }
 
 // Requires question details sidebar to be open


### PR DESCRIPTION
This PR enables "simple mode" for native datasets. Datasets are displayed as raw tables opened in simple mode, so you can explore the data, filter, summarize it and eventually create a new saved question.

This PR is relying on refactored dataset simple mode from #19101

### To Verify

1. Open a native dataset (you can create one following the steps from #18702)
2. Make sure the native query editor is not shown and you can only see a results table
3. Add a filter / summarize something
4. Make sure the URL is changed from /question/:id-:slug to /question#hash (moved to ad-hoc mode)
5. Click the "Save" button
6. Make sure you're not offered to replace the dataset, only to save a new question
7. Save the question
8. Make sure it shows the dataset name and its collection instead of database and tables

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/143485455-91d24b20-68b1-4ddc-9245-0980b936d263.mov

**After**

https://user-images.githubusercontent.com/17258145/143485473-06319270-4818-4209-9526-56e570edcf94.mov