### PR TITLE
Custom expression editor: initial overflow to fix text cut-off

### DIFF
--- a/frontend/src/metabase/query_builder/components/ExpressionPopover.css
+++ b/frontend/src/metabase/query_builder/components/ExpressionPopover.css
@@ -1,3 +1,3 @@
 .PopoverBody .ExpressionPopover {
-  width: 498px;
+  width: 480px;
 }

--- a/frontend/src/metabase/query_builder/components/expressions/expressions.css
+++ b/frontend/src/metabase/query_builder/components/expressions/expressions.css
@@ -1,3 +1,7 @@
+.expression-editor-textfield .ace_editor {
+  overflow: initial;
+}
+
 .expression-editor-textfield .ace_content * {
   font-family: monospace !important;
 }

--- a/frontend/src/metabase/query_builder/components/expressions/expressions.css
+++ b/frontend/src/metabase/query_builder/components/expressions/expressions.css
@@ -2,6 +2,10 @@
   overflow: initial;
 }
 
+.expression-editor-textfield textarea {
+  min-height: 5px;
+}
+
 .expression-editor-textfield .ace_content * {
   font-family: monospace !important;
 }


### PR DESCRIPTION
The fix from @flamber!

How to verify (Make sure to tweak Chrome/Chromium, if the problem isn't demonstrated. See #19706 for details) 

1. New, Question
2. Sample Dataset, Products table
3. Custom column, type something e.g. `42`

**Before this PR**

The text is cut-off because the line for the editor (in Ace) is shifted vertically:

![image](https://user-images.githubusercontent.com/7288/150234263-610d38d3-53d4-4b9c-a61e-4d1333e759a4.png)


**After this PR**

Beautiful as expected:

![image](https://user-images.githubusercontent.com/7288/150234150-cceb9da9-3f37-4b38-bef2-60386c635718.png)

## Note

Another place where this popover needs to be checked:

* Filter, Custom Expression from the Notebook

![image](https://user-images.githubusercontent.com/7288/150235671-2937f322-07b2-49df-8f3e-8db2a88c5850.png)

* Filter, Custom Expression from the Sidebar

![image](https://user-images.githubusercontent.com/7288/150234530-20b4b52e-674d-4ff3-9fc8-5e1f13ad956e.png)
