### PR TITLE
Repro #20229: Custom columns not appearing in result set when selecting subset of fields

### DIFF
--- a/frontend/test/metabase/scenarios/custom-column/reproductions/20229-cc-missing-if-all-columns-not-selected.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/reproductions/20229-cc-missing-if-all-columns-not-selected.cy.spec.js
@@ -1,0 +1,58 @@
+import { restore, popover, visualize } from "__support__/e2e/cypress";
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
+const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
+
+const questionDetails = {
+  name: "20229",
+  type: "query",
+  query: {
+    "source-table": ORDERS_ID,
+    expressions: {
+      Adjective: [
+        "case",
+        [[[">", ["field", ORDERS.TOTAL, null], 100], "expensive"]],
+        { default: "cheap" },
+      ],
+    },
+    limit: 10,
+  },
+};
+
+describe.skip("issue 20229", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.createQuestion(questionDetails, { visitQuestion: true });
+  });
+
+  it("should display custom column regardless of how many columns are selected (metabase#20229)", () => {
+    ccAssertion();
+
+    // Switch to the notebook view to deselect at least one column
+    cy.icon("notebook").click();
+
+    cy.findAllByTestId("fields-picker").click();
+    popover().within(() => {
+      unselectColumn("Tax");
+    });
+
+    visualize();
+
+    ccAssertion();
+  });
+});
+
+function ccAssertion() {
+  cy.findByText("Adjective");
+  cy.contains("expensive");
+  cy.contains("cheap");
+}
+
+function unselectColumn(column) {
+  cy.findByText(column)
+    .siblings()
+    .find(".Icon-check")
+    .click({ force: true });
+}


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #20229

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/custom-column/reproductions/20229-cc-missing-if-all-columns-not-selected.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/152447026-369d42dd-fdb1-48e6-98b6-760a2b9ca332.png)

