### PR TITLE
Fix native model results disappear when leaving query editor

### DIFF
--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
@@ -114,6 +114,11 @@ function DatasetEditor(props) {
                 isInitiallyOpen
                 viewHeight={height}
                 hasParametersList={false}
+                // We need to rerun the query after saving changes or canceling edits
+                // By default, NativeQueryEditor cancels an active query on unmount,
+                // which can also cancel the expected query rerun
+                // (see https://github.com/metabase/metabase/issues/19180)
+                cancelQueryOnLeave={false}
               />
             ) : (
               <ResizableNotebook

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
@@ -84,6 +84,7 @@ export default class NativeQueryEditor extends Component {
 
   static defaultProps = {
     isOpen: false,
+    cancelQueryOnLeave: true,
   };
 
   UNSAFE_componentWillMount() {
@@ -177,7 +178,9 @@ export default class NativeQueryEditor extends Component {
   }
 
   componentWillUnmount() {
-    this.props.cancelQuery();
+    if (this.props.cancelQueryOnLeave) {
+      this.props.cancelQuery();
+    }
     document.removeEventListener("keydown", this.handleKeyDown);
     document.removeEventListener("contextmenu", this.handleRightClick);
   }

--- a/frontend/test/metabase/scenarios/models/reproductions/19180-native-model-results-disappear.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/reproductions/19180-native-model-results-disappear.cy.spec.js
@@ -1,0 +1,30 @@
+import { restore } from "__support__/e2e/cypress";
+
+const QUESTION = {
+  native: { query: "select * from products" },
+};
+
+describe("issue 19180", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+    cy.intercept("/api/card/*/query").as("cardQuery");
+  });
+
+  it("shouldn't drop native model query results after leaving the query editor", () => {
+    cy.createNativeQuestion(QUESTION).then(({ body: { id: QUESTION_ID } }) => {
+      cy.request("PUT", `/api/card/${QUESTION_ID}`, { dataset: true }).then(
+        () => {
+          cy.visit(`/model/${QUESTION_ID}/query`);
+          cy.wait("@cardQuery");
+          cy.button("Cancel").click();
+          cy.wait("@cardQuery");
+          cy.get(".TableInteractive");
+          cy.findByText("Here's where your results will appear").should(
+            "not.exist",
+          );
+        },
+      );
+    });
+  });
+});


### PR DESCRIPTION
Reproduces #19180, fixes #19180

When clicking "Cancel" on the native model query editor, the query results disappear, so you need to either refresh the page or click the refresh button to see the results again. When clicking "Cancel", we need to rerun the original query (before any changes) to display the correct results. But `NativeQueryEditor` cancels any active query when it unmounts, including the actually necessary query.

### To Verify

1. Create any native question and convert it into a model
2. Go to `/model/$YOUR_MODEL_ID/query`
3. Click "Cancel"
4. You should see a regular table view with model data in place

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/149937596-79aa2100-fdd1-4dca-8a50-f0ac2a204098.mov

**After**

https://user-images.githubusercontent.com/17258145/149937613-0e8cefa4-ab2c-4589-9d74-e4e87319a9fb.mov
