### PR TITLE
React Ace: add syntax highlighting types

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionMode.js
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionMode.js
@@ -9,6 +9,11 @@ class ExpressionHighlight extends window.ace.acequire(
     this.$rules = {
       start: [
         {
+          token: "aggregation",
+          regex:
+            "Average|CountIf|CumulativeCount|CumulativeSum|Median|Min|Max|Percentile|Share|StandardDeviation|SumIf|Variance",
+        },
+        {
           token: "constant.numeric",
           regex: "[+-]?\\d+(?:(?:\\.\\d*)?(?:[eE][+-]?\\d+)?)?\\b",
         },

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionMode.js
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionMode.js
@@ -15,8 +15,7 @@ class ExpressionHighlight extends window.ace.acequire(
         },
         {
           token: "boolean",
-          regex:
-            "between|contains|endsWith|interval|isempty|isnull||startsWith",
+          regex: "between|contains|endsWith|interval|isempty|isnull|startsWith",
         },
         {
           token: "constant.numeric",

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionMode.js
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionMode.js
@@ -31,7 +31,7 @@ class ExpressionHighlight extends window.ace.acequire(
         },
         {
           token: "variable",
-          regex: "\\[.+\\]",
+          regex: "\\[.*?\\]",
         },
         {
           token: "paren.lparen",

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionMode.js
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionMode.js
@@ -14,6 +14,11 @@ class ExpressionHighlight extends window.ace.acequire(
             "Average|CountIf|CumulativeCount|CumulativeSum|Median|Min|Max|Percentile|Share|StandardDeviation|SumIf|Variance",
         },
         {
+          token: "boolean",
+          regex:
+            "between|contains|endsWith|interval|isempty|isnull||startsWith",
+        },
+        {
           token: "constant.numeric",
           regex: "[+-]?\\d+(?:(?:\\.\\d*)?(?:[eE][+-]?\\d+)?)?\\b",
         },

--- a/frontend/src/metabase/query_builder/components/expressions/expressions.css
+++ b/frontend/src/metabase/query_builder/components/expressions/expressions.css
@@ -16,6 +16,10 @@
   color: var(--color-accent1);
 }
 
+.expression-editor-textfield .ace-tm .ace_boolean {
+  color: var(--color-accent2);
+}
+
 .ace_cursor {
   border-left-width: 1px;
 }

--- a/frontend/src/metabase/query_builder/components/expressions/expressions.css
+++ b/frontend/src/metabase/query_builder/components/expressions/expressions.css
@@ -12,6 +12,10 @@
   color: var(--color-brand);
 }
 
+.expression-editor-textfield .ace-tm .ace_aggregation {
+  color: var(--color-accent1);
+}
+
 .ace_cursor {
   border-left-width: 1px;
 }

--- a/frontend/src/metabase/query_builder/components/expressions/expressions.css
+++ b/frontend/src/metabase/query_builder/components/expressions/expressions.css
@@ -20,6 +20,10 @@
   color: var(--color-accent2);
 }
 
+.expression-editor-textfield .ace-tm .ace_string {
+  color: var(--color-accent5);
+}
+
 .ace_cursor {
   border-left-width: 1px;
 }


### PR DESCRIPTION
This is not the full thing. Let's call it a step forward.

The main keywords are mapped to their colors, using css vars.

What isn't happening is parens taking the color of the keyword.

<hr />

### Examples:

```
contains([Title], "Enormous") OR contains([Title], "Aerodynamic")
```

In the original:

<img src=https://user-images.githubusercontent.com/380816/146070083-18c8c490-c3c8-471a-a0f3-0f3bc26e9831.png width=300 />

In ours:

<img src=https://user-images.githubusercontent.com/380816/146070122-97198243-cf70-46b1-973a-2abdce3ccbe9.png width=300 />

<hr />

```
SumIf([Subtotal], ([Subtotal] + [Tax] > 20))
```

In the original:

<img src=https://user-images.githubusercontent.com/380816/146070520-24152637-be95-47e7-b32f-0cbcba5b1d2e.png width=300 />

In ours:

<img src=https://user-images.githubusercontent.com/380816/146070718-7744521b-f837-452c-a198-7a7c9efea05e.png width=300 />



