### PR TITLE
Fix no visual feedback when updating data model field details

### DIFF
--- a/frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx
@@ -53,7 +53,7 @@ export default class MetadataTable extends Component {
 
   updateProperty(name, value) {
     this.setState({ saving: true });
-    this.props.table.update({ [name]: value });
+    this.props.table.updateProperty(name, value);
   }
 
   onNameChange(event) {

--- a/frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx
@@ -69,7 +69,7 @@ const mapDispatchToProps = {
   fetchDatabaseMetadata: Databases.actions.fetchDatabaseMetadata,
   fetchTableMetadata: Tables.actions.fetchMetadataAndForeignTables,
   fetchFieldValues: Fields.actions.fetchFieldValues,
-  updateField: Fields.actions.update,
+  updateField: Fields.actions.updateField,
   updateFieldValues: Fields.actions.updateFieldValues,
   updateFieldDimension: Fields.actions.updateFieldDimension,
   deleteFieldDimension: Fields.actions.deleteFieldDimension,

--- a/frontend/src/metabase/entities/fields.js
+++ b/frontend/src/metabase/entities/fields.js
@@ -1,5 +1,5 @@
 import { t } from "ttag";
-import { createEntity, undo } from "metabase/lib/entities";
+import { createEntity, notify } from "metabase/lib/entities";
 import {
   compose,
   withAction,
@@ -91,7 +91,7 @@ const Fields = createEntity({
       return Fields.actions.update(
         { id: field.id },
         field,
-        undo(opts, field.display_name, t`updated`),
+        notify(opts, field.display_name, t`updated`),
       );
     },
     // Docstring from m.api.field:

--- a/frontend/src/metabase/entities/tables.js
+++ b/frontend/src/metabase/entities/tables.js
@@ -1,4 +1,5 @@
-import { createEntity } from "metabase/lib/entities";
+import { t } from "ttag";
+import { createEntity, notify } from "metabase/lib/entities";
 import {
   createThunkAction,
   compose,
@@ -73,6 +74,13 @@ const Tables = createEntity({
 
   // ACTION CREATORS
   objectActions: {
+    updateProperty(entityObject, name, value, opts) {
+      return Tables.actions.update(
+        entityObject,
+        { [name]: value },
+        notify(opts, `Table ${name}`, t`updated`),
+      );
+    },
     // loads `query_metadata` for a single table
     fetchMetadata: compose(
       withAction(FETCH_METADATA),

--- a/frontend/src/metabase/lib/entities.js
+++ b/frontend/src/metabase/lib/entities.js
@@ -259,14 +259,12 @@ export function createEntity(def) {
         );
 
         if (notify) {
-          // pick only the attributes that were updated
-          const undoObject = _.pick(
-            originalObject,
-            ...Object.keys(updatedObject || {}),
-          );
-          // https://github.com/metabase/metabase/pull/20874#pullrequestreview-902384264
-          const canUndo = !hasCircularReference(undoObject);
-          if (notify.undo && canUndo) {
+          if (notify.undo) {
+            // pick only the attributes that were updated
+            const undoObject = _.pick(
+              originalObject,
+              ...Object.keys(updatedObject || {}),
+            );
             dispatch(
               addUndo({
                 actions: [
@@ -611,16 +609,6 @@ export function createEntity(def) {
   require("metabase/entities/containers").addEntityContainers(entity);
 
   return entity;
-}
-
-function hasCircularReference(object) {
-  try {
-    JSON.stringify(object);
-  } catch (error) {
-    return true;
-  }
-
-  return false;
 }
 
 export function combineEntities(entities) {


### PR DESCRIPTION
A follow-up from PR: #20874, issue #19710

#### After the fix
![image](https://user-images.githubusercontent.com/1937582/157422080-ce108967-bcee-4f5d-8b2c-d90e1f75f365.png)
![image](https://user-images.githubusercontent.com/1937582/157422116-95be2a3e-4935-4a56-908e-2e1dda97999c.png)

@flamber I somehow could get the `Order` ID into a weird state just like the second screenshot, but `undo` button does nothing. I can't reproduce that again once I drop the db and start with a clean slate again. Just FYI.

As far as I know, there shouldn't be much problem undoing fields that are not FK or ID.