### PR TITLE
Disallow moving items to a collection it's already in via drag-n-drop

### DIFF
--- a/frontend/src/metabase/containers/dnd/CollectionDropTarget.jsx
+++ b/frontend/src/metabase/containers/dnd/CollectionDropTarget.jsx
@@ -15,10 +15,10 @@ const CollectionDropTarget = DropTarget(
       if (collection.can_write === false) {
         return false;
       }
-      const droppingToSameDashboard =
+      const droppingToSameCollection =
         canonicalCollectionId(item.collection_id) ===
         canonicalCollectionId(collection.id);
-      return item.model !== "collection" && !droppingToSameDashboard;
+      return item.model !== "collection" && !droppingToSameCollection;
     },
   },
   (connect, monitor) => ({

--- a/frontend/src/metabase/containers/dnd/CollectionDropTarget.jsx
+++ b/frontend/src/metabase/containers/dnd/CollectionDropTarget.jsx
@@ -1,21 +1,24 @@
 import { DropTarget } from "react-dnd";
-
+import { canonicalCollectionId } from "metabase/collections/utils";
 import DropArea from "./DropArea";
 import { MoveableDragTypes } from ".";
 
 const CollectionDropTarget = DropTarget(
   MoveableDragTypes,
   {
-    drop(props, monitor, component) {
+    drop(props) {
       return { collection: props.collection };
     },
     canDrop(props, monitor) {
+      const { collection } = props;
       const { item } = monitor.getItem();
-      // can't drop if can't write the  collection
-      if (props.collection.can_write === false) {
+      if (collection.can_write === false) {
         return false;
       }
-      return item.model !== "collection" || item.id !== props.collection.id;
+      const droppingToSameDashboard =
+        canonicalCollectionId(item.collection_id) ===
+        canonicalCollectionId(collection.id);
+      return item.model !== "collection" && !droppingToSameDashboard;
     },
   },
   (connect, monitor) => ({


### PR DESCRIPTION
### To Verify

1. Open collections page
2. Grab a question/dashboard/model with a cursor and try to drop it onto the collection it's already in the sidebar
3. Ensure that nothing happens when you drop an item: there is no "Moved item" toast at the bottom left and the items stays in place
4. Make sure it works the same with "Our analytics"
5. Make sure you can move items to other collections via DND