### PR TITLE
Expand GeoJSON validation to all link-local addresses

### DIFF
--- a/src/metabase/api/geojson.clj
+++ b/src/metabase/api/geojson.clj
@@ -36,13 +36,15 @@
        (tru "URLs referring to hosts that supply internal hosting metadata are prohibited.")))
 
 (def ^:private invalid-hosts
-  #{"169.254.169.254" ; internal metadata for AWS, OpenStack, and Azure
-    "metadata.google.internal"}) ; internal metadata for GCP
-
+  ["169.254.169.254" ; internal metadata for AWS, OpenStack, and Azure
+   "metadata.google.internal"]) ; internal metadata for GCP
 
 (defn- valid-host?
   [^URL url]
-  (not (invalid-hosts (.getHost url))))
+  (let [host->url (fn [host] (URL. (str "http://" host)))
+        base-url (host->url (.getHost url))
+        invalid-base-urls (map host->url invalid-hosts)]
+    (not-any? (fn [invalid-url] (.equals base-url invalid-url)) invalid-base-urls)))
 
 (defn- valid-protocol?
   [^URL url]
@@ -52,8 +54,8 @@
   [url-string]
   (try
     (let [url (URL. url-string)]
-      (and (valid-host? url)
-           (valid-protocol? url)))
+      (and (valid-protocol? url)
+           (valid-host? url)))
     (catch Throwable e
       (throw (ex-info (invalid-location-msg) {:status-code 400, :url url-string} e)))))
 

--- a/src/metabase/api/geojson.clj
+++ b/src/metabase/api/geojson.clj
@@ -8,9 +8,8 @@
             [ring.util.codec :as rc]
             [ring.util.response :as rr]
             [schema.core :as s])
-  (:import java.net.URL
-           org.apache.commons.io.input.ReaderInputStream
-           java.net.InetAddress))
+  (:import [java.net InetAddress URL]
+           org.apache.commons.io.input.ReaderInputStream))
 
 (def ^:private CustomGeoJSON
   {s/Keyword {:name                     su/NonBlankString

--- a/src/metabase/api/geojson.clj
+++ b/src/metabase/api/geojson.clj
@@ -43,7 +43,7 @@
   (let [host (.getHost url)
         host->url (fn [host] (URL. (str "http://" host)))
         base-url  (host->url (.getHost url))]
-    (and (not-any? (fn [invalid-url] (.equals base-url invalid-url))
+    (and (not-any? (fn [invalid-url] (.equals ^URL base-url invalid-url))
                    (map host->url invalid-hosts))
          (not (.isLinkLocalAddress (InetAddress/getByName host))))))
 

--- a/src/metabase/api/geojson.clj
+++ b/src/metabase/api/geojson.clj
@@ -41,8 +41,11 @@
 
 (defn- valid-host?
   [^URL url]
-  (let [host (.getHost url)]
-    (and (not (invalid-hosts host))
+  (let [host (.getHost url)
+        host->url (fn [host] (URL. (str "http://" host)))
+        base-url  (host->url (.getHost url))]
+    (and (not-any? (fn [invalid-url] (.equals base-url invalid-url))
+                   (map host->url invalid-hosts))
          (not (.isLinkLocalAddress (InetAddress/getByName host))))))
 
 (defn- valid-protocol?

--- a/src/metabase/api/geojson.clj
+++ b/src/metabase/api/geojson.clj
@@ -9,7 +9,8 @@
             [ring.util.response :as rr]
             [schema.core :as s])
   (:import java.net.URL
-           org.apache.commons.io.input.ReaderInputStream))
+           org.apache.commons.io.input.ReaderInputStream
+           java.net.InetAddress))
 
 (def ^:private CustomGeoJSON
   {s/Keyword {:name                     su/NonBlankString
@@ -36,15 +37,13 @@
        (tru "URLs referring to hosts that supply internal hosting metadata are prohibited.")))
 
 (def ^:private invalid-hosts
-  ["169.254.169.254" ; internal metadata for AWS, OpenStack, and Azure
-   "metadata.google.internal"]) ; internal metadata for GCP
+  #{"metadata.google.internal"}) ; internal metadata for GCP
 
 (defn- valid-host?
   [^URL url]
-  (let [host->url (fn [host] (URL. (str "http://" host)))
-        base-url (host->url (.getHost url))
-        invalid-base-urls (map host->url invalid-hosts)]
-    (not-any? (fn [invalid-url] (.equals base-url invalid-url)) invalid-base-urls)))
+  (let [host (.getHost url)]
+    (and (not (invalid-hosts host))
+         (not (.isLinkLocalAddress (InetAddress/getByName host))))))
 
 (defn- valid-protocol?
   [^URL url]

--- a/test/metabase/api/geojson_test.clj
+++ b/test/metabase/api/geojson_test.clj
@@ -41,6 +41,16 @@
                     "//metadata.google.internal"               false
                     "169.254.169.254"                          false
                     "http://169.254.169.254/secret-stuff.json" false
+                    ;; Prohibited hosts in alternate encodings (hex, octal, integer)
+                    "http://0xa9fea9fe"                        false
+                    "https://0xa9fea9fe"                       false
+                    "http://0xA9FEA9FE"                        false
+                    "http://0xa9.0xfe.0xa9.0xfe"               false
+                    "http://0XA9.0XFE.0xA9.0XFE"               false
+                    "http://0xa9fea9fe/secret-stuff.json"      false
+                    "http://025177524776"                      false
+                    "http://0251.0376.0251.0376"               false
+                    "http://2852039166"                        false
                     ;; Prohibited protocols
                     "ftp://example.com/rivendell.json"         false
                     "example.com/rivendell.json"               false
@@ -48,6 +58,8 @@
                     "http://example.com/"                      true
                     "https://example.com/"                     true
                     "http://example.com/rivendell.json"        true
+                    "http://192.0.2.0"                         true
+                    "http://0xc0000200"                        true
                     ;; Resources (files on classpath) are valid
                     "c3p0.properties"                          true
                     ;; Other files are not

--- a/test/metabase/api/geojson_test.clj
+++ b/test/metabase/api/geojson_test.clj
@@ -35,13 +35,16 @@
 
 (deftest validate-geojson-test
   (testing "It validates URLs and files appropriately"
-    (let [examples {;; Prohibited hosts (see explanation in source file)
+    (let [examples {;; Internal metadata for GCP
                     "metadata.google.internal"                 false
                     "https://metadata.google.internal"         false
                     "//metadata.google.internal"               false
+                    ;; Link-local addresses (internal metadata for AWS, OpenStack, and Azure)
+                    "http://169.254.0.0"                       false
+                    "http://fe80::"                            false
                     "169.254.169.254"                          false
                     "http://169.254.169.254/secret-stuff.json" false
-                    ;; Prohibited hosts in alternate encodings (hex, octal, integer)
+                    ;; alternate IPv4 encodings (hex, octal, integer)
                     "http://0xa9fea9fe"                        false
                     "https://0xa9fea9fe"                       false
                     "http://0xA9FEA9FE"                        false
@@ -54,6 +57,7 @@
                     ;; Prohibited protocols
                     "ftp://example.com/rivendell.json"         false
                     "example.com/rivendell.json"               false
+                    "jar:file:test.jar!/test.json"             false
                     ;; Acceptable URLs
                     "http://example.com/"                      true
                     "https://example.com/"                     true


### PR DESCRIPTION
Expands GeoJSON validation to reject all link-local addresses, in the ranges `169.254.0.0/16` for IPv4 and `fe80::/10` for IPv6. Removes `169.254.169.254` from the `invalid-hosts` set since it is already a link-local address. The method on `InetAddress` being used here automatically takes into account alternate IP address encodings (hex, octal, and integer).

Also adds logic to use `java.net.URL/equals` when comparing hosts rather than basic string comparisons. This should future-proof the validation so that if we need to add another IP address to the `invalid-hosts` set, it will automatically take into account different encodings as well.