### PR TITLE
Backport #20154 to `release-x.42.x`

### DIFF
--- a/frontend/test/metabase/scenarios/joins/joins.cy.spec.js
+++ b/frontend/test/metabase/scenarios/joins/joins.cy.spec.js
@@ -14,7 +14,7 @@ describe("scenarios > question > joined questions", () => {
     cy.signInAsAdmin();
   });
 
-  it.skip("joining on a question with remapped values should work (metabase#15578)", () => {
+  it("joining on a question with remapped values should work (metabase#15578)", () => {
     cy.intercept("POST", "/api/dataset").as("dataset");
     // Remap display value
     cy.request("POST", `/api/field/${ORDERS.PRODUCT_ID}/dimension`, {

--- a/src/metabase/models/params/chain_filter.clj
+++ b/src/metabase/models/params/chain_filter.clj
@@ -391,7 +391,8 @@
                              ;; but sort by [remapped-value]
                              :order-by [[:asc [:field field-id nil]]]}))
                    (add-joins source-table-id joins)
-                   (add-filters source-table-id joined-table-ids constraints)))})
+                   (add-filters source-table-id joined-table-ids constraints)))
+   :middleware {:disable-remaps? true}})
 
 
 ;;; ------------------------ Chain filter (powers GET /api/dashboard/:id/params/:key/values) -------------------------

--- a/test/metabase/query_processor/middleware/add_dimension_projections_test.clj
+++ b/test/metabase/query_processor/middleware/add_dimension_projections_test.clj
@@ -444,3 +444,36 @@
                                       {:display_name "Sender ID [external remap]", :name "NAME", :remapped_from "SENDER_ID"}
                                       {:display_name "Receiver ID [external remap]", :name "NAME_2", :remapped_from "RECEIVER_ID"}]}
                               (#'add-dim-projections/add-remapped-to-and-from-metadata metadata remap-info nil)))))))))))
+
+(deftest add-remappings-inside-joins-test
+  (testing "Remappings should work inside joins (#15578)"
+    (mt/dataset sample-dataset
+      (mt/with-column-remappings [orders.product_id products.title]
+        (is (partial (mt/mbql-query products
+                       {:joins  [{:source-query {:source-table $$orders}
+                                  :alias        "Q1"
+                                  :fields       [&Q1.orders.id
+                                                 &Q1.orders.product_id
+                                                 &PRODUCTS__via__PRODUCT_ID.orders.product_id->title]
+                                  :condition    [:= $id &Q1.orders.product_id]
+                                  :strategy     :left-join}
+                                 {:source-table $$products
+                                  :alias        "PRODUCTS__via__PRODUCT_ID"
+                                  :condition    [:= $orders.product_id &PRODUCTS__via__PRODUCT_ID.products.id]
+                                  :strategy     :left-join
+                                  :fk-field-id  %orders.product_id}]
+                        :fields [&Q1.orders.id
+                                 &Q1.orders.product_id
+                                 &PRODUCTS__via__PRODUCT_ID.orders.product_id->products.title]
+                        :limit  2})
+                     (:query
+                      (#'add-dim-projections/add-fk-remaps
+                       (mt/mbql-query products
+                         {:joins  [{:strategy     :left-join
+                                    :source-query {:source-table $$orders}
+                                    :alias        "Q1"
+                                    :condition    [:= $id &Q1.orders.product_id]
+                                    :fields       [&Q1.orders.id
+                                                   &Q1.orders.product_id]}]
+                          :fields [&Q1.orders.id &Q1.orders.product_id]
+                          :limit  2})))))))))


### PR DESCRIPTION
I thought there would be merge conflicts so I manually backported this. There actually weren't any... oh well.

#20154 is approved upstream already so maybe we can squeeze this in to 42.0, or if not, 42.1