### PR TITLE
Make date widget respect date/time format settings

### DIFF
--- a/frontend/src/metabase/lib/time.js
+++ b/frontend/src/metabase/lib/time.js
@@ -1,6 +1,8 @@
 import moment from "moment-timezone";
 import { t } from "ttag";
 
+import MetabaseSettings from "metabase/lib/settings";
+
 addAbbreviatedLocale();
 
 // when you define a custom locale, moment automatically makes it the active global locale,
@@ -32,6 +34,8 @@ function addAbbreviatedLocale() {
 
   moment.locale(initialLocale);
 }
+
+const TIME_FORMAT_24_HOUR = "HH:mm";
 
 const TEXT_UNIT_FORMATS = {
   "day-of-week": value => moment.parseZone(value, "ddd").startOf("day"),
@@ -191,4 +195,21 @@ export function msToHours(ms) {
 
 export function hoursToSeconds(hours) {
   return hours * 60 * 60;
+}
+
+export function getDateStyleFromSettings() {
+  const customFormattingSettings = MetabaseSettings.get("custom-formatting");
+  const temporalSettings = customFormattingSettings["type/Temporal"];
+  return temporalSettings.date_style;
+}
+
+export function getTimeStyleFromSettings() {
+  const customFormattingSettings = MetabaseSettings.get("custom-formatting");
+  const temporalSettings = customFormattingSettings["type/Temporal"];
+  return temporalSettings.time_style;
+}
+
+export function has24HourModeSetting() {
+  const timeStyle = getTimeStyleFromSettings();
+  return timeStyle === TIME_FORMAT_24_HOUR;
 }

--- a/frontend/src/metabase/lib/time.js
+++ b/frontend/src/metabase/lib/time.js
@@ -199,14 +199,12 @@ export function hoursToSeconds(hours) {
 
 export function getDateStyleFromSettings() {
   const customFormattingSettings = MetabaseSettings.get("custom-formatting");
-  const temporalSettings = customFormattingSettings["type/Temporal"];
-  return temporalSettings.date_style;
+  return customFormattingSettings?.["type/Temporal"]?.date_style;
 }
 
 export function getTimeStyleFromSettings() {
   const customFormattingSettings = MetabaseSettings.get("custom-formatting");
-  const temporalSettings = customFormattingSettings["type/Temporal"];
-  return temporalSettings.time_style;
+  return customFormattingSettings?.["type/Temporal"]?.time_style;
 }
 
 export function has24HourModeSetting() {

--- a/frontend/src/metabase/query_builder/components/filters/pickers/HoursMinutesInput.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/HoursMinutesInput.jsx
@@ -1,9 +1,9 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 
+import { has24HourModeSetting } from "metabase/lib/time";
 import NumericInput from "metabase/components/NumericInput";
 import Icon from "metabase/components/Icon";
-import { isLocale24Hour } from "metabase/lib/i18n";
 
 import cx from "classnames";
 import moment from "moment";
@@ -14,7 +14,7 @@ const HoursMinutesInput = ({
   onChangeHours,
   onChangeMinutes,
   onClear,
-  is24HourMode = isLocale24Hour(),
+  is24HourMode = has24HourModeSetting(),
 }) => (
   <div className="flex align-center">
     <NumericInput

--- a/frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx
@@ -67,7 +67,7 @@ export default class SpecificDatePicker extends Component {
       date = moment(value, DATE_FORMAT, true);
     }
 
-    const dateFormat = getDateStyleFromSettings();
+    const dateFormat = getDateStyleFromSettings() || "MM/DD/YYYY";
 
     return (
       <div className={className}>

--- a/frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx
@@ -3,6 +3,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { t } from "ttag";
 
+import { getDateStyleFromSettings } from "metabase/lib/time";
 import Calendar from "metabase/components/Calendar";
 import InputBlurChange from "metabase/components/InputBlurChange";
 import Icon from "metabase/components/Icon";
@@ -66,18 +67,20 @@ export default class SpecificDatePicker extends Component {
       date = moment(value, DATE_FORMAT, true);
     }
 
+    const dateFormat = getDateStyleFromSettings();
+
     return (
       <div className={className}>
         <div className="mb2 full bordered rounded flex align-center">
           <InputBlurChange
-            placeholder={moment().format("MM/DD/YYYY")}
+            placeholder={moment().format(dateFormat)}
             className="borderless full p1 h3"
             style={{
               outline: "none",
             }}
-            value={date ? date.format("MM/DD/YYYY") : ""}
+            value={date ? date.format(dateFormat) : ""}
             onBlurChange={({ target: { value } }) => {
-              const date = moment(value, "MM/DD/YYYY");
+              const date = moment(value, dateFormat);
               if (date.isValid()) {
                 this.onChange(date, hours, minutes);
               } else {

--- a/frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx
@@ -16,6 +16,9 @@ import cx from "classnames";
 const DATE_FORMAT = "YYYY-MM-DD";
 const DATE_TIME_FORMAT = "YYYY-MM-DDTHH:mm:ss";
 
+const TIME_SELECTOR_DEFAULT_HOUR = 12;
+const TIME_SELECTOR_DEFAULT_MINUTE = 30;
+
 export default class SpecificDatePicker extends Component {
   constructor(props) {
     super(props);
@@ -117,7 +120,13 @@ export default class SpecificDatePicker extends Component {
             {hours == null || minutes == null ? (
               <div
                 className="text-purple-hover cursor-pointer flex align-center"
-                onClick={() => this.onChange(date, 12, 30)}
+                onClick={() =>
+                  this.onChange(
+                    date,
+                    TIME_SELECTOR_DEFAULT_HOUR,
+                    TIME_SELECTOR_DEFAULT_MINUTE,
+                  )
+                }
               >
                 <Icon className="mr1" name="clock" />
                 {t`Add a time`}

--- a/frontend/test/metabase/scenarios/admin/settings/localization.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/localization.cy.spec.js
@@ -152,6 +152,55 @@ describe("scenarios > admin > localization", () => {
 
     cy.findByText("€10.00");
   });
+
+  it("should use date and time styling settings in the date filter widget (metabase#9151, metabase#12472)", () => {
+    cy.visit("/admin/settings/localization");
+
+    // update the date style setting to YYYY/MM/DD
+    cy.findByText("January 7, 2018").click();
+    cy.findByText("2018/1/7").click();
+
+    // update the time style setting to 24 hour
+    cy.findByText("17:24 (24-hour clock)").click();
+
+    cy.visit("/question/1");
+    cy.findByTestId("loading-spinner").should("not.exist");
+
+    // create a date filter and set it to the 'On' view to see a specific date
+    cy.findByText("Created At").click();
+    cy.findByText("Filter by this column").click();
+    cy.findByText("Previous").click();
+    cy.findByText("On").click();
+
+    // update the date input in the widget
+    const date = new Date();
+    const dateString = `${date.getFullYear()}/${date.getMonth() +
+      1}/${date.getDate()}`;
+    cy.findByDisplayValue(dateString)
+      .clear()
+      .type("2018/5/15")
+      .blur();
+
+    // add a time to the date
+    const TIME_SELECTOR_DEFAULT_HOUR = 12;
+    const TIME_SELECTOR_DEFAULT_MINUTE = 30;
+    cy.findByText("Add a time").click();
+    cy.findByDisplayValue(`${TIME_SELECTOR_DEFAULT_HOUR}`)
+      .clear()
+      .type("19");
+    cy.findByDisplayValue(`${TIME_SELECTOR_DEFAULT_MINUTE}`)
+      .clear()
+      .type("56");
+
+    // apply the date filter
+    cy.findByText("Update filter").click();
+
+    cy.findByTestId("loading-spinner").should("not.exist");
+
+    // verify that the correct row is displayed
+    cy.findByText("2018/5/15, 19:56");
+    cy.findByText("127.52");
+  });
 });
 
 function setFirstWeekDayTo(day) {


### PR DESCRIPTION
Fixes #9151
Fixes #12472

Reproduces #9151
Reproduces #12472

The `HoursMinutesInput` component already supports 24 hour time but we were only setting it to that when the user was in the right locale--seems like the correct approach here is to always rely on whatever is set in the localization settings panel.

For the `SpecificDatePicker` component we need to format the date when setting the value and when updating the stored value in the `onBlurChange` callback. We'll still store the date in the URL as `YYYY-MM-DD` but we will convert between the two.

As you can see in the image, there are other places where we don't respect settings, like the little filter blurb in the header. 

Worth noting that this means if the instance is set to show dates like "Monday, February 14, 2022" then the widget will show the entirety of said date like that, a bit of overkill, but IDK if it is a deal breaker. Trying to alter the defined format string is a possibility, but that sort of logic is certain to break if we end up adding more formatting possibilities later. This also means I don't really know what we want to do about the ability to change "Date separators" -- right now, I'm not using that setting, but outside of not knowing how to use it for the date styles like the one above, I could use it, I guess?

<img width="343" alt="Screen Shot 2022-02-14 at 3 43 42 PM" src="https://user-images.githubusercontent.com/13057258/153960636-1e2b23fd-393f-4275-914d-a9723cb0842a.png">

**Testing**
- as an admin, go to `/admin/settings/localization` and fiddle with the "date style" and "time style" inputs
- create a question from the Orders table and create a filter on the Created At column and set the widget to be an "On" filter. The date input in the widget should respect the "date style" format and if you add a time to the filter it should respect the "time style" format.