### PR TITLE
fix progress bar text alignment and missing translations

### DIFF
--- a/frontend/src/metabase/static-viz/components/ProgressBar/ProgressBar.tsx
+++ b/frontend/src/metabase/static-viz/components/ProgressBar/ProgressBar.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { t } from "ttag";
 import { scaleLinear } from "@visx/scale";
 import { Group } from "@visx/group";
 import { ClipPath } from "@visx/clip-path";
@@ -111,7 +112,7 @@ const ProgressBar = ({
               color="white"
               x={layout.iconSize + 16}
               y={layout.barHeight / 2}
-              dominantBaseline="central"
+              verticalAnchor="middle"
               fill="white"
             >
               {barText}
@@ -144,7 +145,7 @@ const ProgressBar = ({
           {formatNumber(0, format)}
         </Text>
         <Text fontSize={layout.fontSize} textAnchor="end" x={xMax}>
-          {`Goal ${formatNumber(data.goal, format)}`}
+          {t`Goal ${formatNumber(data.goal, format)}`}
         </Text>
       </Group>
     </svg>

--- a/frontend/src/metabase/static-viz/components/ProgressBar/utils.ts
+++ b/frontend/src/metabase/static-viz/components/ProgressBar/utils.ts
@@ -1,4 +1,5 @@
 import Color from "color";
+import { t } from "ttag";
 import { measureText } from "metabase/static-viz/lib/text";
 import { ProgressBarData } from "./types";
 
@@ -31,9 +32,9 @@ export const getColors = (
 
 export const getBarText = ({ value, goal }: ProgressBarData) => {
   if (value === goal) {
-    return "Goal met";
+    return t`Goal met`;
   } else if (value > goal) {
-    return "Goal exceeded";
+    return t`Goal exceeded`;
   }
 
   return null;


### PR DESCRIPTION
Fixes missing translations in static viz and incorrect alignment of text inside the progress bar:

Before
<img width="649" alt="Screen Shot 2021-12-07 at 20 38 48" src="https://user-images.githubusercontent.com/14301985/145079052-05ddc75d-7270-49f3-be0d-4f6a46064a7e.png">

After
<img width="651" alt="Screen Shot 2021-12-07 at 20 38 39" src="https://user-images.githubusercontent.com/14301985/145079074-576beb71-2fa2-42f8-9818-e53415a22c40.png">