### PR TITLE
CI with GitHub Actions: cache node_modules

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,6 +28,11 @@ jobs:
       with:
         path: ~/.cache/yarn
         key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+    - name: Get node_modules cache
+      uses: actions/cache@v2
+      with:
+        path: node_modules
+        key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
     - run: yarn install --frozen-lockfile --prefer-offline
     - run: yarn run lint-docs-links
       name: Run docs links checker

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -30,6 +30,11 @@ jobs:
       with:
         path: ~/.cache/yarn
         key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+    - name: Get node_modules cache
+      uses: actions/cache@v2
+      with:
+        path: node_modules
+        key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
     - run: yarn install --frozen-lockfile --prefer-offline
     - run: yarn run lint-prettier
       name: Run Prettier formatting linter
@@ -53,6 +58,11 @@ jobs:
       with:
         path: ~/.cache/yarn
         key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+    - name: Get node_modules cache
+      uses: actions/cache@v2
+      with:
+        path: node_modules
+        key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
     - run: yarn install --frozen-lockfile --prefer-offline
     - run: yarn run lint-eslint
       name: Run ESLint linter
@@ -71,6 +81,11 @@ jobs:
       with:
         path: ~/.cache/yarn
         key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+    - name: Get node_modules cache
+      uses: actions/cache@v2
+      with:
+        path: node_modules
+        key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
     - run: yarn install --frozen-lockfile --prefer-offline
     - run: yarn type-check
       name: Check types
@@ -94,6 +109,11 @@ jobs:
       with:
         path: ~/.cache/yarn
         key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+    - name: Get node_modules cache
+      uses: actions/cache@v2
+      with:
+        path: node_modules
+        key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
     - run: yarn install --frozen-lockfile --prefer-offline
     - run: yarn run test-unit --coverage --silent
       name: Run frontend unit tests
@@ -122,6 +142,11 @@ jobs:
       with:
         path: ~/.cache/yarn
         key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+    - name: Get node_modules cache
+      uses: actions/cache@v2
+      with:
+        path: node_modules
+        key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
     - run: yarn install --frozen-lockfile --prefer-offline
     - run: yarn run test-timezones
       name: Run frontend timezones tests

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -37,6 +37,11 @@ jobs:
       with:
         path: ~/.cache/yarn
         key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+    - name: Get node_modules cache
+      uses: actions/cache@v2
+      with:
+        path: node_modules
+        key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
     - run: yarn install --frozen-lockfile --prefer-offline
     - run: yarn test-unit frontend/test/metabase/lib/expressions/fuzz.tokenizer.unit.spec.js
       env:
@@ -62,6 +67,11 @@ jobs:
       with:
         path: ~/.cache/yarn
         key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+    - name: Get node_modules cache
+      uses: actions/cache@v2
+      with:
+        path: node_modules
+        key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
     - run: yarn install --frozen-lockfile --prefer-offline
     - run: yarn test-unit frontend/test/metabase/lib/expressions/fuzz.parser.unit.spec.js
       env:

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -28,6 +28,11 @@ jobs:
       with:
         path: ~/.cache/yarn
         key: ${{ runner.os }}-i18n-${{ hashFiles('**/yarn.lock') }}
+    - name: Get node_modules cache
+      uses: actions/cache@v2
+      with:
+        path: node_modules
+        key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
     - run: yarn install --frozen-lockfile --prefer-offline
 
     - run: sudo apt install gettext

--- a/.github/workflows/percy-issue-comment.yml
+++ b/.github/workflows/percy-issue-comment.yml
@@ -68,6 +68,11 @@ jobs:
         with:
           path: ~/.cache/yarn
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+      - name: Get node_modules cache
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
       - name: Get M2 cache
         uses: actions/cache@v2
         with:
@@ -126,6 +131,11 @@ jobs:
         with:
           path: ~/.cache/yarn
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+      - name: Get node_modules cache
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile --prefer-offline
 
       - uses: actions/download-artifact@v2

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -49,6 +49,11 @@ jobs:
         with:
           path: ~/.cache/yarn
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+      - name: Get node_modules cache
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
       - name: Get M2 cache
         uses: actions/cache@v2
         with:
@@ -100,6 +105,11 @@ jobs:
         with:
           path: ~/.cache/yarn
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+      - name: Get node_modules cache
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile --prefer-offline
 
       - uses: actions/download-artifact@v2

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -46,6 +46,11 @@ jobs:
       with:
         path: ~/.cache/yarn
         key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+    - name: Get node_modules cache
+      uses: actions/cache@v2
+      with:
+        path: node_modules
+        key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
     - name: Get M2 cache
       uses: actions/cache@v2
       with:

--- a/.github/workflows/yaml.yml
+++ b/.github/workflows/yaml.yml
@@ -26,5 +26,10 @@ jobs:
       with:
         path: ~/.cache/yarn
         key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+    - name: Get node_modules cache
+      uses: actions/cache@v2
+      with:
+        path: node_modules
+        key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
     - run: yarn install --frozen-lockfile --prefer-offline
     - run: yarn run lint-yaml


### PR DESCRIPTION
GitHub hosted-runner seems to get slower and slower over time :sob: , to the point where running `yarn install` (even with `--prefer-offline`, which should pull the packages from the cache) can take anywhere between 3 to 5 minutes.

To overcome this, we also cache `node_modules`. 
This adds another 20 secs, give or take, to the workflow duration, but it's still a net win overall.

**Before**

![image](https://user-images.githubusercontent.com/7288/144718288-ccc8dd67-f6b1-4e6b-ab68-c1608345cb0c.png)

**After**

![image](https://user-images.githubusercontent.com/7288/144718310-5b97fcfb-f881-4848-aeb2-a359f0ed9266.png)
