### PR TITLE
Build and publish branches

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,8 +6,8 @@ on:
       - 'master'
       - 'release**'
       - 'backport**'
-    paths:
-      - "**"
+    paths-ignore:
+      - ".**"
 
 concurrency:
   group: ${{ github.ref }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,11 +32,11 @@ jobs:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Build container image
-      run: docker buildx build . -t metabase/metabase-branch:${{ steps.extract_branch.outputs.branch }} --push --compress --no-cache
+      run: docker buildx build . -t metabase/metabase-dev:${{ steps.extract_branch.outputs.branch }} --push --compress --no-cache
     - name: Launch container
-      run: docker run -dp 3000:3000 metabase/metabase-branch:${{ steps.extract_branch.outputs.branch }}
+      run: docker run -dp 3000:3000 metabase/metabase-dev:${{ steps.extract_branch.outputs.branch }}
       timeout-minutes: 5
     - run: docker ps
     - name: Wait for Metabase to start
-      run: while ! curl -s 'http://localhost:3032/api/health' | grep '{"status":"ok"}'; do sleep 1; done
+      run: while ! curl -s 'http://localhost:3000/api/health' | grep '{"status":"ok"}'; do sleep 1; done
       timeout-minutes: 1

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,26 +1,42 @@
 name: Docker
 
 on:
-  pull_request:
+  push:
+    branches-ignore:
+      - 'master'
+      - 'release**'
+      - 'backport**'
     paths:
-    - 'Dockerfile'
-    - '.github/workflows/docker.yml'
+      - "**"
+
+concurrency: 
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-
   build:
     runs-on: buildjet-2vcpu-ubuntu-2004
     timeout-minutes: 40
     steps:
+    - name: Extract branch name
+      shell: bash
+      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+      id: extract_branch
     - uses: actions/checkout@v2
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Login to Docker Hub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Build container image
-      run: docker build -t test-container-image .
+      run: docker buildx build . -t metabase/metabase-branch:${{ steps.extract_branch.outputs.branch }} --push --compress --no-cache
     - name: Launch container
-      run: docker run -dp 3000:3000 test-container-image
+      run: docker run -dp 3000:3000 metabase/metabase-branch:${{ steps.extract_branch.outputs.branch }}
       timeout-minutes: 5
     - run: docker ps
     - name: Wait for Metabase to start
-      run: while ! curl -s localhost:3000/api/health; do sleep 1; done
+      run: while ! curl -s 'http://localhost:3032/api/health' | grep '{"status":"ok"}'; do sleep 1; done
       timeout-minutes: 1
-    - name: Check API health
-      run: curl -s localhost:3000/api/health

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,7 +9,7 @@ on:
     paths:
       - "**"
 
-concurrency: 
+concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
 


### PR DESCRIPTION
This PR tends to containerize branches so for every PR and every commit that's not in the release/backport/master branch we can build and publish a container to test it out.

We need to create the new dockerhub repo (we used to push images to metabase-head, but I don't think that would be the correct repo)