### PR TITLE
Fix logging test utils & re-enable tests

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -60,6 +60,8 @@
             (p.types/deftype+ '(2 nil nil (:defn)))
             (p/def-map-type '(2 nil nil (:defn)))
             (p/defprotocol+ '(1 (:defn)))
+            (p/defrecord+ '(2 nil nil (:defn)))
+            (p/deftype+ '(2 nil nil (:defn)))
             (tools.macro/macrolet '(1 ((:defn)) :form))))
   (cider-clojure-cli-aliases . "dev:drivers:drivers-dev:ee:ee-dev:user")
   (clojure-indent-style . always-align)

--- a/test/metabase/api/session_test.clj
+++ b/test/metabase/api/session_test.clj
@@ -67,8 +67,7 @@
       (let [body (assoc (mt/user->credentials :rasta) :remember false)
             response (mt/client-full-response :post 200 "session" body)]
         (is (nil? (get-in response [:cookies session-cookie :expires]))))))
-  ;; disabled due to CVE-2021-44228
-  #_(testing "failure should log an error(#14317)"
+  (testing "failure should log an error(#14317)"
     (mt/with-temp User [user]
       (is (schema= [(s/one (s/eq :error)
                            "log type")
@@ -111,8 +110,7 @@
       (testing "throttling should now be triggered"
         (is (re= #"^Too many attempts! You must wait \d+ seconds before trying again\.$"
                  (login))))
-      ;; disabled due to CVE-2021-44228
-      #_(testing "Error should be logged (#14317)"
+      (testing "Error should be logged (#14317)"
         (is (schema= [(s/one (s/eq :error)
                              "log type")
                       (s/one clojure.lang.ExceptionInfo

--- a/test/metabase/pulse/render/png_test.clj
+++ b/test/metabase/pulse/render/png_test.clj
@@ -1,26 +1,24 @@
 (ns metabase.pulse.render.png-test
   (:require [clojure.test :refer :all]
             [metabase.pulse.render.png :as png]
-            #_[metabase.test :as mt]
-            #_[schema.core :as s]))
+            [metabase.test :as mt]
+            [schema.core :as s]))
 
 (deftest register-fonts-test
   (testing "Under normal circumstances, font registration should work as expected"
     (is (= nil
            (#'png/register-fonts-if-needed!))))
 
-  ;; disabled due to CVE-2021-44228
-  #_(testing "If font regsitration fails, we should an Exception with a useful error message"
-      (with-redefs [png/register-font! (fn [& _]
-                                         (throw (ex-info "Oops!" {})))]
-        (let [messages (mt/with-log-level :error
-                         (mt/with-log-messages
-                           (is (thrown-with-msg?
-                                clojure.lang.ExceptionInfo
-                                #"Error registering fonts: Metabase will not be able to send Pulses"
-                                (#'png/register-fonts!)))))]
-          (testing "Should log the Exception"
-            (is (schema= [(s/one (s/eq :error) "log type")
-                          (s/one Throwable "exception")
-                          (s/one #"^Error registering fonts" "message")]
-                         (first messages))))))))
+  (testing "If font registration fails, we should an Exception with a useful error message"
+    (with-redefs [png/register-font! (fn [& _]
+                                       (throw (ex-info "Oops!" {})))]
+      (let [messages (mt/with-log-messages-for-level :error
+                       (is (thrown-with-msg?
+                            clojure.lang.ExceptionInfo
+                            #"Error registering fonts: Metabase will not be able to send Pulses"
+                            (#'png/register-fonts!))))]
+        (testing "Should log the Exception"
+          (is (schema= [(s/one (s/eq :error) "log type")
+                        (s/one Throwable "exception")
+                        (s/one #"^Error registering fonts" "message")]
+                       (first messages))))))))

--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -208,7 +208,6 @@
   ns-log-level
   set-ns-log-level!
   suppress-output
-  with-log-messages
   with-log-messages-for-level
   with-log-level]
 

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -50,7 +50,6 @@
 (p/import-vars
  [tu.log
   with-log-level
-  with-log-messages
   with-log-messages-for-level])
 
 (defn- random-uppercase-letter []

--- a/test/metabase/test/util/log.clj
+++ b/test/metabase/test/util/log.clj
@@ -2,13 +2,21 @@
   "Utils for controlling the logging that goes on when running tests."
   (:require [clojure.test :refer :all]
             [clojure.tools.logging :as log]
+            [clojure.tools.logging.impl :as log.impl]
             [metabase.test-runner.parallel :as test-runner.parallel]
+            [potemkin :as p]
             [schema.core :as s])
   (:import java.io.PrintStream
            [org.apache.commons.io.output NullOutputStream NullWriter]
            [org.apache.logging.log4j Level LogManager]
-           [org.apache.logging.log4j.core Logger LoggerContext]
+           [org.apache.logging.log4j.core Appender LifeCycle LogEvent Logger LoggerContext]
            [org.apache.logging.log4j.core.config Configuration LoggerConfig]))
+
+;; make sure [[clojure.tools.logging]] is using the Log4j2 factory, otherwise the swaps we attempt to do here don't seem
+;; to work.
+(when-not (= (log.impl/name log/*logger-factory*) "org.apache.logging.log4j")
+  (println "Setting clojure.tools.logging factory to" `log.impl/log4j2-factory)
+  (alter-var-root #'log/*logger-factory* (constantly (log.impl/log4j2-factory))))
 
 (def ^:private ^:deprecated logger->original-level
   (delay
@@ -55,22 +63,6 @@
   [& body]
   `(do-with-suppressed-output (fn [] ~@body)))
 
-(defn do-with-log-messages [f]
-  (let [messages (atom [])]
-    (with-redefs [log/log* (fn [_ & message]
-                             (swap! messages conj (vec message)))]
-      (f))
-    @messages))
-
-(defmacro with-log-messages
-  "Execute `body`, and return a vector of all messages logged using the `log/` family of functions. Messages are of the
-  format `[:level throwable message]`, and are returned in chronological order from oldest to newest.
-
-     (with-log-messages (log/warn \"WOW\")) ; -> [[:warn nil \"WOW\"]]"
-  {:style/indent 0}
-  [& body]
-  `(do-with-log-messages (fn [] ~@body)))
-
 (def ^:private keyword->Level
   {:off   Level/OFF
    :fatal Level/FATAL
@@ -99,93 +91,86 @@
             k))
         keyword->Level))
 
+(defn- logger-name ^String [a-namespace]
+  (if (instance? clojure.lang.Namespace a-namespace)
+    (recur (ns-name a-namespace))
+    (name a-namespace)))
+
 (defn- logger-context ^LoggerContext []
-  (LogManager/getContext true))
+  (LogManager/getContext false))
 
 (defn- configuration ^Configuration []
   (.getConfiguration (logger-context)))
 
 (defn- effective-ns-logger
-  "Get the logger that will be used for the namespace named by `ns-symb`."
-  ^LoggerConfig [ns-symb]
-  {:pre [(symbol? ns-symb)]}
-  (.getLoggerConfig (configuration) (name ns-symb)))
+  "Get the logger that will be used for the namespace named by `a-namespace`."
+  ^LoggerConfig [a-namespace]
+  (assert (= (log.impl/name log/*logger-factory*) "org.apache.logging.log4j"))
+  (let [^Logger logger (log.impl/get-logger log/*logger-factory* (logger-name a-namespace))]
+      (.get logger)))
 
 (s/defn ns-log-level :- LogLevelKeyword
-  "Get the log level currently applied to the namespace named by symbol `ns-symb`. `ns-symb` may be a symbol that names
-  an actual namespace, or a prefix such or `metabase` that applies to all 'sub' namespaces that start with
+  "Get the log level currently applied to the namespace named by symbol `a-namespace`. `a-namespace` may be a symbol
+  that names an actual namespace, or a prefix such or `metabase` that applies to all 'sub' namespaces that start with
   `metabase.` (unless a more specific logger is defined for them).
 
     (mt/ns-log-level 'metabase.query-processor.middleware.cache) ; -> :info"
-  [ns-symb]
-  (log-level->keyword (.getLevel (effective-ns-logger ns-symb))))
-
-(defn- logger-name
-  ^String [^LoggerConfig logger]
-  (.getName logger))
+  [a-namespace]
+  (log-level->keyword (.getLevel (effective-ns-logger a-namespace))))
 
 (defn- exact-ns-logger
-  "Get the logger defined for `ns-symb` if it is an exact match; otherwise `nil` if a 'parent' logger will be used."
-  ^LoggerConfig [ns-symb]
-  (let [logger (effective-ns-logger ns-symb)]
-    (when (= (logger-name logger) (name ns-symb))
+  "Get the logger defined for `a-namespace` if it is an exact match; otherwise `nil` if a 'parent' logger will be used."
+  ^LoggerConfig [a-namespace]
+  (let [logger (effective-ns-logger a-namespace)]
+    (when (= (.getName logger) (logger-name a-namespace))
       logger)))
 
-(defn- get-or-create-ns-logger!
-  "Get the logger currently used for `ns-symb`. If this logger is a parent logger, create a new logger specifically for
-  this namespace and return that."
-  ^LoggerConfig [ns-symb]
-  (or (exact-ns-logger ns-symb)
-      (let [parent-logger (effective-ns-logger ns-symb)
-            new-logger    (LoggerConfig/createLogger
-                           (.isAdditive parent-logger)
-                           (.getLevel parent-logger)
-                           (name ns-symb)
-                           (str (.isIncludeLocation parent-logger))
-                           ^"[Lorg.apache.logging.log4j.core.config.AppenderRef;"
-                           (into-array org.apache.logging.log4j.core.config.AppenderRef (.getAppenderRefs parent-logger))
-                           ^"[Lorg.apache.logging.log4j.core.config.Property;"
-                           (into-array org.apache.logging.log4j.core.config.Property (.getPropertyList parent-logger))
-                           (configuration)
-                           (.getFilter parent-logger))]
-        (.addLogger (configuration) (name ns-symb) new-logger)
-        (println "Created a new logger for" ns-symb)
-        new-logger)))
-
-(defn- logger-info [^LoggerConfig logger]
-  {:additive?         (.isAdditive logger)
-   :include-location? (.isIncludeLocation logger)
-   :level             (log-level->keyword (.getLevel logger))
-   :name              (.getName logger)
-   :properties        (.getProperties logger)})
+(defn- ensure-unique-logger!
+  "Ensure that `a-namespace` has its own unique logger, e.g. it's not a parent logger like `metabase`. This way we can
+  set the level for this namespace without affecting others."
+  [a-namespace]
+  (when-not (exact-ns-logger a-namespace)
+    (let [parent-logger (effective-ns-logger a-namespace)
+          new-logger    (LoggerConfig/createLogger
+                         (.isAdditive parent-logger)
+                         (.getLevel parent-logger)
+                         (logger-name a-namespace)
+                         (str (.isIncludeLocation parent-logger))
+                         ^"[Lorg.apache.logging.log4j.core.config.AppenderRef;"
+                         (into-array org.apache.logging.log4j.core.config.AppenderRef (.getAppenderRefs parent-logger))
+                         ^"[Lorg.apache.logging.log4j.core.config.Property;"
+                         (into-array org.apache.logging.log4j.core.config.Property (.getPropertyList parent-logger))
+                         (configuration)
+                         (.getFilter parent-logger))]
+      (.addLogger (configuration) (logger-name a-namespace) new-logger)
+      (println "Created a new logger for" (logger-name a-namespace)))))
 
 (s/defn set-ns-log-level!
-  "Set the log level for the namespace named by `ns-symb`. Intended primarily for REPL usage; for tests,
-  with [[with-log-messages-for-level]] instead. `ns-symb` may be a symbol that names an actual namespace, or can be a
-  prefix such as `metabase` that applies to all 'sub' namespaces that start with `metabase.` (unless a more specific
-  logger is defined for them).
+  "Set the log level for the namespace named by `a-namespace`. Intended primarily for REPL usage; for tests,
+  with [[with-log-messages-for-level]] instead. `a-namespace` may be a symbol that names an actual namespace, or can
+  be a prefix such as `metabase` that applies to all 'sub' namespaces that start with `metabase.` (unless a more
+  specific logger is defined for them).
 
     (mt/set-ns-log-level! 'metabase.query-processor.middleware.cache :debug)"
   ([new-level :- LogLevelKeyword]
    (set-ns-log-level! (ns-name *ns*) new-level))
 
-  ([ns-symb new-level :- LogLevelKeyword]
-   (let [logger    (get-or-create-ns-logger! ns-symb)
+  ([a-namespace new-level :- LogLevelKeyword]
+   (ensure-unique-logger! a-namespace)
+   (let [logger    (exact-ns-logger a-namespace)
          new-level (->Level new-level)]
+     (println "\nSet logger" (pr-str (logger-name a-namespace)) (pr-str logger) "level to" new-level)
      (.setLevel logger new-level)
      (.updateLoggers (logger-context)))))
 
-(defn do-with-log-messages-for-level [x thunk]
+(defn do-with-log-level [a-namespace level thunk]
   (test-runner.parallel/assert-test-is-not-parallel "with-log-level")
-  (let [[ns-symb level] (if (sequential? x)
-                          x
-                          ['metabase x])
-        old-level       (ns-log-level ns-symb)]
+  (let [original-log-level (ns-log-level a-namespace)]
     (try
-      (set-ns-log-level! ns-symb level)
+      (set-ns-log-level! a-namespace level)
       (thunk)
       (finally
-        (set-ns-log-level! ns-symb old-level)))))
+        (set-ns-log-level! a-namespace original-log-level)))))
 
 (defmacro with-log-level
   "Sets the log level (e.g. `:debug` or `:trace`) while executing `body`. Not thread safe! But good for debugging from
@@ -202,12 +187,72 @@
       ...)"
   {:arglists '([level & body]
                [[namespace level] & body])}
-  [level & body]
-  `(do-with-log-messages-for-level ~(if (sequential? level)
-                                      `(quote ~level)
-                                      level)
-                                   (fn [] ~@body)))
+  [ns+level & body]
+  (let [[a-namespace level] (if (sequential? ns+level)
+                              ns+level
+                              ['metabase ns+level])
+        a-namespace         (if (symbol? a-namespace)
+                              (list 'quote a-namespace)
+                              a-namespace)]
+    `(do-with-log-level ~a-namespace ~level (fn [] ~@body))))
 
+
+;;;; [[with-log-messages-for-level]]
+
+(p/defprotocol+ ^:private IInMemoryAppender
+  (^:private appender-logs [this]))
+
+(p/defrecord+ ^:private InMemoryAppender [appender-name state]
+  Appender
+  (append [_this event]
+    (let [event ^LogEvent event]
+      (swap! state update :logs (fn [logs]
+                                  (conj (vec logs)
+                                        [(log-level->keyword (.getLevel event))
+                                         (.getThrown event)
+                                         (str (.getMessage event))
+                                         #_(.getLoggerName event)]))))
+    nil)
+  (getHandler [_this]
+    (:error-handler @state))
+  (getLayout [_this])
+  (getName [_this]
+    appender-name)
+  (ignoreExceptions [_this]
+    true)
+  (setHandler [_this new-handler]
+    (swap! state assoc :error-handler new-handler))
+
+  LifeCycle
+  (getState [_this])
+  (initialize [_this])
+  (isStarted [_this]
+    (not (:stopped @state)))
+  (isStopped [_this]
+    (boolean (:stopped @state)))
+  (start [_this]
+    (swap! state assoc :stopped false))
+  (stop [_this]
+    (swap! state assoc :stopped true))
+
+  IInMemoryAppender
+  (appender-logs [_this]
+    (:logs @state)))
+
+(defn do-with-log-messages-for-level [a-namespace level f]
+  (test-runner.parallel/assert-test-is-not-parallel "with-log-messages-for-level")
+  (ensure-unique-logger! a-namespace)
+  (let [state         (atom nil)
+        appender-name (format "%s-%s-%s" `InMemoryAppender (logger-name a-namespace) (name level))
+        appender      (->InMemoryAppender appender-name state)
+        logger        (exact-ns-logger a-namespace)]
+    (try
+      (.addAppender logger appender (->Level level) nil)
+      (f (fn [] (appender-logs appender)))
+      (finally
+        (.removeAppender logger appender-name)))))
+
+;; TODO -- this macro should probably just take a binding for the `logs` function so you can eval when needed
 (defmacro with-log-messages-for-level
   "Executes `body` with the metabase logging level set to `level-kwd`. This is needed when the logging level is set at a
   higher threshold than the log messages you're wanting to example. As an example if the metabase logging level is set
@@ -216,10 +261,28 @@
   the log function will never be invoked. This macro will temporarily set the logging level to `level-kwd`, then
   invoke `with-log-messages`, then set the level back to what it was before the invocation. This allows testing log
   messages even if the threshold is higher than the message you are looking for."
-  [level-kwd & body]
-  `(with-log-level ~level-kwd
-     (with-log-messages
-       ~@body)))
+  {:arglists '([level & body] [[a-namespace level] & body])}
+  [ns+level & body]
+  (let [[a-namespace level] (if (sequential? ns+level)
+                              ns+level
+                              ['metabase ns+level])
+        a-namespace (if (symbol? a-namespace)
+                      (list 'quote a-namespace)
+                      a-namespace)]
+    `(do-with-log-level
+      ~a-namespace
+      ~level
+      (fn []
+        (do-with-log-messages-for-level
+         ~a-namespace
+         ~level
+         (fn [logs#]
+           ~@body
+           (logs#)))))))
+
+
+
+;;;; tests
 
 (deftest set-ns-log-level!-test
   (let [original-mb-log-level (ns-log-level 'metabase)]

--- a/test/metabase/test/util/log.clj
+++ b/test/metabase/test/util/log.clj
@@ -107,7 +107,7 @@
   ^LoggerConfig [a-namespace]
   (assert (= (log.impl/name log/*logger-factory*) "org.apache.logging.log4j"))
   (let [^Logger logger (log.impl/get-logger log/*logger-factory* (logger-name a-namespace))]
-      (.get logger)))
+    (.get logger)))
 
 (s/defn ns-log-level :- LogLevelKeyword
   "Get the log level currently applied to the namespace named by symbol `a-namespace`. `a-namespace` may be a symbol
@@ -129,6 +129,7 @@
   "Ensure that `a-namespace` has its own unique logger, e.g. it's not a parent logger like `metabase`. This way we can
   set the level for this namespace without affecting others."
   [a-namespace]
+  {:post [(exact-ns-logger a-namespace)]}
   (when-not (exact-ns-logger a-namespace)
     (let [parent-logger (effective-ns-logger a-namespace)
           new-logger    (LoggerConfig/createLogger
@@ -143,6 +144,7 @@
                          (configuration)
                          (.getFilter parent-logger))]
       (.addLogger (configuration) (logger-name a-namespace) new-logger)
+      (.updateLoggers (logger-context))
       (println "Created a new logger for" (logger-name a-namespace)))))
 
 (s/defn set-ns-log-level!
@@ -159,7 +161,6 @@
    (ensure-unique-logger! a-namespace)
    (let [logger    (exact-ns-logger a-namespace)
          new-level (->Level new-level)]
-     (println "\nSet logger" (pr-str (logger-name a-namespace)) (pr-str logger) "level to" new-level)
      (.setLevel logger new-level)
      (.updateLoggers (logger-context)))))
 

--- a/test/metabase/util/encryption_test.clj
+++ b/test/metabase/util/encryption_test.clj
@@ -88,9 +88,8 @@
 
 (deftest no-errors-for-unencrypted-test
   (testing "Something obviously not encrypted should avoiding trying to decrypt it (and thus not log an error)"
-    (is (= []
-           (tu/with-log-messages-for-level :warn
-             (encryption/maybe-decrypt secret "abc"))))))
+    (is (empty? (tu/with-log-messages-for-level :warn
+                  (encryption/maybe-decrypt secret "abc"))))))
 
 (def ^:private fake-ciphertext
   "AES+CBC's block size is 16 bytes and the tag length is 32 bytes. This is a string of characters that is the same
@@ -99,8 +98,7 @@
   (apply str (repeat 64 "a")))
 
 (deftest log-warning-on-failure-test
-  ;; disabled due to CVE-2021-44228
-  #_(testing (str "Something that is not encrypted, but might be (is the correct shape etc) should attempt to be "
+  (testing (str "Something that is not encrypted, but might be (is the correct shape etc) should attempt to be "
                 "decrypted. If unable to decrypt it, log a warning.")
     (is (includes-encryption-warning?
          (tu/with-log-messages-for-level :warn

--- a/test_config/log4j2-test.xml
+++ b/test_config/log4j2-test.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration>
   <Appenders>
-    <Console name="Console" target="SYSTEM_OUT">
+    <Console name="Console" target="SYSTEM_OUT" follow="true">
       <PatternLayout pattern="[%t] %-5level %logger{36} - %msg%n"/>
     </Console>
   </Appenders>


### PR DESCRIPTION
Fixes #19331

For whatever reason the old way we were getting and creating loggers wasn't returning the same logger that `tools.logging` was ultimately using anymore -- so I just tweaked things to piggyback off of the code in `clojure.tools.logging.impl` instead