### PR TITLE
Add "radio" form widget

### DIFF
--- a/frontend/src/metabase/components/Radio.jsx
+++ b/frontend/src/metabase/components/Radio.jsx
@@ -14,7 +14,7 @@ import {
   UnderlinedItem,
 } from "./Radio.styled";
 
-const optionShape = PropTypes.shape({
+export const optionShape = PropTypes.shape({
   name: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.element,

--- a/frontend/src/metabase/components/form/FormWidget.jsx
+++ b/frontend/src/metabase/components/form/FormWidget.jsx
@@ -8,6 +8,7 @@ import FormInputWidget from "./widgets/FormInputWidget";
 import FormEmailWidget from "./widgets/FormEmailWidget";
 import FormTextAreaWidget from "./widgets/FormTextAreaWidget";
 import FormPasswordWidget from "./widgets/FormPasswordWidget";
+import FormRadioWidget from "./widgets/FormRadioWidget";
 import FormCheckBoxWidget from "./widgets/FormCheckBoxWidget";
 import FormColorWidget from "./widgets/FormColorWidget";
 import FormSelectWidget from "./widgets/FormSelectWidget";
@@ -26,6 +27,7 @@ const WIDGETS = {
   checkbox: FormCheckBoxWidget,
   color: FormColorWidget,
   password: FormPasswordWidget,
+  radio: FormRadioWidget,
   select: FormSelectWidget,
   integer: FormNumericInputWidget,
   boolean: FormToggleWidget,

--- a/frontend/src/metabase/components/form/widgets/FormRadioWidget.jsx
+++ b/frontend/src/metabase/components/form/widgets/FormRadioWidget.jsx
@@ -1,0 +1,21 @@
+import React from "react";
+import PropTypes from "prop-types";
+import styled from "styled-components";
+import Radio, { optionShape } from "metabase/components/Radio";
+
+const StyledRadio = styled(Radio)`
+  font-weight: bold;
+`;
+
+const propTypes = {
+  field: PropTypes.object.isRequired,
+  options: PropTypes.arrayOf(optionShape).isRequired,
+};
+
+function FormRadioWidget({ field, options }) {
+  return <StyledRadio showButtons vertical {...field} options={options} />;
+}
+
+FormRadioWidget.propTypes = propTypes;
+
+export default FormRadioWidget;


### PR DESCRIPTION
This PR adds a "radio" form widget (needed for the upcoming dataset metadata editor)

### To Verify

At the moment, there are no forms using the `"radio"` widget. If you want to test it locally, you'll need to add a field using the widget. Example

1. Open `/entities/databases/forms`
2. Replace `type: "select"` for "engine" field with `type: "radio"`
3. Open `/admin/databases/create`
4. You should see radio buttons instead of a dropdown select

### Demo

![CleanShot 2021-11-25 at 18 59 31](https://user-images.githubusercontent.com/17258145/143480080-f67c9376-1300-4dd0-b626-813e59e874e0.gif)
