### PR TITLE
Match TippyPopover's and Tooltip's z-index to Popover/Modal

### DIFF
--- a/frontend/src/metabase/components/Popover/TippyPopover.tsx
+++ b/frontend/src/metabase/components/Popover/TippyPopover.tsx
@@ -9,6 +9,8 @@ import EventSandbox from "metabase/components/EventSandbox";
 import { isCypressActive } from "metabase/env";
 import useSequencedContentCloseHandler from "metabase/hooks/use-sequenced-content-close-handler";
 
+import { DEFAULT_Z_INDEX } from "./constants";
+
 const TippyComponent = TippyReact.default;
 type TippyProps = TippyReact.TippyProps;
 type TippyInstance = tippy.Instance;
@@ -89,6 +91,7 @@ function TippyPopover({
     <TippyComponent
       className={cx("popover", className)}
       theme="popover"
+      zIndex={DEFAULT_Z_INDEX}
       arrow={false}
       offset={OFFSET}
       appendTo={appendTo}

--- a/frontend/src/metabase/components/Popover/constants.ts
+++ b/frontend/src/metabase/components/Popover/constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_Z_INDEX = 4;

--- a/frontend/src/metabase/components/Tooltip/Tooltip.tsx
+++ b/frontend/src/metabase/components/Tooltip/Tooltip.tsx
@@ -4,6 +4,7 @@ import * as Tippy from "@tippyjs/react";
 import * as ReactIs from "react-is";
 
 import { isReducedMotionPreferred } from "metabase/lib/dom";
+import { DEFAULT_Z_INDEX } from "metabase/components/Popover/constants";
 
 const TippyComponent = Tippy.default;
 
@@ -90,6 +91,7 @@ function Tooltip({
         delay={delay}
         placement={placement}
         offset={offset}
+        zIndex={DEFAULT_Z_INDEX}
         {...targetProps}
       />
     );


### PR DESCRIPTION
Related to https://github.com/metabase/metabase/issues/18951

Tippy's default z-index is `9999`, much higher than anything we use in our app. Modals and old Popovers are set to a `z-index` of 4, so instances of `TippyPopover` end appearing over everything, including modal backdrops. To fix this, I'm defaulting `Tooltip` and `TippyPopover` to a z-index of 4 as well.

How popover and modal z-index is set:
https://github.com/metabase/metabase/blob/9a5c2b806799a41386739d882e2d845257f0a88b/frontend/src/metabase/components/Popover/Popover.css#L4
https://github.com/metabase/metabase/blob/9a5c2b806799a41386739d882e2d845257f0a88b/frontend/src/metabase/css/components/modal.css#L9

Tippy's default on the `zIndex` prop:
https://atomiks.github.io/tippyjs/v6/all-props/#zindex

**Testing**
1. Make sure tooltips still appear properly (hover over the top right gear icon)
2. Make sure `TippyPopover` instances still appear properly (hover your mouse over the column header of a table in the query builder)
