### PR TITLE
Parser fuzzing: avoid invalid left-hand side in a comparison

### DIFF
--- a/frontend/test/metabase/lib/expressions/generator.js
+++ b/frontend/test/metabase/lib/expressions/generator.js
@@ -252,10 +252,34 @@ export function generateExpression(seed, resultType, depth = 13) {
   };
 
   const comparison = () => {
+    const isNumberValue = value =>
+      typeof value === "number" ||
+      (typeof value === "string" && value[0] !== '"');
+
+    const isValidLHS = node => {
+      const { type, value, op, child } = node;
+      if (type === NODE.Literal && isNumberValue(value)) {
+        return false;
+      }
+      if (type === NODE.Unary && op === "-") {
+        return false;
+      }
+      if (type === NODE.Group) {
+        return isValidLHS(child);
+      }
+      return true;
+    };
+
+    // LIMITATION: no number literal on the left-hand side
+    let left = numberExpression();
+    if (!isValidLHS(left)) {
+      left = field();
+    }
+
     return {
       type: NODE.Binary,
       op: randomItem(["=", "!=", "<", ">", "<=", ">="]),
-      left: numberExpression(),
+      left,
       right: numberExpression(),
     };
   };


### PR DESCRIPTION
As described in #15893, a number literal as the left-hand side in a comparison isn't semantically valid. Therefore the expression generator for the fuzzer has to avoid it.

To give it a try, follow the same steps as in #18942:

```
MB_FUZZ=1 yarn test-unit frontend/test/metabase/lib/expressions/fuzz.parser.unit.spec.js

```