### PR TITLE
Ensure dashcard order is deterministic in dashboard subscription tests

### DIFF
--- a/test/metabase/dashboard_subscription_test.clj
+++ b/test/metabase/dashboard_subscription_test.clj
@@ -25,10 +25,9 @@
                                            :card_id  (u/the-id card)
                                            :position 0}
                                           pulse-card)]
-                  DashboardCard [{dashcard-id :id} (merge
-                                                    {:dashboard_id (u/the-id dashboard)
-                                                     :card_id (u/the-id card)}
-                                                    dashcard)]
+                  DashboardCard [_ (merge {:dashboard_id (u/the-id dashboard)
+                                           :card_id (u/the-id card)}
+                                          dashcard)]
                   PulseChannel  [{pc-id :id} (case channel
                                                :email
                                                {:pulse_id pulse-id}

--- a/test/metabase/dashboard_subscription_test.clj
+++ b/test/metabase/dashboard_subscription_test.clj
@@ -335,8 +335,7 @@
                  (thunk->boolean pulse-results)))))}}))
 
 (deftest mrkdwn-length-limit-test
-  (tests {:pulse {:skip_if_empty false}
-          :dashcard {:row 0, :col 0}}
+  (tests {:pulse {:skip_if_empty false}, :dashcard {:row 0, :col 0}}
     "Dashboard subscription that includes a Markdown card that exceeds Slack's length limit when converted to mrkdwn"
     {:card (checkins-query-card {})
 

--- a/test/metabase/dashboard_subscription_test.clj
+++ b/test/metabase/dashboard_subscription_test.clj
@@ -14,19 +14,21 @@
   specified), then invokes
 
     (f pulse)"
-  [{:keys [dashboard pulse pulse-card channel card]
+  [{:keys [dashboard pulse pulse-card channel card dashcard]
     :or   {channel :email}}
    f]
   (mt/with-temp* [Pulse         [{pulse-id :id, :as pulse}
-                                 (->> pulse
-                                      (merge {:name         "Aviary KPIs"
-                                              :dashboard_id (u/the-id dashboard)}))]
+                                 (merge {:name         "Aviary KPIs"
+                                         :dashboard_id (u/the-id dashboard)}
+                                        pulse)]
                   PulseCard     [_ (merge {:pulse_id pulse-id
                                            :card_id  (u/the-id card)
                                            :position 0}
                                           pulse-card)]
-                  DashboardCard [{dashcard-id :id} {:dashboard_id (u/the-id dashboard)
-                                                    :card_id (u/the-id card)}]
+                  DashboardCard [{dashcard-id :id} (merge
+                                                    {:dashboard_id (u/the-id dashboard)
+                                                     :card_id (u/the-id card)}
+                                                    dashcard)]
                   PulseChannel  [{pc-id :id} (case channel
                                                :email
                                                {:pulse_id pulse-id}
@@ -64,7 +66,7 @@
       :assert {:slack (fn [{:keys [pulse-id]} response]
                         (is (= {:sent pulse-id}
                                response)))}})"
-  [{:keys [card dashboard pulse pulse-card fixture], assertions :assert}]
+  [{:keys [card dashboard dashcard pulse pulse-card fixture], assertions :assert}]
   {:pre [(map? assertions) ((some-fn :email :slack) assertions)]}
   (doseq [channel-type [:email :slack]
           :let         [f (get assertions channel-type)]
@@ -79,6 +81,7 @@
                                       {:card       card-id
                                        :creator_id (mt/user->id :rasta)
                                        :dashboard  dashboard-id
+                                       :dashcard   dashcard
                                        :pulse      pulse
                                        :pulse-card pulse-card
                                        :channel    channel-type}]
@@ -239,13 +242,16 @@
                    (output @#'render.body/attached-results-text))))))}}))
 
 (deftest virtual-card-test
-  (tests {:pulse {:skip_if_empty false}}
+  (tests {:pulse {:skip_if_empty false}, :dashcard {:row 0, :col 0}}
     "Dashboard subscription that includes a virtual (markdown) card"
     {:card (checkins-query-card {})
 
      :fixture
      (fn [{dashboard-id :dashboard-id} thunk]
-       (mt/with-temp DashboardCard [_ {:dashboard_id dashboard-id, :visualization_settings {:text "# header"}}]
+       (mt/with-temp DashboardCard [_ {:dashboard_id dashboard-id
+                                       :row 1
+                                       :col 1
+                                       :visualization_settings {:text "# header"}}]
          (mt/with-temporary-setting-values [site-name "Metabase Test"]
            (thunk))))
 
@@ -329,13 +335,17 @@
                  (thunk->boolean pulse-results)))))}}))
 
 (deftest mrkdwn-length-limit-test
-  (tests {:pulse {:skip_if_empty false}}
+  (tests {:pulse {:skip_if_empty false}
+          :dashcard {:row 0, :col 0}}
     "Dashboard subscription that includes a Markdown card that exceeds Slack's length limit when converted to mrkdwn"
     {:card (checkins-query-card {})
 
      :fixture
      (fn [{dashboard-id :dashboard-id} thunk]
-       (mt/with-temp DashboardCard [_ {:dashboard_id dashboard-id, :visualization_settings {:text "abcdefghijklmnopqrstuvwxyz"}}]
+       (mt/with-temp DashboardCard [_ {:dashboard_id dashboard-id
+                                       :row 1
+                                       :col 1
+                                       :visualization_settings {:text "abcdefghijklmnopqrstuvwxyz"}}]
          (binding [pulse/*slack-mrkdwn-length-limit* 10]
            (thunk))))
 


### PR DESCRIPTION
`virtual-card-test` and `mrkdwn-length-limit-test` both assert on the order of dashboard cards received in a Slack message. However the dashboard cards don't have explicit row & columns assigned, so they're all defaulting to 0, and thus don't have a deterministic order. I believe this is why these tests are flaky, and it can be easily fixed by adding row and column values to ensure the cards are ordered properly in the Slack output.

_However_ I still don't know why this only seems to be an issue with tests run in CI with the postgres driver, and why I can't seem to ever reproduce this locally 🤔 