### PR TITLE
Repro #20493: Dashboard filter with defaults, doesn't work if values are removed, query fails

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard-filters-sql/dashboard-filters-sql-text-category.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters-sql/dashboard-filters-sql-text-category.cy.spec.js
@@ -55,7 +55,7 @@ Object.entries(DASHBOARD_SQL_TEXT_FILTERS).forEach(
         });
       });
 
-      it(`should work for "${filter}" when set as the default filter`, () => {
+      it.skip(`should work for "${filter}" when set as the default filter and when that filter is removed (metabase#20493)`, () => {
         cy.findByText("Default value")
           .next()
           .click();
@@ -67,6 +67,14 @@ Object.entries(DASHBOARD_SQL_TEXT_FILTERS).forEach(
         cy.get(".Card").within(() => {
           cy.contains(representativeResult);
         });
+
+        filterWidget()
+          .find(".Icon-close")
+          .click();
+
+        cy.url().should("not.include", value);
+
+        cy.findByText("Rustic Paper Wallet");
       });
     });
   },


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #20493 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/dashboard-filters-sql/dashboard-filters-sql-text-category.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/153917141-333b3ff7-31fb-47fd-b63b-93d7dd86919e.png)

