### PR TITLE
Handle failing model queries

### DIFF
--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
@@ -430,7 +430,7 @@ function DatasetEditor(props) {
               />
             </DebouncedFrame>
             <TabHintToastContainer
-              isVisible={isEditingMetadata && isTabHintVisible}
+              isVisible={isEditingMetadata && isTabHintVisible && !result.error}
             >
               <TabHintToast onClose={hideTabHint} />
             </TabHintToastContainer>

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
@@ -78,6 +78,7 @@ function getSidebar(
   props,
   {
     datasetEditorTab,
+    isQueryError,
     focusedField,
     focusedFieldIndex,
     focusFirstField,
@@ -95,6 +96,9 @@ function getSidebar(
   } = props;
 
   if (datasetEditorTab === "metadata") {
+    if (isQueryError) {
+      return null;
+    }
     if (!focusedField) {
       // Returning a div, so the sidebar is visible while the data is loading.
       // The field metadata sidebar will appear with an animation once a query completes
@@ -361,6 +365,7 @@ function DatasetEditor(props) {
 
   const sidebar = getSidebar(props, {
     datasetEditorTab,
+    isQueryError: result?.error,
     focusedField,
     focusedFieldIndex,
     focusFirstField,

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
@@ -231,7 +231,7 @@ function DatasetEditor(props) {
     // Focused field has to be set once the query is completed and the result is rendered
     // Visualization render can remove the focus
     const hasQueryResults = !!result;
-    if (!focusedFieldRef && hasQueryResults) {
+    if (!focusedFieldRef && hasQueryResults && !result.error) {
       focusFirstField();
     }
   }, [result, focusedFieldRef, focusFirstField]);

--- a/frontend/test/metabase/scenarios/models/models-query-editor.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models-query-editor.cy.spec.js
@@ -143,4 +143,42 @@ describe("scenarios > models query editor", () => {
     cy.url().should("match", /\/model\/[1-9]\d*.*\d/);
     cy.url().should("not.include", "/query");
   });
+
+  it("handles failing queries", () => {
+    cy.createNativeQuestion(
+      {
+        name: "Erroring Model",
+        dataset: true,
+        native: {
+          query: "S",
+        },
+      },
+      { visitQuestion: true },
+    );
+
+    openDetailsSidebar();
+    cy.findByText("Edit query definition").click();
+
+    cy.findByText(/Syntax error in SQL/);
+    cy.findByText("Metadata").click();
+    cy.findByText(/Syntax error in SQL/);
+    cy.findByText("Query").click();
+
+    cy.get(".ace_content").type("{backspace}SELECT * FROM ORDERS");
+    runNativeQuery();
+    cy.get(".TableInteractive").within(() => {
+      cy.findByText("TAX");
+      cy.findByText("TOTAL");
+    });
+    cy.findByText(/Syntax error in SQL/).should("not.exist");
+
+    cy.button("Save changes").click();
+    cy.wait("@updateCard");
+
+    cy.get(".TableInteractive").within(() => {
+      cy.findByText("TAX");
+      cy.findByText("TOTAL");
+    });
+    cy.findByText(/Syntax error in SQL/).should("not.exist");
+  });
 });


### PR DESCRIPTION
Fixes both model query and metadata editors crash if you try to open them for a model with a failing query.

### To Verify

1. Create a model from a question with a failing query (e.g. `select * from TABLEDOESNOTEXIST`)
2. Try to open both query and metadata editors
3. Ensure they don't crash
4. Try to repair the query and save the changes, it should work fine

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/150841920-4cc7e4d6-4672-4e42-a591-12ba56e00fcb.mov

**After**

https://user-images.githubusercontent.com/17258145/150841434-e7ebffbe-3aca-4ca7-91fa-f6f5f1306756.mov

