### PR TITLE
CI: setup-node@v2 also does yarn caching

### DIFF
--- a/.github/workflows/cljs.yml
+++ b/.github/workflows/cljs.yml
@@ -19,9 +19,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Prepare Node.js
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: 14.x
+        cache: 'yarn'
     - name: Get M2 cache
       uses: actions/cache@v2
       with:
@@ -29,11 +30,6 @@ jobs:
           ~/.m2
           ~/.gitlibs
         key: ${{ runner.os }}-cljs-${{ hashFiles('**/deps.edn') }}
-    - name: Get yarn cache
-      uses: actions/cache@v2
-      with:
-        path: ~/.cache/yarn
-        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
     - name: Get node_modules cache
       uses: actions/cache@v2
       with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,14 +20,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Prepare Node.js
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: 14.x
-    - name: Get yarn cache
-      uses: actions/cache@v2
-      with:
-        path: ~/.cache/yarn
-        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        cache: 'yarn'
     - name: Get node_modules cache
       uses: actions/cache@v2
       with:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -22,14 +22,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Prepare Node.js
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: 14.x
-    - name: Get yarn cache
-      uses: actions/cache@v2
-      with:
-        path: ~/.cache/yarn
-        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        cache: 'yarn'
     - name: Get node_modules cache
       uses: actions/cache@v2
       with:
@@ -45,19 +41,15 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Prepare Node.js
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: 14.x
+        cache: 'yarn'
     - name: Get M2 cache
       uses: actions/cache@v2
       with:
         path: ~/.m2
         key: ${{ runner.os }}-cljs-${{ hashFiles('**/shadow-cljs.edn') }}
-    - name: Get yarn cache
-      uses: actions/cache@v2
-      with:
-        path: ~/.cache/yarn
-        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
     - name: Get node_modules cache
       uses: actions/cache@v2
       with:
@@ -73,14 +65,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Prepare Node.js
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: 14.x
-    - name: Get yarn cache
-      uses: actions/cache@v2
-      with:
-        path: ~/.cache/yarn
-        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        cache: 'yarn'
     - name: Get node_modules cache
       uses: actions/cache@v2
       with:
@@ -96,19 +84,15 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Prepare Node.js
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: 14.x
+        cache: 'yarn'
     - name: Get M2 cache
       uses: actions/cache@v2
       with:
         path: ~/.m2
         key: ${{ runner.os }}-cljs-${{ hashFiles('**/shadow-cljs.edn') }}
-    - name: Get yarn cache
-      uses: actions/cache@v2
-      with:
-        path: ~/.cache/yarn
-        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
     - name: Get node_modules cache
       uses: actions/cache@v2
       with:
@@ -129,19 +113,15 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Prepare Node.js
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: 14.x
+        cache: 'yarn'
     - name: Get M2 cache
       uses: actions/cache@v2
       with:
         path: ~/.m2
         key: ${{ runner.os }}-cljs-${{ hashFiles('**/shadow-cljs.edn') }}
-    - name: Get yarn cache
-      uses: actions/cache@v2
-      with:
-        path: ~/.cache/yarn
-        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
     - name: Get node_modules cache
       uses: actions/cache@v2
       with:
@@ -159,14 +139,10 @@ jobs:
         with:
           fetch-depth: 0
       - name: Prepare Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 14.x
-      - name: Get yarn cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/yarn
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          cache: 'yarn'
       - name: Get node_modules cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -24,19 +24,15 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Prepare Node.js
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: 14.x
+        cache: 'yarn'
     - name: Get M2 cache
       uses: actions/cache@v2
       with:
         path: ~/.m2
         key: ${{ runner.os }}-cljs-${{ hashFiles('**/shadow-cljs.edn') }}
-    - name: Get yarn cache
-      uses: actions/cache@v2
-      with:
-        path: ~/.cache/yarn
-        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
     - name: Get node_modules cache
       uses: actions/cache@v2
       with:
@@ -54,19 +50,15 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Prepare Node.js
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: 14.x
+        cache: 'yarn'
     - name: Get M2 cache
       uses: actions/cache@v2
       with:
         path: ~/.m2
         key: ${{ runner.os }}-cljs-${{ hashFiles('**/shadow-cljs.edn') }}
-    - name: Get yarn cache
-      uses: actions/cache@v2
-      with:
-        path: ~/.cache/yarn
-        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
     - name: Get node_modules cache
       uses: actions/cache@v2
       with:

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -22,14 +22,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Prepare Node.js
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: 14.x
-    - name: Get yarn cache
-      uses: actions/cache@v2
-      with:
-        path: ~/.cache/yarn
-        key: ${{ runner.os }}-i18n-${{ hashFiles('**/yarn.lock') }}
+        cache: 'yarn'
     - name: Get node_modules cache
       uses: actions/cache@v2
       with:

--- a/.github/workflows/percy-issue-comment.yml
+++ b/.github/workflows/percy-issue-comment.yml
@@ -45,9 +45,10 @@ jobs:
           ref: ${{ needs.pr_info.outputs.branch_name }}
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Prepare Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 14.x
+          cache: 'yarn'
       - name: Prepare JDK 8
         uses: actions/setup-java@v2
         with:
@@ -63,11 +64,6 @@ jobs:
           echo "yarn `yarn --version`"
           java -version
 
-      - name: Get yarn cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/yarn
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
       - name: Get node_modules cache
         uses: actions/cache@v2
         with:
@@ -109,9 +105,10 @@ jobs:
           ref: ${{ needs.pr_info.outputs.branch_name }}
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Prepare Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 14.x
+          cache: 'yarn'
       - name: Prepare JDK 8
         uses: actions/setup-java@v2
         with:
@@ -126,11 +123,6 @@ jobs:
           echo "Node.js `node --version`"
           echo "yarn `yarn --version`"
           java -version
-      - name: Get yarn cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/yarn
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile --prefer-offline
       - uses: actions/download-artifact@v2
         name: Retrieve uberjar artifact

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -26,9 +26,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Prepare Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 14.x
+          cache: 'yarn'
       - name: Prepare JDK 8
         uses: actions/setup-java@v2
         with:
@@ -44,11 +45,6 @@ jobs:
           echo "yarn `yarn --version`"
           java -version
 
-      - name: Get yarn cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/yarn
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
       - name: Get node_modules cache
         uses: actions/cache@v2
         with:
@@ -83,9 +79,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Prepare Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 14.x
+          cache: 'yarn'
       - name: Prepare JDK 8
         uses: actions/setup-java@v2
         with:
@@ -100,11 +97,6 @@ jobs:
           echo "Node.js `node --version`"
           echo "yarn `yarn --version`"
           java -version
-      - name: Get yarn cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/yarn
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
       - name: Get node_modules cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -23,9 +23,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Prepare Node.js
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: 14.x
+        cache: 'yarn'
     - name: Prepare JDK 8
       uses: actions/setup-java@v2
       with:
@@ -41,11 +42,6 @@ jobs:
         echo "yarn `yarn --version`"
         java -version
 
-    - name: Get yarn cache
-      uses: actions/cache@v2
-      with:
-        path: ~/.cache/yarn
-        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
     - name: Get node_modules cache
       uses: actions/cache@v2
       with:

--- a/.github/workflows/yaml.yml
+++ b/.github/workflows/yaml.yml
@@ -18,14 +18,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Prepare Node.js
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: 14.x
-    - name: Get yarn cache
-      uses: actions/cache@v2
-      with:
-        path: ~/.cache/yarn
-        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        cache: 'yarn'
     - name: Get node_modules cache
       uses: actions/cache@v2
       with:


### PR DESCRIPTION
https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies

Instead of two separate steps, `setup-node` and `cache`, let's just have them combined by bumping `setup-node` to v2.

**Before this PR**

![image](https://user-images.githubusercontent.com/7288/151629634-d9fb5c18-adc8-4f9d-b012-71beeea08733.png)


**After this PR**

![image](https://user-images.githubusercontent.com/7288/151629583-46a70757-6b65-4cb9-b8eb-76b937fb26a5.png)
