### PR TITLE
docs - fix docker dev branch instructions

### DIFF
--- a/docs/developers-guide/dev-branch-docker.md
+++ b/docs/developers-guide/dev-branch-docker.md
@@ -21,9 +21,11 @@ Once Docker is installed, you’re ready to go.
 
 ## Run a development branch to test or verify features
 
+[See here](https://hub.docker.com/r/metabase/metabase-dev/tags) for a list of development branches that you can run via Docker.
+
 1. Open your terminal app of choice.
 
-2. Copy and paste this command, switching out `<branch-name>` for the name of the branch you’d like to test:
+2. Copy and paste this command, switching out `<branch-name>` for the name of the branch you’d like to test: 
 
 ```bash
 docker run --platform linux/amd64 -d -p 3000:3000 --name metabase-dev metabase/metabase-dev:<branch-name>

--- a/docs/developers-guide/dev-branch-docker.md
+++ b/docs/developers-guide/dev-branch-docker.md
@@ -15,7 +15,7 @@ OR
 - If you like to install things via Homebrew:
 
 ```bash
-brew install docker
+brew install --cask docker
 ```
 Once Docker is installed, you’re ready to go.
 
@@ -26,7 +26,7 @@ Once Docker is installed, you’re ready to go.
 2. Copy and paste this command, switching out `<branch-name>` for the name of the branch you’d like to test:
 
 ```bash
-docker run -d -p 3000:3000 metabase/metabase-dev:<branch-name>
+docker run --platform linux/amd64 -d -p 3000:3000 --name metabase-dev metabase/metabase-dev:<branch-name>
 ```
 
 3. In your browser, navigate to [localhost:3000](http://localhost:3000), where you should see Metabase. It may take a minute or two to start up depending on your computer.
@@ -44,7 +44,7 @@ docker pull metabase/metabase-enterprise-head:latest
 Then:
 
 ```
-docker run -d -p 3000:3000 metabase/metabase-enterprise-head:latest
+docker run --platform linux/amd64 -d -p 3000:3000 --name metabase metabase/metabase-enterprise-head:latest
 ```
 
 The “latest” tag is not automatically upgraded on your local machine, so the above commands ensure that you’re pulling the latest changes.


### PR DESCRIPTION
Fix to instructions on running a development branch of Metabase via Docker