### PR TITLE
Replace the old bigquery e2e test with the Presto deprecation warning

### DIFF
--- a/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
@@ -276,13 +276,13 @@ describe("scenarios > admin > databases > add", () => {
     it("should display driver deprecation messages", () => {
       cy.visit("/admin/databases/create");
 
-      chooseDatabase("BigQuery");
+      chooseDatabase("Presto");
 
-      cy.findByText("BigQuery");
+      cy.findByText("Presto");
       cy.findByText("Need help connecting?");
 
       cy.findByText("find it here").click();
-      cy.findByText("BigQuery (Deprecated Driver)");
+      cy.findByText("Presto (Deprecated Driver)");
       cy.findByText("Need help connecting?");
     });
   });


### PR DESCRIPTION
We removed the driver, so this test is not needed anymore.
