### PR TITLE
Fix display of horizontal lines in dashboard text cards

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/Text.css
+++ b/frontend/src/metabase/visualizations/visualizations/Text.css
@@ -155,6 +155,10 @@
   height: auto;
 }
 
+:local .text-card-markdown hr {
+  margin: 0;
+}
+
 :local .single-row {
   margin: 0;
 }

--- a/src/metabase/pulse/markdown.clj
+++ b/src/metabase/pulse/markdown.clj
@@ -228,7 +228,10 @@
       :hard-line-break
       "\n"
 
-      (:heading)
+      :horizontal-line
+      "\n───────────────────\n"
+
+      :heading
       (str "*" joined-content "*\n")
 
       :bold

--- a/test/metabase/pulse/markdown_test.clj
+++ b/test/metabase/pulse/markdown_test.clj
@@ -40,6 +40,10 @@
     (is (= "foo\nbar" (mrkdwn "foo  \nbar")))
     (is (= "foo\nbar" (mrkdwn "foo\\\nbar"))))
 
+  (testing "Horizontal lines are created using box drawing characters"
+    (is (= "───────────────────" (mrkdwn "----")))
+    (is (= "text\n\n───────────────────\ntext" (mrkdwn "text\n\n----\ntext"))))
+
   (testing "Code blocks are preserved"
     (is (= "`code`"                (mrkdwn "`code`")))
     (is (= "```\ncode\nblock```"   (mrkdwn "    code\n    block")))


### PR DESCRIPTION
By default it seems that `hr` elements in Markdown have a large CSS margin, which makes them appear as just a dot. Explicitly setting margin to 0 makes them appear as normal. (Not sure where the original margin was coming from; might be the default browser style?)

I've also updated the Slack code on the backend to render these elements as a horizontal line using box drawing characters, which I think is a decent approximation.

Fixes #12256