### PR TITLE
Add fix-bad-references middleware

### DIFF
--- a/dev/src/dev/debug_qp.clj
+++ b/dev/src/dev/debug_qp.clj
@@ -11,7 +11,6 @@
             [metabase.models.table :refer [Table]]
             [metabase.query-processor :as qp]
             [metabase.query-processor.reducible :as qp.reducible]
-            [metabase.query-processor.util.add-alias-info :as add]
             [metabase.util :as u]
             [toucan.db :as db]))
 
@@ -47,8 +46,8 @@
          (m :guard (every-pred map? (comp integer? :source-table)))
          (add-names* (update m :source-table add-table-id-name))
 
-         (m :guard (every-pred map? (comp integer? ::add/source-table)))
-         (add-names* (update m ::add/source-table add-table-id-name))
+         (m :guard (every-pred map? (comp integer? :metabase.query-processor.util.add-alias-info/source-table)))
+         (add-names* (update m :metabase.query-processor.util.add-alias-info/source-table add-table-id-name))
 
          (m :guard (every-pred map? (comp integer? :fk-field-id)))
          (-> m

--- a/dev/test/dev/debug_qp_test.clj
+++ b/dev/test/dev/debug_qp_test.clj
@@ -87,9 +87,3 @@
               :source-table (mt/id :categories)
               :fk-field-id  (mt/id :venues :category_id)}]
             "venues")))))
-
-(deftest to-mbql-shorthand-refs-test
-  (testing "Make sure it doesn't do anything kooky with :aggregation references inside :qp/refs"
-    (is (= '(mt/$ids nil {:qp/refs {[:aggregation 0] {:position 0}}})
-           (debug-qp/to-mbql-shorthand
-            {:qp/refs {[:aggregation 0] {:position 0}}})))))

--- a/dev/test/dev/debug_qp_test.clj
+++ b/dev/test/dev/debug_qp_test.clj
@@ -1,0 +1,95 @@
+(ns  dev.debug-qp-test
+  (:require [clojure.test :refer :all]
+            [dev.debug-qp :as debug-qp]
+            [metabase.test :as mt]))
+
+(deftest add-names-test
+  (testing "Joins"
+    (is (= [{:strategy     :left-join
+             :alias        "CATEGORIES__via__CATEGORY_ID"
+             :condition    [:=
+                            [:field
+                             (mt/id :venues :category_id)
+                             (symbol "#_\"VENUES.CATEGORY_ID\"")
+                             nil]
+                            [:field
+                             (mt/id :categories :id)
+                             (symbol "#_\"CATEGORIES.ID\"")
+                             {:join-alias "CATEGORIES__via__CATEGORY_ID"}]]
+             :source-table (list 'do (symbol "#_\"CATEGORIES\"") (mt/id :categories))
+             :fk-field-id  (list 'do (symbol "#_\"VENUES.CATEGORY_ID\"") (mt/id :venues :category_id))}]
+           (debug-qp/add-names
+            [{:strategy     :left-join
+              :alias        "CATEGORIES__via__CATEGORY_ID"
+              :condition    [:=
+                             [:field (mt/id :venues :category_id) nil]
+                             [:field (mt/id :categories :id) {:join-alias "CATEGORIES__via__CATEGORY_ID"}]]
+              :source-table (mt/id :categories)
+              :fk-field-id  (mt/id :venues :category_id)}])))))
+
+(deftest to-mbql-shorthand-test
+  (mt/dataset sample-dataset
+    (testing "Normal Field ID clause"
+      (is (= '$user_id
+             (debug-qp/expand-symbolize [:field (mt/id :orders :user_id) nil])))
+      (is (= '$products.id
+             (debug-qp/expand-symbolize [:field (mt/id :products :id) nil]))))
+    (testing "Field literal name"
+      (is (= '*wow/Text
+             (debug-qp/expand-symbolize [:field "wow" {:base-type :type/Text}])))
+      (is (= [:field "w o w" {:base-type :type/Text}]
+             (debug-qp/expand-symbolize [:field "w o w" {:base-type :type/Text}]))))
+    (testing "Field with join alias"
+      (is (= '&P.people.source
+             (debug-qp/expand-symbolize [:field (mt/id :people :source) {:join-alias "P"}])))
+      (is (= [:field '%people.id {:join-alias "People - User"}]
+             (debug-qp/expand-symbolize [:field (mt/id :people :id) {:join-alias "People - User"}])))
+      (is (= '&Q.*ID/BigInteger
+             (debug-qp/expand-symbolize [:field "ID" {:base-type :type/BigInteger, :join-alias "Q"}]))))
+    (testing "Field with source-field"
+      (is (= '$product_id->products.id
+             (debug-qp/expand-symbolize [:field (mt/id :products :id) {:source-field (mt/id :orders :product_id)}])))
+      (is (= '$product_id->*wow/Text
+             (debug-qp/expand-symbolize [:field "wow" {:base-type :type/Text, :source-field (mt/id :orders :product_id)}]))))
+    (testing "Binned field - no expansion (%id only)"
+      (is (= [:field '%people.source {:binning {:strategy :default}}]
+             (debug-qp/expand-symbolize [:field (mt/id :people :source) {:binning {:strategy :default}}]))))
+    (testing "Field with temporal unit"
+      (is (= '!default.created_at
+             (debug-qp/expand-symbolize [:field (mt/id :orders :created_at) {:temporal-unit :default}]))))
+    (testing "Field with join alias AND temporal unit"
+      (is (= '!default.&P1.created_at
+             (debug-qp/expand-symbolize [:field (mt/id :orders :created_at) {:temporal-unit :default, :join-alias "P1"}]))))
+
+    (testing "source table"
+      (is (= '(mt/mbql-query orders
+                {:joins [{:source-table $$people}]})
+             (debug-qp/to-mbql-shorthand
+              {:database (mt/id)
+               :type     :query
+               :query    {:source-table (mt/id :orders)
+                          :joins        [{:source-table (mt/id :people)}]}}))))))
+
+(deftest to-mbql-shorthand-joins-test
+  (testing :fk-field-id
+    (is (= '(mt/$ids venues
+              [{:strategy     :left-join
+                :alias        "CATEGORIES__via__CATEGORY_ID"
+                :condition    [:= $category_id &CATEGORIES__via__CATEGORY_ID.categories.id]
+                :source-table $$categories
+                :fk-field-id  %category_id}])
+           (debug-qp/to-mbql-shorthand
+            [{:strategy     :left-join
+              :alias        "CATEGORIES__via__CATEGORY_ID"
+              :condition    [:=
+                             [:field (mt/id :venues :category_id) nil]
+                             [:field (mt/id :categories :id) {:join-alias "CATEGORIES__via__CATEGORY_ID"}]]
+              :source-table (mt/id :categories)
+              :fk-field-id  (mt/id :venues :category_id)}]
+            "venues")))))
+
+(deftest to-mbql-shorthand-refs-test
+  (testing "Make sure it doesn't do anything kooky with :aggregation references inside :qp/refs"
+    (is (= '(mt/$ids nil {:qp/refs {[:aggregation 0] {:position 0}}})
+           (debug-qp/to-mbql-shorthand
+            {:qp/refs {[:aggregation 0] {:position 0}}})))))

--- a/src/metabase/query_processor.clj
+++ b/src/metabase/query_processor.clj
@@ -32,6 +32,7 @@
             [metabase.query-processor.middleware.desugar :as desugar]
             [metabase.query-processor.middleware.expand-macros :as expand-macros]
             [metabase.query-processor.middleware.fetch-source-query :as fetch-source-query]
+            [metabase.query-processor.middleware.fix-bad-references :as fix-bad-refs]
             [metabase.query-processor.middleware.format-rows :as format-rows]
             [metabase.query-processor.middleware.large-int-id :as large-int-id]
             [metabase.query-processor.middleware.limit :as limit]
@@ -91,6 +92,7 @@
    ;; yes, this is called a second time, because we need to handle any joins that got added
    (resolve 'ee.sandbox.rows/apply-row-level-permissions)
    #'viz-settings/update-viz-settings
+   #'fix-bad-refs/fix-bad-references-middleware
    #'resolve-joined-fields/resolve-joined-fields
    #'resolve-joins/resolve-joins
    #'add-implicit-joins/add-implicit-joins

--- a/src/metabase/query_processor/middleware/fix_bad_references.clj
+++ b/src/metabase/query_processor/middleware/fix_bad_references.clj
@@ -2,10 +2,9 @@
   (:require [clojure.tools.logging :as log]
             [clojure.walk :as walk]
             [metabase.mbql.util :as mbql.u]
-            [metabase.query-processor.error-type :as qp.error-type]
             [metabase.query-processor.store :as qp.store]
             [metabase.util :as u]
-            [metabase.util.i18n :refer [trs tru]]))
+            [metabase.util.i18n :refer [trs]]))
 
 (defn- find-source-table [{:keys [source-table source-query]}]
   (or source-table

--- a/src/metabase/query_processor/middleware/fix_bad_references.clj
+++ b/src/metabase/query_processor/middleware/fix_bad_references.clj
@@ -1,0 +1,87 @@
+(ns metabase.query-processor.middleware.fix-bad-references
+  (:require [clojure.tools.logging :as log]
+            [clojure.walk :as walk]
+            [metabase.mbql.util :as mbql.u]
+            [metabase.query-processor.error-type :as qp.error-type]
+            [metabase.query-processor.store :as qp.store]
+            [metabase.util :as u]
+            [metabase.util.i18n :refer [trs tru]]))
+
+(defn- find-source-table [{:keys [source-table source-query]}]
+  (or source-table
+      (when source-query
+        (recur source-query))))
+
+(defn- find-join-against-table [{:keys [joins source-query]} table-id]
+  (or (when source-query
+        (find-join-against-table source-query table-id))
+      (some (fn [join]
+              (when (= (find-source-table join) table-id)
+                join))
+            joins)))
+
+(defn- table [table-id]
+  (when table-id
+    (qp.store/fetch-and-store-tables! #{table-id})
+    (qp.store/table table-id)))
+
+(defn- fix-bad-references*
+  ([inner-query]
+   (fix-bad-references* inner-query inner-query (find-source-table inner-query)))
+
+  ([inner-query form source-table & sources]
+   (mbql.u/replace form
+     ;; don't replace anything inside source metadata.
+     (_ :guard (constantly ((set &parents) :source-metadata)))
+     &match
+
+     ;; if we have entered a join map and don't have `join-source` info yet, determine that and recurse.
+     (m :guard (every-pred map?
+                           :condition
+                           (fn [join]
+                             (let [join-source (find-source-table join)]
+                               (not (contains? (set sources) join-source))))))
+     (apply fix-bad-references* inner-query m source-table (cons (find-source-table m) sources))
+
+     ;; find Field ID fields whose Table IS NOT the source table (or not directly available in some `[:source-query+
+     ;; :source-table]` path that do not have `:join-alias` info
+     [:field
+      (id :guard (every-pred integer? (fn [id]
+                                        (let [{table-id :table_id} (qp.store/field id)]
+                                          (not (some (partial = table-id)
+                                                     (cons source-table sources)))))))
+      (opts :guard (complement :join-alias))]
+     (let [{table-id :table_id, :as field} (qp.store/field id)
+           {join-alias :alias}             (find-join-against-table inner-query table-id)]
+       (log/warn (u/colorize 'yellow (trs "Bad :field clause {0} for field {1} at {2}: clause should have a :join-alias. Guessing join {3}"
+                                          (pr-str &match)
+                                          (pr-str (format "%s.%s"
+                                                          (:name (table table-id))
+                                                          (:name field)))
+                                          (pr-str &parents)
+                                          (pr-str join-alias))))
+       (if join-alias
+         [:field id (assoc opts :join-alias join-alias)]
+         &match)))))
+
+(defn fix-bad-references
+  "Walk `query` and look for `:field` ID clauses without `:join-alias` information that reference Fields belonging to
+  Tables other than the source Table (or an 'indirect' source Table that is available via source queries). Such
+  references are technically disallowed. Since we are nice we will look thru joins and try to figure out a join that
+  will work and add appropriate `:join-alias` information if we can. If we can't find any viable join, throw an
+  Exception."
+  [query]
+  (walk/postwalk
+   (fn [form]
+     (if (and (map? form)
+              ((some-fn :source-query :source-table) form)
+              (not (:condition form)))
+       (fix-bad-references* form)
+       form))
+   query))
+
+(defn fix-bad-references-middleware
+  "Middleware version of [[fix-bad-references]]."
+  [qp]
+  (fn [query rff context]
+    (qp (fix-bad-references query) rff context)))

--- a/test/metabase/query_processor/middleware/fix_bad_references_test.clj
+++ b/test/metabase/query_processor/middleware/fix_bad_references_test.clj
@@ -1,0 +1,32 @@
+(ns metabase.query-processor.middleware.fix-bad-references-test
+  (:require [clojure.test :refer :all]
+            [metabase.query-processor.middleware.fix-bad-references :as fix-bad-refs]
+            [metabase.test :as mt]))
+
+(defn- fix-bad-refs [query]
+  (mt/with-everything-store
+    (fix-bad-refs/fix-bad-references query)))
+
+(deftest fix-bad-references-test
+  (mt/dataset sample-dataset
+    (is (query= (mt/mbql-query orders
+                  {:source-query {:source-table $$orders
+                                  :joins        [{:fields       :all
+                                                  :source-table $$products
+                                                  :condition    [:= $orders.product_id &P1.products.id]
+                                                  :alias        "P1"}]}
+                   :joins        [{:fields       :all
+                                   :condition    [:= &P1.products.category &Q2.products.category]
+                                   :alias        "Q2"
+                                   :source-table $$reviews}]})
+                (fix-bad-refs
+                 (mt/mbql-query orders
+                   {:source-query {:source-table $$orders
+                                   :joins        [{:source-table $$products
+                                                   :alias        "P1"
+                                                   :condition    [:= $orders.product_id &P1.products.id]
+                                                   :fields       :all}]}
+                    :joins        [{:fields       :all
+                                    :condition    [:= $products.category &Q2.products.category]
+                                    :alias        "Q2"
+                                    :source-table $$reviews}]}))))))

--- a/test/metabase/test_runner/effects.clj
+++ b/test/metabase/test_runner/effects.clj
@@ -8,13 +8,12 @@
 
   This would not have had the random namespace that requires these helpers and the run fails.
   "
-  (:require
-   [clojure.data :as data]
-   [clojure.test :as t]
-   [dev.debug-qp]
-   [metabase.util.date-2 :as date-2]
-   [metabase.util.i18n.impl :as i18n.impl]
-   [schema.core :as s]))
+  (:require [clojure.data :as data]
+            [clojure.test :as t]
+            dev.debug-qp
+            [metabase.util.date-2 :as date-2]
+            [metabase.util.i18n.impl :as i18n.impl]
+            [schema.core :as s]))
 
 (comment
   ;; these are necessary so data_readers.clj functions can function


### PR DESCRIPTION
Split off from #19384

No actual bug fixes in this PR, but #19384 makes use of this and fixes stuff. At any rate adding it doesn't break anything.

#### New fix-broken-`:field`-clause middleware

Previously, the query processor silently allowed `:field` clauses that did not belong to a directly-visible `:source-table` (i.e., a `:source-table` in the current level or accessible via one or more source queries) with no `:join-alias` or `:source-field`. What happened with these Fields was largely indeterministic and worked sometimes by sheer luck. Since #19384 makes everything else much more explicit and deterministic, these clauses no longer accidentally (sometimes) compiled to the right thing. 

In the spirit of being nice, rather than breaking some previously working (albeit malformed) queries, this PR introduces new QP middleware, `metabase.query-processor.middleware.fix-bad-references`, that finds these sorts of clauses, logs a warning, and attempts to add appropriate `:join-alias` information by looking thru the rest of the query to find a join against the Table the referenced Field belongs to.