### PR TITLE
workaround people pagination flakes

### DIFF
--- a/frontend/test/metabase/scenarios/admin/people/people.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/people/people.cy.spec.js
@@ -223,14 +223,24 @@ describe("scenarios > admin > people", () => {
       const NEW_USERS = 18;
       const NEW_TOTAL_USERS = TOTAL_USERS + NEW_USERS;
 
+      const waitForUserRequests = () => {
+        cy.wait("@users");
+        cy.wait("@memberships");
+      };
+
       beforeEach(() => {
         generateUsers(NEW_USERS);
+
+        cy.intercept("GET", "/api/user").as("users");
+        cy.intercept("GET", "/api/permissions/membership").as("memberships");
       });
 
       it("should allow paginating people forward and backward", () => {
         const PAGE_SIZE = 25;
 
         cy.visit("/admin/people");
+
+        waitForUserRequests();
 
         // Total
         cy.findByText(`${NEW_TOTAL_USERS} people found`);
@@ -241,6 +251,8 @@ describe("scenarios > admin > people", () => {
         cy.findByTestId("previous-page-btn").should("be.disabled");
 
         cy.findByTestId("next-page-btn").click();
+
+        waitForUserRequests();
 
         // Page 2
         cy.findByText(`${PAGE_SIZE + 1} - ${NEW_TOTAL_USERS}`);


### PR DESCRIPTION
Try to fix people pagination flakes:
<img width="1284" alt="Screenshot 2022-02-09 at 14 00 22" src="https://user-images.githubusercontent.com/14301985/153216235-6b4628cc-3d21-4aec-8eb7-2cb6d1fa96fb.png">
Cypress found `next-page-btn` and logged it successfully clicked on it, but no click has happened.