### PR TITLE
Warn when archived model is used as a data source

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
@@ -1,12 +1,17 @@
 import React from "react";
 import { t } from "ttag";
 import PropTypes from "prop-types";
+
+import { color } from "metabase/lib/colors";
 import {
   isVirtualCardId,
   getQuestionIdFromVirtualTableId,
 } from "metabase/lib/saved-questions";
 import * as Urls from "metabase/lib/urls";
 import Questions from "metabase/entities/questions";
+
+import Tooltip from "metabase/components/Tooltip";
+
 import TableInfoPopover from "metabase/components/MetadataInfo/TableInfoPopover";
 
 import { HeadBreadcrumbs } from "./HeaderBreadcrumbs";
@@ -106,13 +111,28 @@ function SourceDatasetBreadcrumbs({ dataset, ...props }) {
         >
           {collection?.name || t`Our analytics`}
         </HeadBreadcrumbs.Badge>,
-        <HeadBreadcrumbs.Badge
-          key="dataset-name"
-          to={Urls.question(dataset)}
-          inactiveColor="text-light"
-        >
-          {dataset.name}
-        </HeadBreadcrumbs.Badge>,
+        dataset.archived ? (
+          <Tooltip
+            key="dataset-name"
+            tooltip={t`This model is archived and shouldn't be used.`}
+            maxWidth="auto"
+            placement="bottom"
+          >
+            <HeadBreadcrumbs.Badge
+              inactiveColor="text-light"
+              icon={{ name: "warning", color: color("danger") }}
+            >
+              {dataset.name}
+            </HeadBreadcrumbs.Badge>
+          </Tooltip>
+        ) : (
+          <HeadBreadcrumbs.Badge
+            to={Urls.question(dataset)}
+            inactiveColor="text-light"
+          >
+            {dataset.name}
+          </HeadBreadcrumbs.Badge>
+        ),
       ]}
     />
   );


### PR DESCRIPTION
Models can be archived like any other application entity. Though we want to let people know if a saved question they're looking at is using an archived model. This PR adds a "warning" icon to saved question's data source breadcrumbs if they're using an archived model.

### To Verify

1. Create a model
2. Create a question based on a model
3. Archive the model
4. Open the saved question based on the model
5. You should see a red "warning" icon on the left side from the model's name in the question header. Hovering the icon or model name should display a tooltip saying the model is archived and shouldn't be used
6. Unarchive the model, the warning icon should be gone

### Demo

<img width="582" alt="CleanShot 2022-01-19 at 18 06 35@2x" src="https://user-images.githubusercontent.com/17258145/150170026-89c85116-d66c-42c7-8abf-006bb6582fbe.png">

