### PR TITLE
Allow to unmap native model column from a real one

### DIFF
--- a/frontend/src/metabase/core/components/SelectButton/SelectButton.stories.tsx
+++ b/frontend/src/metabase/core/components/SelectButton/SelectButton.stories.tsx
@@ -18,3 +18,14 @@ Default.args = {
   hasValue: false,
   fullWidth: false,
 };
+
+export const WithClearBehavior = Template.bind({});
+
+WithClearBehavior.args = {
+  children: "Some value is selected",
+  hasValue: true,
+  onClear: () => {
+    return;
+  },
+  fullWidth: false,
+};

--- a/frontend/src/metabase/core/components/SelectButton/SelectButton.tsx
+++ b/frontend/src/metabase/core/components/SelectButton/SelectButton.tsx
@@ -1,4 +1,9 @@
-import React, { ButtonHTMLAttributes, forwardRef } from "react";
+import React, {
+  ButtonHTMLAttributes,
+  forwardRef,
+  useCallback,
+  useMemo,
+} from "react";
 
 import {
   SelectButtonRoot,
@@ -14,6 +19,7 @@ interface SelectButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   hasValue?: boolean;
   disabled?: boolean;
   fullWidth?: boolean;
+  onClear?: () => void;
 }
 
 const SelectButton = forwardRef(function SelectButton(
@@ -25,10 +31,29 @@ const SelectButton = forwardRef(function SelectButton(
     hasValue = true,
     disabled,
     fullWidth = true,
+    onClear,
     ...rest
   }: SelectButtonProps,
   ref,
 ) {
+  const handleClear = useCallback(
+    event => {
+      if (onClear) {
+        // Required not to trigger the usual SelectButton's onClick handler
+        event.stopPropagation();
+        onClear();
+      }
+    },
+    [onClear],
+  );
+
+  const rightIcon = useMemo(() => {
+    if (hasValue && onClear) {
+      return "close";
+    }
+    return "chevrondown";
+  }, [hasValue, onClear]);
+
   return (
     <SelectButtonRoot
       type="button"
@@ -45,7 +70,11 @@ const SelectButton = forwardRef(function SelectButton(
       <SelectButtonContent data-testid="select-button-content">
         {children}
       </SelectButtonContent>
-      <SelectButtonIcon name="chevrondown" size={12} />
+      <SelectButtonIcon
+        name={rightIcon}
+        size={12}
+        onClick={onClear ? handleClear : undefined}
+      />
     </SelectButtonRoot>
   );
 });

--- a/frontend/src/metabase/core/components/SelectButton/SelectButton.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/SelectButton/SelectButton.unit.spec.tsx
@@ -25,4 +25,46 @@ describe("SelectButton", () => {
 
     expect(screen.getByRole("button")).not.toHaveFocus();
   });
+
+  describe("clear behavior", () => {
+    it("should not display clear icon when the value is selected, but onClear prop is not provided", () => {
+      render(<SelectButton hasValue>{title}</SelectButton>);
+      expect(screen.queryByLabelText("close icon")).not.toBeInTheDocument();
+    });
+
+    it("should not display clear icon when the value is not selected", () => {
+      render(
+        <SelectButton hasValue={false} onClear={jest.fn()}>
+          {title}
+        </SelectButton>,
+      );
+      expect(screen.queryByLabelText("close icon")).not.toBeInTheDocument();
+    });
+
+    it("should call onClear when close icon is clicked", () => {
+      const onClear = jest.fn();
+      render(
+        <SelectButton hasValue onClear={onClear}>
+          {title}
+        </SelectButton>,
+      );
+
+      userEvent.click(screen.getByLabelText("close icon"));
+
+      expect(onClear).toHaveBeenCalledTimes(1);
+    });
+
+    it("should not call usual onClick when close icon is clicked", () => {
+      const onClick = jest.fn();
+      render(
+        <SelectButton hasValue onClick={onClick} onClear={jest.fn()}>
+          {title}
+        </SelectButton>,
+      );
+
+      userEvent.click(screen.getByLabelText("close icon"));
+
+      expect(onClick).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/MappedFieldPicker/MappedFieldPicker.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/MappedFieldPicker/MappedFieldPicker.styled.tsx
@@ -1,0 +1,18 @@
+import styled, { css } from "styled-components";
+import { color } from "metabase/lib/colors";
+import SelectButton from "metabase/core/components/SelectButton";
+import { forwardRefToInnerRef } from "metabase/styled-components/utils";
+
+export const StyledSelectButton = forwardRefToInnerRef(styled(SelectButton)`
+  ${props =>
+    props.hasValue &&
+    css`
+      color: ${color("text-white")} !important;
+      background-color: ${color("brand")};
+      border-color: ${color("brand")};
+
+      .Icon {
+        color: ${color("text-white")};
+      }
+    `};
+`);

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/MappedFieldPicker/MappedFieldPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/MappedFieldPicker/MappedFieldPicker.tsx
@@ -10,12 +10,6 @@ import Fields from "metabase/entities/fields";
 
 import SelectButton from "metabase/core/components/SelectButton";
 
-type CollapsedPickerProps = {
-  isTriggeredComponentOpen: boolean;
-  open: () => void;
-  close: () => void;
-};
-
 type MappedFieldPickerOwnProps = {
   field: {
     value: number | null;

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/MappedFieldPicker/MappedFieldPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/MappedFieldPicker/MappedFieldPicker.tsx
@@ -8,12 +8,12 @@ import { SchemaTableAndFieldDataSelector } from "metabase/query_builder/componen
 import Field from "metabase-lib/lib/metadata/Field";
 import Fields from "metabase/entities/fields";
 
-import SelectButton from "metabase/core/components/SelectButton";
+import { StyledSelectButton } from "./MappedFieldPicker.styled";
 
 type MappedFieldPickerOwnProps = {
   field: {
     value: number | null;
-    onChange: (fieldId: number) => void;
+    onChange: (fieldId: number | null) => void;
   };
   formField: {
     databaseId: number;
@@ -68,15 +68,16 @@ function MappedFieldPicker({
       ? fieldObject.displayName({ includeTable: true })
       : t`None`;
     return (
-      <SelectButton
+      <StyledSelectButton
         hasValue={!!fieldObject}
         tabIndex={tabIndex}
         ref={selectButtonRef}
+        onClear={() => onChange(null)}
       >
         {label}
-      </SelectButton>
+      </StyledSelectButton>
     );
-  }, [fieldObject, tabIndex]);
+  }, [fieldObject, onChange, tabIndex]);
 
   // DataSelector doesn't handle selectedTableId change prop nicely.
   // During the initial load, fieldObject might have `table_id` set to `card__$ID` (retrieved from metadata)


### PR DESCRIPTION
Fixes #20110: when selecting column mapping for a native model, it's impossible to remove the mapping at all. It's only possible to map it to another column.

This PR also adds a new behavior for the `core/components/SelectButton` component. It used to always show the `chevrondown` icon on the right. Now, if you pass an `onClear` prop, it will render `close` icon instead of the chevron when `hasValue` is `true`

### To Verify

1. Create a native model and open its metadata editor
2. Map any column to any real database column (using the "Database column this maps to" field in the metadata editor sidebar)
3. Save the changes
4. Open the metadata editor again and select that column
5. Ensure the mapped field picker is blue (brand color) and has an "x" icon on the right side
6. Click the "x" icon and make sure the mapped field picker is cleared. Note: we don't want inherited metadata to be reset at this moment
7. Save the changes
8. Open the metadata editor again and select that column
9. Ensure the mapped field picker is still empty

### Demo

In the Network tab, you can see that the `id` field property is set to `null` by the frontend and accepted by the backend

https://user-images.githubusercontent.com/17258145/152514408-feea2724-d275-4cdf-8e3e-7eaf2fc2cf9b.mp4
