### PR TITLE
Custom expression editor: hide error on the correction attempt

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -307,7 +307,7 @@ export default class ExpressionEditorTextfield extends React.Component {
   };
 
   handleExpressionChange(source) {
-    this.setState({ source });
+    this.setState({ source, errorMessage: null });
     if (this.props.onBlankChange) {
       this.props.onBlankChange(source.length === 0);
     }
@@ -400,7 +400,7 @@ export default class ExpressionEditorTextfield extends React.Component {
             highlightedIndex={this.state.highlightedSuggestionIndex}
           />
         </EditorContainer>
-        <ErrorMessage error={errorMessage} />
+        {!isFocused && <ErrorMessage error={errorMessage} />}
         <HelpText helpText={this.state.helpText} width={this.props.width} />
       </React.Fragment>
     );


### PR DESCRIPTION
How to verify:

1. Ask a question, Custom question
2. Sample Dataset, Orders table
3. Filter, Custom Expression, type `[Discount] >` (intentionally not complete)
4. Press Tab to switch focus, there will be an error message "Unexpected end of input"
5. Click on the editor and correct the expression to `[Discount] > 3`

**Before this PR**

Even though the expression is now complete and valid, the error message is still displayed:

![image](https://user-images.githubusercontent.com/7288/147961877-18e69580-8bc4-4046-9298-28bec661724f.png)

**After this PR**

As soon as the user tries to correct the expression, the error message is hidden. This restores the behavior like in v41 and earlier.

![image](https://user-images.githubusercontent.com/7288/147961853-5827433e-9338-4a50-b53f-2ac33b453660.png)


