### PR TITLE
Ignore hidden/archived tables cards and dashboards in recent list

### DIFF
--- a/test/metabase/api/activity_test.clj
+++ b/test/metabase/api/activity_test.clj
@@ -1,8 +1,8 @@
 (ns metabase.api.activity-test
   "Tests for /api/activity endpoints."
   (:require [clojure.test :refer :all]
+            [java-time :as t]
             [metabase.api.activity :as activity-api]
-            [metabase.db :as mdb]
             [metabase.models.activity :refer [Activity]]
             [metabase.models.card :refer [Card]]
             [metabase.models.dashboard :refer [Dashboard]]
@@ -86,78 +86,90 @@
 ;;  3. `:model_object` is hydrated in each result
 ;;  4. we filter out entries where `:model_object` is nil (object doesn't exist)
 
-(defn- create-view! [user model model-id]
-  (db/insert! ViewLog
-    :user_id  user
-    :model    model
-    :model_id model-id
-    :timestamp :%now)
-  ;; we sleep a bit to ensure no events have the same timestamp
-  ;; sadly, MySQL doesn't support milliseconds so we have to wait a second
-  ;; otherwise our records are out of order and this test fails :(
-  (Thread/sleep (if (= (mdb/db-type) :mysql)
-                  1000
-                  10)))
+(defn- create-views!
+  "Insert views [user-id model model-id]. Reviews are entered a second apart with last review as most recent."
+  [views]
+  (let [views (map (fn [[user model model-id] hours-ago]
+                     {:user_id user, :model model, :model_id model-id
+                      :timestamp (t/plus (t/local-date-time) (t/seconds (- hours-ago)))})
+                   (reverse views)
+                   (range))]
+    (db/insert-many! ViewLog views)))
 
 (deftest recent-views-test
   (mt/with-temp* [Card      [card1 {:name                   "rand-name"
                                     :creator_id             (mt/user->id :crowberto)
                                     :display                "table"
                                     :visualization_settings {}}]
+                  Card      [archived  {:name                   "archived-card"
+                                        :creator_id             (mt/user->id :crowberto)
+                                        :display                "table"
+                                        :archived               true
+                                        :visualization_settings {}}]
                   Dashboard [dash1 {:name        "rand-name"
                                     :description "rand-name"
                                     :creator_id  (mt/user->id :crowberto)}]
                   Table     [table1 {:name        "rand-name"}]
+                  Table     [hidden-table {:name            "hidden table"
+                                           :visibility_type "hidden"}]
                   Card      [dataset {:name                   "rand-name"
                                       :dataset                true
                                       :creator_id             (mt/user->id :crowberto)
                                       :display                "table"
                                       :visualization_settings {}}]]
-    (create-view! (mt/user->id :crowberto) "card"      (:id dataset))
-    (create-view! (mt/user->id :crowberto) "dashboard" (:id dash1))
-    (create-view! (mt/user->id :crowberto) "card"      (:id card1))
-    (create-view! (mt/user->id :crowberto) "card"      36478)
-    (create-view! (mt/user->id :crowberto) "table"     (:id table1))
-    (create-view! (mt/user->id :rasta)     "card"      (:id card1))
-    (is (= [{:cnt          1,
-             :model        "table",
-             :model_id     (:id table1),
-             :model_object {:db_id               (:db_id table1),
-                            :id                  (:id table1),
-                            :name                (:name table1)
-                            :display_name        (:display_name table1)
-                            :initial_sync_status "incomplete"},
-             :user_id      (mt/user->id :crowberto)}
-            {:cnt          1
-             :user_id      (mt/user->id :crowberto)
-             :model        "card"
-             :model_id     (:id card1)
-             :model_object {:id            (:id card1)
-                            :name          (:name card1)
-                            :collection_id nil
-                            :dataset       false
-                            :description   (:description card1)
-                            :display       (name (:display card1))}}
-            {:cnt          1
-             :user_id      (mt/user->id :crowberto)
-             :model        "dashboard"
-             :model_id     (:id dash1)
-             :model_object {:id            (:id dash1)
-                            :name          (:name dash1)
-                            :collection_id nil
-                            :description   (:description dash1)}}
-            {:cnt          1
-             :user_id      (mt/user->id :crowberto)
-             :model        "dataset"
-             :model_id     (:id dataset)
-             :model_object {:id            (:id dataset)
-                            :name          (:name dataset)
-                            :dataset       true
-                            :collection_id nil
-                            :description   (:description dataset)
-                            :display       (name (:display dataset))}}]
-           (for [recent-view (mt/user-http-request :crowberto :get 200 "activity/recent_views")]
-             (dissoc recent-view :max_ts))))))
+    (mt/with-model-cleanup [ViewLog]
+      (create-views! [[(mt/user->id :crowberto) "card"      (:id dataset)]
+                      [(mt/user->id :crowberto) "dashboard" (:id dash1)]
+                      [(mt/user->id :crowberto) "card"      (:id card1)]
+                      [(mt/user->id :crowberto) "card"      36478]
+                      [(mt/user->id :crowberto) "table"     (:id table1)]
+                      ;; most recent for crowberto are archived card and hidden table
+                      [(mt/user->id :crowberto) "card"      (:id archived)]
+                      [(mt/user->id :crowberto) "table"     (:id hidden-table)]
+                      [(mt/user->id :rasta)     "card"      (:id card1)]])
+      (is (= [{:cnt          1,
+               :model        "table",
+               :model_id     (:id table1),
+               :model_object {:db_id               (:db_id table1),
+                              :id                  (:id table1),
+                              :visibility_type     nil
+                              :name                (:name table1)
+                              :display_name        (:display_name table1)
+                              :initial_sync_status "incomplete"},
+               :user_id      (mt/user->id :crowberto)}
+              {:cnt          1
+               :user_id      (mt/user->id :crowberto)
+               :model        "card"
+               :model_id     (:id card1)
+               :model_object {:id            (:id card1)
+                              :name          (:name card1)
+                              :archived      false
+                              :collection_id nil
+                              :dataset       false
+                              :description   (:description card1)
+                              :display       (name (:display card1))}}
+              {:cnt          1
+               :user_id      (mt/user->id :crowberto)
+               :model        "dashboard"
+               :model_id     (:id dash1)
+               :model_object {:id            (:id dash1)
+                              :name          (:name dash1)
+                              :archived      false
+                              :collection_id nil
+                              :description   (:description dash1)}}
+              {:cnt          1
+               :user_id      (mt/user->id :crowberto)
+               :model        "dataset"
+               :model_id     (:id dataset)
+               :model_object {:id            (:id dataset)
+                              :name          (:name dataset)
+                              :archived      false
+                              :dataset       true
+                              :collection_id nil
+                              :description   (:description dataset)
+                              :display       (name (:display dataset))}}]
+             (for [recent-view (mt/user-http-request :crowberto :get 200 "activity/recent_views")]
+               (dissoc recent-view :max_ts)))))))
 
 
 ;;; activities->referenced-objects, referenced-objects->existing-objects, add-model-exists-info


### PR DESCRIPTION
Fixes #20133 

Expectation after patch:
View a question. That question should appear in the recent list which you see when you focus the cursor in the search bar. Archive the question. You should no longer see that question in the recent list when focusing the search bar. Without this patch the recents list was not aware the question had been archived and would show it at the top.

*** Code:
- ignore hidden tables and archived cards/dashboards
- correct docstring to indicate we are only getting 5 not 10 as
previously claimed
- in query, set limit to 8 in the case we get archived or non-existing
things and then take 5 in memory
- select extra properties from models that we need for this
determination

*** Tests:
- for mysql we were inserting views with a thread/sleep of one second
between each. Just compute timestamps seconds apart and do them all at
once. Should save 7 seconds off mysql test runs. verified temporal
spacing works with

```
 MB_DB_CONNECTION_URI="mysql://username:password@localhost:3306/cli" \
 clj -X:dev:test :only metabase.api.activity-test
```
- cleanup these activities we were creating with `mt/with-model-cleanup`
which introduces a big looking diff. But checking diff with whitespace
shows its just an indentation and then add the extra keys needed for
identifying which are archived (:archived and :visibility_type for cards
and tables respectively)
