### PR TITLE
Fix no visual feedback when updating data model column properties

### DIFF
--- a/frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx
@@ -48,7 +48,7 @@ const mapDispatchToProps = {
       : push(`/admin/datamodel/database/${id}`),
   selectTable: ({ id, db_id }) =>
     push(`/admin/datamodel/database/${db_id}/table/${id}`),
-  updateField: field => Fields.actions.update(field),
+  updateField: field => Fields.actions.updateField(field),
   onRetireMetric: ({ id, ...rest }) =>
     Metrics.actions.setArchived({ id }, true, rest),
 };

--- a/frontend/src/metabase/entities/fields.js
+++ b/frontend/src/metabase/entities/fields.js
@@ -1,4 +1,5 @@
-import { createEntity } from "metabase/lib/entities";
+import { t } from "ttag";
+import { createEntity, undo } from "metabase/lib/entities";
 import {
   compose,
   withAction,
@@ -86,6 +87,13 @@ const Fields = createEntity({
       return { id, values };
     }),
 
+    updateField(field, opts) {
+      return Fields.actions.update(
+        { id: field.id },
+        field,
+        undo(opts, field.display_name, t`updated`),
+      );
+    },
     // Docstring from m.api.field:
     // Update the human-readable values for a `Field` whose semantic type is
     // `category`/`city`/`state`/`country` or whose base type is `type/Boolean`."

--- a/frontend/src/metabase/lib/entities.js
+++ b/frontend/src/metabase/lib/entities.js
@@ -259,12 +259,14 @@ export function createEntity(def) {
         );
 
         if (notify) {
-          if (notify.undo) {
-            // pick only the attributes that were updated
-            const undoObject = _.pick(
-              originalObject,
-              ...Object.keys(updatedObject || {}),
-            );
+          // pick only the attributes that were updated
+          const undoObject = _.pick(
+            originalObject,
+            ...Object.keys(updatedObject || {}),
+          );
+          // https://github.com/metabase/metabase/pull/20874#pullrequestreview-902384264
+          const canUndo = !hasCircularReference(undoObject);
+          if (notify.undo && canUndo) {
             dispatch(
               addUndo({
                 actions: [
@@ -609,6 +611,16 @@ export function createEntity(def) {
   require("metabase/entities/containers").addEntityContainers(entity);
 
   return entity;
+}
+
+function hasCircularReference(object) {
+  try {
+    JSON.stringify(object);
+  } catch (error) {
+    return true;
+  }
+
+  return false;
 }
 
 export function combineEntities(entities) {


### PR DESCRIPTION
Fix #19710

### Repro steps
See #19710

> 1. Go to Admin > Data Model > select a table
> 2. Change "No semantic type" for one of the columns to an FK relationship
> 3. There is no visual feedback to show that this has been persisted and no save button. I had to hit refresh on the page for me to feel confident my changes were actually saved.

### Before the fix
There's no toast message after any property is updated.

### After the fix
![image](https://user-images.githubusercontent.com/1937582/157028630-c43bdd70-11eb-424d-99ca-1e0a5ca926fe.png)
