### PR TITLE
MBQL :expressions should use strings for keys

### DIFF
--- a/docs/developers-guide/driver-changelog.md
+++ b/docs/developers-guide/driver-changelog.md
@@ -1,5 +1,15 @@
 # Driver Interface Changelog
 
+## Metabase 0.43.0
+
+- The `:expressions` map in an MBQL query now uses strings as keys rather than keywords (see . You only need to be
+  concerned with this if you are accessing or manipulating this map directly. Drivers deriving from `:sql`
+  implementing `->honeysql` for `[<driver> :expression]` may need to be updated. A utility function,
+  `metabase.mbql.util/expression-with-name`, has been available since at least Metabase 0.35.0 and handles both types
+  of keys. It is highly recommended that you use this function rather than accessing `:expressions` directly, as doing
+  so can make your driver compatible with both 0.42.0 and with 0.43.0 and newer.
+
+## Metabase 0.42.0
 
 Changes in Metabase 0.42.0 affect drivers that derive from `:sql` (including `:sql-jdbc`).
 Non-SQL drivers likely will require no changes.

--- a/docs/developers-guide/driver-changelog.md
+++ b/docs/developers-guide/driver-changelog.md
@@ -2,12 +2,13 @@
 
 ## Metabase 0.43.0
 
-- The `:expressions` map in an MBQL query now uses strings as keys rather than keywords (see . You only need to be
-  concerned with this if you are accessing or manipulating this map directly. Drivers deriving from `:sql`
-  implementing `->honeysql` for `[<driver> :expression]` may need to be updated. A utility function,
-  `metabase.mbql.util/expression-with-name`, has been available since at least Metabase 0.35.0 and handles both types
-  of keys. It is highly recommended that you use this function rather than accessing `:expressions` directly, as doing
-  so can make your driver compatible with both 0.42.0 and with 0.43.0 and newer.
+- The `:expressions` map in an MBQL query now uses strings as keys rather than keywords (see
+  [#14647](https://github.com/metabase/metabase/issues/14647)). You only need to be concerned with this if you are
+  accessing or manipulating this map directly. Drivers deriving from `:sql` implementing `->honeysql` for `[<driver>
+  :expression]` may need to be updated. A utility function, `metabase.mbql.util/expression-with-name`, has been
+  available since at least Metabase 0.35.0 and handles both types of keys. It is highly recommended that you use this
+  function rather than accessing `:expressions` directly, as doing so can make your driver compatible with both 0.42.0
+  and with 0.43.0 and newer.
 
 ## Metabase 0.42.0
 

--- a/shared/src/metabase/mbql/normalize.cljc
+++ b/shared/src/metabase/mbql/normalize.cljc
@@ -187,11 +187,11 @@
     (normalize-tokens ag-clause :ignore-path)))
 
 (defn- normalize-expressions-tokens
-  "For expressions, we don't want to normalize the name of the expression; keep that as is, but make it a keyword;
+  "For expressions, we don't want to normalize the name of the expression; keep that as is, and make it a string;
    normalize the definitions as normal."
   [expressions-clause]
   (into {} (for [[expression-name definition] expressions-clause]
-             [(keyword expression-name)
+             [(mbql.u/qualified-name expression-name)
               (normalize-tokens definition :ignore-path)])))
 
 (defn- normalize-order-by-tokens

--- a/shared/src/metabase/mbql/schema.cljc
+++ b/shared/src/metabase/mbql/schema.cljc
@@ -1162,8 +1162,7 @@
     (s/optional-key :source-table) SourceTable
     (s/optional-key :aggregation)  (helpers/non-empty [Aggregation])
     (s/optional-key :breakout)     (helpers/non-empty [Field])
-    ;; TODO - expressions keys should be strings; fix this when we get a chance (#14647)
-    (s/optional-key :expressions)  {s/Keyword FieldOrExpressionDef}
+    (s/optional-key :expressions)  {helpers/NonBlankString FieldOrExpressionDef}
     (s/optional-key :fields)       Fields
     (s/optional-key :filter)       Filter
     (s/optional-key :limit)        helpers/IntGreaterThanOrEqualToZero

--- a/shared/src/metabase/mbql/util.cljc
+++ b/shared/src/metabase/mbql/util.cljc
@@ -347,7 +347,7 @@
 
 (s/defn expression-with-name :- mbql.s/FieldOrExpressionDef
   "Return the `Expression` referenced by a given `expression-name`."
-  [inner-query, expression-name :- (s/cond-pre s/Keyword schema.helpers/NonBlankString)]
+  [inner-query expression-name :- (s/cond-pre s/Keyword schema.helpers/NonBlankString)]
   (let [allowed-names [(qualified-name expression-name) (keyword expression-name)]]
     (loop [{:keys [expressions source-query]} inner-query, found #{}]
       (or

--- a/shared/test/metabase/mbql/normalize_test.cljc
+++ b/shared/test/metabase/mbql/normalize_test.cljc
@@ -22,7 +22,7 @@
   [& {:as group-and-input->expected-pairs}]
   (tests 'normalize-tokens #'normalize/normalize-tokens group-and-input->expected-pairs))
 
-(t/deftest normalize-tokens-test
+(t/deftest ^:parallel normalize-tokens-test
   (normalize-tests
     "Query type should get normalized"
     {{:type "NATIVE"}
@@ -64,7 +64,7 @@
 
 ;;; -------------------------------------------------- aggregation ---------------------------------------------------
 
-(t/deftest normalize-aggregations-test
+(t/deftest ^:parallel normalize-aggregations-test
   (normalize-tests
     "Legacy 'rows' aggregations"
     {{:query {"AGGREGATION" "ROWS"}}
@@ -156,7 +156,7 @@
 
 ;;; ---------------------------------------------------- order-by ----------------------------------------------------
 
-(t/deftest normalize-order-by-test
+(t/deftest ^:parallel normalize-order-by-test
   (normalize-tests
     "does order-by get properly normalized?"
     {{:query {"ORDER_BY" [[10 "ASC"]]}}
@@ -174,7 +174,7 @@
 
 ;;; ----------------------------------------------------- filter -----------------------------------------------------
 
-(t/deftest normalize-filter-test
+(t/deftest ^:parallel normalize-filter-test
   (normalize-tests
     "the unit & amount in time interval clauses should get normalized"
     {{:query {"FILTER" ["time-interval" 10 "current" "day"]}}
@@ -211,7 +211,7 @@
 
 ;;; --------------------------------------------------- parameters ---------------------------------------------------
 
-(t/deftest normalize-parmaeters-test
+(t/deftest ^:parallel normalize-parmaeters-test
   (normalize-tests
     "make sure we're not running around trying to normalize the type in native query params"
     {{:type       :native
@@ -244,7 +244,7 @@
                     :target [:dimension [:template-tag "names_list"]]
                     :value  ["=" 10 20]}]}}))
 
-(t/deftest normalize-template-tags-test
+(t/deftest ^:parallel normalize-template-tags-test
   (letfn [(query-with-template-tags [template-tags]
             {:type   :native
              :native {:query         "SELECT COUNT(*) FROM \"PUBLIC\".\"CHECKINS\" WHERE {{checkin_date}}"
@@ -377,7 +377,7 @@
 
 ;;; ------------------------------------------------- source queries -------------------------------------------------
 
-(t/deftest normalize-source-queries-test
+(t/deftest ^:parallel normalize-source-queries-test
   (normalize-tests
     "Make sure token normalization works correctly on source queries"
     {{:database 4
@@ -408,7 +408,7 @@
 
 ;;; ----------------------------------------------------- joins ------------------------------------------------------
 
-(t/deftest normalize-joins-test
+(t/deftest ^:parallel normalize-joins-test
   (normalize-tests
     "do entries in the `:joins` clause get normalized?"
     {{:database 4
@@ -452,7 +452,7 @@
                                                 :fields   [[:field-id 1]
                                                            [:field-literal "MY_FIELD" :type/Integer]]}]}}}}))
 
-(t/deftest normalize-source-query-in-joins-test
+(t/deftest ^:parallel normalize-source-query-in-joins-test
   (t/testing "does a `:source-query` in `:joins` get normalized?"
     (letfn [(query-with-joins [joins]
               {:database 4
@@ -480,7 +480,7 @@
 
 ;;; ----------------------------------------------------- other ------------------------------------------------------
 
-(t/deftest normalize-execution-context-test
+(t/deftest ^:parallel normalize-execution-context-test
   (normalize-tests
     "Does the QueryExecution context get normalized?"
     {{:context "json-download"}
@@ -490,7 +490,7 @@
     {{:context nil}
      {:context nil}}))
 
-(t/deftest params-normalization-test
+(t/deftest ^:parallel params-normalization-test
   (normalize-tests
     ":native :params shouldn't get normalized."
     {{:native {:query  "SELECT * FROM venues WHERE name = ?"
@@ -498,7 +498,7 @@
      {:native {:query  "SELECT * FROM venues WHERE name = ?"
                :params ["Red Medicine"]}}}))
 
-(t/deftest normalize-projections-test
+(t/deftest ^:parallel normalize-projections-test
   (normalize-tests
     "Native :projections shouldn't get normalized."
     {{:type   :native
@@ -507,7 +507,7 @@
       :native {:projections ["_id" "name" "category_id" "latitude" "longitude" "price"]}}}))
 
 ;; this is also covered
-(t/deftest normalize-expressions-test
+(t/deftest ^:parallel normalize-expressions-test
   (normalize-tests
    "Expression names should get normalized to strings."
    {{:query {"expressions" {:abc ["+" 1 2]}
@@ -540,7 +540,7 @@
 (defn- canonicalize-tests {:style/indent 0} [& {:as group->input->expected}]
   (tests 'canonicalize #'normalize/canonicalize group->input->expected))
 
-(t/deftest wrap-implicit-field-id-test
+(t/deftest ^:parallel wrap-implicit-field-id-test
   (t/testing "Does our `wrap-implict-field-id` fn work?"
     (doseq [input [10 [:field 10 nil]]]
       (t/testing (pr-str (list 'wrap-implicit-field-id input))
@@ -550,7 +550,7 @@
       (t/is (= [:field-id 10]
                (#'normalize/wrap-implicit-field-id [:field-id 10]))))))
 
-(t/deftest canonicalize-field-test
+(t/deftest ^:parallel canonicalize-field-test
   (canonicalize-tests
     "If someone accidentally nests `:field` clauses, we should fix it for them."
     {{:query {:fields [[:field [:field 1 {:a 100, :b 200}] {:b 300}]]}}
@@ -566,7 +566,7 @@
 
 ;;; ------------------------------------------------ binning strategy ------------------------------------------------
 
-(t/deftest canonicalize-binning-strategy-test
+(t/deftest ^:parallel canonicalize-binning-strategy-test
   (canonicalize-tests
     "make sure `binning-strategy` wraps implicit Field IDs"
     {{:query {:breakout [[:binning-strategy 10 :bin-width 2000]]}}
@@ -575,7 +575,7 @@
 
 ;;; -------------------------------------------------- aggregation ---------------------------------------------------
 
-(t/deftest canonicalize-aggregations-test
+(t/deftest ^:parallel canonicalize-aggregations-test
   (canonicalize-tests
     "field ID should get wrapped in field-id and ags should be converted to multiple ag syntax"
     {{:query {:aggregation [:count 10]}}
@@ -680,7 +680,7 @@
 
 ;;; ---------------------------------------------------- breakout ----------------------------------------------------
 
-(t/deftest canonicalize-breakout-test
+(t/deftest ^:parallel canonicalize-breakout-test
   (canonicalize-tests
     "implicit Field IDs should get wrapped in [:field-id] in :breakout"
     {{:query {:breakout [10]}}
@@ -702,7 +702,7 @@
 
 ;;; ----------------------------------------------------- fields -----------------------------------------------------
 
-(t/deftest canonicalize-fields-test
+(t/deftest ^:parallel canonicalize-fields-test
   (canonicalize-tests
     "implicit Field IDs should get wrapped in [:field-id] in :fields"
     {{:query {:fields [10]}}
@@ -721,7 +721,7 @@
 
 ;;; ----------------------------------------------------- filter -----------------------------------------------------
 
-(t/deftest canonicalize-filter-test
+(t/deftest ^:parallel canonicalize-filter-test
   (canonicalize-tests
     "implicit Field IDs should get wrapped in [:field-id] in filters"
     {{:query {:filter [:= 10 20]}}
@@ -861,7 +861,7 @@
 
 ;;; ---------------------------------------------------- order-by ----------------------------------------------------
 
-(t/deftest canonicalize-order-by-test
+(t/deftest ^:parallel canonicalize-order-by-test
   (canonicalize-tests
     "ORDER BY: MBQL 95 [field direction] should get translated to MBQL 98+ [direction field]"
     {{:query {:order-by [[[:field-id 10] :asc]]}}
@@ -893,7 +893,7 @@
 
 ;;; ------------------------------------------------- source queries -------------------------------------------------
 
-(t/deftest canonicalize-source-queries-test
+(t/deftest ^:parallel canonicalize-source-queries-test
   (canonicalize-tests
     "Make sure canonicalization works correctly on source queries"
     {{:database 4
@@ -926,7 +926,7 @@
 ;;; |                                          WHOLE-QUERY TRANSFORMATIONS                                           |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(t/deftest whole-query-transformations-test
+(t/deftest ^:parallel whole-query-transformations-test
   (tests 'perform-whole-query-transformations #'normalize/perform-whole-query-transformations
     {(str "If you specify a field in a breakout and in the Fields clause, we should go ahead and remove it from the "
           "Fields clause, because it is (obviously) implied that you should get that Field back.")
@@ -975,7 +975,7 @@
 ;;; |                                              REMOVE EMPTY CLAUSES                                              |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(t/deftest remove-empty-clauses-test
+(t/deftest ^:parallel remove-empty-clauses-test
   (tests 'remove-empty-clauses #'normalize/remove-empty-clauses
     {"empty sequences should get removed"
      {{:x [], :y [100]}
@@ -996,7 +996,7 @@
       {:a {:b 100}, :c {:d nil}}
       {:a {:b 100}}}}))
 
-(t/deftest remove-empty-options-from-field-clause-test
+(t/deftest ^:parallel remove-empty-options-from-field-clause-test
   (tests 'remove-empty-clauses #'normalize/remove-empty-clauses
     {"We should remove empty options maps"
      {[:field 2 {}]
@@ -1028,7 +1028,7 @@
 ;;; |                                            PUTTING IT ALL TOGETHER                                             |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(t/deftest e2e-mbql-95-query-test
+(t/deftest ^:parallel e2e-mbql-95-query-test
   (t/testing "With an ugly MBQL 95 query, does everything get normalized nicely?"
     (t/is (= {:type  :query
               :query {:source-table 10
@@ -1042,7 +1042,7 @@
                                            "filter"       ["and" ["=" 10 ["datetime-field" 20 "as" "day"]]]
                                            "order-by"     [[10 "desc"]]}})))))
 
-(t/deftest e2e-native-query-with-params-test
+(t/deftest ^:parallel e2e-native-query-with-params-test
   (t/testing "let's try doing the full normalization on a native query w/ params"
     (t/is (= {:native     {:query         "SELECT * FROM CATEGORIES WHERE {{names_list}}"
                            :template-tags {"names_list" {:name         "names_list"
@@ -1062,7 +1062,7 @@
                              :target ["dimension" ["template-tag" "names_list"]]
                              :value  ["BBQ" "Bakery" "Bar"]}]})))))
 
-(t/deftest e2e-big-query-with-segments-test
+(t/deftest ^:parallel e2e-big-query-with-segments-test
   (t/testing "let's try normalizing a big query with SEGMENTS"
     (t/is (= {:database 1
               :type     :query
@@ -1080,7 +1080,7 @@
                                          ["SEGMENT" 4]
                                          ["SEGMENT" 5]]}})))))
 
-(t/deftest e2e-source-queries-test
+(t/deftest ^:parallel e2e-source-queries-test
   (t/testing "make sure source queries get normalized properly!"
     (t/is (= {:database 4
               :type     :query
@@ -1100,7 +1100,7 @@
                                                                       :required     true
                                                                       :default      "Widget"}}}}})))))
 
-(t/deftest e2e-rows-aggregation-test
+(t/deftest ^:parallel e2e-rows-aggregation-test
   (t/testing "make sure `rows` aggregations get removed"
     (t/is (= {:database 4
               :type     :query
@@ -1110,7 +1110,7 @@
                :type     :query
                :query    {"source_query" {"source_table" 1, "aggregation" "rows"}}})))))
 
-(t/deftest e2e-parameters-test
+(t/deftest ^:parallel e2e-parameters-test
   (t/testing (str "make sure that parameters get normalized/canonicalized correctly. value should not get normalized, "
                   "but type should; target should do canonicalization for MBQL clauses")
     (t/is (= {:type       :query
@@ -1147,7 +1147,7 @@
                :type "native"
                :parameters []})))))
 
-(t/deftest e2e-source-metadata-test
+(t/deftest ^:parallel e2e-source-metadata-test
   (t/testing "make sure `:source-metadata` gets normalized the way we'd expect:"
     (t/testing "1. Type names should get converted to keywords"
       (t/is (= {:query {:source-metadata
@@ -1196,7 +1196,7 @@
                                                                            "percent-email"  0.0
                                                                            "average-length" 15.63}}}}]}))))))
 
-(t/deftest normalize-nil-values-in-native-maps-test
+(t/deftest ^:parallel normalize-nil-values-in-native-maps-test
   (t/testing "nil values in native query maps (e.g. MongoDB queries) should not get removed during normalization.\n"
     (letfn [(test-normalization [native-query]
               (let [native-source-query (set/rename-keys native-query {:query :native})]
@@ -1225,7 +1225,7 @@
       (t/testing "`nil` values inside native :params shouldn't get removed"
         (test-normalization {:query "SELECT ?" :params [nil]})))))
 
-(t/deftest empty-test
+(t/deftest ^:parallel empty-test
   (t/testing "test a query with :is-empty"
     (t/is (= {:query {:filter [:and
                                [:> [:field 4 nil] 1]
@@ -1239,7 +1239,7 @@
                                                           [:= [:field-id 5] "abc"]
                                                           [:between [:field-id 9] 0 25]]]}})))))
 
-(t/deftest modernize-fields-test
+(t/deftest ^:parallel modernize-fields-test
   (t/testing "some extra tests for Field clause canonicalization to the modern `:field` clause."
     (doseq [[form expected] {[:=
                               [:datetime-field [:joined-field "source" [:field-id 100]] :month]
@@ -1255,7 +1255,7 @@
         (t/is (= expected
                  (#'normalize/canonicalize-mbql-clauses form)))))))
 
-(t/deftest modernize-fields-e2e-test
+(t/deftest ^:parallel modernize-fields-e2e-test
   (t/testing "Should be able to modernize legacy MBQL '95 Field clauses"
     (t/is (= {:database 1
               :type     :query
@@ -1284,7 +1284,7 @@
                                          :aggregation  [[:count]]
                                          :breakout     [:field 3 {:temporal-unit :month, :source-field 4}]}}})))))
 
-(t/deftest normalize-fragment-test
+(t/deftest ^:parallel normalize-fragment-test
   (t/testing "normalize-fragment"
     (t/testing "shouldn't try to do anything crazy non-standard MBQL clauses like `:dimension` (from automagic dashboards)"
       (t/is (= [:time-interval [:dimension "JoinDate"] -30 :day]
@@ -1308,7 +1308,7 @@
                (normalize/normalize-fragment nil
                                              [:field 2 {"temporal-unit" "day"}]))))))
 
-(t/deftest normalize-source-metadata-test
+(t/deftest ^:parallel normalize-source-metadata-test
   (t/testing "normalize-source-metadata"
     (t/testing "should convert legacy field_refs to modern `:field` clauses"
       (t/is (= {:field_ref [:field 1 {:temporal-unit :month}]}
@@ -1319,7 +1319,7 @@
                (normalize/normalize-source-metadata
                 {:field_ref ["field" 1 {:temporal-unit "month"}]}))))))
 
-(t/deftest do-not-normalize-fingerprints-test
+(t/deftest ^:parallel do-not-normalize-fingerprints-test
   (t/testing "Numbers in fingerprints shouldn't get normalized"
     (let [fingerprint {:global {:distinct-count 1, :nil% 0}
                        :type   {:type/Number {:min 1
@@ -1345,7 +1345,7 @@
         (t/is (= query
                  (normalize/normalize query)))))))
 
-(t/deftest error-messages-test
+(t/deftest ^:parallel error-messages-test
   (t/testing "Normalization error messages should be sane"
     (let [bad-query {:database 1
                      :type     :native

--- a/shared/test/metabase/mbql/schema_test.cljc
+++ b/shared/test/metabase/mbql/schema_test.cljc
@@ -3,7 +3,7 @@
             [metabase.mbql.schema :as mbql.s]
             [schema.core :as s]))
 
-(t/deftest field-clause-test
+(t/deftest ^:parallel field-clause-test
   (t/testing "Make sure our schema validates `:field` clauses correctly"
     (t/are [clause expected] (= expected
                                 (not (s/check mbql.s/field clause)))
@@ -27,7 +27,7 @@
       [:field 1 {:binning {:strategy :default}}]                              true
       [:field 1 {:binning {:strategy :fake}}]                                 false)))
 
-(t/deftest validate-template-tag-names-test
+(t/deftest ^:parallel validate-template-tag-names-test
   (t/testing "template tags with mismatched keys/`:names` in definition should be disallowed\n"
     (let [correct-query {:database 1
                          :type     :native

--- a/shared/test/metabase/mbql/util/match_test.cljc
+++ b/shared/test/metabase/mbql/util/match_test.cljc
@@ -2,7 +2,7 @@
   (:require [clojure.test :as t]
             [metabase.mbql.util.match :as mbql.match]))
 
-(t/deftest basic-match-test
+(t/deftest ^:parallel basic-match-test
   (t/testing "can we use `match` to find the instances of a clause?"
     (t/is (= [[:field 10 nil]
               [:field 20 nil]]
@@ -11,13 +11,13 @@
                                                  [:field 20 nil]]}}
                [:field & _])))))
 
-(t/deftest match-keywords-test
+(t/deftest ^:parallel match-keywords-test
   (t/testing "is `match` nice enought to automatically wrap raw keywords in appropriate patterns for us?"
     (t/is (= [[:field 1 nil]]
              (mbql.match/match {:fields [[:field 1 nil] [:expression "wow"]]}
                :field)))))
 
-(t/deftest match-set-of-keywords-tes
+(t/deftest ^:parallel match-set-of-keywords-tes
   (t/testing "if we pass a set of keywords, will that generate an appropriate pattern to match multiple clauses as well?"
     (t/is (= [[:field 1 nil]
               [:field 3 {:source-field 2}]
@@ -28,7 +28,7 @@
                                          [:expression "wow"]]}
                #{:field :expression})))))
 
-(t/deftest match-dont-include-subclauses-test
+(t/deftest ^:parallel match-dont-include-subclauses-test
   (t/testing "`match` shouldn't include subclauses of matches"
     (t/is (= [[:field 1 nil]
               [:field 3 {:source-field 2}]]
@@ -49,7 +49,7 @@
               [:field "Wow" {:base-type :type/*}]]
    :fields   [[:field 40 {:source-field 30}]]})
 
-(t/deftest match-result-paramater-test
+(t/deftest ^:parallel match-result-paramater-test
   (t/testing "can we use the optional `result` parameter to find return something other than the whole clause?"
     (t/is (= [41]
              ;; return just the dest IDs of Fields in a fk-> clause
@@ -59,12 +59,12 @@
     (t/is (= [10 20]
              (mbql.match/match (:breakout a-query) [:field id nil] id)))))
 
-(t/deftest match-return-nil-for-empty-sequences-test
+(t/deftest ^:parallel match-return-nil-for-empty-sequences-test
   (t/testing "match should return `nil` if there are no matches so you don't need to call `seq`"
     (t/is (= nil
              (mbql.match/match {} [:field _ _] :minute)))))
 
-(t/deftest match-guard-test
+(t/deftest ^:parallel match-guard-test
   (t/testing "can we `:guard` a pattern?"
     (t/is (= [[:field 2 nil]]
              (let [a-field-id 2]
@@ -83,7 +83,7 @@
             [:field 2 {:temporal-unit :day}]
             [:field 4 {:source-field 3, :temporal-unit :month}]]})
 
-(t/deftest match-&match-test
+(t/deftest ^:parallel match-&match-test
   (t/testing (str "Ok, if we want to use predicates but still return the whole match, can we use the anaphoric `&match` "
                   "symbol to return the whole thing?")
     (t/is (= [[:field 1 nil]
@@ -95,7 +95,7 @@
                  (when some-pred?
                    &match)))))))
 
-(t/deftest match-&parents-test
+(t/deftest ^:parallel match-&parents-test
   (t/testing "can we use the anaphoric `&parents` symbol to examine the parents of the collection?"
     (t/is (= [[:field 1 nil]]
              (mbql.match/match {:filter [[:time-interval [:field 1 nil] :current :month]
@@ -105,7 +105,7 @@
                  &match))))))
 
 #?(:clj
-   (t/deftest match-by-class-test
+   (t/deftest ^:parallel match-by-class-test
      (t/testing "can we match using a CLASS?"
        (t/is (= [#inst "2018-10-08T00:00:00.000-00:00"]
                 (mbql.match/match [[:field 1 nil]
@@ -114,7 +114,7 @@
                                    4000]
                   java.util.Date))))))
 
-(t/deftest match-by-predicate-test
+(t/deftest ^:parallel match-by-predicate-test
   (t/testing "can we match using a PREDICATE?"
     (t/is (= [4000 5000]
              ;; find the integer args to `:=` clauses that are not inside `:field-id` clauses
@@ -140,7 +140,7 @@
                (i :guard #(integer? %))
                (inc i))))))
 
-(t/deftest match-map-test
+(t/deftest ^:parallel match-map-test
   (t/testing "can we match against a map?"
     (t/is (= ["card__1847"]
              (let [x {:source-table "card__1847"}]
@@ -148,7 +148,7 @@
                  (m :guard (every-pred map? (comp string? :source-table)))
                  (:source-table m)))))))
 
-(t/deftest match-sequence-of-maps-test
+(t/deftest ^:parallel match-sequence-of-maps-test
   (t/testing "how about a sequence of maps?"
     (t/is (= ["card__1847"]
              (let [x [{:source-table "card__1847"}]]
@@ -156,14 +156,14 @@
                  (m :guard (every-pred map? (comp string? :source-table)))
                  (:source-table m)))))))
 
-(t/deftest match-recur-inside-pattern-test
+(t/deftest ^:parallel match-recur-inside-pattern-test
   (t/testing "can we use `recur` inside a pattern?"
     (t/is (= [[0 :month]]
              (mbql.match/match {:filter [:time-interval [:field 1 nil] :current :month]}
                [:time-interval field :current unit] (recur [:time-interval field 0 unit])
                [:time-interval _     n        unit] [n unit])))))
 
-(t/deftest match-short-circut-test
+(t/deftest ^:parallel match-short-circut-test
   (t/testing "can we short-circut a match to prevent recursive matching?"
     (t/is (= [10]
              (mbql.match/match [[:field 10 nil]
@@ -171,7 +171,7 @@
                [:field id nil] id
                [_ [:field-id & _] & _] nil)))))
 
-(t/deftest match-list-with-guard-clause-test
+(t/deftest ^:parallel match-list-with-guard-clause-test
   (t/testing "can we use a list with a :guard clause?"
     (t/is (= [10 20]
              (mbql.match/match {:query {:filter [:=
@@ -179,7 +179,7 @@
                                                  [:field 20 nil]]}}
                (id :guard int?) id)))))
 
-(t/deftest basic-replace-test
+(t/deftest ^:parallel basic-replace-test
   (t/testing "can we use `replace` to replace a specific clause?"
     (t/is (= {:breakout [[:field 10 {:temporal-unit :day}]
                          [:field 20 {:temporal-unit :day}]
@@ -189,7 +189,7 @@
                [:field id nil]
                [:field id {:temporal-unit :day}])))))
 
-(t/deftest basic-replace-in-test
+(t/deftest ^:parallel basic-replace-in-test
   (t/testing "can we wrap the pattern in a map to restrict what gets replaced?"
     (t/is (= {:breakout [[:field 10 {:temporal-unit :day}]
                          [:field 20 {:temporal-unit :day}]
@@ -199,7 +199,7 @@
                [:field (id :guard integer?) nil]
                [:field id {:temporal-unit :day}])))))
 
-(t/deftest replace-multiple-patterns-test
+(t/deftest ^:parallel replace-multiple-patterns-test
   (t/testing "can we use multiple patterns at the same time?!"
     (t/is (= {:breakout [[:field 10 {:temporal-unit :day}]
                          [:field 20 {:temporal-unit :day}]
@@ -212,7 +212,7 @@
                [:field (id :guard string?) opts]
                [:field id (assoc opts :temporal-unit :month)])))))
 
-(t/deftest replace-field-ids-test
+(t/deftest ^:parallel replace-field-ids-test
   (t/testing "can we use `replace` to replace the ID of the Field in :field clauses?"
     (t/is (= {:breakout [[:field 10 nil]
                          [:field 20 nil]
@@ -222,7 +222,7 @@
                [:field 40 opts]
                [:field 100 opts])))))
 
-(t/deftest replace-fix-bad-mbql-test
+(t/deftest ^:parallel replace-fix-bad-mbql-test
   (t/testing "can we use `replace` to fix (legacy) `fk->` clauses where both args are unwrapped IDs?"
     (t/is (= {:query {:fields [[:fk-> [:field 1 nil] [:field 2 nil]]
                                [:fk-> [:field 3 nil] [:field 4 nil]]]}}
@@ -233,24 +233,24 @@
                  [:fk-> (source :guard integer?) (dest :guard integer?)]
                  [:fk-> [:field source nil] [:field dest nil]])))))
 
-(t/deftest replace-raw-keyword-patterns-test
+(t/deftest ^:parallel replace-raw-keyword-patterns-test
   (t/testing "does `replace` accept a raw keyword as the pattern the way `match` does?"
     (t/is (= {:fields ["WOW" "WOW" "WOW"]}
              (mbql.match/replace another-query :field "WOW")))))
 
-(t/deftest replace-set-of-keywords-test
+(t/deftest ^:parallel replace-set-of-keywords-test
   (t/testing "does `replace` accept a set of keywords the way `match` does?"
     (t/is (= {:fields ["WOW" "WOW" "WOW"]}
              (mbql.match/replace another-query #{:field :field-id} "WOW")))))
 
-(t/deftest replace-&match-test
+(t/deftest ^:parallel replace-&match-test
   (t/testing "can we use the anaphor `&match` to look at the entire match?"
     (t/is (= {:fields [[:field 1 nil]
                        [:magical-field [:field 2 {:temporal-unit :day}]]
                        [:magical-field [:field 4 {:source-field 3, :temporal-unit :month}]]]}
              (mbql.match/replace another-query [:field _ (_ :guard :temporal-unit)] [:magical-field &match])))))
 
-(t/deftest replace-&parents-test
+(t/deftest ^:parallel replace-&parents-test
   (t/testing "can we use the anaphor `&parents` to look at the parents of the match?"
     (t/is (= {:fields [[:a "WOW"]
                        [:b 200]]}
@@ -263,7 +263,7 @@
                  &match))))))
 
 #?(:clj
-   (t/deftest replace-by-class-test
+   (t/deftest ^:parallel replace-by-class-test
      (t/testing "can we replace using a CLASS?"
        (t/is (= [[:field 1 nil]
                  [:field 2 nil]
@@ -276,7 +276,7 @@
                   java.util.Date
                   [:timestamp &match]))))))
 
-(t/deftest replace-by-predicate-test
+(t/deftest ^:parallel replace-by-predicate-test
   (t/testing "can we replace using a PREDICATE?"
     (t/is (= {:filter [:and
                        [:= [:field nil nil] 4000.0]
@@ -289,7 +289,7 @@
                (when (= := (last &parents))
                  (float &match)))))))
 
-(t/deftest complex-replace-test
+(t/deftest ^:parallel complex-replace-test
   (t/testing "can we do fancy stuff like remove all the filters that use datetime fields from a query?"
     (t/is (= [:and nil [:= [:field 100 nil] 20]]
              (mbql.match/replace [:and
@@ -299,7 +299,7 @@
                                   [:= [:field 100 nil] 20]]
                [_ [:field _ (_ :guard :temporal-unit)] & _] nil)))))
 
-(t/deftest replace-short-circut-test
+(t/deftest ^:parallel replace-short-circut-test
   (t/testing (str "can we use short-circuting patterns to do something tricky like only replace `:field-id` clauses that "
                   "aren't wrapped by other clauses?")
     (t/is (= [[:field 10 {:temporal-unit :day}]

--- a/shared/test/metabase/mbql/util_test.cljc
+++ b/shared/test/metabase/mbql/util_test.cljc
@@ -696,15 +696,33 @@
 
 (t/deftest expression-with-name-test
   (t/is (= [:+ 1 1]
-           (mbql.u/expression-with-name {:expressions  {:two [:+ 1 1]}
+           (mbql.u/expression-with-name {:expressions  {"two" [:+ 1 1]}
                                          :source-table 1}
                                         "two")))
 
   (t/testing "Make sure `expression-with-name` knows how to reach into the parent query if need be"
     (t/is (= [:+ 1 1]
+             (mbql.u/expression-with-name {:source-query {:expressions  {"two" [:+ 1 1]}
+                                                          :source-table 1}}
+                                          "two"))))
+
+  (t/testing "Should work if passed in a keyword as well"
+    (t/is (= [:+ 1 1]
+             (mbql.u/expression-with-name {:source-query {:expressions  {"two" [:+ 1 1]}
+                                                          :source-table 1}}
+                                          :two))))
+
+  (t/testing "Should work if the key in the expression map is a keyword in pre-Metabase 43 query maps"
+    (t/is (= [:+ 1 1]
              (mbql.u/expression-with-name {:source-query {:expressions  {:two [:+ 1 1]}
                                                           :source-table 1}}
-                                          "two")))))
+                                          "two"))))
+
+  (t/testing "Should throw an Exception if expression does not exist"
+    (t/is (thrown-with-msg?
+           #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core.ExceptionInfo)
+           #"No expression named 'wow'"
+           (mbql.u/expression-with-name {} "wow")))))
 
 (t/deftest update-field-options-test
   (t/is (= [:field 1 {:wow true}]

--- a/shared/test/metabase/mbql/util_test.cljc
+++ b/shared/test/metabase/mbql/util_test.cljc
@@ -721,7 +721,7 @@
   (t/testing "Should throw an Exception if expression does not exist"
     (t/is (thrown-with-msg?
            #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core.ExceptionInfo)
-           #"No expression named 'wow'"
+           #"No expression named"
            (mbql.u/expression-with-name {} "wow")))))
 
 (t/deftest ^:parallel update-field-options-test

--- a/shared/test/metabase/mbql/util_test.cljc
+++ b/shared/test/metabase/mbql/util_test.cljc
@@ -6,7 +6,7 @@
 
 (comment metabase.types/keep-me)
 
-(t/deftest simplify-compound-filter-test
+(t/deftest ^:parallel simplify-compound-filter-test
   (t/is (= [:= [:field 1 nil] 2]
            (mbql.u/simplify-compound-filter [:and [:= [:field 1 nil] 2]]))
         "can `simplify-compound-filter` fix `and` or `or` with only one arg?")
@@ -110,7 +110,7 @@
     (t/is (= [:= [:field 1 nil] nil]
              (mbql.u/simplify-compound-filter [:and nil [:= [:field 1 nil] nil]])))))
 
-(t/deftest add-order-by-clause-test
+(t/deftest ^:parallel add-order-by-clause-test
   (t/testing "can we add an order-by clause to a query?"
     (t/is (= {:source-table 1, :order-by [[:asc [:field 10 nil]]]}
              (mbql.u/add-order-by-clause {:source-table 1} [:asc [:field 10 nil]])))
@@ -143,7 +143,7 @@
                                             :order-by     [[:asc [:field 10 nil]]]}
                                            [:asc [:field 10 {:temporal-unit :day}]]))))))
 
-(t/deftest combine-filter-clauses-test
+(t/deftest ^:parallel combine-filter-clauses-test
   (t/is (= [:and [:= [:field 1 nil] 100] [:= [:field 2 nil] 200]]
            (mbql.u/combine-filter-clauses
             [:= [:field 1 nil] 100]
@@ -173,7 +173,7 @@
              [:= [:field 4 nil] 300]]))
         "Should be able to combine multiple compound clauses"))
 
-(t/deftest add-filter-clause-test
+(t/deftest ^:parallel add-filter-clause-test
   (t/is (= {:database 1
             :type     :query
             :query    {:source-table 1
@@ -186,7 +186,7 @@
             [:= [:field 2 nil] 200]))
         "Should be able to add a filter clause to a query"))
 
-(t/deftest desugar-time-interval-test
+(t/deftest ^:parallel desugar-time-interval-test
   (t/is (= [:between
             [:field 1 {:temporal-unit :month}]
             [:relative-datetime 1 :month]
@@ -228,7 +228,7 @@
            (mbql.u/desugar-filter-clause [:time-interval [:field 1 nil] :current :week]))
         "keywords like `:current` should work correctly"))
 
-(t/deftest desugar-time-interval-with-expression-test
+(t/deftest ^:parallel desugar-time-interval-with-expression-test
   (t/is (= [:between
             [:expression "CC"]
             [:relative-datetime 1 :month]
@@ -270,7 +270,7 @@
            (mbql.u/desugar-filter-clause [:time-interval [:expression "CC"] :current :week]))
         "keywords like `:current` should work correctly"))
 
-(t/deftest desugar-relative-datetime-with-current-test
+(t/deftest ^:parallel desugar-relative-datetime-with-current-test
   (t/testing "when comparing `:relative-datetime`to `:field`, it should take the temporal unit of the `:field`"
     (t/is (= [:=
               [:field 1 {:temporal-unit :minute}]
@@ -296,7 +296,7 @@
                [:field 1 {:temporal-unit :week, :binning {:strategy :default}}]
                [:relative-datetime :current]])))))
 
-(t/deftest desugar-other-filter-clauses-test
+(t/deftest ^:parallel desugar-other-filter-clauses-test
   (t/testing "desugaring := and :!= with extra args"
     (t/is (= [:or
               [:= [:field 1 nil] 2]
@@ -332,7 +332,7 @@
               [:!= [:field 1 nil] ""]]
              (mbql.u/desugar-filter-clause [:not-empty [:field 1 nil]])))))
 
-(t/deftest desugar-does-not-contain-test
+(t/deftest ^:parallel desugar-does-not-contain-test
   (t/testing "desugaring does-not-contain without options"
     (t/is (= [:not [:contains [:field 1 nil] "ABC"]]
              (mbql.u/desugar-filter-clause [:does-not-contain [:field 1 nil] "ABC"]))))
@@ -340,7 +340,7 @@
     (t/is (= [:not [:contains [:field 1 nil] "ABC" {:case-sensitive false}]]
              (mbql.u/desugar-filter-clause [:does-not-contain [:field 1 nil] "ABC" {:case-sensitive false}])))))
 
-(t/deftest negate-simple-filter-clause-test
+(t/deftest ^:parallel negate-simple-filter-clause-test
   (t/testing :=
     (t/is (= [:!= [:field 1 nil] 10]
              (mbql.u/negate-filter-clause [:= [:field 1 nil] 10]))))
@@ -374,7 +374,7 @@
     (t/is (= [:not [:ends-with [:field 1 nil] "ABC"]]
              (mbql.u/negate-filter-clause [:ends-with [:field 1 nil] "ABC"])))))
 
-(t/deftest negate-compund-filter-clause-test
+(t/deftest ^:parallel negate-compund-filter-clause-test
   (t/testing :not
     (t/is (= [:= [:field 1 nil] 10]
              (mbql.u/negate-filter-clause [:not [:= [:field 1 nil] 10]]))
@@ -396,7 +396,7 @@
                [:!= [:field 1 nil] 10]
                [:!= [:field 2 nil] 20]])))))
 
-(t/deftest negate-syntactic-sugar-filter-clause-test
+(t/deftest ^:parallel negate-syntactic-sugar-filter-clause-test
   (t/testing "= with extra args"
     (t/is (= [:and
               [:!= [:field 1 nil] 10]
@@ -437,7 +437,7 @@
              (mbql.u/negate-filter-clause
               [:inside [:field 1 nil] [:field 2 nil] 10.0 -20.0 -10.0 20.0])))))
 
-(t/deftest join->source-table-id-test
+(t/deftest ^:parallel join->source-table-id-test
   (let [join {:strategy  :left-join
               :condition [:=
                           [:field 48 nil]
@@ -460,7 +460,7 @@
               :aggregation  [[:avg [:field 1 nil]]
                              [:max [:field 1 nil]]]}})
 
-(t/deftest aggregation-at-index-test
+(t/deftest ^:parallel aggregation-at-index-test
   (doseq [[input expected] {[0]   [:avg [:field 1 nil]]
                             [1]   [:max [:field 1 nil]]
                             [0 0] [:avg [:field 1 nil]]
@@ -473,7 +473,7 @@
 
 ;;; --------------------------------- Unique names & transforming ags to have names ----------------------------------
 
-(t/deftest uniquify-names
+(t/deftest ^:parallel uniquify-names
   (t/testing "can we generate unique names?"
     (t/is (= ["count" "sum" "count_2" "count_3"]
              (mbql.u/uniquify-names ["count" "sum" "count" "count"]))))
@@ -487,7 +487,7 @@
     (t/is (= ["" "_2"]
              (mbql.u/uniquify-names ["" ""])))))
 
-(t/deftest uniquify-named-aggregations-test
+(t/deftest ^:parallel uniquify-named-aggregations-test
   (t/is (= [[:aggregation-options [:count] {:name "count"}]
             [:aggregation-options [:sum [:field 1 nil]] {:name "sum"}]
             [:aggregation-options [:count] {:name "count_2"}]
@@ -507,7 +507,7 @@
                [:aggregation-options [:count] {:name "count"}]
                [:aggregation-options [:count] {:name "count_2"}]])))))
 
-(t/deftest pre-alias-aggregations-test
+(t/deftest ^:parallel pre-alias-aggregations-test
   (letfn [(simple-ag->name [[ag-name]]
             (name ag-name))]
     (t/testing "can we wrap all of our aggregation clauses in `:named` clauses?"
@@ -589,7 +589,7 @@
                     [:sum [:field 1 nil]]
                     [:aggregation-options [:sum [:field 1 nil]] {:name "sum_2", :display-name "Sum of Field 1"}]])))))))
 
-(t/deftest unique-name-generator-test
+(t/deftest ^:parallel unique-name-generator-test
   (t/testing "Can we get a simple unique name generator"
     (t/is (= ["count" "sum" "count_2" "count_2_2"]
              (map (mbql.u/unique-name-generator) ["count" "sum" "count" "count_2"]))))
@@ -622,7 +622,7 @@
 
 ;;; --------------------------------------------- query->max-rows-limit ----------------------------------------------
 
-(t/deftest query->max-rows-limit-test
+(t/deftest ^:parallel query->max-rows-limit-test
   (doseq [[group query->expected]
           {"should return `:limit` if set"
            {{:database 1, :type :query, :query {:source-table 1, :limit 10}} 10}
@@ -686,7 +686,7 @@
           (t/is (= expected
                    (mbql.u/query->max-rows-limit query))))))))
 
-(t/deftest datetime-arithmetics?-test
+(t/deftest ^:parallel datetime-arithmetics?-test
   (t/is (mbql.u/datetime-arithmetics?
          [:+ [:field-id 13] [:interval -1 :month]]))
   (t/is (mbql.u/datetime-arithmetics?
@@ -694,7 +694,7 @@
   (t/is (not (mbql.u/datetime-arithmetics?
               [:+ [:field-id 13] 3]))))
 
-(t/deftest expression-with-name-test
+(t/deftest ^:parallel expression-with-name-test
   (t/is (= [:+ 1 1]
            (mbql.u/expression-with-name {:expressions  {"two" [:+ 1 1]}
                                          :source-table 1}
@@ -724,7 +724,7 @@
            #"No expression named 'wow'"
            (mbql.u/expression-with-name {} "wow")))))
 
-(t/deftest update-field-options-test
+(t/deftest ^:parallel update-field-options-test
   (t/is (= [:field 1 {:wow true}]
            (mbql.u/update-field-options [:field 1 nil] assoc :wow true)
            (mbql.u/update-field-options [:field 1 {}] assoc :wow true)

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -234,14 +234,10 @@
 
 (defmethod ->honeysql [:sql :expression]
   [driver [_ expression-name {::add/keys [source-table source-alias]} :as clause]]
-  (when-not (get-in *inner-query* [:expressions (keyword expression-name)])
-    (throw (ex-info (tru "No expression named {0} at this level of the query" (pr-str expression-name))
-                    {:type       qp.error-type/invalid-query
-                     :expression clause
-                     :query      *inner-query*})))
-  (->honeysql driver (if (= source-table ::add/source)
-                       (apply hx/identifier :field source-query-alias source-alias)
-                       (mbql.u/expression-with-name *inner-query* expression-name))))
+  (let [expression-definition (mbql.u/expression-with-name *inner-query* expression-name)]
+    (->honeysql driver (if (= source-table ::add/source)
+                         (apply hx/identifier :field source-query-alias source-alias)
+                         expression-definition))))
 
 (defn semantic-type->unix-timestamp-unit
   "Translates coercion types like `:Coercion/UNIXSeconds->DateTime` to the corresponding unit of time to use in

--- a/src/metabase/query_processor/util/nest_query.clj
+++ b/src/metabase/query_processor/util/nest_query.clj
@@ -49,12 +49,8 @@
 (defn- raise-source-query-expression-ref
   "Convert an `:expression` reference from a source query into an appropriate `:field` clause for use in the surrounding
   query."
-  [{:keys [expressions source-query], :as query} [_ expression-name opts :as clause]]
-  (let [expression-definition        (or (get expressions (keyword expression-name))
-                                         (throw (ex-info (tru "No expression named {0}" (pr-str expression-name))
-                                                         {:type            qp.error-type/invalid-query
-                                                          :expression-name expression-name
-                                                          :query           query})))
+  [{:keys [source-query], :as query} [_ expression-name opts :as clause]]
+  (let [expression-definition        (mbql.u/expression-with-name query expression-name)
         {base-type :base_type}       (some-> expression-definition annotate/infer-expression-type)
         {::add/keys [desired-alias]} (mbql.u/match-one source-query
                                        [:expression (_ :guard (partial = expression-name)) source-opts]

--- a/src/metabase/query_processor/util/nest_query.clj
+++ b/src/metabase/query_processor/util/nest_query.clj
@@ -9,12 +9,10 @@
             [metabase.api.common :as api]
             [metabase.mbql.util :as mbql.u]
             [metabase.plugins.classloader :as classloader]
-            [metabase.query-processor.error-type :as qp.error-type]
             [metabase.query-processor.middleware.annotate :as annotate]
             [metabase.query-processor.store :as qp.store]
             [metabase.query-processor.util.add-alias-info :as add]
-            [metabase.util :as u]
-            [metabase.util.i18n :refer [tru]]))
+            [metabase.util :as u]))
 
 (defn- joined-fields [inner-query]
   (m/distinct-by

--- a/src/metabase/transforms/core.clj
+++ b/src/metabase/transforms/core.clj
@@ -62,8 +62,7 @@
     (-> query
         (assoc :expressions (->> expressions
                                  keys
-                                 (select-keys (get-in bindings [name :dimensions]))
-                                 (m/map-keys keyword)))
+                                 (select-keys (get-in bindings [name :dimensions]))))
         (update :fields concat (for [expression (keys expressions)]
                                  [:expression expression])))
     query))

--- a/test/metabase/query_processor/util/add_alias_info_test.clj
+++ b/test/metabase/query_processor/util/add_alias_info_test.clj
@@ -160,13 +160,13 @@
   (mt/dataset sample-dataset
     (is (query= (mt/mbql-query products
                   {:source-table $$products
-                   :expressions  {:CATEGORY [:concat
-                                             [:field %category
-                                              {::add/source-table  $$products
-                                               ::add/source-alias  "CATEGORY"
-                                               ::add/desired-alias "CATEGORY"
-                                               ::add/position      0}]
-                                             "2"]}
+                   :expressions  {"CATEGORY" [:concat
+                                              [:field %category
+                                               {::add/source-table  $$products
+                                                ::add/source-alias  "CATEGORY"
+                                                ::add/desired-alias "CATEGORY"
+                                                ::add/position      0}]
+                                              "2"]}
                    :fields       [[:field %category {::add/source-table  $$products
                                                      ::add/source-alias  "CATEGORY"
                                                      ::add/desired-alias "CATEGORY"
@@ -176,7 +176,7 @@
                    :limit        1})
                 (add-alias-info
                  (mt/mbql-query products
-                   {:expressions {:CATEGORY [:concat [:field %category nil] "2"]}
+                   {:expressions {"CATEGORY" [:concat [:field %category nil] "2"]}
                     :fields      [[:field %category nil]
                                   [:expression "CATEGORY"]]
                     :limit       1}))))))
@@ -258,8 +258,8 @@
                    [:expression "price_divided_by_big_price"] 2})
                 (#'add/selected-clauses
                  (mt/$ids venues
-                   {:expressions {:big_price                  [:+ $price 2]
-                                  :price_divided_by_big_price [:/ $price [:expression "big_price"]]}
+                   {:expressions {"big_price"                  [:+ $price 2]
+                                  "price_divided_by_big_price" [:/ $price [:expression "big_price"]]}
                     :fields      [$price
                                   [:expression "big_price"]
                                   [:expression "price_divided_by_big_price"]]
@@ -279,8 +279,8 @@
                                                   {::add/position      2
                                                    ::add/desired-alias "price_divided_by_big_price"}]]
                   {:source-table $$venues
-                   :expressions  {:big_price                  [:+ price 2]
-                                  :price_divided_by_big_price [:/ price big-price]}
+                   :expressions  {"big_price"                  [:+ price 2]
+                                  "price_divided_by_big_price" [:/ price big-price]}
                    :fields       [price
                                   big-price
                                   price-divided-by-big-price]
@@ -288,8 +288,8 @@
               (:query
                (add-alias-info
                 (mt/mbql-query venues
-                  {:expressions {:big_price                  [:+ $price 2]
-                                 :price_divided_by_big_price [:/ $price [:expression "big_price"]]}
+                  {:expressions {"big_price"                  [:+ $price 2]
+                                 "price_divided_by_big_price" [:/ $price [:expression "big_price"]]}
                    :fields      [$price
                                  [:expression "big_price"]
                                  [:expression "price_divided_by_big_price"]]
@@ -384,7 +384,7 @@
                                                                      ::add/desired-alias "COOL.PRICE"
                                                                      ::add/position      0}]]
                                            {:source-table $$venues
-                                            :expressions  {:double_price [:* price 2]}
+                                            :expressions  {"double_price" [:* price 2]}
                                             :fields       [price
                                                            [:expression "double_price" {::add/desired-alias "COOL.double_price"
                                                                                         ::add/position      1}]]
@@ -407,7 +407,7 @@
                              :order-by    [[:asc double-price]]})))
                     (-> (mt/mbql-query venues
                           {:source-query {:source-table $$venues
-                                          :expressions  {:double_price [:* $price 2]}
+                                          :expressions  {"double_price" [:* $price 2]}
                                           :fields       [$price
                                                          [:expression "double_price"]]
                                           :limit        1}
@@ -471,7 +471,7 @@
 
 (deftest uniquify-aggregation-names-text
   (is (query= (mt/mbql-query checkins
-                {:expressions {:count [:+ 1 1]}
+                {:expressions {"count" [:+ 1 1]}
                  :breakout    [[:expression "count" {::add/desired-alias "count"
                                                      ::add/position      0}]]
                  :aggregation [[:aggregation-options [:count] {:name               "count_2"

--- a/test/metabase/query_processor/util/nest_query_test.clj
+++ b/test/metabase/query_processor/util/nest_query_test.clj
@@ -29,11 +29,11 @@
 (deftest nest-expressions-test
   (is (query= (mt/$ids venues
                 {:source-query {:source-table $$venues
-                                :expressions  {:double_price [:* [:field %price {::add/source-table  $$venues
-                                                                                 ::add/source-alias  "PRICE"
-                                                                                 ::add/desired-alias "PRICE"
-                                                                                 ::add/position      5}]
-                                                              2]}
+                                :expressions  {"double_price" [:* [:field %price {::add/source-table  $$venues
+                                                                                  ::add/source-alias  "PRICE"
+                                                                                  ::add/desired-alias "PRICE"
+                                                                                  ::add/position      5}]
+                                                               2]}
                                 :fields       [[:field %id          {::add/source-table  $$venues
                                                                      ::add/source-alias  "ID"
                                                                      ::add/desired-alias "ID"
@@ -78,7 +78,7 @@
                                                       ::add/position      0}]]]})
               (nest-expressions
                (mt/mbql-query venues
-                 {:expressions {:double_price [:* $price 2]}
+                 {:expressions {"double_price" [:* $price 2]}
                   :breakout    [$price]
                   :aggregation [[:count]]
                   :fields      [[:expression "double_price"]]})))))
@@ -87,12 +87,12 @@
   (testing "Other `:fields` besides the `:expressions` should be preserved in the top level"
     (is (query= (mt/$ids checkins
                   {:source-query {:source-table $$checkins
-                                  :expressions  {:double_id [:*
-                                                             [:field %checkins.id {::add/source-table  $$checkins
-                                                                                   ::add/source-alias  "ID"
-                                                                                   ::add/desired-alias "ID"
-                                                                                   ::add/position      0}]
-                                                             2]}
+                                  :expressions  {"double_id" [:*
+                                                              [:field %checkins.id {::add/source-table  $$checkins
+                                                                                    ::add/source-alias  "ID"
+                                                                                    ::add/desired-alias "ID"
+                                                                                    ::add/position      0}]
+                                                              2]}
                                   :fields       [[:field %id {::add/source-table  $$checkins
                                                               ::add/source-alias  "ID"
                                                               ::add/desired-alias "ID"
@@ -132,7 +132,7 @@
                    :limit        1})
                 (nest-expressions
                  (mt/mbql-query checkins
-                   {:expressions {:double_id [:* $id 2]}
+                   {:expressions {"double_id" [:* $id 2]}
                     :fields      [[:expression "double_id"]
                                   !day.date
                                   !month.date]
@@ -142,7 +142,7 @@
   (testing "Make sure the nested version of the query doesn't mix up expressions if we have ones that reference others"
     (is (query= (mt/$ids venues
                   {:source-query {:source-table $$venues
-                                  :expressions  {:big_price
+                                  :expressions  {"big_price"
                                                  [:+
                                                   [:field %price {::add/position      5
                                                                   ::add/source-table  $$venues
@@ -150,7 +150,7 @@
                                                                   ::add/desired-alias "PRICE"}]
                                                   2]
 
-                                                 :my_cool_new_field
+                                                 "my_cool_new_field"
                                                  [:/
                                                   [:field %price {::add/position      5
                                                                   ::add/source-table  $$venues
@@ -196,8 +196,8 @@
                    :limit    3})
                 (nest-expressions
                  (mt/mbql-query venues
-                   {:expressions {:big_price         [:+ $price 2]
-                                  :my_cool_new_field [:/ $price [:expression "big_price"]]}
+                   {:expressions {"big_price"         [:+ $price 2]
+                                  "my_cool_new_field" [:/ $price [:expression "big_price"]]}
                     :fields      [[:expression "my_cool_new_field"]]
                     :order-by    [[:asc $id]]
                     :limit       3}))))))
@@ -207,9 +207,9 @@
                 "names correctly.")
     (let [query (mt/mbql-query venues
                   {:source-query {:source-table $$venues
-                                  :expressions  {:x [:* $price 2]}
+                                  :expressions  {"x" [:* $price 2]}
                                   :fields       [$id [:expression "x"]]}
-                   :expressions  {:x [:* $price 4]}
+                   :expressions  {"x" [:* $price 4]}
                    :fields       [$id [:expression "x"]]
                    :limit        1})]
       (mt/with-native-query-testing-context query
@@ -223,10 +223,10 @@
                                                      ::add/source-alias  "x_2"
                                                      ::add/desired-alias "x_2"
                                                      ::add/position      1}]]
-                       :source-query {:expressions  {:x [:*
-                                                         [:field %price {::add/source-table ::add/source
-                                                                         ::add/source-alias "PRICE"}]
-                                                         4]}
+                       :source-query {:expressions  {"x" [:*
+                                                          [:field %price {::add/source-table ::add/source
+                                                                          ::add/source-alias "PRICE"}]
+                                                          4]}
                                       :fields       [[:field %id {::add/source-table  ::add/source
                                                                   ::add/source-alias  "ID"
                                                                   ::add/desired-alias "ID"
@@ -239,10 +239,10 @@
                                                      [:expression "x" {::add/desired-alias "x_2"
                                                                        ::add/position      2}]]
                                       :source-query {:source-table $$venues
-                                                     :expressions  {:x [:*
-                                                                        [:field %price {::add/source-table $$venues
-                                                                                        ::add/source-alias "PRICE"}]
-                                                                        2]}
+                                                     :expressions  {"x" [:*
+                                                                         [:field %price {::add/source-table $$venues
+                                                                                         ::add/source-alias "PRICE"}]
+                                                                         2]}
                                                      :fields       [[:field %id {::add/source-table  $$venues
                                                                                  ::add/source-alias  "ID"
                                                                                  ::add/desired-alias "ID"
@@ -321,17 +321,17 @@
                                                                                      ::add/source-alias  "MinPrice"
                                                                                      ::add/desired-alias "CategoriesStats__MinPrice"
                                                                                      ::add/position      10}]]}]
-                                  :expressions  {:RelativePrice [:/
-                                                                 [:field %price {::add/source-table  $$venues
-                                                                                 ::add/source-alias  "PRICE"
-                                                                                 ::add/desired-alias "PRICE"
-                                                                                 ::add/position      5}]
-                                                                 [:field "AvgPrice" {:base-type          :type/Integer
-                                                                                     :join-alias         "CategoriesStats"
-                                                                                     ::add/source-table  "CategoriesStats"
-                                                                                     ::add/source-alias  "AvgPrice"
-                                                                                     ::add/desired-alias "CategoriesStats__AvgPrice"
-                                                                                     ::add/position      9}]]}
+                                  :expressions  {"RelativePrice" [:/
+                                                                  [:field %price {::add/source-table  $$venues
+                                                                                  ::add/source-alias  "PRICE"
+                                                                                  ::add/desired-alias "PRICE"
+                                                                                  ::add/position      5}]
+                                                                  [:field "AvgPrice" {:base-type          :type/Integer
+                                                                                      :join-alias         "CategoriesStats"
+                                                                                      ::add/source-table  "CategoriesStats"
+                                                                                      ::add/source-alias  "AvgPrice"
+                                                                                      ::add/desired-alias "CategoriesStats__AvgPrice"
+                                                                                      ::add/position      9}]]}
                                   :fields       [[:field %id {::add/source-table  $$venues
                                                               ::add/source-alias  "ID"
                                                               ::add/desired-alias "ID"
@@ -447,7 +447,7 @@
                                   &CategoriesStats.*MaxPrice/Integer
                                   &CategoriesStats.*AvgPrice/Integer
                                   &CategoriesStats.*MinPrice/Integer]
-                    :expressions {:RelativePrice [:/ $price &CategoriesStats.*AvgPrice/Integer]}
+                    :expressions {"RelativePrice" [:/ $price &CategoriesStats.*AvgPrice/Integer]}
                     :joins       [{:strategy     :left-join
                                    :condition    [:= $category_id &CategoriesStats.category_id]
                                    :source-query {:source-table $$venues
@@ -465,7 +465,7 @@
                                                            :effective_type    :type/DateTime}
       (is (query= (mt/$ids venues
                     {:source-query {:source-table $$venues
-                                    :expressions  {:test [:* 1 1]}
+                                    :expressions  {"test" [:* 1 1]}
                                     :fields       [[:field %id {::add/source-table  $$venues
                                                                 ::add/source-alias  "ID"
                                                                 ::add/desired-alias "ID"
@@ -507,7 +507,7 @@
                      :limit        1})
                   (nest-expressions
                    (mt/mbql-query venues
-                     {:expressions {:test ["*" 1 1]}
+                     {:expressions {"test" ["*" 1 1]}
                       :fields      [$price
                                     [:expression "test"]]
                       :limit       1})))))))
@@ -571,7 +571,7 @@
                                                              :condition    [:= product-id products-id]
                                                              :strategy     :left-join
                                                              :fk-field-id  %product_id}]
-                                             :expressions  {:pivot-grouping [:abs 0]}
+                                             :expressions  {"pivot-grouping" [:abs 0]}
                                              :fields       [id
                                                             user-id
                                                             product-id
@@ -613,7 +613,7 @@
                       :breakout    [&PRODUCTS__via__PRODUCT_ID.products.category
                                     !year.created_at
                                     [:expression "pivot-grouping"]]
-                      :expressions {:pivot-grouping [:abs 0]}
+                      :expressions {"pivot-grouping" [:abs 0]}
                       :order-by    [[:asc &PRODUCTS__via__PRODUCT_ID.products.category]
                                     [:asc !year.created_at]
                                     [:asc [:expression "pivot-grouping"]]]
@@ -629,12 +629,12 @@
       (mt/with-everything-store
         (is (query= (mt/$ids products
                       {:source-query       {:source-table $$products
-                                            :expressions  {:CATEGORY [:concat
-                                                                      [:field %category {::add/source-table  $$products
-                                                                                         ::add/source-alias  "CATEGORY"
-                                                                                         ::add/desired-alias "CATEGORY"
-                                                                                         ::add/position      3}]
-                                                                      "2"]}
+                                            :expressions  {"CATEGORY" [:concat
+                                                                       [:field %category {::add/source-table  $$products
+                                                                                          ::add/source-alias  "CATEGORY"
+                                                                                          ::add/desired-alias "CATEGORY"
+                                                                                          ::add/position      3}]
+                                                                       "2"]}
                                             :fields       [[:field %id {::add/source-table  $$products
                                                                         ::add/source-alias  "ID"
                                                                         ::add/desired-alias "ID"
@@ -685,10 +685,10 @@
                                                                         ::add/position      0}]]]
                        :limit              1})
                     (-> (mt/mbql-query products
-                          {:expressions {:CATEGORY [:concat $category "2"]}
-                           :breakout    [:expression :CATEGORY]
+                          {:expressions {"CATEGORY" [:concat $category "2"]}
+                           :breakout    [:expression"CATEGORY"]
                            :aggregation [[:count]]
-                           :order-by    [[:asc [:expression :CATEGORY]]]
+                           :order-by    [[:asc [:expression"CATEGORY"]]]
                            :limit       1})
                         qp/query->preprocessed
                         add/add-alias-info


### PR DESCRIPTION
Fixes #14647

MBQL `:expressions` now uses strings instead of keywords as the keys. This is so they match the `[:expression <name>]` reference clauses (which use string names) and so we don't end up interning tons of useless keywords at runtime. Also because expression names can be arbitrary this makes it easier to look at things like "My Expression" in MBQL; `(keyword "My Expression")` is theoretically allowed but unprintable

Also: I made a handful of tests in the shared MBQL lib `:^parallel`. Not really part of this PR but I couldn't help myself.