### PR TITLE
Fix metadata editor sidebar formatting UI

### DIFF
--- a/frontend/src/metabase/core/components/Radio/Radio.tsx
+++ b/frontend/src/metabase/core/components/Radio/Radio.tsx
@@ -17,6 +17,7 @@ import {
   RadioLabelBubble,
   RadioLabelNormal,
   RadioLabelText,
+  RadioGroup,
   RadioGroupBubble,
   RadioGroupNormal,
 } from "./Radio.styled";
@@ -220,4 +221,6 @@ function isDefaultOption<TValue>(
   return typeof option === "object";
 }
 
-export default Radio;
+export default Object.assign(Radio, {
+  RadioGroup,
+});

--- a/frontend/src/metabase/core/components/Radio/index.ts
+++ b/frontend/src/metabase/core/components/Radio/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./Radio";
+export { RadioGroup } from "./Radio.styled";

--- a/frontend/src/metabase/core/components/Radio/index.ts
+++ b/frontend/src/metabase/core/components/Radio/index.ts
@@ -1,2 +1,1 @@
 export { default } from "./Radio";
-export { RadioGroup } from "./Radio.styled";

--- a/frontend/src/metabase/core/components/SelectButton/SelectButton.tsx
+++ b/frontend/src/metabase/core/components/SelectButton/SelectButton.tsx
@@ -50,4 +50,6 @@ const SelectButton = forwardRef(function SelectButton(
   );
 });
 
-export default SelectButton;
+export default Object.assign(SelectButton, {
+  Root: SelectButtonRoot,
+});

--- a/frontend/src/metabase/core/components/SelectButton/index.ts
+++ b/frontend/src/metabase/core/components/SelectButton/index.ts
@@ -1,2 +1,1 @@
 export { default } from "./SelectButton";
-export { SelectButtonRoot } from "./SelectButton.styled";

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.styled.jsx
@@ -1,6 +1,6 @@
 import styled, { css, keyframes } from "styled-components";
-import { RadioGroup } from "metabase/core/components/Radio";
-import { SelectButtonRoot } from "metabase/core/components/SelectButton";
+import Radio from "metabase/core/components/Radio";
+import SelectButton from "metabase/core/components/SelectButton";
 import { color } from "metabase/lib/colors";
 
 const slideInOutAnimation = keyframes`
@@ -24,17 +24,17 @@ export const AnimatableContent = styled.div`
 const CONTENT_PADDING = "24px";
 
 const FormContainer = styled.div`
-  ${RadioGroup} {
+  ${Radio.RadioGroup} {
     color: ${color("text-dark")};
   }
 
-  ${SelectButtonRoot} {
+  ${SelectButton.Root} {
     color: ${color("text-dark")};
     transition: border 0.3s;
     outline: none;
   }
 
-  ${SelectButtonRoot}:focus {
+  ${SelectButton.Root}:focus {
     border-color: ${color("brand")};
   }
 `;

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.styled.jsx
@@ -1,5 +1,5 @@
 import styled, { css, keyframes } from "styled-components";
-import Radio from "metabase/core/components/Radio";
+import { RadioGroup } from "metabase/core/components/Radio";
 import { SelectButtonRoot } from "metabase/core/components/SelectButton";
 import { color } from "metabase/lib/colors";
 
@@ -24,7 +24,7 @@ export const AnimatableContent = styled.div`
 const CONTENT_PADDING = "24px";
 
 const FormContainer = styled.div`
-  ${Radio.BaseItem} {
+  ${RadioGroup} {
     color: ${color("text-dark")};
   }
 


### PR DESCRIPTION
Fixes metadata editor sidebar regression after `Radio` component refactoring (#19581)

* removed extra vertical space between the "Display" / "Formatting" tabs and the divider line
* fixed radio labels had `text-medium` text color instead of `text-dark`

### Demo

**Before**

<img width="348" alt="metadata-editor-before" src="https://user-images.githubusercontent.com/17258145/151001413-d396771e-b83d-473b-9dd8-5494b7f66a98.png">

**After**

<img width="348" alt="metadata-editor-after" src="https://user-images.githubusercontent.com/17258145/151001427-082e024a-3e07-42d7-b07b-4e4e53c9399b.png">

