### PR TITLE
Always show database sync buttons

### DIFF
--- a/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.jsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.jsx
@@ -36,33 +36,29 @@ const DatabaseEditAppSidebar = ({
           <ol>
             {!isSyncCompleted(database) && (
               <li>
-                <Button disabled>{t`Syncing database…`}</Button>
+                <Button disabled borderless>{t`Syncing database…`}</Button>
               </li>
             )}
-            {isSyncCompleted(database) && (
-              <li>
-                <ActionButton
-                  actionFn={() => syncDatabaseSchema(database.id)}
-                  className="Button Button--syncDbSchema"
-                  normalText={t`Sync database schema now`}
-                  activeText={t`Starting…`}
-                  failedText={t`Failed to sync`}
-                  successText={t`Sync triggered!`}
-                />
-              </li>
-            )}
-            {isSyncCompleted(database) && (
-              <li className="mt2">
-                <ActionButton
-                  actionFn={() => rescanDatabaseFields(database.id)}
-                  className="Button Button--rescanFieldValues"
-                  normalText={t`Re-scan field values now`}
-                  activeText={t`Starting…`}
-                  failedText={t`Failed to start scan`}
-                  successText={t`Scan triggered!`}
-                />
-              </li>
-            )}
+            <li>
+              <ActionButton
+                actionFn={() => syncDatabaseSchema(database.id)}
+                className="Button Button--syncDbSchema"
+                normalText={t`Sync database schema now`}
+                activeText={t`Starting…`}
+                failedText={t`Failed to sync`}
+                successText={t`Sync triggered!`}
+              />
+            </li>
+            <li className="mt2">
+              <ActionButton
+                actionFn={() => rescanDatabaseFields(database.id)}
+                className="Button Button--rescanFieldValues"
+                normalText={t`Re-scan field values now`}
+                activeText={t`Starting…`}
+                failedText={t`Failed to start scan`}
+                successText={t`Scan triggered!`}
+              />
+            </li>
           </ol>
         </div>
 

--- a/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.unit.spec.js
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.unit.spec.js
@@ -98,19 +98,12 @@ it("removes database", () => {
   expect(deleteDatabase).toHaveBeenCalled();
 });
 
-it("hides syncing actions until the initial sync", () => {
+it("shows loading indicator when a sync is in progress", () => {
   const databaseId = 1;
   const database = { id: databaseId, initial_sync_status: "incomplete" };
 
   render(<Sidebar database={database} />);
 
   const statusButton = screen.getByText("Syncing database…");
-  const syncButton = screen.queryByText("Sync database schema now");
-  const rescanButton = screen.queryByText("Re-scan field values now");
-  const discardButton = screen.queryByText("Discard saved field values");
-
   expect(statusButton).toBeInTheDocument();
-  expect(syncButton).not.toBeInTheDocument();
-  expect(rescanButton).not.toBeInTheDocument();
-  expect(discardButton).not.toBeInTheDocument();
 });


### PR DESCRIPTION
Resolves #20283

`initial_sync_status` can get stuck at `incomplete` so with no other way to force a resync the solution is to always show the buttons to sync the db. Is this the right thing to do, @noahmoss & @ranquild?

@mazameli -- any stylistic touches you want made here?

![Screen Shot 2022-02-22 at 1 00 27 PM](https://user-images.githubusercontent.com/13057258/155218671-937688f2-2ead-44dd-9daf-d96a141965cb.png)
