### PR TITLE
make init health request a relative url

### DIFF
--- a/resources/frontend_client/inline_js/init.js
+++ b/resources/frontend_client/inline_js/init.js
@@ -40,7 +40,7 @@ var statusElement = document.getElementById("status");
 
 function poll() {
   var req = new XMLHttpRequest();
-  req.open("GET", "/api/health", true);
+  req.open("GET", "api/health", true);
   req.onreadystatechange = function() {
     if (req.readyState === 4) {
       if (req.status === 200) {


### PR DESCRIPTION
A request to `/api/health` fails when metabase is run from a nested path, as the preceding `/` means this is an absolute path.

**Proxy setup**
- Run a proxy so that you can open up an instance of metabase at a url like `localhost:3100/metabase`. I'm using nginx to do this. You can use the config for nginx found in this PR: https://github.com/metabase/metabase/pull/4740
- Go to `/admin/settings/general` and update the site url input to `localhost:3100/metabase`

**Testing**
We just need to confirm that the URL `api/health` is sent to the correct URL, so paste this somewhere in the app so that it will run:

```
function poll() {
  const req = new XMLHttpRequest();
  req.open("GET", "api/health", true);
  req.onreadystatechange = function() {
    if (req.readyState === 4) {
      console.log("it works");
      setTimeout(poll, 1000);
    }
  };
  req.send();
}

poll();
```
And confirm that a request is sent to `http://localhost:3100/metabase/api/health`