### PR TITLE
Fix no-data user can't open a model

### DIFF
--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -232,7 +232,13 @@ export const getQuestion = createSelector(
     // When opening a model, we swap it's `dataset_query`
     // with clean query using the model as a source table,
     // to enable "simple mode" like features
-    return question.isDataset() ? question.composeDataset() : question;
+    // This has to be skipped for users without data permissions
+    // as it would be blocked by the backend as an ad-hoc query
+    // see https://github.com/metabase/metabase/issues/20042
+    const hasDataPermission = !!question.database();
+    return question.isDataset() && hasDataPermission
+      ? question.composeDataset()
+      : question;
   },
 );
 

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -229,8 +229,8 @@ export const getQuestion = createSelector(
       return question.lockDisplay();
     }
 
-    // When opening a dataset, we swap it's `dataset_query`
-    // with clean query using the dataset as a source table,
+    // When opening a model, we swap it's `dataset_query`
+    // with clean query using the model as a source table,
     // to enable "simple mode" like features
     return question.isDataset() ? question.composeDataset() : question;
   },

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -57,11 +57,10 @@ export const getQueryResults = createSelector(
     }
 
     const [result] = queryResults;
-    const { cols, results_metadata } = result.data;
-
-    if (!results_metadata) {
+    if (result.error || !result?.data?.results_metadata) {
       return queryResults;
     }
+    const { cols, results_metadata } = result.data;
 
     function applyMetadataDiff(column) {
       const columnDiff = metadataDiff[column.field_ref];

--- a/frontend/test/metabase/scenarios/models/reproductions/20042-nodata-user-blank-screen.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/reproductions/20042-nodata-user-blank-screen.cy.spec.js
@@ -2,7 +2,7 @@ import { restore } from "__support__/e2e/cypress";
 
 describe.skip("issue 20042", () => {
   beforeEach(() => {
-    cy.intercept("POST", "/api/dataset").as("dataset");
+    cy.intercept("POST", "/api/card/1/query").as("query");
 
     restore();
     cy.signInAsAdmin();
@@ -15,7 +15,7 @@ describe.skip("issue 20042", () => {
   it("nodata user should not see the blank screen when visiting model (metabase#20042)", () => {
     cy.visit("/model/1");
 
-    cy.wait("@dataset");
+    cy.wait("@query");
 
     cy.findByText("Orders Model");
     cy.contains("37.65");

--- a/frontend/test/metabase/scenarios/models/reproductions/20042-nodata-user-blank-screen.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/reproductions/20042-nodata-user-blank-screen.cy.spec.js
@@ -1,6 +1,6 @@
 import { restore } from "__support__/e2e/cypress";
 
-describe.skip("issue 20042", () => {
+describe("issue 20042", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/card/1/query").as("query");
 


### PR DESCRIPTION
Fixes #20042: FE crashes when a no-data user opens a model page. It should actually show a table with results and it shouldn't be possible to modify a query or create a new question based on it.

The problem is a mechanism behind the model page's "simple mode" behavior. When you open a model, the QB behaves as if you opened a raw table: it's not using the `/api/card/:$MODEL_ID/query` endpoint, but the `/api/dataset` one passing `{ "source-table": "card__$MODEL_ID"`. In that way, anything that usually modifies a saved question's query on the UI will just create a new ad-hoc question using the model.

So when a no-data user opens a model page, it also sends a request to `/api/dataset`, and the BE blocks it the same way it would block any new ad-hoc query using a database without permission.

The fix makes the QB actually use `/api/card/:$MODEL_ID/query` if a user is lacking data permissions (and also patches the `wait` in the repro test). This happens _only_ if there are no data permissions, so any attempt to modify the query will result in `403 Forbidden`. The QB was using the card query endpoint for models for some time, but it caused other bugs and was removed in #19952

### To Verify

1. Sign in as a no-data user
2. Open a model, ensure the FE doesn't crash and you can see the results table
3. Ensure you end up on the "You don't have permissions" page when trying to modify a query
4. Sign in as a normal user
5. Open a model and make sure it works as usual and uses the `/api/dataset` endpoint for composing new model-based queries

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/152148654-a49b04b8-1211-451f-9587-521d74a4276e.mp4

**After**

https://user-images.githubusercontent.com/17258145/152148648-45148ac8-643d-4b8f-9618-8a0f7569b681.mp4

