### PR TITLE
Repro #20560: Shouldn't display filter action menu when clicking on a value in single-record view

### DIFF
--- a/frontend/test/metabase/scenarios/visualizations/object_detail.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/object_detail.cy.spec.js
@@ -1,4 +1,10 @@
-import { restore, popover, openPeopleTable } from "__support__/e2e/cypress";
+import {
+  restore,
+  popover,
+  openPeopleTable,
+  POPOVER_ELEMENT,
+} from "__support__/e2e/cypress";
+
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
@@ -104,7 +110,7 @@ describe("scenarios > question > object details", () => {
     cy.url().should("contain", "objectId=2");
 
     cy.findByText("Domenica Williamson").click();
-    popover().should("not.exist");
+    cy.get(POPOVER_ELEMENT).should("not.exist");
   });
 });
 

--- a/frontend/test/metabase/scenarios/visualizations/object_detail.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/object_detail.cy.spec.js
@@ -1,9 +1,4 @@
-import {
-  restore,
-  popover,
-  openPeopleTable,
-  POPOVER_ELEMENT,
-} from "__support__/e2e/cypress";
+import { restore, popover, openPeopleTable } from "__support__/e2e/cypress";
 
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
@@ -110,7 +105,9 @@ describe("scenarios > question > object details", () => {
     cy.url().should("contain", "objectId=2");
 
     cy.findByText("Domenica Williamson").click();
-    cy.get(POPOVER_ELEMENT).should("not.exist");
+    // Popover is blocking the city. If it renders, Cypress will not be able to click on "Searsboro" and the test will fail.
+    // Unfortunately, asserting that the popover does not exist will give us a false positive result.
+    cy.findByText("Searsboro").click();
   });
 });
 

--- a/frontend/test/metabase/scenarios/visualizations/object_detail.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/object_detail.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, popover } from "__support__/e2e/cypress";
+import { restore, popover, openPeopleTable } from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
@@ -93,6 +93,18 @@ describe("scenarios > question > object details", () => {
     cy.contains("Reviews")
       .parent()
       .contains("8");
+  });
+
+  it.skip("should not offer drill-through on the object detail records (metabase#20560)", () => {
+    openPeopleTable({ limit: 2 });
+
+    cy.get(".Table-ID")
+      .contains("2")
+      .click();
+    cy.url().should("contain", "objectId=2");
+
+    cy.findByText("Domenica Williamson").click();
+    popover().should("not.exist");
   });
 });
 


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #20560 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/visualizations/object_detail.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/154494873-f6f713ce-5c1c-4a07-ab9e-6bb4fb0e691a.png)

