### PR TITLE
Fix main page show indefinite loading spinner when any API failed

### DIFF
--- a/frontend/src/metabase/components/EmptyState.jsx
+++ b/frontend/src/metabase/components/EmptyState.jsx
@@ -29,7 +29,18 @@ const LegacyImage = props =>
       className={props.imageClassName}
     />
   ) : null;
-
+/**
+ * @typedef {Record<string, any>} EmptyStateProps
+ * @property {import("react").ReactNode} message
+ * @property {import("react").ReactNode} [title]
+ * @property {import("react").ReactNode} [action]
+ * @property {import("react-router").IndexLinkProps["to"]} [link]
+ * @property {import("react").ReactNode} [illustrationElement]
+ * @property {function} [onActionClick]
+ *
+ * @param {EmptyStateProps} props
+ * @returns {import("react").ReactElement}
+ */
 const EmptyState = ({
   title,
   message,

--- a/frontend/src/metabase/home/homepage/components/Homepage/Homepage.tsx
+++ b/frontend/src/metabase/home/homepage/components/Homepage/Homepage.tsx
@@ -1,5 +1,8 @@
 import React, { Fragment } from "react";
+import { t } from "ttag";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
+import EmptyState from "metabase/components/EmptyState";
+import ErrorDetails from "metabase/components/ErrorDetails";
 import CollectionSection from "../CollectionSection";
 import DatabaseSection from "../DatabaseSection";
 import GreetingSection from "../GreetingSection";
@@ -31,6 +34,7 @@ export interface HomepageProps {
   onCollectionClick?: () => void;
   onDashboardClick?: (dashboard: Dashboard) => void;
   onDatabaseClick?: (database: Database) => void;
+  allError?: boolean;
 }
 
 const Homepage = ({
@@ -49,6 +53,7 @@ const Homepage = ({
   onCollectionClick,
   onDashboardClick,
   onDatabaseClick,
+  allError,
 }: HomepageProps): JSX.Element => {
   return (
     <HomepageRoot>
@@ -87,6 +92,14 @@ const Homepage = ({
             onHideSyncingModal={onHideSyncingModal}
           />
         </Fragment>
+      ) : allError ? (
+        <EmptyState
+          title={t`Something's gone wrong`}
+          message={t`We've run into an error. You can try refreshing the page, or just go back.`}
+          illustrationElement={
+            <div className="QueryError-image QueryError-image--serverError" />
+          }
+        />
       ) : (
         <LoadingAndErrorWrapper loading />
       )}


### PR DESCRIPTION
Fixes #20469

## Repro steps
See https://github.com/metabase/metabase/issues/20469#issue-1133290892

## Before the fix
![image](https://user-images.githubusercontent.com/1937582/156730345-326cf27f-21f5-42f2-a672-d7f41c4f9cdf.png)

## After the fix
![image](https://user-images.githubusercontent.com/1937582/156730169-201571b1-f584-4dfc-9e1a-c80e83c9c81e.png)
