### PR TITLE
Make sure API response streaming context helpers preserve dynamic bindings

### DIFF
--- a/src/metabase/async/streaming_response.clj
+++ b/src/metabase/async/streaming_response.clj
@@ -79,7 +79,7 @@
   `async-context`."
   [^AsyncContext async-context f ^OutputStream os finished-chan canceled-chan]
   {:pre [(some? os)]}
-  (let [task (bound-fn []
+  (let [task (^:once fn* []
                (try
                  (do-f* f os finished-chan canceled-chan)
                  (catch Throwable e
@@ -263,5 +263,5 @@
   {:style/indent 2, :arglists '([options [os-binding canceled-chan-binding] & body])}
   [options [os-binding canceled-chan-binding :as bindings] & body]
   {:pre [(= (count bindings) 2)]}
-  `(streaming-response* (fn [~(vary-meta os-binding assoc :tag 'java.io.OutputStream) ~canceled-chan-binding] ~@body)
+  `(streaming-response* (bound-fn [~(vary-meta os-binding assoc :tag 'java.io.OutputStream) ~canceled-chan-binding] ~@body)
                         ~options))

--- a/src/metabase/query_processor/streaming.clj
+++ b/src/metabase/query_processor/streaming.clj
@@ -3,6 +3,7 @@
             [metabase.async.streaming-response :as streaming-response]
             [metabase.mbql.util :as mbql.u]
             [metabase.query-processor.context :as context]
+            [metabase.query-processor.context.default :as context.default]
             [metabase.query-processor.streaming.csv :as streaming.csv]
             [metabase.query-processor.streaming.interface :as i]
             [metabase.query-processor.streaming.json :as streaming.json]
@@ -126,8 +127,9 @@
       (qp/process-query query (qp.streaming/streaming-context :csv os canceled-chan)))"
   ([export-format os]
    (let [results-writer (i/streaming-results-writer export-format os)]
-     {:rff      (streaming-rff results-writer)
-      :reducedf (streaming-reducedf results-writer os)}))
+     (merge (context.default/default-context)
+            {:rff      (streaming-rff results-writer)
+             :reducedf (streaming-reducedf results-writer os)})))
 
   ([export-format os canceled-chan]
    (assoc (streaming-context export-format os) :canceled-chan canceled-chan)))
@@ -170,7 +172,7 @@
   cancelations properly."
   {:style/indent 1}
   [[context-binding export-format filename-prefix] & body]
-  `(streaming-response* ~export-format ~filename-prefix (fn [~context-binding] ~@body)))
+  `(streaming-response* ~export-format ~filename-prefix (bound-fn [~context-binding] ~@body)))
 
 (defn export-formats
   "Set of valid streaming response formats. Currently, `:json`, `:csv`, `:xlsx`, and `:api` (normal JSON API results


### PR DESCRIPTION
This doesn't actually fix anything but I was trying to refactor something and ended up writing these tests as a sort of sanity check. `metabase.async.streaming-response` actually didn't do the right thing, so this fixes that