### PR TITLE
Add placeholder text for Snowflake additional JDBC options field

### DIFF
--- a/modules/drivers/snowflake/resources/metabase-plugin.yaml
+++ b/modules/drivers/snowflake/resources/metabase-plugin.yaml
@@ -38,7 +38,9 @@ driver:
     - cloud-ip-address-info
     - ssh-tunnel
     - advanced-options-start
-    - additional-options
+    - merge:
+      - additional-options
+      - placeholder: 'queryTimeout=0'
     - default-advanced-options
 init:
   - step: load-namespace


### PR DESCRIPTION
Quick follow-up for [this project](https://www.notion.so/metabase/Simplify-additional-options-in-set-up-flow-db-configuration-574685f825a34f5595011d0680451ea4) to add a missing placeholder to this field.