### PR TITLE
Fix schemas not loading/showing immediately for a saved question

### DIFF
--- a/frontend/src/metabase-lib/lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/lib/queries/StructuredQuery.ts
@@ -1602,9 +1602,15 @@ export default class StructuredQuery extends AtomicQuery {
       }
     }
 
-    // source-table, if set
-    const tableId = this.sourceTableId();
+    const dbId = this.databaseId();
+    if (dbId) {
+      addDependency({
+        type: "schema",
+        id: dbId,
+      });
+    }
 
+    const tableId = this.sourceTableId();
     if (tableId) {
       addDependency({
         type: "table",

--- a/frontend/src/metabase/redux/metadata.js
+++ b/frontend/src/metabase/redux/metadata.js
@@ -8,6 +8,7 @@ import { getMetadata } from "metabase/selectors/metadata";
 import { MetabaseApi, RevisionsApi } from "metabase/services";
 
 import Databases from "metabase/entities/databases";
+import Schemas from "metabase/entities/schemas";
 import Tables from "metabase/entities/tables";
 import Fields from "metabase/entities/fields";
 import Segments from "metabase/entities/segments";
@@ -320,6 +321,8 @@ export const loadMetadataForQueries = queries => dispatch =>
             : Tables.actions.fetchMetadata)({ id });
         } else if (type === "field") {
           return Fields.actions.fetch({ id });
+        } else if (type === "schema") {
+          return Schemas.actions.fetchList({ dbId: id });
         } else {
           console.warn(`loadMetadataForQueries: type ${type} not implemented`);
         }

--- a/frontend/test/metabase-lib/lib/queries/StructuredQuery.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/StructuredQuery.unit.spec.js
@@ -83,17 +83,21 @@ describe("StructuredQuery", () => {
       });
     });
     describe("dependentMetadata", () => {
-      it("should include source table with foreignTables = true", () => {
+      it("should include db schemas and source table with foreignTables = true", () => {
         expect(query.dependentMetadata()).toEqual([
+          { type: "schema", id: SAMPLE_DATABASE.id },
           { type: "table", id: ORDERS.id, foreignTables: true },
         ]);
       });
-      it("should include source table for nested queries with foreignTables = true", () => {
+
+      it("should include db schemas and source table for nested queries with foreignTables = true", () => {
         expect(query.nest().dependentMetadata()).toEqual([
+          { type: "schema", id: SAMPLE_DATABASE.id },
           { type: "table", id: ORDERS.id, foreignTables: true },
         ]);
       });
-      it("should include joined tables with foreignTables = false", () => {
+
+      it("should include db schemas and joined tables with foreignTables = false", () => {
         expect(
           query
             .join({
@@ -102,9 +106,22 @@ describe("StructuredQuery", () => {
             })
             .dependentMetadata(),
         ).toEqual([
+          { type: "schema", id: SAMPLE_DATABASE.id },
           { type: "table", id: ORDERS.id, foreignTables: true },
           { type: "table", id: PRODUCTS.id, foreignTables: false },
         ]);
+      });
+
+      describe("when the query is missing a database", () => {
+        it("should not include db schemas in dependent  metadata", () => {
+          const dependentMetadata = query
+            .setDatabaseId(null)
+            .dependentMetadata();
+
+          expect(dependentMetadata.some(({ type }) => type === "schema")).toBe(
+            false,
+          );
+        });
       });
     });
   });


### PR DESCRIPTION
Related to #20459 (sort of)

In order to show the schema correctly in the header of a saved question we need to fetch the list of schemas for the DB associated with the query as part of the query builder instantiation.

We can't rely on the `schema` property of a table here due to the `hasSchema` method on the metabase-lib Table instance: https://github.com/metabase/metabase/blob/414ef15da438d17e8c6e9b2156bdeddf602981e7/frontend/src/metabase-lib/lib/metadata/Table.ts#L25. Part of the predicate is a check that the table's database has more than one schema so that we are not showing schemas when a db just has a "public" schema.

**Testing**
1. Create a question on a db with schemas (I'm using postgresql) and save it.
2. Refresh the page. The schema name in the question header should be visible.

**Before**

https://user-images.githubusercontent.com/13057258/156240972-6770dda3-09ee-4ef4-842c-3906afc39f7c.mov

**After**

https://user-images.githubusercontent.com/13057258/156240986-f46c5c38-b1da-45ca-8637-6bd89e106b16.mov


