### PR TITLE
Changing circleCI resource for be-tests-sparksql-ee

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1238,6 +1238,7 @@ workflows:
 
       - test-driver:
           name: be-tests-sparksql-ee
+          resource_class: large
           requires:
             - be-tests-java-8-ee
           e: sparksql

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,6 +178,7 @@ executors:
     docker:
       - image: metabase/ci:circleci-java-11-clj-1.10.3.929-07-27-2021-node-browsers
       - image: metabase/spark:2.1.1
+    resource_class: large
 
   vertica:
     working_directory: /home/circleci/metabase/metabase/
@@ -1238,7 +1239,6 @@ workflows:
 
       - test-driver:
           name: be-tests-sparksql-ee
-          resource_class: large
           requires:
             - be-tests-java-8-ee
           e: sparksql


### PR DESCRIPTION
Currently, the workflow `be-tests-sparksql-ee` is one of the offenses in time constraints on circle CI.

Upon analysis was discovered that the machine used is a `Medium` (2 CPU / 4 GB Ram) and is hitting 100% constantly.

<img width="1741" alt="Screen Shot 2022-02-04 at 15 47 55" src="https://user-images.githubusercontent.com/17742979/152585757-a7bf148b-b6ab-4c7f-acb2-00fa6a7e6a33.png">

The goal with this PR is to use a `Large` instance (4 CPU / 8GB Ram) and analyze the gains for that specific workflow.

