### PR TITLE
Add TableInfoPopovers to data selector, query builder header, search, and native query reference sidebar

### DIFF
--- a/frontend/src/metabase-lib/lib/metadata/Table.ts
+++ b/frontend/src/metabase-lib/lib/metadata/Table.ts
@@ -17,6 +17,7 @@ import { memoize, createLookupByProperty } from "metabase-lib/lib/utils";
 export default class Table extends Base {
   id: number;
   description?: string;
+  fks?: any[];
 
   hasSchema() {
     return (this.schema_name && this.db && this.db.schemas.length > 1) || false;

--- a/frontend/src/metabase/components/MetadataInfo/MetadataInfo.styled.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/MetadataInfo.styled.tsx
@@ -72,6 +72,7 @@ type FadeProps = {
 };
 
 export const Fade = styled.div<FadeProps>`
+  position: relative;
   width: 100%;
   transition: opacity ${TRANSITION_DURATION} linear;
   opacity: ${({ visible }) => (visible ? "1" : "0")};

--- a/frontend/src/metabase/components/MetadataInfo/TableInfo/ConnectedTables.styled.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/TableInfo/ConnectedTables.styled.tsx
@@ -1,14 +1,31 @@
 import styled from "styled-components";
 
 import { color } from "metabase/lib/colors";
+import Link from "metabase/components/Link";
 
 import TableLabel from "../TableLabel/TableLabel";
 
 export const InteractiveTableLabel = styled(TableLabel)`
-  cursor: pointer;
   color: ${color("text-light")};
+`;
 
-  &:hover {
-    color: ${color("brand")};
+export const LabelButton = styled.button`
+  cursor: pointer;
+  text-align: left;
+
+  &:hover,
+  &:focus {
+    ${InteractiveTableLabel} {
+      color: ${color("brand")};
+    }
+  }
+`;
+
+export const LabelLink = styled(Link)`
+  &:hover,
+  &:focus {
+    ${InteractiveTableLabel} {
+      color: ${color("brand")};
+    }
   }
 `;

--- a/frontend/src/metabase/components/MetadataInfo/TableInfo/ConnectedTables.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/TableInfo/ConnectedTables.tsx
@@ -3,31 +3,66 @@ import PropTypes from "prop-types";
 import { t } from "ttag";
 
 import Table from "metabase-lib/lib/metadata/Table";
-import Link from "metabase/components/Link";
 
 import { Label, LabelContainer, Container } from "../MetadataInfo.styled";
-import { InteractiveTableLabel } from "./ConnectedTables.styled";
+import {
+  InteractiveTableLabel,
+  LabelButton,
+  LabelLink,
+} from "./ConnectedTables.styled";
 
 ConnectedTables.propTypes = {
   table: PropTypes.instanceOf(Table).isRequired,
 };
 
-function ConnectedTables({ table }: { table: Table }) {
+type Props = {
+  table: Table;
+  onConnectedTableClick?: (table: Table) => void;
+};
+
+function ConnectedTables({ table, onConnectedTableClick }: Props) {
   const fkTables = table.connectedTables();
+
   return fkTables.length ? (
     <Container>
       <LabelContainer color="text-dark">
         <Label>{t`Connected to these tables`}</Label>
       </LabelContainer>
       {fkTables.map(fkTable => {
-        return (
-          <Link key={fkTable.id} to={fkTable.newQuestion().getUrl()}>
-            <InteractiveTableLabel table={fkTable} />
-          </Link>
+        return onConnectedTableClick ? (
+          <ConnectedTableButton
+            key={fkTable.id}
+            table={fkTable}
+            onClick={onConnectedTableClick}
+          />
+        ) : (
+          <ConnectedTableLink key={fkTable.id} table={fkTable} />
         );
       })}
     </Container>
   ) : null;
+}
+
+function ConnectedTableButton({
+  table,
+  onClick,
+}: {
+  table: Table;
+  onClick: (table: Table) => void;
+}) {
+  return (
+    <LabelButton key={table.id} onClick={() => onClick(table)}>
+      <InteractiveTableLabel table={table} />
+    </LabelButton>
+  );
+}
+
+function ConnectedTableLink({ table }: { table: Table }) {
+  return (
+    <LabelLink to={table.newQuestion().getUrl()}>
+      <InteractiveTableLabel table={table} />
+    </LabelLink>
+  );
 }
 
 export default ConnectedTables;

--- a/frontend/src/metabase/components/MetadataInfo/TableInfo/TableInfo.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/TableInfo/TableInfo.tsx
@@ -21,6 +21,7 @@ import ConnectedTables from "./ConnectedTables";
 type OwnProps = {
   className?: string;
   tableId: number;
+  onConnectedTableClick?: (table: Table) => void;
 };
 
 const mapStateToProps = (state: any, props: OwnProps): { table?: Table } => {
@@ -56,7 +57,7 @@ function useDependentTableMetadata({
   table,
   fetchForeignKeys,
   fetchMetadata,
-}: Omit<AllProps, "className">) {
+}: Pick<AllProps, "tableId" | "table" | "fetchForeignKeys" | "fetchMetadata">) {
   const isMissingFields = !table?.numFields();
   const isMissingFks = table?.fks == null;
   const shouldFetchMetadata = isMissingFields || isMissingFks;
@@ -87,6 +88,7 @@ export function TableInfo({
   table,
   fetchForeignKeys,
   fetchMetadata,
+  onConnectedTableClick,
 }: AllProps): JSX.Element {
   const description = table?.description;
   const hasFetchedMetadata = useDependentTableMetadata({
@@ -113,7 +115,12 @@ export function TableInfo({
           {table && <ColumnCount table={table} />}
         </Fade>
         <Fade visible={hasFetchedMetadata}>
-          {table && <ConnectedTables table={table} />}
+          {table && (
+            <ConnectedTables
+              table={table}
+              onConnectedTableClick={onConnectedTableClick}
+            />
+          )}
         </Fade>
       </MetadataContainer>
     </InfoContainer>

--- a/frontend/src/metabase/components/MetadataInfo/TableInfo/TableInfo.unit.spec.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/TableInfo/TableInfo.unit.spec.tsx
@@ -6,12 +6,6 @@ import Table from "metabase-lib/lib/metadata/Table";
 
 import { TableInfo } from "./TableInfo";
 
-const productsTableWithoutMetadata = new Table({
-  ...PRODUCTS,
-  fields: undefined,
-  fks: undefined,
-});
-
 const productsTable = new Table({
   ...PRODUCTS,
   fields: [1, 2, 3],
@@ -36,13 +30,13 @@ const tableWithoutDescription = new Table({
 const fetchForeignKeys = jest.fn();
 const fetchMetadata = jest.fn();
 
-function setup(table: Table) {
+function setup({ id, table }: { table: Table | undefined; id: number }) {
   fetchForeignKeys.mockReset();
   fetchMetadata.mockReset();
 
   return render(
     <TableInfo
-      tableId={table.id}
+      tableId={id}
       table={table}
       fetchForeignKeys={fetchForeignKeys}
       fetchMetadata={fetchMetadata}
@@ -51,33 +45,65 @@ function setup(table: Table) {
 }
 
 describe("TableInfo", () => {
-  it("should send requests fetching table metadata", () => {
-    setup(productsTableWithoutMetadata);
-
-    expect(fetchForeignKeys).toHaveBeenCalledWith({
+  it("should fetch table metadata if fields are missing", () => {
+    setup({
       id: PRODUCTS.id,
+      table: new Table({ ...PRODUCTS, fields: undefined, fks: [] }),
     });
     expect(fetchMetadata).toHaveBeenCalledWith({
+      id: PRODUCTS.id,
+    });
+    expect(fetchForeignKeys).not.toHaveBeenCalled();
+  });
+
+  it("should fetch table metadata if the table is undefined", () => {
+    setup({ id: 123, table: undefined });
+
+    expect(fetchMetadata).toHaveBeenCalledWith({
+      id: 123,
+    });
+    expect(fetchForeignKeys).toHaveBeenCalledWith({
+      id: 123,
+    });
+  });
+
+  it("should fetch fks if fks are undefined on table", () => {
+    setup({
+      id: PRODUCTS.id,
+      table: new Table({ ...PRODUCTS, fields: [1, 2, 3], fks: undefined }),
+    });
+
+    expect(fetchMetadata).not.toHaveBeenCalled();
+    expect(fetchForeignKeys).toHaveBeenCalledWith({
       id: PRODUCTS.id,
     });
   });
 
   it("should not send requests fetching table metadata when metadata is already present", () => {
-    setup(productsTable);
+    setup({
+      id: PRODUCTS.id,
+      table: productsTable,
+    });
 
     expect(fetchForeignKeys).not.toHaveBeenCalled();
     expect(fetchMetadata).not.toHaveBeenCalled();
   });
 
   it("should display a placeholder if table has no description", async () => {
-    setup(tableWithoutDescription);
+    setup({
+      id: tableWithoutDescription.id,
+      table: tableWithoutDescription,
+    });
 
     expect(await screen.findByText("No description")).toBeInTheDocument();
   });
 
   describe("after metadata has been fetched", () => {
     beforeEach(() => {
-      setup(productsTable);
+      setup({
+        id: PRODUCTS.id,
+        table: productsTable,
+      });
     });
 
     it("should display the given table's description", () => {

--- a/frontend/src/metabase/components/MetadataInfo/TableInfoPopover/TableInfoPopover.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/TableInfoPopover/TableInfoPopover.tsx
@@ -13,14 +13,15 @@ const propTypes = {
   tableId: PropTypes.number.isRequired,
   children: PropTypes.node,
   placement: PropTypes.string,
+  offset: PropTypes.arrayOf(PropTypes.number),
 };
 
 type Props = { tableId: number } & Pick<
   ITippyPopoverProps,
-  "children" | "placement"
+  "children" | "placement" | "offset"
 >;
 
-function TableInfoPopover({ tableId, children, placement }: Props) {
+function TableInfoPopover({ tableId, children, placement, offset }: Props) {
   placement = placement || "left-start";
 
   return tableId != null ? (
@@ -28,6 +29,7 @@ function TableInfoPopover({ tableId, children, placement }: Props) {
       interactive
       delay={POPOVER_DELAY}
       placement={placement}
+      offset={offset}
       content={<WidthBoundTableInfo tableId={tableId} />}
     >
       {children}

--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -18,6 +18,7 @@ import Icon from "metabase/components/Icon";
 import PopoverWithTrigger from "metabase/components/PopoverWithTrigger";
 import AccordionList from "metabase/components/AccordionList";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
+import TableInfoPopover from "metabase/components/MetadataInfo/TableInfoPopover";
 
 import MetabaseSettings from "metabase/lib/settings";
 import { getSchemaName } from "metabase/lib/schema";
@@ -1433,6 +1434,17 @@ const TablePicker = ({
             item.table ? <Icon name="table2" size={18} /> : null
           }
           showItemArrows={hasNextStep}
+          renderItemWrapper={(itemContent, item) => {
+            if (item.table?.id != null) {
+              return (
+                <TableInfoPopover tableId={item.table.id}>
+                  {itemContent}
+                </TableInfoPopover>
+              );
+            }
+
+            return itemContent;
+          }}
         />
         {isSavedQuestionList && (
           <div className="bg-light p2 text-centered border-top">

--- a/frontend/src/metabase/query_builder/components/dataref/TablePane.jsx
+++ b/frontend/src/metabase/query_builder/components/dataref/TablePane.jsx
@@ -1,19 +1,11 @@
-/* eslint "react/prop-types": "warn" */
 import React from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { t } from "ttag";
-import cx from "classnames";
 
-// components
 import Icon from "metabase/components/Icon";
 import Expandable from "metabase/components/Expandable";
-
-// lib
-import { foreignKeyCountsByOriginTable } from "metabase/lib/schema_metadata";
-import { inflect } from "metabase/lib/formatting";
-
-// entities
+import { TableInfo } from "./TablePane.styled";
 import Table from "metabase/entities/tables";
 
 const mapStateToProps = (state, ownProps) => ({
@@ -29,7 +21,6 @@ const mapDispatchToProps = {
 @connect(mapStateToProps, mapDispatchToProps)
 export default class TablePane extends React.Component {
   state = {
-    pane: "fields",
     error: null,
   };
 
@@ -57,87 +48,10 @@ export default class TablePane extends React.Component {
     }
   }
 
-  showPane = name => {
-    this.setState({ pane: name });
-  };
-
   render() {
     const { table } = this.props;
-    const { pane, error } = this.state;
+    const { error } = this.state;
     if (table) {
-      const fks = table.fks || [];
-      const panes = {
-        fields: table.fields.length,
-        // "metrics": table.metrics.length,
-        // "segments": table.segments.length,
-        connections: fks.length,
-      };
-      const tabs = Object.entries(panes).map(([name, count]) => (
-        <a
-          key={name}
-          className={cx("Button Button--small", {
-            "Button--active": name === pane,
-          })}
-          onClick={this.showPane.bind(null, name)}
-        >
-          <span className="DataReference-paneCount">{count}</span>
-          <span>{inflect(name, count)}</span>
-        </a>
-      ));
-
-      const descriptionClasses = cx({ "text-medium": !table.description });
-      const description = (
-        <p className={"text-spaced " + descriptionClasses}>
-          {table.description || t`No description set.`}
-        </p>
-      );
-      let content;
-      if (pane === "connections") {
-        const fkCountsByTable = foreignKeyCountsByOriginTable(fks);
-        content = (
-          <ul>
-            {fks
-              .sort((a, b) =>
-                a.origin.table.display_name.localeCompare(
-                  b.origin.table.display_name,
-                ),
-              )
-              .map(fk => (
-                <li key={fk.id}>
-                  <a
-                    onClick={() => this.props.show("field", fk.origin)}
-                    className="flex-full flex p1 text-bold text-brand text-wrap no-decoration bg-medium-hover"
-                  >
-                    {fk.origin.table.display_name}
-                    {fkCountsByTable[fk.origin.table.id] > 1 ? (
-                      <span className="text-medium text-light h5">
-                        {" "}
-                        via {fk.origin.display_name}
-                      </span>
-                    ) : null}
-                  </a>
-                </li>
-              ))}
-          </ul>
-        );
-      } else if (pane) {
-        const itemType = pane.replace(/s$/, "");
-        content = (
-          <ul>
-            {table[pane].map((item, index) => (
-              <li key={item.id}>
-                <a
-                  onClick={() => this.props.show(itemType, item)}
-                  className="flex-full flex p1 text-bold text-brand text-wrap no-decoration bg-medium-hover"
-                >
-                  {item.name}
-                </a>
-              </li>
-            ))}
-          </ul>
-        );
-      }
-
       return (
         <div>
           <div className="ml1">
@@ -145,12 +59,24 @@ export default class TablePane extends React.Component {
               <Icon name="table2" className="text-medium pr1" size={16} />
               <h3 className="text-wrap">{table.name}</h3>
             </div>
-            {description}
+            <TableInfo tableId={table.id} />
             <div className="my2 Button-group Button-group--brand text-uppercase">
-              {tabs}
+              {
+                <ul>
+                  {table.fields.map((item, index) => (
+                    <li key={item.id}>
+                      <a
+                        onClick={() => this.props.show("field", item)}
+                        className="flex-full flex p1 text-bold text-brand text-wrap no-decoration bg-medium-hover"
+                      >
+                        {item.name}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              }
             </div>
           </div>
-          {content}
         </div>
       );
     } else {

--- a/frontend/src/metabase/query_builder/components/dataref/TablePane.jsx
+++ b/frontend/src/metabase/query_builder/components/dataref/TablePane.jsx
@@ -59,8 +59,11 @@ export default class TablePane extends React.Component {
               <Icon name="table2" className="text-medium pr1" size={16} />
               <h3 className="text-wrap">{table.name}</h3>
             </div>
-            <TableInfo tableId={table.id} />
-            <div className="my2 Button-group Button-group--brand text-uppercase">
+            <TableInfo
+              tableId={table.id}
+              onConnectedTableClick={table => this.props.show("table", table)}
+            />
+            <div className="my2 text-uppercase">
               {
                 <ul>
                   {table.fields.map((item, index) => (

--- a/frontend/src/metabase/query_builder/components/dataref/TablePane.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/dataref/TablePane.styled.tsx
@@ -1,0 +1,9 @@
+import styled from "styled-components";
+
+import { color } from "metabase/lib/colors";
+import _TableInfo from "metabase/components/MetadataInfo/TableInfo";
+
+export const TableInfo = styled(_TableInfo)`
+  padding: 1em 0;
+  border-bottom: 1px solid ${color("border")};
+`;

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
@@ -7,6 +7,8 @@ import {
 } from "metabase/lib/saved-questions";
 import * as Urls from "metabase/lib/urls";
 import Questions from "metabase/entities/questions";
+import TableInfoPopover from "metabase/components/MetadataInfo/TableInfoPopover";
+
 import { HeadBreadcrumbs } from "./HeaderBreadcrumbs";
 import { TablesDivider } from "./QuestionDataSource.styled";
 
@@ -202,7 +204,9 @@ function QuestionTableBadges({ tables, subHead, hasLink, isLast }) {
       to={hasLink ? getTableURL(table) : ""}
       inactiveColor={badgeInactiveColor}
     >
-      {table.displayName()}
+      <TableInfoPopover tableId={table.id} placement="bottom-start">
+        <span>{table.displayName()}</span>
+      </TableInfoPopover>
     </HeadBreadcrumbs.Badge>
   ));
 

--- a/frontend/src/metabase/search/components/InfoText.jsx
+++ b/frontend/src/metabase/search/components/InfoText.jsx
@@ -66,7 +66,7 @@ function getCollectionInfoText(collection) {
 
 function TablePath({ result }) {
   return jt`Table in ${(
-    <span>
+    <span key="table-path">
       <Database.Link id={result.database_id} />{" "}
       {result.table_schema && (
         <Schema.ListLoader

--- a/frontend/src/metabase/search/components/SearchResult.jsx
+++ b/frontend/src/metabase/search/components/SearchResult.jsx
@@ -7,6 +7,7 @@ import { isSyncCompleted } from "metabase/lib/syncing";
 
 import Icon from "metabase/components/Icon";
 import Text from "metabase/components/type/Text";
+import TableInfoPopover from "metabase/components/MetadataInfo/TableInfoPopover";
 
 import { PLUGIN_COLLECTIONS, PLUGIN_MODERATION } from "metabase/plugins";
 
@@ -98,14 +99,9 @@ export default function SearchResult({
   const active = isItemActive(result);
   const loading = isItemLoading(result);
 
-  return (
-    <ResultLink
-      active={active}
-      compact={compact}
-      to={!onClick ? result.getUrl() : ""}
-      onClick={onClick ? () => onClick(result) : undefined}
-      data-testid="search-result-item"
-    >
+  const linkContent = wrapInPopover(
+    result,
+    <div>
       <Flex align="start">
         <ItemIcon item={result} type={result.model} active={active} />
         <Box>
@@ -129,6 +125,18 @@ export default function SearchResult({
         {loading && <ResultSpinner size={24} borderWidth={3} />}
       </Flex>
       {compact || <Context context={result.context} />}
+    </div>,
+  );
+
+  return (
+    <ResultLink
+      active={active}
+      compact={compact}
+      to={!onClick ? result.getUrl() : ""}
+      onClick={onClick ? () => onClick(result) : undefined}
+      data-testid="search-result-item"
+    >
+      {linkContent}
     </ResultLink>
   );
 }
@@ -149,5 +157,22 @@ const isItemLoading = result => {
       return !isSyncCompleted(result);
     default:
       return false;
+  }
+};
+
+const wrapInPopover = (result, content) => {
+  switch (result.model) {
+    case "table":
+      return (
+        <TableInfoPopover
+          placement="right-start"
+          offset={[-10, 22]}
+          tableId={result.table_id}
+        >
+          {content}
+        </TableInfoPopover>
+      );
+    default:
+      return content;
   }
 };

--- a/frontend/test/metabase/scenarios/native/data_ref.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/data_ref.cy.spec.js
@@ -13,6 +13,9 @@ describe("scenarios > native question > data reference sidebar", () => {
     // Force-clicking was needed here because Cypress complains that "ORDERS" is covered by a <div>
     // TODO: Maybe re-think the structure of that component because that div seems unnecessary anyway
     cy.findByText("ORDERS").click({ force: true });
+    cy.findByText("This is a confirmed order for a product from a user.");
+    cy.findByText("9 columns");
+
     cy.findByText("QUANTITY").click({ force: true });
     cy.findByText("Number of products bought.");
   });

--- a/frontend/test/metabase/scenarios/question/new.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/new.cy.spec.js
@@ -444,6 +444,20 @@ describe("scenarios > question > new", () => {
       cy.contains("37.65");
     });
 
+    it("should show a table info popover when hovering over the table name in the header", () => {
+      cy.visit("/");
+      cy.contains("Ask a question").click();
+      cy.contains("Custom question").click();
+      cy.contains("Sample Dataset").click();
+      cy.contains("Orders").click();
+
+      visualize();
+
+      cy.findByTestId("question-table-badges").trigger("mouseenter");
+
+      cy.findByText("9 columns");
+    });
+
     it("should allow using `Custom Expression` in orders metrics (metabase#12899)", () => {
       openOrdersTable({ mode: "notebook" });
       cy.findByText("Summarize").click();

--- a/frontend/test/metabase/scenarios/question/saved.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/saved.cy.spec.js
@@ -149,4 +149,10 @@ describe("scenarios > question > saved", () => {
     cy.findByText("Synergistic Granite Chair");
     cy.findByText("Rustic Paper Wallet").should("not.exist");
   });
+
+  it("should show table name in header with a table info popover on hover", () => {
+    cy.visit("/question/1");
+    cy.findByTestId("question-table-badges").trigger("mouseenter");
+    cy.findByText("9 columns");
+  });
 });


### PR DESCRIPTION
#18738 

Adds `TableInfoPopover` to a few places around the app. Also includes a few minor improvements to `TableInfo` to fix a UI issue and to fix scenarios where `table.fields` exists but `table.fks` don't.

I've added a few e2e tests when the popovers aren't used in a list component like `DataSelector` / `TablePicker`. In lists (with scroll) things get a bit flaky, so I've made https://github.com/metabase/metabase/issues/19454 to implement these tests later

**Testing**
1. Go to one of the places mentioned below and hover your mouse over the entry
2. Check it after caching table metadata on a different page or right after a browser refresh

`DataSelector` on `/question/new` and the native query template tag sidebar:
<img width="668" alt="Screen Shot 2021-12-22 at 5 17 03 PM" src="https://user-images.githubusercontent.com/13057258/147173077-c6f2b50c-5569-4374-8c9f-66b1bb5c870b.png">
<img width="672" alt="Screen Shot 2021-12-22 at 5 17 29 PM" src="https://user-images.githubusercontent.com/13057258/147173082-07d386ea-d9aa-497a-855a-8e7b6d0e263e.png">

Searching in the data selector or the nav searchbar:
<img width="650" alt="Screen Shot 2021-12-22 at 5 18 34 PM" src="https://user-images.githubusercontent.com/13057258/147173109-cd218860-3aa2-4b57-9e87-5e6c3cb9dcb2.png">

Table names in the query builder header (first image, an ad hoc table query; second image, a saved question):
<img width="599" alt="Screen Shot 2021-12-22 at 5 19 04 PM" src="https://user-images.githubusercontent.com/13057258/147173160-f60282b5-f530-4e86-8def-c48b49c2c454.png">
<img width="487" alt="Screen Shot 2021-12-22 at 5 19 30 PM" src="https://user-images.githubusercontent.com/13057258/147173166-3e6c90c0-0587-4339-90d0-b459731aacc7.png">

And it replaces the `TablePane` UI found in the native query editor when you click the "reference" icon:
<img width="505" alt="Screen Shot 2021-12-22 at 5 20 02 PM" src="https://user-images.githubusercontent.com/13057258/147173219-3a9c1e69-b945-4c4f-88d8-2eb93051b8d7.png">

