### PR TITLE
Add setup invitation validation

### DIFF
--- a/frontend/src/metabase/setup/components/DatabaseStep/DatabaseStep.tsx
+++ b/frontend/src/metabase/setup/components/DatabaseStep/DatabaseStep.tsx
@@ -13,11 +13,12 @@ import {
   StepLink,
 } from "./DatabaseStep.styled";
 import { FormProps } from "./types";
-import { DatabaseInfo, InviteInfo } from "../../types";
+import { DatabaseInfo, InviteInfo, UserInfo } from "../../types";
 
 export interface DatabaseStepProps {
-  engine?: string;
+  user?: UserInfo;
   database?: DatabaseInfo;
+  engine?: string;
   invite?: InviteInfo;
   isEmailConfigured: boolean;
   isStepActive: boolean;
@@ -31,8 +32,9 @@ export interface DatabaseStepProps {
 }
 
 const DatabaseStep = ({
-  engine,
+  user,
   database,
+  engine,
   invite,
   isEmailConfigured,
   isStepActive,
@@ -74,8 +76,8 @@ const DatabaseStep = ({
         <div>{t`Not ready? Skip and play around with our Sample Dataset.`}</div>
       </StepDescription>
       <DatabaseForm
-        engine={engine}
         database={database}
+        engine={engine}
         onSubmit={onDatabaseSubmit}
       />
       <StepActions>
@@ -86,7 +88,7 @@ const DatabaseStep = ({
           title={t`Need help connecting to your data?`}
           description={t`Invite a teammate. We’ll make them an admin so they can configure your database. You can always change this later on.`}
         >
-          <InviteForm invite={invite} onSubmit={onInviteSubmit} />
+          <InviteForm user={user} invite={invite} onSubmit={onInviteSubmit} />
         </SetupSection>
       )}
     </ActiveStep>
@@ -94,8 +96,8 @@ const DatabaseStep = ({
 };
 
 interface DatabaseFormProps {
-  engine?: string;
   database?: DatabaseInfo;
+  engine?: string;
   onSubmit: (database: DatabaseInfo) => void;
 }
 
@@ -132,14 +134,19 @@ const DatabaseForm = ({
 };
 
 interface InviteFormProps {
+  user?: UserInfo;
   invite?: InviteInfo;
   onSubmit: (invite: InviteInfo) => void;
 }
 
-const InviteForm = ({ invite, onSubmit }: InviteFormProps): JSX.Element => {
+const InviteForm = ({
+  user,
+  invite,
+  onSubmit,
+}: InviteFormProps): JSX.Element => {
   return (
     <Users.Form
-      form={Users.forms.setup_invite}
+      form={Users.forms.setup_invite(user)}
       user={invite}
       onSubmit={onSubmit}
     >

--- a/frontend/src/metabase/setup/components/PreferencesStep/PreferencesStep.tsx
+++ b/frontend/src/metabase/setup/components/PreferencesStep/PreferencesStep.tsx
@@ -41,6 +41,7 @@ const PreferencesStep = ({
       await onStepSubmit(isTrackingAllowed);
     } catch (error) {
       setErrorMessage(getSubmitError(error));
+      throw error;
     }
   };
 
@@ -87,8 +88,8 @@ const PreferencesStep = ({
         </StepInfoList>
       )}
       <ActionButton
-        normalText={t`Next`}
-        activeText={t`Next`}
+        normalText={t`Finish`}
+        activeText={t`Finishing…`}
         failedText={t`Failed`}
         successText={t`Success`}
         primary

--- a/frontend/src/metabase/setup/components/PreferencesStep/PreferencesStep.unit.spec.tsx
+++ b/frontend/src/metabase/setup/components/PreferencesStep/PreferencesStep.unit.spec.tsx
@@ -34,7 +34,7 @@ describe("PreferencesStep", () => {
     });
 
     render(<PreferencesStep {...props} />);
-    userEvent.click(screen.getByText("Next"));
+    userEvent.click(screen.getByText("Finish"));
 
     expect(await screen.findByText("An error occurred")).toBeInTheDocument();
   });

--- a/frontend/src/metabase/setup/components/UserStep/UserStep.tsx
+++ b/frontend/src/metabase/setup/components/UserStep/UserStep.tsx
@@ -80,7 +80,7 @@ const UserForm = ({ user, onSubmit, onPasswordChange }: UserFormProps) => {
 
   return (
     <UserFormRoot
-      form={Users.forms.setup()}
+      form={Users.forms.setup}
       user={user}
       asyncValidate={handleAsyncValidate}
       asyncBlurFields={["password"]}

--- a/frontend/src/metabase/setup/containers/DatabaseStep/DatabaseStep.tsx
+++ b/frontend/src/metabase/setup/containers/DatabaseStep/DatabaseStep.tsx
@@ -15,12 +15,14 @@ import {
   isSetupCompleted,
   getDatabaseEngine,
   getInvite,
+  getUser,
 } from "../../selectors";
 import { DatabaseInfo, InviteInfo } from "../../types";
 
 const mapStateToProps = (state: any) => ({
-  engine: getDatabaseEngine(state),
+  user: getUser(state),
   database: getDatabase(state),
+  engine: getDatabaseEngine(state),
   invite: getInvite(state),
   isEmailConfigured: Settings.isEmailConfigured(),
   isStepActive: isStepActive(state, DATABASE_STEP),

--- a/frontend/test/metabase/scenarios/onboarding/setup/setup.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/setup/setup.cy.spec.js
@@ -156,7 +156,7 @@ describe("scenarios > setup", () => {
       cy.findByText("All collection is completely anonymous.").should(
         "not.exist",
       );
-      cy.findByText("Next").click();
+      cy.findByText("Finish").click();
 
       // ==================
       // Finish & Subscribe

--- a/frontend/test/metabase/scenarios/smoketest/admin.cy.spec.js
+++ b/frontend/test/metabase/scenarios/smoketest/admin.cy.spec.js
@@ -65,7 +65,7 @@ describe("metabase-smoketest > admin", () => {
       cy.findByText("All collection is completely anonymous.").should(
         "not.exist",
       );
-      cy.findByText("Next").click();
+      cy.findByText("Finish").click();
 
       // Finish & Subscribe
 


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/19247

- Adds email validation for the second admin in setup
- Changes copy for the last step in the flow

<img width="749" alt="Screenshot 2021-12-21 at 16 59 47" src="https://user-images.githubusercontent.com/8542534/146942201-797cece3-849f-45b8-a3b2-aeae4d837115.png">

<img width="711" alt="Screenshot 2021-12-21 at 16 59 37" src="https://user-images.githubusercontent.com/8542534/146942186-f357e1de-c12c-4f40-a89c-cecf889da119.png">

How to test:
- `docker run -p 80:80 -p 25:25 maildev/maildev`
- `MB_EMAIL_SMTP_HOST=localhost MB_EMAIL_SMTP_PORT=25 MB_EMAIL_SMTP_USERNAME=admin MB_EMAIL_SMTP_PASSWORD=admin MB_EMAIL_SMTP_SECURITY=none MB_EMAIL_EMAIL_FROM_ADDRESS=mailer@metabase.test yarn dev` with a fresh Metabase instance
- Go through the setup