### PR TITLE
Repro #19744: Custom Column after aggregation causes dashboard filtering to be very limited

### DIFF
--- a/frontend/test/metabase/scenarios/custom-column/reproductions/19744-cc-after-aggregation-limited-filters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/reproductions/19744-cc-after-aggregation-limited-filters.cy.spec.js
@@ -1,0 +1,87 @@
+import {
+  restore,
+  editDashboard,
+  visitQuestionAdhoc,
+  popover,
+} from "__support__/e2e/cypress";
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
+const { PRODUCTS_ID, PRODUCTS } = SAMPLE_DATABASE;
+
+const questionDetails = {
+  dataset_query: {
+    type: "query",
+    query: {
+      "source-query": {
+        "source-table": PRODUCTS_ID,
+        aggregation: [
+          ["count"],
+          ["sum", ["field", PRODUCTS.PRICE, null]],
+          ["sum", ["field", PRODUCTS.RATING, null]],
+        ],
+        breakout: [["field", PRODUCTS.CATEGORY, null]],
+      },
+      expressions: { Math: ["+", 1, 1] },
+    },
+    database: 1,
+  },
+  display: "bar",
+};
+
+describe.skip("issue 19744", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    // For this specific repro, it's crucial to first visit the question in order to load the `results_metadata`...
+    visitQuestionAdhoc(questionDetails);
+    // ...and then to save it using the UI
+    saveQuestion("19744");
+
+    addQuestionToDashboardAndVisit();
+  });
+
+  it("custom column after aggregation shouldn't limit or change the behavior of dashboard filters (metabase#19744)", () => {
+    editDashboard();
+    cy.icon("filter").click();
+
+    cy.findByText("Time").click();
+    cy.findByText("All Options").click();
+
+    cy.get(".DashCard")
+      .contains("Select…")
+      .click();
+    popover().contains("Created At");
+  });
+});
+
+function saveQuestion(name) {
+  cy.intercept("POST", "/api/card").as("saveQuestion");
+
+  cy.findByText("Save").click();
+  cy.findByLabelText("Name").type(name);
+
+  cy.get(".Modal")
+    .button("Save")
+    .click();
+
+  cy.findByText("Not now").click();
+
+  cy.wait("@saveQuestion").then(({ response: { body } }) => {
+    cy.wrap(body.id).as("questionId");
+  });
+}
+
+function addQuestionToDashboardAndVisit() {
+  cy.createDashboard().then(({ body: { id } }) => {
+    cy.get("@questionId").then(cardId => {
+      cy.request("POST", `/api/dashboard/${id}/cards`, {
+        cardId,
+        sizeX: 16,
+        sizeY: 10,
+      });
+    });
+
+    cy.visit(`/dashboard/${id}`);
+  });
+}


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #19744 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/custom-column/reproductions/19744-cc-after-aggregation-limited-filters.cy.spec.js`
- Unskip the repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/155351452-c7cc76d4-1160-43f8-8af7-d104fc0ddee0.png)

