### PR TITLE
Bump buildjet timeout for Cypress tests to 30 minutes

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -50,7 +50,7 @@ jobs:
 
   e2e-tests:
     runs-on: buildjet-2vcpu-ubuntu-2004
-    timeout-minutes: 20
+    timeout-minutes: 30
     needs: build
     name: e2e-tests-${{ matrix.folder }}-${{ matrix.edition }}
     env:


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Bumps `buildjet` timeout for Cypress tests in `master` to 30 minutes
    - Unfortunately, some of our e2e testing groups now take longer than 20 minutes to finish

Example of the latest failed run in `master`:
https://github.com/metabase/metabase/actions/runs/1928417076