### PR TITLE
Models E2E tests: ensure that the dataset is loaded first

### DIFF
--- a/frontend/test/metabase/scenarios/models/models-query-editor.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models-query-editor.cy.spec.js
@@ -35,6 +35,9 @@ describe("scenarios > models query editor", () => {
       .findByText("Summarize")
       .click();
     selectFromDropdown("Count of rows");
+
+    cy.wait("@dataset");
+
     cy.findByText("Pick a column to group by").click();
     selectFromDropdown("Created At");
 
@@ -89,13 +92,15 @@ describe("scenarios > models query editor", () => {
       .findByText("Summarize")
       .click();
     selectFromDropdown("Count of rows");
+
+    cy.wait("@dataset");
+
     cy.findByText("Pick a column to group by").click();
     selectFromDropdown("Created At");
 
     cy.get(".RunButton")
       .should("be.visible")
       .click();
-    cy.wait("@dataset");
 
     cy.get(".LineAreaBarChart").should("not.exist");
     cy.get(".TableInteractive");


### PR DESCRIPTION
How to test? `yarn test-visual-open` and run `models-query-editor.cy.spec.js`.

**Before this PR**

Sometimes, the following happens:

![scenarios  models query editor -- locks display to table (failed)](https://user-images.githubusercontent.com/7288/152038477-072655c2-04c7-4e6b-8a9e-ed602363cec1.png)


**After this PR**

It doesn't happen anymore.