### PR TITLE
use relative urls when setting up new metabase instance on a nested path

### DIFF
--- a/frontend/src/metabase/lib/engine.js
+++ b/frontend/src/metabase/lib/engine.js
@@ -30,7 +30,7 @@ export function getEngineNativeAceMode(engine) {
 }
 
 export function getEngineLogo(engine) {
-  const path = `/app/assets/img/drivers`;
+  const path = `app/assets/img/drivers`;
 
   switch (engine) {
     case "bigquery":

--- a/frontend/src/metabase/setup/components/CompletedStep/CompletedStep.tsx
+++ b/frontend/src/metabase/setup/components/CompletedStep/CompletedStep.tsx
@@ -19,6 +19,8 @@ const CompletedStep = ({
     return null;
   }
 
+  const baseUrl = (window as any).MetabaseRoot || "/";
+
   return (
     <StepRoot>
       <StepTitle>{t`You're all set up!`}</StepTitle>
@@ -26,7 +28,7 @@ const CompletedStep = ({
         <NewsletterForm />
       </StepBody>
       <StepFooter>
-        <a className="Button Button--primary" href="/">
+        <a className="Button Button--primary" href={baseUrl}>
           {t`Take me to Metabase`}
         </a>
       </StepFooter>


### PR DESCRIPTION
Two tweaks:

1. Removed the `/` from the urls of engine logo SVGs so that the URL is relative.
2. Set the link url for the "Take me to Metabase" button to the `window.MetabaseRoot` value set in `resources/frontend_client/inline_js/index_bootstrap.js`. `metabase/setup/components/CompletedStep/CompletedStep.tsx` is obviously typescript, so I've needed to set `window` to `any` here so that the compiler does not complain about me accessing a value that doesn't exist on `Window`. The alternatives felt a bit grosser (creating a namespace where `Window` is extended), but I'm happy to do that if people disagree with what I am doing.

**Proxy setup**
- Run a proxy so that you can open up an instance of metabase at a url like `localhost:3100/metabase`. I'm using nginx to do this. You can use the config for nginx found in this PR: https://github.com/metabase/metabase/pull/4740

**Testing**
1. Navigate to `localhost:3100/metabase` on a new metabase instance and go through the steps of setting it up
2. The DB SVGs should load correctly
3. The "Take me to Metabase" button at the end of the set up should correctly navigate you to the home page of metabase
4. Repeat setting up a new metabase instance, but not on a nested route

**Before**

https://user-images.githubusercontent.com/13057258/155598690-05f87991-6fd2-4bde-989e-41e473416620.mov

**After**

https://user-images.githubusercontent.com/13057258/155598742-718e8ccb-e45c-4b9b-9ef1-6e88de6453bb.mov


