### PR TITLE
localStorage can't be used in Chrome Incognito

### DIFF
--- a/docs/enterprise-guide/full-app-embedding.md
+++ b/docs/enterprise-guide/full-app-embedding.md
@@ -26,7 +26,9 @@ Once you do, you'll see a set of options:
   For example, `https://*.metabase.com http://my-web-app.example.com:8080/`. Leaving this empty will default to a `frame-ancestors` value of `'none'`.
   If you're a fancy person, you can specify this URL in the environment variable `MB_EMBEDDING_APP_ORIGIN`.
 
-A note to IE11 users: only the first URL will be valid for IE11 due to limitations in the HTTP headers it supports. IE11 does not support the `Content-Security-Policy` header, but does support `X-Frame-Options`, which can only accept a single value.
+Notes:
+- IE11: only the first URL will be valid for IE11 due to limitations in the HTTP headers it supports. IE11 does not support the `Content-Security-Policy` header, but does support `X-Frame-Options`, which can only accept a single value.
+- Chrome: localStorage is disabled in Incognito mode, so you won't be able to test this feature in an incognito session with this browser. Please use Chrome in the normal mode or choose another browser to use for testing.
 
 ### Setting things up in your web app
 

--- a/docs/enterprise-guide/full-app-embedding.md
+++ b/docs/enterprise-guide/full-app-embedding.md
@@ -26,7 +26,7 @@ Once you do, you'll see a set of options:
   For example, `https://*.metabase.com http://my-web-app.example.com:8080/`. Leaving this empty will default to a `frame-ancestors` value of `'none'`.
   If you're a fancy person, you can specify this URL in the environment variable `MB_EMBEDDING_APP_ORIGIN`.
 
-**Note:** Some browsers, like Chrome, has `localStorage` is disabled in Incognito mode, so you won't be able to login via FullApp embedded iframe unless you explicitly allow cookies from the Metabase. In Chrome go to chrome://settings/cookies and add the Metabase Site URL under "Sites that can always use cookies".
+**Note:** Some browsers, like Chrome, has `localStorage` is disabled in Incognito mode, so you won't be able to login via FullApp embedded iframe unless you explicitly allow cookies from Metabase. In Chrome go to chrome://settings/cookies and add the Metabase Site URL under "Sites that can always use cookies".
 
 ### Setting things up in your web app
 

--- a/docs/enterprise-guide/full-app-embedding.md
+++ b/docs/enterprise-guide/full-app-embedding.md
@@ -26,8 +26,6 @@ Once you do, you'll see a set of options:
   For example, `https://*.metabase.com http://my-web-app.example.com:8080/`. Leaving this empty will default to a `frame-ancestors` value of `'none'`.
   If you're a fancy person, you can specify this URL in the environment variable `MB_EMBEDDING_APP_ORIGIN`.
 
-Notes:
-- IE11: only the first URL will be valid for IE11 due to limitations in the HTTP headers it supports. IE11 does not support the `Content-Security-Policy` header, but does support `X-Frame-Options`, which can only accept a single value.
 **Note:** Some browsers, like Chrome, has `localStorage` is disabled in Incognito mode, so you won't be able to login via FullApp embedded iframe unless you explicitly allow cookies from the Metabase. In Chrome go to chrome://settings/cookies and add the Metabase Site URL under "Sites that can always use cookies".
 
 ### Setting things up in your web app

--- a/docs/enterprise-guide/full-app-embedding.md
+++ b/docs/enterprise-guide/full-app-embedding.md
@@ -28,7 +28,7 @@ Once you do, you'll see a set of options:
 
 Notes:
 - IE11: only the first URL will be valid for IE11 due to limitations in the HTTP headers it supports. IE11 does not support the `Content-Security-Policy` header, but does support `X-Frame-Options`, which can only accept a single value.
-- Chrome: localStorage is disabled in Incognito mode, so you won't be able to test this feature in an incognito session with this browser. Please use Chrome in the normal mode or choose another browser to use for testing.
+**Note:** Some browsers, like Chrome, has `localStorage` is disabled in Incognito mode, so you won't be able to login via FullApp embedded iframe unless you explicitly allow cookies from the Metabase. In Chrome go to chrome://settings/cookies and add the Metabase Site URL under "Sites that can always use cookies".
 
 ### Setting things up in your web app
 


### PR DESCRIPTION
Added this specific scenario as one of our users wasn't able to test it