### PR TITLE
fix navigation to new dashboard from collection view

### DIFF
--- a/frontend/src/metabase/components/CreateDashboardModal.jsx
+++ b/frontend/src/metabase/components/CreateDashboardModal.jsx
@@ -31,10 +31,12 @@ export default class CreateDashboardModal extends Component {
 
   onSaved = dashboard => {
     const { onClose, onChangeLocation } = this.props;
-    onChangeLocation(Urls.dashboard(dashboard, { editMode: true }));
     if (onClose) {
       onClose();
     }
+
+    const url = Urls.dashboard(dashboard, { editMode: true });
+    onChangeLocation(url);
   };
 
   render() {


### PR DESCRIPTION
Fixes #20638 

The `CreateDashboardModal` here is created using `ModalRoute`. `ModalRoute` passes an `onClose` callback to its child modal component that navigates to the parent path of whatever path you are on -- meaning if you are on the route `collection/12/new_dashboard` the `onClose` call will navigate you to `/collection/12`. As you can see from the code that means the `CreateDashboardModal` `onSaved` call tries navigating you to the new dashboard but then it calls `this.props.onClose`, so you get navigated to the collection instead. Flipping the calls fixes the problem.

Why does `onSaved` need to call `onClose`? So that navigating backwards through your browser history returns you to the collection view instead of the "add a new dashboard" view.

Demo:

https://user-images.githubusercontent.com/13057258/155409280-75d86c49-b9bb-4067-a6c2-3d306323bfa2.mov


