### PR TITLE
Enable quick filter drills on aggregated, custom columns and native query results

### DIFF
--- a/frontend/src/metabase-lib/lib/metadata/Field.ts
+++ b/frontend/src/metabase-lib/lib/metadata/Field.ts
@@ -213,17 +213,17 @@ export default class Field extends Base {
     return getIconForField(this);
   }
 
-  dimension() {
+  reference() {
     if (Array.isArray(this.id)) {
       // if ID is an array, it's a MBQL field reference, typically "field"
-      return Dimension.parseMBQL(this.id, this.metadata, this.query);
+      return this.id;
     } else {
-      return Dimension.parseMBQL(
-        ["field", this.id, null],
-        this.metadata,
-        this.query,
-      );
+      return ["field", this.id, null];
     }
+  }
+
+  dimension() {
+    return Dimension.parseMBQL(this.reference(), this.metadata, this.query);
   }
 
   sourceField() {

--- a/frontend/src/metabase-types/types/Dataset.ts
+++ b/frontend/src/metabase-types/types/Dataset.ts
@@ -13,10 +13,11 @@ export type BinningInfo = {
 
 // TODO: incomplete
 export type Column = {
-  id?: FieldId | FieldLiteral; // NOTE: sometimes id is a field reference, e.x. nested queries?
+  id?: FieldId | FieldLiteral; // NOTE: sometimes id is a field reference, e.g. nested queries
   name: ColumnName;
   display_name: string;
   base_type: string;
+  effective_type: string;
   semantic_type?: string;
   source?: "fields" | "aggregation" | "breakout";
   unit?: DatetimeUnit;

--- a/frontend/src/metabase-types/types/mocks/dataset.ts
+++ b/frontend/src/metabase-types/types/mocks/dataset.ts
@@ -1,0 +1,17 @@
+import { Column } from "../Dataset";
+
+export function createMockColumn({
+  name = "count",
+  display_name = name,
+  base_type = "type/BigInteger",
+  effective_type = base_type,
+  ...rest
+}: Partial<Column> = {}): Column {
+  return {
+    name,
+    display_name,
+    base_type,
+    effective_type,
+    ...rest,
+  };
+}

--- a/frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx
@@ -1,17 +1,13 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 import { jt } from "ttag";
-import { TYPE, isa, isFK, isPK } from "metabase/lib/types";
+import { isFK, isPK } from "metabase/lib/types";
+import { isDate, isNumeric } from "metabase/lib/schema_metadata";
 import { singularize, pluralize, stripId } from "metabase/lib/formatting";
 import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
 
 function getFiltersForColumn(column) {
-  if (
-    isa(column.base_type, TYPE.Number) ||
-    isa(column.base_type, TYPE.Temporal) ||
-    // change to semantic_type or ideally effective_type if that is known after merging into master
-    isa(column.special_type, TYPE.Temporal)
-  ) {
+  if (isNumeric(column) || isDate(column)) {
     return [
       { name: "<", operator: "<" },
       { name: ">", operator: ">" },

--- a/frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx
@@ -26,6 +26,22 @@ function getFiltersForColumn(column) {
   }
 }
 
+function getFKFilter({ question, query, column, value }) {
+  const formattedColumnName = singularize(stripId(column.display_name));
+  const formattedTableName = pluralize(query.table().display_name);
+  return {
+    name: "view-fks",
+    section: "standalone_filter",
+    buttonType: "horizontal",
+    icon: "filter",
+    title: (
+      <span>
+        {jt`View this ${formattedColumnName}'s ${formattedTableName}`}
+      </span>
+    ),
+    question: () => question.filter("=", column, value),
+  };
+}
 export default function QuickFilterDrill({ question, clicked }) {
   const query = question.query();
   if (
@@ -43,23 +59,9 @@ export default function QuickFilterDrill({ question, clicked }) {
   if (isPK(column.semantic_type)) {
     return [];
   }
+
   if (isFK(column.semantic_type)) {
-    return [
-      {
-        name: "view-fks",
-        section: "standalone_filter",
-        buttonType: "horizontal",
-        icon: "filter",
-        title: (
-          <span>
-            {jt`View this ${singularize(
-              stripId(column.display_name),
-            )}'s ${pluralize(query.table().display_name)}`}
-          </span>
-        ),
-        question: () => question.filter("=", column, value),
-      },
-    ];
+    return [getFKFilter({ question, query, column, value })];
   }
 
   const operators = getFiltersForColumn(column) || [];

--- a/frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx
@@ -5,7 +5,6 @@ import { isFK, isPK } from "metabase/lib/types";
 import { isLocalField } from "metabase/lib/query/field_ref";
 import { isDate, isNumeric } from "metabase/lib/schema_metadata";
 import { singularize, pluralize, stripId } from "metabase/lib/formatting";
-import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
 
 function getFiltersForColumn(column) {
   if (isNumeric(column) || isDate(column)) {

--- a/frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx
@@ -96,9 +96,8 @@ function getComparisonFilter({ question, name, operator, column, value }) {
 export default function QuickFilterDrill({ question, clicked }) {
   const query = question.query();
   if (
-    !(query instanceof StructuredQuery) ||
-    !clicked ||
-    !clicked.column ||
+    !question.isStructured() ||
+    !clicked?.column ||
     clicked.value === undefined
   ) {
     return [];

--- a/frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx
@@ -48,7 +48,6 @@ export default function QuickFilterDrill({ question, clicked }) {
     !(query instanceof StructuredQuery) ||
     !clicked ||
     !clicked.column ||
-    clicked.column.id == null ||
     clicked.value === undefined
   ) {
     return [];

--- a/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
@@ -169,6 +169,8 @@ export default class ChartClickActions extends Component {
       .sortBy(([key]) => (SECTIONS[key] ? SECTIONS[key].index : 99))
       .value();
 
+    const hasOnlyOneSection = sections.length === 1;
+
     return (
       <Popover
         target={clicked.element}
@@ -199,7 +201,9 @@ export default class ChartClickActions extends Component {
                     ml1:
                       SECTIONS[key].icon === "bolt" ||
                       SECTIONS[key].icon === "sum" ||
-                      SECTIONS[key].icon === "breakout",
+                      SECTIONS[key].icon === "breakout" ||
+                      (SECTIONS[key].icon === "funnel_outline" &&
+                        !hasOnlyOneSection),
                   },
                 )}
               >
@@ -215,7 +219,13 @@ export default class ChartClickActions extends Component {
                   </p>
                 )}
                 {SECTIONS[key].icon === "funnel_outline" && (
-                  <p className="mt0 text-dark text-small">
+                  <p
+                    className={cx(
+                      "text-small",
+                      hasOnlyOneSection ? "mt0" : "mt2",
+                      hasOnlyOneSection ? "text-dark" : "text-medium",
+                    )}
+                  >
                     {t`Filter by this value`}
                   </p>
                 )}

--- a/frontend/test/metabase/modes/components/drill/QuickFilterDrill.unit.spec.js
+++ b/frontend/test/metabase/modes/components/drill/QuickFilterDrill.unit.spec.js
@@ -1,36 +1,75 @@
+import Question from "metabase-lib/lib/Question";
 import QuickFilterDrill from "metabase/modes/components/drill/QuickFilterDrill";
-import { ORDERS, PEOPLE } from "__support__/sample_database_fixture";
-
-function setup({ question = ORDERS.question(), clicked } = {}) {
-  return QuickFilterDrill({ question, clicked });
-}
+import { createMockColumn } from "metabase-types/types/mocks/dataset";
+import {
+  ORDERS,
+  PEOPLE,
+  SAMPLE_DATABASE,
+} from "__support__/sample_database_fixture";
 
 const NUMBER_AND_DATE_FILTERS = ["<", ">", "=", "!="];
-
 const OTHER_FILTERS = ["=", "!="];
+
+const DEFAULT_NUMERIC_CELL_VALUE = 42;
+
+const AGGREGATED_QUERY = {
+  aggregation: [["count"]],
+  breakout: ["field", ORDERS.CREATED_AT.id, { "temporal-unit": "month" }],
+  "source-table": ORDERS.id,
+};
+
+const AGGREGATED_QUESTION = {
+  display: "table",
+  dataset_query: {
+    type: "query",
+    query: AGGREGATED_QUERY,
+    database: SAMPLE_DATABASE.id,
+  },
+};
+
+const NESTED_QUESTION_SOURCE_TABLE_ID = "card__58";
+const NESTED_QUESTION = {
+  display: "table",
+  dataset_query: {
+    type: "query",
+    query: {
+      "source-table": NESTED_QUESTION_SOURCE_TABLE_ID,
+    },
+    database: SAMPLE_DATABASE.id,
+  },
+};
+
+function setup({
+  question = ORDERS.question(),
+  column,
+  value = DEFAULT_NUMERIC_CELL_VALUE,
+} = {}) {
+  const actions = QuickFilterDrill({
+    question,
+    clicked: { column, value },
+  });
+  return {
+    actions,
+    cellValue: value,
+  };
+}
 
 describe("QuickFilterDrill", () => {
   it("should not be valid for top level actions", () => {
-    const actions = setup({ question: ORDERS.question() });
+    const actions = QuickFilterDrill({ question: ORDERS.question() });
     expect(actions).toHaveLength(0);
   });
 
   it("should not be valid for PK cells", () => {
-    const actions = setup({
-      clicked: {
-        column: ORDERS.ID.column(),
-        value: 1,
-      },
-    });
+    const { actions } = setup({ column: ORDERS.ID.column() });
     expect(actions).toHaveLength(0);
   });
 
   describe("FK cells", () => {
-    const actions = setup({
-      clicked: {
-        column: ORDERS.PRODUCT_ID.column(),
-        value: 1,
-      },
+    const FK_VALUE = 1;
+    const { actions } = setup({
+      column: ORDERS.PRODUCT_ID.column(),
+      value: FK_VALUE,
     });
 
     it("should return only 'view this records' filter", () => {
@@ -42,19 +81,14 @@ describe("QuickFilterDrill", () => {
       const card = action.question().card();
       expect(card.dataset_query.query).toEqual({
         "source-table": ORDERS.id,
-        filter: ["=", ["field", ORDERS.PRODUCT_ID.id, null], 1],
+        filter: ["=", ORDERS.PRODUCT_ID.reference(), FK_VALUE],
       });
     });
   });
 
   describe("numeric cells", () => {
-    const CELL_VALUE = 42;
-    const actions = setup({
-      clicked: {
-        column: ORDERS.TOTAL.column(),
-        value: CELL_VALUE,
-      },
-    });
+    const clickedField = ORDERS.TOTAL;
+    const { actions } = setup({ column: clickedField.column() });
 
     it("should return correct filters", () => {
       const filters = NUMBER_AND_DATE_FILTERS.map(operator => ({
@@ -69,7 +103,11 @@ describe("QuickFilterDrill", () => {
         const card = action.question().card();
         expect(card.dataset_query.query).toEqual({
           "source-table": ORDERS.id,
-          filter: [operator, ["field", ORDERS.TOTAL.id, null], CELL_VALUE],
+          filter: [
+            operator,
+            clickedField.reference(),
+            DEFAULT_NUMERIC_CELL_VALUE,
+          ],
         });
         expect(card.display).toBe("table");
       });
@@ -77,13 +115,9 @@ describe("QuickFilterDrill", () => {
   });
 
   describe("joined numeric field cell", () => {
-    const CELL_VALUE = 42;
     const joinedFieldRef = ["field", ORDERS.TOTAL.id, { "join-alias": "foo" }];
-    const actions = setup({
-      clicked: {
-        column: ORDERS.TOTAL.column({ field_ref: joinedFieldRef }),
-        value: CELL_VALUE,
-      },
+    const { actions, cellValue } = setup({
+      column: ORDERS.TOTAL.column({ field_ref: joinedFieldRef }),
     });
 
     it("should return correct filters", () => {
@@ -99,7 +133,76 @@ describe("QuickFilterDrill", () => {
         const card = action.question().card();
         expect(card.dataset_query.query).toEqual({
           "source-table": ORDERS.id,
-          filter: [operator, joinedFieldRef, CELL_VALUE],
+          filter: [operator, joinedFieldRef, cellValue],
+        });
+        expect(card.display).toBe("table");
+      });
+    });
+  });
+
+  describe("aggregated numeric cell", () => {
+    const { actions, cellValue } = setup({
+      question: new Question(AGGREGATED_QUESTION),
+      column: createMockColumn({
+        name: "count",
+        field_ref: ["aggregation", 0],
+        base_type: "type/BigInteger",
+        semantic_type: "type/Quantity",
+        source: "aggregation",
+      }),
+    });
+
+    it("should return correct filters", () => {
+      const filters = NUMBER_AND_DATE_FILTERS.map(operator => ({
+        name: operator,
+      }));
+      expect(actions).toMatchObject(filters);
+    });
+
+    actions.forEach((action, i) => {
+      const operator = NUMBER_AND_DATE_FILTERS[i];
+      it(`should correctly apply "${operator}" filter`, () => {
+        const card = action.question().card();
+        expect(card.dataset_query.query).toEqual({
+          "source-query": AGGREGATED_QUERY,
+          filter: [
+            operator,
+            ["field", "count", { "base-type": "type/BigInteger" }],
+            cellValue,
+          ],
+        });
+        expect(card.display).toBe("table");
+      });
+    });
+  });
+
+  describe("numeric field cell from a nested query", () => {
+    const fieldRef = ["field", "count", { "base-type": "type/BigInteger" }];
+    const { actions, cellValue } = setup({
+      question: new Question(NESTED_QUESTION),
+      column: createMockColumn({
+        name: "count",
+        field_ref: fieldRef,
+        base_type: "type/BigInteger",
+        semantic_type: "type/Quantity",
+        source: "aggregation",
+      }),
+    });
+
+    it("should return correct filters", () => {
+      const filters = NUMBER_AND_DATE_FILTERS.map(operator => ({
+        name: operator,
+      }));
+      expect(actions).toMatchObject(filters);
+    });
+
+    actions.forEach((action, i) => {
+      const operator = NUMBER_AND_DATE_FILTERS[i];
+      it(`should correctly apply "${operator}" filter`, () => {
+        const card = action.question().card();
+        expect(card.dataset_query.query).toEqual({
+          "source-table": NESTED_QUESTION_SOURCE_TABLE_ID,
+          filter: [operator, fieldRef, cellValue],
         });
         expect(card.display).toBe("table");
       });
@@ -108,11 +211,9 @@ describe("QuickFilterDrill", () => {
 
   describe("date-time cells", () => {
     const CELL_VALUE = new Date().toISOString();
-    const actions = setup({
-      clicked: {
-        column: ORDERS.CREATED_AT.column(),
-        value: CELL_VALUE,
-      },
+    const { actions } = setup({
+      column: ORDERS.CREATED_AT.column(),
+      value: CELL_VALUE,
     });
 
     it("should return correct filters", () => {
@@ -128,7 +229,7 @@ describe("QuickFilterDrill", () => {
         const card = action.question().card();
         expect(card.dataset_query.query).toEqual({
           "source-table": ORDERS.id,
-          filter: [operator, ["field", ORDERS.CREATED_AT.id, null], CELL_VALUE],
+          filter: [operator, ORDERS.CREATED_AT.reference(), CELL_VALUE],
         });
         expect(card.display).toBe("table");
       });
@@ -137,12 +238,10 @@ describe("QuickFilterDrill", () => {
 
   describe("string cells", () => {
     const CELL_VALUE = "Joe";
-    const actions = setup({
+    const { actions } = setup({
       question: PEOPLE.question(),
-      clicked: {
-        column: PEOPLE.NAME.column(),
-        value: CELL_VALUE,
-      },
+      column: PEOPLE.NAME.column(),
+      value: CELL_VALUE,
     });
 
     it("should return correct filters", () => {
@@ -158,7 +257,7 @@ describe("QuickFilterDrill", () => {
         const card = action.question().card();
         expect(card.dataset_query.query).toEqual({
           "source-table": PEOPLE.id,
-          filter: [operator, ["field", PEOPLE.NAME.id, null], CELL_VALUE],
+          filter: [operator, PEOPLE.NAME.reference(), CELL_VALUE],
         });
         expect(card.display).toBe("table");
       });
@@ -166,13 +265,9 @@ describe("QuickFilterDrill", () => {
   });
 
   describe("numeric cells, but not semantically numbers", () => {
-    const CELL_VALUE = 12345;
-    const actions = setup({
+    const { actions, cellValue } = setup({
       question: PEOPLE.question(),
-      clicked: {
-        column: PEOPLE.ZIP.column(),
-        value: CELL_VALUE,
-      },
+      column: PEOPLE.ZIP.column(),
     });
 
     it("should return correct filters", () => {
@@ -188,7 +283,7 @@ describe("QuickFilterDrill", () => {
         const card = action.question().card();
         expect(card.dataset_query.query).toEqual({
           "source-table": PEOPLE.id,
-          filter: [operator, ["field", PEOPLE.ZIP.id, null], CELL_VALUE],
+          filter: [operator, PEOPLE.ZIP.reference(), cellValue],
         });
         expect(card.display).toBe("table");
       });

--- a/frontend/test/metabase/modes/components/drill/QuickFilterDrill.unit.spec.js
+++ b/frontend/test/metabase/modes/components/drill/QuickFilterDrill.unit.spec.js
@@ -60,6 +60,37 @@ describe("QuickFilterDrill", () => {
     expect(actions).toHaveLength(0);
   });
 
+  it("should not be valid for native questions", () => {
+    const actions = QuickFilterDrill({
+      question: new Question({
+        dataset_query: {
+          type: "native",
+          native: {
+            query: "SELECT * FROM ORDERS",
+          },
+          database: SAMPLE_DATABASE.id,
+        },
+      }),
+      column: createMockColumn({
+        name: "TOTAL",
+        field_ref: ["field", "TOTAL", { base_type: "type/BigInteger" }],
+        base_type: "type/BigInteger",
+        source: "native",
+      }),
+    });
+    expect(actions).toHaveLength(0);
+  });
+
+  it("should not be valid when clicked column is missing", () => {
+    const { actions } = setup({ column: null });
+    expect(actions).toHaveLength(0);
+  });
+
+  it("should not be valid when clicked value is undefined", () => {
+    const { actions } = setup({ column: ORDERS.ID.column(), value: undefined });
+    expect(actions).toHaveLength(0);
+  });
+
   it("should not be valid for PK cells", () => {
     const { actions } = setup({ column: ORDERS.ID.column() });
     expect(actions).toHaveLength(0);

--- a/frontend/test/metabase/modes/components/drill/QuickFilterDrill.unit.spec.js
+++ b/frontend/test/metabase/modes/components/drill/QuickFilterDrill.unit.spec.js
@@ -1,45 +1,74 @@
-/* eslint-disable */
-
 import QuickFilterDrill from "metabase/modes/components/drill/QuickFilterDrill";
-
 import { ORDERS } from "__support__/sample_database_fixture";
+
+function setup({ question = ORDERS.question(), clicked } = {}) {
+  return QuickFilterDrill({ question, clicked });
+}
+
+const NUMBER_AND_DATE_FILTERS = ["<", ">", "=", "!="];
 
 describe("QuickFilterDrill", () => {
   it("should not be valid for top level actions", () => {
-    expect(QuickFilterDrill({ question: ORDERS.question() })).toHaveLength(0);
+    const actions = setup({ question: ORDERS.question() });
+    expect(actions).toHaveLength(0);
   });
-  it("should be valid for click on numeric cell", () => {
-    const actions = QuickFilterDrill({
-      question: ORDERS.question(),
+
+  describe("numeric cells", () => {
+    const CELL_VALUE = 42;
+    const actions = setup({
       clicked: {
         column: ORDERS.TOTAL.column(),
-        value: 42,
+        value: CELL_VALUE,
       },
     });
-    expect(actions.length).toEqual(4);
-    let newCard = actions[0].question().card();
-    expect(newCard.dataset_query.query).toEqual({
-      "source-table": ORDERS.id,
-      filter: ["<", ["field", ORDERS.TOTAL.id, null], 42],
+
+    it("should return correct filters", () => {
+      const filters = NUMBER_AND_DATE_FILTERS.map(operator => ({
+        name: operator,
+      }));
+      expect(actions).toMatchObject(filters);
     });
-    expect(newCard.display).toEqual("table");
+
+    actions.forEach((action, i) => {
+      const operator = NUMBER_AND_DATE_FILTERS[i];
+      it(`should correctly apply "${operator}" filter`, () => {
+        const card = action.question().card();
+        expect(card.dataset_query.query).toEqual({
+          "source-table": ORDERS.id,
+          filter: [operator, ["field", ORDERS.TOTAL.id, null], CELL_VALUE],
+        });
+        expect(card.display).toBe("table");
+      });
+    });
   });
-  it('should be valid for click on joined "field" numeric cell ', () => {
-    const actions = QuickFilterDrill({
-      question: ORDERS.question(),
+
+  describe("joined numeric field cell", () => {
+    const CELL_VALUE = 42;
+    const joinedFieldRef = ["field", ORDERS.TOTAL.id, { "join-alias": "foo" }];
+    const actions = setup({
       clicked: {
-        column: ORDERS.TOTAL.column({
-          field_ref: ["field", ORDERS.TOTAL.id, { "join-alias": "foo" }],
-        }),
-        value: 42,
+        column: ORDERS.TOTAL.column({ field_ref: joinedFieldRef }),
+        value: CELL_VALUE,
       },
     });
-    expect(actions.length).toEqual(4);
-    let newCard = actions[0].question().card();
-    expect(newCard.dataset_query.query).toEqual({
-      "source-table": ORDERS.id,
-      filter: ["<", ["field", ORDERS.TOTAL.id, { "join-alias": "foo" }], 42],
+
+    it("should return correct filters", () => {
+      const filters = NUMBER_AND_DATE_FILTERS.map(operator => ({
+        name: operator,
+      }));
+      expect(actions).toMatchObject(filters);
     });
-    expect(newCard.display).toEqual("table");
+
+    actions.forEach((action, i) => {
+      const operator = NUMBER_AND_DATE_FILTERS[i];
+      it(`should correctly apply "${operator}" filter`, () => {
+        const card = action.question().card();
+        expect(card.dataset_query.query).toEqual({
+          "source-table": ORDERS.id,
+          filter: [operator, joinedFieldRef, CELL_VALUE],
+        });
+        expect(card.display).toBe("table");
+      });
+    });
   });
 });

--- a/frontend/test/metabase/modes/components/drill/QuickFilterDrill.unit.spec.js
+++ b/frontend/test/metabase/modes/components/drill/QuickFilterDrill.unit.spec.js
@@ -87,7 +87,13 @@ describe("QuickFilterDrill", () => {
   });
 
   it("should not be valid when clicked value is undefined", () => {
-    const { actions } = setup({ column: ORDERS.ID.column(), value: undefined });
+    const actions = QuickFilterDrill({
+      question: ORDERS.question(),
+      clicked: {
+        column: ORDERS.TOTAL.column(),
+        value: undefined,
+      },
+    });
     expect(actions).toHaveLength(0);
   });
 

--- a/frontend/test/metabase/modes/components/drill/QuickFilterDrill.unit.spec.js
+++ b/frontend/test/metabase/modes/components/drill/QuickFilterDrill.unit.spec.js
@@ -1,5 +1,5 @@
 import QuickFilterDrill from "metabase/modes/components/drill/QuickFilterDrill";
-import { ORDERS } from "__support__/sample_database_fixture";
+import { ORDERS, PEOPLE } from "__support__/sample_database_fixture";
 
 function setup({ question = ORDERS.question(), clicked } = {}) {
   return QuickFilterDrill({ question, clicked });
@@ -7,10 +7,44 @@ function setup({ question = ORDERS.question(), clicked } = {}) {
 
 const NUMBER_AND_DATE_FILTERS = ["<", ">", "=", "!="];
 
+const OTHER_FILTERS = ["=", "!="];
+
 describe("QuickFilterDrill", () => {
   it("should not be valid for top level actions", () => {
     const actions = setup({ question: ORDERS.question() });
     expect(actions).toHaveLength(0);
+  });
+
+  it("should not be valid for PK cells", () => {
+    const actions = setup({
+      clicked: {
+        column: ORDERS.ID.column(),
+        value: 1,
+      },
+    });
+    expect(actions).toHaveLength(0);
+  });
+
+  describe("FK cells", () => {
+    const actions = setup({
+      clicked: {
+        column: ORDERS.PRODUCT_ID.column(),
+        value: 1,
+      },
+    });
+
+    it("should return only 'view this records' filter", () => {
+      expect(actions).toMatchObject([{ name: "view-fks" }]);
+    });
+
+    it("should apply 'view this records' filter correctly", () => {
+      const [action] = actions;
+      const card = action.question().card();
+      expect(card.dataset_query.query).toEqual({
+        "source-table": ORDERS.id,
+        filter: ["=", ["field", ORDERS.PRODUCT_ID.id, null], 1],
+      });
+    });
   });
 
   describe("numeric cells", () => {
@@ -66,6 +100,95 @@ describe("QuickFilterDrill", () => {
         expect(card.dataset_query.query).toEqual({
           "source-table": ORDERS.id,
           filter: [operator, joinedFieldRef, CELL_VALUE],
+        });
+        expect(card.display).toBe("table");
+      });
+    });
+  });
+
+  describe("date-time cells", () => {
+    const CELL_VALUE = new Date().toISOString();
+    const actions = setup({
+      clicked: {
+        column: ORDERS.CREATED_AT.column(),
+        value: CELL_VALUE,
+      },
+    });
+
+    it("should return correct filters", () => {
+      const filters = NUMBER_AND_DATE_FILTERS.map(operator => ({
+        name: operator,
+      }));
+      expect(actions).toMatchObject(filters);
+    });
+
+    actions.forEach((action, i) => {
+      const operator = NUMBER_AND_DATE_FILTERS[i];
+      it(`should correctly apply "${operator}" filter`, () => {
+        const card = action.question().card();
+        expect(card.dataset_query.query).toEqual({
+          "source-table": ORDERS.id,
+          filter: [operator, ["field", ORDERS.CREATED_AT.id, null], CELL_VALUE],
+        });
+        expect(card.display).toBe("table");
+      });
+    });
+  });
+
+  describe("string cells", () => {
+    const CELL_VALUE = "Joe";
+    const actions = setup({
+      question: PEOPLE.question(),
+      clicked: {
+        column: PEOPLE.NAME.column(),
+        value: CELL_VALUE,
+      },
+    });
+
+    it("should return correct filters", () => {
+      const filters = OTHER_FILTERS.map(operator => ({
+        name: operator,
+      }));
+      expect(actions).toMatchObject(filters);
+    });
+
+    actions.forEach((action, i) => {
+      const operator = OTHER_FILTERS[i];
+      it(`should correctly apply "${operator}" filter`, () => {
+        const card = action.question().card();
+        expect(card.dataset_query.query).toEqual({
+          "source-table": PEOPLE.id,
+          filter: [operator, ["field", PEOPLE.NAME.id, null], CELL_VALUE],
+        });
+        expect(card.display).toBe("table");
+      });
+    });
+  });
+
+  describe("numeric cells, but not semantically numbers", () => {
+    const CELL_VALUE = 12345;
+    const actions = setup({
+      question: PEOPLE.question(),
+      clicked: {
+        column: PEOPLE.ZIP.column(),
+        value: CELL_VALUE,
+      },
+    });
+
+    it("should return correct filters", () => {
+      const filters = OTHER_FILTERS.map(operator => ({
+        name: operator,
+      }));
+      expect(actions).toMatchObject(filters);
+    });
+
+    actions.forEach((action, i) => {
+      const operator = OTHER_FILTERS[i];
+      it(`should correctly apply "${operator}" filter`, () => {
+        const card = action.question().card();
+        expect(card.dataset_query.query).toEqual({
+          "source-table": PEOPLE.id,
+          filter: [operator, ["field", PEOPLE.ZIP.id, null], CELL_VALUE],
         });
         expect(card.display).toBe("table");
       });


### PR DESCRIPTION
This PR makes it possible to apply `QuickFilterDrill` (`>`, `<`, `=`, `!=`) on aggregated, custom columns and native question results while exploring the results.

This PR also contains some refactoring for the drill code, but the most valuable diff is pretty small:
1. Removed [this line](https://github.com/metabase/metabase/blob/5918c954aa7fa3b4c1c60a427022b15f2c656377/frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx#L35) that wasn't allowed to apply the drills on fields without ID (aggregated and custom columns, also field literals from nested queries)
2. Simplified [this condition](https://github.com/metabase/metabase/blob/5918c954aa7fa3b4c1c60a427022b15f2c656377/frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx#L9) that was determining which comparison filters should be allowed depending on the field type. Actually just did what [this TODO](https://github.com/metabase/metabase/blob/5918c954aa7fa3b4c1c60a427022b15f2c656377/frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx#L12) was asking for.
3. Added logic specific to aggregated and custom columns [here](https://github.com/metabase/metabase/blob/9164bd8cbbf0b8e1491c0d7233907b0ae57d5857/frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx#L79). I left a comment there that should explain what's exactly happening there. Let me know if it's actually helpful/meaningful.

**Fix for drill popover UI**

The quick filters actions used to show up only on their own, but now they can also appear together with other actions, so had to slightly fix the UI for click actions popover.

<details>
<summary>Screenshots</summary>

**Without the UI fix**

<img width="274" alt="CleanShot 2022-01-28 at 20 11 08@2x" src="https://user-images.githubusercontent.com/17258145/151778038-db5c2776-4992-449e-83a2-72cddd641c11.png">

**After the UI fix**

<img width="268" alt="CleanShot 2022-01-31 at 11 29 05@2x" src="https://user-images.githubusercontent.com/17258145/151778073-f36bd730-a7f5-4f88-a008-3f847b9e20c4.png">

The state when quick filters shown up on their own looks the same as before

<img width="251" alt="CleanShot 2022-01-31 at 11 29 20@2x" src="https://user-images.githubusercontent.com/17258145/151778125-98856eb5-34c3-4c86-b8a1-566a96b2230a.png">


</details>

### To Verify

1. Ask a question > Sample Dataset > Orders
2. Summarize Count by Created At
3. Add a custom column (example: `[ID] * 2`, so you can get different numbers for each row and check that filters work as expected)
3. Click "Visualize" and switch to table visualization (don't save the question!)
4. Click on "Count" cells, you should see `>`, `<`, `=`, `!=` in a drill-through popover now. Play around with them and make sure the results make sense
5. Ask a question > SQL > `SELECT * FROM ORDERS`
6. Click "Explore results"
7. Repeat step 4

### Demo

<details>
<summary>Aggregated field</summary>

**Before**

https://user-images.githubusercontent.com/17258145/151602439-1916d830-86f1-4095-8809-66c4ecfb8359.mp4

**After**

https://user-images.githubusercontent.com/17258145/151602458-e7a1c9c9-5a0f-4926-a56e-6dd2b7f85b4a.mp4

</details>

<details>
<summary>Exploring native query results</summary>

**Before**

https://user-images.githubusercontent.com/17258145/151602488-32c86014-cfec-43eb-bc78-012015f99ec0.mp4

**After**

https://user-images.githubusercontent.com/17258145/151602500-4a502184-86bf-489b-a479-cd32f8f4f064.mp4


</details>