### PR TITLE
Fix BigQuery incorrectly quoting datetime-truncated field literal forms

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -161,7 +161,7 @@
   nil)
 
 (defn- throw-invalid-query [e sql parameters]
-  (throw (ex-info (tru "Error executing query")
+  (throw (ex-info (tru "Error executing query: {0}" (ex-message e))
            {:type error-type/invalid-query, :sql sql, :parameters parameters}
            e)))
 

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
@@ -466,9 +466,9 @@
   table e.g.
 
     `table`.`field` -> `dataset.table`.`field`"
-  [{:keys [identifier-type components], ::keys [already-qualified?], :as identifier}]
+  [{:keys [identifier-type components], ::keys [do-not-qualify?], :as _identifier}]
   (cond
-    already-qualified?
+    do-not-qualify?
     false
 
     ;; If we're currently using a Table alias, don't qualify the alias with the dataset name
@@ -500,7 +500,7 @@
                   more))]
     (cond-> identifier
       (should-qualify-identifier? identifier) (update :components prefix-components)
-      true                                    (assoc ::already-qualified? true))))
+      true                                    (assoc ::do-not-qualify? true))))
 
 (defmethod sql.qp/->honeysql [:bigquery-cloud-sdk :field]
   [driver [_ _ {::add/keys [source-table]} :as field-clause]]

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
@@ -402,6 +402,20 @@
             (is (= expected-type
                    (#'bigquery.qp/temporal-type relative-datetime)))))))))
 
+(deftest field-literal-trunc-form-test
+  (testing "`:field` clauses with literal string names should be quoted correctly when doing date truncation (#20806)"
+    (is (= ["datetime_trunc(CAST(`source`.`date` AS datetime), week(sunday))"]
+           (sql.qp/format-honeysql
+            :bigquery-cloud-sdk
+            (sql.qp/->honeysql
+             :bigquery-cloud-sdk
+             [:field "date" {:temporal-unit      :week
+                             :base-type          :type/Date
+                             ::add/source-table
+                             ::add/source        ::add/source-alias "date"
+                             ::add/desired-alias "date"
+                             ::add/position      0}]))))))
+
 (deftest between-test
   (testing "Make sure :between clauses reconcile the temporal types of their args"
     (letfn [(between->sql [clause]

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
@@ -411,8 +411,8 @@
              :bigquery-cloud-sdk
              [:field "date" {:temporal-unit      :week
                              :base-type          :type/Date
-                             ::add/source-table
-                             ::add/source        ::add/source-alias "date"
+                             ::add/source-table  ::add/source
+                             ::add/source-alias  "date"
                              ::add/desired-alias "date"
                              ::add/position      0}]))))))
 

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
@@ -322,7 +322,8 @@
                       (let [filter-clause       (into [(:mbql clause) field]
                                                       (repeat (dec (:args clause)) filter-value))
                             field-literal?      (mbql.u/match-one field [:field (_ :guard string?) _])
-                            expected-identifier (cond-> (hx/identifier :field "ABC" (name temporal-type))
+                            expected-identifier (cond-> (assoc (hx/identifier :field "ABC" (name temporal-type))
+                                                               ::bigquery.qp/do-not-qualify? true)
                                                   (not field-literal?) (hx/with-database-type-info (name temporal-type)))
                             expected-value      (get-in value [:as temporal-type] (:value value))
                             expected-clause     (build-honeysql-clause-head clause
@@ -339,7 +340,8 @@
 
           (testing "\ndate extraction filters"
             (doseq [[temporal-type field] fields
-                    :let                  [identifier          (hx/identifier :field "ABC" (name temporal-type))
+                    :let                  [identifier          (assoc (hx/identifier :field "ABC" (name temporal-type))
+                                                                      ::bigquery.qp/do-not-qualify? true)
                                            expected-identifier (case temporal-type
                                                                  :date      (hx/with-database-type-info identifier "date")
                                                                  :datetime  (hsql/call :cast identifier (hsql/raw "timestamp"))

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -1,5 +1,6 @@
 (ns metabase.driver.bigquery-cloud-sdk-test
   (:require [clojure.core.async :as a]
+            [clojure.string :as str]
             [clojure.test :refer :all]
             [clojure.tools.logging :as log]
             [metabase.db.metadata-queries :as metadata-queries]
@@ -469,3 +470,20 @@
                 mt/native-query
                 qp/process-query
                 mt/rows))))))
+
+(deftest datetime-truncate-field-literal-form-test
+  (mt/test-driver :bigquery-cloud-sdk
+    (testing "Field literal forms should get datetime-truncated correctly (#20806)"
+      (let [query (mt/mbql-query nil
+                    {:source-query {:native (str/join
+                                             \newline
+                                             ["SELECT date"
+                                              "FROM unnest(generate_date_array('2021-01-01', '2021-01-15')) date"])}
+                     :breakout    [[:field "date" {:temporal-unit :week, :base-type :type/Date}]]
+                     :aggregation [[:count]]})]
+        (mt/with-native-query-testing-context query
+          (is (= [["2020-12-27T00:00:00Z" 2]
+                  ["2021-01-03T00:00:00Z" 7]
+                  ["2021-01-10T00:00:00Z" 6]]
+                 (mt/rows
+                  (qp/process-query query)))))))))

--- a/modules/drivers/druid/src/metabase/driver/druid/execute.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid/execute.clj
@@ -158,7 +158,7 @@
         results    (try
                      (execute* details query)
                      (catch Throwable e
-                       (throw (ex-info (tru "Error executing query")
+                       (throw (ex-info (tru "Error executing query: {0}" (ex-message e))
                                        {:type  qp.error-type/db
                                         :query query}
                                        e))))

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -261,7 +261,7 @@
                     (try
                       (jdbc/reducible-query {:connection conn} sql)
                       (catch Throwable e
-                        (throw (ex-info (trs "Error executing query") {:sql sql} e)))))})))))
+                        (throw (ex-info (trs "Error executing query: {0}" (ex-message e)) {:sql sql} e)))))})))))
 
 (defmethod driver/describe-table :snowflake
   [driver database table]

--- a/src/metabase/util/honeysql_extensions.clj
+++ b/src/metabase/util/honeysql_extensions.clj
@@ -83,8 +83,11 @@
        (for [component components]
          (hformat/quote-identifier component, :split false)))))
   pretty/PrettyPrintable
-  (pretty [_]
-    (cons `identifier (cons identifier-type components))))
+  (pretty [this]
+    (if (= (set (keys this)) #{:identifier-type :components})
+      (cons `identifier (cons identifier-type components))
+      ;; if there's extra info beyond the usual two keys print with the record type reader literal syntax e.g. #metabase..Identifier {...}
+      (list (symbol (str \# `Identifier)) (into {} this)))))
 
 ;; don't use `->Identifier` or `map->Identifier`. Use the `identifier` function instead, which cleans up its input
 (alter-meta! #'->Identifier    assoc :private true)


### PR DESCRIPTION
Our BigQuery driver was incorrectly qualifying Field literal forms that were subject to datetime truncation. 

Clauses like 
```clojure
[:field "date" {:base-type :type/Date, :temporal-unit :week}]
```

were incorrectly compiled to SQL like

```sql
datetime_trunc(CAST(`source.date` AS datetime), week(sunday))
```

As opposed to 

```sql
datetime_trunc(CAST(`source`.`date` AS datetime), week(sunday))
```

BigQuery requires tables to be qualified with the dataset name (project ID), but as if it were a identifier, e.g.

```sql
`my_dataset.table`.`field`
```

Our code that qualified identifiers with the dataset name was incorrectly being applied to identifiers from the `source` query in certain cases, resulting in 

```sql
`source.field`
```

instead of

```sql
`source`.`field`
``` 

The main reason for this is that we were not properly recording that Fields from the `source` query should not be qualified; we were passing this info along with a dynamic variable, but it was out of scope by the time we compiled `TruncForm` objects to SQL. I fixed this by adding the information in the `Identifier` object itself 

Fixes #20806

