### PR TITLE
Custom expression type-checking: less strict for some aggregations

### DIFF
--- a/frontend/src/metabase/lib/expressions/config.js
+++ b/frontend/src/metabase/lib/expressions/config.js
@@ -81,7 +81,11 @@ export const MBQL_CLAUSES = {
     type: "aggregation",
     args: ["number"],
   },
-  distinct: { displayName: `Distinct`, type: "aggregation", args: ["number"] },
+  distinct: {
+    displayName: `Distinct`,
+    type: "aggregation",
+    args: ["expression"],
+  },
   stddev: {
     displayName: `StandardDeviation`,
     type: "aggregation",
@@ -89,8 +93,8 @@ export const MBQL_CLAUSES = {
     requiresFeature: "standard-deviation-aggregations",
   },
   avg: { displayName: `Average`, type: "aggregation", args: ["number"] },
-  min: { displayName: `Min`, type: "aggregation", args: ["number"] },
-  max: { displayName: `Max`, type: "aggregation", args: ["number"] },
+  min: { displayName: `Min`, type: "aggregation", args: ["expression"] },
+  max: { displayName: `Max`, type: "aggregation", args: ["expression"] },
   share: { displayName: `Share`, type: "aggregation", args: ["boolean"] },
   "count-where": {
     displayName: `CountIf`,

--- a/frontend/test/metabase/lib/expressions/resolver.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/resolver.unit.spec.js
@@ -181,6 +181,13 @@ describe("metabase/lib/expressions/resolve", () => {
       // PERCENTILE(A, 0.5)
       expect(() => aggregation(["percentile", A, 0.5])).not.toThrow();
     });
+
+    it("should handle Distinct/Min/Max aggregating over non-numbers", () => {
+      // DISTINCT(COALESCE("F")) also for MIN and MAX
+      expect(() => aggregation(["distinct", ["coalesce", "F"]]).not.toThrow());
+      expect(() => aggregation(["min", ["coalesce", "F"]]).not.toThrow());
+      expect(() => aggregation(["max", ["coalesce", "F"]]).not.toThrow());
+    });
   });
 
   describe("for CASE expressions", () => {


### PR DESCRIPTION
This is a regression in master after the more accurate type-checker is introduced in PR #19187.

The solution is not to fix the type-checker (it's doing the job as prescribed) but to loosen the type definition for some aggregation functions.

To verify:

1. Ask a question, Custom question
2. Sample Dataset, People table
3. Summarize, Custom Expression, type `Distinct(Coalesce([Email], "XYZ"))`

**Before this PR**

The custom aggregation is rejected incorrectly.

![image](https://user-images.githubusercontent.com/7288/146453802-8c252796-248f-49db-9e71-c61f8b69a9ce.png)

**After this PR**

The aggregation is treated as valid, just like the behavior in v41 or earlier.

![image](https://user-images.githubusercontent.com/7288/146453651-adaa10a8-c464-4ff3-884d-533b199b603d.png)