### PR TITLE
Move `is-hosted?` check out of memoized function for cloud gateway IP setting

### DIFF
--- a/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
+++ b/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
@@ -14,6 +14,7 @@
             [metabase.models.database :refer [Database]]
             [metabase.models.field :refer [Field]]
             [metabase.models.table :refer [Table]]
+            [metabase.public-settings.premium-features :as premium-features]
             [metabase.query-processor :as qp]
             [metabase.query-processor-test :as qp.test]
             [metabase.query-processor-test.order-by-test :as qp-test.order-by-test] ; used for one SSL connectivity test
@@ -88,63 +89,63 @@
 
 (deftest connection-properties-test
   (testing "Connection properties should be returned properly (including transformation of secret types)"
-    (let [expected [{:name "host"}
-                    {:name "port"}
-                    {:name "sid"}
-                    {:name "service-name"}
-                    {:name "user"}
-                    {:name "password"}
-                    {:name "cloud-ip-address-info"}
-                    {:name "ssl"}
-                    {:name "ssl-use-keystore"}
-                    {:name       "ssl-keystore-options"
-                     :type       "select"
-                     :options    [{:name  "Local file path"
-                                   :value "local"}
-                                  {:name  "Uploaded file path"
-                                   :value "uploaded"}]
-                     :visible-if {:ssl-use-keystore true}}
-                    {:name       "ssl-keystore-value"
-                     :type       "textFile"
-                     :visible-if {:ssl-keystore-options "uploaded"}}
-                    {:name       "ssl-keystore-path"
-                     :type       "string"
-                     :visible-if {:ssl-keystore-options "local"}}
-                    {:name "ssl-keystore-password-value"
-                     :type "password"}
-                    {:name "ssl-use-truststore"}
-                    {:name       "ssl-truststore-options"
-                     :type       "select"
-                     :options    [{:name  "Local file path"
-                                   :value "local"}
-                                  {:name  "Uploaded file path"
-                                   :value "uploaded"}]
-                     :visible-if {:ssl-use-truststore true}}
-                    {:name       "ssl-truststore-value"
-                     :type       "textFile"
-                     :visible-if {:ssl-truststore-options "uploaded"}}
-                    {:name       "ssl-truststore-path"
-                     :type       "string"
-                     :visible-if {:ssl-truststore-options "local"}}
-                    {:name "ssl-truststore-password-value"
-                     :type "password"}
-                    {:name "tunnel-enabled"}
-                    {:name "tunnel-host"}
-                    {:name "tunnel-port"}
-                    {:name "tunnel-user"}
-                    {:name "tunnel-auth-option"}
-                    {:name "tunnel-pass"}
-                    {:name "tunnel-private-key"}
-                    {:name "tunnel-private-key-passphrase"}
-                    {:name "advanced-options"}
-                    {:name "auto_run_queries"}
-                    {:name "let-user-control-scheduling"}
-                    {:name "schedules.metadata_sync"}
-                    {:name "schedules.cache_field_values"}
-                    {:name "refingerprint"}]
-          actual   (->> (driver/connection-properties :oracle)
-                        (driver.u/connection-props-server->client :oracle))]
-      (is (= expected (mt/select-keys-sequentially expected actual))))))
+    (with-redefs [premium-features/is-hosted? (constantly false)]
+      (let [expected [{:name "host"}
+                      {:name "port"}
+                      {:name "sid"}
+                      {:name "service-name"}
+                      {:name "user"}
+                      {:name "password"}
+                      {:name "ssl"}
+                      {:name "ssl-use-keystore"}
+                      {:name       "ssl-keystore-options"
+                       :type       "select"
+                       :options    [{:name  "Local file path"
+                                     :value "local"}
+                                    {:name  "Uploaded file path"
+                                     :value "uploaded"}]
+                       :visible-if {:ssl-use-keystore true}}
+                      {:name       "ssl-keystore-value"
+                       :type       "textFile"
+                       :visible-if {:ssl-keystore-options "uploaded"}}
+                      {:name       "ssl-keystore-path"
+                       :type       "string"
+                       :visible-if {:ssl-keystore-options "local"}}
+                      {:name "ssl-keystore-password-value"
+                       :type "password"}
+                      {:name "ssl-use-truststore"}
+                      {:name       "ssl-truststore-options"
+                       :type       "select"
+                       :options    [{:name  "Local file path"
+                                     :value "local"}
+                                    {:name  "Uploaded file path"
+                                     :value "uploaded"}]
+                       :visible-if {:ssl-use-truststore true}}
+                      {:name       "ssl-truststore-value"
+                       :type       "textFile"
+                       :visible-if {:ssl-truststore-options "uploaded"}}
+                      {:name       "ssl-truststore-path"
+                       :type       "string"
+                       :visible-if {:ssl-truststore-options "local"}}
+                      {:name "ssl-truststore-password-value"
+                       :type "password"}
+                      {:name "tunnel-enabled"}
+                      {:name "tunnel-host"}
+                      {:name "tunnel-port"}
+                      {:name "tunnel-user"}
+                      {:name "tunnel-auth-option"}
+                      {:name "tunnel-pass"}
+                      {:name "tunnel-private-key"}
+                      {:name "tunnel-private-key-passphrase"}
+                      {:name "advanced-options"}
+                      {:name "auto_run_queries"}
+                      {:name "let-user-control-scheduling"}
+                      {:name "schedules.metadata_sync"}
+                      {:name "schedules.cache_field_values"}
+                      {:name "refingerprint"}]
+            actual   (->> (driver/connection-properties :oracle)
+                          (driver.u/connection-props-server->client :oracle))]
+        (is (= expected (mt/select-keys-sequentially expected actual)))))))
 
 (deftest test-ssh-connection
   (testing "Gets an error when it can't connect to oracle via ssh tunnel"

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -450,14 +450,13 @@
 (def ^:private fetch-cloud-gateway-ips-fn
   (memoize/ttl
    (fn []
-       (when (premium-features/is-hosted?)
-         (try
-           (-> (http/get (cloud-gateway-ips-url))
-               :body
-               (json/parse-string keyword)
-               :ip_addresses)
-           (catch Exception e
-             (log/error e (trs "Error fetching Metabase Cloud gateway IP addresses:"))))))
+     (try
+       (-> (http/get (cloud-gateway-ips-url))
+           :body
+           (json/parse-string keyword)
+           :ip_addresses)
+       (catch Exception e
+         (log/error e (trs "Error fetching Metabase Cloud gateway IP addresses:")))))
    :ttl/threshold (* 1000 60 60 24)))
 
 (defsetting cloud-gateway-ips
@@ -465,7 +464,9 @@
   :visibility :public
   :type       :json
   :setter     :none
-  :getter     fetch-cloud-gateway-ips-fn)
+  :getter     (fn []
+                (when (premium-features/is-hosted?)
+                  (fetch-cloud-gateway-ips-fn))))
 
 (defsetting show-database-syncing-modal
   (str (deferred-tru "Whether an introductory modal should be shown after the next database connection is added.")

--- a/test/metabase/public_settings_test.clj
+++ b/test/metabase/public_settings_test.clj
@@ -206,8 +206,9 @@
         (is (= nil (public-settings/cloud-gateway-ips))))))
 
   (testing "Setting returns nil in self-hosted environments"
-    (memoize/memo-clear! @#'public-settings/fetch-cloud-gateway-ips-fn)
-    (http-fake/with-fake-routes-in-isolation
-      {{:address (public-settings/cloud-gateway-ips-url)}
-       (constantly {:status 200 :body "{\"ip_addresses\": [\"127.0.0.1\"]}"})}
-      (is (= nil (public-settings/cloud-gateway-ips))))))
+    (with-redefs [premium-features/is-hosted? (constantly false)]
+      (memoize/memo-clear! @#'public-settings/fetch-cloud-gateway-ips-fn)
+      (http-fake/with-fake-routes-in-isolation
+        {{:address (public-settings/cloud-gateway-ips-url)}
+         (constantly {:status 200 :body "{\"ip_addresses\": [\"127.0.0.1\"]}"})}
+        (is (= nil (public-settings/cloud-gateway-ips)))))))


### PR DESCRIPTION
Quick refactor to make this easier to test locally. Functionally a no-op in production, but it means that when you add a token with the `hosting` feature to your local instance, the `nil` setting value that was returned previously won't be cached and it'll return the IP addresses immediately.