### PR TITLE
update nav copy to be clearer

### DIFF
--- a/frontend/src/metabase/nav/containers/Navbar.jsx
+++ b/frontend/src/metabase/nav/containers/Navbar.jsx
@@ -157,18 +157,18 @@ export default class Navbar extends Component {
                 data-metabase-event={`NavBar;Create Menu Click`}
               >
                 <Icon name="add" size={14} />
-                <h4 className="hide sm-show ml1 text-nowrap">{t`Create`}</h4>
+                <h4 className="hide sm-show ml1 text-nowrap">{t`New`}</h4>
               </Link>
             }
             items={[
               {
-                title: t`Visual question`,
+                title: t`Question`,
                 icon: `insight`,
                 link: Urls.newQuestion({
                   mode: "notebook",
                   creationType: "complex_question",
                 }),
-                event: `NavBar;New Visual Question Click;`,
+                event: `NavBar;New Question Click;`,
               },
               ...(hasNativeWrite
                 ? [
@@ -184,13 +184,13 @@ export default class Navbar extends Component {
                   ]
                 : []),
               {
-                title: t`New dashboard`,
+                title: t`Dashboard`,
                 icon: `dashboard`,
                 action: () => this.setModal(MODAL_NEW_DASHBOARD),
                 event: `NavBar;New Dashboard Click;`,
               },
               {
-                title: t`New collection`,
+                title: t`Collection`,
                 icon: `all`,
                 link: Urls.newCollection("root"),
                 event: `NavBar;New Collection Click;`,

--- a/frontend/test/__support__/e2e/helpers/e2e-misc-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-misc-helpers.js
@@ -32,7 +32,7 @@ export function openNativeEditor({
   if (!fromCurrentPage) {
     cy.visit("/");
   }
-  cy.findByText("Create").click();
+  cy.findByText("New").click();
   cy.findByText("SQL query").click();
 
   databaseName && cy.findByText(databaseName).click();
@@ -56,8 +56,8 @@ export function openNotebookEditor({ fromCurrentPage } = {}) {
     cy.visit("/");
   }
 
-  cy.findByText("Create").click();
-  cy.findByText("Visual question").click();
+  cy.findByText("New").click();
+  cy.findByText("Question").click();
 }
 
 /**

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -52,7 +52,7 @@ describe("collection permissions", () => {
                   cy.get(".Nav").within(() => {
                     cy.icon("add").click();
                   });
-                  cy.findByText("New dashboard").click();
+                  cy.findByText("Dashboard").click();
                   cy.get(".AdminSelect").findByText("Second collection");
                 });
 
@@ -62,7 +62,7 @@ describe("collection permissions", () => {
                     cy.findByText("Orders in a dashboard").click();
                     cy.icon("add").click();
                     popover()
-                      .findByText("New dashboard")
+                      .findByText("Dashboard")
                       .click();
                     cy.get(".AdminSelect").findByText("Our analytics");
                   });
@@ -480,7 +480,7 @@ describe("collection permissions", () => {
                 const { first_name, last_name } = USERS[user];
                 cy.visit(route);
                 cy.icon("add").click();
-                cy.findByText("New dashboard").click();
+                cy.findByText("Dashboard").click();
 
                 // Coming from the root collection, the initial offered collection will be "Our analytics" (read-only access)
                 cy.findByText(

--- a/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
@@ -28,7 +28,7 @@ describe("scenarios > dashboard", () => {
     // Create dashboard
     cy.visit("/");
     cy.icon("add").click();
-    cy.findByText("New dashboard").click();
+    cy.findByText("Dashboard").click();
     modal().within(() => {
       cy.findByLabelText("Name").type("Test Dash");
       cy.findByLabelText("Description").type("Desc");

--- a/frontend/test/metabase/scenarios/dashboard/text-box.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/text-box.cy.spec.js
@@ -70,7 +70,7 @@ describe("scenarios > dashboard > text-box", () => {
       cy.reload();
 
       // Page should still load
-      cy.findByText("Create");
+      cy.findByText("New");
       cy.findByText("Loading...").should("not.exist");
       cy.findByText("Cannot read property 'type' of undefined").should(
         "not.exist",

--- a/frontend/test/metabase/scenarios/smoketest/admin.cy.spec.js
+++ b/frontend/test/metabase/scenarios/smoketest/admin.cy.spec.js
@@ -88,12 +88,12 @@ describe("metabase-smoketest > admin", () => {
 
       // Following section is repeated-- turn into callback function?
       // Also, selecting Metabase H2 doesn't do anything
-      cy.findByText("Create").click();
+      cy.findByText("New").click();
 
-      cy.findByText("Visual question");
+      cy.findByText("Question");
       cy.findByText("SQL query");
 
-      cy.findByText("Visual question").click();
+      cy.findByText("Question").click();
       cy.findByTextEnsureVisible("Sample Dataset").click();
       cy.findByTextEnsureVisible("People").click();
 
@@ -224,7 +224,7 @@ describe("metabase-smoketest > admin", () => {
       cy.visit("/");
       // New dashboard
       cy.icon("add").click();
-      cy.findByText("New dashboard").click();
+      cy.findByText("Dashboard").click();
 
       cy.findByText("Which collection should this go in?");
 
@@ -323,7 +323,7 @@ describe("metabase-smoketest > admin", () => {
         // =================
         // should create my own question as user
         // =================
-        cy.findByText("Create").click();
+        cy.findByText("New").click();
 
         cy.findByText("SQL query");
 
@@ -361,7 +361,7 @@ describe("metabase-smoketest > admin", () => {
         // should create my own dashboard as user
         // =================
         cy.icon("add").click();
-        cy.findByText("New dashboard").click();
+        cy.findByText("Dashboard").click();
         cy.findByLabelText("Name").type("New User Demo Dash");
         cy.findByLabelText("Description").type("This is my own demo dash!");
         cy.get(".ModalBody")

--- a/frontend/test/metabase/scenarios/smoketest/admin_setup.cy.spec.js
+++ b/frontend/test/metabase/scenarios/smoketest/admin_setup.cy.spec.js
@@ -587,7 +587,7 @@ describe("smoketest > admin_setup", () => {
 
       // Access to SQl queries as user
 
-      cy.findByText("Create").click();
+      cy.findByText("New").click();
       cy.findByText("SQL query");
 
       // Cannot see Review table as no collection user


### PR DESCRIPTION
Updates copy from the changes in #19572 to use simpler wording.

![Screen Shot 2022-01-11 at 10 27 53 AM](https://user-images.githubusercontent.com/5248953/148971636-30f5256e-645c-4bcc-bd4a-d497fcaacabe.png)


- `New` instead of `Create` for the trigger itself
- Change `Visual question` to just `Question`
- Removes other instances of `New` since those would be redundant.