### PR TITLE
Static viz bundlling: don't bother with ESLint

### DIFF
--- a/webpack.static-viz.config.js
+++ b/webpack.static-viz.config.js
@@ -35,18 +35,6 @@ module.exports = {
         exclude: /node_modules/,
         use: [{ loader: "babel-loader", options: BABEL_CONFIG }],
       },
-      {
-        test: /\.(tsx?|jsx?)$/,
-        exclude: /node_modules/,
-        use: [
-          {
-            loader: "eslint-loader",
-            options: {
-              rulePaths: [__dirname + "/frontend/lint/eslint-rules"],
-            },
-          },
-        ],
-      },
     ],
   },
   resolve: {


### PR DESCRIPTION
We have a repo-wide CI run to check ESLint error anyway. Meanwhile, for day-to-day development of static viz frontend, the main webpack config is already equipped with ESLint check (along with hot reload etc).

This cuts the build time (for Uberjar on CircleICI) by ~14 seconds.


**Before this PR**

Webpack bundling for static viz takes 26 seconds.

```
$ "yarn" "build-static-viz"
yarn run v1.22.5
$ yarn && webpack --config webpack.static-viz.config.js
[1/5] Validating package.json...
[2/5] Resolving packages...
asset lib-static-viz.bundle.js 398 KiB [compared for emit] [minimized] [big] (name: lib-static-viz) 1 related asset
orphan modules 795 KiB [orphan] 810 modules
runtime modules 1.19 KiB 5 modules
cacheable modules 884 KiB
webpack 5.37.0 compiled successfully in 25687 ms
```

**After this PR**

Webpack bundling for static viz takes 12 seconds.

```
$ "yarn" "build-static-viz"
yarn run v1.22.5
$ yarn && webpack --config webpack.static-viz.config.js
[1/5] Validating package.json...
[2/5] Resolving packages...
success Already up-to-date.
asset lib-static-viz.bundle.js 398 KiB [compared for emit] [minimized] [big] (name: lib-static-viz) 1 related asset
orphan modules 795 KiB [orphan] 810 modules
runtime modules 1.19 KiB 5 modules
cacheable modules 884 KiB
webpack 5.37.0 compiled successfully in 11674 ms
```
