### PR TITLE
docs - elaborate on dashboard edit options

### DIFF
--- a/docs/users-guide/interactive-dashboards.md
+++ b/docs/users-guide/interactive-dashboards.md
@@ -13,7 +13,16 @@ To configure this interactivity, you'll use the **click behavior** option on a d
 
 ### Customizing click behavior
 
-From your dashboard, click on the **pencil** icon to enter dashboard edit mode. Hover over the card containing the question you want to customize. Metabase will display a menu at the top right of the card. Select the **Click behavior** option (the icon with the mouse cursor clicking on a card).
+From your dashboard, first click on the **pencil** icon to enter dashboard edit mode. 
+
+If you hover over the card that contains question you want to customize, Metabase will display a menu at the top right of that card containing these options, from left to right: 
+
+- **Visualization options**: This icon looks like a painter's palette.
+- **Click behavior**: This is the icon with the mouse cursor clicking on a card.
+- **Add series**: If your question has a visualization to which you can add an [additional series](09-multi-series-charting) (like a line or bar chart), you'll see this icon as a **+** next to a small representation of that chart type. Not all cards will show this option.
+- **Remove**: This icon is an **X**. Selecting this will remove your question from the dashboard.
+
+Select the **Click behavior** option. 
 
 ![Click behavior icon](images/interactive-dashboards/click-behavior-icon.png)
 


### PR DESCRIPTION
Lists the four options when you hover over a card (in the docs for click behavior/interactive dashboards); tried to make those instructions a bit more clear.