### PR TITLE
Fix flaky tests

### DIFF
--- a/test/metabase/api/session_test.clj
+++ b/test/metabase/api/session_test.clj
@@ -232,18 +232,14 @@
             (is (= true
                    (reset-fields-set?))
                 "User `:reset_token` and `:reset_triggered` should be updated")
-            (is (= "[Metabase] Password Reset Request"
-                   (-> @mt/inbox (get "rasta@metabase.com") first :subject))
-                "User should get a password reset email"))))
+            (is (mt/received-email-subject? :rasta #"Password Reset")))))
       (testing "We use `site-url` in the email"
         (let [my-url "abcdefghij"]
           (mt/with-temporary-setting-values [site-url my-url]
             (mt/with-fake-inbox
               (mt/user-http-request :rasta :post 204 "session/forgot_password"
                                     {:email (:username (mt/user->credentials :rasta))})
-              (let [rasta-emails (-> (mt/regex-email-bodies (re-pattern my-url))
-                                     (get (:username (mt/user->credentials :rasta))))]
-                (is (some #(get-in % [:body my-url]) rasta-emails)))))))
+              (is (mt/received-email-body? :rasta (re-pattern my-url)))))))
       (testing "test that email is required"
         (is (= {:errors {:email "value must be a valid email address."}}
                (mt/client :post 400 "session/forgot_password" {}))))

--- a/test/metabase/email_test.clj
+++ b/test/metabase/email_test.clj
@@ -112,6 +112,22 @@
   [& regexes]
   (regex-email-bodies* regexes @inbox))
 
+(defn received-email-subject?
+  "Indicate whether user the user received an email whose subject matches the `regex`. User should be a keyword
+  like :rasta."
+  [user regex]
+  (let [address (:username (user/user->credentials user))
+        emails  (get @inbox address)]
+    (boolean (some #(re-find regex %) (map :subject emails)))))
+
+(defn received-email-body?
+  "Indicate whether user the user received an email whose body matches the `regex`. User should be a keyword
+  like :rasta."
+  [user regex]
+  (let [address (:username (user/user->credentials user))
+        emails  (get @inbox address)]
+    (boolean (some #(re-find regex %) (map (comp :content first :body) emails)))))
+
 (deftest regex-email-bodies-test
   (letfn [(email [body] {:to #{"mail"}
                          :body [{:content body}]})

--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -101,6 +101,8 @@
   email-to
   fake-inbox-email-fn
   inbox
+  received-email-body?
+  received-email-subject?
   regex-email-bodies
   reset-inbox!
   summarize-multipart-email


### PR DESCRIPTION
Our email tests can be a bit brittle. Sometimes we assert the first
email in the email inbox is some password reset email, but a race makes
it such that its a "logged in from new ip" email. Othertimes, we might
assert that there are only emails to a particular user but maybe another
test might have triggered an email to another user.

We often might just want two predicates: did the user receive an email
with this subject, or did the user receive an email with this body.

This simply adds those.

It should be safe from races as it can handle emails to multiple users
and multiple emails to the same user.

Note we have a function `mt/regex-email-bodies` that will take regexes and return a view of the emails received for all users that matches those regexes. But this is a bit more work than we want to do: just assert a user got an email.