### PR TITLE
Replace hard coded sample database id in ALL e2e tests

### DIFF
--- a/frontend/test/metabase-visual/static-visualizations/funnel.cy.spec.js
+++ b/frontend/test/metabase-visual/static-visualizations/funnel.cy.spec.js
@@ -4,7 +4,8 @@ import {
   openEmailPage,
   sendSubscriptionsEmail,
 } from "__support__/e2e/cypress";
-import { USERS } from "__support__/e2e/cypress_data";
+
+import { USERS, SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 
 const { admin } = USERS;
 
@@ -41,7 +42,7 @@ function createFunnelBarQuestion() {
     },
     visualization_settings: {},
     display: "funnel",
-    database: 1,
+    database: SAMPLE_DB_ID,
   };
 
   return query;

--- a/frontend/test/metabase-visual/static-visualizations/line-area-bar-combo.cy.spec.js
+++ b/frontend/test/metabase-visual/static-visualizations/line-area-bar-combo.cy.spec.js
@@ -4,7 +4,8 @@ import {
   openEmailPage,
   sendSubscriptionsEmail,
 } from "__support__/e2e/cypress";
-import { USERS } from "__support__/e2e/cypress_data";
+
+import { USERS, SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { ORDERS_ID, ORDERS, PRODUCTS } = SAMPLE_DATABASE;
@@ -55,7 +56,7 @@ function createOneDimensionTwoMetricsQuestion(display) {
       "graph.metrics": ["count", "avg"],
     },
     display: display,
-    database: 1,
+    database: SAMPLE_DB_ID,
   };
 }
 
@@ -75,6 +76,6 @@ function createOneMetricTwoDimensionsQuestion(display) {
       "graph.metrics": ["count"],
     },
     display: display,
-    database: 1,
+    database: SAMPLE_DB_ID,
   };
 }

--- a/frontend/test/metabase-visual/static-visualizations/progress-bar.cy.spec.js
+++ b/frontend/test/metabase-visual/static-visualizations/progress-bar.cy.spec.js
@@ -4,7 +4,8 @@ import {
   openEmailPage,
   sendSubscriptionsEmail,
 } from "__support__/e2e/cypress";
-import { USERS } from "__support__/e2e/cypress_data";
+
+import { USERS, SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 
 const { admin } = USERS;
 
@@ -48,7 +49,7 @@ function createProgressBarQuestion({ value, goal }) {
       "progress.goal": goal,
     },
     display: "progress",
-    database: 1,
+    database: SAMPLE_DB_ID,
   };
 
   return query;

--- a/frontend/test/metabase-visual/static-visualizations/waterfall.cy.spec.js
+++ b/frontend/test/metabase-visual/static-visualizations/waterfall.cy.spec.js
@@ -4,7 +4,8 @@ import {
   openEmailPage,
   sendSubscriptionsEmail,
 } from "__support__/e2e/cypress";
-import { USERS } from "__support__/e2e/cypress_data";
+
+import { USERS, SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 
 const { admin } = USERS;
 
@@ -46,7 +47,7 @@ function createWaterfallQuestion({ showTotal } = {}) {
     },
     visualization_settings: {},
     display: "waterfall",
-    database: 1,
+    database: SAMPLE_DB_ID,
   };
 
   if (typeof showTotal !== "undefined") {

--- a/frontend/test/metabase-visual/visualizations/bar.cy.spec.js
+++ b/frontend/test/metabase-visual/visualizations/bar.cy.spec.js
@@ -1,4 +1,5 @@
 import { restore, visitQuestionAdhoc } from "__support__/e2e/cypress";
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 
 describe("visual tests > visualizations > bar", () => {
   beforeEach(() => {
@@ -14,7 +15,7 @@ describe("visual tests > visualizations > bar", () => {
           "SELECT X, A, B, C " +
           "FROM (VALUES (1,20,30,30),(2,10,-40,-20),(3,20,10,30)) T (X, A, B, C)",
       },
-      database: 1,
+      database: SAMPLE_DB_ID,
     };
 
     visitQuestionAdhoc({
@@ -38,7 +39,7 @@ describe("visual tests > visualizations > bar", () => {
           .fill("SELECT A, B, C FROM EXAMPLE")
           .join(" UNION ALL\n"),
       },
-      database: 1,
+      database: SAMPLE_DB_ID,
     };
 
     visitQuestionAdhoc({

--- a/frontend/test/metabase-visual/visualizations/funnel.cy.spec.js
+++ b/frontend/test/metabase-visual/visualizations/funnel.cy.spec.js
@@ -1,4 +1,5 @@
 import { restore, visitQuestionAdhoc } from "__support__/e2e/cypress";
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 
 describe("visual tests > visualizations > funnel", () => {
   beforeEach(() => {
@@ -15,7 +16,7 @@ describe("visual tests > visualizations > funnel", () => {
           "select 'b', 0 union all\n" +
           "select 'c', 0",
       },
-      database: 1,
+      database: SAMPLE_DB_ID,
     };
 
     visitQuestionAdhoc({
@@ -40,7 +41,7 @@ describe("visual tests > visualizations > funnel", () => {
           "select 'd', 155 union all\n" +
           "select 'e', 0",
       },
-      database: 1,
+      database: SAMPLE_DB_ID,
     };
 
     visitQuestionAdhoc({

--- a/frontend/test/metabase-visual/visualizations/line.cy.spec.js
+++ b/frontend/test/metabase-visual/visualizations/line.cy.spec.js
@@ -1,4 +1,6 @@
 import { restore, visitQuestionAdhoc } from "__support__/e2e/cypress";
+
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID, PEOPLE } = SAMPLE_DATABASE;
@@ -26,7 +28,7 @@ describe("visual tests > visualizations > line", () => {
             ],
           ],
         },
-        database: 1,
+        database: SAMPLE_DB_ID,
       },
       display: "line",
       visualization_settings: {
@@ -42,7 +44,7 @@ describe("visual tests > visualizations > line", () => {
   it("with vertical legends", () => {
     visitQuestionAdhoc({
       dataset_query: {
-        database: 1,
+        database: SAMPLE_DB_ID,
         type: "query",
         query: {
           "source-table": ORDERS_ID,
@@ -78,7 +80,7 @@ describe("visual tests > visualizations > line", () => {
   it("with vertical legends", () => {
     visitQuestionAdhoc({
       dataset_query: {
-        database: 1,
+        database: SAMPLE_DB_ID,
         type: "query",
         query: {
           "source-table": ORDERS_ID,
@@ -128,7 +130,7 @@ describe("visual tests > visualizations > line", () => {
             ],
           ],
         },
-        database: 1,
+        database: SAMPLE_DB_ID,
       },
       display: "line",
       visualization_settings: {
@@ -169,7 +171,7 @@ describe("visual tests > visualizations > line", () => {
             SELECT CAST('2010-10-03' AS DATE), 6, null
           `,
         },
-        database: 1,
+        database: SAMPLE_DB_ID,
       },
       display: "line",
       visualization_settings: {

--- a/frontend/test/metabase-visual/visualizations/row.cy.spec.js
+++ b/frontend/test/metabase-visual/visualizations/row.cy.spec.js
@@ -1,4 +1,6 @@
 import { restore, visitQuestionAdhoc } from "__support__/e2e/cypress";
+
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
@@ -10,7 +12,7 @@ const testQuery = {
     aggregation: [["count"]],
     breakout: [["field", PRODUCTS.PRICE, { binning: { strategy: "default" } }]],
   },
-  database: 1,
+  database: SAMPLE_DB_ID,
 };
 
 describe("visual tests > visualizations > row", () => {

--- a/frontend/test/metabase-visual/visualizations/scatter.cy.spec.js
+++ b/frontend/test/metabase-visual/visualizations/scatter.cy.spec.js
@@ -1,10 +1,12 @@
 import { restore, visitQuestionAdhoc } from "__support__/e2e/cypress";
+
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID, PRODUCTS } = SAMPLE_DATABASE;
 
 const testQuery = {
-  database: 1,
+  database: SAMPLE_DB_ID,
   query: {
     "source-table": ORDERS_ID,
     aggregation: [

--- a/frontend/test/metabase-visual/visualizations/waterfall.cy.spec.js
+++ b/frontend/test/metabase-visual/visualizations/waterfall.cy.spec.js
@@ -1,4 +1,6 @@
 import { restore, visitQuestionAdhoc } from "__support__/e2e/cypress";
+
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
@@ -18,7 +20,7 @@ const testQuery = {
       ],
     ],
   },
-  database: 1,
+  database: SAMPLE_DB_ID,
 };
 
 describe("visual tests > visualizations > waterfall", () => {

--- a/frontend/test/metabase/scenarios/admin/datamodel/editor.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/editor.cy.spec.js
@@ -1,5 +1,6 @@
 import { restore, popover, visitAlias } from "__support__/e2e/cypress";
 
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { ORDERS_ID } = SAMPLE_DATABASE;
@@ -169,7 +170,7 @@ describe.skip("scenarios > admin > datamodel > editor", () => {
 
     // check that new order is obeyed in queries
     cy.request("POST", "/api/dataset", {
-      database: 1,
+      database: SAMPLE_DB_ID,
       query: { "source-table": ORDERS_ID },
       type: "query",
     }).then(resp => {

--- a/frontend/test/metabase/scenarios/admin/settings/localization.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/localization.cy.spec.js
@@ -1,4 +1,6 @@
 import { restore, visitQuestionAdhoc } from "__support__/e2e/cypress";
+
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
@@ -139,7 +141,7 @@ describe("scenarios > admin > localization", () => {
           query: "SELECT 10 as A",
           "template-tags": {},
         },
-        database: 1,
+        database: SAMPLE_DB_ID,
       },
       visualization_settings: {
         column_settings: {

--- a/frontend/test/metabase/scenarios/binning/binning-options.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/binning-options.cy.spec.js
@@ -6,6 +6,8 @@ import {
   getBinningButtonForDimension,
   summarize,
 } from "__support__/e2e/cypress";
+
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const {
@@ -35,7 +37,7 @@ const ordersJoinPeopleQuery = {
     ],
     fields: [["field", ORDERS.ID, null]],
   },
-  database: 1,
+  database: SAMPLE_DB_ID,
 };
 
 const ordersJoinProductsQuery = {
@@ -56,7 +58,7 @@ const ordersJoinProductsQuery = {
     ],
     fields: [["field", ORDERS.ID, null]],
   },
-  database: 1,
+  database: SAMPLE_DB_ID,
 };
 
 const NUMBER_BUCKETS = [

--- a/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
@@ -8,6 +8,8 @@ import {
   openNotebookEditor,
   summarize,
 } from "__support__/e2e/cypress";
+
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
@@ -43,7 +45,7 @@ describe("binning related reproductions", () => {
   it("should be able to update the bucket size / granularity on a field that has sorting applied to it (metabase#16770)", () => {
     visitQuestionAdhoc({
       dataset_query: {
-        database: 1,
+        database: SAMPLE_DB_ID,
         query: {
           "source-table": ORDERS_ID,
           aggregation: [["count"]],

--- a/frontend/test/metabase/scenarios/custom-column/custom-column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/custom-column.cy.spec.js
@@ -9,6 +9,7 @@ import {
   filter,
 } from "__support__/e2e/cypress";
 
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
@@ -376,7 +377,7 @@ describe("scenarios > question > custom column", () => {
               ],
             },
           },
-          database: 1,
+          database: SAMPLE_DB_ID,
         },
         display: "table",
       },

--- a/frontend/test/metabase/scenarios/custom-column/reproductions/19744-cc-after-aggregation-limited-filters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/reproductions/19744-cc-after-aggregation-limited-filters.cy.spec.js
@@ -4,6 +4,8 @@ import {
   visitQuestionAdhoc,
   popover,
 } from "__support__/e2e/cypress";
+
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { PRODUCTS_ID, PRODUCTS } = SAMPLE_DATABASE;
@@ -23,7 +25,7 @@ const questionDetails = {
       },
       expressions: { Math: ["+", 1, 1] },
     },
-    database: 1,
+    database: SAMPLE_DB_ID,
   },
   display: "bar",
 };

--- a/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard-drill.cy.spec.js
@@ -6,6 +6,7 @@ import {
   showDashboardCardActions,
 } from "__support__/e2e/cypress";
 
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const {
@@ -880,7 +881,7 @@ function createDashboardWithQuestion(
 function createQuestion(options, callback) {
   cy.request("POST", "/api/card", {
     dataset_query: {
-      database: 1,
+      database: SAMPLE_DB_ID,
       type: "native",
       native: {
         query: options.query || "select 111 as my_number, 'foo' as my_string",

--- a/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/dashboard.cy.spec.js
@@ -10,6 +10,7 @@ import {
   openNewCollectionItemFlowFor,
 } from "__support__/e2e/cypress";
 
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, PEOPLE, PEOPLE_ID } = SAMPLE_DATABASE;
@@ -92,7 +93,7 @@ describe("scenarios > dashboard", () => {
     cy.request("POST", "/api/card", {
       name: "11007",
       dataset_query: {
-        database: 1,
+        database: SAMPLE_DB_ID,
         filter: [">", ["field", "sum", { "base-type": "type/Float" }], 100],
         query: {
           "source-table": ORDERS_ID,

--- a/frontend/test/metabase/scenarios/dashboard/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/permissions.cy.spec.js
@@ -1,6 +1,7 @@
 import _ from "underscore";
 import { assoc } from "icepick";
 import { restore } from "__support__/e2e/cypress";
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 
 describe("scenarios > dashboard > permissions", () => {
   let dashboardId;
@@ -38,7 +39,7 @@ describe("scenarios > dashboard > permissions", () => {
 
       cy.request("POST", "/api/card", {
         dataset_query: {
-          database: 1,
+          database: SAMPLE_DB_ID,
           type: "native",
           native: { query: "select 'foo'" },
         },
@@ -50,7 +51,7 @@ describe("scenarios > dashboard > permissions", () => {
 
       cy.request("POST", "/api/card", {
         dataset_query: {
-          database: 1,
+          database: SAMPLE_DB_ID,
           type: "native",
           native: { query: "select 'bar'" },
         },

--- a/frontend/test/metabase/scenarios/dashboard/x-rays.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/x-rays.cy.spec.js
@@ -5,6 +5,8 @@ import {
   popover,
   summarize,
 } from "__support__/e2e/cypress";
+
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const {
@@ -120,7 +122,7 @@ describe("scenarios > x-rays", () => {
       visitQuestionAdhoc({
         name: "15737",
         dataset_query: {
-          database: 1,
+          database: SAMPLE_DB_ID,
           query: {
             "source-table": PEOPLE_ID,
             aggregation: [["count"]],

--- a/frontend/test/metabase/scenarios/downloads/reproductions/18382-old-syntax-missing-renamed-columns.cy.spec.js
+++ b/frontend/test/metabase/scenarios/downloads/reproductions/18382-old-syntax-missing-renamed-columns.cy.spec.js
@@ -3,6 +3,8 @@ import {
   visitQuestionAdhoc,
   downloadAndAssert,
 } from "__support__/e2e/cypress";
+
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { REVIEWS, REVIEWS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
@@ -15,7 +17,7 @@ const { REVIEWS, REVIEWS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
 
 const questionDetails = {
   dataset_query: {
-    database: 1,
+    database: SAMPLE_DB_ID,
     type: "query",
     query: {
       "source-table": REVIEWS_ID,

--- a/frontend/test/metabase/scenarios/downloads/reproductions/18440-remapped-display-value-dropped.cy.spec.js
+++ b/frontend/test/metabase/scenarios/downloads/reproductions/18440-remapped-display-value-dropped.cy.spec.js
@@ -4,6 +4,8 @@ import {
   downloadAndAssert,
   visitQuestion,
 } from "__support__/e2e/cypress";
+
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID, PRODUCTS } = SAMPLE_DATABASE;
@@ -14,7 +16,7 @@ const questionDetails = {
   dataset_query: {
     type: "query",
     query,
-    database: 1,
+    database: SAMPLE_DB_ID,
   },
 };
 

--- a/frontend/test/metabase/scenarios/downloads/reproductions/18573-remapped-fields-not-renamed.cy.spec.js
+++ b/frontend/test/metabase/scenarios/downloads/reproductions/18573-remapped-fields-not-renamed.cy.spec.js
@@ -3,6 +3,8 @@ import {
   visitQuestionAdhoc,
   downloadAndAssert,
 } from "__support__/e2e/cypress";
+
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID, PRODUCTS } = SAMPLE_DATABASE;
@@ -11,7 +13,7 @@ const questionDetails = {
   dataset_query: {
     type: "query",
     query: { "source-table": ORDERS_ID, limit: 2 },
-    database: 1,
+    database: SAMPLE_DB_ID,
   },
   visualization_settings: {
     column_settings: {

--- a/frontend/test/metabase/scenarios/downloads/reproductions/18729-date-formatting-x-of-y.cy.spec.js
+++ b/frontend/test/metabase/scenarios/downloads/reproductions/18729-date-formatting-x-of-y.cy.spec.js
@@ -3,13 +3,15 @@ import {
   downloadAndAssert,
   visitQuestionAdhoc,
 } from "__support__/e2e/cypress";
+
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID, PRODUCTS } = SAMPLE_DATABASE;
 
 const questionDetails = {
   dataset_query: {
-    database: 1,
+    database: SAMPLE_DB_ID,
     query: {
       "source-table": ORDERS_ID,
       aggregation: [["count"]],

--- a/frontend/test/metabase/scenarios/embedding/parameters-embedded.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/parameters-embedded.cy.spec.js
@@ -1,5 +1,6 @@
 import { restore, popover, visitQuestion } from "__support__/e2e/cypress";
 
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { ORDERS, PEOPLE } = SAMPLE_DATABASE;
@@ -335,7 +336,7 @@ const createQuestion = () =>
           },
         },
       },
-      database: 1,
+      database: SAMPLE_DB_ID,
     },
     display: "scalar",
     description: null,

--- a/frontend/test/metabase/scenarios/joins/joins-2.cy.spec.js
+++ b/frontend/test/metabase/scenarios/joins/joins-2.cy.spec.js
@@ -10,6 +10,8 @@ import {
   filter,
   visitQuestion,
 } from "__support__/e2e/cypress";
+
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const {
@@ -432,7 +434,7 @@ describe("scenarios > question > joined questions", () => {
               ["field", REVIEWS.CREATED_AT, { "temporal-unit": "year" }],
             ],
           },
-          database: 1,
+          database: SAMPLE_DB_ID,
         },
         display: "line",
       });
@@ -462,7 +464,7 @@ describe("scenarios > question > joined questions", () => {
             "source-table": ORDERS_ID,
             filter: ["=", ["field-id", ORDERS.USER_ID], 1],
           },
-          database: 1,
+          database: SAMPLE_DB_ID,
         },
       });
 

--- a/frontend/test/metabase/scenarios/native-filters/reproductions/15460.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native-filters/reproductions/15460.cy.spec.js
@@ -7,6 +7,7 @@ import {
 
 import * as SQLFilter from "../helpers/e2e-sql-filter-helpers";
 
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { PRODUCTS } = SAMPLE_DATABASE;
@@ -23,7 +24,7 @@ const filter = {
 
 const questionQuery = {
   dataset_query: {
-    database: 1,
+    database: SAMPLE_DB_ID,
     native: {
       query:
         "select p.created_at, products.category\nfrom products\nleft join products p on p.id=products.id\nwhere {{category}}\n",

--- a/frontend/test/metabase/scenarios/native/reproductions/12439-click-on-legend-breaks-ui.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/reproductions/12439-click-on-legend-breaks-ui.cy.spec.js
@@ -1,5 +1,7 @@
 import { restore, visitQuestionAdhoc, sidebar } from "__support__/e2e/cypress";
 
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
+
 const nativeQuery = `SELECT "PRODUCTS__via__PRODUCT_ID"."CATEGORY" AS "CATEGORY", parsedatetime(formatdatetime("PUBLIC"."ORDERS"."CREATED_AT", 'yyyyMM'), 'yyyyMM') AS "CREATED_AT", count(*) AS "count"
 FROM "PUBLIC"."ORDERS"
 LEFT JOIN "PUBLIC"."PRODUCTS" "PRODUCTS__via__PRODUCT_ID" ON "PUBLIC"."ORDERS"."PRODUCT_ID" = "PRODUCTS__via__PRODUCT_ID"."ID"
@@ -9,7 +11,7 @@ ORDER BY "PRODUCTS__via__PRODUCT_ID"."CATEGORY" ASC, parsedatetime(formatdatetim
 
 const questionDetails = {
   dataset_query: {
-    database: 1,
+    database: SAMPLE_DB_ID,
     native: {
       query: nativeQuery,
     },

--- a/frontend/test/metabase/scenarios/permissions/sandboxes.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/sandboxes.cy.spec.js
@@ -13,7 +13,7 @@ import {
   filter,
   visitQuestion,
 } from "__support__/e2e/cypress";
-import { USER_GROUPS } from "__support__/e2e/cypress_data";
+import { USER_GROUPS, SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
@@ -878,7 +878,7 @@ describeWithToken("formatting > sandboxes", () => {
               ],
             ],
           },
-          database: 1,
+          database: SAMPLE_DB_ID,
         },
         display: "pivot",
         visualization_settings: {},

--- a/frontend/test/metabase/scenarios/question/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/filter.cy.spec.js
@@ -11,6 +11,7 @@ import {
   filter,
 } from "__support__/e2e/cypress";
 
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const {
@@ -261,7 +262,7 @@ describe("scenarios > question > filter", () => {
             ],
           ],
         },
-        database: 1,
+        database: SAMPLE_DB_ID,
       },
       display: "table",
     });
@@ -483,7 +484,7 @@ describe("scenarios > question > filter", () => {
             { "case-sensitive": false },
           ],
         },
-        database: 1,
+        database: SAMPLE_DB_ID,
       },
       display: "table",
     });
@@ -507,7 +508,7 @@ describe("scenarios > question > filter", () => {
             { "case-sensitive": false },
           ],
         },
-        database: 1,
+        database: SAMPLE_DB_ID,
       },
       display: "table",
     });
@@ -555,7 +556,7 @@ describe("scenarios > question > filter", () => {
             { "case-sensitive": false },
           ],
         },
-        database: 1,
+        database: SAMPLE_DB_ID,
       },
       display: "table",
     });
@@ -605,7 +606,7 @@ describe("scenarios > question > filter", () => {
           aggregation: [["count"]],
           breakout: [["field-id", PRODUCTS.CATEGORY]],
         },
-        database: 1,
+        database: SAMPLE_DB_ID,
       },
       display: "table",
     });
@@ -714,7 +715,7 @@ describe("scenarios > question > filter", () => {
   it.skip("should work on twice summarized questions (metabase#15620)", () => {
     visitQuestionAdhoc({
       dataset_query: {
-        database: 1,
+        database: SAMPLE_DB_ID,
         query: {
           "source-query": {
             "source-table": 1,
@@ -755,7 +756,7 @@ describe("scenarios > question > filter", () => {
   it("shoud retain all data series after saving a question where custom expression formula is the first metric (metabase#15882)", () => {
     visitQuestionAdhoc({
       dataset_query: {
-        database: 1,
+        database: SAMPLE_DB_ID,
         query: {
           "source-table": ORDERS_ID,
           aggregation: [
@@ -800,7 +801,7 @@ describe("scenarios > question > filter", () => {
     it("shouldn't display chosen category in a breadcrumb (metabase#16198-1)", () => {
       visitQuestionAdhoc({
         dataset_query: {
-          database: 1,
+          database: SAMPLE_DB_ID,
           query: {
             "source-table": PRODUCTS_ID,
             filter: [

--- a/frontend/test/metabase/scenarios/question/internal/question.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/internal/question.cy.spec.js
@@ -1,4 +1,6 @@
 import { restore, adhocQuestionHash } from "__support__/e2e/cypress";
+
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 // This is really a test of the QuestionLoader component
@@ -24,7 +26,7 @@ describe("scenarios > internal > question", () => {
       dataset_query: {
         type: "query",
         query: { "source-table": SAMPLE_DATABASE.ORDERS_ID },
-        database: 1,
+        database: SAMPLE_DB_ID,
       },
       display: "table",
       visualization_settings: {},

--- a/frontend/test/metabase/scenarios/question/nested.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nested.cy.spec.js
@@ -9,6 +9,7 @@ import {
   summarize,
 } from "__support__/e2e/cypress";
 
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
@@ -275,7 +276,7 @@ describe("scenarios > question > nested", () => {
               "source-table": `card__${questionId}`,
               filter: [">", ["field", ORDERS.TOTAL, null], 50],
             },
-            database: 1,
+            database: SAMPLE_DB_ID,
           },
         });
 

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -13,6 +13,7 @@ import {
   filter,
 } from "__support__/e2e/cypress";
 
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
@@ -82,7 +83,7 @@ describe("scenarios > question > notebook", () => {
   it("should show the original custom expression filter field on subsequent click (metabase#14726)", () => {
     visitQuestionAdhoc({
       dataset_query: {
-        database: 1,
+        database: SAMPLE_DB_ID,
         query: {
           "source-table": ORDERS_ID,
           filter: ["between", ["field", ORDERS.ID, null], 96, 97],

--- a/frontend/test/metabase/scenarios/question/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/settings.cy.spec.js
@@ -7,7 +7,9 @@ import {
   sidebar,
 } from "__support__/e2e/cypress";
 
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
 const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
 
 describe("scenarios > question > settings", () => {
@@ -90,7 +92,7 @@ describe("scenarios > question > settings", () => {
               },
             ],
           },
-          database: 1,
+          database: SAMPLE_DB_ID,
         },
         display: "table",
       });
@@ -149,7 +151,7 @@ describe("scenarios > question > settings", () => {
         dataset_query: {
           type: "query",
           query: { "source-table": ORDERS_ID },
-          database: 1,
+          database: SAMPLE_DB_ID,
         },
       });
 
@@ -175,7 +177,7 @@ describe("scenarios > question > settings", () => {
 
       const questionDetails = {
         dataset_query: {
-          database: 1,
+          database: SAMPLE_DB_ID,
           query: { "source-table": 2 },
           type: "query",
         },

--- a/frontend/test/metabase/scenarios/sharing/reproductions/18669-test-email-with-parameters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/reproductions/18669-test-email-with-parameters.cy.spec.js
@@ -5,7 +5,8 @@ import {
   setupSMTP,
   sidebar,
 } from "__support__/e2e/cypress";
-import { USERS } from "__support__/e2e/cypress_data";
+
+import { USERS, SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { admin } = USERS;
@@ -51,7 +52,7 @@ describeWithToken("issue 18669", () => {
 
 const questionDetails = {
   name: "Product count",
-  database: 1,
+  database: SAMPLE_DB_ID,
   type: "query",
   query: {
     "source-table": PRODUCTS_ID,

--- a/frontend/test/metabase/scenarios/visualizations/bar_chart.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/bar_chart.cy.spec.js
@@ -1,4 +1,6 @@
 import { restore, visitQuestionAdhoc } from "__support__/e2e/cypress";
+
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
@@ -22,7 +24,7 @@ describe("scenarios > visualizations > bar chart", () => {
         dataset_query: {
           type: "native",
           native: { query, "template-tags": {} },
-          database: 1,
+          database: SAMPLE_DB_ID,
         },
         display: "bar",
         visualization_settings: visualizationSettings,
@@ -65,7 +67,7 @@ describe("scenarios > visualizations > bar chart", () => {
               ["field", ORDERS.DISCOUNT, { binning: { strategy: "default" } }],
             ],
           },
-          database: 1,
+          database: SAMPLE_DB_ID,
         },
       });
 
@@ -89,7 +91,7 @@ describe("scenarios > visualizations > bar chart", () => {
               "union all\n" +
               "select '2021-01-03' as x_axis_1, 'A' as x_axis_2, 20000000 as y_axis\n",
           },
-          database: 1,
+          database: SAMPLE_DB_ID,
         },
         visualization_settings: {
           "graph.show_values": true,

--- a/frontend/test/metabase/scenarios/visualizations/combo.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/combo.cy.spec.js
@@ -1,4 +1,6 @@
 import { restore, visitQuestionAdhoc } from "__support__/e2e/cypress";
+
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
@@ -12,7 +14,7 @@ describe("scenarios > visualizations > combo", () => {
   it(`should render values on data points`, () => {
     visitQuestionAdhoc({
       dataset_query: {
-        database: 1,
+        database: SAMPLE_DB_ID,
         query: {
           "source-table": PRODUCTS_ID,
           aggregation: [["count"], ["sum", ["field", PRODUCTS.PRICE, null]]],

--- a/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
@@ -9,7 +9,8 @@ import {
   summarize,
   visitQuestion,
 } from "__support__/e2e/cypress";
-import { USER_GROUPS } from "__support__/e2e/cypress_data";
+
+import { USER_GROUPS, SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const {
@@ -81,7 +82,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
 
       const questionDetails = {
         name: "18011",
-        database: 1,
+        database: SAMPLE_DB_ID,
         query: {
           "source-table": PRODUCTS_ID,
           aggregation: [["count"]],
@@ -420,7 +421,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
           query:
             "select 1 as axis, 5 as value, 9 as breakout union all\nselect 2 as axis, 6 as value, 10 as breakout union all\nselect 2 as axis, 6 as value, 10 as breakout",
         },
-        database: 1,
+        database: SAMPLE_DB_ID,
       },
       display: "bar",
       visualization_settings: {
@@ -513,7 +514,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
     visitQuestionAdhoc({
       name: "15324",
       dataset_query: {
-        database: 1,
+        database: SAMPLE_DB_ID,
         query: {
           "source-table": ORDERS_ID,
           aggregation: [["count"]],
@@ -539,7 +540,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
     visitQuestionAdhoc({
       name: "11345",
       dataset_query: {
-        database: 1,
+        database: SAMPLE_DB_ID,
         query: {
           "source-table": ORDERS_ID,
           aggregation: [["count"]],

--- a/frontend/test/metabase/scenarios/visualizations/drillthroughs/dash_drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/drillthroughs/dash_drill.cy.spec.js
@@ -1,5 +1,7 @@
 // Imported from drillthroughs.e2e.spec.js
 import { restore } from "__support__/e2e/cypress";
+
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, PEOPLE, PEOPLE_ID } = SAMPLE_DATABASE;
@@ -47,7 +49,7 @@ describe("scenarios > visualizations > drillthroughs > dash_drill", () => {
         // Convert Q2 to a scalar with a filter applied
         cy.request("PUT", `/api/card/${Q2.id}`, {
           dataset_query: {
-            database: 1,
+            database: SAMPLE_DB_ID,
             query: {
               aggregation: [["count"]],
               filter: [">", ["field", ORDERS.TOTAL, null], 100],

--- a/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
@@ -1,4 +1,6 @@
 import { restore, visitQuestionAdhoc, popover } from "__support__/e2e/cypress";
+
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
@@ -12,7 +14,7 @@ const testQuery = {
     aggregation: [["count"]],
     breakout: [["datetime-field", ["field-id", ORDERS.CREATED_AT], "month"]],
   },
-  database: 1,
+  database: SAMPLE_DB_ID,
 };
 
 describe("scenarios > visualizations > line chart", () => {
@@ -48,7 +50,7 @@ describe("scenarios > visualizations > line chart", () => {
           ],
           breakout: [["field", ORDERS.CREATED_AT, { "temporal-unit": "year" }]],
         },
-        database: 1,
+        database: SAMPLE_DB_ID,
       },
       display: "line",
       visualization_settings: {
@@ -68,7 +70,7 @@ describe("scenarios > visualizations > line chart", () => {
     visitQuestionAdhoc({
       display: "line",
       dataset_query: {
-        database: 1,
+        database: SAMPLE_DB_ID,
         type: "query",
         query: {
           "source-table": PRODUCTS_ID,
@@ -93,7 +95,7 @@ describe("scenarios > visualizations > line chart", () => {
   it("should correctly display tooltip values when X-axis is numeric and style is 'Ordinal' (metabase#15998)", () => {
     visitQuestionAdhoc({
       dataset_query: {
-        database: 1,
+        database: SAMPLE_DB_ID,
         query: {
           "source-table": ORDERS_ID,
           aggregation: [
@@ -137,7 +139,7 @@ describe("scenarios > visualizations > line chart", () => {
             "SELECT '2020-03-01'::date as date, 'cat1' as category, 23 as value\nUNION ALL\nSELECT '2020-03-01'::date, '', 44\nUNION ALL\nSELECT  '2020-03-01'::date, 'cat3', 58\n\nUNION ALL\n\nSELECT '2020-03-02'::date as date, 'cat1' as category, 20 as value\nUNION ALL\nSELECT '2020-03-02'::date, '', 50\nUNION ALL\nSELECT  '2020-03-02'::date, 'cat3', 58",
           "template-tags": {},
         },
-        database: 1,
+        database: SAMPLE_DB_ID,
       },
       display: "line",
       visualization_settings: {
@@ -184,7 +186,7 @@ describe("scenarios > visualizations > line chart", () => {
           `,
           "template-tags": {},
         },
-        database: 1,
+        database: SAMPLE_DB_ID,
       },
       display: "line",
     });
@@ -390,7 +392,7 @@ describe("scenarios > visualizations > line chart", () => {
     beforeEach(() => {
       visitQuestionAdhoc({
         dataset_query: {
-          database: 1,
+          database: SAMPLE_DB_ID,
           query: {
             "source-table": PRODUCTS_ID,
             aggregation: [["avg", ["field", PRODUCTS.PRICE, null]]],

--- a/frontend/test/metabase/scenarios/visualizations/maps.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/maps.cy.spec.js
@@ -4,6 +4,8 @@ import {
   visitQuestionAdhoc,
   openNativeEditor,
 } from "__support__/e2e/cypress";
+
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { PEOPLE, PEOPLE_ID } = SAMPLE_DATABASE;
@@ -103,7 +105,7 @@ describe("scenarios > visualizations > maps", () => {
     cy.intercept("/app/assets/geojson").as("geojson");
     visitQuestionAdhoc({
       dataset_query: {
-        database: 1,
+        database: SAMPLE_DB_ID,
         query: {
           "source-table": PEOPLE_ID,
           aggregation: [["count"]],
@@ -148,7 +150,7 @@ describe("scenarios > visualizations > maps", () => {
     visitQuestionAdhoc({
       display: "map",
       dataset_query: {
-        database: 1,
+        database: SAMPLE_DB_ID,
         type: "query",
         query: {
           "source-table": PEOPLE_ID,
@@ -200,7 +202,7 @@ describe("scenarios > visualizations > maps", () => {
             `,
           "template-tags": {},
         },
-        database: 1,
+        database: SAMPLE_DB_ID,
       },
       display: "map",
       visualization_settings: {

--- a/frontend/test/metabase/scenarios/visualizations/pie_chart.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/pie_chart.cy.spec.js
@@ -1,4 +1,6 @@
 import { restore, visitQuestionAdhoc } from "__support__/e2e/cypress";
+
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
@@ -10,7 +12,7 @@ const testQuery = {
     aggregation: [["count"]],
     breakout: [["field", PRODUCTS.CATEGORY, null]],
   },
-  database: 1,
+  database: SAMPLE_DB_ID,
 };
 
 describe("scenarios > visualizations > pie chart", () => {

--- a/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -6,6 +6,7 @@ import {
   visitQuestion,
 } from "__support__/e2e/cypress";
 
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const {
@@ -146,7 +147,7 @@ describe("scenarios > visualizations > pivot tables", () => {
             ["field", ORDERS.SUBTOTAL, { binning: { strategy: "default" } }],
           ],
         },
-        database: 1,
+        database: SAMPLE_DB_ID,
       },
       display: "pivot",
       visualization_settings: {},
@@ -179,7 +180,7 @@ describe("scenarios > visualizations > pivot tables", () => {
           aggregation: [["count"]],
           breakout: [b1, b2, b3],
         },
-        database: 1,
+        database: SAMPLE_DB_ID,
       },
       display: "pivot",
       visualization_settings: {
@@ -413,7 +414,7 @@ describe("scenarios > visualizations > pivot tables", () => {
             ],
           ],
         },
-        database: 1,
+        database: SAMPLE_DB_ID,
       },
       display: "pivot",
     });
@@ -441,7 +442,7 @@ describe("scenarios > visualizations > pivot tables", () => {
       dataset_query: {
         type: "native",
         native: { query: "select 1", "template-tags": {} },
-        database: 1,
+        database: SAMPLE_DB_ID,
       },
       display: "pivot",
       visualization_settings: {},
@@ -454,7 +455,7 @@ describe("scenarios > visualizations > pivot tables", () => {
     it("should work with custom columns as values", () => {
       visitQuestionAdhoc({
         dataset_query: {
-          database: 1,
+          database: SAMPLE_DB_ID,
           query: {
             "source-table": ORDERS_ID,
             expressions: {
@@ -502,7 +503,7 @@ describe("scenarios > visualizations > pivot tables", () => {
             aggregation: [["count"]],
             breakout: [["expression", "category_foo"]],
           },
-          database: 1,
+          database: SAMPLE_DB_ID,
         },
         display: "pivot",
       });
@@ -677,7 +678,7 @@ describe("scenarios > visualizations > pivot tables", () => {
     cy.request("POST", "/api/card", {
       name: "14989",
       dataset_query: {
-        database: 1,
+        database: SAMPLE_DB_ID,
         query: {
           "source-table": PRODUCTS_ID,
           aggregation: [["count"]],
@@ -723,7 +724,7 @@ describe("scenarios > visualizations > pivot tables", () => {
 
     visitQuestionAdhoc({
       dataset_query: {
-        database: 1,
+        database: SAMPLE_DB_ID,
         query: {
           "source-table": REVIEWS_ID,
           aggregation: [["count"]],
@@ -775,7 +776,7 @@ describe("scenarios > visualizations > pivot tables", () => {
             ["!=", ["field", ORDERS.PRODUCT_ID, null], 146],
           ],
         },
-        database: 1,
+        database: SAMPLE_DB_ID,
       },
       display: "pivot",
       visualization_settings: {
@@ -830,7 +831,7 @@ describe("scenarios > visualizations > pivot tables", () => {
           ],
           filter: [">", ["field", ORDERS.CREATED_AT, null], "2020-01-01"],
         },
-        database: 1,
+        database: SAMPLE_DB_ID,
       },
       display: "pivot",
       visualization_settings: {
@@ -868,7 +869,7 @@ const testQuery = {
       ["field", PRODUCTS.CATEGORY, { "source-field": ORDERS.PRODUCT_ID }],
     ],
   },
-  database: 1,
+  database: SAMPLE_DB_ID,
 };
 
 function createAndVisitTestQuestion({ display = "pivot" } = {}) {

--- a/frontend/test/metabase/scenarios/visualizations/reproductions/18976-pivot-table-columns.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/reproductions/18976-pivot-table-columns.cy.spec.js
@@ -1,9 +1,10 @@
 import { restore, visitQuestionAdhoc } from "__support__/e2e/cypress";
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 
 const questionDetails = {
   display: "table",
   dataset_query: {
-    database: 1,
+    database: SAMPLE_DB_ID,
     type: "native",
     native: {
       query: "select 'a', 'b'",

--- a/frontend/test/metabase/scenarios/visualizations/scalar.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/scalar.cy.spec.js
@@ -1,4 +1,6 @@
 import { restore, visitQuestionAdhoc } from "__support__/e2e/cypress";
+
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
@@ -65,7 +67,7 @@ describe("scenarios > visualizations > scalar", () => {
           query: `SELECT cast('2018-05-01T00:00:00Z'::timestamp as date)`,
           "template-tags": {},
         },
-        database: 1,
+        database: SAMPLE_DB_ID,
       },
       display: "scalar",
     });

--- a/frontend/test/metabase/scenarios/visualizations/scatter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/scatter.cy.spec.js
@@ -1,10 +1,12 @@
 import { restore, visitQuestionAdhoc, popover } from "__support__/e2e/cypress";
+
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID, PRODUCTS } = SAMPLE_DATABASE;
 
 const testQuery = {
-  database: 1,
+  database: SAMPLE_DB_ID,
   query: {
     "source-table": ORDERS_ID,
     aggregation: [

--- a/frontend/test/metabase/scenarios/visualizations/waterfall.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/waterfall.cy.spec.js
@@ -6,6 +6,8 @@ import {
   visualize,
   summarize,
 } from "__support__/e2e/cypress";
+
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
@@ -150,7 +152,7 @@ describe("scenarios > visualizations > waterfall", () => {
             ["datetime-field", ["field-id", ORDERS.CREATED_AT], "year"],
           ],
         },
-        database: 1,
+        database: SAMPLE_DB_ID,
       },
       display: "line",
     });
@@ -173,7 +175,7 @@ describe("scenarios > visualizations > waterfall", () => {
           query:
             "SELECT parsedatetime('2020-01-01', 'yyyy-MM-dd') AS \"d\", 1 AS \"c\" UNION ALL\nSELECT parsedatetime('2020-01-01', 'yyyy-MM-dd') AS \"d\", 2 AS \"c\" UNION ALL\nSELECT parsedatetime('2020-01-02', 'yyyy-MM-dd') AS \"d\", 3 AS \"c\"",
         },
-        database: 1,
+        database: SAMPLE_DB_ID,
       },
     });
     cy.findByText("Visualization").click();
@@ -190,7 +192,7 @@ describe("scenarios > visualizations > waterfall", () => {
             "SELECT * FROM (\nVALUES \n('a',2),\n('b',1),\n('c',-0.5),\n('d',-0.5),\n('e',0.1),\n('f',0),\n('g', -2)\n)\n",
           "template-tags": {},
         },
-        database: 1,
+        database: SAMPLE_DB_ID,
       },
       display: "waterfall",
       visualization_settings: {
@@ -219,7 +221,7 @@ describe("scenarios > visualizations > waterfall", () => {
             "SELECT * FROM (\nVALUES \n('a',2),\n('b',1),\n('c',-0.5),\n('d',-0.5),\n('e',0.1),\n('f',null),\n('g', -2)\n)\n",
           "template-tags": {},
         },
-        database: 1,
+        database: SAMPLE_DB_ID,
       },
       display: "waterfall",
       visualization_settings: {


### PR DESCRIPTION
### Status
PENDING CI

As explained and defined in https://github.com/metabase/metabase/issues/20722, we're replacing hard coded sample database id with a variable.

This PR updates and replaces hard coded sample database id in all e2e tests.

### How to test?
- All tests should still work in CI and locally for you
