### PR TITLE
CI with GitHub Actions: Run some of them with BuildJet

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,7 +9,7 @@ on:
 jobs:
 
   build:
-    runs-on: ubuntu-20.04
+    runs-on: buildjet-2vcpu-ubuntu-2004
     timeout-minutes: 40
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -91,7 +91,7 @@ jobs:
       name: Check types
 
   fe-tests-unit:
-    runs-on: ubuntu-20.04
+    runs-on: buildjet-2vcpu-ubuntu-2004
     timeout-minutes: 20
     steps:
     - uses: actions/checkout@v2
@@ -124,7 +124,7 @@ jobs:
         flags: front-end
 
   fe-tests-timezones:
-    runs-on: ubuntu-20.04
+    runs-on: buildjet-2vcpu-ubuntu-2004
     timeout-minutes: 14
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: buildjet-2vcpu-ubuntu-2004
     timeout-minutes: 60
     strategy:
       matrix:


### PR DESCRIPTION
Run some of the longest workflows (wrt to the duration) with BuildJet, instead of GitHub-own runner.

Comparison of results:



|Workflow|GitHub runner|BuildJet runner|
| - | - | -- |
|fe-tests-unit|9m 55s|6m 31s|
|fe-tests-timezone|7m 3s|5m 45s|
|build (docker)|20m 5s|12m 52s|
|percy|23m 51s|11m 16s|

