### PR TITLE
Time-series E2E: really wait for the chart construction

### DIFF
--- a/frontend/test/metabase/scenarios/binning/correctness/time-series.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/correctness/time-series.cy.spec.js
@@ -137,6 +137,7 @@ describe("scenarios > binning > correctness > time series", () => {
         }).should("have.text", selected);
 
         cy.findByText("Done").click();
+        cy.wait("@dataset");
         cy.findByTestId("sidebar-right").should("not.be.visible");
 
         getTitle(titleRegex);
@@ -168,11 +169,11 @@ function getVisualization(binningType) {
 }
 
 function assertOnXYAxisLabels() {
-  cy.get(".y-axis-label")
+  cy.get(".y-axis-label", { timeout: 10000 })
     .should("be.visible")
     .invoke("text")
     .should("eq", "Count");
-  cy.get(".x-axis-label")
+  cy.get(".x-axis-label", { timeout: 10000 })
     .should("be.visible")
     .invoke("text")
     .should("eq", "Created At");


### PR DESCRIPTION
How to test? `yarn test-visual-open` and run `time-series.cy.spec.js`.

**Before**

Sometimes, this happens:

![scenarios  binning  correctness  time series -- should return correct values for Minute (failed)](https://user-images.githubusercontent.com/7288/152082041-a8f554a7-cd47-4699-a093-8a19c80f9202.png)

**After**

It should (almost) never happen anymore.