### PR TITLE
Skip node_modules caching for Percy CI

### DIFF
--- a/.github/workflows/percy-issue-comment.yml
+++ b/.github/workflows/percy-issue-comment.yml
@@ -131,11 +131,6 @@ jobs:
         with:
           path: ~/.cache/yarn
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-      - name: Get node_modules cache
-        uses: actions/cache@v2
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile --prefer-offline
 
       - uses: actions/download-artifact@v2

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -105,13 +105,6 @@ jobs:
         with:
           path: ~/.cache/yarn
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-      - name: Get node_modules and Cypress cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            node_modules
-            ~/..cache/Cypress
-          key: ${{ runner.os }}-node-modules-cypress-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile --prefer-offline
 
       - uses: actions/download-artifact@v2


### PR DESCRIPTION
Caching node_modules (see PR #19202) doesn't seem to _always_ work for Percy CI workflow, there must be some non-deterministic behavior somewhere.
Until we figure out that, skip node_modules caching for now to unblock Percy CI runs.
