### PR TITLE
Add DimensionInfoPopover component

### DIFF
--- a/frontend/src/metabase/components/MetadataInfo/DimensionInfoPopover/DimensionInfoPopover.jsx
+++ b/frontend/src/metabase/components/MetadataInfo/DimensionInfoPopover/DimensionInfoPopover.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+import Dimension from "metabase-lib/lib/Dimension";
+import TippyPopver from "metabase/components/Popover/TippyPopover";
+import DimensionInfo from "metabase/components/MetadataInfo/DimensionInfo";
+
+export const POPOVER_DELAY = [1000, 300];
+
+const propTypes = {
+  dimension: PropTypes.instanceOf(Dimension),
+  children: PropTypes.node,
+  placement: PropTypes.string,
+};
+
+function DimensionInfoPopover({ dimension, children, placement }) {
+  return dimension ? (
+    <TippyPopver
+      delay={POPOVER_DELAY}
+      interactive
+      placement={placement || "left-start"}
+      content={<DimensionInfo dimension={dimension} />}
+    >
+      {children}
+    </TippyPopver>
+  ) : (
+    children
+  );
+}
+
+DimensionInfoPopover.propTypes = propTypes;
+
+export default DimensionInfoPopover;

--- a/frontend/src/metabase/components/MetadataInfo/DimensionInfoPopover/DimensionInfoPopover.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/DimensionInfoPopover/DimensionInfoPopover.tsx
@@ -2,10 +2,12 @@ import React from "react";
 import PropTypes from "prop-types";
 
 import Dimension from "metabase-lib/lib/Dimension";
-import TippyPopver from "metabase/components/Popover/TippyPopover";
+import TippyPopver, {
+  ITippyPopoverProps,
+} from "metabase/components/Popover/TippyPopover";
 import DimensionInfo from "metabase/components/MetadataInfo/DimensionInfo";
 
-export const POPOVER_DELAY = [1000, 300];
+export const POPOVER_DELAY: [number, number] = [1000, 300];
 
 const propTypes = {
   dimension: PropTypes.instanceOf(Dimension),
@@ -13,7 +15,12 @@ const propTypes = {
   placement: PropTypes.string,
 };
 
-function DimensionInfoPopover({ dimension, children, placement }) {
+type Props = { dimension: Dimension } & Pick<
+  ITippyPopoverProps,
+  "children" | "placement"
+>;
+
+function DimensionInfoPopover({ dimension, children, placement }: Props) {
   return dimension ? (
     <TippyPopver
       delay={POPOVER_DELAY}

--- a/frontend/src/metabase/components/MetadataInfo/DimensionInfoPopover/index.js
+++ b/frontend/src/metabase/components/MetadataInfo/DimensionInfoPopover/index.js
@@ -1,0 +1,1 @@
+export { default } from "./DimensionInfoPopover";

--- a/frontend/src/metabase/components/Popover/TippyPopover.tsx
+++ b/frontend/src/metabase/components/Popover/TippyPopover.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useMemo } from "react";
+import PropTypes from "prop-types";
 import * as Tippy from "@tippyjs/react";
 
 import { isReducedMotionPreferred } from "metabase/lib/dom";
@@ -7,19 +8,25 @@ import EventSandbox from "metabase/components/EventSandbox";
 const TippyComponent = Tippy.default;
 type TippyProps = Tippy.TippyProps;
 
-interface TippyPopoverProps extends TippyProps {
+export interface ITippyPopoverProps extends TippyProps {
   disableContentSandbox?: boolean;
   lazy?: boolean;
 }
 
 const OFFSET: [number, number] = [0, 5];
 
+const propTypes = {
+  disablContentSandbox: PropTypes.bool,
+  lazy: PropTypes.bool,
+  ...TippyComponent.propTypes,
+};
+
 function TippyPopover({
   disableContentSandbox,
   lazy = true,
   content,
   ...props
-}: TippyPopoverProps) {
+}: ITippyPopoverProps) {
   const animationDuration = isReducedMotionPreferred() ? 0 : undefined;
   const [mounted, setMounted] = useState(!lazy);
   const plugins = useMemo(
@@ -60,5 +67,7 @@ function TippyPopover({
     />
   );
 }
+
+TippyPopover.propTypes = propTypes;
 
 export default TippyPopover;


### PR DESCRIPTION
#18738 

A simple popover wrapper around `DimensionInfo` with a few defaulted props like `delay`. Additional unit tests seemed like overkill, but can add if someone wants 'em.

This PR doesn't use the component anywhere, but you can demo it in a branch like #19283 

![Screen Shot 2021-12-09 at 12 57 51 PM](https://user-images.githubusercontent.com/13057258/145474621-e7f8202f-da35-42e1-87e4-53e80ab78029.png)

