### PR TITLE
Fix X-Ray/Automagic Dashboards when source query has a filter

### DIFF
--- a/src/metabase/automagic_dashboards/core.clj
+++ b/src/metabase/automagic_dashboards/core.clj
@@ -18,6 +18,7 @@
             [metabase.automagic-dashboards.visualization-macros :as visualization]
             [metabase.driver :as driver]
             [metabase.mbql.normalize :as normalize]
+            [metabase.mbql.schema :as mbql.s]
             [metabase.mbql.util :as mbql.u]
             [metabase.models.card :as card :refer [Card]]
             [metabase.models.database :refer [Database]]
@@ -33,6 +34,7 @@
             [metabase.util :as u]
             [metabase.util.date-2 :as u.date]
             [metabase.util.i18n :as ui18n :refer [deferred-tru trs tru]]
+            [metabase.util.schema :as su]
             [ring.util.codec :as codec]
             [schema.core :as s]
             [toucan.db :as db]))
@@ -42,9 +44,9 @@
 (def ^:private ^{:arglists '([field])} id-or-name
   (some-fn :id :name))
 
-(defn ->field
+(s/defn ->field
   "Return `Field` instance for a given ID or name in the context of root."
-  [root id-or-name]
+  [root id-or-name :- (s/cond-pre su/IntGreaterThanZero su/NonBlankString mbql.s/Field)]
   (let [id-or-name (if (sequential? id-or-name)
                      (filters/field-reference->id id-or-name)
                      id-or-name)]
@@ -969,50 +971,46 @@
        (fill-related max-related (related-selectors (-> root :entity type)))))
 
 (defn- filter-referenced-fields
-  "Return a map of fields referenced in filter cluase."
+  "Return a map of fields referenced in filter clause."
   [root filter-clause]
   (->> filter-clause
        filters/collect-field-references
-       (mapcat (fn [[_ & ids]]
-                 (for [id ids]
-                   [id (->field root id)])))
+       (map (fn [[_ id-or-name _options]]
+              [id-or-name (->field root id-or-name)]))
        (remove (comp nil? second))
        (into {})))
 
 (defn- automagic-dashboard
   "Create dashboards for table `root` using the best matching heuristics."
   [{:keys [rule show rules-prefix full-name] :as root}]
-  (if-let [[dashboard rule context] (if rule
-                                      (apply-rule root (rules/get-rule rule))
-                                      (->> root
-                                           (matching-rules (rules/get-rules rules-prefix))
-                                           (keep (partial apply-rule root))
-                                           ;; `matching-rules` returns an `ArraySeq` (via `sort-by`)
-                                           ;; so `first` realises one element at a time
-                                           ;; (no chunking).
-                                           first))]
-    (let [show (or show max-cards)]
-      (log/debug (trs "Applying heuristic {0} to {1}." (:rule rule) full-name))
-      (log/debug (trs "Dimensions bindings:\n{0}"
-                      (->> context
-                           :dimensions
-                           (m/map-vals #(update % :matches (partial map :name)))
-                           u/pprint-to-str)))
-      (log/debug (trs "Using definitions:\nMetrics:\n{0}\nFilters:\n{1}"
-                      (->> context :metrics (m/map-vals :metric) u/pprint-to-str)
-                      (-> context :filters u/pprint-to-str)))
-      (-> dashboard
-          (populate/create-dashboard show)
-          (assoc :related           (related context rule)
-                 :more              (when (and (not= show :all)
-                                               (-> dashboard :cards count (> show)))
-                                      (format "%s#show=all" (:url root)))
-                 :transient_filters (:query-filter context)
-                 :param_fields      (->> context :query-filter (filter-referenced-fields root)))))
-    (throw (ex-info (trs "Can''t create dashboard for {0}" full-name)
-             {:root            root
-              :available-rules (map :rule (or (some-> rule rules/get-rule vector)
-                                              (rules/get-rules rules-prefix)))}))))
+  (let [[dashboard rule context] (or (when rule
+                                       (apply-rule root (rules/get-rule rule)))
+                                     (some
+                                      (fn [rule]
+                                        (apply-rule root rule))
+                                      (matching-rules (rules/get-rules rules-prefix) root))
+                                     (throw (ex-info (trs "Can''t create dashboard for {0}" (pr-str full-name))
+                                                     {:root            root
+                                                      :available-rules (map :rule (or (some-> rule rules/get-rule vector)
+                                                                                      (rules/get-rules rules-prefix)))})))
+        show                     (or show max-cards)]
+    (log/debug (trs "Applying heuristic {0} to {1}." (:rule rule) full-name))
+    (log/debug (trs "Dimensions bindings:\n{0}"
+                    (->> context
+                         :dimensions
+                         (m/map-vals #(update % :matches (partial map :name)))
+                         u/pprint-to-str)))
+    (log/debug (trs "Using definitions:\nMetrics:\n{0}\nFilters:\n{1}"
+                    (->> context :metrics (m/map-vals :metric) u/pprint-to-str)
+                    (-> context :filters u/pprint-to-str)))
+    (-> dashboard
+        (populate/create-dashboard show)
+        (assoc :related           (related context rule)
+               :more              (when (and (not= show :all)
+                                             (-> dashboard :cards count (> show)))
+                                    (format "%s#show=all" (:url root)))
+               :transient_filters (:query-filter context)
+               :param_fields      (->> context :query-filter (filter-referenced-fields root))))))
 
 (defmulti
   ^{:doc "Create a transient dashboard analyzing given entity."
@@ -1210,12 +1208,15 @@
                                                      opts))
                          (decompose-question root card opts))
            cell-query (merge (let [title (tru "A closer look at {0}" (cell-title root cell-query))]
-                               {:transient_name  title
-                                :name            title}))))))))
+                               {:transient_name title
+                                :name           title}))))))))
 
 (defmethod automagic-analysis (type Query)
   [query {:keys [cell-query] :as opts}]
   (let [root     (->root query)
+        cell-query (when cell-query (normalize/normalize-fragment [:query :filter] cell-query))
+        opts       (cond-> opts
+                     cell-query (assoc :cell-query cell-query))
         cell-url (format "%sadhoc/%s/cell/%s" public-endpoint
                          (encode-base64-json (:dataset_query query))
                          (encode-base64-json cell-query))]

--- a/src/metabase/automagic_dashboards/filters.clj
+++ b/src/metabase/automagic_dashboards/filters.clj
@@ -5,6 +5,7 @@
             [metabase.models.field :as field :refer [Field]]
             [metabase.util :as u]
             [metabase.util.date-2 :as u.date]
+            [metabase.util.schema :as su]
             [schema.core :as s]
             [toucan.db :as db]))
 
@@ -12,20 +13,15 @@
   "Is given form an MBQL field reference?"
   (complement (s/checker mbql.s/field)))
 
-(defn field-reference->id
+(s/defn field-reference->id :- (s/maybe (s/cond-pre su/NonBlankString su/IntGreaterThanZero))
   "Extract field ID from a given field reference form."
   [clause]
   (mbql.u/match-one clause [:field id _] id))
 
-(defn collect-field-references
-  "Collect all `:field` references from a given
-   form."
+(s/defn collect-field-references :- [mbql.s/field]
+  "Collect all `:field` references from a given form."
   [form]
-  (->> form
-       (tree-seq (every-pred (some-fn sequential? map?)
-                             (complement field-reference?))
-                 identity)
-       (filter field-reference?)))
+  (mbql.u/match form :field &match))
 
 (defn- temporal?
   "Does `field` represent a temporal value, i.e. a date, time, or datetime?"

--- a/src/metabase/sync/analyze.clj
+++ b/src/metabase/sync/analyze.clj
@@ -123,7 +123,7 @@
 
 (s/defn refingerprint-db!
   "Refingerprint a subset of tables in a given `database`. This will re-fingerprint tables up to a threshold amount of
-  `fingerprint/max-refingerprint-field-count`."
+  [[fingerprint/max-refingerprint-field-count]]."
   [database :- i/DatabaseInstance]
   (sync-util/sync-operation :refingerprint database (format "Refingerprinting tables for %s" (sync-util/name-for-logging database))
     (let [tables (sync-util/db->sync-tables database)

--- a/src/metabase/sync/analyze/fingerprint.clj
+++ b/src/metabase/sync/analyze/fingerprint.clj
@@ -217,7 +217,7 @@
   ;; TODO: Maybe the driver should have a function to tell you if it supports fingerprinting?
   (fingerprint-fields-for-db!* database tables log-progress-fn))
 
-(def max-refingerprint-field-count
+(def ^:private max-refingerprint-field-count
   "Maximum number of fields to refingerprint. Balance updating our fingerprinting values while not spending too much
   time in the db."
   1000)

--- a/test/metabase/sync/analyze/fingerprint_test.clj
+++ b/test/metabase/sync/analyze/fingerprint_test.clj
@@ -283,13 +283,13 @@
                     fingerprint/max-refingerprint-field-count 31] ;; prime number so we don't have exact matches
         (let [table (Table (mt/id :checkins))
               results (fingerprint/refingerprint-fields-for-db! (mt/db)
-                                                                (repeat (* fingerprint/max-refingerprint-field-count 2) table)
+                                                                (repeat (* @#'fingerprint/max-refingerprint-field-count 2) table)
                                                                 (constantly nil))
               attempted (:fingerprints-attempted results)]
           ;; it can exceed the max field count as our resolution is after each table check it.
-          (is (<= fingerprint/max-refingerprint-field-count attempted))
+          (is (<= @#'fingerprint/max-refingerprint-field-count attempted))
           ;; but it is bounded.
-          (is (< attempted (+ fingerprint/max-refingerprint-field-count 10))))))))
+          (is (< attempted (+ @#'fingerprint/max-refingerprint-field-count 10))))))))
 
 (deftest fingerprint-schema-test
   (testing "allows for extra keywords"


### PR DESCRIPTION
Fixes #19241

The main issue here was that the code for iterating over all the Field IDs or names in the query was wrong:

https://github.com/metabase/metabase/compare/fix-xrays-with-filters?expand=1#diff-917546b664c1f28360366030be7ac6c6db5d58df5e6548078b7751859ed4a523L976-R980

It was iterating over everything in a `:field` clause after the initial keyword. This worked fine before the last MBQL refactor because `:field-id` never had a third element. But after the last refactor this code started breaking and the field clause options e.g.`{:temporal-unit :year}` could get treated as a Field ID/name (this is why X-Rays were only failing if there was a temporal filter in the original query).

Everything else in this PR is either adding schema validation to stuff (which would have caught this bug much early/made debugging a lot easier) or some code reformatting for readability