### PR TITLE
Fix flaking repro for 11439

### DIFF
--- a/frontend/test/__support__/e2e/helpers/e2e-misc-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-misc-helpers.js
@@ -57,7 +57,9 @@ export function openNotebookEditor({ fromCurrentPage } = {}) {
   }
 
   cy.findByText("New").click();
-  cy.findByText("Question").click();
+  cy.findByText("Question")
+    .should("be.visible")
+    .click();
 }
 
 /**

--- a/frontend/test/metabase/scenarios/question/new.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/new.cy.spec.js
@@ -1,7 +1,6 @@
 import {
   browse,
   enterCustomColumnDetails,
-  getBinningButtonForDimension,
   openOrdersTable,
   openReviewsTable,
   popover,

--- a/frontend/test/metabase/scenarios/question/new.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/new.cy.spec.js
@@ -373,7 +373,10 @@ describe("scenarios > question > new", () => {
       cy.findByText("Saved Questions").click();
       cy.findByText("11439").click();
       visualize();
-      cy.findByTestId("toggle-summarize-sidebar-button").click();
+      cy.findAllByTestId("toggle-summarize-sidebar-button")
+        .contains("Summarize")
+        .click();
+
       cy.findByText("Group by")
         .parent()
         .within(() => {
@@ -381,13 +384,15 @@ describe("scenarios > question > new", () => {
           cy.log(
             "**Marked as regression of [#10441](https://github.com/metabase/metabase/issues/10441)**",
           );
-          getBinningButtonForDimension({
-            name: "Created At",
-          })
-            .should("have.text", "by month")
-            .click();
+
+          cy.findByText("Created At")
+            .closest("li")
+            .contains("by month")
+            // realHover() or mousemove don't work for whatever reason
+            // have to use this ugly hack for now
+            .click({ force: true });
         });
-      // this step is maybe redundant since it fails to even find "by month"
+      // // this step is maybe redundant since it fails to even find "by month"
       cy.findByText("Hour of Day");
     });
 


### PR DESCRIPTION
An example of this test failing in the CI:
![image](https://user-images.githubusercontent.com/31325167/149538499-a7219c9b-bdc4-45cd-ad26-4d42e641bf54.png)

The first problem was that it finds multiple elements with the `data-testid='toggle-summarize-sidebar-button'` (the second one is rendered on the page, but is hidden - it is visible for tablets and mobile phone resolutions).

The second problem was that `.realHover()` or `mousemove` don't trigger the visibility of the bucket "by month", so I had to click it with the `{ force: true }`. It still reproduces the issue, because originally that string wasn't even present in the DOM.