### PR TITLE
Fix table column titles get cut-off when switching to model metadata editor

### DIFF
--- a/frontend/src/metabase/visualizations/components/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive.jsx
@@ -156,8 +156,11 @@ export default class TableInteractive extends Component {
     );
   }
 
-  componentDidUpdate() {
-    if (!this.state.contentWidths) {
+  componentDidUpdate(prevProps) {
+    if (
+      !this.state.contentWidths ||
+      prevProps.renderTableHeaderWrapper !== this.props.renderTableHeaderWrapper
+    ) {
       this._measure();
     } else if (this.props.onContentWidthChange) {
       const total = this.state.columnWidths.reduce((sum, width) => sum + width);

--- a/frontend/src/metabase/visualizations/components/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive.jsx
@@ -238,7 +238,10 @@ export default class TableInteractive extends Component {
           }
         });
 
-        ReactDOM.unmountComponentAtNode(this._div);
+        // Doing this on next tick makes sure it actually gets removed on initial measure
+        setTimeout(() => {
+          ReactDOM.unmountComponentAtNode(this._div);
+        }, 0);
 
         delete this.columnNeedsResize;
 

--- a/frontend/test/metabase/visualizations/components/Visualization-table.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/Visualization-table.unit.spec.js
@@ -19,6 +19,10 @@ const series = (rows, settings = {}) => {
 };
 
 describe("Table", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
   it("should render correct background colors", () => {
     const rows = [[1], [2], [3], [4]];
     const settings = {
@@ -36,6 +40,7 @@ describe("Table", () => {
     const { getByText } = render(
       <Visualization rawSeries={series(rows, settings)} />,
     );
+    jest.runAllTimers();
     const bgColors = rows.map(
       ([v]) => getByText(String(v)).parentNode.style["background-color"],
     );


### PR DESCRIPTION
If you open the model query editor and then click "Metadata" to switch in the metadata editing mode, some table columns got cut off. This happened because `TableInteractive` explicitly measures how wide every column should be. Once we go into the metadata editing mode, the column header component changes, and some columns now require more horizontal space. This PR makes the `TableInteractive` remeasure column widths when the header component renderer is changed

### To Verify

1. Open the model's query editor
2. Switch to metadata editing by clicking the "Metadata" tab at the top bar
3. Ensure column widths are okay and no text is cut-off
4. Switch back to query editing and back to metadata editing a few times, try refreshing the page to ensure it works well all the time

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/152513337-1be52eaf-415b-49ef-8ebd-061ec0483257.mp4

**After**

https://user-images.githubusercontent.com/17258145/152513352-3195b3b9-1944-4499-9a7c-912789ffef16.mp4

