### PR TITLE
Fix ambiguous run-query-for-dashcard endpoints

### DIFF
--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -290,6 +290,7 @@ Return a list of candidates for automagic dashboards orderd by interestingness.
   - [POST /api/card/:card-id/public_link](#post-apicardcard-idpublic_link)
   - [POST /api/card/:card-id/query](#post-apicardcard-idquery)
   - [POST /api/card/:card-id/query/:export-format](#post-apicardcard-idqueryexport-format)
+  - [POST /api/card/:id/copy](#post-apicardidcopy)
   - [POST /api/card/collections](#post-apicardcollections)
   - [POST /api/card/pivot/:card-id/query](#post-apicardpivotcard-idquery)
   - [POST /api/card/related](#post-apicardrelated)
@@ -434,6 +435,14 @@ Run the query associated with a Card, and return its results as a file in the sp
 *  **`export-format`** value must be one of: `api`, `csv`, `json`, `xlsx`.
 
 *  **`parameters`** value may be nil, or if non-nil, value must be a valid JSON string.
+
+### `POST /api/card/:id/copy`
+
+Copy a `Card`, with the new name 'Copy of _name_'.
+
+##### PARAMS:
+
+*  **`id`** value may be nil, or if non-nil, value must be an integer greater than zero.
 
 ### `POST /api/card/collections`
 
@@ -716,14 +725,14 @@ You must be a superuser to do this.
   - [GET /api/dashboard/params/valid-filter-fields](#get-apidashboardparamsvalid-filter-fields)
   - [GET /api/dashboard/public](#get-apidashboardpublic)
   - [POST /api/dashboard/](#post-apidashboard)
-  - [POST /api/dashboard/:dashboard-id/card/:card-id/query](#post-apidashboarddashboard-idcardcard-idquery)
-  - [POST /api/dashboard/:dashboard-id/card/:card-id/query/:export-format](#post-apidashboarddashboard-idcardcard-idqueryexport-format)
-  - [POST /api/dashboard/:dashboard-id/card/pivot/:card-id/query](#post-apidashboarddashboard-idcardpivotcard-idquery)
+  - [POST /api/dashboard/:dashboard-id/dashcard/:dashcard-id/card/:card-id/query](#post-apidashboarddashboard-iddashcarddashcard-idcardcard-idquery)
+  - [POST /api/dashboard/:dashboard-id/dashcard/:dashcard-id/card/:card-id/query/:export-format](#post-apidashboarddashboard-iddashcarddashcard-idcardcard-idqueryexport-format)
   - [POST /api/dashboard/:dashboard-id/public_link](#post-apidashboarddashboard-idpublic_link)
   - [POST /api/dashboard/:from-dashboard-id/copy](#post-apidashboardfrom-dashboard-idcopy)
   - [POST /api/dashboard/:id/cards](#post-apidashboardidcards)
   - [POST /api/dashboard/:id/favorite](#post-apidashboardidfavorite)
   - [POST /api/dashboard/:id/revert](#post-apidashboardidrevert)
+  - [POST /api/dashboard/pivot/:dashboard-id/dashcard/:dashcard-id/card/:card-id/query](#post-apidashboardpivotdashboard-iddashcarddashcard-idcardcard-idquery)
   - [POST /api/dashboard/save](#post-apidashboardsave)
   - [POST /api/dashboard/save/collection/:parent-collection-id](#post-apidashboardsavecollectionparent-collection-id)
   - [PUT /api/dashboard/:id](#put-apidashboardid)
@@ -901,7 +910,7 @@ Create a new Dashboard.
 
 *  **`dashboard`** 
 
-### `POST /api/dashboard/:dashboard-id/card/:card-id/query`
+### `POST /api/dashboard/:dashboard-id/dashcard/:dashcard-id/card/:card-id/query`
 
 Run the query associated with a Saved Question (`Card`) in the context of a `Dashboard` that includes it.
 
@@ -909,11 +918,13 @@ Run the query associated with a Saved Question (`Card`) in the context of a `Das
 
 *  **`dashboard-id`** 
 
+*  **`dashcard-id`** 
+
 *  **`card-id`** 
 
 *  **`parameters`** value may be nil, or if non-nil, value must be an array. Each value must be a parameter map with an 'id' key
 
-### `POST /api/dashboard/:dashboard-id/card/:card-id/query/:export-format`
+### `POST /api/dashboard/:dashboard-id/dashcard/:dashcard-id/card/:card-id/query/:export-format`
 
 Run the query associated with a Saved Question (`Card`) in the context of a `Dashboard` that includes it, and return
   its results as a file in the specified format.
@@ -925,6 +936,8 @@ Run the query associated with a Saved Question (`Card`) in the context of a `Das
 
 *  **`dashboard-id`** 
 
+*  **`dashcard-id`** 
+
 *  **`card-id`** 
 
 *  **`export-format`** value must be one of: `api`, `csv`, `json`, `xlsx`.
@@ -932,18 +945,6 @@ Run the query associated with a Saved Question (`Card`) in the context of a `Das
 *  **`parameters`** value may be nil, or if non-nil, value must be a valid JSON string.
 
 *  **`request-parameters`** 
-
-### `POST /api/dashboard/:dashboard-id/card/pivot/:card-id/query`
-
-Pivot table version of `POST /api/dashboard/:dashboard-id/card/:card-id`.
-
-##### PARAMS:
-
-*  **`dashboard-id`** 
-
-*  **`card-id`** 
-
-*  **`parameters`** value may be nil, or if non-nil, value must be an array. Each value must be a parameter map with an 'id' key
 
 ### `POST /api/dashboard/:dashboard-id/public_link`
 
@@ -1008,6 +1009,20 @@ Revert a Dashboard to a prior `Revision`.
 *  **`id`** 
 
 *  **`revision_id`** value must be an integer greater than zero.
+
+### `POST /api/dashboard/pivot/:dashboard-id/dashcard/:dashcard-id/card/:card-id/query`
+
+Run a pivot table query for a specific DashCard.
+
+##### PARAMS:
+
+*  **`dashboard-id`** 
+
+*  **`dashcard-id`** 
+
+*  **`card-id`** 
+
+*  **`parameters`** value may be nil, or if non-nil, value must be an array. Each value must be a parameter map with an 'id' key
 
 ### `POST /api/dashboard/save`
 
@@ -2404,7 +2419,7 @@ Metabase API endpoints for viewing publicly-accessible Cards and Dashboards.
   - [GET /api/public/card/:uuid/query](#get-apipubliccarduuidquery)
   - [GET /api/public/card/:uuid/query/:export-format](#get-apipubliccarduuidqueryexport-format)
   - [GET /api/public/dashboard/:uuid](#get-apipublicdashboarduuid)
-  - [GET /api/public/dashboard/:uuid/card/:card-id](#get-apipublicdashboarduuidcardcard-id)
+  - [GET /api/public/dashboard/:uuid/dashcard/:dashcard-id/card/:card-id](#get-apipublicdashboarduuiddashcarddashcard-idcardcard-id)
   - [GET /api/public/dashboard/:uuid/field/:field-id/remapping/:remapped-id](#get-apipublicdashboarduuidfieldfield-idremappingremapped-id)
   - [GET /api/public/dashboard/:uuid/field/:field-id/search/:search-field-id](#get-apipublicdashboarduuidfieldfield-idsearchsearch-field-id)
   - [GET /api/public/dashboard/:uuid/field/:field-id/values](#get-apipublicdashboarduuidfieldfield-idvalues)
@@ -2412,7 +2427,7 @@ Metabase API endpoints for viewing publicly-accessible Cards and Dashboards.
   - [GET /api/public/dashboard/:uuid/params/:param-key/values](#get-apipublicdashboarduuidparamsparam-keyvalues)
   - [GET /api/public/oembed](#get-apipublicoembed)
   - [GET /api/public/pivot/card/:uuid/query](#get-apipublicpivotcarduuidquery)
-  - [GET /api/public/pivot/dashboard/:uuid/card/:card-id](#get-apipublicpivotdashboarduuidcardcard-id)
+  - [GET /api/public/pivot/dashboard/:uuid/dashcard/:dashcard-id/card/:card-id](#get-apipublicpivotdashboarduuiddashcarddashcard-idcardcard-id)
 
 ### `GET /api/public/card/:uuid`
 
@@ -2496,7 +2511,7 @@ Fetch a publicly-accessible Dashboard. Does not require auth credentials. Public
 
 *  **`uuid`** 
 
-### `GET /api/public/dashboard/:uuid/card/:card-id`
+### `GET /api/public/dashboard/:uuid/dashcard/:dashcard-id/card/:card-id`
 
 Fetch the results for a Card in a publicly-accessible Dashboard. Does not require auth credentials. Public
    sharing must be enabled.
@@ -2506,6 +2521,8 @@ Fetch the results for a Card in a publicly-accessible Dashboard. Does not requir
 *  **`uuid`** 
 
 *  **`card-id`** 
+
+*  **`dashcard-id`** 
 
 *  **`parameters`** value may be nil, or if non-nil, value must be a valid JSON string.
 
@@ -2601,7 +2618,7 @@ Fetch a publicly-accessible Card an return query results as well as `:card` info
 
 *  **`parameters`** value may be nil, or if non-nil, value must be a valid JSON string.
 
-### `GET /api/public/pivot/dashboard/:uuid/card/:card-id`
+### `GET /api/public/pivot/dashboard/:uuid/dashcard/:dashcard-id/card/:card-id`
 
 Fetch the results for a Card in a publicly-accessible Dashboard. Does not require auth credentials. Public
    sharing must be enabled.
@@ -2611,6 +2628,8 @@ Fetch the results for a Card in a publicly-accessible Dashboard. Does not requir
 *  **`uuid`** 
 
 *  **`card-id`** 
+
+*  **`dashcard-id`** 
 
 *  **`parameters`** value may be nil, or if non-nil, value must be a valid JSON string.
 

--- a/frontend/src/metabase-lib/lib/Question.ts
+++ b/frontend/src/metabase-lib/lib/Question.ts
@@ -860,8 +860,18 @@ export default class Question {
     );
   }
 
-  setDashboardId(dashboardId: number): Question {
-    return this.setCard(assoc(this.card(), "dashboardId", dashboardId));
+  setDashboardProps({
+    dashboardId,
+    dashcardId,
+  }:
+    | { dashboardId: number; dashcardId: number }
+    | { dashboardId: undefined; dashcardId: undefined }): Question {
+    const card = chain(this.card())
+      .assoc("dashboardId", dashboardId)
+      .assoc("dashcardId", dashcardId)
+      .value();
+
+    return this.setCard(card);
   }
 
   description(): string | null | undefined {
@@ -1062,10 +1072,12 @@ export default class Question {
 
     if (canUseCardApiEndpoint) {
       const dashboardId = this._card.dashboardId;
+      const dashcardId = this._card.dashcardId;
 
       const queryParams = {
         cardId: this.id(),
         dashboardId,
+        dashcardId,
         ignore_cache: ignoreCache,
         parameters,
       };
@@ -1181,7 +1193,10 @@ export default class Question {
         q &&
         new Question(q.card(), this.metadata())
           .setParameters([])
-          .setDashboardId(undefined)
+          .setDashboardProps({
+            dashboardId: undefined,
+            dashcardId: undefined,
+          })
       );
     });
     return a.isDirtyComparedTo(b);
@@ -1222,6 +1237,7 @@ export default class Question {
 
       ...(creationType ? { creationType } : {}),
       dashboardId: this._card.dashboardId,
+      dashcardId: this._card.dashcardId,
     };
     return utf8_to_b64url(JSON.stringify(sortObject(cardCopy)));
   }

--- a/frontend/src/metabase/dashboard/actions.js
+++ b/frontend/src/metabase/dashboard/actions.js
@@ -572,6 +572,7 @@ export const fetchCardData = createThunkAction(FETCH_CARD_DATA, function(
         maybeUsePivotEndpoint(PublicApi.dashboardCardQuery, card)(
           {
             uuid: dashcard.dashboard_id,
+            dashcardId: dashcard.id,
             cardId: card.id,
             parameters: datasetQuery.parameters
               ? JSON.stringify(datasetQuery.parameters)

--- a/frontend/src/metabase/dashboard/actions.js
+++ b/frontend/src/metabase/dashboard/actions.js
@@ -980,7 +980,10 @@ export const navigateToNewCardFromDashboard = createThunkAction(
         .setSettings(dashcard.card.visualization_settings)
         .lockDisplay();
     } else {
-      question = question.setCard(dashcard.card).setDashboardId(dashboard.id);
+      question = question.setCard(dashcard.card).setDashboardProps({
+        dashboardId: dashboard.id,
+        dashcardId: dashcard.id,
+      });
     }
 
     const parametersMappedToCard = getParametersMappedToDashcard(

--- a/frontend/src/metabase/dashboard/actions.js
+++ b/frontend/src/metabase/dashboard/actions.js
@@ -611,6 +611,7 @@ export const fetchCardData = createThunkAction(FETCH_CARD_DATA, function(
         maybeUsePivotEndpoint(endpoint, card)(
           {
             dashboardId: dashcard.dashboard_id,
+            dashcardId: dashcard.id,
             cardId: card.id,
             parameters: datasetQuery.parameters,
             ignore_cache: ignoreCache,

--- a/frontend/src/metabase/lib/card.js
+++ b/frontend/src/metabase/lib/card.js
@@ -84,6 +84,7 @@ export function serializeCardForUrl(card) {
     displayIsLocked: card.displayIsLocked,
     parameters: card.parameters,
     dashboardId: card.dashboardId,
+    dashcardId: card.dashcardId,
     visualization_settings: card.visualization_settings,
     original_card_id: card.original_card_id,
   };

--- a/frontend/src/metabase/parameters/utils/dashboards.js
+++ b/frontend/src/metabase/parameters/utils/dashboards.js
@@ -186,11 +186,15 @@ export function getParametersMappedToDashcard(dashboard, dashcard) {
 
 export function hasMatchingParameters({
   dashboard,
+  dashcardId,
   cardId,
   parameters,
   metadata,
 }) {
-  const dashcard = _.findWhere(dashboard.ordered_cards, { card_id: cardId });
+  const dashcard = _.findWhere(dashboard.ordered_cards, {
+    id: dashcardId,
+    card_id: cardId,
+  });
   if (!dashcard) {
     return false;
   }

--- a/frontend/src/metabase/parameters/utils/dashboards.unit.spec.js
+++ b/frontend/src/metabase/parameters/utils/dashboards.unit.spec.js
@@ -447,6 +447,7 @@ describe("meta/Dashboard", () => {
       const dashboard = {
         ordered_cards: [
           {
+            id: 1,
             card_id: 123,
             parameter_mappings: [
               {
@@ -460,7 +461,18 @@ describe("meta/Dashboard", () => {
       expect(
         hasMatchingParameters({
           dashboard,
+          dashcardId: 1,
           cardId: 456,
+          parameters: [],
+          metadata,
+        }),
+      ).toBe(false);
+
+      expect(
+        hasMatchingParameters({
+          dashboard,
+          dashcardId: 2,
+          cardId: 123,
           parameters: [],
           metadata,
         }),
@@ -471,6 +483,7 @@ describe("meta/Dashboard", () => {
       const dashboard = {
         ordered_cards: [
           {
+            id: 1,
             card_id: 123,
             parameter_mappings: [
               {
@@ -479,6 +492,7 @@ describe("meta/Dashboard", () => {
             ],
           },
           {
+            id: 2,
             card_id: 456,
             parameter_mappings: [
               {
@@ -492,6 +506,7 @@ describe("meta/Dashboard", () => {
       expect(
         hasMatchingParameters({
           dashboard,
+          dashcardId: 1,
           cardId: 123,
           parameters: [
             {
@@ -510,6 +525,7 @@ describe("meta/Dashboard", () => {
       const dashboard = {
         ordered_cards: [
           {
+            id: 1,
             card_id: 123,
             parameter_mappings: [
               {
@@ -526,6 +542,7 @@ describe("meta/Dashboard", () => {
       expect(
         hasMatchingParameters({
           dashboard,
+          dashcardId: 1,
           cardId: 123,
           parameters: [
             {

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -340,13 +340,22 @@ export const resetQB = createAction(RESET_QB);
 async function verifyMatchingDashcardAndParameters({
   dispatch,
   dashboardId,
+  dashcardId,
   cardId,
   parameters,
   metadata,
 }) {
   try {
     const dashboard = await DashboardApi.get({ dashId: dashboardId });
-    if (!hasMatchingParameters({ dashboard, cardId, parameters, metadata })) {
+    if (
+      !hasMatchingParameters({
+        dashboard,
+        dashcardId,
+        cardId,
+        parameters,
+        metadata,
+      })
+    ) {
       dispatch(setErrorPage({ status: 403 }));
     }
   } catch (error) {
@@ -420,10 +429,11 @@ export const initializeQB = (location, params, queryParams) => {
           // if there's a card in the url, it may have parameters from a dashboard
           if (deserializedCard && deserializedCard.parameters) {
             const metadata = getMetadata(getState());
-            const { dashboardId, parameters } = deserializedCard;
+            const { dashboardId, dashcardId, parameters } = deserializedCard;
             verifyMatchingDashcardAndParameters({
               dispatch,
               dashboardId,
+              dashcardId,
               cardId,
               parameters,
               metadata,
@@ -431,6 +441,7 @@ export const initializeQB = (location, params, queryParams) => {
 
             card.parameters = parameters;
             card.dashboardId = dashboardId;
+            card.dashcardId = dashcardId;
           }
         } else if (card.original_card_id) {
           const deserializedCard = card;
@@ -446,10 +457,11 @@ export const initializeQB = (location, params, queryParams) => {
               })
             ) {
               const metadata = getMetadata(getState());
-              const { dashboardId, parameters } = deserializedCard;
+              const { dashboardId, dashcardId, parameters } = deserializedCard;
               verifyMatchingDashcardAndParameters({
                 dispatch,
                 dashboardId,
+                dashcardId,
                 cardId: card.id,
                 parameters,
                 metadata,
@@ -457,6 +469,7 @@ export const initializeQB = (location, params, queryParams) => {
 
               card.parameters = parameters;
               card.dashboardId = dashboardId;
+              card.dashcardId = dashcardId;
             }
           }
         }

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -139,10 +139,14 @@ export const DashboardApi = {
   createPublicLink: POST("/api/dashboard/:id/public_link"),
   deletePublicLink: DELETE("/api/dashboard/:id/public_link"),
 
-  cardQuery: POST("/api/dashboard/:dashboardId/card/:cardId/query"),
-  cardQueryPivot: POST("/api/dashboard/:dashboardId/card/pivot/:cardId/query"),
+  cardQuery: POST(
+    "/api/dashboard/:dashboardId/dashcard/:dashcardId/card/:cardId/query",
+  ),
+  cardQueryPivot: POST(
+    "/api/dashboard/:dashboardId/dashcard/:dashcardId/card/pivot/:cardId/query",
+  ),
   exportCardQuery: POST(
-    "/api/dashboard/:dashboardId/card/:cardId/query/:exportFormat",
+    "/api/dashboard/:dashboardId/dashcard/:dashcardId/card/:cardId/query/:exportFormat",
   ),
 };
 

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -143,7 +143,7 @@ export const DashboardApi = {
     "/api/dashboard/:dashboardId/dashcard/:dashcardId/card/:cardId/query",
   ),
   cardQueryPivot: POST(
-    "/api/dashboard/:dashboardId/dashcard/:dashcardId/card/pivot/:cardId/query",
+    "/api/dashboard/pivot/:dashboardId/dashcard/:dashcardId/card/:cardId/query",
   ),
   exportCardQuery: POST(
     "/api/dashboard/:dashboardId/dashcard/:dashcardId/card/:cardId/query/:exportFormat",

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -168,9 +168,11 @@ export const PublicApi = {
   cardQuery: GET("/api/public/card/:uuid/query"),
   cardQueryPivot: GET(PIVOT_PUBLIC_PREFIX + "card/:uuid/query"),
   dashboard: GET("/api/public/dashboard/:uuid"),
-  dashboardCardQuery: GET("/api/public/dashboard/:uuid/card/:cardId"),
+  dashboardCardQuery: GET(
+    "/api/public/dashboard/:uuid/dashcard/:dashcardId/card/:cardId",
+  ),
   dashboardCardQueryPivot: GET(
-    PIVOT_PUBLIC_PREFIX + "dashboard/:uuid/card/:cardId",
+    PIVOT_PUBLIC_PREFIX + "dashboard/:uuid/dashcard/:dashcardId/card/:cardId",
   ),
 };
 

--- a/frontend/test/metabase-lib/lib/Question.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Question.unit.spec.js
@@ -932,13 +932,17 @@ describe("Question", () => {
     });
   });
 
-  describe("Question.prototype.setDashboardId", () => {
-    it("should set a `dashboardId` property on the question's card", () => {
+  describe("Question.prototype.setDashboardProps", () => {
+    it("should set a `dashboardId` property and a `dashcardId` property on the question's card", () => {
       const question = new Question(card, metadata);
-      const questionWithDashboardId = question.setDashboardId(1);
+      const questionWithDashboardId = question.setDashboardProps({
+        dashboardId: 123,
+        dashcardId: 456,
+      });
 
       expect(question).not.toBe(questionWithDashboardId);
-      expect(questionWithDashboardId.card().dashboardId).toEqual(1);
+      expect(questionWithDashboardId.card().dashboardId).toEqual(123);
+      expect(questionWithDashboardId.card().dashcardId).toEqual(456);
     });
   });
 

--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/12720-no-data-permissions-connected-filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/12720-no-data-permissions-connected-filter.cy.spec.js
@@ -32,7 +32,9 @@ const questionDetails = {
 
 describe.skip("issue 12720", () => {
   beforeEach(() => {
-    cy.intercept("POST", "/api/dashboard/1/card/1/query").as("cardQuery");
+    cy.intercept("POST", "/api/dashboard/1/dashcard/1/card/1/query").as(
+      "cardQuery",
+    );
 
     restore();
     cy.signInAsAdmin();

--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/13150-additional-card-queries-for-all-filters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/13150-additional-card-queries-for-all-filters.cy.spec.js
@@ -24,7 +24,9 @@ const [titleFilter, categoryFilter, vendorFilter] = parameters;
 describe("issue 13150", () => {
   beforeEach(() => {
     cy.server();
-    cy.route("POST", "/api/dashboard/*/card/*/query").as("cardQuery");
+    cy.route("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
+      "cardQuery",
+    );
 
     restore();
     cy.signInAsAdmin();

--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/13960-do-not-preserve-cleared-default-filter-on-refresh.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/13960-do-not-preserve-cleared-default-filter-on-refresh.cy.spec.js
@@ -57,7 +57,7 @@ describe("issue 13960", () => {
 
         cy.intercept(
           "POST",
-          `/api/dashboard/${dashboard_id}/card/${card_id}/query`,
+          `/api/dashboard/${dashboard_id}/dashcard/*/card/${card_id}/query`,
         ).as("cardQuery");
 
         cy.visit(`/dashboard/${dashboard_id}`);

--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/17212-nested-id-filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/17212-nested-id-filter.cy.spec.js
@@ -27,7 +27,7 @@ describe.skip("issue 17212", () => {
         ({ body: { card_id, dashboard_id } }) => {
           cy.intercept(
             "POST",
-            `/api/dashboard/${dashboard_id}/card/${card_id}/query`,
+            `/api/dashboard/${dashboard_id}/dashcard/*/card/${card_id}/query`,
           ).as("cardQuery");
 
           cy.visit(`/dashboard/${dashboard_id}`);

--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/19494-wrong-default-value-multiple-cards-same-question.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/19494-wrong-default-value-multiple-cards-same-question.cy.spec.js
@@ -25,7 +25,7 @@ const filter2 = {
 const card1 = getCardProperties({ id: 1, col: 0 });
 const card2 = getCardProperties({ id: 2, col: 9 });
 
-describe.skip("issue 19494", () => {
+describe("issue 19494", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();

--- a/frontend/test/metabase/scenarios/dashboard/click-behavior.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/click-behavior.cy.spec.js
@@ -51,7 +51,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
 
               cy.intercept(
                 "POST",
-                `/api/dashboard/${dashboardId}/card/${question1Id}/query`,
+                `/api/dashboard/${dashboardId}/dashcard/*/card/${question1Id}/query`,
               ).as("cardQuery");
 
               cy.intercept("POST", `/api/card/${nativeId}/query`).as(
@@ -138,7 +138,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
 
           cy.intercept(
             "POST",
-            `/api/dashboard/${dashboard_id}/card/${card_id}/query`,
+            `/api/dashboard/${dashboard_id}/dashcard/*/card/${card_id}/query`,
           ).as("cardQuery");
         },
       );

--- a/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
@@ -483,7 +483,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
         cy.server();
         cy.route(
           "POST",
-          `/api/dashboard/${DASHBOARD_ID}/card/${QUESTION_ID}/query`,
+          `/api/dashboard/${DASHBOARD_ID}/dashcard/*/card/${QUESTION_ID}/query`,
         ).as("cardQuery");
 
         cy.visit(`/dashboard/${DASHBOARD_ID}`);
@@ -728,7 +728,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
           });
           cy.intercept(
             "POST",
-            `/api/dashboard/${DASHBOARD_ID}/card/${QUESTION2_ID}/query`,
+            `/api/dashboard/${DASHBOARD_ID}/dashcard/*/card/${QUESTION2_ID}/query`,
           ).as("secondCardQuery");
 
           cy.visit(`/dashboard/${DASHBOARD_ID}`);

--- a/frontend/test/metabase/scenarios/dashboard/reproductions/18454-card-description.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/reproductions/18454-card-description.cy.spec.js
@@ -52,7 +52,7 @@ function createDashboardWithQuestionWithDescription() {
 
       cy.intercept(
         "POST",
-        `/api/dashboard/${dashboard_id}/card/${card_id}/query`,
+        `/api/dashboard/${dashboard_id}/dashcard/*/card/${card_id}/query`,
       ).as("cardQuery");
     },
   );

--- a/frontend/test/metabase/scenarios/dashboard/title-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/title-drill.cy.spec.js
@@ -227,7 +227,7 @@ describe("scenarios > dashboard > title drill", () => {
 
           cy.intercept(
             "POST",
-            `/api/dashboard/${dashboard_id}/card/${card_id}/query`,
+            `/api/dashboard/${dashboard_id}/dashcard/*/card/${card_id}/query`,
           ).as("cardQuery");
 
           cy.visit(`/dashboard/${dashboard_id}`);

--- a/frontend/test/metabase/scenarios/question/reproductions/17514-ui-overlay.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/17514-ui-overlay.cy.spec.js
@@ -56,7 +56,7 @@ describe("issue 17514", () => {
 
           cy.intercept(
             "POST",
-            `/api/dashboard/${dashboard_id}/card/${card_id}/query`,
+            `/api/dashboard/${dashboard_id}/dashcard/*/card/${card_id}/query`,
           ).as("cardQuery");
 
           const mapFilterToCard = {

--- a/frontend/test/metabase/scenarios/visualizations/drillthroughs/dash_drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/drillthroughs/dash_drill.cy.spec.js
@@ -97,7 +97,7 @@ describe("scenarios > visualizations > drillthroughs > dash_drill", () => {
               cy.server();
               cy.route(
                 "POST",
-                `/api/dashboard/${DASHBOARD_ID}/card/${CARD_ID}/query`,
+                `/api/dashboard/${DASHBOARD_ID}/dashcard/*/card/${CARD_ID}/query`,
               ).as("cardQuery");
 
               // Add previously created question to the new dashboard
@@ -194,7 +194,7 @@ describe("scenarios > visualizations > drillthroughs > dash_drill", () => {
             cy.server();
             cy.route(
               "POST",
-              `/api/dashboard/${DASHBOARD_ID}/card/${QUESTION_ID}/query`,
+              `/api/dashboard/${DASHBOARD_ID}/dashcard/*/card/${QUESTION_ID}/query`,
             ).as("cardQuery");
             cy.route("POST", `/api/dataset`).as("dataset");
 

--- a/frontend/test/metabase/scenarios/visualizations/gauge.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/gauge.cy.spec.js
@@ -7,7 +7,7 @@ describe("scenarios > visualizations > gauge chart", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
-    cy.intercept(`/api/dashboard/*/card/*/query`).as("cardQuery");
+    cy.intercept(`/api/dashboard/*/dashcard/*/card/*/query`).as("cardQuery");
   });
 
   it("should not rerender on gauge arc hover (metabase#15980)", () => {

--- a/frontend/test/metabase/scenarios/visualizations/reproductions/18061-maps-only-nulls-crash-frontend.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/reproductions/18061-maps-only-nulls-crash-frontend.cy.spec.js
@@ -73,7 +73,7 @@ describe("issue 18061", () => {
         cy.intercept("POST", `/api/card/${card_id}/query`).as("cardQuery");
         cy.intercept(
           "POST",
-          `/api/dashboard/${dashboard_id}/card/${card_id}/query`,
+          `/api/dashboard/${dashboard_id}/dashcard/*/card/${card_id}/query`,
         ).as("dashCardQuery");
         cy.intercept("GET", `/api/card/${card_id}`).as("getCard");
 

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -717,9 +717,9 @@
      s/Keyword s/Any}
     "value must be a parameter map with an 'id' key"))
 
-(api/defendpoint POST "/:dashboard-id/card/:card-id/dashcard/:dashcard-id/query"
+(api/defendpoint POST "/:dashboard-id/dashcard/:dashcard-id/card/:card-id/query"
   "Run the query associated with a Saved Question (`Card`) in the context of a `Dashboard` that includes it."
-  [dashboard-id card-id dashcard-id :as {{:keys [parameters], :as body} :body}]
+  [dashboard-id dashcard-id card-id :as {{:keys [parameters], :as body} :body}]
   {parameters (s/maybe [ParameterWithID])}
   (m/mapply qp.dashboard/run-query-for-dashcard-async
             (merge
@@ -728,13 +728,13 @@
               :card-id      card-id
               :dashcard-id  dashcard-id})))
 
-(api/defendpoint POST "/:dashboard-id/card/:card-id/dashcard/:dashcard-id/query/:export-format"
+(api/defendpoint POST "/:dashboard-id/dashcard/:dashcard-id/card/:card-id/query/:export-format"
   "Run the query associated with a Saved Question (`Card`) in the context of a `Dashboard` that includes it, and return
   its results as a file in the specified format.
 
   `parameters` should be passed as query parameter encoded as a serialized JSON string (this is because this endpoint
   is normally used to power 'Download Results' buttons that use HTML `form` actions)."
-  [dashboard-id card-id dashcard-id export-format :as {{:keys [parameters], :as request-parameters} :params}]
+  [dashboard-id dashcard-id card-id export-format :as {{:keys [parameters], :as request-parameters} :params}]
   {parameters    (s/maybe su/JSONString)
    export-format api.dataset/ExportFormat}
   (m/mapply qp.dashboard/run-query-for-dashcard-async
@@ -755,9 +755,9 @@
                               :format-rows?           false
                               :js-int-to-string?      false}})))
 
-(api/defendpoint POST "/pivot/:dashboard-id/card/:card-id/dashcard/:dashcard-id/query"
-  "Pivot table version of `POST /api/dashboard/:dashboard-id/card/:card-id/dashcard/:dashcard-id/query`."
-  [dashboard-id card-id dashcard-id :as {{:keys [parameters], :as body} :body}]
+(api/defendpoint POST "/pivot/:dashboard-id/dashcard/:dashcard-id/card/:card-id/query"
+  "Run a pivot table query for a specific DashCard."
+  [dashboard-id dashcard-id card-id :as {{:keys [parameters], :as body} :body}]
   {parameters (s/maybe [ParameterWithID])}
   (m/mapply qp.dashboard/run-query-for-dashcard-async
             (merge

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -717,23 +717,24 @@
      s/Keyword s/Any}
     "value must be a parameter map with an 'id' key"))
 
-(api/defendpoint POST "/:dashboard-id/card/:card-id/query"
+(api/defendpoint POST "/:dashboard-id/card/:card-id/dashcard/:dashcard-id/query"
   "Run the query associated with a Saved Question (`Card`) in the context of a `Dashboard` that includes it."
-  [dashboard-id card-id :as {{:keys [parameters], :as body} :body}]
+  [dashboard-id card-id dashcard-id :as {{:keys [parameters], :as body} :body}]
   {parameters (s/maybe [ParameterWithID])}
   (m/mapply qp.dashboard/run-query-for-dashcard-async
             (merge
              body
              {:dashboard-id dashboard-id
-              :card-id      card-id})))
+              :card-id      card-id
+              :dashcard-id  dashcard-id})))
 
-(api/defendpoint POST "/:dashboard-id/card/:card-id/query/:export-format"
+(api/defendpoint POST "/:dashboard-id/card/:card-id/dashcard/:dashcard-id/query/:export-format"
   "Run the query associated with a Saved Question (`Card`) in the context of a `Dashboard` that includes it, and return
   its results as a file in the specified format.
 
   `parameters` should be passed as query parameter encoded as a serialized JSON string (this is because this endpoint
   is normally used to power 'Download Results' buttons that use HTML `form` actions)."
-  [dashboard-id card-id export-format :as {{:keys [parameters], :as request-parameters} :params}]
+  [dashboard-id card-id dashcard-id export-format :as {{:keys [parameters], :as request-parameters} :params}]
   {parameters    (s/maybe su/JSONString)
    export-format api.dataset/ExportFormat}
   (m/mapply qp.dashboard/run-query-for-dashcard-async
@@ -741,6 +742,7 @@
              request-parameters
              {:dashboard-id  dashboard-id
               :card-id       card-id
+              :dashcard-id   dashcard-id
               :export-format export-format
               :parameters    (json/parse-string parameters keyword)
               :constraints   nil
@@ -753,15 +755,16 @@
                               :format-rows?           false
                               :js-int-to-string?      false}})))
 
-(api/defendpoint POST "/:dashboard-id/card/pivot/:card-id/query"
-  "Pivot table version of `POST /api/dashboard/:dashboard-id/card/:card-id`."
-  [dashboard-id card-id :as {{:keys [parameters], :as body} :body}]
+(api/defendpoint POST "/pivot/:dashboard-id/card/:card-id/dashcard/:dashcard-id/query"
+  "Pivot table version of `POST /api/dashboard/:dashboard-id/card/:card-id/dashcard/:dashcard-id/query`."
+  [dashboard-id card-id dashcard-id :as {{:keys [parameters], :as body} :body}]
   {parameters (s/maybe [ParameterWithID])}
   (m/mapply qp.dashboard/run-query-for-dashcard-async
             (merge
              body
              {:dashboard-id dashboard-id
               :card-id      card-id
+              :dashcard-id  dashcard-id
               :qp-runner    qp.pivot/run-pivot-query})))
 
 (api/define-routes)

--- a/src/metabase/api/embed.clj
+++ b/src/metabase/api/embed.clj
@@ -258,10 +258,14 @@
   (let [slug->value (validate-and-merge-params embedding-params token-params (normalize-query-params query-params))
         parameters  (resolve-dashboard-parameters dashboard-id slug->value)]
     (public-api/public-dashcard-results-async
-     dashboard-id card-id export-format parameters
-     :qp-runner   qp-runner
-     :context     :embedded-dashboard
-     :constraints constraints)))
+     :dashboard-id  dashboard-id
+     :card-id       card-id
+     :dashcard-id   dashcard-id
+     :export-format export-format
+     :parameters    parameters
+     :qp-runner     qp-runner
+     :context       :embedded-dashboard
+     :constraints   constraints)))
 
 
 ;;; ------------------------------------- Other /api/embed-specific utility fns --------------------------------------

--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -38,6 +38,7 @@
                     (qp.dashboard/run-query-for-dashcard-async
                      :dashboard-id  (u/the-id dashboard)
                      :card-id       card-id
+                     :dashcard-id   (u/the-id dashcard)
                      :context       :pulse ; TODO - we should support for `:dashboard-subscription` and use that to differentiate the two
                      :export-format :api
                      :parameters    parameters


### PR DESCRIPTION
Fixes #19494

Previously we only passed in Dashboard ID and Card ID when running a query for a DashboardCard. In situations where a Card was included more than once in a Dashboard but with different filter widgets wired up with different defaults things stopped working correctly. We need to pass in the DashboardCard ID as well so we can disambiguate which filter widgets are meant to apply to a specific query execution API request.

As such the following endpoints have been renamed:

| before | after |
|---|---|
| `POST /api/dashboard/:dashboard-id/card/:card-id/query`                | `POST /api/dashboard/:dashboard-id/dashcard/:dashcard-id/card/:card-id/query` |
| `POST /api/dashboard/:dashboard-id/card/:card-id/query/:export-format` | `POST /api/dashboard/:dashboard-id/dashcard/:dashcard-id/card/:card-id/query/:export-format` |
| `POST /api/dashboard/:dashboard-id/card/pivot/:card-id/query`          | `POST /api/dashboard/pivot/:dashboard-id/dashcard/:dashcard-id/card/:card-id/query` |
| `GET /api/public/dashboard/:uuid/card/:card-id`                     | `GET /api/public/dashboard/:uuid/dashcard/:dashcard-id/card/:card-id` |
| `GET /api/public/pivot/dashboard/:uuid/card/:card-id`               | `GET /api/public/pivot/dashboard/:uuid/dashcard/:dashcard-id/card/:card-id` |

Note some of the routes changed a bit more than simply adding `dashcard/:dashcard-id/` to them; they weren't consistent in where `pivot` appeared so I made a few tweaks so all the endpoints follow a consistent pattern.

Frontend will have to be updated to use the new endpoints.