### PR TITLE
Repro #20043: Don't show pins or helper on view-only collections

### DIFF
--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -722,9 +722,13 @@ describe("collection permissions", () => {
               });
 
               it("should be able to access the question's revision history via the revision history button in the header of the query builder", () => {
+                cy.intercept("POST", "/api/card/1/query").as("cardQuery");
+
                 cy.skipOn(user === "nodata");
 
                 cy.visit("/question/1");
+                cy.wait("@cardQuery");
+
                 cy.findByTestId("revision-history-button").click();
                 cy.findByText("Revert").click();
 
@@ -737,9 +741,13 @@ describe("collection permissions", () => {
               });
 
               it("should be able to revert the question via the action button found in the saved question timeline", () => {
+                cy.intercept("POST", "/api/card/1/query").as("cardQuery");
+
                 cy.skipOn(user === "nodata");
 
                 cy.visit("/question/1");
+                cy.wait("@cardQuery");
+
                 cy.findByTestId("saved-question-header-button").click();
                 cy.findByText("History").click();
                 cy.findByText("Revert").click();

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -489,6 +489,13 @@ describe("collection permissions", () => {
               cy.signIn(user);
             });
 
+            it.skip("should not show pins or a helper text (metabase#20043)", () => {
+              cy.visit("/collection/root");
+
+              cy.findByText("Orders in a dashboard");
+              cy.icon("pin").should("not.exist");
+            });
+
             it("should be offered to duplicate dashboard in collections they have `read` access to", () => {
               const { first_name, last_name } = USERS[user];
               cy.visit("/collection/root");


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Reproduces #20043 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/collections/permissions.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/152368406-dbe507ec-64f1-4fd0-a0ee-48623078d2ee.png)

