### PR TITLE
Add timeline & events archiving

### DIFF
--- a/frontend/src/metabase/timelines/actions.ts
+++ b/frontend/src/metabase/timelines/actions.ts
@@ -43,6 +43,17 @@ export const updateTimeline = createThunkAction(
   },
 );
 
+export const ARCHIVE_TIMELINE = "metabase/timelines/ARCHIVE_TIMELINE";
+export const archiveTimeline = createThunkAction(
+  ARCHIVE_TIMELINE,
+  (timeline: Timeline, collection: Collection) => {
+    return async (dispatch: Dispatch) => {
+      await dispatch(Timelines.actions.setArchived(timeline, true));
+      dispatch(push(Urls.timelinesInCollection(collection)));
+    };
+  },
+);
+
 export const CREATE_EVENT = "metabase/timelines/CREATE_EVENT";
 export const createEvent = createThunkAction(
   CREATE_EVENT,

--- a/frontend/src/metabase/timelines/actions.ts
+++ b/frontend/src/metabase/timelines/actions.ts
@@ -82,9 +82,13 @@ export const updateEvent = createThunkAction(
 export const ARCHIVE_EVENT = "metabase/timelines/ARCHIVE_EVENT";
 export const archiveEvent = createThunkAction(
   ARCHIVE_EVENT,
-  (event: TimelineEvent) => {
+  (event: TimelineEvent, timeline?: Timeline, collection?: Collection) => {
     return async (dispatch: Dispatch) => {
       await dispatch(TimelineEvents.actions.setArchived(event, true));
+
+      if (timeline && collection) {
+        dispatch(push(Urls.timelineInCollection(timeline, collection)));
+      }
     };
   },
 );

--- a/frontend/src/metabase/timelines/actions.ts
+++ b/frontend/src/metabase/timelines/actions.ts
@@ -79,4 +79,14 @@ export const updateEvent = createThunkAction(
   },
 );
 
+export const ARCHIVE_EVENT = "metabase/timelines/ARCHIVE_EVENT";
+export const archiveEvent = createThunkAction(
+  ARCHIVE_EVENT,
+  (event: TimelineEvent) => {
+    return async (dispatch: Dispatch) => {
+      await dispatch(TimelineEvents.actions.setArchived(event, true));
+    };
+  },
+);
+
 type Dispatch = any;

--- a/frontend/src/metabase/timelines/components/EditEventModal/EditEventModal.styled.tsx
+++ b/frontend/src/metabase/timelines/components/EditEventModal/EditEventModal.styled.tsx
@@ -1,5 +1,18 @@
 import styled from "@emotion/styled";
+import { color } from "metabase/lib/colors";
+import Button from "metabase/core/components/Button/Button";
 
 export const ModalBody = styled.div`
   padding: 2rem;
+`;
+
+export const ModalDangerButton = styled(Button)`
+  color: ${color("danger")};
+  padding-left: 0;
+  padding-right: 0;
+
+  &:hover {
+    color: ${color("danger")};
+    background-color: transparent;
+  }
 `;

--- a/frontend/src/metabase/timelines/components/EditEventModal/EditEventModal.tsx
+++ b/frontend/src/metabase/timelines/components/EditEventModal/EditEventModal.tsx
@@ -15,7 +15,11 @@ export interface EditEventModalProps {
     timeline: Timeline,
     collection: Collection,
   ) => void;
-  onArchive: (event: TimelineEvent) => void;
+  onArchive: (
+    event: TimelineEvent,
+    timeline: Timeline,
+    collection: Collection,
+  ) => void;
   onCancel: () => void;
   onClose?: () => void;
 }
@@ -37,8 +41,8 @@ const EditEventModal = ({
   );
 
   const handleArchive = useCallback(async () => {
-    await onArchive(event);
-  }, [event, onArchive]);
+    await onArchive(event, timeline, collection);
+  }, [event, timeline, collection, onArchive]);
 
   return (
     <div>

--- a/frontend/src/metabase/timelines/components/EditEventModal/EditEventModal.tsx
+++ b/frontend/src/metabase/timelines/components/EditEventModal/EditEventModal.tsx
@@ -4,7 +4,7 @@ import Form from "metabase/containers/Form";
 import forms from "metabase/entities/timeline-events/forms";
 import { Collection, Timeline, TimelineEvent } from "metabase-types/api";
 import ModalHeader from "../ModalHeader";
-import { ModalBody } from "./EditEventModal.styled";
+import { ModalBody, ModalDangerButton } from "./EditEventModal.styled";
 
 export interface EditEventModalProps {
   event: TimelineEvent;
@@ -15,6 +15,7 @@ export interface EditEventModalProps {
     timeline: Timeline,
     collection: Collection,
   ) => void;
+  onArchive: (event: TimelineEvent) => void;
   onCancel: () => void;
   onClose?: () => void;
 }
@@ -24,6 +25,7 @@ const EditEventModal = ({
   timeline,
   collection,
   onSubmit,
+  onArchive,
   onCancel,
   onClose,
 }: EditEventModalProps): JSX.Element => {
@@ -33,6 +35,10 @@ const EditEventModal = ({
     },
     [timeline, collection, onSubmit],
   );
+
+  const handleArchive = useCallback(async () => {
+    await onArchive(event);
+  }, [event, onArchive]);
 
   return (
     <div>
@@ -44,6 +50,11 @@ const EditEventModal = ({
           isModal={true}
           onSubmit={handleSubmit}
           onClose={onCancel}
+          footerExtraButtons={
+            <ModalDangerButton type="button" borderless onClick={handleArchive}>
+              {t`Archive event`}
+            </ModalDangerButton>
+          }
         />
       </ModalBody>
     </div>

--- a/frontend/src/metabase/timelines/components/EditTimelineModal/EditTimelineModal.styled.tsx
+++ b/frontend/src/metabase/timelines/components/EditTimelineModal/EditTimelineModal.styled.tsx
@@ -1,5 +1,18 @@
 import styled from "@emotion/styled";
+import { color } from "metabase/lib/colors";
+import Button from "metabase/core/components/Button";
 
 export const ModalBody = styled.div`
   padding: 2rem;
+`;
+
+export const ModalDangerButton = styled(Button)`
+  color: ${color("danger")};
+  padding-left: 0;
+  padding-right: 0;
+
+  &:hover {
+    color: ${color("danger")};
+    background-color: transparent;
+  }
 `;

--- a/frontend/src/metabase/timelines/components/EditTimelineModal/EditTimelineModal.tsx
+++ b/frontend/src/metabase/timelines/components/EditTimelineModal/EditTimelineModal.tsx
@@ -4,12 +4,13 @@ import Form from "metabase/containers/Form";
 import forms from "metabase/entities/timelines/forms";
 import { Collection, Timeline } from "metabase-types/api";
 import ModalHeader from "../ModalHeader";
-import { ModalBody } from "./EditTimelineModal.styled";
+import { ModalDangerButton, ModalBody } from "./EditTimelineModal.styled";
 
 export interface EditTimelineModalProps {
   timeline: Timeline;
   collection: Collection;
   onSubmit: (values: Partial<Timeline>, collection: Collection) => void;
+  onArchive: (timeline: Timeline, collection: Collection) => void;
   onCancel: () => void;
   onClose?: () => void;
 }
@@ -18,6 +19,7 @@ const EditTimelineModal = ({
   timeline,
   collection,
   onSubmit,
+  onArchive,
   onCancel,
   onClose,
 }: EditTimelineModalProps): JSX.Element => {
@@ -27,6 +29,10 @@ const EditTimelineModal = ({
     },
     [collection, onSubmit],
   );
+
+  const handleArchive = useCallback(() => {
+    onArchive(timeline, collection);
+  }, [timeline, collection, onArchive]);
 
   return (
     <div>
@@ -38,6 +44,11 @@ const EditTimelineModal = ({
           isModal={true}
           onSubmit={handleSubmit}
           onClose={onCancel}
+          footerExtraButtons={
+            <ModalDangerButton type="button" borderless onClick={handleArchive}>
+              {t`Archive timeline and all events`}
+            </ModalDangerButton>
+          }
         />
       </ModalBody>
     </div>

--- a/frontend/src/metabase/timelines/components/EditTimelineModal/EditTimelineModal.tsx
+++ b/frontend/src/metabase/timelines/components/EditTimelineModal/EditTimelineModal.tsx
@@ -30,8 +30,8 @@ const EditTimelineModal = ({
     [collection, onSubmit],
   );
 
-  const handleArchive = useCallback(() => {
-    onArchive(timeline, collection);
+  const handleArchive = useCallback(async () => {
+    await onArchive(timeline, collection);
   }, [timeline, collection, onArchive]);
 
   return (

--- a/frontend/src/metabase/timelines/components/EventCard/EventCard.tsx
+++ b/frontend/src/metabase/timelines/components/EventCard/EventCard.tsx
@@ -24,14 +24,16 @@ export interface EventCardProps {
   event: TimelineEvent;
   timeline: Timeline;
   collection: Collection;
+  onArchive: (event: TimelineEvent) => void;
 }
 
 const EventCard = ({
   event,
   timeline,
   collection,
+  onArchive,
 }: EventCardProps): JSX.Element => {
-  const menuItems = getMenuItems(event, timeline, collection);
+  const menuItems = getMenuItems(event, timeline, collection, onArchive);
   const dateMessage = getDateMessage(event);
   const creatorMessage = getCreatorMessage(event);
 
@@ -62,11 +64,16 @@ const getMenuItems = (
   event: TimelineEvent,
   timeline: Timeline,
   collection: Collection,
+  onArchive: (event: TimelineEvent) => void,
 ) => {
   return [
     {
       title: t`Edit event`,
       link: Urls.editEventInCollection(event, timeline, collection),
+    },
+    {
+      title: t`Archive event`,
+      action: () => onArchive(event),
     },
   ];
 };

--- a/frontend/src/metabase/timelines/components/EventList/EventList.tsx
+++ b/frontend/src/metabase/timelines/components/EventList/EventList.tsx
@@ -1,7 +1,5 @@
-import React, { useMemo } from "react";
-import _ from "underscore";
+import React from "react";
 import { t } from "ttag";
-import { parseTimestamp } from "metabase/lib/time";
 import { Collection, Timeline, TimelineEvent } from "metabase-types/api";
 import EventCard from "../EventCard";
 import {
@@ -24,14 +22,9 @@ const EventList = ({
   timeline,
   collection,
 }: EventListProps): JSX.Element => {
-  const sortedEvents = useMemo(
-    () => _.sortBy(events, e => parseTimestamp(e.timestamp)).reverse(),
-    [events],
-  );
-
   return (
     <div>
-      {sortedEvents.map(event => (
+      {events.map(event => (
         <EventCard
           key={event.id}
           event={event}

--- a/frontend/src/metabase/timelines/components/EventList/EventList.tsx
+++ b/frontend/src/metabase/timelines/components/EventList/EventList.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from "react";
 import _ from "underscore";
 import { t } from "ttag";
 import { parseTimestamp } from "metabase/lib/time";
-import { Collection, Timeline } from "metabase-types/api";
+import { Collection, Timeline, TimelineEvent } from "metabase-types/api";
 import EventCard from "../EventCard";
 import {
   ListFooter,
@@ -14,15 +14,19 @@ import {
 } from "./EventList.styled";
 
 export interface EventListProps {
+  events: TimelineEvent[];
   timeline: Timeline;
   collection: Collection;
 }
 
-const EventList = ({ timeline, collection }: EventListProps): JSX.Element => {
-  const allEvents = timeline.events;
+const EventList = ({
+  events,
+  timeline,
+  collection,
+}: EventListProps): JSX.Element => {
   const sortedEvents = useMemo(
-    () => _.sortBy(allEvents ?? [], e => parseTimestamp(e.timestamp)).reverse(),
-    [allEvents],
+    () => _.sortBy(events, e => parseTimestamp(e.timestamp)).reverse(),
+    [events],
   );
 
   return (

--- a/frontend/src/metabase/timelines/components/EventList/EventList.tsx
+++ b/frontend/src/metabase/timelines/components/EventList/EventList.tsx
@@ -15,12 +15,14 @@ export interface EventListProps {
   events: TimelineEvent[];
   timeline: Timeline;
   collection: Collection;
+  onArchive: (event: TimelineEvent) => void;
 }
 
 const EventList = ({
   events,
   timeline,
   collection,
+  onArchive,
 }: EventListProps): JSX.Element => {
   return (
     <div>
@@ -30,6 +32,7 @@ const EventList = ({
           event={event}
           timeline={timeline}
           collection={collection}
+          onArchive={onArchive}
         />
       ))}
       <ListFooter>

--- a/frontend/src/metabase/timelines/components/TimelineModal/TimelineModal.tsx
+++ b/frontend/src/metabase/timelines/components/TimelineModal/TimelineModal.tsx
@@ -34,7 +34,11 @@ const TimelineModal = ({
       </ModalToolbar>
       {timeline.events && (
         <ModalBody>
-          <EventList timeline={timeline} collection={collection} />
+          <EventList
+            events={timeline.events}
+            timeline={timeline}
+            collection={collection}
+          />
         </ModalBody>
       )}
     </ModalRoot>

--- a/frontend/src/metabase/timelines/components/TimelineModal/TimelineModal.tsx
+++ b/frontend/src/metabase/timelines/components/TimelineModal/TimelineModal.tsx
@@ -1,9 +1,11 @@
 import React from "react";
 import { t } from "ttag";
+import _ from "underscore";
 import * as Urls from "metabase/lib/urls";
+import { parseTimestamp } from "metabase/lib/time";
 import Link from "metabase/core/components/Link";
 import EntityMenu from "metabase/components/EntityMenu";
-import { Collection, Timeline } from "metabase-types/api";
+import { Collection, Timeline, TimelineEvent } from "metabase-types/api";
 import EventList from "../EventList";
 import ModalHeader from "../ModalHeader";
 import { ModalBody, ModalRoot, ModalToolbar } from "./TimelineModal.styled";
@@ -19,6 +21,7 @@ const TimelineModal = ({
   collection,
   onClose,
 }: TimelineModalProps): JSX.Element => {
+  const events = getEvents(timeline.events, timeline.archived);
   const menuItems = getMenuItems(timeline, collection);
 
   return (
@@ -32,10 +35,10 @@ const TimelineModal = ({
           to={Urls.newEventInCollection(timeline, collection)}
         >{t`Add an event`}</Link>
       </ModalToolbar>
-      {timeline.events && (
+      {events.length > 0 && (
         <ModalBody>
           <EventList
-            events={timeline.events}
+            events={events}
             timeline={timeline}
             collection={collection}
           />
@@ -43,6 +46,14 @@ const TimelineModal = ({
       )}
     </ModalRoot>
   );
+};
+
+const getEvents = (events: TimelineEvent[] = [], archived: boolean) => {
+  return _.chain(events)
+    .filter(e => e.archived === archived)
+    .sortBy(e => parseTimestamp(e.timestamp))
+    .reverse()
+    .value();
 };
 
 const getMenuItems = (timeline: Timeline, collection: Collection) => {

--- a/frontend/src/metabase/timelines/components/TimelineModal/TimelineModal.tsx
+++ b/frontend/src/metabase/timelines/components/TimelineModal/TimelineModal.tsx
@@ -13,12 +13,14 @@ import { ModalBody, ModalRoot, ModalToolbar } from "./TimelineModal.styled";
 export interface TimelineModalProps {
   timeline: Timeline;
   collection: Collection;
+  onArchive: (event: TimelineEvent) => void;
   onClose?: () => void;
 }
 
 const TimelineModal = ({
   timeline,
   collection,
+  onArchive,
   onClose,
 }: TimelineModalProps): JSX.Element => {
   const events = getEvents(timeline.events, timeline.archived);
@@ -41,6 +43,7 @@ const TimelineModal = ({
             events={events}
             timeline={timeline}
             collection={collection}
+            onArchive={onArchive}
           />
         </ModalBody>
       )}

--- a/frontend/src/metabase/timelines/containers/EditEventModal/EditEventModal.tsx
+++ b/frontend/src/metabase/timelines/containers/EditEventModal/EditEventModal.tsx
@@ -7,7 +7,7 @@ import Timelines from "metabase/entities/timelines";
 import TimelineEvents from "metabase/entities/timeline-events";
 import { State } from "metabase-types/store";
 import EditEventModal from "../../components/EditEventModal";
-import { updateEvent } from "../../actions";
+import { archiveEvent, updateEvent } from "../../actions";
 import { ModalProps } from "../../types";
 
 const timelineProps = {
@@ -28,6 +28,7 @@ const collectionProps = {
 
 const mapDispatchToProps = {
   onSubmit: updateEvent,
+  onArchive: archiveEvent,
   onCancel: goBack,
 };
 

--- a/frontend/src/metabase/timelines/containers/EditTimelineModal/EditTimelineModal.tsx
+++ b/frontend/src/metabase/timelines/containers/EditTimelineModal/EditTimelineModal.tsx
@@ -6,7 +6,7 @@ import Collections from "metabase/entities/collections";
 import Timelines from "metabase/entities/timelines";
 import { State } from "metabase-types/store";
 import EditTimelineModal from "../../components/EditTimelineModal";
-import { updateTimeline } from "../../actions";
+import { archiveTimeline, updateTimeline } from "../../actions";
 import { ModalProps } from "../../types";
 
 const timelineProps = {
@@ -21,6 +21,7 @@ const collectionProps = {
 
 const mapDispatchToProps = {
   onSubmit: updateTimeline,
+  onArchive: archiveTimeline,
   onCancel: goBack,
 };
 

--- a/frontend/src/metabase/timelines/containers/TimelineModal/TimelineModal.tsx
+++ b/frontend/src/metabase/timelines/containers/TimelineModal/TimelineModal.tsx
@@ -1,3 +1,4 @@
+import { connect } from "react-redux";
 import _ from "underscore";
 import * as Urls from "metabase/lib/urls";
 import Collections from "metabase/entities/collections";
@@ -5,6 +6,7 @@ import Timelines from "metabase/entities/timelines";
 import { State } from "metabase-types/store";
 import TimelineModal from "../../components/TimelineModal";
 import { ModalProps } from "../../types";
+import { archiveEvent } from "metabase/timelines/actions";
 
 const timelineProps = {
   id: (state: State, props: ModalProps) =>
@@ -17,7 +19,12 @@ const collectionProps = {
     Urls.extractCollectionId(props.params.slug),
 };
 
+const mapDispatchToProps = {
+  onArchive: archiveEvent,
+};
+
 export default _.compose(
   Timelines.load(timelineProps),
   Collections.load(collectionProps),
+  connect(null, mapDispatchToProps),
 )(TimelineModal);


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/20289

How to test:
- Switch to `events-migration` branch, then run `yarn dev`
- When Metabase is ready, switch to this branch without restarting the backend
- Go to a collection and click on `Events` icon
- Add a timeline and a few events
- Click on the ellipses icon on an event and then `Archive`
- Make sure the event is removed from the list

Known issues:
- Clicking `Undo` closes the modal, to be fixed separately

<img width="824" alt="Screenshot 2022-02-14 at 21 00 06" src="https://user-images.githubusercontent.com/8542534/153920408-fb21e097-68d4-4779-b1ca-391067bbe9f4.png">
<img width="665" alt="Screenshot 2022-02-14 at 21 00 15" src="https://user-images.githubusercontent.com/8542534/153920419-c627d92a-adc5-4c28-b542-2cafc22f51e9.png">
<img width="676" alt="Screenshot 2022-02-14 at 21 00 23" src="https://user-images.githubusercontent.com/8542534/153920423-8cac6fee-b85c-4667-b246-d4cc8776e17f.png">
