### PR TITLE
Show timeline events in charts

### DIFF
--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -81,6 +81,7 @@ import { getPersistableDefaultSettingsForSeries } from "metabase/visualizations/
 import Databases from "metabase/entities/databases";
 import Questions from "metabase/entities/questions";
 import Snippets from "metabase/entities/snippets";
+import Timelines from "metabase/entities/timelines";
 
 import { getMetadata } from "metabase/selectors/metadata";
 import { setRequestUnloaded } from "metabase/redux/requests";
@@ -799,6 +800,10 @@ export const loadMetadataForCard = card => (dispatch, getState) => {
     queries.push(question.composeDataset().query());
   }
   return dispatch(loadMetadataForQueries(queries));
+};
+
+export const loadTimelinesForCard = card => dispatch => {
+  dispatch(Timelines.actions.fetchList({ cardId: card.id, include: "events" }));
 };
 
 function hasNewColumns(question, queryResult) {

--- a/frontend/src/metabase/query_builder/components/VisualizationResult.jsx
+++ b/frontend/src/metabase/query_builder/components/VisualizationResult.jsx
@@ -40,7 +40,7 @@ export default class VisualizationResult extends Component {
       navigateToNewCardInsideQB,
       result,
       rawSeries,
-      timelines,
+      timelineEvents,
       className,
     } = this.props;
     const { showCreateAlertModal } = this.state;
@@ -101,7 +101,7 @@ export default class VisualizationResult extends Component {
           queryBuilderMode={queryBuilderMode}
           showTitle={false}
           metadata={question.metadata()}
-          timelines={timelines}
+          timelineEvents={timelineEvents}
           handleVisualizationClick={this.props.handleVisualizationClick}
           onOpenChartSettings={this.props.onOpenChartSettings}
           onUpdateWarnings={this.props.onUpdateWarnings}

--- a/frontend/src/metabase/query_builder/components/VisualizationResult.jsx
+++ b/frontend/src/metabase/query_builder/components/VisualizationResult.jsx
@@ -40,6 +40,7 @@ export default class VisualizationResult extends Component {
       navigateToNewCardInsideQB,
       result,
       rawSeries,
+      timelines,
       className,
     } = this.props;
     const { showCreateAlertModal } = this.state;
@@ -100,6 +101,7 @@ export default class VisualizationResult extends Component {
           queryBuilderMode={queryBuilderMode}
           showTitle={false}
           metadata={question.metadata()}
+          timelines={timelines}
           handleVisualizationClick={this.props.handleVisualizationClick}
           onOpenChartSettings={this.props.onOpenChartSettings}
           onUpdateWarnings={this.props.onUpdateWarnings}

--- a/frontend/src/metabase/query_builder/components/VisualizationResult.jsx
+++ b/frontend/src/metabase/query_builder/components/VisualizationResult.jsx
@@ -103,6 +103,7 @@ export default class VisualizationResult extends Component {
           metadata={question.metadata()}
           timelineEvents={timelineEvents}
           handleVisualizationClick={this.props.handleVisualizationClick}
+          onOpenTimelines={this.props.onOpenTimelines}
           onOpenChartSettings={this.props.onOpenChartSettings}
           onUpdateWarnings={this.props.onUpdateWarnings}
           onUpdateVisualizationSettings={

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
@@ -64,6 +64,7 @@ import {
   getNativeEditorSelectedText,
   getIsBookmarked,
   getTimelineVisibility,
+  getVisibleTimelines,
 } from "../selectors";
 import * as actions from "../actions";
 
@@ -106,6 +107,7 @@ const mapStateToProps = (state, props) => {
 
     query: getQuery(state),
     metadata: getMetadata(state),
+    timelines: getVisibleTimelines(state),
     timelineVisibility: getTimelineVisibility(state),
 
     result: getFirstQueryResult(state),
@@ -178,6 +180,7 @@ function QueryBuilder(props) {
     cancelQuery,
     createBookmark,
     deleteBookmark,
+    loadTimelinesForCard,
   } = props;
 
   const forceUpdate = useForceUpdate();
@@ -266,6 +269,12 @@ function QueryBuilder(props) {
     closeModal();
     clearTimeout(timeout.current);
   });
+
+  useEffect(() => {
+    if (question && question.hasBreakoutByDateTime()) {
+      loadTimelinesForCard(question.card());
+    }
+  }, [question, loadTimelinesForCard]);
 
   useEffect(() => {
     const { isShowingDataReference, isShowingTemplateTagsEditor } = uiControls;

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
@@ -65,6 +65,7 @@ import {
   getIsBookmarked,
   getTimelineVisibility,
   getVisibleTimelines,
+  getVisibleTimelineEvents,
 } from "../selectors";
 import * as actions from "../actions";
 
@@ -107,7 +108,9 @@ const mapStateToProps = (state, props) => {
 
     query: getQuery(state),
     metadata: getMetadata(state),
+
     timelines: getVisibleTimelines(state),
+    timelineEvents: getVisibleTimelineEvents(state),
     timelineVisibility: getTimelineVisibility(state),
 
     result: getFirstQueryResult(state),

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -22,6 +22,7 @@ import NativeQuery from "metabase-lib/lib/queries/NativeQuery";
 import { isAdHocModelQuestion } from "metabase/lib/data-modeling/utils";
 
 import Databases from "metabase/entities/databases";
+import Timelines from "metabase/entities/timelines";
 
 import { getMetadata } from "metabase/selectors/metadata";
 import { getAlerts } from "metabase/alert/selectors";
@@ -279,6 +280,29 @@ export const getQuestion = createSelector(
     return question.isDataset() && hasDataPermission
       ? question.composeDataset()
       : question;
+  },
+);
+
+export const getTimelines = createSelector(
+  [state => state, getQuestion],
+  (state, question) => {
+    if (question) {
+      const entityQuery = { cardId: question.id(), include: "events" };
+      return Timelines.selectors.getList(state, { entityQuery }) ?? [];
+    } else {
+      return [];
+    }
+  },
+);
+
+export const getVisibleTimelines = createSelector(
+  [getQuestion, getTimelines, getTimelineVisibility],
+  (question, timelines, visibility) => {
+    if (question) {
+      return timelines.filter(t => visibility[t.id] ?? question.isSaved());
+    } else {
+      return [];
+    }
   },
 );
 

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -48,6 +48,7 @@ export const getParameterValues = state => state.qb.parameterValues;
 
 export const getMetadataDiff = state => state.qb.metadataDiff;
 
+export const getEntities = state => state.entities;
 export const getTimelineVisibility = state => state.qb.timelineVisibility;
 
 const getRawQueryResults = state => state.qb.queryResults;
@@ -284,11 +285,11 @@ export const getQuestion = createSelector(
 );
 
 export const getTimelines = createSelector(
-  [state => state, getQuestion],
-  (state, question) => {
+  [getEntities, getQuestion],
+  (entities, question) => {
     if (question) {
       const entityQuery = { cardId: question.id(), include: "events" };
-      return Timelines.selectors.getList(state, { entityQuery }) ?? [];
+      return Timelines.selectors.getList({ entities }, { entityQuery }) ?? [];
     } else {
       return [];
     }

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -313,7 +313,7 @@ export const getVisibleTimelineEvents = createSelector(
     return timelines
       .flatMap(timeline => timeline.events)
       .filter(event => !event.archived)
-      .map(event => updateIn(event, "timestamp", parseTimestamp));
+      .map(event => updateIn(event, ["timestamp"], parseTimestamp));
   },
 );
 

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -311,7 +311,7 @@ export const getVisibleTimelineEvents = createSelector(
   [getVisibleTimelines],
   timelines => {
     return timelines
-      .flatMap(timeline => timeline.events)
+      .flatMap(timeline => timeline.events ?? [])
       .filter(event => !event.archived)
       .map(event => updateIn(event, ["timestamp"], parseTimestamp));
   },

--- a/frontend/src/metabase/visualizations/components/LineAreaBarChart.css
+++ b/frontend/src/metabase/visualizations/components/LineAreaBarChart.css
@@ -274,6 +274,7 @@ text.value-label-white {
   stroke: var(--color-brand);
   stroke-width: 2;
   opacity: 0.2;
+  pointer-events: none;
 }
 
 .dc-chart .event-line.hover {

--- a/frontend/src/metabase/visualizations/components/LineAreaBarChart.css
+++ b/frontend/src/metabase/visualizations/components/LineAreaBarChart.css
@@ -245,3 +245,37 @@ text.value-label-white {
   fill: var(--color-text-white);
   font-weight: 800;
 }
+
+/* timeline events */
+
+.dc-chart .events-axis .event-tick {
+  cursor: pointer;
+}
+
+.dc-chart .events-axis .event-tick .event-icon {
+  stroke: var(--color-text-light);
+  fill: var(--color-text-light);
+}
+
+.dc-chart .events-axis .event-tick.hover .event-icon {
+  stroke: var(--color-brand);
+  fill: var(--color-brand);
+}
+
+.dc-chart .events-axis .event-tick text {
+  fill: var(--color-text-light);
+}
+
+.dc-chart .events-axis .event-tick.hover text {
+  fill: var(--color-brand);
+}
+
+.dc-chart .event-line {
+  stroke: var(--color-brand);
+  stroke-width: 2;
+  opacity: 0.2;
+}
+
+.dc-chart .event-line.hover {
+  opacity: 1;
+}

--- a/frontend/src/metabase/visualizations/components/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization.jsx
@@ -82,7 +82,7 @@ export default class Visualization extends React.PureComponent {
     if (
       !isSameSeries(newProps.rawSeries, this.props.rawSeries) ||
       !Utils.equals(newProps.settings, this.props.settings) ||
-      newProps.timelines !== this.props.timelines
+      newProps.timelineEvents !== this.props.timelineEvents
     ) {
       this.transform(newProps);
     }

--- a/frontend/src/metabase/visualizations/components/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization.jsx
@@ -82,7 +82,7 @@ export default class Visualization extends React.PureComponent {
     if (
       !isSameSeries(newProps.rawSeries, this.props.rawSeries) ||
       !Utils.equals(newProps.settings, this.props.settings) ||
-      newProps.timelineEvents !== this.props.timelineEvents
+      !Utils.equals(newProps.timelineEvents, this.props.timelineEvents)
     ) {
       this.transform(newProps);
     }

--- a/frontend/src/metabase/visualizations/components/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization.jsx
@@ -81,7 +81,8 @@ export default class Visualization extends React.PureComponent {
   UNSAFE_componentWillReceiveProps(newProps) {
     if (
       !isSameSeries(newProps.rawSeries, this.props.rawSeries) ||
-      !Utils.equals(newProps.settings, this.props.settings)
+      !Utils.equals(newProps.settings, this.props.settings) ||
+      newProps.timelines !== this.props.timelines
     ) {
       this.transform(newProps);
     }

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
@@ -388,7 +388,7 @@ function onRenderSetZeroGridLineClassName(chart) {
     .attr("class", "zero");
 }
 
-function onRenderAddEvents(
+function onRenderAddTimelineEvents(
   chart,
   { timelineEvents, xDomain, xInterval, isTimeseries, onOpenTimelines },
 ) {
@@ -436,7 +436,7 @@ function onRender(
   onRenderRotateAxis(chart);
   onRenderAddExtraClickHandlers(chart);
   onRenderSetZeroGridLineClassName(chart);
-  onRenderAddEvents(chart, {
+  onRenderAddTimelineEvents(chart, {
     timelineEvents,
     xDomain,
     xInterval,

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
@@ -390,9 +390,7 @@ function onRenderSetZeroGridLineClassName(chart) {
 function onRenderAddEvents(
   chart,
   { timelines, xDomain, xInterval, isTimeseries, onHoverChange },
-) {
-  console.log(timelines);
-}
+) {}
 
 // the various steps that get called
 function onRender(

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
@@ -387,10 +387,12 @@ function onRenderSetZeroGridLineClassName(chart) {
     .attr("class", "zero");
 }
 
-function onRenderAddEvents(
+function onRenderAddTimelineEvents(
   chart,
   { timelines, xDomain, xInterval, isTimeseries, onHoverChange },
-) {}
+) {
+  // TODO (ranquild): render timeline events
+}
 
 // the various steps that get called
 function onRender(
@@ -427,7 +429,7 @@ function onRender(
   onRenderRotateAxis(chart);
   onRenderAddExtraClickHandlers(chart);
   onRenderSetZeroGridLineClassName(chart);
-  onRenderAddEvents(chart, {
+  onRenderAddTimelineEvents(chart, {
     timelines,
     xDomain,
     xInterval,

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
@@ -390,9 +390,15 @@ function onRenderSetZeroGridLineClassName(chart) {
 
 function onRenderAddEvents(
   chart,
-  { timelineEvents, xDomain, xInterval, isTimeseries },
+  { timelineEvents, xDomain, xInterval, isTimeseries, onOpenTimelines },
 ) {
-  renderEvents(chart, { timelineEvents, xDomain, xInterval, isTimeseries });
+  renderEvents(chart, {
+    timelineEvents,
+    xDomain,
+    xInterval,
+    isTimeseries,
+    onOpenTimelines,
+  });
 }
 
 // the various steps that get called
@@ -409,7 +415,7 @@ function onRender(
     isTimeseries,
     formatYValue,
     onGoalHover,
-    onHoverChange,
+    onOpenTimelines,
   },
 ) {
   onRenderRemoveClipPath(chart);
@@ -435,7 +441,7 @@ function onRender(
     xDomain,
     xInterval,
     isTimeseries,
-    onHoverChange,
+    onOpenTimelines,
   });
 }
 

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
@@ -5,6 +5,7 @@ import { color } from "metabase/lib/colors";
 import { clipPathReference, moveToFront } from "metabase/lib/dom";
 import { adjustYAxisTicksIfNeeded } from "./apply_axis";
 import { onRenderValueLabels } from "./chart_values";
+import { renderEvents } from "./timelines";
 
 const X_LABEL_MIN_SPACING = 2; // minimum space we want to leave between labels
 const X_LABEL_ROTATE_90_THRESHOLD = 24; // tick width breakpoint for switching from 45° to 90°
@@ -389,9 +390,9 @@ function onRenderSetZeroGridLineClassName(chart) {
 
 function onRenderAddTimelineEvents(
   chart,
-  { timelines, xDomain, xInterval, isTimeseries, onHoverChange },
+  { timelines, xDomain, xInterval, isTimeseries },
 ) {
-  // TODO render timeline events
+  renderEvents(chart, { timelines, xDomain, xInterval, isTimeseries });
 }
 
 // the various steps that get called

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
@@ -388,7 +388,7 @@ function onRenderSetZeroGridLineClassName(chart) {
     .attr("class", "zero");
 }
 
-function onRenderAddTimelineEvents(
+function onRenderAddEvents(
   chart,
   { timelines, xDomain, xInterval, isTimeseries },
 ) {
@@ -430,7 +430,7 @@ function onRender(
   onRenderRotateAxis(chart);
   onRenderAddExtraClickHandlers(chart);
   onRenderSetZeroGridLineClassName(chart);
-  onRenderAddTimelineEvents(chart, {
+  onRenderAddEvents(chart, {
     timelines,
     xDomain,
     xInterval,
@@ -603,7 +603,7 @@ function beforeRenderComputeXAxisLabelType(chart) {
   }
 }
 
-function beforeRenderFixMargins(chart, { timelines, xDomain, isTimeseries }) {
+function beforeRenderFixMargins(chart, args) {
   // run before adjusting margins
   const mins = computeMinHorizontalMargins(chart);
   const xAxisMargin = computeXAxisMargin(chart);
@@ -651,7 +651,7 @@ function beforeRenderFixMargins(chart, { timelines, xDomain, isTimeseries }) {
     mins.right,
   );
 
-  const minBottomMargin = hasEventAxis(chart, timelines, xDomain, isTimeseries)
+  const minBottomMargin = hasEventAxis(chart, args)
     ? MARGIN_BOTTOM_MIN_WITH_EVENT_AXIS
     : MARGIN_BOTTOM_MIN;
   chart.margins().bottom = Math.max(minBottomMargin, chart.margins().bottom);

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
@@ -387,17 +387,28 @@ function onRenderSetZeroGridLineClassName(chart) {
     .attr("class", "zero");
 }
 
+function onRenderAddEvents(
+  chart,
+  { timelines, xDomain, xInterval, isTimeseries, onHoverChange },
+) {
+  console.log(timelines);
+}
+
 // the various steps that get called
 function onRender(
   chart,
   {
-    onGoalHover,
+    datas,
+    timelines,
     isSplitAxis,
+    xDomain,
     xInterval,
     yAxisSplit,
     isStacked,
+    isTimeseries,
     formatYValue,
-    datas,
+    onGoalHover,
+    onHoverChange,
   },
 ) {
   onRenderRemoveClipPath(chart);
@@ -418,6 +429,13 @@ function onRender(
   onRenderRotateAxis(chart);
   onRenderAddExtraClickHandlers(chart);
   onRenderSetZeroGridLineClassName(chart);
+  onRenderAddEvents(chart, {
+    timelines,
+    xDomain,
+    xInterval,
+    isTimeseries,
+    onHoverChange,
+  });
 }
 
 // +-------------------------------------------------------------------------------------------------------------------+

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
@@ -390,9 +390,9 @@ function onRenderSetZeroGridLineClassName(chart) {
 
 function onRenderAddEvents(
   chart,
-  { timelines, xDomain, xInterval, isTimeseries },
+  { timelineEvents, xDomain, xInterval, isTimeseries },
 ) {
-  renderEvents(chart, { timelines, xDomain, xInterval, isTimeseries });
+  renderEvents(chart, { timelineEvents, xDomain, xInterval, isTimeseries });
 }
 
 // the various steps that get called
@@ -400,7 +400,7 @@ function onRender(
   chart,
   {
     datas,
-    timelines,
+    timelineEvents,
     isSplitAxis,
     xDomain,
     xInterval,
@@ -431,7 +431,7 @@ function onRender(
   onRenderAddExtraClickHandlers(chart);
   onRenderSetZeroGridLineClassName(chart);
   onRenderAddEvents(chart, {
-    timelines,
+    timelineEvents,
     xDomain,
     xInterval,
     isTimeseries,
@@ -658,10 +658,10 @@ function beforeRenderFixMargins(chart, args) {
 }
 
 // collection of function calls that get made *before* we tell the Chart to render
-function beforeRender(chart, { timelines, xDomain, isTimeseries }) {
+function beforeRender(chart, { timelineEvents, xDomain, isTimeseries }) {
   beforeRenderComputeXAxisLabelType(chart);
   beforeRenderHideDisabledAxesAndLabels(chart);
-  beforeRenderFixMargins(chart, { timelines, xDomain, isTimeseries });
+  beforeRenderFixMargins(chart, { timelineEvents, xDomain, isTimeseries });
 }
 
 // +-------------------------------------------------------------------------------------------------------------------+

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
@@ -391,7 +391,7 @@ function onRenderAddTimelineEvents(
   chart,
   { timelines, xDomain, xInterval, isTimeseries, onHoverChange },
 ) {
-  // TODO (ranquild): render timeline events
+  // TODO render timeline events
 }
 
 // the various steps that get called

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -815,7 +815,7 @@ export default function lineAreaBar(element, props) {
     isScalarSeries,
     settings,
     series,
-    timelines,
+    timelineEvents,
     onRender,
     onHoverChange,
   } = props;
@@ -922,7 +922,7 @@ export default function lineAreaBar(element, props) {
   // apply any on-rendering functions (this code lives in `LineAreaBarPostRenderer`)
   lineAndBarOnRender(parent, {
     datas,
-    timelines,
+    timelineEvents,
     isSplitAxis: yAxisProps.isSplit,
     yAxisSplit: yAxisProps.yAxisSplit,
     xDomain: xAxisProps.xDomain,

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -728,9 +728,9 @@ function addTrendlineChart(
   }
 }
 
-function applyXAxisSettings(parent, series, xAxisProps) {
+function applyXAxisSettings(parent, series, xAxisProps, timelineEvents) {
   if (isTimeseries(parent.settings)) {
-    applyChartTimeseriesXAxis(parent, series, xAxisProps);
+    applyChartTimeseriesXAxis(parent, series, xAxisProps, timelineEvents);
   } else if (isQuantitative(parent.settings)) {
     applyChartQuantitativeXAxis(parent, series, xAxisProps);
   } else {
@@ -904,7 +904,7 @@ export default function lineAreaBar(element, props) {
     parent._rangeBandPadding(hasBar ? BAR_PADDING_RATIO : 1);
   }
 
-  applyXAxisSettings(parent, props.series, xAxisProps);
+  applyXAxisSettings(parent, props.series, xAxisProps, timelineEvents);
 
   applyYAxisSettings(parent, yAxisProps);
 

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -818,6 +818,7 @@ export default function lineAreaBar(element, props) {
     timelineEvents,
     onRender,
     onHoverChange,
+    onOpenTimelines,
   } = props;
 
   const warnings = {};
@@ -932,6 +933,7 @@ export default function lineAreaBar(element, props) {
     formatYValue: getYValueFormatter(parent, series, yAxisProps.yExtent),
     onGoalHover,
     onHoverChange,
+    onOpenTimelines,
   });
 
   // only ordinal axis can display "null" values

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -811,7 +811,14 @@ function doHistogramBarStuff(parent) {
 /************************************************************ PUTTING IT ALL TOGETHER ************************************************************/
 
 export default function lineAreaBar(element, props) {
-  const { onRender, isScalarSeries, settings, series } = props;
+  const {
+    isScalarSeries,
+    settings,
+    series,
+    timelines,
+    onRender,
+    onHoverChange,
+  } = props;
 
   const warnings = {};
   // `text` is displayed to users, but we deduplicate based on `key`
@@ -914,13 +921,17 @@ export default function lineAreaBar(element, props) {
 
   // apply any on-rendering functions (this code lives in `LineAreaBarPostRenderer`)
   lineAndBarOnRender(parent, {
-    onGoalHover,
+    datas,
+    timelines,
     isSplitAxis: yAxisProps.isSplit,
     yAxisSplit: yAxisProps.yAxisSplit,
+    xDomain: xAxisProps.xDomain,
     xInterval: xAxisProps.xInterval,
     isStacked: isStacked(parent.settings, datas),
+    isTimeseries: isTimeseries(parent.settings),
     formatYValue: getYValueFormatter(parent, series, yAxisProps.yExtent),
-    datas,
+    onGoalHover,
+    onHoverChange,
   });
 
   // only ordinal axis can display "null" values

--- a/frontend/src/metabase/visualizations/lib/apply_axis.js
+++ b/frontend/src/metabase/visualizations/lib/apply_axis.js
@@ -15,10 +15,13 @@ import timeseriesScale from "./timeseriesScale";
 import { isMultipleOf } from "./numeric";
 import { getFriendlyName } from "./utils";
 import { isHistogram } from "./renderer_utils";
+import { hasEventAxis } from "metabase/visualizations/lib/timelines";
 
 // label offset (doesn't increase padding)
 const X_LABEL_PADDING = 10;
 const Y_LABEL_PADDING = 22;
+const X_AXIS_PADDING = 3;
+const X_AXIS_PADDING_WITH_EVENT_AXIS = 20;
 
 /// d3.js is dumb and sometimes numTicks is a number like 10 and other times it is an Array like [10]
 /// if it's an array then convert to a num. Use this function so you're guaranteed to get a number;
@@ -87,6 +90,7 @@ export function applyChartTimeseriesXAxis(
   chart,
   series,
   { xValues, xDomain, xInterval },
+  timelineEvents,
 ) {
   // find the first nonempty single series
   const firstSeries = _.find(series, s => !datasetContainsNoResults(s.data));
@@ -160,6 +164,12 @@ export function applyChartTimeseriesXAxis(
     }
 
     chart.xAxis().tickFormat(tickFormat);
+
+    if (hasEventAxis({ timelineEvents, xDomain, isTimeseries: true })) {
+      chart.xAxis().tickPadding(X_AXIS_PADDING_WITH_EVENT_AXIS);
+    } else {
+      chart.xAxis().tickPadding(X_AXIS_PADDING);
+    }
 
     // Compute a sane interval to display based on the data granularity, domain, and chart width
     tickInterval = {

--- a/frontend/src/metabase/visualizations/lib/timelines.js
+++ b/frontend/src/metabase/visualizations/lib/timelines.js
@@ -46,7 +46,7 @@ function getXAxis(chart) {
 }
 
 function getEventAxis(xAxis, xDomain, xInterval, eventTicks) {
-  const [[xAxisDomainLine]] = xAxis.select("path.domain");
+  const xAxisDomainLine = xAxis.select("path.domain").node();
   const { width: axisWidth } = xAxisDomainLine.getBoundingClientRect();
 
   const scale = timeseriesScale(xInterval)
@@ -80,7 +80,7 @@ function renderXAxis(xAxis) {
   });
 }
 
-function renderEventTicks(chart, eventAxis, eventGroups) {
+function renderEventTicks(chart, eventAxis, eventGroups, onOpenTimelines) {
   const brushLayer = chart.svg().select("g.brush");
   const brushLayerHeight = brushLayer.select("rect.background").attr("height");
 
@@ -129,12 +129,16 @@ function renderEventTicks(chart, eventAxis, eventGroups) {
           `translate(${EVENT_GROUP_COUNT_MARGIN_LEFT},${EVENT_GROUP_COUNT_MARGIN_TOP})`,
         );
     }
+
+    eventIconContainer.on("click", () => {
+      onOpenTimelines();
+    });
   });
 }
 
 export function renderEvents(
   chart,
-  { timelineEvents, xDomain, xInterval, isTimeseries },
+  { timelineEvents, xDomain, xInterval, isTimeseries, onOpenTimelines },
 ) {
   const xAxis = getXAxis(chart);
   if (!xAxis || !isTimeseries) {
@@ -149,7 +153,7 @@ export function renderEvents(
   }
 
   const eventAxis = getEventAxis(xAxis, xDomain, xInterval, eventTicks);
-  renderEventTicks(chart, eventAxis, eventGroups);
+  renderEventTicks(chart, eventAxis, eventGroups, onOpenTimelines);
   renderXAxis(xAxis);
 }
 

--- a/frontend/src/metabase/visualizations/lib/timelines.js
+++ b/frontend/src/metabase/visualizations/lib/timelines.js
@@ -4,7 +4,6 @@ import { ICON_PATHS } from "metabase/icon_paths";
 import { stretchTimeseriesDomain } from "./apply_axis";
 import timeseriesScale from "./timeseriesScale";
 
-const X_AXIS_TICK_EXTRA_MARGIN_TOP = 20;
 const EVENT_ICON_OFFSET_X = -16;
 const EVENT_ICON_MARGIN_TOP = 10;
 const EVENT_GROUP_COUNT_MARGIN_LEFT = 10;
@@ -67,17 +66,6 @@ function getEventAxis(xAxis, xDomain, xInterval, eventTicks) {
 
   eventsAxis.select("path.domain").remove();
   return eventsAxis;
-}
-
-function renderXAxis(xAxis) {
-  xAxis.selectAll(".tick")[0].forEach(tick => {
-    const style = tick.getAttribute("transform");
-    const [x, y] = getTranslateFromStyle(style);
-    tick.setAttribute(
-      "transform",
-      `translate(${x},${y + X_AXIS_TICK_EXTRA_MARGIN_TOP})`,
-    );
-  });
 }
 
 function renderEventTicks(chart, eventAxis, eventGroups, onOpenTimelines) {
@@ -154,10 +142,9 @@ export function renderEvents(
 
   const eventAxis = getEventAxis(xAxis, xDomain, xInterval, eventTicks);
   renderEventTicks(chart, eventAxis, eventGroups, onOpenTimelines);
-  renderXAxis(xAxis);
 }
 
-export function hasEventAxis(chart, { timelineEvents, xDomain, isTimeseries }) {
+export function hasEventAxis({ timelineEvents, xDomain, isTimeseries }) {
   if (!isTimeseries) {
     return false;
   }

--- a/frontend/src/metabase/visualizations/lib/timelines.js
+++ b/frontend/src/metabase/visualizations/lib/timelines.js
@@ -36,7 +36,7 @@ function getEventGroups(events, xInterval) {
 }
 
 function getEventTicks(eventGroups) {
-  return Object.keys(eventGroups).map(value => new Date(value));
+  return Object.keys(eventGroups).map(value => new Date(parseInt(value)));
 }
 
 function getTranslateFromStyle(value) {

--- a/frontend/src/metabase/visualizations/lib/timelines.js
+++ b/frontend/src/metabase/visualizations/lib/timelines.js
@@ -157,3 +157,12 @@ export function renderEvents(
   renderEventTicks(chart, eventAxis, eventGroups);
   renderXAxis(xAxis);
 }
+
+export function hasEventAxis(chart, { timelines, xDomain, isTimeseries }) {
+  if (!isTimeseries) {
+    return false;
+  }
+
+  const events = getDomainEvents(getFlatEvents(timelines), xDomain);
+  return events.length > 0;
+}

--- a/frontend/src/metabase/visualizations/lib/timelines.js
+++ b/frontend/src/metabase/visualizations/lib/timelines.js
@@ -1,0 +1,159 @@
+import d3 from "d3";
+import _ from "underscore";
+import { ICON_PATHS } from "metabase/icon_paths";
+import { parseTimestamp } from "metabase/lib/time";
+import timeseriesScale from "metabase/visualizations/lib/timeseriesScale";
+import { stretchTimeseriesDomain } from "metabase/visualizations/lib/apply_axis";
+
+const X_AXIS_TICK_EXTRA_MARGIN_TOP = 20;
+const EVENT_ICON_OFFSET_X = -16;
+const EVENT_ICON_MARGIN_TOP = 10;
+const EVENT_GROUP_COUNT_MARGIN_LEFT = 10;
+const EVENT_GROUP_COUNT_MARGIN_TOP = EVENT_ICON_MARGIN_TOP + 8;
+
+function getFlatEvents(timelines) {
+  return timelines
+    .flatMap(timeline => timeline.events)
+    .map(event => ({ ...event, timestamp: parseTimestamp(event.timestamp) }));
+}
+
+function getDomainEvents(events, [xDomainMin, xDomainMax]) {
+  return events.filter(
+    event =>
+      event.timestamp.isSame(xDomainMin) ||
+      event.timestamp.isBetween(xDomainMin, xDomainMax) ||
+      event.timestamp.isSame(xDomainMax),
+  );
+}
+
+function getEventGroups(events, xInterval) {
+  return _.groupBy(events, event =>
+    event.timestamp
+      .clone()
+      .startOf(xInterval.interval)
+      .valueOf(),
+  );
+}
+
+function getEventTicks(eventGroups) {
+  return Object.keys(eventGroups).map(value => new Date(value));
+}
+
+function getTranslateFromStyle(value) {
+  const style = value.replace("translate(", "").replace(")", "");
+  const [x, y] = style.split(",");
+  return [parseFloat(x), parseFloat(y)];
+}
+
+function getXAxis(chart) {
+  return chart.svg().select(".axis.x");
+}
+
+function getEventAxis(xAxis, xDomain, xInterval, eventTicks) {
+  const [[xAxisDomainLine]] = xAxis.select("path.domain");
+  const { width: axisWidth } = xAxisDomainLine.getBoundingClientRect();
+
+  const scale = timeseriesScale(xInterval)
+    .domain(stretchTimeseriesDomain(xDomain, xInterval))
+    .range([0, axisWidth]);
+
+  const eventsAxisGenerator = d3.svg
+    .axis()
+    .scale(scale)
+    .orient("bottom")
+    .ticks(eventTicks.length)
+    .tickValues(eventTicks);
+
+  const eventsAxis = xAxis
+    .append("g")
+    .attr("class", "events-axis")
+    .call(eventsAxisGenerator);
+
+  eventsAxis.select("path.domain").remove();
+  return eventsAxis;
+}
+
+function renderXAxis(xAxis) {
+  xAxis.selectAll(".tick")[0].forEach(tick => {
+    const style = tick.getAttribute("transform");
+    const [x, y] = getTranslateFromStyle(style);
+    tick.setAttribute(
+      "transform",
+      `translate(${x},${y + X_AXIS_TICK_EXTRA_MARGIN_TOP})`,
+    );
+  });
+}
+
+function renderEventTicks(chart, eventAxis, eventGroups) {
+  const brushLayer = chart.svg().select("g.brush");
+  const brushLayerHeight = brushLayer.select("rect.background").attr("height");
+
+  Object.values(eventGroups).forEach(group => {
+    const defaultTick = eventAxis.select(".tick");
+    const transformStyle = defaultTick.attr("transform");
+    const [tickX] = getTranslateFromStyle(transformStyle);
+    defaultTick.remove();
+
+    const isOnlyOneEvent = group.length === 1;
+    const iconName = isOnlyOneEvent ? group[0].icon : "star";
+
+    const iconPath = ICON_PATHS[iconName].path
+      ? ICON_PATHS[iconName].path
+      : ICON_PATHS[iconName];
+    const iconScale = iconName === "mail" ? 0.45 : 0.5;
+
+    brushLayer
+      .append("line")
+      .attr("class", "event-line")
+      .attr("x1", tickX)
+      .attr("x2", tickX)
+      .attr("y1", "0")
+      .attr("y2", brushLayerHeight);
+
+    const eventIconContainer = eventAxis
+      .append("g")
+      .attr("class", "event-tick")
+      .attr("transform", transformStyle);
+
+    eventIconContainer
+      .append("path")
+      .attr("class", "event-icon")
+      .attr("d", iconPath)
+      .attr(
+        "transform",
+        `scale(${iconScale}) translate(${EVENT_ICON_OFFSET_X},${EVENT_ICON_MARGIN_TOP})`,
+      );
+
+    if (!isOnlyOneEvent) {
+      eventIconContainer
+        .append("text")
+        .text(group.length)
+        .attr(
+          "transform",
+          `translate(${EVENT_GROUP_COUNT_MARGIN_LEFT},${EVENT_GROUP_COUNT_MARGIN_TOP})`,
+        );
+    }
+  });
+}
+
+export function renderEvents(
+  chart,
+  { timelines, xDomain, xInterval, isTimeseries },
+) {
+  if (!isTimeseries) {
+    return;
+  }
+
+  const events = getDomainEvents(getFlatEvents(timelines), xDomain);
+  const eventGroups = getEventGroups(events, xInterval);
+  const eventTicks = getEventTicks(eventGroups);
+
+  if (!events.length) {
+    return;
+  }
+
+  const xAxis = getXAxis(chart);
+  const eventAxis = getEventAxis(xAxis, xDomain, xInterval, eventTicks);
+  renderEventTicks(chart, eventAxis, eventGroups);
+  renderXAxis(xAxis);
+}

--- a/frontend/src/metabase/visualizations/lib/timelines.js
+++ b/frontend/src/metabase/visualizations/lib/timelines.js
@@ -131,7 +131,7 @@ function renderEventTicks(chart, eventAxis, eventGroups, onOpenTimelines) {
 
 export function renderEvents(
   chart,
-  { timelineEvents, xDomain, xInterval, isTimeseries, onOpenTimelines },
+  { timelineEvents = [], xDomain, xInterval, isTimeseries, onOpenTimelines },
 ) {
   const xAxis = getXAxis(chart);
   if (!xAxis || !isTimeseries) {
@@ -149,7 +149,7 @@ export function renderEvents(
   renderEventTicks(chart, eventAxis, eventGroups, onOpenTimelines);
 }
 
-export function hasEventAxis({ timelineEvents, xDomain, isTimeseries }) {
+export function hasEventAxis({ timelineEvents = [], xDomain, isTimeseries }) {
   if (!isTimeseries) {
     return false;
   }

--- a/frontend/src/metabase/visualizations/lib/timelines.js
+++ b/frontend/src/metabase/visualizations/lib/timelines.js
@@ -2,8 +2,8 @@ import d3 from "d3";
 import _ from "underscore";
 import { ICON_PATHS } from "metabase/icon_paths";
 import { parseTimestamp } from "metabase/lib/time";
-import timeseriesScale from "metabase/visualizations/lib/timeseriesScale";
-import { stretchTimeseriesDomain } from "metabase/visualizations/lib/apply_axis";
+import { stretchTimeseriesDomain } from "./apply_axis";
+import timeseriesScale from "./timeseriesScale";
 
 const X_AXIS_TICK_EXTRA_MARGIN_TOP = 20;
 const EVENT_ICON_OFFSET_X = -16;

--- a/frontend/src/metabase/visualizations/lib/timelines.js
+++ b/frontend/src/metabase/visualizations/lib/timelines.js
@@ -140,19 +140,18 @@ export function renderEvents(
   chart,
   { timelines, xDomain, xInterval, isTimeseries },
 ) {
-  if (!isTimeseries) {
+  const xAxis = getXAxis(chart);
+  if (!xAxis || !isTimeseries) {
     return;
   }
 
   const events = getDomainEvents(getFlatEvents(timelines), xDomain);
   const eventGroups = getEventGroups(events, xInterval);
   const eventTicks = getEventTicks(eventGroups);
-
   if (!events.length) {
     return;
   }
 
-  const xAxis = getXAxis(chart);
   const eventAxis = getEventAxis(xAxis, xDomain, xInterval, eventTicks);
   renderEventTicks(chart, eventAxis, eventGroups);
   renderXAxis(xAxis);

--- a/frontend/src/metabase/visualizations/lib/timelines.js
+++ b/frontend/src/metabase/visualizations/lib/timelines.js
@@ -47,6 +47,7 @@ function getXAxis(chart) {
 function getEventAxis(xAxis, xDomain, xInterval, eventTicks) {
   const xAxisDomainLine = xAxis.select("path.domain").node();
   const { width: axisWidth } = xAxisDomainLine.getBoundingClientRect();
+  xAxis.selectAll("event-axis").remove();
 
   const scale = timeseriesScale(xInterval)
     .domain(stretchTimeseriesDomain(xDomain, xInterval))
@@ -69,8 +70,12 @@ function getEventAxis(xAxis, xDomain, xInterval, eventTicks) {
 }
 
 function renderEventTicks(chart, eventAxis, eventGroups, onOpenTimelines) {
-  const brushLayer = chart.svg().select("g.brush");
-  const brushLayerHeight = brushLayer.select("rect.background").attr("height");
+  const svg = chart.svg();
+  const brush = svg.select("g.brush");
+  const brushHeight = brush.select("rect.background").attr("height");
+
+  svg.selectAll(".event-tick").remove();
+  svg.selectAll(".event-line").remove();
 
   Object.values(eventGroups).forEach(group => {
     const defaultTick = eventAxis.select(".tick");
@@ -86,13 +91,13 @@ function renderEventTicks(chart, eventAxis, eventGroups, onOpenTimelines) {
       : ICON_PATHS[iconName];
     const iconScale = iconName === "mail" ? 0.45 : 0.5;
 
-    brushLayer
+    brush
       .append("line")
       .attr("class", "event-line")
       .attr("x1", tickX)
       .attr("x2", tickX)
       .attr("y1", "0")
-      .attr("y2", brushLayerHeight);
+      .attr("y2", brushHeight);
 
     const eventIconContainer = eventAxis
       .append("g")


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/20289
Original PR created by Anton: https://github.com/metabase/metabase/pull/20701

Changes to the original PR:
- Changed the way how timelines are loaded. Now they are loaded in parallel with other referenced entities, e.g. tables, databases, etc.
- Tooltip content and date formatting changes
- Bugfixes

How to test:
- Go to the root collection and create several events for years 2017-2019.
- Create and save a new question, Orders, group by Created date
- Make sure events are displayed in the query builder for this question
- It should be possible to hover event icons and see their details

<img width="1728" alt="Screenshot 2022-03-08 at 22 16 07" src="https://user-images.githubusercontent.com/8542534/157309327-afb5d56b-e5e8-48ed-8bda-a473afaf9006.png">
