### PR TITLE
Allow SCOPE type (for Min/Max) to aggregate over category and entity

### DIFF
--- a/frontend/src/metabase/lib/schema_metadata.js
+++ b/frontend/src/metabase/lib/schema_metadata.js
@@ -73,8 +73,8 @@ const TYPES = {
     exclude: [ENTITY, LOCATION, TEMPORAL],
   },
   [SCOPE]: {
-    include: [NUMBER, TEMPORAL],
-    exclude: [ENTITY, LOCATION],
+    include: [NUMBER, TEMPORAL, CATEGORY, ENTITY],
+    exclude: [LOCATION],
   },
   [CATEGORY]: {
     base: [TYPE.Boolean],

--- a/frontend/test/metabase/scenarios/question/reproductions/18207-string-min-max.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/18207-string-min-max.cy.spec.js
@@ -1,0 +1,97 @@
+import {
+  enterCustomColumnDetails,
+  popover,
+  restore,
+  visualize,
+} from "__support__/e2e/cypress";
+
+describe("issue 18207", () => {
+  beforeEach(() => {
+    cy.intercept("POST", "/api/dataset").as("dataset");
+
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should be possible to use MIN on a string column (metabase#18207)", () => {
+    cy.visit("/question/new");
+    cy.contains("Custom question").click();
+    cy.contains("Sample Dataset").click();
+    cy.contains("Products").click();
+
+    cy.contains("Pick the metric").click();
+
+    cy.contains("Minimum of").click();
+    cy.findByText("Price");
+    cy.findByText("Rating");
+    cy.contains("Category").click();
+
+    visualize();
+
+    cy.findByText("Doohickey");
+  });
+
+  it("should be possible to use MAX on a string column (metabase#18207)", () => {
+    cy.visit("/question/new");
+    cy.contains("Custom question").click();
+    cy.contains("Sample Dataset").click();
+    cy.contains("Products").click();
+
+    cy.contains("Pick the metric").click();
+
+    cy.contains("Maximum of").click();
+    cy.findByText("Price");
+    cy.findByText("Rating");
+    cy.contains("Category").click();
+
+    visualize();
+
+    cy.findByText("Widget");
+  });
+
+  it("should be not possible to use AVERAGE on a string column (metabase#18207)", () => {
+    cy.visit("/question/new");
+    cy.contains("Custom question").click();
+    cy.contains("Sample Dataset").click();
+    cy.contains("Products").click();
+
+    cy.contains("Pick the metric").click();
+
+    cy.contains("Average of").click();
+    cy.findByText("Price");
+    cy.findByText("Rating");
+    cy.findByText("Category").should("not.exist");
+  });
+
+  it("should be possible to group by a string expression (metabase#18207)", () => {
+    cy.visit("/question/new");
+    cy.contains("Custom question").click();
+    cy.contains("Sample Dataset").click();
+    cy.contains("Products").click();
+
+    cy.contains("Pick the metric").click();
+    popover()
+      .contains("Custom Expression")
+      .click();
+    popover().within(() => {
+      enterCustomColumnDetails({ formula: "Max([Vendor])" });
+      cy.findByPlaceholderText("Name (required)").type("LastVendor");
+      cy.findByText("Done").click();
+    });
+
+    cy.contains("Pick a column to group by").click();
+    popover()
+      .contains("Category")
+      .click();
+
+    visualize();
+
+    // Why is it not a table?
+    cy.contains("Settings").click();
+    cy.contains("Bar options").click();
+    cy.get("[data-testid=Table-button]").click();
+    cy.contains("Done").click();
+
+    cy.findByText("Zemlak-Wiegand");
+  });
+});


### PR DESCRIPTION
This is a follow-up to PR #18135.

To verify:

1. Ask a question, Custom question
2. Sample Dataset, Products table
3. Summary, _Maximum of ..._ (should also with _Minimum of..._)

**Before this PR**

You can only choose a number or a temporal.

![image](https://user-images.githubusercontent.com/7288/146617941-2493cdf6-fffb-4a16-9c20-5abcebec80c6.png)

**After this PR**

You can also choose a category or an entity.

![image](https://user-images.githubusercontent.com/7288/146617994-2e73d32d-c624-4193-a98b-46af381c62dc.png)
