### PR TITLE
Allow using models in native queries and dashboards

### DIFF
--- a/frontend/src/metabase/containers/QuestionPicker.jsx
+++ b/frontend/src/metabase/containers/QuestionPicker.jsx
@@ -11,7 +11,7 @@ const QuestionPicker = ({ value, onChange, maxHeight, ...props }) => (
     style={maxHeight != null ? { maxHeight } : {}}
     value={value === undefined ? undefined : { model: "card", id: value }}
     onChange={question => onChange(question ? question.id : undefined)}
-    models={["card"]}
+    models={["card", "dataset"]}
   />
 );
 

--- a/frontend/src/metabase/dashboard/components/add-card-sidebar/QuestionList.jsx
+++ b/frontend/src/metabase/dashboard/components/add-card-sidebar/QuestionList.jsx
@@ -37,7 +37,7 @@ export function QuestionList({
 
   query = {
     ...query,
-    models: "card",
+    models: ["card", "dataset"],
     limit: DEFAULT_SEARCH_LIMIT,
   };
 
@@ -61,7 +61,10 @@ export function QuestionList({
                 key={item.id}
                 id={item.id}
                 name={item.getName()}
-                icon={item.getIcon().name}
+                icon={{
+                  name: item.getIcon().name,
+                  size: item.model === "dataset" ? 18 : 16,
+                }}
                 onSelect={onSelect}
                 rightIcon={PLUGIN_MODERATION.getStatusIcon(
                   item.moderated_status,

--- a/frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx
@@ -58,9 +58,9 @@ export default class CardTagEditor extends Component {
     return (
       <SelectButton>
         {tag["card-id"] == null ? (
-          <span className="text-medium">{t`Pick a saved question`}</span>
+          <span className="text-medium">{t`Pick a question or a model`}</span>
         ) : this.errorMessage() ? (
-          <span className="text-medium">{t`Pick a different question`}</span>
+          <span className="text-medium">{t`Pick a different question or a model`}</span>
         ) : question ? (
           question.name
         ) : (
@@ -84,7 +84,9 @@ export default class CardTagEditor extends Component {
           {cardId == null ? (
             t`Question #…`
           ) : (
-            <Link to={this.getQuestionUrl()}>{t`Question #${cardId}`}</Link>
+            <Link to={this.getQuestionUrl()}>
+              {question.dataset ? t`Model #${cardId}` : t`Question #${cardId}`}
+            </Link>
           )}
         </h3>
         {loading ? (

--- a/frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx
@@ -2,6 +2,7 @@
 import React, { Component } from "react";
 import { Link } from "react-router";
 import { t } from "ttag";
+import cx from "classnames";
 
 import Icon from "metabase/components/Icon";
 import QuestionPicker from "metabase/containers/QuestionPicker";
@@ -115,7 +116,9 @@ export default class CardTagEditor extends Component {
                 <Icon name="all" size={12} mr={1} /> {question.collection.name}
               </div>
             )}
-            <div className="flex align-center mt1">
+            <div
+              className={cx("flex align-center", { mt1: question.collection })}
+            >
               <Icon name="calendar" size={12} mr={1} />{" "}
               {t`Last edited ${formatDate(question.updated_at)}`}
             </div>

--- a/frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx
@@ -85,7 +85,7 @@ export default class CardTagEditor extends Component {
             t`Question #…`
           ) : (
             <Link to={this.getQuestionUrl()}>
-              {question.dataset ? t`Model #${cardId}` : t`Question #${cardId}`}
+              {question?.dataset ? t`Model #${cardId}` : t`Question #${cardId}`}
             </Link>
           )}
         </h3>

--- a/frontend/test/metabase/scenarios/models/models.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models.cy.spec.js
@@ -3,9 +3,11 @@ import {
   modal,
   popover,
   getNotebookStep,
+  openNativeEditor,
   openNewCollectionItemFlowFor,
   visualize,
   mockSessionProperty,
+  sidebar,
 } from "__support__/e2e/cypress";
 
 import {
@@ -451,6 +453,46 @@ describe("scenarios > models", () => {
 
       cy.findByText("Saved Questions");
       cy.findByText("Sample Dataset");
+    });
+  });
+
+  describe("listing", () => {
+    beforeEach(() => {
+      cy.request("PUT", "/api/card/1", { name: "Orders Model", dataset: true });
+    });
+
+    it("should allow adding models to dashboards", () => {
+      cy.intercept("GET", "/api/dashboard/*").as("fetchDashboard");
+      cy.createDashboard().then(({ body: { id: dashboardId } }) => {
+        cy.visit(`/dashboard/${dashboardId}`);
+        cy.icon("pencil").click();
+        cy.get(".QueryBuilder-section .Icon-add").click();
+        sidebar()
+          .findByText("Orders Model")
+          .click();
+        cy.button("Save").click();
+        cy.wait("@fetchDashboard");
+        cy.findByText("Orders Model");
+      });
+    });
+
+    it("should allow using models in native queries", () => {
+      cy.intercept("POST", "/api/dataset").as("query");
+      openNativeEditor().type("select * from {{#}}", {
+        parseSpecialCharSequences: false,
+      });
+      sidebar()
+        .findByText("Pick a saved question")
+        .click();
+      selectFromDropdown("Orders Model");
+      cy.get("@editor").contains("select * from {{#1}}");
+      cy.get(".NativeQueryEditor .Icon-play").click();
+      cy.wait("@query");
+      cy.get(".TableInteractive").within(() => {
+        cy.findByText("USER_ID");
+        cy.findByText("PRODUCT_ID");
+        cy.findByText("TAX");
+      });
     });
   });
 });

--- a/frontend/test/metabase/scenarios/models/models.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models.cy.spec.js
@@ -482,7 +482,7 @@ describe("scenarios > models", () => {
         parseSpecialCharSequences: false,
       });
       sidebar()
-        .findByText("Pick a saved question")
+        .findByText("Pick a question or a model")
         .click();
       selectFromDropdown("Orders Model");
       cy.get("@editor").contains("select * from {{#1}}");

--- a/frontend/test/metabase/scenarios/native/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/native.cy.spec.js
@@ -45,7 +45,7 @@ describe("scenarios > question > native", () => {
     cy.contains("Question #…")
       .parent()
       .parent()
-      .contains("Pick a saved question")
+      .contains("Pick a question or a model")
       .click({ force: true });
 
     // selecting a question should update the query


### PR DESCRIPTION
Resolves #19449

This PR makes it possible to use models in native queries (like `select * from {{ #MODEL_ID }}`) and add them to dashboards. Models are still saved questions under the hood, but they're excluded from question listing APIs that are used by the pickers

### To Verify

1. Create a model
2. Create/open an existing dashboard
3. Go to editing mode and open the sidebar for adding questions ("pencil" icon > "add" / "plus" icon)
4. Ensure you can see your model in the list of questions. Click it, so it gets added to the dashboard
5. Click "Save" and make sure the model is displayed correctly
6. Create a new native query ("add" / "plus" icon in the main navbar > "SQL query")
7. Type `select * from {{#}}`
8. The tag editor sidebar should appear on the right. Click "Pick a saved question"
9. Ensure you can see your model in the list of questions. Click it and make sure the query has changed to `select * from {{ #MODEL_ID }}`
10. Run the query (CMD + Enter / click the "Run" button)
11. Ensure you see regular model data in the results

### Demo

<details>
<summary>Adding model to dashboard</summary>

https://user-images.githubusercontent.com/17258145/149953972-3912e36c-140d-413e-8fcf-d19186852d9d.mov

</details>

<details>
<summary>Using model in a native query</summary>

https://user-images.githubusercontent.com/17258145/149953995-da638381-3dbc-4546-8290-fe357741d4bc.mov

</details>