### PR TITLE
Default TippyPopover's interactive prop to true

### DIFF
--- a/frontend/src/metabase/components/MetadataInfo/DimensionInfoPopover/DimensionInfoPopover.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/DimensionInfoPopover/DimensionInfoPopover.tsx
@@ -40,7 +40,6 @@ function DimensionInfoPopover({
     <TippyPopover
       className={className}
       delay={delay}
-      interactive
       placement={placement || "left-start"}
       disabled={disabled}
       content={<WidthBoundDimensionInfo dimension={dimension} />}

--- a/frontend/src/metabase/components/MetadataInfo/TableInfoPopover/TableInfoPopover.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/TableInfoPopover/TableInfoPopover.tsx
@@ -53,7 +53,6 @@ function TableInfoPopover({
   return showPopover ? (
     <TippyPopover
       className={className}
-      interactive
       delay={delay}
       placement={placement}
       offset={offset}

--- a/frontend/src/metabase/components/Popover/TippyPopover.info.js
+++ b/frontend/src/metabase/components/Popover/TippyPopover.info.js
@@ -93,8 +93,8 @@ export const examples = {
       </TippyPopover>
     </React.Fragment>
   ),
-  interactive: (
-    <TippyPopover interactive placement="left-end" content={content}>
+  "interactive disabled": (
+    <TippyPopover interactive={false} placement="left-end" content={content}>
       {target}
     </TippyPopover>
   ),

--- a/frontend/src/metabase/components/Popover/TippyPopover.tsx
+++ b/frontend/src/metabase/components/Popover/TippyPopover.tsx
@@ -36,6 +36,7 @@ function TippyPopover({
   content,
   delay,
   lazy = true,
+  interactive = true,
   onShow,
   onHide,
   ...props
@@ -94,6 +95,7 @@ function TippyPopover({
       appendTo={appendTo}
       plugins={plugins}
       {...props}
+      interactive={interactive}
       duration={animationDuration}
       delay={delay}
       content={

--- a/frontend/src/metabase/core/components/DateWidget/DateWidget.tsx
+++ b/frontend/src/metabase/core/components/DateWidget/DateWidget.tsx
@@ -54,7 +54,6 @@ const DateWidget = forwardRef(function DateWidget(
     <TippyPopover
       visible={isOpened}
       placement="bottom-start"
-      interactive
       content={
         <DateSelector
           value={value}

--- a/frontend/src/metabase/dashboard/components/DashCardCardParameterMapper.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCardCardParameterMapper.jsx
@@ -147,7 +147,6 @@ function DashCardCardParameterMapper({
           visible={isDropdownVisible && !isDisabled && hasPermissionsToMap}
           onClickOutside={() => setIsDropdownVisible(false)}
           placement="bottom-start"
-          interactive
           content={
             <ParameterTargetList
               onChange={target => {


### PR DESCRIPTION
Related to https://github.com/metabase/metabase/issues/18951

I think we can safely assume we'll be making interactive `TippyPopover`s nearly 100% of the time, so I think it makes sense to default the property to `true` so that we don't need to add it everywhere.

**Testing**
Make sure instances of `TippyPopover` can be interactive with via your mouse
1. Go to the Products table in the query builder
2. Hover mouse over a column header of the table viz. A popover should appear.
3. Try to select some text in the popover. It should work, and the popover shouldn't disappear as soon as you try to interact with it.
