### PR TITLE
Fix export type from cljs

### DIFF
--- a/frontend/src/metabase/lib/types.js
+++ b/frontend/src/metabase/lib/types.js
@@ -1,6 +1,6 @@
-import { isa as cljs_isa, TYPE } from "cljs/metabase.types";
+import { isa as cljs_isa, TYPE as cljs_TYPE } from "cljs/metabase.types";
 
-export { TYPE };
+export const TYPE = cljs_TYPE;
 
 /**
  * Is x the same as, or a descendant type of, y?


### PR DESCRIPTION
Fixes warning about missing exports in `metabase.types.js`.

How to test:
- Run `yarn dev`
- There should be no warnings about missing exports 