### PR TITLE
fix data picker another double scroll and add a visual test

### DIFF
--- a/frontend/src/metabase/core/components/AccordionList/AccordionList.jsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionList.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from "react";
+import ReactDOM from "react-dom";
 import PropTypes from "prop-types";
 import { List, CellMeasurer, CellMeasurerCache } from "react-virtualized";
 
@@ -45,8 +46,6 @@ export default class AccordionList extends Component {
       fixedWidth: true,
       minHeight: 10,
     });
-
-    this.containerRef = React.createRef();
   }
 
   static propTypes = {
@@ -127,11 +126,7 @@ export default class AccordionList extends Component {
   };
 
   componentDidMount() {
-    if (this.isVirtualized()) {
-      // HACK: When passing ref to containerProps it becomes unset inside Grid
-      // which causes errors when scrolling in some cases
-      this.containerRef.current = this._list.Grid._scrollingContainer;
-    }
+    this.container = ReactDOM.findDOMNode(this);
 
     // NOTE: for some reason the row heights aren't computed correctly when
     // first rendering, so force the list to update
@@ -140,11 +135,11 @@ export default class AccordionList extends Component {
     // Use list.scrollToRow instead of the scrollToIndex prop since the
     // causes the list's scrolling to be pinned to the selected row
     setTimeout(() => {
-      const hasFocusedChildren = this.containerRef?.current?.contains(
+      const hasFocusedChildren = this.container.contains(
         document.activeElement,
       );
       if (!hasFocusedChildren && this.props.hasInitialFocus) {
-        this.containerRef?.current?.focus();
+        this.container.focus();
       }
 
       const index = this._initialSelectedRowIndex;
@@ -547,7 +542,7 @@ export default class AccordionList extends Component {
   // Because of virtualization, focused search input can be removed which does not trigger blur event.
   // We need to restore focus on the component root container to make keyboard navigation working
   handleSearchRemoval = () => {
-    this.containerRef?.current?.focus();
+    this.container?.focus();
   };
 
   render() {
@@ -565,7 +560,6 @@ export default class AccordionList extends Component {
       return (
         <AccordionListRoot
           role="tree"
-          ref={this.containerRef}
           onKeyDown={this.handleKeyDown}
           tabIndex={-1}
           className={className}

--- a/frontend/test/metabase-visual/notebook/notebook.cy.spec.js
+++ b/frontend/test/metabase-visual/notebook/notebook.cy.spec.js
@@ -1,4 +1,5 @@
-import { restore, popover } from "__support__/e2e/cypress";
+import _ from "underscore";
+import { restore, popover, openNotebookEditor } from "__support__/e2e/cypress";
 
 describe("visual tests > notebook > major UI elements", () => {
   const VIEWPORT_WIDTH = 2500;
@@ -100,6 +101,28 @@ describe("visual tests > notebook > Run buttons", () => {
         widths: [VIEWPORT_WIDTH],
       },
     );
+  });
+});
+
+describe("visual tests > notebook", () => {
+  const VIEWPORT_WIDTH = 1200;
+  const VIEWPORT_HEIGHT = 600;
+
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+    cy.viewport(VIEWPORT_WIDTH, VIEWPORT_HEIGHT);
+
+    _.range(10).forEach(index => {
+      const name = `Sample Database ${index + 1}`;
+      cy.addH2SampleDatabase({ name });
+    });
+  });
+
+  it("data picker", () => {
+    openNotebookEditor();
+    cy.findByText("Sample Database");
+    cy.percySnapshot();
   });
 });
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/20443

Removes a wrapper around virtualized `AccordionList` to prevent double scrolls. Getting a container DOM element is a bit tricky since `react-virtualized` does not expose a clean API to do so. You can get it by `ref` to `containerProps` but it breaks `Grid` internals since the internal `scrollingContainer` becomes uninitialized.

### How to verify
- Add multiple DBs and schemas
- Ensure the data picker does not have any scrolls on question/data model/segments/metrics pages