### PR TITLE
Add enter handling to the database delete form/modal

### DIFF
--- a/frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx
+++ b/frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx
@@ -57,7 +57,10 @@ export default class DeleteDatabaseModal extends Component {
         title={t`Delete the ${database.name} database?`}
         onClose={this.props.onClose}
       >
-        <form onSubmit={confirmed ? this.handleSubmit : undefined}>
+        <form
+          className="flex flex-column"
+          onSubmit={confirmed ? this.handleSubmit : undefined}
+        >
           <div className="mb4">
             <p className="text-paragraph">
               {t`All saved questions, metrics, and segments that rely on this database will be lost.`}{" "}

--- a/frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx
+++ b/frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx
@@ -20,7 +20,9 @@ export default class DeleteDatabaseModal extends Component {
     onDelete: PropTypes.func,
   };
 
-  async deleteDatabase() {
+  handleSubmit = async e => {
+    e.preventDefault();
+
     try {
       this.props.onDelete(this.props.database);
       // immediately call on close because database deletion should be non blocking
@@ -28,7 +30,7 @@ export default class DeleteDatabaseModal extends Component {
     } catch (error) {
       this.setState({ error });
     }
-  }
+  };
 
   render() {
     const { confirmValue } = this.state;
@@ -55,33 +57,38 @@ export default class DeleteDatabaseModal extends Component {
         title={t`Delete the ${database.name} database?`}
         onClose={this.props.onClose}
       >
-        <div className="mb4">
-          <p className="text-paragraph">
-            {t`All saved questions, metrics, and segments that rely on this database will be lost.`}{" "}
-            <strong>{t`This cannot be undone.`}</strong>
-          </p>
-          <p className="text-paragraph">
-            {t`If you're sure, please type`} <strong>{database.name}</strong>{" "}
-            {t`in this box:`}
-          </p>
-          <input
-            className="Form-input"
-            type="text"
-            onChange={e => this.setState({ confirmValue: e.target.value })}
-            autoFocus
-          />
-        </div>
+        <form onSubmit={confirmed ? this.handleSubmit : undefined}>
+          <div className="mb4">
+            <p className="text-paragraph">
+              {t`All saved questions, metrics, and segments that rely on this database will be lost.`}{" "}
+              <strong>{t`This cannot be undone.`}</strong>
+            </p>
+            <p className="text-paragraph">
+              {t`If you're sure, please type`} <strong>{database.name}</strong>{" "}
+              {t`in this box:`}
+            </p>
+            <input
+              className="Form-input"
+              type="text"
+              onChange={e => this.setState({ confirmValue: e.target.value })}
+              autoFocus
+            />
+          </div>
 
-        <div className="ml-auto">
-          <Button onClick={this.props.onClose}>{t`Cancel`}</Button>
-          <Button
-            ml={2}
-            danger
-            disabled={!confirmed}
-            onClick={() => this.deleteDatabase()}
-          >{t`Delete`}</Button>
-          {formError}
-        </div>
+          <div className="ml-auto">
+            <Button
+              type="button"
+              onClick={this.props.onClose}
+            >{t`Cancel`}</Button>
+            <Button
+              ml={2}
+              danger
+              type="submit"
+              disabled={!confirmed}
+            >{t`Delete`}</Button>
+            {formError}
+          </div>
+        </form>
       </ModalContent>
     );
   }


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/19696
Fixes https://github.com/metabase/metabase/issues/2059

How to test:
- Go to Admin > Databases
- Click on `Delete` button for a database
- Type the database name
- Press enter. It should delete the database and close the modal
- Also check that clicking `Cancel` closes the form without database deletion