### PR TITLE
E2E tests: give some time for the popover to appear

### DIFF
--- a/frontend/test/__support__/e2e/helpers/e2e-ui-elements-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-ui-elements-helpers.js
@@ -1,6 +1,9 @@
 // various Metabase-specific "scoping" functions like inside popover/modal/navbar/main/sidebar content area
+export const POPOVER_ELEMENT = ".popover[data-state~='visible']";
+
 export function popover() {
-  return cy.get(".popover[data-state~='visible']");
+  cy.get(POPOVER_ELEMENT).should("be.visible");
+  return cy.get(POPOVER_ELEMENT);
 }
 
 export function modal() {

--- a/frontend/test/metabase/scenarios/native/reproductions/18418-saved-question-db-appears-in-db-picker.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/reproductions/18418-saved-question-db-appears-in-db-picker.cy.spec.js
@@ -1,4 +1,8 @@
-import { restore, popover, openNativeEditor } from "__support__/e2e/cypress";
+import {
+  restore,
+  POPOVER_ELEMENT,
+  openNativeEditor,
+} from "__support__/e2e/cypress";
 
 const questionDetails = {
   name: "REVIEWS SQL",
@@ -31,6 +35,6 @@ describe("issue 18418", () => {
     // Clicking native question's database picker usually opens a popover with a list of databases
     // As default Cypress environment has only the sample database available, we expect no popup to appear
     cy.findByTextEnsureVisible("Sample Database").click();
-    popover().should("not.exist");
+    cy.get(POPOVER_ELEMENT).should("not.exist");
   });
 });


### PR DESCRIPTION
As suggested by @nemanjaglumac, by asserting for visibility, Cypress should attempt to wait and retry.
Based on stress tests, this is proven effective reducing the flakiness on some questions-related tests.

How to verify:
```
yarn test-visual-open
```

and run numerous tests related to questions, e.g. under `frontend/test/metabase/scenarios/question`.