### PR TITLE
Fix year-change CI breaks

### DIFF
--- a/bin/docker/run_metabase.sh
+++ b/bin/docker/run_metabase.sh
@@ -23,21 +23,21 @@ fi
 # taken from https://github.com/docker-library/postgres/blob/master/docker-entrypoint.sh
 # This is the specific function that takes the env var which has a "_FILE" at the end and transforms that into a normal env var.
 file_env() {
-	local var="$1"
-	local fileVar="${var}_FILE"
-	local def="${2:-}"
-	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
-		echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
-		exit 1
-	fi
-	local val="$def"
-	if [ "${!var:-}" ]; then
-		val="${!var}"
-	elif [ "${!fileVar:-}" ]; then
-		val="$(< "${!fileVar}")"
-	fi
-	export "$var"="$val"
-	unset "$fileVar"
+    local var="$1"
+    local fileVar="${var}_FILE"
+    local def="${2:-}"
+    if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+        echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+        exit 1
+    fi
+    local val="$def"
+    if [ "${!var:-}" ]; then
+        val="${!var}"
+    elif [ "${!fileVar:-}" ]; then
+        val="$(< "${!fileVar}")"
+    fi
+    export "$var"="$val"
+    unset "$fileVar"
 }
 
 # Here we define which env vars are the ones that will be supported with a "_FILE" ending. We started with the ones that would contain sensitive data

--- a/test/metabase/query_processor/pivot_test.clj
+++ b/test/metabase/query_processor/pivot_test.clj
@@ -95,7 +95,7 @@
                       :filter       [:and
                                      [:= $user_id->people.source "Facebook" "Google"]
                                      [:= $product_id->products.category "Doohickey" "Gizmo"]
-                                     [:time-interval $created_at -2 :year {}]]}
+                                     [:time-interval $created_at -3 :year {}]]}
        :pivot-rows [0 1 2]
        :pivot-cols []})))
 

--- a/test/metabase/query_processor/pivot_test.clj
+++ b/test/metabase/query_processor/pivot_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.query-processor.pivot-test
   "Tests for pivot table actions for the query processor"
-  (:require [clojure.set :as set]
+  (:require [clj-time.core :as time]
+            [clojure.set :as set]
             [clojure.test :refer :all]
             [medley.core :as m]
             [metabase.api.pivots :as pivot.test-utils]
@@ -95,7 +96,7 @@
                       :filter       [:and
                                      [:= $user_id->people.source "Facebook" "Google"]
                                      [:= $product_id->products.category "Doohickey" "Gizmo"]
-                                     [:time-interval $created_at -3 :year {}]]}
+                                     [:time-interval $created_at (- 2019 (.getYear (time/now))) :year {}]]}
        :pivot-rows [0 1 2]
        :pivot-cols []})))
 

--- a/test/metabase/query_processor_test/implicit_joins_test.clj
+++ b/test/metabase/query_processor_test/implicit_joins_test.clj
@@ -157,6 +157,6 @@
                     :filter      [:and
                                   [:= $user_id->people.source "Facebook" "Google"]
                                   [:= $product_id->products.category "Doohickey" "Gizmo"]
-                                  [:time-interval $created_at -2 :year]]
+                                  [:time-interval $created_at -3 :year]]
                     :expressions {:pivot-grouping [:abs 0]}
                     :limit       5}))))))))

--- a/test/metabase/query_processor_test/implicit_joins_test.clj
+++ b/test/metabase/query_processor_test/implicit_joins_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.query-processor-test.implicit-joins-test
   "Tests for joins that are created automatically when an `:fk->` column is present."
-  (:require [clojure.test :refer :all]
+  (:require [clj-time.core :as time]
+            [clojure.test :refer :all]
             [metabase.driver :as driver]
             [metabase.test :as mt]))
 
@@ -157,6 +158,6 @@
                     :filter      [:and
                                   [:= $user_id->people.source "Facebook" "Google"]
                                   [:= $product_id->products.category "Doohickey" "Gizmo"]
-                                  [:time-interval $created_at -3 :year]]
+                                  [:time-interval $created_at (- 2019 (.getYear (time/now))) :year]]
                     :expressions {:pivot-grouping [:abs 0]}
                     :limit       5}))))))))


### PR DESCRIPTION
CI is broken because of two tests that are secretly contingent upon year and because of whitespace shenanigans from Luis's change. Fixes them