### PR TITLE
Hide pin action button when user can't pin

### DIFF
--- a/frontend/src/metabase/components/EntityItem.jsx
+++ b/frontend/src/metabase/components/EntityItem.jsx
@@ -93,6 +93,7 @@ function EntityItemMenu({
 }) {
   const isPinned = isItemPinned(item);
   const showPinnedAction = onPin && isPinned;
+  const showUnpinnedAction = onPin && !isPinned;
 
   const actions = useMemo(
     () =>
@@ -138,7 +139,7 @@ function EntityItemMenu({
   }
   return (
     <EntityMenuContainer align="center">
-      {showPinnedAction && (
+      {showUnpinnedAction && (
         <Tooltip tooltip={t`Pin this`}>
           <PinButton icon="pin" onClick={onPin} />
         </Tooltip>

--- a/frontend/src/metabase/components/EntityItem.jsx
+++ b/frontend/src/metabase/components/EntityItem.jsx
@@ -138,7 +138,7 @@ function EntityItemMenu({
   }
   return (
     <EntityMenuContainer align="center">
-      {!isPinned && (
+      {showPinnedAction && (
         <Tooltip tooltip={t`Pin this`}>
           <PinButton icon="pin" onClick={onPin} />
         </Tooltip>

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -489,7 +489,7 @@ describe("collection permissions", () => {
               cy.signIn(user);
             });
 
-            it.skip("should not show pins or a helper text (metabase#20043)", () => {
+            it("should not show pins or a helper text (metabase#20043)", () => {
               cy.visit("/collection/root");
 
               cy.findByText("Orders in a dashboard");


### PR DESCRIPTION
Fixes #20043 

The `showPinnedAction` boolean includes whether or not the `onPin` function is defined. For view-only users, `onPin` is undefined.

The banner mentioned in the bug report is no longer shown, so nothing needed there.

**Testing**
1. Create a user and set their **Collection** permissions on a collection with unpinned items to **view only**
2. With this user navigate to the above collection and see that there no longer is a pin icon in the table 