### PR TITLE
Don't consider `:field` `:join-alias` when escaping aliases

### DIFF
--- a/frontend/test/metabase/scenarios/question/reproductions/20627-nested-long-names-wrong-aliases.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/20627-nested-long-names-wrong-aliases.cy.spec.js
@@ -13,7 +13,7 @@ const { ORDERS, PRODUCTS_ID } = SAMPLE_DATABASE;
 const newColumnName = "Product ID with a very long name";
 const newTableName = "Products with a very long name";
 
-describe.skip("issue 20627", () => {
+describe("issue 20627", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -486,10 +486,6 @@
   dispatch-on-initialized-driver
   :hierarchy #'hierarchy)
 
-;; TODO -- I have a PR to add some truncation logic for this so we don't end up with crazy-long identifiers -- see
-;; #19659
-;;
-;; TODO -- we should probably also remove diacritical marks like we do for BigQuery
 (defmethod escape-alias ::driver
   [_driver alias-name]
   (impl/truncate-alias alias-name))

--- a/src/metabase/query_processor/middleware/escape_join_aliases.clj
+++ b/src/metabase/query_processor/middleware/escape_join_aliases.clj
@@ -29,9 +29,6 @@
 
 (defn- all-join-aliases [query]
   (into #{} cat (mbql.u/match query
-                  [:field _ (m :guard :join-alias)]
-                  [(:join-alias m)]
-
                   (join :guard (every-pred map? :condition :alias))
                   (cons
                    (:alias join)

--- a/test/metabase/query_processor_test/nested_queries_test.clj
+++ b/test/metabase/query_processor_test/nested_queries_test.clj
@@ -1299,3 +1299,27 @@
               (is (= [["2016-04-01T00:00:00Z" 175]]
                      (mt/formatted-rows [str int]
                        (qp/process-query query)))))))))))
+
+(deftest really-really-long-identifiers-test
+  (testing "Should correctly handle really really long table and column names (#20627)"
+    (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries :basic-aggregations :left-join)
+      (mt/dataset sample-dataset
+        (let [table-alias "Products with a very long name - Product ID with a very long name"
+              query       (mt/mbql-query orders
+                            {:source-query {:source-table $$orders
+                                            :joins        [{:source-table $$products
+                                                            :alias        table-alias
+                                                            :condition    [:=
+                                                                           $product_id
+                                                                           [:field %products.id {:join-alias table-alias}]]
+                                                            :fields       :all}]
+                                            :breakout     [[:field %products.category {:join-alias table-alias}]]
+                                            :aggregation  [[:count]]}
+                             :filter       [:> *count/Integer 0]})]
+          (mt/with-native-query-testing-context query
+            (is (= [["Doohickey" 3976]
+                    ["Gadget"    4939]
+                    ["Gizmo"     4784]
+                    ["Widget"    5061]]
+                   (mt/formatted-rows [str int]
+                     (qp/process-query query))))))))))


### PR DESCRIPTION
Fixes #20610
Fixes #20627

The new logic in #19659 was getting tripped up when nested queries had `:field` clauses whose join aliases were truncated -- it was incorrectly treating these as duplicate aliases and generating unique escaped join aliases. The fix was to only consider the `:alias` in the join itself for purposes of deduplication/escaping. 