### PR TITLE
Remove legacy EE hard coded version info

### DIFF
--- a/frontend/test/__support__/e2e/cypress.js
+++ b/frontend/test/__support__/e2e/cypress.js
@@ -6,8 +6,6 @@ import "@cypress/skip-test/support";
 import "@percy/cypress";
 import "./commands";
 
-export const version = require("../../../../version.json");
-
 export * from "./helpers/e2e-setup-helpers";
 export * from "./helpers/e2e-ui-elements-helpers";
 export * from "./helpers/e2e-dashboard-helpers";

--- a/frontend/test/metabase/scenarios/embedding/admin-embedding-settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/admin-embedding-settings.cy.spec.js
@@ -1,99 +1,98 @@
-import { restore, version } from "__support__/e2e/cypress";
+import { restore } from "__support__/e2e/cypress";
 
-describe("admin > settings > embedding ", () => {
+// Skipping temporarily because tests need to be updated to work
+describe.skip("admin > settings > embedding ", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
   });
 
-  if (version.edition !== "enterprise") {
-    describe(" > embedding settings", () => {
-      it("should validate a premium embedding token has a valid format", () => {
-        cy.server();
-        cy.route("PUT", "/api/setting/premium-embedding-token").as(
-          "saveEmbeddingToken",
+  describe(" > embedding settings", () => {
+    it("should validate a premium embedding token has a valid format", () => {
+      cy.server();
+      cy.route("PUT", "/api/setting/premium-embedding-token").as(
+        "saveEmbeddingToken",
+      );
+
+      cy.visit("/admin/settings/embedding_in_other_applications");
+      cy.contains("Premium embedding");
+      cy.contains("Enter a token").click();
+
+      // Try an invalid token format
+      cy.contains("Enter the token")
+        .next()
+        .type("Hi")
+        .blur();
+      cy.wait("@saveEmbeddingToken").then(({ response }) => {
+        expect(response.body).to.equal(
+          "Token format is invalid. Token should be 64 hexadecimal characters.",
         );
-
-        cy.visit("/admin/settings/embedding_in_other_applications");
-        cy.contains("Premium embedding");
-        cy.contains("Enter a token").click();
-
-        // Try an invalid token format
-        cy.contains("Enter the token")
-          .next()
-          .type("Hi")
-          .blur();
-        cy.wait("@saveEmbeddingToken").then(({ response }) => {
-          expect(response.body).to.equal(
-            "Token format is invalid. Token should be 64 hexadecimal characters.",
-          );
-        });
-        cy.contains("Token format is invalid.");
       });
-
-      it("should validate a premium embedding token exists", () => {
-        cy.server();
-        cy.route("PUT", "/api/setting/premium-embedding-token").as(
-          "saveEmbeddingToken",
-        );
-
-        cy.visit("/admin/settings/embedding_in_other_applications");
-        cy.contains("Premium embedding");
-        cy.contains("Enter a token").click();
-
-        // Try a valid format, but an invalid token
-        cy.contains("Enter the token")
-          .next()
-          .type(
-            "11397b1e60cfb1372f2f33ac8af234a15faee492bbf5c04d0edbad76da3e614a",
-          )
-          .blur();
-        cy.wait("@saveEmbeddingToken").then(({ response }) => {
-          expect(response.body).to.equal(
-            "Unable to validate token: 404 not found.",
-          );
-        });
-        cy.contains("Unable to validate token: 404 not found.");
-      });
-
-      it("should be able to set a premium embedding token", () => {
-        // A random embedding token with valid format
-        const embeddingToken =
-          "11397b1e60cfb1372f2f33ac8af234a15faee492bbf5c04d0edbad76da3e614a";
-
-        cy.server();
-        cy.route({
-          method: "PUT",
-          url: "/api/setting/premium-embedding-token",
-          response: embeddingToken,
-        }).as("saveEmbeddingToken");
-
-        cy.visit("/admin/settings/embedding_in_other_applications");
-        cy.contains("Premium embedding");
-        cy.contains("Enter a token").click();
-
-        cy.route("GET", "/api/session/properties").as("getSessionProperties");
-        cy.route({
-          method: "GET",
-          url: "/api/setting",
-          response: [
-            { key: "enable-embedding", value: true },
-            { key: "embedding-secret-key", value: embeddingToken },
-            { key: "premium-embedding-token", value: embeddingToken },
-          ],
-        }).as("getSettings");
-
-        cy.contains("Enter the token")
-          .next()
-          .type(embeddingToken)
-          .blur();
-        cy.wait("@saveEmbeddingToken").then(({ response }) => {
-          expect(response.body).to.equal(embeddingToken);
-        });
-        cy.wait("@getSessionProperties");
-        cy.wait("@getSettings");
-        cy.contains("Premium embedding enabled");
-      });
+      cy.contains("Token format is invalid.");
     });
-  }
+
+    it("should validate a premium embedding token exists", () => {
+      cy.server();
+      cy.route("PUT", "/api/setting/premium-embedding-token").as(
+        "saveEmbeddingToken",
+      );
+
+      cy.visit("/admin/settings/embedding_in_other_applications");
+      cy.contains("Premium embedding");
+      cy.contains("Enter a token").click();
+
+      // Try a valid format, but an invalid token
+      cy.contains("Enter the token")
+        .next()
+        .type(
+          "11397b1e60cfb1372f2f33ac8af234a15faee492bbf5c04d0edbad76da3e614a",
+        )
+        .blur();
+      cy.wait("@saveEmbeddingToken").then(({ response }) => {
+        expect(response.body).to.equal(
+          "Unable to validate token: 404 not found.",
+        );
+      });
+      cy.contains("Unable to validate token: 404 not found.");
+    });
+
+    it("should be able to set a premium embedding token", () => {
+      // A random embedding token with valid format
+      const embeddingToken =
+        "11397b1e60cfb1372f2f33ac8af234a15faee492bbf5c04d0edbad76da3e614a";
+
+      cy.server();
+      cy.route({
+        method: "PUT",
+        url: "/api/setting/premium-embedding-token",
+        response: embeddingToken,
+      }).as("saveEmbeddingToken");
+
+      cy.visit("/admin/settings/embedding_in_other_applications");
+      cy.contains("Premium embedding");
+      cy.contains("Enter a token").click();
+
+      cy.route("GET", "/api/session/properties").as("getSessionProperties");
+      cy.route({
+        method: "GET",
+        url: "/api/setting",
+        response: [
+          { key: "enable-embedding", value: true },
+          { key: "embedding-secret-key", value: embeddingToken },
+          { key: "premium-embedding-token", value: embeddingToken },
+        ],
+      }).as("getSettings");
+
+      cy.contains("Enter the token")
+        .next()
+        .type(embeddingToken)
+        .blur();
+      cy.wait("@saveEmbeddingToken").then(({ response }) => {
+        expect(response.body).to.equal(embeddingToken);
+      });
+      cy.wait("@getSessionProperties");
+      cy.wait("@getSettings");
+      cy.contains("Premium embedding enabled");
+    });
+  });
 });

--- a/version.json
+++ b/version.json
@@ -1,3 +1,0 @@
-{
-  "edition": "enterprise"
-}


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Removes the old file `version.json` which was migrated from the EE repo cca 1 year ago.

### More details
We migrated over 300 files from EE repo to the OSS (this one) in https://github.com/metabase/metabase/pull/13590. That PR added more 20k LoC, so it was pretty hard to review and to debug.

One of those files was `version.json`. Apparently it was used for Cypress tests in EE repro. While we still had separate repos, it probably made sense that this file had hard coded `version` set to `enterprise`. However, embedding settings tests were relying on that relic, instead of some newer helpers.

```js
if (version.edition !== "enterprise") {
  // embedding settings tests
}
```

The result - these tests NEVER ran for more than a year! 😮 

You can [check this run](https://app.circleci.com/pipelines/github/metabase/metabase/29987/workflows/06afae67-6769-4020-9158-75398b232622/jobs/1491369/artifacts) in the CircleCI - it is clearly an OSS version, but tests didn't even run. Open the video for `admin-embedding-settings.cy.spec.js.mp4`.

- This PR removes `version.json` and the CI confirms that no other file relied on it.
- All tests in this file are skipped for now
    - Need to update them because UI changed so they are not relevant any more