### PR TITLE
Add home page analytics

### DIFF
--- a/frontend/src/metabase/home/homepage/analytics.ts
+++ b/frontend/src/metabase/home/homepage/analytics.ts
@@ -1,0 +1,22 @@
+import { trackStructEvent } from "metabase/lib/analytics";
+import { Database, Dashboard } from "./types";
+
+export const trackCollectionClick = () => {
+  trackStructEvent("Homepage", "Browse Items Clicked");
+};
+
+export const trackDatabaseClick = (database: Database) => {
+  trackStructEvent(
+    "Homepage",
+    "Browse DB Clicked",
+    `DB Type ${database.engine}`,
+  );
+};
+
+export const trackDashboardClick = (dashboard: Dashboard) => {
+  trackStructEvent(
+    "Homepage",
+    "Pinned Item Click",
+    `Pin Type ${dashboard.model}`,
+  );
+};

--- a/frontend/src/metabase/home/homepage/components/CollectionSection/CollectionSection.tsx
+++ b/frontend/src/metabase/home/homepage/components/CollectionSection/CollectionSection.tsx
@@ -18,9 +18,10 @@ import {
 interface Props {
   user: User;
   collections: Collection[];
+  onCollectionClick?: () => void;
 }
 
-const CollectionSection = ({ user, collections }: Props) => {
+const CollectionSection = ({ user, collections, onCollectionClick }: Props) => {
   const showList = collections.some(c => c.id !== user.personal_collection_id);
   const collectionUrl = Urls.collection(ROOT_COLLECTION);
 
@@ -38,7 +39,7 @@ const CollectionSection = ({ user, collections }: Props) => {
         ) : (
           <EmptyState user={user} />
         )}
-        <CollectionLink to={collectionUrl}>
+        <CollectionLink to={collectionUrl} onClick={onCollectionClick}>
           <CollectionLinkText>{t`Browse all items`}</CollectionLinkText>
           <CollectionLinkIcon name="chevronright" />
         </CollectionLink>

--- a/frontend/src/metabase/home/homepage/components/DatabaseSection/DatabaseSection.tsx
+++ b/frontend/src/metabase/home/homepage/components/DatabaseSection/DatabaseSection.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from "react";
+import React, { ReactNode, useCallback } from "react";
 import { t } from "ttag";
 import Button from "metabase/components/Button";
 import Ellipsified from "metabase/components/Ellipsified";
@@ -25,9 +25,16 @@ interface Props {
   databases: Database[];
   showData?: boolean;
   onHideData?: () => void;
+  onDatabaseClick?: (database: Database) => void;
 }
 
-const DatabaseSection = ({ user, databases, showData, onHideData }: Props) => {
+const DatabaseSection = ({
+  user,
+  databases,
+  showData,
+  onHideData,
+  onDatabaseClick,
+}: Props) => {
   const hasAddLink = user.is_superuser;
   const hasUserDatabase = databases.some(d => !d.is_sample);
 
@@ -55,6 +62,7 @@ const DatabaseSection = ({ user, databases, showData, onHideData }: Props) => {
           <DatabaseCardRoot
             key={database.id}
             to={Urls.browseDatabase(database)}
+            onClick={() => onDatabaseClick && onDatabaseClick(database)}
           >
             <CardIcon name="database" />
             <CardTitle>

--- a/frontend/src/metabase/home/homepage/components/DatabaseSection/DatabaseSection.tsx
+++ b/frontend/src/metabase/home/homepage/components/DatabaseSection/DatabaseSection.tsx
@@ -62,7 +62,7 @@ const DatabaseSection = ({
           <DatabaseCardRoot
             key={database.id}
             to={Urls.browseDatabase(database)}
-            onClick={() => onDatabaseClick && onDatabaseClick(database)}
+            onClick={() => onDatabaseClick?.(database)}
           >
             <CardIcon name="database" />
             <CardTitle>

--- a/frontend/src/metabase/home/homepage/components/DatabaseSection/DatabaseSection.unit.spec.tsx
+++ b/frontend/src/metabase/home/homepage/components/DatabaseSection/DatabaseSection.unit.spec.tsx
@@ -104,6 +104,7 @@ const getUser = (opts?: Partial<User>): User => ({
 const getDatabase = (opts?: Partial<Database>): Database => ({
   id: 1,
   name: "Our database",
+  engine: "postgres",
   is_sample: false,
   initial_sync_status: "complete",
   ...opts,

--- a/frontend/src/metabase/home/homepage/components/Homepage/Homepage.tsx
+++ b/frontend/src/metabase/home/homepage/components/Homepage/Homepage.tsx
@@ -28,6 +28,9 @@ interface Props {
   onHideXrays?: () => void;
   onHidePinMessage?: () => void;
   onHideSyncingModal?: () => void;
+  onCollectionClick?: () => void;
+  onDashboardClick?: (dashboard: Dashboard) => void;
+  onDatabaseClick?: (database: Database) => void;
 }
 
 const Homepage = ({
@@ -44,6 +47,9 @@ const Homepage = ({
   onHideXrays,
   onHidePinMessage,
   onHideSyncingModal,
+  onCollectionClick,
+  onDashboardClick,
+  onDatabaseClick,
 }: Props) => {
   return (
     <LandingRoot>
@@ -56,6 +62,7 @@ const Homepage = ({
             dashboards={dashboards}
             showPinMessage={showPinMessage}
             onHidePinMessage={onHidePinMessage}
+            onDashboardClick={onDashboardClick}
           />
           <XraySection
             user={user}
@@ -64,12 +71,17 @@ const Homepage = ({
             showXrays={showXrays}
             onHideXrays={onHideXrays}
           />
-          <CollectionSection user={user} collections={collections} />
+          <CollectionSection
+            user={user}
+            collections={collections}
+            onCollectionClick={onCollectionClick}
+          />
           <DatabaseSection
             user={user}
             databases={databases}
             showData={showData}
             onHideData={onHideData}
+            onDatabaseClick={onDatabaseClick}
           />
           <SyncingSection
             user={user}

--- a/frontend/src/metabase/home/homepage/components/StartSection/StartSection.tsx
+++ b/frontend/src/metabase/home/homepage/components/StartSection/StartSection.tsx
@@ -28,6 +28,7 @@ interface Props {
   dashboards: Dashboard[];
   showPinMessage?: boolean;
   onHidePinMessage?: () => void;
+  onDashboardClick?: (dashboard: Dashboard) => void;
 }
 
 const StartSection = ({
@@ -36,6 +37,7 @@ const StartSection = ({
   dashboards,
   showPinMessage,
   onHidePinMessage,
+  onDashboardClick,
 }: Props) => {
   const showDatabaseBanner =
     user.is_superuser && !databases.some(d => !d.is_sample);
@@ -59,7 +61,11 @@ const StartSection = ({
       {showDashboardList && (
         <ListRoot hasMargin={showDatabaseBanner}>
           {dashboards.map(dashboard => (
-            <DashboardCard key={dashboard.id} dashboard={dashboard} />
+            <DashboardCard
+              key={dashboard.id}
+              dashboard={dashboard}
+              onDashboardClick={onDashboardClick}
+            />
           ))}
         </ListRoot>
       )}
@@ -69,13 +75,17 @@ const StartSection = ({
 
 interface DashboardCardProps {
   dashboard: Dashboard;
+  onDashboardClick?: (dashboard: Dashboard) => void;
 }
 
-const DashboardCard = ({ dashboard }: DashboardCardProps) => {
+const DashboardCard = ({ dashboard, onDashboardClick }: DashboardCardProps) => {
   const dashboardUrl = Urls.dashboard(dashboard);
 
   return (
-    <CardRoot to={dashboardUrl}>
+    <CardRoot
+      to={dashboardUrl}
+      onClick={() => onDashboardClick && onDashboardClick(dashboard)}
+    >
       <CardIcon name="dashboard" />
       <CardTitle>
         <Ellipsified>{dashboard.name}</Ellipsified>

--- a/frontend/src/metabase/home/homepage/components/StartSection/StartSection.tsx
+++ b/frontend/src/metabase/home/homepage/components/StartSection/StartSection.tsx
@@ -82,10 +82,7 @@ const DashboardCard = ({ dashboard, onDashboardClick }: DashboardCardProps) => {
   const dashboardUrl = Urls.dashboard(dashboard);
 
   return (
-    <CardRoot
-      to={dashboardUrl}
-      onClick={() => onDashboardClick && onDashboardClick(dashboard)}
-    >
+    <CardRoot to={dashboardUrl} onClick={() => onDashboardClick?.(dashboard)}>
       <CardIcon name="dashboard" />
       <CardTitle>
         <Ellipsified>{dashboard.name}</Ellipsified>

--- a/frontend/src/metabase/home/homepage/components/StartSection/StartSection.unit.spec.tsx
+++ b/frontend/src/metabase/home/homepage/components/StartSection/StartSection.unit.spec.tsx
@@ -178,6 +178,7 @@ const getUser = (opts?: Partial<User>): User => ({
 const getDatabase = (opts?: Partial<Database>): Database => ({
   id: 1,
   name: "Our database",
+  engine: "postgres",
   is_sample: false,
   initial_sync_status: "complete",
   ...opts,

--- a/frontend/src/metabase/home/homepage/components/SyncingSection/SyncingSection.tsx
+++ b/frontend/src/metabase/home/homepage/components/SyncingSection/SyncingSection.tsx
@@ -29,7 +29,7 @@ const SyncingSection = ({
 
   useEffect(() => {
     if (isOpened) {
-      onHideSyncingModal && onHideSyncingModal();
+      onHideSyncingModal?.();
     }
   }, [isOpened, onHideSyncingModal]);
 

--- a/frontend/src/metabase/home/homepage/components/SyncingSection/SyncingSection.unit.spec.tsx
+++ b/frontend/src/metabase/home/homepage/components/SyncingSection/SyncingSection.unit.spec.tsx
@@ -82,6 +82,7 @@ const getUser = (opts?: Partial<User>): User => ({
 const getDatabase = (opts?: Partial<Database>): Database => ({
   id: 1,
   name: "Our database",
+  engine: "postgres",
   is_sample: false,
   initial_sync_status: "complete",
   ...opts,

--- a/frontend/src/metabase/home/homepage/containers/HomepageApp/HomepageApp.tsx
+++ b/frontend/src/metabase/home/homepage/containers/HomepageApp/HomepageApp.tsx
@@ -19,6 +19,11 @@ import {
   getShowSyncingModal,
 } from "../../selectors";
 import { Database } from "../../types";
+import {
+  trackDatabaseClick,
+  trackCollectionClick,
+  trackDashboardClick,
+} from "../../analytics";
 
 const databasesProps = {
   loadingAndErrorWrapper: false,
@@ -70,6 +75,9 @@ const mapStateToProps = (state: any) => ({
   showXrays: getShowXrays(state),
   showPinMessage: getShowPinMessage(state),
   showSyncingModal: getShowSyncingModal(state),
+  onCollectionClick: trackCollectionClick,
+  onDashboardClick: trackDashboardClick,
+  onDatabaseClick: trackDatabaseClick,
 });
 
 const mapDispatchToProps = {

--- a/frontend/src/metabase/home/homepage/types.ts
+++ b/frontend/src/metabase/home/homepage/types.ts
@@ -10,6 +10,7 @@ export interface User {
 export interface Database {
   id: number;
   name: string;
+  engine: string;
   is_sample: boolean;
   creator_id?: number;
   initial_sync_status: InitialSyncStatus;
@@ -22,6 +23,7 @@ export interface Collection {
 export interface Dashboard {
   id: number;
   name: string;
+  model?: string;
 }
 
 export interface DatabaseCandidate {


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/19119

This PR restores previously working Google Analytics events for the homepage.