### PR TITLE
Datasets collection tree archived fix

### DIFF
--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -64,13 +64,21 @@
   "Similar to `GET /`, but returns Collections in a tree structure, e.g.
 
     [{:name     \"A\"
+      :below    #{:card :dataset}
       :children [{:name \"B\"}
                  {:name     \"C\"
+                  :here     #{:dataset :card}
+                  :below    #{:dataset :card}
                   :children [{:name     \"D\"
+                              :here     #{:dataset}
                               :children [{:name \"E\"}]}
                              {:name     \"F\"
+                              :here     #{:card}
                               :children [{:name \"G\"}]}]}]}
-     {:name \"H\"}]"
+     {:name \"H\"}]
+
+  The here and below keys indicate the types of items at this particular level of the tree (here) and in its
+  subtree (below)."
   [namespace]
   {namespace (s/maybe su/NonBlankString)}
   (let [coll-type-ids (reduce (fn [acc {:keys [collection_id dataset] :as x}]

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -79,7 +79,8 @@
                                :card #{}}
                               (db/reducible-query {:select [:collection_id :dataset]
                                                    :modifiers [:distinct]
-                                                   :from [:report_card]}))]
+                                                   :from [:report_card]
+                                                   :where [:= :archived false]}))]
     (collection/collections->tree
      coll-type-ids
      (db/select Collection


### PR DESCRIPTION
When annotating the collection tree, only include unarchived information.

When browsing the tree, we can use this information to only show subtrees with interesting bits (cards or datasets). But if it is archived, they will expand and find nothing.

The scenario is an archived dataset in a collection called "a collection", and a dataset in a child collection.
The api response before the fix:

```clojure
{:authority_level nil
 :description nil
 :archived false
 :children ({:authority_level nil
             :description nil
             :archived false
             :children ()
             :slug "a_sub_collection"
             :color "#509EE3"
             :name "a sub collection"
             :personal_owner_id nil
             :here #{:dataset}   ;; thinks there is a dataset in the child
             :id 533
             :location "/532/"
             :namespace nil})
 :slug "a_collection"
 :color "#509EE3"
 :name "a collection"
 :personal_owner_id nil
 :here #{:dataset}  ;; thinks there is a dataset in the parent
 :id 532
 :location "/"
 :namespace nil
 :below #{:dataset}} ;; parent thinks its subtree includes a dataset
```

When fixed, these misleading annotations are omitted because the datasets (and cards when applicable) are archived.

```clojure
{:authority_level nil
 :description nil
 :archived false
 :children ({:authority_level nil
             :description nil
             :archived false
             :children ()
             :slug "a_sub_collection"
             :color "#509EE3"
             :name "a sub collection"
             :personal_owner_id nil
             :id 533
             :location "/532/"
             :namespace nil})
 :slug "a_collection"
 :color "#509EE3"
 :name "a collection"
 :personal_owner_id nil
 :id 532
 :location "/"
 :namespace nil}
```