### PR TITLE
Only use webpack filesystem caching when FS_CACHE=true is set

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,6 +26,7 @@ const BUILD_PATH = __dirname + "/resources/frontend_client";
 // default WEBPACK_BUNDLE to development
 const WEBPACK_BUNDLE = process.env.WEBPACK_BUNDLE || "development";
 const devMode = WEBPACK_BUNDLE !== "production";
+const useFilesystemCache = process.env.FS_CACHE === "true";
 
 // Babel:
 const BABEL_CONFIG = {
@@ -133,16 +134,15 @@ const config = (module.exports = {
           : SRC_PATH + "/lib/noop",
     },
   },
-  cache:
-    WEBPACK_BUNDLE === "hot"
-      ? {
-          type: "filesystem",
-          buildDependencies: {
-            // invalidates the cache on configuration change
-            config: [__filename],
-          },
-        }
-      : false,
+  cache: useFilesystemCache
+    ? {
+        type: "filesystem",
+        buildDependencies: {
+          // invalidates the cache on configuration change
+          config: [__filename],
+        },
+      }
+    : undefined,
   optimization: {
     splitChunks: {
       cacheGroups: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -133,15 +133,16 @@ const config = (module.exports = {
           : SRC_PATH + "/lib/noop",
     },
   },
-  cache: devMode
-    ? {
-        type: "filesystem",
-        buildDependencies: {
-          // invalidates the cache on configuration change
-          config: [__filename],
-        },
-      }
-    : false,
+  cache:
+    WEBPACK_BUNDLE === "hot"
+      ? {
+          type: "filesystem",
+          buildDependencies: {
+            // invalidates the cache on configuration change
+            config: [__filename],
+          },
+        }
+      : false,
   optimization: {
     splitChunks: {
       cacheGroups: {


### PR DESCRIPTION
filesystem caching appears to be causing problems in CI and for BE engineers, so we're hiding it behind a flag. Using `yarn dev` or `yarn build-hot` etc will not use filesystem caching -- instead, they'll use webpack's default behavior: in development, memory caching will be used; product remains the same in that caching isn't used at all. Memory caching will be slower and cause occasional out of memory errors but that may be preferable to annoying cache issues.

If you want to use filesystem caching, you'll now need to add `FS_CACHE=true` before the comment; so, `FS_CACHE=true yarn dev` or `FS_CACHE=true yarn build-hot` and so on.