### PR TITLE
Fix parsing of some aggregation functions with no args

### DIFF
--- a/frontend/src/metabase/lib/expressions/diagnostics.js
+++ b/frontend/src/metabase/lib/expressions/diagnostics.js
@@ -1,6 +1,7 @@
 import { t } from "ttag";
 
 import {
+  MBQL_CLAUSES,
   getMBQLName,
   parseDimension,
   parseMetric,
@@ -17,6 +18,7 @@ import {
   useShorthands,
   adjustCase,
   adjustOptions,
+  transformNoArgFunction,
 } from "metabase/lib/expressions/recursive-parser";
 import { tokenize, TOKEN, OPERATOR } from "metabase/lib/expressions/tokenizer";
 
@@ -43,7 +45,9 @@ export function diagnose(source, startRule, query) {
     const token = tokens[i];
     if (token.type === TOKEN.Identifier && source[token.start] !== "[") {
       const functionName = source.slice(token.start, token.end);
-      if (getMBQLName(functionName)) {
+      const fn = getMBQLName(functionName);
+      const clause = fn ? MBQL_CLAUSES[fn] : null;
+      if (clause && clause.args.length > 0) {
         const next = tokens[i + 1];
         if (next.op !== OPERATOR.OpenParenthesis) {
           return {
@@ -121,6 +125,7 @@ function prattCompiler(source, startRule, query) {
       passes: [
         adjustOptions,
         useShorthands,
+        transformNoArgFunction,
         adjustCase,
         expr => resolve(expr, startRule, resolveMBQLField),
       ],

--- a/frontend/src/metabase/lib/expressions/recursive-parser.js
+++ b/frontend/src/metabase/lib/expressions/recursive-parser.js
@@ -303,11 +303,30 @@ export const adjustCase = tree =>
     return node;
   });
 
+// [ "dimension", "count "] becomes ["count"], since Count is a valid no-arg function
+export const transformNoArgFunction = tree =>
+  modify(tree, node => {
+    if (Array.isArray(node)) {
+      const [operator, ...operands] = node;
+      if (operands.length === 1 && operator === "dimension") {
+        const text = operands[0];
+        const fn = getMBQLName(text.trim().toLowerCase());
+
+        // refering a function with no args?
+        if (fn && MBQL_CLAUSES[fn].args.length === 0) {
+          return [fn];
+        }
+      }
+    }
+    return node;
+  });
+
 const pipe = (...fns) => x => fns.reduce((v, f) => f(v), x);
 
 export const parse = pipe(
   recursiveParse,
   adjustOptions,
   useShorthands,
+  transformNoArgFunction,
   adjustCase,
 );

--- a/frontend/src/metabase/lib/expressions/resolver.js
+++ b/frontend/src/metabase/lib/expressions/resolver.js
@@ -48,6 +48,9 @@ const isCompatible = (a, b) => {
   if (a === "aggregation" && b === "number") {
     return true;
   }
+  if (a === "number" && b === "aggregation") {
+    return true;
+  }
   return false;
 };
 

--- a/frontend/test/metabase/lib/expressions/recursive-parser.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/recursive-parser.unit.spec.js
@@ -149,6 +149,11 @@ describe("metabase/lib/expressions/recursive-parser", () => {
     expect(process("A and not X")).toEqual(["and", A, ["not", X]]);
   });
 
+  it("should detect aggregation functions with no argument", () => {
+    expect(process("COUNT/2")).toEqual(["/", ["count"], 2]);
+    expect(process("1+CumulativeCount")).toEqual(["+", 1, ["cum-count"]]);
+  });
+
   it("should resolve segments", () => {
     expect(process("Expensive", "boolean")).toEqual(["segment", "Expensive"]);
     expect(process("NOT LowVolume")).toEqual(["not", ["segment", "LowVolume"]]);


### PR DESCRIPTION
In an expression `COUNT/2`, `COUNT` there should be treated as a function (i.e. `COUNT()`) instead of a field. Another function is the same category is `CUMULATIVECOUNT`.
Both don't require any arguments, hence the parentheses are optional.

Run the unit tests with `yarn test-unit frontend/test/metabase/lib/expressions/`.

To verify manually:
1. New, Question
2. Sample Database, Products table
3. Summarize, Count of rows
4. Click on `Count`, Custom Expression
5. Press `tab` to switch focus (to give it a name)

**Before**

![image](https://user-images.githubusercontent.com/7288/153500822-aa7338f6-dd81-4a1a-8734-9a9ec86b1986.png)

**After**

![image](https://user-images.githubusercontent.com/7288/153500879-c544cc24-c4ed-4adf-9c8c-dd157d1beb5f.png)

## Note

The fix is to add a new post-parsing pass which converts the field reference to `count` or `cumulativecount` to a function call.