### PR TITLE
BigQuery should qualify columns from source query with `source` in the `SELECT` clause

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
@@ -511,12 +511,8 @@
     ;; if the Field is from a join or source table, record this fact so that we know never to qualify it with the
     ;; project ID no matter what
     (binding [*field-is-from-join-or-source-query?* (not (integer? source-table))]
-      ;; if this Field is from a source table DO NOT qualify it at all.
-      (let [field-clause (cond-> field-clause
-                           (= source-table ::add/source)
-                           (mbql.u/update-field-options assoc ::add/source-table ::add/none))]
-        (-> (parent-method driver field-clause)
-            (with-temporal-type (temporal-type field-clause)))))))
+      (-> (parent-method driver field-clause)
+          (with-temporal-type (temporal-type field-clause))))))
 
 (defmethod sql.qp/->honeysql [:bigquery-cloud-sdk :relative-datetime]
   [driver clause]

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
@@ -787,11 +787,11 @@
                                     :breakout     [!month.date]}
                      :limit        2})]
         (mt/with-native-query-testing-context query
-          (is (sql= {:select   '[count        AS count
-                                 count (*)    AS count_2]
+          (is (sql= {:select   '[source.count  AS count
+                                 count (*)     AS count_2]
                      :from     [(let [prefix (project-id-prefix-if-set)]
                                   {:select   ['date_trunc (list (symbol (str prefix 'v3_test_data.checkins.date)) 'month) 'AS 'date
-                                              'source.count '(*)                                                          'AS 'count]
+                                              'count '(*)                                                                 'AS 'count]
                                    :from     [(symbol (str prefix 'v3_test_data.checkins))]
                                    :group-by '[date]
                                    :order-by '[date ASC]})

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
@@ -791,7 +791,7 @@
                                  count (*)    AS count_2]
                      :from     [(let [prefix (project-id-prefix-if-set)]
                                   {:select   ['date_trunc (list (symbol (str prefix 'v3_test_data.checkins.date)) 'month) 'AS 'date
-                                              'count '(*)                                                                 'AS 'count]
+                                              'source.count '(*)                                                          'AS 'count]
                                    :from     [(symbol (str prefix 'v3_test_data.checkins))]
                                    :group-by '[date]
                                    :order-by '[date ASC]})
@@ -819,17 +819,20 @@
                                              {:name "CE", :display-name "CE"}]]
                               :limit       10}))))))))
 
-
 (deftest no-qualify-breakout-field-name-with-subquery-test
   (mt/test-driver :bigquery-cloud-sdk
-    (testing "Breakout field name is not qualified if it is from source query (#18742)"
-      (is (sql= '{:select   [source    AS source
-                             count (*) AS count]
-                  :from     [(select 1 as val "2" as source)
-                             source]
-                  :group-by [source]
-                  :order-by [source ASC]}
-                (mt/mbql-query checkins
-                  {:aggregation  [[:count]]
-                   :breakout     [[:field "source" {:base-type :type/Text}]],
-                   :source-query {:native "select 1 as `val`, '2' as `source`"}}))))))
+    (testing "Make sure columns name `source` in source query work correctly (#18742)"
+      (let [query (mt/mbql-query checkins
+                    {:aggregation  [[:count]]
+                     :breakout     [[:field "source" {:base-type :type/Text}]],
+                     :source-query {:native "select 1 as `val`, '2' as `source`"}})]
+        (is (sql= '{:select   [source.source    AS source
+                               count (*)        AS count]
+                    :from     [(select 1 as val "2" as source)
+                               source]
+                    :group-by [source]
+                    :order-by [source ASC]}
+                  query))
+        (mt/with-native-query-testing-context query
+          (is (= [["2" 1]]
+                 (mt/rows (qp/process-query query)))))))))

--- a/test/metabase/query_processor_test/explicit_joins_test.clj
+++ b/test/metabase/query_processor_test/explicit_joins_test.clj
@@ -691,8 +691,7 @@
 
 (deftest join-against-multiple-saved-questions-with-same-column-test
   (testing "Should be able to join multiple against saved questions on the same column (#15863, #20362, #20413)"
-    ;; not fixing this for the deprecated `:bigquery` driver. You better just upgrade.
-    (mt/test-drivers (disj (mt/normal-drivers-with-feature :nested-queries :left-join) :bigquery)
+    (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries :left-join)
       (mt/dataset sample-dataset
         (let [q1         (mt/mbql-query products {:breakout [$category], :aggregation [[:count]]})
               q2         (mt/mbql-query products {:breakout [$category], :aggregation [[:sum $price]]})

--- a/test/metabase/query_processor_test/explicit_joins_test.clj
+++ b/test/metabase/query_processor_test/explicit_joins_test.clj
@@ -691,7 +691,8 @@
 
 (deftest join-against-multiple-saved-questions-with-same-column-test
   (testing "Should be able to join multiple against saved questions on the same column (#15863, #20362, #20413)"
-    (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries :left-join)
+    ;; not fixing this for the deprecated `:bigquery` driver. You better just upgrade.
+    (mt/test-drivers (disj (mt/normal-drivers-with-feature :nested-queries :left-join) :bigquery)
       (mt/dataset sample-dataset
         (let [q1         (mt/mbql-query products {:breakout [$category], :aggregation [[:count]]})
               q2         (mt/mbql-query products {:breakout [$category], :aggregation [[:sum $price]]})


### PR DESCRIPTION
Fixes #20362
~Fixxes #20413~

This was caused by a misunderstaning on our part. In #18772 (to fixx #18742) we removed the `source` alias columns in the source query specifically for BigQuery. With some of the recent changes I made this ended up happening more consistently which broke queries.

This is actually the wrong behavior. We should always be qualifying stuff with `source` in the `SELECT` clause, but nowhere else, which we're already doing. By removing the special casing things now work as expected.