### PR TITLE
Fix locking in new Alpine release container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,9 @@ FROM eclipse-temurin:11-jre-alpine as runner
 ENV FC_LANG en-US LC_CTYPE en_US.UTF-8
 
 # dependencies
-RUN apk upgrade && apk add --update-cache --no-cache bash ttf-dejavu fontconfig curl java-cacerts && \
+RUN apk add -U --update-cache --no-cache bash ttf-dejavu fontconfig curl java-cacerts && \
+    apk -U upgrade && \
+    rm -rf /var/cache/apk/* && \
     mkdir -p /app/certs && \
     curl https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem -o /app/certs/rds-combined-ca-bundle.pem  && \
     /opt/java/openjdk/bin/keytool -noprompt -import -trustcacerts -alias aws-rds -file /app/certs/rds-combined-ca-bundle.pem -keystore /etc/ssl/certs/java/cacerts -keypass changeit -storepass changeit && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ FROM eclipse-temurin:11-jre-alpine as runner
 ENV FC_LANG en-US LC_CTYPE en_US.UTF-8
 
 # dependencies
-RUN apk add -U --update-cache --no-cache bash ttf-dejavu fontconfig curl java-cacerts && \
-    apk -U upgrade && \
+RUN apk add -U bash ttf-dejavu fontconfig curl java-cacerts && \
+    apk upgrade && \
     rm -rf /var/cache/apk/* && \
     mkdir -p /app/certs && \
     curl https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem -o /app/certs/rds-combined-ca-bundle.pem  && \

--- a/bin/docker/Dockerfile
+++ b/bin/docker/Dockerfile
@@ -3,8 +3,8 @@ FROM eclipse-temurin:11-jre-alpine
 ENV FC_LANG en-US LC_CTYPE en_US.UTF-8
 
 # dependencies
-RUN apk add -U --update-cache --no-cache bash ttf-dejavu fontconfig curl java-cacerts && \
-    apk -U upgrade && \
+RUN apk add -U bash ttf-dejavu fontconfig curl java-cacerts && \
+    apk upgrade && \
     rm -rf /var/cache/apk/* && \
     mkdir -p /app/certs && \
     curl https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem -o /app/certs/rds-combined-ca-bundle.pem  && \

--- a/bin/docker/Dockerfile
+++ b/bin/docker/Dockerfile
@@ -3,7 +3,9 @@ FROM eclipse-temurin:11-jre-alpine
 ENV FC_LANG en-US LC_CTYPE en_US.UTF-8
 
 # dependencies
-RUN apk upgrade & apk add --update-cache --no-cache bash ttf-dejavu fontconfig curl java-cacerts && \
+RUN apk add -U --update-cache --no-cache bash ttf-dejavu fontconfig curl java-cacerts && \
+    apk -U upgrade && \
+    rm -rf /var/cache/apk/* && \
     mkdir -p /app/certs && \
     curl https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem -o /app/certs/rds-combined-ca-bundle.pem  && \
     /opt/java/openjdk/bin/keytool -noprompt -import -trustcacerts -alias aws-rds -file /app/certs/rds-combined-ca-bundle.pem -keystore /etc/ssl/certs/java/cacerts -keypass changeit -storepass changeit && \


### PR DESCRIPTION
Seems like the new Alpine container (3.15) has some issue when doing apk upgrade first which ends up erroring out the process, so moving it to the last part of the process (after installing the packages) makes the trick.

You can test it out by using the current process (errors with a "Unable to lock database: temporary error (try again later)") and the one in this branch which will finish successfully