### PR TITLE
PoC: Restore from a custom snapshot in the `before` hook

### DIFF
--- a/frontend/test/metabase/scenarios/binning/sql.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/sql.cy.spec.js
@@ -1,5 +1,6 @@
 import {
   restore,
+  snapshot,
   visualize,
   changeBinningForDimension,
 } from "__support__/e2e/cypress";
@@ -13,12 +14,20 @@ const questionDetails = {
 };
 
 describe("scenarios > binning > from a saved sql question", () => {
+  before(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.createNativeQuestion(questionDetails, { loadMetadata: true });
+
+    snapshot("binningSql");
+  });
+
   beforeEach(() => {
     cy.intercept("POST", "/api/dataset").as("dataset");
 
-    restore();
+    restore("binningSql");
     cy.signInAsAdmin();
-    cy.createNativeQuestion(questionDetails, { loadMetadata: true });
   });
 
   context("via simple question", () => {


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Starts using our own custom `snapshot` and `restore` test endpoints in actual running tests. Previously, they've been used exclusively for creating the default snapshot (see: [default.cy.snap.js](https://github.com/metabase/metabase/blob/master/frontend/test/snapshot-creators/default.cy.snap.js)) that we restore to in every single spec.

### More info:
- We're using `beforeEeach` hook for the setup phase. Sometimes that setup can be quite complex and can require a significant amount of time to finish. Now, imagine repeating that same flow before **each** test. It adds up and it gets worse if there are many individual tests in a file.
- By creating that setup **once** (in the `before` hook) and then taking a snapshot of that state, we can then restore to that exact point in every single test. This saves tens of seconds per file.

So why did we even use `beforeEeach` before?
1. I tried this approach and it didn't work for whatever reason
2. This can potentially lead to failures in the CI, because snapshot is writing a file to the system. That's happening outside of the Cypress runner (async), and it's quite possible that we'll have some race conditions.

However, this brings such huge speed improvements that we should try it.
My suggestion is to keep this approach in this one spec only, and observe how it behaves in CI over a week or so. If nothing unpredictable happens, we can apply that approach to other files as well.

### Screenshots

Before
![image](https://user-images.githubusercontent.com/31325167/151452435-0c751c41-832d-48ea-9ad3-ee4b1b44f7c3.png)

After
![image](https://user-images.githubusercontent.com/31325167/151453637-43efeba0-d25c-4974-ad8d-8265c70d9aa4.png)