### PR TITLE
Custom expression editor: don't suggest a unique matching function

### DIFF
--- a/frontend/src/metabase/lib/expressions/suggest.js
+++ b/frontend/src/metabase/lib/expressions/suggest.js
@@ -151,11 +151,22 @@ export function suggest({
   suggestions = suggestions.filter(suggestion => suggestion.range);
 
   // deduplicate suggestions and sort by type then name
-  return {
-    suggestions: _.chain(suggestions)
-      .uniq(suggestion => suggestion.text)
-      .sortBy("text")
-      .sortBy("order")
-      .value(),
-  };
+  suggestions = _.chain(suggestions)
+    .uniq(suggestion => suggestion.text)
+    .sortBy("text")
+    .sortBy("order")
+    .value();
+
+  // the only suggested function equals the prefix match?
+  if (suggestions.length === 1 && matchPrefix) {
+    const { icon } = suggestions[0];
+    if (icon === "function") {
+      const helpText = getHelpText(getMBQLName(matchPrefix));
+      if (helpText) {
+        return { helpText };
+      }
+    }
+  }
+
+  return { suggestions };
 }

--- a/frontend/test/metabase/lib/expressions/suggest.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/suggest.unit.spec.js
@@ -161,6 +161,16 @@ describe("metabase/lib/expression/suggest", () => {
         expect(args).toHaveLength(3);
       });
 
+      it("should provide help text for the unique match", () => {
+        const { structure, args } = helpText({
+          source: "lower", // doesn't need to be "lower(" since it's a unique match
+          query: ORDERS.query(),
+          startRule: "expression",
+        });
+        expect(structure).toEqual("lower(text)");
+        expect(args).toHaveLength(1);
+      });
+
       it("should provide help text after first argument if there's only one argument", () => {
         expect(
           helpText({


### PR DESCRIPTION
How to verify:
1. New, Question
2. Sample Database, Products table
3. Custom Column , type `lower(`. There is a nice help text for the said function:

![Screenshot_20220213_200449](https://user-images.githubusercontent.com/7288/153798599-97b18098-0d5b-40a1-a82d-1bb80340f5fd.png)

4. Press Backspace to remove one character, now the expression is only `lower`

**Before this PR**

The suggestion popover shows up, with only one suggestion there, i.e. the function`lower`.
This is mildly **annoying** and rather **useless**, since the typed expression `lower` should only _uniquely_ match the function anyway, i.e. there is no other functions which can match the characters.

![image](https://user-images.githubusercontent.com/7288/153798582-cbe53e39-4c3b-41b5-82fe-f5bb7af638cc.png)

**After this PR**

The suggestion for `lower` is exactly the same as `lower(` (note the open parenthesis), i.e. the help text showing some more detailed information about the function. For the former, the reason is that it is an exact match.

![image](https://user-images.githubusercontent.com/7288/153798763-82b19f5b-d667-4e34-8864-be3d5f4d5fac.png)


