### PR TITLE
Fix model toast messages say "question" instead of "model"

### DIFF
--- a/frontend/src/metabase/entities/questions.js
+++ b/frontend/src/metabase/entities/questions.js
@@ -28,18 +28,22 @@ const Questions = createEntity({
   },
 
   objectActions: {
-    setArchived: ({ id }, archived, opts) =>
+    setArchived: ({ id, model }, archived, opts) =>
       Questions.actions.update(
         { id },
         { archived },
-        undo(opts, "question", archived ? "archived" : "unarchived"),
+        undo(
+          opts,
+          model === "dataset" ? "model" : "question",
+          archived ? "archived" : "unarchived",
+        ),
       ),
 
-    setCollection: ({ id }, collection, opts) =>
+    setCollection: ({ id, model }, collection, opts) =>
       Questions.actions.update(
         { id },
         { collection_id: canonicalCollectionId(collection && collection.id) },
-        undo(opts, "question", "moved"),
+        undo(opts, model === "dataset" ? "model" : "question", "moved"),
       ),
 
     setPinned: ({ id }, pinned, opts) =>

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -161,11 +161,23 @@ describe("collection permissions", () => {
 
               describe("archive", () => {
                 it("should be able to archive/unarchive question (metabase#15253)", () => {
-                  archiveUnarchive("Orders");
+                  archiveUnarchive("Orders", "question");
                 });
 
                 it("should be able to archive/unarchive dashboard", () => {
-                  archiveUnarchive("Orders in a dashboard");
+                  archiveUnarchive("Orders in a dashboard", "dashboard");
+                });
+
+                it("should be able to archive/unarchive model", () => {
+                  cy.skipOn(user === "nodata");
+                  cy.createNativeQuestion({
+                    name: "Model",
+                    dataset: true,
+                    native: {
+                      query: "SELECT * FROM ORDERS",
+                    },
+                  });
+                  archiveUnarchive("Model", "model");
                 });
 
                 describe("archive page", () => {
@@ -296,12 +308,12 @@ describe("collection permissions", () => {
                   });
                 });
 
-                function archiveUnarchive(item) {
+                function archiveUnarchive(item, expectedEntityName) {
                   cy.visit("/collection/root");
                   openEllipsisMenuFor(item);
                   cy.findByText("Archive this item").click();
                   cy.findByText(item).should("not.exist");
-                  cy.findByText(/Archived (question|dashboard)/);
+                  cy.findByText(`Archived ${expectedEntityName}`);
                   cy.findByText("Undo").click();
                   cy.findByText(
                     "Sorry, you don’t have permission to see that.",


### PR DESCRIPTION
Fixes undo toast message appearing on the bottom left after archiving/moving a model would say "question" instead of "model"

### To Verify

1. Open collections
2. Move a model to another collection, you should see a "Moved model" toast message in the bottom left
3. Archive & unarchive a model, you should see a "Archived model" / "Unarchived model" toast message in the bottom left
4. Repeat the same steps, but for a regular saved question, it should still use "question"