### PR TITLE
Handle nested queries which have agg at top level and nested

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -44,6 +44,7 @@
   (eval . (put-clojure-indent 'mbql.match/replace 1))
   (eval . (put-clojure-indent 'mbql.match/replace-in 2))
   (eval . (put-clojure-indent 'mt/dataset 1))
+  (eval . (put-clojure-indent 'mt/format-rows-by 1))
   (eval . (put-clojure-indent 'mt/query 1))
   (eval . (put-clojure-indent 'mt/test-drivers 1))
   (eval . (put-clojure-indent 'prop/for-all 1))

--- a/src/metabase/query_processor/middleware/annotate.clj
+++ b/src/metabase/query_processor/middleware/annotate.clj
@@ -520,9 +520,10 @@
 (defn- flow-field-metadata
   "Merge information about fields from `source-metadata` into the returned `cols`."
   [source-metadata cols]
-  (let [ref->metadata (u/key-by (comp u/field-ref->key :field_ref) source-metadata)]
+  (let [index          (fn [col] (or (:id col) (:name col "")))
+        name->metadata (u/key-by index source-metadata)]
     (for [col cols]
-      (if-let [source-metadata-for-field (-> col :field_ref u/field-ref->key ref->metadata)]
+      (if-let [source-metadata-for-field (-> col index name->metadata)]
         (merge-source-metadata-col source-metadata-for-field col)
         col))))
 

--- a/src/metabase/query_processor/middleware/annotate.clj
+++ b/src/metabase/query_processor/middleware/annotate.clj
@@ -497,11 +497,6 @@
   (merge
    source-metadata-col
    col
-   (select-keys source-metadata-col preserved-keys)
-   ;; if there is a join involved, allow a possible "Question 5 → B Column" display name from the outer query to
-   ;; dominate
-   (when (:source_alias col)
-     (select-keys col [:display_name]))
    ;; pass along the unit from the source query metadata if the top-level metadata has unit `:default`. This way the
    ;; frontend will display the results correctly if bucketing was applied in the nested query, e.g. it will format
    ;; temporal values in results using that unit
@@ -519,12 +514,15 @@
 
 (defn- flow-field-metadata
   "Merge information about fields from `source-metadata` into the returned `cols`."
-  [source-metadata cols]
-  (let [index          (fn [col] (or (:id col) (:name col "")))
-        name->metadata (u/key-by index source-metadata)]
+  [source-metadata cols dataset?]
+  (let [index           (fn [col] (or (:id col) (:name col "")))
+        index->metadata (u/key-by index source-metadata)]
     (for [col cols]
-      (if-let [source-metadata-for-field (-> col index name->metadata)]
-        (merge-source-metadata-col source-metadata-for-field col)
+      (if-let [source-metadata-for-field (-> col index index->metadata)]
+        (merge-source-metadata-col source-metadata-for-field
+                                   (merge col
+                                          (when dataset?
+                                            (select-keys source-metadata-for-field preserved-keys))))
         col))))
 
 (declare mbql-cols)
@@ -539,14 +537,14 @@
 (defn mbql-cols
   "Return the `:cols` result metadata for an 'inner' MBQL query based on the fields/breakouts/aggregations in the
   query."
-  [{:keys [source-metadata source-query fields], :as inner-query}, results]
+  [{:keys [source-metadata source-query :source-query/dataset? fields], :as inner-query}, results]
   (let [cols (cols-for-mbql-query inner-query)]
     (cond
       (and (empty? cols) source-query)
       (cols-for-source-query inner-query results)
 
       source-query
-      (flow-field-metadata (cols-for-source-query inner-query results) cols)
+      (flow-field-metadata (cols-for-source-query inner-query results) cols dataset?)
 
       (every? #(mbql.u/match-one % [:field (field-name :guard string?) _] field-name) fields)
       (maybe-merge-source-metadata source-metadata cols)

--- a/test/metabase/query_processor/middleware/annotate_test.clj
+++ b/test/metabase/query_processor/middleware/annotate_test.clj
@@ -52,7 +52,8 @@
 
 (defn- info-for-field
   ([field-id]
-   (into {} (db/select-one (into [Field] (disj (set @#'qp.store/field-columns-to-fetch) :database_type)) :id field-id)))
+   (into {} (db/select-one (into [Field] (disj (set @#'qp.store/field-columns-to-fetch) :database_type))
+                           :id field-id)))
 
   ([table-key field-key]
    (info-for-field (mt/id table-key field-key))))

--- a/test/metabase/query_processor_test/nested_queries_test.clj
+++ b/test/metabase/query_processor_test/nested_queries_test.clj
@@ -170,24 +170,23 @@
                                                     :order-by     [[:asc $category]]}})}]]
           (is (= {:cols [{:name "count" :display_name "Count"}
                          {:name "avg" :display_name "Average of Sum of Price"}]
-                  :rows [[4 2787.0]]}
-                 (-> {:type     :query
-                      :database (mt/id)
-                      :query    {:source-table (str "card__" card-id)
-                                 :aggregation  [[:aggregation-options
-                                                 [:count]
-                                                 {:name "count"}]
-                                                [:aggregation-options
-                                                 [:avg
-                                                  [:field
-                                                   "sum"
-                                                   {:base-type :type/Float}]]
-                                                 {:name "avg"}]]}}
-                     qp/process-query
+                  :rows [[4 2787]]}
+                 (-> (mt/format-rows-by [int int]
+                       (qp/process-query {:type     :query
+                                          :database (mt/id)
+                                          :query    {:source-table (str "card__" card-id)
+                                                     :aggregation  [[:aggregation-options
+                                                                     [:count]
+                                                                     {:name "count"}]
+                                                                    [:aggregation-options
+                                                                     [:avg
+                                                                      [:field
+                                                                       "sum"
+                                                                       {:base-type :type/Float}]]
+                                                                     {:name "avg"}]]}}))
                      :data
                      (select-keys [:cols :rows])
-                     (update :cols #(map (fn [c] (select-keys c [:name :display_name])) %))
-                     (update :rows #(mt/round-all-decimals 0 %))))))))))
+                     (update :cols #(map (fn [c] (select-keys c [:name :display_name])) %))))))))))
 
 (deftest sql-source-query-breakout-aggregation-test
   (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries)


### PR DESCRIPTION
Fixes #19403 

Previously when matching columns in the outer query with columns in the
inner query we had use id, and then recently, field_ref. This is
problematic for aggregations.

Consider https://github.com/metabase/metabase/issues/19403

The mbql for this query is

```clojure
{:type :query
 :query {:aggregation [[:aggregation-options
                        [:count]
                        {:name "count"}]
                       [:aggregation-options
                        [:avg
                         [:field
                          "sum"
                          {:base-type :type/Float}]]
                        {:name "avg"}]]
         :limit 10
         :source-card-id 1960
         :source-query {:source-table 1
                        :aggregation [[:aggregation-options
                                       [:sum
                                        [:field 23 nil]]
                                       {:name "sum"}]
                                      [:aggregation-options
                                       [:max
                                        [:field 28 nil]]
                                       {:name "max"}]]
                        :breakout [[:field 26 nil]]
                        :order-by [[:asc
                                    [:field 26 nil]]]}}
 :database 1}
```

The aggregations in the top level select will be type checked as :name
"count" :field_ref [:aggregation 0]. The aggregations in the nested
query will be turned into :name "sum" :field_ref [:aggregation 0]! This
is because aggregations are numbered "on their level" and not
globally. So when the fields on the top level look at the metadata for
the nested query and merge it, it unifies the two [:aggregation 0]
fields but this is INCORRECT. These aggregations are not the same, they
just happen to be the first aggregations at each level.

Its illustrative to see what a (select * from (query with aggregations))
looks like:

```clojure
{:database 1
 :query {:source-card-id 1960
         :source-metadata [{:description "The type of product, valid values include: Doohicky, Gadget, Gizmo and Widget"
                            :semantic_type :type/Category
                            :coercion_strategy nil
                            :name "CATEGORY"
                            :field_ref [:field 26 nil]
                            :effective_type :type/Text
                            :id 26
                            :display_name "Category"
                            :fingerprint {:global {:distinct-count 4
                                                   :nil% 0}
                                          :type {:type/Text {:percent-json 0
                                                             :percent-url 0
                                                             :percent-email 0
                                                             :percent-state 0
                                                             :average-length 6.375}}}
                            :base_type :type/Text}
                           {:name "sum"
                            :display_name "Sum of Price"
                            :base_type :type/Float
                            :effective_type :type/Float
                            :semantic_type nil
                            :field_ref [:aggregation 0]}
                           {:name "max"
                            :display_name "Max of Rating"
                            :base_type :type/Float
                            :effective_type :type/Float
                            :semantic_type :type/Score
                            :field_ref [:aggregation 1]}]
         :fields ([:field 26 nil]
                  [:field
                   "sum"
                   {:base-type :type/Float}]
                  [:field
                   "max"
                   {:base-type :type/Float}])
         :source-query {:source-table 1
                        :aggregation [[:aggregation-options
                                       [:sum
                                        [:field 23 nil]]
                                       {:name "sum"}]
                                      [:aggregation-options
                                       [:max
                                        [:field 28 nil]]
                                       {:name "max"}]]
                        :breakout [[:field 26 nil]]
                        :order-by [[:asc
                                    [:field 26 nil]]]}}
 :type :query
 :middleware {:js-int-to-string? true
              :add-default-userland-constraints? true}
 :info {:executed-by 1
        :context :ad-hoc
        :card-id 1960
        :nested? true
        :query-hash #object["[B" 0x10227bf4 "[B@10227bf4"]}
 :constraints {:max-results 10000
               :max-results-bare-rows 2000}}
```

The important bits are that it understands the nested query's metadata
to be

```clojure
{:name "sum"
 :display_name "Sum of Price"
 :field_ref [:aggregation 0]}
{:name "max"
 :display_name "Max of Rating"
 :field_ref [:aggregation 1]}
```

And the fields on the outer query to be:
```clojure
([:field
  "sum"
  {:base-type :type/Float}]
 [:field
  "max"
  {:base-type :type/Float}])
```

So there's the mismatch: the field_ref on the outside is [:field "sum"]
but on the inside the field_ref is [:aggregation 0]. So the best way to
match up when "looking down" into sub queries is by id and then by name.
