### PR TITLE
Dashboard checkbox should honor reduced-motion

### DIFF
--- a/frontend/src/metabase/components/Swapper.jsx
+++ b/frontend/src/metabase/components/Swapper.jsx
@@ -2,6 +2,8 @@
 import React from "react";
 import { Motion, spring } from "react-motion";
 
+import { isReducedMotionPreferred } from "metabase/lib/dom";
+
 class Swapper extends React.Component {
   state = {
     hovered: false,
@@ -19,6 +21,11 @@ class Swapper extends React.Component {
     const { defaultElement, swappedElement, startSwapped } = this.props;
     const { hovered } = this.state;
 
+    const preferReducedMotion = isReducedMotionPreferred();
+    const springOpts = preferReducedMotion
+      ? { stiffness: 500 }
+      : { stiffness: 170 };
+
     return (
       <span
         onMouseEnter={() => this._onMouseEnter()}
@@ -31,12 +38,22 @@ class Swapper extends React.Component {
             scale: 1,
           }}
           style={{
-            scale: hovered || startSwapped ? spring(0) : spring(1),
+            scale:
+              hovered || startSwapped
+                ? spring(0, springOpts)
+                : spring(1, springOpts),
           }}
         >
           {({ scale }) => {
+            const snapScale = scale < 0.5 ? 0 : 1;
+            const _scale = preferReducedMotion ? snapScale : scale;
             return (
-              <span style={{ display: "block", transform: `scale(${scale})` }}>
+              <span
+                style={{
+                  display: "block",
+                  transform: `scale(${_scale})`,
+                }}
+              >
                 {defaultElement}
               </span>
             );
@@ -47,14 +64,19 @@ class Swapper extends React.Component {
             scale: 0,
           }}
           style={{
-            scale: hovered || startSwapped ? spring(1) : spring(0),
+            scale:
+              hovered || startSwapped
+                ? spring(1, springOpts)
+                : spring(0, springOpts),
           }}
         >
           {({ scale }) => {
+            const snapScale = scale < 0.5 ? 0 : 1;
+            const _scale = preferReducedMotion ? snapScale : scale;
             return (
               <span
                 className="absolute top left bottom right"
-                style={{ display: "block", transform: `scale(${scale})` }}
+                style={{ display: "block", transform: `scale(${_scale})` }}
               >
                 {swappedElement}
               </span>


### PR DESCRIPTION
How to verify:

1. Make sure to enable [prefers-reduced-motion](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion#user_preferences)
2. From the main page, Browser all items (alternatively, go to `/collection/root`)
3. Hover the mouse to the icon of any row

![image](https://user-images.githubusercontent.com/7288/153273494-0a374957-cf0b-4e96-bba1-f3de9ae190a6.png)

**Before**

The icon turns into a checkbox with some animation (scaling).

**After**

The icon turns into a checkbox instantly (no animation).