### PR TITLE
Increase "randomness" for caching tests

### DIFF
--- a/frontend/test/metabase/scenarios/admin/settings/cache.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/cache.cy.spec.js
@@ -4,7 +4,7 @@ import {
   runNativeQuery,
 } from "__support__/e2e/cypress";
 
-const nativeQuery = "select random(), pg_sleep(2)";
+const nativeQuery = "select (random() * random() * random()), pg_sleep(2)";
 
 describe("scenarios > admin > settings > cache", () => {
   beforeEach(() => {


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- As part of trying to understand and mitigate the recent e2e test failures in the CI, @flamber suggested to increase the randomness in the SQL query used for caching
- This PR does that