### PR TITLE
Fix add-implicit-clauses middleware not properly handling source queries

### DIFF
--- a/dev/src/dev/debug_qp.clj
+++ b/dev/src/dev/debug_qp.clj
@@ -11,7 +11,6 @@
             [metabase.models.table :refer [Table]]
             [metabase.query-processor :as qp]
             [metabase.query-processor.reducible :as qp.reducible]
-            [metabase.query-processor.util.add-alias-info :as add]
             [metabase.util :as u]
             [toucan.db :as db]))
 
@@ -47,8 +46,8 @@
          (m :guard (every-pred map? (comp integer? :source-table)))
          (add-names* (update m :source-table add-table-id-name))
 
-         (m :guard (every-pred map? (comp integer? ::add/source-table)))
-         (add-names* (update m ::add/source-table add-table-id-name))
+         (m :guard (every-pred map? (comp integer? :metabase.query-processor.util.add-alias-info/source-table)))
+         (add-names* (update m :metabase.query-processor.util.add-alias-info/source-table add-table-id-name))
 
          (m :guard (every-pred map? (comp integer? :fk-field-id)))
          (-> m

--- a/dev/test/dev/debug_qp_test.clj
+++ b/dev/test/dev/debug_qp_test.clj
@@ -87,9 +87,3 @@
               :source-table (mt/id :categories)
               :fk-field-id  (mt/id :venues :category_id)}]
             "venues")))))
-
-(deftest to-mbql-shorthand-refs-test
-  (testing "Make sure it doesn't do anything kooky with :aggregation references inside :qp/refs"
-    (is (= '(mt/$ids nil {:qp/refs {[:aggregation 0] {:position 0}}})
-           (debug-qp/to-mbql-shorthand
-            {:qp/refs {[:aggregation 0] {:position 0}}})))))

--- a/dev/test/dev/debug_qp_test.clj
+++ b/dev/test/dev/debug_qp_test.clj
@@ -1,0 +1,95 @@
+(ns  dev.debug-qp-test
+  (:require [clojure.test :refer :all]
+            [dev.debug-qp :as debug-qp]
+            [metabase.test :as mt]))
+
+(deftest add-names-test
+  (testing "Joins"
+    (is (= [{:strategy     :left-join
+             :alias        "CATEGORIES__via__CATEGORY_ID"
+             :condition    [:=
+                            [:field
+                             (mt/id :venues :category_id)
+                             (symbol "#_\"VENUES.CATEGORY_ID\"")
+                             nil]
+                            [:field
+                             (mt/id :categories :id)
+                             (symbol "#_\"CATEGORIES.ID\"")
+                             {:join-alias "CATEGORIES__via__CATEGORY_ID"}]]
+             :source-table (list 'do (symbol "#_\"CATEGORIES\"") (mt/id :categories))
+             :fk-field-id  (list 'do (symbol "#_\"VENUES.CATEGORY_ID\"") (mt/id :venues :category_id))}]
+           (debug-qp/add-names
+            [{:strategy     :left-join
+              :alias        "CATEGORIES__via__CATEGORY_ID"
+              :condition    [:=
+                             [:field (mt/id :venues :category_id) nil]
+                             [:field (mt/id :categories :id) {:join-alias "CATEGORIES__via__CATEGORY_ID"}]]
+              :source-table (mt/id :categories)
+              :fk-field-id  (mt/id :venues :category_id)}])))))
+
+(deftest to-mbql-shorthand-test
+  (mt/dataset sample-dataset
+    (testing "Normal Field ID clause"
+      (is (= '$user_id
+             (debug-qp/expand-symbolize [:field (mt/id :orders :user_id) nil])))
+      (is (= '$products.id
+             (debug-qp/expand-symbolize [:field (mt/id :products :id) nil]))))
+    (testing "Field literal name"
+      (is (= '*wow/Text
+             (debug-qp/expand-symbolize [:field "wow" {:base-type :type/Text}])))
+      (is (= [:field "w o w" {:base-type :type/Text}]
+             (debug-qp/expand-symbolize [:field "w o w" {:base-type :type/Text}]))))
+    (testing "Field with join alias"
+      (is (= '&P.people.source
+             (debug-qp/expand-symbolize [:field (mt/id :people :source) {:join-alias "P"}])))
+      (is (= [:field '%people.id {:join-alias "People - User"}]
+             (debug-qp/expand-symbolize [:field (mt/id :people :id) {:join-alias "People - User"}])))
+      (is (= '&Q.*ID/BigInteger
+             (debug-qp/expand-symbolize [:field "ID" {:base-type :type/BigInteger, :join-alias "Q"}]))))
+    (testing "Field with source-field"
+      (is (= '$product_id->products.id
+             (debug-qp/expand-symbolize [:field (mt/id :products :id) {:source-field (mt/id :orders :product_id)}])))
+      (is (= '$product_id->*wow/Text
+             (debug-qp/expand-symbolize [:field "wow" {:base-type :type/Text, :source-field (mt/id :orders :product_id)}]))))
+    (testing "Binned field - no expansion (%id only)"
+      (is (= [:field '%people.source {:binning {:strategy :default}}]
+             (debug-qp/expand-symbolize [:field (mt/id :people :source) {:binning {:strategy :default}}]))))
+    (testing "Field with temporal unit"
+      (is (= '!default.created_at
+             (debug-qp/expand-symbolize [:field (mt/id :orders :created_at) {:temporal-unit :default}]))))
+    (testing "Field with join alias AND temporal unit"
+      (is (= '!default.&P1.created_at
+             (debug-qp/expand-symbolize [:field (mt/id :orders :created_at) {:temporal-unit :default, :join-alias "P1"}]))))
+
+    (testing "source table"
+      (is (= '(mt/mbql-query orders
+                {:joins [{:source-table $$people}]})
+             (debug-qp/to-mbql-shorthand
+              {:database (mt/id)
+               :type     :query
+               :query    {:source-table (mt/id :orders)
+                          :joins        [{:source-table (mt/id :people)}]}}))))))
+
+(deftest to-mbql-shorthand-joins-test
+  (testing :fk-field-id
+    (is (= '(mt/$ids venues
+              [{:strategy     :left-join
+                :alias        "CATEGORIES__via__CATEGORY_ID"
+                :condition    [:= $category_id &CATEGORIES__via__CATEGORY_ID.categories.id]
+                :source-table $$categories
+                :fk-field-id  %category_id}])
+           (debug-qp/to-mbql-shorthand
+            [{:strategy     :left-join
+              :alias        "CATEGORIES__via__CATEGORY_ID"
+              :condition    [:=
+                             [:field (mt/id :venues :category_id) nil]
+                             [:field (mt/id :categories :id) {:join-alias "CATEGORIES__via__CATEGORY_ID"}]]
+              :source-table (mt/id :categories)
+              :fk-field-id  (mt/id :venues :category_id)}]
+            "venues")))))
+
+(deftest to-mbql-shorthand-refs-test
+  (testing "Make sure it doesn't do anything kooky with :aggregation references inside :qp/refs"
+    (is (= '(mt/$ids nil {:qp/refs {[:aggregation 0] {:position 0}}})
+           (debug-qp/to-mbql-shorthand
+            {:qp/refs {[:aggregation 0] {:position 0}}})))))

--- a/src/metabase/query_processor/middleware/add_implicit_clauses.clj
+++ b/src/metabase/query_processor/middleware/add_implicit_clauses.clj
@@ -1,16 +1,16 @@
 (ns metabase.query-processor.middleware.add-implicit-clauses
   "Middlware for adding an implicit `:fields` and `:order-by` clauses to certain queries."
   (:require [clojure.tools.logging :as log]
+            [clojure.walk :as walk]
             [metabase.mbql.schema :as mbql.s]
             [metabase.mbql.util :as mbql.u]
             [metabase.models.field :refer [Field]]
             [metabase.models.table :as table]
             [metabase.query-processor.error-type :as error-type]
-            [metabase.query-processor.interface :as qp.i]
             [metabase.query-processor.store :as qp.store]
             [metabase.types :as types]
             [metabase.util :as u]
-            [metabase.util.i18n :refer [trs tru]]
+            [metabase.util.i18n :refer [tru]]
             [metabase.util.schema :as su]
             [schema.core :as s]
             [toucan.db :as db]))
@@ -19,7 +19,7 @@
 ;;; |                                              Add Implicit Fields                                               |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(defn- table->sorted-fields
+(defn- table->sorted-fields*
   [table-id]
   (db/select [Field :id :base_type :effective_type :coercion_strategy :semantic_type]
     :table_id        table-id
@@ -28,9 +28,19 @@
     :parent_id       nil
     {:order-by table/field-order-rule}))
 
+(defn- table->sorted-fields
+  "Return a sequence of all Fields for table that we'd normally include in the equivalent of a `SELECT *`."
+  [table-id]
+  (if (qp.store/initialized?)
+    ;; cache duplicate calls to this function in the same QP run.
+    (qp.store/cached-fn [::table-sorted-fields (u/the-id table-id)] #(table->sorted-fields* table-id))
+    ;; if QP store is not initialized don't try to cache the value (this is mainly for the benefit of tests and code
+    ;; that uses this outside of the normal QP execution context)
+    (table->sorted-fields* table-id)))
+
 (s/defn sorted-implicit-fields-for-table :- mbql.s/Fields
   "For use when adding implicit Field IDs to a query. Return a sequence of field clauses, sorted by the rules listed
-  in `metabase.query-processor.sort`, for all the Fields in a given Table."
+  in [[metabase.query-processor.sort]], for all the Fields in a given Table."
   [table-id :- su/IntGreaterThanZero]
   (let [fields (table->sorted-fields table-id)]
     (when (empty? fields)
@@ -74,10 +84,9 @@
     aggregations :aggregation} :- mbql.s/MBQLQuery]
   ;; if someone is trying to include an explicit `source-query` but isn't specifiying `source-metadata` warn that
   ;; there's nothing we can do to help them
-  (when (and source-query (empty? source-metadata))
-    (when-not qp.i/*disable-qp-logging*
-      (log/warn
-       (trs "Warning: cannot determine fields for an explicit `source-query` unless you also include `source-metadata`."))))
+  (when (and source-query
+             (empty? source-metadata))
+    (log/debug "Warning: cannot determine fields for an explicit `source-query` unless you also include `source-metadata`."))
   ;; Determine whether we can add the implicit `:fields`
   (and (or source-table
            (and source-query (seq source-metadata)))
@@ -125,14 +134,17 @@
 
 (defn add-implicit-mbql-clauses
   "Add implicit clauses such as `:fields` and `:order-by` to an 'inner' MBQL query as needed."
-  [{:keys [source-query], :as inner-query}]
-  (let [mbql-source-query? (and source-query (not (:native source-query)))
-        inner-query        (-> inner-query add-implicit-breakout-order-by add-implicit-fields)]
-    (if mbql-source-query?
-      ;; if query has an MBQL source query recursively add implicit clauses to that too as needed
-      (update inner-query :source-query add-implicit-mbql-clauses)
-      ;; otherwise we're done
-      inner-query)))
+  [form]
+  (walk/postwalk
+   (fn [form]
+     ;; add implicit clauses to any 'inner query', except for joins themselves (we should still add implicit clauses
+     ;; like `:fields` to source queries *inside* joins)
+     (if (and (map? form)
+              ((some-fn :source-table :source-query) form)
+              (not (:condition form)))
+       (-> form add-implicit-breakout-order-by add-implicit-fields)
+       form))
+   form))
 
 (defn- maybe-add-implicit-clauses [{query-type :type, :as query}]
   (if (= query-type :native)

--- a/test/metabase/driver/sql/query_processor_test.clj
+++ b/test/metabase/driver/sql/query_processor_test.clj
@@ -448,7 +448,8 @@
                 "SELECT VENUES.CATEGORY_ID AS CATEGORY_ID, max(VENUES.PRICE) AS MaxPrice, avg(VENUES.PRICE) AS AvgPrice,"
                 " min(VENUES.PRICE) AS MinPrice "
                 "FROM VENUES "
-                "GROUP BY VENUES.CATEGORY_ID"
+                "GROUP BY VENUES.CATEGORY_ID "
+                "ORDER BY VENUES.CATEGORY_ID ASC"
                 ") CategoriesStats"
                 " ON VENUES.CATEGORY_ID = CategoriesStats.CATEGORY_ID"
                 ") source "
@@ -518,15 +519,14 @@
                                    [:asc &People.people.source]]
                     :joins        [{:strategy     :left-join
                                     :source-table $$products
-                                    :condition
-                                    [:= $orders.product_id &P1.products.id]
+                                    :condition    [:= $orders.product_id &P1.products.id]
                                     :alias        "P1"}
                                    {:strategy     :left-join
                                     :source-table $$people
                                     :condition    [:= $orders.user_id &People.people.id]
                                     :alias        "People"}]}
      :joins        [{:strategy     :left-join
-                     :condition    [:= $products.category &Q2.products.category]
+                     :condition    [:= &P1.products.category &Q2.products.category]
                      :alias        "Q2"
                      :source-query {:source-table $$reviews
                                     :aggregation  [[:aggregation-options [:avg $reviews.rating] {:name "avg"}]]
@@ -603,6 +603,7 @@
                  "    LEFT JOIN PRODUCTS P2"
                  "           ON REVIEWS.PRODUCT_ID = P2.ID"
                  "    GROUP BY P2.CATEGORY"
+                 "    ORDER BY P2.CATEGORY ASC"
                  ") Q2"
                  "       ON source.P1__CATEGORY = Q2.P2__CATEGORY"
                  "LIMIT 2"]

--- a/test/metabase/query_processor/test_util.clj
+++ b/test/metabase/query_processor/test_util.clj
@@ -89,7 +89,8 @@
         (update :fields (fn [fields]
                           (set
                            (for [[_ {table-id :table_id, field-name :name}] fields]
-                             [(get-in store [:tables table-id :name]) field-name])))))))
+                             [(get-in store [:tables table-id :name]) field-name]))))
+        (dissoc :misc))))
 
 (defn card-with-source-metadata-for-query
   "Given an MBQL `query`, return the relevant keys for creating a Card with that query and matching `:result_metadata`.

--- a/test/metabase/test_runner/effects.clj
+++ b/test/metabase/test_runner/effects.clj
@@ -8,13 +8,12 @@
 
   This would not have had the random namespace that requires these helpers and the run fails.
   "
-  (:require
-   [clojure.data :as data]
-   [clojure.test :as t]
-   [dev.debug-qp]
-   [metabase.util.date-2 :as date-2]
-   [metabase.util.i18n.impl :as i18n.impl]
-   [schema.core :as s]))
+  (:require [clojure.data :as data]
+            [clojure.test :as t]
+            dev.debug-qp
+            [metabase.util.date-2 :as date-2]
+            [metabase.util.i18n.impl :as i18n.impl]
+            [schema.core :as s]))
 
 (comment
   ;; these are necessary so data_readers.clj functions can function


### PR DESCRIPTION
Split off from #19384 

The `add-implicit-clauses` middleware did not properly transform source queries. Fixes the bug and adds some tests