### PR TITLE
Custom expression editor: avoid null ref

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -231,8 +231,10 @@ export default class ExpressionEditorTextfield extends React.Component {
 
   handleFocus = () => {
     this.setState({ isFocused: true });
-    const { editor } = this.input.current;
-    this.handleCursorChange(editor.selection);
+    if (this.input.current) {
+      const { editor } = this.input.current;
+      this.handleCursorChange(editor.selection);
+    }
   };
 
   handleInputBlur = e => {


### PR DESCRIPTION
Seems that the very first focus happens when the element ref isn't ready yet (the component did not completely get mounted).

To try, do the following with the DevTools opened (to see the console):

1. Ask a question, Custom question
2. Sample Dataset, Products table
3. Filter, Custom Expression

**Before this PR**

The error "Uncaught TypeError" appears in the browser console.

![image](https://user-images.githubusercontent.com/7288/148577755-6cf0ea38-e92a-4fd3-a558-7db203364dda.png)

**After this PR**
The above console error does not appear.