### PR TITLE
Custom expression editor: restore the color of string literals

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/expressions.css
+++ b/frontend/src/metabase/query_builder/components/expressions/expressions.css
@@ -16,6 +16,10 @@
   color: var(--color-brand);
 }
 
+.expression-editor-textfield .ace-tm .ace_string {
+  color: var(--color-accent5);
+}
+
 .ace_cursor {
   border-left-width: 1px;
 }


### PR DESCRIPTION
This is taken from PR #19345 but just for the string color.

Just like in v41 and earlier, string literals should be colored with "accent5".

1. Ask a question, Custom question
2. Sample Dataset, Orders table
3. Filter, Custom Expression, type `[Product → Category] = "Gadget"`

**Before this PR**

String literal `Gadget` is green.

![image](https://user-images.githubusercontent.com/7288/146616655-0b8018cc-dbd2-433e-8895-6da91085f83f.png)

**After this PR**

String literal `Gadget` is colored like in v41.

![image](https://user-images.githubusercontent.com/7288/146616757-8267a183-01b8-4d56-920a-e5de1ec0482d.png)
