### PR TITLE
Don't update tables in a schema one by one

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -323,7 +323,7 @@
       (let [db-id (u/the-id database)]
         (log/infof (trs "DB {0} had hardcoded dataset-id; changing to an inclusion pattern and updating table schemas"
                         db-id))
-        (db/update-where! MetabaseTable {:db_id db-id} :schema dataset-id)
+        (db/update-where! MetabaseTable {:db_id db-id, :schema nil} :schema dataset-id)
         (-> (assoc-in database [:details :dataset-filters-type] "inclusion")
             (assoc-in [:details :dataset-filters-patterns] dataset-id)
             (m/dissoc-in [:details :dataset-id])))

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -323,10 +323,7 @@
       (let [db-id (u/the-id database)]
         (log/infof (trs "DB {0} had hardcoded dataset-id; changing to an inclusion pattern and updating table schemas"
                         db-id))
-        (doseq [table (db/select MetabaseTable :db_id db-id)]
-          (let [table-id (u/the-id table)]
-            (log/infof (trs "Updating table {0} to set schema to dataset-id of {1}" table-id dataset-id))
-            (db/update! MetabaseTable table-id :schema dataset-id)))
+        (db/update-where! MetabaseTable {:db_id db-id} :schema dataset-id)
         (-> (assoc-in database [:details :dataset-filters-type] "inclusion")
             (assoc-in [:details :dataset-filters-patterns] dataset-id)
             (m/dissoc-in [:details :dataset-id])))

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -323,7 +323,13 @@
       (let [db-id (u/the-id database)]
         (log/infof (trs "DB {0} had hardcoded dataset-id; changing to an inclusion pattern and updating table schemas"
                         db-id))
-        (db/update-where! MetabaseTable {:db_id db-id, :schema nil} :schema dataset-id)
+        (db/execute! {:update MetabaseTable
+                      :set    {:schema dataset-id}
+                      :where  [:and
+                               [:= :db_id db-id]
+                               [:or
+                                [:= :schema nil]
+                                [:not= :schema dataset-id]]]})
         (-> (assoc-in database [:details :dataset-filters-type] "inclusion")
             (assoc-in [:details :dataset-filters-patterns] dataset-id)
             (m/dissoc-in [:details :dataset-id])))


### PR DESCRIPTION
Code had wanted to log each table which is admirable. But on bigquery
there can be 15,000 tables and this will lock up calls to
/api/database. On stats they are taking about 18s for me. Need to do
once and let the db do the heavy lifting

example from stats:
```
[ed53363d-e9b4-4313-b29e-cd106171d2cf] 2022-01-12T23:20:56-06:00 INFO metabase.driver.bigquery-cloud-sdk Updating table 17,002 to set schema to dataset-id of census_bureau_usa
[ed53363d-e9b4-4313-b29e-cd106171d2cf] 2022-01-12T23:20:56-06:00 INFO metabase.driver.bigquery-cloud-sdk Updating table 17,611 to set schema to dataset-id of census_bureau_usa
[ed53363d-e9b4-4313-b29e-cd106171d2cf] 2022-01-12T23:20:56-06:00 INFO metabase.driver.bigquery-cloud-sdk Updating table 17,413 to set schema to dataset-id of census_bureau_usa
[ed53363d-e9b4-4313-b29e-cd106171d2cf] 2022-01-12T23:20:56-06:00 INFO metabase.driver.bigquery-cloud-sdk Updating table 16,319 to set schema to dataset-id of census_bureau_usa
[ed53363d-e9b4-4313-b29e-cd106171d2cf] 2022-01-12T23:20:56-06:00 INFO metabase.driver.bigquery-cloud-sdk Updating table 17,807 to set schema to dataset-id of census_bureau_usa
```