### PR TITLE
Add info from `field.fingerprint` to the `DimensionInfo` component

### DIFF
--- a/frontend/src/metabase/components/MetadataInfo/DimensionInfo/DimensionInfo.info.js
+++ b/frontend/src/metabase/components/MetadataInfo/DimensionInfo/DimensionInfo.info.js
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { PRODUCTS, metadata } from "__support__/sample_dataset_fixture";
+import { PRODUCTS, ORDERS, metadata } from "__support__/sample_dataset_fixture";
 import Dimension from "metabase-lib/lib/Dimension";
 import Card from "metabase/components/Card";
 import PopoverWithTrigger from "metabase/components/PopoverWithTrigger";
@@ -12,6 +12,43 @@ const fieldDimension = Dimension.parseMBQL(
   ["field", PRODUCTS.CATEGORY.id, null],
   metadata,
 );
+fieldDimension.field().fingerprint = {
+  global: {
+    "distinct-count": 5,
+  },
+};
+
+const numberDimension = Dimension.parseMBQL(
+  ["field", ORDERS.TOTAL.id, null],
+  metadata,
+);
+numberDimension.field().fingerprint = {
+  type: {
+    "type/Number": {
+      avg: 3.5,
+      min: 2,
+      max: 5,
+    },
+  },
+};
+
+const dateDimension = Dimension.parseMBQL(
+  ["field", PRODUCTS.CREATED_AT.id, null],
+  metadata,
+);
+dateDimension.field().table = {
+  database: {
+    timezone: "America/Los_Angeles",
+  },
+};
+dateDimension.field().fingerprint = {
+  type: {
+    "type/DateTime": {
+      earliest: "2021-11-09T04:43:33.667Z",
+      latest: "2021-12-09T04:43:33.667Z",
+    },
+  },
+};
 
 const expressionDimension = Dimension.parseMBQL(
   [
@@ -49,5 +86,15 @@ export const examples = {
     <PopoverWithTrigger triggerElement={<Button>click me</Button>}>
       <DimensionInfo dimension={longDescriptionDimension} />
     </PopoverWithTrigger>
+  ),
+  "with number fingerprint": (
+    <Card>
+      <DimensionInfo dimension={numberDimension} />
+    </Card>
+  ),
+  "with date fingerprint": (
+    <Card>
+      <DimensionInfo dimension={dateDimension} />
+    </Card>
   ),
 };

--- a/frontend/src/metabase/components/MetadataInfo/DimensionInfo/DimensionInfo.jsx
+++ b/frontend/src/metabase/components/MetadataInfo/DimensionInfo/DimensionInfo.jsx
@@ -4,6 +4,7 @@ import { t } from "ttag";
 
 import Dimension from "metabase-lib/lib/Dimension";
 import DimensionLabel from "metabase/components/MetadataInfo/DimensionLabel";
+import FieldFingerprintInfo from "metabase/components/MetadataInfo/FieldFingerprintInfo";
 
 import {
   InfoContainer,
@@ -27,6 +28,7 @@ function DimensionInfo({ className, dimension }) {
         <EmptyDescription>{t`No description`}</EmptyDescription>
       )}
       <DimensionLabel dimension={dimension} />
+      <FieldFingerprintInfo field={dimension.field()} />
     </InfoContainer>
   );
 }

--- a/frontend/src/metabase/components/MetadataInfo/FieldFingerprintInfo/FieldFingerprintInfo.jsx
+++ b/frontend/src/metabase/components/MetadataInfo/FieldFingerprintInfo/FieldFingerprintInfo.jsx
@@ -1,0 +1,117 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { t, ngettext, msgid } from "ttag";
+
+import { formatDateTimeWithUnit } from "metabase/lib/formatting";
+import Field from "metabase-lib/lib/metadata/Field";
+
+import FieldValuesList from "./FieldValuesList";
+
+const propTypes = {
+  field: PropTypes.instanceOf(Field),
+};
+
+function FieldFingerprintInfo({ field }) {
+  if (!field?.fingerprint) {
+    return null;
+  }
+
+  if (field.isDate()) {
+    return <DateTimeFingerprint field={field} />;
+  } else if (field.isNumber()) {
+    return <NumberFingerprint field={field} />;
+  } else if (field.isCategory()) {
+    return <CategoryFingerprint field={field} />;
+  } else {
+    return null;
+  }
+}
+
+function DateTimeFingerprint({ field }) {
+  const dateTimeFingerprint = field.fingerprint.type["type/DateTime"];
+  if (!dateTimeFingerprint) {
+    return null;
+  }
+
+  const timezone = field?.table?.database?.timezone;
+  const { earliest, latest } = dateTimeFingerprint;
+  const formattedEarliest = formatDateTimeWithUnit(earliest, "minute");
+  const formattedLatest = formatDateTimeWithUnit(latest, "minute");
+
+  return (
+    <table>
+      <tbody>
+        <tr>
+          <th>{t`Timezone`}</th>
+          <td>{timezone}</td>
+        </tr>
+        <tr>
+          <th>{t`Earliest date`}</th>
+          <td>{formattedEarliest}</td>
+        </tr>
+        <tr>
+          <th>{t`Latest date`}</th>
+          <td>{formattedLatest}</td>
+        </tr>
+      </tbody>
+    </table>
+  );
+}
+
+function NumberFingerprint({ field }) {
+  const numberFingerprint = field.fingerprint.type["type/Number"];
+  if (!numberFingerprint) {
+    return null;
+  }
+
+  const { avg, min, max } = numberFingerprint;
+  const fixedAvg = Number.isInteger(avg) ? avg : avg.toFixed(2);
+  const fixedMin = Number.isInteger(min) ? min : min.toFixed(2);
+  const fixedMax = Number.isInteger(max) ? max : max.toFixed(2);
+
+  return (
+    <table>
+      <thead>
+        <tr>
+          <th>{t`Average`}</th>
+          <th>{t`Min`}</th>
+          <th>{t`Max`}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>{fixedAvg}</td>
+          <td>{fixedMin}</td>
+          <td>{fixedMax}</td>
+        </tr>
+      </tbody>
+    </table>
+  );
+}
+
+function CategoryFingerprint({ field }) {
+  const distinctCount = field.fingerprint.global?.["distinct-count"];
+  if (distinctCount == null) {
+    return null;
+  }
+
+  return (
+    <div>
+      <div>
+        {ngettext(
+          msgid`${distinctCount} distinct value`,
+          `${distinctCount} distinct values`,
+          distinctCount,
+        )}
+      </div>
+      <FieldValuesList field={field} />
+    </div>
+  );
+}
+
+FieldFingerprintInfo.propTypes = propTypes;
+DateTimeFingerprint.propTypes = propTypes;
+NumberFingerprint.propTypes = propTypes;
+CategoryFingerprint.propTypes = propTypes;
+
+export default FieldFingerprintInfo;

--- a/frontend/src/metabase/components/MetadataInfo/FieldFingerprintInfo/FieldFingerprintInfo.unit.spec.js
+++ b/frontend/src/metabase/components/MetadataInfo/FieldFingerprintInfo/FieldFingerprintInfo.unit.spec.js
@@ -1,0 +1,182 @@
+import React from "react";
+import { renderWithProviders, screen } from "__support__/ui";
+
+import { PRODUCTS, metadata } from "__support__/sample_dataset_fixture";
+import Dimension from "metabase-lib/lib/Dimension";
+
+import FieldFingerprintInfo from "./FieldFingerprintInfo";
+
+function setup(field) {
+  return renderWithProviders(<FieldFingerprintInfo field={field} />);
+}
+
+describe("FieldFingerprintInfo", () => {
+  describe("without fingerprint", () => {
+    it("should render nothing", () => {
+      const field = Dimension.parseMBQL(
+        ["field", PRODUCTS.CREATED_AT.id, null],
+        metadata,
+      ).field();
+
+      delete field.fingerprint;
+      const { container } = setup(field);
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  describe("Date field", () => {
+    const dateField = Dimension.parseMBQL(
+      ["field", PRODUCTS.CREATED_AT.id, null],
+      metadata,
+    ).field();
+    let container;
+
+    describe("without type/DateTime fingerprint", () => {
+      beforeEach(() => {
+        dateField.fingerprint = { type: {} };
+        const wrapper = setup(dateField);
+        container = wrapper.container;
+      });
+
+      it("should render nothing", () => {
+        expect(container.firstChild).toBeNull();
+      });
+    });
+
+    describe("with type/DateTime fingerprint", () => {
+      beforeEach(() => {
+        dateField.fingerprint = {
+          type: {
+            "type/DateTime": {
+              earliest: "2021-11-09T04:43:33.667Z",
+              latest: "2021-12-09T04:43:33.667Z",
+            },
+          },
+        };
+        dateField.table = {
+          database: {
+            timezone: "America/Los_Angeles",
+          },
+        };
+        setup(dateField);
+      });
+
+      it("should show the timezone of the field", () => {
+        expect(screen.getByText("America/Los_Angeles")).toBeVisible();
+      });
+
+      it("should render formatted earliest time", () => {
+        expect(screen.getByText("November 9, 2021, 4:43 AM")).toBeVisible();
+      });
+
+      it("should render formatted latest time", () => {
+        expect(screen.getByText("December 9, 2021, 4:43 AM")).toBeVisible();
+      });
+    });
+  });
+
+  describe("Number field", () => {
+    const numberField = Dimension.parseMBQL(
+      ["field", PRODUCTS.RATING.id, null],
+      metadata,
+    ).field();
+    numberField.semantic_type = null;
+    let container;
+
+    describe("without type/Number fingerprint", () => {
+      beforeEach(() => {
+        numberField.fingerprint = { type: {} };
+        const wrapper = setup(numberField);
+        container = wrapper.container;
+      });
+
+      it("should render nothing", () => {
+        expect(container.firstChild).toBeNull();
+      });
+    });
+
+    describe("with type/Number fingerprint", () => {
+      beforeEach(() => {
+        numberField.fingerprint = {
+          type: {
+            "type/Number": {
+              avg: 3.33333,
+              min: 1,
+              max: 5,
+            },
+          },
+        };
+
+        setup(numberField);
+      });
+
+      it("should render avg", () => {
+        expect(screen.getByText("3.33")).toBeVisible();
+      });
+
+      it("should render min", () => {
+        expect(screen.getByText("1")).toBeVisible();
+      });
+
+      it("should render max", () => {
+        expect(screen.getByText("5")).toBeVisible();
+      });
+    });
+  });
+
+  describe("Category field", () => {
+    const categoryField = Dimension.parseMBQL(
+      ["field", PRODUCTS.CATEGORY.id, null],
+      metadata,
+    ).field();
+    let container;
+
+    describe("without type/Category fingerprint", () => {
+      beforeEach(() => {
+        categoryField.fingerprint = { type: {} };
+        const wrapper = setup(categoryField);
+        container = wrapper.container;
+      });
+
+      it("should render nothing", () => {
+        expect(container.firstChild).toBeNull();
+      });
+    });
+
+    describe("with type/Category fingerprint", () => {
+      beforeEach(() => {
+        categoryField.fingerprint = {
+          global: {
+            "distinct-count": 123,
+          },
+        };
+
+        setup(categoryField);
+      });
+
+      it("should render the distinct count value", () => {
+        expect(screen.getByText("123 distinct values")).toBeVisible();
+      });
+    });
+  });
+
+  describe("Other field types", () => {
+    it("should render nothing", () => {
+      const idField = Dimension.parseMBQL(
+        ["field", PRODUCTS.ID.id, null],
+        metadata,
+      ).field();
+      idField.fingerprint = {
+        type: {
+          global: {
+            "distinct-count": 123,
+          },
+          "type/ID": {},
+        },
+      };
+
+      const { container } = setup(idField);
+      expect(container.firstChild).toBeNull();
+    });
+  });
+});

--- a/frontend/src/metabase/components/MetadataInfo/FieldFingerprintInfo/FieldValuesList.jsx
+++ b/frontend/src/metabase/components/MetadataInfo/FieldFingerprintInfo/FieldValuesList.jsx
@@ -37,7 +37,4 @@ export function FieldValuesList({ field, fieldValues = [], fetchFieldValues }) {
 
 FieldValuesList.propTypes = propTypes;
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(FieldValuesList);
+export default connect(mapStateToProps, mapDispatchToProps)(FieldValuesList);

--- a/frontend/src/metabase/components/MetadataInfo/FieldFingerprintInfo/FieldValuesList.jsx
+++ b/frontend/src/metabase/components/MetadataInfo/FieldFingerprintInfo/FieldValuesList.jsx
@@ -1,0 +1,43 @@
+import React, { useEffect } from "react";
+import PropTypes from "prop-types";
+import { connect } from "react-redux";
+
+import Fields from "metabase/entities/fields";
+import Field from "metabase-lib/lib/metadata/Field";
+
+import { NoWrap } from "./FieldValuesList.styled";
+
+const mapStateToProps = (state, props) => ({
+  fieldValues: Fields.selectors.getFieldValues(state, {
+    entityId: props.field.id,
+  }),
+});
+
+const mapDispatchToProps = {
+  fetchFieldValues: Fields.actions.fetchFieldValues,
+};
+
+const propTypes = {
+  field: PropTypes.instanceOf(Field).isRequired,
+  fieldValues: PropTypes.array,
+  fetchFieldValues: PropTypes.func.isRequired,
+};
+
+export function FieldValuesList({ field, fieldValues = [], fetchFieldValues }) {
+  useEffect(() => {
+    if (fieldValues.length === 0 && field.has_field_values === "list") {
+      fetchFieldValues({ id: field.id });
+    }
+  }, [fetchFieldValues, field, fieldValues]);
+
+  const shortenedValuesStr = fieldValues.slice(0, 35).join(", ");
+
+  return fieldValues.length ? <NoWrap>{shortenedValuesStr}</NoWrap> : null;
+}
+
+FieldValuesList.propTypes = propTypes;
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(FieldValuesList);

--- a/frontend/src/metabase/components/MetadataInfo/FieldFingerprintInfo/FieldValuesList.jsx
+++ b/frontend/src/metabase/components/MetadataInfo/FieldFingerprintInfo/FieldValuesList.jsx
@@ -23,6 +23,8 @@ const propTypes = {
   fetchFieldValues: PropTypes.func.isRequired,
 };
 
+const FIELD_VALUES_SHOW_LIMIT = 35;
+
 export function FieldValuesList({ field, fieldValues = [], fetchFieldValues }) {
   useEffect(() => {
     if (fieldValues.length === 0 && field.has_field_values === "list") {
@@ -30,7 +32,9 @@ export function FieldValuesList({ field, fieldValues = [], fetchFieldValues }) {
     }
   }, [fetchFieldValues, field, fieldValues]);
 
-  const shortenedValuesStr = fieldValues.slice(0, 35).join(", ");
+  const shortenedValuesStr = fieldValues
+    .slice(0, FIELD_VALUES_SHOW_LIMIT)
+    .join(", ");
 
   return fieldValues.length ? <NoWrap>{shortenedValuesStr}</NoWrap> : null;
 }

--- a/frontend/src/metabase/components/MetadataInfo/FieldFingerprintInfo/FieldValuesList.styled.jsx
+++ b/frontend/src/metabase/components/MetadataInfo/FieldFingerprintInfo/FieldValuesList.styled.jsx
@@ -1,0 +1,11 @@
+import styled from "styled-components";
+
+import { space } from "metabase/styled-components/theme";
+
+export const NoWrap = styled.div`
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  font-weight: bold;
+  padding-top: ${space(0)} 0;
+`;

--- a/frontend/src/metabase/components/MetadataInfo/FieldFingerprintInfo/FieldValuesList.unit.spec.js
+++ b/frontend/src/metabase/components/MetadataInfo/FieldFingerprintInfo/FieldValuesList.unit.spec.js
@@ -1,0 +1,68 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import { PRODUCTS, metadata } from "__support__/sample_dataset_fixture";
+import Dimension from "metabase-lib/lib/Dimension";
+
+import { FieldValuesList } from "./FieldValuesList";
+
+const categoryField = Dimension.parseMBQL(
+  ["field", PRODUCTS.CATEGORY.id, null],
+  metadata,
+).field();
+
+const mockFetchFieldValues = jest.fn();
+function setup(field, fieldValues) {
+  mockFetchFieldValues.mockReset();
+  return render(
+    <FieldValuesList
+      field={field}
+      fieldValues={fieldValues}
+      fetchFieldValues={mockFetchFieldValues}
+    />,
+  );
+}
+
+describe("FieldValuesList", () => {
+  it("should return nothing when there are no values", () => {
+    const { container } = setup(categoryField, []);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("should return a formatted values list", () => {
+    setup(categoryField, ["foo", "bar"]);
+    expect(screen.getByText("foo, bar")).toBeInTheDocument();
+  });
+
+  it("should return a shortened, formatted values list", () => {
+    setup(categoryField, Array(50).fill("a"));
+    expect(
+      screen.getByText(
+        Array(35)
+          .fill("a")
+          .join(", "),
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("should fetch field values when `fieldValues` is empty and the field is set to list values", () => {
+    categoryField.has_field_values = "list";
+    setup(categoryField, []);
+
+    expect(mockFetchFieldValues).toHaveBeenCalledWith({ id: categoryField.id });
+  });
+
+  it("should not fetch field values when `fieldValues` is not empty", () => {
+    categoryField.has_field_values = "list";
+    setup(categoryField, ["hey"]);
+
+    expect(mockFetchFieldValues).not.toHaveBeenCalled();
+  });
+
+  it("should not fetch field values when the field is not set to list values", () => {
+    categoryField.has_field_values = "search";
+    setup(categoryField, [""]);
+
+    expect(mockFetchFieldValues).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/metabase/components/MetadataInfo/FieldFingerprintInfo/index.js
+++ b/frontend/src/metabase/components/MetadataInfo/FieldFingerprintInfo/index.js
@@ -1,0 +1,1 @@
+export { default } from "./FieldFingerprintInfo";

--- a/frontend/src/metabase/entities/fields.js
+++ b/frontend/src/metabase/entities/fields.js
@@ -62,6 +62,10 @@ const Fields = createEntity({
         }
       );
     },
+    getFieldValues: (state, { entityId }) => {
+      const field = state.entities.fields[entityId];
+      return field ? getFieldValues(field) : [];
+    },
   },
 
   // ACTION CREATORS


### PR DESCRIPTION
#18738

Adds a section to the `DimensionInfo` component based on a field's `fingerprint` property. Seems like this property isn't always there, so settling for a return value of `null` whenever data is unavailable.

![Screen Shot 2021-12-09 at 3 42 35 PM](https://user-images.githubusercontent.com/13057258/145492896-71640e00-1df8-429a-acab-190acb3a573f.png)
![Screen Shot 2021-12-09 at 3 42 47 PM](https://user-images.githubusercontent.com/13057258/145492901-d800d086-1056-4587-9ce7-997016a1b515.png)
