### PR TITLE
Add e2e embedding `jwt` helper

### DIFF
--- a/frontend/test/__support__/e2e/cypress.js
+++ b/frontend/test/__support__/e2e/cypress.js
@@ -27,5 +27,6 @@ export * from "./helpers/e2e-custom-column-helpers";
 export * from "./helpers/e2e-dimension-list-helpers";
 export * from "./helpers/e2e-downloads-helpers";
 export * from "./helpers/e2e-bi-basics-helpers";
+export * from "./helpers/e2e-embedding-helpers";
 
 Cypress.on("uncaught:exception", (err, runnable) => false);

--- a/frontend/test/__support__/e2e/external/e2e-jwt-sign.js
+++ b/frontend/test/__support__/e2e/external/e2e-jwt-sign.js
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+/*eslint-disable import/no-commonjs */
+
+const process = require("process");
+const jwt = require("jsonwebtoken");
+
+const payload = process.argv[2];
+const METABASE_SECRET_KEY = process.argv[3];
+
+const token = jwt.sign(payload, METABASE_SECRET_KEY);
+
+console.log(token);

--- a/frontend/test/__support__/e2e/helpers/e2e-embedding-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-embedding-helpers.js
@@ -1,0 +1,14 @@
+import { METABASE_SECRET_KEY } from "__support__/e2e/cypress_data";
+
+const jwtSignLocation =
+  "frontend/test/__support__/e2e/external/e2e-jwt-sign.js";
+
+export function visitEmbeddedPage(payload) {
+  const stringifiedPayload = JSON.stringify(payload);
+
+  cy.exec(
+    `node  ${jwtSignLocation} '${stringifiedPayload}' ${METABASE_SECRET_KEY}`,
+  ).then(({ stdout: token }) => {
+    cy.visit("/embed/question/" + token + "#bordered=true&titled=true");
+  });
+}


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Adds an external node script that uses `jwt` to sign the payloads and obtain the token needed for embedding e2e tests
- Adds an embedding helper which uses that node script

### Notes:
- Please note that this is just an early "sketch" and some improvements will be needed later.
- For example, helper currently works only for questions and has hard coded borders and title.
- I needed to quickly put something together in order to be able to reproduce #20845
- The full helper functionality for both dashboards and questions with optional parameters is out of scope of this PR

```js
const payload = {
  resource: { question: questionId },
  params: {},
};

visitEmbeddedPage(payload);
```