### PR TITLE
use site-url setting when opening links via JS

### DIFF
--- a/frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx
@@ -2,12 +2,12 @@
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import PropTypes from "prop-types";
-import cx from "classnames";
 import { t } from "ttag";
 import _ from "underscore";
 
 import Question from "metabase-lib/lib/Question";
 
+import Link from "metabase/core/components/Link";
 import { getMetadata } from "metabase/selectors/metadata";
 import Tables from "metabase/entities/tables";
 import GuiQueryEditor from "metabase/query_builder/components/GuiQueryEditor";
@@ -122,13 +122,13 @@ export default class PartialQueryBuilder extends Component {
         >
           <div className="flex align-center mx2 my2">
             <span className="text-bold px3">{previewSummary}</span>
-            <a
+            <Link
+              to={previewUrl}
               data-metabase-event={"Data Model;Preview Click"}
               target={window.OSX ? null : "_blank"}
               rel="noopener noreferrer"
-              className={cx("Button Button--primary")}
-              href={previewUrl}
-            >{t`Preview`}</a>
+              className="Button Button--primary"
+            >{t`Preview`}</Link>
           </div>
         </GuiQueryEditor>
       </div>

--- a/frontend/src/metabase/dashboard/actions.js
+++ b/frontend/src/metabase/dashboard/actions.js
@@ -3,7 +3,6 @@ import { assoc, assocIn, dissocIn, getIn } from "icepick";
 import _ from "underscore";
 
 import { createAction, createThunkAction } from "metabase/lib/redux";
-import { open } from "metabase/lib/dom";
 import { defer } from "metabase/lib/promise";
 import { normalize, schema } from "normalizr";
 
@@ -12,6 +11,7 @@ import Question from "metabase-lib/lib/Question";
 import Dashboards from "metabase/entities/dashboards";
 import Questions from "metabase/entities/questions";
 
+import { openUrl } from "metabase/redux/app";
 import {
   createParameter,
   setParameterName as setParamName,
@@ -40,7 +40,6 @@ import {
   addFields,
   loadMetadataForQueries,
 } from "metabase/redux/metadata";
-import { push } from "react-router-redux";
 
 import {
   DashboardApi,
@@ -997,10 +996,7 @@ export const navigateToNewCardFromDashboard = createThunkAction(
       ? Urls.serializedQuestion(question.card())
       : question.getUrlWithParameters(parametersMappedToCard, parameterValues);
 
-    open(url, {
-      blankOnMetaOrCtrlKey: true,
-      openInSameWindow: url => dispatch(push(url)),
-    });
+    dispatch(openUrl(url));
   },
 );
 

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -112,12 +112,12 @@ export default class Dashboard extends Component {
     });
   }
 
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    if (this.props.dashboardId !== nextProps.dashboardId) {
-      this.loadDashboard(nextProps.dashboardId);
+  componentDidUpdate(prevProps) {
+    if (prevProps.dashboardId !== this.props.dashboardId) {
+      this.loadDashboard(this.props.dashboardId);
     } else if (
-      !_.isEqual(this.props.parameterValues, nextProps.parameterValues) ||
-      !this.props.dashboard
+      !_.isEqual(prevProps.parameterValues, this.props.parameterValues) ||
+      !prevProps.dashboard
     ) {
       this.props.fetchDashboardCardData({ reload: false, clear: true });
     }

--- a/frontend/src/metabase/lib/dom.js
+++ b/frontend/src/metabase/lib/dom.js
@@ -1,5 +1,6 @@
 import _ from "underscore";
 import { isCypressActive } from "metabase/env";
+import MetabaseSettings from "metabase/lib/settings";
 
 // IE doesn't support scrollX/scrollY:
 export const getScrollX = () =>
@@ -297,6 +298,11 @@ export function open(
   } else {
     openInSameWindow(url);
   }
+}
+
+export function openInBlankWindow(url) {
+  const siteUrl = MetabaseSettings.get("site-url");
+  clickLink(url.startsWith("/") ? siteUrl + url : url, true);
 }
 
 function clickLink(url, blank = false) {

--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/normalizeValue.js
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/normalizeValue.js
@@ -3,5 +3,5 @@ export function normalizeValue(value) {
     return value;
   }
 
-  return value ? [value] : [];
+  return value || value === 0 ? [value] : [];
 }

--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/normalizeValue.unit.spec.js
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/normalizeValue.unit.spec.js
@@ -1,26 +1,32 @@
 import { normalizeValue } from "./normalizeValue";
 
-it("returns empty array if value is null", () => {
-  const value = null;
-  const expected = [];
+describe("normalizeValue", () => {
+  it("returns empty array if value is null", () => {
+    const value = null;
+    const expected = [];
 
-  const normalized = normalizeValue(value);
+    const normalized = normalizeValue(value);
 
-  expect(normalized).toEqual(expected);
-});
+    expect(normalized).toEqual(expected);
+  });
 
-it("returns value if value is an array", () => {
-  const value = [1];
+  it("returns value if value is an array", () => {
+    const value = [1];
 
-  const normalized = normalizeValue(value);
+    const normalized = normalizeValue(value);
 
-  expect(normalized).toBe(value);
-});
+    expect(normalized).toBe(value);
+  });
 
-it("returns value as item of array if passed value is not an array", () => {
-  const value = 1;
+  it("returns value as item of array if passed value is not an array", () => {
+    const value = 1;
 
-  const normalized = normalizeValue(value);
+    const normalized = normalizeValue(value);
 
-  expect(normalized).toEqual([value]);
+    expect(normalized).toEqual([value]);
+  });
+
+  it("should correctly normalize a 0 value", () => {
+    expect(normalizeValue(0)).toEqual([0]);
+  });
 });

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -11,7 +11,7 @@ import * as Urls from "metabase/lib/urls";
 
 import { createThunkAction } from "metabase/lib/redux";
 import { push, replace } from "react-router-redux";
-import { setErrorPage } from "metabase/redux/app";
+import { setErrorPage, openUrl } from "metabase/redux/app";
 import { loadMetadataForQueries } from "metabase/redux/metadata";
 import { addUndo } from "metabase/redux/undo";
 
@@ -24,7 +24,7 @@ import {
   serializeCardForUrl,
   cleanCopyCard,
 } from "metabase/lib/card";
-import { open, shouldOpenInBlankWindow } from "metabase/lib/dom";
+import { shouldOpenInBlankWindow } from "metabase/lib/dom";
 import * as Q_DEPRECATED from "metabase/lib/query";
 import { isSameField, isLocalField } from "metabase/lib/query/field_ref";
 import { isAdHocModelQuestion } from "metabase/lib/data-modeling/utils";
@@ -999,7 +999,7 @@ export const navigateToNewCardInsideQB = createThunkAction(
         const card = getCardAfterVisualizationClick(nextCard, previousCard);
         const url = Urls.serializedQuestion(card);
         if (shouldOpenInBlankWindow(url, { blankOnMetaOrCtrlKey: true })) {
-          open(url);
+          dispatch(openUrl(url));
         } else {
           dispatch(onCloseSidebars());
           if (!cardQueryIsEquivalent(previousCard, nextCard)) {

--- a/frontend/src/metabase/redux/app.js
+++ b/frontend/src/metabase/redux/app.js
@@ -1,6 +1,7 @@
-import { combineReducers, handleActions } from "metabase/lib/redux";
+import { push, LOCATION_CHANGE } from "react-router-redux";
 
-import { LOCATION_CHANGE } from "react-router-redux";
+import { combineReducers, handleActions } from "metabase/lib/redux";
+import { openInBlankWindow, shouldOpenInBlankWindow } from "metabase/lib/dom";
 
 export const SET_ERROR_PAGE = "metabase/app/SET_ERROR_PAGE";
 export function setErrorPage(error) {
@@ -10,6 +11,14 @@ export function setErrorPage(error) {
     payload: error,
   };
 }
+
+export const openUrl = (url, options) => dispatch => {
+  if (shouldOpenInBlankWindow(url, options)) {
+    openInBlankWindow(url);
+  } else {
+    dispatch(push(url));
+  }
+};
 
 const errorPage = handleActions(
   {

--- a/frontend/src/metabase/visualizations/lib/action.js
+++ b/frontend/src/metabase/visualizations/lib/action.js
@@ -1,7 +1,7 @@
 /* eslint-disable react/prop-types */
-import { open } from "metabase/lib/dom";
-
 import _ from "underscore";
+
+import { openUrl } from "metabase/redux/app";
 
 export function performAction(action, { dispatch, onChangeCardAndRun }) {
   let didPerform = false;
@@ -15,7 +15,7 @@ export function performAction(action, { dispatch, onChangeCardAndRun }) {
   if (action.url) {
     const url = action.url();
     if (url) {
-      open(url);
+      dispatch(openUrl(url));
       didPerform = true;
     }
   }


### PR DESCRIPTION
Fixes #13602 

We weren't using the `site-url` setting in places where we relied on the `open` function from `metabase/lib/dom`. I've changed it so that intra-app navigation uses the router via `push`. This is nice because it avoids a site reload. In scenarios where we open a new tab/window, I'm appending the `site-url` when `openInBlankWindow` is given a path.

**Testing**

Setup
- Run a proxy so that you can open up an instance of metabase at a url like `localhost:3100/metabase`. I'm using nginx to do this. You can use the config for nginx found in this PR: https://github.com/metabase/metabase/pull/4740
- Go to `/admin/settings/general` and update the site url input to `localhost:3100/metabase`

Click behavior

Question link:

https://user-images.githubusercontent.com/13057258/154768273-514e1453-661e-4ddd-8f37-6f2488d2cb6d.mov

Dashboard link:

https://user-images.githubusercontent.com/13057258/154768583-d16e3116-62a5-441f-9574-afff81e1e593.mov




Clicking a dashcard title while holding down ctrl or cmd opens the correct link:

https://user-images.githubusercontent.com/13057258/154767725-df4c268c-342a-478f-bf16-2c27de81b2bb.mov



QB viz click -- cmd + clicking on a drilldown option opens the correct link:

https://user-images.githubusercontent.com/13057258/154767664-e472c876-49e8-4f5e-80d7-4ef8f4c34660.mov


