### PR TITLE
Tweak QP resolve-joins middleware to preserve `:fields`

### DIFF
--- a/dev/src/dev/debug_qp.clj
+++ b/dev/src/dev/debug_qp.clj
@@ -11,7 +11,6 @@
             [metabase.models.table :refer [Table]]
             [metabase.query-processor :as qp]
             [metabase.query-processor.reducible :as qp.reducible]
-            [metabase.query-processor.util.add-alias-info :as add]
             [metabase.util :as u]
             [toucan.db :as db]))
 
@@ -47,8 +46,8 @@
          (m :guard (every-pred map? (comp integer? :source-table)))
          (add-names* (update m :source-table add-table-id-name))
 
-         (m :guard (every-pred map? (comp integer? ::add/source-table)))
-         (add-names* (update m ::add/source-table add-table-id-name))
+         (m :guard (every-pred map? (comp integer? :metabase.query-processor.util.add-alias-info/source-table)))
+         (add-names* (update m :metabase.query-processor.util.add-alias-info/source-table add-table-id-name))
 
          (m :guard (every-pred map? (comp integer? :fk-field-id)))
          (-> m

--- a/dev/test/dev/debug_qp_test.clj
+++ b/dev/test/dev/debug_qp_test.clj
@@ -87,9 +87,3 @@
               :source-table (mt/id :categories)
               :fk-field-id  (mt/id :venues :category_id)}]
             "venues")))))
-
-(deftest to-mbql-shorthand-refs-test
-  (testing "Make sure it doesn't do anything kooky with :aggregation references inside :qp/refs"
-    (is (= '(mt/$ids nil {:qp/refs {[:aggregation 0] {:position 0}}})
-           (debug-qp/to-mbql-shorthand
-            {:qp/refs {[:aggregation 0] {:position 0}}})))))

--- a/dev/test/dev/debug_qp_test.clj
+++ b/dev/test/dev/debug_qp_test.clj
@@ -1,0 +1,95 @@
+(ns  dev.debug-qp-test
+  (:require [clojure.test :refer :all]
+            [dev.debug-qp :as debug-qp]
+            [metabase.test :as mt]))
+
+(deftest add-names-test
+  (testing "Joins"
+    (is (= [{:strategy     :left-join
+             :alias        "CATEGORIES__via__CATEGORY_ID"
+             :condition    [:=
+                            [:field
+                             (mt/id :venues :category_id)
+                             (symbol "#_\"VENUES.CATEGORY_ID\"")
+                             nil]
+                            [:field
+                             (mt/id :categories :id)
+                             (symbol "#_\"CATEGORIES.ID\"")
+                             {:join-alias "CATEGORIES__via__CATEGORY_ID"}]]
+             :source-table (list 'do (symbol "#_\"CATEGORIES\"") (mt/id :categories))
+             :fk-field-id  (list 'do (symbol "#_\"VENUES.CATEGORY_ID\"") (mt/id :venues :category_id))}]
+           (debug-qp/add-names
+            [{:strategy     :left-join
+              :alias        "CATEGORIES__via__CATEGORY_ID"
+              :condition    [:=
+                             [:field (mt/id :venues :category_id) nil]
+                             [:field (mt/id :categories :id) {:join-alias "CATEGORIES__via__CATEGORY_ID"}]]
+              :source-table (mt/id :categories)
+              :fk-field-id  (mt/id :venues :category_id)}])))))
+
+(deftest to-mbql-shorthand-test
+  (mt/dataset sample-dataset
+    (testing "Normal Field ID clause"
+      (is (= '$user_id
+             (debug-qp/expand-symbolize [:field (mt/id :orders :user_id) nil])))
+      (is (= '$products.id
+             (debug-qp/expand-symbolize [:field (mt/id :products :id) nil]))))
+    (testing "Field literal name"
+      (is (= '*wow/Text
+             (debug-qp/expand-symbolize [:field "wow" {:base-type :type/Text}])))
+      (is (= [:field "w o w" {:base-type :type/Text}]
+             (debug-qp/expand-symbolize [:field "w o w" {:base-type :type/Text}]))))
+    (testing "Field with join alias"
+      (is (= '&P.people.source
+             (debug-qp/expand-symbolize [:field (mt/id :people :source) {:join-alias "P"}])))
+      (is (= [:field '%people.id {:join-alias "People - User"}]
+             (debug-qp/expand-symbolize [:field (mt/id :people :id) {:join-alias "People - User"}])))
+      (is (= '&Q.*ID/BigInteger
+             (debug-qp/expand-symbolize [:field "ID" {:base-type :type/BigInteger, :join-alias "Q"}]))))
+    (testing "Field with source-field"
+      (is (= '$product_id->products.id
+             (debug-qp/expand-symbolize [:field (mt/id :products :id) {:source-field (mt/id :orders :product_id)}])))
+      (is (= '$product_id->*wow/Text
+             (debug-qp/expand-symbolize [:field "wow" {:base-type :type/Text, :source-field (mt/id :orders :product_id)}]))))
+    (testing "Binned field - no expansion (%id only)"
+      (is (= [:field '%people.source {:binning {:strategy :default}}]
+             (debug-qp/expand-symbolize [:field (mt/id :people :source) {:binning {:strategy :default}}]))))
+    (testing "Field with temporal unit"
+      (is (= '!default.created_at
+             (debug-qp/expand-symbolize [:field (mt/id :orders :created_at) {:temporal-unit :default}]))))
+    (testing "Field with join alias AND temporal unit"
+      (is (= '!default.&P1.created_at
+             (debug-qp/expand-symbolize [:field (mt/id :orders :created_at) {:temporal-unit :default, :join-alias "P1"}]))))
+
+    (testing "source table"
+      (is (= '(mt/mbql-query orders
+                {:joins [{:source-table $$people}]})
+             (debug-qp/to-mbql-shorthand
+              {:database (mt/id)
+               :type     :query
+               :query    {:source-table (mt/id :orders)
+                          :joins        [{:source-table (mt/id :people)}]}}))))))
+
+(deftest to-mbql-shorthand-joins-test
+  (testing :fk-field-id
+    (is (= '(mt/$ids venues
+              [{:strategy     :left-join
+                :alias        "CATEGORIES__via__CATEGORY_ID"
+                :condition    [:= $category_id &CATEGORIES__via__CATEGORY_ID.categories.id]
+                :source-table $$categories
+                :fk-field-id  %category_id}])
+           (debug-qp/to-mbql-shorthand
+            [{:strategy     :left-join
+              :alias        "CATEGORIES__via__CATEGORY_ID"
+              :condition    [:=
+                             [:field (mt/id :venues :category_id) nil]
+                             [:field (mt/id :categories :id) {:join-alias "CATEGORIES__via__CATEGORY_ID"}]]
+              :source-table (mt/id :categories)
+              :fk-field-id  (mt/id :venues :category_id)}]
+            "venues")))))
+
+(deftest to-mbql-shorthand-refs-test
+  (testing "Make sure it doesn't do anything kooky with :aggregation references inside :qp/refs"
+    (is (= '(mt/$ids nil {:qp/refs {[:aggregation 0] {:position 0}}})
+           (debug-qp/to-mbql-shorthand
+            {:qp/refs {[:aggregation 0] {:position 0}}})))))

--- a/test/metabase/query_processor/middleware/resolve_joins_test.clj
+++ b/test/metabase/query_processor/middleware/resolve_joins_test.clj
@@ -45,56 +45,59 @@
 
 (deftest fields-all-test
   (testing "Can we resolve some joins w/ fields = all ???"
-    (is (= {:resolved
-            (mt/mbql-query venues
-              {:joins
-               [{:source-table $$categories
-                 :alias        "c"
-                 :strategy     :left-join
-                 :condition    [:= $category_id &c.categories.id]}]
-               :fields [$venues.id
-                        $venues.name
-                        &c.categories.id
-                        &c.categories.name]})
-            :store
-            {:database "test-data"
-             :tables   #{"CATEGORIES" "VENUES"}
-             :fields   #{["CATEGORIES" "ID"]
-                         ["VENUES" "CATEGORY_ID"]
-                         ["CATEGORIES" "NAME"]}}}
-           (resolve-joins-and-inspect-store
-            (mt/mbql-query venues
-              {:fields [$venues.id $venues.name]
-               :joins  [{:source-table $$categories
-                         :alias        "c"
-                         :condition    [:= $category_id &c.categories.id]
-                         :fields       :all}]}))))))
+    (is (query= {:resolved
+                 (mt/mbql-query venues
+                   {:joins
+                    [{:source-table $$categories
+                      :alias        "c"
+                      :strategy     :left-join
+                      :condition    [:= $category_id &c.categories.id]
+                      :fields       [&c.categories.id
+                                     &c.categories.name]}]
+                    :fields [$venues.id
+                             $venues.name
+                             &c.categories.id
+                             &c.categories.name]})
+                 :store
+                 {:database "test-data"
+                  :tables   #{"CATEGORIES" "VENUES"}
+                  :fields   #{["CATEGORIES" "ID"]
+                              ["VENUES" "CATEGORY_ID"]
+                              ["CATEGORIES" "NAME"]}}}
+                (resolve-joins-and-inspect-store
+                 (mt/mbql-query venues
+                   {:fields [$venues.id $venues.name]
+                    :joins  [{:source-table $$categories
+                              :alias        "c"
+                              :condition    [:= $category_id &c.categories.id]
+                              :fields       :all}]}))))))
 
 (deftest fields-sequence-test
   (testing "can we resolve joins w/ fields = <sequence>"
-    (is (= {:resolved
-            (mt/mbql-query venues
-              {:joins
-               [{:source-table $$categories
-                 :alias        "c"
-                 :strategy     :left-join
-                 :condition    [:= $category_id &c.categories.id]}]
-               :fields [$venues.id
-                        $venues.name
-                        &c.categories.name]})
-            :store
-            {:database "test-data"
-             :tables   #{"CATEGORIES" "VENUES"}
-             :fields   #{["CATEGORIES" "ID"]
-                         ["VENUES" "CATEGORY_ID"]
-                         ["CATEGORIES" "NAME"]}}}
-           (resolve-joins-and-inspect-store
-            (mt/mbql-query venues
-              {:fields [$venues.id $venues.name]
-               :joins  [{:source-table $$categories
-                         :alias        "c"
-                         :condition    [:= $category_id &c.categories.id]
-                         :fields       [&c.categories.name]}]}))))))
+    (is (query= {:resolved
+                 (mt/mbql-query venues
+                   {:joins
+                    [{:source-table $$categories
+                      :alias        "c"
+                      :strategy     :left-join
+                      :condition    [:= $category_id &c.categories.id]
+                      :fields       [&c.categories.name]}]
+                    :fields [$venues.id
+                             $venues.name
+                             &c.categories.name]})
+                 :store
+                 {:database "test-data"
+                  :tables   #{"CATEGORIES" "VENUES"}
+                  :fields   #{["CATEGORIES" "ID"]
+                              ["VENUES" "CATEGORY_ID"]
+                              ["CATEGORIES" "NAME"]}}}
+                (resolve-joins-and-inspect-store
+                 (mt/mbql-query venues
+                   {:fields [$venues.id $venues.name]
+                    :joins  [{:source-table $$categories
+                              :alias        "c"
+                              :condition    [:= $category_id &c.categories.id]
+                              :fields       [&c.categories.name]}]}))))))
 
 (deftest join-same-table-twice-test
   (testing "Does joining the same table twice without an explicit alias give both joins unique aliases?"
@@ -206,17 +209,19 @@
                                                                      [:field "ID" {:base-type :type/BigInteger, :join-alias "cat"}]]}]
                                        :order-by [[:asc $name]]
                                        :limit    3}))]
-      (is (= (mt/mbql-query venues
-               {:fields   [[:field (mt/id :categories :id) {:join-alias "cat"}]
-                           [:field (mt/id :categories :name) {:join-alias "cat"}]]
-                :joins    [{:alias           "cat"
-                            :source-query    {:source-table $$categories}
-                            :source-metadata source-metadata
-                            :strategy        :left-join
-                            :condition       [:= $category_id [:field "ID" {:base-type :type/BigInteger, :join-alias "cat"}]]}]
-                :order-by [[:asc $name]]
-                :limit    3})
-             resolved))
+      (is (query= (mt/mbql-query venues
+                    {:fields   [[:field (mt/id :categories :id) {:join-alias "cat"}]
+                                [:field (mt/id :categories :name) {:join-alias "cat"}]]
+                     :joins    [{:alias           "cat"
+                                 :source-query    {:source-table $$categories}
+                                 :source-metadata source-metadata
+                                 :strategy        :left-join
+                                 :condition       [:= $category_id [:field "ID" {:base-type :type/BigInteger, :join-alias "cat"}]]
+                                 :fields          [&cat.categories.id
+                                                   &cat.categories.name]}]
+                     :order-by [[:asc $name]]
+                     :limit    3})
+                  resolved))
       (is (= {:database "test-data"
               :tables   #{"CATEGORIES" "VENUES"}
               :fields   #{["CATEGORIES" "ID"] ["VENUES" "CATEGORY_ID"] ["CATEGORIES" "NAME"]}}
@@ -224,21 +229,25 @@
 
 (deftest dont-append-fields-if-parent-has-breakout-or-aggregation-test
   (testing "if the parent level has a breakout or aggregation, we shouldn't append Join fields to the parent level"
-    (is (= (mt/mbql-query users
-             {:joins       [{:source-table $$checkins
-                             :alias        "c"
-                             :strategy     :left-join
-                             :condition    [:= $id [:field "USER_ID" {:base-type :type/Integer, :join-alias "c"}]]}],
-              :aggregation [[:sum [:field "id" {:base-type :type/Float, :join-alias "c"}]]]
-              :breakout    [[:field %last_login {:temporal-unit :month}]]})
-           (resolve-joins
-            (mt/mbql-query users
-              {:joins       [{:fields       :all
-                              :alias        "c"
-                              :source-table $$checkins
-                              :condition    [:= $id [:field "USER_ID" {:base-type :type/Integer, :join-alias "c"}]]}]
-               :aggregation [[:sum [:field "id" {:base-type :type/Float, :join-alias "c"}]]]
-               :breakout    [[:field %last_login {:temporal-unit :month}]]}))))))
+    (is (query= (mt/mbql-query users
+                  {:joins       [{:source-table $$checkins
+                                  :alias        "c"
+                                  :strategy     :left-join
+                                  :condition    [:= $id [:field "USER_ID" {:base-type :type/Integer, :join-alias "c"}]]
+                                  :fields       [&c.checkins.id
+                                                 !default.&c.checkins.date
+                                                 &c.checkins.user_id
+                                                 &c.checkins.venue_id]}]
+                   :aggregation [[:sum [:field "id" {:base-type :type/Float, :join-alias "c"}]]]
+                   :breakout    [[:field %last_login {:temporal-unit :month}]]})
+                (resolve-joins
+                 (mt/mbql-query users
+                   {:joins       [{:fields       :all
+                                   :alias        "c"
+                                   :source-table $$checkins
+                                   :condition    [:= $id [:field "USER_ID" {:base-type :type/Integer, :join-alias "c"}]]}]
+                    :aggregation [[:sum [:field "id" {:base-type :type/Float, :join-alias "c"}]]]
+                    :breakout    [[:field %last_login {:temporal-unit :month}]]}))))))
 
 (deftest aggregation-field-ref-test
   (testing "Should correctly handle [:aggregation n] field refs"
@@ -268,3 +277,35 @@
                                :field_ref     [:aggregation 0]
                                :fingerprint   nil}]}]
                    :limit  10}))))))
+
+(deftest join-against-source-query-test
+  (is (query= (mt/mbql-query venues
+                {:joins    [{:source-query {:source-table $$categories
+                                            :fields       [$categories.id
+                                                           $categories.name]}
+                             :alias        "cat"
+                             :condition    [:= $venues.category_id &cat.*ID/BigInteger]
+                             :strategy     :left-join}]
+                 :fields   [$venues.id
+                            $venues.name
+                            $venues.category_id
+                            $venues.latitude
+                            $venues.longitude
+                            $venues.price]
+                 :order-by [[:asc $venues.name]]
+                 :limit    3})
+              (resolve-joins
+               (mt/mbql-query venues
+                 {:joins    [{:source-query {:source-table $$categories
+                                             :fields       [$categories.id
+                                                            $categories.name]}
+                              :alias        "cat"
+                              :condition    [:= $venues.category_id &cat.*ID/BigInteger]}]
+                  :fields   [$venues.id
+                             $venues.name
+                             $venues.category_id
+                             $venues.latitude
+                             $venues.longitude
+                             $venues.price]
+                  :order-by [[:asc $venues.name]]
+                  :limit    3})))))

--- a/test/metabase/test_runner/effects.clj
+++ b/test/metabase/test_runner/effects.clj
@@ -8,13 +8,12 @@
 
   This would not have had the random namespace that requires these helpers and the run fails.
   "
-  (:require
-   [clojure.data :as data]
-   [clojure.test :as t]
-   [dev.debug-qp]
-   [metabase.util.date-2 :as date-2]
-   [metabase.util.i18n.impl :as i18n.impl]
-   [schema.core :as s]))
+  (:require [clojure.data :as data]
+            [clojure.test :as t]
+            dev.debug-qp
+            [metabase.util.date-2 :as date-2]
+            [metabase.util.i18n.impl :as i18n.impl]
+            [schema.core :as s]))
 
 (comment
   ;; these are necessary so data_readers.clj functions can function


### PR DESCRIPTION
Split off from #19384 

Tweaks the `resolve-joins` middleware to preserve `:fields` clauses present in the join when resolving it -- this information is important for things like the new nest-expressions logic in #19384