### PR TITLE
Update `dataset` to `model` references in the activity page

### DIFF
--- a/frontend/src/metabase/home/components/Activity.jsx
+++ b/frontend/src/metabase/home/components/Activity.jsx
@@ -153,7 +153,7 @@ export default class Activity extends Component {
           description.summary = (
             <span>
               {item.model === "dataset"
-                ? t`saved a dataset based on `
+                ? t`saved a model based on `
                 : t`saved a question about `}
               <Link
                 to={Urls.tableRowsQuery(item.database_id, item.table_id)}
@@ -168,14 +168,12 @@ export default class Activity extends Component {
           );
         } else {
           description.summary =
-            item.model === "dataset" ? t`saved a dataset` : t`saved a question`;
+            item.model === "dataset" ? t`saved a model` : t`saved a question`;
         }
         break;
       case "card-delete":
         description.summary =
-          item.model === "dataset"
-            ? t`deleted a dataset`
-            : t`deleted a question`;
+          item.model === "dataset" ? t`deleted a model` : t`deleted a question`;
         break;
       case "dashboard-create":
         description.summary = t`created a dashboard`;


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Updates the previously missed references of `dataset` to `model` in the `/activity` page

Before
![image](https://user-images.githubusercontent.com/31325167/149853863-32abf409-0d50-4643-ab27-f1335ccbaa96.png)

After
![image](https://user-images.githubusercontent.com/31325167/149853948-718ba310-2c2d-4ce4-ac0c-651aaa25f867.png)
