### PR TITLE
Incorrect progressbar alert 10899

### DIFF
--- a/frontend/src/metabase/query_builder/components/AlertModals.jsx
+++ b/frontend/src/metabase/query_builder/components/AlertModals.jsx
@@ -504,9 +504,7 @@ export const AlertGoalToggles = ({ alertType, alert, onAlertChange }) => {
             ? t`Alert me when the line…`
             : t`Alert me when the progress bar…`
         }
-        trueText={
-          isTimeseries ? t`Reaches the goal line` : t`Reaches the goal`
-        }
+        trueText={isTimeseries ? t`Reaches the goal line` : t`Reaches the goal`}
         falseText={
           isTimeseries ? t`Goes below the goal line` : t`Goes below the goal`
         }

--- a/frontend/src/metabase/query_builder/components/AlertModals.jsx
+++ b/frontend/src/metabase/query_builder/components/AlertModals.jsx
@@ -505,7 +505,7 @@ export const AlertGoalToggles = ({ alertType, alert, onAlertChange }) => {
             : t`Alert me when the progress bar…`
         }
         trueText={
-          isTimeseries ? t`Goes above the goal line` : t`Reaches the goal`
+          isTimeseries ? t`Reaches the goal line` : t`Reaches the goal`
         }
         falseText={
           isTimeseries ? t`Goes below the goal line` : t`Goes below the goal`

--- a/frontend/test/metabase/scenarios/sharing/alert/alert-types.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/alert/alert-types.cy.spec.js
@@ -81,7 +81,7 @@ describe("scenarios > alert > types", () => {
 
       openAlertModal();
 
-      cy.findByText("Goes above the goal line").click();
+      cy.findByText("Reaches the goal line").click();
       cy.findByText("The first time").click();
 
       cy.button("Done").click();

--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -214,8 +214,8 @@
   (not= :progress (get-in result [:card :display])))
 
 (defn- goal-met? [{:keys [alert_above_goal], :as pulse} [first-result]]
-  (let [[above below] (if (timeseries-goal? first-result) [<= >=] [<= >])
-        goal-comparison (if alert_above_goal above below)
+  (let [[above below]        (if (timeseries-goal? first-result) [<= >=] [<= >])
+        goal-comparison      (if alert_above_goal above below)
         goal-val             (ui/find-goal-value first-result)
         comparison-col-rowfn (ui/make-goal-comparison-rowfn (:card first-result)
                                                             (get-in first-result [:result :data]))]

--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -207,8 +207,16 @@
   [results]
   (every? is-card-empty? results))
 
+
+(defn- timeseries-goal?
+  "Is the the goal for a timeseries (as opposed to a Progress Bar Goal)?"
+  [viz-settings]
+  (boolean (and (:graph.show_goal viz-settings)
+                (= 1 (count (:graph.metrics viz-settings))))))
+
 (defn- goal-met? [{:keys [alert_above_goal], :as pulse} [first-result]]
-  (let [goal-comparison      (if alert_above_goal <= >=)
+  (let [[above below] (if (timeseries-goal? (get-in first-result [:result :data :viz-settings])) [<= >=] [<= >])
+        goal-comparison (if alert_above_goal above below)
         goal-val             (ui/find-goal-value first-result)
         comparison-col-rowfn (ui/make-goal-comparison-rowfn (:card first-result)
                                                             (get-in first-result [:result :data]))]

--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -209,13 +209,12 @@
 
 
 (defn- timeseries-goal?
-  "Is the the goal for a timeseries (as opposed to a Progress Bar Goal)?"
-  [viz-settings]
-  (boolean (and (:graph.show_goal viz-settings)
-                (= 1 (count (:graph.metrics viz-settings))))))
+  "Is the the goal for a timeseries (:area, :bar, :line)? as opposed to a Progress Bar Goal?"
+  [result]
+  (not= :progress (get-in result [:card :display])))
 
 (defn- goal-met? [{:keys [alert_above_goal], :as pulse} [first-result]]
-  (let [[above below] (if (timeseries-goal? (get-in first-result [:result :data :viz-settings])) [<= >=] [<= >])
+  (let [[above below] (if (timeseries-goal? first-result) [<= >=] [<= >])
         goal-comparison (if alert_above_goal above below)
         goal-val             (ui/find-goal-value first-result)
         comparison-col-rowfn (ui/make-goal-comparison-rowfn (:card first-result)
@@ -225,9 +224,10 @@
       (throw (ex-info (tru "Unable to compare results to goal for alert.")
                       {:pulse  pulse
                        :result first-result})))
-    (some (fn [row]
-            (goal-comparison goal-val (comparison-col-rowfn row)))
-          (get-in first-result [:result :data :rows]))))
+    (boolean
+     (some (fn [row]
+             (goal-comparison goal-val (comparison-col-rowfn row)))
+           (get-in first-result [:result :data :rows])))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -207,14 +207,8 @@
   [results]
   (every? is-card-empty? results))
 
-(defn- timeseries-goal?
-  "Is the goal for a timeseries (:area, :bar, :line)? as opposed to a Progress Bar Goal?"
-  [result]
-  (not= :progress (get-in result [:card :display])))
-
 (defn- goal-met? [{:keys [alert_above_goal], :as pulse} [first-result]]
-  (let [[below above]        (if (timeseries-goal? first-result) [<= >=] [< >=])
-        goal-comparison      (if alert_above_goal above below)
+  (let [goal-comparison      (if alert_above_goal >= <)
         goal-val             (ui/find-goal-value first-result)
         comparison-col-rowfn (ui/make-goal-comparison-rowfn (:card first-result)
                                                             (get-in first-result [:result :data]))]

--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -207,9 +207,8 @@
   [results]
   (every? is-card-empty? results))
 
-
 (defn- timeseries-goal?
-  "Is the the goal for a timeseries (:area, :bar, :line)? as opposed to a Progress Bar Goal?"
+  "Is the goal for a timeseries (:area, :bar, :line)? as opposed to a Progress Bar Goal?"
   [result]
   (not= :progress (get-in result [:card :display])))
 

--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -214,7 +214,7 @@
   (not= :progress (get-in result [:card :display])))
 
 (defn- goal-met? [{:keys [alert_above_goal], :as pulse} [first-result]]
-  (let [[above below]        (if (timeseries-goal? first-result) [<= >=] [<= >])
+  (let [[below above]        (if (timeseries-goal? first-result) [<= >=] [< >=])
         goal-comparison      (if alert_above_goal above below)
         goal-val             (ui/find-goal-value first-result)
         comparison-col-rowfn (ui/make-goal-comparison-rowfn (:card first-result)
@@ -226,7 +226,7 @@
                        :result first-result})))
     (boolean
      (some (fn [row]
-             (goal-comparison goal-val (comparison-col-rowfn row)))
+             (goal-comparison (comparison-col-rowfn row) goal-val))
            (get-in first-result [:result :data :rows])))))
 
 

--- a/test/metabase/pulse_test.clj
+++ b/test/metabase/pulse_test.clj
@@ -564,87 +564,6 @@
                                     [test-card-result png-attachment png-attachment])
                  (mt/summarize-multipart-email test-card-regex))))}})))
 
-(deftest above-goal-alert-test-2
-  (testing "above goal alert"
-    (tests {:pulse {:alert_condition  "goal"
-                    :alert_first_only false
-                    :alert_above_goal true}}
-      "timeseries data - above goal"
-      {:card
-       (merge (checkins-query-card {:filter   [:between $date "2014-04-01" "2014-06-01"]
-                                    :breakout [!day.date]})
-              {:display                :line
-               :visualization_settings {:graph.goal_value 5.9 ;; query value is 6, so alert is sent
-                                        :graph.show_goal true
-                                        :graph.metrics ["some-value"]}})
-       :assert
-       {:email
-        (fn [_ _]
-          (is (= (rasta-alert-email "Alert: Test card has reached its goal"
-                                    [test-card-result png-attachment png-attachment])
-                 (mt/summarize-multipart-email test-card-regex))))}}
-      "timeseries data - at goal, not above"
-      {:card
-       (merge (checkins-query-card {:filter   [:between $date "2014-04-01" "2014-06-01"]
-                                    :breakout [!day.date]})
-              {:display                :line
-               :visualization_settings {:graph.goal_value 6 ;; query value is 6, so alert is not sent
-                                        :graph.show_goal true
-                                        :graph.metrics ["some-value"]}})
-       :assert
-       {:email
-        (fn [_ _]
-          (is (= {}
-                 (mt/summarize-multipart-email test-card-regex))))}}
-      "timeseries data - below goal"
-      {:card
-       (merge (checkins-query-card {:filter   [:between $date "2014-04-01" "2014-06-01"]
-                                    :breakout [!day.date]})
-              {:display                :line
-               :visualization_settings {:graph.goal_value 6.1 ;; query value is 6, so alert is not sent
-                                        :graph.show_goal true
-                                        :graph.metrics ["some-value"]}})
-       :assert
-       {:email
-        (fn [_ _]
-          (is (= {}
-                 (mt/summarize-multipart-email test-card-regex))))}}
-      "with progress bar - above goal"
-      {:card
-       (merge (venues-query-card "max")
-              {:display                :progress
-               :visualization_settings {:progress.goal 3}})
-
-       :assert
-       {:email
-        (fn [_ _]
-          (is (= (rasta-alert-email "Alert: Test card has reached its goal"
-                                    [test-card-result png-attachment png-attachment])
-                 (mt/summarize-multipart-email test-card-regex))))}}
-      "with progress bar - at goal"
-      {:card
-       (merge (venues-query-card "max")
-              {:display                :progress
-               :visualization_settings {:progress.goal 4}})
-
-       :assert
-       {:email
-        (fn [_ _]
-          (is (= (rasta-alert-email "Alert: Test card has reached its goal"
-                                    [test-card-result png-attachment png-attachment])
-                 (mt/summarize-multipart-email test-card-regex))))}}
-      "with progress bar - below goal"
-      {:card
-       (merge (venues-query-card "max")
-              {:display                :progress
-               :visualization_settings {:progress.goal 5}})
-
-       :assert
-       {:email
-        (fn [_ _]
-          (is (= {}
-                 (mt/summarize-multipart-email test-card-regex))))}})))
-
 (deftest below-goal-alert-test
   (testing "Below goal alert"
     (tests {:card  {:visualization_settings {:graph.show_goal true :graph.goal_value 1.1}}
@@ -689,85 +608,40 @@
                                     [test-card-result png-attachment png-attachment])
                  (mt/summarize-multipart-email test-card-regex))))}})))
 
-(deftest below-goal-alert-test-2
-  (testing "below goal alert"
-    (tests {:pulse {:alert_condition  "goal"
-                    :alert_first_only false
-                    :alert_above_goal false}}
-      "timeseries data - below goal"
-      {:card
-       (merge (checkins-query-card {:filter   [:between $date "2014-04-01" "2014-06-01"]
-                                    :breakout [!day.date]})
-              {:display                :line
-               :visualization_settings {:graph.goal_value 6.1 ;; query value is 6, so alert is sent
-                                        :graph.show_goal true
-                                        :graph.metrics ["some-value"]}})
-       :assert
-       {:email
-        (fn [_ _]
-          (is (= (rasta-alert-email "Alert: Test card has gone below its goal"
-                                    [test-card-result png-attachment png-attachment])
-                 (mt/summarize-multipart-email test-card-regex))))}}
-      "timeseries data - at goal, not above"
-      {:card
-       (merge (checkins-query-card {:filter   [:between $date "2014-04-01" "2014-06-01"]
-                                    :breakout [!day.date]})
-              {:display                :line
-               :visualization_settings {:graph.goal_value 6 ;; query value is 6, so alert is not sent
-                                        :graph.show_goal true
-                                        :graph.metrics ["some-value"]}})
-       :assert
-       {:email
-        (fn [_ _]
-          (is (= {}
-                 (mt/summarize-multipart-email test-card-regex))))}}
-      "timeseries data - above goal"
-      {:card
-       (merge (checkins-query-card {:filter   [:between $date "2014-04-01" "2014-06-01"]
-                                    :breakout [!day.date]})
-              {:display                :line
-               :visualization_settings {:graph.goal_value 5.9 ;; query value is 6, so alert is not sent
-                                        :graph.show_goal true
-                                        :graph.metrics ["some-value"]}})
-       :assert
-       {:email
-        (fn [_ _]
-          (is (= {}
-                 (mt/summarize-multipart-email test-card-regex))))}}
-      "with progress bar - above goal"
-      {:card
-       (merge (venues-query-card "max")
-              {:display                :progress
-               :visualization_settings {:progress.goal 3}})
-
-       :assert
-       {:email
-        (fn [_ _]
-          (is (= {}
-                 (mt/summarize-multipart-email test-card-regex))))}}
-      "with progress bar - at goal"
-      {:card
-       (merge (venues-query-card "max")
-              {:display                :progress
-               :visualization_settings {:progress.goal 4}})
-
-       :assert
-       {:email
-        (fn [_ _]
-          (is (= {}
-                 (mt/summarize-multipart-email test-card-regex))))}}
-      "with progress bar - below goal"
-      {:card
-       (merge (venues-query-card "max")
-              {:display                :progress
-               :visualization_settings {:progress.goal 5}})
-
-       :assert
-       {:email
-        (fn [_ _]
-          (is (= (rasta-alert-email "Alert: Test card has gone below its goal"
-                                    [test-card-result png-attachment png-attachment])
-                 (mt/summarize-multipart-email test-card-regex))))}})))
+(deftest goal-met-test
+  (let [alert-above-pulse {:alert_above_goal true}
+        alert-below-pulse {:alert_above_goal false}
+        progress-result (fn [val] [{:card {:display :progress
+                                            :visualization_settings {:progress.goal 5}}
+                                     :result {:data {:rows [[val]]}}}])
+        timeseries-result (fn [val] [{:card {:display :bar
+                                             :visualization_settings {:graph.goal_value 5}}
+                                      :result {:data {:cols [{:source :breakout}
+                                                             {:name "avg"
+                                                              :source :aggregation
+                                                              :base_type :type/Integer
+                                                              :effective-type :type/Integer
+                                                              :semantic_type :type/Quantity}]
+                                                      :rows [["2021-01-01T00:00:00Z" val]]}}}])
+        goal-met? (fn [pulse [first-result]] (#'metabase.pulse/goal-met? pulse [first-result]))]
+    (testing "Progress bar"
+      (testing "alert above"
+        (testing "value below goal"  (is (= false (goal-met? alert-above-pulse (progress-result 4)))))
+        (testing "value equals goal" (is (=  true (goal-met? alert-above-pulse (progress-result 5)))))
+        (testing "value above goal"  (is (=  true (goal-met? alert-above-pulse (progress-result 6))))))
+      (testing "alert below"
+        (testing "value below goal"  (is (=  true (goal-met? alert-below-pulse (progress-result 4)))))
+        (testing "value equals goal" (is (= false (goal-met? alert-below-pulse (progress-result 5)))))
+        (testing "value above goal"  (is (= false (goal-met? alert-below-pulse (progress-result 6)))))))
+    (testing "Timeseries"
+      (testing "alert above"
+        (testing "value below goal"  (is (= false (goal-met? alert-above-pulse (timeseries-result 4)))))
+        (testing "value equals goal" (is (=  true (goal-met? alert-above-pulse (timeseries-result 5)))))
+        (testing "value above goal"  (is (=  true (goal-met? alert-above-pulse (timeseries-result 6))))))
+      (testing "alert below"
+        (testing "value below goal"  (is (=  true (goal-met? alert-below-pulse (timeseries-result 4)))))
+        (testing "value equals goal" (is (=  true (goal-met? alert-below-pulse (timeseries-result 5)))))
+        (testing "value above goal"  (is (= false (goal-met? alert-below-pulse (timeseries-result 6)))))))))
 
 (deftest native-query-with-user-specified-axes-test
   (testing "Native query with user-specified x and y axis"

--- a/test/metabase/pulse_test.clj
+++ b/test/metabase/pulse_test.clj
@@ -640,7 +640,7 @@
         (testing "value above goal"  (is (=  true (goal-met? alert-above-pulse (timeseries-result 6))))))
       (testing "alert below"
         (testing "value below goal"  (is (=  true (goal-met? alert-below-pulse (timeseries-result 4)))))
-        (testing "value equals goal" (is (=  true (goal-met? alert-below-pulse (timeseries-result 5)))))
+        (testing "value equals goal" (is (= false (goal-met? alert-below-pulse (timeseries-result 5)))))
         (testing "value above goal"  (is (= false (goal-met? alert-below-pulse (timeseries-result 6)))))))))
 
 (deftest native-query-with-user-specified-axes-test

--- a/test/metabase/pulse_test.clj
+++ b/test/metabase/pulse_test.clj
@@ -631,7 +631,7 @@
         (testing "value above goal"  (is (=  true (goal-met? alert-above-pulse (progress-result 6))))))
       (testing "alert below"
         (testing "value below goal"  (is (=  true (goal-met? alert-below-pulse (progress-result 4)))))
-        (testing "value equals goal" (is (= false (goal-met? alert-below-pulse (progress-result 5)))))
+        (testing "value equals goal (#10899)" (is (= false (goal-met? alert-below-pulse (progress-result 5)))))
         (testing "value above goal"  (is (= false (goal-met? alert-below-pulse (progress-result 6)))))))
     (testing "Timeseries"
       (testing "alert above"

--- a/test/metabase/pulse_test.clj
+++ b/test/metabase/pulse_test.clj
@@ -564,6 +564,87 @@
                                     [test-card-result png-attachment png-attachment])
                  (mt/summarize-multipart-email test-card-regex))))}})))
 
+(deftest above-goal-alert-test-2
+  (testing "above goal alert"
+    (tests {:pulse {:alert_condition  "goal"
+                    :alert_first_only false
+                    :alert_above_goal true}}
+      "timeseries data - above goal"
+      {:card
+       (merge (checkins-query-card {:filter   [:between $date "2014-04-01" "2014-06-01"]
+                                    :breakout [!day.date]})
+              {:display                :line
+               :visualization_settings {:graph.goal_value 5.9 ;; query value is 6, so alert is sent
+                                        :graph.show_goal true
+                                        :graph.metrics ["some-value"]}})
+       :assert
+       {:email
+        (fn [_ _]
+          (is (= (rasta-alert-email "Alert: Test card has reached its goal"
+                                    [test-card-result png-attachment png-attachment])
+                 (mt/summarize-multipart-email test-card-regex))))}}
+      "timeseries data - at goal, not above"
+      {:card
+       (merge (checkins-query-card {:filter   [:between $date "2014-04-01" "2014-06-01"]
+                                    :breakout [!day.date]})
+              {:display                :line
+               :visualization_settings {:graph.goal_value 6 ;; query value is 6, so alert is not sent
+                                        :graph.show_goal true
+                                        :graph.metrics ["some-value"]}})
+       :assert
+       {:email
+        (fn [_ _]
+          (is (= {}
+                 (mt/summarize-multipart-email test-card-regex))))}}
+      "timeseries data - below goal"
+      {:card
+       (merge (checkins-query-card {:filter   [:between $date "2014-04-01" "2014-06-01"]
+                                    :breakout [!day.date]})
+              {:display                :line
+               :visualization_settings {:graph.goal_value 6.1 ;; query value is 6, so alert is not sent
+                                        :graph.show_goal true
+                                        :graph.metrics ["some-value"]}})
+       :assert
+       {:email
+        (fn [_ _]
+          (is (= {}
+                 (mt/summarize-multipart-email test-card-regex))))}}
+      "with progress bar - above goal"
+      {:card
+       (merge (venues-query-card "max")
+              {:display                :progress
+               :visualization_settings {:progress.goal 3}})
+
+       :assert
+       {:email
+        (fn [_ _]
+          (is (= (rasta-alert-email "Alert: Test card has reached its goal"
+                                    [test-card-result png-attachment png-attachment])
+                 (mt/summarize-multipart-email test-card-regex))))}}
+      "with progress bar - at goal"
+      {:card
+       (merge (venues-query-card "max")
+              {:display                :progress
+               :visualization_settings {:progress.goal 4}})
+
+       :assert
+       {:email
+        (fn [_ _]
+          (is (= (rasta-alert-email "Alert: Test card has reached its goal"
+                                    [test-card-result png-attachment png-attachment])
+                 (mt/summarize-multipart-email test-card-regex))))}}
+      "with progress bar - below goal"
+      {:card
+       (merge (venues-query-card "max")
+              {:display                :progress
+               :visualization_settings {:progress.goal 5}})
+
+       :assert
+       {:email
+        (fn [_ _]
+          (is (= {}
+                 (mt/summarize-multipart-email test-card-regex))))}})))
+
 (deftest below-goal-alert-test
   (testing "Below goal alert"
     (tests {:card  {:visualization_settings {:graph.show_goal true :graph.goal_value 1.1}}
@@ -600,6 +681,86 @@
        (merge (venues-query-card "min")
               {:display                :progress
                :visualization_settings {:progress.goal 2}})
+
+       :assert
+       {:email
+        (fn [_ _]
+          (is (= (rasta-alert-email "Alert: Test card has gone below its goal"
+                                    [test-card-result png-attachment png-attachment])
+                 (mt/summarize-multipart-email test-card-regex))))}})))
+
+(deftest below-goal-alert-test-2
+  (testing "below goal alert"
+    (tests {:pulse {:alert_condition  "goal"
+                    :alert_first_only false
+                    :alert_above_goal false}}
+      "timeseries data - below goal"
+      {:card
+       (merge (checkins-query-card {:filter   [:between $date "2014-04-01" "2014-06-01"]
+                                    :breakout [!day.date]})
+              {:display                :line
+               :visualization_settings {:graph.goal_value 6.1 ;; query value is 6, so alert is sent
+                                        :graph.show_goal true
+                                        :graph.metrics ["some-value"]}})
+       :assert
+       {:email
+        (fn [_ _]
+          (is (= (rasta-alert-email "Alert: Test card has gone below its goal"
+                                    [test-card-result png-attachment png-attachment])
+                 (mt/summarize-multipart-email test-card-regex))))}}
+      "timeseries data - at goal, not above"
+      {:card
+       (merge (checkins-query-card {:filter   [:between $date "2014-04-01" "2014-06-01"]
+                                    :breakout [!day.date]})
+              {:display                :line
+               :visualization_settings {:graph.goal_value 6 ;; query value is 6, so alert is not sent
+                                        :graph.show_goal true
+                                        :graph.metrics ["some-value"]}})
+       :assert
+       {:email
+        (fn [_ _]
+          (is (= {}
+                 (mt/summarize-multipart-email test-card-regex))))}}
+      "timeseries data - above goal"
+      {:card
+       (merge (checkins-query-card {:filter   [:between $date "2014-04-01" "2014-06-01"]
+                                    :breakout [!day.date]})
+              {:display                :line
+               :visualization_settings {:graph.goal_value 5.9 ;; query value is 6, so alert is not sent
+                                        :graph.show_goal true
+                                        :graph.metrics ["some-value"]}})
+       :assert
+       {:email
+        (fn [_ _]
+          (is (= {}
+                 (mt/summarize-multipart-email test-card-regex))))}}
+      "with progress bar - above goal"
+      {:card
+       (merge (venues-query-card "max")
+              {:display                :progress
+               :visualization_settings {:progress.goal 3}})
+
+       :assert
+       {:email
+        (fn [_ _]
+          (is (= {}
+                 (mt/summarize-multipart-email test-card-regex))))}}
+      "with progress bar - at goal"
+      {:card
+       (merge (venues-query-card "max")
+              {:display                :progress
+               :visualization_settings {:progress.goal 4}})
+
+       :assert
+       {:email
+        (fn [_ _]
+          (is (= {}
+                 (mt/summarize-multipart-email test-card-regex))))}}
+      "with progress bar - below goal"
+      {:card
+       (merge (venues-query-card "max")
+              {:display                :progress
+               :visualization_settings {:progress.goal 5}})
 
        :assert
        {:email


### PR DESCRIPTION
The goal-met predicate is tested directly with mock data to make the tests more readable.

The change to `metabase.pulse/goal-met?` fixes #10899 while preserving the goal-met behaviour for any non-progress
goal. The behaviour should now be as follows:

Edit: After some discussion, it's clear that Progress Bar and Time Series comparators _should be the same_. The Table is edited to reflect this. It means the change is simpler than originally thought, yay!

```
| alert_above? | goal | val | goal-met? |
+--------------+------+-----+-----------+
|      t       |  5   |  4  |     f     |
|      t       |  5   |  5  |     t     |
|      t       |  5   |  6  |     t     |
|      f       |  5   |  4  |     t     |
|      f       |  5   |  5  |     f     | <--- this is new behaviour
|      f       |  5   |  6  |     f     | 
```
