### PR TITLE
increase font weight on selected AM/PM in filter

### DIFF
--- a/frontend/src/metabase/query_builder/components/filters/pickers/HoursMinutesInput.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/HoursMinutesInput.jsx
@@ -48,7 +48,7 @@ const HoursMinutesInput = ({
       <div className="flex align-center pl1">
         <span
           className={cx("text-purple-hover mr1", {
-            "text-purple": hours < 12,
+            "text-purple text-heavy": hours < 12,
             "cursor-pointer": hours >= 12,
           })}
           onClick={hours >= 12 ? () => onChangeHours(hours - 12) : null}
@@ -57,7 +57,7 @@ const HoursMinutesInput = ({
         </span>
         <span
           className={cx("text-purple-hover mr1", {
-            "text-purple": hours >= 12,
+            "text-purple text-heavy": hours >= 12,
             "cursor-pointer": hours < 12,
           })}
           onClick={hours < 12 ? () => onChangeHours(hours + 12) : null}


### PR DESCRIPTION
Resolves #20010 

A font weight of 700 still felt too subtle to me, so I bumped it up to 900 when the option is selected. The widget as a whole is incredibly inaccessible, still -- see that these buttons are spans. We are addressing these sorts of accessibility problems in a separate project entirely, so I won't look at them here (it'll be a lot more work to make the entire calendar widget accessible unfortunately). See https://www.notion.so/metabase/Support-keyboard-navigation-in-filter-widgets-44779113bbaa4e2e95f92a2172784513

<img width="407" alt="Screen Shot 2022-01-28 at 1 37 26 PM" src="https://user-images.githubusercontent.com/13057258/151617870-2f449691-bc7e-4343-9e83-a89fd899b255.png">

