### PR TITLE
Show model metadata changes revisions

### DIFF
--- a/frontend/src/metabase/lib/revisions/revisions.js
+++ b/frontend/src/metabase/lib/revisions/revisions.js
@@ -114,9 +114,9 @@ const CHANGE_DESCRIPTIONS = {
     [CHANGE_TYPE.REMOVE]: t`changed the visualization settings`,
   },
   result_metadata: {
-    [CHANGE_TYPE.ADD]: t`changed the metadata`,
-    [CHANGE_TYPE.UPDATE]: t`changed the metadata`,
-    [CHANGE_TYPE.REMOVE]: t`changed the metadata`,
+    [CHANGE_TYPE.ADD]: t`edited the metadata`,
+    [CHANGE_TYPE.UPDATE]: t`edited the metadata`,
+    [CHANGE_TYPE.REMOVE]: t`edited the metadata`,
   },
 
   // Dashboards

--- a/frontend/src/metabase/lib/revisions/revisions.js
+++ b/frontend/src/metabase/lib/revisions/revisions.js
@@ -93,7 +93,7 @@ const CHANGE_DESCRIPTIONS = {
     [CHANGE_TYPE.REMOVE]: getCollectionChangeDescription,
   },
 
-  // Questions
+  // Questions & Models
   dataset: {
     [CHANGE_TYPE.UPDATE]: (wasDataset, isDataset) =>
       isDataset
@@ -112,6 +112,11 @@ const CHANGE_DESCRIPTIONS = {
     [CHANGE_TYPE.ADD]: t`changed the visualization settings`,
     [CHANGE_TYPE.UPDATE]: t`changed the visualization settings`,
     [CHANGE_TYPE.REMOVE]: t`changed the visualization settings`,
+  },
+  result_metadata: {
+    [CHANGE_TYPE.ADD]: t`changed the metadata`,
+    [CHANGE_TYPE.UPDATE]: t`changed the metadata`,
+    [CHANGE_TYPE.REMOVE]: t`changed the metadata`,
   },
 
   // Dashboards

--- a/frontend/src/metabase/lib/revisions/revisions.unit.spec.js
+++ b/frontend/src/metabase/lib/revisions/revisions.unit.spec.js
@@ -276,6 +276,16 @@ describe("getRevisionDescription | questions", () => {
       "changed this from a model to a saved question",
     );
   });
+
+  it("handles metadata changes for models", () => {
+    const revision = getSimpleRevision({
+      field: "result_metadata",
+      before: [{ foo: "" }],
+      after: [{ foo: "bar" }],
+    });
+
+    expect(getRevisionDescription(revision)).toBe("changed the metadata");
+  });
 });
 
 describe("getRevisionDescription | dashboards", () => {

--- a/frontend/src/metabase/lib/revisions/revisions.unit.spec.js
+++ b/frontend/src/metabase/lib/revisions/revisions.unit.spec.js
@@ -284,7 +284,7 @@ describe("getRevisionDescription | questions", () => {
       after: [{ foo: "bar" }],
     });
 
-    expect(getRevisionDescription(revision)).toBe("changed the metadata");
+    expect(getRevisionDescription(revision)).toBe("edited the metadata");
   });
 });
 

--- a/frontend/test/metabase/scenarios/models/helpers/e2e-models-metadata-helpers.js
+++ b/frontend/test/metabase/scenarios/models/helpers/e2e-models-metadata-helpers.js
@@ -14,9 +14,7 @@ export function setColumnType(oldType, newType) {
   cy.findByText(oldType).click();
   cy.get(".ReactVirtualized__Grid.MB-Select").scrollTo("top");
   cy.findByPlaceholderText("Search for a special type").type(newType);
-
   cy.findByText(newType).click();
-  cy.button("Save changes").click();
 }
 
 export function mapColumnTo({ table, column } = {}) {

--- a/frontend/test/metabase/scenarios/models/models-metadata.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models-metadata.cy.spec.js
@@ -57,16 +57,16 @@ describe("scenarios > models metadata", () => {
   });
 
   it("should edit native model metadata", () => {
-    cy.createNativeQuestion({
-      name: "Native Model",
-      native: {
-        query: "SELECT * FROM ORDERS",
+    cy.createNativeQuestion(
+      {
+        name: "Native Model",
+        dataset: true,
+        native: {
+          query: "SELECT * FROM ORDERS",
+        },
       },
-    }).then(({ body: { id: nativeModelId } }) => {
-      cy.request("PUT", `/api/card/${nativeModelId}`, { dataset: true });
-
-      cy.visit(`/model/${nativeModelId}`);
-    });
+      { visitQuestion: true },
+    );
 
     openDetailsSidebar();
 

--- a/frontend/test/metabase/scenarios/models/models-metadata.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models-metadata.cy.spec.js
@@ -48,6 +48,7 @@ describe("scenarios > models metadata", () => {
 
     renameColumn("Subtotal", "Pre-tax");
     setColumnType("No special type", "Cost");
+    cy.button("Save changes").click();
 
     startQuestionFromModel("GUI Model");
 
@@ -91,6 +92,8 @@ describe("scenarios > models metadata", () => {
     renameColumn("Subtotal", "Pre-tax");
 
     setColumnType("No special type", "Cost");
+
+    cy.button("Save changes").click();
 
     startQuestionFromModel("Native Model");
 


### PR DESCRIPTION
This PR makes the model details sidebar to show revision messages about changes to `result_metadata`

### To Verify

1. Create a model and open the metadata editor
2. Change a column (let's say column "A") and save the changes
3. Open the editor again, change another column (let's say column "B"), and save changes
4. In the history sidebar, click the "History" button at the bottom to reveal the revision records. Click "Revert" on the latest revision
5. Make sure you can see changes to the column "A", but not changes to the column "B"