### PR TITLE
Disable model editor's "Save changes" button when there are no changes

### DIFF
--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
@@ -17,7 +17,10 @@ import SnippetSidebar from "metabase/query_builder/components/template_tags/Snip
 import { calcInitialEditorHeight } from "metabase/query_builder/components/NativeQueryEditor/utils";
 
 import { setDatasetEditorTab } from "metabase/query_builder/actions";
-import { getDatasetEditorTab } from "metabase/query_builder/selectors";
+import {
+  getDatasetEditorTab,
+  isResultsMetadataDirty,
+} from "metabase/query_builder/selectors";
 
 import { isLocalField, isSameField } from "metabase/lib/query/field_ref";
 import { getSemanticTypeIcon } from "metabase/lib/schema_metadata";
@@ -45,6 +48,7 @@ const propTypes = {
   question: PropTypes.object.isRequired,
   datasetEditorTab: PropTypes.oneOf(["query", "metadata"]).isRequired,
   metadata: PropTypes.object,
+  isMetadataDirty: PropTypes.object,
   result: PropTypes.object,
   height: PropTypes.number,
   isDirty: PropTypes.bool.isRequired,
@@ -70,6 +74,7 @@ const TABLE_HEADER_HEIGHT = 45;
 function mapStateToProps(state) {
   return {
     datasetEditorTab: getDatasetEditorTab(state),
+    isMetadataDirty: isResultsMetadataDirty(state),
   };
 }
 
@@ -165,6 +170,7 @@ function DatasetEditor(props) {
     datasetEditorTab,
     result,
     metadata,
+    isMetadataDirty,
     height,
     isDirty: isModelQueryDirty,
     setQueryBuilderMode,
@@ -372,8 +378,10 @@ function DatasetEditor(props) {
       return false;
     }
     const hasFieldWithoutDisplayName = fields.some(f => !f.display_name);
-    return !hasFieldWithoutDisplayName && isModelQueryDirty;
-  }, [dataset, fields, isModelQueryDirty]);
+    return (
+      !hasFieldWithoutDisplayName && (isModelQueryDirty || isMetadataDirty)
+    );
+  }, [dataset, fields, isModelQueryDirty, isMetadataDirty]);
 
   const sidebar = getSidebar(props, {
     datasetEditorTab,

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
@@ -47,6 +47,7 @@ const propTypes = {
   metadata: PropTypes.object,
   result: PropTypes.object,
   height: PropTypes.number,
+  isDirty: PropTypes.bool.isRequired,
   setQueryBuilderMode: PropTypes.func.isRequired,
   setDatasetEditorTab: PropTypes.func.isRequired,
   setFieldMetadata: PropTypes.func.isRequired,
@@ -165,6 +166,7 @@ function DatasetEditor(props) {
     result,
     metadata,
     height,
+    isDirty,
     setQueryBuilderMode,
     setDatasetEditorTab,
     setFieldMetadata,
@@ -370,8 +372,8 @@ function DatasetEditor(props) {
       return false;
     }
     const hasFieldWithoutDisplayName = fields.some(f => !f.display_name);
-    return !hasFieldWithoutDisplayName;
-  }, [dataset, fields]);
+    return !hasFieldWithoutDisplayName && isDirty;
+  }, [dataset, fields, isDirty]);
 
   const sidebar = getSidebar(props, {
     datasetEditorTab,

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
@@ -48,7 +48,7 @@ const propTypes = {
   question: PropTypes.object.isRequired,
   datasetEditorTab: PropTypes.oneOf(["query", "metadata"]).isRequired,
   metadata: PropTypes.object,
-  isMetadataDirty: PropTypes.object,
+  isMetadataDirty: PropTypes.bool.isRequired,
   result: PropTypes.object,
   height: PropTypes.number,
   isDirty: PropTypes.bool.isRequired,

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
@@ -166,7 +166,7 @@ function DatasetEditor(props) {
     result,
     metadata,
     height,
-    isDirty,
+    isDirty: isModelQueryDirty,
     setQueryBuilderMode,
     setDatasetEditorTab,
     setFieldMetadata,
@@ -372,8 +372,8 @@ function DatasetEditor(props) {
       return false;
     }
     const hasFieldWithoutDisplayName = fields.some(f => !f.display_name);
-    return !hasFieldWithoutDisplayName && isDirty;
-  }, [dataset, fields, isDirty]);
+    return !hasFieldWithoutDisplayName && isModelQueryDirty;
+  }, [dataset, fields, isModelQueryDirty]);
 
   const sidebar = getSidebar(props, {
     datasetEditorTab,

--- a/frontend/src/metabase/query_builder/reducers.js
+++ b/frontend/src/metabase/query_builder/reducers.js
@@ -398,6 +398,7 @@ export const queryResults = handleActions(
 export const metadataDiff = handleActions(
   {
     [RESET_QB]: { next: () => ({}) },
+    [API_UPDATE_QUESTION]: { next: () => ({}) },
     [SET_METADATA_DIFF]: {
       next: (state, { payload }) => {
         const { field_ref, changes } = payload;

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -375,6 +375,13 @@ export const getResultsMetadata = createSelector(
   result => result && result.data && result.data.results_metadata,
 );
 
+export const isResultsMetadataDirty = createSelector(
+  [getMetadataDiff],
+  metadataDiff => {
+    return Object.keys(metadataDiff).length > 0;
+  },
+);
+
 /**
  * Returns the card and query results data in a format that `Visualization.jsx` expects
  */

--- a/frontend/test/metabase/scenarios/models/models-query-editor.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models-query-editor.cy.spec.js
@@ -29,6 +29,7 @@ describe("scenarios > models query editor", () => {
 
       openDetailsSidebar();
       cy.findByText("Edit query definition").click();
+      cy.button("Save changes").should("be.disabled");
 
       cy.findByText("Row limit").click();
       cy.findByPlaceholderText("Enter a limit").type("2");
@@ -92,6 +93,7 @@ describe("scenarios > models query editor", () => {
       cy.findByText("Edit query definition").click();
 
       cy.url().should("include", "/query");
+      cy.button("Save changes").should("be.disabled");
 
       cy.get(".ace_content").type("{backspace}2");
 


### PR DESCRIPTION
Model editor's "Save changes" button used to be active even if you just opened the editor and there are no changes to be saved. This PR makes sure the button remains disabled until the model's query or metadata are changed.

### To Verify

1. Open a model
2. Ensure the "Save changes" button is disabled by default and you can't click it
3. Modify the query, "Save changes" should become enabled. Revert the changes you've made, the button should become disabled again.
5. Switch to the metadata editor, change some metadata and make sure the button is active again