### PR TITLE
Circle CI: Build with Java 8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,12 +11,12 @@ executors:
   builder:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:circleci-java-11-clj-1.10.3.929-07-27-2021-node-browsers
+      - image: metabase/ci:circleci-java-8-clj-1.10.3.929-07-27-2021-node-browsers
 
   tester:
     working_directory: /home/circleci/metabase/metabase/
     docker:
-      - image: metabase/ci:circleci-java-11-clj-1.10.3.929-07-27-2021-node-browsers
+      - image: metabase/ci:circleci-java-8-clj-1.10.3.929-07-27-2021-node-browsers
       - image: maildev/maildev
       - image: metabase/qa-databases:postgres-sample-12
       - image: metabase/qa-databases:mongo-sample-4.0


### PR DESCRIPTION
We want to start utilizing the Uberjars (OSS and EE) built by CI as the authoritative ones, to be packaged for the official release.
Hence, it makes more sense to build those with JDK 8 (minimizing any compatibility issues), just as when the release manager has to build manually.