### PR TITLE
Visual repro #20559: Static viz multi-series shows two Y-axes

### DIFF
--- a/frontend/test/metabase-visual/static-visualizations/reproductions/20559-multi-series-two-Y-axes.cy.spec.js
+++ b/frontend/test/metabase-visual/static-visualizations/reproductions/20559-multi-series-two-Y-axes.cy.spec.js
@@ -32,6 +32,10 @@ const questionDetails = {
     ],
   },
   display: "line",
+  visualization_settings: {
+    "graph.dimensions": ["CREATED_AT", "CATEGORY"],
+    "graph.metrics": ["sum"],
+  },
 };
 
 const dashboardName = "20559D";

--- a/frontend/test/metabase-visual/static-visualizations/reproductions/20559-multi-series-two-Y-axes.cy.spec.js
+++ b/frontend/test/metabase-visual/static-visualizations/reproductions/20559-multi-series-two-Y-axes.cy.spec.js
@@ -1,0 +1,61 @@
+import {
+  restore,
+  setupSMTP,
+  sendSubscriptionsEmail,
+  openEmailPage,
+} from "__support__/e2e/cypress";
+
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+import { USERS } from "__support__/e2e/cypress_data";
+
+const {
+  admin: { first_name, last_name },
+} = USERS;
+const FULL_NAME = `${first_name} ${last_name}`;
+
+const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
+
+const questionDetails = {
+  name: "20559",
+  query: {
+    "source-table": PRODUCTS_ID,
+    aggregation: [["sum", ["field", PRODUCTS.PRICE, null]]],
+    breakout: [
+      [
+        "field",
+        PRODUCTS.CREATED_AT,
+        {
+          "temporal-unit": "year",
+        },
+      ],
+      ["field", PRODUCTS.CATEGORY, null],
+    ],
+  },
+  display: "line",
+};
+
+const dashboardName = "20559D";
+const dashboardDetails = { name: dashboardName };
+
+describe.skip("issue 20559", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    setupSMTP();
+  });
+
+  it("shouldn show only one Y-axis for multi-series visualization (metabase#20559)", () => {
+    cy.createQuestionAndDashboard({ questionDetails, dashboardDetails }).then(
+      ({ body: { dashboard_id } }) => {
+        cy.visit(`/dashboard/${dashboard_id}`);
+      },
+    );
+
+    sendSubscriptionsEmail(FULL_NAME);
+
+    openEmailPage(dashboardName).then(() => {
+      cy.percySnapshot();
+    });
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Creates a visual repro for #20559

### How to test this manually?
- `yarn test-visual-open`
- `frontend/test/metabase-visual/static-visualizations/reproductions/20559-multi-series-two-Y-axes.cy.spec.js`
- Observe the Cypress GUI and notice that the two Y-axes are being rendered (see the screenshot below)

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Visually inspect and make sure the values are not rounded anymore
- Merge the test together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/154686182-7eff9808-802b-4481-ba08-7dd79be8f8e1.png)

