### PR TITLE
Add extra spacing for form toggles

### DIFF
--- a/frontend/src/metabase/components/form/FormField.jsx
+++ b/frontend/src/metabase/components/form/FormField.jsx
@@ -4,7 +4,13 @@ import cx from "classnames";
 
 import Tooltip from "metabase/components/Tooltip";
 
-import { FieldRow, Label, InfoIcon, InputContainer } from "./FormField.styled";
+import {
+  FieldRow,
+  Label,
+  InfoIcon,
+  InputContainer,
+  FieldContainer,
+} from "./FormField.styled";
 
 const formFieldCommon = {
   title: PropTypes.string,
@@ -79,7 +85,7 @@ function FormField(props) {
   return (
     <div id={formFieldId} className={rootClassNames}>
       {(title || description) && (
-        <div>
+        <FieldContainer horizontal={horizontal}>
           <FieldRow>
             {title && (
               <Label
@@ -100,7 +106,7 @@ function FormField(props) {
           {description && descriptionPosition === "top" && (
             <div className="mb1">{description}</div>
           )}
-        </div>
+        </FieldContainer>
       )}
       <InputContainer horizontal={horizontal}>{children}</InputContainer>
       {description && descriptionPosition === "bottom" && (

--- a/frontend/src/metabase/components/form/FormField.styled.jsx
+++ b/frontend/src/metabase/components/form/FormField.styled.jsx
@@ -27,6 +27,10 @@ export const InfoIcon = styled(Icon).attrs({ name: "info", size: 12 })`
   }
 `;
 
+export const FieldContainer = styled.div`
+  margin-right: ${props => (props.horizontal ? "1rem" : "")};
+`;
+
 export const InputContainer = styled.div`
   flex-shrink: 0;
   ${props =>


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/19057

Adds extra spacing to solve an issue with database form toggles.

How to test:
- Go to Admin > Databases > Add new
- Check that the is extra space for horizontal form controls (currently boolean toggles only), e.g. Use SSH tunnel.