### PR TITLE
Waterfall bignum display fix (#19025)

### DIFF
--- a/src/metabase/pulse/render/common.clj
+++ b/src/metabase/pulse/render/common.clj
@@ -94,13 +94,26 @@
    (or (ui-logic/y-axis-rowfn card data)
        second)])
 
-(defn non-nil-rows
+(defn coerce-bignum-to-int
+  "Graal polyglot system (not the JS machine itself, the polyglot system)
+  is not happy with BigInts or BigDecimals.
+  Because of this unfortunately they all have to get smushed into normal ints and decimals in JS land."
+  [row]
+  (for [member row]
+    (cond
+      ;; this returns true for bigint only, not normal int or long
+      (and (not (int? member)) (integer? member))
+      (int member)
+
+      ;; this returns true for bigdec only, not actual normal decimals
+      ;; not the clearest clojure native function in the world
+      (decimal? member)
+      (double member)
+
+      :else
+      member)))
+
+(defn row-preprocess
   "Remove any rows that have a nil value for the `x-axis-fn` OR `y-axis-fn`"
   [x-axis-fn y-axis-fn rows]
-  (filter (every-pred x-axis-fn y-axis-fn) rows))
-
-(defn non-nil-combo-rows
-  "Remove any rows that have a nil value for the entire row because
-  the row-function-generating functions themselves choke on nil values, for combo rowfuncs"
-  [rows]
-  (filter #(every? some? %) rows))
+  (map coerce-bignum-to-int (filter (every-pred x-axis-fn y-axis-fn) rows)))

--- a/src/metabase/pulse/render/common.clj
+++ b/src/metabase/pulse/render/common.clj
@@ -97,6 +97,8 @@
 (defn coerce-bignum-to-int
   "Graal polyglot system (not the JS machine itself, the polyglot system)
   is not happy with BigInts or BigDecimals.
+  For more information, this is the GraalVM issue, open a while
+  https://github.com/oracle/graal/issues/2737
   Because of this unfortunately they all have to get smushed into normal ints and decimals in JS land."
   [row]
   (for [member row]

--- a/src/metabase/pulse/render/common.clj
+++ b/src/metabase/pulse/render/common.clj
@@ -104,7 +104,7 @@
   (for [member row]
     (cond
       ;; this returns true for bigint only, not normal int or long
-      (and (not (int? member)) (integer? member))
+      (instance? clojure.lang.BigInt member)
       (int member)
 
       ;; this returns true for bigdec only, not actual normal decimals
@@ -116,6 +116,9 @@
       member)))
 
 (defn row-preprocess
-  "Remove any rows that have a nil value for the `x-axis-fn` OR `y-axis-fn`"
+  "Preprocess rows.
+
+  - Removes any rows that have a nil value for the `x-axis-fn` OR `y-axis-fn`
+  - Normalizes bigints and bigdecs to ordinary sizes"
   [x-axis-fn y-axis-fn rows]
   (map coerce-bignum-to-int (filter (every-pred x-axis-fn y-axis-fn) rows)))

--- a/src/metabase/pulse/render/sparkline.clj
+++ b/src/metabase/pulse/render/sparkline.clj
@@ -107,7 +107,7 @@
   [timezone-id :- (s/maybe s/Str) card {:keys [rows cols], :as data}]
   (let [[x-axis-rowfn y-axis-rowfn] (common/graphing-column-row-fns card data)
         format-val                  (format-val-fn timezone-id cols x-axis-rowfn)
-        present-rows                (common/non-nil-rows x-axis-rowfn y-axis-rowfn rows)
+        present-rows                (common/row-preprocess x-axis-rowfn y-axis-rowfn rows)
         formatted-value             (comp format-val x-axis-rowfn)
         x-col                       (x-axis-rowfn cols)]
     (if (and (comparable? x-col)

--- a/test/metabase/pulse/render/body_test.clj
+++ b/test/metabase/pulse/render/body_test.clj
@@ -481,6 +481,10 @@
     (is (has-inline-image?
          (render-waterfall {:cols default-columns
                             :rows [[10.0 1] [5.0 10] [2.50 20] [1.25 30]]}))))
+  (testing "Render a waterfall graph with bigdec, bigint values for the x and y axis"
+    (is (has-inline-image?
+          (render-waterfall {:cols default-columns
+                             :rows [[10.0M 1M] [5.0 10N] [2.50 20N] [1.25M 30]]}))))
   (testing "Check to make sure we allow nil values for the y-axis"
     (is (has-inline-image?
          (render-waterfall {:cols default-columns


### PR DESCRIPTION
Pursuant to #19025.

I had a devil of a time actually reproducing because the actual bug is not in waterfall, it's in getting bignum to display with Graal / JS polyglot. Viz.: you can't, gotta coerce.

If someone actually wants to display an integer 1e200 without logarithm, this will still blow up, but in that case it's their fault and the error message in logs will be much better.