### PR TITLE
Fix Browse Data section items padding

### DIFF
--- a/frontend/src/metabase/components/EntityItem.jsx
+++ b/frontend/src/metabase/components/EntityItem.jsx
@@ -190,9 +190,6 @@ const EntityItem = ({
         selected={selected}
         disabled={disabled}
         onToggleSelected={onToggleSelected}
-        style={{
-          marginRight: "16px",
-        }}
       />
 
       <div className="overflow-hidden">

--- a/frontend/src/metabase/components/EntityItem.styled.jsx
+++ b/frontend/src/metabase/components/EntityItem.styled.jsx
@@ -44,7 +44,7 @@ export const EntityIconWrapper = styled(IconButtonWrapper)`
 export const EntityItemWrapper = styled.div`
   display: flex;
   align-items: center;
-  padding: ${props => getItemPadding(props.variant)}
+  padding: ${props => getItemPadding(props.variant)};
   color: ${props =>
     props.disabled ? color("text-medium") : color("text-dark")};
 


### PR DESCRIPTION
### Before

<img width="1214" alt="CleanShot 2022-02-03 at 20 16 32@2x" src="https://user-images.githubusercontent.com/17258145/152404090-c6796007-8232-4055-a029-27dd1c375206.png">

### After

<img width="1208" alt="CleanShot 2022-02-03 at 20 16 52@2x" src="https://user-images.githubusercontent.com/17258145/152404076-17fe146e-2e13-4680-ba49-5aea15d455fd.png">