### PR TITLE
Binning E2E tests: ensure that the query result is available

### DIFF
--- a/frontend/test/metabase/scenarios/binning/binning-options.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/binning-options.cy.spec.js
@@ -101,6 +101,7 @@ const LONGITUDE_BUCKETS = [
 
 describe("scenarios > binning > binning options", () => {
   beforeEach(() => {
+    cy.intercept("POST", "/api/dataset").as("dataset");
     restore();
     cy.signInAsAdmin();
   });
@@ -181,6 +182,9 @@ describe("scenarios > binning > binning options", () => {
   context("via time series footer", () => {
     it("should render time series binning options correctly", () => {
       openTable({ table: ORDERS_ID });
+
+      cy.wait("@dataset");
+
       cy.findByText("Created At").click();
       cy.findByText("Distribution").click();
 


### PR DESCRIPTION
How to verify: `yarn test-visual-open` and then run `binning-options.cy.spec.js`.

**Before this PR**

There is a potential that the query result isn't ready yet, before the checks:

![scenarios  binning  binning options -- via time series footer -- should render time series binning options correctly (failed)](https://user-images.githubusercontent.com/7288/151268073-03731c3a-5675-4dd4-ae34-b73ef60dd14a.png)

**After this PR**

It does not happen anymore.