### PR TITLE
Fix bad merge stomping on the improved version of test from #20434

### DIFF
--- a/test/metabase/query_processor_test/explicit_joins_test.clj
+++ b/test/metabase/query_processor_test/explicit_joins_test.clj
@@ -691,42 +691,45 @@
                      (qp/process-query query))))))))))
 
 (deftest join-against-multiple-saved-questions-with-same-column-test
-  (testing "Should be able to join multiple against saved questions on the same column (#15863)"
-    (mt/dataset sample-dataset
-      (let [q1         (mt/mbql-query products {:breakout [$category], :aggregation [[:count]]})
-            q2         (mt/mbql-query products {:breakout [$category], :aggregation [[:sum $price]]})
-            q3         (mt/mbql-query products {:breakout [$category], :aggregation [[:avg $rating]]})
-            metadata   (fn [query]
-                         {:post [(some? %)]}
-                         (-> query qp/process-query :data :results_metadata :columns))
-            query-card (fn [query]
-                         {:dataset_query query, :result_metadata (metadata query)})]
-        (mt/with-temp* [Card [{card-1-id :id} (query-card q1)]
-                        Card [{card-2-id :id} (query-card q2)]
-                        Card [{card-3-id :id} (query-card q3)]]
-          (let [query (mt/mbql-query products
-                        {:source-table (format "card__%d" card-1-id)
-                         :joins        [{:fields       :all
-                                         :source-table (format "card__%d" card-2-id)
-                                         :condition    [:=
-                                                        $category
-                                                        &Q2.category]
-                                         :alias        "Q2"}
-                                        {:fields       :all
-                                         :source-table (format "card__%d" card-3-id)
-                                         :condition    [:=
-                                                        $category
-                                                        &Q3.category]
-                                         :alias        "Q3"}]})]
-            (mt/with-native-query-testing-context query
-              (let [results (qp/process-query query)]
-                (is (= ["Category" "Count" "Q2 → Category" "Q2 → Sum" "Q3 → Category" "Q3 → Avg"]
-                       (map :display_name (get-in results [:data :results_metadata :columns]))))
-                (is (= [["Doohickey" 42 "Doohickey" 2185.89 "Doohickey" 3.73]
-                        ["Gadget"    53 "Gadget"    3019.2  "Gadget"    3.43]
-                        ["Gizmo"     51 "Gizmo"     2834.88 "Gizmo"     3.64]
-                        ["Widget"    54 "Widget"    3109.31 "Widget"    3.15]]
-                       (mt/formatted-rows [str int str 2.0 str 2.0] results)))))))))))
+  (testing "Should be able to join multiple against saved questions on the same column (#15863, #20362)"
+    (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries :left-join)
+      (mt/dataset sample-dataset
+        (let [q1         (mt/mbql-query products {:breakout [$category], :aggregation [[:count]]})
+              q2         (mt/mbql-query products {:breakout [$category], :aggregation [[:sum $price]]})
+              q3         (mt/mbql-query products {:breakout [$category], :aggregation [[:avg $rating]]})
+              metadata   (fn [query]
+                           {:post [(some? %)]}
+                           (-> query qp/process-query :data :results_metadata :columns))
+              query-card (fn [query]
+                           {:dataset_query query, :result_metadata (metadata query)})]
+          (mt/with-temp* [Card [{card-1-id :id} (query-card q1)]
+                          Card [{card-2-id :id} (query-card q2)]
+                          Card [{card-3-id :id} (query-card q3)]]
+            (let [query (mt/mbql-query products
+                          {:source-table (format "card__%d" card-1-id)
+                           :joins        [{:fields       :all
+                                           :source-table (format "card__%d" card-2-id)
+                                           :condition    [:=
+                                                          $category
+                                                          &Q2.category]
+                                           :alias        "Q2"}
+                                          {:fields       :all
+                                           :source-table (format "card__%d" card-3-id)
+                                           :condition    [:=
+                                                          $category
+                                                          &Q3.category]
+                                           :alias        "Q3"}]
+                           :order-by     [[:asc $category]]})]
+              (mt/with-native-query-testing-context query
+                (let [results (qp/process-query query)]
+                  (when (#{:postgres :h2} driver/*driver*)
+                    (is (= ["Category" "Count" "Q2 → Category" "Q2 → Sum" "Q3 → Category" "Q3 → Avg"]
+                           (map :display_name (get-in results [:data :results_metadata :columns])))))
+                  (is (= [["Doohickey" 42 "Doohickey" 2185.89 "Doohickey" 3.73]
+                          ["Gadget"    53 "Gadget"    3019.2  "Gadget"    3.43]
+                          ["Gizmo"     51 "Gizmo"     2834.88 "Gizmo"     3.64]
+                          ["Widget"    54 "Widget"    3109.31 "Widget"    3.15]]
+                         (mt/formatted-rows [str int str 2.0 str 2.0] results))))))))))))
 
 (deftest use-correct-source-alias-for-fields-from-joins-test
   (testing "Make sure we use the correct escaped alias for a Fields coming from joins (#20413)"


### PR DESCRIPTION
I just realized when I was fixing merge conflicts in #19659 I accidentally stomped on the improved version of `metabase.query-processor-test.explicit-joins-test/join-against-multiple-saved-questions-with-same-column-test` from #20434. This PR restores the improved version