### PR TITLE
Support new permission graph structure

### DIFF
--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions.unit.spec.js
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions.unit.spec.js
@@ -8,35 +8,47 @@ const initialPermissions = {
   1: {
     // Sample database
     1: {
-      native: "write",
-      schemas: "all",
+      data: {
+        native: "write",
+        schemas: "all",
+      },
     },
     // Imaginary multi-schema
     2: {
-      native: "write",
-      schemas: "all",
+      data: {
+        native: "write",
+        schemas: "all",
+      },
     },
     // Imaginary schemaless
     3: {
-      native: "write",
-      schemas: "all",
+      data: {
+        native: "write",
+        schemas: "all",
+      },
     },
   },
   2: {
     // Sample database
     1: {
-      native: "none",
-      schemas: "none",
+      data: {
+        native: "none",
+        schemas: "none",
+      },
     },
     // Imaginary multi-schema
     2: {
-      native: "none",
-      schemas: "none",
+      data: {
+        native: "none",
+        schemas: "none",
+      },
     },
     // Imaginary schemaless
     3: {
-      native: "none",
-      schemas: "none",
+      data: {
+        native: "none",
+        schemas: "none",
+      },
     },
   },
 };

--- a/frontend/src/metabase/lib/permissions.js
+++ b/frontend/src/metabase/lib/permissions.js
@@ -60,11 +60,16 @@ export function updatePermission(permissions, groupId, path, value, entityIds) {
 }
 
 export const getSchemasPermission = (permissions, groupId, { databaseId }) => {
-  return getPermission(permissions, groupId, [databaseId, "schemas"], true);
+  return getPermission(
+    permissions,
+    groupId,
+    [databaseId, "data", "schemas"],
+    true,
+  );
 };
 
 export const getNativePermission = (permissions, groupId, { databaseId }) => {
-  return getPermission(permissions, groupId, [databaseId, "native"]);
+  return getPermission(permissions, groupId, [databaseId, "data", "native"]);
 };
 
 export const getTablesPermission = (
@@ -77,7 +82,7 @@ export const getTablesPermission = (
     return getPermission(
       permissions,
       groupId,
-      [databaseId, "schemas", schemaName || ""],
+      [databaseId, "data", "schemas", schemaName || ""],
       true,
     );
   } else {
@@ -98,7 +103,7 @@ export const getFieldsPermission = (
     return getPermission(
       permissions,
       groupId,
-      [databaseId, "schemas", schemaName || "", tableId],
+      [databaseId, "data", "schemas", schemaName || "", tableId],
       true,
     );
   } else {
@@ -268,7 +273,7 @@ export function updateFieldsPermission(
   permissions = updatePermission(
     permissions,
     groupId,
-    [databaseId, "schemas", schemaName, tableId],
+    [databaseId, "data", "schemas", schemaName, tableId],
     PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_PERMISSION_VALUE[value] || value,
   );
 
@@ -295,7 +300,7 @@ export function updateTablesPermission(
   permissions = updatePermission(
     permissions,
     groupId,
-    [databaseId, "schemas", schemaName || ""],
+    [databaseId, "data", "schemas", schemaName || ""],
     value,
     tableIds,
   );
@@ -329,7 +334,7 @@ export function updateSchemasPermission(
   return updatePermission(
     permissions,
     groupId,
-    [databaseId, "schemas"],
+    [databaseId, "data", "schemas"],
     value,
     schemaNamesOrNoSchema,
   );
@@ -352,7 +357,12 @@ export function updateNativePermission(
       metadata,
     );
   }
-  return updatePermission(permissions, groupId, [databaseId, "native"], value);
+  return updatePermission(
+    permissions,
+    groupId,
+    [databaseId, "data", "native"],
+    value,
+  );
 }
 
 function deleteIfEmpty(object, key) {


### PR DESCRIPTION
### Support new permission graph structure

Before
```
{
  "groups": {
    "1": {
      "1": {
        "native": "write",
        "schemas": "all"
      }
    }
  },
  "revision": 0
}
```

After
```
{
  "groups": {
    "1": {
      "1": {
        "data": {
          "native": "write",
          "schemas": "all"
        }
      }
    }
  },
  "revision": 0
}

```