### PR TITLE
Visual repro #20552: Static viz Y-axis values are rounded, which are confusing for low values

### DIFF
--- a/frontend/test/metabase-visual/static-visualizations/reproductions/20552-20554-static-viz-rounding-y-axis-values-no-data-points.cy.spec.js
+++ b/frontend/test/metabase-visual/static-visualizations/reproductions/20552-20554-static-viz-rounding-y-axis-values-no-data-points.cy.spec.js
@@ -16,7 +16,7 @@ const FULL_NAME = `${first_name} ${last_name}`;
 const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
 
 const questionDetails = {
-  name: "20552",
+  name: "20552-20554",
   query: {
     "source-table": PRODUCTS_ID,
     aggregation: [["avg", ["field", PRODUCTS.RATING, null]]],
@@ -26,13 +26,14 @@ const questionDetails = {
   visualization_settings: {
     "graph.dimensions": ["CATEGORY"],
     "graph.metrics": ["avg"],
+    "graph.show_values": true,
   },
 };
 
-const dashboardName = "20552D";
+const dashboardName = "20552-20554D";
 const dashboardDetails = { name: dashboardName };
 
-describe.skip("issue 20552", () => {
+describe.skip("issue 20552/20554", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
@@ -40,7 +41,7 @@ describe.skip("issue 20552", () => {
     setupSMTP();
   });
 
-  it("shouldn't round Y-axis values (metabase#20552)", () => {
+  it("shouldn't round Y-axis values (metabase#20552) and should show data point values (metabase#20554)", () => {
     cy.createQuestionAndDashboard({ questionDetails, dashboardDetails }).then(
       ({ body: { dashboard_id } }) => {
         cy.visit(`/dashboard/${dashboard_id}`);

--- a/frontend/test/metabase-visual/static-visualizations/reproductions/20552-static-viz-rounding-y-axis-values.cy.spec.js
+++ b/frontend/test/metabase-visual/static-visualizations/reproductions/20552-static-viz-rounding-y-axis-values.cy.spec.js
@@ -23,6 +23,10 @@ const questionDetails = {
     breakout: [["field", PRODUCTS.CATEGORY, null]],
   },
   display: "bar",
+  visualization_settings: {
+    "graph.dimensions": ["CATEGORY"],
+    "graph.metrics": ["avg"],
+  },
 };
 
 const dashboardName = "20552D";

--- a/frontend/test/metabase-visual/static-visualizations/reproductions/20552-static-viz-rounding-y-axis-values.cy.spec.js
+++ b/frontend/test/metabase-visual/static-visualizations/reproductions/20552-static-viz-rounding-y-axis-values.cy.spec.js
@@ -1,0 +1,52 @@
+import {
+  restore,
+  setupSMTP,
+  sendSubscriptionsEmail,
+  openEmailPage,
+} from "__support__/e2e/cypress";
+
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+import { USERS } from "__support__/e2e/cypress_data";
+
+const {
+  admin: { first_name, last_name },
+} = USERS;
+const FULL_NAME = `${first_name} ${last_name}`;
+
+const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
+
+const questionDetails = {
+  name: "20552",
+  query: {
+    "source-table": PRODUCTS_ID,
+    aggregation: [["avg", ["field", PRODUCTS.RATING, null]]],
+    breakout: [["field", PRODUCTS.CATEGORY, null]],
+  },
+  display: "bar",
+};
+
+const dashboardName = "20552D";
+const dashboardDetails = { name: dashboardName };
+
+describe.skip("issue 20552", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    setupSMTP();
+  });
+
+  it("shouldn't round Y-axis values (metabase#20552)", () => {
+    cy.createQuestionAndDashboard({ questionDetails, dashboardDetails }).then(
+      ({ body: { dashboard_id } }) => {
+        cy.visit(`/dashboard/${dashboard_id}`);
+      },
+    );
+
+    sendSubscriptionsEmail(FULL_NAME);
+
+    openEmailPage(dashboardName).then(() => {
+      cy.percySnapshot();
+    });
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Creates a visual repro for #20552
- Creates a visual repro for #20554


### How to test this manually?
- `yarn test-visual-open`
- `frontend/test/metabase-visual/static-visualizations/reproductions/20552-static-viz-rounding-y-axis-values.cy.spec.js`
- Observe the Cypress GUI and notice the rounding for the Y-axis values (see the screenshot)
- Also, from that same screenshot it is clear that data point values (#20554) are not being rendered

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Visually inspect and make sure the values are not rounded anymore
- Merge the test together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/154692829-1e0fca20-c67e-4d24-92d0-3aca75482cbd.png)

How the graph (properly) looks like in the dashboard before sending it as a subscription:
![image](https://user-images.githubusercontent.com/31325167/154693073-46c04376-7145-40ae-9fd6-cc78f2e500fd.png)
