### PR TITLE
Unused bindings part1

### DIFF
--- a/.lsp/config.edn
+++ b/.lsp/config.edn
@@ -1,4 +1,8 @@
 {:keep-require-at-start?        true
  :show-docs-arity-on-same-line? true
  :project-specs                 [{:project-path "deps.edn"
-                                  :classpath-cmd ["clojure" "-A:dev:ee:ee-dev:drivers:drivers-dev" "-Spath"]}]}
+                                  :classpath-cmd ["clojure" "-A:dev:ee:ee-dev:drivers:drivers-dev" "-Spath"]}]
+
+ :linters {:clojure-lsp/unused-public-var {:level :warning
+                                           :exclude-when-defined-by
+                                           #{metabase.api.common/defendpoint}}}}

--- a/shared/src/metabase/mbql/util.cljc
+++ b/shared/src/metabase/mbql/util.cljc
@@ -326,7 +326,7 @@
 (s/defn add-order-by-clause :- mbql.s/MBQLQuery
   "Add a new `:order-by` clause to an MBQL `inner-query`. If the new order-by clause references a Field that is
   already being used in another order-by clause, this function does nothing."
-  [inner-query :- mbql.s/MBQLQuery, [_ [_ id-or-name :as field], :as order-by-clause] :- mbql.s/OrderBy]
+  [inner-query :- mbql.s/MBQLQuery, [_ [_ id-or-name :as _field], :as order-by-clause] :- mbql.s/OrderBy]
   (let [existing-fields (set (for [[_ [_ id-or-name]] (:order-by inner-query)]
                                id-or-name))]
     (if (existing-fields id-or-name)
@@ -552,7 +552,7 @@
   "Make the names of a sequence of named aggregations unique by adding suffixes such as `_2`."
   [named-aggregations :- [NamedAggregation]]
   (let [unique-names (uniquify-names
-                      (for [[_ wrapped-ag {ag-name :name}] named-aggregations]
+                      (for [[_ _wrapped-ag {ag-name :name}] named-aggregations]
                         ag-name))]
     (map
      (fn [[_ wrapped-ag options] unique-name]

--- a/shared/src/metabase/shared/models/visualization_settings.cljc
+++ b/shared/src/metabase/shared/models/visualization_settings.cljc
@@ -561,7 +561,7 @@
                  (let [k1 (parse-db-column-ref k)
                        v1 (db->norm-column-settings-entries v)]
                    (assoc m k1 v1))
-                 (catch #?(:clj Throwable :cljs js/Error) e
+                 (catch #?(:clj Throwable :cljs js/Error) _e
                    m)))
              {}
              settings))

--- a/shared/src/metabase/types.cljc
+++ b/shared/src/metabase/types.cljc
@@ -322,16 +322,6 @@
 
 ;;; ---------------------------------------------------- Util Fns ----------------------------------------------------
 
-(defn- types->parents
-  "Return a map of various types to their parent types.
-
-  This is intended for export to the frontend as part of `MetabaseBootstrap` so it can build its own implementation of
-  `isa?`."
-  ([] (types->parents :type/*))
-  ([root]
-   (into {} (for [t (descendants root)]
-              {t (parents t)}))))
-
 (defn field-is-type?
   "True if a Metabase `Field` instance has a temporal base or semantic type, i.e. if this Field represents a value
   relating to a moment in time."

--- a/src/metabase/analytics/snowplow.clj
+++ b/src/metabase/analytics/snowplow.clj
@@ -1,6 +1,7 @@
 (ns metabase.analytics.snowplow
   "Functions for sending Snowplow analytics events"
   (:require [clojure.tools.logging :as log]
+            [java-time :as t]
             [medley.core :as m]
             [metabase.config :as config]
             [metabase.models.setting :as setting :refer [defsetting Setting]]
@@ -166,7 +167,7 @@
                   ;; For instances that were started before this setting was added (in 0.41.3), use the creation
                   ;; timestamp of the first user. For all new instances, use the timestamp at which this setting
                   ;; is first read.
-                  (let [value (or (first-user-creation) (java-time/offset-date-time))]
+                  (let [value (or (first-user-creation) (t/offset-date-time))]
                     (setting/set-value-of-type! :timestamp :instance-creation value)
                     (track-event! ::new-instance-created)))
                 (setting/get-value-of-type :timestamp :instance-creation)))

--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -98,7 +98,7 @@
   (cond
     (config/config-str :rds-hostname)        :elastic-beanstalk
     (config/config-str :database-url)        :heroku ;; Putting this last as 'database-url' seems least specific
-    :default                                 :unknown))
+    :else                                    :unknown))
 
 (defn- instance-settings
   "Figure out global info about this instance"

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -74,7 +74,7 @@
                                     :write
                                     :none))))
 
-(defn- card-database-supports-nested-queries? [{{database-id :database} :dataset_query, :as card}]
+(defn- card-database-supports-nested-queries? [{{database-id :database} :dataset_query, :as _card}]
   (when database-id
     (when-let [driver (driver.u/database->driver database-id)]
       (driver/supports? driver :nested-queries))))

--- a/src/metabase/api/field.clj
+++ b/src/metabase/api/field.clj
@@ -64,7 +64,7 @@
     ;; ...but if we do, return the Field <3
     field))
 
-(defn- clear-dimension-on-fk-change! [{{dimension-id :id dimension-type :type} :dimensions :as field}]
+(defn- clear-dimension-on-fk-change! [{{dimension-id :id dimension-type :type} :dimensions :as _field}]
   (when (and dimension-id (= :external dimension-type))
     (db/delete! Dimension :id dimension-id))
   true)
@@ -85,7 +85,7 @@
 (defn- clear-dimension-on-type-change!
   "Removes a related dimension if the field is moving to a type that
   does not support remapping"
-  [{{old-dim-id :id, old-dim-type :type} :dimensions, :as old-field} base-type new-semantic-type]
+  [{{old-dim-id :id, old-dim-type :type} :dimensions, :as _old-field} base-type new-semantic-type]
   (when (and old-dim-id
              (= :internal old-dim-type)
              (not (internal-remapping-allowed? base-type new-semantic-type)))

--- a/src/metabase/api/geojson.clj
+++ b/src/metabase/api/geojson.clj
@@ -105,7 +105,7 @@
                   is     (ReaderInputStream. reader)]
         (respond (-> (rr/response is)
                      (rr/content-type "application/json"))))
-      (catch Throwable e
+      (catch Throwable _e
         (raise (ex-info (tru "GeoJSON URL failed to load") {:status-code 400}))))
     (raise (ex-info (tru "Invalid custom GeoJSON key: {0}" key) {:status-code 400}))))
 

--- a/src/metabase/api/segment.clj
+++ b/src/metabase/api/segment.clj
@@ -66,7 +66,7 @@
 (defn- write-check-and-update-segment!
   "Check whether current user has write permissions, then update Segment with values in `body`. Publishes appropriate
   event and returns updated/hydrated Segment."
-  [id {:keys [revision_message archived], :as body}]
+  [id {:keys [revision_message], :as body}]
   (let [existing   (api/write-check Segment id)
         clean-body (u/select-keys-when body
                      :present #{:description :caveats :points_of_interest}

--- a/src/metabase/api/setup.clj
+++ b/src/metabase/api/setup.clj
@@ -70,7 +70,7 @@
       ;; return user ID, session ID, and the Session object itself
       {:session-id session-id, :user-id user-id, :session session})))
 
-(defn- setup-maybe-create-and-invite-user! [{:keys [email first_name last_name] :as user}, invitor]
+(defn- setup-maybe-create-and-invite-user! [{:keys [email] :as user}, invitor]
   (when email
     (if-not (email/email-configured?)
       (log/error (trs "Could not invite user because email is not configured."))
@@ -93,7 +93,7 @@
        (when schedules
          (sync.schedules/schedule-map->cron-strings schedules))))))
 
-(defn- setup-set-settings! [request {:keys [email site-name site-locale allow-tracking?]}]
+(defn- setup-set-settings! [_request {:keys [email site-name site-locale allow-tracking?]}]
   ;; set a couple preferences
   (public-settings/site-name site-name)
   (public-settings/admin-email email)

--- a/src/metabase/api/tiles.clj
+++ b/src/metabase/api/tiles.clj
@@ -109,7 +109,7 @@
         (throw (Exception. (tru "No appropriate image writer found!"))))
       (.flush output-stream)
       (.toByteArray output-stream)
-      (catch Throwable e
+      (catch Throwable _e
         (byte-array 0)) ; return empty byte array if we fail for some reason
       (finally
         (u/ignore-exceptions

--- a/src/metabase/async/api_response.clj
+++ b/src/metabase/async/api_response.clj
@@ -49,7 +49,7 @@
     (.write out (str \newline))
     (.flush out)
     true
-    (catch EofException e
+    (catch EofException _e
       (log/debug (u/format-color 'yellow (trs "connection closed, canceling request")))
       false)
     (catch Throwable e
@@ -199,5 +199,5 @@
                     :status 202))))
 
 ;; everthing in this namespace is deprecated!
-(doseq [[symb varr] (ns-interns *ns*)]
+(doseq [[_symb varr] (ns-interns *ns*)]
   (alter-meta! varr assoc :deprecated "0.35.0"))

--- a/src/metabase/async/streaming_response.clj
+++ b/src/metabase/async/streaming_response.clj
@@ -60,7 +60,7 @@
         (catch Throwable e
           (log/error e (trs "Error writing error to output stream") obj))))))
 
-(defn- do-f* [f ^OutputStream os finished-chan canceled-chan]
+(defn- do-f* [f ^OutputStream os _finished-chan canceled-chan]
   (try
     (f os canceled-chan)
     (catch EofException _
@@ -178,7 +178,7 @@
 
 (defn- respond
   [{:keys [^HttpServletResponse response ^AsyncContext async-context request-map response-map request]}
-   f {:keys [content-type status headers], :as options} finished-chan]
+   f {:keys [content-type status headers], :as _options} finished-chan]
   (let [canceled-chan (a/promise-chan)]
     (try
       (.setStatus response (or status 202))
@@ -209,7 +209,7 @@
     (list (pretty/qualify-symbol-for-*ns* `->StreamingResponse) f options donechan))
 
   server.protocols/Respond
-  (respond [this context]
+  (respond [_this context]
     (respond context f options donechan))
 
   ;; sync responses only (in some cases?)

--- a/src/metabase/automagic_dashboards/comparison.clj
+++ b/src/metabase/automagic_dashboards/comparison.clj
@@ -272,7 +272,7 @@
                               :parameters        []
                               :related           (update-related (:related dashboard) left right)}
                              (add-title-row left right))))
-                      ([[dashboard row]] dashboard)
+                      ([[dashboard _row]] dashboard)
                       ([[dashboard row] card]
                        [(comparison-row dashboard row left right card)
                         (+ row (:height card))]))))))

--- a/src/metabase/automagic_dashboards/core.clj
+++ b/src/metabase/automagic_dashboards/core.clj
@@ -312,7 +312,7 @@
       reference)))
 
 (defmethod ->reference [:string (type Field)]
-  [_ {:keys [display_name full-name link table_id]}]
+  [_ {:keys [display_name full-name link]}]
   (cond
     full-name full-name
     link      (format "%s → %s"
@@ -1111,7 +1111,7 @@
 (defmulti
   ^{:private true
     :arglists '([fieldset [op & args]])}
-  humanize-filter-value (fn [_ [op & args]]
+  humanize-filter-value (fn [_ [op & _args]]
                           (qp.util/normalize-token op)))
 
 (def ^:private unit-name (comp {:minute-of-hour  (deferred-tru "minute")
@@ -1127,7 +1127,7 @@
 (defn- field-name
   ([root field-reference]
    (->> field-reference (field-reference->field root) field-name))
-  ([{:keys [display_name unit] :as field}]
+  ([{:keys [display_name unit] :as _field}]
    (cond->> display_name
      (some-> unit u.date/extract-units) (tru "{0} of {1}" (unit-name unit)))))
 
@@ -1169,7 +1169,7 @@
   (boolean (let [coll-zip (zip/zipper coll? #(if (map? %) (vals %) %) nil coll)]
             (loop [x coll-zip]
               (when-not (zip/end? x)
-                (if-let [v (k (zip/node x))] true (recur (zip/next x))))))))
+                (if (k (zip/node x)) true (recur (zip/next x))))))))
 
 (defn- splice-in
   [join-statement card-member]

--- a/src/metabase/automagic_dashboards/core.clj
+++ b/src/metabase/automagic_dashboards/core.clj
@@ -144,10 +144,12 @@
   [table]
   (isa? (:entity_type table) :entity/GoogleAnalyticsTable))
 
-(defmulti
-  ^{:doc ""
-    :arglists '([entity])}
-  ->root type)
+(defmulti ->root
+  "root is a datatype that is an entity augmented with metadata for the purposes of creating an automatic dashboard with
+  respect to that entity. It is called a root because the automated dashboard uses productions to recursively create a
+  tree of dashboard cards to fill the dashboards. This multimethod is for turning a given entity into a root."
+  {:arglists '([entity])}
+  type)
 
 (defmethod ->root (type Table)
   [table]

--- a/src/metabase/automagic_dashboards/filters.clj
+++ b/src/metabase/automagic_dashboards/filters.clj
@@ -110,7 +110,7 @@
 
 (defn- filter-type
   "Return filter type for a given field."
-  [{:keys [base_type semantic_type] :as field}]
+  [{:keys [semantic_type] :as field}]
   (cond
     (temporal? field)                   "date/all-options"
     (isa? semantic_type :type/State)    "location/state"

--- a/src/metabase/automagic_dashboards/populate.clj
+++ b/src/metabase/automagic_dashboards/populate.clj
@@ -253,7 +253,7 @@
 (defn create-dashboard
   "Create dashboard and populate it with cards."
   ([dashboard] (create-dashboard dashboard :all))
-  ([{:keys [title transient_title description groups filters cards refinements]} n]
+  ([{:keys [title transient_title description groups filters cards]} n]
    (let [n             (cond
                          (= n :all)   (count cards)
                          (keyword? n) (Integer/parseInt (name n))

--- a/src/metabase/automagic_dashboards/visualization_macros.clj
+++ b/src/metabase/automagic_dashboards/visualization_macros.clj
@@ -9,7 +9,7 @@
 
 (defmethod expand-visualization "smart-row"
   [card dimensions metrics]
-  (let [[display settings] (:visualization card)]
+  (let [[_display settings] (:visualization card)]
     (-> card
         (assoc :visualization (if (->> dimensions
                                        (keep #(get-in % [:fingerprint :global :distinct-count]))

--- a/src/metabase/cmd.clj
+++ b/src/metabase/cmd.clj
@@ -168,7 +168,7 @@
     ((resolve 'metabase.cmd.rotate-encryption-key/rotate-encryption-key!) new-key)
     (log/info "Encryption key rotation OK.")
     (system-exit! 0)
-    (catch Throwable e
+    (catch Throwable _e
       (log/error "ERROR ROTATING KEY.")
       (system-exit! 1))))
 

--- a/src/metabase/cmd/endpoint_dox.clj
+++ b/src/metabase/cmd/endpoint_dox.clj
@@ -87,7 +87,7 @@
   []
   (for [ns-symb     u/metabase-namespace-symbols
         :when       (str/includes? (name ns-symb) "metabase.api")
-        [symb varr] (do (classloader/require ns-symb)
+        [_sym varr] (do (classloader/require ns-symb)
                         (sort (ns-interns ns-symb)))
         :when       (:is-endpoint? (meta varr))]
     (meta varr)))

--- a/src/metabase/db/setup.clj
+++ b/src/metabase/db/setup.clj
@@ -52,6 +52,8 @@
    data-source :- javax.sql.DataSource
    direction   :- s/Keyword]
   (with-open [conn (.getConnection data-source)]
+    ;; TODO: this try has no catch. We need to make sure the catches are at the right level and possibly remove this
+    ;; outer try?
     (try
       (.setAutoCommit conn false)
       ;; Set up liquibase and let it do its thing

--- a/src/metabase/domain_entities/core.clj
+++ b/src/metabase/domain_entities/core.clj
@@ -56,7 +56,7 @@
     [:field name {:base-type base_type}]))
 
 (defn- has-attribute?
-  [entity {:keys [field domain_entity has_many]}]
+  [entity {:keys [field _domain_entity _has_many]}]
   (cond
     field (some (fn [col]
                   (when (or (isa? (field-type col) field)
@@ -84,7 +84,7 @@
           (resolve-dimension-clauses bindings source entity))))
 
 (defn- instantiate-domain-entity
-  [table {:keys [name description required_attributes optional_attributes metrics segments breakout_dimensions type]}]
+  [table {:keys [name description metrics segments breakout_dimensions type]}]
   (let [dimensions (into {} (for [field (:fields table)]
                               [(-> field field-type clojure.core/name) field]))
         bindings   {name {:entity     table

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -15,8 +15,7 @@
             [metabase.util.schema :as su]
             [potemkin :as p]
             [schema.core :as s]
-            [toucan.db :as db])
-  (:import org.joda.time.DateTime))
+            [toucan.db :as db]))
 
 (declare notify-database-updated)
 
@@ -438,7 +437,7 @@
 
     (database-supports? :mongo :set-timezone mongo-db) ; -> true"
   {:arglists '([driver feature database]), :added "0.41.0"}
-  (fn [driver feature database]
+  (fn [driver feature _database]
     (when-not (driver-features feature)
       (throw (Exception. (tru "Invalid driver feature: {0}" feature))))
     [(dispatch-on-initialized-driver driver) feature])

--- a/src/metabase/driver/common.clj
+++ b/src/metabase/driver/common.clj
@@ -251,7 +251,7 @@
              (when-let [ips (public-settings/cloud-gateway-ips)]
                (str (deferred-tru "If your database is behind a firewall, you may need to allow connections from our Metabase Cloud IP addresses:")
                     "\n"
-                    (str/join " - " (public-settings/cloud-gateway-ips)))))})
+                    (str/join " - " ips))))})
 
 (def default-connection-info-fields
   "Default definitions for informational banners that can be included in a database connection form. These keys can be
@@ -335,15 +335,13 @@
   (driver/with-driver driver
     (let [native-query    (current-db-time-native-query driver)
           date-formatters (current-db-time-date-formatters driver)
-          settings        (when-let [report-tz (driver.u/report-timezone-if-supported driver)]
-                            {:settings {:report-timezone report-tz}})
           time-str        (try
                             ;; need to initialize the store since we're calling `execute-reducible-query` directly
                             ;; instead of going thru normal QP pipeline
                             (qp.store/with-store
                               (qp.store/fetch-and-store-database! (u/the-id database))
                               (let [query {:database (u/the-id database), :native {:query native-query}}
-                                    reduce (fn [metadata reducible-rows]
+                                    reduce (fn [_metadata reducible-rows]
                                              (transduce
                                               identity
                                               (fn

--- a/src/metabase/driver/common.clj
+++ b/src/metabase/driver/common.clj
@@ -6,7 +6,6 @@
             [clojure.string :as str]
             [clojure.tools.logging :as log]
             [metabase.driver :as driver]
-            [metabase.driver.util :as driver.u]
             [metabase.models.setting :as setting]
             [metabase.public-settings :as public-settings]
             [metabase.query-processor.context.default :as context.default]

--- a/src/metabase/driver/common/parameters/dates.clj
+++ b/src/metabase/driver/common/parameters/dates.clj
@@ -250,7 +250,7 @@
 
 (s/defn ^:private adjust-inclusive-range-if-needed :- (s/maybe TemporalRange)
   "Make an inclusive date range exclusive as needed."
-  [{:keys [inclusive-start? inclusive-end?]}, {:keys [start end], :as m} :- (s/maybe TemporalRange)]
+  [{:keys [inclusive-start? inclusive-end?]}, {:keys [start end]} :- (s/maybe TemporalRange)]
   (merge
    (when start
      {:start (if inclusive-start?

--- a/src/metabase/driver/common/parameters/operators.clj
+++ b/src/metabase/driver/common/parameters/operators.clj
@@ -55,7 +55,7 @@
 (s/defn to-clause :- mbql.s/Filter
   "Convert an operator style parameter into an mbql clause. Will also do arity checks and throws an ex-info with
   `:type qp.error-type/invalid-parameter` if arity is incorrect."
-  [{param-type :type [a b :as param-value] :value [_ field :as _target] :target :as param}]
+  [{param-type :type [a b :as param-value] :value [_ field :as _target] :target :as _param}]
   (verify-type-and-arity field param-type param-value)
   (let [field' (params/wrap-field-id-if-needed field)]
     (condp = (operator-arity param-type)

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -70,7 +70,7 @@
       (let [[_ {:strs [USER]}] (connection-string->file+options db)]
         USER)))
 
-(defn- check-native-query-not-using-default-user [{query-type :type, database-id :database, :as query}]
+(defn- check-native-query-not-using-default-user [{query-type :type, :as query}]
   (u/prog1 query
     ;; For :native queries check to make sure the DB in question has a (non-default) NAME property specified in the
     ;; connection string. We don't allow SQL execution on H2 databases for the default admin account for security
@@ -313,7 +313,7 @@
   (apply sql-jdbc.sync/post-filtered-active-tables args))
 
 (defmethod sql-jdbc.execute/connection-with-timezone :h2
-  [driver database ^String timezone-id]
+  [driver database ^String _timezone-id]
   ;; h2 doesn't support setting timezones, or changing the transaction level without admin perms, so we can skip those
   ;; steps that are in the default impl
   (let [conn (.getConnection (sql-jdbc.execute/datasource-with-diagnostic-info! driver database))]

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -339,7 +339,7 @@
    (keyword "timestamp without timezone") :type/DateTime})
 
 (defmethod sql-jdbc.sync/database-type->base-type :postgres
-  [driver column]
+  [_driver column]
   (if (contains? *enum-types* column)
     :type/PostgresEnum
     (default-base-types column)))
@@ -449,7 +449,7 @@
 ;; around this by checking whether the column type name is `money`, and reading it out as a String and parsing to a
 ;; BigDecimal if so; otherwise, proceeding as normal
 (defmethod sql-jdbc.execute/read-column-thunk [:postgres Types/DOUBLE]
-  [driver ^ResultSet rs ^ResultSetMetaData rsmeta ^Integer i]
+  [_driver ^ResultSet rs ^ResultSetMetaData rsmeta ^Integer i]
   (if (= (.getColumnTypeName rsmeta i) "money")
     (fn []
       (some-> (.getString rs i) u/parse-currency))

--- a/src/metabase/driver/sql/parameters/substitute.clj
+++ b/src/metabase/driver/sql/parameters/substitute.clj
@@ -6,7 +6,7 @@
             [metabase.query-processor.error-type :as error-type]
             [metabase.util.i18n :refer [tru]]))
 
-(defn- substitute-field-filter [[sql args missing] in-optional? k {:keys [field value], :as v}]
+(defn- substitute-field-filter [[sql args missing] in-optional? k {:keys [_field value], :as v}]
   (if (and (= i/no-value value) in-optional?)
     ;; no-value field filters inside optional clauses are ignored, and eventually emitted entirely
     [sql args (conj missing k)]

--- a/src/metabase/driver/sql/parameters/substitution.clj
+++ b/src/metabase/driver/sql/parameters/substitution.clj
@@ -84,11 +84,11 @@
 
 ;; TIMEZONE FIXME - remove this since we aren't using `Date` anymore
 (s/defmethod ->prepared-substitution [:sql Date] :- PreparedStatementSubstitution
-  [driver date]
+  [_driver date]
   (make-stmt-subs "?" [date]))
 
 (s/defmethod ->prepared-substitution [:sql Temporal] :- PreparedStatementSubstitution
-  [driver t]
+  [_driver t]
   (make-stmt-subs "?" [t]))
 
 
@@ -140,11 +140,11 @@
   (create-replacement-snippet driver this))
 
 (defmethod ->replacement-snippet-info [:sql UUID]
-  [driver this]
+  [_driver this]
   {:replacement-snippet (format "CAST('%s' AS uuid)" (str this))})
 
 (defmethod ->replacement-snippet-info [:sql CommaSeparatedNumbers]
-  [driver {:keys [numbers]}]
+  [_driver {:keys [numbers]}]
   {:replacement-snippet (str/join ", " numbers)})
 
 (defmethod ->replacement-snippet-info [:sql MultipleValues]
@@ -225,7 +225,7 @@
      :prepared-statement-args args}))
 
 (s/defn ^:private field->clause :- mbql.s/field
-  [driver {table-id :table_id, base-type :base_type, field-id :id, :as field} param-type]
+  [_driver {table-id :table_id, field-id :id, :as field} param-type]
   ;; The [[metabase.query-processor.middleware.parameters/substitute-parameters]] QP middleware actually happens before
   ;; the [[metabase.query-processor.middleware.resolve-fields/resolve-fields]] middleware that would normally fetch all
   ;; the Fields we need in a single pass, so this is actually necessary here. I don't think switching the order of the

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -96,7 +96,7 @@
   :hierarchy #'driver/hierarchy)
 
 (defmethod current-datetime-honeysql-form :sql
-  [driver]
+  [_driver]
   :%now)
 
 ;; TODO - rename this to `temporal-bucket` or something that better describes what it actually does
@@ -144,7 +144,7 @@
   ([driver day-of-week offset]
    (adjust-day-of-week driver day-of-week offset hx/mod))
 
-  ([driver
+  ([_driver
     day-of-week
     offset :- s/Int
     mod-fn :- (s/pred fn?)]
@@ -291,7 +291,7 @@
 (defn apply-binning
   "Apply `:binning` options from a `:field` clause; return a new HoneySQL form that bins `honeysql-form`
   appropriately."
-  [{{:keys [bin-width min-value max-value]} :binning} honeysql-form]
+  [{{:keys [bin-width min-value _max-value]} :binning} honeysql-form]
   ;;
   ;; Equation is | (value - min) |
   ;;             | ------------- | * bin-width + min-value
@@ -344,17 +344,19 @@
           allow-casting?       (and field
                                     (not outer-select))
           database-type        (or database-type
-                                   (:database_type field))]
-      (let [identifier (->honeysql driver (apply hx/identifier :field (concat source-table-aliases [source-alias])))]
-        (u/prog1
-          (cond->> identifier
-            allow-casting?           (cast-field-if-needed driver field)
-            database-type            (#(hx/with-database-type-info % database-type))
-            (:temporal-unit options) (apply-temporal-bucketing driver options)
-            (:binning options)       (apply-binning options))
-          (log/trace (binding [*print-meta* true]
-                       (format "Compiled field clause\n%s\n=>\n%s"
-                               (u/pprint-to-str field-clause) (u/pprint-to-str <>)))))))
+                                   (:database_type field))
+          identifier           (->honeysql driver
+                                           (apply hx/identifier :field
+                                                  (concat source-table-aliases [source-alias])))]
+      (u/prog1
+       (cond->> identifier
+         allow-casting?           (cast-field-if-needed driver field)
+         database-type            (#(hx/with-database-type-info % database-type))
+         (:temporal-unit options) (apply-temporal-bucketing driver options)
+         (:binning options)       (apply-binning options))
+       (log/trace (binding [*print-meta* true]
+                    (format "Compiled field clause\n%s\n=>\n%s"
+                            (u/pprint-to-str field-clause) (u/pprint-to-str <>))))))
     (catch Throwable e
       (throw (ex-info (tru "Error compiling :field clause: {0}" (ex-message e))
                       {:clause field-clause}
@@ -603,7 +605,7 @@
 ;;; ----------------------------------------------- breakout & fields ------------------------------------------------
 
 (defmethod apply-top-level-clause [:sql :breakout]
-  [driver _ honeysql-form {breakout-fields :breakout, fields-fields :fields :as query}]
+  [driver _ honeysql-form {breakout-fields :breakout, fields-fields :fields :as _query}]
   (as-> honeysql-form new-hsql
     (apply h/merge-select new-hsql (->> breakout-fields
                                         (remove (set fields-fields))
@@ -749,7 +751,7 @@
    (s/one (s/pred sequential?) "join condition")])
 
 (s/defmethod join->honeysql :sql :- HoneySQLJoin
-  [driver {:keys [condition], join-alias :alias, refs :qp/refs, :as join} :- mbql.s/Join]
+  [driver {:keys [condition], join-alias :alias, :as join} :- mbql.s/Join]
   [[(join-source driver join)
     (->honeysql driver (hx/identifier :table-alias join-alias))]
    (->honeysql driver condition)])
@@ -927,7 +929,7 @@
 (defn mbql->native
   "Transpile MBQL query into a native SQL statement. This is the `:sql` driver implementation
   of [[driver/mbql->native]] (actual multimethod definition is in [[metabase.driver.sql]]."
-  [driver {database :database, :as outer-query}]
+  [driver outer-query]
   (let [honeysql-form (mbql->honeysql driver outer-query)
         [sql & args]  (format-honeysql driver honeysql-form)]
     {:query sql, :params args}))

--- a/src/metabase/driver/sql_jdbc/common.clj
+++ b/src/metabase/driver/sql_jdbc/common.clj
@@ -52,7 +52,7 @@
   ([connection-spec]
    (handle-additional-options connection-spec connection-spec))
   ;; two-arity+options version provided for when `connection-spec` is being built up separately from `details` source
-  ([{connection-string :subname, :as connection-spec} {additional-options :additional-options, :as details} & {:keys [seperator-style]
+  ([{connection-string :subname, :as connection-spec} {additional-options :additional-options, :as _details} & {:keys [seperator-style]
                                                                                                                :or   {seperator-style :url}}]
    (-> (dissoc connection-spec :additional-options)
        (assoc :subname (conn-str-with-additional-opts connection-string seperator-style additional-options)))))

--- a/src/metabase/driver/sql_jdbc/execute/old_impl.clj
+++ b/src/metabase/driver/sql_jdbc/execute/old_impl.clj
@@ -41,7 +41,7 @@
   :hierarchy #'driver/hierarchy)
 
 (defmethod read-column :default
-  [_ col-type ^ResultSet rs _ ^Integer i]
+  [_ _col-type ^ResultSet rs _ ^Integer i]
   (.getObject rs i))
 
 (defn- get-object-of-class [^ResultSet rs, ^Integer index, ^Class klass]

--- a/src/metabase/driver/sql_jdbc/sync/describe_database.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_database.clj
@@ -72,8 +72,8 @@
                 (pr-str sql-args))
     (try
       (execute-select-probe-query driver conn sql-args)
-      (do (log/trace "SELECT privileges confirmed")
-          true)
+      (log/trace "SELECT privileges confirmed")
+      true
       (catch Throwable _
         (log/trace "No SELECT privileges")
         false))))
@@ -134,7 +134,7 @@
         (int? db-or-id-or-spec)
         (Database db-or-id-or-spec)
 
-        true
+        :else
         nil))
 
 (defn describe-database

--- a/src/metabase/driver/sql_jdbc/sync/describe_table.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_table.clj
@@ -170,7 +170,7 @@
         (describe-table* driver conn table)))))
 
 (defn- describe-table-fks*
-  [driver ^Connection conn {^String schema :schema, ^String table-name :name} & [^String db-name-or-nil]]
+  [_driver ^Connection conn {^String schema :schema, ^String table-name :name} & [^String db-name-or-nil]]
   (into
    #{}
    (common/reducible-results #(.getImportedKeys (.getMetaData conn) db-name-or-nil schema table-name)

--- a/src/metabase/driver/sync.clj
+++ b/src/metabase/driver/sync.clj
@@ -33,7 +33,7 @@
                       {::inclusion-patterns inclusion-patterns
                        ::exclusion-patterns exclusion-patterns}))
 
-      true
+      :else
       (let [inclusion? exclusion-blank?
             pattern    (schema-pattern->re-pattern (if inclusion? inclusion-patterns exclusion-patterns))]
         (fn [s]
@@ -55,7 +55,7 @@
   "Given a `prop-nm` (which is expected to be a connection property of type `:schema-filters`), and a `database`
   instance, return a vector containing [inclusion-patterns exclusion-patterns]."
   {:added "0.42.0"}
-  [prop-nm {db-details :details :as database}]
+  [prop-nm {db-details :details :as _database}]
   (let [schema-filter-type     (get db-details (keyword (str prop-nm "-type")))
         schema-filter-patterns (get db-details (keyword (str prop-nm "-patterns")))
         exclusion-type?        (= "exclusion" schema-filter-type)]

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -138,7 +138,7 @@
     (name k)
     (str k)))
 
-(defn- expand-secret-conn-prop [{prop-name :name, visible-if :visible-if, :as conn-prop}]
+(defn- expand-secret-conn-prop [{prop-name :name, :as conn-prop}]
   (case (->str (:secret-kind conn-prop))
     "password"    [(-> conn-prop
                        (assoc :type "password")
@@ -156,7 +156,7 @@
   "Invokes the getter function on a info type connection property and adds it to the connection property map as its
   placeholder value. Returns nil if no placeholder value or getter is provided, or if the getter returns a non-string
   value or throws an exception."
-  [{prop-name :name, getter :getter, placeholder :placeholder, :as conn-prop}]
+  [{ getter :getter, placeholder :placeholder, :as conn-prop}]
   (let [content (or placeholder
                     (try (getter)
                          (catch Throwable e
@@ -282,7 +282,7 @@
                                            (assoc acc (keyword (:name prop)) prop))
                                    {}
                                    (connection-props-server->client driver (vals secret-names->props)))]
-      (reduce-kv (fn [acc prop-name prop]
+      (reduce-kv (fn [acc prop-name _prop]
                    (let [subprop    (fn [suffix]
                                       (keyword (str prop-name suffix)))
                          path-kw    (subprop "-path")

--- a/src/metabase/email.clj
+++ b/src/metabase/email.clj
@@ -201,7 +201,7 @@
 
   Attempts to connect with different `:security` options. If able to connect successfully, returns working
   [[SMTPSettings]]. If unable to connect with any `:security` options, returns an [[SMTPStatus]] with the `::error`."
-  [{:keys [port security], :as details} :- SMTPSettings]
+  [details :- SMTPSettings]
   (let [initial-attempt (test-smtp-settings details)]
     (if-not (::error initial-attempt)
       details

--- a/src/metabase/email/messages.clj
+++ b/src/metabase/email/messages.clj
@@ -3,7 +3,6 @@
    NOTE: we want to keep this about email formatting, so don't put heavy logic here RE: building data for emails."
   (:require [clojure.core.cache :as cache]
             [clojure.java.io :as io]
-            [clojure.string :as str]
             [clojure.tools.logging :as log]
             [hiccup.core :refer [html]]
             [java-time :as t]

--- a/src/metabase/email/messages.clj
+++ b/src/metabase/email/messages.clj
@@ -47,21 +47,6 @@
   (alter-meta! #'stencil.core/render-file assoc :style/indent 1)
   (stencil-loader/set-cache (cache/ttl-cache-factory {} :ttl 0)))
 
-(def ^:private ^:const data-uri-svg-regex #"^data:image/svg\+xml;base64,(.*)$")
-
-(defn- data-uri-svg? [url]
-  (re-matches data-uri-svg-regex url))
-
-(defn- themed-image-url
-  [url color]
-  (try
-    (let [base64 (second (re-matches data-uri-svg-regex url))
-          svg    (u/decode-base64 base64)
-          themed (str/replace svg #"<svg\b([^>]*)( fill=\"[^\"]*\")([^>]*)>" (str "<svg$1$3 fill=\"" color "\">"))]
-      (str "data:image/svg+xml;base64," (u/encode-base64 themed)))
-    (catch Throwable _e
-      url)))
-
 (defn- logo-url []
   (let [url (public-settings/application-logo-url)]
     (cond

--- a/src/metabase/email/messages.clj
+++ b/src/metabase/email/messages.clj
@@ -59,19 +59,20 @@
           svg    (u/decode-base64 base64)
           themed (str/replace svg #"<svg\b([^>]*)( fill=\"[^\"]*\")([^>]*)>" (str "<svg$1$3 fill=\"" color "\">"))]
       (str "data:image/svg+xml;base64," (u/encode-base64 themed)))
-    (catch Throwable e
+    (catch Throwable _e
       url)))
 
 (defn- logo-url []
-  (let [url   (public-settings/application-logo-url)
-        color (render.style/primary-color)]
+  (let [url (public-settings/application-logo-url)]
     (cond
       (= url "app/assets/img/logo.svg") "http://static.metabase.com/email_logo.png"
+
+      :else nil
       ;; NOTE: disabling whitelabeled URLs for now since some email clients don't render them correctly
       ;; We need to extract them and embed as attachments like we do in metabase.pulse.render.image-bundle
-      true                              nil
-      (data-uri-svg? url)               (themed-image-url url color)
-      :else                             url)))
+      ;; (data-uri-svg? url)               (themed-image-url url color)
+      ;; :else                             url
+      )))
 
 (defn- icon-bundle
   [icon-name]
@@ -491,7 +492,7 @@
 
 (defn pulse->alert-condition-kwd
   "Given an `alert` return a keyword representing what kind of goal needs to be met."
-  [{:keys [alert_above_goal alert_condition card creator] :as alert}]
+  [{:keys [alert_above_goal alert_condition] :as _alert}]
   (if (= "goal" alert_condition)
     (if (true? alert_above_goal)
       :meets
@@ -627,14 +628,14 @@
 
 (defn send-admin-unsubscribed-alert-email!
   "Send an email to `user-added` letting them know `admin` has unsubscribed them from `alert`"
-  [alert user-added {:keys [first_name last_name] :as admin}]
+  [alert user-added {:keys [first_name last_name] :as _admin}]
   (let [admin-name (format "%s %s" first_name last_name)]
     (send-email! user-added "You’ve been unsubscribed from an alert" admin-unsubscribed-template
                  (assoc (common-alert-context alert) :adminName admin-name))))
 
 (defn send-you-were-added-alert-email!
   "Send an email to `user-added` letting them know `admin-adder` has added them to `alert`"
-  [alert user-added {:keys [first_name last_name] :as admin-adder}]
+  [alert user-added {:keys [first_name last_name] :as _admin-adder}]
   (let [subject (format "%s %s added you to an alert" first_name last_name)]
     (send-email! user-added subject added-template (common-alert-context alert alert-condition-text))))
 
@@ -642,13 +643,13 @@
 
 (defn send-alert-stopped-because-archived-email!
   "Email to notify users when a card associated to their alert has been archived"
-  [alert user {:keys [first_name last_name] :as archiver}]
+  [alert user {:keys [first_name last_name] :as _archiver}]
   (let [deletion-text (format "the question was archived by %s %s" first_name last_name)]
     (send-email! user not-working-subject stopped-template (assoc (common-alert-context alert) :deletionCause deletion-text))))
 
 (defn send-alert-stopped-because-changed-email!
   "Email to notify users when a card associated to their alert changed in a way that invalidates their alert"
-  [alert user {:keys [first_name last_name] :as archiver}]
+  [alert user {:keys [first_name last_name] :as _archiver}]
   (let [edited-text (format "the question was edited by %s %s" first_name last_name)]
     (send-email! user not-working-subject stopped-template (assoc (common-alert-context alert) :deletionCause edited-text))))
 

--- a/src/metabase/events/driver_notifications.clj
+++ b/src/metabase/events/driver_notifications.clj
@@ -25,7 +25,7 @@
   "Handle processing for a single event notification received on the driver-notifications-channel"
   [driver-notifications-event]
   ;; try/catch here to prevent individual topic processing exceptions from bubbling up.  better to handle them here.
-  (when-let [{topic :topic database :item} driver-notifications-event]
+  (when-let [{_topic :topic database :item} driver-notifications-event]
     (try
       ;; notify the appropriate driver about the updated database
       (driver/notify-database-updated (:engine database) database)

--- a/src/metabase/integrations/google.clj
+++ b/src/metabase/integrations/google.clj
@@ -92,7 +92,7 @@
 
 (defn do-google-auth
   "Call to Google to perform an authentication"
-  [{{:keys [token]} :body, :as request}]
+  [{{:keys [token]} :body, :as _request}]
   (let [token-info-response                    (http/post (format google-auth-token-info-url token))
         {:keys [given_name family_name email]} (google-auth-token-info token-info-response)]
     (log/info (trs "Successfully authenticated Google Sign-In token for: {0} {1}" given_name family_name))

--- a/src/metabase/integrations/ldap.clj
+++ b/src/metabase/integrations/ldap.clj
@@ -162,13 +162,13 @@
        (try
          (when-not (ldap/get conn user-base)
            user-base-error)
-         (catch Exception e
+         (catch Exception _e
            user-base-error))
        (when group-base
          (try
            (when-not (ldap/get conn group-base)
              group-base-error)
-           (catch Exception e
+           (catch Exception _e
              group-base-error)))
        {:status :SUCCESS}))
     (catch LDAPException e

--- a/src/metabase/logger.clj
+++ b/src/metabase/logger.clj
@@ -4,7 +4,7 @@
             [clj-time.format :as time]
             [metabase.config :refer [local-process-uuid]])
   (:import org.apache.commons.lang3.exception.ExceptionUtils
-           [org.apache.logging.log4j.core Appender Filter Layout LogEvent LoggerContext]
+           [org.apache.logging.log4j.core Appender LogEvent LoggerContext]
            org.apache.logging.log4j.core.config.LoggerConfig
            org.apache.logging.log4j.LogManager))
 
@@ -43,7 +43,6 @@
   (when-not @has-added-appender?
     (reset! has-added-appender? true)
     (let [^LoggerContext ctx                           (LogManager/getContext true)
-          root-logger                                  (LogManager/getRootLogger)
           config                                       (.getConfiguration ctx)
           appender                                     (metabase-appender)
           ^org.apache.logging.log4j.Level level        nil

--- a/src/metabase/models/activity.clj
+++ b/src/metabase/models/activity.clj
@@ -36,7 +36,7 @@
 
 ;; For every other activity topic we'll look at the read/write perms for the object the activty is about (e.g. a Card
 ;; or Dashboard). For all other activity feed items with no model everyone can read/write
-(defmethod can-? :default [perms-check-fn {model :model, model-id :model_id, :as activity}]
+(defmethod can-? :default [perms-check-fn {model :model, model-id :model_id}]
   (if-let [object (when-let [entity (model->entity model)]
                     (entity model-id))]
     (perms-check-fn object)

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -180,7 +180,7 @@
     (seq (:dataset_query card)) (update :dataset_query normalize/normalize)))
 
 ;; TODO -- consider whether we should validate the Card query when you save/update it??
-(defn- pre-insert [{query :dataset_query, :as card}]
+(defn- pre-insert [card]
   (u/prog1 card
     ;; make sure this Card doesn't have circular source query references
     (check-for-circular-source-query-references card)

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -6,7 +6,7 @@
             [metabase.mbql.normalize :as normalize]
             [metabase.mbql.util :as mbql.u]
             [metabase.models.collection :as collection]
-            [metabase.models.dependency :as dependency :refer [Dependency]]
+            [metabase.models.dependency :as dependency]
             [metabase.models.field-values :as field-values]
             [metabase.models.interface :as i]
             [metabase.models.params :as params]

--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -129,7 +129,7 @@
 (s/defn update-dashboard-card!
   "Update an existing DashboardCard` including all DashboardCardSeries.
    Returns the updated DashboardCard or throws an Exception."
-  [{:keys [id series parameter_mappings visualization_settings] :as dashboard-card} :- DashboardCardUpdates]
+  [{:keys [id parameter_mappings visualization_settings] :as dashboard-card} :- DashboardCardUpdates]
   (let [{:keys [sizeX sizeY row col series]} (merge {:series []} dashboard-card)]
     (db/transaction
      ;; update the dashcard itself (positional attributes)
@@ -168,7 +168,7 @@
   "Create a new DashboardCard by inserting it into the database along with all associated pieces of data such as
    DashboardCardSeries. Returns the newly created DashboardCard or throws an Exception."
   [dashboard-card :- NewDashboardCard]
-  (let [{:keys [dashboard_id card_id creator_id parameter_mappings visualization_settings sizeX sizeY row col series]
+  (let [{:keys [dashboard_id card_id parameter_mappings visualization_settings sizeX sizeY row col series]
          :or   {sizeX 2, sizeY 2, series []}} dashboard-card]
     (db/transaction
      (let [dashboard-card (db/insert! DashboardCard

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -82,7 +82,7 @@
                        id))
         (db/delete! Secret :id secret-id)))))
 
-(defn- pre-delete [{id :id, driver :engine, details :details :as database}]
+(defn- pre-delete [{id :id, driver :engine, :as database}]
   (unschedule-tasks! database)
   (db/execute! {:delete-from (db/resolve-model 'Permissions)
                 :where       [:or

--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -203,7 +203,7 @@
 (defn field-values->pairs
   "Returns a list of pairs (or single element vectors if there are no human_readable_values) for the given
   `field-values` instance."
-  [{:keys [values human_readable_values] :as field-values}]
+  [{:keys [values human_readable_values]}]
   (if (seq human_readable_values)
     (map vector values human_readable_values)
     (map vector values)))

--- a/src/metabase/models/login_history.clj
+++ b/src/metabase/models/login_history.clj
@@ -66,7 +66,7 @@
 (defn- maybe-send-login-from-new-device-email
   "If set to send emails on first login from new devices, that is the case, and its not the users first login, send an
   email from a separate thread."
-  [{user-id :user_id, device-id :device_id, :as login-history}]
+  [login-history]
   (when (and (send-email-on-first-login-from-new-device)
              (first-login-on-this-device? login-history)
              (not (first-login-ever? login-history)))
@@ -82,7 +82,7 @@
   (maybe-send-login-from-new-device-email login-history)
   login-history)
 
-(defn- pre-update [login-history]
+(defn- pre-update [_login-history]
   (throw (RuntimeException. (tru "You can''t update a LoginHistory after it has been created."))))
 
 (extend (class LoginHistory)

--- a/src/metabase/models/metric.clj
+++ b/src/metabase/models/metric.clj
@@ -18,7 +18,7 @@
 (models/defmodel Metric :metric)
 
 (defn- pre-delete [{:keys [id]}]
-  (db/delete! 'Dependency :model "Metric", :model_id id))
+  (db/delete! Dependency :model "Metric", :model_id id))
 
 (defn- pre-update [{:keys [creator_id id], :as updates}]
   (u/prog1 updates

--- a/src/metabase/models/params/chain_filter.clj
+++ b/src/metabase/models/params/chain_filter.clj
@@ -189,7 +189,7 @@
     (reduce
      (partial merge-with merge)
      {}
-     (for [{:keys [t1 f1 t2 f2] :as m} rows]
+     (for [{:keys [t1 f1 t2 f2]} rows]
        (merge
         {t1 {t2 [{:lhs {:table t1, :field f1}, :rhs {:table t2, :field f2}}]}}
         (let [reverse-join {:lhs {:table t2, :field f2}, :rhs {:table t1, :field f1}}]

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -611,28 +611,28 @@
   "Fetch a graph representing the current *data* permissions status for every Group and all permissioned databases.
   See [[metabase.models.collection.graph]] for the Collection permissions graph code."
   []
-  (let [permissions (db/select [Permissions [:group_id :group-id] [:object :path]]
-                      {:where [:and
-                               [:not= :group_id (:id (group/metabot))]
-                               [:or
-                                [:= :object (hx/literal "/")]
-                                [:like :object (hx/literal "/db/%")]
-                                [:like :object (hx/literal "/block/db/%")]]]})
-        db-ids      (delay (db/select-ids 'Database))]
-    (let [group-id->paths (reduce
-                           (fn [m {:keys [group-id path]}]
-                             (update m group-id conj path))
-                           {}
-                           permissions)
-          group-id->graph (m/map-vals
-                           (fn [paths]
-                             (let [permissions-graph (perms-parse/permissions->graph paths)]
-                               (if (= :all permissions-graph)
-                                 (all-permissions @db-ids)
-                                 (:db permissions-graph))))
-                           group-id->paths)]
-      {:revision (perms-revision/latest-id)
-       :groups   group-id->graph})))
+  (let [permissions     (db/select [Permissions [:group_id :group-id] [:object :path]]
+                                   {:where [:and
+                                            [:not= :group_id (:id (group/metabot))]
+                                            [:or
+                                             [:= :object (hx/literal "/")]
+                                             [:like :object (hx/literal "/db/%")]
+                                             [:like :object (hx/literal "/block/db/%")]]]})
+        db-ids          (delay (db/select-ids 'Database))
+        group-id->paths (reduce
+                         (fn [m {:keys [group-id path]}]
+                           (update m group-id conj path))
+                         {}
+                         permissions)
+        group-id->graph (m/map-vals
+                         (fn [paths]
+                           (let [permissions-graph (perms-parse/permissions->graph paths)]
+                             (if (= :all permissions-graph)
+                               (all-permissions @db-ids)
+                               (:db permissions-graph))))
+                         group-id->paths)]
+    {:revision (perms-revision/latest-id)
+     :groups   group-id->graph}))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/src/metabase/models/pulse.clj
+++ b/src/metabase/models/pulse.clj
@@ -143,7 +143,7 @@
 (defn will-delete-channel
   "This function is called by [[metabase.models.pulse-channel/pre-delete]] when the `PulseChannel` is about to be
   deleted. Archives `Pulse` if the channel being deleted is its last channel."
-  [{pulse-id :pulse_id, pulse-channel-id :id, :as pulse-channel}]
+  [{pulse-id :pulse_id, pulse-channel-id :id}]
   (when *automatically-archive-when-last-channel-is-deleted*
     (let [other-channels-count (db/count PulseChannel :pulse_id pulse-id, :id [:not= pulse-channel-id])]
       (when (zero? other-channels-count)

--- a/src/metabase/models/pulse_channel_recipient.clj
+++ b/src/metabase/models/pulse_channel_recipient.clj
@@ -5,7 +5,7 @@
 
 (models/defmodel PulseChannelRecipient :pulse_channel_recipient)
 
-(defn- pre-delete [{id :id, pulse-channel-id :pulse_channel_id, :as pcr}]
+(defn- pre-delete [pcr]
   ;; call [[metabase.models.pulse-channel/will-delete-recipient]] to let it know we're about to delete this
   ;; PulseChannelRecipient; that function will decide whether to automatically delete the PulseChannel as well.
   (classloader/require 'metabase.models.pulse-channel)

--- a/src/metabase/models/revision.clj
+++ b/src/metabase/models/revision.clj
@@ -35,7 +35,7 @@
 
 (defn default-revert-to-revision!
   "Default implementation of `revert-to-revision!` which simply does an update using the values from `serialized-instance`."
-  [entity id user-id serialized-instance]
+  [entity id _user-id serialized-instance]
   (db/update! entity id, serialized-instance))
 
 (defn default-diff-map

--- a/src/metabase/models/secret.clj
+++ b/src/metabase/models/secret.clj
@@ -37,7 +37,7 @@
   "Returns the value of the given `secret` as a String.  `secret` can be a Secret model object, or a
   secret-map (i.e. return value from `db-details-prop->secret-map`)."
   {:added "0.42.0"}
-  ^String [{:keys [value] :as secret}]
+  ^String [{:keys [value] :as _secret}]
   (cond (string? value)
         value
         (bytes? value)
@@ -76,7 +76,7 @@
                                (tru "File path for {0}" (-> (get secret-props connection-property-name)
                                                           :display-name)))
 
-                             true
+                             :else
                              (tru "Path"))]
           (throw (ex-info (tru "{0} points to non-existent file: {1}" error-source secret-val)
                    {:file-path secret-val

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -140,7 +140,7 @@
 (defn- validate-default-value-for-type
   "Check whether the `:default` value of a Setting (if provided) agrees with the Setting's `:type` and its `:tag` (which
   usually comes from [[default-tag-for-type]])."
-  [{setting-type :type, setting-name :name, :keys [tag default], :as setting-definition}]
+  [{:keys [tag default] :as _setting-definition}]
   ;; the errors below don't need to be i18n'ed since they're definition-time errors rather than user-facing
   (when (some? tag)
     (assert ((some-fn symbol? string?) tag) (format "Setting :tag should be a symbol or string, got: ^%s %s"
@@ -882,7 +882,7 @@
       parsed-value)))
 
 (defn- user-facing-info
-  [{:keys [sensitive? default description], k :name, :as setting} & {:as options}]
+  [{:keys [default description], k :name, :as setting} & {:as options}]
   (let [set-via-env-var? (boolean (env-var-value setting))]
     {:key            k
      :value          (try

--- a/src/metabase/plugins/dependencies.clj
+++ b/src/metabase/plugins/dependencies.clj
@@ -50,7 +50,7 @@
          message)))
 
 (defmethod dependency-satisfied? :class
-  [_ {{plugin-name :name} :info} {^String classname :class, message :message, :as dep}]
+  [_ {{plugin-name :name} :info} {^String classname :class, message :message, :as _dep}]
   (try
     (Class/forName classname false (classloader/the-classloader))
     (catch ClassNotFoundException _
@@ -58,12 +58,12 @@
       false)))
 
 (defmethod dependency-satisfied? :plugin
-  [initialized-plugin-names {{plugin-name :name} :info, :as info} {dep-plugin-name :plugin}]
+  [initialized-plugin-names {{plugin-name :name} :info} {dep-plugin-name :plugin}]
   (log-once plugin-name (trs "Plugin ''{0}'' depends on plugin ''{1}''" plugin-name dep-plugin-name))
   ((set initialized-plugin-names) dep-plugin-name))
 
 (defmethod dependency-satisfied? :env-var
-  [_ {{plugin-name :name} :info, :as info} {env-var-name :env-var}]
+  [_ {{plugin-name :name} :info} {env-var-name :env-var}]
   (if (str/blank? (env/env (keyword env-var-name)))
     (do
       (log-once plugin-name (trs "Plugin ''{0}'' depends on environment variable ''{1}'' being set to something"

--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -63,7 +63,7 @@
 
 (defn- execute-dashboard
   "Fetch all the dashcards in a dashboard for a Pulse, and execute non-text cards"
-  [{pulse-creator-id :creator_id, :as pulse} dashboard & {:as options}]
+  [{pulse-creator-id :creator_id, :as pulse} dashboard & {:as _options}]
   (let [dashboard-id      (u/the-id dashboard)
         dashcards         (db/select DashboardCard :dashboard_id dashboard-id)
         ordered-dashcards (sort dashcard-comparator dashcards)]
@@ -250,7 +250,7 @@
       (throw (IllegalArgumentException. error-text)))))
 
 (defmethod should-send-notification? :pulse
-  [{:keys [alert_condition] :as pulse} results]
+  [pulse results]
   (if (:skip_if_empty pulse)
     (not (are-all-cards-empty? results))
     true))
@@ -388,7 +388,7 @@
    Example:
        (send-pulse! pulse)                       Send to all Channels
        (send-pulse! pulse :channel-ids [312])    Send only to Channel with :id = 312"
-  [{:keys [cards dashboard_id], :as pulse} & {:keys [channel-ids]}]
+  [{:keys [dashboard_id], :as pulse} & {:keys [channel-ids]}]
   {:pre [(map? pulse) (integer? (:creator_id pulse))]}
   (let [dashboard (Dashboard :id dashboard_id)
         pulse     (-> pulse

--- a/src/metabase/pulse/markdown.clj
+++ b/src/metabase/pulse/markdown.clj
@@ -159,7 +159,7 @@
     (str (.getChars this)))
 
   nil
-  (to-clojure [this]
+  (to-clojure [_this]
     nil))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -311,7 +311,7 @@
         lr-factory (reify LinkResolverFactory
                      (^LinkResolver apply [_this ^LinkResolverBasicContext _context]
                       (reify LinkResolver
-                        (resolveLink [_this node context link]
+                        (resolveLink [_this _node _context link]
                           (if-let [url (resolve-uri (.getUrl link))]
                             (.. link
                                 (withStatus LinkStatus/VALID)

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -66,7 +66,7 @@
 
 (defn show-in-table?
   "Should this column be shown in a rendered table in a Pulse?"
-  [{:keys [semantic_type visibility_type] :as column}]
+  [{:keys [semantic_type visibility_type] :as _column}]
   (and (not (isa? semantic_type :type/Description))
        (not (contains? #{:details-only :retired :sensitive} visibility_type))))
 
@@ -168,11 +168,11 @@
        :row (for [[maybe-remapped-col maybe-remapped-row-cell fmt-fn] (map vector cols row formatters)
                   :when (and (not (:remapped_from maybe-remapped-col))
                              (show-in-table? maybe-remapped-col))
-                  :let [[formatter row-cell] (if (:remapped_to maybe-remapped-col)
-                                               (let [remapped-index (get remapping-lookup (:name maybe-remapped-col))]
-                                                [(nth formatters remapped-index)
-                                                 (nth row remapped-index)])
-                                               [fmt-fn maybe-remapped-row-cell])]]
+                  :let [[_formatter row-cell] (if (:remapped_to maybe-remapped-col)
+                                                (let [remapped-index (get remapping-lookup (:name maybe-remapped-col))]
+                                                  [(nth formatters remapped-index)
+                                                   (nth row remapped-index)])
+                                                [fmt-fn maybe-remapped-row-cell])]]
               (fmt-fn row-cell))})))
 
 (s/defn ^:private prep-for-html-rendering
@@ -181,7 +181,7 @@
   ([timezone-id :- (s/maybe s/Str) card data column-limit]
    (prep-for-html-rendering timezone-id card data column-limit {}))
   ([timezone-id :- (s/maybe s/Str) card {:keys [cols rows viz-settings]} column-limit
-    {:keys [bar-column min-value max-value] :as data-attributes}]
+    {:keys [bar-column] :as data-attributes}]
    (let [remapping-lookup (create-remapping-lookup cols)
          limited-cols (take column-limit cols)]
      (cons
@@ -448,7 +448,7 @@
                 (percentages label)]]))]}))
 
 (s/defmethod render :progress :- common/RenderedPulseCard
-  [_ render-type timezone-id card _ {:keys [cols rows viz-settings] :as data}]
+  [_ render-type _timezone-id _card _ {:keys [cols rows viz-settings] :as _data}]
   (let [value        (ffirst rows)
         goal         (:progress.goal viz-settings)
         ;; See issue #19248 on GH for why it's the second color
@@ -494,7 +494,7 @@
 
 
 (s/defmethod render :multiple
-  [_ render-type timezone-id card dashcard {:keys [viz-settings] :as data}]
+  [_ render-type _timezone-id card dashcard {:keys [viz-settings] :as data}]
   (let [multi-res     (pu/execute-multi-card card dashcard)
         ;; multi-res gets the other results from the set of multis.
         ;; we shove cards and data here all together below for uniformity's sake
@@ -535,7 +535,7 @@
 (defn- single-x-axis-combo-series
   "This munges rows and columns into series in the format that we want for combo staticviz for literal combo displaytype,
   for a single x-axis with multiple y-axis."
-  [chart-type joined-rows x-cols y-cols viz-settings]
+  [chart-type joined-rows _x-cols y-cols viz-settings]
   (for [[idx y-col] (map-indexed vector y-cols)]
     (let [y-col-key     (keyword (:name y-col))
           card-name     (or (series-setting viz-settings y-col-key :name)
@@ -560,7 +560,7 @@
 
   This mimics default behavior in JS viz, which is to group by the second dimension and make every group-by-value a series.
   This can have really high cardinality of series but the JS viz will complain about more than 100 already"
-  [chart-type joined-rows x-cols y-cols viz-settings]
+  [chart-type joined-rows _x-cols _y-cols viz-settings]
   (let [grouped-rows (group-by #(second (first %)) joined-rows)
         groups       (keys grouped-rows)]
     (for [[idx group-key] (map-indexed vector groups)]
@@ -608,7 +608,7 @@
       (js-svg/combo-chart series settings))))
 
 (s/defmethod render :line :- common/RenderedPulseCard
-  [_ render-type timezone-id card _dashcard {:keys [rows cols viz-settings] :as data}]
+  [_ render-type timezone-id card _dashcard data]
   (let [image-bundle     (lab-image-bundle :line render-type timezone-id card _dashcard data)]
     {:attachments
      (when image-bundle
@@ -621,7 +621,7 @@
              :src   (:image-src image-bundle)}]]}))
 
 (s/defmethod render :area :- common/RenderedPulseCard
-  [_ render-type timezone-id card _dashcard {:keys [rows cols viz-settings] :as data}]
+  [_ render-type timezone-id card _dashcard data]
   (let [image-bundle     (lab-image-bundle :area render-type timezone-id card _dashcard data)]
     {:attachments
      (when image-bundle
@@ -634,7 +634,7 @@
              :src   (:image-src image-bundle)}]]}))
 
 (s/defmethod render :bar :- common/RenderedPulseCard
-  [_ render-type _timezone-id :- (s/maybe s/Str) card _dashcard {:keys [cols rows viz-settings] :as data}]
+  [_ render-type _timezone-id :- (s/maybe s/Str) card _dashcard data]
   (let [image-bundle (lab-image-bundle :bar render-type _timezone-id card _dashcard data)]
     {:attachments
      (when image-bundle
@@ -646,7 +646,7 @@
              :src   (:image-src image-bundle)}]]}))
 
 (s/defmethod render :combo :- common/RenderedPulseCard
-  [_ render-type _timezone-id :- (s/maybe s/Str) card _dashcard {:keys [cols rows viz-settings] :as data}]
+  [_ render-type _timezone-id :- (s/maybe s/Str) card _dashcard data]
   (let [image-bundle (lab-image-bundle :combo render-type _timezone-id card _dashcard data)]
     {:attachments
      (when image-bundle
@@ -658,9 +658,8 @@
              :src   (:image-src image-bundle)}]]}))
 
 (s/defmethod render :scalar :- common/RenderedPulseCard
-  [_ _ timezone-id _card _ {:keys [cols rows viz-settings] :as data}]
-  (let [col             (first cols)
-        value           (format-cell timezone-id (ffirst rows) (first cols) viz-settings)]
+  [_ _ timezone-id _card _ {:keys [cols rows viz-settings]}]
+  (let [value (format-cell timezone-id (ffirst rows) (first cols) viz-settings)]
     {:attachments
      nil
 
@@ -670,7 +669,7 @@
      :render/text (str value)}))
 
 (s/defmethod render :smartscalar :- common/RenderedPulseCard
-  [_ _ timezone-id _card _ {:keys [cols rows insights viz-settings] :as data}]
+  [_ _ timezone-id _card _ {:keys [cols insights viz-settings]}]
   (letfn [(col-of-type [t c] (or (isa? (:effective_type c) t)
                                  ;; computed and agg columns don't have an effective type
                                  (isa? (:base_type c) t)))
@@ -766,13 +765,12 @@
          (second labels)]]]]}))
 
 (s/defmethod render :waterfall :- common/RenderedPulseCard
-  [_ render-type timezone-id card _ {:keys [rows cols viz-settings] :as data}]
+  [_ render-type _timezone-id card _ {:keys [rows cols viz-settings] :as data}]
   (let [[x-axis-rowfn
          y-axis-rowfn] (common/graphing-column-row-fns card data)
         [x-col y-col]  ((juxt x-axis-rowfn y-axis-rowfn) cols)
         rows           (map (juxt x-axis-rowfn y-axis-rowfn)
                             (common/row-preprocess x-axis-rowfn y-axis-rowfn rows))
-        last-rows      (reverse (take-last 2 rows))
         labels         (x-and-y-axis-label-info x-col y-col viz-settings)
         render-fn      (if (isa? (-> cols x-axis-rowfn :effective_type) :type/Temporal)
                          js-svg/timelineseries-waterfall
@@ -798,7 +796,7 @@
              :src   (:image-src image-bundle)}]]}))
 
 (s/defmethod render :funnel :- common/RenderedPulseCard
-  [_ render-type timezone-id card _ {:keys [rows cols viz-settings] :as data}]
+  [_ render-type _timezone-id card _ {:keys [rows cols viz-settings] :as data}]
   (let [[x-axis-rowfn
          y-axis-rowfn] (common/graphing-column-row-fns card data)
         rows           (map (juxt x-axis-rowfn y-axis-rowfn)

--- a/src/metabase/pulse/render/common.clj
+++ b/src/metabase/pulse/render/common.clj
@@ -88,7 +88,7 @@
 (defn graphing-column-row-fns
   "Return a pair of `[get-x-axis get-y-axis]` functions that can be used to get the x-axis and y-axis values in a row,
   or columns, respectively."
-  [card {:keys [cols] :as data}]
+  [card data]
   [(or (ui-logic/x-axis-rowfn card data)
        first)
    (or (ui-logic/y-axis-rowfn card data)

--- a/src/metabase/pulse/render/image_bundle.clj
+++ b/src/metabase/pulse/render/image_bundle.clj
@@ -3,8 +3,7 @@
   either encode the image inline in a URL (when `render-type` is `:inline`), or create the hashes/references needed
   for an attached image (`render-type` of `:attachment`)"
   (:require [clojure.java.io :as io])
-  (:import java.net.URL
-           java.util.Arrays
+  (:import java.util.Arrays
            org.apache.commons.io.IOUtils
            org.fit.cssbox.misc.Base64Coder))
 

--- a/src/metabase/pulse/render/table.clj
+++ b/src/metabase/pulse/render/table.clj
@@ -42,7 +42,7 @@
   ([color positive? width-in-pixels]
    (render-bar-component color positive? width-in-pixels 0))
 
-  ([color positive? width-in-pixels offset]
+  ([color positive? width-in-pixels _offset]
    [:div
     {:style (style/style
              (merge
@@ -125,7 +125,7 @@
   background color for a given cell. `column-names` is different from the header in `header+rows` as the header is the
   display_name (i.e. human friendly. `header+rows` includes the text contents of the table we're about ready to
   create. If `normalized-zero` is set (defaults to 0), render values less than it as negative"
-  ([color-selector column-names [header & rows :as contents]]
+  ([color-selector column-names contents]
    (render-table color-selector 0 column-names contents))
 
   ([color-selector normalized-zero column-names [header & rows]]

--- a/src/metabase/query_processor/context/default.clj
+++ b/src/metabase/query_processor/context/default.clj
@@ -42,7 +42,7 @@
        (vswap! rows conj row)
        result))))
 
-(defn- default-reducedf [metadata reduced-result context]
+(defn- default-reducedf [_metadata reduced-result context]
   (context/resultf reduced-result context))
 
 (defn default-reducef

--- a/src/metabase/query_processor/middleware/add_dimension_projections.clj
+++ b/src/metabase/query_processor/middleware/add_dimension_projections.clj
@@ -210,7 +210,7 @@
 (defn- transform-values-for-col
   "Converts `values` to a type compatible with the base_type found for `col`. These values should be directly comparable
   with the values returned from the database for the given `col`."
-  [{:keys [base_type] :as col} values]
+  [{:keys [base_type]} values]
   (let [transform (condp #(isa? %2 %1) base_type
                     :type/Decimal    bigdec
                     :type/Float      double

--- a/src/metabase/query_processor/middleware/annotate.clj
+++ b/src/metabase/query_processor/middleware/annotate.clj
@@ -88,7 +88,7 @@
               driver-col-metadata))))))
 
 (defmethod column-info :native
-  [_query {:keys [cols rows] :as results}]
+  [_query {:keys [cols rows] :as _results}]
   (check-driver-native-columns cols rows)
   (annotate-native-cols cols))
 
@@ -288,7 +288,7 @@
   or expression). Takes an options map as schema won't support passing keypairs directly as a varargs.
 
   These names are also used directly in queries, e.g. in the equivalent of a SQL `AS` clause."
-  [ag-clause :- mbql.s/Aggregation & [{:keys [recursive-name-fn], :or {recursive-name-fn aggregation-name}}]]
+  [ag-clause :- mbql.s/Aggregation]
   (when-not driver/*driver*
     (throw (Exception. (tru "*driver* is unbound."))))
   (mbql.u/match-one ag-clause
@@ -371,7 +371,7 @@
     (:display_name (col-info-for-field-clause inner-query ag-clause))
 
     _
-    (aggregation-name ag-clause {:recursive-name-fn (partial aggregation-arg-display-name inner-query)})))
+    (aggregation-name ag-clause)))
 
 (defn- ag->name-info [inner-query ag]
   {:name         (aggregation-name ag)
@@ -540,7 +540,7 @@
       cols)))
 
 (defmethod column-info :query
-  [{inner-query :query, :as query} results]
+  [{inner-query :query} results]
   (u/prog1 (mbql-cols inner-query results)
     (check-correct-number-of-columns-returned <> results)))
 

--- a/src/metabase/query_processor/middleware/cache/impl.clj
+++ b/src/metabase/query_processor/middleware/cache/impl.clj
@@ -38,7 +38,7 @@
   [in-chan out-chan ^ByteArrayOutputStream bos ^DataOutputStream os]
   (a/go
     (let [timeout-chan (a/timeout serialization-timeout-ms)
-          [val port]   (a/alts! [out-chan timeout-chan])]
+          [_val port]   (a/alts! [out-chan timeout-chan])]
       (when (= port timeout-chan)
         (a/>! out-chan (ex-info (tru "Serialization timed out after {0}." (u/format-milliseconds serialization-timeout-ms))
                                 {}))))
@@ -124,7 +124,7 @@
   [^InputStream is]
   (try
     (nippy/thaw-from-in! is)
-    (catch EOFException e
+    (catch EOFException _e
       ::eof)))
 
 (defn- reducible-rows

--- a/src/metabase/query_processor/middleware/cache_backend/db.clj
+++ b/src/metabase/query_processor/middleware/cache_backend/db.clj
@@ -60,13 +60,12 @@
   "Delete any cache entries that are older than the global max age `max-cache-entry-age-seconds` (currently 3 months)."
   [max-age-seconds]
   {:pre [(number? max-age-seconds)]}
-  (do
-    (log/tracef "Purging old cache entries.")
-    (try
-      (db/simple-delete! QueryCache
-        :updated_at [:<= (seconds-ago max-age-seconds)])
-      (catch Throwable e
-        (log/error e (trs "Error purging old cache entries")))))
+  (log/tracef "Purging old cache entries.")
+  (try
+    (db/simple-delete! QueryCache
+                       :updated_at [:<= (seconds-ago max-age-seconds)])
+    (catch Throwable e
+      (log/error e (trs "Error purging old cache entries"))))
   nil)
 
 (defn- save-results!

--- a/src/metabase/query_processor/middleware/catch_exceptions.clj
+++ b/src/metabase/query_processor/middleware/catch_exceptions.clj
@@ -25,7 +25,7 @@
    :stacktrace (u/filtered-stacktrace e)})
 
 (defmethod format-exception InterruptedException
-  [^InterruptedException e]
+  [^InterruptedException _e]
   {:status :interrupted})
 
 ;; TODO - consider moving this into separate middleware as part of a try-catch setup so queries running in a

--- a/src/metabase/query_processor/middleware/optimize_temporal_filters.clj
+++ b/src/metabase/query_processor/middleware/optimize_temporal_filters.clj
@@ -118,7 +118,7 @@
   (mbql.u/negate-filter-clause ((get-method optimize-filter :=) filter-clause)))
 
 (defn- optimize-comparison-filter
-  [optimize-temporal-value-fn [filter-type field temporal-value] new-filter-type]
+  [optimize-temporal-value-fn [_filter-type field temporal-value] new-filter-type]
   [new-filter-type
    (change-temporal-unit-to-default field)
    (optimize-temporal-value-fn temporal-value (temporal-unit field))])

--- a/src/metabase/query_processor/middleware/parameters/native.clj
+++ b/src/metabase/query_processor/middleware/parameters/native.clj
@@ -30,7 +30,7 @@
 (defn expand-inner
   "Expand parameters inside an *inner* native `query`. Not recursive -- recursive transformations are handled in
   the `middleware.parameters` functions that invoke this function."
-  [{:keys [parameters query native] :as inner-query}]
+  [inner-query]
   (if-not (driver/supports? driver/*driver* :native-parameters)
     inner-query
     ;; Totally ridiculous, but top-level native queries use the key `:query` for SQL or equivalent, while native

--- a/src/metabase/query_processor/middleware/permissions.clj
+++ b/src/metabase/query_processor/middleware/permissions.clj
@@ -55,10 +55,10 @@
 (s/defn ^:private check-card-read-perms
   "Check that the current user has permissions to read Card with `card-id`, or throw an Exception. "
   [card-id :- su/IntGreaterThanZero]
-  (let [{collection-id :collection_id, :as card} (or (db/select-one [Card :collection_id] :id card-id)
-                                                     (throw (ex-info (tru "Card {0} does not exist." card-id)
-                                                                     {:type    error-type/invalid-query
-                                                                      :card-id card-id})))]
+  (let [card (or (db/select-one [Card :collection_id] :id card-id)
+                 (throw (ex-info (tru "Card {0} does not exist." card-id)
+                                 {:type    error-type/invalid-query
+                                  :card-id card-id})))]
     (log/tracef "Required perms to run Card: %s" (pr-str (mi/perms-objects-set card :read)))
     (when-not (mi/can-read? card)
       (throw (perms-exception (tru "You do not have permissions to view Card {0}." card-id)
@@ -126,7 +126,7 @@
   "If current user is bound, do they have ad-hoc native query permissions for `query`'s database? (This is used by
   `qp/query->native` and the `catch-exceptions` middleware to check the user should be allowed to see the native query
   before converting the MBQL query to native.)"
-  [{database-id :database, :as query}]
+  [{database-id :database, :as _query}]
   (or
    (not *current-user-id*)
    (let [required-perms (perms/adhoc-native-query-path database-id)]

--- a/src/metabase/query_processor/middleware/process_userland_query.clj
+++ b/src/metabase/query_processor/middleware/process_userland_query.clj
@@ -83,15 +83,14 @@
        (rf))
 
       ([acc]
-       (do
-         ;; We don't actually have a guarantee that it's from a card just because it's userland
-         (when (integer? (:card_id execution-info))
-           (events/publish-event! :card-query {:card_id      (:card_id execution-info)
-                                               :actor_id     (:executor_id execution-info)
-                                               :cached       (:cached acc)
-                                               :ignore_cache (get-in execution-info [:json_query :middleware :ignore-cached-results?])}))
-         (when-not (:cached acc)
-           (save-successful-query-execution! (:cached acc) execution-info @row-count)))
+       ;; We don't actually have a guarantee that it's from a card just because it's userland
+       (when (integer? (:card_id execution-info))
+         (events/publish-event! :card-query {:card_id      (:card_id execution-info)
+                                             :actor_id     (:executor_id execution-info)
+                                             :cached       (:cached acc)
+                                             :ignore_cache (get-in execution-info [:json_query :middleware :ignore-cached-results?])}))
+       (when-not (:cached acc)
+         (save-successful-query-execution! (:cached acc) execution-info @row-count))
        (rf (if (map? acc)
              (success-response execution-info acc)
              acc)))

--- a/src/metabase/query_processor/middleware/reconcile_breakout_and_order_by_bucketing.clj
+++ b/src/metabase/query_processor/middleware/reconcile_breakout_and_order_by_bucketing.clj
@@ -38,7 +38,7 @@
             [schema.core :as s]))
 
 (s/defn ^:private reconcile-bucketing :- mbql.s/Query
-  [{{breakouts :breakout, order-bys :order-by} :query, :as query}]
+  [{{breakouts :breakout} :query, :as query}]
   ;; Look for bucketed fields in the `breakout` clause and build a map of unbucketed reference -> bucketed reference,
   ;; like:
   ;;

--- a/src/metabase/query_processor/middleware/resolve_joined_fields.clj
+++ b/src/metabase/query_processor/middleware/resolve_joined_fields.clj
@@ -35,15 +35,14 @@
       0
       (if (empty? source-query)
         clause
-        (do
-          (recur field source-query clause)))
+        (recur field source-query clause))
 
       ;; if there are multiple candidates, try ignoring the implicit ones
       ;; presence of `:fk-field-id` indicates that the join was implicit, as the result of an `fk->` form
       (let [explicit-joins (remove :fk-field-id joins)]
         (if (= (count explicit-joins) 1)
           (recur field {:joins explicit-joins} clause)
-          (let [{:keys [id name]} (qp.store/table table-id)]
+          (let [{:keys [_id name]} (qp.store/table table-id)]
             (throw (ex-info (tru "Cannot resolve joined field due to ambiguous joins: table {0} (ID {1}) joined multiple times. You need to specify an explicit `:join-alias` in the field reference."
                                  name field-id)
                             {:field      field

--- a/src/metabase/query_processor/middleware/resolve_joins.clj
+++ b/src/metabase/query_processor/middleware/resolve_joins.clj
@@ -131,7 +131,7 @@
       (seq join-fields) (update :fields (comp vec distinct concat) join-fields))))
 
 (s/defn ^:private resolve-joins-in-mbql-query :- ResolvedMBQLQuery
-  [{:keys [joins], :as query} :- mbql.s/MBQLQuery]
+  [query :- mbql.s/MBQLQuery]
   (-> query
       (update :joins (comp resolve-join-source-queries resolve-references-and-deduplicate))
       merge-joins-fields))

--- a/src/metabase/query_processor/streaming/csv.clj
+++ b/src/metabase/query_processor/streaming/csv.clj
@@ -26,7 +26,7 @@
         (csv/write-csv writer [(map (some-fn :display_name :name) ordered-cols)])
         (.flush writer))
 
-      (write-row! [_ row row-num _ {:keys [output-order]}]
+      (write-row! [_ row _row-num _ {:keys [output-order]}]
         (let [ordered-row (if output-order
                             (let [row-v (into [] row)]
                               (for [i output-order] (row-v i)))

--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -461,6 +461,12 @@
   (let [workbook            (SXSSFWorkbook.)
         sheet               (spreadsheet/add-sheet! workbook (tru "Query result"))]
     (reify i/StreamingResultsWriter
+      (begin! [_ {{:keys [ordered-cols]} :data} {col-settings ::mb.viz/column-settings}]
+        (doseq [i (range (count ordered-cols))]
+          (.trackColumnForAutoSizing ^SXSSFSheet sheet i))
+        (setup-header-row! sheet (count ordered-cols))
+        (spreadsheet/add-row! sheet (column-titles ordered-cols col-settings)))
+
       (write-row! [_ row row-num ordered-cols {:keys [output-order] :as viz-settings}]
         (let [ordered-row  (if output-order
                              (let [row-v (into [] row)]

--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -461,12 +461,6 @@
   (let [workbook            (SXSSFWorkbook.)
         sheet               (spreadsheet/add-sheet! workbook (tru "Query result"))]
     (reify i/StreamingResultsWriter
-      (begin! [_ {{:keys [ordered-cols]} :data} {col-settings ::mb.viz/column-settings}]
-        (doseq [i (range (count ordered-cols))]
-          (.trackColumnForAutoSizing ^SXSSFSheet sheet i))
-        (setup-header-row! sheet (count ordered-cols))
-        (spreadsheet/add-row! sheet (column-titles ordered-cols col-settings)))
-
       (write-row! [_ row row-num ordered-cols {:keys [output-order] :as viz-settings}]
         (let [ordered-row  (if output-order
                              (let [row-v (into [] row)]

--- a/src/metabase/query_processor/util.clj
+++ b/src/metabase/query_processor/util.clj
@@ -27,7 +27,7 @@
 (defn default-query->remark
   "Generates the default query remark. Exists as a separate function so that overrides of the query->remark multimethod
    can access the default value."
-  [{{:keys [executed-by query-hash], :as info} :info, query-type :type}]
+  [{{:keys [executed-by query-hash], :as _info} :info, query-type :type}]
   (str "Metabase" (when executed-by
                     (assert (instance? (Class/forName "[B") query-hash))
                     (format ":: userID: %s queryType: %s queryHash: %s"

--- a/src/metabase/query_processor/util/add_alias_info.clj
+++ b/src/metabase/query_processor/util/add_alias_info.clj
@@ -257,8 +257,8 @@
 (defn- field-source-alias
   "Determine the appropriate `::source-alias` for a `field-clause`."
   {:arglists '([inner-query field-clause expensive-field-info])}
-  [{:keys [source-table], :as inner-query}
-   [_ _id-or-name {:keys [join-alias]}, :as field-clause]
+  [{:keys [_source-table], :as _inner-query}
+   [_ _id-or-name {:keys [join-alias]}, :as _field-clause]
    {:keys [field-name join-is-this-level? alias-from-join alias-from-source-query]}]
   (cond
     (and join-alias (not join-is-this-level?)) (prefix-field-alias join-alias field-name)
@@ -269,8 +269,8 @@
 (defn- field-desired-alias
   "Determine the appropriate `::desired-alias` for a `field-clause`."
   {:arglists '([inner-query field-clause expensive-field-info])}
-  [inner-query
-   [_ _id-or-name {:keys [join-alias]} :as field-clause]
+  [_inner-query
+   [_ _id-or-name {:keys [join-alias]} :as _field-clause]
    {:keys [field-name alias-from-join alias-from-source-query]}]
   (cond
     join-alias              (prefix-field-alias join-alias (or alias-from-join field-name))
@@ -292,7 +292,7 @@
               ::position      position}))))
 
 (defmethod clause-alias-info :aggregation
-  [{aggregations :aggregation, :as inner-query} unique-alias-fn [_ index opts :as ag-ref-clause]]
+  [{aggregations :aggregation, :as inner-query} unique-alias-fn [_ index _opts :as ag-ref-clause]]
   (let [position (clause->position inner-query ag-ref-clause)]
     ;; an aggregation is ALWAYS returned, so it HAS to have a `position`. If it does not, the aggregation reference
     ;; is busted.
@@ -318,7 +318,7 @@
      ::position      position}))
 
 (defn- add-info-to-aggregation-definition
-  [inner-query unique-alias-fn [_ wrapped-ag-clause {original-ag-name :name, :as opts}, :as ag-clause] ag-index]
+  [inner-query unique-alias-fn [_ wrapped-ag-clause {original-ag-name :name, :as opts}, :as _ag-clause] ag-index]
   (let [position     (clause->position inner-query [:aggregation ag-index])
         unique-alias (unique-alias-fn position original-ag-name)]
     [:aggregation-options wrapped-ag-clause (assoc opts

--- a/src/metabase/query_processor/util/nest_query.clj
+++ b/src/metabase/query_processor/util/nest_query.clj
@@ -47,7 +47,7 @@
 (defn- raise-source-query-expression-ref
   "Convert an `:expression` reference from a source query into an appropriate `:field` clause for use in the surrounding
   query."
-  [{:keys [source-query], :as query} [_ expression-name opts :as clause]]
+  [{:keys [source-query], :as query} [_ expression-name opts :as _clause]]
   (let [expression-definition        (mbql.u/expression-with-name query expression-name)
         {base-type :base_type}       (some-> expression-definition annotate/infer-expression-type)
         {::add/keys [desired-alias]} (mbql.u/match-one source-query

--- a/src/metabase/server/middleware/exceptions.clj
+++ b/src/metabase/server/middleware/exceptions.clj
@@ -74,7 +74,7 @@
                                                         #"\s*\n\s*"))))
 
 (defmethod api-exception-response EofException
-  [e]
+  [_e]
   (log/info (trs "Request canceled before finishing."))
   {:status-code 204, :body nil, :headers (mw.security/security-headers)})
 
@@ -82,7 +82,7 @@
   "Middleware that catches API Exceptions and returns them in our normal-style format rather than the Jetty 500
   Stacktrace page, which is not so useful for our frontend."
   [handler]
-  (fn [request respond raise]
+  (fn [request respond _raise]
     (handler
      request
      respond

--- a/src/metabase/server/middleware/json.clj
+++ b/src/metabase/server/middleware/json.clj
@@ -1,8 +1,8 @@
 (ns metabase.server.middleware.json
   "Middleware related to parsing JSON requests and generating JSON responses."
   (:require [cheshire.core :as json]
-            [cheshire.generate :as json.generate]
             cheshire.factory
+            [cheshire.generate :as json.generate]
             [metabase.util.date-2 :as u.date]
             [ring.middleware.json :as ring.json]
             [ring.util.io :as rui]

--- a/src/metabase/server/middleware/json.clj
+++ b/src/metabase/server/middleware/json.clj
@@ -2,6 +2,7 @@
   "Middleware related to parsing JSON requests and generating JSON responses."
   (:require [cheshire.core :as json]
             [cheshire.generate :as json.generate]
+            cheshire.factory
             [metabase.util.date-2 :as u.date]
             [ring.middleware.json :as ring.json]
             [ring.util.io :as rui]

--- a/src/metabase/server/middleware/log.clj
+++ b/src/metabase/server/middleware/log.clj
@@ -40,10 +40,9 @@
      (format " [%s: %s]" (trs "ASYNC") async-status))))
 
 (defn- format-performance-info
-  [{:keys [start-time call-count-fn diag-info-fn]
+  [{:keys [start-time call-count-fn _diag-info-fn]
     :or {start-time    (System/nanoTime)
-         call-count-fn (constantly -1)
-         diag-info-fn  (constantly {})}}]
+         call-count-fn (constantly -1)}}]
   (let [elapsed-time (u/format-nanoseconds (- (System/nanoTime) start-time))
         db-calls     (call-count-fn)]
     (trs "{0} ({1} DB calls)" elapsed-time db-calls)))
@@ -151,14 +150,14 @@
 (defn- log-core-async-response
   "For async responses that return a `core.async` channel, wait for the channel to return a response before logging the
   API request info."
-  [{{chan :body, :as response} :response, :as info}]
+  [{{chan :body, :as _response} :response, :as info}]
   {:pre [(async.u/promise-chan? chan)]}
   ;; [async] wait for the pipe to close the canceled/finished channel and log the API response
   (a/go
     (let [result (a/<! chan)]
       (log-info (assoc info :async-status (if (nil? result) "canceled" "completed"))))))
 
-(defn- log-streaming-response [{{streaming-response :body, :as response} :response, :as info}]
+(defn- log-streaming-response [{{streaming-response :body, :as _response} :response, :as info}]
   ;; [async] wait for the streaming response to be canceled/finished channel and log the API response
   (let [finished-chan (streaming-response/finished-chan streaming-response)]
     (a/go

--- a/src/metabase/server/middleware/session.clj
+++ b/src/metabase/server/middleware/session.clj
@@ -206,7 +206,7 @@
       (first (jdbc/query (db/connection) (cons sql params))))))
 
 (defn- merge-current-user-info
-  [{:keys [metabase-session-id anti-csrf-token], {:strs [x-metabase-locale]} :headers, :as request}]9
+  [{:keys [metabase-session-id anti-csrf-token], {:strs [x-metabase-locale]} :headers, :as request}]
   (merge
    request
    (current-user-info-for-session metabase-session-id anti-csrf-token)

--- a/src/metabase/server/request/util.clj
+++ b/src/metabase/server/request/util.clj
@@ -30,7 +30,7 @@
 
 (defn cacheable?
   "Can the ring request be permanently cached?"
-  [{:keys [request-method uri query-string], :as request}]
+  [{:keys [request-method uri query-string], :as _request}]
   (and (= request-method :get)
        (or
         ;; match requests that are js/css and have a cache-busting query string
@@ -132,7 +132,7 @@
                              (tru "Unknown browser"))]
         (format "%s (%s/%s)" device-type browser-name os-name)))))
 
-(defn- describe-location [{:keys [city region country], :as info}]
+(defn- describe-location [{:keys [city region country]}]
   (when-let [info (not-empty (remove str/blank? [city region country]))]
     (str/join ", " info)))
 
@@ -153,18 +153,17 @@
   [ip-addresses :- [s/Str]]
   (let [ip-addresses (set (filter u/ip-address? ip-addresses))]
     (when (seq ip-addresses)
-      (try
-        (let [url (str "https://get.geojs.io/v1/ip/geo.json?ip=" (str/join "," ip-addresses))]
-          (try
-            (let [response (-> (http/get url {:headers            {"User-Agent" config/mb-app-id-string}
-                                              :socket-timeout     gecode-ip-address-timeout-ms
-                                              :connection-timeout gecode-ip-address-timeout-ms})
-                               :body
-                               (json/parse-string true))]
-              (into {} (for [info response]
-                         [(:ip info) {:description (or (describe-location info)
-                                                       "Unknown location")
-                                      :timezone    (u/ignore-exceptions (some-> (:timezone info) t/zone-id))}])))
-            (catch Throwable e
-              (log/error e (trs "Error geocoding IP addresses") {:url url})
-              nil)))))))
+      (let [url (str "https://get.geojs.io/v1/ip/geo.json?ip=" (str/join "," ip-addresses))]
+        (try
+          (let [response (-> (http/get url {:headers            {"User-Agent" config/mb-app-id-string}
+                                            :socket-timeout     gecode-ip-address-timeout-ms
+                                            :connection-timeout gecode-ip-address-timeout-ms})
+                             :body
+                             (json/parse-string true))]
+            (into {} (for [info response]
+                       [(:ip info) {:description (or (describe-location info)
+                                                     "Unknown location")
+                                    :timezone    (u/ignore-exceptions (some-> (:timezone info) t/zone-id))}])))
+          (catch Throwable e
+            (log/error e (trs "Error geocoding IP addresses") {:url url})
+            nil))))))

--- a/src/metabase/server/routes/index.clj
+++ b/src/metabase/server/routes/index.clj
@@ -92,7 +92,7 @@
 
 (defn- entrypoint
   "Response that serves up an entrypoint into the Metabase application, e.g. `index.html`."
-  [entrypoint-name embeddable? {:keys [uri]} respond raise]
+  [entrypoint-name embeddable? {:keys [uri]} respond _raise]
   (respond
     (-> (resp/response (if (init-status/complete?)
                          (load-entrypoint-template entrypoint-name embeddable? uri)

--- a/src/metabase/sync.clj
+++ b/src/metabase/sync.clj
@@ -59,10 +59,9 @@
   "Perform all the different sync operations synchronously for a given `table`. Since often called on a sequence of
   tables, caller should check if can connect."
   [table :- i/TableInstance]
-  (let [database (table/database table)]
-    (sync-metadata/sync-table-metadata! table)
-    (analyze/analyze-table! table)
-    (field-values/update-field-values-for-table! table)))
+  (sync-metadata/sync-table-metadata! table)
+  (analyze/analyze-table! table)
+  (field-values/update-field-values-for-table! table))
 
 (s/defn refingerprint-field!
   "Refingerprint a field, usually after its type changes. Checks if can connect to database, returning

--- a/src/metabase/sync/analyze.clj
+++ b/src/metabase/sync/analyze.clj
@@ -68,7 +68,7 @@
 
 (s/defn ^:private update-fields-last-analyzed-for-db!
   "Update the `last_analyzed` date for all the recently re-fingerprinted/re-classified Fields in TABLE."
-  [database :- i/DatabaseInstance
+  [_database :- i/DatabaseInstance
    tables :- [i/TableInstance]]
   ;; The WHERE portion of this query should match up with that of `classify/fields-to-classify`
   (update-last-analyzed! tables))

--- a/src/metabase/sync/analyze/classify.clj
+++ b/src/metabase/sync/analyze/classify.clj
@@ -137,7 +137,7 @@
 
 (s/defn classify-tables-for-db!
   "Classify all tables found in a given database"
-  [database :- i/DatabaseInstance
+  [_database :- i/DatabaseInstance
    tables :- [i/TableInstance]
    log-progress-fn]
   {:total-tables      (count tables)
@@ -151,7 +151,7 @@
 
 (s/defn classify-fields-for-db!
   "Classify all fields found in a given database"
-  [database :- i/DatabaseInstance
+  [_database :- i/DatabaseInstance
    tables :- [i/TableInstance]
    log-progress-fn]
   (apply merge-with +

--- a/src/metabase/sync/analyze/fingerprint/fingerprinters.clj
+++ b/src/metabase/sync/analyze/fingerprint/fingerprinters.clj
@@ -95,7 +95,7 @@
 (defmulti fingerprinter
   "Return a fingerprinter transducer for a given field based on the field's type."
   {:arglists '([field])}
-  (fn [{base-type :base_type, effective-type :effective_type, semantic-type :semantic_type, :keys [unit], :as field}]
+  (fn [{base-type :base_type, effective-type :effective_type, semantic-type :semantic_type, :keys [unit]}]
     [(cond
        (u.date/extract-units unit)
        :type/Integer

--- a/src/metabase/sync/sync_metadata.clj
+++ b/src/metabase/sync/sync_metadata.clj
@@ -17,11 +17,11 @@
             [metabase.util.i18n :refer [trs]]
             [schema.core :as s]))
 
-(defn- sync-fields-summary [{:keys [total-fields updated-fields] :as step-info}]
+(defn- sync-fields-summary [{:keys [total-fields updated-fields] :as _step-info}]
   (trs "Total number of fields sync''d {0}, number of fields updated {1}"
        total-fields updated-fields))
 
-(defn- sync-tables-summary [{:keys [total-tables updated-tables :as step-info]}]
+(defn- sync-tables-summary [{:keys [total-tables updated-tables] :as _step-info}]
   (trs "Total number of tables sync''d {0}, number of tables updated {1}"
        total-tables updated-tables))
 

--- a/src/metabase/sync/sync_metadata/fields/sync_instances.clj
+++ b/src/metabase/sync/sync_metadata/fields/sync_instances.clj
@@ -112,7 +112,6 @@
        (sync-util/with-error-handling (trs "Error checking if Fields {0} need to be created or reactivated"
                                            (pr-str (map :name db-field-chunk)))
          (let [known-field?        (comp known-fields common/canonical-name)
-               fields-to-update    (filter known-field? db-field-chunk)
                new-fields          (remove known-field? db-field-chunk)
                new-field-instances (create-or-reactivate-fields! table new-fields parent-id)]
            ;; save any updates to `our-metadata`

--- a/src/metabase/sync/sync_metadata/tables.clj
+++ b/src/metabase/sync/sync_metadata/tables.clj
@@ -123,7 +123,7 @@
   (log/info (trs "Marking tables as inactive:")
             (for [table old-tables]
               (sync-util/name-for-logging (table/map->TableInstance table))))
-  (doseq [{schema :schema, table-name :name, :as table} old-tables]
+  (doseq [{schema :schema, table-name :name, :as _table} old-tables]
     (db/update-where! Table {:db_id  (u/the-id database)
                              :schema schema
                              :name   table-name

--- a/src/metabase/sync/util.clj
+++ b/src/metabase/sync/util.clj
@@ -378,7 +378,7 @@
 (s/defn run-step-with-metadata :- StepNameWithMetadata
   "Runs `step` on `database` returning metadata from the run"
   [database :- i/DatabaseInstance
-   {:keys [step-name sync-fn log-summary-fn] :as step} :- StepDefinition]
+   {:keys [step-name sync-fn log-summary-fn] :as _step} :- StepDefinition]
   (let [start-time (t/zoned-date-time)
         results    (with-start-and-finish-debug-logging (trs "step ''{0}'' for {1}"
                                                              step-name
@@ -401,7 +401,7 @@
   this function unless the logging level is at debug (or higher)."
   [operation :- s/Str
    database :- i/DatabaseInstance
-   {:keys [start-time end-time steps log-summary-fn]} :- SyncOperationMetadata]
+   {:keys [start-time end-time steps]} :- SyncOperationMetadata]
   (str
    (apply format
           (str "\n#################################################################\n"

--- a/src/metabase/transforms/core.clj
+++ b/src/metabase/transforms/core.clj
@@ -103,7 +103,7 @@
   (m/assoc-some query :filter (de/resolve-dimension-clauses bindings name filter)))
 
 (defn- maybe-add-limit
-  [bindings {:keys [limit]} query]
+  [_bindings {:keys [limit]} query]
   (m/assoc-some query :limit limit))
 
 (s/defn ^:private transform-step! :- Bindings
@@ -140,7 +140,7 @@
                :entity     table}])))
 
 (s/defn ^:private apply-transform-to-tableset! :- Bindings
-  [tableset :- Tableset, {:keys [steps provides]} :- TransformSpec]
+  [tableset :- Tableset, {:keys [steps _provides]} :- TransformSpec]
   (driver/with-driver (-> tableset first table/database :engine)
     (reduce transform-step! (tableset->bindings tableset) (vals steps))))
 

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -891,7 +891,7 @@
 
 (defmacro or-with
   "Like or, but determines truthiness with `pred`."
-  ([pred]
+  ([_pred]
    nil)
   ([pred x & more]
    `(let [pred# ~pred

--- a/src/metabase/util/date_2.clj
+++ b/src/metabase/util/date_2.clj
@@ -515,13 +515,13 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 ;; Mainly for REPL usage. Have various temporal types print as a `java-time` function call you can use
-(doseq [[klass f-symb] {Instant        't/instant
-                        LocalDate      't/local-date
-                        LocalDateTime  't/local-date-time
-                        LocalTime      't/local-time
-                        OffsetDateTime 't/offset-date-time
-                        OffsetTime     't/offset-time
-                        ZonedDateTime  't/zoned-date-time}]
+(doseq [[klass _f-symb] {Instant        't/instant
+                         LocalDate      't/local-date
+                         LocalDateTime  't/local-date-time
+                         LocalTime      't/local-time
+                         OffsetDateTime 't/offset-date-time
+                         OffsetTime     't/offset-time
+                         ZonedDateTime  't/zoned-date-time}]
   (defmethod print-method klass
     [t writer]
     ((get-method print-dup klass) t writer))

--- a/src/metabase/util/date_2/parse/builder.clj
+++ b/src/metabase/util/date_2/parse/builder.clj
@@ -121,7 +121,7 @@
 
 (defn fraction
   "Define a section for a fractional value, e.g. milliseconds or nanoseconds."
-  [temporal-field-name min-val-width max-val-width & {:keys [decimal-point?]}]
+  [temporal-field-name _min-val-width _max-val-width & {:keys [decimal-point?]}]
   (fn [^DateTimeFormatterBuilder builder]
     (.appendFraction builder (temporal-field temporal-field-name) 0 9 (boolean decimal-point?))))
 

--- a/src/metabase/util/ssh.clj
+++ b/src/metabase/util/ssh.clj
@@ -11,7 +11,6 @@
            org.apache.sshd.client.SshClient
            [org.apache.sshd.common.config.keys FilePasswordProvider FilePasswordProvider$ResourceDecodeResult]
            [org.apache.sshd.common.session
-            SessionHeartbeatController
             SessionHeartbeatController$HeartbeatType
             SessionHolder]
            org.apache.sshd.common.util.GenericUtils
@@ -110,7 +109,7 @@
         (ssh-tunnel-open? db-details)
         ;; tunnel in use, and is open
         db-details
-        :default
+        :else
         ;; tunnel in use, and is not open
         (include-ssh-tunnel! db-details)))
 

--- a/src/metabase/util/ui_logic.clj
+++ b/src/metabase/util/ui_logic.clj
@@ -26,7 +26,7 @@
   "For graphs with goals, this function returns the index of the default column that should be used to compare against
   the goal. This follows the frontend code getDefaultLineAreaBarColumns closely with a slight change (detailed in the
   code)"
-  [{graph-type :display :as card} {[col-1 col-2 col-3 :as all-cols] :cols :as result}]
+  [{graph-type :display :as _card} {[col-1 col-2 col-3 :as all-cols] :cols :as _result}]
   (let [cols-count (count all-cols)]
     (cond
       ;; Progress goals return a single row and column, compare that
@@ -59,7 +59,7 @@
 
 (defn- column-name->index
   "The results seq is seq of vectors, this function returns the index in that vector of the given `COLUMN-NAME`"
-  [column-name {:keys [cols] :as result}]
+  [column-name {:keys [cols] :as _result}]
   (first (remove nil? (map-indexed (fn [idx column]
                                      (when (.equalsIgnoreCase (name column-name) (name (:name column)))
                                        idx))

--- a/test/metabase/query_processor/streaming/xlsx_test.clj
+++ b/test/metabase/query_processor/streaming/xlsx_test.clj
@@ -10,6 +10,7 @@
   (:import com.fasterxml.jackson.core.JsonGenerator
            [java.io BufferedInputStream BufferedOutputStream ByteArrayInputStream ByteArrayOutputStream]))
 
+
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                     Format string generation unit tests                                        |
 ;;; +----------------------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
Cleaning up the warnings from `clj-kondo --lint src:shared/src`

Currently

```
clj-kondo --lint src:shared/src | grep -v deprecated | wc -l
      63
```

<details>
<summary> List of non-deprecated warnings</summary>

There are some weird things going on with the `api/defendpoint` macro which is causing the unused binding `p1_23217#` and the other named unused var warnings. Future work with borkdude.
```
❯ clj-kondo --lint src:shared/src | grep -v deprecated
src/metabase/api/database.clj:715:1: warning: unused binding p1__23217#
src/metabase/api/dataset.clj:109:1: warning: unused binding p1__21335#
src/metabase/api/email.clj:68:1: warning: unused binding p1__19748#
src/metabase/api/field.clj:161:1: warning: unused binding field
src/metabase/api/field.clj:184:1: warning: unused binding field
src/metabase/api/metric.clj:79:32: warning: unused binding archived
src/metabase/api/notify.clj:14:1: warning: unused binding table
src/metabase/api/notify.clj:14:1: warning: unused binding database
src/metabase/api/notify.clj:14:1: warning: unused binding db-sync-fn
src/metabase/api/notify.clj:14:1: warning: unused binding table-sync-fn
src/metabase/api/query_description.clj:14:13: warning: unused binding query
src/metabase/api/query_description.clj:66:4: warning: unused binding metadata
src/metabase/api/query_description.clj:71:4: warning: unused binding metadata
src/metabase/api/query_description.clj:88:4: warning: unused binding metadata
src/metabase/api/query_description.clj:89:14: warning: unused binding order-by
src/metabase/api/query_description.clj:96:4: warning: unused binding metadata
src/metabase/api/routes.clj:60:46: warning: Unresolved var: activity/routes
src/metabase/api/routes.clj:61:46: warning: Unresolved var: alert/routes
src/metabase/api/routes.clj:62:46: warning: Unresolved var: magic/routes
src/metabase/api/routes.clj:63:46: warning: Unresolved var: card/routes
src/metabase/api/routes.clj:64:46: warning: Unresolved var: collection/routes
src/metabase/api/routes.clj:65:46: warning: Unresolved var: dashboard/routes
src/metabase/api/routes.clj:66:46: warning: Unresolved var: database/routes
src/metabase/api/routes.clj:67:46: warning: Unresolved var: dataset/routes
src/metabase/api/routes.clj:68:46: warning: Unresolved var: email/routes
src/metabase/api/routes.clj:69:65: warning: Unresolved var: embed/routes
src/metabase/api/routes.clj:70:46: warning: Unresolved var: field/routes
src/metabase/api/routes.clj:71:39: warning: Unresolved var: geojson/routes
src/metabase/api/routes.clj:72:46: warning: Unresolved var: ldap/routes
src/metabase/api/routes.clj:73:46: warning: Unresolved var: login-history/routes
src/metabase/api/routes.clj:74:46: warning: Unresolved var: premium-features/routes
src/metabase/api/routes.clj:75:46: warning: Unresolved var: metric/routes
src/metabase/api/routes.clj:76:46: warning: Unresolved var: native-query-snippet/routes
src/metabase/api/routes.clj:77:48: warning: Unresolved var: notify/routes
src/metabase/api/routes.clj:78:46: warning: Unresolved var: permissions/routes
src/metabase/api/routes.clj:79:46: warning: Unresolved var: preview-embed/routes
src/metabase/api/routes.clj:80:60: warning: Unresolved var: public/routes
src/metabase/api/routes.clj:81:46: warning: Unresolved var: pulse/routes
src/metabase/api/routes.clj:82:46: warning: Unresolved var: revision/routes
src/metabase/api/routes.clj:83:46: warning: Unresolved var: search/routes
src/metabase/api/routes.clj:84:46: warning: Unresolved var: segment/routes
src/metabase/api/routes.clj:85:39: warning: Unresolved var: session/routes
src/metabase/api/routes.clj:86:46: warning: Unresolved var: setting/routes
src/metabase/api/routes.clj:87:39: warning: Unresolved var: setup/routes
src/metabase/api/routes.clj:88:46: warning: Unresolved var: slack/routes
src/metabase/api/routes.clj:89:46: warning: Unresolved var: table/routes
src/metabase/api/routes.clj:90:46: warning: Unresolved var: task/routes
src/metabase/api/routes.clj:93:41: warning: Unresolved var: testing/routes
src/metabase/api/routes.clj:95:46: warning: Unresolved var: tiles/routes
src/metabase/api/routes.clj:96:46: warning: Unresolved var: transform/routes
src/metabase/api/routes.clj:97:46: warning: Unresolved var: user/routes
src/metabase/api/routes.clj:98:39: warning: Unresolved var: util/routes
src/metabase/api/search.clj:168:4: warning: unused binding model
src/metabase/api/search.clj:344:46: warning: unused binding k
src/metabase/api/segment.clj:69:32: warning: unused binding archived
src/metabase/api/setup.clj:61:59: warning: unused binding first_name
src/metabase/api/setup.clj:61:70: warning: unused binding last_name
src/metabase/api/setup.clj:84:29: warning: unused binding request
src/metabase/api/table.clj:199:30: warning: unused binding k
src/metabase/api/tiles.clj:112:24: warning: unused binding e
src/metabase/api/user.clj:85:41: warning: Unresolved namespace clojure.string. Are you missing a require?
src/metabase/query_processor/middleware/parameters.clj:22:25: warning: unused binding source-query
linting took 4993ms, errors: 0, warnings: 151
```
</details>


<details>
<summary>List of deprecation warnings for completeness</summary>

```
❯ clj-kondo --lint src:shared/src | grep deprecated
src/metabase/api/database.clj:80:7: warning: #'metabase.driver/supports? is deprecated since 0.41.0
src/metabase/api/database.clj:119:62: warning: #'metabase.driver/supports? is deprecated since 0.41.0
src/metabase/api/table.clj:213:15: warning: #'metabase.driver/supports? is deprecated since 0.41.0
src/metabase/automagic_dashboards/comparison.clj:39:9: warning: #'metabase.query-processor.util/normalize-token is deprecated
src/metabase/automagic_dashboards/core.clj:95:50: warning: #'metabase.query-processor.util/normalize-token is deprecated
src/metabase/automagic_dashboards/core.clj:211:20: warning: #'metabase.query-processor.util/normalize-token is deprecated
src/metabase/automagic_dashboards/core.clj:424:54: warning: #'metabase.query-processor.util/normalize-token is deprecated
src/metabase/automagic_dashboards/core.clj:593:12: warning: #'metabase.driver/supports? is deprecated since 0.41.0
src/metabase/automagic_dashboards/core.clj:599:30: warning: #'metabase.query-processor.util/normalize-token is deprecated
src/metabase/automagic_dashboards/core.clj:1040:18: warning: #'metabase.query-processor.util/normalize-token is deprecated
src/metabase/automagic_dashboards/core.clj:1117:27: warning: #'metabase.query-processor.util/normalize-token is deprecated
src/metabase/automagic_dashboards/core.clj:1127:32: warning: #'metabase.query-processor.util/normalize-token is deprecated
src/metabase/automagic_dashboards/populate.clj:89:42: warning: #'metabase.query-processor.util/normalize-token is deprecated
src/metabase/automagic_dashboards/rules.clj:125:75: warning: #'metabase.query-processor.util/normalize-token is deprecated
src/metabase/db/metadata_queries.clj:115:55: warning: #'metabase.driver/supports? is deprecated since 0.41.0
src/metabase/driver.clj:417:12: warning: #'metabase.driver/supports? is deprecated since 0.41.0
src/metabase/driver.clj:419:12: warning: #'metabase.driver/supports? is deprecated since 0.41.0
src/metabase/driver.clj:420:12: warning: #'metabase.driver/supports? is deprecated since 0.41.0
src/metabase/driver.clj:446:59: warning: #'metabase.driver/supports? is deprecated since 0.41.0
src/metabase/driver.clj:598:12: warning: #'metabase.driver/current-db-time is deprecated since 0.34.0
src/metabase/driver/common.clj:293:5: warning: #'metabase.driver.common/ThreadSafeSimpleDateFormat is deprecated
src/metabase/driver/common.clj:335:27: warning: #'metabase.driver.common/current-db-time-native-query is deprecated
src/metabase/driver/common.clj:336:27: warning: #'metabase.driver.common/current-db-time-date-formatters is deprecated
src/metabase/driver/common.clj:360:11: warning: #'metabase.driver.common/first-successful-parse is deprecated
src/metabase/driver/h2.clj:33:14: warning: #'metabase.driver/supports? is deprecated since 0.41.0
src/metabase/driver/h2.clj:124:12: warning: #'metabase.driver.common/current-db-time-date-formatters is deprecated
src/metabase/driver/h2.clj:126:3: warning: #'metabase.driver.common/create-db-time-formatters is deprecated
src/metabase/driver/h2.clj:128:12: warning: #'metabase.driver.common/current-db-time-native-query is deprecated
src/metabase/driver/h2.clj:132:12: warning: #'metabase.driver/current-db-time is deprecated since 0.34.0
src/metabase/driver/h2.clj:134:10: warning: #'metabase.driver.common/current-db-time is deprecated
src/metabase/driver/mysql.clj:33:12: warning: #'metabase.driver/supports? is deprecated since 0.41.0
src/metabase/driver/mysql.clj:34:12: warning: #'metabase.driver/supports? is deprecated since 0.41.0
src/metabase/driver/mysql.clj:76:12: warning: #'metabase.driver/supports? is deprecated since 0.41.0
src/metabase/driver/mysql.clj:165:12: warning: #'metabase.driver/supports? is deprecated since 0.41.0
src/metabase/driver/mysql.clj:371:12: warning: #'metabase.driver.sql-jdbc.execute.old-impl/set-timezone-sql is deprecated since 0.35.0
src/metabase/driver/postgres.clj:73:12: warning: #'metabase.driver.common/current-db-time-date-formatters is deprecated
src/metabase/driver/postgres.clj:75:3: warning: #'metabase.driver.common/create-db-time-formatters is deprecated
src/metabase/driver/postgres.clj:77:12: warning: #'metabase.driver.common/current-db-time-native-query is deprecated
src/metabase/driver/postgres.clj:81:12: warning: #'metabase.driver/current-db-time is deprecated since 0.34.0
src/metabase/driver/postgres.clj:83:10: warning: #'metabase.driver.common/current-db-time is deprecated
src/metabase/driver/postgres.clj:420:12: warning: #'metabase.driver.sql-jdbc.execute.old-impl/set-timezone-sql is deprecated since 0.35.0
src/metabase/driver/sql.clj:28:14: warning: #'metabase.driver/supports? is deprecated since 0.41.0
src/metabase/driver/sql.clj:34:14: warning: #'metabase.driver/supports? is deprecated since 0.41.0
src/metabase/driver/sql.clj:36:5: warning: #'metabase.driver/supports? is deprecated since 0.41.0
src/metabase/driver/sql/query_processor.clj:947:3: warning: #'metabase.driver.sql.query-processor.deprecated/*field-options* is deprecated since 0.42.0
src/metabase/driver/sql/query_processor.clj:948:3: warning: #'metabase.driver.sql.query-processor.deprecated/*source-query* is deprecated since 0.42.0
src/metabase/driver/sql/query_processor.clj:949:3: warning: #'metabase.driver.sql.query-processor.deprecated/*table-alias* is deprecated since 0.42.0
src/metabase/driver/sql/query_processor.clj:950:3: warning: #'metabase.driver.sql.query-processor.deprecated/escape-alias is deprecated since 0.42.0
src/metabase/driver/sql/query_processor.clj:951:3: warning: #'metabase.driver.sql.query-processor.deprecated/field->alias is deprecated since 0.41.0
src/metabase/driver/sql/query_processor.clj:952:3: warning: #'metabase.driver.sql.query-processor.deprecated/field->identifier is deprecated since 0.42.0
src/metabase/driver/sql/query_processor.clj:953:3: warning: #'metabase.driver.sql.query-processor.deprecated/prefix-field-alias is deprecated since 0.42.0
src/metabase/driver/sql/query_processor.clj:961:12: warning: #'metabase.driver.sql.query-processor.deprecated/field->identifier is deprecated since 0.42.0
src/metabase/driver/sql/query_processor.clj:963:47: warning: #'metabase.driver.sql.query-processor.deprecated/field->identifier is deprecated since 0.42.0
src/metabase/driver/sql/query_processor/deprecated.clj:55:12: warning: #'metabase.driver.sql.query-processor.deprecated/field->alias is deprecated since 0.41.0
src/metabase/driver/sql/query_processor/deprecated.clj:103:12: warning: #'metabase.driver.sql.query-processor.deprecated/escape-alias is deprecated since 0.42.0
src/metabase/driver/sql/query_processor/deprecated.clj:111:28: warning: #'metabase.driver.sql.query-processor.deprecated/escape-alias is deprecated since 0.42.0
src/metabase/driver/sql/query_processor/deprecated.clj:112:28: warning: #'metabase.driver.sql.query-processor.deprecated/escape-alias is deprecated since 0.42.0
src/metabase/driver/sql/query_processor/deprecated.clj:114:3: warning: #'metabase.driver.sql.query-processor.deprecated/escape-alias is deprecated since 0.42.0
src/metabase/driver/sql/query_processor/deprecated.clj:127:12: warning: #'metabase.driver.sql.query-processor.deprecated/prefix-field-alias is deprecated since 0.42.0
src/metabase/driver/sql_jdbc.clj:42:12: warning: #'metabase.driver/supports? is deprecated since 0.41.0
src/metabase/driver/sql_jdbc.clj:44:17: warning: #'metabase.driver.sql-jdbc.execute.old-impl/set-timezone-sql is deprecated since 0.35.0
src/metabase/driver/sql_jdbc/execute.clj:152:30: warning: #'metabase.driver.sql-jdbc.execute.old-impl/set-timezone-sql is deprecated since 0.35.0
src/metabase/driver/sql_jdbc/execute.clj:193:7: warning: #'metabase.driver.sql-jdbc.execute/set-time-zone-if-supported! is deprecated since 0.35.0
src/metabase/driver/sql_jdbc/execute.clj:435:30: warning: #'metabase.driver.sql-jdbc.execute.old-impl/read-column is deprecated since 0.35.0
src/metabase/driver/sql_jdbc/execute.clj:437:48: warning: #'metabase.driver.sql-jdbc.execute.old-impl/read-column is deprecated since 0.35.0
src/metabase/driver/sql_jdbc/execute.clj:517:3: warning: #'metabase.driver.sql-jdbc.execute.old-impl/set-timezone-sql is deprecated since 0.35.0
src/metabase/driver/sql_jdbc/execute.clj:518:3: warning: #'metabase.driver.sql-jdbc.execute.old-impl/read-column is deprecated since 0.35.0
src/metabase/driver/sql_jdbc/execute/old_impl.clj:24:12: warning: #'metabase.driver.sql-jdbc.execute.old-impl/set-timezone-sql is deprecated since 0.35.0
src/metabase/driver/sql_jdbc/execute/old_impl.clj:43:12: warning: #'metabase.driver.sql-jdbc.execute.old-impl/read-column is deprecated since 0.35.0
src/metabase/driver/sql_jdbc/execute/old_impl.clj:50:12: warning: #'metabase.driver.sql-jdbc.execute.old-impl/read-column is deprecated since 0.35.0
src/metabase/driver/sql_jdbc/execute/old_impl.clj:54:12: warning: #'metabase.driver.sql-jdbc.execute.old-impl/read-column is deprecated since 0.35.0
src/metabase/driver/sql_jdbc/execute/old_impl.clj:58:12: warning: #'metabase.driver.sql-jdbc.execute.old-impl/read-column is deprecated since 0.35.0
src/metabase/driver/sql_jdbc/execute/old_impl.clj:62:12: warning: #'metabase.driver.sql-jdbc.execute.old-impl/read-column is deprecated since 0.35.0
src/metabase/driver/sql_jdbc/execute/old_impl.clj:66:12: warning: #'metabase.driver.sql-jdbc.execute.old-impl/read-column is deprecated since 0.35.0
src/metabase/driver/sql_jdbc/sync.clj:20:3: warning: #'metabase.driver.sql-jdbc.sync.interface/syncable-schemas is deprecated since 0.43.0
src/metabase/driver/sql_jdbc/sync/interface.clj:60:12: warning: #'metabase.driver.sql-jdbc.sync.interface/syncable-schemas is deprecated since 0.43.0
src/metabase/driver/util.clj:64:9: warning: #'metabase.driver/supports? is deprecated since 0.41.0
src/metabase/models/collection.clj:868:19: warning: #'metabase.public-settings.premium-features/enable-enhancements? is deprecated
src/metabase/models/collection/root.clj:23:17: warning: #'metabase.public-settings.premium-features/enable-enhancements? is deprecated
src/metabase/query_processor/middleware/add_implicit_joins.clj:184:17: warning: #'metabase.driver/supports? is deprecated since 0.41.0
src/metabase/query_processor/middleware/parameters/native.clj:34:11: warning: #'metabase.driver/supports? is deprecated since 0.41.0
src/metabase/query_processor/middleware/resolve_joins.clj:159:5: warning: #'metabase.query-processor.middleware.resolve-joins/maybe-resolve-source-table is deprecated
src/metabase/query_processor/middleware/results_metadata.clj:30:16: warning: #'metabase.driver/supports? is deprecated since 0.41.0
src/metabase/query_processor/timezone.clj:44:10: warning: #'metabase.driver/supports? is deprecated since 0.41.0
src/metabase/related.clj:29:32: warning: #'metabase.query-processor.util/normalize-token is deprecated
src/metabase/related.clj:38:35: warning: #'metabase.query-processor.util/normalize-token is deprecated
src/metabase/related.clj:100:33: warning: #'metabase.query-processor.util/normalize-token is deprecated
src/metabase/sync/fetch_metadata.clj:24:11: warning: #'metabase.driver/supports? is deprecated since 0.41.0
src/metabase/sync/sync_metadata/sync_timezone.clj:20:29: warning: #'metabase.driver/current-db-time is deprecated since 0.34.0
```

</details>

vs master

```
clj-kondo --lint src:shared/src | grep -v deprecated | wc -l
     286
```

I'm omitting deprecations since those will require a bit more work or manually excluding them with `#_:clj-kondo/ignore` in the cases where we are calling the deprecated method for legacy compatibility reasons.

Things removed in this PR:
- try without catch
- redundant `do`s
- unused bindings
- unused private vars. Following a convention of sometimes leaving the name with an underscore prepended to retain context where appropriate. There are no bright-line rules for this so just "season to taste".

This does require a slight change in how we code. Presumably everyone should have some editor integration with clj-kondo. Clojure-lsp is quite nice as well.