### PR TITLE
Fix metadata typo for Sample Dataset json

### DIFF
--- a/frontend/test/__support__/sample_dataset_fixture.json
+++ b/frontend/test/__support__/sample_dataset_fixture.json
@@ -1010,7 +1010,7 @@
         "values": []
       },
       "21": {
-        "description": "The type of product, valid values include: Doohicky, Gadget, Gizmo and Widget",
+        "description": "The type of product, valid values include: Doohickey, Gadget, Gizmo and Widget",
         "table_id": 3,
         "semantic_type": "type/Category",
         "name": "CATEGORY",


### PR DESCRIPTION
"~~Doohicky~~" -> "Doohickey"

This is used in the metadata popovers:
![image](https://user-images.githubusercontent.com/31325167/148460650-2ffd03cc-878a-40ce-9c21-3200c127d4c4.png)
