### PR TITLE
Fix x-ray dashcard drilldown

### DIFF
--- a/frontend/src/metabase-lib/lib/Question.ts
+++ b/frontend/src/metabase-lib/lib/Question.ts
@@ -228,6 +228,21 @@ export default class Question {
     );
   }
 
+  omitTransientCardIds() {
+    let question = this;
+
+    const card = question.card();
+    const { id, original_card_id } = card;
+    if (isTransientId(id)) {
+      question = question.setCard(_.omit(question.card(), "id"));
+    }
+    if (isTransientId(original_card_id)) {
+      question = question.setCard(_.omit(question.card(), "original_card_id"));
+    }
+
+    return question;
+  }
+
   /**
    * A question contains either a:
    * - StructuredQuery for queries written in MBQL
@@ -900,13 +915,15 @@ export default class Question {
     includeDisplayIsLocked?: boolean;
     creationType: string;
   } = {}): string {
+    const question = this.omitTransientCardIds();
+
     if (
-      !this.id() ||
-      (originalQuestion && this.isDirtyComparedTo(originalQuestion))
+      !question.id() ||
+      (originalQuestion && question.isDirtyComparedTo(originalQuestion))
     ) {
       return Urls.question(
         null,
-        this._serializeForUrl({
+        question._serializeForUrl({
           clean,
           includeDisplayIsLocked,
           creationType,
@@ -914,7 +931,7 @@ export default class Question {
         query,
       );
     } else {
-      return Urls.question(this.card(), "", query);
+      return Urls.question(question.card(), "", query);
     }
   }
 

--- a/frontend/test/metabase/scenarios/dashboard/x-rays.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/x-rays.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, visitQuestionAdhoc } from "__support__/e2e/cypress";
+import { restore, visitQuestionAdhoc, popover } from "__support__/e2e/cypress";
 import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
 
 const {
@@ -152,5 +152,37 @@ describe("scenarios > x-rays", () => {
 
     cy.get(".Card").contains("18,760");
     cy.findByText("How these transactions are distributed");
+  });
+
+  it("should be able to click the title of an x-ray dashcard to see it in the query builder", () => {
+    const timeout = { timeout: 10000 };
+
+    cy.visit("/");
+    cy.contains("A look at your Orders table").click();
+
+    // confirm results of "Total transactions" card are present
+    cy.findByText("18,760", timeout);
+    cy.findByText("Total transactions").click();
+
+    // confirm we're in the query builder with the same results
+    cy.url().should("contain", "/question");
+    cy.findByText("18,760");
+
+    cy.go("back");
+
+    // add a parameter filter to the auto dashboard
+    cy.findByText("State", timeout).click();
+    popover().within(() => {
+      cy.get("input").type("GA{enter}");
+      cy.findByText("Add filter").click();
+    });
+
+    // confirm results of "Total transactions" card were updated
+    cy.findByText("463", timeout);
+    cy.findByText("Total transactions").click();
+
+    // confirm parameter filter is applied as filter in query builder
+    cy.findByText("State is GA");
+    cy.findByText("463");
   });
 });


### PR DESCRIPTION
Fixes #19405 

https://github.com/metabase/metabase/pull/19027 replaced some old `metabase/meta/Card` logic with code that went through `metabase-lib`'s `Question` class methods. Unfortunately, `Question.prototype.getUrl` doesn't handle transient ids, such as the ones that you see on auto-generated cards (eg `"G__123"`), unlike the old function (see the now-deleted `questionUrlWithParameters` in `metabase/meta/Card`) . Removing `card.id` and `card.original_card_id` when they are transient card ids fixes this issue.

https://user-images.githubusercontent.com/13057258/146848771-af5eb9b8-f44a-442d-8cf2-354de6f1f0f0.mov


