### PR TITLE
Fix focus color

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/lib/whitelabel.js
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/lib/whitelabel.js
@@ -138,9 +138,14 @@ function initColorJS(colorName) {
   if (JS_COLOR_UPDATORS_BY_COLOR_NAME[colorName]) {
     return;
   }
+
+  const colorMappings = getColorMappings(colorName);
+
   JS_COLOR_UPDATORS_BY_COLOR_NAME[colorName] = [];
   JS_COLOR_UPDATORS_BY_COLOR_NAME[colorName].push(themeColor => {
-    colors[colorName] = themeColor;
+    for (const [newColorName, colorMapping] of Object.entries(colorMappings)) {
+      colors[newColorName] = colorMapping(themeColor);
+    }
   });
 }
 

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/lib/whitelabel.js
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/lib/whitelabel.js
@@ -2,7 +2,7 @@ import MetabaseSettings from "metabase/lib/settings";
 
 import Color from "color";
 
-import colors, { syncColors } from "metabase/lib/colors";
+import colors, { getColorMappings, syncColors } from "metabase/lib/colors";
 import { addCSSRule } from "metabase/lib/dom";
 
 import memoize from "lodash.memoize";
@@ -61,7 +61,7 @@ function walkStyleSheets(sheets, fn) {
 const replaceColors = (cssValue, matchColor, replacementColor) => {
   return cssValue.replace(COLOR_REGEX, colorString => {
     const color = Color(colorString);
-    if (color.hex() === matchColor.hex()) {
+    if (color.hex() === Color(matchColor).hex()) {
       if (color.alpha() < 1) {
         return Color(replacementColor)
           .alpha(color.alpha())
@@ -99,7 +99,7 @@ function initColorCSS(colorName) {
     initCSSBrandHueUpdator();
   }
 
-  const originalColor = Color(originalColors[colorName]);
+  const colorMappings = getColorMappings(colorName);
   // look for CSS rules which have colors matching the brand colors or very light or desaturated
   for (const {
     style,
@@ -107,12 +107,16 @@ function initColorCSS(colorName) {
     cssValue,
     cssPriority,
   } of getColorStyleProperties()) {
-    // try replacing with a random color to see if we actually need to
-    if (cssValue !== replaceColors(cssValue, originalColor, RANDOM_COLOR)) {
-      CSS_COLOR_UPDATORS_BY_COLOR_NAME[colorName].push(themeColor => {
-        const newCssValue = replaceColors(cssValue, originalColor, themeColor);
-        style.setProperty(cssProperty, newCssValue, cssPriority);
-      });
+    for (const [newColorName, colorMapping] of Object.entries(colorMappings)) {
+      const originalColor = originalColors[newColorName];
+      // try replacing with a random color to see if we actually need to
+      if (cssValue !== replaceColors(cssValue, originalColor, RANDOM_COLOR)) {
+        CSS_COLOR_UPDATORS_BY_COLOR_NAME[colorName].push(themeColor => {
+          const newColor = colorMapping(themeColor);
+          const newCssValue = replaceColors(cssValue, originalColor, newColor);
+          style.setProperty(cssProperty, newCssValue, cssPriority);
+        });
+      }
     }
   }
 }

--- a/frontend/src/metabase/admin/databases/components/widgets/EngineWidget/EngineWidget.styled.tsx
+++ b/frontend/src/metabase/admin/databases/components/widgets/EngineWidget/EngineWidget.styled.tsx
@@ -103,7 +103,7 @@ export const EngineButtonRoot = styled.button`
   }
 
   &:focus {
-    outline: 2px solid ${color("brand-light")};
+    outline: 2px solid ${color("focus")};
   }
 
   &:focus:not(:focus-visible) {

--- a/frontend/src/metabase/admin/databases/components/widgets/EngineWidget/EngineWidget.styled.tsx
+++ b/frontend/src/metabase/admin/databases/components/widgets/EngineWidget/EngineWidget.styled.tsx
@@ -35,8 +35,7 @@ export const EngineCardRoot = styled.li<EngineCardRootProps>`
   border-radius: 0.375rem;
   background-color: ${color("white")};
   cursor: pointer;
-  outline: ${props =>
-    props.isActive ? `2px solid ${color("brand-light")}` : ""};
+  outline: ${props => (props.isActive ? `2px solid ${color("focus")}` : "")};
 
   &:hover {
     border-color: ${color("brand")};

--- a/frontend/src/metabase/core/components/CheckBox/CheckBox.styled.tsx
+++ b/frontend/src/metabase/core/components/CheckBox/CheckBox.styled.tsx
@@ -37,7 +37,7 @@ export const CheckBoxContainer = styled.span<CheckBoxContainerProps>`
   opacity: ${props => (props.disabled ? "0.4" : "")};
 
   ${CheckBoxInput}:focus + & {
-    outline: 2px solid ${color("brand-light")};
+    outline: 2px solid ${color("focus")};
   }
 
   ${CheckBoxInput}:focus:not(:focus-visible) + & {

--- a/frontend/src/metabase/core/components/Radio/Radio.styled.tsx
+++ b/frontend/src/metabase/core/components/Radio/Radio.styled.tsx
@@ -71,7 +71,7 @@ export const RadioContainer = styled.div<RadioContainerProps>`
   }
 
   ${RadioInput}:focus + & {
-    outline: 2px solid ${color("brand-light")};
+    outline: 2px solid ${color("focus")};
   }
 
   ${RadioInput}:focus:not(:focus-visible) + & {

--- a/frontend/src/metabase/core/components/SelectButton/SelectButton.styled.tsx
+++ b/frontend/src/metabase/core/components/SelectButton/SelectButton.styled.tsx
@@ -24,7 +24,7 @@ export const SelectButtonRoot = styled.button<SelectButtonRootProps>`
 
   &:focus {
     border-color: ${color("brand")};
-    outline: 2px solid ${color("brand-light")};
+    outline: 2px solid ${color("focus")};
   }
 
   &:not(:focus-visible) {

--- a/frontend/src/metabase/core/components/Toggle/Toggle.styled.tsx
+++ b/frontend/src/metabase/core/components/Toggle/Toggle.styled.tsx
@@ -56,7 +56,7 @@ export const ToggleRoot = styled.input<ToggleRootProps>`
   }
 
   &:focus {
-    outline: 2px solid ${color("brand-light")};
+    outline: 2px solid ${color("focus")};
   }
 
   &:focus:not(:focus-visible) {

--- a/frontend/src/metabase/css/components/buttons.css
+++ b/frontend/src/metabase/css/components/buttons.css
@@ -26,7 +26,7 @@
 }
 
 .Button:focus {
-  outline: 2px solid var(--color-brand-light);
+  outline: 2px solid var(--color-focus);
 }
 
 .Button:focus:not(:focus-visible) {

--- a/frontend/src/metabase/css/core/colors.css
+++ b/frontend/src/metabase/css/core/colors.css
@@ -28,6 +28,7 @@
   --color-bg-light: #f9fbfc;
   --color-bg-white: #ffffff;
   --color-bg-yellow: #fffcf2;
+  --color-focus: #cbe2f7;
   --color-shadow: rgba(0, 0, 0, 0.13);
   --color-border: #f0f0f0;
   --color-outline: #cbe7ff;

--- a/frontend/src/metabase/lib/colors.ts
+++ b/frontend/src/metabase/lib/colors.ts
@@ -33,6 +33,7 @@ const colors: Record<string, string> = {
   "bg-light": "#F9FBFC",
   "bg-white": "#FFFFFF",
   "bg-yellow": "#FFFCF2",
+  focus: "#CBE2F7",
   shadow: "rgba(0,0,0,0.08)",
   border: "#F0F0F0",
   outline: "#CBE7FF",

--- a/frontend/src/metabase/lib/colors.ts
+++ b/frontend/src/metabase/lib/colors.ts
@@ -199,8 +199,8 @@ export type ColorMapping = (color: string) => string;
 const COLOR_MAPPINGS: Record<ColorName, Record<ColorName, ColorMapping>> = {
   brand: {
     brand: color => color,
-    focus: color => lighten(color, 0.7),
     "brand-light": color => lighten(color, 0.532),
+    focus: color => lighten(color, 0.7),
   },
 };
 export const getColorMappings = (

--- a/frontend/src/metabase/lib/colors.ts
+++ b/frontend/src/metabase/lib/colors.ts
@@ -194,6 +194,24 @@ export function lighten(
     .lighten(f)
     .string();
 }
+
+export type ColorMapping = (color: string) => string;
+const COLOR_MAPPINGS: Record<ColorName, Record<ColorName, ColorMapping>> = {
+  brand: {
+    brand: (color: string) => color,
+    focus: (color: string) => lighten(color, 0.7),
+  },
+};
+export const getColorMappings = (
+  colorName: ColorName,
+): Record<ColorName, ColorMapping> => {
+  if (colorName in COLOR_MAPPINGS) {
+    return COLOR_MAPPINGS[colorName];
+  } else {
+    return { [colorName]: color => color };
+  }
+};
+
 const PREFERRED_COLORS: Record<string, string[]> = {
   success: [
     "success",

--- a/frontend/src/metabase/lib/colors.ts
+++ b/frontend/src/metabase/lib/colors.ts
@@ -198,8 +198,9 @@ export function lighten(
 export type ColorMapping = (color: string) => string;
 const COLOR_MAPPINGS: Record<ColorName, Record<ColorName, ColorMapping>> = {
   brand: {
-    brand: (color: string) => color,
-    focus: (color: string) => lighten(color, 0.7),
+    brand: color => color,
+    focus: color => lighten(color, 0.7),
+    "brand-light": color => lighten(color, 0.532),
   },
 };
 export const getColorMappings = (

--- a/frontend/src/metabase/setup/components/LanguageStep/LanguageStep.styled.tsx
+++ b/frontend/src/metabase/setup/components/LanguageStep/LanguageStep.styled.tsx
@@ -44,7 +44,7 @@ export const LocaleButton = styled.span<LocaleContainerProps>`
   }
 
   ${LocaleInput}:focus + & {
-    outline: 2px solid ${color("brand-light")};
+    outline: 2px solid ${color("focus")};
   }
 
   ${LocaleInput}:focus:not(:focus-visible) + & {


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/19696

- Use a new `focus` color for the focus ring.
- Makes whitelabelling work with computed colors (both in CSS and JS). The problem is that `color-mod(color light(70%))` is replaced by a specific value at compile time.