### PR TITLE
Fix creation type (for 0.42)

### DIFF
--- a/frontend/src/metabase/nav/containers/Navbar.jsx
+++ b/frontend/src/metabase/nav/containers/Navbar.jsx
@@ -170,7 +170,7 @@ export default class Navbar extends Component {
                       icon: `insight`,
                       link: Urls.newQuestion({
                         mode: "notebook",
-                        creationType: "complex_question",
+                        creationType: "custom_question",
                       }),
                       event: `NavBar;New Question Click;`,
                     },

--- a/frontend/src/metabase/new_query/containers/NewQueryOptions.jsx
+++ b/frontend/src/metabase/new_query/containers/NewQueryOptions.jsx
@@ -98,7 +98,7 @@ export default class NewQueryOptions extends Component {
                 width={180}
                 to={Urls.newQuestion({
                   mode: "notebook",
-                  creationType: "complex_question",
+                  creationType: "custom_question",
                 })}
                 data-metabase-event={`New Question; Custom Question Start`}
               />


### PR DESCRIPTION
`creationType` is used for snowplow events and for some questions it had a wrong value. This PR fixes it.