### PR TITLE
Add option to force latest GitHub release

### DIFF
--- a/bin/release/src/release/common.clj
+++ b/bin/release/src/release/common.clj
@@ -69,6 +69,16 @@
   (assert (#{:oss :ee} new-edition))
   (swap! build-options assoc :edition new-edition))
 
+(defn force-latest-release?
+  "Whether this release should be set/forced as the \"latest\" one on GitHub. This is accomplished by overriding the
+  GIT_COMMITTER_DATE env var when creating the tag to be *now* rather than whatever the latest commit date is."
+  []
+  (build-option-or-throw :force-latest-release))
+
+(defn set-force-latest-release?! [latest?]
+  (assert boolean? latest?)
+  (swap! build-options assoc :force-latest-release latest?))
+
 (defn pre-release-version?
   "Whether this version should be considered a prerelease. True if the version doesn't follow the usual
   `major.minor.patch[.build]` format."

--- a/bin/release/src/release/common/git.clj
+++ b/bin/release/src/release/common/git.clj
@@ -1,6 +1,8 @@
 (ns release.common.git
   (:require [metabuild-common.core :as u]
-            [release.common :as c]))
+            [release.common :as c])
+  (:import (java.time.format DateTimeFormatter)
+           (java.time ZonedDateTime)))
 
 (defn delete-local-tag!
   "Delete `tag` if it exists locally."
@@ -24,6 +26,15 @@
       (delete-local-tag! repo-dir tag)
       (delete-remote-tag! repo-dir tag))
     (u/step "Push updated tag to GitHub"
-      (u/sh {:dir repo-dir} "git" "tag" "-a" tag "-m" tag)
+      (u/sh (cond-> {:dir repo-dir}
+              (c/force-latest-release?)
+              (assoc :env (do
+                            (u/announce (str "Forcing this to be \"latest\" release in GitHub by overriding"
+                                             "GIT_COMMITTER_DATE as \"now\" when creating the tag"))
+                            (into {"GIT_COMMITTER_DATE"
+                                   (.format (DateTimeFormatter/ofPattern "eee, d MMM yyyy hh:mm:ss Z")
+                                            (ZonedDateTime/now))}
+                                  System/getenv))))
+            "git" "tag" "-a" tag "-m" tag)
       (u/sh {:dir repo-dir} "git" "push" "--follow-tags" "--set-upstream" "origin" (c/branch)))
     (u/announce "Tag updated.")))

--- a/bin/release/src/release/set_build_options.clj
+++ b/bin/release/src/release/set_build_options.clj
@@ -9,6 +9,7 @@
     (loop []
       (let [version                    (u/read-line-with-prompt "What version are we building (e.g. 0.36.0)?")
             branch                     current-branch
+            latest-release?            (u/yes-or-no-prompt "Should this be set as the \"latest\" release on GitHub?")
             [github-milestone edition] (case (first version)
                                          \0 [version :oss]
                                          ;; always query GitHub milestone on the basis of OSS form of version
@@ -22,4 +23,5 @@
             (c/set-version! version)
             (c/set-branch! branch)
             (c/set-edition! edition)
+            (c/set-force-latest-release?! latest-release?)
             (c/set-github-milestone! github-milestone)))))))

--- a/bin/release/test/release/version_info_test.clj
+++ b/bin/release/test/release/version_info_test.clj
@@ -36,6 +36,7 @@
                                                                     {:title title})
                                                                   (last (first test-versions))))]
         (c/set-version! (case edition :oss "0.39.0" "1.39.0"))
+        (c/set-force-latest-release?! false)
         (c/set-branch!  "testing")
         (c/set-edition! edition)
         (#'v-info/generate-version-info!)


### PR DESCRIPTION
Updating release script with a new build option to force the release to be latest (by overriding the `GIT_COMMITTER_DATE` env var when creating the tag)
