### PR TITLE
Custom expression parser: error messages are i18n-ready

### DIFF
--- a/frontend/src/metabase/lib/expressions/recursive-parser.js
+++ b/frontend/src/metabase/lib/expressions/recursive-parser.js
@@ -87,7 +87,8 @@ function recursiveParse(source) {
     }
     const { type, start, end } = token;
     if (type === TOKEN.Operator) {
-      throw new Error(t`Unexpected operator`);
+      const text = source.substring(start, end);
+      throw new Error(t`Unexpected operator ${text}`);
     }
     const text = source.substring(start, end);
     if (type === TOKEN.Identifier) {

--- a/frontend/src/metabase/lib/expressions/recursive-parser.js
+++ b/frontend/src/metabase/lib/expressions/recursive-parser.js
@@ -1,5 +1,6 @@
-import { tokenize, TOKEN, OPERATOR as OP } from "./tokenizer";
+import { t } from "ttag";
 
+import { tokenize, TOKEN, OPERATOR as OP } from "./tokenizer";
 import { getMBQLName, MBQL_CLAUSES } from "./index";
 
 const COMPARISON_OPS = [
@@ -21,12 +22,12 @@ function recursiveParse(source) {
   const expectOp = nextOp => {
     const token = next();
     if (!token) {
-      throw new Error(`Unexpected end of input, expecting ${nextOp}`);
+      throw new Error(t`Unexpected end of input, expecting ${nextOp}`);
     }
     const { type, op, start, end } = token;
     if (type !== TOKEN.Operator || op !== nextOp) {
       const text = source.substring(start, end);
-      throw new Error(`Expecting ${nextOp} but got ${text} instead`);
+      throw new Error(t`Expecting ${nextOp} but got ${text} instead`);
     }
   };
 
@@ -43,7 +44,7 @@ function recursiveParse(source) {
     const terminated = matchOps([OP.CloseParenthesis]);
     expectOp(OP.CloseParenthesis);
     if (!terminated) {
-      throw new Error("Expecting a closing parenthesis");
+      throw new Error(t`Expecting a closing parenthesis`);
     }
     return expr;
   };
@@ -82,11 +83,11 @@ function recursiveParse(source) {
     }
     const token = next();
     if (!token) {
-      throw new Error("Unexpected end of input");
+      throw new Error(t`Unexpected end of input`);
     }
     const { type, start, end } = token;
     if (type === TOKEN.Operator) {
-      throw new Error("Unexpected operator");
+      throw new Error(t`Unexpected operator`);
     }
     const text = source.substring(start, end);
     if (type === TOKEN.Identifier) {


### PR DESCRIPTION
Steps to verify:

1. Ask a question, Custom question
2. Sample Dataset, pick any table (e.g. Product)
3. Filter, Custom Expression, type `A + /`

**Before this PR**

Even if the language is set to non-English, the error message is still in English: _Unexpected operator_.

![image](https://user-images.githubusercontent.com/7288/146867230-718966a9-3eff-4305-af2c-32ab85a5670f.png)

**After this PR**

Assuming the translated string already appears in the proper locale files:

![image](https://user-images.githubusercontent.com/7288/146986801-8c5cefc8-8b9c-499d-b763-c2f775899b10.png)

