### PR TITLE
Moving validation for tru/trs message-format

### DIFF
--- a/src/metabase/util/i18n.clj
+++ b/src/metabase/util/i18n.clj
@@ -103,20 +103,9 @@
   [format-string args]
   (assert (string? format-string)
           "The first arg to (deferred-)trs/tru must be a String! `gettext` does not eval Clojure files.")
-  (let [message-format             (MessageFormat. format-string)
-        ;; number of {n} placeholders in format string including any you may have skipped. e.g. "{0} {2}" -> 3
-        expected-num-args-by-index (count (.getFormatsByArgumentIndex message-format))
-        ;; number of {n} placeholders in format string *not* including ones you make have skipped. e.g. "{0} {2}" -> 2
-        expected-num-args          (count (.getFormats message-format))
-        actual-num-args            (count args)]
-    (assert (= expected-num-args expected-num-args-by-index)
-            (format "(deferred-)trs/tru with format string %s is missing some {} placeholders. Expected %s. Did you skip any?"
-                    (pr-str (.toPattern message-format))
-                    (str/join ", " (map (partial format "{%d}") (range expected-num-args-by-index)))))
-    (assert (= expected-num-args actual-num-args)
-            (str (format (str "(deferred-)trs/tru with format string %s expects %d args, got %d.")
-                         (pr-str (.toPattern message-format)) expected-num-args actual-num-args)
-                 " Did you forget to escape a single quote?"))))
+  (let [validate-impl #'impl/validate-number-of-args
+        message-format             (MessageFormat. format-string)]
+    (validate-impl message-format args)))
 
 (defmacro deferred-tru
   "Similar to `tru` but creates a `UserLocalizedString` instance so that conversion to the correct locale can be delayed

--- a/test/metabase/util/i18n_test.clj
+++ b/test/metabase/util/i18n_test.clj
@@ -34,6 +34,18 @@
                 (is (= "deben tener 140 caracteres o menos"
                        (f)))))))))))
 
+(comment
+  (defn example-translation-failure
+    []
+    (mt/with-mock-i18n-bundles {"fr"
+                                {"asdf" "le asdf {0}"
+                                 "execution duration: {0}; ''magic'' TTL: {1}"
+                                 "La durée d'exécution: {0}; TTL ''magique'': {1}"}}
+      [(mt/with-temporary-setting-values [site-locale "fr"]
+         (str (i18n/deferred-tru "asdf")))
+       (mt/with-temporary-setting-values [site-locale "en"]
+         (i18n/tru "execution duration: {0}; ''magic'' TTL: {1}" 2 "David Blaine"))])))
+
 (deftest trs-test
   (mt/with-mock-i18n-bundles {"es" {"must be {0} characters or less" "deben tener {0} caracteres o menos"}}
     (doseq [[message f] {"trs"          (fn [] (i18n/trs "must be {0} characters or less" 140))


### PR DESCRIPTION
This is being done as a potential solution for invalid translation strings.

Relates to: #15531.

In that issue, we can see that a French localization string is rendered incorrectly in the logs: {0} and {1} should be
replaced with their values, but are treated as part of the string instead. This arises because the translation text
had the word "d'execution" with an unescaped ' character.

The tru/trs macros have a validation step which would catch this and throw an assertion, but the validation as written
only ever checks the original input, which will always be the English string, as Metabase is developed in English.

This (draft) PR is a work in progress to try address this failure mode. As reference, Cam proposed the following
changes in a Slack thread:

> 1. extend that error detection logic to also work on strings with no parameters
> 2. fix all the busted strings on the backend as part of the 43 cycle
> 3. PO Editor people can supply updated translations for the fixed strings as part of the 43 cycle (poeditor.com does suggest similar strings IIRC so it should be fairly straightforward to update the strings)
> 4. Add some logic in the i18n build script to detect and fix busted translated strings as well OR just have the i18n CI script detect them and fail (which would mean we'd have to do a one-time fix of everything in POEditor)

This is a first pass at 1

## Before this PR:
Notice that in both cases, the string passes validation in English (the validation check occurs in [deferred-tru](https://github.com/metabase/metabase/blob/82b3147c57766c90647992c7203ba2cc7e1d6859/src/metabase/util/i18n.clj#L127)), but no validation occurs with the translated string.

```clojure
metabase.util.i18n-test>
(mt/with-mock-i18n-bundles {"fr"
                                {"asdf" "le asdf {0}"
                                 "execution duration: {0}; ''magic'' TTL: {1}"
                                 "La durée d'exécution: {0}; TTL ''magique'': {1}"}}
      {:en-1 (mt/with-temporary-setting-values [site-locale "en"]
               (str (i18n/deferred-tru "asdf")))
       :fr-1 (mt/with-temporary-setting-values [site-locale "fr"]
               (str (i18n/deferred-tru "asdf")))
       :en-2 (mt/with-temporary-setting-values [site-locale "en"]
         (i18n/tru "execution duration: {0}; ''magic'' TTL: {1}" 2 "David Blaine"))
       :fr-2 (mt/with-temporary-setting-values [site-locale "fr"]
         (i18n/tru "execution duration: {0}; ''magic'' TTL: {1}" 2 "David Blaine"))})

{:en-1 "asdf",
 :fr-1 "le asdf {0}",
 :en-2 "execution duration: 2; 'magic' TTL: David Blaine",
 :fr-2 "La durée dexécution: {0}; TTL 'magique': {1}"}
```

Running that example in the REPL will show that the original string can pass validation while having an incorrect translation string. The second example (en-2/fr-2) is a shortened version of the incorrect log in #15531.

## After this PR:
I've moved `validate-number-of-args` into impl and call it in `translate` so that validation also occurs on the localized string. This then catches the error and throws an AssertionError

```clojure
metabase.util.i18n-test>
(mt/with-mock-i18n-bundles {"fr"
                                {"asdf" "le asdf {0}"
                                 "execution duration: {0}; ''magic'' TTL: {1}"
                                 "La durée d'exécution: {0}; TTL ''magique'': {1}"}}
      {:en-1 (mt/with-temporary-setting-values [site-locale "en"]
               (str (i18n/deferred-tru "asdf")))
       :fr-1 (mt/with-temporary-setting-values [site-locale "fr"]
               (str (i18n/deferred-tru "asdf")))
       :en-2 (mt/with-temporary-setting-values [site-locale "en"]
         (i18n/tru "execution duration: {0}; ''magic'' TTL: {1}" 2 "David Blaine"))
       :fr-2 (mt/with-temporary-setting-values [site-locale "fr"]
         (i18n/tru "execution duration: {0}; ''magic'' TTL: {1}" 2 "David Blaine"))})

2022-01-27 20:13:57,103 ERROR i18n.impl :: Unable to translate string "asdf" to fr
java.lang.AssertionError: Assert failed: (deferred-)trs/tru with format string "le asdf {0}" expects 1 args, got 0. Did you forget to escape a single quote?
 ...
2022-01-27 20:13:57,118 ERROR i18n.impl :: Unable to translate string "execution duration: {0}; ''magic'' TTL: {1}" to fr
java.lang.AssertionError: Assert failed: (deferred-)trs/tru with format string "La durée dexécution: '{'0}; TTL ''magique'': '{'1}" expects 0 args, got 2. Did you forget to escape a single quote?
 ...
{:en-1 "asdf",
 :fr-1 "asdf",
 :en-2 "execution duration: 2; 'magic' TTL: David Blaine",
 :fr-2 "execution duration: 2; 'magic' TTL: David Blaine"}
```