### PR TITLE
Upgrade to Prism v1.27.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -250,7 +250,8 @@
     "set-value": "4.0.1",
     "immer": "9.0.6",
     "ansi-html": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
-    "cypress": "6.4.0"
+    "cypress": "6.4.0",
+    "prismjs": "1.27.0"
   },
   "scripts": {
     "concurrently": "yarn && concurrently --kill-others -p name",


### PR DESCRIPTION
This is only used for Storybook during development. Hopefully once Storybook is updated, this is a non-issue but meanwhile we can fix up the version resolution for Prism.

```
$ yarn why v1.22.17
[1/4] Why do we have the module "prismjs"...?
[2/4] Initialising dependency graph...
[3/4] Finding dependency...
[4/4] Calculating file sizes...
=> Found "prismjs@1.27.0"
info Reasons this module exists
   - "@storybook#addon-actions#@storybook#components#react-syntax-highlighter" depends on it
   - Hoisted from "@storybook#addon-actions#@storybook#components#react-syntax-highlighter#prismjs"
   - Hoisted from "@storybook#addon-actions#@storybook#components#react-syntax-highlighter#refractor#prismjs"
info Disk size without dependencies: "3.63MB"
info Disk size with unique dependencies: "3.63MB"
info Disk size with transitive dependencies: "3.63MB"
info Number of shared dependencies: 0
Done in 1.15s.
```

For more detailed info, check [CVE-2022-23647](https://github.com/PrismJS/prism/security/advisories/GHSA-3949-f494-cm99).

See also the code diff [1.25.0 -> 1.27.0](https://app.renovatebot.com/package-diff?name=prismjs&from=1.25.0&to=1.27.0).