### PR TITLE
Consistent namespace aliases

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,59 +1,135 @@
 {:config-paths ["macros"]
- :linters {:unresolved-symbol {:exclude [schema= re=
-                                         (metabase.util/prog1 [<>])
-                                         (metabase.mbql.util/match-one)
-                                         (metabase.mbql.util/match)
-                                         (metabase.mbql.util.match/match)
-                                         (metabase.mbql.util.match/match-one)
-                                         (metabase.mbql.util.match/replace)
-                                         (metabase.mbql.util/replace)
-                                         (metabase.mbql.util/replace-in)
-                                         (metabase.query-processor.middleware.cache-backend.interface/with-cached-results)
-                                         (metabase.util.regex/rx [opt])
-                                         (metabase.async.streaming-response/streaming-response)
-                                         (clojure.core.logic/fresh)
-                                         (clojure.core.logic/matcha)
-                                         (clojure.core.logic/run)]}
-           ;; TODO: clj-kondo should have a way to disable this in certain macro calls like
-           ;; metabase.mbql.util.match/replace
-           :unexpected-recur {:level :off}
-           :unused-referred-var {:exclude {compojure.core [GET DELETE POST PUT]}}}
- :lint-as {metabase.api.common/let-404 clojure.core/let
-           metabase.db.data-migrations/defmigration clojure.core/def
-           metabase.query-processor.error-type/deferror clojure.core/def
-           metabase.models.setting/defsetting clj-kondo.lint-as/def-catch-all
-           metabase.mbql.schema.macros/defclause clj-kondo.lint-as/def-catch-all
-           metabase.public-settings.premium-features/define-premium-feature clojure.core/def
-           metabase.sync.util/sum-for clojure.core/for
-           metabase.sync.util/with-emoji-progress-bar clojure.core/let
-           metabase.driver.sql-jdbc.execute.diagnostic/capturing-diagnostic-info clojure.core/fn
-           metabase.util.files/with-open-path-to-resource clojure.core/let
-           metabase.db.liquibase/with-liquibase clojure.core/let
-           metabase.models.setting.multi-setting/define-multi-setting clojure.core/def
-           metabase.integrations.ldap/with-ldap-connection clojure.core/fn
-           toucan.db/with-call-counting clojure.core/fn
 
-           potemkin.types/defprotocol+ clojure.core/defprotocol
-           potemkin/defprotocol+ clojure.core/defprotocol
-           potemkin.types/defrecord+ clojure.core/defrecord
-           potemkin/defrecord+ clojure.core/defrecord
-           potemkin.types/deftype+ clojure.core/deftype
-           potemkin/deftype+ clojure.core/deftype
-           clojurewerkz.quartzite.jobs/defjob clojure.core/defn}
- :hooks   {:analyze-call {metabase.test.data/dataset        hooks.metabase.test.data/dataset
-                          metabase.test/dataset             hooks.metabase.test.data/dataset
-                          metabase.test.data/$ids           hooks.metabase.test.data/$ids
-                          metabase.test/$ids                hooks.metabase.test.data/$ids
-                          metabase.test.data/mbql-query     hooks.metabase.test.data/$ids
-                          metabase.test/mbql-query          hooks.metabase.test.data/$ids
-                          metabase.test.data/run-mbql-query hooks.metabase.test.data/$ids
-                          metabase.test/run-mbql-query      hooks.metabase.test.data/$ids}
-           :macroexpand {metabase.api.common/defendpoint*   metabase.api.common/defendpoint*
-                         metabase.api.common/defendpoint    metabase.api.common/defendpoint
-                         metabase.api.common/defendpoint-async metabase.api.common/defendpoint
-                         metabase.query-processor.streaming/streaming-response
-                         metabase.query-processor.streaming/streaming-response
+ :linters
+ {:unresolved-symbol
+  {:exclude [schema= re=
+             (metabase.util/prog1 [<>])
+             (metabase.mbql.util/match-one)
+             (metabase.mbql.util/match)
+             (metabase.mbql.util.match/match)
+             (metabase.mbql.util.match/match-one)
+             (metabase.mbql.util.match/replace)
+             (metabase.mbql.util/replace)
+             (metabase.mbql.util/replace-in)
+             (metabase.query-processor.middleware.cache-backend.interface/with-cached-results)
+             (metabase.util.regex/rx [opt])
+             (metabase.async.streaming-response/streaming-response)
+             (clojure.core.logic/fresh)
+             (clojure.core.logic/matcha)
+             (clojure.core.logic/run)]}
 
-                         toucan.models/defmodel toucan.models/defmodel
-                         }}
- :config-in-comment {:linters {:unresolved-symbol {:level :off}}}}
+  :consistent-alias
+  {:level   :error
+   :aliases {cheshire.core                       json
+             clojure.core.cache                  cache
+             clojure.core.logic                  l
+             clojure.core.match                  match
+             clojure.data                        data
+             clojure.java.io                     io
+             clojure.java.jdbc                   jdbc
+             clojure.math.numeric-tower          math
+             clojure.set                         set
+             clojure.string                      str
+             clojure.tools.logging               log
+             clojure.walk                        walk
+             compojure.core                      compojure
+             environ.core                        env
+             honeysql.core                       hsql
+             java-time                           t
+             medley.core                         m
+             metabase.api.common                 api
+             metabase.config                     config
+             metabase.db                         mdb
+             metabase.driver                     driver
+             metabase.driver.common              driver.common
+             metabase.driver.sql.query-processor sql.qp
+             metabase.driver.util                driver.u
+             metabase.events                     events
+             metabase.mbql.schema                mbql.s
+             metabase.mbql.util                  mbql.u
+             metabase.models.collection.root     collection.root
+             metabase.models.setting             setting
+             metabase.plugins.classloader        classloader
+             metabase.public-settings            public-settings
+             metabase.query-processor            qp
+             metabase.query-processor.error-type qp.error-type
+             metabase.query-processor.pivot      qp.pivot
+             metabase.query-processor.reducible  qp.reducible
+             metabase.query-processor.store      qp.store
+             metabase.query-processor.util       qp.util
+             metabase.server                     server
+             metabase.server.handler             handler
+             metabase.setup                      setup
+             metabase.task                       task
+             metabase.test                       mt
+             metabase.util                       u
+             metabase.util.date-2                u.date
+             metabase.util.honeysql-extensions   hx
+             metabase.util.i18n                  i18n
+             metabase.util.schema                su
+             potemkin                            p
+             potemkin.types                      p.types
+             schema.core                         s
+             stencil.core                        stencil
+             toucan.db                           db
+             yaml.core                           yaml}}
+
+  ;; additional optional linters
+  :docstring-leading-trailing-whitespace {:level :warning}
+  :missing-docstring                     {:level :warning}
+  :refer-all                             {:level :warning, :exclude [clojure.test]}
+  :single-key-in                         {:level :warning}
+  :unsorted-required-namespaces          {:level :warning}
+  :used-underscored-binding              {:level :warning}
+  #_:docstring-no-summary                #_ {:level :warning} ; broken -- see https://github.com/clj-kondo/clj-kondo/issues/1507
+
+  ;; WARN, not WARNING => log a warning but don't fail
+  :shadowed-var   {:level :warn}
+  :deprecated-var {:level :warn}
+
+  ;; TODO: clj-kondo should have a way to disable this in certain macro calls like
+  ;; metabase.mbql.util.match/replace
+  :unexpected-recur    {:level :off}
+  :unused-referred-var {:exclude {compojure.core [GET DELETE POST PUT]}}}
+
+ :lint-as
+ {metabase.api.common/let-404                                           clojure.core/let
+  metabase.db.data-migrations/defmigration                              clojure.core/def
+  metabase.query-processor.error-type/deferror                          clojure.core/def
+  metabase.models.setting/defsetting                                    clj-kondo.lint-as/def-catch-all
+  metabase.mbql.schema.macros/defclause                                 clj-kondo.lint-as/def-catch-all
+  metabase.public-settings.premium-features/define-premium-feature      clojure.core/def
+  metabase.sync.util/sum-for                                            clojure.core/for
+  metabase.sync.util/with-emoji-progress-bar                            clojure.core/let
+  metabase.driver.sql-jdbc.execute.diagnostic/capturing-diagnostic-info clojure.core/fn
+  metabase.util.files/with-open-path-to-resource                        clojure.core/let
+  metabase.db.liquibase/with-liquibase                                  clojure.core/let
+  metabase.models.setting.multi-setting/define-multi-setting            clojure.core/def
+  metabase.integrations.ldap/with-ldap-connection                       clojure.core/fn
+  toucan.db/with-call-counting                                          clojure.core/fn
+
+  potemkin.types/defprotocol+        clojure.core/defprotocol
+  potemkin/defprotocol+              clojure.core/defprotocol
+  potemkin.types/defrecord+          clojure.core/defrecord
+  potemkin/defrecord+                clojure.core/defrecord
+  potemkin.types/deftype+            clojure.core/deftype
+  potemkin/deftype+                  clojure.core/deftype
+  clojurewerkz.quartzite.jobs/defjob clojure.core/defn}
+
+ :hooks
+ {:analyze-call {metabase.test.data/dataset        hooks.metabase.test.data/dataset
+                 metabase.test/dataset             hooks.metabase.test.data/dataset
+                 metabase.test.data/$ids           hooks.metabase.test.data/$ids
+                 metabase.test/$ids                hooks.metabase.test.data/$ids
+                 metabase.test.data/mbql-query     hooks.metabase.test.data/$ids
+                 metabase.test/mbql-query          hooks.metabase.test.data/$ids
+                 metabase.test.data/run-mbql-query hooks.metabase.test.data/$ids
+                 metabase.test/run-mbql-query      hooks.metabase.test.data/$ids}
+  :macroexpand  {metabase.api.common/defendpoint*                      metabase.api.common/defendpoint*
+                 metabase.api.common/defendpoint                       metabase.api.common/defendpoint
+                 metabase.api.common/defendpoint-async                 metabase.api.common/defendpoint
+                 metabase.query-processor.streaming/streaming-response metabase.query-processor.streaming/streaming-response
+                 toucan.models/defmodel                                toucan.models/defmodel}}
+
+ :config-in-comment
+ {:linters {:unresolved-symbol {:level :off}}}}

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -19,7 +19,7 @@
              (clojure.core.logic/run)]}
 
   :consistent-alias
-  {:level   :error
+  {:level   :warning
    :aliases {cheshire.core                       json
              clojure.core.cache                  cache
              clojure.core.logic                  l

--- a/enterprise/backend/src/metabase_enterprise/audit_app/query_processor/middleware/handle_audit_queries.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_app/query_processor/middleware/handle_audit_queries.clj
@@ -42,7 +42,7 @@
             [metabase.api.common :as api]
             [metabase.public-settings.premium-features :as premium-features]
             [metabase.query-processor.context :as context]
-            [metabase.query-processor.error-type :as error-type]
+            [metabase.query-processor.error-type :as qp.error-type]
             [metabase.util.i18n :refer [tru]]
             [metabase.util.schema :as su]
             [schema.core :as s]))
@@ -116,7 +116,7 @@
   ;; allow non-audit-app queries if and when we add some
   (when-not (premium-features/enable-audit-app?)
     (throw (ex-info (tru "Audit App queries are not enabled on this instance.")
-                    {:type error-type/invalid-query})))
+                    {:type qp.error-type/invalid-query})))
   (binding [*additional-query-params* (dissoc query :fn :args)]
     (let [resolved (apply audit.i/resolve-internal-query qualified-fn-str args)]
       (reduce-results rff context resolved))))

--- a/enterprise/backend/src/metabase_enterprise/serialization/load.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/load.clj
@@ -9,7 +9,7 @@
             [metabase-enterprise.serialization.upsert :refer [maybe-upsert-many!]]
             [metabase.config :as config]
             [metabase.mbql.normalize :as mbql.normalize]
-            [metabase.mbql.util :as mbql.util]
+            [metabase.mbql.util :as mbql.u]
             [metabase.models.card :refer [Card]]
             [metabase.models.collection :refer [Collection]]
             [metabase.models.dashboard :refer [Dashboard]]
@@ -149,7 +149,7 @@
 
 (defn- mbql-fully-qualified-names->ids*
   [entity]
-  (mbql.util/replace entity
+  (mbql.u/replace entity
     ;; handle legacy `:field-id` forms encoded prior to 0.39.0
     ;; and also *current* expresion forms used in parameter mapping dimensions
     ;; example relevant clause - [:dimension [:fk-> [:field-id 1] [:field-id 2]]]
@@ -604,7 +604,7 @@
           (-> card
               :dataset_query
               :type
-              mbql.util/normalize-token
+              mbql.u/normalize-token
               (= :query)) resolve-card-dataset-query
           (-> card
               :dataset_query

--- a/enterprise/backend/src/metabase_enterprise/serialization/serialize.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/serialize.clj
@@ -5,7 +5,7 @@
             [metabase-enterprise.serialization.names :refer [fully-qualified-name]]
             [metabase.mbql.normalize :as mbql.normalize]
             [metabase.mbql.schema :as mbql.s]
-            [metabase.mbql.util :as mbql.util]
+            [metabase.mbql.util :as mbql.u]
             [metabase.models.card :refer [Card]]
             [metabase.models.dashboard :refer [Dashboard]]
             [metabase.models.dashboard-card :refer [DashboardCard]]
@@ -41,7 +41,7 @@
   [mbql]
   (-> mbql
       mbql.normalize/normalize-tokens
-      (mbql.util/replace
+      (mbql.u/replace
         ;; `integer?` guard is here to make the operation idempotent
         [:field (id :guard integer?) opts]
         [:field (fully-qualified-name Field id) (mbql-id->fully-qualified-name opts)]
@@ -64,7 +64,7 @@
 
 (defn- ids->fully-qualified-names
   [entity]
-  (mbql.util/replace entity
+  (mbql.u/replace entity
     mbql-entity-reference?
     (mbql-id->fully-qualified-name &match)
 

--- a/enterprise/backend/src/metabase_enterprise/serialization/upsert.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/upsert.clj
@@ -1,7 +1,7 @@
 (ns metabase-enterprise.serialization.upsert
   "Upsert-or-skip functionality for our models."
   (:require [cheshire.core :as json]
-            [clojure.data :as diff]
+            [clojure.data :as data]
             [clojure.tools.logging :as log]
             [medley.core :as m]
             [metabase-enterprise.serialization.names :refer [name-for-logging]]
@@ -100,7 +100,7 @@
 (defn- group-by-action
   "Return `entities` grouped by the action that needs to be done given the `context`."
   [{:keys [mode on-error]} model entities]
-  (let [same?                        (comp nil? second diff/diff)]
+  (let [same?                        (comp nil? second data/diff)]
     (->> entities
          (map-indexed (fn [position entity]
                         [position

--- a/enterprise/backend/test/metabase_enterprise/audit_app/pages_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_app/pages_test.clj
@@ -10,7 +10,7 @@
             [metabase.plugins.classloader :as classloader]
             [metabase.public-settings.premium-features-test :as premium-features-test]
             [metabase.query-processor :as qp]
-            [metabase.query-processor.util :as qp-util]
+            [metabase.query-processor.util :as qp.util]
             [metabase.test :as mt]
             [metabase.test.fixtures :as fixtures]
             [metabase.util :as u]
@@ -128,7 +128,7 @@
                :database-id       (u/the-id database)
                :table-id          (u/the-id table)
                :model             "card"
-               :query-hash        (codec/base64-encode (qp-util/query-hash {:database 1, :type :native}))
+               :query-hash        (codec/base64-encode (qp.util/query-hash {:database 1, :type :native}))
                :query-string      "toucans"
                :question-filter   "bird sales"
                :collection-filter "coin collection"

--- a/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions_test.clj
@@ -19,7 +19,7 @@
             [metabase.query-processor.middleware.cache-test :as cache-test]
             [metabase.query-processor.middleware.permissions :as qp.perms]
             [metabase.query-processor.pivot :as qp.pivot]
-            [metabase.query-processor.util :as qputil]
+            [metabase.query-processor.util :as qp.util]
             [metabase.query-processor.util.add-alias-info :as add]
             [metabase.test :as mt]
             [metabase.test.data.env :as tx.env]
@@ -389,8 +389,8 @@
 
 (defn- run-query-returning-remark [run-query-fn]
   (let [remark (atom nil)
-        orig   qputil/query->remark]
-    (with-redefs [qputil/query->remark (fn [driver outer-query]
+        orig   qp.util/query->remark]
+    (with-redefs [qp.util/query->remark (fn [driver outer-query]
                                          (u/prog1 (orig driver outer-query)
                                            (reset! remark <>)))]
       (let [results (run-query-fn)]

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -11,10 +11,10 @@
             [metabase.driver.sync :as driver.s]
             [metabase.models :refer [Database Table] :rename {Table MetabaseTable}] ; Table clashes with the class below
             [metabase.query-processor.context :as context]
-            [metabase.query-processor.error-type :as error-type]
+            [metabase.query-processor.error-type :as qp.error-type]
             [metabase.query-processor.store :as qp.store]
             [metabase.query-processor.timezone :as qp.timezone]
-            [metabase.query-processor.util :as qputil]
+            [metabase.query-processor.util :as qp.util]
             [metabase.util :as u]
             [metabase.util.i18n :refer [trs tru]]
             [metabase.util.schema :as su]
@@ -162,7 +162,7 @@
 
 (defn- throw-invalid-query [e sql parameters]
   (throw (ex-info (tru "Error executing query")
-           {:type error-type/invalid-query, :sql sql, :parameters parameters}
+           {:type qp.error-type/invalid-query, :sql sql, :parameters parameters}
            e)))
 
 (defn- ^TableResult execute-bigquery
@@ -293,7 +293,7 @@
     (binding [bigquery.common/*bigquery-timezone-id* (effective-query-timezone-id database)]
       (log/tracef "Running BigQuery query in %s timezone" bigquery.common/*bigquery-timezone-id*)
       (let [sql (if (get-in database [:details :include-user-id-and-hash] true)
-                  (str "-- " (qputil/query->remark :bigquery-cloud-sdk outer-query) "\n" sql)
+                  (str "-- " (qp.util/query->remark :bigquery-cloud-sdk outer-query) "\n" sql)
                   sql)]
         (process-native* respond database sql params (context/canceled-chan context))))))
 

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
@@ -16,7 +16,7 @@
             [metabase.mbql.util :as mbql.u]
             [metabase.models.field :refer [Field]]
             [metabase.models.setting :as setting]
-            [metabase.query-processor.error-type :as error-type]
+            [metabase.query-processor.error-type :as qp.error-type]
             [metabase.query-processor.store :as qp.store]
             [metabase.query-processor.util.add-alias-info :as add]
             [metabase.query-processor.util.nest-query :as nest-query]
@@ -234,7 +234,7 @@
 
 (defn- throw-unsupported-conversion [from to]
   (throw (ex-info (tru "Cannot convert a {0} to a {1}" from to)
-           {:type error-type/invalid-query})))
+           {:type qp.error-type/invalid-query})))
 
 (defmethod ->temporal-type [:date LocalTime]           [_ t] (throw-unsupported-conversion "time" "date"))
 (defmethod ->temporal-type [:date OffsetTime]          [_ t] (throw-unsupported-conversion "time" "date"))
@@ -670,7 +670,7 @@
     ;; the first place
     (throw (ex-info (tru "Invalid query: you cannot add a {0} to a {1} column."
                          (name unit) (name t-type))
-             {:type error-type/invalid-query}))))
+             {:type qp.error-type/invalid-query}))))
 
 ;; We can coerce the HoneySQL form this wraps to whatever we want and generate the appropriate SQL.
 ;; Thus for something like filtering against a relative datetime
@@ -704,7 +704,7 @@
   (let [current-type (temporal-type (:hsql-form add-interval-form))]
     (when (#{[:date :time] [:time :date]} [current-type target-type])
       (throw (ex-info (tru "It doesn''t make sense to convert between DATEs and TIMEs!")
-               {:type error-type/invalid-query}))))
+               {:type qp.error-type/invalid-query}))))
   (map->AddIntervalForm (update add-interval-form :hsql-form (partial ->temporal-type target-type))))
 
 (defmethod sql.qp/add-interval-honeysql-form :bigquery-cloud-sdk

--- a/modules/drivers/bigquery/src/metabase/driver/bigquery.clj
+++ b/modules/drivers/bigquery/src/metabase/driver/bigquery.clj
@@ -8,10 +8,10 @@
             [metabase.driver.bigquery.params :as bigquery.params]
             [metabase.driver.bigquery.query-processor :as bigquery.qp]
             [metabase.driver.google :as google]
-            [metabase.query-processor.error-type :as error-type]
+            [metabase.query-processor.error-type :as qp.error-type]
             [metabase.query-processor.store :as qp.store]
             [metabase.query-processor.timezone :as qp.timezone]
-            [metabase.query-processor.util :as qputil]
+            [metabase.query-processor.util :as qp.util]
             [metabase.util :as u]
             [metabase.util.i18n :refer [tru]]
             [metabase.util.schema :as su]
@@ -222,7 +222,7 @@
          (get-query-results client proj-id job-id location nil)))
      (catch Throwable e
        (throw (ex-info (tru "Error executing query")
-                       {:type error-type/invalid-query, :sql sql, :parameters parameters}
+                       {:type qp.error-type/invalid-query, :sql sql, :parameters parameters}
                        e))))))
 
 (defn- post-process-native
@@ -294,7 +294,7 @@
     (binding [bigquery.common/*bigquery-timezone-id* (effective-query-timezone-id database)]
       (log/tracef "Running BigQuery query in %s timezone" bigquery.common/*bigquery-timezone-id*)
       (let [sql (if (get-in database [:details :include-user-id-and-hash] true)
-                  (str "-- " (qputil/query->remark :bigquery outer-query) "\n" sql)
+                  (str "-- " (qp.util/query->remark :bigquery outer-query) "\n" sql)
                   sql)]
         (process-native* respond database sql params)))))
 

--- a/modules/drivers/bigquery/src/metabase/driver/bigquery/query_processor.clj
+++ b/modules/drivers/bigquery/src/metabase/driver/bigquery/query_processor.clj
@@ -16,7 +16,7 @@
             [metabase.mbql.util :as mbql.u]
             [metabase.models.field :refer [Field]]
             [metabase.models.setting :as setting]
-            [metabase.query-processor.error-type :as error-type]
+            [metabase.query-processor.error-type :as qp.error-type]
             [metabase.query-processor.store :as qp.store]
             [metabase.query-processor.util.add-alias-info :as add]
             [metabase.util :as u]
@@ -216,7 +216,7 @@
 
 (defn- throw-unsupported-conversion [from to]
   (throw (ex-info (tru "Cannot convert a {0} to a {1}" from to)
-           {:type error-type/invalid-query})))
+           {:type qp.error-type/invalid-query})))
 
 (defmethod ->temporal-type [:date LocalTime]           [_ t] (throw-unsupported-conversion "time" "date"))
 (defmethod ->temporal-type [:date OffsetTime]          [_ t] (throw-unsupported-conversion "time" "date"))
@@ -550,7 +550,7 @@
       ((partial apply h/group) (for [breakout breakouts
                                      :let     [alias (or (sql.qp/field-clause->alias driver breakout)
                                                          (throw (ex-info (tru "Error compiling SQL: breakout does not have an alias")
-                                                                         {:type     error-type/qp
+                                                                         {:type     qp.error-type/qp
                                                                           :breakout breakout
                                                                           :query    query})))]]
                                  alias))
@@ -604,7 +604,7 @@
     ;; the first place
     (throw (ex-info (tru "Invalid query: you cannot add a {0} to a {1} column."
                          (name unit) (name t-type))
-             {:type error-type/invalid-query}))))
+             {:type qp.error-type/invalid-query}))))
 
 ;; We can coerce the HoneySQL form this wraps to whatever we want and generate the appropriate SQL.
 ;; Thus for something like filtering against a relative datetime
@@ -638,7 +638,7 @@
   (let [current-type (temporal-type (:hsql-form add-interval-form))]
     (when (#{[:date :time] [:time :date]} [current-type target-type])
       (throw (ex-info (tru "It doesn''t make sense to convert between DATEs and TIMEs!")
-               {:type error-type/invalid-query}))))
+               {:type qp.error-type/invalid-query}))))
   (map->AddIntervalForm (update add-interval-form :hsql-form (partial ->temporal-type target-type))))
 
 (defmethod sql.qp/add-interval-honeysql-form :bigquery

--- a/modules/drivers/druid/src/metabase/driver/druid/query_processor.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid/query_processor.clj
@@ -14,7 +14,7 @@
             [metabase.types :as types]
             [metabase.util :as u]
             [metabase.util.date-2 :as u.date]
-            [metabase.util.i18n :as ui18n :refer [trs tru]]
+            [metabase.util.i18n :as i18n :refer [trs tru]]
             [schema.core :as s]))
 
 (def ^:private ^:const topN-max-results

--- a/modules/drivers/google/src/metabase/driver/google.clj
+++ b/modules/drivers/google/src/metabase/driver/google.clj
@@ -4,7 +4,7 @@
             [metabase.config :as config]
             [metabase.driver :as driver]
             [metabase.models.database :refer [Database]]
-            [metabase.query-processor.error-type :as error-type]
+            [metabase.query-processor.error-type :as qp.error-type]
             [metabase.util :as u]
             [metabase.util.i18n :refer [trs]]
             [ring.util.codec :as codec]

--- a/modules/drivers/googleanalytics/src/metabase/driver/googleanalytics/query_processor.clj
+++ b/modules/drivers/googleanalytics/src/metabase/driver/googleanalytics/query_processor.clj
@@ -8,7 +8,7 @@
             [metabase.query-processor.store :as qp.store]
             [metabase.query-processor.timezone :as qp.timezone]
             [metabase.util.date-2 :as u.date]
-            [metabase.util.i18n :as ui18n :refer [tru]]
+            [metabase.util.i18n :as i18n :refer [tru]]
             [metabase.util.schema :as su]
             [schema.core :as s]))
 

--- a/modules/drivers/mongo/src/metabase/driver/mongo/execute.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/execute.clj
@@ -6,9 +6,9 @@
             [metabase.driver.mongo.query-processor :as mongo.qp]
             [metabase.driver.mongo.util :refer [*mongo-connection*]]
             [metabase.query-processor.context :as context]
-            [metabase.query-processor.error-type :as error-type]
+            [metabase.query-processor.error-type :as qp.error-type]
             [metabase.query-processor.reducible :as qp.reducible]
-            [metabase.util.i18n :as ui18n :refer [tru]]
+            [metabase.util.i18n :as i18n :refer [tru]]
             [monger.conversion :as m.conversion]
             [monger.util :as m.util]
             [schema.core :as s])
@@ -42,7 +42,7 @@
           not-in-expected (set/difference actual-cols expected-cols)]
       (when (seq not-in-expected)
         (throw (ex-info (tru "Unexpected columns in results: {0}" (sort not-in-expected))
-                        {:type     error-type/driver
+                        {:type     qp.error-type/driver
                          :actual   actual-cols
                          :expected expected-cols}))))))
 
@@ -150,7 +150,7 @@
       (com.mongodb.BasicDBObject. (.asDocument v)))
     (catch Throwable e
       (throw (ex-info (tru "Unable to parse query: {0}" (.getMessage e))
-               {:type  error-type/invalid-query
+               {:type  qp.error-type/invalid-query
                 :query s}
                e)))))
 

--- a/modules/drivers/mongo/src/metabase/driver/mongo/parameters.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/parameters.clj
@@ -11,7 +11,7 @@
             [metabase.driver.common.parameters.values :as values]
             [metabase.driver.mongo.query-processor :as mongo.qp]
             [metabase.mbql.util :as mbql.u]
-            [metabase.query-processor.error-type :as error-type]
+            [metabase.query-processor.error-type :as qp.error-type]
             [metabase.query-processor.middleware.wrap-value-literals :as wrap-value-literals]
             [metabase.query-processor.store :as qp.store]
             [metabase.util :as u]
@@ -170,7 +170,7 @@
 
        :else
        (throw (ex-info (tru "Don''t know how to substitute {0} {1}" (.getName (class x)) (pr-str x))
-                {:type error-type/driver}))))
+                {:type qp.error-type/driver}))))
    [[] nil]
    xs))
 
@@ -178,7 +178,7 @@
   (let [[replaced missing] (substitute* param->value xs false)]
     (when (seq missing)
       (throw (ex-info (tru "Cannot run query: missing required parameters: {0}" (set missing))
-               {:type error-type/invalid-query})))
+               {:type qp.error-type/invalid-query})))
     (when (seq replaced)
       (str/join replaced))))
 

--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -16,7 +16,7 @@
             [metabase.query-processor.timezone :as qp.timezone]
             [metabase.util :as u]
             [metabase.util.date-2 :as u.date]
-            [metabase.util.i18n :as ui18n :refer [tru]]
+            [metabase.util.i18n :as i18n :refer [tru]]
             [metabase.util.schema :as su]
             [monger.operators :refer :all]
             [schema.core :as s])

--- a/modules/drivers/presto/src/metabase/driver/presto.clj
+++ b/modules/drivers/presto/src/metabase/driver/presto.clj
@@ -15,7 +15,7 @@
             [metabase.query-processor.context :as context]
             [metabase.query-processor.store :as qp.store]
             [metabase.query-processor.timezone :as qp.timezone]
-            [metabase.query-processor.util :as qputil]
+            [metabase.query-processor.util :as qp.util]
             [metabase.util :as u]
             [metabase.util.date-2 :as u.date]
             [metabase.util.i18n :refer [trs tru]]
@@ -238,7 +238,7 @@
    context
    respond]
   (let [sql     (str "-- "
-                     (qputil/query->remark :presto outer-query) "\n"
+                     (qp.util/query->remark :presto outer-query) "\n"
                      (binding [presto-common/*param-splice-style* :paranoid]
                        (unprepare/unprepare driver (cons sql params))))
         details (merge (:details (qp.store/database))

--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -15,7 +15,7 @@
             [metabase.mbql.util :as mbql.u]
             [metabase.public-settings :as pubset]
             [metabase.query-processor.store :as qp.store]
-            [metabase.query-processor.util :as qputil]
+            [metabase.query-processor.util :as qp.util]
             [metabase.util.honeysql-extensions :as hx]
             [metabase.util.i18n :refer [trs]])
   (:import [java.sql Connection PreparedStatement ResultSet Types]
@@ -236,7 +236,7 @@
                     [(:name (qp.store/field field-id)) (:value param)]))))
         user-parameters))
 
-(defmethod qputil/query->remark :redshift
+(defmethod qp.util/query->remark :redshift
   [_ {{:keys [executed-by query-hash card-id]} :info, :as query}]
   (str "/* partner: \"metabase\", "
        (json/generate-string {:dashboard_id        nil ;; requires metabase/metabase#11909
@@ -245,7 +245,7 @@
                               :optional_account_id (pubset/site-uuid)
                               :filter_values       (field->parameter-value query)})
        " */ "
-       (qputil/default-query->remark query)))
+       (qp.util/default-query->remark query)))
 
 (defn- reducible-schemas-with-usage-permissions
   "Takes something `reducible` that returns a collection of string schema names (e.g. an `Eduction`) and returns an

--- a/modules/drivers/sparksql/src/metabase/driver/sparksql.clj
+++ b/modules/drivers/sparksql/src/metabase/driver/sparksql.clj
@@ -17,7 +17,7 @@
             [metabase.driver.sql.util.unprepare :as unprepare]
             [metabase.mbql.util :as mbql.u]
             [metabase.query-processor.store :as qp.store]
-            [metabase.query-processor.util :as qputil]
+            [metabase.query-processor.util :as qp.util]
             [metabase.query-processor.util.add-alias-info :as add]
             [metabase.util.honeysql-extensions :as hx])
   (:import [java.sql Connection ResultSet]))
@@ -143,7 +143,7 @@
 (defmethod driver/execute-reducible-query :sparksql
   [driver {:keys [database settings], {sql :query, :keys [params], :as inner-query} :native, :as outer-query} context respond]
   (let [inner-query (-> (assoc inner-query
-                               :remark (qputil/query->remark :sparksql outer-query)
+                               :remark (qp.util/query->remark :sparksql outer-query)
                                :query  (if (seq params)
                                          (binding [hive-like/*param-splice-style* :paranoid]
                                            (unprepare/unprepare driver (cons sql params)))

--- a/shared/src/metabase/mbql/util/match.clj
+++ b/shared/src/metabase/mbql/util/match.clj
@@ -1,7 +1,7 @@
 (ns metabase.mbql.util.match
   "Internal implementation of the MBQL `match` and `replace` macros. Don't use these directly."
   (:refer-clojure :exclude [replace])
-  (:require [clojure.core.match :as clojure.core.match]
+  (:require clojure.core.match
             [clojure.walk :as walk]
             [metabase.mbql.util.match.impl :as metabase.mbql.util.match.impl]
             [net.cgrand.macrovich :as macros]))

--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -10,7 +10,7 @@
             [metabase.models.interface :as mi]
             [metabase.public-settings :as public-settings]
             [metabase.util :as u]
-            [metabase.util.i18n :as ui18n :refer [deferred-tru tru]]
+            [metabase.util.i18n :as i18n :refer [deferred-tru tru]]
             [metabase.util.schema :as su]
             [schema.core :as s]
             [toucan.db :as db]))
@@ -44,7 +44,7 @@
 (defn- check-one [condition code message]
   (when-not condition
     (let [[message info] (if (and (map? message)
-                                  (not (ui18n/localized-string? message)))
+                                  (not (i18n/localized-string? message)))
                            [(:message message) message]
                            [message])]
       (throw (ex-info (str message) (assoc info :status-code code)))))

--- a/src/metabase/api/common/internal.clj
+++ b/src/metabase/api/common/internal.clj
@@ -6,7 +6,7 @@
             [metabase.async.streaming-response :as streaming-response]
             [metabase.config :as config]
             [metabase.util :as u]
-            [metabase.util.i18n :as ui18n :refer [tru]]
+            [metabase.util.i18n :as i18n :refer [tru]]
             [metabase.util.schema :as su]
             [potemkin.types :as p.types]
             [schema.core :as s])

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -29,7 +29,7 @@
             [metabase.query-processor.error-type :as qp.error-type]
             [metabase.query-processor.middleware.constraints :as constraints]
             [metabase.query-processor.pivot :as qp.pivot]
-            [metabase.query-processor.util :as qp-util]
+            [metabase.query-processor.util  :as qp.util]
             [metabase.related :as related]
             [metabase.util :as u]
             [metabase.util.i18n :refer [tru]]
@@ -160,8 +160,8 @@
   run."
   [{:keys [dataset_query]}]
   (u/ignore-exceptions
-    [(qp-util/query-hash dataset_query)
-     (qp-util/query-hash (assoc dataset_query :constraints constraints/default-query-constraints))]))
+    [(qp.util/query-hash dataset_query)
+     (qp.util/query-hash (assoc dataset_query :constraints constraints/default-query-constraints))]))
 
 (defn- dashcard->query-hashes
   "Return a sequence of all the query hashes for this `dashcard`, including the top-level Card and any Series."

--- a/src/metabase/api/dataset.clj
+++ b/src/metabase/api/dataset.clj
@@ -15,9 +15,9 @@
             [metabase.query-processor :as qp]
             [metabase.query-processor.middleware.constraints :as qp.constraints]
             [metabase.query-processor.middleware.permissions :as qp.perms]
-            [metabase.query-processor.pivot :as pivot]
+            [metabase.query-processor.pivot :as qp.pivot]
             [metabase.query-processor.streaming :as qp.streaming]
-            [metabase.query-processor.util :as qputil]
+            [metabase.query-processor.util :as qp.util]
             [metabase.shared.models.visualization-settings :as mb.viz]
             [metabase.util :as u]
             [metabase.util.i18n :refer [trs tru]]
@@ -33,7 +33,7 @@
   is a wrapper for the function of the same name in the QP util namespace; it adds additional permissions checking as
   well."
   [outer-query]
-  (when-let [source-card-id (qputil/query->source-card-id outer-query)]
+  (when-let [source-card-id (qp.util/query->source-card-id outer-query)]
     (log/info (trs "Source query for this query is Card {0}" source-card-id))
     (api/read-check Card source-card-id)
     source-card-id))
@@ -142,7 +142,7 @@
   ;; try calculating the average for the query as it was given to us, otherwise with the default constraints if
   ;; there's no data there. If we still can't find relevant info, just default to 0
   {:average (or
-             (some (comp query/average-execution-time-ms qputil/query-hash)
+             (some (comp query/average-execution-time-ms qp.util/query-hash)
                    [query
                     (assoc query :constraints qp.constraints/default-query-constraints)])
              0)})
@@ -165,6 +165,6 @@
   (let [info {:executed-by api/*current-user-id*
               :context     :ad-hoc}]
     (qp.streaming/streaming-response [context :api]
-      (pivot/run-pivot-query (assoc query :async? true) info context))))
+      (qp.pivot/run-pivot-query (assoc query :async? true) info context))))
 
 (api/define-routes)

--- a/src/metabase/api/geojson.clj
+++ b/src/metabase/api/geojson.clj
@@ -3,7 +3,7 @@
             [compojure.core :refer [GET]]
             [metabase.api.common :as api]
             [metabase.models.setting :as setting :refer [defsetting]]
-            [metabase.util.i18n :as ui18n :refer [deferred-tru tru]]
+            [metabase.util.i18n :as i18n :refer [deferred-tru tru]]
             [metabase.util.schema :as su]
             [ring.util.codec :as rc]
             [ring.util.response :as rr]

--- a/src/metabase/api/query_description.clj
+++ b/src/metabase/api/query_description.clj
@@ -7,7 +7,7 @@
             [metabase.models.field :refer [Field]]
             [metabase.models.metric :refer [Metric]]
             [metabase.models.segment :refer [Segment]]
-            [metabase.util.i18n :as ui18n :refer [deferred-tru]]
+            [metabase.util.i18n :as i18n :refer [deferred-tru]]
             [toucan.db :as db]))
 
 (defn- get-table-description

--- a/src/metabase/api/session.clj
+++ b/src/metabase/api/session.clj
@@ -18,7 +18,7 @@
             [metabase.server.middleware.session :as mw.session]
             [metabase.server.request.util :as request.u]
             [metabase.util :as u]
-            [metabase.util.i18n :as ui18n :refer [deferred-tru trs tru]]
+            [metabase.util.i18n :as i18n :refer [deferred-tru trs tru]]
             [metabase.util.password :as pass]
             [metabase.util.schema :as su]
             [schema.core :as s]

--- a/src/metabase/async/api_response.clj
+++ b/src/metabase/async/api_response.clj
@@ -14,7 +14,7 @@
             [compojure.response :refer [Sendable]]
             [metabase.server.middleware.exceptions :as mw.exceptions]
             [metabase.util :as u]
-            [metabase.util.i18n :as ui18n :refer [trs]]
+            [metabase.util.i18n :as i18n :refer [trs]]
             [ring.core.protocols :as ring.protocols]
             [ring.util.response :as response])
   (:import clojure.core.async.impl.channels.ManyToManyChannel

--- a/src/metabase/automagic_dashboards/core.clj
+++ b/src/metabase/automagic_dashboards/core.clj
@@ -33,7 +33,7 @@
             [metabase.sync.analyze.classify :as classify]
             [metabase.util :as u]
             [metabase.util.date-2 :as u.date]
-            [metabase.util.i18n :as ui18n :refer [deferred-tru trs tru]]
+            [metabase.util.i18n :as i18n :refer [deferred-tru trs tru]]
             [metabase.util.schema :as su]
             [ring.util.codec :as codec]
             [schema.core :as s]
@@ -574,7 +574,7 @@
   [x context bindings]
   (-> (walk/postwalk
        (fn [form]
-         (if (ui18n/localized-string? form)
+         (if (i18n/localized-string? form)
            (let [s     (str form)
                  new-s (fill-templates :string context bindings s)]
              (if (not= new-s s)

--- a/src/metabase/config.clj
+++ b/src/metabase/config.clj
@@ -3,7 +3,7 @@
             [clojure.java.io :as io]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
-            [environ.core :as environ]
+            [environ.core :as env]
             [metabase.plugins.classloader :as classloader])
   (:import clojure.lang.Keyword
            java.util.UUID))
@@ -58,7 +58,7 @@
    3.  hard coded `app-defaults`"
   [k]
   (let [k       (keyword k)
-        env-val (k environ/env)]
+        env-val (k env/env)]
     (or (when-not (str/blank? env-val) env-val)
         (k app-defaults))))
 
@@ -148,5 +148,5 @@
 (defn mb-user-defaults
   "Default user details provided as a JSON string at launch time for first-user setup flow."
   []
-  (when-let [user-json (environ/env :mb-user-defaults)]
+  (when-let [user-json (env/env :mb-user-defaults)]
     (json/parse-string user-json true)))

--- a/src/metabase/driver/common/parameters/dates.clj
+++ b/src/metabase/driver/common/parameters/dates.clj
@@ -5,7 +5,7 @@
             [metabase.mbql.schema :as mbql.s]
             [metabase.mbql.util :as mbql.u]
             [metabase.models.params :as params]
-            [metabase.query-processor.error-type :as error-type]
+            [metabase.query-processor.error-type :as qp.error-type]
             [metabase.util.date-2 :as u.date]
             [metabase.util.i18n :refer [tru]]
             [metabase.util.schema :as su]
@@ -308,7 +308,7 @@
          ;; if both of the decoders above fail, then the date string is invalid
          (throw (ex-info (tru "Don''t know how to parse date param ''{0}'' — invalid format" date-string)
                   {:param date-string
-                   :type  error-type/invalid-parameter}))))))
+                   :type  qp.error-type/invalid-parameter}))))))
 
 (s/defn date-string->filter :- mbql.s/Filter
   "Takes a string description of a *date* (not datetime) range such as 'lastmonth' or '2016-07-15~2016-08-6' and

--- a/src/metabase/driver/common/parameters/parse.clj
+++ b/src/metabase/driver/common/parameters/parse.clj
@@ -2,7 +2,7 @@
   (:require [clojure.string :as str]
             [clojure.tools.logging :as log]
             [metabase.driver.common.parameters :as i]
-            [metabase.query-processor.error-type :as error-type]
+            [metabase.query-processor.error-type :as qp.error-type]
             [metabase.util :as u]
             [metabase.util.i18n :refer [tru]]
             [schema.core :as s])
@@ -68,17 +68,17 @@
   (when (or (seq more)
             (not (string? k)))
     (throw (ex-info (tru "Invalid '{{...}}' clause: expected a param name")
-             {:type error-type/invalid-query})))
+             {:type qp.error-type/invalid-query})))
   (let [k (str/trim k)]
     (when (empty? k)
       (throw (ex-info (tru "'{{...}}' clauses cannot be empty.")
-               {:type error-type/invalid-query})))
+               {:type qp.error-type/invalid-query})))
     (i/->Param k)))
 
 (defn- optional [& parsed]
   (when-not (some i/Param? parsed)
     (throw (ex-info (tru "'[[...]]' clauses must contain at least one '{{...}}' clause.")
-             {:type error-type/invalid-query})))
+             {:type qp.error-type/invalid-query})))
   (i/->Optional parsed))
 
 (s/defn ^:private parse-tokens* :- [(s/one [ParsedToken] "parsed tokens") (s/one [StringOrToken] "remaining tokens")]
@@ -88,7 +88,7 @@
       nil
       (if (pos? level)
         (throw (ex-info (tru "Invalid query: found '[[' or '{{' with no matching ']]' or '}}'")
-                 {:type error-type/invalid-query}))
+                 {:type qp.error-type/invalid-query}))
         [acc nil])
 
       :optional-begin

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -12,7 +12,7 @@
             [metabase.driver.sql-jdbc.sync :as sql-jdbc.sync]
             [metabase.driver.sql.query-processor :as sql.qp]
             [metabase.plugins.classloader :as classloader]
-            [metabase.query-processor.error-type :as error-type]
+            [metabase.query-processor.error-type :as qp.error-type]
             [metabase.query-processor.store :as qp.store]
             [metabase.util :as u]
             [metabase.util.honeysql-extensions :as hx]
@@ -82,7 +82,7 @@
                   (= user "sa"))        ; "sa" is the default USER
           (throw
            (ex-info (tru "Running SQL queries against H2 databases using the default (admin) database user is forbidden.")
-             {:type error-type/db})))))))
+             {:type qp.error-type/db})))))))
 
 (defmethod driver/execute-reducible-query :h2
   [driver query chans respond]

--- a/src/metabase/driver/sql/parameters/substitute.clj
+++ b/src/metabase/driver/sql/parameters/substitute.clj
@@ -3,7 +3,7 @@
             [metabase.driver :as driver]
             [metabase.driver.common.parameters :as i]
             [metabase.driver.sql.parameters.substitution :as substitution]
-            [metabase.query-processor.error-type :as error-type]
+            [metabase.query-processor.error-type :as qp.error-type]
             [metabase.util.i18n :refer [tru]]))
 
 (defn- substitute-field-filter [[sql args missing] in-optional? k {:keys [field value], :as v}]
@@ -81,12 +81,12 @@
                              (substitute* param->value parsed-query false)
                              (catch Throwable e
                                (throw (ex-info (tru "Unable to substitute parameters: {0}" (ex-message e))
-                                        {:type         (or (:type (ex-data e)) error-type/qp)
+                                        {:type         (or (:type (ex-data e)) qp.error-type/qp)
                                          :params       param->value
                                          :parsed-query parsed-query}
                                         e))))]
     (when (seq missing)
       (throw (ex-info (tru "Cannot run the query: missing required parameters: {0}" (set missing))
-               {:type    error-type/missing-required-parameter
+               {:type    qp.error-type/missing-required-parameter
                 :missing missing})))
     [(str/trim sql) args]))

--- a/src/metabase/driver/sql_jdbc/execute.clj
+++ b/src/metabase/driver/sql_jdbc/execute.clj
@@ -20,7 +20,7 @@
             [metabase.query-processor.reducible :as qp.reducible]
             [metabase.query-processor.store :as qp.store]
             [metabase.query-processor.timezone :as qp.timezone]
-            [metabase.query-processor.util :as qputil]
+            [metabase.query-processor.util :as qp.util]
             [metabase.util :as u]
             [metabase.util.i18n :refer [trs tru]]
             [potemkin :as p])
@@ -488,7 +488,7 @@
   {:added "0.35.0", :arglists '([driver query context respond] [driver sql params max-rows context respond])}
   ([driver {{sql :query, params :params} :native, :as outer-query} context respond]
    {:pre [(string? sql) (seq sql)]}
-   (let [remark   (qputil/query->remark driver outer-query)
+   (let [remark   (qp.util/query->remark driver outer-query)
          sql      (str "-- " remark "\n" sql)
          max-rows (limit/determine-query-max-rows outer-query)]
      (execute-reducible-query driver sql params max-rows context respond)))

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -8,7 +8,7 @@
             [metabase.driver :as driver]
             [metabase.models.setting :refer [defsetting]]
             [metabase.public-settings.premium-features :as premium-features]
-            [metabase.query-processor.error-type :as error-type]
+            [metabase.query-processor.error-type :as qp.error-type]
             [metabase.util :as u]
             [metabase.util.i18n :refer [trs]]
             [toucan.db :as db])
@@ -253,7 +253,7 @@
                                  (recur transitive-props next-acc)
                                  (-> "Cycle detected resolving dependent visible-if properties for driver {0}: {1}"
                                      (trs driver cyclic-props)
-                                     (ex-info {:type               error-type/driver
+                                     (ex-info {:type               qp.error-type/driver
                                                :driver             driver
                                                :cyclic-visible-ifs cyclic-props})
                                      throw)))

--- a/src/metabase/integrations/google.clj
+++ b/src/metabase/integrations/google.clj
@@ -10,7 +10,7 @@
             [metabase.models.user :as user :refer [User]]
             [metabase.plugins.classloader :as classloader]
             [metabase.util :as u]
-            [metabase.util.i18n :as ui18n :refer [deferred-tru trs tru]]
+            [metabase.util.i18n :as i18n :refer [deferred-tru trs tru]]
             [schema.core :as s]
             [toucan.db :as db]))
 

--- a/src/metabase/integrations/ldap/default_implementation.clj
+++ b/src/metabase/integrations/ldap/default_implementation.clj
@@ -6,7 +6,7 @@
             [metabase.integrations.ldap.interface :as i]
             [metabase.models.user :as user :refer [User]]
             [metabase.util :as u]
-            [metabase.util.i18n :as ui18n :refer [trs]]
+            [metabase.util.i18n :as i18n :refer [trs]]
             [metabase.util.schema :as su]
             [pretty.core :refer [PrettyPrintable]]
             [schema.core :as s]

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -16,10 +16,10 @@
             [metabase.moderation :as moderation]
             [metabase.plugins.classloader :as classloader]
             [metabase.public-settings :as public-settings]
-            [metabase.query-processor.util :as qputil]
+            [metabase.query-processor.util :as qp.util]
             [metabase.server.middleware.session :as session]
             [metabase.util :as u]
-            [metabase.util.i18n :as ui18n :refer [tru]]
+            [metabase.util.i18n :as i18n :refer [tru]]
             [toucan.db :as db]
             [toucan.models :as models]))
 
@@ -159,7 +159,7 @@
   forth.)"
   [{query :dataset_query, id :id}]      ; don't use `u/the-id` here so that we can use this with `pre-insert` too
   (loop [query query, ids-already-seen #{id}]
-    (let [source-card-id (qputil/query->source-card-id query)]
+    (let [source-card-id (qp.util/query->source-card-id query)]
       (cond
         (not source-card-id)
         :ok

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -15,7 +15,7 @@
             [metabase.public-settings.premium-features :as settings.premium-features]
             [metabase.util :as u]
             [metabase.util.honeysql-extensions :as hx]
-            [metabase.util.i18n :as ui18n :refer [trs tru]]
+            [metabase.util.i18n :as i18n :refer [trs tru]]
             [metabase.util.schema :as su]
             [potemkin :as p]
             [schema.core :as s]

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -21,7 +21,7 @@
             [metabase.public-settings :as public-settings]
             [metabase.query-processor.async :as qp.async]
             [metabase.util :as u]
-            [metabase.util.i18n :as ui18n :refer [tru]]
+            [metabase.util.i18n :as i18n :refer [tru]]
             [metabase.util.schema :as su]
             [schema.core :as s]
             [toucan.db :as db]
@@ -346,7 +346,7 @@
 (defn save-transient-dashboard!
   "Save a denormalized description of `dashboard`."
   [dashboard parent-collection-id]
-  (let [dashboard  (ui18n/localized-strings->strings dashboard)
+  (let [dashboard  (i18n/localized-strings->strings dashboard)
         dashcards  (:ordered_cards dashboard)
         collection (magic.populate/create-collection!
                     (ensure-unique-collection-name (:name dashboard) parent-collection-id)

--- a/src/metabase/models/params.clj
+++ b/src/metabase/models/params.clj
@@ -8,7 +8,7 @@
             [metabase.mbql.util :as mbql.u]
             [metabase.models.params.field-values :as params.field-values]
             [metabase.util :as u]
-            [metabase.util.i18n :as ui18n :refer [tru]]
+            [metabase.util.i18n :as i18n :refer [tru]]
             [metabase.util.schema :as su]
             [schema.core :as s]
             [toucan.db :as db]

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -184,7 +184,7 @@
             [metabase.public-settings.premium-features :as premium-features]
             [metabase.util :as u]
             [metabase.util.honeysql-extensions :as hx]
-            [metabase.util.i18n :as ui18n :refer [deferred-tru trs tru]]
+            [metabase.util.i18n :as i18n :refer [deferred-tru trs tru]]
             [metabase.util.regex :as u.regex]
             [metabase.util.schema :as su]
             [schema.core :as s]

--- a/src/metabase/models/permissions_group.clj
+++ b/src/metabase/models/permissions_group.clj
@@ -14,7 +14,7 @@
             [metabase.models.setting :as setting]
             [metabase.plugins.classloader :as classloader]
             [metabase.util :as u]
-            [metabase.util.i18n :as ui18n :refer [trs tru]]
+            [metabase.util.i18n :as i18n :refer [trs tru]]
             [toucan.db :as db]
             [toucan.models :as models]))
 

--- a/src/metabase/models/permissions_group_membership.clj
+++ b/src/metabase/models/permissions_group_membership.clj
@@ -1,7 +1,7 @@
 (ns metabase.models.permissions-group-membership
   (:require [metabase.models.permissions-group :as group]
             [metabase.util :as u]
-            [metabase.util.i18n :as ui18n :refer [tru]]
+            [metabase.util.i18n :as i18n :refer [tru]]
             [toucan.db :as db]
             [toucan.models :as models]))
 

--- a/src/metabase/models/query/permissions.clj
+++ b/src/metabase/models/query/permissions.clj
@@ -9,7 +9,7 @@
             [metabase.models.interface :as i]
             [metabase.models.permissions :as perms]
             [metabase.models.table :refer [Table]]
-            [metabase.query-processor.util :as qputil]
+            [metabase.query-processor.util :as qp.util]
             [metabase.util :as u]
             [metabase.util.i18n :refer [tru]]
             [metabase.util.schema :as su]
@@ -117,7 +117,7 @@
   (try
     (let [query (normalize/normalize query)]
       ;; if we are using a Card as our perms are that Card's (i.e. that Card's Collection's) read perms
-      (if-let [source-card-id (qputil/query->source-card-id query)]
+      (if-let [source-card-id (qp.util/query->source-card-id query)]
         (source-card-read-perms source-card-id)
         ;; otherwise if there's no source card then calculate perms based on the Tables referenced in the query
         (let [{:keys [query database]} (cond-> query

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -77,7 +77,7 @@
             [metabase.models.setting.cache :as cache]
             [metabase.util :as u]
             [metabase.util.date-2 :as u.date]
-            [metabase.util.i18n :as ui18n :refer [deferred-trs deferred-tru trs tru]]
+            [metabase.util.i18n :as i18n :refer [deferred-trs deferred-tru trs tru]]
             [schema.core :as s]
             [toucan.db :as db]
             [toucan.models :as models])

--- a/src/metabase/models/setting/cache.clj
+++ b/src/metabase/models/setting/cache.clj
@@ -8,7 +8,7 @@
             [metabase.db.connection :as mdb.connection]
             [metabase.util :as u]
             [metabase.util.honeysql-extensions :as hx]
-            [metabase.util.i18n :as ui18n :refer [trs]]
+            [metabase.util.i18n :as i18n :refer [trs]]
             [toucan.db :as db])
   (:import java.util.concurrent.locks.ReentrantLock))
 

--- a/src/metabase/query_processor.clj
+++ b/src/metabase/query_processor.clj
@@ -12,7 +12,7 @@
             [metabase.mbql.util :as mbql.u]
             [metabase.plugins.classloader :as classloader]
             [metabase.query-processor.context :as context]
-            [metabase.query-processor.error-type :as error-type]
+            [metabase.query-processor.error-type :as qp.error-type]
             [metabase.query-processor.middleware.add-default-temporal-unit :as add-default-temporal-unit]
             [metabase.query-processor.middleware.add-dimension-projections :as add-dim]
             [metabase.query-processor.middleware.add-implicit-clauses :as implicit-clauses]
@@ -166,7 +166,7 @@
     (when (>= *preprocessing-level* max-preprocessing-level)
       (throw (ex-info (str (tru "Infinite loop detected: recursively preprocessed query {0} times."
                                 max-preprocessing-level))
-               {:type error-type/qp})))
+               {:type qp.error-type/qp})))
     (process-query-sync query context)))
 
 (defn query->preprocessed
@@ -186,7 +186,7 @@
   [{query-type :type, :as query}]
   (when-not (= (mbql.u/normalize-token query-type) :query)
     (throw (ex-info (tru "Can only determine expected columns for MBQL queries.")
-             {:type error-type/qp})))
+             {:type qp.error-type/qp})))
   ;; TODO - we should throw an Exception if the query has a native source query or at least warn about it. Need to
   ;; check where this is used.
   (qp.store/with-store

--- a/src/metabase/query_processor/async.clj
+++ b/src/metabase/query_processor/async.clj
@@ -7,7 +7,7 @@
             [metabase.query-processor :as qp]
             [metabase.query-processor.context :as context]
             [metabase.query-processor.interface :as qpi]
-            [metabase.query-processor.util :as qputil]
+            [metabase.query-processor.util :as qp.util]
             [metabase.util :as u]
             [metabase.util.i18n :refer [trs]]
             [schema.core :as s])
@@ -25,7 +25,7 @@
     ;; (normally middleware takes care of calculating query hashes for 'userland' queries but this is not
     ;; technically a userland query -- we don't want to save a QueryExecution -- so we need to add `executed-by`
     ;; and `query-hash` ourselves so the remark gets added)
-    (assoc-in query [:info :query-hash] (qputil/query-hash query))))
+    (assoc-in query [:info :query-hash] (qp.util/query-hash query))))
 
 (defn- async-result-metadata-reducedf [_ result context]
   (let [results-metdata (or (get-in result [:data :results_metadata :columns])

--- a/src/metabase/query_processor/card.clj
+++ b/src/metabase/query_processor/card.clj
@@ -17,7 +17,7 @@
             [metabase.query-processor.middleware.constraints :as constraints]
             [metabase.query-processor.middleware.permissions :as qp.perms]
             [metabase.query-processor.streaming :as qp.streaming]
-            [metabase.query-processor.util :as qputil]
+            [metabase.query-processor.util :as qp.util]
             [metabase.util :as u]
             [metabase.util.i18n :refer [trs tru]]
             [metabase.util.schema :as su]
@@ -29,7 +29,7 @@
   `query-caching-ttl-ratio`. If the TTL is less than a second, this returns `nil` (i.e., the cache should not be
   utilized.)"
   [query]
-  (when-let [average-duration (query/average-execution-time-ms (qputil/query-hash query))]
+  (when-let [average-duration (query/average-execution-time-ms (qp.util/query-hash query))]
     (let [ttl-seconds (Math/round (float (/ (* average-duration (public-settings/query-caching-ttl-ratio))
                                             1000.0)))]
       (when-not (zero? ttl-seconds)

--- a/src/metabase/query_processor/context/default.clj
+++ b/src/metabase/query_processor/context/default.clj
@@ -4,7 +4,7 @@
             [metabase.config :as config]
             [metabase.driver :as driver]
             [metabase.query-processor.context :as context]
-            [metabase.query-processor.error-type :as error-type]
+            [metabase.query-processor.error-type :as qp.error-type]
             [metabase.util :as u]
             [metabase.util.i18n :refer [trs tru]]))
 
@@ -58,7 +58,7 @@
                               (transduce identity rf reducible-rows)
                               (catch Throwable e
                                 (context/raisef (ex-info (tru "Error reducing result rows")
-                                                         {:type error-type/qp}
+                                                         {:type qp.error-type/qp}
                                                          e)
                                                 context)))]
       (context/reducedf metadata reduced-rows context))))
@@ -89,7 +89,7 @@
     (log/debug (trs "Query timed out after {0}, raising timeout exception." (u/format-milliseconds timeout)))
     (context/raisef (ex-info (tru "Timed out after {0}." (u/format-milliseconds timeout))
                       {:status :timed-out
-                       :type   error-type/timed-out})
+                       :type   qp.error-type/timed-out})
                     context)))
 
 (defn- identity1

--- a/src/metabase/query_processor/middleware/add_implicit_clauses.clj
+++ b/src/metabase/query_processor/middleware/add_implicit_clauses.clj
@@ -6,7 +6,7 @@
             [metabase.mbql.util :as mbql.u]
             [metabase.models.field :refer [Field]]
             [metabase.models.table :as table]
-            [metabase.query-processor.error-type :as error-type]
+            [metabase.query-processor.error-type :as qp.error-type]
             [metabase.query-processor.store :as qp.store]
             [metabase.types :as types]
             [metabase.util :as u]
@@ -46,7 +46,7 @@
     (when (empty? fields)
       (throw (ex-info (tru "No fields found for table {0}." (pr-str (:name (qp.store/table table-id))))
                       {:table-id table-id
-                       :type     error-type/invalid-query})))
+                       :type     qp.error-type/invalid-query})))
     (mapv
      (fn [field]
        ;; implicit datetime Fields get bucketing of `:default`. This is so other middleware doesn't try to give it
@@ -114,7 +114,7 @@
       ;; if the Table has no Fields, throw an Exception, because there is no way for us to proceed
       (when-not (seq fields)
         (throw (ex-info (tru "Table ''{0}'' has no Fields associated with it." (:name (qp.store/table source-table-id)))
-                        {:type error-type/invalid-query})))
+                        {:type qp.error-type/invalid-query})))
       ;; add the fields & expressions under the `:fields` clause
       (assoc inner-query :fields (vec (concat fields expressions))))))
 

--- a/src/metabase/query_processor/middleware/add_implicit_joins.clj
+++ b/src/metabase/query_processor/middleware/add_implicit_joins.clj
@@ -9,7 +9,7 @@
             [metabase.mbql.util :as mbql.u]
             [metabase.models.field :refer [Field]]
             [metabase.models.table :refer [Table]]
-            [metabase.query-processor.error-type :as error-type]
+            [metabase.query-processor.error-type :as qp.error-type]
             [metabase.query-processor.middleware.add-implicit-clauses :as add-implicit-clauses]
             [metabase.query-processor.store :as qp.store]
             [metabase.util :as u]
@@ -184,7 +184,7 @@
       (when-not (driver/supports? driver/*driver* :foreign-keys)
         (throw (ex-info (tru "{0} driver does not support foreign keys." driver/*driver*)
                  {:driver driver/*driver*
-                  :type   error-type/unsupported-feature})))
+                  :type   qp.error-type/unsupported-feature})))
       (update query :query resolve-implicit-joins))
     query))
 

--- a/src/metabase/query_processor/middleware/add_rows_truncated.clj
+++ b/src/metabase/query_processor/middleware/add_rows_truncated.clj
@@ -1,10 +1,10 @@
 (ns metabase.query-processor.middleware.add-rows-truncated
   "Adds `:rows_truncated` to the query results if the results were truncated because of the query's constraints."
   (:require [metabase.query-processor.interface :as i]
-            [metabase.query-processor.util :as qputil]))
+            [metabase.query-processor.util :as qp.util]))
 
 (defn- results-limit [{{:keys [max-results max-results-bare-rows]} :constraints, :as query}]
-  (or (when (qputil/query-without-aggregations-or-limits? query)
+  (or (when (qp.util/query-without-aggregations-or-limits? query)
         max-results-bare-rows)
       max-results
       i/absolute-max-results))

--- a/src/metabase/query_processor/middleware/annotate.clj
+++ b/src/metabase/query_processor/middleware/annotate.clj
@@ -9,7 +9,7 @@
             [metabase.mbql.schema :as mbql.s]
             [metabase.mbql.util :as mbql.u]
             [metabase.models.humanization :as humanization]
-            [metabase.query-processor.error-type :as error-type]
+            [metabase.query-processor.error-type :as qp.error-type]
             [metabase.query-processor.reducible :as qp.reducible]
             [metabase.query-processor.store :as qp.store]
             [metabase.sync.analyze.fingerprint.fingerprinters :as f]
@@ -49,7 +49,7 @@
 (defmethod column-info :default
   [{query-type :type, :as query} _]
   (throw (ex-info (tru "Unknown query type {0}" (pr-str query-type))
-           {:type  error-type/invalid-query
+           {:type  qp.error-type/invalid-query
             :query query})))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -69,7 +69,7 @@
                                expected-count actual-count))
                  {:expected-columns (map :name cols)
                   :first-row        (first rows)
-                  :type             error-type/qp}))))))
+                  :type             qp.error-type/qp}))))))
 
 (defn- annotate-native-cols [cols]
   (let [unique-name-fn (mbql.u/unique-name-generator)]

--- a/src/metabase/query_processor/middleware/auto_parse_filter_values.clj
+++ b/src/metabase/query_processor/middleware/auto_parse_filter_values.clj
@@ -6,7 +6,7 @@
   historic reasons. When time permits it should be moved into this middleware since it's really a separate
   transformation from wrapping the value literals themselves."
   (:require [metabase.mbql.util :as mbql.u]
-            [metabase.query-processor.error-type :as error-type]
+            [metabase.query-processor.error-type :as qp.error-type]
             [metabase.util.i18n :refer [tru]]
             [metabase.util.schema :as su]
             [schema.core :as s]))
@@ -26,7 +26,7 @@
                            base-type
                            (pr-str v)
                            base-type)
-                      {:type error-type/invalid-query}
+                      {:type qp.error-type/invalid-query}
                       e)))))
 
 (defn- auto-parse-filter-values* [query]

--- a/src/metabase/query_processor/middleware/binning.clj
+++ b/src/metabase/query_processor/middleware/binning.clj
@@ -5,7 +5,7 @@
             [metabase.mbql.schema :as mbql.s]
             [metabase.mbql.util :as mbql.u]
             [metabase.public-settings :as public-settings]
-            [metabase.query-processor.error-type :as error-type]
+            [metabase.query-processor.error-type :as qp.error-type]
             [metabase.query-processor.store :as qp.store]
             [metabase.util :as u]
             [metabase.util.i18n :refer [tru]]
@@ -47,7 +47,7 @@
                                                global-max)]
     (when-not (and min-value max-value)
       (throw (ex-info (tru "Unable to bin Field without a min/max value")
-               {:type        error-type/invalid-query
+               {:type        qp.error-type/invalid-query
                 :field-id    field-id
                 :fingerprint fingerprint})))
     {:min-value min-value, :max-value max-value}))

--- a/src/metabase/query_processor/middleware/cache.clj
+++ b/src/metabase/query_processor/middleware/cache.clj
@@ -20,7 +20,7 @@
             [metabase.query-processor.middleware.cache-backend.db :as backend.db]
             [metabase.query-processor.middleware.cache-backend.interface :as i]
             [metabase.query-processor.middleware.cache.impl :as impl]
-            [metabase.query-processor.util :as qputil]
+            [metabase.query-processor.util :as qp.util]
             [metabase.util :as u]
             [metabase.util.i18n :refer [trs]])
   (:import org.eclipse.jetty.io.EofException))
@@ -169,7 +169,7 @@
   [qp {:keys [cache-ttl middleware], :as query} rff context]
   ;; TODO - Query will already have `info.hash` if it's a userland query. I'm not 100% sure it will be the same hash,
   ;; because this is calculated after normalization, instead of before
-  (let [query-hash (qputil/query-hash query)
+  (let [query-hash (qp.util/query-hash query)
         result     (maybe-reduce-cached-results (:ignore-cached-results? middleware) query-hash cache-ttl rff context)]
     (when (= result ::miss)
       (let [start-time-ms (System/currentTimeMillis)]

--- a/src/metabase/query_processor/middleware/catch_exceptions.clj
+++ b/src/metabase/query_processor/middleware/catch_exceptions.clj
@@ -2,7 +2,7 @@
   "Middleware for catching exceptions thrown by the query processor and returning them in a friendlier format."
   (:require [clojure.tools.logging :as log]
             [metabase.query-processor.context :as context]
-            [metabase.query-processor.error-type :as error-type]
+            [metabase.query-processor.error-type :as qp.error-type]
             [metabase.query-processor.middleware.permissions :as perms]
             [metabase.query-processor.reducible :as qp.reducible]
             [metabase.util :as u]
@@ -70,7 +70,7 @@
      ((get-method format-exception Throwable) e)
      (when (= error-type :schema.core/error)
        (merge
-        {:error_type error-type/invalid-query}
+        {:error_type qp.error-type/invalid-query}
         (when-let [error-msg (explain-schema-validation-error error)]
           {:error error-msg})))
      (when (error-type/known-error-type? error-type)

--- a/src/metabase/query_processor/middleware/check_features.clj
+++ b/src/metabase/query_processor/middleware/check_features.clj
@@ -2,7 +2,7 @@
   (:require [metabase.driver :as driver]
             [metabase.mbql.schema :as mbql.s]
             [metabase.mbql.util :as mbql.u]
-            [metabase.query-processor.error-type :as error-type]
+            [metabase.query-processor.error-type :as qp.error-type]
             [metabase.query-processor.store :as qp.store]
             [metabase.util :as u]
             [metabase.util.i18n :refer [tru]]))
@@ -12,7 +12,7 @@
   [feature]
   (when-not (driver/database-supports? driver/*driver* feature (qp.store/database))
     (throw (ex-info (tru "{0} is not supported by this driver." (name feature))
-                    {:type    error-type/unsupported-feature
+                    {:type    qp.error-type/unsupported-feature
                      :feature feature}))))
 
 ;; TODO - definitely a little incomplete. It would be cool if we cool look at the metadata in the schema namespace and

--- a/src/metabase/query_processor/middleware/limit.clj
+++ b/src/metabase/query_processor/middleware/limit.clj
@@ -3,12 +3,12 @@
   (:require [metabase.mbql.util :as mbql.u]
             [metabase.models.setting :as setting]
             [metabase.query-processor.interface :as i]
-            [metabase.query-processor.util :as qputil]))
+            [metabase.query-processor.util :as qp.util]))
 
 (defn- add-limit [max-rows {query-type :type, :as query}]
   (cond-> query
     (and (= query-type :query)
-         (qputil/query-without-aggregations-or-limits? query))
+         (qp.util/query-without-aggregations-or-limits? query))
     (assoc-in [:query :limit] max-rows)))
 
 (defn- limit-xform [max-rows rf]

--- a/src/metabase/query_processor/middleware/normalize_query.clj
+++ b/src/metabase/query_processor/middleware/normalize_query.clj
@@ -2,7 +2,7 @@
   "Middleware that converts a query into a normalized, canonical form."
   (:require [clojure.tools.logging :as log]
             [metabase.mbql.normalize :as normalize]
-            [metabase.query-processor.error-type :as error-type]
+            [metabase.query-processor.error-type :as qp.error-type]
             [metabase.util :as u]))
 
 (defn normalize
@@ -16,7 +16,7 @@
                      (log/tracef "Normalized query:\n%s" (u/pprint-to-str <>)))
                    (catch Throwable e
                      (throw (ex-info (.getMessage e)
-                                     {:type  error-type/invalid-query
+                                     {:type  qp.error-type/invalid-query
                                       :query query}
                                      e))))]
       (qp query' rff context))))

--- a/src/metabase/query_processor/middleware/permissions.clj
+++ b/src/metabase/query_processor/middleware/permissions.clj
@@ -8,7 +8,7 @@
             [metabase.models.permissions :as perms]
             [metabase.models.query.permissions :as query-perms]
             [metabase.plugins.classloader :as classloader]
-            [metabase.query-processor.error-type :as error-type]
+            [metabase.query-processor.error-type :as qp.error-type]
             [metabase.query-processor.middleware.resolve-referenced :as qp.resolve-referenced]
             [metabase.util :as u]
             [metabase.util.i18n :refer [tru]]
@@ -27,7 +27,7 @@
 
   ([message required-perms & [additional-ex-data]]
    (ex-info message
-            (merge {:type                 error-type/missing-required-permissions
+            (merge {:type                 qp.error-type/missing-required-permissions
                     :required-permissions required-perms
                     :actual-permissions   @*current-user-permissions-set*
                     :permissions-error?   true}
@@ -56,7 +56,7 @@
   [card-id :- su/IntGreaterThanZero]
   (let [{collection-id :collection_id, :as card} (or (db/select-one [Card :collection_id] :id card-id)
                                                      (throw (ex-info (tru "Card {0} does not exist." card-id)
-                                                                     {:type    error-type/invalid-query
+                                                                     {:type    qp.error-type/invalid-query
                                                                       :card-id card-id})))]
     (log/tracef "Required perms to run Card: %s" (pr-str (mi/perms-objects-set card :read)))
     (when-not (mi/can-read? card)

--- a/src/metabase/query_processor/middleware/process_userland_query.clj
+++ b/src/metabase/query_processor/middleware/process_userland_query.clj
@@ -7,7 +7,7 @@
             [metabase.events :as events]
             [metabase.models.query :as query]
             [metabase.models.query-execution :as query-execution :refer [QueryExecution]]
-            [metabase.query-processor.util :as qputil]
+            [metabase.query-processor.util :as qp.util]
             [metabase.util.i18n :refer [trs]]
             [toucan.db :as db]))
 
@@ -128,7 +128,7 @@
   etc.). This includes recording QueryExecution entries and returning the results in an FE-client-friendly format."
   [qp]
   (fn [query rff {:keys [raisef], :as context}]
-    (let [query          (assoc-in query [:info :query-hash] (qputil/query-hash query))
+    (let [query          (assoc-in query [:info :query-hash] (qp.util/query-hash query))
           execution-info (query-execution-info query)]
       (letfn [(rff* [metadata]
                 (add-and-save-execution-info-xform! execution-info (rff metadata)))

--- a/src/metabase/query_processor/middleware/resolve_database_and_driver.clj
+++ b/src/metabase/query_processor/middleware/resolve_database_and_driver.clj
@@ -2,7 +2,7 @@
   (:require [metabase.driver :as driver]
             [metabase.mbql.schema :as mbql.s]
             [metabase.models.setting :as setting]
-            [metabase.query-processor.error-type :as error-type]
+            [metabase.query-processor.error-type :as qp.error-type]
             [metabase.query-processor.store :as qp.store]
             [metabase.util :as u]
             [metabase.util.i18n :refer [tru]]))
@@ -20,7 +20,7 @@
     (when-not ((every-pred integer? pos?) database-id)
       (throw (ex-info (tru "Unable to resolve database for query: missing or invalid `:database` ID.")
                       {:database database-id
-                       :type     error-type/invalid-query})))
+                       :type     qp.error-type/invalid-query})))
     (resolve-database* query)
     (let [{:keys [settings], driver :engine} (qp.store/database)]
       ;; make sure the driver is initialized.
@@ -28,7 +28,7 @@
         (driver/the-initialized-driver driver)
         (catch Throwable e
           (throw (ex-info (tru "Unable to resolve driver for query")
-                          {:type error-type/invalid-query}
+                          {:type qp.error-type/invalid-query}
                           e))))
       (binding [setting/*database-local-values* settings]
         (driver/with-driver driver

--- a/src/metabase/query_processor/middleware/resolve_joined_fields.clj
+++ b/src/metabase/query_processor/middleware/resolve_joined_fields.clj
@@ -4,7 +4,7 @@
             [clojure.tools.logging :as log]
             [metabase.mbql.schema :as mbql.s]
             [metabase.mbql.util :as mbql.u]
-            [metabase.query-processor.error-type :as error-type]
+            [metabase.query-processor.error-type :as qp.error-type]
             [metabase.query-processor.store :as qp.store]
             [metabase.util :as u]
             [metabase.util.i18n :refer [tru]]
@@ -46,7 +46,7 @@
             (throw (ex-info (tru "Cannot resolve joined field due to ambiguous joins: table {0} (ID {1}) joined multiple times. You need to specify an explicit `:join-alias` in the field reference."
                                  name field-id)
                             {:field      field
-                             :error      error-type/invalid-query
+                             :error      qp.error-type/invalid-query
                              :joins      joins
                              :candidates candidate-tables}))))))))
 

--- a/src/metabase/server/middleware/exceptions.clj
+++ b/src/metabase/server/middleware/exceptions.clj
@@ -4,7 +4,7 @@
             [clojure.string :as str]
             [clojure.tools.logging :as log]
             [metabase.server.middleware.security :as mw.security]
-            [metabase.util.i18n :as ui18n :refer [trs]])
+            [metabase.util.i18n :as i18n :refer [trs]])
   (:import java.sql.SQLException
            org.eclipse.jetty.io.EofException))
 

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -7,7 +7,7 @@
             [metabase.models.setting :refer [defsetting]]
             [metabase.public-settings :as public-settings]
             [metabase.server.request.util :as request.u]
-            [metabase.util.i18n :as ui18n :refer [deferred-tru]]
+            [metabase.util.i18n :as i18n :refer [deferred-tru]]
             [ring.util.codec :refer [base64-encode]])
   (:import java.security.MessageDigest))
 

--- a/src/metabase/server/request/util.clj
+++ b/src/metabase/server/request/util.clj
@@ -8,7 +8,7 @@
             [metabase.config :as config]
             [metabase.public-settings :as public-settings]
             [metabase.util :as u]
-            [metabase.util.i18n :as ui18n :refer [trs tru]]
+            [metabase.util.i18n :as i18n :refer [trs tru]]
             [metabase.util.schema :as su]
             [schema.core :as s]
             [user-agent :as user-agent]))

--- a/src/metabase/transforms/specs.clj
+++ b/src/metabase/transforms/specs.clj
@@ -2,7 +2,7 @@
   (:require [medley.core :as m]
             [metabase.domain-entities.specs :refer [FieldType MBQL]]
             [metabase.mbql.normalize :as mbql.normalize]
-            [metabase.mbql.schema :as mbql.schema]
+            [metabase.mbql.schema :as mbql.s]
             [metabase.mbql.util :as mbql.u]
             [metabase.util :as u]
             [metabase.util.schema :as su]
@@ -28,7 +28,7 @@
 
 (def ^:private Joins [{(s/required-key :source)    Source
                        (s/required-key :condition) MBQL
-                       (s/optional-key :strategy)  mbql.schema/JoinStrategy}])
+                       (s/optional-key :strategy)  mbql.s/JoinStrategy}])
 
 (def ^:private TransformName s/Str)
 
@@ -91,7 +91,7 @@
                                    breakout)))
     FieldType                (partial keyword "type")
     [DomainEntity]           u/one-or-many
-    mbql.schema/JoinStrategy keyword
+    mbql.s/JoinStrategy keyword
     ;; Since `Aggregation` and `Expressions` are structurally the same, we can't use them directly
     {Dimension MBQL}         (comp (partial u/topological-sort extract-dimensions)
                                    stringify-keys)

--- a/src/metabase/troubleshooting.clj
+++ b/src/metabase/troubleshooting.clj
@@ -2,7 +2,7 @@
   (:require [clojure.java.jdbc :as jdbc]
             [clojure.java.jmx :as jmx]
             [metabase.analytics.stats :as mus]
-            [metabase.config :as mc]
+            [metabase.config :as config]
             [metabase.db :as mdb]
             [metabase.driver :as driver]
             [toucan.db :as db])
@@ -36,8 +36,8 @@
                                                   :version (.getDatabaseProductVersion metadata)}
                                     :jdbc-driver {:name    (.getDriverName metadata)
                                                   :version (.getDriverVersion metadata)}})
-   :run-mode                     (mc/config-kw :mb-run-mode)
-   :version                      mc/mb-version-info
+   :run-mode                     (config/config-kw :mb-run-mode)
+   :version                      config/mb-version-info
    :settings                     {:report-timezone (driver/report-timezone)}})
 
 (defn- conn-pool-bean-diag-info [acc ^ObjectName jmx-bean]

--- a/test/metabase/api/dataset_test.clj
+++ b/test/metabase/api/dataset_test.clj
@@ -17,7 +17,7 @@
             [metabase.models.query-execution :refer [QueryExecution]]
             [metabase.query-processor-test :as qp.test]
             [metabase.query-processor.middleware.constraints :as constraints]
-            [metabase.query-processor.util :as qp-util]
+            [metabase.query-processor.util :as qp.util]
             [metabase.test :as mt]
             [metabase.test.data.users :as test-users]
             [metabase.test.fixtures :as fixtures]
@@ -52,7 +52,7 @@
   ;; and retry if it's not there yet.
   (letfn [(thunk []
             (db/select-one QueryExecution
-                           :hash (qp-util/query-hash query)
+                           :hash (qp.util/query-hash query)
                            {:order-by [[:started_at :desc]]}))]
     (loop [retries 3]
       (or (thunk)

--- a/test/metabase/api/query_description_test.clj
+++ b/test/metabase/api/query_description_test.clj
@@ -6,7 +6,7 @@
             [metabase.models.table :refer [Table]]
             [metabase.test :as mt]
             [metabase.test.fixtures :as fixtures]
-            [metabase.util.i18n :as ui18n :refer [deferred-tru]]
+            [metabase.util.i18n :as i18n :refer [deferred-tru]]
             [toucan.util.test :as tt]))
 
 (use-fixtures :once (fixtures/initialize :db))

--- a/test/metabase/query_processor/middleware/cache_test.clj
+++ b/test/metabase/query_processor/middleware/cache_test.clj
@@ -20,7 +20,7 @@
             [metabase.query-processor.middleware.cache.impl-test :as impl-test]
             [metabase.query-processor.middleware.process-userland-query :as process-userland-query]
             [metabase.query-processor.streaming :as qp.streaming]
-            [metabase.query-processor.util :as qputil]
+            [metabase.query-processor.util :as qp.util]
             [metabase.server.middleware.session :as session]
             [metabase.test :as mt]
             [metabase.test.fixtures :as fixtures]
@@ -266,7 +266,7 @@
     (with-mock-cache [save-chan]
       (run-query)
       (mt/wait-for-result save-chan)
-      (let [query-hash (qputil/query-hash (test-query nil))]
+      (let [query-hash (qp.util/query-hash (test-query nil))]
         (testing "Cached results should exist"
           (is (= true
                  (i/cached-results cache/*backend* query-hash 100
@@ -327,7 +327,7 @@
   (testing "Cached results don't impact average execution time"
     (let [query                         (assoc (mt/mbql-query venues {:order-by [[:asc $id]] :limit 42})
                                                :cache-ttl 5000)
-          q-hash                        (qputil/query-hash query)
+          q-hash                        (qp.util/query-hash query)
           call-count                    (atom 0)
           called-promise                (promise)
           save-query-execution-original (var-get #'process-userland-query/save-query-execution!*)]

--- a/test/metabase/query_processor/middleware/catch_exceptions_test.clj
+++ b/test/metabase/query_processor/middleware/catch_exceptions_test.clj
@@ -4,7 +4,7 @@
             [metabase.models.permissions-group :as group]
             [metabase.query-processor :as qp]
             [metabase.query-processor.context :as context]
-            [metabase.query-processor.error-type :as error-type]
+            [metabase.query-processor.error-type :as qp.error-type]
             [metabase.query-processor.middleware.catch-exceptions :as catch-exceptions]
             [metabase.test :as mt]
             [metabase.test.data :as data]
@@ -24,7 +24,7 @@
   (testing "Should nicely format a chain of exceptions, with the top-level Exception appearing first"
     (testing "lowest-level error `:type` should be pulled up to the top-level"
       (let [e1 (ex-info "1" {:level 1})
-            e2 (ex-info "2" {:level 2, :type error-type/qp} e1)
+            e2 (ex-info "2" {:level 2, :type qp.error-type/qp} e1)
             e3 (ex-info "3" {:level 3} e2)]
         (is (= {:status     :failed
                 :class      clojure.lang.ExceptionInfo

--- a/test/metabase/query_processor/middleware/permissions_test.clj
+++ b/test/metabase/query_processor/middleware/permissions_test.clj
@@ -6,7 +6,7 @@
             [metabase.models.permissions :as perms]
             [metabase.models.permissions-group :as perms-group]
             [metabase.query-processor :as qp]
-            [metabase.query-processor.error-type :as error-type]
+            [metabase.query-processor.error-type :as qp.error-type]
             [metabase.query-processor.middleware.permissions :as qp.perms]
             [metabase.test :as mt]
             [metabase.util :as u]
@@ -220,7 +220,7 @@
                     :ex-data  {:required-permissions (s/eq #{(perms/table-query-path (mt/id) "PUBLIC" (mt/id :venues))})
                                :actual-permissions   (s/eq #{})
                                :permissions-error?   (s/eq true)
-                               :type                 (s/eq error-type/missing-required-permissions)
+                               :type                 (s/eq qp.error-type/missing-required-permissions)
                                s/Keyword             s/Any}
                     s/Keyword s/Any}
                    (mt/suppress-output

--- a/test/metabase/query_processor/middleware/process_userland_query_test.clj
+++ b/test/metabase/query_processor/middleware/process_userland_query_test.clj
@@ -3,9 +3,9 @@
             [clojure.test :refer :all]
             [metabase.events :as events]
             [metabase.query-processor.context :as context]
-            [metabase.query-processor.error-type :as error-type]
+            [metabase.query-processor.error-type :as qp.error-type]
             [metabase.query-processor.middleware.process-userland-query :as process-userland-query]
-            [metabase.query-processor.util :as qputil]
+            [metabase.query-processor.util :as qp.util]
             [metabase.test :as mt]))
 
 (defn- do-with-query-execution [query run]
@@ -18,7 +18,7 @@
               (:running_time qe) (update :running_time int?)
               (:hash qe)         (update :hash (fn [^bytes a-hash]
                                                  (when a-hash
-                                                   (java.util.Arrays/equals a-hash (qputil/query-hash query))))))))))))
+                                                   (java.util.Arrays/equals a-hash (qp.util/query-hash query))))))))))))
 
 (defmacro ^:private with-query-execution {:style/indent 1} [[qe-result-binding query] & body]
   `(do-with-query-execution ~query (fn [~qe-result-binding] ~@body)))
@@ -71,7 +71,7 @@
            clojure.lang.ExceptionInfo
            #"Oops!"
            (process-userland-query query {:runf (fn [_ _ context]
-                                                  (context/raisef (ex-info "Oops!" {:type error-type/qp})
+                                                  (context/raisef (ex-info "Oops!" {:type qp.error-type/qp})
                                                                   context))})))
       (is (= {:hash         true
               :database_id  nil

--- a/test/metabase/query_processor/middleware/results_metadata_test.clj
+++ b/test/metabase/query_processor/middleware/results_metadata_test.clj
@@ -6,7 +6,7 @@
             [metabase.models.permissions :as perms]
             [metabase.models.permissions-group :as group]
             [metabase.query-processor :as qp]
-            [metabase.query-processor.util :as qputil]
+            [metabase.query-processor.util :as qp.util]
             [metabase.sync.analyze.query-results :as qr]
             [metabase.test :as mt]
             [metabase.test.mock.util :as mutil]
@@ -79,7 +79,7 @@
       (let [result (qp/process-userland-query
                     (assoc (mt/native-query {:query "SELECT ID, NAME, PRICE, CATEGORY_ID, LATITUDE, LONGITUDE FROM VENUES"})
                            :info {:card-id    (u/the-id card)
-                                  :query-hash (qputil/query-hash {})}))]
+                                  :query-hash (qp.util/query-hash {})}))]
         (when-not (= :completed (:status result))
           (throw (ex-info "Query failed." result))))
       (is (= default-card-results-native
@@ -188,7 +188,7 @@
                    :aggregation  [[:count]]
                    :breakout     [[:field (mt/id :checkins :date) {:temporal-unit :year}]]}
         :info     {:card-id    (u/the-id card)
-                   :query-hash (qputil/query-hash {})}})
+                   :query-hash (qp.util/query-hash {})}})
       (is (= [{:base_type    :type/DateTime
                :effective_type    :type/DateTime
                :coercion_strategy nil


### PR DESCRIPTION
This is part of the project towards making the `.clj-kondo/config.edn` file the one we use in CI. Add a bunch of expected namespace aliases to the kondo config and fix them.

Also add some of the option linters we enable for the version we use for GitHub actions.