### PR TITLE
Sort static viz data

### DIFF
--- a/frontend/src/metabase/static-viz/components/TimeSeriesAreaChart/TimeSeriesAreaChart.jsx
+++ b/frontend/src/metabase/static-viz/components/TimeSeriesAreaChart/TimeSeriesAreaChart.jsx
@@ -12,6 +12,7 @@ import {
 } from "../../lib/axes";
 import { formatDate } from "../../lib/dates";
 import { formatNumber } from "../../lib/numbers";
+import { sortTimeSeries } from "../../lib/sort";
 
 const propTypes = {
   data: PropTypes.array.isRequired,
@@ -58,6 +59,7 @@ const layout = {
 };
 
 const TimeSeriesAreaChart = ({ data, accessors, settings, labels }) => {
+  data = sortTimeSeries(data);
   const colors = settings?.colors;
   const yTickWidth = getYTickWidth(data, accessors, settings, layout.font.size);
   const yLabelOffset = yTickWidth + layout.labelPadding;

--- a/frontend/src/metabase/static-viz/components/TimeSeriesBarChart/TimeSeriesBarChart.jsx
+++ b/frontend/src/metabase/static-viz/components/TimeSeriesBarChart/TimeSeriesBarChart.jsx
@@ -12,6 +12,7 @@ import {
 } from "../../lib/axes";
 import { formatDate } from "../../lib/dates";
 import { formatNumber } from "../../lib/numbers";
+import { sortTimeSeries } from "../../lib/sort";
 
 const propTypes = {
   data: PropTypes.array.isRequired,
@@ -56,6 +57,7 @@ const layout = {
 };
 
 const TimeSeriesBarChart = ({ data, accessors, settings, labels }) => {
+  data = sortTimeSeries(data);
   const colors = settings?.colors;
   const yTickWidth = getYTickWidth(data, accessors, settings, layout.font.size);
   const yLabelOffset = yTickWidth + layout.labelPadding;

--- a/frontend/src/metabase/static-viz/components/TimeSeriesLineChart/TimeSeriesLineChart.jsx
+++ b/frontend/src/metabase/static-viz/components/TimeSeriesLineChart/TimeSeriesLineChart.jsx
@@ -12,6 +12,7 @@ import {
 } from "../../lib/axes";
 import { formatDate } from "../../lib/dates";
 import { formatNumber } from "../../lib/numbers";
+import { sortTimeSeries } from "../../lib/sort";
 
 const propTypes = {
   data: PropTypes.array.isRequired,
@@ -56,6 +57,7 @@ const layout = {
 };
 
 const TimeSeriesLineChart = ({ data, accessors, settings, labels }) => {
+  data = sortTimeSeries(data);
   const colors = settings?.colors;
   const yTickWidth = getYTickWidth(data, accessors, settings, layout.font.size);
   const yLabelOffset = yTickWidth + layout.labelPadding;

--- a/frontend/src/metabase/static-viz/components/TimeSeriesWaterfallChart/TimeSeriesWaterfallChart.jsx
+++ b/frontend/src/metabase/static-viz/components/TimeSeriesWaterfallChart/TimeSeriesWaterfallChart.jsx
@@ -18,6 +18,7 @@ import {
   formatTimescaleWaterfallTick,
   getWaterfallEntryColor,
 } from "metabase/static-viz/lib/waterfall";
+import { sortTimeSeries } from "../../lib/sort";
 
 const propTypes = {
   data: PropTypes.array.isRequired,
@@ -66,6 +67,7 @@ const layout = {
 };
 
 const TimeSeriesWaterfallChart = ({ data, accessors, settings, labels }) => {
+  data = sortTimeSeries(data);
   const colors = settings?.colors;
   const yTickWidth = getYTickWidth(data, accessors, settings, layout.font.size);
   const yLabelOffset = yTickWidth + layout.labelPadding;

--- a/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
@@ -30,6 +30,7 @@ import {
   calculateLegendItems,
   calculateBounds,
   calculateYDomains,
+  sortSeries,
 } from "metabase/static-viz/components/XYChart/utils";
 import { GoalLine } from "metabase/static-viz/components/XYChart/GoalLine";
 
@@ -48,6 +49,7 @@ export const XYChart = ({
   settings,
   style,
 }: XYChartProps) => {
+  series = sortSeries(series, settings.x.type);
   const yDomains = calculateYDomains(series, settings.goal?.value);
   const yTickWidths = getYTickWidths(
     settings.y.format,

--- a/frontend/src/metabase/static-viz/components/XYChart/utils/series.ts
+++ b/frontend/src/metabase/static-viz/components/XYChart/utils/series.ts
@@ -2,6 +2,7 @@ import _ from "underscore";
 import {
   Series,
   SeriesDatum,
+  XAxisType,
 } from "metabase/static-viz/components/XYChart/types";
 
 export const getX = (d: SeriesDatum) => d[0];
@@ -12,4 +13,28 @@ export const partitionByYAxis = (series: Series[]) => {
     series,
     series => series.yAxisPosition === "left" || series.yAxisPosition == null,
   );
+};
+
+export const sortSeries = (series: Series[], type: XAxisType) => {
+  if (type === "ordinal") {
+    return series;
+  }
+
+  return series.map(s => {
+    const sortedData = s.data.slice().sort((left, right) => {
+      const leftX = getX(left);
+      const rightX = getX(right);
+
+      if (type === "timeseries") {
+        return new Date(leftX).valueOf() - new Date(rightX).valueOf();
+      }
+
+      return Number(leftX) - Number(rightX);
+    });
+
+    return {
+      ...s,
+      data: sortedData,
+    };
+  });
 };

--- a/frontend/src/metabase/static-viz/components/XYChart/utils/series.unit.spec.ts
+++ b/frontend/src/metabase/static-viz/components/XYChart/utils/series.unit.spec.ts
@@ -1,0 +1,102 @@
+import { sortSeries } from "./series";
+
+describe("sortSeries", () => {
+  it("sorts timeseries data", () => {
+    const sortedSeries = sortSeries(
+      [
+        {
+          name: "series",
+          color: "#ef8c8c",
+          yAxisPosition: "right",
+          type: "line",
+          data: [
+            ["2020-10-22", 3],
+            ["2020-10-20", 4],
+            ["2020-10-21", 5],
+          ],
+        },
+      ],
+      "timeseries",
+    );
+
+    expect(sortedSeries).toStrictEqual([
+      {
+        name: "series",
+        color: "#ef8c8c",
+        yAxisPosition: "right",
+        type: "line",
+        data: [
+          ["2020-10-20", 4],
+          ["2020-10-21", 5],
+          ["2020-10-22", 3],
+        ],
+      },
+    ]);
+  });
+
+  it("sorts numeric data", () => {
+    const sortedSeries = sortSeries(
+      [
+        {
+          name: "series",
+          color: "#ef8c8c",
+          yAxisPosition: "right",
+          type: "line",
+          data: [
+            [5, 3],
+            [4, 4],
+            [1, 5],
+          ],
+        },
+      ],
+      "linear",
+    );
+
+    expect(sortedSeries).toStrictEqual([
+      {
+        name: "series",
+        color: "#ef8c8c",
+        yAxisPosition: "right",
+        type: "line",
+        data: [
+          [1, 5],
+          [4, 4],
+          [5, 3],
+        ],
+      },
+    ]);
+  });
+
+  it("keeps existing order for ordinal data", () => {
+    const sortedSeries = sortSeries(
+      [
+        {
+          name: "series",
+          color: "#ef8c8c",
+          yAxisPosition: "right",
+          type: "line",
+          data: [
+            ["stage 3", 3],
+            ["stage 2", 4],
+            ["stage 1", 5],
+          ],
+        },
+      ],
+      "ordinal",
+    );
+
+    expect(sortedSeries).toStrictEqual([
+      {
+        name: "series",
+        color: "#ef8c8c",
+        yAxisPosition: "right",
+        type: "line",
+        data: [
+          ["stage 3", 3],
+          ["stage 2", 4],
+          ["stage 1", 5],
+        ],
+      },
+    ]);
+  });
+});

--- a/frontend/src/metabase/static-viz/lib/sort.js
+++ b/frontend/src/metabase/static-viz/lib/sort.js
@@ -1,0 +1,4 @@
+export const sortTimeSeries = series =>
+  series
+    .slice()
+    .sort((a, b) => new Date(a[0]).valueOf() - new Date(b[0]).valueOf());


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/19098

Unsorted data make static viz look weird.

Before:
<img width="572" alt="Screen Shot 2021-12-01 at 02 10 28" src="https://user-images.githubusercontent.com/14301985/144136316-311fc413-c233-4b8f-9ca8-5dd6aca94019.png">

After:
<img width="581" alt="Screen Shot 2021-12-01 at 02 10 09" src="https://user-images.githubusercontent.com/14301985/144136390-33527755-dfbb-4f26-90ea-4730921cb4de.png">


### How to verify 
The easiest way is to replace chart data inside `frontend/src/metabase/internal/pages/StaticVizPage.jsx`

Here is an unsorted set.
```
                    ["2020-10-27", 80],
                    ["2020-10-20", 15],
                    ["2020-10-22", 35],
                    ["2020-10-24", 55],
                    ["2020-10-26", 75],
                    ["2020-10-28", 95],
                    ["2020-10-21", 20],
                    ["2020-10-23", 40],
                    ["2020-10-25", 60],
```

- Run Metabase
- Open code of the static viz demo page
- Use the data series above for `timeseries/line`, `timeseries/area`, `combo-chart` and ensure they look as expected.