### PR TITLE
Add dataset metadata strength indicator

### DIFF
--- a/frontend/src/metabase/components/ProgressBar.jsx
+++ b/frontend/src/metabase/components/ProgressBar.jsx
@@ -1,14 +1,15 @@
 import React, { Component } from "react";
+import PropTypes from "prop-types";
 import styled from "styled-components";
 
 import { color as c } from "metabase/lib/colors";
 
-type Props = {
-  percentage: number,
-  animated?: boolean,
-  color?: string,
-  height?: number | string,
-  className?: String,
+const propTypes = {
+  percentage: PropTypes.number.isRequired,
+  animated: PropTypes.bool,
+  color: PropTypes.string,
+  height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  className: PropTypes.string,
 };
 
 const ProgressWrapper = styled.div`
@@ -44,8 +45,6 @@ const Progress = styled.div`
 
 // @Question - why is this separate from our progress Viz type?
 export default class ProgressBar extends Component {
-  props: Props;
-
   static defaultProps = {
     animated: false,
     height: 10,
@@ -71,3 +70,4 @@ export default class ProgressBar extends Component {
 }
 
 ProgressBar.Progress = Progress;
+ProgressBar.propTypes = propTypes;

--- a/frontend/src/metabase/components/ProgressBar.jsx
+++ b/frontend/src/metabase/components/ProgressBar.jsx
@@ -7,13 +7,13 @@ type Props = {
   percentage: number,
   animated: boolean,
   color: string,
-  height: number,
+  height: number | string,
 };
 
 const ProgressWrapper = styled.div`
   position: relative;
   border: 1px solid ${props => props.color};
-  height: 10px;
+  height: ${props => props.height};
   border-radius: 99px;
 `;
 
@@ -51,12 +51,12 @@ export default class ProgressBar extends Component {
   };
 
   render() {
-    const { percentage, animated, color = c("brand") } = this.props;
+    const { percentage, height, animated, color = c("brand") } = this.props;
 
     const width = percentage * 100;
 
     return (
-      <ProgressWrapper color={color}>
+      <ProgressWrapper color={color} height={height}>
         <Progress width={width} animated={animated} color={color} />
       </ProgressWrapper>
     );

--- a/frontend/src/metabase/components/ProgressBar.jsx
+++ b/frontend/src/metabase/components/ProgressBar.jsx
@@ -5,9 +5,9 @@ import { color as c } from "metabase/lib/colors";
 
 type Props = {
   percentage: number,
-  animated: boolean,
-  color: string,
-  height: number | string,
+  animated?: boolean,
+  color?: string,
+  height?: number | string,
 };
 
 const ProgressWrapper = styled.div`

--- a/frontend/src/metabase/components/ProgressBar.jsx
+++ b/frontend/src/metabase/components/ProgressBar.jsx
@@ -71,5 +71,4 @@ export default class ProgressBar extends Component {
   }
 }
 
-ProgressBar.Progress = Progress;
 ProgressBar.propTypes = propTypes;

--- a/frontend/src/metabase/components/ProgressBar.jsx
+++ b/frontend/src/metabase/components/ProgressBar.jsx
@@ -8,6 +8,7 @@ type Props = {
   animated?: boolean,
   color?: string,
   height?: number | string,
+  className?: String,
 };
 
 const ProgressWrapper = styled.div`
@@ -51,14 +52,22 @@ export default class ProgressBar extends Component {
   };
 
   render() {
-    const { percentage, height, animated, color = c("brand") } = this.props;
+    const {
+      percentage,
+      height,
+      animated,
+      color = c("brand"),
+      className,
+    } = this.props;
 
     const width = percentage * 100;
 
     return (
-      <ProgressWrapper color={color} height={height}>
+      <ProgressWrapper color={color} height={height} className={className}>
         <Progress width={width} animated={animated} color={color} />
       </ProgressWrapper>
     );
   }
 }
+
+ProgressBar.Progress = Progress;

--- a/frontend/src/metabase/components/ProgressBar.jsx
+++ b/frontend/src/metabase/components/ProgressBar.jsx
@@ -17,6 +17,7 @@ const ProgressWrapper = styled.div`
   border: 1px solid ${props => props.color};
   height: ${props => props.height};
   border-radius: 99px;
+  transition: border-color 0.3s;
 `;
 
 const Progress = styled.div`
@@ -30,6 +31,7 @@ const Progress = styled.div`
       border-top-left-radius: 0;
       border-bottom-left-radius: 0;
       width: ${props => props.width}%;
+      transition: background-color 0.3s;
       ":before": {
         display: ${props => (props.animated ? "block" : "none")};
         position: absolute;

--- a/frontend/src/metabase/components/Tooltip/Tooltip.tsx
+++ b/frontend/src/metabase/components/Tooltip/Tooltip.tsx
@@ -19,7 +19,7 @@ Tooltip.propTypes = {
 
 interface TooltipProps
   extends Partial<
-    Pick<Tippy.TippyProps, "reference" | "placement" | "maxWidth">
+    Pick<Tippy.TippyProps, "delay" | "reference" | "placement" | "maxWidth">
   > {
   tooltip?: React.ReactNode;
   children?: React.ReactNode;
@@ -58,6 +58,7 @@ function getTargetProps(
 function Tooltip({
   tooltip,
   children,
+  delay,
   reference,
   placement,
   isEnabled,
@@ -80,6 +81,7 @@ function Tooltip({
         maxWidth={maxWidth}
         reference={reference}
         duration={animationDuration}
+        delay={delay}
         placement={placement}
         {...targetProps}
       />

--- a/frontend/src/metabase/hooks/use-hover.ts
+++ b/frontend/src/metabase/hooks/use-hover.ts
@@ -1,0 +1,23 @@
+import React, { useEffect, useCallback, useState, useRef } from "react";
+
+export function useHover(): [React.RefObject<HTMLElement>, boolean] {
+  const [isHovered, setHovered] = useState(false);
+  const ref = useRef<HTMLElement>(null);
+
+  const onMouseOver = useCallback(() => setHovered(true), []);
+  const onMouseOut = useCallback(() => setHovered(false), []);
+
+  useEffect(() => {
+    const node = ref.current;
+    if (node) {
+      node.addEventListener("mouseover", onMouseOver);
+      node.addEventListener("mouseout", onMouseOut);
+      return () => {
+        node.removeEventListener("mouseover", onMouseOver);
+        node.removeEventListener("mouseout", onMouseOut);
+      };
+    }
+  }, [onMouseOut, onMouseOver]);
+
+  return [ref, isHovered];
+}

--- a/frontend/src/metabase/lib/data-modeling/metadata.ts
+++ b/frontend/src/metabase/lib/data-modeling/metadata.ts
@@ -63,5 +63,5 @@ export function getDatasetMetadataCompletenessPercentage(
     .reduce((sum, fieldPoints) => sum + fieldPoints, 0);
 
   const percent = points / MAX_POINTS;
-  return Number(percent.toFixed(2));
+  return Math.round(percent * 100) / 100;
 }

--- a/frontend/src/metabase/lib/data-modeling/metadata.ts
+++ b/frontend/src/metabase/lib/data-modeling/metadata.ts
@@ -1,0 +1,67 @@
+export type FieldMetadata = {
+  id?: number;
+  name: string;
+  description?: string | null;
+  semantic_type?: string | null;
+};
+
+const MAX_FIELD_SCORE = 3;
+
+/**
+ * Calculates field metadata completeness score for individual column
+ *
+ * Score is an int value between 0 and 3
+ * (where 0 is fully incomplete metadata and 1 is fully complete one)
+ *
+ * Each score "point" is granted when one of the requirements is met
+ *
+ * 1. No "→" and "_" characters in column name
+ * 2. Field description is provided
+ * 3. Field semantic type is set
+ *
+ * @param {FieldMetadata} field
+ * @returns {number} — int between 0 and 3
+ */
+function getFieldMetadataScore({
+  name,
+  description,
+  semantic_type,
+}: FieldMetadata): number {
+  let score = 0;
+
+  const isNameDirty = name.includes("→") || name.includes("_");
+
+  if (!isNameDirty) {
+    score++;
+  }
+  if (description) {
+    score++;
+  }
+  if (semantic_type) {
+    score++;
+  }
+
+  return score;
+}
+
+/**
+ * Calculates overall metadata completeness percent among given a list of field metadata
+ *
+ * @param {FieldMetadata[]}
+ * @returns {number} — percent value between 0 and 1
+ */
+export function getDatasetMetadataCompletenessPercentage(
+  fieldsMetadata: FieldMetadata[],
+): number {
+  if (!Array.isArray(fieldsMetadata) || fieldsMetadata.length === 0) {
+    return 0;
+  }
+
+  const MAX_POINTS = MAX_FIELD_SCORE * fieldsMetadata.length;
+  const points = fieldsMetadata
+    .map(getFieldMetadataScore)
+    .reduce((sum, fieldPoints) => sum + fieldPoints, 0);
+
+  const percent = points / MAX_POINTS;
+  return Number(percent.toFixed(2));
+}

--- a/frontend/src/metabase/lib/data-modeling/metadata.unit.spec.js
+++ b/frontend/src/metabase/lib/data-modeling/metadata.unit.spec.js
@@ -1,0 +1,54 @@
+import { getDatasetMetadataCompletenessPercentage } from "./metadata";
+
+describe("getDatasetMetadataCompletenessPercentage", () => {
+  it("returns 0 when no field metadata list is empty", () => {
+    expect(getDatasetMetadataCompletenessPercentage([])).toBe(0);
+  });
+
+  it("returns 0 for completely missing metadata", () => {
+    const percent = getDatasetMetadataCompletenessPercentage([
+      { name: "Created_At" },
+      { name: "Products → Category" },
+    ]);
+    expect(percent).toBe(0);
+  });
+
+  it("returns 1 for complete metadata", () => {
+    const percent = getDatasetMetadataCompletenessPercentage([
+      {
+        name: "Created At",
+        description: "Date created",
+        semantic_type: "DateTime",
+      },
+      {
+        name: "Product Category",
+        description: "The name is pretty self-explaining",
+        semantic_type: "String",
+      },
+    ]);
+    expect(percent).toBe(1);
+  });
+
+  it("returns 0.5 for half-complete metadata", () => {
+    const percent = getDatasetMetadataCompletenessPercentage([
+      { name: "Created_At" },
+      {
+        name: "Product Category",
+        description: "The name is pretty self-explaining",
+        semantic_type: "String",
+      },
+    ]);
+    expect(percent).toBe(0.5);
+  });
+
+  it("returns percent value for partially complete metadata", () => {
+    const percent = getDatasetMetadataCompletenessPercentage([
+      { name: "Created_At" },
+      {
+        name: "Product Category",
+        semantic_type: "String",
+      },
+    ]);
+    expect(percent).toBe(0.33);
+  });
+});

--- a/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetManagementSection.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetManagementSection.jsx
@@ -43,6 +43,7 @@ function DatasetManagementSection({
           icon="notebook"
           onClick={onEditQueryDefinitionClick}
         >{t`Edit query definition`}</Button>
+        <Button icon="label">{t`Edit metadata`}</Button>
         <Button
           icon="dataset_framed"
           onClick={turnDatasetIntoQuestion}

--- a/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetManagementSection.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetManagementSection.jsx
@@ -48,7 +48,7 @@ function DatasetManagementSection({
           onClick={onEditQueryDefinitionClick}
         >{t`Edit query definition`}</Button>
         <Row>
-          <Button icon="label">{t`Edit metadata`}</Button>
+          <Button icon="label">{t`Customize metadata`}</Button>
           <MetadataIndicatorContainer>
             <DatasetMetadataStrengthIndicator dataset={dataset} />
           </MetadataIndicatorContainer>

--- a/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetManagementSection.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetManagementSection.jsx
@@ -10,8 +10,11 @@ import {
   turnDatasetIntoQuestion,
 } from "metabase/query_builder/actions";
 
+import DatasetMetadataStrengthIndicator from "./DatasetMetadataStrengthIndicator";
 import {
   Button,
+  MetadataIndicatorContainer,
+  Row,
   SectionContent,
   SectionTitle,
 } from "./DatasetManagementSection.styled";
@@ -28,6 +31,7 @@ DatasetManagementSection.propTypes = {
 };
 
 function DatasetManagementSection({
+  dataset,
   setQueryBuilderMode,
   turnDatasetIntoQuestion,
 }) {
@@ -43,7 +47,12 @@ function DatasetManagementSection({
           icon="notebook"
           onClick={onEditQueryDefinitionClick}
         >{t`Edit query definition`}</Button>
-        <Button icon="label">{t`Edit metadata`}</Button>
+        <Row>
+          <Button icon="label">{t`Edit metadata`}</Button>
+          <MetadataIndicatorContainer>
+            <DatasetMetadataStrengthIndicator dataset={dataset} />
+          </MetadataIndicatorContainer>
+        </Row>
         <Button
           icon="dataset_framed"
           onClick={turnDatasetIntoQuestion}

--- a/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetManagementSection.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetManagementSection.styled.jsx
@@ -14,6 +14,12 @@ export const SectionContent = styled.div`
   right: 8px;
 `;
 
+export const Row = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
 export const Button = styled(DefaultButton)`
   padding: 8px;
   color: ${color("brand")};
@@ -24,3 +30,8 @@ export const Button = styled(DefaultButton)`
 Button.defaultProps = {
   iconSize: 16,
 };
+
+export const MetadataIndicatorContainer = styled.div`
+  display: flex;
+  flex: 0.4;
+`;

--- a/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/DatasetMetadataStrengthIndicator.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/DatasetMetadataStrengthIndicator.styled.tsx
@@ -27,3 +27,13 @@ export const Root = styled.div`
     }
   }
 `;
+
+export const TooltipParagraph = styled.p`
+  margin: 0;
+`;
+
+export const TooltipContent = styled.div`
+  ${TooltipParagraph}:last-child {
+    margin-top: 1em;
+  }
+`;

--- a/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/DatasetMetadataStrengthIndicator.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/DatasetMetadataStrengthIndicator.styled.tsx
@@ -1,4 +1,38 @@
 import styled from "styled-components";
+import ProgressBar from "metabase/components/ProgressBar";
+import { color as c } from "metabase/lib/colors";
+
+function getIndicationColor(percentage: number): string {
+  if (percentage <= 0.5) {
+    return c("danger");
+  }
+  return percentage >= 0.9 ? c("success") : c("warning");
+}
+
+function getDefaultProgressBarColor({
+  percentage,
+}: {
+  percentage: number;
+  color: string;
+}) {
+  const tooIncompleteMetadata = percentage <= 0.5;
+  return tooIncompleteMetadata
+    ? getIndicationColor(percentage)
+    : c("bg-medium");
+}
+
+export const MetadataProgressBar = styled(ProgressBar)<{
+  percentage: number;
+  height: string | number;
+}>`
+  border-color: ${props => getDefaultProgressBarColor(props)};
+  transition: border-color 0.3s;
+
+  ${ProgressBar.Progress} {
+    background-color: ${props => getDefaultProgressBarColor(props)};
+    transition: background-color 0.3s;
+  }
+`;
 
 export const PercentageLabel = styled.span`
   position: absolute;
@@ -7,23 +41,35 @@ export const PercentageLabel = styled.span`
 
   font-size: 0.8rem;
   font-weight: bold;
-  color: ${props => props.color};
+  user-select: none;
 
   opacity: 0;
   transform: translateY(60%);
   transition: all 0.4s;
 `;
 
-export const Root = styled.div`
+export const Root = styled.div<{ percentage: number }>`
   display: flex;
   flex: 1;
   position: relative;
   flex-direction: column;
 
+  ${PercentageLabel} {
+    color: ${props => getIndicationColor(props.percentage)};
+  }
+
   &:hover {
     ${PercentageLabel} {
       opacity: 1;
       transform: translateY(0);
+    }
+
+    ${MetadataProgressBar} {
+      border-color: ${props => getIndicationColor(props.percentage)};
+
+      ${ProgressBar.Progress} {
+        background-color: ${props => getIndicationColor(props.percentage)};
+      }
     }
   }
 `;

--- a/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/DatasetMetadataStrengthIndicator.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/DatasetMetadataStrengthIndicator.styled.tsx
@@ -1,38 +1,5 @@
 import styled from "styled-components";
-import ProgressBar from "metabase/components/ProgressBar";
-import { color as c } from "metabase/lib/colors";
-
-function getIndicationColor(percentage: number): string {
-  if (percentage <= 0.5) {
-    return c("danger");
-  }
-  return percentage >= 0.9 ? c("success") : c("warning");
-}
-
-function getDefaultProgressBarColor({
-  percentage,
-}: {
-  percentage: number;
-  color: string;
-}) {
-  const tooIncompleteMetadata = percentage <= 0.5;
-  return tooIncompleteMetadata
-    ? getIndicationColor(percentage)
-    : c("bg-medium");
-}
-
-export const MetadataProgressBar = styled(ProgressBar)<{
-  percentage: number;
-  height: string | number;
-}>`
-  border-color: ${props => getDefaultProgressBarColor(props)};
-  transition: border-color 0.3s;
-
-  ${ProgressBar.Progress} {
-    background-color: ${props => getDefaultProgressBarColor(props)};
-    transition: background-color 0.3s;
-  }
-`;
+import { forwardRefToInnerRef } from "metabase/styled-components/utils";
 
 export const PercentageLabel = styled.span`
   position: absolute;
@@ -41,6 +8,7 @@ export const PercentageLabel = styled.span`
   left: 50%;
   transform: translate(-50%, 60%);
 
+  color: ${props => props.color};
   font-size: 0.8rem;
   font-weight: bold;
   user-select: none;
@@ -50,31 +18,19 @@ export const PercentageLabel = styled.span`
   transition: all 0.4s;
 `;
 
-export const Root = styled.div<{ percentage: number }>`
+export const Root = forwardRefToInnerRef(styled.div<{ ref?: React.Ref<any> }>`
   display: flex;
   flex: 1;
   position: relative;
   flex-direction: column;
-
-  ${PercentageLabel} {
-    color: ${props => getIndicationColor(props.percentage)};
-  }
 
   &:hover {
     ${PercentageLabel} {
       opacity: 1;
       transform: translate(-50%, 0);
     }
-
-    ${MetadataProgressBar} {
-      border-color: ${props => getIndicationColor(props.percentage)};
-
-      ${ProgressBar.Progress} {
-        background-color: ${props => getIndicationColor(props.percentage)};
-      }
-    }
   }
-`;
+`);
 
 export const TooltipParagraph = styled.p`
   margin: 0;

--- a/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/DatasetMetadataStrengthIndicator.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/DatasetMetadataStrengthIndicator.styled.tsx
@@ -1,0 +1,29 @@
+import styled from "styled-components";
+
+export const PercentageLabel = styled.span`
+  position: absolute;
+  left: 30%;
+  top: -1rem;
+
+  font-size: 0.8rem;
+  font-weight: bold;
+  color: ${props => props.color};
+
+  opacity: 0;
+  transform: translateY(80%);
+  transition: all 0.4s;
+`;
+
+export const Root = styled.div`
+  display: flex;
+  flex: 1;
+  position: relative;
+  flex-direction: column;
+
+  &:hover {
+    ${PercentageLabel} {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+`;

--- a/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/DatasetMetadataStrengthIndicator.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/DatasetMetadataStrengthIndicator.styled.tsx
@@ -36,15 +36,17 @@ export const MetadataProgressBar = styled(ProgressBar)<{
 
 export const PercentageLabel = styled.span`
   position: absolute;
-  left: 35%;
+
   top: -1rem;
+  left: 50%;
+  transform: translate(-50%, 60%);
 
   font-size: 0.8rem;
   font-weight: bold;
   user-select: none;
 
   opacity: 0;
-  transform: translateY(60%);
+
   transition: all 0.4s;
 `;
 
@@ -61,7 +63,7 @@ export const Root = styled.div<{ percentage: number }>`
   &:hover {
     ${PercentageLabel} {
       opacity: 1;
-      transform: translateY(0);
+      transform: translate(-50%, 0);
     }
 
     ${MetadataProgressBar} {

--- a/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/DatasetMetadataStrengthIndicator.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/DatasetMetadataStrengthIndicator.styled.tsx
@@ -2,7 +2,7 @@ import styled from "styled-components";
 
 export const PercentageLabel = styled.span`
   position: absolute;
-  left: 30%;
+  left: 35%;
   top: -1rem;
 
   font-size: 0.8rem;
@@ -10,7 +10,7 @@ export const PercentageLabel = styled.span`
   color: ${props => props.color};
 
   opacity: 0;
-  transform: translateY(80%);
+  transform: translateY(60%);
   transition: all 0.4s;
 `;
 

--- a/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/DatasetMetadataStrengthIndicator.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/DatasetMetadataStrengthIndicator.tsx
@@ -22,7 +22,7 @@ function getTooltipMessage(percentage: number) {
   }
 
   const columnCountDescription =
-    percentage <= 0.5 ? t`Most` : percentage >= 0.9 ? t`Some` : t`Many`;
+    percentage <= 0.5 ? t`Most` : percentage >= 0.8 ? t`Some` : t`Many`;
 
   return (
     <TooltipContent>

--- a/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/DatasetMetadataStrengthIndicator.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/DatasetMetadataStrengthIndicator.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+
+// eslint-disable-next-line import/namespace, import/default, import/no-named-as-default, import/no-named-as-default-member
+import Question from "metabase-lib/lib/Question";
+
+import ProgressBar from "metabase/components/ProgressBar";
+
+import { color } from "metabase/lib/colors";
+import { getDatasetMetadataCompletenessPercentage } from "metabase/lib/data-modeling/metadata";
+
+function getIndicatorColor(percentage: number): string {
+  if (percentage <= 0.5) {
+    return color("danger");
+  }
+  return percentage >= 0.9 ? color("success") : color("warning");
+}
+
+type Props = {
+  dataset: Question;
+};
+
+function DatasetMetadataStrengthIndicator({ dataset }: Props) {
+  const resultMetadata = dataset.getResultMetadata();
+
+  if (resultMetadata?.length === 0) {
+    return null;
+  }
+
+  const percentage = getDatasetMetadataCompletenessPercentage(resultMetadata);
+  const indicationColor = getIndicatorColor(percentage);
+
+  return <ProgressBar percentage={percentage} color={indicationColor} />;
+}
+
+export default DatasetMetadataStrengthIndicator;

--- a/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/DatasetMetadataStrengthIndicator.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/DatasetMetadataStrengthIndicator.tsx
@@ -1,17 +1,32 @@
 import React from "react";
 import { t } from "ttag";
 
+import ProgressBar from "metabase/components/ProgressBar";
 import Tooltip from "metabase/components/Tooltip";
 
-import { getDatasetMetadataCompletenessPercentage } from "metabase/lib/data-modeling/metadata";
+import { color } from "metabase/lib/colors";
+import {
+  FieldMetadata,
+  getDatasetMetadataCompletenessPercentage,
+} from "metabase/lib/data-modeling/metadata";
+import { useHover } from "metabase/hooks/use-hover";
 
 import {
   Root,
   PercentageLabel,
-  MetadataProgressBar,
   TooltipContent,
   TooltipParagraph,
 } from "./DatasetMetadataStrengthIndicator.styled";
+
+function getIndicationColor(percentage: number, isHovered: boolean): string {
+  if (percentage <= 0.5) {
+    return color("danger");
+  }
+  if (!isHovered) {
+    return color("bg-medium");
+  }
+  return percentage >= 0.9 ? color("success") : color("warning");
+}
 
 function getTooltipMessage(percentage: number) {
   if (percentage === 1) {
@@ -46,6 +61,7 @@ type Props = {
 const TOOLTIP_DELAY: [number, null] = [700, null];
 
 function DatasetMetadataStrengthIndicator({ dataset, ...props }: Props) {
+  const [hoverRef, isHovered] = useHover();
   const resultMetadata = dataset.getResultMetadata();
 
   if (!Array.isArray(resultMetadata) || resultMetadata.length === 0) {
@@ -53,16 +69,23 @@ function DatasetMetadataStrengthIndicator({ dataset, ...props }: Props) {
   }
 
   const percentage = getDatasetMetadataCompletenessPercentage(resultMetadata);
+  const indicationColor = getIndicationColor(percentage, isHovered);
 
   return (
-    <Root {...props} percentage={percentage}>
+    <Root {...props} ref={hoverRef}>
       <Tooltip
         tooltip={getTooltipMessage(percentage)}
         delay={TOOLTIP_DELAY}
         placement="bottom"
       >
-        <PercentageLabel>{formatPercentage(percentage)}</PercentageLabel>
-        <MetadataProgressBar percentage={percentage} height="8px" />
+        <PercentageLabel color={indicationColor}>
+          {formatPercentage(percentage)}
+        </PercentageLabel>
+        <ProgressBar
+          percentage={percentage}
+          color={indicationColor}
+          height="8px"
+        />
       </Tooltip>
     </Root>
   );

--- a/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/DatasetMetadataStrengthIndicator.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/DatasetMetadataStrengthIndicator.tsx
@@ -1,9 +1,11 @@
 import React from "react";
+import { t } from "ttag";
 
 // eslint-disable-next-line import/namespace, import/default, import/no-named-as-default, import/no-named-as-default-member
 import Question from "metabase-lib/lib/Question";
 
 import ProgressBar from "metabase/components/ProgressBar";
+import Tooltip from "metabase/components/Tooltip";
 
 import { color } from "metabase/lib/colors";
 import { getDatasetMetadataCompletenessPercentage } from "metabase/lib/data-modeling/metadata";
@@ -11,6 +13,8 @@ import { getDatasetMetadataCompletenessPercentage } from "metabase/lib/data-mode
 import {
   Root,
   PercentageLabel,
+  TooltipContent,
+  TooltipParagraph,
 } from "./DatasetMetadataStrengthIndicator.styled";
 
 function getIndicatorColor(percentage: number): string {
@@ -20,6 +24,26 @@ function getIndicatorColor(percentage: number): string {
   return percentage >= 0.9 ? color("success") : color("warning");
 }
 
+function getTooltipMessage(percentage: number) {
+  if (percentage === 1) {
+    return t`Every column has a type, a description, and a friendly name. Nice!`;
+  }
+
+  const columnCountDescription =
+    percentage <= 0.5 ? t`Most` : percentage >= 0.9 ? t`Some` : t`Many`;
+
+  return (
+    <TooltipContent>
+      <TooltipParagraph>
+        {t`${columnCountDescription} columns are missing a column type, description, or friendly name.`}
+      </TooltipParagraph>
+      <TooltipParagraph>
+        {t`Adding metadata makes it easier for your team to explore this data.`}
+      </TooltipParagraph>
+    </TooltipContent>
+  );
+}
+
 function formatPercentage(percentage: number): string {
   return (percentage * 100).toFixed() + "%";
 }
@@ -27,6 +51,8 @@ function formatPercentage(percentage: number): string {
 type Props = {
   dataset: Question;
 };
+
+const TOOLTIP_DELAY: [number, null] = [500, null];
 
 function DatasetMetadataStrengthIndicator({ dataset }: Props) {
   const resultMetadata = dataset.getResultMetadata();
@@ -40,14 +66,20 @@ function DatasetMetadataStrengthIndicator({ dataset }: Props) {
 
   return (
     <Root>
-      <PercentageLabel color={indicationColor}>
-        {formatPercentage(percentage)}
-      </PercentageLabel>
-      <ProgressBar
-        percentage={percentage}
-        color={indicationColor}
-        height="6px"
-      />
+      <Tooltip
+        tooltip={getTooltipMessage(percentage)}
+        delay={TOOLTIP_DELAY}
+        placement="bottom"
+      >
+        <PercentageLabel color={indicationColor}>
+          {formatPercentage(percentage)}
+        </PercentageLabel>
+        <ProgressBar
+          percentage={percentage}
+          color={indicationColor}
+          height="6px"
+        />
+      </Tooltip>
     </Root>
   );
 }

--- a/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/DatasetMetadataStrengthIndicator.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/DatasetMetadataStrengthIndicator.tsx
@@ -8,11 +8,20 @@ import ProgressBar from "metabase/components/ProgressBar";
 import { color } from "metabase/lib/colors";
 import { getDatasetMetadataCompletenessPercentage } from "metabase/lib/data-modeling/metadata";
 
+import {
+  Root,
+  PercentageLabel,
+} from "./DatasetMetadataStrengthIndicator.styled";
+
 function getIndicatorColor(percentage: number): string {
   if (percentage <= 0.5) {
     return color("danger");
   }
   return percentage >= 0.9 ? color("success") : color("warning");
+}
+
+function formatPercentage(percentage: number): string {
+  return (percentage * 100).toFixed() + "%";
 }
 
 type Props = {
@@ -29,7 +38,17 @@ function DatasetMetadataStrengthIndicator({ dataset }: Props) {
   const percentage = getDatasetMetadataCompletenessPercentage(resultMetadata);
   const indicationColor = getIndicatorColor(percentage);
 
-  return <ProgressBar percentage={percentage} color={indicationColor} />;
+  return (
+    <Root>
+      <PercentageLabel color={indicationColor}>
+        {formatPercentage(percentage)}
+      </PercentageLabel>
+      <ProgressBar
+        percentage={percentage}
+        color={indicationColor}
+      />
+    </Root>
+  );
 }
 
 export default DatasetMetadataStrengthIndicator;

--- a/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/DatasetMetadataStrengthIndicator.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/DatasetMetadataStrengthIndicator.tsx
@@ -44,7 +44,7 @@ type Props = {
   dataset: Question;
 };
 
-const TOOLTIP_DELAY: [number, null] = [500, null];
+const TOOLTIP_DELAY: [number, null] = [700, null];
 
 function DatasetMetadataStrengthIndicator({ dataset, ...props }: Props) {
   const resultMetadata = dataset.getResultMetadata();

--- a/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/DatasetMetadataStrengthIndicator.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/DatasetMetadataStrengthIndicator.tsx
@@ -46,17 +46,17 @@ type Props = {
 
 const TOOLTIP_DELAY: [number, null] = [500, null];
 
-function DatasetMetadataStrengthIndicator({ dataset }: Props) {
+function DatasetMetadataStrengthIndicator({ dataset, ...props }: Props) {
   const resultMetadata = dataset.getResultMetadata();
 
-  if (resultMetadata?.length === 0) {
+  if (!Array.isArray(resultMetadata) || resultMetadata.length === 0) {
     return null;
   }
 
   const percentage = getDatasetMetadataCompletenessPercentage(resultMetadata);
 
   return (
-    <Root percentage={percentage}>
+    <Root {...props} percentage={percentage}>
       <Tooltip
         tooltip={getTooltipMessage(percentage)}
         delay={TOOLTIP_DELAY}

--- a/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/DatasetMetadataStrengthIndicator.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/DatasetMetadataStrengthIndicator.tsx
@@ -1,9 +1,6 @@
 import React from "react";
 import { t } from "ttag";
 
-// eslint-disable-next-line import/namespace, import/default, import/no-named-as-default, import/no-named-as-default-member
-import Question from "metabase-lib/lib/Question";
-
 import Tooltip from "metabase/components/Tooltip";
 
 import { getDatasetMetadataCompletenessPercentage } from "metabase/lib/data-modeling/metadata";
@@ -41,7 +38,9 @@ function formatPercentage(percentage: number): string {
 }
 
 type Props = {
-  dataset: Question;
+  dataset: {
+    getResultMetadata: () => FieldMetadata[];
+  };
 };
 
 const TOOLTIP_DELAY: [number, null] = [700, null];

--- a/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/DatasetMetadataStrengthIndicator.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/DatasetMetadataStrengthIndicator.tsx
@@ -4,25 +4,17 @@ import { t } from "ttag";
 // eslint-disable-next-line import/namespace, import/default, import/no-named-as-default, import/no-named-as-default-member
 import Question from "metabase-lib/lib/Question";
 
-import ProgressBar from "metabase/components/ProgressBar";
 import Tooltip from "metabase/components/Tooltip";
 
-import { color } from "metabase/lib/colors";
 import { getDatasetMetadataCompletenessPercentage } from "metabase/lib/data-modeling/metadata";
 
 import {
   Root,
   PercentageLabel,
+  MetadataProgressBar,
   TooltipContent,
   TooltipParagraph,
 } from "./DatasetMetadataStrengthIndicator.styled";
-
-function getIndicatorColor(percentage: number): string {
-  if (percentage <= 0.5) {
-    return color("danger");
-  }
-  return percentage >= 0.9 ? color("success") : color("warning");
-}
 
 function getTooltipMessage(percentage: number) {
   if (percentage === 1) {
@@ -62,23 +54,16 @@ function DatasetMetadataStrengthIndicator({ dataset }: Props) {
   }
 
   const percentage = getDatasetMetadataCompletenessPercentage(resultMetadata);
-  const indicationColor = getIndicatorColor(percentage);
 
   return (
-    <Root>
+    <Root percentage={percentage}>
       <Tooltip
         tooltip={getTooltipMessage(percentage)}
         delay={TOOLTIP_DELAY}
         placement="bottom"
       >
-        <PercentageLabel color={indicationColor}>
-          {formatPercentage(percentage)}
-        </PercentageLabel>
-        <ProgressBar
-          percentage={percentage}
-          color={indicationColor}
-          height="6px"
-        />
+        <PercentageLabel>{formatPercentage(percentage)}</PercentageLabel>
+        <MetadataProgressBar percentage={percentage} height="8px" />
       </Tooltip>
     </Root>
   );

--- a/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/DatasetMetadataStrengthIndicator.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/DatasetMetadataStrengthIndicator.tsx
@@ -46,6 +46,7 @@ function DatasetMetadataStrengthIndicator({ dataset }: Props) {
       <ProgressBar
         percentage={percentage}
         color={indicationColor}
+        height="6px"
       />
     </Root>
   );

--- a/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/DatasetMetadataStrengthIndicator.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/DatasetMetadataStrengthIndicator.unit.spec.js
@@ -1,0 +1,73 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import DatasetMetadataStrengthIndicator from "./DatasetMetadataStrengthIndicator";
+
+function setup({ resultMetadata } = {}) {
+  const mockDataset = {
+    getResultMetadata: () => resultMetadata,
+  };
+  render(
+    <DatasetMetadataStrengthIndicator
+      dataset={mockDataset}
+      data-testid="indicator"
+    />,
+  );
+}
+
+describe("DatasetMetadataStrengthIndicator", () => {
+  const FULLY_COMPLETE_METADATA = {
+    id: 1,
+    name: "ID",
+    description: "Well, that's an ID",
+    semantic_type: "type/PK",
+  };
+  const PARTIALLY_COMPLETE_METADATA = {
+    id: 1,
+    name: "ID",
+    semantic_type: "type/PK",
+  };
+  const FULLY_INCOMPLETE_METADATA = { name: "CREATED_AT" };
+
+  it("doesn't render if result metadata is not defined", () => {
+    setup({ resultMetadata: undefined });
+    expect(screen.queryByTestId("indicator")).not.toBeInTheDocument();
+  });
+
+  it("doesn't render if result metadata is empty", () => {
+    setup({ resultMetadata: [] });
+    expect(screen.queryByTestId("indicator")).not.toBeInTheDocument();
+  });
+
+  [
+    {
+      name: "fully complete metadata (100%)",
+      resultMetadata: [FULLY_COMPLETE_METADATA],
+      completenessPercent: "100%",
+    },
+    {
+      name: "half complete metadata (50%)",
+      resultMetadata: [FULLY_COMPLETE_METADATA, FULLY_INCOMPLETE_METADATA],
+      completenessPercent: "50%",
+    },
+    {
+      name: "partially complete metadata",
+      resultMetadata: [PARTIALLY_COMPLETE_METADATA],
+      completenessPercent: "67%",
+    },
+    {
+      name: "fully incomplete metadata (0%)",
+      resultMetadata: [FULLY_INCOMPLETE_METADATA],
+      completenessPercent: "0%",
+    },
+  ].forEach(testCase => {
+    const { name, resultMetadata, completenessPercent } = testCase;
+
+    describe(name, () => {
+      it("renders correctly", () => {
+        setup({ resultMetadata });
+        expect(screen.queryByTestId("indicator")).toBeInTheDocument();
+        expect(screen.queryByText(completenessPercent)).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/DatasetMetadataStrengthIndicator.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/DatasetMetadataStrengthIndicator.unit.spec.js
@@ -65,8 +65,8 @@ describe("DatasetMetadataStrengthIndicator", () => {
     describe(name, () => {
       it("renders correctly", () => {
         setup({ resultMetadata });
-        expect(screen.queryByTestId("indicator")).toBeInTheDocument();
-        expect(screen.queryByText(completenessPercent)).toBeInTheDocument();
+        expect(screen.getByTestId("indicator")).toBeInTheDocument();
+        expect(screen.getByText(completenessPercent)).toBeInTheDocument();
       });
     });
   });

--- a/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/index.ts
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DatasetMetadataStrengthIndicator";


### PR DESCRIPTION
Adds a small progress bar to the dataset details sidebar indicating how complete is the dataset metadata. 

### How metadata strength is calculated

For any field in dataset's `result_medatata`, we're checking if:

* the name doesn't have "_" and "→" characters
* a description is provided
* a `semantic_type` is selected

Every item gives a field one "point", so any field can have a score between 0 and 3. We compute the score for every field and then divide it by the maximum possible number of points (3 * number of fields). As a result, we get a percent value of metadata completeness

### States

The indicator has four possible states. States vary by progress bar color and tooltip contents.

1. `progress == 100%` The indicator becomes green on hover and the tooltip says that metadata is fully complete
2. `100% > progress >= 90%` The indicator becomes green on hover and the tooltip says that _some_ fields are missing metadata
3. `90% > progress > 50%`. The indicator becomes yellow on hover and the tooltip says that _many_ fields are missing metadata
4. `progress <= 50%`. The indicator is always red (not only on hover) and the tooltip says that _most_ fields are missing metadata

## To Verify

It's not very convenient to test that until we have a fully functioning metadata editor. However, it should be pretty easy to test `< 50%` and `90% > progress > 50%` states without any actions. In order to test the `>= 90%` state, you can either hardcode a percent variable here or edit metadata on `/admin/datamodel`

<details>
<summary>For metadata strength < 50%</summary>

1. Create a native dataset from `select * from orders` query
2. Open dataset sidebar
3. You should see a red progress bar next to the "Customize metadata" button
4. Hover the progress bar, you should see a percent label slide up and become visible, the progress bar should not change color
5. A tooltip saying "Most columns are missing a column type, description, or friendly name" should appear after a short delay
</details>

<details>
<summary>For metadata strength > 50%</summary>

1. Create a dataset from the Sample Dataset Orders table
2. Open dataset sidebar
3. You see a grey progress bar next to the "Customize metadata" button
4. Hover the progress bar, you should see a percent label slide up and become visible, the progress bar itself should become yellow
5. A tooltip saying "Many columns are missing a column type, description, or friendly name" should appear after a short delay
</details>

<details>
<summary>For metadata strength > 90%</summary>

1. Create a dataset from the Sample Dataset Orders table
2. Fill in missing metadata on the `/admin/datamodel` page or hardcode this to `0.92` as an example
2. Open dataset sidebar
3. You see a grey progress bar next to the "Customize metadata" button
4. Hover the progress bar, you should see a percent label slide up and become visible, the progress itself bar should become green
5. A tooltip saying "Many columns are missing a column type, description, or friendly name" should appear after a short delay

</details>

<details>
<summary>For metadata strength == 100%</summary>

1. Create a dataset from the Sample Dataset Orders table
2. Fill in missing metadata on the `/admin/datamodel` page or hardcode this to `1`
2. Open dataset sidebar
3. You see a grey progress bar next to the "Customize metadata" button
4. Hover the progress bar, you should see a percent label slide up and become visible, the progress itself bar should become green
5. A tooltip saying "Every column has a type, a description, and a friendly name. Nice!" should appear after a short delay
</details>

## Demo

<details>
<summary>Mostly incomplete metadata (< 50%)</summary>

![red](https://user-images.githubusercontent.com/17258145/144645267-07ccd197-185b-4fb7-9806-52f6554b2d92.gif)
</details>

<details>
<summary>Many fields missing metadata (90% > progress > 50%)</summary>

![yellow](https://user-images.githubusercontent.com/17258145/144645530-bc153246-b4f3-48ca-892c-b92d361ae14e.gif)

</details>

<details>
<summary>Some fields missing metadata (>= 90%)</summary>


![green](https://user-images.githubusercontent.com/17258145/144645598-cce333d8-f5c0-42ac-b870-06c49da4d3c5.gif)
</details>

<details>
<summary>Fully Complete metadata (100%)</summary>

![green-all](https://user-images.githubusercontent.com/17258145/144645299-bfffc4cf-43ad-4899-b6a2-e4619d65594d.gif)
</details>
