### PR TITLE
Embed query endpoints should handle operator filters with a single arg

### DIFF
--- a/src/metabase/api/embed.clj
+++ b/src/metabase/api/embed.clj
@@ -162,10 +162,11 @@
   (when (seq parameters)
     (for [param parameters
           :let  [value (get slug->value (keyword (:slug param)))
+                 ;; operator parameters expect a sequence of values so if we get a lone value (e.g. from a single URL
+                 ;; query parameter) wrap it in a sequence
                  value (if (and (seq value)
-                              (params.operators/operator? (:type param))
-                              (not (sequential? value)))
-                         [value]
+                                (params.operators/operator? (:type param)))
+                         (u/one-or-many value)
                          value)]
           :when (some? value)]
       (assoc (select-keys param [:type :target :slug])

--- a/src/metabase/query_processor/dashboard.clj
+++ b/src/metabase/query_processor/dashboard.clj
@@ -3,6 +3,7 @@
   (:require [clojure.tools.logging :as log]
             [medley.core :as m]
             [metabase.api.common :as api]
+            [metabase.driver.common.parameters.operators :as params.operators]
             [metabase.mbql.normalize :as normalize]
             [metabase.models.dashboard :as dashboard :refer [Dashboard]]
             [metabase.models.dashboard-card :refer [DashboardCard]]
@@ -64,6 +65,12 @@
       (merge
        {:type (:type matching-param)}
        request-param
+       ;; if value comes in as a lone value for an operator filter type (as will be the case for embedding) wrap it in a
+       ;; vector so the parameter handling code doesn't explode.
+       (when (and (params.operators/operator? (:type matching-param))
+                  (seq (:value request-param))
+                  (not (sequential? (:value request-param))))
+         {:value [(:value request-param)]})
        {:id     param-id
         :target (:target matching-mapping)}))))
 

--- a/test/metabase/api/embed_test.clj
+++ b/test/metabase/api/embed_test.clj
@@ -9,7 +9,7 @@
             [crypto.random :as crypto-random]
             [dk.ative.docjure.spreadsheet :as spreadsheet]
             [metabase.api.dashboard-test :as dashboard-api-test]
-            [metabase.api.embed :as embed-api]
+            [metabase.api.embed :as api.embed]
             [metabase.api.pivots :as pivots]
             [metabase.api.public-test :as public-test]
             [metabase.http-client :as http]
@@ -201,8 +201,10 @@
 
 ;;; ------------------------- GET /api/embed/card/:token/query (and JSON/CSV/XLSX variants) --------------------------
 
-(defn card-query-url [card response-format & [additional-token-params]]
+(defn card-query-url
   "Generate a query URL for an embedded card"
+  [card response-format & [additional-token-params]]
+  {:pre [(#{"" "/json" "/csv" "/xlsx"} response-format)]}
   (str "embed/card/"
        (card-token card additional-token-params)
        "/query"
@@ -537,7 +539,7 @@
   (testing (str "parameters that are not in the `embedding-params` map at all should get removed by "
                 "`remove-locked-and-disabled-params`")
     (is (= {:parameters []}
-           (#'embed-api/remove-locked-and-disabled-params {:parameters {:slug "foo"}} {})))))
+           (#'api.embed/remove-locked-and-disabled-params {:parameters {:slug "foo"}} {})))))
 
 
 (deftest make-sure-that-multiline-series-word-as-expected---4768-
@@ -1083,3 +1085,56 @@
             (is (= "completed" (:status result)))
             (is (= 6 (count (get-in result [:data :cols]))))
             (is (= 1144 (count rows)))))))))
+
+(deftest apply-slug->value-test
+  (testing "For operator filter types treat a lone value as a one-value sequence (#20438)"
+    (is (= (#'api.embed/apply-slug->value [{:type    :string/=
+                                            :target  [:dimension [:template-tag "NAME"]]
+                                            :name    "Name"
+                                            :slug    "NAME"
+                                            :default nil}]
+                                          {:NAME ["Aaron Hand"]})
+           (#'api.embed/apply-slug->value [{:type    :string/=
+                                            :target  [:dimension [:template-tag "NAME"]]
+                                            :name    "Name"
+                                            :slug    "NAME"
+                                            :default nil}]
+                                          {:NAME "Aaron Hand"})))))
+
+(deftest handle-single-params-for-operator-filters-test
+  (testing "Query endpoints should work with a single URL parameter for an operator filter (#20438)"
+    (mt/dataset sample-dataset
+      (with-embedding-enabled-and-new-secret-key
+        (mt/with-temp Card [{card-id :id, :as card} {:dataset_query    (mt/native-query
+                                                                         {:query         "SELECT count(*) AS count FROM PUBLIC.PEOPLE WHERE true [[AND {{NAME}}]]"
+                                                                          :template-tags {"NAME"
+                                                                                          {:id           "9ddca4ca-3906-83fd-bc6b-8480ae9ab05e"
+                                                                                           :name         "NAME"
+                                                                                           :display-name "Name"
+                                                                                           :type         :dimension
+                                                                                           :dimension    [:field (mt/id :people :name) nil]
+                                                                                           :widget-type  :string/=
+                                                                                           :default      nil}}})
+                                                     :enable_embedding true
+                                                     :embedding_params {:NAME "enabled"}}]
+          (testing "Card"
+            (is (= [[1]]
+                   (mt/rows (http/client :get 202 (str (card-query-url card "") "?NAME=Hudson%20Borer")))
+                   (mt/rows (http/client :get 202 (str (card-query-url card "") "?NAME=Hudson%20Borer&NAME=x"))))))
+          (testing "Dashcard"
+            (mt/with-temp* [Dashboard [{dashboard-id :id, :as dashboard} {:enable_embedding true
+                                                                          :embedding_params {:name "enabled"}
+                                                                          :parameters       [{:name      "Name"
+                                                                                              :slug      "name"
+                                                                                              :id        "_name_"
+                                                                                              :type      :string/=
+                                                                                              :sectionId "string"}]}]
+
+                            DashboardCard [{dashcard-id :id, :as dashcard} {:card_id            card-id
+                                                                            :dashboard_id       dashboard-id
+                                                                            :parameter_mappings [{:parameter_id "_name_"
+                                                                                                  :card_id      card-id
+                                                                                                  :target       [:dimension [:template-tag "NAME"]]}]}]]
+              (is (= [[1]]
+                     (mt/rows (http/client :get 202 (str (dashcard-url dashcard) "?name=Hudson%20Borer")))
+                     (mt/rows (http/client :get 202 (str (dashcard-url dashcard) "?name=Hudson%20Borer&name=x"))))))))))))


### PR DESCRIPTION
Operator parameter types like `:string/=` expect a sequence of values. Embed query endpoints specify parameter values as URL query params, meaning something like `GET ...?name=Cam` gets translated to `{:value "Cam"}` rather than the `{:value ["Cam"]}` the operator parameter type handlers expect. Fixed by tweaking code to fix up non-sequential operator parameter values when we encounter them.

Fixes #20438