### PR TITLE
Custom expression suggestions: honor database features

### DIFF
--- a/frontend/src/metabase/lib/expressions/suggest.js
+++ b/frontend/src/metabase/lib/expressions/suggest.js
@@ -42,6 +42,7 @@ export function suggest({
     return { suggestions };
   }
 
+  const database = query.database();
   if (_.first(matchPrefix) !== "[") {
     suggestions.push({
       type: "functions",
@@ -54,6 +55,7 @@ export function suggest({
     suggestions.push(
       ...Array.from(EXPRESSION_FUNCTIONS)
         .map(name => MBQL_CLAUSES[name])
+        .filter(clause => database.hasFeature(clause.requiresFeature))
         .map(func => ({
           type: "functions",
           name: func.displayName,
@@ -67,6 +69,7 @@ export function suggest({
       suggestions.push(
         ...Array.from(AGGREGATION_FUNCTIONS)
           .map(name => MBQL_CLAUSES[name])
+          .filter(clause => database.hasFeature(clause.requiresFeature))
           .map(func => ({
             type: "aggregations",
             name: func.displayName,


### PR DESCRIPTION
The functions to be suggested in the expression editor should be filtered according to what is supported by the database.

How to verify (test this using H2 as application DB and the source of sample dataset):
1. New, Question
2. Sample Database, Product
3. Custom Column and type `re`

**Before this PR**

`regextract` appears in the popover, in addition to `re` (both match the prefix `re`), even if H2 doesn't support it.

![Screenshot_20220125_091152](https://user-images.githubusercontent.com/7288/151052166-500026a1-c661-4d5d-8f43-5644374a39ea.png)

**After this PR**

Only `replace` is offered.

![Screenshot_20220125_091226](https://user-images.githubusercontent.com/7288/151052201-3ffcf57b-58c6-4d09-a9fe-2cd6a269b160.png)
