### PR TITLE
Fix the icon for custom column

### DIFF
--- a/frontend/src/metabase-lib/lib/Dimension.ts
+++ b/frontend/src/metabase-lib/lib/Dimension.ts
@@ -1210,17 +1210,8 @@ export class ExpressionDimension extends Dimension {
   }
 
   icon(): IconName {
-    const { base_type } = this.field();
-
-    switch (base_type) {
-      case "type/Text":
-        return "string";
-
-      default:
-        break;
-    }
-
-    return "int";
+    const field = this.field();
+    return field ? field.icon() : "unknown";
   }
 }
 // These types aren't aggregated. e.g. if you take the distinct count of a FK


### PR DESCRIPTION
No need to infer the icon, just delegate it to the field (see e.g. `getIconForField()`).

How to verify:
1. New, Question
2. Sample Database, Reviews
3. Custom Column, type `[Product → Created At]` and name it e.g. `Product Date`
4. Filter, highlight `Product Date`

**Before this PR**

The icon for `Product Date` is a `#`, which is incorrect since this icon is designated for a numeric field (suitable for e.g.`Rating`), while `Product Date` is clearly a date/time field.

![image](https://user-images.githubusercontent.com/7288/155588657-f0994630-29ad-4243-9f7f-59d9fdbcbef0.png)

**After this PR**

The icon for `Product Date` is a calendar, just like the original field `[Product → Created At]`.

![Screenshot_20220224_104415](https://user-images.githubusercontent.com/7288/155588735-6072ac4a-2f13-468a-99aa-7ab0b4ac953c.png)
