### PR TITLE
Ensure that XLSX temp files are cleared if output stream closes before export completes

### DIFF
--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -483,6 +483,7 @@
         (when (or (nil? row_count) (< row_count *auto-sizing-threshold*))
           ;; Auto-size columns if we never hit the row threshold, or a final row count was not provided
           (autosize-columns! sheet))
-        (spreadsheet/save-workbook-into-stream! os workbook)
-        (.dispose workbook)
-        (.close os)))))
+        (try
+          (spreadsheet/save-workbook-into-stream! os workbook)
+          (finally
+            (.dispose workbook)))))))

--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -486,4 +486,5 @@
         (try
           (spreadsheet/save-workbook-into-stream! os workbook)
           (finally
-            (.dispose workbook)))))))
+            (.dispose workbook)
+            (.close os)))))))

--- a/test/metabase/query_processor/streaming/xlsx_test.clj
+++ b/test/metabase/query_processor/streaming/xlsx_test.clj
@@ -1,14 +1,15 @@
 (ns metabase.query-processor.streaming.xlsx-test
   (:require [cheshire.generate :as generate]
+            [clojure.java.io :as io]
             [clojure.test :refer :all]
             [dk.ative.docjure.spreadsheet :as spreadsheet]
             [metabase.query-processor.streaming.interface :as i]
             [metabase.query-processor.streaming.xlsx :as xlsx]
             [metabase.shared.models.visualization-settings :as mb.viz]
-            [metabase.test :as mt])
+            [metabase.test :as mt]
+            [metabase.util :as u])
   (:import com.fasterxml.jackson.core.JsonGenerator
            [java.io BufferedInputStream BufferedOutputStream ByteArrayInputStream ByteArrayOutputStream]))
-
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                     Format string generation unit tests                                        |
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -487,10 +488,10 @@
 
 (deftest poi-tempfiles-test
   (testing "POI temporary files are cleaned up if output stream is closed before export completes"
-    (let [poifiles-directory (clojure.java.io/file (str (System/getProperty "java.io.tmpdir") "/poifiles"))]
+    (let [poifiles-directory (io/file (str (System/getProperty "java.io.tmpdir") "/poifiles"))]
       ;; Clear any existing contents of poifiles directory
       (doseq [file (file-seq poifiles-directory)]
-        (try (clojure.java.io/delete-file file)))
+        (u/ignore-exceptions (io/delete-file file)))
       (let [bos                (ByteArrayOutputStream.)
             os                 (BufferedOutputStream. bos)
             results-writer     (i/streaming-results-writer :xlsx os)]

--- a/test/metabase/query_processor/streaming/xlsx_test.clj
+++ b/test/metabase/query_processor/streaming/xlsx_test.clj
@@ -6,8 +6,7 @@
             [metabase.query-processor.streaming.interface :as i]
             [metabase.query-processor.streaming.xlsx :as xlsx]
             [metabase.shared.models.visualization-settings :as mb.viz]
-            [metabase.test :as mt]
-            [metabase.util :as u])
+            [metabase.test :as mt])
   (:import com.fasterxml.jackson.core.JsonGenerator
            [java.io BufferedInputStream BufferedOutputStream ByteArrayInputStream ByteArrayOutputStream]))
 

--- a/test/metabase/query_processor/streaming/xlsx_test.clj
+++ b/test/metabase/query_processor/streaming/xlsx_test.clj
@@ -487,7 +487,7 @@
       (is (= 65280 col-width)))))
 
 (deftest poi-tempfiles-test
-  (testing "POI temporary files are cleaned up if output stream is closed before export completes"
+  (testing "POI temporary files are cleaned up if output stream is closed before export completes (#19480)"
     (let [poifiles-directory (io/file (str (System/getProperty "java.io.tmpdir") "/poifiles"))]
       ;; Clear any existing contents of poifiles directory
       (doseq [file (file-seq poifiles-directory)]

--- a/test/metabase/query_processor/streaming/xlsx_test.clj
+++ b/test/metabase/query_processor/streaming/xlsx_test.clj
@@ -489,15 +489,13 @@
 
 (deftest poi-tempfiles-test
   (testing "POI temporary files are cleaned up if output stream is closed before export completes (#19480)"
-    (let [poifiles-directory (io/file (str (System/getProperty "java.io.tmpdir") "/poifiles"))]
-      ;; Clear any existing contents of poifiles directory
-      (doseq [file (file-seq poifiles-directory)]
-        (u/ignore-exceptions (io/delete-file file)))
+    (let [poifiles-directory      (io/file (str (System/getProperty "java.io.tmpdir") "/poifiles"))
+          expected-poifiles-count (count (file-seq poifiles-directory))]
       (let [bos                (ByteArrayOutputStream.)
             os                 (BufferedOutputStream. bos)
             results-writer     (i/streaming-results-writer :xlsx os)]
         (.close os)
         (i/begin! results-writer {:data {:ordered-cols []}} {})
         (i/finish! results-writer {:row_count 0})
-        ;; Only the directory itself should be present in the file-seq results
-        (is (= 1 (count (file-seq poifiles-directory))))))))
+        ;; No additional files should exist in the temp directory
+        (is (= expected-poifiles-count (count (file-seq poifiles-directory))))))))

--- a/test/metabase/query_processor/streaming/xlsx_test.clj
+++ b/test/metabase/query_processor/streaming/xlsx_test.clj
@@ -10,6 +10,7 @@
             [metabase.util :as u])
   (:import com.fasterxml.jackson.core.JsonGenerator
            [java.io BufferedInputStream BufferedOutputStream ByteArrayInputStream ByteArrayOutputStream]))
+
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                     Format string generation unit tests                                        |
 ;;; +----------------------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
When an XLSX export finishes, we need to call `.dispose` on the workbook to clear out temporary files created by Apache POI. However, if the export is cancelled (i.e. if the browser is closed before it completes), the output stream is closed, and the `spreadsheet/save-workbook-into-stream!` call throws an exception, causing the `.dispose` call to be skipped. We just need to wrap this in `try`/`finally` to ensure that the cleanup happens properly every time.

Fixes #19480