### PR TITLE
Respect disabled nested queries on the frontend

### DIFF
--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -738,7 +738,13 @@ export class UnconnectedDataSelector extends Component {
       this.switchToStep(DATABASE_STEP, { selectedDataBucketId });
       return;
     }
-    this.switchToStep(DATABASE_STEP, { selectedDataBucketId });
+    this.switchToStep(
+      DATABASE_STEP,
+      {
+        selectedDataBucketId,
+      },
+      false,
+    );
     const database = databases.find(db => db.is_saved_questions);
     if (database) {
       this.onChangeDatabase(database);

--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -498,6 +498,20 @@ export class UnconnectedDataSelector extends Component {
     return loaded && search?.length > 0;
   };
 
+  getDatabases = () => {
+    const { databases } = this.state;
+
+    // When there is at least one dataset,
+    // "Saved Questions" are presented in a different picker step
+    // So it should be excluded from a regular databases list
+    const shouldRemoveSavedQuestionDatabaseFromList =
+      !MetabaseSettings.get("enable-nested-queries") || this.hasDatasets();
+
+    return shouldRemoveSavedQuestionDatabaseFromList
+      ? databases.filter(db => !db.is_saved_questions)
+      : databases;
+  };
+
   async hydrateActiveStep() {
     const { steps } = this.props;
     if (this.isSavedQuestionSelected()) {
@@ -524,7 +538,7 @@ export class UnconnectedDataSelector extends Component {
       this.props.useOnlyAvailableDatabase &&
       this.props.selectedDatabaseId == null
     ) {
-      const { databases } = this.state;
+      const databases = this.getDatabases();
       if (databases && databases.length === 1) {
         this.onChangeDatabase(databases[0]);
       }
@@ -817,16 +831,10 @@ export class UnconnectedDataSelector extends Component {
 
   renderActiveStep() {
     const { combineDatabaseSchemaSteps } = this.props;
-    const { databases } = this.state;
-
-    const showSavedQuestionsInDatabasePicker = !this.hasDatasets();
-    const filteredDatabases = showSavedQuestionsInDatabasePicker
-      ? databases
-      : databases?.filter(db => !db.is_saved_questions);
 
     const props = {
       ...this.state,
-      databases: filteredDatabases,
+      databases: this.getDatabases(),
 
       onChangeDataBucket: this.onChangeDataBucket,
       onChangeDatabase: this.onChangeDatabase,

--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -981,6 +981,9 @@ export class UnconnectedDataSelector extends Component {
 
   getSearchModels = () => {
     const { selectedDataBucketId, isSavedQuestionPickerShown } = this.state;
+    if (!MetabaseSettings.get("enable-nested-queries")) {
+      return ["table"];
+    }
     if (!this.hasUsableDatasets()) {
       return isSavedQuestionPickerShown ? ["card"] : ["card", "table"];
     }

--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -498,6 +498,11 @@ export class UnconnectedDataSelector extends Component {
     return loaded && search?.length > 0;
   };
 
+  hasUsableDatasets = () => {
+    // As datasets are actually saved questions, nested queries must be enabled
+    return this.hasDatasets() && MetabaseSettings.get("enable-nested-queries");
+  };
+
   getDatabases = () => {
     const { databases } = this.state;
 
@@ -522,7 +527,7 @@ export class UnconnectedDataSelector extends Component {
       await this.switchToStep(TABLE_STEP);
     } else if (this.state.selectedDatabaseId && steps.includes(SCHEMA_STEP)) {
       await this.switchToStep(SCHEMA_STEP);
-    } else if (steps[0] === DATA_BUCKET_STEP && !this.hasDatasets()) {
+    } else if (steps[0] === DATA_BUCKET_STEP && !this.hasUsableDatasets()) {
       await this.switchToStep(steps[1]);
     } else {
       await this.switchToStep(steps[0]);
@@ -587,7 +592,7 @@ export class UnconnectedDataSelector extends Component {
     }
 
     // data bucket step doesn't make a lot of sense when there're no datasets
-    if (steps[index] === DATA_BUCKET_STEP && !this.hasDatasets()) {
+    if (steps[index] === DATA_BUCKET_STEP && !this.hasUsableDatasets()) {
       return null;
     }
 
@@ -823,7 +828,10 @@ export class UnconnectedDataSelector extends Component {
 
   handleSavedQuestionPickerClose = () => {
     const { selectedDataBucketId } = this.state;
-    if (selectedDataBucketId === DATA_BUCKET.DATASETS || this.hasDatasets()) {
+    if (
+      selectedDataBucketId === DATA_BUCKET.DATASETS ||
+      this.hasUsableDatasets()
+    ) {
       this.previousStep();
     }
     this.setState({ isSavedQuestionPickerShown: false });
@@ -865,7 +873,7 @@ export class UnconnectedDataSelector extends Component {
         return combineDatabaseSchemaSteps ? (
           <DatabaseSchemaPicker
             {...props}
-            hasBackButton={this.hasDatasets() && props.onBack}
+            hasBackButton={this.hasUsableDatasets() && props.onBack}
           />
         ) : (
           <DatabasePicker {...props} />
@@ -874,7 +882,7 @@ export class UnconnectedDataSelector extends Component {
         return combineDatabaseSchemaSteps ? (
           <DatabaseSchemaPicker
             {...props}
-            hasBackButton={this.hasDatasets() && props.onBack}
+            hasBackButton={this.hasUsableDatasets() && props.onBack}
           />
         ) : (
           <SchemaPicker {...props} />
@@ -929,7 +937,9 @@ export class UnconnectedDataSelector extends Component {
 
   handleCollectionDatasetsPickerClose = () => {
     this.props.onCloseCollectionDatasets();
-    this.switchToStep(this.hasDatasets() ? DATA_BUCKET_STEP : DATABASE_STEP);
+    this.switchToStep(
+      this.hasUsableDatasets() ? DATA_BUCKET_STEP : DATABASE_STEP,
+    );
   };
 
   handleSearchItemSelect = async item => {
@@ -965,7 +975,7 @@ export class UnconnectedDataSelector extends Component {
 
   getSearchModels = () => {
     const { selectedDataBucketId, isSavedQuestionPickerShown } = this.state;
-    if (!this.hasDatasets()) {
+    if (!this.hasUsableDatasets()) {
       return isSavedQuestionPickerShown ? ["card"] : ["card", "table"];
     }
     if (!selectedDataBucketId) {

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -4,6 +4,7 @@ import { t } from "ttag";
 import cx from "classnames";
 
 import * as Urls from "metabase/lib/urls";
+import MetabaseSettings from "metabase/lib/settings";
 
 import ButtonBar from "metabase/components/ButtonBar";
 import CollectionBadge from "metabase/questions/components/CollectionBadge";
@@ -441,6 +442,8 @@ function ViewTitleHeaderRightSide(props) {
     setQueryBuilderMode,
   } = props;
   const isShowingNotebook = queryBuilderMode === "notebook";
+  const hasExploreResultsLink =
+    isNative && isSaved && MetabaseSettings.get("enable-nested-queries");
 
   return (
     <div
@@ -501,7 +504,7 @@ function ViewTitleHeaderRightSide(props) {
           data-metabase-event={`Notebook Mode; Convert to SQL Click`}
         />
       )}
-      {isNative && isSaved && <ExploreResultsLink question={question} />}
+      {hasExploreResultsLink && <ExploreResultsLink question={question} />}
       {isRunnable && !isNativeEditorOpen && (
         <RunButtonWithTooltip
           className={cx("text-brand-hover hide", {

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.unit.spec.js
@@ -12,6 +12,7 @@ import {
   metadata,
 } from "__support__/sample_dataset_fixture";
 import Question from "metabase-lib/lib/Question";
+import MetabaseSettings from "metabase/lib/settings";
 import { ViewTitleHeader } from "./ViewHeader";
 
 const BASE_GUI_QUESTION = {
@@ -84,7 +85,18 @@ function getSavedNativeQuestion(overrides) {
   });
 }
 
-function setup({ question, isRunnable = true, ...props } = {}) {
+function mockSettings({ enableNestedQueries = true } = {}) {
+  MetabaseSettings.get = jest.fn().mockImplementation(key => {
+    if (key === "enable-nested-queries") {
+      return enableNestedQueries;
+    }
+    return false;
+  });
+}
+
+function setup({ question, isRunnable = true, settings, ...props } = {}) {
+  mockSettings(settings);
+
   const callbacks = {
     runQuestionQuery: jest.fn(),
     setQueryBuilderMode: jest.fn(),
@@ -484,5 +496,10 @@ describe("View Header | Saved native question", () => {
   it("offers to explore query results", () => {
     setupSavedNative();
     expect(screen.queryByText("Explore results")).toBeInTheDocument();
+  });
+
+  it("doesn't offer to explore results if nested queries are disabled", () => {
+    setupSavedNative({ settings: { enableNestedQueries: false } });
+    expect(screen.queryByText("Explore results")).not.toBeInTheDocument();
   });
 });

--- a/frontend/test/metabase/scenarios/question/datasets.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/datasets.cy.spec.js
@@ -206,7 +206,7 @@ describe("scenarios > datasets", () => {
         cy.icon("chevronleft").click();
 
         cy.findByText("Raw Data").click();
-        cy.findByText("Sample Dataset");
+        cy.findByText("Sample Dataset").click(); // go back to db list
         cy.findByText("Saved Questions").should("not.exist");
         testDataPickerSearch({
           inputPlaceholderText: "Search for a table…",

--- a/frontend/test/metabase/scenarios/question/datasets.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/datasets.cy.spec.js
@@ -6,6 +6,7 @@ import {
   openNewCollectionItemFlowFor,
   visualize,
   runNativeQuery,
+  mockSessionProperty,
 } from "__support__/e2e/cypress";
 
 describe("scenarios > datasets", () => {
@@ -251,6 +252,16 @@ describe("scenarios > datasets", () => {
       });
 
       cy.url().should("match", /\/question\/\d+-[a-z0-9-]*$/);
+    });
+
+    it("should not display datasets if nested queries are disabled", () => {
+      mockSessionProperty("enable-nested-queries", false);
+      cy.visit("/question/new");
+      cy.findByText("Custom question").click();
+      popover().within(() => {
+        cy.findByText("Datasets").should("not.exist");
+        cy.findByText("Saved Questions").should("not.exist");
+      });
     });
   });
 

--- a/frontend/test/metabase/scenarios/question/reproductions/19341-disabled-nested-queries.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/19341-disabled-nested-queries.cy.spec.js
@@ -30,6 +30,14 @@ describe("issue 19341", () => {
 
       cy.findByText("Sample Dataset").click(); // go back to DB list
       cy.findByText("Saved Questions").should("not.exist");
+
+      // Ensure the search doesn't list saved questions
+      cy.findByPlaceholderText("Search for a table…").type("Ord");
+      cy.findByText("Loading...").should("not.exist");
+      cy.findAllByText(/Saved question in/i).should("not.exist");
+      cy.findAllByText(/Table in/i).should("exist");
+      cy.icon("close").click();
+
       cy.findByText("Sample Dataset").click();
       cy.findByText("Orders").click();
     });

--- a/frontend/test/metabase/scenarios/question/reproductions/19341-disabled-nested-queries.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/19341-disabled-nested-queries.cy.spec.js
@@ -1,0 +1,49 @@
+import { restore, mockSessionProperty, popover } from "__support__/e2e/cypress";
+
+describe("issue 19341", () => {
+  const TEST_NATIVE_QUESTION_NAME = "Native";
+
+  beforeEach(() => {
+    restore();
+    mockSessionProperty("enable-nested-queries", false);
+    cy.signInAsAdmin();
+    cy.createNativeQuestion({
+      name: TEST_NATIVE_QUESTION_NAME,
+      native: {
+        query: "SELECT * FROM products",
+      },
+    });
+    cy.intercept("POST", "/api/card/*/query").as("cardQuery");
+  });
+
+  it("should correctly disable nested queries (metabase#19341)", () => {
+    // Test "Saved Questions" table is hidden in QB data selector
+    cy.visit("/question/new");
+    cy.findByText("Custom question").click();
+    popover().within(() => {
+      // Wait until picker init
+      // When working as expected, the test environment only has "Sample Dataset" DB
+      // So it should automatically select it as a database
+      // When "Orders" table name appears, it means the picker has selected the sample dataset
+      cy.findByText("Loading...").should("not.exist");
+      cy.findByText("Orders");
+
+      cy.findByText("Sample Dataset").click(); // go back to DB list
+      cy.findByText("Saved Questions").should("not.exist");
+      cy.findByText("Sample Dataset").click();
+      cy.findByText("Orders").click();
+    });
+
+    cy.icon("join_left_outer").click();
+    popover().within(() => {
+      cy.findByText("Sample Dataset").click(); // go back to DB list
+      cy.findByText("Saved Questions").should("not.exist");
+    });
+
+    // Test "Explore results" button is hidden for native questions
+    cy.visit("/collection/root");
+    cy.findByText(TEST_NATIVE_QUESTION_NAME).click();
+    cy.wait("@cardQuery");
+    cy.findByText("Explore results").should("not.exist");
+  });
+});

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -175,7 +175,8 @@
 (defsetting enable-nested-queries
   (deferred-tru "Allow using a saved question as the source for other queries?")
   :type    :boolean
-  :default true)
+  :default true
+  :visibility :authenticated)
 
 (defsetting enable-query-caching
   (deferred-tru "Enabling caching will save the results of queries that take a long time to run.")


### PR DESCRIPTION
Admins can completely disable nested queries on `/admin/settings/general`. This PR fixes the FE to respect that setting:

* hides the "Explore results" button for native questions
* hides "Saved Questions" option from the data selector

Related issue: #19341 (we should also reject nested queries execution on the BE if they're disabled, so not using the closing keywords here)

⚠️ Not backporting it automatically, as it will most likely fail due to new datasets code in the data selector. Will do it manually once this PR is merged

### To Verify

**Disable nested queries**
1. As an admin, go to `/admin/settings/general`
2. Scroll to the bottom and disable the "Enabled Nested Queries" option

**Native Questions**
1. Open any saved native question
2. Ensure the "Explore results" button is not shown at the top right

**QB Data Selector**
1. Ask a question > Simple / Custom Question
2. Ensure "Saved Questions" DB is removed from the list
3. Try with and without datasets in your instance, as the picker behaves differently in that case. When there are saved datasets, but nested queries are disabled, you shouldn't be able to pick a dataset either (because it's a saved question too)

### Demo

<details>
<summary>Native Question's "Explore results" button</summary>

**Before**
Even when nested queries are disabled, the "Explore results" button is still visible

![enabled-native-question](https://user-images.githubusercontent.com/17258145/146014582-585ce993-e632-4f33-8977-955101f1ff9a.png)

**After**
Now when nested queries are disabled, the "Explore results" is hidden

![disabled-native-question](https://user-images.githubusercontent.com/17258145/146014601-fa3ed1b6-19e2-4f02-86d8-fa33358087ca.png)

</details>

<details>
<summary>QB Data Selector</summary>

**Before**
Even when nested queries are disabled, people can still pick "Datasets" or "Saved Questions"

<img width="367" alt="CleanShot 2021-12-14 at 16 11 11@2x" src="https://user-images.githubusercontent.com/17258145/146014787-e1a56547-aff2-4cac-a9b7-5bafc7d83ab2.png">

**After**
Even when nested queries are disabled, Metabase only allows picking a raw table

<img width="379" alt="CleanShot 2021-12-14 at 16 10 58@2x" src="https://user-images.githubusercontent.com/17258145/146014805-d2da9876-4ba6-4f69-b7ed-3d95127918e0.png">

</details>