### PR TITLE
Fix Data Selector failing to load

### DIFF
--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -676,7 +676,10 @@ export class UnconnectedDataSelector extends Component {
         return this.props.fetchDatabases(this.props.databaseQuery);
       },
       [SCHEMA_STEP]: () => {
-        return this.props.fetchSchemas(this.state.selectedDatabaseId);
+        return Promise.all([
+          this.props.fetchDatabases(this.props.databaseQuery),
+          this.props.fetchSchemas(this.state.selectedDatabaseId),
+        ]);
       },
       [TABLE_STEP]: () => {
         if (this.state.selectedSchemaId != null) {


### PR DESCRIPTION
Fixes #20459 

The `SCHEMA_STEP` of the Data Selector can use the `DatabaseSchemaPicker` component, which depends on `databases` not being empty (https://github.com/metabase/metabase/blob/888e90d1f343f0533a129fe5ed3ad786a0c5efdb/frontend/src/metabase/query_builder/components/DataSelector.jsx#L1317). Coming from a saved question --> the notebook view makes the data selector skip directly to the `SCHEMA_STEP` without going through the `DATABASE_STEP`, so databases aren't fetched. We need to fetch databases explicitly in the `SCHEMA_STEP` in order to make the data selector load properly.

**Testing**
Follow the steps in #20459 

**Before**

https://user-images.githubusercontent.com/13057258/156239208-a5ffa29d-760b-4f7d-bb54-61eac6681970.mov

**After**

https://user-images.githubusercontent.com/13057258/156239279-8f784cfd-b628-4871-a692-8fc5f1631fa4.mov



