### PR TITLE
Dashboard Subscription overview: display useful piece of text, instead of null 

### DIFF
--- a/frontend/src/metabase/sharing/components/PulsesListSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/PulsesListSidebar.jsx
@@ -219,41 +219,49 @@ PulseDetails.propTypes = {
 };
 
 function friendlySchedule(channel) {
+  const {
+    channel_type,
+    details,
+    schedule_day,
+    schedule_frame,
+    schedule_hour,
+    schedule_type,
+  } = channel;
+
   let scheduleString = "";
-  if (channel.channel_type === "email") {
+
+  if (channel_type === "email") {
     scheduleString += t`Emailed `;
-  } else if (channel.channel_type === "slack") {
-    scheduleString += t`Sent to ` + channel.details.channel + " ";
+  } else if (channel_type === "slack") {
+    scheduleString += t`Sent to ` + details.channel + " ";
   } else {
     scheduleString += t`Sent `;
   }
 
-  switch (channel.schedule_type) {
+  switch (schedule_type) {
     case "hourly":
       scheduleString += t`hourly`;
       break;
     case "daily": {
-      const ampm = formatHourAMPM(channel.schedule_hour);
+      const ampm = formatHourAMPM(schedule_hour);
       scheduleString += t`daily at ${ampm}`;
       break;
     }
     case "weekly": {
-      const ampm = formatHourAMPM(channel.schedule_hour);
-      const day = formatDay(channel.schedule_day);
+      const ampm = formatHourAMPM(schedule_hour);
+      const day = formatDay(schedule_day);
       scheduleString += t`${day} at ${ampm}`;
       break;
     }
     case "monthly": {
-      const ampm = formatHourAMPM(channel.schedule_hour);
-      const day = channel.schedule_day
-        ? formatDay(channel.schedule_day) + " "
-        : "calendar day";
-      const frame = formatFrame(channel.schedule_frame);
+      const ampm = formatHourAMPM(schedule_hour);
+      const day = schedule_day ? formatDay(schedule_day) : "calendar day";
+      const frame = formatFrame(schedule_frame);
       scheduleString += t`monthly on the ${frame} ${day} at ${ampm}`;
       break;
     }
     default:
-      scheduleString += channel.schedule_type;
+      scheduleString += schedule_type;
   }
 
   return scheduleString;

--- a/frontend/src/metabase/sharing/components/PulsesListSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/PulsesListSidebar.jsx
@@ -245,7 +245,9 @@ function friendlySchedule(channel) {
     }
     case "monthly": {
       const ampm = formatHourAMPM(channel.schedule_hour);
-      const day = formatDay(channel.schedule_day);
+      const day = channel.schedule_day
+        ? formatDay(channel.schedule_day) + " "
+        : "calendar day";
       const frame = formatFrame(channel.schedule_frame);
       scheduleString += t`monthly on the ${frame} ${day} at ${ampm}`;
       break;


### PR DESCRIPTION
Fixes #17916

### How to Test
1. Go to dashboard with a card
2. Click Sharing :arrow_upper_right: 
3.  Dashboard subscriptions
4. Create a subscription for "Monthly" with either "15th (Midpoint)" or "First"/"Last" and "Calendar Day"

![image](https://user-images.githubusercontent.com/1447303/133584854-6ec3b2ed-339a-40b9-9b5c-ad8df53b4168.png)

#### After

In the overview it makes it explicit we're talking about `calendar day`s.

![image](https://user-images.githubusercontent.com/380816/151411102-46fe0870-97d9-4b81-b9c7-2ca801e8be5b.png)

#### Before 

In the overview it showed `null`

![image](https://user-images.githubusercontent.com/1447303/133585291-385a7bd7-17be-4c51-9b34-97ae73c3fff2.png)