### PR TITLE
Isolating Node on CI

### DIFF
--- a/.github/actions/prepare-frontend/action.yml
+++ b/.github/actions/prepare-frontend/action.yml
@@ -2,20 +2,10 @@ name: Prepare front-end environment
 runs:
   using: "composite"
   steps:
-    - name: Prepare Node.js
-      uses: actions/setup-node@v2
-      with:
-        node-version: 14.x
-        cache: 'yarn'
+    - name: Prepare node environment
+      uses: ./.github/actions/prepare-node
     - name: Get M2 cache
       uses: actions/cache@v2
       with:
         path: ~/.m2
         key: ${{ runner.os }}-cljs-${{ hashFiles('**/shadow-cljs.edn') }}
-    - name: Get node_modules cache
-      uses: actions/cache@v2
-      with:
-        path: node_modules
-        key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
-    - run: yarn install --frozen-lockfile --prefer-offline
-      shell: bash

--- a/.github/actions/prepare-node/action.yml
+++ b/.github/actions/prepare-node/action.yml
@@ -1,0 +1,13 @@
+name: Prepare node environment
+runs:
+  using: "composite"
+  steps:
+    - name: Prepare Node.js
+      uses: actions/setup-node@v2
+      with:
+        node-version: 14.x
+        cache: 'yarn'
+        path: node_modules
+        key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
+    - run: yarn install --frozen-lockfile --prefer-offline
+      shell: bash


### PR DESCRIPTION
Isolating `prepare-node` to be used from other actions