### PR TITLE
Revert expression editor HelpText vertical offset

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -39,7 +39,6 @@ const HelpText = ({ helpText, width }) =>
         attachment: "top left",
         targetAttachment: "bottom left",
       }}
-      targetOffsetY={-47}
       style={{ width }}
       isOpen
     >


### PR DESCRIPTION
### How to Test

Use a browser window that is no more than 1000 pixels high.

1. Ask a question
2. Custom question
3. Sample Dataset
4. Orders
5. Pick the metric you want to see
6. Custom Expression
7. Type `SumIf` then enter

*Before:* 

When the HelpText is calculated to be rendered above (not below) the editor input, the y offset we recently added works against us. It make the HelpText cover the input.

*After:*

The HelpText will be a little more distant from the editor when rendered below it.
And it will not cover the editor when rendered above it.

Note: It may be possible to make conditional calculations, and pass props just for when a Popover ends up rendered below or above the reference component. Considering the Popover is in the line for modernization, and how complex it is to maintain even now, this PR aims for a simple solution.