### PR TITLE
Fix type-checking with COALESCE

### DIFF
--- a/frontend/src/metabase/lib/expressions/typechecker.js
+++ b/frontend/src/metabase/lib/expressions/typechecker.js
@@ -78,7 +78,11 @@ export function typeCheck(cst, rootType) {
       if (type === "number") {
         const op = getMBQLName(name);
         const returnType = MBQL_CLAUSES[op].type;
-        if (returnType !== "number" && returnType !== "string") {
+        if (
+          returnType !== "number" &&
+          returnType !== "string" &&
+          returnType !== "expression"
+        ) {
           const message = t`Expecting ${type} but found function ${name} returning ${returnType}`;
           this.errors.push({ message });
         }

--- a/frontend/test/metabase/lib/expressions/typechecker.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/typechecker.unit.spec.js
@@ -190,6 +190,10 @@ describe("type-checker", () => {
       expect(() => validate("Lower([State]) > 'AB'")).not.toThrow();
     });
 
+    it("should allow a comparison on the result of COALESCE", () => {
+      expect(() => validate("Coalesce([X],[Y]) > 0")).not.toThrow();
+    });
+
     it("should reject a less/greater comparison on functions returning boolean", () => {
       expect(() => validate("IsEmpty([Tax]) < 5")).toThrow();
       expect(() => validate("IsEmpty([Tax]) >= 0")).toThrow();


### PR DESCRIPTION
This is a regression in master after PR #18206. Thanks to @flamber for catching this!

To verify:
1. Ask a question, Custom question
2. Sample Dataset, Products table
3. Filter, Custom Expression, and type `coalesce([Rating], [Price]) > 0`

**Before this PR**

The filter is incorrectly rejected.

![image](https://user-images.githubusercontent.com/7288/144280462-9ebb6320-21ad-4a8c-b31d-b5c3756b875d.png)


**After this PR**

The filter is accepted as a valid one, just line in v41 or earlier.

