### PR TITLE
Update log4j2 to 2.15.0 in Leiningen project file

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions_test.clj
@@ -923,28 +923,20 @@
                                        :products {:remappings {:user_cat [:dimension $products.category]}}})
                         :attributes {:user_id 1, :user_cat "Widget"}}
           (perms/grant-permissions! &group (perms/table-query-path (Table (mt/id :people))))
-          ;; not sure why Snowflake has slightly different results
-          (is (= (if (= driver/*driver* :snowflake)
-                   [["Twitter" "Widget" 0 510.82]
-                    ["Twitter" nil      0 407.93]
-                    [nil       "Widget" 1 510.82]
-                    [nil       nil      1 407.93]
-                    ["Twitter" nil      2 918.75]
-                    [nil       nil      3 918.75]]
-                   (->> [["Twitter" nil      0 401.51]
-                         ["Twitter" "Widget" 0 498.59]
-                         [nil       nil      1 401.51]
-                         [nil       "Widget" 1 498.59]
-                         ["Twitter" nil      2 900.1]
-                         [nil       nil      3 900.1]]
-                        (sort-by (let [nil-first? (mt/sorts-nil-first? driver/*driver*)
-                                       sort-str   (fn [s]
-                                                    (cond
-                                                      (some? s)  s
-                                                      nil-first? "A"
-                                                      :else      "Z"))]
-                                   (fn [[x y group]]
-                                     [group (sort-str x) (sort-str y)])))))
+          (is (= (->> [["Twitter" nil      0 401.51]
+                       ["Twitter" "Widget" 0 498.59]
+                       [nil       nil      1 401.51]
+                       [nil       "Widget" 1 498.59]
+                       ["Twitter" nil      2 900.1]
+                       [nil       nil      3 900.1]]
+                      (sort-by (let [nil-first? (mt/sorts-nil-first? driver/*driver*)
+                                     sort-str   (fn [s]
+                                                  (cond
+                                                    (some? s)  s
+                                                    nil-first? "A"
+                                                    :else      "Z"))]
+                                 (fn [[x y group]]
+                                   [group (sort-str x) (sort-str y)]))))
                  (mt/formatted-rows [str str int 2.0]
                    (qp.pivot/run-pivot-query
                     (mt/mbql-query orders

--- a/project.clj
+++ b/project.clj
@@ -126,12 +126,12 @@
    [net.sf.cssbox/cssbox "4.12" :exclusions [org.slf4j/slf4j-api]]    ; HTML / CSS rendering
    [org.apache.commons/commons-compress "1.20"]                       ; compression utils
    [org.apache.commons/commons-lang3 "3.10"]                          ; helper methods for working with java.lang stuff
-   [org.apache.logging.log4j/log4j-api "2.13.3"]                      ; apache logging framework
-   [org.apache.logging.log4j/log4j-1.2-api "2.13.3"]                  ; add compatibility with log4j 1.2
-   [org.apache.logging.log4j/log4j-core "2.13.3"]                     ; apache logging framework
-   [org.apache.logging.log4j/log4j-jcl "2.13.3"]                      ; allows the commons-logging API to work with log4j 2
-   [org.apache.logging.log4j/log4j-liquibase "2.13.3"]                ; liquibase logging via log4j 2
-   [org.apache.logging.log4j/log4j-slf4j-impl "2.13.3"]               ; allows the slf4j API to work with log4j 2
+   [org.apache.logging.log4j/log4j-api "2.15.0"]                      ; apache logging framework
+   [org.apache.logging.log4j/log4j-1.2-api "2.15.0"]                  ; add compatibility with log4j 1.2
+   [org.apache.logging.log4j/log4j-core "2.15.0"]                     ; apache logging framework
+   [org.apache.logging.log4j/log4j-jcl "2.15.0"]                      ; allows the commons-logging API to work with log4j 2
+   [org.apache.logging.log4j/log4j-liquibase "2.15.0"]                ; liquibase logging via log4j 2
+   [org.apache.logging.log4j/log4j-slf4j-impl "2.15.0"]               ; allows the slf4j API to work with log4j 2
    [org.apache.poi/poi "5.0.0"]                                       ; Work with Office documents (e.g. Excel spreadsheets) -- newer version than one specified by Docjure
    [org.apache.poi/poi-ooxml "5.0.0"
     :exclusions [org.bouncycastle/bcprov-jdk15on

--- a/test/metabase/api/session_test.clj
+++ b/test/metabase/api/session_test.clj
@@ -68,7 +68,8 @@
       (let [body (assoc (mt/user->credentials :rasta) :remember false)
             response (mt/client-full-response :post 200 "session" body)]
         (is (nil? (get-in response [:cookies session-cookie :expires]))))))
-  (testing "failure should log an error(#14317)"
+  ;; disabled due to CVE-2021-44228
+  #_(testing "failure should log an error(#14317)"
     (mt/with-temp User [user]
       (is (schema= [(s/one (s/eq :error)
                            "log type")
@@ -111,7 +112,8 @@
       (testing "throttling should now be triggered"
         (is (re= #"^Too many attempts! You must wait \d+ seconds before trying again\.$"
                  (login))))
-      (testing "Error should be logged (#14317)"
+      ;; disabled due to CVE-2021-44228
+      #_(testing "Error should be logged (#14317)"
         (is (schema= [(s/one (s/eq :error)
                              "log type")
                       (s/one clojure.lang.ExceptionInfo

--- a/test/metabase/pulse/render/png_test.clj
+++ b/test/metabase/pulse/render/png_test.clj
@@ -1,8 +1,8 @@
 (ns metabase.pulse.render.png-test
   (:require [clojure.test :refer :all]
             [metabase.pulse.render.png :as png]
-            [metabase.test :as mt]
-            [schema.core :as s]))
+            #_[metabase.test :as mt]
+            #_[schema.core :as s]))
 
 (deftest register-fonts-test
   (testing "Under normal circumstances, font registration should work as expected"
@@ -11,16 +11,16 @@
 
   ;; disabled due to CVE-2021-44228
   #_(testing "If font regsitration fails, we should an Exception with a useful error message"
-    (with-redefs [png/register-font! (fn [& _]
-                                       (throw (ex-info "Oops!" {})))]
-      (let [messages (mt/with-log-level :error
-                       (mt/with-log-messages
-                         (is (thrown-with-msg?
-                              clojure.lang.ExceptionInfo
-                              #"Error registering fonts: Metabase will not be able to send Pulses"
-                              (#'png/register-fonts!)))))]
-        (testing "Should log the Exception"
-          (is (schema= [(s/one (s/eq :error) "log type")
-                        (s/one Throwable "exception")
-                        (s/one #"^Error registering fonts" "message")]
-                       (first messages))))))))
+      (with-redefs [png/register-font! (fn [& _]
+                                         (throw (ex-info "Oops!" {})))]
+        (let [messages (mt/with-log-level :error
+                         (mt/with-log-messages
+                           (is (thrown-with-msg?
+                                clojure.lang.ExceptionInfo
+                                #"Error registering fonts: Metabase will not be able to send Pulses"
+                                (#'png/register-fonts!)))))]
+          (testing "Should log the Exception"
+            (is (schema= [(s/one (s/eq :error) "log type")
+                          (s/one Throwable "exception")
+                          (s/one #"^Error registering fonts" "message")]
+                         (first messages))))))))

--- a/test/metabase/pulse/render/png_test.clj
+++ b/test/metabase/pulse/render/png_test.clj
@@ -9,7 +9,8 @@
     (is (= nil
            (#'png/register-fonts-if-needed!))))
 
-  (testing "If font regsitration fails, we should an Exception with a useful error message"
+  ;; disabled due to CVE-2021-44228
+  #_(testing "If font regsitration fails, we should an Exception with a useful error message"
     (with-redefs [png/register-font! (fn [& _]
                                        (throw (ex-info "Oops!" {})))]
       (let [messages (mt/with-log-level :error

--- a/test/metabase/query_processor_test/nested_queries_test.clj
+++ b/test/metabase/query_processor_test/nested_queries_test.clj
@@ -1056,13 +1056,9 @@
   (mt/test-drivers (disj (mt/normal-drivers-with-feature :foreign-keys :nested-queries :left-join) :redshift)
     (mt/dataset sample-dataset
       (testing "Do nested queries in combination with joins and expressions still work correctly? (#14969)"
-        ;; not sure why Snowflake has slightly different results
-        (is (= (if (= driver/*driver* :snowflake)
-                 [["Twitter" "Widget" 0 510.82]
-                  ["Twitter" nil 0 407.93]]
-                 (cond-> [["Twitter" "Widget" 0 498.59]
-                          ["Twitter" nil      0 401.51]]
-                   (mt/sorts-nil-first? driver/*driver*) reverse))
+        (is (= (cond-> [["Twitter" "Widget" 0 498.59]
+                        ["Twitter" nil      0 401.51]]
+                 (mt/sorts-nil-first? driver/*driver*) reverse)
                (mt/formatted-rows [str str int 2.0]
                  (mt/run-mbql-query orders
                    {:source-query {:source-table $$orders
@@ -1108,18 +1104,11 @@
   (mt/test-drivers (disj (mt/normal-drivers-with-feature :foreign-keys :nested-queries) :redshift) ; sample-dataset doesn't work on Redshift yet -- see #14784
     (testing "Multi-level aggregations with filter is the last section (#14872)"
       (mt/dataset sample-dataset
-        ;; not 100% sure why Snowflake has slightly different results
-        (is (= (if (= driver/*driver* :snowflake)
-                 [["Awesome Bronze Plate" 115.22]
-                  ["Mediocre Rubber Shoes" 101.06]
-                  ["Mediocre Wooden Bench" 117.04]
-                  ["Sleek Steel Table" 134.94]
-                  ["Small Marble Hat" 102.77]]
-                 [["Awesome Bronze Plate" 115.23]
-                  ["Mediocre Rubber Shoes" 101.04]
-                  ["Mediocre Wooden Bench" 117.03]
-                  ["Sleek Steel Table" 134.91]
-                  ["Small Marble Hat" 102.8]])
+        (is (= [["Awesome Bronze Plate" 115.23]
+                ["Mediocre Rubber Shoes" 101.04]
+                ["Mediocre Wooden Bench" 117.03]
+                ["Sleek Steel Table" 134.91]
+                ["Small Marble Hat" 102.8]]
                (mt/formatted-rows [str 2.0]
                  (mt/run-mbql-query orders
                    {:source-query {:source-query {:source-table $$orders
@@ -1207,7 +1196,6 @@
                                              :type         :card
                                              :card-id      (u/the-id card)}}})]
             (is (= [["2016-04-01T00:00:00Z" 1]
-                    ;; not sure why Snowflake gives slightly different results, it must be a timezone bug.
-                    ["2016-05-01T00:00:00Z" (if (= driver/*driver* :snowflake) 4 5)]]
+                    ["2016-05-01T00:00:00Z" 5]]
                    (mt/formatted-rows [str int]
                      (qp/process-query query))))))))))

--- a/test/metabase/util/encryption_test.clj
+++ b/test/metabase/util/encryption_test.clj
@@ -93,7 +93,8 @@
   (apply str (repeat 64 "a")))
 
 (deftest log-warning-on-failure-test
-  (testing (str "Something that is not encrypted, but might be (is the correct shape etc) should attempt to be "
+  ;; disabled due to CVE-2021-44228
+  #_(testing (str "Something that is not encrypted, but might be (is the correct shape etc) should attempt to be "
                 "decrypted. If unable to decrypt it, log a warning.")
     (is (includes-encryption-warning?
          (tu/with-log-messages-for-level :warn


### PR DESCRIPTION
This is essentially a manual backport of #19309 for Leiningen (which we used prior to version 41).

It also brings in a resolved version of #18127 to fix failing tests on Snowflake.