### PR TITLE
Build EE on branches

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,7 +32,7 @@ jobs:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Build container image
-      run: docker buildx build . -t metabase/metabase-dev:${{ steps.extract_branch.outputs.branch }} --push --compress --no-cache
+      run: docker buildx build . -t metabase/metabase-dev:${{ steps.extract_branch.outputs.branch }} --push --compress --no-cache --build-arg MB_EDITION=ee
     - name: Launch container
       run: docker run -dp 3000:3000 metabase/metabase-dev:${{ steps.extract_branch.outputs.branch }}
       timeout-minutes: 5


### PR DESCRIPTION
We have to build and publish EE, otherwise some features can't be tested.