### PR TITLE
Clean up `QueryBuilder` top container and view components

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -1,17 +1,13 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 import { Motion, spring } from "react-motion";
-import cx from "classnames";
 
 import ExplicitSize from "metabase/components/ExplicitSize";
 import Popover from "metabase/components/Popover";
-import DebouncedFrame from "metabase/components/DebouncedFrame";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 
 import NativeQuery from "metabase-lib/lib/queries/NativeQuery";
 import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
-
-import SyncedParametersList from "metabase/parameters/components/SyncedParametersList/SyncedParametersList";
 
 import AggregationPopover from "../AggregationPopover";
 import BreakoutPopover from "../BreakoutPopover";
@@ -30,12 +26,23 @@ import SummarizeSidebar from "./sidebars/SummarizeSidebar/SummarizeSidebar";
 import FilterSidebar from "./sidebars/FilterSidebar";
 import QuestionDetailsSidebar from "./sidebars/QuestionDetailsSidebar";
 
-import { ViewTitleHeader, ViewSubHeader } from "./ViewHeader";
+import { ViewSubHeader } from "./ViewHeader";
 import NewQuestionHeader from "./NewQuestionHeader";
 import ViewFooter from "./ViewFooter";
 import ViewSidebar from "./ViewSidebar";
 import NewQuestionView from "./View/NewQuestionView";
 import QueryViewNotebook from "./View/QueryViewNotebook";
+
+import {
+  QueryBuilderViewRoot,
+  QueryBuilderContentContainer,
+  QueryBuilderMain,
+  QueryBuilderViewHeaderContainer,
+  BorderedViewTitleHeader,
+  NativeQueryEditorContainer,
+  StyledDebouncedFrame,
+  StyledSyncedParametersList,
+} from "./View.styled";
 
 const DEFAULT_POPOVER_STATE = {
   aggregationIndex: null,
@@ -216,20 +223,15 @@ export default class View extends React.Component {
         style={isNewQuestion ? { opacity: spring(0) } : { opacity: spring(1) }}
       >
         {({ opacity }) => (
-          <div className="flex-no-shrink z3 bg-white relative">
-            <ViewTitleHeader
-              {...this.props}
-              style={{ opacity }}
-              py={1}
-              className="border-bottom"
-            />
+          <QueryBuilderViewHeaderContainer>
+            <BorderedViewTitleHeader {...this.props} style={{ opacity }} />
             {opacity < 1 && (
               <NewQuestionHeader
                 className="spread"
                 style={{ opacity: 1 - opacity }}
               />
             )}
-          </div>
+          </QueryBuilderViewHeaderContainer>
         )}
       </Motion>
     );
@@ -293,6 +295,7 @@ export default class View extends React.Component {
     if (!card || !databases) {
       return <LoadingAndErrorWrapper className={fitClassNames} loading />;
     }
+
     const queryMode = mode && mode.queryMode();
     const ModeFooter = queryMode && queryMode.ModeFooter;
     const isStructured = query instanceof StructuredQuery;
@@ -328,10 +331,9 @@ export default class View extends React.Component {
 
     return (
       <div className={fitClassNames}>
-        <div className={cx("QueryBuilder flex flex-column bg-white spread")}>
+        <QueryBuilderViewRoot className="QueryBuilder">
           {this.renderHeader()}
-
-          <div className="flex flex-full relative">
+          <QueryBuilderContentContainer>
             {isStructured && (
               <QueryViewNotebook
                 isNotebookContainerOpen={isNotebookContainerOpen}
@@ -343,23 +345,18 @@ export default class View extends React.Component {
               {leftSidebar}
             </ViewSidebar>
 
-            <div
-              className={cx("flex-full flex flex-column flex-basis-none", {
-                "hide sm-show": isSidebarOpen,
-              })}
-            >
+            <QueryBuilderMain isSidebarOpen={isSidebarOpen}>
               {isNative ? (
-                <div className="z2 hide sm-show border-bottom mb2">
+                <NativeQueryEditorContainer className="hide sm-show">
                   <NativeQueryEditor
                     {...this.props}
                     viewHeight={height}
                     isOpen={!card.dataset_query.native.query || isDirty}
                     datasetQuery={card && card.dataset_query}
                   />
-                </div>
+                </NativeQueryEditorContainer>
               ) : (
-                <SyncedParametersList
-                  className="mt2 ml3"
+                <StyledSyncedParametersList
                   parameters={this.props.parameters}
                   setParameterValue={this.props.setParameterValue}
                   commitImmediately
@@ -368,34 +365,30 @@ export default class View extends React.Component {
 
               <ViewSubHeader {...this.props} />
 
-              <DebouncedFrame
-                className="flex-full"
-                style={{ flexGrow: 1 }}
-                enabled={!isLiveResizable}
-              >
+              <StyledDebouncedFrame enabled={!isLiveResizable}>
                 <QueryVisualization
                   {...this.props}
+                  noHeader
+                  className="spread"
                   onAddSeries={onAddSeries}
                   onEditSeries={onEditSeries}
                   onRemoveSeries={onRemoveSeries}
                   onEditBreakout={onEditBreakout}
-                  noHeader
-                  className="spread"
                 />
-              </DebouncedFrame>
+              </StyledDebouncedFrame>
 
               {ModeFooter && (
                 <ModeFooter {...this.props} className="flex-no-shrink" />
               )}
 
               <ViewFooter {...this.props} className="flex-no-shrink" />
-            </div>
+            </QueryBuilderMain>
 
             <ViewSidebar side="right" isOpen={!!rightSidebar}>
               {rightSidebar}
             </ViewSidebar>
-          </div>
-        </div>
+          </QueryBuilderContentContainer>
+        </QueryBuilderViewRoot>
 
         {isShowingNewbModal && (
           <SavedQuestionIntroModal

--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -110,6 +110,36 @@ export default class View extends React.Component {
     this.handleClosePopover();
   };
 
+  getLeftSidebar = () => {
+    const {
+      question,
+      isShowingChartSettingsSidebar,
+      isShowingChartTypeSidebar,
+      isShowingQuestionDetailsSidebar,
+      onOpenModal,
+      onCloseChartSettings,
+      onCloseChartType,
+    } = this.props;
+
+    if (isShowingChartSettingsSidebar) {
+      return (
+        <ChartSettingsSidebar {...this.props} onClose={onCloseChartSettings} />
+      );
+    }
+
+    if (isShowingChartTypeSidebar) {
+      return <ChartTypeSidebar {...this.props} onClose={onCloseChartType} />;
+    }
+
+    if (isShowingQuestionDetailsSidebar) {
+      return (
+        <QuestionDetailsSidebar question={question} onOpenModal={onOpenModal} />
+      );
+    }
+
+    return null;
+  };
+
   render() {
     const {
       question,
@@ -123,17 +153,13 @@ export default class View extends React.Component {
       isShowingTemplateTagsEditor,
       isShowingDataReference,
       isShowingNewbModal,
-      isShowingChartTypeSidebar,
-      isShowingChartSettingsSidebar,
       isShowingSummarySidebar,
       isShowingFilterSidebar,
       isShowingSnippetSidebar,
-      isShowingQuestionDetailsSidebar,
       queryBuilderMode,
       mode,
       fitClassNames,
       height,
-      onOpenModal,
     } = this.props;
     const {
       aggregationIndex,
@@ -185,17 +211,6 @@ export default class View extends React.Component {
     const onEditBreakout =
       topQuery && topQuery.hasBreakouts() ? this.handleEditBreakout : null;
 
-    const leftSideBar = isShowingChartSettingsSidebar ? (
-      <ChartSettingsSidebar
-        {...this.props}
-        onClose={this.props.onCloseChartSettings}
-      />
-    ) : isShowingChartTypeSidebar ? (
-      <ChartTypeSidebar {...this.props} onClose={this.props.onCloseChartType} />
-    ) : isShowingQuestionDetailsSidebar ? (
-      <QuestionDetailsSidebar question={question} onOpenModal={onOpenModal} />
-    ) : null;
-
     const rightSideBar =
       isStructured && isShowingSummarySidebar ? (
         <SummarizeSidebar
@@ -223,7 +238,8 @@ export default class View extends React.Component {
         />
       ) : null;
 
-    const isSidebarOpen = leftSideBar || rightSideBar;
+    const leftSidebar = this.getLeftSidebar();
+    const isSidebarOpen = leftSidebar || rightSideBar;
 
     const isNotebookContainerOpen =
       isNewQuestion || queryBuilderMode === "notebook";
@@ -263,8 +279,8 @@ export default class View extends React.Component {
               />
             )}
 
-            <ViewSidebar side="left" isOpen={!!leftSideBar}>
-              {leftSideBar}
+            <ViewSidebar side="left" isOpen={!!leftSidebar}>
+              {leftSidebar}
             </ViewSidebar>
 
             <div

--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -235,6 +235,46 @@ export default class View extends React.Component {
     );
   };
 
+  renderAggregationPopover = () => {
+    const { query } = this.props;
+    const { aggregationPopoverTarget, aggregationIndex } = this.state;
+    return (
+      <Popover
+        isOpen={!!aggregationPopoverTarget}
+        target={aggregationPopoverTarget}
+        onClose={this.handleClosePopover}
+      >
+        <AggregationPopover
+          query={query}
+          aggregation={
+            aggregationIndex >= 0 ? query.aggregations()[aggregationIndex] : 0
+          }
+          onChangeAggregation={this.onChangeAggregation}
+          onClose={this.handleClosePopover}
+        />
+      </Popover>
+    );
+  };
+
+  renderBreakoutPopover = () => {
+    const { query } = this.props;
+    const { breakoutPopoverTarget, breakoutIndex } = this.state;
+    return (
+      <Popover
+        isOpen={!!breakoutPopoverTarget}
+        onClose={this.handleClosePopover}
+        target={breakoutPopoverTarget}
+      >
+        <BreakoutPopover
+          query={query}
+          breakout={breakoutIndex >= 0 ? query.breakouts()[breakoutIndex] : 0}
+          onChangeBreakout={this.onChangeBreakout}
+          onClose={this.handleClosePopover}
+        />
+      </Popover>
+    );
+  };
+
   render() {
     const {
       query,
@@ -248,12 +288,6 @@ export default class View extends React.Component {
       fitClassNames,
       height,
     } = this.props;
-    const {
-      aggregationIndex,
-      aggregationPopoverTarget,
-      breakoutIndex,
-      breakoutPopoverTarget,
-    } = this.state;
 
     // if we don't have a card at all or no databases then we are initializing, so keep it simple
     if (!card || !databases) {
@@ -298,7 +332,7 @@ export default class View extends React.Component {
           {this.renderHeader()}
 
           <div className="flex flex-full relative">
-            {query instanceof StructuredQuery && (
+            {isStructured && (
               <QueryViewNotebook
                 isNotebookContainerOpen={isNotebookContainerOpen}
                 {...this.props}
@@ -372,40 +406,8 @@ export default class View extends React.Component {
 
         <QueryModals {...this.props} />
 
-        {isStructured && (
-          <Popover
-            isOpen={!!aggregationPopoverTarget}
-            target={aggregationPopoverTarget}
-            onClose={this.handleClosePopover}
-          >
-            <AggregationPopover
-              query={query}
-              aggregation={
-                aggregationIndex >= 0
-                  ? query.aggregations()[aggregationIndex]
-                  : 0
-              }
-              onChangeAggregation={this.onChangeAggregation}
-              onClose={this.handleClosePopover}
-            />
-          </Popover>
-        )}
-        {isStructured && (
-          <Popover
-            isOpen={!!breakoutPopoverTarget}
-            onClose={this.handleClosePopover}
-            target={breakoutPopoverTarget}
-          >
-            <BreakoutPopover
-              query={query}
-              breakout={
-                breakoutIndex >= 0 ? query.breakouts()[breakoutIndex] : 0
-              }
-              onChangeBreakout={this.onChangeBreakout}
-              onClose={this.handleClosePopover}
-            />
-          </Popover>
-        )}
+        {isStructured && this.renderAggregationPopover()}
+        {isStructured && this.renderBreakoutPopover()}
       </div>
     );
   }

--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -140,22 +140,79 @@ export default class View extends React.Component {
     return null;
   };
 
-  render() {
+  getRightSidebarForStructuredQuery = () => {
     const {
       question,
+      isResultDirty,
+      isShowingSummarySidebar,
+      isShowingFilterSidebar,
+      runQuestionQuery,
+      onCloseSummary,
+    } = this.props;
+
+    if (isShowingSummarySidebar) {
+      return (
+        <SummarizeSidebar
+          question={question}
+          onClose={onCloseSummary}
+          isResultDirty={isResultDirty}
+          runQuestionQuery={runQuestionQuery}
+        />
+      );
+    }
+
+    if (isShowingFilterSidebar) {
+      return (
+        <FilterSidebar question={question} onClose={this.props.onCloseFilter} />
+      );
+    }
+
+    return null;
+  };
+
+  getRightSidebarForNativeQuery = () => {
+    const {
+      isShowingTemplateTagsEditor,
+      isShowingDataReference,
+      isShowingSnippetSidebar,
+      toggleTemplateTagsEditor,
+      toggleDataReference,
+      toggleSnippetSidebar,
+    } = this.props;
+
+    if (isShowingTemplateTagsEditor) {
+      return (
+        <TagEditorSidebar {...this.props} onClose={toggleTemplateTagsEditor} />
+      );
+    }
+
+    if (isShowingDataReference) {
+      return <DataReference {...this.props} onClose={toggleDataReference} />;
+    }
+
+    if (isShowingSnippetSidebar) {
+      return <SnippetSidebar {...this.props} onClose={toggleSnippetSidebar} />;
+    }
+
+    return null;
+  };
+
+  getRightSidebar = () => {
+    const { question } = this.props;
+    const isStructured = question.isStructured();
+    return isStructured
+      ? this.getRightSidebarForStructuredQuery()
+      : this.getRightSidebarForNativeQuery();
+  };
+
+  render() {
+    const {
       query,
       card,
       isDirty,
-      isResultDirty,
       isLiveResizable,
-      runQuestionQuery,
       databases,
-      isShowingTemplateTagsEditor,
-      isShowingDataReference,
       isShowingNewbModal,
-      isShowingSummarySidebar,
-      isShowingFilterSidebar,
-      isShowingSnippetSidebar,
       queryBuilderMode,
       mode,
       fitClassNames,
@@ -211,35 +268,9 @@ export default class View extends React.Component {
     const onEditBreakout =
       topQuery && topQuery.hasBreakouts() ? this.handleEditBreakout : null;
 
-    const rightSideBar =
-      isStructured && isShowingSummarySidebar ? (
-        <SummarizeSidebar
-          question={question}
-          onClose={this.props.onCloseSummary}
-          isResultDirty={isResultDirty}
-          runQuestionQuery={runQuestionQuery}
-        />
-      ) : isStructured && isShowingFilterSidebar ? (
-        <FilterSidebar question={question} onClose={this.props.onCloseFilter} />
-      ) : isNative && isShowingTemplateTagsEditor ? (
-        <TagEditorSidebar
-          {...this.props}
-          onClose={this.props.toggleTemplateTagsEditor}
-        />
-      ) : isNative && isShowingDataReference ? (
-        <DataReference
-          {...this.props}
-          onClose={this.props.toggleDataReference}
-        />
-      ) : isNative && isShowingSnippetSidebar ? (
-        <SnippetSidebar
-          {...this.props}
-          onClose={this.props.toggleSnippetSidebar}
-        />
-      ) : null;
-
     const leftSidebar = this.getLeftSidebar();
-    const isSidebarOpen = leftSidebar || rightSideBar;
+    const rightSidebar = this.getRightSidebar();
+    const isSidebarOpen = leftSidebar || rightSidebar;
 
     const isNotebookContainerOpen =
       isNewQuestion || queryBuilderMode === "notebook";
@@ -331,8 +362,8 @@ export default class View extends React.Component {
               <ViewFooter {...this.props} className="flex-no-shrink" />
             </div>
 
-            <ViewSidebar side="right" isOpen={!!rightSideBar}>
-              {rightSideBar}
+            <ViewSidebar side="right" isOpen={!!rightSidebar}>
+              {rightSidebar}
             </ViewSidebar>
           </div>
         </div>

--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -62,6 +62,7 @@ export default class View extends React.Component {
       aggregationPopoverTarget: e.target,
     });
   };
+
   handleEditSeries = (e, index) => {
     this.setState({
       ...DEFAULT_POPOVER_STATE,
@@ -69,10 +70,12 @@ export default class View extends React.Component {
       aggregationIndex: index,
     });
   };
+
   handleRemoveSeries = (e, index) => {
     const { query } = this.props;
     query.removeAggregation(index).update(null, { run: true });
   };
+
   handleEditBreakout = (e, index) => {
     this.setState({
       ...DEFAULT_POPOVER_STATE,
@@ -80,10 +83,35 @@ export default class View extends React.Component {
       breakoutIndex: index,
     });
   };
+
   handleClosePopover = () => {
     this.setState({
       ...DEFAULT_POPOVER_STATE,
     });
+  };
+
+  onChangeAggregation = aggregation => {
+    const { query } = this.props;
+    const { aggregationIndex } = this.state;
+    if (aggregationIndex != null) {
+      query
+        .updateAggregation(aggregationIndex, aggregation)
+        .update(null, { run: true });
+    } else {
+      query.aggregate(aggregation).update(null, { run: true });
+    }
+    this.handleClosePopover();
+  };
+
+  onChangeBreakout = breakout => {
+    const { query } = this.props;
+    const { breakoutIndex } = this.state;
+    if (breakoutIndex != null) {
+      query.updateBreakout(breakoutIndex, breakout).update(null, { run: true });
+    } else {
+      query.breakout(breakout).update(null, { run: true });
+    }
+    this.handleClosePopover();
   };
 
   render() {
@@ -319,16 +347,7 @@ export default class View extends React.Component {
                   ? query.aggregations()[aggregationIndex]
                   : 0
               }
-              onChangeAggregation={aggregation => {
-                if (aggregationIndex != null) {
-                  query
-                    .updateAggregation(aggregationIndex, aggregation)
-                    .update(null, { run: true });
-                } else {
-                  query.aggregate(aggregation).update(null, { run: true });
-                }
-                this.handleClosePopover();
-              }}
+              onChangeAggregation={this.onChangeAggregation}
               onClose={this.handleClosePopover}
             />
           </Popover>
@@ -344,16 +363,7 @@ export default class View extends React.Component {
               breakout={
                 breakoutIndex >= 0 ? query.breakouts()[breakoutIndex] : 0
               }
-              onChangeBreakout={breakout => {
-                if (breakoutIndex != null) {
-                  query
-                    .updateBreakout(breakoutIndex, breakout)
-                    .update(null, { run: true });
-                } else {
-                  query.breakout(breakout).update(null, { run: true });
-                }
-                this.handleClosePopover();
-              }}
+              onChangeBreakout={this.onChangeBreakout}
               onClose={this.handleClosePopover}
             />
           </Popover>

--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/prop-types */
 import React from "react";
+import { Motion, spring } from "react-motion";
 import { t } from "ttag";
-
 import cx from "classnames";
 
 import ExplicitSize from "metabase/components/ExplicitSize";
@@ -10,22 +10,21 @@ import DebouncedFrame from "metabase/components/DebouncedFrame";
 import Subhead from "metabase/components/type/Subhead";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 
+import NativeQuery from "metabase-lib/lib/queries/NativeQuery";
+import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
+
+import SyncedParametersList from "metabase/parameters/components/SyncedParametersList/SyncedParametersList";
+
+import AggregationPopover from "../AggregationPopover";
+import BreakoutPopover from "../BreakoutPopover";
+import DatasetEditor from "../DatasetEditor";
 import NativeQueryEditor from "../NativeQueryEditor";
 import QueryVisualization from "../QueryVisualization";
 import DataReference from "../dataref/DataReference";
 import TagEditorSidebar from "../template_tags/TagEditorSidebar";
 import SnippetSidebar from "../template_tags/SnippetSidebar";
 import SavedQuestionIntroModal from "../SavedQuestionIntroModal";
-
-import AggregationPopover from "../AggregationPopover";
-import BreakoutPopover from "../BreakoutPopover";
-
 import QueryModals from "../QueryModals";
-import { ViewTitleHeader, ViewSubHeader } from "./ViewHeader";
-import NewQuestionHeader from "./NewQuestionHeader";
-import ViewFooter from "./ViewFooter";
-import ViewSidebar from "./ViewSidebar";
-import QuestionDataSelector from "./QuestionDataSelector";
 
 import ChartSettingsSidebar from "./sidebars/ChartSettingsSidebar";
 import ChartTypeSidebar from "./sidebars/ChartTypeSidebar";
@@ -33,14 +32,11 @@ import SummarizeSidebar from "./sidebars/SummarizeSidebar/SummarizeSidebar";
 import FilterSidebar from "./sidebars/FilterSidebar";
 import QuestionDetailsSidebar from "./sidebars/QuestionDetailsSidebar";
 
-import { Motion, spring } from "react-motion";
-
-import NativeQuery from "metabase-lib/lib/queries/NativeQuery";
-import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
-import SyncedParametersList from "metabase/parameters/components/SyncedParametersList/SyncedParametersList";
-
-import DatasetEditor from "../DatasetEditor";
-
+import { ViewTitleHeader, ViewSubHeader } from "./ViewHeader";
+import NewQuestionHeader from "./NewQuestionHeader";
+import ViewFooter from "./ViewFooter";
+import ViewSidebar from "./ViewSidebar";
+import QuestionDataSelector from "./QuestionDataSelector";
 import QueryViewNotebook from "./View/QueryViewNotebook";
 
 const DEFAULT_POPOVER_STATE = {

--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -203,6 +203,38 @@ export default class View extends React.Component {
       : this.getRightSidebarForNativeQuery();
   };
 
+  renderHeader = () => {
+    const { query } = this.props;
+    const isStructured = query instanceof StructuredQuery;
+
+    const isNewQuestion =
+      isStructured && !query.sourceTableId() && !query.sourceQuery();
+
+    return (
+      <Motion
+        defaultStyle={isNewQuestion ? { opacity: 0 } : { opacity: 1 }}
+        style={isNewQuestion ? { opacity: spring(0) } : { opacity: spring(1) }}
+      >
+        {({ opacity }) => (
+          <div className="flex-no-shrink z3 bg-white relative">
+            <ViewTitleHeader
+              {...this.props}
+              style={{ opacity }}
+              py={1}
+              className="border-bottom"
+            />
+            {opacity < 1 && (
+              <NewQuestionHeader
+                className="spread"
+                style={{ opacity: 1 - opacity }}
+              />
+            )}
+          </div>
+        )}
+      </Motion>
+    );
+  };
+
   render() {
     const {
       query,
@@ -263,29 +295,7 @@ export default class View extends React.Component {
     return (
       <div className={fitClassNames}>
         <div className={cx("QueryBuilder flex flex-column bg-white spread")}>
-          <Motion
-            defaultStyle={isNewQuestion ? { opacity: 0 } : { opacity: 1 }}
-            style={
-              isNewQuestion ? { opacity: spring(0) } : { opacity: spring(1) }
-            }
-          >
-            {({ opacity }) => (
-              <div className="flex-no-shrink z3 bg-white relative">
-                <ViewTitleHeader
-                  {...this.props}
-                  style={{ opacity }}
-                  py={1}
-                  className="border-bottom"
-                />
-                {opacity < 1 && (
-                  <NewQuestionHeader
-                    className="spread"
-                    style={{ opacity: 1 - opacity }}
-                  />
-                )}
-              </div>
-            )}
-          </Motion>
+          {this.renderHeader()}
 
           <div className="flex flex-full relative">
             {query instanceof StructuredQuery && (

--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -153,6 +153,7 @@ export default class View extends React.Component {
       isShowingFilterSidebar,
       runQuestionQuery,
       onCloseSummary,
+      onCloseFilter,
     } = this.props;
 
     if (isShowingSummarySidebar) {
@@ -167,9 +168,7 @@ export default class View extends React.Component {
     }
 
     if (isShowingFilterSidebar) {
-      return (
-        <FilterSidebar question={question} onClose={this.props.onCloseFilter} />
-      );
+      return <FilterSidebar question={question} onClose={onCloseFilter} />;
     }
 
     return null;
@@ -238,7 +237,19 @@ export default class View extends React.Component {
   };
 
   renderMain = ({ leftSidebar, rightSidebar }) => {
-    const { query, card, mode, isDirty, isLiveResizable, height } = this.props;
+    const {
+      query,
+      card,
+      mode,
+      parameters,
+      isDirty,
+      isLiveResizable,
+      isPreviewable,
+      isPreviewing,
+      height,
+      setParameterValue,
+      setIsPreviewing,
+    } = this.props;
 
     const queryMode = mode && mode.queryMode();
     const ModeFooter = queryMode && queryMode.ModeFooter;
@@ -270,13 +281,17 @@ export default class View extends React.Component {
           </NativeQueryEditorContainer>
         ) : (
           <StyledSyncedParametersList
-            parameters={this.props.parameters}
-            setParameterValue={this.props.setParameterValue}
+            parameters={parameters}
+            setParameterValue={setParameterValue}
             commitImmediately
           />
         )}
 
-        <ViewSubHeader {...this.props} />
+        <ViewSubHeader
+          isPreviewable={isPreviewable}
+          isPreviewing={isPreviewing}
+          setIsPreviewing={setIsPreviewing}
+        />
 
         <StyledDebouncedFrame enabled={!isLiveResizable}>
           <QueryVisualization
@@ -341,12 +356,14 @@ export default class View extends React.Component {
 
   render() {
     const {
+      question,
       query,
       card,
       databases,
       isShowingNewbModal,
       queryBuilderMode,
       fitClassNames,
+      closeQbNewbModal,
     } = this.props;
 
     // if we don't have a card at all or no databases then we are initializing, so keep it simple
@@ -396,8 +413,8 @@ export default class View extends React.Component {
 
         {isShowingNewbModal && (
           <SavedQuestionIntroModal
-            question={this.props.question}
-            onClose={() => this.props.closeQbNewbModal()}
+            question={question}
+            onClose={() => closeQbNewbModal()}
           />
         )}
 

--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -1,13 +1,11 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 import { Motion, spring } from "react-motion";
-import { t } from "ttag";
 import cx from "classnames";
 
 import ExplicitSize from "metabase/components/ExplicitSize";
 import Popover from "metabase/components/Popover";
 import DebouncedFrame from "metabase/components/DebouncedFrame";
-import Subhead from "metabase/components/type/Subhead";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 
 import NativeQuery from "metabase-lib/lib/queries/NativeQuery";
@@ -36,7 +34,7 @@ import { ViewTitleHeader, ViewSubHeader } from "./ViewHeader";
 import NewQuestionHeader from "./NewQuestionHeader";
 import ViewFooter from "./ViewFooter";
 import ViewSidebar from "./ViewSidebar";
-import QuestionDataSelector from "./QuestionDataSelector";
+import NewQuestionView from "./View/NewQuestionView";
 import QueryViewNotebook from "./View/QueryViewNotebook";
 
 const DEFAULT_POPOVER_STATE = {
@@ -235,23 +233,10 @@ export default class View extends React.Component {
     const isNative = query instanceof NativeQuery;
 
     const isNewQuestion =
-      query instanceof StructuredQuery &&
-      !query.sourceTableId() &&
-      !query.sourceQuery();
+      isStructured && !query.sourceTableId() && !query.sourceQuery();
 
     if (isNewQuestion && queryBuilderMode === "view") {
-      return (
-        <div className={fitClassNames}>
-          <div className="p4 mx2">
-            <QuestionDataSelector
-              query={query}
-              triggerElement={
-                <Subhead className="mb2">{t`Pick your data`}</Subhead>
-              }
-            />
-          </div>
-        </div>
-      );
+      return <NewQuestionView query={query} fitClassNames={fitClassNames} />;
     }
 
     if (card.dataset && queryBuilderMode === "dataset") {

--- a/frontend/src/metabase/query_builder/components/view/View.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/View.styled.tsx
@@ -5,9 +5,9 @@ import DebouncedFrame from "metabase/components/DebouncedFrame";
 import SyncedParametersList from "metabase/parameters/components/SyncedParametersList/SyncedParametersList";
 
 import { color } from "metabase/lib/colors";
-import { breakpointMinSmall } from "metabase/styled-components/theme/media-queries";
+import { breakpointMaxSmall } from "metabase/styled-components/theme/media-queries";
 
-import { ViewTitleHeader, ViewSubHeader } from "./ViewHeader";
+import { ViewTitleHeader } from "./ViewHeader";
 
 export const QueryBuilderViewRoot = styled.div`
   display: flex;
@@ -20,9 +20,7 @@ export const QueryBuilderViewRoot = styled.div`
   bottom: 0;
 `;
 
-export const QueryBuilderContentContainer = styled.div<{
-  isSidebarOpen: boolean;
-}>`
+export const QueryBuilderContentContainer = styled.div`
   display: flex;
   flex: 1 0 auto;
   position: relative;
@@ -34,7 +32,7 @@ export const QueryBuilderMain = styled.main<{ isSidebarOpen: boolean }>`
   flex: 1 0 auto;
   flex-basis: 0;
 
-  ${breakpointMinSmall} {
+  ${breakpointMaxSmall} {
     ${props =>
       props.isSidebarOpen &&
       css`

--- a/frontend/src/metabase/query_builder/components/view/View.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/View.styled.tsx
@@ -1,0 +1,73 @@
+import styled from "@emotion/styled";
+import { css } from "@emotion/react";
+
+import DebouncedFrame from "metabase/components/DebouncedFrame";
+import SyncedParametersList from "metabase/parameters/components/SyncedParametersList/SyncedParametersList";
+
+import { color } from "metabase/lib/colors";
+import { breakpointMinSmall } from "metabase/styled-components/theme/media-queries";
+
+import { ViewTitleHeader, ViewSubHeader } from "./ViewHeader";
+
+export const QueryBuilderViewRoot = styled.div`
+  display: flex;
+  flex-direction: column;
+  background-color: ${color("bg-white")};
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+`;
+
+export const QueryBuilderContentContainer = styled.div<{
+  isSidebarOpen: boolean;
+}>`
+  display: flex;
+  flex: 1 0 auto;
+  position: relative;
+`;
+
+export const QueryBuilderMain = styled.main<{ isSidebarOpen: boolean }>`
+  display: flex;
+  flex-direction: column;
+  flex: 1 0 auto;
+  flex-basis: 0;
+
+  ${breakpointMinSmall} {
+    ${props =>
+      props.isSidebarOpen &&
+      css`
+        display: none !important;
+      `};
+  }
+`;
+
+export const BorderedViewTitleHeader = styled(ViewTitleHeader)`
+  border-bottom: 1px solid ${color("border")};
+  padding-top: 8px;
+  padding-bottom: 8px;
+`;
+
+export const QueryBuilderViewHeaderContainer = styled.div`
+  flex-shrink: 0;
+  background-color: ${color("bg-white")};
+  position: relative;
+  z-index: 3;
+`;
+
+export const NativeQueryEditorContainer = styled.div`
+  margin-bottom: 1rem;
+  border-bottom: 1px solid ${color("border")};
+  z-index: 2;
+`;
+
+export const StyledDebouncedFrame = styled(DebouncedFrame)`
+  flex: 1 0 auto;
+  flex-grow: 1;
+`;
+
+export const StyledSyncedParametersList = styled(SyncedParametersList)`
+  margin-top: 1rem;
+  margin-left: 1.5rem;
+`;

--- a/frontend/src/metabase/query_builder/components/view/View/NewQuestionView/NewQuestionView.tsx
+++ b/frontend/src/metabase/query_builder/components/view/View/NewQuestionView/NewQuestionView.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { t } from "ttag";
+
+import Subhead from "metabase/components/type/Subhead";
+import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
+
+import QuestionDataSelector from "../../QuestionDataSelector";
+
+type Props = {
+  query: StructuredQuery;
+  fitClassNames: string;
+};
+
+function NewQuestionView({ query, fitClassNames }: Props) {
+  return (
+    <div className={fitClassNames}>
+      <div className="p4 mx2">
+        <QuestionDataSelector
+          query={query}
+          triggerElement={
+            <Subhead className="mb2">{t`Pick your data`}</Subhead>
+          }
+        />
+      </div>
+    </div>
+  );
+}
+
+export default NewQuestionView;

--- a/frontend/src/metabase/query_builder/components/view/View/NewQuestionView/index.ts
+++ b/frontend/src/metabase/query_builder/components/view/View/NewQuestionView/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./NewQuestionView";

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
@@ -1,16 +1,20 @@
 /* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import { connect } from "react-redux";
+import { push } from "react-router-redux";
 import { t } from "ttag";
 import _ from "underscore";
 
+import Collections from "metabase/entities/collections";
+import { MetabaseApi } from "metabase/services";
+import { getMetadata } from "metabase/selectors/metadata";
+import { getUser, getUserIsAdmin } from "metabase/selectors/user";
+
 import fitViewport from "metabase/hoc/FitViewPort";
-
-import View from "../components/view/View";
-// import Notebook from "../components/notebook/Notebook";
-
 import title from "metabase/hoc/Title";
 import titleWithLoadingTime from "metabase/hoc/TitleWithLoadingTime";
+
+import View from "../components/view/View";
 
 import {
   getCard,
@@ -53,15 +57,7 @@ import {
   getNativeEditorCursorOffset,
   getNativeEditorSelectedText,
 } from "../selectors";
-
-import { getMetadata } from "metabase/selectors/metadata";
-import { getUser, getUserIsAdmin } from "metabase/selectors/user";
-
 import * as actions from "../actions";
-import { push } from "react-router-redux";
-
-import Collections from "metabase/entities/collections";
-import { MetabaseApi } from "metabase/services";
 
 function autocompleteResults(card, prefix) {
   const databaseId = card && card.dataset_query && card.dataset_query.database;

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
@@ -90,11 +90,9 @@ const mapStateToProps = (state, props) => {
 
     parameterValues: getParameterValues(state),
 
-    // TODO: data ref
     tableForeignKeys: getTableForeignKeys(state),
     tableForeignKeyReferences: getTableForeignKeyReferences(state),
 
-    // TODO: legacy
     card: getCard(state),
     originalCard: getOriginalCard(state),
     databases: getDatabasesList(state),
@@ -102,7 +100,6 @@ const mapStateToProps = (state, props) => {
     tables: getTables(state),
     tableMetadata: getTableMetadata(state),
 
-    // TODO: redundant, accessible through question
     query: getQuery(state),
     metadata: getMetadata(state),
 
@@ -161,8 +158,6 @@ const mapDispatchToProps = {
 export default class QueryBuilder extends Component {
   constructor(props, context) {
     super(props, context);
-
-    // TODO: React tells us that forceUpdate() is not the best thing to use, so ideally we can find a different way to trigger this
     this.forceUpdateDebounced = _.debounce(this.forceUpdate.bind(this), 400);
   }
 
@@ -209,14 +204,10 @@ export default class QueryBuilder extends Component {
   }
 
   componentWillUnmount() {
-    // cancel the query if one is running
     this.props.cancelQuery();
-
     window.removeEventListener("resize", this.handleResize);
-
     clearTimeout(this.timeout);
-
-    this.closeModal(); // close any modal that might be open
+    this.closeModal();
   }
 
   // When the window is resized we need to re-render, mainly so that our visualization pane updates
@@ -225,10 +216,10 @@ export default class QueryBuilder extends Component {
     this.forceUpdateDebounced();
   };
 
-  // NOTE: these were lifted from QueryHeader. Move to Redux?
   openModal = modal => {
     this.props.setUIControls({ modal });
   };
+
   closeModal = () => {
     this.props.setUIControls({ modal: null });
   };
@@ -264,15 +255,6 @@ export default class QueryBuilder extends Component {
     }
   };
 
-  resetStateOnTimeout = () => {
-    // clear any previously set timeouts then start a new one
-    clearTimeout(this.timeout);
-    this.timeout = setTimeout(() => {
-      this.props.onSetRecentlySaved(null);
-      this.timeout = null;
-    }, 5000);
-  };
-
   render() {
     const {
       uiControls: { modal, recentlySaved },
@@ -281,14 +263,11 @@ export default class QueryBuilder extends Component {
     return (
       <View
         {...this.props}
-        // NOTE: these were lifted from QueryHeader. Move to Redux?
         modal={modal}
         onOpenModal={this.openModal}
         onCloseModal={this.closeModal}
-        // recently saved indication
         recentlySaved={recentlySaved}
         onSetRecentlySaved={this.setRecentlySaved}
-        // save/create actions
         onSave={this.handleSave}
         onCreate={this.handleCreate}
         handleResize={this.handleResize}


### PR DESCRIPTION
This PR cleans up QB's container (`QueryBuilder`) and `View` components. Most of the changes are around `View` as it's pretty bloated:

* sorted out imports
* extracted some methods to reduce the number of functions it spawns on each rerendering
* broke down the huge `render` method into smaller chunks like `getLeftSidebar`, `getRightSidebar`, `renderMain`, etc.
* extracted some styled-components

There should be no visible / behavioral changes, just pure refactoring