### PR TITLE
Invalidate tables after manual re-syncing

### DIFF
--- a/frontend/src/metabase/admin/databases/database.js
+++ b/frontend/src/metabase/admin/databases/database.js
@@ -10,6 +10,7 @@ import MetabaseSettings from "metabase/lib/settings";
 
 import { MetabaseApi } from "metabase/services";
 import Databases from "metabase/entities/databases";
+import Tables from "metabase/entities/tables";
 import { updateSetting } from "metabase/admin/settings/settings";
 
 import { editParamsForUserControlledScheduling } from "./editParamsForUserControlledScheduling";
@@ -241,6 +242,7 @@ export const syncDatabaseSchema = createThunkAction(
     return async function(dispatch, getState) {
       try {
         const call = await MetabaseApi.db_sync_schema({ dbId: databaseId });
+        dispatch({ type: Tables.actionTypes.INVALIDATE_LISTS_ACTION });
         MetabaseAnalytics.trackStructEvent("Databases", "Manual Sync");
         return call;
       } catch (error) {


### PR DESCRIPTION
Fixes partially https://github.com/metabase/metabase/issues/10330

After the manual re-sync there might be changes in tables. Invalidate `Table` cache for fetch new data. 

How to test:
- Follow the steps from the issue