### PR TITLE
Add hideOnEsc plugin to TippyPopover

### DIFF
--- a/frontend/src/metabase/components/Popover/TippyPopover.info.js
+++ b/frontend/src/metabase/components/Popover/TippyPopover.info.js
@@ -54,6 +54,20 @@ function LazyContentExample() {
   return <LazyPopoverBody opacity={opacity}>popover content</LazyPopoverBody>;
 }
 
+function VisiblePropExample() {
+  const [visible, setVisible] = React.useState(true);
+  return (
+    <TippyPopover
+      visible={visible}
+      onHide={() => setVisible(false)}
+      placement="left-end"
+      content={content}
+    >
+      <div onClick={() => setVisible(true)}>{target}</div>
+    </TippyPopover>
+  );
+}
+
 export const examples = {
   "vertical placement": (
     <TippyPopover placement="top-start" content={content}>
@@ -84,9 +98,5 @@ export const examples = {
       {target}
     </TippyPopover>
   ),
-  "control mode using the 'visible' prop": (
-    <TippyPopover visible placement="left-end" content={content}>
-      {target}
-    </TippyPopover>
-  ),
+  "control mode + handling of Esc press": <VisiblePropExample />,
 };

--- a/frontend/src/metabase/components/Popover/TippyPopover.info.js
+++ b/frontend/src/metabase/components/Popover/TippyPopover.info.js
@@ -84,4 +84,9 @@ export const examples = {
       {target}
     </TippyPopover>
   ),
+  "control mode using the 'visible' prop": (
+    <TippyPopover visible placement="left-end" content={content}>
+      {target}
+    </TippyPopover>
+  ),
 };

--- a/frontend/src/metabase/components/Popover/TippyPopover.tsx
+++ b/frontend/src/metabase/components/Popover/TippyPopover.tsx
@@ -1,14 +1,16 @@
 import React, { useState, useMemo } from "react";
 import PropTypes from "prop-types";
-import * as Tippy from "@tippyjs/react";
+import * as TippyReact from "@tippyjs/react";
+import * as tippy from "tippy.js";
 import cx from "classnames";
 
 import { isReducedMotionPreferred } from "metabase/lib/dom";
 import EventSandbox from "metabase/components/EventSandbox";
 import { isCypressActive } from "metabase/env";
 
-const TippyComponent = Tippy.default;
-type TippyProps = Tippy.TippyProps;
+const TippyComponent = TippyReact.default;
+type TippyProps = TippyReact.TippyProps;
+type TippyInstance = tippy.Instance;
 
 export interface ITippyPopoverProps extends TippyProps {
   disableContentSandbox?: boolean;
@@ -23,40 +25,56 @@ const propTypes = {
   ...TippyComponent.propTypes,
 };
 
+function appendTo() {
+  return document.body;
+}
+
+const hideOnEscPlugin = {
+  name: "hideOnEsc",
+  defaultValue: true,
+  fn({ hide }: TippyInstance) {
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        hide();
+      }
+    }
+
+    return {
+      onShow() {
+        document.addEventListener("keydown", onKeyDown);
+      },
+      onHide() {
+        document.removeEventListener("keydown", onKeyDown);
+      },
+    };
+  },
+};
+
 function TippyPopover({
   className,
   disableContentSandbox,
-  lazy = true,
   content,
   delay,
+  lazy = true,
   ...props
 }: ITippyPopoverProps) {
   delay = isCypressActive ? 0 : delay;
   const animationDuration = isReducedMotionPreferred() ? 0 : undefined;
   const [mounted, setMounted] = useState(!lazy);
-  const plugins = useMemo(
-    () =>
-      lazy
-        ? [
-            {
-              fn: () => ({
-                onMount: () => setMounted(true),
-                onHidden: () => setMounted(false),
-              }),
-            },
-          ]
-        : [],
+  const shouldShowContent = mounted && content != null;
+
+  const lazyPlugin = useMemo(
+    () => ({
+      name: "lazy",
+      fn: () => ({
+        onMount: () => setMounted(true),
+        onHidden: () => setMounted(!lazy),
+      }),
+    }),
     [lazy],
   );
 
-  let computedContent;
-  if (!mounted) {
-    computedContent = "";
-  } else if (content != null) {
-    computedContent = (
-      <EventSandbox disabled={disableContentSandbox}>{content}</EventSandbox>
-    );
-  }
+  const plugins = useMemo(() => [lazyPlugin, hideOnEscPlugin], [lazyPlugin]);
 
   return (
     <TippyComponent
@@ -64,12 +82,18 @@ function TippyPopover({
       theme="popover"
       arrow={false}
       offset={OFFSET}
-      appendTo={() => document.body}
+      appendTo={appendTo}
       plugins={plugins}
       {...props}
       duration={animationDuration}
       delay={delay}
-      content={computedContent}
+      content={
+        shouldShowContent ? (
+          <EventSandbox disabled={disableContentSandbox}>
+            {content}
+          </EventSandbox>
+        ) : null
+      }
     />
   );
 }

--- a/frontend/src/metabase/components/Popover/TippyPopover.tsx
+++ b/frontend/src/metabase/components/Popover/TippyPopover.tsx
@@ -31,7 +31,6 @@ function appendTo() {
 
 const hideOnEscPlugin = {
   name: "hideOnEsc",
-  defaultValue: true,
   fn({ hide }: TippyInstance) {
     function onKeyDown(event: KeyboardEvent) {
       if (event.key === "Escape") {


### PR DESCRIPTION
Related to https://github.com/metabase/metabase/issues/18951

This PR adds an additional plugin to the `TippyPopover` component so that the popover is hidden when the user presses the "Escape" key. This mimics behavior of our deprecated `Popover` component, which relies on the `OnClickOutsideWrapper` HOC for this behavior. While `Popover` has a prop `noOnClickOutsideWrapper` to disable this functionality, I've chosen not to make this optional for simplicity's sake and because `noOnClickOutsideWrapper` isn't actually used anywhere.

Note: If a parent component controls a popover's visibility using the `visible` prop (vs letting tippy take care of it), it will also be expected to handle this plugin hiding the popover by using the `onHide` prop to propagate the hide action (if they want this behavior), otherwise the popover will re-show after the user presses the Escape key. This ought to be fairly easy--see the contrived example I added to `frontend/src/metabase/components/Popover/TippyPopover.info.js`

In addition to the above change I've tweaked the logic of the `lazyPlugin` (to make it always be defined) so that TypeScript is happier about the `plugins` array

**Testing**
1. Navigate to the simple query builder view of the People table
2. Hover your mouse over the column headers of the table to see the `DimensionInfoPopover` appear
3. Press the escape key
4. You should see the popover go away