### PR TITLE
Fix error after turning a question into a model

### DIFF
--- a/frontend/src/metabase/visualizations/components/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive.jsx
@@ -110,11 +110,14 @@ export default class TableInteractive extends Component {
   }
 
   UNSAFE_componentWillReceiveProps(newProps) {
-    if (
-      this.props.data &&
-      newProps.data &&
-      !_.isEqual(this.props.data.cols, newProps.data.cols)
-    ) {
+    const { card, data } = this.props;
+    const { card: nextCard, data: nextData } = newProps;
+
+    const isDataChange =
+      data && nextData && !_.isEqual(data.cols, nextData.cols);
+    const isDatasetStatusChange = card.dataset !== nextCard.dataset;
+
+    if (isDataChange && !isDatasetStatusChange) {
       this.resetColumnWidths();
     }
 


### PR DESCRIPTION
This should fix #19546 and fix #19548

When turning a saved question into a model (ex dataset) or back into a question, there are two unexpected things happening:

* the revision history is reloaded and fails due to missing ID and an "Error occurred" message appears in the details sidebar
* the QB turns into an ad-hoc mode, so if you had "Model A" opened, the QB will turn into a question based on the "Model A", instead of just being on the "Model A"

### Background (QB lifecycle for models)

The issue is about the QB lifecycle when we're turning a question into a model and vice-versa.

When a saved question is open in the QB, you can modify the query and either replace the question with the new changes or save them as a new question.

<details>
<summary>Example</summary>

Let's say we have a query based on some table and joining another table

```js
{
    "source-table": 1,
    "joins": [ /* some joins in here */ ]
}
```

We can add a filter to it using the UI and then replace the original question or save it as a new question

```js
{
    "source-table": 1,
    "joins": [ /* some joins in here */ ],
    "filter": [ /* now with some data filtered */ ],
}
```
</details>

We need a slightly different behavior for models. Models opened in the QB should behave as if you're browsing a table in "Simple Mode". So the QB should start with a clean query, but with the model used as a source table.

<details>
<summary>Example</summary>

Let's say we have a model with `id: 14`. When you open it in the QB and add a filter or something, you should end up with a query looking like

```js
{
    "source-table": "card__14",
    "filter": [ /* some filters */ ]
}
```
</details>

But we still want to keep some "saved question behaviors" when opening a model (like being able to rename, duplicate the model, go to the query/metadata editor, etc.), so it's a bit tricky. You can learn more and see the implementation in #19101

### Root cause

When you turn a question into a model or vice-versa, we need to rerun the query to refresh metadata and change the visualization to "table" if any other viz was selected. Field metadata can change after that, so queries `results` might end up different. This triggers a sequence of events causing the bugs

1. Question is turned into a model or vice-versa
2. Once the change is done, we're rerunning the query
3. Metadata changes and `TableInteractive` triggers column widths reset: it triggers a question update with column widths reset in `visualization_settings`
4. The update is handled the same way as if you resize a column manually or modify the question in any other way: the FE turns into "we're now building a new question based on a model" mode by dropping the question's ID, description, and some other fields. This is #19548
5. Looks like the QB doesn't land in the ad-hoc mode properly and tries to refresh the revisions, but it fails because the card ID was removed in the previous step. This is #19546

I tried to ban the column widths reset action in the `qb/actions` or anywhere closer to the business logic, but it's not that simple. The original idea was to compare `state.qb.originalCard.dataset` and `state.qb.card.dataset` in `updateCardVisualizationSettings` ([link](updateCardVisualizationSettings)), but the `originalCard` gets replaced after a question is turned into a model, so `originalCard` and `card` have the same `dataset` field value and it's not possible to distinguish the events

### To Verify

1. Open SQL / GUI question
2. Click the title to open the details sidebar
3. Click the model icon ("waffle") to turn it into a model
4. Ensure there is no error message in the sidebar
5. Ensure you're still on the model page (no message like "question started from ..." in the header and the URL is `dataset/:id`

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/149808487-b07150d6-12da-4509-adf6-cb1fc7891836.mov

**After**

https://user-images.githubusercontent.com/17258145/149808477-cc955597-89f5-401d-9749-086d5dea6f3b.mov

