### PR TITLE
E2E tests on master: add permissions and sharing test groups

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -70,6 +70,8 @@ jobs:
           - "downloads"
           - "moderation"
           - "native"
+          - "permissions"
+          - "sharing"
           - "smoketest"
     services:
       maildev:


### PR DESCRIPTION
**Before**

![image](https://user-images.githubusercontent.com/7288/154358866-fe5c509c-5ed7-4009-b041-f4ce3c41a3bc.png)

**After**

There are 4 additional jobs (2 new test groups, for each OSS and EE):

![image](https://user-images.githubusercontent.com/7288/154358930-607e4384-1d88-4885-90fe-26b7ce488bf1.png)
