### PR TITLE
Fix COALESCE with string type

### DIFF
--- a/frontend/src/metabase/lib/expressions/resolver.js
+++ b/frontend/src/metabase/lib/expressions/resolver.js
@@ -63,7 +63,7 @@ export function resolve(expression, type = "expression", fn = undefined) {
     let operandType = null;
     if (LOGICAL_OPS.includes(op)) {
       operandType = "boolean";
-    } else if (NUMBER_OPS.includes(op) || op === "coalesce") {
+    } else if (NUMBER_OPS.includes(op)) {
       operandType = type === "aggregation" ? type : "number";
     } else if (COMPARISON_OPS.includes(op)) {
       operandType = "expression";
@@ -73,6 +73,8 @@ export function resolve(expression, type = "expression", fn = undefined) {
       }
     } else if (op === "concat") {
       operandType = "string";
+    } else if (op === "coalesce") {
+      operandType = type;
     } else if (op === "case") {
       const [pairs, options] = operands;
       if (pairs.length < 1) {

--- a/frontend/test/metabase/lib/expressions/resolver.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/resolver.unit.spec.js
@@ -143,6 +143,13 @@ describe("metabase/lib/expressions/resolve", () => {
       expect(() => expr(["concat", "1", "2"])).not.toThrow();
       expect(() => expr(["concat", "1", "2", "3"])).not.toThrow();
     });
+
+    it("should accept COALESCE for number", () => {
+      expect(() => expr(["round", ["coalesce", 0]])).not.toThrow();
+    });
+    it("should accept COALESCE for string", () => {
+      expect(() => expr(["trim", ["coalesce", "B"]])).not.toThrow();
+    });
   });
 
   describe("for aggregations", () => {


### PR DESCRIPTION
How to verify:

1. Ask a question, Custom question
2. Sample Dataset, People table
3. Custom column, type `trim(coalesce("Joe", [Name]))`

**Before this PR**

![image](https://user-images.githubusercontent.com/7288/145504040-7100a89f-c775-4f7c-a251-bb86ffad417e.png)


**After this PR**

Just like the behavior in v41 and earlier, the expression is accepted as a valid custom column:

![image](https://user-images.githubusercontent.com/7288/145504083-ca0a345e-4b78-4bef-a092-1bdf882d5f92.png)

