### PR TITLE
Include (new) site UUID in EE token check request

### DIFF
--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -85,6 +85,17 @@
   ;; magic getter will either fetch value from DB, or if no value exists, set the value to a random UUID.
   :type       ::uuid-nonce)
 
+(defsetting site-uuid-for-premium-features-token-checks
+  "In the interest of respecting everyone's privacy and keeping things as anonymous as possible we have a *different*
+  site-wide UUID that we use for the EE/premium features token feature check API calls. It works in fundamentally the
+  same way as [[site-uuid]] but should only be used by the token check logic
+  in [[metabase.public-settings.premium-features/fetch-token-status]]. (`site-uuid` is used for anonymous
+  analytics/stats and if we sent it along with the premium features token check API request it would no longer be
+  anonymous.)"
+  :visibility :internal
+  :setter     :none
+  :type       ::uuid-nonce)
+
 (defn- normalize-site-url [^String s]
   (let [ ;; remove trailing slashes
         s (str/replace s #"/$" "")

--- a/src/metabase/public_settings/premium_features.clj
+++ b/src/metabase/public_settings/premium_features.clj
@@ -55,19 +55,6 @@
    ;; don't explode in the future if we add more to the response! lol
    s/Any                           s/Any})
 
-(defsetting site-uuid-for-premium-features-token-checks
-  "In the interest of respecting everyone's privacy and keeping things as anonymous as possible we have a *different*
-  site-wide UUID that we use for the EE/premium features token feature check API calls. It works in fundamentally the
-  same way as [[metabase.public-settings/site-uuid]] but should only be used by the token check logic
-  in [[metabase.public-settings.premium-features/fetch-token-status]]. (`site-uuid` is used for anonymous
-  analytics/stats and if we sent it along with the premium features token check API request it would no longer be
-  anonymous.)"
-  :visibility :internal
-  :setter     :none
-  ;; `:metabase.public-settings/uuid-nonce` is a Setting that sets a site-wide random UUID value the first time it is
-  ;; fetched.
-  :type       :metabase.public-settings/uuid-nonce)
-
 (s/defn ^:private fetch-token-status* :- TokenStatus
   "Fetch info about the validity of `token` from the MetaStore."
   [token :- ValidToken]
@@ -80,7 +67,7 @@
    (future
      (try (some-> (token-status-url token)
                   (http/get {:query-params {:users     (active-user-count)
-                                            :site-uuid (public-settings/site-uuid-for-premium-features-token-checks)}})
+                                            :site-uuid (setting/get :site-uuid-for-premium-features-token-checks)}})
                   :body
                   (json/parse-string keyword))
           ;; if there was an error fetching the token, log it and return a generic message about the

--- a/src/metabase/public_settings/premium_features.clj
+++ b/src/metabase/public_settings/premium_features.clj
@@ -55,6 +55,19 @@
    ;; don't explode in the future if we add more to the response! lol
    s/Any                           s/Any})
 
+(defsetting site-uuid-for-premium-features-token-checks
+  "In the interest of respecting everyone's privacy and keeping things as anonymous as possible we have a *different*
+  site-wide UUID that we use for the EE/premium features token feature check API calls. It works in fundamentally the
+  same way as [[metabase.public-settings/site-uuid]] but should only be used by the token check logic
+  in [[metabase.public-settings.premium-features/fetch-token-status]]. (`site-uuid` is used for anonymous
+  analytics/stats and if we sent it along with the premium features token check API request it would no longer be
+  anonymous.)"
+  :visibility :internal
+  :setter     :none
+  ;; `:metabase.public-settings/uuid-nonce` is a Setting that sets a site-wide random UUID value the first time it is
+  ;; fetched.
+  :type       :metabase.public-settings/uuid-nonce)
+
 (s/defn ^:private fetch-token-status* :- TokenStatus
   "Fetch info about the validity of `token` from the MetaStore."
   [token :- ValidToken]
@@ -66,7 +79,8 @@
   (deref
    (future
      (try (some-> (token-status-url token)
-                  (http/get {:query-params {:users (active-user-count)}})
+                  (http/get {:query-params {:users     (active-user-count)
+                                            :site-uuid (public-settings/site-uuid-for-premium-features-token-checks)}})
                   :body
                   (json/parse-string keyword))
           ;; if there was an error fetching the token, log it and return a generic message about the

--- a/test/metabase/public_settings/premium_features_test.clj
+++ b/test/metabase/public_settings/premium_features_test.clj
@@ -3,6 +3,7 @@
             [clj-http.fake :as http-fake]
             [clojure.test :refer :all]
             [metabase.models.user :refer [User]]
+            [metabase.public-settings :as public-settings]
             [metabase.public-settings.premium-features :as premium-features]
             [metabase.test :as mt]
             [toucan.util.test :as tt]))
@@ -30,7 +31,8 @@
   [token premium-features-response]
   (http-fake/with-fake-routes-in-isolation
     {{:address      (#'premium-features/token-status-url token)
-      :query-params {:users (str (#'premium-features/active-user-count))}}
+      :query-params {:users     (str (#'premium-features/active-user-count))
+                     :site-uuid (public-settings/site-uuid-for-premium-features-token-checks)}}
      (constantly premium-features-response)}
     (#'premium-features/fetch-token-status* token)))
 


### PR DESCRIPTION
Add a new Setting that's basically the same idea as `site-uuid` but with a different value to keep things decoupled and anonymous (`site-uuid` is used for anonymous usage stats, and if we used it here it would cease to be anonymous). This new site-wide random UUID is sent along with the premium features token check API request for EE/premium tokens

See https://github.com/metabase/metaboat/issues/146