### PR TITLE
E2E oss/ee versions helpers cleanup

### DIFF
--- a/frontend/test/__support__/e2e/helpers/e2e-enterprise-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-enterprise-helpers.js
@@ -1,7 +1,6 @@
-export const describeWithToken = Cypress.env("HAS_ENTERPRISE_TOKEN")
-  ? describe
-  : describe.skip;
+export const isEE = Cypress.env("HAS_ENTERPRISE_TOKEN");
+export const isOSS = !isEE;
 
-export const describeWithoutToken = !Cypress.env("HAS_ENTERPRISE_TOKEN")
-  ? describe
-  : describe.skip;
+export const describeWithToken = isEE ? describe : describe.skip;
+
+export const describeWithoutToken = isOSS ? describe : describe.skip;

--- a/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
@@ -3,6 +3,7 @@ import {
   popover,
   describeWithToken,
   mockSessionProperty,
+  isEE,
 } from "__support__/e2e/cypress";
 
 function typeField(label, value) {
@@ -155,7 +156,7 @@ describe("scenarios > admin > databases > add", () => {
   });
 
   it("EE should ship with Oracle and Vertica as options", () => {
-    cy.onlyOn(!!Cypress.env("HAS_ENTERPRISE_TOKEN"));
+    cy.onlyOn(isEE);
 
     cy.visit("/admin/databases/create");
     cy.contains("Database type")

--- a/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
@@ -5,6 +5,8 @@ import {
   describeWithToken,
   setupMetabaseCloud,
   describeWithoutToken,
+  isOSS,
+  isEE,
 } from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
@@ -17,7 +19,7 @@ describe("scenarios > admin > settings", () => {
   });
 
   it("should prompt admin to migrate to the hosted instance", () => {
-    cy.skipOn(!!Cypress.env("HAS_ENTERPRISE_TOKEN"));
+    cy.onlyOn(isOSS);
     cy.visit("/admin/settings/setup");
     cy.findByText("Have your server maintained for you.");
     cy.findByText("Migrate to Metabase Cloud.");
@@ -240,9 +242,7 @@ describe("scenarios > admin > settings", () => {
   });
 
   it("should display the order of the settings items consistently between OSS/EE versions (metabase#15441)", () => {
-    const lastItem = Cypress.env("HAS_ENTERPRISE_TOKEN")
-      ? "Whitelabel"
-      : "Caching";
+    const lastItem = isEE ? "Whitelabel" : "Caching";
 
     cy.visit("/admin/settings/setup");
     cy.get(".AdminList .AdminList-item")

--- a/frontend/test/metabase/scenarios/embedding/embedding-smoketests.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/embedding-smoketests.cy.spec.js
@@ -1,13 +1,10 @@
-import { restore, visitQuestion } from "__support__/e2e/cypress";
+import { restore, visitQuestion, isEE, isOSS } from "__support__/e2e/cypress";
 
 const embeddingPage = "/admin/settings/embedding_in_other_applications";
 const licenseUrl = "https://metabase.com/license/embedding";
 const upgradeUrl = "https://www.metabase.com/upgrade/";
 
 const licenseExplanation = `In plain English, when you embed charts or dashboards from Metabase in your own application, that application isn't subject to the Affero General Public License that covers the rest of Metabase, provided you keep the Metabase logo and the "Powered by Metabase" visible on those embeds. You should, however, read the license text linked above as that is the actual license that you will be agreeing to by enabling this feature.`;
-
-const isEE = Cypress.env("HAS_ENTERPRISE_TOKEN");
-const isOSS = !isEE;
 
 describe("scenarios > embedding > smoke tests", () => {
   beforeEach(() => {

--- a/frontend/test/metabase/scenarios/moderation/reproductions/18021-verified-badge-not-visible-in-recents.cy.spec.js
+++ b/frontend/test/metabase/scenarios/moderation/reproductions/18021-verified-badge-not-visible-in-recents.cy.spec.js
@@ -1,9 +1,9 @@
-import { restore } from "__support__/e2e/cypress";
+import { restore, isEE } from "__support__/e2e/cypress";
 
 describe.skip("issue 18021", () => {
   beforeEach(() => {
     // Run the test only for EE version
-    cy.onlyOn(!!Cypress.env("HAS_ENTERPRISE_TOKEN"));
+    cy.onlyOn(isEE);
 
     restore();
     cy.signInAsAdmin();

--- a/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
@@ -5,6 +5,7 @@ import {
   popover,
   sidebar,
   mockSlackConfigured,
+  isOSS,
 } from "__support__/e2e/cypress";
 import { USERS } from "__support__/e2e/cypress_data";
 const { admin } = USERS;
@@ -276,7 +277,7 @@ describe("scenarios > dashboard > subscriptions", () => {
 
   describe("OSS email subscriptions", () => {
     beforeEach(() => {
-      cy.skipOn(!!Cypress.env("HAS_ENTERPRISE_TOKEN"));
+      cy.onlyOn(isOSS);
       cy.visit(`/dashboard/1`);
       setupSMTP();
     });


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Makes variables that determine whether the current version in e2e tests is OSS or EE human readable and more intuitive

```js
// before
if (Cypress.env("HAS_ENTERPRISE_TOKEN")) {
  // do something
}

// now
if (isEE) {
  // do something
}
```