### PR TITLE
Fix deselecting a column removes all custom expressions from query

### DIFF
--- a/frontend/test/metabase/scenarios/custom-column/reproductions/20229-cc-missing-if-all-columns-not-selected.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/reproductions/20229-cc-missing-if-all-columns-not-selected.cy.spec.js
@@ -19,7 +19,7 @@ const questionDetails = {
   },
 };
 
-describe.skip("issue 20229", () => {
+describe("issue 20229", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/20229

Changing columns in the column selector wiped out `expression` fields except when all columns were selected.

### How to verify
- New -> Question
- Select Orders table
- Add any custom column 
- Visualize — the custom column should exist
- Untick any column from Orders table
- Visualize — ensure the custom column still exist
