### PR TITLE
Apply `visitQuestion` helper to the related tests

### DIFF
--- a/frontend/test/__support__/e2e/helpers/e2e-misc-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-misc-helpers.js
@@ -155,7 +155,8 @@ export function visitQuestion(id) {
   // In case we use this function multiple times in a test, make sure aliases are unique for each question
   const alias = "cardQuery" + id;
 
-  cy.intercept("POST", `/api/card/${id}/query`).as(alias);
+  // We need to use the wildcard becase endpoint for pivot tables has the following format: `/api/card/pivot/${id}/query`
+  cy.intercept("POST", `/api/card/**/${id}/query`).as(alias);
 
   cy.visit(`/question/${id}`);
 

--- a/frontend/test/metabase/scenarios/admin/audit/questions-audit.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/audit/questions-audit.cy.spec.js
@@ -1,13 +1,9 @@
 import _ from "underscore";
-import { restore, describeWithToken } from "__support__/e2e/cypress";
-
-const visitQuestion = id => {
-  cy.visit(`/question/${id}`);
-
-  // Visualization button is visible means
-  // that we waited enough to fetch the question data
-  cy.findByText("Visualization");
-};
+import {
+  restore,
+  describeWithToken,
+  visitQuestion,
+} from "__support__/e2e/cypress";
 
 describeWithToken("audit > auditing > questions", () => {
   beforeEach(() => {

--- a/frontend/test/metabase/scenarios/dashboard-filters-sql/dashboard-filters-sql-date.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters-sql/dashboard-filters-sql-date.cy.spec.js
@@ -5,6 +5,7 @@ import {
   editDashboard,
   saveDashboard,
   setFilter,
+  visitQuestion,
 } from "__support__/e2e/cypress";
 
 import { DASHBOARD_SQL_DATE_FILTERS } from "./helpers/e2e-dashboard-filter-sql-data-objects";
@@ -24,12 +25,8 @@ Object.entries(DASHBOARD_SQL_DATE_FILTERS).forEach(
         const questionDetails = getQuestionDetails(sqlFilter);
 
         cy.createNativeQuestionAndDashboard({ questionDetails }).then(
-          ({ body: { id, card_id, dashboard_id } }) => {
-            cy.intercept("POST", `/api/card/${card_id}/query`).as("cardQuery");
-            cy.visit(`/question/${card_id}`);
-
-            // Wait for `result_metadata` to load
-            cy.wait("@cardQuery");
+          ({ body: { card_id, dashboard_id } }) => {
+            visitQuestion(card_id);
 
             cy.visit(`/dashboard/${dashboard_id}`);
           },

--- a/frontend/test/metabase/scenarios/dashboard-filters-sql/dashboard-filters-sql-id.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters-sql/dashboard-filters-sql-id.cy.spec.js
@@ -5,6 +5,7 @@ import {
   editDashboard,
   saveDashboard,
   setFilter,
+  visitQuestion,
 } from "__support__/e2e/cypress";
 
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
@@ -100,12 +101,8 @@ function prepareDashboardWithFilterConnectedTo(rowId) {
   };
 
   cy.createNativeQuestionAndDashboard({ questionDetails }).then(
-    ({ body: { id, card_id, dashboard_id } }) => {
-      cy.intercept("POST", `/api/card/${card_id}/query`).as("cardQuery");
-      cy.visit(`/question/${card_id}`);
-
-      // Wait for `result_metadata` to load
-      cy.wait("@cardQuery");
+    ({ body: { card_id, dashboard_id } }) => {
+      visitQuestion(card_id);
 
       cy.visit(`/dashboard/${dashboard_id}`);
     },

--- a/frontend/test/metabase/scenarios/dashboard-filters-sql/dashboard-filters-sql-location.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters-sql/dashboard-filters-sql-location.cy.spec.js
@@ -5,6 +5,7 @@ import {
   editDashboard,
   saveDashboard,
   setFilter,
+  visitQuestion,
 } from "__support__/e2e/cypress";
 
 import { DASHBOARD_SQL_LOCATION_FILTERS } from "./helpers/e2e-dashboard-filter-sql-data-objects";
@@ -24,12 +25,8 @@ Object.entries(DASHBOARD_SQL_LOCATION_FILTERS).forEach(
         const questionDetails = getQuestionDetails(sqlFilter);
 
         cy.createNativeQuestionAndDashboard({ questionDetails }).then(
-          ({ body: { id, card_id, dashboard_id } }) => {
-            cy.intercept("POST", `/api/card/${card_id}/query`).as("cardQuery");
-            cy.visit(`/question/${card_id}`);
-
-            // Wait for `result_metadata` to load
-            cy.wait("@cardQuery");
+          ({ body: { card_id, dashboard_id } }) => {
+            visitQuestion(card_id);
 
             cy.visit(`/dashboard/${dashboard_id}`);
           },

--- a/frontend/test/metabase/scenarios/dashboard-filters-sql/dashboard-filters-sql-number.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters-sql/dashboard-filters-sql-number.cy.spec.js
@@ -5,6 +5,7 @@ import {
   editDashboard,
   saveDashboard,
   setFilter,
+  visitQuestion,
 } from "__support__/e2e/cypress";
 
 import { DASHBOARD_SQL_NUMBER_FILTERS } from "./helpers/e2e-dashboard-filter-sql-data-objects";
@@ -24,12 +25,8 @@ Object.entries(DASHBOARD_SQL_NUMBER_FILTERS).forEach(
         const questionDetails = getQuestionDetails(sqlFilter);
 
         cy.createNativeQuestionAndDashboard({ questionDetails }).then(
-          ({ body: { id, card_id, dashboard_id } }) => {
-            cy.intercept("POST", `/api/card/${card_id}/query`).as("cardQuery");
-            cy.visit(`/question/${card_id}`);
-
-            // Wait for `result_metadata` to load
-            cy.wait("@cardQuery");
+          ({ body: { card_id, dashboard_id } }) => {
+            visitQuestion(card_id);
 
             cy.visit(`/dashboard/${dashboard_id}`);
           },

--- a/frontend/test/metabase/scenarios/dashboard-filters-sql/dashboard-filters-sql-text-category.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters-sql/dashboard-filters-sql-text-category.cy.spec.js
@@ -5,6 +5,7 @@ import {
   editDashboard,
   saveDashboard,
   setFilter,
+  visitQuestion,
 } from "__support__/e2e/cypress";
 
 import { DASHBOARD_SQL_TEXT_FILTERS } from "./helpers/e2e-dashboard-filter-sql-data-objects";
@@ -24,12 +25,8 @@ Object.entries(DASHBOARD_SQL_TEXT_FILTERS).forEach(
         const questionDetails = getQuestionDetails(sqlFilter);
 
         cy.createNativeQuestionAndDashboard({ questionDetails }).then(
-          ({ body: { id, card_id, dashboard_id } }) => {
-            cy.intercept("POST", `/api/card/${card_id}/query`).as("cardQuery");
-            cy.visit(`/question/${card_id}`);
-
-            // Wait for `result_metadata` to load
-            cy.wait("@cardQuery");
+          ({ body: { card_id, dashboard_id } }) => {
+            visitQuestion(card_id);
 
             cy.visit(`/dashboard/${dashboard_id}`);
           },

--- a/frontend/test/metabase/scenarios/dashboard/parameters-embedded.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/parameters-embedded.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, popover } from "__support__/e2e/cypress";
+import { restore, popover, visitQuestion } from "__support__/e2e/cypress";
 
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
@@ -150,7 +150,7 @@ describe("scenarios > dashboard > parameters-embedded", () => {
     beforeEach(cy.signInAsAdmin);
 
     sharedParametersTests(() => {
-      cy.visit(`/question/${questionId}`);
+      visitQuestion(questionId);
       // wait for question to load/run
       cy.contains("Test Question");
       cy.contains("2,500");

--- a/frontend/test/metabase/scenarios/downloads/reproductions/18219-temporal-units-not-formatted.cy.spec.js
+++ b/frontend/test/metabase/scenarios/downloads/reproductions/18219-temporal-units-not-formatted.cy.spec.js
@@ -1,4 +1,8 @@
-import { restore, downloadAndAssert } from "__support__/e2e/cypress";
+import {
+  restore,
+  downloadAndAssert,
+  visitQuestion,
+} from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
@@ -24,11 +28,7 @@ describe.skip("issue 18219", () => {
     it("should format temporal units on export (metabase#18219)", () => {
       cy.createQuestion(questionDetails).then(
         ({ body: { id: questionId } }) => {
-          cy.intercept("POST", `/api/card/${questionId}/query`).as("cardQuery");
-          cy.visit(`/question/${questionId}`);
-
-          // Wait for `result_metadata` to load
-          cy.wait("@cardQuery");
+          visitQuestion(questionId);
 
           cy.findByText("Created At: Year");
           cy.findByText("2016");

--- a/frontend/test/metabase/scenarios/downloads/reproductions/18440-remapped-display-value-dropped.cy.spec.js
+++ b/frontend/test/metabase/scenarios/downloads/reproductions/18440-remapped-display-value-dropped.cy.spec.js
@@ -2,6 +2,7 @@ import {
   restore,
   visitQuestionAdhoc,
   downloadAndAssert,
+  visitQuestion,
 } from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
@@ -46,10 +47,7 @@ describe("issue 18440", () => {
 
     it(`export should include a column with remapped values for ${fileType} for a saved question (metabase#18440-2)`, () => {
       cy.createQuestion({ query }).then(({ body: { id } }) => {
-        cy.intercept("POST", `/api/card/${id}/query`).as("cardQuery");
-
-        cy.visit(`/question/${id}`);
-        cy.wait("@cardQuery");
+        visitQuestion(id);
 
         cy.findByText("Product ID");
         cy.findByText("Awesome Concrete Shoes");

--- a/frontend/test/metabase/scenarios/downloads/reproductions/19889-native-query-export-column-order.cy.spec.js
+++ b/frontend/test/metabase/scenarios/downloads/reproductions/19889-native-query-export-column-order.cy.spec.js
@@ -1,4 +1,8 @@
-import { restore, downloadAndAssert } from "__support__/e2e/cypress";
+import {
+  restore,
+  downloadAndAssert,
+  visitQuestion,
+} from "__support__/e2e/cypress";
 
 const questionDetails = {
   name: "19889",
@@ -60,8 +64,7 @@ describe("issue 19889", () => {
       saveAndOverwrite();
 
       cy.get("@questionId").then(questionId => {
-        cy.visit(`/question/${questionId}`);
-        cy.wait("@cardQuery");
+        visitQuestion(questionId);
 
         downloadAndAssert({ fileType, questionId, raw: true }, sheet => {
           expect(sheet["A1"].v).to.equal("column x");

--- a/frontend/test/metabase/scenarios/joins/joins-2.cy.spec.js
+++ b/frontend/test/metabase/scenarios/joins/joins-2.cy.spec.js
@@ -8,6 +8,7 @@ import {
   visitQuestionAdhoc,
   summarize,
   filter,
+  visitQuestion,
 } from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
@@ -361,21 +362,13 @@ describe("scenarios > question > joined questions", () => {
             "source-table": PRODUCTS_ID,
           },
         }).then(({ body: { id: joinedQuestionId } }) => {
-          // listen on the final card query which means the data for this question loaded
-          cy.route("POST", `/api/card/${joinedQuestionId}/query`).as(
-            "cardQuery",
-          );
-
           // Assert phase begins here
-          cy.visit(`/question/${joinedQuestionId}`);
-          cy.findByText("13744_joined");
+          visitQuestion(joinedQuestionId);
 
           cy.log("Reported failing on v0.34.3 - v0.37.0.2");
           cy.log("Reported error log: 'No aggregation at index: 0'");
-          // assert directly on XHR instead of relying on UI
-          cy.wait("@cardQuery").then(xhr => {
-            expect(xhr.response.body.error).not.to.exist;
-          });
+
+          cy.findByText("13744_joined");
           cy.findAllByText("Gizmo");
         });
       });

--- a/frontend/test/metabase/scenarios/native-filters/reproductions/16739.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native-filters/reproductions/16739.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore } from "__support__/e2e/cypress";
+import { restore, visitQuestion } from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { PRODUCTS } = SAMPLE_DATABASE;
@@ -28,15 +28,12 @@ describe("issue 16739", () => {
           "template-tags": { filter },
         },
       }).then(({ body: { id } }) => {
-        cy.intercept("POST", `/api/card/${id}/query`).as("cardQuery");
-
         if (user === "nodata") {
           cy.signOut();
           cy.signIn(user);
         }
 
-        cy.visit(`/question/${id}`);
-        cy.wait("@cardQuery");
+        visitQuestion(id);
       });
 
       cy.icon("play").should("not.exist");

--- a/frontend/test/metabase/scenarios/native-filters/reproductions/17019.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native-filters/reproductions/17019.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore } from "__support__/e2e/cypress";
+import { restore, visitQuestion } from "__support__/e2e/cypress";
 
 const question = {
   name: "17019",
@@ -22,13 +22,10 @@ describe("issue 17019", () => {
     cy.signInAsAdmin();
 
     cy.createNativeQuestion(question).then(({ body: { id } }) => {
-      cy.intercept("POST", `/api/card/${id}/query`).as("cardQuery");
-
       // Enable sharing
       cy.request("POST", `/api/card/${id}/public_link`);
 
-      cy.visit(`/question/${id}`);
-      cy.wait("@cardQuery");
+      visitQuestion(id);
     });
   });
 

--- a/frontend/test/metabase/scenarios/native/native_subquery.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/native_subquery.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore } from "__support__/e2e/cypress";
+import { restore, visitQuestion } from "__support__/e2e/cypress";
 
 describe("scenarios > question > native subquery", () => {
   beforeEach(() => {
@@ -37,7 +37,7 @@ describe("scenarios > question > native subquery", () => {
       .then(response => {
         cy.wrap(response.body.id).as("toplevelQuestionId");
 
-        cy.visit(`/question/${response.body.id}`);
+        visitQuestion(response.body.id);
         cy.contains("41");
       });
 
@@ -46,12 +46,12 @@ describe("scenarios > question > native subquery", () => {
 
     // They should be able to access both questions
     cy.get("@nestedQuestionId").then(nestedQuestionId => {
-      cy.visit(`/question/${nestedQuestionId}`);
+      visitQuestion(nestedQuestionId);
       cy.contains("Showing 41 rows");
     });
 
     cy.get("@toplevelQuestionId").then(toplevelQuestionId => {
-      cy.visit(`/question/${toplevelQuestionId}`);
+      visitQuestion(toplevelQuestionId);
       cy.contains("41");
     });
   });

--- a/frontend/test/metabase/scenarios/native/reproductions/20044-no-data-sees-explore-results.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/reproductions/20044-no-data-sees-explore-results.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore } from "__support__/e2e/cypress";
+import { restore, visitQuestion } from "__support__/e2e/cypress";
 
 const questionDetails = {
   name: "20044",
@@ -15,12 +15,9 @@ describe("issue 20044", () => {
 
   it("nodata user should not see 'Explore results' (metabase#20044)", () => {
     cy.createNativeQuestion(questionDetails).then(({ body: { id } }) => {
-      cy.intercept("POST", `/api/card/${id}/query`).as("cardQuery");
-
       cy.signIn("nodata");
 
-      cy.visit(`/question/${id}`);
-      cy.wait("@cardQuery");
+      visitQuestion(id);
 
       cy.get(".cellData").contains("1");
       cy.findByText("Explore results").should("not.exist");

--- a/frontend/test/metabase/scenarios/permissions/reproductions/14873-regextract-in-sandboxed-table.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/reproductions/14873-regextract-in-sandboxed-table.cy.spec.js
@@ -2,6 +2,7 @@ import {
   restore,
   withDatabase,
   describeWithToken,
+  visitQuestion,
 } from "__support__/e2e/cypress";
 import { USER_GROUPS } from "__support__/e2e/cypress_data";
 
@@ -51,8 +52,6 @@ describeWithToken("postgres > user > query", () => {
         },
         database: PG_DB_ID,
       }).then(({ body: { id: QUESTION_ID } }) => {
-        cy.intercept("POST", `/api/card/${QUESTION_ID}/query`).as("cardQuery");
-
         cy.sandboxTable({
           table_id: PEOPLE_ID,
           attribute_remappings: {
@@ -63,11 +62,7 @@ describeWithToken("postgres > user > query", () => {
         cy.signOut();
         cy.signInAsSandboxedUser();
 
-        cy.visit(`/question/${QUESTION_ID}`);
-
-        cy.wait("@cardQuery").then(xhr => {
-          expect(xhr.response.body.error).not.to.exist;
-        });
+        visitQuestion(QUESTION_ID);
 
         cy.findByText(CC_NAME);
         cy.findByText(/^Hudson$/);

--- a/frontend/test/metabase/scenarios/permissions/sandboxes.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/sandboxes.cy.spec.js
@@ -11,6 +11,7 @@ import {
   visualize,
   summarize,
   filter,
+  visitQuestion,
 } from "__support__/e2e/cypress";
 import { USER_GROUPS } from "__support__/e2e/cypress_data";
 
@@ -263,18 +264,11 @@ describeWithToken("formatting > sandboxes", () => {
         cy.signOut();
         cy.signInAsSandboxedUser();
 
-        cy.server();
-        cy.route("POST", `/api/card/${QUESTION_ID}/query`).as("cardQuery");
-
         // Assertion phase starts here
-        cy.visit(`/question/${QUESTION_ID}`);
+        visitQuestion(QUESTION_ID);
         cy.findByText(QUESTION_NAME);
 
         cy.log("Reported failing since v1.36.4");
-        cy.wait("@cardQuery").then(xhr => {
-          expect(xhr.response.body.error).not.to.exist;
-        });
-
         cy.contains(CC_NAME);
       });
     });
@@ -808,7 +802,7 @@ describeWithToken("formatting > sandboxes", () => {
       cy.signOut();
       cy.signInAsSandboxedUser();
       createJoinedQuestion("14841").then(({ body: { id: QUESTION_ID } }) => {
-        cy.visit(`/question/${QUESTION_ID}`);
+        visitQuestion(QUESTION_ID);
       });
 
       cy.findByText("Settings").click();
@@ -889,19 +883,10 @@ describeWithToken("formatting > sandboxes", () => {
         display: "pivot",
         visualization_settings: {},
       }).then(({ body: { id: QUESTION_ID } }) => {
-        cy.server();
-        cy.route("POST", `/api/card/pivot/${QUESTION_ID}/query`).as(
-          "cardQuery",
-        );
-
         cy.signOut();
         cy.signInAsSandboxedUser();
 
-        cy.visit(`/question/${QUESTION_ID}`);
-
-        cy.wait("@cardQuery").then(xhr => {
-          expect(xhr.response.body.cause).not.to.exist;
-        });
+        visitQuestion(QUESTION_ID);
       });
 
       cy.findByText("Twitter");

--- a/frontend/test/metabase/scenarios/question/nested.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nested.cy.spec.js
@@ -267,8 +267,6 @@ describe("scenarios > question > nested", () => {
         name: "12507",
         query: ORIGINAL_QUERY,
       }).then(({ body: { id: questionId } }) => {
-        cy.intercept("POST", `/api/card/${questionId}/query`).as("cardQuery");
-
         cy.log("Create and visit a nested question based on the previous one");
         visitQuestionAdhoc({
           dataset_query: {
@@ -282,10 +280,6 @@ describe("scenarios > question > nested", () => {
         });
 
         cy.log("Reported failing since v0.35.2");
-        cy.visit(`/question/${questionId}`);
-        cy.wait("@cardQuery").then(xhr => {
-          expect(xhr.response.body.error).not.to.exist;
-        });
         cy.get(".cellData").contains(METRIC_NAME);
       });
     });

--- a/frontend/test/metabase/scenarios/question/public/question.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/public/question.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, filterWidget } from "__support__/e2e/cypress";
+import { restore, filterWidget, visitQuestion } from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { PEOPLE } = SAMPLE_DATABASE;
@@ -47,7 +47,7 @@ describe("scenarios > question > public", () => {
     cy.createNativeQuestion(questionData).then(({ body: { id } }) => {
       enableSharingQuestion(id);
 
-      cy.visit(`/question/${id}`);
+      visitQuestion(id);
       // Make sure metadata fully loaded before we continue
       cy.wait("@cardQuery");
     });

--- a/frontend/test/metabase/scenarios/question/reproductions/18978-18977-nested-question-nodata-user.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/18978-18977-nested-question-nodata-user.cy.spec.js
@@ -1,10 +1,9 @@
-import { restore, popover } from "__support__/e2e/cypress";
+import { restore, popover, visitQuestion } from "__support__/e2e/cypress";
 
 describe("18978, 18977", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
-    cy.intercept("/api/card/*/query").as("cardQuery");
   });
 
   it("should not display query editing controls and 'Browse Data' link", () => {
@@ -14,8 +13,7 @@ describe("18978, 18977", () => {
       },
     }).then(({ body: { id } }) => {
       cy.signIn("nodata");
-      cy.visit(`/question/${id}`);
-      cy.wait("@cardQuery");
+      visitQuestion(id);
 
       cy.get(".Nav").within(() => {
         cy.findByText(/Browse data/i).should("not.exist");

--- a/frontend/test/metabase/scenarios/sharing/alert/alert-permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/alert/alert-permissions.cy.spec.js
@@ -36,7 +36,7 @@ describe("scenarios > alert > alert permissions", () => {
       cy.intercept("PUT", "/api/alert/1").as("updatedAlert");
 
       // Change alert
-      cy.visit(`/question/1`);
+      visitQuestion(1);
       cy.icon("bell").click();
       cy.findByText("Edit").click();
 

--- a/frontend/test/metabase/scenarios/sharing/alert/alert-types.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/alert/alert-types.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, setupSMTP } from "__support__/e2e/cypress";
+import { restore, setupSMTP, visitQuestion } from "__support__/e2e/cypress";
 
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
@@ -49,7 +49,7 @@ describe("scenarios > alert > types", () => {
   describe("rows based alerts", () => {
     rawTestCases.forEach(({ questionType, questionId }) => {
       it(`should be supported for ${questionType}`, () => {
-        cy.visit(`/question/${questionId}`);
+        visitQuestion(questionId);
 
         openAlertModal();
 
@@ -65,7 +65,7 @@ describe("scenarios > alert > types", () => {
   describe("goal based alerts", () => {
     it("should work for timeseries questions with a set goal", () => {
       // Set goal on timeseries question
-      cy.visit(`/question/${timeSeriesQuestionId}`);
+      visitQuestion(timeSeriesQuestionId);
 
       cy.findByText("Settings").click();
       cy.findByText("Line options");

--- a/frontend/test/metabase/scenarios/sharing/alert/email-alert.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/alert/email-alert.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, setupSMTP } from "__support__/e2e/cypress";
+import { restore, setupSMTP, visitQuestion } from "__support__/e2e/cypress";
 
 describe("scenarios > alert > email_alert", () => {
   beforeEach(() => {
@@ -50,7 +50,7 @@ describe("scenarios > alert > email_alert", () => {
 });
 
 function openAlertForQuestion(id = 1) {
-  cy.visit(`/question/${id}`);
+  visitQuestion(id);
   cy.icon("bell").click();
 
   cy.findByText("Set up an alert").click();

--- a/frontend/test/metabase/scenarios/sharing/public.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/public.cy.spec.js
@@ -1,4 +1,9 @@
-import { restore, popover, modal } from "__support__/e2e/cypress";
+import {
+  restore,
+  popover,
+  modal,
+  visitQuestion,
+} from "__support__/e2e/cypress";
 
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
@@ -61,7 +66,7 @@ describe.skip("scenarios > public", () => {
   describe("questions", () => {
     // Note: Test suite is sequential, so individual test cases can't be run individually
     it("should allow users to create parameterized dashboards", () => {
-      cy.visit(`/question/${questionId}`);
+      visitQuestion(questionId);
 
       cy.findByTestId("saved-question-header-button").click();
       cy.findByTestId("add-to-dashboard-button").click();
@@ -116,7 +121,7 @@ describe.skip("scenarios > public", () => {
     it("should allow users to create public questions", () => {
       cy.request("PUT", "/api/setting/enable-public-sharing", { value: true });
 
-      cy.visit(`/question/${questionId}`);
+      visitQuestion(questionId);
 
       cy.icon("share").click();
 
@@ -140,7 +145,7 @@ describe.skip("scenarios > public", () => {
         value: "http://localhost:4000/", // Cypress.config().baseUrl
       });
 
-      cy.visit(`/question/${questionId}`);
+      visitQuestion(questionId);
 
       cy.icon("share").click();
 

--- a/frontend/test/metabase/scenarios/sharing/reproductions/17547.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/reproductions/17547.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, popover } from "__support__/e2e/cypress";
+import { restore, popover, visitQuestion } from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID, PEOPLE } = SAMPLE_DATABASE;
@@ -21,12 +21,9 @@ describe("issue 17547", () => {
     cy.signInAsAdmin();
 
     cy.createQuestion(questionDetails).then(({ body: { id: questionId } }) => {
-      cy.intercept("POST", `/api/card/${questionId}/query`).as("cardQuery");
-
       setUpAlert(questionId);
 
-      cy.visit(`/question/${questionId}`);
-      cy.wait("@cardQuery");
+      visitQuestion(questionId);
     });
   });
 

--- a/frontend/test/metabase/scenarios/sharing/reproductions/18352-subscription-int64-value-card.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/reproductions/18352-subscription-int64-value-card.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, setupSMTP } from "__support__/e2e/cypress";
+import { restore, setupSMTP, visitQuestion } from "__support__/e2e/cypress";
 import { USERS } from "__support__/e2e/cypress_data";
 
 const {
@@ -21,10 +21,7 @@ describe("issue 18352", () => {
 
     cy.createNativeQuestionAndDashboard({ questionDetails }).then(
       ({ body: { card_id, dashboard_id } }) => {
-        cy.intercept("POST", `/api/card/${card_id}/query`).as("cardQuery");
-
-        cy.visit(`/question/${card_id}`);
-        cy.wait("@cardQuery");
+        visitQuestion(card_id);
 
         cy.visit(`/dashboard/${dashboard_id}`);
       },

--- a/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
@@ -7,6 +7,7 @@ import {
   visitQuestionAdhoc,
   visualize,
   summarize,
+  visitQuestion,
 } from "__support__/e2e/cypress";
 import { USER_GROUPS } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
@@ -487,17 +488,13 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
         },
         display: "bar",
       }).then(({ body: { id: QUESTION_ID } }) => {
-        // Prepare to wait for certain imporatnt queries
-        cy.server();
-        cy.route("POST", `/api/card/${QUESTION_ID}/query`).as("cardQuery");
-        cy.route("POST", "/api/dataset").as("dataset");
+        cy.intercept("POST", "/api/dataset").as("dataset");
 
         // Switch to the normal user who has restricted SQL access
         cy.signInAsNormalUser();
-        cy.visit(`/question/${QUESTION_ID}`);
+        visitQuestion(QUESTION_ID);
 
         // Initial visualization has rendered and we can now drill-through
-        cy.wait("@cardQuery");
         cy.get(".Visualization .bar")
           .eq(4)
           .click({ force: true });

--- a/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -3,6 +3,7 @@ import {
   visitQuestionAdhoc,
   popover,
   sidebar,
+  visitQuestion,
 } from "__support__/e2e/cypress";
 
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
@@ -612,7 +613,8 @@ describe("scenarios > visualizations > pivot tables", () => {
             });
           },
         );
-        cy.visit(`/question/${QUESTION_ID}`);
+
+        visitQuestion(QUESTION_ID);
       });
     });
 
@@ -690,7 +692,7 @@ describe("scenarios > visualizations > pivot tables", () => {
       visualization_settings: {},
     }).then(({ body: { id: QUESTION_ID } }) => {
       cy.signIn("nodata");
-      cy.visit(`/question/${QUESTION_ID}`);
+      visitQuestion(QUESTION_ID);
     });
 
     cy.findByText("Grand totals");


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Continuation of #20630
- Applies `visitQuestion()` helper to all related tests

### Note
A slight adjustment for the interception of pivot table queries was needed. See [this](https://github.com/metabase/metabase/pull/20671/files#diff-592a02dc2cb12e8d36d4c38052fb4b61336d164ebe6cffa85af3fcf9fba2b26aR158-R159)