### PR TITLE
Custom expression editor: make the I-beam cursor more subtle

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/expressions.css
+++ b/frontend/src/metabase/query_builder/components/expressions/expressions.css
@@ -11,3 +11,11 @@
 .ace-tm .ace_variable {
   color: var(--color-brand);
 }
+
+.ace_cursor {
+  border-left-width: 1px;
+}
+
+.ace_hidden-cursors .ace_cursor {
+  opacity: 0;
+}


### PR DESCRIPTION

To verify:
1. Ask a question, Custom question
2. Sample Dataset, People table
3. Filter, Custom Expression and type any expression

**Before this PR**

The default I-beam (insertion) cursor is 2px thick. The cursor is also still visible even when the editor doesn't have the focus.

![image](https://user-images.githubusercontent.com/7288/145447488-22b3e7b2-c4f7-499d-aa0c-b04d28748f46.png)


**After this PR**

Just like the editor in v41, the cursor is only 1px thick. Also, the cursor disappears when the editor loses focus.

![image](https://user-images.githubusercontent.com/7288/145447430-cb880735-c060-4fef-93f1-97e7599442c3.png)
