### PR TITLE
Use matrixes to reduce complexity

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ executors:
     docker:
       - image: metabase/ci:circleci-java-16-clj-1.10.3.929-07-27-2021-node-browsers
 
-  postgres-9-6:
+  postgres:
     working_directory: /home/circleci/metabase/metabase/
     docker:
       - image: metabase/ci:circleci-java-11-clj-1.10.3.929-07-27-2021-node-browsers
@@ -683,6 +683,12 @@ jobs:
       skip-when-no-change:
         type: boolean
         default: false
+      java-version:
+        type: string
+        default: ""
+      version:
+        type: string
+        default: ""
       <<: *Params
     executor: << parameters.e >>
     steps:
@@ -743,6 +749,9 @@ jobs:
         type: string
         default: ""
       test-args:
+        type: string
+        default: ""
+      version:
         type: string
         default: ""
     executor: << parameters.e >>
@@ -1063,31 +1072,16 @@ workflows:
             - checkout
 
       - clojure:
-          name: be-tests-<< matrix.edition >>
+          matrix:
+            parameters:
+              edition: ["ee", "oss"]
+              java-version: ["java-8", "java-11", "java-16"]
+          name: be-tests-<< matrix.java-version >>-<< matrix.edition >>
           requires:
             - be-deps
-          e: java-8
+          e: << matrix.java-version >>
           clojure-args: -X:dev:ci:test
           skip-when-no-change: true
-          <<: *Matrix
-
-      - clojure:
-          name: be-tests-java-11-<< matrix.edition >>
-          requires:
-            - be-deps
-          e: java-11
-          clojure-args: -X:dev:ci:test
-          skip-when-no-change: true
-          <<: *Matrix
-
-      - clojure:
-          name: be-tests-java-16-<< matrix.edition >>
-          requires:
-            - be-deps
-          e: java-16
-          clojure-args: -X:dev:ci:test
-          skip-when-no-change: true
-          <<: *Matrix
 
       - clojure:
           name: be-linter-cloverage
@@ -1103,69 +1097,61 @@ workflows:
           skip-when-no-change: true
 
       - test-driver:
-          name: be-tests-bigquery-ee
+          matrix:
+            parameters:
+              driver: ["bigquery", "bigquery-cloud-sdk", "googleanalytics", "sqlite"]
+          name: be-tests-<< matrix.driver >>
           requires:
-            - be-tests-ee
-          driver: bigquery
+            - be-tests-java-8-ee
+          driver: << matrix.driver >>
 
       - test-driver:
-          name: be-tests-bigquery-cloud-sdk-ee
+          matrix:
+            parameters:
+              driver: ["sqlserver", "druid", "postgres"]
+          name: be-tests-<< matrix.driver >>-ee
           requires:
-            - be-tests-ee
-          driver: bigquery-cloud-sdk
+            - be-tests-java-8-ee
+          e: << matrix.driver >>
+          driver: << matrix.driver >>
 
       - test-driver:
           name: be-google-related-drivers-classpath-test
           requires:
-            - be-tests-ee
+            - be-tests-java-8-ee
           driver: googleanalytics,bigquery,bigquery-cloud-sdk
           test-args: >-
             :only "[metabase.query-processor-test.expressions-test metabase.driver.google-test
                     metabase.driver.googleanalytics-test]"
 
       - test-driver:
-          name: be-tests-druid-ee
+          matrix:
+            parameters:
+              version: ["mongo-4-0", "mongo-latest"]
+          name: be-tests-<< matrix.version >>-ee
+          description: "(<< matrix.version >>)"
           requires:
-            - be-tests-ee
-          e: druid
-          driver: druid
-
-      - test-driver:
-          name: be-tests-googleanalytics-ee
-          requires:
-            - be-tests-ee
-          driver: googleanalytics
-
-      - test-driver:
-          name: be-tests-mongo-ee
-          description: "(Mongo 4.0)"
-          requires:
-            - be-tests-ee
-          e: mongo-4-0
+            - be-tests-java-8-ee
+          e: << matrix.version >>
           driver: mongo
 
       - test-driver:
-          name: be-tests-mongo-latest-ee
-          description: "(Mongo latest)"
+          matrix:
+            parameters:
+              version: ["mysql-5-7", "mariadb-10-2", "mariadb-latest"]
+          name: be-tests-<< matrix.version >>-ee
+          description: "(<< matrix.version >>)"
           requires:
-            - be-tests-ee
-          e: mongo-latest
-          driver: mongo
-
-      - test-driver:
-          name: be-tests-mysql-ee
-          description: "(MySQL 5.7)"
-          requires:
-            - be-tests-ee
+            - be-tests-java-8-ee
           e:
-            name: mysql-5-7
+            name: << matrix.version >>
           driver: mysql
 
       - test-driver:
           name: be-tests-mysql-latest-ee
           description: "(MySQL latest)"
           requires:
-            - be-tests-ee
+            - be-tests-java-8-ee
           e:
             name: mysql-latest
           driver: mysql
@@ -1183,27 +1169,9 @@ workflows:
             MB_MYSQL_SSL_TEST_PASSWORD=$MYSQL_RDS_SSL_INSTANCE_PASSWORD
 
       - test-driver:
-          name: be-tests-mariadb-ee
-          description: "(MariaDB 10.2)"
-          requires:
-            - be-tests-ee
-          e:
-            name: mariadb-10-2
-          driver: mysql
-
-      - test-driver:
-          name: be-tests-mariadb-latest-ee
-          description: "(MariaDB latest)"
-          requires:
-            - be-tests-ee
-          e:
-            name: mariadb-latest
-          driver: mysql
-
-      - test-driver:
           name: be-tests-oracle-ee
           requires:
-            - be-tests-ee
+            - be-tests-java-8-ee
           before-steps:
             - fetch-jdbc-driver:
                 source: ORACLE_JDBC_JAR
@@ -1221,18 +1189,10 @@ workflows:
             MB_ORACLE_SSL_TEST_SSL_TRUSTSTORE_PASSWORD_VALUE=metabase
 
       - test-driver:
-          name: be-tests-postgres-ee
-          description: "(9.6)"
-          requires:
-            - be-tests-ee
-          e: postgres-9-6
-          driver: postgres
-
-      - test-driver:
           name: be-tests-postgres-latest-ee
           description: "(Latest)"
           requires:
-            - be-tests-ee
+            - be-tests-java-8-ee
           e: postgres-latest
           driver: postgres
           extra-env: >-
@@ -1243,7 +1203,7 @@ workflows:
       - test-driver:
           name: be-tests-presto-ee
           requires:
-            - be-tests-ee
+            - be-tests-java-8-ee
           e: presto-186
           before-steps:
             - wait-for-port:
@@ -1253,7 +1213,7 @@ workflows:
       - test-driver:
           name: be-tests-presto-jdbc-ee
           requires:
-            - be-tests-ee
+            - be-tests-java-8-ee
           e: presto-jdbc-env # specific env for running Presto JDBC tests (newer Presto version, SSL, etc.)
           before-steps:
             - wait-for-port:
@@ -1289,21 +1249,21 @@ workflows:
       - test-driver:
           name: be-tests-redshift-ee
           requires:
-            - be-tests-ee
+            - be-tests-java-8-ee
           driver: redshift
           timeout: 15m
 
       - test-driver:
           name: be-tests-snowflake-ee
           requires:
-            - be-tests-ee
+            - be-tests-java-8-ee
           driver: snowflake
           timeout: 115m
 
       - test-driver:
           name: be-tests-sparksql-ee
           requires:
-            - be-tests-ee
+            - be-tests-java-8-ee
           e: sparksql
           before-steps:
             - wait-for-port:
@@ -1311,22 +1271,9 @@ workflows:
           driver: sparksql
 
       - test-driver:
-          name: be-tests-sqlite-ee
-          requires:
-            - be-tests-ee
-          driver: sqlite
-
-      - test-driver:
-          name: be-tests-sqlserver-ee
-          requires:
-            - be-tests-ee
-          e: sqlserver
-          driver: sqlserver
-
-      - test-driver:
           name: be-tests-vertica-ee
           requires:
-            - be-tests-ee
+            - be-tests-java-8-ee
           e: vertica
           before-steps:
             - fetch-jdbc-driver:
@@ -1403,14 +1350,12 @@ workflows:
             - wait-for-databases
 
       - fe-tests-cypress:
-          matrix:
-            parameters:
-              edition: ["ee", "oss"]
           name: percy-visual-tests-<< matrix.edition >>
           requires:
             - build-uberjar-<< matrix.edition >>
           cypress-group: "percy-visual-<< matrix.edition >>"
           test-files: "./frontend/test/metabase-visual/**/*.cy.spec.js"
+          <<: *Matrix
 
       - snowplow-deps:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ executors:
     docker:
       - image: metabase/ci:circleci-java-16-clj-1.10.3.929-07-27-2021-node-browsers
 
-  postgres:
+  postgres-9-6:
     working_directory: /home/circleci/metabase/metabase/
     docker:
       - image: metabase/ci:circleci-java-11-clj-1.10.3.929-07-27-2021-node-browsers
@@ -1100,7 +1100,7 @@ workflows:
           matrix:
             parameters:
               driver: ["bigquery", "bigquery-cloud-sdk", "googleanalytics", "sqlite"]
-          name: be-tests-<< matrix.driver >>
+          name: be-tests-<< matrix.driver >>-ee
           requires:
             - be-tests-java-8-ee
           driver: << matrix.driver >>
@@ -1108,7 +1108,7 @@ workflows:
       - test-driver:
           matrix:
             parameters:
-              driver: ["sqlserver", "druid", "postgres"]
+              driver: ["sqlserver", "druid"]
           name: be-tests-<< matrix.driver >>-ee
           requires:
             - be-tests-java-8-ee
@@ -1187,6 +1187,14 @@ workflows:
             MB_ORACLE_SSL_TEST_SSL_TRUSTSTORE_PATH=/home/circleci/metabase/metabase/resources/certificates/rds_root_ca_truststore.jks
             MB_ORACLE_SSL_TEST_SSL_TRUSTSTORE_OPTIONS=local
             MB_ORACLE_SSL_TEST_SSL_TRUSTSTORE_PASSWORD_VALUE=metabase
+
+      - test-driver:
+          name: be-tests-postgres-ee
+          description: "(9.6)"
+          requires:
+            - be-tests-java-8-ee
+          e: postgres-9-6
+          driver: postgres
 
       - test-driver:
           name: be-tests-postgres-latest-ee


### PR DESCRIPTION
Using matrixes to shed a few lines from the CircleCI config

NOTE: 
- I changed a node from be-tests-ee to be-tests-java-8-ee as I needed that to reuse a node (line 1072)