### PR TITLE
Fix focus-visible bug

### DIFF
--- a/frontend/src/metabase/css/components/buttons.css
+++ b/frontend/src/metabase/css/components/buttons.css
@@ -25,9 +25,13 @@
   transition-property: color, border-color, background-color;
 }
 
-.Button:focus-visible {
-  outline: 2px solid var(--color-brand-light);
+.Button:focus {
+   outline: 2px solid var(--color-brand-light);
 }
+
+.Button:focus:not(:focus-visible) {
+   outline: none;
+ }
 
 @media screen and (--breakpoint-min-lg) {
   .Button {

--- a/frontend/src/metabase/css/components/buttons.css
+++ b/frontend/src/metabase/css/components/buttons.css
@@ -26,12 +26,12 @@
 }
 
 .Button:focus {
-   outline: 2px solid var(--color-brand-light);
+  outline: 2px solid var(--color-brand-light);
 }
 
 .Button:focus:not(:focus-visible) {
-   outline: none;
- }
+  outline: none;
+}
 
 @media screen and (--breakpoint-min-lg) {
   .Button {

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -19,6 +19,7 @@ module.exports = {
           preserve: false,
         },
         "color-mod-function": true,
+        "focus-visible-pseudo-class": false,
       },
     },
   },


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/19696

Fixes focus-ring in Safari.

How to test:
- Open Metabase with Safari
- Enable "tabbing" into controls in System Settings > Keyboard Settings
- Make sure you can tab into a button
- You should see a focus ring