### PR TITLE
Repro #20519: Summarizing with implicit join does not allow subsequent joins and nested query

### DIFF
--- a/frontend/test/metabase/scenarios/joins/reproductions/20519-cannot-join-on-aggregation-with-implicit-joins-and-nested-query.cy.spec.js
+++ b/frontend/test/metabase/scenarios/joins/reproductions/20519-cannot-join-on-aggregation-with-implicit-joins-and-nested-query.cy.spec.js
@@ -5,7 +5,7 @@ import {
 } from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
-const { ORDERS, ORDERS_ID, PRODUCTS } = SAMPLE_DATABASE;
+const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
 
 const questionDetails = {
   name: "20519",

--- a/frontend/test/metabase/scenarios/joins/reproductions/20519-cannot-join-on-aggregation-with-implicit-joins-and-nested-query.cy.spec.js
+++ b/frontend/test/metabase/scenarios/joins/reproductions/20519-cannot-join-on-aggregation-with-implicit-joins-and-nested-query.cy.spec.js
@@ -1,0 +1,72 @@
+import {
+  restore,
+  enterCustomColumnDetails,
+  visualize,
+} from "__support__/e2e/cypress";
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
+const { ORDERS, ORDERS_ID, PRODUCTS } = SAMPLE_DATABASE;
+
+const questionDetails = {
+  name: "20519",
+  query: {
+    "source-query": {
+      "source-table": ORDERS_ID,
+      aggregation: [["count"]],
+      breakout: [
+        ["field", PRODUCTS.CATEGORY, { "source-field": ORDERS.PRODUCT_ID }],
+      ],
+    },
+    joins: [
+      {
+        fields: "all",
+        "source-table": 1,
+        condition: [
+          "=",
+          ["field", "CATEGORY", { "base-type": "type/Text" }],
+          ["field", PRODUCTS.CATEGORY, { "join-alias": "Products" }],
+        ],
+        alias: "Products",
+      },
+    ],
+    limit: 2,
+  },
+};
+
+describe.skip("issue 20519", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.createQuestion(questionDetails, { visitQuestion: true });
+    switchToNotebookView();
+  });
+
+  // Tightly related issue: metabase#17767
+  it("should allow subsequent joins and nested query after summarizing on the implicit joins (metabase#20519)", () => {
+    cy.icon("add_data")
+      .last()
+      .click();
+
+    enterCustomColumnDetails({
+      formula: "1 + 1",
+      name: "Two",
+    });
+
+    cy.button("Done").click();
+
+    visualize(response => {
+      expect(response.body.error).not.to.exist;
+    });
+
+    cy.contains("Doohickey");
+    cy.contains("Two");
+  });
+});
+
+function switchToNotebookView() {
+  cy.intercept("GET", "/api/database/1/schema/PUBLIC").as("publicSchema");
+
+  cy.icon("notebook").click();
+  cy.wait("@publicSchema");
+}

--- a/frontend/test/metabase/scenarios/joins/reproductions/20519-cannot-join-on-aggregation-with-implicit-joins-and-nested-query.cy.spec.js
+++ b/frontend/test/metabase/scenarios/joins/reproductions/20519-cannot-join-on-aggregation-with-implicit-joins-and-nested-query.cy.spec.js
@@ -20,7 +20,7 @@ const questionDetails = {
     joins: [
       {
         fields: "all",
-        "source-table": 1,
+        "source-table": PRODUCTS_ID,
         condition: [
           "=",
           ["field", "CATEGORY", { "base-type": "type/Text" }],


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #20519 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/joins/reproductions/20519-cannot-join-on-aggregation-with-implicit-joins-and-nested-query.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/154069907-9498dac9-5a83-4396-9642-573ab1fd80ad.png)

