### PR TITLE
Fix pivot tables with missing pivot columns

### DIFF
--- a/frontend/test/metabase/scenarios/visualizations/reproductions/18976-pivot-table-columns.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/reproductions/18976-pivot-table-columns.cy.spec.js
@@ -1,0 +1,34 @@
+import { restore, visitQuestionAdhoc } from "__support__/e2e/cypress";
+
+const questionDetails = {
+  display: "table",
+  dataset_query: {
+    database: 1,
+    type: "native",
+    native: {
+      query: "select 'a', 'b', 1",
+      "template-tags": {},
+    },
+  },
+  visualization_settings: {
+    "table.pivot": true,
+    "table.pivot_column": "'a'",
+    "table.cell_column": "1",
+  },
+};
+
+describe("issue 18976", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+    cy.intercept("POST", "/api/dataset").as("dataset");
+  });
+
+  it("should display a pivot table as regular one when pivot columns are missing (metabase#18976)", () => {
+    visitQuestionAdhoc(questionDetails);
+
+    cy.wait("@dataset");
+
+    cy.findByText("Showing 1 row");
+  });
+});

--- a/frontend/test/metabase/scenarios/visualizations/reproductions/18976-pivot-table-columns.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/reproductions/18976-pivot-table-columns.cy.spec.js
@@ -6,7 +6,7 @@ const questionDetails = {
     database: 1,
     type: "native",
     native: {
-      query: "select 'a', 'b', 1",
+      query: "select 'a', 'b'",
       "template-tags": {},
     },
   },


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/18976

How to test:
- Create a native question with `select 'a', 'b', 1` query
- Go to question settings -> enable `Pivot the table`
- Run the query to display the results
- Change the query to `select 'a', 'b'`
- Run the query to display the results
- It should display the regular table