### PR TITLE
Fix metadata table overflow

### DIFF
--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.styled.jsx
@@ -90,6 +90,7 @@ export const MainContainer = styled.div`
   display: flex;
   flex: 1 0 auto;
   flex-direction: column;
+  flex-basis: 0;
   position: relative;
 `;
 


### PR DESCRIPTION
Fixes #19880: when opening the metadata editor for a model with many fields having long names, the results table horizontal overflow isn't handled properly

### To Verify

1. Create a GUI query following the example:

<details>
<summary>Example</summary>

<img width="989" alt="CleanShot 2022-01-24 at 19 03 52@2x" src="https://user-images.githubusercontent.com/17258145/150830717-9ed2660f-a1c2-4540-bb87-bd78c247d0ee.png">

</details>

2. Open the metadata editor
3. The table should fit into the screen and I should be able to just scroll it to see other columns

**Demo**

**Before**

https://user-images.githubusercontent.com/17258145/150830880-f3f3d88a-5dc2-4be2-994b-6c1338f04051.mov

**After**

https://user-images.githubusercontent.com/17258145/150831129-a32efbb3-6460-45ec-b8b3-ffb7d92cae2c.mov


