### PR TITLE
Permissions UI groundwork

### DIFF
--- a/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditor.styled.js
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditor.styled.js
@@ -2,6 +2,7 @@ import styled from "@emotion/styled";
 
 export const PermissionsEditorRoot = styled.div`
   flex-grow: 1;
-  overflow: auto;
+  position: relative;
+  overflow: hidden;
   padding: 1rem 0 2rem 0;
 `;

--- a/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditorContent.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditorContent.jsx
@@ -15,7 +15,8 @@ import { PermissionsEditorBreadcrumbs } from "./PermissionsEditorBreadcrumbs";
 import {
   EditorEmptyStateContainer,
   EditorFilterContainer,
-  EditorHeaderContainer,
+  PermissionEditorContentRoot,
+  PermissionTableWrapper,
 } from "./PermissionsEditorContent.styled";
 
 export const permissionEditorContentPropTypes = {
@@ -59,48 +60,48 @@ export function PermissionsEditorContent({
   }, [entities, debouncedFilter]);
 
   return (
-    <>
-      <EditorHeaderContainer>
-        <Subhead>
-          {title}{" "}
-          {breadcrumbs && (
-            <PermissionsEditorBreadcrumbs
-              items={breadcrumbs}
-              onBreadcrumbsItemSelect={onBreadcrumbsItemSelect}
-            />
-          )}
-        </Subhead>
-
-        {description && <Text>{description}</Text>}
-
-        <EditorFilterContainer>
-          <TextInput
-            hasClearButton
-            colorScheme="admin"
-            placeholder={filterPlaceholder}
-            onChange={setFilter}
-            value={filter}
-            padding="sm"
-            borderRadius="md"
-            icon={<Icon name="search" size={16} />}
+    <PermissionEditorContentRoot>
+      <Subhead>
+        {title}{" "}
+        {breadcrumbs && (
+          <PermissionsEditorBreadcrumbs
+            items={breadcrumbs}
+            onBreadcrumbsItemSelect={onBreadcrumbsItemSelect}
           />
-        </EditorFilterContainer>
-      </EditorHeaderContainer>
+        )}
+      </Subhead>
 
-      <PermissionsTable
-        horizontalPadding="lg"
-        entities={filteredEntities || entities}
-        columns={columns}
-        onSelect={onSelect}
-        onChange={onChange}
-        onAction={onAction}
-        emptyState={
-          <EditorEmptyStateContainer>
-            <EmptyState message={t`Nothing here`} icon="all" />
-          </EditorEmptyStateContainer>
-        }
-      />
-    </>
+      {description && <Text>{description}</Text>}
+
+      <EditorFilterContainer>
+        <TextInput
+          hasClearButton
+          colorScheme="admin"
+          placeholder={filterPlaceholder}
+          onChange={setFilter}
+          value={filter}
+          padding="sm"
+          borderRadius="md"
+          icon={<Icon name="search" size={16} />}
+        />
+      </EditorFilterContainer>
+
+      <PermissionTableWrapper>
+        <PermissionsTable
+          horizontalPadding="lg"
+          entities={filteredEntities || entities}
+          columns={columns}
+          onSelect={onSelect}
+          onChange={onChange}
+          onAction={onAction}
+          emptyState={
+            <EditorEmptyStateContainer>
+              <EmptyState message={t`Nothing here`} icon="all" />
+            </EditorEmptyStateContainer>
+          }
+        />
+      </PermissionTableWrapper>
+    </PermissionEditorContentRoot>
   );
 }
 

--- a/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditorContent.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditorContent.jsx
@@ -88,7 +88,6 @@ export function PermissionsEditorContent({
 
       <PermissionTableWrapper>
         <PermissionsTable
-          horizontalPadding="lg"
           entities={filteredEntities || entities}
           columns={columns}
           onSelect={onSelect}

--- a/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditorContent.styled.tsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditorContent.styled.tsx
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 
-export const EditorHeaderContainer = styled.div`
-  padding: 0 3rem;
+export const PermissionEditorContentRoot = styled.div`
+  padding-left: 40px;
 `;
 
 export const EditorFilterContainer = styled.div`
@@ -11,4 +11,10 @@ export const EditorFilterContainer = styled.div`
 
 export const EditorEmptyStateContainer = styled.div`
   margin-top: 7.5rem;
+`;
+
+export const PermissionTableWrapper = styled.div`
+  position: relative;
+  overflow: auto;
+  padding-bottom: 20px;
 `;

--- a/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditorContent.styled.tsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditorContent.styled.tsx
@@ -15,6 +15,6 @@ export const EditorEmptyStateContainer = styled.div`
 
 export const PermissionTableWrapper = styled.div`
   position: relative;
-  overflow: auto;
+  overflow-x: auto;
   padding-bottom: 20px;
 `;

--- a/frontend/src/metabase/admin/permissions/components/PermissionsSelect/PermissionsSelect.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsSelect/PermissionsSelect.jsx
@@ -2,8 +2,6 @@ import React, { useState, memo } from "react";
 import PropTypes from "prop-types";
 
 import PopoverWithTrigger from "metabase/components/PopoverWithTrigger";
-import { lighten } from "metabase/lib/colors";
-import Icon from "metabase/components/Icon";
 import Toggle from "metabase/core/components/Toggle";
 import Tooltip from "metabase/components/Tooltip";
 
@@ -21,6 +19,7 @@ import {
   ToggleLabel,
   WarningIcon,
   DisabledPermissionOption,
+  SelectedOption,
 } from "./PermissionsSelect.styled";
 
 const propTypes = {
@@ -66,7 +65,7 @@ export const PermissionsSelect = memo(function PermissionsSelect({
           iconColor="text-light"
         />
       ) : (
-        <PermissionsSelectOption {...selectedOption} />
+        <SelectedOption {...selectedOption} />
       )}
 
       {warning && (
@@ -74,13 +73,6 @@ export const PermissionsSelect = memo(function PermissionsSelect({
           <WarningIcon />
         </Tooltip>
       )}
-
-      <Icon
-        style={{ visibility: isDisabled ? "hidden" : "visible" }}
-        name="chevrondown"
-        size={16}
-        color={lighten("text-light", 0.15)}
-      />
     </PermissionsSelectRoot>
   );
 

--- a/frontend/src/metabase/admin/permissions/components/PermissionsSelect/PermissionsSelect.styled.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsSelect/PermissionsSelect.styled.jsx
@@ -13,6 +13,14 @@ export const PermissionsSelectRoot = styled.div`
   cursor: ${props => (props.isDisabled ? "default" : "pointer")};
 `;
 
+export const SelectedOption = styled(PermissionsSelectOption)`
+  transition: color 200ms;
+
+  &:hover {
+    color: ${color("accent7")};
+  }
+`;
+
 export const PermissionsSelectText = styled(Label)`
   flex-grow: 1;
 `;

--- a/frontend/src/metabase/admin/permissions/components/PermissionsTable/PermissionsTable.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsTable/PermissionsTable.jsx
@@ -26,7 +26,6 @@ const propTypes = {
   onChange: PropTypes.func,
   onAction: PropTypes.func,
   colorScheme: PropTypes.oneOf(["default", "admin"]),
-  horizontalPadding: PropTypes.oneOf(["sm", "lg"]),
 };
 
 export function PermissionsTable({
@@ -35,7 +34,6 @@ export function PermissionsTable({
   onSelect,
   onAction,
   onChange,
-  horizontalPadding = "sm",
   colorScheme,
   emptyState = null,
 }) {
@@ -79,11 +77,7 @@ export function PermissionsTable({
           <tr>
             {columns.map(column => {
               return (
-                <PermissionTableHeaderCell
-                  as="th"
-                  key={column}
-                  horizontalPadding={horizontalPadding}
-                >
+                <PermissionTableHeaderCell key={column}>
                   <ColumnName>{column}</ColumnName>
                 </PermissionTableHeaderCell>
               );
@@ -94,7 +88,7 @@ export function PermissionsTable({
           {entities.map(entity => {
             return (
               <PermissionsTableRow key={entity.id}>
-                <EntityNameCell horizontalPadding={horizontalPadding}>
+                <EntityNameCell>
                   {entity.canSelect ? (
                     <EntityNameLink onClick={() => onSelect(entity)}>
                       {entity.name}
@@ -112,10 +106,7 @@ export function PermissionsTable({
 
                 {entity.permissions.map(permission => {
                   return (
-                    <PermissionsTableCell
-                      key={permission.name}
-                      horizontalPadding={horizontalPadding}
-                    >
+                    <PermissionsTableCell key={permission.name}>
                       <PermissionsSelect
                         {...permission}
                         onChange={(value, toggleState) =>

--- a/frontend/src/metabase/admin/permissions/components/PermissionsTable/PermissionsTable.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsTable/PermissionsTable.jsx
@@ -1,7 +1,6 @@
 import React, { useState, useRef } from "react";
 import PropTypes from "prop-types";
 
-import Label from "metabase/components/type/Label";
 import Tooltip from "metabase/components/Tooltip";
 import Modal from "metabase/components/Modal";
 import ConfirmContent from "metabase/components/ConfirmContent";
@@ -11,10 +10,12 @@ import {
   PermissionsTableRoot,
   PermissionsTableRow,
   PermissionsTableCell,
+  PermissionTableHeaderCell,
   EntityNameCell,
   EntityNameLink,
   EntityName,
   HintIcon,
+  ColumnName,
 } from "./PermissionsTable.styled";
 
 const propTypes = {
@@ -72,23 +73,21 @@ export function PermissionsTable({
   const hasItems = entities.length > 0;
 
   return (
-    <React.Fragment>
+    <>
       <PermissionsTableRoot data-testid="permission-table">
         <thead>
           <tr>
             {columns.map(column => {
               return (
-                <PermissionsTableCell
+                <PermissionTableHeaderCell
+                  as="th"
                   key={column}
                   horizontalPadding={horizontalPadding}
                 >
-                  <Label>{column}</Label>
-                </PermissionsTableCell>
+                  <ColumnName>{column}</ColumnName>
+                </PermissionTableHeaderCell>
               );
             })}
-            <PermissionsTableCell
-              style={{ width: "100%", minWidth: "unset" }}
-            />
           </tr>
         </thead>
         <tbody>
@@ -145,7 +144,7 @@ export function PermissionsTable({
           />
         </Modal>
       )}
-    </React.Fragment>
+    </>
   );
 }
 

--- a/frontend/src/metabase/admin/permissions/components/PermissionsTable/PermissionsTable.styled.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsTable/PermissionsTable.styled.jsx
@@ -19,9 +19,18 @@ export const PermissionsTableCell = styled.td`
     min-width: 300px;
     background: white;
     left: 0;
+    top: 0;
     position: sticky;
     padding-left: 0;
-    border-right: 1px solid ${alpha(color("border"), 0.5)};
+
+    &:after {
+      position: absolute;
+      right: 0;
+      top: 0;
+      height: 100%;
+      border-right: 1px solid ${alpha(color("border"), 0.5)};
+      content: " ";
+    }
   }
 `;
 
@@ -29,7 +38,9 @@ export const PermissionTableHeaderCell = styled(
   PermissionsTableCell.withComponent("th"),
 )`
   &:first-of-type {
-    border-right: none;
+    &:after {
+      display: none;
+    }
   }
 `;
 
@@ -39,7 +50,6 @@ export const PermissionsTableRow = styled.tr`
 `;
 
 export const EntityNameCell = styled(PermissionsTableCell)`
-  display: flex;
   align-items: center;
 `;
 

--- a/frontend/src/metabase/admin/permissions/components/PermissionsTable/PermissionsTable.styled.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsTable/PermissionsTable.styled.jsx
@@ -3,35 +3,42 @@ import styled from "@emotion/styled";
 import { color, alpha, lighten } from "metabase/lib/colors";
 import Link from "metabase/core/components/Link";
 import Icon from "metabase/components/Icon";
-
-const HORIZONTAL_PADDING_VARIANTS = {
-  sm: "0.5rem",
-  lg: "3rem",
-};
+import Label from "metabase/components/type/Label";
 
 export const PermissionsTableRoot = styled.table`
   border-collapse: collapse;
-  width: 100%;
+`;
+
+export const PermissionsTableCell = styled.td`
+  vertical-align: center;
+  padding: 0.625rem 2rem;
+  box-sizing: border-box;
+  min-height: 40px;
+
+  &:first-of-type {
+    min-width: 300px;
+    background: white;
+    left: 0;
+    position: sticky;
+    padding-left: 0;
+    border-right: 1px solid ${alpha(color("border"), 0.5)};
+  }
+`;
+
+export const PermissionTableHeaderCell = styled(
+  PermissionsTableCell.withComponent("th"),
+)`
+  &:first-of-type {
+    border-right: none;
+  }
 `;
 
 export const PermissionsTableRow = styled.tr`
   border-top: 1px solid ${alpha(color("border"), 0.5)};
-`;
-
-export const PermissionsTableCell = styled.td`
-  padding: 0.5rem 1rem;
-  width: auto;
-  min-width: 220px;
-
-  &:first-of-type {
-    max-width: 340px;
-    padding: 0.5rem
-      ${props => HORIZONTAL_PADDING_VARIANTS[props.horizontalPadding]};
-  }
+  border-bottom: 1px solid ${alpha(color("border"), 0.5)};
 `;
 
 export const EntityNameCell = styled(PermissionsTableCell)`
-  min-width: 280px;
   display: flex;
   align-items: center;
 `;
@@ -58,3 +65,8 @@ HintIcon.defaultProps = {
   name: "info",
   size: 12,
 };
+
+export const ColumnName = styled(Label)`
+  display: inline;
+  margin: 0;
+`;


### PR DESCRIPTION
## Changes

- slightly tweak UI according to [figma](https://www.figma.com/file/jrJFMiVRWPoYLJ4zFIc0sU/Feature-level-permissions?node-id=5%3A990)
- make permission editor horizontally scrollable with the fixed first column
- ~open permission menu on hover instead of click~ — we decided to keep click as a trigger

## How to verify
- [Open Permissions Editor](http://localhost:3000/admin/permissions/data/group/1)
- Ensure it looks like on the mockups
- Shrink the window and ensure the permissions table scrolls horizontally 