### PR TITLE
Cache dashboard parameter values

### DIFF
--- a/frontend/src/metabase/dashboard/reducers.js
+++ b/frontend/src/metabase/dashboard/reducers.js
@@ -30,6 +30,8 @@ import {
   HIDE_ADD_PARAMETER_POPOVER,
   SET_SIDEBAR,
   CLOSE_SIDEBAR,
+  FETCH_DASHBOARD_PARAMETER_FIELD_VALUES,
+  SAVE_DASHBOARD_AND_CARDS,
 } from "./actions";
 
 import { isVirtualDashCard, syncParametersAndEmbeddingParams } from "./utils";
@@ -253,6 +255,20 @@ const parameterValues = handleActions(
   {},
 );
 
+const parameterValuesSearchCache = handleActions(
+  {
+    [INITIALIZE]: { next: () => ({}) },
+    [SAVE_DASHBOARD_AND_CARDS]: {
+      next: () => ({}),
+    },
+    [FETCH_DASHBOARD_PARAMETER_FIELD_VALUES]: {
+      next: (state, { payload }) =>
+        payload ? assoc(state, payload.id, payload.results) : state,
+    },
+  },
+  {},
+);
+
 const loadingDashCards = handleActions(
   {
     [FETCH_DASHBOARD]: {
@@ -336,4 +352,5 @@ export default combineReducers({
   loadingDashCards,
   isAddParameterPopoverOpen,
   sidebar,
+  parameterValuesSearchCache,
 });

--- a/frontend/src/metabase/dashboard/reducers.js
+++ b/frontend/src/metabase/dashboard/reducers.js
@@ -263,7 +263,7 @@ const parameterValuesSearchCache = handleActions(
     },
     [FETCH_DASHBOARD_PARAMETER_FIELD_VALUES]: {
       next: (state, { payload }) =>
-        payload ? assoc(state, payload.id, payload.results) : state,
+        payload ? assoc(state, payload.cacheKey, payload.results) : state,
     },
   },
   {},

--- a/frontend/src/metabase/dashboard/reducers.unit.spec.js
+++ b/frontend/src/metabase/dashboard/reducers.unit.spec.js
@@ -28,6 +28,7 @@ describe("dashboard reducers", () => {
         startTime: null,
       },
       parameterValues: {},
+      parameterValuesSearchCache: {},
       sidebar: { props: {} },
       slowCards: {},
     });

--- a/frontend/src/metabase/dashboard/selectors.js
+++ b/frontend/src/metabase/dashboard/selectors.js
@@ -143,3 +143,30 @@ export const getDefaultParametersById = createSelector(
       return map;
     }, {}),
 );
+
+export const getDashboardParameterValuesSearch = state =>
+  state.dashboard.parameterValuesSearchCache;
+
+export const getDashboardParameterValuesCache = state => {
+  return {
+    get: ({ dashboardId, parameter, parameters, query }) => {
+      const { parameterValuesSearchCache } = state.dashboard;
+      const { id: paramId, filteringParameters = [] } = parameter;
+      const otherValues = _.chain(parameters)
+        .filter(p => filteringParameters.includes(p.id) && p.value != null)
+        .map(p => [p.id, p.value])
+        .object()
+        .value();
+
+      const args = {
+        paramId,
+        dashId: dashboardId,
+        ...otherValues,
+        ...(query != null ? { query } : {}),
+      };
+
+      const key = JSON.stringify(args);
+      return parameterValuesSearchCache[key];
+    },
+  };
+};

--- a/frontend/src/metabase/parameters/utils/dashboards.js
+++ b/frontend/src/metabase/parameters/utils/dashboards.js
@@ -204,3 +204,29 @@ export function hasMatchingParameters({
     return dashcardMappingsByParameterId[parameter.id] != null;
   });
 }
+
+export function getFilteringParameterValuesMap(parameter, parameters) {
+  const { filteringParameters = [] } = parameter || {};
+  const filteringParameterValues = Object.fromEntries(
+    parameters
+      .filter(p => filteringParameters.includes(p.id) && p.value != null)
+      .map(p => [p.id, p.value]),
+  );
+
+  return filteringParameterValues;
+}
+
+export function getParameterValuesSearchKey({
+  dashboardId,
+  parameterId,
+  query = null,
+  filteringParameterValues = {},
+}) {
+  const sortedParameterValues = _.sortBy(
+    Object.entries(filteringParameterValues),
+    "0",
+  );
+  const stringifiedParameterValues = JSON.stringify(sortedParameterValues);
+
+  return `dashboardId: ${dashboardId}, parameterId: ${parameterId}, query: ${query}, filteringParameterValues: ${stringifiedParameterValues}`;
+}

--- a/frontend/src/metabase/parameters/utils/dashboards.js
+++ b/frontend/src/metabase/parameters/utils/dashboards.js
@@ -222,9 +222,11 @@ export function getParameterValuesSearchKey({
   query = null,
   filteringParameterValues = {},
 }) {
+  const BY_PARAMETER_ID = "0";
+  // sorting the filteringParameterValues map by its parameter id key to ensure entry order doesn't affect the outputted cache key
   const sortedParameterValues = _.sortBy(
     Object.entries(filteringParameterValues),
-    "0",
+    BY_PARAMETER_ID,
   );
   const stringifiedParameterValues = JSON.stringify(sortedParameterValues);
 

--- a/frontend/test/metabase/scenarios/dashboard/chained-filters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/chained-filters.cy.spec.js
@@ -197,6 +197,38 @@ describe("scenarios > dashboard > chained filter", () => {
         ).type("An");
         cy.findByText("Anchorage");
         cy.findByText("Anacoco").should("not.exist");
+
+        cy.get("input").clear();
+      });
+
+      cy.findByText("AK").click();
+      popover().within(() => {
+        cy.icon("close").click();
+        cy.get("input").type("GA");
+        cy.findByText("Update filter").click();
+      });
+
+      // do it again to make sure it isn't cached incorrectly
+      cy.findByText("Location 1").click();
+      popover().within(() => {
+        cy.get("input").type("An");
+        cy.findByText("Canton");
+        cy.findByText("Anchorage").should("not.exist");
+      });
+
+      cy.findByText("GA").click();
+      popover().within(() => {
+        cy.icon("close").click();
+        cy.findByText("Update filter").click();
+      });
+
+      // do it again without a state filter to make sure it isn't cached incorrectly
+      cy.findByText("Location 1").click();
+      popover().within(() => {
+        cy.get("input").type("An");
+        cy.findByText("Adrian");
+        cy.findByText("Anchorage");
+        cy.findByText("Canton");
       });
     });
   }

--- a/frontend/test/metabase/scenarios/dashboard/chained-filters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/chained-filters.cy.spec.js
@@ -198,34 +198,41 @@ describe("scenarios > dashboard > chained filter", () => {
         cy.findByText("Anchorage");
         cy.findByText("Anacoco").should("not.exist");
 
-        cy.get("input").clear();
+        cy.get("input")
+          .first()
+          .clear();
       });
 
       cy.findByText("AK").click();
       popover().within(() => {
-        cy.icon("close").click();
-        cy.get("input").type("GA");
+        cy.findByText("AK").click();
+        cy.findByText("GA").click();
+
         cy.findByText("Update filter").click();
       });
 
       // do it again to make sure it isn't cached incorrectly
       cy.findByText("Location 1").click();
       popover().within(() => {
-        cy.get("input").type("An");
+        cy.get("input")
+          .first()
+          .type("An");
         cy.findByText("Canton");
         cy.findByText("Anchorage").should("not.exist");
       });
 
       cy.findByText("GA").click();
       popover().within(() => {
-        cy.icon("close").click();
+        cy.findByText("GA").click();
         cy.findByText("Update filter").click();
       });
 
       // do it again without a state filter to make sure it isn't cached incorrectly
       cy.findByText("Location 1").click();
       popover().within(() => {
-        cy.get("input").type("An");
+        cy.get("input")
+          .first()
+          .type("An");
         cy.findByText("Adrian");
         cy.findByText("Anchorage");
         cy.findByText("Canton");


### PR DESCRIPTION
Resolves #16103 

Some basic caching for parameter widget values. I'm creating a key out of the args we pass to the two endpoints we use and using it to store results in redux. The cache is totally cleared when a dashboard is visited (the `INITIALIZE` action) and when a dashboard is saved (the `SAVE_DASHBOARD_AND_CARDS` action).

**Testing**
1. Create a dashboard, add some parameters, map the parameters to card. Open a parameter widget that is mapped to a field that lists values and it should only send a single request for the values list, even if you close it. Once you navigate off the page and back, it should refetch. If you save the dashboard for any reason it should refetch.
2. Test a parameter that is mapped to a field where you must search for values. Repeat the above steps.
3. Test a parameter that has been filtered by another parameter (in the parameters sidebar there's a linked filters tab -- use that to set this up) and make sure that the works and that the parameter is correctly cached using filtering parameter values.
4. Any other ideas to mess up the cache and cause problems

https://user-images.githubusercontent.com/13057258/147375462-94c681ad-909e-47a9-b7d8-5e38ab47268d.mov

Cache is cleared on re-entry

https://user-images.githubusercontent.com/13057258/147375482-3dab3609-2422-42cd-ae40-2926c17a2eb3.mov

Cache is cleared when the dashboard is saved

https://user-images.githubusercontent.com/13057258/147375488-34336b8c-d81b-47e4-9596-5e7c2da0f671.mov


