### PR TITLE
ScalarValue: display line break

### DIFF
--- a/frontend/src/metabase/css/dashboard.css
+++ b/frontend/src/metabase/css/dashboard.css
@@ -351,6 +351,7 @@
 .ScalarValue {
   font-weight: 900;
   font-size: 1.8rem;
+  white-space: pre;
 }
 
 .SmartWrapper {


### PR DESCRIPTION
Display line breaks inside ScalarValue visualisation.

<img width="1292" alt="Capture d’écran 2022-02-19 à 17 33 08" src="https://user-images.githubusercontent.com/51329768/154809718-309c3272-0792-45d2-a314-174cda266392.png">

