### PR TITLE
Override IP address in Snowplow logging

### DIFF
--- a/src/metabase/analytics/snowplow.clj
+++ b/src/metabase/analytics/snowplow.clj
@@ -79,6 +79,8 @@
   [user-id]
   (-> (Subject$SubjectBuilder.)
       (.userId (str user-id))
+      ;; Override with localhost IP to avoid logging actual user IP addresses
+      (.ipAddress "127.0.0.1")
       .build))
 
 (def ^:private schema->version

--- a/test/metabase/analytics/snowplow_test.clj
+++ b/test/metabase/analytics/snowplow_test.clj
@@ -79,6 +79,13 @@
                      :token-features (public-settings/token-features)}}
              (:context (first @*snowplow-collector*)))))))
 
+(deftest ip-address-override-test
+  (testing "IP address on Snowplow subject is overridden with a dummy value (127.0.0.1)"
+    (with-fake-snowplow-collector
+      (snowplow/track-event! ::snowplow/dashboard-created 1 {:dashboard-id 1})
+      (is (partial= {:uid "1", :ip "127.0.0.1"}
+                    (:subject (first @*snowplow-collector*)))))))
+
 (deftest track-event-test
   (with-fake-snowplow-collector
     (testing "Data sent into [[snowplow/track-event!]] for each event type is propagated to the Snowplow collector,


### PR DESCRIPTION
Overrides the IP address field on the `Subject` class to `127.0.0.1` to avoid logging actual user IP addresses. We need to use a dummy value because it doesn't work to pass an empty string or `nil`, unfortunately. 