### PR TITLE
Fix typing flake in models query editor test

### DIFF
--- a/frontend/test/metabase/scenarios/models/models-query-editor.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models-query-editor.cy.spec.js
@@ -150,35 +150,33 @@ describe("scenarios > models query editor", () => {
         name: "Erroring Model",
         dataset: true,
         native: {
-          query: "S",
+          // Let's use API to type the most of the query, but stil make it invalid
+          query: "SELECT ",
         },
       },
       { visitQuestion: true },
     );
 
     openDetailsSidebar();
-    cy.findByText("Edit query definition").click();
 
+    cy.findByText("Customize metadata").click();
     cy.findByText(/Syntax error in SQL/);
-    cy.findByText("Metadata").click();
-    cy.findByText(/Syntax error in SQL/);
+
     cy.findByText("Query").click();
+    cy.findByText(/Syntax error in SQL/);
 
-    cy.get(".ace_content").type("{backspace}SELECT * FROM ORDERS");
+    // Using `text-input` here, which is the textarea HTML element instead of the `ace_content` (div)
+    cy.get(".ace_text-input").type("1");
+
     runNativeQuery();
-    cy.get(".TableInteractive").within(() => {
-      cy.findByText("TAX");
-      cy.findByText("TOTAL");
-    });
+
+    cy.get(".cellData").contains(1);
     cy.findByText(/Syntax error in SQL/).should("not.exist");
 
     cy.button("Save changes").click();
     cy.wait("@updateCard");
 
-    cy.get(".TableInteractive").within(() => {
-      cy.findByText("TAX");
-      cy.findByText("TOTAL");
-    });
+    cy.get(".cellData").contains(1);
     cy.findByText(/Syntax error in SQL/).should("not.exist");
   });
 });


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Fixes a typing flake for e2e models query test

Example of one of the previous failures in CircleCI
![image](https://user-images.githubusercontent.com/31325167/151891033-3fa706f4-28b0-4861-bf68-7ba2f4d66164.png)

### Additional info:
- Instead of using `.ace-content` (a plain `div`), I used `textarea` element that is hidden but accepts user input
- Simplified the query from `SELECT * FROM ORDERS` to `SELECT 1`
    - Wrote everything but the last character via API when the question was created, and let Cypress type only that one char
    - Apart from giving the Cypress less to type this also speeds up the whole test
 - Simplified flow, so instead of visiting query editor, then metadata then turning back to the query editor, the test now starts from the metadata and then ends up on the query editor, removing a superfluous step
 - No matter how many times I ran this locally, it always worked