### PR TITLE
Fix empty state icon in activity page misalignment

### DIFF
--- a/frontend/src/metabase/css/home.css
+++ b/frontend/src/metabase/css/home.css
@@ -11,6 +11,7 @@
   border-radius: 99px;
   border: 3px solid currentcolor;
   text-align: center;
+  line-height: normal;
 }
 
 .break-word {

--- a/frontend/src/metabase/home/components/Activity.jsx
+++ b/frontend/src/metabase/home/components/Activity.jsx
@@ -528,7 +528,7 @@ export default class Activity extends Component {
           <div className="full flex flex-column">
             <div className="">
               {activity.length === 0 ? (
-                <div className="flex flex-column layout-centered mt4">
+                <div className="flex flex-column layout-centered my4">
                   <span className="QuestionCircle">!</span>
                   <div className="text-normal mt3 mb1">
                     {t`Hmmm, looks like nothing has happened yet.`}


### PR DESCRIPTION
Fixes #18960

## What
Fix the empty icon state icon misalignment on activity page.

### Before the fix
![image](https://user-images.githubusercontent.com/1937582/156559989-292d9096-b62e-4c00-ad66-cae271fa1bdf.png)

### After the fix
![image](https://user-images.githubusercontent.com/1937582/156560103-7c2cb4f0-e0e8-447e-931d-c3b50bfb0e97.png)


## Why
- It's because <Card /> has a line-height set to `24px` which throw things off.
- I set the `line-height` inline because there's seem to only be 2 places that use `.QuestionCircle` class so far. And while there's a class named `text-unspaced` that set `line-height: normal;` I don't think that represents what we want to do here, that's why I inlined it.
- And after observing the card, there's no `margin-bottom` set, so I added it to make the text look center-aligned.

## Reproduction steps
I couldn't find a way to enforce an empty state in activity page so I change https://github.com/metabase/metabase/blob/c52c6b9ef33928768fc95f62b097de0fd77cd88d/frontend/src/metabase/home/containers/ActivityApp.jsx#L61

to

```ts
<Activity {...this.props} activity={[]} />
```


