### PR TITLE
don't pass dashcard viz settings to query builder

### DIFF
--- a/frontend/src/metabase/dashboard/actions.js
+++ b/frontend/src/metabase/dashboard/actions.js
@@ -965,14 +965,15 @@ export const navigateToNewCardFromDashboard = createThunkAction(
       previousCard,
     );
 
-    const questionWithVizSettings = new Question(cardAfterClick, metadata)
-      .setDisplay(cardAfterClick.display || previousCard.display)
-      .setSettings(
-        cardAfterClick.visualization_settings ||
-          previousCard.visualization_settings,
-      )
-      .lockDisplay()
-      .setDashboardId(dashboard.id);
+    let question = new Question(cardAfterClick, metadata);
+    if (question.query().isEditable()) {
+      question = question
+        .setDisplay(cardAfterClick.display || previousCard.display)
+        .setSettings(dashcard.card.visualization_settings)
+        .lockDisplay();
+    } else {
+      question = question.setCard(dashcard.card).setDashboardId(dashboard.id);
+    }
 
     const parametersMappedToCard = getParametersMappedToDashcard(
       dashboard,
@@ -981,12 +982,9 @@ export const navigateToNewCardFromDashboard = createThunkAction(
 
     // when the query is for a specific object it does not make sense to apply parameter filters
     // because we'll be navigating to the details view of a specific row on a table
-    const url = questionWithVizSettings.isObjectDetail()
-      ? Urls.serializedQuestion(questionWithVizSettings.card())
-      : questionWithVizSettings.getUrlWithParameters(
-          parametersMappedToCard,
-          parameterValues,
-        );
+    const url = question.isObjectDetail()
+      ? Urls.serializedQuestion(question.card())
+      : question.getUrlWithParameters(parametersMappedToCard, parameterValues);
 
     open(url, {
       blankOnMetaOrCtrlKey: true,

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -1159,7 +1159,8 @@ export const runQuestionQuery = ({
     }
 
     const cardIsDirty = originalQuestion
-      ? question.isDirtyComparedToWithoutParameters(originalQuestion)
+      ? question.isDirtyComparedToWithoutParameters(originalQuestion) ||
+        question.card().id == null
       : true;
 
     if (shouldUpdateUrl) {


### PR DESCRIPTION
Related to #13595 

1. When drilling from dashboard --> question, use the original `card.visualization_settings` prop so that dashcard viz settings don't get sent to the query builder
2. When a user lacks self service data permissions, use the original `dashcard.card` object to avoid scenarios where our logic thinks the card is "dirty" and thus tries to run an ad hoc query