### PR TITLE
Fix revision history display

### DIFF
--- a/frontend/src/metabase/lib/revisions/components.jsx
+++ b/frontend/src/metabase/lib/revisions/components.jsx
@@ -29,26 +29,32 @@ RevisionTitle.propTypes = revisionTitlePropTypes;
 
 const revisionBatchedDescriptionPropTypes = {
   changes: PropTypes.arrayOf(PropTypes.node).isRequired,
+  fallback: PropTypes.string,
 };
 
-export function RevisionBatchedDescription({ changes }) {
+export function RevisionBatchedDescription({ changes, fallback }) {
   const formattedChanges = useMemo(() => {
-    const result = [];
+    let result = [];
 
     changes.forEach((change, i) => {
-      const isFirst = i === 0;
-      result.push(isFirst ? capitalizeChangeRecord(change) : change);
-      const isLast = i === changes.length - 1;
-      const isBeforeLast = i === changes.length - 2;
-      if (isBeforeLast) {
-        result.push(" " + t`and` + " ");
-      } else if (!isLast) {
-        result.push(", ");
+      try {
+        const isFirst = i === 0;
+        result.push(isFirst ? capitalizeChangeRecord(change) : change);
+        const isLast = i === changes.length - 1;
+        const isBeforeLast = i === changes.length - 2;
+        if (isBeforeLast) {
+          result.push(" " + t`and` + " ");
+        } else if (!isLast) {
+          result.push(", ");
+        }
+      } catch {
+        console.warn("Error formatting revision changes", changes);
+        result = fallback;
       }
     });
 
     return result;
-  }, [changes]);
+  }, [changes, fallback]);
 
   return <span>{formattedChanges}</span>;
 }

--- a/frontend/src/metabase/lib/revisions/components.jsx
+++ b/frontend/src/metabase/lib/revisions/components.jsx
@@ -56,6 +56,9 @@ export function RevisionBatchedDescription({ changes }) {
 function capitalizeChangeRecord(change) {
   if (Array.isArray(change)) {
     const [first, ...rest] = change;
+    if (Array.isArray(first)) {
+      return capitalizeChangeRecord(first);
+    }
     return [capitalize(first, { lowercase: false }), ...rest];
   }
   return capitalize(change, { lowercase: false });

--- a/frontend/src/metabase/lib/revisions/components.unit.spec.js
+++ b/frontend/src/metabase/lib/revisions/components.unit.spec.js
@@ -1,5 +1,6 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, renderWithProviders, screen } from "__support__/ui";
+import { getCollectionChangeDescription } from "./revisions";
 import { RevisionTitle, RevisionBatchedDescription } from "./components";
 
 describe("RevisionTitle", () => {
@@ -39,5 +40,15 @@ describe("RevisionBatchedDescription", () => {
       />,
     );
     expect(screen.queryByText("Renamed this and moved to Our analytics"));
+  });
+
+  it("should handle nested messages (metabase#20414)", () => {
+    renderWithProviders(
+      <RevisionBatchedDescription
+        changes={[getCollectionChangeDescription(1, 2), "edited metadata"]}
+      />,
+    );
+    expect(screen.getByText(/Moved this to/)).toBeInTheDocument();
+    expect(screen.getByText(/edited metadata/)).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/lib/revisions/components.unit.spec.js
+++ b/frontend/src/metabase/lib/revisions/components.unit.spec.js
@@ -11,6 +11,16 @@ describe("RevisionTitle", () => {
 });
 
 describe("RevisionBatchedDescription", () => {
+  const originalWarn = console.warn;
+
+  beforeAll(() => {
+    console.warn = jest.fn();
+  });
+
+  afterAll(() => {
+    console.warn = originalWarn;
+  });
+
   it("correctly renders two change records", () => {
     render(
       <RevisionBatchedDescription
@@ -50,5 +60,15 @@ describe("RevisionBatchedDescription", () => {
     );
     expect(screen.getByText(/Moved this to/)).toBeInTheDocument();
     expect(screen.getByText(/edited metadata/)).toBeInTheDocument();
+  });
+
+  it("should use fallback when failing to format changes message", () => {
+    render(
+      <RevisionBatchedDescription
+        changes={[{ key: "try to parse this" }, -1, false]}
+        fallback="Just a fallback"
+      />,
+    );
+    expect(screen.getByText("Just a fallback")).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/lib/revisions/revisions.js
+++ b/frontend/src/metabase/lib/revisions/revisions.js
@@ -245,7 +245,12 @@ export function getRevisionEventsForTimeline(
       // like "John added a description"
       if (isChangeEvent && isMultipleFieldsChange) {
         event.title = t`${username} edited this`;
-        event.description = <RevisionBatchedDescription changes={changes} />;
+        event.description = (
+          <RevisionBatchedDescription
+            changes={changes}
+            fallback={revision.description}
+          />
+        );
       } else {
         event.title = <RevisionTitle username={username} message={changes} />;
       }

--- a/frontend/src/metabase/lib/revisions/revisions.js
+++ b/frontend/src/metabase/lib/revisions/revisions.js
@@ -63,7 +63,7 @@ function getSeriesChangeDescription(prevCards, cards) {
     : t`removed series from a question`;
 }
 
-function getCollectionChangeDescription(prevCollectionId, collectionId) {
+export function getCollectionChangeDescription(prevCollectionId, collectionId) {
   const key = `collection-from-${prevCollectionId}-to-${collectionId}`;
   return [
     jt`moved this to ${(


### PR DESCRIPTION
Fixes a weird bug with revision history rendering and one of its possible occurrences: #20414

If you want to understand the issue in full detail, I'd recommend going through #17858 PR description as it explains how revisions are rendered.

There are two ways we render the message:

1. In case only one property was changed, we just display something like "$USERNAME renamed this to ..."
2. In case there were > 1 properties changed in a single revision, the message is broken down into `title` ("$USERNAM edited this") and joined `description` ("Renamed this to ... and added description")

There is a special case when an item is moved to another collection. In this case, we display a link to the new collection using `jt'moved this to ${<CollectionLink />}'`. `jt` returns an array like `[ "moved this to", "", React.Element ]` and the component rendering a description capitalizes the "moved this to" part.

This was working fine because the current UI only lets you move items with a separate flow, so only the `collection_id` is changed on the UI (for some reason `collection_id` change is not tracked for dashboards 🤔). We started tracking `result_metadata` field changes for models as their metadata can be changed now. And looks like there is an edge-case when the table fingerprint gets updated at the same time you move a model to another collection 😵 So the description component receives nested `changes` array prop and crashes

Fixed by adding support to nested `changes` list, though it'd probably make sense to make revision rendering less magical. Also added a generic safety net: now if rendering a change description would fail, it'd fall back to the original ugly revision description.

There is no clear way how to reproduce this issue, you just have to catch it somehow, hopefully @flamber confirmed it works