### PR TITLE
Changing circleCI resource to handle be-tests-sparksql-ee faster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,6 +178,7 @@ executors:
     docker:
       - image: metabase/ci:circleci-java-11-clj-1.10.3.929-07-27-2021-node-browsers
       - image: metabase/spark:2.1.1
+    resource_class: large
 
   vertica:
     working_directory: /home/circleci/metabase/metabase/


### PR DESCRIPTION
Currently, the workflow `be-tests-sparksql-ee` is one of the offenses in time constraints on circle CI.

Upon analysis was discovered that the machine used is a Medium (2 CPU / 4 GB Ram) and is hitting 100% constantly.

<img width="1741" alt="Screen Shot 2022-02-04 at 15 47 55" src="https://user-images.githubusercontent.com/17742979/152591111-c015653d-1c7e-4882-bde5-96be7c5d66f5.png">


The goal with this PR is to use a Large instance (4 CPU / 8GB Ram) and analyze the gains for that specific workflow.
