### PR TITLE
fix missing text wrapping

### DIFF
--- a/frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx
@@ -59,7 +59,7 @@ export default class MetadataSchemaList extends Component {
             <li key={schema}>
               <a
                 className={cx(
-                  "AdminList-item flex align-center no-decoration",
+                  "AdminList-item flex align-center no-decoration text-wrap",
                   {
                     selected: selectedSchema && selectedSchema === schema,
                   },

--- a/frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx
@@ -71,7 +71,7 @@ export default class MetadataTableList extends Component {
 
     if (queryableTables.length > 0) {
       queryableTablesHeader = (
-        <li className="AdminList-section">
+        <li className="AdminList-section flex justify-between align-center">
           {(n =>
             ngettext(msgid`${n} Queryable Table`, `${n} Queryable Tables`, n))(
             queryableTables.length,
@@ -117,7 +117,7 @@ export default class MetadataTableList extends Component {
           />
         </div>
         {(this.props.onBack || this.props.schema) && (
-          <h4 className="p2 border-bottom">
+          <h4 className="p2 border-bottom break-anywhere">
             {this.props.onBack && (
               <span
                 className="text-brand cursor-pointer"

--- a/frontend/src/metabase/css/core/text.css
+++ b/frontend/src/metabase/css/core/text.css
@@ -218,3 +218,7 @@
 .text-measure {
   max-width: 620px;
 }
+
+.break-anywhere {
+  line-break: anywhere;
+}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/18584
Closes https://github.com/metabase/metabase/issues/16267

Tiny css tweaks of the data model page.
- wrap schema names
- wrap table list header text

#### Before
<img width="405" alt="Screenshot 2021-12-21 at 17 21 19" src="https://user-images.githubusercontent.com/14301985/146954645-233d1aae-d1fd-47b2-86a9-22c5ba4d88d4.png">

<img width="383" alt="Screenshot 2021-12-21 at 17 21 15" src="https://user-images.githubusercontent.com/14301985/146954687-bcf0608e-3402-4309-8b49-8990cf531d5a.png">

<img width="269" alt="Screenshot 2021-12-21 at 17 10 25" src="https://user-images.githubusercontent.com/14301985/146954711-5ad5a5b1-949c-4f90-9ce9-879a6454e867.png">

#### After
<img width="294" alt="Screenshot 2021-12-21 at 17 20 37" src="https://user-images.githubusercontent.com/14301985/146954786-12c1ebf8-8ee2-4d90-b35d-91a9b8d54715.png">

<img width="285" alt="Screenshot 2021-12-21 at 17 20 53" src="https://user-images.githubusercontent.com/14301985/146954837-ae2a7c17-0389-4aa4-8425-5841f2f9a644.png">

<img width="271" alt="Screenshot 2021-12-21 at 17 10 13" src="https://user-images.githubusercontent.com/14301985/146954869-db8727bb-a176-4911-adf8-3a71aaee40e0.png">


