### PR TITLE
Fix missing item descriptions in search results

### DIFF
--- a/frontend/src/metabase/query_builder/components/data-search/SearchResults.jsx
+++ b/frontend/src/metabase/query_builder/components/data-search/SearchResults.jsx
@@ -52,7 +52,12 @@ export function SearchResults({
             <ul>
               {list.map(item => (
                 <li key={`${item.id}_${item.model}`}>
-                  <SearchResult result={item} onClick={onSelect} compact />
+                  <SearchResult
+                    result={item}
+                    onClick={onSelect}
+                    compact
+                    hasDescription={false}
+                  />
                 </li>
               ))}
             </ul>

--- a/frontend/src/metabase/search/components/SearchResult.jsx
+++ b/frontend/src/metabase/search/components/SearchResult.jsx
@@ -92,7 +92,7 @@ function Context({ context }) {
 export default function SearchResult({
   result,
   compact,
-  hasDescription,
+  hasDescription = true,
   onClick,
 }) {
   const active = isItemActive(result);


### PR DESCRIPTION
Fixes #20018: items in search results were missing descriptions. A regression caused by #18876

### To Verify

1. Use the main search
2. Ensure search result items have descriptions
3. Note: the recent items list you see after clicking the search bar without any queries, shouldn't have descriptions (please correct me if I'm wrong)

### Demo

**Before**
![before](https://user-images.githubusercontent.com/17258145/151952857-a77ddc6b-6f50-4182-a919-c7cbbf7a79d0.png)

**After**
![after](https://user-images.githubusercontent.com/17258145/151952849-2acc996c-9a7e-4c3e-97f2-c2dad1c073e1.png)
