### PR TITLE
Remove unused parseOperators()

### DIFF
--- a/frontend/src/metabase/lib/expressions/compile.js
+++ b/frontend/src/metabase/lib/expressions/compile.js
@@ -5,7 +5,6 @@ import {
   parseSegment,
   parseStringLiteral,
   parseIdentifierString,
-  OPERATOR_PRECEDENCE,
 } from "../expressions";
 
 import { MBQL_CLAUSES } from "./config";
@@ -209,43 +208,4 @@ export function compile({ cst, ...options }) {
     startRule,
     options.resolve ? options.resolve : resolveMBQLField,
   );
-}
-
-export function parseOperators(operands, operators) {
-  let initial = operands[0];
-  const stack = [];
-  for (let i = 1; i < operands.length; i++) {
-    const operator = operators[i - 1];
-    const operand = operands[i];
-    const top = stack[stack.length - 1];
-    if (top) {
-      if (top[0] === operator) {
-        top.push(operand);
-      } else {
-        const a = OPERATOR_PRECEDENCE[operator];
-        const b = OPERATOR_PRECEDENCE[top[0]];
-        if (b < a) {
-          top[top.length - 1] = [operator, top[top.length - 1], operand];
-          stack.push(top[top.length - 1]);
-        } else {
-          do {
-            stack.pop();
-          } while (
-            stack.length > 0 &&
-            OPERATOR_PRECEDENCE[stack[stack.length - 1][0]] > a
-          );
-          if (stack.length > 0) {
-            stack[stack.length - 1].push(operand);
-          } else {
-            initial = [operator, initial, operand];
-            stack.push(initial);
-          }
-        }
-      }
-    } else {
-      initial = [operator, initial, operand];
-      stack.push(initial);
-    }
-  }
-  return initial;
 }

--- a/frontend/test/metabase/lib/expressions/compile.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/compile.unit.spec.js
@@ -18,46 +18,10 @@ function expectFast(fn, milliseconds = 1000) {
 }
 
 describe("metabase/lib/expressions/compile", () => {
-  let compile, parseOperators;
+  let compile;
   it("should load compile quickly", () => {
     expectFast(() => {
-      ({
-        compile,
-        parseOperators,
-      } = require("metabase/lib/expressions/compile"));
-    });
-  });
-
-  describe("parseOperators", () => {
-    it("should compile 1", () => {
-      expect(parseOperators([1], [])).toEqual(1);
-    });
-    it("should compile 1 + 2", () => {
-      expect(parseOperators([1, 2], ["+"])).toEqual(["+", 1, 2]);
-    });
-    it("should compile 1 + 2 - 3", () => {
-      expect(parseOperators([1, 2, 3], ["+", "-"])).toEqual([
-        "-",
-        ["+", 1, 2],
-        3,
-      ]);
-    });
-    it("should compile 1 + 2 - 3 + 4", () => {
-      expect(parseOperators([1, 2, 3, 4], ["+", "-", "+"])).toEqual([
-        "+",
-        ["-", ["+", 1, 2], 3],
-        4,
-      ]);
-    });
-    it("should compile 1 + 2 * 3 * 4 + 5 + 6", () => {
-      expect(
-        parseOperators([1, 2, 3, 4, 5, 6], ["+", "*", "*", "+", "+"]),
-      ).toEqual(["+", 1, ["*", 2, 3, 4], 5, 6]);
-    });
-    it("should compile 1 * 2 + 3 + 4 * 5 * 6", () => {
-      expect(
-        parseOperators([1, 2, 3, 4, 5, 6], ["*", "+", "+", "*", "*"]),
-      ).toEqual(["+", ["*", 1, 2], 3, ["*", 4, 5, 6]]);
+      ({ compile } = require("metabase/lib/expressions/compile"));
     });
   });
 


### PR DESCRIPTION
This function was not needed anymore after custom expression was introduced.