### PR TITLE
Teach custom column's type inference about semantic_type

### DIFF
--- a/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
@@ -679,7 +679,7 @@ describe("Dimension", () => {
           name: "Hello World",
           display_name: "Hello World",
           base_type: "type/Text",
-          semantic_type: null,
+          semantic_type: "type/Text",
           field_ref: ["expression", "Hello World", null],
         });
       });


### PR DESCRIPTION
This fix the custom column icon, when the custom expression thereof uses some fields with semantic type.

How to verify:
1. New, Question
2. Sample Database, People
3. Custom Column, `[Latitude]` and name it as `User Latitude`
4. Custom Column, `[ID]` and name it as `User ID`
5. Custom Column, `[Zip]` and name it as `User ZIP code`
6. Filter, search for the above custom columns

**Before this PR**

The icons are incorrect.

`User Latitude` and `User ID` are `#`, which is supposed to be for numeric fields. Meanwhile `User ZIP code` carries the same icon as a text field.

![image](https://user-images.githubusercontent.com/7288/155750076-05f69f6e-44c1-42a1-842d-f38dca29972a.png)

**After this PR**

As expected, the three custom columns have the same exact icon as their corresponding fields used in the expression.

![image](https://user-images.githubusercontent.com/7288/155750432-d50d2248-99b7-4cf3-baaf-9439a41c6055.png)

## Note

The type inference isn't fancy enough to understand more complex expression and their consequences, e.g. adding some number to a longitude/latitude must still result in a `type/Coordinate` semantic type etc. This is a much bigger scope and likely it needs to be addressed as a separate new improvement/feature.