### PR TITLE
Add org.quartz-scheduler/quartz as an explict dep and bump version from 2.1.7 -> 2.3.2

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -22,7 +22,8 @@
                                                            commons-io/commons-io
                                                            slingshot/slingshot]}
   clojurewerkz/quartzite                    {:mvn/version "2.1.0"               ; scheduling library
-                                             :exclusions  [c3p0/c3p0]}
+                                             :exclusions  [c3p0/c3p0
+                                                           org.quartz-scheduler/quartz]}
   colorize/colorize                         {:mvn/version "0.1.1"               ; string output with ANSI color codes (for logging)
                                              :exclusions  [org.clojure/clojure]}
   com.cemerick/friend                       {:mvn/version "0.2.3"               ; auth library
@@ -119,6 +120,7 @@
                                              :exclusions  [ch.qos.logback/logback-classic]}
   org.mariadb.jdbc/mariadb-java-client      {:mvn/version "2.7.5"}              ; MySQL/MariaDB driver
   org.postgresql/postgresql                 {:mvn/version "42.3.2"}             ; Postgres driver
+  org.quartz-scheduler/quartz               {:mvn/version "2.3.2"}              ; Quartz job scheduler, provided by quartzite but this is a newer version.
   org.slf4j/slf4j-api                       {:mvn/version "1.7.35"}             ; abstraction for logging frameworks -- allows end user to plug in desired logging framework at deployment time
   org.tcrawley/dynapath                     {:mvn/version "1.1.0"}              ; Dynamically add Jars (e.g. Oracle or Vertica) to classpath
   org.threeten/threeten-extra               {:mvn/version "1.7.0"}              ; extra Java 8 java.time classes like DayOfMonth and Quarter

--- a/src/metabase/task.clj
+++ b/src/metabase/task.clj
@@ -94,6 +94,7 @@
 
 (defrecord ^:private ConnectionProvider []
   org.quartz.utils.ConnectionProvider
+  (initialize [_])
   (getConnection [_]
     ;; get a connection from our application DB connection pool. Quartz will close it (i.e., return it to the pool)
     ;; when it's done


### PR DESCRIPTION
We're using https://github.com/michaelklishin/quartzite which includes Quartz a transient dependency. Quartzite hasn't been bumped in a long time now so we've been pinned at `2.1.7` for a long time... `2.1.7` has a CVE (https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-13990) in the `XMLSchedulingDataProcessor` that I'm 99.9% sure doesn't affect us but we get a lot of emails about it. 

This PR adds `quartz` as an explicit dependency so we can keep it up to date regardless of what Quartzite does