### PR TITLE
use column settings instead of display_name for pivot table value header

### DIFF
--- a/frontend/src/metabase/lib/data_grid.js
+++ b/frontend/src/metabase/lib/data_grid.js
@@ -2,7 +2,7 @@ import _ from "underscore";
 import { getIn } from "icepick";
 import { t } from "ttag";
 
-import { formatValue } from "metabase/lib/formatting";
+import { formatValue, formatColumn } from "metabase/lib/formatting";
 
 export function isPivotGroupColumn(col) {
   return col.name === "pivot-grouping";
@@ -141,7 +141,10 @@ export function multiLevelPivot(data, settings) {
   const columnIndex = addEmptyIndexItem(
     formattedColumnTreeWithoutValues.flatMap(root => enumeratePaths(root)),
   );
-  const valueColumns = valueColumnIndexes.map(index => columns[index]);
+  const valueColumns = valueColumnIndexes.map(index => [
+    columns[index],
+    columnSettings[index],
+  ]);
   const formattedColumnTree = addValueColumnNodes(
     formattedColumnTreeWithoutValues,
     valueColumns,
@@ -334,11 +337,13 @@ function formatValuesInTree(
 // We display the value column names if there are multiple
 // or if there are no columns pivoted to the top header.
 function addValueColumnNodes(nodes, valueColumns) {
-  const leafNodes = valueColumns.map(column => ({
-    value: column.display_name,
-    children: [],
-    isValueColumn: true,
-  }));
+  const leafNodes = valueColumns.map(([column, columnSettings]) => {
+    return {
+      value: columnSettings.column_title || formatColumn(column),
+      children: [],
+      isValueColumn: true,
+    };
+  });
   if (nodes.length === 0) {
     return leafNodes;
   }


### PR DESCRIPTION
Fixes #15353 

We were using the column's `display_name` instead of what is set as the `column_title` in column settings. Not 100% but I think the fallback usage of `formatColumn(column)` will just default to `column.display_name` here, but figured it wouldn't hurt to use it instead of `column.display_name`

**Testing**
Follow the repro steps in #15353 


https://user-images.githubusercontent.com/13057258/153515465-4dc0bf31-e2b7-44a0-bb71-f21e7344ee9f.mov


