### PR TITLE
fix list of values filter height

### DIFF
--- a/frontend/src/metabase/query_builder/components/filters/pickers/DefaultPicker.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DefaultPicker.jsx
@@ -19,6 +19,7 @@ import {
   BetweenLayoutContainer,
   BetweenLayoutFieldSeparator,
   BetweenLayoutFieldContainer,
+  DefaultPickerContainer,
 } from "./DefaultPicker.styled";
 
 const defaultPickerPropTypes = {
@@ -45,6 +46,7 @@ export default function DefaultPicker({
   className,
   minWidth,
   maxWidth,
+  isSidebar,
 }) {
   const operator = filter.operator();
   if (!operator) {
@@ -147,7 +149,12 @@ export default function DefaultPicker({
   }
 
   return (
-    <div className={cx(className, "PopoverBody--marginBottom")}>{layout}</div>
+    <DefaultPickerContainer
+      limitHeight={!isSidebar}
+      className={cx(className, "PopoverBody--marginBottom")}
+    >
+      {layout}
+    </DefaultPickerContainer>
   );
 }
 

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DefaultPicker.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DefaultPicker.styled.tsx
@@ -1,5 +1,5 @@
 import { color } from "metabase/lib/colors";
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 
 export const BetweenLayoutContainer = styled.div`
   display: flex;
@@ -16,4 +16,18 @@ export const BetweenLayoutFieldSeparator = styled.div`
   padding: 0.5rem 0.5rem 0 0.5rem;
   font-weight: 700;
   color: ${color("text-medium")};
+`;
+
+interface DefaultPickerContainerProps {
+  limitHeight: boolean;
+}
+
+export const DefaultPickerContainer = styled.div<DefaultPickerContainerProps>`
+  ${props =>
+    props.limitHeight
+      ? css`
+          max-height: 300px;
+          overflow: auto;
+        `
+      : null}
 `;


### PR DESCRIPTION
### How to verify

- Change [People -> State column](http://localhost:3000/admin/datamodel/database/1/table/3/25/general) "Filtering on this field" setting to "A list of all values"
- Open People table in the simple mode
- Click on State column header -> Filter by this column
- Ensure the popover has reasonably fixed max height

### Screenshots

**Before**
<img width="572" alt="Screenshot 2022-01-13 at 21 39 29" src="https://user-images.githubusercontent.com/14301985/149413857-03a6b284-dfb8-4988-aa35-3a83ed7e37e3.png">

**After**
<img width="495" alt="Screenshot 2022-01-13 at 21 39 10" src="https://user-images.githubusercontent.com/14301985/149413866-238b224f-186c-48c4-abd2-e2639df81f3d.png">