### PR TITLE
Make expression variable regex less greedy

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionMode.js
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionMode.js
@@ -22,7 +22,7 @@ class ExpressionHighlight extends window.ace.acequire(
         },
         {
           token: "variable",
-          regex: "\\[.+\\]",
+          regex: "\\[.*?\\]",
         },
         {
           token: "paren.lparen",


### PR DESCRIPTION
Fixes issue in Custom Expression Editor where, if there is more than one variable, that is, a term surrounded by brackets, everything between the inner and outer variable is marked as a variable and colored blue.

### After

<img src=https://user-images.githubusercontent.com/380816/146245599-09127c55-77eb-4557-bb8a-a412878250ea.png width=500 />

### Before

<img src=https://user-images.githubusercontent.com/380816/146245647-b34bb7c0-5310-4990-8053-6ed5c7da3709.png width=500 />

👁️‍🗨️ Note how the `=` sign is wrongly colored blue in the before version.