### PR TITLE
Move Liquibase migration tests to GitHub Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1035,10 +1035,6 @@ workflows:
     jobs:
       - checkout
 
-      - check-migrations:
-          requires:
-            - checkout
-
       - be-deps:
           requires:
             - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -607,25 +607,6 @@ jobs:
           paths:
             - metabase/metabase
 
-  check-migrations:
-    executor:
-      builder
-    steps:
-      - attach-workspace
-      - create-checksum-file:
-          filename: .MIGRATIONS-CHECKSUM
-          find-args: resources/migrations -type f -name '*.yaml'
-      - create-checksum-file:
-          filename: .MIGRATIONS-LINTER-CHECKSUMS
-          find-args: bin/lint-migrations-file -type f -name '*.clj' -or -name 'deps.edn'
-      - run-on-change:
-          checksum: '{{ checksum ".MIGRATIONS-CHECKSUM" }}-{{ checksum ".MIGRATIONS-LINTER-CHECKSUMS" }}'
-          steps:
-            - run:
-                name: Verify Liquibase Migrations
-                command: ./bin/lint-migrations-file.sh
-                no_output_timeout: 15m
-
 ########################################################################################################################
 #                                                       BACKEND                                                        #
 ########################################################################################################################

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -1,0 +1,20 @@
+name: Migrations
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'release-**'
+  pull_request:
+
+jobs:
+
+  check-migrations:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 15
+    steps:
+    - uses: actions/checkout@v2
+    - name: Prepare back-end environment
+      uses: ./.github/actions/prepare-backend
+    - name: Verify Liquibase Migrations
+      run: ./bin/lint-migrations-file.sh


### PR DESCRIPTION
**Before**

The migration checks run on Circle CI.

![image](https://user-images.githubusercontent.com/7288/152374258-1b8ee67f-ba41-4d8a-b770-32b1ccbe963e.png)


**After**

The migration checks run on GitHub Actions. Same spirit as PR #15507, #14701, #14050, #20128 (to leverage faster/tweakable GitHub CI runner, leaving more Circle CI containers to run e.g. Cypress tests).

![image](https://user-images.githubusercontent.com/7288/152374076-d7a54bf4-30ec-474d-b1a7-e628d9bdb25d.png)

![image](https://user-images.githubusercontent.com/7288/152374174-40405a07-7f80-468c-9484-e5cff5a7db0a.png)
