### PR TITLE
Fix nested query controls for no-data users

### DIFF
--- a/frontend/src/metabase-lib/lib/queries/NativeQuery.ts
+++ b/frontend/src/metabase-lib/lib/queries/NativeQuery.ts
@@ -133,6 +133,12 @@ export default class NativeQuery extends AtomicQuery {
     return !database || database.native_permissions !== "write";
   }
 
+  // This basically just mirrors StructuredQueries `isEditable` method,
+  // so there is no need to do `isStructured ? isEditable() : readOnly()`
+  isEditable() {
+    return !this.readOnly();
+  }
+
   /* Methods unique to this query type */
 
   /**

--- a/frontend/src/metabase-lib/lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/lib/queries/StructuredQuery.ts
@@ -109,7 +109,7 @@ export default class StructuredQuery extends AtomicQuery {
    * @returns true if this query is in a state where it can be edited. Must have database and table set, and metadata for the table loaded.
    */
   isEditable() {
-    return this.hasMetadata();
+    return !this.readOnly() && this.hasMetadata();
   }
 
   /* AtomicQuery superclass methods */

--- a/frontend/src/metabase/internal/components/QuestionApp.jsx
+++ b/frontend/src/metabase/internal/components/QuestionApp.jsx
@@ -24,11 +24,7 @@ export default class QuestionApp extends React.Component {
         >
           {({ question, rawSeries }) =>
             rawSeries && (
-              <Visualization
-                className="flex-full"
-                rawSeries={rawSeries}
-                query={question.query()}
-              />
+              <Visualization className="flex-full" rawSeries={rawSeries} />
             )
           }
         </QuestionAndResultLoader>

--- a/frontend/src/metabase/internal/components/QuestionApp.jsx
+++ b/frontend/src/metabase/internal/components/QuestionApp.jsx
@@ -22,9 +22,13 @@ export default class QuestionApp extends React.Component {
           questionHash={location.hash}
           questionId={params.questionId ? parseInt(params.questionId) : null}
         >
-          {({ rawSeries }) =>
+          {({ question, rawSeries }) =>
             rawSeries && (
-              <Visualization className="flex-full" rawSeries={rawSeries} />
+              <Visualization
+                className="flex-full"
+                rawSeries={rawSeries}
+                query={question.query()}
+              />
             )
           }
         </QuestionAndResultLoader>

--- a/frontend/src/metabase/new_query/selectors.js
+++ b/frontend/src/metabase/new_query/selectors.js
@@ -26,7 +26,10 @@ export const getPlainNativeQuery = state => {
 
 export const getHasDataAccess = createSelector(
   [getDatabases],
-  databases => databases && Object.values(databases).length > 0,
+  (databaseMap = {}) =>
+    // This ensures there is at least one real (not saved questions) DB available
+    // If there is only the saved questions DB, it doesn't mean a user has data access
+    Object.values(databaseMap).some(db => !db.is_saved_questions),
 );
 export const getHasNativeWrite = createSelector(
   [getDatabases],

--- a/frontend/src/metabase/new_query/selectors.js
+++ b/frontend/src/metabase/new_query/selectors.js
@@ -31,9 +31,9 @@ export const getHasDataAccess = createSelector(
     // If there is only the saved questions DB, it doesn't mean a user has data access
     Object.values(databaseMap).some(db => !db.is_saved_questions),
 );
+
 export const getHasNativeWrite = createSelector(
   [getDatabases],
-  databases =>
-    databases &&
-    Object.values(databases).some(d => d.native_permissions === "write"),
+  (databaseMap = {}) =>
+    Object.values(databaseMap).some(d => d.native_permissions === "write"),
 );

--- a/frontend/src/metabase/query_builder/components/view/HeaderBreadcrumbs/HeaderBreadcrumbs.jsx
+++ b/frontend/src/metabase/query_builder/components/view/HeaderBreadcrumbs/HeaderBreadcrumbs.jsx
@@ -29,7 +29,7 @@ export function HeadBreadcrumbs({
   ...props
 }) {
   return (
-    <Container {...props} variant={variant}>
+    <Container {...props} variant={variant} data-testid="head-crumbs-container">
       {parts.map((part, index) => {
         const isLast = index === parts.length - 1;
         const badgeInactiveColor =

--- a/frontend/src/metabase/query_builder/components/view/HeaderBreadcrumbs/HeaderBreadcrumbs.jsx
+++ b/frontend/src/metabase/query_builder/components/view/HeaderBreadcrumbs/HeaderBreadcrumbs.jsx
@@ -29,7 +29,7 @@ export function HeadBreadcrumbs({
   ...props
 }) {
   return (
-    <Container {...props} variant={variant} data-testid="head-crumbs-container">
+    <Container data-testid="head-crumbs-container" {...props} variant={variant}>
       {parts.map((part, index) => {
         const isLast = index === parts.length - 1;
         const badgeInactiveColor =

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
@@ -146,12 +146,17 @@ function getDataSourceParts({ question, subHead, isObjectDetail }) {
     return [];
   }
 
-  const parts = [];
-
   const isStructuredQuery = question.isStructured();
   const query = isStructuredQuery
     ? question.query().rootQuery()
     : question.query();
+
+  const hasDataPermission = query.isEditable();
+  if (!hasDataPermission) {
+    return [];
+  }
+
+  const parts = [];
 
   const database = query.database();
   if (database) {

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSource.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSource.unit.spec.js
@@ -331,6 +331,16 @@ describe("QuestionDataSource", () => {
             Urls.browseDatabase(question.database()),
           );
         });
+
+        it("shows nothing if a user doesn't have data permissions", () => {
+          const originalMethod = question.query().database;
+          question.query().database = () => null;
+
+          setup({ question });
+          expect(screen.getByTestId("head-crumbs-container")).toBeEmpty();
+
+          question.query().database = originalMethod;
+        });
       });
     });
   });

--- a/frontend/src/metabase/query_builder/components/view/ViewFooter.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewFooter.jsx
@@ -69,6 +69,8 @@ const ViewFooter = ({
     return null;
   }
 
+  const hasDataPermission = question.query().isEditable();
+
   return (
     <ViewFooterRoot className={cx(className, "text-medium border-top")}>
       <ButtonBar
@@ -97,26 +99,30 @@ const ViewFooter = ({
               onCloseSummary={onCloseSummary}
             />
           ),
-          <VizTypeButton
-            key="viz-type"
-            question={question}
-            result={result}
-            active={isShowingChartTypeSidebar}
-            onClick={
-              isShowingChartTypeSidebar ? onCloseChartType : onOpenChartType
-            }
-          />,
-          <VizSettingsButton
-            key="viz-settings"
-            ml={1}
-            mr={[3, 0]}
-            active={isShowingChartSettingsSidebar}
-            onClick={
-              isShowingChartSettingsSidebar
-                ? onCloseChartSettings
-                : onOpenChartSettings
-            }
-          />,
+          hasDataPermission && (
+            <VizTypeButton
+              key="viz-type"
+              question={question}
+              result={result}
+              active={isShowingChartTypeSidebar}
+              onClick={
+                isShowingChartTypeSidebar ? onCloseChartType : onOpenChartType
+              }
+            />
+          ),
+          hasDataPermission && (
+            <VizSettingsButton
+              key="viz-settings"
+              ml={1}
+              mr={[3, 0]}
+              active={isShowingChartSettingsSidebar}
+              onClick={
+                isShowingChartSettingsSidebar
+                  ? onCloseChartSettings
+                  : onOpenChartSettings
+              }
+            />
+          ),
         ]}
         center={
           isVisualized && (

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.unit.spec.js
@@ -213,6 +213,21 @@ describe("ViewHeader", () => {
             screen.queryByLabelText("refresh icon"),
           ).not.toBeInTheDocument();
         });
+
+        it("does not offer to modify a query when a user doesn't have data permissions", () => {
+          const originalMethod = question.query().database;
+          question.query().database = () => null;
+
+          setup({ question });
+          expect(screen.queryByText("Filter")).not.toBeInTheDocument();
+          expect(screen.queryByText("Summarize")).not.toBeInTheDocument();
+          expect(
+            screen.queryByLabelText("notebook icon"),
+          ).not.toBeInTheDocument();
+          expect(screen.queryByLabelText("refresh icon")).toBeInTheDocument();
+
+          question.query().database = originalMethod;
+        });
       });
     });
   });

--- a/frontend/src/metabase/visualizations/components/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive.jsx
@@ -586,7 +586,7 @@ export default class TableInteractive extends Component {
 
     const clicked = this.getHeaderClickedObject(columnIndex);
 
-    const isDraggable = !isPivoted && query.isEditable();
+    const isDraggable = !isPivoted && query && query.isEditable();
     const isDragging = dragColIndex === columnIndex;
     const isClickable = this.visualizationIsClickable(clicked);
     const isSortable = isClickable && column.source && !isPivoted;

--- a/frontend/src/metabase/visualizations/components/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive.jsx
@@ -570,6 +570,7 @@ export default class TableInteractive extends Component {
   // We should maybe rethink the approach to measurements or render a very basic table header, without react-draggable
   tableHeaderRenderer = ({ key, style, columnIndex, isVirtual = false }) => {
     const {
+      query,
       data,
       sort,
       isPivoted,
@@ -585,7 +586,7 @@ export default class TableInteractive extends Component {
 
     const clicked = this.getHeaderClickedObject(columnIndex);
 
-    const isDraggable = !isPivoted;
+    const isDraggable = !isPivoted && query.isEditable();
     const isDragging = dragColIndex === columnIndex;
     const isClickable = this.visualizationIsClickable(clicked);
     const isSortable = isClickable && column.source && !isPivoted;

--- a/frontend/test/metabase-lib/lib/Question.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Question.unit.spec.js
@@ -1170,6 +1170,7 @@ describe("Question", () => {
         query: {
           "source-table": 1,
         },
+        database: 1,
       },
     };
 

--- a/frontend/test/metabase-lib/lib/queries/StructuredQuery.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/StructuredQuery.unit.spec.js
@@ -158,6 +158,12 @@ describe("StructuredQuery", () => {
       it("A valid query should be editable", () => {
         expect(query.isEditable()).toBe(true);
       });
+
+      it("should be not editable when database object is missing", () => {
+        const q = makeQuery();
+        q.database = () => null;
+        expect(q.isEditable()).toBe(false);
+      });
     });
     describe("isEmpty", () => {
       it("tells that a non-empty query is not empty", () => {

--- a/frontend/test/metabase/scenarios/question/reproductions/18978-18977-nested-question-nodata-user.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/18978-18977-nested-question-nodata-user.cy.spec.js
@@ -1,0 +1,39 @@
+import { restore, popover } from "__support__/e2e/cypress";
+
+describe("18978, 18977", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+    cy.intercept("/api/card/*/query").as("cardQuery");
+  });
+
+  it("should not display query editing controls and 'Browse Data' link", () => {
+    cy.createQuestion({
+      query: {
+        "source-table": "card__1",
+      },
+    }).then(({ body: { id } }) => {
+      cy.signIn("nodata");
+      cy.visit(`/question/${id}`);
+      cy.wait("@cardQuery");
+
+      cy.get(".Nav").within(() => {
+        cy.findByText(/Browse data/i).should("not.exist");
+        cy.icon("add").click();
+      });
+
+      popover().within(() => {
+        cy.findByText("Question").should("not.exist");
+        cy.findByText("SQL query").should("not.exist");
+      });
+
+      cy.findByTestId("qb-header-action-panel").within(() => {
+        cy.icon("notebook").should("not.exist");
+        cy.findByText("Filter").should("not.exist");
+        cy.findByText("Summarize").should("not.exist");
+      });
+      cy.findByTestId("viz-type-button").should("not.exist");
+      cy.findByTestId("viz-settings-button").should("not.exist");
+    });
+  });
+});

--- a/frontend/test/metabase/visualizations/components/Visualization-table.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/Visualization-table.unit.spec.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { render } from "@testing-library/react";
 
+import { ORDERS } from "__support__/sample_database_fixture";
 import { NumberColumn } from "../__support__/visualizations";
 
 import Visualization from "metabase/visualizations/components/Visualization";
@@ -38,7 +39,10 @@ describe("Table", () => {
       ],
     };
     const { getByText } = render(
-      <Visualization rawSeries={series(rows, settings)} />,
+      <Visualization
+        rawSeries={series(rows, settings)}
+        query={ORDERS.question().query()}
+      />,
     );
     jest.runAllTimers();
     const bgColors = rows.map(

--- a/frontend/test/metabase/visualizations/components/Visualization-table.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/Visualization-table.unit.spec.js
@@ -1,7 +1,6 @@
 import React from "react";
 import { render } from "@testing-library/react";
 
-import { ORDERS } from "__support__/sample_database_fixture";
 import { NumberColumn } from "../__support__/visualizations";
 
 import Visualization from "metabase/visualizations/components/Visualization";
@@ -39,10 +38,7 @@ describe("Table", () => {
       ],
     };
     const { getByText } = render(
-      <Visualization
-        rawSeries={series(rows, settings)}
-        query={ORDERS.question().query()}
-      />,
+      <Visualization rawSeries={series(rows, settings)} />,
     );
     jest.runAllTimers();
     const bgColors = rows.map(


### PR DESCRIPTION
Reproduces #18977, fixes #18977, reproduces #18978, fixes #18978

When a no-data user visits a nested query (a question with `source-table: "card__$ID"`), some UI controls allowing to modify the query are exposed. Any attempt to modify a query (filtering, aggregating, reordering columns, changing viz) ends up in "You don't have permission for that" error page.

### To Verify

1. Create a nested query (e.g. in the top navbar "+ Add" > "Question" "Saved Questions" > pick any question > Save)
2. Sign in as a no-data user and open that question
3. Make sure there are no controls to modify a query
    * no "Filter" button
    * no "Summarize" button
    * no "notebook" icon in the view header
    * no "Visualization" and "Settings" buttons in the view footer (@flamber this was not explicitly mentioned in the issues, but changing anything in there doesn't work for no-data users, so I removed them. Please LMK if I'm missing something)
    * no way to reorder table columns by dragging
    * no "Browse Data" link the top navbar
    * no "Question" option in "+ Add" menu in the top navbar
4. Make sure other questions look as before for no-data and normal users

NOTE: we still offer to use drill-throughs in this case (#11914), will fix that in the next PR

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/152987807-736413d2-696f-4c72-8408-ff7a75bdd925.mp4

**After**

https://user-images.githubusercontent.com/17258145/152987836-c3713412-dea3-4265-ba03-91fe7d0becdb.mp4


