### PR TITLE
Update datasets' route to `model`

### DIFF
--- a/frontend/src/metabase/lib/urls.js
+++ b/frontend/src/metabase/lib/urls.js
@@ -50,7 +50,7 @@ export function question(card, hash = "", query = "") {
 
   const { card_id, id, name } = card;
   const basePath =
-    card?.dataset || card?.model === "dataset" ? "dataset" : "question";
+    card?.dataset || card?.model === "dataset" ? "model" : "question";
 
   /**
    * If the question has been added to the dashboard we're reading the dashCard's properties.

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -492,7 +492,7 @@ export const initializeQB = (location, params, queryParams) => {
           card = null;
         }
 
-        if (!card.dataset && location.pathname.startsWith("/dataset")) {
+        if (!card.dataset && location.pathname.startsWith("/model")) {
           dispatch(
             setErrorPage({
               data: {

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -236,7 +236,7 @@ export const getRoutes = store => (
           <Route path=":slug/notebook" component={QueryBuilder} />
         </Route>
 
-        <Route path="/dataset">
+        <Route path="/model">
           <IndexRoute component={QueryBuilder} />
           <Route path="notebook" component={QueryBuilder} />
           <Route path=":slug" component={QueryBuilder} />

--- a/frontend/test/__support__/e2e/commands/api/question.js
+++ b/frontend/test/__support__/e2e/commands/api/question.js
@@ -74,7 +74,7 @@ function question(
 
     if (loadMetadata || visitQuestion) {
       cy.intercept("POST", `/api/card/${body.id}/query`).as("cardQuery");
-      const url = dataset ? `/dataset/${body.id}` : `/question/${body.id}`;
+      const url = dataset ? `/model/${body.id}` : `/question/${body.id}`;
       cy.visit(url);
 
       // Wait for `result_metadata` to load

--- a/frontend/test/metabase/lib/urls.unit.spec.js
+++ b/frontend/test/metabase/lib/urls.unit.spec.js
@@ -67,17 +67,17 @@ describe("urls", () => {
       });
     });
 
-    describe("dataset", () => {
-      it("returns /dataset URLS", () => {
+    describe("model", () => {
+      it("returns /model URLS", () => {
         expect(question({ id: 1, dataset: true, name: "Foo" })).toEqual(
-          "/dataset/1-foo",
+          "/model/1-foo",
         );
         expect(
           question({ id: 1, card_id: 42, dataset: true, name: "Foo" }),
-        ).toEqual("/dataset/42-foo");
+        ).toEqual("/model/42-foo");
         expect(
           question({ id: 1, card_id: 42, model: "dataset", name: "Foo" }),
-        ).toEqual("/dataset/42-foo");
+        ).toEqual("/model/42-foo");
       });
     });
   });

--- a/frontend/test/metabase/scenarios/models/models-query-editor.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models-query-editor.cy.spec.js
@@ -22,7 +22,7 @@ describe("scenarios > models query editor", () => {
 
   it("allows to edit GUI model query", () => {
     cy.request("PUT", "/api/card/1", { dataset: true });
-    cy.visit("/dataset/1");
+    cy.visit("/model/1");
 
     openDetailsSidebar();
     cy.findByText("Edit query definition").click();
@@ -49,10 +49,10 @@ describe("scenarios > models query editor", () => {
     cy.button("Save changes").click();
     cy.wait("@updateCard");
 
-    cy.url().should("include", "/dataset/1");
+    cy.url().should("include", "/model/1");
     cy.url().should("not.include", "/query");
 
-    cy.visit("/dataset/1/query");
+    cy.visit("/model/1/query");
     getNotebookStep("summarize").within(() => {
       cy.findByText("Created At: Month");
       cy.findByText("Count");
@@ -63,7 +63,7 @@ describe("scenarios > models query editor", () => {
     });
 
     cy.button("Cancel").click();
-    cy.url().should("include", "/dataset/1");
+    cy.url().should("include", "/model/1");
     cy.url().should("not.include", "/query");
 
     cy.go("back");
@@ -72,7 +72,7 @@ describe("scenarios > models query editor", () => {
 
   it("locks display to table", () => {
     cy.request("PUT", "/api/card/1", { dataset: true });
-    cy.visit("/dataset/1/query");
+    cy.visit("/model/1/query");
 
     cy.findByTestId("action-buttons")
       .findByText("Join data")

--- a/frontend/test/metabase/scenarios/models/models-query-editor.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models-query-editor.cy.spec.js
@@ -29,7 +29,7 @@ describe("scenarios > models query editor", () => {
 
     getNotebookStep("data").findByText("Orders");
     cy.get(".TableInteractive");
-    cy.url().should("match", /\/dataset\/[1-9]\d*.*\/query/);
+    cy.url().should("match", /\/model\/[1-9]\d*.*\/query/);
 
     cy.findByTestId("action-buttons")
       .findByText("Summarize")
@@ -67,7 +67,7 @@ describe("scenarios > models query editor", () => {
     cy.url().should("not.include", "/query");
 
     cy.go("back");
-    cy.url().should("match", /\/dataset\/[1-9]\d*.*\/query/);
+    cy.url().should("match", /\/model\/[1-9]\d*.*\/query/);
   });
 
   it("locks display to table", () => {
@@ -114,7 +114,7 @@ describe("scenarios > models query editor", () => {
 
     cy.get(".ace_content").as("editor");
     cy.get(".TableInteractive");
-    cy.url().should("match", /\/dataset\/[1-9]\d*.*\/query/);
+    cy.url().should("match", /\/model\/[1-9]\d*.*\/query/);
 
     cy.get("@editor").type(
       " LEFT JOIN products ON orders.PRODUCT_ID = products.ID",
@@ -129,7 +129,7 @@ describe("scenarios > models query editor", () => {
     cy.button("Save changes").click();
     cy.wait("@updateCard");
 
-    cy.url().should("match", /\/dataset\/[1-9]\d*.*\d/);
+    cy.url().should("match", /\/model\/[1-9]\d*.*\d/);
     cy.url().should("not.include", "/query");
 
     cy.findByText("Edit query definition").click();
@@ -140,7 +140,7 @@ describe("scenarios > models query editor", () => {
     });
 
     cy.button("Cancel").click();
-    cy.url().should("match", /\/dataset\/[1-9]\d*.*\d/);
+    cy.url().should("match", /\/model\/[1-9]\d*.*\d/);
     cy.url().should("not.include", "/query");
   });
 });

--- a/frontend/test/metabase/scenarios/models/models.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models.cy.spec.js
@@ -165,12 +165,12 @@ describe("scenarios > models", () => {
     cy.findByText(/We're a little lost/i);
   });
 
-  it("redirects to /dataset URL when opening a model with /question URL", () => {
+  it("redirects to /model URL when opening a model with /question URL", () => {
     cy.request("PUT", "/api/card/1", { dataset: true });
     cy.visit("/question/1");
     openDetailsSidebar();
     assertIsModel();
-    cy.url().should("include", "/dataset");
+    cy.url().should("include", "/model");
   });
 
   describe("data picker", () => {

--- a/frontend/test/metabase/scenarios/models/models.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models.cy.spec.js
@@ -146,7 +146,7 @@ describe("scenarios > models", () => {
   it("allows to turn a model back into a saved question", () => {
     cy.request("PUT", "/api/card/1", { dataset: true });
     cy.intercept("PUT", "/api/card/1").as("cardUpdate");
-    cy.visit("/dataset/1");
+    cy.visit("/model/1");
 
     openDetailsSidebar();
     cy.findByText("Turn back into a saved question").click();
@@ -161,7 +161,7 @@ describe("scenarios > models", () => {
   });
 
   it("shows 404 when opening a question with a /dataset URL", () => {
-    cy.visit("/dataset/1");
+    cy.visit("/model/1");
     cy.findByText(/We're a little lost/i);
   });
 


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- As stated in #19668, there are some important parts in the code that need to be updated in order to reflect the change from `dataset` to `model`
- This PR fixes the route for all models

### How to test?
- All tests should pass (unit, e2e)
- Manually:

#### Existing model
- should have url in the form `/model/:id-slug`
- if you visit the model via `/question/:id`, it should convert it to `/model/:id-slug`

#### Non-existing model
- try to visit a question (not a model) with `/model/:id` - it should give you 404
- try to visit non-existing model id `/model/:id` - it should give you 404