### PR TITLE
Accept UnsavedCard type in Question class

### DIFF
--- a/frontend/src/metabase-lib/lib/Question.ts
+++ b/frontend/src/metabase-lib/lib/Question.ts
@@ -61,7 +61,8 @@ import {
   ParameterValues,
 } from "metabase-types/types/Parameter";
 import {
-  Card as CardObject,
+  Card as SavedCardObject,
+  UnsavedCard as UnsavedCardObject,
   DatasetQuery,
   VisualizationSettings,
 } from "metabase-types/types/Card";
@@ -75,7 +76,11 @@ import {
   ALERT_TYPE_TIMESERIES_GOAL,
 } from "metabase-lib/lib/Alert";
 import { utf8_to_b64url } from "metabase/lib/encoding";
+
 type QuestionUpdateFn = (q: Question) => Promise<void> | null | undefined;
+
+type CardObject = SavedCardObject | UnsavedCardObject;
+
 /**
  * This is a wrapper around a question/card object, which may contain one or more Query objects
  */

--- a/frontend/src/metabase-lib/lib/Question.ts
+++ b/frontend/src/metabase-lib/lib/Question.ts
@@ -61,8 +61,7 @@ import {
   ParameterValues,
 } from "metabase-types/types/Parameter";
 import {
-  Card as SavedCardObject,
-  UnsavedCard as UnsavedCardObject,
+  Card as CardObject,
   DatasetQuery,
   VisualizationSettings,
 } from "metabase-types/types/Card";
@@ -78,8 +77,6 @@ import {
 import { utf8_to_b64url } from "metabase/lib/encoding";
 
 type QuestionUpdateFn = (q: Question) => Promise<void> | null | undefined;
-
-type CardObject = SavedCardObject | UnsavedCardObject;
 
 /**
  * This is a wrapper around a question/card object, which may contain one or more Query objects

--- a/frontend/src/metabase-types/types/Card.ts
+++ b/frontend/src/metabase-types/types/Card.ts
@@ -13,24 +13,21 @@ export type UnsavedCard = {
   display: string;
   visualization_settings: VisualizationSettings;
   parameters?: Array<Parameter>;
-  original_card_id?: CardId;
-};
-
-export type Card = {
-  id: CardId;
-  name?: string;
-  description?: string;
-  dataset?: boolean;
-  dataset_query: DatasetQuery;
-  display: string;
-  visualization_settings: VisualizationSettings;
-  parameters?: Array<Parameter>;
-  can_write: boolean;
-  public_uuid: string;
 
   // Not part of the card API contract, a field used by query builder for showing lineage
   original_card_id?: CardId;
 };
+
+export type SavedCard = UnsavedCard & {
+  id: CardId;
+  name?: string;
+  description?: string;
+  dataset?: boolean;
+  can_write: boolean;
+  public_uuid: string;
+};
+
+export type Card = SavedCard | UnsavedCard;
 
 export type StructuredDatasetQuery = {
   type: "query";

--- a/frontend/src/metabase/lib/data-modeling/utils.ts
+++ b/frontend/src/metabase/lib/data-modeling/utils.ts
@@ -4,7 +4,11 @@ import Database from "metabase-lib/lib/metadata/Database";
 import { isStructured } from "metabase/lib/query";
 import { getQuestionVirtualTableId } from "metabase/lib/saved-questions";
 import { TemplateTag } from "metabase-types/types/Query";
-import { Card, StructuredDatasetQuery } from "metabase-types/types/Card";
+import {
+  Card as CardObject,
+  CardId,
+  StructuredDatasetQuery,
+} from "metabase-types/types/Card";
 
 export function isSupportedTemplateTagForModel(tag: TemplateTag) {
   return tag.type === "card";
@@ -29,6 +33,11 @@ export function checkCanBeModel(question: Question) {
     .templateTags()
     .every(isSupportedTemplateTagForModel);
 }
+
+type Card = CardObject & {
+  id?: CardId;
+  dataset?: boolean;
+};
 
 export function isAdHocModelQuestionCard(card: Card, originalCard?: Card) {
   if (!originalCard || !isStructured(card.dataset_query)) {


### PR DESCRIPTION
Currently, `Question` only accepts the `Card` type with required `id` and `name` properties. This doesn't allow to create ad-hoc questions programmatically in TypeScript files, which is sometimes required in unit tests