### PR TITLE
QP refactor 2022 part 2: `preprocess` handles recursion automatically

### DIFF
--- a/shared/src/metabase/mbql/util.cljc
+++ b/shared/src/metabase/mbql/util.cljc
@@ -695,5 +695,7 @@
     [mbql.match
      match
      match-one
+     match-this-level
      replace
-     replace-in]))
+     replace-in
+     replace-this-level]))

--- a/shared/src/metabase/mbql/util/match.clj
+++ b/shared/src/metabase/mbql/util/match.clj
@@ -143,7 +143,7 @@
   Pattern-matching works almost exactly the way it does when using `core.match**` directly, with a few
   differences:
 
-  *  `mbql.util/match` returns a sequence of everything that matches, rather than the first match it finds
+  *  [[metabase.mbql.util/match]] returns a sequence of everything that matches, rather than the first match it finds
 
   *  patterns are automatically wrapped in vectors for you when appropriate
 
@@ -193,6 +193,15 @@
   ;; would like to discourage you from using directly.
   `(match* ~x ~patterns-and-results))
 
+(defmacro match-this-level
+  {:style/indent 1}
+  [x & patterns-and-results]
+  `(match ~x
+     ~'(_ :guard (constantly (#{:source-query :source-metadata} (last &parents))))
+     nil
+
+     ~@patterns-and-results))
+
 (defmacro match-one
   "Like `match` but returns a single match rather than a sequence of matches."
   {:style/indent 1}
@@ -234,6 +243,15 @@
   ;; as with `match` actual impl is in `match` namespace to discourage you from using the constituent functions and
   ;; macros that power this macro directly
   `(replace* ~x ~patterns-and-results))
+
+(defmacro replace-this-level
+  {:style/indent 1}
+  [x & patterns-and-results]
+  `(replace ~x
+     ~'(_ :guard (constantly (#{:source-query :source-metadata} (last &parents))))
+     ~'&match
+
+     ~@patterns-and-results))
 
 (defmacro replace-in
   "Like `replace`, but only replaces things in the part of `x` in the keypath `ks` (i.e. the way to `update-in` works.)"

--- a/src/metabase/query_processor/interface.clj
+++ b/src/metabase/query_processor/interface.clj
@@ -20,7 +20,7 @@
 ;;
 ;; TODO - I think we should just remove this entirely, it's not used consistently and it's more trouble than it's
 ;; worth. Just dial down the log level a bit where we're currently using this
-(def ^:dynamic ^Boolean *disable-qp-logging*
+(def ^:dynamic ^Boolean ^:deprecated *disable-qp-logging*
   "Should we disable logging for the QP? (e.g., during sync we probably want to turn it off to keep logs less
   cluttered)."
   false)

--- a/src/metabase/query_processor/middleware/add_default_temporal_unit.clj
+++ b/src/metabase/query_processor/middleware/add_default_temporal_unit.clj
@@ -6,7 +6,7 @@
   "Add `:temporal-unit` `:default` to any temporal `:field` clauses that don't already have a `:temporal-unit`. This
   makes things more consistent because code downstream can rely on the key being present."
   [query]
-  (mbql.u/replace-in query [:query]
+  (mbql.u/replace-this-level query
     [:field (_ :guard string?) (_ :guard (every-pred
                                           :base-type
                                           #(isa? (:base-type %) :type/Temporal)

--- a/src/metabase/query_processor/middleware/add_dimension_projections.clj
+++ b/src/metabase/query_processor/middleware/add_dimension_projections.clj
@@ -23,342 +23,172 @@
   appropriate `:remapped_from` and `:remapped_to` attributes in the result `:cols` in post-processing.
   `:remapped_from` and `:remapped_to` are the names of the columns, e.g. `category_id` is `:remapped_to` `name`, and
   `name` is `:remapped_from` `:category_id`."
-  (:require [clojure.data :as data]
-            [clojure.tools.logging :as log]
-            [clojure.walk :as walk]
-            [medley.core :as m]
+  (:require [medley.core :as m]
             [metabase.mbql.schema :as mbql.s]
             [metabase.mbql.util :as mbql.u]
             [metabase.models.dimension :refer [Dimension]]
             [metabase.models.field :refer [Field]]
-            [metabase.query-processor.store :as qp.store]
             [metabase.util :as u]
             [metabase.util.schema :as su]
             [schema.core :as s]
             [toucan.db :as db]
             [toucan.hydrate :refer [hydrate]]))
 
-(def ^:private ExternalRemappingDimensionInitialInfo
-  "External remapping dimensions when they're first fetched from the app DB. We'll add extra info to this."
-  {:id                      su/IntGreaterThanZero   ; unique ID for the remapping
-   :name                    su/NonBlankString       ; display name for the remapping
-   :field_id                su/IntGreaterThanZero   ; ID of the Field being remapped
-   :human_readable_field_id su/IntGreaterThanZero}) ; ID of the FK Field to remap values to
-
 (def ^:private ExternalRemappingDimension
   "Schema for the info we fetch about `external` type Dimensions that will be used for remappings in this Query. Fetched
   by the pre-processing portion of the middleware, and passed along to the post-processing portion."
-  (assoc ExternalRemappingDimensionInitialInfo
-         :field_name                su/NonBlankString   ; Name of the Field being remapped
-         :human_readable_field_name su/NonBlankString)) ; Name of the FK field to remap values to
+  {:name                                       su/NonBlankString       ; display name for the remapping
+   :field_id                                   su/IntGreaterThanZero   ; ID of the Field being remapped
+   :human_readable_field_id                    su/IntGreaterThanZero   ; ID of the FK Field to remap values to
+   (s/optional-key :field_name)                su/NonBlankString       ; Name of the Field being remapped
+   (s/optional-key :human_readable_field_name) su/NonBlankString})     ; Name of the FK field to remap values to
 
 ;;;; Pre-processing
 
-(s/defn ^:private fields->field-id->remapping-dimension :- (s/maybe {su/IntGreaterThanZero ExternalRemappingDimensionInitialInfo})
+(s/defn ^:private fields->field-id->remapping-dimension :- (s/maybe {su/IntGreaterThanZero ExternalRemappingDimension})
   "Given a sequence of field clauses (from the `:fields` clause), return a map of `:field-id` clause (other clauses
   are ineligable) to a remapping dimension information for any Fields that have an `external` type dimension remapping."
   [fields :- [mbql.s/Field]]
   (when-let [field-ids (not-empty (set (mbql.u/match fields [:field (id :guard integer?) _] id)))]
-    (letfn [(thunk []
-              (u/key-by :field_id (db/select [Dimension :id :field_id :name :human_readable_field_id]
-                                    :field_id [:in field-ids]
-                                    :type     "external")))]
-      (if (qp.store/initialized?)
-        (qp.store/cached [::fetch-dimensions field-ids]
-          (thunk))
-        (thunk)))))
+    (u/key-by :field_id (db/select [Dimension :field_id :name :human_readable_field_id]
+                          :field_id [:in field-ids]
+                          :type     "external"))))
 
-(def ^:private RemapColumnInfo
-  {:original-field-clause mbql.s/field
-   :new-field-clause      mbql.s/field
-   :dimension             ExternalRemappingDimension})
-
-(s/defn ^:private remap-column-infos :- [RemapColumnInfo]
-  "Return tuples of `:field-id` clauses, the new remapped column `:fk->` clauses that the Field should be remapped to
+(s/defn ^:private create-remap-col-tuples :- [[(s/one mbql.s/field            "Field")
+                                               (s/one mbql.s/field            "remapped FK Field")
+                                               (s/one ExternalRemappingDimension "remapping Dimension info")]]
+  "Return tuples of `:field-id` clauses, the new remapped column `:fk->` clauses that the Field should be remapped to,
   and the Dimension that suggested the remapping, which is used later in this middleware for post-processing. Order is
   important here, because the results are added to the `:fields` column in order. (TODO - why is it important, if they
   get hidden when displayed anyway?)"
   [fields :- [mbql.s/Field]]
   (when-let [field-id->remapping-dimension (fields->field-id->remapping-dimension fields)]
-    ;; Reconstruct how we uniquify names in [[metabase.query-processor.middleware.annotate]]
-    ;;
-    ;; Not sure this isn't broken. Probably better to have [[metabase.query-processor.util.add-alias-info]] do the name
-    ;; deduplication instead.
+    ;; Reconstruct how we uniquify names in `metabase.query-processor.middleware.annotate`
     (let [unique-name (comp (mbql.u/unique-name-generator) :name Field)]
       (vec
        (mbql.u/match fields
          ;; don't match Fields that have been joined from another Table
-         [:field
-          (id :guard (every-pred integer? field-id->remapping-dimension))
-          (_ :guard (complement (some-fn :join-alias :source-field)))]
+         [:field (id :guard (every-pred integer? field-id->remapping-dimension)) (_ :guard (complement (some-fn :join-alias :source-field)))]
          (let [dimension (field-id->remapping-dimension id)]
-           {:original-field-clause &match
-            :new-field-clause      [:field
-                                    (u/the-id (:human_readable_field_id dimension))
-                                    {:source-field            id
-                                     ::new-field-dimension-id (u/the-id dimension)}]
-            :dimension             (assoc dimension
-                                          :field_name                (-> dimension :field_id unique-name)
-                                          :human_readable_field_name (-> dimension :human_readable_field_id unique-name))}))))))
+           [&match
+            [:field (:human_readable_field_id dimension) {:source-field id}]
+            (assoc dimension
+              :field_name                (-> dimension :field_id unique-name)
+              :human_readable_field_name (-> dimension :human_readable_field_id unique-name))]))))))
 
-(s/defn ^:private add-fk-remaps-rewrite-existing-fields-add-original-field-dimension-id :- [mbql.s/Field]
-  "Rewrite existing `:fields` in a query. Add `::original-field-dimension-id` to any Field clauses that are
-  remapped-from."
-  [infos  :- [RemapColumnInfo]
-   fields :- [mbql.s/Field]]
-  (let [field->remapped-col (into {} (map (juxt :original-field-clause :new-field-clause)) infos)]
-    (mapv
-     (fn [field]
-       (let [[_ _ {::keys [new-field-dimension-id]}] (get field->remapped-col field)]
-         (cond-> field
-           new-field-dimension-id (mbql.u/update-field-options assoc ::original-field-dimension-id new-field-dimension-id))))
-     fields)))
-
-(s/defn ^:private add-fk-remaps-rewrite-existing-fields-add-new-field-dimension-id :- [mbql.s/Field]
-  "Rewrite existing `:fields` in a query. Add `::new-field-dimension-id` to any existing remap-to Fields that *would*
-  have been added if they did not already exist."
-  [infos  :- [RemapColumnInfo]
-   fields :- [mbql.s/Field]]
-  (let [normalized-clause->new-options (into {}
-                                             (map (juxt (fn [{clause :new-field-clause}]
-                                                          (mbql.u/remove-namespaced-options clause))
-                                                        (fn [{[_ _ options] :new-field-clause}]
-                                                          options)))
-                                             infos)]
-    (mapv (fn [field]
-            (let [options (normalized-clause->new-options (mbql.u/remove-namespaced-options field))]
-              (cond-> field
-                options (mbql.u/update-field-options merge options))))
-          fields)))
-
-(s/defn ^:private add-fk-remaps-rewrite-existing-fields :- [mbql.s/Field]
-  "Rewrite existing `:fields` in a query. Add `::original-field-dimension-id` and ::new-field-dimension-id` where
-  appropriate."
-  [infos  :- [RemapColumnInfo]
-   fields :- [mbql.s/Field]]
-  (->> fields
-       (add-fk-remaps-rewrite-existing-fields-add-original-field-dimension-id infos)
-       (add-fk-remaps-rewrite-existing-fields-add-new-field-dimension-id infos)))
-
-(s/defn ^:private add-fk-remaps-rewrite-order-by :- [mbql.s/OrderBy]
+(s/defn ^:private update-remapped-order-by :- [mbql.s/OrderBy]
   "Order by clauses that include an external remapped column should be replace that original column in the order by with
   the newly remapped column. This should order by the text of the remapped column vs. the id of the source column
   before the remapping"
-  [field->remapped-col :- {mbql.s/field mbql.s/field}
-   order-by-clauses    :- [mbql.s/OrderBy]]
-  (into []
-        (comp (map (fn [[direction field, :as order-by-clause]]
-                     (if-let [remapped-col (get field->remapped-col field)]
-                       [direction remapped-col]
-                       order-by-clause)))
-              (distinct))
-        order-by-clauses))
+  [field->remapped-col :- {mbql.s/field mbql.s/field}, order-by-clauses :- [mbql.s/OrderBy]]
+  (->> (for [[direction field, :as order-by-clause] order-by-clauses]
+         (if-let [remapped-col (get field->remapped-col field)]
+           [direction remapped-col]
+           order-by-clause))
+       distinct
+       vec))
 
-(defn- add-fk-remaps-rewrite-breakout
+(defn- update-remapped-breakout
   [field->remapped-col breakout-clause]
-  (into []
-        (comp (mapcat (fn [field]
-                        (if-let [[_ _ {::keys [new-field-dimension-id]} :as remapped-col] (get field->remapped-col field)]
-                          [remapped-col (mbql.u/update-field-options field assoc ::original-field-dimension-id new-field-dimension-id)]
-                          [field])))
-              (distinct))
-        breakout-clause))
+  (->> breakout-clause
+       (mapcat (fn [field]
+                 (if-let [remapped-col (get field->remapped-col field)]
+                   [remapped-col field]
+                   [field])))
+       distinct
+       vec))
 
-(def ^:private QueryAndRemaps
-  {:remaps (s/maybe (su/distinct [ExternalRemappingDimension]))
-   :query  mbql.s/Query})
-
-(defn- add-fk-remaps-one-level
-  [{:keys [fields order-by breakout], {source-query-remaps ::remaps} :source-query, :as query}]
-  (let [query (m/dissoc-in query [:source-query ::remaps])]
-    ;; fetch remapping column pairs if any exist...
-    (if-let [infos (not-empty (remap-column-infos (concat fields breakout)))]
-      ;; if they do, update `:fields`, `:order-by` and `:breakout` clauses accordingly and add to the query
-      (let [ ;; make a map of field-id-clause -> fk-clause from the tuples
-            original->remapped             (into {} (map (juxt :original-field-clause :new-field-clause)) infos)
-            existing-fields                (add-fk-remaps-rewrite-existing-fields infos fields)
-            ;; don't add any new entries for fields that already exist. Use [[mbql.u/remove-namespaced-options]] here so
-            ;; we don't add new entries even if the existing Field has some extra info e.g. extra unknown namespaced
-            ;; keys.
-            existing-normalized-fields-set (into #{} (map mbql.u/remove-namespaced-options) existing-fields)
-            new-fields                     (into
-                                            existing-fields
-                                            (comp (map :new-field-clause)
-                                                  (remove (comp existing-normalized-fields-set mbql.u/remove-namespaced-options)))
-                                            infos)
-            new-breakout                   (add-fk-remaps-rewrite-breakout original->remapped breakout)
-            new-order-by                   (add-fk-remaps-rewrite-order-by original->remapped order-by)
-            remaps                         (into [] (comp cat (distinct)) [source-query-remaps (map :dimension infos)])]
-        ;; return the Dimensions we are using and the query
-        (cond-> query
-          (seq fields)   (assoc :fields new-fields)
-          (seq order-by) (assoc :order-by new-order-by)
-          (seq breakout) (assoc :breakout new-breakout)
-          (seq remaps)   (assoc ::remaps remaps)))
-      ;; otherwise return query as-is
-      (cond-> query
-        (seq source-query-remaps) (assoc ::remaps source-query-remaps)))))
-
-(s/defn ^:private add-fk-remaps :- QueryAndRemaps
-  "Add any Fields needed for `:external` remappings to the `:fields` clause of the query, and update `:order-by` and
-  `breakout` clauses as needed. Returns a map with `:query` (the updated query) and `:remaps` (a sequence
-  of [[ExternalRemappingDimension]] information maps)."
-  [query]
-  (let [query (walk/postwalk
-               (fn [form]
-                 (if (and (map? form)
-                          ((some-fn :source-table :source-query) form)
-                          (not (:condition form)))
-                   (add-fk-remaps-one-level form)
-                   form))
-               query)]
-    {:query (m/dissoc-in query [:query ::remaps]), :remaps (get-in query [:query ::remaps])}))
+(s/defn ^:private add-fk-remaps :- [(s/one (s/maybe [ExternalRemappingDimension]) "external remapping dimensions")
+                                    (s/one mbql.s/MBQLQuery "query")]
+  "Add any Fields needed for `:external` remappings to the `:fields` clause of the query, and update `:order-by`
+  and `breakout` clauses as needed. Returns a pair like `[external-remapping-dimensions updated-query]`."
+  [{:keys                                       [fields order-by breakout]
+    {source-query-remappings ::external-remaps} :source-query
+    :as                                         query}
+   :- mbql.s/MBQLQuery]
+  ;; fetch remapping column pairs if any exist...
+  (if-let [remap-col-tuples (seq (create-remap-col-tuples (concat fields breakout)))]
+    ;; if they do, update `:fields`, `:order-by` and `:breakout` clauses accordingly and add to the query
+    (let [new-fields          (->> remap-col-tuples
+                                   (map second)
+                                   (concat fields)
+                                   distinct
+                                   vec)
+          ;; make a map of field-id-clause -> fk-clause from the tuples
+          field->remapped-col (into {} (for [[field-clause fk-clause] remap-col-tuples]
+                                         [field-clause fk-clause]))
+          new-breakout        (update-remapped-breakout field->remapped-col breakout)
+          new-order-by        (update-remapped-order-by field->remapped-col order-by)]
+      ;; return the Dimensions we are using and the query
+      [(concat source-query-remappings (map last remap-col-tuples))
+       (cond-> query
+         (seq fields)   (assoc-in [:query :fields] new-fields)
+         (seq order-by) (assoc-in [:query :order-by] new-order-by)
+         (seq breakout) (assoc-in [:query :breakout] new-breakout))])
+    ;; otherwise return query as-is
+    [source-query-remappings query]))
 
 (defn add-remapped-columns
   "Pre-processing middleware. For columns that have remappings to other columns (FK remaps), rewrite the query to
   include the extra column. Add `::external-remaps` information about which columns were remapped so [[remap-results]]
   can do appropriate results transformations in post-processing."
-  [{{:keys [disable-remaps?]} :middleware, query-type :type, :as query}]
+  [{{:keys [disable-remaps?]} :qp/middleware, :qp/keys [query-type], :as query}]
   (if (or disable-remaps?
           (= query-type :native))
     query
-    (let [{:keys [remaps query]} (add-fk-remaps query)]
+    (let [[remappings query] (add-fk-remaps query)]
       (cond-> query
         ;; convert the remappings to plain maps so we don't have to look at record type nonsense everywhere
-        (seq remaps) (assoc ::external-remaps (mapv (partial into {}) remaps))))))
+        (seq remappings) (assoc ::external-remaps (mapv (partial into {}) remappings))))))
 
 
 ;;;; Post-processing
-
-(def ^:private InternalDimensionInfo
-  {;; index of original column
-   :col-index       s/Int
-   ;; names
-   :from            su/NonBlankString
-   ;; I'm not convinced this works if there's already a column with the same name in the results.
-   :to              su/NonBlankString
-   ;; map of original value -> human readable value
-   :value->readable su/Map
-   ;; Info about the new column we will tack on to end of `:cols`
-   :new-column      su/Map})
-
-(def ^:private InternalColumnsInfo
-  {:internal-only-dims (s/maybe [InternalDimensionInfo])
-   ;; this is just (map :new-column internal-only-dims)
-   :internal-only-cols (s/maybe [su/Map])})
-
-
-;;;; Metadata
-
-(s/defn ^:private merge-metadata-for-internally-remapped-column :- [su/Map]
-  "If one of the internal remapped columns says it's remapped from this column, merge in the `:remapped_to` info."
-  [columns :- [su/Map] {:keys [col-index to]} :- InternalDimensionInfo]
-  (update (vec columns) col-index assoc :remapped_to to))
-
-(s/defn ^:private merge-metadata-for-internal-remaps :- [su/Map]
-  [columns :- [su/Map] {:keys [internal-only-dims]} :- (s/maybe InternalColumnsInfo)]
-  (reduce
-   (fn [columns internal-dimension-info]
-     (merge-metadata-for-internally-remapped-column columns internal-dimension-info))
-   columns
-   internal-only-dims))
-
-;; Example external dimension:
-;;
-;;    {:name                      "Sender ID"
-;;     :id                        1000
-;;     :field_id                  %messages.sender_id
-;;     :field_name                "SENDER_ID"
-;;     :human_readable_field_id   %users.name
-;;     :human_readable_field_name "NAME"}
-;;
-;; Example remap-from column (need to add info about column it is `:remapped_to`):
-;;
-;;    {:id           %messages.sender_id
-;;     :name         "SENDER_ID"
-;;     :options      {::original-field-dimension-id 1000}
-;;     :display_name "Sender ID"}
-;;
-;; Example remap-to column (need to add info about column it is `:remapped_from`):
-;;
-;;    {:fk_field_id   %messages.sender_id
-;;     :id            %users.name
-;;     :options       {::new-field-dimension-id 1000}
-;;     :name          "NAME"
-;;     :display_name  "Sender ID"}
-(s/defn ^:private merge-metadata-for-externally-remapped-column* :- su/Map
-  [columns
-   {{::keys [original-field-dimension-id new-field-dimension-id]} :options
-    :as                                          column}
-   {dimension-id      :id
-    from-name         :field_name
-    from-display-name :name
-    to-name           :human_readable_field_name} :- ExternalRemappingDimension]
-  (log/trace "Considering column\n"
-             (u/pprint-to-str 'cyan (select-keys column [:id :name :fk_field_id :display_name :options]))
-             (u/colorize :magenta "\nAdd :remapped_to metadata?")
-             "\n=>" '(= dimension-id original-field-dimension-id)
-             "\n=>" (list '= dimension-id original-field-dimension-id)
-             "\n=>" (if (= dimension-id original-field-dimension-id)
-                      (u/colorize :green true)
-                      (u/colorize :red false))
-             (u/colorize :magenta "\nAdd :remapped_from metadata?")
-             "\n=>" '(= dimension-id new-field-dimension-id)
-             "\n=>" (list '= dimension-id new-field-dimension-id)
-             "\n=>" (if (= dimension-id new-field-dimension-id)
-                      (u/colorize :green true)
-                      (u/colorize :red false)))
-  (u/prog1 (merge
-            column
-            ;; if this is a column we're remapping FROM, we need to add information about which column we're remapping
-            ;; TO
-            (when (= dimension-id original-field-dimension-id)
-              {:remapped_to (or (some (fn [{{::keys [new-field-dimension-id]} :options, target-name :name}]
-                                        (when (= new-field-dimension-id dimension-id)
-                                          target-name))
-                                      columns)
-                                to-name)})
-            ;; if this is a column we're remapping TO, we need to add information about which column we're remapping
-            ;; FROM
-            (when (= dimension-id new-field-dimension-id)
-              {:remapped_from (or (some (fn [{{::keys [original-field-dimension-id]} :options, source-name :name}]
-                                          (when (= original-field-dimension-id dimension-id)
-                                            source-name))
-                                        columns)
-                                  from-name)
-               :display_name  from-display-name}))
-    (when (not= column <>)
-      (log/tracef "Added metadata:\n%s" (u/pprint-to-str 'green (second (data/diff column <>)))))))
-
-(s/defn ^:private merge-metadata-for-externally-remapped-column :- [su/Map]
-  [columns :- [su/Map] dimension :- ExternalRemappingDimension]
-  (log/tracef "Merging metadata for external dimension\n%s" (u/pprint-to-str 'yellow (into {} dimension)))
-  (mapv #(merge-metadata-for-externally-remapped-column* columns % dimension)
-        columns))
-
-(s/defn ^:private merge-metadata-for-external-remaps :- [su/Map]
-  [columns :- [su/Map] remapping-dimensions :- (s/maybe [ExternalRemappingDimension])]
-  (reduce
-   (fn [columns dimension]
-     (merge-metadata-for-externally-remapped-column columns dimension))
-   columns
-   remapping-dimensions))
 
 (s/defn ^:private add-remapping-info :- [su/Map]
   "Add `:display_name`, `:remapped_to`, and `:remapped_from` keys to columns for the results, needed by the frontend.
   To get this critical information, this uses the `remapping-dimensions` info saved by the pre-processing portion of
   this middleware for external remappings, and the internal-only remapped columns handled by post-processing
   middleware below for internal columns."
-  [columns              :- [su/Map]
-   remapping-dimensions :- (s/maybe [ExternalRemappingDimension])
-  internal-cols-info    :- (s/maybe InternalColumnsInfo)]
-  (-> columns
-      (merge-metadata-for-internal-remaps internal-cols-info)
-      (merge-metadata-for-external-remaps remapping-dimensions)))
-
-
-;;;; Transform to add additional cols to results
-
+  [columns                :- [su/Map]
+   remapping-dimensions   :- (s/maybe [ExternalRemappingDimension])
+   internal-remap-columns :- (s/maybe [su/Map])]
+  ;; We have to complicate our lives a bit and account for the possibility that dimensions might be
+  ;; used in an upstream `source-query`. If so, `columns` will treat them as `:field` w/ names, erasing
+  ;; IDs. In that case reconstruct the mappings using names.
+  ;;
+  ;; TODO:
+  ;; Matching by name is brittle and might produce wrong results when there are name clashes
+  ;; in the source fields.
+  (let [column-id->column              (u/key-by (some-fn :id :name) columns)
+        name->internal-remapped-to-col (u/key-by :remapped_from internal-remap-columns)
+        id->remapped-to-dimension      (merge (u/key-by :field_id remapping-dimensions)
+                                              (u/key-by :field_name remapping-dimensions))
+        id->remapped-from-dimension    (merge (u/key-by :human_readable_field_id remapping-dimensions)
+                                              (u/key-by :human_readable_field_name remapping-dimensions))
+        get-first-key                  (fn [m & ks]
+                                         (some-> (m/find-first m ks) m))]
+    (for [{:keys [id], column-name :name, :as column} columns]
+      (merge
+       {:base_type :type/*}
+       column
+       ;; if one of the internal remapped columns says it's remapped from this column, add a matching `:remapped_to`
+       ;; entry
+       (when-let [{remapped-to-name :name} (name->internal-remapped-to-col column-name)]
+         {:remapped_to remapped-to-name})
+       ;; if the pre-processing remapping Dimension info contains an entry where this Field's ID is `:field_id`, add
+       ;; an entry noting the name of the Field it gets remapped to
+       (when-let [{remapped-to-id   :human_readable_field_id
+                   remapped-to-name :human_readable_field_name}
+                  (id->remapped-to-dimension (or id column-name))]
+         {:remapped_to (:name (get-first-key column-id->column remapped-to-id remapped-to-name))})
+       ;; if the pre-processing remapping Dimension info contains an entry where this Field's ID is
+       ;; `:human_readable_field_id`, add an entry noting the name of the Field it gets remapped from, and use the
+       ;; `:display_name` of the Dimension
+       (when-let [{dimension-name     :name
+                   remapped-from-id   :field_id
+                   remapped-from-name :field_name} (id->remapped-from-dimension (or id column-name))]
+         {:display_name  dimension-name
+          :remapped_from (:name (get-first-key column-id->column remapped-from-id remapped-from-name))})))))
 
 (defn- create-remapped-col [col-name remapped-from base-type]
   {:description   nil
@@ -384,6 +214,17 @@
                     :type/Text       str
                     identity)]
     (map #(some-> % transform) values)))
+
+(def ^:private InternalDimensionInfo
+  {;; index of original column
+   :col-index       s/Int
+   ;; names
+   :from            su/NonBlankString
+   :to              su/NonBlankString
+   ;; map of original value -> human readable value
+   :value->readable su/Map
+   ;; Info about the new column we will tack on to end of `:cols`
+   :new-column      su/Map})
 
 (defn- infer-human-readable-values-type
   [values]
@@ -411,8 +252,7 @@
        :to              remap-to
        :value->readable (zipmap (transform-values-for-col col values)
                                 human-readable-values)
-       :new-column      (create-remapped-col remap-to
-                                             remap-from
+       :new-column      (create-remapped-col remap-to remap-from
                                              (infer-human-readable-values-type human-readable-values))})))
 
 (s/defn ^:private make-row-map-fn :- (s/maybe (s/pred fn? "function"))
@@ -426,7 +266,7 @@
       (fn [row]
         (into (vec row) (f row))))))
 
-(s/defn ^:private internal-columns-info :- InternalColumnsInfo
+(defn- internal-columns-info
   "Info about the internal-only columns we add to the query."
   [cols]
   ;; hydrate Dimensions and FieldValues for all of the columns in the results, then make a map of dimension info for
@@ -438,23 +278,21 @@
      ;; Get the entries we're going to add to `:cols` for each of the remapped values we add
      :internal-only-cols (map :new-column internal-only-dims)}))
 
-(s/defn ^:private add-remapped-to-and-from-metadata
+(defn- add-remapped-cols
   "Add remapping info `:remapped_from` and `:remapped_to` to each existing column in the results metadata, and add
   entries for each newly added column to the end of `:cols`."
-  [metadata
-   remapping-dimensions                                 :- (s/maybe [ExternalRemappingDimension])
-   {:keys [internal-only-cols], :as internal-cols-info} :- (s/maybe InternalColumnsInfo)]
+  [metadata remapping-dimensions {:keys [internal-only-cols]}]
   (update metadata :cols (fn [cols]
                            (-> cols
-                               (add-remapping-info remapping-dimensions internal-cols-info)
+                               (add-remapping-info remapping-dimensions internal-only-cols)
                                (concat internal-only-cols)))))
 
-(s/defn ^:private remap-results-xform
+(defn- remap-results-xform
   "Munges results for remapping after the query has been executed. For internal remappings, a new column needs to be
-  added and each row flowing through needs to include the remapped data for the new column. For external remappings
+  added and each row flowing through needs to include the remapped data for the new column. For external remappings,
   the column information needs to be updated with what it's being remapped from and the user specified name for the
   remapped column."
-  [{:keys [internal-only-dims]} :- InternalColumnsInfo rf]
+  [{:keys [internal-only-dims]} rf]
   (if-let [remap-fn (make-row-map-fn internal-only-dims)]
     (fn
       ([]
@@ -475,5 +313,5 @@
     rff
     (fn remap-results-rff* [metadata]
       (let [internal-cols-info (internal-columns-info (:cols metadata))
-            metadata           (add-remapped-to-and-from-metadata metadata external-remaps internal-cols-info)]
+            metadata           (add-remapped-cols metadata external-remaps internal-cols-info)]
         (remap-results-xform internal-cols-info (rff metadata))))))

--- a/src/metabase/query_processor/middleware/auto_parse_filter_values.clj
+++ b/src/metabase/query_processor/middleware/auto_parse_filter_values.clj
@@ -32,7 +32,7 @@
 (defn auto-parse-filter-values
   "Automatically parse String filter clause values to the appropriate type."
   [query]
-  (mbql.u/replace-in query [:query]
+  (mbql.u/replace-this-level query
     [:value (v :guard string?) (info :guard (fn [{base-type :base_type}]
                                               (and base-type
                                                    (not (isa? base-type :type/Text)))))]

--- a/src/metabase/query_processor/middleware/binning.clj
+++ b/src/metabase/query_processor/middleware/binning.clj
@@ -208,7 +208,7 @@
   "Update `:field` clauses with `:binning` strategy options in an `inner` [MBQL] query."
   [{filters :filter, :as inner-query}]
   (let [field-id->filters (filter->field-map filters)]
-    (mbql.u/replace inner-query
+    (mbql.u/replace-this-level inner-query
       [:field _ (_ :guard :binning)]
       (try
         (update-binned-field inner-query field-id->filters &match)
@@ -219,7 +219,6 @@
   "When a binned field is found, it might need to be updated if a relevant query criteria affects the min/max value of
   the binned field. This middleware looks for that criteria, then updates the related min/max values and calculates
   the bin-width based on the criteria values (or global min/max information)."
-  [{query-type :type, :as query}]
-  (if (= query-type :native)
-    query
-    (update query :query update-binning-strategy-in-inner-query)))
+  [{:qp/keys [query-type], :as query}]
+  (cond-> query
+    (= query-type :mbql) update-binning-strategy-in-inner-query))

--- a/src/metabase/query_processor/middleware/check_features.clj
+++ b/src/metabase/query_processor/middleware/check_features.clj
@@ -20,7 +20,7 @@
 (defn- query->required-features [query]
   (into
    #{}
-   (mbql.u/match (:query query)
+   (mbql.u/match-this-level query
      :stddev
      :standard-deviation-aggregations
 
@@ -30,7 +30,7 @@
 
 (defn check-features
   "Middleware that checks that drivers support the `:features` required to use certain clauses, like `:stddev`."
-  [{query-type :type, :as query}]
+  [{:qp/keys [query-type], :as query}]
   (if-not (= query-type :query)
     query
     (u/prog1 query

--- a/src/metabase/query_processor/middleware/cumulative_aggregations.clj
+++ b/src/metabase/query_processor/middleware/cumulative_aggregations.clj
@@ -19,7 +19,7 @@
 (s/defn ^:private replace-cumulative-ags :- mbql.s/Query
   "Replace `cum-count` and `cum-sum` aggregations in `query` with `count` and `sum` aggregations, respectively."
   [query]
-  (mbql.u/replace-in query [:query :aggregation]
+  (mbql.u/replace-in query [:aggregation]
     ;; cumulative count doesn't neccesarily have a field-id arg
     [:cum-count]       [:count]
     [:cum-count field] [:count field]
@@ -28,14 +28,14 @@
 (defn rewrite-cumulative-aggregations
   "Pre-processing middleware. Rewrite `:cum-count` and `:cum-sum` aggregations as `:count` and `:sum` respectively. Add
   information about the indecies of the replaced aggregations under the `::replaced-indecies` key."
-  [{{breakouts :breakout, aggregations :aggregation} :query, :as query}]
+  [{breakouts :breakout, aggregations :aggregation, :as query}]
   (if-not (mbql.u/match aggregations #{:cum-count :cum-sum})
     query
     (let [query'            (replace-cumulative-ags query)
           ;; figure out which indexes are being changed in the results. Since breakouts always get included in
           ;; results first we need to offset the indexes to change by the number of breakouts
-          replaced-indecies (set (for [i (diff-indecies (-> query  :query :aggregation)
-                                                        (-> query' :query :aggregation))]
+          replaced-indecies (set (for [i (diff-indecies (-> query  :aggregation)
+                                                        (-> query' :aggregation))]
                                    (+ (count breakouts) i)))]
       (cond-> query'
         (seq replaced-indecies) (assoc ::replaced-indecies replaced-indecies)))))

--- a/src/metabase/query_processor/middleware/desugar.clj
+++ b/src/metabase/query_processor/middleware/desugar.clj
@@ -1,16 +1,15 @@
 (ns metabase.query-processor.middleware.desugar
-  (:require [medley.core :as m]
-            [metabase.mbql.predicates :as mbql.preds]
+  (:require [metabase.mbql.predicates :as mbql.preds]
             [metabase.mbql.schema :as mbql.s]
             [metabase.mbql.util :as mbql.u]
             [schema.core :as s]))
 
-(s/defn desugar :- mbql.s/Query
+(s/defn desugar :- mbql.s/MBQLQuery
   "Middleware that uses MBQL lib functions to replace high-level 'syntactic sugar' clauses like `time-interval` and
   `inside` with lower-level clauses like `between`. This is done to minimize the number of MBQL clauses individual
   drivers need to support. Clauses replaced by this middleware are marked `^:sugar` in the MBQL schema."
-  [query]
-  (m/update-existing query :query (fn [query]
-                                    (mbql.u/replace query
-                                      (filter-clause :guard mbql.preds/Filter?)
-                                      (mbql.u/desugar-filter-clause filter-clause)))))
+  [{:qp/keys [query-type], :as query}]
+  (cond-> query
+    (= query-type :mbql) (mbql.u/replace-this-level
+                           (filter-clause :guard mbql.preds/Filter?)
+                           (mbql.u/desugar-filter-clause filter-clause))))

--- a/src/metabase/query_processor/middleware/fix_bad_references.clj
+++ b/src/metabase/query_processor/middleware/fix_bad_references.clj
@@ -29,11 +29,7 @@
    (fix-bad-references* inner-query inner-query (find-source-table inner-query)))
 
   ([inner-query form source-table & sources]
-   (mbql.u/replace form
-     ;; don't replace anything inside source metadata.
-     (_ :guard (constantly ((set &parents) :source-metadata)))
-     &match
-
+   (mbql.u/replace-this-level form
      ;; if we have entered a join map and don't have `join-source` info yet, determine that and recurse.
      (m :guard (every-pred map?
                            :condition
@@ -75,11 +71,4 @@
   This middleware performs a best-effort DWIM transformation, and isn't smart enough to fix every broken query out
   there. If the query cannot be fixed, this log a warning and move on. See #19612 for more information."
   [query]
-  (walk/postwalk
-   (fn [form]
-     (if (and (map? form)
-              ((some-fn :source-query :source-table) form)
-              (not (:condition form)))
-       (fix-bad-references* form)
-       form))
-   query))
+  (fix-bad-references* query))

--- a/src/metabase/query_processor/middleware/pre_alias_aggregations.clj
+++ b/src/metabase/query_processor/middleware/pre_alias_aggregations.clj
@@ -15,22 +15,14 @@
    aggregations
    (mbql.u/pre-alias-and-uniquify-aggregations ag-name aggregations)))
 
-(defn pre-alias-aggregations-in-inner-query
+(defn pre-alias-aggregations-in-query
   "Make sure all aggregations have aliases, and all aliases are unique, in an 'inner' MBQL query."
-  [{:keys [aggregation source-query joins], :as inner-query}]
-  (cond-> inner-query
-    (seq aggregation)
-    (update :aggregation pre-alias-and-uniquify)
-
-    source-query
-    (update :source-query pre-alias-aggregations-in-inner-query)
-
-    joins
-    (update :joins (partial mapv pre-alias-aggregations-in-inner-query))))
+  [{:keys [aggregation], :as query}]
+  (cond-> query
+    (seq aggregation) (update :aggregation pre-alias-and-uniquify)))
 
 (defn pre-alias-aggregations
   "Middleware that generates aliases for all aggregations anywhere in a query, and makes sure they're unique."
-  [{query-type :type, :as query}]
-  (if-not (= query-type :query)
-    query
-    (update query :query pre-alias-aggregations-in-inner-query)))
+  [{:qp/keys [query-type], :as query}]
+  (cond-> query
+    (= query-type :mbql) pre-alias-aggregations-in-query))

--- a/src/metabase/query_processor/middleware/reconcile_breakout_and_order_by_bucketing.clj
+++ b/src/metabase/query_processor/middleware/reconcile_breakout_and_order_by_bucketing.clj
@@ -38,7 +38,7 @@
             [schema.core :as s]))
 
 (s/defn ^:private reconcile-bucketing :- mbql.s/Query
-  [{{breakouts :breakout} :query, :as query}]
+  [{breakouts :breakout, :as query}]
   ;; Look for bucketed fields in the `breakout` clause and build a map of unbucketed reference -> bucketed reference,
   ;; like:
   ;;
@@ -52,7 +52,7 @@
                                                          [[:field id-or-name (not-empty (dissoc opts :temporal-unit :binning))]
                                                           &match])))]
     ;; rewrite order-by clauses as needed...
-    (-> (mbql.u/replace-in query [:query :order-by]
+    (-> (mbql.u/replace-in query [:order-by]
           ;; if order by is already bucketed, nothing to do
           [:field id-or-name (_ :guard (some-fn :temporal-unit :binning))]
           &match
@@ -66,7 +66,7 @@
             ;; if there's not, again nothing to do.
             &match))
         ;; now remove any duplicate order-by clauses we may have introduced, as those are illegal in MBQL 2000
-        (update-in [:query :order-by] (comp vec distinct)))))
+        (update-in [:order-by] (comp vec distinct)))))
 
 (defn reconcile-breakout-and-order-by-bucketing
   "Replace any unbucketed `:field` clauses (anything without `:temporal-unit` or `:bucketing` options) in the `order-by`
@@ -77,7 +77,7 @@
    ->
    {:query {:breakout [[:field 1 {:temporal-unit :day}]]
             :order-by [[:asc [:field 1 {:temporal-unit :day}]]]}}"
-  [{{breakouts :breakout, order-bys :order-by} :query, :as query}]
+  [{breakouts :breakout, order-bys :order-by, :as query}]
   (if (or
        ;; if there's no breakouts bucketed by a datetime-field or binning-strategy...
        (empty? (mbql.u/match breakouts [:field _ (_ :guard (some-fn :temporal-unit :binning))]))

--- a/src/metabase/query_processor/middleware/resolve_fields.clj
+++ b/src/metabase/query_processor/middleware/resolve_fields.clj
@@ -3,7 +3,6 @@
   (:require [metabase.mbql.util :as mbql.u]
             [metabase.query-processor.error-type :as qp.error-type]
             [metabase.query-processor.store :as qp.store]
-            [metabase.util :as u]
             [metabase.util.i18n :refer [tru]]))
 
 (defn- resolve-fields-with-ids!
@@ -15,13 +14,15 @@
 (defn resolve-fields
   "Resolve all field referenced in the `query`, and store them in the QP Store."
   [query]
-  (let [ids (set (mbql.u/match (:query query) [:field (id :guard integer?) _] id))]
+  (when-let [ids (not-empty
+                  (set
+                   (mbql.u/match-this-level query [:field (id :guard integer?) _] id)))]
     (try
-      (u/prog1 query
-        (resolve-fields-with-ids! ids))
+      (resolve-fields-with-ids! ids)
       (catch Throwable e
         (throw (ex-info (tru "Error resolving Fields in query: {0}" (ex-message e))
                         {:field-ids ids
                          :query     query
                          :type      qp.error-type/qp}
-                        e))))))
+                        e)))))
+  query)

--- a/src/metabase/query_processor/middleware/resolve_referenced.clj
+++ b/src/metabase/query_processor/middleware/resolve_referenced.clj
@@ -2,6 +2,7 @@
   (:require [metabase.models.card :refer [Card]]
             [metabase.query-processor.middleware.resolve-fields :as qp.resolve-fields]
             [metabase.query-processor.middleware.resolve-source-table :as qp.resolve-tables]
+            [metabase.query-processor.store :as qp.store]
             [metabase.util.i18n :refer [tru]]
             [schema.core :as s]
             [toucan.db :as db]
@@ -29,10 +30,10 @@
 
 (defn- check-query-database-id=
   [query database-id]
-  (when-not (= (:database query) database-id)
+  (when-not (= database-id (:id (qp.store/database)))
     (throw (ex-info (tru "Referenced query is from a different database")
                     {:referenced-query     query
-                     :expected-database-id database-id}))))
+                     :expected-database-id (:id (qp.store/database))}))))
 
 (s/defn ^:private resolve-referenced-card-resources* :- clojure.lang.IPersistentMap
   [query]

--- a/src/metabase/query_processor/middleware/resolve_source_table.clj
+++ b/src/metabase/query_processor/middleware/resolve_source_table.clj
@@ -1,39 +1,17 @@
 (ns metabase.query-processor.middleware.resolve-source-table
   "Fetches Tables corresponding to any `:source-table` IDs anywhere in the query."
-  (:require [metabase.mbql.util :as mbql.u]
-            [metabase.query-processor.store :as qp.store]
-            [metabase.util.i18n :refer [tru]]
-            [metabase.util.schema :as su]
-            [schema.core :as s]))
-
-(defn- check-all-source-table-ids-are-valid
-  "Sanity check: Any non-positive-integer value of `:source-table` should have been resolved by now. The
-  `resolve-card-id-source-tables` middleware should have already taken care of it."
-  [query]
-  (mbql.u/match-one query
-    (m :guard (every-pred map? :source-table #(string? (:source-table %))))
-    (throw
-      (ex-info
-        (tru "Invalid :source-table ''{0}'': should be resolved to a Table ID by now." (:source-table m))
-        {:form m}))))
-
-(s/defn ^:private query->source-table-ids :- (s/maybe (su/non-empty #{su/IntGreaterThanZero}))
-  "Fetch a set of all `:source-table` IDs anywhere in `query`."
-  [query]
-  (some->
-   (mbql.u/match query
-     (m :guard (every-pred map? :source-table #(integer? (:source-table %))))
-     ;; Recursively look in the rest of `m` for any other source tables
-     (cons
-      (:source-table m)
-      (filter some? (recur (dissoc m :source-table)))))
-   flatten
-   set))
+  (:require [metabase.query-processor.store :as qp.store]
+            [metabase.util.i18n :refer [tru]]))
 
 (defn resolve-source-tables
-  "Middleware that will take any `:source-table`s (integer IDs) anywhere in the query and fetch and save the
+  "Middleware that will take any `:source-table`s (integer IDs) at the current level of the query and fetch and save the
   corresponding Table in the Query Processor Store."
-  [query]
-  (check-all-source-table-ids-are-valid query)
-  (qp.store/fetch-and-store-tables! (query->source-table-ids query))
+  [{:keys [source-table], :as query}]
+  (when source-table
+    (when (string? source-table)
+      (throw
+       (ex-info
+        (tru "Invalid :source-table {0}: should be resolved to a Table ID by now." (pr-str source-table))
+        {:query query})))
+    (qp.store/fetch-and-store-tables! [source-table]))
   query)

--- a/src/metabase/query_processor/middleware/validate_temporal_bucketing.clj
+++ b/src/metabase/query_processor/middleware/validate_temporal_bucketing.clj
@@ -30,7 +30,8 @@
   "Make sure temporal bucketing of Fields (i.e., `:datetime-field` clauses) in this query is valid given the combination
   of Field base-type and unit. For example, you should not be allowed to bucket a `:type/Date` Field by `:minute`."
   [query]
-  (doseq [[_ id-or-name {:keys [temporal-unit base-type]} :as clause] (mbql.u/match query [:field _ (_ :guard :temporal-unit)])]
+  (doseq [[_ id-or-name {:keys [temporal-unit base-type]} :as clause] (mbql.u/match-this-level query
+                                                                        [:field _ (_ :guard :temporal-unit)])]
     (let [base-type (if (integer? id-or-name)
                       (:base_type (qp.store/field id-or-name))
                       base-type)


### PR DESCRIPTION
Instead of each piece of QP preprocessing middleware having to roll their own logic to walk the query and recursively preprocess source queries, have each piece of middleware just preprocess the current level and handle all the walking/recursion at the top level.

Work in progress.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/20363)
<!-- Reviewable:end -->
