### PR TITLE
change between filter layout

### DIFF
--- a/frontend/src/metabase/components/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget.jsx
@@ -24,7 +24,6 @@ const MAX_SEARCH_RESULTS = 100;
 const fieldValuesWidgetPropTypes = {
   addRemappings: PropTypes.func,
   expand: PropTypes.bool,
-  isSidebar: PropTypes.bool,
 };
 
 const optionsMessagePropTypes = {
@@ -422,7 +421,6 @@ export class FieldValuesWidget extends Component {
 
     return (
       <div
-        className={cx({ "PopoverBody--marginBottom": !this.props.isSidebar })}
         style={{
           width: this.props.expand ? this.props.maxWidth : null,
           minWidth: this.props.minWidth,

--- a/frontend/src/metabase/components/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import cx from "classnames";
 import { connect } from "react-redux";
 import { t, jt } from "ttag";
 import _ from "underscore";

--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/ParameterFieldWidget.jsx
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/ParameterFieldWidget.jsx
@@ -119,7 +119,11 @@ export default class ParameterFieldWidget extends Component {
     } else {
       return (
         <Popover hasArrow={false} onClose={() => focusChanged(false)}>
-          <div className={cx("relative", { p2: !isEqualsOp })}>
+          <div
+            className={cx("relative PopoverBody--marginBottom", {
+              p2: !isEqualsOp,
+            })}
+          >
             {verboseName && !isEqualsOp && (
               <div className="text-bold mb1">{verboseName}...</div>
             )}

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DefaultPicker.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DefaultPicker.jsx
@@ -2,6 +2,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import cx from "classnames";
+import { t } from "ttag";
 
 import NumberPicker from "./NumberPicker";
 import SelectPicker from "./SelectPicker";
@@ -13,6 +14,12 @@ import {
   getFilterArgumentFormatOptions,
   isFuzzyOperator,
 } from "metabase/lib/schema_metadata";
+
+import {
+  BetweenLayoutContainer,
+  BetweenLayoutFieldSeparator,
+  BetweenLayoutFieldContainer,
+} from "./DefaultPicker.styled";
 
 const defaultPickerPropTypes = {
   filter: PropTypes.object,
@@ -36,7 +43,6 @@ export default function DefaultPicker({
   setValues,
   onCommit,
   className,
-  isSidebar,
   minWidth,
   maxWidth,
 }) {
@@ -49,6 +55,9 @@ export default function DefaultPicker({
   const field = dimension && dimension.field();
   const operatorFields = operator.fields || [];
   const disableSearch = isFuzzyOperator(operator);
+
+  const isBetweenLayout =
+    operator.name === "between" && operatorFields.length === 2;
 
   const fieldWidgets = operatorFields
     .map((operatorField, index) => {
@@ -76,7 +85,7 @@ export default function DefaultPicker({
             onCommit={onCommit}
           />
         );
-      } else if (field && field.id != null) {
+      } else if (field && field.id != null && !isBetweenLayout) {
         // get the underling field if the query is nested
         let underlyingField = field;
         let sourceField;
@@ -92,7 +101,6 @@ export default function DefaultPicker({
             placeholder={placeholder}
             fields={underlyingField ? [underlyingField] : []}
             disablePKRemappingForSearch={true}
-            isSidebar={isSidebar}
             autoFocus={index === 0}
             alwaysShowOptions={operator.fields.length === 1}
             formatOptions={getFilterArgumentFormatOptions(operator, index)}
@@ -105,6 +113,7 @@ export default function DefaultPicker({
         return (
           <TextPicker
             key={index}
+            autoFocus={index === 0}
             values={values}
             onValuesChange={onValuesChange}
             placeholder={placeholder}
@@ -116,6 +125,7 @@ export default function DefaultPicker({
         return (
           <NumberPicker
             key={index}
+            autoFocus={index === 0}
             values={values}
             onValuesChange={onValuesChange}
             placeholder={placeholder}
@@ -128,11 +138,21 @@ export default function DefaultPicker({
     })
     .filter(f => f);
 
-  if (fieldWidgets.length > 0) {
-    return <DefaultLayout className={className} fieldWidgets={fieldWidgets} />;
-  } else {
-    return <div className={cx(className, "PopoverBody--marginBottom")} />;
+  let layout = null;
+
+  if (isBetweenLayout) {
+    layout = (
+      <BetweenLayout className={className} fieldWidgets={fieldWidgets} />
+    );
+  } else if (fieldWidgets.length > 0) {
+    layout = (
+      <DefaultLayout className={className} fieldWidgets={fieldWidgets} />
+    );
   }
+
+  return (
+    <div className={cx(className, "PopoverBody--marginBottom")}>{layout}</div>
+  );
 }
 
 DefaultPicker.propTypes = defaultPickerPropTypes;
@@ -151,3 +171,15 @@ const DefaultLayout = ({ className, fieldWidgets }) => (
 );
 
 DefaultLayout.propTypes = defaultLayoutPropTypes;
+
+const BetweenLayout = ({ className, fieldWidgets }) => {
+  const [left, right] = fieldWidgets;
+
+  return (
+    <BetweenLayoutContainer>
+      <BetweenLayoutFieldContainer>{left}</BetweenLayoutFieldContainer>{" "}
+      <BetweenLayoutFieldSeparator>{t`and`}</BetweenLayoutFieldSeparator>
+      <BetweenLayoutFieldContainer>{right}</BetweenLayoutFieldContainer>
+    </BetweenLayoutContainer>
+  );
+};

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DefaultPicker.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DefaultPicker.styled.tsx
@@ -1,0 +1,19 @@
+import { color } from "metabase/lib/colors";
+import styled from "styled-components";
+
+export const BetweenLayoutContainer = styled.div`
+  display: flex;
+  align-items: center;
+  padding-bottom: 1rem;
+`;
+
+export const BetweenLayoutFieldContainer = styled.div`
+  flex: 1 0;
+  max-width: 190px;
+`;
+
+export const BetweenLayoutFieldSeparator = styled.div`
+  padding: 0.5rem 0.5rem 0 0.5rem;
+  font-weight: 700;
+  color: ${color("text-medium")};
+`;

--- a/frontend/src/metabase/query_builder/components/filters/pickers/NumberPicker.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/NumberPicker.jsx
@@ -48,6 +48,7 @@ export default class NumberPicker extends Component {
     return (
       <TextPicker
         {...this.props}
+        isSingleLine
         values={values}
         validations={this.state.validations}
         onValuesChange={values => this.onValuesChange(values)}

--- a/frontend/src/metabase/query_builder/components/filters/pickers/TextPicker.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/TextPicker.jsx
@@ -14,11 +14,13 @@ export default class TextPicker extends Component {
     validations: PropTypes.array,
     multi: PropTypes.bool,
     onCommit: PropTypes.func,
+    isSingleLine: PropTypes.bool,
   };
 
   static defaultProps = {
     validations: [],
     placeholder: t`Enter desired text`,
+    autoFocus: true,
   };
 
   constructor(props) {
@@ -48,7 +50,13 @@ export default class TextPicker extends Component {
   }
 
   render() {
-    const { validations, multi, onCommit } = this.props;
+    const {
+      validations,
+      multi,
+      onCommit,
+      isSingleLine,
+      autoFocus,
+    } = this.props;
     const hasInvalidValues = _.some(validations, v => v === false);
 
     const commitOnEnter = e => {
@@ -60,19 +68,35 @@ export default class TextPicker extends Component {
     return (
       <div>
         <div className="FilterInput px1 pt1 relative">
-          <AutosizeTextarea
-            className={cx("input block full border-purple", {
-              "border-error": hasInvalidValues,
-            })}
-            type="text"
-            value={this.state.fieldString}
-            onChange={e => this.setValue(e.target.value)}
-            onKeyPress={commitOnEnter}
-            placeholder={this.props.placeholder}
-            autoFocus={true}
-            style={{ resize: "none" }}
-            maxRows={8}
-          />
+          {!isSingleLine && (
+            <AutosizeTextarea
+              className={cx("input block full border-purple", {
+                "border-error": hasInvalidValues,
+              })}
+              type="text"
+              value={this.state.fieldString}
+              onChange={e => this.setValue(e.target.value)}
+              onKeyPress={commitOnEnter}
+              placeholder={this.props.placeholder}
+              autoFocus={autoFocus}
+              style={{ resize: "none" }}
+              maxRows={8}
+            />
+          )}
+
+          {isSingleLine && (
+            <input
+              className={cx("input block full border-purple", {
+                "border-error": hasInvalidValues,
+              })}
+              type="text"
+              value={this.state.fieldString}
+              onChange={e => this.setValue(e.target.value)}
+              onKeyPress={commitOnEnter}
+              placeholder={this.props.placeholder}
+              autoFocus={autoFocus}
+            />
+          )}
         </div>
 
         {multi ? (


### PR DESCRIPTION
[[Notion task]](https://www.notion.so/metabase/Bring-joy-to-filtering-50531005d4584c19bcb2a531c6771aa8?p=9f9404f6743d4b478059d26ea4753e47)

Change between filter layout from vertical stack to row. Also, between filter used `TokenField` which seems to be redundant — correct me if I'm wrong. It shows entered value inside a tag when the input is blurred.

## Screenshots

### Before

**Popups**

<img width="541" alt="Screenshot 2021-12-15 at 19 10 42" src="https://user-images.githubusercontent.com/14301985/146222707-bd378bc3-c3f2-46a1-9b13-b0fc1eab04a3.png">

<img width="351" alt="Screenshot 2021-12-15 at 19 10 53" src="https://user-images.githubusercontent.com/14301985/146222729-d5d9b4fd-d82a-4f81-b27a-57ec918e1bb8.png">

**Sidebar**

<img width="381" alt="Screenshot 2021-12-15 at 19 11 10" src="https://user-images.githubusercontent.com/14301985/146222777-a8b13454-fd82-4075-b575-0ab4eba921a6.png">


### After

**Popups**

<img width="591" alt="Screenshot 2021-12-15 at 19 07 11" src="https://user-images.githubusercontent.com/14301985/146222851-8a0694ed-4e5b-4dfe-b1a8-f8a76baec523.png">

<img width="467" alt="Screenshot 2021-12-15 at 19 07 02" src="https://user-images.githubusercontent.com/14301985/146222867-91ae5a39-9772-4052-99be-917422174e85.png">

**Sidebar**

<img width="371" alt="Screenshot 2021-12-15 at 19 06 54" src="https://user-images.githubusercontent.com/14301985/146222909-018f4a78-75d8-434b-9776-c41c68c52448.png">



