### PR TITLE
Update permission path regex & parser to support download permissions

### DIFF
--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -222,7 +222,8 @@
   "Regex for a valid permissions path. The [[metabase.util.regex/rx]] macro is used to make the big-and-hairy regex
   somewhat readable."
   (u.regex/rx "^/"
-              ;; any path starting with /db/ is a DATA PERMISSIONS path
+              ;; any path containing /db/ is a DATA permissions path
+              ;; any path starting with /db/ is a DATA ACCESS permissions path
               (or
                ;; /db/:id/ -> permissions for the entire DB -- native and all schemas
                (and #"db/\d+/"
@@ -243,6 +244,17 @@
                                                               ;; .../segmented/ -> Permissions to run a query against
                                                               ;; a Table using GTAP
                                                               (opt "segmented/"))))))))))))
+               ;; any path starting with /download/ is a DOWNLOAD permissions path
+               ;; /download/db/:id/ -> permissions to download 1M rows in query results
+               ;; /download/limited/db/:id/ -> permissions to download 1k rows in query results
+               (and "download/"
+                    (opt "limited/")
+                    (and #"db/\d+/"
+                         (opt (or
+                               "native/"
+                               (and "schema/"
+                                    (opt (and path-char "*/"
+                                              (opt #"table/\d+/"))))))))
                ;; any path starting with /collection/ is a COLLECTION permissions path
                (and "collection/"
                     (or

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -618,6 +618,7 @@
                                             [:or
                                              [:= :object (hx/literal "/")]
                                              [:like :object (hx/literal "/db/%")]
+                                             [:like :object (hx/literal "/download/%")]
                                              [:like :object (hx/literal "/block/db/%")]]]})
         db-ids          (delay (db/select-ids 'Database))
         group-id->paths (reduce

--- a/src/metabase/models/permissions/parse.clj
+++ b/src/metabase/models/permissions/parse.clj
@@ -12,7 +12,7 @@
 
 (def ^:private grammar
   "Describes permission strings like /db/3/ or /collection/root/read/"
-  "permission = ( all | db | collection | block )
+  "permission = ( all | db | download | collection | block )
   all         = <'/'>
   db          = <'/db/'> #'\\d+' <'/'> ( native | schemas )?
   native      = <'native/'>
@@ -20,6 +20,14 @@
   schema      = #'[^/]*' <'/'> table?
   table       = <'table/'> #'\\d+' <'/'> (table-perm <'/'>)?
   table-perm  = ('read'|'query'|'query/segmented')
+
+  download    = <'/download'> ( dl-limited | dl-db )
+  dl-limited  = <'/limited'>  dl-db
+  dl-db       = <'/db/'> #'\\d+' <'/'> ( dl-native | dl-schemas )?
+  dl-native   = <'native/'>
+  dl-schemas  = <'schema/'> dl-schema?
+  dl-schema   = #'[^/]*' <'/'> dl-table?
+  dl-table    = <'table/'> #'\\d+' <'/'>
 
   collection  = <'/collection/'> #'[^/]*' <'/'> ('read' <'/'>)?
 
@@ -33,34 +41,55 @@
   [id]
   (if (= id "root") :root (Long/parseUnsignedLong id)))
 
+(defn- append
+  [path-or-paths x]
+  (if (seqable? (first path-or-paths))
+    (map (fn [path] (append path x)) (seq path-or-paths))
+    (into path-or-paths [x])))
+
 (defn- path
   "Recursively build permission path from parse tree"
   [tree]
   (match/match tree
-    (_ :guard insta/failure?)    (log/error (trs "Error parsing permissions tree {0}" (pr-str tree)))
-    [:permission t]              (path t)
-    [:all]                       [:all] ; admin permissions
-    [:db db-id]                  (let [db-id (Long/parseUnsignedLong db-id)]
-                                   [[:db db-id :data :native :write]
-                                    [:db db-id :data :schemas :all]])
-    [:db db-id db-node]          (let [db-id (Long/parseUnsignedLong db-id)]
-                                   (into [:db db-id] (path db-node)))
-    [:schemas]                   [:data :schemas :all]
-    [:schemas schema]            (into [:data :schemas] (path schema))
-    [:schema schema-name]        [schema-name :all]
-    [:schema schema-name table]  (into [schema-name] (path table))
-    [:table table-id]            [(Long/parseUnsignedLong table-id) :all]
-    [:table table-id table-perm] (into [(Long/parseUnsignedLong table-id)] (path table-perm))
-    [:table-perm perm]            (case perm
-                                    "read"            [:read :all]
-                                    "query"           [:query :all]
-                                    "query/segmented" [:query :segmented])
-    [:native]                    [:data :native :write]
+    (_ :guard insta/failure?)      (log/error (trs "Error parsing permissions tree {0}" (pr-str tree)))
+    [:permission t]                (path t)
+    [:all]                         [:all] ; admin permissions
+    [:db db-id]                    (let [db-id (Long/parseUnsignedLong db-id)]
+                                     [[:db db-id :data :native :write]
+                                      [:db db-id :data :schemas :all]])
+    [:db db-id db-node]            (let [db-id (Long/parseUnsignedLong db-id)]
+                                     (into [:db db-id] (path db-node)))
+    [:schemas]                     [:data :schemas :all]
+    [:schemas schema]              (into [:data :schemas] (path schema))
+    [:schema schema-name]          [schema-name :all]
+    [:schema schema-name table]    (into [schema-name] (path table))
+    [:table table-id]              [(Long/parseUnsignedLong table-id) :all]
+    [:table table-id table-perm]   (into [(Long/parseUnsignedLong table-id)] (path table-perm))
+    [:table-perm perm]              (case perm
+                                      "read"            [:read :all]
+                                      "query"           [:query :all]
+                                      "query/segmented" [:query :segmented])
+    [:native]                      [:data :native :write]
+    ;; download perms
+    [:download
+     [:limited db-node]]           (append (path db-node) :limited)
+    [:download db-node]            (append (path db-node) :full)
+    [:dl-db db-id]                 (let [db-id (Long/parseUnsignedLong db-id)]
+                                     #{[:db db-id :download :native]
+                                       [:db db-id :download :schemas]})
+    [:dl-db db-id db-node]         (let [db-id (Long/parseUnsignedLong db-id)]
+                                     (into [:db db-id] (path db-node)))
+    [:dl-schemas]                  [:download :schemas]
+    [:dl-schemas schema]           (into [:data :schemas] (path schema))
+    [:dl-schema schema-name]       [schema-name]
+    [:dl-schema schema-name table] (into [schema-name] (path table))
+    [:dl-table table-id]           [(Long/parseUnsignedLong table-id) :all]
+    [:dl-native]                   [:download :native]
     ;; collection perms
-    [:collection id]             [:collection (collection-id id) :write]
-    [:collection id "read"]      [:collection (collection-id id) :read]
+    [:collection id]               [:collection (collection-id id) :write]
+    [:collection id "read"]        [:collection (collection-id id) :read]
     ;; block perms. Parse something like /block/db/1/ to {:db {1 {:schemas :block}}}
-    [:block db-id]               [:db (Long/parseUnsignedLong db-id) :data :schemas :block]))
+    [:block db-id]                 [:db (Long/parseUnsignedLong db-id) :data :schemas :block]))
 
 (defn- graph
   "Given a set of permission paths, return a graph that expresses the most permissions possible for the set
@@ -95,7 +124,7 @@
        (walk/prewalk (fn [x]
                        (or (when (map? x)
                              (some #(and (= (% x) '()) %)
-                                   [:block :all :some :write :read :segmented]))
+                                   [:block :all :some :write :read :segmented :full :limited]))
                            x)))))
 
 (defn permissions->graph

--- a/src/metabase/models/permissions/parse.clj
+++ b/src/metabase/models/permissions/parse.clj
@@ -41,10 +41,11 @@
   [id]
   (if (= id "root") :root (Long/parseUnsignedLong id)))
 
-(defn- append
+(defn- append-to-all
+  "If `path-or-paths` is a single path, append `x` to the end of it. If it's a vector of paths, append `x` to each path."
   [path-or-paths x]
   (if (seqable? (first path-or-paths))
-    (map (fn [path] (append path x)) (seq path-or-paths))
+    (map (fn [path] (append-to-all path x)) (seq path-or-paths))
     (into path-or-paths [x])))
 
 (defn- path
@@ -72,8 +73,8 @@
     [:native]                      [:data :native :write]
     ;; download perms
     [:download
-     [:limited db-node]]           (append (path db-node) :limited)
-    [:download db-node]            (append (path db-node) :full)
+     [:limited db-node]]           (append-to-all (path db-node) :limited)
+    [:download db-node]            (append-to-all (path db-node) :full)
     [:dl-db db-id]                 (let [db-id (Long/parseUnsignedLong db-id)]
                                      #{[:db db-id :download :native]
                                        [:db db-id :download :schemas]})

--- a/src/metabase/models/permissions/parse.clj
+++ b/src/metabase/models/permissions/parse.clj
@@ -73,7 +73,7 @@
     [:native]                      [:data :native :write]
     ;; download perms
     [:download
-     [:limited db-node]]           (append-to-all (path db-node) :limited)
+     [:dl-limited db-node]]        (append-to-all (path db-node) :limited)
     [:download db-node]            (append-to-all (path db-node) :full)
     [:dl-db db-id]                 (let [db-id (Long/parseUnsignedLong db-id)]
                                      #{[:db db-id :download :native]
@@ -81,10 +81,10 @@
     [:dl-db db-id db-node]         (let [db-id (Long/parseUnsignedLong db-id)]
                                      (into [:db db-id] (path db-node)))
     [:dl-schemas]                  [:download :schemas]
-    [:dl-schemas schema]           (into [:data :schemas] (path schema))
+    [:dl-schemas schema]           (into [:download :schemas] (path schema))
     [:dl-schema schema-name]       [schema-name]
     [:dl-schema schema-name table] (into [schema-name] (path table))
-    [:dl-table table-id]           [(Long/parseUnsignedLong table-id) :all]
+    [:dl-table table-id]           [(Long/parseUnsignedLong table-id)]
     [:dl-native]                   [:download :native]
     ;; collection perms
     [:collection id]               [:collection (collection-id id) :write]

--- a/test/metabase/models/permissions/parse_test.clj
+++ b/test/metabase/models/permissions/parse_test.clj
@@ -5,15 +5,27 @@
 (deftest permissions->graph
   (testing "Parses each permission string to the correct graph"
     (are [x y] (= y (parse/permissions->graph [x]))
-      "/db/3/"                                       {:db {3 {:data {:native  :write
-                                                                     :schemas :all}}}}
-      "/db/3/native/"                                {:db {3 {:data {:native :write}}}}
-      "/db/3/schema/"                                {:db {3 {:data {:schemas :all}}}}
-      "/db/3/schema/PUBLIC/"                         {:db {3 {:data {:schemas {"PUBLIC" :all}}}}}
-      "/db/3/schema/PUBLIC/table/4/"                 {:db {3 {:data {:schemas {"PUBLIC" {4 :all}}}}}}
-      "/db/3/schema/PUBLIC/table/4/read/"            {:db {3 {:data {:schemas {"PUBLIC" {4 {:read :all}}}}}}}
-      "/db/3/schema/PUBLIC/table/4/query/"           {:db {3 {:data {:schemas {"PUBLIC" {4 {:query :all}}}}}}}
-      "/db/3/schema/PUBLIC/table/4/query/segmented/" {:db {3 {:data {:schemas {"PUBLIC" {4 {:query :segmented}}}}}}})))
+      "/db/3/"                                        {:db {3 {:data {:native  :write
+                                                                       :schemas :all}}}}
+      "/db/3/native/"                                 {:db {3 {:data {:native :write}}}}
+      "/db/3/schema/"                                 {:db {3 {:data {:schemas :all}}}}
+      "/db/3/schema/PUBLIC/"                          {:db {3 {:data {:schemas {"PUBLIC" :all}}}}}
+      "/db/3/schema/PUBLIC/table/4/"                  {:db {3 {:data {:schemas {"PUBLIC" {4 :all}}}}}}
+      "/db/3/schema/PUBLIC/table/4/read/"             {:db {3 {:data {:schemas {"PUBLIC" {4 {:read :all}}}}}}}
+      "/db/3/schema/PUBLIC/table/4/query/"            {:db {3 {:data {:schemas {"PUBLIC" {4 {:query :all}}}}}}}
+      "/db/3/schema/PUBLIC/table/4/query/segmented/"  {:db {3 {:data {:schemas {"PUBLIC" {4 {:query :segmented}}}}}}}
+      "/download/db/3/"                               {:db {3 {:download {:native  :full
+                                                                          :schemas :full}}}}
+      "/download/limited/db/3/"                       {:db {3 {:download {:native  :limited
+                                                                          :schemas :limited}}}}
+      "/download/db/3/native/"                        {:db {3 {:download {:native :full}}}}
+      "/download/limited/db/3/native/"                {:db {3 {:download {:native :limited}}}}
+      "/download/db/3/schema/"                        {:db {3 {:download {:schemas :full}}}}
+      "/download/limited/db/3/schema/"                {:db {3 {:download {:schemas :limited}}}}
+      "/download/db/3/schema/PUBLIC/"                 {:db {3 {:download {:schemas {"PUBLIC" :full}}}}}
+      "/download/limited/db/3/schema/PUBLIC/"         {:db {3 {:download {:schemas {"PUBLIC" :limited}}}}}
+      "/download/db/3/schema/PUBLIC/table/4/"         {:db {3 {:download {:schemas {"PUBLIC" {4 :full}}}}}}
+      "/download/limited/db/3/schema/PUBLIC/table/4/" {:db {3 {:download {:schemas {"PUBLIC" {4 :limited}}}}}})))
 
 
 (deftest combines-permissions-for-graph

--- a/test/metabase/models/permissions_test.clj
+++ b/test/metabase/models/permissions_test.clj
@@ -33,6 +33,15 @@
              "/db/1/schema/1234/table/1/"
              "/db/1/schema/PUBLIC/table/1/query/"
              "/db/1/schema/PUBLIC/table/1/query/segmented/"
+             ;; download permissions
+             "/download/db/1/"
+             "/download/limited/db/1/"
+             "/download/db/1/native/"
+             "/download/limited/db/1/native/"
+             "/download/db/1/schema/PUBLIC/"
+             "/download/limited/db/1/schema/PUBLIC/"
+             "/download/db/1/schema/PUBLIC/table/1/"
+             "/download/limited/db/1/schema/PUBLIC/table/1/"
              ;; block permissions
              "/block/db/1/"
              "/block/db/1000/"
@@ -43,7 +52,7 @@
                (perms/valid-path? path)))))
 
     (testing "\nWe should allow slashes in permissions paths? (#8693, #13263)\n"
-      (doseq [path [ ;; COMPANY-NET\ should get escaped to COMPANY-NET\\
+      (doseq [path [;; COMPANY-NET\ should get escaped to COMPANY-NET\\
                     "/db/16/schema/COMPANY-NET\\\\john.doe/"
                     ;; COMPANY-NET/ should get escaped to COMPANY-NET\/
                     "/db/16/schema/COMPANY-NET\\/john.doe/"
@@ -156,7 +165,14 @@
               "/block/db/1/schema/PUBLIC/"
               "/block/db/1/schema/PUBLIC/table/"
               "/block/db/1/schema/PUBLIC/table/2/"
-              "/block/collection/1/"]}]
+              "/block/collection/1/"]
+
+             "invalid download permissions"
+             ["/download/"
+              "/download/limited/"
+              "/download/db/1/schema/PUBLIC/table/1/query/"
+              "/download/db/1/schema/PUBLIC/table/1/query/segmented/"]}]
+
       (testing reason
         (doseq [path paths]
           (testing (str "\n" (pr-str path))


### PR DESCRIPTION
A few more pieces of backend groundwork for download permissions.

I've updated the `path-regex` for valid permissions paths, so that download paths are recognized as valid.

I've also updated the permissions path parser & graph generation code so that download paths in the DB will be included in the graph that is returned to the frontend.

The next step is to allow download permission paths to be written from the frontend, by including them in the graph sent to the backend.

Epic #20380