### PR TITLE
Render previous scalar value in narrow public embeds

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 import React from "react";
-import { Box, Flex } from "grid-styled";
+import { Box } from "grid-styled";
 import { t, jt } from "ttag";
 import _ from "underscore";
 
@@ -24,6 +24,7 @@ import {
   PreviousValueContainer,
   PreviousValueSeparator,
   PreviousValueVariation,
+  Variation,
 } from "./SmartScalar.styled";
 
 export default class Smart extends React.Component {
@@ -192,14 +193,14 @@ export default class Smart extends React.Component {
             t`No change from last ${granularity}`
           ) : (
             <PreviousValueContainer>
-              <Flex align="center" color={changeColor}>
+              <Variation color={changeColor}>
                 <Icon
                   size={13}
                   pr={1}
                   name={isNegative ? "arrow_down" : "arrow_up"}
                 />
                 {changeDisplay}
-              </Flex>
+              </Variation>
               <PreviousValueVariation id="SmartScalar-PreviousValue">
                 {jt`${separator} was ${formatValue(
                   previousValue,

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx
@@ -20,6 +20,12 @@ import ScalarValue, {
   ScalarTitle,
 } from "metabase/visualizations/components/ScalarValue";
 
+import {
+  PreviousValueContainer,
+  PreviousValueSeparator,
+  PreviousValueVariation,
+} from "./SmartScalar.styled";
+
 export default class Smart extends React.Component {
   static uiName = t`Trend`;
   static identifier = "smartscalar";
@@ -125,18 +131,7 @@ export default class Smart extends React.Component {
         {formatNumber(Math.abs(lastChange), { number_style: "percent" })}
       </span>
     );
-    const separator = (
-      <span
-        style={{
-          color: color("text-light"),
-          fontSize: "0.7rem",
-          marginLeft: 4,
-          marginRight: 4,
-        }}
-      >
-        •
-      </span>
-    );
+    const separator = <PreviousValueSeparator>•</PreviousValueSeparator>;
     const granularityDisplay = (
       <span style={{ marginLeft: 5 }}>{jt`last ${granularity}`}</span>
     );
@@ -196,7 +191,7 @@ export default class Smart extends React.Component {
           ) : lastChange === 0 ? (
             t`No change from last ${granularity}`
           ) : (
-            <Flex align="center" mt={1} flexWrap="wrap">
+            <PreviousValueContainer>
               <Flex align="center" color={changeColor}>
                 <Icon
                   size={13}
@@ -205,19 +200,13 @@ export default class Smart extends React.Component {
                 />
                 {changeDisplay}
               </Flex>
-              <h4
-                id="SmartScalar-PreviousValue"
-                className="flex align-center hide lg-show"
-                style={{
-                  color: color("text-medium"),
-                }}
-              >
+              <PreviousValueVariation id="SmartScalar-PreviousValue">
                 {jt`${separator} was ${formatValue(
                   previousValue,
                   settings.column(column),
                 )} ${granularityDisplay}`}
-              </h4>
-            </Flex>
+              </PreviousValueVariation>
+            </PreviousValueContainer>
           )}
         </Box>
       </ScalarWrapper>

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar.styled.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar.styled.jsx
@@ -1,0 +1,38 @@
+import styled from "styled-components";
+
+import { color } from "metabase/lib/colors";
+import {
+  breakpointMaxExtraSmall,
+  space,
+} from "metabase/styled-components/theme";
+
+export const PreviousValueContainer = styled.div`
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  margin-top: ${space(0)};
+
+  ${breakpointMaxExtraSmall} {
+    flex-direction: column;
+  }
+`;
+
+export const PreviousValueVariation = styled.h4`
+  align-items: center;
+  color: ${color("text-light")};
+  display: flex;
+
+  ${breakpointMaxExtraSmall} {
+    text-transform: capitalize;
+  }
+`;
+
+export const PreviousValueSeparator = styled.span`
+  color: ${color("text-light")};
+  font-size: 0.7rem;
+  margin: 0 ${space(0)};
+
+  ${breakpointMaxExtraSmall} {
+    display: none;
+  }
+`;

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar.styled.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar.styled.jsx
@@ -1,10 +1,17 @@
 import styled from "styled-components";
 
 import { color } from "metabase/lib/colors";
-import {
-  breakpointMaxExtraSmall,
-  space,
-} from "metabase/styled-components/theme";
+import { breakpointMaxSmall, space } from "metabase/styled-components/theme";
+
+export const Variation = styled.div`
+  color: ${props => props.color};
+  display: flex;
+  align-items: center;
+
+  ${breakpointMaxSmall} {
+    margin: ${space(1)} 0;
+  }
+`;
 
 export const PreviousValueContainer = styled.div`
   align-items: center;
@@ -12,7 +19,7 @@ export const PreviousValueContainer = styled.div`
   flex-wrap: wrap;
   margin-top: ${space(0)};
 
-  ${breakpointMaxExtraSmall} {
+  ${breakpointMaxSmall} {
     flex-direction: column;
   }
 `;
@@ -22,7 +29,7 @@ export const PreviousValueVariation = styled.h4`
   color: ${color("text-light")};
   display: flex;
 
-  ${breakpointMaxExtraSmall} {
+  ${breakpointMaxSmall} {
     text-transform: capitalize;
   }
 `;
@@ -32,7 +39,7 @@ export const PreviousValueSeparator = styled.span`
   font-size: 0.7rem;
   margin: 0 ${space(0)};
 
-  ${breakpointMaxExtraSmall} {
+  ${breakpointMaxSmall} {
     display: none;
   }
 `;


### PR DESCRIPTION
Fixes #18453

## How to Test

1. Create a trend chart and save it
2. Go to `Sharing`->`Enable sharing` 
3. Copy `Public link` URL
4. Open URL in browser
5. Resize window width to something very narrow

Text about recent variation should now be displayed.
Also, it should appear capitalized, and below the % variation (to make it fit and look good overall).

Same works for embedded questions.

### After

<img src=https://user-images.githubusercontent.com/380816/149982873-054bf4fd-75d7-4c39-a614-9e18afb41b53.png width=300 />

### Before

<img src=https://user-images.githubusercontent.com/380816/149982106-dd7a62a4-f4e5-4496-98b0-cb314bf6bc3a.png width=300 />
