### PR TITLE
Docs - revamp README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -60,22 +60,22 @@
 - [Editing your account settings](./users-guide/account-settings.html)
 - [Managing people and groups](./administration-guide/04-managing-users.html)
 - [Google Sign-In or LDAP](./administration-guide/10-single-sign-on.html)
-- [SAML](./administration-guide/authenticating-with-saml.html)
-- [JWT](./administration-guide/authenticating-with-jwt.html)
-- [Password complexity](./administration-guide/changing-password-complexity.html)
-- [Session expiration](./administration-guide/changing-session-expiration.html)
+- [SAML](./enterprise-guide/authenticating-with-saml.html)
+- [JWT](./enterprise-guide/authenticating-with-jwt.html)
+- [Password complexity](./operations-guide/changing-password-complexity.html)
+- [Session expiration](./operations-guide/changing-session-expiration.html)
 
 ## Permissions
 
 - [Data permissions](./administration-guide/05-setting-permissions.html)
 - [Collection permissions](./administration-guide/06-collections.html)
-- [Sandboxing data based on user attributes](./administration-guide/data-sandboxes.html)
-- [Organizing SQL snippets with folders and permissions](./administration-guide/sql-snippets.html)
+- [Sandboxing data based on user attributes](./enterprise-guide/data-sandboxes.html)
+- [SQL snippets folder permissions](./enterprise-guide/sql-snippets.html)
 
 ## Embedding questions and dashboards
 
-- [Sharing dashboards and questions with public links](./administration-guide/12-public-links.html)
-- [Embedding Metabase in other Applications](./administration-guide/13-embedding.html)
+- [Public links for dashboards and questions](./administration-guide/12-public-links.html)
+- [Embedding Metabase in other applications](./administration-guide/13-embedding.html)
 - [Embedding the entire Metabase app in your own web app](./administration-guide/full-app-embedding.html)
 - [Embedding example apps][embedding-ref-apps]
 - [White labeling charts (branding)](./enterprise-guide/whitelabeling.html)
@@ -86,23 +86,23 @@
 - [Encrypting your database connection](./operations-guide/encrypting-database-details-at-rest.html)
 - [Editing your database metadata](./administration-guide/03-metadata-editing.html)
 - [Creating segments and metrics](./administration-guide/07-segments-and-metrics.html)
-- [SSH tunneling](./operations-guide/ssh-tunnel-for-database-connections.html)
-- [SSL certificate](./operations-guide/secure-database-connections-with-ssl-certificates.html)
+- [SSH tunneling](./administration-guide/ssh-tunnel-for-database-connections.html)
+- [SSL certificate](./administration-guide/secure-database-connections-with-ssl-certificates.html)
 
 ## Configuring Metabase
 
 - [Settings](./administration-guide/08-configuration-settings.html)
 - [Email](./administration-guide/02-setting-up-email.html)
 - [Slack](./administration-guide/09-setting-up-slack.html)
-- [Environment variables](./administration-guide/environment-variables.html)
-- [Handling Timezones](./administration-guide/handling-timezones.html)
-- [Customizing the Metabase Jetty Webserver](./administration-guide/customizing-jetty-webserver.html)
+- [Environment variables](./operations-guide/environment-variables.html)
+- [Handling Timezones](./operations-guide/handling-timezones.html)
+- [Customizing the Metabase Jetty Webserver](./operations-guide/customizing-jetty-webserver.html)
 - [Default formatting](./administration-guide/19-formatting-settings.html)
 - [Localization](./administration-guide/localization.html)
 - [Caching query results](./administration-guide/14-caching.html)
 - [Custom map settings](./administration-guide/20-custom-maps.html)
 
-## Analyzing Metabase
+## Usage and performance tools
 
 - [Auditing tools](./enterprise-guide/audit.html)
 - [Tracking query errors](./enterprise-guide/tools.html)
@@ -118,9 +118,9 @@
 - [Metabase forum][forum].
 - [Configuring Logging](./operations-guide/log-configuration.html)
 
-## Pro and Enterprise
+## Enterprise and Pro editions
 
-- [Getting and activating the Enterprise edition](activating-the-enterprise-edition.html)
+- [Getting and activating the Enterprise edition](./enterprise-guide/activating-the-enterprise-edition.html)
 - [List of premium features][enterprise]
 
 ## Metabase community

--- a/docs/README.md
+++ b/docs/README.md
@@ -76,7 +76,7 @@
 
 - [Public links for dashboards and questions](./administration-guide/12-public-links.html)
 - [Embedding Metabase in other applications](./administration-guide/13-embedding.html)
-- [Embedding the entire Metabase app in your own web app](./administration-guide/full-app-embedding.html)
+- [Embedding the entire Metabase app in your own web app](./enterprise-guide/full-app-embedding.html)
 - [Embedding example apps][embedding-ref-apps]
 - [White labeling charts (branding)](./enterprise-guide/whitelabeling.html)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,103 +1,164 @@
-# Metabase documentation and resources
+## Getting started
 
-## Tutorials
+- [Getting started][getting-started]
+- [A tour of Metabase][tour]
 
-### [Learn Metabase][learn]
+## Tutorials and guides
 
-Learn how to set Metabase up, build out your analytics, organize things and set permissions, and how to do data ops right.
+- [Learn Metabase][learn]
 
-## Getting help
+## Installation and operation
 
-### [Troubleshooting Guide][troubleshooting]
+- [Installing Metabase](./operations-guide/installing-metabase.html)
+- [How to upgrade Metabase](./operations-guide/upgrading-metabase.html)
+- [Application database](./operations-guide/configuring-application-database.html)
+- [Backing up Metabase](./operations-guide/backing-up-metabase-application-data.html)
+- [Migrating to a production application database](./operations-guide/migrating-from-h2.html)
+- [Running database migrations manually](./operations-guide/running-migrations-manually.html)
+- [A word on Java versions](./operations-guide/java-versions.html)
+- [How to setup monitoring via JMX](./operations-guide/jmx-monitoring.html)
+- [Serialization: copying one Metabase instance to another](./enterprise-guide/serialization.html)
 
-Problems, their causes, how to detect them, and how to fix them.
+## Asking questions
 
-### [Metabase forum][forum]
+### Query builder
 
-A place to get help on installation, setting up as well as sharing tips and tricks.
+- [Simple questions](./users-guide/04-asking-questions.html)
+- [Custom questions](./users-guide/custom-questions.html)
+- [Custom expressions](./users-guide/expressions.html)
+- [List of expressions: aggregations and functions](./users-guide/expressions-list.html)
+- [Visualizing data](./users-guide/05-visualizing-results.html)
+- [Using results to ask new questions](./users-guide/referencing-saved-questions-in-queries.html)
 
-### [FAQs][faq]
+### SQL and native queries
 
-Frequently asked questions about Metabase.
+- [The native SQL editor](./users-guide/writing-sql.html)
+- [Viewing metadata](./users-guide/12-data-model-reference.html)
+- [SQL Templates](./users-guide/13-sql-parameters.html)
+- [SQL snippets](./users-guide/sql-snippets.html)
 
-## Metabase reference guides
+### Alerts
 
-Documentation guides for the Metabase application.
+- [Setting and getting alerts](./users-guide/15-alerts.html)
+- [Get answers in Slack with Metabot](./users-guide/11-metabot.html)
 
-### [Users Guide][users-guide]
+## Dashboards
 
-How to ask questions, how to visualize answers, as well as how to share questions and create dashboards.
+- [Creating dashboards](./users-guide/07-dashboards.html)
+- [Dashboard filters](./users-guide/08-dashboard-filters.html)
+- [Interactive dashboards](./users-guide/interactive-dashboards.html)
+- [Dashboard charts with multiple series](./users-guide/09-multi-series-charting.html)
+- [Setting up dashboard subscriptions](./users-guide/dashboard-subscriptions.html)
 
-### [Admin Guide][admin-guide]
+## Collections
 
-How to set up Metabase, configure common settings, manage accounts and permissions, and add databases.
+- [Sharing and organizing your saved questions](./users-guide/06-sharing-answers.html)
+- [Collections](./users-guide/collections.html)
 
-### [Operations Guide][operations-guide]
+## People and groups
 
-Learn how to install Metabase for production use. The guide covers topics like SSL termination, deploying via Docker Containers vs. JAR files, as well as the tradeoffs involved.
+- [Editing your account settings](./users-guide/account-settings.html)
+- [Managing people and groups](./administration-guide/04-managing-users.html)
+- [Google Sign-In or LDAP](./administration-guide/10-single-sign-on.html)
+- [SAML](./administration-guide/authenticating-with-saml.html)
+- [JWT](./administration-guide/authenticating-with-jwt.html)
+- [Password complexity](./administration-guide/changing-password-complexity.html)
+- [Session expiration](./administration-guide/changing-session-expiration.html)
 
-### [Enterprise Guide][enterprise]
+## Permissions
 
-Here’s where to go for help using the features included in [Metabase Enterprise Edition][enterprise-landing].
+- [Data permissions](./administration-guide/05-setting-permissions.html)
+- [Collection permissions](./administration-guide/06-collections.html)
+- [Sandboxing data based on user attributes](./administration-guide/data-sandboxes.html)
+- [Organizing SQL snippets with folders and permissions](./administration-guide/sql-snippets.html)
 
-## Metabase for developers
+## Embedding questions and dashboards
 
-### [Developers Guide][developers]
+- [Sharing dashboards and questions with public links](./administration-guide/12-public-links.html)
+- [Embedding Metabase in other Applications](./administration-guide/13-embedding.html)
+- [Embedding the entire Metabase app in your own web app](./administration-guide/full-app-embedding.html)
+- [Embedding example apps][embedding-ref-apps]
+- [White labeling charts (branding)](./enterprise-guide/whitelabeling.html)
 
-Learn how to contribute to the Metabase open source project.
+## Databases
 
-### [Driver Development][drivers]
+- [Adding data sources](./administration-guide/01-managing-databases.html)
+- [Encrypting your database connection](./operations-guide/encrypting-database-details-at-rest.html)
+- [Editing your database metadata](./administration-guide/03-metadata-editing.html)
+- [Creating segments and metrics](./administration-guide/07-segments-and-metrics.html)
+- [SSH tunneling](./operations-guide/ssh-tunnel-for-database-connections.html)
+- [SSL certificate](./operations-guide/secure-database-connections-with-ssl-certificates.html)
 
-This guide lists existing community drivers, and shows how to get started with driver development.
+## Configuring Metabase
 
-### [Embedding reference apps][embedding-ref-apps]
+- [Settings](./administration-guide/08-configuration-settings.html)
+- [Email](./administration-guide/02-setting-up-email.html)
+- [Slack](./administration-guide/09-setting-up-slack.html)
+- [Environment variables](./administration-guide/environment-variables.html)
+- [Handling Timezones](./administration-guide/handling-timezones.html)
+- [Customizing the Metabase Jetty Webserver](./administration-guide/customizing-jetty-webserver.html)
+- [Default formatting](./administration-guide/19-formatting-settings.html)
+- [Localization](./administration-guide/localization.html)
+- [Caching query results](./administration-guide/14-caching.html)
+- [Custom map settings](./administration-guide/20-custom-maps.html)
 
-Code examples for embedding Metabase in applications.
+## Analyzing Metabase
+
+- [Auditing tools](./enterprise-guide/audit.html)
+- [Tracking query errors](./enterprise-guide/tools.html)
+
+## Metabase API
+
+- [API reference][api-documentation]
+- [API tutorial][api-tutorial]
+
+## Troubleshooting & getting help
+
+- [Troubleshooting Guide][troubleshooting]. 
+- [Metabase forum][forum].
+- [Configuring Logging](./operations-guide/log-configuration.html)
+
+## Pro and Enterprise
+
+- [Getting and activating the Enterprise edition](activating-the-enterprise-edition.html)
+- [List of premium features][enterprise]
 
 ## Metabase community
 
-Connect with others using Metabase and catch up on the latest news.
+- [Metabase forum][forum]
+- [Data Bytes][data-bytes]
+- [Case studies][case-studies]
+- [Blog][blog]
+- [Source code repository on GitHub][source-code]
 
-### [Metabase forum][forum]
+## Developers guide
 
-A place to get help on installation, setting up as well as sharing tips and tricks.
-
-### [Data Bytes][data-bytes]
-
-Real stories about teams working and learning with data. You can also share your own stories.
-
-### [Case studies][case-studies]
-
-See how other organizations, big and small, have leveled up using Metabase.
-
-### [Blog][blog]
-
-Stay up to date on the latest from Metabase.
-
-### [Source code repository on GitHub][source-code]
-
-Metabase is open source: come on over and check out the code.
+- [Developers Guide][developers]
 
 ## Reference
 
-### [Anonymous Information Collection Reference][info-collection]
+- [Anonymous Information Collection Reference][info-collection]
+- [FAQs][faq]: Frequently asked questions about Metabase.
 
-This page describes the anonymous usage information we collect (only if you opt-in), why we collect it, and how we use it to improve Metabase.
-
-[admin-guide]: administration-guide/start.md
+[api-documentation]: ./api-documentation.html
+[api-tutorial]: /learn/administration/metabase-api.html
+[admin-guide]: administration-guide/start.html
 [blog]: /blog
 [case-studies]: https://www.metabase.com/case_studies/
 [embedding-ref-apps]: https://github.com/metabase/embedding-reference-apps
-[enterprise]: enterprise-guide/start.md
+[enterprise]: enterprise-guide/start.html
 [enterprise-landing]: /enterprise
 [data-bytes]: /community
-[developers]: developers-guide/start.md
-[drivers]: developers-guide-drivers.md
-[faq]: faq/start.md
+[developers]: developers-guide/start.html
+[drivers]: developers-guide-drivers.html
+[faq]: faq/start.html
 [forum]: https://discourse.metabase.com/
-[info-collection]: information-collection.md
+[getting-started]: /learn/getting-started/getting-started.html
+[info-collection]: information-collection.html
 [learn]: /learn
-[operations-guide]: operations-guide/start.md
+[operations-guide]: operations-guide/start.html
 [source-code]: https://github.com/metabase/metabase
-[troubleshooting]: troubleshooting-guide/index.md
-[users-guide]: users-guide/start.md
+[tour]: /learn/getting-started/tour-of-metabase.html
+[troubleshooting]: troubleshooting-guide/index.html
+[users-guide]: users-guide/start.html
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,7 +34,7 @@
 
 - [The native SQL editor](./users-guide/writing-sql.html)
 - [Viewing metadata](./users-guide/12-data-model-reference.html)
-- [SQL Templates](./users-guide/13-sql-parameters.html)
+- [SQL templates](./users-guide/13-sql-parameters.html)
 - [SQL snippets](./users-guide/sql-snippets.html)
 
 ### Alerts and Metabot
@@ -95,7 +95,7 @@
 - [Email](./administration-guide/02-setting-up-email.html)
 - [Slack](./administration-guide/09-setting-up-slack.html)
 - [Environment variables](./operations-guide/environment-variables.html)
-- [Handling Timezones](./operations-guide/handling-timezones.html)
+- [Handling timezones](./operations-guide/handling-timezones.html)
 - [Customizing the Metabase Jetty Webserver](./operations-guide/customizing-jetty-webserver.html)
 - [Default formatting](./administration-guide/19-formatting-settings.html)
 - [Localization](./administration-guide/localization.html)
@@ -114,9 +114,9 @@
 
 ## Troubleshooting and getting help
 
-- [Troubleshooting Guide][troubleshooting]. 
-- [Metabase forum][forum].
-- [Configuring Logging](./operations-guide/log-configuration.html)
+- [Troubleshooting guide][troubleshooting] 
+- [Metabase forum][forum]
+- [Configuring logging](./operations-guide/log-configuration.html)
 
 ## Enterprise and Pro editions
 
@@ -143,6 +143,7 @@
 
 - [Anonymous Information Collection Reference][info-collection]
 - [FAQs][faq]
+- [Glossary][glossary]
 
 [api-documentation]: ./api-documentation.html
 [api-tutorial]: /learn/administration/metabase-api.html
@@ -158,6 +159,7 @@
 [faq]: faq/start.html
 [forum]: https://discourse.metabase.com/
 [getting-started]: /learn/getting-started/getting-started.html
+[glossary]: /glossary.html
 [info-collection]: information-collection.html
 [learn]: /learn
 [operations-guide]: operations-guide/start.html

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,7 +37,7 @@
 - [SQL Templates](./users-guide/13-sql-parameters.html)
 - [SQL snippets](./users-guide/sql-snippets.html)
 
-### Alerts
+### Alerts and Metabot
 
 - [Setting and getting alerts](./users-guide/15-alerts.html)
 - [Get answers in Slack with Metabot](./users-guide/11-metabot.html)
@@ -112,7 +112,7 @@
 - [API reference][api-documentation]
 - [API tutorial][api-tutorial]
 
-## Troubleshooting getting help
+## Troubleshooting and getting help
 
 - [Troubleshooting Guide][troubleshooting]. 
 - [Metabase forum][forum].
@@ -133,10 +133,11 @@
 
 ## Documentation guides
 
-- [Users Guide](users-guide/start.html)
-- [Admin Guide](administration-guide/start.html)
-- [Operations Guide](operations-guide/start.html)
-- [Developers Guide][developers]
+- [Users guide](users-guide/start.html)
+- [Admin guide](administration-guide/start.html)
+- [Operations guide](operations-guide/start.html)
+- [Troubleshooting guide][troubleshooting] 
+- [Developers guide][developers]
 
 ## Reference
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@
 
 ## Tutorials and guides
 
-- [Learn Metabase][learn]
+- [Learn Metabase][learn] has a ton of articles on how to use Metabase and level up as a data analyst.
 
 ## Installation and operation
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -112,7 +112,7 @@
 - [API reference][api-documentation]
 - [API tutorial][api-tutorial]
 
-## Troubleshooting & getting help
+## Troubleshooting getting help
 
 - [Troubleshooting Guide][troubleshooting]. 
 - [Metabase forum][forum].
@@ -131,14 +131,17 @@
 - [Blog][blog]
 - [Source code repository on GitHub][source-code]
 
-## Developers guide
+## Documentation guides
 
+- [Users Guide](users-guide/start.html)
+- [Admin Guide](administration-guide/start.html)
+- [Operations Guide](operations-guide/start.html)
 - [Developers Guide][developers]
 
 ## Reference
 
 - [Anonymous Information Collection Reference][info-collection]
-- [FAQs][faq]: Frequently asked questions about Metabase.
+- [FAQs][faq]
 
 [api-documentation]: ./api-documentation.html
 [api-tutorial]: /learn/administration/metabase-api.html

--- a/docs/administration-guide/05-setting-permissions.md
+++ b/docs/administration-guide/05-setting-permissions.md
@@ -76,5 +76,5 @@ Metabase lets you [set permissions on databases and their tables][data-permissio
 [sandbox-columns]: /learn/permissions/data-sandboxing-column-permissions.html
 [sandbox-rows]: /learn/permissions/data-sandboxing-row-permissions.html
 [slack-integration]: 09-setting-up-slack.md
-[sql-snippet-folders]: ../enterprise-guide/sql-snippets.md
+[sql-snippet-folders]: ../enterprise-guide/sql-snippets.html
 [table-permissions]: data-permissions.md#table-permissions

--- a/docs/enterprise-guide/start.md
+++ b/docs/enterprise-guide/start.md
@@ -1,30 +1,63 @@
-# Enterprise Edition Guide
+# Enterprise and Pro edition
 
-The Enterprise Edition of Metabase provides additional features that help organizations scale Metabase and deliver self-service, embedded analytics.
+The [Enterprise and Pro][pricing] editions of Metabase provide additional features that help organizations scale Metabase and deliver self-service, embedded analytics.
 
 ## Setting up
+
+Metabase Pro is hosted, so you should already be setup with all the paid features, but you may have to activate a Metabase Enterprise edition to access all the features.
 
 - [Getting and activating the Enterprise edition](activating-the-enterprise-edition.md)
 
 ## Authentication
 
+Paid plans include more ways to authenticate people and manage groups.
+
 - [Authenticating with SAML](authenticating-with-saml.md)
 - [Authenticating with JWT](authenticating-with-jwt.md)
 
-## Data sandboxing: row and column-level permissions
+## Permissions
 
-- [Sandboxing data based on user attributes](data-sandboxes.md)
+Paid plans include more ways to manage permissions, including data sandboxing, which brings row and column-level permissions to Metabase.
+
+- [Data sandboxes](data-sandboxes.md)
+- [Block permissions](../administration-guide/data-permissions.html#block)
+- [SQL snippet controls](sql-snippets.md)
 
 ## Embedding
 
-- [Embedding the entire Metabase app in your own web app](full-app-embedding.md)
+You can embed all of Metabase in your app.
+
+- [Embedding the entire Metabase app in your app](full-app-embedding.md)
 - [Customizing how Metabase looks with white labeling](whitelabeling.md)
 
-## Administration tools
+## Dashboard subscription customization 
 
-- [Copying contents of one Metabase instance to another (serialization)](serialization.md)
-- [Using the audit logs](audit.md)
-- [Caching answers to questions](cache.md);
-- [Organizing SQL snippets with folders and permissions](sql-snippets.md)
+Send different groups of people the contents of the dashboard with different filters applied. You only need to maintain one dashboard, which you can use to send results relevant to each subscriber.
+
 - [Customizing filter values for each dashboard subscription](dashboard-subscriptions.md)
+
+## Advanced caching controls
+
+All Metabase editions include global caching controls. Paid plans includes additional caching options that let you control caching for individual questions.
+
+- [Caching controls for individual questions](../users-guide/06-sharing-answers.html#caching-results)
+
+## Auditing
+
+See how people are using your Metabase.
+
+- [Using the audit logs](audit.md)
+
+## Admin tools
+
+See which queries are failing to help keep your Metabase tidy.
+
 - [Tracking query errors](tools.md)
+
+## Serialization
+
+You can export Metabase application data and use that to spin up new instances preloaded with questions, dashboards, and collections.
+
+- [Serialization](serialization.md)
+
+[pricing]: https://www.metabase.com/pricing/

--- a/docs/operations-guide/start.md
+++ b/docs/operations-guide/start.md
@@ -25,11 +25,11 @@ This guide contains detailed information about how to install and configure Meta
 -  [Customizing the Metabase Jetty Webserver](customizing-jetty-webserver.html)
 -  [Changing password complexity](changing-password-complexity.html)
 -  [Changing session expiration](changing-session-expiration.html)
--  [Handling Timezones](handling-timezones.html)
--  [Configuring Logging](log-configuration.html)
+-  [Handling timezones](handling-timezones.html)
+-  [Configuring logging](log-configuration.html)
 -  [How to setup monitoring via JMX](jmx-monitoring.html)
 -  [A word on Java versions](java-versions.html)
 
 ## Scaling Metabase
 
-- [Metabase at Scale](https://www.metabase.com/blog/scaling-metabase/index.html)
+- [Metabase at scale](https://www.metabase.com/blog/scaling-metabase/index.html)

--- a/docs/operations-guide/start.md
+++ b/docs/operations-guide/start.md
@@ -1,26 +1,35 @@
 # Operations Guide
 
-This guide contains detailed information about how to install and configure Metabase for production use. 
+This guide contains detailed information about how to install and configure Metabase for production use. If you'd prefer we take care of the details of running Metabase for you, check out our [paid plans](https://www.metabase.com/pricing/).
 
-If you'd prefer we take care of the details of running your Metabase instance for you, check out our hosted offering, [Metabase Cloud](https://www.metabase.com/start/hosted/index.html).
+## Installing and upgrading
 
-**Covered in this guide:**
+-  [How to install Metabase](installing-metabase.html)
+-  [How to upgrade Metabase](upgrading-metabase.html)
 
-*  [How to install Metabase](installing-metabase.md)
-*  [How to upgrade Metabase](upgrading-metabase.md)
-*  [Configuring settings using environment variables](environment-variables.md)
-*  [Configuring the application database](configuring-application-database.md)
-*  [Connecting Metabase to databases in your organization](../administration-guide/01-managing-databases.md)
-*  [Migrating from using the H2 database to MySQL or Postgres](migrating-from-h2.md)
-*  [Running database migrations manually](running-migrations-manually.md)
-*  [Backing up Metabase Application Data](backing-up-metabase-application-data.md)
-*  [Encrypting your database connection details at rest](encrypting-database-details-at-rest.md)
-*  [Customizing the Metabase Jetty Webserver](customizing-jetty-webserver.md)
-*  [Changing password complexity](changing-password-complexity.md)
-*  [Changing session expiration](changing-session-expiration.md)
-*  [Handling Timezones](handling-timezones.md)
-*  [Configuring Logging](log-configuration.md)
-*  [How to setup monitoring via JMX](jmx-monitoring.md)
-*  [A word on Java versions](java-versions.md)
+## Metabase application database
 
-For scaling best practices, check out [Metabase at Scale](https://www.metabase.com/blog/scaling-metabase/index.html).
+-  [Configuring the application database](configuring-application-database.html)
+-  [Migrating from using the H2 database to MySQL or Postgres](migrating-from-h2.html)
+-  [Backing up Metabase Application Data](backing-up-metabase-application-data.html)
+-  [Running database migrations manually](running-migrations-manually.html)
+
+## Connecting to databases
+
+-  [Configuring settings using environment variables](environment-variables.html)
+-  [Connecting Metabase to databases in your organization](../administration-guide/01-managing-databases.html)
+-  [Encrypting your database connection details at rest](encrypting-database-details-at-rest.html)
+
+## Configuring Metabase
+
+-  [Customizing the Metabase Jetty Webserver](customizing-jetty-webserver.html)
+-  [Changing password complexity](changing-password-complexity.html)
+-  [Changing session expiration](changing-session-expiration.html)
+-  [Handling Timezones](handling-timezones.html)
+-  [Configuring Logging](log-configuration.html)
+-  [How to setup monitoring via JMX](jmx-monitoring.html)
+-  [A word on Java versions](java-versions.html)
+
+## Scaling Metabase
+
+- [Metabase at Scale](https://www.metabase.com/blog/scaling-metabase/index.html)


### PR DESCRIPTION
This PR aims to improve our docs landing page, the [README](https://www.metabase.com/docs/latest/):

## What this PR does

### Revamps the README

- Adds a lot more info.
- Reduces word count and groups items into sections to make the list easier to scan.
- Groups content by use case rather than persona (though it retains the guides). The idea here is to surface functionality, rather than hide it under packages like "Users guide".

### Updates the Enterprise page

- Incorporates Pro plans.
- Adds some sections and links.

### Updates Operations guide

- Adds sections.

## What this PR doesn't do

It doesn't change the docs file/directory structure. The README is a list of links to curate existing content regardless of where the content lives. For example, documents covering permissions were scattered in different places and different guides; this PR groups them in one section. We can consider changing directory structure later on, but that will involve some heavy lifting managing redirects in the website repo that serves these pages (which could include rewriting the code that decorates these pages with frontmatter).

## Concerns

- Some of our docs have a sequential Next link at the bottom to take them to the next article in the sequence. The groupings don't respect those sequences, which could cause some confusion. We've already broken away from this sequencing lock-in as we've added more docs, but we should consider rooting out these vestigial "Next" sections.
- The README is long. I included the brutalist version with links to all pages because it's still manageable and people might want to skim and/or ctrl-f through the page, but we could also consider a shorter version with landing pages for subsections. E.g., instead of a Permissions section that lists all of the links in the README, Permissions is just one item on the README list that will take you to a landing page on Permissions that lists the subpages.

## Next steps

If/once this PR is merged, we should consider:

- Going through and marking existing pages in the Enterprise guide with the plans blockquote, so people don't have to know they're in the Enterprise guide to understand what they're looking at describes a paid feature.
- (Maybe) starring or somehow marking items in the main README list to indicate they're paid features. 
- Consolidating some pages with related content. For example, the page that talks about [customizing filter values for dashboard subscriptions](https://www.metabase.com/docs/latest/enterprise-guide/dashboard-subscriptions.html) should probably just be a section on the dashboard subscription page rather than a standalone note. Their current split is an artifact of our current (awkward) demarcation of paid/free feature this PR sets up to correct.
- Folding the FAQ content into relevant contexts and delete the FAQ.
- Condense the line height on lists so they're easier to skim.

