### PR TITLE
Make pinned cards drag-and-droppable into the collections sidebar

### DIFF
--- a/frontend/src/metabase/collections/components/CollectionCardVisualization/CollectionCardVisualization.jsx
+++ b/frontend/src/metabase/collections/components/CollectionCardVisualization/CollectionCardVisualization.jsx
@@ -17,7 +17,7 @@ import { HoverMenu, VizCard } from "./CollectionCardVisualization.styled";
 const propTypes = {
   item: PropTypes.object.isRequired,
   collection: PropTypes.object.isRequired,
-  metadata: PropTypes.object.isRequired,
+  metadata: PropTypes.object,
   onCopy: PropTypes.func.isRequired,
   onMove: PropTypes.func.isRequired,
 };

--- a/frontend/src/metabase/collections/components/CollectionCardVisualization/CollectionCardVisualization.jsx
+++ b/frontend/src/metabase/collections/components/CollectionCardVisualization/CollectionCardVisualization.jsx
@@ -17,7 +17,7 @@ import { HoverMenu, VizCard } from "./CollectionCardVisualization.styled";
 const propTypes = {
   item: PropTypes.object.isRequired,
   collection: PropTypes.object.isRequired,
-  metadata: PropTypes.object,
+  metadata: PropTypes.object.isRequired,
   onCopy: PropTypes.func.isRequired,
   onMove: PropTypes.func.isRequired,
 };

--- a/frontend/src/metabase/collections/components/PinnedItemOverview/PinnedItemOverview.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemOverview/PinnedItemOverview.tsx
@@ -6,6 +6,7 @@ import Metadata from "metabase-lib/lib/metadata/Metadata";
 import PinnedItemCard from "metabase/collections/components/PinnedItemCard";
 import CollectionCardVisualization from "metabase/collections/components/CollectionCardVisualization";
 import { Item, Collection, isRootCollection } from "metabase/collections/utils";
+import ItemDragSource from "metabase/containers/dnd/ItemDragSource";
 
 import { Container, Grid, SectionHeader } from "./PinnedItemOverview.styled";
 
@@ -15,6 +16,7 @@ type Props = {
   metadata: Metadata;
   onCopy: (items: Item[]) => void;
   onMove: (items: Item[]) => void;
+  onDrop: any;
 };
 
 function PinnedItemOverview({
@@ -23,6 +25,7 @@ function PinnedItemOverview({
   metadata,
   onCopy,
   onMove,
+  onDrop,
 }: Props) {
   const sortedItems = _.sortBy(items, item => item.name);
   const {
@@ -36,27 +39,43 @@ function PinnedItemOverview({
       {cardItems.length > 0 && (
         <Grid>
           {cardItems.map(item => (
-            <CollectionCardVisualization
+            <ItemDragSource
               key={item.id}
               item={item}
               collection={collection}
-              metadata={metadata}
-              onCopy={onCopy}
-              onMove={onMove}
-            />
+              onDrop={onDrop}
+            >
+              <div>
+                <CollectionCardVisualization
+                  item={item}
+                  collection={collection}
+                  metadata={metadata}
+                  onCopy={onCopy}
+                  onMove={onMove}
+                />
+              </div>
+            </ItemDragSource>
           ))}
         </Grid>
       )}
       {dashboardItems.length > 0 && (
         <Grid>
           {dashboardItems.map(item => (
-            <PinnedItemCard
+            <ItemDragSource
               key={item.id}
               item={item}
               collection={collection}
-              onCopy={onCopy}
-              onMove={onMove}
-            />
+              onDrop={onDrop}
+            >
+              <div>
+                <PinnedItemCard
+                  item={item}
+                  collection={collection}
+                  onCopy={onCopy}
+                  onMove={onMove}
+                />
+              </div>
+            </ItemDragSource>
           ))}
         </Grid>
       )}
@@ -72,13 +91,21 @@ function PinnedItemOverview({
           </SectionHeader>
           <Grid>
             {dataModelItems.map(item => (
-              <PinnedItemCard
+              <ItemDragSource
                 key={item.id}
                 item={item}
                 collection={collection}
-                onCopy={onCopy}
-                onMove={onMove}
-              />
+                onDrop={onDrop}
+              >
+                <div>
+                  <PinnedItemCard
+                    item={item}
+                    collection={collection}
+                    onCopy={onCopy}
+                    onMove={onMove}
+                  />
+                </div>
+              </ItemDragSource>
             ))}
           </Grid>
         </div>

--- a/frontend/src/metabase/collections/components/PinnedItemOverview/PinnedItemOverview.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemOverview/PinnedItemOverview.tsx
@@ -16,7 +16,7 @@ type Props = {
   metadata: Metadata;
   onCopy: (items: Item[]) => void;
   onMove: (items: Item[]) => void;
-  onDrop: any;
+  onDrop: () => void;
 };
 
 function PinnedItemOverview({

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -157,6 +157,7 @@ function CollectionContent({
                 onMove={handleMove}
                 onCopy={handleCopy}
                 onToggleSelected={toggleItem}
+                onDrop={clear}
               />
               <Search.ListLoader
                 query={unpinnedQuery}
@@ -242,6 +243,7 @@ function CollectionContent({
             <ItemsDragLayer
               selectedItems={selected}
               pinnedItems={pinnedItems}
+              collection={collection}
             />
           </Box>
         );

--- a/frontend/src/metabase/containers/dnd/ItemDragSource.jsx
+++ b/frontend/src/metabase/containers/dnd/ItemDragSource.jsx
@@ -15,7 +15,9 @@ import { dragTypeForItem } from ".";
         return false;
       }
 
-      return isSelected || selected.length === 0;
+      const numSelected = selected?.length ?? 0;
+
+      return isSelected || numSelected === 0;
     },
     beginDrag(props, monitor, component) {
       return { item: props.item };

--- a/frontend/src/metabase/containers/dnd/ItemsDragLayer.jsx
+++ b/frontend/src/metabase/containers/dnd/ItemsDragLayer.jsx
@@ -6,7 +6,6 @@ import _ from "underscore";
 import BodyComponent from "metabase/components/BodyComponent";
 import BaseItemsTable from "metabase/collections/components/BaseItemsTable";
 import PinnedItemCard from "metabase/collections/components/PinnedItemCard";
-import CollectionCardVisualization from "metabase/collections/components/CollectionCardVisualization";
 
 // NOTE: our version of react-hot-loader doesn't play nice with react-dnd's DragLayer,
 // so we exclude files named `*DragLayer.jsx` in webpack.config.js
@@ -77,26 +76,11 @@ class DraggedItems extends React.Component {
 
   renderItem = ({ item, ...itemProps }) => {
     const isPinned = this.checkIsPinned(item);
-    const isCard = item.model === "card";
 
     const key = `${item.model}-${item.id}`;
     const PINNED_WIDTH = 400;
 
     if (isPinned) {
-      if (isCard) {
-        return (
-          <div style={{ width: PINNED_WIDTH }}>
-            <CollectionCardVisualization
-              key={key}
-              item={item}
-              collection={this.props.collection}
-              onCopy={_.noop}
-              onMove={_.noop}
-            />
-          </div>
-        );
-      }
-
       return (
         <div style={{ width: PINNED_WIDTH }}>
           <PinnedItemCard

--- a/frontend/src/metabase/containers/dnd/ItemsDragLayer.jsx
+++ b/frontend/src/metabase/containers/dnd/ItemsDragLayer.jsx
@@ -5,6 +5,8 @@ import _ from "underscore";
 
 import BodyComponent from "metabase/components/BodyComponent";
 import BaseItemsTable from "metabase/collections/components/BaseItemsTable";
+import PinnedItemCard from "metabase/collections/components/PinnedItemCard";
+import CollectionCardVisualization from "metabase/collections/components/CollectionCardVisualization";
 
 // NOTE: our version of react-hot-loader doesn't play nice with react-dnd's DragLayer,
 // so we exclude files named `*DragLayer.jsx` in webpack.config.js
@@ -25,6 +27,7 @@ export default class ItemsDragLayer extends React.Component {
       selectedItems,
       pinnedItems,
       item,
+      collection,
     } = this.props;
     if (!isDragging || !currentOffset) {
       return null;
@@ -40,12 +43,14 @@ export default class ItemsDragLayer extends React.Component {
           left: 0,
           transform: `translate(${x}px, ${y}px)`,
           pointerEvents: "none",
+          opacity: 0.65,
         }}
       >
         <DraggedItems
           items={items}
           draggedItem={item.item}
           pinnedItems={pinnedItems}
+          collection={collection}
         />
       </div>
     );
@@ -70,16 +75,51 @@ class DraggedItems extends React.Component {
     return index >= 0;
   };
 
-  renderItem = ({ item, ...itemProps }) => (
-    <BaseItemsTable.Item
-      key={`${item.model}-${item.id}`}
-      {...itemProps}
-      item={item}
-      isPinned={this.checkIsPinned(item)}
-      draggable={false}
-      hasBottomBorder={false}
-    />
-  );
+  renderItem = ({ item, ...itemProps }) => {
+    const isPinned = this.checkIsPinned(item);
+    const isCard = item.model === "card";
+
+    const key = `${item.model}-${item.id}`;
+    const PINNED_WIDTH = 400;
+
+    if (isPinned) {
+      if (isCard) {
+        return (
+          <div style={{ width: PINNED_WIDTH }}>
+            <CollectionCardVisualization
+              key={key}
+              item={item}
+              collection={this.props.collection}
+              onCopy={_.noop}
+              onMove={_.noop}
+            />
+          </div>
+        );
+      }
+
+      return (
+        <div style={{ width: PINNED_WIDTH }}>
+          <PinnedItemCard
+            key={key}
+            item={item}
+            collection={this.props.collection}
+            onCopy={_.noop}
+            onMove={_.noop}
+          />
+        </div>
+      );
+    }
+    return (
+      <BaseItemsTable.Item
+        key={key}
+        {...itemProps}
+        item={item}
+        isPinned={false}
+        draggable={false}
+        hasBottomBorder={false}
+      />
+    );
+  };
 
   render() {
     const { items, draggedItem } = this.props;


### PR DESCRIPTION
Related to #19758.

This PR makes it so that you can drag and drop pinned cards into new folders in the collections sidebar. Now that table rows (and now also cards) are opaque with a white background (previously, they were transparent, I think?), I've tweaked their opacity so that it is easier to see which option your mouse is on while you're drag-and-dropping. Also, drag-and-dropping card visualizations can be really unperformant, so I've made it so that when dragging, a question card appears instead.

https://user-images.githubusercontent.com/13057258/150463238-473a740c-f8f7-4a8c-aa21-3cf2ab973bce.mov


