### PR TITLE
Add an unintentional removed ESLint rule back

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -29,6 +29,7 @@
       "warn",
       { "additionalHooks": "useSyncedQueryString" }
     ],
+    "no-color-literals": 1,
     "prefer-const": [1, { "destructuring": "all" }],
     "no-useless-escape": 0,
     "no-only-tests/no-only-tests": "error",


### PR DESCRIPTION
This fixes #19111 where the ESLint rule was removed via #12951.

FYI, it catches a lot of errors, which I don't want to fix yet.