### PR TITLE
fix double scroll bar in the data picker

### DIFF
--- a/frontend/src/metabase/core/components/AccordionList/AccordionList.styled.tsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionList.styled.tsx
@@ -2,4 +2,5 @@ import styled from "@emotion/styled";
 
 export const AccordionListRoot = styled.div`
   outline: none;
+  overflow: auto;
 `;


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/20443

It was caused by adding keyboard navigation to the AccordionList because of a new wrapper around the list.

### How to verify
- Add multiple databases and schemas
- New -> Question
- Check the data picker has no double scrolls

Before:
<img width="358" alt="Screenshot 2022-02-14 at 20 31 56" src="https://user-images.githubusercontent.com/14301985/153947146-b98848cc-a9d1-4ee8-b929-b462f01a905f.png">

After:
<img width="350" alt="Screenshot 2022-02-14 at 21 10 40" src="https://user-images.githubusercontent.com/14301985/153947158-d55c47d4-9d0c-4ddb-a122-cdf5dba1be7e.png">

