### PR TITLE
docs - fixing glossary links

### DIFF
--- a/docs/administration-guide/data-permissions.md
+++ b/docs/administration-guide/data-permissions.md
@@ -56,10 +56,9 @@ Only available in paid plans, Sandboxed access to a table can restrict access to
 
 ## Permissions and dashboard subscriptions
 
-You don't explicitly set permissions on [dashboards subscriptions][dashboard-subscriptions], as the subscriptions are a feature of a dashboard. Which means that What you can do j
+You don't explicitly set permissions on [dashboards subscriptions][dashboard-subscriptions], as the subscriptions are a feature of a dashboard. If a person is in a group that has __Curate access__ to the collection containing the dashboard, they can view and edit all subscriptions for the dashboard, including subscriptions created by other people.
 
-If a person is in a group that has __Curate access__ to the collection containing the dashboard, they can view and edit all subscriptions for the dashboard, including subscriptions created by other people.
-If a group has read-only access to a dashboard (based on its collection permissions), they can view all subscriptions for that dashboard. They can also create subscriptions and edit ones that they’ve created, but they can’t edit ones that other users created. (That last point is enforced by the BE only, the FE still needs to be updated to show the subscriptions as read-only.)
+If a group has __read-only access__ to a dashboard (based on its collection permissions), they can view all subscriptions for that dashboard. They can also create subscriptions and edit ones that they’ve created, but they can’t edit ones that other users created. (That last point is enforced by the BE only, the FE still needs to be updated to show the subscriptions as read-only.)
 If a group has no access to a dashboard, they can’t view any of its subscriptions, including ones that they may have created in the past, prior to having access revoked.
 
 If you have read-only access to a dashboard, you can also unsubscribe yourself from a subscription that somebody else created via the new page in account settings.

--- a/docs/setting-up-metabase.md
+++ b/docs/setting-up-metabase.md
@@ -15,7 +15,7 @@ For now, let's just create an account for ourselves to explore Metabase. Type in
 ![Account Setup](images/AccountSetup.png)
 
 ## Gathering your database info
-At this point you’ll need to gather some information about the database you want to use with Metabase. We won’t be able to connect to your database without it, but you’d like to deal with all of this later, that’s okay: just click **I’ll add my data later**. Metabase comes with a [Sample Database](/glossary.html#sample_database) that you can play around with to get a feel for how Metabase works.
+At this point you’ll need to gather some information about the database you want to use with Metabase. We won’t be able to connect to your database without it, but you’d like to deal with all of this later, that’s okay: just click **I’ll add my data later**. Metabase comes with a [Sample Database](/glossary/sample_database) that you can play around with to get a feel for how Metabase works.
 
 If you’re ready to connect, here’s what you’ll need:
 

--- a/docs/troubleshooting-guide/filters.md
+++ b/docs/troubleshooting-guide/filters.md
@@ -57,8 +57,8 @@ If a filter that used to work no longer seems to, or seems to eliminate all of t
 3. Modify the question to match the current database schema.
 
 [field-filter]: /learn/sql-questions/field-filters.html
-[filter-widget-gloss]: /glossary.html#filter_widget
-[linked-filter-gloss]: /glossary.html#linked_filter
+[filter-widget-gloss]: /glossary/filter_widget
+[linked-filter-gloss]: /glossary/linked_filter
 [sql-variable]: /learn/sql-questions/sql-variables.html
 [sync-scan]: ./sync-fingerprint-scan.html
 [troubleshoot-linked-filters]: ./linked-filters.html

--- a/docs/troubleshooting-guide/linked-filters.md
+++ b/docs/troubleshooting-guide/linked-filters.md
@@ -53,8 +53,8 @@ If you are having problems with a regular [filter widget][filter-widget-gloss], 
 
 1. Check that Metabase's data model for your database includes the foreign key relationship.
 
-[filter-widget-gloss]: /glossary.html#filter_widget
-[foreign-key-gloss]: /glossary.html#foreign_key
+[filter-widget-gloss]: /glossary/filter_widget
+[foreign-key-gloss]: /glossary/foreign_key
 [join-types]: /learn/sql-questions/sql-join-types.html
 [learn-linking]: /learn/dashboards/linking-filters.html
-[linked-filter-gloss]: /glossary.html#linked_filter
+[linked-filter-gloss]: /glossary/linked_filter

--- a/docs/troubleshooting-guide/sandboxing.md
+++ b/docs/troubleshooting-guide/sandboxing.md
@@ -162,7 +162,6 @@ The administrator can [create a new group][groups] to capture precisely who's al
 [groups]: ../administration-guide/05-setting-permissions.html#groups
 [jwt-auth]: ../enterprise-guide/authenticating-with-jwt.html
 [permissions]: /learn/permissions/data-permissions.html
-[prepared-statement]: /glossary.html#prepared_statement
 [public-sharing]: ../administration-guide/12-public-links.html
 [row-permissions]: /learn/permissions/data-sandboxing-row-permissions.html
 [sandboxing-your-data]: ../enterprise-guide/data-sandboxes.html

--- a/docs/troubleshooting-guide/sync-fingerprint-scan.md
+++ b/docs/troubleshooting-guide/sync-fingerprint-scan.md
@@ -81,7 +81,7 @@ You can "fix" this by disabling scan entirely by going to the database in the Ad
 [api-learn]: /learn/administration/metabase-api.html
 [bugs]: ./bugs.html
 [community-db-drivers]: ../developers-guide-drivers.html
-[etl]: /glossary.html#etl
+[etl]: /glossary/etl
 [metabase-api]: ../api-documentation.html
 [metabase-mongo-missing]: ../administration-guide/databases/mongodb.html#i-added-fields-to-my-database-but-dont-see-them-in-metabase
 [sync-frequency]: ../administration-guide/01-managing-databases.html#choose-when-metabase-syncs-and-scans

--- a/docs/users-guide/06-sharing-answers.md
+++ b/docs/users-guide/06-sharing-answers.md
@@ -6,7 +6,7 @@ Whenever you’ve arrived at an answer that you want to save for later, click th
 
 ![Save button](images/sharing-answers/save-button.png)
 
-A pop-up box will appear, prompting you to give your question a name and description, and to pick which [collection](#collection) to save it in. Note that your administrator might have set things up so that you're only allowed to [save questions in certain collection][collection-permissions], but you can always save things in your Personal Collection. After saving your question, you'll be asked if you want to add it to a new or existing dashboard.
+A pop-up box will appear, prompting you to give your question a name and description, and to pick which [collection][collections] to save it in. Note that your administrator might have set things up so that you're only allowed to [save questions in certain collection][collection-permissions], but you can always save things in your Personal Collection. After saving your question, you'll be asked if you want to add it to a new or existing dashboard.
 
 Now, whenever you want to refer to your question again you can find it by searching for it in the search bar at the top of Metabase, or by navigating to the collection where you saved it.
 
@@ -80,6 +80,6 @@ Next, we'll learn about how to organize our questions in [collections][collectio
 [archiving-items]: collections.html#archiving-items
 [caching]: ../administration-guide/14-caching.md
 [collections]: collections.html
-[collection-permissions]: collections.md#collection-permissions
+[collection-permissions]: ../administration-guide/06-collections.md
 [dashboards]: 07-dashboards.md
 [model]: models.md


### PR DESCRIPTION
Fixes broken links due to glossary update and incomplete sentence in data permissions doc