### PR TITLE
Use Docker Hub credentials to avoid being rate-throttled

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -77,18 +77,30 @@ jobs:
         ports:
           - "80:80"
           - "25:25"
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       postgres-sample:
         image: metabase/qa-databases:postgres-sample-12
         ports:
           - "5432:5432"
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       mongo-sample:
         image: metabase/qa-databases:mongo-sample-4.0
         ports:
           - 27017:27017
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       mysql-sample:
         image: metabase/qa-databases:mysql-sample-8
         ports:
           - 3306:3306
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
     - uses: actions/checkout@v2
     - name: Prepare front-end environment


### PR DESCRIPTION
Since we need some service containers to run selected groups via GitHub Actions on master branch, occasionally the workflow failed because of the rate-limit on unauthenticated access imposed by Docker Hub.

The solution: pull those service containers with authenticated access.