### PR TITLE
CI with GitHub Actions: focus on PR trigger

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -1,16 +1,11 @@
 name: Backend
 
 on:
-  pull_request:
   push:
     branches:
-      - '**'
-    paths:
-    - '**.clj*'
-    - '**.edn'
-    - '**.java'
-    - '**/metabase-plugin.yaml'
-    - '.github/workflows/**'
+      - 'master'
+      - 'release-**'
+  pull_request:
 
 jobs:
 

--- a/.github/workflows/cljs.yml
+++ b/.github/workflows/cljs.yml
@@ -3,12 +3,8 @@ name: CLJS
 on:
   push:
     branches:
-      - '**'
-    paths:
-    - 'shared/src/'
-    - '**/package.json'
-    - '**/yarn.lock'
-    - '.github/workflows/**'
+      - 'master'
+      - 'release-**'
   pull_request:
 
 jobs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,13 +3,8 @@ name: Docs
 on:
   push:
     branches:
-      - '**'
-    paths:
-    - 'docs/**'
-    - './bin/verify-docs-links'
-    - '**/package.json'
-    - '**/yarn.lock'
-    - '.github/workflows/**'
+      - 'master'
+      - 'release-**'
   pull_request:
 
 jobs:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,18 +1,11 @@
 name: Frontend
 
 on:
-  pull_request:
   push:
     branches:
-      - '**'
-    paths:
-    - 'frontend/**'
-    - 'shared/**'
-    - 'enterprise/frontend/**'
-    - '**/package.json'
-    - '**/yarn.lock'
-    - '**/.eslintrc'
-    - '.github/workflows/**'
+      - 'master'
+      - 'release-**'
+  pull_request:
 
 jobs:
 

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -3,15 +3,8 @@ name: Fuzzing
 on:
   push:
     branches:
-      - '**'
-    paths:
-    - 'frontend/**'
-    - 'shared/**'
-    - 'enterprise/frontend/**'
-    - '**/package.json'
-    - '**/yarn.lock'
-    - '**/.eslintrc'
-    - '.github/workflows/**'
+      - 'master'
+      - 'release-**'
   pull_request:
     paths-ignore:
     - 'docs/**'

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -1,18 +1,11 @@
 name: i18n
 
 on:
-  pull_request:
   push:
     branches:
-      - '**'
-    paths:
-    - '**.clj*'
-    - '**.js'
-    - '**.jsx'
-    - '**.ts'
-    - '**.tsx'
-    - '.github/workflows/**'
-    - 'bin/**'
+      - 'master'
+      - 'release-**'
+  pull_request:
 
 jobs:
 

--- a/.github/workflows/whitespace.yml
+++ b/.github/workflows/whitespace.yml
@@ -1,20 +1,11 @@
 name: Whitespace
 
 on:
-  pull_request:
   push:
     branches:
-      - '**'
-    paths:
-      - '**.yaml'
-      - '**.yml'
-      - '**.clj'
-      - '**.edn'
-      - '**.el'
-      - '**.html'
-      - '**.json'
-      - '**.js*'
-      - '**.sh'
+      - 'master'
+      - 'release-**'
+  pull_request:
 
 jobs:
   whitespace-linter:

--- a/.github/workflows/yaml.yml
+++ b/.github/workflows/yaml.yml
@@ -1,14 +1,11 @@
 name: YAML
 
 on:
-  pull_request:
   push:
     branches:
-      - '**'
-    paths:
-    - '**.yml'
-    - '**.yaml'
-    - 'package.json'
+      - 'master'
+      - 'release-**'
+  pull_request:
 
 jobs:
 


### PR DESCRIPTION
To avoid double runs of various checks (linters, tests, etc) on feature branch, we mainly run on pull_request trigger, i.e. the checks are carried out once that feature branch appears in a PR, and not before.

We do however still run on push trigger for the important branches (master, release-*).

**Before**

In every PR, we spot two runs (one for each, pull_request and push) for the same check, such as:

![image](https://user-images.githubusercontent.com/7288/152041386-e1058e29-d3c2-40f6-a9e2-a36f7e19a2cd.png)

**After**

There is only one run:

![image](https://user-images.githubusercontent.com/7288/152041587-84e2c1f8-e3de-4048-a4cb-c4ae03da7405.png)
