### PR TITLE
Make time-series filter work with expression dimension

### DIFF
--- a/frontend/test/metabase/modes/TimeseriesFilterWidget.unit.spec.js
+++ b/frontend/test/metabase/modes/TimeseriesFilterWidget.unit.spec.js
@@ -12,7 +12,7 @@ import {
 const getTimeseriesFilterWidget = question => (
   <TimeseriesFilterWidget
     card={question.card()}
-    datasetQuery={question.query().datasetQuery()}
+    query={question.query()}
     setDatasetQuery={() => {}}
   />
 );


### PR DESCRIPTION
The widget to filter time-series dimension should not assume that the dimension is from a field, as it can be also an expression, i.e. when the breakout is originated from a custom column. Hence, generalize the case to avoid any crashing.

How to verify:
1. New, Question
2. Sample Database, Orders table
3. Summarize, Count, Created At: Year
4. Custom column, `[Created At]` and name it as _Custom Created At_
5. Summarize, Count, _Custom Created At_
6. Visualize

![image](https://user-images.githubusercontent.com/7288/153965439-48574ddb-d01c-453c-bcdf-d324d4595825.png)

**Before this PR**

No result, because the front-end crashes and throws an exception.

**After this PR**

You can view the result.

# Note

There are still other broken behavior, only slightly related to the crash.

First, the result (when viewed as table) is wrong:

![image](https://user-images.githubusercontent.com/7288/153965753-635028da-f716-41c9-850a-64c211f9e073.png)

Second, the dropdown next to "All Time" does not show the time unit. This is very likely the same cause as #11371.

Compared to the result of summarizing with the real `Created At` field (and not the custom column): the values of Count and the time unit _Year_ for the dropdown.

![image](https://user-images.githubusercontent.com/7288/153965920-3591c692-a512-4058-be40-d5ba442c1933.png)


