### PR TITLE
Simplify QP cache middleware

### DIFF
--- a/src/metabase/query_processor.clj
+++ b/src/metabase/query_processor.clj
@@ -219,11 +219,11 @@
         (apply (qp) args))
       (qp))))
 
-(def ^{:arglists '([query] [query context])} process-query-async
+(def ^{:arglists '([query] [query context] [query rff context])} process-query-async
   "Process a query asynchronously, returning a `core.async` channel that is called with the final result (or Throwable)."
   (base-qp default-middleware))
 
-(def ^{:arglists '([query] [query context])} process-query-sync
+(def ^{:arglists '([query] [query context] [query rff context])} process-query-sync
   "Process a query synchronously, blocking until results are returned. Throws raised Exceptions directly."
   (qp.reducible/sync-qp process-query-async))
 
@@ -231,7 +231,7 @@
   "Process an MBQL query. This is the main entrypoint to the magical realm of the Query Processor. Returns a *single*
   core.async channel if option `:async?` is true; otherwise returns results in the usual format. For async queries, if
   the core.async channel is closed, the query will be canceled."
-  {:arglists '([query] [query context])}
+  {:arglists '([query] [query context] [query rff context])}
   [{:keys [async?], :as query} & args]
   (apply (if async? process-query-async process-query-sync)
          query

--- a/src/metabase/query_processor/context.clj
+++ b/src/metabase/query_processor/context.clj
@@ -1,9 +1,9 @@
 (ns metabase.query-processor.context
   "Interface for the QP context/utility functions for using the things in the context correctly.
 
-  The default implementations of all these functions live in `metabase.query-processor.context.default`; refer to
-  those when overriding individual functions. Some wiring for the `core.async` channels takes place in
-  `metabase.query-processor.reducible.`"
+  The default implementations of all these functions live in [[metabase.query-processor.context.default]]; refer to
+  those when overriding individual functions. Some wiring for the [[clojure.core.async]] channels takes place in
+  [[metabase.query-processor.reducible]]."
   (:require [metabase.async.util :as async.u]))
 
 (defn raisef
@@ -28,17 +28,17 @@
 ;;                       [message sent to canceled chan]
 ;;
 ;; 1. Query normally runs thru middleware and then a series of context functions as described above; result is sent thru
-;;    `resultf` and finally to `out-chan`
+;;    [[resultf]] and finally to [[out-chan]]
 ;;
-;; 2. If an `Exception` is thrown, it is sent thru `raisef`, `resultf` and finally to `out-chan`
+;; 2. If an `Exception` is thrown, it is sent thru [[raisef]], [[resultf]] and finally to [[out-chan]]
 ;;
 ;; 3. If the query times out, `timeoutf` throws an Exception
 ;;
-;; 4. If the query is canceled (either by closing `out-chan` before it gets a result, or by sending `canceled-chan` a
-;; message), the execution is canceled and `out-chan` is closed (if not already closed).
+;; 4. If the query is canceled (either by closing [[out-chan]] before it gets a result, or by sending [[canceled-chan]]
+;;    a message), the execution is canceled and [[out-chan]] is closed (if not already closed).
 (defn runf
-  "Called by pivot fn to run preprocessed query. Normally, this simply calls `executef`, but you can override this for
-  test purposes. The result of this function is ignored."
+  "Called by the [[metabase.query-processor.reducible/identity-qp]] fn to run preprocessed query. Normally, this simply
+  calls [[executef]], but you can override this for test purposes. The result of this function is ignored."
   {:arglists '([query rff context])}
   [query rff {runf* :runf, :as context}]
   {:pre [(fn? runf*)]}
@@ -46,12 +46,12 @@
   nil)
 
 (defn executef
-  "Called by `runf` to have driver run query. By default, `driver/execute-reducible-query`. `respond` is a callback with
-  the signature:
+  "Called by [[runf]] to have driver run query. By default, [[metabase.driver/execute-reducible-query]]. `respond` is a
+  callback with the signature:
 
     (respond results-metadata reducible-rows)
 
-  The implementation of `executef` should call `respond` with this information once it is available. The result of
+  The implementation of [[executef]] should call `respond` with this information once it is available. The result of
   this function is ignored."
   {:arglists '([driver query context respond])}
   [driver query {executef* :executef, :as context} respond]
@@ -60,9 +60,9 @@
   nil)
 
 (defn reducef
-  "Called by `runf` (inside the `respond` callback provided by it) to reduce results of query. `reducedf` is called with
-  the reduced results. The actual output of this function is ignored, but the entire result set must be reduced and
-  passed to `reducedf` before this function completes."
+  "Called by [[runf]] (inside the `respond` callback provided by it) to reduce results of query. [[reducedf]] is called
+  with the reduced results. The actual output of this function is ignored, but the entire result set must be reduced
+  and passed to [[reducedf]] before this function completes."
   {:arglists '([rff context metadata reducible-rows])}
   [rff {reducef* :reducef, :as context} metadata reducible-rows]
   {:pre [(fn? reducef*)]}
@@ -70,7 +70,7 @@
   nil)
 
 (defn reducedf
-  "Called in `reducedf` with fully reduced results. This result is passed to `resultf`."
+  "Called in [[reducedf]] with fully reduced results. This result is passed to [[resultf]]."
   {:arglists '([metadata reduced-rows context])}
   [metadata reduced-rows {reducedf* :reducedf, :as context}]
   {:pre [(fn? reducedf*)]}
@@ -84,7 +84,7 @@
   (timeoutf* context))
 
 (defn resultf
-  "Called exactly once with the final result, which is the result of either `reducedf` or `raisef`."
+  "Called exactly once with the final result, which is the result of either [[reducedf]] or [[raisef]]."
   {:arglists '([result context])}
   [result {resultf* :resultf, :as context}]
   {:pre [(fn? resultf*)]}

--- a/src/metabase/query_processor/context/default.clj
+++ b/src/metabase/query_processor/context/default.clj
@@ -95,7 +95,8 @@
 (defn default-context
   "Return a new context for executing queries using the default values. These can be overrided as needed."
   []
-  {:timeout       query-timeout-ms
+  {::complete?    true
+   :timeout       query-timeout-ms
    :rff           default-rff
    :raisef        default-raisef
    :runf          default-runf

--- a/src/metabase/query_processor/middleware/cache.clj
+++ b/src/metabase/query_processor/middleware/cache.clj
@@ -10,8 +10,7 @@
   The default backend is `db`, which uses the application database; this value can be changed by setting the env var
   `MB_QP_CACHE_BACKEND`. Refer to [[metabase.query-processor.middleware.cache-backend.interface]] for more details
   about how the cache backends themselves."
-  (:require [clojure.core.async :as a]
-            [clojure.tools.logging :as log]
+  (:require [clojure.tools.logging :as log]
             [java-time :as t]
             [medley.core :as m]
             [metabase.config :as config]
@@ -52,58 +51,64 @@
   []
   (* (public-settings/query-caching-min-ttl) 1000))
 
-(defn- cache-results-async!
-  "Save the results of a query asynchronously once they are delivered (as a byte array) to the promise channel
-  `out-chan`."
-  [query-hash out-chan]
-  (log/info (trs "Caching results for next time for query with hash {0}." (pr-str (i/short-hex-hash query-hash))) (u/emoji "💾"))
-  (a/go
-    (let [x (a/<! out-chan)]
-      (condp instance? x
-        Throwable
-        (if (= (:type (ex-data x)) ::impl/max-bytes)
-          (log/debug x (trs "Not caching results: results are larger than {0} KB" (public-settings/query-caching-max-kb)))
-          (log/error x (trs "Error saving query results to cache.")))
+(def ^:private ^:dynamic *in-fn*
+  "The `in-fn` provided by [[impl/do-with-serialization]]."
+  nil)
 
-        (Class/forName "[B")
-        (let [y (a/<! (a/thread
-                        (try
-                          (i/save-results! *backend* query-hash x)
-                          (catch Throwable e
-                            e))))]
-          (if (instance? Throwable y)
-            (log/error y (trs "Error saving query results to cache."))
-            (do
-              (log/debug (trs "Successfully cached results for query."))
-              (purge! *backend*))))
+(defn- add-object-to-cache!
+  "Add `object` (e.g. a result row or metadata) to the current cache entry."
+  [object]
+  (when *in-fn*
+    (*in-fn* object)))
 
-        (log/error (trs "Cannot cache results: expected byte array, got {0}" (class x)))))))
+(def ^:private ^:dynamic *result-fn*
+  "The `result-fn` provided by [[impl/do-with-serialization]]."
+  nil)
+
+(defn- serialized-bytes []
+  (when *result-fn*
+    (*result-fn*)))
+
+(defn- cache-results!
+  "Save the final results of a query."
+  [query-hash]
+  (log/info (trs "Caching results for next time for query with hash {0}."
+                 (pr-str (i/short-hex-hash query-hash))) (u/emoji "💾"))
+  (try
+    (let [bytez (serialized-bytes)]
+      (if-not (instance? (Class/forName "[B") bytez)
+        (log/error (trs "Cannot cache results: expected byte array, got {0}" (class bytez)))
+        (do
+          (i/save-results! *backend* query-hash bytez)
+          (log/debug (trs "Successfully cached results for query."))
+          (purge! *backend*))))
+    (catch Throwable e
+      (if (= (:type (ex-data e)) ::impl/max-bytes)
+        (log/debug e (trs "Not caching results: results are larger than {0} KB" (public-settings/query-caching-max-kb)))
+        (log/error e (trs "Error saving query results to cache."))))))
 
 (defn- save-results-xform [start-time metadata query-hash rf]
-  (let [{:keys [in-chan out-chan]} (impl/serialize-async)
-        has-rows?                  (volatile! false)]
-    (a/put! in-chan (assoc metadata
-                           :cache-version cache-version
-                           :last-ran      (t/zoned-date-time)))
+  (let [has-rows? (volatile! false)]
+    (add-object-to-cache! (assoc metadata
+                                 :cache-version cache-version
+                                 :last-ran      (t/zoned-date-time)))
     (fn
       ([] (rf))
 
       ([result]
-       (a/put! in-chan (if (map? result)
-                         (m/dissoc-in result [:data :rows])
-                         {}))
-       (a/close! in-chan)
+       (add-object-to-cache! (if (map? result)
+                               (m/dissoc-in result [:data :rows])
+                               {}))
        (let [duration-ms (- (System/currentTimeMillis) start-time)]
          (log/info (trs "Query took {0} to run; minimum for cache eligibility is {1}"
                         (u/format-milliseconds duration-ms) (u/format-milliseconds (min-duration-ms))))
          (when (and @has-rows?
                     (> duration-ms (min-duration-ms)))
-           (cache-results-async! query-hash out-chan)))
+           (cache-results! query-hash)))
        (rf result))
 
       ([acc row]
-       ;; Blocking so we don't exceed async's MAX-QUEUE-SIZE when transducing a large result set
-       (a/>!! in-chan row)
+       (add-object-to-cache! row)
        (vreset! has-rows? true)
        (rf acc row)))))
 
@@ -167,7 +172,7 @@
 ;;; --------------------------------------------------- Middleware ---------------------------------------------------
 
 (defn- run-query-with-cache
-  [qp {:keys [cache-ttl middleware], :as query} rff context]
+  [qp {:keys [cache-ttl middleware], :as query} rff {:keys [reducef], :as context}]
   ;; TODO - Query will already have `info.hash` if it's a userland query. I'm not 100% sure it will be the same hash,
   ;; because this is calculated after normalization, instead of before
   (let [query-hash (qputil/query-hash query)
@@ -175,10 +180,16 @@
     (when (= result ::miss)
       (let [start-time-ms (System/currentTimeMillis)]
         (log/trace "Running query and saving cached results (if eligible)...")
-        (qp query
-            (fn [metadata]
-              (save-results-xform start-time-ms metadata query-hash (rff metadata)))
-            context)))))
+        (let [reducef' (fn [rff context metadata rows]
+                         (impl/do-with-serialization
+                          (fn [in-fn result-fn]
+                            (binding [*in-fn*     in-fn
+                                      *result-fn* result-fn]
+                              (reducef rff context metadata rows)))))]
+          (qp query
+              (fn [metadata]
+                (save-results-xform start-time-ms metadata query-hash (rff metadata)))
+              (assoc context :reducef reducef')))))))
 
 (defn- is-cacheable? {:arglists '([query])} [{:keys [cache-ttl]}]
   (and (public-settings/enable-query-caching)
@@ -197,7 +208,7 @@
         running the query, satisfying this requirement.)
      *  The result *rows* of the query must be less than `query-caching-max-kb` when serialized (before compression)."
   [qp]
-  (fn [query rff context]
+  (fn maybe-return-cached-results* [query rff context]
     (let [cacheable? (is-cacheable? query)]
       (log/tracef "Query is cacheable? %s" (boolean cacheable?))
       (if cacheable?

--- a/src/metabase/query_processor/middleware/cache/impl.clj
+++ b/src/metabase/query_processor/middleware/cache/impl.clj
@@ -1,9 +1,8 @@
 (ns metabase.query-processor.middleware.cache.impl
-  (:require [clojure.core.async :as a]
-            [clojure.tools.logging :as log]
+  (:require [clojure.tools.logging :as log]
             [metabase.public-settings :as public-settings]
             [metabase.util :as u]
-            [metabase.util.i18n :refer [trs tru]]
+            [metabase.util.i18n :refer [trs]]
             [taoensso.nippy :as nippy])
   (:import [java.io BufferedInputStream BufferedOutputStream ByteArrayOutputStream DataInputStream DataOutputStream
             EOFException FilterOutputStream InputStream OutputStream]
@@ -31,95 +30,58 @@
          (check-total (swap! byte-count + len))
          (.write os ba off len))))))
 
-(def ^:private serialization-timeout-ms (u/minutes->ms 10))
-
-(defn- start-out-chan-close-block!
-  "When `out-chan` closes, close everything. Wait up to 10 minutes for `out-chan` to close, and throw an Exception if
-  it's not done by then."
-  [in-chan out-chan ^ByteArrayOutputStream bos ^DataOutputStream os]
-  (a/go
-    (let [timeout-chan (a/timeout serialization-timeout-ms)
-          [_val port]   (a/alts! [out-chan timeout-chan])]
-      (when (= port timeout-chan)
-        (a/>! out-chan (ex-info (tru "Serialization timed out after {0}." (u/format-milliseconds serialization-timeout-ms))
-                                {}))))
-    (log/tracef "Closing core.async channels and output streams.")
-    (try
-      ;; don't really need to close both, probably
-      (.close os)
-      (.close bos)
-      (catch Throwable e
-        (a/>! out-chan e)))
-    (a/close! out-chan)
-    (a/close! in-chan)))
-
 (defn- freeze!
   [^OutputStream os obj]
-  (try
-    (nippy/freeze-to-out! os obj)
-    (.flush os)
-    :ok
-    (catch Throwable e
-      e)))
+  (log/tracef "Freezing %s" (pr-str obj))
+  (nippy/freeze-to-out! os obj)
+  (.flush os))
 
-(defn- start-input-loop!
-  "Listen for things sent to `in-chan`. When we get an object to `in-chan`, write it to the ouput stream (async), then
-  recur and wait for the next obj. When `in-chan` is closed, write the bytes to `out-chan` (async).
+(defn do-with-serialization
+  "Create output streams for serializing QP results and invoke `f`, a function of the form
 
-  If serialization fails, writes thrown Exception to `out-chan`."
-  [in-chan out-chan ^ByteArrayOutputStream bos ^DataOutputStream os]
-  (a/go-loop []
-    ;; we got a result
-    (if-let [obj (a/<! in-chan)]
-      (do
-        (log/tracef "Serializing %s" (pr-str obj))
-        (let [result (a/<! (a/thread (freeze! os obj)))]
-          (if (instance? Throwable result)
-            (do
-              ;; Serialization has failed, close the channel as there's no point in continuing writing to it
-              (a/close! in-chan)
-              ;; Drain the channel to unblock
-              (while (a/poll! in-chan))
-              (a/>! out-chan result))
-            (recur))))
-      ;; `in-chan` is closed
-      (a/thread
-        (try
-          (.flush os)
-          (let [result (.toByteArray bos)]
-            (a/>!! out-chan result))
-          (catch Throwable e
-            (a/>!! out-chan e)))))))
+    (f in-fn result-fn)
 
-(defn serialize-async
-  "Create output streams for serializing QP results. Returns a map of core.async channels, `in-chan` and `out-chan`.
-  Send all objects to be serialized to `in-chan`; then close it when finished; the result of `out-chan` will be the
-  serialized byte array (or an Exception, if one was thrown).
+  `in-fn` is of the form `(in-fn object)` and should be called once for each object that should be serialized. `in-fn`
+  will catch any exceptions thrown during serialization; these will be thrown later when invoking `result-fn`. After
+  the first exception `in-fn` will no-op for all subsequent calls.
 
-  `out-chan` is closed automatically upon receiving a result; all chans and output streams are closed thereafter.
+  When you have serialized *all* objects, call `result-fn` to get the serialized byte array. If an error was
+  encountered during serialization (such as the serialized bytes being longer than `max-bytes`), `result-fn` will
+  throw an Exception rather than returning a byte array; be sure to handle this case.
 
-    (let [{:keys [in-chan out-chan]} (serialize-async)]
-      (doseq [obj objects]
-        (a/put! in-chan obj))
-      (a/close! in-chan)
-      (let [[val] (a/alts!! [out-chan (a/timeout 1000)])]
-        (when (instance? Throwable val)
-          (throw val))
-         val))"
-  ([]
-   (serialize-async {:max-bytes (* (public-settings/query-caching-max-kb) 1024)}))
+    (do-with-serialization
+      (fn [in result]
+        (doseq [obj objects]
+          (in obj))
+        (result)))"
+  ([f]
+   (do-with-serialization f {:max-bytes (* (public-settings/query-caching-max-kb) 1024)}))
 
-  ([{:keys [max-bytes]}]
-   (let [in-chan  (a/chan 1)
-         out-chan (a/promise-chan)
-         bos      (ByteArrayOutputStream.)
-         os       (-> (max-bytes-output-stream max-bytes bos)
-                      BufferedOutputStream.
-                      (GZIPOutputStream. true)
-                      DataOutputStream.)]
-     (start-out-chan-close-block! in-chan out-chan bos os)
-     (start-input-loop! in-chan out-chan bos os)
-     {:in-chan in-chan, :out-chan out-chan})))
+  ([f {:keys [max-bytes]}]
+   (with-open [bos (ByteArrayOutputStream.)]
+     (let [os    (-> (max-bytes-output-stream max-bytes bos)
+                     BufferedOutputStream.
+                     (GZIPOutputStream. true)
+                     DataOutputStream.)
+           error (atom nil)]
+       (try
+         (f (fn in* [obj]
+              (when-not @error
+                (try
+                  (freeze! os obj)
+                  (catch Throwable e
+                    (log/trace e "Caught error when freezing object")
+                    (reset! error e))))
+              nil)
+            (fn result* []
+              (when @error
+                (throw @error))
+              (log/trace "Getting result byte array")
+              (.toByteArray bos)))
+         ;; this is done manually instead of `with-open` because it might throw an Exception when we close it if it's
+         ;; past the byte limit; that's fine and we can ignore it
+         (finally
+           (u/ignore-exceptions (.close os))))))))
 
 (defn- thaw!
   [^InputStream is]

--- a/test/metabase/query_processor/middleware/cache/impl_test.clj
+++ b/test/metabase/query_processor/middleware/cache/impl_test.clj
@@ -1,6 +1,5 @@
 (ns metabase.query-processor.middleware.cache.impl-test
-  (:require [clojure.core.async :as a]
-            [clojure.test :refer :all]
+  (:require [clojure.test :refer :all]
             [metabase.query-processor.middleware.cache.impl :as impl]
             [potemkin.types :as p.types])
   (:import java.io.ByteArrayInputStream))
@@ -27,26 +26,26 @@
            (reduce rf (rf) rows)))))))
 
 (deftest e2e-test
-  (let [{:keys [in-chan out-chan]} (impl/serialize-async)]
-    (doseq [obj objects]
-      (a/put! in-chan obj))
-    (a/close! in-chan)
-    (let [[val] (a/alts!! [out-chan (a/timeout 1000)])]
-      (is (= objects
-             (if (instance? Throwable val)
-               (throw val)
-               (deserialize val)))))))
+  (impl/do-with-serialization
+   (fn [in result]
+     (doseq [obj objects]
+       (is (= nil
+              (in obj))))
+     (let [val (result)]
+       (is (instance? (Class/forName "[B") val))
+       (is (= objects
+              (if (instance? Throwable val)
+                (throw val)
+                (deserialize val))))))))
 
 (deftest max-bytes-test
-  (let [{:keys [in-chan out-chan]} (impl/serialize-async {:max-bytes 50})]
-    (doseq [obj objects]
-      (a/put! in-chan obj))
-    (a/close! in-chan)
-    (let [[val] (a/alts!! [out-chan (a/timeout 1000)])]
-      (is (thrown-with-msg?
-           Exception
-           #"Results are too large to cache\."
-           (if (instance? Throwable val)
-             (throw val)
-             val)))
-      nil)))
+  (impl/do-with-serialization
+   (fn [in result]
+     (doseq [obj objects]
+       (is (= nil
+              (in obj))))
+     (is (thrown-with-msg?
+          Exception
+          #"Results are too large to cache\."
+          (result))))
+   {:max-bytes 50}))

--- a/test/metabase/query_processor/reducible_test.clj
+++ b/test/metabase/query_processor/reducible_test.clj
@@ -147,7 +147,7 @@
   (testing "Rows don't actually have to be reducible. And you can build your own QP with your own middleware."
     (is (= {:data {:cols [{:name "n"}]
                    :rows [{:n 1} {:n 2} {:n 3} {:n 4} {:n 5}]}}
-           ((qp.reducible/sync-qp (qp.reducible/async-qp qp.reducible/pivot))
+           ((qp.reducible/sync-qp (qp.reducible/async-qp qp.reducible/identity-qp))
             {}
             {:executef (fn [_ _ _ respond]
                          (respond {:cols [{:name "n"}]}

--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -3,6 +3,7 @@
 
   (Prefer using `metabase.test` to requiring bits and pieces from these various namespaces going forward, since it
   reduces the cognitive load required to write tests.)"
+  (:refer-clojure :exclude [compile])
   (:require clojure.data
             [clojure.test :refer :all]
             [clojure.tools.macro :as tools.macro]

--- a/test/metabase/test/util/log.clj
+++ b/test/metabase/test/util/log.clj
@@ -56,9 +56,11 @@
   "Execute `body` with all logging/`*out*`/`*err*` messages suppressed. Useful for avoiding cluttering up test output
   for tests with stacktraces and error messages from tests that are supposed to fail.
 
-  DEPRECATED -- you don't need to do this anymore. Tests now have a default log level of `CRITICAL` which means error
+  DEPRECATED -- you don't need to do this anymore. Tests now have a default log level of `FATAL` which means error
   logging will be suppressed by default. This macro predates the current test logging levels. You can remove usages of
-  this macro."
+  this macro.
+
+  If you want to suppress log messages for REPL usage you can use [[with-log-level]] instead."
   {:style/indent 0}
   [& body]
   `(do-with-suppressed-output (fn [] ~@body)))


### PR DESCRIPTION
Follow-on to #19959
Implements #14386

This simplifies our QP cache middleware and makes it completely synchronous. (i.e., it serializes result rows to bytes as they come in and saves them to the database when we finish reducing result rows). This make the code an order of magnitude simpler and should finally fix the super annoying flaky cache test that has been around for years.

See #14386 for more details. There was too much asyncerry going on and I'm not convinced the theoretical multithreading performance benefit (never actually profiled) was worth the extra memory overhead and confusing code.

I did a little bit of docstring cleanup and code reorganization as part of this PR. It's entirely unrelated; only changes in the `cache` and `cache.impl` namespaces are actual real changes.
