### PR TITLE
Copy API endpoint (BE bit of #15255)

### DIFF
--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -281,7 +281,7 @@
   ;; Return a channel that can be used to fetch the results asynchronously
   (create-card-async! body))
 
-(api/defendpoint ^:returns-chan POST "/:id/copies"
+(api/defendpoint ^:returns-chan POST "/:id/copy"
   "Copy a `Card`, with the new name 'Copy of _name_'"
   [id]
   {id (s/maybe su/IntGreaterThanZero)}

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -281,12 +281,13 @@
   ;; Return a channel that can be used to fetch the results asynchronously
   (create-card-async! body))
 
-(api/defendpoint ^:returns-chan POST "/some shit/copies"
+(api/defendpoint ^:returns-chan POST "/:id/copies"
   "Copy a `Card`."
-  [:as {{:keys [card_id], :as body} :body}]
-  {card_id                (s/maybe su/IntGreaterThanZero)}
-  ;; check that we have permissions to run the card that we're trying to copy
-  (check-data-permissions-some shit for the card)
+  [id :as some shit...]
+  {id (s/maybe su/IntGreaterThanZero)}
+  (let [orig-card (api/read-check Card id)
+        body      {:keys []
+    ;; Do various permissions checks
   (let [body get the fucking thing]
     ;; check that we have permissions for the collection we're trying to save this card to, if applicable
     (collection/check-write-perms-for-collection collection_id)

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -281,7 +281,7 @@
   ;; Return a channel that can be used to fetch the results asynchronously
   (create-card-async! body))
 
-(api/defendpoint ^:returns-chan GET "/:id/copies"
+(api/defendpoint ^:returns-chan POST "/:id/copies"
   "Copy a `Card`, with the new name 'Copy of _name_'"
   [id]
   {id (s/maybe su/IntGreaterThanZero)}

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -281,6 +281,18 @@
   ;; Return a channel that can be used to fetch the results asynchronously
   (create-card-async! body))
 
+(api/defendpoint ^:returns-chan POST "/some shit/copies"
+  "Copy a `Card`."
+  [:as {{:keys [card_id], :as body} :body}]
+  {card_id                (s/maybe su/IntGreaterThanZero)}
+  ;; check that we have permissions to run the card that we're trying to copy
+  (check-data-permissions-some shit for the card)
+  (let [body get the fucking thing]
+    ;; check that we have permissions for the collection we're trying to save this card to, if applicable
+    (collection/check-write-perms-for-collection collection_id)
+    ;; Return a channel that can be used to fetch the results asynchronously
+    (create-card-async! body)))
+
 
 ;;; ------------------------------------------------- Updating Cards -------------------------------------------------
 

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -281,18 +281,15 @@
   ;; Return a channel that can be used to fetch the results asynchronously
   (create-card-async! body))
 
-(api/defendpoint ^:returns-chan POST "/:id/copies"
-  "Copy a `Card`."
-  [id :as some shit...]
+(api/defendpoint ^:returns-chan GET "/:id/copies"
+  "Copy a `Card`, with the new name 'Copy of _name_'"
+  [id]
   {id (s/maybe su/IntGreaterThanZero)}
   (let [orig-card (api/read-check Card id)
-        body      {:keys []
-    ;; Do various permissions checks
-  (let [body get the fucking thing]
-    ;; check that we have permissions for the collection we're trying to save this card to, if applicable
-    (collection/check-write-perms-for-collection collection_id)
+        new-name  (str (trs "Copy of ") (:name orig-card))
+        new-card  (assoc orig-card :name new-name)]
     ;; Return a channel that can be used to fetch the results asynchronously
-    (create-card-async! body)))
+    (create-card-async! new-card)))
 
 
 ;;; ------------------------------------------------- Updating Cards -------------------------------------------------

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -586,6 +586,26 @@
                           s/Keyword       s/Any}
                          (create-card! :rasta 403)))))))))
 
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                   COPYING A CARD (POST /api/card/:id/copies)                                   |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+(deftest copy-card
+  (testing "POST /api/card/:id/copies"
+    (testing "Test that we can copy a Card"
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (mt/with-temp Collection [collection]
+          (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection)
+          (mt/with-model-cleanup [Card]
+            (let [card    (assoc (card-with-name-and-query (mt/random-name)
+                                                           (mbql-count-query (mt/id) (mt/id :venues)))
+                                 :collection_id (u/the-id collection))
+                  card    (mt/user-http-request :rasta :post 202 "card" card)
+                  newcard (mt/user-http-request :rasta :post 202 (format "card/%d/copies" (u/the-id card)))]
+              (is (= (:name newcard) (str "Copy of " (:name card))))
+              (is (= (:display newcard) (:display card)))
+              (is (not= (:id newcard) (:id card))))))))))
+
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                            FETCHING A SPECIFIC CARD                                            |

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -587,11 +587,11 @@
                          (create-card! :rasta 403)))))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
-;;; |                                   COPYING A CARD (POST /api/card/:id/copies)                                   |
+;;; |                                    COPYING A CARD (POST /api/card/:id/copy)                                    |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 (deftest copy-card
-  (testing "POST /api/card/:id/copies"
+  (testing "POST /api/card/:id/copy"
     (testing "Test that we can copy a Card"
       (mt/with-non-admin-groups-no-root-collection-perms
         (mt/with-temp Collection [collection]
@@ -601,7 +601,7 @@
                                                            (mbql-count-query (mt/id) (mt/id :venues)))
                                  :collection_id (u/the-id collection))
                   card    (mt/user-http-request :rasta :post 202 "card" card)
-                  newcard (mt/user-http-request :rasta :post 202 (format "card/%d/copies" (u/the-id card)))]
+                  newcard (mt/user-http-request :rasta :post 202 (format "card/%d/copy" (u/the-id card)))]
               (is (= (:name newcard) (str "Copy of " (:name card))))
               (is (= (:display newcard) (:display card)))
               (is (not= (:id newcard) (:id card))))))))))


### PR DESCRIPTION
This is an API update that I rigged up to repro a separate issue but found it to be pursuant to #15255. FE noted that #15255 needed BE work to whack in a copy endpoint to API and here is a simple one