### PR TITLE
Release script: no need for `git pull`

### DIFF
--- a/bin/release/src/release.clj
+++ b/bin/release/src/release.clj
@@ -5,7 +5,6 @@
             [metabuild-common.core :as u]
             [release
              [check-prereqs :as check-prereqs]
-             [checkout-latest :as checkout-latest]
              [common :as c]
              [docker :as docker]
              [draft-release :as draft-release]
@@ -22,7 +21,6 @@
 
 (def ^:private steps*
   (ordered-map/ordered-map
-   :checkout-latest                     checkout-latest/checkout-latest!
    :build-uberjar                       uberjar/build-uberjar!
    :build-docker                        docker/build-docker-image!
    :push-git-tags                       git-tags/push-tags!

--- a/bin/release/src/release/checkout_latest.clj
+++ b/bin/release/src/release/checkout_latest.clj
@@ -1,7 +1,0 @@
-(ns release.checkout-latest
-  (:require [metabuild-common.core :as u]
-            [release.common :as c]))
-
-(defn checkout-latest! []
-  (u/step (format "Checkout latest code for %s" (c/branch))
-    (u/sh {:dir u/project-root-directory} "git" "pull")))


### PR DESCRIPTION
The release script shouldn't update the checkout. Rationale:

1. Before running the release script, the release manager should already test ("kick the tires") the build associated with the commit they choose. If the release script update the checkout by doing `git pull`, the commit may change from what was tested earlier.

2. Between doing EE and OSS releases, the commit for the checkout should also remain the same. Otherwise we risk the inconsistency.