### PR TITLE
Update copy for SavedQuestionIntoModal when model is open

### DIFF
--- a/frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx
+++ b/frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx
@@ -7,20 +7,25 @@ import { t } from "ttag";
 
 export default class SavedQuestionIntroModal extends Component {
   render() {
+    const { question, isShowingNewbModal, onClose } = this.props;
+
+    const isModel = question.isDataset();
+    const title = isModel
+      ? t`It's okay to play around with models`
+      : t`It's okay to play around with saved questions`;
+    const message = isModel
+      ? t`You won't make any permanent changes to them unless you edit their query definition.`
+      : t`You won't make any permanent changes to a saved question unless you click Save and choose to replace the original question.`;
+
     return (
-      <Modal isOpen={this.props.isShowingNewbModal}>
-        <ModalContent
-          title={t`It's okay to play around with saved questions`}
-          className="Modal-content text-centered py2"
-        >
-          <div className="px2 pb2 text-paragraph">
-            {t`You won't make any permanent changes to a saved question unless you click Save and choose to replace the original question.`}
-          </div>
+      <Modal isOpen={isShowingNewbModal}>
+        <ModalContent title={title} className="Modal-content text-centered py2">
+          <div className="px2 pb2 text-paragraph">{message}</div>
           <div className="Form-actions flex justify-center py1">
             <button
               data-metabase-event={"QueryBuilder;IntroModal"}
               className="Button Button--primary"
-              onClick={() => this.props.onClose()}
+              onClick={onClose}
             >
               {t`Okay`}
             </button>

--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -299,6 +299,7 @@ export default class View extends React.Component {
 
         {isShowingNewbModal && (
           <SavedQuestionIntroModal
+            question={this.props.question}
             onClose={() => this.props.closeQbNewbModal()}
           />
         )}


### PR DESCRIPTION
The first time a user enters the saved question page, Metabase shows a modal saying that's okay to play around with saved questions and they won't be updated before you hit the "Save" button. Since models are saved questions too and they might also be fear of changing something by accident, we slightly update the modal copy when a model is open.

### To Verify

1. Create a new user via `/admin/people` and sign in as that user
2. Open any model
3. You should see a modal with the copy matching the screenshot below

### Demo

<img width="684" alt="CleanShot 2022-01-20 at 17 55 14@2x" src="https://user-images.githubusercontent.com/17258145/150374907-aa1aeabe-ad16-4861-a64c-59fcd49cc913.png">

