### PR TITLE
Repro #15353: Pivot Table: Cannot change name of fields used for "values"

### DIFF
--- a/frontend/test/metabase/scenarios/visualizations/reproductions/15353-pivot-settings-change-name-values.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/reproductions/15353-pivot-settings-change-name-values.cy.spec.js
@@ -1,0 +1,42 @@
+import { restore, sidebar } from "__support__/e2e/cypress";
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
+const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
+
+const questionDetails = {
+  name: "15353",
+  query: {
+    "source-table": ORDERS_ID,
+    aggregation: [["count"]],
+    breakout: [["field", ORDERS.CREATED_AT, { "temporal-unit": "year" }]],
+  },
+  display: "pivot",
+};
+
+describe("issue 15353", () => {
+  beforeEach(() => {
+    cy.intercept("POST", "/api/dataset/pivot").as("pivotDataset");
+
+    restore();
+    cy.signInAsAdmin();
+
+    cy.createQuestion(questionDetails, { visitQuestion: true });
+  });
+
+  it("should be able to change field name used for values (metabase#15353)", () => {
+    cy.findByTestId("viz-settings-button").click();
+    sidebar()
+      .contains("Count")
+      .click();
+
+    cy.findByText("See options…").click();
+
+    cy.findByDisplayValue("Count")
+      .type(" renamed")
+      .blur();
+
+    cy.wait("@pivotDataset");
+
+    cy.get(".Visualization").should("contain", "Count renamed");
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #15353 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/visualizations/reproductions/15353-pivot-settings-change-name-values.cy.spec.js`
- All tests should pass

### Additional notes:
- The bug was fixed in #20435

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/155016970-f547ab5b-b774-445c-95fe-53c381a4dc81.png)

