### PR TITLE
Repro 20638: Creating a new dashboard from the New button in a collection should take me to that dashboard

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
@@ -7,6 +7,7 @@ import {
   filterWidget,
   sidebar,
   modal,
+  openNewCollectionItemFlowFor,
 } from "__support__/e2e/cypress";
 
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
@@ -39,6 +40,16 @@ describe("scenarios > dashboard", () => {
     cy.visit("/collection/root?type=dashboard");
     cy.findByText("This dashboard is looking empty.").should("not.exist");
     cy.findByText("Test Dash");
+  });
+
+  it.skip("should create new dashboard and navigate to it from the root collection (metabase#20638)", () => {
+    cy.visit("/collection/root");
+    openNewCollectionItemFlowFor("dashboard");
+
+    createDashboardUsingUI("Test Dash", "Desc");
+
+    cy.findByText("This dashboard is looking empty.");
+    cy.findByText("You're editing this dashboard.");
   });
 
   it("should add a filter", () => {


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #20638 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/154988621-74dc88dd-b0c3-40f2-a6cf-cf2c76fe180c.png)

