### PR TITLE
Replace `add-databases-to-magic-permissions-groups` with Liquibase migrations

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -10027,7 +10027,7 @@ databaseChangeLog:
       changes:
         - sql:
             sql: >-
-              INSERT INTO permissions (group_id, object)
+              INSERT INTO permissions (object, group_id)
               SELECT db.object, all_users.id AS group_id
               FROM (
                 SELECT concat('/db/', id, '/') AS object

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -10005,6 +10005,46 @@ databaseChangeLog:
                   AND pgm.id IS NULL;
 
   #
+  # The following migration replaces metabase.db.data-migrations/add-databases-to-magic-permissions-groups, added 0.20.0
+  #
+
+  # Add permissions entries for 'All Users' for all Databases created BEFORE we created the 'All Users' Permissions
+  # Group. This replaces the old 'add-databases-to-magic-permissions-groups' Clojure-land data migration. Only run
+  # this migration if that one hasn't been run yet.
+  - changeSet:
+      id: v43.00-007
+      author: camsaul
+      comment: >-
+        Added 0.43.0. Grant permissions for existing Databases to 'All Users' permissions group.
+      preConditions:
+        - onFail: MARK_RAN
+        - sqlCheck:
+            expectedResult: 0
+            sql: >-
+              SELECT count(*)
+              FROM data_migrations
+              WHERE id = 'add-databases-to-magic-permissions-groups';
+      changes:
+        - sql:
+            sql: >-
+              INSERT INTO permissions (group_id, object)
+              SELECT db.object, all_users.id AS group_id
+              FROM (
+                SELECT concat('/db/', id, '/') AS object
+                FROM metabase_database
+              ) db
+              LEFT JOIN (
+                SELECT id
+                FROM permissions_group
+                WHERE name = 'All Users'
+              ) all_users
+                ON true
+              LEFT JOIN permissions p
+                     ON p.group_id = all_users.id
+                    AND db.object = p.object
+              WHERE p.object IS NULL;
+
+  #
   # The following migration replaces metabase.db.migrations/copy-site-url-setting-and-remove-trailing-slashes, added 0.23.0
   #
   # Copy the value of the old setting `-site-url` to the new `site-url` if applicable. (`site-url` used to be stored

--- a/src/metabase/db/data_migrations.clj
+++ b/src/metabase/db/data_migrations.clj
@@ -15,7 +15,6 @@
             [metabase.models.collection :as collection :refer [Collection]]
             [metabase.models.dashboard :refer [Dashboard]]
             [metabase.models.dashboard-card :refer [DashboardCard]]
-            [metabase.models.database :refer [Database]]
             [metabase.models.permissions :as perms :refer [Permissions]]
             [metabase.models.permissions-group :as perm-group :refer [PermissionsGroup]]
             [metabase.models.pulse :refer [Pulse]]
@@ -82,18 +81,6 @@
       (db/insert! Permissions
         :group_id (:id (perm-group/admin))
         :object   "/"))))
-
-;; add existing databases to default permissions groups. default and metabot groups have entries for each individual
-;; DB
-(defmigration ^{:author "camsaul", :added "0.20.0"} add-databases-to-magic-permissions-groups
-  (let [db-ids (db/select-ids Database)]
-    (doseq [{group-id :id} [(perm-group/all-users)
-                            (perm-group/metabot)]
-            database-id    db-ids]
-      (u/ignore-exceptions
-        (db/insert! Permissions
-          :object   (perms/data-perms-path database-id)
-          :group_id group-id)))))
 
 ;; Before 0.30.0, we were storing the LDAP user's password in the `core_user` table (though it wasn't used).  This
 ;; migration clears those passwords and replaces them with a UUID. This is similar to a new account setup, or how we

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -16,6 +16,7 @@
             [metabase.driver :as driver]
             [metabase.models :refer [Database Field Permissions PermissionsGroup Setting Table]]
             [metabase.models.interface :as mi]
+            [metabase.models.permissions-group :as group]
             [metabase.models.user :refer [User]]
             [metabase.test :as mt]
             [metabase.test.fixtures :as fixtures]
@@ -339,7 +340,7 @@
                  (db/query {:select    [:p.object]
                             :from      [[Permissions :p]]
                             :left-join [[PermissionsGroup :pg] [:= :p.group_id :pg.id]]
-                            :where     [:= :pg.name "All Users"]}))))))))
+                            :where     [:= :pg.name group/all-users-group-name]}))))))))
 
 (deftest migrate-legacy-site-url-setting-test
   (testing "Migration v043.00-008: migrate legacy `-site-url` Setting to `site-url`; remove trailing slashes (#4123, #4188, #20402)"


### PR DESCRIPTION
Part of #20449