### PR TITLE
Revert to old template tag validation logic

### DIFF
--- a/frontend/src/metabase-lib/lib/queries/NativeQuery.ts
+++ b/frontend/src/metabase-lib/lib/queries/NativeQuery.ts
@@ -286,18 +286,10 @@ export default class NativeQuery extends AtomicQuery {
   }
 
   allTemplateTagsAreValid() {
-    return this.templateTags().every(t => {
-      if (["text", "number", "date", "card", "snippet"].includes(t.type)) {
-        return true;
-      }
-
-      const isDimensionType = t.type === "dimension";
-      const hasDefinedWidgetType =
-        t["widget-type"] && t["widget-type"] !== "none";
-      const hasDefinedDimension = t.dimension != null;
-
-      return isDimensionType && hasDefinedWidgetType && hasDefinedDimension;
-    });
+    return this.templateTags().every(
+      // field filters require a field
+      t => !(t.type === "dimension" && t.dimension == null),
+    );
   }
 
   setTemplateTag(name, tag) {

--- a/frontend/test/metabase-lib/lib/queries/NativeQuery.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/NativeQuery.unit.spec.js
@@ -193,49 +193,6 @@ describe("NativeQuery", () => {
         expect(q.canRun()).toBe(true);
       });
 
-      it("bad type", () => {
-        q = q.setDatasetQuery(
-          assocIn(
-            q.datasetQuery(),
-            ["native", "template-tags", "foo", "type"],
-            "type-that-does-not-exist",
-          ),
-        );
-        expect(q.canRun()).toBe(false);
-
-        q = q.setDatasetQuery(
-          assocIn(
-            q.datasetQuery(),
-            ["native", "template-tags", "foo", "type"],
-            "text",
-          ),
-        );
-        expect(q.canRun()).toBe(true);
-      });
-
-      it("dimension type without a widget-type", () => {
-        q = q.setDatasetQuery(
-          assocIn(q.datasetQuery(), ["native", "template-tags", "foo"], {
-            type: "dimension",
-            dimension: ["field", 123, null],
-          }),
-        );
-
-        expect(q.canRun()).toBe(false);
-      });
-
-      it("dimension type with a widget-type of none", () => {
-        q = q.setDatasetQuery(
-          assocIn(q.datasetQuery(), ["native", "template-tags", "foo"], {
-            type: "dimension",
-            "widget-type": "none",
-            dimension: ["field", 123, null],
-          }),
-        );
-
-        expect(q.canRun()).toBe(false);
-      });
-
       it("dimension type without a dimension", () => {
         q = q.setDatasetQuery(
           assocIn(q.datasetQuery(), ["native", "template-tags", "foo"], {

--- a/frontend/test/metabase/scenarios/native-filters/sql-field-filter-none.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native-filters/sql-field-filter-none.cy.spec.js
@@ -30,9 +30,13 @@ describe("scenarios > filters > sql filters > field filter > None", () => {
     filterWidget().should("not.exist");
   });
 
-  it("should disallow the running of the query and the saving of the question", () => {
-    cy.get(".RunButton").should("be.disabled");
-    cy.findByText("Save").should("have.attr", "aria-disabled", "true");
+  it("should be runnable with the None filter being ignored (metabase#20643)", () => {
+    cy.get(".RunButton")
+      .first()
+      .click();
+
+    cy.wait("@dataset");
+    cy.findByText("Hudson Borer");
   });
 
   it("should let you change the field filter type to something else and restore the filter widget (metabase#13825)", () => {

--- a/shared/src/metabase/mbql/normalize.cljc
+++ b/shared/src/metabase/mbql/normalize.cljc
@@ -222,13 +222,21 @@
 (defn- normalize-template-tag-definition
   "For a template tag definition, normalize all the keys appropriately."
   [tag-definition]
-  (into
-   {}
-   (map (fn [[k v]]
-          (let [k            (maybe-normalize-token k)
-                transform-fn (template-tag-definition-key->transform-fn k)]
-            [k (transform-fn v)])))
-   tag-definition))
+  (let [tag-def (into
+                 {}
+                 (map (fn [[k v]]
+                        (let [k            (maybe-normalize-token k)
+                              transform-fn (template-tag-definition-key->transform-fn k)]
+                          [k (transform-fn v)])))
+                 tag-definition)]
+    ;; `:widget-type` is a required key for Field Filter (dimension) template tags -- see
+    ;; [[metabase.mbql.schema/TemplateTag:FieldFilter]] -- but prior to v42 it wasn't usually included by the
+    ;; frontend. See #20643. If it's not present, just add in `:category` which will make things work they way they
+    ;; did in the past.
+    (cond-> tag-def
+      (and (= (:type tag-def) :dimension)
+           (not (:widget-type tag-def)))
+      (assoc :widget-type :category))))
 
 (defn- normalize-template-tags
   "Normalize native-query template tags. Like `expressions` we want to preserve the original name rather than normalize

--- a/shared/test/metabase/mbql/normalize_test.cljc
+++ b/shared/test/metabase/mbql/normalize_test.cljc
@@ -404,12 +404,12 @@
       ;; don't add if this isn't a Field filter (`:type` is not `:dimension`)
       {:database 1
        :type     :native
-       :native   {:template-tags {"x" {:name        "x"
-                                       :type        :nonsense}}}}
+       :native   {:template-tags {"x" {:name "x"
+                                       :type :nonsense}}}}
       {:database 1
        :type     :native
-       :native   {:template-tags {"x" {:name        "x"
-                                       :type        :nonsense}}}}})))
+       :native   {:template-tags {"x" {:name "x"
+                                       :type :nonsense}}}}})))
 
 
 ;;; ------------------------------------------------- source queries -------------------------------------------------

--- a/shared/test/metabase/mbql/normalize_test.cljc
+++ b/shared/test/metabase/mbql/normalize_test.cljc
@@ -262,7 +262,8 @@
                 :template-tags {"checkin_date" {:name         "checkin_date"
                                                 :display-name "Checkin Date"
                                                 :type         :dimension
-                                                :dimension    [:field 14 nil]}}}}}
+                                                :dimension    [:field 14 nil]
+                                                :widget-type  :category}}}}}
 
      "Don't try to normalize template-tag name/display name. Names should get converted to strings."
      {(query-with-template-tags
@@ -274,7 +275,8 @@
        {"checkin_date" {:name         "checkin_date"
                         :display-name "looks/like-a-keyword"
                         :type         :dimension
-                        :dimension    [:field 14 nil]}})
+                        :dimension    [:field 14 nil]
+                        :widget-type  :category}})
 
       (query-with-template-tags
        {:checkin_date {:name         :checkin_date
@@ -285,7 +287,8 @@
        {"checkin_date" {:name         "checkin_date"
                         :display-name "Checkin Date"
                         :type         :dimension
-                        :dimension    [:field 14 nil]}})}
+                        :dimension    [:field 14 nil]
+                        :widget-type  :category}})}
 
      "Actually, `:name` should just get copied over from the map key if it's missing or different"
      {(query-with-template-tags
@@ -296,7 +299,8 @@
        {"checkin_date" {:name         "checkin_date"
                         :display-name "Checkin Date"
                         :type         :dimension
-                        :dimension    [:field 14 nil]}})
+                        :dimension    [:field 14 nil]
+                        :widget-type  :category}})
 
       (query-with-template-tags
        {"checkin_date" {:name         "something_else"
@@ -307,7 +311,8 @@
        {"checkin_date" {:name         "checkin_date"
                         :display-name "Checkin Date"
                         :type         :dimension
-                        :dimension    [:field 14 nil]}})}
+                        :dimension    [:field 14 nil]
+                        :widget-type  :category}})}
 
      "`:type` should get normalized"
      {(query-with-template-tags
@@ -319,7 +324,8 @@
        {"names_list" {:name         "names_list"
                       :display-name "Names List"
                       :type         :dimension
-                      :dimension    [:field-id 49]}})}
+                      :dimension    [:field-id 49]
+                      :widget-type  :category}})}
 
      "`:widget-type` should get normalized"
      {(query-with-template-tags
@@ -346,7 +352,8 @@
        {"checkin_date" {:name         "checkin_date"
                         :display-name "Checkin Date"
                         :type         :dimension
-                        :dimension    [:field-id 14]}})}
+                        :dimension    [:field-id 14]
+                        :widget-type  :category}})}
 
      "Don't normalize `:default` values"
      {(query-with-template-tags
@@ -372,7 +379,37 @@
       ;; `:name` still gets copied over from the map key.
       {:database 1
        :type     :native
-       :native   {:template-tags {"x" {:name "x"}}}}})))
+       :native   {:template-tags {"x" {:name "x"}}}}}
+
+     ":dimension (Field filter) template tags with no :widget-type should get :category as a default type (#20643)"
+     {{:database 1
+       :type     :native
+       :native   {:template-tags {"x" {:name "x", :type :dimension}}}}
+      {:database 1
+       :type     :native
+       :native   {:template-tags {"x" {:name        "x"
+                                       :type        :dimension
+                                       :widget-type :category}}}}
+      ;; don't add if there's already an existing `:widget-type`
+      {:database 1
+       :type     :native
+       :native   {:template-tags {"x" {:name        "x"
+                                       :type        :dimension
+                                       :widget-type :string/=}}}}
+      {:database 1
+       :type     :native
+       :native   {:template-tags {"x" {:name        "x"
+                                       :type        :dimension
+                                       :widget-type :string/=}}}}
+      ;; don't add if this isn't a Field filter (`:type` is not `:dimension`)
+      {:database 1
+       :type     :native
+       :native   {:template-tags {"x" {:name        "x"
+                                       :type        :nonsense}}}}
+      {:database 1
+       :type     :native
+       :native   {:template-tags {"x" {:name        "x"
+                                       :type        :nonsense}}}}})))
 
 
 ;;; ------------------------------------------------- source queries -------------------------------------------------

--- a/shared/test/metabase/mbql/normalize_test.cljc
+++ b/shared/test/metabase/mbql/normalize_test.cljc
@@ -1085,6 +1085,7 @@
                            :template-tags {"names_list" {:name         "names_list"
                                                          :display-name "Names List"
                                                          :type         :dimension
+                                                         :widget-type  :category
                                                          :dimension    [:field 49 nil]}}}
               :parameters [{:type   :text
                             :target [:dimension [:template-tag "names_list"]]

--- a/test/metabase/query_processor_test/parameters_test.clj
+++ b/test/metabase/query_processor_test/parameters_test.clj
@@ -219,3 +219,16 @@
                                                                         {:source-field (mt/id :venues :category_id)}]]}]))
                  (m/dissoc-in [:data :native_form :params])
                  (m/dissoc-in [:data :results_metadata :checksum])))))))
+
+(deftest legacy-parameters-with-no-widget-type-test
+  (testing "Legacy queries with parameters that don't specify `:widget-type` should still work (#20643)"
+    (mt/dataset sample-dataset
+        (let [query (mt/native-query
+                     {:query         "SELECT count(*) FROM products WHERE {{cat}};"
+                      :template-tags {"cat" {:id           "__MY_CAT__"
+                                             :name         "cat"
+                                             :display-name "Cat"
+                                             :type         :dimension
+                                             :dimension    [:field (mt/id :products :category) nil]}}})]
+        (is (= [200]
+               (mt/first-row (qp/process-query query))))))))


### PR DESCRIPTION
The FE portion of #20643 
Reproduces #20643 

We tweaked the validation logic for template tags for 42 (https://github.com/metabase/metabase/commit/0c4be936ee706cea5268f4a6f86d80b278349c10#diff-35530654dacf442e018646103bab4d1932ec13fbe6627010d9dabee025775ee5R278), but a lot of users have template tags without `widget-type` properties apparently. Previously, these funky template tags would just be ignored. In 42, the queries aren't runnable. We are returning the queries to their previous behavior.

There's still some weirdness around how a broken parameters widget appears on save, but we will resolve that in a different PR.



https://user-images.githubusercontent.com/13057258/155801289-f4212d58-624d-440c-87a0-3122190721f4.mov


**Testing**
1. Create an sql query with `select * from PEOPLE where {{lat}}`
2. In the sidebar make it a field filter and then select the field Sample Dataset > People > Latitude
3. the "filter widget type" dropdown below should show "None"
4. the query should still be runnable
5. save the query and refresh. the query should still run.
