### PR TITLE
Fix file upload of secret values

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1209,8 +1209,8 @@ workflows:
             MB_ORACLE_SSL_TEST_SSL=true
             MB_ORACLE_SSL_TEST_PORT=2484
             MB_ORACLE_SSL_TEST_SSL_USE_TRUSTSTORE=true
-            MB_ORACLE_SSL_TEST_SSL_TRUSTSTORE_VALUE="$(base64 /home/circleci/metabase/metabase/resources/certificates/rds_root_ca_truststore.jks)"
-            MB_ORACLE_SSL_TEST_SSL_TRUSTSTORE_OPTIONS=uploaded
+            MB_ORACLE_SSL_TEST_SSL_TRUSTSTORE_PATH=/home/circleci/metabase/metabase/resources/certificates/rds_root_ca_truststore.jks
+            MB_ORACLE_SSL_TEST_SSL_TRUSTSTORE_OPTIONS=local
             MB_ORACLE_SSL_TEST_SSL_TRUSTSTORE_PASSWORD_VALUE=metabase
 
       - test-driver:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1209,7 +1209,7 @@ workflows:
             MB_ORACLE_SSL_TEST_SSL=true
             MB_ORACLE_SSL_TEST_PORT=2484
             MB_ORACLE_SSL_TEST_SSL_USE_TRUSTSTORE=true
-            MB_ORACLE_SSL_TEST_SSL_TRUSTSTORE_VALUE=$(base64 /home/circleci/metabase/metabase/resources/certificates/rds_root_ca_truststore.jks)
+            MB_ORACLE_SSL_TEST_SSL_TRUSTSTORE_VALUE="$(base64 /home/circleci/metabase/metabase/resources/certificates/rds_root_ca_truststore.jks)"
             MB_ORACLE_SSL_TEST_SSL_TRUSTSTORE_OPTIONS=uploaded
             MB_ORACLE_SSL_TEST_SSL_TRUSTSTORE_PASSWORD_VALUE=metabase
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1204,15 +1204,12 @@ workflows:
             - run:
                 name: Ensure truststore file
                 command: ls /home/circleci/metabase/metabase/resources/certificates/rds_root_ca_truststore.jks
-            - run:
-                name: Export base64 encoded truststore to env var
-                command: >-
-                  export MB_ORACLE_SSL_TEST_SSL_TRUSTSTORE_VALUE=$(base64 /home/circleci/metabase/metabase/resources/certificates/rds_root_ca_truststore.jks)
           driver: oracle
           extra-env: >-
             MB_ORACLE_SSL_TEST_SSL=true
             MB_ORACLE_SSL_TEST_PORT=2484
             MB_ORACLE_SSL_TEST_SSL_USE_TRUSTSTORE=true
+            MB_ORACLE_SSL_TEST_SSL_TRUSTSTORE_VALUE=$(base64 /home/circleci/metabase/metabase/resources/certificates/rds_root_ca_truststore.jks)
             MB_ORACLE_SSL_TEST_SSL_TRUSTSTORE_OPTIONS=uploaded
             MB_ORACLE_SSL_TEST_SSL_TRUSTSTORE_PASSWORD_VALUE=metabase
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1207,7 +1207,7 @@ workflows:
             - run:
                 name: Export base64 encoded truststore to env var
                 command: >-
-                  export MB_ORACLE_SSL_TEST_SSL_TRUSTSTORE_VALUE=$(base64 /home/circleci/metabase/metabase/resources/certificates/rds_root_ca_truststore.jks
+                  export MB_ORACLE_SSL_TEST_SSL_TRUSTSTORE_VALUE=$(base64 /home/circleci/metabase/metabase/resources/certificates/rds_root_ca_truststore.jks)
           driver: oracle
           extra-env: >-
             MB_ORACLE_SSL_TEST_SSL=true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1204,13 +1204,16 @@ workflows:
             - run:
                 name: Ensure truststore file
                 command: ls /home/circleci/metabase/metabase/resources/certificates/cacerts_with_RDS_root_ca.jks
+            - run:
+                name: Export base64 encoded truststore to env var
+                command: >-
+                  MB_ORACLE_SSL_TEST_SSL_TRUSTSTORE_VALUE=$(base64 /home/circleci/metabase/metabase/resources/certificates/cacerts_with_RDS_root_ca.jks)
           driver: oracle
           extra-env: >-
             MB_ORACLE_SSL_TEST_SSL=true
             MB_ORACLE_SSL_TEST_PORT=2484
             MB_ORACLE_SSL_TEST_SSL_USE_TRUSTSTORE=true
             MB_ORACLE_SSL_TEST_SSL_TRUSTSTORE_OPTIONS=uploaded
-            MB_ORACLE_SSL_TEST_SSL_TRUSTSTORE_VALUE=$(base64 /home/circleci/metabase/metabase/resources/certificates/cacerts_with_RDS_root_ca.jks)
             MB_ORACLE_SSL_TEST_SSL_TRUSTSTORE_PASSWORD_VALUE=metabase
 
       - test-driver:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1203,11 +1203,11 @@ workflows:
                 dest: ojdbc8.jar
             - run:
                 name: Ensure truststore file
-                command: ls /home/circleci/metabase/metabase/resources/certificates/cacerts_with_RDS_root_ca.jks
+                command: ls /home/circleci/metabase/metabase/resources/certificates/rds_root_ca_truststore.jks
             - run:
                 name: Export base64 encoded truststore to env var
                 command: >-
-                  MB_ORACLE_SSL_TEST_SSL_TRUSTSTORE_VALUE=$(base64 /home/circleci/metabase/metabase/resources/certificates/cacerts_with_RDS_root_ca.jks)
+                  export MB_ORACLE_SSL_TEST_SSL_TRUSTSTORE_VALUE=$(base64 /home/circleci/metabase/metabase/resources/certificates/rds_root_ca_truststore.jks
           driver: oracle
           extra-env: >-
             MB_ORACLE_SSL_TEST_SSL=true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1209,7 +1209,8 @@ workflows:
             MB_ORACLE_SSL_TEST_SSL=true
             MB_ORACLE_SSL_TEST_PORT=2484
             MB_ORACLE_SSL_TEST_SSL_USE_TRUSTSTORE=true
-            MB_ORACLE_SSL_TEST_SSL_TRUSTSTORE_PATH=/home/circleci/metabase/metabase/resources/certificates/cacerts_with_RDS_root_ca.jks
+            MB_ORACLE_SSL_TEST_SSL_TRUSTSTORE_OPTIONS=uploaded
+            MB_ORACLE_SSL_TEST_SSL_TRUSTSTORE_VALUE=$(base64 /home/circleci/metabase/metabase/resources/certificates/cacerts_with_RDS_root_ca.jks)
             MB_ORACLE_SSL_TEST_SSL_TRUSTSTORE_PASSWORD_VALUE=metabase
 
       - test-driver:

--- a/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
+++ b/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
@@ -29,7 +29,8 @@
             [metabase.util :as u]
             [metabase.util.honeysql-extensions :as hx]
             [toucan.db :as db]
-            [toucan.util.test :as tt]))
+            [toucan.util.test :as tt])
+  (:import java.util.Base64))
 
 
 (deftest connection-details->spec-test
@@ -310,34 +311,47 @@
       ;; swap out :oracle env vars with any :oracle-ssl ones that were defined
       (mt/with-env-keys-renamed-by #(str/replace-first % "mb-oracle-ssl-test" "mb-oracle-test")
         ;; need to get a fresh instance of details to pick up env key changes
-        (println "env in ssl test: " (pr-str env/env))
-        (let [details      (->> (#'oracle.tx/connection-details)
-                                (driver.u/db-details-client->server :oracle))
+        (let [ssl-details  (#'oracle.tx/connection-details)
               orig-user-id api/*current-user-id*]
           (testing "Oracle can-connect? with SSL connection"
-            (is (driver/can-connect? :oracle details)))
+            (is (driver/can-connect? :oracle ssl-details)))
           (testing "Sync works with SSL connection"
             (binding [metabase.sync.util/*log-exceptions-and-continue?* false
                       api/*current-user-id* (mt/user->id :crowberto)]
-              (mt/with-temp Database [database {:engine :oracle,
-                                                :name (format "SSL connection version of %d" (mt/id)),
-                                                :details details}]
-                (mt/with-db database
-                  (sync/sync-database! database {:scan :schema})
-                  ;; should be four tables from test-data
-                  (is (= 4 (db/count Table :db_id (u/the-id database) :name [:like "test_data%"])))
-                  (binding [api/*current-user-id* orig-user-id ; restore original user-id to avoid perm errors
-                            ;; we also need to rebind this dynamic var so that we can pretend "test-data" is
-                            ;; actually the name of the database, and not some variation on the :name specified
-                            ;; above, so that the table names resolve correctly in the generated query we can't
-                            ;; simply call this new temp database "test-data", because then it will no longer be
-                            ;; unique compared to the "real" "test-data" DB associated with the non-SSL (default)
-                            ;; database, and the logic within metabase.test.data.interface/metabase-instance would
-                            ;; be wrong (since we would end up with two :oracle Databases both named "test-data",
-                            ;; violating its assumptions, in case the app DB ends up in an inconsistent state)
-                            tx/*database-name-override* "test-data"]
-                    (testing "Execute query with SSL connection"
-                      (qp-test.order-by-test/order-by-test)))))))))
+              (doseq [[details variant] [[ssl-details "SSL with Truststore Path"]
+                                         ;; in the file upload scenario, the truststore bytes are base64 encoded
+                                         ;; to the -value suffix property, and the -path suffix property is removed
+                                         [(-> (assoc
+                                               ssl-details
+                                               :ssl-truststore-value
+                                               (.encodeToString (Base64/getEncoder)
+                                                                (mt/file->bytes (:ssl-truststore-path ssl-details)))
+                                               :ssl-truststore-options
+                                               "uploaded")
+                                              (dissoc :ssl-truststore-path))
+                                          "SSL with Truststore Upload"]]]
+                (testing (str " " variant)
+                  (mt/with-temp Database [database {:engine  :oracle,
+                                                    :name    (format (str variant " version of %d") (mt/id)),
+                                                    :details (->> details
+                                                                  (driver.u/db-details-client->server :oracle))}]
+                    (mt/with-db database
+                      (testing " can sync correctly"
+                        (sync/sync-database! database {:scan :schema})
+                        ;; should be four tables from test-data
+                        (is (= 4 (db/count Table :db_id (u/the-id database) :name [:like "test_data%"])))
+                        (binding [api/*current-user-id* orig-user-id ; restore original user-id to avoid perm errors
+                                  ;; we also need to rebind this dynamic var so that we can pretend "test-data" is
+                                  ;; actually the name of the database, and not some variation on the :name specified
+                                  ;; above, so that the table names resolve correctly in the generated query we can't
+                                  ;; simply call this new temp database "test-data", because then it will no longer be
+                                  ;; unique compared to the "real" "test-data" DB associated with the non-SSL (default)
+                                  ;; database, and the logic within metabase.test.data.interface/metabase-instance would
+                                  ;; be wrong (since we would end up with two :oracle Databases both named "test-data",
+                                  ;; violating its assumptions, in case the app DB ends up in an inconsistent state)
+                                  tx/*database-name-override* "test-data"]
+                          (testing " and execute a query correctly"
+                            (qp-test.order-by-test/order-by-test))))))))))))
       (println (u/format-color 'yellow
                                "Skipping %s because %s env var is not set"
                                "oracle-connect-with-ssl-test"

--- a/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
+++ b/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
@@ -3,7 +3,6 @@
   (:require [clojure.java.jdbc :as jdbc]
             [clojure.string :as str]
             [clojure.test :refer :all]
-            [environ.core :as env]
             [honeysql.core :as hsql]
             [metabase.api.common :as api]
             [metabase.driver :as driver]
@@ -310,7 +309,6 @@
       ;; swap out :oracle env vars with any :oracle-ssl ones that were defined
       (mt/with-env-keys-renamed-by #(str/replace-first % "mb-oracle-ssl-test" "mb-oracle-test")
         ;; need to get a fresh instance of details to pick up env key changes
-        (println "env: " (pr-str env/env))
         (let [details      (->> (#'oracle.tx/connection-details)
                                 (driver.u/db-details-client->server :oracle))
               orig-user-id api/*current-user-id*]

--- a/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
+++ b/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
@@ -3,6 +3,7 @@
   (:require [clojure.java.jdbc :as jdbc]
             [clojure.string :as str]
             [clojure.test :refer :all]
+            [environ.core :as env]
             [honeysql.core :as hsql]
             [metabase.api.common :as api]
             [metabase.driver :as driver]
@@ -29,6 +30,7 @@
             [metabase.util.honeysql-extensions :as hx]
             [toucan.db :as db]
             [toucan.util.test :as tt]))
+
 
 (deftest connection-details->spec-test
   (doseq [[^String message expected-spec details]
@@ -308,6 +310,7 @@
       ;; swap out :oracle env vars with any :oracle-ssl ones that were defined
       (mt/with-env-keys-renamed-by #(str/replace-first % "mb-oracle-ssl-test" "mb-oracle-test")
         ;; need to get a fresh instance of details to pick up env key changes
+        (println "env: " (pr-str env/env))
         (let [details      (->> (#'oracle.tx/connection-details)
                                 (driver.u/db-details-client->server :oracle))
               orig-user-id api/*current-user-id*]

--- a/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
+++ b/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
@@ -3,6 +3,7 @@
   (:require [clojure.java.jdbc :as jdbc]
             [clojure.string :as str]
             [clojure.test :refer :all]
+            [environ.core :as env]
             [honeysql.core :as hsql]
             [metabase.api.common :as api]
             [metabase.driver :as driver]
@@ -309,6 +310,7 @@
       ;; swap out :oracle env vars with any :oracle-ssl ones that were defined
       (mt/with-env-keys-renamed-by #(str/replace-first % "mb-oracle-ssl-test" "mb-oracle-test")
         ;; need to get a fresh instance of details to pick up env key changes
+        (println "env in ssl test: " (pr-str env/env))
         (let [details      (->> (#'oracle.tx/connection-details)
                                 (driver.u/db-details-client->server :oracle))
               orig-user-id api/*current-user-id*]

--- a/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
+++ b/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
@@ -3,7 +3,6 @@
   (:require [clojure.java.jdbc :as jdbc]
             [clojure.string :as str]
             [clojure.test :refer :all]
-            [environ.core :as env]
             [honeysql.core :as hsql]
             [metabase.api.common :as api]
             [metabase.driver :as driver]
@@ -31,7 +30,6 @@
             [toucan.db :as db]
             [toucan.util.test :as tt])
   (:import java.util.Base64))
-
 
 (deftest connection-details->spec-test
   (doseq [[^String message expected-spec details]

--- a/modules/drivers/oracle/test/metabase/test/data/oracle.clj
+++ b/modules/drivers/oracle/test/metabase/test/data/oracle.clj
@@ -46,14 +46,10 @@
         ssl-keys [:ssl-use-truststore :ssl-truststore-options :ssl-truststore-path :ssl-truststore-value
                   :ssl-truststore-password-value
                   :ssl-use-keystore :ssl-use-keystore-options :ssl-keystore-path :ssl-keystore-value
-                  :ssl-keystore-password-value]
-        with-ssl (merge details*
-                   (m/filter-vals some?
-                        (zipmap ssl-keys (map #(tx/db-test-env-var :oracle % nil) ssl-keys))))]
-    ;; test environments are setting properties as if from the client perspective (i.e. with keys matching those
-    ;; sent by the client when saving DB details), therefore these values need to pass through the translation layer
-    ;; to turn back into the server side props
-    (driver.u/db-details-client->server :oracle with-ssl)))
+                  :ssl-keystore-password-value]]
+    (merge details*
+      (m/filter-vals some?
+        (zipmap ssl-keys (map #(tx/db-test-env-var :oracle % nil) ssl-keys))))))
 
 (defmethod tx/dbdef->connection-details :oracle [& _]
   (let [conn-details (connection-details)]

--- a/modules/drivers/oracle/test/metabase/test/data/oracle.clj
+++ b/modules/drivers/oracle/test/metabase/test/data/oracle.clj
@@ -7,7 +7,6 @@
             [metabase.db :as mdb]
             [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
             [metabase.driver.sql-jdbc.sync :as sql-jdbc.sync]
-            [metabase.driver.util :as driver.u]
             [metabase.models :refer [Database Table]]
             [metabase.test.data.impl :as data.impl]
             [metabase.test.data.interface :as tx]

--- a/modules/drivers/oracle/test/metabase/test/data/oracle.clj
+++ b/modules/drivers/oracle/test/metabase/test/data/oracle.clj
@@ -42,8 +42,10 @@
                   :password (tx/db-test-env-var-or-throw :oracle :password)
                   :sid      (tx/db-test-env-var-or-throw :oracle :sid)
                   :ssl      (tx/db-test-env-var :oracle :ssl false)}
-        ssl-keys [:ssl-use-truststore :ssl-truststore-path :ssl-truststore-value :ssl-truststore-password-value
-                  :ssl-use-keystore :ssl-keystore-path :ssl-keystore-value :ssl-keystore-password-value]]
+        ssl-keys [:ssl-use-truststore :ssl-truststore-options :ssl-truststore-path :ssl-truststore-value
+                  :ssl-truststore-password-value
+                  :ssl-use-keystore :ssl-use-keystore-options :ssl-keystore-path :ssl-keystore-value
+                  :ssl-keystore-password-value]]
     (merge details*
            (m/filter-vals some?
                           (zipmap ssl-keys (map #(tx/db-test-env-var :oracle % nil) ssl-keys))))))

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -8536,7 +8536,7 @@ databaseChangeLog:
                     deferrable: false
                     foreignKeyName: fk_secret_ref_user_id
                     initiallyDeferred: false
-                    nullable: false
+                    nullable: true
                     references: core_user(id)
                   name: creator_id
                   remarks: User ID who created this secret instance

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -227,26 +227,48 @@
   [driver db-details]
   (when db-details
     (assert (some? driver))
-    (let [secret-names->props (reduce (fn [acc prop]
-                                        (if (= "secret" (:type prop))
-                                          (assoc acc (:name prop) prop)
-                                          acc))
-                                      {}
-                                      (driver/connection-properties driver))]
+    (let [secret-names->props    (reduce (fn [acc prop]
+                                           (if (= "secret" (:type prop))
+                                             (assoc acc (:name prop) prop)
+                                             acc))
+                                         {}
+                                         (driver/connection-properties driver))
+
+          secrets-server->client (reduce (fn [acc prop]
+                                           (assoc acc (keyword (:name prop)) prop))
+                                   {}
+                                   (connection-props-server->client driver (vals secret-names->props)))]
       (reduce-kv (fn [acc prop-name prop]
-                   (let [subprop (fn [suffix]
-                                   (keyword (str prop-name suffix)))
-                         path-kw (subprop "-path")
-                         val-kw  (subprop "-value")
-                         path    (path-kw acc)
-                         treat   (:treat-before-posting prop)
-                         value   (let [^String v (val-kw acc)]
-                                   (case treat
-                                     "base64" (.decode (Base64/getDecoder) v)
-                                     v))]
+                   (let [subprop    (fn [suffix]
+                                      (keyword (str prop-name suffix)))
+                         path-kw    (subprop "-path")
+                         val-kw     (subprop "-value")
+                         source-kw  (subprop "-source")
+                         options-kw (subprop "-options")
+                         path       (path-kw acc)
+                         get-treat  (fn []
+                                      (let [options (options-kw acc)]
+                                        (when (= "uploaded" options)
+                                          ;; the :treat-before-posting, if defined, would be applied to the client
+                                          ;; version of the -value property (the :type "textFile" one)
+                                          (let [textfile-prop (val-kw secrets-server->client)]
+                                            (:treat-before-posting textfile-prop)))))
+                         value      (let [^String v (val-kw acc)]
+                                      (case (get-treat)
+                                        "base64" (.decode (Base64/getDecoder) v)
+                                        v))]
                      (cond-> (assoc acc val-kw value)
-                       path  (dissoc val-kw) ; local path specified; remove the -value entry, if it exists
-                       value (dissoc path-kw) ; value specified; remove the -path entry, if it exists
+                       ;; keywords here are associated to nil, rather than being dissoced, because they will be merged
+                       ;; with the existing db-details blob to produce the final details
+                       ;; therefore, if we want a changed setting to take effect (i.e. switching from a file path to an
+                       ;; upload), then we need to ensure the nil value is merged, rather than the stale value from the
+                       ;; app DB being picked
+                       path  (-> ; from outer cond->
+                               (assoc val-kw nil) ; local path specified; remove the -value entry, if it exists
+                               (assoc source-kw :file-path)) ; and set the :source to :file-path
+                       value (-> ; from outer cond->
+                               (assoc path-kw nil) ; value specified; remove the -path entry, if it exists
+                               (assoc source-kw nil)) ; and remove the :source mapping
                        true  (dissoc (subprop "-options")))))
                  db-details
                  secret-names->props))))

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -72,7 +72,9 @@
 
 (defn- database->driver* [database-or-id]
   (or
-   (:engine database-or-id)
+   (when-let [engine (:engine database-or-id)]
+     ;; ensure we get the engine as a keyword (sometimes it's a String)
+     (keyword engine))
    (db/select-one-field :engine 'Database, :id (u/the-id database-or-id))))
 
 (def ^{:arglists '([database-or-id])} database->driver

--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -175,6 +175,7 @@
   call-with-paused-query
   discard-setting-changes
   doall-recursive
+  file->bytes
   is-uuid-string?
   obj->json->obj
   postwalk-pred

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -33,7 +33,8 @@
             [toucan.db :as db]
             [toucan.models :as t.models]
             [toucan.util.test :as tt])
-  (:import java.net.ServerSocket
+  (:import [java.io File FileInputStream]
+           java.net.ServerSocket
            java.nio.charset.StandardCharsets
            java.util.concurrent.TimeoutException
            java.util.Locale
@@ -1059,3 +1060,12 @@
 
     :else
     actual))
+
+(defn file->bytes
+  "Reads a file at `file-path` completely into a byte array, returning that array."
+  [file-path]
+  (let [f   (File. file-path)
+        ary (byte-array (.length f))]
+    (with-open [is (FileInputStream. f)]
+      (.read is ary)
+      ary)))


### PR DESCRIPTION
Fix logic in db-details-client->server to properly consider the -options suffixed connection property from the client version, to determine the treatment to be applied (i.e. base64 decode)

Change logic in db-details-client->server to assoc nil rather than dissoc unused keywords (so they override the saved db details on merge)

Updating CircleCI configuration to use base64 encoded version of keystore (to simulate client upload)
