### PR TITLE
hide new question menu item when there are no dbs

### DIFF
--- a/frontend/src/metabase/nav/containers/Navbar.jsx
+++ b/frontend/src/metabase/nav/containers/Navbar.jsx
@@ -163,15 +163,19 @@ export default class Navbar extends Component {
               </Link>
             }
             items={[
-              {
-                title: t`Question`,
-                icon: `insight`,
-                link: Urls.newQuestion({
-                  mode: "notebook",
-                  creationType: "complex_question",
-                }),
-                event: `NavBar;New Question Click;`,
-              },
+              ...(hasDataAccess
+                ? [
+                    {
+                      title: t`Question`,
+                      icon: `insight`,
+                      link: Urls.newQuestion({
+                        mode: "notebook",
+                        creationType: "complex_question",
+                      }),
+                      event: `NavBar;New Question Click;`,
+                    },
+                  ]
+                : []),
               ...(hasNativeWrite
                 ? [
                     {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/19809

### How to test
- Remove all databases from an instance
- Ensure there is no "Question" item under "New" menu in the navbar