### PR TITLE
Repro #20845: Embedding with Locked parameters does not allow numeric values

### DIFF
--- a/frontend/test/metabase/scenarios/embedding/reproductions/20845-locked-numeric-param.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/reproductions/20845-locked-numeric-param.cy.spec.js
@@ -1,0 +1,71 @@
+import { restore, visitQuestion } from "__support__/e2e/cypress";
+
+const defaultFilterValues = [undefined, "10"];
+
+describe.skip("issue 20845", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  defaultFilterValues.forEach(value => {
+    const conditionalPartOfTestTitle = value
+      ? "and the required filter with the default value"
+      : "";
+
+    it(`locked parameter should work with numeric values ${conditionalPartOfTestTitle} (metabase#20845)`, () => {
+      const questionDetails = getQuestionDetails(value);
+
+      cy.createNativeQuestion(questionDetails).then(({ body: { id } }) => {
+        cy.request("PUT", `/api/card/${id}`, { enable_embedding: true });
+
+        visitQuestion(id);
+      });
+
+      cy.icon("share").click();
+      cy.findByText("Embed this question in an application").click();
+
+      cy.findByText("Disabled").click();
+      cy.findByText("Locked").click();
+
+      cy.findByText("Preview Locked Parameters")
+        .parent()
+        .within(() => {
+          cy.findByPlaceholderText("Qty locked").type("15{enter}");
+        });
+
+      cy.document().then(doc => {
+        const iframe = doc.querySelector("iframe");
+
+        cy.signOut();
+        cy.visit(iframe.src);
+      });
+
+      cy.findByText("COUNT(*)");
+      cy.findByText("5");
+    });
+  });
+});
+
+/**
+ * @param {string} defaultValue - The default value for the defined filter
+ * @returns object
+ */
+function getQuestionDetails(defaultValue = undefined) {
+  return {
+    name: "20845",
+    native: {
+      "template-tags": {
+        qty_locked: {
+          id: "6bd8d7be-bd5b-382c-cfa2-683461891663",
+          name: "qty_locked",
+          "display-name": "Qty locked",
+          type: "number",
+          required: defaultValue ? true : false,
+          default: defaultValue,
+        },
+      },
+      query: "select count(*) from orders where quantity={{qty_locked}}",
+    },
+  };
+}


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Reproduces #20845
    - With a default filter value
    - Without a default filter value
- On top of this, we're also manually signing and sending the payload, effectively creating 4 test scenarios (2x2 matrix)
    - With the `string` as the filter value in the payload
    - With the `integer` as the filter value in the payload 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/embedding/reproductions/20845-locked-numeric-param.cy.spec.js`
- Unskip repro
- Both test scenarios should fail

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
For both scenarios it is the same failure - it works when the payload is string, but fails when we send an integer
![image](https://user-images.githubusercontent.com/31325167/156840063-700f7409-f27e-4287-81a4-01544ae913c2.png)


![image](https://user-images.githubusercontent.com/31325167/156839923-78836121-6efe-4d93-8c74-d5903a9c4c48.png)



