### PR TITLE
CI for Percy: cache Cypress binaries

### DIFF
--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -105,6 +105,24 @@ jobs:
         with:
           path: ~/.cache/yarn
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+      - name: Get node_modules cache
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Get Cypress cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/Cypress
+          key: ${{ runner.os }}-Cypress-${{ hashFiles('**/yarn.lock') }}
+      - name: Ensure that Cypress is ready
+        run: |
+          yarn cypress install
+          yarn cypress cache path
+          yarn cypress cache list
+          yarn cypress verify
+
       - run: yarn install --frozen-lockfile --prefer-offline
 
       - uses: actions/download-artifact@v2


### PR DESCRIPTION
This is another attempt at speeding up Percy CI (see the previous failed ones PR #19202 and then #19243, which got reverted in PR #19266).

The new trick is here is caching `~/.cache/Cypress` _**and**_ ensuring that Cypress binaries are download there (via `yarn  cypress install`) when the cache is empty.

**Before the PR**

The `yarn install` step is taking some time (~3 mins) due to the need to prepare `node_modules` from yarn's cache.

![image](https://user-images.githubusercontent.com/7288/149647812-b799ed70-1967-4d0b-ac52-4703a4eee319.png)


**After the PR**

The `yarn install` step is blazing fast, because `node_modules` (~20s retrieval time) and Cypress binaries (~25s retrieval time) are handily available.

![image](https://user-images.githubusercontent.com/7288/149647709-e2bfd141-4c41-4ae0-886a-bd8b3d272d7a.png)
