### PR TITLE
Repro #20551: Filter dropdown only allows filtering on "starts with"

### DIFF
--- a/frontend/test/metabase/scenarios/question/reproductions/20551-filter-starts-with.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/20551-filter-starts-with.cy.spec.js
@@ -1,0 +1,26 @@
+import { restore, openProductsTable, filter } from "__support__/e2e/cypress";
+
+describe("issue 20551", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should allow filtering with includes, rather than starts with (metabase#20551)", () => {
+    openProductsTable({ mode: "notebook" });
+    filter({ mode: "notebook" });
+    cy.findByText("Category").click();
+
+    // Make sure input field is auto-focused
+    cy.focused()
+      .should("have.attr", "placeholder", "Search the list")
+      .type("i");
+
+    // All categories that contain `i`
+    cy.findByText("Doohickey");
+    cy.findByText("Gizmo");
+    cy.findByText("Widget");
+
+    cy.findByText("Gadget").should("not.exist");
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #20551 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/question/reproductions/20551-filter-starts-with.cy.spec.js`
- All tests should pass

### Additional notes:
- The bug was fixed in #20561

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/154478519-ed4b07f8-0e71-43f8-988e-912a3a20d2b1.png)

