### PR TITLE
Fix database created at check

### DIFF
--- a/frontend/src/metabase-types/api/database.ts
+++ b/frontend/src/metabase-types/api/database.ts
@@ -7,5 +7,6 @@ export interface Database {
   is_sample: boolean;
   creator_id?: number;
   created_at: string;
+  timezone?: string;
   initial_sync_status: InitialSyncStatus;
 }

--- a/frontend/src/metabase-types/api/mocks/database.ts
+++ b/frontend/src/metabase-types/api/mocks/database.ts
@@ -7,6 +7,7 @@ export const createMockDatabase = (opts?: Partial<Database>): Database => ({
   is_sample: false,
   creator_id: undefined,
   created_at: "2015-01-01T20:10:30.200",
+  timezone: "UTC",
   initial_sync_status: "complete",
   ...opts,
 });

--- a/frontend/src/metabase/home/homepage/components/SyncingSection/SyncingSection.tsx
+++ b/frontend/src/metabase/home/homepage/components/SyncingSection/SyncingSection.tsx
@@ -4,7 +4,7 @@ import React, {
   useLayoutEffect,
   useState,
 } from "react";
-import moment, { Moment } from "moment";
+import moment, { Moment } from "moment-timezone";
 import { isSyncInProgress } from "metabase/lib/syncing";
 import Modal from "metabase/components/Modal";
 import SyncingModal from "metabase/containers/SyncingModal";
@@ -83,8 +83,8 @@ const getSyncingDatabase = (
 };
 
 const isSyncingForLongTime = (database: Database, now: Moment): boolean => {
-  if (isSyncInProgress(database)) {
-    const createdAt = moment.utc(database.created_at);
+  if (isSyncInProgress(database) && database.timezone) {
+    const createdAt = moment.tz(database.created_at, database.timezone);
     return now.diff(createdAt, "ms") > SYNC_TIMEOUT;
   } else {
     return false;

--- a/package.json
+++ b/package.json
@@ -156,6 +156,7 @@
     "@types/lodash.memoize": "^4.1.6",
     "@types/mini-css-extract-plugin": "^2.4.0",
     "@types/mockdate": "^3.0.0",
+    "@types/moment-timezone": "^0.5.26",
     "@types/mustache": "^4.1.2",
     "@types/postcss-import": "^12.0.1",
     "@types/postcss-url": "^8.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4839,6 +4839,13 @@
   dependencies:
     mockdate "*"
 
+"@types/moment-timezone@^0.5.26":
+  version "0.5.30"
+  resolved "https://registry.yarnpkg.com/@types/moment-timezone/-/moment-timezone-0.5.30.tgz#340ed45fe3e715f4a011f5cfceb7cb52aad46fc7"
+  integrity sha512-aDVfCsjYnAQaV/E9Qc24C5Njx1CoDjXsEgkxtp9NyXDpYu4CCbmclb6QhWloS9UTU/8YROUEEdEkWI0D7DxnKg==
+  dependencies:
+    moment-timezone "*"
+
 "@types/mustache@^4.1.2":
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/@types/mustache/-/mustache-4.1.2.tgz#d0e158013c81674a5b6d8780bc3fe234e1804eaf"
@@ -15415,6 +15422,13 @@ module-deps-sortable@^5.0.3:
     subarg "^1.0.0"
     through2 "^2.0.0"
     xtend "^4.0.0"
+
+moment-timezone@*:
+  version "0.5.34"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.34.tgz#a75938f7476b88f155d3504a9343f7519d9a405c"
+  integrity sha512-3zAEHh2hKUs3EXLESx/wsgw6IQdusOT8Bxm3D9UrHPQR7zlMmzwybC8zHEM1tQ4LJwP7fcxrWr8tuBg05fFCbg==
+  dependencies:
+    moment ">= 2.9.0"
 
 moment-timezone@^0.5.26:
   version "0.5.31"


### PR DESCRIPTION
Fixes the check used in https://github.com/metabase/metabase/pull/19925

The problem is that there are databases with `created_at` not in UTC, that's why it's important to check for `timezone` explicitly. If there is no `timezone`, `created_at` is useless.