### PR TITLE
Fix language selection in setup (for 0.42)

### DIFF
--- a/frontend/src/metabase/setup/components/SettingsPage/SettingsPage.tsx
+++ b/frontend/src/metabase/setup/components/SettingsPage/SettingsPage.tsx
@@ -14,7 +14,11 @@ export interface SettingsPageProps {
   onStepShow: (step: number) => void;
 }
 
-const SettingsPage = ({ step, onStepShow }: SettingsPageProps): JSX.Element => {
+const SettingsPage = ({
+  step,
+  onStepShow,
+  ...props
+}: SettingsPageProps): JSX.Element => {
   useEffect(() => {
     onStepShow(step);
   }, [step, onStepShow]);
@@ -25,13 +29,13 @@ const SettingsPage = ({ step, onStepShow }: SettingsPageProps): JSX.Element => {
         <LogoIcon height={51} />
       </PageHeader>
       <PageBody>
-        <LanguageStep />
-        <UserStep />
-        <DatabaseStep />
-        <DatabaseHelp />
-        <PreferencesStep />
-        <CompletedStep />
-        <SetupHelp />
+        <LanguageStep {...props} />
+        <UserStep {...props} />
+        <DatabaseStep {...props} />
+        <DatabaseHelp {...props} />
+        <PreferencesStep {...props} />
+        <CompletedStep {...props} />
+        <SetupHelp {...props} />
       </PageBody>
     </div>
   );

--- a/frontend/src/metabase/setup/components/Setup/Setup.tsx
+++ b/frontend/src/metabase/setup/components/Setup/Setup.tsx
@@ -6,11 +6,11 @@ export interface SetupProps {
   isWelcome: boolean;
 }
 
-const Setup = ({ isWelcome }: SetupProps): JSX.Element => {
+const Setup = ({ isWelcome, ...props }: SetupProps): JSX.Element => {
   if (isWelcome) {
-    return <WelcomePage />;
+    return <WelcomePage {...props} />;
   } else {
-    return <SettingsPage />;
+    return <SettingsPage {...props} />;
   }
 };
 


### PR DESCRIPTION
The root cause is that: 
1. locale is loaded asynchronously, when it's been loaded `forceUpdate` is called https://github.com/metabase/metabase/blob/b12e72607baa807ab3790923c94e0ca193672e8b/frontend/src/metabase/app.js#L100
2. `connect` is `pure` by default

How to test:
- Run a fresh instance
- During setup, on the language selection step, try switching languages
- Whole UI should be updated with this language instantly