### PR TITLE
Fix 19704 - Use "folder" icon for collections everywhere

### DIFF
--- a/frontend/src/metabase/admin/permissions/pages/CollectionPermissionsPage/CollectionPermissionsPage.jsx
+++ b/frontend/src/metabase/admin/permissions/pages/CollectionPermissionsPage/CollectionPermissionsPage.jsx
@@ -106,7 +106,7 @@ function CollectionsPermissionsPage({
 
       {!permissionEditor && (
         <PermissionsEditorEmptyState
-          icon="all"
+          icon="folder"
           message={t`Select a collection to see its permissions`}
         />
       )}

--- a/frontend/src/metabase/home/containers/SearchApp.jsx
+++ b/frontend/src/metabase/home/containers/SearchApp.jsx
@@ -31,7 +31,7 @@ const SEARCH_FILTERS = [
   {
     name: t`Collections`,
     filter: "collection",
-    icon: "all",
+    icon: "folder",
   },
   {
     name: t`Databases`,

--- a/frontend/src/metabase/nav/containers/Navbar.jsx
+++ b/frontend/src/metabase/nav/containers/Navbar.jsx
@@ -193,7 +193,7 @@ export default class Navbar extends Component {
               },
               {
                 title: t`Collection`,
-                icon: `all`,
+                icon: `folder`,
                 action: () => this.setModal(MODAL_NEW_COLLECTION),
                 event: `NavBar;New Collection Click;`,
               },


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- Replaces icons for collections across different pages in our app and sets the "folder" icon as the default one
- Fixes #19704 

### How to test?

1. Search app (`/search`)
![image](https://user-images.githubusercontent.com/31325167/149816119-a0ecb718-aeeb-46e7-9595-07d983338ca3.png)


2. Collections permissions (`/admin/permissions/collections`)
![image](https://user-images.githubusercontent.com/31325167/149816092-7fb05034-93a1-4897-b28c-69904893eaf3.png)

3. "New" dropdown
![image](https://user-images.githubusercontent.com/31325167/149816146-4e832005-2147-4982-9457-34069711556c.png)
