### PR TITLE
Ensure Concat's implicit type casting is honored

### DIFF
--- a/frontend/src/metabase/lib/expressions/resolver.js
+++ b/frontend/src/metabase/lib/expressions/resolver.js
@@ -72,7 +72,7 @@ export function resolve(expression, type = "expression", fn = undefined) {
         throw new Error(t`Expecting field but found ${firstOperand}`);
       }
     } else if (op === "concat") {
-      operandType = "string";
+      operandType = "expression";
     } else if (op === "coalesce") {
       operandType = type;
     } else if (op === "case") {

--- a/frontend/test/metabase/lib/expressions/resolver.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/resolver.unit.spec.js
@@ -150,6 +150,10 @@ describe("metabase/lib/expressions/resolve", () => {
     it("should accept COALESCE for string", () => {
       expect(() => expr(["trim", ["coalesce", "B"]])).not.toThrow();
     });
+
+    it("should honor CONCAT's implicit casting", () => {
+      expect(() => expr(["concat", ["coalesce", "B", 1]])).not.toThrow();
+    });
   });
 
   describe("for aggregations", () => {


### PR DESCRIPTION
This is a follow-up to PR #19305. Just like in SQL, concat can do an implicit casting from string to number, hence it should be honored.

1. Ask a question, Custom question
2. Sample Dataset, Orders table
3. Custom column and type `concat(coalesce([Discount], 1), "A")`

**Before this PR**

The expression is incorrectly rejected with an error message "Expecting string but found 1".

![image](https://user-images.githubusercontent.com/7288/145628409-241f9c6c-2f22-4164-a313-3c4c41eea41d.png)

**After this PR**

Just like in v41, the expression is accepted as a valid custom column.

![image](https://user-images.githubusercontent.com/7288/145628504-f07d2acb-e22a-4f94-aace-95e435c96043.png)
