### PR TITLE
Only reject number literal on the left-hand side of a comparison

### DIFF
--- a/frontend/src/metabase/lib/expressions/resolver.js
+++ b/frontend/src/metabase/lib/expressions/resolver.js
@@ -68,7 +68,7 @@ export function resolve(expression, type = "expression", fn = undefined) {
     } else if (COMPARISON_OPS.includes(op)) {
       operandType = "expression";
       const [firstOperand] = operands;
-      if (typeof firstOperand !== "undefined" && !Array.isArray(firstOperand)) {
+      if (typeof firstOperand === "number" && !Array.isArray(firstOperand)) {
         throw new Error(t`Expecting field but found ${firstOperand}`);
       }
     } else if (op === "concat") {

--- a/frontend/test/metabase/lib/expressions/resolver.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/resolver.unit.spec.js
@@ -102,9 +102,13 @@ describe("metabase/lib/expressions/resolve", () => {
     });
 
     // backward-compatibility
-    it("should reject a literal on the left-hand side of a comparison", () => {
+    it("should reject a number literal on the left-hand side of a comparison", () => {
       // 0 < [A]
       expect(() => filter(["<", 0, A])).toThrow();
+    });
+    it("should still allow a string literal on the left-hand side of a comparison", () => {
+      // "XYZ" < [B]
+      expect(() => filter(["<", "XYZ", B])).not.toThrow();
     });
 
     it("should work on functions with optional flag", () => {


### PR DESCRIPTION
The fix in the previous PR #18017 was too aggressive, causing string literal on the left-hand side to be rejected.
This PR rectifies the situation.

To verify:
1. Ask a question, Custom question
2. Sample Dataset, People table
3. Filter, Custom Expression and type `"CA" = [State]`

**Before this PR**

The filter is incorrectly rejected.

![image](https://user-images.githubusercontent.com/7288/145444714-3e72231e-5355-48e9-b1f1-be075cd651d0.png)


**After this PR**

Just like in v41 and earlier, the filter is accepted as a valid one:

![image](https://user-images.githubusercontent.com/7288/145444886-ba17c449-4ed0-4719-baea-b7b67cd4b7d9.png)

