### PR TITLE
Repro #19737: New question picker doesn't show moved model's collection until page refresh

### DIFF
--- a/frontend/test/metabase/scenarios/models/reproductions/19737-data-picker-not-showing-moved-model.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/reproductions/19737-data-picker-not-showing-moved-model.cy.spec.js
@@ -1,0 +1,45 @@
+import { restore, modal, popover } from "__support__/e2e/cypress";
+
+const modelName = "Orders Model";
+
+describe.skip("issue 19737", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.request("PUT", "/api/card/1", { name: modelName, dataset: true });
+  });
+
+  it("should show moved model in the data picker without refreshing (metabase#19737)", () => {
+    cy.visit("/collection/root");
+
+    openEllipsisMenuFor(modelName);
+    popover()
+      .contains("Move")
+      .click();
+
+    modal().within(() => {
+      cy.findByText("My personal collection").click();
+      cy.findByText("Move").click();
+    });
+
+    cy.findByText("Moved model");
+
+    cy.findByText("New").click();
+    cy.findByText("Question")
+      .should("be.visible")
+      .click();
+
+    cy.findByText("Models").click();
+
+    cy.findByText("Your personal collection").click();
+    cy.findByText(modelName);
+  });
+});
+
+function openEllipsisMenuFor(item) {
+  cy.findByText(item)
+    .closest("tr")
+    .find(".Icon-ellipsis")
+    .click();
+}


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #19737 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/models/reproductions/19737-data-picker-not-showing-moved-model.cy.spec.js`
- Unskip the repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/152055573-4025501e-30d6-4f75-897a-185d5b796497.png)

