### PR TITLE
Enable subdimensions for aggregation

### DIFF
--- a/frontend/src/metabase/query_builder/components/AggregationPopover.jsx
+++ b/frontend/src/metabase/query_builder/components/AggregationPopover.jsx
@@ -351,7 +351,8 @@ export default class AggregationPopover extends Component {
             field={fieldId}
             fieldOptions={query.aggregationFieldOptions(agg)}
             onFieldChange={this.onPickField}
-            enableSubDimensions={false}
+            enableSubDimensions={true}
+            preventNumberSubDimensions={true}
           />
         </div>
       );

--- a/frontend/src/metabase/query_builder/components/FieldList.jsx
+++ b/frontend/src/metabase/query_builder/components/FieldList.jsx
@@ -64,9 +64,7 @@ export default class FieldList extends Component {
         // forward DimensionList props
         useOriginalDimension={this.props.useOriginalDimension}
         enableSubDimensions={this.props.enableSubDimensions}
-        preventNumberSubDimensions={
-          this.props.fieldOptions.preventNumberSubDimensions
-        }
+        preventNumberSubDimensions={this.props.preventNumberSubDimensions}
       />
     );
   }

--- a/frontend/test/metabase/scenarios/question/new.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/new.cy.spec.js
@@ -414,7 +414,7 @@ describe("scenarios > question > new", () => {
       });
     });
 
-    it.skip("summarizing by distinct datetime should allow granular selection (metabase#13098)", () => {
+    it("summarizing by distinct datetime should allow granular selection (metabase#13098)", () => {
       // Go straight to orders table in custom questions
       cy.visit("/question/new?database=1&table=2&mode=notebook");
 
@@ -432,7 +432,7 @@ describe("scenarios > question > new", () => {
           .click({ force: true });
       });
       // this should be among the granular selection choices
-      cy.findByText("Hour of day").click();
+      cy.findByText("Hour of Day").click();
     });
 
     it("'read-only' user should be able to resize column width (metabase#9772)", () => {


### PR DESCRIPTION
1. New, Question, Sample Database, Products table
2. Summarize, Pick the metric you want to see
3. Number of distinct values, `Created At`

**Before this PR**

Note that the temporal unit for `Created At` is set to `Month` (despite there was no explicit step to do that) and also there is no way to change it.

![Screenshot_20220303_152053](https://user-images.githubusercontent.com/7288/156672120-15c91880-3257-44f0-8266-dc744b59e1ae.png)


**After this PR**

It is possible to choose the temporal unit for `Created At`, and after that, it is also possible to change it to something else.

![image](https://user-images.githubusercontent.com/7288/156672074-acfadd83-95a1-4c43-aa2b-1e9a0aa96069.png)

And thus, it is possible to craft a question like this:

![image](https://user-images.githubusercontent.com/7288/156672621-754658ae-ef44-4b92-9b0e-de85c90411f6.png)
