### PR TITLE
Visual Design Cleanup for Headers - Fix header secondary buttons

### DIFF
--- a/frontend/src/metabase/core/components/Button/Button.tsx
+++ b/frontend/src/metabase/core/components/Button/Button.tsx
@@ -13,7 +13,6 @@ const BUTTON_VARIANTS = [
   "large",
   "round",
   "primary",
-  "secondary",
   "danger",
   "warning",
   "cancel",
@@ -40,7 +39,6 @@ interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
   large?: boolean;
 
   primary?: boolean;
-  secondary?: boolean;
   success?: boolean;
   danger?: boolean;
   warning?: boolean;

--- a/frontend/src/metabase/css/components/buttons.css
+++ b/frontend/src/metabase/css/components/buttons.css
@@ -73,28 +73,6 @@
   background-color: color-mod(var(--color-brand) alpha(-12%));
 }
 
-.Button--secondary {
-  color: var(--color-text-dark);
-  background-color: transparent;
-  border: 1px solid var(--color-border);
-}
-
-.Button--secondary:hover {
-  color: var(--color-text-dark);
-  background-color: transparent;
-  border: 1px solid transparent;
-  outline: 2px solid var(--color-outline);
-  transition: none;
-}
-
-.Button--secondary:focus {
-  outline: 2px solid var(--color-outline);
-}
-
-.Button.Button--secondary:focus:not(:focus-visible):hover {
-  outline: 2px solid var(--color-outline);
-}
-
 .Button--warning {
   color: var(--color-text-white);
   background: var(--color-error);

--- a/frontend/src/metabase/css/core/colors.css
+++ b/frontend/src/metabase/css/core/colors.css
@@ -31,7 +31,6 @@
   --color-focus: #cbe2f7;
   --color-shadow: rgba(0, 0, 0, 0.13);
   --color-border: #f0f0f0;
-  --color-outline: #cbe7ff;
 
   /* Saturated colors for the SQL editor. Shouldn't be used elsewhere since they're not white-labelable. */
   --color-saturated-blue: #2d86d4;

--- a/frontend/src/metabase/lib/colors.ts
+++ b/frontend/src/metabase/lib/colors.ts
@@ -36,7 +36,6 @@ const colors: Record<string, string> = {
   focus: "#CBE2F7",
   shadow: "rgba(0,0,0,0.08)",
   border: "#F0F0F0",
-  outline: "#CBE7FF",
 
   /* Saturated colors for the SQL editor. Shouldn't be used elsewhere since they're not white-labelable. */
   "saturated-blue": "#2D86D4",

--- a/frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx
+++ b/frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx
@@ -2,7 +2,6 @@
 import React from "react";
 import { t } from "ttag";
 import _ from "underscore";
-import cx from "classnames";
 
 import Modal from "metabase/components/Modal";
 import Button from "metabase/core/components/Button";
@@ -89,11 +88,7 @@ export default class NativeQueryButton extends React.Component {
           title={title}
           footer={
             loading || error ? null : (
-              <Button
-                primary
-                className={cx("text-dark")}
-                onClick={this.handleConvert}
-              >
+              <Button primary onClick={this.handleConvert}>
                 {button}
               </Button>
             )

--- a/frontend/src/metabase/query_builder/components/view/NativeQueryButton.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/view/NativeQueryButton.styled.jsx
@@ -12,7 +12,7 @@ export const SqlIconButton = forwardRefToInnerRef(styled(Button).attrs({
   padding: ${space(1)};
   border: none;
   background-color: transparent;
-  color: ${color("text-medium")};
+  color: ${color("text-dark")};
   cursor: pointer;
 
   :hover {

--- a/frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx
@@ -157,7 +157,6 @@ export function QuestionFilterWidget({
   return (
     <HeaderButton
       large
-      secondary
       labelBreakpoint="sm"
       color={color("filter")}
       onClick={isShowingFilterSidebar ? onCloseFilter : onAddFilter}

--- a/frontend/src/metabase/query_builder/components/view/QuestionNotebookButton.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionNotebookButton.jsx
@@ -23,7 +23,7 @@ export default function QuestionNotebookButton({
         borderless={!isShowingNotebook}
         primary={isShowingNotebook}
         medium
-        className={cx(className, "text-dark", {
+        className={cx(className, isShowingNotebook ? undefined : "text-dark", {
           "text-brand-hover": !isShowingNotebook,
         })}
         icon="notebook"

--- a/frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx
@@ -39,7 +39,6 @@ export function QuestionSummarizeWidget({
   return (
     <HeaderButton
       large
-      secondary
       data-testid="toggle-summarize-sidebar-button"
       color={color("accent1")}
       labelBreakpoint="sm"

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.styled.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.styled.jsx
@@ -56,13 +56,13 @@ export const DatasetHeaderButtonContainer = styled.div`
 `;
 
 export const HeaderButton = styled(Button)`
+  font-size: 0.875rem;
   background-color: ${({ active, color = getDefaultColor() }) =>
     active ? alpha(color, 0.8) : "transparent"};
   color: ${({ active }) => (active ? "white" : color("text-dark"))};
   &:hover {
-    background-color: ${({ active, color = getDefaultColor() }) =>
-      active ? alpha(color, 0.8) : "transparent"};
-    color: ${({ active }) => (active ? "white" : color("text-dark"))};
+    background-color: ${({ color = getDefaultColor() }) => alpha(color, 0.15)};
+    color: ${color};
   }
   transition: background 300ms linear, border 300ms linear;
   > .Icon {

--- a/frontend/src/metabase/reference/components/EditableReferenceHeader.jsx
+++ b/frontend/src/metabase/reference/components/EditableReferenceHeader.jsx
@@ -80,12 +80,7 @@ const EditableReferenceHeader = ({
           ]
         )}
         {user && user.is_superuser && !isEditing && (
-          <Button
-            secondary
-            icon="pencil"
-            style={{ fontSize: 14 }}
-            onClick={startEditing}
-          >
+          <Button icon="pencil" style={{ fontSize: 14 }} onClick={startEditing}>
             {t`Edit`}
           </Button>
         )}


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/653604/151811238-1f493915-5d4e-4f3c-b0c8-786b2130eb50.png)


**Changes**
* Fixes the header buttons as per designer feedback
  * Remove hover outline
  * Change background color on hover to the color provided by the parent * .15 opacity
  * Change text to color provided by parent
  * Change `font-size` to `0.875 rem`
* moves the secondary styling into the `HeaderButton`
* removes the secondary button style added in #19912, since the styling is specific to the header.