### PR TITLE
Custom expression: allow a leading decimal point

### DIFF
--- a/frontend/src/metabase/lib/expressions/tokenizer.js
+++ b/frontend/src/metabase/lib/expressions/tokenizer.js
@@ -129,9 +129,6 @@ export function tokenize(expression) {
       }
       ++index;
     }
-    if (index <= start) {
-      return null;
-    }
     const dot = source[index];
     if (dot === ".") {
       ++index;
@@ -142,6 +139,13 @@ export function tokenize(expression) {
         }
         ++index;
       }
+      // just a dot?
+      if (index - start <= 1) {
+        index = start;
+        return null;
+      }
+    } else if (index <= start) {
+      return null;
     }
     const exp = source[index];
     if (exp === "e" || exp === "E") {

--- a/frontend/test/metabase/lib/expressions/tokenizer.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/tokenizer.unit.spec.js
@@ -32,6 +32,9 @@ describe("metabase/lib/expressions/tokenizer", () => {
   });
 
   it("should tokenize numeric literals", () => {
+    expect(types(".0")).toEqual([T.Number]);
+    expect(types(".5")).toEqual([T.Number]);
+    expect(types("9.")).toEqual([T.Number]);
     expect(types("42")).toEqual([T.Number]);
     expect(types("0")).toEqual([T.Number]);
     expect(types("123456789")).toEqual([T.Number]);
@@ -47,6 +50,10 @@ describe("metabase/lib/expressions/tokenizer", () => {
     expect(errors("2e")[0].message).toEqual("Missing exponent");
     expect(errors("3e+")[0].message).toEqual("Missing exponent");
     expect(errors("4E-")[0].message).toEqual("Missing exponent");
+  });
+
+  it("should catch a lone decimal point", () => {
+    expect(errors(".")[0].message).toEqual("Invalid character: .");
   });
 
   it("should tokenize string literals", () => {

--- a/frontend/test/metabase/scenarios/custom-column/custom-column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/custom-column.cy.spec.js
@@ -395,14 +395,6 @@ describe("scenarios > question > custom column", () => {
     cy.get("[contenteditable='true']").contains("Sum([MyCC [2021]])");
   });
 
-  it.skip("should handle floating point numbers with '0' omitted (metabase#15741)", () => {
-    openOrdersTable({ mode: "notebook" });
-    cy.findByText("Custom column").click();
-    enterCustomColumnDetails({ formula: ".5 * [Discount]", name: "Foo" });
-    cy.findByText("Unknown Field: .5").should("not.exist");
-    cy.button("Done").should("not.be.disabled");
-  });
-
   it.skip("should work with `isNull` function (metabase#15922)", () => {
     openOrdersTable({ mode: "notebook" });
     cy.findByText("Custom column").click();


### PR DESCRIPTION
Steps to verify:

1. Ask a question, Custom question
2. Sample Dataset, Orders table
3. Custom column, enter `.5 * [Discount]`

**Before this PR**

`.5` is rejected.

![image](https://user-images.githubusercontent.com/7288/146594854-34414ed2-def8-4666-879c-7e3dea9de589.png)

**After this PR**

`.5` is correctly accepted as a valid number.

![image](https://user-images.githubusercontent.com/7288/146594961-e22d3cca-1945-421c-ba64-a35437503828.png)