### PR TITLE
Fix LDAP port validation and add LDAP API tests

### DIFF
--- a/src/metabase/api/ldap.clj
+++ b/src/metabase/api/ldap.clj
@@ -90,10 +90,13 @@
   [:as {settings :body}]
   {settings su/Map}
   (api/check-superuser)
-  (let [ldap-settings (select-keys settings (keys mb-settings->ldap-details))
-        ldap-details  (-> (set/rename-keys ldap-settings mb-settings->ldap-details)
-                          (assoc :port (when-let [^String ldap-port (not-empty (:ldap-port settings))]
-                                         (Long/parseLong ldap-port))))
+  (def my-settings settings)
+  (comment (clojure.pprint/pprint my-settings))
+  (let [ldap-settings (-> settings
+                          (select-keys (keys mb-settings->ldap-details))
+                          (assoc :ldap-port (when-let [^String ldap-port (not-empty (str (:ldap-port settings)))]
+                                              (Long/parseLong ldap-port))))
+        ldap-details  (set/rename-keys ldap-settings mb-settings->ldap-details)
         results       (if-not (:ldap-enabled settings)
                         ;; when disabled just respond with a success message
                         {:status :SUCCESS}

--- a/src/metabase/api/ldap.clj
+++ b/src/metabase/api/ldap.clj
@@ -90,8 +90,6 @@
   [:as {settings :body}]
   {settings su/Map}
   (api/check-superuser)
-  (def my-settings settings)
-  (comment (clojure.pprint/pprint my-settings))
   (let [ldap-settings (-> settings
                           (select-keys (keys mb-settings->ldap-details))
                           (assoc :ldap-port (when-let [^String ldap-port (not-empty (str (:ldap-port settings)))]

--- a/test/metabase/api/ldap_test.clj
+++ b/test/metabase/api/ldap_test.clj
@@ -1,0 +1,38 @@
+(ns metabase.api.ldap-test
+  (:require [clojure.test :refer :all]
+            [metabase.api.ldap :as ldap-api]
+            [metabase.test :as mt]
+            [metabase.test.integrations.ldap :as ldap.test]
+            [clojure.set :as set]
+            [metabase.integrations.ldap :as ldap]))
+
+(ldap.test/with-ldap-server
+  (set/rename-keys (ldap.test/get-ldap-details)
+                   (set/map-invert @#'ldap-api/mb-settings->ldap-details)))
+
+(deftest ldap-settings-test
+  (testing "PUT /api/ldap/settings"
+    (ldap.test/with-ldap-server
+      (let [ldap-test-details (-> (ldap.test/get-ldap-details)
+                                  (set/rename-keys (set/map-invert @#'ldap-api/mb-settings->ldap-details))
+                                  (assoc :ldap-enabled true))]
+        (testing "Valid LDAP settings can be saved via an API call"
+          (mt/user-http-request :crowberto :put 200 "ldap/settings" ldap-test-details))
+
+        (testing "Invalid LDAP settings return a server error"
+          (mt/user-http-request :crowberto :put 500 "ldap/settings"
+                                (assoc ldap-test-details :ldap-password "wrong-password")))
+
+        (testing "Invalid LDAP settings can be saved if LDAP is disabled"
+          (mt/user-http-request :crowberto :put 200 "ldap/settings"
+                                (assoc ldap-test-details :ldap-password "wrong-password" :ldap-enabled false)))
+
+        (testing "Valid LDAP settings can still be saved if port is a integer (#18936)"
+          (mt/user-http-request :crowberto :put 200 "ldap/settings"
+                                (assoc ldap-test-details
+                                       :ldap-port (Integer. (ldap.test/get-ldap-port)))))
+
+        (testing "LDAP port is saved as default value if passed as an empty string (#18936)"
+          (mt/user-http-request :crowberto :put 200 "ldap/settings"
+                                (assoc ldap-test-details :ldap-port "" :ldap-enabled false))
+          (is (= 389 (ldap/ldap-port))))))))

--- a/test/metabase/api/ldap_test.clj
+++ b/test/metabase/api/ldap_test.clj
@@ -1,14 +1,10 @@
 (ns metabase.api.ldap-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.set :as set]
+            [clojure.test :refer :all]
             [metabase.api.ldap :as ldap-api]
+            [metabase.integrations.ldap :as ldap]
             [metabase.test :as mt]
-            [metabase.test.integrations.ldap :as ldap.test]
-            [clojure.set :as set]
-            [metabase.integrations.ldap :as ldap]))
-
-(ldap.test/with-ldap-server
-  (set/rename-keys (ldap.test/get-ldap-details)
-                   (set/map-invert @#'ldap-api/mb-settings->ldap-details)))
+            [metabase.test.integrations.ldap :as ldap.test]))
 
 (deftest ldap-settings-test
   (testing "PUT /api/ldap/settings"

--- a/test/metabase/integrations/ldap_test.clj
+++ b/test/metabase/integrations/ldap_test.clj
@@ -98,26 +98,26 @@
                 :last-name  "Miller"
                 :email      "jane.miller@metabase.com"
                 :groups     []}
-               (ldap/find-user "jane.miller@metabase.com")))
+               (ldap/find-user "jane.miller@metabase.com")))))
 
     ;; Test group lookups for directory servers that use the memberOf attribute overlay, such as Active Directory
-       (ldap.test/with-active-directory-ldap-server
-         (testing "find user with one group using memberOf attribute"
-           (is (= {:dn         "cn=John Smith,ou=People,dc=metabase,dc=com"
-                   :first-name "John"
-                   :last-name  "Smith"
-                   :email      "John.Smith@metabase.com"
-                   :groups     ["cn=Accounting,ou=Groups,dc=metabase,dc=com"]}
-                  (ldap/find-user "jsmith1"))))
+    (ldap.test/with-active-directory-ldap-server
+      (testing "find user with one group using memberOf attribute"
+        (is (= {:dn         "cn=John Smith,ou=People,dc=metabase,dc=com"
+                :first-name "John"
+                :last-name  "Smith"
+                :email      "John.Smith@metabase.com"
+                :groups     ["cn=Accounting,ou=Groups,dc=metabase,dc=com"]}
+               (ldap/find-user "jsmith1"))))
 
-         (testing "find user with two groups using memberOf attribute"
-           (is (= {:dn         "cn=Sally Brown,ou=People,dc=metabase,dc=com"
-                   :first-name "Sally"
-                   :last-name  "Brown"
-                   :email      "sally.brown@metabase.com"
-                   :groups     ["cn=Accounting,ou=Groups,dc=metabase,dc=com",
-                                "cn=Engineering,ou=Groups,dc=metabase,dc=com"]}
-                  (ldap/find-user "sbrown20")))))))))
+      (testing "find user with two groups using memberOf attribute"
+        (is (= {:dn         "cn=Sally Brown,ou=People,dc=metabase,dc=com"
+                :first-name "Sally"
+                :last-name  "Brown"
+                :email      "sally.brown@metabase.com"
+                :groups     ["cn=Accounting,ou=Groups,dc=metabase,dc=com",
+                             "cn=Engineering,ou=Groups,dc=metabase,dc=com"]}
+               (ldap/find-user "sbrown20")))))))
 
 (deftest fetch-or-create-user-test
   ;; there are EE-specific versions of this test in `metabase-enterprise.enhancements.integrations.ldap-test`

--- a/test/metabase/integrations/ldap_test.clj
+++ b/test/metabase/integrations/ldap_test.clj
@@ -9,15 +9,6 @@
             [toucan.db :as db])
   (:import com.unboundid.ldap.sdk.LDAPConnectionPool))
 
-(defn- get-ldap-details []
-  {:host       "localhost"
-   :port       (ldap.test/get-ldap-port)
-   :bind-dn    "cn=Directory Manager"
-   :password   "password"
-   :security   :none
-   :user-base  "dc=metabase,dc=com"
-   :group-base "dc=metabase,dc=com"})
-
 ;; See test_resources/ldap.ldif for fixtures
 
 ;; The connection test should pass with valid settings
@@ -26,24 +17,24 @@
     (testing "anonymous binds"
       (testing "successfully connect to IPv4 host"
         (is (= {:status :SUCCESS}
-               (ldap/test-ldap-connection (get-ldap-details))))))
+               (ldap/test-ldap-connection (ldap.test/get-ldap-details))))))
 
     (testing "invalid user search base"
       (is (= :ERROR
-             (:status (ldap/test-ldap-connection (assoc (get-ldap-details)
+             (:status (ldap/test-ldap-connection (assoc (ldap.test/get-ldap-details)
                                                         :user-base "dc=example,dc=com"))))))
 
     (testing "invalid group search base"
       (is (= :ERROR
-             (:status (ldap/test-ldap-connection (assoc (get-ldap-details) :group-base "dc=example,dc=com"))))))
+             (:status (ldap/test-ldap-connection (assoc (ldap.test/get-ldap-details) :group-base "dc=example,dc=com"))))))
 
     (testing "invalid bind DN"
       (is (= :ERROR
-             (:status (ldap/test-ldap-connection (assoc (get-ldap-details) :bind-dn "cn=Not Directory Manager"))))))
+             (:status (ldap/test-ldap-connection (assoc (ldap.test/get-ldap-details) :bind-dn "cn=Not Directory Manager"))))))
 
     (testing "invalid bind password"
       (is (= :ERROR
-             (:status (ldap/test-ldap-connection (assoc (get-ldap-details) :password "wrong"))))))
+             (:status (ldap/test-ldap-connection (assoc (ldap.test/get-ldap-details) :password "wrong"))))))
 
     (testing "basic get-connection works, will throw otherwise"
       (is (= nil
@@ -110,23 +101,23 @@
                (ldap/find-user "jane.miller@metabase.com")))
 
     ;; Test group lookups for directory servers that use the memberOf attribute overlay, such as Active Directory
-    (ldap.test/with-active-directory-ldap-server
-      (testing "find user with one group using memberOf attribute"
-        (is (= {:dn         "cn=John Smith,ou=People,dc=metabase,dc=com"
-                :first-name "John"
-                :last-name  "Smith"
-                :email      "John.Smith@metabase.com"
-                :groups     ["cn=Accounting,ou=Groups,dc=metabase,dc=com"]}
-               (ldap/find-user "jsmith1"))))
+       (ldap.test/with-active-directory-ldap-server
+         (testing "find user with one group using memberOf attribute"
+           (is (= {:dn         "cn=John Smith,ou=People,dc=metabase,dc=com"
+                   :first-name "John"
+                   :last-name  "Smith"
+                   :email      "John.Smith@metabase.com"
+                   :groups     ["cn=Accounting,ou=Groups,dc=metabase,dc=com"]}
+                  (ldap/find-user "jsmith1"))))
 
-      (testing "find user with two groups using memberOf attribute"
-        (is (= {:dn         "cn=Sally Brown,ou=People,dc=metabase,dc=com"
-                :first-name "Sally"
-                :last-name  "Brown"
-                :email      "sally.brown@metabase.com"
-                :groups     ["cn=Accounting,ou=Groups,dc=metabase,dc=com",
-                             "cn=Engineering,ou=Groups,dc=metabase,dc=com"]}
-               (ldap/find-user "sbrown20")))))))))
+         (testing "find user with two groups using memberOf attribute"
+           (is (= {:dn         "cn=Sally Brown,ou=People,dc=metabase,dc=com"
+                   :first-name "Sally"
+                   :last-name  "Brown"
+                   :email      "sally.brown@metabase.com"
+                   :groups     ["cn=Accounting,ou=Groups,dc=metabase,dc=com",
+                                "cn=Engineering,ou=Groups,dc=metabase,dc=com"]}
+                  (ldap/find-user "sbrown20")))))))))
 
 (deftest fetch-or-create-user-test
   ;; there are EE-specific versions of this test in `metabase-enterprise.enhancements.integrations.ldap-test`
@@ -181,7 +172,7 @@
 (deftest ipv6-test
   (testing "successfully connect to IPv6 host"
     (let [actual (ldap.test/with-ldap-server
-                   (ldap/test-ldap-connection (assoc (get-ldap-details)
+                   (ldap/test-ldap-connection (assoc (ldap.test/get-ldap-details)
                                                      :host "[::1]")))]
       (if (= (:status actual) :ERROR)
         (is (re-matches #"An error occurred while attempting to connect to server \[::1].*" (:message actual)))

--- a/test/metabase/test/integrations/ldap.clj
+++ b/test/metabase/test/integrations/ldap.clj
@@ -33,6 +33,15 @@
   []
   (.getListenPort *ldap-server*))
 
+(defn get-ldap-details []
+  {:host       "localhost"
+   :port       (get-ldap-port)
+   :bind-dn    "cn=Directory Manager"
+   :password   "password"
+   :security   :none
+   :user-base  "dc=metabase,dc=com"
+   :group-base "dc=metabase,dc=com"})
+
 (defn get-default-schema
   "Get the default schema for the directory server."
   []


### PR DESCRIPTION
* Calls `str` on the port value passed in the request body before calling `not-empty`. This _should_ fix the main errors reported in #18936, which seem to have been caused by the request body containing int port values rather than strings. But I'm still not sure how this comes about, or how to reproduce.. 
* Applies port parsing logic to `ldap-settings` rather than just `ldap-details` which should fix the other error reported by @flamber [here](https://github.com/metabase/metabase/issues/18936#issuecomment-971688930). This is because an empty string in the port field (which is passed by the frontend in some cases) needs to be converted to `nil` before being written to the setting. But this conversion was only happening in the `ldap-details` map, not the `ldap-settings` map, which is the one used to update the setting values.
* Adds a basic test suite for the LDAP API namespace, including tests for these two cases.

Resolves #18936