### PR TITLE
Repro #20042: Blank screen when accessing Models with no-data user

### DIFF
--- a/frontend/test/metabase/scenarios/models/reproductions/20042-nodata-user-blank-screen.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/reproductions/20042-nodata-user-blank-screen.cy.spec.js
@@ -1,0 +1,23 @@
+import { restore } from "__support__/e2e/cypress";
+
+describe.skip("issue 20042", () => {
+  beforeEach(() => {
+    cy.intercept("POST", "/api/dataset").as("dataset");
+
+    restore();
+    cy.signInAsAdmin();
+
+    cy.request("PUT", "/api/card/1", { name: "Orders Model", dataset: true });
+
+    cy.signIn("nodata");
+  });
+
+  it("nodata user should not see the blank screen when visiting model (metabase#20042)", () => {
+    cy.visit("/model/1");
+
+    cy.wait("@dataset");
+
+    cy.findByText("Orders Model");
+    cy.contains("37.65");
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #20042 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/models/reproductions/20042-nodata-user-blank-screen.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/152077161-f36c33f2-35e3-4c8f-b4c0-9df5b5166e08.png)

