### PR TITLE
Chromatic in CI: only publish if the token is available

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -175,6 +175,9 @@ jobs:
       - run: yarn install --frozen-lockfile --prefer-offline
       - name: Publish to Chromatic
         uses: chromaui/action@v1
+        env:
+          PUBLISH_CHROMATIC: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+        if: env.PUBLISH_CHROMATIC != null
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}


### PR DESCRIPTION
**Before this PR**

If an external contributor forks Metabase repo, the Chromatic publish step in the CI will fail if they don't have (likely the case) a Chromatic project token. This causes the `fe-chromatic` to fail (red).

![image](https://user-images.githubusercontent.com/7288/148691122-b1bdb1e1-deeb-40ba-9f5b-7ad406129c73.png)


**After this PR**

Without Chromatic project token, the publishing step ("Publish to Chromatic") is skipped and thus the `fe-chromatic` won't fail.

![image](https://user-images.githubusercontent.com/7288/148691463-8e43ef79-714c-46e7-92bf-a35c532c9aed.png)