### PR TITLE
React Ace: fix basePath console error

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -32,6 +32,10 @@ import ExpressionMode from "./ExpressionMode";
 
 import "./expressions.css";
 
+import * as ace from "ace-builds/src-noconflict/ace";
+
+ace.config.set("basePath", "/assets/ui/");
+
 const HelpText = ({ helpText, width }) =>
   helpText ? (
     <Popover


### PR DESCRIPTION
1. Open dev console.
2. Open custom column editor.

You should **no longer** get the following error:

![image](https://user-images.githubusercontent.com/380816/149411399-01b9f929-4656-4821-9a23-4793a08cc46b.png)
