### PR TITLE
Replace hard coded ids in E2E custom commands and helpers

### DIFF
--- a/frontend/test/__support__/e2e/commands/api/question.js
+++ b/frontend/test/__support__/e2e/commands/api/question.js
@@ -1,3 +1,5 @@
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
+
 Cypress.Commands.add("createQuestion", (questionDetails, customOptions) => {
   const { name, query } = questionDetails;
 
@@ -50,7 +52,7 @@ function question(
     dataset = false,
     native,
     query,
-    database = 1,
+    database = SAMPLE_DB_ID,
     display = "table",
     visualization_settings = {},
     collection_id,

--- a/frontend/test/__support__/e2e/commands/permissions/sandboxTable.js
+++ b/frontend/test/__support__/e2e/commands/permissions/sandboxTable.js
@@ -1,9 +1,6 @@
 import { USER_GROUPS } from "__support__/e2e/cypress_data";
-import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { COLLECTION_GROUP } = USER_GROUPS;
-
-const { ORDERS_ID } = SAMPLE_DATABASE;
 
 Cypress.Commands.add(
   "sandboxTable",
@@ -11,7 +8,7 @@ Cypress.Commands.add(
     attribute_remappings = {},
     card_id = null,
     group_id = COLLECTION_GROUP,
-    table_id = ORDERS_ID,
+    table_id = 2,
   } = {}) => {
     // Extract the name of the table, as well as `schema` and `db_id` that we'll need later on for `cy.updatePermissionsSchemas()`
     cy.request("GET", "/api/table").then(({ body: tables }) => {

--- a/frontend/test/__support__/e2e/commands/permissions/sandboxTable.js
+++ b/frontend/test/__support__/e2e/commands/permissions/sandboxTable.js
@@ -1,10 +1,17 @@
+import { USER_GROUPS } from "__support__/e2e/cypress_data";
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
+const { COLLECTION_GROUP } = USER_GROUPS;
+
+const { ORDERS_ID } = SAMPLE_DATABASE;
+
 Cypress.Commands.add(
   "sandboxTable",
   ({
     attribute_remappings = {},
     card_id = null,
-    group_id = 3,
-    table_id = 2,
+    group_id = COLLECTION_GROUP,
+    table_id = ORDERS_ID,
   } = {}) => {
     // Extract the name of the table, as well as `schema` and `db_id` that we'll need later on for `cy.updatePermissionsSchemas()`
     cy.request("GET", "/api/table").then(({ body: tables }) => {

--- a/frontend/test/__support__/e2e/commands/permissions/updatePermissions.js
+++ b/frontend/test/__support__/e2e/commands/permissions/updatePermissions.js
@@ -1,3 +1,7 @@
+import { SAMPLE_DB_ID, USER_GROUPS } from "__support__/e2e/cypress_data";
+
+const { COLLECTION_GROUP } = USER_GROUPS;
+
 /**
  * PERMISSIONS
  *
@@ -34,7 +38,11 @@ Cypress.Commands.add(
 
 Cypress.Commands.add(
   "updatePermissionsSchemas",
-  ({ schemas = {}, user_group = 3, database_id = 1 } = {}) => {
+  ({
+    schemas = {},
+    user_group = COLLECTION_GROUP,
+    database_id = SAMPLE_DB_ID,
+  } = {}) => {
     if (typeof schemas !== "object") {
       throw new Error("`schemas` must be an object!");
     }

--- a/frontend/test/__support__/e2e/helpers/e2e-ad-hoc-question-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-ad-hoc-question-helpers.js
@@ -1,3 +1,8 @@
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
+const { PRODUCTS_ID, ORDERS_ID, REVIEWS_ID, PEOPLE_ID } = SAMPLE_DATABASE;
+
 export function adhocQuestionHash(question) {
   if (question.display) {
     // without "locking" the display, the QB will run its picking logic and override the setting
@@ -32,7 +37,7 @@ export function visitQuestionAdhoc(question, { callback, mode } = {}) {
  * @param {{database:number, table: number, mode: (undefined|"notebook"), limit: number, callback: function}} config
  */
 export function openTable({
-  database = 1,
+  database = SAMPLE_DB_ID,
   table,
   mode = null,
   limit,
@@ -54,19 +59,19 @@ export function openTable({
 }
 
 export function openProductsTable({ mode, limit, callback } = {}) {
-  return openTable({ table: 1, mode, limit, callback });
+  return openTable({ table: PRODUCTS_ID, mode, limit, callback });
 }
 
 export function openOrdersTable({ mode, limit, callback } = {}) {
-  return openTable({ table: 2, mode, limit, callback });
+  return openTable({ table: ORDERS_ID, mode, limit, callback });
 }
 
 export function openPeopleTable({ mode, limit, callback } = {}) {
-  return openTable({ table: 3, mode, limit, callback });
+  return openTable({ table: PEOPLE_ID, mode, limit, callback });
 }
 
 export function openReviewsTable({ mode, limit, callback } = {}) {
-  return openTable({ table: 4, mode, limit, callback });
+  return openTable({ table: REVIEWS_ID, mode, limit, callback });
 }
 
 function getInterceptDetails(question, mode) {
@@ -74,7 +79,7 @@ function getInterceptDetails(question, mode) {
   // Therefore, there is no `dataset` to wait for.
   // But we need to make sure the schema for our database is loaded before we can proceed.
   if (mode === "notebook") {
-    return ["/api/database/1/schema/PUBLIC", "publicSchema"];
+    return [`/api/database/${SAMPLE_DB_ID}/schema/PUBLIC`, "publicSchema"];
   }
 
   const {

--- a/frontend/test/__support__/e2e/helpers/e2e-ad-hoc-question-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-ad-hoc-question-helpers.js
@@ -1,7 +1,4 @@
 import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
-import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
-
-const { PRODUCTS_ID, ORDERS_ID, REVIEWS_ID, PEOPLE_ID } = SAMPLE_DATABASE;
 
 export function adhocQuestionHash(question) {
   if (question.display) {
@@ -59,19 +56,19 @@ export function openTable({
 }
 
 export function openProductsTable({ mode, limit, callback } = {}) {
-  return openTable({ table: PRODUCTS_ID, mode, limit, callback });
+  return openTable({ table: 1, mode, limit, callback });
 }
 
 export function openOrdersTable({ mode, limit, callback } = {}) {
-  return openTable({ table: ORDERS_ID, mode, limit, callback });
+  return openTable({ table: 2, mode, limit, callback });
 }
 
 export function openPeopleTable({ mode, limit, callback } = {}) {
-  return openTable({ table: PEOPLE_ID, mode, limit, callback });
+  return openTable({ table: 3, mode, limit, callback });
 }
 
 export function openReviewsTable({ mode, limit, callback } = {}) {
-  return openTable({ table: REVIEWS_ID, mode, limit, callback });
+  return openTable({ table: 4, mode, limit, callback });
 }
 
 function getInterceptDetails(question, mode) {


### PR DESCRIPTION
As explained and defined in https://github.com/metabase/metabase/issues/20722, we're replacing hard coded sample database id with a variable.

This PR updates global e2e helpers and custom commands.

### How to test?
- All tests should still work in CI
- Whichever way you run Cypress locally, it should still work after this
