### PR TITLE
Remove duplicated binning repros

### DIFF
--- a/frontend/test/metabase/scenarios/binning/binning-options.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/binning-options.cy.spec.js
@@ -180,7 +180,7 @@ describe("scenarios > binning > binning options", () => {
     });
   });
 
-  context("via time series footer", () => {
+  context("via time series footer (metabase#11183)", () => {
     it("should render time series binning options correctly", () => {
       openTable({ table: ORDERS_ID });
 

--- a/frontend/test/metabase/scenarios/binning/binning-options.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/binning-options.cy.spec.js
@@ -98,6 +98,9 @@ const LONGITUDE_BUCKETS = [
  * Makes sure that all binning options (bucket sizes) are rendered correctly for the regular table.
  *  1. no option should be rendered multiple times
  *  2. the selected option should be highlighted when the popover with all options opens
+ *
+ * This spec covers the following issues:
+ *  - metabase#15574
  */
 
 describe("scenarios > binning > binning options", () => {

--- a/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
@@ -10,57 +10,12 @@ import {
 } from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
-const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
+const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 
 describe("binning related reproductions", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
-  });
-
-  it("binning for a date column on a joined table should offer only a single set of values (metabase#15446)", () => {
-    cy.createQuestion({
-      name: "15446",
-      query: {
-        "source-table": ORDERS_ID,
-        joins: [
-          {
-            fields: "all",
-            "source-table": PRODUCTS_ID,
-            condition: [
-              "=",
-              ["field", ORDERS.PRODUCT_ID, null],
-              [
-                "field",
-                PRODUCTS.ID,
-                {
-                  "join-alias": "Products",
-                },
-              ],
-            ],
-            alias: "Products",
-          },
-        ],
-        aggregation: [["sum", ["field", ORDERS.TOTAL, null]]],
-      },
-    }).then(({ body: { id: QUESTION_ID } }) => {
-      cy.visit(`/question/${QUESTION_ID}/notebook`);
-    });
-    cy.findByText("Pick a column to group by").click();
-    // In the first popover we'll choose the breakout method
-    popover().within(() => {
-      cy.findByText("User").click();
-      cy.findByPlaceholderText("Find...").type("cr");
-    });
-
-    changeBinningForDimension({
-      name: "Created At",
-      fromBinning: "by month",
-      toBinning: "Minute",
-    });
-
-    // Given that the previous step passes, we should now see this in the UI
-    cy.findByText("User → Created At: Minute");
   });
 
   it("shouldn't render double binning options when question is based on the saved native question (metabase#16327)", () => {

--- a/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
@@ -270,37 +270,6 @@ describe("binning related reproductions", () => {
     cy.findByText("Hour of Day");
   });
 
-  it("binning on values from joined table should work (metabase#15648)", () => {
-    // Simple question
-    openOrdersTable();
-    summarize();
-    cy.findByText("Group by")
-      .parent()
-      .findByText("Rating")
-      .click();
-    cy.get(".Visualization .bar").should("have.length", 6);
-
-    // Custom question ("Notebook")
-    openOrdersTable({ mode: "notebook" });
-    summarize({ mode: "notebook" });
-    cy.findByText("Count of rows").click();
-    cy.findByText("Pick a column to group by").click();
-    popover().within(() => {
-      // Close expanded "Orders" section in order to bring everything else into view
-      cy.get(".List-section-title")
-        .contains(/Orders?/)
-        .click();
-      cy.get(".List-section-title")
-        .contains(/Products?/)
-        .click();
-      cy.findByText("Rating").click();
-    });
-
-    visualize();
-
-    cy.get(".Visualization .bar").should("have.length", 6);
-  });
-
   describe("binning should work on nested question based on question that has aggregation (metabase#16379)", () => {
     beforeEach(() => {
       cy.createQuestion(

--- a/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
@@ -2,7 +2,6 @@ import {
   restore,
   popover,
   visualize,
-  openOrdersTable,
   visitQuestionAdhoc,
   changeBinningForDimension,
   getBinningButtonForDimension,
@@ -17,19 +16,6 @@ describe("binning related reproductions", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
-  });
-
-  // This is basically covered with tests in `frontend/test/metabase/scenarios/binning/binning-options.cy.spec.js`
-  it("should not render duplicated values in date binning popover (metabase#15574)", () => {
-    openOrdersTable({ mode: "notebook" });
-    summarize({ mode: "notebook" });
-    cy.findByText("Pick a column to group by").click();
-
-    changeBinningForDimension({
-      name: "Created At",
-      fromBinning: "by month",
-      toBinning: "Minute",
-    });
   });
 
   it("binning for a date column on a joined table should offer only a single set of values (metabase#15446)", () => {

--- a/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
@@ -213,27 +213,6 @@ describe("binning related reproductions", () => {
     });
   });
 
-  // Probably safe to delete in the future - we're covering this steps in the main binnig tests
-  it("should display timeseries filter and granularity widgets at the bottom of the screen (metabase#11183)", () => {
-    const questionDetails = {
-      name: "11183",
-      query: {
-        "source-table": ORDERS_ID,
-        aggregation: [["sum", ["field", ORDERS.SUBTOTAL, null]]],
-        breakout: [["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }]],
-      },
-      display: "line",
-    };
-
-    cy.createQuestion(questionDetails, { visitQuestion: true });
-
-    cy.log("Reported missing in v0.33.1");
-    cy.findAllByTestId("select-button")
-      .as("select")
-      .contains(/All Time/i);
-    cy.get("@select").contains(/Month/i);
-  });
-
   it("should display date granularity on Summarize when opened from saved question (metabase#11439)", () => {
     // save "Orders" as question
     cy.createQuestion({

--- a/frontend/test/metabase/scenarios/binning/correctness/time-series.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/correctness/time-series.cy.spec.js
@@ -19,6 +19,11 @@ const questionDetails = {
   },
 };
 
+/**
+ * The list of issues this spec covers:
+ *  - metabase#11183
+ *  -
+ */
 describe("scenarios > binning > correctness > time series", () => {
   beforeEach(() => {
     restore();

--- a/frontend/test/metabase/scenarios/binning/qb-explicit-joins.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/qb-explicit-joins.cy.spec.js
@@ -15,6 +15,11 @@ const {
   PRODUCTS,
 } = SAMPLE_DATABASE;
 
+/**
+ * The list of issues this spec covers:
+ *  - metabase#15446
+ *  -
+ */
 describe("scenarios > binning > from a saved QB question with explicit joins", () => {
   beforeEach(() => {
     restore();

--- a/frontend/test/metabase/scenarios/binning/qb-implicit-joins.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/qb-implicit-joins.cy.spec.js
@@ -5,6 +5,12 @@ import {
   summarize,
 } from "__support__/e2e/cypress";
 
+/**
+ * The list of issues this spec covers:
+ *  - metabase#15648
+ *  -
+ */
+
 describe("scenarios > binning > from a saved QB question using implicit joins", () => {
   beforeEach(() => {
     restore();


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Removes the superfluous isolated reproductions that have been covered by the [extensive binning coverage](https://github.com/metabase/metabase/issues/16387) we put in place quite a while ago
- This should speed up the binning e2e group without losing the coverage
- It should also reduce the flakiness that was happening on these reproductions specifically