### PR TITLE
Fix native query editor resizing gets stuck

### DIFF
--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -974,8 +974,11 @@ export class UnconnectedDataSelector extends Component {
   };
 
   handleClose = () => {
+    const { onClose } = this.props;
     this.setState({ searchText: "" });
-    this.props?.onClose();
+    if (typeof onProps === "function") {
+      onClose();
+    }
   };
 
   getSearchInputPlaceholder = () => {

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
@@ -465,7 +465,9 @@ export default class NativeQueryEditor extends Component {
           {...resizableBoxProps}
           onResizeStop={(e, data) => {
             this.props.handleResize();
-            resizableBoxProps?.onResizeStop(e, data);
+            if (typeof resizableBoxProps?.onResizeStop === "function") {
+              resizableBoxProps.onResizeStop(e, data);
+            }
             this._editor.resize();
           }}
         >


### PR DESCRIPTION
Fixes #20046: after you begin to resize a native query editor, you can't release the resize handle, and moving a cursor keeps resizing the editor. It was caused by incorrect handling of optional callbacks in the query editor. Also fixed the same problem in the `DataSelector`

1. Native query > Sample Dataset
2. Try to resize the editor, you should be able to resize it and then do something else: the editor shouldn't keep resizing following the cursor