### PR TITLE
Repro #20045: Rerunning a saved Model causes it to add queryhash

### DIFF
--- a/frontend/test/metabase/scenarios/models/reproductions/20045-rerun-model-adds-hash.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/reproductions/20045-rerun-model-adds-hash.cy.spec.js
@@ -1,0 +1,30 @@
+import { restore } from "__support__/e2e/cypress";
+
+describe.skip("issue 20045", () => {
+  beforeEach(() => {
+    cy.intercept("POST", "/api/dataset").as("dataset");
+
+    restore();
+    cy.signInAsAdmin();
+
+    cy.request("PUT", "/api/card/1", { name: "Orders Model", dataset: true });
+  });
+
+  it("should not add query hash on the rerun (metabase#20045)", () => {
+    cy.visit("/model/1");
+
+    cy.wait("@dataset");
+
+    cy.location("pathname").should("eq", "/model/1-orders-model");
+    cy.location("hash").should("eq", "");
+
+    cy.findByTestId("qb-header-action-panel")
+      .find(".Icon-refresh")
+      .click();
+
+    cy.wait("@dataset");
+
+    cy.location("pathname").should("eq", "/model/1-orders-model");
+    cy.location("hash").should("eq", "");
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #20045

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/models/reproductions/20045-rerun-model-adds-hash.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/152155036-569be6c8-b7b7-4e9e-adf1-d563b83b4dc4.png)

