### PR TITLE
Wrap names in AccordionList

### DIFF
--- a/frontend/src/metabase/components/AccordionList/AccordionList.jsx
+++ b/frontend/src/metabase/components/AccordionList/AccordionList.jsx
@@ -518,9 +518,7 @@ const AccordionListCell = ({
               {icon}
             </span>
           )}
-          {name && (
-            <h3 className="List-section-title flex-full text-wrap">{name}</h3>
-          )}
+          {name && <h3 className="List-section-title text-wrap">{name}</h3>}
           {extra}
           {sections.length > 1 && section.items && section.items.length > 0 && (
             <span className="flex-align-right ml1 hover-child">


### PR DESCRIPTION
Fixes #19034 

### How to Test

1. Add or edit a database so that it has a very long **word** as a name.
2. Ask a question
3. Simple question

### After

<img src=https://user-images.githubusercontent.com/380816/146799600-00679d8e-8813-4bb4-b16e-2c4452b3dc0d.png width=300 />

### Before

<img src=https://user-images.githubusercontent.com/380816/146799705-e5a97d7f-94a4-4c5d-8ee6-1980666f2db0.png width=300 />

After you select a database, you select a table and the database name should be rendered wrapped if the case:

<img src=https://user-images.githubusercontent.com/380816/146801469-dc443296-a167-46be-aa7c-62e3bd594445.png width=300 />
