### PR TITLE
Fix pin map lat/lon column selection when query uses :breakout

### DIFF
--- a/src/metabase/api/tiles.clj
+++ b/src/metabase/api/tiles.clj
@@ -205,7 +205,6 @@
         lon-idx (find-fn lon-key)
         points  (for [row rows]
                   [(nth row lat-idx) (nth row lon-idx)])]
-    ;; manual ring response here.  we simply create an inputstream from the byte[] of our image
     (if (= status :completed)
       {:status  200
        :headers {"Content-Type" "image/png"}

--- a/src/metabase/api/tiles.clj
+++ b/src/metabase/api/tiles.clj
@@ -14,7 +14,7 @@
             [schema.core :as s])
   (:import java.awt.Color
            java.awt.image.BufferedImage
-           [java.io ByteArrayInputStream ByteArrayOutputStream]
+           java.io.ByteArrayOutputStream
            javax.imageio.ImageIO))
 
 ;;; --------------------------------------------------- CONSTANTS ----------------------------------------------------

--- a/test/metabase/api/tiles_test.clj
+++ b/test/metabase/api/tiles_test.clj
@@ -46,8 +46,8 @@
                      :query {:source-table 88
                              :fields [[:field 562 nil]
                                       [:field 574 nil] ; lat
-                                      [:field 576 nil] ; lon
-                                      ]
+                                      [:field 576 nil]] ; lon
+
                              :limit 50000}
                      :type :query}]
           (is (= {:database 19
@@ -58,10 +58,10 @@
                           :filter [:inside [:field 574 nil] [:field 576 nil]]}
                   :type :query
                   :async? false}
-                 (clean (tiles/query->tiles-query query
-                                                  {:zoom 2 :x 3 :y 1
-                                                   :lat-field "574"
-                                                   :lon-field "576"})))))))
+                 (clean (#'tiles/query->tiles-query query
+                                                    {:zoom 2 :x 3 :y 1
+                                                     :lat-field [:field 574 nil]
+                                                     :lon-field [:field 576 nil]})))))))
     (testing "native"
       (testing "nests the query, selects fields"
         (let [query {:type :native
@@ -78,10 +78,31 @@
                           :limit  2000}
                   :type :query
                   :async? false}
-                 (clean (tiles/query->tiles-query query
-                                                  {:zoom 2 :x 2 :y 1
-                                                   :lat-field "latitude"
-                                                   :lon-field "longitude"})))))))))
+                 (clean (@#'tiles/query->tiles-query query
+                                                     {:zoom 2 :x 2 :y 1
+                                                      :lat-field [:field "latitude" {:base-type :type/Float}]
+                                                      :lon-field [:field "longitude" {:base-type :type/Float}]})))))))))
+
+(deftest breakout-query-test
+  (testing "the appropriate lat/lon fields are selected from the results, if the query contains a :breakout clause (#20182)"
+    (mt/dataset sample-dataset
+      (with-redefs [tiles/create-tile (fn [_ points] points)
+                    tiles/tile->byte-array identity]
+        (let [result (mt/user-http-request
+                      :rasta :get 200 (format "tiles/7/30/49/%d/%d"
+                                              (mt/id :people :latitude)
+                                              (mt/id :people :longitude))
+                      :query (json/generate-string
+                              {:database (mt/id)
+                               :type :query
+                               :query {:source-table (mt/id :people)
+                                       :breakout [[:field (mt/id :people :latitude)]
+                                                  [:field (mt/id :people :longitude)]]
+                                       :aggregation [[:count]]}}))]
+          (is (= [[36.6163612 -94.5197949]
+                  [36.8177783 -93.8447328]
+                  [36.8311004 -95.0253779]]
+                 (take 3 result))))))))
 
 (deftest failure-test
   (testing "if the query fails, don't attempt to generate a map without any points -- the endpoint should return a 400"
@@ -104,3 +125,10 @@
                         :type     :query
                         :query    {:source-table (mt/id :venues)}
                         :async?   true}))))))
+
+(deftest field-ref-test
+  (testing "Field refs can be constructed from strings representing integer field IDs or field names"
+    (is (= [:field 1 nil]
+           (@#'tiles/field-ref "1")))
+    (is (= [:field "Latitude" {:base-type :type/Float}]
+           (@#'tiles/field-ref "Latitude")))))


### PR DESCRIPTION
The root cause of #20182 is that the `:fields` clause of the query was entirely stripped out by MBQL normalization, since the query also included a `:breakout` clause with both the lat & long fields already included. This caused the results to be returned as `[long lat count]` rather than `[lat long]`, which was expected.

To fix this, I'm using the results metadata in `cols` to determine the index of the lat & long fields in `rows`, correlating them by field ref. This should fix the results for the `:breakout` query case, and not change anything for queries that don't use `:breakout`.

Also a bit of mild refactor and new test cases.

Addresses #20182