### PR TITLE
Update question/save e2e test

### DIFF
--- a/frontend/test/metabase/scenarios/question/saved.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/saved.cy.spec.js
@@ -123,7 +123,7 @@ describe("scenarios > question > saved", () => {
 
     cy.findByRole("button", { name: "Revert" }).click();
 
-    cy.findByText(/Reverted to an earlier revision/i);
+    cy.findByText(/This is a question/i).should("not.exist");
   });
 
   it("should be able to use integer filter on a saved native query (metabase#15808)", () => {


### PR DESCRIPTION
Fixes currently failing e2e test.

Feature seems to have changed, as there are no more notifications of `Reverted to an earlier revision` on a history revert.

Rather, we now check for the disappearance of the question description as it's been reverted away from.