### PR TITLE
Repro #19776: New data picker shows blank after archiving a model

### DIFF
--- a/frontend/test/metabase/scenarios/models/reproductions/19776-data-picker-not-displayed-after-archiving-model.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/reproductions/19776-data-picker-not-displayed-after-archiving-model.cy.spec.js
@@ -1,0 +1,39 @@
+import { restore, popover } from "__support__/e2e/cypress";
+
+const modelName = "Orders Model";
+
+describe("issue 19776", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.request("PUT", "/api/card/1", { name: modelName, dataset: true });
+  });
+
+  it("should show moved model in the data picker without refreshing (metabase#19776)", () => {
+    cy.visit("/collection/root");
+
+    openEllipsisMenuFor(modelName);
+    popover()
+      .contains("Archive")
+      .click();
+
+    cy.findByText("Archived model");
+
+    cy.findByText("New").click();
+    cy.findByText("Question")
+      .should("be.visible")
+      .click();
+
+    cy.findByText("Sample Database");
+    cy.findByText("Saved Questions");
+    cy.findByText("Models").should("not.exist");
+  });
+});
+
+function openEllipsisMenuFor(item) {
+  cy.findByText(item)
+    .closest("tr")
+    .find(".Icon-ellipsis")
+    .click();
+}


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Reproduces #19776

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/models/reproductions/19776-data-picker-not-displayed-after-archiving-model.cy.spec.js`
- The test should pass

### Additional notes:
Not sure exactly when was this fixed.

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/152057881-ef313625-3641-4c05-92ea-bfe8a73bbb7c.png)

