### PR TITLE
A truststore is still a keystore

### DIFF
--- a/modules/drivers/oracle/resources-ee/metabase-plugin.yaml
+++ b/modules/drivers/oracle/resources-ee/metabase-plugin.yaml
@@ -48,7 +48,7 @@ driver:
     - name: ssl-truststore
       display-name: Truststore
       type: secret
-      secret-kind: truststore
+      secret-kind: keystore
       placeholder: /path/to/truststore.jks
       visible-if:
         ssl-use-truststore: true


### PR DESCRIPTION
The secret expansion logic doesn't understand `secret-kind: truststore`.  In any case, a truststore is still a keystore (physically), just with different semantics.