### PR TITLE
Refactor question URL builder arguments

### DIFF
--- a/frontend/src/metabase-lib/lib/Question.ts
+++ b/frontend/src/metabase-lib/lib/Question.ts
@@ -931,17 +931,16 @@ export default class Question {
       !question.id() ||
       (originalQuestion && question.isDirtyComparedTo(originalQuestion))
     ) {
-      return Urls.question(
-        null,
-        question._serializeForUrl({
+      return Urls.question(null, {
+        hash: question._serializeForUrl({
           clean,
           includeDisplayIsLocked,
           creationType,
         }),
         query,
-      );
+      });
     } else {
-      return Urls.question(question.card(), "", query);
+      return Urls.question(question.card(), { query });
     }
   }
 

--- a/frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx
@@ -108,7 +108,7 @@ export default class PartialQueryBuilder extends Component {
     const previewCard = {
       dataset_query: datasetQuery,
     };
-    const previewUrl = Urls.question(null, previewCard);
+    const previewUrl = Urls.question(null, { hash: previewCard });
 
     return (
       <div className="py1">

--- a/frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx
@@ -108,7 +108,7 @@ export default class PartialQueryBuilder extends Component {
     const previewCard = {
       dataset_query: datasetQuery,
     };
-    const previewUrl = Urls.question(null, { hash: previewCard });
+    const previewUrl = Urls.serializedQuestion(previewCard);
 
     return (
       <div className="py1">

--- a/frontend/src/metabase/lib/card.js
+++ b/frontend/src/metabase/lib/card.js
@@ -97,10 +97,9 @@ export function deserializeCardFromUrl(serialized) {
 }
 
 export function urlForCardState(state, dirty) {
-  return Urls.question(
-    state.card,
-    state.serializedCard && dirty ? state.serializedCard : "",
-  );
+  return Urls.question(state.card, {
+    hash: state.serializedCard && dirty ? state.serializedCard : "",
+  });
 }
 
 export function cleanCopyCard(card) {

--- a/frontend/src/metabase/lib/urls.js
+++ b/frontend/src/metabase/lib/urls.js
@@ -75,8 +75,8 @@ export function question(card, { hash = "", query = "" } = {}) {
   return `${path}${query}${hash}`;
 }
 
-export function serializedQuestion(card) {
-  return question(null, { hash: card });
+export function serializedQuestion(card, opts = {}) {
+  return question(null, { ...opts, hash: card });
 }
 
 export const extractQueryParams = query => {

--- a/frontend/src/metabase/lib/urls.js
+++ b/frontend/src/metabase/lib/urls.js
@@ -163,7 +163,10 @@ export function tableRowsQuery(databaseId, tableId, metricId, segmentId) {
     query += `&segment=${segmentId}`;
   }
 
-  return question(null, { query });
+  // This will result in a URL like "/question#?db=1&table=1"
+  // The QB will parse the querystring and use DB and table IDs to create an ad-hoc question
+  // We should refactor the initializeQB to avoid passing query string to hash as it's pretty confusing
+  return question(null, { hash: query });
 }
 
 function slugifyPersonalCollection(collection) {

--- a/frontend/src/metabase/lib/urls.js
+++ b/frontend/src/metabase/lib/urls.js
@@ -25,7 +25,7 @@ export const newPulse = () => `/pulse/create`;
 export const newCollection = collectionId =>
   `collection/${collectionId}/new_collection`;
 
-export function question(card, hash = "", query = "") {
+export function question(card, { hash = "", query = "" } = {}) {
   if (hash && typeof hash === "object") {
     hash = serializeCardForUrl(hash);
   }
@@ -76,7 +76,7 @@ export function question(card, hash = "", query = "") {
 }
 
 export function serializedQuestion(card) {
-  return question(null, card);
+  return question(null, { hash: card });
 }
 
 export const extractQueryParams = query => {
@@ -163,7 +163,7 @@ export function tableRowsQuery(databaseId, tableId, metricId, segmentId) {
     query += `&segment=${segmentId}`;
   }
 
-  return question(null, query);
+  return question(null, { query });
 }
 
 function slugifyPersonalCollection(collection) {

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -967,7 +967,7 @@ export const navigateToNewCardInsideQB = createThunkAction(
         dispatch(setCardAndRun(await loadCard(nextCard.id)));
       } else {
         const card = getCardAfterVisualizationClick(nextCard, previousCard);
-        const url = Urls.question(null, card);
+        const url = Urls.question(null, { hash: card });
         if (shouldOpenInBlankWindow(url, { blankOnMetaOrCtrlKey: true })) {
           open(url);
         } else {

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -967,7 +967,7 @@ export const navigateToNewCardInsideQB = createThunkAction(
         dispatch(setCardAndRun(await loadCard(nextCard.id)));
       } else {
         const card = getCardAfterVisualizationClick(nextCard, previousCard);
-        const url = Urls.question(null, { hash: card });
+        const url = Urls.serializedQuestion(card);
         if (shouldOpenInBlankWindow(url, { blankOnMetaOrCtrlKey: true })) {
           open(url);
         } else {

--- a/frontend/src/metabase/reference/utils.js
+++ b/frontend/src/metabase/reference/utils.js
@@ -105,7 +105,7 @@ export const getQuestion = ({
 };
 
 export const getQuestionUrl = getQuestionArgs =>
-  Urls.question(null, getQuestion(getQuestionArgs));
+  Urls.question(null, { hash: getQuestion(getQuestionArgs) });
 
 export const typeToLinkClass = {
   dashboard: "text-green",

--- a/frontend/test/metabase/lib/urls.unit.spec.js
+++ b/frontend/test/metabase/lib/urls.unit.spec.js
@@ -13,24 +13,28 @@ describe("urls", () => {
   describe("question", () => {
     describe("with a query", () => {
       it("returns the correct url", () => {
-        expect(question({}, "", { foo: "bar" })).toEqual("/question?foo=bar");
-        expect(question({}, "hash", { foo: "bar" })).toEqual(
+        expect(question({}, { query: { foo: "bar" } })).toEqual(
+          "/question?foo=bar",
+        );
+        expect(question({}, { hash: "hash", query: { foo: "bar" } })).toEqual(
           "/question?foo=bar#hash",
         );
-        expect(question(null, "hash", { foo: "bar" })).toEqual(
+        expect(question(null, { hash: "hash", query: { foo: "bar" } })).toEqual(
           "/question?foo=bar#hash",
         );
-        expect(question(null, "", { foo: "bar" })).toEqual("/question?foo=bar");
-        expect(question(null, "", { foo: "bar+bar" })).toEqual(
+        expect(question(null, { query: { foo: "bar" } })).toEqual(
+          "/question?foo=bar",
+        );
+        expect(question(null, { query: { foo: "bar+bar" } })).toEqual(
           "/question?foo=bar%2Bbar",
         );
-        expect(question(null, "", { foo: ["bar", "baz"] })).toEqual(
+        expect(question(null, { query: { foo: ["bar", "baz"] } })).toEqual(
           "/question?foo=bar&foo=baz",
         );
-        expect(question(null, "", { foo: ["bar", "baz+bay"] })).toEqual(
+        expect(question(null, { query: { foo: ["bar", "baz+bay"] } })).toEqual(
           "/question?foo=bar&foo=baz%2Bbay",
         );
-        expect(question(null, "", { foo: ["bar", "baz&bay"] })).toEqual(
+        expect(question(null, { query: { foo: ["bar", "baz&bay"] } })).toEqual(
           "/question?foo=bar&foo=baz%26bay",
         );
       });


### PR DESCRIPTION
`Urls.question` from `metabase/lib/urls` accepts three arguments (`card`, `hash` and `query`). The problem is that _all of them_ are optional, so there are some cases when you need to pass `null` for args you don't need. Examples:

1. Need a saved question URL with query parameters: `Urls.question(card, null, query)`
2. Need an ad-hoc question URL: `Urls.question(null, cardHash)` (however there is a `Urls.serializedQuestion` for that)
3. Need an ad-hoc question URL with query params `Urls.question(null, cardHash, query)`. `Urls.serializedQuestion` won't help here as it only accepts the deserialized card object

This PR makes the `Urls.question` function accept a `card` / `Question` object and an optional object with `hash` and `query`. So you can do things like `Urls.question(card, { query })` and `Urls.serializedQuestion(hash, { query })`