### PR TITLE
CI for i18n: Cache those M2 packages

### DIFF
--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -41,6 +41,13 @@ jobs:
       run: |
         curl -O https://download.clojure.org/install/linux-install-1.10.3.933.sh &&
         sudo bash ./linux-install-1.10.3.933.sh
+    - name: Get M2 cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.m2
+          ~/.gitlibs
+        key: ${{ runner.os }}-i18n-${{ hashFiles('**/deps.edn') }}
 
     - run: ./bin/i18n/update-translation-template
       name: Check i18n tags/make sure template can be built


### PR DESCRIPTION
Let's not hit Maven Central for every single run, that's not good for workflow duration and reliability.

**Before**

![image](https://user-images.githubusercontent.com/7288/145658556-f416ddaa-3490-4d99-944b-82b692077171.png)

**After**

![image](https://user-images.githubusercontent.com/7288/145658592-204c5db5-fd7f-481c-a857-cb7289c3df1f.png)
