### PR TITLE
show trend previous value in full-screen mode

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx
@@ -82,7 +82,6 @@ export default class Smart extends React.Component {
       onChangeCardAndRun,
       onVisualizationClick,
       isDashboard,
-      isFullscreen,
       settings,
       visualizationIsClickable,
       series: [

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx
@@ -215,11 +215,10 @@ export default class Smart extends React.Component {
                   color: color("text-medium"),
                 }}
               >
-                {!isFullscreen &&
-                  jt`${separator} was ${formatValue(
-                    previousValue,
-                    settings.column(column),
-                  )} ${granularityDisplay}`}
+                {jt`${separator} was ${formatValue(
+                  previousValue,
+                  settings.column(column),
+                )} ${granularityDisplay}`}
               </h4>
             </Flex>
           )}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/10786

Not sure why, but in the full-screen mode Trend visualization did not show the previous value. 

### How to verify
- Create a trend visualization
- Add it on a dashboard
- Ensure that it shows the previous value in the full-screen mode

Before:
<img width="319" alt="Screen Shot 2021-11-26 at 21 26 20" src="https://user-images.githubusercontent.com/14301985/143615032-f4c61330-10d8-447b-bb55-5e5aa890f9e1.png">

After:
<img width="362" alt="Screen Shot 2021-11-26 at 21 20 52" src="https://user-images.githubusercontent.com/14301985/143614851-1a8ee407-0c21-4957-a3bc-a313211e60ab.png">

