### PR TITLE
Custom expression editor: don't commit an invalid expression

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -290,10 +290,19 @@ export default class ExpressionEditorTextfield extends React.Component {
   }
 
   commitExpression() {
-    const expression = this.compileExpression();
+    const { query, startRule } = this.props;
+    const { source } = this.state;
+    const errorMessage = diagnose(source, startRule, query);
+    this.setState({ errorMessage });
 
-    if (isExpression(expression)) {
-      this.props.onCommit(expression);
+    if (errorMessage) {
+      this.props.onError(errorMessage);
+    } else {
+      const expression = this.compileExpression();
+
+      if (isExpression(expression)) {
+        this.props.onCommit(expression);
+      }
     }
   }
 
@@ -423,7 +432,7 @@ export default class ExpressionEditorTextfield extends React.Component {
             highlightedIndex={this.state.highlightedSuggestionIndex}
           />
         </EditorContainer>
-        {!isFocused && <ErrorMessage error={errorMessage} />}
+        <ErrorMessage error={errorMessage} />
         <HelpText helpText={this.state.helpText} width={this.props.width} />
       </React.Fragment>
     );

--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -469,6 +469,17 @@ describe("scenarios > question > filter", () => {
     });
   });
 
+  it("should reject Enter when the filter expression is invalid", () => {
+    openReviewsTable({ mode: "notebook" });
+    cy.findByText("Filter").click();
+    cy.findByText("Custom Expression").click();
+
+    enterCustomColumnDetails({ formula: "[Rating] > 2E{enter}" }); // there should numbers after 'E'
+
+    cy.findByText("Missing exponent");
+    cy.findByText("Rating is greater than 2").should("not.exist");
+  });
+
   it("should offer case expression in the auto-complete suggestions", () => {
     openExpressionEditorFromFreshlyLoadedPage();
 


### PR DESCRIPTION
To verify, run the E2E tests in `frontend/test/metabase/scenarios/question/filter.cy.spec.js`.

For manual repro:

1. Ask a question, Custom question
2. Sample Dataset, Products table
3. Filter, Custom Expression, type `[Rating] < 3E` and press Enter

Note the said expression is not valid since there is a missing digit after the exponent sign. 

**Before this PR**

The expression is (silently) accepted, although it is rewritten to `[Rating] < 3`.

![image](https://user-images.githubusercontent.com/7288/148143311-b656de85-1508-4562-992e-d7fc5a2e8db4.png)

**After this PR**

The expression is rejected with the error message, "Missing exponent". This is the same behavior as if the user switching focus away instead of pressing Enter.

![image](https://user-images.githubusercontent.com/7288/148143292-7ce3f2de-73c7-43d3-946e-9479dca08961.png)
