### PR TITLE
change email table styles

### DIFF
--- a/src/metabase/pulse/render/table.clj
+++ b/src/metabase/pulse/render/table.clj
@@ -11,7 +11,7 @@
 (defn- bar-th-style []
   (merge
    (style/font-style)
-   {:font-size :12.5px
+   {:font-size :12px
     :font-weight     700
     :color           style/color-text-medium
     :border-bottom   (str "1px solid " style/color-header-row-border)
@@ -23,14 +23,14 @@
 (defn- bar-td-style []
   (merge
    (style/font-style)
-   {:font-size      :12.5px
+   {:font-size      :12px
     :font-weight    700
     :text-align     :left
     :color          style/color-text-dark
     :border-bottom  (str "1px solid " style/color-body-row-border)
-    :height         :36px
-    :padding-right  :0.5em
-    :padding-left   :0.5em}))
+    :height         :28px
+    :padding-right  :0.375em
+    :padding-left   :0.375em}))
 
 (defn- bar-th-style-numeric []
   (merge (style/font-style) (bar-th-style) {:text-align :right}))
@@ -78,7 +78,7 @@
   [:thead
    [:tr
     (for [header-cell row]
-      [:th {:style (style/style (row-style-for-type header-cell) (heading-style-for-type header-cell) {:min-width :60px})}
+      [:th {:style (style/style (row-style-for-type header-cell) (heading-style-for-type header-cell) {:min-width :42px})}
        (h header-cell)])
     (when bar-width
       [:th {:style (style/style (bar-td-style) (bar-th-style) {:width (str bar-width "%")})}])]])


### PR DESCRIPTION
Change email table styles to fit more content.

**Before**
<img width="487" alt="Screenshot 2022-01-13 at 00 18 04" src="https://user-images.githubusercontent.com/14301985/149243502-0ee1406b-1df2-486c-94d8-869a85a4dbab.png">

**After**
<img width="480" alt="Screenshot 2022-01-13 at 00 16 40" src="https://user-images.githubusercontent.com/14301985/149243451-db5f8d6b-704d-4378-826b-b789822e284f.png">