### PR TITLE
Modify expression dimension to support subdimensions

### DIFF
--- a/frontend/src/metabase-lib/lib/Dimension.ts
+++ b/frontend/src/metabase-lib/lib/Dimension.ts
@@ -25,6 +25,7 @@ import { DATETIME_UNITS, formatBucketing } from "metabase/lib/query_time";
 import Aggregation from "./queries/structured/Aggregation";
 import StructuredQuery from "./queries/StructuredQuery";
 import { infer, MONOTYPE } from "metabase/lib/expressions/typeinferencer";
+import { isa } from "cljs/metabase.types";
 
 /**
  * A dimension option returned by the query_metadata API
@@ -1130,12 +1131,21 @@ const isFieldDimension = dimension => dimension instanceof FieldDimension;
 export class ExpressionDimension extends Dimension {
   _expressionName: ExpressionName;
 
+  /**
+   * Whether `clause` is an array, and a valid `:expression` clause
+   */
+  static isExpressionClause(clause): boolean {
+    return (
+      Array.isArray(clause) && clause.length >= 2 && clause[0] === "expression"
+    );
+  }
+
   static parseMBQL(
     mbql: any,
     metadata?: Metadata | null | undefined,
     query?: StructuredQuery | null | undefined,
   ): Dimension | null | undefined {
-    if (Array.isArray(mbql) && mbql[0] === "expression") {
+    if (ExpressionDimension.isExpressionClause(mbql)) {
       const [expressionName, options] = mbql.slice(1);
       return new ExpressionDimension(expressionName, options, metadata, query);
     }
@@ -1164,6 +1174,26 @@ export class ExpressionDimension extends Dimension {
     }
 
     Object.freeze(this);
+  }
+
+  isEqual(somethingElse) {
+    if (isExpressionDimension(somethingElse)) {
+      return (
+        somethingElse._expressionName === this._expressionName &&
+        _.isEqual(somethingElse._options, this._options)
+      );
+    }
+
+    if (ExpressionDimension.isExpressionClause(somethingElse)) {
+      const dimension = Expression.parseMBQL(
+        somethingElse,
+        this._metadata,
+        this._query,
+      );
+      return dimension ? this.isEqual(dimension) : false;
+    }
+
+    return false;
   }
 
   mbql(): ExpressionReference {
@@ -1229,6 +1259,18 @@ export class ExpressionDimension extends Dimension {
       semantic_type = base_type;
     }
 
+    const subsOptions = getOptions(semantic_type ? semantic_type : base_type);
+    const dimension_options =
+      subsOptions && Array.isArray(subsOptions)
+        ? subsOptions.map(({ name, options }) => {
+            return {
+              name,
+              type: base_type,
+              mbql: ["expression", null, options],
+            };
+          })
+        : null;
+
     return new Field({
       id: this.mbql(),
       name: this.name(),
@@ -1237,6 +1279,7 @@ export class ExpressionDimension extends Dimension {
       semantic_type,
       query,
       table,
+      dimension_options,
     });
   }
 
@@ -1244,7 +1287,82 @@ export class ExpressionDimension extends Dimension {
     const field = this.field();
     return field ? field.icon() : "unknown";
   }
+
+  _dimensionForOption(option): ExpressionDimension {
+    const dimension = option.mbql
+      ? ExpressionDimension.parseMBQL(option.mbql, this._metadata, this._query)
+      : this;
+
+    const additionalProperties = {
+      _expressionName: this._expressionName,
+    };
+
+    if (option.name) {
+      additionalProperties._subDisplayName = option.name;
+      additionalProperties._subTriggerDisplayName = option.name;
+    }
+
+    return new ExpressionDimension(
+      dimension._expressionName,
+      dimension._options,
+      this._metadata,
+      this._query,
+      additionalProperties,
+    );
+  }
+
+  /**
+   * Return a copy of this ExpressionDimension that excludes `options`.
+   */
+  withoutOptions(...options: string[]): ExpressionDimension {
+    // optimization: if we don't have any options, we can return ourself as-is
+    if (!this._options) {
+      return this;
+    }
+
+    return new ExpressionDimension(
+      this._expressionName,
+      _.omit(this._options, ...options),
+      this._metadata,
+      this._query,
+    );
+  }
+
+  /**
+   * Return a copy of this ExpressionDimension that includes the specified `options`.
+   */
+  withOptions(options: any): ExpressionDimension {
+    // optimization : if options is empty return self as-is
+    if (!options || !Object.entries(options).length) {
+      return this;
+    }
+
+    return new ExpressionDimension(
+      this._expressionName,
+      { ...this._options, ...options },
+      this._metadata,
+      this._query,
+    );
+  }
+
+  render(): string {
+    let displayName = this.displayName();
+
+    if (this.temporalUnit()) {
+      displayName = `${displayName}: ${formatBucketing(this.temporalUnit())}`;
+    }
+
+    if (this.binningOptions()) {
+      displayName = `${displayName}: ${this.describeBinning()}`;
+    }
+
+    return displayName;
+  }
 }
+
+const isExpressionDimension = dimension =>
+  dimension instanceof ExpressionDimension;
+
 // These types aren't aggregated. e.g. if you take the distinct count of a FK
 // column, you now have a normal integer and should see relevant filters for
 // that type.
@@ -1471,3 +1589,193 @@ const DIMENSION_TYPES: typeof Dimension[] = [
   AggregationDimension,
   TemplateTagDimension,
 ];
+
+const NUMBER_SUBDIMENSIONS = [
+  {
+    name: t`Auto bin`,
+    options: {
+      binning: {
+        strategy: "default",
+      },
+    },
+  },
+  {
+    name: t`10 bins`,
+    options: {
+      binning: {
+        strategy: "num-bins",
+        "num-bins": 10,
+      },
+    },
+  },
+  {
+    name: t`50 bins`,
+    options: {
+      binning: {
+        strategy: "num-bins",
+        "num-bins": 50,
+      },
+    },
+  },
+  {
+    name: t`100 bins`,
+    options: {
+      binning: {
+        strategy: "num-bins",
+        "num-bins": 100,
+      },
+    },
+  },
+  {
+    name: t`Don't bin`,
+    options: null,
+  },
+];
+
+const DATETIME_SUBDIMENSIONS = [
+  {
+    name: t`Minute`,
+    options: {
+      "temporal-unit": "minute",
+    },
+  },
+  {
+    name: t`Hour`,
+    options: {
+      "temporal-unit": "hour",
+    },
+  },
+  {
+    name: t`Day`,
+    options: {
+      "temporal-unit": "day",
+    },
+  },
+  {
+    name: t`Week`,
+    options: {
+      "temporal-unit": "week",
+    },
+  },
+  {
+    name: t`Month`,
+    options: {
+      "temporal-unit": "month",
+    },
+  },
+  {
+    name: t`Quarter`,
+    options: {
+      "temporal-unit": "quarter",
+    },
+  },
+  {
+    name: t`Year`,
+    options: {
+      "temporal-unit": "year",
+    },
+  },
+  {
+    name: t`Minute of Hour`,
+    options: {
+      "temporal-unit": "minute-of-hour",
+    },
+  },
+  {
+    name: t`Hour of Day`,
+    options: {
+      "temporal-unit": "hour-of-day",
+    },
+  },
+  {
+    name: t`Day of Week`,
+    options: {
+      "temporal-unit": "day-of-week",
+    },
+  },
+  {
+    name: t`Day of Month`,
+    options: {
+      "temporal-unit": "day-of-month",
+    },
+  },
+  {
+    name: t`Day of Year`,
+    options: {
+      "temporal-unit": "day-of-year",
+    },
+  },
+  {
+    name: t`Week of Year`,
+    options: {
+      "temporal-unit": "week-of-year",
+    },
+  },
+  {
+    name: t`Month of Year`,
+    options: {
+      "temporal-unit": "month-of-year",
+    },
+  },
+  {
+    name: t`Quarter of Year`,
+    options: {
+      "temporal-unit": "quarter-of-year",
+    },
+  },
+];
+
+const COORDINATE_SUBDIMENSIONS = [
+  {
+    name: t`Bin every 0.1 degrees`,
+    options: {
+      binning: {
+        strategy: "bin-width",
+        "bin-width": 0.1,
+      },
+    },
+  },
+  {
+    name: t`Bin every 1 degree`,
+    options: {
+      binning: {
+        strategy: "bin-width",
+        "bin-width": 1,
+      },
+    },
+  },
+  {
+    name: t`Bin every 10 degrees`,
+    options: {
+      binning: {
+        strategy: "bin-width",
+        "bin-width": 10,
+      },
+    },
+  },
+  {
+    name: t`Bin every 20 degrees`,
+    options: {
+      binning: {
+        strategy: "bin-width",
+        "bin-width": 20,
+      },
+    },
+  },
+  {
+    name: t`Don't bin`,
+    options: null,
+  },
+];
+
+function getOptions(type) {
+  if (isa(type, "type/Coordinate")) {
+    return COORDINATE_SUBDIMENSIONS;
+  } else if (isa(type, "type/Number")) {
+    return NUMBER_SUBDIMENSIONS;
+  } else if (isa(type, "type/DateTime")) {
+    return DATETIME_SUBDIMENSIONS;
+  }
+
+  return null;
+}

--- a/frontend/src/metabase-lib/lib/Dimension.ts
+++ b/frontend/src/metabase-lib/lib/Dimension.ts
@@ -1185,7 +1185,7 @@ export class ExpressionDimension extends Dimension {
     }
 
     if (ExpressionDimension.isExpressionClause(somethingElse)) {
-      const dimension = Expression.parseMBQL(
+      const dimension = ExpressionDimension.parseMBQL(
         somethingElse,
         this._metadata,
         this._query,

--- a/frontend/src/metabase/lib/query/field_ref.js
+++ b/frontend/src/metabase/lib/query/field_ref.js
@@ -43,6 +43,9 @@ export function getFieldTargetId(field) {
     const type = typeof field[1];
     return type === "number" || type === "string" ? field[1] : field;
   }
+  if (isExpressionField(field) && _.isString(field[1])) {
+    return field[1];
+  }
   console.warn("Unknown field type:", field);
 }
 

--- a/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
@@ -709,6 +709,18 @@ describe("Dimension", () => {
         });
       });
     });
+
+    describe("dimensions()", () => {
+      it("should return subdimensions according to the field type", () => {
+        const question = new Question(nestedQuestionCard, metadata);
+        const dimension = Dimension.parseMBQL(
+          ["expression", 42],
+          metadata,
+          question.query(),
+        );
+        expect(dimension.dimensions().length).toEqual(5); // 5 different binnings for a number
+      });
+    });
   });
 
   describe("Field with join-alias", () => {

--- a/frontend/test/metabase/scenarios/custom-column/custom-column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/custom-column.cy.spec.js
@@ -4,8 +4,10 @@ import {
   summarize,
   visualize,
   openOrdersTable,
+  openPeopleTable,
   visitQuestionAdhoc,
   enterCustomColumnDetails,
+  getBinningButtonForDimension,
   filter,
 } from "__support__/e2e/cypress";
 
@@ -33,6 +35,108 @@ describe("scenarios > question > custom column", () => {
 
     cy.findByText("There was a problem with your question").should("not.exist");
     cy.get(".Visualization").contains("Math");
+  });
+
+  it("should allow choosing a binning for a numeric custom column", () => {
+    openOrdersTable({ mode: "notebook" });
+    cy.icon("add_data").click();
+
+    enterCustomColumnDetails({
+      formula: "[Product.Price] / 2",
+      name: "Half Price",
+    });
+    cy.button("Done").click();
+
+    cy.findByText("Summarize").click();
+    popover()
+      .findByText("Count of rows")
+      .click();
+
+    cy.findByText("Pick a column to group by").click();
+    popover()
+      .findByText("Half Price")
+      .click();
+
+    cy.get("[data-testid='step-summarize-0-0']")
+      .findByText("Half Price")
+      .click();
+    getBinningButtonForDimension({
+      name: "Half Price",
+    }).click();
+
+    popover()
+      .findByText("10 bins")
+      .click();
+
+    cy.findByText("Half Price: 10 bins").should("be.visible");
+  });
+
+  it("should allow choosing a temporal unit for a date/time custom column", () => {
+    openOrdersTable({ mode: "notebook" });
+    cy.icon("add_data").click();
+
+    enterCustomColumnDetails({
+      formula: "[Product.Created At]",
+      name: "Product Date",
+    });
+    cy.button("Done").click();
+
+    cy.findByText("Summarize").click();
+    popover()
+      .findByText("Count of rows")
+      .click();
+
+    cy.findByText("Pick a column to group by").click();
+    popover()
+      .findByText("Product Date")
+      .click();
+
+    cy.get("[data-testid='step-summarize-0-0']")
+      .findByText("Product Date")
+      .click();
+    getBinningButtonForDimension({
+      name: "Product Date",
+    }).click();
+
+    popover()
+      .findByText("Month of Year")
+      .click();
+
+    cy.findByText("Product Date: Month of year").should("be.visible");
+  });
+
+  it("should allow choosing a binning for a coordinate custom column", () => {
+    openPeopleTable({ mode: "notebook" });
+    cy.icon("add_data").click();
+
+    enterCustomColumnDetails({
+      formula: "[Latitude]",
+      name: "UserLAT",
+    });
+    cy.button("Done").click();
+
+    cy.findByText("Summarize").click();
+    popover()
+      .findByText("Count of rows")
+      .click();
+
+    cy.findByText("Pick a column to group by").click();
+    popover()
+      .findByText("UserLAT")
+      .click();
+
+    cy.get("[data-testid='step-summarize-0-0']")
+      .findByText("UserLAT")
+      .click();
+    getBinningButtonForDimension({
+      name: "UserLAT",
+    }).click();
+
+    popover()
+      .findByText("Bin every 10 degrees")
+      .click();
+
+    cy.findByText("UserLAT: 10°").should("be.visible");
   });
 
   // flaky test (#19454)


### PR DESCRIPTION
This is necessary so that custom columns can have binning (strategy), temporal unit, etc.

**Note**: This PR only addressed the front-end aspect. If you click Visualize in the repro below, the query result is still not correct. For that, we need to wait for @camsaul's tweak on the QP. 

<hr>

How to try:

1. New, Question
2. Sample Database, Products table
3. Custom Column, type `[Price] / 2` and name it `HalfPrice`
4. Custom Column, type `[Created At]` and name it `Product Date`

5. Summarize, `Count`, by `Price`. Here you can choose various binning for the breakout:

![image](https://user-images.githubusercontent.com/7288/155830060-ef899f02-a4f0-4b9e-b0f9-e187a5b7343c.png)

6. Summarize, `Count`, by `Created At`. Here you can choose various temporal units for the breakout:

![image](https://user-images.githubusercontent.com/7288/155830049-276cd601-882b-499f-8d04-c2234f575de4.png)

7. Instead of `Price`, change the breakout to `HalfPrice` instead.
8. Instead of `Created At`, change the breakout to `Product Date` instead.

**Before**

In step 7, no binning is available for this custom column `HalfPrice`. This is confusing since choosing the original column, `Price`, gives the choice of various bins.

![image](https://user-images.githubusercontent.com/7288/155830130-6eb7600f-4650-46b1-8708-101043cff0a5.png)

In step 8, no choice of temporal unit is available for `Product Date`, despite the original column `Created At` actually has many choices.

![image](https://user-images.githubusercontent.com/7288/155830151-66055d48-b2c8-4b13-9c68-01390a7174d2.png)

**After**

`HalfPrice` offers the same binning options. The chosen binning will be persistent (i.e. choose one, select it again, and the previous chosen binning is highlighted).

![image](https://user-images.githubusercontent.com/7288/155830185-0c58a350-4785-47f4-ad73-291f14b69515.png)

The same goes for `Product Date`:

![image](https://user-images.githubusercontent.com/7288/155830224-a285a211-8bd3-4ca8-bb26-a12ea82ded99.png)

