### PR TITLE
Add card visualizations to the pinned section of collections

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx
@@ -3,7 +3,7 @@ import React from "react";
 import { t } from "ttag";
 
 import MetabaseSettings from "metabase/lib/settings";
-import { canonicalCollectionId } from "metabase/entities/collections";
+import { canonicalCollectionId } from "metabase/collections/utils";
 import PopoverWithTrigger from "metabase/components/PopoverWithTrigger";
 import AccordionList from "metabase/components/AccordionList";
 import Icon from "metabase/components/Icon";

--- a/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.styled.tsx
+++ b/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.styled.tsx
@@ -1,0 +1,8 @@
+import styled from "styled-components";
+
+import EntityItem from "metabase/components/EntityItem";
+import { color } from "metabase/lib/colors";
+
+export const EntityItemMenu = styled(EntityItem.Menu)`
+  color: ${color("text-medium")};
+`;

--- a/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.tsx
+++ b/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.tsx
@@ -1,0 +1,56 @@
+import React, { useCallback } from "react";
+
+import { ANALYTICS_CONTEXT } from "metabase/collections/constants";
+import { Item, Collection } from "metabase/collections/utils";
+
+import { EntityItemMenu } from "./ActionMenu.styled";
+
+type Props = {
+  className?: string;
+  item: Item;
+  collection: Collection;
+  onCopy: (items: Item[]) => void;
+  onMove: (items: Item[]) => void;
+};
+
+function ActionMenu({ className, item, collection, onCopy, onMove }: Props) {
+  const handlePin = useCallback(() => {
+    item.setPinned(false);
+  }, [item]);
+
+  const handleCopy = useCallback(() => {
+    onCopy([item]);
+  }, [item, onCopy]);
+
+  const handleMove = useCallback(() => {
+    onMove([item]);
+  }, [item, onMove]);
+
+  const handleArchive = useCallback(() => {
+    item.setArchived(true);
+  }, [item]);
+
+  return (
+    <div
+      className={className}
+      onClick={e => {
+        e.stopPropagation();
+        e.preventDefault();
+      }}
+    >
+      <EntityItemMenu
+        item={item}
+        onPin={collection.can_write ? handlePin : null}
+        onMove={collection.can_write && item.setCollection ? handleMove : null}
+        onCopy={item.copy ? handleCopy : null}
+        onArchive={
+          collection.can_write && item.setArchived ? handleArchive : null
+        }
+        analyticsContext={ANALYTICS_CONTEXT}
+        className={undefined}
+      />
+    </div>
+  );
+}
+
+export default ActionMenu;

--- a/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.tsx
+++ b/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from "react";
 
 import { ANALYTICS_CONTEXT } from "metabase/collections/constants";
-import { Item, Collection } from "metabase/collections/utils";
+import { Item, Collection, isItemPinned } from "metabase/collections/utils";
 
 import { EntityItemMenu } from "./ActionMenu.styled";
 
@@ -15,7 +15,7 @@ type Props = {
 
 function ActionMenu({ className, item, collection, onCopy, onMove }: Props) {
   const handlePin = useCallback(() => {
-    item.setPinned(false);
+    item.setPinned(!isItemPinned(item));
   }, [item]);
 
   const handleCopy = useCallback(() => {

--- a/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.tsx
+++ b/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.tsx
@@ -2,6 +2,7 @@ import React, { useCallback } from "react";
 
 import { ANALYTICS_CONTEXT } from "metabase/collections/constants";
 import { Item, Collection, isItemPinned } from "metabase/collections/utils";
+import EventSandbox from "metabase/components/EventSandbox";
 
 import { EntityItemMenu } from "./ActionMenu.styled";
 
@@ -31,14 +32,11 @@ function ActionMenu({ className, item, collection, onCopy, onMove }: Props) {
   }, [item]);
 
   return (
-    <div
-      className={className}
-      onClick={e => {
-        e.stopPropagation();
-        e.preventDefault();
-      }}
-    >
+    // this component is used within a `<Link>` component,
+    // so we must prevent events from triggering the activation of the link
+    <EventSandbox>
       <EntityItemMenu
+        className={className}
         item={item}
         onPin={collection.can_write ? handlePin : null}
         onMove={collection.can_write && item.setCollection ? handleMove : null}
@@ -47,9 +45,8 @@ function ActionMenu({ className, item, collection, onCopy, onMove }: Props) {
           collection.can_write && item.setArchived ? handleArchive : null
         }
         analyticsContext={ANALYTICS_CONTEXT}
-        className={undefined}
       />
-    </div>
+    </EventSandbox>
   );
 }
 

--- a/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.tsx
+++ b/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.tsx
@@ -34,7 +34,7 @@ function ActionMenu({ className, item, collection, onCopy, onMove }: Props) {
   return (
     // this component is used within a `<Link>` component,
     // so we must prevent events from triggering the activation of the link
-    <EventSandbox>
+    <EventSandbox preventDefault>
       <EntityItemMenu
         className={className}
         item={item}

--- a/frontend/src/metabase/collections/components/ActionMenu/index.ts
+++ b/frontend/src/metabase/collections/components/ActionMenu/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ActionMenu";

--- a/frontend/src/metabase/collections/components/BaseTableItem.jsx
+++ b/frontend/src/metabase/collections/components/BaseTableItem.jsx
@@ -9,8 +9,7 @@ import ItemDragSource from "metabase/containers/dnd/ItemDragSource";
 import EntityItem from "metabase/components/EntityItem";
 import DateTime from "metabase/components/DateTime";
 import Tooltip from "metabase/components/Tooltip";
-
-import { ANALYTICS_CONTEXT } from "metabase/collections/constants";
+import ActionMenu from "metabase/collections/components/ActionMenu";
 
 import {
   EntityIconCheckBox,
@@ -52,14 +51,6 @@ export function BaseTableItem({
   const handleSelectionToggled = useCallback(() => {
     onToggleSelected(item);
   }, [item, onToggleSelected]);
-
-  const handlePin = useCallback(() => {
-    item.setPinned(!isPinned);
-  }, [item, isPinned]);
-
-  const handleMove = useCallback(() => onMove([item]), [item, onMove]);
-  const handleCopy = useCallback(() => onCopy([item]), [item, onCopy]);
-  const handleArchive = useCallback(() => item.setArchived(true), [item]);
 
   const renderRow = useCallback(() => {
     const canSelect = typeof onToggleSelected === "function";
@@ -127,34 +118,26 @@ export function BaseTableItem({
           )}
         </td>
         <td>
-          <EntityItem.Menu
+          <ActionMenu
             item={item}
-            onPin={collection.can_write ? handlePin : null}
-            onMove={
-              collection.can_write && item.setCollection ? handleMove : null
-            }
-            onCopy={item.copy ? handleCopy : null}
-            onArchive={
-              collection.can_write && item.setArchived ? handleArchive : null
-            }
-            ANALYTICS_CONTEXT={ANALYTICS_CONTEXT}
+            collection={collection}
+            onCopy={onCopy}
+            onMove={onMove}
           />
         </td>
       </tr>
     );
   }, [
-    collection,
+    onToggleSelected,
     item,
     isPinned,
     isSelected,
-    linkProps,
-    handleArchive,
-    handleCopy,
-    handleMove,
-    handlePin,
     handleSelectionToggled,
-    onToggleSelected,
     isHoveringOverRow,
+    linkProps,
+    collection,
+    onCopy,
+    onMove,
   ]);
 
   if (!draggable) {

--- a/frontend/src/metabase/collections/components/CollectionCardVisualization/CollectionCardVisualization.jsx
+++ b/frontend/src/metabase/collections/components/CollectionCardVisualization/CollectionCardVisualization.jsx
@@ -1,42 +1,23 @@
 /* eslint-disable react/prop-types */
 import React, { useCallback } from "react";
-import { connect } from "react-redux";
 import _ from "underscore";
 
 import Questions from "metabase/entities/questions";
 import Question from "metabase-lib/lib/Question";
-import { push } from "react-router-redux";
-
-import { getMetadata } from "metabase/selectors/metadata";
-import { question as questionUrl } from "metabase/lib/urls";
 import Visualization from "metabase/visualizations/components/Visualization";
 import QuestionResultLoader from "metabase/containers/QuestionResultLoader";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import { ANALYTICS_CONTEXT } from "metabase/collections/constants";
 
-import {
-  HEIGHT,
-  HoverMenu,
-  VizCard,
-} from "./CollectionCardVisualization.styled";
-
-// todo -- move this to containers
-const mapStateToProps = (state, props) => ({
-  metadata: getMetadata(state),
-});
-
-const mapDispatchToProps = {
-  push,
-};
+import { HoverMenu, VizCard } from "./CollectionCardVisualization.styled";
 
 function CollectionCardVisualization({
   item,
   collection,
   metadata,
-  dispatch,
-  push,
   onCopy,
   onMove,
+  onCardTitleClick,
 }) {
   const handlePin = useCallback(() => {
     item.setPinned(false);
@@ -80,14 +61,10 @@ function CollectionCardVisualization({
                     noWrapper
                   >
                     <Visualization
-                      onChangeCardAndRun={({ nextCard }) =>
-                        push(questionUrl(nextCard))
-                      }
-                      onChangeLocation={push}
+                      onChangeCardAndRun={onCardTitleClick}
                       isDashboard
                       showTitle
                       metadata={metadata}
-                      dispatch={dispatch}
                       {...resultProps}
                     />
                   </LoadingAndErrorWrapper>
@@ -101,7 +78,4 @@ function CollectionCardVisualization({
   );
 }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(CollectionCardVisualization);
+export default CollectionCardVisualization;

--- a/frontend/src/metabase/collections/components/CollectionCardVisualization/CollectionCardVisualization.jsx
+++ b/frontend/src/metabase/collections/components/CollectionCardVisualization/CollectionCardVisualization.jsx
@@ -1,5 +1,5 @@
-/* eslint-disable react/prop-types */
 import React, { useCallback } from "react";
+import PropTypes from "prop-types";
 import _ from "underscore";
 
 import Questions from "metabase/entities/questions";
@@ -14,6 +14,14 @@ import { ANALYTICS_CONTEXT } from "metabase/collections/constants";
 
 import { ItemLink } from "../PinnedItemCard/PinnedItemCard.styled";
 import { HoverMenu, VizCard } from "./CollectionCardVisualization.styled";
+
+const propTypes = {
+  item: PropTypes.object.isRequired,
+  collection: PropTypes.object.isRequired,
+  metadata: PropTypes.object.isRequired,
+  onCopy: PropTypes.func.isRequired,
+  onMove: PropTypes.func.isRequired,
+};
 
 function CollectionCardVisualization({
   item,
@@ -99,6 +107,8 @@ function CollectionCardVisualization({
     </ItemLink>
   );
 }
+
+CollectionCardVisualization.propTypes = propTypes;
 
 export default CollectionCardVisualization;
 

--- a/frontend/src/metabase/collections/components/CollectionCardVisualization/CollectionCardVisualization.jsx
+++ b/frontend/src/metabase/collections/components/CollectionCardVisualization/CollectionCardVisualization.jsx
@@ -73,13 +73,11 @@ function CollectionCardVisualization({
             const question = new Question(card, metadata);
             return (
               <QuestionResultLoader question={question}>
-                {({ loading, error, reload, ...resultProps }) => {
-                  const shouldShowLoader =
-                    loading && resultProps.results == null;
-
+                {({ loading, error, reload, rawSeries, results, result }) => {
+                  const shouldShowLoader = loading && results == null;
                   const { errorMessage, errorIcon } = getErrorProps(
                     error,
-                    resultProps,
+                    result,
                   );
 
                   return (
@@ -94,7 +92,7 @@ function CollectionCardVisualization({
                         metadata={metadata}
                         error={errorMessage}
                         errorIcon={errorIcon}
-                        {...resultProps}
+                        rawSeries={rawSeries}
                       />
                     </LoadingAndErrorWrapper>
                   );
@@ -112,8 +110,8 @@ CollectionCardVisualization.propTypes = propTypes;
 
 export default CollectionCardVisualization;
 
-function getErrorProps(error, resultProps) {
-  error = error || resultProps?.result?.error;
+function getErrorProps(error, result) {
+  error = error || result?.error;
   let errorMessage;
   let errorIcon;
   if (error) {

--- a/frontend/src/metabase/collections/components/CollectionCardVisualization/CollectionCardVisualization.jsx
+++ b/frontend/src/metabase/collections/components/CollectionCardVisualization/CollectionCardVisualization.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React from "react";
 import PropTypes from "prop-types";
 import _ from "underscore";
 
@@ -10,7 +10,6 @@ import Visualization, {
 } from "metabase/visualizations/components/Visualization";
 import QuestionResultLoader from "metabase/containers/QuestionResultLoader";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
-import { ANALYTICS_CONTEXT } from "metabase/collections/constants";
 
 import { ItemLink } from "../PinnedItemCard/PinnedItemCard.styled";
 import { HoverMenu, VizCard } from "./CollectionCardVisualization.styled";
@@ -30,44 +29,15 @@ function CollectionCardVisualization({
   onCopy,
   onMove,
 }) {
-  const handlePin = useCallback(() => {
-    item.setPinned(false);
-  }, [item]);
-
-  const handleCopy = useCallback(() => {
-    onCopy([item]);
-  }, [item, onCopy]);
-
-  const handleMove = useCallback(() => {
-    onMove([item]);
-  }, [item, onMove]);
-
-  const handleArchive = useCallback(() => {
-    item.setArchived(true);
-  }, [item]);
-
   return (
     <ItemLink to={item.getUrl()}>
       <VizCard flat>
-        <div
-          onClick={e => {
-            e.stopPropagation();
-            e.preventDefault();
-          }}
-        >
-          <HoverMenu
-            item={item}
-            onPin={collection.can_write ? handlePin : null}
-            onMove={
-              collection.can_write && item.setCollection ? handleMove : null
-            }
-            onCopy={item.copy ? handleCopy : null}
-            onArchive={
-              collection.can_write && item.setArchived ? handleArchive : null
-            }
-            analyticsContext={ANALYTICS_CONTEXT}
-          />
-        </div>
+        <HoverMenu
+          item={item}
+          collection={collection}
+          onCopy={onCopy}
+          onMove={onMove}
+        />
         <Questions.Loader id={item.id}>
           {({ question: card }) => {
             const question = new Question(card, metadata);

--- a/frontend/src/metabase/collections/components/CollectionCardVisualization/CollectionCardVisualization.jsx
+++ b/frontend/src/metabase/collections/components/CollectionCardVisualization/CollectionCardVisualization.jsx
@@ -4,7 +4,10 @@ import _ from "underscore";
 
 import Questions from "metabase/entities/questions";
 import Question from "metabase-lib/lib/Question";
-import Visualization from "metabase/visualizations/components/Visualization";
+import Visualization, {
+  ERROR_MESSAGE_GENERIC,
+  ERROR_MESSAGE_PERMISSION,
+} from "metabase/visualizations/components/Visualization";
 import QuestionResultLoader from "metabase/containers/QuestionResultLoader";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import { ANALYTICS_CONTEXT } from "metabase/collections/constants";
@@ -65,10 +68,15 @@ function CollectionCardVisualization({
                 {({ loading, error, reload, ...resultProps }) => {
                   const shouldShowLoader =
                     loading && resultProps.results == null;
+
+                  const { errorMessage, errorIcon } = getErrorProps(
+                    error,
+                    resultProps,
+                  );
+
                   return (
                     <LoadingAndErrorWrapper
                       loading={shouldShowLoader}
-                      error={error || resultProps?.result?.error}
                       noWrapper
                     >
                       <Visualization
@@ -76,6 +84,8 @@ function CollectionCardVisualization({
                         isDashboard
                         showTitle
                         metadata={metadata}
+                        error={errorMessage}
+                        errorIcon={errorIcon}
                         {...resultProps}
                       />
                     </LoadingAndErrorWrapper>
@@ -91,3 +101,19 @@ function CollectionCardVisualization({
 }
 
 export default CollectionCardVisualization;
+
+function getErrorProps(error, resultProps) {
+  error = error || resultProps?.result?.error;
+  let errorMessage;
+  let errorIcon;
+  if (error) {
+    if (error.status === 403) {
+      errorMessage = ERROR_MESSAGE_PERMISSION;
+    } else {
+      errorMessage = ERROR_MESSAGE_GENERIC;
+    }
+    errorIcon = "warning";
+  }
+
+  return { errorMessage, errorIcon };
+}

--- a/frontend/src/metabase/collections/components/CollectionCardVisualization/CollectionCardVisualization.jsx
+++ b/frontend/src/metabase/collections/components/CollectionCardVisualization/CollectionCardVisualization.jsx
@@ -1,0 +1,108 @@
+/* eslint-disable react/prop-types */
+import React, { useCallback } from "react";
+import { connect } from "react-redux";
+import _ from "underscore";
+
+import Questions from "metabase/entities/questions";
+import Question from "metabase-lib/lib/Question";
+import { push } from "react-router-redux";
+
+import { getMetadata } from "metabase/selectors/metadata";
+import { question as questionUrl } from "metabase/lib/urls";
+import Visualization from "metabase/visualizations/components/Visualization";
+import QuestionResultLoader from "metabase/containers/QuestionResultLoader";
+import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
+import { ANALYTICS_CONTEXT } from "metabase/collections/constants";
+
+import { HoverMenu, VizCard } from "./CollectionCardVisualization.styled";
+
+// todo -- move this to containers
+const mapStateToProps = (state, props) => ({
+  metadata: getMetadata(state),
+});
+
+const mapDispatchToProps = {
+  push,
+};
+
+const HEIGHT = 250;
+const style = { minHeight: HEIGHT };
+
+function CollectionCardVisualization({
+  item,
+  collection,
+  metadata,
+  dispatch,
+  push,
+  onCopy,
+  onMove,
+}) {
+  const handlePin = useCallback(() => {
+    item.setPinned(false);
+  }, [item]);
+
+  const handleCopy = useCallback(() => {
+    onCopy([item]);
+  }, [item, onCopy]);
+
+  const handleMove = useCallback(() => {
+    onMove([item]);
+  }, [item, onMove]);
+
+  const handleArchive = useCallback(() => {
+    item.setArchived(true);
+  }, [item]);
+
+  return (
+    <VizCard style={style}>
+      <HoverMenu
+        item={item}
+        onPin={collection.can_write ? handlePin : null}
+        onMove={collection.can_write && item.setCollection ? handleMove : null}
+        onCopy={item.copy ? handleCopy : null}
+        onArchive={
+          collection.can_write && item.setArchived ? handleArchive : null
+        }
+        analyticsContext={ANALYTICS_CONTEXT}
+      />
+      <Questions.Loader id={item.id}>
+        {({ question: card }) => {
+          const question = new Question(card, metadata);
+          return (
+            <QuestionResultLoader question={question}>
+              {({ loading, error, reload, ...resultProps }) => {
+                const shouldShowLoader = loading && resultProps.results == null;
+                return (
+                  <LoadingAndErrorWrapper
+                    loading={shouldShowLoader}
+                    error={error || resultProps?.result?.error}
+                    noWrapper
+                    style={style}
+                  >
+                    <Visualization
+                      onChangeCardAndRun={({ nextCard }) =>
+                        push(questionUrl(nextCard))
+                      }
+                      onChangeLocation={push}
+                      isDashboard
+                      showTitle
+                      metadata={metadata}
+                      height={HEIGHT}
+                      dispatch={dispatch}
+                      {...resultProps}
+                    />
+                  </LoadingAndErrorWrapper>
+                );
+              }}
+            </QuestionResultLoader>
+          );
+        }}
+      </Questions.Loader>
+    </VizCard>
+  );
+}
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(CollectionCardVisualization);

--- a/frontend/src/metabase/collections/components/CollectionCardVisualization/CollectionCardVisualization.jsx
+++ b/frontend/src/metabase/collections/components/CollectionCardVisualization/CollectionCardVisualization.jsx
@@ -9,6 +9,7 @@ import QuestionResultLoader from "metabase/containers/QuestionResultLoader";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import { ANALYTICS_CONTEXT } from "metabase/collections/constants";
 
+import { ItemLink } from "../PinnedItemCard/PinnedItemCard.styled";
 import { HoverMenu, VizCard } from "./CollectionCardVisualization.styled";
 
 function CollectionCardVisualization({
@@ -17,7 +18,6 @@ function CollectionCardVisualization({
   metadata,
   onCopy,
   onMove,
-  onCardTitleClick,
 }) {
   const handlePin = useCallback(() => {
     item.setPinned(false);
@@ -36,45 +36,57 @@ function CollectionCardVisualization({
   }, [item]);
 
   return (
-    <VizCard flat>
-      <HoverMenu
-        item={item}
-        onPin={collection.can_write ? handlePin : null}
-        onMove={collection.can_write && item.setCollection ? handleMove : null}
-        onCopy={item.copy ? handleCopy : null}
-        onArchive={
-          collection.can_write && item.setArchived ? handleArchive : null
-        }
-        analyticsContext={ANALYTICS_CONTEXT}
-      />
-      <Questions.Loader id={item.id}>
-        {({ question: card }) => {
-          const question = new Question(card, metadata);
-          return (
-            <QuestionResultLoader question={question}>
-              {({ loading, error, reload, ...resultProps }) => {
-                const shouldShowLoader = loading && resultProps.results == null;
-                return (
-                  <LoadingAndErrorWrapper
-                    loading={shouldShowLoader}
-                    error={error || resultProps?.result?.error}
-                    noWrapper
-                  >
-                    <Visualization
-                      onChangeCardAndRun={onCardTitleClick}
-                      isDashboard
-                      showTitle
-                      metadata={metadata}
-                      {...resultProps}
-                    />
-                  </LoadingAndErrorWrapper>
-                );
-              }}
-            </QuestionResultLoader>
-          );
-        }}
-      </Questions.Loader>
-    </VizCard>
+    <ItemLink to={item.getUrl()}>
+      <VizCard flat>
+        <div
+          onClick={e => {
+            e.stopPropagation();
+            e.preventDefault();
+          }}
+        >
+          <HoverMenu
+            item={item}
+            onPin={collection.can_write ? handlePin : null}
+            onMove={
+              collection.can_write && item.setCollection ? handleMove : null
+            }
+            onCopy={item.copy ? handleCopy : null}
+            onArchive={
+              collection.can_write && item.setArchived ? handleArchive : null
+            }
+            analyticsContext={ANALYTICS_CONTEXT}
+          />
+        </div>
+        <Questions.Loader id={item.id}>
+          {({ question: card }) => {
+            const question = new Question(card, metadata);
+            return (
+              <QuestionResultLoader question={question}>
+                {({ loading, error, reload, ...resultProps }) => {
+                  const shouldShowLoader =
+                    loading && resultProps.results == null;
+                  return (
+                    <LoadingAndErrorWrapper
+                      loading={shouldShowLoader}
+                      error={error || resultProps?.result?.error}
+                      noWrapper
+                    >
+                      <Visualization
+                        onChangeCardAndRun={_.noop}
+                        isDashboard
+                        showTitle
+                        metadata={metadata}
+                        {...resultProps}
+                      />
+                    </LoadingAndErrorWrapper>
+                  );
+                }}
+              </QuestionResultLoader>
+            );
+          }}
+        </Questions.Loader>
+      </VizCard>
+    </ItemLink>
   );
 }
 

--- a/frontend/src/metabase/collections/components/CollectionCardVisualization/CollectionCardVisualization.jsx
+++ b/frontend/src/metabase/collections/components/CollectionCardVisualization/CollectionCardVisualization.jsx
@@ -14,7 +14,11 @@ import QuestionResultLoader from "metabase/containers/QuestionResultLoader";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import { ANALYTICS_CONTEXT } from "metabase/collections/constants";
 
-import { HoverMenu, VizCard } from "./CollectionCardVisualization.styled";
+import {
+  HEIGHT,
+  HoverMenu,
+  VizCard,
+} from "./CollectionCardVisualization.styled";
 
 // todo -- move this to containers
 const mapStateToProps = (state, props) => ({
@@ -24,9 +28,6 @@ const mapStateToProps = (state, props) => ({
 const mapDispatchToProps = {
   push,
 };
-
-const HEIGHT = 250;
-const style = { minHeight: HEIGHT };
 
 function CollectionCardVisualization({
   item,
@@ -54,7 +55,7 @@ function CollectionCardVisualization({
   }, [item]);
 
   return (
-    <VizCard style={style}>
+    <VizCard flat>
       <HoverMenu
         item={item}
         onPin={collection.can_write ? handlePin : null}
@@ -77,7 +78,6 @@ function CollectionCardVisualization({
                     loading={shouldShowLoader}
                     error={error || resultProps?.result?.error}
                     noWrapper
-                    style={style}
                   >
                     <Visualization
                       onChangeCardAndRun={({ nextCard }) =>
@@ -87,7 +87,6 @@ function CollectionCardVisualization({
                       isDashboard
                       showTitle
                       metadata={metadata}
-                      height={HEIGHT}
                       dispatch={dispatch}
                       {...resultProps}
                     />

--- a/frontend/src/metabase/collections/components/CollectionCardVisualization/CollectionCardVisualization.styled.jsx
+++ b/frontend/src/metabase/collections/components/CollectionCardVisualization/CollectionCardVisualization.styled.jsx
@@ -4,6 +4,8 @@ import EntityItem from "metabase/components/EntityItem";
 import Card from "metabase/components/Card";
 import { color } from "metabase/lib/colors";
 
+const HEIGHT = 250;
+
 export const HoverMenu = styled(EntityItem.Menu)`
   visibility: hidden;
   color: ${color("text-medium")};
@@ -16,6 +18,8 @@ export const HoverMenu = styled(EntityItem.Menu)`
 
 export const VizCard = styled(Card)`
   position: relative;
+  line-height: inherit;
+  height: ${HEIGHT}px;
 
   &:hover {
     ${HoverMenu} {

--- a/frontend/src/metabase/collections/components/CollectionCardVisualization/CollectionCardVisualization.styled.jsx
+++ b/frontend/src/metabase/collections/components/CollectionCardVisualization/CollectionCardVisualization.styled.jsx
@@ -1,0 +1,25 @@
+import styled from "styled-components";
+
+import EntityItem from "metabase/components/EntityItem";
+import Card from "metabase/components/Card";
+import { color } from "metabase/lib/colors";
+
+export const HoverMenu = styled(EntityItem.Menu)`
+  visibility: hidden;
+  color: ${color("text-medium")};
+
+  position: absolute;
+  top: 3px;
+  right: 3px;
+  z-index: 3;
+`;
+
+export const VizCard = styled(Card)`
+  position: relative;
+
+  &:hover {
+    ${HoverMenu} {
+      visibility: visible;
+    }
+  }
+`;

--- a/frontend/src/metabase/collections/components/CollectionCardVisualization/CollectionCardVisualization.styled.jsx
+++ b/frontend/src/metabase/collections/components/CollectionCardVisualization/CollectionCardVisualization.styled.jsx
@@ -11,12 +11,13 @@ export const HoverMenu = styled(EntityItem.Menu)`
   color: ${color("text-medium")};
 
   position: absolute;
-  top: 3px;
-  right: 3px;
+  top: 5px;
+  right: 5px;
   z-index: 3;
 `;
 
 export const VizCard = styled(Card)`
+  padding: 0.5rem 0;
   position: relative;
   line-height: inherit;
   height: ${HEIGHT}px;

--- a/frontend/src/metabase/collections/components/CollectionCardVisualization/CollectionCardVisualization.styled.jsx
+++ b/frontend/src/metabase/collections/components/CollectionCardVisualization/CollectionCardVisualization.styled.jsx
@@ -1,12 +1,12 @@
 import styled from "styled-components";
 
-import EntityItem from "metabase/components/EntityItem";
+import ActionMenu from "metabase/collections/components/ActionMenu";
 import Card from "metabase/components/Card";
 import { color } from "metabase/lib/colors";
 
 const HEIGHT = 250;
 
-export const HoverMenu = styled(EntityItem.Menu)`
+export const HoverMenu = styled(ActionMenu)`
   visibility: hidden;
   color: ${color("text-medium")};
 

--- a/frontend/src/metabase/collections/components/CollectionCardVisualization/index.js
+++ b/frontend/src/metabase/collections/components/CollectionCardVisualization/index.js
@@ -1,0 +1,1 @@
+export { default } from "./CollectionCardVisualization";

--- a/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.styled.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.styled.tsx
@@ -5,7 +5,7 @@ import { forwardRefToInnerRef } from "metabase/styled-components/utils";
 import Icon from "metabase/components/Icon";
 import Link from "metabase/components/Link";
 import Card from "metabase/components/Card";
-import EntityItem from "metabase/components/EntityItem";
+import ActionMenu from "metabase/collections/components/ActionMenu";
 
 export const ItemCard = styled(Card)``;
 
@@ -20,9 +20,8 @@ export const ItemIcon = styled(Icon)`
   width: 1.7rem;
 `;
 
-export const HoverMenu = styled(EntityItem.Menu)`
+export const HoverMenu = styled(ActionMenu)`
   visibility: hidden;
-  color: ${color("text-medium")};
 `;
 
 export const Title = styled.div`

--- a/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.tsx
@@ -1,8 +1,7 @@
-import React, { useState, useCallback } from "react";
+import React, { useState } from "react";
 import { t } from "ttag";
 
 import Tooltip from "metabase/components/Tooltip";
-import { ANALYTICS_CONTEXT } from "metabase/collections/constants";
 import { Item, Collection } from "metabase/collections/utils";
 
 import {
@@ -59,50 +58,18 @@ function PinnedItemCard({
     }
   };
 
-  const handlePin = useCallback(() => {
-    item.setPinned(false);
-  }, [item]);
-
-  const handleCopy = useCallback(() => {
-    onCopy([item]);
-  }, [item, onCopy]);
-
-  const handleMove = useCallback(() => {
-    onMove([item]);
-  }, [item, onMove]);
-
-  const handleArchive = useCallback(() => {
-    item.setArchived(true);
-  }, [item]);
-
   return (
     <ItemLink className={className} to={item.getUrl()}>
       <ItemCard flat>
         <Body>
           <Header>
             <ItemIcon name={icon} />
-            <div
-              onClick={e => {
-                e.stopPropagation();
-                e.preventDefault();
-              }}
-            >
-              <HoverMenu
-                item={item}
-                onPin={collection.can_write ? handlePin : null}
-                onMove={
-                  collection.can_write && item.setCollection ? handleMove : null
-                }
-                onCopy={item.copy ? handleCopy : null}
-                onArchive={
-                  collection.can_write && item.setArchived
-                    ? handleArchive
-                    : null
-                }
-                analyticsContext={ANALYTICS_CONTEXT}
-                className={undefined}
-              />
-            </div>
+            <HoverMenu
+              item={item}
+              collection={collection}
+              onCopy={onCopy}
+              onMove={onMove}
+            />
           </Header>
           <Tooltip
             tooltip={name}

--- a/frontend/src/metabase/collections/components/PinnedItemOverview/PinnedItemOverview.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemOverview/PinnedItemOverview.tsx
@@ -3,6 +3,7 @@ import _ from "underscore";
 import { t } from "ttag";
 
 import PinnedItemCard from "metabase/collections/components/PinnedItemCard/PinnedItemCard";
+import CollectionCardVisualization from "metabase/collections/components/CollectionCardVisualization";
 import { Item, Collection, isRootCollection } from "metabase/collections/utils";
 
 import { Container, Grid, SectionHeader } from "./PinnedItemOverview.styled";
@@ -27,7 +28,7 @@ function PinnedItemOverview({ items, collection, onCopy, onMove }: Props) {
       {cardItems.length > 0 && (
         <Grid>
           {cardItems.map(item => (
-            <PinnedItemCard
+            <CollectionCardVisualization
               key={item.id}
               item={item}
               collection={collection}

--- a/frontend/src/metabase/collections/components/PinnedItemOverview/PinnedItemOverview.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemOverview/PinnedItemOverview.tsx
@@ -2,7 +2,8 @@ import React from "react";
 import _ from "underscore";
 import { t } from "ttag";
 
-import PinnedItemCard from "metabase/collections/components/PinnedItemCard/PinnedItemCard";
+import Metadata from "metabase-lib/lib/metadata/Metadata";
+import PinnedItemCard from "metabase/collections/components/PinnedItemCard";
 import CollectionCardVisualization from "metabase/collections/components/CollectionCardVisualization";
 import { Item, Collection, isRootCollection } from "metabase/collections/utils";
 
@@ -11,11 +12,20 @@ import { Container, Grid, SectionHeader } from "./PinnedItemOverview.styled";
 type Props = {
   items: Item[];
   collection: Collection;
+  metadata: Metadata;
   onCopy: (items: Item[]) => void;
   onMove: (items: Item[]) => void;
+  onCardTitleClick: (state: unknown) => void;
 };
 
-function PinnedItemOverview({ items, collection, onCopy, onMove }: Props) {
+function PinnedItemOverview({
+  items,
+  collection,
+  metadata,
+  onCopy,
+  onMove,
+  onCardTitleClick,
+}: Props) {
   const sortedItems = _.sortBy(items, item => item.name);
   const {
     card: cardItems = [],
@@ -32,8 +42,10 @@ function PinnedItemOverview({ items, collection, onCopy, onMove }: Props) {
               key={item.id}
               item={item}
               collection={collection}
+              metadata={metadata}
               onCopy={onCopy}
               onMove={onMove}
+              onCardTitleClick={onCardTitleClick}
             />
           ))}
         </Grid>

--- a/frontend/src/metabase/collections/components/PinnedItemOverview/PinnedItemOverview.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemOverview/PinnedItemOverview.tsx
@@ -15,7 +15,6 @@ type Props = {
   metadata: Metadata;
   onCopy: (items: Item[]) => void;
   onMove: (items: Item[]) => void;
-  onCardTitleClick: (state: unknown) => void;
 };
 
 function PinnedItemOverview({
@@ -24,7 +23,6 @@ function PinnedItemOverview({
   metadata,
   onCopy,
   onMove,
-  onCardTitleClick,
 }: Props) {
   const sortedItems = _.sortBy(items, item => item.name);
   const {
@@ -45,7 +43,6 @@ function PinnedItemOverview({
               metadata={metadata}
               onCopy={onCopy}
               onMove={onMove}
-              onCardTitleClick={onCardTitleClick}
             />
           ))}
         </Grid>

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -3,11 +3,14 @@ import React, { useState, useCallback } from "react";
 import { Box } from "grid-styled";
 import _ from "underscore";
 import { connect } from "react-redux";
+import { push } from "react-router-redux";
 
 import Collection from "metabase/entities/collections";
 import Search from "metabase/entities/search";
 
 import { getUserIsAdmin } from "metabase/selectors/user";
+import { getMetadata } from "metabase/selectors/metadata";
+import { question as questionUrl } from "metabase/lib/urls";
 
 import BulkActions from "metabase/collections/components/BulkActions";
 import CollectionEmptyState from "metabase/components/CollectionEmptyState";
@@ -31,8 +34,13 @@ const itemKeyFn = item => `${item.id}:${item.model}`;
 function mapStateToProps(state) {
   return {
     isAdmin: getUserIsAdmin(state),
+    metadata: getMetadata(state),
   };
 }
+
+const mapDispatchToProps = {
+  push,
+};
 
 function CollectionContent({
   collection,
@@ -41,6 +49,8 @@ function CollectionContent({
   isAdmin,
   isRoot,
   handleToggleMobileSidebar,
+  metadata,
+  push,
 }) {
   const [selectedItems, setSelectedItems] = useState(null);
   const [selectedAction, setSelectedAction] = useState(null);
@@ -107,6 +117,10 @@ function CollectionContent({
     setSelectedAction("copy");
   };
 
+  const handleCardTitleClick = ({ nextCard }) => {
+    push(questionUrl(nextCard));
+  };
+
   const unpinnedQuery = {
     collection: collectionId,
     models: ALL_MODELS,
@@ -150,9 +164,11 @@ function CollectionContent({
               <PinnedItemOverview
                 items={pinnedItems}
                 collection={collection}
+                metadata={metadata}
                 onMove={handleMove}
                 onCopy={handleCopy}
                 onToggleSelected={toggleItem}
+                onCardTitleClick={handleCardTitleClick}
               />
               <Search.ListLoader
                 query={unpinnedQuery}
@@ -255,5 +271,5 @@ export default _.compose(
     id: (_, props) => props.collectionId,
     reload: true,
   }),
-  connect(mapStateToProps),
+  connect(mapStateToProps, mapDispatchToProps),
 )(CollectionContent);

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -3,14 +3,12 @@ import React, { useState, useCallback } from "react";
 import { Box } from "grid-styled";
 import _ from "underscore";
 import { connect } from "react-redux";
-import { push } from "react-router-redux";
 
 import Collection from "metabase/entities/collections";
 import Search from "metabase/entities/search";
 
 import { getUserIsAdmin } from "metabase/selectors/user";
 import { getMetadata } from "metabase/selectors/metadata";
-import { question as questionUrl } from "metabase/lib/urls";
 
 import BulkActions from "metabase/collections/components/BulkActions";
 import CollectionEmptyState from "metabase/components/CollectionEmptyState";
@@ -38,10 +36,6 @@ function mapStateToProps(state) {
   };
 }
 
-const mapDispatchToProps = {
-  push,
-};
-
 function CollectionContent({
   collection,
   collections: collectionList = [],
@@ -50,7 +44,6 @@ function CollectionContent({
   isRoot,
   handleToggleMobileSidebar,
   metadata,
-  push,
 }) {
   const [selectedItems, setSelectedItems] = useState(null);
   const [selectedAction, setSelectedAction] = useState(null);
@@ -117,10 +110,6 @@ function CollectionContent({
     setSelectedAction("copy");
   };
 
-  const handleCardTitleClick = ({ nextCard }) => {
-    push(questionUrl(nextCard));
-  };
-
   const unpinnedQuery = {
     collection: collectionId,
     models: ALL_MODELS,
@@ -168,7 +157,6 @@ function CollectionContent({
                 onMove={handleMove}
                 onCopy={handleCopy}
                 onToggleSelected={toggleItem}
-                onCardTitleClick={handleCardTitleClick}
               />
               <Search.ListLoader
                 query={unpinnedQuery}
@@ -271,5 +259,5 @@ export default _.compose(
     id: (_, props) => props.collectionId,
     reload: true,
   }),
-  connect(mapStateToProps, mapDispatchToProps),
+  connect(mapStateToProps),
 )(CollectionContent);

--- a/frontend/src/metabase/collections/utils.ts
+++ b/frontend/src/metabase/collections/utils.ts
@@ -109,3 +109,7 @@ export function isPersonalCollectionChild(
 export function isRootCollection(collection: Collection): boolean {
   return collection.id === "root";
 }
+
+export function isItemPinned(item: Item) {
+  return item.collection_position != null;
+}

--- a/frontend/src/metabase/collections/utils.ts
+++ b/frontend/src/metabase/collections/utils.ts
@@ -1,5 +1,4 @@
 import { t } from "ttag";
-import { canonicalCollectionId } from "metabase/entities/collections";
 
 export type Item = {
   name: string;
@@ -112,4 +111,16 @@ export function isRootCollection(collection: Collection): boolean {
 
 export function isItemPinned(item: Item) {
   return item.collection_position != null;
+}
+
+// API requires items in "root" collection be persisted with a "null" collection ID
+// Also ensure it's parsed as a number
+function canonicalCollectionId(
+  collectionId: string | null | undefined,
+): number | null {
+  if (collectionId === "root" || collectionId == null) {
+    return null;
+  }
+
+  return parseInt(collectionId, 10);
 }

--- a/frontend/src/metabase/collections/utils.ts
+++ b/frontend/src/metabase/collections/utils.ts
@@ -115,7 +115,7 @@ export function isItemPinned(item: Item) {
 
 // API requires items in "root" collection be persisted with a "null" collection ID
 // Also ensure it's parsed as a number
-function canonicalCollectionId(
+export function canonicalCollectionId(
   collectionId: string | null | undefined,
 ): number | null {
   if (collectionId === "root" || collectionId == null) {

--- a/frontend/src/metabase/components/EntityItem.jsx
+++ b/frontend/src/metabase/components/EntityItem.jsx
@@ -10,6 +10,7 @@ import CheckBox from "metabase/components/CheckBox";
 import Ellipsified from "metabase/components/Ellipsified";
 import Icon from "metabase/components/Icon";
 import Tooltip from "metabase/components/Tooltip";
+import { isItemPinned } from "metabase/collections/utils";
 
 import {
   EntityIconWrapper,
@@ -78,7 +79,7 @@ function EntityItemMenu({
   className,
   analyticsContext,
 }) {
-  const isPinned = item.collection_position != null;
+  const isPinned = isItemPinned(item);
   const showPinnedAction = onPin && isPinned;
 
   const actions = useMemo(

--- a/frontend/src/metabase/components/EventSandbox.tsx
+++ b/frontend/src/metabase/components/EventSandbox.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from "react";
 
 function stop<E extends React.SyntheticEvent>(event: E) {
   event.stopPropagation();
+  event.preventDefault();
 }
 
 const mouseEventBlockers = {

--- a/frontend/src/metabase/components/EventSandbox.tsx
+++ b/frontend/src/metabase/components/EventSandbox.tsx
@@ -1,24 +1,24 @@
-import React, { useMemo } from "react";
+import React, { useMemo, useCallback } from "react";
 
-function stop<E extends React.SyntheticEvent>(event: E) {
-  event.stopPropagation();
-  event.preventDefault();
-}
-
-const mouseEventBlockers = {
-  onMouseDown: stop,
-  onMouseEnter: stop,
-  onMouseLeave: stop,
-  onMouseMove: stop,
-  onMouseOver: stop,
-  onMouseOut: stop,
-  onMouseUp: stop,
+type Options = {
+  preventDefault?: boolean;
 };
+
+function _stop<E extends React.SyntheticEvent>(
+  event: E,
+  { preventDefault }: Options,
+) {
+  event.stopPropagation();
+  if (preventDefault) {
+    event.preventDefault();
+  }
+}
 
 type EventSandboxProps = {
   children: React.ReactNode;
   enableMouseEvents?: boolean;
   disabled?: boolean;
+  preventDefault?: boolean;
 };
 
 // Prevent DOM events from bubbling through the React component tree
@@ -28,10 +28,28 @@ function EventSandbox({
   children,
   disabled,
   enableMouseEvents = false,
+  preventDefault = false,
 }: EventSandboxProps) {
+  const stop = useCallback(
+    (event: React.SyntheticEvent) => {
+      _stop(event, { preventDefault });
+    },
+    [preventDefault],
+  );
+
   const extraProps = useMemo(() => {
+    const mouseEventBlockers = {
+      onMouseDown: stop,
+      onMouseEnter: stop,
+      onMouseLeave: stop,
+      onMouseMove: stop,
+      onMouseOver: stop,
+      onMouseOut: stop,
+      onMouseUp: stop,
+    };
+
     return enableMouseEvents ? {} : mouseEventBlockers;
-  }, [enableMouseEvents]);
+  }, [stop, enableMouseEvents]);
 
   return disabled === true ? (
     <React.Fragment>{children}</React.Fragment>

--- a/frontend/src/metabase/entities/collections.js
+++ b/frontend/src/metabase/entities/collections.js
@@ -9,7 +9,10 @@ import { createSelector } from "reselect";
 import { GET } from "metabase/lib/api";
 
 import { getUser, getUserPersonalCollectionId } from "metabase/selectors/user";
-import { isPersonalCollection } from "metabase/collections/utils";
+import {
+  isPersonalCollection,
+  canonicalCollectionId,
+} from "metabase/collections/utils";
 
 import { t } from "ttag";
 
@@ -157,13 +160,6 @@ export function getCollectionIcon(collection, { tooltip = "default" } = {}) {
       }
     : { name: "folder" };
 }
-
-// API requires items in "root" collection be persisted with a "null" collection ID
-// Also ensure it's parsed as a number
-export const canonicalCollectionId = collectionId =>
-  collectionId == null || collectionId === "root"
-    ? null
-    : parseInt(collectionId, 10);
 
 export function normalizedCollection(collection) {
   if (canonicalCollectionId(collection.id) === null) {

--- a/frontend/src/metabase/entities/dashboards.js
+++ b/frontend/src/metabase/entities/dashboards.js
@@ -15,10 +15,10 @@ import { addUndo } from "metabase/redux/undo";
 
 import { POST, DELETE } from "metabase/lib/api";
 import {
-  canonicalCollectionId,
   getCollectionType,
   normalizedCollection,
 } from "metabase/entities/collections";
+import { canonicalCollectionId } from "metabase/collections/utils";
 
 import forms from "./dashboards/forms";
 

--- a/frontend/src/metabase/entities/pulses.js
+++ b/frontend/src/metabase/entities/pulses.js
@@ -4,10 +4,8 @@ import * as Urls from "metabase/lib/urls";
 import { color } from "metabase/lib/colors";
 import { PulseApi } from "metabase/services";
 import { addUndo } from "metabase/redux/undo";
-import {
-  canonicalCollectionId,
-  getCollectionType,
-} from "metabase/entities/collections";
+import { getCollectionType } from "metabase/entities/collections";
+import { canonicalCollectionId } from "metabase/collections/utils";
 
 export const UNSUBSCRIBE = "metabase/entities/pulses/unsubscribe";
 

--- a/frontend/src/metabase/entities/questions.js
+++ b/frontend/src/metabase/entities/questions.js
@@ -5,10 +5,10 @@ import * as Urls from "metabase/lib/urls";
 import { color } from "metabase/lib/colors";
 
 import {
-  canonicalCollectionId,
   getCollectionType,
   normalizedCollection,
 } from "metabase/entities/collections";
+import { canonicalCollectionId } from "metabase/collections/utils";
 
 import { POST, DELETE } from "metabase/lib/api";
 

--- a/frontend/src/metabase/entities/search.js
+++ b/frontend/src/metabase/entities/search.js
@@ -5,7 +5,7 @@ import { entityTypeForObject } from "metabase/lib/schema";
 
 import { ObjectUnionSchema, ENTITIES_SCHEMA_MAP } from "metabase/schema";
 
-import { canonicalCollectionId } from "metabase/entities/collections";
+import { canonicalCollectionId } from "metabase/collections/utils";
 
 const ENTITIES_TYPES = Object.keys(ENTITIES_SCHEMA_MAP);
 

--- a/frontend/src/metabase/entities/snippet-collections.js
+++ b/frontend/src/metabase/entities/snippet-collections.js
@@ -6,9 +6,9 @@ import { color } from "metabase/lib/colors";
 import { createEntity, undo } from "metabase/lib/entities";
 import { SnippetCollectionSchema } from "metabase/schema";
 import NormalCollections, {
-  canonicalCollectionId,
   getExpandedCollectionsById,
 } from "metabase/entities/collections";
+import { canonicalCollectionId } from "metabase/collections/utils";
 
 const SnippetCollections = createEntity({
   name: "snippetCollections",

--- a/frontend/src/metabase/entities/snippets.js
+++ b/frontend/src/metabase/entities/snippets.js
@@ -2,7 +2,7 @@ import { t } from "ttag";
 
 import { createEntity } from "metabase/lib/entities";
 import validate from "metabase/lib/validate";
-import { canonicalCollectionId } from "metabase/entities/collections";
+import { canonicalCollectionId } from "metabase/collections/utils";
 
 const formFields = [
   {

--- a/frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar.jsx
@@ -21,7 +21,8 @@ import { color } from "metabase/lib/colors";
 
 import Snippets from "metabase/entities/snippets";
 import SnippetCollections from "metabase/entities/snippet-collections";
-import { canonicalCollectionId } from "metabase/entities/collections";
+import { canonicalCollectionId } from "metabase/collections/utils";
+
 import Search from "metabase/entities/search";
 
 const ICON_SIZE = 16;


### PR DESCRIPTION
Related to #19758. Merging into a feature branch.

This PR makes it so that pinned cards are like little, simplified dashcards, with their visualizations showing. Clicking anywhere on the card navigates you to the query builder. The card has a little upper-right action menu like the other pinned cards.

**Testing**
1. Pin various types of visualizations to a collection
2. Pin a question that has a broken query to make sure the error state is correct -- an easy way to see this is to create a native question with an empty variable tag

<img width="1494" alt="Screen Shot 2022-01-20 at 4 49 01 PM" src="https://user-images.githubusercontent.com/13057258/150445773-f593295c-43c7-45ea-b15c-c21e9401e74a.png">

<img width="718" alt="Screen Shot 2022-01-20 at 4 49 09 PM" src="https://user-images.githubusercontent.com/13057258/150445783-363eb64d-aa78-4239-a764-048526f14370.png">

