### PR TITLE
Custom expression editor: show error marker

### DIFF
--- a/frontend/src/metabase/css/core/colors.css
+++ b/frontend/src/metabase/css/core/colors.css
@@ -16,6 +16,7 @@
   --color-black: #2e353b;
   --color-success: #84bb4c;
   --color-error: #ed6e6e;
+  --color-error-background: #ed6e6e55;
   --color-warning: #f9cf48;
   --color-text-dark: #4c5773;
   --color-text-medium: #949aab;

--- a/frontend/src/metabase/lib/expressions/tokenizer.js
+++ b/frontend/src/metabase/lib/expressions/tokenizer.js
@@ -322,7 +322,8 @@ export function tokenize(expression) {
         if (error) {
           const message = error;
           const pos = t.start;
-          errors.push({ message, pos });
+          const len = t.end - t.start;
+          errors.push({ message, pos, len });
         }
       } else {
         const char = source[index];
@@ -330,6 +331,7 @@ export function tokenize(expression) {
           break;
         }
         const pos = index;
+        const len = 1;
         if (char === "]") {
           const prev = tokens[tokens.length - 1];
           const ref =
@@ -339,10 +341,10 @@ export function tokenize(expression) {
           const message = ref
             ? t`Missing an opening bracket for ${ref}`
             : t`Missing an opening bracket`;
-          errors.push({ message, pos });
+          errors.push({ message, pos, len });
         } else {
           const message = t`Invalid character: ${char}`;
-          errors.push({ message, pos });
+          errors.push({ message, pos, len });
         }
         ++index;
       }

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -331,6 +331,25 @@ export default class ExpressionEditorTextfield extends React.Component {
     });
   }
 
+  errorAsMarkers(errorMessage = null) {
+    if (errorMessage) {
+      const { pos, len } = errorMessage;
+      if (typeof pos === "number") {
+        return [
+          {
+            startRow: 0,
+            startCol: pos,
+            endRow: 0,
+            endCol: pos + len,
+            className: "error",
+            type: "text",
+          },
+        ];
+      }
+    }
+    return [];
+  }
+
   commands = [
     {
       name: "arrowDown",
@@ -373,6 +392,7 @@ export default class ExpressionEditorTextfield extends React.Component {
             commands={this.commands}
             ref={this.input}
             value={source}
+            markers={this.errorAsMarkers(errorMessage)}
             focus={true}
             highlightActiveLine={false}
             wrapEnabled={true}

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -334,6 +334,7 @@ export default class ExpressionEditorTextfield extends React.Component {
   errorAsMarkers(errorMessage = null) {
     if (errorMessage) {
       const { pos, len } = errorMessage;
+      // Because not every error message offers location info (yet)
       if (typeof pos === "number") {
         return [
           {

--- a/frontend/src/metabase/query_builder/components/expressions/expressions.css
+++ b/frontend/src/metabase/query_builder/components/expressions/expressions.css
@@ -27,3 +27,9 @@
 .expression-editor-textfield .ace_hidden-cursors .ace_cursor {
   opacity: 0;
 }
+
+.expression-editor-textfield .ace_content .error {
+  position: absolute;
+  border-bottom: 2px solid var(--color-error);
+  border-radius: 0px;
+}

--- a/frontend/src/metabase/query_builder/components/expressions/expressions.css
+++ b/frontend/src/metabase/query_builder/components/expressions/expressions.css
@@ -32,4 +32,5 @@
   position: absolute;
   border-bottom: 2px solid var(--color-error);
   border-radius: 0px;
+  background-color: var(--color-error-background);
 }

--- a/frontend/test/metabase/lib/expressions/tokenizer.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/tokenizer.unit.spec.js
@@ -50,10 +50,12 @@ describe("metabase/lib/expressions/tokenizer", () => {
     expect(errors("2e")[0].message).toEqual("Missing exponent");
     expect(errors("3e+")[0].message).toEqual("Missing exponent");
     expect(errors("4E-")[0].message).toEqual("Missing exponent");
+    expect(errors("4E-")[0].len).toEqual(3);
   });
 
   it("should catch a lone decimal point", () => {
     expect(errors(".")[0].message).toEqual("Invalid character: .");
+    expect(errors(".")[0].len).toEqual(1);
   });
 
   it("should tokenize string literals", () => {
@@ -157,5 +159,6 @@ describe("metabase/lib/expressions/tokenizer", () => {
     expect(errors("!")[0].message).toEqual("Invalid character: !");
     expect(errors(" % @")[1].message).toEqual("Invalid character: @");
     expect(errors("    #")[0].pos).toEqual(4);
+    expect(errors("    #")[0].len).toEqual(1);
   });
 });


### PR DESCRIPTION
**Note**: this doesn't work for all error messages yet. I plan to do a few follow-up PRs to add support for various errors.

~~**WIP caveat**: if the expression spans two lines or more, the location is still incorrect.~~ This is not true, see more screenshot below.

How to verify:

1. Ask a question, Custom question
2. Sample Dataset, Orders table
3. Filter, Custom Expression, type `[Quantity] > # AND [Tax] = 0` (intentionally mistaking `#` vs `3` due to the sticky Shift)
4. Press Tab to switch focus, there will be an error message "Invalid character: #"

**Before this PR**

The editor does not show the error location.

![image](https://user-images.githubusercontent.com/7288/147974804-af315159-da2d-44d0-805a-f8858b93a8d3.png)

**After this PR**

The editor marks the error with the red underline, in this case, the offending character `#`.

![image](https://user-images.githubusercontent.com/7288/148107935-51f06478-794b-49e9-bcbd-cc2da8696347.png)
**Note**

Even if the expression spans multiple lines, the error marker should still point to the correct location of error.

![image](https://user-images.githubusercontent.com/7288/147994671-3657d7b9-3b70-4f58-a5be-8a3ac68938ac.png)
