### PR TITLE
Update about copy to reflect our global team

### DIFF
--- a/frontend/src/metabase/nav/components/ProfileLink.jsx
+++ b/frontend/src/metabase/nav/components/ProfileLink.jsx
@@ -146,7 +146,7 @@ export default class ProfileLink extends Component {
                   <span className="text-bold">Metabase</span>{" "}
                   {t`is a Trademark of`} Metabase, Inc
                 </span>
-                <span>{t`and is built with care in San Francisco, CA`}</span>
+                <span>{t`and is built with care by a team from all across this pale blue dot.`}</span>
               </div>
             )}
           </Modal>


### PR DESCRIPTION
We're lucky to have a team from all over the world building Metabase, so our about modal should reflect that. Thanks @jeff-bruemmer for the catch.