### PR TITLE
Fix a flake where Cypress cannot click "Exit admin"

### DIFF
--- a/frontend/test/metabase/scenarios/smoketest/admin_setup.cy.spec.js
+++ b/frontend/test/metabase/scenarios/smoketest/admin_setup.cy.spec.js
@@ -380,7 +380,7 @@ describe("smoketest > admin_setup", () => {
 
     it("should reflect changes to column name, visibility, and formatting in the notebook editor for admin", () => {
       // Navigate
-      cy.findByText("Exit admin").click();
+      cy.findByText("Exit admin").click({ force: true });
 
       // Checking table name
 


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Fixes a flake where Cypress cannot click on "Exit admin" button because "Saved" text lingers for far too long in the UI

### Why does this happen?
It started after we introduced a CTA for models "Simplify your schema with models". That pushed the "Saved" text up, which then obstructs the button.

Force clicking should ignore that and do the job.

### Before this
![image](https://user-images.githubusercontent.com/31325167/155613975-e140e70c-628d-42ca-a589-f0a83182cc31.png)

### After
Shouldn't happen any more