### PR TITLE
Maps E2E test: ensure that the map data is received

### DIFF
--- a/frontend/test/metabase/scenarios/visualizations/maps.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/maps.cy.spec.js
@@ -99,6 +99,7 @@ describe("scenarios > visualizations > maps", () => {
   });
 
   it("should not assign the full name of the state as the filter value on a drill-through (metabase#14650)", () => {
+    cy.intercept("/app/assets/geojson").as("geojson");
     visitQuestionAdhoc({
       dataset_query: {
         database: 1,
@@ -116,7 +117,10 @@ describe("scenarios > visualizations > maps", () => {
       },
     });
 
+    cy.wait("@geojson");
+
     cy.get(".CardVisualization svg path")
+      .should("be.visible")
       .eq(22)
       .as("texas");
 


### PR DESCRIPTION
How to test? `yarn test-visual-open` and then run `visualizations/maps.cy.spec.js`.

**Before**

Have you seen this failure from time to time? Yeah, that's the problem!

![scenarios  visualizations  maps -- should not assign the full name of the state as the filter value on a drill-through (metabase#14650) (failed)](https://user-images.githubusercontent.com/7288/152219233-49a20d80-2179-4810-b3f7-a02900d68b9d.png)

**After**

This should happen less often. Ideally though, zilch.




