### PR TITLE
Fix noisy backend tests

### DIFF
--- a/frontend/test/metabase/scenarios/embedding/embedding-premium-token.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/embedding-premium-token.cy.spec.js
@@ -63,8 +63,8 @@ describeOSS("scenarios > embedding > premium embedding token", () => {
     cy.button("Activate").click();
 
     cy.wait("@saveEmbeddingToken").then(({ response: { body } }) => {
-      expect(body.cause).to.eq("Unable to validate token");
-      expect(body["error-details"]).to.eq("clj-http: status 404");
+      expect(body.cause).to.eq("Token does not exist.");
+      expect(body["error-details"]).to.be.null;
     });
 
     cy.findByText(invalidTokenMessage);

--- a/modules/drivers/druid/src/metabase/driver/druid/client.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid/client.clj
@@ -18,7 +18,6 @@
 
 (defn- do-request
   "Perform a JSON request using `request-fn` against `url`.
-   Tho
 
      (do-request http/get \"http://my-json-api.net\")"
   [request-fn url & {:as options}]
@@ -39,7 +38,7 @@
                             e)))))
       (catch Throwable e
         (let [response (u/ignore-exceptions
-                         (when-let [body (:body (:object (ex-data e)))]
+                         (when-let [body (:body (ex-data e))]
                            (json/parse-string body keyword)))]
           (throw (ex-info (or (:errorMessage response)
                               (.getMessage e))

--- a/src/metabase/public_settings/premium_features.clj
+++ b/src/metabase/public_settings/premium_features.clj
@@ -75,7 +75,7 @@
           ;; we do not want something complicated
           (catch clojure.lang.ExceptionInfo e
             (log/error e (trs "Error fetching token status:"))
-            (let [body (u/ignore-exceptions (some-> (ex-data e) :object :body (json/parse-string keyword)))]
+            (let [body (u/ignore-exceptions (some-> (ex-data e) :body (json/parse-string keyword)))]
               (or
                body
                {:valid         false

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -808,22 +808,22 @@
 (defn profile-print-time
   "Impl for [[profile]] macro -- don't use this directly. Prints the `___ took ___` message at the conclusion of a
   [[profile]]d form."
-  [message start-time]
+  [message-delay start-time]
   ;; indent the message according to [[*profile-level*]] and add a little down-left arrow so it (hopefully) points to
   ;; the parent form
-  (println (format-color (case (int (mod *profile-level* 4))
-                           0 :green
-                           1 :cyan
-                           2 :magenta
-                           3 :yellow) "%s%s took %s"
-             (if (pos? *profile-level*)
-               (str (str/join (repeat (dec *profile-level*) "  ")) " ⮦ ")
-               "")
-             message
-             (format-nanoseconds (- (System/nanoTime) start-time)))))
+  (log/info (format-color (case (int (mod *profile-level* 4))
+                            0 :green
+                            1 :cyan
+                            2 :magenta
+                            3 :yellow) "%s%s took %s"
+                          (if (pos? *profile-level*)
+                            (str (str/join (repeat (dec *profile-level*) "  ")) " ⮦ ")
+                            "")
+                          @message-delay
+                          (format-nanoseconds (- (System/nanoTime) start-time)))))
 
 (defmacro profile
-  "Like `clojure.core/time`, but lets you specify a `message` that gets printed with the total time, formats the
+  "Like [[clojure.core/time]], but lets you specify a `message` that gets printed with the total time, formats the
   time nicely using `format-nanoseconds`, and indents nested calls to `profile`.
 
     (profile \"top-level\"
@@ -837,7 +837,7 @@
   ([form]
    `(profile ~(str form) ~form))
   ([message & body]
-   `(let [message#    ~message
+   `(let [message#    (delay ~message)
           start-time# (System/nanoTime)
           result#     (binding [*profile-level* (inc *profile-level*)]
                         ~@body)]

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -805,10 +805,10 @@
   `profile` form or 1 for a form inside that."
   0)
 
-(defn profile-print-time
+(defn -profile-print-time
   "Impl for [[profile]] macro -- don't use this directly. Prints the `___ took ___` message at the conclusion of a
   [[profile]]d form."
-  [message-delay start-time]
+  [message-thunk start-time]
   ;; indent the message according to [[*profile-level*]] and add a little down-left arrow so it (hopefully) points to
   ;; the parent form
   (log/info (format-color (case (int (mod *profile-level* 4))
@@ -819,7 +819,7 @@
                           (if (pos? *profile-level*)
                             (str (str/join (repeat (dec *profile-level*) "  ")) " ⮦ ")
                             "")
-                          @message-delay
+                          (message-thunk)
                           (format-nanoseconds (- (System/nanoTime) start-time)))))
 
 (defmacro profile
@@ -837,11 +837,13 @@
   ([form]
    `(profile ~(str form) ~form))
   ([message & body]
-   `(let [message#    (delay ~message)
+   ;; message is wrapped in a thunk so we don't incur the overhead of calculating it if the log level does not include
+   ;; INFO
+   `(let [message#    (fn [] ~message)
           start-time# (System/nanoTime)
           result#     (binding [*profile-level* (inc *profile-level*)]
                         ~@body)]
-      (profile-print-time message# start-time#)
+      (-profile-print-time message# start-time#)
       result#)))
 
 (defn seconds->ms

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -195,9 +195,8 @@
               update! (fn [expected-status-code]
                         (mt/user-http-request :crowberto :put expected-status-code (format "database/%d" db-id) updates))]
           (testing "Should check that connection details are valid on save"
-            (mt/suppress-output
-              (is (= false
-                     (:valid (update! 400))))))
+            (is (= false
+                   (:valid (update! 400)))))
           (testing "If connection details are valid, we should be able to update the Database"
             (with-redefs [driver/can-connect? (constantly true)]
               (is (= nil
@@ -212,17 +211,16 @@
                       :features     (driver.u/features :h2 curr-db)}
                      (into {} curr-db)))))))))
 
-    (mt/with-log-level :info
-      (testing "should be able to set `auto_run_queries`"
-        (testing "when creating a Database"
-          (is (= {:auto_run_queries false}
-                 (select-keys (create-db-via-api! {:auto_run_queries false}) [:auto_run_queries]))))
-        (testing "when updating a Database"
-          (mt/with-temp Database [{db-id :id} {:engine ::test-driver}]
-            (let [updates {:auto_run_queries false}]
-              (mt/user-http-request :crowberto :put 200 (format "database/%d" db-id) updates))
-            (is (= false
-                   (db/select-one-field :auto_run_queries Database, :id db-id)))))))
+    (testing "should be able to set `auto_run_queries`"
+      (testing "when creating a Database"
+        (is (= {:auto_run_queries false}
+               (select-keys (create-db-via-api! {:auto_run_queries false}) [:auto_run_queries]))))
+      (testing "when updating a Database"
+        (mt/with-temp Database [{db-id :id} {:engine ::test-driver}]
+          (let [updates {:auto_run_queries false}]
+            (mt/user-http-request :crowberto :put 200 (format "database/%d" db-id) updates))
+          (is (= false
+                 (db/select-one-field :auto_run_queries Database, :id db-id))))))
     (testing "should be able to unset cache_ttl"
       (mt/with-temp Database [{db-id :id}]
         (let [updates1 {:cache_ttl    1337}

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -19,7 +19,6 @@
    [metabase.models.interface :as mi]
    [metabase.models.permissions-group :as group]
    [metabase.models.user :refer [User]]
-   [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [metabase.test.util :as tu]
    [metabase.util :as u]

--- a/test/metabase/test/data/interface.clj
+++ b/test/metabase/test/data/interface.clj
@@ -6,6 +6,7 @@
 
   TODO - We should rename this namespace to `metabase.driver.test-extensions` or something like that."
   (:require [clojure.string :as str]
+            [clojure.tools.logging :as log]
             [clojure.tools.reader.edn :as edn]
             [environ.core :refer [env]]
             [medley.core :as m]
@@ -93,7 +94,7 @@
   ;; no-op during AOT compilation
   (when-not *compile-files*
     (driver/add-parent! driver ::test-extensions)
-    (println "Added test extensions for" driver "💯")))
+    (log/infof "Added test extensions for %s 💯" driver)))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -110,7 +111,7 @@
     (locking has-done-before-run
       (when-not (@has-done-before-run driver)
         (when (not= (get-method before-run driver) (get-method before-run ::test-extensions))
-          (println "doing before-run for" driver))
+          (log/infof "doing before-run for %s" driver))
         ;; avoid using the dispatch fn here because it dispatches on driver with test extensions which would result in
         ;; a circular call back to this function
         ((get-method before-run driver) driver)
@@ -120,8 +121,8 @@
 (defn- require-driver-test-extensions-ns [driver & require-options]
   (let [expected-ns (symbol (or (namespace driver)
                                 (str "metabase.test.data." (name driver))))]
-    (println (format "Loading driver %s test extensions %s"
-                     (u/format-color 'blue driver) (apply list 'require expected-ns require-options)))
+    (log/infof "Loading driver %s test extensions %s"
+               (u/format-color 'blue driver) (apply list 'require expected-ns require-options))
     (apply classloader/require expected-ns require-options)))
 
 (defonce ^:private has-loaded-extensions (atom #{}))

--- a/test/metabase/test/data/sql.clj
+++ b/test/metabase/test/data/sql.clj
@@ -15,7 +15,7 @@
 
 (defn add-test-extensions! [driver]
   (driver/add-parent! driver :sql/test-extensions)
-  (println "Added SQL test extensions for" driver "✏️"))
+  (log/infof "Added SQL test extensions for %s ✏️" driver))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/test/metabase/test/data/sql_jdbc.clj
+++ b/test/metabase/test/data/sql_jdbc.clj
@@ -1,6 +1,7 @@
 (ns metabase.test.data.sql-jdbc
   "Common test extension functionality for SQL-JDBC drivers."
-  (:require [metabase.driver :as driver]
+  (:require [clojure.tools.logging :as log]
+            [metabase.driver :as driver]
             [metabase.test.data.interface :as tx]
             [metabase.test.data.sql :as sql.tx]
             [metabase.test.data.sql-jdbc.load-data :as load-data]
@@ -13,7 +14,7 @@
 (defn add-test-extensions! [driver]
   (initialize/initialize-if-needed! :plugins)
   (driver/add-parent! driver :sql-jdbc/test-extensions)
-  (println "Added SQL JDBC test extensions for" driver "➕"))
+  (log/infof "Added SQL JDBC test extensions for %s ➕" driver))
 
 (defmethod tx/create-db! :sql-jdbc/test-extensions
   [& args]

--- a/test/metabase/test/initialize.clj
+++ b/test/metabase/test/initialize.clj
@@ -1,7 +1,7 @@
 (ns metabase.test.initialize
   "Logic for initializing different components that need to be initialized when running tests."
   (:require [clojure.string :as str]
-            [colorize.core :as colorize]
+            [clojure.tools.logging :as log]
             [metabase.config :as config]
             [metabase.plugins.classloader :as classloader]
             [metabase.test-runner.init :as test-runner.init]
@@ -15,11 +15,9 @@
 (defn- log-init-message [task-name]
   (let [body   (format "| Initializing %s... |" task-name)
         border (str \+ (str/join (repeat (- (count body) 2) \-)) \+)]
-    (println
-     (colorize/blue
-      (str "\n"
-           (str/join "\n" [border body border])
-           "\n")))))
+    (log/info (u/colorize :blue (str "\n"
+                                     (str/join "\n" [border body border])
+                                     "\n")))))
 
 (def ^:private init-timeout-ms (* 30 1000))
 
@@ -41,8 +39,7 @@
       (u/with-timeout init-timeout-ms
         (do-initialization! step)))
     (catch Throwable e
-      (println "Error initializing" step)
-      (println e)
+      (log/fatalf e "Error initializing %s" step)
       (when config/is-test?
         (System/exit -1))
       (throw e))))

--- a/test/metabase/test/initialize/db.clj
+++ b/test/metabase/test/initialize/db.clj
@@ -1,13 +1,16 @@
 (ns metabase.test.initialize.db
   (:require [clojure.java.jdbc :as jdbc]
+            [clojure.tools.logging :as log]
             [metabase.db :as mdb]
             [metabase.task :as task]
             [metabase.util :as u]
             [toucan.db :as db]))
 
 (defn init! []
-  (println (u/format-color 'blue "Setting up %s test DB and running migrations..." (mdb/db-type)))
+  (log/info (u/format-color 'blue "Setting up %s test DB and running migrations..." (mdb/db-type)))
   (#'task/set-jdbc-backend-properties!)
   (mdb/setup-db!)
-  (jdbc/with-db-metadata [metadata (db/connection)]
-    (println (u/format-color 'blue "Application DB is %s %s" (.getDatabaseProductName metadata) (.getDatabaseProductVersion metadata)))))
+  (log/info (jdbc/with-db-metadata [metadata (db/connection)]
+              (u/format-color 'blue "Application DB is %s %s"
+                              (.getDatabaseProductName metadata)
+                              (.getDatabaseProductVersion metadata)))))

--- a/test/metabase/test/initialize/plugins.clj
+++ b/test/metabase/test/initialize/plugins.clj
@@ -1,5 +1,6 @@
 (ns metabase.test.initialize.plugins
   (:require [clojure.java.io :as io]
+            [clojure.tools.logging :as log]
             [clojure.tools.reader.edn :as edn]
             [metabase.plugins :as plugins]
             [metabase.plugins.initialize :as plugins.init]
@@ -10,16 +11,16 @@
 (defn- driver-plugin-manifest [driver]
   (let [nm    (name driver)
         paths (mapv
-                #(format "%s/drivers/%s/resources/metabase-plugin.yaml" % nm)
-                ;; look for driver definition in both the regular modules directory, as well as in a top-level
-                ;; test_modules directory, specifically designed for test driver definitions
-                ["modules" "test_modules"])]
+               #(format "%s/drivers/%s/resources/metabase-plugin.yaml" % nm)
+               ;; look for driver definition in both the regular modules directory, as well as in a top-level
+               ;; test_modules directory, specifically designed for test driver definitions
+               ["modules" "test_modules"])]
     (first (filter some?
                    (for [path paths
                          :let [manifest (io/file path)]
                          :when (.exists manifest)]
                      (do
-                       (println (u/format-color
+                       (log/info (u/format-color
                                   'green
                                   "Loading plugin manifest (from %s) for driver as if it were a real plugin: %s"
                                   path

--- a/test/metabase/test/initialize/web_server.clj
+++ b/test/metabase/test/initialize/web_server.clj
@@ -1,5 +1,6 @@
 (ns metabase.test.initialize.web-server
-  (:require [metabase.config :as config]
+  (:require [clojure.tools.logging :as log]
+            [metabase.config :as config]
             [metabase.core.initialization-status :as init-status]
             [metabase.models.setting :as setting]
             [metabase.server :as server]
@@ -29,10 +30,9 @@
 (defn init! []
   (try
     (server/start-web-server! test-handler)
-    (printf "Started test server on port %d\n" (config/config-int :mb-jetty-port))
+    (log/infof "Started test server on port %d" (config/config-int :mb-jetty-port))
     (catch Throwable e
-      (println "Web server failed to start")
-      (println e)
+      (log/fatalf e "Web server failed to start")
       (when config/is-test?
         (System/exit -2))))
   (init-status/set-complete!)

--- a/test/metabase/test/util/log.clj
+++ b/test/metabase/test/util/log.clj
@@ -15,8 +15,8 @@
 ;; make sure [[clojure.tools.logging]] is using the Log4j2 factory, otherwise the swaps we attempt to do here don't seem
 ;; to work.
 (when-not (= (log.impl/name log/*logger-factory*) "org.apache.logging.log4j")
-  (println "Setting clojure.tools.logging factory to" `log.impl/log4j2-factory)
-  (alter-var-root #'log/*logger-factory* (constantly (log.impl/log4j2-factory))))
+  (alter-var-root #'log/*logger-factory* (constantly (log.impl/log4j2-factory)))
+  (log/infof "Setting clojure.tools.logging factory to %s" `log.impl/log4j2-factory))
 
 (def ^:private ^:deprecated logger->original-level
   (delay

--- a/test/metabase/test_runner.clj
+++ b/test/metabase/test_runner.clj
@@ -17,6 +17,7 @@
             [metabase.test-runner.parallel :as parallel]
             [metabase.test.data.env :as tx.env]
             metabase.test.redefs
+            [metabase.util :as u]
             [metabase.util.date-2 :as date-2]
             [metabase.util.i18n.impl :as i18n.impl]
             [pjstadig.humane-test-output :as humane-test-output]))
@@ -103,7 +104,9 @@
 (defn tests [{:keys [only]}]
   (when only
     (println "Running tests in" (pr-str only)))
-  (let [tests (find-tests only)]
+  (let [start-time-ms (System/currentTimeMillis)
+        tests         (find-tests only)]
+    (printf "Finding tests took %s.\n" (u/format-milliseconds (- (System/currentTimeMillis) start-time-ms)))
     (println "Running" (count tests) "tests")
     tests))
 
@@ -171,9 +174,11 @@
 
   To use our test runner from the REPL, use [[run]] instead."
   [options]
-  (let [summary (run (tests options) options)
-        fail?   (pos? (+ (:error summary) (:fail summary)))]
+  (let [start-time-ms (System/currentTimeMillis)
+        summary       (run (tests options) options)
+        fail?         (pos? (+ (:error summary) (:fail summary)))]
     (pprint/pprint summary)
     (printf "Ran %d tests in parallel, %d single-threaded.\n" (:parallel summary 0) (:single-threaded summary 0))
+    (printf "Finding and running tests took %s.\n" (u/format-milliseconds (- (System/currentTimeMillis) start-time-ms)))
     (println (if fail? "Tests failed." "All tests passed."))
     (System/exit (if fail? 1 0))))


### PR DESCRIPTION
I noticed there was a stray `mt/with-log-level` form in the tests that I accidentally added a few weeks ago which resulted in the test in question logging a ton of noise... I removed that and thought I should try to remove other noise from the tests. This mostly involved changing a bunch of `println`s to `log/` forms

- Changed `u/profile` from `println` to `log/info`
- Changed a bunch of test setup messages to `log/info`

I also noticed that `clj-http` status code exceptions don't wrap the response in `:body` anymore (after upgrading to the latest version) so I fixed a couple places destructuring the ExceptionInfo based on the old shape -- this fixes an issue where token status check 404 responses didn't include the info coming back from  @nemanjaglumac noticed last week (he pinged me about this but didn't open an issue for it AFAIK)

