### PR TITLE
Site url validation fixes #14491

### DIFF
--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -137,7 +137,7 @@
   "Is `s` a valid HTTP/HTTPS URL string?"
   ^Boolean [s]
   (let [validator (UrlValidator. (varargs String ["http" "https"])
-                                 (RegexValidator. "^\\p{Alnum}+([\\.|\\-]\\p{Alnum}+)*(:\\d*)?")
+                                 (RegexValidator. "^[\\p{Alnum}\\_]+([\\.|\\-][\\p{Alnum}\\_]+)*(:\\d*)?")
                                  UrlValidator/ALLOW_LOCAL_URLS)]
     (.isValid validator (str s))))
 
@@ -164,7 +164,6 @@
   [f x]
   (or (nil? x)
       (f x)))
-
 
 (def ^:private ^:const host-up-timeout
   "Timeout (in ms) for checking if a host is available with `host-up?` and `host-port-up?`."

--- a/test/metabase/util_test.clj
+++ b/test/metabase/util_test.clj
@@ -53,6 +53,7 @@
     "http://localhost:3000/auth/reset_password/144_f98987de-53ca-4335-81da-31bb0de8ea2b#new" true
     "http://192.168.1.10/"                                                                   true
     "http://metabase.intranet/"                                                              true
+    "http://under_score.ca/"                                                                 true
     ;; missing protocol
     "google.com"                                                                             false
     ;; protocol isn't HTTP/HTTPS

--- a/test/metabase/util_test.clj
+++ b/test/metabase/util_test.clj
@@ -58,7 +58,7 @@
     "http://_under_score.ca/"                                                                true
     "http://__under_score.ca/"                                                               true
     "http://hy-phen.ca/"                                                                     true
-    "http://hy--phen.ca/"                                                                     true
+    "http://hy--phen.ca/"                                                                    true
     "http://two..dots.ca"                                                                    false
     ;; missing protocol
     "google.com"                                                                             false

--- a/test/metabase/util_test.clj
+++ b/test/metabase/util_test.clj
@@ -54,6 +54,12 @@
     "http://192.168.1.10/"                                                                   true
     "http://metabase.intranet/"                                                              true
     "http://under_score.ca/"                                                                 true
+    "http://under__score.ca/"                                                                true
+    "http://_under_score.ca/"                                                                true
+    "http://__under_score.ca/"                                                               true
+    "http://hy-phen.ca/"                                                                     true
+    "http://hy--phen.ca/"                                                                     true
+    "http://two..dots.ca"                                                                    false
     ;; missing protocol
     "google.com"                                                                             false
     ;; protocol isn't HTTP/HTTPS


### PR DESCRIPTION
The url? predicate function in our utils namespace uses UrlValidator from Apache commons with a custom regex. This was done, I think, to allow URLs with internal TLDs. (eg. "https://metabase.intranet").

Now, a url like this: "https://under_score.ca" is accepted.

Relevant RFC for domain names:
[RFC2181 Section 11](https://www.rfc-editor.org/rfc/rfc2181#section-11)

Relevant RFC for hostnames:
[RFC1123 Section 2.1](https://www.ietf.org/rfc/rfc1123.html#section-2.1)

It seems that our url? regex is for hostnames, and is based on the UrlValidator code . 

Though the issue #14491 author brings up the RFC1034 (which links to RFC1123 with a bit of a spec) to indicate that underscores SHOULD be allowed, they aren't really in that case. But it seems that there's wiggle room in allowing it for domains generally, and perhaps we should permit the use of underscores in this URL validation to allow for more configuration options for our users.

A stackoverflow page with helpful context and explanantion which helped me think about this:
[can-domain-name-subdomains-have-an-underscore-in-it](https://stackoverflow.com/questions/2180465/can-domain-name-subdomains-have-an-underscore-in-it)