### PR TITLE
Bump log4j2 version to 2.16.0

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -81,12 +81,12 @@
                                              :exclusions  [org.slf4j/slf4j-api]}
   org.apache.commons/commons-compress       {:mvn/version "1.21"}               ; compression utils
   org.apache.commons/commons-lang3          {:mvn/version "3.12.0"}             ; helper methods for working with java.lang stuff
-  org.apache.logging.log4j/log4j-1.2-api    {:mvn/version "2.15.0"}             ; apache logging framework
-  org.apache.logging.log4j/log4j-api        {:mvn/version "2.15.0"}             ; add compatibility with log4j 1.2
-  org.apache.logging.log4j/log4j-core       {:mvn/version "2.15.0"}             ; apache logging framework
-  org.apache.logging.log4j/log4j-jcl        {:mvn/version "2.15.0"}             ; allows the commons-logging API to work with log4j 2
-  org.apache.logging.log4j/log4j-liquibase  {:mvn/version "2.15.0"}             ; liquibase logging via log4j 2
-  org.apache.logging.log4j/log4j-slf4j-impl {:mvn/version "2.15.0"}             ; allows the slf4j API to work with log4j 2
+  org.apache.logging.log4j/log4j-1.2-api    {:mvn/version "2.16.0"}             ; apache logging framework
+  org.apache.logging.log4j/log4j-api        {:mvn/version "2.16.0"}             ; add compatibility with log4j 1.2
+  org.apache.logging.log4j/log4j-core       {:mvn/version "2.16.0"}             ; apache logging framework
+  org.apache.logging.log4j/log4j-jcl        {:mvn/version "2.16.0"}             ; allows the commons-logging API to work with log4j 2
+  org.apache.logging.log4j/log4j-liquibase  {:mvn/version "2.16.0"}             ; liquibase logging via log4j 2
+  org.apache.logging.log4j/log4j-slf4j-impl {:mvn/version "2.16.0"}             ; allows the slf4j API to work with log4j 2
   org.apache.poi/poi                        {:mvn/version "5.0.0"}              ; Work with Office documents (e.g. Excel spreadsheets) -- newer version than one specified by Docjure
   org.apache.poi/poi-ooxml                  {:mvn/version "5.0.0"
                                              :exclusions  [org.bouncycastle/bcpkix-jdk15on


### PR DESCRIPTION
We probably never want to use message lookups or JNDI integration
