### PR TITLE
add renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base",
+    ":preserveSemverRanges"
+  ],
+  "schedule": ["every month on the first day of the month"],
+  "prHourlyLimit": 10,
+  "prConcurrentLimit": 20,
+  "postUpdateOptions": ["yarnDedupeFewer"],
+  "labels": ["dependencies", "bot"],
+  "enabledManagers": ["npm"],
+  "packageRules": [{
+      "matchPackagePatterns": [
+        "*"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "groupName": "all non-major dependencies",
+      "groupSlug": "all-minor-patch"
+    },
+    {
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "enabled": false
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds [Renovate](https://github.com/marketplace/renovate) config, which is a tool that helps to keep our dependencies up to date. Compared to [dependabot](https://github.com/dependabot), it is way more flexible and allows group changes together.

Since we have a lot of major outdated dependencies upgrading, which will require a significant amount of work, I enabled the bot only for minor and patch dependencies. It is scheduled to create PRs `every month on the first day of the month`.

Please share what do you think about this approach.

### How to verify
- Fork Metabase and merge this config into `master`
- Install [Renovate](https://github.com/marketplace/renovate) and give it access to the Metabase repo

It will create a PR: [Update all non-major dependencies](https://github.com/alxnddr/metabase/pull/57)
Also, it provides an issue with a [Dependency Dashboard](https://github.com/alxnddr/metabase/issues/39) where you can trigger the bot to run again.