### PR TITLE
Indicate selected item in the admin nav

### DIFF
--- a/frontend/src/metabase/components/Link.tsx
+++ b/frontend/src/metabase/components/Link.tsx
@@ -6,7 +6,7 @@ import { color, display, hover, space } from "styled-system";
 import Tooltip from "metabase/components/Tooltip";
 import { stripLayoutProps } from "metabase/lib/utils";
 
-interface Props extends HTMLProps<HTMLAnchorElement> {
+export interface LinkProps extends HTMLProps<HTMLAnchorElement> {
   to: string;
   disabled?: boolean;
   className?: string;
@@ -24,7 +24,7 @@ function BaseLink({
   disabled,
   tooltip,
   ...props
-}: Props) {
+}: LinkProps) {
   const link = (
     <ReactRouterLink
       to={to}

--- a/frontend/src/metabase/css/admin.css
+++ b/frontend/src/metabase/css/admin.css
@@ -6,45 +6,10 @@
   --page-header-padding: 2.375rem;
 }
 
-.AdminNav {
-  background: var(--color-admin-navbar);
-  color: var(--color-text-white);
-  font-size: 0.85rem;
-}
-
-.AdminNav .NavItem {
-  color: color-mod(var(--color-text-white) alpha(-37%));
-}
-
-.AdminNav .NavItem:hover,
-.AdminNav .NavItem.is--selected {
-  color: var(--color-text-white);
-}
-
-/* TODO: this feels itchy. should refactor .NavItem.is--selected to be less cascadey */
-.AdminNav .NavItem:hover:after,
-.AdminNav .NavItem.is--selected:after {
-  display: none;
-}
-
-.AdminNav .NavDropdown.open .NavDropdown-button,
-.AdminNav .NavDropdown .NavDropdown-content-layer {
-  background-color: var(--color-bg-dark);
-}
-
-.AdminNav .Dropdown-item:hover {
-  background-color: var(--color-bg-dark);
-}
-
 /* utility to get a simple common hover state for admin items */
-.HoverItem:hover,
-.AdminHoverItem:hover {
+.HoverItem:hover {
   background-color: var(--color-bg-medium);
   transition: background 0.2s linear;
-}
-
-.AdminNav .Dropdown-chevron {
-  color: var(--color-text-white);
 }
 
 .Actions-group {

--- a/frontend/src/metabase/nav/components/AdminNavbar/AdminNavItem.styled.tsx
+++ b/frontend/src/metabase/nav/components/AdminNavbar/AdminNavItem.styled.tsx
@@ -1,0 +1,13 @@
+import styled from "styled-components";
+import Link, { LinkProps } from "metabase/components/Link";
+import { alpha, color } from "metabase/lib/colors";
+
+interface AdminNavLinkProps extends LinkProps {
+  isSelected?: boolean;
+}
+
+export const AdminNavLink = styled<AdminNavLinkProps>(Link)`
+  padding: 0.5rem 1rem;
+  text-decoration: none;
+  color: ${props => (props.isSelected ? color("white") : alpha("white", 0.63))};
+`;

--- a/frontend/src/metabase/nav/components/AdminNavbar/AdminNavItem.tsx
+++ b/frontend/src/metabase/nav/components/AdminNavbar/AdminNavItem.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import cx from "classnames";
 import Link from "metabase/components/Link";
+import { AdminNavLink } from "./AdminNavItem.styled";
 
 interface AdminNavItem {
   name: string;
@@ -10,14 +11,12 @@ interface AdminNavItem {
 
 export const AdminNavItem = ({ name, path, currentPath }: AdminNavItem) => (
   <li>
-    <Link
+    <AdminNavLink
       to={path}
       data-metabase-event={`NavBar;${name}`}
-      className={cx("NavItem py1 px2 no-decoration", {
-        "is--selected": currentPath.startsWith(path),
-      })}
+      isSelected={currentPath.startsWith(path)}
     >
       {name}
-    </Link>
+    </AdminNavLink>
   </li>
 );

--- a/frontend/src/metabase/nav/components/AdminNavbar/AdminNavbar.tsx
+++ b/frontend/src/metabase/nav/components/AdminNavbar/AdminNavbar.tsx
@@ -3,7 +3,6 @@ import { t } from "ttag";
 import { PLUGIN_ADMIN_NAV_ITEMS } from "metabase/plugins";
 import MetabaseSettings from "metabase/lib/settings";
 import { AdminNavItem } from "./AdminNavItem";
-import Link from "metabase/components/Link";
 import StoreLink from "../StoreLink";
 import LogoIcon from "metabase/components/LogoIcon";
 import {


### PR DESCRIPTION
Caused by https://github.com/metabase/metabase/pull/19304

Fixes missing indication of the current page in the admin nav.

Before:
<img width="1029" alt="Screenshot 2021-12-20 at 11 56 08" src="https://user-images.githubusercontent.com/14301985/146748508-7c3d33e2-69c2-44ab-8c66-d9827e518ce7.png">

After:
<img width="1034" alt="Screenshot 2021-12-20 at 11 50 52" src="https://user-images.githubusercontent.com/14301985/146748015-45d3dcb9-8180-4c95-84e2-c317771fc245.png">

