### PR TITLE
Use GitHub Actions to run shared CLJS tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -832,15 +832,6 @@ jobs:
                   - /home/circleci/metabase/metabase/node_modules
                   - /home/circleci/.cache/Cypress
 
-  shared-tests-cljs:
-    executor: builder
-    steps:
-      - attach-workspace
-      - run-yarn-command:
-          command-name: Run Cljs tests for shared/ code
-          command: run test-cljs
-          skip-when-no-change: true
-
   # Unlike the other build-uberjar steps, this step should be run once overall and the results can be shared between
   # OSS and EE uberjars.
   build-uberjar-drivers:
@@ -1360,10 +1351,6 @@ workflows:
       - fe-deps:
           requires:
             - checkout
-
-      - shared-tests-cljs:
-          requires:
-            - fe-deps
 
       - fe-tests-cypress:
           matrix:

--- a/.github/workflows/cljs.yml
+++ b/.github/workflows/cljs.yml
@@ -1,0 +1,44 @@
+name: CLJS
+
+on:
+  push:
+    branches:
+      - '**'
+    paths:
+    - 'shared/src/'
+    - '**/package.json'
+    - '**/yarn.lock'
+    - '.github/workflows/**'
+  pull_request:
+
+jobs:
+
+  shared-tests-cljs:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@v2
+    - name: Prepare Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: 14.x
+    - name: Get M2 cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.m2
+          ~/.gitlibs
+        key: ${{ runner.os }}-cljs-${{ hashFiles('**/deps.edn') }}
+    - name: Get yarn cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/yarn
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+    - name: Get node_modules cache
+      uses: actions/cache@v2
+      with:
+        path: node_modules
+        key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
+    - run: yarn install --frozen-lockfile --prefer-offline
+    - name: Run Cljs tests for shared/ code
+      run: yarn run test-cljs


### PR DESCRIPTION
**Before this PR**

The tests for shared CLJS run on Circle CI.

**After this PR**

The tests run on GitHub Actions. Same spirit as PR #15507, #14701, #14050, etc: frees more Circle CI containers to run other priority tasks (e.g. Cypress tests).

![image](https://user-images.githubusercontent.com/7288/150620123-de8d4149-d2c1-4c13-8636-ea2d1d02f049.png)
