### PR TITLE
Update presto-kerberos-docker branch used by run-presto-kerberos-test

### DIFF
--- a/.github/workflows/presto-kerberos-integration-test.yml
+++ b/.github/workflows/presto-kerberos-integration-test.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           repository: metabase/presto-kerberos-docker
           # use a custom branch if/until upstream (mik-laj/presto-kerberos-docker) can be fixed with PRs 23 and 24
-          ref: fixed-dec-2021
+          ref: hacked-dec-2021
           token: ${{ secrets.GITHUB_TOKEN }}
           path: presto-kerberos-docker
       - name: Bring up Presto+Kerberos cluster

--- a/.github/workflows/presto-kerberos-integration-test.yml
+++ b/.github/workflows/presto-kerberos-integration-test.yml
@@ -37,7 +37,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: metabase/presto-kerberos-docker
-          ref: add-test_data-catalog
+          # use a custom branch if/until upstream (mik-laj/presto-kerberos-docker) can be fixed with PRs 23 and 24
+          ref: fixed-dec-2021
           token: ${{ secrets.GITHUB_TOKEN }}
           path: presto-kerberos-docker
       - name: Bring up Presto+Kerberos cluster

--- a/modules/drivers/presto-jdbc/test/metabase/test/data/presto_jdbc.clj
+++ b/modules/drivers/presto-jdbc/test/metabase/test/data/presto_jdbc.clj
@@ -18,6 +18,7 @@
 
 (defmethod tx/sorts-nil-first? :presto-jdbc [_ _] false)
 
+
 ;; during unit tests don't treat presto as having FK support
 (defmethod driver/supports? [:presto-jdbc :foreign-keys] [_ _] (not config/is-test?))
 

--- a/modules/drivers/presto-jdbc/test/metabase/test/data/presto_jdbc.clj
+++ b/modules/drivers/presto-jdbc/test/metabase/test/data/presto_jdbc.clj
@@ -18,7 +18,6 @@
 
 (defmethod tx/sorts-nil-first? :presto-jdbc [_ _] false)
 
-
 ;; during unit tests don't treat presto as having FK support
 (defmethod driver/supports? [:presto-jdbc :foreign-keys] [_ _] (not config/is-test?))
 


### PR DESCRIPTION
Point the Presto Kerberos integration test to a `fixed-dec-2021` branch of `metabase/presto-kerberos-docker`, which contains

* the test_data catalog, which was added under `add-test_data-catalog`
* commits from upstream PRs (mik-laj/presto-kerberos-docker) 23 and 24, which fix the problem that forego binary is no longer available to download
