### PR TITLE
Static viz card vs. normal errors 18676

### DIFF
--- a/src/metabase/pulse/render.clj
+++ b/src/metabase/pulse/render.clj
@@ -143,11 +143,11 @@
     (catch Throwable e
       (if (:card-error (ex-data e))
         (do
-          (body/render :card-error nil nil nil nil nil)
-          (log/error e (trs "Pulse card query error")))
+          (log/error e (trs "Pulse card query error"))
+          (body/render :card-error nil nil nil nil nil))
         (do
-          (body/render :render-error nil nil nil nil nil)
-          (log/error e (trs "Pulse card render error")))))))
+          (log/error e (trs "Pulse card render error"))
+          (body/render :render-error nil nil nil nil nil))))))
 
 (defn- card-href
   [card]

--- a/src/metabase/pulse/render.clj
+++ b/src/metabase/pulse/render.clj
@@ -144,7 +144,7 @@
       (log/error e (trs "Pulse card render error"))
       (if (:card-error (ex-data e))
         (body/render :card-error nil nil nil nil nil)
-        (body/render :error nil nil nil nil nil))))
+        (body/render :error nil nil nil nil nil)))))
 
 (defn- card-href
   [card]

--- a/src/metabase/pulse/render.clj
+++ b/src/metabase/pulse/render.clj
@@ -141,10 +141,13 @@
       (log/debug (trs "Rendering pulse card with chart-type {0} and render-type {1}" chart-type render-type))
       (body/render chart-type render-type timezone-id card dashcard data))
     (catch Throwable e
-      (log/error e (trs "Pulse card render error"))
       (if (:card-error (ex-data e))
-        (body/render :card-error nil nil nil nil nil)
-        (body/render :error nil nil nil nil nil)))))
+        (do
+          (body/render :card-error nil nil nil nil nil)
+          (log/error e (trs "Pulse card query error")))
+        (do
+          (body/render :render-error nil nil nil nil nil)
+          (log/error e (trs "Pulse card render error")))))))
 
 (defn- card-href
   [card]

--- a/src/metabase/pulse/render.clj
+++ b/src/metabase/pulse/render.clj
@@ -133,7 +133,7 @@
   [render-type timezone-id :- (s/maybe s/Str) card dashcard {:keys [data error], :as results}]
   (try
     (when error
-      (throw (ex-info (tru "Card has errors: {0}" error) results)))
+      (throw (ex-info (tru "Card has errors: {0}" error) (assoc results :card-error true))))
     (let [chart-type (or (detect-pulse-chart-type card dashcard data)
                          (when (is-attached? card)
                            :attached)
@@ -142,7 +142,9 @@
       (body/render chart-type render-type timezone-id card dashcard data))
     (catch Throwable e
       (log/error e (trs "Pulse card render error"))
-      (body/render :error nil nil nil nil nil))))
+      (if (:card-error (ex-data e))
+        (body/render :card-error nil nil nil nil nil)
+        (body/render :error nil nil nil nil nil))))
 
 (defn- card-href
   [card]

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -21,8 +21,23 @@
             [schema.core :as s])
   (:import [java.text DecimalFormat DecimalFormatSymbols]))
 
+(def ^:private card-error-rendered-info
+  "Default rendered-info map when there is an error displaying a card on the card run.
+  Is a delay due to the call to `trs`."
+  (delay {:attachments
+          nil
+
+          :content
+          [:div {:style (style/style
+                         (style/font-style)
+                         {:color       style/color-error
+                          :font-weight 700
+                          :padding     :16px})}
+           (trs "There was a problem with this question.")]}))
+
 (def ^:private error-rendered-info
-  "Default rendered-info map when there is an error displaying a card. Is a delay due to the call to `trs`."
+  "Default rendered-info map when there is an error displaying a card on the static viz side.
+  Is a delay due to the call to `trs`."
   (delay {:attachments
           nil
 
@@ -838,6 +853,11 @@
     (trs "We were unable to display this Pulse.")
     [:br]
     (trs "Please view this card in Metabase.")]})
+
+(s/defmethod render :card-error :- common/RenderedPulseCard
+  "Card error means that the error is in the card, not the static viz rendering apparatus"
+  [_ _ _ _ _ _]
+  @card-error-rendered-info)
 
 (s/defmethod render :error :- common/RenderedPulseCard
   [_ _ _ _ _ _]

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -22,7 +22,7 @@
   (:import [java.text DecimalFormat DecimalFormatSymbols]))
 
 (def ^:private card-error-rendered-info
-  "Default rendered-info map when there is an error displaying a card on the card run.
+  "Default rendered-info map when there is an error running a card on the card run.
   Is a delay due to the call to `trs`."
   (delay {:attachments
           nil

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -855,7 +855,6 @@
     (trs "Please view this card in Metabase.")]})
 
 (s/defmethod render :card-error :- common/RenderedPulseCard
-  "Card error means that the error is in the card, not the static viz rendering apparatus"
   [_ _ _ _ _ _]
   @card-error-rendered-info)
 

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -858,6 +858,6 @@
   [_ _ _ _ _ _]
   @card-error-rendered-info)
 
-(s/defmethod render :error :- common/RenderedPulseCard
+(s/defmethod render :render-error :- common/RenderedPulseCard
   [_ _ _ _ _ _]
   @error-rendered-info)

--- a/test/metabase/pulse/render/body_test.clj
+++ b/test/metabase/pulse/render/body_test.clj
@@ -253,7 +253,7 @@
 (deftest error-test
   (testing "renders error"
     (= "An error occurred while displaying this card."
-       (-> (body/render :error nil nil nil nil nil) :content last)))
+       (-> (body/render :render-error nil nil nil nil nil) :content last)))
   (testing "renders card error"
     (= "There was a problem with this question."
        (-> (body/render :card-error nil nil nil nil nil) :content last))))

--- a/test/metabase/pulse/render/body_test.clj
+++ b/test/metabase/pulse/render/body_test.clj
@@ -250,6 +250,14 @@
                                                {:cols test-columns-with-date-semantic-type :rows test-data}
                                                (count test-columns))))))
 
+(deftest error-test
+  (testing "renders error"
+    (= "An error occurred while displaying this card."
+       (-> (body/render :error nil nil nil nil nil) :content last)))
+  (testing "renders card error"
+    (= "There was a problem with this question."
+       (-> (body/render :card-error nil nil nil nil nil) :content last))))
+
 (defn- render-scalar-value [results]
   (-> (body/render :scalar nil pacific-tz nil nil results)
       :content

--- a/test/metabase/pulse/render_test.clj
+++ b/test/metabase/pulse/render_test.clj
@@ -33,8 +33,8 @@
 (deftest render-error-test
   (testing "gives us a proper error if we have erroring card"
     (is (= (get-in (render/render-pulse-card-for-display
-                 nil nil
-                 {:error "some error"}) [1 2 4 2 2])
+                     nil nil
+                     {:error "some error"}) [1 2 4 2 2])
            "There was a problem with this question."))))
 
 (deftest detect-pulse-chart-type-test

--- a/test/metabase/pulse/render_test.clj
+++ b/test/metabase/pulse/render_test.clj
@@ -30,6 +30,13 @@
                                      :breakout    [!month.date]}))
                                  [:td _ "November 2015"])))))
 
+(deftest render-error-test
+  (testing "gives us a proper error if we have erroring card"
+    (is (= (get-in (render/render-pulse-card-for-display
+                 nil nil
+                 {:error "some error"}) [1 2 4 2 2])
+           "There was a problem with this question."))))
+
 (deftest detect-pulse-chart-type-test
   (is (= :scalar
          (render/detect-pulse-chart-type {:display :anything}


### PR DESCRIPTION
Tests are upcoming.

Previously card errors and static-viz-qua-static-viz errors were not differentiated in UI. This is not very helpful because the end user can only debug their own queries, not the static viz errors (unless they want to spelunk in the rendering codebase). So there is to be an error and a card-error rendering, to differentiate between the two. Think of it as getting a HTTP error in the 400s (client's fault) vs the 500s (server's fault).