### PR TITLE
Clear google auth client ID setting if empty string is saved

### DIFF
--- a/src/metabase/integrations/google.clj
+++ b/src/metabase/integrations/google.clj
@@ -24,7 +24,7 @@
   (deferred-tru "Client ID for Google Sign-In. If this is set, Google Sign-In is considered to be enabled.")
   :visibility :public
   :setter (fn [client-id]
-            (if client-id
+            (if-not (str/blank? client-id)
               (let [trimmed-client-id (str/trim client-id)]
                 (when-not (str/ends-with? trimmed-client-id ".apps.googleusercontent.com")
                   (throw (ex-info (tru "Invalid Google Sign-In Client ID: must end with \".apps.googleusercontent.com\"")

--- a/src/metabase/integrations/google.clj
+++ b/src/metabase/integrations/google.clj
@@ -24,7 +24,7 @@
   (deferred-tru "Client ID for Google Sign-In. If this is set, Google Sign-In is considered to be enabled.")
   :visibility :public
   :setter (fn [client-id]
-            (if-not (str/blank? client-id)
+            (if (seq client-id)
               (let [trimmed-client-id (str/trim client-id)]
                 (when-not (str/ends-with? trimmed-client-id ".apps.googleusercontent.com")
                   (throw (ex-info (tru "Invalid Google Sign-In Client ID: must end with \".apps.googleusercontent.com\"")

--- a/test/metabase/integrations/google_test.clj
+++ b/test/metabase/integrations/google_test.clj
@@ -11,15 +11,20 @@
 ;;; --------------------------------------------- google-auth-client-id ----------------------------------------------
 
 (deftest google-auth-client-id-test
-  (testing "Client ID must end with correct suffix"
-    (is (thrown-with-msg?
-         clojure.lang.ExceptionInfo
-         #"Invalid Google Sign-In Client ID: must end with \".apps.googleusercontent.com\""
-         (google/google-auth-client-id "invalid-client-id"))))
+  (mt/with-temporary-setting-values [google-auth-client-id nil]
+    (testing "Client ID must end with correct suffix"
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"Invalid Google Sign-In Client ID: must end with \".apps.googleusercontent.com\""
+           (google/google-auth-client-id "invalid-client-id"))))
 
-  (testing "Trailing whitespace in client ID is stripped upon save"
-    (google/google-auth-client-id "test-client-id.apps.googleusercontent.com     ")
-    (is (= "test-client-id.apps.googleusercontent.com" (google/google-auth-client-id)))))
+    (testing "Trailing whitespace in client ID is stripped upon save"
+      (google/google-auth-client-id "test-client-id.apps.googleusercontent.com     ")
+      (is (= "test-client-id.apps.googleusercontent.com" (google/google-auth-client-id))))
+
+    (testing "Saving an empty string will clear the client ID setting"
+      (google/google-auth-client-id "")
+      (is (= nil (google/google-auth-client-id))))))
 
 
 ;;; --------------------------------------------- account autocreation -----------------------------------------------


### PR DESCRIPTION
Apparently the frontend will send an empty string for the client ID if you're trying to clear a previously saved value. This is an issue because we now have validation that the suffix of the client ID is correct, so an empty string is failing validation.

We can fix this by just calling `seq` on the string before the conditional check.

Fixes #20442