### PR TITLE
Repro #20469: Main page loading spinner spins forever on API error

### DIFF
--- a/frontend/test/metabase/scenarios/onboarding/home/homepage.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/home/homepage.cy.spec.js
@@ -10,6 +10,18 @@ describe("scenarios > home > homepage", () => {
       cy.signInAsAdmin();
     });
 
+    it.skip("should handle server errors on load (metabase#20469)", () => {
+      cy.intercept("GET", "/api/database", req => {
+        req.reply({
+          statusCode: 500,
+        });
+      });
+
+      cy.visit("/");
+      // Even if we don't receive a list of our databases, we should still be able to load all items in the root collection
+      cy.findByText("Browse all items");
+    });
+
     it("should allow basic navigation", () => {
       cy.visit("/");
       cy.findByText("Add my data").click();


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #20469 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/onboarding/home/homepage.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/155150848-8fa082b4-f497-414a-b240-19783e62102b.png)

