### PR TITLE
Bi-basics e2e helpers

### DIFF
--- a/frontend/test/__support__/e2e/cypress.js
+++ b/frontend/test/__support__/e2e/cypress.js
@@ -28,5 +28,6 @@ export * from "./helpers/e2e-snowplow-helpers";
 export * from "./helpers/e2e-custom-column-helpers";
 export * from "./helpers/e2e-dimension-list-helpers";
 export * from "./helpers/e2e-downloads-helpers";
+export * from "./helpers/e2e-bi-basics-helpers";
 
 Cypress.on("uncaught:exception", (err, runnable) => false);

--- a/frontend/test/__support__/e2e/helpers/e2e-bi-basics-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-bi-basics-helpers.js
@@ -1,0 +1,52 @@
+export function summarize({ mode } = {}) {
+  initiateAction("Summarize", mode);
+}
+
+export function filter({ mode } = {}) {
+  initiateAction("Filter", mode);
+}
+
+/**
+ * Initiate a certain action such as filtering or summarizing taking the question's mode into account.
+ *
+ * @param {("Summarize"|"Filter")} actionType
+ * @param {(undefined|"notebook")} mode
+ */
+function initiateAction(actionType, mode) {
+  const icon = getIcon(actionType);
+
+  if (mode === "notebook") {
+    cy.findAllByTestId("action-buttons")
+      .find(`.Icon-${icon}`)
+      .click();
+  } else {
+    cy.findByTestId("qb-header-action-panel")
+      .contains(actionType)
+      .click();
+  }
+}
+
+/**
+ * Get the appropriate icon depending on the action type.
+ *
+ * @param {("Summarize"|"Filter")} actionType
+ * @returns string
+ */
+function getIcon(actionType) {
+  let icon;
+
+  switch (actionType) {
+    case "Filter":
+      icon = "filter";
+      break;
+
+    case "Summarize":
+      icon = "sum";
+      break;
+
+    default:
+      break;
+  }
+
+  return icon;
+}

--- a/frontend/test/metabase/scenarios/admin/datamodel/metadata.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/metadata.cy.spec.js
@@ -3,6 +3,7 @@ import {
   openOrdersTable,
   openReviewsTable,
   popover,
+  summarize,
 } from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
@@ -115,7 +116,7 @@ describe("scenarios > admin > datamodel > metadata", () => {
     });
 
     openReviewsTable({ mode: "notebook" });
-    cy.findByText("Summarize").click();
+    summarize({ mode: "notebook" });
     cy.findByText("Count of rows").click();
     cy.findByText("Pick a column to group by").click();
     cy.get(".List-section-header")

--- a/frontend/test/metabase/scenarios/admin/datamodel/metrics.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/metrics.cy.spec.js
@@ -4,6 +4,7 @@ import {
   modal,
   openOrdersTable,
   visualize,
+  summarize,
 } from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
@@ -29,7 +30,7 @@ describe("scenarios > admin > datamodel > metrics", () => {
 
     openOrdersTable({ mode: "notebook" });
 
-    cy.findByText("Summarize").click();
+    summarize({ mode: "notebook" });
     cy.findByText("Common Metrics").click();
     cy.findByText("Revenue").click();
 

--- a/frontend/test/metabase/scenarios/admin/datamodel/reproductions/17768-entity-key-showing-binning-options.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/reproductions/17768-entity-key-showing-binning-options.cy.spec.js
@@ -1,4 +1,9 @@
-import { restore, openReviewsTable, popover } from "__support__/e2e/cypress";
+import {
+  restore,
+  openReviewsTable,
+  popover,
+  summarize,
+} from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { REVIEWS } = SAMPLE_DATABASE;
@@ -27,7 +32,7 @@ describe("issue 17768", () => {
   it("should not show binning options for an entity key, regardless of its underlying type (metabase#17768)", () => {
     openReviewsTable({ mode: "notebook" });
 
-    cy.findByText("Summarize").click();
+    summarize({ mode: "notebook" });
     cy.findByText("Pick a column to group by").click();
 
     popover().within(() => {

--- a/frontend/test/metabase/scenarios/admin/datamodel/table.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/table.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore } from "__support__/e2e/cypress";
+import { restore, filter } from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
@@ -68,7 +68,7 @@ describe("scenarios > admin > databases > table", () => {
     it("simple question (metabase#15947-1)", () => {
       turnTableVisibilityOff(ORDERS_ID);
       cy.visit("/question/1");
-      cy.findByText("Filter");
+      filter();
     });
 
     it("question with joins (metabase#15947-2)", () => {

--- a/frontend/test/metabase/scenarios/admin/settings/whitelabel.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/whitelabel.cy.spec.js
@@ -2,6 +2,7 @@ import {
   restore,
   openOrdersTable,
   describeWithToken,
+  summarize,
 } from "__support__/e2e/cypress";
 
 // Define colors that we use for whitelabeling
@@ -156,9 +157,7 @@ describeWithToken("formatting > whitelabel", () => {
       // *** Test should pass when issue #470 is resolved
       cy.signInAsNormalUser();
       openOrdersTable();
-      cy.findAllByText("Summarize")
-        .first()
-        .click();
+      summarize();
       cy.findByText("Price").click();
       cy.findByText("Done").click();
 

--- a/frontend/test/metabase/scenarios/binning/binning-options.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/binning-options.cy.spec.js
@@ -4,6 +4,7 @@ import {
   openTable,
   visitQuestionAdhoc,
   getBinningButtonForDimension,
+  summarize,
 } from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
@@ -267,7 +268,7 @@ describe("scenarios > binning > binning options", () => {
 
 function chooseInitialBinningOption({ table, column, mode = null } = {}) {
   openTable({ table, mode });
-  cy.findByText("Summarize").click();
+  summarize({ mode });
 
   if (mode === "notebook") {
     cy.findByText("Count of rows").click();
@@ -287,7 +288,7 @@ function chooseInitialBinningOptionForExplicitJoin({
 } = {}) {
   visitQuestionAdhoc({ dataset_query: baseTableQuery });
 
-  cy.findByTextEnsureVisible("Summarize").click();
+  summarize();
 
   cy.findByTestId("sidebar-right").within(() => {
     cy.findByText("Count"); // Test fails without this because of some weird race condition

--- a/frontend/test/metabase/scenarios/binning/correctness/longitude.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/correctness/longitude.cy.spec.js
@@ -1,4 +1,9 @@
-import { restore, popover, openPeopleTable } from "__support__/e2e/cypress";
+import {
+  restore,
+  popover,
+  openPeopleTable,
+  summarize,
+} from "__support__/e2e/cypress";
 
 import { LONGITUDE_OPTIONS } from "./constants";
 
@@ -7,7 +12,7 @@ describe("scenarios > binning > correctness > longitude", () => {
     restore();
     cy.signInAsAdmin();
     openPeopleTable();
-    cy.findByText("Summarize").click();
+    summarize();
     openPopoverFromDefaultBucketSize("Longitude", "Auto bin");
   });
 

--- a/frontend/test/metabase/scenarios/binning/correctness/time-series.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/correctness/time-series.cy.spec.js
@@ -2,6 +2,7 @@ import {
   restore,
   popover,
   getBinningButtonForDimension,
+  summarize,
 } from "__support__/e2e/cypress";
 
 import { TIME_OPTIONS } from "./constants";
@@ -27,9 +28,7 @@ describe("scenarios > binning > correctness > time series", () => {
 
     cy.createQuestion(questionDetails, { visitQuestion: true });
 
-    cy.findByTestId("qb-header-action-panel")
-      .contains("Summarize")
-      .click();
+    summarize();
 
     openPopoverFromDefaultBucketSize("Created At", "by month");
   });

--- a/frontend/test/metabase/scenarios/binning/qb-explicit-joins.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/qb-explicit-joins.cy.spec.js
@@ -2,6 +2,7 @@ import {
   restore,
   visualize,
   changeBinningForDimension,
+  summarize,
 } from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
@@ -64,8 +65,8 @@ describe("scenarios > binning > from a saved QB question with explicit joins", (
       cy.findByText("Simple question").click();
       cy.findByText("Saved Questions").click();
       cy.findByText("QB Binning").click();
-      cy.findByText("Summarize").click();
       cy.wait("@dataset");
+      summarize();
     });
 
     it("should work for time series", () => {
@@ -129,7 +130,6 @@ describe("scenarios > binning > from a saved QB question with explicit joins", (
       cy.findByText("Saved Questions").click();
       cy.findByText("QB Binning").click();
 
-      cy.findByText("Summarize").click();
       cy.findByText("Pick the metric you want to see").click();
       cy.findByText("Count of rows").click();
       cy.findByText("Pick a column to group by").click();

--- a/frontend/test/metabase/scenarios/binning/qb-implicit-joins.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/qb-implicit-joins.cy.spec.js
@@ -2,6 +2,7 @@ import {
   restore,
   changeBinningForDimension,
   visualize,
+  summarize,
 } from "__support__/e2e/cypress";
 
 describe("scenarios > binning > from a saved QB question using implicit joins", () => {
@@ -15,7 +16,7 @@ describe("scenarios > binning > from a saved QB question using implicit joins", 
   context("via simple question", () => {
     beforeEach(() => {
       cy.visit("/question/1");
-      cy.findByText("Summarize").click();
+      summarize();
     });
 
     it("should work for time series", () => {
@@ -73,7 +74,7 @@ describe("scenarios > binning > from a saved QB question using implicit joins", 
   context("via custom question", () => {
     beforeEach(() => {
       cy.visit("/question/1/notebook");
-      cy.findByText("Summarize").click();
+      summarize({ mode: "notebook" });
       cy.findByText("Count of rows").click();
       cy.findByText("Pick a column to group by").click();
       // Click "Order" accordion to collapse it and expose the other tables

--- a/frontend/test/metabase/scenarios/binning/qb-regular-table.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/qb-regular-table.cy.spec.js
@@ -3,6 +3,7 @@ import {
   openTable,
   visualize,
   changeBinningForDimension,
+  summarize,
 } from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
@@ -149,7 +150,7 @@ function chooseInitialBinningOption({
   mode = null,
 } = {}) {
   openTable({ table, mode });
-  cy.findByText("Summarize").click();
+  summarize({ mode });
 
   if (mode === "notebook") {
     cy.findByText("Count of rows").click();

--- a/frontend/test/metabase/scenarios/binning/sql.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/sql.cy.spec.js
@@ -3,6 +3,7 @@ import {
   snapshot,
   visualize,
   changeBinningForDimension,
+  summarize,
 } from "__support__/e2e/cypress";
 
 const questionDetails = {
@@ -36,8 +37,8 @@ describe("scenarios > binning > from a saved sql question", () => {
       cy.findByText("Simple question").click();
       cy.findByText("Saved Questions").click();
       cy.findByText("SQL Binning").click();
-      cy.findByText("Summarize").click();
       cy.wait("@dataset");
+      summarize();
     });
 
     it("should work for time series", () => {
@@ -98,7 +99,6 @@ describe("scenarios > binning > from a saved sql question", () => {
       cy.findByText("Saved Questions").click();
       cy.findByText("SQL Binning").click();
 
-      cy.findByText("Summarize").click();
       cy.findByText("Pick the metric you want to see").click();
       cy.findByText("Count of rows").click();
       cy.findByText("Pick a column to group by").click();

--- a/frontend/test/metabase/scenarios/custom-column/cc-data-type.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/cc-data-type.cy.spec.js
@@ -3,6 +3,7 @@ import {
   openTable,
   popover,
   enterCustomColumnDetails,
+  filter,
 } from "__support__/e2e/cypress";
 
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
@@ -25,7 +26,8 @@ describe("scenarios > question > custom column > data type", () => {
 
     cy.button("Done").click();
 
-    cy.findByText("Filter").click();
+    filter({ mode: "notebook" });
+
     popover()
       .findByText("CategoryTitle")
       .click();
@@ -40,7 +42,7 @@ describe("scenarios > question > custom column > data type", () => {
     enterCustomColumnDetails({ formula: "[Birth Date]", name: "DoB" });
     cy.button("Done").click();
 
-    cy.findByText("Filter").click();
+    filter({ mode: "notebook" });
     popover()
       .findByText("DoB")
       .click();
@@ -60,7 +62,7 @@ describe("scenarios > question > custom column > data type", () => {
     });
     cy.button("Done").click();
 
-    cy.findByText("Filter").click();
+    filter({ mode: "notebook" });
     popover()
       .findByText("MiscDate")
       .click();
@@ -80,7 +82,7 @@ describe("scenarios > question > custom column > data type", () => {
     });
     cy.button("Done").click();
 
-    cy.findByText("Filter").click();
+    filter({ mode: "notebook" });
     popover()
       .findByText("MiscDate")
       .click();

--- a/frontend/test/metabase/scenarios/custom-column/custom-column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/custom-column.cy.spec.js
@@ -6,6 +6,7 @@ import {
   openOrdersTable,
   visitQuestionAdhoc,
   enterCustomColumnDetails,
+  filter,
 } from "__support__/e2e/cypress";
 
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
@@ -444,7 +445,7 @@ describe("scenarios > question > custom column", () => {
 
     cy.button("Done").click();
 
-    cy.findByText("Filter").click();
+    filter({ mode: "notebook" });
     popover()
       .contains("MiscDate")
       .click();

--- a/frontend/test/metabase/scenarios/custom-column/custom-column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/custom-column.cy.spec.js
@@ -1,6 +1,7 @@
 import {
   restore,
   popover,
+  summarize,
   visualize,
   openOrdersTable,
   visitQuestionAdhoc,
@@ -42,9 +43,8 @@ describe("scenarios > question > custom column", () => {
 
     visualize();
 
-    cy.findAllByText("Summarize")
-      .first()
-      .click();
+    summarize();
+
     cy.findByText("Group by")
       .parent()
       .findByText("Math")
@@ -82,7 +82,7 @@ describe("scenarios > question > custom column", () => {
   it("should create custom column with fields from aggregated data (metabase#12762)", () => {
     openOrdersTable({ mode: "notebook" });
 
-    cy.findByText("Summarize").click();
+    summarize({ mode: "notebook" });
 
     popover().within(() => {
       cy.findByText("Sum of ...").click();
@@ -401,7 +401,7 @@ describe("scenarios > question > custom column", () => {
     }).then(({ body: { id: QUESTION_ID } }) => {
       cy.visit(`/question/${QUESTION_ID}/notebook`);
     });
-    cy.findByText("Summarize").click();
+    summarize({ mode: "notebook" });
     cy.findByText("Sum of ...").click();
     popover()
       .findByText("MyCC [2021]")

--- a/frontend/test/metabase/scenarios/custom-column/reproductions/13289-cc-post-aggregation-zoom-in.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/reproductions/13289-cc-post-aggregation-zoom-in.cy.spec.js
@@ -4,6 +4,7 @@ import {
   popover,
   enterCustomColumnDetails,
   visualize,
+  summarize,
 } from "__support__/e2e/cypress";
 
 const CC_NAME = "Math";
@@ -24,7 +25,7 @@ describe("issue 13289", () => {
   });
 
   it("should allow 'zoom in' drill-through when grouped by custom column (metabase#13289) (metabase#13289)", () => {
-    cy.findByText("Summarize").click();
+    summarize({ mode: "notebook" });
     cy.findByText("Count of rows").click();
 
     cy.findByText("Pick a column to group by").click();

--- a/frontend/test/metabase/scenarios/custom-column/reproductions/14843-cc-apply-filter-not-equal-to.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/reproductions/14843-cc-apply-filter-not-equal-to.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, popover, visualize } from "__support__/e2e/cypress";
+import { restore, popover, visualize, filter } from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { PEOPLE, PEOPLE_ID } = SAMPLE_DATABASE;
@@ -15,6 +15,7 @@ const questionDetails = {
 describe("issue 14843", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/dataset").as("dataset");
+    cy.intercept("GET", "/api/database/1/schema/PUBLIC").as("schema");
 
     restore();
     cy.signInAsAdmin();
@@ -24,7 +25,10 @@ describe("issue 14843", () => {
     cy.createQuestion(questionDetails, { visitQuestion: true });
 
     cy.icon("notebook").click();
-    cy.icon("filter").click();
+
+    cy.wait("@schema");
+
+    filter({ mode: "notebook" });
 
     popover()
       .findByText(CC_NAME)

--- a/frontend/test/metabase/scenarios/custom-column/reproductions/18069-cc-sum-aggregation-dimension-type.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/reproductions/18069-cc-sum-aggregation-dimension-type.cy.spec.js
@@ -1,4 +1,9 @@
-import { restore, popover, visualize } from "__support__/e2e/cypress";
+import {
+  restore,
+  popover,
+  visualize,
+  summarize,
+} from "__support__/e2e/cypress";
 
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
@@ -29,7 +34,7 @@ describe("issue 18069", () => {
   });
 
   it("should not allow choosing text fields for SUM (metabase#18069)", () => {
-    cy.findByText("Summarize").click();
+    summarize({ mode: "notebook" });
     cy.findByText("Sum of ...").click();
 
     popover().within(() => {

--- a/frontend/test/metabase/scenarios/dashboard/x-rays.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/x-rays.cy.spec.js
@@ -3,6 +3,7 @@ import {
   getDimensionByName,
   visitQuestionAdhoc,
   popover,
+  summarize,
 } from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
@@ -101,7 +102,7 @@ describe("scenarios > x-rays", () => {
       cy.findByText("Simple question").click();
       cy.findByText("Saved Questions").click();
       cy.findByText("15655").click();
-      cy.findByText("Summarize").click();
+      summarize();
       getDimensionByName({ name: "SOURCE" }).click();
       cy.button("Done").click();
       cy.get(".bar")

--- a/frontend/test/metabase/scenarios/joins/joins-2.cy.spec.js
+++ b/frontend/test/metabase/scenarios/joins/joins-2.cy.spec.js
@@ -7,6 +7,7 @@ import {
   enterCustomColumnDetails,
   visitQuestionAdhoc,
   summarize,
+  filter,
 } from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
@@ -94,10 +95,8 @@ describe("scenarios > question > joined questions", () => {
 
       visualize();
 
-      cy.contains("Showing first 2,000");
-
       cy.log("Attempt to filter on the joined table");
-      cy.contains("Filter").click();
+      filter();
       cy.contains("Email").click();
       cy.contains("People – Email");
       cy.findByPlaceholderText("Search by Email")

--- a/frontend/test/metabase/scenarios/joins/joins-2.cy.spec.js
+++ b/frontend/test/metabase/scenarios/joins/joins-2.cy.spec.js
@@ -6,6 +6,7 @@ import {
   openNotebookEditor,
   enterCustomColumnDetails,
   visitQuestionAdhoc,
+  summarize,
 } from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
@@ -209,7 +210,7 @@ describe("scenarios > question > joined questions", () => {
       });
 
       cy.log("It shouldn't use FK for a column title");
-      cy.findByText("Summarize").click();
+      summarize({ mode: "notebook" });
       cy.findByText("Pick a column to group by").click();
 
       // NOTE: Since there is no better way to "get" the element we need, below is a representation of the current DOM structure.
@@ -484,7 +485,7 @@ describe("scenarios > question > joined questions", () => {
 
     it("breakout binning popover should have normal height even when it's rendered lower on the screen (metabase#15445)", () => {
       cy.visit("/question/1/notebook");
-      cy.findByText("Summarize").click();
+      summarize({ mode: "notebook" });
       cy.findByText("Count of rows").click();
       cy.findByText("Pick a column to group by").click();
       cy.findByText("Created At")

--- a/frontend/test/metabase/scenarios/joins/joins.cy.spec.js
+++ b/frontend/test/metabase/scenarios/joins/joins.cy.spec.js
@@ -3,6 +3,7 @@ import {
   openOrdersTable,
   popover,
   visualize,
+  summarize,
 } from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
@@ -102,7 +103,7 @@ describe("scenarios > question > joined questions", () => {
     assertDimensionName("parent", "Created At: Day");
     assertDimensionName("join", "Created At: Day");
 
-    cy.findByText("Summarize").click();
+    summarize({ mode: "notebook" });
     selectFromDropdown("Count of rows");
 
     visualize();
@@ -115,7 +116,7 @@ describe("scenarios > question > joined questions", () => {
   it("should show 'Previous results' instead of a table name for non-field dimensions", () => {
     openOrdersTable({ mode: "notebook" });
 
-    cy.findByText("Summarize").click();
+    summarize({ mode: "notebook" });
     selectFromDropdown("Count of rows");
 
     cy.findByText("Pick a column to group by").click();

--- a/frontend/test/metabase/scenarios/joins/reproductions/18589-numeric-binning-in-joins.cy.spec.js
+++ b/frontend/test/metabase/scenarios/joins/reproductions/18589-numeric-binning-in-joins.cy.spec.js
@@ -1,8 +1,9 @@
 import {
   restore,
   openOrdersTable,
-  getNotebookStep,
+  visualize,
   popover,
+  summarize,
 } from "__support__/e2e/cypress";
 
 describe("issue 18589", () => {
@@ -19,14 +20,12 @@ describe("issue 18589", () => {
     selectFromDropdown("Quantity");
     selectFromDropdown("Rating");
 
-    cy.findByText("Summarize").click();
+    summarize({ mode: "notebook" });
     selectFromDropdown("Count of rows");
 
-    getNotebookStep("summarize").within(() => {
-      cy.icon("play").click();
-      cy.wait("@dataset");
-      cy.findByText("2,860,368");
-    });
+    visualize();
+
+    cy.findByText("2,860,368");
   });
 });
 

--- a/frontend/test/metabase/scenarios/models/models-query-editor.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models-query-editor.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, runNativeQuery } from "__support__/e2e/cypress";
+import { restore, runNativeQuery, summarize } from "__support__/e2e/cypress";
 
 import {
   selectFromDropdown,
@@ -57,9 +57,7 @@ describe("scenarios > models query editor", () => {
     it("locks display to table", () => {
       cy.visit("/model/1/query");
 
-      cy.findByTestId("action-buttons")
-        .findByText("Summarize")
-        .click();
+      summarize({ mode: "notebook" });
 
       selectFromDropdown("Count of rows");
 

--- a/frontend/test/metabase/scenarios/models/models-revision-history.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models-revision-history.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, modal } from "__support__/e2e/cypress";
+import { restore, modal, filter } from "__support__/e2e/cypress";
 
 import {
   assertIsModel,
@@ -37,9 +37,7 @@ describe("scenarios > models > revision history", () => {
     assertIsQuestion();
     cy.get(".LineAreaBarChart");
 
-    cy.findByTestId("qb-header-action-panel").within(() => {
-      cy.findByText("Filter").click();
-    });
+    filter();
     selectDimensionOptionFromSidebar("Discount");
     cy.findByText("Equal to").click();
     selectFromDropdown("Not empty");
@@ -69,9 +67,7 @@ describe("scenarios > models > revision history", () => {
     assertIsModel();
     cy.get(".LineAreaBarChart").should("not.exist");
 
-    cy.findByTestId("qb-header-action-panel").within(() => {
-      cy.findByText("Filter").click();
-    });
+    filter();
     selectDimensionOptionFromSidebar("Count");
     cy.findByText("Equal to").click();
     selectFromDropdown("Greater than");

--- a/frontend/test/metabase/scenarios/models/models.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models.cy.spec.js
@@ -9,6 +9,7 @@ import {
   mockSessionProperty,
   sidebar,
   summarize,
+  filter,
 } from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 import {
@@ -38,9 +39,7 @@ describe("scenarios > models", () => {
     turnIntoModel();
     assertIsModel();
 
-    cy.findByTestId("qb-header-action-panel").within(() => {
-      cy.findByText("Filter").click();
-    });
+    filter();
     selectDimensionOptionFromSidebar("Discount");
     cy.findByText("Equal to").click();
     selectFromDropdown("Not empty");
@@ -88,9 +87,7 @@ describe("scenarios > models", () => {
     turnIntoModel();
     assertIsModel();
 
-    cy.findByTestId("qb-header-action-panel").within(() => {
-      cy.findByText("Filter").click();
-    });
+    filter();
     selectDimensionOptionFromSidebar("DISCOUNT");
     cy.findByText("Equal to").click();
     selectFromDropdown("Not empty");
@@ -293,9 +290,7 @@ describe("scenarios > models", () => {
     it("can create a question by filtering and summarizing a model", () => {
       cy.visit("/question/1");
 
-      cy.findByTestId("qb-header-action-panel").within(() => {
-        cy.findByText("Filter").click();
-      });
+      filter();
       selectDimensionOptionFromSidebar("Discount");
       cy.findByText("Equal to").click();
       selectFromDropdown("Not empty");

--- a/frontend/test/metabase/scenarios/models/models.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models.cy.spec.js
@@ -8,6 +8,7 @@ import {
   visualize,
   mockSessionProperty,
   sidebar,
+  summarize,
 } from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 import {
@@ -306,9 +307,8 @@ describe("scenarios > models", () => {
         table: "Orders",
       });
 
-      cy.findByTestId("qb-header-action-panel").within(() => {
-        cy.findByText("Summarize").click();
-      });
+      summarize();
+
       selectDimensionOptionFromSidebar("Created At");
       cy.button("Done").click();
 

--- a/frontend/test/metabase/scenarios/native/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/native.cy.spec.js
@@ -5,6 +5,7 @@ import {
   openNativeEditor,
   openNotebookEditor,
   visualize,
+  summarize,
 } from "__support__/e2e/cypress";
 
 describe("scenarios > question > native", () => {
@@ -141,16 +142,12 @@ describe("scenarios > question > native", () => {
         "**Final assertion: Count of rows with 'null' value should be 1**",
       );
       // "Count" is pre-selected option for "Summarize"
-      cy.findAllByText("Summarize")
-        .first()
-        .click();
+      summarize();
       cy.findByText("Done").click();
       cy.get(".ScalarValue").contains("1");
 
       cy.icon("close").click();
-      cy.findAllByText("Summarize")
-        .first()
-        .click();
+      summarize();
       cy.icon("close").click();
       cy.findByText("Done").click();
     });

--- a/frontend/test/metabase/scenarios/permissions/sandboxes.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/sandboxes.cy.spec.js
@@ -9,6 +9,7 @@ import {
   remapDisplayValueToFK,
   setupSMTP,
   visualize,
+  summarize,
 } from "__support__/e2e/cypress";
 import { USER_GROUPS } from "__support__/e2e/cypress_data";
 
@@ -198,7 +199,7 @@ describeWithToken("formatting > sandboxes", () => {
       cy.signInAsSandboxedUser();
 
       openOrdersTable({ mode: "notebook" });
-      cy.findByText("Summarize").click();
+      summarize({ mode: "notebook" });
       cy.findByText("Count of rows").click();
       cy.findByText("Pick a column to group by").click();
 

--- a/frontend/test/metabase/scenarios/permissions/sandboxes.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/sandboxes.cy.spec.js
@@ -10,6 +10,7 @@ import {
   setupSMTP,
   visualize,
   summarize,
+  filter,
 } from "__support__/e2e/cypress";
 import { USER_GROUPS } from "__support__/e2e/cypress_data";
 
@@ -140,7 +141,7 @@ describeWithToken("formatting > sandboxes", () => {
 
         cy.log("Add filter to a question");
         cy.icon("notebook").click();
-        cy.findByText("Filter").click();
+        filter({ mode: "notebook" });
         popover().within(() => {
           cy.findByText("Total").click({ force: true });
         });

--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -8,6 +8,7 @@ import {
   popover,
   visitQuestionAdhoc,
   visualize,
+  filter,
 } from "__support__/e2e/cypress";
 
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
@@ -36,7 +37,7 @@ describe("scenarios > question > filter", () => {
     cy.findByText("Join data").click();
     cy.findByText("Products").click();
     // add filter
-    cy.findByText("Filter").click();
+    filter({ mode: "notebook" });
     popover().within(() => {
       // we've run into weird "name normalization" issue
       // where it displays "Product" locally, and "Products" in CI
@@ -116,7 +117,7 @@ describe("scenarios > question > filter", () => {
 
     // Add filter as remapped Product ID (Product name)
     openOrdersTable();
-    cy.findByText("Filter").click();
+    filter();
     cy.get(".List-item-title")
       .contains("Product ID")
       .click();
@@ -206,7 +207,7 @@ describe("scenarios > question > filter", () => {
 
   it("in a simple question should display popup for custom expression options (metabase#14341) (metabase#15244)", () => {
     openProductsTable();
-    cy.findByText("Filter").click();
+    filter();
     cy.findByText("Custom Expression").click();
     enterCustomColumnDetails({ formula: "c" });
 
@@ -229,7 +230,7 @@ describe("scenarios > question > filter", () => {
 
   it("should be able to add date filter with calendar collapsed (metabase#14327)", () => {
     openOrdersTable({ mode: "notebook" });
-    cy.findByText("Filter").click();
+    filter({ mode: "notebook" });
     cy.findByText("Created At").click({ force: true });
     cy.findByText("Previous").click();
     cy.findByText("Before").click();
@@ -309,7 +310,7 @@ describe("scenarios > question > filter", () => {
 
   it("should reject Enter when the filter expression is invalid", () => {
     openReviewsTable({ mode: "notebook" });
-    cy.findByText("Filter").click();
+    filter({ mode: "notebook" });
     cy.findByText("Custom Expression").click();
 
     enterCustomColumnDetails({ formula: "[Rating] > 2E{enter}" }); // there should numbers after 'E'
@@ -393,7 +394,7 @@ describe("scenarios > question > filter", () => {
 
   it("should filter using IsNull() and IsEmpty()", () => {
     openReviewsTable({ mode: "notebook" });
-    cy.findByText("Filter").click();
+    filter({ mode: "notebook" });
     cy.findByText("Custom Expression").click();
 
     enterCustomColumnDetails({ formula: "NOT IsNull([Rating])" });
@@ -520,7 +521,7 @@ describe("scenarios > question > filter", () => {
     openOrdersTable({ mode: "notebook" });
 
     // Via the GUI, create a filter with "include-current" option
-    cy.findByText("Filter").click();
+    filter({ mode: "notebook" });
     cy.findByText("Created At").click({ force: true });
     cy.get("input[type='text']").type("{selectall}{del}5");
     cy.contains("Include today").click();
@@ -571,7 +572,7 @@ describe("scenarios > question > filter", () => {
 
   it("should reject a number literal", () => {
     openProductsTable();
-    cy.findByText("Filter").click();
+    filter();
     cy.findByText("Custom Expression").click();
 
     enterCustomColumnDetails({ formula: "3.14159" });
@@ -583,7 +584,7 @@ describe("scenarios > question > filter", () => {
 
   it("should reject a string literal", () => {
     openProductsTable();
-    cy.findByText("Filter").click();
+    filter();
     cy.findByText("Custom Expression").click();
 
     enterCustomColumnDetails({ formula: '"TheAnswer"' });
@@ -621,7 +622,7 @@ describe("scenarios > question > filter", () => {
 
   it("custom expression filter should reference fields by their name, not by their id (metabase#15748)", () => {
     openOrdersTable({ mode: "notebook" });
-    cy.findByText("Filter").click();
+    filter({ mode: "notebook" });
     cy.findByText("Custom Expression").click();
 
     enterCustomColumnDetails({ formula: "[Total] < [Subtotal]" });
@@ -632,7 +633,7 @@ describe("scenarios > question > filter", () => {
 
   it("custom expression filter should allow the use of parentheses in combination with logical operators (metabase#15754)", () => {
     openOrdersTable({ mode: "notebook" });
-    cy.findByText("Filter").click();
+    filter({ mode: "notebook" });
     cy.findByText("Custom Expression").click();
     cy.get(".ace_text-input")
       .type("([ID] > 2 OR [Subtotal] = 100) and [Tax] < 4")
@@ -647,7 +648,7 @@ describe("scenarios > question > filter", () => {
     cy.intercept("POST", "/api/dataset").as("dataset");
 
     openOrdersTable({ mode: "notebook" });
-    cy.findByText("Filter").click();
+    filter({ mode: "notebook" });
     cy.findByText("Custom Expression").click();
     cy.get(".ace_text-input")
       .type("0 < [ID]")
@@ -657,7 +658,7 @@ describe("scenarios > question > filter", () => {
 
   it("should allow switching focus with Tab", () => {
     openOrdersTable({ mode: "notebook" });
-    cy.findByText("Filter").click();
+    filter({ mode: "notebook" });
     cy.findByText("Custom Expression").click();
     cy.get(".ace_text-input").type("[Tax] > 0");
 
@@ -670,7 +671,7 @@ describe("scenarios > question > filter", () => {
 
   it("should allow choosing a suggestion with Tab", () => {
     openOrdersTable({ mode: "notebook" });
-    cy.findByText("Filter").click();
+    filter({ mode: "notebook" });
     cy.findByText("Custom Expression").click();
 
     // Try to auto-complete Tax
@@ -713,9 +714,7 @@ describe("scenarios > question > filter", () => {
     });
 
     cy.get(".ScalarValue").contains("5");
-    cy.findAllByRole("button")
-      .contains("Filter")
-      .click();
+    filter();
     cy.findByTestId("sidebar-right").within(() => {
       cy.findByText("Category").click();
       cy.findByText("Gizmo").click();
@@ -729,7 +728,7 @@ describe("scenarios > question > filter", () => {
   it("user shouldn't need to scroll to add filter (metabase#14307)", () => {
     cy.viewport(1280, 720);
     openPeopleTable({ mode: "notebook" });
-    cy.findByText("Filter").click();
+    filter({ mode: "notebook" });
     popover()
       .findByText("State")
       .click({ force: true });
@@ -801,7 +800,7 @@ describe("scenarios > question > filter", () => {
 
     it("adding an ID filter shouldn't cause page error and page reload (metabase#16198-2)", () => {
       openOrdersTable({ mode: "notebook" });
-      cy.findByText("Filter").click();
+      filter({ mode: "notebook" });
       cy.findByText("Custom Expression").click();
       cy.get(".ace_text-input")
         .type("[Total] < [Product → Price]")
@@ -824,7 +823,7 @@ describe("scenarios > question > filter", () => {
 
     it("removing first filter in a sequence shouldn't result in an empty page (metabase#16198-3)", () => {
       openOrdersTable({ mode: "notebook" });
-      cy.findByText("Filter").click();
+      filter({ mode: "notebook" });
       popover()
         .findByText("Total")
         .click({ force: true });
@@ -908,9 +907,7 @@ describe("scenarios > question > filter", () => {
       });
 
       it("from the simple question (metabase#16386-2)", () => {
-        cy.findAllByRole("button")
-          .contains("Filter")
-          .click();
+        filter();
 
         cy.findByTestId("sidebar-right").within(() => {
           cy.findByText("boolean").click();
@@ -923,7 +920,7 @@ describe("scenarios > question > filter", () => {
       it("from the custom question (metabase#16386-3)", () => {
         cy.icon("notebook").click();
 
-        cy.findByText("Filter").click();
+        filter({ mode: "notebook" });
 
         popover().within(() => {
           cy.findByText("boolean").click();
@@ -954,6 +951,6 @@ describe("scenarios > question > filter", () => {
 
 function openExpressionEditorFromFreshlyLoadedPage() {
   openReviewsTable({ mode: "notebook" });
-  cy.findByText("Filter").click();
+  filter({ mode: "notebook" });
   cy.findByText("Custom Expression").click();
 }

--- a/frontend/test/metabase/scenarios/question/nested.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nested.cy.spec.js
@@ -6,6 +6,7 @@ import {
   visitQuestionAdhoc,
   visualize,
   getDimensionByName,
+  summarize,
 } from "__support__/e2e/cypress";
 
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
@@ -177,16 +178,16 @@ describe("scenarios > question > nested", () => {
 
   it.skip("should display granularity for aggregated fields in nested questions (metabase#13764)", () => {
     openOrdersTable({ mode: "notebook" });
+
     // add initial aggregation ("Average of Total by Order ID")
-    cy.findByText("Summarize").click();
+    summarize({ mode: "notebook" });
     cy.findByText("Average of ...").click();
     cy.findByText("Total").click();
     cy.findByText("Pick a column to group by").click();
     cy.findByText("ID").click();
+
     // add another aggregation ("Count by Average of Total")
-    cy.get(".Button")
-      .contains("Summarize")
-      .click();
+    summarize({ mode: "notebook" });
     cy.findByText("Count of rows").click();
     cy.findByText("Pick a column to group by").click();
     cy.log("Reported failing on v0.34.3 - v0.37.0.2");
@@ -399,7 +400,7 @@ describe("scenarios > question > nested", () => {
     // The column title
     cy.findByText("Products → Category").click();
     cy.findByText("Distribution").click();
-    cy.contains("Summarize").click();
+    summarize();
     cy.findByText("Group by")
       .parent()
       .within(() => {
@@ -455,9 +456,7 @@ describe("scenarios > question > nested", () => {
       cy.findByText("15397").click();
 
       cy.wait("@dataset");
-      cy.findAllByText("Summarize")
-        .first()
-        .click();
+      summarize();
 
       if (test === "average") {
         cy.findByTestId("sidebar-right")
@@ -586,9 +585,7 @@ describe("scenarios > question > nested", () => {
 
       visualize();
 
-      cy.findAllByRole("button")
-        .contains("Summarize")
-        .click();
+      summarize();
       cy.findByTestId("add-aggregation-button").click();
       cy.findByText(/^Sum of/).click();
       popover()

--- a/frontend/test/metabase/scenarios/question/new.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/new.cy.spec.js
@@ -6,6 +6,7 @@ import {
   popover,
   restore,
   visualize,
+  summarize,
   openNotebookEditor,
 } from "__support__/e2e/cypress";
 
@@ -235,55 +236,53 @@ describe("scenarios > question > new", () => {
     });
 
     it.skip("should handle (removing) multiple metrics when one is sorted (metabase#13990)", () => {
-      cy.createQuestion({
-        name: "12625",
-        query: {
-          "source-table": ORDERS_ID,
-          aggregation: [
-            ["count"],
-            ["sum", ["field", ORDERS.SUBTOTAL, null]],
-            ["sum", ["field", ORDERS.TOTAL, null]],
-          ],
-          breakout: [["field", ORDERS.CREATED_AT, { "temporal-unit": "year" }]],
-          "order-by": [["desc", ["aggregation", 1]]],
+      cy.intercept("POST", `/api/dataset`).as("dataset");
+
+      cy.createQuestion(
+        {
+          name: "12625",
+          query: {
+            "source-table": ORDERS_ID,
+            aggregation: [
+              ["count"],
+              ["sum", ["field", ORDERS.SUBTOTAL, null]],
+              ["sum", ["field", ORDERS.TOTAL, null]],
+            ],
+            breakout: [
+              ["field", ORDERS.CREATED_AT, { "temporal-unit": "year" }],
+            ],
+            "order-by": [["desc", ["aggregation", 1]]],
+          },
         },
-      }).then(({ body: { id: QESTION_ID } }) => {
-        cy.server();
-        cy.route("POST", `/api/card/${QESTION_ID}/query`).as("cardQuery");
-        cy.route("POST", `/api/dataset`).as("dataset");
+        { visitQuestion: true },
+      );
 
-        cy.visit(`/question/${QESTION_ID}`);
+      summarize();
 
-        cy.wait("@cardQuery");
-        cy.get("button")
-          .contains("Summarize")
-          .click();
+      // CSS class of a sorted header cell
+      cy.get("[class*=TableInteractive-headerCellData--sorted]").as(
+        "sortedCell",
+      );
 
-        // CSS class of a sorted header cell
-        cy.get("[class*=TableInteractive-headerCellData--sorted]").as(
-          "sortedCell",
-        );
+      // At this point only "Sum of Subtotal" should be sorted
+      cy.get("@sortedCell")
+        .its("length")
+        .should("eq", 1);
+      removeMetricFromSidebar("Sum of Subtotal");
 
-        // At this point only "Sum of Subtotal" should be sorted
-        cy.get("@sortedCell")
-          .its("length")
-          .should("eq", 1);
-        removeMetricFromSidebar("Sum of Subtotal");
+      cy.wait("@dataset");
+      cy.findByText("Sum of Subtotal").should("not.exist");
 
-        cy.wait("@dataset");
-        cy.findByText("Sum of Subtotal").should("not.exist");
+      // "Sum of Total" should not be sorted, nor any other header cell
+      cy.get("@sortedCell")
+        .its("length")
+        .should("eq", 0);
 
-        // "Sum of Total" should not be sorted, nor any other header cell
-        cy.get("@sortedCell")
-          .its("length")
-          .should("eq", 0);
+      removeMetricFromSidebar("Sum of Total");
 
-        removeMetricFromSidebar("Sum of Total");
-
-        cy.wait("@dataset");
-        cy.findByText(/No results!/i).should("not.exist");
-        cy.contains("744"); // `Count` for year 2016
-      });
+      cy.wait("@dataset");
+      cy.findByText(/No results!/i).should("not.exist");
+      cy.contains("744"); // `Count` for year 2016
     });
 
     it("should remove `/notebook` from URL when converting question to SQL/Native (metabase#12651)", () => {
@@ -330,7 +329,7 @@ describe("scenarios > question > new", () => {
     it.skip("should show an info popover when hovering over summarize dimension options", () => {
       openReviewsTable();
 
-      cy.findByText("Summarize").click();
+      summarize();
       cy.findByText("Group by")
         .parent()
         .findByText("Title")
@@ -362,7 +361,7 @@ describe("scenarios > question > new", () => {
 
     it("should allow using `Custom Expression` in orders metrics (metabase#12899)", () => {
       openOrdersTable({ mode: "notebook" });
-      cy.findByText("Summarize").click();
+      summarize({ mode: "notebook" });
       popover()
         .contains("Custom Expression")
         .click();
@@ -382,7 +381,7 @@ describe("scenarios > question > new", () => {
         "Sum([Total]) / (Sum([Product → Price]) * Average([Quantity]))";
 
       openOrdersTable({ mode: "notebook" });
-      cy.findByText("Summarize").click();
+      summarize({ mode: "notebook" });
       popover()
         .contains("Custom Expression")
         .click();
@@ -399,7 +398,7 @@ describe("scenarios > question > new", () => {
 
     it("distinct inside custom expression should suggest non-numeric types (metabase#13469)", () => {
       openReviewsTable({ mode: "notebook" });
-      cy.findByText("Summarize").click();
+      summarize({ mode: "notebook" });
       popover()
         .contains("Custom Expression")
         .click();
@@ -419,7 +418,7 @@ describe("scenarios > question > new", () => {
       // Go straight to orders table in custom questions
       cy.visit("/question/new?database=1&table=2&mode=notebook");
 
-      cy.findByText("Summarize").click();
+      summarize({ mode: "notebook" });
       popover().within(() => {
         cy.findByText("Number of distinct values of ...").click();
         cy.log(

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -10,6 +10,7 @@ import {
   visitQuestionAdhoc,
   visualize,
   summarize,
+  filter,
 } from "__support__/e2e/cypress";
 
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
@@ -132,7 +133,7 @@ describe("scenarios > question > notebook", () => {
 
   it("should process the updated expression when pressing Enter", () => {
     openProductsTable({ mode: "notebook" });
-    cy.findByText("Filter").click();
+    filter({ mode: "notebook" });
     cy.findByText("Custom Expression").click();
     enterCustomColumnDetails({ formula: "[Price] > 1" });
 
@@ -313,7 +314,7 @@ describe("scenarios > question > notebook", () => {
     });
 
     it("should work on custom filter", () => {
-      cy.findByText("Filter").click();
+      filter({ mode: "notebook" });
       cy.findByText("Custom Expression").click();
 
       enterCustomColumnDetails({ formula: "[Subtotal] - Tax > 140" });

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -9,6 +9,7 @@ import {
   restore,
   visitQuestionAdhoc,
   visualize,
+  summarize,
 } from "__support__/e2e/cypress";
 
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
@@ -69,7 +70,7 @@ describe("scenarios > question > notebook", () => {
 
   it("shouldn't show sub-dimensions for FK (metabase#16787)", () => {
     openOrdersTable({ mode: "notebook" });
-    cy.findByText("Summarize").click();
+    summarize({ mode: "notebook" });
     cy.findByText("Pick a column to group by").click();
     cy.findByText("User ID")
       .closest(".List-item")
@@ -244,7 +245,7 @@ describe("scenarios > question > notebook", () => {
     it("should create a nested question with post-aggregation filter", () => {
       openProductsTable({ mode: "notebook" });
 
-      cy.findByText("Summarize").click();
+      summarize({ mode: "notebook" });
       popover().within(() => {
         cy.findByText("Count of rows").click();
       });
@@ -337,7 +338,7 @@ describe("scenarios > question > notebook", () => {
       const [expression, result] = formula;
 
       it(`should work on custom aggregation with ${filter}`, () => {
-        cy.findByText("Summarize").click();
+        summarize({ mode: "notebook" });
         cy.findByText("Custom Expression").click();
 
         enterCustomColumnDetails({ formula: expression });

--- a/frontend/test/metabase/scenarios/question/nulls.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nulls.cy.spec.js
@@ -1,4 +1,9 @@
-import { restore, openOrdersTable, popover } from "__support__/e2e/cypress";
+import {
+  restore,
+  openOrdersTable,
+  popover,
+  summarize,
+} from "__support__/e2e/cypress";
 
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
@@ -184,7 +189,7 @@ describe("scenarios > question > null", () => {
     it("summarize with null values (metabase#12585)", () => {
       openOrdersTable();
 
-      cy.contains("Summarize").click();
+      summarize();
       // remove pre-selected "Count"
       cy.icon("close").click();
       // dropdown immediately opens with the new set of metrics to choose from

--- a/frontend/test/metabase/scenarios/question/reproductions/17512.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/17512.cy.spec.js
@@ -3,6 +3,7 @@ import {
   openOrdersTable,
   popover,
   visualize,
+  summarize,
 } from "__support__/e2e/cypress";
 
 describe("issue 17512", () => {
@@ -36,7 +37,7 @@ describe("issue 17512", () => {
 });
 
 function addSummarizeCustomExpression(formula, name) {
-  cy.findByText("Summarize").click();
+  summarize({ mode: "notebook" });
   popover()
     .contains("Custom Expression")
     .click();

--- a/frontend/test/metabase/scenarios/question/reproductions/6239-sort-using-cust-exp.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/6239-sort-using-cust-exp.cy.spec.js
@@ -3,6 +3,7 @@ import {
   popover,
   restore,
   visualize,
+  summarize,
 } from "__support__/e2e/cypress";
 
 describe("issue 6239", () => {
@@ -12,7 +13,7 @@ describe("issue 6239", () => {
 
     openOrdersTable({ mode: "notebook" });
 
-    cy.findByText("Summarize").click();
+    summarize({ mode: "notebook" });
     cy.findByText("Custom Expression").click();
 
     cy.get(".ace_text-input")

--- a/frontend/test/metabase/scenarios/question/saved.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/saved.cy.spec.js
@@ -3,6 +3,7 @@ import {
   popover,
   modal,
   openOrdersTable,
+  summarize,
 } from "__support__/e2e/cypress";
 
 describe("scenarios > question > saved", () => {
@@ -14,7 +15,7 @@ describe("scenarios > question > saved", () => {
   it("should should correctly display 'Save' modal (metabase#13817)", () => {
     openOrdersTable();
     cy.icon("notebook").click();
-    cy.findByText("Summarize").click();
+    summarize({ mode: "notebook" });
     cy.findByText("Count of rows").click();
     cy.findByText("Pick a column to group by").click();
     popover()

--- a/frontend/test/metabase/scenarios/question/summarization.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/summarization.cy.spec.js
@@ -3,6 +3,7 @@ import {
   changeBinningForDimension,
   getDimensionByName,
   getRemoveDimensionButton,
+  summarize,
 } from "__support__/e2e/cypress";
 
 describe("scenarios > question > summarize sidebar", () => {
@@ -13,7 +14,7 @@ describe("scenarios > question > summarize sidebar", () => {
     cy.intercept("POST", "/api/dataset").as("dataset");
 
     cy.visit("/question/1");
-    cy.findByText("Summarize").click();
+    summarize();
   });
 
   it("removing all aggregations should show add aggregation button with label", () => {
@@ -34,9 +35,8 @@ describe("scenarios > question > summarize sidebar", () => {
       .should("have.attr", "aria-selected", "true");
 
     cy.button("Done").click();
-    cy.findAllByText("Summarize")
-      .first()
-      .click();
+
+    summarize();
 
     // Removed from the unpinned list
     cy.findByTestId("unpinned-dimensions").within(() => {
@@ -65,9 +65,8 @@ describe("scenarios > question > summarize sidebar", () => {
     getDimensionByName({ name: "State" }).click();
 
     cy.button("Done").click();
-    cy.findAllByText("Summarize")
-      .first()
-      .click();
+
+    summarize();
 
     cy.findByTestId("pinned-dimensions").within(() => {
       getDimensionByName({ name: "People → State" }).should(

--- a/frontend/test/metabase/scenarios/question/view.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/view.cy.spec.js
@@ -5,6 +5,7 @@ import {
   getAddDimensionButton,
   summarize,
   sidebar,
+  filter,
 } from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
@@ -64,7 +65,7 @@ describe("scenarios > question > view", () => {
   describe("filter sidebar", () => {
     it("should filter a table", () => {
       openOrdersTable();
-      cy.contains("Filter").click();
+      filter();
       cy.contains("Vendor").click({ force: true });
       cy.findByPlaceholderText("Search by Vendor")
         .clear()
@@ -78,7 +79,7 @@ describe("scenarios > question > view", () => {
     // flaky test (#19454)
     it.skip("should show info popover for dimension in the filter list", () => {
       openOrdersTable();
-      cy.contains("Filter").click();
+      filter();
 
       cy.contains("Name").trigger("mouseenter");
       popover().contains("Name");

--- a/frontend/test/metabase/scenarios/question/view.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/view.cy.spec.js
@@ -3,6 +3,8 @@ import {
   openOrdersTable,
   popover,
   getAddDimensionButton,
+  summarize,
+  sidebar,
 } from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
@@ -18,7 +20,7 @@ describe("scenarios > question > view", () => {
     it("should summarize by category and show a bar chart", () => {
       openOrdersTable();
 
-      cy.contains("Summarize").click();
+      summarize();
       cy.contains("Category").click();
       cy.contains("Done").click();
       cy.contains("Count by Product → Category");
@@ -26,16 +28,10 @@ describe("scenarios > question > view", () => {
 
     it("should show orders by year and product category", () => {
       openOrdersTable();
-      cy.contains("Showing first 2,000 rows");
-      cy.contains("Summarize").click();
 
-      // alias @sidebar so we can more easily click dimensions
-      cy.contains("Summarize by")
-        .parent()
-        .parent()
-        .as("sidebar");
+      summarize();
 
-      cy.get("@sidebar")
+      sidebar()
         .contains("Created At")
         .click();
       cy.findByText("Done").click();
@@ -43,14 +39,9 @@ describe("scenarios > question > view", () => {
       cy.contains("Count by Created At: Month");
 
       // Go back into sidebar
-      cy.contains("Summarize").click();
+      summarize();
 
-      // change grouping from month to year
-      cy.contains("Summarize by")
-        .parent()
-        .parent()
-        .as("sidebar");
-      cy.get("@sidebar")
+      sidebar()
         .contains("by month")
         .click();
       cy.get(".PopoverBody")

--- a/frontend/test/metabase/scenarios/smoketest/admin.cy.spec.js
+++ b/frontend/test/metabase/scenarios/smoketest/admin.cy.spec.js
@@ -3,6 +3,7 @@ import {
   sidebar,
   visualize,
   openNotebookEditor,
+  summarize,
 } from "__support__/e2e/cypress";
 import { USERS } from "__support__/e2e/cypress_data";
 
@@ -198,9 +199,7 @@ describe("metabase-smoketest > admin", () => {
       cy.findByText("Pick your data").should("not.exist");
 
       // Summarize by date ordered
-      cy.findAllByText("Summarize")
-        .first()
-        .click();
+      summarize();
       sidebar()
         .contains("Created At")
         .click();

--- a/frontend/test/metabase/scenarios/smoketest/user.cy.spec.js
+++ b/frontend/test/metabase/scenarios/smoketest/user.cy.spec.js
@@ -4,6 +4,7 @@ import {
   popover,
   visualize,
   openNotebookEditor,
+  summarize,
 } from "__support__/e2e/cypress";
 
 describe("smoketest > user", () => {
@@ -156,17 +157,13 @@ describe("smoketest > user", () => {
   it("should summarize via both the sidebar and notebook editor", () => {
     // Sidebar summary
 
-    cy.findAllByText("Summarize")
-      .first()
-      .click();
+    summarize();
     cy.findByText("Category").click();
     cy.findByText("Done").click();
 
     // Delete summary from sidebar
 
-    cy.findAllByText("Summarize")
-      .first()
-      .click();
+    summarize();
     cy.icon("close")
       .first()
       .click();
@@ -181,7 +178,7 @@ describe("smoketest > user", () => {
 
     cy.icon("notebook").click();
 
-    cy.icon("sum").click();
+    summarize({ mode: "notebook" });
     cy.findByText("Count of rows").click();
     cy.findByText("Pick a column to group by").click();
     cy.icon("calendar").click();

--- a/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
@@ -6,6 +6,7 @@ import {
   sidebar,
   visitQuestionAdhoc,
   visualize,
+  summarize,
 } from "__support__/e2e/cypress";
 import { USER_GROUPS } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
@@ -292,7 +293,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
     cy.contains("Saved Questions").click();
     cy.contains("CA People").click();
     cy.contains("Hudson Borer");
-    cy.contains("Summarize").click();
+    summarize();
     cy.contains("Summarize by")
       .parent()
       .parent()
@@ -306,7 +307,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
     cy.get(".bar")
       .first()
       .click({ force: true });
-    cy.contains("View this CA Person").click();
+    cy.contains("View this CA People").click();
 
     // check that filter is applied and person displayed
     cy.contains("City is Beaver Dams");
@@ -345,7 +346,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
 
   it.skip("should drill-through on filtered aggregated results (metabase#13504)", () => {
     openOrdersTable({ mode: "notebook" });
-    cy.findByText("Summarize").click();
+    summarize({ mode: "notebook" });
     cy.findByText("Count of rows").click();
     cy.findByText("Pick a column to group by").click();
     cy.findByText("Created At").click();
@@ -625,7 +626,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
     beforeEach(() => {
       // Build a question without saving
       openProductsTable();
-      cy.findByText("Summarize").click();
+      summarize();
       sidebar().within(() => {
         cy.contains("Category").click();
       });

--- a/frontend/test/metabase/scenarios/visualizations/reproductions/16170-line-mongo-replace-missing-values-with-zero.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/reproductions/16170-line-mongo-replace-missing-values-with-zero.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, popover } from "__support__/e2e/cypress";
+import { restore, popover, summarize } from "__support__/e2e/cypress";
 
 const MONGO_DB_NAME = "QA Mongo4";
 
@@ -14,9 +14,7 @@ describe.skip("issue 16170", () => {
   });
 
   it("should correctly replace only the missing values with zero (metabase#16170)", () => {
-    cy.findAllByRole("button")
-      .contains("Summarize")
-      .click();
+    summarize();
 
     cy.findByTestId("sidebar-right")
       .findByText("Created At")

--- a/frontend/test/metabase/scenarios/visualizations/reproductions/17524.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/reproductions/17524.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, filterWidget } from "__support__/e2e/cypress";
+import { restore, filterWidget, filter } from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
@@ -70,9 +70,8 @@ describe("issue 17524", () => {
     it("should not alter visualization type when applying filter on a QB question (metabase#17524-2)", () => {
       cy.get("polygon");
 
-      cy.findAllByRole("button")
-        .contains("Filter")
-        .click();
+      filter();
+
       cy.findByText("ID").click();
       cy.findByText("Is").click();
       cy.findByText("Greater than").click();

--- a/frontend/test/metabase/scenarios/visualizations/table.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/table.cy.spec.js
@@ -6,6 +6,7 @@ import {
   popover,
   enterCustomColumnDetails,
   visualize,
+  summarize,
 } from "__support__/e2e/cypress";
 
 describe("scenarios > visualizations > table", () => {
@@ -149,9 +150,8 @@ describe("scenarios > visualizations > table", () => {
         .trigger("mouseleave");
     });
 
-    cy.findAllByText("Summarize")
-      .first()
-      .click();
+    summarize();
+
     cy.findAllByTestId("dimension-list-item-name")
       .first()
       .click();

--- a/frontend/test/metabase/scenarios/visualizations/waterfall.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/waterfall.cy.spec.js
@@ -4,6 +4,7 @@ import {
   visitQuestionAdhoc,
   openNativeEditor,
   visualize,
+  summarize,
 } from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
@@ -102,7 +103,7 @@ describe("scenarios > visualizations > waterfall", () => {
 
   it("should work with time-series data", () => {
     openOrdersTable({ mode: "notebook" });
-    cy.findByText("Summarize").click();
+    summarize({ mode: "notebook" });
     cy.findByText("Count of rows").click();
     cy.findByText("Pick a column to group by").click();
     cy.findByText("Created At").click();
@@ -123,7 +124,7 @@ describe("scenarios > visualizations > waterfall", () => {
 
   it("should hide the Total label if there is no space", () => {
     openOrdersTable({ mode: "notebook" });
-    cy.findByText("Summarize").click();
+    summarize({ mode: "notebook" });
     cy.findByText("Count of rows").click();
     cy.findByText("Pick a column to group by").click();
     cy.findByText("Created At").click();


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Adds new bi-basics e2e helper functions
    - Namely, those are `summarize` and `filter`
- Helps reduce flakiness in CI due to element not being ready to receive click, or due to Cypress finding multiple elements which happened a lot with "Filter" and/or "Summarize" in a simple mode
- Applies new helpers to all related tests

### Examples of the related failures
Finding multiple strings
<details>
  <summary>Screenshot 1</summary>

![image](https://user-images.githubusercontent.com/31325167/153308331-7f0ee4b1-c700-426f-98e7-271d4569a178.png)

</details>

<details>
  <summary>Screenshot 2</summary>

![image](https://user-images.githubusercontent.com/31325167/153308567-152842ae-8f3a-4ab4-b828-63921f51426e.png)

</details>

Clicking too early results in a (summarize) sidebar not being rendered
<details>
  <summary>Screenshot 3</summary>

![image](https://user-images.githubusercontent.com/31325167/153308630-82dd1ef6-340e-4a47-931f-e08d0a3d1fa0.png)

</details>


### Some of the hacks we had to use before this change
```js
// 1
cy.contains("Summarize").click();

// 2
cy.findAllByText("Summarize")
  .first()
  .click();

// 3
cy.findByTextEnsureVisible("Summarize").click();

// 4
cy.findAllByTestId("toggle-summarize-sidebar-button")
  .contains("Summarize")
  .click();

// 5
cy.findByTestId("qb-header-action-panel")
  .contains("Summarize")
  .click();

// 6
cy.findByTestId("action-buttons")
  .findByText("Summarize")
  .click();

// 7
cy.findAllByRole("button")
  .contains("Summarize")
  .click();
  
// 8
cy.get(".Button")
  .contains("Summarize")
  .click();
```