### PR TITLE
React Ace: keep autosuggestions on backspace

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -368,7 +368,6 @@ export default class ExpressionEditorTextfield extends React.Component {
   }
 
   onCursorChange(selection) {
-    const range = selection.getRange();
     const cursor = selection.getCursor();
 
     const { query, startRule } = this.props;
@@ -381,7 +380,7 @@ export default class ExpressionEditorTextfield extends React.Component {
     });
 
     this.setState({
-      suggestions: range.isEmpty() ? suggestions : [],
+      suggestions: suggestions || [],
       helpText,
     });
   }


### PR DESCRIPTION
### How to Test

Type `tri` in the custom expression editor.
Then hit backspace.

Autosuggestion should still be rendered with `trim()` as an option.