### PR TITLE
Collections page UI changes

### DIFF
--- a/frontend/src/metabase/collections/components/BaseItemsTable.jsx
+++ b/frontend/src/metabase/collections/components/BaseItemsTable.jsx
@@ -8,6 +8,7 @@ import {
   Table,
   SortingIcon,
   SortingControlContainer,
+  Tbody,
 } from "./BaseItemsTable.styled";
 
 const sortingOptsShape = PropTypes.shape({
@@ -119,7 +120,7 @@ function BaseItemsTable({
         <col />
         <col style={{ width: "140px" }} />
         <col style={{ width: "140px" }} />
-        <col style={{ width: "60px" }} />
+        <col style={{ width: "100px" }} />
       </colgroup>
       {!headless && (
         <thead
@@ -161,7 +162,7 @@ function BaseItemsTable({
           </tr>
         </thead>
       )}
-      <tbody>{items.map(itemRenderer)}</tbody>
+      <Tbody>{items.map(itemRenderer)}</Tbody>
     </Table>
   );
 }

--- a/frontend/src/metabase/collections/components/BaseItemsTable.jsx
+++ b/frontend/src/metabase/collections/components/BaseItemsTable.jsx
@@ -8,7 +8,7 @@ import {
   Table,
   SortingIcon,
   SortingControlContainer,
-  Tbody,
+  TBody,
 } from "./BaseItemsTable.styled";
 
 const sortingOptsShape = PropTypes.shape({
@@ -162,7 +162,7 @@ function BaseItemsTable({
           </tr>
         </thead>
       )}
-      <Tbody>{items.map(itemRenderer)}</Tbody>
+      <TBody>{items.map(itemRenderer)}</TBody>
     </Table>
   );
 }

--- a/frontend/src/metabase/collections/components/BaseItemsTable.styled.jsx
+++ b/frontend/src/metabase/collections/components/BaseItemsTable.styled.jsx
@@ -12,6 +12,7 @@ const LAST_EDITED_AT_INDEX = 4;
 
 export const Table = styled.table.attrs({ className: "ContentTable" })`
   table-layout: fixed;
+  border-collapse: unset;
 
   ${breakpointMaxMedium} {
     & td:nth-child(${LAST_EDITED_BY_INDEX}),
@@ -68,8 +69,54 @@ export const SortingControlContainer = styled.div`
   }
 `;
 
-export const TableItemSecondaryField = styled.p`
+export const TableItemSecondaryField = styled.span`
   font-size: 0.95em;
-  font-weight: bold;
-  color: ${color("text-dark")};
+  color: ${color("text-medium")};
+`;
+
+export const Tbody = styled.tbody`
+  background-color: ${color("white")};
+
+  td {
+    border: none;
+    background-color: transparent;
+
+    border-top: 1px solid ${color("border")};
+
+    &:first-child {
+      border-left: 1px solid ${color("border")};
+    }
+
+    &:last-child {
+      border-right: 1px solid ${color("border")};
+    }
+  }
+
+  tr {
+    background-color: transparent;
+  }
+
+  tr:first-child {
+    td:first-child {
+      border-top-left-radius: 8px;
+    }
+
+    td:last-child {
+      border-top-right-radius: 8px;
+    }
+  }
+
+  tr:last-child {
+    td {
+      border-bottom: 1px solid ${color("border")};
+
+      &:last-child {
+        border-bottom-right-radius: 8px;
+      }
+
+      &:first-child {
+        border-bottom-left-radius: 8px;
+      }
+    }
+  }
 `;

--- a/frontend/src/metabase/collections/components/BaseItemsTable.styled.jsx
+++ b/frontend/src/metabase/collections/components/BaseItemsTable.styled.jsx
@@ -74,7 +74,7 @@ export const TableItemSecondaryField = styled.span`
   color: ${color("text-medium")};
 `;
 
-export const Tbody = styled.tbody`
+export const TBody = styled.tbody`
   background-color: ${color("white")};
 
   td {

--- a/frontend/src/metabase/collections/components/BaseTableItem.jsx
+++ b/frontend/src/metabase/collections/components/BaseTableItem.jsx
@@ -1,9 +1,8 @@
-import React, { useCallback } from "react";
+import React, { useState, useCallback } from "react";
 import PropTypes from "prop-types";
 import moment from "moment";
 
 import { PLUGIN_MODERATION } from "metabase/plugins";
-import { color } from "metabase/lib/colors";
 
 import ItemDragSource from "metabase/containers/dnd/ItemDragSource";
 
@@ -48,6 +47,8 @@ export function BaseTableItem({
   onDrop,
   onToggleSelected,
 }) {
+  const [isHoveringOverRow, setIsHoveringOverRow] = useState(false);
+
   const handleSelectionToggled = useCallback(() => {
     onToggleSelected(item);
   }, [item, onToggleSelected]);
@@ -77,15 +78,24 @@ export function BaseTableItem({
     const testId = isPinned ? "pinned-collection-entry" : "collection-entry";
 
     const trStyles = {
-      height: 80,
-      borderBottom: hasBottomBorder ? `1px solid ${color("border")}` : "",
+      height: 48,
     };
 
     // Table row can be wrapped with ItemDragSource,
     // that only accepts native DOM elements as its children
     // So styled-components can't be used here
     return (
-      <tr key={item.id} data-testid={testId} style={trStyles}>
+      <tr
+        onMouseEnter={() => {
+          setIsHoveringOverRow(true);
+        }}
+        onMouseLeave={() => {
+          setIsHoveringOverRow(false);
+        }}
+        key={item.id}
+        data-testid={testId}
+        style={trStyles}
+      >
         <td data-testid={`${testId}-type`}>
           <EntityIconCheckBox
             item={item}
@@ -95,6 +105,7 @@ export function BaseTableItem({
             selectable={canSelect}
             selected={isSelected}
             onToggleSelected={handleSelectionToggled}
+            showCheckbox={isHoveringOverRow}
           />
         </td>
         <td data-testid={`${testId}-name`}>
@@ -137,13 +148,13 @@ export function BaseTableItem({
     isPinned,
     isSelected,
     linkProps,
-    hasBottomBorder,
     handleArchive,
     handleCopy,
     handleMove,
     handlePin,
     handleSelectionToggled,
     onToggleSelected,
+    isHoveringOverRow,
   ]);
 
   if (!draggable) {

--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.jsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.jsx
@@ -17,27 +17,27 @@ import { PLUGIN_COLLECTION_COMPONENTS } from "metabase/plugins";
 
 import {
   Container,
-  DescriptionTooltipIcon,
+  DescriptionHeading,
   MenuContainer,
   ToggleMobileSidebarIcon,
 } from "./CollectionHeader.styled";
 
 function Title({ collection, handleToggleMobileSidebar }) {
   return (
-    <Flex align="center">
-      <ToggleMobileSidebarIcon onClick={handleToggleMobileSidebar} />
-      <PLUGIN_COLLECTION_COMPONENTS.CollectionAuthorityLevelIcon
-        collection={collection}
-        mr={1}
-        size={24}
-      />
-      <PageHeading className="text-wrap">{collection.name}</PageHeading>
+    <div>
+      <Flex align="center">
+        <ToggleMobileSidebarIcon onClick={handleToggleMobileSidebar} />
+        <PLUGIN_COLLECTION_COMPONENTS.CollectionAuthorityLevelIcon
+          collection={collection}
+          mr={1}
+          size={24}
+        />
+        <PageHeading className="text-wrap">{collection.name}</PageHeading>
+      </Flex>
       {collection.description && (
-        <Tooltip tooltip={collection.description}>
-          <DescriptionTooltipIcon />
-        </Tooltip>
+        <DescriptionHeading>{collection.description}</DescriptionHeading>
       )}
-    </Flex>
+    </div>
   );
 }
 

--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.styled.jsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.styled.jsx
@@ -21,6 +21,7 @@ export const Container = styled(Flex)`
 
 export const MenuContainer = styled(Flex)`
   margin-top: ${space(1)};
+  align-self: start;
 `;
 
 export const ToggleMobileSidebarIcon = styled(Icon).attrs({
@@ -46,4 +47,11 @@ export const DescriptionTooltipIcon = styled(Icon).attrs({
   &:hover {
     color: ${color("brand")};
   }
+`;
+
+export const DescriptionHeading = styled.div`
+  font-size: 1.15rem;
+  line-height: 1.7rem;
+  padding-top: 1.15rem;
+  max-width: 400px;
 `;

--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.styled.jsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.styled.jsx
@@ -50,8 +50,8 @@ export const DescriptionTooltipIcon = styled(Icon).attrs({
 `;
 
 export const DescriptionHeading = styled.div`
-  font-size: 1.15rem;
-  line-height: 1.7rem;
+  font-size: 1rem;
+  line-height: 1.5rem;
   padding-top: 1.15rem;
   max-width: 400px;
 `;

--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.unit.spec.js
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.unit.spec.js
@@ -14,13 +14,10 @@ it("should display collection name", () => {
 });
 
 describe("description tooltip", () => {
-  const ariaLabel = "info icon";
-
   describe("should not be displayed", () => {
     it("if description is not received", () => {
-      render(<Header collection={collection} />);
-
-      expect(screen.queryByLabelText(ariaLabel)).not.toBeInTheDocument();
+      const { container } = render(<Header collection={collection} />);
+      expect(container.textContent).toEqual("Name");
     });
   });
 
@@ -30,7 +27,7 @@ describe("description tooltip", () => {
 
       render(<Header collection={{ ...collection, description }} />);
 
-      screen.getByLabelText(ariaLabel);
+      screen.getByText(description);
     });
   });
 });

--- a/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.styled.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.styled.tsx
@@ -27,8 +27,8 @@ export const HoverMenu = styled(EntityItem.Menu)`
 
 export const Title = styled.div`
   font-weight: bold;
-  font-size: 1.15rem;
-  line-height: 1.7rem;
+  font-size: 1rem;
+  line-height: 1.5rem;
   color: ${color("text-dark")};
   transition: color 0.2s ease;
 `;

--- a/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.styled.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.styled.tsx
@@ -31,6 +31,9 @@ export const Title = styled.div`
   line-height: 1.5rem;
   color: ${color("text-dark")};
   transition: color 0.2s ease;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
 `;
 
 export const Description = forwardRefToInnerRef(styled.div`

--- a/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.tsx
@@ -24,6 +24,8 @@ type Props = {
   onMove: (items: Item[]) => void;
 };
 
+const TOOLTIP_MAX_WIDTH = 450;
+
 function getDefaultDescription(model: string) {
   return {
     card: t`A question`,
@@ -39,20 +41,21 @@ function PinnedItemCard({
   onCopy,
   onMove,
 }: Props) {
+  const [showTitleTooltip, setShowTitleTooltip] = useState(false);
   const [showDescriptionTooltip, setShowDescriptionTooltip] = useState(false);
   const icon = item.getIcon().name;
   const { description, name, model } = item;
 
   const defaultedDescription = description || getDefaultDescription(model);
 
-  const maybeEnableDescriptionTooltip = (
+  const maybeEnableTooltip = (
     event: React.MouseEvent<HTMLDivElement, MouseEvent>,
+    setterFn: React.Dispatch<React.SetStateAction<boolean>>,
   ) => {
     const target = event.target as HTMLDivElement;
-    const isDescriptionWiderThanCard =
-      target?.scrollWidth > target?.clientWidth;
-    if (isDescriptionWiderThanCard) {
-      setShowDescriptionTooltip(true);
+    const isTargetElWiderThanCard = target?.scrollWidth > target?.clientWidth;
+    if (isTargetElWiderThanCard) {
+      setterFn(true);
     }
   };
 
@@ -101,15 +104,30 @@ function PinnedItemCard({
               />
             </div>
           </Header>
-          <Title>{name}</Title>
+          <Tooltip
+            tooltip={name}
+            placement="bottom"
+            maxWidth={TOOLTIP_MAX_WIDTH}
+            isEnabled={showTitleTooltip}
+          >
+            <Title
+              onMouseEnter={e => maybeEnableTooltip(e, setShowTitleTooltip)}
+            >
+              {name}
+            </Title>
+          </Tooltip>
           <Tooltip
             tooltip={description}
             placement="bottom"
-            maxWidth={450}
+            maxWidth={TOOLTIP_MAX_WIDTH}
             isEnabled={showDescriptionTooltip}
           >
             {defaultedDescription && (
-              <Description onMouseEnter={maybeEnableDescriptionTooltip}>
+              <Description
+                onMouseEnter={e =>
+                  maybeEnableTooltip(e, setShowDescriptionTooltip)
+                }
+              >
                 {defaultedDescription}
               </Description>
             )}

--- a/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback } from "react";
+import { t } from "ttag";
 
 import Tooltip from "metabase/components/Tooltip";
 import { ANALYTICS_CONTEXT } from "metabase/collections/constants";
@@ -23,6 +24,14 @@ type Props = {
   onMove: (items: Item[]) => void;
 };
 
+function getDefaultDescription(model: string) {
+  return {
+    card: t`A question`,
+    dashboard: t`A dashboard`,
+    dataset: t`A model`,
+  }[model];
+}
+
 function PinnedItemCard({
   className,
   item,
@@ -32,7 +41,9 @@ function PinnedItemCard({
 }: Props) {
   const [showDescriptionTooltip, setShowDescriptionTooltip] = useState(false);
   const icon = item.getIcon().name;
-  const { description, name } = item;
+  const { description, name, model } = item;
+
+  const defaultedDescription = description || getDefaultDescription(model);
 
   const maybeEnableDescriptionTooltip = (
     event: React.MouseEvent<HTMLDivElement, MouseEvent>,
@@ -97,9 +108,9 @@ function PinnedItemCard({
             maxWidth={450}
             isEnabled={showDescriptionTooltip}
           >
-            {description && (
+            {defaultedDescription && (
               <Description onMouseEnter={maybeEnableDescriptionTooltip}>
-                {description}
+                {defaultedDescription}
               </Description>
             )}
           </Tooltip>

--- a/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebar.styled.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionSidebar/CollectionSidebar.styled.jsx
@@ -30,6 +30,7 @@ export const Sidebar = styled(Box.withComponent("aside"))`
   position: fixed;
   top: 65px;
   width: 0;
+  background-color: ${color("white")};
 
   ${props =>
     props.shouldDisplayMobileSidebar &&

--- a/frontend/src/metabase/components/CollectionLanding/CollectionLanding.styled.jsx
+++ b/frontend/src/metabase/components/CollectionLanding/CollectionLanding.styled.jsx
@@ -5,7 +5,6 @@ import { SIDEBAR_WIDTH } from "metabase/collections/constants";
 import { breakpointMinSmall } from "metabase/styled-components/theme/media-queries";
 
 export const ContentBox = styled(Box)`
-  background-color: white;
   display: ${props => (props.shouldDisplayMobileSidebar ? "none" : "block")};
   height: 100%;
   margin-left: ${props =>

--- a/frontend/src/metabase/components/EntityItem.jsx
+++ b/frontend/src/metabase/components/EntityItem.jsx
@@ -9,11 +9,14 @@ import Swapper from "metabase/components/Swapper";
 import CheckBox from "metabase/components/CheckBox";
 import Ellipsified from "metabase/components/Ellipsified";
 import Icon from "metabase/components/Icon";
+import Button from "metabase/components/Button";
 
 import {
   EntityIconWrapper,
   EntityItemSpinner,
   EntityItemWrapper,
+  EntityMenuContainer,
+  PinButton,
 } from "./EntityItem.styled";
 
 function EntityIconCheckBox({
@@ -23,6 +26,7 @@ function EntityIconCheckBox({
   pinned,
   selectable,
   selected,
+  showCheckbox,
   disabled,
   onToggleSelected,
   ...props
@@ -38,13 +42,13 @@ function EntityIconCheckBox({
       isPinned={pinned}
       model={item.model}
       onClick={selectable ? handleClick : null}
-      circle
+      rounded
       disabled={disabled}
       {...props}
     >
       {selectable ? (
         <Swapper
-          startSwapped={selected}
+          startSwapped={selected || showCheckbox}
           defaultElement={
             <Icon name={iconName} color={"inherit"} size={iconSize} />
           }
@@ -74,14 +78,14 @@ function EntityItemMenu({
   className,
   analyticsContext,
 }) {
+  const isPinned = item.collection_position != null;
+  const showPinnedAction = onPin && isPinned;
+
   const actions = useMemo(
     () =>
       [
-        onPin && {
-          title:
-            item.collection_position != null
-              ? t`Unpin this item`
-              : t`Pin this item`,
+        showPinnedAction && {
+          title: isPinned ? t`Unpin this item` : t`Pin this item`,
           icon: "pin",
           action: onPin,
           event: `${analyticsContext};Entity Item;Pin Item;${item.model}`,
@@ -105,17 +109,29 @@ function EntityItemMenu({
           event: `${analyticsContext};Entity Item;Archive Item;${item.model}`,
         },
       ].filter(action => action),
-    [item, onPin, onMove, onCopy, onArchive, analyticsContext],
+    [
+      showPinnedAction,
+      isPinned,
+      onPin,
+      analyticsContext,
+      item.model,
+      onMove,
+      onCopy,
+      onArchive,
+    ],
   );
   if (actions.length === 0) {
     return null;
   }
   return (
-    <EntityMenu
-      className={cx(className, "hover-child")}
-      triggerIcon="ellipsis"
-      items={actions}
-    />
+    <EntityMenuContainer align="center">
+      {!isPinned && <PinButton icon="pin" onClick={onPin} />}
+      <EntityMenu
+        className={cx(className, "hover-child")}
+        triggerIcon="ellipsis"
+        items={actions}
+      />
+    </EntityMenuContainer>
   );
 }
 

--- a/frontend/src/metabase/components/EntityItem.jsx
+++ b/frontend/src/metabase/components/EntityItem.jsx
@@ -9,7 +9,7 @@ import Swapper from "metabase/components/Swapper";
 import CheckBox from "metabase/components/CheckBox";
 import Ellipsified from "metabase/components/Ellipsified";
 import Icon from "metabase/components/Icon";
-import Button from "metabase/components/Button";
+import Tooltip from "metabase/components/Tooltip";
 
 import {
   EntityIconWrapper,
@@ -125,7 +125,11 @@ function EntityItemMenu({
   }
   return (
     <EntityMenuContainer align="center">
-      {!isPinned && <PinButton icon="pin" onClick={onPin} />}
+      {!isPinned && (
+        <Tooltip tooltip={t`Pin this`}>
+          <PinButton icon="pin" onClick={onPin} />
+        </Tooltip>
+      )}
       <EntityMenu
         className={cx(className, "hover-child")}
         triggerIcon="ellipsis"

--- a/frontend/src/metabase/components/EntityItem.styled.jsx
+++ b/frontend/src/metabase/components/EntityItem.styled.jsx
@@ -5,31 +5,10 @@ import { alpha, color, darken, lighten } from "metabase/lib/colors";
 
 import IconButtonWrapper from "metabase/components/IconButtonWrapper";
 import LoadingSpinner from "metabase/components/LoadingSpinner";
+import Button from "metabase/components/Button";
 
-function getPinnedBackground(model, disabled) {
-  return disabled
-    ? color("border")
-    : model === "dashboard"
-    ? color("accent4")
-    : lighten(color("accent4"), 0.28);
-}
-
-function getPinnedForeground(model, disabled) {
-  return disabled
-    ? darken(color("border"), 0.38)
-    : model === "dashboard"
-    ? color("white")
-    : color("accent4");
-}
-
-function getBackground(model, disabled) {
-  return disabled
-    ? color("border")
-    : model === "dataset"
-    ? alpha(color("accent2"), 0.08)
-    : model === "dashboard"
-    ? color("brand")
-    : color("brand-light");
+function getPinnedForeground(disabled) {
+  return disabled ? darken(color("border"), 0.38) : color("accent4");
 }
 
 function getForeground(model, disabled) {
@@ -37,25 +16,18 @@ function getForeground(model, disabled) {
     ? darken(color("border"), 0.38)
     : model === "dataset"
     ? color("accent2")
-    : model === "dashboard"
-    ? color("white")
     : color("brand");
 }
 
 export const EntityIconWrapper = styled(IconButtonWrapper)`
-  background-color: ${color("bg-medium")};
+  background-color: transparent;
   padding: 12px;
   cursor: ${props => (props.disabled ? "default" : "pointer")};
 
   color: ${props =>
     props.isPinned
-      ? getPinnedForeground(props.model, props.disabled)
-      : getForeground(props.model, props.disabled)};
-
-  background-color: ${props =>
-    props.isPinned
-      ? getPinnedBackground(props.model, props.disabled)
-      : getBackground(props.model, props.disabled)};
+      ? getPinnedForeground(props.disabled)
+      : getForeground(props.disabled)};
 `;
 
 export const EntityItemWrapper = styled(Flex)`
@@ -73,4 +45,17 @@ export const EntityItemSpinner = styled(LoadingSpinner)`
   flex-direction: column;
   justify-content: center;
   color: ${color("brand")};
+`;
+
+export const EntityMenuContainer = styled(Flex)`
+  color: ${color("text-medium")};
+`;
+
+export const PinButton = styled(Button)`
+  color: ${color("text-medium")};
+  border: none;
+
+  &:hover {
+    color: ${color("brand")};
+  }
 `;

--- a/frontend/src/metabase/components/EntityItem.styled.jsx
+++ b/frontend/src/metabase/components/EntityItem.styled.jsx
@@ -1,7 +1,8 @@
 import styled from "styled-components";
 import { Flex } from "grid-styled";
 
-import { alpha, color, darken, lighten } from "metabase/lib/colors";
+import { color, darken } from "metabase/lib/colors";
+import { forwardRefToInnerRef } from "metabase/styled-components/utils";
 
 import IconButtonWrapper from "metabase/components/IconButtonWrapper";
 import LoadingSpinner from "metabase/components/LoadingSpinner";
@@ -51,11 +52,11 @@ export const EntityMenuContainer = styled(Flex)`
   color: ${color("text-medium")};
 `;
 
-export const PinButton = styled(Button)`
+export const PinButton = forwardRefToInnerRef(styled(Button)`
   color: ${color("text-medium")};
   border: none;
 
   &:hover {
     color: ${color("brand")};
   }
-`;
+`);

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -391,9 +391,6 @@ describe("scenarios > collection_defaults", () => {
       // Make sure modal closed
       cy.findByText("Update").should("not.exist");
 
-      // This click is a weird "hack" that simply gives time for an UI to update - nothing else worked (not even waiting for XHR)
-      cy.icon("info").click();
-
       cy.get("[class*=CollectionSidebar]")
         .as("sidebar")
         .within(() => {

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -781,8 +781,11 @@ function clickButton(name) {
 }
 
 function pinItem(item) {
-  openEllipsisMenuFor(item);
-  cy.findByText("Pin this item").click();
+  cy.findAllByText(item)
+    .closest("tr")
+    .within(() => {
+      cy.icon("pin").click();
+    });
 }
 
 function exposeChildrenFor(collectionName) {


### PR DESCRIPTION
Related to #19758 

Bunch of UI tweaks to the Collections page

- the collection description is shown now
- some background colors have changed
- the pin action is exposed for unpinned items

<img width="1507" alt="Screen Shot 2022-01-19 at 7 40 17 PM" src="https://user-images.githubusercontent.com/13057258/150269200-05f3b4c4-4e5b-4f7e-8cff-f7d1d901fe13.png">
