### PR TITLE
Remove accidental `.debug()` from a test

### DIFF
--- a/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
@@ -173,7 +173,7 @@ describe("scenarios > admin > settings", () => {
 
     // check the new formatting in a question
     openOrdersTable();
-    cy.contains(/^February 11, 2019, 21:40$/).debug();
+    cy.contains(/^February 11, 2019, 21:40$/);
 
     // reset the formatting
     cy.visit("/admin/settings/localization");


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Removes the accidental `.debug()` from one e2e test

### Additional Information
- I've discovered this accidentally while working on this test locally
- Tbh, not sure how and why it passed in CI, or why it didn't halt the whole CI