### PR TITLE
Add aliases for H2 and Liquibase CLIs

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -413,12 +413,11 @@
    :jvm-opts  ["-XX:+CITime" ; print time spent in JIT compiler
                "-XX:+PrintGC"]}
 
-  ;; get the H2 shell with clojure -M:h2
-  ;; TODO -- this doesn't currently work correctly -- use this instead:
-  ;;
-  ;;    java -cp `clojure -Spath` org.h2.tools.Shell
+  ;; get the H2 shell with clojure -X:h2
   :h2
-  {:jvm-opts ["org.h2.tools.Shell"]}
+  {:extra-paths ["dev/src"]
+   :exec-fn     dev.h2-shell/shell
+   :java-opts   ["-Dfile.encoding=UTF-8"]}
 
   ;; clojure -M:generate-automagic-dashboards-pot
   :generate-automagic-dashboards-pot
@@ -430,6 +429,18 @@
   :nrepl
   {:extra-deps {nrepl/nrepl {:mvn/version "0.9.0"}}
    :main-opts  ["-m" "nrepl.cmdline"]}
+
+  ;; Liquibase CLI:
+  ;;
+  ;;    clojure -M:liquibase <command>
+  ;;
+  ;; e.g.
+  ;;
+  ;;    clojure -M:liquibase dbDoc target/liquibase
+  :liquibase
+  {:extra-deps  {ch.qos.logback/logback-classic {:mvn/version "1.2.10"}}
+   :extra-paths ["dev/src"]
+   :main-opts   ["-m" "dev.liquibase"]}
 
   ;; TODO -- consider creating an alias that includes the `./bin` build-drivers & release code as well so we can work
   ;; on them all from a single REPL process.

--- a/dev/src/dev/h2_shell.clj
+++ b/dev/src/dev/h2_shell.clj
@@ -1,0 +1,14 @@
+(ns dev.h2-shell
+  (:require [metabase.db.data-source :as mdb.data-source]
+            [metabase.db.env :as mdb.env]))
+
+(comment mdb.data-source/keep-me)
+
+(defn shell
+  "Open an H2 shell with `clojure -X:h2`."
+  [& _args]
+  (org.h2.tools.Shell/main
+   (into-array
+    String
+    ["-url" (let [^metabase.db.data_source.DataSource data-source mdb.env/data-source]
+              (.url data-source))])))

--- a/dev/src/dev/liquibase.clj
+++ b/dev/src/dev/liquibase.clj
@@ -1,0 +1,22 @@
+(ns dev.liquibase
+  (:require [clojure.string :as str]
+            [metabase.db.data-source :as mdb.data-source]
+            [metabase.db.env :as mdb.env]))
+
+(comment mdb.data-source/keep-me)
+
+(defn -main [& args]
+  (let [args (into ["--changeLogFile=resources/migrations/000_migrations.yaml"]
+                   (comp cat
+                         (filter seq))
+                   (let [^metabase.db.data_source.DataSource data-source mdb.env/data-source
+                         ^java.util.Properties properties                (.properties data-source)]
+                     [(when-let [user (some-> properties (.get "user"))]
+                        ["--username" user])
+                      (when-let [password (some-> properties (.get "password"))]
+                        ["--password" password])
+                      ["--url" (.url data-source)]
+                      (map str args)]))]
+    (println (str/join " " (cons "liquibase" (map pr-str args))))
+    (liquibase.integration.commandline.Main/main
+     (into-array String args))))

--- a/dev/src/dev/liquibase.clj
+++ b/dev/src/dev/liquibase.clj
@@ -1,12 +1,18 @@
 (ns dev.liquibase
   (:require [clojure.string :as str]
+            [colorize.core :as colorize]
             [metabase.db.data-source :as mdb.data-source]
             [metabase.db.env :as mdb.env]))
 
 (comment mdb.data-source/keep-me)
 
-(defn -main [& args]
-  (let [args (into ["--changeLogFile=resources/migrations/000_migrations.yaml"]
+(defn -main
+  "Use the Liquibase CLI with `clojure -M:liquibase <command>`."
+  [& args]
+  (let [args (if (empty? args)
+               ["help"]
+               args)
+        args (into ["--changeLogFile=resources/migrations/000_migrations.yaml"]
                    (comp cat
                          (filter seq))
                    (let [^metabase.db.data_source.DataSource data-source mdb.env/data-source
@@ -17,6 +23,10 @@
                         ["--password" password])
                       ["--url" (.url data-source)]
                       (map str args)]))]
-    (println (str/join " " (cons "liquibase" (map pr-str args))))
-    (liquibase.integration.commandline.Main/main
-     (into-array String args))))
+    (println (colorize/green (str/join " " (cons "liquibase" (map pr-str args)))))
+    ;; use reflection here instead of static method calls because `liquibase.integration.commandline.Main` fails to load
+    ;; without having the `logback` dependency available. We add this as `:extra-deps` for the `:liquibase` profile. We
+    ;; don't want other stuff like the linters to choke here tho.
+    (let [klass  (Class/forName "liquibase.integration.commandline.Main")
+          method (.getMethod klass "main" (into-array Class [(Class/forName "[Ljava.lang.String;")]))]
+      (.invoke method klass ^"[Ljava.lang.Object" (into-array Object [(into-array String args)])))))


### PR DESCRIPTION
Add some aliases to our `deps.edn`.

`clojure -X:h2` to run a Liquibase shell against the Liquibase file specified by the usual application DB configuration env vars/Java properties.

`clojure -M:liquibase <command>` to run a Liquibase CLI command. Adds appropriate options based on the usual application DB configuration env vars/Java properties. 

e.g. 

```
clojure -M:liquibase dbDoc target/liquibase
```

to generate DB and migration documentation you can view in the browser e.g.

![image](https://user-images.githubusercontent.com/1455846/153326713-c580c4bf-9b13-40bd-8da1-f0e682cc7639.png)