### PR TITLE
Postgres: avoid unnecessary casts of DATE or TIMESTAMPTZ to TIMESTAMP

### DIFF
--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -37,9 +37,12 @@
 
 (defmethod driver/display-name :postgres [_] "PostgreSQL")
 
+(defn- ->timestamp [honeysql-form]
+  (hx/cast-unless-type-in "timestamp" #{"timestamp" "timestamptz" "date"} honeysql-form))
+
 (defmethod sql.qp/add-interval-honeysql-form :postgres
   [_ hsql-form amount unit]
-  (hx/+ (hx/->timestamp hsql-form)
+  (hx/+ (->timestamp hsql-form)
         (hsql/raw (format "(INTERVAL '%s %s')" amount (name unit)))))
 
 (defmethod driver/humanize-connection-error-message :postgres
@@ -180,8 +183,8 @@
   (sql.qp/cast-temporal-string driver :Coercion/YYYYMMDDHHMMSSString->Temporal
                                (hsql/call :convert_from expr (hx/literal "UTF8"))))
 
-(defn- date-trunc [unit expr] (hsql/call :date_trunc (hx/literal unit) (hx/->timestamp expr)))
-(defn- extract    [unit expr] (hsql/call :extract    unit              (hx/->timestamp expr)))
+(defn- date-trunc [unit expr] (hsql/call :date_trunc (hx/literal unit) (->timestamp expr)))
+(defn- extract    [unit expr] (hsql/call :extract    unit              (->timestamp expr)))
 
 (def ^:private extract-integer (comp hx/->integer extract))
 

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -665,6 +665,23 @@
                       "ORDER BY attempts.date ASC")
                  (some-> (qp/query->native query) :query pretty-sql))))))))
 
+(deftest do-not-cast-to-timestamp-if-column-if-timestamp-tz-or-date-test
+  (testing "Don't cast a DATE or TIMESTAMPTZ to TIMESTAMP, it's not necessary (#19816)"
+    (mt/test-driver :postgres
+      (mt/dataset sample-dataset
+        (let [query (mt/mbql-query people
+                      {:fields [!month.birth_date
+                                !month.created_at
+                                !month.id]
+                       :limit  1})]
+          (is (sql= '{:select [date_trunc ("month" people.birth_date)             AS birth_date
+                               date_trunc ("month" people.created_at)             AS created_at
+                               ;; non-temporal types should still get casted.
+                               date_trunc ("month" CAST (people.id AS timestamp)) AS id]
+                      :from   [people]
+                      :limit  [1]}
+                    query)))))))
+
 (deftest postgres-ssl-connectivity-test
   (mt/test-driver :postgres
     (if (System/getenv "MB_POSTGRES_SSL_TEST_SSL")

--- a/test/metabase/util/honeysql_extensions_test.clj
+++ b/test/metabase/util/honeysql_extensions_test.clj
@@ -110,11 +110,12 @@
     (is (= ["SELECT 0.1 AS one_tenth"]
            (hsql/format {:select [[(/ 1 10) :one_tenth]]})))))
 
+(defn- ->sql [expr]
+  (hsql/format {:select [expr]}))
+
 (deftest ^:parallel maybe-cast-test
   (testing "maybe-cast should only cast things that need to be cast"
-    (letfn [(->sql [expr]
-              (hsql/format {:select [expr]}))
-            (maybe-cast [expr]
+    (letfn [(maybe-cast [expr]
               (->sql (hx/maybe-cast "text" expr)))]
       (is (= ["SELECT CAST(field AS text)"]
              (maybe-cast :field)))
@@ -135,6 +136,16 @@
                  (hx/maybe-cast "text" (hx/maybe-cast "text" :field))))
           (is (= ["SELECT CAST(field AS text)"]
                  (maybe-cast (hx/maybe-cast "text" :field)))))))))
+
+(deftest ^:parallel cast-unless-type-in-test
+  (letfn [(cast-unless-type-in [expr]
+            (first (->sql (hx/cast-unless-type-in "timestamp" #{"timestamp" "timestamptz"} expr))))]
+    (is (= "SELECT field"
+           (cast-unless-type-in (hx/with-type-info :field {::hx/database-type "timestamp"}))))
+    (is (= "SELECT field"
+           (cast-unless-type-in (hx/with-type-info :field {::hx/database-type "timestamptz"}))))
+    (is (= "SELECT CAST(field AS timestamp)"
+           (cast-unless-type-in (hx/with-type-info :field {::hx/database-type "date"}))))))
 
 (def ^:private typed-form (hx/with-type-info :field {::hx/database-type "text"}))
 


### PR DESCRIPTION
Backport #19790 to `release-x.42.x`

Backported manually because this didn't make it in to `master` before `release-x.42.x` was cut 