### PR TITLE
E2E tests on master: add dashboard groups

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -64,6 +64,9 @@ jobs:
         edition: [oss]
         folder:
           - "custom-column"
+          - "dashboard"
+          - "dashboard-filters"
+          - "dashboard-filters-sql"
           - "downloads"
           - "moderation"
           - "native"


### PR DESCRIPTION
This continues from PR #20266 by adding 3 more test groups related to dashboard.

**Before**

![image](https://user-images.githubusercontent.com/7288/152891065-88a87316-f0ef-4f67-809c-1eaae2695343.png)


**After**

![image](https://user-images.githubusercontent.com/7288/152891021-e3f22fc6-76d5-41c9-996f-e503a56317ee.png)
