### PR TITLE
Remove trailing slash from /api/tiles call on frontend

### DIFF
--- a/frontend/src/metabase/visualizations/components/LeafletTilePinMap.jsx
+++ b/frontend/src/metabase/visualizations/components/LeafletTilePinMap.jsx
@@ -51,7 +51,6 @@ export default class LeafletTilePinMap extends LeafletMap {
       (latitudeField.id || encodeURIComponent(latitudeField.name)) +
       "/" +
       (longitudeField.id || encodeURIComponent(longitudeField.name)) +
-      "/" +
       "?query=" +
       encodeURIComponent(JSON.stringify(dataset_query))
     );


### PR DESCRIPTION
#18912 modified the path for this endpoint, and in the process removed a trailing slash (which makes it consistent with most of our other endpoints); however, the frontend call was not correspondingly updated to remove the slash as well. This broke pin maps since the calls now 404. This PR simply removers the slash from the sole frontend call site to restore pin map functionality.

It's a bit concerning that no tests caught this. Maybe this is a good case for a visual test but I don't know how to add those.

Fixes #20090