### PR TITLE
Migrate test-build-scripts CI to GitHub Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -756,45 +756,6 @@ jobs:
                 path: /home/circleci/metabase/metabase/target/junit
             - steps: << parameters.after-steps >>
 
-  test-build-scripts:
-    executor: builder
-    steps:
-      - attach-workspace
-      - run-on-change:
-          checksum: '{{ checksum ".BACKEND-CHECKSUMS" }}'
-          steps:
-            - restore-be-deps-cache
-            - run:
-                name: Run metabuild-common build script tests
-                command: |
-                  cd /home/circleci/metabase/metabase/bin/common && clojure -M:test
-                no_output_timeout: 15m
-            - run:
-                name: Run build-drivers build script tests
-                command: |
-                  cd /home/circleci/metabase/metabase/bin/build-drivers && clojure -M:test
-                no_output_timeout: 15m
-            - run:
-                name: Run i18n script tests
-                command: |
-                  cd /home/circleci/metabase/metabase/bin/i18n && clojure -M:test
-                no_output_timeout: 15m
-            - run:
-                name: Run build-mb build script tests
-                command: |
-                  cd /home/circleci/metabase/metabase/bin/build-mb && clojure -M:test
-                no_output_timeout: 15m
-            - run:
-                name: Run release script tests
-                command: |
-                  cd /home/circleci/metabase/metabase/bin/release && clojure -M:test
-                no_output_timeout: 15m
-            - run:
-                name: Run Liquibase migrations linter tests
-                command: |
-                  cd /home/circleci/metabase/metabase/bin/lint-migrations-file && clojure -M:test
-                no_output_timeout: 15m
-
 
 ########################################################################################################################
 #                                                       FRONTEND                                                       #
@@ -1256,10 +1217,6 @@ workflows:
                 source: VERTICA_JDBC_JAR
                 dest: vertica-jdbc-7.1.2-0.jar
           driver: vertica
-
-      - test-build-scripts:
-          requires:
-            - be-deps
 
       - build-uberjar-drivers:
           name: build-uberjar-drivers-<< matrix.edition >>

--- a/.github/workflows/build-scripts.yml
+++ b/.github/workflows/build-scripts.yml
@@ -1,0 +1,46 @@
+name: Build scripts
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'release-**'
+  pull_request:
+
+jobs:
+
+  test-build-scripts:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Prepare back-end environment
+      uses: ./.github/actions/prepare-backend
+      with:
+        m2-cache-key: 'build-scripts'
+    - name: Compile Java & AOT Sources
+      run: source ./bin/prep.sh && prep_deps
+
+    - name: Run metabuild-common build script tests
+      run: clojure -M:test
+      working-directory: bin/common
+      timeout-minutes: 15
+    - name: Run build-drivers build script tests
+      run: clojure -M:test
+      working-directory: bin/build-drivers
+      timeout-minutes: 15
+    - name: Run i18n script tests
+      run: clojure -M:test
+      working-directory: bin/i18n
+      timeout-minutes: 15
+    - name: Run build-mb build script tests
+      run: clojure -M:test
+      working-directory: bin/build-mb
+      timeout-minutes: 15
+    - name: Run release script tests
+      run: clojure -M:test
+      working-directory: bin/release
+      timeout-minutes: 15
+    - name: Run Liquibase migrations linter tests
+      run: clojure -M:test
+      working-directory: bin/lint-migrations-file
+      timeout-minutes: 15


### PR DESCRIPTION
**Before**

The tests run on Circle CI.

![image](https://user-images.githubusercontent.com/7288/152556568-92d43e8f-9996-4303-8250-ef2f0da6d013.png)


**After**

The tests run on GitHub Actions. Same spirit as PR #15507, #14701, #14050, #20128 (to leverage faster/tweakable GitHub CI runner, leaving more Circle CI containers to run e.g. Cypress tests).

![image](https://user-images.githubusercontent.com/7288/152556421-e90231cf-62ef-4561-b3ca-c534613e0f50.png)
