### PR TITLE
Custom expression editor: Esc hides the suggestion list/help text

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -395,6 +395,13 @@ export default class ExpressionEditorTextfield extends React.Component {
         this.chooseSuggestion();
       },
     },
+    {
+      name: "clearSuggestions",
+      bindKey: { win: "Esc", mac: "Esc" },
+      exec: () => {
+        this.clearSuggestions();
+      },
+    },
   ];
 
   render() {

--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -695,6 +695,20 @@ describe("scenarios > question > filter", () => {
       .and("contains", "Button");
   });
 
+  it("should allow hiding the suggestion list with Escape", () => {
+    openOrdersTable({ mode: "notebook" });
+    filter({ mode: "notebook" });
+    cy.findByText("Custom Expression").click();
+
+    // Try to auto-complete Tax
+    cy.get(".ace_text-input").type("Ta");
+    cy.findByText("Tax");
+
+    // Esc closes the suggestion popover
+    cy.realPress("{esc}");
+    cy.findByText("Tax").should("not.exist");
+  });
+
   it.skip("should work on twice summarized questions (metabase#15620)", () => {
     visitQuestionAdhoc({
       dataset_query: {


### PR DESCRIPTION
While typing a custom expression, the suggestions can be in your way and thus mildly annoying.

How to verify:
1. New, Question
2. Sample Database, Reviews table
3. Custom Column, type `p`
4. Suggestions popover shows up

![image](https://user-images.githubusercontent.com/7288/153720967-888e40a9-83f3-412d-b528-e7e8f6065a53.png)

5. Press `Tab` to choose `power`. Now the help text shows up

![image](https://user-images.githubusercontent.com/7288/153721025-b67c63e5-4a09-4992-b5aa-fe4ca28b0b61.png)


**Before**

There is no way to close the popover which may obstruct other (useful) parts of the UI.

**After**

Just like many other common UI pattern out there, press `Esc` does the magic: the popover disappears :magic_wand:.