### PR TITLE
Custom expression editor: don't process invalid expression

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -255,16 +255,18 @@ export default class ExpressionEditorTextfield extends React.Component {
     this.setState({ errorMessage });
 
     // whenever our input blurs we push the updated expression to our parent if valid
-    const expression = this.compileExpression();
-    if (expression) {
-      if (!isExpression(expression)) {
-        console.warn("isExpression=false", expression);
-      }
-      this.props.onChange(expression);
-    } else if (errorMessage) {
+    if (errorMessage) {
       this.props.onError(errorMessage);
     } else {
-      this.props.onError({ message: t`Invalid expression` });
+      const expression = this.compileExpression();
+      if (expression) {
+        if (!isExpression(expression)) {
+          console.warn("isExpression=false", expression);
+        }
+        this.props.onChange(expression);
+      } else {
+        this.props.onError({ message: t`Invalid expression` });
+      }
     }
   };
 


### PR DESCRIPTION
If the expression is not valid, i.e. there is an error message
associated with processing it, do not blindly continue with it, since it
leads to a potential rewrite of the expression (the rest of
the parser/compiler can tolerate certain brokenness).

1. Ask a question, Custom question
2. Sample Dataset, Products table
3. Filter, Custom Expression, type `[Price] > 1E`
4. Press Tab to switch focus

(Note that the typed expression above is incomplete due to missing number after the exponent `e`.
A valid example will be e.g. `[Price] > 1E2`)

**Before this PR**

An error message is displayed (as expected) but the expression gets rewritten to `[Price] > 1`, i.e. the `E` is deleted.

![image](https://user-images.githubusercontent.com/7288/148107597-820a8b28-0c6f-41f4-9b21-8d620e884c43.png)

**After this PR**

An error message is displayed. The expression is kept intact as is.

![image](https://user-images.githubusercontent.com/7288/148107566-87c75d24-4719-41b9-b0a3-a60ff78995c5.png)
