### PR TITLE
add delay prop to table/dimension info popovers

### DIFF
--- a/frontend/src/metabase/components/MetadataInfo/DimensionInfoPopover/DimensionInfoPopover.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/DimensionInfoPopover/DimensionInfoPopover.tsx
@@ -6,7 +6,6 @@ import Dimension from "metabase-lib/lib/Dimension";
 import TippyPopover, {
   ITippyPopoverProps,
 } from "metabase/components/Popover/TippyPopover";
-import { isCypressActive } from "metabase/env";
 
 import { WidthBoundDimensionInfo } from "./DimensionInfoPopover.styled";
 
@@ -40,7 +39,7 @@ function DimensionInfoPopover({
   return hasMetadata ? (
     <TippyPopover
       className={className}
-      delay={isCypressActive ? 0 : delay}
+      delay={delay}
       interactive
       placement={placement || "left-start"}
       disabled={disabled}

--- a/frontend/src/metabase/components/MetadataInfo/DimensionInfoPopover/DimensionInfoPopover.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/DimensionInfoPopover/DimensionInfoPopover.tsx
@@ -21,7 +21,7 @@ const propTypes = {
 
 type Props = { dimension: Dimension } & Pick<
   ITippyPopoverProps,
-  "children" | "placement" | "disabled"
+  "children" | "placement" | "disabled" | "delay"
 >;
 
 const className = "dimension-info-popover";
@@ -31,6 +31,7 @@ function DimensionInfoPopover({
   children,
   placement,
   disabled,
+  delay = POPOVER_DELAY,
 }: Props) {
   // avoid a scenario where we may have a Dimension instance but not enough metadata
   // to even show a display name (probably indicative of a bug)
@@ -39,7 +40,7 @@ function DimensionInfoPopover({
   return hasMetadata ? (
     <TippyPopover
       className={className}
-      delay={isCypressActive ? 0 : POPOVER_DELAY}
+      delay={isCypressActive ? 0 : delay}
       interactive
       placement={placement || "left-start"}
       disabled={disabled}

--- a/frontend/src/metabase/components/MetadataInfo/TableInfoPopover/TableInfoPopover.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/TableInfoPopover/TableInfoPopover.tsx
@@ -5,6 +5,7 @@ import { hideAll } from "tippy.js";
 import TippyPopover, {
   ITippyPopoverProps,
 } from "metabase/components/Popover/TippyPopover";
+import { isCypressActive } from "metabase/env";
 
 import { WidthBoundTableInfo } from "./TableInfoPopover.styled";
 
@@ -19,19 +20,25 @@ const propTypes = {
 
 type Props = { tableId: number } & Pick<
   ITippyPopoverProps,
-  "children" | "placement" | "offset"
+  "children" | "placement" | "offset" | "delay"
 >;
 
 const className = "table-info-popover";
 
-function TableInfoPopover({ tableId, children, placement, offset }: Props) {
+function TableInfoPopover({
+  tableId,
+  children,
+  placement,
+  offset,
+  delay = POPOVER_DELAY,
+}: Props) {
   placement = placement || "left-start";
 
   return tableId != null ? (
     <TippyPopover
       className={className}
       interactive
-      delay={POPOVER_DELAY}
+      delay={isCypressActive ? 0 : delay}
       placement={placement}
       offset={offset}
       content={<WidthBoundTableInfo tableId={tableId} />}

--- a/frontend/src/metabase/components/MetadataInfo/TableInfoPopover/TableInfoPopover.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/TableInfoPopover/TableInfoPopover.tsx
@@ -5,7 +5,6 @@ import { hideAll } from "tippy.js";
 import TippyPopover, {
   ITippyPopoverProps,
 } from "metabase/components/Popover/TippyPopover";
-import { isCypressActive } from "metabase/env";
 
 import { WidthBoundTableInfo } from "./TableInfoPopover.styled";
 
@@ -38,7 +37,7 @@ function TableInfoPopover({
     <TippyPopover
       className={className}
       interactive
-      delay={isCypressActive ? 0 : delay}
+      delay={delay}
       placement={placement}
       offset={offset}
       content={<WidthBoundTableInfo tableId={tableId} />}

--- a/frontend/src/metabase/components/Popover/TippyPopover.tsx
+++ b/frontend/src/metabase/components/Popover/TippyPopover.tsx
@@ -5,6 +5,7 @@ import cx from "classnames";
 
 import { isReducedMotionPreferred } from "metabase/lib/dom";
 import EventSandbox from "metabase/components/EventSandbox";
+import { isCypressActive } from "metabase/env";
 
 const TippyComponent = Tippy.default;
 type TippyProps = Tippy.TippyProps;
@@ -27,8 +28,10 @@ function TippyPopover({
   disableContentSandbox,
   lazy = true,
   content,
+  delay,
   ...props
 }: ITippyPopoverProps) {
+  delay = isCypressActive ? 0 : delay;
   const animationDuration = isReducedMotionPreferred() ? 0 : undefined;
   const [mounted, setMounted] = useState(!lazy);
   const plugins = useMemo(
@@ -65,6 +68,7 @@ function TippyPopover({
       plugins={plugins}
       {...props}
       duration={animationDuration}
+      delay={delay}
       content={computedContent}
     />
   );


### PR DESCRIPTION
@mazameli  wants to tweak the DimensionInfoPopover and TableInfoPopover `delay` value and perhaps customize it depending on where in the app we are using it, so I'm exposing the popover's `delay` prop on these two components.

Also, setting TableInfoPopover's delay to 0 when in cypress, as I've already done for DimensionInfoPopover. Just speeds things up. You have to manually trigger `mouseenter` events in cypress, so this won't cause popovers to unexpectedly show up.

**Testing**
nothing to test yet