### PR TITLE
Handle missing `dataset_query` when trying to map parameter targets to fields

### DIFF
--- a/frontend/src/metabase/parameters/utils/dashboards.js
+++ b/frontend/src/metabase/parameters/utils/dashboards.js
@@ -64,7 +64,7 @@ export function isDashboardParameterWithoutMapping(parameter, dashboard) {
 }
 
 function getMappingTargetField(card, mapping, metadata) {
-  if (!card) {
+  if (!card || !card.dataset_query) {
     return null;
   }
 

--- a/frontend/src/metabase/parameters/utils/dashboards.js
+++ b/frontend/src/metabase/parameters/utils/dashboards.js
@@ -64,7 +64,7 @@ export function isDashboardParameterWithoutMapping(parameter, dashboard) {
 }
 
 export function getMappingTargetField(card, mapping, metadata) {
-  if (!card || !card.dataset_query) {
+  if (!card?.dataset_query) {
     return null;
   }
 

--- a/frontend/src/metabase/parameters/utils/dashboards.js
+++ b/frontend/src/metabase/parameters/utils/dashboards.js
@@ -63,7 +63,7 @@ export function isDashboardParameterWithoutMapping(parameter, dashboard) {
   return parameterExistsOnDashboard && !parameterHasMapping;
 }
 
-function getMappingTargetField(card, mapping, metadata) {
+export function getMappingTargetField(card, mapping, metadata) {
   if (!card || !card.dataset_query) {
     return null;
   }

--- a/frontend/src/metabase/parameters/utils/dashboards.unit.spec.js
+++ b/frontend/src/metabase/parameters/utils/dashboards.unit.spec.js
@@ -9,6 +9,7 @@ import {
   hasMatchingParameters,
   getFilteringParameterValuesMap,
   getParameterValuesSearchKey,
+  getMappingTargetField,
 } from "metabase/parameters/utils/dashboards";
 import { metadata } from "__support__/sample_database_fixture";
 
@@ -691,6 +692,56 @@ describe("meta/Dashboard", () => {
       ).toEqual(
         "dashboardId: 123, parameterId: 456, query: abc, filteringParameterValues: []",
       );
+    });
+  });
+
+  describe("getMappingTargetField", () => {
+    const mapping = {
+      parameter_id: "dbe38f17",
+      card_id: 1,
+      target: ["dimension", ["field", 4, null]],
+    };
+
+    const metadata = {
+      field: jest.fn(),
+    };
+
+    it("should return null when not given a card", () => {
+      expect(getMappingTargetField(null, mapping, metadata)).toBe(null);
+    });
+
+    it("should return null when given a card without a `dataset_query`", () => {
+      const card = {
+        id: 1,
+      };
+
+      expect(getMappingTargetField(card, mapping, metadata)).toBe(null);
+    });
+
+    it("should return the field that maps to the mapping target", () => {
+      const field = {
+        id: 4,
+        name: "foo",
+      };
+
+      metadata.field.mockImplementation(id => {
+        if (id === 4) {
+          return field;
+        }
+      });
+
+      const card = {
+        id: 1,
+        dataset_query: {
+          type: "query",
+          database: 1,
+          query: {
+            "source-table": 1,
+          },
+        },
+      };
+
+      expect(getMappingTargetField(card, mapping, metadata)).toEqual(field);
     });
   });
 });

--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/20656-dashboard-breaks-for-user-without-card-permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/20656-dashboard-breaks-for-user-without-card-permissions.cy.spec.js
@@ -11,7 +11,7 @@ const filter = {
   sectionId: "id",
 };
 
-describe.skip("issue 20656", () => {
+describe("issue 20656", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
@@ -55,6 +55,6 @@ describe.skip("issue 20656", () => {
     // Make sure the filter widget is there
     filterWidget();
 
-    cy.findByText("Sorry, you don't have permissions to see this card.");
+    cy.findByText("Sorry, you don't have permission to see this card.");
   });
 });


### PR DESCRIPTION
Fixes #20656

When a user visits a dashboard that contains a card they do not have the proper permissions to view, the card data structure the FE is given is essentially `{ id }` and nothing else. The new parameters code added in 42 instantiates a `Question` with this `card` and calls `question.query()` when instantiating a `Dimension` instance, but `Question.prototype.query` does not handle scenarios where `dataset_query` is undefined.

I'm adding an additional predicate to check for a missing `card.dataset_query` in a dashboard parameters util function. Long term it probably makes more sense to avoid having parameters code inspect the internals of a `card`, but I want to avoid making a hasty decision regarding how to handle a question with a missing `card.dataset_query` -- alternatives to this likely need a bit more thinking. If `Question.prototype.query` is changed to return `null` or something, it'd force a cascade of changes as the function is currently guaranteed to return some sort of Query. Another possible alternative is that we default to something like `OpaqueQuery` if `dataset_query` is undefined.

**Testing**
Follow the steps in #20656 

**Before**

https://user-images.githubusercontent.com/13057258/155383111-3e967912-f911-47e7-a660-1426d5a73a8a.mov

**After**


https://user-images.githubusercontent.com/13057258/155383161-e7e4bc91-872b-408e-9f2e-41b48d4734af.mov


