### PR TITLE
Allow user-local settings to be fetched and set via the API

### DIFF
--- a/src/metabase/api/setting.clj
+++ b/src/metabase/api/setting.clj
@@ -34,5 +34,4 @@
   (setting/set! key value)
   api/generic-204-no-content)
 
-
 (api/define-routes)

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -110,9 +110,12 @@
   `User.settings` in the application DB. When bound, any Setting that *can* be User-local will have a value from this
   map returned preferentially to the site-wide value.
 
+  This is a delay so that the settings for a user are loaded only if and when they are actually needed during a given
+  API request.
+
   This is normally bound automatically by session middleware, in
   [[metabase.server.middleware.session/do-with-current-user]]."
-  (atom nil))
+  (delay (atom nil)))
 
 (def ^:private retired-setting-names
   "A set of setting names which existed in previous versions of Metabase, but are no longer used. New settings may not use
@@ -287,22 +290,22 @@
 (defn- user-local-value [setting-definition-or-name]
   (let [{setting-name :name, :as setting} (resolve-setting setting-definition-or-name)]
     (when (allows-user-local-values? setting)
-      (core/get @*user-local-values* setting-name))))
+      (core/get @@*user-local-values* setting-name))))
 
 (defn- should-set-user-local-value? [setting-definition-or-name]
   (let [setting (resolve-setting setting-definition-or-name)]
     (and (allows-user-local-values? setting)
-         @*user-local-values*)))
+         @@*user-local-values*)))
 
 (defn- set-user-local-value! [setting-definition-or-name value]
   (let [{setting-name :name} (resolve-setting setting-definition-or-name)]
     ;; Update the atom in *user-local-values* with the new value before writing to the DB. This ensures that
     ;; subsequent setting updates within the same API request will not overwrite this value.
-    (swap! *user-local-values*
+    (swap! @*user-local-values*
            (fn [old-settings] (if value
                                 (assoc old-settings setting-name value)
                                 (dissoc old-settings setting-name))))
-    (db/update! 'User api/*current-user-id* {:settings (json/generate-string @*user-local-values*)})))
+    (db/update! 'User api/*current-user-id* {:settings (json/generate-string @@*user-local-values*)})))
 
 (defn- munge-setting-name
   "Munge names so that they are legal for bash. Only allows for alphanumeric characters,  underscores, and hyphens."
@@ -969,7 +972,7 @@
      []
      (comp (filter (fn [setting]
                      (and (not= (:visibility setting) :internal)
-                          (allows-site-wide-values? setting))))
+                          (not= (:database-local setting) :only))))
            (map #(m/mapply user-facing-info % options)))
      (sort-by :name (vals @registered-settings)))))
 
@@ -980,7 +983,7 @@
 
   This is used in [[metabase-enterprise.serialization.dump/dump-settings]] to serialize site-wide Settings."
   [& options]
-  (binding [*user-local-values* (atom nil)]
+  (binding [*user-local-values* (delay (atom nil))]
     (apply admin-writable-settings options)))
 
 (defn user-readable-values-map

--- a/test/metabase/api/setting_test.clj
+++ b/test/metabase/api/setting_test.clj
@@ -1,7 +1,7 @@
 (ns metabase.api.setting-test
   (:require [clojure.test :refer :all]
             [metabase.models.setting-test :refer [test-sensitive-setting test-setting-1 test-setting-2 test-setting-3
-                                                  test-user-local-only-setting test-user-local-allowed-setting]]
+                                                  test-user-local-allowed-setting test-user-local-only-setting]]
             [metabase.public-settings.premium-features-test :as premium-features-test]
             [metabase.test :as mt]
             [metabase.test.fixtures :as fixtures]

--- a/test/metabase/api/setting_test.clj
+++ b/test/metabase/api/setting_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.api.setting-test
   (:require [clojure.test :refer :all]
-            [metabase.models.setting-test :refer [test-sensitive-setting test-setting-1 test-setting-2 test-setting-3]]
+            [metabase.models.setting-test :refer [test-sensitive-setting test-setting-1 test-setting-2 test-setting-3
+                                                  test-user-local-only-setting test-user-local-allowed-setting]]
             [metabase.public-settings.premium-features-test :as premium-features-test]
             [metabase.test :as mt]
             [metabase.test.fixtures :as fixtures]
@@ -137,3 +138,74 @@
              (test-setting-1)))
       (is (= "DEF"
              (test-setting-2))))))
+
+(defn- fetch-user-local-test-settings [user]
+  (for [setting (mt/user-http-request user :get 200 "setting")
+        :when   (re-find #"^test-user-local.*setting$" (name (:key setting)))]
+    setting))
+
+(defn- set-initial-user-local-values []
+  (mt/with-current-user (mt/user->id :crowberto)
+    (test-user-local-only-setting "ABC")
+    (test-user-local-allowed-setting "ABC"))
+  (mt/with-current-user (mt/user->id :rasta)
+    (test-user-local-only-setting "DEF")
+    (test-user-local-allowed-setting "DEF")))
+
+(defn- clear-user-local-values []
+  (mt/with-current-user (mt/user->id :crowberto)
+    (test-user-local-only-setting nil)
+    (test-user-local-allowed-setting nil))
+  (mt/with-current-user (mt/user->id :rasta)
+    (test-user-local-only-setting nil)
+    (test-user-local-allowed-setting nil)))
+
+(deftest user-local-settings-test
+  (testing "GET /api/setting/"
+    (testing "should return the user-local value of a user-local setting"
+      (set-initial-user-local-values)
+      (is (= [{:key "test-user-local-allowed-setting"
+               :value "ABC" ,
+               :is_env_setting false,
+               :env_name "MB_TEST_USER_LOCAL_ALLOWED_SETTING",
+               :description "test Setting",
+               :default nil}
+              {:key "test-user-local-only-setting",
+               :value "ABC" ,
+               :is_env_setting false,
+               :env_name "MB_TEST_USER_LOCAL_ONLY_SETTING",
+               :description "test Setting",
+               :default nil}]
+             (fetch-user-local-test-settings :crowberto)))
+      (clear-user-local-values)))
+
+  (testing "GET /api/setting/:key"
+    (testing "should return the user-local value of a user-local setting"
+      (set-initial-user-local-values)
+      (is (= "ABC"
+             (mt/user-http-request :crowberto :get 200 "setting/test-user-local-only-setting")))
+      (is (= "ABC"
+             (mt/user-http-request :crowberto :get 200 "setting/test-user-local-allowed-setting")))
+      (clear-user-local-values)))
+
+  (testing "PUT /api/setting/:key"
+    (testing "should update the user-local value of a user-local setting"
+      (set-initial-user-local-values)
+      (mt/user-http-request :crowberto :put 204 "setting/test-user-local-only-setting" {:value "GHI"})
+      (is (= "GHI"
+             (mt/user-http-request :crowberto :get 200 "setting/test-user-local-only-setting")))
+      (mt/user-http-request :crowberto :put 204 "setting/test-user-local-allowed-setting" {:value "JKL"})
+      (is (= "JKL"
+             (mt/user-http-request :crowberto :get 200 "setting/test-user-local-allowed-setting")))
+      (clear-user-local-values)))
+
+  (testing "PUT /api/setting"
+    (testing "can updated multiple user-local settings at once"
+      (set-initial-user-local-values)
+      (mt/user-http-request :crowberto :put 204 "setting" {:test-user-local-only-setting "GHI"
+                                                           :test-user-local-allowed-setting "JKL"})
+      (is (= "GHI"
+             (mt/user-http-request :crowberto :get 200 "setting/test-user-local-only-setting")))
+      (is (= "JKL"
+             (mt/user-http-request :crowberto :get 200 "setting/test-user-local-allowed-setting")))
+      (clear-user-local-values))))

--- a/test/metabase/models/setting_test.clj
+++ b/test/metabase/models/setting_test.clj
@@ -824,67 +824,64 @@
           (is (= "Setting name 'retired-setting' is retired; use a different name instead"
                  (ex-message e))))))))
 
-(defsetting ^:private test-user-local-only-setting
-  "test Setting"
-  :visibility :internal
-  :type       :integer
+(defsetting test-user-local-only-setting
+  (deferred-tru  "test Setting")
+  :visibility :authenticated
   :user-local :only)
 
-(defsetting ^:private test-user-local-allowed-setting
+(defsetting test-user-local-allowed-setting
   (deferred-tru "test Setting")
   :visibility :authenticated
-  :type       :integer
   :user-local :allowed)
 
 (defsetting ^:private test-user-local-never-setting
-  "test Setting"
-  :visibility :internal
-  :type       :integer) ; `:never` should be the default
+  (deferred-tru "test Setting")
+  :visibility :internal) ; `:never` should be the default
 
 (deftest user-local-settings-test
   (testing "Reading and writing a user-local-only setting in the context of a user uses the user-local value"
     (mt/with-current-user (mt/user->id :rasta)
-      (test-user-local-only-setting 1)
-      (is (= 1 (test-user-local-only-setting))))
+      (test-user-local-only-setting "ABC")
+      (is (= "ABC" (test-user-local-only-setting))))
     (mt/with-current-user (mt/user->id :crowberto)
-      (test-user-local-only-setting 2)
-      (is (= 2 (test-user-local-only-setting))))
+      (test-user-local-only-setting "DEF")
+      (is (= "DEF" (test-user-local-only-setting))))
     (mt/with-current-user (mt/user->id :rasta)
-      (is (= 1 (test-user-local-only-setting)))))
+      (is (= "ABC" (test-user-local-only-setting)))))
 
   (testing "A user-local-only setting cannot have a site-wide value"
-    (is (thrown-with-msg? Throwable #"Site-wide values are not allowed" (test-user-local-only-setting 1))))
+    (is (thrown-with-msg? Throwable #"Site-wide values are not allowed" (test-user-local-only-setting "ABC"))))
 
   (testing "Reading and writing a user-local-allowed setting in the context of a user uses the user-local value"
     ;; TODO: mt/with-temporary-setting-values only affects site-wide value, we should figure out whether it should also
     ;; affect user-local settings.
     (mt/with-temporary-setting-values [test-user-local-allowed-setting nil]
       (mt/with-current-user (mt/user->id :rasta)
-        (test-user-local-allowed-setting 1)
-        (is (= 1 (test-user-local-allowed-setting))))
+        (test-user-local-allowed-setting "ABC")
+        (is (= "ABC" (test-user-local-allowed-setting))))
       (mt/with-current-user (mt/user->id :crowberto)
-        (test-user-local-allowed-setting 2)
-        (is (= 2 (test-user-local-allowed-setting))))
+        (test-user-local-allowed-setting "DEF")
+        (is (= "DEF" (test-user-local-allowed-setting))))
       (mt/with-current-user (mt/user->id :rasta)
-        (is (= 1 (test-user-local-allowed-setting))))
+        (is (= "ABC" (test-user-local-allowed-setting))))
       ;; Calling the setter when not in the context of a user should set the site-wide value
       (is (nil? (test-user-local-allowed-setting)))
-      (test-user-local-allowed-setting 3)
+      (test-user-local-allowed-setting "GHI")
       (mt/with-current-user (mt/user->id :crowberto)
-        (is (= 2 (test-user-local-allowed-setting))))
+        (is (= "DEF" (test-user-local-allowed-setting))))
       (mt/with-current-user (mt/user->id :rasta)
-        (is (= 1 (test-user-local-allowed-setting))))))
+        (is (= "ABC" (test-user-local-allowed-setting))))))
 
   (testing "Reading and writing a user-local-never setting in the context of a user uses the site-wide value"
     (mt/with-current-user (mt/user->id :rasta)
-      (test-user-local-never-setting 1)
-      (is (= 1 (test-user-local-never-setting))))
+      (test-user-local-never-setting "ABC")
+      (is (= "ABC" (test-user-local-never-setting))))
     (mt/with-current-user (mt/user->id :crowberto)
-      (test-user-local-never-setting 2)
-      (is (= 2 (test-user-local-never-setting))))
+      (test-user-local-never-setting "DEF")
+      (is (= "DEF" (test-user-local-never-setting))))
     (mt/with-current-user (mt/user->id :rasta)
-      (is (= 2 (test-user-local-never-setting))))
-    (is (= 2 (test-user-local-never-setting))))
+      (is (= "DEF" (test-user-local-never-setting))))
+    (is (= "DEF" (test-user-local-never-setting))))
 
   (testing "A setting cannot be defined to allow both user-local and database-local values"
     (is (thrown-with-msg?


### PR DESCRIPTION
This fixes some remaining issues with user-local settings that I didn't catch in my [first PR](https://github.com/metabase/metabase/pull/20456).

Specifically, though user-local settings were fully functional on the backend, they couldn't be accessed via the `/api/setting/` API. This is because, during an API request, `do-with-current-user` is passed data that comes from the body of the request itself, not from the `User` stored in the database. And the request itself obviously doesn't include user-local settings.

I've fixed this by binding `*user-local-values*` to a delay that fetches the current user's settings from the DB when it is first dereferenced, similar to how `*current-user-permissions-set*` works.

I've also added API tests, and I've changed the test user-local settings to use strings rather than integers, because I was hitting #20735 otherwise.

**Note:** the `/api/setting/` APIs are currently entirely restricted to admins, which means that there's currently no way for user-local settings to be set by non-admins. I'm not totally sure what the best solution for this should be...we could change these endpoints to allow non-admins to call them, but only allow them to operate on user-local settings for non-admins. Or we could create new endpoints for user-local settings. In any case, this will need to be fixed before we can use these in any real projects.