### PR TITLE
Fix model metadata strength calculation

### DIFF
--- a/frontend/src/metabase/lib/data-modeling/metadata.ts
+++ b/frontend/src/metabase/lib/data-modeling/metadata.ts
@@ -1,6 +1,7 @@
 export type FieldMetadata = {
   id?: number;
   name: string;
+  display_name: string;
   description?: string | null;
   semantic_type?: string | null;
 };
@@ -23,13 +24,13 @@ const MAX_FIELD_SCORE = 3;
  * @returns {number} — int between 0 and 3
  */
 function getFieldMetadataScore({
-  name,
+  display_name,
   description,
   semantic_type,
 }: FieldMetadata): number {
   let score = 0;
 
-  const isNameDirty = name.includes("→") || name.includes("_");
+  const isNameDirty = display_name.includes("→") || display_name.includes("_");
 
   if (!isNameDirty) {
     score++;

--- a/frontend/src/metabase/lib/data-modeling/metadata.unit.spec.js
+++ b/frontend/src/metabase/lib/data-modeling/metadata.unit.spec.js
@@ -7,8 +7,8 @@ describe("getDatasetMetadataCompletenessPercentage", () => {
 
   it("returns 0 for completely missing metadata", () => {
     const percent = getDatasetMetadataCompletenessPercentage([
-      { name: "Created_At" },
-      { name: "Products → Category" },
+      { display_name: "Created_At" },
+      { display_name: "Products → Category" },
     ]);
     expect(percent).toBe(0);
   });
@@ -16,12 +16,12 @@ describe("getDatasetMetadataCompletenessPercentage", () => {
   it("returns 1 for complete metadata", () => {
     const percent = getDatasetMetadataCompletenessPercentage([
       {
-        name: "Created At",
+        display_name: "Created At",
         description: "Date created",
         semantic_type: "DateTime",
       },
       {
-        name: "Product Category",
+        display_name: "Product Category",
         description: "The name is pretty self-explaining",
         semantic_type: "String",
       },
@@ -31,9 +31,9 @@ describe("getDatasetMetadataCompletenessPercentage", () => {
 
   it("returns 0.5 for half-complete metadata", () => {
     const percent = getDatasetMetadataCompletenessPercentage([
-      { name: "Created_At" },
+      { display_name: "Created_At" },
       {
-        name: "Product Category",
+        display_name: "Product Category",
         description: "The name is pretty self-explaining",
         semantic_type: "String",
       },
@@ -43,9 +43,9 @@ describe("getDatasetMetadataCompletenessPercentage", () => {
 
   it("returns percent value for partially complete metadata", () => {
     const percent = getDatasetMetadataCompletenessPercentage([
-      { name: "Created_At" },
+      { display_name: "Created_At" },
       {
-        name: "Product Category",
+        display_name: "Product Category",
         semantic_type: "String",
       },
     ]);

--- a/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/DatasetMetadataStrengthIndicator.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetMetadataStrengthIndicator/DatasetMetadataStrengthIndicator.unit.spec.js
@@ -17,16 +17,16 @@ function setup({ resultMetadata } = {}) {
 describe("DatasetMetadataStrengthIndicator", () => {
   const FULLY_COMPLETE_METADATA = {
     id: 1,
-    name: "ID",
+    display_name: "ID",
     description: "Well, that's an ID",
     semantic_type: "type/PK",
   };
   const PARTIALLY_COMPLETE_METADATA = {
     id: 1,
-    name: "ID",
+    display_name: "ID",
     semantic_type: "type/PK",
   };
-  const FULLY_INCOMPLETE_METADATA = { name: "CREATED_AT" };
+  const FULLY_INCOMPLETE_METADATA = { display_name: "CREATED_AT" };
 
   it("doesn't render if result metadata is not defined", () => {
     setup({ resultMetadata: undefined });


### PR DESCRIPTION
Fix for model metadata strength progress indicator from #19724 One of the criteria used to calculate metadata strength, is the absence of underscore and arrow characters in the column name. It was using columns `name` prop which is column's _real_ name in a table, but it should have used `display_name` that actually can change

### To Verify

1. Create a native query like `select * from orders` and turn it into a model
2. Go to the model query editor and fill in metadata for every column (the easiest way is to set "Database column this maps to" for every column" and then specify semantic types for missing columns"
3. Save changes, click the model name to open the details sidebar
4. Hover the progress bar next to the "Customize metadata" button, it should display 100%