### PR TITLE
JWT Login URL configured by user may have URL parameters

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
@@ -1,6 +1,7 @@
 (ns metabase-enterprise.sso.integrations.jwt
   "Implementation of the JWT backend for sso"
   (:require [buddy.sign.jwt :as jwt]
+            [clojure.string :as str]
             [metabase-enterprise.sso.api.interface :as sso.i]
             [metabase-enterprise.sso.integrations.sso-settings :as sso-settings]
             [metabase-enterprise.sso.integrations.sso-utils :as sso-utils]
@@ -10,8 +11,7 @@
             [metabase.server.middleware.session :as mw.session]
             [metabase.server.request.util :as request.u]
             [metabase.util.i18n :refer [trs tru]]
-            [ring.util.response :as resp]
-            [clojure.string :as str])
+            [ring.util.response :as resp])
   (:import java.net.URLEncoder))
 
 (defn fetch-or-create-user!

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
@@ -10,7 +10,8 @@
             [metabase.server.middleware.session :as mw.session]
             [metabase.server.request.util :as request.u]
             [metabase.util.i18n :refer [trs tru]]
-            [ring.util.response :as resp])
+            [ring.util.response :as resp]
+            [clojure.string :as str])
   (:import java.net.URLEncoder))
 
 (defn fetch-or-create-user!
@@ -95,9 +96,10 @@
   (check-jwt-enabled)
   (if jwt
     (login-jwt-user jwt request)
-    (resp/redirect (str (sso-settings/jwt-identity-provider-uri)
-                        (when redirect
-                          (str "?return_to=" redirect))))))
+    (let [idp (sso-settings/jwt-identity-provider-uri)
+          return-to-param (if (str/includes? idp "?") "&return_to=" "?return_to=")]
+      (resp/redirect (str idp (when redirect
+                                (str return-to-param redirect)))))))
 
 (defmethod sso.i/sso-post :jwt
   [req]

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
@@ -77,7 +77,16 @@
                                                          {:request-options {:redirect-strategy :none}}
                                                          :redirect default-redirect-uri)
             redirect-url (get-in result [:headers "Location"])]
-        (is (str/starts-with? redirect-url default-idp-uri))))))
+        (is (str/starts-with? redirect-url default-idp-uri)))))
+  (testing (str "JWT configured with a redirect-uri containing query params, "
+                "a GET request should result in a redirect to the IdP as a correctly formatted URL")
+    (with-jwt-default-setup
+      (mt/with-temporary-setting-values [jwt-identity-provider-uri "http://test.idp.metabase.com/login?some_param=yes"]
+        (let [result       (saml-test/client-full-response :get 302 "/auth/sso"
+                                                           {:request-options {:redirect-strategy :none}}
+                                                           :redirect default-redirect-uri)
+              redirect-url (get-in result [:headers "Location"])]
+          (is (str/includes? redirect-url "&return_to=")))))))
 
 (deftest happy-path-test
   (testing (str "Happy path login, valid JWT, checks to ensure the user was logged in successfully and the redirect to "

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
@@ -79,7 +79,7 @@
             redirect-url (get-in result [:headers "Location"])]
         (is (str/starts-with? redirect-url default-idp-uri)))))
   (testing (str "JWT configured with a redirect-uri containing query params, "
-                "a GET request should result in a redirect to the IdP as a correctly formatted URL")
+                "a GET request should result in a redirect to the IdP as a correctly formatted URL (#13078)")
     (with-jwt-default-setup
       (mt/with-temporary-setting-values [jwt-identity-provider-uri "http://test.idp.metabase.com/login?some_param=yes"]
         (let [result       (saml-test/client-full-response :get 302 "/auth/sso"


### PR DESCRIPTION
Since params may already exist in the login URL, a check is performed to make sure the generated URL
with 'return_to' param formats correctly.

If a param already exists, all subsequent params should have an '&' character.

fixes: #13078