### PR TITLE
Fix native model editor initial height

### DIFF
--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
@@ -10,11 +10,11 @@ import Button from "metabase/core/components/Button";
 import DebouncedFrame from "metabase/components/DebouncedFrame";
 
 import QueryVisualization from "metabase/query_builder/components/QueryVisualization";
-
 import ViewSidebar from "metabase/query_builder/components/view/ViewSidebar";
 import DataReference from "metabase/query_builder/components/dataref/DataReference";
 import TagEditorSidebar from "metabase/query_builder/components/template_tags/TagEditorSidebar";
 import SnippetSidebar from "metabase/query_builder/components/template_tags/SnippetSidebar";
+import { calcInitialEditorHeight } from "metabase/query_builder/components/NativeQueryEditor/utils";
 
 import { setDatasetEditorTab } from "metabase/query_builder/actions";
 import { getDatasetEditorTab } from "metabase/query_builder/selectors";
@@ -198,8 +198,18 @@ function DatasetEditor(props) {
   const isEditingQuery = datasetEditorTab === "query";
   const isEditingMetadata = datasetEditorTab === "metadata";
 
+  const initialEditorHeight = useMemo(() => {
+    if (dataset.isStructured()) {
+      return INITIAL_NOTEBOOK_EDITOR_HEIGHT;
+    }
+    return calcInitialEditorHeight({
+      query: dataset.query(),
+      viewHeight: height,
+    });
+  }, [dataset, height]);
+
   const [editorHeight, setEditorHeight] = useState(
-    isEditingQuery ? INITIAL_NOTEBOOK_EDITOR_HEIGHT : 0,
+    isEditingQuery ? initialEditorHeight : 0,
   );
 
   const [focusedFieldRef, setFocusedFieldRef] = useState();
@@ -276,7 +286,7 @@ function DatasetEditor(props) {
   const onChangeEditorTab = useCallback(
     tab => {
       setDatasetEditorTab(tab);
-      setEditorHeight(tab === "query" ? INITIAL_NOTEBOOK_EDITOR_HEIGHT : 0);
+      setEditorHeight(tab === "query" ? initialEditorHeight : 0);
     },
     [setDatasetEditorTab],
   );

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
@@ -288,7 +288,7 @@ function DatasetEditor(props) {
       setDatasetEditorTab(tab);
       setEditorHeight(tab === "query" ? initialEditorHeight : 0);
     },
-    [setDatasetEditorTab],
+    [initialEditorHeight, setDatasetEditorTab],
   );
 
   const handleCancel = useCallback(() => {

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
@@ -31,16 +31,14 @@ import NativeQueryEditorSidebar from "./NativeQueryEditor/NativeQueryEditorSideb
 import VisibilityToggler from "./NativeQueryEditor/VisibilityToggler";
 import RightClickPopover from "./NativeQueryEditor/RightClickPopover";
 import DataSourceSelectors from "./NativeQueryEditor/DataSourceSelectors";
+import { SCROLL_MARGIN, MIN_HEIGHT_LINES } from "./NativeQueryEditor/constants";
+import {
+  calcInitialEditorHeight,
+  getEditorLineHeight,
+  getMaxAutoSizeLines,
+} from "./NativeQueryEditor/utils";
 
 import "./NativeQueryEditor.css";
-
-const SCROLL_MARGIN = 8;
-const LINE_HEIGHT = 16;
-
-const MIN_HEIGHT_LINES = 13;
-
-const getEditorLineHeight = lines => lines * LINE_HEIGHT + 2 * SCROLL_MARGIN;
-const getLinesForHeight = height => (height - 2 * SCROLL_MARGIN) / LINE_HEIGHT;
 
 @ExplicitSize()
 @Snippets.loadList({ loadingAndErrorWrapper: false })
@@ -51,16 +49,9 @@ export default class NativeQueryEditor extends Component {
   constructor(props) {
     super(props);
 
-    const lines = Math.max(
-      Math.min(
-        this.maxAutoSizeLines(),
-        props.query?.lineCount() || this.maxAutoSizeLines(),
-      ),
-      MIN_HEIGHT_LINES,
-    );
-
+    const { query, viewHeight } = props;
     this.state = {
-      initialHeight: getEditorLineHeight(lines),
+      initialHeight: calcInitialEditorHeight({ query, viewHeight }),
       isSelectedTextPopoverOpen: false,
     };
 
@@ -70,16 +61,6 @@ export default class NativeQueryEditor extends Component {
 
     this.editor = React.createRef();
     this.resizeBox = React.createRef();
-  }
-
-  maxAutoSizeLines() {
-    // This determines the max height that the editor *automatically* takes.
-    // - On load, long queries will be capped at this length
-    // - When loading an empty query, this is the height
-    // - When the editor grows during typing this is the max height
-    const FRACTION_OF_TOTAL_VIEW_HEIGHT = 0.4;
-    const pixelHeight = this.props.viewHeight * FRACTION_OF_TOTAL_VIEW_HEIGHT;
-    return Math.ceil(getLinesForHeight(pixelHeight));
   }
 
   static defaultProps = {
@@ -342,10 +323,10 @@ export default class NativeQueryEditor extends Component {
     const doc = this._editor.getSession().getDocument();
     const element = this.resizeBox.current;
     // set the newHeight based on the line count, but ensure it's within
-    // [MIN_HEIGHT_LINES, this.maxAutoSizeLines()]
+    // [MIN_HEIGHT_LINES, getMaxAutoSizeLines()]
     const newHeight = getEditorLineHeight(
       Math.max(
-        Math.min(doc.getLength(), this.maxAutoSizeLines()),
+        Math.min(doc.getLength(), getMaxAutoSizeLines()),
         MIN_HEIGHT_LINES,
       ),
     );

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/constants.ts
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/constants.ts
@@ -1,0 +1,2 @@
+export const SCROLL_MARGIN = 8;
+export const MIN_HEIGHT_LINES = 13;

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/utils.ts
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/utils.ts
@@ -1,0 +1,39 @@
+import NativeQuery from "metabase-lib/lib/queries/NativeQuery";
+import { SCROLL_MARGIN, MIN_HEIGHT_LINES } from "./constants";
+
+const LINE_HEIGHT = 16;
+
+export function getEditorLineHeight(lines: number) {
+  return lines * LINE_HEIGHT + 2 * SCROLL_MARGIN;
+}
+
+function getLinesForHeight(height: number) {
+  return (height - 2 * SCROLL_MARGIN) / LINE_HEIGHT;
+}
+
+const FRACTION_OF_TOTAL_VIEW_HEIGHT = 0.4;
+
+// This determines the max height that the editor *automatically* takes.
+// - On load, long queries will be capped at this length
+// - When loading an empty query, this is the height
+// - When the editor grows during typing this is the max height
+export function getMaxAutoSizeLines(viewHeight: number) {
+  const pixelHeight = viewHeight * FRACTION_OF_TOTAL_VIEW_HEIGHT;
+  return Math.ceil(getLinesForHeight(pixelHeight));
+}
+
+type GetVisibleLinesCountParams = { query?: NativeQuery; viewHeight: number };
+
+function getVisibleLinesCount({
+  query,
+  viewHeight,
+}: GetVisibleLinesCountParams) {
+  const maxAutoSizeLines = getMaxAutoSizeLines(viewHeight);
+  const queryLineCount = query?.lineCount() || maxAutoSizeLines;
+  return Math.max(Math.min(queryLineCount, maxAutoSizeLines), MIN_HEIGHT_LINES);
+}
+
+export function calcInitialEditorHeight(params: GetVisibleLinesCountParams) {
+  const lines = getVisibleLinesCount(params);
+  return getEditorLineHeight(lines);
+}


### PR DESCRIPTION
This PR should fix models Cypress tests flakiness caused by native query editor height. The default editor height for native models should also make more sense now.

`NativeQueryEditor` calculates its height on its own based on the number of lines and keeps it inside `state`. That worked quite well because it was also handling the resizing, so it could contain this whole logic inside. On the other hand, in the model editor, we need to have more control over `NativeQueryEditor's` height. We need to completely hide it when switching into the metadata editing mode and show it again once we switch back to the query editing mode ([code](https://github.com/metabase/metabase/blob/f4388814df2cfe5a114f8c0c4a250db13f6e7bd1/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx#L279), don't be confused by the `INITIAL_NOTEBOOK_EDITOR_HEIGHT` name, it's just poor naming and it was used for native queries too). The default value for editor height was too big, the editor looks odd for small queries and it also causes flaky tests. This PR extracts native editor's height calculation logic from the `NativeQueryEditor`, so it can be used in the `DatasetEditor` too and makes it use them

### Demo

**Before**

<img width="1448" alt="CleanShot 2022-01-31 at 16 07 35@2x" src="https://user-images.githubusercontent.com/17258145/151809939-f8c068b1-5d4e-4933-a855-676e30796513.png">

**After**
<img width="1447" alt="CleanShot 2022-01-31 at 16 07 15@2x" src="https://user-images.githubusercontent.com/17258145/151809981-b15ff577-98fb-41d4-9e11-8017c9f4bc36.png">

