### PR TITLE
Fix `ExpressionDimension.prototype.field` error when associated with nested question

### DIFF
--- a/frontend/src/metabase-lib/lib/Dimension.ts
+++ b/frontend/src/metabase-lib/lib/Dimension.ts
@@ -101,7 +101,7 @@ export default class Dimension {
    * Returns true if these two dimensions are identical to one another.
    */
   static isEqual(
-    a: (Dimension | null | undefined) | ConcreteField,
+    a: Dimension | null | undefined | ConcreteField,
     b: Dimension | null | undefined,
   ): boolean {
     const dimensionA: Dimension | null | undefined =
@@ -210,7 +210,7 @@ export default class Dimension {
   /**
    * Is this dimension idential to another dimension or MBQL clause
    */
-  isEqual(other: (Dimension | null | undefined) | ConcreteField): boolean {
+  isEqual(other: Dimension | null | undefined | ConcreteField): boolean {
     if (other == null) {
       return false;
     }
@@ -230,7 +230,7 @@ export default class Dimension {
    * Does this dimension have the same underlying base dimension, typically a field
    */
   isSameBaseDimension(
-    other: (Dimension | null | undefined) | ConcreteField,
+    other: Dimension | null | undefined | ConcreteField,
   ): boolean {
     if (other == null) {
       return false;
@@ -1121,7 +1121,7 @@ export class ExpressionDimension extends Dimension {
 
     if (query) {
       const datasetQuery = query.query();
-      const expressions = datasetQuery ? datasetQuery.expressions : {};
+      const expressions = datasetQuery?.expressions ?? {};
 
       const env = mbql => {
         const dimension = Dimension.parseMBQL(

--- a/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
@@ -15,6 +15,48 @@ import {
   SAMPLE_DATASET,
 } from "__support__/sample_dataset_fixture";
 
+const nestedQuestionCard = {
+  table_id: null,
+  result_metadata: [
+    {
+      name: "boolean",
+      display_name: "boolean",
+      base_type: "type/Boolean",
+      effective_type: "type/Boolean",
+      semantic_type: null,
+      field_ref: [
+        "field",
+        "boolean",
+        {
+          "base-type": "type/Boolean",
+        },
+      ],
+    },
+    {
+      base_type: "type/Text",
+      display_name: "Foo",
+      effective_type: "type/Text",
+      field_ref: ["expression", "Foo"],
+      id: ["field", "Foo", { "base-type": "type/Text" }],
+      name: "Foo",
+      semantic_type: null,
+      table_id: "card__61",
+    },
+  ],
+  database_id: 1,
+  query_type: "query",
+  name: "nested question",
+  dataset_query: {
+    database: 1,
+    query: {
+      "source-table": "card__61",
+    },
+    type: "query",
+  },
+  id: 62,
+  display: "table",
+};
+
 const PRODUCT_CATEGORY_FIELD_ID = 21;
 
 describe("Dimension", () => {
@@ -591,6 +633,31 @@ describe("Dimension", () => {
           field_ref: ["expression", "Hello World"],
         });
       });
+
+      describe("field", () => {
+        it("should return a field inferred from the expression", () => {
+          const field = dimension.field();
+
+          expect(field).toBeInstanceOf(Field);
+          expect(field.name).toEqual("Hello World");
+        });
+
+        describe("when an expression dimension has a query that relies on a nested card", () => {
+          const question = new Question(nestedQuestionCard, metadata);
+          const dimension = Dimension.parseMBQL(
+            ["expression", "Foo"],
+            metadata,
+            question.query(),
+          );
+
+          it("should return a field inferred from the expression", () => {
+            const field = dimension.field();
+
+            expect(field).toBeInstanceOf(Field);
+            expect(field.name).toEqual("Foo");
+          });
+        });
+      });
     });
   });
 
@@ -724,39 +791,7 @@ describe("Dimension", () => {
   });
 
   describe("Nested Question Field Dimension", () => {
-    const card = {
-      table_id: null,
-      result_metadata: [
-        {
-          name: "boolean",
-          display_name: "boolean",
-          base_type: "type/Boolean",
-          effective_type: "type/Boolean",
-          semantic_type: null,
-          field_ref: [
-            "field",
-            "boolean",
-            {
-              "base-type": "type/Boolean",
-            },
-          ],
-        },
-      ],
-      database_id: 1,
-      query_type: "query",
-      name: "nested question",
-      dataset_query: {
-        database: 1,
-        query: {
-          "source-table": "card__61",
-        },
-        type: "query",
-      },
-      id: 62,
-      display: "table",
-    };
-
-    const question = new Question(card, metadata);
+    const question = new Question(nestedQuestionCard, metadata);
 
     const dimension = Dimension.parseMBQL(
       ["field", "boolean", { "base-type": "type/Boolean" }],


### PR DESCRIPTION
`datasetQuery.expressions` is undefined for questions based on nested questions, so we need add a bit more logic to ensure we aren't looking for values on an `undefined` `expressions` variable.

Added a unit test for the specific scenario. It's broken pre-fix:
<img width="717" alt="Screen Shot 2021-12-09 at 12 02 03 AM" src="https://user-images.githubusercontent.com/13057258/145357667-43bce59b-fd8c-49c0-91b3-870fbdddf808.png">

