### PR TITLE
Fix navigation with contextual help

### DIFF
--- a/frontend/src/metabase/components/Input/Input.jsx
+++ b/frontend/src/metabase/components/Input/Input.jsx
@@ -1,7 +1,7 @@
 import React, { forwardRef } from "react";
 import PropTypes from "prop-types";
 import Icon from "metabase/components/Icon";
-import { InputField, InputHelpButton, InputRoot } from "./Input.styled";
+import { InputField, InputIconContainer, InputRoot } from "./Input.styled";
 import Tooltip from "metabase/components/Tooltip";
 
 const propTypes = {
@@ -30,9 +30,9 @@ const Input = ({ error, fullWidth, helperText, ...rest }) => {
 
 const InputHelpContent = forwardRef(function InputHelpContent(props, ref) {
   return (
-    <InputHelpButton innerRef={ref}>
+    <InputIconContainer innerRef={ref}>
       <Icon name="info" />
-    </InputHelpButton>
+    </InputIconContainer>
   );
 });
 

--- a/frontend/src/metabase/components/Input/Input.styled.jsx
+++ b/frontend/src/metabase/components/Input/Input.styled.jsx
@@ -1,6 +1,5 @@
 import styled, { css } from "styled-components";
 import { color, darken } from "metabase/lib/colors";
-import IconButtonWrapper from "metabase/components/IconButtonWrapper";
 
 export const InputRoot = styled.div`
   display: inline-flex;
@@ -44,8 +43,13 @@ export const InputField = styled.input`
     `}
 `;
 
-export const InputHelpButton = styled(IconButtonWrapper)`
+export const InputIconContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
   position: absolute;
   right: 0.75rem;
   color: ${color("text-light")};
+  cursor: pointer;
+  border-radius: 50%;
 `;


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/19099

Fixes navigation with `tab` for fields with context help. The problem was that icons were wrapped in buttons, making direct navigation between fields impossible.

How to test:
- Admin > Databases > Sample dataset
- Try navigating between form fields with keyboard. Help icons should not be focused.