### PR TITLE
Fix useSequencedContentClose keydown/mousedown listeners

### DIFF
--- a/frontend/src/metabase/hooks/use-sequenced-content-close-handler.ts
+++ b/frontend/src/metabase/hooks/use-sequenced-content-close-handler.ts
@@ -70,8 +70,8 @@ export default function useSequencedContentCloseHandler() {
       popoverDataRef.current = undefined;
     }
 
-    document.removeEventListener("mousedown", handleEvent, true);
     document.removeEventListener("keydown", handleEvent);
+    window.removeEventListener("mousedown", handleEvent, true);
   }, [handleEvent]);
 
   const setupCloseHandler = useCallback(
@@ -83,8 +83,8 @@ export default function useSequencedContentCloseHandler() {
         RENDERED_POPOVERS.push(popover);
         popoverDataRef.current = popover;
 
-        document.addEventListener("mousedown", handleEvent, true);
-        window.addEventListener("keydown", handleEvent);
+        document.addEventListener("keydown", handleEvent);
+        window.addEventListener("mousedown", handleEvent, true);
       }
     },
     [handleEvent, removeCloseHandler],


### PR DESCRIPTION
Should've been glaringly obvious that these were wrong but they are only active when a popover is open, so the mistake fortunately didn't have awful consequences. This caused a memory leak and for popovers that are open behind a modal to not close when the user presses the "Escape" key. Besides that, I didn't notice any other wrong behavior.

**Testing**
1. Hover over a table viz column header and press the escape key. It should close properly. Execute `getEventListeners(window).keydown` in the browser (if you're using a webkit browser); you shouldn't see a listener for the use-sequenced-content-close.ts file.