### PR TITLE
Force clojure -X:h2 to use H2

### DIFF
--- a/dev/src/dev/h2_shell.clj
+++ b/dev/src/dev/h2_shell.clj
@@ -1,5 +1,6 @@
 (ns dev.h2-shell
-  (:require [metabase.db.data-source :as mdb.data-source]
+  (:require [environ.core :as env]
+            [metabase.db.data-source :as mdb.data-source]
             [metabase.db.env :as mdb.env]))
 
 (comment mdb.data-source/keep-me)
@@ -7,6 +8,9 @@
 (defn shell
   "Open an H2 shell with `clojure -X:h2`."
   [& _args]
+  ;; Force the DB to use h2 regardless of what's actually in the env vars for Java properties
+  (alter-var-root #'env/env assoc :mb-db-type "h2")
+  (require 'metabase.db.env :reload)
   (org.h2.tools.Shell/main
    (into-array
     String


### PR DESCRIPTION
Follow-on to #20409

Force `clojure -X:h2` to use H2 regardless of env vars.

I meant to do this in #20409 but accidentally merged it first. Here's the extra stuff