### PR TITLE
Mask page urls we track with Snowplow

### DIFF
--- a/frontend/src/metabase/lib/analytics.js
+++ b/frontend/src/metabase/lib/analytics.js
@@ -115,10 +115,10 @@ const createSnowplowPlugin = store => {
 };
 
 const trackSnowplowPageView = url => {
-  const baseUrl = Settings.snowplowUrl();
+  const maskedUrl = new URL(url, Settings.snowplowUrl());
 
   Snowplow.setReferrerUrl("#");
-  Snowplow.setCustomUrl(`${baseUrl}${url}`);
+  Snowplow.setCustomUrl(maskedUrl.href);
   Snowplow.trackPageView();
 };
 

--- a/frontend/src/metabase/lib/analytics.js
+++ b/frontend/src/metabase/lib/analytics.js
@@ -115,8 +115,10 @@ const createSnowplowPlugin = store => {
 };
 
 const trackSnowplowPageView = url => {
+  const baseUrl = Settings.snowplowUrl();
+
   Snowplow.setReferrerUrl("#");
-  Snowplow.setCustomUrl(`https://sp.metabase.com${url}`);
+  Snowplow.setCustomUrl(`${baseUrl}${url}`);
   Snowplow.trackPageView();
 };
 

--- a/frontend/src/metabase/lib/analytics.js
+++ b/frontend/src/metabase/lib/analytics.js
@@ -116,7 +116,7 @@ const createSnowplowPlugin = store => {
 
 const trackSnowplowPageView = url => {
   Snowplow.setReferrerUrl("#");
-  Snowplow.setCustomUrl(url);
+  Snowplow.setCustomUrl(`https://sp.metabase.com${url}`);
   Snowplow.trackPageView();
 };
 


### PR DESCRIPTION
Currently we track full page URLs with Snowplow. The library we use for tracking does not allow us to track relative URLs, we we mask the URLs by replacing the hostname with the hostname of the tracker itself.