### PR TITLE
Fix forcefully undefaulted number parameter filters getting set to NaN

### DIFF
--- a/frontend/src/metabase/parameters/utils/parameter-values.js
+++ b/frontend/src/metabase/parameters/utils/parameter-values.js
@@ -52,7 +52,7 @@ function parseParameterValueForFields(value, fields) {
   if (fields.length > 0) {
     // unix dates fields are numeric but query params shouldn't be parsed as numbers
     if (fields.every(f => f.isNumeric() && !f.isDate())) {
-      return parseFloat(value);
+      return value === "" ? value : parseFloat(value);
     }
 
     if (fields.every(f => f.isBoolean())) {

--- a/frontend/src/metabase/parameters/utils/parameter-values.unit.spec.js
+++ b/frontend/src/metabase/parameters/utils/parameter-values.unit.spec.js
@@ -194,7 +194,7 @@ describe("parameters/utils/parameter-values", () => {
           },
           metadata,
         ),
-      ).toBe(NaN);
+      ).toBe("");
     });
 
     it("should not parse numeric values that are dates as floats", () => {


### PR DESCRIPTION
Related to removing the operator parameter feature flag in https://github.com/metabase/metaboat/issues/144 and this change https://github.com/metabase/metabase/pull/17522 where we started treating a query param like `foo=` where the value is parsed as `""` to signify a defaulted parameter being forcefully unset so that the parameter isn't populated with a value on page load. We need to avoid a `parseFloat("")` so that the empty string is passed along and handled properly.

**Testing**
1. Create a dashboard, add a card to it that has numbers on it, like the Products table
2. Create a Number parameter filter and map it to a number field like Rating or Price
3. Set a default value for the filter
4. Save the dashboard and click the X in the parameter widget to forcefully clear the value.
5. Refresh the page -- the defaulted parameter shouldn't get defaulted
6. Clear the query params in the browser URL. Refresh again and the parameter should be populated with default values.

Before, after clicking the "X" on two defaulted number parameters and refreshing the page:
<img width="1254" alt="Screen Shot 2021-12-23 at 4 11 23 PM" src="https://user-images.githubusercontent.com/13057258/147301400-cc2d8e38-6b23-4b6c-8caf-611d8bd7b9d8.png">

After
<img width="1214" alt="Screen Shot 2021-12-23 at 4 15 31 PM" src="https://user-images.githubusercontent.com/13057258/147301410-147a8131-fe6d-46ed-b368-67817603b16f.png">

