### PR TITLE
React Ace: Fix expression editor’s cursor position in Safari

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/expressions.css
+++ b/frontend/src/metabase/query_builder/components/expressions/expressions.css
@@ -1,3 +1,7 @@
+.ace_content * {
+  font-family: monospace !important;
+}
+
 .expression-editor-textfield .ace_hidpi .ace_content {
   color: #4c5773;
   font-weight: 700;


### PR DESCRIPTION
### How to Test

1. Be in Safari
2. Use the Custom Expression editor, say in a Custom Question › Custom Column
3. Type away

### After

The cursor is rendered in the expected places.

### Before

After a few chars typed, the cursor appears more and more to the left of where it should.