### PR TITLE
Add validation logic to TemplateTagDimension dimension tag handling

### DIFF
--- a/frontend/src/metabase-lib/lib/Dimension.ts
+++ b/frontend/src/metabase-lib/lib/Dimension.ts
@@ -1523,8 +1523,7 @@ export class TemplateTagDimension extends FieldDimension {
 
     if (this.isDimensionType() && tag.dimension == null) {
       return new Error(
-        t`Field filter "${this.displayName() ||
-          this.tagName()}" is missing a field.`,
+        t`The variable "${this.tagName()}" needs to be mapped to a field.`,
       );
     }
 

--- a/frontend/src/metabase-lib/lib/Dimension.ts
+++ b/frontend/src/metabase-lib/lib/Dimension.ts
@@ -19,6 +19,7 @@ import {
   ExpressionReference,
   DatetimeUnit,
 } from "metabase-types/types/Query";
+import { ValidationError, VALIDATION_ERROR_TYPES } from "./ValidationError";
 import { IconName } from "metabase-types/types";
 import { getFieldValues, getRemappings } from "metabase/lib/query/field";
 import { DATETIME_UNITS, formatBucketing } from "metabase/lib/query_time";
@@ -1522,8 +1523,9 @@ export class TemplateTagDimension extends FieldDimension {
     }
 
     if (this.isDimensionType() && tag.dimension == null) {
-      return new Error(
+      return new ValidationError(
         t`The variable "${this.tagName()}" needs to be mapped to a field.`,
+        VALIDATION_ERROR_TYPES.MISSING_TAG_DIMENSION,
       );
     }
 

--- a/frontend/src/metabase-lib/lib/Dimension.ts
+++ b/frontend/src/metabase-lib/lib/Dimension.ts
@@ -1515,6 +1515,27 @@ export class TemplateTagDimension extends FieldDimension {
     return Array.isArray(clause) && clause[0] === "template-tag";
   }
 
+  validateTemplateTag(): Error | null {
+    const tag = this.tag();
+    if (!tag) {
+      return new Error(t`Invalid template tag "${this.tagName()}"`);
+    }
+
+    if (this.isDimensionType() && tag.dimension == null) {
+      return new Error(
+        t`Field filter "${this.displayName() ||
+          this.tagName()}" is missing a field.`,
+      );
+    }
+
+    return null;
+  }
+
+  isValidDimensionType() {
+    const maybeErrors = this.validateTemplateTag();
+    return this.isDimensionType() && maybeErrors === null;
+  }
+
   isDimensionType() {
     const maybeTag = this.tag();
     return maybeTag?.type === "dimension";
@@ -1526,7 +1547,7 @@ export class TemplateTagDimension extends FieldDimension {
   }
 
   dimension() {
-    if (this.isDimensionType()) {
+    if (this.isValidDimensionType()) {
       const tag = this.tag();
       return Dimension.parseMBQL(tag.dimension, this._metadata, this._query);
     }
@@ -1549,7 +1570,7 @@ export class TemplateTagDimension extends FieldDimension {
   }
 
   field() {
-    if (this.isDimensionType()) {
+    if (this.isValidDimensionType()) {
       return this.dimension().field();
     }
 
@@ -1557,7 +1578,7 @@ export class TemplateTagDimension extends FieldDimension {
   }
 
   name() {
-    return this.isDimensionType() ? this.field().name : this.tagName();
+    return this.isValidDimensionType() ? this.field().name : this.tagName();
   }
 
   tagName() {
@@ -1574,7 +1595,7 @@ export class TemplateTagDimension extends FieldDimension {
   }
 
   icon() {
-    if (this.isDimensionType()) {
+    if (this.isValidDimensionType()) {
       return this.dimension().icon();
     } else if (this.isVariableType()) {
       return this.variable().icon();

--- a/frontend/src/metabase-lib/lib/Dimension.ts
+++ b/frontend/src/metabase-lib/lib/Dimension.ts
@@ -1516,10 +1516,10 @@ export class TemplateTagDimension extends FieldDimension {
     return Array.isArray(clause) && clause[0] === "template-tag";
   }
 
-  validateTemplateTag(): Error | null {
+  validateTemplateTag(): ValidationError | null {
     const tag = this.tag();
     if (!tag) {
-      return new Error(t`Invalid template tag "${this.tagName()}"`);
+      return new ValidationError(t`Invalid template tag "${this.tagName()}"`);
     }
 
     if (this.isDimensionType() && tag.dimension == null) {

--- a/frontend/src/metabase-lib/lib/ValidationError.ts
+++ b/frontend/src/metabase-lib/lib/ValidationError.ts
@@ -1,0 +1,14 @@
+export const VALIDATION_ERROR_TYPES = {
+  MISSING_TAG_DIMENSION: "MISSING_TAG_DIMENSION",
+} as const;
+
+type ErrorType = typeof VALIDATION_ERROR_TYPES[keyof typeof VALIDATION_ERROR_TYPES];
+
+export class ValidationError extends Error {
+  type: ErrorType;
+
+  constructor(message: string, errorType: ErrorType) {
+    super(message);
+    this.type = errorType;
+  }
+}

--- a/frontend/src/metabase-lib/lib/ValidationError.ts
+++ b/frontend/src/metabase-lib/lib/ValidationError.ts
@@ -5,9 +5,9 @@ export const VALIDATION_ERROR_TYPES = {
 type ErrorType = typeof VALIDATION_ERROR_TYPES[keyof typeof VALIDATION_ERROR_TYPES];
 
 export class ValidationError extends Error {
-  type: ErrorType;
+  type?: ErrorType;
 
-  constructor(message: string, errorType: ErrorType) {
+  constructor(message: string, errorType?: ErrorType) {
     super(message);
     this.type = errorType;
   }

--- a/frontend/src/metabase-lib/lib/ValidationError.ts
+++ b/frontend/src/metabase-lib/lib/ValidationError.ts
@@ -2,7 +2,7 @@ export const VALIDATION_ERROR_TYPES = {
   MISSING_TAG_DIMENSION: "MISSING_TAG_DIMENSION",
 } as const;
 
-type ErrorType = typeof VALIDATION_ERROR_TYPES[keyof typeof VALIDATION_ERROR_TYPES];
+export type ErrorType = typeof VALIDATION_ERROR_TYPES[keyof typeof VALIDATION_ERROR_TYPES];
 
 export class ValidationError extends Error {
   type?: ErrorType;

--- a/frontend/src/metabase-lib/lib/queries/NativeQuery.ts
+++ b/frontend/src/metabase-lib/lib/queries/NativeQuery.ts
@@ -26,6 +26,8 @@ import AtomicQuery from "metabase-lib/lib/queries/AtomicQuery";
 import Dimension, { TemplateTagDimension, FieldDimension } from "../Dimension";
 import Variable, { TemplateTagVariable } from "../Variable";
 import DimensionOptions from "../DimensionOptions";
+import { ValidationError } from "../ValidationError";
+
 type DimensionFilter = (dimension: Dimension) => boolean;
 type VariableFilter = (variable: Variable) => boolean;
 export const NATIVE_QUERY_TEMPLATE: NativeDatasetQuery = {
@@ -301,12 +303,14 @@ export default class NativeQuery extends AtomicQuery {
           this,
         );
         if (!dimension) {
-          return new Error(t`Invalid template tag: ${tag.name}`);
+          return new ValidationError(t`Invalid template tag: ${tag.name}`);
         }
 
         return dimension.validateTemplateTag();
       })
-      .filter(Boolean);
+      .filter(
+        (maybeError): maybeError is ValidationError => maybeError != null,
+      );
   }
 
   allTemplateTagsAreValid() {

--- a/frontend/src/metabase/query_builder/components/QueryValidationError/ErrorActionButton.tsx
+++ b/frontend/src/metabase/query_builder/components/QueryValidationError/ErrorActionButton.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { t } from "ttag";
+import { connect } from "react-redux";
+
+import {
+  ValidationError,
+  VALIDATION_ERROR_TYPES,
+} from "metabase-lib/lib/ValidationError";
+import { getUiControls } from "metabase/query_builder/selectors";
+import { toggleTemplateTagsEditor } from "metabase/query_builder/actions";
+
+import { QueryValidationErrorProps } from "./QueryValidationError";
+import { QueryErrorActionButton } from "./QueryValidationError.styled";
+
+type QueryBuilderUiControls = {
+  isShowingTemplateTagsEditor?: boolean;
+};
+
+type ErrorActionButton = QueryValidationErrorProps & {
+  uiControls: QueryBuilderUiControls;
+  toggleTemplateTagsEditor: () => void;
+};
+
+const mapStateToProps = (state: any, props: QueryValidationErrorProps) => ({
+  uiControls: getUiControls(state),
+});
+
+const mapDispatchToProps = {
+  toggleTemplateTagsEditor,
+};
+
+function ErrorActionButton({
+  error,
+  uiControls,
+  toggleTemplateTagsEditor,
+}: ErrorActionButton) {
+  const type = error instanceof ValidationError ? error.type : undefined;
+
+  switch (type) {
+    case VALIDATION_ERROR_TYPES.MISSING_TAG_DIMENSION:
+      return (
+        <QueryErrorActionButton
+          onClick={() => {
+            if (!uiControls.isShowingTemplateTagsEditor) {
+              toggleTemplateTagsEditor();
+            }
+          }}
+        >
+          {t`Edit variables`}
+        </QueryErrorActionButton>
+      );
+    default:
+      return null;
+  }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(ErrorActionButton);

--- a/frontend/src/metabase/query_builder/components/QueryValidationError/ErrorActionButton.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/QueryValidationError/ErrorActionButton.unit.spec.tsx
@@ -1,0 +1,103 @@
+import React from "react";
+import { render, screen } from "__support__/ui";
+import userEvent from "@testing-library/user-event";
+
+import {
+  ValidationError,
+  VALIDATION_ERROR_TYPES,
+} from "metabase-lib/lib/ValidationError";
+
+import {
+  ErrorActionButton,
+  BUTTON_ACTIONS,
+  ErrorActionButtonProps,
+} from "./ErrorActionButton";
+
+let props: ErrorActionButtonProps;
+describe("ErrorActionButton", () => {
+  beforeEach(() => {
+    props = {
+      error: new ValidationError(
+        "oof",
+        VALIDATION_ERROR_TYPES.MISSING_TAG_DIMENSION,
+      ),
+      uiControls: {
+        isShowingTemplateTagsEditor: false,
+      },
+      toggleTemplateTagsEditor: jest.fn(),
+    };
+  });
+
+  describe("when using an error that does not have an associated action", () => {
+    const errorWithoutType = new ValidationError("oof"); // undefined action type
+    beforeEach(() => {
+      props.error = errorWithoutType;
+      render(<ErrorActionButton {...props} />);
+    });
+
+    it("should not render an action button", () => {
+      expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("when using an error with an associated action", () => {
+    const [buttonLabel] = BUTTON_ACTIONS[
+      VALIDATION_ERROR_TYPES.MISSING_TAG_DIMENSION
+    ];
+
+    beforeEach(() => {
+      render(<ErrorActionButton {...props} />);
+    });
+
+    it("should render an action button using the button label it is mapped to", () => {
+      expect(
+        screen.getByRole("button", {
+          name: buttonLabel,
+        }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("when clicking an ErrorActionButton mapped to the MISSING_TAG_DIMENSION validation error", () => {
+    const validationError = new ValidationError(
+      "oof",
+      VALIDATION_ERROR_TYPES.MISSING_TAG_DIMENSION,
+    );
+    const [buttonLabel] = BUTTON_ACTIONS[
+      VALIDATION_ERROR_TYPES.MISSING_TAG_DIMENSION
+    ];
+
+    describe("when `isShowingTemplateTagsEditor` is falsy", () => {
+      beforeEach(() => {
+        props.error = validationError;
+        render(<ErrorActionButton {...props} />);
+      });
+
+      it("should call the toggleTemplateTagsEditor action", () => {
+        userEvent.click(
+          screen.getByRole("button", {
+            name: buttonLabel,
+          }),
+        );
+        expect(props.toggleTemplateTagsEditor).toHaveBeenCalled();
+      });
+    });
+
+    describe("when `isShowingTemplateTagsEditor` is true", () => {
+      beforeEach(() => {
+        props.error = validationError;
+        props.uiControls.isShowingTemplateTagsEditor = true;
+        render(<ErrorActionButton {...props} />);
+      });
+
+      it("should not call the toggleTemplateTagsEditor action", () => {
+        userEvent.click(
+          screen.getByRole("button", {
+            name: buttonLabel,
+          }),
+        );
+        expect(props.toggleTemplateTagsEditor).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/frontend/src/metabase/query_builder/components/QueryValidationError/QueryValidationError.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/QueryValidationError/QueryValidationError.styled.tsx
@@ -1,0 +1,34 @@
+import styled from "@emotion/styled";
+
+import Button from "metabase/core/components/Button";
+import { color } from "metabase/lib/colors";
+
+export const QueryValidationErrorRoot = styled.div`
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  row-gap: 0.75rem;
+`;
+
+export const QueryValidationErrorHeader = styled.div`
+  font-size: 20px;
+  font-weight: bold;
+  color: ${color("text-medium")};
+`;
+
+export const QueryValidationErrorMessage = styled.div`
+  color: ${color("text-medium")};
+`;
+
+export const QueryErrorActionButton = styled(Button)`
+  color: ${color("brand")};
+  border: none;
+  padding: 0;
+
+  &:hover {
+    text-decoration: underline;
+    background-color: transparent;
+  }
+`;

--- a/frontend/src/metabase/query_builder/components/QueryValidationError/QueryValidationError.tsx
+++ b/frontend/src/metabase/query_builder/components/QueryValidationError/QueryValidationError.tsx
@@ -26,7 +26,7 @@ type ErrorActionButton = QueryValidationErrorProps & {
 function QueryValidationError({ error }: QueryValidationErrorProps) {
   return (
     <QueryValidationErrorRoot>
-      <QueryValidationErrorHeader>{t`Something's wrong with your Question`}</QueryValidationErrorHeader>
+      <QueryValidationErrorHeader>{t`Something's wrong with your question`}</QueryValidationErrorHeader>
       <QueryValidationErrorMessage>{error.message}</QueryValidationErrorMessage>
       <ErrorActionButton error={error} />
     </QueryValidationErrorRoot>

--- a/frontend/src/metabase/query_builder/components/QueryValidationError/QueryValidationError.tsx
+++ b/frontend/src/metabase/query_builder/components/QueryValidationError/QueryValidationError.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { t } from "ttag";
+
+import { ValidationError } from "metabase-lib/lib/ValidationError";
+
+import {
+  QueryValidationErrorRoot,
+  QueryValidationErrorHeader,
+  QueryValidationErrorMessage,
+} from "./QueryValidationError.styled";
+import ErrorActionButton from "./ErrorActionButton";
+
+type QueryBuilderUiControls = {
+  isShowingTemplateTagsEditor?: boolean;
+};
+
+export type QueryValidationErrorProps = {
+  error: Error | ValidationError;
+};
+
+type ErrorActionButton = QueryValidationErrorProps & {
+  uiControls: QueryBuilderUiControls;
+  toggleTemplateTagsEditor: () => void;
+};
+
+function QueryValidationError({ error }: QueryValidationErrorProps) {
+  return (
+    <QueryValidationErrorRoot>
+      <QueryValidationErrorHeader>{t`Something's wrong with your Question`}</QueryValidationErrorHeader>
+      <QueryValidationErrorMessage>{error.message}</QueryValidationErrorMessage>
+      <ErrorActionButton error={error} />
+    </QueryValidationErrorRoot>
+  );
+}
+
+export default QueryValidationError;

--- a/frontend/src/metabase/query_builder/components/QueryValidationError/QueryValidationError.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/QueryValidationError/QueryValidationError.unit.spec.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { renderWithProviders, screen } from "__support__/ui";
+
+import {
+  ValidationError,
+  VALIDATION_ERROR_TYPES,
+} from "metabase-lib/lib/ValidationError";
+
+import QueryValidationError from "./QueryValidationError";
+
+const providers = {
+  reducers: {
+    qb: () => ({}),
+  },
+};
+
+describe("QueryValidationError", () => {
+  describe("when using an Error", () => {
+    const error = new Error("oof");
+    beforeEach(() => {
+      renderWithProviders(<QueryValidationError error={error} />, providers);
+    });
+
+    it("should render the error message", () => {
+      expect(screen.getByText("oof")).toBeInTheDocument();
+    });
+
+    it("should not render an action button because there is no associated action", () => {
+      expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("when using a ValidationError with an associated action", () => {
+    const validationError = new ValidationError(
+      "oof",
+      VALIDATION_ERROR_TYPES.MISSING_TAG_DIMENSION,
+    );
+    beforeEach(() => {
+      renderWithProviders(
+        <QueryValidationError error={validationError} />,
+        providers,
+      );
+    });
+
+    it("should render the error message", () => {
+      expect(screen.getByText("oof")).toBeInTheDocument();
+    });
+
+    it("should render an action button", () => {
+      expect(screen.getByRole("button")).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/metabase/query_builder/components/QueryValidationError/index.ts
+++ b/frontend/src/metabase/query_builder/components/QueryValidationError/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./QueryValidationError";

--- a/frontend/src/metabase/query_builder/components/QueryVisualization.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryVisualization.jsx
@@ -3,7 +3,6 @@ import React, { Component } from "react";
 import { t } from "ttag";
 
 import LoadingSpinner from "metabase/components/LoadingSpinner";
-import ErrorMessage from "metabase/components/ErrorMessage";
 
 import VisualizationError from "./VisualizationError";
 import VisualizationResult from "./VisualizationResult";
@@ -60,7 +59,6 @@ export default class QueryVisualization extends Component {
       isResultDirty,
       isNativeEditorOpen,
       result,
-      validationError,
     } = this.props;
 
     return (
@@ -84,12 +82,7 @@ export default class QueryVisualization extends Component {
             "Visualization--loading": isRunning,
           })}
         >
-          {validationError ? (
-            <ErrorMessage
-              title={t`Something's wrong with your question`}
-              message={validationError.message}
-            />
-          ) : result && result.error ? (
+          {result && result.error ? (
             <VisualizationError
               className="spread"
               error={result.error}

--- a/frontend/src/metabase/query_builder/components/QueryVisualization.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryVisualization.jsx
@@ -3,6 +3,7 @@ import React, { Component } from "react";
 import { t } from "ttag";
 
 import LoadingSpinner from "metabase/components/LoadingSpinner";
+import ErrorMessage from "metabase/components/ErrorMessage";
 
 import VisualizationError from "./VisualizationError";
 import VisualizationResult from "./VisualizationResult";
@@ -59,6 +60,7 @@ export default class QueryVisualization extends Component {
       isResultDirty,
       isNativeEditorOpen,
       result,
+      validationError,
     } = this.props;
 
     return (
@@ -82,7 +84,12 @@ export default class QueryVisualization extends Component {
             "Visualization--loading": isRunning,
           })}
         >
-          {result && result.error ? (
+          {validationError ? (
+            <ErrorMessage
+              title={t`Something's wrong with your question`}
+              message={validationError.message}
+            />
+          ) : result && result.error ? (
             <VisualizationError
               className="spread"
               error={result.error}

--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -5,6 +5,7 @@ import _ from "underscore";
 
 import ExplicitSize from "metabase/components/ExplicitSize";
 import Popover from "metabase/components/Popover";
+import QueryValidationError from "metabase/query_builder/components/QueryValidationError";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 
 import NativeQuery from "metabase-lib/lib/queries/NativeQuery";
@@ -323,18 +324,21 @@ export default class View extends React.Component {
           setIsPreviewing={setIsPreviewing}
         />
 
-        <StyledDebouncedFrame enabled={!isLiveResizable}>
-          <QueryVisualization
-            {...this.props}
-            noHeader
-            className="spread"
-            onAddSeries={onAddSeries}
-            onEditSeries={onEditSeries}
-            onRemoveSeries={onRemoveSeries}
-            onEditBreakout={onEditBreakout}
-            validationError={validationError}
-          />
-        </StyledDebouncedFrame>
+        {validationError ? (
+          <QueryValidationError error={validationError} />
+        ) : (
+          <StyledDebouncedFrame enabled={!isLiveResizable}>
+            <QueryVisualization
+              {...this.props}
+              noHeader
+              className="spread"
+              onAddSeries={onAddSeries}
+              onEditSeries={onEditSeries}
+              onRemoveSeries={onRemoveSeries}
+              onEditBreakout={onEditBreakout}
+            />
+          </StyledDebouncedFrame>
+        )}
 
         {ModeFooter && (
           <ModeFooter {...this.props} className="flex-no-shrink" />

--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 import { Motion, spring } from "react-motion";
+import _ from "underscore";
 
 import ExplicitSize from "metabase/components/ExplicitSize";
 import Popover from "metabase/components/Popover";
@@ -283,6 +284,8 @@ export default class View extends React.Component {
     const isStructured = query instanceof StructuredQuery;
     const isNative = query instanceof NativeQuery;
 
+    const validationError = _.first(query.validate?.());
+
     const topQuery = isStructured && query.topLevelQuery();
 
     // only allow editing of series for structured queries
@@ -329,6 +332,7 @@ export default class View extends React.Component {
             onEditSeries={onEditSeries}
             onRemoveSeries={onRemoveSeries}
             onEditBreakout={onEditBreakout}
+            validationError={validationError}
           />
         </StyledDebouncedFrame>
 

--- a/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
@@ -977,6 +977,12 @@ describe("Dimension", () => {
           });
         });
 
+        describe("isValidDimensionType", () => {
+          it("should evaluate to true", () => {
+            expect(dimension.isValidDimensionType()).toBe(true);
+          });
+        });
+
         describe("isVariableType", () => {
           it("should evaluate to false", () => {
             expect(dimension.isVariableType()).toBe(false);
@@ -1181,6 +1187,72 @@ describe("Dimension", () => {
         describe("icon", () => {
           it("should return the icon associated with the underlying field", () => {
             expect(dimension.icon()).toEqual("string");
+          });
+        });
+      });
+    });
+
+    describe("broken dimension tag", () => {
+      const templateTagClause = ["template-tag", "foo"];
+      const query = new NativeQuery(PRODUCTS.question(), {
+        database: SAMPLE_DATABASE.id,
+        type: "native",
+        native: {
+          query: "select * from PRODUCTS where {{foo}}",
+          "template-tags": {
+            foo: {
+              id: "5928ca74-ca36-8706-7bed-0143d7646b6a",
+              name: "foo",
+              "display-name": "Foo",
+              type: "dimension",
+              "widget-type": "category",
+              // this should be defined
+              dimension: null,
+            },
+          },
+        },
+      });
+
+      const brokenDimension = Dimension.parseMBQL(
+        templateTagClause,
+        metadata,
+        query,
+      );
+
+      describe("instance methods", () => {
+        describe("isDimensionType", () => {
+          it("should evaluate to true", () => {
+            expect(brokenDimension.isDimensionType()).toBe(true);
+          });
+        });
+
+        describe("isValidDimensionType", () => {
+          it("should return false", () => {
+            expect(brokenDimension.isValidDimensionType()).toBe(false);
+          });
+        });
+
+        describe("isVariableType", () => {
+          it("should evaluate to false", () => {
+            expect(brokenDimension.isVariableType()).toBe(false);
+          });
+        });
+
+        describe("field", () => {
+          it("should evaluate to null", () => {
+            expect(brokenDimension.field()).toBeNull();
+          });
+        });
+
+        describe("name", () => {
+          it("should evaluate to the tag's name instead of the field's", () => {
+            expect(brokenDimension.name()).toEqual("foo");
+          });
+        });
+
+        describe("icon", () => {
+          it("should use a fallback icon", () => {
+            expect(brokenDimension.icon()).toEqual("label");
           });
         });
       });

--- a/frontend/test/metabase-lib/lib/queries/NativeQuery.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/NativeQuery.unit.spec.js
@@ -205,6 +205,7 @@ describe("NativeQuery", () => {
 
         q = q.setDatasetQuery(
           assocIn(q.datasetQuery(), ["native", "template-tags", "foo"], {
+            name: "foo",
             type: "dimension",
             "widget-type": "category",
             dimension: ["field", 123, null],


### PR DESCRIPTION
Resolves #20865 

Apparently there's a way for the `dimension` property of a `type: "dimension"` template tag to be undefined. It breaks the QB and leaves the loading state up. The query itself needs to be fixed by the user before we can do anything, so I'm introducing a new way to validate queries.

I added a `validate` method to `NativeQuery` that will return a list of errors. I've extended the `Error` class so that we can have `ValidationErrors` with an associated `type` string. `metabase-lib` obviously doesn't know anything about our UI code, so I needed a way to connect an instance of `ValidationError` to a specific error state -- the `type` string is what I'm using to do this. 

The `QueryValidationError` shows the `message` on the `ValidationError` and not much else; the real action happens in `ErrorActionButton`, which I've connected to redux state so that we can look at the specific type of error and then put a button on the screen that directs the user where to go to fix the error. In this specific case, the button opens the variable sidebar, but I suppose it could really do anything. It doesn't even need to be a button, necessarily. This opens up a lot of options for our error UI code beyond showing some static message.

**Testing**
Forcing the broken template tag state requires some fiddling with the dev console. Here's me doing it:

https://user-images.githubusercontent.com/13057258/157134171-9831c625-0dc4-4983-a967-306fddbd6dc5.mov

Here's what the fix looks like:

https://user-images.githubusercontent.com/13057258/158914180-53d8d301-9171-46d4-a3b1-65de107947d2.mov





