### PR TITLE
Tweak Block permissions to check for presence of the :advanced-permissions feature flag

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions/block_permissions.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions/block_permissions.clj
@@ -1,4 +1,4 @@
-(ns metabase-enterprise.enhancements.models.permissions.block-permissions
+(ns metabase-enterprise.advanced-permissions.models.permissions.block-permissions
   (:require [metabase.api.common :as api]
             [metabase.models.permissions :as perms]
             [metabase.public-settings.premium-features :as settings.premium-features]
@@ -21,8 +21,8 @@
   exists."
   [{database-id :database, :as query}]
   (cond
-    (not (settings.premium-features/enable-enhancements?))
-    ::enhancements-not-enabled
+    (not (settings.premium-features/enable-advanced-permissions?))
+    ::advanced-permissions-not-enabled
 
     (not (current-user-has-block-permissions-for-database? database-id))
     ::no-block-permissions-for-db

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/block_permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/block_permissions_test.clj
@@ -1,6 +1,6 @@
-(ns metabase-enterprise.enhancements.models.permissions.block-permissions-test
+(ns metabase-enterprise.advanced-permissions.models.permissions.block-permissions-test
   (:require [clojure.test :refer :all]
-            [metabase-enterprise.enhancements.models.permissions.block-permissions :as block-perms]
+            [metabase-enterprise.advanced-permissions.models.permissions.block-permissions :as block-perms]
             [metabase-enterprise.sandbox.models.group-table-access-policy :refer [GroupTableAccessPolicy]]
             [metabase.api.common :as api]
             [metabase.models :refer [Card Collection Database Permissions PermissionsGroup PermissionsGroupMembership User]]
@@ -183,7 +183,7 @@
                       Card                       [{card-id :id} {:collection_id collection-id
                                                                  :dataset_query query}]
                       Permissions                [_ {:group_id group-id, :object (perms/collection-read-path collection-id)}]]
-        (premium-features-test/with-premium-features #{:enhancements}
+        (premium-features-test/with-premium-features #{:advanced-permissions}
           (perms/revoke-data-perms! (group/all-users) (mt/id))
           (perms/revoke-data-perms! group-id (mt/id))
           (letfn [(run-ad-hoc-query []
@@ -208,9 +208,9 @@
                      (check-block-perms))))
             ;; 'grant' the block permissions.
             (mt/with-temp Permissions [_ {:group_id group-id, :object (perms/database-block-perms-path (mt/id))}]
-              (testing "if EE token does not have the `:enhancements` feature: should not do check"
+              (testing "if EE token does not have the `:advanced-permissions` feature: should not do check"
                 (premium-features-test/with-premium-features #{}
-                  (is (= ::block-perms/enhancements-not-enabled
+                  (is (= ::block-perms/advanced-permissions-not-enabled
                          (check-block-perms)))))
               (testing "disallow running the query"
                 (is (thrown-with-msg?
@@ -233,7 +233,7 @@
                           (testing message
                             (is (f)))))))
                   (testing "\nSandboxed permissions"
-                    (premium-features-test/with-premium-features #{:enhancements :sandboxing}
+                    (premium-features-test/with-premium-features #{:advanced-permissions :sandboxing}
                       (mt/with-temp* [Permissions            [_ {:group_id group-2-id
                                                                  :object   (perms/table-segmented-query-path (mt/id :venues))}]
                                       GroupTableAccessPolicy [_ {:table_id (mt/id :venues), :group_id group-id}]]

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -862,6 +862,8 @@
                      (db/select-one [Collection :id :namespace] :id (collection-or-id))
                      collection-or-id)]
     ;; HACK Collections in the "snippets" namespace have no-op permissions unless EE enhancements are enabled
+    ;;
+    ;; TODO -- Pretty sure snippet perms should be feature flagged by `advanced-permissions` instead
     (if (and (= (u/qualified-name (:namespace collection)) "snippets")
              (not (settings.premium-features/enable-enhancements?)))
       #{}

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -125,7 +125,7 @@
 
   The Query Processor middleware in [[metabase.query-processor.middleware.permissions]],
   [[metabase-enterprise.sandbox.query-processor.middleware.row-level-restrictions]], and
-  [[metabase-enterprise.enhancements.models.permissions.block-permissions]] determines whether the current
+  [[metabase-enterprise.advanced-permissions.models.permissions.block-permissions]] determines whether the current
   User has permissions to run the current query. Permissions are as follows:
 
   | Data perms? | Coll perms? | Block? | Segmented? | Can run? |
@@ -397,6 +397,7 @@
   ([database-or-id schema-name table-or-id]
    (str (data-perms-path (u/the-id database-or-id) schema-name (u/the-id table-or-id)) "query/")))
 
+;; TODO -- consider renaming this to `table-sandboxed-query-path`  since that terminology is used more frequently
 (s/defn table-segmented-query-path :- Path
   "Return the permissions path for *segmented* query access for a Table. Segmented access means running queries against
   the Table will automatically replace the Table with a GTAP-specified question as the new source of the query,

--- a/src/metabase/query_processor/middleware/permissions.clj
+++ b/src/metabase/query_processor/middleware/permissions.clj
@@ -41,12 +41,12 @@
   for [[metabase.models.collection]] for more details.
 
   Note that this feature is Metabase© Enterprise Edition™ only. Actual implementation is
-  in [[metabase-enterprise.enhancements.models.permissions.block-permissions/check-block-permissions]] if EE code is
+  in [[metabase-enterprise.advanced-permissions.models.permissions.block-permissions/check-block-permissions]] if EE code is
   present. This feature is only enabled if we have a valid Enterprise Edition™ token."
   (let [dlay (delay
                (u/ignore-exceptions
-                 (classloader/require 'metabase-enterprise.enhancements.models.permissions.block-permissions)
-                 (resolve 'metabase-enterprise.enhancements.models.permissions.block-permissions/check-block-permissions)))]
+                 (classloader/require 'metabase-enterprise.advanced-permissions.models.permissions.block-permissions)
+                 (resolve 'metabase-enterprise.advanced-permissions.models.permissions.block-permissions/check-block-permissions)))]
     (fn [query]
       (when-let [f @dlay]
         (f query)))))


### PR DESCRIPTION
We added the new `:advanced-permissions` EE token feature pretty late in the development cycle after the block permissions stuff had already been merged. Originally block permissions were set up to just check for _any_ EE token. Once `:advanced-permissions` was added as a feature, the original intention was that block permissions should feature flag on that key, but it looks like for one reason or another I forgot to update that code to check the new feature.

Practically, this does not have any effect at the time being because all of our tokens have the `:advanced-permissions` feature. But in the future this might not hold true.

This PR also renames the block permissions code namespaces to match the feature they're flagged on, in line with other EE namespaces