### PR TITLE
tweak driver deprecation banner BannerCloseIcon size and add hover

### DIFF
--- a/frontend/src/metabase/admin/databases/components/DriverDeprecationBanner/DriverDeprecationBanner.styled.jsx
+++ b/frontend/src/metabase/admin/databases/components/DriverDeprecationBanner/DriverDeprecationBanner.styled.jsx
@@ -29,7 +29,8 @@ export const BannerWarningIcon = styled(Icon)`
 
 export const BannerCloseIcon = styled(Icon)`
   color: ${color("bg-dark")};
-  width: 1.5rem;
-  height: 1.5rem;
   cursor: pointer;
+  &:hover {
+    color: ${color("admin-navbar")};
+  }
 `;


### PR DESCRIPTION
A quick tweak to the close icon sizing in the driver deprecation. Also adds a hover state to the icon.

Before:
![Screen Shot 2021-12-17 at 3 27 39 PM](https://user-images.githubusercontent.com/5248953/146604139-3ddf9db0-7343-43ab-8ade-39ecc10f3235.png)
After

![Screen Shot 2021-12-17 at 3 27 25 PM](https://user-images.githubusercontent.com/5248953/146604141-0afd0a3c-b660-4150-b80a-b38c18932a66.png)
: