### PR TITLE
Remove the ability to delete archived items

### DIFF
--- a/frontend/src/metabase/components/ArchivedItem.jsx
+++ b/frontend/src/metabase/components/ArchivedItem.jsx
@@ -19,7 +19,6 @@ const ArchivedItem = ({
   color = c("text-light"),
   isAdmin = false,
   onUnarchive,
-  onDelete,
 
   selected,
   onToggleSelected,
@@ -36,7 +35,7 @@ const ArchivedItem = ({
       />
     </IconWrapper>
     {name}
-    {isAdmin && (onUnarchive || onDelete) && (
+    {isAdmin && onUnarchive && (
       <span className="ml-auto mr2">
         {onUnarchive && (
           <Tooltip tooltip={t`Unarchive this ${type}`}>
@@ -44,15 +43,6 @@ const ArchivedItem = ({
               onClick={onUnarchive}
               className="cursor-pointer text-brand-hover hover-child ml4"
               name="unarchive"
-            />
-          </Tooltip>
-        )}
-        {onDelete && (
-          <Tooltip tooltip={t`Delete this ${type}`}>
-            <Icon
-              onClick={onDelete}
-              className="cursor-pointer text-brand-hover hover-child ml4"
-              name="trash"
             />
           </Tooltip>
         )}

--- a/frontend/src/metabase/entities/questions.js
+++ b/frontend/src/metabase/entities/questions.js
@@ -28,6 +28,9 @@ const Questions = createEntity({
   },
 
   objectActions: {
+    // permanently deleting a card is deprecated
+    delete: null,
+
     setArchived: ({ id, model }, archived, opts) =>
       Questions.actions.update(
         { id },

--- a/frontend/src/metabase/home/containers/ArchiveApp.jsx
+++ b/frontend/src/metabase/home/containers/ArchiveApp.jsx
@@ -72,14 +72,6 @@ export default class ArchiveApp extends Component {
                           }
                         : null
                     }
-                    onDelete={
-                      item.delete
-                        ? async () => {
-                            await item.delete();
-                            reload();
-                          }
-                        : null
-                    }
                     selected={selection.has(item)}
                     onToggleSelected={() => onToggleSelected(item)}
                     showSelect={selected.length > 0}

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -100,7 +100,6 @@ export const CardApi = {
   create: POST("/api/card"),
   get: GET("/api/card/:cardId"),
   update: PUT("/api/card/:id"),
-  delete: DELETE("/api/card/:cardId"),
   query: POST("/api/card/:cardId/query"),
   query_pivot: POST("/api/card/pivot/:cardId/query"),
   // isfavorite:                  GET("/api/card/:cardId/favorite"),


### PR DESCRIPTION
The card delete endpoint is deprecated. Apparently there's still a way to use it, through the `/archive` page, so I'm removing the endpoint and the associated UI for deleting archived items.