### PR TITLE
Backport -- Hide pin action button when user can't pin (#20272)

### DIFF
--- a/frontend/src/metabase/components/EntityItem.jsx
+++ b/frontend/src/metabase/components/EntityItem.jsx
@@ -93,6 +93,7 @@ function EntityItemMenu({
 }) {
   const isPinned = isItemPinned(item);
   const showPinnedAction = onPin && isPinned;
+  const showUnpinnedAction = onPin && !isPinned;
 
   const actions = useMemo(
     () =>
@@ -138,7 +139,7 @@ function EntityItemMenu({
   }
   return (
     <EntityMenuContainer align="center">
-      {!isPinned && (
+      {showUnpinnedAction && (
         <Tooltip tooltip={t`Pin this`}>
           <PinButton icon="pin" onClick={onPin} />
         </Tooltip>

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -485,6 +485,13 @@ describe("collection permissions", () => {
               cy.signIn(user);
             });
 
+            it("should not show pins or a helper text (metabase#20043)", () => {
+              cy.visit("/collection/root");
+
+              cy.findByText("Orders in a dashboard");
+              cy.icon("pin").should("not.exist");
+            });
+
             it("should be offered to duplicate dashboard in collections they have `read` access to", () => {
               const { first_name, last_name } = USERS[user];
               cy.visit("/collection/root");


### PR DESCRIPTION
Manual backport of https://github.com/metabase/metabase/pull/20272; the repro wasn't backported, so there was a conflict