### PR TITLE
Hide explore results button for no-data users

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -398,8 +398,12 @@ function ViewTitleHeaderRightSide(props) {
     onCollapseFilters,
   } = props;
   const isShowingNotebook = queryBuilderMode === "notebook";
+  const canRunAdhocQueries = !question.query().readOnly();
   const hasExploreResultsLink =
-    isNative && isSaved && MetabaseSettings.get("enable-nested-queries");
+    isNative &&
+    isSaved &&
+    canRunAdhocQueries &&
+    MetabaseSettings.get("enable-nested-queries");
 
   return (
     <div

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.unit.spec.js
@@ -455,6 +455,29 @@ describe("View Header | Saved GUI question", () => {
   });
 });
 
+describe("View Header | native question without write permissions on database (eg user without self serve data permissions)", () => {
+  let originalNativePermissions;
+  beforeEach(() => {
+    setupNative();
+    originalNativePermissions = SAMPLE_DATABASE.native_permissions;
+    SAMPLE_DATABASE.native_permissions = "none";
+  });
+
+  afterEach(() => {
+    SAMPLE_DATABASE.native_permissions = originalNativePermissions;
+  });
+
+  it("does not display question database", () => {
+    const { question } = setupNative();
+    const databaseName = question.database().displayName();
+    expect(screen.queryByText(databaseName)).not.toBeInTheDocument();
+  });
+
+  it("does not offer to explore query results", () => {
+    expect(screen.queryByText("Explore results")).not.toBeInTheDocument();
+  });
+});
+
 describe("View Header | Not saved native question", () => {
   it("does not display question database", () => {
     const { question } = setupNative();


### PR DESCRIPTION
Fixes #20044 

Throwing an additional condition into the `hasExploreResultsLink` check -- that the question's query is not read-only via:

```
!question.query().readOnly();
```

The page blanks out due to a scripting error because there's code in the query builder that assumes there is query metadata--obviously, not the case for a user without permissions. Not doing anything about that since the we shouldn't let users get into this state.

**Testing**
1. Log into a user without self-serve data permissions
2. Navigate to a saved native question
3. You should not see the "Explore Results" button in the header
4. Log into a user _with_ data permissions
5. Go to the same saved questions
6. You _should_ see the "Explore Results" button in the header