### PR TITLE
Add the ability to show popovers from `AccordionList` options

### DIFF
--- a/frontend/src/metabase/components/AccordionList/AccordionList.info.js
+++ b/frontend/src/metabase/components/AccordionList/AccordionList.info.js
@@ -1,4 +1,6 @@
 import React from "react";
+import styled from "styled-components";
+
 import AccordionList from "metabase/components/AccordionList";
 
 export const component = AccordionList;
@@ -8,6 +10,9 @@ export const description = `
 An expandable and searchable list of sections and items.
 `;
 
+const PopoverContent = styled.div`
+  padding: 1em;
+`;
 const sections = [
   {
     name: "Widgets",
@@ -49,6 +54,19 @@ export const examples = {
       sections={sections.slice(0, 1)}
       itemIsSelected={item => item.name === "Foo"}
       hideSingleSectionTitle
+    />
+  ),
+  "List Item Popover": (
+    <AccordionList
+      className="text-brand full"
+      sections={sections}
+      itemIsSelected={item => item.name === "Foo"}
+      itemPopover={{
+        // eslint-disable-next-line react/display-name
+        renderContent: item => <PopoverContent>{item.name}</PopoverContent>,
+        placement: "left-start",
+        interactive: true,
+      }}
     />
   ),
 };

--- a/frontend/src/metabase/components/AccordionList/AccordionList.jsx
+++ b/frontend/src/metabase/components/AccordionList/AccordionList.jsx
@@ -10,6 +10,7 @@ import Icon from "metabase/components/Icon";
 import LoadingSpinner from "metabase/components/LoadingSpinner";
 import ListSearchField from "metabase/components/ListSearchField";
 import { List, CellMeasurer, CellMeasurerCache } from "react-virtualized";
+import TippyPopover from "metabase/components/Popover/TippyPopover";
 
 export default class AccordionList extends Component {
   constructor(props, context) {
@@ -87,6 +88,11 @@ export default class AccordionList extends Component {
     searchPlaceholder: PropTypes.string,
 
     itemTestId: PropTypes.string,
+
+    itemPopover: PropTypes.shape({
+      ...TippyPopover.propTypes,
+      renderItemPopover: PropTypes.func,
+    }),
   };
 
   static defaultProps = {
@@ -441,6 +447,7 @@ export default class AccordionList extends Component {
                   sectionIsExpanded={sectionIsExpanded}
                   sectionIsTogglable={sectionIsTogglable}
                   toggleSection={this.toggleSection}
+                  itemPopover={this.props.itemPopover}
                 />
               )}
             </CellMeasurer>
@@ -480,6 +487,7 @@ const AccordionListCell = ({
   showItemArrows,
   itemTestId,
   getItemClassName,
+  itemPopover,
 }) => {
   const { type, section, sectionIndex, item, itemIndex, isLastItem } = row;
   let content;
@@ -601,6 +609,19 @@ const AccordionListCell = ({
         )}
       </div>
     );
+
+    if (itemPopover) {
+      const { renderContent, ...popoverProps } = itemPopover;
+      const popoverContent = renderContent
+        ? renderContent(item)
+        : itemPopover.content;
+
+      content = (
+        <TippyPopover {...popoverProps} content={popoverContent}>
+          {content}
+        </TippyPopover>
+      );
+    }
   }
 
   return (

--- a/frontend/src/metabase/components/AccordionList/AccordionList.unit.spec.js
+++ b/frontend/src/metabase/components/AccordionList/AccordionList.unit.spec.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import AccordionList from "metabase/components/AccordionList";
 
@@ -79,6 +80,19 @@ describe("AccordionList", () => {
 
     fireEvent.change(SEARCH_FIELD, { target: { value: "Something Else" } });
     assertAbsence(["Foo", "Bar", "Baz"]);
+  });
+
+  describe("with the `itemPopover` prop", () => {
+    it("should render a popover upon hover of an item in the list", async () => {
+      const itemPopover = {
+        content: <div>popover</div>,
+      };
+
+      render(<AccordionList sections={SECTIONS} itemPopover={itemPopover} />);
+
+      userEvent.hover(screen.getByText("Foo"));
+      expect(await screen.findByText("popover")).toBeVisible();
+    });
   });
 });
 

--- a/frontend/src/metabase/components/AccordionList/index.js
+++ b/frontend/src/metabase/components/AccordionList/index.js
@@ -1,0 +1,1 @@
+export { default } from "./AccordionList";

--- a/frontend/src/metabase/components/Popover/TippyPopover.tsx
+++ b/frontend/src/metabase/components/Popover/TippyPopover.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useMemo } from "react";
+import PropTypes from "prop-types";
 import * as Tippy from "@tippyjs/react";
 
 import { isReducedMotionPreferred } from "metabase/lib/dom";
@@ -13,6 +14,12 @@ interface TippyPopoverProps extends TippyProps {
 }
 
 const OFFSET: [number, number] = [0, 5];
+
+const propTypes = {
+  ...TippyComponent.propTypes,
+  disableContentSandbox: PropTypes.bool,
+  lazy: PropTypes.bool,
+};
 
 function TippyPopover({
   disableContentSandbox,
@@ -59,5 +66,7 @@ function TippyPopover({
     />
   );
 }
+
+TippyPopover.propTypes = propTypes;
 
 export default TippyPopover;


### PR DESCRIPTION
This PR adds the `itemPopover` prop to our `AccordionList` component so that a popover can be shown upon hover of a given item.

**Testing**
Go to `/_internal/components/accordionlist` and go to the final example on the page and move your mouse over an item in the `AccordionList`.

Here's a screenshot from a forthcoming feature:

![Screen Shot 2021-12-07 at 11 07 25 AM](https://user-images.githubusercontent.com/13057258/145090949-6077a507-0ab0-4fcc-bbf2-f9628abd256c.png)


