### PR TITLE
E2E admin l10n tests: wait for table header to be visible first

### DIFF
--- a/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
@@ -162,32 +162,7 @@ describe("scenarios > admin > settings", () => {
     restore(); // avoid leaving https site url
   });
 
-  it("should update the formatting", () => {
-    cy.server();
-    cy.route("PUT", "**/custom-formatting").as("saveFormatting");
-
-    // update the formatting
-    cy.visit("/admin/settings/localization");
-    cy.contains("17:24 (24-hour clock)").click();
-    cy.wait("@saveFormatting");
-
-    // check the new formatting in a question
-    openOrdersTable();
-    cy.contains(/^February 11, 2019, 21:40$/);
-
-    // reset the formatting
-    cy.visit("/admin/settings/localization");
-    cy.contains("5:24 PM (12-hour clock)").click();
-    cy.wait("@saveFormatting");
-
-    // check the reset formatting in a question
-    openOrdersTable();
-
-    cy.findByText("Created At").should("be.visible");
-    cy.contains(/^February 11, 2019, 9:40 PM$/);
-  });
-
-  it("should correctly apply the globalized date formats (metabase#11394)", () => {
+  it("should correctly apply the globalized date formats (metabase#11394) and update the formatting", () => {
     cy.intercept("PUT", "**/custom-formatting").as("saveFormatting");
 
     cy.request("PUT", `/api/field/${ORDERS.CREATED_AT}`, {
@@ -208,6 +183,16 @@ describe("scenarios > admin > settings", () => {
     cy.get(".cellData")
       .should("contain", "Created At")
       .and("contain", "2019/2/11, 21:40");
+
+    // Go back to the settings and reset the time formatting
+    cy.visit("/admin/settings/localization");
+
+    cy.findByText("5:24 PM (12-hour clock)").click();
+    cy.wait("@saveFormatting");
+
+    openOrdersTable({ limit: 2 });
+
+    cy.get(".cellData").and("contain", "2019/2/11, 9:40 PM");
   });
 
   it("should search for and select a new timezone", () => {

--- a/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
@@ -205,8 +205,9 @@ describe("scenarios > admin > settings", () => {
 
     openOrdersTable({ limit: 2 });
 
-    cy.findByText("Created At").should("be.visible");
-    cy.contains(/^2019\/2\/11, 21:40$/);
+    cy.get(".cellData")
+      .should("contain", "Created At")
+      .and("contain", "2019/2/11, 21:40");
   });
 
   it("should search for and select a new timezone", () => {

--- a/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
@@ -196,11 +196,7 @@ describe("scenarios > admin > settings", () => {
 
     cy.visit("/admin/settings/localization");
 
-    cy.contains("Date style")
-      .closest("li")
-      .find("[data-testid='select-button']")
-      .first()
-      .click();
+    cy.findByText("January 7, 2018").click({ force: true });
     cy.findByText("2018/1/7").click({ force: true });
     cy.contains("17:24 (24-hour clock)").click();
     cy.wait("@saveFormatting");

--- a/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
@@ -198,7 +198,9 @@ describe("scenarios > admin > settings", () => {
 
     cy.findByText("January 7, 2018").click({ force: true });
     cy.findByText("2018/1/7").click({ force: true });
-    cy.contains("17:24 (24-hour clock)").click();
+    cy.wait("@saveFormatting");
+
+    cy.findByText("17:24 (24-hour clock)").click();
     cy.wait("@saveFormatting");
 
     openOrdersTable();

--- a/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
@@ -182,6 +182,8 @@ describe("scenarios > admin > settings", () => {
 
     // check the reset formatting in a question
     openOrdersTable();
+
+    cy.findByText("Created At").should("be.visible");
     cy.contains(/^February 11, 2019, 9:40 PM$/);
   });
 
@@ -205,6 +207,8 @@ describe("scenarios > admin > settings", () => {
     cy.wait("@saveFormatting");
 
     openOrdersTable();
+
+    cy.findByText("Created At").should("be.visible");
     cy.contains(/^2019\/2\/11, 21:40$/);
   });
 

--- a/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
@@ -203,7 +203,7 @@ describe("scenarios > admin > settings", () => {
     cy.findByText("17:24 (24-hour clock)").click();
     cy.wait("@saveFormatting");
 
-    openOrdersTable();
+    openOrdersTable({ limit: 2 });
 
     cy.findByText("Created At").should("be.visible");
     cy.contains(/^2019\/2\/11, 21:40$/);

--- a/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
@@ -188,8 +188,7 @@ describe("scenarios > admin > settings", () => {
   });
 
   it("should correctly apply the globalized date formats (metabase#11394)", () => {
-    cy.server();
-    cy.route("PUT", "**/custom-formatting").as("saveFormatting");
+    cy.intercept("PUT", "**/custom-formatting").as("saveFormatting");
 
     cy.request("PUT", `/api/field/${ORDERS.CREATED_AT}`, {
       semantic_type: null,


### PR DESCRIPTION
Not sure if this is the best idea, but seems that waiting for the table to render properly is a prospective ~fix~ workaround worth trying.

**Before this PR**

A few times, the localization tests failed like this:

![scenarios  admin  settings -- should correctly apply the globalized date formats (metabase#11394) (failed)](https://user-images.githubusercontent.com/7288/155249402-cce4be11-8a23-418a-ab99-89378e1314c7.png)

**After this PR**

The failure should happen less frequently (ideally, never happen again).
