### PR TITLE
React Ace: update test Postgres percentile accepts two params

### DIFF
--- a/frontend/test/metabase/scenarios/custom-column/reproductions/15714-cc-postgres-percentile-accepts-two-params.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/reproductions/15714-cc-postgres-percentile-accepts-two-params.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore } from "__support__/e2e/cypress";
+import { restore, enterCustomColumnDetails } from "__support__/e2e/cypress";
 
 const PG_DB_NAME = "QA Postgres12";
 
@@ -15,9 +15,9 @@ describe("postgres > question > custom columns", () => {
 
   it("`Percentile` custom expression function should accept two parameters (metabase#15714)", () => {
     cy.icon("add_data").click();
-    cy.get("[contenteditable='true']")
-      .click()
-      .type("Percentile([Subtotal], 0.1)");
+    enterCustomColumnDetails({
+      formula: "Percentile([Subtotal], 0.1)",
+    });
     cy.findByPlaceholderText("Something nice and descriptive")
       .as("description")
       .click();


### PR DESCRIPTION
For a manual check, run e2e tests on file:

frontend/test/metabase/scenarios/custom-column/reproductions/15714-cc-postgres-percentile-accepts-two-params.cy.spec.js

In CI below, click for `details` besides:
ci/circleci: e2e-tests-custom-column-ee 
ci/circleci: e2e-tests-custom-column-os

Click on `Artifacts`.

Tests related to `15714-cc-postgres-percentile-accepts-two-params.cy.spec.js` should have passed.