### PR TITLE
add renderItemWrapper function to AccordionList

### DIFF
--- a/frontend/src/metabase/components/AccordionList/AccordionList.info.js
+++ b/frontend/src/metabase/components/AccordionList/AccordionList.info.js
@@ -1,5 +1,8 @@
 import React from "react";
+import styled from "styled-components";
+
 import AccordionList from "metabase/components/AccordionList";
+import TippyPopover from "metabase/components/Popover/TippyPopover";
 
 export const component = AccordionList;
 export const category = "pickers";
@@ -8,6 +11,9 @@ export const description = `
 An expandable and searchable list of sections and items.
 `;
 
+const PopoverContent = styled.div`
+  padding: 1em;
+`;
 const sections = [
   {
     name: "Widgets",
@@ -49,6 +55,22 @@ export const examples = {
       sections={sections.slice(0, 1)}
       itemIsSelected={item => item.name === "Foo"}
       hideSingleSectionTitle
+    />
+  ),
+  "List Item Popover": (
+    <AccordionList
+      className="text-brand full"
+      sections={sections}
+      itemIsSelected={item => item.name === "Foo"}
+      renderItemWrapper={(itemContent, item) => (
+        <TippyPopover
+          placement="left-start"
+          interactive
+          content={<PopoverContent>{item.name}</PopoverContent>}
+        >
+          {itemContent}
+        </TippyPopover>
+      )}
     />
   ),
 };

--- a/frontend/src/metabase/components/AccordionList/AccordionList.jsx
+++ b/frontend/src/metabase/components/AccordionList/AccordionList.jsx
@@ -73,6 +73,7 @@ export default class AccordionList extends Component {
     renderItemDescription: PropTypes.func,
     renderItemIcon: PropTypes.func,
     renderItemExtra: PropTypes.func,
+    renderItemWrapper: PropTypes.func,
     getItemClassName: PropTypes.func,
 
     alwaysTogglable: PropTypes.bool,
@@ -474,6 +475,7 @@ const AccordionListCell = ({
   renderItemDescription,
   renderItemIcon,
   renderItemExtra,
+  renderItemWrapper,
   searchText,
   onChangeSearchText,
   searchPlaceholder,
@@ -601,6 +603,10 @@ const AccordionListCell = ({
         )}
       </div>
     );
+
+    if (renderItemWrapper) {
+      content = renderItemWrapper(content, item);
+    }
   }
 
   return (

--- a/frontend/src/metabase/components/AccordionList/AccordionList.unit.spec.js
+++ b/frontend/src/metabase/components/AccordionList/AccordionList.unit.spec.js
@@ -1,7 +1,9 @@
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import AccordionList from "metabase/components/AccordionList";
+import TippyPopover from "metabase/components/Popover/TippyPopover";
 
 const SECTIONS = [
   {
@@ -79,6 +81,28 @@ describe("AccordionList", () => {
 
     fireEvent.change(SEARCH_FIELD, { target: { value: "Something Else" } });
     assertAbsence(["Foo", "Bar", "Baz"]);
+  });
+
+  describe("with the `renderItemWrapper` prop", () => {
+    it("should be able to wrap the list items in components like popovers", async () => {
+      const renderItemWrapper = (itemContent, item) => {
+        return (
+          <TippyPopover content={<div>popover</div>}>
+            {itemContent}
+          </TippyPopover>
+        );
+      };
+
+      render(
+        <AccordionList
+          sections={SECTIONS}
+          renderItemWrapper={renderItemWrapper}
+        />,
+      );
+
+      userEvent.hover(screen.getByText("Foo"));
+      expect(await screen.findByText("popover")).toBeVisible();
+    });
   });
 });
 

--- a/frontend/src/metabase/components/AccordionList/index.js
+++ b/frontend/src/metabase/components/AccordionList/index.js
@@ -1,0 +1,1 @@
+export { default } from "./AccordionList";


### PR DESCRIPTION
#18738

This PR adds the `renderItemWrapper` function prop to `AccordionList`. This gives us more control over modifying specific items in the list. For example, it enables us to wrap specific items in tooltips or popovers. There's an example on the `/_internal/components/accordionlist` route:

![Screen Shot 2021-12-09 at 12 50 50 PM](https://user-images.githubusercontent.com/13057258/145473696-67c57e8c-e674-4051-9f3e-00478b4f6724.png)
 