### PR TITLE
Tweak the font

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -137,6 +137,11 @@ export default class ExpressionEditorTextfield extends React.Component {
     const { editor } = this.input.current;
     editor.getSession().setMode(new ExpressionMode());
 
+    editor.setOptions({
+      fontFamily: "Monaco, monospace",
+      fontSize: "12px",
+    });
+
     this._setCaretPosition(
       this.state.source.length,
       this.state.source.length === 0,

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.styled.jsx
@@ -31,8 +31,7 @@ export const EditorContainer = styled.div`
 `;
 
 export const EditorEqualsSign = styled.div`
-  font: 12px / normal "Monaco", "Menlo", "Ubuntu Mono", "Consolas",
-    "source-code-pro", monospace;
+  font: 12px / normal "Monaco", monospace;
   height: 12px;
   font-weight: 700;
   margin: 0 3px 0 ${space(0)};


### PR DESCRIPTION
It turns out that we have to change the font through Ace API because the font metrics are used for e.g. cursor calculation etc.

This PR makes it so that the look is now identical (left: v41, right: react-ace):

![image](https://user-images.githubusercontent.com/7288/145283355-f8472f2c-362b-430e-b3e3-7d65e7363c81.png)
