### PR TITLE
E2E tests on master: run for EE as well

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 25
     strategy:
       matrix:
-        edition: [oss]
+        edition: [oss, ee]
     env:
       MB_EDITION: ${{ matrix.edition }}
       INTERACTIVE: false
@@ -61,7 +61,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        edition: [oss]
+        edition: [oss, ee]
         folder:
           - "custom-column"
           - "dashboard"


### PR DESCRIPTION
This is to continue what was started in PR #20266.

**Before**

![image](https://user-images.githubusercontent.com/7288/154169935-590e4f85-5662-479b-bbfc-65c1a67e7306.png)

**After**

Double the E2E jobs, due to the EE build.

![image](https://user-images.githubusercontent.com/7288/154169878-ee4c3e09-00b8-4507-8c1f-46c2ed78f9a9.png)
