### PR TITLE
add standard cookie policy to test http client

### DIFF
--- a/test/metabase/http_client.clj
+++ b/test/metabase/http_client.clj
@@ -127,6 +127,7 @@
                      (if (map? credentials)
                        (authenticate credentials)
                        credentials))}
+    :cookie-policy :standard
     :content-type :json}
    (when (seq http-body)
      {:body (json/generate-string http-body)})))

--- a/test/metabase/server/middleware/browser_cookie_test.clj
+++ b/test/metabase/server/middleware/browser_cookie_test.clj
@@ -27,7 +27,7 @@
 
 (deftest no-existing-cookie
   (testing "set DEVICE cookie with SameSite=Lax if served over HTTP"
-    (let [request    (-> (mock/request :get "http://localhost/foo"))
+    (let [request    (mock/request :get "http://localhost/foo")
           response   (handler request)
           browser-id (:body response)]
       (is (some? (UUID/fromString browser-id)))
@@ -38,7 +38,7 @@
              (-> (get-in response [:cookies browser-id-cookie-name])
                  (dissoc :expires))))))
   (testing "set DEVICE cookie with SameSite=None if served over HTTPS"
-    (let [request    (-> (mock/request :get "https://localhost/foo"))
+    (let [request    (mock/request :get "https://localhost/foo")
           response   (handler request)
           browser-id (:body response)]
       (is (some? (UUID/fromString browser-id)))


### PR DESCRIPTION
This addresses issue #12934

I was able to reproduce the warning logs, and noticed the 'expires' cookie set to "Thu, 1 Jan 1970 00:00:00 GMT" (which we set when clearing cookies) , or 20 years in the future (as we [set here](https://github.com/metabase/metabase/blob/master/src/metabase/server/middleware/browser_cookie.clj#L25)).

This logging occurs in our http _client_, clj-http, since the log is coming from [ResponseProcessCookies](https://www.javadoc.io/doc/org.apache.httpcomponents/httpclient/4.3.2/org/apache/http/client/protocol/ResponseProcessCookies.html) which is wrapped by `clj-http`.

Found [this issue on clj-http](https://github.com/dakrone/clj-http/issues/325) which addresses the issue directly, so that is what I implemented.

Running `metabase.api.session-test/login-test` prints one of these errors:

    2022-01-28 16:13:38,155 DEBUG middleware.log :: POST /api/session 200 102.5 ms (7 DB calls) App DB connections: 0/4 Jetty threads: 5/50 (2 idle, 0 queued) (44 total active threads) Queries in flight: 0 (0 queued)
    2022-01-28 16:13:38,162 WARN protocol.ResponseProcessCookies :: Invalid cookie header: "Set-Cookie: metabase.DEVICE=4580373d-bbf6-4d44-bc73-860784222b8c;HttpOnly;Path=/;Expires=Tue, 28 Jan 2042 16:13:38 GMT;SameSite=Lax". Invalid 'expires' attribute: Tue, 28 Jan 2042 16:13:38 GMT
    2022-01-28 16:13:38,233 WARN metabase.email :: Failed to send email

after the fix to the test http client, the log looks like this:

    2022-01-28 16:15:13,458 DEBUG middleware.log :: POST /api/session 200 102.7 ms (7 DB calls) App DB connections: 0/4 Jetty threads: 5/50 (2 idle, 0 queued) (46 total active threads) Queries in flight: 0 (0 queued)
    2022-01-28 16:15:13,515 WARN metabase.email :: Failed to send email
