### PR TITLE
More collection overview styling

### DIFF
--- a/frontend/src/metabase/collections/components/BaseItemsTable.styled.jsx
+++ b/frontend/src/metabase/collections/components/BaseItemsTable.styled.jsx
@@ -28,7 +28,7 @@ export const Table = styled.table.attrs({ className: "ContentTable" })`
 
 export const ColumnHeader = styled.th`
   font-weight: bold;
-  color: ${color("text-light")};
+  color: ${color("text-medium")};
 `;
 
 export const EntityIconCheckBox = styled(EntityItem.IconCheckBox)`

--- a/frontend/src/metabase/collections/components/BaseItemsTable.styled.jsx
+++ b/frontend/src/metabase/collections/components/BaseItemsTable.styled.jsx
@@ -31,6 +31,10 @@ export const ColumnHeader = styled.th`
   color: ${color("text-medium")};
 `;
 
+export const ItemCell = styled.td`
+  padding: 0.25em 0 0.25em 1em !important;
+`;
+
 export const EntityIconCheckBox = styled(EntityItem.IconCheckBox)`
   width: 3em;
   height: 3em;

--- a/frontend/src/metabase/collections/components/BaseTableItem.jsx
+++ b/frontend/src/metabase/collections/components/BaseTableItem.jsx
@@ -101,7 +101,7 @@ export function BaseTableItem({
         </td>
         <td data-testid={`${testId}-name`}>
           <ItemLink {...linkProps} to={item.getUrl()}>
-            <EntityItem.Name name={item.name} />
+            <EntityItem.Name name={item.name} variant="list" />
             <PLUGIN_MODERATION.ModerationStatusIcon
               status={item.moderated_status}
             />

--- a/frontend/src/metabase/collections/components/BaseTableItem.jsx
+++ b/frontend/src/metabase/collections/components/BaseTableItem.jsx
@@ -12,6 +12,7 @@ import Tooltip from "metabase/components/Tooltip";
 import ActionMenu from "metabase/collections/components/ActionMenu";
 
 import {
+  ItemCell,
   EntityIconCheckBox,
   ItemLink,
   TableItemSecondaryField,
@@ -87,7 +88,7 @@ export function BaseTableItem({
         data-testid={testId}
         style={trStyles}
       >
-        <td data-testid={`${testId}-type`}>
+        <ItemCell data-testid={`${testId}-type`}>
           <EntityIconCheckBox
             item={item}
             variant="list"
@@ -98,33 +99,33 @@ export function BaseTableItem({
             onToggleSelected={handleSelectionToggled}
             showCheckbox={isHoveringOverRow}
           />
-        </td>
-        <td data-testid={`${testId}-name`}>
+        </ItemCell>
+        <ItemCell data-testid={`${testId}-name`}>
           <ItemLink {...linkProps} to={item.getUrl()}>
             <EntityItem.Name name={item.name} variant="list" />
             <PLUGIN_MODERATION.ModerationStatusIcon
               status={item.moderated_status}
             />
           </ItemLink>
-        </td>
-        <td data-testid={`${testId}-last-edited-by`}>
+        </ItemCell>
+        <ItemCell data-testid={`${testId}-last-edited-by`}>
           <TableItemSecondaryField>{lastEditedBy}</TableItemSecondaryField>
-        </td>
-        <td data-testid={`${testId}-last-edited-at`}>
+        </ItemCell>
+        <ItemCell data-testid={`${testId}-last-edited-at`}>
           {lastEditInfo && (
             <Tooltip tooltip={<DateTime value={lastEditInfo.timestamp} />}>
               <TableItemSecondaryField>{lastEditedAt}</TableItemSecondaryField>
             </Tooltip>
           )}
-        </td>
-        <td>
+        </ItemCell>
+        <ItemCell>
           <ActionMenu
             item={item}
             collection={collection}
             onCopy={onCopy}
             onMove={onMove}
           />
-        </td>
+        </ItemCell>
       </tr>
     );
   }, [

--- a/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.styled.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.styled.tsx
@@ -16,8 +16,8 @@ export const ItemLink = styled(Link)`
 
 export const ItemIcon = styled(Icon)`
   color: ${color("brand")};
-  height: 1.7rem;
-  width: 1.7rem;
+  height: 1.5rem;
+  width: 1.5rem;
 `;
 
 export const HoverMenu = styled(ActionMenu)`
@@ -43,7 +43,7 @@ export const Description = forwardRefToInnerRef(styled.div`
 `);
 
 export const Body = styled.div`
-  padding: 1.7rem;
+  padding: 1rem 1.5rem;
   display: flex;
   flex-direction: column;
   cursor: pointer;
@@ -60,7 +60,7 @@ export const Body = styled.div`
 `;
 
 export const Header = styled.div`
-  padding-bottom: 1rem;
+  padding-bottom: 0.5rem;
   display: flex;
   justify-content: space-between;
   align-items: center;

--- a/frontend/src/metabase/collections/components/PinnedItemOverview/PinnedItemOverview.styled.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemOverview/PinnedItemOverview.styled.tsx
@@ -1,5 +1,6 @@
 import styled from "styled-components";
 
+import { color } from "metabase/lib/colors";
 import { breakpointMaxMedium } from "metabase/styled-components/theme";
 
 export const Container = styled.div`
@@ -20,4 +21,10 @@ export const Grid = styled.div`
 
 export const SectionHeader = styled.div`
   padding-bottom: 1.15rem;
+  margin-top: 1.5rem;
+`;
+
+export const SectionSubHeader = styled.div`
+  color: ${color("text-medium")};
+  padding-top: 0.5rem;
 `;

--- a/frontend/src/metabase/collections/components/PinnedItemOverview/PinnedItemOverview.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemOverview/PinnedItemOverview.tsx
@@ -9,7 +9,12 @@ import EmptyPinnedItemsBanner from "../EmptyPinnedItemsBanner/EmptyPinnedItemsBa
 import { Item, Collection, isRootCollection } from "metabase/collections/utils";
 import ItemDragSource from "metabase/containers/dnd/ItemDragSource";
 
-import { Container, Grid, SectionHeader } from "./PinnedItemOverview.styled";
+import {
+  Container,
+  Grid,
+  SectionHeader,
+  SectionSubHeader,
+} from "./PinnedItemOverview.styled";
 
 type Props = {
   items: Item[];
@@ -87,12 +92,12 @@ function PinnedItemOverview({
       {dataModelItems.length > 0 && (
         <div>
           <SectionHeader>
-            <h4>{t`Useful data`}</h4>
-            <div>
+            <h3>{t`Useful data`}</h3>
+            <SectionSubHeader>
               {isRootCollection(collection)
                 ? t`Start new explorations here`
                 : t`Start new explorations about ${collection.name} here`}
-            </div>
+            </SectionSubHeader>
           </SectionHeader>
           <Grid>
             {dataModelItems.map(item => (

--- a/frontend/src/metabase/components/EntityItem.jsx
+++ b/frontend/src/metabase/components/EntityItem.jsx
@@ -70,9 +70,13 @@ function EntityIconCheckBox({
   );
 }
 
-function EntityItemName({ name }) {
+function EntityItemName({ name, variant }) {
   return (
-    <h3 className="overflow-hidden">
+    <h3
+      className={cx("overflow-hidden", {
+        "text-list": variant === "list",
+      })}
+    >
       <Ellipsified>{name}</Ellipsified>
     </h3>
   );

--- a/frontend/src/metabase/css/core/text.css
+++ b/frontend/src/metabase/css/core/text.css
@@ -140,6 +140,10 @@
   color: var(--color-text-medium); /* TODO - is this bad? */
 }
 
+.text-list {
+  font-size: 1em;
+}
+
 .text-paragraph,
 :local(.text-paragraph) {
   font-size: 1.143em;


### PR DESCRIPTION
This is a re-do of #19853, whose changes accidentally got clobbered we think in a rebase, along with some additional styling for the unpinned items list.

This:
- tightens up the spacing of pinned cards
- fixes the size and spacing for the "Useful data" subheading
- makes the font size for unpinned list items' titles smaller
- (WIP) reduces the vertical padding of rows in the unpinned items list to condense it

## Before 

![image](https://user-images.githubusercontent.com/2223916/151275152-c2bb3600-e299-4175-9511-bb925dfd21bd.png)

## After

![image](https://user-images.githubusercontent.com/2223916/151456834-b465fbdd-6df9-4de6-bf10-043641b81b01.png)

