### PR TITLE
Fix models e2e typing flake pt2

### DIFF
--- a/frontend/test/__support__/e2e/commands/api/question.js
+++ b/frontend/test/__support__/e2e/commands/api/question.js
@@ -26,7 +26,7 @@ Cypress.Commands.add(
  * @param {object} questionDetails
  * @param {string} [questionDetails.name="test question"]
  * @param {string} questionDetails.description
- * @param {boolean} questionDetails.dataset
+ * @param {boolean} questionDetails.dataset - Is this a Model or no? (model = dataset)
  * @param {object} questionDetails.native
  * @param {object} questionDetails.query
  * @param {number} [questionDetails.database=1]
@@ -73,16 +73,15 @@ function question(
     }
 
     if (loadMetadata || visitQuestion) {
-      if (dataset) {
-        cy.intercept("POST", `/api/dataset`).as("cardQuery");
-      } else {
-        cy.intercept("POST", `/api/card/${body.id}/query`).as("cardQuery");
-      }
+      dataset
+        ? cy.intercept("POST", `/api/dataset`).as("dataset")
+        : cy.intercept("POST", `/api/card/${body.id}/query`).as("cardQuery");
+
       const url = dataset ? `/model/${body.id}` : `/question/${body.id}`;
       cy.visit(url);
 
       // Wait for `result_metadata` to load
-      cy.wait("@cardQuery");
+      dataset ? cy.wait("@dataset") : cy.wait("@cardQuery");
     }
   });
 }

--- a/frontend/test/metabase/scenarios/models/models-query-editor.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models-query-editor.cy.spec.js
@@ -149,6 +149,8 @@ describe("scenarios > models query editor", () => {
   });
 
   it("handles failing queries", () => {
+    cy.intercept("POST", "/api/card/*/query").as("cardQuery");
+
     cy.createNativeQuestion(
       {
         name: "Erroring Model",
@@ -164,14 +166,16 @@ describe("scenarios > models query editor", () => {
     openDetailsSidebar();
 
     cy.findByText("Customize metadata").click();
-    cy.findByText(/Syntax error in SQL/);
+
+    cy.wait("@cardQuery");
+    cy.findByText(/Syntax error in SQL/).should("be.visible");
 
     cy.findByText("Query").click();
-    cy.findByText(/Syntax error in SQL/);
 
-    // Using `text-input` here, which is the textarea HTML element instead of the `ace_content` (div)
-    cy.get(".ace_text-input").type("1");
+    cy.wait("@cardQuery");
+    cy.findByText(/Syntax error in SQL/).should("be.visible");
 
+    cy.get(".ace_content").type("1");
     runNativeQuery();
 
     cy.get(".cellData").contains(1);


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Attempts to fix the annoying and all too prevalent flake in the `frontend/test/metabase/scenarios/models/models-query-editor.cy.spec.js` ("handles failing queries") test

The previous attempt didn't succeed, as we can see from the recent CircleCI logs.

The source of the race condition was that the Cypress started typing before the full card query was loaded/executed. Because of the weird aliasing in the helper function, we've had some conflicts between waiting for `dataset` and for `cardQuery`.

This PR distinguishes between the two and explicitly waits for the `POST /api/card/*/query` to finish before typing.

### Additional context
Even when I try this approach on the original, longer test (before the previous fix attempt) - it works.