### PR TITLE
Support running Oracle tests with local Docker image

### DIFF
--- a/modules/drivers/oracle/test/metabase/test/data/oracle.clj
+++ b/modules/drivers/oracle/test/metabase/test/data/oracle.clj
@@ -36,12 +36,13 @@
 ;; Session password is only used when creating session user, not anywhere else
 
 (defn- connection-details []
-  (let [details* {:host     (tx/db-test-env-var-or-throw :oracle :host)
-                  :port     (Integer/parseInt (tx/db-test-env-var-or-throw :oracle :port "1521"))
-                  :user     (tx/db-test-env-var-or-throw :oracle :user)
-                  :password (tx/db-test-env-var-or-throw :oracle :password)
-                  :sid      (tx/db-test-env-var-or-throw :oracle :sid)
-                  :ssl      (tx/db-test-env-var :oracle :ssl false)}
+  (let [details* {:host         (tx/db-test-env-var-or-throw :oracle :host "localhost")
+                  :port         (Integer/parseInt (tx/db-test-env-var-or-throw :oracle :port "1521"))
+                  :user         (tx/db-test-env-var-or-throw :oracle :user "system")
+                  :password     (tx/db-test-env-var-or-throw :oracle :password "password")
+                  :sid          (tx/db-test-env-var :oracle :sid)
+                  :service-name (tx/db-test-env-var :oracle :service-name (when-not (tx/db-test-env-var :oracle :sid) "XEPDB1"))
+                  :ssl          (tx/db-test-env-var :oracle :ssl false)}
         ssl-keys [:ssl-use-truststore :ssl-truststore-options :ssl-truststore-path :ssl-truststore-value
                   :ssl-truststore-password-value
                   :ssl-use-keystore :ssl-use-keystore-options :ssl-keystore-path :ssl-keystore-value


### PR DESCRIPTION
Step 1 of #20356

This tweaks the Oracle test connection details code to work with the Docker Oracle images added in https://github.com/metabase/dev-scripts and sets the defaults to the same ones we're using there.

Next step is to tweak CircleCI to use a local image. I was going to do it as part of this PR but we're testing SSL stuff for Oracle in CircleCI so I need to think about what to do there first before switching over