### PR TITLE
disable leaflet pointer-events in collection visualizations

### DIFF
--- a/frontend/src/metabase/collections/components/CollectionCardVisualization/CollectionCardVisualization.styled.jsx
+++ b/frontend/src/metabase/collections/components/CollectionCardVisualization/CollectionCardVisualization.styled.jsx
@@ -32,4 +32,9 @@ export const VizCard = styled(Card)`
       color: ${color("brand")};
     }
   }
+
+  .leaflet-container,
+  .leaflet-container * {
+    pointer-events: none !important;
+  }
 `;


### PR DESCRIPTION
Fixes #20262 

Most visualizations can't be interacted with if you don't have a `onChangeCardAndRun` function on the `Visualization` component, but this is not true for visualizations that rely on leaflet, as leaflet has some fairly specific css selectors that set `pointer-events` to `all` so that the map can be dragged. In order to disable the dragging of the map I am forced to override these rules. Setting `pointer-events: none` on the `leaflet-container` is not sufficient; it disables dragging in most places on the map but pins and various panes have more specific rules that override a simple `.leaflet-container { ... }` rule, so I've also added `.leaflet-container * { pointer-events: none !important; }` as I'm sure there are various niche features of leaflet that have specific selectors turning pointer-events back on. Pinned visualizations aren't intended to be interacted with, so I don't think this should be too offensive to people, but let me know if there are better options like some sort of disabled prop (I didn't see one implemented).

https://user-images.githubusercontent.com/13057258/152583363-82079370-e1a5-4d0a-b7c0-effd29763d21.mov
