### PR TITLE
Revision history fixes

### DIFF
--- a/frontend/src/metabase/lib/revisions/revisions.js
+++ b/frontend/src/metabase/lib/revisions/revisions.js
@@ -200,7 +200,7 @@ function getRevisionEpochTimestamp(revision) {
 
 export const REVISION_EVENT_ICON = "pencil";
 
-export function getRevisionEventsForTimeline(revisions = [], canWrite) {
+export function getRevisionEventsForTimeline(revisions = [], { canWrite }) {
   return revisions
     .filter(isValidRevision)
     .map((revision, index) => {

--- a/frontend/src/metabase/lib/revisions/revisions.js
+++ b/frontend/src/metabase/lib/revisions/revisions.js
@@ -190,8 +190,11 @@ export function isValidRevision(revision) {
   return getChangedFields(revision).length > 0;
 }
 
-function getRevisionUsername(revision) {
-  return revision.user.common_name;
+function getRevisionUsername(revision, currentUser) {
+  const revisionUser = revision.user;
+  return revisionUser.id === currentUser?.id
+    ? t`You`
+    : revisionUser.common_name;
 }
 
 function getRevisionEpochTimestamp(revision) {
@@ -200,12 +203,15 @@ function getRevisionEpochTimestamp(revision) {
 
 export const REVISION_EVENT_ICON = "pencil";
 
-export function getRevisionEventsForTimeline(revisions = [], { canWrite }) {
+export function getRevisionEventsForTimeline(
+  revisions = [],
+  { currentUser, canWrite = false },
+) {
   return revisions
     .filter(isValidRevision)
     .map((revision, index) => {
       const isRevertable = canWrite && index !== 0;
-      const username = getRevisionUsername(revision);
+      const username = getRevisionUsername(revision, currentUser);
       const changes = getRevisionDescription(revision);
 
       const event = {

--- a/frontend/src/metabase/lib/revisions/revisions.js
+++ b/frontend/src/metabase/lib/revisions/revisions.js
@@ -65,13 +65,15 @@ function getSeriesChangeDescription(prevCards, cards) {
 
 function getCollectionChangeDescription(prevCollectionId, collectionId) {
   const key = `collection-from-${prevCollectionId}-to-${collectionId}`;
-  return jt`moved this to ${(
-    <EntityLink
-      key={key}
-      entityId={collectionId || "root"}
-      entityType="collections"
-    />
-  )}`;
+  return [
+    jt`moved this to ${(
+      <EntityLink
+        key={key}
+        entityId={collectionId || "root"}
+        entityType="collections"
+      />
+    )}`,
+  ];
 }
 
 const CHANGE_DESCRIPTIONS = {
@@ -232,7 +234,8 @@ export function getRevisionEventsForTimeline(
       if (
         !revision.is_creation &&
         !revision.is_reversion &&
-        Array.isArray(changes)
+        Array.isArray(changes) &&
+        changes.length > 1
       ) {
         event.title = t`${username} edited this`;
         event.description = <RevisionBatchedDescription changes={changes} />;

--- a/frontend/src/metabase/lib/revisions/revisions.js
+++ b/frontend/src/metabase/lib/revisions/revisions.js
@@ -223,6 +223,14 @@ export function getRevisionEventsForTimeline(
         revision,
       };
 
+      const isChangeEvent = !revision.is_creation && !revision.is_reversion;
+
+      // For some events, like moving an item to another collection,
+      // the `changes` object are an array, however they represent a single change
+      // This happens when we need to have JSX inside a message (e.g. a link to a new collection)
+      const isMultipleFieldsChange =
+        Array.isArray(changes) && changes.length > 1;
+
       // If > 1 item's fields are changed in a single revision,
       // the changes are batched into a single string like:
       // "added a description, moved cards around and archived this"
@@ -230,13 +238,7 @@ export function getRevisionEventsForTimeline(
       // we want to show the changelog in a description and set a title to just "User edited this"
       // If only one field is changed, we just show everything in the title
       // like "John added a description"
-
-      if (
-        !revision.is_creation &&
-        !revision.is_reversion &&
-        Array.isArray(changes) &&
-        changes.length > 1
-      ) {
+      if (isChangeEvent && isMultipleFieldsChange) {
         event.title = t`${username} edited this`;
         event.description = <RevisionBatchedDescription changes={changes} />;
       } else {

--- a/frontend/src/metabase/lib/revisions/revisions.unit.spec.js
+++ b/frontend/src/metabase/lib/revisions/revisions.unit.spec.js
@@ -425,11 +425,9 @@ describe("getRevisionEvents", () => {
   const revisionEvents = [latestRevisionEvent, changeEvent, creationEvent];
 
   it("should convert a revision object into an object for use in a <Timeline /> component", () => {
-    const canWrite = false;
-    const timelineEvents = getRevisionEventsForTimeline(
-      revisionEvents,
-      canWrite,
-    );
+    const timelineEvents = getRevisionEventsForTimeline(revisionEvents, {
+      canWrite: false,
+    });
 
     expect(timelineEvents).toEqual([
       getExpectedEvent({
@@ -456,28 +454,23 @@ describe("getRevisionEvents", () => {
   });
 
   it("should set the `isRevertable` to false when the user doesn't have write access", () => {
-    const canWrite = false;
-    const timelineEvents = getRevisionEventsForTimeline(
-      revisionEvents,
-      canWrite,
-    );
+    const timelineEvents = getRevisionEventsForTimeline(revisionEvents, {
+      canWrite: false,
+    });
 
     expect(timelineEvents.every(event => event.isRevertable)).toBe(false);
   });
 
   it("should set the `isRevertable` to true on all revisions that are not the most recent revision when the user has write access", () => {
-    const canWrite = true;
-    const timelineEvents = getRevisionEventsForTimeline(
-      revisionEvents,
-      canWrite,
-    );
+    const timelineEvents = getRevisionEventsForTimeline(revisionEvents, {
+      canWrite: true,
+    });
 
     expect(timelineEvents[0].isRevertable).toBe(false);
     expect(timelineEvents[1].isRevertable).toBe(true);
   });
 
   it("should drop invalid revisions", () => {
-    const canWrite = true;
     const timelineEvents = getRevisionEventsForTimeline(
       [
         changeEvent,
@@ -486,7 +479,7 @@ describe("getRevisionEvents", () => {
           after: null,
         }),
       ],
-      canWrite,
+      { canWrite: true },
     );
     expect(timelineEvents).toEqual([
       getExpectedEvent({
@@ -498,7 +491,6 @@ describe("getRevisionEvents", () => {
   });
 
   it("should drop revisions with not registered fields", () => {
-    const canWrite = true;
     const timelineEvents = getRevisionEventsForTimeline(
       [
         changeEvent,
@@ -509,7 +501,7 @@ describe("getRevisionEvents", () => {
           after: { "dont-know-this-field": 2 },
         }),
       ],
-      canWrite,
+      { canWrite: true },
     );
     expect(timelineEvents).toEqual([
       getExpectedEvent({

--- a/frontend/src/metabase/lib/revisions/revisions.unit.spec.js
+++ b/frontend/src/metabase/lib/revisions/revisions.unit.spec.js
@@ -14,6 +14,7 @@ const DEFAULT_EPOCH_TIMESTAMP = new Date(DEFAULT_TIMESTAMP).valueOf();
 function getRevision({
   isCreation = false,
   isReversion = false,
+  userId = 1,
   username = "Foo",
   before,
   after,
@@ -25,6 +26,7 @@ function getRevision({
       after,
     },
     user: {
+      id: userId,
       common_name: username,
     },
     is_creation: isCreation,
@@ -508,6 +510,25 @@ describe("getRevisionEvents", () => {
         title: <RevisionTitle username="Foo" message="added a description" />,
         isRevertable: false,
         revision: changeEvent,
+      }),
+    ]);
+  });
+
+  it("should use 'You' instead of a username if it's current user", () => {
+    const currentUser = { id: 5 };
+    const event = getRevision({
+      isCreation: true,
+      userId: currentUser.id,
+    });
+    const timelineEvents = getRevisionEventsForTimeline([event], {
+      currentUser,
+    });
+
+    expect(timelineEvents).toEqual([
+      getExpectedEvent({
+        title: <RevisionTitle username="You" message="created this" />,
+        isRevertable: false,
+        revision: event,
       }),
     ]);
   });

--- a/frontend/src/metabase/query_builder/components/QuestionActivityTimeline.jsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActivityTimeline.jsx
@@ -99,7 +99,9 @@ export function QuestionActivityTimeline({
       usersById,
       currentUser,
     );
-    const revisionEvents = getRevisionEventsForTimeline(revisions, canWrite);
+    const revisionEvents = getRevisionEventsForTimeline(revisions, {
+      canWrite,
+    });
     return [...revisionEvents, ...moderationEvents];
   }, [canWrite, moderationReviews, revisions, usersById, currentUser]);
 

--- a/frontend/src/metabase/query_builder/components/QuestionActivityTimeline.jsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActivityTimeline.jsx
@@ -16,11 +16,10 @@ import { getQuestionDetailsTimelineDrawerState } from "metabase/query_builder/se
 
 import Revision from "metabase/entities/revisions";
 import User from "metabase/entities/users";
-import Timeline from "metabase/components/Timeline";
 import DrawerSection, {
   STATES as DRAWER_STATES,
 } from "metabase/components/DrawerSection/DrawerSection";
-import { RevertButton } from "./QuestionActivityTimeline.styled";
+import { Timeline, RevertButton } from "./QuestionActivityTimeline.styled";
 
 const { getModerationTimelineEvents } = PLUGIN_MODERATION;
 

--- a/frontend/src/metabase/query_builder/components/QuestionActivityTimeline.jsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActivityTimeline.jsx
@@ -100,6 +100,7 @@ export function QuestionActivityTimeline({
       currentUser,
     );
     const revisionEvents = getRevisionEventsForTimeline(revisions, {
+      currentUser,
       canWrite,
     });
     return [...revisionEvents, ...moderationEvents];

--- a/frontend/src/metabase/query_builder/components/QuestionActivityTimeline.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActivityTimeline.styled.jsx
@@ -1,6 +1,11 @@
 import styled from "styled-components";
 import { color } from "metabase/lib/colors";
 import ActionButton from "metabase/components/ActionButton";
+import DefaultTimeline from "metabase/components/Timeline";
+
+export const Timeline = styled(DefaultTimeline)`
+  padding-bottom: 1em;
+`;
 
 export const RevertButton = styled(ActionButton).attrs({
   successClassName: "",


### PR DESCRIPTION
1. For current user's actions, makes it display messages like "You changed this" instead of "John Doe changed this"
2. Fixes how "moved to $COLLECTION_NAME" messages are displayed
3. Adds extra bottom padding to events timeline, so there is some extra space between the last event and the end of the sidebar

### To Verify

1. Open a question/modal with many revisions. Click its name to open the details sidebar and then click the "History" link at the bottom of the sidebar
2. Make sure changes made by you use "You" instead of your name
3. Make sure "move" events are displayed like "$USERNAME moved this to $COLLECTION_NAME"
4. Make sure there is some extra space between the end of the sidebar and the last revision message

### Demo

<details>
<summary>Fix for current user's name</summary>

**Before**

![current-user-before](https://user-images.githubusercontent.com/17258145/151370704-97ff44a7-aeba-48d0-a817-2cd5545f4d8f.png)

**After**

<img width="175" alt="current-user-after" src="https://user-images.githubusercontent.com/17258145/151370715-accdeb5c-3348-4986-9140-6aaec4ee02aa.png">

</details>

<details>
<summary>Fix for "move" event</summary>

**Before**

![move-before](https://user-images.githubusercontent.com/17258145/151370736-4f71700b-b91d-41ec-8934-a616522dd562.png)

**After**

<img width="254" alt="move-after" src="https://user-images.githubusercontent.com/17258145/151370747-134920e0-2a3f-4a7e-8be5-593f7dc42bc0.png">

</details>

<details>
<summary>Extra bottom space</summary>

**Before**

<img width="225" alt="bottom-space-before" src="https://user-images.githubusercontent.com/17258145/151370762-24bebe6a-ffa1-4e7f-8714-8710d8e6574f.png">

**After**

![bottom-space-after](https://user-images.githubusercontent.com/17258145/151370757-2d6e5f64-8ed0-4a87-a001-6a00d3aa06e1.png)

</details>