### PR TITLE
Add useAsyncFunction and useIsMounted hooks

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -27,7 +27,7 @@
     "react/forbid-component-props": [2, { "forbid": ["w", "h"] }],
     "react-hooks/exhaustive-deps": [
       "warn",
-      { "additionalHooks": "useSyncedQueryString" }
+      { "additionalHooks": "(useSyncedQueryString|useAsyncFunction)" }
     ],
     "prefer-const": [1, { "destructuring": "all" }],
     "no-useless-escape": 0,

--- a/frontend/src/metabase/hooks/use-async-function.ts
+++ b/frontend/src/metabase/hooks/use-async-function.ts
@@ -1,0 +1,31 @@
+import { useCallback } from "react";
+import { useIsMounted } from "./use-is-mounted";
+
+type AsyncFn = (...args: any[]) => Promise<any>;
+
+// wraps the given async function in a promise that does not resolve
+// after the component has unmounted
+export function useAsyncFunction(fn: AsyncFn, deps?: any[]): AsyncFn {
+  const isMounted = useIsMounted();
+
+  const safeFn: AsyncFn = useCallback(
+    (...args: any[]) =>
+      new Promise((resolve, reject) => {
+        return fn(...args)
+          .then((res: any) => {
+            if (isMounted()) {
+              resolve(res);
+            }
+          })
+          .catch((err: Error) => {
+            if (isMounted()) {
+              reject(err);
+            }
+          });
+      }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    deps ? [...deps, isMounted] : [isMounted],
+  );
+
+  return safeFn;
+}

--- a/frontend/src/metabase/hooks/use-is-mounted.ts
+++ b/frontend/src/metabase/hooks/use-is-mounted.ts
@@ -1,0 +1,15 @@
+import { useEffect, useRef, useCallback } from "react";
+
+export function useIsMounted() {
+  const isMountedRef = useRef(false);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  return useCallback(() => isMountedRef.current, []);
+}


### PR DESCRIPTION
This PR adds two new hooks, `useIsMounted` and `useAsyncFunction` for use in a near-future PR.

`useIsMounted` returns a function that can be used to determine if a component is still mounted. This is useful for components with `useEffect` hooks that have asynchronous behavior as setting state in an unmounted component results in an error. I'm also using the hook to implement `useAsyncFunction`.

```
function FooComponent ({asyncFn}) {
  const isMounted = useIsMounted();
  const [result, setResult] = useState();
  
  useEffect(() => {
    asyncFn().then(result => {
      if (isMounted()) {
        setResult(result);
      }
    });
  }, [asyncFn, isMounted]);
  
  // ...
}
```

`useAsyncFunction` wraps asynchronous functions and prevents them from resolving when the component it is in has unmounted.
```
function FooComponent ({asyncFn}) {
  const safeAsyncFn = useAsyncFunction(asyncFn);
  const [result, setResult] = useState();
  
  useEffect(() => {
    safeAsyncFn().then(result => {
      setResult(result);
    });
  }, [safeAsyncFn]);

  // ...
}
```

I've added it to the `exhaustive-deps` eslint rule so that you can also use it like...
```
function DelayReadyComponent () {
  const [incr, setIncr] = useState(0);

  const delayedIncrement = useAsyncFunction(async () => {
    await new Promise(resolve => setTimeout(resolve, 1000));
    setIncr(incr => incr + 1);
  }, []);

  return <button onClick={delayedIncrement}>{incr}</button>
}
```

