### PR TITLE
Fix data selector crashes and closes after hiding a table

### DIFF
--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -1433,7 +1433,7 @@ const TablePicker = ({
     const sections = [
       {
         name: header,
-        items: tables.map(table => ({
+        items: tables.filter(Boolean).map(table => ({
           name: table.displayName(),
           table: table,
           database: selectedDatabase,

--- a/frontend/test/metabase/scenarios/question/reproductions/19742-data-picker-closes-after-hiding-table.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/19742-data-picker-closes-after-hiding-table.cy.spec.js
@@ -1,0 +1,45 @@
+import { restore, popover } from "__support__/e2e/cypress";
+
+describe("issue 19742", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("shouldn't auto-close the data selector after a table was hidden", () => {
+    cy.visit("/");
+    cy.findByText("New").click();
+    selectFromDropdown("Question");
+    selectFromDropdown("Sample Database");
+
+    cy.icon("gear").click();
+    selectFromDropdown("Admin settings");
+
+    cy.findByText("Data Model").click();
+    hideTable("Orders");
+    cy.findByText("Exit admin").click();
+
+    cy.findByText("New").click();
+    selectFromDropdown("Question");
+    selectFromDropdown("Sample Database");
+
+    popover().within(() => {
+      cy.findByText("Products");
+      cy.findByText("Reviews");
+      cy.findByText("People");
+      cy.findByText("Orders").should("not.exist");
+    });
+  });
+});
+
+function selectFromDropdown(optionName) {
+  popover()
+    .findByText(optionName)
+    .click();
+}
+
+function hideTable(tableName) {
+  cy.findByText(tableName)
+    .find(".Icon-eye_crossed_out")
+    .click({ force: true });
+}

--- a/frontend/test/metabase/scenarios/question/reproductions/19742-data-picker-closes-after-hiding-table.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/19742-data-picker-closes-after-hiding-table.cy.spec.js
@@ -6,6 +6,8 @@ describe("issue 19742", () => {
     cy.signInAsAdmin();
   });
 
+  // In order to reproduce the issue, it's important to only use in-app links
+  // and don't refresh the app state (like by doing cy.visit)
   it("shouldn't auto-close the data selector after a table was hidden", () => {
     cy.visit("/");
     cy.findByText("New").click();


### PR DESCRIPTION
Reproduces #19742 and fixes #19742: the data selector was crashing and closing after hiding any table in "Admin > Data Model".

The issue can only be reproduced if you open a picker, hide the table in "Admin > Data Model" and go back to the picker when you _only_ use in-app links (see how the repro test is running). If you e.g. hide a table in one tab and try to open a picker in another tab, it would work as expected. This makes me think the root cause is a combo of some state memorization in the `DataSelector` + redux state and/or metadata turning into some unexpected state.

### To Verify

1. Open Metabase in a new tab
2. Click "+ Add" at the top right > "Question" > "Sample Dataset". This is important, so the app loads some metadata and tables into redux state
3. _Without leaving the tab or page refreshing_: click the gear icon at the top right > "Admin settings"
4. Open "Data Model" admin tab > "Sample Database" > hide any table
5. _Without leaving the tab or page refreshing_: click the "Exit admin" button at the top right
6. Click "+ Add" at the top right > "Question" > "Sample Dataset"
7. You should see a table picker listing only visible tables

### Demo

Attaching repro test runs as a demo and prove the test works

**Before**

https://user-images.githubusercontent.com/17258145/152157953-0e613b71-5a7d-4cfe-b71f-6a591618b751.mp4

**After**

https://user-images.githubusercontent.com/17258145/152157937-047957e4-f6c7-46c1-b3f6-23adf5bd8c1d.mp4
