### PR TITLE
fix select button look

### DIFF
--- a/frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx
@@ -279,7 +279,7 @@ export default class FieldRemapping extends React.Component {
               triggerElement={
                 <SelectButton
                   hasValue={hasFKMappingValue}
-                  className={cx("flex inline-block no-decoration", {
+                  className={cx({
                     "border-error": dismissedInitialFkTargetPopover,
                     "border-dark": !dismissedInitialFkTargetPopover,
                   })}


### PR DESCRIPTION
Fixes `SelectButton` look in one place that hacked its styles.

### How to test
- open http://localhost:3000/admin/datamodel/database/1/table/2/13/general
- click on the select under "Display values"  -> "Use foreign key"
- ensure the second select looks fine

Before:
<img width="790" alt="Screenshot 2022-01-31 at 20 09 36" src="https://user-images.githubusercontent.com/14301985/151867300-21fb3a7a-607b-4574-b9f6-df5dc90dfc86.png">

After:
<img width="865" alt="Screenshot 2022-01-31 at 20 09 21" src="https://user-images.githubusercontent.com/14301985/151867274-e72e62d8-487a-48de-bb22-64d89a8ee260.png">
