### PR TITLE
Fix revision message timestamp color

### DIFF
--- a/frontend/src/metabase/components/Timeline.styled.jsx
+++ b/frontend/src/metabase/components/Timeline.styled.jsx
@@ -33,7 +33,7 @@ export const ItemHeader = styled.div`
 `;
 
 export const Timestamp = styled.time`
-  color: ${color("text-medium")}
+  color: ${color("text-medium")};
   font-size: 0.875em;
   padding-bottom: 0.5rem;
 `;


### PR DESCRIPTION
From the code I assume it was to be `text-medium`, but a missed semicolon made it skip the style

### Before

<img width="330" alt="CleanShot 2022-02-03 at 20 17 02@2x" src="https://user-images.githubusercontent.com/17258145/152404357-ec9b3cf2-5432-41d2-9ef6-c628444a48cc.png">

### After

<img width="322" alt="CleanShot 2022-02-03 at 20 16 12@2x" src="https://user-images.githubusercontent.com/17258145/152404441-eedfab09-c2cc-4da0-b88f-df76911a64a1.png">