### PR TITLE
Remove unused dep on aleph (and thus unused transient dep on Netty)

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -4,9 +4,7 @@
  ;; !!                                   PLEASE KEEP THESE ORGANIZED ALPHABETICALLY                                  !!
  ;; !!                                   AND ADD A COMMENT EXPLAINING THEIR PURPOSE                                  !!
  ;; !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
- {aleph/aleph                               {:mvn/version "0.4.6"               ; Async HTTP library; WebSockets
-                                             :exclusions  [org.clojure/tools.logging]}
-  amalloy/ring-buffer                       {:mvn/version "1.3.1"               ; fixed length queue implementation, used in log buffering
+ {amalloy/ring-buffer                       {:mvn/version "1.3.1"               ; fixed length queue implementation, used in log buffering
                                              :exclusions  [org.clojure/clojure
                                                            org.clojure/clojurescript]}
   amalloy/ring-gzip-middleware              {:mvn/version "0.1.4"}              ; Ring middleware to GZIP responses if client can handle it


### PR DESCRIPTION
We used to use https://github.com/clj-commons/aleph for its WebSockets implementation which under the hood uses Netty. However `aleph` hasn't been updated in a million years and thus the version of Netty it's using is almost 4 years old at this point 
 -- https://mvnrepository.com/artifact/io.netty/netty-buffer/4.1.25.Final. We used WebSockets to power the MetaBot which was removed in #19755 (42.0). Now `aleph` and `netty` are unused.

This PR removes `aleph` and thus `netty` to slim down our JAR size a bit, speed up CI since we have to download less stuff, and remove a whole class of CVEs

**This actually ends up removing over thirty transient dependencies from our project.** Nice 💪 

(Not sure what difference that makes in terms of JAR size -- we'll have to build one and see)