### PR TITLE
Repro #20044: "Explore results" shown for no-data users

### DIFF
--- a/frontend/test/metabase/scenarios/native/reproductions/20044-no-data-sees-explore-results.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/reproductions/20044-no-data-sees-explore-results.cy.spec.js
@@ -1,0 +1,29 @@
+import { restore } from "__support__/e2e/cypress";
+
+const questionDetails = {
+  name: "20044",
+  native: {
+    query: "select 1",
+  },
+};
+
+describe("issue 20044", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("nodata user should not see 'Explore results' (metabase#20044)", () => {
+    cy.createNativeQuestion(questionDetails).then(({ body: { id } }) => {
+      cy.intercept("POST", `/api/card/${id}/query`).as("cardQuery");
+
+      cy.signIn("nodata");
+
+      cy.visit(`/question/${id}`);
+      cy.wait("@cardQuery");
+
+      cy.get(".cellData").contains("1");
+      cy.findByText("Explore results").should("not.exist");
+    });
+  });
+});


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Reproduces #20044 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/native/reproductions/20044-no-data-sees-explore-results.cy.spec.js`
- The test should pass

### Additional notes:
- The bug was fixed in #20065

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/152233266-3cbf1dc7-e303-4909-8fc6-3c8e96cc19ad.png)

