### PR TITLE
Sharing E2E tests: ensure that the question is fully loaded

### DIFF
--- a/frontend/test/metabase/scenarios/sharing/alert/alert-permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/alert/alert-permissions.cy.spec.js
@@ -9,6 +9,9 @@ describe("scenarios > alert > alert permissions", () => {
 
     setupSMTP();
 
+    cy.intercept("/api/card").as("card");
+    cy.intercept("/api/database").as("database");
+
     // Create alert as admin
     cy.visit("/question/1");
     createBasicAlert({ firstAlert: true });
@@ -97,6 +100,9 @@ describe("scenarios > alert > alert permissions", () => {
 });
 
 function createBasicAlert({ firstAlert, includeNormal } = {}) {
+  cy.wait("@card");
+  cy.wait("@database");
+
   cy.get(".Icon-bell").click();
 
   if (firstAlert) {


### PR DESCRIPTION
This gives the test a better chance to wait until the bell icon appears (and then assert for it).

To verify manually: `yarn test-visual-open` and choose `sharing/alert/alert-permissions.cy.spec.js`.

**Before**

Once a while, you'll spot this failure (or similar ones):

![scenarios  alert  alert permissions -- should let you see all created alerts -- before all hook (failed)](https://user-images.githubusercontent.com/7288/154620969-f311f9a7-22cc-4dad-bc0b-1fad0009a4d5.png)

**After**

That shall not happen again.
