### PR TITLE
Validate dashboard parameter types

### DIFF
--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -408,7 +408,7 @@
   [dashboard-id dashcards]
   (let [dashcard-id->existing-mappings (existing-parameter-mappings dashboard-id)
         existing-mapping?              (fn [dashcard-id mapping]
-                                         (let [[mapping]         (dashboard-card/normalize-parameter-mappings [mapping])
+                                         (let [[mapping]         (mi/normalize-parameters-list [mapping])
                                                existing-mappings (get dashcard-id->existing-mappings dashcard-id)]
                                            (contains? existing-mappings (select-keys mapping [:target :parameter_id]))))
         new-mappings                   (for [{mappings :parameter_mappings, dashcard-id :id} dashcards

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -135,7 +135,7 @@
   models/IModel
   (merge models/IModelDefaults
          {:properties  (constantly {:timestamped? true})
-          :types       (constantly {:parameters :json, :embedding_params :json})
+          :types       (constantly {:parameters :parameters-list, :embedding_params :json})
           :pre-delete  pre-delete
           :pre-insert  pre-insert
           :pre-update  pre-update

--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -2,7 +2,6 @@
   (:require [clojure.set :as set]
             [metabase.db.util :as mdb.u]
             [metabase.events :as events]
-            [metabase.mbql.normalize :as normalize]
             [metabase.models.card :refer [Card]]
             [metabase.models.dashboard-card-series :refer [DashboardCardSeries]]
             [metabase.models.interface :as i]
@@ -36,21 +35,11 @@
                   :visualization_settings {}}]
     (merge defaults dashcard)))
 
-(defn normalize-parameter-mappings
-  "Normalize `parameter-mappings` when coming out of the application database or in via an API request."
-  [parameter-mappings]
-  (or (normalize/normalize-fragment [:parameters] parameter-mappings)
-      []))
-
-(models/add-type! ::parameter-mappings
-  :in  (comp i/json-in normalize-parameter-mappings)
-  :out (comp (i/catch-normalization-exceptions normalize-parameter-mappings) i/json-out-with-keywordization))
-
 (u/strict-extend (class DashboardCard)
   models/IModel
   (merge models/IModelDefaults
          {:properties  (constantly {:timestamped? true})
-          :types       (constantly {:parameter_mappings     ::parameter-mappings
+          :types       (constantly {:parameter_mappings     :parameters-list
                                     :visualization_settings :visualization-settings})
           :pre-insert  pre-insert
           :post-select #(set/rename-keys % {:sizex :sizeX, :sizey :sizeY})})

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -86,6 +86,16 @@
   :in  (comp json-in maybe-normalize)
   :out (comp (catch-normalization-exceptions maybe-normalize) json-out-with-keywordization))
 
+(defn normalize-parameters-list
+  "Normalize `parameters` or `parameter-mappings` when coming out of the application database or in via an API request."
+  [parameters]
+  (or (normalize/normalize-fragment [:parameters] parameters)
+      []))
+
+(models/add-type! :parameters-list
+  :in  (comp json-in normalize-parameters-list)
+  :out (comp (catch-normalization-exceptions normalize-parameters-list) json-out-with-keywordization))
+
 (def ^:private MetricSegmentDefinition
   {(s/optional-key :filter)      (s/maybe mbql.s/Filter)
    (s/optional-key :aggregation) (s/maybe [mbql.s/Aggregation])

--- a/src/metabase/query_processor/card.clj
+++ b/src/metabase/query_processor/card.clj
@@ -116,6 +116,28 @@
                   :when                                  (contains? allowed-for widget-type)]
               parameter-type)))
 
+(s/defn check-allowed-parameter-value-type
+  "If a parameter (i.e., a template tag or Dashboard parameter) is specified with `widget-type` (e.g.
+  `:date/all-options`), make sure a user is allowed to pass in parameters with value type `parameter-value-type` (e.g.
+  `:date/range`) for it when running the query, otherwise throw an Exception.
+
+  `parameter-name` is used only for the Exception message and data and can be a name or parameter ID (whichever is
+  more appropriate; Dashboard stuff uses ID while Card stuff tends to use `:name` at this point).
+
+  Background: some more-specific parameter types aren't allowed for certain types of parameters.
+  See [[metabase.mbql.schema/parameter-types]] for details."
+  [parameter-name widget-type :- mbql.s/ParameterType parameter-value-type :- mbql.s/ParameterType]
+  (when-not (allowed-parameter-type-for-template-tag-widget-type? parameter-value-type widget-type)
+    (let [allowed-types (allowed-parameter-types-for-template-tag-widget-type widget-type)]
+      (throw (ex-info (tru "Invalid parameter type {0} for parameter {1}. Parameter type must be one of: {2}"
+                           parameter-value-type
+                           (pr-str parameter-name)
+                           (str/join ", " (sort allowed-types)))
+                      {:type              qp.error-type/invalid-parameter
+                       :invalid-parameter parameter-name
+                       :template-tag-type widget-type
+                       :allowed-types     allowed-types})))))
+
 (defn- infer-parameter-name
   "Attempt to infer the name of a parameter. Uses `:name` if explicitly specified, otherwise attempts to infer this by
   parsing `:target`. Parameters are matched up by name for validation purposes."
@@ -142,16 +164,7 @@
                                                         :invalid-parameter  request-parameter
                                                         :allowed-parameters (keys template-tags)})))]
           ;; now make sure the type agrees as well
-          (when-not (allowed-parameter-type-for-template-tag-widget-type? (:type request-parameter) matching-widget-type)
-            (let [allowed-types (allowed-parameter-types-for-template-tag-widget-type matching-widget-type)]
-              (throw (ex-info (tru "Invalid parameter type {0} for template tag {1}. Parameter type must be one of: {2}"
-                                   (:type request-parameter)
-                                   (pr-str parameter-name)
-                                   (str/join ", " (sort allowed-types)))
-                              {:type              qp.error-type/invalid-parameter
-                               :invalid-parameter request-parameter
-                               :template-tag-type matching-widget-type
-                               :allowed-types     allowed-types})))))))))
+          (check-allowed-parameter-value-type parameter-name matching-widget-type (:type request-parameter)))))))
 
 (defn run-query-for-card-async
   "Run the query for Card with `parameters` and `constraints`, and return results in a

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -1667,13 +1667,7 @@
                              (mt/user-http-request :rasta :post 202 url
                                                    {:parameters [{:id    "_PRICE_"
                                                                   :type  :number/=
-                                                                  :value [1 2 3]}]}))))
-              (testing :number/<=
-                (is (schema= (dashboard-card-query-expected-results-schema :row-count 94)
-                             (mt/user-http-request :rasta :post 202 url
-                                                   {:parameters [{:id    "_PRICE_"
-                                                                  :type  :number/<=
-                                                                  :value [3]}]}))))))
+                                                                  :value [1 2 3]}]}))))))
           (testing "Should return error if parameter doesn't exist"
             (is (= "Dashboard does not have a parameter with ID \"_THIS_PARAMETER_DOES_NOT_EXIST_\"."
                    (mt/user-http-request :rasta :post 400 url

--- a/test/metabase/models/dashboard_card_test.clj
+++ b/test/metabase/models/dashboard_card_test.clj
@@ -242,13 +242,13 @@
 (deftest normalize-parameter-mappings-test
   (testing "make sure parameter mappings correctly normalize things like legacy MBQL clauses"
     (is (= [{:target [:dimension [:field 30 {:source-field 23}]]}]
-           ((i.test/type-fn ::dashboard-card/parameter-mappings :out)
+           ((i.test/type-fn :parameters-list :out)
             (json/generate-string
              [{:target [:dimension [:fk-> 23 30]]}]))))
 
     (testing "...but parameter mappings we should not normalize things like :target"
       (is (= [{:card-id 123, :hash "abc", :target "foo"}]
-             ((i.test/type-fn ::dashboard-card/parameter-mappings :out)
+             ((i.test/type-fn :parameters-list :out)
               (json/generate-string
                [{:card-id 123, :hash "abc", :target "foo"}])))))))
 
@@ -256,5 +256,5 @@
   (testing (str "we should keep empty parameter mappings as empty instead of making them nil (if `normalize` removes "
                 "them because they are empty) (I think this is to prevent NPEs on the FE? Not sure why we do this)")
     (is (= []
-           ((i.test/type-fn ::dashboard-card/parameter-mappings :out)
+           ((i.test/type-fn :parameters-list :out)
             (json/generate-string []))))))

--- a/test/metabase/models/dashboard_test.clj
+++ b/test/metabase/models/dashboard_test.clj
@@ -290,3 +290,20 @@
              clojure.lang.ExceptionInfo
              #":parameters must be a sequence of maps with String :id keys"
              (db/update! Dashboard id :parameters [{:id 100}])))))))
+
+(deftest normalize-parameters-test
+  (testing ":parameters should get normalized when coming out of the DB"
+    (doseq [[target expected] {[:dimension [:field-id 1000]] [:dimension [:field 1000 nil]]
+                               [:field-id 1000]              [:field 1000 nil]}]
+      (testing (format "target = %s" (pr-str target))
+        (mt/with-temp Dashboard [{dashboard-id :id} {:parameters [{:name   "Category Name"
+                                                                   :slug   "category_name"
+                                                                   :id     "_CATEGORY_NAME_"
+                                                                   :type   "category"
+                                                                   :target target}]}]
+          (is (= [{:name   "Category Name"
+                   :slug   "category_name"
+                   :id     "_CATEGORY_NAME_"
+                   :type   :category
+                   :target expected}]
+                 (db/select-one-field :parameters Dashboard :id dashboard-id))))))))

--- a/test/metabase/models/interface_test.clj
+++ b/test/metabase/models/interface_test.clj
@@ -56,7 +56,7 @@
                 "sure the Toucan type fn handles the error gracefully")
     (with-redefs [normalize/normalize-tokens (fn [& _] (throw (Exception. "BARF")))]
       (is (= nil
-             ((type-fn ::dashboard-card/parameter-mappings :out)
+             ((type-fn :parameters-list :out)
               (json/generate-string
                [{:target [:dimension [:field "ABC" nil]]}])))))))
 
@@ -65,5 +65,5 @@
     (is (thrown?
          Exception
          (with-redefs [normalize/normalize-tokens (fn [& _] (throw (Exception. "BARF")))]
-           ((type-fn ::dashboard-card/parameter-mappings :in)
+           ((type-fn :parameters-list :in)
             [{:target [:dimension [:field "ABC" nil]]}]))))))

--- a/test/metabase/models/interface_test.clj
+++ b/test/metabase/models/interface_test.clj
@@ -2,7 +2,6 @@
   (:require [cheshire.core :as json]
             [clojure.test :refer :all]
             [metabase.mbql.normalize :as normalize]
-            [metabase.models.dashboard-card :as dashboard-card]
             [toucan.models :as t.models]))
 
 ;; let's make sure the `:metabase-query`/`:metric-segment-definition`/`::dashboard-card/parameter-mappings`

--- a/test/metabase/query_processor/card_test.clj
+++ b/test/metabase/query_processor/card_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.query-processor.card-test
+  "There are more e2e tests in [[metabase.api.card-test]]."
   (:require [clojure.test :refer :all]
             [metabase.api.common :as api]
             [metabase.models :refer [Card Dashboard Database]]
@@ -146,7 +147,7 @@
             (testing disallowed-type
               (is (thrown-with-msg?
                    clojure.lang.ExceptionInfo
-                   #"Invalid parameter type :[^\s]+ for template tag \"date\".*/"
+                   #"Invalid parameter type :[^\s]+ for parameter \"date\".*/"
                    (validate disallowed-type)))
               (testing "should be ignored if `*allow-arbitrary-mbql-parameters*` is enabled"
                 (binding [qp.card/*allow-arbitrary-mbql-parameters* true]

--- a/test/metabase/query_processor/dashboard_test.clj
+++ b/test/metabase/query_processor/dashboard_test.clj
@@ -67,7 +67,7 @@
                                                             :target       [:variable [:template-tag "x"]]}]}]]
       (testing "param resolution code should include default values"
         (is (schema= [(s/one
-                       {:type     (s/eq "category")
+                       {:type     (s/eq :category)
                         :id       (s/eq "__X__")
                         :default  (s/eq 3)
                         :target   (s/eq [:variable [:template-tag "x"]])

--- a/test/metabase/query_processor/dashboard_test.clj
+++ b/test/metabase/query_processor/dashboard_test.clj
@@ -1,13 +1,37 @@
 (ns metabase.query-processor.dashboard-test
-  "There are a lot of additional tests in [[metabase.api.dashboard-test]]"
+  "There are more e2e tests in [[metabase.api.dashboard-test]]."
   (:require [clojure.test :refer :all]
             [metabase.api.common :as api]
+            [metabase.api.dashboard-test :as api.dashboard-test]
             [metabase.models :refer [Card Dashboard DashboardCard]]
             [metabase.query-processor :as qp]
             [metabase.query-processor.card-test :as qp.card-test]
             [metabase.query-processor.dashboard :as qp.dashboard]
             [metabase.test :as mt]
             [schema.core :as s]))
+
+;; there are more tests in [[metabase.api.dashboard-test]]
+
+(deftest resolve-parameters-validation-test
+  (api.dashboard-test/with-chain-filter-fixtures [{{dashboard-id :id} :dashboard, {card-id :id} :card}]
+    (letfn [(resolve-params [params]
+              (#'qp.dashboard/resolve-params-for-query dashboard-id card-id params))]
+      (testing "Valid parameters"
+        (is (= [{:type   :category
+                 :id     "_PRICE_"
+                 :value  4
+                 :target [:dimension [:field (mt/id :venues :price) nil]]}]
+               (resolve-params [{:id "_PRICE_", :value 4}]))))
+      (testing "Should error if parameter doesn't exist"
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"Dashboard does not have a parameter with ID \"_THIS_PARAMETER_DOES_NOT_EXIST_\".*"
+             (resolve-params [{:id "_THIS_PARAMETER_DOES_NOT_EXIST_", :value 3}]))))
+      (testing "Should error if parameter is of a different type"
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"Invalid parameter type :number/!= for parameter \"_PRICE_\".*"
+             (resolve-params [{:id "_PRICE_", :value 4, :type :number/!=}])))))))
 
 (defn- run-query-for-dashcard [dashboard-id card-id & options]
   ;; TODO -- we shouldn't do the perms checks if there is no current User context. It seems like API-level perms check


### PR DESCRIPTION
Part of https://github.com/metabase/metaboat/issues/144

Follow-on to #19188 and #18994

This PR tweaks the Dashboard parameters validation code added in #18994 to also check parameter types like we do for Cards starting in #19188