### PR TITLE
Fix passing treat-before-posting on the FE

### DIFF
--- a/frontend/src/metabase/entities/databases/forms.js
+++ b/frontend/src/metabase/entities/databases/forms.js
@@ -296,6 +296,7 @@ function getEngineFormFields(engine, details, id) {
         readOnly: field.readOnly || false,
         helperText: field["helper-text"],
         visibleIf: field["visible-if"],
+        treatBeforePosting: field["treat-before-posting"],
         ...(overrides && overrides(engine, details, id)),
       };
     })


### PR DESCRIPTION
Currently it's not passed, meaning that file contents are always sent as plain text.