### PR TITLE
Add a few features to TippyPopover to reach parity (I think) with Popover

### DIFF
--- a/frontend/src/metabase/components/Popover/Popover.css
+++ b/frontend/src/metabase/components/Popover/Popover.css
@@ -52,6 +52,12 @@
   padding: 0;
 }
 
+.tippy-box,
+.tippy-content {
+  max-height: inherit;
+  transition: transform 0s, visibility 0.3s, opacity 0.3s;
+}
+
 /* remove the max-width in cases where the popover content needs to expand
  * initially added  for date pickers so the dual date picker can fully
  * expand as necessary - metabase#5971

--- a/frontend/src/metabase/components/Popover/TippyPopover.info.js
+++ b/frontend/src/metabase/components/Popover/TippyPopover.info.js
@@ -19,6 +19,10 @@ const PopoverBody = styled(Base)`
   width: 200px;
 `;
 
+const LongPopoverBody = styled(PopoverBody)`
+  height: 600px;
+`;
+
 const LazyPopoverBody = styled(Base)`
   border: none;
   height: 200px;
@@ -33,6 +37,7 @@ const PopoverTarget = styled(Base)`
 `;
 
 const content = <PopoverBody>popover body</PopoverBody>;
+const longContent = <LongPopoverBody>popover body</LongPopoverBody>;
 const target = <PopoverTarget>popover target</PopoverTarget>;
 
 function LazyContentExample() {
@@ -105,6 +110,17 @@ export const examples = {
       flip={false}
       placement="bottom-start"
       content={content}
+    >
+      {target}
+    </TippyPopover>
+  ),
+  "sizeToFit enabled": (
+    <TippyPopover
+      visible
+      interactive
+      placement="bottom-start"
+      sizeToFit
+      content={longContent}
     >
       {target}
     </TippyPopover>

--- a/frontend/src/metabase/components/Popover/TippyPopover.info.js
+++ b/frontend/src/metabase/components/Popover/TippyPopover.info.js
@@ -99,4 +99,14 @@ export const examples = {
     </TippyPopover>
   ),
   "control mode + handling of Esc press": <VisiblePropExample />,
+  "flip disabled": (
+    <TippyPopover
+      visible
+      flip={false}
+      placement="bottom-start"
+      content={content}
+    >
+      {target}
+    </TippyPopover>
+  ),
 };

--- a/frontend/src/metabase/components/Popover/TippyPopover.info.js
+++ b/frontend/src/metabase/components/Popover/TippyPopover.info.js
@@ -98,8 +98,8 @@ export const examples = {
       </TippyPopover>
     </React.Fragment>
   ),
-  interactive: (
-    <TippyPopover interactive placement="left-end" content={content}>
+  "interactive disabled": (
+    <TippyPopover interactive={false} placement="left-end" content={content}>
       {target}
     </TippyPopover>
   ),
@@ -117,7 +117,6 @@ export const examples = {
   "sizeToFit enabled": (
     <TippyPopover
       visible
-      interactive
       placement="bottom-start"
       sizeToFit
       content={longContent}

--- a/frontend/src/metabase/components/Popover/TippyPopover.tsx
+++ b/frontend/src/metabase/components/Popover/TippyPopover.tsx
@@ -105,6 +105,7 @@ function TippyPopover({
   lazy = true,
   flip = true,
   sizeToFit = false,
+  interactive = true,
   maxHeight,
   popperOptions,
   onShow,
@@ -171,6 +172,7 @@ function TippyPopover({
       appendTo={appendTo}
       plugins={plugins}
       {...props}
+      interactive={interactive}
       popperOptions={computedPopperOptions}
       duration={animationDuration}
       delay={delay}

--- a/frontend/src/metabase/components/Popover/TippyPopover.tsx
+++ b/frontend/src/metabase/components/Popover/TippyPopover.tsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import * as TippyReact from "@tippyjs/react";
 import * as tippy from "tippy.js";
 import cx from "classnames";
+import { merge } from "icepick";
 
 import { isReducedMotionPreferred } from "metabase/lib/dom";
 import EventSandbox from "metabase/components/EventSandbox";
@@ -16,6 +17,7 @@ type TippyInstance = tippy.Instance;
 export interface ITippyPopoverProps extends TippyProps {
   disableContentSandbox?: boolean;
   lazy?: boolean;
+  flip?: boolean;
 }
 
 const OFFSET: [number, number] = [0, 5];
@@ -30,12 +32,33 @@ function appendTo() {
   return document.body;
 }
 
+function getPopperOptions(
+  flip: ITippyPopoverProps["flip"],
+  popperOptions: ITippyPopoverProps["popperOptions"],
+): ITippyPopoverProps["popperOptions"] {
+  return merge(
+    flip === false
+      ? {
+          modifiers: [
+            {
+              name: "flip",
+              enabled: false,
+            },
+          ],
+        }
+      : {},
+    popperOptions,
+  );
+}
+
 function TippyPopover({
   className,
   disableContentSandbox,
   content,
   delay,
   lazy = true,
+  flip = true,
+  popperOptions,
   onShow,
   onHide,
   ...props
@@ -85,6 +108,11 @@ function TippyPopover({
 
   const plugins = useMemo(() => [lazyPlugin], [lazyPlugin]);
 
+  const computedPopperOptions = useMemo(
+    () => getPopperOptions(flip, popperOptions),
+    [flip, popperOptions],
+  );
+
   return (
     <TippyComponent
       className={cx("popover", className)}
@@ -94,6 +122,7 @@ function TippyPopover({
       appendTo={appendTo}
       plugins={plugins}
       {...props}
+      popperOptions={computedPopperOptions}
       duration={animationDuration}
       delay={delay}
       content={

--- a/frontend/src/metabase/components/Popover/TippyPopover.tsx
+++ b/frontend/src/metabase/components/Popover/TippyPopover.tsx
@@ -21,6 +21,7 @@ export interface ITippyPopoverProps extends TippyProps {
 }
 
 const OFFSET: [number, number] = [0, 5];
+const DEFAULT_Z_INDEX = 4;
 
 const propTypes = {
   disablContentSandbox: PropTypes.bool,
@@ -117,6 +118,7 @@ function TippyPopover({
     <TippyComponent
       className={cx("popover", className)}
       theme="popover"
+      zIndex={DEFAULT_Z_INDEX}
       arrow={false}
       offset={OFFSET}
       appendTo={appendTo}


### PR DESCRIPTION
https://github.com/metabase/metabase/pull/20838/commits/6ed7b533c26b71b719d9ff03917cb7d50bf7bb8f

Our legacy `Popover` component is less aggressive about flipping when the edge of the content hits a viewport edge, so I've added a `flip` boolean that can be set to `false` to disable popper's flip modifier. I don't think there are too many places where this is a huge deal but I figured it'd be nice to be able to set this instead of messing with `popperOptions`.

https://github.com/metabase/metabase/pull/20838/commits/4264f4eae7dda6fcf455e2f5e05da352b536e7e5

Tippy's default `z-index` is 9999, so `TippyPopover` would appear over the dark background of an open modal. This commit fixes that by setting the `z-index` to 4 like `Popover`.

https://github.com/metabase/metabase/pull/20838/commits/31e0e06097db1ad72b7d42b1c4d5a50c6b3c5a45

I didn't really want to add this to `TippyPopover` because it increases the complexity of how the popover interacts with the page and in some cases can make the popover kind of ugly and long, but we use it in so many places (around 20 places) that I think it makes sense to add it so that we can more quickly replace old instances of `Popover`. Then, we can go in and fix the places where this makes the popover odd looking. Fortunately, the implementation a _little_ better than what you might find in `metabase/components/Popover.jsx` 🙂 

https://github.com/metabase/metabase/pull/20838/commits/9730813a56f651b63300acb9b3b0103b10c66d27

I think nearly 100% of components using `TippyPopover` expect it to be `interactive` by default, so I'm making it `interactive` by default.
