### PR TITLE
React Ace: Update e2e tests for "allow strings in filter"

### DIFF
--- a/frontend/test/metabase/scenarios/custom-column/reproductions/13751-cc-allow-strings-in-filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/reproductions/13751-cc-allow-strings-in-filter.cy.spec.js
@@ -1,4 +1,9 @@
-import { restore, popover, visualize } from "__support__/e2e/cypress";
+import {
+  enterCustomColumnDetails,
+  popover,
+  visualize,
+  restore,
+} from "__support__/e2e/cypress";
 
 const CC_NAME = "C-States";
 const PG_DB_NAME = "QA Postgres12";
@@ -19,9 +24,9 @@ describe("issue 13751", () => {
 
     cy.icon("add_data").click();
     popover().within(() => {
-      cy.get("[contenteditable='true']").type(
-        'regexextract([State], "^C[A-Z]")',
-      );
+      enterCustomColumnDetails({
+        formula: 'regexextract([State], "^C[A-Z]")',
+      });
       cy.findByPlaceholderText("Something nice and descriptive").type(CC_NAME);
       cy.get(".Button")
         .contains("Done")


### PR DESCRIPTION
Updates selectors for allow-strings-in-filter e2e tests.

For a manual check, run e2e tests on file:

frontend/test/metabase/scenarios/custom-column/reproductions/13751-cc-allow-strings-in-filter.cy.spec.js

In CI below, click for `details` besides:
ci/circleci: e2e-tests-custom-column-ee 
ci/circleci: e2e-tests-custom-column-os

Click on `Artifacts`.

Tests related to `13751-cc-allow-strings-in-filter.cy.spec.js` should have passed.