### PR TITLE
Add question link to the 'stopped working' email template.

### DIFF
--- a/src/metabase/email/alert_stopped_working.mustache
+++ b/src/metabase/email/alert_stopped_working.mustache
@@ -1,3 +1,3 @@
 {{> metabase/email/_header }}
-    <p>Alerts about {{questionName}} have stopped because {{deletionCause}}.</p>
+    <p>Alerts about <a href="{{questionURL}}">{{questionName}}</a> have stopped because {{deletionCause}}.</p>
 {{> metabase/email/_footer}}

--- a/src/metabase/email/alert_you_were_added.mustache
+++ b/src/metabase/email/alert_you_were_added.mustache
@@ -1,5 +1,5 @@
 {{> metabase/email/_header }}
     <p>You’re now getting alerts about <a href="{{questionURL}}">{{questionName}}</a>.</p>
     <p>We’ll send you an email {{alertCondition}}.</p>
-    <p>If you don’t want to receive these alerts, you can <a href="{{questionURL}}">go to this question</a> and unsubscribe from the menu in the top-right.</p>
+    <p>If you don’t want to receive these alerts, you can <a href="{{questionURL}}">go to this question</a> and unsubscribe by clicking the bell icon on the bottom right.</p>
 {{> metabase/email/_footer}}


### PR DESCRIPTION
Fixes: #19814

This is a quick change to the 'stopped working' email template to add a link. This immediately makes the email more useful. 