### PR TITLE
fix lack of metadata in QB when coming from dashcard

### DIFF
--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -412,17 +412,31 @@ export const initializeQB = (location, params, queryParams) => {
             card.dashboardId = dashboardId;
           }
         } else if (card.original_card_id) {
+          const deserializedCard = card;
           // deserialized card contains the card id, so just populate originalCard
           originalCard = await loadCard(card.original_card_id);
-          if (
-            cardIsEquivalent(card, originalCard, { checkParameters: false }) &&
-            !cardIsEquivalent(card, originalCard, { checkParameters: true })
-          ) {
-            // if the cards are equal except for parameters, copy over the id to undirty the card
-            card.id = originalCard.id;
-          } else if (cardIsEquivalent(card, originalCard)) {
-            // if the cards are equal then show the original
+
+          if (cardIsEquivalent(deserializedCard, originalCard)) {
             card = Utils.copy(originalCard);
+
+            if (
+              !cardIsEquivalent(deserializedCard, originalCard, {
+                checkParameters: true,
+              })
+            ) {
+              const metadata = getMetadata(getState());
+              const { dashboardId, parameters } = deserializedCard;
+              verifyMatchingDashcardAndParameters({
+                dispatch,
+                dashboardId,
+                cardId: card.id,
+                parameters,
+                metadata,
+              });
+
+              card.parameters = parameters;
+              card.dashboardId = dashboardId;
+            }
           }
         }
         // if this card has any snippet tags we might need to fetch snippets pending permissions


### PR DESCRIPTION
Related to #18738 

When drilling from dashcard --> query builder, we are using the `card` that is deserialized from the URL. This `card` is missing all its metadata that it needs to show the `DimensionInfoPopover`. Fixable by taking the fetched card and setting anything "extra" that comes from the deserialized card (like `parameters` and `dashboardId`).

**Testing**
1. Create a user without self serve data permissions (as an admin, got into permissions and set All Users to "self serve" for the Sample Dataset)
2. Log in to the user without self serve data perms and navigate to a dashboard with parameters connected to cards
3. Click the title of a dashcard and hover your mouse over table headers in the QB. You should see popovers filled with metadata for the given `dimension`.

Before

https://user-images.githubusercontent.com/13057258/147287622-3f55395f-3ed3-4b75-8f02-d42dc7841427.mov

After

https://user-images.githubusercontent.com/13057258/147287629-97bdf6c7-263b-4212-9647-a4ec3693c045.mov


