### PR TITLE
Repro #20656: Dashboard with filter connected to a card that a user doesn't have permissions to view breaks

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/20656-dashboard-breaks-for-user-without-card-permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/20656-dashboard-breaks-for-user-without-card-permissions.cy.spec.js
@@ -1,0 +1,60 @@
+import { restore, filterWidget } from "__support__/e2e/cypress";
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
+const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
+
+const filter = {
+  name: "ID",
+  slug: "id",
+  id: "11d79abe",
+  type: "id",
+  sectionId: "id",
+};
+
+describe.skip("issue 20656", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should allow a user to visit a dashboard even without a permission to see the dashboard card (metabase#20656)", () => {
+    cy.createQuestionAndDashboard({
+      questionDetails: {
+        query: { "source-table": PRODUCTS_ID, limit: 2 },
+        // Admin's personal collection is always the first one (hence, the id 1)
+        collection_id: 1,
+      },
+    }).then(({ body: { id, card_id, dashboard_id } }) => {
+      cy.addFilterToDashboard({ filter, dashboard_id });
+
+      cy.request("PUT", `/api/dashboard/${dashboard_id}/cards`, {
+        cards: [
+          {
+            id,
+            card_id,
+            row: 0,
+            col: 0,
+            sizeX: 18,
+            sizeY: 10,
+            parameter_mappings: [
+              {
+                parameter_id: filter.id,
+                card_id,
+                target: ["dimension", ["field", PRODUCTS.ID, null]],
+              },
+            ],
+          },
+        ],
+      });
+
+      cy.signInAsNormalUser();
+
+      cy.visit(`/dashboard/${dashboard_id}`);
+    });
+
+    // Make sure the filter widget is there
+    filterWidget();
+
+    cy.findByText("Sorry, you don't have permissions to see this card.");
+  });
+});


### PR DESCRIPTION
### Status
PENDING CI / PENDING REVIEW / READY _(choose one and update accordingly)_

### What does this PR accomplish?
- Reproduces #20656 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/dashboard-filters/reproductions/20656-dashboard-breaks-for-user-without-card-permissions.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/154955541-3dfba126-448a-4b45-a7fc-cbadb50a8c23.png)

