### PR TITLE
🤖  Manual backport: Allow to unmap native model column from a real one 

### DIFF
--- a/frontend/src/metabase/components/SelectButton.tsx
+++ b/frontend/src/metabase/components/SelectButton.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, HTMLAttributes } from "react";
+import React, { forwardRef, useMemo, useCallback, HTMLAttributes } from "react";
 import cx from "classnames";
 import Icon from "metabase/components/Icon";
 
@@ -6,12 +6,31 @@ type Props = HTMLAttributes<HTMLDivElement> & {
   hasValue?: boolean;
   children: React.ReactNode;
   left?: React.ReactNode;
+  onClear?: () => void;
 };
 
 const SelectButton = forwardRef<HTMLDivElement, Props>(function SelectButton(
-  { className, children, left, hasValue, ...props }: Props,
+  { className, children, left, hasValue, onClear, ...props }: Props,
   ref,
 ) {
+  const handleClear = useCallback(
+    event => {
+      if (onClear) {
+        // Required not to trigger the usual SelectButton's onClick handler
+        event.stopPropagation();
+        onClear();
+      }
+    },
+    [onClear],
+  );
+
+  const rightIcon = useMemo(() => {
+    if (hasValue && onClear) {
+      return "close";
+    }
+    return "chevrondown";
+  }, [hasValue, onClear]);
+
   return (
     <div
       {...props}
@@ -24,8 +43,9 @@ const SelectButton = forwardRef<HTMLDivElement, Props>(function SelectButton(
       <span className="AdminSelect-content mr1">{children}</span>
       <Icon
         className="AdminSelect-chevron flex-align-right"
-        name="chevrondown"
+        name={rightIcon}
         size={12}
+        onClick={onClear ? handleClear : undefined}
       />
     </div>
   );

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/MappedFieldPicker/MappedFieldPicker.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/MappedFieldPicker/MappedFieldPicker.styled.tsx
@@ -1,9 +1,19 @@
-import styled from "styled-components";
-
+import styled, { css } from "styled-components";
+import { color } from "metabase/lib/colors";
 import SelectButton from "metabase/components/SelectButton";
-
 import { forwardRefToInnerRef } from "metabase/styled-components/utils";
 
 export const StyledSelectButton = forwardRefToInnerRef(styled(SelectButton)`
   width: 100%;
+
+  ${props =>
+    props.hasValue &&
+    css`
+      color: ${color("text-white")} !important;
+      background-color: ${color("brand")};
+      border-color: ${color("brand")};
+      .Icon {
+        color: ${color("text-white")};
+      }
+    `};
 `);

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/MappedFieldPicker/MappedFieldPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/MappedFieldPicker/MappedFieldPicker.tsx
@@ -19,7 +19,7 @@ type CollapsedPickerProps = {
 type MappedFieldPickerOwnProps = {
   field: {
     value: number | null;
-    onChange: (fieldId: number) => void;
+    onChange: (fieldId: number | null) => void;
   };
   formField: {
     databaseId: number;
@@ -84,12 +84,13 @@ function MappedFieldPicker({
             }
           }}
           ref={selectButtonRef}
+          onClear={() => onChange(null)}
         >
           {label}
         </StyledSelectButton>
       );
     },
-    [fieldObject, tabIndex],
+    [fieldObject, onChange, tabIndex],
   );
 
   // DataSelector doesn't handle selectedTableId change prop nicely.


### PR DESCRIPTION
Had to backport #20219 manually as it changes `SelectButton` that was moved to `core/components` on `master`