### PR TITLE
Honor `enable-nested-queries` setting in expansion

### DIFF
--- a/src/metabase/query_processor/middleware/fetch_source_query.clj
+++ b/src/metabase/query_processor/middleware/fetch_source_query.clj
@@ -29,6 +29,7 @@
             [metabase.mbql.schema :as mbql.s]
             [metabase.mbql.util :as mbql.u]
             [metabase.models.card :refer [Card]]
+            [metabase.public-settings :as public-settings]
             [metabase.query-processor.interface :as i]
             [metabase.query-processor.middleware.permissions :as qp.perms]
             [metabase.util :as u]
@@ -163,7 +164,10 @@
     map-with-card-id-source-table?
     ;; if this is a map that has a Card ID `:source-table`, resolve that (replacing it with the appropriate
     ;; `:source-query`, then recurse and resolve any nested-nested queries that need to be resolved too
-    (let [resolved (resolve-one &match)]
+    (let [resolved (if (public-settings/enable-nested-queries)
+                     (resolve-one &match)
+                     (throw (ex-info (trs "Nested queries are disabled")
+                                     {:clause &match})))]
       ;; wrap the recursive call in a try-catch; if the recursive resolution fails, add context about the
       ;; resolution that were we in the process of
       (try

--- a/test/metabase/query_processor/middleware/fetch_source_query_test.clj
+++ b/test/metabase/query_processor/middleware/fetch_source_query_test.clj
@@ -8,7 +8,8 @@
             [metabase.query-processor.middleware.fetch-source-query :as fetch-source-query]
             [metabase.test :as mt]
             [metabase.util :as u]
-            [toucan.db :as db]))
+            [toucan.db :as db]
+            [schema.core :as s]))
 
 (defn- resolve-card-id-source-tables [query]
   (:pre (mt/test-qp-middleware fetch-source-query/resolve-card-id-source-tables query)))
@@ -71,7 +72,24 @@
                   :filter       [:between
                                  [:field "date" {:base-type :type/Date}]
                                  "2015-01-01"
-                                 "2015-02-01"]}))))))))
+                                 "2015-02-01"]})))))))
+  (testing "respects `enable-nested-queries` server setting"
+    (mt/with-temp* [Card [{card-id :id} {:dataset_query (mt/mbql-query venues)}]]
+      (letfn [(resolve [] (resolve-card-id-source-tables
+                           (mt/mbql-query nil
+                                          {:source-table (str "card__" card-id)})))]
+        (mt/with-temporary-setting-values [enable-nested-queries true]
+          (is (some? (resolve-card-id-source-tables
+                      (mt/mbql-query nil
+                                     {:source-table (str "card__" card-id)})))))
+        (mt/with-temporary-setting-values [enable-nested-queries false]
+          (try (resolve-card-id-source-tables
+                (mt/mbql-query nil
+                               {:source-table (str "card__" card-id)}))
+               (is false "Nested queries disabled not honored")
+               (catch Exception e
+                 (is (schema= {:clause {:source-table (s/eq (str "card__" card-id))}}
+                              (ex-data e))))))))))
 
 (deftest resolve-native-queries-test
   (testing "make sure that the `resolve-card-id-source-tables` middleware correctly resolves native queries"

--- a/test/metabase/query_processor/middleware/fetch_source_query_test.clj
+++ b/test/metabase/query_processor/middleware/fetch_source_query_test.clj
@@ -8,8 +8,8 @@
             [metabase.query-processor.middleware.fetch-source-query :as fetch-source-query]
             [metabase.test :as mt]
             [metabase.util :as u]
-            [toucan.db :as db]
-            [schema.core :as s]))
+            [schema.core :as s]
+            [toucan.db :as db]))
 
 (defn- resolve-card-id-source-tables [query]
   (:pre (mt/test-qp-middleware fetch-source-query/resolve-card-id-source-tables query)))


### PR DESCRIPTION
Simply honor this setting when expanding the query in the middleware.

Addresses #19341 on the backend.

<img width="760" alt="image" src="https://user-images.githubusercontent.com/6377293/146273312-def19b93-b2a5-4672-932c-c57b73f023a0.png">
