### PR TITLE
Ensure token_features and created_at are included in backend Snowplow events

### DIFF
--- a/src/metabase/analytics/snowplow.clj
+++ b/src/metabase/analytics/snowplow.clj
@@ -100,7 +100,8 @@
        (str "iglu:com.metabase/instance/jsonschema/" (schema->version ::instance))
        {"id"             (analytics-uuid),
         "version"        {"tag" (:tag (public-settings/version))},
-        "token-features" (m/map-keys name (public-settings/token-features))}))
+        "token_features" (m/map-keys name (public-settings/token-features))
+        "created_at"     (instance-creation)}))
 
 (defn- normalize-kw
   [kw]

--- a/src/metabase/analytics/snowplow.clj
+++ b/src/metabase/analytics/snowplow.clj
@@ -58,6 +58,9 @@
   []
   (:min (db/select-one [User [:%min.date_joined :min]])))
 
+;; We need to declare `track-event!` up front so that we can use it in the custom getter of `instance-creation`.
+;; We can't move `instance-creation` below `track-event!` because it has to be defined before `context`, which is called
+;; by `track-event!`.
 (declare track-event!)
 
 (defsetting instance-creation

--- a/src/metabase/analytics/snowplow.clj
+++ b/src/metabase/analytics/snowplow.clj
@@ -8,6 +8,7 @@
             [metabase.models.user :refer [User]]
             [metabase.public-settings :as public-settings]
             [metabase.util :as u]
+            [metabase.util.date-2 :as u.date]
             [metabase.util.i18n :as i18n :refer [deferred-tru trs]]
             [toucan.db :as db])
   (:import [com.snowplowanalytics.snowplow.tracker Subject$SubjectBuilder Tracker Tracker$TrackerBuilder]
@@ -123,7 +124,7 @@
        {"id"             (analytics-uuid),
         "version"        {"tag" (:tag (public-settings/version))},
         "token_features" (m/map-keys name (public-settings/token-features))
-        "created_at"     (instance-creation)}))
+        "created_at"     (u.date/format (instance-creation))}))
 
 (defn- normalize-kw
   [kw]

--- a/test/metabase/analytics/snowplow_test.clj
+++ b/test/metabase/analytics/snowplow_test.clj
@@ -70,13 +70,15 @@
          events)))
 
 (deftest custom-content-test
-  (testing "Snowplow events include a custom context that includes the schema, instance ID, version and token features"
+  (testing "Snowplow events include a custom context that includes the schema, instance ID, version, token features
+           and creation timestamp"
     (with-fake-snowplow-collector
       (snowplow/track-event! ::snowplow/new-instance-created)
       (is (= {:schema "iglu:com.metabase/instance/jsonschema/1-1-0",
               :data {:id             (snowplow/analytics-uuid)
                      :version        {:tag (:tag (public-settings/version))},
-                     :token-features (public-settings/token-features)}}
+                     :token_features (public-settings/token-features)
+                     :created_at     (snowplow/instance-creation)}}
              (:context (first @*snowplow-collector*)))))))
 
 (deftest ip-address-override-test

--- a/test/metabase/analytics/snowplow_test.clj
+++ b/test/metabase/analytics/snowplow_test.clj
@@ -8,6 +8,7 @@
             [metabase.test :as mt]
             [metabase.test.fixtures :as fixtures]
             [metabase.util :as u]
+            [metabase.util.date-2 :as u.date]
             [toucan.db :as db])
   (:import java.util.LinkedHashMap))
 
@@ -78,7 +79,7 @@
               :data {:id             (snowplow/analytics-uuid)
                      :version        {:tag (:tag (public-settings/version))},
                      :token_features (public-settings/token-features)
-                     :created_at     (snowplow/instance-creation)}}
+                     :created_at     (u.date/format (snowplow/instance-creation))}}
              (:context (first @*snowplow-collector*)))))))
 
 (deftest ip-address-override-test


### PR DESCRIPTION
This PR fixes a couple of small issues in the data sent to Snowplow from the backend which weren't caught before the release.

* `token-features` is renamed to `token_features`, which is what is expected by the schema
* the instance creation timestamp is included as the `created_at` field (this was added late to the `instance` schema and the backend was never updated accordingly)

Also some mild refactor & test fixes