### PR TITLE
Fix 'Compare to the rest' action styling

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartClickActions.jsx
@@ -279,7 +279,11 @@ export const ChartClickAction = ({ action, isLastItem, handleClickAction }) => {
   });
   if (action.url) {
     return (
-      <div className="full">
+      <div
+        className={cx({
+          full: action.buttonType === "horizontal",
+        })}
+      >
         <Link
           to={action.url()}
           className={className}


### PR DESCRIPTION
Fixes #20641 

The `full` class was added to the `div` wrapping the click action `Link` to make the link cover the entire width of the popover.

Without `full`:
<img width="439" alt="Screen Shot 2022-02-28 at 10 41 00 AM" src="https://user-images.githubusercontent.com/13057258/156043920-829b36bc-d4c3-4ef9-acc3-453eed41e972.png">

With `full`:
<img width="392" alt="Screen Shot 2022-02-28 at 10 40 27 AM" src="https://user-images.githubusercontent.com/13057258/156043924-eefdbec2-50f4-43cc-b542-f658deb3d8cc.png">

The click actions in the "Automatic explorations" section are styled using flexbox, so we need to make the use of `full` specific to the above click action `buttonType` (the above click actions have a `buttonType` of `"horizontal"` while the Automatic exploration click actions have a `buttonType` of `"token"`).

**Before**

<img width="348" alt="Screen Shot 2022-02-28 at 11 03 39 AM" src="https://user-images.githubusercontent.com/13057258/156044562-8130713a-8c6e-4593-823a-83fd68356580.png">

**After**

<img width="313" alt="Screen Shot 2022-02-28 at 11 03 19 AM" src="https://user-images.githubusercontent.com/13057258/156044573-97acd341-3e47-42a8-9f12-a5194acf736d.png">


