### PR TITLE
Funnel static viz BE

### DIFF
--- a/resources/frontend_shared/static_viz_interface.js
+++ b/resources/frontend_shared/static_viz_interface.js
@@ -56,6 +56,13 @@ function timeseries_waterfall(data, labels, settings) {
   });
 }
 
+function funnel(data, settings) {
+  return StaticViz.RenderChart("funnel", {
+    data: JSON.parse(data),
+    settings: JSON.parse(settings),
+  });
+}
+
 function categorical_bar(data, labels, settings) {
   return StaticViz.RenderChart("categorical/bar", {
     data: toJSArray(data),

--- a/src/metabase/pulse/render.clj
+++ b/src/metabase/pulse/render.clj
@@ -83,7 +83,7 @@
         (#{:pin_map :state :country} display-type)
         (chart-type nil "display-type is %s" display-type)
 
-        (#{:progress :waterfall} display-type)
+        (#{:funnel :progress :waterfall} display-type)
         (chart-type display-type "display-type is %s" display-type)
 
         (= @col-sample-count @row-sample-count 1)

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -543,6 +543,24 @@
       [:img {:style (style/style {:display :block :width :100%})
              :src   (:image-src image-bundle)}]]}))
 
+(s/defmethod render :funnel :- common/RenderedPulseCard
+  [_ render-type timezone-id card {:keys [rows cols viz-settings] :as data}]
+  (let [[x-col y-col] cols
+        settings      (->js-viz x-col y-col viz-settings)
+        settings      (assoc settings
+                             :step    {:name   (:display_name x-col)
+                                       :format (:x settings)}
+                             :measure {:format (:y settings)})
+        svg           (js-svg/funnel rows settings)
+        image-bundle  (image-bundle/make-image-bundle render-type svg)]
+  {:attachments
+   (image-bundle/image-bundle->attachment image-bundle)
+
+   :content
+   [:div
+    [:img {:style (style/style {:display :block :width :100%})
+           :src   (:image-src image-bundle)}]]}))
+
 
 (s/defmethod render :empty :- common/RenderedPulseCard
   [_ render-type _ _ _]

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -545,7 +545,9 @@
 
 (s/defmethod render :funnel :- common/RenderedPulseCard
   [_ render-type timezone-id card {:keys [rows cols viz-settings] :as data}]
-  (let [[x-col y-col] cols
+  ;; x-axis-rowfn is always first, y-axis-rowfn is always second
+  (let [rows          (common/non-nil-rows first second rows)
+        [x-col y-col] cols
         settings      (->js-viz x-col y-col viz-settings)
         settings      (assoc settings
                              :step    {:name   (:display_name x-col)

--- a/src/metabase/pulse/render/js_svg.clj
+++ b/src/metabase/pulse/render/js_svg.clj
@@ -118,6 +118,14 @@
                                                   (json/generate-string settings)))]
     (svg-string->bytes svg-string)))
 
+(defn funnel
+  "Clojure entrypoint to render a timeseries waterfall chart. Data should be vec of [{AAAAAHHHHH FILL IN HERE AAAAAHHHH}].
+  Returns a byte array of a png file."
+  [data settings]
+  (let [svg-string (.asString (js/execute-fn-name @context "funnel" (json/generate_string data)
+                                                  (json/generate-string settings)))]
+    (svg-string->bytes svg-string)))
+
 (defn timelineseries-bar
   "Clojure entrypoint to render a timeseries bar char. Rows should be tuples of [datetime numeric-value]. Labels is a
   map of {:left \"left-label\" :botton \"bottom-label\"}. Returns a byte array of a png file."

--- a/src/metabase/pulse/render/js_svg.clj
+++ b/src/metabase/pulse/render/js_svg.clj
@@ -119,10 +119,10 @@
     (svg-string->bytes svg-string)))
 
 (defn funnel
-  "Clojure entrypoint to render a timeseries waterfall chart. Data should be vec of [{AAAAAHHHHH FILL IN HERE AAAAAHHHH}].
+  "Clojure entrypoint to render a timeseries waterfall chart. Data should be vec of [[Step Measure]] where Step is {:name name :format format-options} and Measure is {:format format-options} and you go and look to frontend/src/metabase/static-viz/components/FunnelChart/types.ts for the actual format options.
   Returns a byte array of a png file."
   [data settings]
-  (let [svg-string (.asString (js/execute-fn-name @context "funnel" (json/generate_string data)
+  (let [svg-string (.asString (js/execute-fn-name @context "funnel" (json/generate-string data)
                                                   (json/generate-string settings)))]
     (svg-string->bytes svg-string)))
 

--- a/test/metabase/pulse/render/body_test.clj
+++ b/test/metabase/pulse/render/body_test.clj
@@ -473,7 +473,7 @@
 (defn- render-funnel [results]
   (body/render :funnel :inline pacific-tz render.tu/test-card results))
 
-(deftest render-funnel
+(deftest render-funnel-test
   (testing "Test that we can render a funnel with all valid values"
     (is (has-inline-image?
          (render-funnel

--- a/test/metabase/pulse/render/body_test.clj
+++ b/test/metabase/pulse/render/body_test.clj
@@ -470,6 +470,21 @@
           {:cols default-columns
            :rows [[10.0 1] [11.0 2] [nil 20] [1.25 nil]]})))))
 
+(defn- render-funnel [results]
+  (body/render :funnel :inline pacific-tz render.tu/test-card results))
+
+(deftest render-funnel
+  (testing "Test that we can render a funnel with all valid values"
+    (is (has-inline-image?
+         (render-funnel
+          {:cols default-columns
+           :rows [[10.0 1] [5.0 10] [2.50 20] [1.25 30]]}))))
+  (testing "Test that we can have some nil values stuck everywhere"
+    (is (has-inline-image?
+         (render-funnel
+          {:cols default-columns
+           :rows [[nil 1] [11.0 nil] [nil nil] [2.50 20] [1.25 30]]})))))
+
 (deftest render-categorical-donut-test
   (let [columns [{:name          "category",
                   :display_name  "Category",

--- a/test/metabase/pulse/render_test.clj
+++ b/test/metabase/pulse/render_test.clj
@@ -52,6 +52,12 @@
                                                  {:base_type :type/Number}]
                                           :rows [["A" 2]]})))
 
+  (is (= :funnel
+         (render/detect-pulse-chart-type {:display :funnel}
+                                         {:cols [{:base_type :type/Text}
+                                                 {:base_type :type/Number}]
+                                          :rows [["A" 2]]})))
+
   ;; timeseries line chart
   (is (= :sparkline
          (render/detect-pulse-chart-type {:display :line}


### PR DESCRIPTION
Funnel static viz BE bits. Pursuant to #18676. This would mean that you would be able to see funnel static viz on pulses, dashboard subs, etc etc.

FE bits already landed so this should enable the thing.