### PR TITLE
Build in GH actions and push to Dockerhub head

### DIFF
--- a/.github/workflows/build-and-push-head-images.yml
+++ b/.github/workflows/build-and-push-head-images.yml
@@ -1,0 +1,43 @@
+name: Build and push head branch container images
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build-and-push-oss-image:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Create multi-arch image
+        run: docker buildx build . -t metabase/metabase-head:latest --push --compress --no-cache
+
+  build-and-push-ee-image:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Create multi-arch image
+        run: docker buildx build . --build-arg MB_EDITION=ee -t metabase/metabase-enteprise-head:latest --push --compress --no-cache

--- a/.github/workflows/build-and-push-head-images.yml
+++ b/.github/workflows/build-and-push-head-images.yml
@@ -1,4 +1,4 @@
-name: Build and push head branch container images
+name: Build and push to Dockerhub
 
 on:
   push:
@@ -21,7 +21,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Create multi-arch image
+      - name: Create container image
         run: docker buildx build . -t metabase/metabase-head:latest --push --compress --no-cache
 
   build-and-push-ee-image:
@@ -39,5 +39,5 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Create multi-arch image
+      - name: Create container image
         run: docker buildx build . --build-arg MB_EDITION=ee -t metabase/metabase-enteprise-head:latest --push --compress --no-cache


### PR DESCRIPTION
Building master in GH actions and the pushing images to dockerhub

We need to set up DOCKERHUB_TOKEN and DOCKERHUB_USERNAME in the Metabase repository secrets (yes, it's a personal token) to make this work.

As soon as this is set up and merged, we will have to disconnect the webhook of Dockerhub so images are not being overwritten