### PR TITLE
Fix semantic type picker in model metadata editor

### DIFF
--- a/frontend/src/metabase/core/components/SelectButton/index.ts
+++ b/frontend/src/metabase/core/components/SelectButton/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./SelectButton";
+export { SelectButtonRoot } from "./SelectButton.styled";

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.styled.jsx
@@ -1,5 +1,6 @@
 import styled, { css, keyframes } from "styled-components";
 import Radio from "metabase/core/components/Radio";
+import { SelectButtonRoot } from "metabase/core/components/SelectButton";
 import { color } from "metabase/lib/colors";
 
 const slideInOutAnimation = keyframes`
@@ -27,13 +28,13 @@ const FormContainer = styled.div`
     color: ${color("text-dark")};
   }
 
-  .AdminSelect {
+  ${SelectButtonRoot} {
     color: ${color("text-dark")};
     transition: border 0.3s;
     outline: none;
   }
 
-  .AdminSelect:focus {
+  ${SelectButtonRoot}:focus {
     border-color: ${color("brand")};
   }
 `;

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/SemanticTypePicker/SemanticTypePicker.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/SemanticTypePicker/SemanticTypePicker.jsx
@@ -37,9 +37,12 @@ function SemanticTypePicker({
   }, []);
 
   const onSelectValue = useCallback(
-    value => {
-      field.onChange(value);
-      onChange(value);
+    e => {
+      if (e.target.value === field.value) {
+        return;
+      }
+      field.onChange(e);
+      onChange(e);
       selectButtonRef.current?.focus();
     },
     [field, onChange],

--- a/frontend/test/metabase/scenarios/models/helpers/e2e-models-metadata-helpers.js
+++ b/frontend/test/metabase/scenarios/models/helpers/e2e-models-metadata-helpers.js
@@ -22,7 +22,7 @@ export function setColumnType(oldType, newType) {
 export function mapColumnTo({ table, column } = {}) {
   cy.findByText("Database column this maps to")
     .closest(".Form-field")
-    .find(".AdminSelect")
+    .findByTestId("select-button")
     .click();
 
   popover()


### PR DESCRIPTION
Fixes #19872: the semantic type picker in the model metadata editor turns into an unexpected state when you selected an already selected option.

### To Verify

1. Create a native model and open the metadata editor
2. For any column select the "Special type"
3. Click the "Special type" picker again and click the _same_ option
4. The picker should close and the type should be displayed instead of "None"

### Demo

**Before**

![CleanShot 2022-01-24 at 16 41 46](https://user-images.githubusercontent.com/17258145/150804252-04babc8e-b1ca-4284-a635-c8ab763611c1.gif)

**After**

![after](https://user-images.githubusercontent.com/17258145/150804275-fe86782d-291b-4633-9839-782bb55d7adf.gif)

