### PR TITLE
Handle unauthed/data mismatch dashcard query builder states better

### DIFF
--- a/frontend/src/metabase/parameters/utils/dashboards.js
+++ b/frontend/src/metabase/parameters/utils/dashboards.js
@@ -183,3 +183,24 @@ export function getParametersMappedToDashcard(dashboard, dashcard) {
     })
     .filter(Boolean);
 }
+
+export function hasMatchingParameters({
+  dashboard,
+  cardId,
+  parameters,
+  metadata,
+}) {
+  const dashcard = _.findWhere(dashboard.ordered_cards, { card_id: cardId });
+  if (!dashcard) {
+    return false;
+  }
+
+  const dashcardMappingsByParameterId = _.indexBy(
+    getMapping(dashcard, metadata),
+    "parameter_id",
+  );
+
+  return parameters.every(parameter => {
+    return dashcardMappingsByParameterId[parameter.id] != null;
+  });
+}

--- a/frontend/src/metabase/parameters/utils/dashboards.unit.spec.js
+++ b/frontend/src/metabase/parameters/utils/dashboards.unit.spec.js
@@ -6,7 +6,10 @@ import {
   isDashboardParameterWithoutMapping,
   getMappingsByParameter,
   getParametersMappedToDashcard,
+  hasMatchingParameters,
 } from "metabase/parameters/utils/dashboards";
+import { metadata } from "__support__/sample_dataset_fixture";
+
 import DASHBOARD_WITH_BOOLEAN_PARAMETER from "./fixtures/dashboard-with-boolean-parameter.json";
 
 import Field from "metabase-lib/lib/metadata/Field";
@@ -434,6 +437,105 @@ describe("meta/Dashboard", () => {
           target: ["dimension", ["field", 123, null]],
         },
       ]);
+    });
+  });
+
+  describe("hasMatchingParameters", () => {
+    it("should return false when the given card is not found on the dashboard", () => {
+      const dashboard = {
+        ordered_cards: [
+          {
+            card_id: 123,
+            parameter_mappings: [
+              {
+                parameter_id: "foo",
+              },
+            ],
+          },
+        ],
+      };
+
+      expect(
+        hasMatchingParameters({
+          dashboard,
+          cardId: 456,
+          parameters: [],
+          metadata,
+        }),
+      ).toBe(false);
+    });
+
+    it("should return false when a given parameter is not found in the dashcard mappings", () => {
+      const dashboard = {
+        ordered_cards: [
+          {
+            card_id: 123,
+            parameter_mappings: [
+              {
+                parameter_id: "foo",
+              },
+            ],
+          },
+          {
+            card_id: 456,
+            parameter_mappings: [
+              {
+                parameter_id: "bar",
+              },
+            ],
+          },
+        ],
+      };
+
+      expect(
+        hasMatchingParameters({
+          dashboard,
+          cardId: 123,
+          parameters: [
+            {
+              id: "foo",
+            },
+            {
+              id: "bar",
+            },
+          ],
+          metadata,
+        }),
+      ).toBe(false);
+    });
+
+    it("should return when all given parameters are found mapped to the dashcard", () => {
+      const dashboard = {
+        ordered_cards: [
+          {
+            card_id: 123,
+            parameter_mappings: [
+              {
+                parameter_id: "foo",
+              },
+              {
+                parameter_id: "bar",
+              },
+            ],
+          },
+        ],
+      };
+
+      expect(
+        hasMatchingParameters({
+          dashboard,
+          cardId: 123,
+          parameters: [
+            {
+              id: "foo",
+            },
+            {
+              id: "bar",
+            },
+          ],
+          metadata,
+        }),
+      ).toBe(true);
     });
   });
 });

--- a/frontend/src/metabase/parameters/utils/dashboards.unit.spec.js
+++ b/frontend/src/metabase/parameters/utils/dashboards.unit.spec.js
@@ -504,7 +504,7 @@ describe("meta/Dashboard", () => {
       ).toBe(false);
     });
 
-    it("should return when all given parameters are found mapped to the dashcard", () => {
+    it("should return true when all given parameters are found mapped to the dashcard", () => {
       const dashboard = {
         ordered_cards: [
           {

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -397,7 +397,7 @@ export const initializeQB = (location, params, queryParams) => {
           card.original_card_id = card.id;
 
           // if there's a card in the url, it may have parameters from a dashboard
-          if (deserializedCard) {
+          if (deserializedCard && deserializedCard.parameters) {
             const metadata = getMetadata(getState());
             const { dashboardId, parameters } = deserializedCard;
             verifyMatchingDashcardAndParameters({


### PR DESCRIPTION
This is a follow up on #19027 to add a bit more polish around error handling.
https://github.com/metabase/metaboat/issues/144

This PR adds improved error handling when a user navigates to a dashcard query builder URL after there have been permissions or data changes to the dashboard. If the user loses permissions to view the dashboard, the user will be navigated to an unauthed screen (demoed below). In addition, if the card is removed from the dashboard or some of the parameters mapped to it have been removed, the user will be navigated to an unauthed screen.

Before

https://user-images.githubusercontent.com/13057258/145471226-2b7aa016-c725-4654-bf82-ef6d3b250f94.mov

After

https://user-images.githubusercontent.com/13057258/145471246-397090db-f156-42dd-aa2d-d1700268bdad.mov


