### PR TITLE
Add DimensionInfoPopover to TableInteractive column headers

### DIFF
--- a/frontend/src/metabase/components/MetadataInfo/DimensionInfoPopover/DimensionInfoPopover.jsx
+++ b/frontend/src/metabase/components/MetadataInfo/DimensionInfoPopover/DimensionInfoPopover.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+import Dimension from "metabase-lib/lib/Dimension";
+import TippyPopver from "metabase/components/Popover/TippyPopover";
+import DimensionInfo from "metabase/components/MetadataInfo/DimensionInfo";
+
+export const POPOVER_DELAY = [1000, 300];
+
+const propTypes = {
+  dimension: PropTypes.instanceOf(Dimension),
+  children: PropTypes.node,
+  placement: PropTypes.string,
+};
+
+function DimensionInfoPopover({ dimension, children, placement }) {
+  return dimension ? (
+    <TippyPopver
+      delay={POPOVER_DELAY}
+      interactive
+      placement={placement || "left-start"}
+      content={<DimensionInfo dimension={dimension} />}
+    >
+      {children}
+    </TippyPopver>
+  ) : (
+    children
+  );
+}
+
+DimensionInfoPopover.propTypes = propTypes;
+
+export default DimensionInfoPopover;

--- a/frontend/src/metabase/visualizations/components/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive.jsx
@@ -30,6 +30,7 @@ import MiniBar from "./MiniBar";
 import { Grid, ScrollSync } from "react-virtualized";
 import Draggable from "react-draggable";
 import Ellipsified from "metabase/components/Ellipsified";
+import DimensionInfoPopover from "metabase/components/MetadataInfo/DimensionInfoPopover";
 
 const HEADER_HEIGHT = 36;
 const ROW_HEIGHT = 36;
@@ -522,6 +523,17 @@ export default class TableInteractive extends Component {
     return style.left;
   }
 
+  @memoize
+  getDimension(column) {
+    const { query } = this.props;
+    const dimension = Dimension.parseMBQL(
+      column.field_ref,
+      query.metadata(),
+      query,
+    );
+    return dimension;
+  }
+
   tableHeaderRenderer = ({ key, style, columnIndex }) => {
     const {
       data,
@@ -631,31 +643,39 @@ export default class TableInteractive extends Component {
               : undefined
           }
         >
-          {renderTableHeaderWrapper(
-            <Ellipsified tooltip={columnTitle}>
-              {isSortable && isRightAligned && (
-                <Icon
-                  className="Icon mr1"
-                  name={isAscending ? "chevronup" : "chevrondown"}
-                  size={8}
-                />
-              )}
-              {columnTitle}
-              {isSortable && !isRightAligned && (
-                <Icon
-                  className="Icon ml1"
-                  name={isAscending ? "chevronup" : "chevrondown"}
-                  size={8}
-                />
-              )}
-            </Ellipsified>,
-            column,
-            columnIndex,
-          )}
+          <DimensionInfoPopover
+            placement="bottom-start"
+            dimension={this.getDimension(column)}
+          >
+            {renderTableHeaderWrapper(
+              <Ellipsified tooltip={columnTitle}>
+                {isSortable && isRightAligned && (
+                  <Icon
+                    className="Icon mr1"
+                    name={isAscending ? "chevronup" : "chevrondown"}
+                    size={8}
+                  />
+                )}
+                {columnTitle}
+                {isSortable && !isRightAligned && (
+                  <Icon
+                    className="Icon ml1"
+                    name={isAscending ? "chevronup" : "chevrondown"}
+                    size={8}
+                  />
+                )}
+              </Ellipsified>,
+              column,
+              columnIndex,
+            )}
+          </DimensionInfoPopover>
           <Draggable
             axis="x"
             bounds={{ left: RESIZE_HANDLE_WIDTH }}
-            position={{ x: this.getColumnWidth({ index: columnIndex }), y: 0 }}
+            position={{
+              x: this.getColumnWidth({ index: columnIndex }),
+              y: 0,
+            }}
             onStart={e => {
               e.stopPropagation();
               this.setState({ dragColIndex: columnIndex });

--- a/frontend/src/metabase/visualizations/components/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive.jsx
@@ -524,13 +524,17 @@ export default class TableInteractive extends Component {
   }
 
   @memoize
-  getDimension(column) {
-    const { query } = this.props;
+  getDimension(column, query) {
+    if (!query) {
+      return undefined;
+    }
+
     const dimension = Dimension.parseMBQL(
       column.field_ref,
       query.metadata(),
       query,
     );
+
     return dimension;
   }
 
@@ -645,7 +649,7 @@ export default class TableInteractive extends Component {
         >
           <DimensionInfoPopover
             placement="bottom-start"
-            dimension={this.getDimension(column)}
+            dimension={this.getDimension(column, this.props.query)}
           >
             {renderTableHeaderWrapper(
               <Ellipsified tooltip={columnTitle}>


### PR DESCRIPTION
This PR adds the `DimensionInfoPopover` from #19281 to the `TableInteractive` component's column headers.

I'm creating a `Dimension` instance in `TableInteractive` using the column's `field_ref` plus the `query` prop that exists on the component. However, it seems like some e2e tests are missing it. In those scenarios, I'm playing it safe and returning `undefined` so that the popover doesn't render.

https://user-images.githubusercontent.com/13057258/145483599-6638753f-0266-42fd-931d-a4efcd18e625.mov

**Testing**
1. Navigate to a Table and hover over the column headers of the table. After 1 second, a popover should appear.
2. Clicking and dragging to move columns around should still work.
3. Navigate to a Dataset -- the popovers should also appear for datasets.
4. Add a Custom Column to a table and hover over the column header for it --  a popover should appear
5. On a GUI question, click "Summarize" and group on a field. If this action converted the qb into some sort of non-table visualization, turn it back into a table and try hovering over the aggregate column header -- should still work.
6. Create a native question and try hovering over column headers -- should still work.
