### PR TITLE
Add visual tests for model query and metadata editors

### DIFF
--- a/frontend/src/metabase/core/components/Radio/Radio.tsx
+++ b/frontend/src/metabase/core/components/Radio/Radio.tsx
@@ -17,6 +17,7 @@ import {
   RadioLabelBubble,
   RadioLabelNormal,
   RadioLabelText,
+  RadioGroup,
   RadioGroupBubble,
   RadioGroupNormal,
 } from "./Radio.styled";
@@ -220,4 +221,6 @@ function isDefaultOption<TValue>(
   return typeof option === "object";
 }
 
-export default Radio;
+export default Object.assign(Radio, {
+  RadioGroup,
+});

--- a/frontend/src/metabase/core/components/Radio/index.ts
+++ b/frontend/src/metabase/core/components/Radio/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./Radio";
+export { RadioGroup } from "./Radio.styled";

--- a/frontend/src/metabase/core/components/Radio/index.ts
+++ b/frontend/src/metabase/core/components/Radio/index.ts
@@ -1,2 +1,1 @@
 export { default } from "./Radio";
-export { RadioGroup } from "./Radio.styled";

--- a/frontend/src/metabase/core/components/SelectButton/SelectButton.tsx
+++ b/frontend/src/metabase/core/components/SelectButton/SelectButton.tsx
@@ -50,4 +50,6 @@ const SelectButton = forwardRef(function SelectButton(
   );
 });
 
-export default SelectButton;
+export default Object.assign(SelectButton, {
+  Root: SelectButtonRoot,
+});

--- a/frontend/src/metabase/core/components/SelectButton/index.ts
+++ b/frontend/src/metabase/core/components/SelectButton/index.ts
@@ -1,2 +1,1 @@
 export { default } from "./SelectButton";
-export { SelectButtonRoot } from "./SelectButton.styled";

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.styled.jsx
@@ -1,6 +1,6 @@
 import styled, { css, keyframes } from "styled-components";
-import { RadioGroup } from "metabase/core/components/Radio";
-import { SelectButtonRoot } from "metabase/core/components/SelectButton";
+import Radio from "metabase/core/components/Radio";
+import SelectButton from "metabase/core/components/SelectButton";
 import { color } from "metabase/lib/colors";
 
 const slideInOutAnimation = keyframes`
@@ -24,17 +24,17 @@ export const AnimatableContent = styled.div`
 const CONTENT_PADDING = "24px";
 
 const FormContainer = styled.div`
-  ${RadioGroup} {
+  ${Radio.RadioGroup} {
     color: ${color("text-dark")};
   }
 
-  ${SelectButtonRoot} {
+  ${SelectButton.Root} {
     color: ${color("text-dark")};
     transition: border 0.3s;
     outline: none;
   }
 
-  ${SelectButtonRoot}:focus {
+  ${SelectButton.Root}:focus {
     border-color: ${color("brand")};
   }
 `;

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.styled.jsx
@@ -1,5 +1,5 @@
 import styled, { css, keyframes } from "styled-components";
-import Radio from "metabase/core/components/Radio";
+import { RadioGroup } from "metabase/core/components/Radio";
 import { SelectButtonRoot } from "metabase/core/components/SelectButton";
 import { color } from "metabase/lib/colors";
 
@@ -24,7 +24,7 @@ export const AnimatableContent = styled.div`
 const CONTENT_PADDING = "24px";
 
 const FormContainer = styled.div`
-  ${Radio.BaseItem} {
+  ${RadioGroup} {
     color: ${color("text-dark")};
   }
 

--- a/frontend/test/metabase-visual/models/editor.cy.spec.js
+++ b/frontend/test/metabase-visual/models/editor.cy.spec.js
@@ -19,6 +19,7 @@ describe("visual tests > models > editor", () => {
       }).then(({ body: { id: MODEL_ID } }) => {
         cy.visit(`/model/${MODEL_ID}/query`);
         cy.wait("@cardQuery");
+        cy.findByText(/Doing science/).should("not.exist");
         cy.percySnapshot(
           "visual tests > models > editor > GUI query > renders query editor correctly",
         );
@@ -33,6 +34,7 @@ describe("visual tests > models > editor", () => {
       }).then(({ body: { id: MODEL_ID } }) => {
         cy.visit(`/model/${MODEL_ID}/metadata`);
         cy.wait("@cardQuery");
+        cy.findByText(/Doing science/).should("not.exist");
         cy.percySnapshot(
           "visual tests > models > editor > GUI query > renders metadata editor correctly",
         );
@@ -51,6 +53,7 @@ describe("visual tests > models > editor", () => {
       }).then(({ body: { id: MODEL_ID } }) => {
         cy.visit(`/model/${MODEL_ID}/query`);
         cy.wait("@cardQuery");
+        cy.findByText(/Doing science/).should("not.exist");
         cy.percySnapshot(
           "visual tests > models > editor > native query > renders query editor correctly",
         );
@@ -67,6 +70,7 @@ describe("visual tests > models > editor", () => {
       }).then(({ body: { id: MODEL_ID } }) => {
         cy.visit(`/model/${MODEL_ID}/metadata`);
         cy.wait("@cardQuery");
+        cy.findByText(/Doing science/).should("not.exist");
         cy.percySnapshot(
           "visual tests > models > editor > native query > renders metadata editor correctly",
         );

--- a/frontend/test/metabase-visual/models/editor.cy.spec.js
+++ b/frontend/test/metabase-visual/models/editor.cy.spec.js
@@ -1,0 +1,105 @@
+import { restore } from "__support__/e2e/cypress";
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
+const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
+
+describe("visual tests > models > editor", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+    cy.intercept("POST", "/api/card/*/query").as("cardQuery");
+  });
+
+  describe("GUI query", () => {
+    it("renders query editor correctly", () => {
+      cy.createQuestion({
+        name: "GUI Model",
+        dataset: true,
+        query: GUI_QUERY,
+      }).then(({ body: { id: MODEL_ID } }) => {
+        cy.visit(`/model/${MODEL_ID}/query`);
+        cy.wait("@cardQuery");
+        cy.percySnapshot(
+          "visual tests > models > editor > GUI query > renders query editor correctly",
+        );
+      });
+    });
+
+    it("renders metadata editor correctly", () => {
+      cy.createQuestion({
+        name: "GUI Model",
+        dataset: true,
+        query: GUI_QUERY,
+      }).then(({ body: { id: MODEL_ID } }) => {
+        cy.visit(`/model/${MODEL_ID}/metadata`);
+        cy.wait("@cardQuery");
+        cy.percySnapshot(
+          "visual tests > models > editor > GUI query > renders metadata editor correctly",
+        );
+      });
+    });
+  });
+
+  describe("native query", () => {
+    it("renders query editor correctly", () => {
+      cy.createNativeQuestion({
+        name: "Native Model",
+        dataset: true,
+        native: {
+          query: "SELECT * FROM orders",
+        },
+      }).then(({ body: { id: MODEL_ID } }) => {
+        cy.visit(`/model/${MODEL_ID}/query`);
+        cy.wait("@cardQuery");
+        cy.percySnapshot(
+          "visual tests > models > editor > native query > renders query editor correctly",
+        );
+      });
+    });
+
+    it("renders metadata editor correctly", () => {
+      cy.createNativeQuestion({
+        name: "Native Model",
+        dataset: true,
+        native: {
+          query: "SELECT * FROM orders",
+        },
+      }).then(({ body: { id: MODEL_ID } }) => {
+        cy.visit(`/model/${MODEL_ID}/metadata`);
+        cy.wait("@cardQuery");
+        cy.percySnapshot(
+          "visual tests > models > editor > native query > renders metadata editor correctly",
+        );
+      });
+    });
+  });
+});
+
+const GUI_QUERY = {
+  "source-table": ORDERS_ID,
+  joins: [
+    {
+      fields: "all",
+      "source-table": PRODUCTS_ID,
+      condition: [
+        "=",
+        ["field", ORDERS.PRODUCT_ID, null],
+        ["field", PRODUCTS.ID, { "join-alias": "Products" }],
+      ],
+      alias: "Products",
+    },
+  ],
+  filter: [
+    "and",
+    ["=", ["field", ORDERS.QUANTITY, null], 1],
+    [">", ["field", PRODUCTS.RATING, { "join-alias": "Products" }], 3],
+  ],
+  aggregation: [
+    ["sum", ["field", ORDERS.TOTAL, null]],
+    ["sum", ["field", PRODUCTS.RATING, { "join-alias": "Products" }]],
+  ],
+  breakout: [
+    ["field", ORDERS.CREATED_AT, { "temporal-unit": "year" }],
+    ["field", PRODUCTS.CATEGORY, { "join-alias": "Products" }],
+  ],
+};


### PR DESCRIPTION
Adds Percy visual tests for:

* GUI model query editor
* GUI model metadata editor
* native model query editor
* native model metadata editor

### To Verify

1. Run Cypress
2. Run the visual tests (`metabase-visual/models/editor.cy.spec.js`)