### PR TITLE
Bump log4j from 2.14.1 to 2.15.0

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -81,12 +81,12 @@
                                              :exclusions  [org.slf4j/slf4j-api]}
   org.apache.commons/commons-compress       {:mvn/version "1.21"}               ; compression utils
   org.apache.commons/commons-lang3          {:mvn/version "3.12.0"}             ; helper methods for working with java.lang stuff
-  org.apache.logging.log4j/log4j-1.2-api    {:mvn/version "2.14.1"}             ; apache logging framework
-  org.apache.logging.log4j/log4j-api        {:mvn/version "2.14.1"}             ; add compatibility with log4j 1.2
-  org.apache.logging.log4j/log4j-core       {:mvn/version "2.14.1"}             ; apache logging framework
-  org.apache.logging.log4j/log4j-jcl        {:mvn/version "2.14.1"}             ; allows the commons-logging API to work with log4j 2
-  org.apache.logging.log4j/log4j-liquibase  {:mvn/version "2.14.1"}             ; liquibase logging via log4j 2
-  org.apache.logging.log4j/log4j-slf4j-impl {:mvn/version "2.14.1"}             ; allows the slf4j API to work with log4j 2
+  org.apache.logging.log4j/log4j-1.2-api    {:mvn/version "2.15.0"}             ; apache logging framework
+  org.apache.logging.log4j/log4j-api        {:mvn/version "2.15.0"}             ; add compatibility with log4j 1.2
+  org.apache.logging.log4j/log4j-core       {:mvn/version "2.15.0"}             ; apache logging framework
+  org.apache.logging.log4j/log4j-jcl        {:mvn/version "2.15.0"}             ; allows the commons-logging API to work with log4j 2
+  org.apache.logging.log4j/log4j-liquibase  {:mvn/version "2.15.0"}             ; liquibase logging via log4j 2
+  org.apache.logging.log4j/log4j-slf4j-impl {:mvn/version "2.15.0"}             ; allows the slf4j API to work with log4j 2
   org.apache.poi/poi                        {:mvn/version "5.0.0"}              ; Work with Office documents (e.g. Excel spreadsheets) -- newer version than one specified by Docjure
   org.apache.poi/poi-ooxml                  {:mvn/version "5.0.0"
                                              :exclusions  [org.bouncycastle/bcpkix-jdk15on


### PR DESCRIPTION
Bump log4j from 2.14.1 to 2.15.0

CVE-2021-44228
Log4j versions prior to 2.15.0 are subject to a remote code execution vulnerability via the ldap JNDI parser.
### Tests

- [x] Run the frontend and Cypress end-to-end tests with `yarn lint && yarn test`)
- [x] If there are changes to the backend codebase, run the backend tests with `clojure -X:dev:test`
- [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
      (unless it's a tiny documentation change).
