### PR TITLE
Repro #20627: Nested queries with long Data Model names causes failing query with incorrect aliasing

### DIFF
--- a/frontend/test/metabase/scenarios/question/reproductions/20627-nested-long-names-wrong-aliases.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/20627-nested-long-names-wrong-aliases.cy.spec.js
@@ -1,0 +1,60 @@
+import {
+  restore,
+  openOrdersTable,
+  popover,
+  enterCustomColumnDetails,
+  visualize,
+} from "__support__/e2e/cypress";
+
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
+const { ORDERS, PRODUCTS_ID } = SAMPLE_DATABASE;
+
+const newColumnName = "Product ID with a very long name";
+const newTableName = "Products with a very long name";
+
+describe.skip("issue 20627", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    renameColumn(ORDERS.PRODUCT_ID, newColumnName);
+    renameTable(PRODUCTS_ID, newTableName);
+  });
+
+  it("nested queries should handle long column and/or table names (metabase#20627)", () => {
+    openOrdersTable({ mode: "notebook" });
+
+    cy.findByText("Join data").click();
+    cy.findByText(newTableName).click();
+
+    cy.findByText("Summarize").click();
+    cy.findByText("Count of rows").click();
+
+    cy.findByText("Pick a column to group by").click();
+    popover().within(() => {
+      cy.contains(newTableName).click();
+
+      cy.findByText("Category").click();
+    });
+
+    cy.findByText("Custom column").click();
+    enterCustomColumnDetails({ formula: "1 + 1", name: "Math" });
+    cy.button("Done").click();
+
+    visualize();
+
+    cy.get(".cellData")
+      .should("contain", "Math")
+      .and("contain", "Doohickey")
+      .and("contain", "3,976");
+  });
+});
+
+function renameColumn(columnId, name) {
+  cy.request("PUT", `/api/field/${columnId}`, { display_name: name });
+}
+
+function renameTable(tableId, name) {
+  cy.request("PUT", `/api/table/${tableId}`, { display_name: name });
+}


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #20627 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/question/reproductions/20627-nested-long-names-wrong-aliases.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/154717583-31a329b6-0c61-4d96-87cd-7bb3ba4b8ce9.png)

How this worked in 41.6?
![image](https://user-images.githubusercontent.com/31325167/154717661-dfaf8c67-a00d-4fee-a8a0-ef0e5ab49c99.png)

