### PR TITLE
Repro #20548: Changing Y-axis order can cause duplicate legends when modifying metrics after 

### DIFF
--- a/frontend/test/metabase/scenarios/visualizations/reproductions/20548-bar-duplicate-y-axis-after-changing-metrics.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/reproductions/20548-bar-duplicate-y-axis-after-changing-metrics.cy.spec.js
@@ -1,0 +1,75 @@
+import { restore, summarize, popover, sidebar } from "__support__/e2e/cypress";
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
+const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
+
+const questionDetails = {
+  name: "20548",
+  query: {
+    "source-table": PRODUCTS_ID,
+    aggregation: [["sum", ["field", PRODUCTS.PRICE, null]], ["count"]],
+    breakout: [["field", PRODUCTS.CATEGORY, null]],
+  },
+  display: "bar",
+  // We are reversing the order of metrics via API
+  visualization_settings: {
+    "graph.metrics": ["count", "sum"],
+    "graph.dimensions": ["CATEGORY"],
+  },
+};
+
+describe.skip("issue 20548", () => {
+  beforeEach(() => {
+    cy.intercept("POST", "/api/dataset").as("dataset");
+
+    restore();
+    cy.signInAsAdmin();
+
+    cy.createQuestion(questionDetails, { visitQuestion: true });
+    summarize();
+  });
+
+  it("should not display duplicate Y-axis after modifying/reordering metrics (metabase#20548)", () => {
+    removeAggregationItem("Count");
+    cy.get(".bar").should("have.length", 4);
+
+    addAggregationItem("Count");
+    cy.get(".bar").should("have.length", 8);
+
+    // Although the test already fails on the previous step, let's add some more assertions to prevent future regressions
+    assertOnLegendItemFrequency("Count", 1);
+    assertOnLegendItemFrequency("Sum of Price", 1);
+
+    cy.findByTestId("viz-settings-button").click();
+    // Implicit assertion - it would fail if it finds more than one "Count" in the sidebar
+    sidebar().findByDisplayValue("Count");
+  });
+});
+
+function removeAggregationItem(item) {
+  cy.findAllByTestId("aggregation-item")
+    .contains(item)
+    .siblings(".Icon-close")
+    .click();
+
+  cy.wait("@dataset");
+}
+
+function addAggregationItem(item) {
+  cy.findByTestId("add-aggregation-button").click();
+  popover()
+    .contains(item)
+    .click();
+
+  cy.wait("@dataset");
+}
+
+/**
+ * @param {string} item
+ * @param {number} frequency
+ */
+function assertOnLegendItemFrequency(item, frequency) {
+  cy.findAllByTestId("legend-item")
+    .contains(item)
+    .should("have.length", frequency);
+}


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #20548 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/visualizations/reproductions/20548-bar-duplicate-y-axis-after-changing-metrics.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/154506121-8492ef6e-7daf-4e6e-8c06-2d72fda88afa.png)

