### PR TITLE
When recording activity, indicate if dataset

### DIFF
--- a/src/metabase/events/activity_feed.clj
+++ b/src/metabase/events/activity_feed.clj
@@ -50,8 +50,11 @@
   (log/warn (trs "Don''t know how to process event with model {0}" model-name)))
 
 (defmethod process-activity! :card
-  [_ topic {query :dataset_query, :as object}]
-  (let [details-fn  #(select-keys % [:name :description])
+  [_ topic {query :dataset_query, dataset? :dataset :as object}]
+  (let [details-fn  #(cond-> (select-keys % [:name :description])
+                       ;; right now datasets are all models. In the future this will change so lets keep a breadcumb
+                       ;; around
+                       dataset? (assoc :original-model "card"))
         query       (when (seq query)
                       (try (qp/query->preprocessed query)
                            (catch Throwable e
@@ -61,6 +64,7 @@
     (activity/record-activity!
       :topic       topic
       :object      object
+      :model       (when dataset? "dataset")
       :details-fn  details-fn
       :database-id database-id
       :table-id    table-id)))


### PR DESCRIPTION
Fixes #19741 

Handle writing activity with model "dataset" rather than "card" so your activity feed shows you have edited models.

<img width="971" alt="image" src="https://user-images.githubusercontent.com/6377293/152249695-3e9fc47e-f6d5-4c80-bcf1-ce7a3c9cfbcc.png">

We have some controversy about whether you should be able to delete models, and whether you should even be able to delete cards. If we need to restrict this we can in the future. But right now it is possible to delete cards and therefore possible to delete models ("datasets").

Right now, datasets are all cards. In the future this could change so
record the original model of the dataset as a card. In the future, maybe
we care about the underlying model and this allows us to at least query
and distinguish
