### PR TITLE
Handle transform visualization error

### DIFF
--- a/frontend/src/metabase/visualizations/components/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization.jsx
@@ -152,7 +152,7 @@ export default class Visualization extends React.PureComponent {
       });
     } catch (error) {
       this.setState({
-        error: new Error(error.message || t`Could not transform series.`),
+        error: new Error(error.message || t`Could not display this chart with this data.`),
       });
     }
   }

--- a/frontend/src/metabase/visualizations/components/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization.jsx
@@ -152,7 +152,9 @@ export default class Visualization extends React.PureComponent {
       });
     } catch (error) {
       this.setState({
-        error: new Error(error.message || t`Could not display this chart with this data.`),
+        error: new Error(
+          error.message || t`Could not display this chart with this data.`,
+        ),
       });
     }
   }

--- a/frontend/src/metabase/visualizations/components/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization.jsx
@@ -131,24 +131,30 @@ export default class Visualization extends React.PureComponent {
   }
 
   transform(newProps) {
-    const transformed = newProps.rawSeries
-      ? getVisualizationTransformed(extractRemappings(newProps.rawSeries))
-      : null;
-    const series = transformed && transformed.series;
-    const visualization = transformed && transformed.visualization;
-    const computedSettings = series
-      ? getComputedSettingsForSeries(series)
-      : null;
-    this.setState({
-      hovered: null,
-      clicked: null,
-      error: null,
-      warnings: [],
-      yAxisSplit: null,
-      series: series,
-      visualization: visualization,
-      computedSettings: computedSettings,
-    });
+    try {
+      const transformed = newProps.rawSeries
+        ? getVisualizationTransformed(extractRemappings(newProps.rawSeries))
+        : null;
+      const series = transformed && transformed.series;
+      const visualization = transformed && transformed.visualization;
+      const computedSettings = series
+        ? getComputedSettingsForSeries(series)
+        : null;
+      this.setState({
+        hovered: null,
+        clicked: null,
+        error: null,
+        warnings: [],
+        yAxisSplit: null,
+        series: series,
+        visualization: visualization,
+        computedSettings: computedSettings,
+      });
+    } catch (error) {
+      this.setState({
+        error: new Error(error.message || t`Could not transform series.`),
+      });
+    }
   }
 
   handleHoverChange = hovered => {


### PR DESCRIPTION
`getVisualizationTransformed` occasionally throws error on invalid query results. Since the `getVisualizationTransformed` error takes place in component `Visualization` itself, it won't be caught by `componentDidCatch`. 

After upgraded to React 16 (https://github.com/metabase/metabase/pull/14391), the entire root DOM will be dropped if an uncaught error happens causing issues like https://github.com/metabase/metabase/issues/4488 and https://github.com/metabase/metabase/issues/13736