### PR TITLE
Custom expression editor: handle source reformatting

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -118,8 +118,15 @@ export default class ExpressionEditorTextfield extends React.Component {
     const { expression, query, startRule } = newProps;
     if (!this.state || !_.isEqual(this.props.expression, expression)) {
       const source = format(expression, { query, startRule });
+      const currentSource = this.state?.source;
       this.setState({ source, expression });
       this.clearSuggestions();
+
+      // Reset caret position due to reformatting
+      if (currentSource !== source && this.input.current) {
+        const { editor } = this.input.current;
+        setTimeout(() => editor.gotoLine(1, source.length), 0);
+      }
     }
   }
 

--- a/frontend/test/metabase/scenarios/custom-column/custom-column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/custom-column.cy.spec.js
@@ -495,6 +495,24 @@ describe("scenarios > question > custom column", () => {
       .and("eq", "ace_text-input");
   });
 
+  it("should allow tabbing away from, then back to editor, while formatting expression and placing caret after reformatted expression", () => {
+    openOrdersTable({ mode: "notebook" });
+    cy.icon("add_data").click();
+
+    enterCustomColumnDetails({ formula: "1+1" });
+
+    cy.realPress("Tab");
+    cy.realPress(["Shift", "Tab"]);
+
+    // `1+1` (3 chars) is reformatted to `1 + 1` (5 chars)
+    cy.findByDisplayValue("1 + 1").type("2");
+
+    // Fix needed will prevent display value from being `1 +2 1`.
+    // That's because the caret position after refocusing on textarea
+    // would still be after the 3rd character
+    cy.findByDisplayValue("1 + 12");
+  });
+
   it("should allow choosing a suggestion with Tab", () => {
     openOrdersTable({ mode: "notebook" });
     cy.icon("add_data").click();


### PR DESCRIPTION
When the text representation gets reformatted, the old caret position might not be sensible anymore. Hence, just push the caret to the end.

To verify:

1. New, Question
2. Sample Dataset, Products table
3. Custom Column, type `1+2` for the expression
4. Press Left arrow once to place the caret between `+` and `2`
5. Press Tab to switch focus away
6. Press Shift+Tab to get the focus back to the editor

**Before this PR**

After Step 5, the expression is reformatted to `1 + 2` (note the whitespaces).
After Step 6, the caret is positioned right before `+`, which is confusing.

![image](https://user-images.githubusercontent.com/7288/149226415-a56c7720-b6c7-4161-a044-e104b063b0db.png)

**After this PR**

The caret is positioned at the end, because the expression is reformatted, to avoid such a confusion.

![image](https://user-images.githubusercontent.com/7288/149226749-c19c85c5-bfd8-4aa0-bd28-3def9a4f28d2.png)

**Note**
Yes, this "reformat while editing" is (mildly) annoying. This PR is just a stop-gap measure, while we're iterating on a long-term UX improvement.