### PR TITLE
Remove the `field-filter-operators-enabled?` feature flag

### DIFF
--- a/frontend/src/metabase/parameters/utils/cards.js
+++ b/frontend/src/metabase/parameters/utils/cards.js
@@ -2,7 +2,6 @@ import _ from "underscore";
 
 import Question from "metabase-lib/lib/Question";
 
-import { areFieldFilterOperatorsEnabled } from "./feature-flag";
 import {
   getParameterTargetField,
   getTemplateTagFromTarget,
@@ -18,9 +17,9 @@ export function getTemplateTagParameters(tags) {
     const { type } = tag;
     if (type === "date") {
       return "date/single";
-    } else if (areFieldFilterOperatorsEnabled() && type === "string") {
+    } else if (type === "string") {
       return "string/=";
-    } else if (areFieldFilterOperatorsEnabled() && type === "number") {
+    } else if (type === "number") {
       return "number/=";
     } else {
       return "category";

--- a/frontend/src/metabase/parameters/utils/cards.unit.spec.js
+++ b/frontend/src/metabase/parameters/utils/cards.unit.spec.js
@@ -1,25 +1,9 @@
-import MetabaseSettings from "metabase/lib/settings";
 import {
   getTemplateTagParameters,
   remapParameterValuesToTemplateTags,
 } from "./cards";
 
-MetabaseSettings.get = jest.fn();
-
-function mockFieldFilterOperatorsFlag(value) {
-  MetabaseSettings.get.mockImplementation(flag => {
-    if (flag === "field-filter-operators-enabled?") {
-      return value;
-    }
-  });
-}
-
 describe("parameters/utils/cards", () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-    MetabaseSettings.get.mockReturnValue(false);
-  });
-
   describe("getTemplateTagParameters", () => {
     let tags;
     beforeEach(() => {
@@ -70,107 +54,53 @@ describe("parameters/utils/cards", () => {
       ];
     });
 
-    describe("field filter operators enabled", () => {
-      beforeEach(() => {
-        mockFieldFilterOperatorsFlag(true);
-      });
+    it("should convert tags into tag parameters with field filter operator types", () => {
+      const parametersWithFieldFilterOperatorTypes = [
+        {
+          default: "abc",
+          id: 1,
+          name: "A",
+          slug: "a",
+          target: ["variable", ["template-tag", "a"]],
+          type: "foo",
+        },
+        {
+          default: undefined,
+          id: 2,
+          name: "B",
+          slug: "b",
+          target: ["variable", ["template-tag", "b"]],
+          type: "string/=",
+        },
+        {
+          default: undefined,
+          id: 3,
+          name: "C",
+          slug: "c",
+          target: ["variable", ["template-tag", "c"]],
+          type: "number/=",
+        },
+        {
+          default: undefined,
+          id: 4,
+          name: "D",
+          slug: "d",
+          target: ["variable", ["template-tag", "d"]],
+          type: "date/single",
+        },
+        {
+          default: undefined,
+          id: 5,
+          name: "E",
+          slug: "e",
+          target: ["dimension", ["template-tag", "e"]],
+          type: "foo",
+        },
+      ];
 
-      it("should convert tags into tag parameters with field filter operator types", () => {
-        const parametersWithFieldFilterOperatorTypes = [
-          {
-            default: "abc",
-            id: 1,
-            name: "A",
-            slug: "a",
-            target: ["variable", ["template-tag", "a"]],
-            type: "foo",
-          },
-          {
-            default: undefined,
-            id: 2,
-            name: "B",
-            slug: "b",
-            target: ["variable", ["template-tag", "b"]],
-            type: "string/=",
-          },
-          {
-            default: undefined,
-            id: 3,
-            name: "C",
-            slug: "c",
-            target: ["variable", ["template-tag", "c"]],
-            type: "number/=",
-          },
-          {
-            default: undefined,
-            id: 4,
-            name: "D",
-            slug: "d",
-            target: ["variable", ["template-tag", "d"]],
-            type: "date/single",
-          },
-          {
-            default: undefined,
-            id: 5,
-            name: "E",
-            slug: "e",
-            target: ["dimension", ["template-tag", "e"]],
-            type: "foo",
-          },
-        ];
-
-        expect(getTemplateTagParameters(tags)).toEqual(
-          parametersWithFieldFilterOperatorTypes,
-        );
-      });
-    });
-
-    describe("field filter operators disabled", () => {
-      it("should convert tags into tag parameters", () => {
-        const parameters = [
-          {
-            default: "abc",
-            id: 1,
-            name: "A",
-            slug: "a",
-            target: ["variable", ["template-tag", "a"]],
-            type: "foo",
-          },
-          {
-            default: undefined,
-            id: 2,
-            name: "B",
-            slug: "b",
-            target: ["variable", ["template-tag", "b"]],
-            type: "category",
-          },
-          {
-            default: undefined,
-            id: 3,
-            name: "C",
-            slug: "c",
-            target: ["variable", ["template-tag", "c"]],
-            type: "category",
-          },
-          {
-            default: undefined,
-            id: 4,
-            name: "D",
-            slug: "d",
-            target: ["variable", ["template-tag", "d"]],
-            type: "date/single",
-          },
-          {
-            default: undefined,
-            id: 5,
-            name: "E",
-            slug: "e",
-            target: ["dimension", ["template-tag", "e"]],
-            type: "foo",
-          },
-        ];
-        expect(getTemplateTagParameters(tags)).toEqual(parameters);
-      });
+      expect(getTemplateTagParameters(tags)).toEqual(
+        parametersWithFieldFilterOperatorTypes,
+      );
     });
   });
 

--- a/frontend/src/metabase/parameters/utils/dashboard-options.js
+++ b/frontend/src/metabase/parameters/utils/dashboard-options.js
@@ -1,12 +1,6 @@
 import { t } from "ttag";
-import { areFieldFilterOperatorsEnabled } from "./feature-flag";
 import { getOperatorDisplayName } from "./operators";
-import {
-  PARAMETER_OPERATOR_TYPES,
-  LOCATION_OPTIONS,
-  ID_OPTION,
-  CATEGORY_OPTION,
-} from "../constants";
+import { PARAMETER_OPERATOR_TYPES, ID_OPTION } from "../constants";
 
 function buildTypedOperatorOptions(operatorType, sectionId, sectionName) {
   return PARAMETER_OPERATOR_TYPES[operatorType].map(operatorOption => {
@@ -34,9 +28,7 @@ export function getDashboardParameterSections() {
       id: "location",
       name: t`Location`,
       description: t`City, State, Country, ZIP code.`,
-      options: areFieldFilterOperatorsEnabled()
-        ? buildTypedOperatorOptions("string", "location", t`Location`)
-        : LOCATION_OPTIONS,
+      options: buildTypedOperatorOptions("string", "location", t`Location`),
     },
     {
       id: "id",
@@ -49,24 +41,17 @@ export function getDashboardParameterSections() {
         },
       ],
     },
-    areFieldFilterOperatorsEnabled() && {
+    {
       id: "number",
       name: t`Number`,
       description: t`Subtotal, Age, Price, Quantity, etc.`,
       options: buildTypedOperatorOptions("number", "number", t`Number`),
     },
-    areFieldFilterOperatorsEnabled()
-      ? {
-          id: "string",
-          name: t`Text or Category`,
-          description: t`Name, Rating, Description, etc.`,
-          options: buildTypedOperatorOptions("string", "string", t`Text`),
-        }
-      : {
-          id: "category",
-          name: t`Other Categories`,
-          description: t`Category, Type, Model, Rating, etc.`,
-          options: [CATEGORY_OPTION],
-        },
+    {
+      id: "string",
+      name: t`Text or Category`,
+      description: t`Name, Rating, Description, etc.`,
+      options: buildTypedOperatorOptions("string", "string", t`Text`),
+    },
   ].filter(Boolean);
 }

--- a/frontend/src/metabase/parameters/utils/dashboard-options.js
+++ b/frontend/src/metabase/parameters/utils/dashboard-options.js
@@ -1,20 +1,6 @@
 import { t } from "ttag";
-import { getOperatorDisplayName } from "./operators";
-import { PARAMETER_OPERATOR_TYPES, ID_OPTION } from "../constants";
-
-function buildTypedOperatorOptions(operatorType, sectionId, sectionName) {
-  return PARAMETER_OPERATOR_TYPES[operatorType].map(operatorOption => {
-    return {
-      ...operatorOption,
-      sectionId,
-      combinedName: getOperatorDisplayName(
-        operatorOption,
-        operatorType,
-        sectionName,
-      ),
-    };
-  });
-}
+import { buildTypedOperatorOptions } from "./operators";
+import { ID_OPTION } from "../constants";
 
 export function getDashboardParameterSections() {
   return [

--- a/frontend/src/metabase/parameters/utils/dashboard-options.unit.spec.js
+++ b/frontend/src/metabase/parameters/utils/dashboard-options.unit.spec.js
@@ -1,83 +1,33 @@
 import _ from "underscore";
-import MetabaseSettings from "metabase/lib/settings";
 import { getDashboardParameterSections } from "./dashboard-options";
-
-MetabaseSettings.get = jest.fn();
-
-function mockFieldFilterOperatorsFlag(value) {
-  MetabaseSettings.get.mockImplementation(flag => {
-    if (flag === "field-filter-operators-enabled?") {
-      return value;
-    }
-  });
-}
 
 describe("parameters/utils/dashboard-options", () => {
   describe("getDashboardParameterSections", () => {
-    beforeEach(() => {
-      mockFieldFilterOperatorsFlag(false);
+    it("should have a number section", () => {
+      expect(
+        _.findWhere(getDashboardParameterSections(), { id: "number" }),
+      ).toBeDefined();
     });
 
-    describe("when `field-filter-operators-enabled?` is false", () => {
-      it("should not have a number section", () => {
-        expect(
-          _.findWhere(getDashboardParameterSections(), { id: "number" }),
-        ).not.toBeDefined();
+    it("should have location options that map to string/* parameters", () => {
+      const locationSection = _.findWhere(getDashboardParameterSections(), {
+        id: "location",
       });
-
-      it("should have location options that map to location/* parameters", () => {
-        const locationSection = _.findWhere(getDashboardParameterSections(), {
-          id: "location",
-        });
-        expect(
-          locationSection.options.every(option =>
-            option.type.startsWith("location"),
-          ),
-        ).toBe(true);
-      });
-
-      it("should have a category section", () => {
-        expect(
-          _.findWhere(getDashboardParameterSections(), { id: "category" }),
-        ).toBeDefined();
-
-        expect(
-          _.findWhere(getDashboardParameterSections(), { id: "string" }),
-        ).not.toBeDefined();
-      });
+      expect(
+        locationSection.options.every(option =>
+          option.type.startsWith("string"),
+        ),
+      ).toBe(true);
     });
 
-    describe("when `field-filter-operators-enabled?` is true", () => {
-      beforeEach(() => {
-        mockFieldFilterOperatorsFlag(true);
-      });
+    it("should have a string section", () => {
+      expect(
+        _.findWhere(getDashboardParameterSections(), { id: "category" }),
+      ).not.toBeDefined();
 
-      it("should have a number section", () => {
-        expect(
-          _.findWhere(getDashboardParameterSections(), { id: "number" }),
-        ).toBeDefined();
-      });
-
-      it("should have location options that map to string/* parameters", () => {
-        const locationSection = _.findWhere(getDashboardParameterSections(), {
-          id: "location",
-        });
-        expect(
-          locationSection.options.every(option =>
-            option.type.startsWith("string"),
-          ),
-        ).toBe(true);
-      });
-
-      it("should have a string section", () => {
-        expect(
-          _.findWhere(getDashboardParameterSections(), { id: "category" }),
-        ).not.toBeDefined();
-
-        expect(
-          _.findWhere(getDashboardParameterSections(), { id: "string" }),
-        ).toBeDefined();
-      });
+      expect(
+        _.findWhere(getDashboardParameterSections(), { id: "string" }),
+      ).toBeDefined();
     });
   });
 });

--- a/frontend/src/metabase/parameters/utils/feature-flag.js
+++ b/frontend/src/metabase/parameters/utils/feature-flag.js
@@ -1,5 +1,0 @@
-import MetabaseSettings from "metabase/lib/settings";
-
-export function areFieldFilterOperatorsEnabled() {
-  return MetabaseSettings.get("field-filter-operators-enabled?");
-}

--- a/frontend/src/metabase/parameters/utils/filters.js
+++ b/frontend/src/metabase/parameters/utils/filters.js
@@ -13,20 +13,7 @@ export function fieldFilterForParameter(parameter) {
     case "category":
       return field => field.isCategory();
     case "location":
-      return field => {
-        switch (subtype) {
-          case "city":
-            return field.isCity();
-          case "state":
-            return field.isState();
-          case "zip_code":
-            return field.isZipCode();
-          case "country":
-            return field.isCountry();
-          default:
-            return field.isLocation();
-        }
-      };
+      return field => field.isLocation();
     case "number":
       return field => field.isNumber() && !field.isCoordinate();
     case "string":

--- a/frontend/src/metabase/parameters/utils/filters.unit.spec.js
+++ b/frontend/src/metabase/parameters/utils/filters.unit.spec.js
@@ -46,8 +46,12 @@ describe("parameters/utils/field-filters", () => {
       [
         { type: "location/city" },
         {
-          type: "city",
-          field: () => ({ ...field, isCity: () => true }),
+          type: "location",
+          field: () => ({
+            ...field,
+            isLocation: () => true,
+            isCity: () => true,
+          }),
         },
       ],
       [

--- a/frontend/src/metabase/parameters/utils/operators.js
+++ b/frontend/src/metabase/parameters/utils/operators.js
@@ -6,6 +6,7 @@ import {
   STRING,
   PRIMARY_KEY,
 } from "metabase/lib/schema_metadata";
+import { PARAMETER_OPERATOR_TYPES } from "../constants";
 
 export function getOperatorDisplayName(option, operatorType, sectionName) {
   if (operatorType === "date" || operatorType === "number") {
@@ -44,4 +45,22 @@ function getParameterOperatorType(parameterType) {
     default:
       return undefined;
   }
+}
+
+export function buildTypedOperatorOptions(
+  operatorType,
+  sectionId,
+  sectionName,
+) {
+  return PARAMETER_OPERATOR_TYPES[operatorType].map(operatorOption => {
+    return {
+      ...operatorOption,
+      sectionId,
+      combinedName: getOperatorDisplayName(
+        operatorOption,
+        operatorType,
+        sectionName,
+      ),
+    };
+  });
 }

--- a/frontend/src/metabase/parameters/utils/template-tag-options.js
+++ b/frontend/src/metabase/parameters/utils/template-tag-options.js
@@ -1,4 +1,6 @@
-import { getOperatorDisplayName } from "./operators";
+import { t } from "ttag";
+
+import { getOperatorDisplayName, buildTypedOperatorOptions } from "./operators";
 import { fieldFilterForParameter } from "./filters";
 
 import {
@@ -13,6 +15,7 @@ export function getParameterOptions() {
     ...OPTIONS_WITH_OPERATOR_SUBTYPES.map(option =>
       buildOperatorSubtypeOptions(option),
     ),
+    ...buildTypedOperatorOptions("string", "location", t`Location`),
   ].flat();
 }
 

--- a/frontend/src/metabase/parameters/utils/template-tag-options.js
+++ b/frontend/src/metabase/parameters/utils/template-tag-options.js
@@ -1,27 +1,18 @@
-import { areFieldFilterOperatorsEnabled } from "./feature-flag";
 import { getOperatorDisplayName } from "./operators";
 import { fieldFilterForParameter } from "./filters";
 
 import {
   OPTIONS_WITH_OPERATOR_SUBTYPES,
   PARAMETER_OPERATOR_TYPES,
-  LOCATION_OPTIONS,
   ID_OPTION,
-  CATEGORY_OPTION,
 } from "../constants";
 
 export function getParameterOptions() {
   return [
     ID_OPTION,
-    ...(areFieldFilterOperatorsEnabled()
-      ? OPTIONS_WITH_OPERATOR_SUBTYPES.map(option =>
-          buildOperatorSubtypeOptions(option),
-        )
-      : [
-          CATEGORY_OPTION,
-          ...LOCATION_OPTIONS,
-          ...PARAMETER_OPERATOR_TYPES["date"],
-        ]),
+    ...OPTIONS_WITH_OPERATOR_SUBTYPES.map(option =>
+      buildOperatorSubtypeOptions(option),
+    ),
   ].flat();
 }
 

--- a/frontend/src/metabase/parameters/utils/template-tag-options.unit.spec.js
+++ b/frontend/src/metabase/parameters/utils/template-tag-options.unit.spec.js
@@ -22,12 +22,18 @@ describe("parameters/utils/template-tag-options", () => {
     });
 
     it("should add a `combinedName` property to options", () => {
-      const optionsByType = _.indexBy(getParameterOptions(), "type");
+      const optionsByType = _.groupBy(getParameterOptions(), "type");
 
-      expect(optionsByType["string/="].combinedName).toEqual("String");
-      expect(optionsByType["string/!="].combinedName).toEqual("String is not");
-      expect(optionsByType["number/!="].combinedName).toEqual("Not equal to");
-      expect(optionsByType["date/single"].combinedName).toEqual("Single Date");
+      expect(optionsByType["string/="][0].combinedName).toEqual("String");
+      expect(optionsByType["string/!="][0].combinedName).toEqual(
+        "String is not",
+      );
+      expect(optionsByType["number/!="][0].combinedName).toEqual(
+        "Not equal to",
+      );
+      expect(optionsByType["date/single"][0].combinedName).toEqual(
+        "Single Date",
+      );
     });
   });
 
@@ -69,10 +75,13 @@ describe("parameters/utils/template-tag-options", () => {
       ).toBe(true);
     });
 
-    it("as a result of all location parameters haiving subtypes should return nothing for a generic location field", () => {
+    it("should return string options for a location field", () => {
       const locationField = { ...field, isLocation: () => true };
       const availableOptions = getParameterOptionsForField(locationField);
-      expect(availableOptions).toEqual([]);
+      expect(
+        availableOptions.length > 0 &&
+          availableOptions.every(option => option.type.startsWith("string")),
+      ).toBe(true);
     });
   });
 });

--- a/frontend/src/metabase/parameters/utils/template-tag-options.unit.spec.js
+++ b/frontend/src/metabase/parameters/utils/template-tag-options.unit.spec.js
@@ -1,81 +1,33 @@
 import _ from "underscore";
-import MetabaseSettings from "metabase/lib/settings";
 import { PARAMETER_OPERATOR_TYPES } from "../constants";
 import {
   getParameterOptions,
   getParameterOptionsForField,
 } from "./template-tag-options";
 
-MetabaseSettings.get = jest.fn();
-
-function mockFieldFilterOperatorsFlag(value) {
-  MetabaseSettings.get.mockImplementation(flag => {
-    if (flag === "field-filter-operators-enabled?") {
-      return value;
-    }
-  });
-}
-
 describe("parameters/utils/template-tag-options", () => {
-  beforeEach(() => {
-    mockFieldFilterOperatorsFlag(false);
-  });
-
   describe("getParameterOptions", () => {
-    describe("when `field-filter-operators-enabled?` is false", () => {
-      beforeEach(() => {
-        mockFieldFilterOperatorsFlag(false);
-      });
+    it("should return options with operator subtypes", () => {
+      const options = new Set(_.map(getParameterOptions(), "type"));
+      const expectedOptionTypes = ["id"].concat(
+        _.map(PARAMETER_OPERATOR_TYPES.number, "type"),
+        _.map(PARAMETER_OPERATOR_TYPES.string, "type"),
+        _.map(PARAMETER_OPERATOR_TYPES.date, "type"),
+      );
 
-      it("should return options without operator subtypes (except for date parameters)", () => {
-        const options = new Set(_.map(getParameterOptions(), "type"));
-        const expectedOptionTypes = [
-          "id",
-          "category",
-          "location/city",
-          "location/state",
-          "location/zip_code",
-          "location/country",
-        ].concat(_.map(PARAMETER_OPERATOR_TYPES.date, "type"));
-
-        expect(expectedOptionTypes.length).toEqual(options.size);
-        expect(expectedOptionTypes.every(option => options.has(option))).toBe(
-          true,
-        );
-      });
+      expect(expectedOptionTypes.length).toEqual(options.size);
+      expect(expectedOptionTypes.every(option => options.has(option))).toBe(
+        true,
+      );
     });
 
-    describe("when `field-filter-operators-enabled?` is true", () => {
-      beforeEach(() => {
-        mockFieldFilterOperatorsFlag(true);
-      });
+    it("should add a `combinedName` property to options", () => {
+      const optionsByType = _.indexBy(getParameterOptions(), "type");
 
-      it("should return options with operator subtypes", () => {
-        const options = new Set(_.map(getParameterOptions(), "type"));
-        const expectedOptionTypes = ["id"].concat(
-          _.map(PARAMETER_OPERATOR_TYPES.number, "type"),
-          _.map(PARAMETER_OPERATOR_TYPES.string, "type"),
-          _.map(PARAMETER_OPERATOR_TYPES.date, "type"),
-        );
-
-        expect(expectedOptionTypes.length).toEqual(options.size);
-        expect(expectedOptionTypes.every(option => options.has(option))).toBe(
-          true,
-        );
-      });
-
-      it("should add a `combinedName` property to options", () => {
-        const optionsByType = _.indexBy(getParameterOptions(), "type");
-
-        expect(optionsByType["string/="].combinedName).toEqual("String");
-        expect(optionsByType["string/!="].combinedName).toEqual(
-          "String is not",
-        );
-        expect(optionsByType["number/!="].combinedName).toEqual("Not equal to");
-        expect(optionsByType["date/single"].combinedName).toEqual(
-          "Single Date",
-        );
-      });
+      expect(optionsByType["string/="].combinedName).toEqual("String");
+      expect(optionsByType["string/!="].combinedName).toEqual("String is not");
+      expect(optionsByType["number/!="].combinedName).toEqual("Not equal to");
+      expect(optionsByType["date/single"].combinedName).toEqual("Single Date");
     });
   });
 
@@ -92,6 +44,7 @@ describe("parameters/utils/template-tag-options", () => {
       isString: () => false,
       isLocation: () => false,
     };
+
     it("should return relevantly typed options for date field", () => {
       const dateField = {
         ...field,
@@ -114,17 +67,6 @@ describe("parameters/utils/template-tag-options", () => {
         availableOptions.length > 0 &&
           availableOptions.every(option => option.type.startsWith("id")),
       ).toBe(true);
-    });
-
-    it("should return the specific location/state option for a state field", () => {
-      const stateField = {
-        ...field,
-        isState: () => true,
-      };
-      const availableOptions = getParameterOptionsForField(stateField);
-      expect(availableOptions).toEqual([
-        expect.objectContaining({ type: "location/state" }),
-      ]);
     });
 
     it("as a result of all location parameters haiving subtypes should return nothing for a generic location field", () => {

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx
@@ -95,6 +95,19 @@ export default class TagEditorParam extends Component {
     }
   }
 
+  getFilterWidgetTypeValue = (tag, widgetOptions) => {
+    // avoid `undefined` value because it makes the component "uncontrollable"
+    // (see Uncontrollable.jsx, metabase#13825)
+    const widgetType = tag["widget-type"] || "none";
+
+    const isOldWidgetType =
+      widgetType.startsWith("location") || widgetType === "category";
+
+    // old parameters with widget-type of `location/state` etc. need be remapped to string/= so that the
+    // dropdown is correctly populated with a set option
+    return isOldWidgetType ? "string/=" : widgetType;
+  };
+
   render() {
     const { tag, database, databases, metadata, parameter } = this.props;
     let widgetOptions = [],
@@ -177,9 +190,7 @@ export default class TagEditorParam extends Component {
             </h4>
             <Select
               className="block"
-              // avoid `undefined` value because it makes the component "uncontrollable"
-              // (see Uncontrollable.jsx, metabase#13825)
-              value={tag["widget-type"] || "none"}
+              value={this.getFilterWidgetTypeValue(tag, widgetOptions)}
               onChange={e =>
                 this.setWidgetType(
                   e.target.value === "none" ? undefined : e.target.value,

--- a/frontend/test/metabase/scenarios/dashboard-filters-sql/dashboard-filters-sql-date.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters-sql/dashboard-filters-sql-date.cy.spec.js
@@ -1,7 +1,6 @@
 import {
   restore,
   popover,
-  mockSessionProperty,
   filterWidget,
   editDashboard,
   saveDashboard,
@@ -21,8 +20,6 @@ Object.entries(DASHBOARD_SQL_DATE_FILTERS).forEach(
       beforeEach(() => {
         restore();
         cy.signInAsAdmin();
-
-        mockSessionProperty("field-filter-operators-enabled?", true);
 
         const questionDetails = getQuestionDetails(sqlFilter);
 

--- a/frontend/test/metabase/scenarios/dashboard-filters-sql/dashboard-filters-sql-id.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters-sql/dashboard-filters-sql-id.cy.spec.js
@@ -1,7 +1,6 @@
 import {
   restore,
   popover,
-  mockSessionProperty,
   filterWidget,
   editDashboard,
   saveDashboard,
@@ -18,8 +17,6 @@ describe("scenarios > dashboard > filters > SQL > ID", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
-
-    mockSessionProperty("field-filter-operators-enabled?", true);
   });
 
   describe("should work for the primary key", () => {

--- a/frontend/test/metabase/scenarios/dashboard-filters-sql/dashboard-filters-sql-location.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters-sql/dashboard-filters-sql-location.cy.spec.js
@@ -1,7 +1,6 @@
 import {
   restore,
   popover,
-  mockSessionProperty,
   filterWidget,
   editDashboard,
   saveDashboard,
@@ -21,8 +20,6 @@ Object.entries(DASHBOARD_SQL_LOCATION_FILTERS).forEach(
       beforeEach(() => {
         restore();
         cy.signInAsAdmin();
-
-        mockSessionProperty("field-filter-operators-enabled?", true);
 
         const questionDetails = getQuestionDetails(sqlFilter);
 

--- a/frontend/test/metabase/scenarios/dashboard-filters-sql/dashboard-filters-sql-number.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters-sql/dashboard-filters-sql-number.cy.spec.js
@@ -1,7 +1,6 @@
 import {
   restore,
   popover,
-  mockSessionProperty,
   filterWidget,
   editDashboard,
   saveDashboard,
@@ -21,8 +20,6 @@ Object.entries(DASHBOARD_SQL_NUMBER_FILTERS).forEach(
       beforeEach(() => {
         restore();
         cy.signInAsAdmin();
-
-        mockSessionProperty("field-filter-operators-enabled?", true);
 
         const questionDetails = getQuestionDetails(sqlFilter);
 

--- a/frontend/test/metabase/scenarios/dashboard-filters-sql/dashboard-filters-sql-text-category.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters-sql/dashboard-filters-sql-text-category.cy.spec.js
@@ -1,7 +1,6 @@
 import {
   restore,
   popover,
-  mockSessionProperty,
   filterWidget,
   editDashboard,
   saveDashboard,
@@ -21,8 +20,6 @@ Object.entries(DASHBOARD_SQL_TEXT_FILTERS).forEach(
       beforeEach(() => {
         restore();
         cy.signInAsAdmin();
-
-        mockSessionProperty("field-filter-operators-enabled?", true);
 
         const questionDetails = getQuestionDetails(sqlFilter);
 

--- a/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-date.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-date.cy.spec.js
@@ -1,7 +1,6 @@
 import {
   restore,
   popover,
-  mockSessionProperty,
   filterWidget,
   editDashboard,
   saveDashboard,
@@ -19,8 +18,6 @@ Object.entries(DASHBOARD_DATE_FILTERS).forEach(
 
         restore();
         cy.signInAsAdmin();
-
-        mockSessionProperty("field-filter-operators-enabled?", true);
 
         cy.visit("/dashboard/1");
 

--- a/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-id.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-id.cy.spec.js
@@ -1,7 +1,6 @@
 import {
   restore,
   popover,
-  mockSessionProperty,
   filterWidget,
   editDashboard,
   saveDashboard,
@@ -15,8 +14,6 @@ describe("scenarios > dashboard > filters > ID", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
-
-    mockSessionProperty("field-filter-operators-enabled?", true);
 
     cy.visit("/dashboard/1");
 

--- a/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-location.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-location.cy.spec.js
@@ -1,7 +1,6 @@
 import {
   restore,
   popover,
-  mockSessionProperty,
   filterWidget,
   editDashboard,
   saveDashboard,
@@ -17,8 +16,6 @@ Object.entries(DASHBOARD_LOCATION_FILTERS).forEach(
       beforeEach(() => {
         restore();
         cy.signInAsAdmin();
-
-        mockSessionProperty("field-filter-operators-enabled?", true);
 
         cy.visit("/dashboard/1");
 

--- a/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-number.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-number.cy.spec.js
@@ -1,7 +1,6 @@
 import {
   restore,
   popover,
-  mockSessionProperty,
   filterWidget,
   editDashboard,
   saveDashboard,
@@ -19,8 +18,6 @@ Object.entries(DASHBOARD_NUMBER_FILTERS).forEach(
 
         restore();
         cy.signInAsAdmin();
-
-        mockSessionProperty("field-filter-operators-enabled?", true);
 
         cy.visit("/dashboard/1");
 

--- a/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-text-category.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-text-category.cy.spec.js
@@ -1,7 +1,6 @@
 import {
   restore,
   popover,
-  mockSessionProperty,
   filterWidget,
   editDashboard,
   saveDashboard,
@@ -17,8 +16,6 @@ Object.entries(DASHBOARD_TEXT_FILTERS).forEach(
       beforeEach(() => {
         restore();
         cy.signInAsAdmin();
-
-        mockSessionProperty("field-filter-operators-enabled?", true);
 
         cy.visit("/dashboard/1");
 

--- a/frontend/test/metabase/scenarios/dashboard-filters/old-parameters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/old-parameters.cy.spec.js
@@ -1,13 +1,136 @@
-import { restore } from "__support__/e2e/cypress";
+import { restore, popover } from "__support__/e2e/cypress";
 // NOTE: some overlap with parameters-embedded.cy.spec.js
+import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
 
-describe.skip("scenarios > dashboard > parameters", () => {
+const { PEOPLE, PEOPLE_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATASET;
+
+// the dashboard parameters used in these tests ('category' and 'location/...') are no longer accessible
+// via the UI but should still work as expected
+
+describe("scenarios > dashboard > OLD parameters", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
   });
 
-  describe("native question variable connected to 'category' parameter", () => {
+  describe("question connected to a 'category' parameter", () => {
+    beforeEach(() => {
+      const filter = {
+        id: "c2967a17",
+        name: "Category",
+        slug: "category",
+        type: "category",
+      };
+
+      cy.createQuestion({
+        name: "Products table",
+        query: {
+          "source-table": PRODUCTS_ID,
+        },
+      }).then(({ body: { id: card_id } }) => {
+        cy.createDashboard().then(({ body: { id: dashboard_id } }) => {
+          cy.request("POST", `/api/dashboard/${dashboard_id}/cards`, {
+            cardId: card_id,
+          }).then(({ body: { id } }) => {
+            cy.addFilterToDashboard({ filter, dashboard_id });
+            cy.request("PUT", `/api/dashboard/${dashboard_id}/cards`, {
+              cards: [
+                {
+                  id,
+                  card_id,
+                  row: 0,
+                  col: 0,
+                  sizeX: 8,
+                  sizeY: 6,
+                  parameter_mappings: [
+                    {
+                      card_id,
+                      parameter_id: filter.id,
+                      target: ["dimension", ["field", PRODUCTS.CATEGORY, null]],
+                    },
+                  ],
+                },
+              ],
+            });
+
+            cy.visit(`/dashboard/${dashboard_id}`);
+          });
+        });
+      });
+    });
+
+    it("should work", () => {
+      cy.findAllByText("Doohickey");
+
+      cy.contains("Category").click();
+      popover().within(() => {
+        cy.get("input").type("Gadget{enter}");
+        cy.findByText("Add filter").click();
+      });
+
+      // verify that the filter is applied
+      cy.findByText("Doohickey").should("not.exist");
+    });
+  });
+
+  describe("question connected to a 'location/state' parameter", () => {
+    beforeEach(() => {
+      const filter = {
+        id: "c2967a17",
+        name: "City",
+        slug: "city",
+        type: "location/city",
+      };
+
+      cy.createQuestion({
+        name: "People table",
+        query: {
+          "source-table": PEOPLE_ID,
+        },
+      }).then(({ body: { id: card_id } }) => {
+        cy.createDashboard().then(({ body: { id: dashboard_id } }) => {
+          cy.request("POST", `/api/dashboard/${dashboard_id}/cards`, {
+            cardId: card_id,
+          }).then(({ body: { id } }) => {
+            cy.addFilterToDashboard({ filter, dashboard_id });
+            cy.request("PUT", `/api/dashboard/${dashboard_id}/cards`, {
+              cards: [
+                {
+                  id,
+                  card_id,
+                  row: 0,
+                  col: 0,
+                  sizeX: 8,
+                  sizeY: 6,
+                  parameter_mappings: [
+                    {
+                      card_id,
+                      parameter_id: filter.id,
+                      target: ["dimension", ["field", PEOPLE.CITY, null]],
+                    },
+                  ],
+                },
+              ],
+            });
+
+            cy.visit(`/dashboard/${dashboard_id}`);
+          });
+        });
+      });
+    });
+
+    it("should work", () => {
+      cy.contains("City").click();
+      popover().within(() => {
+        cy.get("input").type("Flagstaff{enter}");
+        cy.findByText("Add filter").click();
+      });
+
+      cy.get(".DashCard tbody tr").should("have.length", 1);
+    });
+  });
+
+  describe("native question field filter connected to 'category' parameter", () => {
     beforeEach(() => {
       const filter = {
         id: "c2967a17",
@@ -19,47 +142,44 @@ describe.skip("scenarios > dashboard > parameters", () => {
       cy.createNativeQuestion({
         name: "Products SQL",
         native: {
-          query: "select * from products",
-          "template-tags": {},
+          query: "select * from products where {{category}}",
+          "template-tags": {
+            category: {
+              "display-name": "Field Filter",
+              id: "abc123",
+              name: "category",
+              type: "dimension",
+              "widget-type": "category",
+              dimension: ["field", PRODUCTS.CATEGORY, null],
+              default: ["Doohickey"],
+            },
+          },
         },
         display: "table",
       }).then(({ body: { id: card_id } }) => {
-        cy.createQuestion({
-          name: "Products use saved SQL question",
-          query: {
-            "source-table": `card__${card_id}`,
-            aggregation: [],
-            breakout: [],
-          },
-        }).then(({ body: { id: card_id } }) => {
-          cy.createDashboard().then(({ body: { id: dashboard_id } }) => {
-            // Add previously created question to the dashboard
-            cy.request("POST", `/api/dashboard/${dashboard_id}/cards`, {
-              cardId: card_id,
-            }).then(({ body: { id } }) => {
-              cy.addFilterToDashboard({ filter, dashboard_id });
-              cy.request("PUT", `/api/dashboard/${dashboard_id}/cards`, {
-                cards: [
-                  {
-                    id,
-                    card_id,
-                    row: 0,
-                    col: 0,
-                    sizeX: 8,
-                    sizeY: 6,
-                    parameter_mappings: [
-                      {
-                        card_id: 5,
-                        parameter_id: "c2967a17",
-                        target: [
-                          "dimension",
-                          ["field", "TITLE", { "base-type": "type/Text" }],
-                        ],
-                      },
-                    ],
-                  },
-                ],
-              });
+        cy.createDashboard().then(({ body: { id: dashboard_id } }) => {
+          cy.request("POST", `/api/dashboard/${dashboard_id}/cards`, {
+            cardId: card_id,
+          }).then(({ body: { id } }) => {
+            cy.addFilterToDashboard({ filter, dashboard_id });
+            cy.request("PUT", `/api/dashboard/${dashboard_id}/cards`, {
+              cards: [
+                {
+                  id,
+                  card_id,
+                  row: 0,
+                  col: 0,
+                  sizeX: 8,
+                  sizeY: 6,
+                  parameter_mappings: [
+                    {
+                      card_id,
+                      parameter_id: "c2967a17",
+                      target: ["dimension", ["field", PRODUCTS.CATEGORY, null]],
+                    },
+                  ],
+                },
+              ],
             });
 
             cy.visit(`/dashboard/${dashboard_id}`);
@@ -67,87 +187,18 @@ describe.skip("scenarios > dashboard > parameters", () => {
         });
       });
     });
+
+    it("should work", () => {
+      cy.findAllByText("Doohickey");
+
+      cy.contains("Category").click();
+      popover().within(() => {
+        cy.get("input").type("Gadget{enter}");
+        cy.findByText("Add filter").click();
+      });
+
+      // verify that the filter is applied
+      cy.findByText("Doohickey").should("not.exist");
+    });
   });
-
-  // beforeEach(() => {
-  //   mockSessionProperty("field-filter-operators-enabled?", false);
-  //   restore();
-  //   cy.signInAsAdmin();
-  // });
-
-  // it("should hide field operator parameters/show old options", () => {
-  //   cy.visit("/dashboard/1");
-
-  //   // Add a filter
-  //   cy.icon("pencil").click();
-  //   cy.icon("filter").click();
-
-  //   cy.findByText("Number").should("not.exist");
-  //   cy.findByText("Text or Category").should("not.exist");
-
-  //   cy.findByText("Location").click();
-  //   cy.findByText("Contains").should("not.exist");
-  //   cy.findByText("City").should("exist");
-
-  //   cy.icon("filter").click();
-  // });
-
-  // it("should filter by city", () => {
-  //   cy.visit("/dashboard/1");
-
-  //   cy.icon("pencil").click();
-  //   cy.icon("filter").click();
-
-  //   cy.findByText("Location").click();
-  //   cy.findByText("City").click();
-
-  //   cy.findByText("Select…").click();
-  //   popover().within(() => {
-  //     cy.findByText("City").click();
-  //   });
-
-  //   cy.findByText("No default").click();
-  //   cy.findByPlaceholderText("Search by City")
-  //     .click()
-  //     .type("B");
-  //   cy.findByText("Baker").click();
-  //   cy.findByText("Add filter").click();
-  //   cy.get(".Button--primary")
-  //     .contains("Done")
-  //     .click();
-
-  //   cy.findByText("Save").click();
-  //   cy.findByText("You're editing this dashboard.").should("not.exist");
-  //   cy.findByText("Baker");
-
-  //   cy.findAllByTestId("table-row").should("have.length", 8);
-  // });
-
-  // it("should filter by category", () => {
-  //   cy.visit("/dashboard/1");
-
-  //   cy.icon("pencil").click();
-  //   cy.icon("filter").click();
-
-  //   cy.findByText("Other Categories").click();
-
-  //   cy.findByText("Select…").click();
-  //   popover().within(() => {
-  //     cy.findByText("Name").click();
-  //   });
-
-  //   cy.contains("Done").click();
-
-  //   cy.findByText("Save").click();
-  //   cy.findByText("You're editing this dashboard.").should("not.exist");
-
-  //   cy.findByText("Category").click();
-  //   cy.findByPlaceholderText("Search by Name")
-  //     .click()
-  //     .type("bb");
-  //   cy.findByText("Abbie Parisian").click();
-  //   cy.findByText("Add filter").click();
-
-  //   cy.contains("of 18");
-  // });
 });

--- a/frontend/test/metabase/scenarios/dashboard-filters/old-parameters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/old-parameters.cy.spec.js
@@ -1,86 +1,153 @@
-import { popover, restore, mockSessionProperty } from "__support__/e2e/cypress";
+import { restore } from "__support__/e2e/cypress";
 // NOTE: some overlap with parameters-embedded.cy.spec.js
 
-describe("scenarios > dashboard > parameters", () => {
+describe.skip("scenarios > dashboard > parameters", () => {
   beforeEach(() => {
-    mockSessionProperty("field-filter-operators-enabled?", false);
     restore();
     cy.signInAsAdmin();
   });
 
-  it("should hide field operator parameters/show old options", () => {
-    cy.visit("/dashboard/1");
+  describe("native question variable connected to 'category' parameter", () => {
+    beforeEach(() => {
+      const filter = {
+        id: "c2967a17",
+        name: "Category",
+        slug: "category",
+        type: "category",
+      };
 
-    // Add a filter
-    cy.icon("pencil").click();
-    cy.icon("filter").click();
+      cy.createNativeQuestion({
+        name: "Products SQL",
+        native: {
+          query: "select * from products",
+          "template-tags": {},
+        },
+        display: "table",
+      }).then(({ body: { id: card_id } }) => {
+        cy.createQuestion({
+          name: "Products use saved SQL question",
+          query: {
+            "source-table": `card__${card_id}`,
+            aggregation: [],
+            breakout: [],
+          },
+        }).then(({ body: { id: card_id } }) => {
+          cy.createDashboard().then(({ body: { id: dashboard_id } }) => {
+            // Add previously created question to the dashboard
+            cy.request("POST", `/api/dashboard/${dashboard_id}/cards`, {
+              cardId: card_id,
+            }).then(({ body: { id } }) => {
+              cy.addFilterToDashboard({ filter, dashboard_id });
+              cy.request("PUT", `/api/dashboard/${dashboard_id}/cards`, {
+                cards: [
+                  {
+                    id,
+                    card_id,
+                    row: 0,
+                    col: 0,
+                    sizeX: 8,
+                    sizeY: 6,
+                    parameter_mappings: [
+                      {
+                        card_id: 5,
+                        parameter_id: "c2967a17",
+                        target: [
+                          "dimension",
+                          ["field", "TITLE", { "base-type": "type/Text" }],
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              });
+            });
 
-    cy.findByText("Number").should("not.exist");
-    cy.findByText("Text or Category").should("not.exist");
-
-    cy.findByText("Location").click();
-    cy.findByText("Contains").should("not.exist");
-    cy.findByText("City").should("exist");
-
-    cy.icon("filter").click();
-  });
-
-  it("should filter by city", () => {
-    cy.visit("/dashboard/1");
-
-    cy.icon("pencil").click();
-    cy.icon("filter").click();
-
-    cy.findByText("Location").click();
-    cy.findByText("City").click();
-
-    cy.findByText("Select…").click();
-    popover().within(() => {
-      cy.findByText("City").click();
+            cy.visit(`/dashboard/${dashboard_id}`);
+          });
+        });
+      });
     });
-
-    cy.findByText("No default").click();
-    cy.findByPlaceholderText("Search by City")
-      .click()
-      .type("B");
-    cy.findByText("Baker").click();
-    cy.findByText("Add filter").click();
-    cy.get(".Button--primary")
-      .contains("Done")
-      .click();
-
-    cy.findByText("Save").click();
-    cy.findByText("You're editing this dashboard.").should("not.exist");
-    cy.findByText("Baker");
-
-    cy.findAllByTestId("table-row").should("have.length", 8);
   });
 
-  it("should filter by category", () => {
-    cy.visit("/dashboard/1");
+  // beforeEach(() => {
+  //   mockSessionProperty("field-filter-operators-enabled?", false);
+  //   restore();
+  //   cy.signInAsAdmin();
+  // });
 
-    cy.icon("pencil").click();
-    cy.icon("filter").click();
+  // it("should hide field operator parameters/show old options", () => {
+  //   cy.visit("/dashboard/1");
 
-    cy.findByText("Other Categories").click();
+  //   // Add a filter
+  //   cy.icon("pencil").click();
+  //   cy.icon("filter").click();
 
-    cy.findByText("Select…").click();
-    popover().within(() => {
-      cy.findByText("Name").click();
-    });
+  //   cy.findByText("Number").should("not.exist");
+  //   cy.findByText("Text or Category").should("not.exist");
 
-    cy.contains("Done").click();
+  //   cy.findByText("Location").click();
+  //   cy.findByText("Contains").should("not.exist");
+  //   cy.findByText("City").should("exist");
 
-    cy.findByText("Save").click();
-    cy.findByText("You're editing this dashboard.").should("not.exist");
+  //   cy.icon("filter").click();
+  // });
 
-    cy.findByText("Category").click();
-    cy.findByPlaceholderText("Search by Name")
-      .click()
-      .type("bb");
-    cy.findByText("Abbie Parisian").click();
-    cy.findByText("Add filter").click();
+  // it("should filter by city", () => {
+  //   cy.visit("/dashboard/1");
 
-    cy.contains("of 18");
-  });
+  //   cy.icon("pencil").click();
+  //   cy.icon("filter").click();
+
+  //   cy.findByText("Location").click();
+  //   cy.findByText("City").click();
+
+  //   cy.findByText("Select…").click();
+  //   popover().within(() => {
+  //     cy.findByText("City").click();
+  //   });
+
+  //   cy.findByText("No default").click();
+  //   cy.findByPlaceholderText("Search by City")
+  //     .click()
+  //     .type("B");
+  //   cy.findByText("Baker").click();
+  //   cy.findByText("Add filter").click();
+  //   cy.get(".Button--primary")
+  //     .contains("Done")
+  //     .click();
+
+  //   cy.findByText("Save").click();
+  //   cy.findByText("You're editing this dashboard.").should("not.exist");
+  //   cy.findByText("Baker");
+
+  //   cy.findAllByTestId("table-row").should("have.length", 8);
+  // });
+
+  // it("should filter by category", () => {
+  //   cy.visit("/dashboard/1");
+
+  //   cy.icon("pencil").click();
+  //   cy.icon("filter").click();
+
+  //   cy.findByText("Other Categories").click();
+
+  //   cy.findByText("Select…").click();
+  //   popover().within(() => {
+  //     cy.findByText("Name").click();
+  //   });
+
+  //   cy.contains("Done").click();
+
+  //   cy.findByText("Save").click();
+  //   cy.findByText("You're editing this dashboard.").should("not.exist");
+
+  //   cy.findByText("Category").click();
+  //   cy.findByPlaceholderText("Search by Name")
+  //     .click()
+  //     .type("bb");
+  //   cy.findByText("Abbie Parisian").click();
+  //   cy.findByText("Add filter").click();
+
+  //   cy.contains("of 18");
+  // });
 });

--- a/frontend/test/metabase/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -3,7 +3,6 @@ import {
   popover,
   restore,
   openNativeEditor,
-  mockSessionProperty,
 } from "__support__/e2e/cypress";
 import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
 
@@ -370,7 +369,6 @@ describe("scenarios > dashboard > parameters", () => {
   });
 
   it("should render other categories filter that allows selecting multiple values (metabase#18113)", () => {
-    mockSessionProperty("field-filter-operators-enabled?", false);
     const filter = {
       id: "c2967a17",
       name: "Category",

--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/17139-do-not-reset-filters-on-edit.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/17139-do-not-reset-filters-on-edit.cy.spec.js
@@ -1,7 +1,6 @@
 import {
   restore,
   popover,
-  mockSessionProperty,
   filterWidget,
   editDashboard,
   cancelEditingDashboard,
@@ -15,8 +14,6 @@ describe.skip("issue 17139", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
-    mockSessionProperty("field-filter-operators-enabled?", true);
-
     cy.visit("/dashboard/1");
 
     editDashboard();

--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/17775-filter-custom-column-date.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/17775-filter-custom-column-date.cy.spec.js
@@ -4,7 +4,6 @@ import {
   filterWidget,
   editDashboard,
   saveDashboard,
-  mockSessionProperty,
 } from "__support__/e2e/cypress";
 
 import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
@@ -33,8 +32,6 @@ const dashboardDetails = { parameters };
 
 describe.skip("issue 17775", () => {
   beforeEach(() => {
-    mockSessionProperty("field-filter-operators-enabled?", true);
-
     restore();
     cy.signInAsAdmin();
 

--- a/frontend/test/metabase/scenarios/native-filters/reproductions/15700.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native-filters/reproductions/15700.cy.spec.js
@@ -1,40 +1,28 @@
-import {
-  restore,
-  mockSessionProperty,
-  openNativeEditor,
-} from "__support__/e2e/cypress";
+import { restore, openNativeEditor } from "__support__/e2e/cypress";
 
 import * as SQLFilter from "../helpers/e2e-sql-filter-helpers";
 import * as FieldFilter from "../helpers/e2e-field-filter-helpers";
 
-["old", "new"].forEach(test => {
-  const isFeatureFlagTurnedOn = test === "old" ? false : true;
-  const widgetType = test === "old" ? "Category" : "String is not";
+const widgetType = "String is not";
 
-  describe("issue 15700", () => {
-    beforeEach(() => {
-      restore();
-      cy.signInAsAdmin();
+describe("issue 15700", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
 
-      mockSessionProperty(
-        "field-filter-operators-enabled?",
-        isFeatureFlagTurnedOn,
-      );
+  it("should be able to select 'Field Filter' category in native query (metabase#15700)", () => {
+    openNativeEditor();
+    SQLFilter.enterParameterizedQuery("{{filter}}");
+
+    SQLFilter.openTypePickerFromDefaultFilterType();
+    SQLFilter.chooseType("Field Filter");
+
+    FieldFilter.mapTo({
+      table: "Products",
+      field: "Category",
     });
 
-    it(`${test} syntax:\n should be able to select "Field Filter" category in native query (metabase#15700)`, () => {
-      openNativeEditor();
-      SQLFilter.enterParameterizedQuery("{{filter}}");
-
-      SQLFilter.openTypePickerFromDefaultFilterType();
-      SQLFilter.chooseType("Field Filter");
-
-      FieldFilter.mapTo({
-        table: "Products",
-        field: "Category",
-      });
-
-      FieldFilter.setWidgetType(widgetType);
-    });
+    FieldFilter.setWidgetType(widgetType);
   });
 });

--- a/frontend/test/metabase/scenarios/native-filters/reproductions/16739.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native-filters/reproductions/16739.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, mockSessionProperty } from "__support__/e2e/cypress";
+import { restore } from "__support__/e2e/cypress";
 import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
 
 const { PRODUCTS } = SAMPLE_DATASET;
@@ -17,8 +17,6 @@ describe("issue 16739", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
-
-    mockSessionProperty("field-filter-operators-enabled?", true);
   });
 
   ["normal", "nodata"].forEach(user => {

--- a/frontend/test/metabase/scenarios/native-filters/reproductions/17490.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native-filters/reproductions/17490.cy.spec.js
@@ -1,14 +1,9 @@
-import {
-  mockSessionProperty,
-  openNativeEditor,
-  restore,
-} from "__support__/e2e/cypress";
+import { openNativeEditor, restore } from "__support__/e2e/cypress";
 
 import * as SQLFilter from "../helpers/e2e-sql-filter-helpers";
 
 describe("issue 17490", () => {
   beforeEach(() => {
-    mockSessionProperty("field-filter-operators-enabled?", true);
     mockDatabaseTables();
 
     restore();

--- a/frontend/test/metabase/scenarios/native-filters/reproductions/17751-long-filter-name-hides-close-icon.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native-filters/reproductions/17751-long-filter-name-hides-close-icon.cy.spec.js
@@ -1,9 +1,4 @@
-import {
-  restore,
-  mockSessionProperty,
-  filterWidget,
-  popover,
-} from "__support__/e2e/cypress";
+import { restore, filterWidget, popover } from "__support__/e2e/cypress";
 
 import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
 
@@ -33,8 +28,6 @@ describe("issue 17751", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
-
-    mockSessionProperty("field-filter-operators-enabled?", true);
 
     cy.createNativeQuestion(questionDetails, { visitQuestion: true });
   });

--- a/frontend/test/metabase/scenarios/native-filters/sql-field-filter-category.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native-filters/sql-field-filter-category.cy.spec.js
@@ -1,0 +1,59 @@
+import { restore, popover } from "__support__/e2e/cypress";
+import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
+
+const { PRODUCTS } = SAMPLE_DATASET;
+
+describe("scenarios > filters > sql filters > field filter > Category", () => {
+  beforeEach(() => {
+    restore();
+    cy.intercept("POST", "api/dataset").as("dataset");
+
+    cy.signInAsAdmin();
+
+    cy.createNativeQuestion({
+      name: "Products SQL",
+      native: {
+        query: "select * from products where {{category}}",
+        "template-tags": {
+          category: {
+            "display-name": "Field Filter",
+            id: "abc123",
+            name: "category",
+            type: "dimension",
+            "widget-type": "category",
+            dimension: ["field", PRODUCTS.CATEGORY, null],
+            default: ["Doohickey"],
+          },
+        },
+      },
+      display: "table",
+    }).then(({ body: { id: card_id } }) => {
+      cy.visit(`/question/${card_id}`);
+    });
+  });
+
+  it("should work despite it not showing up in the widget type list", () => {
+    cy.findByText("Showing 42 rows");
+
+    cy.icon("close").click();
+    cy.findByText("Field Filter").click();
+
+    popover().within(() => {
+      cy.findByText("Gizmo").click();
+      cy.findByText("Add filter").click();
+    });
+
+    cy.get(".RunButton")
+      .first()
+      .click();
+    cy.findByText("Showing 51 rows");
+
+    cy.findByText("Open Editor").click();
+    cy.icon("variable").click();
+
+    cy.findByText("Filter widget type")
+      .parent()
+      .find(".AdminSelect")
+      .contains("String");
+  });
+});

--- a/frontend/test/metabase/scenarios/native-filters/sql-field-filter-date.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native-filters/sql-field-filter-date.cy.spec.js
@@ -1,8 +1,4 @@
-import {
-  restore,
-  mockSessionProperty,
-  openNativeEditor,
-} from "__support__/e2e/cypress";
+import { restore, openNativeEditor } from "__support__/e2e/cypress";
 
 import { DATE_FILTER_SUBTYPES } from "./helpers/e2e-field-filter-data-objects";
 
@@ -16,8 +12,6 @@ describe("scenarios > filters > sql filters > field filter > Date", () => {
     cy.intercept("POST", "api/dataset").as("dataset");
 
     cy.signInAsAdmin();
-    // Make sure feature flag is on regardles of the environment where this is running.
-    mockSessionProperty("field-filter-operators-enabled?", true);
 
     openNativeEditor();
     SQLFilter.enterParameterizedQuery(

--- a/frontend/test/metabase/scenarios/native-filters/sql-field-filter-id.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native-filters/sql-field-filter-id.cy.spec.js
@@ -1,8 +1,4 @@
-import {
-  restore,
-  mockSessionProperty,
-  openNativeEditor,
-} from "__support__/e2e/cypress";
+import { restore, openNativeEditor } from "__support__/e2e/cypress";
 
 import * as SQLFilter from "./helpers/e2e-sql-filter-helpers";
 import * as FieldFilter from "./helpers/e2e-field-filter-helpers";
@@ -13,8 +9,6 @@ describe("scenarios > filters > sql filters > field filter > ID", () => {
     cy.intercept("POST", "api/dataset").as("dataset");
 
     cy.signInAsAdmin();
-    // Make sure feature flag is on regardless of the environment where this is running
-    mockSessionProperty("field-filter-operators-enabled?", true);
 
     openNativeEditor();
     SQLFilter.enterParameterizedQuery(

--- a/frontend/test/metabase/scenarios/native-filters/sql-field-filter-none.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native-filters/sql-field-filter-none.cy.spec.js
@@ -1,6 +1,5 @@
 import {
   restore,
-  mockSessionProperty,
   openNativeEditor,
   filterWidget,
 } from "__support__/e2e/cypress";
@@ -14,8 +13,6 @@ describe("scenarios > filters > sql filters > field filter > None", () => {
     cy.intercept("POST", "api/dataset").as("dataset");
 
     cy.signInAsAdmin();
-    // Make sure feature flag is on regardless of the environment where this is running
-    mockSessionProperty("field-filter-operators-enabled?", true);
 
     openNativeEditor();
     SQLFilter.enterParameterizedQuery("SELECT * FROM people WHERE {{filter}}");

--- a/frontend/test/metabase/scenarios/native-filters/sql-field-filter-number.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native-filters/sql-field-filter-number.cy.spec.js
@@ -1,8 +1,4 @@
-import {
-  restore,
-  mockSessionProperty,
-  openNativeEditor,
-} from "__support__/e2e/cypress";
+import { restore, openNativeEditor } from "__support__/e2e/cypress";
 
 import { NUMBER_FILTER_SUBTYPES } from "./helpers/e2e-field-filter-data-objects";
 
@@ -15,8 +11,6 @@ describe("scenarios > filters > sql filters > field filter > Number", () => {
     cy.intercept("POST", "api/dataset").as("dataset");
 
     cy.signInAsAdmin();
-    // Make sure feature flag is on regardles of the environment where this is running.
-    mockSessionProperty("field-filter-operators-enabled?", true);
 
     openNativeEditor();
     SQLFilter.enterParameterizedQuery(

--- a/frontend/test/metabase/scenarios/native-filters/sql-field-filter-string.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native-filters/sql-field-filter-string.cy.spec.js
@@ -1,8 +1,4 @@
-import {
-  restore,
-  mockSessionProperty,
-  openNativeEditor,
-} from "__support__/e2e/cypress";
+import { restore, openNativeEditor } from "__support__/e2e/cypress";
 
 import { STRING_FILTER_SUBTYPES } from "./helpers/e2e-field-filter-data-objects";
 
@@ -15,8 +11,6 @@ describe("scenarios > filters > sql filters > field filter > String", () => {
     cy.intercept("POST", "api/dataset").as("dataset");
 
     cy.signInAsAdmin();
-    // Make sure feature flag is on regardles of the environment where this is running.
-    mockSessionProperty("field-filter-operators-enabled?", true);
 
     openNativeEditor();
     SQLFilter.enterParameterizedQuery(

--- a/frontend/test/metabase/scenarios/native-filters/sql-filters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native-filters/sql-filters.cy.spec.js
@@ -1,6 +1,5 @@
 import {
   restore,
-  mockSessionProperty,
   openNativeEditor,
   filterWidget,
 } from "__support__/e2e/cypress";
@@ -13,8 +12,6 @@ describe("scenarios > filters > sql filters > basic filter types", () => {
     cy.intercept("POST", "api/dataset").as("dataset");
 
     cy.signInAsAdmin();
-    // Make sure feature flag is on regardles of the environment where this is running.
-    mockSessionProperty("field-filter-operators-enabled?", true);
 
     openNativeEditor();
   });

--- a/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
@@ -3,7 +3,6 @@ import {
   setupSMTP,
   describeWithToken,
   popover,
-  mockSessionProperty,
   sidebar,
   mockSlackConfigured,
 } from "__support__/e2e/cypress";
@@ -155,9 +154,6 @@ describe("scenarios > dashboard > subscriptions", () => {
     });
 
     it("should work when using dashboard default filter value on native query with required parameter (metabase#15705)", () => {
-      // In order to reproduce this test, we need to use the old syntac for dashboard filters
-      mockSessionProperty("field-filter-operators-enabled?", false);
-
       cy.createNativeQuestion({
         name: "15705",
         native: {

--- a/frontend/test/metabase/scenarios/visualizations/reproductions/18061-maps-only-nulls-crash-frontend.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/reproductions/18061-maps-only-nulls-crash-frontend.cy.spec.js
@@ -1,6 +1,5 @@
 import {
   restore,
-  mockSessionProperty,
   visitAlias,
   popover,
   filterWidget,
@@ -54,8 +53,6 @@ const dashboardDetails = { name: "18061D", parameters: [filter] };
 
 describe("issue 18061", () => {
   beforeEach(() => {
-    mockSessionProperty("field-filter-operators-enabled?", true);
-
     restore();
     cy.signInAsAdmin();
 

--- a/modules/drivers/mongo/src/metabase/driver/mongo/parameters.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/parameters.clj
@@ -123,7 +123,6 @@
                                            [:template-tag
                                             [:field (field->name (:field v) false)
                                              {:base-type (get-in v [:field :base_type])}]])
-                                    params/throw-if-field-filter-operators-not-enabled
                                     ops/to-clause
                                     ;; desugar only impacts :does-not-contain -> [:not [:contains ... but it prevents
                                     ;; an optimization of [:= 'field 1 2 3] -> [:in 'field [1 2 3]] since that

--- a/src/metabase/api/embed.clj
+++ b/src/metabase/api/embed.clj
@@ -23,7 +23,6 @@
             [metabase.api.dashboard :as dashboard-api]
             [metabase.api.dataset :as dataset-api]
             [metabase.api.public :as public-api]
-            [metabase.driver.common.parameters :as params]
             [metabase.models.card :refer [Card]]
             [metabase.models.dashboard :refer [Dashboard]]
             [metabase.query-processor :as qp]
@@ -137,8 +136,8 @@
                                            (or widget-type (not= tag-type :dimension)))]
     {:id      (:id tag)
      :type    (or widget-type (cond (= tag-type :date)                                                  :date/single
-                                    (and (params/field-filter-operators-enabled?) (= tag-type :string)) :string/=
-                                    (and (params/field-filter-operators-enabled?) (= tag-type :number)) :number/=
+                                    (= tag-type :string) :string/=
+                                    (= tag-type :number) :number/=
                                     :else                                                               :category))
      :target  (if (= tag-type :dimension)
                 [:dimension [:template-tag (:name tag)]]

--- a/src/metabase/driver/common/parameters.clj
+++ b/src/metabase/driver/common/parameters.clj
@@ -1,29 +1,8 @@
 (ns metabase.driver.common.parameters
   "Various record types below are used as a convenience for differentiating the different param types."
-  (:require [metabase.models.setting :refer [defsetting]]
-            [metabase.query-processor.error-type :as qp.error-type]
-            [metabase.util.i18n :as i18n :refer [deferred-tru tru]]
-            [potemkin.types :as p.types]
+  (:require [potemkin.types :as p.types]
             [pretty.core :as pretty]
             [schema.core :as s]))
-
-(defsetting field-filter-operators-enabled?
-  (deferred-tru "Enable the new field-filter operators")
-  :type       :boolean
-  :visibility :public
-  :setter     :none)
-
-(defn throw-if-field-filter-operators-not-enabled
-  "Feature flag check for new field filter operations. Assumed already has been checked that `ops/operator?` is
-  true. Throws if the new field filter operators are not enabled. Intended to be removed when feature flag is no
-  longer necessary; designed so it can be used in a threading context and just raised out."
-  {:added "0.39.0"}
-  [field-filter]
-  (if (field-filter-operators-enabled?)
-    field-filter
-    (throw (ex-info (tru "New field filter operators are not enabled")
-                    {:type qp.error-type/invalid-parameter
-                     :operator (:type field-filter)}))))
 
 ;; "FieldFilter" is something that expands to a clause like "some_field BETWEEN 1 AND 10"
 ;;

--- a/src/metabase/driver/sql/parameters/substitution.clj
+++ b/src/metabase/driver/sql/parameters/substitution.clj
@@ -246,7 +246,6 @@
             (->> (assoc params :target
                         [:template-tag [:field (field->identifier driver field param-type)
                                         {:base-type (:base_type field)}]])
-                 i/throw-if-field-filter-operators-not-enabled
                  ops/to-clause
                  mbql.u/desugar-filter-clause
                  wrap-value-literals/wrap-value-literals-in-mbql

--- a/src/metabase/query_processor/middleware/parameters/mbql.clj
+++ b/src/metabase/query_processor/middleware/parameters/mbql.clj
@@ -1,7 +1,6 @@
 (ns metabase.query-processor.middleware.parameters.mbql
   "Code for handling parameter substitution in MBQL queries."
-  (:require [metabase.driver.common.parameters :as i]
-            [metabase.driver.common.parameters.dates :as date-params]
+  (:require [metabase.driver.common.parameters.dates :as date-params]
             [metabase.driver.common.parameters.operators :as ops]
             [metabase.mbql.schema :as mbql.s]
             [metabase.mbql.util :as mbql.u]
@@ -46,7 +45,7 @@
   [{param-type :type, param-value :value, [_ field :as target] :target, :as param}]
   (cond
     (ops/operator? param-type)
-    (ops/to-clause (i/throw-if-field-filter-operators-not-enabled param))
+    (ops/to-clause param)
     ;; multipe values. Recursively handle them all and glue them all together with an OR clause
     (sequential? param-value)
     (mbql.u/simplify-compound-filter

--- a/test/metabase/driver/sql/parameters/substitute_test.clj
+++ b/test/metabase/driver/sql/parameters/substitute_test.clj
@@ -166,17 +166,7 @@
                    (substitute query {"param" (i/map->FieldFilter
                                                {:field (Field (mt/id :venues field))
                                                 :value {:type  operator
-                                                        :value value}})})))))))
-    (testing "Throws if not enabled (#15488)"
-      (with-redefs [i/field-filter-operators-enabled? (constantly false)]
-        (is (= :invalid-parameter
-               (try
-                 (substitute ["select * from venues where " (param "param")]
-                             {"param" (i/map->FieldFilter
-                                       {:field (Field (mt/id :venues :price))
-                                        :value {:type  :number/>=
-                                                :value [3]}})})
-                 (catch Exception e (:type (ex-data e)))))))))
+                                                        :value value}})}))))))))
 
 
 ;;; -------------------------------------------- Referenced Card Queries ---------------------------------------------

--- a/test/metabase/query_processor/middleware/parameters/mbql_test.clj
+++ b/test/metabase/query_processor/middleware/parameters/mbql_test.clj
@@ -2,10 +2,8 @@
   "Tests for *MBQL* parameter substitution."
   (:require [clojure.test :refer :all]
             [metabase.driver :as driver]
-            [metabase.driver.common.parameters :as params]
             [metabase.mbql.normalize :as normalize]
             [metabase.query-processor :as qp]
-            [metabase.query-processor.error-type :as qp.error-type]
             [metabase.query-processor.middleware.parameters.mbql :as mbql-params]
             [metabase.test :as mt]))
 
@@ -161,18 +159,7 @@
                        :parameters [{:name   "name"
                                      :type   :string/starts-with
                                      :target $name
-                                     :value ["B"]}]})))))
-        (with-redefs [params/field-filter-operators-enabled? (constantly false)]
-          (testing "Throws if not enabled (#15488)"
-            (is (= {:type     qp.error-type/invalid-parameter
-                    :operator :number/between}
-                   (try (f (mt/query venues
-                             {:query      {:aggregation [[:count]]}
-                              :parameters [{:name   "price"
-                                            :type   :number/between
-                                            :target $price
-                                            :value  [2 5]}]}))
-                        (catch Exception e (ex-data e)))))))))))
+                                     :value ["B"]}]})))))))))
 
 (deftest basic-where-test
   (mt/test-drivers (params-test-drivers)


### PR DESCRIPTION
https://github.com/metabase/metaboat/issues/144

This PR exposes the operator-based parameter filters to everyone by removing the associated feature flag.

I've also included a small bug fix in https://github.com/metabase/metabase/pull/19378/commits/a3f5e0290af6326cb174d10522e078b2e55ed567. Template tags with widget types of `"category"` and `"location/..."` weren't populating the widget type dropdown in the variables sidebar of the native query editor.

**Testing**
1. Create a native question with template `select * from PRODUCTS where {{category}}` and set the filter type to "field filter" and the widget type to "String". The parameter widget should behave as it would've before if set to a "Category" widget type. The "category" should no longer show up.
2. Create a native question with template `select * from PEOPLE where {{state}}` and set the filter type to "field filter" and the widget type to "Location". Sub location types should no longer be available. Instead, the types should mirror the various string operator types.
3. Create a GUI question (something simple like the Products table) and add it to a dashboard. Create a "Text or Category" > "Dropdown" filter and map it to the Category field of the Products table. Play around with it and make sure it shows field values and filters correctly.
4. Add a Number filter and map it to Products.Rating and make sure it works/filters/etc.
5. Checkout `master` and connect a question on a dashboard to a Category filter. Check this branch out and make sure it still works.
6. Checkout `master` and create a native question with a Category filter and make sure it works after checking this branch back out.
7. Checkout `master` and create a native question with a Location/State filter and make sure it works after checking this branch back out.