### PR TITLE
Only use bold for custom question in expression editor

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.styled.jsx
@@ -3,7 +3,9 @@ import styled, { css } from "styled-components";
 import { space } from "metabase/styled-components/theme";
 import { color } from "metabase/lib/colors";
 
-export const EditorContainer = styled.div`
+export const EditorContainer = styled.div.attrs({
+  className: "expression-editor-textfield",
+})`
   border: 1px solid;
   border-color: ${color("border")};
   border-radius: ${space(0)};

--- a/frontend/src/metabase/query_builder/components/expressions/expressions.css
+++ b/frontend/src/metabase/query_builder/components/expressions/expressions.css
@@ -1,13 +1,13 @@
-.ace_hidpi .ace_content {
+.expression-editor-textfield .ace_hidpi .ace_content {
   color: #4c5773;
   font-weight: 700;
 }
 
-.ace-tm .ace_keyword,
-.ace-tm .ace_constant.ace_numeric {
+.expression-editor-textfield .ace-tm .ace_keyword,
+.expression-editor-textfield .ace-tm .ace_constant.ace_numeric {
   color: #4c5773;
 }
 
-.ace-tm .ace_variable {
+.expression-editor-textfield .ace-tm .ace_variable {
   color: var(--color-brand);
 }


### PR DESCRIPTION
## How to Test

1. Ask a question
2. Native query
3. Type in the editor

Text should not be bold.

<img src=https://user-images.githubusercontent.com/380816/145462035-866cf504-854a-4f4d-b531-716dfd478430.png width=400 />
