### PR TITLE
Truncate static viz legend items

### DIFF
--- a/frontend/src/metabase/static-viz/components/TimeSeriesWaterfallChart/TimeSeriesWaterfallChart.jsx
+++ b/frontend/src/metabase/static-viz/components/TimeSeriesWaterfallChart/TimeSeriesWaterfallChart.jsx
@@ -59,7 +59,7 @@ const layout = {
     waterfallPositive: "#88BF4D",
     waterfallNegative: "#EF8C8C",
   },
-  numTicks: 5,
+  numTicks: 4,
   barPadding: 0.2,
   labelFontWeight: 700,
   labelPadding: 12,

--- a/frontend/src/metabase/static-viz/components/XYChart/Legend/Legend.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/Legend/Legend.tsx
@@ -1,57 +1,63 @@
 import React from "react";
 import { Group } from "@visx/group";
 import { LegendItem } from "./LegendItem";
-
-type LegendItem = {
-  top: number;
-  label: string;
-  color: string;
-};
+import { LegendItemData } from "../utils";
 
 type LegendProps = {
-  legend: {
-    leftItems?: LegendItem[];
-    rightItems?: LegendItem[];
-    columnWidth: number;
-    maxTextWidth: number;
-  };
-  width: number;
+  leftColumn: LegendItemData[];
+  rightColumn: LegendItemData[];
   top: number;
-  left: number;
+  width: number;
+  padding: number;
+  lineHeight: number;
+  fontSize: number;
 };
 
-export const Legend = ({ legend, top, left, width }: LegendProps) => {
-  const { leftItems, rightItems, columnWidth, maxTextWidth } = legend;
+export const Legend = ({
+  leftColumn,
+  rightColumn,
+  top,
+  width,
+  padding,
+  lineHeight,
+  fontSize,
+}: LegendProps) => {
+  const columnWidth = width / 2;
+  const innerWidth = columnWidth - padding;
 
   return (
-    <Group left={left} top={top}>
+    <Group left={padding} top={top}>
       <Group>
-        {leftItems?.map(item => {
+        {leftColumn?.map((item, index) => {
           return (
             <LegendItem
-              key={item.label}
-              top={item.top}
+              left={padding}
+              key={index}
+              top={index * lineHeight}
               align="left"
-              width={columnWidth}
-              textWidth={maxTextWidth}
-              label={item.label}
+              width={rightColumn.length > 0 ? innerWidth : width}
+              label={item.name}
               color={item.color}
+              fontSize={fontSize}
+              lineHeight={lineHeight}
             />
           );
         })}
       </Group>
 
-      <Group left={width}>
-        {rightItems?.map(item => {
+      <Group left={columnWidth}>
+        {rightColumn?.map((item, index) => {
           return (
             <LegendItem
-              key={item.label}
-              top={item.top}
+              key={index}
+              top={index * lineHeight}
               align="right"
-              width={columnWidth}
-              textWidth={maxTextWidth}
-              label={item.label}
+              left={columnWidth - padding * 2}
+              width={leftColumn.length > 0 ? innerWidth : width}
+              label={item.name}
               color={item.color}
+              fontSize={fontSize}
+              lineHeight={lineHeight}
             />
           );
         })}

--- a/frontend/src/metabase/static-viz/components/XYChart/Legend/LegendItem.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/Legend/LegendItem.tsx
@@ -3,8 +3,12 @@ import { Group } from "@visx/group";
 import { Text } from "metabase/static-viz/components/Text";
 import {
   LEGEND_CIRCLE_SIZE,
+  LEGEND_COLUMNS_MARGIN,
   LEGEND_TEXT_MARGIN,
 } from "metabase/static-viz/components/XYChart/constants";
+import { truncateText } from "metabase/static-viz/lib/text";
+
+const FONT_WEIGHT = 700;
 
 type LegendItemProps = {
   label: string;
@@ -12,8 +16,9 @@ type LegendItemProps = {
   top?: number;
   left?: number;
   width: number;
-  textWidth: number;
   align?: "left" | "right";
+  fontSize: number;
+  lineHeight: number;
 };
 
 export const LegendItem = ({
@@ -22,13 +27,20 @@ export const LegendItem = ({
   left,
   top,
   width,
-  textWidth,
+  fontSize,
+  lineHeight,
   align = "left",
 }: LegendItemProps) => {
   const radius = LEGEND_CIRCLE_SIZE / 2;
   const textAnchor = align === "left" ? "start" : "end";
   const textX = align === "left" ? LEGEND_TEXT_MARGIN : -LEGEND_TEXT_MARGIN;
   const circleCX = align === "left" ? radius : -radius;
+  const truncatedLabel = truncateText(
+    label,
+    width - LEGEND_TEXT_MARGIN - LEGEND_COLUMNS_MARGIN,
+    fontSize,
+    FONT_WEIGHT,
+  );
 
   return (
     <Group left={left} top={top} width={width}>
@@ -36,12 +48,12 @@ export const LegendItem = ({
       <Text
         textAnchor={textAnchor}
         verticalAnchor="start"
-        width={textWidth}
         x={textX}
-        fontWeight={700}
-        fontSize={13}
+        fontWeight={FONT_WEIGHT}
+        lineHeight={lineHeight}
+        fontSize={fontSize}
       >
-        {label}
+        {truncatedLabel}
       </Text>
     </Group>
   );

--- a/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
@@ -104,7 +104,7 @@ export const XYChart = ({
     xTicksDimensions.maxTextWidth,
     xScale.bandwidth,
   );
-  const xTicksCount = settings.x.type === "ordinal" ? Infinity : 5;
+  const xTicksCount = settings.x.type === "ordinal" ? Infinity : 4;
 
   const labelProps: Partial<TextProps> = {
     fontWeight: style.axes.labels.fontWeight,

--- a/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
@@ -27,10 +27,10 @@ import {
   calculateMargin,
   getXTicksDimensions,
   getXTickWidthLimit,
-  calculateLegendItems,
   calculateBounds,
   calculateYDomains,
   sortSeries,
+  getLegendColumns,
 } from "metabase/static-viz/components/XYChart/utils";
 import { GoalLine } from "metabase/static-viz/components/XYChart/GoalLine";
 
@@ -95,13 +95,9 @@ export const XYChart = ({
 
   const defaultYScale = yScaleLeft || yScaleRight;
 
-  const legendWidth = width - 2 * CHART_PADDING;
-  const legend = calculateLegendItems(
-    series,
-    legendWidth,
-    style.legend.lineHeight,
-    style.legend.fontSize,
-  );
+  const { leftColumn, rightColumn } = getLegendColumns(series);
+  const legendHeight =
+    Math.max(leftColumn.length, rightColumn.length) * style.legend.lineHeight;
 
   const xTickWidthLimit = getXTickWidthLimit(
     settings.x,
@@ -128,7 +124,7 @@ export const XYChart = ({
   const areXTicksRotated = settings.x.tick_display === "rotate-45";
 
   return (
-    <svg width={width} height={height + legend.height}>
+    <svg width={width} height={height + legendHeight}>
       <Group top={margin.top} left={xMin}>
         {defaultYScale && (
           <GridRows
@@ -232,10 +228,13 @@ export const XYChart = ({
       />
 
       <Legend
-        legend={legend}
-        left={CHART_PADDING}
+        leftColumn={leftColumn}
+        rightColumn={rightColumn}
+        padding={CHART_PADDING}
         top={height}
-        width={legendWidth}
+        width={width}
+        lineHeight={style.legend.lineHeight}
+        fontSize={style.legend.fontSize}
       />
     </svg>
   );

--- a/frontend/src/metabase/static-viz/components/XYChart/constants.ts
+++ b/frontend/src/metabase/static-viz/components/XYChart/constants.ts
@@ -6,3 +6,4 @@ export const LABEL_PADDING = 12;
 
 export const LEGEND_CIRCLE_SIZE = 10;
 export const LEGEND_TEXT_MARGIN = LEGEND_CIRCLE_SIZE * 2;
+export const LEGEND_COLUMNS_MARGIN = 24;

--- a/frontend/src/metabase/static-viz/components/XYChart/utils/legend.ts
+++ b/frontend/src/metabase/static-viz/components/XYChart/utils/legend.ts
@@ -1,104 +1,34 @@
-import { measureText } from "metabase/static-viz/lib/text";
-import { LEGEND_TEXT_MARGIN } from "metabase/static-viz/components/XYChart/constants";
 import { Series } from "metabase/static-viz/components/XYChart/types";
 import { partitionByYAxis } from "metabase/static-viz/components/XYChart/utils";
 
-const calculateLegendItemHeight = (
-  label: string,
-  maxTextWidth: number,
-  lineHeight: number,
-  fontSize: number,
-) => {
-  const linesCount = Math.ceil(measureText(label, fontSize) / maxTextWidth);
-  return linesCount * lineHeight;
+export type LegendItemData = {
+  name: string;
+  color: string;
 };
 
-const calculateLegendColumn = (
-  columnSeries: Series[],
-  maxTextWidth: number,
-  lineHeight: number,
-  fontSize: number,
-) => {
-  let currentOffset = 0;
+const getLegendItem = (series: Series): LegendItemData => ({
+  name: series.name,
+  color: series.color,
+});
 
-  const items = columnSeries.map(series => {
-    const item = {
-      color: series.color,
-      label: series.name,
-      top: currentOffset,
-    };
-
-    currentOffset += calculateLegendItemHeight(
-      item.label,
-      maxTextWidth,
-      lineHeight,
-      fontSize,
-    );
-
-    return item;
-  });
-
-  return {
-    items,
-    columnHeight: currentOffset,
-  };
-};
-
-export const calculateLegendItems = (
-  series: Series[],
-  width: number,
-  lineHeight: number,
-  fontSize: number,
-) => {
-  const columnWidth = width / 2;
-  const maxTextWidth = columnWidth - LEGEND_TEXT_MARGIN * 2;
-  const [leftSeries, rightSeries] = partitionByYAxis(series);
-
-  if (leftSeries?.length > 0 && rightSeries?.length > 0) {
-    const leftColumn = calculateLegendColumn(
-      leftSeries,
-      maxTextWidth,
-      lineHeight,
-      fontSize,
-    );
-    const rightColumn = calculateLegendColumn(
-      rightSeries,
-      maxTextWidth,
-      lineHeight,
-      fontSize,
-    );
-
+export const getLegendColumns = (series: Series[]) => {
+  if (series.length < 2) {
     return {
-      leftItems: leftColumn.items,
-      rightItems: rightColumn.items,
-      height: Math.max(leftColumn.columnHeight, rightColumn.columnHeight),
-      columnWidth,
-      maxTextWidth,
+      leftColumn: [],
+      rightColumn: [],
     };
   }
 
-  const singleColumnSeries = leftSeries?.length > 0 ? leftSeries : rightSeries;
+  let [leftColumn, rightColumn] = partitionByYAxis(series);
 
-  if (singleColumnSeries.length < 2) {
-    return {
-      height: 0,
-      columnWidth: 0,
-      maxTextWidth: 0,
-    };
+  // Always show legend in the left column for a single Y-axis
+  if (leftColumn.length === 0) {
+    leftColumn = rightColumn;
+    rightColumn = [];
   }
 
-  const singleColumnTextWidth = width - LEGEND_TEXT_MARGIN * 2;
-  const leftColumn = calculateLegendColumn(
-    singleColumnSeries,
-    singleColumnTextWidth,
-    lineHeight,
-    fontSize,
-  );
-
   return {
-    leftItems: leftColumn.items,
-    height: leftColumn.columnHeight,
-    columnWidth: singleColumnTextWidth,
-    maxTextWidth: singleColumnTextWidth,
+    leftColumn: leftColumn.map(getLegendItem),
+    rightColumn: rightColumn.map(getLegendItem),
   };
 };

--- a/frontend/src/metabase/static-viz/components/XYChart/utils/legend.unit.spec.ts
+++ b/frontend/src/metabase/static-viz/components/XYChart/utils/legend.unit.spec.ts
@@ -1,9 +1,5 @@
 import { YAxisPosition } from "./../types";
-import { calculateLegendItems } from "./legend";
-
-const width = 500;
-const lineHeight = 10;
-const fontSize = 13;
+import { getLegendColumns } from "./legend";
 
 const defaultColor = "#509ee3";
 
@@ -25,19 +21,13 @@ const createSeries = ({
   };
 };
 
-describe("calculateLegendItems", () => {
+describe("getLegendColumns", () => {
   it("returns no legend items for a single series", () => {
     const series = [createSeries()];
-    const { leftItems, rightItems, height } = calculateLegendItems(
-      series,
-      width,
-      lineHeight,
-      fontSize,
-    );
+    const { leftColumn, rightColumn } = getLegendColumns(series);
 
-    expect(leftItems).not.toBeDefined();
-    expect(rightItems).not.toBeDefined();
-    expect(height).toBe(0);
+    expect(leftColumn).toHaveLength(0);
+    expect(rightColumn).toHaveLength(0);
   });
 
   it("returns left column items for two series that use a single Y-axis", () => {
@@ -45,19 +35,13 @@ describe("calculateLegendItems", () => {
       createSeries({ name: "line 1", yAxisPosition: "right" }),
       createSeries({ name: "line 2", yAxisPosition: "right" }),
     ];
-    const { leftItems, rightItems, height } = calculateLegendItems(
-      series,
-      width,
-      lineHeight,
-      fontSize,
-    );
+    const { leftColumn, rightColumn } = getLegendColumns(series);
 
-    expect(leftItems).toStrictEqual([
-      { color: "#509ee3", label: "line 1", top: 0 },
-      { color: "#509ee3", label: "line 2", top: 10 },
+    expect(leftColumn).toStrictEqual([
+      { color: "#509ee3", name: "line 1" },
+      { color: "#509ee3", name: "line 2" },
     ]);
-    expect(rightItems).not.toBeDefined();
-    expect(height).toBe(20);
+    expect(rightColumn).toHaveLength(0);
   });
 
   it("returns two column multiple series that use both Y-axes", () => {
@@ -68,24 +52,17 @@ describe("calculateLegendItems", () => {
       createSeries({ name: "line left 1", yAxisPosition: "left" }),
       createSeries({ name: "line left 2", yAxisPosition: "left" }),
     ];
-    const { leftItems, rightItems, height } = calculateLegendItems(
-      series,
-      width,
-      lineHeight,
-      fontSize,
-    );
+    const { leftColumn, rightColumn } = getLegendColumns(series);
 
-    expect(leftItems).toStrictEqual([
-      { color: "#509ee3", label: "line left 1", top: 0 },
-      { color: "#509ee3", label: "line left 2", top: 10 },
+    expect(leftColumn).toStrictEqual([
+      { color: "#509ee3", name: "line left 1" },
+      { color: "#509ee3", name: "line left 2" },
     ]);
 
-    expect(rightItems).toStrictEqual([
-      { color: "#509ee3", label: "line right 1", top: 0 },
-      { color: "#509ee3", label: "line right 2", top: 10 },
-      { color: "#509ee3", label: "line right 3", top: 20 },
+    expect(rightColumn).toStrictEqual([
+      { color: "#509ee3", name: "line right 1" },
+      { color: "#509ee3", name: "line right 2" },
+      { color: "#509ee3", name: "line right 3" },
     ]);
-
-    expect(height).toBe(30);
   });
 });

--- a/frontend/src/metabase/static-viz/lib/text.ts
+++ b/frontend/src/metabase/static-viz/lib/text.ts
@@ -1,32 +1,47 @@
 const CHAR_ELLIPSES = "…";
+const DEFAULT_FONT_WEIGHT = 400;
 
 // TODO: Replace this rough simple approximation with a correct one
-const getCharWidth = (fontSize: number) => {
+const getCharWidth = (fontSize: number, fontWeight: number) => {
+  const fontWeightDivider = Math.sqrt(fontWeight / DEFAULT_FONT_WEIGHT);
+
   if (fontSize <= 12) {
-    return fontSize / 2.15;
+    return fontSize / (2.15 * fontWeightDivider);
   }
 
   if (fontSize <= 16) {
-    return fontSize / 1.84;
+    return fontSize / (1.84 * fontWeightDivider);
   }
 
-  return fontSize / 1.7;
+  return fontSize / (1.7 * fontWeightDivider);
 };
 
-export const measureText = (text: string, fontSize: number) => {
-  return text.length * getCharWidth(fontSize);
+export const measureText = (
+  text: string,
+  fontSize: number,
+  fontWeight = DEFAULT_FONT_WEIGHT,
+) => {
+  return text.length * getCharWidth(fontSize, fontWeight);
 };
 
 export const measureTextHeight = (fontSize: number) => {
   return fontSize * 1.3;
 };
 
-export const truncateText = (text: string, width: number, fontSize: number) => {
-  if (measureText(text, fontSize) <= width) {
+export const truncateText = (
+  text: string,
+  width: number,
+  fontSize: number,
+  fontWeight = DEFAULT_FONT_WEIGHT,
+) => {
+  if (measureText(text, fontSize, fontWeight) <= width) {
     return text;
   }
 
-  while (text.length && measureText(text + CHAR_ELLIPSES, fontSize) > width) {
+  while (
+    text.length &&
+    measureText(text + CHAR_ELLIPSES, fontSize, fontWeight) > width
+  ) {
     text = text.substring(0, text.length - 1).trim();
   }
 


### PR DESCRIPTION
Since we cannot measure text width in the static viz environment precisely enough to make a custom text wrap function, we can show only one truncated line per series in charts legend.

Also, I reduced the number of X-ticks to avoid overlaps.

### Screenshot
<img width="591" alt="Screenshot 2022-01-17 at 22 24 37" src="https://user-images.githubusercontent.com/14301985/149843959-30955977-26d3-41bc-8054-455e8f9f06d7.png">