### PR TITLE
permissions table ui fixes

### DIFF
--- a/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditor.styled.js
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditor.styled.js
@@ -3,6 +3,6 @@ import styled from "@emotion/styled";
 export const PermissionsEditorRoot = styled.div`
   flex-grow: 1;
   position: relative;
-  overflow: hidden;
+  overflow: auto;
   padding: 1rem 0 2rem 0;
 `;

--- a/frontend/src/metabase/admin/permissions/components/PermissionsSidebar/PermissionsSidebar.styled.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsSidebar/PermissionsSidebar.styled.jsx
@@ -46,6 +46,7 @@ export const BackButton = styled.button`
   padding: 0.5rem;
   cursor: pointer;
   transition: color 200ms;
+  text-align: left;
 
   &:hover {
     color: ${color("accent7")};

--- a/frontend/src/metabase/admin/permissions/components/PermissionsTable/PermissionsTable.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsTable/PermissionsTable.jsx
@@ -11,7 +11,6 @@ import {
   PermissionsTableRow,
   PermissionsTableCell,
   PermissionTableHeaderCell,
-  EntityNameCell,
   EntityNameLink,
   EntityName,
   HintIcon,
@@ -88,7 +87,7 @@ export function PermissionsTable({
           {entities.map(entity => {
             return (
               <PermissionsTableRow key={entity.id}>
-                <EntityNameCell>
+                <PermissionsTableCell>
                   {entity.canSelect ? (
                     <EntityNameLink onClick={() => onSelect(entity)}>
                       {entity.name}
@@ -102,7 +101,7 @@ export function PermissionsTable({
                       <HintIcon />
                     </Tooltip>
                   )}
-                </EntityNameCell>
+                </PermissionsTableCell>
 
                 {entity.permissions.map(permission => {
                   return (

--- a/frontend/src/metabase/admin/permissions/components/PermissionsTable/PermissionsTable.styled.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsTable/PermissionsTable.styled.jsx
@@ -49,15 +49,12 @@ export const PermissionsTableRow = styled.tr`
   border-bottom: 1px solid ${alpha(color("border"), 0.5)};
 `;
 
-export const EntityNameCell = styled(PermissionsTableCell)`
-  align-items: center;
-`;
-
-export const EntityName = styled.div`
+export const EntityName = styled.span`
   font-weight: 700;
 `;
 
 export const EntityNameLink = styled(Link)`
+  display: inline;
   font-weight: 700;
   text-decoration: underline;
   color: ${color("admin-navbar")};

--- a/frontend/src/metabase/components/tree/TreeNode.styled.jsx
+++ b/frontend/src/metabase/components/tree/TreeNode.styled.jsx
@@ -61,6 +61,7 @@ ExpandToggleIcon.defaultProps = {
 };
 
 export const NameContainer = styled.div`
+  word-break: break-word;
   padding: 0.5rem 0.5rem 0.5rem 0.25rem;
   flex: 1;
 `;


### PR DESCRIPTION
A set of UI fixes of the [permissions table](http://localhost:3000/admin/permissions/data/group)

### Before
<img width="662" alt="Screenshot 2022-02-19 at 00 34 14" src="https://user-images.githubusercontent.com/14301985/154778327-39bd89a1-7116-4200-ad61-03ff080a59c6.png">

### After
<img width="659" alt="Screenshot 2022-02-19 at 00 32 53" src="https://user-images.githubusercontent.com/14301985/154778326-0cd53ded-3bee-4173-b789-db29600d4787.png">

4) Also, fixes missing vertical scroll for tables with many rows

