### PR TITLE
Extract hard coded embedding key for e2e tests

### DIFF
--- a/frontend/test/__support__/e2e/cypress_data.js
+++ b/frontend/test/__support__/e2e/cypress_data.js
@@ -111,3 +111,7 @@ export const USERS = {
     group_ids: [ALL_USERS_GROUP],
   },
 };
+
+// Embedding
+export const METABASE_SECRET_KEY =
+  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";

--- a/frontend/test/snapshot-creators/default.cy.snap.js
+++ b/frontend/test/snapshot-creators/default.cy.snap.js
@@ -5,6 +5,7 @@ import {
   USER_GROUPS,
   SAMPLE_DB_ID,
   SAMPLE_DB_TABLES,
+  METABASE_SECRET_KEY,
 } from "__support__/e2e/cypress_data";
 
 const {
@@ -68,7 +69,7 @@ describe("snapshots", () => {
     cy.request("PUT", "/api/setting/enable-public-sharing", { value: true });
     cy.request("PUT", "/api/setting/enable-embedding", { value: true });
     cy.request("PUT", "/api/setting/embedding-secret-key", {
-      value: "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      value: METABASE_SECRET_KEY,
     });
 
     // update the Sample db connection string so it is valid in both CI and locally


### PR DESCRIPTION
### Status
PENDING REVIEW

As explained and defined in https://github.com/metabase/metabase/issues/20722, we're replacing hard coded values in e2e test and storing them in `cypress_data.js` file.

This PR updates and replaces hard coded `METABASE_SECRET_KEY` used for embedding signing.

### How to test?
- All tests should still work in CI and locally for you
- Also, since this value is used in the `default.cy.snap.js`, if anything is wrong even the snapshots would fail and not a single Cypress test would even start running after that