### PR TITLE
Repro #20624: Model metadata not overriding question column settings

### DIFF
--- a/frontend/test/metabase/scenarios/models/reproductions/20624-model-metadata-should-override-column-settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/reproductions/20624-model-metadata-should-override-column-settings.cy.spec.js
@@ -1,0 +1,42 @@
+import { restore } from "__support__/e2e/cypress";
+import { openDetailsSidebar } from "../helpers/e2e-models-helpers";
+
+const renamedColumn = "TITLE renamed";
+
+const questionDetails = {
+  name: "20624",
+  dataset: true,
+  native: { query: "select * from PRODUCTS limit 2" },
+  visualization_settings: {
+    column_settings: { '["name","TITLE"]': { column_title: renamedColumn } },
+  },
+};
+
+describe.skip("issue 20624", () => {
+  beforeEach(() => {
+    cy.intercept("PUT", "/api/card/*").as("updateCard");
+
+    restore();
+    cy.signInAsAdmin();
+
+    cy.createNativeQuestion(questionDetails, { visitQuestion: true });
+  });
+
+  it("models metadata should override previously defined column settings (metabase#20624)", () => {
+    openDetailsSidebar();
+    cy.findByText("Customize metadata").click();
+
+    // Open settings for this column
+    cy.findByText(renamedColumn).click();
+    // Let's set a new name for it
+    cy.findByDisplayValue(renamedColumn)
+      .clear()
+      .type("Foo")
+      .blur();
+
+    cy.button("Save changes").click();
+    cy.wait("@updateCard");
+
+    cy.get(".cellData").should("contain", "Foo");
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #20624 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/models/reproductions/20624-model-metadata-should-override-column-settings.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/154965732-ffef594c-9a48-4a87-b2bb-9b3bfebdf1fa.png)

