### PR TITLE
Send error response when bookmark already exists

### DIFF
--- a/src/metabase/api/bookmark.clj
+++ b/src/metabase/api/bookmark.clj
@@ -57,6 +57,9 @@
    id    su/IntGreaterThanZero}
   (let [[item-model bookmark-model item-key] (lookup model)]
     (api/read-check item-model id)
+    (api/check (not (db/exists? bookmark-model item-key id
+                                :user_id api/*current-user-id*))
+      [400 "Bookmark already exists"])
     (db/insert! bookmark-model {item-key id :user_id api/*current-user-id*})))
 
 (api/defendpoint DELETE "/:model/:id"


### PR DESCRIPTION
This is a small PR to cover  the following from #20318 

- [ ] Handle the error from bookmarking an item twice: it will throw a constraint violation which we need to discern from other errors. As far as I can tell there's no programmatic information to use. The message is parseable in english but i'm sure we cannot rely on these messages being in english.