### PR TITLE
Add DimensionInfoPopover to DataSelector

### DIFF
--- a/frontend/src/metabase/components/MetadataInfo/DimensionInfoPopover/DimensionInfoPopover.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/DimensionInfoPopover/DimensionInfoPopover.tsx
@@ -23,7 +23,11 @@ type Props = { dimension: Dimension } & Pick<
 >;
 
 function DimensionInfoPopover({ dimension, children, placement }: Props) {
-  return dimension ? (
+  // avoid a scenario where we may have a Dimension instance but not enough metadata
+  // to even show a display name (probably indicative of a bug)
+  const hasMetadata = !!(dimension && dimension.displayName());
+
+  return hasMetadata ? (
     <TippyPopver
       delay={isCypressActive ? 0 : POPOVER_DELAY}
       interactive

--- a/frontend/src/metabase/components/MetadataInfo/DimensionInfoPopover/DimensionInfoPopover.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/DimensionInfoPopover/DimensionInfoPopover.tsx
@@ -22,19 +22,8 @@ type Props = { dimension: Dimension } & Pick<
   "children" | "placement"
 >;
 
-function checkForMetadata(dimension: Dimension): boolean {
-  const query = dimension?.query?.();
-  if (dimension && query) {
-    return query.metadata() != null;
-  }
-
-  return false;
-}
-
 function DimensionInfoPopover({ dimension, children, placement }: Props) {
-  const hasMetadata = checkForMetadata(dimension);
-
-  return hasMetadata ? (
+  return dimension ? (
     <TippyPopver
       delay={isCypressActive ? 0 : POPOVER_DELAY}
       interactive

--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -1473,15 +1473,11 @@ const TablePicker = ({
 class FieldPicker extends Component {
   renderItemWrapper = (itemContent, item) => {
     const dimension = item.field?.dimension?.();
-    if (dimension) {
-      return (
-        <DimensionInfoPopover dimension={dimension}>
-          {itemContent}
-        </DimensionInfoPopover>
-      );
-    }
-
-    return itemContent;
+    return (
+      <DimensionInfoPopover dimension={dimension}>
+        {itemContent}
+      </DimensionInfoPopover>
+    );
   };
 
   render() {

--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -16,6 +16,7 @@ import ListSearchField from "metabase/components/ListSearchField";
 import ExternalLink from "metabase/components/ExternalLink";
 import Icon from "metabase/components/Icon";
 import PopoverWithTrigger from "metabase/components/PopoverWithTrigger";
+import DimensionInfoPopover from "metabase/components/MetadataInfo/DimensionInfoPopover";
 import AccordionList from "metabase/components/AccordionList";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 
@@ -1470,6 +1471,19 @@ const TablePicker = ({
 };
 
 class FieldPicker extends Component {
+  renderItemWrapper = (itemContent, item) => {
+    const dimension = item.field?.dimension?.();
+    if (dimension) {
+      return (
+        <DimensionInfoPopover dimension={dimension}>
+          {itemContent}
+        </DimensionInfoPopover>
+      );
+    }
+
+    return itemContent;
+  };
+
   render() {
     const {
       isLoading,
@@ -1531,6 +1545,7 @@ class FieldPicker extends Component {
               <Icon name={item.field.dimension().icon()} size={18} />
             ) : null
           }
+          renderItemWrapper={this.renderItemWrapper}
         />
       </div>
     );

--- a/frontend/test/metabase/scenarios/native-filters/sql-filters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native-filters/sql-filters.cy.spec.js
@@ -2,6 +2,7 @@ import {
   restore,
   openNativeEditor,
   filterWidget,
+  popover,
 } from "__support__/e2e/cypress";
 
 import * as SQLFilter from "./helpers/e2e-sql-filter-helpers";
@@ -118,5 +119,20 @@ describe("scenarios > filters > sql filters > basic filter types", () => {
         cy.findByText("No results!");
       });
     });
+  });
+
+  it("should show an info popover when hovering over fields in the field filter field picker", () => {
+    SQLFilter.enterParameterizedQuery("SELECT * FROM products WHERE {{cat}}");
+
+    SQLFilter.openTypePickerFromDefaultFilterType();
+    SQLFilter.chooseType("Field Filter");
+
+    popover().within(() => {
+      cy.findByText("People").click();
+      cy.findByText("City").trigger("mouseenter");
+    });
+
+    popover().contains("City");
+    popover().contains("1,966 distinct values");
   });
 });

--- a/frontend/test/metabase/scenarios/native-filters/sql-filters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native-filters/sql-filters.cy.spec.js
@@ -121,7 +121,8 @@ describe("scenarios > filters > sql filters > basic filter types", () => {
     });
   });
 
-  it("should show an info popover when hovering over fields in the field filter field picker", () => {
+  // flaky test (#19454)
+  it.skip("should show an info popover when hovering over fields in the field filter field picker", () => {
     SQLFilter.enterParameterizedQuery("SELECT * FROM products WHERE {{cat}}");
 
     SQLFilter.openTypePickerFromDefaultFilterType();


### PR DESCRIPTION
This PR adds the DimensionInfoPopover to the `DataSelector` `FieldPicker` component. This is used in the Native Question's Variable sidebar when selecting a field for a field filter.

**Testing**
1. new question > native question
2. type `{{foo}}` to make the variable sidebar open up
3. change variable type to "field filter"
4. in the dropdown beneath label "Field to map to" hover over field options to see the popover

I've added an e2e test that passes locally (for me), but hover-triggered popover tests are, as I've learned, very flaky. Intend to fix in #19454.

<img width="1499" alt="Screen Shot 2021-12-21 at 2 09 00 PM" src="https://user-images.githubusercontent.com/13057258/147007971-abc82ca4-7449-49cd-bf33-96b98c6cfd7b.png">

