### PR TITLE
Advanced date/time/zone manipulation, part 1: date extraction functions

### DIFF
--- a/frontend/src/metabase/lib/expressions/config.js
+++ b/frontend/src/metabase/lib/expressions/config.js
@@ -321,6 +321,46 @@ export const MBQL_CLAUSES = {
     type: "boolean",
     args: ["expression", "expression"],
   },
+  "get-year": {
+    displayName: `year`,
+    type: "number",
+    args: ["expression"],
+  },
+  "get-quarter": {
+    displayName: `quarter`,
+    type: "number",
+    args: ["expression"],
+  },
+  "get-month": {
+    displayName: `month`,
+    type: "number",
+    args: ["expression"],
+  },
+  "get-day": {
+    displayName: `day`,
+    type: "number",
+    args: ["expression"],
+  },
+  "get-day-of-week": {
+    displayName: `weekday`,
+    type: "number",
+    args: ["expression"],
+  },
+  "get-hour": {
+    displayName: `hour`,
+    type: "number",
+    args: ["expression"],
+  },
+  "get-minute": {
+    displayName: `minute`,
+    type: "number",
+    args: ["expression"],
+  },
+  "get-second": {
+    displayName: `second`,
+    type: "number",
+    args: ["expression"],
+  },
 };
 
 for (const [name, clause] of Object.entries(MBQL_CLAUSES)) {
@@ -402,6 +442,15 @@ export const EXPRESSION_FUNCTIONS = new Set([
   "is-empty",
   // other
   "coalesce",
+  // date/time
+  "get-year",
+  "get-quarter",
+  "get-month",
+  "get-day",
+  "get-weekday",
+  "get-hour",
+  "get-minute",
+  "get-second",
 ]);
 
 export const EXPRESSION_OPERATORS = new Set(["+", "-", "*", "/"]);

--- a/frontend/src/metabase/lib/expressions/helper_text_strings.js
+++ b/frontend/src/metabase/lib/expressions/helper_text_strings.js
@@ -532,6 +532,114 @@ const helperTextStrings = [
       },
     ],
   },
+  {
+    name: "is-empty",
+    structure: "isempty(" + t`column` + ")",
+    description: t`Checks if a column is empty`,
+    example: "isempty([" + t`Name` + "])",
+    args: [
+      {
+        name: t`column`,
+        description: t`The column to check.`,
+      },
+    ],
+  },
+  {
+    name: "get-year",
+    structure: "year(" + t`column` + ")",
+    description: t`Gets the year of a date column`,
+    example: "year([" + t`Created At` + "])",
+    args: [
+      {
+        name: t`column`,
+        description: t`The date time`,
+      },
+    ],
+  },
+  {
+    name: "get-quarter",
+    structure: "quarter(" + t`column` + ")",
+    description: t`Gets the quarter of a date column`,
+    example: "quarter([" + t`Created At` + "])",
+    args: [
+      {
+        name: t`column`,
+        description: t`The date time`,
+      },
+    ],
+  },
+  {
+    name: "get-month",
+    structure: "month(" + t`column` + ")",
+    description: t`Gets the month of a date column`,
+    example: "month([" + t`Created At` + "])",
+    args: [
+      {
+        name: t`column`,
+        description: t`The date time`,
+      },
+    ],
+  },
+  {
+    name: "get-day",
+    structure: "day(" + t`column` + ")",
+    description: t`Gets the day of a date column`,
+    example: "day([" + t`Created At` + "])",
+    args: [
+      {
+        name: t`column`,
+        description: t`The date time`,
+      },
+    ],
+  },
+  {
+    name: "get-day-of-week",
+    structure: "weekday(" + t`column` + ")",
+    description: t`Gets the week of a date column`,
+    example: "weekday([" + t`Created At` + "])",
+    args: [
+      {
+        name: t`column`,
+        description: t`The date time`,
+      },
+    ],
+  },
+  {
+    name: "get-hour",
+    structure: "hour(" + t`column` + ")",
+    description: t`Gets the hour of a date column`,
+    example: "hour([" + t`Created At` + "])",
+    args: [
+      {
+        name: t`column`,
+        description: t`The date time`,
+      },
+    ],
+  },
+  {
+    name: "get-minute",
+    structure: "minute(" + t`column` + ")",
+    description: t`Gets the minute of a date column`,
+    example: "minute([" + t`Created At` + "])",
+    args: [
+      {
+        name: t`column`,
+        description: t`The date time`,
+      },
+    ],
+  },
+  {
+    name: "get-second",
+    structure: "second(" + t`column` + ")",
+    description: t`Gets the second of a date column`,
+    example: "second([" + t`Created At` + "])",
+    args: [
+      {
+        name: t`column`,
+        description: t`The date time`,
+      },
+    ],
+  },
 ];
 
 export default name => helperTextStrings.find(h => h.name === name);

--- a/frontend/src/metabase/lib/expressions/suggest.js
+++ b/frontend/src/metabase/lib/expressions/suggest.js
@@ -61,7 +61,7 @@ export function suggest({
     suggestions.push(
       ...Array.from(EXPRESSION_FUNCTIONS)
         .map(name => MBQL_CLAUSES[name])
-        .filter(clause => database.hasFeature(clause.requiresFeature))
+        .filter(clause => clause && database.hasFeature(clause.requiresFeature))
         .map(func => ({
           type: "functions",
           name: func.displayName,
@@ -75,7 +75,9 @@ export function suggest({
       suggestions.push(
         ...Array.from(AGGREGATION_FUNCTIONS)
           .map(name => MBQL_CLAUSES[name])
-          .filter(clause => database.hasFeature(clause.requiresFeature))
+          .filter(
+            clause => clause && database.hasFeature(clause.requiresFeature),
+          )
           .map(func => ({
             type: "aggregations",
             name: func.displayName,

--- a/frontend/test/metabase/scenarios/custom-column/cc-expression-editor.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/cc-expression-editor.cy.spec.js
@@ -59,3 +59,75 @@ describe("scenarios > question > custom column > expression editor", () => {
     cy.button("Done").should("not.be.disabled");
   });
 });
+
+describe("scenarios > question > custom column > advanced date/time functions", () => {
+  beforeEach(() => {
+    cy.signInAsAdmin();
+    openOrdersTable({ mode: "notebook" });
+    cy.findByText("Custom column").click();
+  });
+
+  it("should support get-year", () => {
+    enterCustomColumnDetails({
+      formula: "year([Created At])", // Formula was intentionally written without spaces (important for this repro)!
+      name: "Math",
+    });
+    cy.button("Done").should("not.be.disabled");
+  });
+
+  it("should support get-quarter", () => {
+    enterCustomColumnDetails({
+      formula: "quarter([Created At])", // Formula was intentionally written without spaces (important for this repro)!
+      name: "Math",
+    });
+    cy.button("Done").should("not.be.disabled");
+  });
+
+  it("should support get-month", () => {
+    enterCustomColumnDetails({
+      formula: "month([Created At])", // Formula was intentionally written without spaces (important for this repro)!
+      name: "Math",
+    });
+    cy.button("Done").should("not.be.disabled");
+  });
+
+  it("should support get-day", () => {
+    enterCustomColumnDetails({
+      formula: "day([Created At])", // Formula was intentionally written without spaces (important for this repro)!
+      name: "Math",
+    });
+    cy.button("Done").should("not.be.disabled");
+  });
+
+  it("should support get-day-of-week", () => {
+    enterCustomColumnDetails({
+      formula: "weekday([Created At])", // Formula was intentionally written without spaces (important for this repro)!
+      name: "Math",
+    });
+    cy.button("Done").should("not.be.disabled");
+  });
+
+  it("should support get-hour", () => {
+    enterCustomColumnDetails({
+      formula: "hour([Created At])", // Formula was intentionally written without spaces (important for this repro)!
+      name: "Math",
+    });
+    cy.button("Done").should("not.be.disabled");
+  });
+
+  it("should support get-minute", () => {
+    enterCustomColumnDetails({
+      formula: "minute([Created At])", // Formula was intentionally written without spaces (important for this repro)!
+      name: "Math",
+    });
+    cy.button("Done").should("not.be.disabled");
+  });
+
+  it("should support get-second", () => {
+    enterCustomColumnDetails({
+      formula: "second([Created At])", // Formula was intentionally written without spaces (important for this repro)!
+      name: "Math",
+    });
+    cy.button("Done").should("not.be.disabled");
+  });
+});

--- a/frontend/test/metabase/scenarios/custom-column/custom-column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/custom-column.cy.spec.js
@@ -647,4 +647,37 @@ describe("scenarios > question > custom column", () => {
       .should("have.attr", "class")
       .and("eq", "ace_text-input");
   });
+
+  it("should work with date extraction functions", () => {
+    openOrdersTable({ mode: "notebook" });
+    filter({ mode: "notebook" });
+    cy.findByText("Custom Expression").click();
+    cy.get(".ace_text-input")
+      .type("[ID] = 1")
+      .blur();
+    cy.button("Done").click();
+
+    const createColumn = (name, formula) => {
+      cy.findByText("Custom column").click();
+      enterCustomColumnDetails({ formula, name });
+      cy.button("Done").click();
+    };
+
+    createColumn("Year", "get-year([Created At])");
+    createColumn("Quarter", "get-quarter([Created At])");
+    createColumn("Month", "get-month([Created At])");
+    createColumn("Day", "get-day([Created At])");
+    createColumn("Weekday", "get-day-of-week([Created At])");
+    createColumn("Hour", "get-hour([Created At])");
+    createColumn("Minute", "get-minute([Created At])");
+    visualize();
+
+    cy.get(".Grid-cell").contains("2,019"); // Year
+    cy.get(".Grid-cell").contains("1"); // Quarter
+    cy.get(".Grid-cell").contains("2"); // Month
+    cy.get(".Grid-cell").contains("11"); // Day
+    cy.get(".Grid-cell").contains("3"); // Weekday
+    cy.get(".Grid-cell").contains("9"); // Hour
+    cy.get(".Grid-cell").contains("40"); // Minute
+  });
 });

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
@@ -385,6 +385,39 @@
 (defmethod sql.qp/date [:bigquery-cloud-sdk :quarter-of-year] [_ _ expr] (extract :quarter   expr))
 (defmethod sql.qp/date [:bigquery-cloud-sdk :year]            [_ _ expr] (trunc   :year      expr))
 
+;; date extraction functions
+(defmethod sql.qp/->honeysql [:bigquery-cloud-sdk :get-year]
+  [driver [_ arg]]
+  (extract :year (sql.qp/->honeysql driver arg)))
+
+(defmethod sql.qp/->honeysql [:bigquery-cloud-sdk :get-quarter]
+  [driver [_ arg]]
+  (sql.qp/date driver :quarter-of-year arg))
+
+(defmethod sql.qp/->honeysql [:bigquery-cloud-sdk :get-month]
+  [driver [_ arg]]
+  (sql.qp/date driver :month-of-year arg))
+
+(defmethod sql.qp/->honeysql [:bigquery-cloud-sdk :get-day]
+  [driver [_ arg]]
+  (sql.qp/date driver :day-of-month arg))
+
+(defmethod sql.qp/->honeysql [:bigquery-cloud-sdk :get-day-of-week]
+  [driver [_ arg]]
+  (sql.qp/date driver :day-of-week arg))
+
+(defmethod sql.qp/->honeysql [:bigquery-cloud-sdk :get-hour]
+  [driver [_ arg]]
+  (sql.qp/date driver :hour-of-day arg))
+
+(defmethod sql.qp/->honeysql [:bigquery-cloud-sdk :get-minute]
+  [driver [_ arg]]
+  (sql.qp/date driver :minute-of-hour arg))
+
+(defmethod sql.qp/->honeysql [:bigquery-cloud-sdk :get-second]
+  [driver [_ arg]]
+  (extract :second (sql.qp/->honeysql driver arg)))
+
 ;; BigQuery mod is a function like mod(x, y) rather than an operator like x mod y
 (defmethod hformat/fn-handler (u/qualified-name ::mod)
   [_ x y]

--- a/modules/drivers/mongo/src/metabase/driver/mongo.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo.clj
@@ -217,6 +217,10 @@
                  :native-parameters]]
   (defmethod driver/supports? [:mongo feature] [_ _] true))
 
+;; TODO: figure out how to support this for MongoDB, which doesn't extend :sql (and hence doesn't get sql.qp stuff)
+(defmethod driver/database-supports? [:mongo :date-functions] [& more]
+  false)
+
 (defmethod driver/database-supports? [:mongo :expressions] [_ _ db]
   (let [version (some-> (get-in db [:details :version])
                         (str/split #"\.")

--- a/modules/drivers/presto-jdbc/src/metabase/driver/presto_jdbc.clj
+++ b/modules/drivers/presto-jdbc/src/metabase/driver/presto_jdbc.clj
@@ -185,6 +185,45 @@
   ;; Presto mod is a function like mod(x, y) rather than an operator like x mod y
   (format "mod(%s, %s)" (hformat/to-sql x) (hformat/to-sql y)))
 
+(defn- col-or-ts [driver arg]
+  (if (string? arg)
+      (hx/->timestamp arg)
+      (sql.qp/->honeysql driver arg)))
+
+;; date extraction functions
+(defmethod sql.qp/->honeysql [:presto-jdbc :get-year]
+  [driver [_ arg]]
+  ;; TODO: figure out if ->timestamp here is really the proper way
+  (sql.qp/->honeysql :sql [:get-year (col-or-ts driver arg)]))
+
+(defmethod sql.qp/->honeysql [:presto-jdbc :get-quarter]
+  [driver [_ arg]]
+  (sql.qp/->honeysql :sql [:get-quarter (col-or-ts driver arg)]))
+
+(defmethod sql.qp/->honeysql [:presto-jdbc :get-month]
+  [driver [_ arg]]
+  (sql.qp/->honeysql :sql [:get-month (col-or-ts driver arg)]))
+
+(defmethod sql.qp/->honeysql [:presto-jdbc :get-day]
+  [driver [_ arg]]
+  (sql.qp/->honeysql :sql [:get-day (col-or-ts driver arg)]))
+
+(defmethod sql.qp/->honeysql [:presto-jdbc :get-day-of-week]
+  [driver [_ arg]]
+  (sql.qp/date :presto-jdbc :day-of-week (col-or-ts driver arg)))
+
+(defmethod sql.qp/->honeysql [:presto-jdbc :get-hour]
+  [driver [_ arg]]
+  (sql.qp/->honeysql :sql [:get-hour (col-or-ts driver arg)]))
+
+(defmethod sql.qp/->honeysql [:presto-jdbc :get-minute]
+  [driver [_ arg]]
+  (sql.qp/->honeysql :sql [:get-minute (col-or-ts driver arg)]))
+
+(defmethod sql.qp/->honeysql [:presto-jdbc :get-second]
+  [driver [_ arg]]
+  (sql.qp/->honeysql :sql [:get-second (col-or-ts driver arg)]))
+
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                                  Connectivity                                                  |
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/shared/src/metabase/mbql/schema.cljc
+++ b/shared/src/metabase/mbql/schema.cljc
@@ -569,6 +569,41 @@
   "Schema for the definition of an string expression."
   (s/recursive #'StringExpression*))
 
+(def date+time+timezone-functions
+  "Date, time, and timezone related functions."
+  #{;; extraction functions (get some component of a given temporal value/column)
+    :get-year :get-quarter :get-month :get-day :get-day-of-week :get-hour :get-minute :get-second})
+
+(defclause ^{:requires-features #{:date-functions}} get-year
+  date StringExpressionArg)
+
+(defclause ^{:requires-features #{:date-functions}} get-quarter
+  date StringExpressionArg)
+
+(defclause ^{:requires-features #{:date-functions}} get-month
+  date StringExpressionArg)
+
+(defclause ^{:requires-features #{:date-functions}} get-day
+  date StringExpressionArg)
+
+(defclause ^{:requires-features #{:date-functions}} get-day-of-week
+  date StringExpressionArg)
+
+(defclause ^{:requires-features #{:date-functions}} get-hour
+  datetime StringExpressionArg)
+
+(defclause ^{:requires-features #{:date-functions}} get-minute
+  datetime StringExpressionArg)
+
+(defclause ^{:requires-features #{:date-functions}} get-second
+  datetime StringExpressionArg)
+
+(def ^:private DateFunctionExpression*
+  (one-of get-year get-quarter get-month get-day get-day-of-week get-hour get-minute get-second))
+
+(def ^:private DateFunctionExpression
+  "Schema for the definition of a date function expression."
+  (s/recursive #'DateFunctionExpression*))
 
 ;;; ----------------------------------------------------- Filter -----------------------------------------------------
 
@@ -735,10 +770,11 @@
   "Schema for anything that is accepted as a top-level expression definition, either an arithmetic expression such as a
   `:+` clause or a `:field` clause."
   (s/conditional
-   (partial is-clause? arithmetic-expressions) ArithmeticExpression
-   (partial is-clause? string-expressions)     StringExpression
-   (partial is-clause? :case)                  case
-   :else                                       Field))
+   (partial is-clause? arithmetic-expressions)       ArithmeticExpression
+   (partial is-clause? string-expressions)           StringExpression
+   (partial is-clause? date+time+timezone-functions) DateFunctionExpression
+   (partial is-clause? :case)                        case
+   :else                                             Field))
 
 
 ;;; -------------------------------------------------- Aggregations --------------------------------------------------

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -427,7 +427,11 @@
     :advanced-math-expressions
 
     ;; Does the driver support percentile calculations (including median)
-    :percentile-aggregations})
+    :percentile-aggregations
+
+    ;; Does the driver support date, time, and timezone manipulation functions?
+    ;; DEFAULTS TO TRUE
+    :date-functions})
 
 (defmulti supports?
   "Does this driver support a certain `feature`? (A feature is a keyword, and can be any of the ones listed above in
@@ -474,8 +478,27 @@
 
 (defmethod database-supports? :default [driver feature _] (supports? driver feature))
 
-(defmulti ^{:deprecated "0.42.0"} format-custom-field-name
-  "Unused in Metabase 0.42.0+. Implement [[escape-alias]] instead. This method will be removed in a future release."
+(defmethod database-supports? [::driver :date-functions] [_ _ _]
+  true)
+
+(defmulti ^:deprecated format-custom-field-name
+  "Prior to Metabase 0.33.0, you could specifiy custom names for aggregations in MBQL by wrapping the clause in a
+  `:named` clause:
+
+    [:named [:count] \"My Count\"]
+
+  This name was used for both the `:display_name` in the query results, and for the `:name` used as an alias in the
+  query (e.g. the right-hand side of a SQL `AS` expression). Because some custom display names weren't allowed by some
+  drivers, or would be transformed in some way (for example, Redshift always lowercases custom aliases), this method
+  was needed so we could match the name we had given the column with the one in the query results.
+
+  In 0.33.0, we started using `:named` internally to alias aggregations in middleware in *all* queries to prevent
+  issues with referring to multiple aggregations of the same type when that query was used as a source query.
+  See [#9767](https://github.com/metabase/metabase/issues/9767) for more details. After this change, it became
+  desirable to differentiate between such internally-generated aliases and display names, which need not be used in
+  the query at all; thus in MBQL 1.3.0 [`:named` was replaced by the more general
+  `:aggregation-options`](https://github.com/metabase/mbql/pull/7). Because user-generated names are no longer used as
+  aliases in native queries themselves, this method is no longer needed and will be removed in a future release."
   {:arglists '([driver custom-field-name])}
   dispatch-on-initialized-driver
   :hierarchy #'hierarchy)

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -240,6 +240,42 @@
   [_ _ expr]
   (sql.qp/adjust-start-of-week :postgres (partial date-trunc :week) expr))
 
+;; date extraction functions
+(defmethod sql.qp/->honeysql [:postgres :get-year]
+  [driver [_ arg]]
+  (extract-integer :year (sql.qp/->honeysql driver arg)))
+
+(defmethod sql.qp/->honeysql [:postgres :get-quarter]
+  [driver [_ arg]]
+  (sql.qp/date driver :quarter-of-year (sql.qp/->honeysql driver arg)))
+
+(defmethod sql.qp/->honeysql [:postgres :get-month]
+  [driver [_ arg]]
+  (sql.qp/date driver :month-of-year (sql.qp/->honeysql driver arg)))
+
+(defmethod sql.qp/->honeysql [:postgres :get-day]
+  [driver [_ arg]]
+  (sql.qp/date driver :day-of-month (sql.qp/->honeysql driver arg)))
+
+(defmethod sql.qp/->honeysql [:postgres :get-day-of-week]
+  [driver [_ arg]]
+  (sql.qp/date driver :day-of-week (sql.qp/->honeysql driver arg)))
+
+(defmethod sql.qp/->honeysql [:postgres :get-hour]
+  [driver [_ arg]]
+  (sql.qp/date driver :hour-of-day (sql.qp/->honeysql driver arg)))
+
+(defmethod sql.qp/->honeysql [:postgres :get-minute]
+  [driver [_ arg]]
+  (sql.qp/date driver :minute-of-hour (sql.qp/->honeysql driver arg)))
+
+(defmethod sql.qp/->honeysql [:postgres :get-second]
+  [driver [_ arg]]
+  (->> (sql.qp/->honeysql driver arg)
+       (extract :second)
+       (hsql/call :floor)
+       hx/->integer))
+
 (defmethod sql.qp/->honeysql [:postgres :value]
   [driver value]
   (let [[_ value {base-type :base_type, database-type :database_type}] value]

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -545,6 +545,38 @@
                       (current-datetime-honeysql-form driver)
                       (add-interval-honeysql-form driver (current-datetime-honeysql-form driver) amount unit))))
 
+;; date extraction functions
+(defmethod ->honeysql [:sql :get-year]
+  [driver [_ arg]]
+  (hx/year (->honeysql driver arg)))
+
+(defmethod ->honeysql [:sql :get-quarter]
+  [driver [_ arg]]
+  (hx/quarter (->honeysql driver arg)))
+
+(defmethod ->honeysql [:sql :get-month]
+  [driver [_ arg]]
+  (hx/month (->honeysql driver arg)))
+
+(defmethod ->honeysql [:sql :get-day]
+  [driver [_ arg]]
+  (hx/day (->honeysql driver arg)))
+
+(defmethod ->honeysql [:sql :get-day-of-week]
+  [driver [_ arg]]
+  (date driver :day-of-week (->honeysql driver arg)))
+
+(defmethod ->honeysql [:sql :get-hour]
+  [driver [_ arg]]
+  (hx/hour (->honeysql driver arg)))
+
+(defmethod ->honeysql [:sql :get-minute]
+  [driver [_ arg]]
+  (hx/minute (->honeysql driver arg)))
+
+(defmethod ->honeysql [:sql :get-second]
+  [driver [_ arg]]
+  (hsql/call :second (->honeysql driver arg)))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                            Field Aliases (AS Forms)                                            |

--- a/test/metabase/query_processor_test/date_time_zone_functions_test.clj
+++ b/test/metabase/query_processor_test/date_time_zone_functions_test.clj
@@ -1,0 +1,180 @@
+(ns metabase.query-processor-test.date-time-zone-functions-test
+  (:require [clojure.test :as t]
+            [metabase.test :as mt]
+            [metabase.test.data :as data]
+            [metabase.test.data.dataset-definitions :as defs]
+            [metabase.test.data.interface :as tx])
+  (:import (java.time ZonedDateTime)))
+
+(defn- test-date-extract
+  [expr & [{:keys [:fields :filter :breakout :aggregation :limit]
+            :or   {fields      [[:expression "expr"]]
+                   filter      nil
+                   breakout    nil
+                   aggregation nil
+                   ;; for breakout/agg, don't limit by default
+                   limit       (if breakout nil 1)}}]]
+  (if breakout
+    (->> {:expressions {"expr" expr}
+          ;; filter clause is optional
+          :filter      filter
+          :breakout    breakout
+          :aggregation aggregation
+          :limit       limit}
+         (mt/run-mbql-query users)
+         mt/rows)
+    (->> {:expressions {"expr" expr}
+          :fields      fields
+          ;; filter clause is optional
+          :filter      filter
+          ;; To ensure stable ordering
+          :order-by    [[:asc [:field (data/id :users :id) nil]]]
+          :limit       limit}
+      (mt/run-mbql-query users)
+      mt/rows
+      first)))
+
+(t/deftest extraction-function-tests
+  (mt/test-drivers (mt/normal-drivers-with-feature :date-functions)
+    (doseq [[expected expr more-clauses]
+            ;; get-year
+            [[[2016] [:get-year "2016-05-01 01:23:45Z"]]
+             [[2021] [:get-year "2021-12-08"]]
+             [[2014]
+              [:get-year [:field (mt/id :users :last_login) nil]]
+              {:filter [:= [:field (mt/id :users :id) nil] 10]}]
+             [[[2014 15]]
+              [:get-year [:field (mt/id :users :last_login) nil]]
+              {:aggregation [[:count]]
+               :breakout    [[:expression "expr"]]}]
+
+             ;; get-quarter
+             [[2] [:get-quarter "2016-05-01 01:23:45Z"]]
+             [[4] [:get-quarter "2021-12-08"]]
+             [[1]
+              [:get-quarter [:field (mt/id :users :last_login) nil]]
+              {:filter [:= [:field (mt/id :users :id) nil] 4]}]
+             [[[1 2]
+               [2 2]
+               [3 6]
+               [4 5]]
+              [:get-quarter [:field (mt/id :users :last_login) nil]]
+              {:aggregation [[:count]]
+               :breakout    [[:expression "expr"]]}]
+
+             ;; get-month
+             [[5] [:get-month "2016-05-01 01:23:45Z"]]
+             [[12] [:get-month "2021-12-08"]]
+             [[1]
+              [:get-month [:field (mt/id :users :last_login) nil]]
+              {:filter [:= [:field (mt/id :users :id) nil] 4]}]
+             [[[1 1]
+               [2 1]
+               [4 2]
+               [7 2]
+               [8 4]
+               [10 2]
+               [11 2]
+               [12 1]]
+              [:get-month [:field (mt/id :users :last_login) nil]]
+              {:aggregation [[:count]]
+               :breakout    [[:expression "expr"]]}]
+
+             ;; get-day
+             [[27] [:get-day "2016-05-27 01:23:45Z"]]
+             [[8] [:get-day "2021-12-08"]]
+             [[6]
+              [:get-day [:field (mt/id :users :last_login) nil]]
+              {:filter [:= [:field (mt/id :users :id) nil] 3]}]
+             [[[1 6] ; our login days aren't very widely distributed
+               [2 2]
+               [3 5]
+               [5 1]
+               [6 1]]
+              [:get-day [:field (mt/id :users :last_login) nil]]
+              {:aggregation [[:count]]
+               :breakout    [[:expression "expr"]]}]
+
+             ;; get-day-of-week
+             [[6] [:get-day-of-week "2016-05-27 01:23:45Z"]]
+             [[4] [:get-day-of-week "2021-12-08"]]
+             [[5]
+              [:get-day-of-week [:field (mt/id :users :last_login) nil]]
+              {:filter [:= [:field (mt/id :users :id) nil] 3]}]
+             [[[3 1]
+               [4 1]
+               [5 4]
+               [6 5]
+               [7 4]]
+              [:get-day-of-week [:field (mt/id :users :last_login) nil]]
+              {:aggregation [[:count]]
+               :breakout    [[:expression "expr"]]}]
+
+             ;; get-hour
+             [[19] [:get-hour "2016-05-27 19:23:45Z"]]
+             [[9]
+              [:get-hour [:field (mt/id :users :last_login) nil]]
+              {:filter [:= [:field (mt/id :users :id) nil] 7]}]
+             [[[1 1]
+               [10 2]
+               [12 2]
+               [13 1]
+               [15 1]
+               [16 1]
+               [17 1]
+               [19 1]
+               [7 1]
+               [8 2]
+               [9 2]]
+              [:get-hour [:field (mt/id :users :last_login) nil]]
+              {:aggregation [[:count]]
+               :breakout    [[:expression "expr"]]}]
+
+             ;; get-minute
+             [[23] [:get-minute "2016-05-27 19:23:45Z"]]
+             [[45]
+              [:get-minute [:field (mt/id :users :last_login) nil]]
+              {:filter [:= [:field (mt/id :users :id) nil] 14]}]
+             [[[0 1]
+               [15 3]
+               [30 9]
+               [45 2]]
+              [:get-minute [:field (mt/id :users :last_login) nil]]
+              {:aggregation [[:count]]
+               :breakout    [[:expression "expr"]]}]
+
+             ;; get-second
+             [[13] [:get-second "2016-05-27 19:23:13Z"]]
+             [[0]
+              [:get-second [:field (mt/id :users :last_login) nil]]
+              {:filter [:= [:field (mt/id :users :id) nil] 14]}]]]
+      (t/testing (format "%s function works as expected on %s" (first expr) (second expr))
+        ;; compare vectors of more than one item (i.e. aggregation results) on the basis of sets
+        (let [compare-on-fn (if (< 1 (count expected)) set identity)]
+          (t/is (= (compare-on-fn expected) (compare-on-fn (test-date-extract expr more-clauses)))))))
+    (t/testing ":get-second works on fields"
+      ;; need to test this on a separate dataset because test-data doesn't have any
+      ;; timestamp data with second level precision
+      (mt/dataset sample-dataset
+        ;; use Clojure to group the sample timestamps by second to create the expectation
+        ;; since this would be a giant literal map otherwise
+        (let [timestamps       (group-by (fn [^ZonedDateTime review-ts]
+                                           (.getSecond review-ts))
+                                         (->> (tx/get-dataset-definition defs/sample-dataset)
+                                              :table-definitions
+                                              (filter #(= "reviews" (:table-name %)))
+                                              first
+                                              :rows
+                                              (map last)))
+              timestamp-counts (reduce-kv (fn [m k v]
+                                            (assoc m k (count v)))
+                                          {}
+                                          timestamps)]
+          (t/is (= timestamp-counts
+                   (->> (mt/run-mbql-query reviews
+                          {:expressions {"review-second" [:get-second $created_at]}
+                           :aggregation [[:count]]
+                           :breakout    [[:expression "review-second"]]})
+                        mt/rows
+                        (into {})))))))))
+

--- a/test/metabase/query_processor_test/date_time_zone_functions_test.clj
+++ b/test/metabase/query_processor_test/date_time_zone_functions_test.clj
@@ -4,7 +4,7 @@
             [metabase.test.data :as data]
             [metabase.test.data.dataset-definitions :as defs]
             [metabase.test.data.interface :as tx])
-  (:import (java.time ZonedDateTime)))
+  (:import java.time.ZonedDateTime))
 
 (defn- test-date-extract
   [expr & [{:keys [:fields :filter :breakout :aggregation :limit]
@@ -177,4 +177,3 @@
                            :breakout    [[:expression "review-second"]]})
                         mt/rows
                         (into {})))))))))
-

--- a/test/metabase/test/data/interface.clj
+++ b/test/metabase/test/data/interface.clj
@@ -157,6 +157,15 @@
   [driver]
   (test-runner.init/assert-tests-are-not-initializing (pr-str (list 'the-driver-with-test-extensions driver)))
   (initialize/initialize-if-needed! :plugins)
+  ;; without this check, people will see an error like the following
+  ;;   Caused by: java.io.FileNotFoundException: Could not locate metabase/driver/all__init.class,
+  ;;   metabase/driver/all.clj or metabase/driver/all.cljc on classpath.
+  ;; add a more explicit check to make it clear what the problem is
+  (when (= :all driver)
+    (throw (ex-info (str "DRIVERS was set to \"all\" in the environment. To run certain tests, you need to set a"
+                         " specific driver by calling, for instance, `(mt/set-test-drivers! #{:h2})`, or by restarting"
+                         " with DRIVERS set to a specific name (ex: `DRIVERS=postgres`)")
+                    {})))
   (let [driver (driver/the-initialized-driver driver)]
     (load-test-extensions-namespace-if-needed driver)
     driver))
@@ -551,7 +560,7 @@
          (update (table tabledef) :rows rows)
          tabledef)))))
 
-
+load
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                      Flattening Dataset Definitions (i.e. for timeseries DBs like Druid)                       |
 ;;; +----------------------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
This PR takes over from [Jeff's unfinished PR](https://github.com/metabase/metabase/pull/19275) (w/ rebase)

### Example

1. New, Question, Sample Database, Orders table
2. Add custom column with formula `year([Created At])` and name `Year`
3. Visualize

You should see a new column with values ranging from `2,016` to `2,020`:

![image](https://user-images.githubusercontent.com/653604/157426279-169f1dc3-13cd-4087-bc8b-d54066a611ce.png)

The date extraction functions should also show up in the suggestions

### Blockers

See [this comment in Jeff's draft PR](https://github.com/metabase/metabase/pull/19275#issuecomment-1033150421)