### PR TITLE
Data picker empty state

### DIFF
--- a/frontend/src/metabase/components/EmptyState.jsx
+++ b/frontend/src/metabase/components/EmptyState.jsx
@@ -35,7 +35,12 @@ const EmptyState = ({
   ...rest
 }) => (
   <Box>
-    <Flex justify="center" flexDirection="column" align="center">
+    <Flex
+      className="text-centered"
+      justify="center"
+      flexDirection="column"
+      align="center"
+    >
       {illustrationElement && <Box mb={[2, 3]}>{illustrationElement}</Box>}
       <Box>
         <LegacyIcon {...rest} />

--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -1015,6 +1015,11 @@ export class UnconnectedDataSelector extends Component {
     }[selectedDataBucketId];
   };
 
+  hasDataAccess = () => {
+    const { hasDataAccess, databases } = this.props;
+    return hasDataAccess || databases?.length > 0;
+  };
+
   render() {
     const {
       searchText,
@@ -1022,7 +1027,7 @@ export class UnconnectedDataSelector extends Component {
       selectedDataBucketId,
       selectedTable,
     } = this.state;
-    const { canChangeDatabase, selectedDatabaseId, hasDataAccess } = this.props;
+    const { canChangeDatabase, selectedDatabaseId } = this.props;
 
     const currentDatabaseId = canChangeDatabase ? null : selectedDatabaseId;
 
@@ -1050,7 +1055,7 @@ export class UnconnectedDataSelector extends Component {
       >
         {this.isLoadingDatasets() ? (
           <LoadingAndErrorWrapper loading />
-        ) : hasDataAccess ? (
+        ) : this.hasDataAccess() ? (
           <>
             {this.showTableSearch() && (
               <ListSearchField

--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -12,6 +12,7 @@ import {
   SAVED_QUESTIONS_VIRTUAL_DB_ID,
 } from "metabase/lib/saved-questions";
 
+import EmptyState from "metabase/components/EmptyState";
 import ListSearchField from "metabase/components/ListSearchField";
 import ExternalLink from "metabase/components/ExternalLink";
 import Icon from "metabase/components/Icon";
@@ -39,6 +40,7 @@ import {
 import SavedQuestionPicker from "./saved-question-picker/SavedQuestionPicker";
 
 import { getMetadata } from "metabase/selectors/metadata";
+import { getHasDataAccess } from "metabase/new_query/selectors";
 
 import {
   DataBucketList,
@@ -47,6 +49,7 @@ import {
   RawDataBackButton,
   CollectionDatasetSelectList,
   CollectionDatasetAllDataLink,
+  EmptyStateContainer,
 } from "./DataSelector.styled";
 import "./DataSelector.css";
 
@@ -209,6 +212,7 @@ const FieldTriggerContent = ({ selectedDatabase, selectedField }) => {
     hasFetchedDatabasesWithTables: !!Databases.selectors.getList(state, {
       entityQuery: { include: "tables" },
     }),
+    hasDataAccess: getHasDataAccess(state),
   }),
   {
     fetchDatabases: databaseQuery => Databases.actions.fetchList(databaseQuery),
@@ -1018,7 +1022,8 @@ export class UnconnectedDataSelector extends Component {
       selectedDataBucketId,
       selectedTable,
     } = this.state;
-    const { canChangeDatabase, selectedDatabaseId } = this.props;
+    const { canChangeDatabase, selectedDatabaseId, hasDataAccess } = this.props;
+
     const currentDatabaseId = canChangeDatabase ? null : selectedDatabaseId;
 
     const isSearchActive = searchText.trim().length >= MIN_SEARCH_LENGTH;
@@ -1045,8 +1050,8 @@ export class UnconnectedDataSelector extends Component {
       >
         {this.isLoadingDatasets() ? (
           <LoadingAndErrorWrapper loading />
-        ) : (
-          <React.Fragment>
+        ) : hasDataAccess ? (
+          <>
             {this.showTableSearch() && (
               <ListSearchField
                 hasClearButton
@@ -1082,7 +1087,14 @@ export class UnconnectedDataSelector extends Component {
               ) : (
                 this.renderActiveStep()
               ))}
-          </React.Fragment>
+          </>
+        ) : (
+          <EmptyStateContainer>
+            <EmptyState
+              message={t`To pick some data, you'll need to add some first`}
+              icon="database"
+            />
+          </EmptyStateContainer>
         )}
       </PopoverWithTrigger>
     );

--- a/frontend/src/metabase/query_builder/components/DataSelector.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.styled.jsx
@@ -148,3 +148,8 @@ CollectionDatasetAllDataLink.Content = styled.span`
     margin-left: ${space(0)};
   }
 `;
+
+export const EmptyStateContainer = styled.div`
+  width: 300px;
+  padding: 80px 60px;
+`;

--- a/frontend/test/metabase/query_builder/components/DataSelector.unit.spec.js
+++ b/frontend/test/metabase/query_builder/components/DataSelector.unit.spec.js
@@ -126,6 +126,7 @@ describe("DataSelector", () => {
     // on initial load, we fetch databases
     await delay(1);
     expect(fetchDatabases).toHaveBeenCalled();
+    rerender(<DataSelector {...props} loading />);
     getByText("Loading...");
 
     // select a db
@@ -300,6 +301,7 @@ describe("DataSelector", () => {
       <DataSelector
         steps={["SCHEMA", "TABLE", "FIELD"]}
         selectedDatabaseId={SAMPLE_DATABASE.id}
+        databases={[SAMPLE_DATABASE]}
         triggerElement={<div />}
         metadata={metadata}
         isOpen={true}
@@ -315,6 +317,7 @@ describe("DataSelector", () => {
       <DataSelector
         steps={["SCHEMA", "TABLE", "FIELD"]}
         selectedDatabaseId={MULTI_SCHEMA_DATABASE.id}
+        databases={[MULTI_SCHEMA_DATABASE]}
         triggerElement={<div />}
         metadata={metadata}
         isOpen={true}
@@ -386,6 +389,19 @@ describe("DataSelector", () => {
     fireEvent.click(getByText("Sample Database"));
     await delay(1);
     getByText("Orders");
+  });
+
+  it("shows an empty state without any databases", async () => {
+    const { getByText } = render(
+      <DataSelector
+        steps={["DATABASE", "SCHEMA", "TABLE"]}
+        databases={[]}
+        triggerElement={<div />}
+        isOpen={true}
+      />,
+    );
+
+    getByText("To pick some data, you'll need to add some first");
   });
 });
 


### PR DESCRIPTION
Follow-up on https://github.com/metabase/metabase/pull/19811

Users won't be likely to see it because we should hide links to all pages that contain data pickers. 

<img width="637" alt="Screenshot 2022-01-20 at 22 35 00" src="https://user-images.githubusercontent.com/14301985/150433587-76cd199f-e2d8-4336-a789-7276ebe6f685.png">

### How to verify
- Remove all DBs from an instance
- Open http://localhost:3000/question/notebook#eyJjcmVhdGlvblR5cGUiOiJjb21wbGV4X3F1ZXN0aW9uIiwiZGF0YXNldF9xdWVyeSI6eyJkYXRhYmFzZSI6bnVsbCwicXVlcnkiOnsic291cmNlLXRhYmxlIjpudWxsfSwidHlwZSI6InF1ZXJ5In0sImRpc3BsYXkiOiJ0YWJsZSIsInZpc3VhbGl6YXRpb25fc2V0dGluZ3MiOnt9fQ==
 - Ensure it shows an empty state