### PR TITLE
Don't hydrate param_values/param_fields for public/embed Cards/Dashboards

### DIFF
--- a/src/metabase/models/params.clj
+++ b/src/metabase/models/params.clj
@@ -42,11 +42,6 @@
     (throw (ex-info (trs "Don''t know how to wrap Field ID.")
                     {:form field-id-or-form}))))
 
-(defn- field-ids->param-field-values-ignoring-current-user
-  [param-field-ids]
-  (u/key-by :field_id (db/select ['FieldValues :values :human_readable_values :field_id]
-                        :field_id [:in param-field-ids])))
-
 (defn- field-ids->param-field-values
   "Given a collection of `param-field-ids` return a map of FieldValues for the Fields they reference. This map is
   returned by various endpoints as `:param_values`."

--- a/src/metabase/models/params.clj
+++ b/src/metabase/models/params.clj
@@ -42,13 +42,6 @@
     (throw (ex-info (trs "Don''t know how to wrap Field ID.")
                     {:form field-id-or-form}))))
 
-(def ^:dynamic *ignore-current-user-perms-and-return-all-field-values*
-  "Whether to ignore permissions for the current User and return *all* FieldValues for the Fields being parameterized by
-  Cards and Dashboards. This determines how `:param_values` gets hydrated for Card and Dashboard. Normally, this is
-  `false`, but the public and embed versions of the API endpoints can bind this to `true` to bypass normal perms
-  checks (since there is no current User) and get *all* values."
-  false)
-
 (defn- field-ids->param-field-values-ignoring-current-user
   [param-field-ids]
   (u/key-by :field_id (db/select ['FieldValues :values :human_readable_values :field_id]
@@ -59,9 +52,7 @@
   returned by various endpoints as `:param_values`."
   [param-field-ids]
   (when (seq param-field-ids)
-    ((if *ignore-current-user-perms-and-return-all-field-values*
-       field-ids->param-field-values-ignoring-current-user
-       params.field-values/field-id->field-values-for-current-user) param-field-ids)))
+    (params.field-values/field-id->field-values-for-current-user param-field-ids)))
 
 (defn- template-tag->field-form
   "Fetch the `:field` clause from `dashcard` referenced by `template-tag`.

--- a/test/metabase/api/embed_test.clj
+++ b/test/metabase/api/embed_test.clj
@@ -137,12 +137,10 @@
    :display                "table"
    :visualization_settings {}
    :dataset_query          {:type "query"}
-   :parameters             []
-   :param_values           nil
-   :param_fields           nil})
+   :parameters             []})
 
 (def successful-dashboard-info
-  {:description nil, :parameters [], :ordered_cards [], :param_values nil, :param_fields nil})
+  {:description nil, :parameters [], :ordered_cards []})
 
 (def ^:private yesterday (time/minus (time/now) (time/days 1)))
 


### PR DESCRIPTION
Part of https://github.com/metabase/metaboat/issues/144

Field values no longer come back when fetching a public Card or Dashboard. TBH I do not understand the exact reasoning behind this change (@daltojohnso might be able to explain it better) but the PR itself just involved removing the code we had to make it work and then deleting tests for that stuff. (Presumably you can use the chain filter endpoints to fetch values anyway?)