### PR TITLE
Log a shortened version of the enterprise token

### DIFF
--- a/src/metabase/public_settings/premium_features.clj
+++ b/src/metabase/public_settings/premium_features.clj
@@ -58,32 +58,32 @@
 (s/defn ^:private fetch-token-status* :- TokenStatus
   "Fetch info about the validity of `token` from the MetaStore."
   [token :- ValidToken]
-  (let [;; ValidToken will ensure the length of token is 64
-        print-token (str (subs token 0 4) "..." (subs token 60 64))]
-    ;; attempt to query the metastore API about the status of this token. If the request doesn't complete in a
-    ;; reasonable amount of time throw a timeout exception
-    (log/info (trs "Checking with the MetaStore to see whether {0} is valid..." print-token))
-    (deref
-     (future
-       (try (some-> (token-status-url token)
-                    (http/get {:query-params {:users (active-user-count)}})
-                    :body
-                    (json/parse-string keyword))
-            ;; if there was an error fetching the token, log it and return a generic message about the
-            ;; token being invalid. This message will get displayed in the Settings page in the admin panel so
-            ;; we do not want something complicated
-            (catch clojure.lang.ExceptionInfo e
-              (log/error e (trs "Error fetching token status:"))
-              (let [body (u/ignore-exceptions (some-> (ex-data e) :object :body (json/parse-string keyword)))]
-                (or
-                 body
-                 {:valid         false
-                  :status        (tru "Unable to validate token")
-                  :error-details (.getMessage e)})))))
-     fetch-token-status-timeout-ms
-     {:valid         false
-      :status        (tru "Unable to validate token")
-      :error-details (tru "Token validation timed out.")})))
+  ;; attempt to query the metastore API about the status of this token. If the request doesn't complete in a
+  ;; reasonable amount of time throw a timeout exception
+  (log/info (trs "Checking with the MetaStore to see whether {0} is valid..."
+                 ;; ValidToken will ensure the length of token is 64 chars long
+                 (str (subs token 0 4) "..." (subs token 60 64))))
+  (deref
+   (future
+     (try (some-> (token-status-url token)
+                  (http/get {:query-params {:users (active-user-count)}})
+                  :body
+                  (json/parse-string keyword))
+          ;; if there was an error fetching the token, log it and return a generic message about the
+          ;; token being invalid. This message will get displayed in the Settings page in the admin panel so
+          ;; we do not want something complicated
+          (catch clojure.lang.ExceptionInfo e
+            (log/error e (trs "Error fetching token status:"))
+            (let [body (u/ignore-exceptions (some-> (ex-data e) :object :body (json/parse-string keyword)))]
+              (or
+               body
+               {:valid         false
+                :status        (tru "Unable to validate token")
+                :error-details (.getMessage e)})))))
+   fetch-token-status-timeout-ms
+   {:valid         false
+    :status        (tru "Unable to validate token")
+    :error-details (tru "Token validation timed out.")}))
 
 (def ^{:arglists '([token])} fetch-token-status
   "TTL-memoized version of `fetch-token-status*`. Caches API responses for 5 minutes. This is important to avoid making

--- a/src/metabase/public_settings/premium_features.clj
+++ b/src/metabase/public_settings/premium_features.clj
@@ -65,7 +65,6 @@
     (log/info (trs "Checking with the MetaStore to see whether {0} is valid..." print-token))
     (deref
      (future
-       (log/info (u/format-color 'green (trs "Using this URL to check token: {0}" (token-status-url print-token))))
        (try (some-> (token-status-url token)
                     (http/get {:query-params {:users (active-user-count)}})
                     :body

--- a/test/metabase/public_settings/premium_features_test.clj
+++ b/test/metabase/public_settings/premium_features_test.clj
@@ -41,7 +41,7 @@
                 :trial    false}))
 
 (deftest fetch-token-status-test
-  (tt/with-temp User [user {:email "admin@example.com"}]
+  (tt/with-temp User [_user {:email "admin@example.com"}]
     (let [token       "fa3ebfa3ebfa3ebfa3ebfa3ebfa3ebfa3ebfa3ebfa3ebfa3ebfa3ebfa3ebfa3e"
           print-token "fa3e...fa3e"]
 
@@ -50,7 +50,7 @@
                             (#'premium-features/fetch-token-status* token))
               pr-str-logs (mapv pr-str logs)]
           (is (every? (complement #(re-find (re-pattern token) %)) pr-str-logs))
-          (is (= 2 (count (filter #(re-find (re-pattern print-token) %) pr-str-logs))))))
+          (is (= 1 (count (filter #(re-find (re-pattern print-token) %) pr-str-logs))))))
 
       (testing "With the backend unavailable"
         (let [result (token-status-response token {:status 500})]

--- a/test/metabase/public_settings/premium_features_test.clj
+++ b/test/metabase/public_settings/premium_features_test.clj
@@ -4,7 +4,7 @@
             [clojure.test :refer :all]
             [metabase.models.user :refer [User]]
             [metabase.public-settings.premium-features :as premium-features]
-            [metabase.test.util :as tu] ;; Circular reference with mt in here, so use tu
+            [metabase.test :as mt]
             [toucan.util.test :as tt]))
 
 (defn do-with-premium-features [features f]
@@ -42,11 +42,11 @@
 
 (deftest fetch-token-status-test
   (tt/with-temp User [_user {:email "admin@example.com"}]
-    (let [token       "fa3ebfa3ebfa3ebfa3ebfa3ebfa3ebfa3ebfa3ebfa3ebfa3ebfa3ebfa3ebfa3e"
-          print-token "fa3e...fa3e"]
+    (let [token       "d7ad0b5f9ddfd1953b1b427b75d620e4ba91d38e7bcbc09d8982480863dbc611"
+          print-token "d7ad...c611"]
 
       (testing "Do not log the token (#18249)"
-        (let [logs        (tu/with-log-messages-for-level :info
+        (let [logs        (mt/with-log-messages-for-level :info
                             (#'premium-features/fetch-token-status* token))
               pr-str-logs (mapv pr-str logs)]
           (is (every? (complement #(re-find (re-pattern token) %)) pr-str-logs))

--- a/test/metabase/public_settings/premium_features_test.clj
+++ b/test/metabase/public_settings/premium_features_test.clj
@@ -4,9 +4,8 @@
             [clojure.test :refer :all]
             [metabase.models.user :refer [User]]
             [metabase.public-settings.premium-features :as premium-features]
-            [toucan.util.test :as tt]
-            ;; Circular reference with mt in here, so use tu
-            [metabase.test.util :as tu]))
+            [metabase.test.util :as tu] ;; Circular reference with mt in here, so use tu
+            [toucan.util.test :as tt]))
 
 (defn do-with-premium-features [features f]
   (let [features (set (map name features))]


### PR DESCRIPTION
fixes #18249 
- when checking that an enterprise token is valid
- test captures the logs, and checks for no token
- in the test, regrettably we print the logs we need to capture

