### PR TITLE
Describe the JSON within tables for postgres

### DIFF
--- a/docs/developers-guide/driver-changelog.md
+++ b/docs/developers-guide/driver-changelog.md
@@ -10,6 +10,15 @@
   function rather than accessing `:expressions` directly, as doing so can make your driver compatible with both 0.42.0
   and with 0.43.0 and newer.
 
+- There is now a `describe-nested-field-columns` method under `sql-jdbc.sync` namespace which returns an instance of
+  NestedFCMetadata. This is in order to allow JSON columns in Postgres and eventually other DB's which are usually
+  ordinary RDBMS's but then sometimes they have a denormalized column with JSON or some other semantics. Given a table
+  with denormalized columns which have nested field semantics (so, typed sub-fields which are still denormalized but
+  stable in type between rows), return value should be a NestedFCMetadata, a map of flattened key paths to the
+  detected sub-field. Field detection in syncing will then be enriched with those nested types. This is materially
+  different from the way we do it for mongo because every kind of JSON column is different, but it's going to run
+  every sync so it can't be too slow, even on enormous tables and enormous denormalized columns on those enormous tables.
+
 ## Metabase 0.42.0
 
 Changes in Metabase 0.42.0 affect drivers that derive from `:sql` (including `:sql-jdbc`).

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -264,14 +264,14 @@
 (defmethod describe-table-fks ::driver [_ _ _]
   nil)
 
-(defmulti describe-table-json
+(defmulti describe-nested-field-columns
   "Return information about the nestable columns in a `table`. Required for drivers that support `:nested-field-columns`. Results
   should match the [[metabase.sync.interface/JSONMetadata]] schema."
-  {:arglists '([this database table])}
+  {:added "0.43.0", :arglists '([this database table])}
   dispatch-on-initialized-driver
   :hierarchy #'hierarchy)
 
-(defmethod describe-table-json ::driver [_ _ _]
+(defmethod describe-nested-field-columns ::driver [_ _ _]
   nil)
 
 (def ConnectionDetailsProperty

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -352,7 +352,7 @@
     ;; Does this database support foreign key relationships?
     :foreign-keys
 
-    ;; Does this database support nested fields for any and every field (e.g. Mongo)?
+    ;; Does this database support nested fields for any and every field except primary key (e.g. Mongo)?
     :nested-fields
 
     ;; Does this database support nested fields but only for certain field types (e.g. Postgres and JSON / JSONB columns)?

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -264,16 +264,6 @@
 (defmethod describe-table-fks ::driver [_ _ _]
   nil)
 
-(defmulti describe-nested-field-columns
-  "Return information about the nestable columns in a `table`. Required for drivers that support `:nested-field-columns`. Results
-  should match the [[metabase.sync.interface/JSONMetadata]] schema."
-  {:added "0.43.0", :arglists '([this database table])}
-  dispatch-on-initialized-driver
-  :hierarchy #'hierarchy)
-
-(defmethod describe-nested-field-columns ::driver [_ _ _]
-  nil)
-
 (def ConnectionDetailsProperty
   "Schema for a map containing information about a connection property we should ask the user to supply when setting up
   a new database, as returned by an implementation of `connection-properties`."

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -264,6 +264,16 @@
 (defmethod describe-table-fks ::driver [_ _ _]
   nil)
 
+(defmulti describe-table-json
+  "Return information about the nestable columns in a `table`. Required for drivers that support `:nested-field-columns`. Results
+  should match the [[metabase.sync.interface/JSONMetadata]] schema."
+  {:arglists '([this database table])}
+  dispatch-on-initialized-driver
+  :hierarchy #'hierarchy)
+
+(defmethod describe-table-json ::driver [_ _ _]
+  nil)
+
 (def ConnectionDetailsProperty
   "Schema for a map containing information about a connection property we should ask the user to supply when setting up
   a new database, as returned by an implementation of `connection-properties`."
@@ -344,6 +354,9 @@
 
     ;; Does this database support nested fields (e.g. Mongo)?
     :nested-fields
+
+    ;; Does this database support nested fields but only for certain field types (e.g. Postgres and JSON / JSONB columns)?
+    :nested-field-columns
 
     ;; Does this driver support setting a timezone for the query?
     :set-timezone

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -352,7 +352,7 @@
     ;; Does this database support foreign key relationships?
     :foreign-keys
 
-    ;; Does this database support nested fields (e.g. Mongo)?
+    ;; Does this database support nested fields for any and every field (e.g. Mongo)?
     :nested-fields
 
     ;; Does this database support nested fields but only for certain field types (e.g. Postgres and JSON / JSONB columns)?

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -157,7 +157,7 @@
 
 (def ^:private ^:dynamic *enum-types* nil)
 
-;; Describe the Fields present in a `table`. This just hands off to the normal SQL driver implementation of the same
+; Describe the Fields present in a `table`. This just hands off to the normal SQL driver implementation of the same
 ;; name, but first fetches database enum types so we have access to them. These are simply binded to the dynamic var
 ;; and used later in `database-type->base-type`, which you will find below.
 (defmethod driver/describe-table :postgres
@@ -170,7 +170,11 @@
 ;; since this one only applies to JSON fields.
 (defmethod driver/describe-table-json :postgres
   [driver database table]
-  ;;;;; implement here...
+  ;;; get connection
+  ;;; sample
+  ;;; determine if samey schema or not, somehow fast
+  ;;; if samey schema, make that field list
+  ;;; return that sucker
   )
 
 

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -165,17 +165,25 @@
   (binding [*enum-types* (enum-types driver database)]
     (sql-jdbc.sync/describe-table driver database table)))
 
+(defn- describe-table-json*
+  [driver conn table]
+  (let [table-fields (sql-jdbc.sync/describe-table-fields driver conn table)
+        json-fields  (filter those suckers)]
+    (for [json-field json-fields]
+      (let [sample sample that fucker
+            same-schema filter it down to see if it's good for us]
+        (if same-schema
+          (get that schema)
+          false)))))
+
 ;; Describe the JSON fields present in a table.
 ;; Not to be confused with existing nested field functionality for mongo,
 ;; since this one only applies to JSON fields.
 (defmethod driver/describe-table-json :postgres
   [driver database table]
-  ;;; get connection
-  ;;; sample
-  ;;; determine if samey schema or not, somehow fast
-  ;;; if samey schema, make that field list
-  ;;; return that sucker
-  )
+  (let [spec (sql-jdbc.conn/db->pooled-connection-spec database)]
+    (with-open [conn (jdbc/get-connection spec)]
+      (describe-table-json* driver conn table))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -221,8 +221,8 @@
 ;; including if they have proper keyword and type stability.
 ;; Not to be confused with existing nested field functionality for mongo,
 ;; since this one only applies to JSON fields, whereas mongo only has BSON (JSON basically) fields.
-;; Every single database major is fiddly and weird and different about JSON so this one doesn't go in sql.jdbc.
-(defmethod driver/describe-nested-field-columns :postgres
+;; Every single database major is fiddly and weird and different about JSON so there's only a trivial default impl in sql.jdbc
+(defmethod sql-jdbc.sync/describe-nested-field-columns :postgres
   [driver database table]
   (let [spec (sql-jdbc.conn/db->pooled-connection-spec database)]
     (describe-nested-field-columns* driver spec table)))

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -195,7 +195,6 @@
     (into {} (map (fn [[k v]] [k (type v)]) flattened-row))))
 
 (defn- describe-table-json*
-  ;;;; types for this for chrissakes
   [driver conn table]
   (let [table-fields     (sql-jdbc.sync/describe-table-fields driver conn table)
         json-fields      (filter #(= (:semantic-type %) :type/SerializedJSON) table-fields)
@@ -203,13 +202,14 @@
         query            (db/query {:select json-field-names
                                     :from   [(keyword (:name table))]
                                     :limit  json-sample-limit})
-        printo           (for [q query]
-                           (first (for [[k v] q]
-                             (json/parse-string v))))
-        types            (map row->types printo)
+        parsed-query     (map #(into {}
+                                     (for [[k v] %]
+                                       [k (json/parse-string v)])) query)
+        types            (map row->types parsed-query)
+        ;;;;; gotta do a group by de facto, because we want hash dealios from columns being borked...
         hashes           (map hash types)]
-    (println printo)
     (println query)
+    (println parsed-query)
     (println types)
     (println hashes)
     hashes))

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -158,7 +158,7 @@
 
 (def ^:private ^:dynamic *enum-types* nil)
 
-; Describe the Fields present in a `table`. This just hands off to the normal SQL driver implementation of the same
+;; Describe the Fields present in a `table`. This just hands off to the normal SQL driver implementation of the same
 ;; name, but first fetches database enum types so we have access to them. These are simply binded to the dynamic var
 ;; and used later in `database-type->base-type`, which you will find below.
 (defmethod driver/describe-table :postgres
@@ -166,7 +166,9 @@
   (binding [*enum-types* (enum-types driver database)]
     (sql-jdbc.sync/describe-table driver database table)))
 
-(def ^:const json-sample-limit 10000)
+(def ^:const json-sample-limit
+  "Number of rows to sample for describe-table-json."
+  10000)
 
 (defn- flatten-row [row]
   (letfn [(flatten-row [row path]

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -165,6 +165,14 @@
   (binding [*enum-types* (enum-types driver database)]
     (sql-jdbc.sync/describe-table driver database table)))
 
+;; Describe the JSON fields present in a table.
+;; Not to be confused with existing nested field functionality for mongo,
+;; since this one only applies to JSON fields.
+(defmethod driver/describe-table-json :postgres
+  [driver database table]
+  ;;;;; implement here...
+  )
+
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                           metabase.driver.sql impls                                            |

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -169,15 +169,6 @@
 
 (def ^:const json-sample-limit 10000)
 
-;; Describe the JSON fields present in a table, including if they have proper keyword and type stability.
-;; Not to be confused with existing nested field functionality for mongo,
-;; since this one only applies to JSON fields.
-(defmethod driver/describe-table-json :postgres
-  [driver database table]
-  (let [spec (sql-jdbc.conn/db->pooled-connection-spec database)]
-    (with-open [conn (jdbc/get-connection spec)]
-      (describe-table-json* driver conn table))))
-
 (defn- flatten-row [row]
   (letfn [(flatten-row [row path]
             (lazy-seq
@@ -222,6 +213,16 @@
                                               :from   [(keyword (:name table))]
                                               :limit  json-sample-limit})]
     (transduce describe-json-xform describe-json-rf query)))
+
+;; Describe the JSON fields present in a table, including if they have proper keyword and type stability.
+;; Not to be confused with existing nested field functionality for mongo,
+;; since this one only applies to JSON fields.
+(defmethod driver/describe-table-json :postgres
+  [driver database table]
+  (let [spec (sql-jdbc.conn/db->pooled-connection-spec database)]
+    (with-open [conn (jdbc/get-connection spec)]
+      (describe-table-json* driver conn table))))
+
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                           metabase.driver.sql impls                                            |

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -180,22 +180,16 @@
 (defn- describe-table-json*
   ;;;; types for this for chrissakes
   [driver conn table]
-  (let [table-fields (sql-jdbc.sync/describe-table-fields driver conn table)
-        json-fields  (filter #(= (:semantic-type %) :type/SerializedJSON) table-fields)
-        ;;; need to only select json fields...
-        query        (db/reducible-query {:select [:*]
-                      :from   [(keyword (:name table))]
-                      :limit  json-sample-limit})
-        stability    (hash-map some shit)
-        description  {:is-stable stability}]
-    ;; (reduce {} some shit query)
-    ;;; figure out reducible-query stuf...
-    ;;; {:is-stable {stability dict here...}} -
-    ;;; not just a straight stability dict because we're gonna have other bullshit, i guarantee it
-    ;; (reduce #(some shit) description query)
-    (println description)
-    (for [json-field json-fields]
-      (println json-field))))
+  (let [table-fields     (sql-jdbc.sync/describe-table-fields driver conn table)
+        json-fields      (filter #(= (:semantic-type %) :type/SerializedJSON) table-fields)
+        json-field-names (mapv (comp keyword :name) json-fields)
+        query            (db/reducible-query {:select json-field-names
+                          :from   [(keyword (:name table))]
+                          :limit  json-sample-limit})
+        stability        (apply hash-map (interleave json-field-names (repeat true)))
+        description      {:is-stable stability}
+        res              (reduce (fn [some shit] some shit) description query)]
+    res))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                           metabase.driver.sql impls                                            |

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -211,10 +211,10 @@
           table-fields     (sql-jdbc.sync/describe-table-fields driver conn table)
           json-fields      (filter #(= (:semantic-type %) :type/SerializedJSON) table-fields)
           json-field-names (mapv (comp keyword :name) json-fields)
-          query-vec        (hsql/format {:select json-field-names
+          sql-args         (hsql/format {:select json-field-names
                                          :from   [(keyword (:name table))]
                                          :limit  json-sample-limit})
-          query            (jdbc/reducible-query spec query-vec)]
+          query            (jdbc/reducible-query spec sql-args)]
       {:types (transduce describe-json-xform describe-json-rf query)})))
 
 ;; Describe the JSON fields present in a table, including if they have proper keyword and type stability.

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -24,7 +24,8 @@
             [metabase.util.honeysql-extensions :as hx]
             [metabase.util.i18n :refer [trs]]
             [potemkin :as p]
-            [pretty.core :refer [PrettyPrintable]])
+            [pretty.core :refer [PrettyPrintable]]
+            [toucan.db :as db])
   (:import [java.sql ResultSet ResultSetMetaData Time Types]
            [java.time LocalDateTime OffsetDateTime OffsetTime]
            [java.util Date UUID]))
@@ -167,14 +168,22 @@
 
 (defn- describe-table-json*
   [driver conn table]
-  (let [table-fields (sql-jdbc.sync/describe-table-fields driver conn table)
-        json-fields  (filter those suckers)]
+  (let [table-fields     (sql-jdbc.sync/describe-table-fields driver conn table)
+        json-fields      (filter #(= (:semantic-type %) :type/SerializedJSON) table-fields)
+        query            {:select [:*]
+                          :from   [(keyword (:name table))]
+                          :limit  2}
+        sample           (db/query query)]
+    ;;; figure out reducible-query stuf...
+    (println sample)
     (for [json-field json-fields]
-      (let [sample sample that fucker
-            same-schema filter it down to see if it's good for us]
-        (if same-schema
-          (get that schema)
-          false)))))
+      (println json-field))))
+        
+;;       (let [sample sample that fucker
+;;             same-schema filter it down to see if it's good for us]
+;;         (if same-schema
+;;           (get that schema)
+;;           false)))))
 
 ;; Describe the JSON fields present in a table.
 ;; Not to be confused with existing nested field functionality for mongo,

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -204,6 +204,7 @@
   ([] nil)
   ([fst] fst)
   ([fst snd]
+   ;;;;; gotta not hardcode that field name....
    (if (or (nil? fst) (= (hash (:data fst)) (hash (:data snd))))
      snd
      {:data nil})))

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -1,7 +1,8 @@
 (ns metabase.driver.postgres
   "Database driver for PostgreSQL databases. Builds on top of the SQL JDBC driver, which implements most functionality
   for JDBC-based drivers."
-  (:require [clojure.java.jdbc :as jdbc]
+  (:require [cheshire.core :as json]
+            [clojure.java.jdbc :as jdbc]
             [clojure.set :as set]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
@@ -200,12 +201,18 @@
         json-fields      (filter #(= (:semantic-type %) :type/SerializedJSON) table-fields)
         json-field-names (mapv (comp keyword :name) json-fields)
         query            (db/query {:select json-field-names
-                          :from   [(keyword (:name table))]
-                          :limit  json-sample-limit})
-        types            (map (comp hash row->types) query)]
+                                    :from   [(keyword (:name table))]
+                                    :limit  json-sample-limit})
+        printo           (for [q query]
+                           (first (for [[k v] q]
+                             (json/parse-string v))))
+        types            (map row->types printo)
+        hashes           (map hash types)]
+    (println printo)
     (println query)
     (println types)
-    types))
+    (println hashes)
+    hashes))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                           metabase.driver.sql impls                                            |

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -180,17 +180,20 @@
 (defn- describe-table-json*
   ;;;; types for this for chrissakes
   [driver conn table]
-  (let [table-fields     (sql-jdbc.sync/describe-table-fields driver conn table)
-        json-fields      (filter #(= (:semantic-type %) :type/SerializedJSON) table-fields)
+  (let [table-fields (sql-jdbc.sync/describe-table-fields driver conn table)
+        json-fields  (filter #(= (:semantic-type %) :type/SerializedJSON) table-fields)
         ;;; need to only select json fields...
-        query            {:select [:*]
-                          :from   [(keyword (:name table))]
-                          :limit  json-sample-limit}
-        sample           (db/query query)]
+        query        (db/reducible-query {:select [:*]
+                      :from   [(keyword (:name table))]
+                      :limit  json-sample-limit})
+        stability    (hash-map some shit)
+        description  {:is-stable stability}]
+    ;; (reduce {} some shit query)
     ;;; figure out reducible-query stuf...
     ;;; {:is-stable {stability dict here...}} -
     ;;; not just a straight stability dict because we're gonna have other bullshit, i guarantee it
-    (println sample)
+    ;; (reduce #(some shit) description query)
+    (println description)
     (for [json-field json-fields]
       (println json-field))))
 

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -204,10 +204,11 @@
   ([] nil)
   ([fst] fst)
   ([fst snd]
-   ;;;;; gotta not hardcode that field name....
-   (if (or (nil? fst) (= (hash (:data fst)) (hash (:data snd))))
-     snd
-     {:data nil})))
+   (into {}
+         (for [json-column (keys snd)]
+           (if (or (nil? fst) (= (hash (fst json-column)) (hash (snd json-column))))
+             [json-column (snd json-column)]
+             [json-column nil])))))
 
 (defn- describe-table-json*
   [driver conn table]

--- a/src/metabase/driver/sql_jdbc/sync.clj
+++ b/src/metabase/driver/sql_jdbc/sync.clj
@@ -13,6 +13,7 @@
   column->semantic-type
   database-type->base-type
   db-default-timezone
+  describe-nested-field-columns
   excluded-schemas
   fallback-metadata-query
   filtered-syncable-schemas

--- a/src/metabase/driver/sql_jdbc/sync/interface.clj
+++ b/src/metabase/driver/sql_jdbc/sync/interface.clj
@@ -107,7 +107,7 @@
 
 (defmulti describe-nested-field-columns
   "Return information about the nestable columns in a `table`. Required for drivers that support `:nested-field-columns`. Results
-  should match the [[metabase.sync.interface/JSONMetadata]] schema."
+  should match the [[metabase.sync.interface/NestedFCMetadata]] schema."
   {:added "0.43.0", :arglists '([driver database table])}
   driver/dispatch-on-initialized-driver
   :hierarchy #'driver/hierarchy)

--- a/src/metabase/driver/sql_jdbc/sync/interface.clj
+++ b/src/metabase/driver/sql_jdbc/sync/interface.clj
@@ -104,3 +104,13 @@
 (defmethod db-default-timezone :sql-jdbc
   [_ _]
   nil)
+
+(defmulti describe-nested-field-columns
+  "Return information about the nestable columns in a `table`. Required for drivers that support `:nested-field-columns`. Results
+  should match the [[metabase.sync.interface/JSONMetadata]] schema."
+  {:added "0.43.0", :arglists '([driver database table])}
+  driver/dispatch-on-initialized-driver
+  :hierarchy #'driver/hierarchy)
+
+(defmethod describe-nested-field-columns :sql-jdbc [_ _ _]
+  nil)

--- a/src/metabase/sync/interface.clj
+++ b/src/metabase/sync/interface.clj
@@ -54,6 +54,12 @@
   "Schema for the expected output of `describe-table-fks`."
   (s/maybe #{FKMetadataEntry}))
 
+(def JSONMetadata
+  "Schema for the expected output of `describe-table-json`.
+  Recall that the TableMetadataFields are supposed to be flattened for `describe-table-json`,
+  which is why this one doesn't recurse."
+  (s/maybe #{#'TableMetadataField}))
+
 (def TimeZoneId
   "Schema predicate ensuring a valid time zone string"
   (s/pred (fn [tz-str]

--- a/src/metabase/sync/interface.clj
+++ b/src/metabase/sync/interface.clj
@@ -54,12 +54,6 @@
   "Schema for the expected output of `describe-table-fks`."
   (s/maybe #{FKMetadataEntry}))
 
-(def JSONMetadata
-  "Schema for the expected output of `describe-table-json`.
-  Recall that the TableMetadataFields are supposed to be flattened for `describe-table-json`,
-  which is why this one doesn't recurse."
-  (s/maybe #{#'TableMetadataField}))
-
 (def TimeZoneId
   "Schema predicate ensuring a valid time zone string"
   (s/pred (fn [tz-str]

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -285,7 +285,12 @@
 
 (deftest describe-json-test
   (mt/test-driver :postgres
-    (testing "flatten row")
+    (testing "flatten-row"
+      (let [row some shit]
+        (is (= (flatten-row row) some shit))))
+    (testing "row->types"
+      (let [row some shit]
+        (is (= (row->types row) some shit))))
     (testing "describes a json column which has a coherent schema")
     (testing "describes a json column which does not a coherent schema")
     (testing "handles multiple mixed json columns OK")))

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -303,8 +303,10 @@
                            "CREATE TABLE PUBLIC.describe_json_table (coherent_json_val JSON NOT NULL, incoherent_json_val JSON NOT NULL);"
                            "INSERT INTO PUBLIC.describe_json_table (coherent_json_val incoherent_json_val) VALUES ('{\"a\": 1, \"b\": 2}', '{\"a\": 1, \"b\": 2}');"
                            "INSERT INTO PUBLIC.describe_json_table (coherent_json_val incoherent_json_val) VALUES ('{\"a\": 2, \"b\": 3}', '{\"a\": [1, 2], \"b\": 2}');"]]
-          (jdbc/execute! spec [statement])))
-      (is (= (describe-table-json :postgres db table) {"bob" "dobbs})))))
+          (jdbc/execute! spec [statement]))
+        (mt/with-temp Database [database {:engine :postgres, :details details}]
+          (sync/sync-database! database)
+          (is (= (driver/describe-table-json :postgres database {:name "describe_json_table"}) {"bob" "dobbs"})))))
 
 (mt/defdataset with-uuid
   [["users"

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -306,7 +306,7 @@
           (jdbc/execute! spec [statement]))
         (mt/with-temp Database [database {:engine :postgres, :details details}]
           (sync/sync-database! database)
-          (is (= (driver/describe-table-json :postgres database {:name "describe_json_table"}) {"bob" "dobbs"})))))
+          (is (= (driver/describe-table-json :postgres database {:name "describe_json_table"}) {"bob" "dobbs"})))))))
 
 (mt/defdataset with-uuid
   [["users"

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -299,14 +299,14 @@
       (drop-if-exists-and-create-db! "describe-json-test")
       (let [details (mt/dbdef->connection-details :postgres :db {:database-name "describe-json-test"})
             spec    (sql-jdbc.conn/connection-details->spec :postgres details)]
-        (doseq [statement ["DROP TABLE IF EXISTS PUBLIC.describe_json_table;"
-                           "CREATE TABLE PUBLIC.describe_json_table (coherent_json_val JSON NOT NULL, incoherent_json_val JSON NOT NULL);"
-                           "INSERT INTO PUBLIC.describe_json_table (coherent_json_val incoherent_json_val) VALUES ('{\"a\": 1, \"b\": 2}', '{\"a\": 1, \"b\": 2}');"
-                           "INSERT INTO PUBLIC.describe_json_table (coherent_json_val incoherent_json_val) VALUES ('{\"a\": 2, \"b\": 3}', '{\"a\": [1, 2], \"b\": 2}');"]]
+        (doseq [statement ["DROP TABLE IF EXISTS describe_json_table;"
+                           "CREATE TABLE describe_json_table (coherent_json_val JSON NOT NULL, incoherent_json_val JSON NOT NULL);"
+                           "INSERT INTO describe_json_table (coherent_json_val, incoherent_json_val) VALUES ('{\"a\": 1, \"b\": 2}', '{\"a\": 1, \"b\": 2}');"
+                           "INSERT INTO describe_json_table (coherent_json_val, incoherent_json_val) VALUES ('{\"a\": 2, \"b\": 3}', '{\"a\": [1, 2], \"b\": 2}');"]]
           (jdbc/execute! spec [statement]))
         (mt/with-temp Database [database {:engine :postgres, :details details}]
           (sync/sync-database! database)
-          (is (= (driver/describe-table-json :postgres database {:name "describe_json_table"}) {"bob" "dobbs"})))))))
+          (is (= (driver/describe-table :postgres database {:name "describe_json_table"}) {"bob" "dobbs"})))))))
 
 (mt/defdataset with-uuid
   [["users"

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -283,6 +283,13 @@
         (is (= :type/SerializedJSON
                (db/select-one-field :semantic_type Field, :id (mt/id :venues :address))))))))
 
+(deftest describe-json-test
+  (mt/test-driver :postgres
+    (testing "flatten row")
+    (testing "describes a json column which has a coherent schema")
+    (testing "describes a json column which does not a coherent schema")
+    (testing "handles multiple mixed json columns OK")))
+
 (mt/defdataset with-uuid
   [["users"
     [{:field-name "user_id", :base-type :type/UUID}]

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -283,7 +283,7 @@
         (is (= :type/SerializedJSON
                (db/select-one-field :semantic_type Field, :id (mt/id :venues :address))))))))
 
-(deftest describe-json-test
+(deftest describe-nested-field-columns-test
   (mt/test-driver :postgres
     (testing "flatten-row"
       (let [row       {:bob {:dobbs 123 :cobbs "boop"}}
@@ -303,7 +303,7 @@
                              "INSERT INTO describe_json_table (coherent_json_val, incoherent_json_val) VALUES ('{\"a\": 1, \"b\": 2}', '{\"a\": 1, \"b\": 2}');"
                              "INSERT INTO describe_json_table (coherent_json_val, incoherent_json_val) VALUES ('{\"a\": 2, \"b\": 3}', '{\"a\": [1, 2], \"b\": 2}');")])
         (mt/with-temp Database [database {:engine :postgres, :details details}]
-          (is (= (into (sorted-map) (driver/describe-table-json :postgres database {:name "describe_json_table"}))
+          (is (= (into (sorted-map) (driver/describe-nested-field-columns :postgres database {:name "describe_json_table"}))
                  (into (sorted-map) {:types {:coherent_json_val {["a"] java.lang.Integer, ["b"] java.lang.Integer} :incoherent_json_val nil}}))))))))
 
 (mt/defdataset with-uuid

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -9,6 +9,7 @@
             [metabase.driver.postgres :as postgres]
             [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
             [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
+            [metabase.driver.sql-jdbc.sync :as sql-jdbc.sync]
             [metabase.driver.sql.query-processor :as sql.qp]
             [metabase.driver.sql.query-processor-test-util :as sql.qp-test-util]
             [metabase.models.database :refer [Database]]
@@ -303,7 +304,7 @@
                              "INSERT INTO describe_json_table (coherent_json_val, incoherent_json_val) VALUES ('{\"a\": 1, \"b\": 2}', '{\"a\": 1, \"b\": 2}');"
                              "INSERT INTO describe_json_table (coherent_json_val, incoherent_json_val) VALUES ('{\"a\": 2, \"b\": 3}', '{\"a\": [1, 2], \"b\": 2}');")])
         (mt/with-temp Database [database {:engine :postgres, :details details}]
-          (is (= (into (sorted-map) (driver/describe-nested-field-columns :postgres database {:name "describe_json_table"}))
+          (is (= (into (sorted-map) (sql-jdbc.sync/describe-nested-field-columns :postgres database {:name "describe_json_table"}))
                  (into (sorted-map) {:types {:coherent_json_val {["a"] java.lang.Integer, ["b"] java.lang.Integer} :incoherent_json_val nil}}))))))))
 
 (mt/defdataset with-uuid

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -295,7 +295,7 @@
             types {:bob {[:cobbs] clojure.lang.PersistentVector
                          [:dobbs :robbs] java.lang.Long}}]
         (is (= (#'postgres/row->types row) types))))
-    (testing "describes json columns and gives types for ones with coherent schemas"
+    (testing "describes json columns and gives types for ones with coherent schemas only"
       (drop-if-exists-and-create-db! "describe-json-test")
       (let [details (mt/dbdef->connection-details :postgres :db {:database-name "describe-json-test"})
             spec    (sql-jdbc.conn/connection-details->spec :postgres details)]
@@ -306,7 +306,8 @@
           (jdbc/execute! spec [statement]))
         (mt/with-temp Database [database {:engine :postgres, :details details}]
           (sync/sync-database! database)
-          (is (= (driver/describe-table :postgres database {:name "describe_json_table"}) {"bob" "dobbs"})))))))
+          (is (= (driver/describe-table-json :postgres database {:name "describe_json_table"})
+                 {:coherent_json_val {["a"] java.lang.Long, ["b"] java.lang.Long} :incoherent_json_val nil})))))))
 
 (mt/defdataset with-uuid
   [["users"


### PR DESCRIPTION
Start of the long grind towards whacking #708. In order to have JSON columns display in whatever display we're deciding on, there needs to a representation of the fields-within-the-field. This one is to get the types and identities of those in a format that will definitely change. This, then probably multiple PR's for the sync, then a PR for the handling of the postgres JSON sugar

This is for 'consistent' json schemata only and limited to 10k rows. Sync performance is kind of scary for 20 gb JSON table of exactly 10k rows but otherwise not terrible.