### PR TITLE
Manual backport: Fix semantic type picker

### DIFF
--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/SemanticTypePicker/SemanticTypePicker.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/SemanticTypePicker/SemanticTypePicker.jsx
@@ -36,9 +36,12 @@ function SemanticTypePicker({
   }, []);
 
   const onSelectValue = useCallback(
-    value => {
-      field.onChange(value);
-      onChange(value);
+    e => {
+      if (e.target.value === field.value) {
+        return;
+      }
+      field.onChange(e);
+      onChange(e);
       selectButtonRef.current?.focus();
     },
     [field, onChange],


### PR DESCRIPTION
Manually backporting #19877 fix. The original PR also contains E2E test fixes caused by `SelectButton` moved to `core/components`. Component refactorings are not backported to the release branches, so it only makes sense to backport the fix itself