### PR TITLE
React Ace: Have custom expression suggestions and help block closer to editor

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
@@ -88,6 +88,7 @@ export default class ExpressionEditorSuggestions extends React.Component {
           attachment: "top left",
           targetAttachment: "bottom left",
         }}
+        targetOffsetY={0}
         sizeToFit
       >
         <UlStyled data-testid="expression-suggestions-list">

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -39,6 +39,7 @@ const HelpText = ({ helpText, width }) =>
         attachment: "top left",
         targetAttachment: "bottom left",
       }}
+      targetOffsetY={-47}
       style={{ width }}
       isOpen
     >


### PR DESCRIPTION
### How to Test

1. Ask a question
2. Custom question
3. Sample Dataset
4. Any table, say Orders
5. Click on Custom Column icon
6. Type `c` on the custom expressions editor

Autosuggestion list should be right below the editor.

7. Select `case` from suggestions list.

Help block should be right below the editor.

### After

<img src=https://user-images.githubusercontent.com/380816/145604257-c8b3338b-b609-4829-9743-1a9aff32d8a1.png width=300 />

<img src=https://user-images.githubusercontent.com/380816/145616049-1ecbf286-a958-459a-8022-5e4f6659454e.png width=300 />

### Before

<img src=https://user-images.githubusercontent.com/380816/145604394-15c6fb44-cf6a-497b-8a5a-61a0d5553e1c.png width=300 />

<img src=https://user-images.githubusercontent.com/380816/145616134-c16840c7-3185-4838-b850-df0355b6e3a5.png width=300 />
