### PR TITLE
don't try to show number fingerprint for ID fields

### DIFF
--- a/frontend/src/metabase/components/MetadataInfo/FieldFingerprintInfo/FieldFingerprintInfo.jsx
+++ b/frontend/src/metabase/components/MetadataInfo/FieldFingerprintInfo/FieldFingerprintInfo.jsx
@@ -20,7 +20,7 @@ function FieldFingerprintInfo({ className, field }) {
 
   if (field.isDate()) {
     return <DateTimeFingerprint className={className} field={field} />;
-  } else if (field.isNumber()) {
+  } else if (field.isNumber() && !field.isID()) {
     return <NumberFingerprint className={className} field={field} />;
   } else if (field.isCategory()) {
     return <CategoryFingerprint className={className} field={field} />;
@@ -34,7 +34,7 @@ function getTimezone(field) {
 }
 
 function DateTimeFingerprint({ className, field }) {
-  const dateTimeFingerprint = field.fingerprint.type["type/DateTime"];
+  const dateTimeFingerprint = field.fingerprint.type?.["type/DateTime"];
   if (!dateTimeFingerprint) {
     return null;
   }
@@ -65,7 +65,7 @@ function DateTimeFingerprint({ className, field }) {
 }
 
 function NumberFingerprint({ className, field }) {
-  const numberFingerprint = field.fingerprint.type["type/Number"];
+  const numberFingerprint = field.fingerprint.type?.["type/Number"];
   if (!numberFingerprint) {
     return null;
   }

--- a/frontend/test/metabase/scenarios/visualizations/table.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/table.cy.spec.js
@@ -1,6 +1,7 @@
 import {
   restore,
   openPeopleTable,
+  openOrdersTable,
   openNativeEditor,
   popover,
   enterCustomColumnDetails,
@@ -152,6 +153,18 @@ describe("scenarios > visualizations > table", () => {
     popover().within(() => {
       cy.contains("Count");
       cy.findByText("No description");
+    });
+  });
+
+  it("should show the field metadata popover for a foreign key field (metabase#19577)", () => {
+    openOrdersTable();
+    cy.wait("@dataset");
+
+    cy.findByText("Product ID").trigger("mouseenter");
+
+    popover().within(() => {
+      cy.contains("Product ID");
+      cy.contains("The product ID.");
     });
   });
 


### PR DESCRIPTION
Fixes #19577 

In order to determine which `fingerprint` UI to show we do a few `field.isX()` calls: `field.isDate()`, `field.isNumber()`, etc. Well, surprise, fields that are IDs return true for `field.isNumber()` because they are in fact numbers. So, I'm adding `!field.isID()` to that specific predicate. I'm also adding optional chaining to the `fingerprint.type` reference as that is the actual problem -- the `fingerprint` object may exist but the `fingerprint.type` object might not exist.

This issue was discovered on a dataset, but it affects all instances of foreign key fields.

**Testing**
1. Go to the Orders table
2. Hover over the Product ID column header
3. The app shouldn't break

<img width="401" alt="Screen Shot 2022-01-06 at 4 14 39 PM" src="https://user-images.githubusercontent.com/13057258/148470417-3fd55d93-a163-4bba-bb5d-bfd5dfc58f76.png">

