### PR TITLE
Increase H2 lock timeout for E2E tests

### DIFF
--- a/src/metabase/api/testing.clj
+++ b/src/metabase/api/testing.clj
@@ -24,7 +24,7 @@
     (api/check-404 (.exists (java.io.File. path)))
     (with-open [conn (jdbc/get-connection (db/connection))]
       (let [conn-spec {:connection conn}]
-        (jdbc/execute! conn-spec ["SET LOCK_TIMEOUT 120000"])
+        (jdbc/execute! conn-spec ["SET LOCK_TIMEOUT 180000"])
         (jdbc/execute! conn-spec ["DROP ALL OBJECTS"])
         (jdbc/execute! conn-spec ["RUNSCRIPT FROM ?" path]))))
   (cache/restore-cache!)


### PR DESCRIPTION
The previously set 120-second timeout in PR #19412 is apparently
not sufficient, as admin-ee and sharing-ee still occasionally fail.

**Before this PR**

Something like this happens, e.g. in sharing-ee or admin-ee test groups. Note that the tests did not even run yet:

![scenarios  dashboard  subscriptions -- should allow sharing if dashboard contains only text cards (metabase#15077) (failed)](https://user-images.githubusercontent.com/7288/155222507-061ebac7-ae37-4c63-a8c5-c2a95c156a25.png)

**After this PR**

Such failures should happen less frequently (if we're superlucky, never).