### PR TITLE
Custom expression editor: do not always suggest an open parenthesis

### DIFF
--- a/frontend/src/metabase/lib/expressions/suggest.js
+++ b/frontend/src/metabase/lib/expressions/suggest.js
@@ -19,6 +19,12 @@ import {
   EDITOR_FK_SYMBOLS,
 } from "./config";
 
+const suggestionText = func => {
+  const { displayName, args } = func;
+  const suffix = args.length > 0 ? "(" : " ";
+  return displayName + suffix;
+};
+
 export function suggest({
   source,
   query,
@@ -59,7 +65,7 @@ export function suggest({
         .map(func => ({
           type: "functions",
           name: func.displayName,
-          text: func.displayName + "(",
+          text: suggestionText(func),
           index: targetOffset,
           icon: "function",
           order: 1,
@@ -73,7 +79,7 @@ export function suggest({
           .map(func => ({
             type: "aggregations",
             name: func.displayName,
-            text: func.displayName + "(",
+            text: suggestionText(func),
             index: targetOffset,
             icon: "function",
             order: 1,

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx
@@ -138,7 +138,7 @@ export default class ExpressionEditorTextfield extends React.Component {
         const extraTrim = openParen && alreadyOpenParen ? 1 : 0;
         const replacement = suggested.slice(0, suggested.length - extraTrim);
 
-        const updatedExpression = prefix + replacement.trim() + postfix;
+        const updatedExpression = prefix + replacement + postfix;
         this.handleExpressionChange(updatedExpression);
         const caretPos = updatedExpression.length - postfix.length;
 

--- a/frontend/test/metabase/lib/expressions/suggest.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/suggest.unit.spec.js
@@ -207,9 +207,9 @@ describe("metabase/lib/expression/suggest", () => {
       it("should suggest partial matches after an aggregation", () => {
         expect(suggest({ source: "average(c", ...aggregationOpts })).toEqual([
           // FIXME: the next four should not appear
-          { type: "aggregations", text: "Count(" },
+          { type: "aggregations", text: "Count " },
           { type: "aggregations", text: "CountIf(" },
-          { type: "aggregations", text: "CumulativeCount(" },
+          { type: "aggregations", text: "CumulativeCount " },
           { type: "aggregations", text: "CumulativeSum(" },
           { type: "fields", text: "[C] " },
           { type: "fields", text: "[count] " },
@@ -223,9 +223,9 @@ describe("metabase/lib/expression/suggest", () => {
 
       it("should suggest partial matches in aggregation", () => {
         expect(suggest({ source: "1 + C", ...aggregationOpts })).toEqual([
-          { type: "aggregations", text: "Count(" },
+          { type: "aggregations", text: "Count " },
           { type: "aggregations", text: "CountIf(" },
-          { type: "aggregations", text: "CumulativeCount(" },
+          { type: "aggregations", text: "CumulativeCount " },
           { type: "aggregations", text: "CumulativeSum(" },
           { type: "fields", text: "[C] " },
           { type: "fields", text: "[count] " },
@@ -258,7 +258,7 @@ describe("metabase/lib/expression/suggest", () => {
             startRule: "aggregation",
           }),
         ).toEqual([
-          { type: "aggregations", text: "Count(" },
+          { type: "aggregations", text: "Count " },
           { type: "aggregations", text: "CountIf(" },
         ]);
       });


### PR DESCRIPTION
For functions which do not accept any arguments, i.e. COUNT and CUMULATIVECOUNT, do not suggest the completion with the "(" character.

This is a follow-up to PR #20432.

How to verify:
1. New, Question
2. Sample Database, Products table
3. Summarize, Custom Expression
4. Type `c`, wait for the suggestions, and press Enter to choose 'Count' (the first one)

*Note*: this also applies to `CumulativeCount`.

**Before this PR**

The completed expression is `Count(`. Note the open parenthesis, which leads to an impression that #11558 is already supported.

![image](https://user-images.githubusercontent.com/7288/154135673-cbdae879-e575-456f-a022-8eb966a3a393.png)

**After this PR**

The completed expression is just `Count`, because this function does not accept any argument.

![image](https://user-images.githubusercontent.com/7288/154135892-f2f401aa-76c1-4825-bce0-613382546ad9.png)
