### PR TITLE
Models E2E tests: ensure that the Run button is visible first

### DIFF
--- a/frontend/test/metabase/scenarios/models/models-query-editor.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models-query-editor.cy.spec.js
@@ -38,7 +38,9 @@ describe("scenarios > models query editor", () => {
     cy.findByText("Pick a column to group by").click();
     selectFromDropdown("Created At");
 
-    cy.get(".RunButton").click();
+    cy.get(".RunButton")
+      .should("be.visible")
+      .click();
 
     cy.get(".TableInteractive").within(() => {
       cy.findByText("Created At: Month");
@@ -90,7 +92,9 @@ describe("scenarios > models query editor", () => {
     cy.findByText("Pick a column to group by").click();
     selectFromDropdown("Created At");
 
-    cy.get(".RunButton").click();
+    cy.get(".RunButton")
+      .should("be.visible")
+      .click();
     cy.wait("@dataset");
 
     cy.get(".LineAreaBarChart").should("not.exist");


### PR DESCRIPTION
How to verify: `yarn test-visual-open` and run `models-query-editor.cy.spec.js`.

**Before this PR**

Occasionally, this happens:

![scenarios  models query editor -- locks display to table (failed)](https://user-images.githubusercontent.com/7288/151823892-ca860885-fcbc-472e-974a-0ebde7ff5c05.png)

**After this PR**

It doesn't happen anymore, since the button has to be visible first (and Cypress will wait/retry) before proceeding with the next step.