### PR TITLE
remove tsc-files

### DIFF
--- a/package.json
+++ b/package.json
@@ -235,7 +235,6 @@
     "raf": "^3.4.0",
     "shadow-cljs": "2.11.20",
     "style-loader": "^0.19.0",
-    "tsc-files": "^1.1.3",
     "typescript": "^4.4.3",
     "webpack": "^5.37.0",
     "webpack-cli": "^4.7.0",
@@ -314,8 +313,7 @@
     "+(enterprise|frontend)/**/*.{js,jsx,ts,tsx}": [
       "eslint --rulesdir frontend/lint/eslint-rules --max-warnings 0",
       "prettier --write"
-    ],
-    "+(enterprise|frontend)/**/*.{ts,tsx}": "tsc-files --noEmit frontend/src/types/global.d.ts frontend/src/types/color-harmony.d.ts frontend/src/types/styled-system.d.ts"
+    ]
   },
   "browserslist": [
     "defaults"

--- a/yarn.lock
+++ b/yarn.lock
@@ -20874,11 +20874,6 @@ ts-pnp@^1.1.6:
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
   integrity sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==
 
-tsc-files@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/tsc-files/-/tsc-files-1.1.3.tgz#ef4cfcb7affc9b90577d707a879dc53bb105be83"
-  integrity sha512-G6uXkTNofGU9EE1fYBaCpR72x/aqXW4PDAuznWj4JYlDwhcaKnUn4CiCHBMc89lDxLmikK+hhaEWLoTPEKKvXg==
-
 tsconfig-paths@^3.9.0:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz#098547a6c4448807e8fcb8eae081064ee9a3c90b"


### PR DESCRIPTION
It causes random errors on a pre-commit hook.
When importing `import { connect } from "react-redux";` in any file, `tsc-files` emits errors in `frontend/src/metabase/core/components/CheckBox/CheckBox.tsx`