### PR TITLE
Fix brackets and ordering for two dependencies in deps.edn

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -48,8 +48,8 @@
                                                            commons-logging/commons-logging]}
   compojure/compojure                       {:mvn/version "1.6.2"               ; HTTP Routing library built on Ring
                                              :exclusions  [ring/ring-codec]}
-  dk.ative/docjure                          {:mvn/version "1.17.0"              ; excel export
   crypto-random/crypto-random               {:mvn/version "1.2.1"}              ; library for generating cryptographically secure random bytes and strings
+  dk.ative/docjure                          {:mvn/version "1.17.0"              ; excel export
                                              :exclusions  [org.apache.poi/poi
                                                            org.apache.poi/poi-ooxml]}
   environ/environ                           {:mvn/version "1.2.0"}              ; env vars/Java properties abstraction
@@ -62,8 +62,8 @@
                                                            org.flatland/ordered
                                                            org.yaml/snakeyaml]}
   javax.xml.bind/jaxb-api                   {:mvn/version "2.4.0-b180830.0359"} ; add the `javax.xml.bind` classes which we're still using but were removed in Java 11
-  kixi/stats                                {:mvn/version "0.4.4"               ; Various statistic measures implemented as transducers
   joda-time/joda-time                       {:mvn/version "2.10.13"}
+  kixi/stats                                {:mvn/version "0.4.4"               ; Various statistic measures implemented as transducers
                                              :exclusions  [org.clojure/data.avl]}
   me.raynes/fs                              {:mvn/version "1.4.6"               ; Filesystem tools
                                              :exclusions  [org.apache.commons/commons-compress]}
@@ -442,8 +442,7 @@
   :liquibase
   {:extra-deps  {ch.qos.logback/logback-classic {:mvn/version "1.2.10"}}
    :extra-paths ["dev/src"]
-   :main-opts   ["-m" "dev.liquibase"]}
+   :main-opts   ["-m" "dev.liquibase"]}}}
 
   ;; TODO -- consider creating an alias that includes the `./bin` build-drivers & release code as well so we can work
   ;; on them all from a single REPL process.
-  }}


### PR DESCRIPTION
#19827 seems to have swapped the order of lines in deps.edn in two places. In both cases, the closing bracket of the dependency's maven coordinates map was missing, which _I think_ means that the following dependencies were not being included correctly?

In any case, I noticed these because my editor (or rather, my parinfer-rust plugin) was trying to automatically "fix" the indentation when I opened the file.

I also removed the trailing brackets at the end of the file since my editor also tries to fix that every time I open the file, which is pretty annoying. I can undo this if anyone objects though.