### PR TITLE
fix rendering of the progress bar static viz without a grouping separator

### DIFF
--- a/frontend/src/metabase/static-viz/lib/numbers.ts
+++ b/frontend/src/metabase/static-viz/lib/numbers.ts
@@ -45,7 +45,7 @@ export const formatNumber = (number: number, options: NumberFormatOptions) => {
   const formattedNumber = format
     .format(number * scale)
     .replace(/\./g, decimal_separator)
-    .replace(/,/g, grouping_separator);
+    .replace(/,/g, grouping_separator ?? "");
 
   return `${prefix}${formattedNumber}${suffix}`;
 };

--- a/frontend/src/metabase/static-viz/lib/numbers.unit.spec.js
+++ b/frontend/src/metabase/static-viz/lib/numbers.unit.spec.js
@@ -89,6 +89,16 @@ describe("formatNumber", () => {
 
     expect(text).toEqual("prefix15suffix");
   });
+
+  it("should format a number without grouping separator", () => {
+    const number = 10000.11;
+
+    const text = formatNumber(number, {
+      number_separators: ".",
+    });
+
+    expect(text).toEqual("10000.11");
+  });
 });
 
 describe("formatPercent", () => {


### PR DESCRIPTION
Fixes https://www.notion.so/metabase/x-42-Merged-Work-So-Far-755f51366eb8478a84fe7d77e769e493?p=d6d81517781548f8a2675d3f5de4ff96

### How to test
1. Create a scalar question, e.g. the number of products
2. Set goal to `20000`
3. Go to formatting settings and remove the digits separator. The option should look like `20000`, when others are `20,000`, `20.000` etc.
4. Add this question to a dashboard
5. Send the dashboard to Slack

#### Before
<img width="172" alt="Screen Shot 2021-12-03 at 22 29 29" src="https://user-images.githubusercontent.com/14301985/144655327-89937767-13b1-4fad-a1f1-efea1784a4b3.png">

#### After
<img width="221" alt="Screen Shot 2021-12-03 at 22 29 11" src="https://user-images.githubusercontent.com/14301985/144655341-bbcc0c7b-22ab-46a1-b2f4-94a9caf49e44.png">