### PR TITLE
Use shareable, local actions to avoid workflow repetitions

### DIFF
--- a/.github/actions/prepare-backend/action.yml
+++ b/.github/actions/prepare-backend/action.yml
@@ -1,0 +1,33 @@
+name: Prepare back-end environment
+inputs:
+  java-version:
+    required: true
+    default: '11'
+  clojure-version:
+    required: true
+    default: '1.10.3.933'
+  m2-cache-key:
+    description: 'Key to cache M2 packages from Maven Central'
+    required: true
+    default: 'm2'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Prepare JDK ${{ inputs.java-version }}
+      uses: actions/setup-java@v2
+      with:
+        java-version: ${{ inputs.java-version }}
+        distribution: 'temurin'
+    - name: Install Clojure CLI
+      shell: bash
+      run: |
+        curl -O https://download.clojure.org/install/linux-install-${{ inputs.clojure-version }}.sh &&
+        sudo bash ./linux-install-${{ inputs.clojure-version }}.sh
+    - name: Get M2 cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.m2
+          ~/.gitlibs
+        key: ${{ runner.os }}-${{ inputs.m2-cache-key }}-${{ hashFiles('**/deps.edn') }}

--- a/.github/actions/prepare-frontend/action.yml
+++ b/.github/actions/prepare-frontend/action.yml
@@ -1,0 +1,21 @@
+name: Prepare front-end environment
+runs:
+  using: "composite"
+  steps:
+    - name: Prepare Node.js
+      uses: actions/setup-node@v2
+      with:
+        node-version: 14.x
+        cache: 'yarn'
+    - name: Get M2 cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-cljs-${{ hashFiles('**/shadow-cljs.edn') }}
+    - name: Get node_modules cache
+      uses: actions/cache@v2
+      with:
+        path: node_modules
+        key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
+    - run: yarn install --frozen-lockfile --prefer-offline
+      shell: bash

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -22,22 +22,10 @@ jobs:
     timeout-minutes: 20
     steps:
     - uses: actions/checkout@v2
-    - name: Prepare JDK 11
-      uses: actions/setup-java@v2
+    - name: Prepare back-end environment
+      uses: ./.github/actions/prepare-backend
       with:
-        java-version: 11
-        distribution: 'temurin'
-    - name: Install Clojure CLI
-      run: |
-        curl -O https://download.clojure.org/install/linux-install-1.10.3.933.sh &&
-        sudo bash ./linux-install-1.10.3.933.sh
-    - name: Get M2 cache
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.m2
-          ~/.gitlibs
-        key: ${{ runner.os }}-eastwood-${{ hashFiles('**/deps.edn') }}
+        m2-cache-key: 'eastwood'
     - name: Compile Java & AOT Sources
       run: |
         source ./bin/prep.sh && prep_deps
@@ -49,22 +37,10 @@ jobs:
     timeout-minutes: 10
     steps:
     - uses: actions/checkout@v2
-    - name: Prepare JDK 11
-      uses: actions/setup-java@v2
+    - name: Prepare back-end environment
+      uses: ./.github/actions/prepare-backend
       with:
-        java-version: 11
-        distribution: 'temurin'
-    - name: Install Clojure CLI
-      run: |
-        curl -O https://download.clojure.org/install/linux-install-1.10.3.933.sh &&
-        sudo bash ./linux-install-1.10.3.933.sh
-    - name: Get M2 cache
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.m2
-          ~/.gitlibs
-        key: ${{ runner.os }}-namespace-decls-${{ hashFiles('**/deps.edn') }}
+        m2-cache-key: 'namespace-decls'
     - name: Compile Java & AOT Sources
       run: |
         source ./bin/prep.sh && prep_deps

--- a/.github/workflows/cljs.yml
+++ b/.github/workflows/cljs.yml
@@ -14,23 +14,7 @@ jobs:
     timeout-minutes: 10
     steps:
     - uses: actions/checkout@v2
-    - name: Prepare Node.js
-      uses: actions/setup-node@v2
-      with:
-        node-version: 14.x
-        cache: 'yarn'
-    - name: Get M2 cache
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.m2
-          ~/.gitlibs
-        key: ${{ runner.os }}-cljs-${{ hashFiles('**/deps.edn') }}
-    - name: Get node_modules cache
-      uses: actions/cache@v2
-      with:
-        path: node_modules
-        key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
-    - run: yarn install --frozen-lockfile --prefer-offline
+    - name: Prepare front-end environment
+      uses: ./.github/actions/prepare-frontend
     - name: Run Cljs tests for shared/ code
       run: yarn run test-cljs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,16 +14,7 @@ jobs:
     timeout-minutes: 10
     steps:
     - uses: actions/checkout@v2
-    - name: Prepare Node.js
-      uses: actions/setup-node@v2
-      with:
-        node-version: 14.x
-        cache: 'yarn'
-    - name: Get node_modules cache
-      uses: actions/cache@v2
-      with:
-        path: node_modules
-        key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
-    - run: yarn install --frozen-lockfile --prefer-offline
+    - name: Prepare front-end environment
+      uses: ./.github/actions/prepare-frontend
     - run: yarn run lint-docs-links
       name: Run docs links checker

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -14,17 +14,8 @@ jobs:
     timeout-minutes: 10
     steps:
     - uses: actions/checkout@v2
-    - name: Prepare Node.js
-      uses: actions/setup-node@v2
-      with:
-        node-version: 14.x
-        cache: 'yarn'
-    - name: Get node_modules cache
-      uses: actions/cache@v2
-      with:
-        path: node_modules
-        key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
-    - run: yarn install --frozen-lockfile --prefer-offline
+    - name: Prepare front-end environment
+      uses: ./.github/actions/prepare-frontend
     - run: yarn run lint-prettier
       name: Run Prettier formatting linter
 
@@ -33,22 +24,8 @@ jobs:
     timeout-minutes: 20
     steps:
     - uses: actions/checkout@v2
-    - name: Prepare Node.js
-      uses: actions/setup-node@v2
-      with:
-        node-version: 14.x
-        cache: 'yarn'
-    - name: Get M2 cache
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-cljs-${{ hashFiles('**/shadow-cljs.edn') }}
-    - name: Get node_modules cache
-      uses: actions/cache@v2
-      with:
-        path: node_modules
-        key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
-    - run: yarn install --frozen-lockfile --prefer-offline
+    - name: Prepare front-end environment
+      uses: ./.github/actions/prepare-frontend
     - run: yarn run lint-eslint
       name: Run ESLint linter
 
@@ -57,17 +34,8 @@ jobs:
     timeout-minutes: 10
     steps:
     - uses: actions/checkout@v2
-    - name: Prepare Node.js
-      uses: actions/setup-node@v2
-      with:
-        node-version: 14.x
-        cache: 'yarn'
-    - name: Get node_modules cache
-      uses: actions/cache@v2
-      with:
-        path: node_modules
-        key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
-    - run: yarn install --frozen-lockfile --prefer-offline
+    - name: Prepare front-end environment
+      uses: ./.github/actions/prepare-frontend
     - run: yarn type-check
       name: Check types
 
@@ -76,22 +44,8 @@ jobs:
     timeout-minutes: 20
     steps:
     - uses: actions/checkout@v2
-    - name: Prepare Node.js
-      uses: actions/setup-node@v2
-      with:
-        node-version: 14.x
-        cache: 'yarn'
-    - name: Get M2 cache
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-cljs-${{ hashFiles('**/shadow-cljs.edn') }}
-    - name: Get node_modules cache
-      uses: actions/cache@v2
-      with:
-        path: node_modules
-        key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
-    - run: yarn install --frozen-lockfile --prefer-offline
+    - name: Prepare front-end environment
+      uses: ./.github/actions/prepare-frontend
     - run: yarn run test-unit --coverage --silent
       name: Run frontend unit tests
     - name: Upload coverage to codecov.io
@@ -105,22 +59,8 @@ jobs:
     timeout-minutes: 14
     steps:
     - uses: actions/checkout@v2
-    - name: Prepare Node.js
-      uses: actions/setup-node@v2
-      with:
-        node-version: 14.x
-        cache: 'yarn'
-    - name: Get M2 cache
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-cljs-${{ hashFiles('**/shadow-cljs.edn') }}
-    - name: Get node_modules cache
-      uses: actions/cache@v2
-      with:
-        path: node_modules
-        key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
-    - run: yarn install --frozen-lockfile --prefer-offline
+    - name: Prepare front-end environment
+      uses: ./.github/actions/prepare-frontend
     - run: yarn run test-timezones
       name: Run frontend timezones tests
 
@@ -131,17 +71,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Prepare Node.js
-        uses: actions/setup-node@v2
-        with:
-          node-version: 14.x
-          cache: 'yarn'
-      - name: Get node_modules cache
-        uses: actions/cache@v2
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
-      - run: yarn install --frozen-lockfile --prefer-offline
+      - name: Prepare front-end environment
+        uses: ./.github/actions/prepare-frontend
       - name: Publish to Chromatic
         uses: chromaui/action@v1
         env:

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -16,22 +16,8 @@ jobs:
     timeout-minutes: 15
     steps:
     - uses: actions/checkout@v2
-    - name: Prepare Node.js
-      uses: actions/setup-node@v2
-      with:
-        node-version: 14.x
-        cache: 'yarn'
-    - name: Get M2 cache
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-cljs-${{ hashFiles('**/shadow-cljs.edn') }}
-    - name: Get node_modules cache
-      uses: actions/cache@v2
-      with:
-        path: node_modules
-        key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
-    - run: yarn install --frozen-lockfile --prefer-offline
+    - name: Prepare front-end environment
+      uses: ./.github/actions/prepare-frontend
     - run: yarn test-unit frontend/test/metabase/lib/expressions/fuzz.tokenizer.unit.spec.js
       env:
         MB_FUZZ: 1
@@ -42,22 +28,8 @@ jobs:
     timeout-minutes: 15
     steps:
     - uses: actions/checkout@v2
-    - name: Prepare Node.js
-      uses: actions/setup-node@v2
-      with:
-        node-version: 14.x
-        cache: 'yarn'
-    - name: Get M2 cache
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-cljs-${{ hashFiles('**/shadow-cljs.edn') }}
-    - name: Get node_modules cache
-      uses: actions/cache@v2
-      with:
-        path: node_modules
-        key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
-    - run: yarn install --frozen-lockfile --prefer-offline
+    - name: Prepare front-end environment
+      uses: ./.github/actions/prepare-frontend
     - run: yarn test-unit frontend/test/metabase/lib/expressions/fuzz.recursive-parser.unit.spec.js
       env:
         MB_FUZZ: 1

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -14,31 +14,13 @@ jobs:
     timeout-minutes: 15
     steps:
     - uses: actions/checkout@v2
-    - name: Prepare Node.js
-      uses: actions/setup-node@v2
+    - name: Prepare front-end environment
+      uses: ./.github/actions/prepare-frontend
+    - name: Prepare back-end environment
+      uses: ./.github/actions/prepare-backend
       with:
-        node-version: 14.x
-        cache: 'yarn'
-    - name: Get node_modules cache
-      uses: actions/cache@v2
-      with:
-        path: node_modules
-        key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
-    - run: yarn install --frozen-lockfile --prefer-offline
-
+        m2-cache-key: 'i18n'
     - run: sudo apt install gettext
-
-    - name: Install Clojure CLI
-      run: |
-        curl -O https://download.clojure.org/install/linux-install-1.10.3.933.sh &&
-        sudo bash ./linux-install-1.10.3.933.sh
-    - name: Get M2 cache
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.m2
-          ~/.gitlibs
-        key: ${{ runner.os }}-i18n-${{ hashFiles('**/deps.edn') }}
 
     - run: ./bin/i18n/update-translation-template
       name: Check i18n tags/make sure template can be built

--- a/.github/workflows/percy-issue-comment.yml
+++ b/.github/workflows/percy-issue-comment.yml
@@ -44,38 +44,11 @@ jobs:
         with:
           ref: ${{ needs.pr_info.outputs.branch_name }}
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Prepare Node.js
-        uses: actions/setup-node@v2
-        with:
-          node-version: 14.x
-          cache: 'yarn'
-      - name: Prepare JDK 8
-        uses: actions/setup-java@v2
-        with:
-          java-version: 8
-          distribution: "temurin"
-      - name: Install Clojure CLI
-        run: |
-          curl -O https://download.clojure.org/install/linux-install-1.10.3.933.sh &&
-          sudo bash ./linux-install-1.10.3.933.sh
-      - name: Check versions
-        run: |
-          echo "Node.js `node --version`"
-          echo "yarn `yarn --version`"
-          java -version
+      - name: Prepare front-end environment
+        uses: ./.github/actions/prepare-frontend
+      - name: Prepare back-end environment
+        uses: ./.github/actions/prepare-backend
 
-      - name: Get node_modules cache
-        uses: actions/cache@v2
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
-      - name: Get M2 cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/deps.edn') }}
-
-      - run: yarn install --frozen-lockfile --prefer-offline
       - run: ./bin/build
 
       - name: Mark with the commit hash
@@ -104,26 +77,11 @@ jobs:
         with:
           ref: ${{ needs.pr_info.outputs.branch_name }}
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Prepare Node.js
-        uses: actions/setup-node@v2
-        with:
-          node-version: 14.x
-          cache: 'yarn'
-      - name: Prepare JDK 8
-        uses: actions/setup-java@v2
-        with:
-          java-version: 8
-          distribution: "temurin"
-      - name: Install Clojure CLI
-        run: |
-          curl -O https://download.clojure.org/install/linux-install-1.10.3.933.sh &&
-          sudo bash ./linux-install-1.10.3.933.sh
-      - name: Check versions
-        run: |
-          echo "Node.js `node --version`"
-          echo "yarn `yarn --version`"
-          java -version
-      - run: yarn install --frozen-lockfile --prefer-offline
+      - name: Prepare front-end environment
+        uses: ./.github/actions/prepare-frontend
+      - name: Prepare back-end environment
+        uses: ./.github/actions/prepare-backend
+
       - uses: actions/download-artifact@v2
         name: Retrieve uberjar artifact
         with:

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -25,38 +25,11 @@ jobs:
       INTERACTIVE: false
     steps:
       - uses: actions/checkout@v2
-      - name: Prepare Node.js
-        uses: actions/setup-node@v2
-        with:
-          node-version: 14.x
-          cache: 'yarn'
-      - name: Prepare JDK 8
-        uses: actions/setup-java@v2
-        with:
-          java-version: 8
-          distribution: "temurin"
-      - name: Install Clojure CLI
-        run: |
-          curl -O https://download.clojure.org/install/linux-install-1.10.3.933.sh &&
-          sudo bash ./linux-install-1.10.3.933.sh
-      - name: Check versions
-        run: |
-          echo "Node.js `node --version`"
-          echo "yarn `yarn --version`"
-          java -version
+      - name: Prepare front-end environment
+        uses: ./.github/actions/prepare-frontend
+      - name: Prepare back-end environment
+        uses: ./.github/actions/prepare-backend
 
-      - name: Get node_modules cache
-        uses: actions/cache@v2
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
-      - name: Get M2 cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/deps.edn') }}
-
-      - run: yarn install --frozen-lockfile --prefer-offline
       - run: ./bin/build
 
       - name: Mark with the commit hash
@@ -78,30 +51,10 @@ jobs:
     needs: build
     steps:
       - uses: actions/checkout@v2
-      - name: Prepare Node.js
-        uses: actions/setup-node@v2
-        with:
-          node-version: 14.x
-          cache: 'yarn'
-      - name: Prepare JDK 8
-        uses: actions/setup-java@v2
-        with:
-          java-version: 8
-          distribution: "temurin"
-      - name: Install Clojure CLI
-        run: |
-          curl -O https://download.clojure.org/install/linux-install-1.10.3.933.sh &&
-          sudo bash ./linux-install-1.10.3.933.sh
-      - name: Check versions
-        run: |
-          echo "Node.js `node --version`"
-          echo "yarn `yarn --version`"
-          java -version
-      - name: Get node_modules cache
-        uses: actions/cache@v2
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
+      - name: Prepare front-end environment
+        uses: ./.github/actions/prepare-frontend
+      - name: Prepare back-end environment
+        uses: ./.github/actions/prepare-backend
 
       - name: Get Cypress cache
         uses: actions/cache@v2
@@ -114,8 +67,6 @@ jobs:
           yarn cypress cache path
           yarn cypress cache list
           yarn cypress verify
-
-      - run: yarn install --frozen-lockfile --prefer-offline
 
       - uses: actions/download-artifact@v2
         name: Retrieve uberjar artifact

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -22,41 +22,12 @@ jobs:
       INTERACTIVE: false
     steps:
     - uses: actions/checkout@v2
-    - name: Prepare Node.js
-      uses: actions/setup-node@v2
-      with:
-        node-version: 14.x
-        cache: 'yarn'
-    - name: Prepare JDK 8
-      uses: actions/setup-java@v2
-      with:
-        java-version: 8
-        distribution: 'temurin'
-    - name: Install Clojure CLI
-      run: |
-        curl -O https://download.clojure.org/install/linux-install-1.10.3.933.sh &&
-        sudo bash ./linux-install-1.10.3.933.sh
-    - name: Check versions
-      run: |
-        echo "Node.js `node --version`"
-        echo "yarn `yarn --version`"
-        java -version
+    - name: Prepare front-end environment
+      uses: ./.github/actions/prepare-frontend
+    - name: Prepare back-end environment
+      uses: ./.github/actions/prepare-backend
 
-    - name: Get node_modules cache
-      uses: actions/cache@v2
-      with:
-        path: node_modules
-        key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
-    - name: Get M2 cache
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.m2
-          ~/.gitlibs
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/deps.edn') }}
-
-    - run: yarn install --frozen-lockfile --prefer-offline
-    - run: MB_EDITION=${{ matrix.edition }} ./bin/build
+    - run: ./bin/build
 
     - name: Mark with the commit hash
       run:  git rev-parse --short HEAD > COMMIT-ID

--- a/.github/workflows/whitespace.yml
+++ b/.github/workflows/whitespace.yml
@@ -13,21 +13,9 @@ jobs:
     timeout-minutes: 5
     steps:
     - uses: actions/checkout@v2
-    - name: Prepare JDK 11
-      uses: actions/setup-java@v2
+    - name: Prepare back-end environment
+      uses: ./.github/actions/prepare-backend
       with:
-        java-version: 11
-        distribution: 'temurin'
-    - name: Install Clojure CLI
-      run: |
-        curl -O https://download.clojure.org/install/linux-install-1.10.3.933.sh &&
-        sudo bash ./linux-install-1.10.3.933.sh
-    - name: Get M2 cache
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.m2
-          ~/.gitlibs
-        key: ${{ runner.os }}-whitespace-linter-${{ hashFiles('**/deps.edn') }}
+        m2-cache-key: 'whitespace-linter'
     - run: clojure -T:whitespace-linter lint
       name: Run Whitespace Linter

--- a/.github/workflows/yaml.yml
+++ b/.github/workflows/yaml.yml
@@ -14,15 +14,6 @@ jobs:
     timeout-minutes: 10
     steps:
     - uses: actions/checkout@v2
-    - name: Prepare Node.js
-      uses: actions/setup-node@v2
-      with:
-        node-version: 14.x
-        cache: 'yarn'
-    - name: Get node_modules cache
-      uses: actions/cache@v2
-      with:
-        path: node_modules
-        key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
-    - run: yarn install --frozen-lockfile --prefer-offline
+    - name: Prepare front-end environment
+      uses: ./.github/actions/prepare-frontend
     - run: yarn run lint-yaml


### PR DESCRIPTION
**Before**

An example CI job in the workflow might look at this. Now imagine this is being repeated again over and over again for other similar jobs.

```yaml
  fe-tests-unit:
    runs-on: buildjet-2vcpu-ubuntu-2004
    timeout-minutes: 20
    steps:
    - uses: actions/checkout@v2
    - name: Prepare Node.js
      uses: actions/setup-node@v2
      with:
        node-version: 14.x
        cache: 'yarn'
    - name: Get M2 cache
      uses: actions/cache@v2
      with:
        path: ~/.m2
        key: ${{ runner.os }}-cljs-${{ hashFiles('**/shadow-cljs.edn') }}
    - name: Get node_modules cache
      uses: actions/cache@v2
      with:
        path: node_modules
        key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
    - run: yarn install --frozen-lockfile --prefer-offline
    - run: yarn run test-unit --coverage --silent
      name: Run frontend unit tests
```

**After**

Much concise:

```yaml
  fe-tests-unit:
    runs-on: buildjet-2vcpu-ubuntu-2004
    timeout-minutes: 20
    steps:
    - uses: actions/checkout@v2
    - name: Prepare front-end environment
      uses: ./.github/actions/prepare-frontend
    - run: yarn run test-unit --coverage --silent
      name: Run frontend unit tests
```