### PR TITLE
Repro #20637: Can't combine saved questions on a dashboard card

### DIFF
--- a/frontend/test/metabase/scenarios/visualizations/reproductions/20637-multi-series-second-question-incompatible.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/reproductions/20637-multi-series-second-question-incompatible.cy.spec.js
@@ -1,0 +1,59 @@
+import {
+  restore,
+  editDashboard,
+  showDashboardCardActions,
+} from "__support__/e2e/cypress";
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
+const { ORDERS, ORDERS_ID, PEOPLE_ID, PEOPLE } = SAMPLE_DATABASE;
+
+const questionDetails = {
+  name: "First Series",
+  query: {
+    "source-table": ORDERS_ID,
+    aggregation: [["count"]],
+    breakout: [["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }]],
+  },
+  display: "line",
+};
+
+const secondSeriesQuestion = {
+  name: "Second Series",
+  query: {
+    "source-table": PEOPLE_ID,
+    aggregation: [["count"]],
+    breakout: [["field", PEOPLE.CREATED_AT, { "temporal-unit": "month" }]],
+  },
+  display: "line",
+};
+
+describe.skip("issue 20637", () => {
+  beforeEach(() => {
+    cy.intercept("GET", "/api/collection/root").as("rootCollection");
+
+    restore();
+    cy.signInAsAdmin();
+
+    cy.createQuestion(secondSeriesQuestion);
+  });
+
+  it("should be able to add a second series to the dashboard card (metabase#20637)", () => {
+    cy.createQuestionAndDashboard({ questionDetails }).then(
+      ({ body: { dashboard_id } }) => {
+        cy.visit(`/dashboard/${dashboard_id}`);
+        cy.wait("@rootCollection");
+      },
+    );
+
+    editDashboard();
+
+    showDashboardCardActions();
+    cy.icon("line").click();
+
+    cy.findByText(secondSeriesQuestion.name).click();
+
+    cy.findAllByTestId("legend-item")
+      .should("contain", "Count")
+      .and("have.length", 2);
+  });
+});

--- a/frontend/test/metabase/scenarios/visualizations/reproductions/20637-multi-series-second-question-incompatible.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/reproductions/20637-multi-series-second-question-incompatible.cy.spec.js
@@ -7,25 +7,17 @@ import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID, PEOPLE_ID, PEOPLE } = SAMPLE_DATABASE;
 
-const questionDetails = {
+const questionDetails = getQuestionDetails({
   name: "First Series",
-  query: {
-    "source-table": ORDERS_ID,
-    aggregation: [["count"]],
-    breakout: [["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }]],
-  },
-  display: "line",
-};
+  source: ORDERS_ID,
+  breakout: ORDERS.CREATED_AT,
+});
 
-const secondSeriesQuestion = {
+const secondSeriesQuestion = getQuestionDetails({
   name: "Second Series",
-  query: {
-    "source-table": PEOPLE_ID,
-    aggregation: [["count"]],
-    breakout: [["field", PEOPLE.CREATED_AT, { "temporal-unit": "month" }]],
-  },
-  display: "line",
-};
+  source: PEOPLE_ID,
+  breakout: PEOPLE.CREATED_AT,
+});
 
 describe.skip("issue 20637", () => {
   beforeEach(() => {
@@ -57,3 +49,15 @@ describe.skip("issue 20637", () => {
       .and("have.length", 2);
   });
 });
+
+function getQuestionDetails({ name, source, breakout } = {}) {
+  return {
+    name,
+    query: {
+      "source-table": source,
+      aggregation: [["count"]],
+      breakout: [["field", breakout, { "temporal-unit": "month" }]],
+    },
+    display: "line",
+  };
+}


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #20637 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/visualizations/reproductions/20637-multi-series-second-question-incompatible.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/155201725-73594ee5-4496-424d-91c3-faaaab41b9b0.png)

