### PR TITLE
Nbotelho/issue18808

### DIFF
--- a/frontend/src/metabase/entities/databases/forms.js
+++ b/frontend/src/metabase/entities/databases/forms.js
@@ -95,6 +95,9 @@ const DATABASE_DETAIL_OVERRIDES = {
   refingerprint: () => ({
     name: "refingerprint",
   }),
+  "auth-token": () => ({
+    name: "auth-token",
+  }),
 };
 
 function getEngineName(engine) {

--- a/frontend/src/metabase/entities/databases/forms.js
+++ b/frontend/src/metabase/entities/databases/forms.js
@@ -95,9 +95,6 @@ const DATABASE_DETAIL_OVERRIDES = {
   refingerprint: () => ({
     name: "refingerprint",
   }),
-  "auth-token": () => ({
-    name: "auth-token",
-  }),
 };
 
 function getEngineName(engine) {

--- a/modules/drivers/druid/resources/metabase-plugin.yaml
+++ b/modules/drivers/druid/resources/metabase-plugin.yaml
@@ -18,7 +18,7 @@ driver:
     - ssh-tunnel
     - advanced-options-start
     - default-advanced-options
-    - auth-token
+    - auth-basic-token
 
 init:
   - step: load-namespace

--- a/modules/drivers/druid/resources/metabase-plugin.yaml
+++ b/modules/drivers/druid/resources/metabase-plugin.yaml
@@ -18,6 +18,8 @@ driver:
     - ssh-tunnel
     - advanced-options-start
     - default-advanced-options
+    - auth-token
+
 init:
   - step: load-namespace
     namespace: metabase.driver.druid

--- a/modules/drivers/druid/src/metabase/driver/druid.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid.clj
@@ -15,7 +15,11 @@
   [_ details]
   {:pre [(map? details)]}
   (ssh/with-ssh-tunnel [details-with-tunnel details]
-    (= 200 (:status (http/get (client/details->url details-with-tunnel "/status"))))))
+    (let [auth-token (-> details :auth-token)]
+      (= 200 (:status (http/get (client/details->url details-with-tunnel "/status")
+                                (cond-> {}
+                                  auth-token (assoc "Authorization" (str "Basic " auth-token)))))))))
+
 
 (defmethod driver/describe-table :druid
   [_ database table]

--- a/modules/drivers/druid/src/metabase/driver/druid.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid.clj
@@ -15,11 +15,10 @@
   [_ details]
   {:pre [(map? details)]}
   (ssh/with-ssh-tunnel [details-with-tunnel details]
-    (let [auth-token (-> details :auth-token)]
+    (let [{:keys [auth-enabled auth-username auth-token]} details]
       (= 200 (:status (http/get (client/details->url details-with-tunnel "/status")
                                 (cond-> {}
-                                  auth-token (assoc "Authorization" (str "Basic " auth-token)))))))))
-
+                                  auth-enabled (assoc :basic-auth (str auth-username ":" auth-token)))))))))
 
 (defmethod driver/describe-table :druid
   [_ database table]

--- a/modules/drivers/druid/src/metabase/driver/druid/client.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid/client.clj
@@ -66,9 +66,9 @@
     (try
       (POST (details->url details-with-tunnel "/druid/v2"),
         :body           query
-        :auth-enabled  (details :auth-enabled)
-        :auth-token    (details :auth-token)
-        :auth-username (details :auth-username))
+        :auth-enabled  (:auth-enabled  details)
+        :auth-token    (:auth-token    details)
+        :auth-username (:auth-username details))
       ;; don't need to do anything fancy if the query was killed
       (catch InterruptedException e
         (throw e))
@@ -89,9 +89,9 @@
       (try
         (log/debug (trs "Canceling Druid query with ID {0}" query-id))
         (DELETE (details->url details-with-tunnel (format "/druid/v2/%s" query-id))
-          :auth-enabled  (details :auth-enabled)
-          :auth-token    (details :auth-token)
-          :auth-username (details :auth-username))
+          :auth-enabled  (:auth-enabled  details)
+          :auth-token    (:auth-token    details)
+          :auth-username (:auth-username details))
         (catch Exception cancel-e
           (log/warn cancel-e (trs "Failed to cancel Druid query with queryId {0}" query-id)))))))
 

--- a/modules/drivers/druid/src/metabase/driver/druid/client.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid/client.clj
@@ -63,7 +63,6 @@
   [details query]
   {:pre [(map? details) (map? query)]}
   (ssh/with-ssh-tunnel [details-with-tunnel details]
-                       (prn query)
     (try
       (POST (details->url details-with-tunnel "/druid/v2"),
         :body           query

--- a/modules/drivers/druid/src/metabase/driver/druid/sync.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid/sync.clj
@@ -50,6 +50,7 @@
   [database]
   {:pre [(map? (:details database))]}
   (ssh/with-ssh-tunnel [details-with-tunnel (:details database)]
-    (let [druid-datasources (client/GET (client/details->url details-with-tunnel "/druid/v2/datasources"))]
+    (let [druid-datasources (client/GET (client/details->url details-with-tunnel "/druid/v2/datasources")
+                                        :auth-token (-> database :details :auth-token))]
       {:tables (set (for [table-name druid-datasources]
                       {:schema nil, :name table-name}))})))

--- a/modules/drivers/druid/src/metabase/driver/druid/sync.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid/sync.clj
@@ -51,6 +51,8 @@
   {:pre [(map? (:details database))]}
   (ssh/with-ssh-tunnel [details-with-tunnel (:details database)]
     (let [druid-datasources (client/GET (client/details->url details-with-tunnel "/druid/v2/datasources")
-                                        :auth-token (-> database :details :auth-token))]
+                              :auth-enabled (-> database :details :auth-enabled)
+                              :auth-token (-> database :details :auth-token)
+                              :auth-username (-> database :details :auth-username))]
       {:tables (set (for [table-name druid-datasources]
                       {:schema nil, :name table-name}))})))

--- a/modules/drivers/druid/src/metabase/driver/druid/sync.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid/sync.clj
@@ -51,8 +51,8 @@
   {:pre [(map? (:details database))]}
   (ssh/with-ssh-tunnel [details-with-tunnel (:details database)]
     (let [druid-datasources (client/GET (client/details->url details-with-tunnel "/druid/v2/datasources")
-                              :auth-enabled (-> database :details :auth-enabled)
-                              :auth-token (-> database :details :auth-token)
+                              :auth-enabled  (-> database :details :auth-enabled)
+                              :auth-token    (-> database :details :auth-token)
                               :auth-username (-> database :details :auth-username))]
       {:tables (set (for [table-name druid-datasources]
                       {:schema nil, :name table-name}))})))

--- a/modules/drivers/druid/test/metabase/driver/druid/client_test.clj
+++ b/modules/drivers/druid/test/metabase/driver/druid/client_test.clj
@@ -57,3 +57,22 @@
               (or (when (instance? java.net.ConnectException e)
                     (throw e))
                   (some-> (.getCause e) recur)))))))))
+
+(defn- test-request [request-fn]
+  (try
+    (request-fn "http://localhost:8082/druid/v2"
+      :auth-token "12345678910")
+    (catch Exception e
+      (ex-data e))))
+
+(defn- get-auth-header [m]
+  (select-keys (:request-options m) ["Authorization"]))
+
+(deftest auth-token-methods
+  (let [get-request    (test-request druid.client/GET)
+        post-request   (test-request druid.client/POST)
+        delete-request (test-request druid.client/DELETE)]
+    (is (= {"Authorization" "Basic 12345678910"}
+          (get-auth-header get-request)
+          (get-auth-header post-request)
+          (get-auth-header delete-request)))))

--- a/modules/drivers/druid/test/metabase/driver/druid/client_test.clj
+++ b/modules/drivers/druid/test/metabase/driver/druid/client_test.clj
@@ -61,18 +61,20 @@
 (defn- test-request [request-fn]
   (try
     (request-fn "http://localhost:8082/druid/v2"
-      :auth-token "12345678910")
+      :auth-enabled true
+      :auth-username "nbotelho"
+      :auth-token    "12345678910")
     (catch Exception e
       (ex-data e))))
 
 (defn- get-auth-header [m]
-  (select-keys (:request-options m) ["Authorization"]))
+  (select-keys (:request-options m) [:basic-auth]))
 
 (deftest auth-token-methods
   (let [get-request    (test-request druid.client/GET)
         post-request   (test-request druid.client/POST)
         delete-request (test-request druid.client/DELETE)]
-    (is (= {"Authorization" "Basic 12345678910"}
+    (is (= {:basic-auth "nbotelho:12345678910"}
           (get-auth-header get-request)
           (get-auth-header post-request)
           (get-auth-header delete-request)))))

--- a/modules/drivers/druid/test/metabase/driver/druid/client_test.clj
+++ b/modules/drivers/druid/test/metabase/driver/druid/client_test.clj
@@ -86,6 +86,6 @@
         get-request    (test-request druid.client/GET no-auth-basic)
         post-request   (test-request druid.client/POST no-auth-basic)
         delete-request (test-request druid.client/DELETE no-auth-basic)]
-    (is (= (contains? (get-auth-header get-request) :basic-auth)
-          (contains? (get-auth-header post-request) :basic-auth)
-          (contains? (get-auth-header delete-request) :basic-auth)) "basic auth header not included")))
+    (is (= (contains? (get-auth-header get-request)    :basic-auth)
+           (contains? (get-auth-header post-request)   :basic-auth)
+           (contains? (get-auth-header delete-request) :basic-auth)) "basic auth header not included")))

--- a/modules/drivers/druid/test/metabase/driver/druid/client_test.clj
+++ b/modules/drivers/druid/test/metabase/driver/druid/client_test.clj
@@ -58,23 +58,34 @@
                     (throw e))
                   (some-> (.getCause e) recur)))))))))
 
-(defn- test-request [request-fn]
-  (try
-    (request-fn "http://localhost:8082/druid/v2"
-      :auth-enabled true
-      :auth-username "nbotelho"
-      :auth-token    "12345678910")
-    (catch Exception e
-      (ex-data e))))
+(defn- test-request
+  ([request-fn]
+   (test-request request-fn true))
+  ([request-fn basic-auth?]
+   (try
+     (request-fn "http://localhost:8082/druid/v2"
+       :auth-enabled basic-auth?
+       :auth-username "nbotelho"
+       :auth-token "12345678910")
+     (catch Exception e
+       (ex-data e)))))
 
 (defn- get-auth-header [m]
   (select-keys (:request-options m) [:basic-auth]))
 
-(deftest auth-token-methods
+(deftest basic-auth-test
   (let [get-request    (test-request druid.client/GET)
         post-request   (test-request druid.client/POST)
         delete-request (test-request druid.client/DELETE)]
     (is (= {:basic-auth "nbotelho:12345678910"}
           (get-auth-header get-request)
           (get-auth-header post-request)
-          (get-auth-header delete-request)))))
+          (get-auth-header delete-request)) "basic auth header included with successfully"))
+
+  (let [no-auth-basic false
+        get-request    (test-request druid.client/GET no-auth-basic)
+        post-request   (test-request druid.client/POST no-auth-basic)
+        delete-request (test-request druid.client/DELETE no-auth-basic)]
+    (is (= (contains? (get-auth-header get-request) :basic-auth)
+          (contains? (get-auth-header post-request) :basic-auth)
+          (contains? (get-auth-header delete-request) :basic-auth)) "basic auth header not included")))

--- a/src/metabase/driver/common.clj
+++ b/src/metabase/driver/common.clj
@@ -217,6 +217,18 @@
    :description  (deferred-tru "This enables Metabase to scan for additional field values during syncs allowing smarter behavior, like improved auto-binning on your bar charts.")
    :visible-if   {"advanced-options" true}})
 
+(def auth-token
+  "Map representing the authentication token option in a Druid DB connection."
+  [{:name         "auth-enabled"
+    :display-name (deferred-tru "Authentication header")
+    :type         :boolean
+    :default      false
+    :visible-if   {"advanced-options" true}}
+   {:name         "auth-token"
+    :display-name (deferred-tru "Authentication token")
+    :required     true
+    :visible-if   {"auth-enabled" true}}])
+
 (def default-advanced-options
   "Vector containing the three most common options present in the advanced option section of the DB connection form."
   [auto-run-queries let-user-control-scheduling metadata-sync-schedule cache-field-values-schedule refingerprint])
@@ -240,7 +252,8 @@
    :ssh-tunnel               ssh-tunnel-preferences
    :additional-options       additional-options
    :advanced-options-start   advanced-options-start
-   :default-advanced-options default-advanced-options})
+   :default-advanced-options default-advanced-options
+   :auth-token               auth-token})
 
 (def cloud-ip-address-info
   "Map of the `cloud-ip-address-info` info field. The getter is invoked and converted to a `:placeholder` value prior

--- a/src/metabase/driver/common.clj
+++ b/src/metabase/driver/common.clj
@@ -217,15 +217,21 @@
    :description  (deferred-tru "This enables Metabase to scan for additional field values during syncs allowing smarter behavior, like improved auto-binning on your bar charts.")
    :visible-if   {"advanced-options" true}})
 
-(def auth-token
+(def auth-basic-token
   "Map representing the authentication token option in a Druid DB connection."
   [{:name         "auth-enabled"
     :display-name (deferred-tru "Authentication header")
     :type         :boolean
     :default      false
     :visible-if   {"advanced-options" true}}
+   {:name         "auth-username"
+    :display-name (deferred-tru "Username")
+    :type         :string
+    :required     true
+    :visible-if   {"auth-enabled" true}}
    {:name         "auth-token"
     :display-name (deferred-tru "Authentication token")
+    :type         :string
     :required     true
     :visible-if   {"auth-enabled" true}}])
 
@@ -253,7 +259,7 @@
    :additional-options       additional-options
    :advanced-options-start   advanced-options-start
    :default-advanced-options default-advanced-options
-   :auth-token               auth-token})
+   :auth-basic-token         auth-basic-token})
 
 (def cloud-ip-address-info
   "Map of the `cloud-ip-address-info` info field. The getter is invoked and converted to a `:placeholder` value prior


### PR DESCRIPTION
### Objective 
This PR allows using of basic header authentication only in Druid Database connection, files modified are exclusive of Druid code except for the `src/metabase/driver/common.clj`. 

### Feature 
It's a simple adjustment, I added three fields in additional options UI and receive the values in Druid driver core to put in the basic header option of `clj-http`.

### Tests
- [X] My tests check if the basic header option is in clj-http request options or not.
- [X] Run the frontend and Cypress end-to-end tests with `yarn lint && yarn test`)
- [X] If there are changes to the backend codebase, run the backend tests with `Clojure -X:dev:test`
- [X] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
      (unless it's a tiny documentation change).
