### PR TITLE
Convert the newsletter form to the standard form

### DIFF
--- a/frontend/src/metabase/entities/users/forms.js
+++ b/frontend/src/metabase/entities/users/forms.js
@@ -172,4 +172,13 @@ export default {
   password_reset: {
     fields: [...PASSWORD_FORM_FIELDS],
   },
+  newsletter: {
+    fields: [
+      {
+        name: "email",
+        placeholder: "youlooknicetoday@email.com",
+        validate: validate.required().email(),
+      },
+    ],
+  },
 };

--- a/frontend/src/metabase/setup/components/NewsletterForm/NewsletterForm.styled.tsx
+++ b/frontend/src/metabase/setup/components/NewsletterForm/NewsletterForm.styled.tsx
@@ -3,7 +3,7 @@ import { color } from "metabase/lib/colors";
 import Icon from "metabase/components/Icon";
 import Button from "metabase/components/Button";
 
-export const FormRoot = styled.form`
+export const FormRoot = styled.div`
   position: relative;
   padding: 2rem;
   border: 1px solid ${color("border")};
@@ -46,13 +46,13 @@ export const FormHeader = styled.div`
   margin-bottom: 1.5rem;
 `;
 
-export const FormInputContainer = styled.div`
+export const FormContainer = styled.div`
   display: flex;
 `;
 
-export const FormInputButton = styled(Button)`
-  flex: 0 0 auto;
-  margin-left: 1rem;
+export const FormFieldContainer = styled.div`
+  flex: 1 0 auto;
+  margin-right: 1rem;
 `;
 
 export const FormSuccessContainer = styled.div`

--- a/frontend/src/metabase/setup/components/NewsletterForm/NewsletterForm.styled.tsx
+++ b/frontend/src/metabase/setup/components/NewsletterForm/NewsletterForm.styled.tsx
@@ -53,6 +53,7 @@ export const FormContainer = styled.div`
 export const FormFieldContainer = styled.div`
   flex: 1 0 auto;
   margin-right: 1rem;
+  margin-bottom: -1.5em;
 `;
 
 export const FormSuccessContainer = styled.div`

--- a/frontend/src/metabase/setup/components/NewsletterForm/NewsletterForm.tsx
+++ b/frontend/src/metabase/setup/components/NewsletterForm/NewsletterForm.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { t } from "ttag";
 import Users from "metabase/entities/users";
+import Form from "metabase/containers/Form";
 import {
   FormContainer,
   FormFieldContainer,
@@ -46,18 +47,23 @@ const NewsletterForm = ({
         {t`Get infrequent emails about new releases and feature updates.`}
       </FormHeader>
       {!isSubscribed && (
-        <Users.Form initialValues={initialValues} onSubmit={onSubmit}>
+        <Form
+          form={Users.forms.newsletter}
+          initialValues={initialValues}
+          submitTitle={t`Subscribe`}
+          onSubmit={onSubmit}
+        >
           {({ Form, FormField, FormSubmit }: FormProps) => (
             <Form>
               <FormContainer>
                 <FormFieldContainer>
                   <FormField name="email" />
                 </FormFieldContainer>
-                <FormSubmit submitTitle={t`Subscribe`} />
+                <FormSubmit primary={false} />
               </FormContainer>
             </Form>
           )}
-        </Users.Form>
+        </Form>
       )}
       {isSubscribed && (
         <FormSuccessContainer>

--- a/frontend/src/metabase/setup/components/NewsletterForm/NewsletterForm.tsx
+++ b/frontend/src/metabase/setup/components/NewsletterForm/NewsletterForm.tsx
@@ -1,19 +1,21 @@
-import React, { ChangeEvent, SyntheticEvent, useState } from "react";
+import React, { useState } from "react";
 import { t } from "ttag";
-import Input from "metabase/components/Input";
+import Users from "metabase/entities/users";
 import {
-  FormInputButton,
-  FormInputContainer,
+  FormContainer,
+  FormFieldContainer,
+  FormHeader,
   FormLabel,
   FormLabelCard,
   FormLabelIcon,
   FormLabelText,
-  FormHeader,
   FormRoot,
   FormSuccessContainer,
   FormSuccessIcon,
   FormSuccessText,
 } from "./NewsletterForm.styled";
+import { FormProps } from "./types";
+import { SubscribeInfo } from "../../types";
 
 export interface NewsletterFormProps {
   initialEmail?: string;
@@ -24,21 +26,16 @@ const NewsletterForm = ({
   initialEmail = "",
   onSubscribe,
 }: NewsletterFormProps): JSX.Element => {
-  const [email, setEmail] = useState(initialEmail);
+  const initialValues = { email: initialEmail };
   const [isSubscribed, setIsSubscribed] = useState(false);
 
-  const onChange = (event: ChangeEvent<HTMLInputElement>) => {
-    setEmail(event.currentTarget.value);
-  };
-
-  const onSubmit = (event: SyntheticEvent) => {
-    event.preventDefault();
-    onSubscribe(email);
+  const onSubmit = async ({ email }: SubscribeInfo) => {
+    await onSubscribe(email);
     setIsSubscribed(true);
   };
 
   return (
-    <FormRoot onSubmit={onSubmit}>
+    <FormRoot>
       <FormLabel>
         <FormLabelCard>
           <FormLabelIcon name="mail" />
@@ -49,17 +46,18 @@ const NewsletterForm = ({
         {t`Get infrequent emails about new releases and feature updates.`}
       </FormHeader>
       {!isSubscribed && (
-        <FormInputContainer>
-          <Input
-            name="email"
-            type="email"
-            defaultValue={initialEmail}
-            placeholder={t`Email address`}
-            fullWidth
-            onChange={onChange}
-          />
-          <FormInputButton type="submit">{t`Subscribe`}</FormInputButton>
-        </FormInputContainer>
+        <Users.Form initialValues={initialValues} onSubmit={onSubmit}>
+          {({ Form, FormField, FormSubmit }: FormProps) => (
+            <Form>
+              <FormContainer>
+                <FormFieldContainer>
+                  <FormField name="email" />
+                </FormFieldContainer>
+                <FormSubmit submitTitle={t`Subscribe`} />
+              </FormContainer>
+            </Form>
+          )}
+        </Users.Form>
       )}
       {isSubscribed && (
         <FormSuccessContainer>

--- a/frontend/src/metabase/setup/components/NewsletterForm/NewsletterForm.unit.spec.tsx
+++ b/frontend/src/metabase/setup/components/NewsletterForm/NewsletterForm.unit.spec.tsx
@@ -9,11 +9,11 @@ const FormMock = (props: FormHTMLAttributes<HTMLFormElement>) => (
   </form>
 );
 
+jest.mock("metabase/containers/Form", () => FormMock);
+
 jest.mock("metabase/entities/users", () => ({
   forms: { newsletter: jest.fn() },
 }));
-
-jest.mock("metabase/containers/Form", () => FormMock);
 
 describe("NewsletterForm", () => {
   it("allows to submit the form with an email", async () => {

--- a/frontend/src/metabase/setup/components/NewsletterForm/NewsletterForm.unit.spec.tsx
+++ b/frontend/src/metabase/setup/components/NewsletterForm/NewsletterForm.unit.spec.tsx
@@ -1,18 +1,27 @@
-import React from "react";
+import React, { FormHTMLAttributes } from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import NewsletterForm from "./NewsletterForm";
 
+const FormMock = (props: FormHTMLAttributes<HTMLFormElement>) => (
+  <form {...props}>
+    <button>Subscribe</button>
+  </form>
+);
+
+jest.mock("metabase/entities/users", () => ({
+  forms: { newsletter: jest.fn() },
+}));
+
+jest.mock("metabase/containers/Form", () => FormMock);
+
 describe("NewsletterForm", () => {
-  it("allows to submit the form with an email", () => {
+  it("allows to submit the form with an email", async () => {
     const onSubscribe = jest.fn();
 
     render(<NewsletterForm onSubscribe={onSubscribe} />);
-
-    userEvent.type(screen.getByPlaceholderText("Email address"), "a@b.com");
     userEvent.click(screen.getByText("Subscribe"));
 
-    expect(screen.getByText(/You're subscribed/)).toBeInTheDocument();
-    expect(onSubscribe).toHaveBeenCalledWith("a@b.com");
+    expect(await screen.findByText(/You're subscribed/)).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/setup/components/NewsletterForm/types.ts
+++ b/frontend/src/metabase/setup/components/NewsletterForm/types.ts
@@ -1,0 +1,19 @@
+import { ComponentType } from "react";
+
+export interface FormField {
+  name: string;
+}
+
+export interface FormProps {
+  Form: ComponentType;
+  FormField: ComponentType<FormFieldProps>;
+  FormSubmit: ComponentType<FormSubmitProps>;
+}
+
+export interface FormFieldProps {
+  name: string;
+}
+
+export interface FormSubmitProps {
+  submitTitle?: string;
+}

--- a/frontend/src/metabase/setup/components/NewsletterForm/types.ts
+++ b/frontend/src/metabase/setup/components/NewsletterForm/types.ts
@@ -15,5 +15,6 @@ export interface FormFieldProps {
 }
 
 export interface FormSubmitProps {
+  primary?: boolean;
   submitTitle?: string;
 }

--- a/frontend/src/metabase/setup/types.ts
+++ b/frontend/src/metabase/setup/types.ts
@@ -28,4 +28,8 @@ export interface DatabaseDetails {
   ssl: boolean;
 }
 
+export interface SubscribeInfo {
+  email: string;
+}
+
 export type LocaleData = [string, string];


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/19696

To improve a11y, convert the newsletter to use the standard component for forms.

How to test:
- Run a fresh instance and go through the setup process
- The last step prompts the user to subscribe to the newsletter. Click `Subscribe` and check the request is fired and it succeeds. 