### PR TITLE
Hide drills for no-data users

### DIFF
--- a/frontend/src/metabase/modes/components/drill/AutomaticDashboardDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/AutomaticDashboardDrill.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable react/prop-types */
-import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
 import { t } from "ttag";
 import { isExpressionField } from "metabase/lib/query/field_ref";
 
@@ -7,7 +5,8 @@ import MetabaseSettings from "metabase/lib/settings";
 
 export default ({ question, clicked }) => {
   const query = question.query();
-  if (!(query instanceof StructuredQuery)) {
+
+  if (!question.isStructured() || !query.isEditable()) {
     return [];
   }
 

--- a/frontend/src/metabase/modes/components/drill/ColumnFilterDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/ColumnFilterDrill.jsx
@@ -2,7 +2,6 @@
 import React from "react";
 import { t } from "ttag";
 
-import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
 import Filter from "metabase-lib/lib/queries/structured/Filter";
 
 import FilterPopover from "metabase/query_builder/components/filters/FilterPopover";
@@ -10,7 +9,8 @@ import FilterPopover from "metabase/query_builder/components/filters/FilterPopov
 export default function QuickFilterDrill({ question, clicked }) {
   const query = question.query();
   if (
-    !(query instanceof StructuredQuery) ||
+    !question.isStructured() ||
+    !query.isEditable() ||
     !clicked ||
     !clicked.column ||
     clicked.column.field_ref == null ||

--- a/frontend/src/metabase/modes/components/drill/ColumnFilterDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/ColumnFilterDrill.jsx
@@ -6,7 +6,7 @@ import Filter from "metabase-lib/lib/queries/structured/Filter";
 
 import FilterPopover from "metabase/query_builder/components/filters/FilterPopover";
 
-export default function QuickFilterDrill({ question, clicked }) {
+export default function ColumnFilterDrill({ question, clicked }) {
   const query = question.query();
   if (
     !question.isStructured() ||

--- a/frontend/src/metabase/modes/components/drill/CompareToRestDrill.js
+++ b/frontend/src/metabase/modes/components/drill/CompareToRestDrill.js
@@ -1,5 +1,3 @@
-/* eslint-disable react/prop-types */
-import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
 import { t } from "ttag";
 
 import { isExpressionField } from "metabase/lib/query/field_ref";
@@ -7,7 +5,7 @@ import MetabaseSettings from "metabase/lib/settings";
 
 export default ({ question, clicked }) => {
   const query = question.query();
-  if (!(query instanceof StructuredQuery)) {
+  if (!question.isStructured() || !query.isEditable()) {
     return [];
   }
 

--- a/frontend/src/metabase/modes/components/drill/DistributionDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/DistributionDrill.jsx
@@ -15,7 +15,8 @@ export default ({ question, clicked }) => {
     !clicked ||
     !clicked.column ||
     clicked.value !== undefined ||
-    _.any(DENYLIST_TYPES, t => isa(clicked.column.semantic_type, t))
+    _.any(DENYLIST_TYPES, t => isa(clicked.column.semantic_type, t)) ||
+    !question.query().isEditable()
   ) {
     return [];
   }

--- a/frontend/src/metabase/modes/components/drill/FormatAction.jsx
+++ b/frontend/src/metabase/modes/components/drill/FormatAction.jsx
@@ -10,7 +10,12 @@ function showChartSettings(...args) {
 import { keyForColumn } from "metabase/lib/dataset";
 
 export default ({ question, clicked }) => {
-  if (!clicked || clicked.value !== undefined || !clicked.column) {
+  if (
+    !clicked ||
+    clicked.value !== undefined ||
+    !clicked.column ||
+    !question.query().isEditable()
+  ) {
     return [];
   }
   const { column } = clicked;

--- a/frontend/src/metabase/modes/components/drill/ObjectDetailDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/ObjectDetailDrill.jsx
@@ -42,7 +42,8 @@ export default ({ question, clicked }) => {
   if (
     !clicked?.column ||
     clicked?.value === undefined ||
-    !(isFK(clicked.column) || isPK(clicked.column))
+    !(isFK(clicked.column) || isPK(clicked.column)) ||
+    !question.query().isEditable()
   ) {
     return [];
   }

--- a/frontend/src/metabase/modes/components/drill/PivotByDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/PivotByDrill.jsx
@@ -2,13 +2,12 @@
 import React from "react";
 import { jt } from "ttag";
 import BreakoutPopover from "metabase/query_builder/components/BreakoutPopover";
-import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
 
 // PivotByDrill displays a breakout picker, and optionally filters by the
-// clicked dimesion values (and removes corresponding breakouts)
+// clicked dimension values (and removes corresponding breakouts)
 export default (name, icon, fieldFilter) => ({ question, clicked }) => {
   const query = question.query();
-  if (!(query instanceof StructuredQuery)) {
+  if (!question.isStructured() || !query.isEditable()) {
     return [];
   }
 

--- a/frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx
@@ -96,6 +96,7 @@ export default function QuickFilterDrill({ question, clicked }) {
   const query = question.query();
   if (
     !question.isStructured() ||
+    !query.isEditable() ||
     !clicked?.column ||
     clicked.value === undefined
   ) {

--- a/frontend/src/metabase/modes/components/drill/SortAction.jsx
+++ b/frontend/src/metabase/modes/components/drill/SortAction.jsx
@@ -1,11 +1,9 @@
-/* eslint-disable react/prop-types */
 import { t } from "ttag";
-import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
 import Dimension from "metabase-lib/lib/Dimension";
 
 export default ({ question, clicked }) => {
   const query = question.query();
-  if (!(query instanceof StructuredQuery)) {
+  if (!question.isStructured() || !query.isEditable()) {
     return [];
   }
 

--- a/frontend/src/metabase/modes/components/drill/SummarizeColumnByTimeDrill.js
+++ b/frontend/src/metabase/modes/components/drill/SummarizeColumnByTimeDrill.js
@@ -1,7 +1,6 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
-import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
 import { fieldRefForColumn } from "metabase/lib/dataset";
 import {
   getAggregationOperator,
@@ -12,7 +11,8 @@ import { capitalize } from "metabase/lib/formatting";
 export default ({ question, clicked = {} }) => {
   const { column, value } = clicked;
   const query = question.query();
-  if (!column || value !== undefined || !(query instanceof StructuredQuery)) {
+  const isStructured = question.isStructured();
+  if (!column || value !== undefined || !isStructured || !query.isEditable()) {
     return [];
   }
   const dateDimension = query

--- a/frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js
+++ b/frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js
@@ -5,7 +5,6 @@ import {
   isCompatibleAggregationOperatorForField,
 } from "metabase/lib/schema_metadata";
 import { t } from "ttag";
-import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
 
 const AGGREGATIONS = {
   sum: {
@@ -28,13 +27,11 @@ const AGGREGATIONS = {
 export default ({ question, clicked = {} }) => {
   const { column, value } = clicked;
   if (!column || value !== undefined) {
-    // TODO Atte Keinänen 7/21/17: Does it slow down the drill-through option calculations remarkably
-    // that I removed the `isSummable` condition from here and use `isCompatibleAggregator` method below instead?
     return [];
   }
 
   const query = question.query();
-  if (!(query instanceof StructuredQuery)) {
+  if (!question.isStructured() || !query.isEditable()) {
     return [];
   }
 

--- a/frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx
@@ -1,8 +1,5 @@
-/* eslint-disable react/prop-types */
 import { ngettext, msgid } from "ttag";
 import { inflect } from "metabase/lib/formatting";
-
-import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
 
 import { AggregationDimension } from "metabase-lib/lib/Dimension";
 
@@ -12,7 +9,7 @@ export default ({ question, clicked }) => {
   question = question.topLevelQuestion();
 
   const query = question.query();
-  if (!(query instanceof StructuredQuery)) {
+  if (!question.isStructured() || !query.isEditable()) {
     return [];
   }
 

--- a/frontend/src/metabase/modes/components/drill/ZoomDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/ZoomDrill.jsx
@@ -1,9 +1,12 @@
-/* eslint-disable react/prop-types */
 import { drillDownForDimensions } from "metabase/modes/lib/actions";
 
 import { t } from "ttag";
 
-export default ({ question, clicked, settings }) => {
+export default ({ question, clicked }) => {
+  if (!question.query().isEditable()) {
+    return [];
+  }
+
   const dimensions = (clicked && clicked.dimensions) || [];
   const drilldown = drillDownForDimensions(dimensions, question.metadata());
   if (!drilldown) {

--- a/frontend/src/metabase/query_builder/components/VisualizationResult.jsx
+++ b/frontend/src/metabase/query_builder/components/VisualizationResult.jsx
@@ -102,13 +102,15 @@ export default class VisualizationResult extends Component {
         this.props,
         ...ALLOWED_VISUALIZATION_PROPS,
       );
-
+      const hasDrills = this.props.query.isEditable();
       return (
         <>
           <Visualization
             className={className}
             rawSeries={rawSeries}
-            onChangeCardAndRun={navigateToNewCardInsideQB}
+            onChangeCardAndRun={
+              hasDrills ? navigateToNewCardInsideQB : undefined
+            }
             isEditing={true}
             isObjectDetail={false}
             isQueryBuilder={true}

--- a/frontend/src/metabase/visualizations/components/LineAreaBarChart.css
+++ b/frontend/src/metabase/visualizations/components/LineAreaBarChart.css
@@ -196,8 +196,11 @@
 }
 
 .LineAreaBarChart .dc-chart .voronoi {
-  cursor: pointer;
   fill: transparent;
+}
+
+.LineAreaBarChart .dc-chart .voronoi-drill {
+  cursor: pointer;
 }
 
 /* we put the brush behind everything so this isn't necessary

--- a/frontend/src/metabase/visualizations/components/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive.jsx
@@ -641,7 +641,8 @@ export default class TableInteractive extends Component {
 
     const clicked = this.getHeaderClickedObject(columnIndex);
 
-    const isDraggable = !isPivoted && query && query.isEditable();
+    const isEditableQuery = query && query.isEditable();
+    const isDraggable = !isPivoted && isEditableQuery;
     const isDragging = dragColIndex === columnIndex;
     const isClickable = this.visualizationIsClickable(clicked);
     const isSortable = isClickable && column.source && !isPivoted;
@@ -767,38 +768,40 @@ export default class TableInteractive extends Component {
               columnIndex,
             )}
           </DimensionInfoPopover>
-          <Draggable
-            enableUserSelectHack={!isVirtual}
-            axis="x"
-            bounds={{ left: RESIZE_HANDLE_WIDTH }}
-            position={{
-              x: this.getColumnWidth({ index: columnIndex }),
-              y: 0,
-            }}
-            onStart={e => {
-              e.stopPropagation();
-              this.setState({ dragColIndex: columnIndex });
-            }}
-            onStop={(e, { x }) => {
-              // prevent onVisualizationClick from being fired
-              e.stopPropagation();
-              this.onColumnResize(columnIndex, x);
-              this.setState({ dragColIndex: null });
-            }}
-          >
-            <div
-              className="bg-brand-hover bg-brand-active"
-              style={{
-                zIndex: 99,
-                position: "absolute",
-                width: RESIZE_HANDLE_WIDTH,
-                top: 0,
-                bottom: 0,
-                left: -RESIZE_HANDLE_WIDTH - 1,
-                cursor: "ew-resize",
+          {isEditableQuery && (
+            <Draggable
+              enableUserSelectHack={!isVirtual}
+              axis="x"
+              bounds={{ left: RESIZE_HANDLE_WIDTH }}
+              position={{
+                x: this.getColumnWidth({ index: columnIndex }),
+                y: 0,
               }}
-            />
-          </Draggable>
+              onStart={e => {
+                e.stopPropagation();
+                this.setState({ dragColIndex: columnIndex });
+              }}
+              onStop={(e, { x }) => {
+                // prevent onVisualizationClick from being fired
+                e.stopPropagation();
+                this.onColumnResize(columnIndex, x);
+                this.setState({ dragColIndex: null });
+              }}
+            >
+              <div
+                className="bg-brand-hover bg-brand-active"
+                style={{
+                  zIndex: 99,
+                  position: "absolute",
+                  width: RESIZE_HANDLE_WIDTH,
+                  top: 0,
+                  bottom: 0,
+                  left: -RESIZE_HANDLE_WIDTH - 1,
+                  cursor: "ew-resize",
+                }}
+              />
+            </Draggable>
+          )}
         </div>
       </Draggable>
     );

--- a/frontend/src/metabase/visualizations/components/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive.jsx
@@ -641,8 +641,7 @@ export default class TableInteractive extends Component {
 
     const clicked = this.getHeaderClickedObject(columnIndex);
 
-    const isEditableQuery = query && query.isEditable();
-    const isDraggable = !isPivoted && isEditableQuery;
+    const isDraggable = !isPivoted && query && query.isEditable();
     const isDragging = dragColIndex === columnIndex;
     const isClickable = this.visualizationIsClickable(clicked);
     const isSortable = isClickable && column.source && !isPivoted;
@@ -768,40 +767,38 @@ export default class TableInteractive extends Component {
               columnIndex,
             )}
           </DimensionInfoPopover>
-          {isEditableQuery && (
-            <Draggable
-              enableUserSelectHack={!isVirtual}
-              axis="x"
-              bounds={{ left: RESIZE_HANDLE_WIDTH }}
-              position={{
-                x: this.getColumnWidth({ index: columnIndex }),
-                y: 0,
+          <Draggable
+            enableUserSelectHack={!isVirtual}
+            axis="x"
+            bounds={{ left: RESIZE_HANDLE_WIDTH }}
+            position={{
+              x: this.getColumnWidth({ index: columnIndex }),
+              y: 0,
+            }}
+            onStart={e => {
+              e.stopPropagation();
+              this.setState({ dragColIndex: columnIndex });
+            }}
+            onStop={(e, { x }) => {
+              // prevent onVisualizationClick from being fired
+              e.stopPropagation();
+              this.onColumnResize(columnIndex, x);
+              this.setState({ dragColIndex: null });
+            }}
+          >
+            <div
+              className="bg-brand-hover bg-brand-active"
+              style={{
+                zIndex: 99,
+                position: "absolute",
+                width: RESIZE_HANDLE_WIDTH,
+                top: 0,
+                bottom: 0,
+                left: -RESIZE_HANDLE_WIDTH - 1,
+                cursor: "ew-resize",
               }}
-              onStart={e => {
-                e.stopPropagation();
-                this.setState({ dragColIndex: columnIndex });
-              }}
-              onStop={(e, { x }) => {
-                // prevent onVisualizationClick from being fired
-                e.stopPropagation();
-                this.onColumnResize(columnIndex, x);
-                this.setState({ dragColIndex: null });
-              }}
-            >
-              <div
-                className="bg-brand-hover bg-brand-active"
-                style={{
-                  zIndex: 99,
-                  position: "absolute",
-                  width: RESIZE_HANDLE_WIDTH,
-                  top: 0,
-                  bottom: 0,
-                  left: -RESIZE_HANDLE_WIDTH - 1,
-                  cursor: "ew-resize",
-                }}
-              />
-            </Draggable>
-          )}
+            />
+          </Draggable>
         </div>
       </Draggable>
     );

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
@@ -168,7 +168,7 @@ function dispatchUIEvent(element, eventName) {
 
 // logic for determining the bounding shapes for showing tooltips for a given point.
 // Wikipedia has a good explanation here: https://en.wikipedia.org/wiki/Voronoi_diagram
-function onRenderVoronoiHover(chart) {
+function onRenderVoronoiHover(chart, { hasDrills }) {
   const parent = chart.svg().select("svg > g");
   const dots = chart.svg().selectAll(".sub .dc-tooltip .dot")[0];
   const axis = chart.svg().select(".axis.x");
@@ -215,6 +215,7 @@ function onRenderVoronoiHover(chart) {
   parent
     .append("svg:g")
     .classed("voronoi", true)
+    .classed("voronoi-drill", hasDrills)
     .selectAll("path")
     .data(voronoi(vertices), d => d && d.join(","))
     .enter()
@@ -425,6 +426,7 @@ function onRender(
     yAxisSplit,
     isStacked,
     isTimeseries,
+    hasDrills,
     formatYValue,
     onGoalHover,
     onHoverChange,
@@ -439,7 +441,7 @@ function onRender(
   onRenderSetDotStyle(chart);
   onRenderSetLineWidth(chart);
   onRenderEnableDots(chart);
-  onRenderVoronoiHover(chart);
+  onRenderVoronoiHover(chart, { hasDrills });
   onRenderCleanupGoalAndTrend(chart, onGoalHover, isSplitAxis); // do this before hiding x-axis
   onRenderValueLabels(chart, { formatYValue, xInterval, yAxisSplit, datas });
   onRenderHideDisabledLabels(chart);

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -934,6 +934,7 @@ export default function lineAreaBar(element, props) {
     xInterval: xAxisProps.xInterval,
     isStacked: isStacked(parent.settings, datas),
     isTimeseries: isTimeseries(parent.settings),
+    hasDrills: typeof props.onChangeCardAndRun === "function",
     formatYValue: getYValueFormatter(parent, series, yAxisProps.yExtent),
     onGoalHover,
     onHoverChange,

--- a/frontend/test/metabase/modes/components/drill/QuickFilterDrill.unit.spec.js
+++ b/frontend/test/metabase/modes/components/drill/QuickFilterDrill.unit.spec.js
@@ -5,6 +5,7 @@ import {
   ORDERS,
   PEOPLE,
   SAMPLE_DATABASE,
+  metadata,
 } from "__support__/sample_database_fixture";
 
 const NUMBER_AND_DATE_FILTERS = ["<", ">", "=", "!="];
@@ -62,15 +63,18 @@ describe("QuickFilterDrill", () => {
 
   it("should not be valid for native questions", () => {
     const actions = QuickFilterDrill({
-      question: new Question({
-        dataset_query: {
-          type: "native",
-          native: {
-            query: "SELECT * FROM ORDERS",
+      question: new Question(
+        {
+          dataset_query: {
+            type: "native",
+            native: {
+              query: "SELECT * FROM ORDERS",
+            },
+            database: SAMPLE_DATABASE.id,
           },
-          database: SAMPLE_DATABASE.id,
         },
-      }),
+        metadata,
+      ),
       column: createMockColumn({
         name: "TOTAL",
         field_ref: ["field", "TOTAL", { base_type: "type/BigInteger" }],
@@ -179,7 +183,7 @@ describe("QuickFilterDrill", () => {
 
   describe("aggregated numeric cell", () => {
     const { actions, cellValue } = setup({
-      question: new Question(AGGREGATED_QUESTION),
+      question: new Question(AGGREGATED_QUESTION, metadata),
       column: createMockColumn({
         name: "count",
         field_ref: ["aggregation", 0],
@@ -214,9 +218,12 @@ describe("QuickFilterDrill", () => {
   });
 
   describe("numeric field cell from a nested query", () => {
+    const question = new Question(NESTED_QUESTION);
+    question.query().isEditable = () => true;
+
     const fieldRef = ["field", "count", { "base-type": "type/BigInteger" }];
     const { actions, cellValue } = setup({
-      question: new Question(NESTED_QUESTION),
+      question,
       column: createMockColumn({
         name: "count",
         field_ref: fieldRef,

--- a/frontend/test/metabase/scenarios/question/reproductions/18978-18977-nested-question-nodata-user.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/18978-18977-nested-question-nodata-user.js
@@ -3,10 +3,11 @@ import {
   popover,
   openNavigationSidebar,
   visitQuestion,
+  POPOVER_ELEMENT,
 } from "__support__/e2e/cypress";
 
 export function issue18978() {
-  describe("18978, 18977", () => {
+  describe("11914, 18978, 18977", () => {
     beforeEach(() => {
       restore();
       cy.signInAsAdmin();
@@ -38,7 +39,24 @@ export function issue18978() {
         });
         cy.findByTestId("viz-type-button").should("not.exist");
         cy.findByTestId("viz-settings-button").should("not.exist");
+
+        // Ensure no drills offered when clicking a column header
+        cy.findByText("Subtotal").click();
+        assertNoOpenPopover();
+
+        // Ensure no drills offered when clicking a regular cell
+        cy.findByText("6.42").click();
+        assertNoOpenPopover();
+
+        // Ensure no drills offered when clicking FK
+        cy.findByText("184").click();
+        assertNoOpenPopover();
+        cy.url().should("include", `/question/${id}`);
       });
     });
   });
+}
+
+function assertNoOpenPopover() {
+  cy.get(POPOVER_ELEMENT).should("not.exist");
 }

--- a/frontend/test/metabase/scenarios/question/reproductions/18978-18977-nested-question-nodata-user.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/18978-18977-nested-question-nodata-user.js
@@ -1,5 +1,6 @@
 import {
   restore,
+  appBar,
   popover,
   openNavigationSidebar,
   visitQuestion,
@@ -31,6 +32,9 @@ export function issue18978() {
           cy.findByText(/SQL query/).should("not.exist");
           cy.findByText(/Native query/).should("not.exist");
         });
+
+        // Click outside to close the "new" button popover
+        appBar().click();
 
         cy.findByTestId("qb-header-action-panel").within(() => {
           cy.icon("notebook").should("not.exist");


### PR DESCRIPTION
Reproduces #11914, fixes #11914

No-data users could click on column headers and cells to trigger drills, but they just fail without data permissions. This PR is based on #20317 work and hides the drills

### To Verify

1. Create a nested query (e.g. in the top navbar "+ Add" > "Question" "Saved Questions" > pick any question > Save)
2. Sign in as a no-data user and open that question
3. Click on a table column header, a cell, and on any PK/FK cell. You shouldn't trigger any drills

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/152996934-fe3c15c6-4421-4e39-b626-6fe98bdf3fff.mp4

**After**

https://user-images.githubusercontent.com/17258145/152996947-a93c5907-17d7-4ebc-9d32-0419fa9ca795.mp4
