### PR TITLE
Fix google-api-client version from google driver

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -736,6 +736,9 @@ jobs:
       extra-env:
         type: string
         default: ""
+      test-args:
+        type: string
+        default: ""
     executor: << parameters.e >>
     steps:
       - attach-workspace
@@ -749,7 +752,9 @@ jobs:
                 name: Test << parameters.driver >> driver << parameters.description >>
                 environment:
                   DRIVERS: << parameters.driver >>
-                command: << parameters.extra-env >> clojure -X:dev:ci:ee:ee-dev:drivers:drivers-dev:test
+                command: >
+                  << parameters.extra-env >> clojure -X:dev:ci:ee:ee-dev:drivers:drivers-dev:test
+                  << parameters.test-args >>
                 no_output_timeout: << parameters.timeout >>
             - store_test_results:
                 path: /home/circleci/metabase/metabase/target/junit
@@ -1097,6 +1102,13 @@ workflows:
           requires:
             - be-tests-ee
           driver: bigquery-cloud-sdk
+
+      - test-driver:
+          name: be-google-related-drivers-classpath-test
+          requires:
+            - be-tests-ee
+          driver: bigquery,bigquery-cloud-sdk,googleanalytics
+          test-args: :only [metabase.query-processor-test.expressions-test metabase.driver.google-test]
 
       - test-driver:
           name: be-tests-druid-ee

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1108,7 +1108,7 @@ workflows:
           requires:
             - be-tests-ee
           driver: bigquery,bigquery-cloud-sdk,googleanalytics
-          test-args: :only [metabase.query-processor-test.expressions-test metabase.driver.google-test]
+          test-args: :only "[metabase.query-processor-test.expressions-test metabase.driver.google-test]"
 
       - test-driver:
           name: be-tests-druid-ee

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1107,7 +1107,7 @@ workflows:
           name: be-google-related-drivers-classpath-test
           requires:
             - be-tests-ee
-          driver: google,googleanalytics,bigquery,bigquery-cloud-sdk
+          driver: googleanalytics,bigquery,bigquery-cloud-sdk
           test-args: >-
             :only "[metabase.query-processor-test.expressions-test metabase.driver.google-test
                     metabase.driver.googleanalytics-test]"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1107,8 +1107,10 @@ workflows:
           name: be-google-related-drivers-classpath-test
           requires:
             - be-tests-ee
-          driver: bigquery,bigquery-cloud-sdk,googleanalytics
-          test-args: :only "[metabase.query-processor-test.expressions-test metabase.driver.google-test]"
+          driver: google,googleanalytics,bigquery,bigquery-cloud-sdk
+          test-args: >-
+            :only "[metabase.query-processor-test.expressions-test metabase.driver.google-test
+                    metabase.driver.googleanalytics-test]"
 
       - test-driver:
           name: be-tests-druid-ee

--- a/modules/drivers/google/deps.edn
+++ b/modules/drivers/google/deps.edn
@@ -2,4 +2,6 @@
  ["src" "resources"]
 
  :deps
- {com.google.api-client/google-api-client {:mvn/version "1.30.7"}}}
+ ;; ensure the version of google-http-client transitively depended on here matches that of bigquery-cloud-sdk
+ ;; (which, at the moment, is 1.39.2)
+ {com.google.api-client/google-api-client {:mvn/version "1.32.1"}}}

--- a/modules/drivers/google/deps.edn
+++ b/modules/drivers/google/deps.edn
@@ -4,4 +4,8 @@
  :deps
  ;; ensure the version of google-http-client transitively depended on here matches that of bigquery-cloud-sdk
  ;; (which, at the moment, is 1.39.2)
- {com.google.api-client/google-api-client {:mvn/version "1.32.1"}}}
+ {com.google.api-client/google-api-client {:mvn/version "1.32.1"}
+  ;; 2.12.3 is the version used by bigquery-cloud-sdk (transitively)
+  ;; for some reason, Google stopped depending on Jackson from google-api-client somewhere between 1.30.7 and 1.32.1
+  ;; so we must explicitly bring it in because the google driver uses it directly
+  com.fasterxml.jackson.core/jackson-core {:mvn/version "2.12.3"}}}

--- a/modules/drivers/google/deps.edn
+++ b/modules/drivers/google/deps.edn
@@ -5,7 +5,8 @@
  ;; ensure the version of google-http-client transitively depended on here matches that of bigquery-cloud-sdk
  ;; (which, at the moment, is 1.39.2)
  {com.google.api-client/google-api-client {:mvn/version "1.32.1"}
-  ;; 2.12.3 is the version used by bigquery-cloud-sdk (transitively)
-  ;; for some reason, Google stopped depending on Jackson from google-api-client somewhere between 1.30.7 and 1.32.1
-  ;; so we must explicitly bring it in because the google driver uses it directly
-  com.fasterxml.jackson.core/jackson-core {:mvn/version "2.12.3"}}}
+  ;; for some reason, Google stopped depending on google-http-client-jackson2 from google-api-client somewhere between
+  ;; 1.30.7 and 1.32.1, so we must explicitly bring it in because the google driver uses it directly
+  ;; this version is closest to depending on Jackson 2.12.3, which is the version transitively depended on by
+  ;; bigquery-cloud-sdk
+  com.google.http-client/google-http-client-jackson2 {:mvn/version "1.39.2-sp.1"}}}


### PR DESCRIPTION
Update google-api-client version 1.30.7 -> 1.32.1, so that google-http-client ends up as 1.39.2 to match the other drivers
