### PR TITLE
Wipe special chars from branch names

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
     - name: Extract branch name
       shell: bash
-      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/} | sed 's/[^-._a-zA-Z0-9]/-/g')"
       id: extract_branch
     - uses: actions/checkout@v2
     - name: Set up Docker Buildx


### PR DESCRIPTION
This is a safeguard against branch names with special chars which will be replaced by a "-" char