### PR TITLE
Fix/mongo srv connection string

### DIFF
--- a/modules/drivers/mongo/resources/metabase-plugin.yaml
+++ b/modules/drivers/mongo/resources/metabase-plugin.yaml
@@ -12,7 +12,7 @@ driver:
     - name: conn-uri
       type: string
       display-name: Paste your connection string
-      placeholder: 'mongodb://[username:password@]host1[:port1][,...hostN[:portN]][/[defaultauthdb][?options]]'
+      placeholder: 'mongodb://[username:password@]host1[:port1][,...hostN[:portN]][/[dbname][?options]]'
       required: true
     - merge:
         - port

--- a/modules/drivers/mongo/src/metabase/driver/mongo/util.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/util.clj
@@ -90,8 +90,8 @@
 (defn- srv-conn-str
   "Creates Mongo client connection string to connect using
    DNS + SRV discovery mechanism."
-  [user pass host authdb]
-  (format "mongodb+srv://%s:%s@%s/%s" user pass host authdb))
+  [user pass host dbname authdb]
+  (format "mongodb+srv://%s:%s@%s/%s?authSource=%s" user pass host authdb))
 
 (defn- normalize-details [details]
   (let [{:keys [dbname host port user pass ssl authdb tunnel-host tunnel-user tunnel-pass additional-options use-srv ssl-cert conn-uri]
@@ -135,8 +135,8 @@
     (let [conn-opts (connection-options-builder :ssl? ssl, :additional-options additional-options, :ssl-cert ssl-cert)
           authdb (if (seq authdb)
                    authdb
-                   dbname)
-          conn-str (srv-conn-str user pass host authdb)]
+                   "admin")
+          conn-str (srv-conn-str user pass host dbname authdb)]
       {:type :srv
        :uri  (MongoClientURI. conn-str conn-opts)})))
 

--- a/modules/drivers/mongo/src/metabase/driver/mongo/util.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/util.clj
@@ -91,19 +91,16 @@
   "Creates Mongo client connection string to connect using
    DNS + SRV discovery mechanism."
   [user pass host dbname authdb]
-  (format "mongodb+srv://%s:%s@%s/%s?authSource=%s" user pass host authdb))
+  (format "mongodb+srv://%s:%s@%s/%s?authSource=%s" user pass host dbname authdb))
 
 (defn- normalize-details [details]
   (let [{:keys [dbname host port user pass ssl authdb tunnel-host tunnel-user tunnel-pass additional-options use-srv ssl-cert conn-uri]
-         :or   {port 27017, pass "", ssl false, use-srv false, ssl-cert ""}} details
+         :or   {port 27017, pass "", ssl false, use-srv false, ssl-cert "", authdb "admin"}} details
         ;; ignore empty :user and :pass strings
         user             (when (seq user)
                            user)
         pass             (when (seq pass)
-                           pass)
-        authdb           (if (seq authdb)
-                           authdb
-                           dbname)]
+                           pass)]
     {:host               host
      :port               port
      :user               user

--- a/modules/drivers/mongo/test/metabase/driver/mongo/util_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/util_test.clj
@@ -31,8 +31,10 @@
 
 (deftest srv-conn-str-test
   (testing "test srv connection string"
-    (is (= "mongodb+srv://test-user:test-pass@test-host.place.com/authdb"
-           (#'mongo-util/srv-conn-str "test-user" "test-pass" "test-host.place.com" "authdb")))))
+    (is (= "mongodb+srv://test-user:test-pass@test-host.place.com/datadb?authSource=authdb"
+           (#'mongo-util/srv-conn-str "test-user" "test-pass" "test-host.place.com" "datadb" "authdb")))))
+    (is (= "mongodb+srv://test-user:test-pass@test-host.place.com/datadb?authSource=admin"
+           (#'mongo-util/srv-conn-str "test-user" "test-pass" "test-host.place.com" "datadb")))))
 
 (deftest srv-toggle-test
   (testing "test that srv toggle works"

--- a/modules/drivers/mongo/test/metabase/driver/mongo/util_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/util_test.clj
@@ -33,8 +33,6 @@
   (testing "test srv connection string"
     (is (= "mongodb+srv://test-user:test-pass@test-host.place.com/datadb?authSource=authdb"
            (#'mongo-util/srv-conn-str "test-user" "test-pass" "test-host.place.com" "datadb" "authdb")))))
-    (is (= "mongodb+srv://test-user:test-pass@test-host.place.com/datadb?authSource=admin"
-           (#'mongo-util/srv-conn-str "test-user" "test-pass" "test-host.place.com" "datadb")))))
 
 (deftest srv-toggle-test
   (testing "test that srv toggle works"


### PR DESCRIPTION
Update mongo connection string generation when SRV is enabled, it was not generated correctly.

The correct format of the connection string is: mongodb://$[hostlist]/$[database]?authSource=$[authSource] (ie: https://docs.mongodb.com/guides/server/drivers/)

The default authDb is admin if authDb is not defined.

