### PR TITLE
Add useSequencedContentCloseHandler hook to replace OnClickOutsideWrapper HOC

### DIFF
--- a/frontend/src/metabase/components/OnClickOutsideWrapper.jsx
+++ b/frontend/src/metabase/components/OnClickOutsideWrapper.jsx
@@ -1,74 +1,55 @@
-/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import ReactDOM from "react-dom";
 
-import { KEYCODE_ESCAPE } from "metabase/lib/keyboard";
-
-// keep track of the order popovers were opened so we only close the last one when clicked outside
-const popoverStack = [];
+import {
+  RENDERED_POPOVERS,
+  removePopoverData,
+  shouldClosePopover,
+} from "metabase/hooks/use-sequenced-content-close-handler";
 
 export default class OnClickOutsideWrapper extends Component {
   static propTypes = {
+    children: PropTypes.node,
     handleDismissal: PropTypes.func.isRequired,
-  };
-
-  static defaultProps = {
-    dismissOnClickOutside: true,
-    dismissOnEscape: true,
   };
 
   componentDidMount() {
     // necessary to ignore click events that fire immediately, causing modals/popovers to close prematurely
     this._timeout = setTimeout(() => {
-      popoverStack.push(this);
+      const contentEl = ReactDOM.findDOMNode(this);
+
+      this.popoverData = {
+        contentEl,
+        close: () => this.props.handleDismissal(),
+      };
+
+      RENDERED_POPOVERS.push(this.popoverData);
 
       // HACK: set the z-index of the parent element to ensure it"s always on top
       // NOTE: this actually doesn"t seem to be working correctly for popovers since PopoverBody creates a stacking context
-      ReactDOM.findDOMNode(this).parentNode.style.zIndex =
-        popoverStack.length + 2; // HACK: add 2 to ensure it"s in front of main and nav elements
+      contentEl.parentNode.style.zIndex = RENDERED_POPOVERS.length + 2; // HACK: add 2 to ensure it"s in front of main and nav elements
 
-      if (this.props.dismissOnEscape) {
-        document.addEventListener("keydown", this._handleKeyPress, false);
-      }
-      if (this.props.dismissOnClickOutside) {
-        window.addEventListener("mousedown", this._handleClick, true);
-      }
+      document.addEventListener("keydown", this._handleEvent, false);
+      window.addEventListener("mousedown", this._handleEvent, true);
     }, 0);
   }
 
   componentWillUnmount() {
-    document.removeEventListener("keydown", this._handleKeyPress, false);
-    window.removeEventListener("mousedown", this._handleClick, true);
+    document.removeEventListener("keydown", this._handleEvent, false);
+    window.removeEventListener("mousedown", this._handleEvent, true);
     clearTimeout(this._timeout);
 
     // remove from the stack after a delay, if it is removed through some other
     // means this will happen too early causing parent modal to close
     setTimeout(() => {
-      const index = popoverStack.indexOf(this);
-      if (index >= 0) {
-        popoverStack.splice(index, 1);
-      }
+      removePopoverData(this.popoverData);
     }, 0);
   }
 
-  _handleClick = e => {
-    if (!ReactDOM.findDOMNode(this).contains(e.target)) {
-      setTimeout(this._handleDismissal, 0);
-    }
-  };
-
-  _handleKeyPress = e => {
-    if (e.keyCode === KEYCODE_ESCAPE) {
-      e.preventDefault();
-      this._handleDismissal();
-    }
-  };
-
-  _handleDismissal = e => {
-    // only propagate event for the popover on top of the stack
-    if (this === popoverStack[popoverStack.length - 1]) {
-      this.props.handleDismissal(e);
+  _handleEvent = e => {
+    if (shouldClosePopover(e, this.popoverData)) {
+      this.popoverData.close();
     }
   };
 

--- a/frontend/src/metabase/components/Popover/TippyPopover.info.js
+++ b/frontend/src/metabase/components/Popover/TippyPopover.info.js
@@ -57,7 +57,9 @@ function VisiblePropExample() {
   return (
     <TippyPopover
       visible={visible}
-      onHide={() => setVisible(false)}
+      onHide={() => {
+        setVisible(false);
+      }}
       placement="left-end"
       content={content}
     >

--- a/frontend/src/metabase/hooks/use-sequenced-content-close-handler.ts
+++ b/frontend/src/metabase/hooks/use-sequenced-content-close-handler.ts
@@ -1,0 +1,91 @@
+import { useCallback, useRef } from "react";
+import _ from "underscore";
+
+type PopoverData = {
+  contentEl: Element;
+  close: () => void;
+};
+
+export const RENDERED_POPOVERS: PopoverData[] = [];
+
+function isElement(a: any): a is Element {
+  return a instanceof Element;
+}
+
+function isEventOutsideOfElement(e: Event, el: Element) {
+  return isElement(e.target) && !el.contains(e.target);
+}
+
+export function removePopoverData(popoverData: PopoverData) {
+  const index = RENDERED_POPOVERS.indexOf(popoverData);
+  if (index >= 0) {
+    RENDERED_POPOVERS.splice(index, 1);
+  }
+}
+
+export function shouldClosePopover(
+  e: MouseEvent | KeyboardEvent,
+  popoverData: PopoverData,
+) {
+  const mostRecentPopover = _.last(RENDERED_POPOVERS);
+
+  if (e instanceof MouseEvent) {
+    return (
+      mostRecentPopover &&
+      mostRecentPopover === popoverData &&
+      isEventOutsideOfElement(e, mostRecentPopover.contentEl)
+    );
+  }
+
+  if (e instanceof KeyboardEvent) {
+    return (
+      mostRecentPopover &&
+      mostRecentPopover === popoverData &&
+      e.key === "Escape"
+    );
+  }
+
+  console.warn("Unsupported event type", e);
+  return false;
+}
+
+export default function useSequencedContentCloseHandler() {
+  const popoverDataRef = useRef<PopoverData>();
+
+  const handleEvent = useCallback((e: MouseEvent | KeyboardEvent) => {
+    if (
+      popoverDataRef.current &&
+      shouldClosePopover(e, popoverDataRef.current)
+    ) {
+      popoverDataRef.current.close();
+    }
+  }, []);
+
+  const removeCloseHandler = useCallback(() => {
+    if (popoverDataRef.current) {
+      removePopoverData(popoverDataRef.current);
+      popoverDataRef.current = undefined;
+    }
+
+    document.removeEventListener("mousedown", handleEvent, true);
+    document.removeEventListener("keydown", handleEvent);
+  }, [handleEvent]);
+
+  const setupCloseHandler = useCallback(
+    (contentEl: Element | null, close: () => void) => {
+      removeCloseHandler();
+
+      if (isElement(contentEl)) {
+        const popover = { contentEl, close };
+        RENDERED_POPOVERS.push(popover);
+        popoverDataRef.current = popover;
+
+        document.addEventListener("mousedown", handleEvent, true);
+        window.addEventListener("keydown", handleEvent);
+      }
+    },
+    [handleEvent, removeCloseHandler],
+  );
+
+  return { setupCloseHandler, removeCloseHandler };
+}


### PR DESCRIPTION
Here I'm introducing a new hook that'll eventually totally replace the HOC `OnClickOutsideWrapper`, and I'm adding it to `TippyPopover` to handle outside clicks and Escape key presses.

The `OnClickOutsideWrapper` HOC is used to handle the closing of popovers/modals when a user clicks outside of the popover/modal content or when the user presses the "Escape" key. Previous to this PR, `TippyPopover` popovers couldn't be used in modals because they weren't added to the global array of rendered popovers found in the HOC file. Originally, I intended to try to get away from using anything but the behavior built into tippy but we need to handle  popovers _in_ modals (which don't use tippy) and the sequenced, one-by-one closing of popovers, so it seemed necessary to either rely on `OnClickOutsideWrapper` or rewrite it to be a hook.

I chose to make a new hook. Using a hook instead of an HOC lets us keep the configurable `lazy` prop on `TippyPopover`, and it seems like a decent opportunity to start moving away from some of our code that relies on `ReactDOM.findDOMNode`.

 The functionality here is _mostly_ the same as it was, except that for now I'm seeing if we can get away without implementing:
1. the `setTimeout(..., 0)` calls that wrap some logic in the `OnClickOutsideWrapper` lifecycle methods
2. the `el.parentNode.style.zIndex = popoverStack.length + 2;` hack also found in `OnClickOutsideWrapper`
3. two unused props, `dismissOnEscape` and `dismissOnClickOutside`

I've made it so that `OnClickOutsideWrapper` uses the `RENDERED_POPOVERS` array found in the file for `useSequencedContentCloseHandler`, and I exported a few of the functions used in the hook so that I can use them in `OnClickOutsideWrapper` as well. Besides that, the component should work the same as it did.

Here's a little demo. You can't see the escape presses, but they're what close the two popovers (notably, one that is a tippy popover and one that is a tether popover) at the start of the video:

https://user-images.githubusercontent.com/13057258/153504348-09c34be0-39ce-4d4c-bafc-14f7d0369a1c.mov


