### PR TITLE
MBQL schema: allows :case for a string expression

### DIFF
--- a/shared/src/metabase/mbql/schema.cljc
+++ b/shared/src/metabase/mbql/schema.cljc
@@ -421,7 +421,7 @@
 
 (def string-expressions
   "String functions"
-  #{:substring :trim :rtrim :ltrim :upper :lower :replace :concat :regex-match-first :coalesce})
+  #{:substring :trim :rtrim :ltrim :upper :lower :replace :concat :regex-match-first :coalesce :case})
 
 (declare StringExpression)
 
@@ -523,13 +523,6 @@
 (defclause ^{:requires-features #{:expressions :regex}} regex-match-first
   s StringExpressionArg, pattern s/Str)
 
-(def ^:private StringExpression*
-  (one-of substring trim ltrim rtrim replace lower upper concat regex-match-first coalesce))
-
-(def ^:private StringExpression
-  "Schema for the definition of an string expression."
-  (s/recursive #'StringExpression*))
-
 (defclause ^{:requires-features #{:expressions}} +
   x NumericExpressionArg, y NumericExpressionArgOrInterval, more (rest NumericExpressionArgOrInterval))
 
@@ -569,6 +562,12 @@
 (def ^:private ArithmeticExpression
   "Schema for the definition of an arithmetic expression."
   (s/recursive #'ArithmeticExpression*))
+
+(declare StringExpression*)
+
+(def ^:private StringExpression
+  "Schema for the definition of an string expression."
+  (s/recursive #'StringExpression*))
 
 
 ;;; ----------------------------------------------------- Filter -----------------------------------------------------
@@ -727,6 +726,10 @@
 
 (def ^:private ArithmeticExpression*
   (one-of + - / * coalesce length floor ceil round abs power sqrt exp log case))
+
+(def ^:private StringExpression*
+  (one-of substring trim ltrim rtrim replace lower upper concat regex-match-first coalesce case))
+
 
 (def FieldOrExpressionDef
   "Schema for anything that is accepted as a top-level expression definition, either an arithmetic expression such as a


### PR DESCRIPTION
How to verify:

1. New, Question, Sample Database, Products
2. Custom Column, type `upper(case([Rating] > 2, "GOOD", "meh"))`
3. Give it a name, e.g. `Quality`
4. Preview (or Visualize)

**Before this PR**

The query fails:

![image](https://user-images.githubusercontent.com/7288/157354001-37de693f-2f1c-4faa-8a3c-9406cec90fe9.png)


**After this PR**

The query runs without a problem:

![image](https://user-images.githubusercontent.com/7288/157353960-b8d3cd20-4e22-4453-ae32-2d68702351d8.png)
