### PR TITLE
Fix drill-through popover look for native models

### DIFF
--- a/frontend/src/metabase/modes/components/drill/DistributionDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/DistributionDrill.jsx
@@ -15,7 +15,6 @@ export default ({ question, clicked }) => {
     !clicked ||
     !clicked.column ||
     clicked.value !== undefined ||
-    clicked.column.source !== "fields" ||
     _.any(DENYLIST_TYPES, t => isa(clicked.column.semantic_type, t))
   ) {
     return [];

--- a/frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js
+++ b/frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js
@@ -27,7 +27,7 @@ const AGGREGATIONS = {
 
 export default ({ question, clicked = {} }) => {
   const { column, value } = clicked;
-  if (!column || column.source !== "fields" || value !== undefined) {
+  if (!column || value !== undefined) {
     // TODO Atte Keinänen 7/21/17: Does it slow down the drill-through option calculations remarkably
     // that I removed the `isSummable` condition from here and use `isCompatibleAggregator` method below instead?
     return [];

--- a/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
@@ -156,11 +156,8 @@ export default class ChartClickActions extends Component {
       });
       delete groupedClickActions["sum"];
     }
-    if (
-      clicked.column &&
-      clicked.column.source === "native" &&
-      groupedClickActions["sort"]
-    ) {
+    const hasOnlyOneSortAction = groupedClickActions["sort"]?.length === 1;
+    if (clicked.column?.source === "native" && hasOnlyOneSortAction) {
       // restyle the Formatting action for SQL columns
       groupedClickActions["sort"][0] = {
         ...groupedClickActions["sort"][0],


### PR DESCRIPTION
### To Verify

1. Open a native dataset
2. Click any column header in the results table
3. Ensure the "sort" action buttons don't look weird
4. Open a saved native question (not a dataset)
5. Click any column header in the results table
6. Ensure you can see a single "Column formatting" action, not only a gear icon as in (#14027)

### Demo

**Before**
<img width="208" alt="CleanShot 2021-11-30 at 18 12 22@2x" src="https://user-images.githubusercontent.com/17258145/144087463-8e1ff6f5-863a-40c2-ab29-f3ba9e1b5a99.png">

**After** 
<img width="442" alt="CleanShot 2021-11-30 at 18 21 44@2x" src="https://user-images.githubusercontent.com/17258145/144087479-fb6c1feb-b825-48ea-8c2c-6353ebab3877.png">
 
