### PR TITLE
Disable `auditing` e2e CI group

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1246,7 +1246,6 @@ workflows:
               folder:
                 [
                   "admin",
-                  "auditing",
                   "binning",
                   "collections",
                   "custom-column",

--- a/frontend/test/metabase/scenarios/auditing/README.md
+++ b/frontend/test/metabase/scenarios/auditing/README.md
@@ -1,0 +1,6 @@
+# IMPORTANT:
+We are not running these tests in CI!
+
+You can still run them locally using the following command:
+
+`yarn test-cypress-no-build --folder auditing`


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Removes the `auditing` tests from the CI
- As explained in https://github.com/metabase/metabase/issues/20792, we tried to dissect and understand some of the most stubborn failures
- After separating `auditing` from `admin` test group, it is clear that the issue with locking the H2 database is affecting auditing tests. Therefore, we're temporarily removing them from the CI until the underlying issue gets solved.