### PR TITLE
Small cleanup for Events and Timelines

### DIFF
--- a/frontend/src/metabase/timelines/components/EventList/EventList.tsx
+++ b/frontend/src/metabase/timelines/components/EventList/EventList.tsx
@@ -44,7 +44,7 @@ const EventList = ({
         </ListThreadContainer>
         <ListIconContainer>
           <ListIcon name="dyno" />
-          <ListIconText>{t`The Paleozoic Era`}</ListIconText>
+          <ListIconText>{t`The Mesozoic era`}</ListIconText>
         </ListIconContainer>
       </ListFooter>
     </div>

--- a/frontend/src/metabase/timelines/components/TimelineDetailsModal/TimelineDetailsModal.tsx
+++ b/frontend/src/metabase/timelines/components/TimelineDetailsModal/TimelineDetailsModal.tsx
@@ -59,7 +59,7 @@ const TimelineDetailsModal = ({
   return (
     <ModalRoot>
       <ModalHeader title={title} onClose={onClose}>
-        {!isArchive && <EntityMenu items={menuItems} triggerIcon="kebab" />}
+        {!isArchive && <EntityMenu items={menuItems} triggerIcon="ellipsis" />}
       </ModalHeader>
       {(isNotEmpty || isSearching) && (
         <ModalToolbar>

--- a/frontend/src/metabase/timelines/components/TimelineListModal/TimelineListModal.tsx
+++ b/frontend/src/metabase/timelines/components/TimelineListModal/TimelineListModal.tsx
@@ -75,7 +75,7 @@ const TimelineMenu = ({ collection }: TimelineMenuProps): JSX.Element => {
     [collection],
   );
 
-  return <EntityMenu items={items} triggerIcon="kebab" />;
+  return <EntityMenu items={items} triggerIcon="ellipsis" />;
 };
 
 export default TimelineListModal;


### PR DESCRIPTION
- Changes "Paleozoic" to "Mesozoic" (@jeff-bruemmer pointed out that's the correct era for dinosaurs 😅 )
- Switches out the vertical triple dot icon for the ellipses icon per our Slack conversation

<img width="691" alt="Screen Shot 2022-02-24 at 11 58 39 AM" src="https://user-images.githubusercontent.com/2223916/155598923-c177f769-4fc7-4cd8-9f66-feced5400654.png">

<img width="691" alt="Screen Shot 2022-02-24 at 11 58 32 AM" src="https://user-images.githubusercontent.com/2223916/155598942-7390f5bf-cf39-4ffb-833e-a659d4a6b6f9.png">

