### PR TITLE
yarn upgrade icepick@2.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "eslint-plugin-no-only-tests": "^2.4.0",
     "history": "3",
     "humanize-plus": "^1.8.1",
-    "icepick": "2.3.0",
+    "icepick": "2.4.0",
     "iframe-resizer": "^4.3.2",
     "inflection": "^1.7.1",
     "isomorphic-fetch": "^2.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12428,10 +12428,10 @@ husky@^7.0.4:
   resolved "https://registry.yarnpkg.com/husky/-/husky-7.0.4.tgz#242048245dc49c8fb1bf0cc7cfb98dd722531535"
   integrity sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==
 
-icepick@2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/icepick/-/icepick-2.3.0.tgz#1d1b0b28b80c1ff720a1f62359dab46392806f5c"
-  integrity sha512-1l106azHB9v3J9S4x5wYJyk+34rmFh2uptHyH8SCrYTy9f0qFAdMtUeOQTsBYtF+TuKQ0jdWpxClLec/7H5BjQ==
+icepick@2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/icepick/-/icepick-2.4.0.tgz#1ff31e080d9b64ca5d164916ea725f8cb9514b7a"
+  integrity sha512-tr62H2DxpN9dEdgFZ4CGKiE0yzcz/kST4dJiRN6jkPn4CllniywYl1LvPTErWTBxJ2GAG4c7Em/pzy0WZi9eNw==
 
 iconv-lite@0.4.24, iconv-lite@^0.4.5:
   version "0.4.24"


### PR DESCRIPTION
This is purely package upgrade, everything and all tests should continue work as is.

Note that v2.4.0 is already the latest version of icepick.

See also the [code diff 2.3.0 -> 2.4.0](https://app.renovatebot.com/package-diff?name=icepick&from=2.3.0&to=2.4.0) (stolen from #20150).
