### PR TITLE
Add empty pinned items section banner & new empty state svg

### DIFF
--- a/frontend/src/metabase/collections/components/EmptyPinnedItemsBanner/EmptyPinnedItemsBanner.styled.tsx
+++ b/frontend/src/metabase/collections/components/EmptyPinnedItemsBanner/EmptyPinnedItemsBanner.styled.tsx
@@ -1,0 +1,19 @@
+import styled from "styled-components";
+
+import { color, lighten } from "metabase/lib/colors";
+import Banner from "metabase/components/Banner";
+import Icon from "metabase/components/Icon";
+
+export const EmptyBanner = styled(Banner)`
+  border: 1px solid ${color("brand")};
+  background-color: ${lighten("brand", 0.6)};
+  display: flex;
+  align-items: center;
+  color: ${color("text-dark")};
+  gap: 0.5rem;
+  padding: 1rem;
+`;
+
+export const ColoredIcon = styled(Icon)`
+  color: ${color("brand")};
+`;

--- a/frontend/src/metabase/collections/components/EmptyPinnedItemsBanner/EmptyPinnedItemsBanner.styled.tsx
+++ b/frontend/src/metabase/collections/components/EmptyPinnedItemsBanner/EmptyPinnedItemsBanner.styled.tsx
@@ -10,6 +10,7 @@ export const EmptyBanner = styled(Banner)`
   display: flex;
   align-items: center;
   color: ${color("text-dark")};
+  font-weight: bold;
   gap: 0.5rem;
   padding: 1rem;
 `;

--- a/frontend/src/metabase/collections/components/EmptyPinnedItemsBanner/EmptyPinnedItemsBanner.tsx
+++ b/frontend/src/metabase/collections/components/EmptyPinnedItemsBanner/EmptyPinnedItemsBanner.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { t } from "ttag";
+
+import { EmptyBanner, ColoredIcon } from "./EmptyPinnedItemsBanner.styled";
+
+function EmptyPinnedItemsBanner() {
+  return (
+    <EmptyBanner className={undefined}>
+      <ColoredIcon name="pin" />
+      {t`Save your questions, dashboads, and datasets in collections — and pin them to feature them at the top.`}
+    </EmptyBanner>
+  );
+}
+
+export default EmptyPinnedItemsBanner;

--- a/frontend/src/metabase/collections/components/PinnedItemOverview/PinnedItemOverview.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemOverview/PinnedItemOverview.tsx
@@ -5,6 +5,7 @@ import { t } from "ttag";
 import Metadata from "metabase-lib/lib/metadata/Metadata";
 import PinnedItemCard from "metabase/collections/components/PinnedItemCard";
 import CollectionCardVisualization from "metabase/collections/components/CollectionCardVisualization";
+import EmptyPinnedItemsBanner from "../EmptyPinnedItemsBanner/EmptyPinnedItemsBanner";
 import { Item, Collection, isRootCollection } from "metabase/collections/utils";
 import ItemDragSource from "metabase/containers/dnd/ItemDragSource";
 
@@ -34,7 +35,11 @@ function PinnedItemOverview({
     dataset: dataModelItems = [],
   } = _.groupBy(sortedItems, "model");
 
-  return items.length ? (
+  return items.length === 0 ? (
+    <Container>
+      <EmptyPinnedItemsBanner />
+    </Container>
+  ) : (
     <Container data-testid="pinned-items">
       {cardItems.length > 0 && (
         <Grid>
@@ -111,7 +116,7 @@ function PinnedItemOverview({
         </div>
       )}
     </Container>
-  ) : null;
+  );
 }
 
 export default PinnedItemOverview;

--- a/frontend/src/metabase/collections/components/PinnedItemOverview/PinnedItemOverview.unit.spec.js
+++ b/frontend/src/metabase/collections/components/PinnedItemOverview/PinnedItemOverview.unit.spec.js
@@ -45,8 +45,10 @@ function setup({ items, collection } = {}) {
 }
 
 describe("PinnedItemOverview", () => {
-  it("should render nothing if there are no items", () => {
+  it("should render an empty banner when there are no items", () => {
     const { container } = setup({ items: [] });
-    expect(container.firstChild).toBeNull();
+    expect(container.textContent).toContain(
+      "Save your questions, dashboads, and datasets in collections — and pin them to feature them at the top.",
+    );
   });
 });

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 import React, { useState, useCallback } from "react";
-import { Box } from "grid-styled";
+import { Flex, Box } from "grid-styled";
 import _ from "underscore";
 import { connect } from "react-redux";
 
@@ -187,9 +187,9 @@ function CollectionContent({
 
                   if (isEmpty) {
                     return (
-                      <Box mt="120px">
+                      <Flex justifyContent="center" mt="3rem">
                         <CollectionEmptyState />
-                      </Box>
+                      </Flex>
                     );
                   }
 

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -150,15 +150,17 @@ function CollectionContent({
                 )}
                 handleToggleMobileSidebar={handleToggleMobileSidebar}
               />
-              <PinnedItemOverview
-                items={pinnedItems}
-                collection={collection}
-                metadata={metadata}
-                onMove={handleMove}
-                onCopy={handleCopy}
-                onToggleSelected={toggleItem}
-                onDrop={clear}
-              />
+              {!loadingPinnedItems && (
+                <PinnedItemOverview
+                  items={pinnedItems}
+                  collection={collection}
+                  metadata={metadata}
+                  onMove={handleMove}
+                  onCopy={handleCopy}
+                  onToggleSelected={toggleItem}
+                  onDrop={clear}
+                />
+              )}
               <Search.ListLoader
                 query={unpinnedQuery}
                 loadingAndErrorWrapper={false}
@@ -185,7 +187,7 @@ function CollectionContent({
                   const isEmpty =
                     !loading && !hasPinnedItems && unpinnedItems.length === 0;
 
-                  if (isEmpty) {
+                  if (isEmpty && !loadingUnpinnedItems) {
                     return (
                       <Flex justifyContent="center" mt="3rem">
                         <CollectionEmptyState />

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -189,7 +189,11 @@ function CollectionContent({
 
                   if (isEmpty && !loadingUnpinnedItems) {
                     return (
-                      <Flex justifyContent="center" mt="3rem">
+                      <Flex
+                        alignItems="start"
+                        justifyContent="center"
+                        mt="3rem"
+                      >
                         <CollectionEmptyState />
                       </Flex>
                     );

--- a/frontend/src/metabase/components/Banner/Banner.jsx
+++ b/frontend/src/metabase/components/Banner/Banner.jsx
@@ -3,11 +3,12 @@ import PropTypes from "prop-types";
 import { BannerRoot } from "metabase/components/Banner/Banner.styled";
 
 const propTypes = {
+  className: PropTypes.string,
   children: PropTypes.node,
 };
 
-const Banner = ({ children }) => {
-  return <BannerRoot>{children}</BannerRoot>;
+const Banner = ({ className, children }) => {
+  return <BannerRoot className={className}>{children}</BannerRoot>;
 };
 
 Banner.propTypes = propTypes;

--- a/frontend/src/metabase/components/CollectionEmptyState.jsx
+++ b/frontend/src/metabase/components/CollectionEmptyState.jsx
@@ -1,65 +1,273 @@
-/* eslint-disable react/prop-types */
 import React from "react";
-import { t } from "ttag";
-import { withRouter } from "react-router";
-import { Box, Flex } from "grid-styled";
 
-import { color } from "metabase/lib/colors";
-import * as Urls from "metabase/lib/urls";
-
-import Icon from "metabase/components/Icon";
-import EmptyState from "metabase/components/EmptyState";
-import IconWrapper from "metabase/components/IconWrapper";
-import Link from "metabase/components/Link";
-
-const Element = ({
-  iconName,
-  iconBackgroundColor = color("brand-light"),
-  textWidth,
-}) => (
-  <Flex
-    className="bg-white rounded"
-    align="center"
-    p={2}
-    mb={1}
-    style={{ width: 300, boxShadow: `0 1px 4px 1px rgba(0, 0, 0, 0.08)` }}
-  >
-    <IconWrapper borderRadius={"99px"} bg={iconBackgroundColor} p={1} mr={1}>
-      <Icon name={iconName} color="white" />
-    </IconWrapper>
-    <Box
-      style={{
-        width: textWidth,
-        height: 8,
-        borderRadius: 99,
-        backgroundColor: color("brand-light"),
-      }}
-    />
-  </Flex>
-);
-
-const CollectionEmptyState = ({ params }) => {
+function CollectionEmptyState() {
   return (
-    <EmptyState
-      title={t`Nothing to see yet.`}
-      message={t`Use collections to organize and group dashboards and questions for your team or yourself`}
-      className="text-medium"
-      illustrationElement={
-        <Box>
-          <Element iconName="dashboard" textWidth={110} />
-          <Element iconName="line" textWidth={48} />
-          <Element iconName="folder" textWidth={72} />
-        </Box>
-      }
-      link={
-        <Link
-          className="link text-bold"
-          mt={2}
-          to={Urls.newCollection(params.collectionId)}
-        >{t`Create another collection`}</Link>
-      }
-    />
+    <svg
+      width="944"
+      height="672"
+      viewBox="0 0 944 672"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <rect
+        opacity="0.7"
+        x="0.5"
+        y="0.5"
+        width="463"
+        height="215"
+        rx="7.5"
+        fill="white"
+        stroke="#F0F0F0"
+      />
+      <rect
+        width="42"
+        height="200"
+        transform="matrix(-1 0 0 1 428 16)"
+        fill="#EDF2F5"
+        fillOpacity="0.5"
+      />
+      <rect
+        width="42"
+        height="177"
+        transform="matrix(-1 0 0 1 378 39)"
+        fill="#EDF2F5"
+        fillOpacity="0.5"
+      />
+      <rect
+        width="42"
+        height="127.941"
+        transform="matrix(-1 0 0 1 328 88.0588)"
+        fill="#EDF2F5"
+        fillOpacity="0.5"
+      />
+      <rect
+        width="42"
+        height="83.8235"
+        transform="matrix(-1 0 0 1 278 132.176)"
+        fill="#EDF2F5"
+        fillOpacity="0.5"
+      />
+      <rect
+        width="42"
+        height="41.1765"
+        transform="matrix(-1 0 0 1 228 174.824)"
+        fill="#EDF2F5"
+        fillOpacity="0.5"
+      />
+      <rect
+        width="42"
+        height="147.059"
+        transform="matrix(-1 0 0 1 178 68.9412)"
+        fill="#EDF2F5"
+        fillOpacity="0.5"
+      />
+      <rect
+        width="42"
+        height="110"
+        transform="matrix(-1 0 0 1 128 106)"
+        fill="#EDF2F5"
+        fillOpacity="0.5"
+      />
+      <rect
+        width="42"
+        height="84"
+        transform="matrix(-1 0 0 1 78 132)"
+        fill="#EDF2F5"
+        fillOpacity="0.5"
+      />
+      <rect
+        opacity="0.7"
+        x="483.049"
+        y="0.5"
+        width="460.451"
+        height="215"
+        rx="7.5"
+        fill="white"
+        stroke="#F0F0F0"
+      />
+      <path
+        opacity="0.5"
+        d="M550.992 198.14L515.496 184.744L480 192.48V208C480 212.418 483.582 216 488 216H933.451C937.869 216 941.451 212.418 941.451 208V24L905.954 35.1628L870.458 59.7209L834.962 44.093L799.466 77.5814L763.97 59.7209L728.473 86.5116L692.977 104.372L657.481 77.5814L621.985 176.93L586.489 150.14L550.992 198.14Z"
+        fill="#EDF2F5"
+      />
+      <path
+        d="M481.275 193.44L515.496 184.744L550.992 198.14L586.488 150.14L621.985 176.93L657.481 77.5814L692.977 104.372L728.473 86.5116L763.969 59.7209L799.466 77.5814L834.962 44.093L870.458 59.7209L905.954 35.1628L941.45 24"
+        stroke="#EDF2F5"
+        strokeWidth="2"
+      />
+      <rect
+        opacity="0.7"
+        x="0.5"
+        y="232.5"
+        width="463"
+        height="127"
+        rx="7.5"
+        fill="white"
+        stroke="#F0F0F0"
+      />
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M216 281.714C216 279.505 217.791 277.714 220 277.714H244H245C246.657 277.714 248 279.057 248 280.714V281.714V285.714V305.714C248 307.923 246.209 309.714 244 309.714H220C218.136 309.714 216.57 308.44 216.126 306.714H216V305.714V285.714V281.714ZM244 285.714V305.714H220V285.714H244ZM233.455 296.623H223.273V300.987H233.455V296.623ZM223.273 289.805H240.727V294.169H223.273V289.805ZM240.727 296.623H236.364V300.987H240.727V296.623Z"
+        fill="#EDF2F5"
+      />
+      <rect
+        opacity="0.7"
+        x="480.5"
+        y="232.5"
+        width="463"
+        height="127"
+        rx="7.5"
+        fill="white"
+        stroke="#F0F0F0"
+      />
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M696 281.714C696 279.505 697.791 277.714 700 277.714H724H725C726.657 277.714 728 279.057 728 280.714V281.714V285.714V305.714C728 307.923 726.209 309.714 724 309.714H700C698.136 309.714 696.57 308.44 696.126 306.714H696V305.714V285.714V281.714ZM724 285.714V305.714H700V285.714H724ZM713.455 296.623H703.273V300.987H713.455V296.623ZM703.273 289.805H720.727V294.169H703.273V289.805ZM720.727 296.623H716.364V300.987H720.727V296.623Z"
+        fill="#EDF2F5"
+      />
+      <rect y="440" width="258.683" height="8" rx="4" fill="#EDF2F5" />
+      <rect
+        x="630.708"
+        y="440"
+        width="113.898"
+        height="8"
+        rx="4"
+        fill="#EDF2F5"
+      />
+      <rect
+        x="830.102"
+        y="440"
+        width="103.28"
+        height="8"
+        rx="4"
+        fill="#EDF2F5"
+      />
+      <rect y="472" width="402.503" height="8" rx="4" fill="#EDF2F5" />
+      <rect
+        x="630.708"
+        y="472"
+        width="99.4192"
+        height="8"
+        rx="4"
+        fill="#EDF2F5"
+      />
+      <rect
+        x="830.102"
+        y="472"
+        width="113.898"
+        height="8"
+        rx="4"
+        fill="#EDF2F5"
+      />
+      <rect y="504" width="207.526" height="8" rx="4" fill="#EDF2F5" />
+      <rect
+        x="630.708"
+        y="504"
+        width="130.307"
+        height="8"
+        rx="4"
+        fill="#EDF2F5"
+      />
+      <rect
+        x="830.102"
+        y="504"
+        width="89.7669"
+        height="8"
+        rx="4"
+        fill="#EDF2F5"
+      />
+      <rect y="536" width="354.241" height="8" rx="4" fill="#EDF2F5" />
+      <rect
+        x="630.708"
+        y="536"
+        width="113.898"
+        height="8"
+        rx="4"
+        fill="#EDF2F5"
+      />
+      <rect
+        x="830.102"
+        y="536"
+        width="103.28"
+        height="8"
+        rx="4"
+        fill="#EDF2F5"
+      />
+      <rect y="568" width="370.65" height="8" rx="4" fill="#EDF2F5" />
+      <rect
+        x="630.708"
+        y="568"
+        width="106.176"
+        height="8"
+        rx="4"
+        fill="#EDF2F5"
+      />
+      <rect
+        x="830.102"
+        y="568"
+        width="89.7669"
+        height="8"
+        rx="4"
+        fill="#EDF2F5"
+      />
+      <rect y="600" width="233.587" height="8" rx="4" fill="#EDF2F5" />
+      <rect
+        x="630.708"
+        y="600"
+        width="138.029"
+        height="8"
+        rx="4"
+        fill="#EDF2F5"
+      />
+      <rect
+        x="830.102"
+        y="600"
+        width="103.28"
+        height="8"
+        rx="4"
+        fill="#EDF2F5"
+      />
+      <rect y="632" width="284.744" height="8" rx="4" fill="#EDF2F5" />
+      <rect
+        x="630.708"
+        y="632"
+        width="106.176"
+        height="8"
+        rx="4"
+        fill="#EDF2F5"
+      />
+      <rect
+        x="830.102"
+        y="632"
+        width="103.28"
+        height="8"
+        rx="4"
+        fill="#EDF2F5"
+      />
+      <rect y="664" width="258.683" height="8" rx="4" fill="#EDF2F5" />
+      <rect
+        x="630.708"
+        y="664"
+        width="113.898"
+        height="8"
+        rx="4"
+        fill="#EDF2F5"
+      />
+      <rect
+        x="830.102"
+        y="664"
+        width="113.898"
+        height="8"
+        rx="4"
+        fill="#EDF2F5"
+      />
+      <rect y="408" width="50.1239" height="8" rx="4" fill="#EDF2F5" />
+      <rect x="631" y="408" width="73.515" height="8" rx="4" fill="#EDF2F5" />
+      <rect x="830" y="408" width="60.9841" height="8" rx="4" fill="#EDF2F5" />
+    </svg>
   );
-};
+}
 
-export default withRouter(CollectionEmptyState);
+export default CollectionEmptyState;

--- a/frontend/src/metabase/components/CollectionEmptyState.jsx
+++ b/frontend/src/metabase/components/CollectionEmptyState.jsx
@@ -4,8 +4,6 @@ function CollectionEmptyState() {
   return (
     <svg
       data-testid="collection-empty-state"
-      width="944"
-      height="672"
       viewBox="0 0 944 672"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/frontend/src/metabase/components/CollectionEmptyState.jsx
+++ b/frontend/src/metabase/components/CollectionEmptyState.jsx
@@ -3,6 +3,7 @@ import React from "react";
 function CollectionEmptyState() {
   return (
     <svg
+      data-testid="collection-empty-state"
       width="944"
       height="672"
       viewBox="0 0 944 672"

--- a/frontend/src/metabase/components/CollectionEmptyState.jsx
+++ b/frontend/src/metabase/components/CollectionEmptyState.jsx
@@ -3,6 +3,7 @@ import React from "react";
 function CollectionEmptyState() {
   return (
     <svg
+      style={{ maxWidth: 1120 }}
       data-testid="collection-empty-state"
       viewBox="0 0 944 672"
       fill="none"

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -254,7 +254,7 @@ describe("scenarios > collection_defaults", () => {
       it("should not render collections in items list if user doesn't have collection access (metabase#16555)", () => {
         cy.visit("/collection/root");
         // Since this user doesn't have access rights to the root collection, it should render empty
-        cy.findByText("Nothing to see yet.");
+        cy.findByTestId("collection-empty-state");
       });
 
       it("should see a child collection in a sidebar even with revoked access to its parent (metabase#14114)", () => {


### PR DESCRIPTION
Related to #19758.

Adds banner + new empty state svg when there are no collection items. Not making the banner removable yet since there's no BE support for it.

<img width="1160" alt="Screen Shot 2022-01-22 at 1 56 05 PM" src="https://user-images.githubusercontent.com/13057258/150656704-744d9284-a1cd-48e3-900c-00e50511913e.png">
<img width="1144" alt="Screen Shot 2022-01-22 at 1 56 11 PM" src="https://user-images.githubusercontent.com/13057258/150656705-7d64cf3a-c993-449a-9943-2694b1f7459b.png">

