### PR TITLE
Make Ad hoc question e2e helper automatically wait for the query results

### DIFF
--- a/frontend/test/__support__/e2e/helpers/e2e-ad-hoc-question-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-ad-hoc-question-helpers.js
@@ -6,7 +6,7 @@ export function adhocQuestionHash(question) {
   return btoa(unescape(encodeURIComponent(JSON.stringify(question))));
 }
 
-export function visitQuestionAdhoc(question) {
+export function visitQuestionAdhoc(question, { callback } = {}) {
   const {
     display,
     dataset_query: { type },
@@ -21,5 +21,7 @@ export function visitQuestionAdhoc(question) {
 
   cy.visit("/question#" + adhocQuestionHash(question));
 
-  cy.wait("@" + alias);
+  cy.wait("@" + alias).then(xhr => {
+    callback && callback(xhr);
+  });
 }

--- a/frontend/test/__support__/e2e/helpers/e2e-ad-hoc-question-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-ad-hoc-question-helpers.js
@@ -7,15 +7,7 @@ export function adhocQuestionHash(question) {
 }
 
 export function visitQuestionAdhoc(question, { callback } = {}) {
-  const {
-    display,
-    dataset_query: { type },
-  } = question;
-
-  const isPivotEndpoint = display === "pivot" && type === "query";
-
-  const url = isPivotEndpoint ? "/api/dataset/pivot" : "/api/dataset";
-  const alias = isPivotEndpoint ? "pivotDataset" : "dataset";
+  const [url, alias] = getInterceptDetails(question);
 
   cy.intercept(url).as(alias);
 
@@ -24,4 +16,19 @@ export function visitQuestionAdhoc(question, { callback } = {}) {
   cy.wait("@" + alias).then(xhr => {
     callback && callback(xhr);
   });
+}
+
+function getInterceptDetails(question) {
+  const {
+    display,
+    dataset_query: { type },
+  } = question;
+
+  // native queries should use the normal dataset endpoint even when set to pivot
+  const isPivotEndpoint = display === "pivot" && type === "query";
+
+  const url = isPivotEndpoint ? "/api/dataset/pivot" : "/api/dataset";
+  const alias = isPivotEndpoint ? "pivotDataset" : "dataset";
+
+  return [url, alias];
 }

--- a/frontend/test/__support__/e2e/helpers/e2e-ad-hoc-question-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-ad-hoc-question-helpers.js
@@ -7,5 +7,8 @@ export function adhocQuestionHash(question) {
 }
 
 export function visitQuestionAdhoc(question) {
+  cy.intercept("POST", "/api/dataset").as("dataset");
+
   cy.visit("/question#" + adhocQuestionHash(question));
+  cy.wait("@dataset");
 }

--- a/frontend/test/__support__/e2e/helpers/e2e-ad-hoc-question-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-ad-hoc-question-helpers.js
@@ -7,8 +7,19 @@ export function adhocQuestionHash(question) {
 }
 
 export function visitQuestionAdhoc(question) {
-  cy.intercept("POST", "/api/dataset").as("dataset");
+  const {
+    display,
+    dataset_query: { type },
+  } = question;
+
+  const isPivotEndpoint = display === "pivot" && type === "query";
+
+  const url = isPivotEndpoint ? "/api/dataset/pivot" : "/api/dataset";
+  const alias = isPivotEndpoint ? "pivotDataset" : "dataset";
+
+  cy.intercept(url).as(alias);
 
   cy.visit("/question#" + adhocQuestionHash(question));
-  cy.wait("@dataset");
+
+  cy.wait("@" + alias);
 }

--- a/frontend/test/metabase-visual/visualizations/bar.cy.spec.js
+++ b/frontend/test/metabase-visual/visualizations/bar.cy.spec.js
@@ -4,8 +4,6 @@ describe("visual tests > visualizations > bar", () => {
   beforeEach(() => {
     restore();
     cy.signInAsNormalUser();
-    cy.server();
-    cy.route("POST", "/api/dataset").as("dataset");
   });
 
   it("with stacked series", () => {
@@ -28,8 +26,6 @@ describe("visual tests > visualizations > bar", () => {
         "stackable.stack_type": "stacked",
       },
     });
-
-    cy.wait("@dataset");
 
     cy.percySnapshot();
   });
@@ -54,8 +50,6 @@ describe("visual tests > visualizations > bar", () => {
         "stackable.stack_type": "stacked",
       },
     });
-
-    cy.wait("@dataset");
 
     cy.percySnapshot();
   });

--- a/frontend/test/metabase-visual/visualizations/funnel.cy.spec.js
+++ b/frontend/test/metabase-visual/visualizations/funnel.cy.spec.js
@@ -4,8 +4,6 @@ describe("visual tests > visualizations > funnel", () => {
   beforeEach(() => {
     restore();
     cy.signInAsNormalUser();
-    cy.server();
-    cy.route("POST", "/api/dataset").as("dataset");
   });
 
   it("empty", () => {
@@ -27,8 +25,6 @@ describe("visual tests > visualizations > funnel", () => {
         "funnel.type": "funnel",
       },
     });
-
-    cy.wait("@dataset");
 
     cy.percySnapshot();
   });
@@ -54,8 +50,6 @@ describe("visual tests > visualizations > funnel", () => {
         "funnel.type": "funnel",
       },
     });
-
-    cy.wait("@dataset");
 
     cy.percySnapshot();
   });

--- a/frontend/test/metabase-visual/visualizations/line.cy.spec.js
+++ b/frontend/test/metabase-visual/visualizations/line.cy.spec.js
@@ -7,8 +7,6 @@ describe("visual tests > visualizations > line", () => {
   beforeEach(() => {
     restore();
     cy.signInAsNormalUser();
-    cy.server();
-    cy.route("POST", "/api/dataset").as("dataset");
   });
 
   it("with data points", () => {
@@ -38,8 +36,6 @@ describe("visual tests > visualizations > line", () => {
       },
     });
 
-    cy.wait("@dataset");
-
     cy.percySnapshot();
   });
 
@@ -76,8 +72,6 @@ describe("visual tests > visualizations > line", () => {
       },
     });
 
-    cy.wait("@dataset");
-
     cy.percySnapshot();
   });
 
@@ -113,8 +107,6 @@ describe("visual tests > visualizations > line", () => {
         "graph.metrics": ["count"],
       },
     });
-
-    cy.wait("@dataset");
 
     cy.percySnapshot();
   });
@@ -155,8 +147,6 @@ describe("visual tests > visualizations > line", () => {
       },
     });
 
-    cy.wait("@dataset");
-
     cy.percySnapshot();
   });
 
@@ -196,8 +186,6 @@ describe("visual tests > visualizations > line", () => {
         },
       },
     });
-
-    cy.wait("@dataset");
 
     cy.percySnapshot();
   });

--- a/frontend/test/metabase-visual/visualizations/row.cy.spec.js
+++ b/frontend/test/metabase-visual/visualizations/row.cy.spec.js
@@ -17,8 +17,6 @@ describe("visual tests > visualizations > row", () => {
   beforeEach(() => {
     restore();
     cy.signInAsNormalUser();
-    cy.server();
-    cy.route("POST", "/api/dataset").as("dataset");
   });
 
   it("with formatted x-axis", () => {
@@ -32,8 +30,6 @@ describe("visual tests > visualizations > row", () => {
         },
       },
     });
-
-    cy.wait("@dataset");
 
     cy.percySnapshot();
   });

--- a/frontend/test/metabase-visual/visualizations/scatter.cy.spec.js
+++ b/frontend/test/metabase-visual/visualizations/scatter.cy.spec.js
@@ -23,8 +23,6 @@ describe("visual tests > visualizations > scatter", () => {
   beforeEach(() => {
     restore();
     cy.signInAsNormalUser();
-    cy.server();
-    cy.route("POST", "/api/dataset").as("dataset");
   });
 
   it("with date dimension", () => {
@@ -36,8 +34,6 @@ describe("visual tests > visualizations > scatter", () => {
         "graph.metrics": ["count", "count_2"],
       },
     });
-
-    cy.wait("@dataset");
 
     cy.percySnapshot();
   });

--- a/frontend/test/metabase-visual/visualizations/waterfall.cy.spec.js
+++ b/frontend/test/metabase-visual/visualizations/waterfall.cy.spec.js
@@ -25,8 +25,6 @@ describe("visual tests > visualizations > waterfall", () => {
   beforeEach(() => {
     restore();
     cy.signInAsNormalUser();
-    cy.server();
-    cy.route("POST", "/api/dataset").as("dataset");
   });
 
   it("with positive and negative series", () => {
@@ -39,8 +37,6 @@ describe("visual tests > visualizations > waterfall", () => {
         "graph.metrics": ["count"],
       },
     });
-
-    cy.wait("@dataset");
 
     cy.percySnapshot();
   });

--- a/frontend/test/metabase/scenarios/binning/binning-options.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/binning-options.cy.spec.js
@@ -289,7 +289,6 @@ function chooseInitialBinningOptionForExplicitJoin({
 } = {}) {
   visitQuestionAdhoc({ dataset_query: baseTableQuery });
 
-  cy.wait("@dataset");
   cy.findByTextEnsureVisible("Summarize").click();
 
   cy.findByTestId("sidebar-right").within(() => {

--- a/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
@@ -99,8 +99,6 @@ describe("binning related reproductions", () => {
   });
 
   it("should be able to update the bucket size / granularity on a field that has sorting applied to it (metabase#16770)", () => {
-    cy.intercept("POST", "/api/dataset").as("dataset");
-
     visitQuestionAdhoc({
       dataset_query: {
         database: 1,
@@ -118,8 +116,6 @@ describe("binning related reproductions", () => {
       },
       display: "line",
     });
-
-    cy.wait("@dataset");
 
     cy.contains("Summarize").click();
 

--- a/frontend/test/metabase/scenarios/custom-column/custom-column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/custom-column.cy.spec.js
@@ -355,38 +355,37 @@ describe("scenarios > question > custom column", () => {
   it("should handle using `case()` when referencing the same column names (metabase#14854)", () => {
     const CC_NAME = "CE with case";
 
-    visitQuestionAdhoc({
-      dataset_query: {
-        type: "query",
-        query: {
-          "source-table": ORDERS_ID,
-          expressions: {
-            [CC_NAME]: [
-              "case",
-              [
+    visitQuestionAdhoc(
+      {
+        dataset_query: {
+          type: "query",
+          query: {
+            "source-table": ORDERS_ID,
+            expressions: {
+              [CC_NAME]: [
+                "case",
                 [
-                  [">", ["field", ORDERS.DISCOUNT, null], 0],
-                  ["field", ORDERS.CREATED_AT, null],
+                  [
+                    [">", ["field", ORDERS.DISCOUNT, null], 0],
+                    ["field", ORDERS.CREATED_AT, null],
+                  ],
                 ],
+                {
+                  default: [
+                    "field",
+                    PRODUCTS.CREATED_AT,
+                    { "source-field": ORDERS.PRODUCT_ID },
+                  ],
+                },
               ],
-              {
-                default: [
-                  "field",
-                  PRODUCTS.CREATED_AT,
-                  { "source-field": ORDERS.PRODUCT_ID },
-                ],
-              },
-            ],
+            },
           },
+          database: 1,
         },
-        database: 1,
+        display: "table",
       },
-      display: "table",
-    });
-
-    cy.wait("@dataset").should(xhr => {
-      expect(xhr.response.body.error).not.to.exist;
-    });
+      { callback: xhr => expect(xhr.response.body.error).not.to.exist },
+    );
 
     cy.findByText(CC_NAME);
     cy.contains("37.65");

--- a/frontend/test/metabase/scenarios/downloads/reproductions/18382-old-syntax-missing-renamed-columns.cy.spec.js
+++ b/frontend/test/metabase/scenarios/downloads/reproductions/18382-old-syntax-missing-renamed-columns.cy.spec.js
@@ -93,13 +93,10 @@ testCases.forEach(fileType => {
       // TODO: Please remove this line when issue gets fixed
       cy.skipOn(fileType === "csv");
 
-      cy.intercept("POST", "/api/dataset").as("dataset");
-
       restore();
       cy.signInAsAdmin();
 
       visitQuestionAdhoc(questionDetails);
-      cy.wait("@dataset");
     });
 
     it(`should handle the old syntax in downloads for ${fileType} (metabase#18382)`, () => {

--- a/frontend/test/metabase/scenarios/downloads/reproductions/18440-remapped-display-value-dropped.cy.spec.js
+++ b/frontend/test/metabase/scenarios/downloads/reproductions/18440-remapped-display-value-dropped.cy.spec.js
@@ -22,7 +22,6 @@ const testCases = ["csv", "xlsx"];
 describe("issue 18440", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/card").as("saveQuestion");
-    cy.intercept("POST", "/api/dataset").as("dataset");
 
     restore();
     cy.signInAsAdmin();
@@ -38,7 +37,6 @@ describe("issue 18440", () => {
   testCases.forEach(fileType => {
     it(`export should include a column with remapped values for ${fileType} (metabase#18440-1)`, () => {
       visitQuestionAdhoc(questionDetails);
-      cy.wait("@dataset");
 
       cy.findByText("Product ID");
       cy.findByText("Awesome Concrete Shoes");

--- a/frontend/test/metabase/scenarios/downloads/reproductions/18573-remapped-fields-not-renamed.cy.spec.js
+++ b/frontend/test/metabase/scenarios/downloads/reproductions/18573-remapped-fields-not-renamed.cy.spec.js
@@ -24,8 +24,6 @@ const questionDetails = {
 
 describe.skip("issue 18573", () => {
   beforeEach(() => {
-    cy.intercept("POST", "/api/dataset").as("dataset");
-
     restore();
     cy.signInAsAdmin();
 
@@ -40,7 +38,6 @@ describe.skip("issue 18573", () => {
   ["csv", "xlsx"].forEach(fileType => {
     it(`for the remapped columns, it should preserve renamed column name in exports for ${fileType} (metabase#18573)`, () => {
       visitQuestionAdhoc(questionDetails);
-      cy.wait("@dataset");
 
       cy.findByText("Foo");
       cy.findByText("Awesome Concrete Shoes");

--- a/frontend/test/metabase/scenarios/downloads/reproductions/18729-date-formatting-x-of-y.cy.spec.js
+++ b/frontend/test/metabase/scenarios/downloads/reproductions/18729-date-formatting-x-of-y.cy.spec.js
@@ -26,8 +26,6 @@ const questionDetails = {
 
 describe("issue 18729", () => {
   beforeEach(() => {
-    cy.intercept("POST", "/api/dataset").as("dataset");
-
     restore();
     cy.signInAsAdmin();
   });
@@ -38,7 +36,6 @@ describe("issue 18729", () => {
       cy.skipOn(fileType === "xlsx");
 
       visitQuestionAdhoc(questionDetails);
-      cy.wait("@dataset");
 
       downloadAndAssert({ fileType }, assertion);
     });

--- a/frontend/test/metabase/scenarios/joins/joins-2.cy.spec.js
+++ b/frontend/test/metabase/scenarios/joins/joins-2.cy.spec.js
@@ -418,9 +418,7 @@ describe("scenarios > question > joined questions", () => {
     });
 
     it("x-rays should work on explicit joins when metric is for the joined table (metabase#14793)", () => {
-      cy.server();
-      cy.route("POST", "/api/dataset").as("dataset");
-      cy.route("GET", "/api/automagic-dashboards/adhoc/**").as("xray");
+      cy.intercept("GET", "/api/automagic-dashboards/adhoc/**").as("xray");
 
       visitQuestionAdhoc({
         dataset_query: {
@@ -451,7 +449,6 @@ describe("scenarios > question > joined questions", () => {
         display: "line",
       });
 
-      cy.wait("@dataset");
       cy.get(".dot")
         .eq(2)
         .click({ force: true });

--- a/frontend/test/metabase/scenarios/native-filters/reproductions/15460.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native-filters/reproductions/15460.cy.spec.js
@@ -40,10 +40,7 @@ describe("issue 15460", () => {
     restore();
     cy.signInAsAdmin();
 
-    cy.intercept("POST", "/api/dataset").as("dataset");
-
     visitQuestionAdhoc(questionQuery);
-    cy.wait("@dataset");
   });
 
   it("should be possible to use field filter on a query with joins where tables have similar columns (metabase#15460)", () => {

--- a/frontend/test/metabase/scenarios/native/reproductions/12439-click-on-legend-breaks-ui.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/reproductions/12439-click-on-legend-breaks-ui.cy.spec.js
@@ -20,13 +20,10 @@ const questionDetails = {
 
 describe("issue 12439", () => {
   beforeEach(() => {
-    cy.intercept("POST", "/api/dataset").as("dataset");
-
     restore();
     cy.signInAsAdmin();
 
     visitQuestionAdhoc(questionDetails);
-    cy.wait("@dataset");
   });
 
   it("should allow clicking on a legend in a native question without breaking the UI (metabase#12439)", () => {

--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -243,8 +243,6 @@ describe("scenarios > question > filter", () => {
   });
 
   it("should display original custom expression filter with dates on subsequent click (metabase#12492)", () => {
-    cy.intercept("POST", "/api/dataset").as("dataset");
-
     visitQuestionAdhoc({
       dataset_query: {
         type: "query",
@@ -265,7 +263,6 @@ describe("scenarios > question > filter", () => {
       display: "table",
     });
 
-    cy.wait("@dataset");
     cy.findByText(/Created At > Product? → Created At/i).click();
 
     cy.contains(/\[Created At\] > \[Products? → Created At\]/);
@@ -487,6 +484,7 @@ describe("scenarios > question > filter", () => {
       },
       display: "table",
     });
+
     cy.findByText("Title does not contain Wallet").click();
     cy.get(".Icon-chevronleft").click();
     cy.findByText("Custom Expression").click();
@@ -510,6 +508,7 @@ describe("scenarios > question > filter", () => {
       },
       display: "table",
     });
+
     cy.findByText("Title does not contain Wallet").click();
     cy.get(".Icon-chevronleft").click();
     cy.findByText("Custom Expression").click();
@@ -541,8 +540,6 @@ describe("scenarios > question > filter", () => {
   });
 
   it("should be able to convert case-insensitive filter to custom expression (metabase#14959)", () => {
-    cy.intercept("POST", "/api/dataset").as("dataset");
-
     visitQuestionAdhoc({
       dataset_query: {
         type: "query",
@@ -559,7 +556,7 @@ describe("scenarios > question > filter", () => {
       },
       display: "table",
     });
-    cy.wait("@dataset");
+
     cy.findByText("wilma-muller");
     cy.findByText("Reviewer contains MULLER").click();
     cy.get(".Icon-chevronleft").click();
@@ -714,6 +711,7 @@ describe("scenarios > question > filter", () => {
         type: "query",
       },
     });
+
     cy.get(".ScalarValue").contains("5");
     cy.findAllByRole("button")
       .contains("Filter")
@@ -766,6 +764,7 @@ describe("scenarios > question > filter", () => {
       },
       display: "line",
     });
+
     assertOnLegendLabels();
     cy.get(".line").should("have.length", 3);
     cy.findByText("Save").click();

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -78,9 +78,6 @@ describe("scenarios > question > notebook", () => {
   });
 
   it("should show the original custom expression filter field on subsequent click (metabase#14726)", () => {
-    cy.server();
-    cy.route("POST", "/api/dataset").as("dataset");
-
     visitQuestionAdhoc({
       dataset_query: {
         database: 1,
@@ -93,7 +90,6 @@ describe("scenarios > question > notebook", () => {
       display: "table",
     });
 
-    cy.wait("@dataset");
     cy.findByText("ID between 96 97").click();
     cy.findByText("Between").click();
     popover().within(() => {

--- a/frontend/test/metabase/scenarios/visualizations/bar_chart.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/bar_chart.cy.spec.js
@@ -37,7 +37,6 @@ describe("scenarios > visualizations > bar chart", () => {
         }),
       );
 
-      cy.wait("@dataset");
       cy.findByText("(empty)").should("not.exist");
     });
 
@@ -50,7 +49,6 @@ describe("scenarios > visualizations > bar chart", () => {
         }),
       );
 
-      cy.wait("@dataset");
       cy.findByText("(empty)");
     });
   });

--- a/frontend/test/metabase/scenarios/visualizations/bar_chart.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/bar_chart.cy.spec.js
@@ -98,8 +98,9 @@ describe("scenarios > visualizations > bar chart", () => {
         },
       });
 
-      cy.findByText("19");
-      cy.findAllByText("20.0M");
+      cy.get(".value-labels")
+        .should("contain", "19")
+        .and("contain", "20.0M");
     });
   });
 });

--- a/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
@@ -118,6 +118,7 @@ describe("scenarios > visualizations > line chart", () => {
         "graph.metrics": ["count", "sum", "avg"],
       },
     });
+
     cy.get(".Visualization .enable-dots")
       .last()
       .find(".dot")

--- a/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
@@ -19,18 +19,14 @@ describe("scenarios > visualizations > line chart", () => {
   beforeEach(() => {
     restore();
     cy.signInAsNormalUser();
-    cy.server();
   });
 
   it("should be able to change y axis position (metabase#13487)", () => {
-    cy.route("POST", "/api/dataset").as("dataset");
-
     visitQuestionAdhoc({
       dataset_query: testQuery,
       display: "line",
     });
 
-    cy.wait("@dataset");
     cy.findByText("Settings").click();
     cy.findByText("Right").click();
     cy.get(Y_AXIS_RIGHT_SELECTOR);

--- a/frontend/test/metabase/scenarios/visualizations/maps.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/maps.cy.spec.js
@@ -131,8 +131,6 @@ describe("scenarios > visualizations > maps", () => {
     cy.findByText("State:"); // column name key
     cy.findByText("Texas"); // feature name as value
 
-    cy.server();
-    cy.route("POST", `/api/dataset`).as("dataset");
     // open actions menu and drill within it
     cy.get("@texas").click();
     cy.findByText(/View these People/i).click();

--- a/frontend/test/metabase/scenarios/visualizations/pie_chart.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/pie_chart.cy.spec.js
@@ -21,14 +21,11 @@ describe("scenarios > visualizations > pie chart", () => {
   });
 
   it("should render a pie chart (metabase#12506)", () => {
-    cy.route("POST", "/api/dataset").as("dataset");
-
     visitQuestionAdhoc({
       dataset_query: testQuery,
       display: "pie",
     });
 
-    cy.wait("@dataset");
     ensurePieChartRendered(["Doohickey", "Gadget", "Gizmo", "Widget"], 200);
   });
 });

--- a/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -436,10 +436,7 @@ describe("scenarios > visualizations > pivot tables", () => {
   });
 
   it("should display an error message for native queries", () => {
-    cy.server();
     // native queries should use the normal dataset endpoint even when set to pivot
-    cy.route("POST", `/api/dataset`).as("dataset");
-
     visitQuestionAdhoc({
       dataset_query: {
         type: "native",
@@ -450,7 +447,6 @@ describe("scenarios > visualizations > pivot tables", () => {
       visualization_settings: {},
     });
 
-    cy.wait("@dataset");
     cy.findByText("Pivot tables can only be used with aggregated queries.");
   });
 
@@ -740,7 +736,6 @@ describe("scenarios > visualizations > pivot tables", () => {
       display: "line",
     });
 
-    cy.wait("@dataset");
     cy.findByText("Visualization").click();
     sidebar().within(() => {
       cy.findByText("Pivot Table")
@@ -821,8 +816,6 @@ describe("scenarios > visualizations > pivot tables", () => {
   });
 
   it("should not show subtotals for flat tables", () => {
-    cy.intercept("POST", "api/dataset/pivot").as("createPivotedDataset");
-
     visitQuestionAdhoc({
       dataset_query: {
         type: "query",
@@ -860,7 +853,6 @@ describe("scenarios > visualizations > pivot tables", () => {
       },
     });
 
-    cy.wait("@createPivotedDataset");
     cy.findAllByText(/Totals for .*/i).should("have.length", 0);
   });
 });

--- a/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -436,7 +436,6 @@ describe("scenarios > visualizations > pivot tables", () => {
   });
 
   it("should display an error message for native queries", () => {
-    // native queries should use the normal dataset endpoint even when set to pivot
     visitQuestionAdhoc({
       dataset_query: {
         type: "native",

--- a/frontend/test/metabase/scenarios/visualizations/reproductions/14148-pivot-table-postgres.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/reproductions/14148-pivot-table-postgres.cy.spec.js
@@ -10,35 +10,37 @@ describe("issue 14148", () => {
   beforeEach(() => {
     restore("postgres-12");
     cy.signInAsAdmin();
-
-    cy.intercept("POST", "/api/dataset/pivot").as("pivotDataset");
   });
 
   it("postgres should display pivot tables (metabase#14148)", () => {
     withDatabase(PG_DB_ID, ({ PEOPLE, PEOPLE_ID }) =>
-      visitQuestionAdhoc({
-        display: "pivot",
-        dataset_query: {
-          type: "query",
-          database: PG_DB_ID,
-          query: {
-            "source-table": PEOPLE_ID,
-            aggregation: [["count"]],
-            breakout: [
-              ["field", PEOPLE.SOURCE, null],
-              ["field", PEOPLE.CREATED_AT, { "temporal-unit": "year" }],
-            ],
+      visitQuestionAdhoc(
+        {
+          display: "pivot",
+          dataset_query: {
+            type: "query",
+            database: PG_DB_ID,
+            query: {
+              "source-table": PEOPLE_ID,
+              aggregation: [["count"]],
+              breakout: [
+                ["field", PEOPLE.SOURCE, null],
+                ["field", PEOPLE.CREATED_AT, { "temporal-unit": "year" }],
+              ],
+            },
           },
         },
-      }),
+        {
+          callback: xhr =>
+            expect(xhr.response.body.cause || "").not.to.contain("ERROR"),
+        },
+      ),
     );
 
     cy.log(
       "Reported failing on v0.38.0-rc1 querying Postgres, Redshift and BigQuery. It works on MySQL and H2.",
     );
-    cy.wait("@pivotDataset").then(xhr => {
-      expect(xhr.response.body.cause || "").not.to.contain("ERROR");
-    });
+
     cy.findByText(/Grand totals/i);
     cy.findByText("2,500");
   });

--- a/frontend/test/metabase/scenarios/visualizations/reproductions/18976-pivot-table-columns.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/reproductions/18976-pivot-table-columns.cy.spec.js
@@ -21,13 +21,10 @@ describe("issue 18976", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
-    cy.intercept("POST", "/api/dataset").as("dataset");
   });
 
   it("should display a pivot table as regular one when pivot columns are missing (metabase#18976)", () => {
     visitQuestionAdhoc(questionDetails);
-
-    cy.wait("@dataset");
 
     cy.findByText("Showing 1 row");
   });

--- a/frontend/test/metabase/scenarios/visualizations/scatter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/scatter.cy.spec.js
@@ -23,8 +23,6 @@ describe("scenarios > visualizations > scatter", () => {
   beforeEach(() => {
     restore();
     cy.signInAsNormalUser();
-    cy.server();
-    cy.route("POST", "/api/dataset").as("dataset");
   });
 
   it("should show correct labels in tooltip (metabase#15150)", () => {
@@ -88,7 +86,6 @@ describe("scenarios > visualizations > scatter", () => {
 });
 
 function triggerPopoverForBubble(index = 13) {
-  cy.wait("@dataset");
   // Hack that is needed because of the flakiness caused by adding throttle to the ExplicitSize component
   // See: https://github.com/metabase/metabase/pull/15235
   cy.get("[class*=ViewFooter]").within(() => {

--- a/frontend/test/metabase/scenarios/visualizations/waterfall.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/waterfall.cy.spec.js
@@ -139,9 +139,6 @@ describe("scenarios > visualizations > waterfall", () => {
   });
 
   it("should show error for multi-series questions (metabase#15152)", () => {
-    cy.server();
-    cy.route("POST", "/api/dataset").as("dataset");
-
     visitQuestionAdhoc({
       dataset_query: {
         type: "query",
@@ -156,8 +153,6 @@ describe("scenarios > visualizations > waterfall", () => {
       },
       display: "line",
     });
-
-    cy.wait("@dataset");
 
     cy.findByText("Visualization").click();
     cy.findByTestId("Waterfall-button").click();


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Hides away implementation details for the `visitQuestionAdhoc` helper function and updates the test suite accordingly

### Additional context
When we open/visit an ad-hoc query, the xhr that renders the results on the page is always `POST /api/dataset`. It's tedious to write it manually every single time we want to use this helper function, so I thought it would be good to intercept the request and wait for it in the function itself.

Since there are slight differences in the endpoint we use for regular queries and the pivot_table queries, this PR also accounts for that.

### How to test?
- All tests should be passing in the CI
- Manually, whenever you write the test that includes `visitQuestionAdhoc`, you can make sure that it waits for the `@dataset` alias, without you ever having to manually intercept it.

```js
// before

cy.intercept("POST", "/api/dataset").as("dataset);

visitQuestionAdhoc(query);

cy.wait("@dataset");

// do some assertions on the results
```

```js
// now

visitQuestionAdhoc(query);

// do some assertions on the results
```