### PR TITLE
Fix clj-kondo warning introduced in #19963 

### DIFF
--- a/test/metabase/query_processor/streaming/xlsx_test.clj
+++ b/test/metabase/query_processor/streaming/xlsx_test.clj
@@ -489,12 +489,12 @@
 (deftest poi-tempfiles-test
   (testing "POI temporary files are cleaned up if output stream is closed before export completes (#19480)"
     (let [poifiles-directory      (io/file (str (System/getProperty "java.io.tmpdir") "/poifiles"))
-          expected-poifiles-count (count (file-seq poifiles-directory))]
-      (let [bos                (ByteArrayOutputStream.)
-            os                 (BufferedOutputStream. bos)
-            results-writer     (i/streaming-results-writer :xlsx os)]
-        (.close os)
-        (i/begin! results-writer {:data {:ordered-cols []}} {})
-        (i/finish! results-writer {:row_count 0})
+          expected-poifiles-count (count (file-seq poifiles-directory))
+          bos                (ByteArrayOutputStream.)
+          os                 (BufferedOutputStream. bos)
+          results-writer     (i/streaming-results-writer :xlsx os)]
+      (.close os)
+      (i/begin! results-writer {:data {:ordered-cols []}} {})
+      (i/finish! results-writer {:row_count 0})
         ;; No additional files should exist in the temp directory
-        (is (= expected-poifiles-count (count (file-seq poifiles-directory))))))))
+      (is (= expected-poifiles-count (count (file-seq poifiles-directory)))))))

--- a/test/metabase/query_processor/streaming/xlsx_test.clj
+++ b/test/metabase/query_processor/streaming/xlsx_test.clj
@@ -496,5 +496,5 @@
       (.close os)
       (i/begin! results-writer {:data {:ordered-cols []}} {})
       (i/finish! results-writer {:row_count 0})
-        ;; No additional files should exist in the temp directory
+      ;; No additional files should exist in the temp directory
       (is (= expected-poifiles-count (count (file-seq poifiles-directory)))))))


### PR DESCRIPTION
Just added a clj-kondo integration to my editor and noticed that I accidentally merged a redundant `let` expression in #19963, which produces a warning (originally had a couple lines of code between the two `let` expressions, but removed it and forgot to combine the two). Fixing it here; should be a no-op.