### PR TITLE
Remove hardcoded project-id from bigquery-cloud-sdk tests

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/common.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/common.clj
@@ -14,13 +14,19 @@
   this dynamic var to the JVM TZ rather than UTC"
   "UTC")
 
+(defn service-account-json->service-account-credential
+  "Returns a `ServiceAccountCredentials` (not scoped) for the given `service-account-json` (String)."
+  {:added "0.42.0"}
+  ^ServiceAccountCredentials [^String service-account-json]
+  (ServiceAccountCredentials/fromStream (ByteArrayInputStream. (.getBytes service-account-json))))
+
 (defn database-details->service-account-credential
   "Returns a `ServiceAccountCredentials` (not scoped) for the given `db-details`, which is based upon the value
   associated to its `service-account-json` key (a String)."
   {:added "0.42.0"}
   ^ServiceAccountCredentials [{:keys [^String service-account-json] :as db-details}]
   {:pre [(map? db-details) (seq service-account-json)]}
-  (ServiceAccountCredentials/fromStream (ByteArrayInputStream. (.getBytes service-account-json))))
+  (service-account-json->service-account-credential service-account-json))
 
 (defn database-details->credential-project-id
   "Uses the given DB `details` credentials to determine the embedded project-id.  This is basically an

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -176,9 +176,10 @@
 (def ^:private bignumeric-val "-7.5E30")
 (def ^:private bigdecimal-val "5.2E35")
 
-(def ^:private bigquery-project-id (-> (tx/db-test-env-var-or-throw :bigquery-cloud-sdk :service-account-json)
-                                       bigquery.common/service-account-json->service-account-credential
-                                       (.getProjectId)))
+(defn- bigquery-project-id []
+  (-> (tx/db-test-env-var-or-throw :bigquery-cloud-sdk :service-account-json)
+      bigquery.common/service-account-json->service-account-credential
+      (.getProjectId)))
 
 (defmacro with-numeric-types-table [[table-name-binding] & body]
   `(do-with-temp-obj "table_%s"
@@ -282,7 +283,7 @@
                        {:filter [:= [:field (mt/id :taxi_trips :unique_key) nil]
                                     "67794e631648a002f88d4b7f3ab0bcb6a9ed306a"]})))))
           (testing " has project-id-from-credentials set correctly"
-            (is (= bigquery-project-id (get-in temp-db [:details :project-id-from-credentials])))))))))
+            (is (= (bigquery-project-id) (get-in temp-db [:details :project-id-from-credentials])))))))))
 
 (deftest bigquery-specific-types-test
   (testing "Table with decimal types"
@@ -405,17 +406,15 @@
                 (mt/with-db (Database db-id)
                   ;; having only changed the driver old->new, the existing card query should produce the same results
                   (check-card-query-res temp-card)
-                  (is (= bigquery-project-id
+                  (is (= (bigquery-project-id)
                          (get-in (Database db-id)
                                  [:details :project-id-from-credentials]))))))))))))
 
 (defn- sync-and-assert-filtered-tables [database assert-table-fn]
   (mt/with-temp Database [db-filtered database]
-    (let [sync-results (sync/sync-database! db-filtered {:scan :schema})
-          tables       (Table :db_id (u/the-id db-filtered))]
-      (is (not (empty? tables)))
-      (doseq [table (Table :db_id (u/the-id db-filtered))]
-        (assert-table-fn table)))))
+    (sync/sync-database! db-filtered {:scan :schema})
+    (doseq [table (Table :db_id (u/the-id db-filtered))]
+      (assert-table-fn table))))
 
 (deftest dataset-filtering-test
   (mt/test-driver :bigquery-cloud-sdk

--- a/test/metabase/models/database_test.clj
+++ b/test/metabase/models/database_test.clj
@@ -59,6 +59,7 @@
 
 (deftest sensitive-data-redacted-test
   (let [encode-decode (fn [obj] (decode (encode obj)))
+        project-id    "random-project-id" ; the actual value here doesn't seem to matter
         ;; this is trimmed for the parts we care about in the test
         pg-db         (mdb/map->DatabaseInstance
                        {:description nil
@@ -85,7 +86,7 @@
                                       :dataset-id           "office_checkins"
                                       :service-account-json "SERVICE-ACCOUNT-JSON-HERE"
                                       :use-jvm-timezone     false
-                                      :project-id           "metabase-bigquery-driver"}
+                                      :project-id           project-id}
                         :id          2
                         :engine      :bigquery})]
     (testing "sensitive fields are redacted when database details are encoded"
@@ -129,7 +130,7 @@
                                  "dataset-id"           "office_checkins"
                                  "service-account-json" "**MetabasePass**"
                                  "use-jvm-timezone"     false
-                                 "project-id"           "metabase-bigquery-driver"}
+                                 "project-id"           project-id}
                   "id"          2
                   "engine"      "bigquery"}
                  (encode-decode bq-db))))))))


### PR DESCRIPTION
Pull out common helper fn to extract project-id from credentials

Update `bigquery_cloud_sdk_test.clj` to have a var that loads the `service-account-json` from the env var, then uses aforementioned function to determine project-id

Change `sensitive-data-redacted-test` to use an arbitrary/fake project-id to remove any sort of confusion
