### PR TITLE
Make auth page scene img src relative

### DIFF
--- a/frontend/src/metabase/auth/components/AuthLayout/AuthLayout.tsx
+++ b/frontend/src/metabase/auth/components/AuthLayout/AuthLayout.tsx
@@ -19,8 +19,8 @@ const AuthLayout = ({ showScene, children }: AuthLayoutProps): JSX.Element => {
       {showScene && (
         <LayoutScene>
           <LayoutSceneImage
-            src="/app/img/bridge.png"
-            srcSet="/app/img/bridge.png 1x, /app/img/bridge@2x.png 2x, /app/img/bridge@3x.png 3x"
+            src="app/img/bridge.png"
+            srcSet="app/img/bridge.png 1x, app/img/bridge@2x.png 2x, app/img/bridge@3x.png 3x"
           />
         </LayoutScene>
       )}


### PR DESCRIPTION
Fixes the loading of the bridge scene image on the login page when you are on a nested path:

![Screen Shot 2022-02-24 at 12 22 41 PM](https://user-images.githubusercontent.com/13057258/155603613-f17da8f9-1b36-4aae-be37-1320a369d3d9.png)

**Proxy setup**
- Run a proxy so that you can open up an instance of metabase at a url like `localhost:3100/metabase`. I'm using nginx to do this. You can use the config for nginx found in this PR: https://github.com/metabase/metabase/pull/4740
- Go to `/admin/settings/general` and update the site url input to `localhost:3100/metabase`

**Testing**
- Log out
- You should see a bridge