### PR TITLE
Rotate crowded ordinal ticks on static charts

### DIFF
--- a/frontend/src/metabase/internal/pages/StaticVizPage.jsx
+++ b/frontend/src/metabase/internal/pages/StaticVizPage.jsx
@@ -524,6 +524,77 @@ export default function StaticVizPage() {
             }}
           />
         </Box>
+
+        <Box py={3}>
+          <Subhead>
+            Combo chart with ordinal X-axis and more than 10 ticks
+          </Subhead>
+          <StaticChart
+            type="combo-chart"
+            options={{
+              settings: {
+                goal: {
+                  value: 120,
+                  label: "Goal",
+                },
+                x: {
+                  type: "ordinal",
+                },
+                y: {
+                  type: "linear",
+                },
+                labels: {
+                  left: "Count",
+                  right: "Sum",
+                  bottom: "Date",
+                },
+              },
+              series: [
+                {
+                  name: "line series",
+                  color: "#509ee3",
+                  yAxisPosition: "left",
+                  type: "line",
+                  data: [
+                    ["Alden Sparks", 70],
+                    ["Areli Guerra", 30],
+                    ["Arturo Hopkins", 80],
+                    ["Beatrice Lane", 120],
+                    ["Brylee Davenport", 100],
+                    ["Cali Nixon", 60],
+                    ["Dane Terrell", 150],
+                    ["Deshawn Rollins", 40],
+                    ["Isabell Bright", 70],
+                    ["Kaya Rowe", 20],
+                    ["Roderick Herman", 50],
+                    ["Ruth Dougherty", 75],
+                  ],
+                },
+                {
+                  name: "bar series 1",
+                  color: "#88bf4d",
+                  yAxisPosition: "left",
+                  type: "bar",
+                  data: [
+                    ["Alden Sparks", 20],
+                    ["Areli Guerra", 80],
+                    ["Arturo Hopkins", 10],
+                    ["Beatrice Lane", 10],
+                    ["Brylee Davenport", 15],
+                    ["Cali Nixon", 20],
+                    ["Dane Terrell", 40],
+                    ["Deshawn Rollins", 60],
+                    ["Isabell Bright", 80],
+                    ["Kaya Rowe", 50],
+                    ["Roderick Herman", 40],
+                    ["Ruth Dougherty", 65],
+                  ],
+                },
+              ],
+            }}
+          />
+        </Box>
+
         <Box py={3}>
           <Subhead>Funnel</Subhead>
           <StaticChart

--- a/frontend/src/metabase/static-viz/components/LineAreaBarChart/LineAreaBarChart.tsx
+++ b/frontend/src/metabase/static-viz/components/LineAreaBarChart/LineAreaBarChart.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { XYChart } from "../XYChart";
 import { ChartSettings, ChartStyle, Series } from "../XYChart/types";
 import { Colors } from "./types";
+import { adjustSettings } from "./utils/settings";
 
 const defaultColors = {
   brand: "#509ee3",
@@ -44,10 +45,12 @@ const LineAreaBarChart = ({
     goalColor: palette.textMedium,
   };
 
+  const adjustedSettings = adjustSettings(settings, series);
+
   return (
     <XYChart
       series={series}
-      settings={settings}
+      settings={adjustedSettings}
       style={chartStyle}
       width={540}
       height={300}

--- a/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/settings.ts
+++ b/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/settings.ts
@@ -1,0 +1,26 @@
+import { assocIn } from "icepick";
+import { ChartSettings, Series } from "../../XYChart/types";
+import { getX } from "../../XYChart/utils";
+
+// We want to adjust display settings based on chart data to achieve better-looking charts on smaller static images.
+export const adjustSettings = (settings: ChartSettings, series: Series[]) => {
+  return rotateCrowdedOrdinalXTicks(settings, series);
+};
+
+const rotateCrowdedOrdinalXTicks = (
+  settings: ChartSettings,
+  series: Series[],
+) => {
+  if (settings.x.type !== "ordinal") {
+    return settings;
+  }
+
+  const items = new Set();
+  series.forEach(s => {
+    s.data.forEach(datum => items.add(getX(datum)));
+  });
+
+  return items.size > 10
+    ? assocIn(settings, ["x", "tick_display"], "rotate-45")
+    : settings;
+};

--- a/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/settings.unit.spec.ts
+++ b/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/settings.unit.spec.ts
@@ -1,0 +1,42 @@
+import _ from "underscore";
+import { ChartSettings, Series } from "../../XYChart/types";
+import { adjustSettings } from "./settings";
+
+const settings: ChartSettings = {
+  x: {
+    type: "ordinal",
+  },
+  y: {
+    type: "linear",
+  },
+  labels: {
+    left: "Count",
+    bottom: "Date",
+  },
+};
+
+const getSeries = (length: number): Series[] => [
+  {
+    name: "series",
+    color: "black",
+    yAxisPosition: "left",
+    type: "line",
+    data: _.range(length).map(index => [`X:${index}`, index]),
+  },
+];
+
+describe("adjustSettings", () => {
+  describe("ordinal x-axis", () => {
+    it("returns unchanged settings when the number X-ticks is less or equal than 10", () => {
+      const adjustedSettings = adjustSettings(settings, getSeries(10));
+
+      expect(adjustedSettings).toBe(settings);
+    });
+
+    it("rotates X-ticks when the number X-ticks is greater than 10", () => {
+      const adjustedSettings = adjustSettings(settings, getSeries(11));
+
+      expect(adjustedSettings.x.tick_display).toBe("rotate-45");
+    });
+  });
+});

--- a/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
@@ -125,6 +125,8 @@ export const XYChart = ({
     textAnchor: "end",
   };
 
+  const areXTicksRotated = settings.x.tick_display === "rotate-45";
+
   return (
     <svg width={width} height={height + legend.height}>
       <Group top={margin.top} left={xMin}>
@@ -206,7 +208,7 @@ export const XYChart = ({
 
       <AxisBottom
         scale={xScale.scale}
-        label={settings.labels.bottom}
+        label={areXTicksRotated ? undefined : settings.labels.bottom}
         top={yMin}
         left={xMin}
         numTicks={xTicksCount}
@@ -222,7 +224,7 @@ export const XYChart = ({
               props,
               style.axes.ticks.fontSize,
               xTickWidthLimit,
-              settings.x.tick_display === "rotate-45",
+              areXTicksRotated,
             )}
           />
         )}

--- a/frontend/src/metabase/static-viz/components/XYChart/types.ts
+++ b/frontend/src/metabase/static-viz/components/XYChart/types.ts
@@ -30,11 +30,11 @@ export type ChartSettings = {
   x: {
     type: XAxisType;
     tick_display?: TickDisplay;
-    format: DateFormatOptions | NumberFormatOptions;
+    format?: DateFormatOptions | NumberFormatOptions;
   };
   y: {
     type: YAxisType;
-    format: NumberFormatOptions;
+    format?: NumberFormatOptions;
   };
   goal?: {
     value: number;

--- a/frontend/src/metabase/static-viz/lib/numbers.ts
+++ b/frontend/src/metabase/static-viz/lib/numbers.ts
@@ -20,7 +20,7 @@ const DEFAULT_OPTIONS = {
   suffix: "",
 };
 
-export const formatNumber = (number: number, options: NumberFormatOptions) => {
+export const formatNumber = (number: number, options?: NumberFormatOptions) => {
   const {
     number_style,
     currency,

--- a/frontend/src/metabase/static-viz/lib/text.ts
+++ b/frontend/src/metabase/static-viz/lib/text.ts
@@ -27,7 +27,7 @@ export const truncateText = (text: string, width: number, fontSize: number) => {
   }
 
   while (text.length && measureText(text + CHAR_ELLIPSES, fontSize) > width) {
-    text = text.substring(0, text.length - 1);
+    text = text.substring(0, text.length - 1).trim();
   }
 
   return text + CHAR_ELLIPSES;


### PR DESCRIPTION
On ordinal charts X-axis with a lot of values becomes unreadable. To achieve better-looking charts on smaller static images we want to force rotate ticks when there are more than 10 values.

### Screenshot

<img width="608" alt="Screenshot 2022-01-14 at 23 21 15" src="https://user-images.githubusercontent.com/14301985/149597635-bdc1155c-91b0-4e7b-9cf3-189654a2a286.png">
