### PR TITLE
Add flip prop to TippyPopover

### DIFF
--- a/frontend/src/metabase/components/Popover/TippyPopover.info.js
+++ b/frontend/src/metabase/components/Popover/TippyPopover.info.js
@@ -99,4 +99,9 @@ export const examples = {
     </TippyPopover>
   ),
   "control mode + handling of Esc press": <VisiblePropExample />,
+  "flip disabled": (
+    <TippyPopover flip={false} placement="bottom-start" content={content}>
+      {target}
+    </TippyPopover>
+  ),
 };

--- a/frontend/src/metabase/components/Popover/TippyPopover.tsx
+++ b/frontend/src/metabase/components/Popover/TippyPopover.tsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import * as TippyReact from "@tippyjs/react";
 import * as tippy from "tippy.js";
 import cx from "classnames";
+import { merge } from "icepick";
 
 import { isReducedMotionPreferred } from "metabase/lib/dom";
 import EventSandbox from "metabase/components/EventSandbox";
@@ -18,6 +19,7 @@ type TippyInstance = tippy.Instance;
 export interface ITippyPopoverProps extends TippyProps {
   disableContentSandbox?: boolean;
   lazy?: boolean;
+  flip?: boolean;
 }
 
 const OFFSET: [number, number] = [0, 5];
@@ -32,6 +34,23 @@ function appendTo() {
   return document.body;
 }
 
+function getPopperOptions({
+  flip,
+  popperOptions = {},
+}: Pick<ITippyPopoverProps, "flip" | "popperOptions">) {
+  return merge(
+    {
+      modifiers: [
+        {
+          name: "flip",
+          enabled: flip,
+        },
+      ],
+    },
+    popperOptions,
+  );
+}
+
 function TippyPopover({
   className,
   disableContentSandbox,
@@ -39,6 +58,8 @@ function TippyPopover({
   delay,
   lazy = true,
   interactive = true,
+  flip = true,
+  popperOptions,
   onShow,
   onHide,
   ...props
@@ -88,6 +109,11 @@ function TippyPopover({
 
   const plugins = useMemo(() => [lazyPlugin], [lazyPlugin]);
 
+  const computedPopperOptions = useMemo(
+    () => getPopperOptions({ flip, popperOptions }),
+    [flip, popperOptions],
+  );
+
   return (
     <TippyComponent
       className={cx("popover", className)}
@@ -98,6 +124,7 @@ function TippyPopover({
       appendTo={appendTo}
       plugins={plugins}
       {...props}
+      popperOptions={computedPopperOptions}
       interactive={interactive}
       duration={animationDuration}
       delay={delay}

--- a/frontend/src/metabase/components/Popover/TippyPopover.tsx
+++ b/frontend/src/metabase/components/Popover/TippyPopover.tsx
@@ -9,6 +9,8 @@ import EventSandbox from "metabase/components/EventSandbox";
 import { isCypressActive } from "metabase/env";
 import useSequencedContentCloseHandler from "metabase/hooks/use-sequenced-content-close-handler";
 
+import { DEFAULT_Z_INDEX } from "./constants";
+
 const TippyComponent = TippyReact.default;
 type TippyProps = TippyReact.TippyProps;
 type TippyInstance = tippy.Instance;
@@ -90,6 +92,7 @@ function TippyPopover({
     <TippyComponent
       className={cx("popover", className)}
       theme="popover"
+      zIndex={DEFAULT_Z_INDEX}
       arrow={false}
       offset={OFFSET}
       appendTo={appendTo}

--- a/frontend/src/metabase/components/Popover/constants.ts
+++ b/frontend/src/metabase/components/Popover/constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_Z_INDEX = 4;

--- a/frontend/src/metabase/components/Tooltip/Tooltip.tsx
+++ b/frontend/src/metabase/components/Tooltip/Tooltip.tsx
@@ -4,6 +4,7 @@ import * as Tippy from "@tippyjs/react";
 import * as ReactIs from "react-is";
 
 import { isReducedMotionPreferred } from "metabase/lib/dom";
+import { DEFAULT_Z_INDEX } from "metabase/components/Popover/constants";
 
 const TippyComponent = Tippy.default;
 
@@ -90,6 +91,7 @@ function Tooltip({
         delay={delay}
         placement={placement}
         offset={offset}
+        zIndex={DEFAULT_Z_INDEX}
         {...targetProps}
       />
     );


### PR DESCRIPTION
Related to https://github.com/metabase/metabase/issues/18951

Popper is a bit more consistent about flipping popover positions when a popover hits a viewport edge, so I'm anticipating we will need an easy way to disabling flipping in a handful of scenarios as we migrate old Popovers. The interface for interacting with this functionality in popper is pretty verbose, so I'm exposing a `flip` boolean that defaults to `true`.

**Testing**
Check out the bottom example in `/_internal/components/tippypopover` where I've disabled `flip`. I'll move this to storybook eventually 🙂 