### PR TITLE
New structure for data permission graphs

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sandbox/models/permissions/delete_sandboxes.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/models/permissions/delete_sandboxes.clj
@@ -111,7 +111,7 @@
   (doseq [database-id (set (keys changes))]
     (delete-gtaps-for-group-database!
      {:group-id group-id, :database-id database-id}
-     (get-in changes [database-id :schemas]))))
+     (get-in changes [database-id :data :schemas]))))
 
 (defn- delete-gtaps-if-needed-after-permissions-change! [changes]
   (log/debug "Permissions updated, deleting unneeded GTAPs...")

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/block_permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/block_permissions_test.clj
@@ -17,7 +17,7 @@
 ;;;; Graph-related stuff
 
 (defn- test-db-perms [group-id]
-  (get-in (perms/data-perms-graph) [:groups group-id (mt/id)]))
+  (get-in (perms/data-perms-graph) [:groups group-id (mt/id) :data]))
 
 (defn- api-test-db-perms [group-id]
   (into {}
@@ -26,7 +26,8 @@
         (get-in (mt/user-http-request :crowberto :get 200 "permissions/graph")
                 [:groups
                  (keyword (str group-id))
-                 (keyword (str (mt/id)))])))
+                 (keyword (str (mt/id)))
+                 :data])))
 
 (deftest graph-test
   (testing "block permissions should come back from"
@@ -60,17 +61,18 @@
                        (perms group-id)))))))))))
 
 (defn- grant-block-perms! [group-id]
-  (perms/update-data-perms-graph! [group-id (mt/id)] {:schemas :block}))
+  (perms/update-data-perms-graph! [group-id (mt/id) :data] {:schemas :block}))
 
 (defn- api-grant-block-perms! [group-id]
   (let [current-graph (perms/data-perms-graph)
-        new-graph     (assoc-in current-graph [:groups group-id (mt/id)] {:schemas :block})
+        new-graph     (assoc-in current-graph [:groups group-id (mt/id) :data] {:schemas :block})
         result        (premium-features-test/with-premium-features #{:advanced-permissions}
                         (mt/user-http-request :crowberto :put 200 "permissions/graph" new-graph))]
     (is (= "block"
            (get-in result [:groups
                            (keyword (str group-id))
                            (keyword (str (mt/id)))
+                           :data
                            :schemas])))))
 
 (deftest api-throws-error-if-premium-feature-not-enabled
@@ -79,7 +81,7 @@
                   ":advanced-permissions premium feature enabled")
       (mt/with-temp PermissionsGroup [{group-id :id}]
         (let [current-graph (perms/data-perms-graph)
-              new-graph     (assoc-in current-graph [:groups group-id (mt/id)] {:schemas :block})
+              new-graph     (assoc-in current-graph [:groups group-id (mt/id) :data] {:schemas :block})
               result        (premium-features-test/with-premium-features #{} ; disable premium features
                               (mt/user-http-request :crowberto :put 402 "permissions/graph" new-graph))]
           (is (= "Can't use block permissions without having the advanced-permissions premium feature"
@@ -131,7 +133,7 @@
                     Permissions      [_ {:group_id group-id, :object (perms/database-block-perms-path (mt/id))}]]
       (is (= {:schemas :block}
              (test-db-perms group-id)))
-      (perms/update-data-perms-graph! [group-id (mt/id) :schemas] {"public" {(mt/id :venues) {:read :all}}})
+      (perms/update-data-perms-graph! [group-id (mt/id) :data :schemas] {"public" {(mt/id :venues) {:read :all}}})
       (is (= {:schemas {"public" {(mt/id :venues) {:read :all}}}}
              (test-db-perms group-id))))))
 
@@ -145,12 +147,12 @@
              ;; TODO -- this error message is totally garbage, fix this
              #"DB permissions with a valid combination of values for :native and :schemas"
              ;; #"DB permissions with a valid combination of values for :native and :schemas"
-             (perms/update-data-perms-graph! [group-id (mt/id)]
+             (perms/update-data-perms-graph! [group-id (mt/id) :data]
                                              {:schemas :block, :native :write}))))
       (testing "via the API"
         (let [current-graph (perms/data-perms-graph)
               new-graph     (assoc-in current-graph
-                                      [:groups group-id (mt/id)]
+                                      [:groups group-id (mt/id) :data]
                                       {:schemas :block, :native :write})]
           (is (schema= {:message  #".*DB permissions with a valid combination of values for :native and :schemas.*"
                         s/Keyword s/Any}

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/permissions_test.clj
@@ -13,7 +13,7 @@
   (keyword (str (u/the-id id))))
 
 (defn- db-graph-keypath [group]
-  [:groups (id->keyword group) (id->keyword (mt/id))])
+  [:groups (id->keyword group) (id->keyword (mt/id)) :data])
 
 (defn- venues-perms-graph-keypath [group]
   (concat

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions.unit.spec.js
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions.unit.spec.js
@@ -8,35 +8,47 @@ const initialPermissions = {
   1: {
     // Sample database
     1: {
-      native: "write",
-      schemas: "all",
+      data: {
+        native: "write",
+        schemas: "all",
+      },
     },
     // Imaginary multi-schema
     2: {
-      native: "write",
-      schemas: "all",
+      data: {
+        native: "write",
+        schemas: "all",
+      },
     },
     // Imaginary schemaless
     3: {
-      native: "write",
-      schemas: "all",
+      data: {
+        native: "write",
+        schemas: "all",
+      },
     },
   },
   2: {
     // Sample database
     1: {
-      native: "none",
-      schemas: "none",
+      data: {
+        native: "none",
+        schemas: "none",
+      },
     },
     // Imaginary multi-schema
     2: {
-      native: "none",
-      schemas: "none",
+      data: {
+        native: "none",
+        schemas: "none",
+      },
     },
     // Imaginary schemaless
     3: {
-      native: "none",
-      schemas: "none",
+      data: {
+        native: "none",
+        schemas: "none",
+      },
     },
   },
 };

--- a/frontend/src/metabase/lib/permissions.js
+++ b/frontend/src/metabase/lib/permissions.js
@@ -60,11 +60,16 @@ export function updatePermission(permissions, groupId, path, value, entityIds) {
 }
 
 export const getSchemasPermission = (permissions, groupId, { databaseId }) => {
-  return getPermission(permissions, groupId, [databaseId, "schemas"], true);
+  return getPermission(
+    permissions,
+    groupId,
+    [databaseId, "data", "schemas"],
+    true,
+  );
 };
 
 export const getNativePermission = (permissions, groupId, { databaseId }) => {
-  return getPermission(permissions, groupId, [databaseId, "native"]);
+  return getPermission(permissions, groupId, [databaseId, "data", "native"]);
 };
 
 export const getTablesPermission = (
@@ -77,7 +82,7 @@ export const getTablesPermission = (
     return getPermission(
       permissions,
       groupId,
-      [databaseId, "schemas", schemaName || ""],
+      [databaseId, "data", "schemas", schemaName || ""],
       true,
     );
   } else {
@@ -98,7 +103,7 @@ export const getFieldsPermission = (
     return getPermission(
       permissions,
       groupId,
-      [databaseId, "schemas", schemaName || "", tableId],
+      [databaseId, "data", "schemas", schemaName || "", tableId],
       true,
     );
   } else {
@@ -268,7 +273,7 @@ export function updateFieldsPermission(
   permissions = updatePermission(
     permissions,
     groupId,
-    [databaseId, "schemas", schemaName, tableId],
+    [databaseId, "data", "schemas", schemaName, tableId],
     PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_PERMISSION_VALUE[value] || value,
   );
 
@@ -295,7 +300,7 @@ export function updateTablesPermission(
   permissions = updatePermission(
     permissions,
     groupId,
-    [databaseId, "schemas", schemaName || ""],
+    [databaseId, "data", "schemas", schemaName || ""],
     value,
     tableIds,
   );
@@ -329,7 +334,7 @@ export function updateSchemasPermission(
   return updatePermission(
     permissions,
     groupId,
-    [databaseId, "schemas"],
+    [databaseId, "data", "schemas"],
     value,
     schemaNamesOrNoSchema,
   );
@@ -352,7 +357,12 @@ export function updateNativePermission(
       metadata,
     );
   }
-  return updatePermission(permissions, groupId, [databaseId, "native"], value);
+  return updatePermission(
+    permissions,
+    groupId,
+    [databaseId, "data", "native"],
+    value,
+  );
 }
 
 function deleteIfEmpty(object, key) {

--- a/frontend/test/__support__/e2e/commands/permissions/updatePermissions.js
+++ b/frontend/test/__support__/e2e/commands/permissions/updatePermissions.js
@@ -44,7 +44,9 @@ Cypress.Commands.add(
         const UPDATED_GROUPS = Object.assign(groups, {
           [user_group]: {
             [database_id]: {
-              schemas,
+              data: {
+                schemas,
+              },
             },
           },
         });

--- a/frontend/test/metabase/scenarios/native-filters/reproductions/15163.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native-filters/reproductions/15163.cy.spec.js
@@ -77,7 +77,7 @@ const dashboardFilter = {
           if (test === "nosql") {
             cy.updatePermissionsGraph({
               [COLLECTION_GROUP]: {
-                "1": { schemas: "all", native: "none" },
+                "1": { data: { schemas: "all", native: "none" } },
               },
             });
           }

--- a/frontend/test/metabase/scenarios/permissions/reproductions/13347-cannot-select-saved-question-in-database-without-data-permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/reproductions/13347-cannot-select-saved-question-in-database-without-data-permissions.cy.spec.js
@@ -14,8 +14,8 @@ describe.skip("issue 13347", () => {
 
     cy.updatePermissionsGraph({
       [ALL_USERS_GROUP]: {
-        1: { schemas: "all", native: "write" },
-        [PG_DB_ID]: { schemas: "none", native: "none" },
+        1: { data: { schemas: "all", native: "write" } },
+        [PG_DB_ID]: { data: { schemas: "none", native: "none" } },
       },
     });
 

--- a/frontend/test/metabase/scenarios/permissions/reproductions/14873-regextract-in-sandboxed-table.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/reproductions/14873-regextract-in-sandboxed-table.cy.spec.js
@@ -17,11 +17,13 @@ describeWithToken("postgres > user > query", () => {
     // Update basic permissions (the same starting "state" as we have for the "Sample Database")
     cy.updatePermissionsGraph({
       [ALL_USERS_GROUP]: {
-        [PG_DB_ID]: { schemas: "none", native: "none" },
+        [PG_DB_ID]: { data: { schemas: "none", native: "none" } },
       },
-      [DATA_GROUP]: { [PG_DB_ID]: { schemas: "all", native: "write" } },
+      [DATA_GROUP]: {
+        [PG_DB_ID]: { data: { schemas: "all", native: "write" } },
+      },
       [COLLECTION_GROUP]: {
-        [PG_DB_ID]: { schemas: "none", native: "none" },
+        [PG_DB_ID]: { data: { schemas: "none", native: "none" } },
       },
     });
 

--- a/frontend/test/metabase/scenarios/permissions/reproductions/17763-cannot-edit-granular-after-block.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/reproductions/17763-cannot-edit-granular-after-block.cy.spec.js
@@ -10,7 +10,7 @@ describeWithToken("issue 17763", () => {
 
     cy.updatePermissionsGraph({
       [ALL_USERS_GROUP]: {
-        "1": { schemas: "block", native: "none" },
+        "1": { data: { schemas: "block", native: "none" } },
       },
     });
   });

--- a/frontend/test/metabase/scenarios/permissions/reproductions/20436-incorrect-display-of-database-permissions-level.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/reproductions/20436-incorrect-display-of-database-permissions-level.cy.spec.js
@@ -14,7 +14,7 @@ describe.skip("issue 20436", () => {
 
     cy.updatePermissionsGraph({
       [ALL_USERS_GROUP]: {
-        1: { schemas: "all", native: "none" },
+        1: { data: { schemas: "all", native: "none" } },
       },
     });
   });

--- a/frontend/test/snapshot-creators/default.cy.snap.js
+++ b/frontend/test/snapshot-creators/default.cy.snap.js
@@ -98,11 +98,13 @@ describe("snapshots", () => {
     cy.request("GET", "/api/user");
 
     cy.updatePermissionsGraph({
-      [ALL_USERS_GROUP]: { "1": { schemas: "none", native: "none" } },
-      [DATA_GROUP]: { "1": { schemas: "all", native: "write" } },
-      [NOSQL_GROUP]: { "1": { schemas: "all", native: "none" } },
-      [COLLECTION_GROUP]: { "1": { schemas: "none", native: "none" } },
-      [READONLY_GROUP]: { "1": { schemas: "none", native: "none" } },
+      [ALL_USERS_GROUP]: { "1": { data: { schemas: "none", native: "none" } } },
+      [DATA_GROUP]: { "1": { data: { schemas: "all", native: "write" } } },
+      [NOSQL_GROUP]: { "1": { data: { schemas: "all", native: "none" } } },
+      [COLLECTION_GROUP]: {
+        "1": { data: { schemas: "none", native: "none" } },
+      },
+      [READONLY_GROUP]: { "1": { data: { schemas: "none", native: "none" } } },
     });
 
     cy.updateCollectionGraph({

--- a/src/metabase/api/permission_graph.clj
+++ b/src/metabase/api/permission_graph.clj
@@ -44,8 +44,8 @@
 
 (s/def ::schema-name (s/or :kw->str keyword?))
 
-;; {:groups {1 {:schemas {"PUBLIC" ::schema-perms-granular}}}} =>
-;; {:groups {1 {:schemas {"PUBLIC" {1 :all}}}}}
+;; {:groups {1 {:data {:schemas {"PUBLIC" ::schema-perms-granular}}}}} =>
+;; {:groups {1 {:data {:schemas {"PUBLIC" {1 :all}}}}}}
 (s/def ::read (s/or :str->kw #{"all" "none"}))
 (s/def ::query (s/or :str->kw #{"all" "none" "segmented"}))
 
@@ -60,20 +60,21 @@
 (s/def ::schema-perms (s/or :str->kw #{"all" "segmented" "none"}
                             :identity ::table-graph))
 
-;; {:groups {1 {:schemas {"PUBLIC" ::schema-perms}}}}
+;; {:groups {1 {:data {:schemas {"PUBLIC" ::schema-perms}}}}}
 (s/def ::schema-graph (s/map-of ::schema-name ::schema-perms
                                 :conform-keys true))
 
-;; {:groups {1 {:schemas ::schemas}}}
+;; {:groups {1 {:data {:schemas ::schemas}}}}
 (s/def ::schemas (s/or :str->kw   #{"all" "segmented" "none" "block"}
                        :nil->none nil?
                        :identity  ::schema-graph))
 
-(s/def ::db-perms (s/keys :opt-un [::native ::schemas]))
+(s/def ::data (s/keys :opt-un [::native ::schemas]))
+
+(s/def ::db-perms (s/keys :opt-un [::data]))
 
 (s/def ::db-graph (s/map-of ::id ::db-perms
                             :conform-keys true))
-
 
 (s/def :metabase.api.permission-graph.data/groups
   (s/map-of ::id ::db-graph

--- a/src/metabase/models/permissions/parse.clj
+++ b/src/metabase/models/permissions/parse.clj
@@ -41,12 +41,12 @@
     [:permission t]              (path t)
     [:all]                       [:all] ; admin permissions
     [:db db-id]                  (let [db-id (Long/parseUnsignedLong db-id)]
-                                   [[:db db-id :native :write]
-                                    [:db db-id :schemas :all]])
+                                   [[:db db-id :data :native :write]
+                                    [:db db-id :data :schemas :all]])
     [:db db-id db-node]          (let [db-id (Long/parseUnsignedLong db-id)]
                                    (into [:db db-id] (path db-node)))
-    [:schemas]                   [:schemas :all]
-    [:schemas schema]            (into [:schemas] (path schema))
+    [:schemas]                   [:data :schemas :all]
+    [:schemas schema]            (into [:data :schemas] (path schema))
     [:schema schema-name]        [schema-name :all]
     [:schema schema-name table]  (into [schema-name] (path table))
     [:table table-id]            [(Long/parseUnsignedLong table-id) :all]
@@ -55,7 +55,7 @@
                                     "read"            [:read :all]
                                     "query"           [:query :all]
                                     "query/segmented" [:query :segmented])
-    [:native]                    [:native :write]
+    [:native]                    [:data :native :write]
     ;; collection perms
     [:collection id]             [:collection (collection-id id) :write]
     [:collection id "read"]      [:collection (collection-id id) :read]

--- a/src/metabase/models/permissions/parse.clj
+++ b/src/metabase/models/permissions/parse.clj
@@ -60,7 +60,7 @@
     [:collection id]             [:collection (collection-id id) :write]
     [:collection id "read"]      [:collection (collection-id id) :read]
     ;; block perms. Parse something like /block/db/1/ to {:db {1 {:schemas :block}}}
-    [:block db-id]               [:db (Long/parseUnsignedLong db-id) :schemas :block]))
+    [:block db-id]               [:db (Long/parseUnsignedLong db-id) :data :schemas :block]))
 
 (defn- graph
   "Given a set of permission paths, return a graph that expresses the most permissions possible for the set

--- a/test/metabase/api/permissions_test.clj
+++ b/test/metabase/api/permissions_test.clj
@@ -59,7 +59,7 @@
       (is (= (mt/user-http-request :crowberto :get 200 "permissions/group" :offset "1" :limit 50)
              (mt/user-http-request :crowberto :get 200 "permissions/group" :offset "1"))))
     (testing "Limit and offset pagination works for permissions list"
-      (is (= [{:id 1, :name "All Users", :member_count 3}]
+      (is (partial= [{:id 1, :name "All Users"}]
              (mt/user-http-request :crowberto :get 200 "permissions/group" :limit "1" :offset "1"))))))
 
 (deftest fetch-group-test
@@ -96,21 +96,21 @@
         (mt/user-http-request
          :crowberto :put 200 "permissions/graph"
          (assoc-in (perms/data-perms-graph)
-                   [:groups (u/the-id group) (mt/id) :schemas]
+                   [:groups (u/the-id group) (mt/id) :data :schemas]
                    {"PUBLIC" {(mt/id :venues) :all}}))
         (is (= {(mt/id :venues) :all}
-               (get-in (perms/data-perms-graph) [:groups (u/the-id group) (mt/id) :schemas "PUBLIC"]))))
+               (get-in (perms/data-perms-graph) [:groups (u/the-id group) (mt/id) :data :schemas "PUBLIC"]))))
 
       (testing "Table-specific perms"
         (mt/with-temp PermissionsGroup [group]
           (mt/user-http-request
            :crowberto :put 200 "permissions/graph"
            (assoc-in (perms/data-perms-graph)
-                     [:groups (u/the-id group) (mt/id) :schemas]
+                     [:groups (u/the-id group) (mt/id) :data :schemas]
                      {"PUBLIC" {(mt/id :venues) {:read :all, :query :segmented}}}))
           (is (= {(mt/id :venues) {:read  :all
                                    :query :segmented}}
-                 (get-in (perms/data-perms-graph) [:groups (u/the-id group) (mt/id) :schemas "PUBLIC"]))))))
+                 (get-in (perms/data-perms-graph) [:groups (u/the-id group) (mt/id) :data :schemas "PUBLIC"]))))))
 
     (testing "permissions for new db"
       (let [new-id (inc (mt/id))]
@@ -120,10 +120,10 @@
           (mt/user-http-request
            :crowberto :put 200 "permissions/graph"
            (assoc-in (perms/data-perms-graph)
-                     [:groups (u/the-id group) db-id :schemas]
+                     [:groups (u/the-id group) db-id :data :schemas]
                      :all))
           (is (= :all
-                 (get-in (perms/data-perms-graph) [:groups (u/the-id group) db-id :schemas]))))))
+                 (get-in (perms/data-perms-graph) [:groups (u/the-id group) db-id :data :schemas]))))))
 
     (testing "permissions for new db with no tables"
       (let [new-id (inc (mt/id))]
@@ -132,7 +132,7 @@
           (mt/user-http-request
            :crowberto :put 200 "permissions/graph"
            (assoc-in (perms/data-perms-graph)
-                     [:groups (u/the-id group) db-id :schemas]
+                     [:groups (u/the-id group) db-id :data :schemas]
                      :all))
           (is (= :all
-                 (get-in (perms/data-perms-graph) [:groups (u/the-id group) db-id :schemas]))))))))
+                 (get-in (perms/data-perms-graph) [:groups (u/the-id group) db-id :data :schemas]))))))))

--- a/test/metabase/models/permissions/parse_test.clj
+++ b/test/metabase/models/permissions/parse_test.clj
@@ -5,15 +5,15 @@
 (deftest permissions->graph
   (testing "Parses each permission string to the correct graph"
     (are [x y] (= y (parse/permissions->graph [x]))
-      "/db/3/"                                       {:db {3 {:native  :write
-                                                              :schemas :all}}}
-      "/db/3/native/"                                {:db {3 {:native :write}}}
-      "/db/3/schema/"                                {:db {3 {:schemas :all}}}
-      "/db/3/schema/PUBLIC/"                         {:db {3 {:schemas {"PUBLIC" :all}}}}
-      "/db/3/schema/PUBLIC/table/4/"                 {:db {3 {:schemas {"PUBLIC" {4 :all}}}}}
-      "/db/3/schema/PUBLIC/table/4/read/"            {:db {3 {:schemas {"PUBLIC" {4 {:read :all}}}}}}
-      "/db/3/schema/PUBLIC/table/4/query/"           {:db {3 {:schemas {"PUBLIC" {4 {:query :all}}}}}}
-      "/db/3/schema/PUBLIC/table/4/query/segmented/" {:db {3 {:schemas {"PUBLIC" {4 {:query :segmented}}}}}})))
+      "/db/3/"                                       {:db {3 {:data {:native  :write
+                                                                     :schemas :all}}}}
+      "/db/3/native/"                                {:db {3 {:data {:native :write}}}}
+      "/db/3/schema/"                                {:db {3 {:data {:schemas :all}}}}
+      "/db/3/schema/PUBLIC/"                         {:db {3 {:data {:schemas {"PUBLIC" :all}}}}}
+      "/db/3/schema/PUBLIC/table/4/"                 {:db {3 {:data {:schemas {"PUBLIC" {4 :all}}}}}}
+      "/db/3/schema/PUBLIC/table/4/read/"            {:db {3 {:data {:schemas {"PUBLIC" {4 {:read :all}}}}}}}
+      "/db/3/schema/PUBLIC/table/4/query/"           {:db {3 {:data {:schemas {"PUBLIC" {4 {:query :all}}}}}}}
+      "/db/3/schema/PUBLIC/table/4/query/segmented/" {:db {3 {:data {:schemas {"PUBLIC" {4 {:query :segmented}}}}}}})))
 
 
 (deftest combines-permissions-for-graph
@@ -33,17 +33,16 @@
     ;;
     ;; Visually, the map is structured to mean "When the permission set includes only this key and the ones below it,
     ;; the permission graph for this key should be returned"
-    (doseq [group (let [groups (->> {"/db/3/"                                       {:db {3 {:native  :write
-                                                                                             :schemas :all}}}
+    (doseq [group (let [groups (->> {"/db/3/"                                       {:db {3 {:data {:native  :write :schemas :all}}}}
 
-                                     "/db/3/schema/"                                {:db {3 {:schemas :all}}}
-                                     "/db/3/schema/PUBLIC/"                         {:db {3 {:schemas {"PUBLIC" :all}}}}
-                                     "/db/3/schema/PUBLIC/table/4/"                 {:db {3 {:schemas {"PUBLIC" {4 :all}}}}}
-                                     "/db/3/schema/PUBLIC/table/4/query/"           {:db {3 {:schemas {"PUBLIC" {4 {:read  :all
-                                                                                                                    :query :all}}}}}}
-                                     "/db/3/schema/PUBLIC/table/4/query/segmented/" {:db {3 {:schemas {"PUBLIC" {4 {:read  :all
-                                                                                                                    :query :segmented}}}}}}
-                                     "/db/3/schema/PUBLIC/table/4/read/"            {:db {3 {:schemas {"PUBLIC" {4 {:read :all}}}}}}}
+                                     "/db/3/schema/"                                {:db {3 {:data {:schemas :all}}}}
+                                     "/db/3/schema/PUBLIC/"                         {:db {3 {:data {:schemas {"PUBLIC" :all}}}}}
+                                     "/db/3/schema/PUBLIC/table/4/"                 {:db {3 {:data {:schemas {"PUBLIC" {4 :all}}}}}}
+                                     "/db/3/schema/PUBLIC/table/4/query/"           {:db {3 {:data {:schemas {"PUBLIC" {4 {:read  :all
+                                                                                                                           :query :all}}}}}}}
+                                     "/db/3/schema/PUBLIC/table/4/query/segmented/" {:db {3 {:data {:schemas {"PUBLIC" {4 {:read  :all
+                                                                                                                           :query :segmented}}}}}}}
+                                     "/db/3/schema/PUBLIC/table/4/read/"            {:db {3 {:data {:schemas {"PUBLIC" {4 {:read :all}}}}}}}}
                                     (into [])
                                     (sort-by first))]
                     (->> groups
@@ -61,9 +60,9 @@
 
 (deftest combines-all-permissions
   (testing "Permision graph includes broadest permissions for all dbs in permission set"
-    (is (= {:db         {3 {:native  :write
-                            :schemas :all}
-                         5 {:schemas {"PUBLIC" {10 {:read :all}}}}}
+    (is (= {:db         {3 {:data {:native  :write
+                                   :schemas :all}}
+                         5 {:data {:schemas {"PUBLIC" {10 {:read :all}}}}}}
             :collection {:root :write
                          1     :read}}
            (parse/permissions->graph #{"/db/3/"
@@ -73,8 +72,8 @@
 
 (deftest block-permissions-test
   (testing "Should parse block permissions entries correctly"
-    (is (= {:db {1 {:schemas :block}
-                 2 {:schemas :block}}}
+    (is (= {:db {1 {:data {:schemas :block}}
+                 2 {:data {:schemas :block}}}}
            (parse/permissions->graph #{"/block/db/1/" "/block/db/2/"}))))
   (testing (str "Block perms and data perms shouldn't exist together at the same time for a given DB, but if they do "
                 "for some  reason, ignore the data perms and return the block perms")
@@ -88,10 +87,10 @@
             :let  [paths ["/block/db/1/" path]]
             paths [paths (reverse paths)]]
       (testing (format "\nPaths = %s" (pr-str paths))
-        (is (= {:db {1 (merge {:schemas :block}
-                              ;; block permissions should only affect the `:schema` key. `/db/1/` also sets the
-                              ;; `:native` key. In reality, it makes no sense to have block perms AND allow native
-                              ;; access but that's not the parsing code's concern.
-                              (when (= path "/db/1/")
-                                {:native :write}))}}
+        (is (= {:db {1 {:data (merge {:schemas :block}
+                                     ;; block permissions should only affect the `:schema` key. `/db/1/` also sets the
+                                     ;; `:native` key. In reality, it makes no sense to have block perms AND allow native
+                                     ;; access but that's not the parsing code's concern.
+                                     (when (= path "/db/1/")
+                                       {:native :write}))}}}
                (parse/permissions->graph paths)))))))

--- a/test/metabase/models/permissions_test.clj
+++ b/test/metabase/models/permissions_test.clj
@@ -546,20 +546,21 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 (defn- test-data-graph [group]
-  (get-in (perms/data-perms-graph) [:groups (u/the-id group) (mt/id) :schemas "PUBLIC"]))
+  (get-in (perms/data-perms-graph) [:groups (u/the-id group) (mt/id) :data :schemas "PUBLIC"]))
 
 (deftest graph-set-partial-permissions-for-table-test
   (testing "Test that setting partial permissions for a table retains permissions for other tables -- #3888"
     (mt/with-temp PermissionsGroup [group]
       (testing "before"
         ;; first, graph permissions only for VENUES
+        (perms/grant-permissions! my-group my-data-path)
         (perms/grant-permissions! group (perms/data-perms-path (mt/id) "PUBLIC" (mt/id :venues)))
         (is (= {(mt/id :venues) :all}
                (test-data-graph group))))
       (testing "after"
         ;; next, grant permissions via `update-graph!` for CATEGORIES as well. Make sure permissions for VENUES are
         ;; retained (#3888)
-        (perms/update-data-perms-graph! [(u/the-id group) (mt/id) :schemas "PUBLIC" (mt/id :categories)] :all)
+        (perms/update-data-perms-graph! [(u/the-id group) (mt/id) :data :schemas "PUBLIC" (mt/id :categories)] :all)
         (is (= {(mt/id :categories) :all, (mt/id :venues) :all}
                (test-data-graph group)))))))
 
@@ -569,11 +570,11 @@
                     Database         [database]
                     Table            [table    {:db_id (u/the-id database)}]]
       ;; try to grant idential permissions to the table twice
-      (perms/update-data-perms-graph! [(u/the-id group) (u/the-id database) :schemas] {"" {(u/the-id table) :all}})
-      (perms/update-data-perms-graph! [(u/the-id group) (u/the-id database) :schemas] {"" {(u/the-id table) :all}})
+      (perms/update-data-perms-graph! [(u/the-id group) (u/the-id database) :data :schemas] {"" {(u/the-id table) :all}})
+      (perms/update-data-perms-graph! [(u/the-id group) (u/the-id database) :data :schemas] {"" {(u/the-id table) :all}})
       ;; now fetch the perms that have been granted
       (is (= {"" {(u/the-id table) :all}}
-             (get-in (perms/data-perms-graph) [:groups (u/the-id group) (u/the-id database) :schemas]))))))
+             (get-in (perms/data-perms-graph) [:groups (u/the-id group) (u/the-id database) :data :schemas]))))))
 
 (deftest metabot-graph-test
   (testing (str "The data permissions graph should never return permissions for the MetaBot, because the MetaBot can "
@@ -598,7 +599,7 @@
              (test-data-graph group))))
 
     (mt/with-temp PermissionsGroup [group]
-      (perms/update-data-perms-graph! [(u/the-id group) (mt/id) :schemas]
+      (perms/update-data-perms-graph! [(u/the-id group) (mt/id) :data :schemas]
                                       {"PUBLIC"
                                        {(mt/id :venues)
                                         {:read :all, :query :segmented}}})
@@ -610,8 +611,9 @@
   (testing "A \"/\" permission grants all dataset permissions"
     (mt/with-temp Database [{db-id :id}]
       (let [{:keys [group_id]} (db/select-one Permissions {:object "/"})]
-        (is (= {db-id {:native  :write
-                       :schemas :all}}
+        (is (= {db-id {:data
+                       {:native  :write
+                        :schemas :all}}}
                (-> (perms/data-perms-graph)
                    (get-in [:groups group_id])
                    (select-keys [db-id]))))))))
@@ -620,7 +622,7 @@
   (testing "Check that validation of DB `:schemas` and `:native` perms doesn't fail if only one of them changes"
     (mt/with-temp Database [{db-id :id}]
       (perms/revoke-data-perms! (group/all-users) db-id)
-      (let [ks [:groups (u/the-id (group/all-users)) db-id]]
+      (let [ks [:groups (u/the-id (group/all-users)) db-id :data]]
         (letfn [(perms []
                   (get-in (perms/data-perms-graph) ks))
                 (set-perms! [new-perms]

--- a/test/metabase/models/permissions_test.clj
+++ b/test/metabase/models/permissions_test.clj
@@ -553,7 +553,6 @@
     (mt/with-temp PermissionsGroup [group]
       (testing "before"
         ;; first, graph permissions only for VENUES
-        (perms/grant-permissions! my-group my-data-path)
         (perms/grant-permissions! group (perms/data-perms-path (mt/id) "PUBLIC" (mt/id :venues)))
         (is (= {(mt/id :venues) :all}
                (test-data-graph group))))


### PR DESCRIPTION
This PR provides some groundwork for supporting [feature-level database permissions](https://www.notion.so/metabase/Add-feature-level-permissions-to-groups-8027685681774932ac7221131f061295) like download and data-model permissions.

Currently, the structure of the permissions graph for data permissions looks something like this:
```
{
  "groups": {
    "1": {
      "1": {
        "native": "write",
        "schemas": "all"
      }
    }
  },
  "revision": 0
}
```

This PR changes the permissions graph structure used on both the backend and frontend, adding a `data` key under each database ID:

```
{
  "groups": {
    "1": {
      "1": {
        "data": {
          "native": "write",
          "schemas": "all"
        }
      }
    }
  },
  "revision": 0
}
```

This lays the groundwork for us adding other keys alongside `data` for other permission types, like `download`.

Overall this PR should be a no-op from a user's POV.

Pursuant to epic #20380