### PR TITLE
Fix x-raying a nested question

### DIFF
--- a/frontend/src/metabase/parameters/utils/parameter-values.js
+++ b/frontend/src/metabase/parameters/utils/parameter-values.js
@@ -166,6 +166,7 @@ export function getParameterValuesBySlug(
   parameterValuesById,
   { preserveDefaultedParameters } = {},
 ) {
+  parameters = parameters || [];
   parameterValuesById = parameterValuesById || {};
   const parameterValuePairs = parameters.map(parameter => [
     parameter,

--- a/frontend/src/metabase/parameters/utils/parameter-values.unit.spec.js
+++ b/frontend/src/metabase/parameters/utils/parameter-values.unit.spec.js
@@ -575,6 +575,11 @@ describe("parameters/utils/parameter-values", () => {
           ),
         ).toEqual(getParameterValuesBySlug(parameters, parameterValues));
       });
+
+      it("should handle nullish parameters", () => {
+        expect(getParameterValuesBySlug(undefined, {})).toEqual({});
+        expect(getParameterValuesBySlug(null, {})).toEqual({});
+      });
     });
 
     describe("`preserveDefaultedParameters` === true", () => {
@@ -602,6 +607,28 @@ describe("parameters/utils/parameter-values", () => {
           [defaultedParameter.slug]: undefined,
           [defaultedParameterWithValue.slug]: defaultedParameterWithValue.value,
         });
+      });
+
+      it("should handle nullish parameters", () => {
+        expect(
+          getParameterValuesBySlug(
+            undefined,
+            {},
+            {
+              preserveDefaultedParameters: true,
+            },
+          ),
+        ).toEqual({});
+
+        expect(
+          getParameterValuesBySlug(
+            null,
+            {},
+            {
+              preserveDefaultedParameters: true,
+            },
+          ),
+        ).toEqual({});
       });
     });
   });

--- a/frontend/test/metabase/scenarios/dashboard/x-rays.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/x-rays.cy.spec.js
@@ -1,4 +1,9 @@
-import { restore, visitQuestionAdhoc, popover } from "__support__/e2e/cypress";
+import {
+  restore,
+  getDimensionByName,
+  visitQuestionAdhoc,
+  popover,
+} from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const {
@@ -84,7 +89,8 @@ describe("scenarios > x-rays", () => {
   });
 
   ["X-ray", "Compare to the rest"].forEach(action => {
-    it.skip(`"${action.toUpperCase()}" should work on a nested question made from base native question (metabase#15655)`, () => {
+    it(`"${action.toUpperCase()}" should work on a nested question made from base native question (metabase#15655)`, () => {
+      cy.skipOn(action === "Compare to the rest");
       cy.intercept("GET", "/api/automagic-dashboards/**").as("xray");
       cy.createNativeQuestion({
         name: "15655",
@@ -96,9 +102,8 @@ describe("scenarios > x-rays", () => {
       cy.findByText("Saved Questions").click();
       cy.findByText("15655").click();
       cy.findByText("Summarize").click();
-      cy.get(".List-item-title")
-        .contains(/Source/i)
-        .click();
+      getDimensionByName({ name: "SOURCE" }).click();
+      cy.button("Done").click();
       cy.get(".bar")
         .first()
         .click({ force: true });
@@ -107,7 +112,7 @@ describe("scenarios > x-rays", () => {
         expect(xhr.response.body.cause).not.to.exist;
         expect(xhr.response.statusCode).not.to.eq(500);
       });
-      cy.findByText("A look at the number of People");
+      cy.findByText(/A closer look at the number of/);
       cy.get(".DashCard");
     });
 


### PR DESCRIPTION
Partial fix for #15655: doing automatic "X-ray" exploration from nested question errors with "Something's gone wrong". The problem is the FE parameters code fails if the resulting dashboard has no parameters.

It doesn't completely fix the issue as the "Compare" actions don't work still and the problem is probably the BE.

### To Verify

1. Native query > Sample Database > `select * from orders` - save as "Q1"
2. Click "Explore results"
3. Summarize Count by Created At
4. Click the first result and select "X-ray" or "Compare to the rest"
5. You should see the x-rayed dashboard

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/151027630-39ecd657-6ebb-48c0-914d-7307d19e393b.mov

**After**

https://user-images.githubusercontent.com/17258145/151027650-5496799f-dbce-41ef-b9e0-7f609a92d01e.mov
