### PR TITLE
Repro #20488: Trend visualization percentage rounding decimals

### DIFF
--- a/frontend/test/metabase/scenarios/visualizations/smartscalar-trend.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/smartscalar-trend.cy.spec.js
@@ -51,7 +51,7 @@ describe("scenarios > visualizations > scalar", () => {
     cy.icon("arrow_down");
 
     cy.get(".SmartWrapper")
-      .should("contain", "99.9%")
+      .should("contain", "99,900%")
       .and("contain", "was 1,000 last year");
   });
 });

--- a/frontend/test/metabase/scenarios/visualizations/smartscalar-trend.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/smartscalar-trend.cy.spec.js
@@ -31,4 +31,27 @@ describe("scenarios > visualizations > scalar", () => {
     cy.get(".ScalarValue").contains("100");
     cy.findByText("Nothing to compare for the previous month.");
   });
+
+  it.skip("should display correct trend percentage (metabase#20488)", () => {
+    const questionDetails = {
+      native: {
+        query:
+          "SELECT parsedatetime('2020-12-31', 'yyyy-MM-dd'), 1000\nUNION ALL\nSELECT parsedatetime('2021-12-31', 'yyyy-MM-dd'), 1",
+        "template-tags": {},
+      },
+      display: "smartscalar",
+    };
+
+    cy.createNativeQuestion(questionDetails, { visitQuestion: true });
+
+    cy.get(".ScalarValue")
+      .invoke("text")
+      .should("eq", "1");
+
+    cy.icon("arrow_down");
+
+    cy.get(".SmartWrapper")
+      .should("contain", "999%")
+      .and("contain", "was 1,000 last year");
+  });
 });

--- a/frontend/test/metabase/scenarios/visualizations/smartscalar-trend.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/smartscalar-trend.cy.spec.js
@@ -51,7 +51,7 @@ describe("scenarios > visualizations > scalar", () => {
     cy.icon("arrow_down");
 
     cy.get(".SmartWrapper")
-      .should("contain", "999%")
+      .should("contain", "99.9%")
       .and("contain", "was 1,000 last year");
   });
 });


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #20488 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/visualizations/smartscalar-trend.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/153883805-c72b4b17-9a72-42c5-97d0-238c39d52991.png)

