### PR TITLE
The return of parallel tests

### DIFF
--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -265,7 +265,7 @@
         (thunk)))))
 
 (defmacro with-clock
-  "Same as `t/with-clock`, but adds `testing` context, and also supports using `ZonedDateTime` instances
+  "Same as [[t/with-clock]], but adds [[testing]] context, and also supports using `ZonedDateTime` instances
   directly (converting them to a mock clock automatically).
 
     (mt/with-clock #t \"2019-12-10T00:00-08:00[US/Pacific]\"

--- a/test/metabase/test_runner.clj
+++ b/test/metabase/test_runner.clj
@@ -17,7 +17,8 @@
             [metabase.test-runner.parallel :as parallel]
             [metabase.test.data.env :as tx.env]
             metabase.test.redefs
-            [pjstadig.humane-test-output :as humane-test-output]))
+            [pjstadig.humane-test-output :as humane-test-output]
+            [metabase.util :as u]))
 
 ;; initialize Humane Test Output if it's not already initialized.
 (humane-test-output/activate!)
@@ -26,6 +27,12 @@
 ;; parallel tests.
 (comment metabase.test.redefs/keep-me
          effects/keep-me)
+
+;; Disable parallel tests with `PARALLEL=false`
+(def ^:private enable-parallel-tests?
+  (if-let [^String s (env/env :parallel)]
+    (Boolean/parseBoolean s)
+    true))
 
 ;;;; Finding tests
 
@@ -100,10 +107,18 @@
 
 (defonce ^:private orig-test-var t/test-var)
 
+(def ^:private ^:dynamic *parallel-test-counter*
+  nil)
+
 (defn run-test
   "Run a single test `test-var`. Wraps/replaces [[clojure.test/test-var]]."
   [test-var]
   (binding [parallel/*parallel?* (parallel/parallel? test-var)]
+    (some-> *parallel-test-counter* (swap! update
+                                           (if (and parallel/*parallel?* enable-parallel-tests?)
+                                             :parallel
+                                             :single-threaded)
+                                           (fnil inc 0)))
     (orig-test-var test-var)))
 
 (alter-var-root #'t/test-var (constantly run-test))
@@ -133,15 +148,16 @@
   ([test-vars options]
    ;; don't randomize test order for now please, thanks anyway
    (with-redefs [eftest.runner/deterministic-shuffle (fn [_ test-vars] test-vars)]
-     (eftest.runner/run-tests
-      test-vars
-      (merge
-       {:capture-output? false
-        ;; parallel tests disabled for the time being -- some tests randomly fail if the data warehouse connection pool
-        ;; gets nuked by a different thread. Once we fix that we can re-enable parallel tests.
-        :multithread?    false #_:vars
-        :report          (reporter)}
-       options)))))
+     (binding [*parallel-test-counter* (atom {})]
+       (merge
+        (eftest.runner/run-tests
+         test-vars
+         (merge
+          {:capture-output? false
+           :multithread?    (when enable-parallel-tests? :vars)
+           :report          (reporter)}
+          options))
+        @*parallel-test-counter*)))))
 
 ;;;; `clojure -X` entrypoint
 
@@ -151,8 +167,13 @@
 
   To use our test runner from the REPL, use [[run]] instead."
   [options]
-  (let [summary (run (tests options) options)
-        fail?   (pos? (+ (:error summary) (:fail summary)))]
+  (let [start-ms    (System/currentTimeMillis)
+        summary     (run (tests options) options)
+        duration-ms (- (System/currentTimeMillis) start-ms)
+        fail?       (pos? (+ (:error summary) (:fail summary)))]
     (pprint/pprint summary)
+    (printf "Ran %d tests in parallel, %d single-threaded in %s.\n"
+            (:parallel summary 0) (:single-threaded summary 0)
+            (u/format-milliseconds duration-ms))
     (println (if fail? "Tests failed." "All tests passed."))
     (System/exit (if fail? 1 0))))

--- a/test/metabase/test_runner.clj
+++ b/test/metabase/test_runner.clj
@@ -17,8 +17,7 @@
             [metabase.test-runner.parallel :as parallel]
             [metabase.test.data.env :as tx.env]
             metabase.test.redefs
-            [pjstadig.humane-test-output :as humane-test-output]
-            [metabase.util :as u]))
+            [pjstadig.humane-test-output :as humane-test-output]))
 
 ;; initialize Humane Test Output if it's not already initialized.
 (humane-test-output/activate!)
@@ -167,13 +166,9 @@
 
   To use our test runner from the REPL, use [[run]] instead."
   [options]
-  (let [start-ms    (System/currentTimeMillis)
-        summary     (run (tests options) options)
-        duration-ms (- (System/currentTimeMillis) start-ms)
-        fail?       (pos? (+ (:error summary) (:fail summary)))]
+  (let [summary (run (tests options) options)
+        fail?   (pos? (+ (:error summary) (:fail summary)))]
     (pprint/pprint summary)
-    (printf "Ran %d tests in parallel, %d single-threaded in %s.\n"
-            (:parallel summary 0) (:single-threaded summary 0)
-            (u/format-milliseconds duration-ms))
+    (printf "Ran %d tests in parallel, %d single-threaded.\n" (:parallel summary 0) (:single-threaded summary 0))
     (println (if fail? "Tests failed." "All tests passed."))
     (System/exit (if fail? 1 0))))

--- a/test/metabase/util/cron_test.clj
+++ b/test/metabase/util/cron_test.clj
@@ -5,7 +5,7 @@
   (:require [clojure.test :refer :all]
             [metabase.util.cron :as cron-util]))
 
-(deftest schedule-map->cron-string-test
+(deftest ^:parallel schedule-map->cron-string-test
   (testing "basic schedule"
     (is (= "0 0 * * * ? *"
            (cron-util/schedule-map->cron-string

--- a/test/metabase/util/date_2_test.clj
+++ b/test/metabase/util/date_2_test.clj
@@ -138,7 +138,7 @@
                (u.date/parse "   ")))))))
 
 ;; TODO - more tests!
-(deftest format-test
+(deftest ^:parallel format-test
   (testing "ZonedDateTime"
     (testing "should get formatted as the same way as an OffsetDateTime"
       (is (= "2019-11-01T18:39:00-07:00"
@@ -198,7 +198,7 @@
             (is (contains? expected actual))
             (is (= expected actual))))))))
 
-(deftest format-sql-test
+(deftest ^:parallel format-sql-test
   (testing "LocalDateTime"
     (is (= "2019-11-05 19:27:00"
            (u.date/format-sql (t/local-date-time "2019-11-05T19:27")))))
@@ -207,7 +207,7 @@
            (u.date/format-sql (t/zoned-date-time "2019-11-01T18:39:00-07:00[US/Pacific]")))
         "should get formatted as the same way as an OffsetDateTime")))
 
-(deftest adjuster-test
+(deftest ^:parallel adjuster-test
   (let [now (t/zoned-date-time "2019-12-10T17:17:00-08:00[US/Pacific]")]
     (testing "adjust temporal value to first day of week (Sunday)"
       (is (= (t/zoned-date-time "2019-12-08T17:17-08:00[US/Pacific]")
@@ -244,8 +244,8 @@
                (u.date/extract t unit))
             (format "Extract %s from %s %s should be %s" unit (class t) t expected)))))
   (testing "u.date/extract with 1 arg (extract from now)"
-    (is (= 2
-           (t/with-clock (t/mock-clock (t/instant "2019-11-18T22:31:00Z"))
+    (mt/with-clock (t/mock-clock (t/instant "2019-11-18T22:31:00Z"))
+      (is (= 2
              (u.date/extract :day-of-week))))))
 
 (deftest extract-start-of-week-test
@@ -311,8 +311,8 @@
                (u.date/truncate t unit))
             (format "Truncate %s %s to %s should be %s" (class t) t unit expected)))))
   (testing "u.date/truncate with 1 arg (truncate now)"
-    (is (= (t/zoned-date-time "2019-11-18T00:00Z[UTC]")
-           (t/with-clock (t/mock-clock (t/instant "2019-11-18T22:31:00Z"))
+    (mt/with-clock (t/mock-clock (t/instant "2019-11-18T22:31:00Z"))
+      (is (= (t/zoned-date-time "2019-11-18T00:00Z[UTC]")
              (u.date/truncate :day))))))
 
 (deftest truncate-start-of-week-test
@@ -330,8 +330,8 @@
 
 (deftest add-test
   (testing "with 2 args (datetime relative to now)"
-    (is (= (t/zoned-date-time "2019-11-20T22:31Z[UTC]")
-           (t/with-clock (t/mock-clock (t/instant "2019-11-18T22:31:00Z"))
+    (mt/with-clock (t/mock-clock (t/instant "2019-11-18T22:31:00Z"))
+      (is (= (t/zoned-date-time "2019-11-20T22:31Z[UTC]")
              (u.date/add :day 2)))))
   (testing "with 3 args"
     (let [t (t/zoned-date-time "2019-06-14T00:00:00.000Z[UTC]")]
@@ -347,7 +347,7 @@
                (u.date/add t unit n))
             (format "%s plus %d %ss should be %s" t n unit expected))))))
 
-(deftest range-test
+(deftest ^:parallel range-test
   (testing "with 1 arg (range relative to now)"
     (is (= {:start (t/zoned-date-time "2019-11-17T00:00Z[UTC]")
             :end   (t/zoned-date-time "2019-11-24T00:00Z[UTC]")}
@@ -368,7 +368,7 @@
       (is (= {:start (t/local-date "2019-11-01"), :end (t/local-date "2019-11-30")}
              (u.date/range (t/local-date "2019-11-18") :month {:end :inclusive, :resolution :day}))))))
 
-(deftest comparison-range-test
+(deftest ^:parallel comparison-range-test
   (testing "Comparing MONTH"
     (letfn [(comparison-range [comparison-type options]
               (u.date/comparison-range (t/local-date "2019-11-18") :month comparison-type (merge {:resolution :day} options)))]
@@ -458,7 +458,7 @@
                   (u.date/comparison-range t :week :>= {:resolution :day})
                   (u.date/comparison-range t :week :<= {:resolution :day, :end :inclusive})))))))))
 
-(deftest period-duration-test
+(deftest ^:parallel period-duration-test
   (testing "Creating a period duration from a string"
     (is (= (org.threeten.extra.PeriodDuration/of (t/duration "PT59S"))
            (u.date/period-duration "PT59S"))))

--- a/test/metabase/util/embed_test.clj
+++ b/test/metabase/util/embed_test.clj
@@ -8,15 +8,15 @@
 (def ^:private ^String token-with-alg-none
   "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJhZG1pbiI6dHJ1ZX0.3Dbtd6Z0yuSfw62fOzBGHyiL0BJp3pod_PZE-BBdR-I")
 
-(deftest validate-token-test
+(deftest ^:parallel validate-token-test
   (testing "check that are token is in fact valid"
     (is (= {:admin true}
            (jwt/unsign token-with-alg-none "")))))
 
 (deftest disallow-unsigned-tokens-test
   (testing "check that we disallow tokens signed with alg = none"
-    (is (thrown-with-msg?
-         clojure.lang.ExceptionInfo
-         #"JWT `alg` cannot be `none`"
-         (mt/with-temporary-setting-values [embedding-secret-key (crypto-random/hex 32)]
+    (mt/with-temporary-setting-values [embedding-secret-key (crypto-random/hex 32)]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"JWT `alg` cannot be `none`"
            (embed/unsign token-with-alg-none))))))

--- a/test/metabase/util/encryption_test.clj
+++ b/test/metabase/util/encryption_test.clj
@@ -29,50 +29,50 @@
 (def ^:private secret   (encryption/secret-key->hash "Orw0AAyzkO/kPTLJRxiyKoBHXa/d6ZcO+p+gpZO/wSQ="))
 (def ^:private secret-2 (encryption/secret-key->hash "0B9cD6++AME+A7/oR7Y2xvPRHX3cHA2z7w+LbObd/9Y="))
 
-(deftest repeatable-hashing-test
+(deftest ^:parallel repeatable-hashing-test
   (testing "test that hashing a secret key twice gives you the same results"
     (is (= (vec (encryption/secret-key->hash "Toucans"))
            (vec (encryption/secret-key->hash "Toucans"))))))
 
-(deftest unique-hashes-test
+(deftest ^:parallel unique-hashes-test
   (testing (is (not= (vec secret)
                      (vec secret-2)))))
 
-(deftest hash-pattern-test
+(deftest ^:parallel hash-pattern-test
   (is (re= #"^[0-9A-Za-z/+]+=*$"
            (encryption/encrypt secret "Hello!"))))
 
-(deftest hashing-isnt-idempotent-test
+(deftest ^:parallel hashing-isnt-idempotent-test
   (testing "test that encrypting something twice gives you two different ciphertexts"
     (is (not= (encryption/encrypt secret "Hello!")
               (encryption/encrypt secret "Hello!")))))
 
-(deftest decrypt-test
+(deftest ^:parallel decrypt-test
   (testing "test that we can decrypt something"
     (is (= "Hello!"
            (encryption/decrypt secret (encryption/encrypt secret "Hello!"))))))
 
-(deftest decrypt-bytes-test
+(deftest ^:parallel decrypt-bytes-test
   (testing "test that we can decrypt binary data"
     (let [data (byte-array (range 0 100))]
       (is (= (seq data)
              (seq (encryption/decrypt-bytes secret (encryption/encrypt-bytes secret data))))))))
 
-(deftest exception-with-wrong-decryption-key-test
+(deftest ^:parallel exception-with-wrong-decryption-key-test
   (testing "trying to decrypt something with the wrong key with `decrypt` should throw an Exception"
     (is (thrown-with-msg?
          clojure.lang.ExceptionInfo
          #"Message seems corrupt or manipulated"
          (encryption/decrypt secret-2 (encryption/encrypt secret "WOW"))))))
 
-(deftest maybe-decrypt-not-encrypted-test
+(deftest ^:parallel maybe-decrypt-not-encrypted-test
   (testing "trying to `maybe-decrypt` something that's not encrypted should return it as-is"
     (is (= "{\"a\":100}"
            (encryption/maybe-decrypt secret "{\"a\":100}")))
     (is (= "abc"
            (encryption/maybe-decrypt secret "abc")))))
 
-(deftest maybe-decrypt-with-wrong-key-test
+(deftest ^:parallel maybe-decrypt-with-wrong-key-test
   (testing (str "trying to decrypt something that is encrypted with the wrong key with `maybe-decrypt` should return "
                 "the ciphertext...")
     (let [original-ciphertext (encryption/encrypt secret "WOW")]
@@ -107,7 +107,7 @@
          (tu/with-log-messages-for-level :warn
            (encryption/maybe-decrypt secret-2 (encryption/encrypt secret "WOW")))))))
 
-(deftest possibly-encrypted-test
+(deftest ^:parallel possibly-encrypted-test
   (testing "Something that is not encrypted, but might be should return the original text"
     (is (= fake-ciphertext
            (encryption/maybe-decrypt secret fake-ciphertext)))))

--- a/test/metabase/util/honeysql_extensions_test.clj
+++ b/test/metabase/util/honeysql_extensions_test.clj
@@ -6,7 +6,7 @@
             [metabase.util.honeysql-extensions :as hx])
   (:import metabase.util.honeysql_extensions.Identifier))
 
-(deftest format-test
+(deftest ^:parallel format-test
   (testing "Basic format test not including a specific quoting option"
     (is (= ["setting"]
            (hformat/format :setting))))
@@ -15,7 +15,7 @@
     (is (= ["\"SETTING\""]
            (hformat/format :setting :quoting :h2)))))
 
-(deftest literal-test
+(deftest ^:parallel literal-test
   (testing "`literal` should be compiled to a single-quoted literal"
     (is (= ["WHERE name = 'Cam'"]
            (hsql/format {:where [:= :name (hx/literal "Cam")]}))))
@@ -104,13 +104,13 @@
       (is (= ["\"SETTING\""]
              (hformat/format :setting :quoting :h2))))))
 
-(deftest ratios-test
+(deftest ^:parallel ratios-test
   (testing (str "test ToSql behavior for Ratios (#9246). Should convert to a double rather than leaving it as a "
                 "division operation. The double itself should get converted to a numeric literal")
     (is (= ["SELECT 0.1 AS one_tenth"]
            (hsql/format {:select [[(/ 1 10) :one_tenth]]})))))
 
-(deftest maybe-cast-test
+(deftest ^:parallel maybe-cast-test
   (testing "maybe-cast should only cast things that need to be cast"
     (letfn [(->sql [expr]
               (hsql/format {:select [expr]}))
@@ -138,12 +138,12 @@
 
 (def ^:private typed-form (hx/with-type-info :field {::hx/database-type "text"}))
 
-(deftest TypedHoneySQLForm-test
+(deftest ^:parallel TypedHoneySQLForm-test
   (testing "should generate readable output"
     (is (= (pr-str `(hx/with-type-info :field {::hx/database-type "text"}))
            (pr-str typed-form)))))
 
-(deftest type-info-test
+(deftest ^:parallel type-info-test
   (testing "should let you get info"
     (is (= {::hx/database-type "text"}
            (hx/type-info typed-form)))
@@ -151,7 +151,7 @@
            (hx/type-info :field)
            (hx/type-info nil)))))
 
-(deftest with-type-info-test
+(deftest ^:parallel with-type-info-test
   (testing "should let you update info"
     (is (= (hx/with-type-info :field {::hx/database-type "date"})
            (hx/with-type-info typed-form {::hx/database-type "date"})))
@@ -159,7 +159,7 @@
       (is (= (hx/with-type-info :field {::hx/database-type "date"})
              (hx/with-type-info typed-form {::hx/database-type "date"}))))))
 
-(deftest with-database-type-info-test
+(deftest ^:parallel with-database-type-info-test
   (testing "should be the same as calling `with-type-info` with `::hx/database-type`"
     (is (= (hx/with-type-info :field {::hx/database-type "date"})
            (hx/with-database-type-info :field "date"))))
@@ -171,7 +171,7 @@
       (is (= :field
              (hx/with-database-type-info (hx/with-database-type-info :field "date") nil))))))
 
-(deftest is-of-type?-test
+(deftest ^:parallel is-of-type?-test
   (mt/are+ [expr tyype expected] (= expected (hx/is-of-type? expr tyype))
     typed-form     "text" true
     typed-form     "TEXT" true
@@ -186,7 +186,7 @@
     nil            nil    true
     :%current_date nil    true))
 
-(deftest unwrap-typed-honeysql-form-test
+(deftest ^:parallel unwrap-typed-honeysql-form-test
   (testing "should be able to unwrap"
     (is (= :field
            (hx/unwrap-typed-honeysql-form typed-form)

--- a/test/metabase/util/i18n/impl_test.clj
+++ b/test/metabase/util/i18n/impl_test.clj
@@ -4,7 +4,7 @@
             [metabase.util.i18n.impl :as impl])
   (:import java.util.Locale))
 
-(deftest normalized-locale-string-test
+(deftest ^:parallel normalized-locale-string-test
   (doseq [[s expected] {"en"      "en"
                         "EN"      "en"
                         "En"      "en"
@@ -18,7 +18,7 @@
       (is (= expected
              (impl/normalized-locale-string s))))))
 
-(deftest locale-test
+(deftest ^:parallel locale-test
   (testing "Should be able to coerce various types of objects to Locales"
     (doseq [arg-type [:str :keyword]
             country   ["en" "En" "EN"]
@@ -41,7 +41,7 @@
     (is (= nil
            (impl/locale nil)))))
 
-(deftest available-locale?-test
+(deftest ^:parallel available-locale?-test
   (doseq [[locale expected] {"en"      true
                              "EN"      true
                              "en-US"   true
@@ -55,7 +55,7 @@
       (is (= expected
              (impl/available-locale? locale))))))
 
-(deftest fallback-locale-test
+(deftest ^:parallel fallback-locale-test
   (doseq [[locale expected] {nil                             nil
                              :es                             nil
                              "es"                            nil
@@ -71,7 +71,7 @@
       (is (= expected
              (impl/fallback-locale locale))))))
 
-(deftest graceful-fallback-test
+(deftest ^:parallel graceful-fallback-test
   (testing "If a resource bundle doesn't exist, we should gracefully fall back to English"
     (is (= "Translate me 100"
            (impl/translate "zz" "Translate me {0}" 100)))))

--- a/test/metabase/util/i18n_test.clj
+++ b/test/metabase/util/i18n_test.clj
@@ -4,7 +4,7 @@
             [metabase.test :as mt]
             [metabase.util.i18n :as i18n]))
 
-(deftest available-locales-test
+(deftest ^:parallel available-locales-test
   (testing "Should return locale in normalized format"
     (is (contains? (set (i18n/available-locales-with-names))
                    ["pt_BR", "Portuguese (Brazil)"]))))
@@ -54,13 +54,13 @@
                 (is (= "deben tener 140 caracteres o menos"
                        (f)))))))))))
 
-(deftest localized-string?-test
+(deftest ^:parallel localized-string?-test
   (is (= true
          (i18n/localized-string? (i18n/deferred-trs "WOW"))))
   (is (= false
          (i18n/localized-string? "WOW"))))
 
-(deftest validate-number-of-args-test
+(deftest ^:parallel validate-number-of-args-test
   (testing "`trs` and `tru` should validate that the are being called with the correct number of args\n"
     (testing "not enough args"
       (is (thrown?

--- a/test/metabase/util/password_test.clj
+++ b/test/metabase/util/password_test.clj
@@ -8,7 +8,7 @@
 
 ;; Password Complexity testing
 
-(deftest count-occurrences-test
+(deftest ^:parallel count-occurrences-test
   (testing "Check that password occurance counting works"
     (doseq [[input expected] {"abc"        {:total 3, :lower 3, :upper 0, :letter 3, :digit 0, :special 0}
                               "PASSWORD"   {:total 8, :lower 0, :upper 8, :letter 8, :digit 0, :special 0}
@@ -20,7 +20,7 @@
         (is (= expected
                (#'pwu/count-occurrences input)))))))
 
-(deftest password-has-char-counts?-test
+(deftest ^:parallel password-has-char-counts?-test
   (doseq [[group input->expected]
           {"Check that password length complexity applies"
            {[{:total 3} "god1"] true
@@ -51,7 +51,7 @@
           (is (= expected
                  (apply #'pwu/password-has-char-counts? input))))))))
 
-(deftest is-valid?-normal-test
+(deftest ^:parallel is-valid?-normal-test
   (testing "Do some tests with the default (:normal) password requirements"
     (doseq [[input expected] {"ABC"           false
                               "ABCDEF"        false

--- a/test/metabase/util/regex_test.clj
+++ b/test/metabase/util/regex_test.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test :refer :all]
             [metabase.util.regex :as u.regex]))
 
-(deftest rx-test
+(deftest ^:parallel rx-test
   (let [regex (u.regex/rx (and "^" (or "Cam" "can") (opt #"\s+") #"\d+"))]
     (is (instance? java.util.regex.Pattern regex))
     (is (= (str #"^(?:(?:Cam)|(?:can))(?:\s+)?\d+")

--- a/test/metabase/util/schema_test.clj
+++ b/test/metabase/util/schema_test.clj
@@ -7,7 +7,7 @@
             [metabase.util.schema :as su]
             [schema.core :as s]))
 
-(deftest generate-api-error-message-test
+(deftest ^:parallel generate-api-error-message-test
   (testing "check that the API error message generation is working as intended"
     (is (= (str "value may be nil, or if non-nil, value must satisfy one of the following requirements: "
                 "1) value must be a boolean. "
@@ -21,7 +21,7 @@
    dimension-name          su/NonBlankString})
 (alter-meta! #'POST_:id_dimension assoc :private true)
 
-(deftest api-param-test
+(deftest ^:parallel api-param-test
   (testing "check that API error message respects `api-param` when specified"
     (is (= (str "### `POST metabase.util.schema-test/:id/dimension`\n"
                 "\n"
@@ -50,7 +50,7 @@
       (is (re= #".*INTEGER GREATER THAN ZERO.*"
                (ex-info-msg #(s/validate su/IntGreaterThanZero -1)))))))
 
-(deftest distinct-test
+(deftest ^:parallel distinct-test
   (is (= nil
          (s/check (su/distinct [s/Int]) [])))
 
@@ -62,7 +62,7 @@
 
   (is (some? (s/check (su/distinct [s/Int]) [1 2 1]))))
 
-(deftest open-schema-test
+(deftest ^:parallel open-schema-test
   (let [value  {:thing     3
                 :extra-key 5
                 :sub       {:key 3 :another-extra 5}}

--- a/test/metabase/util_test.clj
+++ b/test/metabase/util_test.clj
@@ -8,7 +8,7 @@
             [metabase.test :as mt]
             [metabase.util :as u]))
 
-(deftest add-period-test
+(deftest ^:parallel add-period-test
   (is (= "This sentence needs a period."
          (u/add-period "This sentence needs a period")))
   (is (= "This sentence doesn't need a period!"
@@ -18,7 +18,7 @@
   (is (= "   "
          (u/add-period "   "))))
 
-(deftest decolorize-test
+(deftest ^:parallel decolorize-test
   (is (= "[31mmessage[0m"
          (u/colorize 'red "message")))
   (is (= "message"
@@ -28,7 +28,7 @@
   (is (= nil
          (u/decolorize nil))))
 
-(deftest host-up?-test
+(deftest ^:parallel host-up?-test
   (testing "host-up?"
     (mt/are+ [s expected] (= expected
                              (u/host-up? s))
@@ -38,7 +38,7 @@
     (is (= false
            (u/host-port-up? "nosuchhost" 8005)))))
 
-(deftest url?-test
+(deftest ^:parallel url?-test
   (mt/are+ [s expected] (= expected
                         (u/url? s))
     "http://google.com"                                                                      true
@@ -73,7 +73,7 @@
     ;; nil .getAuthority needs to be handled or NullPointerException
     "http:/"                                                                                 false))
 
-(deftest state?-test
+(deftest ^:parallel state?-test
   (mt/are+ [s expected] (= expected
                         (u/state? s))
     "louisiana"      true
@@ -86,7 +86,7 @@
     3                false
     (Object.)        false))
 
-(deftest qualified-name-test
+(deftest ^:parallel qualified-name-test
   (mt/are+ [k expected] (= expected
                         (u/qualified-name k))
     :keyword                          "keyword"
@@ -103,19 +103,19 @@
     (is (thrown? ClassCastException
                  (u/qualified-name false)))))
 
-(deftest rpartial-test
+(deftest ^:parallel rpartial-test
   (is (= 3
          ((u/rpartial - 5) 8)))
   (is (= -7
          ((u/rpartial - 5 10) 8))))
 
-(deftest key-by-test
+(deftest ^:parallel key-by-test
   (is (= {1 {:id 1, :name "Rasta"}
           2 {:id 2, :name "Lucky"}}
          (u/key-by :id [{:id 1, :name "Rasta"}
                         {:id 2, :name "Lucky"}]))))
 
-(deftest remove-diacritical-marks-test
+(deftest ^:parallel remove-diacritical-marks-test
   (doseq [[s expected] {"üuuü" "uuuu"
                         "åéîü" "aeiu"
                         "åçñx" "acnx"
@@ -125,7 +125,7 @@
       (is (= expected
              (u/remove-diacritical-marks s))))))
 
-(deftest slugify-test
+(deftest ^:parallel slugify-test
   (doseq [[group s->expected]
           {nil
            {"ToucanFest 2017"               "toucanfest_2017"
@@ -144,7 +144,7 @@
           (is (= expected
                  (u/slugify s))))))))
 
-(deftest full-exception-chain-test
+(deftest ^:parallel full-exception-chain-test
   (testing "Not an Exception"
     (is (= nil
            (u/full-exception-chain nil)))
@@ -163,7 +163,7 @@
       (is (= [{:a 1} {:b 2} {:c 3}]
              (map ex-data (u/full-exception-chain e)))))))
 
-(deftest select-nested-keys-test
+(deftest ^:parallel select-nested-keys-test
   (mt/are+ [m keyseq expected] (= expected
                                   (u/select-nested-keys m keyseq))
     {:a 100, :b {:c 200, :d 300}}              [:a [:b :d] :c]   {:a 100, :b {:d 300}}
@@ -179,7 +179,7 @@
     {:a 100, :b {:c 200, :d 300}}              []                {}
     {}                                         [:c]              {}))
 
-(deftest base64-string?-test
+(deftest ^:parallel base64-string?-test
   (mt/are+ [s expected]    (= expected
                         (u/base64-string? s))
     "ABc="         true
@@ -199,7 +199,7 @@
     ;; padding has to go at the end
     "==QQ"         false))
 
-(deftest select-keys-test
+(deftest ^:parallel select-keys-test
   (testing "select-non-nil-keys"
     (is (= {:a 100}
            (u/select-non-nil-keys {:a 100, :b nil} #{:a :b :c}))))
@@ -209,7 +209,7 @@
              :present #{:a :b :c}
              :non-nil #{:d :e :f})))))
 
-(deftest order-of-magnitude-test
+(deftest ^:parallel order-of-magnitude-test
   (mt/are+ [n expected] (= expected
                         (u/order-of-magnitude n))
     0.01  -2
@@ -221,7 +221,7 @@
     0     0
     -1444 3))
 
-(deftest index-of-test
+(deftest ^:parallel index-of-test
   (are [input expected] (= expected
                            (u/index-of pos? input))
     [-1 0 2 3]   2
@@ -229,11 +229,11 @@
     nil          nil
     []           nil))
 
-(deftest snake-key-test
+(deftest ^:parallel snake-key-test
   (is (= {:num_cans 2, :lisp_case? {:nested_maps? true}}
          (u/snake-keys {:num-cans 2, :lisp-case? {:nested-maps? true}}))))
 
-(deftest one-or-many-test
+(deftest ^:parallel one-or-many-test
   (mt/are+ [input expected] (= expected
                             (u/one-or-many input))
     nil   nil
@@ -241,7 +241,7 @@
     42    [42]
     [42]  [42]))
 
-(deftest topological-sort-test
+(deftest ^:parallel topological-sort-test
   (mt/are+ [input expected] (= expected
                             (u/topological-sort identity input))
     {:b []
@@ -264,7 +264,7 @@
     (is (= "ID"
            (u/upper-case-en "id")))))
 
-(deftest parse-currency-test
+(deftest ^:parallel parse-currency-test
   (mt/are+ [s expected] (= expected
                         (u/parse-currency s))
     nil             nil
@@ -285,7 +285,7 @@
     "$.05"          0.05M
     "0.05"          0.05M))
 
-(deftest or-with-test
+(deftest ^:parallel or-with-test
   (testing "empty case"
     (is (= nil (u/or-with identity))))
   (testing "short-circuiting"
@@ -300,7 +300,7 @@
   (testing "failure"
     (is (nil? (u/or-with even? 1 3 5)))))
 
-(deftest ip-address?-test
+(deftest ^:parallel ip-address?-test
   (mt/are+ [x expected] (= expected
                            (u/ip-address? x))
     "8.8.8.8"              true
@@ -317,7 +317,7 @@
     100                    false))
 
 ;; this would be such a good spot for test.check
-(deftest sorted-take-test
+(deftest ^:parallel sorted-take-test
   (testing "It ensures there are never more than `size` items in the priority queue"
     (let [limit 5
           rf    (u/sorted-take limit compare)]
@@ -348,7 +348,7 @@
          (transduce (map identity)
                     (u/sorted-take size kompare)
                     coll)))))
-(deftest email->domain-test
+(deftest ^:parallel email->domain-test
   (are [domain email] (is (= domain
                              (u/email->domain email))
                           (format "Domain of email address '%s'" email))
@@ -357,7 +357,7 @@
     "metabase.co.uk" "cam@metabase.co.uk"
     "metabase.com"   "cam.saul+1@metabase.com"))
 
-(deftest email-in-domain-test
+(deftest ^:parallel email-in-domain-test
   (are [in-domain? email domain] (is (= in-domain?
                                         (u/email-in-domain? email domain))
                                      (format "Is email '%s' in domain '%s'?" email domain))


### PR DESCRIPTION
- Re-enable parallel tests in the test runner. Tests have to opt-in to being ran in parallel, and have to be marked with `^:parallel`
- Add support for disabling parallel tests with the env var `PARALLEL=false`
- Mark ~70 tests in `metabase.util.*` as `^:parallel`. This shaves about half a second on our test runs. That might not seem like much but as we start marking more stuff as parallel the numbers should go up a bit
- Add a counter to the test runner that prints out the number of tests in parallel vs the number single-threaded
