### PR TITLE
Clone of Fix empty result with suffix "%" shows "null%" in Gauge visualization  

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/Gauge.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Gauge.jsx
@@ -111,7 +111,7 @@ export default class Gauge extends Component {
       getDefault(series) {
         let value = 100;
         try {
-          value = series[0].data.rows[0][0];
+          value = series[0].data.rows[0][0] || 0;
         } catch (e) {}
         return [
           { min: 0, max: value / 2, color: color("error"), label: "" },
@@ -203,7 +203,7 @@ export default class Gauge extends Component {
       ])
       .clamp(true);
 
-    const value = rows[0][0];
+    const value = rows[0][0] || 0;
     const column = cols[0];
 
     const valuePosition = (value, distance) => {

--- a/test/metabase/query_processor/streaming/xlsx_test.clj
+++ b/test/metabase/query_processor/streaming/xlsx_test.clj
@@ -489,12 +489,12 @@
 (deftest poi-tempfiles-test
   (testing "POI temporary files are cleaned up if output stream is closed before export completes (#19480)"
     (let [poifiles-directory      (io/file (str (System/getProperty "java.io.tmpdir") "/poifiles"))
-          expected-poifiles-count (count (file-seq poifiles-directory))]
-      (let [bos                (ByteArrayOutputStream.)
-            os                 (BufferedOutputStream. bos)
-            results-writer     (i/streaming-results-writer :xlsx os)]
-        (.close os)
-        (i/begin! results-writer {:data {:ordered-cols []}} {})
-        (i/finish! results-writer {:row_count 0})
-        ;; No additional files should exist in the temp directory
-        (is (= expected-poifiles-count (count (file-seq poifiles-directory))))))))
+          expected-poifiles-count (count (file-seq poifiles-directory))
+          bos                (ByteArrayOutputStream.)
+          os                 (BufferedOutputStream. bos)
+          results-writer     (i/streaming-results-writer :xlsx os)]
+      (.close os)
+      (i/begin! results-writer {:data {:ordered-cols []}} {})
+      (i/finish! results-writer {:row_count 0})
+      ;; No additional files should exist in the temp directory
+      (is (= expected-poifiles-count (count (file-seq poifiles-directory)))))))


### PR DESCRIPTION
Running a full test suite for https://github.com/metabase/metabase/pull/19558, from an external contributor.