### PR TITLE
Update copy: replace "dataset" references with the "model"

### DIFF
--- a/frontend/src/metabase/home/containers/SearchApp.jsx
+++ b/frontend/src/metabase/home/containers/SearchApp.jsx
@@ -39,7 +39,7 @@ const SEARCH_FILTERS = [
     icon: "database",
   },
   {
-    name: t`Datasets`,
+    name: t`Models`,
     filter: "dataset",
     icon: "dataset",
   },

--- a/frontend/src/metabase/lib/revisions/revisions.js
+++ b/frontend/src/metabase/lib/revisions/revisions.js
@@ -97,8 +97,8 @@ const CHANGE_DESCRIPTIONS = {
   dataset: {
     [CHANGE_TYPE.UPDATE]: (wasDataset, isDataset) =>
       isDataset
-        ? t`turned this into a dataset`
-        : t`reverted this from a dataset to a saved question`,
+        ? t`turned this into a model`
+        : t`reverted this from a model to a saved question`,
   },
   dataset_query: {
     [CHANGE_TYPE.ADD]: t`edited the question`,

--- a/frontend/src/metabase/lib/revisions/revisions.js
+++ b/frontend/src/metabase/lib/revisions/revisions.js
@@ -98,7 +98,7 @@ const CHANGE_DESCRIPTIONS = {
     [CHANGE_TYPE.UPDATE]: (wasDataset, isDataset) =>
       isDataset
         ? t`turned this into a model`
-        : t`reverted this from a model to a saved question`,
+        : t`changed this from a model to a saved question`,
   },
   dataset_query: {
     [CHANGE_TYPE.ADD]: t`edited the question`,

--- a/frontend/src/metabase/lib/revisions/revisions.unit.spec.js
+++ b/frontend/src/metabase/lib/revisions/revisions.unit.spec.js
@@ -255,17 +255,17 @@ describe("getRevisionDescription | questions", () => {
     );
   });
 
-  it("handles turning a question into a dataset", () => {
+  it("handles turning a question into a model", () => {
     const revision = getSimpleRevision({
       field: "dataset",
       before: false,
       after: true,
     });
 
-    expect(getRevisionDescription(revision)).toBe("turned this into a dataset");
+    expect(getRevisionDescription(revision)).toBe("turned this into a model");
   });
 
-  it("handles turning a dataset back into a saved question", () => {
+  it("handles turning a model back into a saved question", () => {
     const revision = getSimpleRevision({
       field: "dataset",
       before: true,
@@ -273,7 +273,7 @@ describe("getRevisionDescription | questions", () => {
     });
 
     expect(getRevisionDescription(revision)).toBe(
-      "reverted this from a dataset to a saved question",
+      "reverted this from a model to a saved question",
     );
   });
 });

--- a/frontend/src/metabase/lib/revisions/revisions.unit.spec.js
+++ b/frontend/src/metabase/lib/revisions/revisions.unit.spec.js
@@ -273,7 +273,7 @@ describe("getRevisionDescription | questions", () => {
     });
 
     expect(getRevisionDescription(revision)).toBe(
-      "reverted this from a model to a saved question",
+      "changed this from a model to a saved question",
     );
   });
 });

--- a/frontend/src/metabase/lib/saved-questions/saved-questions.unit.spec.js
+++ b/frontend/src/metabase/lib/saved-questions/saved-questions.unit.spec.js
@@ -69,7 +69,7 @@ describe("saved question helpers", () => {
       });
     });
 
-    it("should return correct schema for collection datasets", () => {
+    it("should return correct schema for collection models", () => {
       const collection = { id: 1, name: "Marketing" };
       const payload = getEncodedPayload({ isDatasets: true });
       const expectedId = `${SAVED_QUESTIONS_VIRTUAL_DB_ID}:Marketing:${payload}`;

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -1528,7 +1528,7 @@ export const turnQuestionIntoDataset = () => async (dispatch, getState) => {
 
   dispatch(
     addUndo({
-      message: t`This is a dataset now.`,
+      message: t`This is a model now.`,
       actions: [apiUpdateQuestion(question, { rerunQuery: true })],
     }),
   );

--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -1153,7 +1153,7 @@ const DataBucketPicker = ({ onChangeDataBucket }) => {
     {
       id: DATA_BUCKET.DATASETS,
       icon: "dataset",
-      name: t`Datasets`,
+      name: t`Models`,
       description: t`The best starting place for new questions.`,
     },
     {

--- a/frontend/src/metabase/query_builder/components/NewDatasetModal/NewDatasetModal.jsx
+++ b/frontend/src/metabase/query_builder/components/NewDatasetModal/NewDatasetModal.jsx
@@ -48,7 +48,7 @@ function NewDatasetModal({ turnQuestionIntoDataset, onClose }) {
     >
       <FeatureOverviewContainer>
         <DatasetImg src="app/img/dataset-illustration.svg" />
-        <DatasetTitle>{t`Datasets`}</DatasetTitle>
+        <DatasetTitle>{t`Models`}</DatasetTitle>
         <ul>
           <DatasetValueProp>
             {t`Let you update column descriptions and customize metadata to create

--- a/frontend/src/metabase/query_builder/components/NewDatasetModal/NewDatasetModal.jsx
+++ b/frontend/src/metabase/query_builder/components/NewDatasetModal/NewDatasetModal.jsx
@@ -43,7 +43,7 @@ function NewDatasetModal({ turnQuestionIntoDataset, onClose }) {
           key="action"
           primary
           onClick={onConfirm}
-        >{t`Turn this into a dataset`}</Button>,
+        >{t`Turn this into a model`}</Button>,
       ]}
     >
       <FeatureOverviewContainer>

--- a/frontend/src/metabase/query_builder/components/QuestionActionButtons.jsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActionButtons.jsx
@@ -60,7 +60,7 @@ function QuestionActionButtons({ canWrite, isDataset, onOpenModal }) {
         </Tooltip>
       )}
       {canWrite && !isDataset && (
-        <Tooltip tooltip={t`Turn this into a dataset`}>
+        <Tooltip tooltip={t`Turn this into a model`}>
           <Button
             onlyIcon
             icon="dataset"

--- a/frontend/src/metabase/query_builder/components/saved-question-picker/SavedQuestionPicker.jsx
+++ b/frontend/src/metabase/query_builder/components/saved-question-picker/SavedQuestionPicker.jsx
@@ -114,7 +114,7 @@ function SavedQuestionPicker({
       <CollectionsContainer>
         <BackButton onClick={onBack}>
           <Icon name="chevronleft" className="mr1" />
-          {isDatasets ? t`Datasets` : t`Saved Questions`}
+          {isDatasets ? t`Models` : t`Saved Questions`}
         </BackButton>
         <Box my={1}>
           <Tree

--- a/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetManagementSection.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetManagementSection.jsx
@@ -37,7 +37,7 @@ function DatasetManagementSection({
 
   return (
     <div>
-      <SectionTitle>{t`Dataset management`}</SectionTitle>
+      <SectionTitle>{t`Model management`}</SectionTitle>
       <SectionContent>
         <Button
           icon="notebook"

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebarPanel.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebarPanel.unit.spec.js
@@ -84,15 +84,15 @@ describe("QuestionDetailsSidebarPanel", () => {
   describe("datasets", () => {
     it("displays management section", () => {
       setup({ question: getDataset() });
-      expect(screen.queryByText("Dataset management")).toBeInTheDocument();
+      expect(screen.queryByText("Model management")).toBeInTheDocument();
       expect(
         screen.queryByText("Turn back into a saved question"),
       ).toBeInTheDocument();
     });
 
-    it("does not display dataset management section with read-only-access", () => {
+    it("does not display model management section with read-only-access", () => {
       setup({ question: getDataset({ can_write: false }) });
-      expect(screen.queryByText("Dataset management")).not.toBeInTheDocument();
+      expect(screen.queryByText("Model management")).not.toBeInTheDocument();
       expect(
         screen.queryByText("Turn back into a saved question"),
       ).not.toBeInTheDocument();
@@ -100,9 +100,9 @@ describe("QuestionDetailsSidebarPanel", () => {
   });
 
   describe("saved questions", () => {
-    it("does not display dataset management section", () => {
+    it("does not display model management section", () => {
       setup({ question: getQuestion() });
-      expect(screen.queryByText("Dataset management")).not.toBeInTheDocument();
+      expect(screen.queryByText("Model management")).not.toBeInTheDocument();
       expect(
         screen.queryByText("Turn back into a saved question"),
       ).not.toBeInTheDocument();

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebarPanel.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebarPanel.unit.spec.js
@@ -81,8 +81,8 @@ describe("QuestionDetailsSidebarPanel", () => {
     });
   });
 
-  describe("datasets", () => {
-    it("displays management section", () => {
+  describe("models", () => {
+    it("displays model management section", () => {
       setup({ question: getDataset() });
       expect(screen.queryByText("Model management")).toBeInTheDocument();
       expect(

--- a/frontend/src/metabase/search/components/InfoText.jsx
+++ b/frontend/src/metabase/search/components/InfoText.jsx
@@ -32,7 +32,7 @@ export function InfoText({ result }) {
     case "card":
       return jt`Saved question in ${formatCollection(result.getCollection())}`;
     case "dataset":
-      return jt`Dataset in ${formatCollection(result.getCollection())}`;
+      return jt`Model in ${formatCollection(result.getCollection())}`;
     case "collection":
       return getCollectionInfoText(result.collection);
     case "database":

--- a/frontend/test/metabase/query_builder/selectors.unit.spec.js
+++ b/frontend/test/metabase/query_builder/selectors.unit.spec.js
@@ -269,7 +269,7 @@ describe("getIsResultDirty", () => {
     });
   });
 
-  describe("datasets", () => {
+  describe("models", () => {
     function getDataset(query) {
       return getBaseCard({
         id: 1,
@@ -284,7 +284,7 @@ describe("getIsResultDirty", () => {
 
     const dataset = getDataset({ "source-table": 1 });
 
-    it("should not be dirty if dataset is not changed", () => {
+    it("should not be dirty if model is not changed", () => {
       const state = getState({
         card: dataset,
         originalCard: dataset,
@@ -293,7 +293,7 @@ describe("getIsResultDirty", () => {
       expect(getIsResultDirty(state)).toBe(false);
     });
 
-    it("should be dirty if dataset is changed", () => {
+    it("should be dirty if model is changed", () => {
       const state = getState({
         card: dataset,
         originalCard: dataset,
@@ -302,7 +302,7 @@ describe("getIsResultDirty", () => {
       expect(getIsResultDirty(state)).toBe(false);
     });
 
-    it("should not be dirty if dataset simple mode is active", () => {
+    it("should not be dirty if model simple mode is active", () => {
       const adHocDatasetCard = getDataset({ "source-table": "card__1" });
       const state = getState({
         card: adHocDatasetCard,
@@ -312,7 +312,7 @@ describe("getIsResultDirty", () => {
       expect(getIsResultDirty(state)).toBe(false);
     });
 
-    it("should be dirty when building a new question on a dataset", () => {
+    it("should be dirty when building a new question on a model", () => {
       const card = getBaseCard({
         dataset_query: {
           type: "query",

--- a/frontend/test/metabase/scenarios/models/helpers/e2e-models-helpers.js
+++ b/frontend/test/metabase/scenarios/models/helpers/e2e-models-helpers.js
@@ -91,7 +91,7 @@ export function turnIntoDataset() {
     cy.icon("dataset").click();
   });
   modal().within(() => {
-    cy.button("Turn this into a dataset").click();
+    cy.button("Turn this into a model").click();
   });
 }
 

--- a/frontend/test/metabase/scenarios/models/helpers/e2e-models-helpers.js
+++ b/frontend/test/metabase/scenarios/models/helpers/e2e-models-helpers.js
@@ -68,7 +68,7 @@ export function assertIsDataset() {
   getDetailsSidebarActions().within(() => {
     cy.icon("dataset").should("not.exist");
   });
-  cy.findByText("Dataset management");
+  cy.findByText("Model management");
   cy.findByText("Sample Dataset").should("not.exist");
 
   // For native
@@ -81,7 +81,7 @@ export function assertIsQuestion() {
   getDetailsSidebarActions().within(() => {
     cy.icon("dataset");
   });
-  cy.findByText("Dataset management").should("not.exist");
+  cy.findByText("Model management").should("not.exist");
   cy.findByText("Sample Dataset");
 }
 

--- a/frontend/test/metabase/scenarios/models/models-revision-history.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models-revision-history.cy.spec.js
@@ -59,7 +59,7 @@ describe("scenarios > datasets", () => {
     assertIsQuestion();
 
     cy.findByText("History").click();
-    cy.findByText(/Turned this into a dataset/i)
+    cy.findByText(/Turned this into a model/i)
       .closest("li")
       .within(() => {
         cy.button("Revert").click();

--- a/frontend/test/metabase/scenarios/models/models-revision-history.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models-revision-history.cy.spec.js
@@ -10,7 +10,7 @@ import {
   openDetailsSidebar,
 } from "./helpers/e2e-models-helpers";
 
-describe("scenarios > datasets", () => {
+describe("scenarios > models > revision history", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();

--- a/frontend/test/metabase/scenarios/models/models-revision-history.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models-revision-history.cy.spec.js
@@ -18,7 +18,7 @@ describe("scenarios > models > revision history", () => {
 
   beforeEach(() => {
     cy.request("PUT", "/api/card/3", {
-      name: "Orders Dataset",
+      name: "Orders Model",
       dataset: true,
     });
     cy.intercept("PUT", "/api/card/3").as("updateCard");
@@ -51,7 +51,7 @@ describe("scenarios > models > revision history", () => {
     });
   });
 
-  it("should allow reverting to a dataset state", () => {
+  it("should allow reverting to a model state", () => {
     cy.request("PUT", "/api/card/3", { dataset: false });
 
     cy.visit("/question/3");
@@ -79,7 +79,7 @@ describe("scenarios > models > revision history", () => {
     cy.button("Add filter").click();
 
     assertQuestionIsBasedOnDataset({
-      dataset: "Orders Dataset",
+      dataset: "Orders Model",
       collection: "Our analytics",
       table: "Orders",
     });
@@ -88,7 +88,7 @@ describe("scenarios > models > revision history", () => {
 
     assertQuestionIsBasedOnDataset({
       questionName: "Q1",
-      dataset: "Orders Dataset",
+      dataset: "Orders Model",
       collection: "Our analytics",
       table: "Orders",
     });

--- a/frontend/test/metabase/scenarios/models/models.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models.cy.spec.js
@@ -131,19 +131,19 @@ describe("scenarios > datasets", () => {
     cy.get(".LineAreaBarChart").should("not.exist");
   });
 
-  it("allows to undo turning a question into a dataset", () => {
+  it("allows to undo turning a question into a model", () => {
     cy.visit("/question/3");
     cy.get(".LineAreaBarChart");
 
     turnIntoDataset();
-    cy.findByText("This is a dataset now.");
+    cy.findByText("This is a model now.");
     cy.findByText("Undo").click();
 
     cy.get(".LineAreaBarChart");
     assertIsQuestion();
   });
 
-  it("allows to turn a dataset back into a saved question", () => {
+  it("allows to turn a model back into a saved question", () => {
     cy.request("PUT", "/api/card/1", { dataset: true });
     cy.intercept("PUT", "/api/card/1").as("cardUpdate");
     cy.visit("/dataset/1");

--- a/frontend/test/metabase/scenarios/models/models.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models.cy.spec.js
@@ -469,7 +469,7 @@ function testDataPickerSearch({
   cy.findByPlaceholderText(inputPlaceholderText).type(query);
   cy.wait("@search");
 
-  cy.findAllByText(/Dataset in/i).should(datasets ? "exist" : "not.exist");
+  cy.findAllByText(/Model in/i).should(datasets ? "exist" : "not.exist");
   cy.findAllByText(/Saved question in/i).should(cards ? "exist" : "not.exist");
   cy.findAllByText(/Table in/i).should(tables ? "exist" : "not.exist");
 

--- a/frontend/test/metabase/scenarios/models/models.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models.cy.spec.js
@@ -20,14 +20,14 @@ import {
   getDetailsSidebarActions,
 } from "./helpers/e2e-models-helpers";
 
-describe("scenarios > datasets", () => {
+describe("scenarios > models", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
   });
 
-  it("allows to turn a GUI question into a dataset", () => {
-    cy.request("PUT", "/api/card/1", { name: "Orders Dataset" });
+  it("allows to turn a GUI question into a model", () => {
+    cy.request("PUT", "/api/card/1", { name: "Orders model" });
     cy.visit("/question/1");
 
     turnIntoDataset();
@@ -192,7 +192,7 @@ describe("scenarios > datasets", () => {
           tables: true,
         });
 
-        cy.findByText("Datasets").click();
+        cy.findByText("Models").click();
         cy.findByTestId("select-list").within(() => {
           cy.findByText("Orders");
           cy.findByText("Orders, Count").should("not.exist");
@@ -232,7 +232,7 @@ describe("scenarios > datasets", () => {
       cy.findByText("Custom question").click();
 
       popover().within(() => {
-        cy.findByText("Datasets").click();
+        cy.findByText("Models").click();
         cy.findByText("Orders").click();
       });
 
@@ -272,7 +272,7 @@ describe("scenarios > datasets", () => {
       cy.visit("/question/new");
       cy.findByText("Custom question").click();
       popover().within(() => {
-        cy.findByText("Datasets").should("not.exist");
+        cy.findByText("Models").should("not.exist");
         cy.findByText("Saved Questions").should("not.exist");
       });
     });
@@ -378,7 +378,7 @@ describe("scenarios > datasets", () => {
   });
 
   describe("adding a question to collection from its page", () => {
-    it("should offer to pick one of the collection's datasets by default", () => {
+    it("should offer to pick one of the collection's models by default", () => {
       cy.request("PUT", "/api/card/1", { dataset: true });
       cy.request("PUT", "/api/card/2", { dataset: true });
 
@@ -389,7 +389,7 @@ describe("scenarios > datasets", () => {
       cy.findByText("Orders, Count");
       cy.findByText("All data");
 
-      cy.findByText("Datasets").should("not.exist");
+      cy.findByText("Models").should("not.exist");
       cy.findByText("Raw Data").should("not.exist");
       cy.findByText("Saved Questions").should("not.exist");
       cy.findByText("Sample Dataset").should("not.exist");
@@ -412,7 +412,7 @@ describe("scenarios > datasets", () => {
 
       cy.findByText("All data").click({ force: true });
 
-      cy.findByText("Datasets");
+      cy.findByText("Models");
       cy.findByText("Raw Data");
       cy.findByText("Saved Questions");
     });
@@ -429,24 +429,24 @@ describe("scenarios > datasets", () => {
       cy.button("Visualize");
     });
 
-    it("should use correct picker if collection has no datasets", () => {
+    it("should use correct picker if collection has no models", () => {
       cy.request("PUT", "/api/card/1", { dataset: true });
 
       cy.visit("/collection/9");
       openNewCollectionItemFlowFor("question");
 
       cy.findByText("All data").should("not.exist");
-      cy.findByText("Datasets");
+      cy.findByText("Models");
       cy.findByText("Raw Data");
       cy.findByText("Saved Questions");
     });
 
-    it("should use correct picker if there are datasets at all", () => {
+    it("should use correct picker if there are models at all", () => {
       cy.visit("/collection/root");
       openNewCollectionItemFlowFor("question");
 
       cy.findByText("All data").should("not.exist");
-      cy.findByText("Datasets").should("not.exist");
+      cy.findByText("Models").should("not.exist");
       cy.findByText("Raw Data").should("not.exist");
 
       cy.findByText("Saved Questions");

--- a/frontend/test/metabase/scenarios/models/models.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models.cy.spec.js
@@ -27,7 +27,7 @@ describe("scenarios > models", () => {
   });
 
   it("allows to turn a GUI question into a model", () => {
-    cy.request("PUT", "/api/card/1", { name: "Orders model" });
+    cy.request("PUT", "/api/card/1", { name: "Orders Model" });
     cy.visit("/question/1");
 
     turnIntoDataset();
@@ -42,7 +42,7 @@ describe("scenarios > models", () => {
     cy.button("Add filter").click();
 
     assertQuestionIsBasedOnDataset({
-      dataset: "Orders Dataset",
+      dataset: "Orders Model",
       collection: "Our analytics",
       table: "Orders",
     });
@@ -51,7 +51,7 @@ describe("scenarios > models", () => {
 
     assertQuestionIsBasedOnDataset({
       questionName: "Q1",
-      dataset: "Orders Dataset",
+      dataset: "Orders Model",
       collection: "Our analytics",
       table: "Orders",
     });
@@ -59,7 +59,7 @@ describe("scenarios > models", () => {
     cy.findAllByText("Our analytics")
       .first()
       .click();
-    getCollectionItemRow("Orders Dataset").within(() => {
+    getCollectionItemRow("Orders Model").within(() => {
       cy.icon("dataset");
     });
     getCollectionItemRow("Q1").within(() => {
@@ -69,10 +69,10 @@ describe("scenarios > models", () => {
     cy.url().should("not.include", "/question/1");
   });
 
-  it("allows to turn a native question into a dataset", () => {
+  it("allows to turn a native question into a model", () => {
     cy.createNativeQuestion(
       {
-        name: "Orders Dataset",
+        name: "Orders Model",
         native: {
           query: "SELECT * FROM orders",
         },
@@ -92,7 +92,7 @@ describe("scenarios > models", () => {
     cy.button("Add filter").click();
 
     assertQuestionIsBasedOnDataset({
-      dataset: "Orders Dataset",
+      dataset: "Orders Model",
       collection: "Our analytics",
       table: "Orders",
     });
@@ -101,7 +101,7 @@ describe("scenarios > models", () => {
 
     assertQuestionIsBasedOnDataset({
       questionName: "Q1",
-      dataset: "Orders Dataset",
+      dataset: "Orders Model",
       collection: "Our analytics",
       table: "Orders",
     });
@@ -109,7 +109,7 @@ describe("scenarios > models", () => {
     cy.findAllByText("Our analytics")
       .first()
       .click();
-    getCollectionItemRow("Orders Dataset").within(() => {
+    getCollectionItemRow("Orders Model").within(() => {
       cy.icon("dataset");
     });
     getCollectionItemRow("Q1").within(() => {
@@ -119,7 +119,7 @@ describe("scenarios > models", () => {
     cy.url().should("not.include", "/question/1");
   });
 
-  it("changes dataset's display to table", () => {
+  it("changes model's display to table", () => {
     cy.visit("/question/3");
 
     cy.get(".LineAreaBarChart");
@@ -165,7 +165,7 @@ describe("scenarios > models", () => {
     cy.findByText(/We're a little lost/i);
   });
 
-  it("redirects to /dataset URL when opening a dataset with /question URL", () => {
+  it("redirects to /dataset URL when opening a model with /question URL", () => {
     cy.request("PUT", "/api/card/1", { dataset: true });
     cy.visit("/question/1");
     openDetailsSidebar();
@@ -227,7 +227,7 @@ describe("scenarios > models", () => {
       });
     });
 
-    it("allows to create a question based on a dataset", () => {
+    it("allows to create a question based on a model", () => {
       cy.visit("/question/new");
       cy.findByText("Custom question").click();
 
@@ -267,7 +267,7 @@ describe("scenarios > models", () => {
       cy.url().should("match", /\/question\/\d+-[a-z0-9-]*$/);
     });
 
-    it("should not display datasets if nested queries are disabled", () => {
+    it("should not display models if nested queries are disabled", () => {
       mockSessionProperty("enable-nested-queries", false);
       cy.visit("/question/new");
       cy.findByText("Custom question").click();
@@ -281,12 +281,12 @@ describe("scenarios > models", () => {
   describe("simple mode", () => {
     beforeEach(() => {
       cy.request("PUT", "/api/card/1", {
-        name: "Orders Dataset",
+        name: "Orders Model",
         dataset: true,
       });
     });
 
-    it("can create a question by filtering and summarizing a dataset", () => {
+    it("can create a question by filtering and summarizing a model", () => {
       cy.visit("/question/1");
 
       cy.findByTestId("qb-header-action-panel").within(() => {
@@ -298,7 +298,7 @@ describe("scenarios > models", () => {
       cy.button("Add filter").click();
 
       assertQuestionIsBasedOnDataset({
-        dataset: "Orders Dataset",
+        dataset: "Orders Model",
         collection: "Our analytics",
         table: "Orders",
       });
@@ -311,7 +311,7 @@ describe("scenarios > models", () => {
 
       assertQuestionIsBasedOnDataset({
         questionName: "Count by Created At: Month",
-        dataset: "Orders Dataset",
+        dataset: "Orders Model",
         collection: "Our analytics",
         table: "Orders",
       });
@@ -320,7 +320,7 @@ describe("scenarios > models", () => {
 
       assertQuestionIsBasedOnDataset({
         questionName: "Q1",
-        dataset: "Orders Dataset",
+        dataset: "Orders Model",
         collection: "Our analytics",
         table: "Orders",
       });
@@ -336,7 +336,7 @@ describe("scenarios > models", () => {
 
       assertQuestionIsBasedOnDataset({
         questionName: "Sum of Subtotal by Created At: Month",
-        dataset: "Orders Dataset",
+        dataset: "Orders Model",
         collection: "Our analytics",
         table: "Orders",
       });
@@ -345,7 +345,7 @@ describe("scenarios > models", () => {
 
       assertQuestionIsBasedOnDataset({
         questionName: "Q1",
-        dataset: "Orders Dataset",
+        dataset: "Orders Model",
         collection: "Our analytics",
         table: "Orders",
       });
@@ -353,7 +353,7 @@ describe("scenarios > models", () => {
       cy.url().should("not.include", "/question/1");
     });
 
-    it("can edit dataset info", () => {
+    it("can edit model info", () => {
       cy.intercept("PUT", "/api/card/1").as("updateCard");
       cy.visit("/question/1");
 
@@ -364,7 +364,7 @@ describe("scenarios > models", () => {
       modal().within(() => {
         cy.findByLabelText("Name")
           .clear()
-          .type("D1");
+          .type("M1");
         cy.findByLabelText("Description")
           .clear()
           .type("foo");
@@ -372,7 +372,7 @@ describe("scenarios > models", () => {
       });
       cy.wait("@updateCard");
 
-      cy.findByText("D1");
+      cy.findByText("M1");
       cy.findByText("foo");
     });
   });
@@ -417,7 +417,7 @@ describe("scenarios > models", () => {
       cy.findByText("Saved Questions");
     });
 
-    it("should automatically use the only collection dataset as a data source", () => {
+    it("should automatically use the only collection model as a data source", () => {
       cy.request("PUT", "/api/card/2", { dataset: true });
 
       cy.visit("/collection/root");


### PR DESCRIPTION
### Status
PENDING CI

### What does this PR accomplish?
As explained in #19668, we need to update copy across Metabase and to replace all "datasets" references with "models". This PR accomplishes exactly that.

### How to test?
___

### Basic Model Flow (turning a question into a model)
1. Open any saved question (GUI or native)
2. Click the chevron down icon to open a sidebar
3. You should see the "waffle" icon - hover over it and it should say "Turn this into a model"
![image](https://user-images.githubusercontent.com/31325167/149426459-2cc820b0-b3b2-48bd-a05d-1d7928441867.png)
4. Click on that icon
5. A popup modal should appear with the title "Models" and the button "Turn this into a model"
![image](https://user-images.githubusercontent.com/31325167/149426524-aeea2fea-fe60-424e-bd61-41f643eba58e.png)

### Data picker
1. Click on the "New" in the header
2. Choose Question
3. Data picker should offer "Models" instead of "Datasets"
![image](https://user-images.githubusercontent.com/31325167/149424404-bb98f081-2a1b-4c55-bfff-30410ae7529d.png)
4. Click on "Models"
5. The next data picker should show a search that says "Search for a model..."
6. It should also offer to go back to "Models"
![image](https://user-images.githubusercontent.com/31325167/149424553-f4cb051f-a726-417f-8921-ab6cc469e190.png)

### Search
1. go to `/search`
2. On the right side you should see a list of filters for the search
3. "Datasets" should not exist and you should see "Models"
![image](https://user-images.githubusercontent.com/31325167/149424215-1a505533-4026-4f4f-b6fb-475d5331e1d6.png)
4. Click on the "Models" filter
5. If you have any models in your collections, the text under their names should say "Model in ${collection_name}"

### Revision history
1. Crete a model from a question
2. Turn it back into a saved question
3. Open the history sidebar
4. It should say "changed this from a model to a saved question"
![image](https://user-images.githubusercontent.com/31325167/149425128-4858513a-60f7-4898-8370-8ee4b1b58d25.png)


### Management sidebar
1. Open a model
2. Click on the chevron down icon to open a sidebar
3. It should say "Model management"
![image](https://user-images.githubusercontent.com/31325167/149423479-d80bec9b-6ba0-4060-b5eb-f2b0b5b55a70.png)

### Undo action popup
1. Open a question
2. Convert it to a model
3. A popup in the lower left corner should appear
4. It should say "This is a model now"
![image](https://user-images.githubusercontent.com/31325167/149423378-4429cc3c-9418-4be1-ab1e-3d38804e4b2b.png)


### What's not in scope?
- Updating code implementation - methods, urls, etc.