### PR TITLE
Validate slack files channel name on save

### DIFF
--- a/src/metabase/api/slack.clj
+++ b/src/metabase/api/slack.clj
@@ -27,7 +27,6 @@
         ;; Clear the deprecated `slack-token` when setting a new `slack-app-token`
         (slack/slack-token nil)))
     (let [processed-files-channel (slack/process-files-channel-name slack-files-channel)]
-      (slack/channel-with-name my-processed-files-channel1)
       (when (and processed-files-channel (not (slack/channel-with-name processed-files-channel)))
         (throw (ex-info (tru "Slack channel not found.")
                         {:errors {:slack-files-channel (tru "channel not found")}})))

--- a/src/metabase/api/slack.clj
+++ b/src/metabase/api/slack.clj
@@ -19,15 +19,19 @@
     (when (and slack-app-token (not config/is-test?))
       (when-not (slack/valid-token? slack-app-token)
         (throw (ex-info (tru "Invalid Slack token.")
-                        {:errors {:slack-app-token (tru "invalid token")}
-                         :status-code 400}))))
+                        {:errors {:slack-app-token (tru "invalid token")}}))))
     (slack/slack-app-token slack-app-token)
     (when slack-app-token
       (do
         (slack/slack-token-valid? true)
         ;; Clear the deprecated `slack-token` when setting a new `slack-app-token`
         (slack/slack-token nil)))
-    (slack/slack-files-channel slack-files-channel)
+    (let [processed-files-channel (slack/process-files-channel-name slack-files-channel)]
+      (slack/channel-with-name my-processed-files-channel1)
+      (when (and processed-files-channel (not (slack/channel-with-name processed-files-channel)))
+        (throw (ex-info (tru "Slack channel not found.")
+                        {:errors {:slack-files-channel (tru "channel not found")}})))
+      (slack/slack-files-channel processed-files-channel))
     {:ok true}
     (catch clojure.lang.ExceptionInfo info
       {:status 400, :body (ex-data info)})))

--- a/src/metabase/integrations/slack.clj
+++ b/src/metabase/integrations/slack.clj
@@ -34,7 +34,6 @@
   "Converts empty strings to `nil`, and removes leading `#` from the channel name if present."
   [channel-name]
   (when-not (str/blank? channel-name)
-    ;; Strip leading # if present, since the Slack API doesn't like it
     (if (str/starts-with? channel-name "#") (subs channel-name 1) channel-name)))
 
 (defsetting slack-files-channel


### PR DESCRIPTION
Epic: #19435

A little enhancement to check that we can fetch information about the files channel when the Slack settings are saved, and display an error message if we can't. Otherwise the settings could be saved with a non-existant channel name, and the error would only be detected when a dashboard subscription fails to send.