### PR TITLE
Pass metadata-populated parameters to the embedded dashboard modal

### DIFF
--- a/frontend/src/metabase/dashboard/containers/DashboardSharingEmbeddingModal.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardSharingEmbeddingModal.jsx
@@ -6,7 +6,7 @@ import cx from "classnames";
 import ModalWithTrigger from "metabase/components/ModalWithTrigger";
 
 import EmbedModalContent from "metabase/public/components/widgets/EmbedModalContent";
-
+import { getParameters } from "metabase/dashboard/selectors";
 import * as Urls from "metabase/lib/urls";
 import * as MetabaseAnalytics from "metabase/lib/analytics";
 
@@ -20,6 +20,10 @@ import {
 const defaultProps = {
   isLinkEnabled: true,
 };
+
+const mapStateToProps = (state, props) => ({
+  parameters: getParameters(state, props),
+});
 
 const mapDispatchToProps = {
   createPublicLink,
@@ -37,6 +41,7 @@ class DashboardSharingEmbeddingModal extends Component {
       className,
       createPublicLink,
       dashboard,
+      parameters,
       deletePublicLink,
       enabled,
       linkClassNames,
@@ -78,7 +83,7 @@ class DashboardSharingEmbeddingModal extends Component {
           {...props}
           className={className}
           resource={dashboard}
-          resourceParameters={dashboard && dashboard.parameters}
+          resourceParameters={parameters}
           resourceType="dashboard"
           onCreatePublicLink={() => createPublicLink(dashboard)}
           onDisablePublicLink={() => deletePublicLink(dashboard)}
@@ -102,6 +107,6 @@ class DashboardSharingEmbeddingModal extends Component {
 DashboardSharingEmbeddingModal.defaultProps = defaultProps;
 
 export default connect(
-  null,
+  mapStateToProps,
   mapDispatchToProps,
 )(DashboardSharingEmbeddingModal);


### PR DESCRIPTION
Fixes #20357
Reproduces #20357

We were not passing the embedding components the correct parameter
objects; instead of `dashboard.parameters` we need to pass the components
parameters that have had metadata added to them such as the fields they
are mapped to, as child parameters components now expect this metadata
to exist.

The aggravator was a bit of refactoring done to simplify parameters code: https://github.com/metabase/metabase/pull/18721 -- I missed updating this bit of code, apparently.

**Testing**
Follow the repro steps in #20357 