### PR TITLE
Ignore `cypress_sample_database.json`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,7 +72,7 @@ xcshareddata
 xcuserdata
 dev/src/dev/nocommit/
 *~
-**/cypress_sample_dataset.json
+**/cypress_sample_database.json
 /frontend/src/cljs
 .shadow-cljs
 


### PR DESCRIPTION
As part of this PR https://github.com/metabase/metabase/pull/19682, references of "sample dataset" were updated to the "sample database".

In the Cypress creation phase, we're generating a list of all tables, columns and their IDs.
https://github.com/metabase/metabase/blob/84429c3b8a95dd0f2dc213277756b5dbfde5eb23/frontend/test/snapshot-creators/default.cy.snap.js#L25

That file should always be in `.gitignore` (which wasn't updated).