### PR TITLE
Bump tools build

### DIFF
--- a/bin/build-drivers/deps.edn
+++ b/bin/build-drivers/deps.edn
@@ -8,7 +8,7 @@
   expound/expound                 {:mvn/version "0.7.0"} ; better output of spec validation errors
   hiccup/hiccup                   {:mvn/version "1.0.5"}
   io.forward/yaml                 {:mvn/version "1.0.9"} ; Don't upgrade yet, new version doesn't support Java 8 (see https://github.com/owainlewis/yaml/issues/37)
-  io.github.clojure/tools.build   {:git/tag "v0.1.6", :git/sha "5636e61"}
+  io.github.clojure/tools.build   {:git/tag "v0.7.4" :git/sha "ac442da"}
   org.clojure/tools.deps.alpha    {:mvn/version "0.12.985"}
   org.flatland/ordered            {:mvn/version "1.5.9"} ; used by io.forward/yaml -- need the newer version
   com.bhauman/spell-spec          {:mvn/version "0.1.1"} ; used to find misspellings in YAML files

--- a/deps.edn
+++ b/deps.edn
@@ -399,7 +399,7 @@
   ;; clojure -T:build uberjar
   ;; clojure -T:build uberjar :edition :ee
   :build
-  {:deps       {io.github.clojure/tools.build   {:git/tag "v0.1.6", :git/sha "5636e61"}
+  {:deps       {io.github.clojure/tools.build   {:git/tag "v0.7.4" :git/sha "ac442da"}
                 com.github.seancorfield/depstar {:mvn/version "2.1.278"}
                 metabase/build.common           {:local/root "bin/common"}
                 metabase/buid-mb                {:local/root "bin/build-mb"}}

--- a/java/deps.edn
+++ b/java/deps.edn
@@ -7,7 +7,7 @@
 
  :aliases
  {:build
-  {:deps       {io.github.clojure/tools.build {:git/tag "v0.1.6" :git/sha "5636e61"}}
+  {:deps       {io.github.clojure/tools.build {:git/tag "v0.7.4" :git/sha "ac442da"}}
    :ns-default build}
 
   ;; dependencies needed for compiling the Java files.

--- a/modules/drivers/sparksql/deps.edn
+++ b/modules/drivers/sparksql/deps.edn
@@ -35,7 +35,7 @@
 
  :aliases
  {:aot
-  {:deps       {io.github.clojure/tools.build {:git/tag "v0.1.6" :git/sha "5636e61"}}
+  {:deps       {io.github.clojure/tools.build {:git/tag "v0.7.4" :git/sha "ac442da"}}
    :ns-default build}
 
   ;; dependencies needed for AOT compilation. Same as deps above but without all the exclusions.


### PR DESCRIPTION
Bump tools.build

Investigating a strange build error when CI ran the prep for drivers

```
Error AOT compiling Spark SQL namespaces: Syntax error compiling at (clojure/tools/reader/reader_types.clj:1:1).
{:via
 [{:type clojure.lang.Compiler$CompilerException,
   :message
   "Syntax error compiling at (clojure/tools/reader/reader_types.clj:1:1).",
   :data
   #:clojure.error{:phase :compile-syntax-check,
                   :line 1,
                   :column 1,
                   :source "clojure/tools/reader/reader_types.clj"},
   :at [clojure.lang.Compiler load "Compiler.java" 7652]}
  {:type java.lang.IllegalAccessError,
   :message "whitespace? does not exist",
   :at [clojure.core$refer invokeStatic "core.clj" 4237]}],
```

I don't think this solves it but might as well upgrade to the latest version.