### PR TITLE
Handle nulls in ListField filter

### DIFF
--- a/frontend/src/metabase/components/ListField/ListField.tsx
+++ b/frontend/src/metabase/components/ListField/ListField.tsx
@@ -77,8 +77,7 @@ export const ListField = ({
     }
 
     return augmentedOptions.filter(option =>
-      option[0]
-        .toString()
+      String(option[0])
         .toLowerCase()
         .includes(trimmedFilter),
     );

--- a/frontend/src/metabase/components/ListField/ListField.tsx
+++ b/frontend/src/metabase/components/ListField/ListField.tsx
@@ -50,7 +50,7 @@ export const ListField = ({
   );
 
   const augmentedOptions = useMemo(() => {
-    return [...options, ...addedOptions];
+    return [...options.filter(option => option[0] != null), ...addedOptions];
   }, [addedOptions, options]);
 
   const sortedOptions = useMemo(() => {


### PR DESCRIPTION
Fixes #20618

`option[0]` can be `null`. These options are unusable, so I'm filtering them out. In addition to that, I've replaced `option[0].toString()` with `String(option[0])` to avoid any future scenarios where `option[0]` might not have a `toString` method. This is similar to what is found in `FieldValuesWidget`

**Testing**
Follow the steps in #20618 
You can also fake the presence of nulls by going to `FieldValuesWidget` and replacing ListField's options prop with `options={[[null]].concat(options)}`. The options shouldn't show up in the `ListField` list of options.


