### PR TITLE
upgrade-field-literals should do case-insensitive fixes

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions.clj
@@ -138,7 +138,7 @@
                          ((requiring-resolve 'metabase.query-processor/query->preprocessed) query))]
       (select-keys (:query preprocessed) [:source-query :source-metadata]))
     (catch Throwable e
-      (throw (ex-info (tru "Error preprocessing source query when applying GTAP")
+      (throw (ex-info (tru "Error preprocessing source query when applying GTAP: {0}" (ex-message e))
                       {:source-query source-query}
                       e)))))
 

--- a/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions_test.clj
@@ -339,12 +339,13 @@
   keys from the JDBC metadata, even though we enable the feature in the UI."
   []
   (cond-> (mt/normal-drivers-with-feature :nested-queries :foreign-keys)
-    (@tx.env/test-drivers :bigquery) (conj :bigquery)
-    true                             (disj :presto-jdbc)))
+    (@tx.env/test-drivers :bigquery)           (conj :bigquery)
+    (@tx.env/test-drivers :bigquery-cloud-sdk) (conj :bigquery-cloud-sdk)
+    true                                       (disj :presto-jdbc)))
 
 (deftest e2e-fks-test
   (mt/test-drivers (row-level-restrictions-fk-drivers)
-    (mt/with-bigquery-fks :bigquery
+    (mt/with-bigquery-fks #{:bigquery :bigquery-cloud-sdk}
      (testing (str "1 - Creates a GTAP filtering question, looking for any checkins happening on or after 2014\n"
                    "2 - Apply the `user` attribute, looking for only our user (i.e. `user_id` =  5)\n"
                    "3 - Checkins are related to Venues, query for checkins, grouping by the Venue's price\n"

--- a/src/metabase/query_processor/middleware/add_source_metadata.clj
+++ b/src/metabase/query_processor/middleware/add_source_metadata.clj
@@ -58,7 +58,7 @@
         (select-keys col [:name :id :table_id :display_name :base_type :effective_type :coercion_strategy
                           :semantic_type :unit :fingerprint :settings :source_alias :field_ref :parent_id])))
     (catch Throwable e
-      (log/error e (str (trs "Error determining expected columns for query")))
+      (log/error e (str (trs "Error determining expected columns for query: {0}" (ex-message e))))
       nil)))
 
 (s/defn ^:private add-source-metadata :- {(s/optional-key :source-metadata) [mbql.s/SourceQueryMetadata], s/Keyword s/Any}
@@ -105,7 +105,9 @@
 (defn- add-source-metadata-at-all-levels [inner-query]
   (walk/postwalk maybe-add-source-metadata inner-query))
 
-(defn- add-source-metadata-for-source-queries* [{query-type :type, :as query}]
+(defn add-source-metadata-for-source-queries*
+  "Add `:source-metadata` for source queries inside `query`."
+  [{query-type :type, :as query}]
   (if-not (= query-type :query)
     query
     (update query :query add-source-metadata-at-all-levels)))

--- a/src/metabase/query_processor/middleware/resolve_fields.clj
+++ b/src/metabase/query_processor/middleware/resolve_fields.clj
@@ -20,7 +20,7 @@
       (u/prog1 query
         (resolve-fields-with-ids! ids))
       (catch Throwable e
-        (throw (ex-info (tru "Error resolving Fields in query")
+        (throw (ex-info (tru "Error resolving Fields in query: {0}" (ex-message e))
                         {:field-ids ids
                          :query     query
                          :type      qp.error-type/qp}

--- a/src/metabase/query_processor/middleware/upgrade_field_literals.clj
+++ b/src/metabase/query_processor/middleware/upgrade_field_literals.clj
@@ -76,7 +76,7 @@
         field-clause))))
 
 (defn- upgrade-field-literals-one-level [{:keys [source-metadata], :as inner-query}]
-  (let [source-aliases    (into #{} (comp (map :source_alias) (filter some?)) source-metadata)
+  (let [source-aliases    (into #{} (keep :source_alias) source-metadata)
         field-name->field (merge (u/key-by :name source-metadata)
                                  (u/key-by (comp str/lower-case :name) source-metadata))]
     (mbql.u/replace inner-query

--- a/src/metabase/query_processor/middleware/upgrade_field_literals.clj
+++ b/src/metabase/query_processor/middleware/upgrade_field_literals.clj
@@ -1,36 +1,113 @@
 (ns metabase.query-processor.middleware.upgrade-field-literals
-  (:require [clojure.walk :as walk]
+  (:require [clojure.string :as str]
+            [clojure.tools.logging :as log]
+            [clojure.walk :as walk]
+            [metabase.config :as config]
             [metabase.mbql.util :as mbql.u]
-            [metabase.util :as u]))
+            [metabase.query-processor.middleware.resolve-fields :as resolve-fields]
+            [metabase.query-processor.store :as qp.store]
+            [metabase.util :as u]
+            [metabase.util.i18n :refer [trs]]))
+
+(defn- has-a-native-source-query-at-some-level? [{:keys [source-query]}]
+  (or (:native source-query)
+      (when source-query
+        (has-a-native-source-query-at-some-level? source-query))))
+
+(defn- warn-once
+  "Log only one warning per QP run (regardless of message)."
+  [message]
+  ;; Make sure QP store is available since we use caching below (it may not be in some unit tests)
+  (when (qp.store/initialized?)
+    ;; by caching the block below, the warning will only get trigger a maximum of one time per query run. We don't need
+    ;; to blow up the logs with a million warnings.
+    (qp.store/cached ::bad-clause-warning
+      (log/warn (u/colorize :red message)))))
+
+(defn- fix-clause [{:keys [inner-query source-aliases field-name->field]} [_ field-name options :as field-clause]]
+  ;; attempt to find a corresponding Field ref from the source metadata.
+  (let [field-ref (:field_ref (get field-name->field field-name))]
+    (cond
+      field-ref
+      (mbql.u/match-one field-ref
+        ;; If the matching Field ref is an integer `:field` clause then replace it with the corrected clause and log
+        ;; a developer-facing warning. Things will still work and this should be fixed on the FE, but we don't need to
+        ;; blow up prod logs
+        [:field (id :guard integer?) new-options]
+        (u/prog1 [:field id (merge new-options (dissoc options :base-type))]
+          (when (and (not config/is-prod?)
+                     (not (has-a-native-source-query-at-some-level? inner-query)))
+            ;; don't i18n this because it's developer-facing only.
+            (warn-once
+             (str "Warning: query is using a [:field <string> ...] clause to refer to a Field in an MBQL source query."
+                  \newline
+                  "Use [:field <integer> ...] clauses to refer to Fields in MBQL source queries."
+                  \newline
+                  "We will attempt to fix this, but it may lead to incorrect queries."
+                  \newline
+                  "See https://github.com/metabase/metabase/issues/16389#issuecomment-1013780973 for more information."
+                  \newline
+                  (str "Clause:       " (pr-str field-clause))
+                  \newline
+                  (str "Corrected to: " (pr-str <>))))))
+
+        ;; Otherwise the Field clause in the source query uses a string Field name as well, but that name differs from
+        ;; the one in `source-aliases`. Will this work? Not sure whether or not we need to log something about this.
+        [:field (field-name :guard string?) new-options]
+        (u/prog1 [:field field-name (merge new-options (dissoc options :base-type))]
+          (warn-once
+           (trs "Warning: clause {0} does not match a column in the source query. Attempting to correct this to {1}"
+                (pr-str field-clause)
+                (pr-str <>)))))
+
+      ;; If the field name exists in the ACTUAL names returned by the source query then we're g2g and don't need to
+      ;; complain about anything.
+      (contains? source-aliases field-name)
+      field-clause
+
+      ;; no matching Field ref means there's no column with this name in the source query. The query may not work, so
+      ;; log a warning about it. This query is probably not going to work so we should let everyone know why.
+      :else
+      (do
+        (warn-once
+         (trs "Warning: clause {0} refers to a Field that may not be present in the source query. Query may not work as expected. Found: {1}"
+              (pr-str field-clause) (pr-str (or (not-empty source-aliases)
+                                                (set (keys field-name->field))))))
+        field-clause))))
 
 (defn- upgrade-field-literals-one-level [{:keys [source-metadata], :as inner-query}]
-  (let [field-name->field (u/key-by :name source-metadata)]
-    ;; look for `field` clauses that use a string name...
+  (let [source-aliases    (into #{} (comp (map :source_alias) (filter some?)) source-metadata)
+        field-name->field (merge (u/key-by :name source-metadata)
+                                 (u/key-by (comp str/lower-case :name) source-metadata))]
     (mbql.u/replace inner-query
-      [:field (field-name :guard string?) options]
       ;; don't upgrade anything inside `source-query` or `source-metadata`.
-      (or (when-not (or (contains? (set &parents) :source-query)
-                        (contains? (set &parents) :source-metadata))
-            (when-let [{field-ref :field_ref} (get field-name->field field-name)]
-              ;; only do a replacement if the field ref is a `field` clause that uses an ID
-              (mbql.u/match-one field-ref
-                [:field (id :guard integer?) new-options]
-                [:field id (merge new-options (dissoc options :base-type))])))
-          ;; if they don't meet the conditions above, return them as is
+      (_ :guard (constantly (some (set &parents) [:source-query :source-metadata])))
+      &match
+
+      ;; look for `field` clauses that use a string name that doesn't appear in `source-aliases` (the ACTUAL names that
+      ;; are returned by the source query)
+      [:field (field-name :guard (every-pred string? (complement source-aliases))) options]
+      (or (fix-clause {:inner-query inner-query, :source-aliases source-aliases, :field-name->field field-name->field}
+                      &match)
           &match))))
 
 (defn- upgrade-field-literals-all-levels [query]
-  (walk/postwalk
-   (fn [form]
-     ;; find maps that have `source-query` and `source-metadata`, but whose source query is an MBQL source query
-     ;; rather than an native one
-     (if (and (map? form)
-              (:source-query form)
-              (seq (:source-metadata form))
-              (not (get-in form [:source-query :native])))
-       (upgrade-field-literals-one-level form)
-       form))
-   query))
+  (-> (walk/postwalk
+       (fn [form]
+         ;; find maps that have `source-query` and `source-metadata`, but whose source query is an MBQL source query
+         ;; rather than an native one
+         (if (and (map? form)
+                  (:source-query form)
+                  (seq (:source-metadata form))
+                  ;; we probably shouldn't upgrade things at all if we have a source MBQL query whose source is a native
+                  ;; query at ANY level, since `[:field <name>]` might mean `source.<name>` or it might mean
+                  ;; `some_join.<name>`. But we'll probably break more things than we fix if turn off this middleware in
+                  ;; that case. See https://github.com/metabase/metabase/issues/16389#issuecomment-1013780973 for more info
+                  (not (get-in form [:source-query :native])))
+           (upgrade-field-literals-one-level form)
+           form))
+       (resolve-fields/resolve-fields* query))
+      resolve-fields/resolve-fields*))
 
 (defn upgrade-field-literals
   "Look for usage of `:field` (name) forms where `field` (ID) would have been the correct thing to use, and fix it, so

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -251,7 +251,7 @@
     false
     (config/config-bool :mb-colorize-logs)))
 
-(def ^{:arglists '(^String [color-symb x]), :style/indent 1} colorize
+(def ^{:arglists '(^String [color-symb x])} colorize
   "Colorize string `x` using `color`, a symbol or keyword, but only if `MB_COLORIZE_LOGS` is enabled (the default).
   `color` can be `green`, `red`, `yellow`, `blue`, `cyan`, `magenta`, etc. See the entire list of avaliable
   colors [here](https://github.com/ibdknox/colorize/blob/master/src/colorize/core.clj)"
@@ -811,7 +811,7 @@
   [message start-time]
   ;; indent the message according to [[*profile-level*]] and add a little down-left arrow so it (hopefully) points to
   ;; the parent form
-  (println (format-color (case (mod *profile-level* 4)
+  (println (format-color (case (int (mod *profile-level* 4))
                            0 :green
                            1 :cyan
                            2 :magenta

--- a/test/metabase/query_processor/middleware/upgrade_field_literals_test.clj
+++ b/test/metabase/query_processor/middleware/upgrade_field_literals_test.clj
@@ -1,12 +1,15 @@
 (ns metabase.query-processor.middleware.upgrade-field-literals-test
   (:require [clojure.test :refer :all]
+            [medley.core :as m]
             [metabase.query-processor :as qp]
+            [metabase.query-processor.middleware.add-source-metadata :as add-source-metadata]
             [metabase.query-processor.middleware.upgrade-field-literals :as upgrade-field-literals]
             [metabase.test :as mt]))
 
 (defn- upgrade-field-literals [query]
-  (-> (mt/test-qp-middleware upgrade-field-literals/upgrade-field-literals query)
-      :pre))
+  (mt/with-everything-store
+    (-> (mt/test-qp-middleware upgrade-field-literals/upgrade-field-literals query)
+        :pre)))
 
 (deftest dont-replace-aggregations-test
   (testing "Don't replace field-literals forms with aggregation references"
@@ -84,3 +87,29 @@
                      :source-metadata source-metadata
                      ;; not sure why FE is using `field-literal` here... but it should work anyway.
                      :filter          [:= *CATEGORY/Text "Widget"]})))))))))
+
+(deftest attempt-case-insensitive-match-test
+  (testing "Attempt to fix things even if the name used is the wrong case (#16389)"
+    (mt/dataset sample-dataset
+      (mt/with-everything-store
+        (is (query= (mt/mbql-query orders
+                      {:source-query {:source-table $$orders
+                                      :aggregation  [[:count]]
+                                      :breakout     [!month.product_id->products.created_at]}
+                       :aggregation  [[:sum *count/Integer]]
+                       :breakout     [[:field %products.created_at {:source-field  %product_id
+                                                                    :temporal-unit :month}]]
+                       :limit        1})
+                    ;; This query is actually broken -- see
+                    ;; https://github.com/metabase/metabase/issues/16389#issuecomment-1013780973 -- but since we're nice
+                    ;; we'll try to fix it anyway.
+                    (-> (mt/mbql-query orders
+                          {:source-query {:source-table $$orders
+                                          :aggregation  [[:count]]
+                                          :breakout     [!month.product_id->products.created_at]}
+                           :aggregation  [[:sum *count/Integer]]
+                           :breakout     [[:field "created_at" {:base-type :type/DateTimeWithLocalTZ}]]
+                           :limit        1})
+                        add-source-metadata/add-source-metadata-for-source-queries*
+                        upgrade-field-literals
+                        (m/dissoc-in [:query :source-metadata]))))))))

--- a/test/metabase/query_processor_test/explicit_joins_test.clj
+++ b/test/metabase/query_processor_test/explicit_joins_test.clj
@@ -609,4 +609,24 @@
                      "Gizmo"
                      51]]
                    (mt/formatted-rows [int str str str str 2.0 1.0 str str int]
-                    (qp/process-query query))))))))))
+                     (qp/process-query query))))))))))
+
+(deftest join-with-space-in-alias-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries :left-join)
+    (testing "Some drivers don't allow Table alises with spaces in them. Make sure joins still work."
+      (mt/dataset sample-dataset
+        (mt/with-bigquery-fks #{:bigquery :bigquery-cloud-sdk}
+          (let [query (mt/mbql-query products
+                        {:joins    [{:source-query {:source-table $$orders}
+                                     :alias        "Q 1"
+                                     :condition    [:= $id [:field %orders.product_id {:join-alias "Q 1"}]]
+                                     :fields       :all}]
+                         :fields   [$id
+                                    [:field %orders.id {:join-alias "Q 1"}]]
+                         :order-by [[:asc $id]
+                                    [:asc [:field %orders.id {:join-alias "Q 1"}]]]
+                         :limit    2})]
+            (mt/with-native-query-testing-context query
+              (is (= [[1 448] [1 493]]
+                     (mt/formatted-rows [int int]
+                       (qp/process-query query)))))))))))

--- a/test/metabase/query_processor_test/nested_queries_test.clj
+++ b/test/metabase/query_processor_test/nested_queries_test.clj
@@ -347,18 +347,23 @@
                :aggregation  [[:avg *stddev/Integer]]}))))))
 
 (deftest handle-incorrect-field-forms-gracefully-test
-  (testing "make sure that we handle [field-id [field-literal ...]] forms gracefully, despite that not making any sense"
-    (is (= (honeysql->sql
-            {:select   [[:source.category_id :category_id]]
-             :from     [[venues-source-honeysql :source]]
-             :group-by [:source.category_id]
-             :order-by [[:source.category-id :asc]]
-             :limit    10})
-           (qp/query->native
-            (mt/mbql-query venues
-              {:source-query {:source-table $$venues}
-               :breakout     [[:field [:field "category_id" {:base-type :type/Integer}] nil]]
-               :limit        10}))))))
+  (testing "make sure that we handle [:field [:field <name> ...]] forms gracefully, despite that not making any sense"
+    (is (sql= '{:select   [source.CATEGORY_ID AS CATEGORY_ID]
+                :from     [{:select [VENUES.ID          AS ID
+                                     VENUES.NAME        AS NAME
+                                     VENUES.CATEGORY_ID AS CATEGORY_ID
+                                     VENUES.LATITUDE    AS LATITUDE
+                                     VENUES.LONGITUDE   AS LONGITUDE
+                                     VENUES.PRICE       AS PRICE]
+                            :from [VENUES]}
+                           source]
+                :group-by [source.CATEGORY_ID]
+                :order-by [source.CATEGORY_ID ASC]
+                :limit    [10]}
+              (mt/mbql-query venues
+                {:source-query {:source-table $$venues}
+                 :breakout     [[:field [:field "category_id" {:base-type :type/Integer}] nil]]
+                 :limit        10})))))
 
 (deftest filter-by-string-fields-test
   (testing "Make sure we can filter by string fields from a source query"
@@ -1271,4 +1276,25 @@
                        "Ad perspiciatis quis et consectetur. Laboriosam fuga voluptas ut et modi ipsum. Odio et eum numquam eos nisi. Assumenda aut magnam libero maiores nobis vel beatae officia."
                        "2018-05-15T20:25:48.517Z"]]
                      (mt/formatted-rows [int int int int str int str str]
+                       (qp/process-query query)))))))))))
+
+(deftest breakout-on-temporally-bucketed-implicitly-joined-column-inside-source-query-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries :basic-aggregations :left-join)
+    (testing (str "Should be able to breakout on a temporally-bucketed, implicitly-joined column from the source query "
+                  "incorrectly using `:field` literals to refer to the Field (#16389)")
+      ;; See https://github.com/metabase/metabase/issues/16389#issuecomment-1013780973 for more details on why this query
+      ;; is broken
+      (mt/dataset sample-dataset
+        (mt/with-bigquery-fks #{:bigquery :bigquery-cloud-sdk}
+          (let [query (mt/mbql-query orders
+                        {:source-query {:source-table $$orders
+                                        :breakout     [!month.product_id->products.created_at]
+                                        :aggregation  [[:count]]}
+                         :filter       [:time-interval *created_at/DateTimeWithLocalTZ -30 :year]
+                         :aggregation  [[:sum *count/Integer]]
+                         :breakout     [*created_at/DateTimeWithLocalTZ]
+                         :limit        1})]
+            (mt/with-native-query-testing-context query
+              (is (= [["2016-04-01T00:00:00Z" 175]]
+                     (mt/formatted-rows [str int]
                        (qp/process-query query)))))))))))


### PR DESCRIPTION
Follow on to #19384
Fixes #16389

The root cause of #16389 is that the frontend in some places is still disregarding the `:field_ref` in query results metadata and incorrectly generating `[:field <string> ...]` ("field literal") clauses to refer to Fields returned by joins or source queries, even when they're normal Fields returned by normal MBQL queries. `:field`+String name clauses are only meant for referring to things that have no corresponding `Field`, e.g. columns that come back from a native query or columns introduced by aggregations or expressions in the source query. See https://github.com/metabase/metabase/issues/16389#issuecomment-1013780973 for a longer explanation.

The frontend has been generating "broken" queries like these basically forever, so in #14812 I introduced middleware that would attempt to rewrite "field literals" to proper `[:field <integer> ...]` clauses. This fixed a bunch of bugs. However this middleware only attempted case-sensitive fixes. 

For #16389 in particular it turns out the frontend is generating clauses like `[:field "price" ...]` even when the **actual** name of the Field is `PRICE`. 

This PR: 
- extends the `upgrade-field-literals` middleware from #14812 to be case-insensitive
- Logs warnings on "bad" field literal clauses so we can catch and fix code in the FE client that is generating them
- Logs warnings on "bad" field literal clauses that cannot figure out how to fix (which would have made debugging #16389 much easier). I considered throwing an Exception if the clause is bad and we can't fix it, but there's still a _chance_ the query might work somehow, and I didn't want to end up breaking things that used to work for one reason or another