### PR TITLE
Remove questions object and query classes from global `window`

### DIFF
--- a/frontend/src/metabase-lib/lib/Question.ts
+++ b/frontend/src/metabase-lib/lib/Question.ts
@@ -1298,6 +1298,3 @@ export default class Question {
     return getIn(this, ["_card", "moderation_reviews"]) || [];
   }
 }
-window.Question = Question;
-window.NativeQuery = NativeQuery;
-window.StructuredQuery = StructuredQuery;

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
@@ -203,7 +203,6 @@ export default class QueryBuilder extends Component {
     //    @connect(null, { updateQuestion })
     //    @connect(mapStateToProps, mapDispatchToProps)
     if (nextProps.question) {
-      window.question = nextProps.question;
       nextProps.question._update = nextProps.updateQuestion;
     }
   }


### PR DESCRIPTION
For some reason QB puts open `question` object into `window`. Also `metabase-lib` puts a few of its classes there too. I couldn't find any usages of that in the codebase and the CI is green, so I'd suggest to remove them