### PR TITLE
Revert "Attempt to fix flaky tests in `e2e-tests-admin-ee` by adding retry logic to `restore`"

### DIFF
--- a/frontend/test/__support__/e2e/helpers/e2e-setup-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-setup-helpers.js
@@ -1,23 +1,8 @@
-const RESTORE_ATTEMPTS = 4;
-
 export function snapshot(name) {
   cy.request("POST", `/api/testing/snapshot/${name}`);
 }
 
 export function restore(name = "default") {
   cy.log("Restore Data Set");
-  // Restore sometimes throw a 500 error in e2e tests but it's idempotent so
-  // we can retry a couple of times
-  for (let i = 0; i < RESTORE_ATTEMPTS; i++) {
-    try {
-      cy.request("POST", `/api/testing/restore/${name}`);
-      // If the restore doesn't throw, we can break out
-      return;
-    } catch {
-      // If we fail, wait a second before trying again in case its a race condition
-      cy.wait(1000);
-    }
-  }
-  // One final request to throw an exception
   cy.request("POST", `/api/testing/restore/${name}`);
 }


### PR DESCRIPTION
Reverts metabase/metabase#19386

This fix didn't work but led me to the actual error in the logs and a minimum value for the timeout. See metabase/metabase#19412 for backend fix