### PR TITLE
Fix x-axis granularity for time series in static viz

### DIFF
--- a/frontend/src/metabase/static-viz/components/TimeSeriesAreaChart/TimeSeriesAreaChart.jsx
+++ b/frontend/src/metabase/static-viz/components/TimeSeriesAreaChart/TimeSeriesAreaChart.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { scaleLinear, scaleTime } from "@visx/scale";
+import { scaleLinear, scaleBand } from "@visx/scale";
 import { GridRows } from "@visx/grid";
 import { AxisBottom, AxisLeft } from "@visx/axis";
 import { AreaClosed, LinePath } from "@visx/shape";
@@ -71,12 +71,10 @@ const TimeSeriesAreaChart = ({ data, accessors, settings, labels }) => {
   const bottomLabel = labels?.bottom;
   const palette = { ...layout.colors, ...colors };
 
-  const xScale = scaleTime({
-    domain: [
-      Math.min(...data.map(accessors.x)),
-      Math.max(...data.map(accessors.x)),
-    ],
+  const xScale = scaleBand({
+    domain: data.map(accessors.x),
     range: [xMin, xMax],
+    round: true,
   });
 
   const yScale = scaleLinear({
@@ -98,14 +96,14 @@ const TimeSeriesAreaChart = ({ data, accessors, settings, labels }) => {
         yScale={yScale}
         fill={palette.brand}
         opacity={layout.areaOpacity}
-        x={d => xScale(accessors.x(d))}
+        x={d => xScale(accessors.x(d)) + xScale.bandwidth() / 2}
         y={d => yScale(accessors.y(d))}
       />
       <LinePath
         data={data}
         stroke={palette.brand}
         strokeWidth={layout.strokeWidth}
-        x={d => xScale(accessors.x(d))}
+        x={d => xScale(accessors.x(d)) + xScale.bandwidth() / 2}
         y={d => yScale(accessors.y(d))}
       />
       <AxisLeft

--- a/frontend/src/metabase/static-viz/components/TimeSeriesLineChart/TimeSeriesLineChart.jsx
+++ b/frontend/src/metabase/static-viz/components/TimeSeriesLineChart/TimeSeriesLineChart.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { scaleLinear, scaleTime } from "@visx/scale";
+import { scaleLinear, scaleBand } from "@visx/scale";
 import { GridRows } from "@visx/grid";
 import { AxisBottom, AxisLeft } from "@visx/axis";
 import { LinePath } from "@visx/shape";
@@ -69,12 +69,10 @@ const TimeSeriesLineChart = ({ data, accessors, settings, labels }) => {
   const bottomLabel = labels?.bottom;
   const palette = { ...layout.colors, ...colors };
 
-  const xScale = scaleTime({
-    domain: [
-      Math.min(...data.map(accessors.x)),
-      Math.max(...data.map(accessors.x)),
-    ],
+  const xScale = scaleBand({
+    domain: data.map(accessors.x),
     range: [xMin, xMax],
+    round: true,
   });
 
   const yScale = scaleLinear({
@@ -95,7 +93,7 @@ const TimeSeriesLineChart = ({ data, accessors, settings, labels }) => {
         data={data}
         stroke={palette.brand}
         strokeWidth={layout.strokeWidth}
-        x={d => xScale(accessors.x(d))}
+        x={d => xScale(accessors.x(d)) + xScale.bandwidth() / 2}
         y={d => yScale(accessors.y(d))}
       />
       <AxisLeft


### PR DESCRIPTION
`TimeSeriesLineChart` and `TimeSeriesAreaChart` are updated to use `scaleBand` rather than `scaleTime` from `@visx/scale`.
These changes make the line and area charts visually closer to the ones in __Metabase__.

# Line

__Metabase__
![image](https://user-images.githubusercontent.com/348552/157438937-c3867797-5a10-4a79-ad9f-a32e3846caf1.png)

__Before__
![image](https://user-images.githubusercontent.com/348552/157438844-a25476b8-f657-444b-b985-a95ea6a2d96f.png)

__After__
![image](https://user-images.githubusercontent.com/348552/157439114-87dcf893-6be0-4e2f-8daf-438bf494cd7b.png)

# Area

__Metabase__
![image](https://user-images.githubusercontent.com/348552/157439320-64bc7c59-5944-4c85-8be4-84c0aea633c5.png)

__Before__
![image](https://user-images.githubusercontent.com/348552/157440115-bdbb5053-6574-4508-be00-ba8434dbfd70.png)

__After__
![image](https://user-images.githubusercontent.com/348552/157440189-e09689d2-9585-4c89-bdff-35198d055603.png)
