### PR TITLE
Ensure PNG cropping doesn't clip table content 

### DIFF
--- a/src/metabase/pulse/render/png.clj
+++ b/src/metabase/pulse/render/png.clj
@@ -86,7 +86,11 @@
                                                    RenderingHints/VALUE_FRACTIONALMETRICS_ON))))]
       (.createLayout graphics-engine dimension)
       (let [image         (.getImage graphics-engine)
-            content-width (int (.getMaximalWidth (.getViewport graphics-engine)))]
+            viewport      (.getViewport graphics-engine)
+            ;; CSSBox voodoo -- sometimes maximal width < minimal width, no idea why
+            content-width (max (int (.getMinimalWidth viewport))
+                               (int (.getMaximalWidth viewport)))]
+        ;; Crop the image to the actual size of the rendered content so that tables don't have a ton of whitespace.
         (if (< content-width (.getWidth image))
           (.getSubimage image 0 0 content-width (.getHeight image))
           image)))))

--- a/test/metabase/pulse/render/png_test.clj
+++ b/test/metabase/pulse/render/png_test.clj
@@ -23,11 +23,17 @@
                         (s/one #"^Error registering fonts" "message")]
                        (first messages))))))))
 
-(def ^:private test-table-html
+(def ^:private test-table-html-1
   "<table><tr><th>Column 1</th><th>Column 2</th></tr><tr><td>Data</td><td>Data</td></tr></table>")
+
+(def ^:private test-table-html-2
+  "<html><body style=\"margin: 0; padding: 0; background-color: white;\"><p><div style=\"overflow-x: auto;\"><a href=\"http://localhost:3000/question/2\" rel=\"noopener noreferrer\" style=\"font-family: Lato, &quot;Helvetica Neue&quot;, Helvetica, Arial, sans-serif; display: block; text-decoration: none;\" target=\"_blank\"><div class=\"pulse-body\" style=\"display: block; margin: 16px;\"><div><table cellpadding=\"0\" cellspacing=\"0\" style=\"max-width: 100%; white-space: nowrap; padding-bottom: 8px; border-collapse: collapse; width: 1%;\"><thead><tr><th style=\"min-width: 42px; color: #949AAB; text-align: left; font-size: 12px; font-weight: 700; padding-right: 0.375em; padding-top: 20px; padding-left: 0.375em; padding-bottom: 5px; font-family: Lato, &quot;Helvetica Neue&quot;, Helvetica, Arial, sans-serif; height: 28px; border-bottom: 1px solid #EDF0F1;\">Test URL</th><th style=\"min-width: 42px; color: #949AAB; text-align: left; font-size: 12px; font-weight: 700; padding-right: 0.375em; padding-top: 20px; padding-left: 0.375em; padding-bottom: 5px; font-family: Lato, &quot;Helvetica Neue&quot;, Helvetica, Arial, sans-serif; height: 28px; border-bottom: 1px solid #EDF0F1;\">Another Column</th><th style=\"min-width: 42px; color: #949AAB; text-align: right; font-size: 12px; font-weight: 700; padding-right: 0.375em; padding-top: 20px; padding-left: 0.375em; padding-bottom: 5px; font-family: Lato, &quot;Helvetica Neue&quot;, Helvetica, Arial, sans-serif; height: 28px; border-bottom: 1px solid #EDF0F1;\">Test Version ID</th></tr></thead><tbody><tr style=\"color: #7C8381;\"><td style=\"color: #4C5773; text-align: left; font-size: 12px; font-weight: 700; padding-right: 0.375em; padding-left: 0.375em; font-family: Lato, &quot;Helvetica Neue&quot;, Helvetica, Arial, sans-serif; height: 28px; border-bottom: 1px solid #F0F0F04D;\">test.example.com</td><td style=\"color: #4C5773; text-align: left; font-size: 12px; font-weight: 700; padding-right: 0.375em; padding-left: 0.375em; font-family: Lato, &quot;Helvetica Neue&quot;, Helvetica, Arial, sans-serif; height: 28px; border-bottom: 1px solid #F0F0F04D;\">this-is-a-test-value</td><td style=\"color: #4C5773; text-align: right; font-size: 12px; font-weight: 700; padding-right: 0.375em; padding-left: 0.375em; font-family: Lato, &quot;Helvetica Neue&quot;, Helvetica, Arial, sans-serif; height: 28px; border-bottom: 1px solid #F0F0F04D;\">123</td></tr></tbody></table></div></div></a></div></p></body></html>")
 
 (deftest table-width-test
   (testing "The PNG of a table should be cropped to the width of its content"
-    (let [png (@#'png/render-to-png test-table-html 1200)]
+    (let [png (@#'png/render-to-png test-table-html-1 1200)]
       ;; Check that width is within a range, since actual rendered result can very slightly by environment
-      (is (< 170 (.getWidth png) 210)))))
+      (is (< 170 (.getWidth png) 210))))
+  (testing "The PNG of a table should not clip any of its content"
+    (let [png (@#'png/render-to-png test-table-html-2 1200)]
+      (is (< 320 (.getWidth png) 360)))))


### PR DESCRIPTION
I assumed in https://github.com/metabase/metabase/pull/20032 that `.getMaximalWidth` would always returned a larger value than `.getMinimalWidth`, and so we should crop pngs to the value returned by `.getMaximalWidth` to be safe. 

This assumption apparently was unfounded. In specific cases, such as the example in #20444, `.getMinimalWidth` returns the larger value. This might be a bug in CSSBox? I'm starting to get a headache whenever a try to read through [the source](https://github.com/radkovo/CSSBox/blob/master/src/main/java/org/fit/cssbox/layout/BlockBox.java) for BlockBox (which the Viewport class inherits from, and where these methods are defined) so I haven't been able to fully understand why these methods behave the way they do. I also don't understand why certain queries cause this and others (even very similar ones) don't. If anyone else wants to try to figure this out be my guest.

In any case, cropping images to the max of `.getMaximalWidth` and `.getMinimalWidth` seems to do the trick empirically. I've added a test that uses the real HTML generated for a table that reproduces the issue. But after I merge this I'll test it out with as many possible dashboards on stats as I can, to make sure there aren't more weird edge cases that this doesn't work with.

Before and after:
<img width="594" alt="Screen Shot 2022-02-11 at 11 07 16 AM" src="https://user-images.githubusercontent.com/32746338/153626462-a1b79004-6919-4e6f-b23d-708a7dd6b299.png">


(Hopefully) fixes #20444