### PR TITLE
Repro #20815: Models should not be embeddable

### DIFF
--- a/frontend/test/metabase/scenarios/embedding/embedding-smoketests.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/embedding-smoketests.cy.spec.js
@@ -164,6 +164,17 @@ describe("scenarios > embedding > smoke tests", () => {
       });
     });
   });
+
+  it.skip("should not offer to share or embed models (metabase#20815)", () => {
+    cy.intercept("POST", "/api/dataset").as("dataset");
+
+    cy.request("PUT", "/api/card/1", { dataset: true });
+
+    cy.visit("/model/1");
+    cy.wait("@dataset");
+
+    cy.icon("share").should("not.exist");
+  });
 });
 
 function resetEmbedding() {


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #20815

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/embedding/embedding-smoketests.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix