### PR TITLE
Custom expression editor: workaround focus issue on Firefox

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -244,6 +244,12 @@ export default class ExpressionEditorTextfield extends React.Component {
     if (this.input.current) {
       const { editor } = this.input.current;
       this.handleCursorChange(editor.selection);
+
+      // workaround some unknown issue on Firefox
+      // without explicit focus, the editor is vertically shifted
+      setTimeout(() => {
+        editor.focus();
+      }, 0);
     }
   };
 


### PR DESCRIPTION

Use Firefox to try this:

1. New, Question
2. Sample Dataset, Products table
3. Custom Column, type `42`
4. Press Tab and then Shift+Tab to lose focus and get it back

**Before this PR**

The editor is shifted vertically, making it only barely visible and not usable at all.

![image](https://user-images.githubusercontent.com/7288/149407466-6215e96e-b978-463f-b0b0-0a5ed863cd0e.png)

**After this PR**

The editor is positioned correctly, as expected.

![image](https://user-images.githubusercontent.com/7288/149407631-26f46f86-6d2f-4173-ab41-1bfdf922af57.png)

