### PR TITLE
Select no columns in the custom question mode

### DIFF
--- a/frontend/src/metabase/query_builder/components/notebook/FieldsPickerIcon.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/FieldsPickerIcon.jsx
@@ -25,7 +25,7 @@ export function FieldsPickerIcon({ isTriggeredComponentOpen }) {
       tooltip={<span>{t`Pick columns`}</span>}
       isEnabled={!isTriggeredComponentOpen}
     >
-      <FieldPickerContentContainer>
+      <FieldPickerContentContainer data-testid="fields-picker">
         <StyledIcon name="table" size={14} />
       </FieldPickerContentContainer>
     </Tooltip>

--- a/frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx
@@ -99,7 +99,7 @@ const DataFieldsPicker = ({ query, updateQuery, ...props }) => {
       )
       .update(updateQuery);
 
-  const hasOneColumnSelected = selected.size === 1;
+  const hasOneColumnSelected = fields.length === 1;
 
   return (
     <FieldsPicker

--- a/frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx
@@ -79,6 +79,28 @@ const DataFieldsPicker = ({ query, updateQuery, ...props }) => {
   const selectedDimensions = query.columnDimensions();
   const selected = new Set(selectedDimensions.map(d => d.key()));
   const fields = query.fields();
+
+  const handleSelectNone = () => {
+    query.setFields([dimensions[0].mbql()]).update(updateQuery);
+  };
+
+  const handleToggleDimension = dimension =>
+    query
+      .setFields(
+        dimensions
+          .filter(d => {
+            if (d === dimension) {
+              return !selected.has(d.key());
+            } else {
+              return selected.has(d.key());
+            }
+          })
+          .map(d => d.mbql()),
+      )
+      .update(updateQuery);
+
+  const hasOneColumnSelected = selected.size === 1;
+
   return (
     <FieldsPicker
       {...props}
@@ -86,21 +108,9 @@ const DataFieldsPicker = ({ query, updateQuery, ...props }) => {
       selectedDimensions={selectedDimensions}
       isAll={!fields || fields.length === 0}
       onSelectAll={() => query.clearFields().update(updateQuery)}
-      onToggleDimension={(dimension, enable) => {
-        query
-          .setFields(
-            dimensions
-              .filter(d => {
-                if (d === dimension) {
-                  return !selected.has(d.key());
-                } else {
-                  return selected.has(d.key());
-                }
-              })
-              .map(d => d.mbql()),
-          )
-          .update(updateQuery);
-      }}
+      onSelectNone={handleSelectNone}
+      disableSelected={hasOneColumnSelected}
+      onToggleDimension={handleToggleDimension}
     />
   );
 };

--- a/frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx
@@ -17,6 +17,7 @@ export default function FieldsPicker({
   onSelectNone,
   onToggleDimension,
   triggerElement = t`Columns`,
+  disableSelected,
   ...props
 }) {
   const selected = new Set(selectedDimensions.map(d => d.key()));
@@ -49,6 +50,8 @@ export default function FieldsPicker({
         {dimensions.map(dimension => (
           <li key={dimension.key()} className="px1 pb1 flex align-center">
             <CheckBox
+              data-testid={`field-${dimension.displayName()}`}
+              disabled={disableSelected && selected.has(dimension.key())}
               checked={selected.has(dimension.key())}
               label={dimension.displayName()}
               onChange={() => {

--- a/frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx
@@ -32,7 +32,7 @@ export default function FieldsPicker({
         {(onSelectAll || onSelectNone) && (
           <li className="px1 pb1 flex align-center border-bottom mb1">
             <StackedCheckBox
-              label={isAll && onSelectNone ? t`Select None` : t`Select All`}
+              label={isAll && onSelectNone ? t`Select none` : t`Select all`}
               checked={isAll}
               indeterminate={!isAll && !isNone}
               disabled={isAll && !onSelectNone}

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -907,6 +907,30 @@ function joinTwoSavedQuestions() {
       cy.url().should("contain", "/notebook");
     });
   });
+
+  // intentional simplification of "Select none" to quickly
+  // fix users' pain caused by the inability to unselect all columns
+  it("select no columns select the first one", () => {
+    cy.visit("/question/new");
+    cy.contains("Custom question").click();
+    cy.contains("Sample Dataset").click();
+    cy.contains("Orders").click();
+    cy.findByTestId("fields-picker").click();
+
+    cy.findByText("Select None").click();
+    cy.findByTestId("field-ID").should("be.disabled");
+
+    cy.findByTestId("field-Tax").click();
+
+    cy.findByTestId("field-ID")
+      .should("be.enabled")
+      .click();
+
+    visualize();
+
+    cy.findByText("Tax");
+    cy.findByText("ID").should("not.exist");
+  });
 }
 
 function addSimpleCustomColumn(name) {


### PR DESCRIPTION
<img width="319" alt="Screen Shot 2021-12-07 at 22 58 51" src="https://user-images.githubusercontent.com/14301985/145097607-65fb3d48-e954-480c-b069-47d03c28f800.png">

Allow unticking all columns except the first one by clicking on "Select None" in the custom question query builder.

### How to verify
- New question -> Custom question
- Select any table, open column picker
- Click "Select none"
- Ensure it unselected all the columns except the first one which has become disabled
- Select any other column
- Ensure you can untick the first column
- Ensure clicking on "Visualize" shows the correct set of columns
