### PR TITLE
Repro #20436:Restricting and unrestricting access to a table results in the DB-level permission still being "Granular"

### DIFF
--- a/frontend/test/metabase/scenarios/permissions/reproductions/20436-incorrect-display-of-database-permissions-level.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/reproductions/20436-incorrect-display-of-database-permissions-level.cy.spec.js
@@ -1,0 +1,60 @@
+import { restore, popover } from "__support__/e2e/cypress";
+import { USER_GROUPS } from "__support__/e2e/cypress_data";
+
+const { ALL_USERS_GROUP } = USER_GROUPS;
+
+const url = `/admin/permissions/data/group/${ALL_USERS_GROUP}`;
+
+describe.skip("issue 20436", () => {
+  beforeEach(() => {
+    cy.intercept("PUT", "/api/permissions/graph").as("updatePermissions");
+
+    restore();
+    cy.signInAsAdmin();
+
+    cy.updatePermissionsGraph({
+      [ALL_USERS_GROUP]: {
+        1: { schemas: "all", native: "none" },
+      },
+    });
+  });
+
+  it("should display correct permissions on the database level after changes on the table level (metabase#20436)", () => {
+    cy.visit(url);
+    cy.findByText("Unrestricted");
+
+    // Go the the view where we can change permissions for individual tables
+    cy.findByText("Sample Database").click();
+
+    // Change the permission levels for ANY of the tables - it doesn't matter which one
+    changePermissions("Unrestricted", "No self-service");
+
+    cy.button("Change").click();
+    saveChanges();
+    cy.wait("@updatePermissions");
+
+    // Now turn it back to the "Unrestricted" access
+    changePermissions("No self-service", "Unrestricted");
+
+    saveChanges();
+    cy.wait("@updatePermissions");
+
+    cy.visit(url);
+    cy.findByText("Unrestricted");
+  });
+});
+
+function changePermissions(from, to) {
+  cy.findAllByText(from)
+    .first()
+    .click();
+
+  popover()
+    .contains(to)
+    .click();
+}
+
+function saveChanges() {
+  cy.button("Save changes").click();
+  cy.button("Yes").click();
+}


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #20436 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/permissions/reproductions/20436-incorrect-display-of-database-permissions-level.cy.spec.js`
- Unskip the repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/153940105-f3b45af3-65da-4905-9021-36b874ff3f69.png)
