### PR TITLE
Disable Notebook animation

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/View/QueryViewNotebook/QueryViewNotebook.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View/QueryViewNotebook/QueryViewNotebook.jsx
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 import Notebook from "metabase/query_builder/components/notebook/Notebook";
 import { NotebookContainer } from "./QueryViewNotebook.styled";
 
-const delayBeforeNotRenderingNotebook = 300;
+const delayBeforeNotRenderingNotebook = 10;
 
 const QueryViewNotebook = ({ isNotebookContainerOpen, ...props }) => {
   const [shouldShowNotebook, setShouldShowNotebook] = useState(


### PR DESCRIPTION
This is a forward-port of PR #19131 (targeting 41), intended as a band-aid to the performance problem in #12378. There was at least [one positive feedback](https://github.com/metabase/metabase/issues/12378#issuecomment-985381040) of this workaround.

To verify:

1. Browse data, Sample Dataset, Products
2. Click "Show Editor" button on the top right

**Before this PR**

The notebook shows up with a slide-down animation.

**After this PR**

The notebook appears instantly without any animation.

For a more extreme stress-test, follow the steps in PR #19131.