### PR TITLE
Fix combos in tables of column cardinality bigger than the columns being used in combo being broken

### DIFF
--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -594,7 +594,7 @@
         x-rows           (map x-axis-rowfn clean-rows)
         y-rows           (map y-axis-rowfn clean-rows)
         joined-rows      (map vector x-rows y-rows)
-        [x-cols y-cols]  ((juxt x-axis-rowfn y-axis-rowfn) cols)
+        [x-cols y-cols]  ((juxt x-axis-rowfn y-axis-rowfn) (vec cols))
 
         ;; NB: There's a hardcoded limit of arity 2 on x-axis, so there's only the 1-axis or 2-axis case
         series           (if (= (count x-cols) 1)

--- a/src/metabase/util/ui_logic.clj
+++ b/src/metabase/util/ui_logic.clj
@@ -99,9 +99,9 @@
   "This is used as the X-axis column in the UI
   when we have comboes, which have more than one x axis."
   [card results]
-  (let [metrics     (some-> card
+  (let [dimensions  (some-> card
                             (get-in [:visualization_settings :graph.dimensions]))
-        col-indices (map #(column-name->index % results) metrics)]
+        col-indices (map #(column-name->index % results) dimensions)]
     (when (seq? col-indices)
       (fn [row]
         (vec (for [idx col-indices]

--- a/test/metabase/pulse/render/body_test.clj
+++ b/test/metabase/pulse/render/body_test.clj
@@ -406,6 +406,10 @@
    {:name         "NumKazoos",
     :display_name "NumKazoos",
     :base_type    :type/BigInteger
+    :semantic_type nil}
+   {:name         "ExtraneousColumn",
+    :display_name "ExtraneousColumn",
+    :base_type    :type/BigInteger
     :semantic_type nil}])
 
 (defn has-inline-image? [rendered]
@@ -484,15 +488,15 @@
   (testing "Render a combo graph with non-nil values for the x and y axis"
     (is (has-inline-image?
           (render-combo {:cols default-combo-columns
-                         :rows [[10.0 1 123] [5.0 10 12] [2.50 20 1337] [1.25 30 -22]]}))))
+                         :rows [[10.0 1 123 111] [5.0 10 12 111] [2.50 20 1337 12312] [1.25 30 -22 123124]]}))))
   (testing "Render a combo graph with multiple x axes"
     (is (has-inline-image?
           (render-combo-multi-x {:cols default-combo-columns
-                                 :rows [[10.0 "Bob" 123] [5.0 "Dobbs" 12] [2.50 "Robbs" 1337] [1.25 "Mobbs" -22]]}))))
+                                 :rows [[10.0 "Bob" 123 123124] [5.0 "Dobbs" 12 23423] [2.50 "Robbs" 1337 234234] [1.25 "Mobbs" -22 1234123]]}))))
   (testing "Check to make sure we allow nil values for any axis"
     (is (has-inline-image?
           (render-combo {:cols default-combo-columns
-                         :rows [[nil 1 1] [10.0 1 nil] [5.0 10 22] [2.50 nil 22] [1.25 nil nil]]})))))
+                         :rows [[nil 1 1 23453] [10.0 1 nil nil] [5.0 10 22 1337] [2.50 nil 22 1231] [1.25 nil nil 1231232]]})))))
 
 ;; Test rendering a sparkline
 ;;


### PR DESCRIPTION
Pursuant to #18676. Noticed as regression during debugging the weekly engineering GH issue waterfall problem. Changed existing tests to cover it