### PR TITLE
Area static viz

### DIFF
--- a/resources/frontend_shared/static_viz_interface.js
+++ b/resources/frontend_shared/static_viz_interface.js
@@ -47,6 +47,15 @@ function timeseries_bar(data, labels, settings) {
   });
 }
 
+function timeseries_area(data, labels, settings) {
+  return StaticViz.RenderChart("timeseries/area", {
+    data: toJSArray(data),
+    labels: toJSMap(labels),
+    accessors: date_accessors,
+    settings: JSON.parse(settings),
+  });
+}
+
 function combo_chart(series, settings, colors) {
   // Thinking of combo as similar to multiple, although they're different in BE
   return StaticViz.RenderChart("combo-chart", {
@@ -74,6 +83,15 @@ function funnel(data, settings) {
 
 function categorical_bar(data, labels, settings) {
   return StaticViz.RenderChart("categorical/bar", {
+    data: toJSArray(data),
+    labels: toJSMap(labels),
+    accessors: positional_accessors,
+    settings: JSON.parse(settings),
+  });
+}
+
+function categorical_area(data, labels, settings) {
+  return StaticViz.RenderChart("categorical/area", {
     data: toJSArray(data),
     labels: toJSMap(labels),
     accessors: positional_accessors,

--- a/src/metabase/pulse/render.clj
+++ b/src/metabase/pulse/render.clj
@@ -108,7 +108,7 @@
         (and (= @col-sample-count 2)
              (> @row-sample-count 1)
              (number-field? @col-2)
-             (not (#{:waterfall :pie :table} display-type)))
+             (not (#{:waterfall :pie :table :area} display-type)))
         (chart-type :sparkline "result has 2 cols (%s and %s (number)) and > 1 row" (col-description @col-1) (col-description @col-2))
 
         (and (= @col-sample-count 2)

--- a/src/metabase/pulse/render.clj
+++ b/src/metabase/pulse/render.clj
@@ -84,7 +84,7 @@
         (#{:pin_map :state :country} display-type)
         (chart-type nil "display-type is %s" display-type)
 
-        (#{:progress :waterfall :combo :funnel} display-type)
+        (#{:progress :waterfall :combo :funnel :area} display-type)
         (chart-type display-type "display-type is %s" display-type)
 
         (= @col-sample-count @row-sample-count 1)

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -716,11 +716,8 @@
   (let [[x-axis-rowfn
          y-axis-rowfn] (common/graphing-column-row-fns card data)
         [x-col y-col]  ((juxt x-axis-rowfn y-axis-rowfn) cols)
-        ;; clean works differentlike...
-        rows           (sparkline/cleaned-rows timezone-id card data)
+        rows           (common/non-nil-rows x-axis-rowfn y-axis-rowfn rows)
         last-rows      (reverse (take-last 2 rows))
-        values         (for [row last-rows]
-                         (some-> row y-axis-rowfn common/format-number))
         labels         (datetime/format-temporal-string-pair timezone-id
                                                              (map x-axis-rowfn last-rows)
                                                              (x-axis-rowfn cols))

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -712,7 +712,7 @@
          (second labels)]]]]}))
 
 (s/defmethod render :area :- common/RenderedPulseCard
-  [_ render-type timezone-id card _ {:keys [_rows cols viz-settings] :as data}]
+  [_ render-type timezone-id card _ {:keys [rows cols viz-settings] :as data}]
   (let [[x-axis-rowfn
          y-axis-rowfn] (common/graphing-column-row-fns card data)
         [x-col y-col]  ((juxt x-axis-rowfn y-axis-rowfn) cols)

--- a/src/metabase/pulse/render/js_svg.clj
+++ b/src/metabase/pulse/render/js_svg.clj
@@ -127,10 +127,19 @@
     (svg-string->bytes svg-string)))
 
 (defn timelineseries-bar
-  "Clojure entrypoint to render a timeseries bar char. Rows should be tuples of [datetime numeric-value]. Labels is a
+  "Clojure entrypoint to render a timeseries bar chart. Rows should be tuples of [datetime numeric-value]. Labels is a
   map of {:left \"left-label\" :botton \"bottom-label\"}. Returns a byte array of a png file."
   [rows labels settings]
   (let [svg-string (.asString (js/execute-fn-name @context "timeseries_bar" rows
+                                                  (map (fn [[k v]] [(name k) v]) labels)
+                                                  (json/generate-string settings)))]
+    (svg-string->bytes svg-string)))
+
+(defn timelineseries-area
+  "Clojure entrypoint to render a timeseries area chart. Rows should be tuples of [datetime numeric-value]. Labels is a
+  map of {:left \"left-label\" :botton \"bottom-label\"}. Returns a byte array of a png file."
+  [rows labels settings]
+  (let [svg-string (.asString (js/execute-fn-name @context "timeseries_area" rows
                                                   (map (fn [[k v]] [(name k) v]) labels)
                                                   (json/generate-string settings)))]
     (svg-string->bytes svg-string)))
@@ -173,6 +182,15 @@
   a map of {:left \"left-label\" :botton \"bottom-label\". Returns a byte array of a png file."
   [rows labels settings]
   (let [svg-string (.asString (js/execute-fn-name @context "categorical_bar" rows
+                                                  (map (fn [[k v]] [(name k) v]) labels)
+                                                  (json/generate-string settings)))]
+    (svg-string->bytes svg-string)))
+
+(defn categorical-area
+  "Clojure entrypoint to render a categorical area chart. Rows should be tuples of [stringable numeric-value]. Labels is a
+  map of {:left \"left-label\" :botton \"bottom-label\"}. Returns a byte array of a png file."
+  [rows labels settings]
+  (let [svg-string (.asString (js/execute-fn-name @context "categorical_area" rows
                                                   (map (fn [[k v]] [(name k) v]) labels)
                                                   (json/generate-string settings)))]
     (svg-string->bytes svg-string)))

--- a/test/metabase/pulse/render/body_test.clj
+++ b/test/metabase/pulse/render/body_test.clj
@@ -378,9 +378,6 @@
   [html-data]
   (tree-seq coll? seq html-data))
 
-(defn- render-bar-graph [results]
-  (body/render :bar :inline pacific-tz render.tu/test-card nil results))
-
 (def ^:private default-columns
   [{:name         "Price",
     :display_name "Price",
@@ -408,6 +405,9 @@
 (defn has-inline-image? [rendered]
   (some #{:img} (flatten-html-data rendered)))
 
+(defn- render-bar-graph [results]
+  (body/render :bar :inline pacific-tz render.tu/test-card nil results))
+
 (deftest render-bar-graph-test
   (testing "Render a bar graph with non-nil values for the x and y axis"
     (is (has-inline-image?
@@ -426,6 +426,26 @@
          (render-bar-graph {:cols default-columns
                             :rows [[10.0 1] [5.0 10] [nil 20] [1.25 nil]]})))))
 
+(defn- render-area-graph [results]
+  (body/render :area :inline pacific-tz render.tu/test-card nil results))
+
+(deftest render-area-graph-tet
+  (testing "Render an area graph with non-nil values for the x and y axis"
+    (is (has-inline-image?
+         (render-area-graph {:cols default-columns
+                            :rows [[10.0 1] [5.0 10] [2.50 20] [1.25 30]]}))))
+  (testing "Check to make sure we allow nil values for the y-axis"
+    (is (has-inline-image?
+         (render-area-graph {:cols default-columns
+                            :rows [[10.0 1] [5.0 10] [2.50 20] [1.25 nil]]}))))
+  (testing "Check to make sure we allow nil values for the y-axis"
+    (is (has-inline-image?
+         (render-area-graph {:cols default-columns
+                            :rows [[10.0 1] [5.0 10] [2.50 20] [nil 30]]}))))
+  (testing "Check to make sure we allow nil values for both x and y on different rows"
+    (is (has-inline-image?
+         (render-area-graph {:cols default-columns
+                            :rows [[10.0 1] [5.0 10] [nil 20] [1.25 nil]]})))))
 
 (defn- render-waterfall [results]
   (body/render :waterfall :inline pacific-tz render.tu/test-card nil results))

--- a/test/metabase/pulse/render/js_svg_test.clj
+++ b/test/metabase/pulse/render/js_svg_test.clj
@@ -146,6 +146,28 @@
           (is (= true (s/valid? spec text-nodes))
               text-nodes))))))
 
+(deftest area-test
+  (let [tl-rows    [[#t "2020" 2]
+                    [#t "2021" 3]]
+        cat-rows   [["bob" 2]
+                    ["dobbs" 3]]
+        tl-labels  {:left "count" :bottom "year"}
+        cat-labels {:left "count" :bottom "string stuff"}
+        settings   (json/generate-string {:y {:prefix   "prefix"
+                                              :decimals 4}})]
+    (testing "It returns bytes"
+      (let [tl-svg-bytes  (js-svg/timelineseries-area tl-rows tl-labels settings)
+            cat-svg-bytes (js-svg/categorical-area cat-rows cat-labels settings)]
+        (is (bytes? tl-svg-bytes))
+        (is (bytes? cat-svg-bytes))))
+    (let [tl-svg-string (.asString (js/execute-fn-name @context "timeseries_area" tl-rows tl-labels settings))
+          tl-svg-hiccup (-> tl-svg-string parse-svg document-tag-hiccup)
+          cat-svg-string (.asString (js/execute-fn-name @context "categorical_area" cat-rows cat-labels settings))
+          cat-svg-hiccup (-> cat-svg-string parse-svg document-tag-hiccup)]
+      (testing "it returns a valid svg string (no html in it)"
+        (validate-svg-string :timelineseries-area tl-svg-string)
+        (validate-svg-string :categorical-area cat-svg-string)))))
+
 (deftest timelineseries-waterfall-test
   (let [rows     [[#t "2020" 2]
                   [#t "2021" 3]]


### PR DESCRIPTION
Pursuant to #18676.

Previously area charts had the strange and unintuitive behavior of showing up as a table for static viz. This one shoves the BE in for getting the hooks into the existing and long-landed FE implementation of area charts for static viz.

This does not implement the "implicit combo" you can do by specifying multiple metrics, because annoyingly it doesn't hook into the combo in any explicit way so there's going to be a moderately twisty bit to actually detect this.
