### PR TITLE
preserve colums order when a query changes

### DIFF
--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -9,6 +9,7 @@ import {
   columnsAreValid,
   getFriendlyName,
   getDefaultDimensionsAndMetrics,
+  preserveExistingColumnsOrder,
 } from "metabase/visualizations/lib/utils";
 
 import { seriesSetting } from "metabase/visualizations/lib/settings/series";
@@ -104,7 +105,11 @@ export const GRAPH_DATA_SETTINGS = {
             vizSettings["graph._metric_filter"],
           ),
       ),
-    getDefault: (series, vizSettings) => getDefaultColumns(series).dimensions,
+    getDefault: (series, vizSettings) =>
+      preserveExistingColumnsOrder(
+        vizSettings["graph.dimensions"] ?? [],
+        getDefaultColumns(series).dimensions,
+      ),
     persistDefault: true,
     getProps: ([{ card, data }], vizSettings) => {
       const value = vizSettings["graph.dimensions"];

--- a/frontend/src/metabase/visualizations/lib/utils.js
+++ b/frontend/src/metabase/visualizations/lib/utils.js
@@ -344,3 +344,39 @@ export function computeMaxDecimalsForValues(values, options) {
     return undefined;
   }
 }
+
+export const preserveExistingColumnsOrder = (prevColumns, newColumns) => {
+  if (!prevColumns || prevColumns.length === 0) {
+    return newColumns;
+  }
+
+  const newSet = new Set(newColumns);
+  const prevSet = new Set(prevColumns);
+
+  const addedColumns = newColumns.filter(column => !prevSet.has(column));
+  const prevOrderedColumnsExceptRemoved = prevColumns.map(column =>
+    newSet.has(column) ? column : null,
+  );
+
+  const mergedColumnsResult = [];
+
+  while (
+    prevOrderedColumnsExceptRemoved.length > 0 ||
+    addedColumns.length > 0
+  ) {
+    const column = prevOrderedColumnsExceptRemoved.shift();
+
+    if (column != null) {
+      mergedColumnsResult.push(column);
+      continue;
+    }
+
+    const addedColumn = addedColumns.shift();
+
+    if (addedColumn != null) {
+      mergedColumnsResult.push(addedColumn);
+    }
+  }
+
+  return mergedColumnsResult;
+};

--- a/frontend/test/metabase/visualizations/lib/utils.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/utils.unit.spec.js
@@ -5,6 +5,7 @@ import {
   getColumnCardinality,
   getFriendlyName,
   getDefaultDimensionsAndMetrics,
+  preserveExistingColumnsOrder,
 } from "metabase/visualizations/lib/utils";
 
 import _ from "underscore";
@@ -305,6 +306,38 @@ describe("metabase/visualization/lib/utils", () => {
           },
         ]),
       ).toEqual({ dimensions: ["date", "category"], metrics: ["count"] });
+    });
+  });
+
+  describe("preserveExistingColumnsOrder", () => {
+    it("preserves order of columns when one is renamed", () => {
+      const columns = preserveExistingColumnsOrder(
+        ["b", "a"],
+        ["a_renamed", "b"],
+      );
+      expect(columns).toStrictEqual(["b", "a_renamed"]);
+    });
+
+    it("returns new columns when no previous one specified", () => {
+      expect(
+        preserveExistingColumnsOrder(null, ["a_renamed", "b"]),
+      ).toStrictEqual(["a_renamed", "b"]);
+
+      expect(
+        preserveExistingColumnsOrder([], ["a_renamed", "b"]),
+      ).toStrictEqual(["a_renamed", "b"]);
+    });
+
+    it("returns no columns if when there are no new columns", () => {
+      expect(
+        preserveExistingColumnsOrder(["a_renamed", "b"], []),
+      ).toStrictEqual([]);
+    });
+
+    it("returns new columns in order when previous columns completely different", () => {
+      expect(
+        preserveExistingColumnsOrder(["a", "b"], ["c", "d"]),
+      ).toStrictEqual(["c", "d"]);
     });
   });
 });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/19747

When a column set changes for a query, `graph.dimensions` column list becomes invalid. Previously, we just dropped `graph.dimensions` value and created a new column list from the updated query. However, dimensions order is important and it can change chart appearance. To avoid that, I wrote a function that preserves the order of previously existing columns.

### How to verify
Check [repro steps](https://github.com/metabase/metabase/issues/19747)