### PR TITLE
React Ace: Add PropType option to expression editor

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -94,7 +94,11 @@ export default class ExpressionEditorTextfield extends React.Component {
   }
 
   static propTypes = {
-    expression: PropTypes.array, // should be an array like [expressionObj, source]
+    expression: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.number,
+      PropTypes.array,
+    ]),
     onChange: PropTypes.func.isRequired,
     onError: PropTypes.func.isRequired,
     startRule: PropTypes.string.isRequired,

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx
@@ -13,7 +13,11 @@ import ExternalLink from "metabase/components/ExternalLink";
 // TODO: combine with ExpressionPopover
 export default class ExpressionWidget extends Component {
   static propTypes = {
-    expression: PropTypes.array,
+    expression: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.string,
+      PropTypes.array,
+    ]),
     name: PropTypes.string,
     query: PropTypes.object.isRequired,
     onChangeExpression: PropTypes.func.isRequired,


### PR DESCRIPTION
I am not 100% certain we should be accepting pure numbers like described below — I may not know the use case.

The editor does not error when we tab away with a pure number, so if that is acceptable, let's simply have PropTypes for it.

### Steps to tests

1. Open dev console.
2. Open Custom Column editor
3. Type `42`
4. Press `Tab`

You should not see a mention of a missing PropType `number`.