### PR TITLE
Set the H2 lock timeout to 120 seconds in the testing restore API to workaround `e2e-tests-admin-ee` failures

### DIFF
--- a/src/metabase/api/testing.clj
+++ b/src/metabase/api/testing.clj
@@ -24,6 +24,7 @@
     (api/check-404 (.exists (java.io.File. path)))
     (with-open [conn (jdbc/get-connection (db/connection))]
       (let [conn-spec {:connection conn}]
+        (jdbc/execute! conn-spec ["SET LOCK_TIMEOUT 120000"])
         (jdbc/execute! conn-spec ["DROP ALL OBJECTS"])
         (jdbc/execute! conn-spec ["RUNSCRIPT FROM ?" path]))))
   (cache/restore-cache!)


### PR DESCRIPTION
According to the [h2 docs](https://h2database.com/html/commands.html#set_lock_timeout) the default timeout is 1 second but it looks like some unrelated operation is locking the table for about a minute. This breaks the `restore` testing API which fails on random tests in `beforeEach` with the following backend error:

![image](https://user-images.githubusercontent.com/653604/146607976-f4b01fae-7306-4931-9e41-82439acce157.png)

This is a naive workaround to increase the lock timeout to 120 seconds to get the CI into a more reliable state.