### PR TITLE
Make conditional `describe` blocks more readable

### DIFF
--- a/frontend/test/__support__/e2e/helpers/e2e-enterprise-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-enterprise-helpers.js
@@ -1,6 +1,6 @@
 export const isEE = Cypress.env("HAS_ENTERPRISE_TOKEN");
 export const isOSS = !isEE;
 
-export const describeWithToken = isEE ? describe : describe.skip;
+export const describeEE = isEE ? describe : describe.skip;
 
-export const describeWithoutToken = isOSS ? describe : describe.skip;
+export const describeOSS = isOSS ? describe : describe.skip;

--- a/frontend/test/metabase/scenarios/admin/audit/ad-hoc.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/audit/ad-hoc.cy.spec.js
@@ -1,10 +1,6 @@
-import {
-  restore,
-  describeWithToken,
-  openNativeEditor,
-} from "__support__/e2e/cypress";
+import { restore, describeEE, openNativeEditor } from "__support__/e2e/cypress";
 
-describeWithToken("audit > ad-hoc", () => {
+describeEE("audit > ad-hoc", () => {
   describe("native query", () => {
     beforeEach(() => {
       restore();

--- a/frontend/test/metabase/scenarios/admin/audit/auditing.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/audit/auditing.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, describeWithToken } from "__support__/e2e/cypress";
+import { restore, describeEE } from "__support__/e2e/cypress";
 import { USERS } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 const { normal } = USERS;
@@ -32,7 +32,7 @@ function generateDashboards(user) {
   cy.createDashboard({ name: `${user} dashboard` });
 }
 
-describeWithToken("audit > auditing", () => {
+describeEE("audit > auditing", () => {
   const ADMIN_QUESTION = "admin question";
   const ADMIN_DASHBOARD = "admin dashboard";
   const NORMAL_QUESTION = "normal question";

--- a/frontend/test/metabase/scenarios/admin/audit/questions-audit.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/audit/questions-audit.cy.spec.js
@@ -1,11 +1,7 @@
 import _ from "underscore";
-import {
-  restore,
-  describeWithToken,
-  visitQuestion,
-} from "__support__/e2e/cypress";
+import { restore, describeEE, visitQuestion } from "__support__/e2e/cypress";
 
-describeWithToken("audit > auditing > questions", () => {
+describeEE("audit > auditing > questions", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();

--- a/frontend/test/metabase/scenarios/admin/audit/subscriptions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/audit/subscriptions.cy.spec.js
@@ -4,7 +4,7 @@ import {
   modal,
   popover,
 } from "__support__/e2e/helpers/e2e-ui-elements-helpers";
-import { describeWithToken } from "__support__/e2e/cypress";
+import { describeEE } from "__support__/e2e/cypress";
 
 const { ORDERS_ID } = SAMPLE_DATABASE;
 
@@ -59,7 +59,7 @@ const getSubscriptionsDetails = ({ card_id, dashboard_id, user_id }) => ({
   ],
 });
 
-describeWithToken("audit > auditing > subscriptions", () => {
+describeEE("audit > auditing > subscriptions", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();

--- a/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
@@ -1,7 +1,7 @@
 import {
   restore,
   popover,
-  describeWithToken,
+  describeEE,
   mockSessionProperty,
   isEE,
 } from "__support__/e2e/cypress";
@@ -305,7 +305,7 @@ describe("scenarios > admin > databases > add", () => {
     });
   });
 
-  describeWithToken("caching", () => {
+  describeEE("caching", () => {
     beforeEach(() => {
       mockSessionProperty("enable-query-caching", true);
     });

--- a/frontend/test/metabase/scenarios/admin/databases/edit.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/edit.cy.spec.js
@@ -2,7 +2,7 @@ import {
   restore,
   popover,
   modal,
-  describeWithToken,
+  describeEE,
   mockSessionProperty,
 } from "__support__/e2e/cypress";
 
@@ -80,7 +80,7 @@ describe("scenarios > admin > databases > edit", () => {
       );
     });
 
-    describeWithToken("caching", () => {
+    describeEE("caching", () => {
       beforeEach(() => {
         mockSessionProperty("enable-query-caching", true);
       });

--- a/frontend/test/metabase/scenarios/admin/people/people.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/people/people.cy.spec.js
@@ -4,7 +4,7 @@ import {
   modal,
   popover,
   setupSMTP,
-  describeWithToken,
+  describeEE,
 } from "__support__/e2e/cypress";
 import { USERS, USER_GROUPS } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
@@ -295,7 +295,7 @@ describe("scenarios > admin > people", () => {
   });
 });
 
-describeWithToken("scenarios > admin > people", () => {
+describeEE("scenarios > admin > people", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();

--- a/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
@@ -2,9 +2,9 @@ import {
   restore,
   openOrdersTable,
   popover,
-  describeWithToken,
+  describeEE,
   setupMetabaseCloud,
-  describeWithoutToken,
+  describeOSS,
   isOSS,
   isEE,
 } from "__support__/e2e/cypress";
@@ -289,7 +289,7 @@ describe("scenarios > admin > settings", () => {
   });
 });
 
-describeWithoutToken("scenarios > admin > settings (OSS)", () => {
+describeOSS("scenarios > admin > settings (OSS)", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
@@ -303,7 +303,7 @@ describeWithoutToken("scenarios > admin > settings (OSS)", () => {
   });
 });
 
-describeWithToken("scenarios > admin > settings (EE)", () => {
+describeEE("scenarios > admin > settings (EE)", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();

--- a/frontend/test/metabase/scenarios/admin/settings/sso/jwt.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/sso/jwt.cy.spec.js
@@ -1,6 +1,6 @@
-import { restore, describeWithToken } from "__support__/e2e/cypress";
+import { restore, describeEE } from "__support__/e2e/cypress";
 
-describeWithToken("scenarios > admin > settings > SSO > JWT", () => {
+describeEE("scenarios > admin > settings > SSO > JWT", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();

--- a/frontend/test/metabase/scenarios/admin/settings/whitelabel-color-theme.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/whitelabel-color-theme.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, describeWithToken } from "__support__/e2e/cypress";
+import { restore, describeEE } from "__support__/e2e/cypress";
 
 // Define colors that we use for whitelabeling
 // If rbg values exist, it's because we explicit test those
@@ -22,7 +22,7 @@ function changeThemeColor(location, colorhex) {
   cy.findByText("Done").click();
 }
 
-describeWithToken("formatting > whitelabel > color theme", () => {
+describeEE("formatting > whitelabel > color theme", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();

--- a/frontend/test/metabase/scenarios/admin/settings/whitelabel.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/whitelabel.cy.spec.js
@@ -1,7 +1,7 @@
 import {
   restore,
   openOrdersTable,
-  describeWithToken,
+  describeEE,
   summarize,
 } from "__support__/e2e/cypress";
 
@@ -41,7 +41,7 @@ function checkLogo() {
   );
 }
 
-describeWithToken("formatting > whitelabel", () => {
+describeEE("formatting > whitelabel", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();

--- a/frontend/test/metabase/scenarios/admin/tools/erroring-questions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/tools/erroring-questions.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, describeWithToken } from "__support__/e2e/cypress";
+import { restore, describeEE } from "__support__/e2e/cypress";
 
 const TOOLS_ERRORS_URL = "/admin/tools/errors";
 
@@ -20,7 +20,7 @@ const brokenQuestionDetails = {
   display: "scalar",
 };
 
-describeWithToken("admin > tools > erroring questions ", () => {
+describeEE("admin > tools > erroring questions ", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();

--- a/frontend/test/metabase/scenarios/admin/troubleshooting/help.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/troubleshooting/help.cy.spec.js
@@ -1,6 +1,6 @@
 import {
-  describeWithoutToken,
-  describeWithToken,
+  describeOSS,
+  describeEE,
   restore,
   setupMetabaseCloud,
 } from "__support__/e2e/cypress";
@@ -21,7 +21,7 @@ describe("scenarios > admin > troubleshooting > help", () => {
   });
 });
 
-describeWithoutToken("scenarios > admin > troubleshooting > help", () => {
+describeOSS("scenarios > admin > troubleshooting > help", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
@@ -35,7 +35,7 @@ describeWithoutToken("scenarios > admin > troubleshooting > help", () => {
   });
 });
 
-describeWithToken("scenarios > admin > troubleshooting > help (EE)", () => {
+describeEE("scenarios > admin > troubleshooting > help (EE)", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();

--- a/frontend/test/metabase/scenarios/collections/collection-types.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collection-types.cy.spec.js
@@ -2,8 +2,8 @@ import {
   restore,
   modal,
   sidebar,
-  describeWithToken,
-  describeWithoutToken,
+  describeEE,
+  describeOSS,
   openNewCollectionItemFlowFor,
 } from "__support__/e2e/cypress";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
@@ -18,7 +18,7 @@ const TEST_QUESTION_QUERY = {
   breakout: [["field", ORDERS.CREATED_AT, { "temporal-unit": "hour-of-day" }]],
 };
 
-describeWithToken("collections types", () => {
+describeEE("collections types", () => {
   beforeEach(() => {
     restore();
   });
@@ -147,7 +147,7 @@ describeWithToken("collections types", () => {
   });
 });
 
-describeWithoutToken("collection types", () => {
+describeOSS("collection types", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();

--- a/frontend/test/metabase/scenarios/dashboard/caching.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/caching.cy.spec.js
@@ -1,11 +1,11 @@
 import {
   restore,
-  describeWithToken,
+  describeEE,
   mockSessionProperty,
   modal,
 } from "__support__/e2e/cypress";
 
-describeWithToken("scenarios > dashboard > caching", () => {
+describeEE("scenarios > dashboard > caching", () => {
   beforeEach(() => {
     restore();
     mockSessionProperty("enable-query-caching", true);

--- a/frontend/test/metabase/scenarios/embedding/embedding-premium-token.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/embedding-premium-token.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, describeWithoutToken } from "__support__/e2e/cypress";
+import { restore, describeOSS } from "__support__/e2e/cypress";
 
 const embeddingPage = "/admin/settings/embedding_in_other_applications";
 const licensePage = "/admin/settings/premium-embedding-license";
@@ -13,7 +13,7 @@ const invalidTokenMessage =
 const discountedWarning =
   "Our Premium Embedding product has been discontinued, but if you already have a license you can activate it here. You’ll continue to receive support for the duration of your license.";
 
-describeWithoutToken("scenarios > embedding > premium embedding token", () => {
+describeOSS("scenarios > embedding > premium embedding token", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();

--- a/frontend/test/metabase/scenarios/moderation/question-moderation.cy.spec.js
+++ b/frontend/test/metabase/scenarios/moderation/question-moderation.cy.spec.js
@@ -1,6 +1,6 @@
-import { describeWithToken, restore } from "__support__/e2e/cypress";
+import { describeEE, restore } from "__support__/e2e/cypress";
 
-describeWithToken("scenarios > saved question moderation", () => {
+describeEE("scenarios > saved question moderation", () => {
   describe("as an admin", () => {
     beforeEach(() => {
       restore();

--- a/frontend/test/metabase/scenarios/native/snippets/snippet-permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/snippets/snippet-permissions.cy.spec.js
@@ -2,11 +2,11 @@ import {
   restore,
   modal,
   popover,
-  describeWithToken,
+  describeEE,
   openNativeEditor,
 } from "__support__/e2e/cypress";
 
-describeWithToken("scenarios > question > snippets", () => {
+describeEE("scenarios > question > snippets", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();

--- a/frontend/test/metabase/scenarios/onboarding/auth/sso.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/auth/sso.cy.spec.js
@@ -1,5 +1,5 @@
 import {
-  describeWithToken,
+  describeEE,
   restore,
   mockCurrentUserProperty,
 } from "__support__/e2e/cypress";
@@ -63,7 +63,7 @@ describe("scenarios > auth > signin > SSO", () => {
     });
   });
 
-  describeWithToken("EE", () => {
+  describeEE("EE", () => {
     beforeEach(() => {
       // Disable password log-in
       cy.request("PUT", "api/setting/enable-password-login", {

--- a/frontend/test/metabase/scenarios/permissions/admin-permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/admin-permissions.cy.spec.js
@@ -1,9 +1,4 @@
-import {
-  restore,
-  popover,
-  modal,
-  describeWithToken,
-} from "__support__/e2e/cypress";
+import { restore, popover, modal, describeEE } from "__support__/e2e/cypress";
 
 const COLLECTION_ACCESS_PERMISSION_INDEX = 0;
 
@@ -527,7 +522,7 @@ describe("scenarios > admin > permissions", () => {
   });
 });
 
-describeWithToken("scenarios > admin > permissions", () => {
+describeEE("scenarios > admin > permissions", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();

--- a/frontend/test/metabase/scenarios/permissions/reproductions/14873-regextract-in-sandboxed-table.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/reproductions/14873-regextract-in-sandboxed-table.cy.spec.js
@@ -1,7 +1,7 @@
 import {
   restore,
   withDatabase,
-  describeWithToken,
+  describeEE,
   visitQuestion,
 } from "__support__/e2e/cypress";
 import { USER_GROUPS } from "__support__/e2e/cypress_data";
@@ -10,7 +10,7 @@ const PG_DB_ID = 2;
 
 const { ALL_USERS_GROUP, DATA_GROUP, COLLECTION_GROUP } = USER_GROUPS;
 
-describeWithToken("postgres > user > query", () => {
+describeEE("postgres > user > query", () => {
   beforeEach(() => {
     restore("postgres-12");
     cy.signInAsAdmin();

--- a/frontend/test/metabase/scenarios/permissions/reproductions/17763-cannot-edit-granular-after-block.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/reproductions/17763-cannot-edit-granular-after-block.cy.spec.js
@@ -1,9 +1,9 @@
-import { restore, popover, describeWithToken } from "__support__/e2e/cypress";
+import { restore, popover, describeEE } from "__support__/e2e/cypress";
 import { USER_GROUPS } from "__support__/e2e/cypress_data";
 
 const { ALL_USERS_GROUP } = USER_GROUPS;
 
-describeWithToken("issue 17763", () => {
+describeEE("issue 17763", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();

--- a/frontend/test/metabase/scenarios/permissions/sandboxes.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/sandboxes.cy.spec.js
@@ -1,5 +1,5 @@
 import {
-  describeWithToken,
+  describeEE,
   modal,
   openOrdersTable,
   openPeopleTable,
@@ -30,7 +30,7 @@ const {
 
 const { DATA_GROUP } = USER_GROUPS;
 
-describeWithToken("formatting > sandboxes", () => {
+describeEE("formatting > sandboxes", () => {
   describe("admin", () => {
     beforeEach(() => {
       restore();

--- a/frontend/test/metabase/scenarios/question/caching.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/caching.cy.spec.js
@@ -1,11 +1,11 @@
 import {
   restore,
-  describeWithToken,
+  describeEE,
   mockSessionProperty,
   modal,
 } from "__support__/e2e/cypress";
 
-describeWithToken("scenarios > question > caching", () => {
+describeEE("scenarios > question > caching", () => {
   beforeEach(() => {
     restore();
     mockSessionProperty("enable-query-caching", true);

--- a/frontend/test/metabase/scenarios/sharing/approved-domains.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/approved-domains.cy.spec.js
@@ -1,5 +1,5 @@
 import {
-  describeWithToken,
+  describeEE,
   modal,
   restore,
   setupSMTP,
@@ -13,7 +13,7 @@ const deniedEmail = `mailer@${deniedDomain}`;
 const subscriptionError = `You're only allowed to email subscriptions to addresses ending in ${allowedDomain}`;
 const alertError = `You're only allowed to email alerts to addresses ending in ${allowedDomain}`;
 
-describeWithToken("scenarios > sharing > approved domains (EE)", () => {
+describeEE("scenarios > sharing > approved domains (EE)", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();

--- a/frontend/test/metabase/scenarios/sharing/reproductions/18669-test-email-with-parameters.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/reproductions/18669-test-email-with-parameters.cy.spec.js
@@ -1,5 +1,5 @@
 import {
-  describeWithToken,
+  describeEE,
   popover,
   restore,
   setupSMTP,
@@ -12,7 +12,7 @@ import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 const { admin } = USERS;
 const { PRODUCTS_ID, PRODUCTS } = SAMPLE_DATABASE;
 
-describeWithToken("issue 18669", () => {
+describeEE("issue 18669", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();

--- a/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
@@ -1,7 +1,7 @@
 import {
   restore,
   setupSMTP,
-  describeWithToken,
+  describeEE,
   popover,
   sidebar,
   mockSlackConfigured,
@@ -297,7 +297,7 @@ describe("scenarios > dashboard > subscriptions", () => {
     });
   });
 
-  describeWithToken("EE email subscriptions", () => {
+  describeEE("EE email subscriptions", () => {
     beforeEach(() => {
       cy.visit(`/dashboard/1`);
       setupSMTP();


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- As a logical successor to the https://github.com/metabase/metabase/pull/20775, it makes conditional `describe` blocks more intuitive

```js
// before
describeWithToken("foo", ()=> {
  // tests
});

describeWithoutToken("bar", ()=> {
  // tests
});

// now
describeEE("foo", ()=> {
  // tests
});

describeOSS("bar", ()=> {
  // tests
});
```

Many people didn't even realize what does `describeWithToken` mean. My hope is that this will make it more obvious.