### PR TITLE
fix license infinite loop

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/license/components/LicenseAndBillingSettings/LicenseAndBillingSettings.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/license/components/LicenseAndBillingSettings/LicenseAndBillingSettings.tsx
@@ -89,14 +89,14 @@ const LicenseAndBillingSettings = ({
   const isInvalid = !!error || (tokenStatus != null && !tokenStatus.isValid);
   const description = getDescription(tokenStatus, !!token);
 
-  const isStoreManagedBilling = tokenStatus?.features.includes(
+  const isStoreManagedBilling = tokenStatus?.features?.includes(
     STORE_MANAGED_FEATURE_KEY,
   );
-  const shouldShowLicenseInput = !tokenStatus?.features.includes(
+  const shouldShowLicenseInput = !tokenStatus?.features?.includes(
     HOSTING_FEATURE_KEY,
   );
 
-  const shouldUpsell = !tokenStatus?.features.includes(NO_UPSELL_FEATURE_HEY);
+  const shouldUpsell = !tokenStatus?.features?.includes(NO_UPSELL_FEATURE_HEY);
 
   return (
     <SettingsLicenseContainer data-testid="license-and-billing-content">


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/20020

FE expected `features` array to be present in the status response, but it is not. The premium embedding license page was not affected.

<img width="1073" alt="Screenshot 2022-01-31 at 19 24 14" src="https://user-images.githubusercontent.com/14301985/151861954-eb7b56ca-5892-4a91-b32a-d90d7e2b2edc.png">

### How to verify
Obtain a token that you can safely edit (ask me in DM)

- Make the token valid
- Run Metabase EE and enter the token
- Make the token expire and wait a bit
- Ensure the page renders correctly with a message that the token is expired
