### PR TITLE
Enable subdimensions on time column (type/Time)

### DIFF
--- a/frontend/src/metabase-lib/lib/metadata/Field.ts
+++ b/frontend/src/metabase-lib/lib/metadata/Field.ts
@@ -309,6 +309,10 @@ export default class Field extends Base {
         "day",
       );
 
+      if (Number.isNaN(days) || this.isTime()) {
+        return "hour";
+      }
+
       if (days < 1) {
         return "minute";
       } else if (days < 31) {

--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -212,16 +212,10 @@
 (defn- supports-numeric-binning? [driver]
   (and driver (driver/supports? driver :binning)))
 
-(defn- supports-date-binning?
-  "Time fields don't support binning, returns true if it's a DateTime field and not a time field"
-  [{:keys [base_type], :as field}]
-  (and (types/temporal-field? field)
-       (not (isa? base_type :type/Time))))
-
 (defn- assoc-field-dimension-options [driver {:keys [base_type semantic_type fingerprint] :as field}]
   (let [{min_value :min, max_value :max} (get-in fingerprint [:type :type/Number])
         [default-option all-options] (cond
-                                       (supports-date-binning? field)
+                                       (types/temporal-field? field)
                                        [date-default-index datetime-dimension-indexes]
 
                                        (and min_value max_value

--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -120,6 +120,7 @@
 
 (def ^:private auto-bin-str (deferred-tru "Auto bin"))
 (def ^:private dont-bin-str (deferred-tru "Don''t bin"))
+(def ^:private hour-str (deferred-tru "Hour"))
 (def ^:private day-str (deferred-tru "Day"))
 
 (def ^:private dimension-options
@@ -132,7 +133,7 @@
                      :type "type/DateTime"})
                   ;; note the order of these options corresponds to the order they will be shown to the user in the UI
                   [[(deferred-tru "Minute") "minute"]
-                   [(deferred-tru "Hour") "hour"]
+                   [hour-str "hour"]
                    [day-str "day"]
                    [(deferred-tru "Week") "week"]
                    [(deferred-tru "Month") "month"]
@@ -146,6 +147,14 @@
                    [(deferred-tru "Week of Year") "week-of-year"]
                    [(deferred-tru "Month of Year") "month-of-year"]
                    [(deferred-tru "Quarter of Year") "quarter-of-year"]])
+             (map (fn [[name param]]
+                    {:name name
+                     :mbql [:field nil {:temporal-unit param}]
+                     :type "type/Time"})
+                  [[(deferred-tru "Minute") "minute"]
+                   [hour-str "hour"]
+                   [(deferred-tru "Minute of Hour") "minute-of-hour"]
+                   [(deferred-tru "Hour of Day") "hour-of-day"]])
              (conj
               (mapv (fn [[name [strategy param]]]
                       {:name name
@@ -189,6 +198,9 @@
 (def ^:private datetime-dimension-indexes
   (create-dim-index-seq "type/DateTime"))
 
+(def ^:private time-dimension-indexes
+  (create-dim-index-seq "type/Time"))
+
 (def ^:private numeric-dimension-indexes
   (create-dim-index-seq "type/Number"))
 
@@ -203,6 +215,9 @@
 (def ^:private date-default-index
   (dimension-index-for-type "type/DateTime" #(= (str day-str) (str (:name %)))))
 
+(def ^:private time-default-index
+  (dimension-index-for-type "type/Time" #(= (str hour-str) (str (:name %)))))
+
 (def ^:private numeric-default-index
   (dimension-index-for-type "type/Number" #(.contains ^String (str (:name %)) (str auto-bin-str))))
 
@@ -215,6 +230,9 @@
 (defn- assoc-field-dimension-options [driver {:keys [base_type semantic_type fingerprint] :as field}]
   (let [{min_value :min, max_value :max} (get-in fingerprint [:type :type/Number])
         [default-option all-options] (cond
+                                       (types/field-is-type? :type/Time field)
+                                       [time-default-index time-dimension-indexes]
+
                                        (types/temporal-field? field)
                                        [date-default-index datetime-dimension-indexes]
 

--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -153,8 +153,7 @@
                      :type "type/Time"})
                   [[(deferred-tru "Minute") "minute"]
                    [hour-str "hour"]
-                   [(deferred-tru "Minute of Hour") "minute-of-hour"]
-                   [(deferred-tru "Hour of Day") "hour-of-day"]])
+                   [(deferred-tru "Minute of Hour") "minute-of-hour"]])
              (conj
               (mapv (fn [[name [strategy param]]]
                       {:name name

--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -120,6 +120,7 @@
 
 (def ^:private auto-bin-str (deferred-tru "Auto bin"))
 (def ^:private dont-bin-str (deferred-tru "Don''t bin"))
+(def ^:private minute-str (deferred-tru "Minute"))
 (def ^:private hour-str (deferred-tru "Hour"))
 (def ^:private day-str (deferred-tru "Day"))
 
@@ -132,7 +133,7 @@
                      :mbql [:field nil {:temporal-unit param}]
                      :type "type/DateTime"})
                   ;; note the order of these options corresponds to the order they will be shown to the user in the UI
-                  [[(deferred-tru "Minute") "minute"]
+                  [[minute-str "minute"]
                    [hour-str "hour"]
                    [day-str "day"]
                    [(deferred-tru "Week") "week"]
@@ -151,7 +152,7 @@
                     {:name name
                      :mbql [:field nil {:temporal-unit param}]
                      :type "type/Time"})
-                  [[(deferred-tru "Minute") "minute"]
+                  [[minute-str "minute"]
                    [hour-str "hour"]
                    [(deferred-tru "Minute of Hour") "minute-of-hour"]])
              (conj

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -713,7 +713,7 @@
         (mt/test-drivers (mt/normal-drivers-except #{:sparksql :mongo :oracle :redshift})
           (mt/dataset test-data-with-time
             (let [response (mt/user-http-request :rasta :get 200 (format "table/%d/query_metadata" (mt/id :users)))]
-              (is (= []
+              (is (= @#'table-api/datetime-dimension-indexes
                      (dimension-options-for-field response "last_login_time"))))))))))
 
 (deftest nested-queries-binning-options-test

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -713,7 +713,7 @@
         (mt/test-drivers (mt/normal-drivers-except #{:sparksql :mongo :oracle :redshift})
           (mt/dataset test-data-with-time
             (let [response (mt/user-http-request :rasta :get 200 (format "table/%d/query_metadata" (mt/id :users)))]
-              (is (= @#'table-api/datetime-dimension-indexes
+              (is (= @#'table-api/time-dimension-indexes
                      (dimension-options-for-field response "last_login_time"))))))))))
 
 (deftest nested-queries-binning-options-test


### PR DESCRIPTION
To verify manually:

First create a table in e.g. PostgreSQL that contains some columns with `time`, e.g.

```
CREATE TABLE test.test (
	"time" time NULL,
	"timestamp" timestamp NULL,
	count integer NULL
);
```

and the populate it with some data.

1. New, Question
2. Choose the above database and table
3. Summarize, Number of distinct values of
4. Highlight `Timestamp` and we got several choices of subdimensions (correctly, as expected)

![image](https://user-images.githubusercontent.com/7288/157150438-c5cb1eff-cb95-4d43-a12c-6631d7ff8cc4.png)

5. **However**, try to highlight `Time` and observe.

**Before this PR**

There is no subdimension for `Time`. This is confusing because it seems that things are working just fine for `Timestamp`.

![image](https://user-images.githubusercontent.com/7288/157331059-7f02fe16-8be0-45f8-9555-1536491759c0.png)


**After this PR**

The behavior for `Time` matches that of `Timestamp`, i.e. there are suitable dimensions for it.

![image](https://user-images.githubusercontent.com/7288/158277515-d0fb5cc6-8954-439b-91b0-813fc28919ba.png)
