### PR TITLE
React Ace: fix UX after selecting item from autocomplete on a click

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -144,11 +144,12 @@ export default class ExpressionEditorTextfield extends React.Component {
     const { source, suggestions } = this.state;
     const suggestion = suggestions && suggestions[index];
 
+    const { editor } = this.input.current;
+
     if (suggestion) {
       const { tokens } = tokenize(source);
       const token = tokens.find(t => t.end >= suggestion.index);
 
-      const { editor } = this.input.current;
       const { row } = editor.getCursorPosition();
 
       if (token) {
@@ -167,11 +168,14 @@ export default class ExpressionEditorTextfield extends React.Component {
         this.onExpressionChange(updatedExpression);
         const caretPos = updatedExpression.length - postfix.length;
 
-        editor.moveCursorTo(row, caretPos);
+        // setTimeout solves a race condition that happens only
+        // when a suggestion has been selected by
+        // clicking on the autocomplete
+        setTimeout(() => editor.moveCursorTo(row, caretPos));
       } else {
         const newExpression = source + suggestion.text;
         this.onExpressionChange(newExpression);
-        this.input.current.editor.moveCursorTo(row, newExpression.length);
+        editor.moveCursorTo(row, newExpression.length);
       }
     }
   };
@@ -441,7 +445,7 @@ export default class ExpressionEditorTextfield extends React.Component {
           />
           <ExpressionEditorSuggestions
             suggestions={suggestions}
-            onSuggestionMouseDown={this.onSuggestionSelected}
+            onSuggestionMouseDown={this.handleEnter}
             highlightedIndex={this.state.highlightedSuggestionIndex}
           />
         </EditorContainer>

--- a/frontend/test/metabase/scenarios/question/reproductions/17963-mongo-filter-expression-compare-two-fields.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/17963-mongo-filter-expression-compare-two-fields.cy.spec.js
@@ -1,4 +1,9 @@
-import { restore, popover, visualize } from "__support__/e2e/cypress";
+import {
+  enterCustomColumnDetails,
+  popover,
+  restore,
+  visualize,
+} from "__support__/e2e/cypress";
 
 describe("issue 17963", () => {
   beforeEach(() => {
@@ -37,8 +42,8 @@ describe("issue 17963", () => {
 });
 
 function typeAndSelect(arr) {
-  arr.forEach(({ string, field }) => {
-    cy.get("[contenteditable=true]").type(string);
+  arr.forEach(({ formula, field }) => {
+    enterCustomColumnDetails({ formula });
 
     popover()
       .contains(field)

--- a/frontend/test/metabase/scenarios/question/reproductions/17963-mongo-filter-expression-compare-two-fields.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/17963-mongo-filter-expression-compare-two-fields.cy.spec.js
@@ -2,12 +2,12 @@ import { restore, popover, visualize } from "__support__/e2e/cypress";
 
 describe("issue 17963", () => {
   beforeEach(() => {
-    restore("mongo-4");
+    restore();
     cy.signInAsAdmin();
 
     cy.visit("/question/new");
     cy.findByText("Custom question").click();
-    cy.findByText("QA Mongo4").click();
+    cy.findByText("Sample Dataset").click();
     cy.findByText("Orders").click();
   });
 

--- a/frontend/test/metabase/scenarios/question/reproductions/17963-mongo-filter-expression-compare-two-fields.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/17963-mongo-filter-expression-compare-two-fields.cy.spec.js
@@ -2,12 +2,12 @@ import { restore, popover, visualize } from "__support__/e2e/cypress";
 
 describe("issue 17963", () => {
   beforeEach(() => {
-    restore();
+    restore("mongo-4");
     cy.signInAsAdmin();
 
     cy.visit("/question/new");
     cy.findByText("Custom question").click();
-    cy.findByText("Sample Dataset").click();
+    cy.findByText("QA Mongo4").click();
     cy.findByText("Orders").click();
   });
 

--- a/frontend/test/metabase/scenarios/question/reproductions/17963-mongo-filter-expression-compare-two-fields.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/17963-mongo-filter-expression-compare-two-fields.cy.spec.js
@@ -1,9 +1,4 @@
-import {
-  enterCustomColumnDetails,
-  popover,
-  restore,
-  visualize,
-} from "__support__/e2e/cypress";
+import { restore, popover, visualize } from "__support__/e2e/cypress";
 
 describe("issue 17963", () => {
   beforeEach(() => {
@@ -42,8 +37,8 @@ describe("issue 17963", () => {
 });
 
 function typeAndSelect(arr) {
-  arr.forEach(({ formula, field }) => {
-    enterCustomColumnDetails({ formula });
+  arr.forEach(({ string, field }) => {
+    cy.get(".ace_text-input").type(string);
 
     popover()
       .contains(field)


### PR DESCRIPTION
### How to Test

In `custom question` › `custom expression editor`.

1. click on an autocomplete suggestion (for example, type `dis` and **click** on `Discount`)
2. autocomplete should disappear
3. caret in editor should move to end of where suggestion was applied

This was caught by the e2e test:

```
frontend/test/metabase/scenarios/question/reproductions/17963-mongo-filter-expression-compare-two-fields.cy.spec.js
```

which should now be passing in CI suites

ci/circleci: e2e-tests-question-ee
ci/circleci: e2e-tests-question-os

