### PR TITLE
Add sizeToFit prop to TippyPopover

### DIFF
--- a/frontend/src/metabase/components/Popover/Popover.css
+++ b/frontend/src/metabase/components/Popover/Popover.css
@@ -22,6 +22,12 @@
   overflow: auto;
 }
 
+.tippy-box,
+.tippy-content {
+  max-height: inherit;
+  transition: transform 0s, visibility 0.3s, opacity 0.3s;
+}
+
 .tippy-box[data-theme~="tooltip"] {
   color: white;
   font-weight: bold;

--- a/frontend/src/metabase/components/Popover/TippyPopover.info.js
+++ b/frontend/src/metabase/components/Popover/TippyPopover.info.js
@@ -19,6 +19,10 @@ const PopoverBody = styled(Base)`
   width: 200px;
 `;
 
+const LongPopoverBody = styled(PopoverBody)`
+  height: 600px;
+`;
+
 const LazyPopoverBody = styled(Base)`
   border: none;
   height: 200px;
@@ -33,6 +37,7 @@ const PopoverTarget = styled(Base)`
 `;
 
 const content = <PopoverBody>popover body</PopoverBody>;
+const longContent = <LongPopoverBody>long popover body</LongPopoverBody>;
 const target = <PopoverTarget>popover target</PopoverTarget>;
 
 function LazyContentExample() {
@@ -104,4 +109,15 @@ export const examples = {
       {target}
     </TippyPopover>
   ),
+  sizeToFit: (
+    <TippyPopover
+      sizeToFit
+      placement="bottom-start"
+      visible
+      content={longContent}
+    >
+      {target}
+    </TippyPopover>
+  ),
+  extra_space: <div style={{ height: 250 }} />,
 };


### PR DESCRIPTION
Related to https://github.com/metabase/metabase/issues/18951

I was hoping for an alternative to adding `sizeToFit` to `TippyPopover` because it frequently makes popovers awkwardly long, but we use it in so many places with `Popover` (~20) that I think it makes sense to implement it so that we aren't stuck with two different popover implementations forever. 

With `flip` still active, the popover can flip depending on how quickly you scroll. This shouldn't be too big of an issue; most of the pages in our app don't scroll, and you can set `flip={false}` pretty easily.

**Testing**
Scroll to the bottom of `/_internal/components/tippypopover` and there is a `TippyPopover` with `sizeToFit` enabled.
- when scrolling in one direction, the popover shouldn't flicker between positions
- the popover's height should adjust smoothly and remain on the page as you scroll

Also, feel free to change the `placement` string of the example in `frontend/src/metabase/components/Popover/TippyPopover.info.js`. `sizeToFit` should only work for placement strings starting with `bottom` or `start`. It shouldn't work at all for placements starting with `left` or `right`.

Recording where I test it & swap out the set `placement` prop to show how it works for different settings:

https://user-images.githubusercontent.com/13057258/156855811-5624dcbe-b2bc-4fcd-9774-de7e34e0633f.mov


