### PR TITLE
Release script's website update: pull deps using npm

### DIFF
--- a/bin/release/src/release/update_website.clj
+++ b/bin/release/src/release/update_website.clj
@@ -18,8 +18,8 @@
     (u/step (format "Checkout website git repo %s to %s" website-git-repo dir)
       (u/sh "git" "clone" (format "git@github.com:%s.git" website-git-repo) dir)
       (u/sh {:dir dir} "git" "checkout" website-branch))
-    (u/step "Install yarn dependencies"
-      (u/sh {:dir dir} "yarn" "install"))
+    (u/step "Install npm dependencies"
+      (u/sh {:dir dir} "npm" "ci"))
     (u/step "Run docs script"
       (u/sh {:dir dir} "./script/docs" tag "--latest"))
     (u/step "Commit updated docs"


### PR DESCRIPTION
Don't use yarn here since it will fetch dependencies specified in
package.json. Instead, use npm so that dependencies frozen in
package-lock.json, which metabase.github.io uses, are downloaded instead.
