### PR TITLE
Handle scenario where query props are undefined on a StructuredQuery

### DIFF
--- a/frontend/src/metabase-lib/lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/lib/queries/StructuredQuery.ts
@@ -212,7 +212,7 @@ export default class StructuredQuery extends AtomicQuery {
    * @returns the table ID, if a table is selected.
    */
   sourceTableId(): TableId | null | undefined {
-    return this.query()["source-table"];
+    return this.query()?.["source-table"];
   }
 
   /**
@@ -1437,7 +1437,7 @@ export default class StructuredQuery extends AtomicQuery {
    */
   @memoize
   sourceQuery(): StructuredQuery | null | undefined {
-    const sourceQuery = this.query()["source-query"];
+    const sourceQuery = this.query()?.["source-query"];
 
     if (sourceQuery) {
       return new NestedStructuredQuery(

--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/20393-public-dashboard-nested-card-with-parameters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/20393-public-dashboard-nested-card-with-parameters.cy.spec.js
@@ -1,0 +1,71 @@
+import { restore, popover } from "__support__/e2e/cypress";
+
+describe("issue 20393", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should show public dashboards with nested cards mapped to parameters (metabase#20393)", () => {
+    createDashboardWithNestedCard();
+
+    // add a date parameter to the dashboard
+    cy.icon("pencil").click();
+    cy.icon("filter").click();
+    popover()
+      .contains("Time")
+      .click();
+    popover()
+      .contains("All Options")
+      .click();
+
+    // map the date parameter to the card
+    cy.get(".DashCard")
+      .contains("Select")
+      .click();
+    popover()
+      .contains("CREATED_AT")
+      .click();
+
+    // save the dashboard
+    cy.findByText("Save").click();
+
+    // open the sharing modal and enable sharing
+    cy.icon("share").click();
+    cy.findByText("Sharing and embedding").click();
+    cy.findByRole("switch").click();
+
+    // navigate to the public dashboard link
+    cy.findByText("Public link")
+      .parent()
+      .within(() => {
+        cy.get("input").then(input => {
+          cy.visit(input.val());
+        });
+      });
+
+    // verify that the card is visible on the page
+    cy.findByText("Q2");
+  });
+});
+
+function createDashboardWithNestedCard() {
+  cy.createNativeQuestion({
+    name: "Q1",
+    native: { query: 'SELECT * FROM "ORDERS"', "template-tags": {} },
+  }).then(({ body }) =>
+    cy
+      .createQuestion({
+        name: "Q2",
+        query: { "source-table": `card__${body.id}` },
+      })
+      .then(({ body: { id: cardId } }) =>
+        cy
+          .createDashboard("Q2 in a dashboard")
+          .then(({ body: { id: dashId } }) => {
+            cy.request("POST", `/api/dashboard/${dashId}/cards`, { cardId });
+            cy.visit(`/dashboard/${dashId}`);
+          }),
+      ),
+  );
+}


### PR DESCRIPTION
Fixes #20393
Reproduces #20393 

Parameters logic always goes through `Dimension` now which in turn depends heavily on other classes in `metabase-lib`. `dimension.field()` can call `dimension.query().table()` and under the hood of that we look at the query object defined on the dimension. When in a  public dashboard a card's query is returned as `{type: "query"}`, but logic in `StructuredQuery` assumes that other properties are defined on the query, info about the underlying table etc. To fix public dashcards we need to check for undefined query properties now.

Adding more branching logic to all of these foundational classes kind of sucks, so I wonder if we should add a `PublicStructuredQuery` at some point?

**Testing**
Follow the steps in #20393 