### PR TITLE
fix crowded ordinal ticks

### DIFF
--- a/frontend/src/metabase/internal/pages/StaticVizPage.jsx
+++ b/frontend/src/metabase/internal/pages/StaticVizPage.jsx
@@ -714,7 +714,7 @@ export default function StaticVizPage() {
         </Box>
 
         <Box py={3}>
-          <Subhead>Ordinal chart with 80 items</Subhead>
+          <Subhead>Ordinal chart with 200 items</Subhead>
           <StaticChart
             type="combo-chart"
             options={{
@@ -736,7 +736,7 @@ export default function StaticVizPage() {
                   color: "#509ee3",
                   yAxisPosition: "left",
                   type: "bar",
-                  data: _.range(80).map(n => [`bar ${n + 1}`, n + 1]),
+                  data: _.range(200).map(n => [`bar ${n + 1}`, n + 1]),
                 },
               ],
             }}

--- a/frontend/src/metabase/internal/pages/StaticVizPage.jsx
+++ b/frontend/src/metabase/internal/pages/StaticVizPage.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Box } from "grid-styled";
+import _ from "underscore";
 import Heading from "metabase/components/type/Heading";
 import Subhead from "metabase/components/type/Subhead";
 import Text from "metabase/components/type/Text";
@@ -676,6 +677,96 @@ export default function StaticVizPage() {
                     ["2020-10-22", -10],
                     ["2020-10-23", -5],
                   ],
+                },
+              ],
+            }}
+          />
+        </Box>
+
+        <Box py={3}>
+          <Subhead>Ordinal chart with 48 items</Subhead>
+          <StaticChart
+            type="combo-chart"
+            options={{
+              settings: {
+                x: {
+                  type: "ordinal",
+                },
+                y: {
+                  type: "linear",
+                },
+                labels: {
+                  left: "Count",
+                  bottom: "Date",
+                },
+              },
+              series: [
+                {
+                  name: "bar series",
+                  color: "#509ee3",
+                  yAxisPosition: "left",
+                  type: "bar",
+                  data: _.range(48).map(n => [`bar ${n + 1}`, n + 1]),
+                },
+              ],
+            }}
+          />
+        </Box>
+
+        <Box py={3}>
+          <Subhead>Ordinal chart with 80 items</Subhead>
+          <StaticChart
+            type="combo-chart"
+            options={{
+              settings: {
+                x: {
+                  type: "ordinal",
+                },
+                y: {
+                  type: "linear",
+                },
+                labels: {
+                  left: "Count",
+                  bottom: "Date",
+                },
+              },
+              series: [
+                {
+                  name: "bar series",
+                  color: "#509ee3",
+                  yAxisPosition: "left",
+                  type: "bar",
+                  data: _.range(80).map(n => [`bar ${n + 1}`, n + 1]),
+                },
+              ],
+            }}
+          />
+        </Box>
+
+        <Box py={3}>
+          <Subhead>Ordinal chart with 20 items</Subhead>
+          <StaticChart
+            type="combo-chart"
+            options={{
+              settings: {
+                x: {
+                  type: "ordinal",
+                },
+                y: {
+                  type: "linear",
+                },
+                labels: {
+                  left: "Count",
+                  bottom: "Date",
+                },
+              },
+              series: [
+                {
+                  name: "bar series",
+                  color: "#509ee3",
+                  yAxisPosition: "left",
+                  type: "bar",
+                  data: _.range(20).map(n => [`bar ${n + 1}`, n + 1]),
                 },
               ],
             }}

--- a/frontend/src/metabase/static-viz/components/LineAreaBarChart/LineAreaBarChart.tsx
+++ b/frontend/src/metabase/static-viz/components/LineAreaBarChart/LineAreaBarChart.tsx
@@ -2,11 +2,15 @@ import React from "react";
 import { XYChart } from "../XYChart";
 import { ChartSettings, ChartStyle, Series } from "../XYChart/types";
 import { Colors } from "./types";
-import { adjustSettings } from "./utils/settings";
+import {
+  adjustSettings,
+  calculateChartSize,
+  getXValuesCount,
+} from "./utils/settings";
 
 const defaultColors = {
   brand: "#509ee3",
-  brandLight: "#DDECFA",
+  brandLight: "#ddecfa",
   textLight: "#b8bbc3",
   textMedium: "#949aab",
 };
@@ -45,15 +49,23 @@ const LineAreaBarChart = ({
     goalColor: palette.textMedium,
   };
 
-  const adjustedSettings = adjustSettings(settings, series);
+  const minTickSize = chartStyle.axes.ticks.fontSize * 1.5;
+  const xValuesCount = getXValuesCount(series);
+  const chartSize = calculateChartSize(settings, xValuesCount, minTickSize);
+  const adjustedSettings = adjustSettings(
+    settings,
+    xValuesCount,
+    minTickSize,
+    chartSize,
+  );
 
   return (
     <XYChart
       series={series}
       settings={adjustedSettings}
       style={chartStyle}
-      width={540}
-      height={300}
+      width={chartSize.width}
+      height={chartSize.height}
     />
   );
 };

--- a/frontend/src/metabase/static-viz/components/LineAreaBarChart/types.ts
+++ b/frontend/src/metabase/static-viz/components/LineAreaBarChart/types.ts
@@ -4,3 +4,8 @@ export type Colors = {
   textLight: string;
   textMedium: string;
 };
+
+export type Size = {
+  width: number;
+  height: number;
+};

--- a/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/settings.ts
+++ b/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/settings.ts
@@ -1,26 +1,78 @@
 import { assocIn } from "icepick";
 import { ChartSettings, Series } from "../../XYChart/types";
 import { getX } from "../../XYChart/utils";
+import { Size } from "../types";
 
-// We want to adjust display settings based on chart data to achieve better-looking charts on smaller static images.
-export const adjustSettings = (settings: ChartSettings, series: Series[]) => {
-  return rotateCrowdedOrdinalXTicks(settings, series);
+const DEFAULT_SIZE = {
+  width: 540,
+  height: 300,
 };
 
-const rotateCrowdedOrdinalXTicks = (
+const RATIO = DEFAULT_SIZE.width / DEFAULT_SIZE.height;
+
+const MAX_WIDTH = 800;
+
+export const calculateChartSize = (
   settings: ChartSettings,
-  series: Series[],
+  xValuesCount: number,
+  minTickSize: number,
+): Size => {
+  if (settings.x.type !== "ordinal") {
+    return DEFAULT_SIZE;
+  }
+
+  const requiredWidth = minTickSize * xValuesCount;
+
+  const width = Math.max(
+    DEFAULT_SIZE.width,
+    Math.min(MAX_WIDTH, requiredWidth),
+  );
+  const height = width / RATIO;
+
+  return {
+    width,
+    height,
+  };
+};
+
+export const getXValuesCount = (series: Series[]): number => {
+  const items = new Set();
+  series.forEach(s => {
+    s.data.forEach(datum => items.add(getX(datum)));
+  });
+  return items.size;
+};
+
+// We want to adjust display settings based on chart data to achieve better-looking charts on smaller static images.
+export const adjustSettings = (
+  settings: ChartSettings,
+  xValuesCount: number,
+  minTickSize: number,
+  chartSize: Size,
+): ChartSettings => {
+  return handleCrowdedOrdinalXTicks(
+    settings,
+    xValuesCount,
+    minTickSize,
+    chartSize,
+  );
+};
+
+const handleCrowdedOrdinalXTicks = (
+  settings: ChartSettings,
+  xValuesCount: number,
+  minTickSize: number,
+  chartSize: Size,
 ) => {
   if (settings.x.type !== "ordinal") {
     return settings;
   }
 
-  const items = new Set();
-  series.forEach(s => {
-    s.data.forEach(datum => items.add(getX(datum)));
-  });
+  if (minTickSize * xValuesCount > chartSize.width) {
+    return assocIn(settings, ["x", "tick_display"], "hide");
+  }
 
-  return items.size > 10
+  return xValuesCount > 10
     ? assocIn(settings, ["x", "tick_display"], "rotate-45")
     : settings;
 };

--- a/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/settings.unit.spec.ts
+++ b/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/settings.unit.spec.ts
@@ -15,6 +15,13 @@ const settings: ChartSettings = {
   },
 };
 
+const chartSize = {
+  width: 540,
+  height: 300,
+};
+
+const minTickSize = 12;
+
 const getSeries = (length: number): Series[] => [
   {
     name: "series",
@@ -28,15 +35,41 @@ const getSeries = (length: number): Series[] => [
 describe("adjustSettings", () => {
   describe("ordinal x-axis", () => {
     it("returns unchanged settings when the number X-ticks is less or equal than 10", () => {
-      const adjustedSettings = adjustSettings(settings, getSeries(10));
+      const xValuesCount = 10;
+      const adjustedSettings = adjustSettings(
+        settings,
+        xValuesCount,
+        minTickSize,
+        chartSize,
+      );
 
       expect(adjustedSettings).toBe(settings);
     });
 
     it("rotates X-ticks when the number X-ticks is greater than 10", () => {
-      const adjustedSettings = adjustSettings(settings, getSeries(11));
+      const xValuesCount = 11;
+      const adjustedSettings = adjustSettings(
+        settings,
+        xValuesCount,
+        minTickSize,
+        chartSize,
+      );
 
       expect(adjustedSettings.x.tick_display).toBe("rotate-45");
+    });
+
+    it("hides X-ticks when they can't fit", () => {
+      const xValuesCount = 60;
+      const minTickSize = chartSize.width / 60 + 1;
+
+      const adjustedSettings = adjustSettings(
+        settings,
+        xValuesCount,
+        minTickSize,
+        chartSize,
+      );
+
+      expect(adjustedSettings.x.tick_display).toBe("hide");
     });
   });
 });

--- a/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
@@ -130,6 +130,8 @@ export const XYChart = ({
   };
 
   const areXTicksRotated = settings.x.tick_display === "rotate-45";
+  const areXTicksHidden = settings.x.tick_display === "hide";
+  const xLabelOffset = areXTicksHidden ? -style.axes.ticks.fontSize : 0;
 
   return (
     <svg width={width} height={height + legendHeight}>
@@ -217,22 +219,26 @@ export const XYChart = ({
         top={yMin}
         left={xMin}
         numTicks={xTicksCount}
+        labelOffset={xLabelOffset}
         stroke={style.axes.color}
         tickStroke={style.axes.color}
+        hideTicks={settings.x.tick_display === "hide"}
         labelProps={labelProps}
         tickFormat={value =>
           formatXTick(value.valueOf(), settings.x.type, settings.x.format)
         }
-        tickComponent={props => (
-          <Text
-            {...getXTickProps(
-              props,
-              style.axes.ticks.fontSize,
-              xTickWidthLimit,
-              areXTicksRotated,
-            )}
-          />
-        )}
+        tickComponent={props =>
+          areXTicksHidden ? null : (
+            <Text
+              {...getXTickProps(
+                props,
+                style.axes.ticks.fontSize,
+                xTickWidthLimit,
+                areXTicksRotated,
+              )}
+            />
+          )
+        }
         tickLabelProps={() => tickProps}
       />
 

--- a/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
@@ -131,7 +131,7 @@ export const XYChart = ({
 
   const areXTicksRotated = settings.x.tick_display === "rotate-45";
   const areXTicksHidden = settings.x.tick_display === "hide";
-  const xLabelOffset = areXTicksHidden ? -style.axes.ticks.fontSize : 0;
+  const xLabelOffset = areXTicksHidden ? -style.axes.ticks.fontSize : undefined;
 
   return (
     <svg width={width} height={height + legendHeight}>

--- a/frontend/src/metabase/static-viz/components/XYChart/utils/scales.ts
+++ b/frontend/src/metabase/static-viz/components/XYChart/utils/scales.ts
@@ -40,7 +40,6 @@ export const createXScale = (
     const xScale = scaleBand({
       domain,
       range,
-      round: true,
       padding: 0.1,
     });
 

--- a/frontend/src/metabase/static-viz/components/XYChart/utils/ticks.ts
+++ b/frontend/src/metabase/static-viz/components/XYChart/utils/ticks.ts
@@ -47,6 +47,10 @@ export const getXTickWidthLimit = (
   actualMaxWidth: number,
   bandwidth?: number,
 ) => {
+  if (settings.tick_display === "hide") {
+    return 0;
+  }
+
   if (settings.type !== "ordinal" || !bandwidth) {
     return Infinity;
   }
@@ -61,6 +65,14 @@ export const getXTicksDimensions = (
   settings: ChartSettings["x"],
   fontSize: number,
 ) => {
+  if (settings.tick_display === "hide") {
+    return {
+      width: 0,
+      height: 0,
+      maxTextWidth: 0,
+    };
+  }
+
   const maxTextWidth = series
     .flatMap(s => s.data)
     .map(datum => {
@@ -99,10 +111,10 @@ export const getXTickProps = (
 
   const textBaseline = Math.floor(tickFontSize / 2);
   const transform = shouldRotate
-    ? `rotate(45, ${props.x} ${props.y}) translate(-${textBaseline} 0)`
+    ? `rotate(-45, ${props.x} ${props.y}) translate(${textBaseline}, 0)`
     : undefined;
 
-  const textAnchor = shouldRotate ? "start" : "middle";
+  const textAnchor = shouldRotate ? "end" : "middle";
 
   return { ...props, transform, children: value, textAnchor };
 };


### PR DESCRIPTION
### Changes

- When an x-ticks number is > 10, we rotate them https://github.com/metabase/metabase/pull/19702 — in this PR, I changed the rotation angle to match non-static charts
- When an x-ticks number is big enough, it tries to scale the chart up to 800px width to fit all ticks
- If even scaled to 800px width chart can't fit all ticks, it hides them as on our non-static charts

[Internal url](http://localhost:3000/_internal/static-viz)

<img width="575" alt="Screenshot 2022-01-29 at 00 23 32" src="https://user-images.githubusercontent.com/14301985/151639390-b8e07785-b953-4f5d-bf4a-146b24cb9540.png">
<img width="791" alt="Screenshot 2022-01-29 at 00 23 27" src="https://user-images.githubusercontent.com/14301985/151639378-6c7c54be-5cef-41e5-b53b-a228fd5d1b0d.png">




