### PR TITLE
Disable table header info popover when table is clicked

### DIFF
--- a/frontend/src/metabase/components/MetadataInfo/DimensionInfoPopover/DimensionInfoPopover.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/DimensionInfoPopover/DimensionInfoPopover.tsx
@@ -16,16 +16,22 @@ const propTypes = {
   dimension: PropTypes.instanceOf(Dimension),
   children: PropTypes.node,
   placement: PropTypes.string,
+  disabled: PropTypes.bool,
 };
 
 type Props = { dimension: Dimension } & Pick<
   ITippyPopoverProps,
-  "children" | "placement"
+  "children" | "placement" | "disabled"
 >;
 
 const className = "dimension-info-popover";
 
-function DimensionInfoPopover({ dimension, children, placement }: Props) {
+function DimensionInfoPopover({
+  dimension,
+  children,
+  placement,
+  disabled,
+}: Props) {
   // avoid a scenario where we may have a Dimension instance but not enough metadata
   // to even show a display name (probably indicative of a bug)
   const hasMetadata = !!(dimension && dimension.displayName());
@@ -36,6 +42,7 @@ function DimensionInfoPopover({ dimension, children, placement }: Props) {
       delay={isCypressActive ? 0 : POPOVER_DELAY}
       interactive
       placement={placement || "left-start"}
+      disabled={disabled}
       content={<WidthBoundDimensionInfo dimension={dimension} />}
       onTrigger={instance => {
         const dimensionInfoPopovers = document.querySelectorAll(

--- a/frontend/src/metabase/visualizations/components/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive.jsx
@@ -131,7 +131,7 @@ export default class TableInteractive extends Component {
   }
 
   shouldComponentUpdate(nextProps, nextState) {
-    const PROP_KEYS = ["width", "height", "settings", "data"];
+    const PROP_KEYS = ["width", "height", "settings", "data", "clicked"];
     // compare specific props and state to determine if we should re-render
     return (
       !_.isEqual(
@@ -650,6 +650,7 @@ export default class TableInteractive extends Component {
           <DimensionInfoPopover
             placement="bottom-start"
             dimension={this.getDimension(column, this.props.query)}
+            disabled={this.props.clicked != null}
           >
             {renderTableHeaderWrapper(
               <Ellipsified tooltip={columnTitle}>

--- a/frontend/src/metabase/visualizations/components/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization.jsx
@@ -503,6 +503,7 @@ export default class Visualization extends React.PureComponent {
             card={series[0].card} // convenience for single-series visualizations
             data={series[0].data} // convenience for single-series visualizations
             hovered={hovered}
+            clicked={clicked}
             headerIcon={hasHeader ? null : headerIcon}
             onHoverChange={this.handleHoverChange}
             onVisualizationClick={this.handleVisualizationClick}


### PR DESCRIPTION
Trying to avoid this scenario where the info popover appears above the table column header click actions popover if you've clicked and then triggered a subsequent mouseenter event:

<img width="395" alt="Screen Shot 2022-01-05 at 12 32 39 PM" src="https://user-images.githubusercontent.com/13057258/148285342-cf9fae1b-f347-4b9c-a883-718de79438f4.png">

**Testing**
1. new question > products table (or any other table viz) 
2. click on a column header to make the click actions popover appear
3. move mouse out of and then back into the column header element -- the info popover should not appear
4. hide the click action popover by clicking somewhere and then move your mouse back into the column header element -- the info popover should appear