### PR TITLE
Simplify tests by improving custom `cy.createQuestion` command

### DIFF
--- a/frontend/test/__support__/e2e/commands/api/question.js
+++ b/frontend/test/__support__/e2e/commands/api/question.js
@@ -94,7 +94,8 @@ function question(
     if (loadMetadata || visitQuestion) {
       dataset
         ? cy.intercept("POST", `/api/dataset`).as("dataset")
-        : cy.intercept("POST", `/api/card/${body.id}/query`).as("cardQuery");
+        : // We need to use the wildcard becase endpoint for pivot tables has the following format: `/api/card/pivot/${id}/query`
+          cy.intercept("POST", `/api/card/**/${body.id}/query`).as("cardQuery");
 
       const url = dataset ? `/model/${body.id}` : `/question/${body.id}`;
       cy.visit(url);

--- a/frontend/test/__support__/e2e/commands/api/question.js
+++ b/frontend/test/__support__/e2e/commands/api/question.js
@@ -38,6 +38,8 @@ Cypress.Commands.add(
  * @param {object} customOptions
  * @param {boolean} customOptions.loadMetadata - Whether to visit the question in order to load its metadata.
  * @param {boolean} customOptions.visitQuestion - Whether to visit the question after the creation or not.
+ * @param {boolean} customOptions.wrapId - Whether to wrap a question id, to make it available outside of this scope.
+ * @param {string} customOptions.idAlias - Alias a question id in order to use it later with `cy.get("@" + alias).
  */
 function question(
   type,
@@ -53,7 +55,12 @@ function question(
     collection_id,
     collection_position,
   } = {},
-  { loadMetadata = false, visitQuestion = false } = {},
+  {
+    loadMetadata = false,
+    visitQuestion = false,
+    wrapId = false,
+    idAlias = "questionId",
+  } = {},
 ) {
   cy.request("POST", "/api/card", {
     name,
@@ -68,6 +75,18 @@ function question(
     collection_id,
     collection_position,
   }).then(({ body }) => {
+    /**
+     * Optionally, if you need question's id later in the test, outside the scope of this function,
+     * you can use it like this:
+     *
+     * `cy.get("@questionId").then(id=> {
+     *   doSomethingWith(id);
+     * })
+     */
+    if (wrapId) {
+      cy.wrap(body.id).as(idAlias);
+    }
+
     if (dataset) {
       cy.request("PUT", `/api/card/${body.id}`, { dataset });
     }

--- a/frontend/test/metabase/scenarios/admin/datamodel/metadata.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/metadata.cy.spec.js
@@ -86,23 +86,24 @@ describe("scenarios > admin > datamodel > metadata", () => {
       semantic_type: null,
     });
 
-    cy.createQuestion({
-      name: "14124",
-      query: {
-        "source-table": ORDERS_ID,
-        aggregation: [["count"]],
-        breakout: [
-          ["field", ORDERS.CREATED_AT, { "temporal-unit": "hour-of-day" }],
-        ],
+    cy.createQuestion(
+      {
+        name: "14124",
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: [["count"]],
+          breakout: [
+            ["field", ORDERS.CREATED_AT, { "temporal-unit": "hour-of-day" }],
+          ],
+        },
       },
-    }).then(({ body: { id: QUESTION_ID } }) => {
-      cy.visit(`/question/${QUESTION_ID}`);
+      { visitQuestion: true },
+    );
 
-      cy.findByText("Created At: Hour of day");
+    cy.findByText("Created At: Hour of day");
 
-      cy.log("Reported failing in v0.37.2");
-      cy.findByText(/^3:00 AM$/);
-    });
+    cy.log("Reported failing in v0.37.2");
+    cy.findByText(/^3:00 AM$/);
   });
 
   it("should not display multiple 'Created At' fields when they are remapped to PK/FK (metabase#15563)", () => {

--- a/frontend/test/metabase/scenarios/admin/settings/localization.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/localization.cy.spec.js
@@ -79,36 +79,38 @@ describe("scenarios > admin > localization", () => {
   // TODO:
   //  - Keep an eye on this test in CI and update the week range as needed.
   it("should respect start of the week in SQL questions with filters (metabase#14294)", () => {
-    cy.createNativeQuestion({
-      name: "14294",
-      native: {
-        query:
-          "select ID, CREATED_AT, dayname(CREATED_AT) as CREATED_AT_DAY\nfrom ORDERS \n[[where {{date_range}}]]\norder by CREATED_AT",
-        "template-tags": {
-          date_range: {
-            id: "93961154-c3d5-7c93-7b59-f4e494fda499",
-            name: "date_range",
-            "display-name": "Date range",
-            type: "dimension",
-            dimension: ["field", ORDERS.CREATED_AT, null],
-            "widget-type": "date/all-options",
-            default: "past220weeks",
-            required: true,
+    cy.createNativeQuestion(
+      {
+        name: "14294",
+        native: {
+          query:
+            "select ID, CREATED_AT, dayname(CREATED_AT) as CREATED_AT_DAY\nfrom ORDERS \n[[where {{date_range}}]]\norder by CREATED_AT",
+          "template-tags": {
+            date_range: {
+              id: "93961154-c3d5-7c93-7b59-f4e494fda499",
+              name: "date_range",
+              "display-name": "Date range",
+              type: "dimension",
+              dimension: ["field", ORDERS.CREATED_AT, null],
+              "widget-type": "date/all-options",
+              default: "past220weeks",
+              required: true,
+            },
           },
         },
       },
-    }).then(({ body: { id: QUESTION_ID } }) => {
-      cy.visit(`/question/${QUESTION_ID}`);
-      cy.get(".TableInteractive-header")
-        .next()
-        .as("resultTable");
+      { visitQuestion: true },
+    );
 
-      cy.get("@resultTable").within(() => {
-        // The third cell in the first row (CREATED_AT_DAY)
-        cy.get(".cellData")
-          .eq(2)
-          .should("not.contain", "Sunday");
-      });
+    cy.get(".TableInteractive-header")
+      .next()
+      .as("resultTable");
+
+    cy.get("@resultTable").within(() => {
+      // The third cell in the first row (CREATED_AT_DAY)
+      cy.get(".cellData")
+        .eq(2)
+        .should("not.contain", "Sunday");
     });
   });
 

--- a/frontend/test/metabase/scenarios/custom-column/custom-column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/custom-column.cy.spec.js
@@ -151,36 +151,30 @@ describe("scenarios > question > custom column", () => {
 
     cy.signInAsAdmin();
 
-    cy.createQuestion({
-      name: "13857",
-      query: {
-        expressions: {
-          [CC_NAME]: ["*", ["field-literal", CE_NAME, "type/Float"], 1234],
-        },
-        "source-query": {
-          aggregation: [
-            [
-              "aggregation-options",
-              ["*", 1, 1],
-              { name: CE_NAME, "display-name": CE_NAME },
+    cy.createQuestion(
+      {
+        name: "13857",
+        query: {
+          expressions: {
+            [CC_NAME]: ["*", ["field-literal", CE_NAME, "type/Float"], 1234],
+          },
+          "source-query": {
+            aggregation: [
+              [
+                "aggregation-options",
+                ["*", 1, 1],
+                { name: CE_NAME, "display-name": CE_NAME },
+              ],
             ],
-          ],
-          breakout: [
-            ["datetime-field", ["field-id", ORDERS.CREATED_AT], "month"],
-          ],
-          "source-table": ORDERS_ID,
+            breakout: [
+              ["datetime-field", ["field-id", ORDERS.CREATED_AT], "month"],
+            ],
+            "source-table": ORDERS_ID,
+          },
         },
       },
-    }).then(({ body: { id: QUESTION_ID } }) => {
-      cy.intercept("POST", `/api/card/${QUESTION_ID}/query`).as("cardQuery");
-
-      cy.visit(`/question/${QUESTION_ID}`);
-
-      cy.log("Reported failing v0.34.3 through v0.37.2");
-      cy.wait("@cardQuery").then(xhr => {
-        expect(xhr.response.body.error).not.to.exist;
-      });
-    });
+      { visitQuestion: true },
+    );
 
     cy.findByText(CC_NAME);
   });
@@ -189,119 +183,120 @@ describe("scenarios > question > custom column", () => {
     const CC_NAME = "OneisOne";
     cy.signInAsAdmin();
 
-    cy.createQuestion({
-      name: "14080",
-      query: {
-        "source-table": ORDERS_ID,
-        expressions: { [CC_NAME]: ["*", 1, 1] },
-        aggregation: [
-          [
-            "distinct",
+    cy.createQuestion(
+      {
+        name: "14080",
+        query: {
+          "source-table": ORDERS_ID,
+          expressions: { [CC_NAME]: ["*", 1, 1] },
+          aggregation: [
             [
-              "fk->",
-              ["field-id", ORDERS.PRODUCT_ID],
-              ["field-id", PRODUCTS.ID],
+              "distinct",
+              [
+                "fk->",
+                ["field-id", ORDERS.PRODUCT_ID],
+                ["field-id", PRODUCTS.ID],
+              ],
             ],
+            ["sum", ["expression", CC_NAME]],
           ],
-          ["sum", ["expression", CC_NAME]],
-        ],
-        breakout: [["datetime-field", ["field-id", ORDERS.CREATED_AT], "year"]],
+          breakout: [
+            ["datetime-field", ["field-id", ORDERS.CREATED_AT], "year"],
+          ],
+        },
+        display: "line",
       },
-      display: "line",
-    }).then(({ body: { id: QUESTION_ID } }) => {
-      cy.intercept("POST", `/api/card/${QUESTION_ID}/query`).as("cardQuery");
+      { visitQuestion: true },
+    );
 
-      cy.visit(`/question/${QUESTION_ID}`);
-
-      cy.log("Regression since v0.37.1 - it works on v0.37.0");
-      cy.wait("@cardQuery").then(xhr => {
-        expect(xhr.response.body.error).not.to.exist;
-      });
-    });
+    cy.log("Regression since v0.37.1 - it works on v0.37.0");
 
     cy.contains(`Sum of ${CC_NAME}`);
     cy.get(".Visualization .dot").should("have.length.of.at.least", 8);
   });
 
   it.skip("should create custom column after aggregation with 'cum-sum/count' (metabase#13634)", () => {
-    cy.createQuestion({
-      name: "13634",
-      query: {
-        expressions: { "Foo Bar": ["+", 57910, 1] },
-        "source-query": {
-          aggregation: [["cum-count"]],
-          breakout: [
-            ["datetime-field", ["field-id", ORDERS.CREATED_AT], "month"],
-          ],
-          "source-table": ORDERS_ID,
+    cy.createQuestion(
+      {
+        name: "13634",
+        query: {
+          expressions: { "Foo Bar": ["+", 57910, 1] },
+          "source-query": {
+            aggregation: [["cum-count"]],
+            breakout: [
+              ["datetime-field", ["field-id", ORDERS.CREATED_AT], "month"],
+            ],
+            "source-table": ORDERS_ID,
+          },
         },
       },
-    }).then(({ body: { id: questionId } }) => {
-      cy.visit(`/question/${questionId}`);
-      cy.findByText("13634");
+      { visitQuestion: true },
+    );
 
-      cy.log("Reported failing in v0.34.3, v0.35.4, v0.36.8.2, v0.37.0.2");
-      cy.findByText("Foo Bar");
-      cy.findAllByText("57911");
-    });
+    cy.findByText("13634");
+
+    cy.log("Reported failing in v0.34.3, v0.35.4, v0.36.8.2, v0.37.0.2");
+    cy.findByText("Foo Bar");
+    cy.findAllByText("57911");
   });
 
   it.skip("should not be dropped if filter is changed after aggregation (metaabase#14193)", () => {
     const CC_NAME = "Double the fun";
 
-    cy.createQuestion({
-      name: "14193",
-      query: {
-        "source-query": {
-          "source-table": ORDERS_ID,
-          filter: [">", ["field-id", ORDERS.SUBTOTAL], 0],
-          aggregation: [["sum", ["field-id", ORDERS.TOTAL]]],
-          breakout: [
-            ["datetime-field", ["field-id", ORDERS.CREATED_AT], "year"],
-          ],
-        },
-        expressions: {
-          [CC_NAME]: ["*", ["field-literal", "sum", "type/Float"], 2],
+    cy.createQuestion(
+      {
+        name: "14193",
+        query: {
+          "source-query": {
+            "source-table": ORDERS_ID,
+            filter: [">", ["field-id", ORDERS.SUBTOTAL], 0],
+            aggregation: [["sum", ["field-id", ORDERS.TOTAL]]],
+            breakout: [
+              ["datetime-field", ["field-id", ORDERS.CREATED_AT], "year"],
+            ],
+          },
+          expressions: {
+            [CC_NAME]: ["*", ["field-literal", "sum", "type/Float"], 2],
+          },
         },
       },
-    }).then(({ body: { id: QUESTION_ID } }) => {
-      cy.visit(`/question/${QUESTION_ID}`);
+      { visitQuestion: true },
+    );
+    // Test displays collapsed filter - click on number 1 to expand and show the filter name
+    cy.icon("filter")
+      .parent()
+      .contains("1")
+      .click();
 
-      // Test displays collapsed filter - click on number 1 to expand and show the filter name
-      cy.icon("filter")
-        .parent()
-        .contains("1")
-        .click();
+    cy.findByText(/Subtotal is greater than 0/i)
+      .parent()
+      .find(".Icon-close")
+      .click();
 
-      cy.findByText(/Subtotal is greater than 0/i)
-        .parent()
-        .find(".Icon-close")
-        .click();
-
-      cy.findByText(CC_NAME);
-    });
+    cy.findByText(CC_NAME);
   });
 
   it("should handle identical custom column and table column names (metabase#14255)", () => {
     // Uppercase is important for this reproduction on H2
     const CC_NAME = "CATEGORY";
 
-    cy.createQuestion({
-      name: "14255",
-      query: {
-        "source-table": PRODUCTS_ID,
-        expressions: {
-          [CC_NAME]: ["concat", ["field-id", PRODUCTS.CATEGORY], "2"],
+    cy.createQuestion(
+      {
+        name: "14255",
+        query: {
+          "source-table": PRODUCTS_ID,
+          expressions: {
+            [CC_NAME]: ["concat", ["field-id", PRODUCTS.CATEGORY], "2"],
+          },
+          aggregation: [["count"]],
+          breakout: [["expression", CC_NAME]],
         },
-        aggregation: [["count"]],
-        breakout: [["expression", CC_NAME]],
       },
-    }).then(({ body: { id: QUESTION_ID } }) => {
-      cy.visit(`/question/${QUESTION_ID}`);
+      { visitQuestion: true },
+    );
 
-      cy.findByText(CC_NAME);
-      cy.findByText("Gizmo2");
-    });
+    cy.findByText(CC_NAME);
+    cy.findByText("Gizmo2");
   });
 
   it.skip("should drop custom column (based on a joined field) when a join is removed (metabase#14775)", () => {

--- a/frontend/test/metabase/scenarios/dashboard/x-rays.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/x-rays.cy.spec.js
@@ -44,49 +44,47 @@ describe("scenarios > x-rays", () => {
   it.skip("should work on questions with explicit joins (metabase#13112)", () => {
     const PRODUCTS_ALIAS = "Products";
 
-    cy.createQuestion({
-      name: "13112",
-      query: {
-        "source-table": ORDERS_ID,
-        joins: [
-          {
-            fields: "all",
-            "source-table": PRODUCTS_ID,
-            condition: [
-              "=",
-              ["field", ORDERS.PRODUCT_ID, null],
-              ["field", PRODUCTS.ID, { "join-alias": PRODUCTS_ALIAS }],
-            ],
-            alias: PRODUCTS_ALIAS,
-          },
-        ],
-        aggregation: [["count"]],
-        breakout: [
-          ["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }],
-          ["field", PRODUCTS.CATEGORY, { "join-alias": PRODUCTS_ALIAS }],
-        ],
+    cy.createQuestion(
+      {
+        name: "13112",
+        query: {
+          "source-table": ORDERS_ID,
+          joins: [
+            {
+              fields: "all",
+              "source-table": PRODUCTS_ID,
+              condition: [
+                "=",
+                ["field", ORDERS.PRODUCT_ID, null],
+                ["field", PRODUCTS.ID, { "join-alias": PRODUCTS_ALIAS }],
+              ],
+              alias: PRODUCTS_ALIAS,
+            },
+          ],
+          aggregation: [["count"]],
+          breakout: [
+            ["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }],
+            ["field", PRODUCTS.CATEGORY, { "join-alias": PRODUCTS_ALIAS }],
+          ],
+        },
+        display: "line",
       },
-      display: "line",
-    }).then(({ body: { id: QUESTION_ID } }) => {
-      cy.server();
-      cy.route("POST", `/api/card/${QUESTION_ID}/query`).as("cardQuery");
-      cy.route("POST", "/api/dataset").as("dataset");
+      { visitQuestion: true },
+    );
 
-      cy.visit(`/question/${QUESTION_ID}`);
+    cy.intercept("POST", "/api/dataset").as("dataset");
 
-      cy.wait("@cardQuery");
-      cy.get(".dot")
-        .eq(23) // Random dot
-        .click({ force: true });
-      cy.findByText("X-ray").click();
+    cy.get(".dot")
+      .eq(23) // Random dot
+      .click({ force: true });
+    cy.findByText("X-ray").click();
 
-      // x-rays take long time even locally - that can timeout in CI so we have to extend it
-      cy.wait("@dataset", { timeout: 30000 });
-      cy.findByText(
-        "A closer look at number of Orders where Created At is in March 2018 and Category is Gadget",
-      );
-      cy.icon("warning").should("not.exist");
-    });
+    // x-rays take long time even locally - that can timeout in CI so we have to extend it
+    cy.wait("@dataset", { timeout: 30000 });
+    cy.findByText(
+      "A closer look at number of Orders where Created At is in March 2018 and Category is Gadget",
+    );
+    cy.icon("warning").should("not.exist");
   });
 
   ["X-ray", "Compare to the rest"].forEach(action => {

--- a/frontend/test/metabase/scenarios/downloads/reproductions/10803-timestamp-formatting.cy.spec.js
+++ b/frontend/test/metabase/scenarios/downloads/reproductions/10803-timestamp-formatting.cy.spec.js
@@ -15,21 +15,17 @@ describe("issue 10803", () => {
     restore();
     cy.signInAsAdmin();
 
-    cy.createNativeQuestion({
-      name: "10803",
-      native: {
-        query:
-          "SELECT PARSEDATETIME('2020-06-03', 'yyyy-MM-dd') AS \"birth_date\", PARSEDATETIME('2020-06-03 23:41:23', 'yyyy-MM-dd hh:mm:ss') AS \"created_at\"",
-        "template-tags": {},
+    cy.createNativeQuestion(
+      {
+        name: "10803",
+        native: {
+          query:
+            "SELECT PARSEDATETIME('2020-06-03', 'yyyy-MM-dd') AS \"birth_date\", PARSEDATETIME('2020-06-03 23:41:23', 'yyyy-MM-dd hh:mm:ss') AS \"created_at\"",
+          "template-tags": {},
+        },
       },
-    }).then(({ body }) => {
-      questionId = body.id;
-
-      cy.intercept("POST", `/api/card/${questionId}/query`).as("cardQuery");
-      cy.visit(`/question/${questionId}`);
-
-      cy.wait("@cardQuery");
-    });
+      { loadMetadata: true },
+    );
   });
 
   testCases.forEach(fileType => {

--- a/frontend/test/metabase/scenarios/downloads/reproductions/10803-timestamp-formatting.cy.spec.js
+++ b/frontend/test/metabase/scenarios/downloads/reproductions/10803-timestamp-formatting.cy.spec.js
@@ -4,8 +4,6 @@ import {
   runNativeQuery,
 } from "__support__/e2e/cypress";
 
-let questionId;
-
 const testCases = ["csv", "xlsx"];
 
 describe("issue 10803", () => {
@@ -21,19 +19,20 @@ describe("issue 10803", () => {
         native: {
           query:
             "SELECT PARSEDATETIME('2020-06-03', 'yyyy-MM-dd') AS \"birth_date\", PARSEDATETIME('2020-06-03 23:41:23', 'yyyy-MM-dd hh:mm:ss') AS \"created_at\"",
-          "template-tags": {},
         },
       },
-      { loadMetadata: true },
+      { visitQuestion: true, wrapId: true },
     );
   });
 
   testCases.forEach(fileType => {
     it(`should format the date properly for ${fileType} in saved questions (metabase#10803)`, () => {
-      downloadAndAssert(
-        { fileType, questionId, logResults: true, raw: true },
-        testWorkbookDatetimes,
-      );
+      cy.get("@questionId").then(questionId => {
+        downloadAndAssert(
+          { fileType, questionId, logResults: true, raw: true },
+          testWorkbookDatetimes,
+        );
+      });
     });
 
     it(`should format the date properly for ${fileType} in unsaved questions`, () => {

--- a/frontend/test/metabase/scenarios/downloads/reproductions/19889-native-query-export-column-order.cy.spec.js
+++ b/frontend/test/metabase/scenarios/downloads/reproductions/19889-native-query-export-column-order.cy.spec.js
@@ -16,22 +16,18 @@ describe("issue 19889", () => {
     restore();
     cy.signInAsAdmin();
 
-    cy.createNativeQuestion(questionDetails).then(({ body: { id } }) => {
-      cy.wrap(id).as("questionId");
-
-      cy.intercept("POST", `/api/card/${id}/query`).as("cardQuery");
-      cy.visit(`/question/${id}`);
-
-      cy.wait("@cardQuery");
-
-      // Reorder columns a and b
-      cy.findByText("column a")
-        .trigger("mousedown", 0, 0, { force: true })
-        .trigger("mousemove", 5, 5, { force: true })
-        .trigger("mousemove", 100, 0, { force: true })
-        .trigger("mouseup", 100, 0, { force: true });
-      cy.findByText("Started from").click(); // Give DOM some time to update
+    cy.createNativeQuestion(questionDetails, {
+      loadMetadata: true,
+      wrapId: true,
     });
+
+    // Reorder columns a and b
+    cy.findByText("column a")
+      .trigger("mousedown", 0, 0, { force: true })
+      .trigger("mousemove", 5, 5, { force: true })
+      .trigger("mousemove", 100, 0, { force: true })
+      .trigger("mouseup", 100, 0, { force: true });
+    cy.findByText("Started from").click(); // Give DOM some time to update
   });
 
   testCases.forEach(fileType => {

--- a/frontend/test/metabase/scenarios/joins/joins-2.cy.spec.js
+++ b/frontend/test/metabase/scenarios/joins/joins-2.cy.spec.js
@@ -382,39 +382,34 @@ describe("scenarios > question > joined questions", () => {
     });
 
     it("should be able to do subsequent aggregation on a custom expression (metabase#14649)", () => {
-      cy.createQuestion({
-        name: "14649_min",
-        query: {
-          "source-query": {
-            "source-table": ORDERS_ID,
-            aggregation: [
-              [
-                "aggregation-options",
-                ["sum", ["field", ORDERS.SUBTOTAL, null]],
-                { name: "Revenue", "display-name": "Revenue" },
+      cy.createQuestion(
+        {
+          name: "14649_min",
+          query: {
+            "source-query": {
+              "source-table": ORDERS_ID,
+              aggregation: [
+                [
+                  "aggregation-options",
+                  ["sum", ["field", ORDERS.SUBTOTAL, null]],
+                  { name: "Revenue", "display-name": "Revenue" },
+                ],
               ],
-            ],
-            breakout: [
-              ["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }],
+              breakout: [
+                ["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }],
+              ],
+            },
+            aggregation: [
+              ["min", ["field", "Revenue", { "base-type": "type/Float" }]],
             ],
           },
-          aggregation: [
-            ["min", ["field", "Revenue", { "base-type": "type/Float" }]],
-          ],
+
+          display: "scalar",
         },
+        { visitQuestion: true },
+      );
 
-        display: "scalar",
-      }).then(({ body: { id: QUESTION_ID } }) => {
-        cy.server();
-        cy.route("POST", `/api/card/${QUESTION_ID}/query`).as("cardQuery");
-
-        cy.visit(`/question/${QUESTION_ID}`);
-        cy.wait("@cardQuery").then(xhr => {
-          expect(xhr.response.body.error).to.not.exist;
-        });
-
-        cy.findByText("49.54");
-      });
+      cy.findByText("49.54");
     });
 
     it("x-rays should work on explicit joins when metric is for the joined table (metabase#14793)", () => {

--- a/frontend/test/metabase/scenarios/native-filters/reproductions/12228.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native-filters/reproductions/12228.cy.spec.js
@@ -30,8 +30,8 @@ describe("issue 12228", () => {
   });
 
   it("can load a question with a date filter (metabase#12228)", () => {
-    cy.createNativeQuestion(nativeQuery).then(response => {
-      cy.visit(`/question/${response.body.id}?created_at=2020-01`);
+    cy.createNativeQuestion(nativeQuery).then(({ body: { id } }) => {
+      cy.visit(`/question/${id}?created_at=2020-01`);
       cy.contains("580");
     });
   });

--- a/frontend/test/metabase/scenarios/native-filters/reproductions/12581.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native-filters/reproductions/12581.cy.spec.js
@@ -30,9 +30,7 @@ describe("issue 12581", () => {
     restore();
     cy.signInAsAdmin();
 
-    cy.createNativeQuestion(nativeQuery).then(({ body }) => {
-      cy.visit(`/question/${body.id}`);
-    });
+    cy.createNativeQuestion(nativeQuery, { visitQuestion: true });
   });
 
   it("should correctly display a revision state after a restore (metabase#12581)", () => {

--- a/frontend/test/metabase/scenarios/native-filters/reproductions/13961.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native-filters/reproductions/13961.cy.spec.js
@@ -38,12 +38,7 @@ describe.skip("issue 13961", () => {
     restore();
     cy.signInAsAdmin();
 
-    cy.createNativeQuestion(nativeQuery).then(({ body }) => {
-      cy.intercept("POST", `/api/card/${body.id}/query`).as("cardQuery");
-
-      cy.visit(`/question/${body.id}`);
-      cy.wait("@cardQuery");
-    });
+    cy.createNativeQuestion(nativeQuery, { visitQuestion: true });
   });
 
   it("should clear default filter value in native questions (metabase#13961)", () => {

--- a/frontend/test/metabase/scenarios/native-filters/reproductions/14145.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native-filters/reproductions/14145.cy.spec.js
@@ -36,9 +36,7 @@ describe.skip("issue 14145", () => {
       is_full_sync: true,
     });
 
-    cy.createNativeQuestion(nativeQuery).then(({ body }) => {
-      cy.visit(`/question/${body.id}`);
-    });
+    cy.createNativeQuestion(nativeQuery, { visitQuestion: true });
   });
 
   it("`field-id` should update when database source is changed (metabase#14145)", () => {

--- a/frontend/test/metabase/scenarios/native-filters/reproductions/14302.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native-filters/reproductions/14302.cy.spec.js
@@ -25,12 +25,7 @@ describe("issue 14302", () => {
     restore();
     cy.signInAsAdmin();
 
-    cy.createNativeQuestion(nativeQuery).then(({ body }) => {
-      cy.intercept("POST", `/api/card/${body.id}/query`).as("cardQuery");
-
-      cy.visit(`/question/${body.id}`);
-      cy.wait("@cardQuery");
-    });
+    cy.createNativeQuestion(nativeQuery, { visitQuestion: true });
   });
 
   it("should not make the question dirty when there are no changes (metabase#14302)", () => {

--- a/frontend/test/metabase/scenarios/native-filters/sql-field-filter-category.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native-filters/sql-field-filter-category.cy.spec.js
@@ -10,26 +10,27 @@ describe("scenarios > filters > sql filters > field filter > Category", () => {
 
     cy.signInAsAdmin();
 
-    cy.createNativeQuestion({
-      name: "Products SQL",
-      native: {
-        query: "select * from products where {{category}}",
-        "template-tags": {
-          category: {
-            "display-name": "Field Filter",
-            id: "abc123",
-            name: "category",
-            type: "dimension",
-            "widget-type": "category",
-            dimension: ["field", PRODUCTS.CATEGORY, null],
-            default: ["Doohickey"],
+    cy.createNativeQuestion(
+      {
+        name: "Products SQL",
+        native: {
+          query: "select * from products where {{category}}",
+          "template-tags": {
+            category: {
+              "display-name": "Field Filter",
+              id: "abc123",
+              name: "category",
+              type: "dimension",
+              "widget-type": "category",
+              dimension: ["field", PRODUCTS.CATEGORY, null],
+              default: ["Doohickey"],
+            },
           },
         },
+        display: "table",
       },
-      display: "table",
-    }).then(({ body: { id: card_id } }) => {
-      cy.visit(`/question/${card_id}`);
-    });
+      { visitQuestion: true },
+    );
   });
 
   it("should work despite it not showing up in the widget type list", () => {

--- a/frontend/test/metabase/scenarios/native/reproductions/19451.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/reproductions/19451.cy.spec.js
@@ -27,12 +27,7 @@ describe("issue 19451", () => {
     restore();
     cy.signInAsAdmin();
 
-    cy.createNativeQuestion(question).then(({ body: { id } }) => {
-      cy.intercept("POST", `/api/card/${id}/query`).as("cardQuery");
-
-      cy.visit(`/question/${id}`);
-      cy.wait("@cardQuery");
-    });
+    cy.createNativeQuestion(question, { visitQuestion: true });
   });
 
   it("question field filter shows all tables from a selected database (metabase#19451)", () => {

--- a/frontend/test/metabase/scenarios/native/snippets/snippets.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/snippets/snippets.cy.spec.js
@@ -100,24 +100,25 @@ describe("scenarios > question > snippets", () => {
       });
 
       // Create native question using snippet 1
-      cy.createNativeQuestion({
-        name: "15387",
-        native: {
-          "template-tags": {
-            "snippet: Table: Orders": {
-              id: "14a923c5-83a2-b359-64f7-5e287c943caf",
-              name: "snippet: Table: Orders",
-              "display-name": "Snippet: table: orders",
-              type: "snippet",
-              "snippet-name": "Table: Orders",
-              "snippet-id": SNIPPET_ID,
+      cy.createNativeQuestion(
+        {
+          name: "15387",
+          native: {
+            "template-tags": {
+              "snippet: Table: Orders": {
+                id: "14a923c5-83a2-b359-64f7-5e287c943caf",
+                name: "snippet: Table: Orders",
+                "display-name": "Snippet: table: orders",
+                type: "snippet",
+                "snippet-name": "Table: Orders",
+                "snippet-id": SNIPPET_ID,
+              },
             },
+            query: "select * from {{snippet: Table: Orders}} limit 1",
           },
-          query: "select * from {{snippet: Table: Orders}} limit 1",
         },
-      }).then(({ body: { id: QUESTION_ID } }) => {
-        cy.visit(`/question/${QUESTION_ID}`);
-      });
+        { visitQuestion: true },
+      );
     });
 
     cy.get(".Visualization")

--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -61,46 +61,48 @@ describe("scenarios > question > filter", () => {
   });
 
   it("'Between Dates' filter should behave consistently (metabase#12872)", () => {
-    cy.createQuestion({
-      name: "12872",
-      query: {
-        "source-table": PRODUCTS_ID,
-        aggregation: [["count"]],
-        filter: [
-          "and",
-          [
-            "between",
-            ["field", PRODUCTS.CREATED_AT, null],
-            "2019-04-15",
-            "2019-04-15",
-          ],
-          [
-            "between",
-            ["field", PRODUCTS.CREATED_AT, { "join-alias": "Products" }],
-            "2019-04-15",
-            "2019-04-15",
-          ],
-        ],
-        joins: [
-          {
-            alias: "Products",
-            condition: [
-              "=",
-              ["field", PRODUCTS.ID, null],
-              ["field", PRODUCTS.ID, { "join-alias": "Products" }],
+    cy.createQuestion(
+      {
+        name: "12872",
+        query: {
+          "source-table": PRODUCTS_ID,
+          aggregation: [["count"]],
+          filter: [
+            "and",
+            [
+              "between",
+              ["field", PRODUCTS.CREATED_AT, null],
+              "2019-04-15",
+              "2019-04-15",
             ],
-            fields: "all",
-            "source-table": PRODUCTS_ID,
-          },
-        ],
+            [
+              "between",
+              ["field", PRODUCTS.CREATED_AT, { "join-alias": "Products" }],
+              "2019-04-15",
+              "2019-04-15",
+            ],
+          ],
+          joins: [
+            {
+              alias: "Products",
+              condition: [
+                "=",
+                ["field", PRODUCTS.ID, null],
+                ["field", PRODUCTS.ID, { "join-alias": "Products" }],
+              ],
+              fields: "all",
+              "source-table": PRODUCTS_ID,
+            },
+          ],
+        },
+        display: "scalar",
       },
-      display: "scalar",
-    }).then(({ body: { id: questionId } }) => {
-      cy.visit(`/question/${questionId}`);
-      cy.findByText("12872");
-      cy.log("At the moment of unfixed issue, it's showing '0'");
-      cy.get(".ScalarValue").contains("1");
-    });
+      { visitQuestion: true },
+    );
+
+    cy.findByText("12872");
+    cy.log("At the moment of unfixed issue, it's showing '0'");
+    cy.get(".ScalarValue").contains("1");
   });
 
   it("should filter based on remapped values (metabase#13235)", () => {

--- a/frontend/test/metabase/scenarios/question/nested.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nested.cy.spec.js
@@ -42,7 +42,7 @@ describe("scenarios > question > nested (metabase#12568)", () => {
         },
         display: "scalar",
       },
-      { loadMetadata: true },
+      { loadMetadata: true, interceptAlias: "secondCardQuery" },
     );
 
     // [quarantine] The whole CI was timing out

--- a/frontend/test/metabase/scenarios/question/nested.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nested.cy.spec.js
@@ -19,37 +19,31 @@ describe("scenarios > question > nested (metabase#12568)", () => {
     cy.signInAsAdmin();
 
     // Create a simple question of orders by week
-    cy.createQuestion({
-      name: "GH_12568: Simple",
-      query: {
-        "source-table": ORDERS_ID,
-        aggregation: [["count"]],
-        breakout: [["field", ORDERS.CREATED_AT, { "temporal-unit": "week" }]],
+    cy.createQuestion(
+      {
+        name: "GH_12568: Simple",
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: [["count"]],
+          breakout: [["field", ORDERS.CREATED_AT, { "temporal-unit": "week" }]],
+        },
+        display: "line",
       },
-      display: "line",
-    }).then(({ body }) => {
-      cy.intercept("POST", `/api/card/${body.id}/query`).as("cardMetadata");
-
-      cy.visit(`/question/${body.id}`);
-      // We have to wait for the metadata to load
-      cy.wait("@cardMetadata");
-    });
+      { loadMetadata: true },
+    );
 
     // Create a native question of orders by day
-    cy.createNativeQuestion({
-      name: "GH_12568: SQL",
-      native: {
-        query:
-          "SELECT date_trunc('day', CREATED_AT) as date, COUNT(*) as count FROM ORDERS GROUP BY date_trunc('day', CREATED_AT)",
+    cy.createNativeQuestion(
+      {
+        name: "GH_12568: SQL",
+        native: {
+          query:
+            "SELECT date_trunc('day', CREATED_AT) as date, COUNT(*) as count FROM ORDERS GROUP BY date_trunc('day', CREATED_AT)",
+        },
+        display: "scalar",
       },
-      display: "scalar",
-    }).then(({ body }) => {
-      cy.intercept("POST", `/api/card/${body.id}/query`).as("nativeMetadata");
-
-      cy.visit(`/question/${body.id}`);
-      // We have to wait for the metadata to load
-      cy.wait("@nativeMetadata");
-    });
+      { loadMetadata: true },
+    );
 
     // [quarantine] The whole CI was timing out
     // Create a complex native question
@@ -151,29 +145,31 @@ describe("scenarios > question > nested", () => {
   });
 
   it("should handle duplicate column names in nested queries (metabase#10511)", () => {
-    cy.createQuestion({
-      name: "10511",
-      query: {
-        filter: [">", ["field", "count", { "base-type": "type/Integer" }], 5],
-        "source-query": {
-          "source-table": ORDERS_ID,
-          aggregation: [["count"]],
-          breakout: [
-            ["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }],
-            [
-              "field",
-              PRODUCTS.CREATED_AT,
-              { "temporal-unit": "month", "source-field": ORDERS.PRODUCT_ID },
+    cy.createQuestion(
+      {
+        name: "10511",
+        query: {
+          filter: [">", ["field", "count", { "base-type": "type/Integer" }], 5],
+          "source-query": {
+            "source-table": ORDERS_ID,
+            aggregation: [["count"]],
+            breakout: [
+              ["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }],
+              [
+                "field",
+                PRODUCTS.CREATED_AT,
+                { "temporal-unit": "month", "source-field": ORDERS.PRODUCT_ID },
+              ],
             ],
-          ],
+          },
         },
       },
-    }).then(({ body: { id: questionId } }) => {
-      cy.visit(`/question/${questionId}`);
-      cy.findByText("10511");
-      cy.findAllByText("June, 2016");
-      cy.findAllByText("13");
-    });
+      { visitQuestion: true },
+    );
+
+    cy.findByText("10511");
+    cy.findAllByText("June, 2016");
+    cy.findAllByText("13");
   });
 
   it.skip("should display granularity for aggregated fields in nested questions (metabase#13764)", () => {
@@ -436,19 +432,16 @@ describe("scenarios > question > nested", () => {
     it(`${test.toUpperCase()}:\n should be able to use aggregation functions on saved native question (metabase#15397)`, () => {
       cy.intercept("POST", "/api/dataset").as("dataset");
 
-      cy.createNativeQuestion({
-        name: "15397",
-        native: {
-          query:
-            "select count(*), orders.product_id from orders group by orders.product_id;",
+      cy.createNativeQuestion(
+        {
+          name: "15397",
+          native: {
+            query:
+              "select count(*), orders.product_id from orders group by orders.product_id;",
+          },
         },
-      }).then(({ body: { id } }) => {
-        cy.intercept("POST", `/api/card/${id}/query`).as("cardQuery");
-
-        // Visit the question to load the `result_metadata`
-        cy.visit(`/question/${id}`);
-        cy.wait("@cardQuery");
-      });
+        { loadMetadata: true },
+      );
 
       cy.visit("/question/new");
       cy.findByText("Simple question").click();
@@ -517,19 +510,22 @@ describe("scenarios > question > nested", () => {
     });
 
     function assertOnFilter({ name, filter, value } = {}) {
-      cy.createQuestion({
-        name,
-        query: {
-          "source-table": ORDERS_ID,
-          filter,
-          aggregation: [["count"]],
+      cy.createQuestion(
+        {
+          name,
+          query: {
+            "source-table": ORDERS_ID,
+            filter,
+            aggregation: [["count"]],
+          },
+          type: "query",
+          display: "scalar",
         },
-        type: "query",
-        display: "scalar",
-      }).then(({ body }) => {
-        cy.visit(`/question/${body.id}`);
-        cy.get(".ScalarValue").findByText(value);
-      });
+        { visitQuestion: true },
+      );
+
+      cy.get(".ScalarValue").findByText(value);
+
       // Start new question based on the saved one
       cy.visit("/question/new");
       cy.findByText("Simple question").click();

--- a/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
@@ -48,8 +48,6 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
       { visitQuestion: true },
     );
 
-    // wait for chart to expand and display legend/labels
-    cy.contains("Loading..."); // this gives more time to load
     cy.contains("Gadget");
     cy.contains("January, 2017");
     cy.wait(100); // wait longer to avoid grabbing the svg before a chart redraw

--- a/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
@@ -28,48 +28,49 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
   });
 
   it("should allow brush date filter", () => {
-    cy.createQuestion({
-      name: "Brush Date Filter",
-      query: {
-        "source-table": ORDERS_ID,
-        aggregation: [["count"]],
-        breakout: [
-          [
-            "field",
-            PRODUCTS.CREATED_AT,
-            { "source-field": ORDERS.PRODUCT_ID, "temporal-unit": "month" },
+    cy.createQuestion(
+      {
+        name: "Brush Date Filter",
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: [["count"]],
+          breakout: [
+            [
+              "field",
+              PRODUCTS.CREATED_AT,
+              { "source-field": ORDERS.PRODUCT_ID, "temporal-unit": "month" },
+            ],
+            ["field", PRODUCTS.CATEGORY, { "source-field": ORDERS.PRODUCT_ID }],
           ],
-          ["field", PRODUCTS.CATEGORY, { "source-field": ORDERS.PRODUCT_ID }],
-        ],
+        },
+        display: "line",
       },
-      display: "line",
-    }).then(response => {
-      cy.visit(`/question/${response.body.id}`);
+      { visitQuestion: true },
+    );
 
-      // wait for chart to expand and display legend/labels
-      cy.contains("Loading..."); // this gives more time to load
-      cy.contains("Gadget");
-      cy.contains("January, 2017");
-      cy.wait(100); // wait longer to avoid grabbing the svg before a chart redraw
+    // wait for chart to expand and display legend/labels
+    cy.contains("Loading..."); // this gives more time to load
+    cy.contains("Gadget");
+    cy.contains("January, 2017");
+    cy.wait(100); // wait longer to avoid grabbing the svg before a chart redraw
 
-      // drag across to filter
-      cy.get(".Visualization")
-        .trigger("mousedown", 120, 200)
-        .trigger("mousemove", 230, 200)
-        .trigger("mouseup", 230, 200);
+    // drag across to filter
+    cy.get(".Visualization")
+      .trigger("mousedown", 120, 200)
+      .trigger("mousemove", 230, 200)
+      .trigger("mouseup", 230, 200);
 
-      // new filter applied
-      // Note: Test was flaking because apparently mouseup doesn't always happen at the same position.
-      //       It is enough that we assert that the filter exists and that it starts with May, 2016
-      cy.contains(/^Created At between May, 2016/);
-      // more granular axis labels
-      cy.contains("June, 2016");
-      // confirm that product category is still broken out
-      cy.contains("Gadget");
-      cy.contains("Doohickey");
-      cy.contains("Gizmo");
-      cy.contains("Widget");
-    });
+    // new filter applied
+    // Note: Test was flaking because apparently mouseup doesn't always happen at the same position.
+    //       It is enough that we assert that the filter exists and that it starts with May, 2016
+    cy.contains(/^Created At between May, 2016/);
+    // more granular axis labels
+    cy.contains("June, 2016");
+    // confirm that product category is still broken out
+    cy.contains("Gadget");
+    cy.contains("Doohickey");
+    cy.contains("Gizmo");
+    cy.contains("Widget");
   });
 
   ["month", "month-of-year"].forEach(granularity => {
@@ -386,28 +387,29 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
   });
 
   it("should display correct value in a tooltip for unaggregated data (metabase#11907)", () => {
-    cy.createNativeQuestion({
-      name: "11907",
-      native: {
-        query:
-          "SELECT parsedatetime('2020-01-01', 'yyyy-MM-dd') AS \"d\", 5 AS \"c\" UNION ALL\nSELECT parsedatetime('2020-01-01', 'yyyy-MM-dd') AS \"d\", 2 AS \"c\" UNION ALL\nSELECT parsedatetime('2020-01-01', 'yyyy-MM-dd') AS \"d\", 3 AS \"c\" UNION ALL\nSELECT parsedatetime('2020-01-02', 'yyyy-MM-dd') AS \"d\", 1 AS \"c\" UNION ALL\nSELECT parsedatetime('2020-01-02', 'yyyy-MM-dd') AS \"d\", 4 AS \"c\"",
-        "template-tags": {},
+    cy.createNativeQuestion(
+      {
+        name: "11907",
+        native: {
+          query:
+            "SELECT parsedatetime('2020-01-01', 'yyyy-MM-dd') AS \"d\", 5 AS \"c\" UNION ALL\nSELECT parsedatetime('2020-01-01', 'yyyy-MM-dd') AS \"d\", 2 AS \"c\" UNION ALL\nSELECT parsedatetime('2020-01-01', 'yyyy-MM-dd') AS \"d\", 3 AS \"c\" UNION ALL\nSELECT parsedatetime('2020-01-02', 'yyyy-MM-dd') AS \"d\", 1 AS \"c\" UNION ALL\nSELECT parsedatetime('2020-01-02', 'yyyy-MM-dd') AS \"d\", 4 AS \"c\"",
+          "template-tags": {},
+        },
+        display: "line",
       },
-      display: "line",
-    }).then(({ body: { id: QUESTION_ID } }) => {
-      cy.visit(`/question/${QUESTION_ID}`);
+      { visitQuestion: true },
+    );
 
-      clickLineDot({ index: 0 });
-      popover().within(() => {
-        cy.findByText("January 1, 2020");
-        cy.findByText("10");
-      });
+    clickLineDot({ index: 0 });
+    popover().within(() => {
+      cy.findByText("January 1, 2020");
+      cy.findByText("10");
+    });
 
-      clickLineDot({ index: 1 });
-      popover().within(() => {
-        cy.findByText("January 2, 2020");
-        cy.findByText("5");
-      });
+    clickLineDot({ index: 1 });
+    popover().within(() => {
+      cy.findByText("January 2, 2020");
+      cy.findByText("5");
     });
   });
 

--- a/frontend/test/metabase/scenarios/visualizations/maps.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/maps.cy.spec.js
@@ -59,23 +59,24 @@ describe("scenarios > visualizations > maps", () => {
   });
 
   it("should suggest map visualization regardless of the first column type (metabase#14254)", () => {
-    cy.createNativeQuestion({
-      name: "14254",
-      native: {
-        query:
-          'SELECT "PUBLIC"."PEOPLE"."LONGITUDE" AS "LONGITUDE", "PUBLIC"."PEOPLE"."LATITUDE" AS "LATITUDE", "PUBLIC"."PEOPLE"."CITY" AS "CITY"\nFROM "PUBLIC"."PEOPLE"\nLIMIT 10',
-        "template-tags": {},
+    cy.createNativeQuestion(
+      {
+        name: "14254",
+        native: {
+          query:
+            'SELECT "PUBLIC"."PEOPLE"."LONGITUDE" AS "LONGITUDE", "PUBLIC"."PEOPLE"."LATITUDE" AS "LATITUDE", "PUBLIC"."PEOPLE"."CITY" AS "CITY"\nFROM "PUBLIC"."PEOPLE"\nLIMIT 10',
+          "template-tags": {},
+        },
+        display: "map",
+        visualization_settings: {
+          "map.region": "us_states",
+          "map.type": "pin",
+          "map.latitude_column": "LATITUDE",
+          "map.longitude_column": "LONGITUDE",
+        },
       },
-      display: "map",
-      visualization_settings: {
-        "map.region": "us_states",
-        "map.type": "pin",
-        "map.latitude_column": "LATITUDE",
-        "map.longitude_column": "LONGITUDE",
-      },
-    }).then(({ body: { id: QUESTION_ID } }) => {
-      cy.visit(`/question/${QUESTION_ID}`);
-    });
+      { visitQuestion: true },
+    );
 
     cy.findByText("Visualization")
       .closest(".Button")

--- a/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -870,15 +870,18 @@ const testQuery = {
 };
 
 function createAndVisitTestQuestion({ display = "pivot" } = {}) {
-  cy.request("POST", "/api/card", {
-    name: QUESTION_NAME,
-    dataset_query: testQuery,
-    display,
-    description: null,
-    visualization_settings: {},
-  }).then(({ body: { id: QUESTION_ID } }) => {
-    cy.visit(`/question/${QUESTION_ID}`);
-  });
+  cy.request(
+    "POST",
+    "/api/card",
+    {
+      name: QUESTION_NAME,
+      dataset_query: testQuery,
+      display,
+      description: null,
+      visualization_settings: {},
+    },
+    { visitQuestion: true },
+  );
 }
 
 function assertOnPivotSettings() {

--- a/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -870,18 +870,10 @@ const testQuery = {
 };
 
 function createAndVisitTestQuestion({ display = "pivot" } = {}) {
-  cy.request(
-    "POST",
-    "/api/card",
-    {
-      name: QUESTION_NAME,
-      dataset_query: testQuery,
-      display,
-      description: null,
-      visualization_settings: {},
-    },
-    { visitQuestion: true },
-  );
+  const { query } = testQuery;
+  const questionDetails = { name: QUESTION_NAME, query, display };
+
+  cy.createQuestion(questionDetails, { visitQuestion: true });
 }
 
 function assertOnPivotSettings() {

--- a/frontend/test/metabase/scenarios/visualizations/rows.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/rows.cy.spec.js
@@ -13,10 +13,11 @@ describe("scenarios > visualizations > rows", () => {
       `should not collapse rows when last value is ${testValue} (metabase#14285)`,
       { browser: "firefox" },
       () => {
-        cy.createNativeQuestion({
-          name: "14285",
-          native: {
-            query: `
+        cy.createNativeQuestion(
+          {
+            name: "14285",
+            native: {
+              query: `
               with temp as (
                 select 'a' col1, 25 col2 union all
                 select 'b', 10 union all
@@ -27,12 +28,12 @@ describe("scenarios > visualizations > rows", () => {
               ) select * from temp
               order by 2 desc
             `,
-            "template-tags": {},
+              "template-tags": {},
+            },
+            display: "row",
           },
-          display: "row",
-        }).then(({ body: { id: QUESTION_ID } }) => {
-          cy.visit(`/question/${QUESTION_ID}`);
-        });
+          { visitQuestion: true },
+        );
 
         cy.get(".Visualization").within(() => {
           ["a", "b", "c", "d", "e", "f"].forEach(letter => {


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Simplifies some test files by using an optional argument of visiting the question, instead of manually typing the whole chain of commands
- In order to adjust to some edge cases (such as pivot tables, nested questions, etc) I also needed to add a few more params to the main `question` function

You can now:
1. Wrap id of the created question and use it later in the test without having to stay in the nested scope, or (even worse) without using an anti-pattern of first defining an id with the `let questionId;` and then later assigning the value to it.
2. Given that you decided to wrap question id, you can define a custom alias for it, which you're going to need later on
3. You can now define a custom alias for the intercepted route, which was before hard coded as `cardQuery`. The problem with hard coding it was apparent when there were more questions in the same test. Although the routes were different (because they relied on an id), the alias was the same and the test failed

#### Simplify code by hiding away implementation details for visit
```js
// before
cy.createQuestion(questionDetails).then(({ body: { id: QUESTION_ID } }) => {
  cy.intercept("POST", `/api/card/${QUESTION_ID}/query`).as("cardQuery");

  cy.visit(`/question/${QUESTION_ID}`);

  cy.wait("@cardQuery")
});

// now
cy.createQuestion(questionDetails, { visitQuestion: true });
```

#### Use question `id` later in the code, after defining a question
```js
// Anti-pattern
let questionId;

cy.createQuestion(questionDetails).then(({ body: { id: QUESTION_ID } }) => {
  questionId = QUESTION_ID

  doSomethingWithQuestionId(questionId);
});

// now
cy.createQuestion(questionDetails, { visitQuestion: true, wrapId: true, idAlias: "foo" });

// then later in the test whenever you need that id
cy.get("@foo").then(id=> {
  doSomethingWithQuestionId(id);
});
```

#### Using `cy.createQuestion()` multiple times in a single test
```js
// before
cy.createQuestion(questionDetails).then(({ body: { id: firstId } }) => {
  // we need to stay in this scope in order to have access to firstId
  doSomethingWith(firstId);

  // more test code
  cy.createQuestion(questionDetails).then(({ body: { id: secondId } }) => {
    // nesting much?
    // we needed to do this to have access to both `firstId` and `secondId`
    doSomethingWith(secondId);
  });
});

// now
cy.createQuestion(questionDetails, { visitQuestion: true, wrapId: true, idAlias: "firstAlias" });

cy.createQuestion(questionDetails, { visitQuestion: true, wrapId: true, idAlias: "secondAlias" });
// test code...
cy.get("@firstAlias").then(firstId => {
  doSomethingWith(firstId);
});
// more test code
cy.get("@secondAlias").then(secondId => {
  doSomethingWith(secondId);
});
```

or because of the great helper added by @alxnddr , you could also do something like this:
```js
cypressWaitAll([cy.get("@firstAlias"), cy.get("@secondAlias")]).then(ids => {
  const [id1, id2] = ids;
});
```