### PR TITLE
Percy CI: fix node_modules caching

### DIFF
--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -105,11 +105,13 @@ jobs:
         with:
           path: ~/.cache/yarn
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-      - name: Get node_modules cache
+      - name: Get node_modules and Cypress cache
         uses: actions/cache@v2
         with:
-          path: node_modules
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
+          path: |
+            node_modules
+            ~/..cache/Cypress
+          key: ${{ runner.os }}-node-modules-cypress-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile --prefer-offline
 
       - uses: actions/download-artifact@v2


### PR DESCRIPTION
Since Cypress is need, we need to cache ~/.cache/Cypress as well.

The previous PR #19202 wasn't complete since it didn't cache Cypress binary necessary to maintain the consistency before running Cypress.

**Before this PR**

Every Percy CI run, e.g. [this one](https://github.com/metabase/metabase/runs/4446719972?check_suite_focus=true), fails with the following message:

```
 Error: The cypress npm package is installed, but the Cypress binary is missing.

We expected the binary to be installed here: /home/runner/.cache/Cypress/6.8.0/Cypress/Cypress

Reasons it may be missing:

- You're caching 'node_modules' but are not caching this path: /home/runner/.cache/Cypress
- You ran 'npm install' at an earlier build step but did not persist: /home/runner/.cache/Cypress

Properly caching the binary will fix this error and avoid downloading and unzipping Cypress.
```

**After this PR**

None of the above should happen and Percy CI run completes successfully.