### PR TITLE
Events migration

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -35,6 +35,7 @@
   ;; instead of one call to `define-clojure-indent'
   (eval . (put-clojure-indent 'c/step 1))
   (eval . (put-clojure-indent 'db/insert-many! 1))
+  (eval . (put-clojure-indent 'db/update! 2))
   (eval . (put-clojure-indent 'impl/test-migrations 2))
   (eval . (put-clojure-indent 'let-404 0))
   (eval . (put-clojure-indent 'macros/case 0))
@@ -49,6 +50,8 @@
   (eval . (put-clojure-indent 'mt/test-drivers 1))
   (eval . (put-clojure-indent 'prop/for-all 1))
   (eval . (put-clojure-indent 'qp.streaming/streaming-response 1))
+  (eval . (put-clojure-indent 'u/select-keys-when 1))
+  (eval . (put-clojure-indent 'u/strict-extend 1))
   ;; these ones have to be done with `define-clojure-indent' for now because of upstream bug
   ;; https://github.com/clojure-emacs/clojure-mode/issues/600 once that's resolved we should use `put-clojure-indent'
   ;; instead. Please don't add new entries unless they don't work with `put-clojure-indent'

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -9987,7 +9987,7 @@ databaseChangeLog:
       comment: Added 0.43.0 - Events table
       changes:
         - createTable:
-            tableName: timeline_events
+            tableName: timeline_event
             remarks: Events table
             columns:
               - column:

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -9936,6 +9936,12 @@ databaseChangeLog:
                   constraints:
                     nullable: true
               - column:
+                  name: icon
+                  type: varchar(128)
+                  constraints:
+                    nullable: true
+                  remarks: the icon to use when displaying the event
+              - column:
                   remarks: ID of the collection containing the timeline
                   name: collection_id
                   type: int
@@ -9981,7 +9987,7 @@ databaseChangeLog:
       comment: Added 0.43.0 - Events table
       changes:
         - createTable:
-            tableName: events
+            tableName: timeline_events
             remarks: Events table
             columns:
               - column:
@@ -10013,28 +10019,16 @@ databaseChangeLog:
                   constraints:
                     nullable: true
               - column:
-                  name: date
-                  type: date
-                  constraints:
-                    nullable: false
-                  remarks: The date on which the event occurred
-              - column:
-                  name: time
-                  type: time
-                  constraints:
-                    nullable: true
-                  remarks: The optional details of when on the date the event occurred
-              - column:
-                  name: timezone
+                  name: timestamp
                   type: timestamp with time zone
                   constraints:
-                    nullable: true
-                  remarks: The optional timezone to display the event's datetime in
+                    nullable: false
+                  remarks: When the event happened
               - column:
                   name: icon
                   type: varchar(128)
                   constraints:
-                    nullable: false
+                    nullable: true
                   remarks: the icon to use when displaying the event
               - column:
                   remarks: Whether or not the event has been archived

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -9946,7 +9946,7 @@ databaseChangeLog:
                   name: collection_id
                   type: int
                   constraints:
-                    nullable: false
+                    nullable: true
                     references: collection(id)
                     foreignKeyName: fk_timeline_collection_id
                     deleteCascade: true

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -9907,211 +9907,6 @@ databaseChangeLog:
         - sql:
             sql: UPDATE metabase_database SET engine = 'bigquery-cloud-sdk' WHERE engine = 'bigquery'
 
-  - changeSet:
-      id: v43.00-021
-      author: adam-james
-      comment: Added 0.43.0 - Timeline table for Events
-      changes:
-        - createTable:
-            tableName: timeline
-            remarks: Timeline table to organize events
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    nullable: false
-                    primaryKey: true
-              - column:
-                  remarks: Name of the timeline
-                  name: name
-                  type: varchar(255)
-                  constraints:
-                    nullable: false
-              - column:
-                  remarks: Optional description of the timeline
-                  name: description
-                  type: varchar(255)
-                  constraints:
-                    nullable: true
-              - column:
-                  name: icon
-                  type: varchar(128)
-                  constraints:
-                    nullable: true
-                  remarks: the icon to use when displaying the event
-              - column:
-                  remarks: ID of the collection containing the timeline
-                  name: collection_id
-                  type: int
-                  constraints:
-                    nullable: true
-                    references: collection(id)
-                    foreignKeyName: fk_timeline_collection_id
-                    deleteCascade: true
-              - column:
-                  remarks: Whether or not the timeline has been archived
-                  name: archived
-                  type: boolean
-                  defaultValueBoolean: false
-                  constraints:
-                    nullable: false
-              - column:
-                  remarks: ID of the user who created the timeline
-                  name: creator_id
-                  type: int
-                  constraints:
-                    nullable: false
-                    references: core_user(id)
-                    foreignKeyName: fk_timeline_creator_id
-                    deleteCascade: true
-              - column:
-                  remarks: The timestamp of when the timeline was created
-                  name: created_at
-                  type: ${timestamp_type}
-                  defaultValueComputed: current_timestamp
-                  constraints:
-                    nullable: false
-              - column:
-                  remarks: The timestamp of when the timeline was updated
-                  name: updated_at
-                  type: ${timestamp_type}
-                  defaultValueComputed: current_timestamp
-                  constraints:
-                    nullable: false
-
-  - changeSet:
-      id: v43.00-022
-      author: adam-james
-      comment: Added 0.43.0 - Events table
-      changes:
-        - createTable:
-            tableName: timeline_event
-            remarks: Events table
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    nullable: false
-                    primaryKey: true
-              - column:
-                  remarks: ID of the timeline containing the event
-                  name: timeline_id
-                  type: int
-                  constraints:
-                    nullable: false
-                    references: timeline(id)
-                    foreignKeyName: fk_events_timeline_id
-                    deleteCascade: true
-              - column:
-                  remarks: Name of the event
-                  name: name
-                  type: varchar(255)
-                  constraints:
-                    nullable: false
-              - column:
-                  remarks: Optional markdown description of the event
-                  name: description
-                  type: varchar(255)
-                  constraints:
-                    nullable: true
-              - column:
-                  name: timestamp
-                  type: ${timestamp_type}
-                  constraints:
-                    nullable: false
-                  remarks: When the event happened
-              - column:
-                  name: time_matters
-                  type: boolean
-                  constraints:
-                    nullable: false
-                  remarks: >-
-                     Indicate whether the time component matters or if the timestamp should just serve to indicate the
-                     day of the event without any time associated to it.
-              - column:
-                  name: timezone
-                  constraints:
-                    nullable: false
-                  type: varchar(255)
-                  remarks: Timezone to display the underlying UTC timestamp in for the client
-              - column:
-                  name: icon
-                  type: varchar(128)
-                  constraints:
-                    nullable: true
-                  remarks: the icon to use when displaying the event
-              - column:
-                  remarks: Whether or not the event has been archived
-                  name: archived
-                  type: boolean
-                  defaultValueBoolean: false
-                  constraints:
-                    nullable: false
-              - column:
-                  remarks: ID of the user who created the event
-                  name: creator_id
-                  type: int
-                  constraints:
-                    nullable: false
-                    references: core_user(id)
-                    foreignKeyName: fk_event_creator_id
-                    deleteCascade: true
-              - column:
-                  remarks: The timestamp of when the event was created
-                  name: created_at
-                  type: ${timestamp_type}
-                  defaultValueComputed: current_timestamp
-                  constraints:
-                    nullable: false
-              - column:
-                  remarks: The timestamp of when the event was modified
-                  name: updated_at
-                  type: ${timestamp_type}
-                  defaultValueComputed: current_timestamp
-                  constraints:
-                    nullable: false
-
-  - changeSet:
-      id: v43.00-023
-      author: dpsutton
-      comment: Added 0.43.0 - Index on timeline collection_id
-      changes:
-        - createIndex:
-            tableName: timeline
-            indexName: idx_timeline_collection_id
-            columns:
-              - column:
-                  name: collection_id
-
-  - changeSet:
-      id: v43.00-024
-      author: dpsutton
-      comment: Added 0.43.0 - Index on timeline_event timeline_id
-      changes:
-        - createIndex:
-            tableName: timeline_event
-            indexName: idx_timeline_event_timeline_id
-            columns:
-              - column:
-                  name: timeline_id
-
-  - changeSet:
-      id: v43.00-025
-      author: dpsutton
-      comment: Added 0.43.0 - Index on timeline timestamp
-      changes:
-        - createIndex:
-            tableName: timeline_event
-            indexName: idx_timeline_event_timeline_id_timestamp
-            columns:
-              - column:
-                  name: timeline_id
-              - column:
-                  name: timestamp
 
   #
   # The next few migrations replace metabase.db.data-migrations/add-users-to-default-permissions-groups from 0.20.0
@@ -10403,6 +10198,212 @@ databaseChangeLog:
                   'type/Subscription',
                   'type/Title'
                 );
+
+  - changeSet:
+      id: v43.00-021
+      author: adam-james
+      comment: Added 0.43.0 - Timeline table for Events
+      changes:
+        - createTable:
+            tableName: timeline
+            remarks: Timeline table to organize events
+            columns:
+              - column:
+                  name: id
+                  type: int
+                  autoIncrement: true
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+              - column:
+                  remarks: Name of the timeline
+                  name: name
+                  type: varchar(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  remarks: Optional description of the timeline
+                  name: description
+                  type: varchar(255)
+                  constraints:
+                    nullable: true
+              - column:
+                  name: icon
+                  type: varchar(128)
+                  constraints:
+                    nullable: true
+                  remarks: the icon to use when displaying the event
+              - column:
+                  remarks: ID of the collection containing the timeline
+                  name: collection_id
+                  type: int
+                  constraints:
+                    nullable: true
+                    references: collection(id)
+                    foreignKeyName: fk_timeline_collection_id
+                    deleteCascade: true
+              - column:
+                  remarks: Whether or not the timeline has been archived
+                  name: archived
+                  type: boolean
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false
+              - column:
+                  remarks: ID of the user who created the timeline
+                  name: creator_id
+                  type: int
+                  constraints:
+                    nullable: false
+                    references: core_user(id)
+                    foreignKeyName: fk_timeline_creator_id
+                    deleteCascade: true
+              - column:
+                  remarks: The timestamp of when the timeline was created
+                  name: created_at
+                  type: ${timestamp_type}
+                  defaultValueComputed: current_timestamp
+                  constraints:
+                    nullable: false
+              - column:
+                  remarks: The timestamp of when the timeline was updated
+                  name: updated_at
+                  type: ${timestamp_type}
+                  defaultValueComputed: current_timestamp
+                  constraints:
+                    nullable: false
+
+  - changeSet:
+      id: v43.00-022
+      author: adam-james
+      comment: Added 0.43.0 - Events table
+      changes:
+        - createTable:
+            tableName: timeline_event
+            remarks: Events table
+            columns:
+              - column:
+                  name: id
+                  type: int
+                  autoIncrement: true
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+              - column:
+                  remarks: ID of the timeline containing the event
+                  name: timeline_id
+                  type: int
+                  constraints:
+                    nullable: false
+                    references: timeline(id)
+                    foreignKeyName: fk_events_timeline_id
+                    deleteCascade: true
+              - column:
+                  remarks: Name of the event
+                  name: name
+                  type: varchar(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  remarks: Optional markdown description of the event
+                  name: description
+                  type: varchar(255)
+                  constraints:
+                    nullable: true
+              - column:
+                  name: timestamp
+                  type: ${timestamp_type}
+                  constraints:
+                    nullable: false
+                  remarks: When the event happened
+              - column:
+                  name: time_matters
+                  type: boolean
+                  constraints:
+                    nullable: false
+                  remarks: >-
+                     Indicate whether the time component matters or if the timestamp should just serve to indicate the
+                     day of the event without any time associated to it.
+              - column:
+                  name: timezone
+                  constraints:
+                    nullable: false
+                  type: varchar(255)
+                  remarks: Timezone to display the underlying UTC timestamp in for the client
+              - column:
+                  name: icon
+                  type: varchar(128)
+                  constraints:
+                    nullable: true
+                  remarks: the icon to use when displaying the event
+              - column:
+                  remarks: Whether or not the event has been archived
+                  name: archived
+                  type: boolean
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false
+              - column:
+                  remarks: ID of the user who created the event
+                  name: creator_id
+                  type: int
+                  constraints:
+                    nullable: false
+                    references: core_user(id)
+                    foreignKeyName: fk_event_creator_id
+                    deleteCascade: true
+              - column:
+                  remarks: The timestamp of when the event was created
+                  name: created_at
+                  type: ${timestamp_type}
+                  defaultValueComputed: current_timestamp
+                  constraints:
+                    nullable: false
+              - column:
+                  remarks: The timestamp of when the event was modified
+                  name: updated_at
+                  type: ${timestamp_type}
+                  defaultValueComputed: current_timestamp
+                  constraints:
+                    nullable: false
+
+  - changeSet:
+      id: v43.00-023
+      author: dpsutton
+      comment: Added 0.43.0 - Index on timeline collection_id
+      changes:
+        - createIndex:
+            tableName: timeline
+            indexName: idx_timeline_collection_id
+            columns:
+              - column:
+                  name: collection_id
+
+  - changeSet:
+      id: v43.00-024
+      author: dpsutton
+      comment: Added 0.43.0 - Index on timeline_event timeline_id
+      changes:
+        - createIndex:
+            tableName: timeline_event
+            indexName: idx_timeline_event_timeline_id
+            columns:
+              - column:
+                  name: timeline_id
+
+  - changeSet:
+      id: v43.00-025
+      author: dpsutton
+      comment: Added 0.43.0 - Index on timeline timestamp
+      changes:
+        - createIndex:
+            tableName: timeline_event
+            indexName: idx_timeline_event_timeline_id_timestamp
+            columns:
+              - column:
+                  name: timeline_id
+              - column:
+                  name: timestamp
 
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -10075,6 +10075,44 @@ databaseChangeLog:
                   constraints:
                     nullable: false
 
+  - changeSet:
+      id: v43.00-004
+      author: dpsutton
+      comment: Added 0.43.0 - Index on timeline collection_id
+      changes:
+        - createIndex:
+            tableName: timeline
+            indexName: idx_timeline_collection_id
+            columns:
+              - column:
+                  name: collection_id
+
+  - changeSet:
+      id: v43.00-005
+      author: dpsutton
+      comment: Added 0.43.0 - Index on timeline_event timeline_id
+      changes:
+        - createIndex:
+            tableName: timeline_event
+            indexName: idx_timeline_event_timeline_id
+            columns:
+              - column:
+                  name: timeline_id
+
+  - changeSet:
+      id: v43.00-006
+      author: dpsutton
+      comment: Added 0.43.0 - Index on timeline timestamp
+      changes:
+        - createIndex:
+            tableName: timeline_event
+            indexName: idx_timeline_event_timeline_id_timestamp
+            columns:
+              - column:
+                  name: timeline_id
+              - column:
+                  name: timestamp
+
   #
   # The next few migrations replace metabase.db.data-migrations/add-users-to-default-permissions-groups from 0.20.0
   #

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -10020,7 +10020,7 @@ databaseChangeLog:
                     nullable: true
               - column:
                   name: timestamp
-                  type: timestamp with time zone
+                  type: ${timestamp_type}
                   constraints:
                     nullable: false
                   remarks: When the event happened
@@ -10037,6 +10037,7 @@ databaseChangeLog:
                   constraints:
                     nullable: false
                   type: varchar(255)
+                  remarks: Timezone to display the underlying UTC timestamp in for the client
               - column:
                   name: icon
                   type: varchar(128)
@@ -10068,7 +10069,7 @@ databaseChangeLog:
                     nullable: false
               - column:
                   remarks: The timestamp of when the event was modified
-                  name: modified_at
+                  name: updated_at
                   type: ${timestamp_type}
                   defaultValueComputed: current_timestamp
                   constraints:

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -9908,7 +9908,7 @@ databaseChangeLog:
             sql: UPDATE metabase_database SET engine = 'bigquery-cloud-sdk' WHERE engine = 'bigquery'
 
   - changeSet:
-      id: v43.00-002
+      id: v43.00-021
       author: adam-james
       comment: Added 0.43.0 - Timeline table for Events
       changes:
@@ -9982,7 +9982,7 @@ databaseChangeLog:
                     nullable: false
 
   - changeSet:
-      id: v43.00-003
+      id: v43.00-022
       author: adam-james
       comment: Added 0.43.0 - Events table
       changes:
@@ -10076,7 +10076,7 @@ databaseChangeLog:
                     nullable: false
 
   - changeSet:
-      id: v43.00-004
+      id: v43.00-023
       author: dpsutton
       comment: Added 0.43.0 - Index on timeline collection_id
       changes:
@@ -10088,7 +10088,7 @@ databaseChangeLog:
                   name: collection_id
 
   - changeSet:
-      id: v43.00-005
+      id: v43.00-024
       author: dpsutton
       comment: Added 0.43.0 - Index on timeline_event timeline_id
       changes:
@@ -10100,7 +10100,7 @@ databaseChangeLog:
                   name: timeline_id
 
   - changeSet:
-      id: v43.00-006
+      id: v43.00-025
       author: dpsutton
       comment: Added 0.43.0 - Index on timeline timestamp
       changes:

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -9907,6 +9907,166 @@ databaseChangeLog:
         - sql:
             sql: UPDATE metabase_database SET engine = 'bigquery-cloud-sdk' WHERE engine = 'bigquery'
 
+  - changeSet:
+      id: v43.00-002
+      author: adam-james
+      comment: Added 0.43.0 - Timeline table for Events
+      changes:
+        - createTable:
+            tableName: timeline
+            remarks: Timeline table to organize events
+            columns:
+              - column:
+                  name: id
+                  type: int
+                  autoIncrement: true
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+              - column:
+                  remarks: Name of the timeline
+                  name: name
+                  type: varchar(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  remarks: Optional description of the timeline
+                  name: description
+                  type: varchar(255)
+                  constraints:
+                    nullable: true
+              - column:
+                  remarks: ID of the collection containing the timeline
+                  name: collection_id
+                  type: int
+                  constraints:
+                    nullable: false
+                    references: collection(id)
+                    foreignKeyName: fk_timeline_collection_id
+                    deleteCascade: true
+              - column:
+                  remarks: Whether or not the timeline has been archived
+                  name: archived
+                  type: boolean
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false
+              - column:
+                  remarks: ID of the user who created the timeline
+                  name: creator_id
+                  type: int
+                  constraints:
+                    nullable: false
+                    references: core_user(id)
+                    foreignKeyName: fk_timeline_creator_id
+                    deleteCascade: true
+              - column:
+                  remarks: The timestamp of when the timeline was created
+                  name: created_at
+                  type: ${timestamp_type}
+                  defaultValueComputed: current_timestamp
+                  constraints:
+                    nullable: false
+              - column:
+                  remarks: The timestamp of when the timeline was updated
+                  name: updated_at
+                  type: ${timestamp_type}
+                  defaultValueComputed: current_timestamp
+                  constraints:
+                    nullable: false
+
+  - changeSet:
+      id: v43.00-003
+      author: adam-james
+      comment: Added 0.43.0 - Events table
+      changes:
+        - createTable:
+            tableName: events
+            remarks: Events table
+            columns:
+              - column:
+                  name: id
+                  type: int
+                  autoIncrement: true
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+              - column:
+                  remarks: ID of the timeline containing the event
+                  name: timeline_id
+                  type: int
+                  constraints:
+                    nullable: false
+                    references: timeline(id)
+                    foreignKeyName: fk_events_timeline_id
+                    deleteCascade: true
+              - column:
+                  remarks: Name of the event
+                  name: name
+                  type: varchar(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  remarks: Optional markdown description of the event
+                  name: description
+                  type: varchar(255)
+                  constraints:
+                    nullable: true
+              - column:
+                  name: date
+                  type: date
+                  constraints:
+                    nullable: false
+                  remarks: The date on which the event occurred
+              - column:
+                  name: time
+                  type: time
+                  constraints:
+                    nullable: true
+                  remarks: The optional details of when on the date the event occurred
+              - column:
+                  name: timezone
+                  type: timestamp with time zone
+                  constraints:
+                    nullable: true
+                  remarks: The optional timezone to display the event's datetime in
+              - column:
+                  name: icon
+                  type: varchar(128)
+                  constraints:
+                    nullable: false
+                  remarks: the icon to use when displaying the event
+              - column:
+                  remarks: Whether or not the event has been archived
+                  name: archived
+                  type: boolean
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false
+              - column:
+                  remarks: ID of the user who created the event
+                  name: creator_id
+                  type: int
+                  constraints:
+                    nullable: false
+                    references: core_user(id)
+                    foreignKeyName: fk_event_creator_id
+                    deleteCascade: true
+              - column:
+                  remarks: The timestamp of when the event was created
+                  name: created_at
+                  type: ${timestamp_type}
+                  defaultValueComputed: current_timestamp
+                  constraints:
+                    nullable: false
+              - column:
+                  remarks: The timestamp of when the event was modified
+                  name: modified_at
+                  type: ${timestamp_type}
+                  defaultValueComputed: current_timestamp
+                  constraints:
+                    nullable: false
+
   #
   # The next few migrations replace metabase.db.data-migrations/add-users-to-default-permissions-groups from 0.20.0
   #

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -10025,6 +10025,19 @@ databaseChangeLog:
                     nullable: false
                   remarks: When the event happened
               - column:
+                  name: time_matters
+                  type: boolean
+                  constraints:
+                    nullable: false
+                  remarks: >-
+                     Indicate whether the time component matters or if the timestamp should just serve to indicate the
+                     day of the event without any time associated to it.
+              - column:
+                  name: timezone
+                  constraints:
+                    nullable: false
+                  type: varchar(255)
+              - column:
                   name: icon
                   type: varchar(128)
                   constraints:

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -9,6 +9,7 @@
             [medley.core :as m]
             [metabase.api.common :as api]
             [metabase.api.dataset :as dataset-api]
+            [metabase.api.timeline :as timeline-api]
             [metabase.async.util :as async.u]
             [metabase.email.messages :as messages]
             [metabase.events :as events]
@@ -176,12 +177,13 @@
 
 (api/defendpoint GET "/:id/timelines"
   "Get the timelines for card with ID. Looks up the collection the card is in and uses that."
-  [id]
+  [id include]
+  {include (s/maybe timeline-api/include-events-schema)}
   (let [{:keys [collection_id] :as _card} (api/read-check Card id)]
     ;; subtlety here. timeline access is based on the collection at the moment so this check should be identical. If
     ;; we allow adding more timelines to a card in the future, we will need to filter on read-check and i don't think
     ;; the read-checks are particularly fast on multiple items
-    (timeline/timelines-for-collection collection_id)))
+    (timeline/timelines-for-collection collection_id include)))
 
 ;;; -------------------------------------------------- Saving Cards --------------------------------------------------
 

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -24,6 +24,7 @@
             [metabase.models.query.permissions :as query-perms]
             [metabase.models.revision.last-edit :as last-edit]
             [metabase.models.table :refer [Table]]
+            [metabase.models.timeline :as timeline]
             [metabase.models.view-log :refer [ViewLog]]
             [metabase.query-processor.async :as qp.async]
             [metabase.query-processor.card :as qp.card]
@@ -172,6 +173,15 @@
                api/read-check
                (last-edit/with-last-edit-info :card))
     (events/publish-event! :card-read (assoc <> :actor_id api/*current-user-id*))))
+
+(api/defendpoint GET "/:id/timelines"
+  "Get the timelines for card with ID. Looks up the collection the card is in and uses that."
+  [id]
+  (let [{:keys [collection_id] :as _card} (api/read-check Card id)]
+    ;; subtlety here. timeline access is based on the collection at the moment so this check should be identical. If
+    ;; we allow adding more timelines to a card in the future, we will need to filter on read-check and i don't think
+    ;; the read-checks are particularly fast on multiple items
+    (timeline/timelines-for-collection collection_id)))
 
 ;;; -------------------------------------------------- Saving Cards --------------------------------------------------
 

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -184,8 +184,9 @@
     ;; subtlety here. timeline access is based on the collection at the moment so this check should be identical. If
     ;; we allow adding more timelines to a card in the future, we will need to filter on read-check and i don't think
     ;; the read-checks are particularly fast on multiple items
-    (timeline/timelines-for-collection collection_id {:include include
-                                                      :archived archived})))
+    (let [archived? (Boolean/parseBoolean archived)]
+      (timeline/timelines-for-collection collection_id {:include  include
+                                                        :archived archived?}))))
 
 ;;; -------------------------------------------------- Saving Cards --------------------------------------------------
 

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -179,7 +179,7 @@
 (api/defendpoint GET "/:id/timelines"
   "Get the timelines for card with ID. Looks up the collection the card is in and uses that."
   [id include start end]
-  {include (s/maybe timeline-api/include-events-schema)
+  {include (s/maybe timeline-api/Include)
    start   (s/maybe su/TemporalString)
    end     (s/maybe su/TemporalString)}
   (let [{:keys [collection_id] :as _card} (api/read-check Card id)]

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -177,13 +177,15 @@
 
 (api/defendpoint GET "/:id/timelines"
   "Get the timelines for card with ID. Looks up the collection the card is in and uses that."
-  [id include]
-  {include (s/maybe timeline-api/include-events-schema)}
+  [id include archived]
+  {include  (s/maybe timeline-api/include-events-schema)
+   archived (s/maybe su/BooleanString)}
   (let [{:keys [collection_id] :as _card} (api/read-check Card id)]
     ;; subtlety here. timeline access is based on the collection at the moment so this check should be identical. If
     ;; we allow adding more timelines to a card in the future, we will need to filter on read-check and i don't think
     ;; the read-checks are particularly fast on multiple items
-    (timeline/timelines-for-collection collection_id include)))
+    (timeline/timelines-for-collection collection_id {:include include
+                                                      :archived archived})))
 
 ;;; -------------------------------------------------- Saving Cards --------------------------------------------------
 

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -24,7 +24,7 @@
             [metabase.models.pulse :as pulse :refer [Pulse]]
             [metabase.models.pulse-card :refer [PulseCard]]
             [metabase.models.revision.last-edit :as last-edit]
-            [metabase.models.timeline :refer [Timeline]]
+            [metabase.models.timeline :as timeline :refer [Timeline]]
             [metabase.server.middleware.offset-paging :as offset-paging]
             [metabase.util :as u]
             [metabase.util.honeysql-extensions :as hx]
@@ -536,7 +536,7 @@
   "Fetch a specific Collection's timelines."
   ;; todo: do we care about `archived` option?
   [id]
-  (hydrate (db/select Timeline :collection_id id) :timeline-events))
+  (timeline/timelines-for-collection id))
 
 (api/defendpoint GET "/:id/items"
   "Fetch a specific Collection's items with the following options:

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -11,6 +11,7 @@
             [medley.core :as m]
             [metabase.api.card :as card-api]
             [metabase.api.common :as api]
+            [metabase.api.timeline :as timeline-api]
             [metabase.db :as mdb]
             [metabase.models.card :refer [Card]]
             [metabase.models.collection :as collection :refer [Collection]]
@@ -530,14 +531,14 @@
   "Fetch the root Collection's timelines."
   ;; todo: do we care about `archived` option?
   [include]
-  {include (s/maybe (s/enum "events"))}
+  {include (s/maybe timeline-api/include-events-schema)}
   (timeline/timelines-for-collection nil include))
 
 (api/defendpoint GET "/:id/timelines"
   "Fetch a specific Collection's timelines."
   ;; todo: do we care about `archived` option?
   [id include]
-  {include (s/maybe (s/enum "events"))}
+  {include (s/maybe timeline-api/include-events-schema)}
   (timeline/timelines-for-collection id include))
 
 (api/defendpoint GET "/:id/items"

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -530,14 +530,14 @@
   "Fetch the root Collection's timelines."
   ;; todo: do we care about `archived` option?
   [include]
-  {include (s/maybe s/Str)}
+  {include (s/maybe (s/enum "events"))}
   (timeline/timelines-for-collection nil include))
 
 (api/defendpoint GET "/:id/timelines"
   "Fetch a specific Collection's timelines."
   ;; todo: do we care about `archived` option?
   [id include]
-  {include (s/maybe s/Str)}
+  {include (s/maybe (s/enum "events"))}
   (timeline/timelines-for-collection id include))
 
 (api/defendpoint GET "/:id/items"

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -527,16 +527,18 @@
   (collection-detail (api/read-check Collection id)))
 
 (api/defendpoint GET "/root/timelines"
-  "Fetch a specific Collection's timelines."
+  "Fetch the root Collection's timelines."
   ;; todo: do we care about `archived` option?
-  []
-  (hydrate (db/select Timeline :collection_id nil) :timeline-events))
+  [include]
+  {include (s/maybe s/Str)}
+  (timeline/timelines-for-collection nil include))
 
 (api/defendpoint GET "/:id/timelines"
   "Fetch a specific Collection's timelines."
   ;; todo: do we care about `archived` option?
-  [id]
-  (timeline/timelines-for-collection id))
+  [id include]
+  {include (s/maybe s/Str)}
+  (timeline/timelines-for-collection id include))
 
 (api/defendpoint GET "/:id/items"
   "Fetch a specific Collection's items with the following options:

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -24,6 +24,7 @@
             [metabase.models.pulse :as pulse :refer [Pulse]]
             [metabase.models.pulse-card :refer [PulseCard]]
             [metabase.models.revision.last-edit :as last-edit]
+            [metabase.models.timeline :refer [Timeline]]
             [metabase.server.middleware.offset-paging :as offset-paging]
             [metabase.util :as u]
             [metabase.util.honeysql-extensions :as hx]
@@ -506,6 +507,18 @@
   "Fetch a specific Collection with standard details added"
   [id]
   (collection-detail (api/read-check Collection id)))
+
+(api/defendpoint GET "/root/timelines"
+  "Fetch a specific Collection's timelines."
+  ;; todo: do we care about `archived` option?
+  []
+  (hydrate (db/select Timeline :collection_id nil) :timeline-events))
+
+(api/defendpoint GET "/:id/timelines"
+  "Fetch a specific Collection's timelines."
+  ;; todo: do we care about `archived` option?
+  [id]
+  (hydrate (db/select Timeline :collection_id id) :timeline-events))
 
 (api/defendpoint GET "/:id/items"
   "Fetch a specific Collection's items with the following options:

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -189,7 +189,7 @@
 (defmethod post-process-collection-children :pulse
   [_ rows]
   (for [row rows]
-    (dissoc row :description :display :authority_level :moderated_status)))
+    (dissoc row :description :display :authority_level :moderated_status :icon)))
 
 (defmethod collection-children-query :snippet
   [_ collection {:keys [archived?]}]
@@ -216,7 +216,9 @@
 (defmethod post-process-collection-children :snippet
   [_ rows]
   (for [row rows]
-    (dissoc row :description :collection_position :display :authority_level :moderated_status)))
+    (dissoc row
+            :description :collection_position :display :authority_level
+            :moderated_status :icon)))
 
 (defn- card-query [dataset? collection {:keys [archived? pinned-state]}]
   (-> {:select    [:c.id :c.name :c.description :c.collection_position :c.display
@@ -268,7 +270,7 @@
 
 (defmethod post-process-collection-children :card
   [_ rows]
-  (hydrate (map #(dissoc % :authority_level) rows) :favorite))
+  (hydrate (map #(dissoc % :authority_level :icon) rows) :favorite))
 
 (defmethod collection-children-query :dashboard
   [_ collection {:keys [archived? pinned-state]}]
@@ -295,7 +297,7 @@
 
 (defmethod post-process-collection-children :dashboard
   [_ rows]
-  (hydrate (map #(dissoc % :display :authority_level :moderated_status) rows) :favorite))
+  (hydrate (map #(dissoc % :display :authority_level :moderated_status :icon) rows) :favorite))
 
 (defmethod collection-children-query :collection
   [_ collection {:keys [archived? collection-namespace pinned-state]}]
@@ -320,7 +322,7 @@
     ;; don't get models back from ulterior over-query
     ;; Previous examination with logging to DB says that there's no N+1 query for this.
     ;; However, this was only tested on H2 and Postgres
-    (assoc (dissoc row :collection_position :display :moderated_status)
+    (assoc (dissoc row :collection_position :display :moderated_status :icon)
            :can_write
            (mi/can-write? Collection (:id row)))))
 

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -529,17 +529,19 @@
 
 (api/defendpoint GET "/root/timelines"
   "Fetch the root Collection's timelines."
-  ;; todo: do we care about `archived` option?
-  [include]
-  {include (s/maybe timeline-api/include-events-schema)}
-  (timeline/timelines-for-collection nil include))
+  [include archived]
+  {include  (s/maybe timeline-api/include-events-schema)
+   archived (s/maybe su/BooleanString)}
+  (timeline/timelines-for-collection nil {:include  include
+                                          :archived archived}))
 
 (api/defendpoint GET "/:id/timelines"
   "Fetch a specific Collection's timelines."
-  ;; todo: do we care about `archived` option?
-  [id include]
-  {include (s/maybe timeline-api/include-events-schema)}
-  (timeline/timelines-for-collection id include))
+  [id include archived]
+  {include  (s/maybe timeline-api/include-events-schema)
+   archived (s/maybe su/BooleanString)}
+  (timeline/timelines-for-collection id {:include  include
+                                         :archived archived}))
 
 (api/defendpoint GET "/:id/items"
   "Fetch a specific Collection's items with the following options:

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -209,8 +209,7 @@
             [:= :archived (boolean archived?)]]})
 
 (defmethod collection-children-query :timeline
-  [_ collection {:keys [archived? pinned-state] :as x}]
-  ;; might need "poison" this query when asking for pinned items
+  [_ collection {:keys [archived? pinned-state]}]
   {:select [:id :name [(hx/literal "timeline") :model] :description :icon]
    :from   [[Timeline :timeline]]
    :where  [:and

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -532,16 +532,18 @@
   [include archived]
   {include  (s/maybe timeline-api/include-events-schema)
    archived (s/maybe su/BooleanString)}
-  (timeline/timelines-for-collection nil {:include  include
-                                          :archived archived}))
+  (let [archived? (Boolean/parseBoolean archived)]
+    (timeline/timelines-for-collection nil {:include  include
+                                            :archived archived?})))
 
 (api/defendpoint GET "/:id/timelines"
   "Fetch a specific Collection's timelines."
   [id include archived]
   {include  (s/maybe timeline-api/include-events-schema)
    archived (s/maybe su/BooleanString)}
-  (timeline/timelines-for-collection id {:include  include
-                                         :archived archived}))
+  (let [archived? (Boolean/parseBoolean archived)]
+    (timeline/timelines-for-collection id {:include  include
+                                           :archived archived?})))
 
 (api/defendpoint GET "/:id/items"
   "Fetch a specific Collection's items with the following options:

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -533,8 +533,8 @@
   {include  (s/maybe timeline-api/include-events-schema)
    archived (s/maybe su/BooleanString)}
   (let [archived? (Boolean/parseBoolean archived)]
-    (timeline/timelines-for-collection nil {:include  include
-                                            :archived archived?})))
+    (timeline/timelines-for-collection nil {:timeline/events?   (= include "events")
+                                            :timeline/archived? archived?})))
 
 (api/defendpoint GET "/:id/timelines"
   "Fetch a specific Collection's timelines."
@@ -542,8 +542,8 @@
   {include  (s/maybe timeline-api/include-events-schema)
    archived (s/maybe su/BooleanString)}
   (let [archived? (Boolean/parseBoolean archived)]
-    (timeline/timelines-for-collection id {:include  include
-                                           :archived archived?})))
+    (timeline/timelines-for-collection id {:timeline/events?   (= include "events")
+                                           :timeline/archived? archived?})))
 
 (api/defendpoint GET "/:id/items"
   "Fetch a specific Collection's items with the following options:

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -530,7 +530,7 @@
 (api/defendpoint GET "/root/timelines"
   "Fetch the root Collection's timelines."
   [include archived]
-  {include  (s/maybe timeline-api/include-events-schema)
+  {include  (s/maybe timeline-api/Include)
    archived (s/maybe su/BooleanString)}
   (let [archived? (Boolean/parseBoolean archived)]
     (timeline/timelines-for-collection nil {:timeline/events?   (= include "events")
@@ -539,7 +539,7 @@
 (api/defendpoint GET "/:id/timelines"
   "Fetch a specific Collection's timelines."
   [id include archived]
-  {include  (s/maybe timeline-api/include-events-schema)
+  {include  (s/maybe timeline-api/Include)
    archived (s/maybe su/BooleanString)}
   (let [archived? (Boolean/parseBoolean archived)]
     (timeline/timelines-for-collection id {:timeline/events?   (= include "events")

--- a/src/metabase/api/routes.clj
+++ b/src/metabase/api/routes.clj
@@ -36,7 +36,6 @@
             [metabase.api.testing :as testing]
             [metabase.api.tiles :as tiles]
             [metabase.api.timeline :as timeline]
-            ;; todo: singularize these
             [metabase.api.timeline-event :as timeline-event]
             [metabase.api.transform :as transform]
             [metabase.api.user :as user]

--- a/src/metabase/api/routes.clj
+++ b/src/metabase/api/routes.clj
@@ -35,6 +35,7 @@
             [metabase.api.task :as task]
             [metabase.api.testing :as testing]
             [metabase.api.tiles :as tiles]
+            [metabase.api.timeline :as timeline]
             [metabase.api.transform :as transform]
             [metabase.api.user :as user]
             [metabase.api.util :as util]
@@ -93,6 +94,7 @@
                                         testing/routes
                                         (fn [_ respond _] (respond nil))))
   (context "/tiles"                [] (+auth tiles/routes))
+  (context "/timeline"             [] (+auth timeline/routes))
   (context "/transform"            [] (+auth transform/routes))
   (context "/user"                 [] (+auth user/routes))
   (context "/util"                 [] util/routes)

--- a/src/metabase/api/routes.clj
+++ b/src/metabase/api/routes.clj
@@ -36,6 +36,8 @@
             [metabase.api.testing :as testing]
             [metabase.api.tiles :as tiles]
             [metabase.api.timeline :as timeline]
+            ;; todo: singularize these
+            [metabase.api.timeline-events :as timeline-events]
             [metabase.api.transform :as transform]
             [metabase.api.user :as user]
             [metabase.api.util :as util]
@@ -95,6 +97,7 @@
                                         (fn [_ respond _] (respond nil))))
   (context "/tiles"                [] (+auth tiles/routes))
   (context "/timeline"             [] (+auth timeline/routes))
+  (context "/timeline-event"       [] (+auth timeline-events/routes))
   (context "/transform"            [] (+auth transform/routes))
   (context "/user"                 [] (+auth user/routes))
   (context "/util"                 [] util/routes)

--- a/src/metabase/api/routes.clj
+++ b/src/metabase/api/routes.clj
@@ -37,7 +37,7 @@
             [metabase.api.tiles :as tiles]
             [metabase.api.timeline :as timeline]
             ;; todo: singularize these
-            [metabase.api.timeline-events :as timeline-events]
+            [metabase.api.timeline-event :as timeline-event]
             [metabase.api.transform :as transform]
             [metabase.api.user :as user]
             [metabase.api.util :as util]
@@ -97,7 +97,7 @@
                                         (fn [_ respond _] (respond nil))))
   (context "/tiles"                [] (+auth tiles/routes))
   (context "/timeline"             [] (+auth timeline/routes))
-  (context "/timeline-event"       [] (+auth timeline-events/routes))
+  (context "/timeline-event"       [] (+auth timeline-event/routes))
   (context "/transform"            [] (+auth transform/routes))
   (context "/user"                 [] (+auth user/routes))
   (context "/util"                 [] util/routes)

--- a/src/metabase/api/timeline.clj
+++ b/src/metabase/api/timeline.clj
@@ -7,6 +7,7 @@
             [metabase.util.schema :as su]
             [schema.core :as s]
             [toucan.db :as db]
+            [toucan.hydrate :refer [hydrate]]
             [metabase.util :as u]))
 
 
@@ -25,7 +26,8 @@
 (api/defendpoint GET "/:id"
   "Fetch the [[Timeline]] with `id`."
   [id]
-  (api/read-check (Timeline id)))
+  (let [timeline (api/read-check (Timeline id))]
+    (hydrate timeline :creator)))
 
 (api/defendpoint PUT "/:id"
   [id :as {{:keys [name description icon collection_id archived] :as timeline-updates} :body}]
@@ -42,7 +44,7 @@
       (u/select-keys-when timeline-updates
         :present #{:description :icon :collection_id :archived}
         :non-nil #{:name}))
-    (Timeline id)))
+    (hydrate (Timeline id) :creator)))
 
 
 ;; todo: icons

--- a/src/metabase/api/timeline.clj
+++ b/src/metabase/api/timeline.clj
@@ -10,6 +10,7 @@
             [toucan.hydrate :refer [hydrate]]
             [metabase.util :as u]))
 
+(def include-events-schema (s/enum "events"))
 
 (api/defendpoint POST "/"
   "Create a new [[Timeline]]."
@@ -26,7 +27,7 @@
 (api/defendpoint GET "/:id"
   "Fetch the [[Timeline]] with `id`."
   [id include]
-  {include (s/maybe (s/enum "events"))}
+  {include (s/maybe include-events-schema)}
   (let [timeline (api/read-check (Timeline id))]
     (if include
       (hydrate timeline :creator :events)

--- a/src/metabase/api/timeline.clj
+++ b/src/metabase/api/timeline.clj
@@ -26,7 +26,7 @@
 (api/defendpoint GET "/:id"
   "Fetch the [[Timeline]] with `id`."
   [id include]
-  {include (s/maybe s/Str)}
+  {include (s/maybe (s/enum "events"))}
   (let [timeline (api/read-check (Timeline id))]
     (if include
       (hydrate timeline :creator :events)

--- a/src/metabase/api/timeline.clj
+++ b/src/metabase/api/timeline.clj
@@ -25,11 +25,15 @@
 
 (api/defendpoint GET "/:id"
   "Fetch the [[Timeline]] with `id`."
-  [id]
+  [id include]
+  {include (s/maybe s/Str)}
   (let [timeline (api/read-check (Timeline id))]
-    (hydrate timeline :creator)))
+    (if include
+      (hydrate timeline :creator :events)
+      (hydrate timeline :creator))))
 
 (api/defendpoint PUT "/:id"
+  "Update the [[Timeline]] with `id`."
   [id :as {{:keys [name description icon collection_id archived] :as timeline-updates} :body}]
   {name          (s/maybe su/NonBlankString)
    description   (s/maybe s/Str)

--- a/src/metabase/api/timeline.clj
+++ b/src/metabase/api/timeline.clj
@@ -13,12 +13,12 @@
 (api/defendpoint POST "/"
   "Create a new [[Timeline]]."
   [:as {{:keys [name description icon collection_id archived], :as body} :body}]
-  {name su/NonBlankString
-   description (s/maybe s/Str)
+  {name          su/NonBlankString
+   description   (s/maybe s/Str)
    ;; todo: there are six valid ones. What are they?
-   icon (s/maybe s/Str)
+   icon          (s/maybe s/Str)
    collection_id (s/maybe su/IntGreaterThanZero)
-   archived (s/maybe s/Bool)}
+   archived      (s/maybe s/Bool)}
   (collection/check-write-perms-for-collection collection_id)
   (db/insert! Timeline (assoc body :creator_id api/*current-user-id*)))
 
@@ -29,12 +29,12 @@
 
 (api/defendpoint PUT "/:id"
   [id :as {{:keys [name description icon collection_id archived] :as timeline-updates} :body}]
-  {name su/NonBlankString
-   description (s/maybe s/Str)
+  {name          su/NonBlankString
+   description   (s/maybe s/Str)
    ;; todo: there are six valid ones. What are they?
-   icon (s/maybe s/Str)
+   icon          (s/maybe s/Str)
    collection_id (s/maybe su/IntGreaterThanZero)
-   archived (s/maybe s/Bool)}
+   archived      (s/maybe s/Bool)}
   ;; todo: icon is valid
   (let [existing (api/write-check Timeline id)]
     (collection/check-allowed-to-change-collection existing timeline-updates)

--- a/src/metabase/api/timeline.clj
+++ b/src/metabase/api/timeline.clj
@@ -29,7 +29,7 @@
 
 (api/defendpoint PUT "/:id"
   [id :as {{:keys [name description icon collection_id archived] :as timeline-updates} :body}]
-  {name          su/NonBlankString
+  {name          (s/maybe su/NonBlankString)
    description   (s/maybe s/Str)
    ;; todo: there are six valid ones. What are they?
    icon          (s/maybe s/Str)

--- a/src/metabase/api/timeline.clj
+++ b/src/metabase/api/timeline.clj
@@ -1,0 +1,50 @@
+(ns metabase.api.timeline
+  "/api/timeline endpoints."
+  (:require [compojure.core :refer [DELETE GET POST PUT]]
+            [metabase.api.common :as api]
+            [metabase.models.collection :as collection]
+            [metabase.models.timeline :refer [Timeline]]
+            [metabase.util.schema :as su]
+            [schema.core :as s]
+            [toucan.db :as db]
+            [metabase.util :as u]))
+
+
+(api/defendpoint POST "/"
+  "Create a new [[Timeline]]."
+  [:as {{:keys [name description icon collection_id archived], :as body} :body}]
+  {name su/NonBlankString
+   description (s/maybe s/Str)
+   ;; todo: there are six valid ones. What are they?
+   icon (s/maybe s/Str)
+   collection_id (s/maybe su/IntGreaterThanZero)
+   archived (s/maybe s/Bool)}
+  (collection/check-write-perms-for-collection collection_id)
+  (db/insert! Timeline (assoc body :creator_id api/*current-user-id*)))
+
+(api/defendpoint GET "/:id"
+  "Fetch the [[Timeline]] with `id`."
+  [id]
+  (api/read-check (Timeline id)))
+
+(api/defendpoint PUT "/:id"
+  [id :as {{:keys [name description icon collection_id archived] :as timeline-updates} :body}]
+  {name su/NonBlankString
+   description (s/maybe s/Str)
+   ;; todo: there are six valid ones. What are they?
+   icon (s/maybe s/Str)
+   collection_id (s/maybe su/IntGreaterThanZero)
+   archived (s/maybe s/Bool)}
+  ;; todo: icon is valid
+  (let [existing (api/write-check Timeline id)]
+    (collection/check-allowed-to-change-collection existing timeline-updates)
+    (db/update! Timeline id
+      (u/select-keys-when timeline-updates
+        :present #{description icon collection_id archived}
+        :non-nil #{name}))))
+
+
+
+;; todo: icons
+;; todo: how does updated-at work?
+(api/define-routes)

--- a/src/metabase/api/timeline.clj
+++ b/src/metabase/api/timeline.clj
@@ -40,9 +40,9 @@
     (collection/check-allowed-to-change-collection existing timeline-updates)
     (db/update! Timeline id
       (u/select-keys-when timeline-updates
-        :present #{description icon collection_id archived}
-        :non-nil #{name}))))
-
+        :present #{:description :icon :collection_id :archived}
+        :non-nil #{:name}))
+    (Timeline id)))
 
 
 ;; todo: icons

--- a/src/metabase/api/timeline.clj
+++ b/src/metabase/api/timeline.clj
@@ -1,6 +1,6 @@
 (ns metabase.api.timeline
   "/api/timeline endpoints."
-  (:require [compojure.core :refer [GET POST PUT]]
+  (:require [compojure.core :refer [DELETE GET POST PUT]]
             [metabase.api.common :as api]
             [metabase.models.collection :as collection]
             [metabase.models.timeline :refer [Timeline]]
@@ -67,6 +67,13 @@
     (when (and (some? archived) (not= current-archived archived))
       (db/update-where! TimelineEvent {:timeline_id id} :archived archived))
     (hydrate (Timeline id) :creator)))
+
+(api/defendpoint DELETE "/:id"
+  "Delete a [[Timeline]]. Will cascade delete its events as well."
+  [id]
+  (api/write-check Timeline id)
+  (db/delete! Timeline :id id)
+  api/generic-204-no-content)
 
 
 ;; todo: icons

--- a/src/metabase/api/timeline.clj
+++ b/src/metabase/api/timeline.clj
@@ -1,6 +1,6 @@
 (ns metabase.api.timeline
   "/api/timeline endpoints."
-  (:require [compojure.core :refer [DELETE GET POST PUT]]
+  (:require [compojure.core :refer [GET POST PUT]]
             [metabase.api.common :as api]
             [metabase.models.collection :as collection]
             [metabase.models.timeline :refer [Timeline]]

--- a/src/metabase/api/timeline.clj
+++ b/src/metabase/api/timeline.clj
@@ -26,11 +26,13 @@
 
 (api/defendpoint GET "/:id"
   "Fetch the [[Timeline]] with `id`."
-  [id include]
-  {include (s/maybe include-events-schema)}
-  (let [timeline (api/read-check (Timeline id))]
+  [id include archived]
+  {include (s/maybe include-events-schema)
+   archived (s/maybe su/BooleanString)}
+  (let [timeline (api/read-check (Timeline id))
+        event-hydration-key (if archived :archived-events :events)]
     (if include
-      (hydrate timeline :creator :events)
+      (hydrate timeline :creator event-hydration-key [event-hydration-key :creator])
       (hydrate timeline :creator))))
 
 (api/defendpoint PUT "/:id"

--- a/src/metabase/api/timeline.clj
+++ b/src/metabase/api/timeline.clj
@@ -11,7 +11,7 @@
             [toucan.db :as db]
             [toucan.hydrate :refer [hydrate]]))
 
-(def include-events-schema
+(def Include
   "Events Query Parameters Schema"
   (s/enum "events"))
 
@@ -38,7 +38,7 @@
   "Fetch the [[Timeline]] with `id`. Include `include=events` to unarchived events included on the timeline. Add
   `archived=true` to return all events on the timeline, both archived and unarchived."
   [id include archived]
-  {include  (s/maybe include-events-schema)
+  {include  (s/maybe Include)
    archived (s/maybe su/BooleanString)}
   (let [archived? (Boolean/parseBoolean archived)
         timeline  (api/read-check (Timeline id))]

--- a/src/metabase/api/timeline.clj
+++ b/src/metabase/api/timeline.clj
@@ -4,13 +4,13 @@
             [metabase.api.common :as api]
             [metabase.models.collection :as collection]
             [metabase.models.timeline :refer [Timeline]]
+            [metabase.util :as u]
             [metabase.util.schema :as su]
             [schema.core :as s]
             [toucan.db :as db]
-            [toucan.hydrate :refer [hydrate]]
-            [metabase.util :as u]))
+            [toucan.hydrate :refer [hydrate]]))
 
-(def include-events-schema (s/enum "events"))
+(def ^{:doc "Events Query Parameters Schema"} include-events-schema (s/enum "events"))
 
 (api/defendpoint POST "/"
   "Create a new [[Timeline]]."
@@ -23,6 +23,13 @@
    archived      (s/maybe s/Bool)}
   (collection/check-write-perms-for-collection collection_id)
   (db/insert! Timeline (assoc body :creator_id api/*current-user-id*)))
+
+(api/defendpoint GET "/"
+  "Fetch a list of [[Timelines]]."
+  [archived]
+  {archived (s/maybe su/BooleanString)}
+  (let [archived? (Boolean/parseBoolean archived)]
+    (db/select Timeline [:where [:= :archived archived?]])))
 
 (api/defendpoint GET "/:id"
   "Fetch the [[Timeline]] with `id`."

--- a/src/metabase/api/timeline.clj
+++ b/src/metabase/api/timeline.clj
@@ -27,12 +27,14 @@
 (api/defendpoint GET "/:id"
   "Fetch the [[Timeline]] with `id`."
   [id include archived]
-  {include (s/maybe include-events-schema)
+  {include  (s/maybe include-events-schema)
    archived (s/maybe su/BooleanString)}
-  (let [timeline (api/read-check (Timeline id))
-        event-hydration-key (if archived :archived-events :events)]
+  (let [archived? (Boolean/parseBoolean archived)
+        timeline  (api/read-check (Timeline id))
+        filter-fn (fn [e] (filter #(= (:archived %) archived?) e))]
     (if include
-      (hydrate timeline :creator event-hydration-key [event-hydration-key :creator])
+      (-> (hydrate timeline :creator [:events :creator])
+          (update :events filter-fn))
       (hydrate timeline :creator))))
 
 (api/defendpoint PUT "/:id"

--- a/src/metabase/api/timeline.clj
+++ b/src/metabase/api/timeline.clj
@@ -10,7 +10,9 @@
             [toucan.db :as db]
             [toucan.hydrate :refer [hydrate]]))
 
-(def ^{:doc "Events Query Parameters Schema"} include-events-schema (s/enum "events"))
+(def include-events-schema
+  "Events Query Parameters Schema"
+  (s/enum "events"))
 
 (api/defendpoint POST "/"
   "Create a new [[Timeline]]."

--- a/src/metabase/api/timeline.clj
+++ b/src/metabase/api/timeline.clj
@@ -4,6 +4,7 @@
             [metabase.api.common :as api]
             [metabase.models.collection :as collection]
             [metabase.models.timeline :refer [Timeline]]
+            [metabase.models.timeline-event :as timeline-event]
             [metabase.util :as u]
             [metabase.util.schema :as su]
             [schema.core :as s]
@@ -39,12 +40,10 @@
   {include  (s/maybe include-events-schema)
    archived (s/maybe su/BooleanString)}
   (let [archived? (Boolean/parseBoolean archived)
-        timeline  (api/read-check (Timeline id))
-        filter-fn (fn [e] (filter #(= (:archived %) archived?) e))]
-    (if include
-      (-> (hydrate timeline :creator [:events :creator])
-          (update :events filter-fn))
-      (hydrate timeline :creator))))
+        timeline  (api/read-check (Timeline id))]
+    (cond-> (hydrate timeline :creator)
+      (= include "events")
+      (timeline-event/include-events-singular {:events/all? archived?}))))
 
 (api/defendpoint PUT "/:id"
   "Update the [[Timeline]] with `id`."

--- a/src/metabase/api/timeline_event.clj
+++ b/src/metabase/api/timeline_event.clj
@@ -1,5 +1,5 @@
 (ns metabase.api.timeline-event
-  "/api/timeline_events endpoints."
+  "/api/timeline_event endpoints."
   (:require [compojure.core :refer [DELETE GET POST PUT]]
             [metabase.api.common :as api]
             [metabase.models.collection :as collection]

--- a/src/metabase/api/timeline_event.clj
+++ b/src/metabase/api/timeline_event.clj
@@ -1,5 +1,5 @@
 (ns metabase.api.timeline-event
-  "/api/timeline_event endpoints."
+  "/api/timeline-event endpoints."
   (:require [compojure.core :refer [DELETE GET POST PUT]]
             [metabase.api.common :as api]
             [metabase.models.collection :as collection]

--- a/src/metabase/api/timeline_event.clj
+++ b/src/metabase/api/timeline_event.clj
@@ -1,4 +1,4 @@
-(ns metabase.api.timeline-events
+(ns metabase.api.timeline-event
   "/api/timeline_events endpoints."
   (:require [compojure.core :refer [DELETE GET POST PUT]]
             [metabase.api.common :as api]

--- a/src/metabase/api/timeline_event.clj
+++ b/src/metabase/api/timeline_event.clj
@@ -15,15 +15,15 @@
 (api/defendpoint POST "/"
   "Create a new [[TimelineEvent]]."
   [:as {{:keys [name description timestamp time_matters timezone icon timeline_id archived] :as body} :body}]
-  {name su/NonBlankString
-   description (s/maybe s/Str)
+  {name         su/NonBlankString
+   description  (s/maybe s/Str)
    ;; todo: find schema for timestamps?
-   timestamp s/Str
+   timestamp    s/Str
    time_matters (s/maybe s/Bool)
-   timezone s/Str
-   icon (s/maybe s/Str)
-   timeline_id su/IntGreaterThanZero
-   archived (s/maybe s/Bool)}
+   timezone     s/Str
+   icon         (s/maybe s/Str)
+   timeline_id  su/IntGreaterThanZero
+   archived     (s/maybe s/Bool)}
   ;; deliberately not using api/check-404 so we can have a useful error message.
   (let [timeline (Timeline timeline_id)]
     (when-not timeline
@@ -48,16 +48,16 @@
 (api/defendpoint PUT "/:id"
   "Update a [[TimelineEvent]]."
   [id :as {{:keys [name description timestamp time_matters timezone icon timeline_id archived]
-         :as timeline-event-updates} :body}]
-  {name (s/maybe su/NonBlankString)
-   description (s/maybe s/Str)
+            :as   timeline-event-updates} :body}]
+  {name         (s/maybe su/NonBlankString)
+   description  (s/maybe s/Str)
    ;; todo: find schema for timestamps?
-   timestamp (s/maybe s/Str)
+   timestamp    (s/maybe s/Str)
    time_matters (s/maybe s/Bool)
-   timezone (s/maybe s/Str)
-   icon (s/maybe s/Str)
-   timeline_id (s/maybe su/IntGreaterThanZero)
-   archived (s/maybe s/Bool)}
+   timezone     (s/maybe s/Str)
+   icon         (s/maybe s/Str)
+   timeline_id  (s/maybe su/IntGreaterThanZero)
+   archived     (s/maybe s/Bool)}
   (let [existing (api/check-404 (TimelineEvent id))]
     ;; todo: we can do db operations in the permissions (makes sense, we're doing them anyways. that's the cost of
     ;; this. so either do it in the protocol or manually so of course go for protocol. check out dashboard card for a

--- a/src/metabase/api/timeline_event.clj
+++ b/src/metabase/api/timeline_event.clj
@@ -41,9 +41,7 @@
 (api/defendpoint GET "/:id"
   "Fetch the [[TimelineEvent]] with `id`."
   [id]
-  (let [event (api/check-404 (TimelineEvent id))]
-    (api/read-check (Timeline (:timeline_id event)))
-    event))
+  (api/read-check TimelineEvent id))
 
 (api/defendpoint PUT "/:id"
   "Update a [[TimelineEvent]]."
@@ -58,11 +56,7 @@
    icon         (s/maybe s/Str)
    timeline_id  (s/maybe su/IntGreaterThanZero)
    archived     (s/maybe s/Bool)}
-  (let [existing (api/check-404 (TimelineEvent id))]
-    ;; todo: we can do db operations in the permissions (makes sense, we're doing them anyways. that's the cost of
-    ;; this. so either do it in the protocol or manually so of course go for protocol. check out dashboard card for a
-    ;; similar situation
-    (api/write-check Timeline (:timeline_id existing))
+  (let [existing (api/write-check TimelineEvent id)]
     (collection/check-allowed-to-change-collection existing timeline-event-updates)
     ;; todo: if we accept a new timestamp, must we require a timezone? gut says yes?
     (db/update! TimelineEvent id

--- a/src/metabase/api/timeline_event.clj
+++ b/src/metabase/api/timeline_event.clj
@@ -1,6 +1,6 @@
 (ns metabase.api.timeline-event
   "/api/timeline-event endpoints."
-  (:require [compojure.core :refer [DELETE GET POST PUT]]
+  (:require [compojure.core :refer [GET POST PUT]]
             [metabase.api.common :as api]
             [metabase.models.collection :as collection]
             [metabase.models.timeline :refer [Timeline]]

--- a/src/metabase/api/timeline_event.clj
+++ b/src/metabase/api/timeline_event.clj
@@ -1,6 +1,6 @@
 (ns metabase.api.timeline-event
   "/api/timeline-event endpoints."
-  (:require [compojure.core :refer [GET POST PUT]]
+  (:require [compojure.core :refer [DELETE GET POST PUT]]
             [metabase.api.common :as api]
             [metabase.models.collection :as collection]
             [metabase.models.timeline :refer [Timeline]]
@@ -65,6 +65,13 @@
         :present #{:description :timestamp :time_matters :timezone :icon :timeline_id :archived}
         :non-nil #{:name}))
     (TimelineEvent id)))
+
+(api/defendpoint DELETE "/:id"
+  "Delete a [[TimelineEvent]]."
+  [id]
+  (api/write-check TimelineEvent id)
+  (db/delete! TimelineEvent :id id)
+  api/generic-204-no-content)
 
 ;; todo: icons
 ;; collection_id via timeline_id -> slow, how to do this?

--- a/src/metabase/api/timeline_event.clj
+++ b/src/metabase/api/timeline_event.clj
@@ -17,8 +17,7 @@
   [:as {{:keys [name description timestamp time_matters timezone icon timeline_id archived] :as body} :body}]
   {name         su/NonBlankString
    description  (s/maybe s/Str)
-   ;; todo: find schema for timestamps?
-   timestamp    s/Str
+   timestamp    (s/maybe su/TemporalString)
    time_matters (s/maybe s/Bool)
    timezone     s/Str
    icon         (s/maybe s/Str)
@@ -49,8 +48,7 @@
             :as   timeline-event-updates} :body}]
   {name         (s/maybe su/NonBlankString)
    description  (s/maybe s/Str)
-   ;; todo: find schema for timestamps?
-   timestamp    (s/maybe s/Str)
+   timestamp    (s/maybe su/TemporalString)
    time_matters (s/maybe s/Bool)
    timezone     (s/maybe s/Str)
    icon         (s/maybe s/Str)

--- a/src/metabase/api/timeline_events.clj
+++ b/src/metabase/api/timeline_events.clj
@@ -5,10 +5,12 @@
             [metabase.models.collection :as collection]
             [metabase.models.timeline :refer [Timeline]]
             [metabase.models.timeline-event :refer [TimelineEvent]]
+            [metabase.util :as u]
+            [metabase.util.date-2 :as u.date]
+            [metabase.util.i18n :refer [tru]]
             [metabase.util.schema :as su]
             [schema.core :as s]
-            [toucan.db :as db]
-            [metabase.util :as u]))
+            [toucan.db :as db]))
 
 (api/defendpoint POST "/"
   "Create a new [[TimelineEvent]]."
@@ -22,30 +24,47 @@
    icon (s/maybe s/Str)
    timeline_id su/IntGreaterThanZero
    archived (s/maybe s/Bool)}
-  ;; todo, create appropriate fn to check the permissions for editing the timeline
-  #_(collection/check-write-perms-for-collection timeline_id)
-  (db/insert! TimelineEvent (assoc body :creator_id api/*current-user*)))
+  ;; deliberately not using api/check-404 so we can have a useful error message.
+  (let [timeline (Timeline timeline_id)]
+    (when-not timeline
+      (throw (ex-info (tru "Timeline with id {0} not found" timeline_id)
+                      {:status-code 404})))
+    (collection/check-write-perms-for-collection (:collection_id timeline)))
+  ;; todo: revision system
+  (let [parsed (if (nil? timestamp)
+                 (throw (ex-info (tru "Timestamp cannot be null") {:status-code 400}))
+                 (u.date/parse timestamp))]
+    (db/insert! TimelineEvent (assoc body
+                                     :creator_id api/*current-user-id*
+                                     :timestamp parsed))))
 
 (api/defendpoint GET "/:id"
   "Fetch the [[TimelineEvent]] with `id`."
   [id]
-  (api/read-check (TimelineEvent id)))
+  (let [event (api/check-404 (TimelineEvent id))]
+    (api/read-check (Timeline (:timeline_id event)))
+    event))
 
 (api/defendpoint PUT "/:id"
-  "Create a new [[TimelineEvent]]."
-  [:as {{:keys [name description timestamp time_matters timezone icon timeline_id archived]
+  "Update a [[TimelineEvent]]."
+  [id :as {{:keys [name description timestamp time_matters timezone icon timeline_id archived]
          :as timeline-event-updates} :body}]
-  {name su/NonBlankString
+  {name (s/maybe su/NonBlankString)
    description (s/maybe s/Str)
    ;; todo: find schema for timestamps?
-   timestamp s/Str
+   timestamp (s/maybe s/Str)
    time_matters (s/maybe s/Bool)
-   timezone s/Str
+   timezone (s/maybe s/Str)
    icon (s/maybe s/Str)
-   timeline_id su/IntGreaterThanZero
+   timeline_id (s/maybe su/IntGreaterThanZero)
    archived (s/maybe s/Bool)}
-  (let [existing (api/write-check TimelineEvent id)]
+  (let [existing (api/check-404 (TimelineEvent id))]
+    ;; todo: we can do db operations in the permissions (makes sense, we're doing them anyways. that's the cost of
+    ;; this. so either do it in the protocol or manually so of course go for protocol. check out dashboard card for a
+    ;; similar situation
+    (api/write-check Timeline (:timeline_id existing))
     (collection/check-allowed-to-change-collection existing timeline-event-updates)
+    ;; todo: if we accept a new timestamp, must we require a timezone? gut says yes?
     (db/update! TimelineEvent id
       (u/select-keys-when timeline-event-updates
         ;; todo: are there more keys needed in non-nil? timestamp?

--- a/src/metabase/api/timeline_events.clj
+++ b/src/metabase/api/timeline_events.clj
@@ -1,0 +1,59 @@
+(ns metabase.api.timeline-events
+  "/api/timeline_events endpoints."
+  (:require [compojure.core :refer [DELETE GET POST PUT]]
+            [metabase.api.common :as api]
+            [metabase.models.collection :as collection]
+            [metabase.models.timeline :refer [Timeline]]
+            [metabase.models.timeline-event :refer [TimelineEvent]]
+            [metabase.util.schema :as su]
+            [schema.core :as s]
+            [toucan.db :as db]
+            [metabase.util :as u]))
+
+(api/defendpoint POST "/"
+  "Create a new [[TimelineEvent]]."
+  [:as {{:keys [name description timestamp time_matters timezone icon timeline_id archived] :as body} :body}]
+  {name su/NonBlankString
+   description (s/maybe s/Str)
+   ;; todo: find schema for timestamps?
+   timestamp s/Str
+   time_matters (s/maybe s/Bool)
+   timezone s/Str
+   icon (s/maybe s/Str)
+   timeline_id su/IntGreaterThanZero
+   archived (s/maybe s/Bool)}
+  ;; todo, create appropriate fn to check the permissions for editing the timeline
+  #_(collection/check-write-perms-for-collection timeline_id)
+  (db/insert! TimelineEvent (assoc body :creator_id api/*current-user*)))
+
+(api/defendpoint GET "/:id"
+  "Fetch the [[TimelineEvent]] with `id`."
+  [id]
+  (api/read-check (TimelineEvent id)))
+
+(api/defendpoint PUT "/:id"
+  "Create a new [[TimelineEvent]]."
+  [:as {{:keys [name description timestamp time_matters timezone icon timeline_id archived]
+         :as timeline-event-updates} :body}]
+  {name su/NonBlankString
+   description (s/maybe s/Str)
+   ;; todo: find schema for timestamps?
+   timestamp s/Str
+   time_matters (s/maybe s/Bool)
+   timezone s/Str
+   icon (s/maybe s/Str)
+   timeline_id su/IntGreaterThanZero
+   archived (s/maybe s/Bool)}
+  (let [existing (api/write-check TimelineEvent id)]
+    (collection/check-allowed-to-change-collection existing timeline-event-updates)
+    (db/update! TimelineEvent id
+      (u/select-keys-when timeline-event-updates
+        ;; todo: are there more keys needed in non-nil? timestamp?
+        :present #{:description :timestamp :time_matters :timezone :icon :timeline_id :archived}
+        :non-nil #{:name}))
+    (TimelineEvent id)))
+
+;; todo: icons
+;; collection_id via timeline_id -> slow, how to do this?
+
+(api/define-routes)

--- a/src/metabase/cmd/copy.clj
+++ b/src/metabase/cmd/copy.clj
@@ -14,7 +14,7 @@
                                      FieldValues LoginHistory Metric MetricImportantField ModerationReview NativeQuerySnippet
                                      Permissions PermissionsGroup PermissionsGroupMembership PermissionsRevision Pulse PulseCard
                                      PulseChannel PulseChannelRecipient Revision Secret Segment Session Setting Table
-                                     User ViewLog]]
+                                     Timeline TimelineEvent User ViewLog]]
             [metabase.models.permissions-group :as group]
             [metabase.util :as u]
             [metabase.util.i18n :refer [trs]]
@@ -78,6 +78,8 @@
    Dimension
    NativeQuerySnippet
    LoginHistory
+   Timeline
+   TimelineEvent
    Secret
    ;; migrate the list of finished DataMigrations as the very last thing (all models to copy over should be listed
    ;; above this line)

--- a/src/metabase/models.clj
+++ b/src/metabase/models.clj
@@ -35,6 +35,8 @@
             [metabase.models.setting :as setting]
             [metabase.models.table :as table]
             [metabase.models.task-history :as task-history]
+            [metabase.models.timeline :as timeline]
+            [metabase.models.timeline-event :as timeline-event]
             [metabase.models.user :as user]
             [metabase.models.view-log :as view-log]
             [potemkin :as p]))
@@ -76,6 +78,8 @@
          setting/keep-me
          table/keep-me
          task-history/keep-me
+         timeline/keep-me
+         timeline-event/keep-me
          user/keep-me
          view-log/keep-me)
 
@@ -116,5 +120,7 @@
  [setting Setting]
  [table Table]
  [task-history TaskHistory]
+ [timeline Timeline]
+ [timeline-event TimelineEvent]
  [user User]
  [view-log ViewLog])

--- a/src/metabase/models/timeline.clj
+++ b/src/metabase/models/timeline.clj
@@ -14,7 +14,8 @@
   "Load timelines based on `collection-id` passed in (nil means the root collection). Hydrates the events on each
   timeline at `:events` on the timeline."
   [collection-id]
-  (hydrate (db/select Timeline :collection_id collection-id) :timeline-events))
+  (hydrate (db/select Timeline :collection_id collection-id)
+           :timeline-events :creator))
 
 (u/strict-extend (class Timeline)
   models/IModel

--- a/src/metabase/models/timeline.clj
+++ b/src/metabase/models/timeline.clj
@@ -15,7 +15,7 @@
   timeline at `:events` on the timeline."
   [collection-id]
   (hydrate (db/select Timeline :collection_id collection-id)
-           :timeline-events :creator))
+           [:events :creator] :creator))
 
 (u/strict-extend (class Timeline)
   models/IModel

--- a/src/metabase/models/timeline.clj
+++ b/src/metabase/models/timeline.clj
@@ -2,9 +2,19 @@
   (:require [metabase.models.interface :as i]
             [metabase.models.permissions :as perms]
             [metabase.util :as u]
+            [toucan.db :as db]
+            [toucan.hydrate :refer [hydrate]]
             [toucan.models :as models]))
 
 (models/defmodel Timeline :timeline)
+
+;;;; functions
+
+(defn timelines-for-collection
+  "Load timelines based on `collection-id` passed in (nil means the root collection). Hydrates the events on each
+  timeline at `:events` on the timeline."
+  [collection-id]
+  (hydrate (db/select Timeline :collection_id collection-id) :timeline-events))
 
 (u/strict-extend (class Timeline)
   models/IModel

--- a/src/metabase/models/timeline.clj
+++ b/src/metabase/models/timeline.clj
@@ -13,9 +13,11 @@
 (defn timelines-for-collection
   "Load timelines based on `collection-id` passed in (nil means the root collection). Hydrates the events on each
   timeline at `:events` on the timeline."
-  [collection-id]
-  (hydrate (db/select Timeline :collection_id collection-id)
-           [:events :creator] :creator))
+  [collection-id include]
+  (if include
+    (hydrate (db/select Timeline :collection_id collection-id)
+                 [:events :creator] :creator)
+    (hydrate (db/select Timeline :collection_id collection-id) :creator)))
 
 (u/strict-extend (class Timeline)
   models/IModel

--- a/src/metabase/models/timeline.clj
+++ b/src/metabase/models/timeline.clj
@@ -8,7 +8,9 @@
 
 (u/strict-extend (class Timeline)
   models/IModel
-  models/IModelDefaults
+  (merge
+   models/IModelDefaults
+   {:properties (constantly {:timestamped? true})})
 
   i/IObjectPermissions
   perms/IObjectPermissionsForParentCollection)

--- a/src/metabase/models/timeline.clj
+++ b/src/metabase/models/timeline.clj
@@ -1,0 +1,14 @@
+(ns metabase.models.timeline
+  (:require [metabase.models.interface :as i]
+            [metabase.models.permissions :as perms]
+            [metabase.util :as u]
+            [toucan.models :as models]))
+
+(models/defmodel Timeline :timeline)
+
+(u/strict-extend (class Timeline)
+  models/IModel
+  models/IModelDefaults
+
+  i/IObjectPermissions
+  perms/IObjectPermissionsForParentCollection)

--- a/src/metabase/models/timeline.clj
+++ b/src/metabase/models/timeline.clj
@@ -13,11 +13,11 @@
 (defn timelines-for-collection
   "Load timelines based on `collection-id` passed in (nil means the root collection). Hydrates the events on each
   timeline at `:events` on the timeline."
-  [collection-id include]
-  (if include
-    (hydrate (db/select Timeline :collection_id collection-id)
-                 [:events :creator] :creator)
-    (hydrate (db/select Timeline :collection_id collection-id) :creator)))
+  [collection-id {:keys [include archived]}]
+  (let [events-hydration-key (if archived :archived-events :events)]
+    (if include
+      (hydrate (db/select Timeline :collection_id collection-id) [events-hydration-key :creator] :creator)
+      (hydrate (db/select Timeline :collection_id collection-id) :creator))))
 
 (u/strict-extend (class Timeline)
   models/IModel

--- a/src/metabase/models/timeline.clj
+++ b/src/metabase/models/timeline.clj
@@ -14,9 +14,11 @@
   "Load timelines based on `collection-id` passed in (nil means the root collection). Hydrates the events on each
   timeline at `:events` on the timeline."
   [collection-id {:keys [include archived]}]
-  (let [events-hydration-key (if archived :archived-events :events)]
+  (let [filter-fn (fn [e] (filter #(= (:archived %) archived) e))]
     (if include
-      (hydrate (db/select Timeline :collection_id collection-id) [events-hydration-key :creator] :creator)
+      (as-> (db/select Timeline :collection_id collection-id) <>
+          (hydrate <> :creator [:events :creator])
+          (map #(update % :events filter-fn) <>))
       (hydrate (db/select Timeline :collection_id collection-id) :creator))))
 
 (u/strict-extend (class Timeline)

--- a/src/metabase/models/timeline_event.clj
+++ b/src/metabase/models/timeline_event.clj
@@ -19,7 +19,7 @@
 
 (defn hydrate-events
   "Efficiently hydrate the events for a timeline."
-  {:batched-hydrate :timeline-events}
+  {:batched-hydrate :events}
   [timelines]
   (when (seq timelines)
     (let [timeline-id->events (->> (db/select TimelineEvent

--- a/src/metabase/models/timeline_event.clj
+++ b/src/metabase/models/timeline_event.clj
@@ -29,7 +29,7 @@
                                    (group-by :timeline_id))]
       (for [{:keys [id] :as timeline} timelines]
         (when timeline
-          (assoc timeline :timeline-events (timeline-id->events id)))))))
+          (assoc timeline :events (timeline-id->events id)))))))
 
 ;;;; model
 

--- a/src/metabase/models/timeline_event.clj
+++ b/src/metabase/models/timeline_event.clj
@@ -1,5 +1,6 @@
 (ns metabase.models.timeline-event
   (:require [metabase.util :as u]
+            [toucan.db :as db]
             [toucan.models :as models]))
 
 (models/defmodel TimelineEvent :timeline_event)
@@ -16,3 +17,17 @@
   ;; i/IObjectPermissions
   ;; perms/IObjectPermissionsForParentCollection
   )
+
+(defn hydrate-events
+  "Efficiently hydrate the events for a timeline."
+  {:batched-hydrate :timeline-events}
+  [timelines]
+  (when (seq timelines)
+    (let [timeline-id->events (->> (db/select TimelineEvent
+                                     :timeline_id [:in (map :id timelines)]
+                                     :archived false
+                                     {:order-by [[:timestamp :asc]]})
+                                   (group-by :timeline_id))]
+      (for [{:keys [id] :as timeline} timelines]
+        (when timeline
+          (assoc timeline :timeline-events (timeline-id->events id)))))))

--- a/src/metabase/models/timeline_event.clj
+++ b/src/metabase/models/timeline_event.clj
@@ -1,0 +1,18 @@
+(ns metabase.models.timeline-event
+  (:require [metabase.util :as u]
+            [toucan.models :as models]))
+
+(models/defmodel TimelineEvent :timeline_event)
+
+(u/strict-extend (class TimelineEvent)
+  models/IModel
+  (merge
+   models/IModelDefaults
+   {:properties (constantly {:timestamped? true})})
+
+  ;; todo: need correct the following to follow collection id of the timeline, the parent of the current timeline
+  ;; event
+
+  ;; i/IObjectPermissions
+  ;; perms/IObjectPermissionsForParentCollection
+  )

--- a/src/metabase/models/timeline_event.clj
+++ b/src/metabase/models/timeline_event.clj
@@ -40,8 +40,7 @@
   (merge
    models/IModelDefaults
    ;; todo: add hydration keys??
-   {#_#_:hydration-keys (constantly [:timeline-event])
-    :properties (constantly {:timestamped? true})})
+   {:properties (constantly {:timestamped? true})})
 
   i/IObjectPermissions
   (merge

--- a/src/metabase/models/timeline_event.clj
+++ b/src/metabase/models/timeline_event.clj
@@ -81,28 +81,3 @@
    {:perms-objects-set perms-objects-set
     :can-read?         (partial i/current-user-has-full-permissions? :read)
     :can-write?        (partial i/current-user-has-full-permissions? :write)}))
-
-(comment
-  (let [start (java.time.OffsetDateTime/of
-               (java.time.LocalDateTime/of 2022 2 8 9 0)
-               (java.time.ZoneOffset/of "+6"))
-        end (java.time.OffsetDateTime/now)]
-    (count
-     (db/query {:select [:*]
-                :from [[TimelineEvent :e]]
-                :where [:and
-                        ;; in our collections
-                        [:in :timeline_id [2 3]]
-                        [:or
-                         ;; absolute time in bounds
-                         [:and
-                          [:= :time_matters true]
-                          ;; less than or equal?
-                          [:<= start :timestamp]
-                          [:<= :timestamp end]]
-                         ;; non-specic time in bounds
-                         [:and
-                          [:= :time_matters false]
-                          [:<= (hx/->date start) (hx/->date :timestamp)]
-                          [:<= (hx/->date :timestamp) (hx/->date end)]]]]})))
-  )

--- a/src/metabase/util/schema.clj
+++ b/src/metabase/util/schema.clj
@@ -7,6 +7,7 @@
             [medley.core :as m]
             [metabase.types :as types]
             [metabase.util :as u]
+            [metabase.util.date-2 :as u.date]
             [metabase.util.i18n :as i18n :refer [deferred-tru]]
             [metabase.util.password :as password]
             [schema.core :as s]
@@ -311,6 +312,11 @@
    Something that adheres to this schema is guaranteed to to work with `Boolean/parseBoolean`."
   (with-api-error-message (s/constrained s/Str boolean-string?)
     (deferred-tru "value must be a valid boolean string (''true'' or ''false'').")))
+
+(def TemporalString
+  "Schema for a string that can be parsed by date2/parse."
+  (with-api-error-message (s/constrained s/Str #(u/ignore-exceptions (boolean (u.date/parse %))))
+    (deferred-tru "value must be a valid date string")))
 
 (def JSONString
   "Schema for a string that is valid serialized JSON."

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -402,12 +402,12 @@
                   (:data (mt/user-http-request :crowberto :get 200
                                                (str "collection/" (u/the-id collection) "/items")
                                                :pinned_state pin-state)))]
-          (let [items (fetch "is_pinned")]
-            (is (= 2 (count items)))
-            (is (= #{"pinned-1" "pinned-2"} (set (map :name items)))))
-          (let [items (fetch "is_not_pinned")]
-            (is (= 2 (count items)))
-            (is (= #{"timeline" "unpinned-card"} (set (map :name items))))))))
+          (is (= #{"pinned-1" "pinned-2"} (->> (fetch "is_pinned")
+                                               (map :name)
+                                               set)))
+          (is (= #{"timeline" "unpinned-card"} (->> (fetch "is_not_pinned")
+                                                    (map :name)
+                                                    set))))))
 
     (testing "check that you get to see the children as appropriate"
       (mt/with-temp Collection [collection {:name "Debt Collection"}]

--- a/test/metabase/api/timeline_event_test.clj
+++ b/test/metabase/api/timeline_event_test.clj
@@ -43,25 +43,26 @@
           ;; make an API call to create a timeline
           (mt/user-http-request :rasta :post 200 "timeline-event" {:name         "Rasta Migrates to Florida for the Winter"
                                                                    :timestamp    (java.time.OffsetDateTime/now)
-                                                                   :timezone     "PST"
+                                                                   :timezone     "US/Pacific"
                                                                    :time_matters false
                                                                    :timeline_id  (u/the-id timeline)}))
           ;; check the Timeline to see if the event is there
-          (is (= (-> (db/select-one TimelineEvent :timeline_id (u/the-id timeline)) :name)
-                 "Rasta Migrates to Florida for the Winter"))))))
+          (is (= "Rasta Migrates to Florida for the Winter"
+                 (-> (db/select-one TimelineEvent :timeline_id (u/the-id timeline)) :name)))))))
 
 (deftest update-timeline-event-test
   (testing "PUT /api/timeline-event/:id"
-    (let [defaults {:creator_id (u/the-id (mt/fetch-user :rasta))}]
-      (mt/with-temp* [Collection    [collection {:name "Important Data"}]
-                      Timeline      [timeline (merge defaults {:name          "Important Events"
-                                                               :collection_id (u/the-id collection)})]
-                      TimelineEvent [event (merge defaults {:name         "Very Important Event"
-                                                            :timestamp    (java.time.OffsetDateTime/now)
-                                                            :timezone     "PST"
-                                                            :time_matters false
-                                                            :timeline_id  (u/the-id timeline)})]]
-        (testing "check that we get the timeline-event with `id`"
-          (is (= (->> (mt/user-http-request :rasta :put 200 (str "timeline-event/" (u/the-id event)) {:archived true})
-                      :archived)
-                 true)))))))
+    (testing "Can archive the timeline event"
+      (let [defaults {:creator_id (u/the-id (mt/user->id :rasta))}]
+        (mt/with-temp* [Collection    [collection {:name "Important Data"}]
+                        Timeline      [timeline (merge defaults {:name          "Important Events"
+                                                                 :collection_id (u/the-id collection)})]
+                        TimelineEvent [event (merge defaults {:name         "Very Important Event"
+                                                              :timestamp    (java.time.OffsetDateTime/now)
+                                                              :timezone     "US/Pacific"
+                                                              :time_matters false
+                                                              :timeline_id  (u/the-id timeline)})]]
+          (testing "check that we get the timeline-event with `id`"
+            (is (true?
+                 (->> (mt/user-http-request :rasta :put 200 (str "timeline-event/" (u/the-id event)) {:archived true})
+                      :archived)))))))))

--- a/test/metabase/api/timeline_event_test.clj
+++ b/test/metabase/api/timeline_event_test.clj
@@ -7,7 +7,8 @@
             [metabase.models.timeline-event :refer [TimelineEvent]]
             [metabase.server.middleware.util :as middleware.u]
             [metabase.test :as mt]
-            [metabase.util :as u]))
+            [metabase.util :as u]
+            [toucan.db :as db]))
 
 (deftest auth-tests
   (testing "Authentication"
@@ -18,36 +19,49 @@
 
 (deftest get-timeline-event-test
   (testing "GET /api/timeline-event/:id"
-    (mt/with-temp TimelineEvent [event {:name "Very Important Event"
-                                        :timestamp "NOW"}]
-      (testing "check that we get the timeline-event with `id`"
-        (is (= (->> (mt/user-http-request :rasta :get 200 "timeline-event")
-                    (filter #(= (:collection_id %) id))
-                    (map :name)
-                    set)
-               #{"Timeline A" "Timeline B"}))))))
+    (let [defaults {:creator_id (u/the-id (mt/fetch-user :rasta))}]
+      (mt/with-temp* [Collection    [collection {:name "Important Data"}]
+                      Timeline      [timeline (merge defaults {:name          "Important Events"
+                                                               :collection_id (u/the-id collection)})]
+                      TimelineEvent [event (merge defaults {:name         "Very Important Event"
+                                                            :timestamp    (java.time.OffsetDateTime/now)
+                                                            :timezone     "PST"
+                                                            :time_matters false
+                                                            :timeline_id  (u/the-id timeline)})]]
+        (testing "check that we get the timeline-event with `id`"
+          (is (= (->> (mt/user-http-request :rasta :get 200 (str "timeline-event/" (u/the-id event)))
+                      :name)
+                 "Very Important Event")))))))
 
-#_(deftest create-timeline-event-test
+(deftest create-timeline-event-test
   (testing "POST /api/timeline-event"
-    (mt/with-temp Collection [collection {:name "Important Data"}]
-      (let [id          (u/the-id collection)
-            tl-defaults {:creator_id    (u/the-id (mt/fetch-user :rasta))
-                         :collection_id id}]
-        (testing "Create a new timeline"
+    (let [defaults {:creator_id (u/the-id (mt/fetch-user :rasta))}]
+      (mt/with-temp* [Collection    [collection {:name "Important Data"}]
+                      Timeline      [timeline (merge defaults {:name          "Important Events"
+                                                               :collection_id (u/the-id collection)})]]
+        (testing "create a timeline event"
           ;; make an API call to create a timeline
-          (mt/user-http-request :rasta :post 200 "timeline" (merge tl-defaults {:name "Rasta's TL"}))
-          ;; check the collection to see if the timeline is there
-          (is (= (-> (db/select-one Timeline :collection_id id) :name)
-                 "Rasta's TL")))))))
+          (mt/user-http-request :rasta :post 200 "timeline-event" {:name         "Rasta Migrates to Florida for the Winter"
+                                                                   :timestamp    (java.time.OffsetDateTime/now)
+                                                                   :timezone     "PST"
+                                                                   :time_matters false
+                                                                   :timeline_id  (u/the-id timeline)}))
+          ;; check the Timeline to see if the event is there
+          (is (= (-> (db/select-one TimelineEvent :timeline_id (u/the-id timeline)) :name)
+                 "Rasta Migrates to Florida for the Winter"))))))
 
-#_(deftest update-timeline-event-test
+(deftest update-timeline-event-test
   (testing "PUT /api/timeline-event/:id"
-    (mt/with-temp Collection [collection {:name "Important Data"}]
-      (let [id          (u/the-id collection)
-            tl-defaults {:creator_id    (u/the-id (mt/fetch-user :rasta))
-                         :collection_id id}]
-        (mt/with-temp* [Timeline [tl-a (merge tl-defaults {:name "Timeline A" :archived true})]]
-          (testing "check that we successfully updated a timeline"
-            (is (= (->> (mt/user-http-request :rasta :put 200 (str "timeline/" (u/the-id tl-a)) {:archived false})
-                        :archived)
-                   false))))))))
+    (let [defaults {:creator_id (u/the-id (mt/fetch-user :rasta))}]
+      (mt/with-temp* [Collection    [collection {:name "Important Data"}]
+                      Timeline      [timeline (merge defaults {:name          "Important Events"
+                                                               :collection_id (u/the-id collection)})]
+                      TimelineEvent [event (merge defaults {:name         "Very Important Event"
+                                                            :timestamp    (java.time.OffsetDateTime/now)
+                                                            :timezone     "PST"
+                                                            :time_matters false
+                                                            :timeline_id  (u/the-id timeline)})]]
+        (testing "check that we get the timeline-event with `id`"
+          (is (= (->> (mt/user-http-request :rasta :put 200 (str "timeline-event/" (u/the-id event)) {:archived true})
+                      :archived)
+                 true)))))))

--- a/test/metabase/api/timeline_event_test.clj
+++ b/test/metabase/api/timeline_event_test.clj
@@ -1,0 +1,53 @@
+(ns metabase.api.timeline-event-test
+  "Tests for /api/timeline-event endpoints"
+  (:require [clojure.test :refer :all]
+            [metabase.http-client :as http]
+            [metabase.models.collection :refer [Collection]]
+            [metabase.models.timeline :refer [Timeline]]
+            [metabase.models.timeline-event :refer [TimelineEvent]]
+            [metabase.server.middleware.util :as middleware.u]
+            [metabase.test :as mt]
+            [metabase.util :as u]))
+
+(deftest auth-tests
+  (testing "Authentication"
+    (is (= (get middleware.u/response-unauthentic :body)
+           (http/client :get 401 "/timeline-event")))
+    (is (= (get middleware.u/response-unauthentic :body)
+           (http/client :get 401 "/timeline-event/1")))))
+
+(deftest get-timeline-event-test
+  (testing "GET /api/timeline-event/:id"
+    (mt/with-temp TimelineEvent [event {:name "Very Important Event"
+                                        :timestamp "NOW"}]
+      (testing "check that we get the timeline-event with `id`"
+        (is (= (->> (mt/user-http-request :rasta :get 200 "timeline-event")
+                    (filter #(= (:collection_id %) id))
+                    (map :name)
+                    set)
+               #{"Timeline A" "Timeline B"}))))))
+
+#_(deftest create-timeline-event-test
+  (testing "POST /api/timeline-event"
+    (mt/with-temp Collection [collection {:name "Important Data"}]
+      (let [id          (u/the-id collection)
+            tl-defaults {:creator_id    (u/the-id (mt/fetch-user :rasta))
+                         :collection_id id}]
+        (testing "Create a new timeline"
+          ;; make an API call to create a timeline
+          (mt/user-http-request :rasta :post 200 "timeline" (merge tl-defaults {:name "Rasta's TL"}))
+          ;; check the collection to see if the timeline is there
+          (is (= (-> (db/select-one Timeline :collection_id id) :name)
+                 "Rasta's TL")))))))
+
+#_(deftest update-timeline-event-test
+  (testing "PUT /api/timeline-event/:id"
+    (mt/with-temp Collection [collection {:name "Important Data"}]
+      (let [id          (u/the-id collection)
+            tl-defaults {:creator_id    (u/the-id (mt/fetch-user :rasta))
+                         :collection_id id}]
+        (mt/with-temp* [Timeline [tl-a (merge tl-defaults {:name "Timeline A" :archived true})]]
+          (testing "check that we successfully updated a timeline"
+            (is (= (->> (mt/user-http-request :rasta :put 200 (str "timeline/" (u/the-id tl-a)) {:archived false})
+                        :archived)
+                   false))))))))

--- a/test/metabase/api/timeline_event_test.clj
+++ b/test/metabase/api/timeline_event_test.clj
@@ -19,50 +19,43 @@
 
 (deftest get-timeline-event-test
   (testing "GET /api/timeline-event/:id"
-    (let [defaults {:creator_id (u/the-id (mt/fetch-user :rasta))}]
-      (mt/with-temp* [Collection    [collection {:name "Important Data"}]
-                      Timeline      [timeline (merge defaults {:name          "Important Events"
-                                                               :collection_id (u/the-id collection)})]
-                      TimelineEvent [event (merge defaults {:name         "Very Important Event"
-                                                            :timestamp    (java.time.OffsetDateTime/now)
-                                                            :timezone     "PST"
-                                                            :time_matters false
-                                                            :timeline_id  (u/the-id timeline)})]]
-        (testing "check that we get the timeline-event with `id`"
-          (is (= (->> (mt/user-http-request :rasta :get 200 (str "timeline-event/" (u/the-id event)))
-                      :name)
-                 "Very Important Event")))))))
+    (mt/with-temp* [Collection    [collection {:name "Important Data"}]
+                    Timeline      [timeline {:name          "Important Events"
+                                             :collection_id (u/the-id collection)}]
+                    TimelineEvent [event {:name         "Very Important Event"
+                                          :timestamp    (java.time.OffsetDateTime/now)
+                                          :time_matters false
+                                          :timeline_id  (u/the-id timeline)}]]
+      (testing "check that we get the timeline-event with `id`"
+        (is (= "Very Important Event"
+               (->> (mt/user-http-request :rasta :get 200 (str "timeline-event/" (u/the-id event)))
+                    :name)))))))
 
 (deftest create-timeline-event-test
   (testing "POST /api/timeline-event"
-    (let [defaults {:creator_id (u/the-id (mt/fetch-user :rasta))}]
-      (mt/with-temp* [Collection    [collection {:name "Important Data"}]
-                      Timeline      [timeline (merge defaults {:name          "Important Events"
-                                                               :collection_id (u/the-id collection)})]]
-        (testing "create a timeline event"
-          ;; make an API call to create a timeline
-          (mt/user-http-request :rasta :post 200 "timeline-event" {:name         "Rasta Migrates to Florida for the Winter"
-                                                                   :timestamp    (java.time.OffsetDateTime/now)
-                                                                   :timezone     "US/Pacific"
-                                                                   :time_matters false
-                                                                   :timeline_id  (u/the-id timeline)}))
-          ;; check the Timeline to see if the event is there
-          (is (= "Rasta Migrates to Florida for the Winter"
-                 (-> (db/select-one TimelineEvent :timeline_id (u/the-id timeline)) :name)))))))
+    (mt/with-temp* [Collection    [collection {:name "Important Data"}]
+                    Timeline      [timeline {:name          "Important Events"
+                                             :collection_id (u/the-id collection)}]]
+      (testing "create a timeline event"
+        ;; make an API call to create a timeline
+        (mt/user-http-request :rasta :post 200 "timeline-event" {:name         "Rasta Migrates to Florida for the Winter"
+                                                                 :timestamp    (java.time.OffsetDateTime/now)
+                                                                 :timezone     "US/Pacific"
+                                                                 :time_matters false
+                                                                 :timeline_id  (u/the-id timeline)}))
+      ;; check the Timeline to see if the event is there
+      (is (= "Rasta Migrates to Florida for the Winter"
+             (-> (db/select-one TimelineEvent :timeline_id (u/the-id timeline)) :name))))))
 
 (deftest update-timeline-event-test
   (testing "PUT /api/timeline-event/:id"
     (testing "Can archive the timeline event"
-      (let [defaults {:creator_id (u/the-id (mt/user->id :rasta))}]
-        (mt/with-temp* [Collection    [collection {:name "Important Data"}]
-                        Timeline      [timeline (merge defaults {:name          "Important Events"
-                                                                 :collection_id (u/the-id collection)})]
-                        TimelineEvent [event (merge defaults {:name         "Very Important Event"
-                                                              :timestamp    (java.time.OffsetDateTime/now)
-                                                              :timezone     "US/Pacific"
-                                                              :time_matters false
-                                                              :timeline_id  (u/the-id timeline)})]]
-          (testing "check that we get the timeline-event with `id`"
-            (is (true?
-                 (->> (mt/user-http-request :rasta :put 200 (str "timeline-event/" (u/the-id event)) {:archived true})
-                      :archived)))))))))
+      (mt/with-temp* [Collection    [collection {:name "Important Data"}]
+                      Timeline      [timeline {:name          "Important Events"
+                                               :collection_id (u/the-id collection)}]
+                      TimelineEvent [event {:name         "Very Important Event"
+                                            :timeline_id  (u/the-id timeline)}]]
+        (testing "check that we get the timeline-event with `id`"
+          (is (true?
+               (->> (mt/user-http-request :rasta :put 200 (str "timeline-event/" (u/the-id event)) {:archived true})
+                    :archived))))))))

--- a/test/metabase/api/timeline_test.clj
+++ b/test/metabase/api/timeline_test.clj
@@ -1,0 +1,47 @@
+(ns metabase.api.timeline-test
+  "Tests for /api/timeline endpoints."
+  (:require [clojure.test :refer :all]
+            [metabase.http-client :as http]
+            [metabase.models.collection :refer [Collection]]
+            [metabase.models.timeline :refer [Timeline]]
+            [metabase.models.permissions :as perms]
+            [metabase.models.permissions-group :as group]
+            [metabase.server.middleware.util :as middleware.u]
+            [metabase.test :as mt]
+            [metabase.util :as u]
+            [toucan.db :as db]
+            [toucan.hydrate :refer [hydrate]]))
+
+(comment
+  (get middleware.u/response-unauthentic :body)
+  (http/client :get 401 "timeline")
+
+  (mt/with-temp Collection [collection {:name "Important Data"}]
+    (println collection))
+
+  )
+
+(deftest auth-tests
+  (testing "Authentication"
+    (is (= (get middleware.u/response-unauthentic :body)
+           (http/client :get 401 "collection/root/timeline")))
+    (is (= (get middleware.u/response-unauthentic :body)
+           (http/client :get 401 "collection/root/timeline/1")))))
+
+(deftest list-timelines-test
+  (testing "GET /api/timeline/:id"
+    (testing "check that we can see timeline details of a collection with :id"
+      (mt/with-temp Collection [collection {:name "Important Data"}]
+        (mt/with-temp Timeline [timeline {:name "Important Events"
+                                          :creator_id 1
+                                          :collection_id (u/the-id collection)}]
+          (perms/grant-collection-read-permissions! (group/all-users) collection)
+          (is (= "Important Events"
+                 (:name (mt/user-http-request :rasta :get 200 (str "timeline/" (u/the-id timeline))))))))))
+  (testing "GET /api/timeline/root"
+    (testing "check that we can see timeline details of the root collection"
+      (mt/with-temp Timeline [timeline {:name "More Important Events"
+                                        :creator_id 1
+                                        :collection_id nil}]
+        (is (= "More Important Events"
+               (:name (mt/user-http-request :rasta :get 200 (str "timeline/" (u/the-id timeline))))))))))

--- a/test/metabase/api/timeline_test.clj
+++ b/test/metabase/api/timeline_test.clj
@@ -4,44 +4,81 @@
             [metabase.http-client :as http]
             [metabase.models.collection :refer [Collection]]
             [metabase.models.timeline :refer [Timeline]]
-            [metabase.models.permissions :as perms]
-            [metabase.models.permissions-group :as group]
             [metabase.server.middleware.util :as middleware.u]
             [metabase.test :as mt]
-            [metabase.util :as u]
-            [toucan.db :as db]
-            [toucan.hydrate :refer [hydrate]]))
-
-(comment
-  (get middleware.u/response-unauthentic :body)
-  (http/client :get 401 "timeline")
-
-  (mt/with-temp Collection [collection {:name "Important Data"}]
-    (println collection))
-
-  )
+            [metabase.util :as u]))
 
 (deftest auth-tests
   (testing "Authentication"
     (is (= (get middleware.u/response-unauthentic :body)
-           (http/client :get 401 "collection/root/timeline")))
+           (http/client :get 401 "/timeline")))
     (is (= (get middleware.u/response-unauthentic :body)
-           (http/client :get 401 "collection/root/timeline/1")))))
+           (http/client :get 401 "/timeline/1")))))
 
 (deftest list-timelines-test
+  (testing "GET /api/timeline"
+    (mt/with-temp Collection [collection {:name "Important Data"}]
+      (let [id          (u/the-id collection)
+            tl-defaults {:creator_id    (u/the-id (mt/fetch-user :rasta))
+                         :collection_id id}]
+        (mt/with-temp* [Timeline [tl-a (merge tl-defaults {:name "Timeline A"})]
+                        Timeline [tl-b (merge tl-defaults {:name "Timeline B"})]
+                        Timeline [tl-c (merge tl-defaults {:name "Timeline C" :archived true})]]
+          (testing "check that we only get un-archived timelines"
+            (is (= (->> (mt/user-http-request :rasta :get 200 "timeline")
+                        (filter #(= (:collection_id %) id))
+                        (map :name)
+                        set)
+                   #{"Timeline A" "Timeline B"})))
+          (testing "check that we only get archived timelines when `archived=true`"
+            (is (= (->> (mt/user-http-request :rasta :get 200 "timeline" :archived true)
+                        (filter #(= (:collection_id %) id))
+                        (map :name)
+                        set)
+                   #{"Timeline C"}))))))))
+
+(deftest get-timeline-test
   (testing "GET /api/timeline/:id"
-    (testing "check that we can see timeline details of a collection with :id"
-      (mt/with-temp Collection [collection {:name "Important Data"}]
-        (mt/with-temp Timeline [timeline {:name "Important Events"
-                                          :creator_id 1
-                                          :collection_id (u/the-id collection)}]
-          (perms/grant-collection-read-permissions! (group/all-users) collection)
-          (is (= "Important Events"
-                 (:name (mt/user-http-request :rasta :get 200 (str "timeline/" (u/the-id timeline))))))))))
-  (testing "GET /api/timeline/root"
-    (testing "check that we can see timeline details of the root collection"
-      (mt/with-temp Timeline [timeline {:name "More Important Events"
-                                        :creator_id 1
-                                        :collection_id nil}]
-        (is (= "More Important Events"
-               (:name (mt/user-http-request :rasta :get 200 (str "timeline/" (u/the-id timeline))))))))))
+    (let [tl-defaults {:creator_id    (u/the-id (mt/fetch-user :rasta))
+                       :collection_id nil}]
+      (mt/with-temp* [Timeline [tl-a (merge tl-defaults {:name "Timeline A"})]
+                      Timeline [tl-b (merge tl-defaults {:name "Timeline B" :archived true})]]
+        (testing "check that we get the timeline with the id specified"
+          (is (= (->> (mt/user-http-request :rasta :get 200 (str "timeline/" (u/the-id tl-a)))
+                      :name)
+                 "Timeline A")))
+        (testing "check that we get the timeline with the id specified, even if the timeline is archived"
+          (is (= (->> (mt/user-http-request :rasta :get 200 (str "timeline/" (u/the-id tl-b)))
+                      :name)
+                 "Timeline B")))))))
+
+(deftest create-timeline-test
+  (testing "POST /api/timeline"
+    (mt/with-temp Collection [collection {:name "Important Data"}]
+      (let [id          (u/the-id collection)
+            tl-defaults {:creator_id    (u/the-id (mt/fetch-user :rasta))
+                         :collection_id id}]
+        (testing "Create a new timeline"
+          ;; make an API call to create a timeline
+          (mt/user-http-request :rasta :post 200 "timeline" (merge tl-defaults {:name "Rasta's TL"}))
+          ;; check the collection to see if the timeline is there
+          (is (= (-> (db/select-one Timeline :collection_id id) :name)
+                 "Rasta's TL")))))))
+
+(deftest update-timeline-test
+  (testing "PUT /api/timeline/:id"
+    (mt/with-temp Collection [collection {:name "Important Data"}]
+      (let [id          (u/the-id collection)
+            tl-defaults {:creator_id    (u/the-id (mt/fetch-user :rasta))
+                         :collection_id id}]
+        (mt/with-temp* [Timeline [tl-a (merge tl-defaults {:name "Timeline A" :archived true})]]
+          (testing "check that we successfully updated a timeline"
+            (is (= (->> (mt/user-http-request :rasta :put 200 (str "timeline/" (u/the-id tl-a)) {:archived false})
+                        :archived)
+                   false))))))))
+
+;; TODO: Add events hydration test(s) here? I think probably
+;; TODO: Add timelines test to collection api tests + hydrating events + archived events
+;; TODO: Add timelines test to card api tests + hydrating events + archived events
+;; TODO: Add collection/card start/end time tests
+;; TODO: Add timeline/timelineevent MODEL Tests?

--- a/test/metabase/api/timeline_test.clj
+++ b/test/metabase/api/timeline_test.clj
@@ -7,7 +7,8 @@
             [metabase.models.timeline-event :refer [TimelineEvent]]
             [metabase.server.middleware.util :as middleware.u]
             [metabase.test :as mt]
-            [metabase.util :as u]))
+            [metabase.util :as u]
+            [toucan.db :as db]))
 
 (deftest auth-tests
   (testing "Authentication"

--- a/test/metabase/api/timeline_test.clj
+++ b/test/metabase/api/timeline_test.clj
@@ -21,15 +21,14 @@
   (testing "GET /api/timeline"
     (mt/with-temp Collection [collection {:name "Important Data"}]
       (let [id          (u/the-id collection)
-            tl-defaults {:creator_id    (u/the-id (mt/fetch-user :rasta))
-                         :collection_id id}
             events-of   (fn [tls]
                           (into #{} (comp (filter (comp #{id} :collection_id))
                                           (map :name))
                                 tls))]
-        (mt/with-temp* [Timeline [tl-a (merge tl-defaults {:name "Timeline A"})]
-                        Timeline [tl-b (merge tl-defaults {:name "Timeline B"})]
-                        Timeline [tl-c (merge tl-defaults {:name "Timeline C" :archived true})]]
+        (mt/with-temp* [Timeline [tl-a {:name "Timeline A", :collection_id id}]
+                        Timeline [tl-b {:name "Timeline B", :collection_id id}]
+                        Timeline [tl-c {:name "Timeline C", :collection_id id
+                                        :archived true}]]
           (testing "check that we only get un-archived timelines"
             (is (= #{"Timeline A" "Timeline B"}
                    (events-of (mt/user-http-request :rasta :get 200 "timeline")))))
@@ -39,28 +38,27 @@
 
 (deftest get-timeline-test
   (testing "GET /api/timeline/:id"
-    (let [tl-defaults {:creator_id    (u/the-id (mt/fetch-user :rasta))
-                       :collection_id nil}]
-      (mt/with-temp* [Timeline [tl-a (merge tl-defaults {:name "Timeline A"})]
-                      Timeline [tl-b (merge tl-defaults {:name "Timeline B" :archived true})]]
-        (testing "check that we get the timeline with the id specified"
-          (is (= "Timeline A"
-                 (->> (mt/user-http-request :rasta :get 200 (str "timeline/" (u/the-id tl-a)))
-                      :name))))
-        (testing "check that we get the timeline with the id specified, even if the timeline is archived"
-          (is (= "Timeline B"
-                 (->> (mt/user-http-request :rasta :get 200 (str "timeline/" (u/the-id tl-b)))
-                      :name))))))))
+    (mt/with-temp* [Timeline [tl-a {:name "Timeline A"}]
+                    Timeline [tl-b {:name "Timeline B" :archived true}]]
+      (testing "check that we get the timeline with the id specified"
+        (is (= "Timeline A"
+               (->> (mt/user-http-request :rasta :get 200 (str "timeline/" (u/the-id tl-a)))
+                    :name))))
+      (testing "check that we get the timeline with the id specified, even if the timeline is archived"
+        (is (= "Timeline B"
+               (->> (mt/user-http-request :rasta :get 200 (str "timeline/" (u/the-id tl-b)))
+                    :name)))))))
 
 (deftest create-timeline-test
   (testing "POST /api/timeline"
     (mt/with-temp Collection [collection {:name "Important Data"}]
-      (let [id          (u/the-id collection)
-            tl-defaults {:creator_id    (u/the-id (mt/fetch-user :rasta))
-                         :collection_id id}]
+      (let [id (u/the-id collection)]
         (testing "Create a new timeline"
           ;; make an API call to create a timeline
-          (mt/user-http-request :rasta :post 200 "timeline" (merge tl-defaults {:name "Rasta's TL"}))
+          (mt/user-http-request :rasta :post 200 "timeline"
+                                {:name          "Rasta's TL"
+                                 :creator_id    (u/the-id (mt/fetch-user :rasta))
+                                 :collection_id id})
           ;; check the collection to see if the timeline is there
           (is (= "Rasta's TL"
                  (-> (db/select-one Timeline :collection_id id) :name))))))))
@@ -68,14 +66,11 @@
 (deftest update-timeline-test
   (testing "PUT /api/timeline/:id"
     (mt/with-temp Collection [collection {:name "Important Data"}]
-      (let [id          (u/the-id collection)
-            tl-defaults {:creator_id    (u/the-id (mt/fetch-user :rasta))
-                         :collection_id id}]
-        (mt/with-temp* [Timeline [tl-a (merge tl-defaults {:name "Timeline A" :archived true})]]
-          (testing "check that we successfully updated a timeline"
-            (is (false?
-                 (->> (mt/user-http-request :rasta :put 200 (str "timeline/" (u/the-id tl-a)) {:archived false})
-                      :archived)))))))))
+      (mt/with-temp* [Timeline [tl-a {:name "Timeline A" :archived true}]]
+        (testing "check that we successfully updated a timeline"
+          (is (false?
+               (->> (mt/user-http-request :rasta :put 200 (str "timeline/" (u/the-id tl-a)) {:archived false})
+                    :archived))))))))
 
 (defn- include-events-request
   [timeline archived?]
@@ -88,41 +83,38 @@
 (deftest timeline-hydration-test
   (testing "GET /api/timeline/:id?include=events"
     (mt/with-temp Collection [collection {:name "Important Data"}]
-      (let [creator-id  (mt/user->id :rasta)
-            tl-defaults {:creator_id    creator-id
-                         :collection_id (u/the-id collection)}]
-        (mt/with-temp* [Timeline      [empty-tl (merge tl-defaults {:name "Empty TL"})]
-                        Timeline      [unarchived-tl (merge tl-defaults {:name "Un-archived Events TL"})]
-                        Timeline      [archived-tl (merge tl-defaults {:name "Archived Events TL"})]
-                        Timeline      [timeline (merge tl-defaults {:name "All Events TL"})]]
-          (let [defaults {:creator_id   creator-id
-                          :timestamp    (java.time.OffsetDateTime/now)
-                          :timezone     "US/Pacific"
-                          :time_matters false}]
-            (mt/with-temp* [TimelineEvent [event-a (merge defaults {:name        "event-a"
-                                                                    :timeline_id (u/the-id unarchived-tl)})]
-                            TimelineEvent [event-b (merge defaults {:name        "event-b"
-                                                                    :timeline_id (u/the-id unarchived-tl)})]
-                            TimelineEvent [event-c (merge defaults {:name        "event-c"
-                                                                    :timeline_id (u/the-id archived-tl)
-                                                                    :archived    true})]
-                            TimelineEvent [event-d (merge defaults {:name        "event-d"
-                                                                    :timeline_id (u/the-id archived-tl)
-                                                                    :archived    true})]
-                            TimelineEvent [event-e (merge defaults {:name        "event-e"
-                                                                    :timeline_id (u/the-id timeline)})]
-                            TimelineEvent [event-f (merge defaults {:name        "event-f"
-                                                                    :timeline_id (u/the-id timeline)
-                                                                    :archived    true})]]
-              (testing "a timeline with no events returns an empty list"
-                (is (= #{} (event-names (include-events-request empty-tl false)))))
-              (testing "a timeline with both (un-)archived events"
-                (testing "Returns only unarchived events when archived is false"
-                  (is (= #{"event-e"}
-                         (event-names (include-events-request timeline false)))))
-                (testing "Returns all events when archived is true"
-                  (is (= #{"event-e" "event-f"}
-                         (event-names (include-events-request timeline true)))))))))))))
+      (mt/with-temp* [Timeline      [empty-tl {:name "Empty TL"
+                                               :collection_id (u/the-id collection)}]
+                      Timeline      [unarchived-tl {:name "Un-archived Events TL"
+                                                    :collection_id (u/the-id collection)}]
+                      Timeline      [archived-tl {:name "Archived Events TL"
+                                                  :collection_id (u/the-id collection)}]
+                      Timeline      [timeline {:name "All Events TL"
+                                               :collection_id (u/the-id collection)}]]
+        (mt/with-temp* [TimelineEvent [event-a {:name        "event-a"
+                                                :timeline_id (u/the-id unarchived-tl)}]
+                        TimelineEvent [event-b {:name        "event-b"
+                                                :timeline_id (u/the-id unarchived-tl)}]
+                        TimelineEvent [event-c {:name        "event-c"
+                                                :timeline_id (u/the-id archived-tl)
+                                                :archived    true}]
+                        TimelineEvent [event-d {:name        "event-d"
+                                                :timeline_id (u/the-id archived-tl)
+                                                :archived    true}]
+                        TimelineEvent [event-e {:name        "event-e"
+                                                :timeline_id (u/the-id timeline)}]
+                        TimelineEvent [event-f {:name        "event-f"
+                                                :timeline_id (u/the-id timeline)
+                                                :archived    true}]]
+          (testing "a timeline with no events returns an empty list"
+            (is (= #{} (event-names (include-events-request empty-tl false)))))
+          (testing "a timeline with both (un-)archived events"
+            (testing "Returns only unarchived events when archived is false"
+              (is (= #{"event-e"}
+                     (event-names (include-events-request timeline false)))))
+            (testing "Returns all events when archived is true"
+              (is (= #{"event-e" "event-f"}
+                     (event-names (include-events-request timeline true)))))))))))
 
 
 ;; TODO: Add timelines test to collection api tests + hydrating events + archived events

--- a/test/metabase/api/timeline_test.clj
+++ b/test/metabase/api/timeline_test.clj
@@ -51,17 +51,18 @@
 
 (deftest create-timeline-test
   (testing "POST /api/timeline"
-    (mt/with-temp Collection [collection {:name "Important Data"}]
-      (let [id (u/the-id collection)]
-        (testing "Create a new timeline"
-          ;; make an API call to create a timeline
-          (mt/user-http-request :rasta :post 200 "timeline"
-                                {:name          "Rasta's TL"
-                                 :creator_id    (u/the-id (mt/fetch-user :rasta))
-                                 :collection_id id})
-          ;; check the collection to see if the timeline is there
-          (is (= "Rasta's TL"
-                 (-> (db/select-one Timeline :collection_id id) :name))))))))
+    (mt/with-model-cleanup [Timeline]
+      (mt/with-temp Collection [collection {:name "Important Data"}]
+        (let [id (u/the-id collection)]
+          (testing "Create a new timeline"
+            ;; make an API call to create a timeline
+            (mt/user-http-request :rasta :post 200 "timeline"
+                                  {:name          "Rasta's TL"
+                                   :creator_id    (u/the-id (mt/fetch-user :rasta))
+                                   :collection_id id})
+            ;; check the collection to see if the timeline is there
+            (is (= "Rasta's TL"
+                   (-> (db/select-one Timeline :collection_id id) :name)))))))))
 
 (deftest update-timeline-test
   (testing "PUT /api/timeline/:id"

--- a/test/metabase/api/timeline_test.clj
+++ b/test/metabase/api/timeline_test.clj
@@ -22,22 +22,20 @@
     (mt/with-temp Collection [collection {:name "Important Data"}]
       (let [id          (u/the-id collection)
             tl-defaults {:creator_id    (u/the-id (mt/fetch-user :rasta))
-                         :collection_id id}]
+                         :collection_id id}
+            events-of   (fn [tls]
+                          (into #{} (comp (filter (comp #{id} :collection_id))
+                                          (map :name))
+                                tls))]
         (mt/with-temp* [Timeline [tl-a (merge tl-defaults {:name "Timeline A"})]
                         Timeline [tl-b (merge tl-defaults {:name "Timeline B"})]
                         Timeline [tl-c (merge tl-defaults {:name "Timeline C" :archived true})]]
           (testing "check that we only get un-archived timelines"
-            (is (= (->> (mt/user-http-request :rasta :get 200 "timeline")
-                        (filter #(= (:collection_id %) id))
-                        (map :name)
-                        set)
-                   #{"Timeline A" "Timeline B"})))
+            (is (= #{"Timeline A" "Timeline B"}
+                   (events-of (mt/user-http-request :rasta :get 200 "timeline")))))
           (testing "check that we only get archived timelines when `archived=true`"
-            (is (= (->> (mt/user-http-request :rasta :get 200 "timeline" :archived true)
-                        (filter #(= (:collection_id %) id))
-                        (map :name)
-                        set)
-                   #{"Timeline C"}))))))))
+            (is (= #{"Timeline C"}
+                   (events-of (mt/user-http-request :rasta :get 200 "timeline" :archived true))))))))))
 
 (deftest get-timeline-test
   (testing "GET /api/timeline/:id"
@@ -46,13 +44,13 @@
       (mt/with-temp* [Timeline [tl-a (merge tl-defaults {:name "Timeline A"})]
                       Timeline [tl-b (merge tl-defaults {:name "Timeline B" :archived true})]]
         (testing "check that we get the timeline with the id specified"
-          (is (= (->> (mt/user-http-request :rasta :get 200 (str "timeline/" (u/the-id tl-a)))
-                      :name)
-                 "Timeline A")))
+          (is (= "Timeline A"
+                 (->> (mt/user-http-request :rasta :get 200 (str "timeline/" (u/the-id tl-a)))
+                      :name))))
         (testing "check that we get the timeline with the id specified, even if the timeline is archived"
-          (is (= (->> (mt/user-http-request :rasta :get 200 (str "timeline/" (u/the-id tl-b)))
-                      :name)
-                 "Timeline B")))))))
+          (is (= "Timeline B"
+                 (->> (mt/user-http-request :rasta :get 200 (str "timeline/" (u/the-id tl-b)))
+                      :name))))))))
 
 (deftest create-timeline-test
   (testing "POST /api/timeline"
@@ -64,8 +62,8 @@
           ;; make an API call to create a timeline
           (mt/user-http-request :rasta :post 200 "timeline" (merge tl-defaults {:name "Rasta's TL"}))
           ;; check the collection to see if the timeline is there
-          (is (= (-> (db/select-one Timeline :collection_id id) :name)
-                 "Rasta's TL")))))))
+          (is (= "Rasta's TL"
+                 (-> (db/select-one Timeline :collection_id id) :name))))))))
 
 (deftest update-timeline-test
   (testing "PUT /api/timeline/:id"
@@ -75,19 +73,22 @@
                          :collection_id id}]
         (mt/with-temp* [Timeline [tl-a (merge tl-defaults {:name "Timeline A" :archived true})]]
           (testing "check that we successfully updated a timeline"
-            (is (= (->> (mt/user-http-request :rasta :put 200 (str "timeline/" (u/the-id tl-a)) {:archived false})
-                        :archived)
-                   false))))))))
+            (is (false?
+                 (->> (mt/user-http-request :rasta :put 200 (str "timeline/" (u/the-id tl-a)) {:archived false})
+                      :archived)))))))))
 
 (defn- include-events-request
   [timeline archived?]
   (mt/user-http-request :rasta :get 200 (str "timeline/" (u/the-id timeline))
                         :include "events" :archived archived?))
 
+(defn- event-names [timeline]
+  (->> timeline :events (map :name) set))
+
 (deftest timeline-hydration-test
   (testing "GET /api/timeline/:id?include=events"
     (mt/with-temp Collection [collection {:name "Important Data"}]
-      (let [creator-id  (u/the-id (mt/fetch-user :rasta))
+      (let [creator-id  (mt/user->id :rasta)
             tl-defaults {:creator_id    creator-id
                          :collection_id (u/the-id collection)}]
         (mt/with-temp* [Timeline      [empty-tl (merge tl-defaults {:name "Empty TL"})]
@@ -96,7 +97,7 @@
                         Timeline      [timeline (merge tl-defaults {:name "All Events TL"})]]
           (let [defaults {:creator_id   creator-id
                           :timestamp    (java.time.OffsetDateTime/now)
-                          :timezone     "PST"
+                          :timezone     "US/Pacific"
                           :time_matters false}]
             (mt/with-temp* [TimelineEvent [event-a (merge defaults {:name        "event-a"
                                                                     :timeline_id (u/the-id unarchived-tl)})]
@@ -113,39 +114,16 @@
                             TimelineEvent [event-f (merge defaults {:name        "event-f"
                                                                     :timeline_id (u/the-id timeline)
                                                                     :archived    true})]]
-              (testing "check that a timeline with no events returns an empty list"
-                (is (->> (include-events-request empty-tl false)
-                         :events
-                         (every-pred empty? seqable?))))
-              (testing "check that a timeline with events returns those events"
-                (is (->> (include-events-request unarchived-tl true)
-                         :events
-                         (every-pred empty? seqable?)))
-                (is (= (->> (include-events-request unarchived-tl false)
-                            :events
-                            (map :name)
-                            set)
-                       #{"event-a" "event-b"})))
-              (testing "check that a timeline with archived events returns those events only when `archived=true`"
-                (is (->> (include-events-request archived-tl false)
-                         :events
-                         (every-pred empty? seqable?)))
-                (is (= (->> (include-events-request archived-tl true)
-                            :events
-                            (map :name)
-                            set)
-                       #{"event-c" "event-d"})))
-              (testing "check that a timeline with both (un-)archived events returns only events respecting the `archived` parameter"
-                (is (= (->> (include-events-request timeline false)
-                            :events
-                            (map :name)
-                            set)
-                       #{"event-e"}))
-                (is (= (->> (include-events-request timeline true)
-                            :events
-                            (map :name)
-                            set)
-                       #{"event-f"}))))))))))
+              (testing "a timeline with no events returns an empty list"
+                (is (= #{} (event-names (include-events-request empty-tl false)))))
+              (testing "a timeline with both (un-)archived events"
+                (testing "Returns only unarchived events when archived is false"
+                  (is (= #{"event-e"}
+                         (event-names (include-events-request timeline false)))))
+                (testing "Returns all events when archived is true"
+                  (is (= #{"event-e" "event-f"}
+                         (event-names (include-events-request timeline true)))))))))))))
+
 
 ;; TODO: Add timelines test to collection api tests + hydrating events + archived events
 ;; TODO: Add timelines test to card api tests + hydrating events + archived events

--- a/test/metabase/models/timeline_event_test.clj
+++ b/test/metabase/models/timeline_event_test.clj
@@ -1,0 +1,28 @@
+(ns metabase.models.timeline-event-test
+  "Tests for TimelineEvent model namespace."
+  (:require [clojure.test :refer :all]
+            [metabase.models.collection :refer [Collection]]
+            [metabase.models.timeline :refer [Timeline]]
+            [metabase.models.timeline-event :as te :refer [TimelineEvent]]
+            [metabase.test :as mt]
+            [metabase.util :as u]))
+
+(deftest hydrate-events-test
+  (testing "hydrate-events function hydrates all timelines with both archived and un-archived events"
+    (let [defaults {:creator_id   (u/the-id (mt/fetch-user :rasta))
+                    :timestamp    (java.time.OffsetDateTime/now)
+                    :timezone     "PST"
+                    :time_matters false}]
+      (mt/with-temp* [Collection [collection {:name "Rasta's Collection"}]
+                      Timeline [tl-a (merge (select-keys defaults [:creator_id]) {:name "tl-a"})]
+                      Timeline [tl-b (merge (select-keys defaults [:creator_id]) {:name "tl-b"})]
+                      TimelineEvent [e-a (merge defaults {:timeline_id (u/the-id tl-a) :name "e-a"})]
+                      TimelineEvent [e-a (merge defaults {:timeline_id (u/the-id tl-a) :name "e-b" :archived true})]
+                      TimelineEvent [e-a (merge defaults {:timeline_id (u/the-id tl-b) :name "e-c"})]
+                      TimelineEvent [e-a (merge defaults {:timeline_id (u/the-id tl-b) :name "e-d" :archived true})]]
+        (is (= (->> (te/hydrate-events [tl-a tl-b])
+                    mt/derecordize
+                    (mapcat :events)
+                    (map :name)
+                    set)
+               #{"e-a" "e-b" "e-c" "e-d"}))))))

--- a/test/metabase/models/timeline_test.clj
+++ b/test/metabase/models/timeline_test.clj
@@ -1,0 +1,38 @@
+(ns metabase.models.timeline-test
+  "Tests for the Timeline model."
+  (:require [clojure.test :refer :all]
+            [metabase.models.collection :refer [Collection]]
+            [metabase.models.timeline :as tl :refer [Timeline]]
+            [metabase.models.timeline-event :refer [TimelineEvent]]
+            [metabase.test :as mt]
+            [metabase.util :as u]))
+
+(deftest timelines-for-collection-test
+  (mt/with-temp Collection [collection {:name "Rasta's Collection"}]
+    (let [coll-id (u/the-id collection)
+          defaults {:creator_id   (u/the-id (mt/fetch-user :rasta))
+                    :timestamp    (java.time.OffsetDateTime/now)
+                    :timezone     "PST"
+                    :time_matters false}]
+      (mt/with-temp* [Timeline [tl-a (merge (select-keys defaults [:creator_id]) {:name "tl-a" :collection_id coll-id})]
+                      Timeline [tl-b (merge (select-keys defaults [:creator_id]) {:name "tl-b" :collection_id coll-id})]
+                      TimelineEvent [e-a (merge defaults {:timeline_id (u/the-id tl-a) :name "e-a"})]
+                      TimelineEvent [e-a (merge defaults {:timeline_id (u/the-id tl-a) :name "e-b" :archived true})]
+                      TimelineEvent [e-a (merge defaults {:timeline_id (u/the-id tl-b) :name "e-c"})]
+                      TimelineEvent [e-a (merge defaults {:timeline_id (u/the-id tl-b) :name "e-d" :archived true})]]
+        (testing "timelines are fetched and not hydrated when there is no `include=events`."
+          (is (->> (tl/timelines-for-collection (u/the-id collection) {})
+                   (mapcat :events)
+                   (every? nil?))))
+        (testing "timelines are fetched and hydrated when there is `include=events`."
+          (is (= (->> (tl/timelines-for-collection (u/the-id collection) {:include "events" :archived false})
+                      (mapcat :events)
+                      (map :name)
+                      set)
+                 #{"e-a" "e-c"})))
+        (testing "timelines are fetched and hydrated with archived events when there is `include=events` and `archived=true`."
+          (is (= (->> (tl/timelines-for-collection (u/the-id collection) {:include "events" :archived true})
+                      (mapcat :events)
+                      (map :name)
+                      set)
+                 #{"e-b" "e-d"})))))))

--- a/test/metabase/models/timeline_test.clj
+++ b/test/metabase/models/timeline_test.clj
@@ -10,18 +10,14 @@
 (deftest timelines-for-collection-test
   (mt/with-temp Collection [collection {:name "Rasta's Collection"}]
     (let [coll-id  (u/the-id collection)
-          defaults {:creator_id   (u/the-id (mt/fetch-user :rasta))
-                    :timestamp    (java.time.OffsetDateTime/now)
-                    :timezone     "US/Pacific"
-                    :time_matters false}
           event-names (fn [timelines]
                         (into #{} (comp (mapcat :events) (map :name)) timelines))]
-      (mt/with-temp* [Timeline [tl-a (merge (select-keys defaults [:creator_id]) {:name "tl-a" :collection_id coll-id})]
-                      Timeline [tl-b (merge (select-keys defaults [:creator_id]) {:name "tl-b" :collection_id coll-id})]
-                      TimelineEvent [e-a (merge defaults {:timeline_id (u/the-id tl-a) :name "e-a"})]
-                      TimelineEvent [e-a (merge defaults {:timeline_id (u/the-id tl-a) :name "e-b" :archived true})]
-                      TimelineEvent [e-a (merge defaults {:timeline_id (u/the-id tl-b) :name "e-c"})]
-                      TimelineEvent [e-a (merge defaults {:timeline_id (u/the-id tl-b) :name "e-d" :archived true})]]
+      (mt/with-temp* [Timeline [tl-a {:name "tl-a" :collection_id coll-id}]
+                      Timeline [tl-b {:name "tl-b" :collection_id coll-id}]
+                      TimelineEvent [e-a {:timeline_id (u/the-id tl-a) :name "e-a"}]
+                      TimelineEvent [e-a {:timeline_id (u/the-id tl-a) :name "e-b" :archived true}]
+                      TimelineEvent [e-a {:timeline_id (u/the-id tl-b) :name "e-c"}]
+                      TimelineEvent [e-a {:timeline_id (u/the-id tl-b) :name "e-d" :archived true}]]
         (testing "Fetching timelines"
           (testing "don't include events by default"
             (is (= #{}

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -13,7 +13,7 @@
             [metabase.driver :as driver]
             [metabase.models :refer [Card Collection Dashboard DashboardCardSeries Database Dimension Field FieldValues
                                      LoginHistory Metric NativeQuerySnippet Permissions PermissionsGroup Pulse PulseCard
-                                     PulseChannel Revision Segment Table TaskHistory User]]
+                                     PulseChannel Revision Segment Table TaskHistory Timeline TimelineEvent User]]
             [metabase.models.collection :as collection]
             [metabase.models.permissions :as perms]
             [metabase.models.permissions-group :as group]
@@ -108,8 +108,8 @@
             :color "#ABCDEF"})
 
    Dashboard
-   (fn [_] {:creator_id   (rasta-id)
-            :name         (random-name)})
+   (fn [_] {:creator_id (rasta-id)
+            :name       (random-name)})
 
    DashboardCardSeries
    (constantly {:position 0})
@@ -172,7 +172,7 @@
             :is_reversion false})
 
    Segment
-   (fn [_] {:creator_id (rasta-id)
+   (fn [_] {:creator_id  (rasta-id)
             :definition  {}
             :description "Lookin' for a blueberry"
             :name        "Toucans in the rainforest"
@@ -194,6 +194,19 @@
         :started_at started
         :ended_at   ended
         :duration   (.toMillis (t/duration started ended))}))
+
+   Timeline
+   (fn [_]
+     {:name       "Timeline of bird squawks"
+      :creator_id (rasta-id)})
+
+   TimelineEvent
+   (fn [_]
+     {:name         "default timeline event"
+      :timestamp    (t/zoned-date-time)
+      :timezone     "US/Pacific"
+      :time_matters true
+      :creator_id   (rasta-id)})
 
    User
    (fn [_] {:first_name (random-name)


### PR DESCRIPTION
Part of Epic #20289 

# Events and Timelines Migrations
This PR adds the basic machinery for *Events* and *Timelines*.

The relevant product doc is [Allow users to annotate (and use) meaningful events](https://www.notion.so/metabase/Allow-users-to-annotate-and-use-meaningful-events-b06ba695b07541d09fc3ac23ea1852b8) 


## API Endpoints (So far)

***timeline***
- [x] POST /api/timeline
- [x] GET /api/timeline/:id
- [x] GET /api/timeline/:id?include=events
- [x] GET /api/timeline/:id?include=events&archived=true
- [x] PUT /api/timeline/:id
- [x] DELETE /api/timeline/:id 

***timeline-event***
- [x] POST /api/timeline-event
- [x] GET /api/timeline-event/:id
- [x] PUT /api/timeline-event/:id
- [x] DELETE /api/timeline-event/:id 

***timelines via collection***
- [x] GET /api/collection/root/timelines
- [x] GET /api/collection/root/timelines?include=events
- [x] GET /api/collection/root/timelines?include=events&archived=true
- [x] GET /api/collection/:id/timelines
- [x] GET /api/collection/:id/timelines?include=events
- [x] GET /api/collection/:id/timelines?include=events&archived=true

***timelines via card***
- [x] GET /api/card/:id/timelines
- [x] GET /api/card/:id/timelines?include=events
- [x] GET /api/card/:id/timelines?include=events&archived=true

***Endpoint for Getting Events within a Range***
- [x] GET /api/card/:id/timelines?start=X&end=Y