### PR TITLE
Remove `metadata_checksum` from the frontend

### DIFF
--- a/frontend/src/metabase-lib/lib/Question.ts
+++ b/frontend/src/metabase-lib/lib/Question.ts
@@ -1000,11 +1000,9 @@ export default class Question {
 
   setResultsMetadata(resultsMetadata) {
     const metadataColumns = resultsMetadata && resultsMetadata.columns;
-    const metadataChecksum = resultsMetadata && resultsMetadata.checksum;
     return this.setCard({
       ...this.card(),
       result_metadata: metadataColumns,
-      metadata_checksum: metadataChecksum,
     });
   }
 

--- a/frontend/src/metabase/entities/questions.js
+++ b/frontend/src/metabase/entities/questions.js
@@ -100,7 +100,6 @@ const Questions = createEntity({
     "collection_id",
     "collection_position",
     "result_metadata",
-    "metadata_checksum",
   ],
 
   getAnalyticsMetadata([object], { action }, getState) {

--- a/frontend/test/metabase/scenarios/dashboard/parameters-embedded.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/parameters-embedded.cy.spec.js
@@ -269,7 +269,6 @@ const createQuestion = () =>
     visualization_settings: {},
     collection_id: null,
     result_metadata: null,
-    metadata_checksum: null,
   });
 
 const createDashboard = () =>

--- a/frontend/test/metabase/visualizations/components/LineAreaBarChart.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/LineAreaBarChart.unit.spec.js
@@ -114,7 +114,6 @@ const millisecondCard = {
       },
     ],
     results_metadata: {
-      checksum: "H2XV8wuuBkFrxukvDt+Ehw==",
       columns: [
         {
           base_type: "type/BigInteger",
@@ -292,7 +291,6 @@ const dateTimeCard = {
       },
     ],
     results_metadata: {
-      checksum: "XIqamTTUJ9nbWlTwKc8Bpg==",
       columns: [
         {
           base_type: "type/DateTime",
@@ -424,7 +422,6 @@ const numberCard = {
       },
     ],
     results_metadata: {
-      checksum: "jTfxUHHttR31J8lQBqJ/EA==",
       columns: [
         {
           base_type: "type/Integer",


### PR DESCRIPTION
Results metadata is was a backend thing, but the FE still had a few mentions of it here and there. Now it was removed to make metadata editable for models, so this PR removes its mentions from the FE too