### PR TITLE
Skip intermittently passing `e2e-tests-sharing-oss/ee` test

### DIFF
--- a/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
@@ -15,7 +15,7 @@ describe("scenarios > dashboard > subscriptions", () => {
     cy.signInAsAdmin();
   });
 
-  it("should not allow sharing if there are no dashboard cards", () => {
+  it.skip("should not allow sharing if there are no dashboard cards", () => {
     cy.createDashboard().then(({ body: { id: DASHBOARD_ID } }) => {
       cy.visit(`/dashboard/${DASHBOARD_ID}`);
     });


### PR DESCRIPTION
This test checks that the share button is disabled on empty dashboards but it's causing intermittent failures in CI. I think it's an "intermittently passing" test that only works thanks to some sort of bug (maybe a rendering race condition?).  `cy.icon("share")` tries to find an element with the class `.Icon-share` but it shouldn't exist.

On `stats.metabase.com` with an empty dashboard, there is no share icon:

![image](https://user-images.githubusercontent.com/653604/147085660-82d1d9c0-92c7-41e1-b275-0ee67e0e7c4a.png)

When the test [**FAILS**](https://app.circleci.com/pipelines/github/metabase/metabase/26280/workflows/08cba030-9fc4-4e13-a139-a7cea97af8b3/jobs/1243336), there is (again) no icon:

![image](https://user-images.githubusercontent.com/653604/147086504-3a9a1620-ca53-45e6-9f87-4a3a985d6f06.png)

When the test [**PASSES**](https://app.circleci.com/pipelines/github/metabase/metabase/26277/workflows/a5604fa0-c079-4074-a92b-39f6c4507460/jobs/1243120), the icon is present but disabled:

![image](https://user-images.githubusercontent.com/653604/147086699-2d5f07e5-2c61-4e27-9cd3-a5d58a061702.png)


The intended behavior according to the test is a sharing button present but disabled. However stats.metabase.com isn't showing the icon and no one has complained in the six months since the last PR to touch that part of the code (metabase/metabase#16586), so I propose merging this PR to improve CI reliability and do a `.skip` grep party later.

Ideally, I would change this to `cy.icon("share").should("not.exist")` but it'd still be an intermittent failure when the disabled icon shows up.