### PR TITLE
Add PinnedItemCard component

### DIFF
--- a/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.stories.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.stories.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+import _ from "underscore";
+import { action } from "@storybook/addon-actions";
+import { ComponentStory } from "@storybook/react";
+import PinnedItemCard from "./PinnedItemCard";
+
+export default {
+  title: "Collections/PinnedItemCard",
+  component: PinnedItemCard,
+};
+
+const onToggleSelected = action("onToggleSelected");
+const onCopy = action("onCopy");
+const onMove = action("onMove");
+
+const Template: ComponentStory<typeof PinnedItemCard> = args => {
+  return <PinnedItemCard {...args} />;
+};
+
+export const Question = Template.bind({});
+Question.args = {
+  collection: {
+    can_write: true,
+  },
+  item: {
+    id: 1,
+    collection_position: 1,
+    name: "Question",
+    description: "This is a description of the question",
+    getIcon: () => ({ name: "question" }),
+    getUrl: () => "/question/1",
+    setArchived: action("setArchived"),
+    copy: true,
+    setCollection: true,
+  },
+  onToggleSelected,
+  onCopy,
+  onMove,
+};
+
+export const Dashboard = Template.bind({});
+Dashboard.args = {
+  collection: {
+    can_write: true,
+  },
+  item: {
+    id: 1,
+    collection_position: 1,
+    name: "Dashboard",
+    description: Array(20)
+      .fill("This is a description of the dashboard.")
+      .join(" "),
+    getIcon: () => ({ name: "dashboard" }),
+    getUrl: () => "/dashboard/1",
+    setArchived: action("setArchived"),
+  },
+  onToggleSelected,
+  onCopy,
+  onMove,
+};
+
+export const Model = Template.bind({});
+Model.args = {
+  collection: {
+    can_write: true,
+  },
+  item: {
+    id: 1,
+    collection_position: 1,
+    name: "Model",
+    description: "This is a description of the model",
+    getIcon: () => ({ name: "model" }),
+    getUrl: () => "/question/1",
+    setArchived: action("setArchived"),
+  },
+  onToggleSelected,
+  onCopy,
+  onMove,
+};

--- a/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.styled.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.styled.tsx
@@ -1,0 +1,79 @@
+import styled from "styled-components";
+
+import { color } from "metabase/lib/colors";
+import { forwardRefToInnerRef } from "metabase/styled-components/utils";
+import Icon from "metabase/components/Icon";
+import Link from "metabase/components/Link";
+import Card from "metabase/components/Card";
+import EntityItem from "metabase/components/EntityItem";
+
+export const ItemCard = styled(Card)``;
+
+export const ItemLink = styled(Link)`
+  display: block;
+
+  &:focus {
+    ${ItemCard} {
+      outline: 1px solid ${color("brand")};
+    }
+  }
+`;
+
+export const ItemIcon = styled(Icon)`
+  color: ${color("brand")};
+  height: 1.7rem;
+  width: 1.7rem;
+`;
+
+export const HoverMenu = styled(EntityItem.Menu)`
+  visibility: hidden;
+  color: ${color("text-medium")};
+
+  &:hover {
+    color: ${color("text-dark")};
+  }
+
+  &.EntityMenu--open {
+    visibility: visible;
+    color: ${color("text-dark")};
+  }
+`;
+
+export const Title = styled.div`
+  font-weight: bold;
+  font-size: 1.15rem;
+  line-height: 1.7rem;
+  color: ${color("text-dark")};
+  transition: color 0.2s ease;
+`;
+
+export const Description = forwardRefToInnerRef(styled.div`
+  color: ${color("text-medium")};
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+`);
+
+export const Body = styled.div`
+  padding: 1.7rem;
+  display: flex;
+  flex-direction: column;
+  cursor: pointer;
+
+  &:hover {
+    ${Title} {
+      color: ${color("brand")};
+    }
+
+    ${HoverMenu} {
+      visibility: visible;
+    }
+  }
+`;
+
+export const Header = styled.div`
+  padding-bottom: 1rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;

--- a/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.styled.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.styled.tsx
@@ -11,12 +11,7 @@ export const ItemCard = styled(Card)``;
 
 export const ItemLink = styled(Link)`
   display: block;
-
-  &:focus {
-    ${ItemCard} {
-      outline: 1px solid ${color("brand")};
-    }
-  }
+  height: min-content;
 `;
 
 export const ItemIcon = styled(Icon)`
@@ -28,15 +23,6 @@ export const ItemIcon = styled(Icon)`
 export const HoverMenu = styled(EntityItem.Menu)`
   visibility: hidden;
   color: ${color("text-medium")};
-
-  &:hover {
-    color: ${color("text-dark")};
-  }
-
-  &.EntityMenu--open {
-    visibility: visible;
-    color: ${color("text-dark")};
-  }
 `;
 
 export const Title = styled.div`

--- a/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.tsx
@@ -1,0 +1,119 @@
+import React, { useState, useCallback } from "react";
+
+import Tooltip from "metabase/components/Tooltip";
+import { ANALYTICS_CONTEXT } from "metabase/collections/constants";
+
+import {
+  ItemLink,
+  ItemCard,
+  Header,
+  Body,
+  ItemIcon,
+  Title,
+  Description,
+  HoverMenu,
+} from "./PinnedItemCard.styled";
+
+type Item = {
+  name: string;
+  description: string | null;
+  collection_position?: number | null;
+  id: number;
+  getIcon: () => { name: string };
+  getUrl: () => string;
+  setArchived: (isArchived: boolean) => void;
+  copy?: boolean;
+  setCollection?: boolean;
+};
+
+type Collection = {
+  can_write: boolean;
+};
+
+type Props = {
+  className?: string;
+  item: Item;
+  collection: Collection;
+  onToggleSelected: (item: Item) => void;
+  onCopy: (items: Item[]) => void;
+  onMove: (items: Item[]) => void;
+};
+
+function PinnedItemCard({
+  className,
+  item,
+  collection,
+  onToggleSelected,
+  onCopy,
+  onMove,
+}: Props) {
+  const [showDescriptionTooltip, setShowDescriptionTooltip] = useState(false);
+  const icon = item.getIcon().name;
+  const { description, name } = item;
+
+  const maybeEnableDescriptionTooltip = (
+    event: React.MouseEvent<HTMLDivElement, MouseEvent>,
+  ) => {
+    const target = event.target as HTMLDivElement;
+    // check if the description is wider than the card
+    if (target && target.scrollWidth > target.clientWidth) {
+      setShowDescriptionTooltip(true);
+    }
+  };
+
+  const handlePin = useCallback(() => {
+    onToggleSelected(item);
+  }, [item, onToggleSelected]);
+
+  const handleCopy = useCallback(() => {
+    onCopy([item]);
+  }, [item, onCopy]);
+
+  const handleMove = useCallback(() => {
+    onMove([item]);
+  }, [item, onMove]);
+
+  const handleArchive = useCallback(() => {
+    item.setArchived(true);
+  }, [item]);
+
+  return (
+    <ItemLink to={item.getUrl()}>
+      <ItemCard className={className}>
+        <Body>
+          <Header>
+            <ItemIcon name={icon} />
+            <HoverMenu
+              item={item}
+              onPin={collection.can_write ? handlePin : null}
+              onMove={
+                collection.can_write && item.setCollection ? handleMove : null
+              }
+              onCopy={item.copy ? handleCopy : null}
+              onArchive={
+                collection.can_write && item.setArchived ? handleArchive : null
+              }
+              analyticsContext={ANALYTICS_CONTEXT}
+              className={undefined}
+            />
+          </Header>
+          <Title>{name}</Title>
+          <Tooltip
+            tooltip={description}
+            placement="bottom"
+            maxWidth={450}
+            isEnabled={showDescriptionTooltip}
+          >
+            {description && (
+              <Description onMouseEnter={maybeEnableDescriptionTooltip}>
+                {description}
+              </Description>
+            )}
+          </Tooltip>
+        </Body>
+      </ItemCard>
+    </ItemLink>
+  );
+}
+
+export default PinnedItemCard;

--- a/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.tsx
@@ -55,8 +55,9 @@ function PinnedItemCard({
     event: React.MouseEvent<HTMLDivElement, MouseEvent>,
   ) => {
     const target = event.target as HTMLDivElement;
-    // check if the description is wider than the card
-    if (target && target.scrollWidth > target.clientWidth) {
+    const isDescriptionWiderThanCard =
+      target?.scrollWidth > target?.clientWidth;
+    if (isDescriptionWiderThanCard) {
       setShowDescriptionTooltip(true);
     }
   };

--- a/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.tsx
@@ -83,19 +83,28 @@ function PinnedItemCard({
         <Body>
           <Header>
             <ItemIcon name={icon} />
-            <HoverMenu
-              item={item}
-              onPin={collection.can_write ? handlePin : null}
-              onMove={
-                collection.can_write && item.setCollection ? handleMove : null
-              }
-              onCopy={item.copy ? handleCopy : null}
-              onArchive={
-                collection.can_write && item.setArchived ? handleArchive : null
-              }
-              analyticsContext={ANALYTICS_CONTEXT}
-              className={undefined}
-            />
+            <div
+              onClick={e => {
+                e.stopPropagation();
+                e.preventDefault();
+              }}
+            >
+              <HoverMenu
+                item={item}
+                onPin={collection.can_write ? handlePin : null}
+                onMove={
+                  collection.can_write && item.setCollection ? handleMove : null
+                }
+                onCopy={item.copy ? handleCopy : null}
+                onArchive={
+                  collection.can_write && item.setArchived
+                    ? handleArchive
+                    : null
+                }
+                analyticsContext={ANALYTICS_CONTEXT}
+                className={undefined}
+              />
+            </div>
           </Header>
           <Title>{name}</Title>
           <Tooltip

--- a/frontend/src/metabase/collections/components/PinnedItemCard/index.ts
+++ b/frontend/src/metabase/collections/components/PinnedItemCard/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./PinnedItemCard";

--- a/frontend/src/metabase/components/Card.tsx
+++ b/frontend/src/metabase/components/Card.tsx
@@ -2,7 +2,15 @@ import styled from "styled-components";
 import { space, width } from "styled-system";
 import { color, alpha } from "metabase/lib/colors";
 
-const Card = styled.div`
+type CardProps = {
+  className?: string;
+  dark?: boolean;
+  hoverable?: boolean;
+  flat?: boolean;
+  compact?: boolean;
+};
+
+const Card = styled.div<CardProps>`
   ${width}
   ${space}
   background-color: ${props => (props.dark ? color("text-dark") : "white")};

--- a/frontend/src/metabase/components/EntityMenu.jsx
+++ b/frontend/src/metabase/components/EntityMenu.jsx
@@ -49,7 +49,11 @@ class EntityMenu extends Component {
     } = this.props;
     const { open, menuItemContent } = this.state;
     return (
-      <div className={cx("relative", className)}>
+      <div
+        className={cx("relative", className, {
+          "EntityMenu--open": open,
+        })}
+      >
         <EntityMenuTrigger
           trigger={trigger}
           icon={triggerIcon}

--- a/frontend/src/metabase/components/EntityMenu.jsx
+++ b/frontend/src/metabase/components/EntityMenu.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { Motion, spring } from "react-motion";
-import cx from "classnames";
 
 import { isReducedMotionPreferred } from "metabase/lib/dom";
 
@@ -9,6 +8,8 @@ import Card from "metabase/components/Card";
 import EntityMenuTrigger from "metabase/components/EntityMenuTrigger";
 import EntityMenuItem from "metabase/components/EntityMenuItem";
 import Popover from "metabase/components/Popover";
+
+import { Container } from "./EntityMenu.styled";
 
 const MENU_SHIFT_Y = 10;
 
@@ -49,11 +50,7 @@ class EntityMenu extends Component {
     } = this.props;
     const { open, menuItemContent } = this.state;
     return (
-      <div
-        className={cx("relative", className, {
-          "EntityMenu--open": open,
-        })}
-      >
+      <Container className={className} open={open}>
         <EntityMenuTrigger
           trigger={trigger}
           icon={triggerIcon}
@@ -156,7 +153,7 @@ class EntityMenu extends Component {
             }}
           </Motion>
         </Popover>
-      </div>
+      </Container>
     );
   }
 }

--- a/frontend/src/metabase/components/EntityMenu.styled.tsx
+++ b/frontend/src/metabase/components/EntityMenu.styled.tsx
@@ -1,0 +1,10 @@
+import styled from "styled-components";
+
+type ContainerProps = {
+  open: boolean;
+};
+
+export const Container = styled.div<ContainerProps>`
+  display: relative;
+  visibility: ${({ open }) => open && "visible"} !important;
+`;


### PR DESCRIPTION
Related to #19758. This is going into a feature branch, `dj-collection-changes`.

This PR adds a new card component wrapped in a link. I'll be using it in the new pinned item section in collections. This PR doesn't use the component in an implementation, but I've added some stories to storybook, so check it out:

<img width="508" alt="Screen Shot 2022-01-18 at 6 10 29 PM" src="https://user-images.githubusercontent.com/13057258/150050589-8de66aef-05e9-4e88-a387-252dce372666.png">

When a description is too long hovering will show a tooltip:
<img width="509" alt="Screen Shot 2022-01-18 at 6 10 34 PM" src="https://user-images.githubusercontent.com/13057258/150050594-a8955875-2546-458b-a8ad-567036942b1e.png">

Hovering over the card shows an ellipsis menu, not unlike what currently exists in the UI:
<img width="509" alt="Screen Shot 2022-01-18 at 6 10 52 PM" src="https://user-images.githubusercontent.com/13057258/150050596-50422fca-6069-4b59-9f17-6ff9e3cde6a0.png">

