### PR TITLE
Custom expression editor: explicit plain text mode

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -406,6 +406,7 @@ export default class ExpressionEditorTextfield extends React.Component {
           <EditorEqualsSign>=</EditorEqualsSign>
           <AceEditor
             commands={this.commands}
+            mode="text"
             ref={this.input}
             value={source}
             markers={this.errorAsMarkers(errorMessage)}


### PR DESCRIPTION
Without this, Ace is trying to load some default mode, which wasn't available.
This leads to an error in the browser console.

To verify (open up DevTools):
1. New, Question
2. Sample Database, Products table
3. Custom Column

**Before this PR**

The browser console shows an error:

> Refused to execute script /assets/ui/mode-mode.js

![image](https://user-images.githubusercontent.com/7288/151071173-7a1bc7c0-d7f2-4b1e-b6c1-052838be44a5.png)

**After this PR**

The browser console doesn't show the error.