### PR TITLE
React-Ace: Handle editor focus via onLoad prop

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -180,6 +180,16 @@ export default class ExpressionEditorTextfield extends React.Component {
     }
   };
 
+  // This method focuses on the editor input.
+  // Using react-ace’s `onFocus` rendered the editor code
+  // with a severe vertical misalignment.
+  // Occurrences of this bug were rare and non-deterministic wrt to browser.
+  handleEditorLoaded = () => {
+    setTimeout(() => {
+      this.input.current.editor.focus();
+    }, 10);
+  };
+
   handleArrowUp = () => {
     const { highlightedSuggestionIndex, suggestions } = this.state;
 
@@ -373,12 +383,14 @@ export default class ExpressionEditorTextfield extends React.Component {
             commands={this.commands}
             ref={this.input}
             value={source}
-            focus={true}
             highlightActiveLine={false}
             wrapEnabled={true}
             fontSize={12}
             onBlur={this.handleInputBlur}
             onFocus={this.handleFocus}
+            // onLoad circumvents a buggy onFocus,
+            // see declaration of `handleEditorLoaded`
+            onLoad={this.handleEditorLoaded}
             role="ace-editor"
             setOptions={{
               behavioursEnabled: false,

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -239,12 +239,6 @@ export default class ExpressionEditorTextfield extends React.Component {
     }
   };
 
-  handleFocus = () => {
-    this.setState({ isFocused: true });
-    const { editor } = this.input.current;
-    this.handleCursorChange(editor.selection);
-  };
-
   handleInputBlur = e => {
     this.setState({ isFocused: false });
 
@@ -387,7 +381,6 @@ export default class ExpressionEditorTextfield extends React.Component {
             wrapEnabled={true}
             fontSize={12}
             onBlur={this.handleInputBlur}
-            onFocus={this.handleFocus}
             // onLoad circumvents a buggy onFocus,
             // see declaration of `handleEditorLoaded`
             onLoad={this.handleEditorLoaded}


### PR DESCRIPTION
This PR attempts to fix a bug where the code editor input is vertically misplaced for some users.

### How to Test

a. Manual use

1. Ask a question
2. Custom question
3. Sample Dataset
4. Orders
5. Click on Custom Column icon

Type in the editor. 
It should show the code normally, vertically aligned with the `=` prefix.

b. In Cypress

🎗️ This is a partial fix.
In complete test functions, the code is still misrendered, or Cypress flies right by it.
On the other hand, if we pause when the editor is rendered and manually go on, the input is rendered correctly. It did not render correctly before these changes.

Edit file `frontend/test/metabase/scenarios/custom-column/custom-column.cy.spec.js`, commenting out lines `41-44` and `51-56`.

Append a `.only` to the `it` in line 35.

Run the test in Cypress.

Take control of the input once the test ends. Input should be rendered nicely. In master, there is the vertical misalignment.