### PR TITLE
use includes instead of startsWith to filter options in ListField

### DIFF
--- a/frontend/src/metabase/components/ListField/ListField.tsx
+++ b/frontend/src/metabase/components/ListField/ListField.tsx
@@ -80,7 +80,7 @@ export const ListField = ({
       option[0]
         .toString()
         .toLowerCase()
-        .startsWith(trimmedFilter),
+        .includes(trimmedFilter),
     );
   }, [augmentedOptions, debouncedFilter, sortedOptions]);
 

--- a/frontend/src/metabase/components/ListField/ListField.tsx
+++ b/frontend/src/metabase/components/ListField/ListField.tsx
@@ -117,6 +117,7 @@ export const ListField = ({
         onChange={setFilter}
         onKeyDown={handleKeyDown}
         hasClearButton
+        autoFocus
       />
 
       {shouldShowEmptyState && (


### PR DESCRIPTION
Fixes #20551 

`ListField` is a new component; we just need to mimic the filter logic that is in `FieldValuesWidget`.

<img width="372" alt="Screen Shot 2022-02-16 at 11 20 25 AM" src="https://user-images.githubusercontent.com/13057258/154330517-7978102d-4719-4f03-8b28-6e762ec2dd6f.png">

**Testing**
Follow steps in #20551 

