### PR TITLE
Repro #20683: Error when filtering date by current quarter in Postgres

### DIFF
--- a/frontend/test/metabase/scenarios/question/reproductions/20683-postgres-current-quarter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/20683-postgres-current-quarter.cy.spec.js
@@ -1,0 +1,36 @@
+import { restore, visualize } from "__support__/e2e/cypress";
+
+describe.skip("issue 20683", () => {
+  beforeEach(() => {
+    restore("postgres-12");
+    cy.signInAsAdmin();
+
+    cy.visit("/");
+    cy.findByText("New").click();
+    cy.findByText("Question")
+      .should("be.visible")
+      .click();
+
+    cy.findByText("QA Postgres12").click();
+    cy.findByText("Orders").click();
+  });
+
+  it("should filter postgres with the 'current quarter' filter (metabase#20683)", () => {
+    cy.findByText("Add filters to narrow your answer").click();
+
+    cy.findByText("Created At").click();
+
+    cy.findByText("Previous").click();
+    cy.findByText("Current").click();
+
+    cy.findByText("Day").click();
+    cy.findByText("Quarter").click();
+
+    cy.button("Add filter").click();
+
+    visualize();
+
+    // We don't have entries for the current quarter so we expect no results
+    cy.findByText("No results!");
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #20683 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/question/reproductions/20683-postgres-current-quarter.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/155327989-79812cc1-37bf-4402-bc6c-ce255d828095.png)

