### PR TITLE
Handle numeric values for :number parameters in JWTs

### DIFF
--- a/src/metabase/api/embed.clj
+++ b/src/metabase/api/embed.clj
@@ -165,7 +165,7 @@
           :let  [value (get slug->value (keyword (:slug param)))
                  ;; operator parameters expect a sequence of values so if we get a lone value (e.g. from a single URL
                  ;; query parameter) wrap it in a sequence
-                 value (if (and (seq value)
+                 value (if (and (some? value)
                                 (params.operators/operator? (:type param)))
                          (u/one-or-many value)
                          value)]

--- a/test/metabase/driver/common/parameters/values_test.clj
+++ b/test/metabase/driver/common/parameters/values_test.clj
@@ -542,3 +542,13 @@
                                   :id      "5791ff38"
                                   :default "Bar"
                                   :target  [:variable [:template-tag "filter"]]}]})))))))
+
+(deftest value->number-test
+  (testing `values/value->number
+    (testing "should handle a vector"
+      (testing "of strings"
+        (is (= 1
+               (#'values/value->number ["1"]))))
+      (testing "of numbers (#20845)"
+        (is (= 1
+               (#'values/value->number [1])))))))


### PR DESCRIPTION
Fixes #20845

There were two things broken here:

1. We assumed the JWT parameters were always something seqable (e.g. a string or a vector). This broke when the parameter was a number
2. The embedding code passes parsed parameters as a vector; and the code that parsed values for `:number` parameters assumed all vectors were vectors of strings (as opposed to a vector of numbers in this case)