### PR TITLE
Debugging QP Improvements

### DIFF
--- a/dev/src/dev/debug_qp.clj
+++ b/dev/src/dev/debug_qp.clj
@@ -11,7 +11,6 @@
             [metabase.models.table :refer [Table]]
             [metabase.query-processor :as qp]
             [metabase.query-processor.reducible :as qp.reducible]
-            [metabase.query-processor.util.add-alias-info :as add]
             [metabase.util :as u]
             [toucan.db :as db]))
 
@@ -47,8 +46,8 @@
          (m :guard (every-pred map? (comp integer? :source-table)))
          (add-names* (update m :source-table add-table-id-name))
 
-         (m :guard (every-pred map? (comp integer? ::add/source-table)))
-         (add-names* (update m ::add/source-table add-table-id-name))
+         (m :guard (every-pred map? (comp integer? :metabase.query-processor.util.add-alias-info/source-table)))
+         (add-names* (update m :metabase.query-processor.util.add-alias-info/source-table add-table-id-name))
 
          (m :guard (every-pred map? (comp integer? :fk-field-id)))
          (-> m

--- a/dev/test/dev/debug_qp_test.clj
+++ b/dev/test/dev/debug_qp_test.clj
@@ -87,9 +87,3 @@
               :source-table (mt/id :categories)
               :fk-field-id  (mt/id :venues :category_id)}]
             "venues")))))
-
-(deftest to-mbql-shorthand-refs-test
-  (testing "Make sure it doesn't do anything kooky with :aggregation references inside :qp/refs"
-    (is (= '(mt/$ids nil {:qp/refs {[:aggregation 0] {:position 0}}})
-           (debug-qp/to-mbql-shorthand
-            {:qp/refs {[:aggregation 0] {:position 0}}})))))

--- a/dev/test/dev/debug_qp_test.clj
+++ b/dev/test/dev/debug_qp_test.clj
@@ -1,0 +1,95 @@
+(ns  dev.debug-qp-test
+  (:require [clojure.test :refer :all]
+            [dev.debug-qp :as debug-qp]
+            [metabase.test :as mt]))
+
+(deftest add-names-test
+  (testing "Joins"
+    (is (= [{:strategy     :left-join
+             :alias        "CATEGORIES__via__CATEGORY_ID"
+             :condition    [:=
+                            [:field
+                             (mt/id :venues :category_id)
+                             (symbol "#_\"VENUES.CATEGORY_ID\"")
+                             nil]
+                            [:field
+                             (mt/id :categories :id)
+                             (symbol "#_\"CATEGORIES.ID\"")
+                             {:join-alias "CATEGORIES__via__CATEGORY_ID"}]]
+             :source-table (list 'do (symbol "#_\"CATEGORIES\"") (mt/id :categories))
+             :fk-field-id  (list 'do (symbol "#_\"VENUES.CATEGORY_ID\"") (mt/id :venues :category_id))}]
+           (debug-qp/add-names
+            [{:strategy     :left-join
+              :alias        "CATEGORIES__via__CATEGORY_ID"
+              :condition    [:=
+                             [:field (mt/id :venues :category_id) nil]
+                             [:field (mt/id :categories :id) {:join-alias "CATEGORIES__via__CATEGORY_ID"}]]
+              :source-table (mt/id :categories)
+              :fk-field-id  (mt/id :venues :category_id)}])))))
+
+(deftest to-mbql-shorthand-test
+  (mt/dataset sample-dataset
+    (testing "Normal Field ID clause"
+      (is (= '$user_id
+             (debug-qp/expand-symbolize [:field (mt/id :orders :user_id) nil])))
+      (is (= '$products.id
+             (debug-qp/expand-symbolize [:field (mt/id :products :id) nil]))))
+    (testing "Field literal name"
+      (is (= '*wow/Text
+             (debug-qp/expand-symbolize [:field "wow" {:base-type :type/Text}])))
+      (is (= [:field "w o w" {:base-type :type/Text}]
+             (debug-qp/expand-symbolize [:field "w o w" {:base-type :type/Text}]))))
+    (testing "Field with join alias"
+      (is (= '&P.people.source
+             (debug-qp/expand-symbolize [:field (mt/id :people :source) {:join-alias "P"}])))
+      (is (= [:field '%people.id {:join-alias "People - User"}]
+             (debug-qp/expand-symbolize [:field (mt/id :people :id) {:join-alias "People - User"}])))
+      (is (= '&Q.*ID/BigInteger
+             (debug-qp/expand-symbolize [:field "ID" {:base-type :type/BigInteger, :join-alias "Q"}]))))
+    (testing "Field with source-field"
+      (is (= '$product_id->products.id
+             (debug-qp/expand-symbolize [:field (mt/id :products :id) {:source-field (mt/id :orders :product_id)}])))
+      (is (= '$product_id->*wow/Text
+             (debug-qp/expand-symbolize [:field "wow" {:base-type :type/Text, :source-field (mt/id :orders :product_id)}]))))
+    (testing "Binned field - no expansion (%id only)"
+      (is (= [:field '%people.source {:binning {:strategy :default}}]
+             (debug-qp/expand-symbolize [:field (mt/id :people :source) {:binning {:strategy :default}}]))))
+    (testing "Field with temporal unit"
+      (is (= '!default.created_at
+             (debug-qp/expand-symbolize [:field (mt/id :orders :created_at) {:temporal-unit :default}]))))
+    (testing "Field with join alias AND temporal unit"
+      (is (= '!default.&P1.created_at
+             (debug-qp/expand-symbolize [:field (mt/id :orders :created_at) {:temporal-unit :default, :join-alias "P1"}]))))
+
+    (testing "source table"
+      (is (= '(mt/mbql-query orders
+                {:joins [{:source-table $$people}]})
+             (debug-qp/to-mbql-shorthand
+              {:database (mt/id)
+               :type     :query
+               :query    {:source-table (mt/id :orders)
+                          :joins        [{:source-table (mt/id :people)}]}}))))))
+
+(deftest to-mbql-shorthand-joins-test
+  (testing :fk-field-id
+    (is (= '(mt/$ids venues
+              [{:strategy     :left-join
+                :alias        "CATEGORIES__via__CATEGORY_ID"
+                :condition    [:= $category_id &CATEGORIES__via__CATEGORY_ID.categories.id]
+                :source-table $$categories
+                :fk-field-id  %category_id}])
+           (debug-qp/to-mbql-shorthand
+            [{:strategy     :left-join
+              :alias        "CATEGORIES__via__CATEGORY_ID"
+              :condition    [:=
+                             [:field (mt/id :venues :category_id) nil]
+                             [:field (mt/id :categories :id) {:join-alias "CATEGORIES__via__CATEGORY_ID"}]]
+              :source-table (mt/id :categories)
+              :fk-field-id  (mt/id :venues :category_id)}]
+            "venues")))))
+
+(deftest to-mbql-shorthand-refs-test
+  (testing "Make sure it doesn't do anything kooky with :aggregation references inside :qp/refs"
+    (is (= '(mt/$ids nil {:qp/refs {[:aggregation 0] {:position 0}}})
+           (debug-qp/to-mbql-shorthand
+            {:qp/refs {[:aggregation 0] {:position 0}}})))))

--- a/test/metabase/test_runner/effects.clj
+++ b/test/metabase/test_runner/effects.clj
@@ -8,13 +8,12 @@
 
   This would not have had the random namespace that requires these helpers and the run fails.
   "
-  (:require
-   [clojure.data :as data]
-   [clojure.test :as t]
-   [dev.debug-qp]
-   [metabase.util.date-2 :as date-2]
-   [metabase.util.i18n.impl :as i18n.impl]
-   [schema.core :as s]))
+  (:require [clojure.data :as data]
+            [clojure.test :as t]
+            dev.debug-qp
+            [metabase.util.date-2 :as date-2]
+            [metabase.util.i18n.impl :as i18n.impl]
+            [schema.core :as s]))
 
 (comment
   ;; these are necessary so data_readers.clj functions can function


### PR DESCRIPTION
Split off from #19384

This PR fixes a big number of bugs in the `dev.debug-qp` namespace around the `add-names` and `to-mbql-shorthand` utility functions.

This PR also adds a new custom test expression handler (by custom test expression handler I mean things like our existing `schema=` and `re=` handlers) called `query=` that compares two MBQL query maps. If the maps differ, it hooks into `dev.debug-qp/add-names` to add name **comments**. Example:

```clj
(deftest =-example-test
  (is (= (mt/mbql-query users {:fields [$id $name]})
         (mt/mbql-query users {:fields [$name $id]}))))

FAIL in (=-example-test) (add_references_test.clj:216)
expected: {:database 441, :type :query, :query {:fields [[:field 6212 nil] [:field 6210 nil]], :source-table 1537}}
  actual: {:database 441, :type :query, :query {:fields [[:field 6210 nil] [:field 6212 nil]], :source-table 1537}}
    diff: - {:query {:fields [[nil 6212] [nil 6210]]}}
          + {:query {:fields [[nil 6210] [nil 6212]]}}

(deftest query=-example-test
  (is (query= (mt/mbql-query users {:fields [$id $name]})
              (mt/mbql-query users {:fields [$name $id]}))))

FAIL in (query=-example-test) (add_references_test.clj:216)
expected: {:database 441,
           :type :query,
           :query
           {:fields [[:field 6212 #_"users.id" nil] [:field 6210 #_"users.name" nil]],
            :source-table (do #_"users" 1537)}}
  actual: {:database 441,
           :type :query,
           :query
           {:fields [[:field 6210 #_"users.name" nil] [:field 6212 #_"users.id" nil]],
            :source-table (do #_"users" 1537)}}
    diff: - {:query {:fields [[nil 6212 #_"users.id"] [nil 6210 #_"users.name"]]}}
          + {:query {:fields [[nil 6210 #_"users.name"] [nil 6212 #_"users.id"]]}}

```

The diffs are exactly the same if you evaluate them but the extra comment info makes things easier to debug when working on mega-hairy nested query bugs like those in the #18580 project.

Other changes:

-  Adds a new namespace with tons of tests for the Debug QP functions -- `dev.debug-qp-test`
- `dev.debug-qp/to-mbql-shorthand` now sorts the resulting MBQL map in "canonical MBQL order" e.g. `:source-table` and `:source-query` are sorted before `:fields` which in turn is sorted before `:limit`. It's easier to compare huge MBQL maps to SQL when they roughly match the same order of the SQL. Why not have the tools do it for use automatically? (I'll probably update more stuff to use this in the future, but `to-mbql-shorthand` is the big one since I use that from the REPL a lot)