### PR TITLE
Add `cloud-ip-address-info` to DB connection config

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/resources/metabase-plugin.yaml
+++ b/modules/drivers/bigquery-cloud-sdk/resources/metabase-plugin.yaml
@@ -21,6 +21,7 @@ driver:
       display-name: Dataset ID
       required: true
       placeholder: toucanSightings
+    - cloud-ip-address-info
     - name: use-jvm-timezone
       display-name: Use JVM Time Zone
       default: false

--- a/modules/drivers/druid/resources/metabase-plugin.yaml
+++ b/modules/drivers/druid/resources/metabase-plugin.yaml
@@ -14,6 +14,7 @@ driver:
         - port
         - display-name: Broker node port
           default: 8082
+    - cloud-ip-address-info
   connection-properties-include-tunnel-config: true
 init:
   - step: load-namespace

--- a/modules/drivers/mongo/resources/metabase-plugin.yaml
+++ b/modules/drivers/mongo/resources/metabase-plugin.yaml
@@ -30,6 +30,7 @@ driver:
         - additional-options
         - display-name: Additional Mongo connection string options
           placeholder: 'retryWrites=true&w=majority&authSource=admin&readPreference=nearest&replicaSet=test'
+    - cloud-ip-address-info
     - name: use-srv
       type: boolean
       default: false

--- a/modules/drivers/oracle/resources-ee/metabase-plugin.yaml
+++ b/modules/drivers/oracle/resources-ee/metabase-plugin.yaml
@@ -20,6 +20,7 @@ driver:
       placeholder: Optional TNS alias
     - user
     - password
+    - cloud-ip-address-info
     - ssl
     - name: ssl-use-keystore
       display-name: Use SSL server certificate?

--- a/modules/drivers/oracle/resources/metabase-plugin.yaml
+++ b/modules/drivers/oracle/resources/metabase-plugin.yaml
@@ -26,6 +26,7 @@ driver:
       placeholder: Optional TNS alias
     - user
     - password
+    - cloud-ip-address-info
     - ssl
     - name: ssl-use-keystore
       display-name: Use SSL server certificate?

--- a/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
+++ b/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
@@ -93,6 +93,7 @@
                     {:name "service-name"}
                     {:name "user"}
                     {:name "password"}
+                    {:name "cloud-ip-address-info"}
                     {:name "ssl"}
                     {:name "ssl-use-keystore"}
                     {:name       "ssl-keystore-options"

--- a/modules/drivers/presto-jdbc/resources/metabase-plugin.yaml
+++ b/modules/drivers/presto-jdbc/resources/metabase-plugin.yaml
@@ -29,6 +29,7 @@ driver:
     - merge:
         - password
         - required: false
+    - cloud-ip-address-info
     - ssl
     - name: kerberos
       type: boolean

--- a/modules/drivers/presto/resources/metabase-plugin.yaml
+++ b/modules/drivers/presto/resources/metabase-plugin.yaml
@@ -20,6 +20,7 @@ driver:
           placeholder: hive
     - user
     - password
+    - cloud-ip-address-info
     - ssl
   connection-properties-include-tunnel-config: true
 init:

--- a/modules/drivers/redshift/resources/metabase-plugin.yaml
+++ b/modules/drivers/redshift/resources/metabase-plugin.yaml
@@ -20,6 +20,7 @@ driver:
           placeholder: toucan_sightings
     - user
     - password
+    - cloud-ip-address-info
     - merge:
       - additional-options
       - placeholder: 'SocketTimeout=0'

--- a/modules/drivers/snowflake/resources/metabase-plugin.yaml
+++ b/modules/drivers/snowflake/resources/metabase-plugin.yaml
@@ -31,6 +31,7 @@ driver:
     - name: role
       display-name: Role
       placeholder: my_role
+    - cloud-ip-address-info
     - additional-options
   connection-properties-include-tunnel-config: true
 init:

--- a/modules/drivers/sparksql/resources/metabase-plugin.yaml
+++ b/modules/drivers/sparksql/resources/metabase-plugin.yaml
@@ -21,6 +21,7 @@ driver:
           - placeholder: default
       - user
       - password
+      - cloud-ip-address-info
       - merge:
           - additional-options
           - name: jdbc-flags

--- a/modules/drivers/sqlite/resources/metabase-plugin.yaml
+++ b/modules/drivers/sqlite/resources/metabase-plugin.yaml
@@ -12,6 +12,7 @@ driver:
       display-name: Filename
       placeholder: /home/camsaul/toucan_sightings.sqlite
       required: true
+    - cloud-ip-address-info
 init:
   - step: load-namespace
     namespace: metabase.driver.sqlite

--- a/modules/drivers/sqlserver/resources/metabase-plugin.yaml
+++ b/modules/drivers/sqlserver/resources/metabase-plugin.yaml
@@ -21,6 +21,7 @@ driver:
       placeholder: N/A
     - user
     - password
+    - cloud-ip-address-info
     - ssl
     - merge:
         - additional-options

--- a/modules/drivers/vertica/resources-ee/metabase-plugin.yaml
+++ b/modules/drivers/vertica/resources-ee/metabase-plugin.yaml
@@ -15,6 +15,7 @@ driver:
     - dbname
     - user
     - password
+    - cloud-ip-address-info
     - merge:
         - additional-options
         - placeholder: 'ConnectionLoadBalance=1'

--- a/modules/drivers/vertica/resources/metabase-plugin.yaml
+++ b/modules/drivers/vertica/resources/metabase-plugin.yaml
@@ -21,6 +21,7 @@ driver:
     - dbname
     - user
     - password
+    - cloud-ip-address-info
     - merge:
         - additional-options
         - placeholder: 'ConnectionLoadBalance=1'

--- a/src/metabase/driver/common.clj
+++ b/src/metabase/driver/common.clj
@@ -3,6 +3,7 @@
   (:require [clj-time.coerce :as tcoerce]
             [clj-time.core :as time]
             [clj-time.format :as tformat]
+            [clojure.string :as str]
             [clojure.tools.logging :as log]
             [metabase.driver :as driver]
             [metabase.driver.util :as driver.u]
@@ -136,7 +137,7 @@
              (when-let [ips (public-settings/cloud-gateway-ips)]
                (str (deferred-tru "If your database is behind a firewall, you may need to allow connections from our Metabase Cloud IP addresses:")
                     "\n"
-                    (clojure.string/join " - " (public-settings/cloud-gateway-ips)))))})
+                    (str/join " - " (public-settings/cloud-gateway-ips)))))})
 
 (def default-connection-info-fields
   "Default definitions for informational banners that can be included in a database connection form. These keys can be

--- a/src/metabase/driver/common.clj
+++ b/src/metabase/driver/common.clj
@@ -128,6 +128,8 @@
    :user               default-user-details})
 
 (def cloud-ip-address-info
+  "Map of the `cloud-ip-address-info` info field. The getter is invoked and converted to a `:placeholder` value prior
+  to being returned to the client, in [[metabase.driver.util/connection-props-server->client]]."
   {:name   "cloud-ip-address-info"
    :type   :info
    :getter (fn []
@@ -137,8 +139,8 @@
                     (clojure.string/join " - " (public-settings/cloud-gateway-ips)))))})
 
 (def default-connection-info-fields
-  "Defaults options for informational text that can be included in a database connection form. These keys can be added
-  to the plugin manifest as connection properties, similar to the keys in the `default-options` map."
+  "Default definitions for informational banners that can be included in a database connection form. These keys can be
+  added to the plugin manifest as connection properties, similar to the keys in the `default-options` map."
   {:cloud-ip-address-info cloud-ip-address-info})
 
 

--- a/src/metabase/driver/common.clj
+++ b/src/metabase/driver/common.clj
@@ -7,6 +7,7 @@
             [metabase.driver :as driver]
             [metabase.driver.util :as driver.u]
             [metabase.models.setting :as setting]
+            [metabase.public-settings :as public-settings]
             [metabase.query-processor.context.default :as context.default]
             [metabase.query-processor.store :as qp.store]
             [metabase.util :as u]
@@ -125,6 +126,20 @@
    :port               default-port-details
    :ssl                default-ssl-details
    :user               default-user-details})
+
+(def cloud-ip-address-info
+  {:name   "cloud-ip-address-info"
+   :type   :info
+   :getter (fn []
+             (when-let [ips (public-settings/cloud-gateway-ips)]
+               (str (deferred-tru "If your database is behind a firewall, you may need to allow connections from our Metabase Cloud IP addresses:")
+                    "\n"
+                    (clojure.string/join " - " (public-settings/cloud-gateway-ips)))))})
+
+(def default-connection-info-fields
+  "Defaults options for informational text that can be included in a database connection form. These keys can be added
+  to the plugin manifest as connection properties, similar to the keys in the `default-options` map."
+  {:cloud-ip-address-info cloud-ip-address-info})
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -37,7 +37,8 @@
   [{:name         "db"
     :display-name (tru "Connection String")
     :placeholder  (str "file:/" (deferred-tru "Users/camsaul/bird_sightings/toucans"))
-    :required     true}])
+    :required     true}
+   driver.common/cloud-ip-address-info])
 
 (defmethod driver/db-start-of-week :h2
   [_]

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -80,8 +80,7 @@
   {:name         "ssl-cert"
    :display-name (deferred-tru "Server SSL certificate chain")
    :placeholder  ""
-   :visible-if   {"ssl" true}}
-)
+   :visible-if   {"ssl" true}})
 
 (defmethod driver/connection-properties :mysql
   [_]
@@ -91,6 +90,7 @@
      driver.common/default-dbname-details
      driver.common/default-user-details
      driver.common/default-password-details
+     driver.common/cloud-ip-address-info
      driver.common/default-ssl-details
      default-ssl-cert-details
      (assoc driver.common/default-additional-options-details

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -85,6 +85,7 @@
      driver.common/default-dbname-details
      driver.common/default-user-details
      driver.common/default-password-details
+     driver.common/cloud-ip-address-info
      driver.common/default-ssl-details
      (assoc driver.common/default-additional-options-details
             :placeholder "prepareThreshold=0")]))

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -136,8 +136,7 @@
   placeholder value. Returns nil if no placeholder value or getter is provided, or if the getter returns a non-string
   value or throws an exception."
   [{prop-name :name, getter :getter, placeholder :placeholder, :as conn-prop}]
-  (let [getter  (:getter conn-prop)
-        content (or (:placeholder conn-prop)
+  (let [content (or placeholder
                     (try (getter)
                          (catch Throwable e
                            (log/error e (trs "Error invoking getter for connection property {0}"

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -1,7 +1,6 @@
 (ns metabase.driver.util
   "Utility functions for common operations on drivers."
   (:require [clojure.core.memoize :as memoize]
-            [clojure.string :as str]
             [clojure.tools.logging :as log]
             [metabase.config :as config]
             [metabase.driver :as driver]
@@ -132,10 +131,11 @@
                    :visible-if {(keyword (str prop-name "-options")) "local"}}])
     [conn-prop]))
 
-(defn- resolve-info-conn-prop [{prop-name :name, getter :getter, placeholder :placeholder, :as conn-prop}]
+(defn- resolve-info-conn-prop
   "Invokes the getter function on a info type connection property and adds it to the connection property map as its
   placeholder value. Returns nil if no placeholder value or getter is provided, or if the getter returns a non-string
   value or throws an exception."
+  [{prop-name :name, getter :getter, placeholder :placeholder, :as conn-prop}]
   (let [getter  (:getter conn-prop)
         content (or (:placeholder conn-prop)
                     (try (getter)
@@ -157,7 +157,6 @@
   This also resolves the :getter function on :type :info properties, if one was provided."
   {:added "0.42.0"}
   [conn-props]
-  (def my-conn-props conn-props)
   (reduce (fn [acc conn-prop]
             (case (keyword (:type conn-prop))
               :secret

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -132,26 +132,41 @@
                    :visible-if {(keyword (str prop-name "-options")) "local"}}])
     [conn-prop]))
 
+(defn- resolve-info-conn-prop [{prop-name :name, getter :getter, placeholder :placeholder, :as conn-prop}]
+  "Invokes the getter function on a info type connection property and adds it to the connection property map as its
+  placeholder value. Returns nil if no placeholder value or getter is provided, or if the getter returns a non-string
+  value or throws an exception."
+  (let [getter  (:getter conn-prop)
+        content (or (:placeholder conn-prop)
+                    (try (getter)
+                         (catch Throwable e
+                           (log/error e (trs "Error invoking getter for connection property {0}"
+                                             (:name conn-prop))))))]
+    (when (string? content)
+      (-> conn-prop
+          (assoc :placeholder content)
+          (dissoc :getter)))))
+
 (defn connection-props-server->client
   "Transforms connection-properties from their server side definition into a client side definition.
 
-  Currently, this just transforms :type :secret properties from the server side definition into other types for client
+  This transforms :type :secret properties from the server side definition into other types for client
   display/editing. For example, a :secret-kind :keystore turns into a bunch of different properties, to encapsulate
-  all the different options that might be available on the client side for populating the value."
+  all the different options that might be available on the client side for populating the value.
+
+  This also resolves the :getter function on :type :info properties, if one was provided."
   {:added "0.42.0"}
   [conn-props]
+  (def my-conn-props conn-props)
   (reduce (fn [acc conn-prop]
             (case (keyword (:type conn-prop))
               :secret
               (concat acc (expand-secret-conn-prop conn-prop))
 
               :info
-              (let [getter  (:getter conn-prop)
-                    content (or (:placeholder conn-prop)
-                                (getter))]
-                (if-not (str/blank? content)
-                  (concat acc [(assoc conn-prop :placeholder content)])
-                  acc))
+              (if-let [conn-prop' (resolve-info-conn-prop conn-prop)]
+                (concat acc [conn-prop'])
+                acc)
 
               (concat acc [conn-prop])))
           []

--- a/src/metabase/plugins/lazy_loaded_driver.clj
+++ b/src/metabase/plugins/lazy_loaded_driver.clj
@@ -19,6 +19,7 @@
   (cond
     (string? prop)
     (or (driver.common/default-options (keyword prop))
+        (driver.common/default-connection-info-fields (keyword prop))
         (throw (Exception. (trs "Default connection property {0} does not exist." prop))))
 
     (not (map? prop))


### PR DESCRIPTION
Adds support for `info` field types in driver `connection-properties`, with optional `getter` functions to compute the value dynamically if needed. Uses this mechanism for the cloud IP address information, and adds this field to most driver configs (excluding GA) in the appropriate spot according to the [product spec](https://www.notion.so/metabase/Simplify-additional-options-in-set-up-flow-db-configuration-574685f825a34f5595011d0680451ea4).

Epic #19046

Frontend changes needed:
- [ ] Info banner component should respect newline characters (`white-space: pre-line`?)
- [ ] Info fields shouldn't be sent to the backend on a DB connection request
- [ ] Remove excess bottom margin on password field