### PR TITLE
Fix permission error when opening revision history

### DIFF
--- a/frontend/src/metabase/entities/containers/EntityLink.jsx
+++ b/frontend/src/metabase/entities/containers/EntityLink.jsx
@@ -8,6 +8,8 @@ const EntityLink = ({
   entityId,
   name = "name",
   LinkComponent = Link,
+  dispatchApiErrorEvent = true,
+  fallback = null,
   ...linkProps
 }) => (
   <EntityObjectLoader
@@ -15,6 +17,7 @@ const EntityLink = ({
     entityId={entityId}
     properties={[name]}
     loadingAndErrorWrapper={false}
+    dispatchApiErrorEvent={dispatchApiErrorEvent}
     wrapped
   >
     {({ object }) =>
@@ -22,7 +25,9 @@ const EntityLink = ({
         <LinkComponent {...linkProps} to={object.getUrl()}>
           <span>{object.getName()}</span>
         </LinkComponent>
-      ) : null
+      ) : (
+        fallback
+      )
     }
   </EntityObjectLoader>
 );

--- a/frontend/src/metabase/entities/containers/EntityObjectLoader.jsx
+++ b/frontend/src/metabase/entities/containers/EntityObjectLoader.jsx
@@ -42,6 +42,7 @@ export default class EntityObjectLoader extends React.Component {
     loadingAndErrorWrapper: true,
     reload: false,
     wrapped: false,
+    dispatchApiErrorEvent: true,
   };
 
   _getWrappedObject;
@@ -61,11 +62,15 @@ export default class EntityObjectLoader extends React.Component {
   }
 
   UNSAFE_componentWillMount() {
-    const { entityId, fetch } = this.props;
+    const { entityId, fetch, dispatchApiErrorEvent } = this.props;
     if (entityId != null) {
       fetch(
         { id: entityId },
-        { reload: this.props.reload, properties: this.props.properties },
+        {
+          reload: this.props.reload,
+          properties: this.props.properties,
+          noEvent: !dispatchApiErrorEvent,
+        },
       );
     }
   }
@@ -121,7 +126,11 @@ export default class EntityObjectLoader extends React.Component {
   reload = () => {
     return this.props.fetch(
       { id: this.props.entityId },
-      { reload: true, properties: this.props.properties },
+      {
+        reload: true,
+        properties: this.props.properties,
+        noEvent: !this.props.dispatchApiErrorEvent,
+      },
     );
   };
 

--- a/frontend/src/metabase/lib/revisions/components.jsx
+++ b/frontend/src/metabase/lib/revisions/components.jsx
@@ -29,26 +29,32 @@ RevisionTitle.propTypes = revisionTitlePropTypes;
 
 const revisionBatchedDescriptionPropTypes = {
   changes: PropTypes.arrayOf(PropTypes.node).isRequired,
+  fallback: PropTypes.string,
 };
 
-export function RevisionBatchedDescription({ changes }) {
+export function RevisionBatchedDescription({ changes, fallback }) {
   const formattedChanges = useMemo(() => {
-    const result = [];
+    let result = [];
 
     changes.forEach((change, i) => {
-      const isFirst = i === 0;
-      result.push(isFirst ? capitalizeChangeRecord(change) : change);
-      const isLast = i === changes.length - 1;
-      const isBeforeLast = i === changes.length - 2;
-      if (isBeforeLast) {
-        result.push(" " + t`and` + " ");
-      } else if (!isLast) {
-        result.push(", ");
+      try {
+        const isFirst = i === 0;
+        result.push(isFirst ? capitalizeChangeRecord(change) : change);
+        const isLast = i === changes.length - 1;
+        const isBeforeLast = i === changes.length - 2;
+        if (isBeforeLast) {
+          result.push(" " + t`and` + " ");
+        } else if (!isLast) {
+          result.push(", ");
+        }
+      } catch {
+        console.warn("Error formatting revision changes", changes);
+        result = fallback;
       }
     });
 
     return result;
-  }, [changes]);
+  }, [changes, fallback]);
 
   return <span>{formattedChanges}</span>;
 }

--- a/frontend/src/metabase/lib/revisions/components.jsx
+++ b/frontend/src/metabase/lib/revisions/components.jsx
@@ -16,6 +16,10 @@ export const EntityLink = styled(RawEntityLink)`
   }
 `;
 
+EntityLink.defaultProps = {
+  dispatchApiErrorEvent: false,
+};
+
 const revisionTitlePropTypes = {
   username: PropTypes.string.isRequired,
   message: PropTypes.node.isRequired,

--- a/frontend/src/metabase/lib/revisions/components.jsx
+++ b/frontend/src/metabase/lib/revisions/components.jsx
@@ -56,6 +56,9 @@ export function RevisionBatchedDescription({ changes }) {
 function capitalizeChangeRecord(change) {
   if (Array.isArray(change)) {
     const [first, ...rest] = change;
+    if (Array.isArray(first)) {
+      return capitalizeChangeRecord(first);
+    }
     return [capitalize(first, { lowercase: false }), ...rest];
   }
   return capitalize(change, { lowercase: false });

--- a/frontend/src/metabase/lib/revisions/components.unit.spec.js
+++ b/frontend/src/metabase/lib/revisions/components.unit.spec.js
@@ -1,5 +1,6 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, renderWithProviders, screen } from "__support__/ui";
+import { getCollectionChangeDescription } from "./revisions";
 import { RevisionTitle, RevisionBatchedDescription } from "./components";
 
 describe("RevisionTitle", () => {
@@ -39,5 +40,15 @@ describe("RevisionBatchedDescription", () => {
       />,
     );
     expect(screen.queryByText("Renamed this and moved to Our analytics"));
+  });
+
+  it("should handle nested messages (metabase#20414)", () => {
+    renderWithProviders(
+      <RevisionBatchedDescription
+        changes={[getCollectionChangeDescription(1, 2), "edited metadata"]}
+      />,
+    );
+    expect(screen.getByText(/Moved this to/)).toBeInTheDocument();
+    expect(screen.getByText(/edited metadata/)).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/lib/revisions/components.unit.spec.js
+++ b/frontend/src/metabase/lib/revisions/components.unit.spec.js
@@ -11,6 +11,16 @@ describe("RevisionTitle", () => {
 });
 
 describe("RevisionBatchedDescription", () => {
+  const originalWarn = console.warn;
+
+  beforeAll(() => {
+    console.warn = jest.fn();
+  });
+
+  afterAll(() => {
+    console.warn = originalWarn;
+  });
+
   it("correctly renders two change records", () => {
     render(
       <RevisionBatchedDescription
@@ -50,5 +60,15 @@ describe("RevisionBatchedDescription", () => {
     );
     expect(screen.getByText(/Moved this to/)).toBeInTheDocument();
     expect(screen.getByText(/edited metadata/)).toBeInTheDocument();
+  });
+
+  it("should use fallback when failing to format changes message", () => {
+    render(
+      <RevisionBatchedDescription
+        changes={[{ key: "try to parse this" }, -1, false]}
+        fallback="Just a fallback"
+      />,
+    );
+    expect(screen.getByText("Just a fallback")).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/lib/revisions/revisions.js
+++ b/frontend/src/metabase/lib/revisions/revisions.js
@@ -245,7 +245,12 @@ export function getRevisionEventsForTimeline(
       // like "John added a description"
       if (isChangeEvent && isMultipleFieldsChange) {
         event.title = t`${username} edited this`;
-        event.description = <RevisionBatchedDescription changes={changes} />;
+        event.description = (
+          <RevisionBatchedDescription
+            changes={changes}
+            fallback={revision.description}
+          />
+        );
       } else {
         event.title = <RevisionTitle username={username} message={changes} />;
       }

--- a/frontend/src/metabase/lib/revisions/revisions.js
+++ b/frontend/src/metabase/lib/revisions/revisions.js
@@ -63,7 +63,7 @@ function getSeriesChangeDescription(prevCards, cards) {
     : t`removed series from a question`;
 }
 
-function getCollectionChangeDescription(prevCollectionId, collectionId) {
+export function getCollectionChangeDescription(prevCollectionId, collectionId) {
   const key = `collection-from-${prevCollectionId}-to-${collectionId}`;
   return [
     jt`moved this to ${(

--- a/frontend/src/metabase/lib/revisions/revisions.js
+++ b/frontend/src/metabase/lib/revisions/revisions.js
@@ -71,6 +71,7 @@ export function getCollectionChangeDescription(prevCollectionId, collectionId) {
         key={key}
         entityId={collectionId || "root"}
         entityType="collections"
+        fallback={t`Unknown`}
       />
     )}`,
   ];


### PR DESCRIPTION
When opening a question that was stored in a collection you don't have access to at some point (not now), you'd get a permission error trying to open the revision history.

This happens because the FE requests the collection object by ID to get its name to generate a human-readable link. If a user doesn't have access to this collection, they receive `403 Forbidden` and the app's global listener will replace the whole page with the permission error page.

Fixed by passing `noEvent: true` down to `EntityObjectLoader` in this case (similarly to #18920). For collections that can't be fetched, the FE will display a message like "User moved this to Unknown" (not the best message, but "Unknown" is a good option since it's already translated and we need to backport that into `release-x.42.x`

### To Verify

1. Sign in as admin
2. Create a collection and block permission to it for everyone except admins
3. Move a question to this collection
4. Move the question from this collection to "Our analytics"
5. Sign in as a non-admin user
6. Open the question and try to see the revision history
7. There should be no errors

### Demo

**Before**
https://user-images.githubusercontent.com/17258145/153442095-efffdc42-b2c8-4872-ad84-56d9fadcfc88.mp4

**After**
https://user-images.githubusercontent.com/17258145/153442087-f6cf1d8c-670e-4b5e-a75b-61baaf9c1c07.mp4


