### PR TITLE
Custom expression editor: use ace-builds instead of brace

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionMode.js
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionMode.js
@@ -1,4 +1,4 @@
-import "brace/mode/java";
+import "ace-builds/src-noconflict/mode-java";
 
 class ExpressionHighlight extends window.ace.acequire(
   "ace/mode/text_highlight_rules",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "@visx/text": "1.7.0",
     "ace-builds": "^1.4.7",
     "arg": "^5.0.0",
-    "brace": "^0.11.1",
     "classlist-polyfill": "^1.2.0",
     "classnames": "^2.1.3",
     "color": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7240,11 +7240,6 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-brace@^0.11.1:
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/brace/-/brace-0.11.1.tgz#4896fcc9d544eef45f4bb7660db320d3b379fe58"
-  integrity sha1-SJb8ydVE7vRfS7dmDbMg07N5/lg=
-
 braces@^2.3.1, braces@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-2.3.2.tgz#5979fd3f14cd531565e5fa2df1abfff1dfaee729"


### PR DESCRIPTION
As documented, react-ace >=8 doesn't need `brace` anymore.

This reduces the bundle size, `resources/frontend_client/app/dist/vendor.bundle.js`, by 218 KB, from 5286809 to 5063129 bytes.
