### PR TITLE
Exclude archived collections from tree view

### DIFF
--- a/frontend/src/metabase/admin/permissions/components/CollectionPermissionsModal/CollectionPermissionsModal.jsx
+++ b/frontend/src/metabase/admin/permissions/components/CollectionPermissionsModal/CollectionPermissionsModal.jsx
@@ -21,6 +21,7 @@ import { permissionEditorPropTypes } from "../PermissionsEditor";
 import {
   getIsDirty,
   getCollectionsPermissionEditor,
+  collectionsQuery,
 } from "../../selectors/collection-permissions";
 import {
   initializeCollectionPermissions,
@@ -161,7 +162,7 @@ CollectionPermissionsModal.propTypes = propTypes;
 
 export default _.compose(
   Collections.loadList({
-    query: () => ({ tree: true }),
+    entityQuery: collectionsQuery,
   }),
   Groups.loadList(),
   connect(mapStateToProps, mapDispatchToProps),

--- a/frontend/src/metabase/admin/permissions/pages/CollectionPermissionsPage/CollectionPermissionsPage.jsx
+++ b/frontend/src/metabase/admin/permissions/pages/CollectionPermissionsPage/CollectionPermissionsPage.jsx
@@ -25,6 +25,7 @@ import {
   getCollectionsPermissionEditor,
   getCollectionEntity,
   getIsDirty,
+  collectionsQuery,
 } from "../../selectors/collection-permissions";
 import {
   PermissionsSidebar,
@@ -124,7 +125,7 @@ CollectionsPermissionsPage.propTypes = propTypes;
 
 export default _.compose(
   Collections.loadList({
-    query: () => ({ tree: true }),
+    entityQuery: collectionsQuery,
   }),
   Groups.loadList(),
   connect(mapStateToProps, mapDispatchToProps),

--- a/frontend/src/metabase/admin/permissions/selectors/collection-permissions.js
+++ b/frontend/src/metabase/admin/permissions/selectors/collection-permissions.js
@@ -16,6 +16,8 @@ import { COLLECTION_OPTIONS } from "../constants/collections-permissions";
 import { UNABLE_TO_CHANGE_ADMIN_PERMISSIONS } from "../constants/messages";
 import { getPermissionWarningModal } from "./confirmations";
 
+export const collectionsQuery = { tree: true, "exclude-archived": true };
+
 export const getIsDirty = createSelector(
   state => state.admin.permissions.collectionPermissions,
   state => state.admin.permissions.originalCollectionPermissions,
@@ -23,10 +25,15 @@ export const getIsDirty = createSelector(
     JSON.stringify(permissions) !== JSON.stringify(originalPermissions),
 );
 
-export const getCurrentCollectionId = (_state, props) =>
-  props.params.collectionId === ROOT_COLLECTION.id
+export const getCurrentCollectionId = (_state, props) => {
+  if (props.params.collectionId == null) {
+    return null;
+  }
+
+  return props.params.collectionId === ROOT_COLLECTION.id
     ? ROOT_COLLECTION.id
     : parseInt(props.params.collectionId);
+};
 
 const getRootCollectionTreeItem = () => {
   const rootCollectionIcon = getCollectionIcon(ROOT_COLLECTION);
@@ -37,20 +44,16 @@ const getRootCollectionTreeItem = () => {
   };
 };
 
-const getCollectionsTree = (state, _props) => {
-  const collections =
+const getCollections = state =>
+  (
     Collections.selectors.getList(state, {
-      entityQuery: { tree: true },
-    }) || [];
-  const nonPersonalCollections = collections.filter(
-    nonPersonalOrArchivedCollection,
-  );
+      entityQuery: collectionsQuery,
+    }) ?? []
+  ).filter(nonPersonalOrArchivedCollection);
 
-  return [
-    getRootCollectionTreeItem(),
-    ...buildCollectionTree(nonPersonalCollections),
-  ];
-};
+const getCollectionsTree = createSelector([getCollections], collections => {
+  return [getRootCollectionTreeItem(), ...buildCollectionTree(collections)];
+});
 
 export function buildCollectionTree(collections) {
   if (collections == null) {
@@ -101,21 +104,23 @@ const findCollection = (collections, collectionId) => {
   );
 };
 
-const getCollection = (state, props) => {
-  const collectionId = getCurrentCollectionId(state, props);
-  const collections = Collections.selectors.getList(state, {
-    entityQuery: { tree: true },
-  });
+const getCollection = createSelector(
+  [getCurrentCollectionId, getCollections],
+  (collectionId, collections) => {
+    if (collectionId == null) {
+      return null;
+    }
 
-  if (collectionId === ROOT_COLLECTION.id) {
-    return {
-      ...ROOT_COLLECTION,
-      children: collections,
-    };
-  }
+    if (collectionId === ROOT_COLLECTION.id) {
+      return {
+        ...ROOT_COLLECTION,
+        children: collections,
+      };
+    }
 
-  return findCollection(collections, collectionId);
-};
+    return findCollection(collections, collectionId);
+  },
+);
 
 const getFolder = (state, props) => {
   const folderId = getCurrentCollectionId(state, props);

--- a/frontend/test/__support__/e2e/commands/api/collection.js
+++ b/frontend/test/__support__/e2e/commands/api/collection.js
@@ -17,3 +17,10 @@ Cypress.Commands.add(
     });
   },
 );
+
+Cypress.Commands.add("archiveCollection", id => {
+  cy.log(`Archiving a collection with id: ${id}`);
+  return cy.request("PUT", `/api/collection/${id}`, {
+    archived: true,
+  });
+});

--- a/frontend/test/metabase/scenarios/permissions/reproductions/19603-do-not-show-archived-collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/reproductions/19603-do-not-show-archived-collections.cy.spec.js
@@ -3,7 +3,7 @@ import { restore } from "__support__/e2e/cypress";
 const UNARCHIVED_PARENT_NAME = "Unarchived parent";
 const ARCHIVED_NAME = "Archived child";
 
-describe("issue 19609", () => {
+describe("issue 19603", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
@@ -23,7 +23,7 @@ describe("issue 19609", () => {
     });
   });
 
-  it("should not show archived collections on the collections permissions page (metabase#19609)", () => {
+  it("should not show archived collections on the collections permissions page (metabase#19603)", () => {
     cy.visit("admin/permissions/collections");
 
     cy.findByText(UNARCHIVED_PARENT_NAME).click();

--- a/frontend/test/metabase/scenarios/permissions/reproductions/19609-do-not-show-archived-collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/reproductions/19609-do-not-show-archived-collections.cy.spec.js
@@ -1,0 +1,32 @@
+import { restore } from "__support__/e2e/cypress";
+
+const UNARCHIVED_PARENT_NAME = "Unarchived parent";
+const ARCHIVED_NAME = "Archived child";
+
+describe("issue 19609", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.createCollection({
+      name: UNARCHIVED_PARENT_NAME,
+    }).then(response => {
+      const { id: collectionId } = response.body;
+      cy.createCollection({
+        name: ARCHIVED_NAME,
+        parent_id: collectionId,
+        archived: true,
+      }).then(response => {
+        const { id: archivedCollectionId } = response.body;
+        cy.archiveCollection(archivedCollectionId);
+      });
+    });
+  });
+
+  it("should not show archived collections on the collections permissions page (metabase#19609)", () => {
+    cy.visit("admin/permissions/collections");
+
+    cy.findByText(UNARCHIVED_PARENT_NAME).click();
+    cy.findByText(ARCHIVED_NAME).should("not.exist");
+  });
+});


### PR DESCRIPTION
Fixes #19603 

This is a bit more nuanced that it might first appear. The bug report is
the permissions editor for collections is showing child collections
which are archived. But the api sends back ALL collections, regardless
of archival state. So the FE knows to omit top-level archived
collections but not archived child collections.

So we thought about just having the FE remove all archived ones, but
best to remove it from the response. One worry is that we're not sure if
any callers want archived collections in the tree view or not. So right
now they are removed with a `?exclude-archived=true` query param, but if
we can demonstrate that no callers of the tree api ever want archived
items we can make this the behavior, rather than an optional behavior.

To verify that the tree api is sending back all collections, you can
check

```clj
collection=> (collection/collections->tree
               {}
               [{:archived false
                 :name "foo"
                 :id 1
                 :location "/"}
                {:archived true
                 :name "foo"
                 :id 2
                 :location "/1/"}
                {:archived true
                 :name "its archived"
                 :location "/"
                 :id 3}])
;; we have always sent back archived collections, both top level and children
({:archived false,
  :name "foo",
  :id 1,
  :location "/",
  :children ({:archived true,
              :name "foo",
              :id 2,
              :location "/1/",
              :children ()})}
 {:archived true,
  :name "its archived",
  :location "/",
  :id 3,
  :children ()})
```
