### PR TITLE
Fix URL hash appended to model URLs

### DIFF
--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -256,9 +256,10 @@ export const updateUrl = createThunkAction(
 
     if (dirty == null) {
       const originalQuestion = getOriginalQuestion(getState());
+      const isAdHocModel = isAdHocModelQuestion(question, originalQuestion);
       dirty =
         !originalQuestion ||
-        (originalQuestion && question.isDirtyComparedTo(originalQuestion));
+        (!isAdHocModel && question.isDirtyComparedTo(originalQuestion));
     }
 
     // prevent clobbering of hash when there are fake parameters on the question
@@ -1236,7 +1237,13 @@ export const runQuestionQuery = ({
       : true;
 
     if (shouldUpdateUrl) {
-      dispatch(updateUrl(question.card(), { dirty: cardIsDirty }));
+      const isAdHocModel =
+        question.isDataset() &&
+        isAdHocModelQuestion(question, originalQuestion);
+
+      dispatch(
+        updateUrl(question.card(), { dirty: !isAdHocModel && cardIsDirty }),
+      );
     }
 
     if (getIsPreviewing(getState())) {

--- a/frontend/test/metabase/scenarios/models/models-query-editor.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models-query-editor.cy.spec.js
@@ -46,6 +46,7 @@ describe("scenarios > models query editor", () => {
       cy.url()
         .should("include", "/model/1")
         .and("not.include", "/query");
+      cy.location("hash").should("eq", "");
 
       cy.get(".cellData")
         .should("contain", "37.65")

--- a/frontend/test/metabase/scenarios/models/reproductions/20045-rerun-model-adds-hash.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/reproductions/20045-rerun-model-adds-hash.cy.spec.js
@@ -1,6 +1,6 @@
 import { restore } from "__support__/e2e/cypress";
 
-describe.skip("issue 20045", () => {
+describe("issue 20045", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/dataset").as("dataset");
 


### PR DESCRIPTION
Fixes #20045: rerunning or saving a model appends a hash to page URL

The hash is actually a serialized card object containing the `dataset_query`, visualization settings, etc. In that way, you can share a URL to a not-yet-saved question and end up in the same QB state. The hash is only appended if a card is considered `dirty`. The checks were false positive for ad-hoc model questions, so had to extend them to handle models too.

### To Verify

1. Open a model
2. Click the refresh button at the top right
3. The URL should remain `/model/:id-:slug`, without the `#rAnd0mChARACt3rs` part
4. Click the model name to open the details sidebar > "Edit query definition"
5. Change the query and click "Save changes"
6. You should be navigated back to the `/model/:id-:slug` page, the URL shouldn't have the `#rAnd0mChARACt3rs` part

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/152194032-70d5712b-f543-4161-b4f4-a61c6cdfb07c.mp4

**After**

https://user-images.githubusercontent.com/17258145/152194055-929af36b-e45c-4a90-b057-f477dd4f0d77.mp4

