### PR TITLE
Fix Radio input UI regressions and remove dependency on styled-system

### DIFF
--- a/frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx
+++ b/frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx
@@ -26,7 +26,7 @@ export default function PeopleListingApp({ children }) {
   } = usePeopleQuery(PAGE_SIZE);
 
   const headingContent = (
-    <div className="mb2 flex">
+    <div className="mb2 flex align-center">
       <SearchInput
         className="text-small mr2"
         type="text"
@@ -43,7 +43,6 @@ export default function PeopleListingApp({ children }) {
           { name: t`Deactivated`, value: USER_STATUS.deactivated },
         ]}
         showButtons
-        py={1}
         onChange={updateStatus}
       />
     </div>

--- a/frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsTabs.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsTabs.jsx
@@ -20,7 +20,6 @@ export const PermissionsTabs = ({ tab, onChangeTab }) => (
       ]}
       onOptionClick={onChangeTab}
       variant="underlined"
-      py={2}
     />
   </div>
 );

--- a/frontend/src/metabase/core/components/Radio/Radio.styled.tsx
+++ b/frontend/src/metabase/core/components/Radio/Radio.styled.tsx
@@ -1,5 +1,4 @@
 import styled from "styled-components";
-import { space, SpaceProps } from "styled-system";
 import { color, lighten } from "metabase/lib/colors";
 import { RadioColorScheme, RadioVariant } from "./types";
 
@@ -21,14 +20,13 @@ export const RadioGroupBubble = styled(RadioGroup)`
   display: flex;
 `;
 
-export interface RadioLabelProps extends SpaceProps {
+export interface RadioLabelProps {
   variant: RadioVariant;
   vertical: boolean;
 }
 
 export const RadioLabel = styled.label<RadioLabelProps>`
   display: block;
-  ${space};
 `;
 
 export const RadioLabelNormal = styled(RadioLabel)`

--- a/frontend/src/metabase/core/components/Radio/Radio.tsx
+++ b/frontend/src/metabase/core/components/Radio/Radio.tsx
@@ -52,7 +52,6 @@ export interface RadioProps<TValue extends Key, TOption = RadioOption<TValue>>
   disabled?: boolean;
   vertical?: boolean;
   showButtons?: boolean;
-  py?: number;
   onChange?: (value: TValue) => void;
   onOptionClick?: (value: TValue) => void;
 }
@@ -78,7 +77,6 @@ const Radio = forwardRef(function Radio<
     disabled = false,
     vertical = false,
     showButtons = vertical && variant !== "bubble",
-    py,
     onChange,
     onOptionClick,
     ...props
@@ -114,7 +112,6 @@ const Radio = forwardRef(function Radio<
             disabled={disabled}
             vertical={vertical}
             showButtons={showButtons}
-            py={py}
             onChange={onChange}
             onOptionClick={onOptionClick}
           />
@@ -134,7 +131,6 @@ interface RadioItemProps<TValue extends Key> {
   disabled: boolean;
   vertical: boolean;
   showButtons: boolean;
-  py: number | undefined;
   onChange?: (value: TValue) => void;
   onOptionClick?: (value: TValue) => void;
 }
@@ -149,7 +145,6 @@ const RadioItem = <TValue extends Key, TOption>({
   disabled,
   vertical,
   showButtons,
-  py,
   onChange,
   onOptionClick,
 }: RadioItemProps<TValue>): JSX.Element => {
@@ -164,12 +159,7 @@ const RadioItem = <TValue extends Key, TOption>({
   }, [value, onOptionClick]);
 
   return (
-    <RadioLabel
-      variant={variant}
-      vertical={vertical}
-      py={py}
-      onClick={handleClick}
-    >
+    <RadioLabel variant={variant} vertical={vertical} onClick={handleClick}>
       <RadioInput
         type="radio"
         name={name}

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.jsx
@@ -362,7 +362,6 @@ function DatasetFieldMetadataSidebar({
                     options={TAB_OPTIONS}
                     onChange={setTab}
                     variant="underlined"
-                    py={1}
                   />
                 </FormTabsContainer>
               )}


### PR DESCRIPTION
Fixes UI regressions caused by after `Radio` component refactoring (#19581)

* on Admin > People, the "Active" / "Deactivated" tabs are not centered vertically
* on Admin > Permissions, the tabs have extra margin from the divider line

Both issues are caused by the `py` prop. This PR removes them fixing the UI issues, so the `Radio` component doesn't rely on the `styled-system` anymore 🎉 

### Demo

<details>
<summary>Admin > People</summary>

**Before**

![CleanShot 2022-01-25 at 17 01 35@2x](https://user-images.githubusercontent.com/17258145/151002259-c1d79885-5b9d-4ffb-9bb9-075d14679655.png)

**After**

![people-admin-after](https://user-images.githubusercontent.com/17258145/151002276-3936b868-8fa0-4437-a274-92c9b5305792.png)

</details>

<details>
<summary>Admin > Permissions</summary>

**Before**

![CleanShot 2022-01-25 at 17 02 15@2x](https://user-images.githubusercontent.com/17258145/151002230-af0c2385-cd71-4af6-9cfa-9fec3b5eb08a.png)

**After**

![permissions-admin-after](https://user-images.githubusercontent.com/17258145/151002243-f6b146a8-2411-490b-bd57-13044330cf22.png)

</details>