### PR TITLE
Disallow variables usage for native models

### DIFF
--- a/frontend/src/metabase-types/types/Query.ts
+++ b/frontend/src/metabase-types/types/Query.ts
@@ -47,7 +47,7 @@ export type DatetimeUnit =
 
 export type TemplateTagId = string;
 export type TemplateTagName = string;
-export type TemplateTagType = "text" | "number" | "date" | "dimension";
+export type TemplateTagType = "card" | "text" | "number" | "date" | "dimension";
 
 export type TemplateTag = {
   id: TemplateTagId;

--- a/frontend/src/metabase/lib/data-modeling/utils.ts
+++ b/frontend/src/metabase/lib/data-modeling/utils.ts
@@ -1,10 +1,15 @@
 import Question from "metabase-lib/lib/Question";
 import NativeQuery from "metabase-lib/lib/queries/NativeQuery";
+import { TemplateTag } from "metabase-types/types/Query";
+
+export function isSupportedTemplateTagForModel(tag: TemplateTag) {
+  return tag.type === "card";
+}
 
 export function checkCanBeModel(question: Question) {
   if (!question.isNative()) {
     return true;
   }
   const query = (question.query() as unknown) as NativeQuery;
-  return query.templateTags().every(tag => tag.type === "card");
+  return query.templateTags().every(isSupportedTemplateTagForModel);
 }

--- a/frontend/src/metabase/lib/data-modeling/utils.ts
+++ b/frontend/src/metabase/lib/data-modeling/utils.ts
@@ -1,0 +1,10 @@
+import Question from "metabase-lib/lib/Question";
+import NativeQuery from "metabase-lib/lib/queries/NativeQuery";
+
+export function checkCanBeModel(question: Question) {
+  if (!question.isNative()) {
+    return true;
+  }
+  const query = (question.query() as unknown) as NativeQuery;
+  return query.templateTags().every(tag => tag.type === "card");
+}

--- a/frontend/src/metabase/lib/data-modeling/utils.unit.spec.ts
+++ b/frontend/src/metabase/lib/data-modeling/utils.unit.spec.ts
@@ -1,0 +1,80 @@
+import Question from "metabase-lib/lib/Question";
+import {
+  TemplateTag,
+  TemplateTagType,
+  TemplateTags,
+} from "metabase-types/types/Query";
+import { ORDERS } from "__support__/sample_dataset_fixture";
+import { checkCanBeModel } from "./utils";
+
+function getNativeQuestion(tags: TemplateTags = {}) {
+  return new Question({
+    id: 1,
+    display: "table",
+    can_write: true,
+    public_uuid: "",
+    dataset_query: {
+      type: "native",
+      native: {
+        query: "select * from orders",
+        "template-tags": tags,
+      },
+    },
+    visualization_settings: {},
+  });
+}
+
+function getTemplateTag(tag: Partial<TemplateTag> = {}): TemplateTag {
+  return {
+    id: "_",
+    name: "_",
+    "display-name": "_",
+    type: "card",
+    ...tag,
+  };
+}
+
+describe("data model utils", () => {
+  describe("checkCanBeModel", () => {
+    const UNSUPPORTED_TEMPLATE_TAG_TYPES: TemplateTagType[] = [
+      "text",
+      "number",
+      "date",
+      "dimension",
+    ];
+
+    it("returns true for structured queries", () => {
+      const question = ORDERS.question();
+      expect(checkCanBeModel(question)).toBe(true);
+    });
+
+    it("returns true for native queries without variables", () => {
+      const question = getNativeQuestion();
+      expect(checkCanBeModel(question)).toBe(true);
+    });
+
+    it("returns true for native queries with 'card' variables", () => {
+      const question = getNativeQuestion({
+        "#5": getTemplateTag({ type: "card" }),
+      });
+      expect(checkCanBeModel(question)).toBe(true);
+    });
+
+    UNSUPPORTED_TEMPLATE_TAG_TYPES.forEach(tagType => {
+      it(`returns false false for native queries with '${tagType}' variables`, () => {
+        const question = getNativeQuestion({
+          foo: getTemplateTag({ type: tagType }),
+        });
+        expect(checkCanBeModel(question)).toBe(false);
+      });
+    });
+
+    it("returns false for native queries if it uses at least one unsupported variable type", () => {
+      const question = getNativeQuestion({
+        "#5": getTemplateTag({ type: "card" }),
+        foo: getTemplateTag({ type: "dimension" }),
+      });
+      expect(checkCanBeModel(question)).toBe(false);
+    });
+  });
+});

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -68,7 +68,6 @@ import { parse as urlParse } from "url";
 import querystring from "querystring";
 
 import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
-import NativeQuery from "metabase-lib/lib/queries/NativeQuery";
 import { getSensibleDisplays } from "metabase/visualizations";
 import { getCardAfterVisualizationClick } from "metabase/visualizations/lib/utils";
 import { getPersistableDefaultSettingsForSeries } from "metabase/visualizations/lib/settings/visualization";
@@ -83,17 +82,11 @@ import { setRequestUnloaded } from "metabase/redux/requests";
 import {
   getQueryBuilderModeFromLocation,
   getPathNameFromQueryBuilderMode,
+  getNextTemplateTagVisibilityState,
   isAdHocDatasetQuestion,
 } from "./utils";
 
 const PREVIEW_RESULT_LIMIT = 10;
-
-const getTemplateTagWithoutSnippetsCount = question => {
-  const query = question.query();
-  return query instanceof NativeQuery
-    ? query.templateTagsWithoutSnippets().length
-    : 0;
-};
 
 export const SET_UI_CONTROLS = "metabase/qb/SET_UI_CONTROLS";
 export const setUIControls = createAction(SET_UI_CONTROLS);
@@ -1035,15 +1028,16 @@ export const updateQuestion = (
     }
 
     // See if the template tags editor should be shown/hidden
-    const oldTagCount = getTemplateTagWithoutSnippetsCount(oldQuestion);
-    const newTagCount = getTemplateTagWithoutSnippetsCount(newQuestion);
-    if (newTagCount > oldTagCount) {
-      dispatch(setIsShowingTemplateTagsEditor(true));
-    } else if (
-      newTagCount === 0 &&
-      getIsShowingTemplateTagsEditor(getState())
-    ) {
-      dispatch(setIsShowingTemplateTagsEditor(false));
+    const isTemplateTagEditorVisible = getIsShowingTemplateTagsEditor(
+      getState(),
+    );
+    const nextTagEditorVisibilityState = getNextTemplateTagVisibilityState({
+      oldQuestion,
+      newQuestion,
+      isTemplateTagEditorVisible,
+    });
+    if (typeof nextTagEditorVisibilityState === "boolean") {
+      dispatch(setIsShowingTemplateTagsEditor(nextTagEditorVisibilityState));
     }
 
     try {

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -1034,8 +1034,12 @@ export const updateQuestion = (
       isTemplateTagEditorVisible,
       queryBuilderMode: mode,
     });
-    if (typeof nextTagEditorVisibilityState === "boolean") {
-      dispatch(setIsShowingTemplateTagsEditor(nextTagEditorVisibilityState));
+    if (nextTagEditorVisibilityState !== "deferToCurrentState") {
+      dispatch(
+        setIsShowingTemplateTagsEditor(
+          nextTagEditorVisibilityState === "visible",
+        ),
+      );
     }
 
     try {

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -1009,10 +1009,7 @@ export const updateQuestion = (
     // </PIVOT LOGIC>
 
     // Native query should never be in notebook mode (metabase#12651)
-    if (
-      getQueryBuilderMode(getState()) === "notebook" &&
-      newQuestion.isNative()
-    ) {
+    if (mode === "notebook" && newQuestion.isNative()) {
       await dispatch(
         setQueryBuilderMode("view", {
           shouldUpdateUrl: false,
@@ -1035,6 +1032,7 @@ export const updateQuestion = (
       oldQuestion,
       newQuestion,
       isTemplateTagEditorVisible,
+      queryBuilderMode: mode,
     });
     if (typeof nextTagEditorVisibilityState === "boolean") {
       dispatch(setIsShowingTemplateTagsEditor(nextTagEditorVisibilityState));

--- a/frontend/src/metabase/query_builder/components/ImpossibleToCreateModelModal/ImpossibleToCreateModelModal.tsx
+++ b/frontend/src/metabase/query_builder/components/ImpossibleToCreateModelModal/ImpossibleToCreateModelModal.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { t, jt } from "ttag";
 
+import Button from "metabase/components/Button";
 import ExternalLink from "metabase/components/ExternalLink";
 import ModalContent from "metabase/components/ModalContent";
 
@@ -30,12 +31,14 @@ export function ImpossibleToCreateModelModal({ onClose }: Props) {
       title={t`Variables in models aren't supported yet`}
       onClose={onClose}
     >
-      <p>{t`This saved question has some variables in it that models can't handle quite yet. To solve this, remove your variables, create your model, then set up your column metadata to tell Metabase which field each one corresponds to.`}</p>
-      <p>{jt`Note: it's okay to use ${(
+      <p className="text-paragraph">{jt`To solve this, just remove the variables in this question and try again. (It's okay to use ${(
         <SQLSnippetsDocLink key="link-1" />
       )} or ${(
         <ReferencingQuestionsDocLink key="link-2" />
-      )} in your query.`}</p>
+      )} in your query.)`}</p>
+      <div className="Form-actions flex justify-center py1">
+        <Button primary onClick={onClose}>{t`Okay`}</Button>
+      </div>
     </ModalContent>
   );
 }

--- a/frontend/src/metabase/query_builder/components/ImpossibleToCreateModelModal/ImpossibleToCreateModelModal.tsx
+++ b/frontend/src/metabase/query_builder/components/ImpossibleToCreateModelModal/ImpossibleToCreateModelModal.tsx
@@ -36,7 +36,7 @@ export function ImpossibleToCreateModelModal({ onClose }: Props) {
       )} or ${(
         <ReferencingQuestionsDocLink key="link-2" />
       )} in your query.)`}</p>
-      <div className="Form-actions flex justify-center py1">
+      <div className="flex justify-center py1">
         <Button primary onClick={onClose}>{t`Okay`}</Button>
       </div>
     </ModalContent>

--- a/frontend/src/metabase/query_builder/components/ImpossibleToCreateModelModal/ImpossibleToCreateModelModal.tsx
+++ b/frontend/src/metabase/query_builder/components/ImpossibleToCreateModelModal/ImpossibleToCreateModelModal.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { t, jt } from "ttag";
+
+import ExternalLink from "metabase/components/ExternalLink";
+import ModalContent from "metabase/components/ModalContent";
+
+import MetabaseSettings from "metabase/lib/settings";
+
+type Props = {
+  onClose: () => void;
+};
+
+function SQLSnippetsDocLink() {
+  const href = MetabaseSettings.docsUrl("users-guide/sql-snippets");
+  return <ExternalLink href={href}>{t`SQL snippets`}</ExternalLink>;
+}
+
+function ReferencingQuestionsDocLink() {
+  const href = MetabaseSettings.docsUrl("users-guide/sql-snippets");
+  return (
+    <ExternalLink
+      href={href}
+    >{t`reference the results of another saved question`}</ExternalLink>
+  );
+}
+
+export function ImpossibleToCreateModelModal({ onClose }: Props) {
+  return (
+    <ModalContent
+      title={t`Variables in models aren't supported yet`}
+      onClose={onClose}
+    >
+      <p>{t`This saved question has some variables in it that models can't handle quite yet. To solve this, remove your variables, create your model, then set up your column metadata to tell Metabase which field each one corresponds to.`}</p>
+      <p>{jt`Note: it's okay to use ${(
+        <SQLSnippetsDocLink key="link-1" />
+      )} or ${(
+        <ReferencingQuestionsDocLink key="link-2" />
+      )} in your query.`}</p>
+    </ModalContent>
+  );
+}

--- a/frontend/src/metabase/query_builder/components/ImpossibleToCreateModelModal/index.ts
+++ b/frontend/src/metabase/query_builder/components/ImpossibleToCreateModelModal/index.ts
@@ -1,0 +1,1 @@
+export * from "./ImpossibleToCreateModelModal";

--- a/frontend/src/metabase/query_builder/components/QueryModals.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryModals.jsx
@@ -19,6 +19,7 @@ import QuestionEmbedWidget from "metabase/query_builder/containers/QuestionEmbed
 
 import QuestionHistoryModal from "metabase/query_builder/containers/QuestionHistoryModal";
 import { CreateAlertModalContent } from "metabase/query_builder/components/AlertModals";
+import { ImpossibleToCreateModelModal } from "metabase/query_builder/components/ImpossibleToCreateModelModal";
 import NewDatasetModal from "metabase/query_builder/components/NewDatasetModal";
 import EntityCopyModal from "metabase/entities/containers/EntityCopyModal";
 
@@ -206,6 +207,10 @@ export default class QueryModals extends React.Component {
     ) : modal === MODAL_TYPES.TURN_INTO_DATASET ? (
       <Modal small onClose={onCloseModal}>
         <NewDatasetModal onClose={onCloseModal} />
+      </Modal>
+    ) : modal === MODAL_TYPES.CAN_NOT_CREATE_MODEL ? (
+      <Modal onClose={onCloseModal}>
+        <ImpossibleToCreateModelModal onClose={onCloseModal} />
       </Modal>
     ) : null;
   }

--- a/frontend/src/metabase/query_builder/components/QuestionActionButtons.jsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActionButtons.jsx
@@ -2,6 +2,8 @@ import React from "react";
 import PropTypes from "prop-types";
 import { t } from "ttag";
 
+import { checkCanBeModel } from "metabase/lib/data-modeling/utils";
+
 import { MODAL_TYPES } from "metabase/query_builder/constants";
 
 import Button from "metabase/components/Button";
@@ -18,14 +20,14 @@ export const ARCHIVE_TESTID = "archive-button";
 const ICON_SIZE = 18;
 
 QuestionActionButtons.propTypes = {
+  question: PropTypes.object.isRequired,
   canWrite: PropTypes.bool.isRequired,
-  isDataset: PropTypes.bool.isRequired,
   onOpenModal: PropTypes.func.isRequired,
 };
 
-export default QuestionActionButtons;
+function QuestionActionButtons({ question, canWrite, onOpenModal }) {
+  const isDataset = question.isDataset();
 
-function QuestionActionButtons({ canWrite, isDataset, onOpenModal }) {
   const duplicateTooltip = isDataset
     ? t`Duplicate this model`
     : t`Duplicate this question`;
@@ -69,7 +71,12 @@ function QuestionActionButtons({ canWrite, isDataset, onOpenModal }) {
             onlyIcon
             icon="model"
             iconSize={ICON_SIZE}
-            onClick={() => onOpenModal(MODAL_TYPES.TURN_INTO_DATASET)}
+            onClick={() => {
+              const modal = checkCanBeModel(question)
+                ? MODAL_TYPES.TURN_INTO_DATASET
+                : MODAL_TYPES.CAN_NOT_CREATE_MODEL;
+              onOpenModal(modal);
+            }}
             data-testid={TURN_INTO_DATASET_TESTID}
           />
         </Tooltip>
@@ -99,3 +106,5 @@ function QuestionActionButtons({ canWrite, isDataset, onOpenModal }) {
     </Container>
   );
 }
+
+export default QuestionActionButtons;

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx
@@ -65,7 +65,7 @@ export default class TagEditorSidebar extends React.Component {
 
     return (
       <SidebarContent title={t`Variables`} onClose={onClose}>
-        <div>
+        <div data-testid="tag-editor-sidebar">
           <div className="mx3 text-centered Button-group Button-group--brand text-uppercase mb2 flex flex-full">
             <a
               className={cx("Button flex-full Button--small", {

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebarPanel.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebarPanel.jsx
@@ -34,8 +34,8 @@ function QuestionDetailsSidebarPanel({ question, onOpenModal }) {
     <Container>
       <SidebarPaddedContent>
         <QuestionActionButtons
+          question={question}
           canWrite={canWrite}
-          isDataset={question.isDataset()}
           onOpenModal={onOpenModal}
         />
         <ClampedDescription

--- a/frontend/src/metabase/query_builder/constants.js
+++ b/frontend/src/metabase/query_builder/constants.js
@@ -13,4 +13,5 @@ export const MODAL_TYPES = {
   HISTORY: "history",
   EMBED: "embed",
   TURN_INTO_DATASET: "turn-into-dataset",
+  CAN_NOT_CREATE_MODEL: "can-not-create-model",
 };

--- a/frontend/src/metabase/query_builder/utils.js
+++ b/frontend/src/metabase/query_builder/utils.js
@@ -1,3 +1,4 @@
+import { isSupportedTemplateTagForModel } from "metabase/lib/data-modeling/utils";
 import { getQuestionVirtualTableId } from "metabase/lib/saved-questions";
 import NativeQuery from "metabase-lib/lib/queries/NativeQuery";
 
@@ -46,21 +47,27 @@ export function isAdHocDatasetQuestion(question, originalQuestion) {
 function getTemplateTagWithoutSnippetsCount(question) {
   const query = question.query();
   return query instanceof NativeQuery
-    ? query.templateTagsWithoutSnippets().length
-    : 0;
+    ? query.templateTagsWithoutSnippets()
+    : [];
 }
 
 export function getNextTemplateTagVisibilityState({
   oldQuestion,
   newQuestion,
   isTemplateTagEditorVisible,
+  queryBuilderMode,
 }) {
-  const oldCount = getTemplateTagWithoutSnippetsCount(oldQuestion);
-  const newCount = getTemplateTagWithoutSnippetsCount(newQuestion);
-  if (newCount > oldCount) {
-    return true;
+  const previousTags = getTemplateTagWithoutSnippetsCount(oldQuestion);
+  const nextTags = getTemplateTagWithoutSnippetsCount(newQuestion);
+
+  if (nextTags.length > previousTags.length) {
+    if (queryBuilderMode !== "dataset") {
+      return true;
+    }
+    return nextTags.every(isSupportedTemplateTagForModel);
   }
-  if (newCount === 0 && isTemplateTagEditorVisible) {
+
+  if (nextTags.length === 0 && isTemplateTagEditorVisible) {
     return false;
   }
 }

--- a/frontend/src/metabase/query_builder/utils.js
+++ b/frontend/src/metabase/query_builder/utils.js
@@ -62,12 +62,14 @@ export function getNextTemplateTagVisibilityState({
 
   if (nextTags.length > previousTags.length) {
     if (queryBuilderMode !== "dataset") {
-      return true;
+      return "visible";
     }
     return nextTags.every(isSupportedTemplateTagForModel);
   }
 
   if (nextTags.length === 0 && isTemplateTagEditorVisible) {
-    return false;
+    return "hidden";
   }
+
+  return "deferToCurrentState";
 }

--- a/frontend/src/metabase/query_builder/utils.js
+++ b/frontend/src/metabase/query_builder/utils.js
@@ -64,7 +64,9 @@ export function getNextTemplateTagVisibilityState({
     if (queryBuilderMode !== "dataset") {
       return "visible";
     }
-    return nextTags.every(isSupportedTemplateTagForModel);
+    return nextTags.every(isSupportedTemplateTagForModel)
+      ? "visible"
+      : "hidden";
   }
 
   if (nextTags.length === 0 && isTemplateTagEditorVisible) {

--- a/frontend/src/metabase/query_builder/utils.js
+++ b/frontend/src/metabase/query_builder/utils.js
@@ -1,4 +1,5 @@
 import { getQuestionVirtualTableId } from "metabase/lib/saved-questions";
+import NativeQuery from "metabase-lib/lib/queries/NativeQuery";
 
 // Query Builder Mode
 
@@ -40,4 +41,26 @@ export function isAdHocDatasetQuestion(question, originalQuestion) {
     getQuestionVirtualTableId(originalQuestion.card());
 
   return isDataset && isSameCard && isSelfReferencing;
+}
+
+function getTemplateTagWithoutSnippetsCount(question) {
+  const query = question.query();
+  return query instanceof NativeQuery
+    ? query.templateTagsWithoutSnippets().length
+    : 0;
+}
+
+export function getNextTemplateTagVisibilityState({
+  oldQuestion,
+  newQuestion,
+  isTemplateTagEditorVisible,
+}) {
+  const oldCount = getTemplateTagWithoutSnippetsCount(oldQuestion);
+  const newCount = getTemplateTagWithoutSnippetsCount(newQuestion);
+  if (newCount > oldCount) {
+    return true;
+  }
+  if (newCount === 0 && isTemplateTagEditorVisible) {
+    return false;
+  }
 }

--- a/frontend/test/metabase/query_builder/components/QuestionActionButtons.unit.spec.js
+++ b/frontend/test/metabase/query_builder/components/QuestionActionButtons.unit.spec.js
@@ -21,6 +21,10 @@ const testIdActionPairs = [
 
 describe("QuestionActionButtons", () => {
   let onOpenModal;
+  const question = {
+    isDataset: () => false,
+  };
+
   beforeEach(() => {
     onOpenModal = jest.fn();
   });
@@ -29,7 +33,11 @@ describe("QuestionActionButtons", () => {
     beforeEach(() => {
       const canWrite = false;
       render(
-        <QuestionActionButtons canWrite={canWrite} onOpenModal={onOpenModal} />,
+        <QuestionActionButtons
+          question={question}
+          canWrite={canWrite}
+          onOpenModal={onOpenModal}
+        />,
       );
     });
 
@@ -51,7 +59,11 @@ describe("QuestionActionButtons", () => {
     beforeEach(() => {
       const canWrite = true;
       render(
-        <QuestionActionButtons canWrite={canWrite} onOpenModal={onOpenModal} />,
+        <QuestionActionButtons
+          question={question}
+          canWrite={canWrite}
+          onOpenModal={onOpenModal}
+        />,
       );
     });
 

--- a/frontend/test/metabase/scenarios/models/models.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models.cy.spec.js
@@ -516,6 +516,7 @@ describe("scenarios > models", () => {
         cy.get(".ace_content")
           .should("be.visible")
           .as("editor")
+          .type("{movetoend}")
           .type(" WHERE {{F", {
             parseSpecialCharSequences: false,
           });

--- a/frontend/test/metabase/scenarios/models/models.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models.cy.spec.js
@@ -9,7 +9,7 @@ import {
   mockSessionProperty,
   sidebar,
 } from "__support__/e2e/cypress";
-
+import { SAMPLE_DATASET } from "__support__/e2e/cypress_sample_dataset";
 import {
   turnIntoModel,
   assertIsModel,
@@ -21,6 +21,8 @@ import {
   openDetailsSidebar,
   getDetailsSidebarActions,
 } from "./helpers/e2e-models-helpers";
+
+const { PRODUCTS } = SAMPLE_DATASET;
 
 describe("scenarios > models", () => {
   beforeEach(() => {
@@ -453,6 +455,74 @@ describe("scenarios > models", () => {
 
       cy.findByText("Saved Questions");
       cy.findByText("Sample Dataset");
+    });
+  });
+
+  it("shouldn't allow to turn native questions with variables into models", () => {
+    cy.createNativeQuestion(
+      {
+        native: {
+          query: "SELECT * FROM products WHERE {{ID}}",
+          "template-tags": {
+            ID: {
+              id: "6b8b10ef-0104-1047-1e1b-2492d5954322",
+              name: "ID",
+              display_name: "ID",
+              type: "dimension",
+              dimension: ["field", PRODUCTS.ID, null],
+              "widget-type": "category",
+              default: null,
+            },
+          },
+        },
+      },
+      { visitQuestion: true },
+    );
+
+    openDetailsSidebar();
+    getDetailsSidebarActions().within(() => {
+      cy.icon("model").click();
+    });
+    modal().within(() => {
+      cy.findByText("Variables in models aren't supported yet");
+      cy.button("Turn this into a model").should("not.exist");
+      cy.icon("close").click();
+    });
+    assertIsQuestion();
+
+    cy.findByText(/Open editor/i).click();
+    cy.get(".ace_content").type(
+      "{leftarrow}{leftarrow}{backspace}{backspace}#",
+    );
+    cy.findByTestId("tag-editor-sidebar").within(() => {
+      cy.get(".AdminSelect").click();
+    });
+    selectFromDropdown("Orders");
+    cy.findByText("Save").click();
+    modal()
+      .findByText("Save")
+      .click();
+
+    turnIntoModel();
+    assertIsModel();
+  });
+
+  it("shouldn't allow using variables in native models", () => {
+    cy.createNativeQuestion({
+      native: { query: "SELECT * FROM products" },
+    }).then(({ body: { id: modelId } }) => {
+      cy.request("PUT", `/api/card/${modelId}`, { dataset: true }).then(() => {
+        cy.visit(`/model/${modelId}/query`);
+        cy.get(".ace_content")
+          .should("be.visible")
+          .as("editor")
+          .type(" WHERE {{F", {
+            parseSpecialCharSequences: false,
+          });
+        cy.findByTestId("tag-editor-sidebar").should("not.exist");
+        cy.get("@editor").type("{leftarrow}{leftarrow}{backspace}#");
+        cy.findByTestId("tag-editor-sidebar").should("be.visible");
+      });
     });
   });
 


### PR DESCRIPTION
For the first version of the data models, we want to disallow using variables in native datasets. That means:

* you shouldn't be able to turn a question using variables into a model
* you shouldn't be able to add variables to existing models

The only exception is referencing other questions like `select * from {{ #1 }}` where `1` is a question ID.

### To Verify

1. Create a native question with a variable (like `select * from products where {{category}}` and configure the "Category" variable in a sidebar that should appear on the right)
2. Click the question name > click the "model" icon
3. You shouldn't see a regular "Turn this into a model" modal, but a modal saying that variables are not yet supported. You shouldn't be able to turn it into a model
4. Open the existing native model, click its name and select "Edit query definition" from the sidebar on the left
5. Try to add a variable like `WHERE {{filter}}`, the variables sidebar should not appear
5. Try to reference another card using `{{ #ID }}` syntax, it should work fine

### Demo

https://user-images.githubusercontent.com/17258145/149995829-dc4aac2d-7b7c-4655-95a7-36fae9b1997d.mov



