### PR TITLE
Attempt to fix flaky tests in `e2e-tests-admin-ee` by adding retry logic to `restore`

### DIFF
--- a/frontend/test/__support__/e2e/helpers/e2e-setup-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-setup-helpers.js
@@ -6,7 +6,7 @@ export function snapshot(name) {
 
 export function restore(name = "default") {
   cy.log("Restore Data Set");
-  // Restore sometimes throughs a 500 error in e2e tests but it's idemptotent so
+  // Restore sometimes throw a 500 error in e2e tests but it's idempotent so
   // we can retry a couple of times
   for (let i = 0; i < RESTORE_ATTEMPTS; i++) {
     try {

--- a/frontend/test/__support__/e2e/helpers/e2e-setup-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-setup-helpers.js
@@ -1,8 +1,20 @@
+const RESTORE_ATTEMPTS = 4;
+
 export function snapshot(name) {
   cy.request("POST", `/api/testing/snapshot/${name}`);
 }
 
 export function restore(name = "default") {
   cy.log("Restore Data Set");
+  // Restore sometimes throughs a 500 error in e2e tests but it's idemptotent so
+  // we can retry a couple of times
+  for (let i = 0; i < RESTORE_ATTEMPTS; i++) {
+    try {
+      cy.request("POST", `/api/testing/restore/${name}`);
+      // If the restore doesn't throw, we can break out
+      return;
+    } catch {}
+  }
+  // One final request to throw an exception
   cy.request("POST", `/api/testing/restore/${name}`);
 }

--- a/frontend/test/__support__/e2e/helpers/e2e-setup-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-setup-helpers.js
@@ -13,7 +13,10 @@ export function restore(name = "default") {
       cy.request("POST", `/api/testing/restore/${name}`);
       // If the restore doesn't throw, we can break out
       return;
-    } catch {}
+    } catch {
+      // If we fail, wait a second before trying again in case its a race condition
+      cy.wait(1000);
+    }
   }
   // One final request to throw an exception
   cy.request("POST", `/api/testing/restore/${name}`);


### PR DESCRIPTION
[Example of the failure this is trying to fix](https://app.circleci.com/pipelines/github/metabase/metabase/26004/workflows/da5792e4-a917-420f-99dd-0b8f6d7aae55/jobs/1224689):

![image](https://user-images.githubusercontent.com/653604/146321411-67814eeb-10cd-47a5-ae42-e7d7dd4cece4.png)

I added basic retry logic (up to 5 times) with a 1 second delay

I don't know if this will actually fix the issue, but it's an attempt