### PR TITLE
Disable Notebook animation

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/View/QueryViewNotebook/QueryViewNotebook.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View/QueryViewNotebook/QueryViewNotebook.jsx
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 import Notebook from "metabase/query_builder/components/notebook/Notebook";
 import { NotebookContainer } from "./QueryViewNotebook.styled";
 
-const delayBeforeNotRenderingNotebook = 300;
+const delayBeforeNotRenderingNotebook = 10;
 
 const QueryViewNotebook = ({ isNotebookContainerOpen, ...props }) => {
   const [shouldShowNotebook, setShouldShowNotebook] = useState(


### PR DESCRIPTION
This is just a follow-up to PR #19048. Since we don't know yet the root cause of the underlying performance issue, we want to disable the sliding animation for the time being.

1. Ask a question, Custom question
2. Sample Dataset, Orders table
3. Join data, Orders >< Orders, ID >< ID
4. Repeat Step 3 a few times
5. Summarize, Count by Created At: Month
6. Visualize
7. Click Show Editor button (top right)

![image](https://user-images.githubusercontent.com/7288/143969995-1797bc87-a3fc-479a-b0da-7f7868c43b92.png)


**Before this PR**

The notebook slides down with some jittering. This is more noticeable on a constrained system (old hardware, virtual machine with just 1 vCPU, DevTools with CPU throttle, etc).


**After this PR**

There is no animation, the notebook appears right away.
Note that there is still a perceptible delay (because this PR doesn't fix the real issue).