### PR TITLE
Time-series chart E2E tests: ensure that the chart is ready first

### DIFF
--- a/frontend/test/metabase/scenarios/binning/correctness/time-series.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/correctness/time-series.cy.spec.js
@@ -168,6 +168,10 @@ function getVisualization(binningType) {
 }
 
 function assertOnXYAxisLabels() {
+  // wait until the chart appears
+  cy.get(".y-axis-label").should("be.visible");
+  cy.get(".x-axis-label").should("be.visible");
+
   cy.get(".y-axis-label")
     .invoke("text")
     .should("eq", "Count");

--- a/frontend/test/metabase/scenarios/binning/correctness/time-series.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/correctness/time-series.cy.spec.js
@@ -168,14 +168,12 @@ function getVisualization(binningType) {
 }
 
 function assertOnXYAxisLabels() {
-  // wait until the chart appears
-  cy.get(".y-axis-label").should("be.visible");
-  cy.get(".x-axis-label").should("be.visible");
-
   cy.get(".y-axis-label")
+    .should("be.visible")
     .invoke("text")
     .should("eq", "Count");
   cy.get(".x-axis-label")
+    .should("be.visible")
     .invoke("text")
     .should("eq", "Created At");
 }


### PR DESCRIPTION
How to verify: `yarn test-visual-open` and then run `time-series.cy.spec.js`.

**Before this PR**

There were cases where the chart isn't rendered yet, before the asserts.

![scenarios  binning  correctness  time series -- should return correct values for Minute (failed)](https://user-images.githubusercontent.com/7288/151268417-0179d957-a17e-40ee-87a2-d164fd8e31db.png)

**After this PR**

Both X and Y axis need to be visible first (Cypress will wait automatically wait and retry), before the subsequent asserts.
