### PR TITLE
Add DimensionInfoPopover to FieldsPicker

### DIFF
--- a/frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx
@@ -4,6 +4,7 @@ import React from "react";
 import { t } from "ttag";
 
 import PopoverWithTrigger from "metabase/components/PopoverWithTrigger";
+import DimensionInfoPopover from "metabase/components/MetadataInfo/DimensionInfoPopover";
 import CheckBox from "metabase/components/CheckBox";
 import StackedCheckBox from "metabase/components/StackedCheckBox";
 
@@ -48,18 +49,19 @@ export default function FieldsPicker({
           </li>
         )}
         {dimensions.map(dimension => (
-          <li key={dimension.key()} className="px1 pb1 flex align-center">
-            <CheckBox
-              data-testid={`field-${dimension.displayName()}`}
-              disabled={disableSelected && selected.has(dimension.key())}
-              checked={selected.has(dimension.key())}
-              label={dimension.displayName()}
-              onChange={() => {
-                onToggleDimension(dimension, !selected.has(dimension.key()));
-              }}
-              className="mr1"
-            />
-          </li>
+          <DimensionInfoPopover dimension={dimension} key={dimension.key()}>
+            <li className="px1 pb1 flex align-center">
+              <CheckBox
+                disabled={disableSelected && selected.has(dimension.key())}
+                checked={selected.has(dimension.key())}
+                label={dimension.displayName()}
+                onChange={() => {
+                  onToggleDimension(dimension, !selected.has(dimension.key()));
+                }}
+                className="mr1"
+              />
+            </li>
+          </DimensionInfoPopover>
         ))}
       </ul>
     </PopoverWithTrigger>

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -878,7 +878,8 @@ describe("scenarios > question > notebook", () => {
     cy.findByText("ID").should("not.exist");
   });
 
-  it("should show an info popover when hovering over a field picker option for a table", () => {
+  // flaky test
+  it.skip("should show an info popover when hovering over a field picker option for a table", () => {
     cy.visit("/question/new");
     cy.contains("Custom question").click();
     cy.contains("Sample Dataset").click();
@@ -892,7 +893,8 @@ describe("scenarios > question > notebook", () => {
     popover().contains("80.36");
   });
 
-  it("should show an info popover when hovering over a field picker option for a saved question", () => {
+  // flaky test
+  it.skip("should show an info popover when hovering over a field picker option for a saved question", () => {
     cy.createNativeQuestion({
       name: "question a",
       native: { query: "select 'foo' as a_column" },

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -853,6 +853,64 @@ describe("scenarios > question > notebook", () => {
       });
     });
   });
+
+  // intentional simplification of "Select none" to quickly
+  // fix users' pain caused by the inability to unselect all columns
+  it("select no columns select the first one", () => {
+    cy.visit("/question/new");
+    cy.contains("Custom question").click();
+    cy.contains("Sample Dataset").click();
+    cy.contains("Orders").click();
+    cy.findByTestId("fields-picker").click();
+
+    popover().within(() => {
+      cy.findByText("Select none").click();
+      cy.findByLabelText("ID").should("be.disabled");
+      cy.findByText("Tax").click();
+      cy.findByLabelText("ID")
+        .should("be.enabled")
+        .click();
+    });
+
+    visualize();
+
+    cy.findByText("Tax");
+    cy.findByText("ID").should("not.exist");
+  });
+
+  it("should show an info popover when hovering over a field picker option for a table", () => {
+    cy.visit("/question/new");
+    cy.contains("Custom question").click();
+    cy.contains("Sample Dataset").click();
+    cy.contains("Orders").click();
+
+    cy.findByTestId("fields-picker").click();
+
+    cy.findByText("Total").trigger("mouseenter");
+
+    popover().contains("The total billed amount.");
+    popover().contains("80.36");
+  });
+
+  it("should show an info popover when hovering over a field picker option for a saved question", () => {
+    cy.createNativeQuestion({
+      name: "question a",
+      native: { query: "select 'foo' as a_column" },
+    });
+
+    // start a custom question with question a
+    cy.visit("/question/new");
+    cy.findByText("Custom question").click();
+    cy.findByText("Saved Questions").click();
+    cy.findByText("question a").click();
+
+    cy.findByTestId("fields-picker").click();
+
+    cy.findByText("A_COLUMN").trigger("mouseenter");
+
+    popover().contains("A_COLUMN");
+    popover().contains("No description");
+  });
 });
 
 // Extracted repro steps for #13000
@@ -900,30 +958,6 @@ function joinTwoSavedQuestions() {
       cy.icon("notebook").click();
       cy.url().should("contain", "/notebook");
     });
-  });
-
-  // intentional simplification of "Select none" to quickly
-  // fix users' pain caused by the inability to unselect all columns
-  it("select no columns select the first one", () => {
-    cy.visit("/question/new");
-    cy.contains("Custom question").click();
-    cy.contains("Sample Dataset").click();
-    cy.contains("Orders").click();
-    cy.findByTestId("fields-picker").click();
-
-    cy.findByText("Select None").click();
-    cy.findByTestId("field-ID").should("be.disabled");
-
-    cy.findByTestId("field-Tax").click();
-
-    cy.findByTestId("field-ID")
-      .should("be.enabled")
-      .click();
-
-    visualize();
-
-    cy.findByText("Tax");
-    cy.findByText("ID").should("not.exist");
   });
 }
 


### PR DESCRIPTION
#18738

This PR wraps the `FieldsPickers` in the `DimensionInfoPopover`.

**Testing**
1. Navigate to the custom question query builder
2. Select a table and then click the directly to the right of the picker to choose columns
3. Hover over options to make the DimensionInfoPopover appear
4. Repeat the above steps for datasets, saved questions, native questions, custom column fields, aggregate fields, template tag fields.

I've added an e2e test that passes locally (for me), but hover-triggered popover tests are, as I've learned, very flaky. Intend to fix in #19454.

![Screen Shot 2021-12-09 at 3 48 15 PM](https://user-images.githubusercontent.com/13057258/145493701-f1143b1b-fdd2-4a6b-a13e-8578ab4de62c.png)
![Screen Shot 2021-12-09 at 3 48 27 PM](https://user-images.githubusercontent.com/13057258/145493702-12dcee6a-dbda-4edd-81de-69c0208cdb52.png)
![Screen Shot 2021-12-09 at 3 48 41 PM](https://user-images.githubusercontent.com/13057258/145493705-06b5da1f-9cc8-457b-a1bf-bba1fa4fe943.png)
![Screen Shot 2021-12-09 at 3 49 20 PM](https://user-images.githubusercontent.com/13057258/145493707-10c1a73c-e0c6-4a54-92a6-95fed7c17bba.png)

