### PR TITLE
Add basic documentation on entity creation

### DIFF
--- a/frontend/src/metabase/lib/entities.js
+++ b/frontend/src/metabase/lib/entities.js
@@ -1,3 +1,67 @@
+/*
+ * # Entities abstract the interface between the back-end and the front-end.
+ *
+ * ## Required Properties:
+ *
+ * name:
+ *   a string in plural form
+ *   examples:
+ *     "questions", "dashboards"
+ *
+ * path:
+ *   a uri
+ *     starting with "/api/"
+ *     conventionally followed by the entity name in singular form
+ *   examples:
+ *     "/api/card", "/api/dashboard"
+ *
+ * ## Optional properties:
+ *
+ * api:
+ *
+ * here you can override the basic entity methods like `list`, `create`, `get`, `update`, `delete` (OR see `path` below)
+ *
+ * schema:
+ *   normalizr schema
+ *   default:
+ *     `new schema.Entity(entity.name)`
+ *
+ * ## How to create a bare-bones entity
+ *
+ * Say we want to create a "books" entity, to be able to fetch a list of "books".
+ *
+ * Add the following line to `frontend/src/metabase/entities.index.js`:
+ *
+ *   export { default as books } from "./books"
+ *
+ * Create file `frontend/src/metabase/entities/books.js`
+ *
+ * Add the following to it:
+ *
+ *   import { createEntity } from "metabase/lib/entities";
+
+ *   const Books = createEntity({
+ *     name: "books",
+ *     nameOne: "book",
+ *     path: "/api/book",
+ *   });
+ *
+ *   export default Books;
+ *
+ * ## How to consume an entity:
+ *
+ * Near the top of a container file, import the entity:
+ *
+ *   import Book from "metabase/entities/books";
+ *
+ * Near the bottom of the container file, add the entity to a `compose` statement:
+ *
+ *   export default _.compose(
+ *     Book.loadList(),
+ *     connect(mapStateToProps),
+ *   )(BookContainer);
+ */
+
 import {
   combineReducers,
   handleEntities,
@@ -21,14 +85,6 @@ import { createSelector } from "reselect";
 import { normalize, denormalize, schema } from "normalizr";
 import { getIn, merge } from "icepick";
 import _ from "underscore";
-
-// entity defintions export the following properties (`name`, and `api` or `path` are required)
-//
-// name: plural, like "questions" or "dashboards"
-// api: object containing `list`, `create`, `get`, `update`, `delete` methods (OR see `path` below)
-// path: API endpoint to create default `api` object
-// schema: normalizr schema, defaults to `new schema.Entity(entity.name)`
-//
 
 export function createEntity(def) {
   const entity = { ...def };


### PR DESCRIPTION
When we write our first entity, we have to trial-and-error based on our existing entities.

However, entity implementations are quite different among them.

Also, there is a necessary import/export in `entities/index.js` that is very hard to know we need, and debug if missing.

This tries to smooth the initial contact with writing entities.

