### PR TITLE
Add the :archived status of card/dashboard/collection for filtering

### DIFF
--- a/src/metabase/models/bookmark.clj
+++ b/src/metabase/models/bookmark.clj
@@ -70,16 +70,20 @@
                      [:card.id (db/qualify 'Card :item_id)]
                      [:card.name (db/qualify 'Card :name)]
                      [:card.description (db/qualify 'Card :description)]
+                     [:card.archived (db/qualify 'Card :archived)]
                      [:dashboard.id (db/qualify 'Dashboard :item_id)]
                      [:dashboard.name (db/qualify 'Dashboard :name)]
                      [:dashboard.description (db/qualify 'Dashboard :description)]
+                     [:dashboard.archived (db/qualify 'Dashboard :archived)]
                      [:collection.id (db/qualify 'Collection :item_id)]
                      [:collection.name (db/qualify 'Collection :name)]
-                     [:collection.description (db/qualify 'Collection :description)]]
+                     [:collection.description (db/qualify 'Collection :description)]
+                     [:collection.archived (db/qualify 'Collection :archived)]]
          :from      [[(bookmarks-union-query id) :bookmark]]
          :left-join [[:report_card :card] [:= :bookmark.card_id :card.id]
                      [:report_dashboard :dashboard] [:= :bookmark.dashboard_id :dashboard.id]
                      :collection [:= :bookmark.collection_id :collection.id]]})
        (map remove-nil-values)
        (sort-by :created_at)
-       (map normalize-bookmark-result)))
+       (map normalize-bookmark-result)
+       (remove :archived)))


### PR DESCRIPTION
Fixes #20919

# Before this PR
The bookmarks endpoint would return a list of all bookmarks for the current user, regardless of archived status. This would result in the ability to follow a link in the sidebar to a page that doesn't exist (404).

# After this PR
The archived status of the bookmarked item is used to filter results. This means that a bookmarked card will show up, but a bookmarked *archived* card will not.

Please note that the archived status of the item has *no effect* on the bookmarked status. A card can be un-archived and will show up in the bookmarked list if it was previously bookmarked.