### PR TITLE
Remove "Filtering on this field" form field for models

### DIFF
--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
@@ -149,7 +149,6 @@ const FIELDS = [
   "semantic_type",
   "fk_target_field_id",
   "visibility_type",
-  "has_field_values",
   "settings",
 ];
 

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.jsx
@@ -14,7 +14,6 @@ import Radio from "metabase/core/components/Radio";
 import {
   field_visibility_types,
   field_semantic_types,
-  has_field_values_options,
 } from "metabase/lib/core";
 import { isLocalField, isSameField } from "metabase/lib/query/field_ref";
 import { isFK, getSemanticTypeIcon } from "metabase/lib/schema_metadata";
@@ -77,10 +76,8 @@ function getFormFields({ dataset }) {
       value: type.id,
     }));
 
-  return fieldFormValues => {
-    const hasMappedColumn =
-      !dataset.isNative() || typeof fieldFormValues.id === "number";
-    return [
+  return fieldFormValues =>
+    [
       { name: "display_name", title: t`Display name` },
       {
         name: "description",
@@ -113,18 +110,7 @@ function getFormFields({ dataset }) {
         type: "radio",
         options: visibilityTypeOptions,
       },
-      // has_field_values is only handled properly when the field has an ID
-      // for native data models, the field has to be mapped to a real DB column
-      // before `has_field_values` can be set
-      hasMappedColumn && {
-        name: "has_field_values",
-        title: t`Filtering on this field`,
-        info: t`When this field is used in a filter, what should people use to enter the value they want to filter on?`,
-        type: "select",
-        options: has_field_values_options,
-      },
     ].filter(Boolean);
-  };
 }
 
 const VIEW_AS_FIELDS = ["view_as", "link_text", "link_url"];
@@ -178,7 +164,6 @@ function DatasetFieldMetadataSidebar({
       semantic_type: field.semantic_type,
       fk_target_field_id: field.fk_target_field_id || null,
       visibility_type: field.visibility_type || "normal",
-      has_field_values: field.has_field_values || "search",
     };
     if (dataset.isNative()) {
       values.id = field.id;
@@ -302,15 +287,6 @@ function DatasetFieldMetadataSidebar({
     [onFieldMetadataChange],
   );
 
-  const onHasFieldValuesChange = useCallback(
-    value => {
-      onFieldMetadataChange({
-        has_field_values: value,
-      });
-    },
-    [onFieldMetadataChange],
-  );
-
   return (
     <SidebarContent>
       <AnimatableContent
@@ -379,10 +355,6 @@ function DatasetFieldMetadataSidebar({
                         allowlist={VIEW_AS_RELATED_FORMATTING_OPTIONS}
                       />
                     </ViewAsFieldContainer>
-                    <FormField
-                      name="has_field_values"
-                      onChange={onHasFieldValuesChange}
-                    />
                   </React.Fragment>
                 ) : (
                   <ColumnSettings


### PR DESCRIPTION
This PR removes the "Filtering on this field" (`has_field_values` under the hood) form field from the model's metadata editor. With the current limitations to how we cache field values for filtering, this field can't actually bring a lot of value, so we're removing it until we have more flexibility for that.

![CleanShot 2022-02-04 at 21 29 21@2x](https://user-images.githubusercontent.com/17258145/152591580-e203636c-8995-48b8-abbd-29879addb5fe.png)

### To Verify

1. Open model metadata editor
2. Ensure there is no "Filtering on this field" form field in the sidebar