### PR TITLE
Correct setting access in enterprise/embedding/utils.clj

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/embedding/utils.clj
+++ b/enterprise/backend/src/metabase_enterprise/embedding/utils.clj
@@ -9,4 +9,5 @@
   :visibility :internal
   :getter (fn []
             (when (premium-features/hide-embed-branding?)
-              (or (setting/get-string :notification-link-base-url) (public-settings/site-url)))))
+              (or (setting/get-value-of-type :string :notification-link-base-url)
+                  (public-settings/site-url)))))


### PR DESCRIPTION
Older third party PR was started before a settings refactor and then merged after the refactor was merged.

`(setting/get-string :setting)` -> `(setting/get-value-of-type :string :setting)`