### PR TITLE
Sanitize tracking urls

### DIFF
--- a/frontend/src/metabase/lib/analytics.js
+++ b/frontend/src/metabase/lib/analytics.js
@@ -22,11 +22,11 @@ export const trackPageView = url => {
   }
 
   if (Settings.googleAnalyticsEnabled()) {
-    trackGoogleAnalyticsPageView(url);
+    trackGoogleAnalyticsPageView(getSanitizedUrl(url));
   }
 
   if (Settings.snowplowEnabled()) {
-    trackSnowplowPageView(url);
+    trackSnowplowPageView(getSanitizedUrl(url));
   }
 };
 
@@ -115,10 +115,8 @@ const createSnowplowPlugin = store => {
 };
 
 const trackSnowplowPageView = url => {
-  const maskedUrl = new URL(url, Settings.snowplowUrl());
-
   Snowplow.setReferrerUrl("#");
-  Snowplow.setCustomUrl(maskedUrl.href);
+  Snowplow.setCustomUrl(url);
   Snowplow.trackPageView();
 };
 
@@ -142,4 +140,11 @@ const handleStructEventClick = event => {
       trackStructEvent(...parts);
     }
   }
+};
+
+const getSanitizedUrl = url => {
+  const urlWithoutSlug = url.replace(/(\/\d+)-[^\/]+$/, (match, path) => path);
+  const urlWithoutHost = new URL(urlWithoutSlug, Settings.snowplowUrl());
+
+  return urlWithoutHost.href;
 };


### PR DESCRIPTION
Removes slugs from urls we track with GA and Snowplow.

How to test:
- Run Snowplow Micro from `docker-compose.yml` in `snowplow` folder
- Run `MB_SNOWPLOW_AVAILABLE=true FS_CACHE=true yarn dev`
- Open a dashboard
- You should see `pageview` event in Snowplow Debugger. Make sure that the hostname is replaced with `sp.metabase.com` and the slug is removed from the `Full URL`.