### PR TITLE
Metadata lifecycle improvements master

### DIFF
--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -199,7 +199,8 @@
       ;; normalized
       (and valid-metadata? dataset?)
       (a/go (let [fresh (a/<! (qp.async/result-metadata-for-query-async query))]
-              (qputil/combine-metadata fresh (mbql.normalize/normalize metadata))))
+              (qputil/combine-metadata fresh (map #(update-in % [:field_ref 0] keyword)
+                                                  metadata))))
       :else
       ;; compute fresh
       (qp.async/result-metadata-for-query-async query))))

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -195,10 +195,11 @@
       (a/to-chan! [metadata])
 
       ;; valid metadata was passed in, its a dataset, so get metadata and then blend in to preserve possible edits in
-      ;; existing metadata
+      ;; existing metadata. But metadata over API will have field_refs of ["field" "SUBTOTAL" nil] and we need that
+      ;; normalized
       (and valid-metadata? dataset?)
       (a/go (let [fresh (a/<! (qp.async/result-metadata-for-query-async query))]
-              (qputil/combine-metadata fresh metadata)))
+              (qputil/combine-metadata fresh (mbql.normalize/normalize metadata))))
       :else
       ;; compute fresh
       (qp.async/result-metadata-for-query-async query))))

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -174,24 +174,27 @@
 
 ;;; -------------------------------------------------- Saving Cards --------------------------------------------------
 
-;; When a new Card is saved, we wouldn't normally have the results metadata for it until the first time its query is
-;; ran.  As a workaround, we'll calculate this metadata and return it with all query responses, and then let the
-;; frontend pass it back to us when saving or updating a Card.  As a basic step to make sure the Metadata is valid
-;; we'll also pass a simple checksum and have the frontend pass it back to us.  See the QP `results-metadata`
-;; middleware namespace for more details
-
 (s/defn ^:private result-metadata-async :- ManyToManyChannel
-  "Get the right results metadata for this `card`, and return them in a channel. We'll check to see whether the
-  `metadata` passed in seems valid,and, if so, return a channel that returns the value as-is; otherwise, we'll run the
-  query ourselves to get the right values, and return a channel where you can listen for the results."
-  [query metadata]
-  (let [valid-metadata? (s/validate qr/ResultsMetadata metadata)]
-    (log/info
-     (if valid-metadata?
-       (trs "Card results metadata passed in to API is VALID. Thanks!")
-       (trs "Card results metadata passed in to API is MISSING. Running query to fetch correct metadata.")))
-    (if valid-metadata?
+  "Return a channel of metadata for the passed in `query`. Takes the `original-query` so it can determine if existing
+  `metadata` might still be valid. Takes `dataset?` since existing metadata might need to be \"blended\" into the
+  fresh metadata to preserve metadata edits from the dataset.
+
+  Note this condition is possible for new cards and edits to cards. New cards can be created from existing cards by
+  copying, and they could be datasets, have edited metadata that needs to be blended into a fresh run."
+  [original-query query metadata dataset?]
+  (let [valid-metadata? (and metadata (nil? (s/check qr/ResultsMetadata metadata)))]
+    (cond
+      ;; query didn't change, preserve existing metadata
+      (and (= original-query query) valid-metadata?)
       (a/to-chan! [metadata])
+
+      ;; valid metadata was passed in, its a dataset, so get metadata and then blend in to preserve possible edits in
+      ;; existing metadata
+      (and valid-metadata? dataset?)
+      (a/go (let [fresh (a/<! (qp.async/result-metadata-for-query-async query))]
+              (u/combine-metadata fresh metadata)))
+      :else
+      ;; compute fresh
       (qp.async/result-metadata-for-query-async query))))
 
 (defn check-data-permissions-for-query
@@ -239,7 +242,7 @@
 (defn- create-card-async!
   "Create a new Card asynchronously. Returns a channel for fetching the newly created Card, or an Exception if one was
   thrown. Closing this channel before it finishes will cancel the Card creation."
-  [{:keys [dataset_query result_metadata], :as card-data}]
+  [{:keys [dataset_query result_metadata dataset], :as card-data}]
   ;; `zipmap` instead of `select-keys` because we want to get `nil` values for keys that aren't present. Required by
   ;; `api/maybe-reconcile-collection-position!`
   (let [data-keys            [:dataset_query :description :display :name
@@ -247,7 +250,7 @@
         card-data            (assoc (zipmap data-keys (map card-data data-keys))
                                     :creator_id api/*current-user-id*
                                     :dataset (boolean (:dataset card-data)))
-        result-metadata-chan (result-metadata-async dataset_query result_metadata)
+        result-metadata-chan (result-metadata-async nil dataset_query result_metadata dataset)
         out-chan             (a/promise-chan)]
     (a/go
       (try
@@ -299,20 +302,6 @@
             (api/column-will-change? :embedding_params card-before-updates card-updates))
     (api/check-embedding-enabled)
     (api/check-superuser)))
-
-(defn- result-metadata-for-updating-async
-  "If `card`'s query is being updated, return the value that should be saved for `result_metadata`. This *should* be
-  passed in to the API; if so, verifiy that it was correct (the checksum is valid); if not, go fetch it. If the query
-  has not changed, this returns a closed channel (so you will get `nil` when you attempt to fetch the result, and
-  will know not to update the value in the DB.)
-
-  Either way, results are returned asynchronously on a channel."
-  [card query metadata]
-  (if (and query
-           (not= query (:dataset_query card)))
-    (result-metadata-async query metadata)
-    (doto (a/chan)
-      (a/onto-chan! (when (seq metadata) [metadata])))))
 
 (defn- publish-card-update!
   "Publish an event appropriate for the update(s) done to this CARD (`:card-update`, or archiving/unarchiving
@@ -515,10 +504,10 @@
     (check-allowed-to-modify-query                 card-before-update card-updates)
     (check-allowed-to-change-embedding             card-before-update card-updates)
     ;; make sure we have the correct `result_metadata`
-    (let [result-metadata-chan (result-metadata-for-updating-async
-                                card-before-update
-                                dataset_query
-                                result_metadata)
+    (let [result-metadata-chan (result-metadata-async (:dataset_query card-before-update)
+                                                      dataset_query
+                                                      result_metadata
+                                                      dataset)
           out-chan             (a/promise-chan)
           card-updates         (merge card-updates
                                       (when dataset

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -31,7 +31,7 @@
             [metabase.related :as related]
             [metabase.sync.analyze.query-results :as qr]
             [metabase.util :as u]
-            [metabase.util.i18n :refer [trs tru]]
+            [metabase.util.i18n :refer [tru]]
             [metabase.util.schema :as su]
             [schema.core :as s]
             [toucan.db :as db]

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -28,6 +28,7 @@
             [metabase.query-processor.async :as qp.async]
             [metabase.query-processor.card :as qp.card]
             [metabase.query-processor.pivot :as qp.pivot]
+            [metabase.query-processor.util :as qputil]
             [metabase.related :as related]
             [metabase.sync.analyze.query-results :as qr]
             [metabase.util :as u]
@@ -194,7 +195,7 @@
       ;; existing metadata
       (and valid-metadata? dataset?)
       (a/go (let [fresh (a/<! (qp.async/result-metadata-for-query-async query))]
-              (u/combine-metadata fresh metadata)))
+              (qputil/combine-metadata fresh metadata)))
       :else
       ;; compute fresh
       (qp.async/result-metadata-for-query-async query))))

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -185,7 +185,9 @@
   (let [valid-metadata? (and metadata (nil? (s/check qr/ResultsMetadata metadata)))]
     (cond
       ;; query didn't change, preserve existing metadata
-      (and (= original-query query) valid-metadata?)
+      (and (= (mbql.normalize/normalize original-query)
+              (mbql.normalize/normalize query))
+           valid-metadata?)
       (a/to-chan! [metadata])
 
       ;; valid metadata was passed in, its a dataset, so get metadata and then blend in to preserve possible edits in

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -199,8 +199,9 @@
       ;; normalized
       (and valid-metadata? dataset?)
       (a/go (let [fresh (a/<! (qp.async/result-metadata-for-query-async query))]
-              (qputil/combine-metadata fresh (map #(update-in % [:field_ref 0] keyword)
-                                                  metadata))))
+              (qputil/combine-metadata
+               fresh
+               (map mbql.normalize/normalize-source-metadata metadata))))
       :else
       ;; compute fresh
       (qp.async/result-metadata-for-query-async query))))

--- a/src/metabase/query_processor/middleware/annotate.clj
+++ b/src/metabase/query_processor/middleware/annotate.clj
@@ -474,24 +474,7 @@
    (cols-for-ags-and-breakouts inner-query)
    (cols-for-fields inner-query)))
 
-(def ^:private preserved-keys
-  "Keys that can survive merging metadata from the database onto metadata computed from the query. When merging
-  metadata, the types returned should be authoritative. But things like semantic_type, display_name, and description
-  can be merged on top."
-  ;; TODO: ideally we don't preserve :id but some notion of :user-entered-id or :identified-id
-  [:id :description :display_name :semantic_type :fk_target_field_id :settings])
 
-(defn- combine-metadata
-  "Ensure that saved metadata from datasets or source queries can remain in the results metadata. We always recompute
-  metadata in general, so need to blend the saved metadata on top of the computed metadata. First argument should be
-  the metadata from a particular run from the query, and `from-db` should be the metadata from the database we wish to
-  ensure survives."
-  [computed from-db]
-  (let [by-key (u/key-by (comp u/field-ref->key :field_ref) from-db)]
-    (for [{:keys [field_ref] :as col} computed]
-      (if-let [existing (get by-key (u/field-ref->key field_ref))]
-        (merge col (select-keys existing preserved-keys))
-        col))))
 
 (s/defn ^:private merge-source-metadata-col :- (s/maybe su/Map)
   [source-metadata-col :- (s/maybe su/Map) col :- (s/maybe su/Map)]
@@ -523,7 +506,7 @@
         (merge-source-metadata-col source-metadata-for-field
                                    (merge col
                                           (when dataset?
-                                            (select-keys source-metadata-for-field preserved-keys))))
+                                            (select-keys source-metadata-for-field u/preserved-keys))))
         col))))
 
 (declare mbql-cols)
@@ -533,7 +516,7 @@
   (let [columns       (if native-source-query
                         (maybe-merge-source-metadata source-metadata (column-info {:type :native} results))
                         (mbql-cols source-query results))]
-    (combine-metadata columns source-metadata)))
+    (u/combine-metadata columns source-metadata)))
 
 (defn mbql-cols
   "Return the `:cols` result metadata for an 'inner' MBQL query based on the fields/breakouts/aggregations in the
@@ -666,13 +649,13 @@
        (if (= query-type :query)
          (rff (cond-> (assoc metadata :cols (merged-column-info query metadata))
                 (seq dataset-metadata)
-                (update :cols combine-metadata dataset-metadata)))
+                (update :cols u/combine-metadata dataset-metadata)))
          ;; rows sampling is only needed for native queries! TODO ­ not sure we really even need to do for native
          ;; queries...
          (let [metadata (cond-> (update metadata :cols annotate-native-cols)
                           ;; annotate-native-cols ensures that column refs are present which we need to match metadata
                           (seq dataset-metadata)
-                          (update :cols combine-metadata dataset-metadata)
+                          (update :cols u/combine-metadata dataset-metadata)
                           ;; but we want those column refs removed since they have type info which we don't know yet
                           :always
                           (update :cols (fn [cols] (map #(dissoc % :field_ref) cols))))]

--- a/src/metabase/query_processor/util.clj
+++ b/src/metabase/query_processor/util.clj
@@ -108,8 +108,8 @@
   "A standard and repeatable way to address a column. Names can collide and sometimes are not unique. Field refs should
   be stable, except we have to exclude the last part as extra information can be tucked in there. Names can be
   non-unique at times, numeric ids are not guaranteed."
-  [field-ref]
-  (into [] (take 2) field-ref))
+  [[tyype identifier]]
+  [tyype identifier])
 
 (def preserved-keys
   "Keys that can survive merging metadata from the database onto metadata computed from the query. When merging

--- a/src/metabase/query_processor/util.clj
+++ b/src/metabase/query_processor/util.clj
@@ -5,6 +5,7 @@
             [cheshire.core :as json]
             [clojure.string :as str]
             [metabase.driver :as driver]
+            [metabase.util :as u]
             [metabase.util.schema :as su]
             [schema.core :as s]))
 
@@ -100,3 +101,33 @@
     (when (string? source-table)
       (when-let [[_ card-id-str] (re-matches #"^card__(\d+$)" source-table)]
         (Integer/parseInt card-id-str)))))
+
+;;; ------------------------------------------- Metadata Combination Utils --------------------------------------------
+
+(defn field-ref->key
+  "A standard and repeatable way to address a column. Names can collide and sometimes are not unique. Field refs should
+  be stable, except we have to exclude the last part as extra information can be tucked in there. Names can be
+  non-unique at times, numeric ids are not guaranteed."
+  [field-ref]
+  (into [] (take 2) field-ref))
+
+(def preserved-keys
+  "Keys that can survive merging metadata from the database onto metadata computed from the query. When merging
+  metadata, the types returned should be authoritative. But things like semantic_type, display_name, and description
+  can be merged on top."
+  ;; TODO: ideally we don't preserve :id but some notion of :user-entered-id or :identified-id
+  [:id :description :display_name :semantic_type :fk_target_field_id :settings])
+
+(defn combine-metadata
+  "Blend saved metadata from previous runs into fresh metadata from an actual run of the query.
+
+  Ensure that saved metadata from datasets or source queries can remain in the results metadata. We always recompute
+  metadata in general, so need to blend the saved metadata on top of the computed metadata. First argument should be
+  the metadata from a run from the query, and `pre-existing` should be the metadata from the database we wish to
+  ensure survives."
+  [fresh pre-existing]
+  (let [by-key (u/key-by (comp field-ref->key :field_ref) pre-existing)]
+    (for [{:keys [field_ref] :as col} fresh]
+      (if-let [existing (get by-key (field-ref->key field_ref))]
+        (merge col (select-keys existing preserved-keys))
+        col))))

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -959,3 +959,24 @@
   non-unique at times, numeric ids are not guaranteed."
   [field-ref]
   (into [] (take 2) field-ref))
+
+(def preserved-keys
+  "Keys that can survive merging metadata from the database onto metadata computed from the query. When merging
+  metadata, the types returned should be authoritative. But things like semantic_type, display_name, and description
+  can be merged on top."
+  ;; TODO: ideally we don't preserve :id but some notion of :user-entered-id or :identified-id
+  [:id :description :display_name :semantic_type :fk_target_field_id :settings])
+
+(defn combine-metadata
+  "Blend saved metadata from previous runs into fresh metadata from an actual run of the query.
+
+  Ensure that saved metadata from datasets or source queries can remain in the results metadata. We always recompute
+  metadata in general, so need to blend the saved metadata on top of the computed metadata. First argument should be
+  the metadata from a run from the query, and `pre-existing` should be the metadata from the database we wish to
+  ensure survives."
+  [fresh pre-existing]
+  (let [by-key (key-by (comp field-ref->key :field_ref) pre-existing)]
+    (for [{:keys [field_ref] :as col} fresh]
+      (if-let [existing (get by-key (field-ref->key field_ref))]
+        (merge col (select-keys existing preserved-keys))
+        col))))

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -1910,4 +1910,10 @@
                           (map (comp str/upper-case :display_name)))))
               (is (= ["EDITED DISPLAY" "EDITED DISPLAY" "PRICE"]
                      (map (comp str/upper-case :display_name)
-                          (db/select-one-field :result_metadata Card :id card-id)))))))))))
+                          (db/select-one-field :result_metadata Card :id card-id))))
+              (testing "Even if you only send the new query and not existing metadata"
+                (is (= ["EDITED DISPLAY" "EDITED DISPLAY"]
+                     (->> (mt/user-http-request
+                           :rasta :put 202 (str "card/" card-id)
+                           {:dataset_query query})
+                          :result_metadata (map :display_name))))))))))))

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -472,20 +472,21 @@
         (with-redefs [qp.async/result-metadata-for-query-async (fn [q]
                                                                  (swap! called inc)
                                                                  (orig q))]
-          (let [card (mt/user-http-request :rasta :post 202 "card"
-                                           (card-with-name-and-query "card-name"
-                                                                     query))]
-            (is (= @called 1))
-            (is (= ["ID" "NAME"] (map norm (:result_metadata card))))
-            (mt/user-http-request
-             :rasta :put 202 (str "card/" (:id card))
-             (assoc card
-                    :description "a change that doesn't change the query"
-                    :name "compelling title"
-                    :cache_ttl 20000
-                    :display "table"
-                    :collection_position 1))
-            (is (= @called 1))))))))
+          (mt/with-model-cleanup [Card]
+            (let [card (mt/user-http-request :rasta :post 202 "card"
+                                             (card-with-name-and-query "card-name"
+                                                                       query))]
+              (is (= @called 1))
+              (is (= ["ID" "NAME"] (map norm (:result_metadata card))))
+              (mt/user-http-request
+               :rasta :put 202 (str "card/" (:id card))
+               (assoc card
+                      :description "a change that doesn't change the query"
+                      :name "compelling title"
+                      :cache_ttl 20000
+                      :display "table"
+                      :collection_position 1))
+              (is (= @called 1)))))))))
 
 (deftest fetch-results-metadata-test
   (testing "Check that the generated query to fetch the query result metadata includes user information in the generated query"

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -497,7 +497,18 @@
           (let [updated (mt/user-http-request :rasta :put 202 (str "card/" (:id card))
                                               {:description "I'm innocently updating the description"
                                                :dataset true})]
-            (is (= ["ID" "NAME"] (map norm (:result_metadata updated))))))))))
+            (is (= ["ID" "NAME"] (map norm (:result_metadata updated))))))))
+    (testing "You can update just the metadata"
+      (mt/with-model-cleanup [Card]
+        (let [card (mt/user-http-request :rasta :post 202 "card"
+                                         (card-with-name-and-query "card-name"
+                                                                   query))]
+          (is (= ["ID" "NAME"] (map norm (:result_metadata card))))
+          (let [new-metadata (map #(assoc % :display_name "UPDATED") (:result_metadata card))
+                updated (mt/user-http-request :rasta :put 202 (str "card/" (:id card))
+                                              {:result_metadata new-metadata})]
+            (is (= ["UPDATED" "UPDATED"]
+                   (map :display_name (:result_metadata updated))))))))))
 
 (deftest fetch-results-metadata-test
   (testing "Check that the generated query to fetch the query result metadata includes user information in the generated query"


### PR DESCRIPTION
same as #19897 but targeting master rather than the 42 release

description copied over:

Previously we have assumed that if valid metadata is passed into the
card create and udpate, that that is valid metadata for the query. There
are a few scenarios where this can fail, but they all boil down to
editing the query after running it. Examples:

- when creating a query, come up with a query, visualize, realize you
wanted to not select all columns, edit to not select those, possibly
select a few extra, and then save. The saved metadata might only have
the columns from when you ran the query and not after you saved it.
- edit an existing query and save without rerunning. Again, adding and
removing some columns.

How it affects:
- if you remove columns, the preserved metadata can cause us to attempt
to select columns that are no longer in that question, leading to errors
for nested queries
- if you add columns, the query builder won't show the new columns until
that information is populated in the metadata by running the query.

Lifecycle now:
- should be encapsulated in `api.card/result-metadata-async`. But we
only allow metadata to remain if is is valid metadata and the query has
not been edited. If the query has been edited (and new queries always
satisfy this since the previous query will be nil) we rerun the query to
get the metadata. No more drift. However, when dealing with datasets we
will attempt to blend the existing metadata into the newly computed
metadata so that metadata edits can persevere.

Other changes:

- removed an extra indirection in the card api that made it harder to
reason about when to recompute metadata
- moved the `combine-metadata` function into a util namespace and gave
some more generic parameter names
- deleted two tests that are no longer relevant after removing the
checksum on metadata. One had to do with how we hash floats vs ints
which is no longer relevant since we aren't hashing at all (RIP
checksum) and one checked that we accepted "valid" checksum-ed
metadata.
- new test that updating a card will update its metadata by rerunning
the query
- when validating the checksum, do not call s/validate since this WILL
THROW. Instead check `(nil? (s/check ...))`.
