### PR TITLE
fix cut-off info popover text in Safari

### DIFF
--- a/frontend/src/metabase/components/MetadataInfo/FieldFingerprintInfo/CategoryFingerprint.jsx
+++ b/frontend/src/metabase/components/MetadataInfo/FieldFingerprintInfo/CategoryFingerprint.jsx
@@ -95,7 +95,7 @@ export function CategoryFingerprint({
         </RelativeContainer>
       )}
       {showFieldValuesBlock && (
-        <RelativeContainer height={isLoading && "1.8em"}>
+        <RelativeContainer height={isLoading ? "1.8em" : "1.5em"}>
           <Fade visible={isLoading}>
             <LoadingSpinner />
           </Fade>

--- a/frontend/src/metabase/components/MetadataInfo/FieldFingerprintInfo/CategoryFingerprint.styled.jsx
+++ b/frontend/src/metabase/components/MetadataInfo/FieldFingerprintInfo/CategoryFingerprint.styled.jsx
@@ -22,6 +22,7 @@ export const NoWrap = styled.div`
   overflow: hidden;
   font-weight: bold;
   padding-top: 0.3em 0;
+  line-height: 1.1em;
 `;
 
 export const LoadingSpinner = styled(_LoadingSpinner).attrs({

--- a/frontend/src/metabase/components/MetadataInfo/FieldFingerprintInfo/CategoryFingerprint.styled.jsx
+++ b/frontend/src/metabase/components/MetadataInfo/FieldFingerprintInfo/CategoryFingerprint.styled.jsx
@@ -22,7 +22,7 @@ export const NoWrap = styled.div`
   overflow: hidden;
   font-weight: bold;
   padding-top: 0.3em 0;
-  line-height: 1.1em;
+  line-height: 1.3em;
 `;
 
 export const LoadingSpinner = styled(_LoadingSpinner).attrs({


### PR DESCRIPTION
Just needs a bit of added line-height, I think.

<img width="389" alt="Screen Shot 2022-01-24 at 11 15 30 AM" src="https://user-images.githubusercontent.com/13057258/150850117-51a3dcb7-dff8-4e71-9775-7945febd8685.png">
