### PR TITLE
Hide empty pin banner til pinned items are fetched

### DIFF
--- a/frontend/src/metabase/collections/components/PinnedItemOverview/PinnedItemOverview.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemOverview/PinnedItemOverview.tsx
@@ -20,6 +20,7 @@ import {
 
 type Props = {
   items: Item[];
+  isLoading: boolean;
   collection: Collection;
   metadata: Metadata;
   onCopy: (items: Item[]) => void;
@@ -28,6 +29,7 @@ type Props = {
 
 function PinnedItemOverview({
   items,
+  isLoading,
   collection,
   metadata,
   onCopy,
@@ -43,7 +45,7 @@ function PinnedItemOverview({
   return items.length === 0 ? (
     <Container>
       <PinDropZone variant="pin" />
-      <EmptyPinnedItemsBanner />
+      {!isLoading && <EmptyPinnedItemsBanner />}
     </Container>
   ) : (
     <Container data-testid="pinned-items">

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -152,6 +152,7 @@ function CollectionContent({
               />
               <PinnedItemOverview
                 items={pinnedItems}
+                isLoading={loadingPinnedItems}
                 collection={collection}
                 metadata={metadata}
                 onMove={handleMove}


### PR DESCRIPTION
Fixes #20068

The pinned item overview component is rendered regardless of state of the request for pinned items, so now we need to hide the empty banner that appears until we know whether or not the list of items is actually empty.

Before

https://user-images.githubusercontent.com/13057258/151852492-f99a6c3f-7cad-4e6b-8adf-7366b8f1c209.mov

After

https://user-images.githubusercontent.com/13057258/151852522-110f18a1-9458-4080-9705-fb3975dcbe0c.mov


