### PR TITLE
Fix reordering model columns

### DIFF
--- a/frontend/src/metabase-types/types/Card.ts
+++ b/frontend/src/metabase-types/types/Card.ts
@@ -20,6 +20,7 @@ export type Card = {
   id: CardId;
   name?: string;
   description?: string;
+  dataset?: boolean;
   dataset_query: DatasetQuery;
   display: string;
   visualization_settings: VisualizationSettings;

--- a/frontend/src/metabase-types/types/Query.ts
+++ b/frontend/src/metabase-types/types/Query.ts
@@ -67,8 +67,13 @@ export type NativeQuery = {
   "template-tags": TemplateTags;
 };
 
+// "card__4" like syntax meaning a query is using card 4 as a data source
+type NestedQueryTableId = string;
+
+export type SourceTableId = TableId | NestedQueryTableId;
+
 export type StructuredQuery = {
-  "source-table"?: TableId;
+  "source-table"?: SourceTableId;
   "source-query"?: StructuredQuery;
   aggregation?: AggregationClause;
   breakout?: BreakoutClause;

--- a/frontend/src/metabase/lib/data-modeling/utils.ts
+++ b/frontend/src/metabase/lib/data-modeling/utils.ts
@@ -1,7 +1,10 @@
 import Question from "metabase-lib/lib/Question";
 import NativeQuery from "metabase-lib/lib/queries/NativeQuery";
 import Database from "metabase-lib/lib/metadata/Database";
+import { isStructured } from "metabase/lib/query";
+import { getQuestionVirtualTableId } from "metabase/lib/saved-questions";
 import { TemplateTag } from "metabase-types/types/Query";
+import { Card, StructuredDatasetQuery } from "metabase-types/types/Card";
 
 export function isSupportedTemplateTagForModel(tag: TemplateTag) {
   return tag.type === "card";
@@ -25,4 +28,28 @@ export function checkCanBeModel(question: Question) {
   return (query as NativeQuery)
     .templateTags()
     .every(isSupportedTemplateTagForModel);
+}
+
+export function isAdHocModelQuestionCard(card: Card, originalCard?: Card) {
+  if (!originalCard || !isStructured(card.dataset_query)) {
+    return false;
+  }
+
+  const isModel = card.dataset || originalCard.dataset;
+  const isSameCard = card.id === originalCard.id;
+  const { query } = card.dataset_query as StructuredDatasetQuery;
+  const isSelfReferencing =
+    query["source-table"] === getQuestionVirtualTableId(originalCard);
+
+  return isModel && isSameCard && isSelfReferencing;
+}
+
+export function isAdHocModelQuestion(
+  question: Question,
+  originalQuestion?: Question,
+) {
+  if (!originalQuestion) {
+    return false;
+  }
+  return isAdHocModelQuestionCard(question.card(), originalQuestion.card());
 }

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -994,6 +994,7 @@ export const updateQuestion = (
       // to start building a new ad-hoc question based on a dataset
       if (newQuestion.isDataset()) {
         newQuestion = newQuestion.setDataset(false);
+        dispatch(onCloseQuestionDetails());
       }
     }
 

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -113,6 +113,9 @@ export const setQueryBuilderMode = (
   if (queryBuilderMode === "notebook") {
     dispatch(cancelQuery());
   }
+  if (queryBuilderMode === "dataset") {
+    dispatch(runQuestionQuery());
+  }
 };
 
 export const onEditSummary = createAction("metabase/qb/EDIT_SUMMARY");

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -1226,15 +1226,6 @@ export const runQuestionQuery = ({
       : getQuestion(getState());
     const originalQuestion = getOriginalQuestion(getState());
 
-    // When viewing a dataset, its dataset_query is swapped with a clean query using the dataset as a source table
-    // This ensures we still run the underlying query instead of a nested one if there are not extra clauses
-    // Otherwise, when turning a dataset into a saved question, some things can go wrong
-    // (like "join-aliases" will appear in field refs and some QB parts will behave as if we're running a completely different question)
-    // Once the dataset_query changes, the question will loose the "dataset" flag and it'll work normally
-    if (isAdHocDatasetQuestion(question, originalQuestion)) {
-      question = originalQuestion;
-    }
-
     const cardIsDirty = originalQuestion
       ? question.isDirtyComparedToWithoutParameters(originalQuestion) ||
         question.card().id == null

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -28,6 +28,7 @@ import {
 import { open, shouldOpenInBlankWindow } from "metabase/lib/dom";
 import * as Q_DEPRECATED from "metabase/lib/query";
 import { isSameField, isLocalField } from "metabase/lib/query/field_ref";
+import { isAdHocModelQuestion } from "metabase/lib/data-modeling/utils";
 import Utils from "metabase/lib/utils";
 import { defer } from "metabase/lib/promise";
 
@@ -85,7 +86,6 @@ import {
   getQueryBuilderModeFromLocation,
   getPathNameFromQueryBuilderMode,
   getNextTemplateTagVisibilityState,
-  isAdHocDatasetQuestion,
 } from "./utils";
 
 const PREVIEW_RESULT_LIMIT = 10;
@@ -1184,7 +1184,7 @@ export const apiUpdateQuestion = (question, { rerunQuery = false } = {}) => {
       // (it's necessary for datasets to behave like tables opened in simple mode)
       // When doing updates like changing name, description, etc., we need to omit the dataset_query in the request body
       .reduxUpdate(dispatch, {
-        excludeDatasetQuery: isAdHocDatasetQuestion(question, originalQuestion),
+        excludeDatasetQuery: isAdHocModelQuestion(question, originalQuestion),
       });
 
     // reload the question alerts for the current question

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useCallback } from "react";
 import PropTypes from "prop-types";
 import { t } from "ttag";
 import cx from "classnames";
@@ -182,6 +182,19 @@ function SavedQuestionLeftSide(props) {
     lastEditInfo,
     onOpenQuestionHistory,
   } = props;
+
+  const onHeaderClick = useCallback(() => {
+    if (isShowingQuestionDetailsSidebar) {
+      onCloseQuestionDetails();
+    } else {
+      onOpenQuestionDetails({ closeOtherSidebars: true });
+    }
+  }, [
+    isShowingQuestionDetailsSidebar,
+    onOpenQuestionDetails,
+    onCloseQuestionDetails,
+  ]);
+
   return (
     <div>
       <ViewHeaderMainLeftContentContainer>
@@ -189,11 +202,7 @@ function SavedQuestionLeftSide(props) {
           <SavedQuestionHeaderButton
             question={question}
             isActive={isShowingQuestionDetailsSidebar}
-            onClick={
-              isShowingQuestionDetailsSidebar
-                ? onCloseQuestionDetails
-                : onOpenQuestionDetails
-            }
+            onClick={onHeaderClick}
           />
         </SavedQuestionHeaderButtonContainer>
         {lastEditInfo && (
@@ -331,6 +340,19 @@ function DatasetLeftSide(props) {
     onExpandFilters,
     onCollapseFilters,
   } = props;
+
+  const onHeaderClick = useCallback(() => {
+    if (isShowingQuestionDetailsSidebar) {
+      onCloseQuestionDetails();
+    } else {
+      onOpenQuestionDetails({ closeOtherSidebars: true });
+    }
+  }, [
+    isShowingQuestionDetailsSidebar,
+    onOpenQuestionDetails,
+    onCloseQuestionDetails,
+  ]);
+
   return (
     <div>
       <ViewHeaderMainLeftContentContainer>
@@ -343,11 +365,7 @@ function DatasetLeftSide(props) {
                 <SavedQuestionHeaderButton
                   question={question}
                   isActive={isShowingQuestionDetailsSidebar}
-                  onClick={
-                    isShowingQuestionDetailsSidebar
-                      ? onCloseQuestionDetails
-                      : onOpenQuestionDetails
-                  }
+                  onClick={onHeaderClick}
                 />
               </DatasetHeaderButtonContainer>,
             ]}

--- a/frontend/src/metabase/query_builder/reducers.js
+++ b/frontend/src/metabase/query_builder/reducers.js
@@ -224,11 +224,23 @@ export const uiControls = handleActions(
       isShowingQuestionDetailsSidebar: true,
       questionDetailsTimelineDrawerState: undefined,
     }),
-    [onCloseQuestionDetails]: state => ({
-      ...state,
-      ...UI_CONTROLS_SIDEBAR_DEFAULTS,
-      questionDetailsTimelineDrawerState: undefined,
-    }),
+    [onCloseQuestionDetails]: (
+      state,
+      { payload: { closeOtherSidebars } = {} } = {},
+    ) => {
+      if (closeOtherSidebars) {
+        return {
+          ...state,
+          ...UI_CONTROLS_SIDEBAR_DEFAULTS,
+          questionDetailsTimelineDrawerState: undefined,
+        };
+      }
+      return {
+        ...state,
+        isShowingQuestionDetailsSidebar: false,
+        questionDetailsTimelineDrawerState: undefined,
+      };
+    },
     [onOpenQuestionHistory]: state => ({
       ...state,
       ...UI_CONTROLS_SIDEBAR_DEFAULTS,

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -343,7 +343,7 @@ export const getIsDirty = createSelector(
     // We need to escape the isDirty check as it will always be true in this case,
     // and the page will always be covered with a 'rerun' overlay.
     // Once the dataset_query changes, the question will loose the "dataset" flag and it'll work normally
-    if (!question || isAdHocDatasetQuestion(question, originalQuestion)) {
+    if (!question || isAdHocModelQuestion(question, originalQuestion)) {
       return false;
     }
     return question.isDirtyComparedToWithoutParameters(originalQuestion);

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -20,14 +20,13 @@ import Utils from "metabase/lib/utils";
 
 import Question from "metabase-lib/lib/Question";
 import NativeQuery from "metabase-lib/lib/queries/NativeQuery";
+import { isAdHocModelQuestion } from "metabase/lib/data-modeling/utils";
 import { isVirtualCardId } from "metabase/lib/saved-questions";
 
 import Databases from "metabase/entities/databases";
 
 import { getMetadata } from "metabase/selectors/metadata";
 import { getAlerts } from "metabase/alert/selectors";
-
-import { isAdHocDatasetQuestion } from "./utils";
 
 export const getUiControls = state => state.qb.uiControls;
 
@@ -298,12 +297,12 @@ export const getIsResultDirty = createSelector(
     nextParameters,
     tableMetadata,
   ) => {
-    // When viewing a dataset, its dataset_query is swapped with a clean query using the dataset as a source table
+    // When viewing a model, its dataset_query is swapped with a clean query using the dataset as a source table
     // (it's necessary for datasets to behave like tables opened in simple mode)
     // We need to escape the isDirty check as it will always be true in this case,
     // and the page will always be covered with a 'rerun' overlay.
     // Once the dataset_query changes, the question will loose the "dataset" flag and it'll work normally
-    if (question && isAdHocDatasetQuestion(question, originalQuestion)) {
+    if (question && isAdHocModelQuestion(question, originalQuestion)) {
       return false;
     }
 

--- a/frontend/src/metabase/query_builder/utils.js
+++ b/frontend/src/metabase/query_builder/utils.js
@@ -1,5 +1,4 @@
 import { isSupportedTemplateTagForModel } from "metabase/lib/data-modeling/utils";
-import { getQuestionVirtualTableId } from "metabase/lib/saved-questions";
 import NativeQuery from "metabase-lib/lib/queries/NativeQuery";
 
 // Query Builder Mode
@@ -34,22 +33,6 @@ export function getPathNameFromQueryBuilderMode({
     return `${pathname}/${datasetEditorTab}`;
   }
   return `${pathname}/${queryBuilderMode}`;
-}
-
-// Datasets
-
-export function isAdHocDatasetQuestion(question, originalQuestion) {
-  if (!originalQuestion || !question.isStructured()) {
-    return false;
-  }
-
-  const isDataset = question.isDataset() || originalQuestion.isDataset();
-  const isSameCard = question.id() === originalQuestion.id();
-  const isSelfReferencing =
-    question.query().sourceTableId() ===
-    getQuestionVirtualTableId(originalQuestion.card());
-
-  return isDataset && isSameCard && isSelfReferencing;
 }
 
 function getTemplateTagWithoutSnippetsCount(question) {

--- a/frontend/src/metabase/visualizations/components/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive.jsx
@@ -19,6 +19,7 @@ import {
 } from "metabase/visualizations/lib/table";
 import { getColumnExtent } from "metabase/visualizations/lib/utils";
 import { fieldRefForColumn } from "metabase/lib/dataset";
+import { isAdHocModelQuestionCard } from "metabase/lib/data-modeling/utils";
 import Dimension from "metabase-lib/lib/Dimension";
 
 import _ from "underscore";
@@ -116,7 +117,9 @@ export default class TableInteractive extends Component {
 
     const isDataChange =
       data && nextData && !_.isEqual(data.cols, nextData.cols);
-    const isDatasetStatusChange = card.dataset !== nextCard.dataset;
+    const isDatasetStatusChange =
+      isAdHocModelQuestionCard(nextCard, card) ||
+      isAdHocModelQuestionCard(card, nextCard);
 
     if (isDataChange && !isDatasetStatusChange) {
       this.resetColumnWidths();

--- a/frontend/test/__support__/e2e/commands/api/question.js
+++ b/frontend/test/__support__/e2e/commands/api/question.js
@@ -73,7 +73,11 @@ function question(
     }
 
     if (loadMetadata || visitQuestion) {
-      cy.intercept("POST", `/api/card/${body.id}/query`).as("cardQuery");
+      if (dataset) {
+        cy.intercept("POST", `/api/dataset`).as("cardQuery");
+      } else {
+        cy.intercept("POST", `/api/card/${body.id}/query`).as("cardQuery");
+      }
       const url = dataset ? `/model/${body.id}` : `/question/${body.id}`;
       cy.visit(url);
 


### PR DESCRIPTION
Fixes the FE crash when trying to reorder columns on a model with aggregations.

**Background**
The query builder opens models in "simple mode" by default, so any added filter/breakout, resized column, etc. will create a new question without modifying the model itself (the same way if you just open a raw DB table in the query builder), you can learn more about the implementation in #19101

**Issue**
There were a few bugs around swapping the original model's query with `{ 'source-table': 'card__${MODEL_ID}' }` (like in #19721). The easy way to fix them was to actually use the original mode's query (`/api/card/:id/query` endpoint instead of sending the query object to `/api/dataset`), but use the self-referencing query when composing a new query. Once a query was changed, its `id`, `name`, etc. got removed, so it looked and behaved like a completely new question. [Here's the line doing the swap](https://github.com/metabase/metabase/blob/75d23718428d8efb6bb8a64bb677cca1d511a7de/frontend/src/metabase/query_builder/actions.js#L1235). 

It worked quite well for simple queries but now it fails for more complex ones in some scenarios. The root cause is that the [`QueryVisualization` and its children](https://github.com/metabase/metabase/blob/master/frontend/src/metabase/query_builder/components/QueryVisualization.jsx) use the `series` object pretty heavily, and the `series` object contains the actual query that was run (the original model query).

About the columns reordering scenario:

1. Once you rearrange columns, their order will be stored in `card.visualization_settings["table.columns"]`
2. `"table.columns"` is a list of column objects like `{ name: "ID", fieldRef: ["field", 5, null], enabled: true }`
3. Column reordering is handled in the `TableInteractive` visualization component. Once you move a column, it builds a list to be set as `"table.columns"` and dispatches an action that's doing all the update work
4. `TableInteractive` uses actual query data. So when the query has aggregation fields, it will use `fieldRef: ["aggregation", 0]` as you can easily access the Nth aggregation from the query object
5. But when you're browsing a model in the ad-hoc QB mode, `["aggregation", 0]` doesn't make any sense for the end nested query using a model as it just references it as a `source-table`. Normally, a nested query will use a field literal to refer to the field, like: `["field", "count", { "base-type": "type/Int" }`
6. Column reordering fails because things like `["aggregation", 0]` can't be properly handled in the nested query context

This whole idea looks like a big opportunity for various bugs, so this PR eliminates the query swapping, so we're always running the `{ 'source-table': 'card__${MODEL_ID}' }` query and everything is consistent. A lot has improved in the modeling land since the original "actually use the real query" approach and bugs it was trying to solve were approached in a different way

### To Verify

1. Create a GUI model using some joins and breakouts
2. Try to rearrange the columns
3. It should work the same way as for saved questions

<details>
<summary>You can use this query to reproduce the issue</summary>

It's not necessary to use that many breakouts, just 2-3 of them should be enough

<img width="1049" alt="CleanShot 2022-01-26 at 19 58 59@2x" src="https://user-images.githubusercontent.com/17258145/151220335-29dae18a-f8a6-4f72-a3fa-85b80d9f0d09.png">

</details>

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/151220366-86592543-ecc9-4557-91bb-3fb9fd001481.mov

**After**

https://user-images.githubusercontent.com/17258145/151220502-15ba64c5-9a0e-4853-b329-1a5e6a8f3569.mov


