### PR TITLE
Hide table info popover when the table has no description & when table is a nested card

### DIFF
--- a/frontend/src/metabase/browse/components/TableBrowser/TableBrowser.jsx
+++ b/frontend/src/metabase/browse/components/TableBrowser/TableBrowser.jsx
@@ -46,7 +46,7 @@ const TableBrowser = ({
       <Grid>
         {tables.map(table => (
           <GridItem key={table.id} width={ITEM_WIDTHS}>
-            <TableInfoPopover tableId={table.id} placement="bottom-start">
+            <TableInfoPopover table={table} placement="bottom-start">
               <TableCard hoverable={isSyncCompleted(table)}>
                 <TableLink
                   to={

--- a/frontend/src/metabase/components/MetadataInfo/TableInfoPopover/TableInfoPopover.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/TableInfoPopover/TableInfoPopover.tsx
@@ -10,14 +10,22 @@ import { WidthBoundTableInfo } from "./TableInfoPopover.styled";
 
 export const POPOVER_DELAY: [number, number] = [500, 300];
 
+interface TableSubset {
+  id: number | string;
+  description?: string;
+}
+
 const propTypes = {
-  tableId: PropTypes.number.isRequired,
+  table: PropTypes.shape({
+    id: PropTypes.oneOf([PropTypes.number, PropTypes.string]),
+    description: PropTypes.string,
+  }).isRequired,
   children: PropTypes.node,
   placement: PropTypes.string,
   offset: PropTypes.arrayOf(PropTypes.number),
 };
 
-type Props = { tableId: number } & Pick<
+type Props = { table: TableSubset } & Pick<
   ITippyPopoverProps,
   "children" | "placement" | "offset" | "delay"
 >;
@@ -25,7 +33,7 @@ type Props = { tableId: number } & Pick<
 const className = "table-info-popover";
 
 function TableInfoPopover({
-  tableId,
+  table,
   children,
   placement,
   offset,
@@ -33,14 +41,18 @@ function TableInfoPopover({
 }: Props) {
   placement = placement || "left-start";
 
-  return tableId != null ? (
+  const hasDescription = !!table.description;
+  const isVirtualTable = typeof table.id === "string";
+  const showPopover = hasDescription && !isVirtualTable;
+
+  return showPopover ? (
     <TippyPopover
       className={className}
       interactive
       delay={delay}
       placement={placement}
       offset={offset}
-      content={<WidthBoundTableInfo tableId={tableId} />}
+      content={<WidthBoundTableInfo tableId={table.id} />}
       onTrigger={instance => {
         const dimensionInfoPopovers = document.querySelectorAll(
           `.${className}[data-state~='visible']`,

--- a/frontend/src/metabase/components/MetadataInfo/TableInfoPopover/TableInfoPopover.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/TableInfoPopover/TableInfoPopover.tsx
@@ -5,6 +5,7 @@ import { hideAll } from "tippy.js";
 import TippyPopover, {
   ITippyPopoverProps,
 } from "metabase/components/Popover/TippyPopover";
+import { isVirtualCardId } from "metabase/lib/saved-questions/saved-questions";
 
 import { WidthBoundTableInfo } from "./TableInfoPopover.styled";
 
@@ -32,6 +33,10 @@ type Props = { table: TableSubset } & Pick<
 
 const className = "table-info-popover";
 
+function isRealTable(id: number | string): id is number {
+  return !isVirtualCardId(id);
+}
+
 function TableInfoPopover({
   table,
   children,
@@ -43,8 +48,7 @@ function TableInfoPopover({
 
   const { id, description } = table;
   const hasDescription = !!description;
-  const isVirtualTable = typeof id === "string";
-  const showPopover = hasDescription && !isVirtualTable;
+  const showPopover = hasDescription && isRealTable(id);
 
   return showPopover ? (
     <TippyPopover

--- a/frontend/src/metabase/components/MetadataInfo/TableInfoPopover/TableInfoPopover.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/TableInfoPopover/TableInfoPopover.tsx
@@ -41,8 +41,9 @@ function TableInfoPopover({
 }: Props) {
   placement = placement || "left-start";
 
-  const hasDescription = !!table.description;
-  const isVirtualTable = typeof table.id === "string";
+  const { id, description } = table;
+  const hasDescription = !!description;
+  const isVirtualTable = typeof id === "string";
   const showPopover = hasDescription && !isVirtualTable;
 
   return showPopover ? (
@@ -52,7 +53,7 @@ function TableInfoPopover({
       delay={delay}
       placement={placement}
       offset={offset}
-      content={<WidthBoundTableInfo tableId={table.id} />}
+      content={<WidthBoundTableInfo tableId={id} />}
       onTrigger={instance => {
         const dimensionInfoPopovers = document.querySelectorAll(
           `.${className}[data-state~='visible']`,

--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -1438,7 +1438,7 @@ const TablePicker = ({
           renderItemWrapper={(itemContent, item) => {
             if (item.table?.id != null) {
               return (
-                <TableInfoPopover tableId={item.table.id}>
+                <TableInfoPopover table={item.table}>
                   {itemContent}
                 </TableInfoPopover>
               );

--- a/frontend/src/metabase/query_builder/components/data-search/SearchResultWithInfoPopover.jsx
+++ b/frontend/src/metabase/query_builder/components/data-search/SearchResultWithInfoPopover.jsx
@@ -18,7 +18,10 @@ export function SearchResultWithInfoPopover({ item, onSelect }) {
         <TableInfoPopover
           placement="right-start"
           offset={OFFSET}
-          tableId={item.table_id}
+          table={{
+            id: item.table_id,
+            description: item.table_description,
+          }}
         >
           <li>
             <SearchResult result={item} onClick={onSelect} compact />

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
@@ -204,7 +204,7 @@ function QuestionTableBadges({ tables, subHead, hasLink, isLast }) {
       to={hasLink ? getTableURL(table) : ""}
       inactiveColor={badgeInactiveColor}
     >
-      <TableInfoPopover tableId={table.id} placement="bottom-start">
+      <TableInfoPopover table={table} placement="bottom-start">
         <span>{table.displayName()}</span>
       </TableInfoPopover>
     </HeadBreadcrumbs.Badge>


### PR DESCRIPTION
Adding a few conditions where `TableInfoPopover` won't render a popover:

1. when a table does not have a description -- this is per product/design
2. when a table is actually a card (surprise) -- this happens when we're in the QB looking at a question that is based on a question.

For 2, since we are sort of treating nested cards as tables I think we'll eventually add more code to support showing popovers for nested cards. For now, this case remains unsupported.

**Testing**
No descriptions
1. Add a new table that doesn't have a description -- if you only have the `Sample Dataset` available this may be a bit annoying since you can't clear a table's description through the UI. Instead, you can try faking it by clearing out a description on a cached table: `Metabase.store.getState().entities.tables[1].description = ""` run in the browser console will clear the Product table's description. This is a clumsy process however because we frequently refresh the table cache.
2. An easy way to avoid a cache refresh is to start on a dashboard that contains a card based on the Products table, clear the cached description, and then click into the card. See the below video:

https://user-images.githubusercontent.com/13057258/148590744-6d1e1f1a-7490-444f-9c3f-b4e5a52fc480.mov

Nested cards
1. Create and save a question -- question A
2. Go to the custom query builder and start a new question based on the question you just created
3. Save it as question "B"
4. For question B, in the header of the QB, you should see the name of question A -- hover over the name, and nothing should happen (compare with `master`, where something _will_ happen).

https://user-images.githubusercontent.com/13057258/148590796-3f5ebd1f-019e-4b87-af4a-b7ce77c4c367.mov





