### PR TITLE
Use spinner for database sync progress 

### DIFF
--- a/frontend/src/metabase/status/components/DatabaseStatusLarge/DatabaseStatusLarge.tsx
+++ b/frontend/src/metabase/status/components/DatabaseStatusLarge/DatabaseStatusLarge.tsx
@@ -104,13 +104,9 @@ const getTitle = (databases: Database[]): string => {
 const getDescription = (database: Database): string => {
   const isDone = isSyncCompleted(database);
   const isError = isSyncAborted(database);
-  const doneCount = database.tables?.filter(isSyncCompleted).length;
-  const totalCount = database.tables?.length;
 
   if (isError) {
     return t`Sync failed`;
-  } else if (totalCount) {
-    return t`${doneCount} of ${totalCount} tables done`;
   } else if (isDone) {
     return t`Syncing completed`;
   } else {

--- a/frontend/src/metabase/status/components/DatabaseStatusLarge/DatabaseStatusLarge.unit.spec.tsx
+++ b/frontend/src/metabase/status/components/DatabaseStatusLarge/DatabaseStatusLarge.unit.spec.tsx
@@ -8,12 +8,6 @@ describe("DatabaseStatusLarge", () => {
     const databases = [
       getDatabase({
         initial_sync_status: "incomplete",
-        tables: [
-          { id: 1, initial_sync_status: "complete" },
-          { id: 2, initial_sync_status: "incomplete" },
-          { id: 3, initial_sync_status: "aborted" },
-          { id: 4, initial_sync_status: "incomplete" },
-        ],
       }),
       getDatabase({
         initial_sync_status: "complete",
@@ -23,7 +17,7 @@ describe("DatabaseStatusLarge", () => {
     render(<DatabaseStatusLarge databases={databases} />);
 
     expect(screen.getByText("Syncing…")).toBeInTheDocument();
-    expect(screen.getByText("1 of 4 tables done")).toBeInTheDocument();
+    expect(screen.getByText("Syncing tables…")).toBeInTheDocument();
   });
 
   it("should render complete status", () => {

--- a/frontend/src/metabase/status/components/DatabaseStatusSmall/DatabaseStatusSmall.styled.tsx
+++ b/frontend/src/metabase/status/components/DatabaseStatusSmall/DatabaseStatusSmall.styled.tsx
@@ -1,6 +1,7 @@
 import styled from "styled-components";
 import { color, lighten } from "metabase/lib/colors";
 import Icon from "metabase/components/Icon";
+import LoadingSpinner from "metabase/components/LoadingSpinner";
 import { InitialSyncStatus } from "../../types";
 
 interface Props {
@@ -22,6 +23,15 @@ const getIconSize = ({ status }: Props): string => {
       return "0.875rem";
     default:
       return "0.75rem";
+  }
+};
+
+const getBorderColor = ({ status }: Props): string => {
+  switch (status) {
+    case "complete":
+      return color("brand");
+    default:
+      return lighten("brand", 0.5);
   }
 };
 
@@ -50,7 +60,7 @@ export const StatusContainer = styled.div<Props>`
   width: 100%;
   height: 100%;
   color: ${getIconColor};
-  border: 0.25rem solid ${lighten("brand", 0.5)};
+  border: 0.25rem solid ${getBorderColor};
   border-radius: 50%;
   background-color: ${lighten("brand", 0.6)};
   box-shadow: 0 1px 12px ${color("shadow")};
@@ -71,17 +81,9 @@ export const StatusIcon = styled(Icon)`
   height: ${getIconSize};
 `;
 
-export const StatusImage = styled.svg`
+export const StatusSpinner = styled(LoadingSpinner)`
   position: absolute;
   top: 0;
   left: 0;
-  width: 100%;
-  height: 100%;
-`;
-
-export const StatusCircle = styled.circle`
-  fill: none;
-  stroke: ${color("brand")};
-  transform: rotate(-90deg);
-  transform-origin: center;
+  color: ${color("brand")};
 `;

--- a/frontend/src/metabase/status/components/DatabaseStatusSmall/DatabaseStatusSmall.unit.spec.tsx
+++ b/frontend/src/metabase/status/components/DatabaseStatusSmall/DatabaseStatusSmall.unit.spec.tsx
@@ -8,12 +8,6 @@ describe("DatabaseStatusSmall", () => {
     const databases = [
       getDatabase({
         initial_sync_status: "incomplete",
-        tables: [
-          { id: 1, initial_sync_status: "complete" },
-          { id: 2, initial_sync_status: "incomplete" },
-          { id: 3, initial_sync_status: "aborted" },
-          { id: 4, initial_sync_status: "incomplete" },
-        ],
       }),
       getDatabase({
         initial_sync_status: "complete",

--- a/frontend/src/metabase/status/containers/DatabaseStatus/DatabaseStatus.tsx
+++ b/frontend/src/metabase/status/containers/DatabaseStatus/DatabaseStatus.tsx
@@ -9,7 +9,6 @@ import { Database } from "../../types";
 const RELOAD_INTERVAL = 2000;
 
 const databasesProps = {
-  query: { include: "tables" },
   loadingAndErrorWrapper: false,
   reloadInterval: (state: any, props: any, databases: Database[] = []) =>
     databases.some(isSyncInProgress) ? RELOAD_INTERVAL : 0,

--- a/frontend/src/metabase/status/types.ts
+++ b/frontend/src/metabase/status/types.ts
@@ -10,10 +10,4 @@ export interface Database {
   is_sample: boolean;
   creator_id?: number;
   initial_sync_status: InitialSyncStatus;
-  tables?: Table[];
-}
-
-export interface Table {
-  id: number;
-  initial_sync_status: InitialSyncStatus;
 }


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/18675

- Uses spinner instead of a custom SVG
- Updates copy

<img width="137" alt="Screenshot 2021-12-20 at 16 03 27" src="https://user-images.githubusercontent.com/8542534/146771411-cdeb9afa-73c7-4290-a7bd-c4ab13ef3cc2.png">

How to test:
- Go to Admin > Databases
- Copy connection string from Sample Dataset
- Add a new H2 database with the same connection string
- Click on the arrow in the sync indicator in the bottom right corner to toggle collapsed state
- Make sure there is a spinner