### PR TITLE
CI with GitHub Actions: Fix the lack of shareable, local Actions

### DIFF
--- a/.github/workflows/build-scripts.yml
+++ b/.github/workflows/build-scripts.yml
@@ -13,10 +13,22 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
-    - name: Prepare back-end environment
-      uses: ./.github/actions/prepare-backend
+    - name: Prepare JDK 11
+      uses: actions/setup-java@v2
       with:
-        m2-cache-key: 'build-scripts'
+        java-version: 11
+        distribution: 'temurin'
+    - name: Install Clojure CLI
+      run: |
+        curl -O https://download.clojure.org/install/linux-install-1.10.3.933.sh &&
+        sudo bash ./linux-install-1.10.3.933.sh
+    - name: Get M2 cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.m2
+          ~/.gitlibs
+        key: ${{ runner.os }}-build-scripts-${{ hashFiles('**/deps.edn') }}
     - name: Compile Java & AOT Sources
       run: source ./bin/prep.sh && prep_deps
 

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -14,7 +14,21 @@ jobs:
     timeout-minutes: 15
     steps:
     - uses: actions/checkout@v2
-    - name: Prepare back-end environment
-      uses: ./.github/actions/prepare-backend
+    - name: Prepare JDK 11
+      uses: actions/setup-java@v2
+      with:
+        java-version: 11
+        distribution: 'temurin'
+    - name: Install Clojure CLI
+      run: |
+        curl -O https://download.clojure.org/install/linux-install-1.10.3.933.sh &&
+        sudo bash ./linux-install-1.10.3.933.sh
+    - name: Get M2 cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.m2
+          ~/.gitlibs
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/deps.edn') }}
     - name: Verify Liquibase Migrations
       run: ./bin/lint-migrations-file.sh


### PR DESCRIPTION
This PR fixes the automated backport for test-build-scripts (#20291) and migrations (#20292), which did not really work since they relied on refactored local Actions (#20187). The last one is not trivial to backport, so rather than risking the release, let's just make the backported test-build-scripts and migrations working for now with the band-aid in this PR.

**Before**

Running either build-scripts or migrations will result in a failure:

![image](https://user-images.githubusercontent.com/7288/152939070-5863f4d2-10bc-4d2f-a3d0-a00d8eca232d.png)

**After**

They should work as expected.