### PR TITLE
Run selected E2E groups with GitHub Actions

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,0 +1,127 @@
+name: E2E Tests
+
+on:
+  push:
+    branches:
+      - 'master'
+
+jobs:
+
+  build:
+    runs-on: buildjet-2vcpu-ubuntu-2004
+    timeout-minutes: 25
+    strategy:
+      matrix:
+        edition: [oss]
+    env:
+      MB_EDITION: ${{ matrix.edition }}
+      INTERACTIVE: false
+    steps:
+    - uses: actions/checkout@v2
+    - name: Prepare front-end environment
+      uses: ./.github/actions/prepare-frontend
+    - name: Prepare back-end environment
+      uses: ./.github/actions/prepare-backend
+
+    - name: Java/AOT prep
+      run: |
+        source "./bin/prep.sh"
+        prep_deps
+
+    - run: ./bin/build version
+    - run: ./bin/build translations
+    - run: ./bin/build frontend
+    - run: ./bin/build licenses
+    - run: ./bin/build drivers
+    - run: ./bin/build uberjar
+
+    - name: Mark with the commit hash
+      run:  git rev-parse --short HEAD > COMMIT-ID
+    - name: Calculate SHA256 checksum
+      run: sha256sum ./target/uberjar/metabase.jar > SHA256.sum
+    - name: Upload JARs as artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: metabase-${{ matrix.edition }}-uberjar
+        path: |
+          ./target/uberjar/metabase.jar
+          ./COMMIT-ID
+          ./SHA256.sum
+
+  e2e-tests:
+    runs-on: buildjet-2vcpu-ubuntu-2004
+    timeout-minutes: 20
+    needs: build
+    name: e2e-tests-${{ matrix.folder }}-${{ matrix.edition }}
+    env:
+      MB_EDITION: ${{ matrix.edition }}
+      DISPLAY: ""
+      QA_DB_ENABLED: true
+      ENTERPRISE_TOKEN: ${{ secrets.ENTERPRISE_TOKEN }}
+    strategy:
+      fail-fast: false
+      matrix:
+        edition: [oss]
+        folder:
+          - "custom-column"
+          - "downloads"
+          - "moderation"
+          - "native"
+          - "smoketest"
+    services:
+      maildev:
+        image: maildev/maildev
+        ports:
+          - "80:80"
+          - "25:25"
+      postgres-sample:
+        image: metabase/qa-databases:postgres-sample-12
+        ports:
+          - "5432:5432"
+      mongo-sample:
+        image: metabase/qa-databases:mongo-sample-4.0
+        ports:
+          - 27017:27017
+      mysql-sample:
+        image: metabase/qa-databases:mysql-sample-8
+        ports:
+          - 3306:3306
+    steps:
+    - uses: actions/checkout@v2
+    - name: Prepare front-end environment
+      uses: ./.github/actions/prepare-frontend
+    - name: Prepare back-end environment
+      uses: ./.github/actions/prepare-backend
+
+    - name: Get Cypress cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/Cypress
+        key: ${{ runner.os }}-Cypress-${{ hashFiles('**/yarn.lock') }}
+    - name: Ensure that Cypress is ready
+      run: |
+        yarn cypress install
+        yarn cypress cache path
+        yarn cypress cache list
+        yarn cypress verify
+
+    - uses: actions/download-artifact@v2
+      name: Retrieve uberjar artifact for ${{ matrix.edition }}
+      with:
+        name: metabase-${{ matrix.edition }}-uberjar
+    - name: Get the version info
+      run: |
+        jar xf target/uberjar/metabase.jar version.properties
+        mv version.properties resources/
+
+    - run: yarn run test-cypress-no-build --folder ${{ matrix.folder }}
+      name: Run Cypress tests on ${{ matrix.folder }}
+      env:
+        TERM: xterm
+    - name: Upload Cypress recording upon failure
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: cypress-recording-${{ matrix.folder }}-${{ matrix.edition }}
+        path: ./cypress
+        if-no-files-found: ignore

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -98,7 +98,7 @@ jobs:
       with:
         path: ~/.cache/Cypress
         key: ${{ runner.os }}-Cypress-${{ hashFiles('**/yarn.lock') }}
-    - name: Ensure that Cypress is ready
+    - name: Ensure that Cypress executable is ready
       run: |
         yarn cypress install
         yarn cypress cache path


### PR DESCRIPTION
@nemanjaglumac and I would like to experiment with running Cypress-based E2E tests on GitHub Actions. We want to observe the stability and suitability when dealing with our complex test suite.

This PR adds a few selected E2E groups to run on `master`. Note that this PR **does not remove** any existing E2E tests on Circle CI at all. Also, it **does not affect** any development workflow at all (since it's not triggered on PR nor will it block any PR).

Once it is merged, there will be a new action:

![image](https://user-images.githubusercontent.com/7288/152589788-b06913ed-58e9-4ddb-8bad-3d65b4c0f078.png)