### PR TITLE
Reinforce time-series binning e2e test

### DIFF
--- a/frontend/test/metabase/scenarios/binning/correctness/time-series.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/correctness/time-series.cy.spec.js
@@ -27,7 +27,10 @@ describe("scenarios > binning > correctness > time series", () => {
 
     cy.createQuestion(questionDetails, { visitQuestion: true });
 
-    cy.findByText("Summarize").click();
+    cy.findByTestId("qb-header-action-panel")
+      .contains("Summarize")
+      .click();
+
     openPopoverFromDefaultBucketSize("Created At", "by month");
   });
 


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Removes the potential flakiness in `time-series` e2e binning test. After the previous simplification of this test (see https://github.com/metabase/metabase/pull/20237), it works as expected on `master`, but the [backport](https://github.com/metabase/metabase/pull/20241) is constantly failing in CI.
- The test cannot click on the "Summarize" string, probably because it finds multiple strings (if notebook is also in the DOM)

Example of the failure on the release branch:
https://app.circleci.com/pipelines/github/metabase/metabase/28676/workflows/7b8d75a7-8093-40f6-9d2a-92fb39a67489/jobs/1403987/artifacts

![image](https://user-images.githubusercontent.com/31325167/152767752-c500dd5b-9d6e-40f8-8e55-f3b761260922.png)

This PR makes it really explicit as to which "Summarize" should Cypress click on.

### Additional notes
I will prepare a larger PR with the helper function for "Summarize". This PR is needed to unblock this [backport](https://github.com/metabase/metabase/pull/20241).