### PR TITLE
Custom expression editor: don't clobber SQL editor

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/expressions.css
+++ b/frontend/src/metabase/query_builder/components/expressions/expressions.css
@@ -1,4 +1,4 @@
-.ace_content * {
+.expression-editor-textfield .ace_content * {
   font-family: monospace !important;
 }
 
@@ -20,10 +20,10 @@
   color: var(--color-accent5);
 }
 
-.ace_cursor {
+.expression-editor-textfield .ace_cursor {
   border-left-width: 1px;
 }
 
-.ace_hidden-cursors .ace_cursor {
+.expression-editor-textfield .ace_hidden-cursors .ace_cursor {
   opacity: 0;
 }


### PR DESCRIPTION
This is a regression in master due to PR #19377. To fix it, we must scope the style change _only_ to the Ace component for the expression editor.

Steps to verify:
1. Ask a question, Native question
2. Sample Dataset
3. Type `select * from product` and move the cursor around

**Before this PR**

The cursor can get trapped in the middle of each character.

![image](https://user-images.githubusercontent.com/7288/146982176-cd8badd9-b7e6-4982-9567-8f23d36d599b.png)

**After this PR**

The cursor should stay in between characters.

![image](https://user-images.githubusercontent.com/7288/146982136-74efcd36-1ce4-4dfc-a3c5-881ec38763c8.png)
