### PR TITLE
Replace deprecated CircleCI image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ executors:
   tester:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:circleci-java-8-clj-1.10.3.929-07-27-2021-node-browsers
+      - image: metabase/ci:java-11-clj-1.10.1040.12-2021-node-browsers
       - image: maildev/maildev:1.1.0
       - image: metabase/qa-databases:postgres-sample-12
       - image: metabase/qa-databases:mongo-sample-4.0
@@ -25,7 +25,7 @@ executors:
   java-8:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:circleci-java-8-clj-1.10.3.929-07-27-2021-node-browsers
+      - image: metabase/ci:java-8-clj-1.10.1040.12-2021-node-browsers
 
   # Java 11 tests also test Metabase with the at-rest encryption enabled. See
   # https://metabase.com/docs/latest/operations-guide/encrypting-database-details-at-rest.html for an explanation of
@@ -33,19 +33,19 @@ executors:
   java-11:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:circleci-java-11-clj-1.10.3.929-07-27-2021-node-browsers
+      - image: metabase/ci:java-11-clj-1.10.1040.12-2021-node-browsers
         environment:
           MB_ENCRYPTION_SECRET_KEY: Orw0AAyzkO/kPTLJRxiyKoBHXa/d6ZcO+p+gpZO/wSQ=
 
-  java-16:
+  java-17:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:circleci-java-16-clj-1.10.3.929-07-27-2021-node-browsers
+      - image: metabase/ci:java-17-clj-1.10.1040.12-2021-node-browsers
 
   postgres-9-6:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:circleci-java-11-clj-1.10.3.929-07-27-2021-node-browsers
+      - image: metabase/ci:java-11-clj-1.10.1040.12-2021-node-browsers
         environment:
           MB_DB_TYPE: postgres
           MB_DB_PORT: 5432
@@ -61,7 +61,7 @@ executors:
   postgres-latest:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:circleci-java-11-clj-1.10.3.929-07-27-2021-node-browsers
+      - image: metabase/ci:java-11-clj-1.10.1040.12-2021-node-browsers
         environment:
           MB_DB_TYPE: postgres
           MB_DB_PORT: 5432
@@ -78,7 +78,7 @@ executors:
   mysql-5-7:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:circleci-java-11-clj-1.10.3.929-07-27-2021-node-browsers
+      - image: metabase/ci:java-11-clj-1.10.1040.12-2021-node-browsers
         environment:
           MB_DB_TYPE: mysql
           MB_DB_HOST: localhost
@@ -91,7 +91,7 @@ executors:
   mysql-latest:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:circleci-java-11-clj-1.10.3.929-07-27-2021-node-browsers
+      - image: metabase/ci:java-11-clj-1.10.1040.12-2021-node-browsers
         environment:
           MB_DB_TYPE: mysql
           MB_DB_HOST: localhost
@@ -104,7 +104,7 @@ executors:
   mariadb-10-2:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:circleci-java-11-clj-1.10.3.929-07-27-2021-node-browsers
+      - image: metabase/ci:java-11-clj-1.10.1040.12-2021-node-browsers
         environment:
           MB_DB_TYPE: mysql
           MB_DB_HOST: localhost
@@ -117,7 +117,7 @@ executors:
   mariadb-latest:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:circleci-java-11-clj-1.10.3.929-07-27-2021-node-browsers
+      - image: metabase/ci:java-11-clj-1.10.1040.12-2021-node-browsers
         environment:
           MB_DB_TYPE: mysql
           MB_DB_HOST: localhost
@@ -134,19 +134,19 @@ executors:
   mongo-4-0:
      working_directory: /home/circleci/metabase/metabase/
      docker:
-       - image: metabase/ci:circleci-java-11-clj-1.10.3.929-07-27-2021-node-browsers
+       - image: metabase/ci:java-11-clj-1.10.1040.12-2021-node-browsers
        - image: circleci/mongo:4.0
 
   mongo-latest:
      working_directory: /home/circleci/metabase/metabase/
      docker:
-       - image: metabase/ci:circleci-java-11-clj-1.10.3.929-07-27-2021-node-browsers
+       - image: metabase/ci:java-11-clj-1.10.1040.12-2021-node-browsers
        - image: circleci/mongo:latest
 
   presto-186:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:circleci-java-11-clj-1.10.3.929-07-27-2021-node-browsers
+      - image: metabase/ci:java-11-clj-1.10.1040.12-2021-node-browsers
       - image: metabase/presto-mb-ci:0.186
         environment:
           JAVA_TOOL_OPTIONS: "-Xmx2g"
@@ -157,7 +157,7 @@ executors:
   presto-jdbc-env:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:circleci-java-11-clj-1.10.3.929-07-27-2021-node-browsers
+      - image: metabase/ci:java-11-clj-1.10.1040.12-2021-node-browsers
       - image: metabase/presto-mb-ci:latest # version 0.254
         environment:
           JAVA_TOOL_OPTIONS: "-Xmx2g"
@@ -176,20 +176,20 @@ executors:
   sparksql:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:circleci-java-11-clj-1.10.3.929-07-27-2021-node-browsers
+      - image: metabase/ci:java-11-clj-1.10.1040.12-2021-node-browsers
       - image: metabase/spark:3.2.1
     resource_class: large
 
   vertica:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:circleci-java-11-clj-1.10.3.929-07-27-2021-node-browsers
+      - image: metabase/ci:java-11-clj-1.10.1040.12-2021-node-browsers
       - image: sumitchawla/vertica
 
   sqlserver:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:circleci-java-11-clj-1.10.3.929-07-27-2021-node-browsers
+      - image: metabase/ci:java-11-clj-1.10.1040.12-2021-node-browsers
         environment:
           MB_SQLSERVER_TEST_HOST: localhost
           MB_SQLSERVER_TEST_PASSWORD: 'P@ssw0rd'
@@ -203,7 +203,7 @@ executors:
   druid:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:circleci-java-11-clj-1.10.3.929-07-27-2021-node-browsers
+      - image: metabase/ci:java-11-clj-1.10.1040.12-2021-node-browsers
       - image: metabase/druid:0.20.2
         environment:
           CLUSTER_SIZE: nano-quickstart
@@ -1008,7 +1008,7 @@ workflows:
           matrix:
             parameters:
               edition: ["ee", "oss"]
-              java-version: ["java-8", "java-11", "java-16"]
+              java-version: ["java-8", "java-11", "java-17"]
           name: be-tests-<< matrix.java-version >>-<< matrix.edition >>
           requires:
             - be-deps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,12 +11,12 @@ executors:
   builder:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:circleci-java-8-clj-1.10.3.929-07-27-2021-node-browsers
+      - image: metabase/ci:java-11-clj-1.11.0.1100.04-2022-build
 
   tester:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:java-11-clj-1.10.1040.12-2021-node-browsers
+      - image: metabase/ci:java-11-clj-1.11.0.1100.04-2022-node-browsers
       - image: maildev/maildev:1.1.0
       - image: metabase/qa-databases:postgres-sample-12
       - image: metabase/qa-databases:mongo-sample-4.0
@@ -25,7 +25,7 @@ executors:
   java-8:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:java-8-clj-1.10.1040.12-2021-node-browsers
+      - image: metabase/ci:java-8-clj-1.11.0.1100.04-2022-build
 
   # Java 11 tests also test Metabase with the at-rest encryption enabled. See
   # https://metabase.com/docs/latest/operations-guide/encrypting-database-details-at-rest.html for an explanation of
@@ -33,19 +33,19 @@ executors:
   java-11:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:java-11-clj-1.10.1040.12-2021-node-browsers
+      - image: metabase/ci:java-11-clj-1.11.0.1100.04-2022-build
         environment:
           MB_ENCRYPTION_SECRET_KEY: Orw0AAyzkO/kPTLJRxiyKoBHXa/d6ZcO+p+gpZO/wSQ=
 
   java-17:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:java-17-clj-1.10.1040.12-2021-node-browsers
+      - image: metabase/ci:java-17-clj-1.11.0.1100.04-2022-build
 
   postgres-9-6:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:java-11-clj-1.10.1040.12-2021-node-browsers
+      - image: metabase/ci:java-11-clj-1.11.0.1100.04-2022-build
         environment:
           MB_DB_TYPE: postgres
           MB_DB_PORT: 5432
@@ -61,7 +61,7 @@ executors:
   postgres-latest:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:java-11-clj-1.10.1040.12-2021-node-browsers
+      - image: metabase/ci:java-11-clj-1.11.0.1100.04-2022-build
         environment:
           MB_DB_TYPE: postgres
           MB_DB_PORT: 5432
@@ -78,7 +78,7 @@ executors:
   mysql-5-7:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:java-11-clj-1.10.1040.12-2021-node-browsers
+      - image: metabase/ci:java-11-clj-1.11.0.1100.04-2022-build
         environment:
           MB_DB_TYPE: mysql
           MB_DB_HOST: localhost
@@ -91,7 +91,7 @@ executors:
   mysql-latest:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:java-11-clj-1.10.1040.12-2021-node-browsers
+      - image: metabase/ci:java-11-clj-1.11.0.1100.04-2022-build
         environment:
           MB_DB_TYPE: mysql
           MB_DB_HOST: localhost
@@ -104,7 +104,7 @@ executors:
   mariadb-10-2:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:java-11-clj-1.10.1040.12-2021-node-browsers
+      - image: metabase/ci:java-11-clj-1.11.0.1100.04-2022-build
         environment:
           MB_DB_TYPE: mysql
           MB_DB_HOST: localhost
@@ -117,7 +117,7 @@ executors:
   mariadb-latest:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:java-11-clj-1.10.1040.12-2021-node-browsers
+      - image: metabase/ci:java-11-clj-1.11.0.1100.04-2022-build
         environment:
           MB_DB_TYPE: mysql
           MB_DB_HOST: localhost
@@ -134,19 +134,19 @@ executors:
   mongo-4-0:
      working_directory: /home/circleci/metabase/metabase/
      docker:
-       - image: metabase/ci:java-11-clj-1.10.1040.12-2021-node-browsers
+       - image: metabase/ci:java-11-clj-1.11.0.1100.04-2022-build
        - image: circleci/mongo:4.0
 
   mongo-latest:
      working_directory: /home/circleci/metabase/metabase/
      docker:
-       - image: metabase/ci:java-11-clj-1.10.1040.12-2021-node-browsers
+       - image: metabase/ci:java-11-clj-1.11.0.1100.04-2022-build
        - image: circleci/mongo:latest
 
   presto-186:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:java-11-clj-1.10.1040.12-2021-node-browsers
+      - image: metabase/ci:java-11-clj-1.11.0.1100.04-2022-build
       - image: metabase/presto-mb-ci:0.186
         environment:
           JAVA_TOOL_OPTIONS: "-Xmx2g"
@@ -157,7 +157,7 @@ executors:
   presto-jdbc-env:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:java-11-clj-1.10.1040.12-2021-node-browsers
+      - image: metabase/ci:java-11-clj-1.11.0.1100.04-2022-build
       - image: metabase/presto-mb-ci:latest # version 0.254
         environment:
           JAVA_TOOL_OPTIONS: "-Xmx2g"
@@ -176,20 +176,20 @@ executors:
   sparksql:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:java-11-clj-1.10.1040.12-2021-node-browsers
+      - image: metabase/ci:java-11-clj-1.11.0.1100.04-2022-build
       - image: metabase/spark:3.2.1
     resource_class: large
 
   vertica:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:java-11-clj-1.10.1040.12-2021-node-browsers
+      - image: metabase/ci:java-11-clj-1.11.0.1100.04-2022-build
       - image: sumitchawla/vertica
 
   sqlserver:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:java-11-clj-1.10.1040.12-2021-node-browsers
+      - image: metabase/ci:java-11-clj-1.11.0.1100.04-2022-build
         environment:
           MB_SQLSERVER_TEST_HOST: localhost
           MB_SQLSERVER_TEST_PASSWORD: 'P@ssw0rd'
@@ -203,7 +203,7 @@ executors:
   druid:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:java-11-clj-1.10.1040.12-2021-node-browsers
+      - image: metabase/ci:java-11-clj-1.11.0.1100.04-2022-build
       - image: metabase/druid:0.20.2
         environment:
           CLUSTER_SIZE: nano-quickstart

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # STAGE 1: builder
 ###################
 
-FROM metabase/ci:circleci-java-11-clj-1.10.3.929-07-27-2021-node-browsers as builder
+FROM metabase/ci:java-11-clj-1.11.0.1100.04-2022-build as builder
 
 ARG MB_EDITION=oss
 
@@ -17,8 +17,9 @@ RUN INTERACTIVE=false CI=true MB_EDITION=$MB_EDITION bin/build
 
 ## Remember that this runner image needs to be the same as bin/docker/Dockerfile with the exception that this one grabs the
 ## jar from the previous stage rather than the local build
+## we're not yet there to provide an ARM runner till https://github.com/adoptium/adoptium/issues/96 is ready
 
-FROM eclipse-temurin:11-jre-alpine as runner
+FROM --platform=linux/amd64 eclipse-temurin:11-jre-alpine as runner
 
 ENV FC_LANG en-US LC_CTYPE en_US.UTF-8
 

--- a/frontend/test/__runner__/backend.js
+++ b/frontend/test/__runner__/backend.js
@@ -81,6 +81,7 @@ const BackendResource = createSharedResource("BackendResource", {
             }),
             MB_SNOWPLOW_AVAILABLE: process.env["MB_SNOWPLOW_AVAILABLE"],
             MB_SNOWPLOW_URL: process.env["MB_SNOWPLOW_URL"],
+            PATH: process.env.PATH,
           },
           stdio:
             process.env["DISABLE_LOGGING"] ||


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/18650

EDIT 04-16-2022: upgraded Clojure CLI version + made the builder image multi-arch

Tests on https://app.circleci.com/pipelines/github/metabase/metabase?branch=check-new-builder&filter=all