### PR TITLE
Use GitHub Actions to run back-end tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1002,8 +1002,8 @@ workflows:
       - clojure:
           matrix:
             parameters:
-              edition: ["ee", "oss"]
-              java-version: ["java-11", "java-17"]
+              edition: ["ee"]
+              java-version: ["java-11"]
           name: be-tests-<< matrix.java-version >>-<< matrix.edition >>
           requires:
             - be-deps

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -40,3 +40,46 @@ jobs:
         m2-cache-key: 'namespace-decls'
     - run: clojure -X:dev:ee:ee-dev:drivers:drivers-dev:test:namespace-checker
       name: Check ns forms
+
+  be-tests:
+    runs-on: ubuntu-20.04
+    name: be-tests-java-${{ matrix.java-version }}-${{ matrix.edition }}
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        edition: [oss, ee]
+        java-version: [11, 17]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Prepare front-end environment
+      uses: ./.github/actions/prepare-frontend
+    - name: Prepare back-end environment
+      uses: ./.github/actions/prepare-backend
+
+    - run: yarn install --frozen-lockfile --prefer-offline
+    - name: Build static viz frontend
+      run: yarn build-static-viz
+
+    - name: Compile Java source file(s)
+      run: clojure -X:deps prep
+    - name: Compile driver AOT namespaces
+      working-directory: modules/drivers
+      run: clojure -X:deps prep
+    - name: Fetch dependencies
+      run: clojure -P -X:dev:ci:ee:ee-dev:drivers:drivers-dev
+    - name: Fetch dependencies  (./bin/build/build-mb)
+      working-directory: bin/build-mb
+      run: clojure -P -M:test
+    - name: Fetch dependencies (./bin/build/build-drivers)
+      working-directory: bin/build-drivers
+      run: clojure -P -M:test
+
+    - name: Run tests
+      run: clojure -X:dev:ci:test:${{ matrix.edition }}:${{ matrix.edition }}-dev
+    - name: Publish Test Report (JUnit)
+      uses: mikepenz/action-junit-report@v2
+      if: always()
+      with:
+        report_paths: 'target/junit/**/*_test.xml'
+        check_name: JUnit Test Report be-tests-java-${{ matrix.java-version }}-${{ matrix.edition }}


### PR DESCRIPTION
**Before this PR**

These tests run on Circle CI.

![image](https://user-images.githubusercontent.com/7288/169105186-eccbc05d-902a-4eff-ad57-567f8a971e80.png)

**After this PR**

The tests run on GitHub Actions. Same spirit as PR #15507, #14701, #14050, ##20128 (to leverage faster/tweakable GitHub CI runner, leaving more Circle CI containers to run e.g. Cypress tests).

![image](https://user-images.githubusercontent.com/7288/169107992-e5fbc391-fe33-46fb-9aa9-571f8c7b1387.png)

A bonus advantage: when there is a failing test, the annotation can be see right here in the Actions workflow report:

![image](https://user-images.githubusercontent.com/7288/152190759-ad202945-e072-4e7e-807f-11727aa120ac.png)


