### PR TITLE
Docs: explicitly mention to target master for bug fixes

### DIFF
--- a/docs/developers-guide/contributing.md
+++ b/docs/developers-guide/contributing.md
@@ -2,6 +2,8 @@
 
 In general, we like to have an open issue for every pull request as a place to discuss the nature of any bug or proposed improvement. Each pull request should address a single issue, and contain both the fix as well as a description of the pull request and tests that validate that the PR fixes the issue in question.
 
+For bug fixes, please submit the pull request to target the `master` branch. From time to time, our team will backport selected critical bug fixes to the stable/release branch.
+
 For significant feature additions, it is expected that discussion will have taken place in the attached issue. Any feature that requires a major decision to be reached will need to have an explicit design document written. The goals of this document are to make explicit the assumptions, constraints and tradeoffs any given feature implementation will contain. The point is not to generate documentation but to allow discussion to reference a specific proposed design and to allow others to consider the implications of a given design.
 
 We don't like getting sued, so before merging any pull request, we'll need each person contributing code to sign a Contributor License Agreement [here](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform).


### PR DESCRIPTION
This is to avoid any potential ambiguities w.r.t. trunk-based approach.

Once this is merged, I will remove the outdated [Repository Branching Strategy wiki page](https://github.com/metabase/metabase/wiki/Metabase-Repository-Branching-Strategy).