### PR TITLE
Fix google auth redirect url and sign-in styling

### DIFF
--- a/frontend/src/metabase/auth/components/ForgotPassword/ForgotPassword.styled.tsx
+++ b/frontend/src/metabase/auth/components/ForgotPassword/ForgotPassword.styled.tsx
@@ -62,5 +62,10 @@ export const InfoMessage = styled.div`
 `;
 
 export const InfoLink = styled(Link)`
+  color: ${color("text-dark")};
   margin-top: 2.5rem;
+
+  &:hover {
+    color: ${color("brand")};
+  }
 `;

--- a/frontend/src/metabase/auth/components/GoogleButton/GoogleButton.tsx
+++ b/frontend/src/metabase/auth/components/GoogleButton/GoogleButton.tsx
@@ -12,11 +12,12 @@ export type AttachCallback = (
 
 export interface GoogleButtonProps {
   isCard?: boolean;
+  redirectUrl?: string;
   onAttach: AttachCallback;
-  onLogin: (token: string) => void;
+  onLogin: (token: string, redirectUrl?: string) => void;
 }
 
-const GoogleButton = ({ isCard, onAttach, onLogin }: GoogleButtonProps) => {
+const GoogleButton = ({ isCard, redirectUrl, onAttach, onLogin }: GoogleButtonProps) => {
   const ref = useRef<HTMLDivElement>(null);
   const [errors, setErrors] = useState<string[]>([]);
 
@@ -24,7 +25,7 @@ const GoogleButton = ({ isCard, onAttach, onLogin }: GoogleButtonProps) => {
     async (token: string) => {
       try {
         setErrors([]);
-        await onLogin(token);
+        await onLogin(token, redirectUrl);
       } catch (error) {
         setErrors(getErrors(error));
       }

--- a/frontend/src/metabase/auth/components/GoogleButton/GoogleButton.tsx
+++ b/frontend/src/metabase/auth/components/GoogleButton/GoogleButton.tsx
@@ -17,7 +17,12 @@ export interface GoogleButtonProps {
   onLogin: (token: string, redirectUrl?: string) => void;
 }
 
-const GoogleButton = ({ isCard, redirectUrl, onAttach, onLogin }: GoogleButtonProps) => {
+const GoogleButton = ({
+  isCard,
+  redirectUrl,
+  onAttach,
+  onLogin,
+}: GoogleButtonProps) => {
   const ref = useRef<HTMLDivElement>(null);
   const [errors, setErrors] = useState<string[]>([]);
 

--- a/frontend/src/metabase/auth/components/GoogleButton/GoogleButton.unit.spec.tsx
+++ b/frontend/src/metabase/auth/components/GoogleButton/GoogleButton.unit.spec.tsx
@@ -5,13 +5,20 @@ import { act, render, screen } from "@testing-library/react";
 describe("GoogleButton", () => {
   it("should login successfully", async () => {
     const token = "oauth";
+    const redirectUrl = "/url";
     const onAttach = jest.fn();
     const onLogin = jest.fn().mockResolvedValue({});
 
-    render(<GoogleButton onAttach={onAttach} onLogin={onLogin} />);
+    render(
+      <GoogleButton
+        redirectUrl={redirectUrl}
+        onAttach={onAttach}
+        onLogin={onLogin}
+      />,
+    );
     await act(() => onAttach.mock.calls[0][1](token));
 
-    expect(onLogin).toHaveBeenCalledWith(token);
+    expect(onLogin).toHaveBeenCalledWith(token, redirectUrl);
   });
 
   it("should render api errors", async () => {


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/19476

How to test:
- Setup google auth.
- Navigate to a specific Metabase page when logged out. You should be redirected to the sign-in page.
- Login via Google. You should be redirected to the initial page you requested.