### PR TITLE
Trim whitespace around commas in schema filtering code

### DIFF
--- a/src/metabase/driver/sync.clj
+++ b/src/metabase/driver/sync.clj
@@ -17,7 +17,7 @@
     crazy\\*schema => crazy\\*schema"
   ^Pattern [^String schema-pattern]
   (re-pattern (->> (str/split schema-pattern #",")
-                   (mapv (comp #(str/replace % #"(^|[^\\\\])\*" "$1.*") str/trim))
+                   (map (comp #(str/replace % #"(^|[^\\\\])\*" "$1.*") str/trim))
                    (str/join "|"))))
 
 (defn- schema-patterns->filter-fn*

--- a/test/metabase/driver/sync_test.clj
+++ b/test/metabase/driver/sync_test.clj
@@ -16,7 +16,8 @@
            ["inclusion filter with commas and wildcards (include)" true "foo" "bar,f*,baz" ""]
            ["inclusion filter with commas and wildcards (exclude)" false "ban" "bar,f*,baz" ""]
            ["exclusion filter with commas and wildcards (include)" true "foo" "" "ba*,fob"]
-           ["exclusion filter with commas and wildcards (exclude)" false "foo" "" "bar,baz,fo*"]]]
+           ["exclusion filter with commas and wildcards (exclude)" false "foo" "" "bar,baz,fo*"]
+           ["multiple inclusion with whitespace trimming" true "bar" "  foo  ,  bar \n  ,  \nbaz  " ""]]]
     (t/testing (str "include-schema? works as expected for " test-kind)
       (t/is (= expect-match? (driver.s/include-schema? inclusion-filters exclusion-filters schema-name))))
     (t/testing "include-schema? throws an exception if both patterns are specified"


### PR DESCRIPTION
Change impl of `schema-pattern->re-pattern` so that strings are trimmed before being joined on `|`

Add test to confirm
