### PR TITLE
yarn upgrade react-motion@0.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "react-hot-loader": "^4.13.0",
     "react-is": "^17.0.2",
     "react-markdown": "^6.0.2",
-    "react-motion": "^0.4.5",
+    "react-motion": "0.5.2",
     "react-redux": "^5.0.4",
     "react-resizable": "^1.9.0",
     "react-router": "3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8744,7 +8744,7 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-create-react-class@^15.5.1, create-react-class@^15.5.2:
+create-react-class@^15.5.1:
   version "15.7.0"
   resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.7.0.tgz#7499d7ca2e69bb51d13faf59bd04f0c65a1d6c1e"
   integrity sha512-QZv4sFWG9S5RUvkTYWbflxeZX+JG7Cz0Tn33rQBJ+WFQTqTfUTjMjiv9tnfXazjsO5r0KhPs+AqCjyrQX6h2ng==
@@ -18175,12 +18175,11 @@ react-markdown@^6.0.2:
     unist-util-visit "^2.0.0"
     vfile "^4.0.0"
 
-react-motion@^0.4.5:
-  version "0.4.8"
-  resolved "https://registry.yarnpkg.com/react-motion/-/react-motion-0.4.8.tgz#23bb2dd27c2d8e00d229e45572d105efcf40a35e"
-  integrity sha1-I7st0nwtjgDSKeRVctEF789Ao14=
+react-motion@0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/react-motion/-/react-motion-0.5.2.tgz#0dd3a69e411316567927917c6626551ba0607316"
+  integrity sha512-9q3YAvHoUiWlP3cK0v+w1N5Z23HXMj4IF4YuvjvWegWqNPfLXsOBE/V7UvQGpXxHFKRQQcNcVQE31g9SB/6qgQ==
   dependencies:
-    create-react-class "^15.5.2"
     performance-now "^0.2.0"
     prop-types "^15.5.8"
     raf "^3.1.0"


### PR DESCRIPTION
This is purely package upgrade, everything and all tests should continue to work as is.

Note that v0.5.2 is already the latest version of react-motion.

See also the [code diff 0.4.8 -> 0.5.2](https://app.renovatebot.com/package-diff?name=react-motion&from=0.4.8&to=0.5.2) (stolen from #20150).


How to verify this package upgrade? Do something that triggers Motion-based animation, e.g.:
1. New, Question
2. Sample Database, Products table
3. Click on the (triangle) Preview button

![image](https://user-images.githubusercontent.com/7288/153767652-016ae76c-7344-486f-8900-66abba0b5562.png)

The query preview should "slide down" with its Motion-based animation.