### PR TITLE
use relative urls in app template so that site-url is correctly prepended to site resources like the favicon

### DIFF
--- a/resources/frontend_client/index_template.html
+++ b/resources/frontend_client/index_template.html
@@ -7,11 +7,11 @@
     <meta name="robots" content="noindex" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/app/assets/img/apple-touch-icon.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="app/assets/img/apple-touch-icon.png">
     <link rel="icon" href="{{{favicon}}}" />
-    <link rel="manifest" crossorigin="use-credentials" href="/app/assets/img/site.webmanifest">
+    <link rel="manifest" crossorigin="use-credentials" href="app/assets/img/site.webmanifest">
     <meta name="msapplication-TileColor" content="#2d89ef">
-    <meta name="msapplication-config" content="/app/assets/img/browserconfig.xml">
+    <meta name="msapplication-config" content="app/assets/img/browserconfig.xml">
     <meta name="theme-color" content="#ffffff">
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <meta name="base-href" content="{{{baseHref}}}" />

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -281,7 +281,7 @@
   (deferred-tru "The url or image that you want to use as the favicon.")
   :visibility :public
   :type       :string
-  :default    "/app/assets/img/favicon.ico")
+  :default    "app/assets/img/favicon.ico")
 
 (defsetting enable-password-login
   (deferred-tru "Allow logging in by email and password.")


### PR DESCRIPTION
Resolves #10743 

We use a `base` tag to specify the app's base URL. For relative URLs it will prepend whatever it is set to (eq the `site-url`), but our favicon and a few other resources are defined as absolute URLs -- note the preceding forward slash. Removing the preceding forward slash solves our issues here.

**Proxy setup**
- Run a proxy so that you can open up an instance of metabase at a url like `localhost:3100/metabase`. I'm using nginx to do this. You can use the config for nginx found in this PR: https://github.com/metabase/metabase/pull/4740
- Go to `/admin/settings/general` and update the site url input to `localhost:3100/metabase`

**Testing**
- Refresh the page; the favicon should show correctly
- Create a new favicon, move it to an app folder, and navigate to the whitelabel settings in the admin panel, and set the favicon path to the new favicon. Refresh the page and it should show. Note that this will only work if the favicon path is relative and not preceded by a forward slash


https://user-images.githubusercontent.com/13057258/155430674-dae78065-a782-4d3b-ac04-b7c5de7028a5.mov


