### PR TITLE
Fix Help link in top right menu when metabase is served from non-root path

### DIFF
--- a/frontend/src/metabase/components/EntityMenuItem.jsx
+++ b/frontend/src/metabase/components/EntityMenuItem.jsx
@@ -1,62 +1,30 @@
 /* eslint-disable react/prop-types */
 import React from "react";
-import styled from "@emotion/styled";
 import { Link } from "react-router";
 
 import Icon from "metabase/components/Icon";
+import { Item, StyledExternalLink } from "./EntityMenuItem.styled";
 
-import { color } from "metabase/lib/colors";
-
-const Item = styled.div`
-  display: flex;
-  align-items: center;
-  cursor: pointer;
-  color: ${color("text-medium")};
-  padding: 0.85em 1.45em;
-  text-decoration: none;
-  transition: all 300ms linear;
-  :hover {
-    color: ${color("brand")};
-  }
-  > .Icon {
-    color: ${color("text-light")};
-    margin-right: 0.65em;
-  }
-  :hover > .Icon {
-    color: ${color("brand")};
-    transition: all 300ms linear;
-  },
-  /* icon specific tweaks
-     the alert icon should be optically aligned  with the x-height of the text */
-  > .Icon.Icon-alert {
-    transform: translate-y(1px),
-  }
-  /* the embed icon should be optically aligned with the x-height of the text */
-  > .Icon.Icon-embed {
-    transform: translate-y(1px);
-  }
-  /* the download icon should be optically aligned with the x-height of the text */
-  > .Icon.Icon-download: {
-    transform: translate-y(1px);
-  }
-  /* the history icon is wider so it needs adjustment to center it with other
-   icons */
-  "> .Icon.Icon-history": {
-    transform: translate-x(-2px);
-  },
-`;
-
-const LinkMenuItem = ({ children, link, onClose, event, externalLink }) => (
-  <Link
-    to={link}
-    target={externalLink ? "_blank" : null}
-    onClick={onClose}
-    data-metabase-event={event}
-    style={{ display: "block" }}
-  >
-    {children}
-  </Link>
-);
+const LinkMenuItem = ({ children, link, onClose, event, externalLink }) =>
+  externalLink ? (
+    <StyledExternalLink
+      href={link}
+      target="_blank"
+      onClick={onClose}
+      data-metabase-event={event}
+    >
+      {children}
+    </StyledExternalLink>
+  ) : (
+    <Link
+      to={link}
+      onClick={onClose}
+      data-metabase-event={event}
+      className="block"
+    >
+      {children}
+    </Link>
+  );
 
 const ActionMenuItem = ({ children, action, event }) => (
   <div onClick={action} data-metabase-event={event}>

--- a/frontend/src/metabase/components/EntityMenuItem.styled.jsx
+++ b/frontend/src/metabase/components/EntityMenuItem.styled.jsx
@@ -1,0 +1,48 @@
+import styled from "@emotion/styled";
+
+import ExternalLink from "metabase/core/components/ExternalLink";
+import { color } from "metabase/lib/colors";
+
+export const Item = styled.div`
+  display: flex;
+align-items: center;
+  cursor: pointer;
+  color: ${color("text-medium")};
+  padding: 0.85em 1.45em;
+  text-decoration: none;
+  transition: all 300ms linear;
+  :hover {
+    color: ${color("brand")};
+  }
+  > .Icon {
+    color: ${color("text-light")};
+    margin-right: 0.65em;
+  }
+  :hover > .Icon {
+    color: ${color("brand")};
+    transition: all 300ms linear;
+  },
+  /* icon specific tweaks
+     the alert icon should be optically aligned  with the x-height of the text */
+  > .Icon.Icon-alert {
+    transform: translate-y(1px),
+}
+  /* the embed icon should be optically aligned with the x-height of the text */
+  > .Icon.Icon-embed {
+    transform: translate-y(1px);
+  }
+  /* the download icon should be optically aligned with the x-height of the text */
+  > .Icon.Icon-download: {
+    transform: translate-y(1px);
+  }
+  /* the history icon is wider so it needs adjustment to center it with other
+   icons */
+  "> .Icon.Icon-history": {
+    transform: translate-x(-2px);
+  },
+`;
+
+export const StyledExternalLink = styled(ExternalLink)`
+  text-decoration: none;
+  display: block;
+`;


### PR DESCRIPTION
We're using a `Link` instead of an `ExternalLink`. This causes a console error, and it breaks the Help link when clicked from an instance served from a non-root path.

![Screen Shot 2022-02-24 at 5 17 28 PM](https://user-images.githubusercontent.com/13057258/155635232-c548a1c0-a2ac-43d4-bfb0-35d3e51610f0.png)

**Before**

https://user-images.githubusercontent.com/13057258/155634719-2176de02-bb31-4782-8a2c-608cbe858938.mov

**After**

https://user-images.githubusercontent.com/13057258/155634736-95fbdc89-d41e-484d-9fd4-654af6655d97.mov

**Proxy setup**
- Run a proxy so that you can open up an instance of metabase at a url like `localhost:3100/metabase`. I'm using nginx to do this. You can use the config for nginx found in this PR: https://github.com/metabase/metabase/pull/4740

**Testing**
- Click the Help link in the top right menu
