### PR TITLE
Fix several intermittent test failures in e2e tests with `should`

### DIFF
--- a/frontend/test/__support__/e2e/helpers/e2e-custom-column-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-custom-column-helpers.js
@@ -3,7 +3,8 @@ export function enterCustomColumnDetails({ formula, name } = {}) {
     .first()
     .as("formula")
     .focus()
-    .type(formula);
+    .type(formula, { delay: 50 })
+    .blur();
 
   if (name) {
     cy.findByPlaceholderText("Something nice and descriptive").type(name);

--- a/frontend/test/__support__/e2e/helpers/e2e-custom-column-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-custom-column-helpers.js
@@ -3,7 +3,7 @@ export function enterCustomColumnDetails({ formula, name } = {}) {
     .first()
     .as("formula")
     .focus()
-    .type(formula, { delay: 50 })
+    .type(formula)
     .blur();
 
   if (name) {

--- a/frontend/test/__support__/e2e/helpers/e2e-custom-column-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-custom-column-helpers.js
@@ -2,9 +2,9 @@ export function enterCustomColumnDetails({ formula, name } = {}) {
   cy.get(".ace_text-input")
     .first()
     .as("formula")
+    .should("exist")
     .focus()
-    .type(formula)
-    .blur();
+    .type(formula);
 
   if (name) {
     cy.findByPlaceholderText("Something nice and descriptive").type(name);

--- a/frontend/test/metabase/scenarios/custom-column/reproductions/13751-cc-allow-strings-in-filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/reproductions/13751-cc-allow-strings-in-filter.cy.spec.js
@@ -15,8 +15,12 @@ describe("issue 13751", () => {
 
     cy.visit("/question/new");
     cy.findByText("Custom question").click();
-    cy.findByText(PG_DB_NAME).click();
-    cy.findByText("People").click();
+    cy.findByText(PG_DB_NAME)
+      .should("be.visible")
+      .click();
+    cy.findByText("People")
+      .should("be.visible")
+      .click();
   });
 
   it("should allow using strings in filter based on a custom column (metabase#13751)", () => {

--- a/frontend/test/metabase/scenarios/custom-column/reproductions/14517-cc-do-not-remove-regex-escape-chars.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/reproductions/14517-cc-do-not-remove-regex-escape-chars.cy.spec.js
@@ -13,8 +13,12 @@ describe.skip("postgres > question > custom columns", () => {
 
     cy.visit("/question/new");
     cy.findByText("Custom question").click();
-    cy.findByText(PG_DB_NAME).click();
-    cy.findByText("People").click();
+    cy.findByText(PG_DB_NAME)
+      .should("be.visible")
+      .click();
+    cy.findByText("People")
+      .should("be.visible")
+      .click();
   });
 
   it("should not remove regex escape characters (metabase#14517)", () => {

--- a/frontend/test/metabase/scenarios/onboarding/setup/setup.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/setup/setup.cy.spec.js
@@ -27,7 +27,9 @@ describe("scenarios > setup", () => {
       });
       cy.location("pathname").should("eq", "/setup");
       cy.findByText("Welcome to Metabase");
-      cy.findByText("Let's get started").click();
+      cy.findByText("Let's get started")
+        .should("be.visible")
+        .click();
 
       // ========
       // Language
@@ -172,7 +174,9 @@ describe("scenarios > setup", () => {
     cy.visit(`/setup#123456`);
 
     cy.findByText("Welcome to Metabase");
-    cy.findByText("Let's get started").click();
+    cy.findByText("Let's get started")
+      .should("be.visible")
+      .click();
 
     cy.findByText("What's your preferred language?");
     cy.findByTestId("language-option-en");
@@ -204,7 +208,9 @@ describeWithSnowplow("scenarios > setup", () => {
 
     // 2 - setup/step_seen
     cy.findByText("Welcome to Metabase");
-    cy.findByText("Let's get started").click();
+    cy.findByText("Let's get started")
+      .should("be.visible")
+      .click();
 
     // 3 - setup/step_seen
     cy.findByText("What's your preferred language?");
@@ -218,7 +224,9 @@ describeWithSnowplow("scenarios > setup", () => {
     cy.visit(`/setup`);
 
     cy.findByText("Welcome to Metabase");
-    cy.findByText("Let's get started").click();
+    cy.findByText("Let's get started")
+      .should("be.visible")
+      .click();
     cy.findByText("What's your preferred language?");
 
     // One backend event should be recorded (on new instance initialization)

--- a/frontend/test/metabase/scenarios/question/reproductions/13263-postgres-show-row-details-on-pk-click.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/13263-postgres-show-row-details-on-pk-click.cy.spec.js
@@ -10,10 +10,10 @@ describe("postgres > user > query", () => {
     cy.visit("/question/new");
     cy.findByText("Simple question").click();
     cy.findByText(PG_DB_NAME)
-      .should("exist")
+      .should("be.visible")
       .click();
     cy.findByText("Orders")
-      .should("exist")
+      .should("be.visible")
       .click();
   });
 

--- a/frontend/test/metabase/scenarios/question/reproductions/13263-postgres-show-row-details-on-pk-click.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/13263-postgres-show-row-details-on-pk-click.cy.spec.js
@@ -9,8 +9,12 @@ describe("postgres > user > query", () => {
 
     cy.visit("/question/new");
     cy.findByText("Simple question").click();
-    cy.findByText(PG_DB_NAME).click();
-    cy.findByText("Orders").click();
+    cy.findByText(PG_DB_NAME)
+      .should("exist")
+      .click();
+    cy.findByText("Orders")
+      .should("exist")
+      .click();
   });
 
   it("should show row details when clicked on its entity key (metabase#13263)", () => {

--- a/frontend/test/metabase/scenarios/question/reproductions/14957-unable-to-save-question-before-query-executed.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/14957-unable-to-save-question-before-query-executed.cy.spec.js
@@ -9,7 +9,9 @@ describe.skip("issue 14957", () => {
 
     cy.visit("/question/new");
     cy.findByText("Native query").click();
-    cy.findByText(PG_DB_NAME).click();
+    cy.findByText(PG_DB_NAME)
+      .should("be.visible")
+      .click();
   });
 
   it("should save a question before query has been executed (metabase#14957)", () => {

--- a/frontend/test/metabase/scenarios/question/reproductions/15714-cc-postgres-percentile-accepts-two-params.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/15714-cc-postgres-percentile-accepts-two-params.cy.spec.js
@@ -10,7 +10,9 @@ describe("postgres > question > custom columns", () => {
     cy.visit("/question/new");
     cy.findByText("Custom question").click();
     cy.findByText(PG_DB_NAME).click();
-    cy.findByText("Orders").click();
+    cy.findByText("Orders")
+      .should("exist")
+      .click();
   });
 
   it("`Percentile` custom expression function should accept two parameters (metabase#15714)", () => {

--- a/frontend/test/metabase/scenarios/question/reproductions/15714-cc-postgres-percentile-accepts-two-params.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/15714-cc-postgres-percentile-accepts-two-params.cy.spec.js
@@ -9,9 +9,11 @@ describe("postgres > question > custom columns", () => {
 
     cy.visit("/question/new");
     cy.findByText("Custom question").click();
-    cy.findByText(PG_DB_NAME).click();
+    cy.findByText(PG_DB_NAME)
+      .should("be.visible")
+      .click();
     cy.findByText("Orders")
-      .should("exist")
+      .should("be.visible")
       .click();
   });
 

--- a/frontend/test/metabase/scenarios/smoketest/admin.cy.spec.js
+++ b/frontend/test/metabase/scenarios/smoketest/admin.cy.spec.js
@@ -17,7 +17,9 @@ describe("metabase-smoketest > admin", () => {
       cy.visit("/");
       cy.findByText("Welcome to Metabase");
       cy.url().should("not.include", "login");
-      cy.findByText("Let's get started").click();
+      cy.findByText("Let's get started")
+        .should("be.visible")
+        .click();
 
       // Language
 


### PR DESCRIPTION
This fixes several races conditions in tests that are likely to have delays due to external data sources or even just DOM lag.

This is the equivalent of adding `cy.delay(...)` but based on an async condition instead of a brittle delay.

Example of intermittent failures:

* [in `e2e-tests-custom-column-oss`](https://app.circleci.com/pipelines/github/metabase/metabase/25815/workflows/74c282d2-3719-4947-9b15-e608c2349b38/jobs/1211547)
* [in `e2e-tests-smoketest-ee`](https://app.circleci.com/pipelines/github/metabase/metabase/25832/workflows/663f47bb-481c-423e-bb82-ba85c85d19f9/jobs/1212741)
* [in `e2e-tests-onboarding-ee`](https://app.circleci.com/pipelines/github/metabase/metabase/25832/workflows/663f47bb-481c-423e-bb82-ba85c85d19f9/jobs/1212747)