### PR TITLE
Hide collections without datasets in dataset picker

### DIFF
--- a/frontend/src/metabase/query_builder/components/saved-question-picker/SavedQuestionPicker.jsx
+++ b/frontend/src/metabase/query_builder/components/saved-question-picker/SavedQuestionPicker.jsx
@@ -57,6 +57,8 @@ function SavedQuestionPicker({
   collectionName,
 }) {
   const collectionTree = useMemo(() => {
+    const targetModels = isDatasets ? ["dataset"] : null;
+
     const preparedCollections = [];
     const userPersonalCollections = currentUserPersonalCollections(
       collections,
@@ -86,9 +88,9 @@ function SavedQuestionPicker({
 
     return [
       OUR_ANALYTICS_COLLECTION,
-      ...buildCollectionTree(preparedCollections),
+      ...buildCollectionTree(preparedCollections, { targetModels }),
     ];
-  }, [collections, currentUser]);
+  }, [collections, currentUser, isDatasets]);
 
   const initialCollection = useMemo(
     () => findCollectionByName(collectionTree, collectionName),

--- a/frontend/src/metabase/query_builder/components/saved-question-picker/utils.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/saved-question-picker/utils.unit.spec.js
@@ -85,7 +85,7 @@ describe("buildCollectionTree", () => {
   });
 
   describe("filtering by models", () => {
-    it("only keeps collections containing target models", () => {
+    it("only keeps collection branches containing target models", () => {
       const grandchild1 = getCollection({
         id: 4,
         name: "Grandchild 1",
@@ -94,18 +94,18 @@ describe("buildCollectionTree", () => {
       const grandchild2 = getCollection({
         id: 3,
         name: "Grandchild 2",
-        here: ["dataset"],
+        here: ["card"],
       });
       const child = getCollection({
         id: 2,
         name: "Child",
-        below: ["dataset"],
+        below: ["dataset", "card"],
         children: [grandchild1, grandchild2],
       });
       const collection = getCollection({
         id: 1,
         name: "Top-level",
-        below: ["dataset"],
+        below: ["dataset", "card"],
         children: [child],
       });
 
@@ -115,29 +115,37 @@ describe("buildCollectionTree", () => {
 
       expect(transformed).toEqual([
         {
-          id: grandchild1.id,
-          name: grandchild1.name,
-          schemaName: grandchild1.name,
+          id: collection.id,
+          name: collection.name,
+          schemaName: collection.name,
           icon: { name: "folder" },
-          children: [],
-        },
-        {
-          id: grandchild2.id,
-          name: grandchild2.name,
-          schemaName: grandchild2.name,
-          icon: { name: "folder" },
-          children: [],
+          children: [
+            {
+              id: child.id,
+              name: child.name,
+              schemaName: child.name,
+              icon: { name: "folder" },
+              children: [
+                {
+                  id: grandchild1.id,
+                  name: grandchild1.name,
+                  schemaName: grandchild1.name,
+                  icon: { name: "folder" },
+                  children: [],
+                },
+              ],
+            },
+          ],
         },
       ]);
     });
 
     it("filters top-level collections not containing target models", () => {
-      const child = getCollection({ id: 2, name: "Child", here: ["dataset"] });
-      const collection = getCollection({
+      const collectionWithDatasets = getCollection({
         id: 1,
         name: "Top-level",
-        below: ["dataset"],
-        children: [child],
+        here: ["dataset"],
+        children: [],
       });
       const collectionWithCards = getCollection({
         id: 5,
@@ -146,7 +154,7 @@ describe("buildCollectionTree", () => {
       });
 
       const transformed = buildCollectionTree(
-        [collection, collectionWithCards],
+        [collectionWithDatasets, collectionWithCards],
         {
           targetModels: ["dataset"],
         },
@@ -154,9 +162,9 @@ describe("buildCollectionTree", () => {
 
       expect(transformed).toEqual([
         {
-          id: child.id,
-          name: child.name,
-          schemaName: child.name,
+          id: collectionWithDatasets.id,
+          name: collectionWithDatasets.name,
+          schemaName: collectionWithDatasets.name,
           icon: { name: "folder" },
           children: [],
         },

--- a/frontend/src/metabase/query_builder/components/saved-question-picker/utils.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/saved-question-picker/utils.unit.spec.js
@@ -84,6 +84,131 @@ describe("buildCollectionTree", () => {
     expect(transformed.icon).toEqual({ name: "folder" });
   });
 
+  describe("filtering by models", () => {
+    it("only keeps collections containing target models", () => {
+      const grandchild1 = getCollection({
+        id: 4,
+        name: "Grandchild 1",
+        here: ["dataset"],
+      });
+      const grandchild2 = getCollection({
+        id: 3,
+        name: "Grandchild 2",
+        here: ["dataset"],
+      });
+      const child = getCollection({
+        id: 2,
+        name: "Child",
+        below: ["dataset"],
+        children: [grandchild1, grandchild2],
+      });
+      const collection = getCollection({
+        id: 1,
+        name: "Top-level",
+        below: ["dataset"],
+        children: [child],
+      });
+
+      const transformed = buildCollectionTree([collection], {
+        targetModels: ["dataset"],
+      });
+
+      expect(transformed).toEqual([
+        {
+          id: grandchild1.id,
+          name: grandchild1.name,
+          schemaName: grandchild1.name,
+          icon: { name: "folder" },
+          children: [],
+        },
+        {
+          id: grandchild2.id,
+          name: grandchild2.name,
+          schemaName: grandchild2.name,
+          icon: { name: "folder" },
+          children: [],
+        },
+      ]);
+    });
+
+    it("filters top-level collections not containing target models", () => {
+      const child = getCollection({ id: 2, name: "Child", here: ["dataset"] });
+      const collection = getCollection({
+        id: 1,
+        name: "Top-level",
+        below: ["dataset"],
+        children: [child],
+      });
+      const collectionWithCards = getCollection({
+        id: 5,
+        name: "Top-level 2",
+        below: ["card"],
+      });
+
+      const transformed = buildCollectionTree(
+        [collection, collectionWithCards],
+        {
+          targetModels: ["dataset"],
+        },
+      );
+
+      expect(transformed).toEqual([
+        {
+          id: child.id,
+          name: child.name,
+          schemaName: child.name,
+          icon: { name: "folder" },
+          children: [],
+        },
+      ]);
+    });
+
+    it("doesn't filter collections if targetModels are not passed", () => {
+      const child = getCollection({ id: 2, name: "Child", here: ["dataset"] });
+      const collection = getCollection({
+        id: 1,
+        name: "Top-level",
+        below: ["dataset"],
+        children: [child],
+      });
+      const collectionWithCards = getCollection({
+        id: 5,
+        name: "Top-level 2",
+        below: ["card"],
+      });
+
+      const transformed = buildCollectionTree([
+        collection,
+        collectionWithCards,
+      ]);
+
+      expect(transformed).toEqual([
+        {
+          id: collection.id,
+          name: collection.name,
+          schemaName: collection.name,
+          icon: { name: "folder" },
+          children: [
+            {
+              id: child.id,
+              name: child.name,
+              schemaName: child.name,
+              icon: { name: "folder" },
+              children: [],
+            },
+          ],
+        },
+        {
+          id: collectionWithCards.id,
+          name: collectionWithCards.name,
+          schemaName: collectionWithCards.name,
+          icon: { name: "folder" },
+          children: [],
+        },
+      ]);
+    });
+  });
+
   describe("EE", () => {
     beforeEach(() => {
       setupEnterpriseTest();

--- a/frontend/src/metabase/query_builder/components/saved-question-picker/utils.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/saved-question-picker/utils.unit.spec.js
@@ -1,0 +1,102 @@
+import { setupEnterpriseTest } from "__support__/enterprise";
+import { buildCollectionTree } from "./utils";
+
+function getCollection({
+  id = 1,
+  name = "Collection",
+  children = [],
+  ...rest
+} = {}) {
+  return {
+    id,
+    name,
+    children,
+    ...rest,
+  };
+}
+
+describe("buildCollectionTree", () => {
+  it("returns an empty array when collections are not passed", () => {
+    expect(buildCollectionTree()).toEqual([]);
+  });
+
+  it("correctly transforms collections", () => {
+    const collection = getCollection({ children: [] });
+    const [transformed] = buildCollectionTree([collection]);
+    expect(transformed).toEqual({
+      id: collection.id,
+      name: collection.name,
+      schemaName: collection.name,
+      icon: { name: "folder" },
+      children: [],
+    });
+  });
+
+  it("prefers originalName over name for schema names", () => {
+    const collection = getCollection({ name: "bar", originalName: "foo" });
+    const [transformed] = buildCollectionTree([collection]);
+    expect(transformed.schemaName).toBe(collection.originalName);
+  });
+
+  it("recursively transforms collection children", () => {
+    const secondChild = getCollection({ id: 3, name: "C3" });
+    const firstChild = getCollection({
+      id: 2,
+      name: "C2",
+      children: [secondChild],
+    });
+    const collection = getCollection({
+      id: 1,
+      name: "C1",
+      children: [firstChild],
+    });
+
+    const [transformed] = buildCollectionTree([collection]);
+
+    expect(transformed).toEqual({
+      id: collection.id,
+      name: collection.name,
+      schemaName: collection.name,
+      icon: { name: "folder" },
+      children: [
+        {
+          id: firstChild.id,
+          name: firstChild.name,
+          schemaName: firstChild.name,
+          icon: { name: "folder" },
+          children: [
+            {
+              id: secondChild.id,
+              name: secondChild.name,
+              schemaName: secondChild.name,
+              icon: { name: "folder" },
+              children: [],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("returns regular icon for official collections in OSS", () => {
+    const collection = getCollection({ authority_level: "official" });
+    const [transformed] = buildCollectionTree([collection]);
+    expect(transformed.icon).toEqual({ name: "folder" });
+  });
+
+  describe("EE", () => {
+    beforeEach(() => {
+      setupEnterpriseTest();
+    });
+
+    it("returns correct icon for official collections", () => {
+      const collection = getCollection({ authority_level: "official" });
+      const [transformed] = buildCollectionTree([collection]);
+      expect(transformed.icon).toEqual({
+        color: expect.any(String),
+        name: "badge",
+        tooltip: "Official collection",
+      });
+    });
+  });
+});

--- a/frontend/src/metabase/query_builder/components/saved-question-picker/utils.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/saved-question-picker/utils.unit.spec.js
@@ -39,16 +39,16 @@ describe("buildCollectionTree", () => {
   });
 
   it("recursively transforms collection children", () => {
-    const secondChild = getCollection({ id: 3, name: "C3" });
-    const firstChild = getCollection({
+    const grandchild = getCollection({ id: 3, name: "C3" });
+    const child = getCollection({
       id: 2,
       name: "C2",
-      children: [secondChild],
+      children: [grandchild],
     });
     const collection = getCollection({
       id: 1,
       name: "C1",
-      children: [firstChild],
+      children: [child],
     });
 
     const [transformed] = buildCollectionTree([collection]);
@@ -60,15 +60,15 @@ describe("buildCollectionTree", () => {
       icon: { name: "folder" },
       children: [
         {
-          id: firstChild.id,
-          name: firstChild.name,
-          schemaName: firstChild.name,
+          id: child.id,
+          name: child.name,
+          schemaName: child.name,
           icon: { name: "folder" },
           children: [
             {
-              id: secondChild.id,
-              name: secondChild.name,
-              schemaName: secondChild.name,
+              id: grandchild.id,
+              name: grandchild.name,
+              schemaName: grandchild.name,
               icon: { name: "folder" },
               children: [],
             },


### PR DESCRIPTION
When selecting a dataset to use for a query, we use the same picker we have for saved questions. The picker has a collection tree on the left and a selected collection's contents on the right. Most likely people are going to have fewer datasets than regular questions, so they'll often need to click through a few empty collections to get the desired one.

This PR hides collections without datasets in the dataset picker, so it's easier to browse and find datasets. It's based on the BE PR #18833 adding `here` and `below` annotations explaining collection contents and its children's contents too.

~~⚠️  There is an edge case not covered on the BE for now. If you have a collection with archived items, they're still taken into account when creating `here` and `below` annotations. So in the picker, you can see collections without datasets that actually have them archived. BE fix PR: #19156~~ UPDATE: rebased on `master` with the fix merged

### To Verify

1. Create collection A and collection B inside of it
2. Add a dataset to collection B
3. Create collection C and leave it empty / add a few questions in it
2. Ask a question > Simple / Custom Question > Datasets
3. Ensure you can see collections A > B, but no C

**Saved question picker**
Since we use the same component for the dataset and saved questions pickers, ensure the saved question picker works the same was it did before

### Demo

**Before**

![CleanShot 2021-12-01 at 14 56 31@2x](https://user-images.githubusercontent.com/17258145/144240353-4465648a-6100-4e44-9360-5d5027282aa1.png)

**After**

<img width="834" alt="CleanShot 2021-12-01 at 14 53 35@2x" src="https://user-images.githubusercontent.com/17258145/144240390-f58bed51-2bd4-4558-a35e-cda4c90bab5e.png">

