### PR TITLE
Repro #20517: Removing or adding column descriptions to metadata of Models results in "failed save"

### DIFF
--- a/frontend/test/metabase/scenarios/models/reproductions/20517-edit-metadata-empty-description.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/reproductions/20517-edit-metadata-empty-description.cy.spec.js
@@ -1,0 +1,29 @@
+import { restore } from "__support__/e2e/cypress";
+
+describe.skip("issue 20517", () => {
+  beforeEach(() => {
+    cy.intercept("PUT", "/api/card/1").as("updateCard");
+
+    restore();
+    cy.signInAsAdmin();
+
+    cy.request("PUT", "/api/card/1", { dataset: true });
+  });
+
+  it("should be able to save metadata changes with empty description (metabase#20517)", () => {
+    cy.visit("/model/1/metadata");
+
+    cy.findByLabelText("Description")
+      .clear()
+      .blur();
+
+    cy.button("Save changes").click();
+
+    cy.wait("@updateCard").then(({ response: { body, statusCode } }) => {
+      expect(statusCode).not.to.eq(400);
+      expect(body.errors).not.to.exist;
+    });
+
+    cy.button("Save failed").should("not.exist");
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #20517

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/models/reproductions/20517-edit-metadata-empty-description.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/154522442-a4b6053d-350a-4b79-b6a8-1a5d4c651fa7.png)

