### PR TITLE
Handle disabled or not available nested queries for models

### DIFF
--- a/frontend/src/metabase-lib/lib/Question.ts
+++ b/frontend/src/metabase-lib/lib/Question.ts
@@ -251,7 +251,7 @@ export default class Question {
    * This is just a wrapper object, the data is stored in `this._card.dataset_query` in a format specific to the query type.
    */
   @memoize
-  query(): Query {
+  query(): AtomicQuery {
     const datasetQuery = this._card.dataset_query;
 
     for (const QueryClass of [StructuredQuery, NativeQuery, InternalQuery]) {

--- a/frontend/src/metabase-lib/lib/queries/NativeQuery.ts
+++ b/frontend/src/metabase-lib/lib/queries/NativeQuery.ts
@@ -14,7 +14,11 @@ import { chain, assoc, getIn, assocIn, updateIn } from "icepick";
 import _ from "underscore";
 import Question from "metabase-lib/lib/Question";
 import { DatasetQuery, NativeDatasetQuery } from "metabase-types/types/Card";
-import { TemplateTags, TemplateTag } from "metabase-types/types/Query";
+import {
+  DependentMetadataItem,
+  TemplateTags,
+  TemplateTag,
+} from "metabase-types/types/Query";
 import { DatabaseEngine, DatabaseId } from "metabase-types/types/Database";
 import AtomicQuery from "metabase-lib/lib/queries/AtomicQuery";
 import Dimension, { TemplateTagDimension, FieldDimension } from "../Dimension";
@@ -79,10 +83,10 @@ export default class NativeQuery extends AtomicQuery {
   }
 
   canRun() {
-    return (
+    return Boolean(
       this.hasData() &&
-      this.queryText().length > 0 &&
-      this.allTemplateTagsAreValid()
+        this.queryText().length > 0 &&
+        this.allTemplateTagsAreValid(),
     );
   }
 
@@ -481,7 +485,7 @@ export default class NativeQuery extends AtomicQuery {
     return {};
   }
 
-  dependentMetadata() {
+  dependentMetadata(): DependentMetadataItem[] {
     const templateTags = this.templateTags();
     return templateTags
       .filter(

--- a/frontend/src/metabase-lib/lib/queries/Query.ts
+++ b/frontend/src/metabase-lib/lib/queries/Query.ts
@@ -1,12 +1,14 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import { DatasetQuery } from "metabase-types/types/Card";
+import { DependentMetadataItem } from "metabase-types/types/Query";
 import Metadata from "metabase-lib/lib/metadata/Metadata";
 import Question from "metabase-lib/lib/Question";
 import Dimension from "metabase-lib/lib/Dimension";
 import Variable from "metabase-lib/lib/Variable";
 import { memoize } from "metabase-lib/lib/utils";
 import DimensionOptions from "metabase-lib/lib/DimensionOptions";
+
 type QueryUpdateFn = (datasetQuery: DatasetQuery) => void;
 /**
  * An abstract class for all query types (StructuredQuery & NativeQuery)
@@ -40,7 +42,7 @@ export default class Query {
   /**
    * Returns a "clean" version of this query with invalid parts removed
    */
-  clean(): Query {
+  clean() {
     return this;
   }
 
@@ -111,7 +113,7 @@ export default class Query {
   /**
    * Metadata this query needs to display correctly
    */
-  dependentMetadata() {
+  dependentMetadata(): DependentMetadataItem[] {
     return [];
   }
 

--- a/frontend/src/metabase-lib/lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/lib/queries/StructuredQuery.ts
@@ -21,6 +21,7 @@ import {
   Filter,
   LimitClause,
   OrderBy,
+  DependentMetadataItem,
 } from "metabase-types/types/Query";
 import {
   DatasetQuery,
@@ -1588,7 +1589,7 @@ export default class StructuredQuery extends AtomicQuery {
   /**
    * Metadata this query needs to display correctly
    */
-  dependentMetadata({ foreignTables = true } = {}) {
+  dependentMetadata({ foreignTables = true } = {}): DependentMetadataItem[] {
     const dependencies = [];
 
     function addDependency(dep) {

--- a/frontend/src/metabase-types/types/Query.ts
+++ b/frontend/src/metabase-types/types/Query.ts
@@ -303,3 +303,16 @@ export type ExpressionOperator = "+" | "-" | "*" | "/";
 export type ExpressionOperand = ConcreteField | NumericLiteral | Expression;
 
 export type FieldsClause = ConcreteField[];
+
+export type DependentTable = {
+  id: number | string;
+  type: "table";
+  foreignTables?: boolean;
+};
+
+export type DependentField = {
+  id: number;
+  type: "field";
+};
+
+export type DependentMetadataItem = DependentTable | DependentField;

--- a/frontend/src/metabase/lib/data-modeling/utils.ts
+++ b/frontend/src/metabase/lib/data-modeling/utils.ts
@@ -1,15 +1,29 @@
 import Question from "metabase-lib/lib/Question";
 import NativeQuery from "metabase-lib/lib/queries/NativeQuery";
+import Database from "metabase-lib/lib/metadata/Database";
 import { TemplateTag } from "metabase-types/types/Query";
 
 export function isSupportedTemplateTagForModel(tag: TemplateTag) {
   return tag.type === "card";
 }
 
+export function checkDatabaseSupportsModels(database: Database) {
+  return database.hasFeature("nested-queries");
+}
+
 export function checkCanBeModel(question: Question) {
+  const query = question.query();
+  const db = query.database();
+
+  if (!db || !checkDatabaseSupportsModels(db)) {
+    return false;
+  }
+
   if (!question.isNative()) {
     return true;
   }
-  const query = (question.query() as unknown) as NativeQuery;
-  return query.templateTags().every(isSupportedTemplateTagForModel);
+
+  return (query as NativeQuery)
+    .templateTags()
+    .every(isSupportedTemplateTagForModel);
 }

--- a/frontend/src/metabase/lib/data-modeling/utils.ts
+++ b/frontend/src/metabase/lib/data-modeling/utils.ts
@@ -7,15 +7,14 @@ export function isSupportedTemplateTagForModel(tag: TemplateTag) {
   return tag.type === "card";
 }
 
-export function checkDatabaseSupportsModels(database: Database) {
-  return database.hasFeature("nested-queries");
+export function checkDatabaseSupportsModels(database?: Database | null) {
+  return database && database.hasFeature("nested-queries");
 }
 
 export function checkCanBeModel(question: Question) {
   const query = question.query();
-  const db = query.database();
 
-  if (!db || !checkDatabaseSupportsModels(db)) {
+  if (!checkDatabaseSupportsModels(query.database())) {
     return false;
   }
 

--- a/frontend/src/metabase/lib/data-modeling/utils.unit.spec.ts
+++ b/frontend/src/metabase/lib/data-modeling/utils.unit.spec.ts
@@ -1,27 +1,34 @@
 import Question from "metabase-lib/lib/Question";
+import Database from "metabase-lib/lib/metadata/Database";
 import {
   TemplateTag,
   TemplateTagType,
   TemplateTags,
 } from "metabase-types/types/Query";
-import { ORDERS } from "__support__/sample_database_fixture";
+import { createMockDatabase } from "metabase-types/api/mocks/database";
+import { ORDERS, metadata } from "__support__/sample_database_fixture";
 import { checkCanBeModel } from "./utils";
 
 function getNativeQuestion(tags: TemplateTags = {}) {
-  return new Question({
-    id: 1,
-    display: "table",
-    can_write: true,
-    public_uuid: "",
-    dataset_query: {
-      type: "native",
-      native: {
-        query: "select * from orders",
-        "template-tags": tags,
+  const question = new Question(
+    {
+      id: 1,
+      display: "table",
+      can_write: true,
+      public_uuid: "",
+      dataset_query: {
+        type: "native",
+        database: 1,
+        native: {
+          query: "select * from orders",
+          "template-tags": tags,
+        },
       },
+      visualization_settings: {},
     },
-    visualization_settings: {},
-  });
+    metadata,
+  );
+  return question;
 }
 
 function getTemplateTag(tag: Partial<TemplateTag> = {}): TemplateTag {
@@ -35,6 +42,11 @@ function getTemplateTag(tag: Partial<TemplateTag> = {}): TemplateTag {
 }
 
 describe("data model utils", () => {
+  const DB_WITHOUT_NESTED_QUERIES_SUPPORT = new Database({
+    ...createMockDatabase(),
+    features: [],
+  });
+
   describe("checkCanBeModel", () => {
     const UNSUPPORTED_TEMPLATE_TAG_TYPES: TemplateTagType[] = [
       "text",
@@ -43,38 +55,54 @@ describe("data model utils", () => {
       "dimension",
     ];
 
-    it("returns true for structured queries", () => {
-      const question = ORDERS.question();
-      expect(checkCanBeModel(question)).toBe(true);
-    });
-
-    it("returns true for native queries without variables", () => {
-      const question = getNativeQuestion();
-      expect(checkCanBeModel(question)).toBe(true);
-    });
-
-    it("returns true for native queries with 'card' variables", () => {
-      const question = getNativeQuestion({
-        "#5": getTemplateTag({ type: "card" }),
+    describe("structured queries", () => {
+      it("returns true for regular questions", () => {
+        const question = ORDERS.question();
+        expect(checkCanBeModel(question)).toBe(true);
       });
-      expect(checkCanBeModel(question)).toBe(true);
-    });
 
-    UNSUPPORTED_TEMPLATE_TAG_TYPES.forEach(tagType => {
-      it(`returns false false for native queries with '${tagType}' variables`, () => {
-        const question = getNativeQuestion({
-          foo: getTemplateTag({ type: tagType }),
-        });
+      it("returns false if database does not support nested queries", () => {
+        const question = ORDERS.question();
+        question.query().database = () => DB_WITHOUT_NESTED_QUERIES_SUPPORT;
         expect(checkCanBeModel(question)).toBe(false);
       });
     });
 
-    it("returns false for native queries if it uses at least one unsupported variable type", () => {
-      const question = getNativeQuestion({
-        "#5": getTemplateTag({ type: "card" }),
-        foo: getTemplateTag({ type: "dimension" }),
+    describe("native queries", () => {
+      it("returns true if no variables used", () => {
+        const question = getNativeQuestion();
+        expect(checkCanBeModel(question)).toBe(true);
       });
-      expect(checkCanBeModel(question)).toBe(false);
+
+      it("returns false if database does not support nested queries", () => {
+        const question = getNativeQuestion();
+        question.query().database = () => DB_WITHOUT_NESTED_QUERIES_SUPPORT;
+
+        expect(checkCanBeModel(question)).toBe(false);
+      });
+      it("returns true when 'card' variables are used", () => {
+        const question = getNativeQuestion({
+          "#5": getTemplateTag({ type: "card" }),
+        });
+        expect(checkCanBeModel(question)).toBe(true);
+      });
+
+      UNSUPPORTED_TEMPLATE_TAG_TYPES.forEach(tagType => {
+        it(`returns false when '${tagType}' variables are used`, () => {
+          const question = getNativeQuestion({
+            foo: getTemplateTag({ type: tagType }),
+          });
+          expect(checkCanBeModel(question)).toBe(false);
+        });
+      });
+
+      it("returns false if at least one unsupported variable type is used", () => {
+        const question = getNativeQuestion({
+          "#5": getTemplateTag({ type: "card" }),
+          foo: getTemplateTag({ type: "dimension" }),
+        });
+        expect(checkCanBeModel(question)).toBe(false);
+      });
     });
   });
 });

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebarPanel.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionDetailsSidebarPanel.unit.spec.js
@@ -51,6 +51,10 @@ function getDataset(card) {
 function setup({ question } = {}) {
   const onOpenModal = jest.fn();
 
+  const settingsState = {
+    values: { "enable-nested-queries": true },
+  };
+
   renderWithProviders(
     <QuestionDetailsSidebarPanel
       question={question}
@@ -58,6 +62,12 @@ function setup({ question } = {}) {
     />,
     {
       withSampleDatabase: true,
+      storeInitialState: {
+        settings: settingsState,
+      },
+      reducers: {
+        settings: () => settingsState,
+      },
     },
   );
 

--- a/frontend/src/metabase/selectors/settings.js
+++ b/frontend/src/metabase/selectors/settings.js
@@ -7,6 +7,7 @@ export const getIsPublicSharingEnabled = state =>
   state.settings.values["enable-public-sharing"];
 export const getIsApplicationEmbeddingEnabled = state =>
   state.settings.values["enable-embedding"];
+
 // Whether or not xrays are enabled on the instance
 export const getXraysEnabled = state => state.settings.values["enable-xrays"];
 
@@ -17,6 +18,9 @@ export const getShowHomepageXrays = createSelector(
   [getXraysEnabled, state => state.settings.values["show-homepage-xrays"]],
   (enabled, show) => enabled && show,
 );
+
+export const getNestedQueriesEnabled = state =>
+  state.settings.values["enable-nested-queries"];
 
 // NOTE: these are admin-only settings
 export const getSiteUrl = state => state.settings.values["site-url"];

--- a/frontend/test/__support__/ui.js
+++ b/frontend/test/__support__/ui.js
@@ -44,7 +44,7 @@ export function renderWithProviders(
   } = {},
 ) {
   const initialReduxState = withSampleDatabase
-    ? merge(withSampleDatabase, storeInitialState)
+    ? merge(sampleDatabaseReduxState, storeInitialState)
     : storeInitialState;
 
   const store = getStore(

--- a/frontend/test/__support__/ui.js
+++ b/frontend/test/__support__/ui.js
@@ -1,6 +1,7 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 import { render } from "@testing-library/react";
+import { merge } from "icepick";
 import { createMemoryHistory } from "history";
 import { Router, Route } from "react-router";
 import { Provider } from "react-redux";
@@ -35,13 +36,16 @@ export function renderWithProviders(
   {
     currentUser,
     reducers,
+    storeInitialState = {},
     withSampleDatabase,
     withRouter = false,
     withDND = false,
     ...options
   } = {},
 ) {
-  const initialReduxState = withSampleDatabase ? sampleDatabaseReduxState : {};
+  const initialReduxState = withSampleDatabase
+    ? merge(withSampleDatabase, storeInitialState)
+    : storeInitialState;
 
   const store = getStore(
     {

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -181,7 +181,7 @@
   :visibility :public)
 
 (defsetting enable-nested-queries
-  (deferred-tru "Allow using a saved question as the source for other queries?")
+  (deferred-tru "Allow using a saved question or Model as the source for other queries?")
   :type    :boolean
   :default true
   :visibility :authenticated)


### PR DESCRIPTION
Since models are essentially saved questions, any other question using them as a data source creates a nested query. So nested queries must be both enabled and supported by a database in order for them to work. This PR does a few things:

* hides "turn this into model" button if nested queries are disabled globally (via Admin > General)
* hides "turn this into model" button if question's database doesn't support nested queries (AFAIK Mongo and GA. Though the check doesn't rely on the `engine` name, but on DB's `features` list, it must include `"nested-queries"`)
* changes nested queries toggle label on Admin > General, so it now explains that nested queries are required for Models to work (based on @mazameli comment from [slack](https://metaboat.slack.com/archives/C0228TSGC1X/p1639500114009900?thread_ts=1639491476.008900&cid=C0228TSGC1X))

Also, had to slightly change the typing in `metabase-lib`, so it's possible to cast `question.query()` to either `StructuredQuery` or `NativeQuery` without casting them to `unknown` first.

### To Verify

**When a database doesn't support nested queries**
1. Open a saved question using MongoDB / GA that's not a model yet
2. Click the question title to open the details sidebar, there should be no "model" icon button

**When nested queries are disabled globally**
1. Sign in as admin
2. Go to `/admin/settings/general` and find the "Enable nested queries" setting at the bottom and turn it off
3. Open any saved question that's not yet a model
4. Click the question title to open the details sidebar, there should be no "model" icon button
