### PR TITLE
Joins E2E tests: ensure that the schema is completely loaded

### DIFF
--- a/frontend/test/metabase/scenarios/joins/reproductions/18502-cannot-join-two-saved-questions-same-table.cy.spec.js
+++ b/frontend/test/metabase/scenarios/joins/reproductions/18502-cannot-join-two-saved-questions-same-table.cy.spec.js
@@ -14,6 +14,8 @@ describe("issue 18502", () => {
   });
 
   it("should be able to join two saved questions based on the same table (metabase#18502)", () => {
+    cy.intercept("/api/database/1/schema/PUBLIC").as("schema");
+
     cy.createQuestion(question1);
     cy.createQuestion(question2);
 
@@ -23,6 +25,7 @@ describe("issue 18502", () => {
 
     cy.findByText("18502#1").click();
     cy.icon("join_left_outer").click();
+    cy.wait("@schema");
 
     popover().within(() => {
       cy.findByTextEnsureVisible("Sample Database").click();

--- a/frontend/test/metabase/scenarios/joins/reproductions/18512-cannot-join-two-saved-questions-with-same-implicit-explicit-grouped-field.cy.spec.js
+++ b/frontend/test/metabase/scenarios/joins/reproductions/18512-cannot-join-two-saved-questions-with-same-implicit-explicit-grouped-field.cy.spec.js
@@ -15,6 +15,8 @@ describe("issue 18512", () => {
   });
 
   it("should join two saved questions with the same implicit/explicit grouped field (metabase#18512)", () => {
+    cy.intercept("/api/database/1/schema/PUBLIC").as("schema");
+
     cy.createQuestion(question1);
     cy.createQuestion(question2);
 
@@ -24,6 +26,7 @@ describe("issue 18512", () => {
 
     cy.findByText("18512#1").click();
     cy.icon("join_left_outer").click();
+    cy.wait("@schema");
 
     popover().within(() => {
       cy.findByTextEnsureVisible("Sample Database").click();


### PR DESCRIPTION
How to verify: `yarn test-visual-open` and run `18502-cannot-join-two-saved-questions-same-table.cy.spec.js` and `18512-cannot-join-two-saved-questions-with-same-implicit-explicit-grouped-field.cy.spec.js`.

**Before this PR**

Sometimes, the following occur:

![issue 18512 -- should join two saved questions with the same implicitexplicit grouped field (metabase#18512) (failed)](https://user-images.githubusercontent.com/7288/151852195-0cd6f00a-ecdc-4deb-9618-66a01c48a5e1.png)

![issue 18502 -- should be able to join two saved questions based on the same table (metabase#18502) (failed)](https://user-images.githubusercontent.com/7288/151852232-68b4ebcc-869f-4230-b449-c763937be27d.png)

**After this PR**

Those issue don't happen anymore.